### PR TITLE
Warn the user when external path isn't found.

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -178,6 +178,7 @@ def get_path_from_module(mod):
             path = words[2]
             return path[:path.find('/lib')]
     # Unable to find module path
+    tty.warn("Was unable to the path for module %s" % mod)
     return None
 
 


### PR DESCRIPTION
Helpful for warning if spack can't find where a module is pointing to.