### PR TITLE
resources: added lookup by name

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -796,14 +796,16 @@ class PackageBase(with_metaclass(PackageMeta, object)):
         for ii, fetcher in enumerate(composite_fetcher):
             if ii == 0:
                 # Construct root stage first
+                name = 'root'
                 stage = self._make_root_stage(fetcher)
             else:
                 # Construct resource stage
                 resource = resources[ii - 1]  # ii == 0 is root!
+                name = resource.name
                 stage = self._make_resource_stage(composite_stage[0], fetcher,
                                                   resource)
             # Append the item to the composite
-            composite_stage.append(stage)
+            composite_stage.append(stage, name)
 
         return composite_stage
 

--- a/lib/spack/spack/test/util/pattern.py
+++ b/lib/spack/spack/test/util/pattern.py
@@ -1,0 +1,258 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
+import pytest
+
+from spack.util.pattern import composite
+
+
+class Base(object):
+    counter = 0
+
+    @classmethod
+    def reset(cls):
+        cls.counter = 0
+
+    def add(self):
+        raise NotImplemented('add not implemented')
+
+    def subtract(self):
+        raise NotImplemented('subtract not implemented')
+
+    @staticmethod
+    def get_number():
+        return Base.counter
+
+
+class One(Base):
+    def add(self):
+        Base.counter += 1
+
+    def subtract(self):
+        Base.counter -= 1
+
+
+class Two(Base):
+    def add(self):
+        Base.counter += 2
+
+    def subtract(self):
+        Base.counter -= 2
+
+
+@pytest.fixture
+def composite_items():
+    Base.reset()  # Make sure that the initial state is always consistent
+    one = One()
+    two = Two()
+    return one, two
+
+
+class TestCompositeUsage:
+    def test_composite_from_method_list(self, composite_items):
+        @composite(method_list=['add', 'subtract'])
+        class CompositeFromMethodList(object):
+            @staticmethod
+            def get_number():
+                return 0
+
+        one, two = composite_items
+
+        composite_object = CompositeFromMethodList()
+        composite_object.append(one)
+        composite_object.append(two)
+        composite_object.add()
+        assert Base.counter == 3
+
+        composite_object.pop()
+        composite_object.subtract()
+        assert Base.counter == 2
+
+        assert CompositeFromMethodList.get_number() == 0
+
+    def test_composite_from_interface(self, composite_items):
+        @composite(interface=Base)
+        class CompositeFromInterface(object):
+            pass
+
+        one, two = composite_items
+
+        composite_object = CompositeFromInterface()
+
+        composite_object.append(one)
+        composite_object.append(two)
+        composite_object.add()
+        assert Base.counter == 3
+
+        composite_object.pop()
+        composite_object.subtract()
+        assert Base.counter == 2
+
+        assert CompositeFromInterface.get_number() == 2
+        assert isinstance(composite_object, Base)
+        assert issubclass(CompositeFromInterface, Base)
+
+    def test_get_item(self, composite_items):
+        @composite(interface=Base)
+        class CompositeFromInterface(object):
+            pass
+
+        one, two = composite_items
+        composite_object = CompositeFromInterface()
+
+        composite_object.append(one, 'one')
+        composite_object.append(two, 'two')
+
+        # Check indexed access
+        assert composite_object[0] is one
+        assert composite_object[1] is two
+
+        # Check access by name
+        assert composite_object['one'] is one
+        assert composite_object['two'] is two
+
+        # Check contains
+        assert one in composite_object
+        assert two in composite_object
+        assert 'one' in composite_object
+        assert 'two' in composite_object
+
+        # Check assignment
+        composite_object[:] = [two, one]
+
+        assert composite_object[0] is two
+        assert composite_object[1] is one
+        assert composite_object['one'] is one
+        assert composite_object['two'] is two
+
+        composite_object[:] = [two, two]
+
+        assert composite_object[0] is two
+        assert composite_object[1] is two
+        assert 'one' not in composite_object
+        assert composite_object['two'] is two
+
+        # Check deletion
+
+        assert len(composite_object) == 2
+
+        del composite_object[0]
+
+        assert len(composite_object) == 1
+        assert composite_object[0] == two
+        assert 'two' in composite_object
+
+        del composite_object[0]
+
+        assert len(composite_object) == 0
+        assert 'two' not in composite_object
+
+
+class TestCompositeFailures:
+    def test_wrong_container(self):
+        with pytest.raises(TypeError):
+
+            @composite(interface=Base, container=2)
+            class CompositeFromInterface:
+                pass
+
+    def test_no_interface_given(self):
+        with pytest.raises(TypeError):
+
+            @composite()
+            class CompositeFromInterface:
+                pass
+
+
+class BaseReduction(object):
+    def get_int(self):
+        pass
+
+    def get_string(self):
+        pass
+
+
+class A(BaseReduction):
+    def get_int(self):
+        return 10
+
+    def get_string(self):
+        return 'Hello '
+
+
+class B(BaseReduction):
+    def get_int(self):
+        return 11
+
+    def get_string(self):
+        return 'world!'
+
+
+@pytest.fixture
+def composite_reduction_items():
+    a = A()
+    b = B()
+    return a, b
+
+
+class TestCompositeReduction:
+    def test_reduction(self, composite_reduction_items):
+        class Multiplier(object):
+            def __init__(self):
+                self.value = 1
+
+            def __call__(self, value):
+                self.value *= value
+                return self.value
+
+        class Adder(object):
+            def __init__(self):
+                self.value = ''
+
+            def __call__(self, value):
+                self.value += value
+                return self.value
+
+        adder, multiplier = Adder(), Multiplier()
+
+        @composite(
+            interface=BaseReduction,
+            reductions={'get_int': multiplier, 'get_string': adder}
+        )
+        class CompositeReduction(object):
+            pass
+
+        composite_object = CompositeReduction()
+        composite_object.extend(composite_reduction_items)
+
+        assert composite_object.get_int() == 110
+        assert composite_object.get_string() == 'Hello world!'
+
+    def test_wrong_reduction_type(self):
+        with pytest.raises(TypeError):
+
+            @composite(interface=BaseReduction, reductions=[])
+            class CompositeReductionInterface(object):
+                pass

