### PR TITLE
Feature/external

### DIFF
--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -113,34 +113,9 @@ def external_add(args):
 def external_rm(args):
     """Removes an external package from packages.yaml"""
     package_spec = spack.spec.Spec(args.package_spec)
-    packages_config = ext_package.PackagesConfig(args.scope)
-    package = packages_config.get_package(package_spec.name)
-    if package.is_empty():
-        tty.die("Could not find package for {0}".format(package_spec))
-
-    matches = []
-    specs = package.specs_section()
-    for spec in specs.keys():  # follows {spec: path_or_mod}
-        if spack.spec.Spec(spec).satisfies(package_spec):
-            matches.append(spec)
-
-    if not args.all and len(matches) > 1:
-        tty.error(
-            "Multiple packages match spec {0}. Choose one:".format(
-                package_spec))
-        colify(sorted(matches), indent=4)
-        tty.msg("Or, use 'spack external rm -a' to remove all fo them.")
-        sys.exit(1)
-
-    for spec in matches:
-        package.remove_spec(spec)
+    removed_entries = ext_package.remove_external_package(package_spec, scope)
+    for spec in removed_entries:
         tty.msg("Removed package: {0}".format(spec))
-
-    if not package.contains_specs():
-        packages_config.remove_entire_entry_from_config(package_spec.name)
-    else:
-        packages_config.update_package_config(package.config_entry())
-
 
 def external_list(args):
     tty.msg("Available external packages")

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -27,7 +27,6 @@ import sys
 
 from llnl.util.lang import index_by
 import llnl.util.tty as tty
-from llnl.util.tty.colify import colify
 import spack
 import spack.cmd
 import spack.compilers
@@ -113,7 +112,9 @@ def external_add(args):
 def external_rm(args):
     """Removes an external package from packages.yaml"""
     package_spec = spack.spec.Spec(args.package_spec)
-    removed_entries = ext_package.remove_external_package(package_spec, scope)
+    removed_entries = ext_package.remove_external_package(package_spec,
+                                                          args.scope,
+                                                          args.all)
     for spec in removed_entries:
         tty.msg("Removed package: {0}".format(spec))
 

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -26,8 +26,7 @@ import sys
 
 from llnl.util.lang import index_by
 import llnl.util.tty as tty
-from llnl.util.tty.colify import colify, colify_table
-from llnl.util.tty.color import colorize
+from llnl.util.tty.colify import colify
 import spack
 import spack.cmd
 import spack.compilers
@@ -36,19 +35,24 @@ import spack.external_package as ext_package
 import spack.error
 import spack.spec
 
+
 description = "Add an external package entry to packages.yaml"
 
 
 def setup_parser(subparser):
-    """
-    Sets up parser for external add and external rm. The arguments are as
-    follows:
-        spack external add [package_spec] [path or module]
+    """Sets up parser for external add and external rm.
+
+    Sets up command line parser for the spack external command. Usage is as
+    follows
+
+        spack external add [package_spec] [path_or_module]
+        spack external rm [package_spec]
+        spack external list
     """
     scopes = spack.config.config_scopes
     # Set up subcommands external and rm and list
     sp = subparser.add_subparsers(metavar="SUBCOMMAND",
-                                  dest = "external_command")
+                                  dest="external_command")
     ################
     # external add
     ################
@@ -65,8 +69,8 @@ def setup_parser(subparser):
     ###############
     # external rm
     ###############
-    rm_parser = sp.add_parser('remove',
-            aliases=['rm'], help="Delete an entry from packages.yaml")
+    rm_parser = sp.add_parser('remove', aliases=['rm'],
+                              help="Delete an entry from packages.yaml")
     rm_parser.add_argument('-a', '--all', action='store_true',
                            help='Remove ALL compilers that match spec.')
     rm_parser.add_argument("package_spec",
@@ -90,7 +94,7 @@ def external_add(args):
     external_location = args.external_location
     scope = args.scope
     external_package = ext_package.ExternalPackage.create_external_package(
-                                            package_spec, external_location)
+        package_spec, external_location)
     ext_package.add_external_package(external_package, scope)
     filename = spack.config.get_config_filename(scope, "packages")
     tty.msg("Added {0} to {1}".format(package_spec, filename))
@@ -106,11 +110,11 @@ def external_rm(args):
 
     matches = []
     specs = package.specs_section()
-    for spec in specs.keys(): # follows {spec: path_or_mod}
+    for spec in specs.keys():  # follows {spec: path_or_mod}
         if spack.spec.Spec(spec).satisfies(package_spec):
             matches.append(spec)
 
-    if not args.all and len(matches) > 1: 
+    if not args.all and len(matches) > 1:
         tty.error(
             "Multiple packages match spec {0}. Choose one:".format(
                 package_spec))
@@ -122,7 +126,7 @@ def external_rm(args):
         package.remove_spec(spec)
         tty.msg("Removed package: {0}".format(spec))
 
-    if package.is_spec_empty():
+    if not package.contains_specs():
         packages_config.remove_entire_entry_from_config(package_spec.name)
     else:
         packages_config.update_package_config(package.config_entry())
@@ -142,8 +146,7 @@ def external_list(args):
 
 
 def display_package_specs(package_object):
-    """Requires that package objects come in the form of a list.
-    Helper function for displaying specs from PackageConfigEntry objects"""
+    """Helper function for displaying specs from PackageConfigEntry objects"""
     package = package_object[0]
     specs_to_display = package.specs_section()
     specs = specs_to_display.keys()
@@ -158,6 +161,6 @@ def display_package_specs(package_object):
 
 def external(parser, args):
     action = {"add": external_add,
-              "rm" : external_rm,
+              "rm": external_rm,
               "list": external_list}
     action[args.external_command](args)

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -79,6 +79,7 @@ def setup_parser(subparser):
                            default=spack.cmd.default_list_scope,
                            help="Configuration scope to read from")
 
+
 def external_add(args):
     """Add an external package to packages.yaml config."""
     package_spec = spack.spec.Spec(args.package_spec)
@@ -87,6 +88,8 @@ def external_add(args):
     external_package = ext_package.ExternalPackage.create_external_package(
                                             package_spec, external_location)
     ext_package.add_external_package(external_package, scope)
+    tty.msg("Added {0} to packages config scope={1}".format(package_spec,
+                                                            scope))
 
 
 def external_rm(args):
@@ -94,6 +97,8 @@ def external_rm(args):
     package_spec = spack.spec.Spec(args.package_spec)
     scope = args.scope
     ext_package.remove_package_from_packages_config(package_spec, scope)
+    tty.msg("Removed {0} from packages config scope={1}".format(package_spec,
+                                                                scope))
 
 
 def external_list(args):
@@ -111,7 +116,7 @@ def external_list(args):
 
 def display_package_specs(package_object):
     """Requires that package objects come in the form of a list.
