### PR TITLE
[WIP] Add pcl package and friends, first attempt.

### DIFF
--- a/var/spack/repos/builtin/packages/libnl/package.py
+++ b/var/spack/repos/builtin/packages/libnl/package.py
@@ -26,8 +26,7 @@ from spack import *
 
 
 class Libnl(AutotoolsPackage):
-    """
-    The libnl suite is a collection of libraries providing APIs to netlink
+    """The libnl suite is a collection of libraries providing APIs to netlink
     protocol based Linux kernel interfaces.
 
     Netlink is a IPC mechanism primarly between the kernel and user space

--- a/var/spack/repos/builtin/packages/libnl/package.py
+++ b/var/spack/repos/builtin/packages/libnl/package.py
@@ -1,0 +1,49 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Libnl(AutotoolsPackage):
+    """
+    The libnl suite is a collection of libraries providing APIs to netlink
+    protocol based Linux kernel interfaces.
+
+    Netlink is a IPC mechanism primarly between the kernel and user space
+    processes. It was designed to be a more flexible successor to ioctl to
+    provide mainly networking related kernel configuration and monitoring
+    interfaces.
+    """
+
+    homepage = "https://www.infradead.org/~tgr/libnl/"
+    url      = "https://www.infradead.org/~tgr/libnl/files/libnl-3.2.25.tar.gz"
+
+    version('3.2.25', '03f74d0cd5037cadc8cdfa313bbd195c')
+
+    depends_on("flex",  type="build")
+    depends_on("m4",    type="build")
+    depends_on("bison", type="build")
+
+    # NOTE: there is something in the configure about pthreads, but
+    #       I do not understand the `spack` + `pthreads` relationship.

--- a/var/spack/repos/builtin/packages/libpcap/package.py
+++ b/var/spack/repos/builtin/packages/libpcap/package.py
@@ -26,8 +26,7 @@ from spack import *
 
 
 class Libpcap(AutotoolsPackage):
-    """
-    The Packet Capture library provides a high level interface to packet
+    """The Packet Capture library provides a high level interface to packet
     capture systems. All packets on the network, even those destined for
     other hosts, are accessible through this mechanism. It also supports
     saving captured packets to a ``savefile'', and reading packets from

--- a/var/spack/repos/builtin/packages/libpcap/package.py
+++ b/var/spack/repos/builtin/packages/libpcap/package.py
@@ -36,11 +36,11 @@ class Libpcap(AutotoolsPackage):
     system, the "packet" protocol must be supported by your kernel.  If it
     is not, you may get error messages such as
 
-        modprobe: can't locate module net-pf-17
+    ``modprobe: can't locate module net-pf-17``
 
     in "/var/adm/messages", or may get messages such as
 
-        socket: Address family not supported by protocol
+    ``socket: Address family not supported by protocol``
 
     from applications using libpcap.
 

