### PR TITLE
[WIP] Fix build of Numpy with Intel

### DIFF
--- a/var/spack/repos/builtin/packages/py-numpy/intelcompiler-1.12.patch
+++ b/var/spack/repos/builtin/packages/py-numpy/intelcompiler-1.12.patch
@@ -1,0 +1,51 @@
+Intel optimization flags suggested by Intel:
+https://software.intel.com/en-us/articles/numpyscipy-with-intel-mkl
+
+diff --git a/numpy/distutils/fcompiler/intel.py b/numpy/distutils/fcompiler/intel.py
+index f6f2d7e..3bbce5e 100644
+--- a/numpy/distutils/fcompiler/intel.py
++++ b/numpy/distutils/fcompiler/intel.py
+@@ -56,7 +56,7 @@ class IntelFCompiler(BaseIntelFCompiler):
+         return ['-fPIC']
+ 
+     def get_flags_opt(self):  # Scipy test failures with -O2
+-        return ['-xhost -openmp -fp-model strict -O1']
++        return ['-xhost -openmp -fp-model strict -fPIC']
+ 
+     def get_flags_arch(self):
+         return []
+@@ -120,7 +120,7 @@ class IntelEM64TFCompiler(IntelFCompiler):
+         return ['-fPIC']
+ 
+     def get_flags_opt(self):  # Scipy test failures with -O2
+-        return ['-openmp -fp-model strict -O1']
++        return ['-xhost -openmp -fp-model strict -fPIC']
+ 
+     def get_flags_arch(self):
+         return ['']
+diff --git a/numpy/distutils/intelccompiler.py b/numpy/distutils/intelccompiler.py
+index 902f19b..457f30d 100644
+--- a/numpy/distutils/intelccompiler.py
++++ b/numpy/distutils/intelccompiler.py
+@@ -17,8 +17,8 @@ class IntelCCompiler(UnixCCompiler):
+ 
+     def __init__(self, verbose=0, dry_run=0, force=0):
+         UnixCCompiler.__init__(self, verbose, dry_run, force)
+-        self.cc_exe = ('icc -fPIC -fp-model strict -O3 '
+-                       '-fomit-frame-pointer -openmp')
++        self.cc_exe = ('icc -O3 -g -fPIC -fp-model strict '
++                       '-fomit-frame-pointer -openmp -xhost')
+         compiler = self.cc_exe
+         if platform.system() == 'Darwin':
+             shared_flag = '-Wl,-undefined,dynamic_lookup'
+@@ -53,8 +53,8 @@ class IntelEM64TCCompiler(UnixCCompiler):
+ 
+     def __init__(self, verbose=0, dry_run=0, force=0):
+         UnixCCompiler.__init__(self, verbose, dry_run, force)
+-        self.cc_exe = ('icc -m64 -fPIC -fp-model strict -O3 '
+-                       '-fomit-frame-pointer -openmp')
++        self.cc_exe = ('icc -O3 -g -fPIC -fp-model strict '
++                       '-fomit-frame-pointer -openmp -xhost')
+         compiler = self.cc_exe
+         if platform.system() == 'Darwin':
+             shared_flag = '-Wl,-undefined,dynamic_lookup'

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+import os
 import platform
 
 
@@ -53,6 +54,8 @@ class PyNumpy(PythonPackage):
     depends_on('blas',   when='+blas')
     depends_on('lapack', when='+lapack')
 
+    patch('intelcompiler-1.12.patch', when='@1.12.0%intel')
+
     def setup_dependent_package(self, module, dep_spec):
         python_version = self.spec['python'].version.up_to(2)
         arch = '{0}-{1}'.format(platform.system().lower(), platform.machine())
@@ -67,68 +70,93 @@ class PyNumpy(PythonPackage):
 
     def patch(self):
         spec = self.spec
-        # for build notes see http://www.scipy.org/scipylib/building/linux.html
-        lapackblas = LibraryList('')
+
+        if spec.satisfies('%intel@16:'):
+            # Intel 16 replaced -openmp with -qopenmp
+            # This change prevents thousands of lines of deprecation warnings
+            filter_file('-openmp', self.compiler.openmp_flag,
+                        'numpy/distutils/intelccompiler.py', string=True)
+            filter_file('-openmp', self.compiler.openmp_flag,
+                        'numpy/distutils/fcompiler/intel.py', string=True)
+
+        # The following patches are only necessary for BLAS/LAPACK support
+        if '+blas' not in spec and '+lapack' not in spec:
+            return
+
+        lapackblas_includes  = set()
+        lapackblas_libraries = LibraryList('')
         if '+lapack' in spec:
