### PR TITLE
Prevent concretization of external packages

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1602,6 +1602,10 @@ class Spec(object):
 
         if self.name in visited:
             return False
+        visited.add(self.name)
+
+        if self.external:
+            return False
 
         changed = False
 
@@ -1626,7 +1630,6 @@ class Spec(object):
                      spack.concretizer.concretize_variants(self)))
             presets[self.name] = self
 
-        visited.add(self.name)
         return changed
 
     def _replace_with(self, concrete):
@@ -1713,7 +1716,6 @@ class Spec(object):
                         changed = True
                         spec._dependencies = DependencyMap(spec)
                     replacement._dependencies = DependencyMap(replacement)
-                    replacement.architecture = self.architecture
 
                 # TODO: could this and the stuff in _dup be cleaned up?
                 def feq(cfield, sfield):

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -328,6 +328,15 @@ class TestConcretize(object):
         assert spec['externaltool'].compiler.satisfies('gcc')
         assert spec['stuff'].compiler.satisfies('gcc')
 
+    def test_external_with_unspecified_default_false_variant(self):
+        """This tests concretization under the following conditions:
+           A spec X->Y is chosen, enabling a variant on Y that is false by
+           default; Y is provided as an external but the variant is not
+           specified in packages.yaml.
+        """
+        spec = Spec('externaltest ^externaltool+v1')
+        spec.concretize()
+
     def test_find_spec_parents(self):
         """Tests the spec finding logic used by concretization. """
         s = Spec('a +foo',

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -336,6 +336,7 @@ class TestConcretize(object):
         """
         spec = Spec('externaltest ^externaltool+v1')
         spec.concretize()
+        assert 'externaltool~v1' not in spec
 
     def test_find_spec_parents(self):
         """Tests the spec finding logic used by concretization. """

--- a/var/spack/repos/builtin.mock/packages/externaltool/package.py
+++ b/var/spack/repos/builtin.mock/packages/externaltool/package.py
@@ -31,6 +31,8 @@ class Externaltool(Package):
 
     version('1.0', '1234567890abcdef1234567890abcdef')
 
+    variant('v1', default=False, description='Test variant')
+
     depends_on('externalprereq')
 
     def install(self, spec, prefix):


### PR DESCRIPTION
This addresses one of the issues brought up in https://github.com/LLNL/spack/issues/4913, specifically https://github.com/LLNL/spack/issues/4913#issuecomment-318433432 - concretization would erroneously report a conflict between the variant settings on an external package and what the dependents require if they are not specified in packages.yaml.

This solution is more drastic than is strictly required but IMO there shouldn't be any concretization of external packages. One of the consequences of this change is that packages specified as external modules must identify their compiler and architecture.