### PR TITLE
Make setup-env.sh compatible with dash

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,5 +11,7 @@ ignore:
   - lib/spack/spack/test/.*
   - lib/spack/docs/.*
   - lib/spack/external/.*
+  - share/spack/qa/.*
+  - share/spack/spack-completion.bash
 
 comment: off

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,24 +50,6 @@ jobs:
       os: linux
       language: python
       env: [ TEST_SUITE=unit, COVERAGE=true ]
-      addons:
-        apt:
-          packages:
-          - cmake
-          - gfortran
-          - graphviz
-          - gnupg2
-          - kcov
-          - mercurial
-          - ninja-build
-          - perl
-          - perl-base
-          - realpath
-          - patchelf
-          - r-base
-          - r-base-core
-          - r-base-dev
-
     - python: '3.7'
       sudo: required
       os: linux
@@ -159,6 +141,7 @@ addons:
       - r-base
       - r-base-core
       - r-base-dev
+      - zsh
   # for Mac builds, we use Homebrew
   homebrew:
     packages:
@@ -166,6 +149,8 @@ addons:
       - gcc
       - gnupg2
       - ccache
+      - dash
+      - kcov
     update: true
 
 # ~/.ccache needs to be cached directly as Travis is not taking care of it
@@ -223,11 +208,13 @@ script:
 
 after_success:
   - ccache -s
-  - if [[ "$TEST_SUITE" == "unit" || "$TEST_SUITE" == "build" ]]; then
-        codecov --env PYTHON_VERSION
-                --required
-                --flags "${TEST_SUITE}${TRAVIS_OS_NAME}";
-    fi
+  - case "$TEST_SUITE" in
+        unit)
+            codecov --env PYTHON_VERSION
+                    --required
+                    --flags "${TEST_SUITE}${TRAVIS_OS_NAME}";
+            ;;
+    esac
 
 #=============================================================================
 # Notifications

--- a/share/spack/qa/run-unit-tests
+++ b/share/spack/qa/run-unit-tests
@@ -16,6 +16,12 @@
 #     Optionally add one or more unit tests
 #     to only run these tests.
 #
+
+#-----------------------------------------------------------
+# Run a few initial commands and set up test environment
+#-----------------------------------------------------------
+ORIGINAL_PATH="$PATH"
+
 . "$(dirname $0)/setup.sh"
 check_dependencies ${coverage} git hg svn
 
@@ -33,9 +39,33 @@ bin/spack help -a
 # Profile and print top 20 lines for a simple call to spack spec
 bin/spack -p --lines 20 spec mpileaks%gcc ^elfutils@0.170
 
+#-----------------------------------------------------------
 # Run unit tests with code coverage
+#-----------------------------------------------------------
 extra_args=""
 if [[ -n "$@" ]]; then
     extra_args="-k $@"
 fi
 ${coverage_run} bin/spack test --verbose "$extra_args"
+
+#-----------------------------------------------------------
+# Run tests for setup-env.sh
+#-----------------------------------------------------------
+# Clean the environment by removing Spack from the path and getting rid of
+# the spack shell function
+export PATH="$ORIGINAL_PATH"
+unset spack
+
+# start in the spack root directory
+cd $SPACK_ROOT
+
+# Run bash tests with coverage enabled, but pipe output to /dev/null
+# because it seems that kcov seems to undo the script's redirection
+if [ "$BASH_COVERAGE" = true ]; then
+    ${QA_DIR}/bashcov ${QA_DIR}/setup-env-test.sh &> /dev/null
+fi
+
+# run the test scripts for their output (these will print nicely)
+bash ${QA_DIR}/setup-env-test.sh
+zsh  ${QA_DIR}/setup-env-test.sh
+dash ${QA_DIR}/setup-env-test.sh

