### PR TITLE
Flags and hashes

### DIFF
--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -355,15 +355,15 @@ class DefaultConcretizer(object):
         for flag in spack.spec.FlagMap.valid_compiler_flags():
             if flag not in spec.compiler_flags:
                 try:
-                    nearest = next(p for p in spec.traverse(direction='parents')
+                    n = next(p for p in spec.traverse(direction='parents')
                                    if (compiler_match(p) and
                                        (p is not spec) and
                                        flag in p.compiler_flags))
 
-                    nearest_flags = set(nearest.compiler_flags[flag])
+                    nearest_flags = set(n.compiler_flags[flag])
                     flags = set()
 
-                    if (nearest_flags - flags) or nearest.compiler_flags[flag] == []:
+                    if (nearest_flags - flags) or n.compiler_flags[flag] == []:
                         spec.compiler_flags[flag] = list(nearest_flags | flags)
                         ret = True
 

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -347,17 +347,15 @@ class DefaultConcretizer(object):
             # running.
             return True
 
-        compiler_match = lambda other: (
-            spec.compiler == other.compiler and
-            spec.architecture == other.architecture)
-
-        def loose_compiler_match(other):
-            # The other compiler could eventually match this one
-            ret = True
-            if other.compiler and other.compiler.concrete:
-                ret = (spec.compiler == other.compiler and
-                       spec.architecture == other.architecture)
-            return ret
+        def compiler_match(other, strict=True):
+            if strict:
+                return (spec.compiler == other.compiler and
+                        spec.architecture == other.architecture)
+            else:
+                if other.compiler and other.compiler.concrete:
+                    return (spec.compiler == other.compiler and
+                            spec.architecture == other.architecture)
+                return True
 
         ret = False
         for flag in spack.spec.FlagMap.valid_compiler_flags():
@@ -378,7 +376,7 @@ class DefaultConcretizer(object):
                 except StopIteration:
                     try:
                         n = next(p for p in spec.traverse(direction='parents')
-                                 if (loose_compiler_match(p) and p is not spec))
+                                 if (compiler_match(p, False) and p is not spec))
                         return True
                     except StopIteration:
                         spec.compiler_flags[flag] = []

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -142,7 +142,7 @@ class DefaultConcretizer(object):
                  between these two extremes.
         """
         # return if already concrete.
-        if spec.versions.concrete:
+        if spec._concrete or spec.versions.concrete:
             return False
 
         # List of versions we could consider, in sorted order
@@ -214,6 +214,9 @@ class DefaultConcretizer(object):
         DAG has an architecture, then use the root otherwise use the defaults
         on the platform.
         """
+        if spec._concrete:
+            return False
+
         root_arch = spec.root.architecture
         sys_arch = spack.spec.ArchSpec(spack.architecture.sys_type())
         spec_changed = False
@@ -243,6 +246,9 @@ class DefaultConcretizer(object):
            the user preferences from packages.yaml or the default variants from
            the package specification.
         """
+        if spec._concrete:
+            return False
+
         changed = False
         preferred_variants = PackagePrefs.preferred_variants(spec.name)
         pkg_cls = spec.package_class
@@ -268,6 +274,9 @@ class DefaultConcretizer(object):
            build with the compiler that will be used by libraries that
            link to this one, to maximize compatibility.
         """
+        if spec._concrete:
+            return False
+
         # Pass on concretizing the compiler if the target or operating system
         # is not yet determined
         if not (spec.architecture.platform_os and spec.architecture.target):
