### PR TITLE
Search for module based compilers by default

### DIFF
--- a/lib/spack/spack/architecture.py
+++ b/lib/spack/spack/architecture.py
@@ -288,7 +288,8 @@ class OperatingSystem(object):
         # on the environment for things such as locations of license files
         compiler_lists = []
         for single_type in types:
-            compiler_lists.append(self.find_compiler(single_type, *filtered_path))
+            compiler_lists.append(self.find_compiler(single_type,
+                                                     *filtered_path))
 
         # ensure all the version calls we made are cached in the parent
         # process, as well.  This speeds up Spack a lot.
@@ -362,10 +363,12 @@ class OperatingSystem(object):
                     # check for conflicts and load required module
                     # This allows the compiler to find license files
                     # if need be.
-                    text = modulecmd('show', mod_name, output=str, error=str).split()
+                    text = modulecmd('show', mod_name,
+                                     output=str, error=str).split()
                     for i, word in enumerate(text):
                         if word == 'conflict':
-                            modulecmd('unload', text[i + 1], output=str, error=str)
+                            modulecmd('unload', text[i + 1],
+                                      output=str, error=str)
                             tty.debug("Removed module %s" % mod_name)
                     modulecmd('load', mod_name, output=str, error=str)
                     tty.debug("Loaded module %s" % mod_name)
@@ -378,17 +381,21 @@ class OperatingSystem(object):
                         output=str, error=str).split()
                     for i, word in enumerate(text):
                         if len(re.findall('path', word)) != 0:
-                            paths.append(text[i+2])
+                            paths.append(text[i + 2])
 
                     # get compilers from paths
                     # we can use parmap here because the appropriate module
                     # has already been loaded.
                     dicts = parmap(
                         lambda t: cmp_cls._find_matches_in_path(*t),
-                        [(cmp_cls.cc_names,  cmp_cls.cc_version)  + tuple(paths),
-                         (cmp_cls.cxx_names, cmp_cls.cxx_version) + tuple(paths),
-                         (cmp_cls.f77_names, cmp_cls.f77_version) + tuple(paths),
-                         (cmp_cls.fc_names,  cmp_cls.fc_version)  + tuple(paths)])
+                        [((cmp_cls.cc_names,  cmp_cls.cc_version) +
+                            tuple(paths)),
+                         ((cmp_cls.cxx_names, cmp_cls.cxx_version) +
+                             tuple(paths)),
+                         ((cmp_cls.f77_names, cmp_cls.f77_version) +
+                             tuple(paths)),
+                         ((cmp_cls.fc_names,  cmp_cls.fc_version) +
+                             tuple(paths))])
                     all_keys = set()
                     for d in dicts:
                         all_keys.update(d)
@@ -399,7 +406,8 @@ class OperatingSystem(object):
                         if ver == 'unknown':
                             continue
 
-                        paths = tuple(pn[k] if k in pn else None for pn in dicts)
+                        paths = tuple(
+                            pn[k] if k in pn else None for pn in dicts)
                         spec = spack.spec.CompilerSpec(cmp_cls.name, ver)
 
                         if ver in compilers:
@@ -408,10 +416,12 @@ class OperatingSystem(object):
                             # prefer the one with more compilers.
                             prev_paths = [prev.cc, prev.cxx, prev.f77, prev.fc]
                             newcount = len([p for p in paths if p is not None])
-                            prevcount = len([p for p in prev_paths if p is not None])
+                            prevcount = len(
+                                [p for p in prev_paths if p is not None])
 
-                            # Don't add if it's not an improvement over prev compiler.
-                            # but only if the previous compiler was module based
+                            # Don't add if it's not an improvement over
+                            # prev compiler. but only if the previous
+                            # compiler was module based
                             if len(prev.modules) > 0 and newcount <= prevcount:
                                 continue
 

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -83,6 +83,9 @@ class Compiler(object):
     # Subclasses use possible names of Fortran 90 compiler
     fc_names = []
 
+    # possible module names
+    module_names = []
+
     # Optional prefix regexes for searching for this type of compiler.
     # Prefixes are sometimes used for toolchains, e.g. 'powerpc-bgq-linux-'
     prefixes = []

--- a/lib/spack/spack/compilers/cce.py
+++ b/lib/spack/spack/compilers/cce.py
@@ -39,6 +39,9 @@ class Cce(Compiler):
     # Subclasses use possible names of Fortran 90 compiler
     fc_names = ['ftn']
 