--- a/lib/spack/spack/util/pattern.py
+++ b/lib/spack/spack/util/pattern.py
@@ -22,13 +22,124 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-import inspect
-import collections
+
+from __future__ import absolute_import, print_function
+
 import functools
+import inspect
+import re
+
+try:
+    from collections.abc import MutableSequence
+except ImportError:
+    from collections import MutableSequence
+
+import six
 
 
-def composite(interface=None, method_list=None, container=list):
-    """Decorator implementing the GoF composite pattern.
+_IS_SPECIAL_PATTERN = re.compile('__[^_]+__')
+
+
+def is_special(item):
+    """Returns True if the item is a special function or method,
+    False otherwise.
+
+    Args:
+        item: item to be inspected
+
+    Returns:
+        True or False
+    """
+    # TODO : this matches any __<name>__ not only special methods
+    name = getattr(item, '__name__')
+    if _IS_SPECIAL_PATTERN.match(name):
+        return True
+    return False
+
+
+def is_private(item):
+    """Returns True if the item is 'private', False otherwise.
+
+    Args:
+        item: item to be inspected
+
+    Returns:
+        True or False
+    """
+    name = getattr(item, '__name__')
+    if name.startswith('_') and not is_special(item):
+        return True
+    return False
+
+
+class _CompositeContainer(MutableSequence):
+    """Container used for the composite implementation.
+
+    This container is basically a list that permits to append items with a
+    name, and retrieve them by name. It doesn't permit to set them by name.
+    """
+
+    def __init__(self):
+        super(_CompositeContainer, self).__init__()
+        self._items = []
+        self._named_items = {}
+
+    def append(self, value, name=None):
+        """Append an item to the container. If it has a name store it to
+        permit also a look-up by name.
+
+        Args:
+           value: value to be appended
+           name (str): name to be associated with the value (optional)
+        """
+        if name is not None:
+            self._named_items[name] = value
+        super(_CompositeContainer, self).append(value)
+
+    def __contains__(self, item):
+        """Try to look-up by name first, delegate to list later."""
+        if item in self._named_items:
+            return self._named_items[item]
+
+        return super(_CompositeContainer, self).__contains__(item)
+
+    def __getitem__(self, item):
+        # If item is a string, return whatever the lookup by name gives
+        if isinstance(item, six.string_types):
+            return self._named_items[item]
+
+        # Otherwise delegate to list
+        return self._items[item]
+
+    def _cleanup_named_items(self):
+        self._named_items = dict(
+            [(k, v) for k, v in self._named_items.items() if v in self._items]
+        )
+
+    def __setitem__(self, key, value):
+        # Delegate to list for setting
+        self._items[key] = value
+
+        # Cleanup the dictionary appropriately
+        self._cleanup_named_items()
+
+    def __delitem__(self, key):
+        # Delegate to list for deletion
+        del self._items[key]
+
+        # Cleanup the dictionary appropriately
+        self._cleanup_named_items()
+
+    def __len__(self):
+        return len(self._items)
+
+    def insert(self, index, value):
+        self._items.insert(index, value)
+
+
+def composite(interface=None, method_list=None, reductions=None):
+    """Class decorator that patches a class adding all the methods
+    it needs to be a composite over a given interface.
 
     Args:
         interface (type): class exposing the interface to which the
