### PR TITLE
support intel composer 2015 directory structure

### DIFF
--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -447,6 +447,13 @@ class IntelParallelStudio(IntelPackage):
             spack_env.set('I_MPI_F90', spack_f77)
             spack_env.set('I_MPI_FC',  spack_fc)
 
+            # Make sure the mpicc executable appears in the path
+            if self.prefix == self.intel_prefix:  # composer 2015
+                bindir = self.intel_prefix.impi_latest.intel64.bin
+            else:
+                bindir = self.intel_prefix.mpi.intel64.bin
+            spack_env.prepend_path('PATH', bindir)
+
         # set up MKLROOT for everyone using MKL package
         if '+mkl' in self.spec:
             mkl_root = self.intel_prefix.mkl.lib.intel64  # noqa

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -157,7 +157,6 @@ class IntelParallelStudio(IntelPackage):
     @property
     def blas_libs(self):
         spec = self.spec
-        prefix = self.prefix
         shared = '+shared' in spec
 
         if '+ilp64' in spec:
@@ -452,7 +451,7 @@ class IntelParallelStudio(IntelPackage):
         if '+mkl' in self.spec:
             mkl_root = self.intel_prefix.mkl.lib.intel64  # noqa
 
-            spack_env.set('MKLROOT', mkl_root)
+            spack_env.set('MKLROOT', self.prefix)
             spack_env.append_path('SPACK_COMPILER_EXTRA_RPATHS', mkl_root)
 
     def setup_dependent_package(self, module, dep_spec):

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -148,6 +148,13 @@ class IntelParallelStudio(IntelPackage):
     conflicts('+vtune',     when='@composer.0:composer.9999')
 
     @property
+    def intel_prefix(self):
+        if self.version[0] == "composer" and self.version[1] == 2015:
+            return self.prefix
+        else:
+            return self.prefix.compilers_and_libraries.linux
+
+    @property
     def blas_libs(self):
         spec = self.spec
         prefix = self.prefix
@@ -167,7 +174,7 @@ class IntelParallelStudio(IntelPackage):
                 mkl_threading = ['libmkl_intel_thread']
                 omp_threading = ['libiomp5']
 
-                omp_root = prefix.compilers_and_libraries.linux.lib.intel64
+                omp_root = self.intel_prefix.lib.intel64
                 omp_libs = find_libraries(
                     omp_threading, root=omp_root, shared=shared)
             elif '%gcc' in spec:
@@ -180,7 +187,7 @@ class IntelParallelStudio(IntelPackage):
 
         # TODO: TBB threading: ['libmkl_tbb_thread', 'libtbb', 'libstdc++']
 