--- a/var/spack/repos/builtin/packages/libpcap/package.py
+++ b/var/spack/repos/builtin/packages/libpcap/package.py
@@ -50,16 +50,9 @@ class Libpcap(AutotoolsPackage):
     """
 
     homepage = "http://www.tcpdump.org/"
-    url      = "https://github.com/the-tcpdump-group/libpcap/archive/libpcap-1.8.1.tar.gz"
+    url      = "http://www.tcpdump.org/release/libpcap-1.8.1.tar.gz"
 
-    version('1.8.1',    '4a70f59c943b21340deca4affe63ea4c')
-    version('1.8.0',    '443376a3b78dfa32dc16264010d8a3c6')
-    version('1.7.4',    '323e59a1a4921a77b7418ced385e59f5')
-    version('1.7.3',    '21627825ae185c3ab374cf71b54462a0')
-    version('1.7.2',    '19e0f562a7bd9b6f9283d323c49b5b75')
-    version('1.7.0',    '7aec0ed3fb273d7634b23668c343291a')
-    version('1.6.2',    '259a4b4ead24d03c3c2a22240460e240')
-    version('1.6.1',    '8e3691f5a58c6255e0414192c05b89f2')
+    version('1.8.1',    '3d48f9cd171ff12b0efd9134b52f1447')
 
     variant("libnl", default=True,
             description="libpcap states a strong preference to using libnl.")

--- a/var/spack/repos/builtin/packages/libpcap/package.py
+++ b/var/spack/repos/builtin/packages/libpcap/package.py
@@ -1,0 +1,88 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Libpcap(AutotoolsPackage):
+    """
+    The Packet Capture library provides a high level interface to packet
+    capture systems. All packets on the network, even those destined for
+    other hosts, are accessible through this mechanism. It also supports
+    saving captured packets to a ``savefile'', and reading packets from
+    a ``savefile''.
+
+    WARNING: In order for libpcap to be able to capture packets on a Linux
+    system, the "packet" protocol must be supported by your kernel.  If it
+    is not, you may get error messages such as
+
+        modprobe: can't locate module net-pf-17
+
+    in "/var/adm/messages", or may get messages such as
+
+        socket: Address family not supported by protocol
+
+    from applications using libpcap.
+
+    The above was taken from README.linux from the main repository homepage,
+    refer to the README for your operating system for more information.
+    """
+
+    homepage = "http://www.tcpdump.org/"
+    url      = "https://github.com/the-tcpdump-group/libpcap/archive/libpcap-1.8.1.tar.gz"
+
+    version('1.8.1',    '4a70f59c943b21340deca4affe63ea4c')
+    version('1.8.0',    '443376a3b78dfa32dc16264010d8a3c6')
+    version('1.7.4',    '323e59a1a4921a77b7418ced385e59f5')
+    version('1.7.3',    '21627825ae185c3ab374cf71b54462a0')
+    version('1.7.2',    '19e0f562a7bd9b6f9283d323c49b5b75')
+    version('1.7.0',    '7aec0ed3fb273d7634b23668c343291a')
+    version('1.6.2',    '259a4b4ead24d03c3c2a22240460e240')
+    version('1.6.1',    '8e3691f5a58c6255e0414192c05b89f2')
+
+    variant("libnl", default=True,
+            description="libpcap states a strong preference to using libnl.")
+
+    # Unsure of deps, link flag for libnl3, hard version 3.2.25 only because
+    # it is the first version packaged.
+    depends_on("libnl@3.2.25:", when="+libnl", type=("build", "link", "run"))
+
+    depends_on("flex",  type="build")
+    depends_on("m4",    type="build")
+    depends_on("bison", type="build")
+    depends_on("pkg-config", type="build")
+
+    def configure_args(self):
+        args = []
+        spec = self.spec
+        if "+libnl" in spec:
+            args.extend([
+                'CFLAGS=-I{0}'.format(spec["libnl"].prefix.include),
+                'LDFLAGS=-L{0}'.format(spec["libnl"].prefix.lib),
+                'LIBS=-lnl-3'
+            ])
+        else:
+            args.append("--without-libnl")
+
+        return args

--- a/var/spack/repos/builtin/packages/libusb/package.py
+++ b/var/spack/repos/builtin/packages/libusb/package.py
@@ -1,0 +1,75 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install libusb
+#
+# You can edit this file again by typing:
+#
+#     spack edit libusb
+#
+# See the Spack documentation for more information on packaging.
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+from spack import *
+
+
+class Libusb(AutotoolsPackage):
+    """
+    libusb is a C library that provides generic access to USB devices. It is
+    intended to be used by developers to facilitate the production of
+    applications that communicate with USB hardware.
+
+    It is portable: Using a single cross-platform API, it provides access to
+    USB devices on Linux, OS X, Windows, Android, OpenBSD, etc.
+
+    It is user-mode: No special privilege or elevation is required for the
+    application to communicate with a device.
+
+    It is version-agnostic: All versions of the USB protocol, from 1.0 to 3.1
+    (latest), are supported.
+    """
+
+    homepage = "http://libusb.info/"
+    url      = "https://github.com/libusb/libusb/releases/download/v1.0.21/libusb-1.0.21.tar.bz2"
+
+    version('1.0.21', '1da9ea3c27b3858fa85c5f4466003e44')
+    version('1.0.20', '1d4eb194eaaa2bcfbba28102768c7dbf')
+
+    # NOTE: this package probably works on all Linux, likely OSX
+    #       *as-is*.  There are far too many options for me to understand.
+    #
+    #       The package likely does not work on Windows.  If you need that
+    #       refer to WIN_INSTALL on their GitHub page.
+
+    # NOTE: this package *RELIES* on libudev, which requires the systemd PR
+    #       to be fixed.  So as it stands, users must ensure that they have
+    #       libudev headers and library.  On Fedora, this was available via
+    #       dnf install systemd systemd-devel systemd-libs
+    #       the apt repos should be similarly named (apt-cache search systemd)

--- a/var/spack/repos/builtin/packages/libusb/package.py
+++ b/var/spack/repos/builtin/packages/libusb/package.py
@@ -26,9 +26,8 @@ from spack import *
 
 
 class Libusb(AutotoolsPackage):
-    """
-    libusb is a C library that provides generic access to USB devices. It is
-    intended to be used by developers to facilitate the production of
+    """libusb is a C library that provides generic access to USB devices. It
+    is intended to be used by developers to facilitate the production of
     applications that communicate with USB hardware.
 
     It is portable: Using a single cross-platform API, it provides access to

--- a/var/spack/repos/builtin/packages/libusb/package.py
+++ b/var/spack/repos/builtin/packages/libusb/package.py
@@ -22,21 +22,6 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install libusb
-#
-# You can edit this file again by typing:
-#
-#     spack edit libusb
-#
-# See the Spack documentation for more information on packaging.
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
 from spack import *
 
 

--- a/var/spack/repos/builtin/packages/libusb/package.py
+++ b/var/spack/repos/builtin/packages/libusb/package.py
@@ -41,10 +41,11 @@ class Libusb(AutotoolsPackage):
     """
 
     homepage = "http://libusb.info/"
