### PR TITLE
Enable creation of mirrors for systems with different compilers

### DIFF
--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -164,6 +164,7 @@ def mirror_create(args):
     """Create a directory to be used as a spack mirror, and fill it with
        package archives."""
     # try to parse specs from the command line first.
+    spack.concretizer.disable_compiler_existence_check()
     specs = spack.cmd.parse_specs(args.specs, concretize=True)
 
     # If there is a file, parse each line as a spec and add it to the list.

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -58,6 +58,9 @@ class DefaultConcretizer(object):
     def disable_compiler_existence_check(self):
         self.check_for_compiler_existence = False
 
+    def enable_compiler_existence_check(self):
+        self.check_for_compiler_existence = True
+
     def _valid_virtuals_and_externals(self, spec):
         """Returns a list of candidate virtual dep providers and external
            packages that coiuld be used to concretize a spec.

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -291,12 +291,7 @@ class DefaultConcretizer(object):
         def _proper_compiler_style(cspec, aspec):
             return spack.compilers.compilers_for_spec(cspec, arch_spec=aspec)
 
-        all_compiler_specs = spack.compilers.all_compiler_specs()
-        if self.check_for_compiler_existence and not all_compiler_specs:
-            raise spack.compilers.NoCompilersError()
-
-        if (spec.compiler and
-                spec.compiler.concrete):
+        if spec.compiler and spec.compiler.concrete:
             if (self.check_for_compiler_existence and not
                     _proper_compiler_style(spec.compiler, spec.architecture)):
                 _compiler_concretization_failure(
@@ -315,11 +310,15 @@ class DefaultConcretizer(object):
             spec.compiler = other_compiler.copy()
             return True
 
+        all_compiler_specs = spack.compilers.all_compiler_specs()
         if not all_compiler_specs:
-            # At this point we know we don't have sufficient hints to form
-            # a full compiler spec so we must choose among the available
-            # compilers. Therefore even if the compiler existence check is
-            # disabled, compilers must be available at this point
+            # If compiler existence checking is disabled, then we would have
+            # exited by now if there were sufficient hints to form a full
+            # compiler spec. Therefore even if compiler existence checking is
+            # disabled, compilers must be available at this point because the
+            # available compilers are used to choose a compiler. If compiler
+            # existence checking is enabled then some compiler must exist in
+            # order to complete the spec.
             raise spack.compilers.NoCompilersError()
 
         if other_compiler in all_compiler_specs:

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -158,6 +158,16 @@ class TestConcretize(object):
         concrete = check_concretize('mpileaks   ^mpich2@1.3.1:1.4')
         assert concrete['mpich2'].satisfies('mpich2@1.3.1:1.4')
 
+    def test_concretize_disable_compiler_existence_check(self):
+        with pytest.raises(spack.concretize.UnavailableCompilerVersionError):
+            check_concretize('python %gcc@100.100')
+
+        try:
+            spack.concretizer.disable_compiler_existence_check()
+            check_concretize('python %gcc@100.100')
+        finally:
+            spack.concretizer.enable_compiler_existence_check()
+
     def test_concretize_with_provides_when(self):
         """Make sure insufficient versions of MPI are not in providers list when
         we ask for some advanced version.

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -160,11 +160,13 @@ class TestConcretize(object):
 
     def test_concretize_disable_compiler_existence_check(self):
         with pytest.raises(spack.concretize.UnavailableCompilerVersionError):
-            check_concretize('python %gcc@100.100')
+            check_concretize('dttop %gcc@100.100')
 
         try:
             spack.concretizer.disable_compiler_existence_check()
-            check_concretize('python %gcc@100.100')
+            spec = check_concretize('dttop %gcc@100.100')
+            assert spec.satisfies('%gcc@100.100')
+            assert spec['dtlink3'].satisfies('%gcc@100.100')
         finally:
             spack.concretizer.enable_compiler_existence_check()
 


### PR DESCRIPTION
Fixes #5147

When creating a mirror with ```spack mirror create <spec>``` the spec should be able to specify compilers and operating systems that don't exist on the current system. This disables compiler existence checks for ```spack mirror create```.