-            lapackblas += spec['lapack'].lapack_libs
+            lapackblas_includes.add(spec['lapack'].prefix.include)
+            lapackblas_libraries += spec['lapack'].lapack_libs
 
         if '+blas' in spec:
-            lapackblas += spec['blas'].blas_libs
+            lapackblas_includes.add(spec['blas'].prefix.include)
+            lapackblas_libraries += spec['blas'].blas_libs
 
-        if '+blas' in spec or '+lapack' in spec:
-            # note that one should not use [blas_opt] and [lapack_opt], see
-            # https://github.com/numpy/numpy/commit/ffd4332262ee0295cb942c94ed124f043d801eb6
-            with open('site.cfg', 'w') as f:
-                # Unfortunately, numpy prefers to provide each BLAS/LAPACK
-                # differently.
-                names  = ','.join(lapackblas.names)
-                dirs   = ':'.join(lapackblas.directories)
+        # Each BLAS/LAPACK requires a custom site.cfg
 
-                # Special treatment for some (!) BLAS/LAPACK. Note that
-                # in this case library_dirs can not be specified within [ALL].
-                if '^openblas' in spec:
-                    f.write('[openblas]\n')
-                    f.write('libraries=%s\n'    % names)
-                elif '^mkl' in spec:
-                    # numpy does not expect system libraries needed for MKL
-                    # here.
-                    # names = [x for x in names if x.startswith('mkl')]
-                    # FIXME: as of @1.11.2, numpy does not work with separately
-                    # specified threading and interface layers. A workaround is
-                    # a terribly bad idea to use mkl_rt. In this case Spack
-                    # won't no longer be able to guarantee that one and the
-                    # same variant of Blas/Lapack (32/64bit, threaded/serial)
-                    # is used within the DAG. This may lead to a lot of
-                    # hard-to-debug segmentation faults on user's side. Users
-                    # may also break working installation by (unconciously)
-                    # setting environment variable to switch between different
-                    # interface and threading layers dynamically. From this
-                    # perspective it is no different from throwing away RPATH's
-                    # and using LD_LIBRARY_PATH throughout Spack.
-                    f.write('[mkl]\n')
-                    f.write('mkl_libs=%s\n'     % 'mkl_rt')
-                elif '^atlas' in spec:
-                    f.write('[atlas]\n')
-                    f.write('atlas_libs=%s\n'   % names)
+        # Generic build notes (very out-of-date):
+        # http://www.scipy.org/scipylib/building/linux.html
+
+        # Example site.cfg:
+        # https://github.com/numpy/numpy/blob/master/site.cfg.example
+        with open('site.cfg', 'w') as f:
+            libraries = ','.join(lapackblas_libraries.names)
+
+            if '^openblas' in spec:
+                f.write('[openblas]\n')
+                f.write('libraries = {0}\n'.format(libraries))
+
+            elif '^mkl' in spec:
+                # Intel MKL build notes:
+                # https://software.intel.com/en-us/articles/numpyscipy-with-intel-mkl
+
+                # library_dirs are in compilers_and_libraries_2017/linux/mkl/lib/intel64  # noqa
+                # include_dirs are in compilers_and_libraries_2017/linux/mkl/include      # noqa
+                lapackblas_includes = set()
+                for libdir in lapackblas_libraries.directories:
+                    incdir = os.path.dirname(os.path.dirname(libdir))
+                    incdir = join_path(incdir, 'include')
+                    lapackblas_includes.add(incdir)
+
+                f.write('[mkl]\n')
+                f.write('mkl_libs = {0}\n'.format('mkl_rt'))
+                f.write('lapack_libs = \n')
+
+            elif '^atlas' in spec:
+                f.write('[atlas]\n')
+                f.write('atlas_libs = {0}\n'.format(libraries))
+
+            else:
+                # The section title for the defaults changed in @1.10
+                if spec.satisfies('@1.10:'):
+                    f.write('[ALL]\n')
                 else:
-                    # The section title for the defaults changed in @1.10, see
-                    # https://github.com/numpy/numpy/blob/master/site.cfg.example
-                    if spec.satisfies('@:1.9.2'):
-                        f.write('[DEFAULT]\n')
-                    else:
-                        f.write('[ALL]\n')
-                    f.write('libraries=%s\n'    % names)
+                    f.write('[DEFAULT]\n')
+                f.write('libraries = {0}\n'.format(libraries))
 
