### PR TITLE
Allow types and 'any' in variant definitions.

### DIFF
--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -67,11 +67,26 @@ class Variant(object):
         self.default = default
         self.description = str(description)
 
+        self.values = None
+        if values is any:
+            # 'any' is a special case to make it easy to say any value is ok
+            self.single_value_validator = lambda x: True
+
+        elif isinstance(values, type):
+            # supplying a type means any value *of that type*
+            def isa_type(v):
+                try:
+                    values(v)
+                    return True
+                except ValueError:
+                    return False
+            self.single_value_validator = isa_type
+
         if callable(values):
             # If 'values' is a callable, assume it is a single value
             # validator and reset the values to be explicit during debug
             self.single_value_validator = values
-            self.values = None
+
         else:
             # Otherwise assume values is the set of allowed explicit values
             self.values = tuple(values)
@@ -114,7 +129,7 @@ class Variant(object):
 
         # Check and record the values that are not allowed
         not_allowed_values = [
-            x for x in value if not self.single_value_validator(x)
+            x for x in value if self.single_value_validator(x) is False
         ]
         if not_allowed_values:
             raise InvalidVariantValueError(self, not_allowed_values, pkg)


### PR DESCRIPTION
- Previously variant values had to be a tuple or a callable predicate.

- This allows 'any' as shorthand for `lambda x: True` and type objects
  as shorthand for "any value of this type", e.g.:

```python
variant('some_value', values=any, description='anything at all')
variant('a_number', values=int, description='any integer')
```

- Makes variant definitions more readable, keeps lambdas out of
  packages for common cases.

@alalazo: do you think you'll have time to do multi-value variant documentation?