-    url      = "https://github.com/libusb/libusb/releases/download/v1.0.21/libusb-1.0.21.tar.bz2"
+    url      = "https://downloads.sourceforge.net/project/libusb/libusb-1.0/libusb-1.0.21/libusb-1.0.21.tar.bz2"
 
     version('1.0.21', '1da9ea3c27b3858fa85c5f4466003e44')
-    version('1.0.20', '1d4eb194eaaa2bcfbba28102768c7dbf')
+
+    depends_on("m4", type="build")
 
     # NOTE: this package probably works on all Linux, likely OSX
     #       *as-is*.  There are far too many options for me to understand.

--- a/var/spack/repos/builtin/packages/pcl/package.py
+++ b/var/spack/repos/builtin/packages/pcl/package.py
@@ -1,0 +1,159 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Pcl(CMakePackage):
+    """
+    The Point Cloud Library (PCL) is a standalone, large scale, open
+    project for 2D/3D image and point cloud processing.
+    """
+
+    homepage = "http://www.pointclouds.org/"
+    url      = "https://github.com/PointCloudLibrary/pcl/archive/pcl-1.8.0.tar.gz"
+
+    version('1.8.0',      '8c1308be2c13106e237e4a4204a32cca')
+    version('1.7.2',      '02c72eb6760fcb1f2e359ad8871b9968')
+    version('1.7.1',      'ce8fa17662544eb4bb7b084191a61ad5')
+    version('1.7.0',      'e2ac2d2e72825d991c6d194f9586b5d8')
+
+    variant("usb",    default=False,
+            description="Build USB RGBD-Camera drivers.")
+    variant("png",    default=True,
+            description="PNG file support.")
+    variant("qhull",  default=True,
+            description="Include convex-hull operations.")
+    variant("cuda",   default=False,
+            description="Build NVIDIA-CUDA support.")
+    variant("qt",     default=False,
+            description="Build QT Front-End. Qt4 or Qt5 required.")
+    variant("vtk",    default=False,
+            description="Build VTK-Visualizations.")
+    variant("opengl", default=False,
+            description="Support for OpenGL.")
+    variant("pcap",   default=False,
+            description="pcap file capabilities in Velodyne HDL driver.")
+
+    conflicts("~opengl", when="+qt")
+    conflicts("~opengl", when="+vtk")
+    conflicts("~qt",     when="+vtk")  # vtk depends on qt, use it
+    conflicts("~opengl", when="+cuda")
+
+    # Dependencies as discerned from here:
+    # http://pointclouds.org/documentation/tutorials/compiling_pcl_posix.php
+    depends_on('pkg-config')
+    # TODO: how to give boost version AND specific boost library
+    # requirements? What should they be / variants can't embed optional
+    # boost deps right?
+    #
+    # REQUIRED boost:
+    #     If OpenNI2: +system+filesystem+thread+date_time+iostreams+chrono
+    #     Else:       +system+filesystem+thread+date_time+iostreams
+    # OPTIONAL boost:
+    #     +serialization+mpi
+    #
+    # Reference:
+    #
+    depends_on('boost@1.47.0:')
+    depends_on('eigen@3.0.0:')
+    depends_on('flann@1.7.0:')
+
+    depends_on("metis")   # unmentioned, they vendor in 3rd party if not found.
+
+    # TODO:
+    # What to do about python?  It depends on opencv+python, but they are
+    # some kind of extension, and install underneath opencv?
+    # https://github.com/PointCloudLibrary/pcl/blob/6f846d242b07b7b2d5a562bbc60b3b488bbf6a47/cmake/pcl_find_python.cmake
+    # There is also a python-pcl package they maintain?
+    # http://pointclouds.org/news/tags/python
+
+    depends_on("libusb",  when="+usb")
+    depends_on("libpng",  when="+png")
+    depends_on("qhull",   when="+qhull")
+    depends_on("cuda",    when="+cuda")
+    depends_on("qt@4:",   when="+qt")
+    depends_on("vtk",     when="+vtk")
+    depends_on("libpcap", when="+pcap")
+
+    # TODO: should something be done with the default options?
+    # https://github.com/PointCloudLibrary/pcl/blob/master/cmake/pcl_options.cmake
+
+    # TODO: spack will never be suited to nor should attempt to be suited
+    # to install RGBD camera drivers.  How should spack inform users to
+    # be sure that they are going to get what they want?
+    #
+    # The drivers require elevated permissions, and most often custom
+    # modules and startup scripts.  The user is advised to try and
+    # install from the official SDK or their system package manager
+    # where possible.
+    #
+    # NOTE: libusb support REQUIRED for ANY to be used.
+    #
+    # Currently, the available driver support that can be built:
+    # https://github.com/PointCloudLibrary/pcl/blob/b9022ebd8ad5f5300662069b5f79995d0c0e18be/CMakeLists.txt#L296-L303
+    #
+    # The way it works is that everything is default to TRUE, the library
+    # is attempted to be found, and if not ignored.
+    #
+    # It takes place here:
+    # https://github.com/PointCloudLibrary/pcl/blob/b89b32b5e812353e93a5c35203c70b878c8ae2b7/cmake/pcl_targets.cmake#L842-L864
+
+    def cmake_args(self):
+        args = []
+        spec = self.spec
+
+        usb_support = "ON" if "+usb" in spec else "OFF"
+        args.append("-DWITH_LIBUSB:BOOL={0}".format(usb_support))
+
+        png_support = "ON" if "+png" in spec else "OFF"
+        args.append("-DWITH_PNG:BOOL={0}".format(png_support))
+
+        with_qhull = "ON" if "+qhull" in spec else "OFF"
+        args.append("-DWITH_QHULL:BOOL={0}".format(with_qhull))
+
+        with_cuda = "ON" if "+cuda" in spec else "OFF"
+        args.append("-DWITH_CUDA:BOOL={0}".format(with_cuda))
+
+        using_qt = "+qt" in spec
+        with_qt = "ON" if using_qt else "OFF"
+        args.append("-DWITH_QT:BOOL={0}".format(with_qt))
+        if using_qt:
+            # TODO: how do i check this?
+            if self.spec.satisfies("^qt@4.8.6"):
+                qt_ver_str = "4"
+            else:
+                qt_ver_str = "5"
+            args.append("-DPCL_QT_VERSION:STRING={0}".format(qt_ver_str))
+
+        with_vtk = "ON" if "+vtk" in spec else "OFF"
+        args.append("-DWITH_VTK:BOOL={0}".format(with_vtk))
+
+        with_pcap = "ON" if "+pcap" in spec else "OFF"
+        args.append("-DWITH_PCAP:BOOL={0}".format(with_pcap))
+
+        with_opengl = "ON" if "+opengl" in spec else "OFF"
+        args.append("-DWITH_OPENGL:BOOL={0}".format(with_opengl))
+
+        return args

