### PR TITLE
Spackenv: Script to create environments based on `spack module loads`

### DIFF
--- a/bin/spackenv
+++ b/bin/spackenv
@@ -1,0 +1,165 @@
+#!/usr/bin/env python
+#
+##############################################################################
+# Copyright (c) 2013-2016, Elizabeth Fischer
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
+from __future__ import print_function
+
+import argparse
+import sys
+import os
+import subprocess
+import tempfile
+
+class SpackError(Exception):
+    pass
+
+def read_env(env_path):
+    # Read the env
+    spack_cmd = ['spack']
+    installs = []    # List of command lines for `spack install`
+    with open(env_path) as fin:
+        for line in fin:
+            line = line.strip()
+            if line[:8] == '# spack=':
+                spack_cmd = line[8:].split()
+                continue
+
+            sharp = line.find('#')
+            if sharp >= 0:
+                line = line[:sharp]
+            if len(line) > 0:
+                sections = line.split(':') + ['']    # Second section is optional
+                parsed = tuple([x.split() for x in sections[0:2]])
+                installs.append(parsed)
+    return spack_cmd,installs
+
+def read_log(log_path):
+    ret = []
+
+    cur_spec = None
+    with open(log_path, 'r') as fin:
+        for line in fin:
+            if line[:9] != 'SPACKENV ':
+                continue
+            line = line[9:].split()
+            if line[0] == 'BEGIN':
+                if cur_spec != None:
+                    ret.append((cur_spec, cur_installed))
+                cur_spec = line[1]
+                cur_installed = list()
+            elif line[0] == 'INSTALLED':
+                cur_installed.append(line[1])
+            elif line[0] == 'COMPLETE':
+                ret.append((cur_spec, cur_installed))
+                return ret
+    raise SpackError('Incomplete logfile; did Spack finish?')
+
+
+def install_env(env_name, src_dir=None, env_dir=None):
+    spack_cmd,installs = read_env(os.path.join(src_dir, env_name + '.env'))
+
+    # Do the `spack installs`
+    with open(os.path.join(os.path.join(env_dir, env_name + '.log')), 'w') as fout:
+        for install,load in installs:
+            with tempfile.TemporaryFile('w+') as ferr:
+                cmd = spack_cmd + ['install', '-I', '--report'] + install
+                fout.write('\n==============> spackenv\n' + ' '.join(cmd) + '\n')
+                proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=ferr)
+                for line in iter(proc.stdout.readline,''):
+                    sys.stdout.write(line)
+                    fout.write(line)
+                proc.wait()
+
+                ferr.seek(0)
+                for line in ferr:
+                    sys.stdout.write(line)
+                    fout.write(line)
+
+
+            if proc.returncode != 0:
+                raise SpackError('Spack failed with return code=%d' % proc.returncode)
+
+        fout.write('SPACKENV COMPLETE\n')
+
+def loads_env(env_name, src_dir=None, env_dir=None):
+    spack_cmd,installs = read_env(os.path.join(src_dir, env_name + '.env'))
+    log = read_log(os.path.join(env_dir, env_name + '.log'))
+
+    with open(os.path.join(env_dir, env_name), 'w') as fout:
+        for (install_args,loads_args),(spec,installed) in zip(installs,log):
+            for hash in installed:
+                cmd = spack_cmd + ['module', 'loads'] + loads_args + [hash]
+                print(' '.join(cmd))
+
+                proc = subprocess.Popen(cmd, stdout=fout)
+                proc.wait()
+
+                if proc.returncode != 0:
+                    raise SpackError('Spack failed with return code=%d' % proc.returncode)
+
+
+def install_envs(env_names, *args, **kwargs):
+    for env in env_names:
+        install_env(env, *args, **kwargs)
+
+def loads_envs(env_names, *args, **kwargs):
+    for env in env_names:
+        loads_env(env, *args, **kwargs)
+
+
+_action = {
+    'install' : install_envs,
+    'loads' : loads_envs
+}
+
+def validate_args(args):
+    kwargs = {
+        'src_dir' : args.src,
+        'env_dir' : args.env
+    }
+    return kwargs
+
+def main():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        description="Manage entire environments built by Spack")
+    parser.add_argument('--env',
+        help="Directory that holds the environments")
+    parser.add_argument('--src',
+        help="Directory that holds the source (.env) files")
+
+    parser.add_argument(dest='command', choices=['install', 'loads'])
+    parser.add_argument(dest='envs', nargs='+')
+
+    # Print help if no commands
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(1)
+
+    args = parser.parse_args()
+
+    try:
+        _action[args.command](args.envs, **validate_args(args))
+    except SpackError as e:
+        print(e)
+
+main()
+

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -376,7 +376,10 @@ def top_install(
             tty.die("Nothing to install, due to the --only flag")
     else:    # install_package = True, install_dependencies=?
         package = spack.repo.get(spec)
-        package.do_install(install_dependencies=False, explicit=True, **kwargs)
+        package.do_install(
+            install_dependencies=install_dependencies,
+            explicit=True,
+            **kwargs)
 
         if report:
             print 'SPACKENV INSTALLED %s/%s' % (spec.name, spec.dag_hash())


### PR DESCRIPTION
The Problem
============

I've been able to build my stuff with Spack, but was still having problems assembling a proper set of `spack module loads` commands to use it.  The reason is because I need to support multiple configurations / subsets of my overall system.  For example, they might be:

1. Just the climate model
2. Just the ice model and coupler
3. Just the Python stuff needed for data processing
4. Any combination of (1), (2) and (3)
5. The kitchen sink
6. Potentially develop or release versions of the above (where some packages in the develop version are set up by hand using `spack setup`).

This PR makes it easier to create *environment scripts* --- that is, files full of `module load` commands --- based on this variety of needs.  It is built as a separate Python executable program that calls Spack multiple times (to ensure robustness, so I don't hit bugs like #2666).

One serious problem up till now is that `spack load`, `spack module loads`, etc. do not have the benefit of concretization; they are resolved completely differently from `spack install` (although concretization is slow, so doing it in `spack load` would be a mixed blessing).  The problem is that once you've used a spec for `spack install`, there is no easy / foolproof / automatable way to subsequently issue a `spack load` command for that module.  If you have many similar installed versions in your Spack, that could be a real problem.  This PR gets around that issue by tracking the hash that Spack uses to install the original spec, and then issuing a `spack module loads` command for that hash.

@tgamblin @eschnett  @mathstuf @adamjstewart @becker33 @hartzell 
Comments welcome, this software is "hot off the press."  I'm especially interested in design ideas at this point.  My guess is this script is a little "far out," and will need some iteration on design.  I'm also hoping to get better / more robust file formats, but am not sure of what would be best.

Brief Docs
========

The user creates *environment files* (`.env`) in a `src` directory.  `spackenv` then turns them into *environment scripts* (no extension) in an `env` directory.  Users can then `source` those scripts in their Bash shell.

Here is a sample environment file:
```
envsrc/test.env
----------------
# `spack install` args : `spack module loads` args
#
# spack=spack --config ~/config-scopes/icebin-develop

--only dependencies libpciaccess
emacs : --dependencies
```
This environment consists of emacs (and all its dependencies), plus the dependencies for libpciaccess (but not their dependencies).  Syntactically, it works as so:

1. The `spack=` directive gives the Spack command that `spackenv` is to use.  This is to allow for environments to use different configurations (eg `packages.yaml` files; see #2686).

2. Each line consists of two parts, separated by a colon.  The first part is command line arguments to be sent to `spack install`.  The second part (optional) is command line arguments to be sent to `spack module loads`.

`spackenv` has two sub-commands: `spackenv install` and `spackenv loads`.

spackenv install
--------------------

`spackenv install` runs `spack install` once per line in the `.env` file.  It creates a `.log` files with Spack's output, and tees it to STDOUT as well.  Here is the log for a typical `spackenv install` command; the contents of `~/env/test.log` is also displayed to STDOUT here:
```
$ spackenv --src ~/envsrc --env ~/env install test
[+]  a6hzhtg  libpciaccess@0.13.4%gcc@4.9.3 arch=linux-centos7-x86_64
[+]  q5ztpkl      ^libtool@2.4.6%gcc@4.9.3 arch=linux-centos7-x86_64
[+]  kmufpwm          ^m4@1.4.17%gcc@4.9.3+sigsegv arch=linux-centos7-x86_64
[+]  ytewamh              ^libsigsegv@2.10%gcc@4.9.3 arch=linux-centos7-x86_64
[+]  zmirozy      ^pkg-config@0.29.1%gcc@4.9.3+internal_glib arch=linux-centos7-x86_64
[+]  36ec63z      ^util-macros@1.19.0%gcc@4.9.3 arch=linux-centos7-x86_64

SPACKENV BEGIN libpciaccess
==> util-macros is already installed in /home2/rpfische/spack5/opt/spack/linux-centos7-x86_64/gcc-4.9.3/util-macros-1.19.0-36ec63zxfqtarj4wzuztzeckh6th53kp
SPACKENV INSTALLED util-macros/36ec63zxfqtarj4wzuztzeckh6th53kp
==> libtool is already installed in /home2/rpfische/spack5/opt/spack/linux-centos7-x86_64/gcc-4.9.3/libtool-2.4.6-q5ztpklzt3emeq3p7rqguoqyht5lac36
SPACKENV INSTALLED libtool/q5ztpklzt3emeq3p7rqguoqyht5lac36
==> pkg-config is already installed in /home2/rpfische/spack5/opt/spack/linux-centos7-x86_64/gcc-4.9.3/pkg-config-0.29.1-zmirozyvyf5jfalrz5vgge2uydgjtviq
SPACKENV INSTALLED pkg-config/zmirozyvyf5jfalrz5vgge2uydgjtviq
[+]  xmvbkdg  emacs@25.1%gcc@4.9.3~X toolkit=gtk arch=linux-centos7-x86_64
[+]  h66uwdb      ^ncurses@6.0%gcc@4.9.3 arch=linux-centos7-x86_64

SPACKENV BEGIN emacs
==> emacs is already installed in /home2/rpfische/spack5/opt/spack/linux-centos7-x86_64/gcc-4.9.3/emacs-25.1-xmvbkdgpwvy4sedr2tl4a2yrx4togbiu
SPACKENV INSTALLED emacs/xmvbkdgpwvy4sedr2tl4a2yrx4togbiu
```
This is just typical Spack output.  The extra lines starting with `SPACKENV` are parsed later by `spackenv`.  Note that if stuff was already installed (for real or via `spack setup`), `spackenv install` won't build anything.

`spackenv loads`
-------------------

The script of `module load` commands is generated by `spackenv loads`.  Once `spackenv install` has run successfully, the user can run `spackenv loads`, as follows:
```
$ spackenv --src ~/envsrc --env ~/env loads test
spack --config ~/config-scopes/icebin-develop module loads util-macros/36ec63zxfqtarj4wzuztzeckh6th53kp
spack --config ~/config-scopes/icebin-develop module loads libtool/q5ztpklzt3emeq3p7rqguoqyht5lac36
spack --config ~/config-scopes/icebin-develop module loads pkg-config/zmirozyvyf5jfalrz5vgge2uydgjtviq
spack --config ~/config-scopes/icebin-develop module loads --dependencies emacs/xmvbkdgpwvy4sedr2tl4a2yrx4togbiu
```
Here, `spackenv` shows you what commands it's running.  It also produces the file `~/env/test`, which looks like:
```
$ cat ~/env/test
# util-macros@1.19.0%gcc@4.9.3 arch=linux-centos7-x86_64
module load util-macros-1.19.0-gcc-4.9.3-36ec63z
# libtool@2.4.6%gcc@4.9.3 arch=linux-centos7-x86_64
module load libtool-2.4.6-gcc-4.9.3-q5ztpkl
# pkg-config@0.29.1%gcc@4.9.3+internal_glib arch=linux-centos7-x86_64
module load pkg-config-0.29.1-gcc-4.9.3-zmirozy
# ncurses@6.0%gcc@4.9.3 arch=linux-centos7-x86_64
module load ncurses-6.0-gcc-4.9.3-h66uwdb
# emacs@25.1%gcc@4.9.3~X toolkit=gtk arch=linux-centos7-x86_64
module load emacs-25.1-gcc-4.9.3-xmvbkdg
```
This file may now be used to load up the specified environment in a Bash shell.









[This PR depends on #2664...]
