### PR TITLE
fix py-configparser  backports,  see #4154

### DIFF
--- a/var/spack/repos/builtin/packages/py-configparser/backports.patch
+++ b/var/spack/repos/builtin/packages/py-configparser/backports.patch
@@ -1,0 +1,11 @@
+--- a/setup.py	2017-05-06 19:51:03.799210224 +0200
++++ b/setup.py	2017-05-06 17:31:41.076833957 +0200
+@@ -42,7 +42,7 @@
+     py_modules=modules,
+     package_dir={'': 'src'},
+     packages=find_packages('src'),
+-    namespace_packages=['backports'],
++#    namespace_packages=['backports'],
+     include_package_data=True,
+     zip_safe=False,
+     install_requires=requirements,

--- a/var/spack/repos/builtin/packages/py-configparser/package.py
+++ b/var/spack/repos/builtin/packages/py-configparser/package.py
@@ -17,3 +17,5 @@ class PyConfigparser(PythonPackage):
 
     depends_on('py-setuptools', type='build')
     depends_on('py-ordereddict', when='^python@:2.6', type=('build', 'run'))
+
+    patch('backports.patch')


### PR DESCRIPTION
Fixes #4154

py_flake8, installed with spack and loaded as module does not work due to 
error in py-configparser (backport ) 