### PR TITLE
Cray libsci and ver

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -294,6 +294,7 @@ def set_build_environment_variables(pkg, env, dirty=False):
         env.unset('CPATH')
         env.unset('LD_RUN_PATH')
         env.unset('DYLD_LIBRARY_PATH')
+        env.unset("CRAY_LD_LIBRARY_PATH")
 
         # Remove any macports installs from the PATH.  The macports ld can
         # cause conflicts with the built-in linker on el capitan.  Solves

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -119,14 +119,6 @@ class MakeExecutable(Executable):
         return super(MakeExecutable, self).__call__(*args, **kwargs)
 
 
-def unload_module(mod, modulecmd):
-    """Similar to load module, it takes a name and removes the module
-    from the environment"""
-    exec(compile(modulecmd("unload", mod, output=str, error=str), "<string>",
-        "exec"))
-    tty.debug("Unloaded %s module" % mod)
-
-
 def load_module(mod):
     """Takes a module name and removes modules until it is possible to
     load that module. It then loads the provided module. Depends on the
@@ -143,7 +135,8 @@ def load_module(mod):
     text = modulecmd('show', mod, output=str, error=str).split()
     for i, word in enumerate(text):
         if word == 'conflict':
-            unload_module(text[i + 1], modulecmd)
+            exec(compile(modulecmd("unload", text[i+1], outout=str, error=str),
+                "<string", "exec"))
     # Load the module now that there are no conflicts
     load = modulecmd('load', mod, output=str, error=str)
     exec(compile(load, '<string>', 'exec'))
@@ -154,7 +147,8 @@ def get_path_from_module(mod):
     at which the library supported by said module can be found.
     """
     # Create a modulecmd executable
-    modulecmd = get_modulecmd()
+    modulecmd = which("modulecmd")
+    modulecmd.add_default_arg("python")
 
     # Read the module
     text = modulecmd('show', mod, output=str, error=str).split('\n')

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -135,8 +135,8 @@ def load_module(mod):
     text = modulecmd('show', mod, output=str, error=str).split()
     for i, word in enumerate(text):
         if word == 'conflict':
-            exec(compile(modulecmd("unload", text[i+1], outout=str, error=str),
-                "<string", "exec"))
+            exec(compile(modulecmd("unload", text[i + 1], output=str, 
+                error=str), "<string", "exec"))
     # Load the module now that there are no conflicts
     load = modulecmd('load', mod, output=str, error=str)
     exec(compile(load, '<string>', 'exec'))

--- a/lib/spack/spack/operating_systems/cnl.py
+++ b/lib/spack/spack/operating_systems/cnl.py
@@ -27,6 +27,7 @@ import re
 from spack.architecture import OperatingSystem
 from spack.util.executable import *
 import spack.spec
+import spack.version
 from spack.util.multiproc import parmap
 import spack.compilers
 
@@ -39,13 +40,22 @@ class Cnl(OperatingSystem):
     updated to indicate that OS has been upgraded (or downgraded)
     """
 
+    def detect_crayos_version(self):
+        modulecmd = which("modulecmd")
+        modulecmd.add_default_arg("python")
+        output = modulecmd("avail", "PrgEnv-intel", output=str, error=str)
+        matches = re.findall(r'PrgEnv-intel/(\d+).\d+.\d+', output)
+        version_set = set(matches) # 
+        recent_version = max(version_set)
+        return spack.version.Version(recent_version)
+
     def __init__(self):
-        name = 'CNL'
-        version = '10'
+        name = 'cnl'
+        version = self.detect_crayos_version()
         super(Cnl, self).__init__(name, version)
 
     def __str__(self):
-        return self.name
+        return self.name + str(self.version)
 
     def find_compilers(self, *paths):
         types = spack.compilers.all_compiler_types()

--- a/lib/spack/spack/operating_systems/cnl.py
+++ b/lib/spack/spack/operating_systems/cnl.py
@@ -25,7 +25,6 @@
 import re
 
 from spack.architecture import OperatingSystem
-from spack.build_environment import get_modulecmd
 from spack.util.executable import *
 import spack.spec
 import spack.version
@@ -42,7 +41,8 @@ class Cnl(OperatingSystem):
     """
 
     def detect_crayos_version(self):
