### PR TITLE
Throw error if external modules cannot be found

### DIFF
--- a/lib/spack/spack/test/module_parsing.py
+++ b/lib/spack/spack/test/module_parsing.py
@@ -62,10 +62,13 @@ def test_get_path_from_module(save_env):
 
         assert path == '/path/to'
 
-    os.environ['BASH_FUNC_module()'] = '() { eval $(echo fill bash $*)\n}'
-    path = get_path_from_module('mod')
-
-    assert path is None
+    try:
+        os.environ['BASH_FUNC_module()'] = '() { eval $(echo fill bash $*)\n}'
+        path = get_path_from_module('mod')
+    except ModuleError:
+        pass
+    else:
+        assert False
 
 
 def test_get_argument_from_module_line():

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -188,7 +188,7 @@ def get_path_from_module(mod):
             return line[L + 2:line.find('/lib')]
 
     # Unable to find module path
-    return None
+    raise ModuleError("Unable to find path for module " + mod)
 
 
 class ModuleError(Exception):


### PR DESCRIPTION
Previously, if the root of an external module was unable to be found, spack would continue until it tried to actually use the module.

This patch makes spack fail earlier and with a clearer error message.