+    # Possible module names
+    module_names = ['cce']
+
     # MacPorts builds gcc versions with prefixes and -mp-X.Y suffixes.
     suffixes = [r'-mp-\d\.\d']
 

--- a/lib/spack/spack/compilers/clang.py
+++ b/lib/spack/spack/compilers/clang.py
@@ -48,6 +48,9 @@ class Clang(Compiler):
     # Subclasses use possible names of Fortran 90 compiler
     fc_names = ['flang', 'gfortran']
 
+    # Possible module names
+    module_names = ['clang']
+
     # Named wrapper links within spack.build_env_path
     link_paths = {'cc': 'clang/clang',
                   'cxx': 'clang/clang++'}

--- a/lib/spack/spack/compilers/gcc.py
+++ b/lib/spack/spack/compilers/gcc.py
@@ -42,6 +42,9 @@ class Gcc(Compiler):
     # Subclasses use possible names of Fortran 90 compiler
     fc_names = ['gfortran']
 
+    # Possible module names
+    module_names = ['gcc']
+
     # MacPorts builds gcc versions with prefixes and -mp-X.Y suffixes.
     # Homebrew and Linuxbrew may build gcc with -X, -X.Y suffixes.
     # Old compatibility versions may contain XY suffixes.

--- a/lib/spack/spack/compilers/intel.py
+++ b/lib/spack/spack/compilers/intel.py
@@ -41,6 +41,9 @@ class Intel(Compiler):
     # Subclasses use possible names of Fortran 90 compiler
     fc_names = ['ifort']
 
+    # Possible module names
+    module_names = ['intel']
+
     # Named wrapper links within spack.build_env_path
     link_paths = {'cc': 'intel/icc',
                   'cxx': 'intel/icpc',

--- a/lib/spack/spack/compilers/nag.py
+++ b/lib/spack/spack/compilers/nag.py
@@ -38,6 +38,9 @@ class Nag(Compiler):
     # Subclasses use possible names of Fortran 90 compiler
     fc_names = ['nagfor']
 
+    # Possible module names
+    module_names = ['nag']
+
     # Named wrapper links within spack.build_env_path
     # Use default wrappers for C and C++, in case provided in compilers.yaml
     link_paths = {

--- a/lib/spack/spack/compilers/pgi.py
+++ b/lib/spack/spack/compilers/pgi.py
@@ -38,6 +38,9 @@ class Pgi(Compiler):
     # Subclasses use possible names of Fortran 90 compiler
     fc_names = ['pgfortran', 'pgf95', 'pgf90']
 
+    # Possible module names
+    module_names = ['pgi']
+
     # Named wrapper links within spack.build_env_path
     link_paths = {'cc': 'pgi/pgcc',
                   'cxx': 'pgi/pgc++',

--- a/lib/spack/spack/compilers/xl.py
+++ b/lib/spack/spack/compilers/xl.py
@@ -41,6 +41,9 @@ class Xl(Compiler):
     # Subclasses use possible names of Fortran 90 compiler
     fc_names = ['xlf90', 'xlf95', 'xlf2003', 'xlf2008']
 
+    # Possible module names
+    module_names = ['xl']
+
     # Named wrapper links within spack.build_env_path
     link_paths = {'cc': 'xl/xlc',
                   'cxx': 'xl/xlc++',

--- a/lib/spack/spack/compilers/xl_r.py
+++ b/lib/spack/spack/compilers/xl_r.py
@@ -42,6 +42,9 @@ class XlR(Compiler):
     # Subclasses use possible names of Fortran 90 compiler
     fc_names = ['xlf90_r', 'xlf95_r', 'xlf2003_r', 'xlf2008_r']
 
+    # Possible module names
+    module_names = ['xl_r']
+
     # Named wrapper links within spack.build_env_path
     link_paths = {'cc': 'xl_r/xlc_r',
                   'cxx': 'xl_r/xlc++_r',


### PR DESCRIPTION
This PR does the following:
- Adds default module names to compilers so that spack may recognize them when they are available on a system.
- Checks if modulecmd is in the current PATH. If it is, it searches the list of available modules for those matching default module names that spack knows about. These are then used to create compilers.

This greatly eases pain for people deploying spack on a new system which uses modules and may have many compiler versions available.