### PR TITLE
Adding NEURON simulator package

### DIFF
--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -110,18 +110,21 @@ class Neuron(Package):
         options = []
 
         if spec.satisfies('+python'):
-            options.append('--with-nrnpython=%s' % spec['python'].command.path)
-            options.append('--disable-pysetup')
-
-            # provide PYINCDIR and PYLIBDIR
+            python_exec = spec['python'].command.path
             py_inc = spec['python'].headers.directories[0]
             py_lib = spec['python'].prefix.lib
 
             if not os.path.isdir(py_lib):
                 py_lib = spec['python'].prefix.lib64
 
-            options.extend(['PYINCDIR=%s' % py_inc,
+            options.extend(['--with-nrnpython=%s' % python_exec,
+                            '--disable-pysetup',
+                            'PYINCDIR=%s' % py_inc,
                             'PYLIBDIR=%s' % py_lib])
+
+            if spec.satisfies('~cross-compile'):
+                options.append('PYTHON_BLD=%s' % python_exec)
+
         else:
             options.append('--without-nrnpython')
 

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -99,6 +99,8 @@ class Neuron(Package):
             arch = 'powerpc64'
         elif 'cray' in self.spec.architecture:
             arch = 'x86_64'
+        elif 'ppc64le' in self.spec.architecture:
+            arch = 'powerpc64le'
         else:
             arch = self.spec.architecture.target
 

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -192,7 +192,7 @@ class Neuron(Package):
         cxx_compiler = spack_cxx
 
         # for bg-q we can't set XL as CC and CXX compiler
-        if 'bgq' in self.spec.architecture:
+        if 'bgq' in self.spec.architecture and self.spec.satisfies('+mpi'):
             c_compiler = spec['mpi'].mpicc
             cxx_compiler = spec['mpi'].mpicxx
 

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -60,7 +60,7 @@ class Neuron(Package):
     depends_on('python@2.6:', when='+python')
     depends_on('mpi', when='+mpi')
 
-    # bg-q platform expects mpi enabled build
+    # bg-q platform build expects mpi enabled
     conflicts('~mpi', when='platform=bgq')
 
     # pgi builds only shared library
@@ -180,20 +180,11 @@ class Neuron(Package):
         make('install')
 
     def install(self, spec, prefix):
-        c_compiler = spack_cc
-        cxx_compiler = spack_cxx
-
-        # TODO: check if bg-q can't set XL as CC and CXX compiler
-        if 'bgq' in self.spec.architecture and self.spec.satisfies('+mpi'):
-            c_compiler = spec['mpi'].mpicc
-            cxx_compiler = spec['mpi'].mpicxx
 
         options = ['--prefix=%s' % prefix,
                    '--without-iv',
                    '--without-x',
-                   '--without-readline',
-                   'CC=%s' % c_compiler,
-                   'CXX=%s' % cxx_compiler]
+                   '--without-readline']
 
         if spec.satisfies('+multisend'):
             options.append('--with-multisend')

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import os
-import sys
 from spack import *
 
 

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -214,3 +214,7 @@ class Neuron(Package):
     def setup_environment(self, spack_env, run_env):
         arch = self.get_arch_dir()
         run_env.prepend_path('PATH', join_path(self.prefix, arch, 'bin'))
+
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        arch = self.get_arch_dir()
+        spack_env.prepend_path('PATH', join_path(self.prefix, arch, 'bin'))

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -1,0 +1,236 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+import os
+import sys
+from spack import *
+
+
+class Neuron(Package):
+
+    """NEURON is a simulation environment for modeling individual
+    and networks of neurons. NEURON models individual neurons via
+    the use of sections that are automatically subdivided into individual
+    compartments, instead of requiring the user to manually create
+    compartments. The primary scripting language is hoc but a Python
+    interface is also available."""
+
+    homepage = "https://www.neuron.yale.edu/"
+    url      = "http://www.neuron.yale.edu/ftp/neuron/versions/v7.4/nrn-7.4.tar.gz"
+    github   = "https://github.com/nrnhines/nrn"
+
+    version('7.4', '2c0bbee8a9e55d60fa26336f4ab7acbf')
+    version('7.3', '993e539cb8bf102ca52e9fefd644ab61')
+    version('7.2', '5486709b6366add932e3a6d141c4f7ad')
+    version('develop', git=github, preferred=True)
+
+    variant('mpi',           default=True,  description='Enable MPI parallelism')
+    variant('python',        default=True,  description='Enable python')
+    variant('static',        default=True,  description='Build static libraries')
+    variant('cross-compile', default=False, description='Build for cross-compile environment')
+    variant('multisend',     default=True, description="Enable multi-send spike exchange")
+
+    depends_on('automake',   type='build')
+    depends_on('autoconf',   type='build')
+    depends_on('libtool',    type='build')
+    depends_on('pkg-config', type='build')
+    depends_on('python@2.6:', when='+python')
+    depends_on('mpi', when='+mpi')
+
+    # on bg-q mpi needs to be enabled : todo test this
+    conflicts('~mpi', when='platform=bgq')
+
+    # pgi compiler can't build static libraries
+    conflicts('%pgi', when='+static')
+
+    def url_for_version(self, version):
+        url = "http://www.neuron.yale.edu/ftp/neuron/versions/v{0}/nrn-{0}.tar.gz"
+        return url.format(version, version)
+
+    def patch(self):
+        # neuron use aclocal which need complete include path especially on os x
+        pkgconfig_inc = '-I %s/share/aclocal/' % (self.spec['pkg-config'].prefix)
+        libtool_inc = '-I %s/share/aclocal/' % (self.spec['libtool'].prefix)
+        newpath = 'aclocal -I m4 %s %s' % (pkgconfig_inc, libtool_inc)
+        filter_file(r'aclocal -I m4', r'%s' % newpath, "build.sh")
+
+    def get_arch_options(self, spec):
+        options = []
+
+        if 'bgq' in self.spec.architecture:
+            options.extend(['--enable-bluegeneQ',
+                            '--host=powerpc64',
+                            '--without-memacs'])
+
+        if 'cray' in self.spec.architecture:
+            options.extend(['--without-memacs',
+                            '--without-nmodl',
+                            'cross_compiling=yes'])
+
+            # TODO: on cray systems we get an error while linking even if
+            # we use cc wrapper. Hence add explicitly add mpi library
+            if spec.satisfies('+mpi'):
+                options.append('LIBS=-lmpich')
+
+            # TODO: -pthread is not a valid pthread option for cray compiler.
+            # for now disable use of pthread with cray compiler.
+            if spec.satisfies('%cce'):
+                options.append('use_pthread=no')
+
+        return options
+
+    def get_opt_flags(self):
+        if 'bgq' in self.spec.architecture:
+            return '-O3 -qtune=qp -qarch=qp -q64 -qstrict -qnohot -g'
+        else:
+            return '-O2 -g'
+
+    def get_arch_dir(self):
+        if 'bgq' in self.spec.architecture:
+            arch = 'powerpc64'
+        elif 'cray' in self.spec.architecture:
+            arch = 'x86_64'
+        else:
+            arch = self.spec.architecture.target
+
+        return arch
+
+    def get_python_options(self, spec):
+        options = []
+
+        if spec.satisfies('+python'):
+            py_prefix = spec['python'].prefix
+            py_version = 'python{0}'.format(spec['python'].version.up_to(2))
+            python_exec = '%s/bin/%s' % (py_prefix, py_version)
+
+            options.append('--with-nrnpython=%s' % python_exec)
+            options.append('--disable-pysetup')
+
+            if spec.satisfies('+cross-compile'):
+                # on cross compile builds we have to provide
+                # PYINCDIR, PYLIB, PYLIBDIR etc
+
+                py_lib = spec['python'].prefix.lib
+                py_inc = '%s/include/%s' % (py_prefix, py_version)
+
+                if not os.path.isdir(py_lib):
+                    py_lib = spec['python'].prefix.lib64
+
+                options.extend(['PYINCDIR=%s' % (py_inc),
+                                'PYLIB=-L%s -l%s' % (py_lib, py_version),
+                                'PYLIBDIR=%s' % py_lib,
+                                'PYLIBLINK=-L%s -l%s' % (py_lib, py_version)])
+        else:
+            options.append('--without-nrnpython')
+        return options
+
+    def get_compiler_options(self, spec):
+        options = []
+        flags = self.get_opt_flags()
+
+        # TODO: issue with static build and pgi compiler.
+        # need to add fpic and enabled-shared
+        if spec.satisfies('%pgi'):
+            options.extend(['CFLAGS=-fPIC %s' % flags,
+                            'CXXFLAGS=-fPIC %s' % flags,
+                            '--enable-shared'])
+        else:
+            options.extend(['CFLAGS=%s' % flags,
+                            'CXXFLAGS=%s' % flags])
+
+        return options
+
+    def get_configure_options(self, spec):
+        options = []
+
+        if spec.satisfies('+static'):
+            options.extend(['--disable-shared',
+                            'linux_nrnmech=no'])
+
+        # on os-x disable building carbon 'click' utility (deprecated)
+        if(sys.platform == 'darwin'):
+            options.extend(['macdarwin=no'])
+
+        options.extend(self.get_arch_options(spec))
+        options.extend(self.get_python_options(spec))
+        options.extend(self.get_compiler_options(spec))
+        return options
+
+    def build_nmodl(self, spec, prefix):
+        # TODO: NEURON has two stage compilation for systems
+        # like cray and bg-q. On these platforms it's ok to
+        # use gcc and g++ as front-end compilers.
+        options = ['--prefix=%s' % prefix,
+                   '--with-nmodl-only',
+                   '--without-x',
+                   'CC=%s' % which("gcc"),
+                   'CXX=%s' % which("g++")]
+
+        configure = Executable(join_path(self.stage.source_path, 'configure'))
+        configure(*options)
+        make()
+        make('install')
+
+    def install(self, spec, prefix):
+        c_compiler = spack_cc
+        cxx_compiler = spack_cxx
+
+        # for bg-q we can't set XL as CC and CXX compiler
+        if 'bgq' in self.spec.architecture:
+            c_compiler = spec['mpi'].mpicc
+            cxx_compiler = spec['mpi'].mpicxx
+
+        options = ['--prefix=%s' % prefix,
+                   '--without-iv',
+                   '--without-x',
+                   '--without-readline',
+                   '--disable-rx3d',
+                   'CC=%s' % c_compiler,
+                   'CXX=%s' % cxx_compiler]
+
+        if spec.satisfies('+multisend'):
+            options.append('--with-multisend')
+
+        if spec.satisfies('+mpi'):
+            options.extend(['MPICC=%s' % spec['mpi'].mpicc,
+                            'MPICXX=%s' % spec['mpi'].mpicxx,
+                            '--with-paranrn'])
+        else:
+            options.append('--without-paranrn')
+
+        options.extend(self.get_configure_options(spec))
+        build = Executable('./build.sh')
+        build()
+
+        with working_dir('build', create=True):
+            if spec.satisfies('+cross-compile'):
+                self.build_nmodl(spec, prefix)
+            configure = Executable(join_path(self.stage.source_path, 'configure'))
+            configure(*options)
+            make()
+            make('install')
+
+    def setup_environment(self, spack_env, run_env):
+        arch = self.get_arch_dir()
+        run_env.prepend_path('PATH', join_path(self.prefix, arch, 'bin'))

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -49,7 +49,7 @@ class Neuron(Package):
     variant('python',        default=True,  description='Enable python')
     variant('static',        default=True,  description='Build static libraries')
     variant('cross-compile', default=False, description='Build for cross-compile environment')
-    variant('multisend',     default=True, description="Enable multi-send spike exchange")
+    variant('multisend',     default=True,  description="Enable multi-send spike exchange")
 
     depends_on('automake',   type='build')
     depends_on('autoconf',   type='build')
@@ -69,10 +69,10 @@ class Neuron(Package):
         return url.format(version, version)
 
     def patch(self):
-        # neuron use aclocal which need complete include path especially on os x
-        pkgconfig_inc = '-I %s/share/aclocal/' % (self.spec['pkg-config'].prefix)
+        # aclocal need complete include path especially on os x
+        pkgconf_inc = '-I %s/share/aclocal/' % (self.spec['pkg-config'].prefix)
         libtool_inc = '-I %s/share/aclocal/' % (self.spec['libtool'].prefix)
-        newpath = 'aclocal -I m4 %s %s' % (pkgconfig_inc, libtool_inc)
+        newpath = 'aclocal -I m4 %s %s' % (pkgconf_inc, libtool_inc)
         filter_file(r'aclocal -I m4', r'%s' % newpath, "build.sh")
 
     def get_arch_options(self, spec):
@@ -226,7 +226,8 @@ class Neuron(Package):
         with working_dir('build', create=True):
             if spec.satisfies('+cross-compile'):
                 self.build_nmodl(spec, prefix)
-            configure = Executable(join_path(self.stage.source_path, 'configure'))
+            srcpath = self.stage.source_path
+            configure = Executable(join_path(srcpath, 'configure'))
             configure(*options)
             make()
             make('install')

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -64,9 +64,6 @@ class Neuron(Package):
     depends_on('python@2.6:', when='+python')
     depends_on('ncurses',     when='~cross-compile')
 
-    conflicts('~mpi', when='platform=bgq')
-    conflicts('%pgi', when='~shared')
-
     def patch(self):
         # aclocal need complete include path (especially on os x)
         pkgconf_inc = '-I %s/share/aclocal/' % (self.spec['pkg-config'].prefix)
@@ -134,6 +131,9 @@ class Neuron(Package):
 
         if 'bgq' in self.spec.architecture:
             flags = '-O3 -qtune=qp -qarch=qp -q64 -qstrict -qnohot -g'
+
+        if self.spec.satisfies('%pgi'):
+            flags += ' ' + self.compiler.pic_flag
 
         return ['CFLAGS=%s' % flags,
                 'CXXFLAGS=%s' % flags]

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -43,7 +43,7 @@ class Neuron(Package):
     version('7.4', '2c0bbee8a9e55d60fa26336f4ab7acbf')
     version('7.3', '993e539cb8bf102ca52e9fefd644ab61')
     version('7.2', '5486709b6366add932e3a6d141c4f7ad')
-    version('develop', git=github)
+    version('develop', git=github, preferred=True)
 
     variant('mpi',           default=True,  description='Enable MPI parallelism')
     variant('python',        default=True,  description='Enable python')

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -50,6 +50,7 @@ class Neuron(Package):
     variant('static',        default=True,  description='Build static libraries')
     variant('cross-compile', default=False, description='Build for cross-compile environment')
     variant('multisend',     default=True,  description="Enable multi-send spike exchange")
+    variant('rx3d',          default=False, description="Enable cython translated 3-d rxd")
 
     depends_on('automake',   type='build')
     depends_on('autoconf',   type='build')
@@ -205,12 +206,14 @@ class Neuron(Package):
                    '--without-iv',
                    '--without-x',
                    '--without-readline',
-                   '--disable-rx3d',
                    'CC=%s' % c_compiler,
                    'CXX=%s' % cxx_compiler]
 
         if spec.satisfies('+multisend'):
             options.append('--with-multisend')