@@ -36,86 +147,98 @@ def composite(interface=None, method_list=None, container=list):
             non-special methods will be taken into account
         method_list (list of str): names of methods that should be part
             of the composite
-        container (MutableSequence): container for the composite object
-            (default = list).  Must fulfill the MutableSequence
-            contract. The composite class will expose the container API
-            to manage object composition
+
+        reductions (dict): dictionary that maps method names to reduction
+            function
 
     Returns:
-        a class decorator that patches a class adding all the methods
-        it needs to be a composite for a given interface.
-
+        class decorator
     """
-    # Check if container fulfills the MutableSequence contract and raise an
-    # exception if it doesn't. The patched class returned by the decorator will
-    # inherit from the container class to expose the interface needed to manage
-    # objects composition
-    if not issubclass(container, collections.MutableSequence):
-        raise TypeError("Container must fulfill the MutableSequence contract")
-
-    # Check if at least one of the 'interface' or the 'method_list' arguments
-    # are defined
+    # Check if at least one of the 'interface' or the 'method_list'
+    # arguments are defined
     if interface is None and method_list is None:
-        raise TypeError(
-            "Either 'interface' or 'method_list' must be defined on a call "
-            "to composite")
+        raise TypeError("Either 'interface' or 'method_list' must be defined")
+
+    if reductions is not None and not isinstance(reductions, dict):
+        raise TypeError("'reduction' should be a dictionary")
 
     def cls_decorator(cls):
         # Retrieve the base class of the composite. Inspect its methods and
-        # decide which ones will be overridden
-        def no_special_no_private(x):
-            return callable(x) and not x.__name__.startswith('_')
+        # decide which ones will be overridden.
+        def no_special_no_private(mthd):
+            # Here we have a nasty difference between python 2 and python 3.
+            # In python 2 x is considered to be an unbound method
+            # when coming from a class
+            # (ismethod(x) == True, isfunction(x) == False)
+            # In python 3 x is considered just a function
+            # when coming from a class
+            # (ismethod(x) == False, isfunction(x) == True)
+            return not is_special(mthd) and not is_private(mthd)
 
         # Patch the behavior of each of the methods in the previous list.
         # This is done associating an instance of the descriptor below to
         # any method that needs to be patched.
         class IterateOver(object):
-            """Decorator used to patch methods in a composite.
+            """Descriptor used to patch methods in a composite.
 
             It iterates over all the items in the instance containing the
             associated attribute and calls for each of them an attribute
-            with the same name
+            with the same name.
             """
 
-            def __init__(self, name, func=None):
+            def __init__(self, name, func=None, reductions=reductions):
                 self.name = name
                 self.func = func
