### PR TITLE
Add table mode to find command to compare installed packages

### DIFF
--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -45,6 +45,11 @@ def setup_parser(subparser):
                               dest='mode',
                               const='paths',
                               help='show paths to package install directories')
+    format_group.add_argument('-t', '--table',
+                              action='store_const',
+                              dest='mode',
+                              const='table',
+                              help='show specs in a combined table')
     format_group.add_argument(
         '-d', '--deps',
         action='store_const',

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2380,6 +2380,7 @@ class Spec(object):
         You can also use full-string versions, which elide the prefixes::
 
             ${PACKAGE}       Package name
+            ${NAMESPACE}     Namespace
             ${VERSION}       Version
             ${COMPILER}      Full compiler string
             ${COMPILERNAME}  Compiler name
@@ -2493,6 +2494,8 @@ class Spec(object):
                 if named_str == 'PACKAGE':
                     name = self.name if self.name else ''
                     write(fmt % self.name, '@')
+                if named_str == 'NAMESPACE':
+                    out.write(fmt % self.namespace)
                 if named_str == 'VERSION':
                     if self.versions and self.versions != _any_version:
                         write(fmt % str(self.versions), '@')


### PR DESCRIPTION
This adds a 'table' mode to the `spack find` command that allows users to compare installations:

```
$ spack find --table libxml2
==> 3 installed packages.
-- linux-ubuntu16-x86_64 / gcc@5.4.0 ----------------------------
libxml2   @2.9.4   @2.9.4   @2.9.4
xz        @5.2.3   @5.2.2   @5.2.2
zlib      @1.2.10  @1.2.10  @1.2.10
python                      @2.7.13
bzip2                       @1.0.6
ncurses                     @6.0
openssl                     @1.0.2j
readline                    @6.3
sqlite                      @3.8.5
```

It is capable of displaying the the same hash, namespace, compiler flags, and variants information as other find modes:

```
$ spack find -lvfNt libxml2
==> 3 installed packages.
-- linux-ubuntu16-x86_64 / gcc@5.4.0 ----------------------------
libxml2   @2.9.4   @2.9.4   @2.9.4
          ivzisvs  vmkp7vv  4sypony
          builtin  builtin  builtin
          %gcc     %gcc     %gcc
          ~python  ~python  +python
xz        @5.2.3   @5.2.2   @5.2.2
          f4p6ysd  uhmzrh6  uhmzrh6
          builtin  builtin  builtin
          %gcc     %gcc     %gcc
zlib      @1.2.10  @1.2.10  @1.2.10
          mr6fyxq  4tpn2be  4tpn2be
          builtin  builtin  builtin
          %gcc     %gcc     %gcc
          +pic     +pic     +pic
          +shared
python                      @2.7.13
                            wpi4mlq
                            builtin
                            %gcc
                            ~tk
                            ~ucs4
bzip2                       @1.0.6
                            j5voaqm
                            builtin
                            %gcc
ncurses                     @6.0
                            edxtvp6
                            builtin
                            %gcc
openssl                     @1.0.2j
                            gkrxtgh
                            builtin
                            %gcc
readline                    @6.3
                            euvtc2m
                            builtin
                            %gcc
sqlite                      @3.8.5
                            tkodb7l
                            builtin
                            %gcc
```