### PR TITLE
Architecture: the target part can be overridden setting an environment variable

### DIFF
--- a/lib/spack/spack/architecture.py
+++ b/lib/spack/spack/architecture.py
@@ -146,6 +146,7 @@ class Platform(object):
         self.targets = {}
         self.operating_sys = {}
         self.name = name
+        self.default = os.environ.get('SPACK_TARGET_TYPE', None)
 
     def add_target(self, name, target):
         """Used by the platform specific subclass to list available targets.
@@ -335,7 +336,10 @@ class OperatingSystem(object):
                 if newcount <= prevcount:
                     continue
 
-            compilers[ver] = cmp_cls(spec, self, py_platform.machine(), paths)
+            target = os.environ.get(
+                'SPACK_TARGET_TYPE', py_platform.machine()
+            )
+            compilers[ver] = cmp_cls(spec, self, target, paths)
 
         return list(compilers.values())
 

--- a/lib/spack/spack/platforms/linux.py
+++ b/lib/spack/spack/platforms/linux.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import platform
+
 from spack.architecture import Platform, Target
 from spack.operating_systems.linux_distro import LinuxDistro
 
@@ -35,7 +36,9 @@ class Linux(Platform):
         self.add_target('x86_64', Target('x86_64'))
         self.add_target('ppc64le', Target('ppc64le'))
 
-        self.default = platform.machine()
+        if self.default is None:
+            self.default = platform.machine()
+
         self.front_end = platform.machine()
         self.back_end = platform.machine()
 

--- a/lib/spack/spack/platforms/test.py
+++ b/lib/spack/spack/platforms/test.py
@@ -30,7 +30,6 @@ class Test(Platform):
     priority    = 1000000
     front_end   = 'x86_32'
     back_end    = 'x86_64'
-    default     = 'x86_64'
 
     front_os = 'redhat6'
     back_os = 'debian6'
@@ -38,6 +37,7 @@ class Test(Platform):
 
     def __init__(self):
         super(Test, self).__init__('test')
+        self.default = 'x86_64'
         self.add_target(self.default, Target(self.default))
         self.add_target(self.front_end, Target(self.front_end))
 


### PR DESCRIPTION
The full description is available at epfl-scitas/spack#59. It may be of help for installations on a shared filesystem for different architectures with differences that are not caught by the triplet `<platform>-<os>-<target>`.