--- a/share/spack/qa/setup-env-test.sh
+++ b/share/spack/qa/setup-env-test.sh
@@ -1,0 +1,289 @@
+#!/bin/sh
+#
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+#
+# This script tests that Spack's setup-env.sh init script works.
+#
+# The tests are portable to bash, zsh, and bourne shell, and can be run
+# in any of these shells.
+#
+
+# ------------------------------------------------------------------------
+# Functions for color output.
+# ------------------------------------------------------------------------
+
+# Colors for output
+red='\033[1;31m'
+cyan='\033[1;36m'
+green='\033[1;32m'
+reset='\033[0m'
+
+echo_red() {
+    printf "${red}$*${reset}\n"
+}
+
+echo_green() {
+    printf "${green}$*${reset}\n"
+}
+
+echo_msg() {
+    printf "${cyan}$*${reset}\n"
+}
+
+# ------------------------------------------------------------------------
+# Generic functions for testing shell code.
+# ------------------------------------------------------------------------
+
+# counts of test successes and failures.
+success=0
+errors=0
+
+# Print out a header for a group of tests.
+title() {
+    echo
+    echo_msg "$@"
+    echo_msg "---------------------------------"
+}
+
+# echo FAIL in red text; increment failures
+fail() {
+    echo_red FAIL
+    errors=$((errors+1))
+}
+
+#
+# Echo SUCCESS in green; increment successes
+#
+pass() {
+    echo_green SUCCESS
+    success=$((success+1))
+}
+
+#
+# Run a command and suppress output unless it fails.
+# On failure, echo the exit code and output.
+#
+succeeds() {
+    printf "'%s' succeeds ... " "$*"
+    output=$("$@" 2>&1)
+    err="$?"
+
+    if [ "$err" != 0 ]; then
+        fail
+        echo_red "Command failed with error $err."
+        if [ -n "$output" ]; then
+            echo_msg "Output:"
+            echo "$output"
+        else
+            echo_msg "No output."
+        fi
+    else
+        pass
+    fi
+}
+
+#
+# Run a command and suppress output unless it succeeds.
+# If the command succeeds, echo the output.
+#
+fails() {
+    printf "'%s' fails ... " "$*"
+    output=$("$@" 2>&1)
+    err="$?"
+
+    if [ "$err" = 0 ]; then
+        fail
+        echo_red "Command failed with error $err."
+        if [ -n "$output" ]; then
+            echo_msg "Output:"
+            echo "$output"
+        else
+            echo_msg "No output."
+        fi
+    else
+        pass
+    fi
+}
+
+#
+# Ensure that a string is in the output of a command.
+# Suppresses output on success.
+# On failure, echo the exit code and output.
+#
+contains() {
+    string="$1"
+    shift
+
+    printf "'%s' output contains '$string' ... " "$*"
+    output=$("$@" 2>&1)
+    err="$?"
+
+    if [ "${output#*$string}" = "${output}" ]; then
+        fail
+        echo_red "Command exited with error $err."
+        echo_red "'$string' was not in output."
+        if [ -n "$output" ]; then
+            echo_msg "Output:"
+            echo "$output"
+        else
+            echo_msg "No output."
+        fi
+    else
+        pass
+    fi
+}
+
+# -----------------------------------------------------------------------
+# Instead of invoking the module/use/dotkit commands, we print the
+# arguments that Spack invokes the command with, so we can check that
+# Spack passes the expected arguments in the tests below.
+#
+# We make that happen by defining the sh functions below.
+# -----------------------------------------------------------------------
+module() {
+    echo module "$@"
+}
+
+use() {
+    echo use "$@"
+}
+
+unuse() {
+    echo unuse "$@"
+}
+
+# -----------------------------------------------------------------------
+# Setup test environment and do some preliminary checks
+# -----------------------------------------------------------------------
+
+# Make sure no environment is active
+unset SPACK_ENV
+
+# Source setup-env.sh before tests
+.  share/spack/setup-env.sh
+
+title "Testing setup-env.sh with $_sp_shell"
+
+# spack command is now avaialble
+succeeds which spack
+
+# mock cd command (intentionally define only AFTER setup-env.sh)
+cd() {
+    echo cd "$@"
+}
+
+# create a fake mock package install and store its location for later
+title "Setup"
+echo "Creating a mock package installation"
+spack -m install --fake a
+a_install=$(spack location -i a)
+a_module=$(spack -m module tcl find a)
+a_dotkit=$(spack -m module dotkit find a)
+
+b_install=$(spack location -i b)
+b_module=$(spack -m module tcl find b)
+b_dotkit=$(spack -m module dotkit find b)
+
+# ensure that we uninstall b on exit
+cleanup() {
+    title "Cleanup"
+    echo "Removing test package before exiting test script."
+    spack -m uninstall -yf b
+    spack -m uninstall -yf a
+
+    echo
+    echo "$success tests succeeded."
+    echo "$errors tests failed."
+    if [ "$errors" = 0 ]; then
+        pass
+        exit 0
+    else
+        fail
+        exit 1
+    fi
+}
+trap cleanup EXIT
+
+# -----------------------------------------------------------------------
+# Test all spack commands with special env support
+# -----------------------------------------------------------------------
+title 'Testing `spack`'
+contains 'usage: spack ' spack
+contains "usage: spack " spack -h
+contains "usage: spack " spack help
+contains "usage: spack " spack -H
+contains "usage: spack " spack help --all
+
+title 'Testing `spack cd`'
+contains "usage: spack cd " spack cd -h
+contains "usage: spack cd " spack cd --help
+contains "cd $b_install" spack cd -i b
+
+title 'Testing `spack module`'
+contains "usage: spack module " spack -m module -h
+contains "usage: spack module " spack -m module --help
+contains "usage: spack module " spack -m module
+
+title 'Testing `spack load`'
+contains "module load $b_module" spack -m load b
+fails spack -m load -l
+contains "module load -l --arg $b_module" spack -m load -l --arg b
+contains "module load $b_module $a_module" spack -m load -r a
+contains "module load $b_module $a_module" spack -m load --dependencies a
+fails spack -m load d
+contains "usage: spack load " spack -m load -h
+contains "usage: spack load " spack -m load -h d
+contains "usage: spack load " spack -m load --help
+
+title 'Testing `spack unload`'
+contains "module unload $b_module" spack -m unload b
+fails spack -m unload -l
+contains "module unload -l --arg $b_module" spack -m unload -l --arg b
+fails spack -m unload d
+contains "usage: spack unload " spack -m unload -h
+contains "usage: spack unload " spack -m unload -h d
+contains "usage: spack unload " spack -m unload --help
+
+title 'Testing `spack use`'
+contains "use $b_dotkit" spack -m use b
+fails spack -m use -l
+contains "use -l --arg $b_dotkit" spack -m use -l --arg b
+contains "use $b_dotkit $a_dotkit" spack -m use -r a
+contains "use $b_dotkit $a_dotkit" spack -m use --dependencies a
+fails spack -m use d
+contains "usage: spack use " spack -m use -h
+contains "usage: spack use " spack -m use -h d
+contains "usage: spack use " spack -m use --help
+
+title 'Testing `spack unuse`'
+contains "unuse $b_dotkit" spack -m unuse b
+fails spack -m unuse -l
+contains "unuse -l --arg $b_dotkit" spack -m unuse -l --arg b
+fails spack -m unuse d
+contains "usage: spack unuse "  spack -m unuse -h
+contains "usage: spack unuse "  spack -m unuse -h d
+contains "usage: spack unuse "  spack -m unuse --help
+
+title 'Testing `spack env`'
+contains "usage: spack env " spack env -h
+contains "usage: spack env " spack env --help
+
+title 'Testing `spack env activate`'
+contains "No such environment:" spack env activate no_such_environment
+contains "usage: spack env activate " spack env activate
+contains "usage: spack env activate " spack env activate -h
+contains "usage: spack env activate " spack env activate --help
+
+title 'Testing `spack env deactivate`'
+contains "Error: No environment is currently active" spack env deactivate
+contains "usage: spack env deactivate " spack env deactivate no_such_environment
+contains "usage: spack env deactivate " spack env deactivate -h
+contains "usage: spack env deactivate " spack env deactivate --help
+
+title 'Testing `spack env list`'
+contains " spack env list " spack env list -h
+contains " spack env list " spack env list --help