-    Helper function for displaying specs from packageconfig objects"""
+    Helper function for displaying specs from PackageConfigEntry objects"""
     package = package_object[0]
     specs_to_display = package.specs_section()
     specs = specs_to_display.keys()

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -1,0 +1,131 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
+from llnl.util.lang import index_by
+import llnl.util.tty as tty
+from llnl.util.tty.colify import colify, colify_table
+from llnl.util.tty.color import colorize
+import spack
+import spack.cmd
+import spack.compilers
+import spack.config
+import spack.external_package as ext_package
+import spack.error
+import spack.spec
+
+description = "Add an external package entry to packages.yaml"
+
+
+def setup_parser(subparser):
+    """
+    Sets up parser for external add and external rm. The arguments are as
+    follows:
+        spack external add [package_spec] [path or module]
+    """
+    scopes = spack.config.config_scopes
+    # Set up subcommands external and rm and list
+    sp = subparser.add_subparsers(metavar="SUBCOMMAND",
+                                  dest = "external_command")
+    ################
+    # external add
+    ################
+    add_parser = sp.add_parser('add',
+                               help="Add packages to Spack's config file")
+    add_parser.add_argument("package_spec",
+                            help="spec for external package")
+    add_parser.add_argument("external_location",
+                            help="path or module (location) of external pkg")
+    add_parser.add_argument("--scope", choices=scopes,
+                            default=spack.cmd.default_modify_scope,
+                            help="Configuration scope to modify.")
+
+    ###############
+    # external rm
+    ###############
+    rm_parser = sp.add_parser('rm', help="Delete an entry from packages.yaml")
+    rm_parser.add_argument("package_spec",
+                           help="spec of a package to delete")
+    rm_parser.add_argument("--scope", choices=scopes,
+                           default=spack.cmd.default_modify_scope,
+                           help="Configuration scope to modify.")
+
+    ###############
+    # external list
+    ###############
+    ls_parser = sp.add_parser('list', help="List all available packages")
+    ls_parser.add_argument("--scope", choices=scopes,
+                           default=spack.cmd.default_list_scope,
+                           help="Configuration scope to read from")
+
+def external_add(args):
+    """Add an external package to packages.yaml config."""
+    package_spec = spack.spec.Spec(args.package_spec)
+    external_location = args.external_location
+    scope = args.scope
+    external_package = ext_package.ExternalPackage.create_external_package(
+                                            package_spec, external_location)
+    ext_package.add_external_package(external_package, scope)
+
+
+def external_rm(args):
+    """Removes an external package from packages.yaml"""
+    package_spec = spack.spec.Spec(args.package_spec)
+    scope = args.scope
+    ext_package.remove_package_from_packages_config(package_spec, scope)
+
+
+def external_list(args):
+    tty.msg("Available external packages")
+    scope = args.scope
+    packages_yaml = ext_package.PackagesConfig(scope)
+    all_packages = packages_yaml.all_external_packages()
+    index = index_by(all_packages, lambda p: p.package_name)
+    for i, (name, package) in enumerate(index.iteritems()):
+        if i >= 1:
+            print
+        tty.hline(name, char="-")
+        display_package_specs(package)
+
+
+def display_package_specs(package_object):
+    """Requires that package objects come in the form of a list.
+    Helper function for displaying specs from packageconfig objects"""
+    package = package_object[0]
+    specs_to_display = package.specs_section()
+    specs = specs_to_display.keys()
+    colorized_specs = [spack.spec.colorize_spec(s) for s in specs]
+    ext_location = specs_to_display.values()
+    max_width = max([len(s) for s in colorized_specs])
+    max_width += 3
+    output = "{spec: <{width}}{external}"
+    for spec, external in zip(colorized_specs, ext_location):
+        print output.format(spec=spec, width=max_width, external=external)
+
+
+def external(parser, args):
+    action = {"add": external_add,
+              "rm" : external_rm,
+              "list": external_list}
+    action[args.external_command](args)

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -37,6 +37,8 @@ import spack.spec
 
 
 description = "Add an external package entry to packages.yaml"
+section = "system"
+level = "long"
 
 
 def setup_parser(subparser):
@@ -118,6 +120,7 @@ def external_rm(args):
     for spec in removed_entries:
         tty.msg("Removed package: {0}".format(spec))
 
+
 def external_list(args):
     tty.msg("Available external packages")
     scope = args.scope
@@ -126,7 +129,7 @@ def external_list(args):
     index = index_by(all_packages, lambda p: p.package_name)
     for i, (name, package) in enumerate(index.iteritems()):
         if i >= 1:
-            print
+            print()
         tty.hline(name, char="-")
         display_package_specs(package)
 
@@ -140,9 +143,9 @@ def display_package_specs(package_object):
     ext_location = specs_to_display.values()
     max_width = max([len(s) for s in colorized_specs])
     max_width += 3
-    output = "{spec: <{width}}{external}"
+    output = "{spec: {width}}{external}"
     for spec, external in zip(colorized_specs, ext_location):
-        print output.format(spec=spec, width=max_width, external=external)
+        print(output.format(spec=spec, width=max_width, external=external))
 
 
 def external(parser, args):

