### PR TITLE
Make libelf the default elf provider again.

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -20,7 +20,7 @@ packages:
       awk: [gawk]
       blas: [openblas]
       daal: [intel-parallel-studio+daal]
-      elf: [elfutils]
+      elf: [libelf]
       golang: [gcc]
       ipp: [intel-parallel-studio+ipp]
       lapack: [openblas]

--- a/var/spack/repos/builtin/packages/dyninst/package.py
+++ b/var/spack/repos/builtin/packages/dyninst/package.py
@@ -48,8 +48,11 @@ class Dyninst(Package):
     variant('stat_dysect', default=False,
             description="patch for STAT's DySectAPI")
 
-    depends_on("elf@0", type='link', when='@:9.2.99')
-    depends_on("elf@1", type='link', when='@9.3.0:')
+    # Dyninst used to work with either elfutils or libelf, but requires
+    # elfutils as of 9.3.0
+    depends_on("elf", type='link', when='@:9.2.99')
+    depends_on("elfutils", type='link', when='@9.3.0:')
+
     depends_on("libdwarf")
     depends_on("boost@1.42:")
     depends_on('cmake', type='build')
@@ -87,7 +90,7 @@ class Dyninst(Package):
             make()
             make("install")
 
-    @when('@:8.1')
+    @when('@:8.1')  # noqa
     def install(self, spec, prefix):
         configure("--prefix=" + prefix)
         make()

--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -42,7 +42,7 @@ class Elfutils(AutotoolsPackage):
     version('0.168', '52adfa40758d0d39e5d5c57689bf38d6')
     version('0.163', '77ce87f259987d2e54e4d87b86cbee41', preferred=True)
 
-    provides('elf@1')
+    provides('elf')
 
     def configure_args(self):
         return ['--enable-maintainer-mode']

--- a/var/spack/repos/builtin/packages/libelf/package.py
+++ b/var/spack/repos/builtin/packages/libelf/package.py
@@ -37,7 +37,7 @@ class Libelf(AutotoolsPackage):
     version('0.8.13', '4136d7b4c04df68b686570afa26988ac')
     version('0.8.12', 'e21f8273d9f5f6d43a59878dc274fec7')
 
-    provides('elf@0')
+    provides('elf')
 
     def configure_args(self):
         args = ["--enable-shared",


### PR DESCRIPTION
We've had fairly frequent issues building `elfutils` and `libdwarf` with `elfutils`.  I don't think these are tested well with each other, while `libelf` is *very* compatible.

So, I move to make `libelf` the default `elf` again.

All in favor, please approve.