--- a/share/spack/qa/setup-env-test.sh
+++ b/share/spack/qa/setup-env-test.sh
@@ -163,6 +163,9 @@ unuse() {
 # Make sure no environment is active
 unset SPACK_ENV
 
+# fail with undefined variables
+set -u
+
 # Source setup-env.sh before tests
 .  share/spack/setup-env.sh
 

--- a/share/spack/qa/setup.sh
+++ b/share/spack/qa/setup.sh
@@ -20,18 +20,24 @@ export SPACK_ROOT=$(realpath "$QA_DIR/../../..")
 coverage=""
 coverage_run=""
 
+# bash coverage depends on some other factors -- there are issues with
+# kcov for Python 2.6, unit tests, and build tests.
+if [[ $TEST_SUITE == unit &&   # kcov segfaults for the MPICH build test
+      $TRAVIS_OS_NAME == linux &&
+      $TRAVIS_PYTHON_VERSION != 2.6 ]];
+then
+    BASH_COVERAGE="true"
+else
+    BASH_COVERAGE="false"
+fi
+
 # Set up some variables for running coverage tests.
 if [[ "$COVERAGE" == "true" ]]; then
     # these set up coverage for Python
     coverage=coverage
     coverage_run="coverage run"
 
-    # make a coverage directory for kcov, and patch cc to use our bashcov
-    # script instead of plain bash
-    if [[ $TEST_SUITE == unit &&   # kcov segfaults for the MPICH build test
-          $TRAVIS_OS_NAME == linux &&
-          $TRAVIS_PYTHON_VERSION != 2.6 ]];
-    then
+    if [ "$BASH_COVERAGE" = true ]; then
         mkdir -p coverage
         cc_script="$SPACK_ROOT/lib/spack/env/cc"
         bashcov=$(realpath ${QA_DIR}/bashcov)

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -6,11 +6,11 @@
 
 ########################################################################
 #
-# This file is part of Spack and sets up the spack environment for
-# bash and zsh.  This includes dotkit support, module support, and
-# it also puts spack in your path.  The script also checks that
-# at least module support exists, and provides suggestions if it
-# doesn't. Source it like this:
+# This file is part of Spack and sets up the spack environment for bash,
+# zsh, and dash (sh).  This includes dotkit support, module support, and
+# it also puts spack in your path.  The script also checks that at least
+# module support exists, and provides suggestions if it doesn't. Source
+# it like this:
 #
 #    . /path/to/spack/share/spack/setup-env.sh
 #
@@ -39,24 +39,25 @@
 # spack dotfiles.
 ########################################################################
 
-function spack {
-    # Zsh does not do word splitting by default, this enables it for this function only
+spack() {
+    # Zsh does not do word splitting by default, this enables it for this
+    # function only
     if [ -n "${ZSH_VERSION:-}" ]; then
         emulate -L sh
     fi
 
-    # save raw arguments into an array before butchering them
-    args=( "$@" )
-
     # accumulate initial flags for main spack command
     _sp_flags=""
-    while [[ "$1" =~ ^- ]]; do
+    while [ "${1#-}" != "${1}" ]; do
         _sp_flags="$_sp_flags $1"
         shift
     done
 
     # h and V flags don't require further output parsing.
-    if [[ (! -z "$_sp_flags") && ("$_sp_flags" =~ '.*h.*' || "$_sp_flags" =~ '.*V.*') ]]; then
+    if [ -n "$_sp_flags" ] && \
+       [ "${_sp_flags#*h}" != "${_sp_flags}" ] || \
+       [ "${_sp_flags#*V}" != "${_sp_flags}" ];
+    then
         command spack $_sp_flags "$@"
         return
     fi
@@ -66,7 +67,6 @@ function spack {
         _sp_subcommand="$1"
         shift
     fi
-    _sp_spec=("$@")
 
     # Filter out use and unuse.  For any other commands, just run the
     # command.
@@ -77,11 +77,11 @@ function spack {
                 _sp_arg="$1"
                 shift
             fi
-            if [[ "$_sp_arg" = "-h" || "$_sp_arg" = "--help" ]]; then
+            if [ "$_sp_arg" = "-h" ] || [ "$_sp_arg" = "--help" ]; then
                 command spack cd -h
             else
                 LOC="$(spack location $_sp_arg "$@")"
-                if [[ -d "$LOC" ]] ; then
+                if [ -d "$LOC" ] ; then
                     cd "$LOC"
                 else
                     return 1
@@ -96,31 +96,41 @@ function spack {
                 shift
             fi
 
-            if [[ "$_sp_arg" = "-h" || "$_sp_arg" = "--help" ]]; then
+            if [ "$_sp_arg" = "-h" ] || [ "$_sp_arg" = "--help" ]; then
                 command spack env -h
             else
                 case $_sp_arg in
                     activate)
                         _a="$@"
-                        if [ -z "$1" -o "${_a#*--sh}" != "$_a" -o "${_a#*--csh}" != "$_a" -o "${_a#*-h}" != "$_a" ]; then
+                        if [ -z "$1" ] || \
+                           [ "${_a#*--sh}" != "$_a" ] || \
+                           [ "${_a#*--csh}" != "$_a" ] || \
+                           [ "${_a#*-h}" != "$_a" ];
+                        then
                             # no args or args contain -h/--help, --sh, or --csh: just execute
-                            command spack "${args[@]}"
+                            command spack env activate "$@"
                         else
                             # actual call to activate: source the output
                             eval $(command spack $_sp_flags env activate --sh "$@")
                         fi
                         ;;
                     deactivate)
-                        if [ -n "$1" ]; then
-                            # with args: execute the command
-                            command spack "${args[@]}"
+                        _a="$@"
+                        if [ "${_a#*--sh}" != "$_a" ] || \
+                           [ "${_a#*--csh}" != "$_a" ];
+                        then
+                            # just  execute the command if --sh or --csh are provided
+                            command spack env deactivate "$@"
+                        elif [ -n "$*" ]; then
+                            # any other arguments are an error or help, so just run help
+                            command spack env deactivate -h
                         else
-                            # no args: source the output.
+                            # no args: source the output of the command
                             eval $(command spack $_sp_flags env deactivate --sh)
                         fi
                         ;;
                     *)
-                        command spack "${args[@]}"
+                        command spack env $_sp_arg "$@"
                         ;;
                 esac
             fi
@@ -130,8 +140,11 @@ function spack {
             # Shift any other args for use off before parsing spec.
             _sp_subcommand_args=""
             _sp_module_args=""
-            while [[ "$1" =~ ^- ]]; do
-                if [ "$1" = "-r" -o "$1" = "--dependencies" ]; then
+            while [ "${1#-}" != "${1}" ]; do
+                if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+                    command spack $_sp_flags $_sp_subcommand $_sp_subcommand_args "$@"
+                    return
+                elif [ "$1" = "-r" ] || [ "$1" = "--dependencies" ]; then
                     _sp_subcommand_args="$_sp_subcommand_args $1"
                 else
                     _sp_module_args="$_sp_module_args $1"
@@ -139,51 +152,54 @@ function spack {
                 shift
             done
 
-            _sp_spec=("$@")
-
             # Here the user has run use or unuse with a spec.  Find a matching
             # spec using 'spack module find', then use the appropriate module
             # tool's commands to add/remove the result from the environment.
             # If spack module command comes back with an error, do nothing.
             case $_sp_subcommand in
                 "use")
-                    if _sp_full_spec=$(command spack $_sp_flags module dotkit find $_sp_subcommand_args "${_sp_spec[@]}"); then
+                    if _sp_full_spec=$(command spack $_sp_flags module dotkit find $_sp_subcommand_args "$@"); then
                         use $_sp_module_args $_sp_full_spec
                     else
                         $(exit 1)
-                    fi ;;
+                    fi
+                    ;;
                 "unuse")
-                    if _sp_full_spec=$(command spack $_sp_flags module dotkit find $_sp_subcommand_args "${_sp_spec[@]}"); then
+                    if _sp_full_spec=$(command spack $_sp_flags module dotkit find $_sp_subcommand_args "$@"); then
                         unuse $_sp_module_args $_sp_full_spec
                     else
                         $(exit 1)
-                    fi ;;
+                    fi
+                    ;;
                 "load")
-                    if _sp_full_spec=$(command spack $_sp_flags module tcl find $_sp_subcommand_args "${_sp_spec[@]}"); then
+                    if _sp_full_spec=$(command spack $_sp_flags module tcl find $_sp_subcommand_args "$@"); then
                         module load $_sp_module_args $_sp_full_spec
                     else
                         $(exit 1)
-                    fi ;;
+                    fi
+                    ;;
                 "unload")
-                    if _sp_full_spec=$(command spack $_sp_flags module tcl find $_sp_subcommand_args "${_sp_spec[@]}"); then
+                    if _sp_full_spec=$(command spack $_sp_flags module tcl find $_sp_subcommand_args "$@"); then
                         module unload $_sp_module_args $_sp_full_spec
                     else
                         $(exit 1)
-                    fi ;;
+                    fi
+                    ;;
             esac
             ;;
         *)