-        modulecmd = get_modulecmd()
+        modulecmd = which("modulecmd")
+        modulecmd.add_default_arg("python")
         output = modulecmd("avail", "PrgEnv-gnu", output=str, error=str)
         matches = re.findall(r'PrgEnv-gnu/(\d+).\d+.\d+', output)
         version_set = set(matches)
@@ -73,7 +73,8 @@ class Cnl(OperatingSystem):
             if not cmp_cls.PrgEnv_compiler:
                 tty.die('Must supply PrgEnv_compiler with PrgEnv')
 
-            modulecmd = get_modulecmd()
+            modulecmd = which("modulecmd")
+            modulecmd.add_default_arg("python")
 
             output = modulecmd(
                 'avail', cmp_cls.PrgEnv_compiler, output=str, error=str)

--- a/lib/spack/spack/operating_systems/cnl.py
+++ b/lib/spack/spack/operating_systems/cnl.py
@@ -45,7 +45,7 @@ class Cnl(OperatingSystem):
         modulecmd.add_default_arg("python")
         output = modulecmd("avail", "PrgEnv-intel", output=str, error=str)
         matches = re.findall(r'PrgEnv-intel/(\d+).\d+.\d+', output)
-        version_set = set(matches) # 
+        version_set = set(matches)
         recent_version = max(version_set)
         return spack.version.Version(recent_version)
 

--- a/lib/spack/spack/operating_systems/cnl.py
+++ b/lib/spack/spack/operating_systems/cnl.py
@@ -25,6 +25,7 @@
 import re
 
 from spack.architecture import OperatingSystem
+from spack.build_environment import get_modulecmd
 from spack.util.executable import *
 import spack.spec
 import spack.version
@@ -41,13 +42,12 @@ class Cnl(OperatingSystem):
     """
 
     def detect_crayos_version(self):
-        modulecmd = which("modulecmd")
-        modulecmd.add_default_arg("python")
-        output = modulecmd("avail", "PrgEnv-intel", output=str, error=str)
-        matches = re.findall(r'PrgEnv-intel/(\d+).\d+.\d+', output)
+        modulecmd = get_modulecmd()
+        output = modulecmd("avail", "PrgEnv-gnu", output=str, error=str)
+        matches = re.findall(r'PrgEnv-gnu/(\d+).\d+.\d+', output)
         version_set = set(matches)
         recent_version = max(version_set)
-        return spack.version.Version(recent_version)
+        return recent_version
 
     def __init__(self):
         name = 'cnl'
@@ -55,7 +55,7 @@ class Cnl(OperatingSystem):
         super(Cnl, self).__init__(name, version)
 
     def __str__(self):
-        return self.name + str(self.version)
+        return self.name + self.version
 
     def find_compilers(self, *paths):
         types = spack.compilers.all_compiler_types()
@@ -73,8 +73,7 @@ class Cnl(OperatingSystem):
             if not cmp_cls.PrgEnv_compiler:
                 tty.die('Must supply PrgEnv_compiler with PrgEnv')
 
-            modulecmd = which('modulecmd')
-            modulecmd.add_default_arg('python')
+            modulecmd = get_modulecmd()
 
             output = modulecmd(
                 'avail', cmp_cls.PrgEnv_compiler, output=str, error=str)

--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -27,7 +27,6 @@ import re
 import llnl.util.tty as tty
 from spack import build_env_path
 from spack.util.executable import which
-from spack.build_environment import get_modulecmd, unload_module
 from spack.architecture import Platform, Target, NoPlatformError
 from spack.operating_systems.linux_distro import LinuxDistro
 from spack.operating_systems.cnl import Cnl
@@ -105,7 +104,10 @@ class Cray(Platform):
         """
         # unload cray-libsci to avoid silently linking if another blas/lapack
         # is used.