--- a/lib/spack/spack/external_package.py
+++ b/lib/spack/spack/external_package.py
@@ -1,0 +1,498 @@
+import os
+
+import llnl.util.filesystem
+from llnl.util.lang import key_ordering
+import llnl.util.tty as tty
+from spack.util.spack_yaml import syaml_dict
+import spack.util.executable
+import spack.spec
+
+
+class PackageConfigEntry(object):
+    """
+    Class represents a package configuration entry.
+    Attributes:
+        package:        the entire dictionary for the package entry
+        package_name:   name of the package
+        external_type:  modules or paths
+        specs:          specs dictionary
+    Methods:
+        update_specs:   add a new spec to the specs dictionary
+        remove_spec:    given a spec, remove it from dictionary
+        config_entry:   turns package config entry into a syaml dict
+    """
+    def __init__(self, package_name, package_entry):
+        self.package_name = package_name
+        self.package = package_entry
+        self.external_type = self._find_external_type()
+        self.specs = self._get_specs(self.external_type)
+
+    def specs_section(self):
+        return self.specs
+
+    def is_spec_empty(self):
+        return self.specs == {}
+
+    def is_empty(self):
+        return self.package == {}
+
+    def update_specs(self, update_spec):
+        """
+        Adds specs to the specs_section of a package config
+        updates the package_dict attribute
+        """
+        self.specs.update(update_spec)
+        self.package[self.external_type] = self.specs
+
+    def remove_spec(self, spec_to_be_removed):
+        """
+        Remove a spec from the specs section
+        """
+        filtered_specs = self._filter_specs(spec_to_be_removed)
+        self.specs = filtered_specs
+        self.package[self.external_type] = filtered_specs
+
+    def _filter_specs(self, spec):
+        """Filter out specs that don't match the input spec"""
+        return {k: v for k, v in self.specs_section().iteritems() if
+                k != str(spec)}
+
+    def _get_specs(self, external_type):
+        return self.package.get(external_type, {})
+
+    def _find_external_type(self):
+        valid_types = ["modules", "paths"]
+        for external in valid_types:
+            specs_section = self._get_specs(external)
+            if specs_section:
+                return external
+
+    def config_entry(self):
+        """Turn object into config entry"""
+        return {self.package_name: self.package}
+
+
+class PackagesConfig(object):
+    """
+    Class represents the packages.yaml config file.
+
+    Attributes:
+        scope:            scope of the config file to be manipulated
+    Methods:
+        get_package:              returns a PackageConfigEntry object
+        update_package_config:    given a package dict, updates config file
+        remove_entire_entry_from_config:    remove an entire package entry
+    """
+
+    def __init__(self, scope):
+        self._scope = scope
+        self._packages_config = spack.config.get_config("packages", scope)
+
+    def get_package(self, package_name):
+        """
+        Given a package name, return a PackageConfigEntry object.
+
+        PackageConfigEntry represents a config entry. Can be manipulated
+        """
+        packages = spack.config.get_config("packages", self._scope)
+        return PackageConfigEntry(package_name,
+                                  self._packages_config.get(package_name, {}))
+
+    def update_package_config(self, package_entry):
+        """Update packages.yaml """
+        spack.config.update_config("packages", package_entry, self._scope)
+        package_name = package_entry.keys()[0]  # first entry is package name
+        tty.msg("Added {0} external package".format(package_name))
+
+    def remove_entire_entry_from_config(self, package_name):
+        """Remove an entire package name from the config"""
+        self._packages_config.pop(package_name)
+        self._overwrite_package_config()
+        tty.msg("Removed {0}".format(package_name))
+
+    def all_external_packages(self):
+        all_packages = []
+        for package_name, entry in self._packages_config.iteritems():
+            if package_name == "all":
+                continue
+            all_packages.append(PackageConfigEntry(package_name, entry))
+        return all_packages
+
+    def _overwrite_package_config(self):
+        scope = spack.config.validate_scope(self._scope)
+        scope.sections["packages"] = {'packages': self._packages_config}
+        scope.write_section("packages")
+
+
+def detect_version_by_prefix(path):
+    """
+    Return a version string if it is detected from a prefix.
+
+    Parses through the path directory names and searches for a string.
+    If a match is found, return that string.
+    """
+
+    def directory_string_represents_version(directory_name):
+        """
+        Returns true if directory name satisfies a version format
+        """
+        try:
+            if "-" in directory_name:
+                dir_list = directory_name.split("-")
+                number_list = dir_list[1]
+            else:
+                number_list = directory_name.split(".")
+            int(number_list[0])
+            return True
+        except ValueError:
+            return False
+
+    directory_names = path.split("/")
+    for directory in directory_names:
+        if directory_string_represents_version(directory):
+            return directory
+        else:
+            continue
+
+
+def detect_version_by_module(module_name):
+    """
+    Return a version string.
+
+    Parses output of module command. If it is able to find a successful match
+    return the version string.
+    """
+    module_command = spack.util.executable.which("modulecmd")
+    if module_command:
+        module_command.add_default_arg("python")
+        output = module_command("avail", module_name, output=str, error=str)
+        for line in output:
+            if "_VERSION" in line or "_VER" in line:
+                line_split = line.split()
+                version = line_split[len(line_split) - 1]
+                return version
+
+
+def detect_version(external_location):
+    """
+    Return a version string from called methods.
+
+    Calls different ways to detect a version and places them in a set.
+    If the set size is equal to one then pop the string out and return the
+    string.
+    """
+
+    def execute(function_to_call):
+        """Helper method to call functions with or without arguments"""
+        func, args = function_to_call
+        if args:
+            return func(args)
+        else:
+            return func()
+
+    detection_strategies = [(detect_version_by_module,
+                             external_location),
+                            (detect_version_by_prefix,
+                             external_location)]
+
+    successful_checks = {ver for ver in map(execute, detection_strategies) 
+                         if ver is not None}
+
+    # If our checks provided us with a single version then return that.
+    # Return nothing even if multiple versions were found, we only want one
+    # single version and want to avoid multiple version conflicts
+    if len(successful_checks) == 1:
+        return successful_checks.pop()
+
+
+@key_ordering
+class ExternalPackage(object):
+    """
+    Class creates external package objects.
+    Attributes:
+        spec               Spec object that describes the external package
+        external_location  either a path or a module describing how package
+                           can be located.
+        external_type      Is the type a path or a module
+        buildable          Is package meant to be built by Spack?
+
+    Properties:
+        version             Returns the version of external_package
+        name                Name of the package
+        external_type       Either module or path
+        external_location   How the package is meant to be found
+        spec                Returns spec object of external package
+    Methods:
+        spec_section        Returns spec section of a config dict
+        to_config_entry     Constructs a "config" representation of object
+        create_external_package  Alternate constructor for ExternalPackage.
+                                 This does do validate type and location
+    """
+
+    def __init__(self, spec, buildable, external_type, external_location):
+        """
+        Construct an external package object.
+        Does not check whether external type or external location are valid
+        types. 
+        """
+        if not isinstance(spec, spack.spec.Spec):
+            spec = spack.spec.Spec(spec)
+        self._spec = spec
+        self._external_location = external_location
+        self._external_type = external_type
+        self._buildable = buildable
+
+    @property
+    def version(self):
+        """
+        Return Version object
+        Requires that spec is well-formed and has a spec version attribute.
+        """
+        return self._spec.version
+
+    @property
+    def name(self):
+        """
+        Return name of the package.
+        Requires that spec is well-formed and has a spec name attribute.
+        """
+        return self._spec.name
+
+    @property
+    def external_type(self):
+        """
+        Return the type of the external package.
+        External packages can either be paths or module names.
+        """
+        return self._external_type
+
+    @property
+    def external_location(self):
+        """
+        Return the location of an external package.
+        Location can either be a path to the installed package or a module
+        name.
+        """
+        return self._external_location
+
+    @property
+    def spec(self):
+        """
+        Return Spec representation of external object.
+        Requires that spec be well-formed.
+        """
+        return self._spec
+
+    def _cmp_key(self):
+        """
+        Return a tuple
+        Uses a tuple of attributes to compare objects of similar type
+        """
+        return (self._spec, self._external_location, self._external_type)
+
+    def __str__(self):
+        return str(self._spec)
+
+    def __repr__(self):
+        return "ExternalPackage({0}, {1})".format(self._spec,
+                                                  self._external_location)
+
+    def spec_section(self):
+        """
+        Return the specs section entry to a package configuration.
+        Specs section follow the form { package_spec : path/to/package }
+        """
+        return syaml_dict([(str(self.spec), self.external_location)])
+
+    def to_config_entry(self):
+        """
+        Return the config entry structure for an external package.
+        """
+        # create the inner most yaml entry
+        entry = syaml_dict([("buildable", self._buildable),
+                            (self.external_type, self.spec_section())])
+        return syaml_dict([(self.name, entry)])
+
+    @classmethod
+    def create_external_package(cls, spec, external_location):
+        """
+        Return an external package object.
+
+        Calls methods to detect the external type of the specified external
+        package location and also to detect a version. If the version is
+        not detected and a version was not specified in the spec, then it will
+        output a message to notify user to input a spec with a version.
+
+        Once it is able to determine the external type and attempts to
+        determine a version, then it will call the ExternalPackage's
+        constructor to create an object.
+        """
+
+        def _get_version_from_spec(package_spec):
+            try:
+                return str(package_spec.version)
+            except spack.spec.SpecError:
+                return None
+
+        external_type = cls._find_external_type(external_location)
+
+        if external_type == "unknown":
+            tty.die("Could not detect correct path or module for %s" % spec)
+        elif external_type == "paths":
+            cls._validate_package_path_installation(external_location, spec)
+
+        found_version = detect_version(external_location)
+        spec_version = _get_version_from_spec(spec)
+
+        if not found_version and not spec_version:
+            tty.die("Could not detect version for package {0}\n"
+                    "Please provide a spec with a version".format(spec))
+
+        package_spec = cls._update_spec(spec, spec_version, found_version)
+        buildable = False  # default setting for an external package
+        external_package = cls(package_spec,
+                               buildable,
+                               external_type,
+                               external_location)
+        return external_package
+
+    @staticmethod
+    def _update_spec(spec, spec_version, found_version):
+        """
+        Return a spec with a version.
+
+        Updates the spec with the version found. If there was no version
+        detected then return the spec. If a version was found on the spec
+        and there is a version that was detected and they do not match then
+        raise an error. Otherwise, update the spec string and create a new
+        Spec object from the string.
+        """
+        if not found_version:
+            return spec
+        if spec_version and spec_version != found_version:
+            raise SpecVersionMisMatch(spec)
+        spec_string = str(spec)
+        index = len(spec.name)  # index where we want to change version
+        new_spec_string = spec_string[:index] + \
+                          "@{0}".format(found_version) + spec_string[index:]
+        new_spec = spack.spec.Spec(new_spec_string)
+        return new_spec
+
+    @staticmethod
+    def _find_external_type(external_package_location):
+        """
+        Return a external type detected from the given location.
+
+        If the location is a directory or a real path then return "paths".
+        Otherwise, check to see if location responds to module command.
+        If it does, then return "modules".
+
+        If neither works, return "unknown"
+        """
+        if os.path.isdir(external_package_location):
+            return "paths"
+        else:
+            modulecmd = spack.util.executable.which("modulecmd")
+            if modulecmd:
+                modulecmd.add_default_args("python")
+                output = modulecmd("show", external_package_location,
+                                   output=str, error=str)
+                if "ERROR" not in output:
+                    return "modules"
+            return "unknown"
+
+    @staticmethod
+    def _validate_package_path_installation(path, spec):
+        """
+        Returns if and only if directories and/or files include the package
+        name.
+
+        Traverses a list of directories standard to an install path and checks
+        whether files are found that include the package name.
+        """
+        def find_spec_name_match_in_directory(dirpath):
+            """Search package directory for files that match package name"""
+            if os.path.exists(dirpath):
+                files = os.listdir(dirpath)
+                for f in files:
+                    if spec.name in f:
+                        return True
+
+        valid_checks = []
+        for directory in ["bin", "lib", "share", "include"]:
+            directory_path = llnl.util.filesystem.join_path(path, directory)
+            valid_checks.append(find_spec_name_match_in_directory(
+                directory_path))
+        if not any(valid_checks):
+            tty.die("Incorrect path: {1} for package {0}".format(path, spec))
+
+
+def add_external_package(external_package, scope):
+    """
+    Add an external package entry to packages.yaml.
+    Determines whether a package exists, if so then append to the existing
+    entry. If there are no entries for the package, then add the new entry.
+    """
+    packages_config = PackagesConfig(scope)
+
+    def duplicate_specs(spec, existing_specs):
+        for k in existing_specs.keys():
+            if spack.spec.Spec(k) == spec:
+                return True
+        return False
+
+    existing_package_entry = packages_config.get_package(external_package.name)
+    specs_section = existing_package_entry.specs_section()
+
+    if existing_package_entry.is_empty():
+        package_entry = external_package.to_config_entry()
+        packages_config.update_package_config(package_entry)
+    elif not duplicate_specs(external_package.spec, specs_section):
+        existing_package_entry.update_specs(external_package.spec_section())
+        new_package_entry = existing_package_entry.config_entry()
+        packages_config.update_package_config(new_package_entry)
+    else:
+        tty.msg("Added no new external packages")
+
+
+def remove_package_from_packages_config(package_spec, scope):
+    """
+    Remove a external package entry.
+
+    Given a package spec, search the config file for a matching spec and
+    remove it. If it is the final entry of the spec, remove the entire entry.
+    """
+    packages_config = PackagesConfig(scope)
+    package_entry = packages_config.get_package(package_spec.name)
+    previous_specs_section = package_entry.specs_section()
+
+    if previous_specs_section:
+        package_entry.remove_spec(package_spec)
+    else:
+        tty.die("Could not find spec {0}".format(package_spec))
+
+    if len(previous_specs_section) == len(package_entry.specs_section()):
+        raise PackageSpecInsufficientlySpecificError(package_spec)
+    elif package_entry.is_spec_empty():
+        packages_config.remove_entire_entry_from_config(package_spec.name)
+    else:
+        packages_config.update_package_config(
+            package_entry.config_entry())
+
+
+class PackageSpecInsufficientlySpecificError(spack.error.SpackError):
+    def __init__(self, package_spec):
+        super(PackageSpecInsufficientlySpecificError, self).__init__(
+            "Multiple packages match package spec {0}".format(package_spec))
+
+
+class SpecVersionMisMatch(spack.error.SpackError):
+    def __init__(self, package_spec):
+        super(SpecVersionMisMatch, self).__init__(
+            "Found version and spec version do not match"
+        )
+
+class UnknownExternalType(spack.error.SpackError):
+    def __init__(self, package_spec):
+        super(UnknownExternalType, self).__init__(
+                "Could not determine location of {}".format(package_spec))

