### PR TITLE
[Discussion] How to handle os/version/arch-specific downloads

### DIFF
--- a/var/spack/repos/builtin/packages/allinea-forge/package.py
+++ b/var/spack/repos/builtin/packages/allinea-forge/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+import platform
 
 
 class AllineaForge(Package):
@@ -33,7 +34,14 @@ class AllineaForge(Package):
 
     homepage = "http://www.allinea.com/products/develop-allinea-forge"
 
-    version('6.0.4', 'df7f769975048477a36f208d0cd57d7e')
+    os_version_arch = self.get_os_version_arch()
+
+    if os_version_arch == 'Redhat-7.0-x86_64':
+        version('6.0.4', '5500d43f4a3a58ded95b2a2f4434c8a0')
+    elif os_version_arch == 'Redhat-6.0-x86_64':
+        version('6.0.4', 'df7f769975048477a36f208d0cd57d7e')
+    elif os_version_arch == 'Ubuntu-14.04-x86_64':
+        version('6.0.4', '5c8ad4bd41c1b60791c8156bf710095d')
 
     # Licensing
     license_required = True
@@ -42,10 +50,135 @@ class AllineaForge(Package):
     license_vars = ['ALLINEA_LICENCE_FILE', 'ALLINEA_LICENSE_FILE']
     license_url = 'http://www.allinea.com/user-guide/forge/Installation.html'
 
+    def get_os_version_arch(self):
+        # Allinea has a different download for each OS/distro/version/arch
+        # See http://www.allinea.com/products/forge/download
+        system = platform.system()
+        machine = platform.machine()
+
+        # Linux
+        if system == 'Linux':
+
+            distro = platform.linux_distribution()[0]
+            version = Version(platform.linux_distribution()[1])
+
+            # Red Hat Enterprise Linux
+            if distro == 'Red Hat Enterprise Linux Server' or distro == 'CentOS':  # noqa
+                my_distro = 'Redhat'
+
+                # AMD/Intel
+                if machine == 'x86_64':
+                    my_mach = 'x86_64'
+
+                    if version >= Version('7.0'):
+                        my_ver = '7.0'
+                    elif version >= Version('6.0'):
+                        my_ver = '6.0'
+                    elif version >= Version('5.7'):
+                        my_ver = '5.7'
+                # AMD/Intel
+                elif machine == 'i686':
+                    my_mach = 'i686'
+
+                    if version >= Version('5.6'):
+                        my_ver = '5.6'
+                # POWER little-endian
+                elif machine == 'ppc64le':
+                    my_mach = 'ppc64le'
+
+                    if version >= Version('7.2'):
+                        my_ver = '7.2'
+                # POWER big-endian
+                elif machine == 'ppc64':
+                    my_mach = 'ppc64'
+
+                    if version >= Version('6.2'):
+                        my_ver = '6.2'
+
+            # SuSE Enterprise Linux Server
+            elif distro == 'OpenSUSE':
+                my_distro = 'Suse'
+
+                # AMD/Intel
+                if machine == 'x86_64':
+                    my_mach = 'x86_64'
+
+                    if version >= Version('12'):
+                        my_ver = '12'
+                    elif version >= Version('11'):
+                        my_ver = '11'
+
+            # Ubuntu
+            elif distro == 'Ubuntu':
+                my_distro = 'Ubuntu'
+
+                # AMD/Intel
+                if machine == 'x86_64':
+                    my_mach = 'x86_64'
+
+                    if version >= Version('14.04'):
+                        my_ver = '14.04'
+                    elif version >= Version('12.04'):
+                        my_ver = '12.04'
+                # ARM v8
+                if machine == 'aarch64':
+                    my_mach = 'aarch64'
+
+                    if version >= Version('14.04'):
+                        my_ver = '14.04'
+
+            # BlueGene/Q
+            elif distro == 'bgq':
+                return 'bgq'
+
+        # macOS
+        elif system == 'Mac OS':
+            my_distro = 'MacOSX'
+            version = platform.mac_ver()[0]
+
+            # AMD/Intel
+            if machine == 'x86_64':
+                my_mach = 'x86_64'
+
+            if version >= Version('10.7.5'):
+                my_ver = '10.7.5'
+
+        # Windows
+        elif system == 'Windows':
+            my_distro = 'Windows'
+            version = platform.win32_ver()[0]
+
+            # AMD/Intel
+            if machine == 'x86_64':
+                my_mach = 'x64'
+            # AMD/Intel
+            elif machine == 'i686':
+                my_mach = 'x86'
+
+            if version >= Version('6.1'):
+                my_ver = '6.1'
+
+        try:
+            return '-'.join([my_distro, my_ver, my_mach])
+        except:
+            msg = "No download available for '{0}', '{1}', '{2}', '{3}'"
+            raise InstallError(msg.format(system, distro, version, machine))
+
     def url_for_version(self, version):
