### PR TITLE
install specs to external prefix

### DIFF
--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -723,6 +723,43 @@ used on Cray machines, see :ref:`cray-support`
 
 .. _sec-virtual-dependencies:
 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Installation to an external prefix
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Spack installs packages to a location determined by the spec.
+
+.. code-block:: console
+
+    $SPACK_ROOT/opt/spack/<architecture>/<compiler>-<compilerversion>/<name>-<version>-<hash>
+
+Spack has a variety of convenience functions used to manage these
+installations, from the ``spack find`` command to see installed
+packages to the ``spack load`` command which sets the environment to
+use an installed package.
+
+It is also possible to specify an external prefix to which Spack will
+install a package. The syntax is similar to an architecture or a
+non-boolean variant.
+
+.. code-block:: console
+
+    $ spack install mpileaks prefix=/path/to/install %intel
+
+If the package is already installed, Spack will not install it to a
+new prefix. If another package is installed to the prefix specified,
+Spack will exit with an error and print a message pointing out the
+package that is installed in that prefix.
+
+.. warning::
+    Spack contains substantial logic to prevent package
+      installations from interfering with one another. Overriding the
+      installation prefix limits the efficacy of this logic. Only
+      override the installation prefix if you are prepared to ensure for
+      yourself that all packages (in all combinatorial versions) are
+      installed to unique prefixes. Overriding the installation prefix
+      is not recommended unless necessary.
+
 --------------------
 Virtual dependencies
 --------------------

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -755,7 +755,7 @@ class Database(object):
 
         if len(results) > 1:
             raise CorruptDatabaseError("Multiple specs installed "
-                                       "to prefix {}".format(path))
+                                       "to prefix {0}".format(path))
 
         return results[0] if results else None
 

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -759,7 +759,6 @@ class Database(object):
 
         return results[0] if results else None
 
-
     def query(self, query_spec=any, known=any, installed=True, explicit=any):
         """Run a query on the database.
 

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -123,6 +123,9 @@ class DirectoryLayout(object):
         """Return absolute path from the root to a directory for the spec."""
         _check_concrete(spec)
 
+        if hasattr(spec, '_prefix') and spec._prefix:
+            return spec._prefix
+
         path = self.relative_path_for_spec(spec)
         assert(not path.startswith(self.root))
         return os.path.join(self.root, path)
@@ -132,7 +135,6 @@ class DirectoryLayout(object):
            Raised RemoveFailedError if something goes wrong.
         """
         path = self.path_for_spec(spec)
-        assert(path.startswith(self.root))
 
         if os.path.exists(path):
             try:
@@ -194,6 +196,9 @@ class YamlDirectoryLayout(DirectoryLayout):
 
         if spec.external:
             return spec.external_path
+
+        if hasattr(spec, '_prefix') and spec._prefix:
+            return spec._prefix
 
         path = spec.format(self.path_scheme)
         return path

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1192,7 +1192,6 @@ class PackageBase(with_metaclass(PackageMeta, object)):
         partial = self.check_for_unfinished_installation(keep_prefix, restage)
 
         # Ensure package is not already installed
