### PR TITLE
openssl: Add perl dependency

### DIFF
--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -59,11 +59,7 @@ class Openssl(Package):
     version('1.0.1h', '8d6d684a9430d5cc98a62a5d8fbda8cf')
 
     depends_on('zlib')
-
-    # TODO: 'make test' requires Perl module Test::More version 0.96
-    # TODO: uncomment when test dependency types are supported.
-    # TODO: This is commented in the meantime to avoid dependnecy bloat.
-    # depends_on('perl@5.14.0:', type='build', when='+tests')
+    depends_on('perl@5.14.0:', type='build')
 
     parallel = False
 


### PR DESCRIPTION
perl is required for the configure script.