### PR TITLE
Package-Level Module Autoloading

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -88,6 +88,11 @@ class PythonPackage(PackageBase):
        def configure(self, spec, prefix):
            self.setup_py('configure')
     """
+
+    # Packages that depend on this should autoload its module.
+    # Because we don't have RPATHs in Python...
+    autoload = True
+
     # Default phases
     phases = ['build', 'install']
 

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -223,12 +223,14 @@ def version(ver, checksum=None, **kwargs):
     return _execute
 
 
-def _depends_on(pkg, spec, when=None, type=None):
+def _depends_on(pkg, spec, when=None, type=None, autoload=None):
+
     # If when is False do nothing
     if when is False:
         return
+
     # If when is None or True make sure the condition is always satisfied
-    if when is None or when is True:
+    if when is None or when:
         when = pkg.name
     when_spec = parse_anonymous_spec(when, pkg.name)
 
@@ -261,15 +263,18 @@ def _depends_on(pkg, spec, when=None, type=None):
     else:
         conditions[when_spec] = dep_spec
 
+    _autoload = dep_spec.package.autoload if autoload is None else autoload
+    if _autoload:
+        pkg.autoloads[dep_spec.name] = True
 
-@directive(('dependencies', 'dependency_types'))
-def depends_on(spec, when=None, type=None):
+@directive(('dependencies', 'dependency_types', 'autoloads'))
+def depends_on(spec, when=None, type=None, autoload=None):
     """Creates a dict of deps with specs defining when they apply.
     This directive is to be used inside a Package definition to declare
     that the package requires other packages to be built first.
     @see The section "Dependency specs" in the Spack Packaging Guide."""
     def _execute(pkg):
-        _depends_on(pkg, spec, when=when, type=type)
+        _depends_on(pkg, spec, when=when, type=type, autoload=autoload)
     return _execute
 
 

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -224,13 +224,12 @@ def version(ver, checksum=None, **kwargs):
 
 
 def _depends_on(pkg, spec, when=None, type=None, autoload=None):
-
     # If when is False do nothing
     if when is False:
         return
 
     # If when is None or True make sure the condition is always satisfied
-    if when is None or when:
+    if when is None or when is True:
         when = pkg.name
     when_spec = parse_anonymous_spec(when, pkg.name)
 
@@ -263,7 +262,18 @@ def _depends_on(pkg, spec, when=None, type=None, autoload=None):
     else:
         conditions[when_spec] = dep_spec
 
-    _autoload = dep_spec.package.autoload if autoload is None else autoload
+    if autoload is not None:
+        _autoload = autoload
+    else:
+        try :
+            _autoload = dep_spec.package.autoload if autoload is None else autoload
+        except:
+            # Exception if dep_spec is virtual.
+            # So... we can't have virtual packages with an autoload attribute.
+            # That is not a big problem.  Things that depend on virtual
+            # packages will need to use `depends_on(..., autoload=...)`
+            _autoload = False
+
     if _autoload:
         pkg.autoloads[dep_spec.name] = True
 

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -265,7 +265,7 @@ def _depends_on(pkg, spec, when=None, type=None, autoload=None):
     if autoload is not None:
         _autoload = autoload
     else:
-        try :
+        try:
             _autoload = dep_spec.package.autoload
         except:
             # Exception if dep_spec is virtual.
@@ -276,6 +276,7 @@ def _depends_on(pkg, spec, when=None, type=None, autoload=None):
 
     if _autoload:
         pkg.autoloads[dep_spec.name] = True
+
 
 @directive(('dependencies', 'dependency_types', 'autoloads'))
 def depends_on(spec, when=None, type=None, autoload=None):

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -266,7 +266,7 @@ def _depends_on(pkg, spec, when=None, type=None, autoload=None):
         _autoload = autoload
     else:
         try :
-            _autoload = dep_spec.package.autoload if autoload is None else autoload
+            _autoload = dep_spec.package.autoload
         except:
             # Exception if dep_spec is virtual.
             # So... we can't have virtual packages with an autoload attribute.

--- a/lib/spack/spack/modules.py
+++ b/lib/spack/spack/modules.py
@@ -207,7 +207,8 @@ def parse_config_options(module_generator):
     autoloads2 = list(module_generator.spec.autoloads())
 
     seen = set()
-    autoloads = [x for x in autoloads2 + autoloads1
+    autoloads = [
+        x for x in autoloads2 + autoloads1
         if not (x in seen or seen.add(x))]
 
     module_file_actions['autoload'] = autoloads
@@ -419,9 +420,9 @@ class EnvModule(object):
         autoloads = module_configuration.pop('autoload', [])
 
         if len(autoloads) > 0:
-            print 'Gxenerating autoloads for {0}:'.format(self.spec.name)
+            print 'Generating autoloads for {0}:'.format(self.spec.name)
             for spec in autoloads:
-                print '    ',spec.name
+                print '    ', spec.name
 
         for x in filter_blacklisted(autoloads, self.name):
             module_file_content += self.autoload(x)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -499,6 +499,10 @@ class PackageBase(object):
        for immediate dependencies."""
     transitive_rpaths = True
 
