### PR TITLE
New packages rdma-core and libnl.

### DIFF
--- a/var/spack/repos/builtin/packages/libnl/package.py
+++ b/var/spack/repos/builtin/packages/libnl/package.py
@@ -37,6 +37,8 @@ class Libnl(AutotoolsPackage):
     version('3.2.25', '03f74d0cd5037cadc8cdfa313bbd195c')
 
     depends_on('bison', type='build')
+    depends_on('flex', type='build')
+    depends_on('m4', type='build')
 
     def configure_args(self):
         if not sys.platform.startswith('linux'):

--- a/var/spack/repos/builtin/packages/libnl/package.py
+++ b/var/spack/repos/builtin/packages/libnl/package.py
@@ -1,0 +1,46 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
+from spack import *
+import sys
+
+
+class Libnl(AutotoolsPackage):
+    """libnl - Netlink Protocol Library Suite"""
+
+    homepage = "https://www.infradead.org/~tgr/libnl/"
+    url      = "https://github.com/thom311/libnl/releases/download/libnl3_3_0/libnl-3.3.0.tar.gz"
+
+    version('3.3.0', 'ab3ef137cad95bdda5ff0ffa5175dfa5')
+    version('3.2.25', '03f74d0cd5037cadc8cdfa313bbd195c')
+
+    depends_on('bison', type='build')
+
+    def configure_args(self):
+        if not sys.platform.startswith('linux'):
+            raise InstallError("libnl requires Linux")
+
+        args = []
+        return args

--- a/var/spack/repos/builtin/packages/libnl/package.py
+++ b/var/spack/repos/builtin/packages/libnl/package.py
@@ -40,9 +40,8 @@ class Libnl(AutotoolsPackage):
     depends_on('flex', type='build')
     depends_on('m4', type='build')
 
-    def configure_args(self):
-        if not sys.platform.startswith('linux'):
-            raise InstallError("libnl requires Linux")
-
-        args = []
-        return args
+    @run_before('autoreconf')
+    def check_platform(self):
+        if not (sys.platform.startswith('freebsd') or
+                sys.platform.startswith('linux')):
+            raise InstallError("libnl requires FreeBSD or Linux")

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -200,8 +200,9 @@ class Openmpi(AutotoolsPackage):
             # for Open-MPI 2.0:, C++ bindings are disabled by default.
             config_args.extend(['--enable-mpi-cxx'])
 
-        if '+rdma' in spec and not 'fabrics=verbs' in spec:
-            raise InstallError("variant '+rdma' requires variant 'fabrics=verbs'")
+        if '+rdma' in spec and 'fabrics=verbs' not in spec:
+            raise InstallError(
+                "variant '+rdma' requires variant 'fabrics=verbs'")
 
         # Fabrics and schedulers
         config_args.extend(self.with_or_without('fabrics'))

--- a/var/spack/repos/builtin/packages/rdma-core/package.py
+++ b/var/spack/repos/builtin/packages/rdma-core/package.py
@@ -38,8 +38,6 @@ class RdmaCore(CMakePackage):
     depends_on('libnl')
 
     def cmake_args(self):
-        spec = self.spec
-
         if not sys.platform.startswith('linux'):
             raise InstallError("rdma-core requires Linux")
 

--- a/var/spack/repos/builtin/packages/rdma-core/package.py
+++ b/var/spack/repos/builtin/packages/rdma-core/package.py
@@ -37,9 +37,8 @@ class RdmaCore(CMakePackage):
 
     depends_on('libnl')
 
-    def cmake_args(self):
-        if not sys.platform.startswith('linux'):
-            raise InstallError("rdma-core requires Linux")
-
-        options = []
-        return options
+    @run_before('cmake_args')
+    def check_platform(self):
+        if not (sys.platform.startswith('freebsd') or
+                sys.platform.startswith('linux')):
+            raise InstallError("rdma-core requires FreeBSD or Linux")

--- a/var/spack/repos/builtin/packages/rdma-core/package.py
+++ b/var/spack/repos/builtin/packages/rdma-core/package.py
@@ -37,7 +37,7 @@ class RdmaCore(CMakePackage):
 
     depends_on('libnl')
 
-    @run_before('cmake_args')
+    @run_before('cmake')
     def check_platform(self):
         if not (sys.platform.startswith('freebsd') or
                 sys.platform.startswith('linux')):

--- a/var/spack/repos/builtin/packages/rdma-core/package.py
+++ b/var/spack/repos/builtin/packages/rdma-core/package.py
@@ -1,0 +1,47 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
+from spack import *
+import sys
+
+
+class RdmaCore(CMakePackage):
+    """RDMA core userspace libraries and daemons"""
+
+    homepage = "https://github.com/linux-rdma/rdma-core"
+    url      = "https://github.com/linux-rdma/rdma-core/releases/download/v13/rdma-core-13.tar.gz"
+
+    version('13', '6b072b4307d1cfe45eba4373f68e2927')
+
+    depends_on('libnl')
+
+    def cmake_args(self):
+        spec = self.spec
+
+        if not sys.platform.startswith('linux'):
+            raise InstallError("rdma-core requires Linux")
+
+        options = []
+        return options


### PR DESCRIPTION
Add “rdma” variant to openmpi that uses the Spack-installed rdma-core library for ibverbs.