-        unload_module("cray-libsci")
+        modulecmd = which("modulecmd")
+        modulecmd.add_default_arg("python")
+        unload_module("cray-libsci", modulecmd)
+
         env.set('CRAYPE_LINK_TYPE', 'dynamic')
         cray_wrapper_names = join_path(build_env_path, 'cray')
         if os.path.isdir(cray_wrapper_names):
@@ -146,7 +148,8 @@ class Cray(Platform):
     def _avail_targets(self):
         '''Return a list of available CrayPE CPU targets.'''
         if getattr(self, '_craype_targets', None) is None:
-            modulecmd = get_modulecmd()
+            modulecmd = which("modulecmd")
+            modulecmd.add_default_arg("python")
             output = modulecmd('avail', '-t', 'craype-', output=str, error=str)
             craype_modules = _get_modules_in_modulecmd_output(output)
             self._craype_targets = targets = []

--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -27,6 +27,7 @@ import re
 import llnl.util.tty as tty
 from spack import build_env_path
 from spack.util.executable import which
+from spack.build_environment import get_modulecmd, unload_module
 from spack.architecture import Platform, Target, NoPlatformError
 from spack.operating_systems.linux_distro import LinuxDistro
 from spack.operating_systems.cnl import Cnl
@@ -102,6 +103,9 @@ class Cray(Platform):
         """ Change the linker to default dynamic to be more
             similar to linux/standard linker behavior
         """
+        # unload cray-libsci to avoid silently linking if another blas/lapack
+        # is used.
+        unload_module("cray-libsci")
         env.set('CRAYPE_LINK_TYPE', 'dynamic')
         cray_wrapper_names = join_path(build_env_path, 'cray')
         if os.path.isdir(cray_wrapper_names):
@@ -142,9 +146,8 @@ class Cray(Platform):
     def _avail_targets(self):
         '''Return a list of available CrayPE CPU targets.'''
         if getattr(self, '_craype_targets', None) is None:
-            module = which('modulecmd', required=True)
-            module.add_default_arg('python')
-            output = module('avail', '-t', 'craype-', output=str, error=str)
+            modulecmd = get_modulecmd()
+            output = modulecmd('avail', '-t', 'craype-', output=str, error=str)
             craype_modules = _get_modules_in_modulecmd_output(output)
             self._craype_targets = targets = []
             _fill_craype_targets_from_modules(targets, craype_modules)

--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -106,8 +106,8 @@ class Cray(Platform):
         # is used.
         modulecmd = which("modulecmd")
         modulecmd.add_default_arg("python")
-        unload_module("cray-libsci", modulecmd)
-
+        exec(compile(modulecmd("unload", "cray-libsci", output=str, error=str),
+            "<string>", "exec"))
         env.set('CRAYPE_LINK_TYPE', 'dynamic')
         cray_wrapper_names = join_path(build_env_path, 'cray')
         if os.path.isdir(cray_wrapper_names):

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -58,7 +58,8 @@ def test_dict_functions_for_architecture():
 
 def test_platform():
         output_platform_class = spack.architecture.real_platform()
-        if os.path.exists('/opt/cray/craype'):
+        cray_dir = os.environ.get("CRAYPE_DIR", "")
+        if cray_dir:
             my_platform_class = Cray()
         elif os.path.exists('/bgsys'):
             my_platform_class = Bgq()

