### PR TITLE
Specify additional configuration directories using command arguments

### DIFF
--- a/bin/spack
+++ b/bin/spack
@@ -111,6 +111,8 @@ parser.add_argument('-m', '--mock', action='store_true',
                     help="use mock packages instead of real ones")
 parser.add_argument('-p', '--profile', action='store_true',
                     help="profile execution using cProfile")
+parser.add_argument('-c', '--config', action='append', default=[], metavar='<package:>dir',
+                    help="Add custom configuration directory dir, optionally relative to package")
 parser.add_argument('-v', '--verbose', action='store_true',
                     help="print additional output during builds")
 parser.add_argument('-s', '--stacktrace', action='store_true',
@@ -127,9 +129,7 @@ import spack.cmd
 for cmd in spack.cmd.commands:
     module = spack.cmd.get_module(cmd)
     cmd_name = cmd.replace('_', '-')
-    subparser = subparsers.add_parser(cmd_name, help=module.description)
-    module.setup_parser(subparser)
-
+    subparsers.add_parser(cmd_name, help=module.description, add_help=False)
 
 def _main(args, unknown_args):
     # Set up environment based on args.
@@ -155,7 +155,32 @@ def _main(args, unknown_args):
         tty.warn("You asked for --insecure. Will NOT check SSL certificates.")
         spack.insecure = True
 
+    for config_arg in args.config:
+        if ':' in config_arg:
+            package, path = config_arg.split(':', 1)
+            path = spack.join_path(
+                spack.repo.dirname_for_package_name(package),
+                path)
+            name = "{0}:{1}".format(package, os.path.split(path)[1])
+        else:
+            path = os.path.normpath(config_arg)
+            name = os.path.split(path)[1]
+
+        try:
+            spack.config.ConfigScope(name, path, required=True)
+        except spack.config.ConfigError as e:
+            tty.die(e)
+        tty.info("Added configuration scope '%s'" % (name,))
+        tty.debug("Config scope '%s'; %s" % (name,path))
+
+    if args.config:
+        # Should refresh repos and packages
+        spack.repo = spack.repository.RepoPath()
+        sys.meta_path.append(spack.repo)
+
     # Try to load the particular command asked for and run it
+    sp = spack.cmd.setup_subparser(parser, args.command)
+    args, unknown_args = sp.parse_known_args(unknown_args, args)
     command = spack.cmd.get_command(args.command.replace('-', '_'))
 
     # Allow commands to inject an optional argument and get unknown args

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -64,6 +64,15 @@ for file in os.listdir(command_path):
 commands.sort()
 
 
+def setup_subparser(parser, command):
+    """Setup arguments for sub-command"""
+    sp = parser.get_subparser(command)
+    sp.add_argument('-h', '--help', action='help',
+                    help="show this help message and exit")
+    spack.cmd.get_module(command).setup_parser(sp)
+    return sp
+
+
 def remove_options(parser, *options):
     """Remove some options from a parser."""
     for option in options:
@@ -205,7 +214,7 @@ def display_specs(specs, **kwargs):
 
             for abbrv, spec in zip(abbreviated, specs):
                 prefix = gray_hash(spec, hlen) if hashes else ''
-                print prefix + (format % (abbrv, spec.prefix))
+                print(prefix + (format % (abbrv, spec.prefix)))
 
         elif mode == 'deps':
             for spec in specs:

--- a/lib/spack/spack/cmd/help.py
+++ b/lib/spack/spack/cmd/help.py
@@ -22,6 +22,8 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
+import spack
+
 description = "get help on spack and its commands"
 
 
@@ -32,6 +34,8 @@ def setup_parser(subparser):
 
 def help(parser, args):
     if args.help_command:
+        spack.cmd.setup_subparser(parser, args.help_command)
+
         parser.parse_args([args.help_command, '-h'])
     else:
         parser.print_help()

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -92,6 +92,11 @@ def test(parser, args, unknown_args):
         pytest.main(['-h'])
         return
 
+    # Setup other command subparsers to guarantee execution
+    for cmd in spack.cmd.commands:
+        if cmd != 'test':
+            spack.cmd.setup_subparser(parser, cmd)
+
     # pytest.ini lives in the root of the sapck repository.
     with working_dir(spack.prefix):
         # --list and --long-list print the test output better.

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -156,14 +156,24 @@ class ConfigScope(object):
        Each file is a config "section" (e.g., mirrors, compilers, etc).
     """
 
-    def __init__(self, name, path):
+    def __init__(self, name, path, required=False):
+        global config_scopes
+
+        if required:
+            if not os.path.exists(path):
+                raise ConfigError("Directory '%s' does not exist" % path)
+            elif not os.path.isdir(path):
+                raise ConfigError("'%s' is not a directory" % path)
+
+        if name in config_scopes:
+            raise ConfigDuplicateScopeError("Scope %s already exists" % name)
+
         self.name = name           # scope name.
         self.path = path           # path to directory containing configs.
         self.sections = {}         # sections read from config files.
 
         # Register in a dict of all ConfigScopes
         # TODO: make this cleaner.  Mocking up for testing is brittle.
-        global config_scopes
         config_scopes[name] = self
 
     def get_section_filename(self, section):
@@ -464,6 +474,10 @@ class ConfigError(SpackError):
 
 
 class ConfigFileError(ConfigError):
+    pass
+
+
+class ConfigDuplicateScopeError(ConfigError):
     pass
 
 


### PR DESCRIPTION
This adds a global command line option to specify additional configuration directories. The argument either takes a directory path, or a combination of package and sub-directory. This form fits in with suggestions from @citibeth for package level `package.yaml` files. Examples:

```
$ spack --config path/to/config/dir install myapp
==> Adding configuration scope 'config/dir'
...
$ spack --config myapplication:dir install myapp
==> Adding configuration scope 'application:dir'
...
```

Some juggling of when to add sub-command arguments was required so that they were aware of the new scopes. Note, that the short form of this argument, `-c`, conflicts with the `--color` command added by me in #3013. On reflection this command should claim the `-c` form, and the other command only use `--color`, `--no-color`, though I am open to suggestions.

There are no tests associated with this PR, but I could write a test suite that repeatedly calls spack using `subprocess` and checks the output, if that is acceptable.