### PR TITLE
Allow packages to set set the paths where they install library and include files

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -1803,6 +1803,20 @@ it installs include files to the ``h`` subdirectory, and libraries to the
        include_paths = ['h']
        lib_paths = ['modules', 'lib64']
 
+If your package has a unique layout or if it has some
+configuration-dependent paths, you can use expressions inside of your
+paths, like this for includes in ``$prefix/include/boost-1.61.0``::
+
+    class Boost(Package):
+        include_paths = ['include/boost-{version.dotted}']
+
+or like this for libraries in ``lib/versioned-libraries-1.61``::
+
+    class VersionedLibraries(Package):
+        lib_paths = ['lib/versioned-libraries-{version.up_to(2)}']
+
+you can use any expression in ``{}`` that would work on a ``Spec``
+object in a package.
 
 When you set ``include_paths`` and ``lib_paths`` this way, it changes the
 behavior of Spack's compiler wrappers.  The compiler wrappers include

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -62,8 +62,9 @@ parameters=(
 #   SPACK_DEBUG
 # Test command is used to unit test the compiler script.
 #   SPACK_TEST_COMMAND
-# Dependencies can be empty for pkgs with no deps:
-#   SPACK_DEPENDENCIES
+# Lists of dependencies' include and library directories,
+# which can be empty for pkgs with no deps:
+#   SPACK_LIB_PATHS, SPACK_RPATHS, SPACK_INCLUDE_PATHS
 
 # die()
 # Prints a message and exits with error 1.
@@ -265,75 +266,34 @@ case "$mode" in cc|ccld)
         ;;
 esac
 
-# Read spack dependencies from the path environment variable
-IFS=':' read -ra deps <<< "$SPACK_DEPENDENCIES"
-for dep in "${deps[@]}"; do
+# Read spack dependencies from the environment variables
+IFS=':' read -ra dirs <<< "$SPACK_LIB_PATHS"
+for dir in "${dirs[@]}"; do
+    # Prepend lib directories
+    if [[ $mode == ccld || $mode == ld ]]; then
+        args=("-L$dir" "${args[@]}")
+    fi
+done
+
+IFS=':' read -ra dirs <<< "$SPACK_INCLUDE_PATHS"
+for dir in "${dirs[@]}"; do
     # Prepend include directories
-    if [[ -d $dep/include ]]; then
-        if [[ $mode == cpp || $mode == cc || $mode == as || $mode == ccld ]]; then
-            args=("-I$dep/include" "${args[@]}")
-        fi
-    fi
-
-    # Prepend lib and RPATH directories
-    if [[ -d $dep/lib ]]; then
-        if [[ $mode == ccld ]]; then
-            if [[ $SPACK_RPATH_DEPS == *$dep* ]]; then
-                $add_rpaths && args=("$rpath$dep/lib" "${args[@]}")
-            fi
-            if [[ $SPACK_LINK_DEPS == *$dep* ]]; then
-                args=("-L$dep/lib" "${args[@]}")
-            fi
-        elif [[ $mode == ld ]]; then
-            if [[ $SPACK_RPATH_DEPS == *$dep* ]]; then
-                $add_rpaths && args=("-rpath" "$dep/lib" "${args[@]}")
-            fi
-            if [[ $SPACK_LINK_DEPS == *$dep* ]]; then
-                args=("-L$dep/lib" "${args[@]}")
-            fi
-        fi
-    fi
-
-    # Prepend lib64 and RPATH directories
-    if [[ -d $dep/lib64 ]]; then
-        if [[ $mode == ccld ]]; then
-            if [[ $SPACK_RPATH_DEPS == *$dep* ]]; then
-                $add_rpaths && args=("$rpath$dep/lib64" "${args[@]}")
-            fi
-            if [[ $SPACK_LINK_DEPS == *$dep* ]]; then
-                args=("-L$dep/lib64" "${args[@]}")
-            fi
-        elif [[ $mode == ld ]]; then
-            if [[ $SPACK_RPATH_DEPS == *$dep* ]]; then
-                $add_rpaths && args=("-rpath" "$dep/lib64" "${args[@]}")
-            fi
-            if [[ $SPACK_LINK_DEPS == *$dep* ]]; then
-                args=("-L$dep/lib64" "${args[@]}")
-            fi
-        fi
+    if [[ $mode == cpp || $mode == cc || $mode == as || $mode == ccld ]]; then
+        args=("-I$dir" "${args[@]}")
     fi
 done
 
