### PR TITLE
makefile package flags

### DIFF
--- a/lib/spack/spack/build_systems/makefile.py
+++ b/lib/spack/spack/build_systems/makefile.py
@@ -85,9 +85,9 @@ class MakefilePackage(PackageBase):
         :return: build directory
         """
         return self.stage.source_path
-    
+
     def make_args(self):
-        """Produces a list containing all the extra arguments 
+        """Produces a list containing all the extra arguments
         that must be passed to make, e.g. CC=spack_cc
 
         :return: list of arguments for make

--- a/lib/spack/spack/build_systems/makefile.py
+++ b/lib/spack/spack/build_systems/makefile.py
@@ -85,6 +85,14 @@ class MakefilePackage(PackageBase):
         :return: build directory
         """
         return self.stage.source_path
+    
+    def make_args(self):
+        """Produces a list containing all the extra arguments 
+        that must be passed to make, e.g. CC=spack_cc
+
+        :return: list of arguments for make
+        """
+        return []
 
     def edit(self, spec, prefix):
         """Edits the Makefile before calling make. This phase cannot
@@ -93,11 +101,12 @@ class MakefilePackage(PackageBase):
         tty.msg('Using default implementation: skipping edit phase.')
 
     def build(self, spec, prefix):
-        """Calls make, passing :py:attr:`~.MakefilePackage.build_targets`
-        as targets.
+        """Calls make, passing :py:attr:`~.MakefilePackage.make_args`
+        and :py:attr:`~.MakefilePackage.build_targets` as targets.
         """
+        options = self.make_args() + self.build_targets
         with working_dir(self.build_directory):
-            inspect.getmodule(self).make(*self.build_targets)
+            inspect.getmodule(self).make(*options)
 
     def install(self, spec, prefix):
         """Calls make, passing :py:attr:`~.MakefilePackage.install_targets`

--- a/var/spack/repos/builtin/packages/libxsmm/package.py
+++ b/var/spack/repos/builtin/packages/libxsmm/package.py
@@ -60,13 +60,13 @@ class Libxsmm(MakefilePackage):
             description='Unoptimized with call-trace (LIBXSMM_TRACE).')
     variant('header-only', default=False,
             description='Produce header-only installation')
-    
+
     def make_args(self):
         options = [
             "CC=%s" % spack_cc,
             "CXX=%s" % spack_cxx,
             "FC=%s" % spack_fc,
-            'SYM=1' ] # include symbols by default
+            'SYM=1']    # include symbols by default
 
         # JIT (AVX and later) makes MNK, M, N, or K spec. superfluous
 #       make_args += ['MNK=1 4 5 6 8 9 13 16 17 22 23 24 26 32']


### PR DESCRIPTION
A couple of packages add target like `CFLAGS=foo`, CC=`bar`, which is a bit hackish. With the new `make_args()`, this can be done much cleaner.

I rewrote `libxsmm` as an example.

With this in place, half of the Makefile edits could be dropped and replaced by `make CC=..`, which is much less brittle than patching.