--- a/var/spack/repos/builtin/packages/pcl/package.py
+++ b/var/spack/repos/builtin/packages/pcl/package.py
@@ -26,8 +26,7 @@ from spack import *
 
 
 class Pcl(CMakePackage):
-    """
-    The Point Cloud Library (PCL) is a standalone, large scale, open
+    """The Point Cloud Library (PCL) is a standalone, large scale, open
     project for 2D/3D image and point cloud processing.
     """
 


### PR DESCRIPTION
#### flann dependency

- [x] `depends_on('flann')`, merge _after_ #3966

#### libnl dependency

- [ ] merge after #4168

#### libpcap dependency

- [ ] `libpcap` likes `libnl`, keep that as default to true.
- [x] will update the url away from github release in next commit

#### libusb dependency

- [ ] Note 1 at bottom: should raise error if on Windows?  I have no idea if it works or not

  ```
  # NOTE: this package probably works on all Linux, likely OSX
  #       *as-is*.  There are far too many options for me to understand.
  #
  #       The package likely does not work on Windows.  If you need that
  #       refer to WIN_INSTALL on their GitHub page.
  ```

- [ ] Note 2 at bottom: `libudev` is too hard to install -- users should be using system package manager to make sure they get it right / `spack` cannot install necessary files (requires elevated permission)

  ```
  # NOTE: this package *RELIES* on libudev, which requires the systemd PR
  #       to be fixed.  So as it stands, users must ensure that they have
  #       libudev headers and library.  On Fedora, this was available via
  #       dnf install systemd systemd-devel systemd-libs
  #       the apt repos should be similarly named (apt-cache search systemd)
  ```

- [x] How do I do a sourceforge url for the official "latest stable tarball"?
- [x] will delete FIXME in next commit with url from 3

#### pcl package: the real goal here

- [ ] What should default `boost` be.  Depends on if we assume OpenNI2 installed.

  ```
  # TODO: how to give boost version AND specific boost library
  # requirements? What should they be / variants can't embed optional
  # boost deps right?
  #
  # REQUIRED boost:
  #     If OpenNI2: +system+filesystem+thread+date_time+iostreams+chrono
  #     Else:       +system+filesystem+thread+date_time+iostreams
  # OPTIONAL boost:
  #     +serialization+mpi
  ```

- [ ] Python treatment, should it depend on `opencv+python` or should we use the `py-pcl`?

  ```
  # TODO:
  # What to do about python?  It depends on opencv+python, but they are
  # some kind of extension, and install underneath opencv?
  # https://github.com/PointCloudLibrary/pcl/blob/6f846d242b07b7b2d5a562bbc60b3b488bbf6a47/cmake/pcl_find_python.cmake
  # There is also a python-pcl package they maintain?
  # http://pointclouds.org/news/tags/python
  ```

- [ ] Are the defaults acceptable or should they be made explicit (even if same as current defaults)?

  ```
  # TODO: should something be done with the default options?
  # https://github.com/PointCloudLibrary/pcl/blob/master/cmake/pcl_options.cmake
  ```

- [ ] Assume depth camera support?  Only builds if available.  But won't be used if we don't default `libusb`

  ```
  # TODO: spack will never be suited to nor should attempt to be suited
  # to install RGBD camera drivers.  How should spack inform users to
  # be sure that they are going to get what they want?
  #
  # The drivers require elevated permissions, and most often custom
  # modules and startup scripts.  The user is advised to try and
  # install from the official SDK or their system package manager
  # where possible.
  ```

    - AKA if we assume yes, it doesn't hurt, but we should maybe make `libusb` a full-blown requirement?

      ```
      # NOTE: libusb support REQUIRED for ANY to be used.
      #
      # Currently, the available driver support that can be built:
      # https://github.com/PointCloudLibrary/pcl/blob/b9022ebd8ad5f5300662069b5f79995d0c0e18be/CMakeLists.txt#L296-L303
      #
      # The way it works is that everything is default to TRUE, the library
      # is attempted to be found, and if not ignored.
      #
      # It takes place here:
      # https://github.com/PointCloudLibrary/pcl/blob/b89b32b5e812353e93a5c35203c70b878c8ae2b7/cmake/pcl_targets.cmake#L842-L864
      ```

- [ ] How do I get the right version number from `qt` correctly?

  ```
  # TODO: how do i check this?
  if self.spec.satisfies("^qt@4.8.6"):
      qt_ver_str = "4"
  else:
      qt_ver_str = "5"
  args.append("-DPCL_QT_VERSION:STRING={0}".format(qt_ver_str))
  ```

- [ ] Choose appropriate defaults for GUI libraries (off right?): `opengl`, `qt`, and `vtk` for `pcl`.
- [ ] Choose appropriate defaults for camera support.
    - See `libusb` note above.  `+usb` shouldn't be hard to compile portably (clusters etc)
    - If we don't force `libusb` in and people _are_ trying to use it for camera support (very likely), they will not actually get it unless `usb` on.
    - Basically: create some form of bolded warning, or force it as a hard dependency.
- GitHub releases are the official releases, not mirrors.