### PR TITLE
open-jdk: a sketch of the package

### DIFF
--- a/var/spack/repos/builtin/packages/open-jdk/package.py
+++ b/var/spack/repos/builtin/packages/open-jdk/package.py
@@ -1,0 +1,47 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class OpenJdk(Package):
+    """Open-source JDK
+    """
+
+    homepage = "http://openjdk.java.net"
+
+    version('9.0', hg='http://hg.openjdk.java.net/jdk9/jdk9')
+
+    def install(self, spec, prefix):
+        Executable('chmod')('u+x', 'get_source.sh')
+        Executable('./get_source.sh')()
+        Executable('chmod')('u+x', 'configure')
+        opt = [
+            # '--with-boot-jdk=/path/to'
+            '--with-toolchain-type=clang'
+        ]
+        configure('--prefix=%s' % prefix,
+                  *opt)
+        make('all')
+        make('install')


### PR DESCRIPTION
currently fails with 
```
checking for version string... 9-internal+0-adhoc.davydden.jdk9
Unable to find any JVMs matching version "(null)".
No Java runtime present, try --request to install.
configure: Found potential Boot JDK using /usr/libexec/java_home 
configure: Potential Boot JDK found at  did not contain bin/java; ignoring
Unable to find any JVMs matching version "1.9".
No Java runtime present, try --request to install.
configure: Found potential Boot JDK using /usr/libexec/java_home -v 1.9
configure: Potential Boot JDK found at  did not contain bin/java; ignoring
Unable to find any JVMs matching version "1.8".
No Java runtime present, try --request to install.
configure: Found potential Boot JDK using /usr/libexec/java_home -v 1.8
configure: Potential Boot JDK found at  did not contain bin/java; ignoring
Unable to find any JVMs matching version "1.7".
No Java runtime present, try --request to install.
configure: Found potential Boot JDK using /usr/libexec/java_home -v 1.7
configure: Potential Boot JDK found at  did not contain bin/java; ignoring
checking for javac... /usr/bin/javac
checking for java... /usr/bin/java
configure: Could not find a valid Boot JDK. 
configure: This might be fixed by explicitly setting --with-boot-jdk
configure: error: Cannot continue
configure exiting with result code 1
```

I would probably not pursue this further, but still could be a starting point for others, thus `up-for-grabs`