-        layout = spack.store.layout
         with spack.store.db.prefix_read_lock(self.spec):
             if partial:
                 tty.msg(
@@ -1204,12 +1203,12 @@ class PackageBase(with_metaclass(PackageMeta, object)):
                 return self._update_explicit_entry_in_db(rec, explicit)
             path_spec = spack.store.db.query_path(self.spec.prefix)
             if path_spec:
-                msg = '{0.name} is already installed in {0.prefix}.\n'.format(path_spec)
+                msg = '{0.name} is already installed in '.format(path_spec)
+                msg += '{0.prefix}.\n'.format(path_spec)
                 ps_hash = path_spec.dag_hash(7)
                 msg += 'Uninstall {0.name} / {1}'.format(path_spec, ps_hash)
                 msg += 'to replace it with {0.name}.'.format(self.spec)
                 tty.die(msg.format(path_spec))
-
 
         # Dirty argument takes precedence over dirty config setting.
         if dirty is None:

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1197,11 +1197,19 @@ class PackageBase(with_metaclass(PackageMeta, object)):
             if partial:
                 tty.msg(
                     "Continuing from partial install of %s" % self.name)
-            elif layout.check_installed(self.spec):
-                msg = '{0.name} is already installed in {0.prefix}'
-                tty.msg(msg.format(self))
+            elif spack.store.db.query_one(self.spec):
                 rec = spack.store.db.get_record(self.spec)
+                msg = '{0.name} is already installed in {0.prefix}'
+                tty.msg(msg.format(rec.spec))
                 return self._update_explicit_entry_in_db(rec, explicit)
+            path_spec = spack.store.db.query_path(self.spec.prefix)
+            if path_spec:
+                msg = '{0.name} is already installed in {0.prefix}'
+                if force:
+                    tty.warn(msg.format(path_spec))
+                else:
+                    tty.die(msg.format(path_spec))
+
 
         # Dirty argument takes precedence over dirty config setting.
         if dirty is None:

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1177,7 +1177,8 @@ class PackageBase(with_metaclass(PackageMeta, object)):
             explicit (bool): True if package was explicitly installed, False
                 if package was implicitly installed (as a dependency).
             dirty (bool): Don't clean the build environment before installing.
-            force (bool): Install again, even if already installed.
+            force (bool): Install again, even if already installed or if
+                another package is installed to its prefix.
         """
         if not self.spec.concrete:
             raise ValueError("Can only install concrete packages: %s."
@@ -1204,11 +1205,11 @@ class PackageBase(with_metaclass(PackageMeta, object)):
                 return self._update_explicit_entry_in_db(rec, explicit)
             path_spec = spack.store.db.query_path(self.spec.prefix)
             if path_spec:
-                msg = '{0.name} is already installed in {0.prefix}'
-                if force:
-                    tty.warn(msg.format(path_spec))
-                else:
-                    tty.die(msg.format(path_spec))
+                msg = '{0.name} is already installed in {0.prefix}.\n'.format(path_spec)
+                ps_hash = path_spec.dag_hash(7)
+                msg += 'Uninstall {0.name} / {1}'.format(path_spec, ps_hash)
+                msg += 'to replace it with {0.name}.'.format(self.spec)
+                tty.die(msg.format(path_spec))
 
 
         # Dirty argument takes precedence over dirty config setting.

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1177,8 +1177,7 @@ class PackageBase(with_metaclass(PackageMeta, object)):
             explicit (bool): True if package was explicitly installed, False
                 if package was implicitly installed (as a dependency).
             dirty (bool): Don't clean the build environment before installing.
-            force (bool): Install again, even if already installed or if
-                another package is installed to its prefix.
+            force (bool): Install again, even if already installed.
         """
         if not self.spec.concrete:
             raise ValueError("Can only install concrete packages: %s."

--- a/lib/spack/spack/repository.py
+++ b/lib/spack/spack/repository.py
@@ -571,7 +571,7 @@ class Repo(object):
                 "Repository %s does not contain package %s"
                 % (self.namespace, spec.fullname))
 
-        key = hash(spec)
+        key = hash((spec, getattr(spec, '_prefix', None)))
         if new or key not in self._instances:
             package_class = self.get_pkg_class(spec.name)
             try:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1385,10 +1385,8 @@ class Spec(object):
             return self._prefix
         elif self._concrete:
             spec = spack.store.db.query_one(self)
-            if spec:
-                print spec, spec.prefix
-                if spec and getattr(spec, '_prefix', None):
-                    return spec.prefix
+            if spec and getattr(spec, '_prefix', None):
+                return spec.prefix
         return Prefix(spack.store.layout.path_for_spec(self))
 
     def dag_hash(self, length=None):
@@ -2492,7 +2490,10 @@ class Spec(object):
                        self.concrete != other.concrete and
                        self.external_path != other.external_path and
                        self.external_module != other.external_module and
-                       self.compiler_flags != other.compiler_flags)
+                       self.compiler_flags != other.compiler_flags and
+                       getattr(self, '_prefix', None) != getattr(other,
+                                                                 '_prefix',
+                                                                 None))
 
         # Local node attributes get copied first.
         self.name = other.name

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1382,12 +1382,12 @@ class Spec(object):
 
     @property
     def prefix(self):
+        assert self.concrete  # prefix of a non-concrete spec is nonsense
         if self._prefix:
             return self._prefix
-        elif self._concrete:
-            spec = spack.store.db.query_one(self)
-            if spec and getattr(spec, '_prefix', None):
-                return spec._prefix
+        spec = spack.store.db.query_one(self)
+        if spec and getattr(spec, '_prefix', None):
+            return spec._prefix
         return Prefix(spack.store.layout.path_for_spec(self))
 
     def dag_hash(self, length=None):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1018,8 +1018,8 @@ class Spec(object):
         # cases we've read them from a file want to assume normal.
         # This allows us to manipulate specs that Spack doesn't have
         # package.py files for.