-# Include all -L's and prefix/whatever dirs in rpath
-if [[ $mode == ccld ]]; then
-    $add_rpaths && args=("$rpath$SPACK_PREFIX/lib64" "${args[@]}")
-    $add_rpaths && args=("$rpath$SPACK_PREFIX/lib"   "${args[@]}")
-elif [[ $mode == ld ]]; then
-    $add_rpaths && args=("-rpath" "$SPACK_PREFIX/lib64" "${args[@]}")
-    $add_rpaths && args=("-rpath" "$SPACK_PREFIX/lib"   "${args[@]}")
+if [[ $add_rpaths == true ]]; then
+    # Add rpath directories
+    IFS=':' read -ra dirs <<< "$SPACK_RPATHS"
+    for dir in "${dirs[@]}"; do
+        if [[ $mode == ccld ]]; then
+            args=("$rpath$dir" "${args[@]}")
+        elif [[ $mode == ld ]]; then
+            args=("-rpath" "$dir" "${args[@]}")
+        fi
+    done
 fi
-
-# Set extra RPATHs
-IFS=':' read -ra extra_rpaths <<< "$SPACK_COMPILER_EXTRA_RPATHS"
-for extra_rpath in "${extra_rpaths[@]}"; do
-    if [[ $mode == ccld ]]; then
-        $add_rpaths && args=("$rpath$extra_rpath" "${args[@]}")
-        args=("-L$extra_rpath" "${args[@]}")
-    elif [[ $mode == ld ]]; then
-        $add_rpaths && args=("-rpath" "$extra_rpath" "${args[@]}")
-        args=("-L$extra_rpath" "${args[@]}")
-    fi
-done
 
 # Add SPACK_LDLIBS to args
 case "$mode" in

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -403,11 +403,13 @@ def get_rpath_deps(pkg):
 def get_rpaths(pkg):
     """Get a list of all the rpaths for a package."""
     rpaths = [pkg.prefix.lib, pkg.prefix.lib64]
+
     deps = get_rpath_deps(pkg)
-    rpaths.extend(d.prefix.lib for d in deps
-                  if os.path.isdir(d.prefix.lib))
-    rpaths.extend(d.prefix.lib64 for d in deps
-                  if os.path.isdir(d.prefix.lib64))
+    rpaths.extend(
+        d.prefix.lib for d in deps if os.path.isdir(d.prefix.lib))
+    rpaths.extend(
+        d.prefix.lib64 for d in deps if os.path.isdir(d.prefix.lib64))
+
     # Second module is our compiler mod name. We use that to get rpaths from
     # module show output.
     if pkg.compiler.modules and len(pkg.compiler.modules) > 1:

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1891,13 +1891,7 @@ class PackageBase(with_metaclass(PackageMeta, object)):
     @property
     def rpath(self):
         """Get the rpath this package links with, as a list of paths."""
-        rpaths = [self.prefix.lib, self.prefix.lib64]
-        deps = self.spec.dependencies(deptype='link')
-        rpaths.extend(d.prefix.lib for d in deps
-                      if os.path.isdir(d.prefix.lib))
-        rpaths.extend(d.prefix.lib64 for d in deps
-                      if os.path.isdir(d.prefix.lib64))
-        return rpaths
+        return spack.build_environment.get_rpaths(self)
 
     @property
     def rpath_args(self):

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -555,6 +555,12 @@ class PackageBase(with_metaclass(PackageMeta, object)):
     #: Do not include @ here in order not to unnecessarily ping the users.
     maintainers = []
 
+    #: Prefix-relative paths where this package installs include files
+    include_paths = ['include']
+
+    #: Prefix-relative paths where this package installs library files
+    lib_paths = ['lib', 'lib64']
+
     def __init__(self, spec):
         # this determines how the package should be built.
         self.spec = spec

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2841,6 +2841,31 @@ class Spec(object):
     def colorized(self):
         return colorize_spec(self)
 