-                f.write('library_dirs=%s\n' % dirs)
-                if not ((platform.system() == "Darwin") and
-                        (platform.mac_ver()[0] == '10.12')):
-                    f.write('rpath=%s\n' % dirs)
+            include_dirs = os.pathsep.join(lapackblas_includes)
+            library_dirs = os.pathsep.join(lapackblas_libraries.directories)
+
+            f.write('include_dirs = {0}\n'.format(include_dirs))
+            f.write('library_dirs = {0}\n'.format(library_dirs))
+
+            # macOS 10.12 does not support RPATHs
+            if not ((platform.system() == "Darwin") and
+                    (platform.mac_ver()[0] == '10.12')):
+                f.write('rpath = {0}\n'.format(library_dirs))
 
     def build_args(self, spec, prefix):
         args = []
 
         # From NumPy 1.10.0 on it's possible to do a parallel build
         if self.version >= Version('1.10.0'):
-            args = ['-j', str(make_jobs)]
+            args.extend(['-j', str(make_jobs)])
+
+        if self.compiler.name == 'intel':
+            if spec.satisfies('target=x86_64'):
+                args.extend(['--compiler=intelem', '--fcompiler=intelem'])
+            else:
+                args.extend(['--compiler=intel', '--fcompiler=intel'])
 
         return args

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -39,6 +39,8 @@ class PyNumpy(PythonPackage):
 
     version('1.12.0', '33e5a84579f31829bbbba084fe0a4300',
             url="https://pypi.io/packages/source/n/numpy/numpy-1.12.0.zip")
+    version('1.11.3', 'aa70cd5bba81b78382694d654ed10036',
+            url="https://pypi.io/packages/source/n/numpy/numpy-1.11.3.zip")
     version('1.11.2', '03bd7927c314c43780271bf1ab795ebc')
     version('1.11.1', '2f44a895a8104ffac140c3a70edbd450')
     version('1.11.0', 'bc56fb9fc2895aa4961802ffbdb31d0b')

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -111,6 +111,18 @@ class PyNumpy(PythonPackage):
                 # Intel MKL build notes:
                 # https://software.intel.com/en-us/articles/numpyscipy-with-intel-mkl
 
+                # FIXME: as of @1.11.2, numpy does not work with separately
+                # specified threading and interface layers. Intel recommends
+                # using mkl_rt instead. Unfortunately, this means that Spack
+                # won't be able to guarantee that the variant of Blas/Lapack
+                # (32/64bit, threaded/serial) in the DAG is the one that is
+                # used. This may lead to a lot of hard-to-debug segmentation
+                # faults on the user's side. Users may also break working
+                # installations by (unconciously) setting environment variables
+                # to switch between different interface and threading layers
+                # dynamically. From this perspective it is no different from
+                # throwing away RPATH's and using LD_LIBRARY_PATH.
+
                 # library_dirs are in compilers_and_libraries_2017/linux/mkl/lib/intel64  # noqa
                 # include_dirs are in compilers_and_libraries_2017/linux/mkl/include      # noqa
                 lapackblas_includes = set()


### PR DESCRIPTION
Fixes #3204.

Or at least, that's what I would like to say. I tried pretty hard to follow https://software.intel.com/en-us/articles/numpyscipy-with-intel-mkl but I'm still seeing the same error message. I opened an issue with the numpy developers (https://github.com/numpy/numpy/issues/8653). Hopefully they can get to the bottom of this.

I figured I would open up this WIP PR in the meantime to show what I'm trying to do. It offers several advantages over the way we were previously doing things.

If I'm going to rework this stuff, I want to do it right this time. Before this PR is merged, I plan on running the full numpy and scipy test suite for the following combinations:

- [ ] Intel 17 - Intel MKL - Python 2 - CentOS 6
- [ ] Intel 17 - Intel MKL - Python 3 - CentOS 6
- [ ] GCC 6 - OpenBLAS - CentOS 6
- [ ] GCC 6 - ATLAS - CentOS 6
- [ ] Clang 8 - OpenBLAS - macOS 10.12
- [ ] Clang 8 - Netlib BLAS/LAPACK - macOS 10.12

Any other combinations anyone would like to see?

Intel also provides a numpy benchmark. I may try that out with a few combinations and report back the performance. I'm curious as to how much of an improvement I get with Intel MKL.