### PR TITLE
Command Line Defaults

### DIFF
--- a/bin/spack
+++ b/bin/spack
@@ -88,40 +88,44 @@ from spack.error import SpackError
 import argparse
 
 # Command parsing
-parser = argparse.ArgumentParser(
-    formatter_class=argparse.RawTextHelpFormatter,
-    description="Spack: the Supercomputing PACKage Manager." + colorize("""
+def _make_main_parser():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        description="Spack: the Supercomputing PACKage Manager." + colorize("""
 
-spec expressions:
-  PACKAGE [CONSTRAINTS]
+    spec expressions:
+      PACKAGE [CONSTRAINTS]
 
-    CONSTRAINTS:
-      @c{@version}
-      @g{%compiler  @compiler_version}
-      @B{+variant}
-      @r{-variant} or @r{~variant}
-      @m{=architecture}
-      [^DEPENDENCY [CONSTRAINTS] ...]"""))
+        CONSTRAINTS:
+          @c{@version}
+          @g{%compiler  @compiler_version}
+          @B{+variant}
+          @r{-variant} or @r{~variant}
+          @m{=architecture}
+          [^DEPENDENCY [CONSTRAINTS] ...]"""))
 
-parser.add_argument('-d', '--debug', action='store_true',
-                    help="Write out debug logs during compile")
-parser.add_argument('-D', '--pdb', action='store_true',
-                    help="Run spack under the pdb debugger")
-parser.add_argument('-k', '--insecure', action='store_true',
-                    help="Do not check ssl certificates when downloading.")
-parser.add_argument('-m', '--mock', action='store_true',
-                    help="Use mock packages instead of real ones.")
-parser.add_argument('-p', '--profile', action='store_true',
-                    help="Profile execution using cProfile.")
-parser.add_argument('-v', '--verbose', action='store_true',
-                    help="Print additional output during builds")
-parser.add_argument('-s', '--stacktrace', action='store_true',
-                    help="Add stacktrace information to all printed statements")
-parser.add_argument('-V', '--version', action='version',
-                    version="%s" % spack.spack_version)
+    parser.add_argument('-d', '--debug', action='store_true',
+                        help="Write out debug logs during compile")
+    parser.add_argument('-D', '--pdb', action='store_true',
+                        help="Run spack under the pdb debugger")
+    parser.add_argument('-k', '--insecure', action='store_true',
+                        help="Do not check ssl certificates when downloading.")
+    parser.add_argument('-m', '--mock', action='store_true',
+                        help="Use mock packages instead of real ones.")
+    parser.add_argument('-p', '--profile', action='store_true',
+                        help="Profile execution using cProfile.")
+    parser.add_argument('-v', '--verbose', action='store_true',
+                        help="Print additional output during builds")
+    parser.add_argument('-s', '--stacktrace', action='store_true',
+                        help="Add stacktrace information to all printed statements")
+    parser.add_argument('-V', '--version', action='version',
+                        version="%s" % spack.spack_version)
+
+    return parser
 
 # each command module implements a parser() function, to which we pass its
 # subparser for setup.
+parser = _make_main_parser()
 subparsers = parser.add_subparsers(metavar='SUBCOMMAND', dest="command")
 
 
@@ -132,6 +136,40 @@ for cmd in spack.cmd.commands:
     subparser = subparsers.add_parser(cmd_name, help=module.description)
     module.setup_parser(subparser)
 
+
+def parse_args_with_defaults():
+    # ---- Parse args, applying defaults based on the Spack subcommand
+
+    # 1. Split the raw command line into (raw_args0, command, raw_args1)
+    #    The Spack subcommand is raw_args1[0]
+    raw_args = sys.argv[1:]
+    main_parser = _make_main_parser()
+    main_parser.add_argument('command', nargs=argparse.REMAINDER)
+    args0 = main_parser.parse_args(raw_args)
+    defaults0 = vars(args0)
+
+    # Get the command-line starting with the Spack command
+    _tail = defaults0['command']
+    if len(_tail) == 0:
+        parser.print_help()
+        sys.exit(1)
+
+    # Get the command line up to the Spack command
+    raw_args0 = raw_args[:len(raw_args) - len(_tail)]
+
+    # Separate _tail
+    command = _tail[0]
+    raw_args1 = _tail[1:]
+
+    # 2. Fetch the default args based on the subcommand
+    aliases = spack.config.get_config('aliases')
+    all_defaults = aliases.get('all', '').split()
+    cmd_defaults = aliases.get(command, '').split()
+
+
+    # 3. Assemble and parse the final command line
+    final_args = all_defaults + raw_args0 + [command] + cmd_defaults + raw_args1
+    return parser.parse_known_args(final_args)
 
 def _main(args, unknown_args):
     # Set up environment based on args.