+    def pyformat(self, string):
+        """Format a Spec with python expressions.
+
+        Args:
+            string (str): a string, potentially with format expressions in
+                curly braces
+
+        Returns:
+            (str): string with all format expressions replaced with
+                their evlauted value
+
+        Format strings are evaluated as though they were called on this
+        spec.  For example, this::
+
+            'lib/python{version.up_to(2)}/site-packages'
+
+        Might evaluate to ``'lib/python2.6/site-packages'`` if the
+        ``version`` attribute of this ``Spec`` is ``2.6``.  This syntax
+        is inteded for packagers and others who deal with Specs in
+        Python, not for end-user facing code.
+        """
+        def replacer(m):
+            return str(eval('self.%s' % m.group(1), {'self': self}, {}))
+        return re.sub(r'\{([^\}]*)\}', replacer, string)
+
     def format(self, format_string='$_$@$%@+$+$=', **kwargs):
         """Prints out particular pieces of a spec, depending on what is
         in the format string.

--- a/lib/spack/spack/test/path_list.py
+++ b/lib/spack/spack/test/path_list.py
@@ -1,0 +1,85 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+"""Test lazily computed path attributes on packages."""
+import os
+import pytest
+
+import spack
+from spack.spec import Spec
+
+
+def test_simple_pathattr(builtin_mock, config):
+    spec = Spec('has-path-attr').concretized()
+    pkg = spack.repo.get(spec)
+    assert pkg.simple_path_list == 'include'
+    assert pkg.path_list('simple_path_list') == [
+        os.path.join(pkg.prefix, 'include')]
+
+
+def test_no_such_pathattr(builtin_mock, config):
+    spec = Spec('has-path-attr').concretized()
+    pkg = spack.repo.get(spec)
+
+    with pytest.raises(AttributeError):
+        pkg.path_list('xxxx')
+
+
+def test_version_pathattr(builtin_mock, config):
+    spec3 = Spec('has-path-attr').concretized()
+    pkg3 = spack.repo.get(spec3)
+
+    assert pkg3.path_list('short_version_path_list') == [
+        os.path.join(pkg3.prefix, 'example/pkg-1.3')]
+    assert pkg3.path_list('long_version_path_list')  == [
+        os.path.join(pkg3.prefix, 'example/pkg-1.3.0')]
+
+    spec2 = Spec('has-path-attr@1.2.0').concretized()
+    pkg2 = spack.repo.get(spec2)
+
+    spec1 = Spec('has-path-attr@1.1.0').concretized()
+    pkg1 = spack.repo.get(spec1)
+
+    assert pkg2.path_list('short_version_path_list') == [
+        os.path.join(pkg2.prefix, 'example/pkg-1.2')]
+    assert pkg2.path_list('long_version_path_list')  == [
+        os.path.join(pkg2.prefix, 'example/pkg-1.2.0')]
+
+    assert pkg1.path_list('short_version_path_list') == [
+        os.path.join(pkg1.prefix, 'example/pkg-1.1')]
+    assert pkg1.path_list('long_version_path_list')  == [
+        os.path.join(pkg1.prefix, 'example/pkg-1.1.0')]
+
+
+def test_path_list_pathattr(builtin_mock, config):
+    spec = Spec('has-path-attr').concretized()
+    pkg = spack.repo.get(spec)
+
+    assert pkg.path_list('subdir_list_path_list') == [
+        os.path.join(pkg.prefix, 'lib64'),
+        os.path.join(pkg.prefix, 'lib/hasattr-1.3.0')]
+
+    assert pkg.path_list('plain_list_path_list') == [
+        os.path.join(pkg.prefix, 'lib64'),
+        os.path.join(pkg.prefix, 'lib')]

--- a/var/spack/repos/builtin.mock/packages/has-path-attr/package.py
+++ b/var/spack/repos/builtin.mock/packages/has-path-attr/package.py
@@ -1,0 +1,43 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class HasPathAttr(Package):
+    homepage = "http://www.example.com"
+    url      = "http://www.example.com/has-path-attr-0.8.13.tar.gz"
+
+    version('1.3.0', '4136d7b4c04df68b686570afa26988ac')
+    version('1.2.0', 'e21f8273d9f5f6d43a59878dc274fec7')
+    version('1.1.0', '9db4d36c283d9790d8fa7df1f4d7b4d9')
+
+    simple_path_list = 'include'
+    short_version_path_list = "example/pkg-{version.up_to(2)}"
+    long_version_path_list = "example/pkg-{version.up_to(3)}"
+    subdir_list_path_list = ['lib64', 'lib/hasattr-{version.up_to(3)}']
+    plain_list_path_list = ['lib64', 'lib']
+
+    def install(self, spec, prefix):
+        pass

--- a/var/spack/repos/builtin/packages/libelf/package.py
+++ b/var/spack/repos/builtin/packages/libelf/package.py
@@ -39,6 +39,8 @@ class Libelf(AutotoolsPackage):
 
     provides('elf@0')
 
+    include_paths = ['include/libelf', 'include']
+
     def configure_args(self):
         args = ["--enable-shared",
                 "--disable-dependency-tracking",


### PR DESCRIPTION
This adds a new capability for Spack packages, allowing them to describe their library and include installation subdirectories so dependent packages can find them.  This was motivated by libelf, which was installing header files to PREFIX/include/libelf/, which other packages weren't finding.

More specifically, packages can now set the `include_paths` and `lib_paths` package-scope variables to new locations (they currently default to `['include']` and `['lib', 'lib64']`).  For packages that do this, it will affect their own `RPATH`'ing to their library install location, and it will affect how dependent packages search for their libraries and include files.

This pull request breaks this down into several parts:
- Refactors the code that computes include, library, and rpath directory locations so it lives in `build_environment.py` rather than the compiler wrappers.  A secondary goal here is to also allow us to eventually do a better job at filtering out system include and library directories (which hasn't been written yet).
- Rewrites large swaths of the cc test to accommodate this refactoring (the test was making assumptions about how Spack communicates with its compiler wrappers).
- Adds the new `lib_paths` and `include_paths` feature, plus documentation.
- Moves libelf to use the new include_paths feature.  Nothing uses `lib_paths` yet, but it's there.