### PR TITLE
Replace copy_file/copy_tree with install/install_tree separately for packages: cub, fastqc, kaldi, sctk.

### DIFF
--- a/var/spack/repos/builtin/packages/cub/package.py
+++ b/var/spack/repos/builtin/packages/cub/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from distutils.dir_util import copy_tree
 
 
 class Cub(Package):
@@ -36,4 +35,4 @@ class Cub(Package):
     version('1.6.4', '924fc12c0efb17264c3ad2d611ed1c51')
 
     def install(self, spec, prefix):
-        copy_tree('cub', prefix.include)
+        install_tree('cub', prefix.include)

--- a/var/spack/repos/builtin/packages/fastqc/package.py
+++ b/var/spack/repos/builtin/packages/fastqc/package.py
@@ -23,8 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from distutils.dir_util import copy_tree, mkpath
-from distutils.file_util import copy_file
 
 
 class Fastqc(Package):
@@ -41,15 +39,14 @@ class Fastqc(Package):
     patch('fastqc.patch', level=0)
 
     def install(self, spec, prefix):
-        mkpath(self.prefix.bin)
-        mkpath(self.prefix.lib)
-        copy_file('fastqc', self.prefix.bin)
+        mkdirp(self.prefix.bin)
+        mkdirp(self.prefix.lib)
+        install('fastqc', self.prefix.bin)
+        set_executable(join_path(self.prefix.bin, 'fastqc'))
         for j in ['cisd-jhdf5.jar', 'jbzip2-0.9.jar', 'sam-1.103.jar']:
-            copy_file(j, self.prefix.lib)
+            install(j, join_path(self.prefix.lib, j))
         for d in ['Configuration', 'net', 'org', 'Templates', 'uk']:
-            copy_tree(d, join_path(self.prefix.lib, d))
-        chmod = which('chmod')
-        chmod('+x', join_path(self.prefix.bin, 'fastqc'))
+            install_tree(d, join_path(self.prefix.lib, d))
 
     # In theory the 'run' dependency on 'jdk' above should take
     # care of this for me. In practice, it does not.

--- a/var/spack/repos/builtin/packages/kaldi/package.py
+++ b/var/spack/repos/builtin/packages/kaldi/package.py
@@ -23,8 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from distutils.dir_util import copy_tree
-from os.path import join
 from fnmatch import fnmatch
 import os
 
@@ -93,15 +91,14 @@ class Kaldi(Package):    # Does not use Autotools
             mkdirp(prefix.bin)
             for root, dirs, files in os.walk('bin'):
                 for name in files:
-                    if os.access(join(root, name), os.X_OK):
-                        install(join(root, name), prefix.bin)
+                    if is_exe(join_path(root, name)):
+                        install(join_path(root, name), prefix.bin)
 
-            mkdir(prefix.lib)
-            copy_tree('lib', prefix.lib)
+            install_tree('lib', prefix.lib)
 
             for root, dirs, files in os.walk('.'):
                 for name in files:
                     if fnmatch(name, '*.h'):
-                        mkdirp(join(prefix.include, root.strip("./")))
-                        install(join(root, name),
-                                join(prefix.include, root.strip("./")))
+                        mkdirp(join_path(prefix.include, root.strip("./")))
+                        install(join_path(root, name),
+                                join_path(prefix.include, root.strip("./")))

--- a/var/spack/repos/builtin/packages/sctk/package.py
+++ b/var/spack/repos/builtin/packages/sctk/package.py
@@ -23,14 +23,13 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from distutils.dir_util import copy_tree
 
 
 class Sctk(Package):
-    """The NIST Scoring Toolkit (SCTK) is a collection of software tools 
-        designed to score benchmark test evaluations of Automatic Speech 
-        Recognition (ASR) Systems. The toolkit is currently used by NIST, 
-        benchmark test participants, and reserchers worldwide to as a 
+    """The NIST Scoring Toolkit (SCTK) is a collection of software tools
+        designed to score benchmark test evaluations of Automatic Speech
+        Recognition (ASR) Systems. The toolkit is currently used by NIST,
+        benchmark test participants, and reserchers worldwide to as a
         common scoring engine."""
 
     homepage = "https://www.nist.gov/itl/iad/mig/tools"
@@ -49,5 +48,4 @@ class Sctk(Package):
         make('config')
         make('all')
         make('install')
-        mkdirp(prefix.bin)
-        copy_tree('bin', prefix.bin)
+        install_tree('bin', prefix.bin)


### PR DESCRIPTION
Replace `distutils.dir_util.copy_tree` and `copy_file` with Spack's built-in `install_tree` and `install` separately.