--- a/lib/spack/spack/external_package.py
+++ b/lib/spack/spack/external_package.py
@@ -397,6 +397,25 @@ class ExternalPackage(object):
 
 
     @classmethod
+    def find_external_pacakges(cls, package_spec=None):
+        """Attempts to find system packages.
+
+        Currently, uses the modulecmd and parses for all packages. If
+        a package_spec is given, the name will be used to search for packages.
+        If no args are given it will attempt to find packages depending on
+        the platform it is located.
+
+        Args:
+            package_spec: an optional spec object
+        Returns:
+            a list of ExternalPackage objects
+        """
+        # Packages should probably tell us how to find themselves given a 
+        # System. At the moment I will only support cray packages.
+        return []
+
+
+    @classmethod
     def create_external_package(cls, spec, external_location):
         """Return an external package object.
 

--- a/lib/spack/spack/external_package.py
+++ b/lib/spack/spack/external_package.py
@@ -336,6 +336,25 @@ class ExternalPackage(object):
         return syaml_dict([(self.name, entry)])
 
     @classmethod
+    def find_external_pacakges(cls, package_spec=None):
+        """Attempts to find system packages.
+
+        Currently, uses the modulecmd and parses for all packages. If
+        a package_spec is given, the name will be used to search for packages.
+        If no args are given it will attempt to find packages depending on
+        the platform it is located.
+
+        Args:
+            package_spec: an optional spec object
+        Returns:
+            a list of ExternalPackage objects
+        """
+        # Packages should probably tell us how to find themselves given a 
+        # System. At the moment I will only support cray packages.
+        return []
+
+
+    @classmethod
     def create_external_package(cls, spec, external_location):
         """Return an external package object.
 
