### PR TITLE
extend Version class so that 2.0 > 1.develop > 1.1 and develop > master > head > trunk > 9999

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -590,13 +590,15 @@ with `RPM <https://bugzilla.redhat.com/show_bug.cgi?id=50977>`_.
 
 Spack versions may also be arbitrary non-numeric strings; any string
 here will suffice; for example, ``@develop``, ``@master``, ``@local``.
-The following rules determine the sort order of numeric
-vs. non-numeric versions:
+Versions are compared as follows. First, a version string is split into
+multiple fields based on delimiters such as ``.``, ``-`` etc. Then
+matching fields are compared using the rules below:
 
-#. The non-numeric version ``@develop`` is considered greatest (newest).
+#. The following develop-like strings are greater (newer) than all
+   numbers and are ordered as ``develop > master > head > trunk``.
 
-#. Numeric versions are all less than ``@develop`` version, and are
-   sorted numerically.
+#. Numbers are all less than the chosen develop-like strings above,
+   and are sorted numerically.
 
 #. All other non-numeric versions are less than numeric versions, and
    are sorted alphabetically.
@@ -610,7 +612,7 @@ The logic behind this sort order is two-fold:
 
 #. The most-recent development version of a package will usually be
    newer than any released numeric versions.  This allows the
-   ``develop`` version to satisfy dependencies like ``depends_on(abc,
+   ``@develop`` version to satisfy dependencies like ``depends_on(abc,
    when="@x.y.z:")``
 
 ^^^^^^^^^^^^^^^^^

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -124,11 +124,39 @@ class TestConcretizePreferences(object):
         spec = concretize('mpileaks')
         assert 'zmpi' in spec
 
-    def test_develop(self):
-        """Test concretization with develop version"""
-        spec = Spec('builtin.mock.develop-test')
+    def test_preferred(self):
+        """"Test packages with some version marked as preferred=True"""
+        spec = Spec('preferred-test')
         spec.concretize()
         assert spec.version == spack.spec.Version('0.2.15')
+
+        # now add packages.yaml with versions other than preferred
+        # ensure that once config is in place, non-preferred version is used
+        update_packages('preferred-test', 'version', ['0.2.16'])
+        spec = Spec('preferred-test')
+        spec.concretize()
+        assert spec.version == spack.spec.Version('0.2.16')
+
+    def test_develop(self):
+        """Test concretization with develop-like versions"""
+        spec = Spec('develop-test')
+        spec.concretize()
+        assert spec.version == spack.spec.Version('0.2.15')
+        spec = Spec('develop-test2')
+        spec.concretize()
+        assert spec.version == spack.spec.Version('0.2.15')
+
+        # now add packages.yaml with develop-like versions
+        # ensure that once config is in place, develop-like version is used
+        update_packages('develop-test', 'version', ['develop'])
+        spec = Spec('develop-test')
+        spec.concretize()
+        assert spec.version == spack.spec.Version('develop')
+
+        update_packages('develop-test2', 'version', ['0.2.15.develop'])
+        spec = Spec('develop-test2')
+        spec.concretize()
+        assert spec.version == spack.spec.Version('0.2.15.develop')
 
     def test_no_virtuals_in_packages_yaml(self):
         """Verify that virtuals are not allowed in packages.yaml."""

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -116,6 +116,9 @@ def test_develop():
     assert_ver_lt('1.develop.1', '1.develop.2')
     assert_ver_gt('1.develop.2', '1.develop.1')
     # other +infinity versions
+    assert_ver_gt('master', '9.0')
+    assert_ver_gt('head', '9.0')
+    assert_ver_gt('trunk', '9.0')
     assert_ver_gt('develop', '9.0')
     assert_ver_gt('9.0', 'system')
     # not develop
@@ -125,6 +128,9 @@ def test_develop():
 
 def test_isdevelop():
     assert ver('develop').isdevelop()
+    assert ver('master').isdevelop()
+    assert ver('head').isdevelop()
+    assert ver('trunk').isdevelop()
     assert ver('1.develop').isdevelop()
     assert ver('1.develop.2').isdevelop()
     assert not ver('1.1').isdevelop()

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -90,13 +90,45 @@ def check_union(expected, a, b):
     assert ver(expected) == ver(a).union(ver(b))
 
 
+def test_string_prefix():
+    assert_ver_eq('xsdk-0.2.0', 'xsdk-0.2.0')
+    assert_ver_lt('xsdk-0.2.0', 'xsdk-0.3')
+    assert_ver_gt('xsdk-0.3', 'xsdk-0.2.0')
+
+
 def test_two_segments():
     assert_ver_eq('1.0', '1.0')
     assert_ver_lt('1.0', '2.0')
     assert_ver_gt('2.0', '1.0')
+
+
+def test_develop():
     assert_ver_eq('develop', 'develop')
     assert_ver_lt('1.0', 'develop')
     assert_ver_gt('develop', '1.0')
+    assert_ver_eq('1.develop', '1.develop')
+    assert_ver_lt('1.1', '1.develop')
+    assert_ver_gt('1.develop', '1.0')
+    assert_ver_gt('0.5.develop', '0.5')
+    assert_ver_lt('0.5', '0.5.develop')
+    assert_ver_lt('1.develop', '2.1')
+    assert_ver_gt('2.1', '1.develop')
+    assert_ver_lt('1.develop.1', '1.develop.2')
+    assert_ver_gt('1.develop.2', '1.develop.1')
+    # other +infinity versions
+    assert_ver_gt('develop', '9.0')
+    assert_ver_gt('9.0', 'system')
+    # not develop
+    assert_ver_lt('1.mydevelopmentnightmare', '1.1')
+    assert_ver_gt('1.1', '1.mydevelopmentnightmare')
+
+
+def test_isdevelop():
+    assert ver('develop').isdevelop()
+    assert ver('1.develop').isdevelop()
+    assert ver('1.develop.2').isdevelop()
+    assert not ver('1.1').isdevelop()
+    assert not ver('1.mydevelopmentnightmare.3').isdevelop()
 
 
 def test_three_segments():

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -104,6 +104,7 @@ def test_two_segments():
 
 def test_develop():
     assert_ver_eq('develop', 'develop')
+    assert_ver_eq('develop.local', 'develop.local')
     assert_ver_lt('1.0', 'develop')
     assert_ver_gt('develop', '1.0')
     assert_ver_eq('1.develop', '1.develop')
@@ -115,6 +116,8 @@ def test_develop():
     assert_ver_gt('2.1', '1.develop')
     assert_ver_lt('1.develop.1', '1.develop.2')
     assert_ver_gt('1.develop.2', '1.develop.1')
+    assert_ver_lt('develop.1', 'develop.2')
+    assert_ver_gt('develop.2', 'develop.1')
     # other +infinity versions
     assert_ver_gt('master', '9.0')
     assert_ver_gt('head', '9.0')
@@ -122,12 +125,15 @@ def test_develop():
     assert_ver_gt('develop', '9.0')
     assert_ver_gt('9.0', 'system')
     # not develop
+    assert_ver_lt('mydevelopmentnightmare', '1.1')
     assert_ver_lt('1.mydevelopmentnightmare', '1.1')
     assert_ver_gt('1.1', '1.mydevelopmentnightmare')
 
 
 def test_isdevelop():
     assert ver('develop').isdevelop()
+    assert ver('develop.1').isdevelop()
+    assert ver('develop.local').isdevelop()
     assert ver('master').isdevelop()
     assert ver('head').isdevelop()
     assert ver('trunk').isdevelop()
@@ -135,6 +141,7 @@ def test_isdevelop():
     assert ver('1.develop.2').isdevelop()
     assert not ver('1.1').isdevelop()
     assert not ver('1.mydevelopmentnightmare.3').isdevelop()
+    assert not ver('mydevelopmentnightmare.3').isdevelop()
 
 
 def test_three_segments():

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -123,6 +123,10 @@ def test_develop():
     assert_ver_gt('head', '9.0')
     assert_ver_gt('trunk', '9.0')
     assert_ver_gt('develop', '9.0')
+    # hierarchical develop-like versions
+    assert_ver_gt('develop', 'master')
+    assert_ver_gt('master', 'head')
+    assert_ver_gt('head', 'trunk')
     assert_ver_gt('9.0', 'system')
     # not develop
     assert_ver_lt('mydevelopmentnightmare', '1.1')

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -39,7 +39,7 @@ __all__ = ['Version', 'VersionRange', 'VersionList', 'ver']
 VALID_VERSION = r'[A-Za-z0-9_.-]'
 
 # Infinity-like versions. The order in the list implies the comparision rules
-infinity_versions = ['develop']
+infinity_versions = ['develop', 'master', 'head', 'trunk']
 
 
 def int_if_int(string):

--- a/var/spack/repos/builtin.mock/packages/develop-test2/package.py
+++ b/var/spack/repos/builtin.mock/packages/develop-test2/package.py
@@ -1,27 +1,8 @@
-##############################################################################
-# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
-# This file is part of Spack.
-# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
-# LLNL-CODE-647188
-#
-# For details, see https://github.com/llnl/spack
-# Please also see the LICENSE file for our notice and the LGPL.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License (as
-# published by the Free Software Foundation) version 2.1, February 1999.
-#
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
-# conditions of the GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public
-# License along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-##############################################################################
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 from spack import *
 
 

--- a/var/spack/repos/builtin.mock/packages/develop-test2/package.py
+++ b/var/spack/repos/builtin.mock/packages/develop-test2/package.py
@@ -1,0 +1,37 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class DevelopTest2(Package):
+    """Dummy package with develop version"""
+    homepage = "http://www.openblas.net"
+    url      = "http://github.com/xianyi/OpenBLAS/archive/v0.2.15.tar.gz"
+
+    version('0.2.15.develop', git='https://github.com/dummy/repo.git')
+    version('0.2.15', 'b1190f3d3471685f17cfd1ec1d252ac9')
+
+    def install(self, spec, prefix):
+        pass

--- a/var/spack/repos/builtin.mock/packages/preferred-test/package.py
+++ b/var/spack/repos/builtin.mock/packages/preferred-test/package.py
@@ -1,27 +1,8 @@
-##############################################################################
-# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
-# This file is part of Spack.
-# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
-# LLNL-CODE-647188
-#
-# For details, see https://github.com/llnl/spack
-# Please also see the LICENSE file for our notice and the LGPL.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License (as
-# published by the Free Software Foundation) version 2.1, February 1999.
-#
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
-# conditions of the GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public
-# License along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-##############################################################################
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 from spack import *
 
 

--- a/var/spack/repos/builtin.mock/packages/preferred-test/package.py
+++ b/var/spack/repos/builtin.mock/packages/preferred-test/package.py
@@ -1,0 +1,39 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PreferredTest(Package):
+    """Dummy package with develop version and preffered version"""
+    homepage = "http://www.openblas.net"
+    url      = "http://github.com/xianyi/OpenBLAS/archive/v0.2.15.tar.gz"
+
+    version('develop', git='https://github.com/dummy/repo.git')
+    version('0.2.16', 'b1190f3d3471685f17cfd1ec1d252ac9')
+    version('0.2.15', 'b1190f3d3471685f17cfd1ec1d252ac9', preferred=True)
+    version('0.2.14', 'b1190f3d3471685f17cfd1ec1d252ac9')
+
+    def install(self, spec, prefix):
+        pass


### PR DESCRIPTION
as per @adamjstewart request, an alternative to https://github.com/LLNL/spack/pull/1979 which defines a list of infinity-like versions.

@adamjstewart : how do I use that `__gt__` operator in places like

```
for a, b in zip(self.version, other.version)
    return a < b
```

?

Closes #1975, Closes #8421