### PR TITLE
Bugfix: flag propagation into concrete specs

### DIFF
--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -47,6 +47,9 @@ def setup_parser(subparser):
         '-N', '--namespaces', action='store_true', default=False,
         help='show fully qualified package names')
     subparser.add_argument(
+        '-C', '--concreteness', action='store_true', default=False,
+        help='show whether nodes are concrete')
+    subparser.add_argument(
         '-I', '--install-status', action='store_true', default=False,
         help='show install status of packages. packages can be: '
              'installed [+], missing and needed by an installed package [-], '
@@ -60,7 +63,8 @@ def setup_parser(subparser):
 
 def spec(parser, args):
     name_fmt = '$.' if args.namespaces else '$_'
-    kwargs = {'cover': args.cover,
+    kwargs = {'concreteness': args.concreteness,
+              'cover': args.cover,
               'format': name_fmt + '$@$%@+$+$=',
               'hashlen': None if args.very_long else 7,
               'show_types': args.types,

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -378,6 +378,10 @@ class Concretizer(object):
         compiler is used, defaulting to no compiler flags in the spec.
         Default specs set at the compiler level will still be added later.
         """
+        # don't modify specs that are already concrete.
+        if spec._hash or spec._concrete:
+            return False
+
         # Pass on concretizing the compiler flags if the target or operating
         # system is not set.
         if not (spec.architecture.platform_os and spec.architecture.target):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3188,7 +3188,9 @@ class Spec(object):
     def tree(self, **kwargs):
         """Prints out this spec and its dependencies, tree-formatted
            with indentation."""
+
         color = kwargs.pop('color', get_color_when())
+        concreteness = kwargs.pop('concreteness', False)
         depth = kwargs.pop('depth', False)
         hashes = kwargs.pop('hashes', False)
         hlen = kwargs.pop('hashlen', None)
@@ -3224,6 +3226,9 @@ class Spec(object):
 
             if hashes:
                 out += colorize('@K{%s}  ', color=color) % node.dag_hash(hlen)
+
+            if concreteness:
+                out += 'C  ' if node._concrete else '   '
 
             if show_types:
                 out += '['

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1654,7 +1654,7 @@ class Spec(object):
         if visited is None:
             visited = set()
 
-        if self.name in visited:
+        if self.name in visited or self._hash or self._concrete:
             return False
 
         if self.concrete:


### PR DESCRIPTION
Fixes #3717.

The `concretize_compiler_flags` would descend into concrete specs when adding flags to specs looked up by hash.  Concretizer will now ignore these.

Note: this wasn't a real SHA-1 collision; the hash just wasn't being recomputed because it had been memoized.

@wscullin: can you verify that this works for you?