### PR TITLE
netcdf: forward 'mpi' to 'hdf5' 

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf/package.py
+++ b/var/spack/repos/builtin/packages/netcdf/package.py
@@ -83,11 +83,16 @@ class Netcdf(AutotoolsPackage):
 
     # Required for NetCDF-4 support
     depends_on("zlib@1.2.5:")
-    depends_on('hdf5')
+
+    # Forward variants to hdf5
+    depends_on('hdf5+mpi', when='+mpi')
+    depends_on('hdf5~mpi', when='~mpi')
 
     # NetCDF 4.4.0 and prior have compatibility issues with HDF5 1.10 and later
     # https://github.com/Unidata/netcdf-c/issues/250
     depends_on('hdf5@:1.8', when='@:4.4.0')
+
+    conflicts('~mpi', when='+parallel-netcdf')
 
     def patch(self):
         try:
@@ -105,10 +110,6 @@ class Netcdf(AutotoolsPackage):
 
     def configure_args(self):
         spec = self.spec
-        # Workaround until variant forwarding works properly
-        if '+mpi' in spec and spec.satisfies('^hdf5~mpi'):
-            raise RuntimeError('Invalid spec. Package netcdf requires '
-                               'hdf5+mpi, but spec asked for hdf5~mpi.')
 
         # Environment variables
         CFLAGS   = []

--- a/var/spack/repos/builtin/packages/netcdf/package.py
+++ b/var/spack/repos/builtin/packages/netcdf/package.py
@@ -85,6 +85,7 @@ class Netcdf(AutotoolsPackage):
     depends_on("zlib@1.2.5:")
 
     # Forward variants to hdf5
+    depends_on('hdf5')
     depends_on('hdf5+mpi', when='+mpi')
     depends_on('hdf5~mpi', when='~mpi')
 


### PR DESCRIPTION
Currently when we ask Spack to build `netcdf~mpi` what we get back after concretization is:
```console
$ spack spec netcdf~mpi
Input spec
--------------------------------
netcdf~mpi

Normalized
--------------------------------
netcdf~mpi
    ^hdf5
        ^zlib@1.2.5:
    ^m4

Concretized
--------------------------------
netcdf@4.4.1.1%gcc@4.8~cdmremote~dap~hdf4 maxdims=1024 maxvars=8192 ~mpi~parallel-netcdf+shared arch=linux-ubuntu14-x86_64 
    ^hdf5@1.10.1%gcc@4.8+cxx~debug+fortran+mpi+pic+shared~szip~threadsafe arch=linux-ubuntu14-x86_64 
        ^openmpi@2.1.1%gcc@4.8~cuda fabrics= ~java schedulers= ~sqlite3~thread_multiple+vt arch=linux-ubuntu14-x86_64 
            ^hwloc@1.11.7%gcc@4.8~cuda+libxml2+pci arch=linux-ubuntu14-x86_64 
                ^libpciaccess@0.13.5%gcc@4.8 arch=linux-ubuntu14-x86_64 
                    ^libtool@2.4.6%gcc@4.8 arch=linux-ubuntu14-x86_64 
                        ^m4@1.4.18%gcc@4.8+sigsegv arch=linux-ubuntu14-x86_64 
                            ^libsigsegv@2.11%gcc@4.8 arch=linux-ubuntu14-x86_64 
                    ^pkg-config@0.29.2%gcc@4.8+internal_glib arch=linux-ubuntu14-x86_64 
                    ^util-macros@1.19.1%gcc@4.8 arch=linux-ubuntu14-x86_64 
                ^libxml2@2.9.4%gcc@4.8~python arch=linux-ubuntu14-x86_64 
                    ^xz@5.2.3%gcc@4.8 arch=linux-ubuntu14-x86_64 
                    ^zlib@1.2.11%gcc@4.8+pic+shared arch=linux-ubuntu14-x86_64 
```
that is a `netcdf` that depends on `mpi` through `hdf5`. This PR prevents this particular combination from being possible as it forwards the `mpi` variant to `hdf5`. It also adds a conflict check on `netcdf+parallel-netcdf~mpi`.