+    """When True, This package's module will be autoloaded by packages
+    that depend on it.  Can be overridden by depends_on(..., autoload=)."""
+    autoload = False
+
     """List of prefix-relative file paths (or a single path). If these do
        not exist after install, or if they exist but are not files,
        sanity checks fail.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -95,6 +95,7 @@ thing.  Spack uses ~variant in directory names and in the canonical form of
 specs to avoid ambiguity.  Both are provided because ~ can cause shell
 expansion when it is the first character in an id typed on the command line.
 """
+from __future__ import print_function
 import base64
 import hashlib
 import ctypes
@@ -835,9 +836,8 @@ class Spec(object):
 
     def _find_deps(self, where, deptype):
         deptype = canonical_deptype(deptype)
-
         return [dep for dep in where.values()
-                if deptype and (not dep.deptypes or
+                if deptype and ((not dep.deptypes) or
                                 any(d in deptype for d in dep.deptypes))]
 
     def dependencies(self, deptype=None):
@@ -1022,6 +1022,12 @@ class Spec(object):
         else:
             for dspec in self.traverse_edges(**kwargs):
                 yield get_spec(dspec)
+
+    def autoloads(self):
+        for dep in self.dependencies(deptype=('run',)):
+            if self.package.autoloads.get(dep.package.name,False):
+                dep.autoloads()
+                yield dep
 
     def traverse_edges(self, visited=None, d=0, deptype=None,
                        deptype_query=None, dep_spec=None, **kwargs):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1025,7 +1025,7 @@ class Spec(object):
 
     def autoloads(self):
         for dep in self.dependencies(deptype=('run',)):
-            if self.package.autoloads.get(dep.package.name,False):
+            if self.package.autoloads.get(dep.package.name, False):
                 dep.autoloads()
                 yield dep
 


### PR DESCRIPTION
@adamjstewart @tgamblin 

This addresses issues brought up in conversation between @citibeth and @alalazo on module autoloading in #1662...

It introduces the concept of autoloading at the `Package` and `depends_on()` level.

1. If you put autoload=True in package, and anything that depends on that package will autoload its module.  The canonical example here is `PythonPackage`.  Anything depending on a `PythonPackage` subclass will be autoloaded.  For example, `py-numpy` will be autoloaded by anything that depends on it.  However, if `py-numpy` depends on (say) `openblas`, then `openblas` will not be autoloaded.

2. You can override the package-level autoloading in the `depends_on()` declarations.  `py-netcdf` depends on `netcdf`.  But by default, `netcdf` will NOT be autoloaded from `py-netcdf` because `netcdf` does not subclass `PythonProject` (and `autoload=True` was not set in `netcdf/package.py`).  However, Python extensions (such as the one generated in `py-netcdf`) do not have RPATHs, and therefore will not be able to properly link `netcdf` without something in `LD_LIBRARY_PATH`.  Therefore, we use the following in `py-netcdf/package.py`:
```
depends_on('netcdf', autoload=True)
```

I believe that this feature will provide the tools to eventually make module autoloading "just work," based on particulars of the packages.  I expect there will be some adjustment, as we find exceptions to the default autoloading rules (such as `PythonPackage.autoload=True`).

The way to specify autoloading described in this PR does not affect the way autoloading is currently specified in `modules.yaml`.  If there is demand, I could also add a switch to `modules.yaml` that would turn this feature off entirely.