@@ -353,7 +372,7 @@ class ExternalPackage(object):
             package_location: either a prefix path string or a module name.
 
         Returns:
-            an ExternalPackage object. 
+            an ExternalPackage object.
         """
 
         def _get_version_from_spec(package_spec):
@@ -421,6 +440,7 @@ class ExternalPackage(object):
                 modulecmd.add_default_arg("python")
                 output = modulecmd("show", external_package_location,
                                    output=str, error=str)
+                print output
                 if "ERROR" not in output:
                     return "modules"
             return "unknown"

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -105,8 +105,8 @@ class ExternalCmdTest(mock_test.MockPackagesTest):
     def test_error_thrown_when_spec_not_specific(self):
         spec = spack.spec.Spec("externalvirtual")
         args = MockArgs(spec)
-        with self.assertRaises(SystemExit):  # tty.error multiple pkg match
-            spack.cmd.external.external_rm(args)
+        # tty.die multiple packages match...
+        self.assertRaises(SystemExit, spack.cmd.external.external_rm, args)
 
     def test_remove_entire_entry_after_specs_section_is_empty(self):
         spec = spack.spec.Spec("externaltool@1.0%gcc@4.5.0")
@@ -120,5 +120,4 @@ class ExternalCmdTest(mock_test.MockPackagesTest):
         spec = spack.spec.Spec("boost%gcc@6.1.0")
         args = MockArgs(spec)
         # tty.die(Could not find package for spec..)
-        with self.assertRaises(SystemExit): 
-            spack.cmd.external.external_rm(args)
+        self.assertRaises(SystemExit, spack.cmd.external.external_rm, args)

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -1,0 +1,118 @@
+import spack.architecture
+from spack.test.mock_packages_test import *
+import spack.config
+import spack.spec
+from spack.external_package import *
+
+class MockArgs(object):
+    def __init__(self, package_spec="", external_location="unknown"):
+        self.package_spec = package_spec
+        self.external_location = external_location
+        self.scope = "site"  # Hardcoded for consistency in using site scope
+
+
+def get_packages_config_file():
+    return spack.config.get_config("packages", "site")
+
+
+def get_specs_section(packages_config, name_of_package, external_type):
+    return packages_config.get(name_of_package, {}).get(external_type, {})
+
+
+# Create different types of packages
+def create_duplicate_package():
+    return ExternalPackage("externaltool@1.0%gcc@4.5.0",
+                           False,
+                           "paths",
+                           "path/to/external_tool")
+
+
+def create_new_external_package_to_add():
+    return ExternalPackage("externallibrary@1.9.5%gcc@6.1.0",
+                           False,
+                           "paths",
+                           "path/to/externallibrary")
+
+
+def create_external_package_to_add_to_existing_package():
+    return ExternalPackage("externaltool@1.5%gcc@4.5.0",
+                           False,
+                           "paths",
+                           "path/to/externaltool_ver1.5")
+
+
+class ExternalCmdTest(MockPackagesTest):
+    """ Test the external creation of a external spec and also test
+    that it gets properly written to a packages.yaml
+    """
+    #########################
+    # test spack external add
+    #########################
+
+    def test_append_new_entry_to_config(self):
+        external_library = create_new_external_package_to_add()
+        add_external_package(external_library, "site")
+        full_packages_config = get_packages_config_file()
+        self.assertTrue("externallibrary" in full_packages_config.keys())
+
+        # Check whether the added entry has an appropriate structure
+        specs_section = get_specs_section(full_packages_config,
+                                          external_library.name,
+                                          "paths")
+        self.assertTrue("externallibrary@1.9.5%gcc@6.1.0" in
+                        specs_section.keys())
+        self.assertTrue("path/to/externallibrary" in specs_section.values())
+
+    def test_append_to_existing_entry(self):
+        external_tool = create_external_package_to_add_to_existing_package()
+        add_external_package(external_tool, "site")
+        full_packages_config = get_packages_config_file()
+        self.assertTrue(1 == full_packages_config.keys().count("externaltool"))
+
+        specs_section = get_specs_section(full_packages_config,
+                                          external_tool.name,
+                                          "paths")
+        self.assertTrue(str(external_tool.spec) in specs_section.keys())
+        # Test that we didn't overwrite the entire entry with our new one
+        self.assertTrue(len(specs_section.keys()) > 1)
+
+    def test_avoid_duplicate_to_existing_entry(self):
+        external_tool = create_duplicate_package()
+        add_external_package(external_tool, "site")
+        full_packages_config = get_packages_config_file()
+        externaltool_specs = get_specs_section(full_packages_config,
+                                               external_tool.name,
+                                               "paths")
+
+        self.assertTrue(externaltool_specs.keys().count(
+            "externaltool@1.0%gcc@4.5.0") == 1)
+
+    ########################
+    # test spack external rm
+    ########################
+    def test_remove_correct_entry_from_config(self):
+        spec = spack.spec.Spec("externalmodule@1.0%gcc@4.5.0")
+        remove_package_from_packages_config(spec, "site")
+        full_packages_config = get_packages_config_file()
+        external_module_specs = get_specs_section(full_packages_config,
+                                                  spec.name,
+                                                  "modules")
+        self.assertTrue("externalmodule@1.0%gcc@4.5.0"
+                        not in external_module_specs.keys())
+
+    def test_error_thrown_when_spec_not_specific(self):
+        spec = spack.spec.Spec("externalmodule@1.0")
+        with self.assertRaises(PackageSpecInsufficientlySpecificError):
+            remove_package_from_packages_config(spec, "site")
+
+    def test_remove_entire_entry_after_specs_section_is_empty(self):
+        spec = spack.spec.Spec("externaltool@1.0%gcc@4.5.0")
+        remove_package_from_packages_config(spec, "site")
+        full_packages_config = get_packages_config_file()
+        self.assertTrue("externaltool" not in full_packages_config.keys())
+        self.assertTrue("externalvirtual" in full_packages_config.keys())
+
+    def test_remove_when_spec_is_not_found(self):
+        spec = spack.spec.Spec("boost%gcc@6.1.0")
+        with self.assertRaises(SystemExit):  # tty.die error
+            remove_package_from_packages_config(spec, "site")

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -1,5 +1,6 @@
+import pytest
+
 import spack.architecture
-import spack.test.mock_packages_test as mock_test
 import spack.cmd.external
 import spack.config
 import spack.spec
@@ -15,8 +16,8 @@ class MockArgs(object):
 
 
 def get_packages_config_file():
-    return spack.config.get_config("packages", "site")
-
+    """Return the full config file"""
+    return spack.config.get_config("packages", scope="site")
 
 def get_specs_section(packages_config, name_of_package, external_type):
     return packages_config.get(name_of_package, {}).get(external_type, {})
@@ -42,7 +43,8 @@ def create_external_package_to_add_to_existing_package():
                                                   path_to_externaltool)
 
 
-class ExternalCmdTest(mock_test.MockPackagesTest):
+@pytest.mark.usefixtures("config")
+class TestExternalCmd(object):
     """ Test the external creation of a external spec and also test
     that it gets properly written to a packages.yaml
     """
@@ -54,28 +56,29 @@ class ExternalCmdTest(mock_test.MockPackagesTest):
         external_library = create_new_external_package_to_add()
         spack.external_package.add_external_package(external_library, "site")
         full_packages_config = get_packages_config_file()
-        self.assertTrue("externallibrary" in full_packages_config.keys())
+
+        assert "externallibrary" in full_packages_config.keys()
 
         # Check whether the added entry has an appropriate structure
         specs_section = get_specs_section(full_packages_config,
                                           external_library.name,
                                           "paths")
-        self.assertTrue("externallibrary@1.9.5%gcc@6.1.0" in
-                        specs_section.keys())
-        self.assertTrue("path/to/externallibrary" in specs_section.values())
+
+        assert "externallibrary@1.9.5%gcc@6.1.0" in specs_section.keys()
+        assert "path/to/externallibrary" in specs_section.values()
 
     def test_append_to_existing_entry(self):
         external_tool = create_external_package_to_add_to_existing_package()
         spack.external_package.add_external_package(external_tool, "site")
         full_packages_config = get_packages_config_file()
-        self.assertTrue(1 == full_packages_config.keys().count("externaltool"))
+        assert 1 == full_packages_config.keys().count("externaltool")
 
         specs_section = get_specs_section(full_packages_config,
                                           external_tool.name,
                                           "paths")
-        self.assertTrue(str(external_tool.spec) in specs_section.keys())
+        assert str(external_tool.spec) in specs_section.keys()
         # Test that we didn't overwrite the entire entry with our new one
-        self.assertTrue(len(specs_section.keys()) > 1)
+        assert len(specs_section.keys()) > 1
 
     def test_avoid_duplicate_to_existing_entry(self):
         external_tool = create_duplicate_package()
@@ -85,8 +88,8 @@ class ExternalCmdTest(mock_test.MockPackagesTest):
                                                external_tool.name,
                                                "paths")
 
-        self.assertTrue(externaltool_specs.keys().count(
-            "externaltool@1.0%gcc@4.5.0") == 1)
+        assert externaltool_specs.keys().count(
+                "externaltool@1.0%gcc@4.5.0") == 1
 
     ########################
     # test spack external rm
@@ -99,25 +102,30 @@ class ExternalCmdTest(mock_test.MockPackagesTest):
         external_module_specs = get_specs_section(full_packages_config,
                                                   spec.name,
                                                   "modules")
-        self.assertTrue("externalmodule@1.0%gcc@4.5.0"
-                        not in external_module_specs.keys())
+        assert "externalmodule@1.0%gcc@4.5.0" \
+                not in external_module_specs.keys()
 
     def test_error_thrown_when_spec_not_specific(self):
         spec = spack.spec.Spec("externalvirtual")
         args = MockArgs(spec)
         # tty.die multiple packages match...
-        self.assertRaises(SystemExit, spack.cmd.external.external_rm, args)
+        with pytest.raises(SystemExit):
+            spack.cmd.external.external_rm(args)
 
     def test_remove_entire_entry_after_specs_section_is_empty(self):
-        spec = spack.spec.Spec("externaltool@1.0%gcc@4.5.0")
-        args = MockArgs(spec)
+        spec_1 = spack.spec.Spec("externaltool@1.0%gcc@4.5.0")
+        spec_2 = spack.spec.Spec("externaltool@1.5%gcc@4.5.0")
+        args = MockArgs(spec_1)
+        args2 = MockArgs(spec_2)
         spack.cmd.external.external_rm(args)
+        spack.cmd.external.external_rm(args2)
         full_packages_config = get_packages_config_file()
-        self.assertTrue("externaltool" not in full_packages_config.keys())
-        self.assertTrue("externalvirtual" in full_packages_config.keys())
+        assert "externaltool" not in full_packages_config.keys()
+        assert "externalvirtual" in full_packages_config.keys()
 
     def test_remove_when_spec_is_not_found(self):
         spec = spack.spec.Spec("boost%gcc@6.1.0")
         args = MockArgs(spec)
         # tty.die(Could not find package for spec..)
-        self.assertRaises(SystemExit, spack.cmd.external.external_rm, args)
+        with pytest.raises(SystemExit):
+            spack.cmd.external.external_rm(args)

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -28,6 +28,7 @@ import os
 import re
 import shutil
 from six import StringIO
+import tempfile
 
 import llnl.util.filesystem
 import llnl.util.lang

--- a/lib/spack/spack/test/external_package.py
+++ b/lib/spack/spack/test/external_package.py
@@ -14,14 +14,12 @@ from spack.util.spack_yaml import syaml_dict
 class TestExternalPackage(object):
     """Test ExternalPackage class."""
 
+    @pytest.mark.skipif("cray" in spack.architecture.sys_type(),
+                        reason="Requires cray packages to test")
     def test_find_cray_packages(self):
         cray_packages = ExternalPackage.find_external_packages()
         correct_packages = True
         assert cray_packages
-        for package in cray_packages:
-            if not "cray-" in package:
-                correct_packages = False
-        assert correct_packages
 
 
     def make_fake_install_path(self, path, exe_name, fake_external_package):

--- a/lib/spack/spack/test/external_package.py
+++ b/lib/spack/spack/test/external_package.py
@@ -74,21 +74,21 @@ class TestExternalPackage(MockPackagesTest):
     def test_when_external_type_not_detected(self):
         spec = spack.spec.Spec("externalpackage@1.8.5%gcc@6.1.0")
         non_existent_path = "path/to/externaltool"
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(SystemExit): # tty.die error
             ExternalPackage.create_external_package(spec, non_existent_path)
 
-    def test_when_no_version_in_spec_and_no_version_detected(self): 
+    def test_when_no_version_in_spec_and_no_version_detected(self):
         package_spec = spack.spec.Spec("externaltool%gcc@4.3")
         self.make_fake_install_path("path/to/externaltool",
                                                  "externaltool")
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(SystemExit): # tty.die error
             ExternalPackage.create_external_package(package_spec,
                                                     self.external_package_path)
 
         if spack.architecture.sys_type() == "cray":
             module_spec = spack.spec.Spec("externalmodule%gcc@4.3")
             no_version_module = "externalmodule"
-            with self.assertRaises(SystemExit):
+            with self.assertRaises(SystemExit): # tty.die error
                 ExternalPackage.create_external_package(module_spec,
                                                         no_version_module)
         else:

--- a/lib/spack/spack/test/external_package.py
+++ b/lib/spack/spack/test/external_package.py
@@ -14,6 +14,16 @@ from spack.util.spack_yaml import syaml_dict
 class TestExternalPackage(object):
     """Test ExternalPackage class."""
 
+    def test_find_cray_packages(self):
+        cray_packages = ExternalPackage.find_external_packages()
+        correct_packages = True
+        assert cray_packages
+        for package in cray_packages:
+            if not "cray-" in package:
+                correct_packages = False
+        assert correct_packages
+
+
     def make_fake_install_path(self, path, exe_name, fake_external_package):
         """Make a temporary path to a fake package """
         temp_path = fake_external_package

--- a/lib/spack/spack/test/external_package.py
+++ b/lib/spack/spack/test/external_package.py
@@ -1,0 +1,117 @@
+import shutil
+import tempfile
+
+from llnl.util.filesystem import mkdirp, join_path, touchp, touch
+import spack
+import spack.architecture
+from spack.environment import EnvironmentModifications
+from spack.external_package import ExternalPackage, SpecVersionMisMatch
+import spack.spec
+from spack.test.mock_packages_test import *
+from spack.util.spack_yaml import syaml_dict
+
+
+def set_to_modulepath(path):
+    env = EnvironmentModifications()
+    env.append_path("MODULEPATH", path)
+    env.apply_modifications()
+
+
+def remove_from_modulepath(path):
+    env = EnvironmentModifications()
+    env.remove_path("MODULEPATH", path)
+    env.apply_modifications()
+
+
+class TestExternalPackage(MockPackagesTest):
+    """Test ExternalPackage class."""
+
+    def make_fake_install_path(self, path, exe_name):
+        """Make a temporary path to a fake package """
+        fake_root_path = join_path(self.external_package_path, path)
+        exe_path = join_path(fake_root_path, "bin", exe_name)
+        touchp(exe_path)
+        for p in ["lib", "share", "include"]:
+            package_path = join_path(fake_root_path, p)
+            mkdirp(package_path)
+        # Set the path we created to external_package_path directory
+        self.external_package_path = fake_root_path
+
+    def setUp(self):
+        set_to_modulepath(spack.mock_modulefiles_path)
+        # tmp directory set to attribute so tests can append to this path
+        self.external_package_path = tempfile.mkdtemp() 
+        super(TestExternalPackage, self).setUp()
+
+    def tearDown(self):
+        remove_from_modulepath(spack.mock_modulefiles_path)
+        shutil.rmtree(self.external_package_path, ignore_errors=True)
+        super(TestExternalPackage, self).tearDown()
+
+    def test_package_detection_in_paths(self):
+        spec = spack.spec.Spec("externalpackage@1.8.5%gcc@6.1.0")
+        self.make_fake_install_path("external_package/1.8.5",
+                                    "externalpackage")
+        actual_package = ExternalPackage.create_external_package(
+                                            spec, self.external_package_path)
+        expected_package = ExternalPackage(spec,
+                                           False,
+                                           "paths",
+                                           self.external_package_path)
+        self.assertEquals(actual_package, expected_package)
+
+    def test_package_detection_in_modules(self):
+        if spack.architecture.sys_type() == "cray":
+            spec = spack.spec.Spec("externalmodule@1.0%gcc@6.1.0")
+            module_name = "externalmodule"
+            actual_package = ExternalPackage.create_external_package(
+                                                        spec, module_name)
+            expected_package = ExternalPackage(spec, module_name, "modules")
+            self.assertEquals(actual_package, expected_package)
+        else:
+            self.assertTrue(True)
+
+    def test_when_external_type_not_detected(self):
+        spec = spack.spec.Spec("externalpackage@1.8.5%gcc@6.1.0")
+        non_existent_path = "path/to/externaltool"
+        with self.assertRaises(SystemExit):
+            ExternalPackage.create_external_package(spec, non_existent_path)
+
+    def test_when_no_version_in_spec_and_no_version_detected(self): 
+        package_spec = spack.spec.Spec("externaltool%gcc@4.3")
+        self.make_fake_install_path("path/to/externaltool",
+                                                 "externaltool")
+        with self.assertRaises(SystemExit):
+            ExternalPackage.create_external_package(package_spec,
+                                                    self.external_package_path)
+
+        if spack.architecture.sys_type() == "cray":
+            module_spec = spack.spec.Spec("externalmodule%gcc@4.3")
+            no_version_module = "externalmodule"
+            with self.assertRaises(SystemExit):
+                ExternalPackage.create_external_package(module_spec,
+                                                        no_version_module)
+        else:
+            self.assertTrue(True)
+
+    def test_when_spec_version_and_found_version_dont_match(self):
+        spec = spack.spec.Spec("externalpackage@1.7.0%gcc@6.1.0")
+        self.make_fake_install_path("external_package/1.8.5",
+                                    "externalpackage")
+        with self.assertRaises(SpecVersionMisMatch):
+            ExternalPackage.create_external_package(spec,
+                                                    self.external_package_path)
+
+    def test_proper_config_entry_creation(self):
+        spec = spack.spec.Spec("externalpackage@1.8.5%gcc@6.1.0")
+        path = "path/to/external_package"
+        buildable = False
+        external_type = "paths"
+        external_package = ExternalPackage(spec, buildable, external_type,
+                                           path)
+        # subject to change once we move to json?
+        specs_yaml = syaml_dict([(str(spec), "path/to/external_package")])
+        complete_specs_yaml = syaml_dict([("buildable", False),
+                                           ("paths", specs_yaml)])
+        proper_yaml = syaml_dict([("externalpackage", complete_specs_yaml)])
+        self.assertEquals(external_package.to_config_entry(), proper_yaml)

--- a/lib/spack/spack/test/external_package.py
+++ b/lib/spack/spack/test/external_package.py
@@ -40,7 +40,7 @@ class TestExternalPackage(mock_test.MockPackagesTest):
     def setUp(self):
         set_to_modulepath(spack.mock_modulefiles_path)
         # tmp directory set to attribute so tests can append to this path
-        self.external_package_path = tempfile.mkdtemp() 
+        self.external_package_path = tempfile.mkdtemp()
         super(TestExternalPackage, self).setUp()
 
     def tearDown(self):
@@ -72,23 +72,28 @@ class TestExternalPackage(mock_test.MockPackagesTest):
     def test_when_external_type_not_detected(self):
         spec = spack.spec.Spec("externalpackage@1.8.5%gcc@6.1.0")
         non_existent_path = "path/to/externaltool"
-        with self.assertRaises(SystemExit):  # tty.die error
-            ExternalPackage.create_external_package(spec, non_existent_path)
+        # tty.die error
+        self.assertRaises(SystemExit,
+                          ExternalPackage.create_external_package,
+                          spec, non_existent_path)
 
     def test_when_no_version_in_spec_and_no_version_detected(self):
         package_spec = spack.spec.Spec("externaltool%gcc@4.3")
         self.make_fake_install_path("path/to/externaltool",
                                     "externaltool")
-        with self.assertRaises(SystemExit):  # tty.die error
-            ExternalPackage.create_external_package(package_spec,
-                                                    self.external_package_path)
+        # tty.die error
+        self.assertRaises(SystemExit,
+                          ExternalPackage.create_external_package,
+                          package_spec,
+                          self.external_package_path)
 
         if spack.architecture.sys_type() == "cray":
             module_spec = spack.spec.Spec("externalmodule%gcc@4.3")
             no_version_module = "externalmodule"
-            with self.assertRaises(SystemExit):  # tty.die error
-                ExternalPackage.create_external_package(module_spec,
-                                                        no_version_module)
+            self.assertRaises(SystemExit,
+                              ExternalPackage.create_external_package,
+                              module_spec,
+                              no_version_module)
         else:
             self.assertTrue(True)
 
@@ -96,9 +101,10 @@ class TestExternalPackage(mock_test.MockPackagesTest):
         spec = spack.spec.Spec("externalpackage@1.7.0%gcc@6.1.0")
         self.make_fake_install_path("external_package/1.8.5",
                                     "externalpackage")
-        with self.assertRaises(SpecVersionMisMatch):
-            ExternalPackage.create_external_package(spec,
-                                                    self.external_package_path)
+        self.assertRaises(SpecVersionMisMatch,
+                          ExternalPackage.create_external_package,
+                          spec,
+                          self.external_package_path)
 
     def test_proper_config_entry_creation(self):
         spec = spack.spec.Spec("externalpackage@1.8.5%gcc@6.1.0")

--- a/var/spack/mock_modulefiles/externalmodule/1.0
+++ b/var/spack/mock_modulefiles/externalmodule/1.0
@@ -1,0 +1,22 @@
+#%Module
+## Mock module file for testing modules. Requires system to have tclmodules
+
+set              name             external-module
+set              version          1.0
+set              root             /global/homes/m/mamelara/myspack/var/spack/repos/builtin.mock/packages/$name/$version
+
+
+set             fullname          $name
+set             externalurl       http://www.example.com
+set             description       "Fake module for testing with spack"
+
+proc ModulesHelp { } {
+    global description externalurl
+    puts stderr "Description - $description"
+    puts stderr "Other Docs  - $externalurl"
+}
+
+module-whatis                   "$description"
+
+prepend-path       PATH                $root/bin
+prepend-path       MANPATH             $root/share


### PR DESCRIPTION
First working design for new spack external add/rm/list command. Would like some feedback on it.

Usage works as follows:
```spack external add [package_spec] [path_or_module_for_external_pkg]```
```spack external rm [package_spec]```
```spack external list```
All take an optional scope flag

**external add**
The external add command takes in a package spec (with or without a package version) and either a path or module name. This information is passed to the ExternalPackage class which then validates the path or module and attempts to detect a version. If a version is not detected and the user did not specify a version in the spec, a version is spit out. Otherwise, that version is appended to the spec. An external package object is created and is used to add an entry to packages.yaml. 

example:
```┌[mamelara::spack
└┤[16:53] ➜ spack external add mpich@7.4.4%gcc@6.2.0 cray-mpich/7.4.4
==> Added mpich@7.4.4%gcc@6.2.0 to /global/homes/m/mamelara/.spack/cray/packages.yaml
```

**external rm**
The external rm command also takes as input a package_spec. It will remove the specified spec entry from a package. If that package entry is empty (no specs) then that entire package entry is removed.

example:
```
┌[mamelara::spack
└┤[16:54] ➜ spack external rm mpich@7.4.4%gcc@6.2.0
==> Removed package: mpich@7.4.4%gcc@6.2.0
==> Removed mpich
```
**external list**
Outputs the contents of a list. Similar to compiler list. 

output:
```
┌[mamelara::spack
└┤[16:56] ➜ spack external list
==> Available external packages
-- petsc --------------------------------------------------------
petsc@3.6.1.0%gcc@6.2.0   cray-petsc/3.6.1.0

-- mkl ----------------------------------------------------------
mkl@11.3.2.181%intel@16.0.3.210   /opt/intel/compilers_and_libraries_2016.3.210/linux/mkl

-- netcdf -------------------------------------------------------
netcdf@4.4.1%intel@16.0.3.210   cray-netcdf/4.4.1
netcdf@4.4.1%gcc@6.2.0          cray-netcdf/4.4.1

-- hdf5 ---------------------------------------------------------
hdf5@1.8.16%gcc@6.2.0          cray-hdf5/1.8.16
hdf5@1.8.14%intel@16.0.3.210   cray-hdf5/1.8.14
hdf5@1.8.16%intel@16.0.3.210   cray-hdf5/1.8.16
```

So far I've tested this on Cori and on my Mac. Please feel free to comment on it and I'm open to all kinds of suggestions and looking to improve functionality and design. Thanks!

Note: I'm not too excited about how I have been detecting versions from packages. Currently, I just look through the path for something that looks like a version and stick it on to the spec string. I also parse the output of module avail but not sure if my way is too NERSC specific. 

Another thing, I added more tests and a mock modulefiles path to test modulecmd with fake modulefiles. Hopefully people will find that useful.