-        # TODO: add support for other architectures/distributions
-        url = "http://content.allinea.com/downloads/"
-        return url + "allinea-forge-%s-Redhat-6.0-x86_64.tar" % version
+        os_version_arch = self.get_os_version_arch()
+        system = platform.system()
+
+        if system == 'Linux':
+            ext = 'tar'
+        elif system == 'Mac OS':
+            ext = 'dmg'
+        elif system == 'Windows':
+            ext = 'exe'
+
+        base_url = "http://content.allinea.com/downloads"
+
+        return "{0}/allinea-forge-{1}-{2}.{3}".format(
+            base_url, version, os_version_arch, ext)
 
     def install(self, spec, prefix):
         textinstall = which('textinstall.sh')

--- a/var/spack/repos/builtin/packages/allinea-forge/package.py
+++ b/var/spack/repos/builtin/packages/allinea-forge/package.py
@@ -26,6 +26,121 @@ from spack import *
 import platform
 
 
+def get_os_version_arch():
+    # Allinea has a different download for each OS/distro/version/arch
+    # See http://www.allinea.com/products/forge/download
+    system = platform.system()
+    machine = platform.machine()
+
+    # Linux
+    if system == 'Linux':
+
+        distro = platform.linux_distribution()[0]
+        version = Version(platform.linux_distribution()[1])
+
+        # Red Hat Enterprise Linux
+        if distro == 'Red Hat Enterprise Linux Server' or distro == 'CentOS':  # noqa
+            my_distro = 'Redhat'
+
+            # AMD/Intel
+            if machine == 'x86_64':
+                my_mach = 'x86_64'
+
+                if version >= Version('7.0'):
+                    my_ver = '7.0'
+                elif version >= Version('6.0'):
+                    my_ver = '6.0'
+                elif version >= Version('5.7'):
+                    my_ver = '5.7'
+            # AMD/Intel
+            elif machine == 'i686':
+                my_mach = 'i686'
+
+                if version >= Version('5.6'):
+                    my_ver = '5.6'
+            # POWER little-endian
+            elif machine == 'ppc64le':
+                my_mach = 'ppc64le'
+
+                if version >= Version('7.2'):
+                    my_ver = '7.2'
+            # POWER big-endian
+            elif machine == 'ppc64':
+                my_mach = 'ppc64'
+
+                if version >= Version('6.2'):
+                    my_ver = '6.2'
+
+        # SuSE Enterprise Linux Server
+        elif distro == 'OpenSUSE':
+            my_distro = 'Suse'
+
+            # AMD/Intel
+            if machine == 'x86_64':
+                my_mach = 'x86_64'
+
+                if version >= Version('12'):
+                    my_ver = '12'
+                elif version >= Version('11'):
+                    my_ver = '11'
+
+        # Ubuntu
+        elif distro == 'Ubuntu':
+            my_distro = 'Ubuntu'
+
+            # AMD/Intel
+            if machine == 'x86_64':
+                my_mach = 'x86_64'
+
+                if version >= Version('14.04'):
+                    my_ver = '14.04'
+                elif version >= Version('12.04'):
+                    my_ver = '12.04'
+            # ARM v8
+            if machine == 'aarch64':
+                my_mach = 'aarch64'
+
+                if version >= Version('14.04'):
+                    my_ver = '14.04'
+
+        # BlueGene/Q
+        elif distro == 'bgq':
+            return 'bgq'
+
+    # macOS
+    elif system == 'Darwin':
+        my_distro = 'MacOSX'
+        version = Version(platform.mac_ver()[0])
+
+        # AMD/Intel
+        if machine == 'x86_64':
+            my_mach = 'x86_64'
+
+        if version >= Version('10.7.5'):
+            my_ver = '10.7.5'
+
+    # Windows
+    elif system == 'Windows':
+        my_distro = 'Windows'
+        version = Version(platform.win32_ver()[0])
+
+        # AMD/Intel
+        if machine == 'x86_64':
+            my_mach = 'x64'
+        # AMD/Intel
+        elif machine == 'i686':
+            my_mach = 'x86'
+
+        if version >= Version('6.1'):
+            my_ver = '6.1'
+
+    try:
+        return '-'.join([my_distro, my_ver, my_mach])
+    except:
+        msg = "No download available for '{0}', '{1}', '{2}', '{3}'"
+        raise InstallError(msg.format(system, distro, version, machine))
+
+
 class AllineaForge(Package):
     """Allinea Forge is the complete toolsuite for software development - with
     everything needed to debug, profile, optimize, edit and build C, C++ and
@@ -34,7 +149,7 @@ class AllineaForge(Package):
 
     homepage = "http://www.allinea.com/products/develop-allinea-forge"
 
-    os_version_arch = self.get_os_version_arch()
+    os_version_arch = get_os_version_arch()
 
     if os_version_arch == 'Redhat-7.0-x86_64':
         version('6.0.4', '5500d43f4a3a58ded95b2a2f4434c8a0')
@@ -42,6 +157,8 @@ class AllineaForge(Package):
         version('6.0.4', 'df7f769975048477a36f208d0cd57d7e')
     elif os_version_arch == 'Ubuntu-14.04-x86_64':
         version('6.0.4', '5c8ad4bd41c1b60791c8156bf710095d')
+    elif os_version_arch == 'MacOSX-10.7.5-x86_64':
+        version('6.0.4', '3ee83901a2afbb255f09f8a2138dd46e')
 
     # Licensing
     license_required = True
@@ -50,135 +167,26 @@ class AllineaForge(Package):
     license_vars = ['ALLINEA_LICENCE_FILE', 'ALLINEA_LICENSE_FILE']
     license_url = 'http://www.allinea.com/user-guide/forge/Installation.html'
 
-    def get_os_version_arch(self):
-        # Allinea has a different download for each OS/distro/version/arch
-        # See http://www.allinea.com/products/forge/download
-        system = platform.system()
-        machine = platform.machine()
-
-        # Linux
-        if system == 'Linux':
-
-            distro = platform.linux_distribution()[0]
-            version = Version(platform.linux_distribution()[1])
-
-            # Red Hat Enterprise Linux
-            if distro == 'Red Hat Enterprise Linux Server' or distro == 'CentOS':  # noqa
-                my_distro = 'Redhat'
-
-                # AMD/Intel
-                if machine == 'x86_64':
-                    my_mach = 'x86_64'
-
-                    if version >= Version('7.0'):
-                        my_ver = '7.0'
-                    elif version >= Version('6.0'):
-                        my_ver = '6.0'
-                    elif version >= Version('5.7'):
-                        my_ver = '5.7'
-                # AMD/Intel
-                elif machine == 'i686':
-                    my_mach = 'i686'
-
-                    if version >= Version('5.6'):
-                        my_ver = '5.6'
-                # POWER little-endian
-                elif machine == 'ppc64le':
-                    my_mach = 'ppc64le'
-
-                    if version >= Version('7.2'):
-                        my_ver = '7.2'
-                # POWER big-endian
-                elif machine == 'ppc64':
-                    my_mach = 'ppc64'
-
-                    if version >= Version('6.2'):
-                        my_ver = '6.2'
-
-            # SuSE Enterprise Linux Server
-            elif distro == 'OpenSUSE':
-                my_distro = 'Suse'
-
-                # AMD/Intel
-                if machine == 'x86_64':
-                    my_mach = 'x86_64'
-
-                    if version >= Version('12'):
-                        my_ver = '12'
-                    elif version >= Version('11'):
-                        my_ver = '11'
-
-            # Ubuntu
-            elif distro == 'Ubuntu':
-                my_distro = 'Ubuntu'
-
-                # AMD/Intel
-                if machine == 'x86_64':
-                    my_mach = 'x86_64'
-
-                    if version >= Version('14.04'):
-                        my_ver = '14.04'
-                    elif version >= Version('12.04'):
-                        my_ver = '12.04'
-                # ARM v8
-                if machine == 'aarch64':
-                    my_mach = 'aarch64'
-
-                    if version >= Version('14.04'):
-                        my_ver = '14.04'
-
-            # BlueGene/Q
-            elif distro == 'bgq':
-                return 'bgq'
-
-        # macOS
-        elif system == 'Mac OS':
-            my_distro = 'MacOSX'
-            version = platform.mac_ver()[0]
-
-            # AMD/Intel
-            if machine == 'x86_64':
-                my_mach = 'x86_64'
-
-            if version >= Version('10.7.5'):
-                my_ver = '10.7.5'
-
-        # Windows
-        elif system == 'Windows':
-            my_distro = 'Windows'
-            version = platform.win32_ver()[0]
-
-            # AMD/Intel
-            if machine == 'x86_64':
-                my_mach = 'x64'
-            # AMD/Intel
-            elif machine == 'i686':
-                my_mach = 'x86'
-
-            if version >= Version('6.1'):
-                my_ver = '6.1'
-
-        try:
-            return '-'.join([my_distro, my_ver, my_mach])
-        except:
-            msg = "No download available for '{0}', '{1}', '{2}', '{3}'"
-            raise InstallError(msg.format(system, distro, version, machine))
 
     def url_for_version(self, version):
-        os_version_arch = self.get_os_version_arch()
+        os_version_arch = get_os_version_arch()
         system = platform.system()
 
         if system == 'Linux':
             ext = 'tar'
-        elif system == 'Mac OS':
+        elif system == 'Darwin':
             ext = 'dmg'
         elif system == 'Windows':
             ext = 'exe'
 
         base_url = "http://content.allinea.com/downloads"
 
-        return "{0}/allinea-forge-{1}-{2}.{3}".format(
-            base_url, version, os_version_arch, ext)
+        if system == 'Linux':
+            return "{0}/allinea-forge-{1}-{2}.{3}".format(
+                base_url, version, os_version_arch, ext)
+        else:
+            return "{0}/allinea-forge-client-{1}-{2}.{3}".format(
+                base_url, version, os_version_arch, ext)
 
     def install(self, spec, prefix):
         textinstall = which('textinstall.sh')


### PR DESCRIPTION
This PR is more of a discussion, but could probably be merged anyway if people like it.

The question is, how do we handle software that provides a different download depending on your operating system, version, architecture, etc? I chose `allinea-forge` as a particularly nasty example. See the downloads page [here](http://www.allinea.com/products/forge/download).

Software like this provides two problems:
1. A single version might have a different URL depending on the cluster
2. A single version might have a different checksum depending on the cluster

The second problem _could_ be solved by including the os-version-arch in the version, but I tried to avoid this hack.

My solution was to create a function that determined the appropriate version to download. For example, if you are on RHEL or CentOS, it uses the "Redhat" version. It would be great if os-version-arch stuff like this could be included in the core Spack libraries, but since each package may name things differently, I don't think this is possible. For example, one package could have a "Redhat" version and another could have both a "rhel" and "centos" version.

With this function, I can define the `url_for_download()` method. And with a case-statement-like if-statement, I can define the checksums for each version, depending on the os-version-arch.

@citibeth This is what I was talking about in #1997.

Note: since I don't have every possible platform available to me, I could only test on CentOS. I couldn't find any good documentation on `platform` so I don't know the exact string for each possible system, linux distro, etc. I also don't know mappings between Fedora versions and RHEL versions, so I didn't provide support for Fedora. There are probably a lot of distros that could use one of these versions even if they aren't explicitly listed. Mint could probably use the Ubuntu download for example. These would have to be added manually. If you can think of a better solution, let me know.
