### PR TITLE
Compile OpenFOAM on Cray platform

### DIFF
--- a/var/spack/repos/builtin/packages/openfoam-com/package.py
+++ b/var/spack/repos/builtin/packages/openfoam-com/package.py
@@ -236,15 +236,19 @@ def mplib_content(spec, pre=None):
     else:
         pre = mpi_spec.prefix
 
+    libname = 'mpi'
+    if mpi_spec.name == 'mpich':
+        libname = 'mpich'
+
     info = {
         'name':   '{0}-{1}'.format(mpi_spec.name, mpi_spec.version),
         'prefix':  pre,
         'include': inc,
         'bindir':  bin,
         'libdir':  lib,
-        'FLAGS':  '-DOMPI_SKIP_MPICXX -DMPICH_IGNORE_CXX_SEEK',
+        'FLAGS':  '-DOMPI_SKIP_MPICXX -DMPICH_SKIP_MPICXX',
         'PINC':   '-I{0}'.format(inc),
-        'PLIBS':  '-L{0} -lmpi'.format(lib),
+        'PLIBS':  '-L{0} -l{1}'.format(lib, libname),
     }
     return info
 
@@ -669,15 +673,17 @@ class OpenfoamArch(object):
                 platform += 'ia64'
             elif target == 'armv7l':
                 platform += 'ARM7'
-            elif target == ppc64:
+            elif target == 'ppc64':
                 platform += 'PPC64'
-            elif target == ppc64le:
+            elif target == 'ppc64le':
                 platform += 'PPC64le'
         elif platform == 'darwin':
             if target == 'x86_64':
                 platform += 'Intel'
                 if self.arch_option == '64':
                     platform += '64'
+        elif platform == 'cray':
+            platform = 'linux64'
         # ... and others?
 
         self.arch = platform


### PR DESCRIPTION
I needed to make a few changes to the `openfoam-com` and `openfoam-org` packages to get them to build on the Cray platform with the system `cray-mpich` library.

The platform is detected as "cray", but it can be treated as "linux64".  Also fix a few typos with the ppc strings.

The MPI library needs to be linked with `-lmpich` instead of `-lmpi`.

OpenFOAM has a weird `#include` of ptscotch inside an `extern "C"` block, which messes with the MPI C++ bindings.  `MPICH_IGNORE_CXX_SEEK` was already defined, but that's not good enough.  `MPICH_SKIP_MPICXX` works fine, though.