### PR TITLE
A package's build environment should include run dep paths as well as build dep paths

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -334,14 +334,14 @@ def set_build_environment_variables(pkg, env, dirty=False):
 
     # Add all bin directories which build dependencies and their
     # run dependencies require.
-    for bdep in [ d for d in pkg.spec.dependencies(deptype='build') ]:
+    for bdep in pkg.spec.dependencies(deptype='build'):
         add_dir_to_list("%s/bin" % bdep.prefix, bin_dirs)
         for brdep in bdep.traverse(root=False, deptype='run'):
             add_dir_to_list("%s/bin" % brdep.prefix, bin_dirs)
 
     # Add all bin directories which run dependencies require.
-    for d in pkg.spec.traverse(root=False, deptype='run'):
-        add_dir_to_list("%s/bin" % d.prefix, bin_dirs)
+    for rdep in pkg.spec.traverse(root=False, deptype='run'):
+        add_dir_to_list("%s/bin" % rdep.prefix, bin_dirs)
 
     bin_dirs = filter_system_bin_paths(bin_dirs)
 

--- a/var/spack/repos/builtin/packages/npm/package.py
+++ b/var/spack/repos/builtin/packages/npm/package.py
@@ -36,7 +36,7 @@ class Npm(AutotoolsPackage):
     version('3.10.9', 'ec1eb22b466ce87cdd0b90182acce07f')
     version('3.10.5', '46002413f4a71de9b0da5b506bf1d992')
 
-    depends_on('node-js')
+    depends_on('node-js', type=('build', 'run'))
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         npm_config_cache_dir = "%s/npm-cache" % dependent_spec.prefix

--- a/var/spack/repos/builtin/packages/npm/package.py
+++ b/var/spack/repos/builtin/packages/npm/package.py
@@ -39,7 +39,7 @@ class Npm(AutotoolsPackage):
     depends_on('node-js', type=('build', 'run'))
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        npm_config_cache_dir = "%s/npm-cache" % dependent_spec.prefix
+        npm_config_cache_dir = "%s/npm-cache" % self.spec.prefix
         if not os.path.isdir(npm_config_cache_dir):
             mkdir(npm_config_cache_dir)
         run_env.set('npm_config_cache', npm_config_cache_dir)


### PR DESCRIPTION
Fixes #3345.