@@ -339,6 +348,9 @@ class DefaultConcretizer(object):
         compiler is used, defaulting to no compiler flags in the spec.
         Default specs set at the compiler level will still be added later.
         """
+        if spec._concrete:
+            return False
+
         # Pass on concretizing the compiler flags if the target or operating
         # system is not set.
         if not (spec.architecture.platform_os and spec.architecture.target):

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -393,12 +393,10 @@ class DefaultConcretizer(object):
         # in default compiler flags.
         compiler = spack.compilers.compiler_for_spec(
             spec.compiler, spec.architecture)
-        for f in compiler.flags:
-            config_flags = set(compiler.flags.get(f, []))
-            flags = set(list())
-            if f in spec.compiler_flags and spec.compiler_flags[f] is not None:
-                flags = set(spec.compiler_flags[f])
-            spec.compiler_flags[f] = list(config_flags | flags)
+        for flag in compiler.flags:
+            config_flags = set(compiler.flags.get(flag, []))
+            flags = set(spec.compiler_flags.get(flag, []))
+            spec.compiler_flags[flag] = list(config_flags | flags)
             if (config_flags - flags):
                 ret = True
 

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -349,9 +349,11 @@ class DefaultConcretizer(object):
 
         def compiler_match(other, strict=True):
             if strict:
+                # Other compiler already matches this compiler.
                 return (spec.compiler == other.compiler and
                         spec.architecture == other.architecture)
             else:
+                # Other compiler may match this compiler.
                 if other.compiler and other.compiler.concrete:
                     return (spec.compiler == other.compiler and
                             spec.architecture == other.architecture)
@@ -376,11 +378,15 @@ class DefaultConcretizer(object):
                 except StopIteration:
                     try:
                         n = next(p for p in spec.traverse(direction='parents')
-                                 if (compiler_match(p, False) and p is not spec))
+                                 if (compiler_match(p, False) and
+                                     p is not spec))
+                        # Wait for things higher up DAG to settle down.
+                        # Don't incorporate compiler config information until
+                        # DAG information is incorporated, so return here.
                         return True
                     except StopIteration:
                         spec.compiler_flags[flag] = []
-                        return True
+                        ret = True
 
         # Include the compiler flag defaults from the config files
         # This ensures that spack will detect conflicts that stem from a change

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -351,6 +351,14 @@ class DefaultConcretizer(object):
             spec.compiler == other.compiler and
             spec.architecture == other.architecture)
 
+        def loose_compiler_match(other):
+            # The other compiler could eventually match this one
+            ret = True
+            if other.compiler and other.compiler.concrete:
+                ret = (spec.compiler == other.compiler and
+                       spec.architecture == other.architecture)
+            return ret
+
         ret = False
         for flag in spack.spec.FlagMap.valid_compiler_flags():
             if flag not in spec.compiler_flags:
@@ -370,13 +378,11 @@ class DefaultConcretizer(object):
                 except StopIteration:
                     try:
                         n = next(p for p in spec.traverse(direction='parents')
-                                 if (compiler_match(p) and p is not spec))
+                                 if (loose_compiler_match(p) and p is not spec))
                         return True
                     except StopIteration:
                         spec.compiler_flags[flag] = []
                         return True
-
-
 
         # Include the compiler flag defaults from the config files
         # This ensures that spack will detect conflicts that stem from a change

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -364,9 +364,9 @@ class DefaultConcretizer(object):
             if flag not in spec.compiler_flags:
                 try:
                     n = next(p for p in spec.traverse(direction='parents')
-                                   if (compiler_match(p) and
-                                       (p is not spec) and
-                                       flag in p.compiler_flags))
+                             if (compiler_match(p) and
+                                 (p is not spec) and
+                                 flag in p.compiler_flags))
 
                     nearest_flags = set(n.compiler_flags[flag])
                     flags = set()

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -669,8 +669,8 @@ class FlagMap(HashableMap):
         sorted_keys = [k for k in sorted(self.keys()) if self[k] != []]
         cond_symbol = ' ' if len(sorted_keys) > 0 else ''
         return cond_symbol + ' '.join(
-            str(key) + '=\"' + ' '.join(
-                str(f) for f in self[key]) + '\"'
+            str(key) + '="' + ' '.join(
+                str(f) for f in self[key]) + '"'
             for key in sorted_keys) + cond_symbol
 
 

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -429,18 +429,6 @@ class TestConcretize(object):
         dyninst = Spec(spec_string)
         dyninst.concretize()
 
-        for f, v in dyninst.compiler_flags.items():
-            print f, v
-        print '------'
-        for f, v in dyninst['libelf'].compiler_flags.items():
-            print f, v
-        print '------'
-        for f, v in libelf.compiler_flags.items():
-            print f, v
-        print '------'
-        for f, v in dyninst['libdwarf'].compiler_flags.items():
-            print f, v
-
         # Libelf appropriately keeps its compiler flags
         assert libelf.compiler_flags == dyninst['libelf'].compiler_flags
         # Dyninst does not pass its flags to libelf.

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -429,9 +429,14 @@ class TestConcretize(object):
         dyninst = Spec(spec_string)
         dyninst.concretize()
 
-        # Libelf appropriately keeps its compiler flags
-        assert libelf.compiler_flags == dyninst['libelf'].compiler_flags
-        # Dyninst does not pass its flags to libelf.
-        assert dyninst.compiler_flags != dyninst['libelf'].compiler_flags
-        # Dyninst appropriately passes its flags to libdwarf
-        assert dyninst.compiler_flags == dyninst['libdwarf'].compiler_flags
+        lflags = libelf.compiler_flags
+        deflags = dyninst['libelf'].compiler_flags
+        ddflags = dyninst['libdwarf'].compiler_flags
+        dflags = dyninst.compiler_flags
+        for flag in libelf.compiler_flags.valid_compiler_flags():
+            # Libelf appropriately keeps its compiler flags
+            assert set(deflags[flag]) == set(lflags[flag])
+            # Dyninst does not pass its flags to libelf.
+            assert set(deflags[flag]) != set(dflags[flag])
+            # Dyninst appropriately passes its flags to libdwarf
+            assert set(ddflags[flag]) == set(dflags[flag])

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -336,11 +336,12 @@ class TestSpecSyntax(object):
         char, specs = find_ambiguous(dbspecs, lambda s: s.dag_hash()[0])
         self._check_raises(AmbiguousHashError, ['/' + char])
 
+        # I don't believe this increases coverage
         # ambiguity in first hash character AND spec name
-        t, specs = find_ambiguous(dbspecs,
-                                  lambda s: (s.name, s.dag_hash()[0]))
-        name, char = t
-        self._check_raises(AmbiguousHashError, [name + '/' + char])
+#        t, specs = find_ambiguous(dbspecs,
+#                                  lambda s: (s.name, s.dag_hash()[0]))
+#        name, char = t
+#        self._check_raises(AmbiguousHashError, [name '/' + char])
 
     def test_invalid_hash(self, database):
         mpileaks_zmpi = database.mock.db.query_one('mpileaks ^zmpi')

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -336,12 +336,11 @@ class TestSpecSyntax(object):
         char, specs = find_ambiguous(dbspecs, lambda s: s.dag_hash()[0])
         self._check_raises(AmbiguousHashError, ['/' + char])
 
-        # I don't believe this increases coverage
         # ambiguity in first hash character AND spec name
-#        t, specs = find_ambiguous(dbspecs,
-#                                  lambda s: (s.name, s.dag_hash()[0]))
-#        name, char = t
-#        self._check_raises(AmbiguousHashError, [name '/' + char])
+        t, specs = find_ambiguous(dbspecs,
+                                  lambda s: (s.name, s.dag_hash()[0]))
+        name, char = t
+        self._check_raises(AmbiguousHashError, [name + '/' + char])
 
     def test_invalid_hash(self, database):
         mpileaks_zmpi = database.mock.db.query_one('mpileaks ^zmpi')


### PR DESCRIPTION
This fixes an issue reported by @mamelara on the slack channel.

Previously, packages specified by hash would inherit additional compiler flags in the spec from their parents, and would therefore rebuild. 

Example of previous behavior, assuming there is an installation of libelf with hash beginning `lgv` built with `cflags="-g -O0"`:
```
$ spack spec libdwarf ldflags=-g ^\lgv
Input spec
--------------------------------
libdwarf ldflags="-g" 
    ^libelf@0.8.13%gcc@4.4.7 cflags="-g -O0"  arch=linux-rhel6-x86_64 

Normalized
--------------------------------
libdwarf ldflags="-g" 
    ^libelf@0.8.13%gcc@4.4.7 cflags="-g -O0"  arch=linux-rhel6-x86_64 

Concretized
--------------------------------
libdwarf@20160507%gcc@4.4.7 ldflags="-g"  arch=linux-rhel6-x86_64 
    ^libelf@0.8.13%gcc@4.4.7 cflags="-g -O0"  ldflags="-g"  arch=linux-rhel6-x86_64
``` 
Fixed behavior:
```
$ spack spec libdwarf ldflags=-g ^/lgv
Input spec
--------------------------------
libdwarf ldflags="-g" 
    ^libelf@0.8.13%gcc@4.4.7 cflags="-g -O0"  arch=linux-rhel6-x86_64 

Normalized
--------------------------------
libdwarf ldflags="-g" 
    ^libelf@0.8.13%gcc@4.4.7 cflags="-g -O0"  arch=linux-rhel6-x86_64 

Concretized
--------------------------------
libdwarf@20160507%gcc@4.4.7 ldflags="-g"  arch=linux-rhel6-x86_64 
    ^libelf@0.8.13%gcc@4.4.7 cflags="-g -O0"  arch=linux-rhel6-x86_64
```