### PR TITLE
CentOS7 Package Versions

### DIFF
--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Curl(Package):
+class Curl(AutotoolsPackage):
     """cURL is an open source command line tool and library for
     transferring data with URL syntax"""
 

--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -44,14 +44,14 @@ class Curl(Package):
     version('7.44.0', '6b952ca00e5473b16a11f05f06aa8dae')
     version('7.43.0', '11bddbb452a8b766b932f859aaeeed39')
     version('7.42.1', '296945012ce647b94083ed427c1877a8')
+    version('7.29.0', 'fa5f37f38a8042020e292ce7ec5341ce') # CentOS7
 
     depends_on("openssl")
     depends_on("zlib")
 
-    def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix,
-                  '--with-zlib=%s' % spec['zlib'].prefix,
-                  '--with-ssl=%s' % spec['openssl'].prefix)
-
-        make()
-        make("install")
+    def configure_args(self):
+        spec = self.spec
+        return [
+            '--prefix=%s' % prefix,
+            '--with-zlib=%s' % spec['zlib'].prefix,
+            '--with-ssl=%s' % spec['openssl'].prefix]

--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -52,6 +52,5 @@ class Curl(AutotoolsPackage):
     def configure_args(self):
         spec = self.spec
         return [
-            '--prefix=%s' % prefix,
             '--with-zlib=%s' % spec['zlib'].prefix,
             '--with-ssl=%s' % spec['openssl'].prefix]

--- a/var/spack/repos/builtin/packages/libpng/package.py
+++ b/var/spack/repos/builtin/packages/libpng/package.py
@@ -46,5 +46,7 @@ class Libpng(AutotoolsPackage):
 
     # Required for qt@3
     version('1.2.57', 'dfcda3603e29dcc11870c48f838ef75b')
+    # CentOS7
+    version('1.5.13', '9c5a584d4eb5fe40d0f1bc2090112c65')
 
     depends_on('zlib@1.0.4:')  # 1.2.5 or later recommended

--- a/var/spack/repos/builtin/packages/libpng/package.py
+++ b/var/spack/repos/builtin/packages/libpng/package.py
@@ -44,9 +44,8 @@ class Libpng(AutotoolsPackage):
     #     1.6.27, 1.5.28, 1.4.20, 1.2.57, and 1.0.67, released on 29
     #     December 2016.
 
+    version('1.5.13', '9c5a584d4eb5fe40d0f1bc2090112c65') # CentOS7
     # Required for qt@3
     version('1.2.57', 'dfcda3603e29dcc11870c48f838ef75b')
-    # CentOS7
-    version('1.5.13', '9c5a584d4eb5fe40d0f1bc2090112c65')
 
     depends_on('zlib@1.0.4:')  # 1.2.5 or later recommended

--- a/var/spack/repos/builtin/packages/libxaw/package.py
+++ b/var/spack/repos/builtin/packages/libxaw/package.py
@@ -33,6 +33,7 @@ class Libxaw(AutotoolsPackage):
     url      = "https://www.x.org/archive/individual/lib/libXaw-1.0.13.tar.gz"
 
     version('1.0.13', '6c522476024df5872cddc5f1562fb656')
+    version('1.0.12', 'a1dd3ced7cefe99b2db8a5d390cf5fe9') # CentOS7
 
     depends_on('libx11')
     depends_on('libxext')

--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -38,10 +38,13 @@ class Openssl(Package):
     list_url = "https://www.openssl.org/source/old/"
     list_depth = 2
 
-    # Note: Version 1.0.2 is the "long-term support" version that will
-    # remain supported until 2019. We could thus make this version the
-    # preferred version, if we find that many packages cannot handle
-    # version 1.1.
+    # Note:
+    # 1. Version 1.0.2 is the "long-term support" version that will
+    #    remain supported until 2019. We could thus make this version the
+    #    preferred version, if we find that many packages cannot handle
+    #    version 1.1.
+    # 1. Many of these versions have known vulnerabilities.
+    #    See: https://www.openssl.org/news/vulnerabilities.html
     version('1.1.0e', '51c42d152122e474754aea96f66928c6')
     version('1.1.0d', '711ce3cd5f53a99c0e12a7d5804f0f63')
     version('1.1.0c', '601e8191f72b18192a937ecf1a800f3f')
@@ -57,6 +60,7 @@ class Openssl(Package):
     version('1.0.1t', '9837746fcf8a6727d46d22ca35953da1')
     version('1.0.1r', '1abd905e079542ccae948af37e393d28')
     version('1.0.1h', '8d6d684a9430d5cc98a62a5d8fbda8cf')
+    version('1.0.1e', '66bf6f10f060d561929de96f9dfe5b8c') # CentOS7
 
     depends_on('zlib')
 

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -36,7 +36,7 @@ from spack.util.environment import *
 import spack.util.spack_json as sjson
 
 
-class Python(AutotoolsPackage):
+class Python(Package):
     """The Python programming language."""
 
     homepage = "http://www.python.org"

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -36,7 +36,7 @@ from spack.util.environment import *
 import spack.util.spack_json as sjson
 
 
-class Python(Package):
+class Python(AutotoolsPackage):
     """The Python programming language."""
 
     homepage = "http://www.python.org"

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -58,6 +58,7 @@ class Python(Package):
     version('2.7.10', 'd7547558fd673bd9d38e2108c6b42521')
     version('2.7.9', '5eebcaa0030dc4061156d3429657fb83')
     version('2.7.8', 'd4bca0159acb0b44a781292b5231936f')
+    version('2.7.5', 'b4f01a1d0ba0b46b05c73b2ac909b1df') # CentOS7
 
     extendable = True
 

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -41,6 +41,7 @@ class Qt(Package):
     version('5.3.2',  'febb001129927a70174467ecb508a682')
     version('5.2.1',  'a78408c887c04c34ce615da690e0b4c8')
     version('4.8.6',  '2edbe4d6c2eff33ef91732602f3518eb')
+    version('4.8.5',  '1864987bdbb2f58f8ae8b350dfdbe133') # CentOS7
     version('3.3.8b', '9f05b4125cfe477cc52c9742c3c09009')
 
     # Add patch for compile issues with qt3 found with use in the

--- a/var/spack/repos/builtin/packages/xz/package.py
+++ b/var/spack/repos/builtin/packages/xz/package.py
@@ -35,5 +35,5 @@ class Xz(AutotoolsPackage):
     list_url = "http://tukaani.org/xz/old.html"
 
     version('5.2.3', '1592e7ca3eece099b03b35f4d9179e7c')
-    version('5.2.2', 'f90c9a0c8b259aee2234c4e0d7fd70af')
+    version('5.2.2', 'f90c9a0c8b259aee2234c4e0d7fd70af')   # CentOS7
     version('5.2.0', '867cc8611760240ebf3440bd6e170bb9')


### PR DESCRIPTION
This PR adds the versions of packages that are provided with CentOS7.  Benefits:

 1. Packages specified as `buildable=False` work better if Spack knows about the version number.  Previously, I had to lie about which version of Python was provided by my system (`2.7.8` instead of the actual `2.7.5`, which Spack didn't know about).

 2. Users not on CentOS7 can replicate the CentOS7 experience.  Ooh fun...

This PR also converts to `AutotoolsPackage` and `CMakePackage` as appropriate.