-        self._normal = kwargs.get('normal', False)
-        self._concrete = kwargs.get('concrete', False)
+        self._normal = False
+        self._concrete = False
 
         # Allow a spec to be constructed with an external path.
         self.external_path = kwargs.get('external_path', None)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1383,6 +1383,12 @@ class Spec(object):
     def prefix(self):
         if self._prefix:
             return self._prefix
+        elif self._concrete:
+            spec = spack.store.db.query_one(self)
+            if spec:
+                print spec, spec.prefix
+                if spec and getattr(spec, '_prefix', None):
+                    return spec.prefix
         return Prefix(spack.store.layout.path_for_spec(self))
 
     def dag_hash(self, length=None):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1386,7 +1386,7 @@ class Spec(object):
         elif self._concrete:
             spec = spack.store.db.query_one(self)
             if spec and getattr(spec, '_prefix', None):
-                return spec.prefix
+                return spec._prefix
         return Prefix(spack.store.layout.path_for_spec(self))
 
     def dag_hash(self, length=None):

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -81,7 +81,7 @@ def test_install_and_uninstall(mock_archive):
 
 @pytest.mark.usefixtures('install_mockery')
 def test_install_to_prefix(mock_archive, tmpdir):
-    spec = Spec('trivial-install-test-package prefix={}/pre'.format(tmpdir))
+    spec = Spec('trivial-install-test-package prefix={0}/pre'.format(tmpdir))
     spec.concretize()
     assert spec.concrete
 
@@ -100,12 +100,12 @@ def test_install_to_prefix(mock_archive, tmpdir):
 @pytest.mark.usefixtures('install_mockery')
 def test_install_to_multiple_prefix(mock_archive, tmpdir):
     prefix1 = '{}/pre1'.format(tmpdir)
-    spec1 = Spec('trivial-install-test-package prefix={}'.format(prefix1))
+    spec1 = Spec('trivial-install-test-package prefix={0}'.format(prefix1))
     spec1.concretize()
     assert spec1.concrete
 
     prefix2 = '{}/pre2'.format(tmpdir)
-    spec2 = Spec('trivial-install-test-package prefix={}'.format(prefix2))
+    spec2 = Spec('trivial-install-test-package prefix={0}'.format(prefix2))
     spec2.concretize()
     assert spec2.concrete
 
@@ -130,11 +130,12 @@ def test_install_to_multiple_prefix(mock_archive, tmpdir):
 
 @pytest.mark.usefixtures('install_mockery')
 def test_multiple_install_to_prefix(mock_archive, tmpdir):
-    spec1 = Spec('trivial-install-test-package prefix={}/pre1'.format(tmpdir))
+    spec1 = Spec('trivial-install-test-package prefix={0}/pre1'.format(tmpdir))
     spec1.concretize()
     assert spec1.concrete
 
-    spec2 = Spec('trivial-install-test-package cflags=-g prefix={}/pre1'.format(tmpdir))
+    s = 'trivial-install-test-package cflags=-g prefix={0}/pre1'.format(tmpdir)
+    spec2 = Spec(s)
     spec2.concretize()
     assert spec2.concrete
 

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -99,12 +99,12 @@ def test_install_to_prefix(mock_archive, tmpdir):
 
 @pytest.mark.usefixtures('install_mockery')
 def test_install_to_multiple_prefix(mock_archive, tmpdir):
-    prefix1 = '{}/pre1'.format(tmpdir)
+    prefix1 = '{0}/pre1'.format(tmpdir)
     spec1 = Spec('trivial-install-test-package prefix={0}'.format(prefix1))
     spec1.concretize()
     assert spec1.concrete
 
-    prefix2 = '{}/pre2'.format(tmpdir)
+    prefix2 = '{0}/pre2'.format(tmpdir)
     spec2 = Spec('trivial-install-test-package prefix={0}'.format(prefix2))
     spec2.concretize()
     assert spec2.concrete


### PR DESCRIPTION
I thought we had an open issue for this, but I couldn't find one.

This PR allows the user to specify `prefix=/path/to/install/to` on a spec on the command line to install to a prefix other than the default.