### PR TITLE
[WIP] Prevent ignoring compiler concretization preferences

### DIFF
--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -118,6 +118,9 @@ class DefaultConcretizer(object):
         # use that spec to calibrate compiler compatibility.
         abi_exemplar = find_spec(spec, lambda x: x.compiler, spec.root)
 
+        if not abi_exemplar.compiler:
+            return [spec]
+
         # Sort candidates from most to least compatibility.
         #   We reverse because True > False.
         #   Sort is stable, so candidates keep their order.


### PR DESCRIPTION
Say our file packages.yaml looks like this:
```yaml
packages:
  all:
    compiler: [gcc, intel, pgi, clang, xl, nag]
    providers:
      mpi: [openmpi, mpich]
  openmpi:
    paths:
      openmpi@1.8.4%gcc@4.8: /some/path/openmpi-1.8.4-gcc48
      openmpi@1.8.4%gcc@4.9:  /some/path/openmpi-1.8.4-gcc49
      openmpi@1.8.4%gcc@5.1:  /some/path/openmpi-1.8.4-gcc51
      openmpi@1.8.4%gcc@6.2:  /some/path/openmpi-1.8.4-gcc62
      openmpi@1.8.4%gcc@7.1:  /some/path/openmpi-1.8.4-gcc71
      openmpi@1.8.4%intel@14:  /some/path/openmpi-1.8.4-intel14
      openmpi@1.8.4%nag@6.0:  /some/path/openmpi-1.8.4-static-nag60
      openmpi@1.10.1%intel@16:  /some/path/openmpi-1.10.1_mlx-intel16
      openmpi@1.10.2%intel@14:  /some/path/openmpi-1.10.2_mlx-intel14
      openmpi@1.10.2%intel@16:  /some/path/openmpi-1.10.2_mlx-intel16
      openmpi@1.10.2%nag@6.0:  /some/path/openmpi-1.10.2_mlx-static-nag60
    buildable: False
```
Now, if we want to install a package 'A' (which depends on mpi, of course) relying on the compiler concretization preferencies:
```
spack install A
```
we get the following error:
```
==> Error: No compilers with spec intel@14 found
```

This happens because Intel compiler is the most ABI compatible to nothing. =)

My solution to the problem is the following: if the input spec does not have any information about the compiler yet, we should just wait untill the situation becomes more clear. I hope that I understood the logic of this part of the code correctly.