@@ -188,28 +226,6 @@ def _main(args, unknown_args):
     else:
         tty.die("Bad return value from command %s: %s"
                 % (args.command, return_val))
-
-
-def parse_args_with_defaults():
-    # ---- Parse args, applying defaults based on the Spack subcommand
-
-    # 1. Parse raw command line once to determine the subcommand
-    # (TODO: This could be done with a simpler parser)
-    args0, unknown = parser.parse_known_args()
-
-    # 2. Fetch the default args based on the subcommand; and parse them
-    # to come up with defaults
-    aliases = spack.config.get_config('aliases')
-    cmd_defaults = aliases.get(args0.command, '').split()
-    all_defaults = aliases.get('all', '').split()
-    default_cmdline = all_defaults + [args0.command] + cmd_defaults
-    defaults = parser.parse_args(default_cmdline)
-
-    # 3. Parse the main args again, with respect to those defaults
-    parser.set_defaults(**vars(defaults))
-    args, unknown = parser.parse_known_args()
-
-    return args, unknown
 
 
 def main():

--- a/bin/spack
+++ b/bin/spack
@@ -24,6 +24,8 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
+from __future__ import print_function
+
 import sys
 if (sys.version_info[0] > 2) or (sys.version_info[:2] < (2, 6)):
     v_info = sys.version_info[:3]
@@ -188,14 +190,37 @@ def _main(args, unknown_args):
                 % (args.command, return_val))
 
 
-def main(args):
+def parse_args_with_defaults():
+    # ---- Parse args, applying defaults based on the Spack subcommand
+
+    # 1. Parse raw command line once to determine the subcommand
+    # (TODO: This could be done with a simpler parser)
+    args0, unknown = parser.parse_known_args()
+
+    # 2. Fetch the default args based on the subcommand; and parse them
+    # to come up with defaults
+    aliases = spack.config.get_config('aliases')
+    cmd_defaults = aliases.get(args0.command, '').split()
+    all_defaults = aliases.get('all', '').split()
+    default_cmdline = all_defaults + [args0.command] + cmd_defaults
+    defaults = parser.parse_args(default_cmdline)
+
+    # 3. Parse the main args again, with respect to those defaults
+    parser.set_defaults(**vars(defaults))
+    args, unknown = parser.parse_known_args()
+
+    return args, unknown
+
+
+def main():
     # Just print help and exit if run with no arguments at all
-    if len(args) == 1:
+    if len(sys.argv) == 1:
         parser.print_help()
         sys.exit(1)
 
+
     # actually parse the args.
-    args, unknown = parser.parse_known_args()
+    args, unknown = parse_args_with_defaults()
 
     if args.profile:
         import cProfile
@@ -209,4 +234,4 @@ def main(args):
 
 
 if __name__ == '__main__':
-    main(sys.argv)
+    main()

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -79,6 +79,7 @@ section_schemas = {
     'packages': spack.schema.packages.schema,
     'modules': spack.schema.modules.schema,
     'config': spack.schema.config.schema,
+    'aliases': spack.schema.aliases.schema,
 }
 
 """OrderedDict of config scopes keyed by name.

--- a/lib/spack/spack/schema/aliases.py
+++ b/lib/spack/spack/schema/aliases.py
@@ -1,0 +1,50 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+"""Schema for aliases.yaml configuration file.
+
+.. literalinclude:: ../spack/schema/aliases.py
+   :lines: 32-
+"""
+
+
+schema = {
+    '$schema': 'http://json-schema.org/schema#',
+    'title': 'Spack aliases configuration file schema',
+    'type': 'object',
+    'additionalProperties': False,
+    'patternProperties': {
+        r'aliases': {
+            'type': 'object',
+            'default': {},
+            'additionalProperties': False,
+            'patternProperties': {
+                r'\w[\w-]*': {
+                    'type': 'string',
+                    'default': ''
+                },
+            },
+        },
+    },
+}


### PR DESCRIPTION
This PR adds command line defaults to Spack.  Default command line arguments can now be specified in a configuration file called `aliases.yaml`.  For example:
```
aliases:
    all: --debug
    spec: --install-status --long
    install: --install-status
    setup: --default-version
```

Example: When the user types `spack spec xz`, that will be converted to `spack --debug spec --install-status --long xz`.

Question: What should the YAML file be called?
 * `aliases.yaml` (because it's kind of like Bash aliases)? 
 * `defaults.yaml` (because it sets defaults for command lines)?
 * `default-args.yaml` (because that's more specific than `defaults.yaml`)?