+                self.reductions = reductions if reductions is not None else {}
 
             def __get__(self, instance, owner):
+                reduction_function = self.reductions.get(self.name, None)
+
                 def getter(*args, **kwargs):
                     for item in instance:
-                        getattr(item, self.name)(*args, **kwargs)
-                # If we are using this descriptor to wrap a method from an
-                # interface, then we must conditionally use the
-                # `functools.wraps` decorator to set the appropriate fields
+                        value = getattr(item, self.name)(*args, **kwargs)
+                        if reduction_function is not None:
+                            value = reduction_function(value)
+                    return value
+
+                # If we are using this descriptor to wrap a method from
+                # an interface, then we must conditionally use the
+                # `functools.wraps` decorator to set the appropriate fields.
                 if self.func is not None:
                     getter = functools.wraps(self.func)(getter)
                 return getter
 
         dictionary_for_type_call = {}
-
-        # Construct a dictionary with the methods explicitly passed as name
+        # Construct a dictionary with the methods explicitly passed as names
         if method_list is not None:
-            dictionary_for_type_call.update(
-                (name, IterateOver(name)) for name in method_list)
+            method_list_dict = {}
+            for name in method_list:
+                method_list_dict[name] = IterateOver(name)
+            dictionary_for_type_call.update(method_list_dict)
 
         # Construct a dictionary with the methods inspected from the interface
+        bases = (cls, _CompositeContainer)
         if interface is not None:
-            dictionary_for_type_call.update(
-                (name, IterateOver(name, method))
-                for name, method in inspect.getmembers(
-                    interface, predicate=no_special_no_private))
+            # If an interface is passed, class methods and static methods
+            # should not be inserted in the list of methods to be wrapped
+            interface_methods = inspect.classify_class_attrs(interface)
+            interface_methods = [
+                x for x in interface_methods if x.kind == 'method'
+            ]
+            interface_methods = [
+                x for x in interface_methods if no_special_no_private(x.object)
+            ]
 
-        # Get the methods that are defined in the scope of the composite
-        # class and override any previous definition
-        dictionary_for_type_call.update(
-            (name, method) for name, method in inspect.getmembers(
-                cls, predicate=inspect.ismethod))
+            interface_methods_dict = dict(
+                (item.name, IterateOver(item.name, item.object))
+                for item in interface_methods
+            )
+            dictionary_for_type_call.update(interface_methods_dict)
+            bases = (cls, interface, _CompositeContainer)
 
         # Generate the new class on the fly and return it
-        # FIXME : inherit from interface if we start to use ABC classes?
-        wrapper_class = type(cls.__name__, (cls, container),
-                             dictionary_for_type_call)
+        wrapper_class = type(cls.__name__, bases, dictionary_for_type_call)
+
         return wrapper_class
 
     return cls_decorator

--- a/var/spack/repos/builtin/packages/atlas/package.py
+++ b/var/spack/repos/builtin/packages/atlas/package.py
@@ -104,8 +104,10 @@ class Atlas(Package):
 
         # Lapack resource to provide full lapack build. Note that
         # ATLAS only provides a few LAPACK routines natively.
-        options.append('--with-netlib-lapack-tarfile=%s' %
-                       self.stage[1].archive_file)
+        archive = self.stage['lapack'].archive_file
+        options.append(
+            '--with-netlib-lapack-tarfile={0}'.format(archive)
+        )
 
         with working_dir('spack-build', create=True):
             configure = Executable('../configure')


### PR DESCRIPTION
If considered useful this is a cut'n paste of the `composite` decorator + tests from a small personal project that I use from time to time as a python gym. Modifications include:

- [x] resources now can be looked up by name (see atlas)
- [x] container customization in the `composite` decorator has been removed
- [x] we can now apply reduction operations over a composite

The modification that is immediately useful is the first one, as it adresses [this comment](https://github.com/LLNL/spack/pull/2371#discussion_r90250916). Let me know if you want me to remove reduction operations or if it is fine to leave them.