### PR TITLE
[WIP] Allow spack create to handle already downloaded tarballs

### DIFF
--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -81,7 +81,7 @@ package_template = '''\
 # If you submit this package back to Spack as a pull request,
 # please first remove this boilerplate and all FIXME comments.
 #
-from spack import *
+{imports}
 
 
 class {class_name}({base_class_name}):
@@ -89,7 +89,7 @@ class {class_name}({base_class_name}):
 
     # FIXME: Add a proper url for your package's homepage here.
     homepage = "http://www.example.com"
-    url      = "{url}"
+    url      = {url}
 
 {versions}
 
@@ -114,8 +114,9 @@ class PackageTemplate(object):
         make()
         make('install')"""
 
-    def __init__(self, name, url, versions):
+    def __init__(self, name, imports, url, versions):
         self.name       = name
+        self.imports    = imports
         self.class_name = mod_to_class(name)
         self.url        = url
         self.versions   = versions
@@ -126,6 +127,7 @@ class PackageTemplate(object):
         # Write out a template for the file
         with open(pkg_path, "w") as pkg_file:
             pkg_file.write(package_template.format(
+                imports=self.imports,
                 name=self.name,
                 class_name=self.class_name,
                 base_class_name=self.base_class_name,
@@ -340,7 +342,7 @@ class BuildSystemGuesser:
     can take a peek at the fetched tarball and discern the build system it uses
     """
 
-    def __call__(self, stage, url):
+    def __call__(self, archive_file, url):
         """Try to guess the type of build system used by a project based on
         the contents of its archive or the URL it was downloaded from."""
 
@@ -366,17 +368,17 @@ class BuildSystemGuesser:
         ]
 
         # Peek inside the compressed file.
-        if stage.archive_file.endswith('.zip'):
+        if archive_file.endswith('.zip'):
             try:
                 unzip  = which('unzip')
-                output = unzip('-lq', stage.archive_file, output=str)
+                output = unzip('-lq', archive_file, output=str)
             except:
                 output = ''
         else:
             try:
                 tar    = which('tar')
                 output = tar('--exclude=*/*/*', '-tf',
-                             stage.archive_file, output=str)
+                             archive_file, output=str)
             except:
                 output = ''
         lines = output.split('\n')
@@ -434,18 +436,25 @@ def get_url(args):
 
     :param argparse.Namespace args: The arguments given to ``spack create``
 
-    :returns: The URL of the package
+    :returns: The URL of the package, and any necessary imports
     :rtype: str
     """
 
-    # Default URL
-    url = 'http://www.example.com/example-1.2.3.tar.gz'
+    # Default URL if one is not provided
+    url = '"http://www.example.com/example-1.2.3.tar.gz"'
+    imports = 'from spack import *'
 
     if args.url:
-        # Use a user-supplied URL if one is present
-        url = args.url
+        if os.path.isfile(args.url):
+            # Archive has already been downloaded
+            # Perhaps this file can only be downloaded manually?
+            # Search for this file in the current directory by default
+            url = '"file://{{0}}/{0}".format(os.getcwd())'.format(args.url)
+            imports += '\nimport os'
+        else:
+            url = '"{0}"'.format(args.url)
 
-    return url
+    return url, imports
 
 
 def get_versions(args, name):
@@ -564,13 +573,13 @@ def get_repository(args, name):
 def create(parser, args):
     # Gather information about the package to be created
     name = get_name(args)
-    url = get_url(args)
+    url, imports = get_url(args)
     versions, guesser = get_versions(args, name)
     build_system = get_build_system(args, guesser)
 
     # Create the package template object
     PackageClass = templates[build_system]
-    package = PackageClass(name, url, versions)
+    package = PackageClass(name, imports, url, versions)
     tty.msg("Created template for {0} package".format(package.name))
 
     # Create a directory for the new package

--- a/lib/spack/spack/test/build_system_guess.py
+++ b/lib/spack/spack/test/build_system_guess.py
@@ -61,5 +61,5 @@ def test_build_systems(url_and_build_system):
     with spack.stage.Stage(url) as stage:
         stage.fetch()
         guesser = spack.cmd.create.BuildSystemGuesser()
-        guesser(stage, url)
+        guesser(stage.archive_file, url)
         assert build_system == guesser.build_system


### PR DESCRIPTION
Fixes #2545 

Ok, here's the situation. Let's say you want to create a new package for your software, but it is licensed and cannot be fetched from a URL. Previous to #2707, you were SOL and had to create a package file manually. With #2707, you could at least create a generic package, but you would still have to specify the name, checksum the file, and add versions manually. With this PR, tarballs in your Downloads folder become equivalent to tarballs from the internet.

For the sake of allowing others to test this PR, let's take a non-licensed package like `py-nose` (which happens to be in my downloads folder). With `nose-1.3.7.tar.gz` in your current directory, simply run:
```
$ spack create -f nose-1.3.7.tar.gz
```
`spack create` is now smart enough to detect that this file is already downloaded and won't try to fetch it again. It will detect the name and version, notice that it is a `PythonPackage`, rename it from `nose` to `py-nose`, and create the following template (comments removed):
```python
from spack import *                                                             
import os                                                                       
                                                                                
                                                                                
class PyNose(PythonPackage):                                                    
    """FIXME: Put a proper description of your package here."""                 
                                                                                
    # FIXME: Add a proper url for your package's homepage here.                 
    homepage = "http://www.example.com"                                         
    url      = "file://{0}/nose-1.3.7.tar.gz".format(os.getcwd())               
                                                                                
    version('1.3.7', '4d3ad0ff07b61373d2cefc89c5d0b20b')
```
This template is similar to other licensed software in Spack, where Spack will first check to see if the tarball can be found in a mirror, and if not will search the current directory.

TODO: There are a couple of additional features I want to add:

1. If the tarball isn't in your current directory and you use `~/Downloads/nose-1.3.7.tar.gz` instead of `nose-1.3.7.tar.gz`, I think the URL will be messed up. Should be a simple fix.

2. What if you have multiple versions of tarballs in the same folder? Much as `spack create` spiders the web searching for additional versions to checksum, `spack create` should do the same thing for directories.

3. If I now run `spack checksum` on this package, it should search in the current directory for new versions. This is probably the same fix as 2.

Now that I got most of this working, I'm starting to wonder if it would have just been easier to prepend `file://` to the abspath of the file and pretended it was a normal URL. Might have to go back and try that out...