### PR TITLE
Features/boost build frontend

### DIFF
--- a/lib/spack/spack/architecture.py
+++ b/lib/spack/spack/architecture.py
@@ -514,3 +514,8 @@ def sys_type():
     """
     arch = Arch(platform(), 'default_os', 'default_target')
     return str(arch)
+
+
+@memoized
+def frontend_sys_type():
+    return str(Arch(platform(), 'frontend', 'frontend'))

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -232,6 +232,17 @@ def set_compiler_environment_variables(pkg, env):
     return env
 
 
+def compiler_paths(pkg):
+    paths = []
+    compiler_specific = join_path(spack.build_env_path, pkg.compiler.name)
+    for item in [spack.build_env_path, compiler_specific]:
+        paths.append(item)
+        ci = join_path(item, 'case-insensitive')
+        if os.path.isdir(ci):
+            paths.append(ci)
+    return paths
+
+
 def set_build_environment_variables(pkg, env, dirty=False):
     """
     This ensures a clean install environment when we build packages.
@@ -250,12 +261,7 @@ def set_build_environment_variables(pkg, env, dirty=False):
     # handled by putting one in the <build_env_path>/case-insensitive
     # directory.  Add that to the path too.
     env_paths = []
-    compiler_specific = join_path(spack.build_env_path, pkg.compiler.name)
-    for item in [spack.build_env_path, compiler_specific]:
-        env_paths.append(item)
-        ci = join_path(item, 'case-insensitive')
-        if os.path.isdir(ci):
-            env_paths.append(ci)
+    env_paths.extend(compiler_paths(pkg))
 
     env_paths = filter_system_paths(env_paths)
 


### PR DESCRIPTION
Intended to handle #3209 

I'd like to test this out on a cray theta machine and have access pending for one. In the meantime this is a WIP that is the first thing I was going to try.

This omits setting the toolset/compiler during the bootstrap phase when the frontend target does not match the boost spec target. This also rearranges the PATH within the boost installation process to put spack compiler wrappers last, so if any compilers are part of the default search paths boost will use those to create the build system.