### PR TITLE
Add the ability to separate architecture in path scheme

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -22,6 +22,9 @@ config:
   template_dirs:
     - $spack/templates
 
+  # default directory layout
+  directory_layout: "${ARCHITECTURE}/${COMPILERNAME}-${COMPILERVER}/${PACKAGE}-${VERSION}-${HASH}"
+
   # Locations where different types of modules should be installed.
   module_roots:
     tcl:    $spack/share/spack/modules

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3077,7 +3077,7 @@ class Spec(object):
                 escape = True
                 if i == length - 1:
                     raise ValueError("Error: unterminated $ in format: '%s'"
-                    % format_string)
+                            % format_string)
             else:
                 out.write(c)
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3042,6 +3042,10 @@ class Spec(object):
                             '='
                         )
                         write(fmt % str(self.architecture), ' arch=')
+                elif named_str == "PLATFORM":
+                    if self.architecture and str(self.architecture):
+                        write(fmt % str(self.architecture.platform),
+                              'platform=')
                 elif named_str == "TARGET":
                     if self.architecture and str(self.architecture):
                         write(fmt % str(self.architecture.target), 'target=')

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2878,6 +2878,9 @@ class Spec(object):
             ${COMPILERFLAGS} Compiler flags
             ${OPTIONS}       Options
             ${ARCHITECTURE}  Architecture
+            ${PLATFORM}      Platform
+            ${OS}            Operating System
+            ${TARGET}        Target
             ${SHA1}          Dependencies 8-char sha1 prefix
             ${HASH:len}      DAG hash with optional length specifier
 
@@ -3035,23 +3038,22 @@ class Spec(object):
                 elif named_str == 'OPTIONS':
                     if self.variants:
                         write(fmt % token_transform(str(self.variants)), '+')
-                elif named_str == 'ARCHITECTURE':
+                elif named_str in ["ARCHITECTURE", "PLATFORM", "TARGET"]:
                     if self.architecture and str(self.architecture):
-                        write(
-                            fmt % token_transform(str(self.architecture)),
-                            '='
-                        )
-                        write(fmt % str(self.architecture), ' arch=')
-                elif named_str == "PLATFORM":
-                    if self.architecture and str(self.architecture):
-                        write(fmt % str(self.architecture.platform),
-                              'platform=')
-                elif named_str == "TARGET":
-                    if self.architecture and str(self.architecture):
-                        write(fmt % str(self.architecture.target), 'target=')
-                elif named_str == "OS":
-                    if self.architecture and str(self.architecture):
-                        write(fmt % str(self.architecture.platform_os), 'os=')
+                        if named_str == "ARCHITECTURE":
+                            write(
+                                fmt % token_transform(str(self.architecture)),
+                                '='
+                            )
+                        elif named_str == "PLATFORM":
+                            platform = str(self.architecture.target)
+                            write(fmt % token_transform(platform), '=')
+                        elif named_str == "OS":
+                            operating_sys = str(self.architecture.platform_os)
+                            write(fmt % token_transform(operating_sys), '=')
+                        elif named_str == "TARGET":
+                            target = str(self.architecture.target)
+                            write(fmt % token_transform(target), '=')
                 elif named_str == 'SHA1':
                     if self.dependencies:
                         out.write(fmt % token_transform(str(self.dag_hash(7))))
@@ -3075,7 +3077,7 @@ class Spec(object):
                 escape = True
                 if i == length - 1:
                     raise ValueError("Error: unterminated $ in format: '%s'"
-                                     % format_string)
+                    % format_string)
             else:
                 out.write(c)
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3038,7 +3038,7 @@ class Spec(object):
                 elif named_str == 'OPTIONS':
                     if self.variants:
                         write(fmt % token_transform(str(self.variants)), '+')