--- a/var/spack/repos/builtin/packages/cray-libsci/package.py
+++ b/var/spack/repos/builtin/packages/cray-libsci/package.py
@@ -1,0 +1,70 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install cray-libsci
+#
+# You can edit this file again by typing:
+#
+#     spack edit cray-libsci
+#
+# See the Spack documentation for more information on packaging.
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+from spack import *
+
+
+class CrayLibsci(Package):
+    """The Cray Scientific Libraries package, LibSci, is a collection of
+    numerical routines optimized for best performance on Cray systems."""
+
+    homepage = "http://www.nersc.gov/users/software/programming-libraries/math-libraries/libsci/"
+    url      = "http://www.nersc.gov/users/software/programming-libraries/math-libraries/libsci/"
+
+    version('16.07.1')
+
+    provides("blas")
+    provides("lapack")
+    provides("scalapack")
+
+    # NOTE: Cray compiler wrappers already include linking for the following
+    @property
+    def blas_libs(self):
+        return self.prefix.lib
+
+    @property
+    def lapack_libs(self):
+        return self.blas_libs
+
+    @property
+    def scalapack_libs(self):
+        return self.blas_libs
+
+    def install(self, spec, prefix):
+        raise NoBuildError(spec)

--- a/var/spack/repos/builtin/packages/cray-libsci/package.py
+++ b/var/spack/repos/builtin/packages/cray-libsci/package.py
@@ -45,6 +45,7 @@ class CrayLibsci(Package):
     numerical routines optimized for best performance on Cray systems."""
 
     homepage = "http://www.nersc.gov/users/software/programming-libraries/math-libraries/libsci/"
+    url      = "http://www.nersc.gov/users/software/programming-libraries/math-libraries/libsci/"
 
     version('16.07.1')
 

--- a/var/spack/repos/builtin/packages/cray-libsci/package.py
+++ b/var/spack/repos/builtin/packages/cray-libsci/package.py
@@ -37,6 +37,7 @@
 # If you submit this package back to Spack as a pull request,
 # please first remove this boilerplate and all FIXME comments.
 #
+from llnl.util.filesystem import LibraryList
 from spack import *
 
 
@@ -47,7 +48,11 @@ class CrayLibsci(Package):
     homepage = "http://www.nersc.gov/users/software/programming-libraries/math-libraries/libsci/"
     url      = "http://www.nersc.gov/users/software/programming-libraries/math-libraries/libsci/"
 
+    version("16.11.1")
+    version("16.09.1")
     version('16.07.1')
+    version("16.06.1")
+    version("16.03.1")
 
     provides("blas")
     provides("lapack")
@@ -56,7 +61,7 @@ class CrayLibsci(Package):
     # NOTE: Cray compiler wrappers already include linking for the following
     @property
     def blas_libs(self):
-        return self.prefix.lib
+        return LibraryList([self.prefix.lib])
 
     @property
     def lapack_libs(self):

--- a/var/spack/repos/builtin/packages/cray-libsci/package.py
+++ b/var/spack/repos/builtin/packages/cray-libsci/package.py
@@ -45,7 +45,6 @@ class CrayLibsci(Package):
     numerical routines optimized for best performance on Cray systems."""
 
     homepage = "http://www.nersc.gov/users/software/programming-libraries/math-libraries/libsci/"
-    url      = "http://www.nersc.gov/users/software/programming-libraries/math-libraries/libsci/"
 
     version('16.07.1')
 


### PR DESCRIPTION
Not intending for this to be merged yet until reviewed and fully tested but this PR does a couple of things.

1. Appends a major version number to the CNL os version in addition to making CNL lowercase.
- Recently found out that the compute node linux os version is found by the version given by PrgEnv-X. This is how Cray displays their os version to NERSC, not sure if this is the same across all Crays.

2. unset CRAY_LD_LIBRARY_PATH
- Unless someone tells me this is a bad idea, this should unset CRAY_LD_LIBRARY_PATH.

3. Adds a dummy package for Cray-libsci (provides lapack, blas and scalapack)
- Used so that Spack is aware that a cray-libsci package exists.

Something I forgot to do is unload cray-libsci in the build-environment prior to building. This could potentially cause issues if a user on a Cray machine wishes to link with MKL or any other lapack, blas, scalapack provider due to the -L statement to cray-libsci found by default in the cray compiler wrappers.