### PR TITLE
Package.is_extension now uses Spec.concrete

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -804,7 +804,7 @@ class PackageBase(with_metaclass(PackageMeta, object)):
 
         # if the spec is concrete already, then it extends something
         # that is an *optional* dependency, and the dep isn't there.
-        if self.spec._concrete:
+        if self.spec.concrete:
             return None
         else:
             # If it's not concrete, then return the spec from the
@@ -828,7 +828,7 @@ class PackageBase(with_metaclass(PackageMeta, object)):
     def is_extension(self):
         # if it is concrete, it's only an extension if it actually
         # dependes on the extendee.
-        if self.spec._concrete:
+        if self.spec.concrete:
             return self.extendee_spec is not None
         else:
             # If not, then it's an extension if it *could* be an extension


### PR DESCRIPTION
This addresses an issue observed in https://github.com/LLNL/spack/pull/3227 where extendee_spec on a package was present because the package was not considered concrete (according to the ```._concrete``` property).

- [ ] I'd like to add a test where a package conditionally extends another package and make sure this fixes the issue

Originally Package.is_extension was using Spec._concrete. This replaces the direct access to the cached variable with a call to the property function (since in some cases, e.g. after a copy, _concrete is not set properly).