### PR TITLE
Package only changes don't trigger build or unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,12 @@ jobs:
       os: linux
       language: python
       env: TEST_SUITE=flake8
-    - stage: 'unit tests + documentation'
+    - stage: 'documentation'
+      python: '2.7'
+      os: linux
+      language: python
+      env: TEST_SUITE=doc
+    - stage: 'unit tests'
       python: '2.6'
       os: linux
       language: python
@@ -47,10 +52,6 @@ jobs:
     - os: osx
       language: generic
       env: [ TEST_SUITE=unit, PYTHON_VERSION=2.7, COVERAGE=true ]
-    - python: '2.7'
-      os: linux
-      language: python
-      env: TEST_SUITE=doc
 # mpich (AutotoolsPackage)
     - stage: 'build tests'
       python: '2.7'
@@ -151,7 +152,8 @@ before_script:
 script: share/spack/qa/run-$TEST_SUITE-tests
 
 after_success:
-  - codecov --env PY_VERSION
+  # Require coverage only if there have been changes in core
+  - share/spack/qa/changes_in_core.py && codecov --env PY_VERSION
 
 #=============================================================================
 # Notifications

--- a/.travis.yml
+++ b/.travis.yml
@@ -153,6 +153,7 @@ script: share/spack/qa/run-$TEST_SUITE-tests
 
 after_success:
   # Require coverage only if there have been changes in core
+  - . share/spack/setup-env.sh
   - share/spack/qa/changes_in_core.py && codecov --env PY_VERSION
 
 #=============================================================================

--- a/lib/spack/spack/cmd/flake8.py
+++ b/lib/spack/spack/cmd/flake8.py
@@ -93,7 +93,7 @@ exemptions = dict((re.compile(file_pattern),
                   for file_pattern, error_dict in exemptions.items())
 
 
-def changed_files(args):
+def changed_files(untracked):
     """Get list of changed files in the Spack repository."""
 
     git = which('git', required=True)
@@ -108,7 +108,7 @@ def changed_files(args):
     ]
 
     # Add new files that are untracked
-    if args.untracked:
+    if untracked:
         git_args.append(['ls-files', '--exclude-standard', '--other'])
 
     excludes = [os.path.realpath(f) for f in exclude_directories]
@@ -198,7 +198,7 @@ def flake8(parser, args):
 
         with working_dir(spack.prefix):
             if not file_list:
-                file_list = changed_files(args)
+                file_list = changed_files(args.untracked)
             shutil.copy('.flake8', os.path.join(temp, '.flake8'))
 
         print('=======================================================')

--- a/share/spack/qa/changes_in_core.py
+++ b/share/spack/qa/changes_in_core.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env spack-python
+#
+# Description:
+#     Helper script that returns 0 if any file in core
+#     has been changed, 1 otherwise
+#
+# Usage:
+#     changes_in_core.py && [command to be run if there are changes in core]
+#
+
+import sys
+import os.path
+
+import spack.spec
+import spack.cmd.flake8
+
+# Get the complete list of files that changed
+files = spack.cmd.flake8.changed_files(True)
+
+# If something changed in the core libraries we need to test it
+core_path = os.path.join('lib', 'spack')
+changes_in_core = any(core_path in x for x in files)
+
+# Exit early because polling the repo may be slow
+# if changes_in_core:
+#    sys.exit(0)
+
+# If we changed any of the packages that are under build tests
+# we consider it a change in core
+
+build_tests = (
+    'mpich',
+    'astyle',
+    'tut',
+    'py-setuptools',
+    'openjpeg',
+    'r-rcpp'
+)
+
+specs = [spack.spec.Spec(x) for x in build_tests]
+for s in specs:
+    s.concretize()
+
+names = []
+for s in specs:
+    names.extend([d.name for d in s.traverse()])
+
+names = [os.path.join(x, 'package.py') for x in names]
+names = sorted(set(names))
+
+changes_in_relevant_packages = any(name in x for x in files for name in names)
+
+if changes_in_relevant_packages:
+    sys.exit(0)
+
+sys.exit(1)

--- a/share/spack/qa/changes_in_core.py
+++ b/share/spack/qa/changes_in_core.py
@@ -22,8 +22,8 @@ core_path = os.path.join('lib', 'spack')
 changes_in_core = any(core_path in x for x in files)
 
 # Exit early because polling the repo may be slow
-# if changes_in_core:
-#    sys.exit(0)
+if changes_in_core:
+    sys.exit(0)
 
 # If we changed any of the packages that are under build tests
 # we consider it a change in core

--- a/share/spack/qa/run-build-tests
+++ b/share/spack/qa/run-build-tests
@@ -15,6 +15,9 @@ check_dependencies ${coverage} git hg svn
 # Allows script to be run from anywhere
 cd "$SPACK_ROOT"
 
+# If there are no changes in core exit early
+share/spack/qa/changes_in_core.py || exit 0
+
 # Make sure we have a spec to build.
 if [ -z "$SPEC" ]; then
     echo "Error: run-build-tests requires the $SPEC to build to be set."

--- a/share/spack/qa/run-unit-tests
+++ b/share/spack/qa/run-unit-tests
@@ -17,6 +17,9 @@ check_dependencies ${coverage} git hg svn
 # Allows script to be run from anywhere
 cd "$SPACK_ROOT"
 
+# If there are no changes in core exit early
+share/spack/qa/changes_in_core.py || exit 0
+
 # Print compiler information
 spack config get compilers
 


### PR DESCRIPTION
This changeset modifies Travis configuration so that PRs with package only changes don't trigger unit-tests or build-tests, but they will exit early and fake a success instead. Consequently, coverage report is not submitted and will not be displayed for them. The time to execute a *fake test* is that of setting up the environment and varies approximately between 1-2 minutes (instead of ~10 minutes of most real tests).

A preferable alternative would be to skip these stages entirely, but [that seems not possible right now.](https://github.com/travis-ci/travis-ci/issues/7181). The major problem we still cannot get rid of is that we need in any case to wait for an OSX executor to become available - and that may mean a waiting time of even half an hour to get scheduled. 