-                elif named_str in ["ARCHITECTURE", "PLATFORM", "TARGET"]:
+                elif named_str in ["ARCHITECTURE", "PLATFORM", "TARGET", "OS"]:
                     if self.architecture and str(self.architecture):
                         if named_str == "ARCHITECTURE":
                             write(
@@ -3046,7 +3046,7 @@ class Spec(object):
                                 '='
                             )
                         elif named_str == "PLATFORM":
-                            platform = str(self.architecture.target)
+                            platform = str(self.architecture.platform)
                             write(fmt % token_transform(platform), '=')
                         elif named_str == "OS":
                             operating_sys = str(self.architecture.platform_os)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3041,6 +3041,13 @@ class Spec(object):
                             fmt % token_transform(str(self.architecture)),
                             '='
                         )
+                        write(fmt % str(self.architecture), ' arch=')
+                elif named_str == "TARGET":
+                    if self.architecture and str(self.architecture):
+                        write(fmt % str(self.architecture.target), 'target=')
+                elif named_str == "OS":
+                    if self.architecture and str(self.architecture):
+                        write(fmt % str(self.architecture.platform_os), 'os=')
                 elif named_str == 'SHA1':
                     if self.dependencies:
                         out.write(fmt % token_transform(str(self.dag_hash(7))))

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3077,7 +3077,7 @@ class Spec(object):
                 escape = True
                 if i == length - 1:
                     raise ValueError("Error: unterminated $ in format: '%s'"
-                            % format_string)
+                                     % format_string)
             else:
                 out.write(c)
 

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -85,8 +85,7 @@ def test_yaml_directory_layout_parameters(
     layout_arch_package = YamlDirectoryLayout(str(tmpdir),
                                               path_scheme=arch_scheme_package)
     arch_path_package = layout_arch_package.relative_path_for_spec(spec)
-    assert(arch_path_package ==
-            spec.format(arch_scheme_package))
+    assert(arch_path_package == spec.format(arch_scheme_package))
 
     # Ensure conflicting parameters caught
     with pytest.raises(InvalidDirectoryLayoutParametersError):

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -45,6 +45,7 @@ def layout_and_dir(tmpdir):
     """Returns a directory layout and the corresponding directory."""
     yield YamlDirectoryLayout(str(tmpdir)), str(tmpdir)
 
+
 def test_yaml_directory_layout_parameters(
         tmpdir, config
 ):
@@ -80,19 +81,19 @@ def test_yaml_directory_layout_parameters(
     assert(package7 == path_package7)
 
     # Test separation of architecture
-    arch_scheme_package = "${PLATFORM}/${TARGET}/${OS}/${PACKAGE}/${VERSION}/${HASH:7}"   #NOQA: ignore=E501
+    arch_scheme_package = "${PLATFORM}/${TARGET}/${OS}/${PACKAGE}/${VERSION}/${HASH:7}"   # NOQA: ignore=E501
     layout_arch_package = YamlDirectoryLayout(str(tmpdir),
-                                               path_scheme=arch_scheme_package)
+                                              path_scheme=arch_scheme_package)
     arch_path_package = layout_arch_package.relative_path_for_spec(spec)
     assert(arch_path_package ==
             spec.format(arch_scheme_package))
-
 
     # Ensure conflicting parameters caught
     with pytest.raises(InvalidDirectoryLayoutParametersError):
         YamlDirectoryLayout(str(tmpdir),
                             hash_len=20,
                             path_scheme=scheme_package7)
+
 
 def test_read_and_write_spec(
         layout_and_dir, config, builtin_mock

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -80,8 +80,7 @@ def test_yaml_directory_layout_parameters(
     assert(package7 == path_package7)
 
     # Test separation of architecture
-    platform, os, target = arch.split("-")
-    arch_scheme_package = "${TARGET}/${OS}/${PACKAGE}/${VERSION}/${HASH:7}"
+    arch_scheme_package = "${PLATFORM}/${TARGET}/${OS}/${PACKAGE}/${VERSION}/${HASH:7}"   #NOQA: ignore=E501
     layout_arch_package = YamlDirectoryLayout(str(tmpdir),
                                                path_scheme=arch_scheme_package)
     arch_path_package = layout_arch_package.relative_path_for_spec(spec)

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -45,7 +45,6 @@ def layout_and_dir(tmpdir):
     """Returns a directory layout and the corresponding directory."""
     yield YamlDirectoryLayout(str(tmpdir)), str(tmpdir)
 
-
 def test_yaml_directory_layout_parameters(
         tmpdir, config
 ):
@@ -74,19 +73,27 @@ def test_yaml_directory_layout_parameters(
     # Test path_scheme
     arch, compiler, package7 = path_7.split('/')
     scheme_package7 = "${PACKAGE}-${VERSION}-${HASH:7}"
-
     layout_package7 = YamlDirectoryLayout(str(tmpdir),
                                           path_scheme=scheme_package7)
     path_package7 = layout_package7.relative_path_for_spec(spec)
 
     assert(package7 == path_package7)
 
+    # Test separation of architecture
+    platform, os, target = arch.split("-")
+    arch_scheme_package = "${TARGET}/${OS}/${PACKAGE}/${VERSION}/${HASH:7}"
+    layout_arch_package = YamlDirectoryLayout(str(tmpdir),
+                                               path_scheme=arch_scheme_package)
+    arch_path_package = layout_arch_package.relative_path_for_spec(spec)
+    assert(arch_path_package ==
+            spec.format(arch_scheme_package))
+
+
     # Ensure conflicting parameters caught
     with pytest.raises(InvalidDirectoryLayoutParametersError):
         YamlDirectoryLayout(str(tmpdir),
                             hash_len=20,
                             path_scheme=scheme_package7)
-
 
 def test_read_and_write_spec(
         layout_and_dir, config, builtin_mock

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -720,3 +720,45 @@ class TestSpecSematics(object):
 
         with pytest.raises(ValueError):
             Spec('libelf foo')
+
+    def test_spec_formatting(self):
+        spec = Spec("libelf cflags=-O2")
+        spec.concretize()
+
+        # Since the default is the full spec see if the string rep of
+        # spec is the same as the output of spec.format()
+        # ignoring whitespace (though should we?)
+        assert str(spec) == spec.format().strip()
+
+        # Testing named strings ie ${STRING} and whether we get
+        # the correct component
+        package_segments = [("${PACKAGE}", "name"),
+                            ("${VERSION}", "versions"),
+                            ("${COMPILER}", "compiler"),
+                            ("${COMPILERFLAGS}", "compiler_flags"),
+                            ("${OPTIONS}", "variants"),
+                            ("${ARCHITECTURE}", "architecture")]
+
+        compiler_segments = [("${COMPILERNAME}", "name"),
+                             ("${COMPILERVER}", "versions")]
+
+        architecture_segments = [("${PLATFORM}", "platform"),
+                                 ("${OS}", "platform_os"),
+                                 ("${TARGET}", "target")]
+
+        for  named_str, prop in package_segments:
+            expected = getattr(spec, prop, "")
+            actual = spec.format(named_str)
+            assert str(expected) == actual
+
+        compiler = spec.compiler
+        for named_str, prop in compiler_segments:
+            expected = getattr(compiler, prop, "")
+            actual = spec.format(named_str)
+            assert str(expected) == actual
+
+        arch = spec.architecture
+        for named_str, prop in architecture_segments:
+            expected = getattr(arch, prop, "")
+            actual = spec.format(named_str)
+            assert str(expected) == actual

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -746,7 +746,7 @@ class TestSpecSematics(object):
                                  ("${OS}", "platform_os"),
                                  ("${TARGET}", "target")]
 
-        for  named_str, prop in package_segments:
+        for named_str, prop in package_segments:
             expected = getattr(spec, prop, "")
             actual = spec.format(named_str)
             assert str(expected) == actual


### PR DESCRIPTION
I think this is a nice change to have. You can create directories separated based off of operating system, target and platform. Helpful for HPC support teams and certainly helpful to NERSC.