-        mkl_root = prefix.compilers_and_libraries.linux.mkl.lib.intel64
+        mkl_root = self.intel_prefix.mkl.lib.intel64
 
         mkl_libs = find_libraries(
             mkl_integer + ['libmkl_core'] + mkl_threading,
@@ -220,7 +227,7 @@ class IntelParallelStudio(IntelPackage):
             raise InstallError('No MPI found for scalapack')
 
         integer = 'ilp64' if '+ilp64' in self.spec else 'lp64'
-        mkl_root = self.prefix.compilers_and_libraries.linux.mkl.lib.intel64
+        mkl_root = self.intel_prefix.mkl.lib.intel64
         shared = True if '+shared' in self.spec else False
 
         libs = find_libraries(
@@ -232,7 +239,10 @@ class IntelParallelStudio(IntelPackage):
 
     @property
     def mpi_libs(self):
-        mpi_root = self.prefix.compilers_and_libraries.linux.mpi.lib64
+        if self.prefx == self.intel_prefix:  # composer 2015
+            mpi_root = self.intel_prefix.impi_latest.intel64.lib
+        else:
+            mpi_root = self.intel_prefix.mpi.lib64
         query_parameters = self.spec.last_query.extra_parameters
         libraries = ['libmpifort', 'libmpi']
 
@@ -247,7 +257,10 @@ class IntelParallelStudio(IntelPackage):
     def mpi_headers(self):
         # recurse from self.prefix will find too many things for all the
         # supported sub-architectures like 'mic'
-        mpi_root = self.prefix.compilers_and_libraries.linux.mpi.include64
+        if self.prefix == self.intel_prefix:  # composer 2015
+            mpi_root = self.intel_prefix.impi_latest.include64
+        else:
+            mpi_root = self.intel_prefix.mpi.include64
         return find_headers('mpi', root=mpi_root, recurse=False)
 
     @property
@@ -437,9 +450,9 @@ class IntelParallelStudio(IntelPackage):
 
         # set up MKLROOT for everyone using MKL package
         if '+mkl' in self.spec:
-            mkl_root = self.prefix.compilers_and_libraries.linux.mkl.lib.intel64  # noqa
+            mkl_root = self.intel_prefix.mkl.lib.intel64  # noqa
 
-            spack_env.set('MKLROOT', self.prefix)
+            spack_env.set('MKLROOT', mkl_root)
             spack_env.append_path('SPACK_COMPILER_EXTRA_RPATHS', mkl_root)
 
     def setup_dependent_package(self, module, dep_spec):
@@ -456,7 +469,10 @@ class IntelParallelStudio(IntelPackage):
             # and friends are set to point to the Intel compilers, but in
             # practice, mpicc fails to compile some applications while
             # mpiicc works.
-            bindir = self.prefix.compilers_and_libraries.linux.mpi.intel64.bin
+            if self.prefix == self.intel_prefix:  # composer 2015
+                bindir = self.intel_prefix.impi_latest.intel64.bin
+            else:
+                bindir = self.intel_prefix.mpi.intel64.bin
 
             if self.compiler.name == 'intel':
                 self.spec.mpicc  = bindir.mpiicc


### PR DESCRIPTION
Directory structure for intel composer 2015 (installed externally) has very different path structure.  @adamjstewart and I need other people to weigh in on their directory structures, I specifically had `composer` from `2015`, so we chose that.  He had access to 2017 installations.

```console
$ ls -al /usr/local/intel
total 48K
drwxr-xr-x. 12 root root 4.0K Aug 26  2015 ./
drwxr-xr-x. 15 root root 4.0K Aug 26  2015 ../
lrwxrwxrwx.  1 root root   45 Aug 26  2015 advisor_xe -> /usr/local/intel//advisor_xe_2015.1.10.380555/
lrwxrwxrwx.  1 root root   45 Aug 26  2015 advisor_xe_2015 -> /usr/local/intel//advisor_xe_2015.1.10.380555/
drwxr-xr-x. 15 root root 4.0K Aug 26  2015 advisor_xe_2015.1.10.380555/
drwxr-xr-x.  2 root root 4.0K Aug 26  2015 bin/
lrwxrwxrwx.  1 root root   16 Aug 26  2015 composerxe -> composer_xe_2015/
drwxr-xr-x.  3 root root 4.0K Aug 26  2015 composer_xe_2015/
drwxr-xr-x. 14 root root 4.0K Apr 10  2015 composer_xe_2015.3.187/
drwxr-xr-x.  3 root root 4.0K Aug 26  2015 imb/
lrwxrwxrwx.  1 root root   31 Aug 26  2015 imb_4.0.3 -> /usr/local/intel/imb/4.0.3.032//
lrwxrwxrwx.  1 root root   31 Aug 26  2015 imb_latest -> /usr/local/intel/imb/4.0.3.032//
drwxr-xr-x.  3 root root 4.0K Aug 26  2015 impi/
lrwxrwxrwx.  1 root root   32 Aug 26  2015 impi_5.0.3 -> /usr/local/intel/impi/5.0.3.048//
lrwxrwxrwx.  1 root root   32 Aug 26  2015 impi_latest -> /usr/local/intel/impi/5.0.3.048//
lrwxrwxrwx.  1 root root   18 Aug 26  2015 include -> composerxe/include/
lrwxrwxrwx.  1 root root   46 Aug 26  2015 inspector_xe -> /usr/local/intel//inspector_xe_2015.1.2.379161/
lrwxrwxrwx.  1 root root   46 Aug 26  2015 inspector_xe_2015 -> /usr/local/intel//inspector_xe_2015.1.2.379161/
drwxr-xr-x. 15 root root 4.0K Aug 26  2015 inspector_xe_2015.1.2.379161/
lrwxrwxrwx.  1 root root   14 Aug 26  2015 ipp -> composerxe/ipp/
drwxr-xr-x.  3 root root 4.0K Aug 26  2015 itac/
lrwxrwxrwx.  1 root root   32 Aug 26  2015 itac_9.0.3 -> /usr/local/intel/itac/9.0.3.051//
lrwxrwxrwx.  1 root root   32 Aug 26  2015 itac_latest -> /usr/local/intel/itac/9.0.3.051//
lrwxrwxrwx.  1 root root   14 Aug 26  2015 lib -> composerxe/lib/
lrwxrwxrwx.  1 root root   14 Aug 26  2015 man -> composerxe/man/
lrwxrwxrwx.  1 root root   14 Aug 26  2015 mkl -> composerxe/mkl/
lrwxrwxrwx.  1 root root   16 Aug 26  2015 mpirt -> composerxe/mpirt/
drwxr-xr-x.  5 root root 4.0K Aug 26  2015 parallel_studio_xe_2015/
lrwxrwxrwx.  1 root root   14 Aug 26  2015 tbb -> composerxe/tbb/
lrwxrwxrwx.  1 root root   52 Aug 26  2015 vtune_amplifier_xe -> /usr/local/intel//vtune_amplifier_xe_2015.3.0.403110/
lrwxrwxrwx.  1 root root   52 Aug 26  2015 vtune_amplifier_xe_2015 -> /usr/local/intel//vtune_amplifier_xe_2015.3.0.403110/
drwxr-xr-x. 19 root root 4.0K Aug 26  2015 vtune_amplifier_xe_2015.3.0.403110/
```