### PR TITLE
Bugs when Merging Configurations

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -199,6 +199,7 @@ class ConfigScope(object):
     def __repr__(self):
         return '<ConfigScope: %s: %s>' % (self.name, self.path)
 
+
 #
 # Below are configuration scopes.
 #

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -342,19 +342,20 @@ def _merge_yaml(dest, source):
 
     # Source list is prepended (for precedence)
     if they_are(list):
-        dest[:] = source + [x for x in dest if x not in source]
-        return dest
+        ret = source + [x for x in dest if x not in source]
+        return ret
 
     # Source dict is merged into dest.
     elif they_are(dict):
+        ret = copy.copy(dest)
         for sk, sv in source.iteritems():
             if override(sk) or sk not in dest:
                 # if sk ended with ::, or if it's new, completely override
-                dest[sk] = copy.copy(sv)
+                ret[sk] = copy.copy(sv)
             else:
                 # otherwise, merge the YAML
-                dest[sk] = _merge_yaml(dest[sk], source[sk])
-        return dest
+                ret[sk] = _merge_yaml(dest[sk], source[sk])
+        return ret
 
     # In any other case, overwrite with a copy of the source value.
     else:


### PR DESCRIPTION
The function `_merge_yaml()` was buggy because objects within two separate `dict` trees could be aliased together.  In my example case, I had `id(dest['packages']['all']['versions']) == id(dest['packages']['ibmisc']['versions'])` because both were initially equal to the empty list `[]`.  When `_merge_yaml()` appended to one list, it appeneded to both --- producing surprising (and wrong) results.

@tgamblin Can you please check this PR to see if there are any other places that need a similar fix?

To see the bug in action without this patch, use the following `packages.yaml` files:

```
etc/spack/defaults/packages.yaml:
-----------------------------------
packages:
  ibmisc:

  all:
    compiler: [gcc, intel, pgi, clang, xl, nag]
    providers:
      mpi: [openmpi, mpich]
      blas: [openblas]
      lapack: [openblas]
      pil: [py-pillow]
```
```
~/.spack/packages.yaml
------------------------
packages:
  ibmisc:
    version: [develop]
```
Then try `spack config get packages`, which yields surprising results:
```
$ spack config get packages
packages:
  all:
    buildable: true
    compiler:
    - gcc
    - intel
    - pgi
    - clang
    - xl
    - nag
    modules: {}
    paths: {}
    providers:
      blas:
      - openblas
      lapack:
      - openblas
      mpi:
      - openmpi
      - mpich
      pil:
      - py-pillow
    version:
    - develop     # <<< This is wrong... should be []
  ibmisc:
    buildable: true
    compiler: []
    modules: {}
    paths: {}
    providers: {}
    version:
    - develop
```

This will cause the `@develop` version to be (wrongly) used on any package where it's possible; for example on `hypre`:
```
$ spack spec hypre
hypre@develop%gcc@4.9.3+internal-superlu+shared arch=linux-centos7-x86_64
    ^openblas@0.2.19%gcc@4.9.3~openmp+pic+shared arch=linux-centos7-x86_64
    ^openmpi@1.10.1%gcc@4.9.3~java~mxm~pmi~psm~psm2~slurm~sqlite3~thread_multiple~tm~verbs+vt arch=linux-centos7-x86_64
        ^hwloc@1.11.4%gcc@4.9.3 arch=linux-centos7-x86_64
            ^libpciaccess@0.13.4%gcc@4.9.3 arch=linux-centos7-x86_64
                ^libtool@2.4.6%gcc@4.9.3 arch=linux-centos7-x86_64
                    ^m4@1.4.17%gcc@4.9.3+sigsegv arch=linux-centos7-x86_64
                        ^libsigsegv@2.10%gcc@4.9.3 arch=linux-centos7-x86_64
                ^pkg-config@0.29.1%gcc@4.9.3+internal_glib arch=linux-centos7-x86_64
                ^util-macros@1.19.0%gcc@4.9.3 arch=linux-centos7-x86_64
```