+
+        if spec.satisfies('~rx3d'):
+            options.append('--disable-rx3d')
 
         if spec.satisfies('+mpi'):
             options.extend(['MPICC=%s' % spec['mpi'].mpicc,

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -43,11 +43,11 @@ class Neuron(Package):
     version('7.4', '2c0bbee8a9e55d60fa26336f4ab7acbf')
     version('7.3', '993e539cb8bf102ca52e9fefd644ab61')
     version('7.2', '5486709b6366add932e3a6d141c4f7ad')
-    version('develop', git=github, preferred=True)
+    version('develop', git=github)
 
     variant('mpi',           default=True,  description='Enable MPI parallelism')
     variant('python',        default=True,  description='Enable python')
-    variant('static',        default=True,  description='Build static libraries')
+    variant('shared',        default=False, description='Build shared libraries')
     variant('cross-compile', default=False, description='Build for cross-compile environment')
     variant('multisend',     default=True,  description="Enable multi-send spike exchange")
     variant('rx3d',          default=False, description="Enable cython translated 3-d rxd")
@@ -63,7 +63,7 @@ class Neuron(Package):
     conflicts('~mpi', when='platform=bgq')
 
     # pgi compiler can't build static libraries
-    conflicts('%pgi', when='+static')
+    conflicts('%pgi', when='~shared')
 
     def patch(self):
         # aclocal need complete include path especially on os x
@@ -149,19 +149,17 @@ class Neuron(Package):
         # need to add fpic and enabled-shared
         if spec.satisfies('%pgi'):
             flags += ' ' + self.compiler.pic_flag
-            options.extend(['CFLAGS=%s' % flags,
-                            'CXXFLAGS=%s' % flags,
-                            '--enable-shared'])
-        else:
-            options.extend(['CFLAGS=%s' % flags,
-                            'CXXFLAGS=%s' % flags])
+            options.append('--enable-shared')
+
+        options.extend(['CFLAGS=%s' % flags,
+                        'CXXFLAGS=%s' % flags])
 
         return options
 
     def get_configure_options(self, spec):
         options = []
 
-        if spec.satisfies('+static'):
+        if spec.satisfies('~shared'):
             options.extend(['--disable-shared',
                             'linux_nrnmech=no'])
 

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -53,12 +53,17 @@ class Neuron(Package):
     variant('multisend',     default=True,  description="Enable multi-send spike exchange")
     variant('rx3d',          default=False, description="Enable cython translated 3-d rxd")
 
+    depends_on('flex',       type='build')
+    depends_on('bison',      type='build')
+    depends_on('automake',   type='build')
     depends_on('automake',   type='build')
     depends_on('autoconf',   type='build')
     depends_on('libtool',    type='build')
     depends_on('pkg-config', type='build')
+
+    depends_on('mpi',         when='+mpi')
     depends_on('python@2.6:', when='+python')
-    depends_on('mpi', when='+mpi')
+    depends_on('ncurses',     when='~cross-compile')
 
     conflicts('~mpi', when='platform=bgq')
     conflicts('%pgi', when='~shared')


### PR DESCRIPTION
This is still based on `Package` and not on `AutotoolsPackage `. For cross-compiling environment we need to follow two step compilation process and hence it's bit complicated (but still doable). In it's current format it has been tested on all platforms (OS X, Linux, BG-Q, Cray, KNL) and hence submitting this in the current form.