### PR TITLE
More sensible duplication of version and compiler info.

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1673,7 +1673,8 @@ class Spec(object):
                 if spec.virtual:
                     spec._replace_with(replacement)
                     changed = True
-                if spec._dup(replacement, deps=False, cleardeps=False, soft_dup=True):
+                if spec._dup(replacement, deps=False, cleardeps=False,
+                             soft_dup=True):
                     changed = True
 
                 self_index.update(spec)
@@ -2417,7 +2418,7 @@ class Spec(object):
         self.name = other.name
         if soft_dup:
             if not (self.versions.concrete and (not other.versions.concrete)):
-                 self.versions = other.versions.copy()
+                self.versions = other.versions.copy()
         else:
             self.versions = other.versions.copy()
         self.architecture = other.architecture.copy() if other.architecture \
@@ -2425,10 +2426,12 @@ class Spec(object):
         if soft_dup:
             if self.compiler:
                 if other.compiler:
-                    if not (self.compiler.versions.concrete and (not other.compiler.versions.concrete)):
+                    if not (self.compiler.versions.concrete and
+                            (not other.compiler.versions.concrete)):
                         self.compiler = other.compiler.copy()
             else:
-                self.compiler = other.compiler.copy() if other.compiler else None
+                self.compiler = other.compiler.copy() if other.compiler \
+                    else None
         else:
             self.compiler = other.compiler.copy() if other.compiler else None
         if cleardeps:


### PR DESCRIPTION
Do not overwrite a concretized version or compiler and or version with a
non concretized version! This can happen from external packages if
their definition is not concrete!

Example: In `packages.yaml` you add an external package with a non-fully concretized spec:

```
packages:
  external-package:
    paths:
      external-package%gcc: /path/to/external-package-with-gcc
    buildable: False
```

Then you install this package with `spack install external-package`.
When checking for external and virtual packages, `external-package%gcc` matches the spec, so the install spec is replaced with `external-package%gcc`. The spec is then concretized to something more specific like `external-package%gcc@5.3.0`. During the next stage, `external-package%gcc` matches the spec again, so the spec is replaced with `external-package%gcc` thus starting an infinite loop.

This commit adds an option `soft_dup` to the `_dup` routine of a spec. When `soft_dup=True`, `_dup` prevents overwriting a spec which is concrete with one which is not.

I ment to include this set of patches with the external pacakges pull request from @alalazo but I forgot to add it.