### PR TITLE
ccache support

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -90,3 +90,7 @@ config:
   # If set to 4, for example, `spack install` will run `make -j4`.
   # If not set, all available cores are used by default.
   # build_jobs: 4
+
+
+  # If set to true, spack will use ccache to cache c compiles.
+  ccache: false

--- a/lib/spack/docs/config_yaml.rst
+++ b/lib/spack/docs/config_yaml.rst
@@ -191,3 +191,22 @@ to 4, for example, commands like ``spack install`` will run ``make -j4``
 instead of hogging every core.
 
 To build all software in serial, set ``build_jobs`` to 1.
+
+--------------------
+``ccache``
+--------------------
+
+When set to ``true`` Spack will use ccache to cache compiles. This is
+useful specifically un two cases: (1) Use with ``spack setup``, (2)
+Build the same package with many different variants. The default is
+``false``.
+
+When enabled Spack will look inside your ``PATH`` for a ``ccache``
+executable and stop if it is not found. Some systems come with
+``ccache``, but it can also be installed using ``spack install
+ccache``. ``ccache`` comes with reasonable defaults for cache size
+and location. (See the *Configuration settings* secion of ``man
+ccache`` to learn more about the default settings and how change
+them.) Please note that we currently disable ccache's ``hash_dir``
+feature to avoid an issue with the stage directory (see
+https://github.com/LLNL/spack/pull/3761#issuecomment-294352232 ).

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -342,7 +342,15 @@ case "$mode" in
         args=("${args[@]}" ${SPACK_LDLIBS[@]}) ;;
 esac
 
-full_command=("$command" "${args[@]}")
+#ccache only supports C languages, so filtering out Fortran
+if [[ ( ${lang_flags} = "C" || ${lang_flags} = "CXX" ) && ${SPACK_CCACHE_BINARY} ]]; then
+    full_command=("${SPACK_CCACHE_BINARY}" "$command" "${args[@]}")
+    # #3761#issuecomment-294352232
+    # workaround for stage being a temp folder
+    export CCACHE_NOHASHDIR=yes
+else
+   full_command=("$command" "${args[@]}")
+fi
 
 # In test command mode, write out full command for Spack tests.
 if [[ $SPACK_TEST_COMMAND == dump-args ]]; then

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -98,6 +98,7 @@ SPACK_DEBUG = 'SPACK_DEBUG'
 SPACK_SHORT_SPEC = 'SPACK_SHORT_SPEC'
 SPACK_DEBUG_LOG_ID = 'SPACK_DEBUG_LOG_ID'
 SPACK_DEBUG_LOG_DIR = 'SPACK_DEBUG_LOG_DIR'
+SPACK_CCACHE_BINARY = 'SPACK_CCACHE_BINARY'
 
 
 # Platform-specific library suffix.
@@ -334,6 +335,13 @@ def set_build_environment_variables(pkg, env, dirty):
     env.set(SPACK_SHORT_SPEC, pkg.spec.short_spec)
     env.set(SPACK_DEBUG_LOG_ID, pkg.spec.format('${PACKAGE}-${HASH:7}'))
     env.set(SPACK_DEBUG_LOG_DIR, spack.main.spack_working_dir)
+
+    # Find ccache binary and hand it to build environment
+    if spack.config.get('config:ccache'):
+        ccache = Executable('ccache')
+        if not ccache:
+            raise RuntimeError("No ccache binary found in PATH")
+        env.set(SPACK_CCACHE_BINARY, ccache)
 
     # Add any pkgconfig directories to PKG_CONFIG_PATH
     for prefix in build_link_prefixes:

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -69,6 +69,7 @@ schema = {
                 'locks': {'type': 'boolean'},
                 'dirty': {'type': 'boolean'},
                 'build_jobs': {'type': 'integer', 'minimum': 1},
+                'ccache': {'type': 'boolean'},
             }
         },
     },


### PR DESCRIPTION
Fix #5504

```
export SPACK_ENABLE_CCACHE=yes
export PATH="/path/to/cache${PATH:+:}${PATH}"
spack install libelf
ccache -z
spack uninstall libelf && spack install libelf
ccache -s
```
and yeah
```
cache directory                     /home/junghans/.ccache
primary config                      /home/junghans/.ccache/ccache.conf
secondary config      (readonly)    /etc/ccache.conf
cache hit (direct)                   114
cache hit (preprocessed)               0
cache miss                             4
called for link                        1
called for preprocessing              18
compile failed                         2
autoconf compile/link                 21
files in cache                       394
cache size                           5.8 MB
max cache size                       5.0 GB
```