-            command spack "${args[@]}"
+            command spack $_sp_flags $_sp_subcommand "$@"
             ;;
     esac
 }
+
 
 ########################################################################
 # Prepends directories to path, if they exist.
 #      pathadd /path/to/dir            # add to PATH
 # or   pathadd OTHERPATH /path/to/dir  # add to OTHERPATH
 ########################################################################
-function _spack_pathadd {
+_spack_pathadd() {
     # If no variable name is supplied, just append to PATH
     # otherwise append to that variable.
     _pa_varname=PATH
@@ -196,7 +212,10 @@ function _spack_pathadd {
     # Do the actual prepending here.
     eval "_pa_oldvalue=\${${_pa_varname}:-}"
 
-    if [ -d "$_pa_new_path" ] && [[ ":$_pa_oldvalue:" != *":$_pa_new_path:"* ]]; then
+    _pa_canonical=":$_pa_oldvalue:"
+    if [ -d "$_pa_new_path" ] && \
+       [ "${_pa_canonical#*:${_pa_new_path}:}" = "${_pa_canonical}" ];
+    then
         if [ -n "$_pa_oldvalue" ]; then
             eval "export $_pa_varname=\"$_pa_new_path:$_pa_oldvalue\""
         else
@@ -205,29 +224,11 @@ function _spack_pathadd {
     fi
 }
 
-# Export spack function so it is available in subshells (only works with bash)
-if [ -n "${BASH_VERSION:-}" ]; then
-    export -f spack
-fi
-
-#
-# Figure out where this file is.  Below code needs to be portable to
-# bash and zsh.
-#
-_sp_source_file="${BASH_SOURCE[0]:-}"  # Bash's location of last sourced file.
-if [ -z "$_sp_source_file" ]; then
-    _sp_source_file="${(%):-%N}"       # zsh way to do it
-    if [ -z "$_sp_source_file" ]; then
-        # Not zsh either... bail out with plain old $0,
-        # which WILL NOT work if this is sourced indirectly.
-        _sp_source_file="$0"
-    fi
-fi
 
 #
 # Determine which shell is being used
 #
-function _spack_determine_shell() {
+_spack_determine_shell() {
     # This logic is derived from the cea-hpc/modules profile.sh example at
     # https://github.com/cea-hpc/modules/blob/master/init/profile.sh.in
     #
@@ -241,23 +242,71 @@ function _spack_determine_shell() {
         PS_FORMAT= ps -p $$ | tail -n 1 | awk '{print $4}' | sed 's/^-//' | xargs basename
     fi
 }
-export SPACK_SHELL=$(_spack_determine_shell)
+_sp_shell=$(_spack_determine_shell)
+
+
+# Export spack function so it is available in subshells (only works with bash)
+if [ "$_sp_shell" = bash ]; then
+    export -f spack
+fi
+
+#
+# Figure out where this file is.
+#
+if [ "$_sp_shell" = bash ]; then
+    _sp_source_file="${BASH_SOURCE[0]:-}"
+elif [ "$_sp_shell" = zsh ]; then
+    _sp_source_file="${(%):-%N}"
+else
+    # Try to read the /proc filesystem (works on linux without lsof)
+    # In dash, the sourced file is the last one opened (and it's kept open)
+    _sp_source_file_fd="$(\ls /proc/$$/fd 2>/dev/null | sort -n | tail -1)"
+    if ! _sp_source_file="$(readlink /proc/$$/fd/$_sp_source_file_fd)"; then
+        # Last resort: try lsof. This works in dash on macos -- same reason.
+        # macos has lsof installed by default; some linux containers don't.
+        _sp_lsof_output="$(lsof -p $$ -Fn0 | tail -1)"
+        _sp_source_file="${_sp_lsof_output#*n}"
+    fi
+
+    # If we can't find this script's path after all that, bail out with
+    # plain old $0, which WILL NOT work if this is sourced indirectly.
+    if [ ! -f "$_sp_source_file" ]; then
+        _sp_source_file="$0"
+    fi
+fi
 
 #
 # Find root directory and add bin to path.
 #
 # We send cd output to /dev/null to avoid because a lot of users set up
 # their shell so that cd prints things out to the tty.
-#
 _sp_share_dir="$(cd "$(dirname $_sp_source_file)" > /dev/null && pwd)"
 _sp_prefix="$(cd "$(dirname $(dirname $_sp_share_dir))" > /dev/null && pwd)"
+if [ -x "$_sp_prefix/bin/spack" ]; then
+    export SPACK_ROOT="${_sp_prefix}"
+else
+    # If the shell couldn't find the sourced script, fall back to
+    # whatever the user set SPACK_ROOT to.
+    if [ -n "$SPACK_ROOT" ]; then
+        _sp_prefix="$SPACK_ROOT"
+        _sp_share_dir="$_sp_prefix/share/spack"
+    fi
+
+    # If SPACK_ROOT didn't work, fail.  We should need this rarely, as
+    # the tricks above for finding the sourced file are pretty robust.
+    if [ ! -x "$_sp_prefix/bin/spack" ]; then
+        echo "==> Error: SPACK_ROOT must point to spack's prefix when using $_sp_shell"
+        echo "Run this with the correct prefix before sourcing setup-env.sh:"
+        echo "    export SPACK_ROOT=</path/to/spack>"
+        return 1
+    fi
+fi
 _spack_pathadd PATH "${_sp_prefix%/}/bin"
-export SPACK_ROOT="${_sp_prefix}"
 
 #
 # Check whether a function of the given name is defined
 #
-function _spack_fn_exists() {
+_spack_fn_exists() {
 	LANG= type $1 2>&1 | grep -q 'function'
 }
 
@@ -265,7 +314,6 @@ need_module="no"
 if ! _spack_fn_exists use && ! _spack_fn_exists module; then
 	need_module="yes"
 fi;
-
 
 #
 # make available environment-modules
@@ -284,18 +332,19 @@ if [ "${need_module}" = "yes" ]; then
         fi
         export MODULE_PREFIX_BIN
         _spack_pathadd PATH "${MODULE_PREFIX_BIN}"
-        module() { eval `${MODULE_PREFIX_BIN}/modulecmd ${SPACK_SHELL} $*`; }
+        module() { eval `${MODULE_PREFIX_BIN}/modulecmd ${_sp_shell} $*`; }
     fi;
 else
     eval `spack --print-shell-vars sh`
 fi;
+
 
 #
 # set module system roots
 #
 _sp_multi_pathadd() {
     local IFS=':'
-    if  [[ -n "${ZSH_VERSION:-}" ]]; then
+    if [ "$_sp_shell" = zsh ]; then
         setopt sh_word_split
     fi
     for pth in $2; do
@@ -307,6 +356,6 @@ _sp_multi_pathadd DK_NODE "$_sp_dotkit_roots"
 
 # Add programmable tab completion for Bash
 #
-if [ -n "${BASH_VERSION:-}" ]; then
+if [ "$_sp_shell" = bash ]; then
     source $_sp_share_dir/spack-completion.bash
 fi

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -46,9 +46,12 @@ spack() {
         emulate -L sh
     fi
 
-    # accumulate initial flags for main spack command
+    # accumulate flags meant for the main spack command
+    # the loop condition is unreadable, but it means:
+    #     while $1 is set (while there are arguments)
+    #       and $1 starts with '-' (and the arguments are flags)
     _sp_flags=""
-    while [ "${1#-}" != "${1}" ]; do
+    while [ ! -z ${1+x} ] && [ "${1#-}" != "${1}" ]; do
         _sp_flags="$_sp_flags $1"
         shift
     done
@@ -62,8 +65,9 @@ spack() {
         return
     fi
 
+    # set the subcommand if there is one (if $1 is set)
     _sp_subcommand=""
-    if [ -n "$1" ]; then
+    if [ ! -z ${1+x} ]; then
         _sp_subcommand="$1"
         shift
     fi
@@ -102,7 +106,7 @@ spack() {
                 case $_sp_arg in
                     activate)
                         _a="$@"
-                        if [ -z "$1" ] || \
+                        if [ -z ${1+x} ] || \
                            [ "${_a#*--sh}" != "$_a" ] || \
                            [ "${_a#*--csh}" != "$_a" ] || \
                            [ "${_a#*-h}" != "$_a" ];


### PR DESCRIPTION
On the latest Ubuntu and Debian, and on Arch, the default system shell is `dash`, and there are systems out there that don't have `bash`.  See [Arch](https://wiki.archlinux.org/index.php/Dash) and [Ubuntu](https://wiki.ubuntu.com/DashAsBinSh)'s docs on this.

If you run as Spack in those environments, you get this:

```shell
+ export SPACK_ROOT=/spack
+ . /spack/share/spack/setup-env.sh
+ function spack {
/bin/sh: 59: /spack/share/spack/setup-env.sh: function: not found
ERROR: Aborting with RETVAL=255
```

This PR makes `setup-env.sh` `dash`-compatible 😄 .  And less readable 😞 .  I think it is worthwhile to be `sh`-compatible so that we can be used easily in these more and more popular minimal environments.

- [x] Replaced use of `[[` with `[`
- [x] Replaced `function foo { .. }` with `foo() { .. }`
- [x] Wrapped some long lines
- [x] Add magic so that we can find the sourced file even in `dash` (whoa!)
- [x] Only do the complicated shell checks in one place; test `$_sp_shell` elsewhere.
- [x] Tests