### PR TITLE
pkgconf migration

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -31,6 +31,7 @@ packages:
       opencl: [pocl]
       openfoam: [openfoam-com, openfoam-org, foam-extend]
       pil: [py-pillow]
+      pkgconfig: [pkgconf, pkg-config]
       scalapack: [netlib-scalapack]
       szip: [libszip, libaec]
       tbb: [intel-tbb]

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -221,10 +221,10 @@ class AutotoolsPackage(PackageBase):
             # This line is what is needed most of the time
             # --install, --verbose, --force
             autoreconf_args = ['-ivf']
-            if 'pkg-config' in spec:
+            if 'pkgconfig' in spec:
                 autoreconf_args += [
                     '-I',
-                    join_path(spec['pkg-config'].prefix, 'share', 'aclocal'),
+                    join_path(spec['pkgconfig'].prefix, 'share', 'aclocal'),
                 ]
             autoreconf_args += self.autoreconf_extra_args
             m.autoreconf(*autoreconf_args)

--- a/var/spack/repos/builtin/packages/applewmproto/package.py
+++ b/var/spack/repos/builtin/packages/applewmproto/package.py
@@ -37,5 +37,5 @@ class Applewmproto(AutotoolsPackage):
 
     version('1.4.2', 'ecc8a4424a893ce120f5652dba62e9e6')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/appres/package.py
+++ b/var/spack/repos/builtin/packages/appres/package.py
@@ -40,5 +40,5 @@ class Appres(AutotoolsPackage):
     depends_on('libxt')
 
     depends_on('xproto@7.0.17:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/atk/package.py
+++ b/var/spack/repos/builtin/packages/atk/package.py
@@ -37,7 +37,7 @@ class Atk(AutotoolsPackage):
     version('2.14.0', 'ecb7ca8469a5650581b1227d78051b8b')
 
     depends_on('glib')
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('gobject-introspection')
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/autogen/package.py
+++ b/var/spack/repos/builtin/packages/autogen/package.py
@@ -40,7 +40,7 @@ class Autogen(AutotoolsPackage):
 
     variant('xml', default=True, description='Enable XML support')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
 
     depends_on('guile@1.8:2.0')
     depends_on('libxml2', when='+xml')

--- a/var/spack/repos/builtin/packages/bdftopcf/package.py
+++ b/var/spack/repos/builtin/packages/bdftopcf/package.py
@@ -40,7 +40,7 @@ class Bdftopcf(AutotoolsPackage):
 
     depends_on('libxfont')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('xproto', type='build')
     depends_on('fontsproto', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/beforelight/package.py
+++ b/var/spack/repos/builtin/packages/beforelight/package.py
@@ -40,5 +40,5 @@ class Beforelight(AutotoolsPackage):
     depends_on('libxscrnsaver')
     depends_on('libxt')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/bigreqsproto/package.py
+++ b/var/spack/repos/builtin/packages/bigreqsproto/package.py
@@ -36,5 +36,5 @@ class Bigreqsproto(AutotoolsPackage):
 
     version('1.1.2', '9b83369ac7a5eb2bf54c8f34db043a0e')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/bitmap/package.py
+++ b/var/spack/repos/builtin/packages/bitmap/package.py
@@ -41,5 +41,5 @@ class Bitmap(AutotoolsPackage):
 
     depends_on('xbitmaps', type='build')
     depends_on('xproto@7.0.25:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -45,7 +45,7 @@ class Cairo(AutotoolsPackage):
     depends_on("glib")
     depends_on("pixman")
     depends_on("freetype")
-    depends_on("pkg-config", type="build")
+    depends_on("pkgconfig", type="build")
     depends_on("fontconfig@2.10.91:")  # Require newer version of fontconfig.
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/compositeproto/package.py
+++ b/var/spack/repos/builtin/packages/compositeproto/package.py
@@ -36,5 +36,5 @@ class Compositeproto(AutotoolsPackage):
 
     version('0.4.2', '2dea7c339432b3363faf2d29c208e7b5')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/constype/package.py
+++ b/var/spack/repos/builtin/packages/constype/package.py
@@ -37,5 +37,5 @@ class Constype(AutotoolsPackage):
 
     version('1.0.4', '2333b9ac9fd32e58b05afa651c4590a3')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/cscope/package.py
+++ b/var/spack/repos/builtin/packages/cscope/package.py
@@ -37,6 +37,6 @@ class Cscope(AutotoolsPackage):
 
     depends_on('flex', type='build')
     depends_on('bison', type='build')
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')
 
     build_targets = ['CURSES_LIBS=-lncursesw']

--- a/var/spack/repos/builtin/packages/czmq/package.py
+++ b/var/spack/repos/builtin/packages/czmq/package.py
@@ -36,7 +36,7 @@ class Czmq(AutotoolsPackage):
     depends_on('libtool', type='build')
     depends_on('automake', type='build')
     depends_on('autoconf', type='build')
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('zeromq')
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/damageproto/package.py
+++ b/var/spack/repos/builtin/packages/damageproto/package.py
@@ -36,5 +36,5 @@ class Damageproto(AutotoolsPackage):
 
     version('1.2.1', 'bf8c47b7f48625230cff155180f8ddce')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/dmxproto/package.py
+++ b/var/spack/repos/builtin/packages/dmxproto/package.py
@@ -37,5 +37,5 @@ class Dmxproto(AutotoolsPackage):
 
     version('2.3.1', '7c52af95aac192e8de31bd9a588ce121')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/dri2proto/package.py
+++ b/var/spack/repos/builtin/packages/dri2proto/package.py
@@ -37,5 +37,5 @@ class Dri2proto(AutotoolsPackage):
 
     version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/dri3proto/package.py
+++ b/var/spack/repos/builtin/packages/dri3proto/package.py
@@ -37,5 +37,5 @@ class Dri3proto(AutotoolsPackage):
 
     version('1.0', '25e84a49a076862277ee12aebd49ff5f')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/editres/package.py
+++ b/var/spack/repos/builtin/packages/editres/package.py
@@ -38,5 +38,5 @@ class Editres(AutotoolsPackage):
     depends_on('libxt')
     depends_on('libxmu')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/emacs/package.py
+++ b/var/spack/repos/builtin/packages/emacs/package.py
@@ -44,7 +44,7 @@ class Emacs(AutotoolsPackage):
         description="Select an X toolkit (gtk, athena)"
     )
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
 
     depends_on('ncurses')
     depends_on('zlib')

--- a/var/spack/repos/builtin/packages/encodings/package.py
+++ b/var/spack/repos/builtin/packages/encodings/package.py
@@ -36,7 +36,7 @@ class Encodings(Package):
     depends_on('font-util')
 
     depends_on('mkfontscale', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/evieext/package.py
+++ b/var/spack/repos/builtin/packages/evieext/package.py
@@ -36,5 +36,5 @@ class Evieext(AutotoolsPackage):
 
     version('1.1.1', '018a7d24d0c7926d594246320bcb6a86')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/exonerate/package.py
+++ b/var/spack/repos/builtin/packages/exonerate/package.py
@@ -33,7 +33,7 @@ class Exonerate(Package):
 
     version('2.4.0', '126fbade003b80b663a1d530c56f1904')
 
-    depends_on('pkg-config', type="build")
+    depends_on('pkgconfig', type="build")
     depends_on('glib')
 
     parallel = False

--- a/var/spack/repos/builtin/packages/fixesproto/package.py
+++ b/var/spack/repos/builtin/packages/fixesproto/package.py
@@ -37,5 +37,5 @@ class Fixesproto(AutotoolsPackage):
 
     version('5.0', '1b3115574cadd4cbea1f197faa7c1de4')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/folly/package.py
+++ b/var/spack/repos/builtin/packages/folly/package.py
@@ -50,7 +50,7 @@ class Folly(AutotoolsPackage):
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
     depends_on('libtool', type='build')
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')
 
     # TODO: folly requires gcc 4.9+ and a version of boost compiled with
     # TODO: C++14 support (but there's no neat way to check that these

--- a/var/spack/repos/builtin/packages/font-adobe-100dpi/package.py
+++ b/var/spack/repos/builtin/packages/font-adobe-100dpi/package.py
@@ -38,7 +38,7 @@ class FontAdobe100dpi(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-adobe-75dpi/package.py
+++ b/var/spack/repos/builtin/packages/font-adobe-75dpi/package.py
@@ -38,7 +38,7 @@ class FontAdobe75dpi(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-adobe-utopia-100dpi/package.py
+++ b/var/spack/repos/builtin/packages/font-adobe-utopia-100dpi/package.py
@@ -38,7 +38,7 @@ class FontAdobeUtopia100dpi(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-adobe-utopia-75dpi/package.py
+++ b/var/spack/repos/builtin/packages/font-adobe-utopia-75dpi/package.py
@@ -38,7 +38,7 @@ class FontAdobeUtopia75dpi(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-adobe-utopia-type1/package.py
+++ b/var/spack/repos/builtin/packages/font-adobe-utopia-type1/package.py
@@ -37,7 +37,7 @@ class FontAdobeUtopiaType1(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('mkfontscale', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-alias/package.py
+++ b/var/spack/repos/builtin/packages/font-alias/package.py
@@ -35,7 +35,7 @@ class FontAlias(Package):
 
     depends_on('font-util')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-arabic-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-arabic-misc/package.py
@@ -38,7 +38,7 @@ class FontArabicMisc(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-bh-100dpi/package.py
+++ b/var/spack/repos/builtin/packages/font-bh-100dpi/package.py
@@ -38,7 +38,7 @@ class FontBh100dpi(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-bh-75dpi/package.py
+++ b/var/spack/repos/builtin/packages/font-bh-75dpi/package.py
@@ -38,7 +38,7 @@ class FontBh75dpi(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-bh-lucidatypewriter-100dpi/package.py
+++ b/var/spack/repos/builtin/packages/font-bh-lucidatypewriter-100dpi/package.py
@@ -38,7 +38,7 @@ class FontBhLucidatypewriter100dpi(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-bh-lucidatypewriter-75dpi/package.py
+++ b/var/spack/repos/builtin/packages/font-bh-lucidatypewriter-75dpi/package.py
@@ -38,7 +38,7 @@ class FontBhLucidatypewriter75dpi(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-bh-ttf/package.py
+++ b/var/spack/repos/builtin/packages/font-bh-ttf/package.py
@@ -38,7 +38,7 @@ class FontBhTtf(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-bh-type1/package.py
+++ b/var/spack/repos/builtin/packages/font-bh-type1/package.py
@@ -38,7 +38,7 @@ class FontBhType1(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('mkfontscale', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-bitstream-100dpi/package.py
+++ b/var/spack/repos/builtin/packages/font-bitstream-100dpi/package.py
@@ -38,7 +38,7 @@ class FontBitstream100dpi(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-bitstream-75dpi/package.py
+++ b/var/spack/repos/builtin/packages/font-bitstream-75dpi/package.py
@@ -38,7 +38,7 @@ class FontBitstream75dpi(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-bitstream-speedo/package.py
+++ b/var/spack/repos/builtin/packages/font-bitstream-speedo/package.py
@@ -38,7 +38,7 @@ class FontBitstreamSpeedo(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('mkfontscale', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-bitstream-type1/package.py
+++ b/var/spack/repos/builtin/packages/font-bitstream-type1/package.py
@@ -38,7 +38,7 @@ class FontBitstreamType1(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('mkfontscale', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-cronyx-cyrillic/package.py
+++ b/var/spack/repos/builtin/packages/font-cronyx-cyrillic/package.py
@@ -38,7 +38,7 @@ class FontCronyxCyrillic(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-cursor-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-cursor-misc/package.py
@@ -38,7 +38,7 @@ class FontCursorMisc(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-daewoo-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-daewoo-misc/package.py
@@ -38,7 +38,7 @@ class FontDaewooMisc(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-dec-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-dec-misc/package.py
@@ -38,7 +38,7 @@ class FontDecMisc(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-ibm-type1/package.py
+++ b/var/spack/repos/builtin/packages/font-ibm-type1/package.py
@@ -38,7 +38,7 @@ class FontIbmType1(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('mkfontscale', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-isas-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-isas-misc/package.py
@@ -38,7 +38,7 @@ class FontIsasMisc(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-jis-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-jis-misc/package.py
@@ -38,7 +38,7 @@ class FontJisMisc(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-micro-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-micro-misc/package.py
@@ -38,7 +38,7 @@ class FontMicroMisc(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-misc-cyrillic/package.py
+++ b/var/spack/repos/builtin/packages/font-misc-cyrillic/package.py
@@ -38,7 +38,7 @@ class FontMiscCyrillic(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-misc-ethiopic/package.py
+++ b/var/spack/repos/builtin/packages/font-misc-ethiopic/package.py
@@ -38,7 +38,7 @@ class FontMiscEthiopic(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('mkfontscale', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-misc-meltho/package.py
+++ b/var/spack/repos/builtin/packages/font-misc-meltho/package.py
@@ -38,7 +38,7 @@ class FontMiscMeltho(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('mkfontscale', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-misc-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-misc-misc/package.py
@@ -38,7 +38,7 @@ class FontMiscMisc(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-mutt-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-mutt-misc/package.py
@@ -38,7 +38,7 @@ class FontMuttMisc(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-schumacher-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-schumacher-misc/package.py
@@ -38,7 +38,7 @@ class FontSchumacherMisc(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-screen-cyrillic/package.py
+++ b/var/spack/repos/builtin/packages/font-screen-cyrillic/package.py
@@ -38,7 +38,7 @@ class FontScreenCyrillic(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-sony-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-sony-misc/package.py
@@ -38,7 +38,7 @@ class FontSonyMisc(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-sun-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-sun-misc/package.py
@@ -37,7 +37,7 @@ class FontSunMisc(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-util/package.py
+++ b/var/spack/repos/builtin/packages/font-util/package.py
@@ -33,5 +33,5 @@ class FontUtil(AutotoolsPackage):
 
     version('1.3.1', 'd153a9af216e4498fa171faea2c82514')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/font-winitzki-cyrillic/package.py
+++ b/var/spack/repos/builtin/packages/font-winitzki-cyrillic/package.py
@@ -38,7 +38,7 @@ class FontWinitzkiCyrillic(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/font-xfree86-type1/package.py
+++ b/var/spack/repos/builtin/packages/font-xfree86-type1/package.py
@@ -38,7 +38,7 @@ class FontXfree86Type1(Package):
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('mkfontscale', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/fontconfig/package.py
+++ b/var/spack/repos/builtin/packages/fontconfig/package.py
@@ -37,7 +37,7 @@ class Fontconfig(AutotoolsPackage):
     depends_on('freetype')
     depends_on('gperf', type='build', when='@2.12.2:')
     depends_on('libxml2')
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('font-util')
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/fontsproto/package.py
+++ b/var/spack/repos/builtin/packages/fontsproto/package.py
@@ -33,5 +33,5 @@ class Fontsproto(AutotoolsPackage):
 
     version('2.1.3', '0415f0360e33f3202af67c6c46782251')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/fonttosfnt/package.py
+++ b/var/spack/repos/builtin/packages/fonttosfnt/package.py
@@ -37,5 +37,5 @@ class Fonttosfnt(AutotoolsPackage):
     depends_on('libfontenc')
 
     depends_on('xproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/freetype/package.py
+++ b/var/spack/repos/builtin/packages/freetype/package.py
@@ -40,7 +40,7 @@ class Freetype(AutotoolsPackage):
 
     depends_on('libpng')
     depends_on('bzip2')
-    depends_on('pkg-config@0.24:', type='build')
+    depends_on('pkgconfig', type='build')
 
     def configure_args(self):
         return ['--with-harfbuzz=no']

--- a/var/spack/repos/builtin/packages/fslsfonts/package.py
+++ b/var/spack/repos/builtin/packages/fslsfonts/package.py
@@ -36,5 +36,5 @@ class Fslsfonts(AutotoolsPackage):
     depends_on('libfs')
 
     depends_on('xproto@7.0.25:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/fstobdf/package.py
+++ b/var/spack/repos/builtin/packages/fstobdf/package.py
@@ -40,5 +40,5 @@ class Fstobdf(AutotoolsPackage):
     depends_on('libfs')
 
     depends_on('xproto@7.0.25:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/gccmakedep/package.py
+++ b/var/spack/repos/builtin/packages/gccmakedep/package.py
@@ -33,4 +33,4 @@ class Gccmakedep(AutotoolsPackage):
 
     version('1.0.3', '127ddb6131eb4a56fdf6644a63ade788')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')

--- a/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
+++ b/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
@@ -38,7 +38,7 @@ class GdkPixbuf(AutotoolsPackage):
 
     version('2.31.2', '6be6bbc4f356d4b79ab4226860ab8523')
 
-    depends_on("pkg-config", type="build")
+    depends_on("pkgconfig", type="build")
     depends_on("gettext")
     depends_on("glib")
     depends_on("jpeg")

--- a/var/spack/repos/builtin/packages/ghostscript/package.py
+++ b/var/spack/repos/builtin/packages/ghostscript/package.py
@@ -35,7 +35,7 @@ class Ghostscript(AutotoolsPackage):
     version('9.21', '5f213281761d2750fcf27476c404d17f')
     version('9.18', '33a47567d7a591c00a253caddd12a88a')
 
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')
 
     depends_on('freetype@2.4.2:')
     depends_on('jpeg')

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -42,7 +42,7 @@ class Glib(AutotoolsPackage):
 
     variant('libmount', default=False, description='Build with libmount support')
 
-    depends_on('pkg-config@0.16:+internal_glib', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('libffi')
     depends_on('zlib')
     depends_on('gettext')

--- a/var/spack/repos/builtin/packages/glproto/package.py
+++ b/var/spack/repos/builtin/packages/glproto/package.py
@@ -36,5 +36,5 @@ class Glproto(AutotoolsPackage):
 
     version('1.4.17', 'd69554c1b51a83f2c6976a640819911b')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/gnuplot/package.py
+++ b/var/spack/repos/builtin/packages/gnuplot/package.py
@@ -66,7 +66,7 @@ class Gnuplot(AutotoolsPackage):
 
     # required dependencies
     depends_on('readline')
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('libxpm')
     depends_on('libiconv')
 

--- a/var/spack/repos/builtin/packages/gnutls/package.py
+++ b/var/spack/repos/builtin/packages/gnutls/package.py
@@ -49,7 +49,7 @@ class Gnutls(AutotoolsPackage):
     depends_on('zlib', when='+zlib')
     depends_on('gettext')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
 
     build_directory = 'spack-build'
 

--- a/var/spack/repos/builtin/packages/gobject-introspection/package.py
+++ b/var/spack/repos/builtin/packages/gobject-introspection/package.py
@@ -44,7 +44,7 @@ class GobjectIntrospection(Package):
     depends_on("cairo")
     depends_on("bison", type="build")
     depends_on("flex", type="build")
-    depends_on("pkg-config@0.9.0:", type="build")
+    depends_on("pkgconfig", type="build")
 
     # GobjectIntrospection does not build with sed from darwin:
     depends_on('sed', when='platform=darwin', type='build')

--- a/var/spack/repos/builtin/packages/gource/package.py
+++ b/var/spack/repos/builtin/packages/gource/package.py
@@ -37,7 +37,7 @@ class Gource(AutotoolsPackage):
     depends_on('autoconf',   type='build')
     depends_on('libtool',    type='build')
     depends_on('glm',        type='build')
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')
 
     depends_on('freetype@2.0:')
     depends_on('pcre')

--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -106,7 +106,7 @@ class Graphviz(AutotoolsPackage):
     depends_on('freetype')
     depends_on('expat')
     depends_on('libtool')
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')
 
     depends_on('java', when='+java')
     depends_on('python@2:2.8', when='+python')

--- a/var/spack/repos/builtin/packages/gtkplus/package.py
+++ b/var/spack/repos/builtin/packages/gtkplus/package.py
@@ -36,7 +36,7 @@ class Gtkplus(AutotoolsPackage):
 
     variant('X', default=False, description="Enable an X toolkit")
 
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')
 
     depends_on("atk")
     depends_on("gdk-pixbuf")

--- a/var/spack/repos/builtin/packages/guile/package.py
+++ b/var/spack/repos/builtin/packages/guile/package.py
@@ -45,7 +45,7 @@ class Guile(AutotoolsPackage):
     depends_on('bdw-gc@7.0:')
     depends_on('libffi')
     depends_on('readline', when='+readline')
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')
 
     build_directory = 'spack-build'
 

--- a/var/spack/repos/builtin/packages/harfbuzz/package.py
+++ b/var/spack/repos/builtin/packages/harfbuzz/package.py
@@ -33,7 +33,7 @@ class Harfbuzz(AutotoolsPackage):
     version('1.4.6', '21a78b81cd20cbffdb04b59ac7edfb410e42141869f637ae1d6778e74928d293')
     version('0.9.37', 'bfe733250e34629a188d82e3b971bc1e')
 
-    depends_on("pkg-config", type="build")
+    depends_on("pkgconfig", type="build")
     depends_on("glib")
     depends_on("icu4c")
     depends_on("freetype")

--- a/var/spack/repos/builtin/packages/hoomd-blue/package.py
+++ b/var/spack/repos/builtin/packages/hoomd-blue/package.py
@@ -71,7 +71,7 @@ class HoomdBlue(CMakePackage):
     depends_on('python@2.7:')
     depends_on('py-numpy@1.7:', type=('build', 'run'))
     depends_on('cmake@2.8.0:', type='build')
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('mpi', when='+mpi')
     depends_on('cuda@7.0:', when='+cuda')
     depends_on('doxygen@1.8.5:', when='+doc', type='build')

--- a/var/spack/repos/builtin/packages/hpx5/package.py
+++ b/var/spack/repos/builtin/packages/hpx5/package.py
@@ -76,7 +76,7 @@ class Hpx5(AutotoolsPackage):
     depends_on("mpi", when='+photon')
     depends_on("opencl", when='+opencl')
     # depends_on("papi")
-    depends_on("pkg-config", type='build')
+    depends_on("pkgconfig", type='build')
 
     configure_directory = "hpx"
     build_directory = "spack-build"

--- a/var/spack/repos/builtin/packages/hwloc/package.py
+++ b/var/spack/repos/builtin/packages/hwloc/package.py
@@ -62,7 +62,7 @@ class Hwloc(AutotoolsPackage):
     depends_on('cuda', when='+cuda')
     depends_on('libpciaccess', when='+pci')
     depends_on('libxml2', when='+libxml2')
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')
 
     def url_for_version(self, version):
         return "http://www.open-mpi.org/software/hwloc/v%s/downloads/hwloc-%s.tar.gz" % (version.up_to(2), version)

--- a/var/spack/repos/builtin/packages/iceauth/package.py
+++ b/var/spack/repos/builtin/packages/iceauth/package.py
@@ -38,5 +38,5 @@ class Iceauth(AutotoolsPackage):
     depends_on('libice')
 
     depends_on('xproto@7.0.22:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/icedtea/package.py
+++ b/var/spack/repos/builtin/packages/icedtea/package.py
@@ -42,7 +42,7 @@ class Icedtea(AutotoolsPackage):
     variant('shenandoah', default=False,
             description="Build with the shenandoah gc. Only for version 3+")
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('gmake', type='build')
     depends_on('cups')
     depends_on('jdk', type='build')

--- a/var/spack/repos/builtin/packages/ico/package.py
+++ b/var/spack/repos/builtin/packages/ico/package.py
@@ -39,5 +39,5 @@ class Ico(AutotoolsPackage):
     depends_on('libx11@0.99.1:')
 
     depends_on('xproto@7.0.22:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/imake/package.py
+++ b/var/spack/repos/builtin/packages/imake/package.py
@@ -34,4 +34,4 @@ class Imake(AutotoolsPackage):
     version('1.0.7', '186ca7b8ff0de8752f2a2d0426542363')
 
     depends_on('xproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')

--- a/var/spack/repos/builtin/packages/inputproto/package.py
+++ b/var/spack/repos/builtin/packages/inputproto/package.py
@@ -36,5 +36,5 @@ class Inputproto(AutotoolsPackage):
 
     version('2.3.2', '6450bad6f8d5ebe354b01b734d1fd7ca')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/intel-gpu-tools/package.py
+++ b/var/spack/repos/builtin/packages/intel-gpu-tools/package.py
@@ -49,7 +49,7 @@ class IntelGpuTools(AutotoolsPackage):
     depends_on('flex', type='build')
     depends_on('bison', type='build')
     depends_on('python@3:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     # xrandr ?

--- a/var/spack/repos/builtin/packages/ipopt/package.py
+++ b/var/spack/repos/builtin/packages/ipopt/package.py
@@ -47,7 +47,7 @@ class Ipopt(Package):
 
     depends_on("blas")
     depends_on("lapack")
-    depends_on("pkg-config", type='build')
+    depends_on("pkgconfig", type='build')
     depends_on("mumps+double~mpi")
     depends_on('coinhsl', when='+coinhsl')
     depends_on('metis@4.0:4.999', when='+metis')

--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -66,7 +66,7 @@ class Julia(Package):
     # Build-time dependencies:
     # depends_on("awk")
     depends_on("m4", type="build")
-    # depends_on("pkg-config")
+    # depends_on("pkgconfig")
 
     # Combined build-time and run-time dependencies:
     # (Yes, these are run-time dependencies used by Julia's package manager.)

--- a/var/spack/repos/builtin/packages/kbproto/package.py
+++ b/var/spack/repos/builtin/packages/kbproto/package.py
@@ -36,5 +36,5 @@ class Kbproto(AutotoolsPackage):
 
     version('1.0.7', '19acc5f02ae80381e216f443134e0bbb')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/lbxproxy/package.py
+++ b/var/spack/repos/builtin/packages/lbxproxy/package.py
@@ -48,5 +48,5 @@ class Lbxproxy(AutotoolsPackage):
     depends_on('xtrans', type='build')
     depends_on('xproxymanagementprotocol', type='build')
     depends_on('bigreqsproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libapplewm/package.py
+++ b/var/spack/repos/builtin/packages/libapplewm/package.py
@@ -40,7 +40,7 @@ class Libapplewm(AutotoolsPackage):
 
     depends_on('xextproto', type='build')
     depends_on('applewmproto@1.4:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     # Crashes with this error message on Linux:

--- a/var/spack/repos/builtin/packages/libbeagle/package.py
+++ b/var/spack/repos/builtin/packages/libbeagle/package.py
@@ -40,7 +40,7 @@ class Libbeagle(AutotoolsPackage):
     depends_on('m4',       type='build')
 
     depends_on('subversion', type='build')
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')
 
     def url_for_version(self, version):
         url = "https://github.com/beagle-dev/beagle-lib/archive/beagle_release_{0}.tar.gz"

--- a/var/spack/repos/builtin/packages/libcanberra/package.py
+++ b/var/spack/repos/builtin/packages/libcanberra/package.py
@@ -55,7 +55,7 @@ class Libcanberra(AutotoolsPackage):
 
     depends_on('libvorbis')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
 
     def configure_args(self):
         args = ['--enable-static']

--- a/var/spack/repos/builtin/packages/libdmx/package.py
+++ b/var/spack/repos/builtin/packages/libdmx/package.py
@@ -39,5 +39,5 @@ class Libdmx(AutotoolsPackage):
 
     depends_on('xextproto', type='build')
     depends_on('dmxproto@2.2.99.1:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libdrm/package.py
+++ b/var/spack/repos/builtin/packages/libdrm/package.py
@@ -39,7 +39,7 @@ class Libdrm(Package):
     version('2.4.59', '105ac7af1afcd742d402ca7b4eb168b6')
     version('2.4.33', '86e4e3debe7087d5404461e0032231c8')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('libpciaccess@0.10:', when=(sys.platform != 'darwin'))
     depends_on('libpthread-stubs')
 

--- a/var/spack/repos/builtin/packages/libemos/package.py
+++ b/var/spack/repos/builtin/packages/libemos/package.py
@@ -49,7 +49,7 @@ class Libemos(CMakePackage):
     depends_on('grib-api', when='grib=grib-api')
     depends_on('fftw+float+double')
     depends_on('cmake@2.8.11:', type='build')
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')
 
     conflicts('grib=eccodes', when='@:4.4.1',
               msg='Eccodes is supported starting version 4.4.2')

--- a/var/spack/repos/builtin/packages/libfontenc/package.py
+++ b/var/spack/repos/builtin/packages/libfontenc/package.py
@@ -36,5 +36,5 @@ class Libfontenc(AutotoolsPackage):
     depends_on('zlib')
 
     depends_on('xproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libfs/package.py
+++ b/var/spack/repos/builtin/packages/libfs/package.py
@@ -39,5 +39,5 @@ class Libfs(AutotoolsPackage):
     depends_on('xproto@7.0.17:', type='build')
     depends_on('fontsproto', type='build')
     depends_on('xtrans', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libgd/package.py
+++ b/var/spack/repos/builtin/packages/libgd/package.py
@@ -50,7 +50,7 @@ class Libgd(AutotoolsPackage):
     depends_on('libtool', type='build')
     depends_on('m4', type='build')
     depends_on('gettext', type='build')
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')
 
     depends_on('libiconv')
     depends_on('libpng')

--- a/var/spack/repos/builtin/packages/libhio/package.py
+++ b/var/spack/repos/builtin/packages/libhio/package.py
@@ -38,4 +38,4 @@ class Libhio(AutotoolsPackage):
 
     depends_on("json-c")
     depends_on("bzip2")
-    depends_on("pkg-config", type="build")
+    depends_on("pkgconfig", type="build")

--- a/var/spack/repos/builtin/packages/libice/package.py
+++ b/var/spack/repos/builtin/packages/libice/package.py
@@ -35,5 +35,5 @@ class Libice(AutotoolsPackage):
 
     depends_on('xproto', type='build')
     depends_on('xtrans', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/liblbxutil/package.py
+++ b/var/spack/repos/builtin/packages/liblbxutil/package.py
@@ -35,7 +35,7 @@ class Liblbxutil(AutotoolsPackage):
 
     depends_on('xextproto@7.0.99.1:', type='build')
     depends_on('xproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     # There is a bug in the library that causes the following messages:

--- a/var/spack/repos/builtin/packages/liboldx/package.py
+++ b/var/spack/repos/builtin/packages/liboldx/package.py
@@ -35,5 +35,5 @@ class Liboldx(AutotoolsPackage):
 
     depends_on('libx11')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libpciaccess/package.py
+++ b/var/spack/repos/builtin/packages/libpciaccess/package.py
@@ -35,5 +35,5 @@ class Libpciaccess(AutotoolsPackage):
     version('0.13.4', 'cc1fad87da60682af1d5fa43a5da45a4')
 
     depends_on('libtool', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libpipeline/package.py
+++ b/var/spack/repos/builtin/packages/libpipeline/package.py
@@ -34,7 +34,7 @@ class Libpipeline(AutotoolsPackage):
 
     version('1.4.2', '30cec7bcd6fee723adea6a54389f3da2')
 
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')
     # TODO: Add a 'test' deptype
     # See https://github.com/spack/spack/issues/1279
     # depends_on('check', type='test')

--- a/var/spack/repos/builtin/packages/libpsl/package.py
+++ b/var/spack/repos/builtin/packages/libpsl/package.py
@@ -36,7 +36,7 @@ class Libpsl(AutotoolsPackage):
     depends_on('icu4c')
 
     depends_on('gettext', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('python@2.7:', type='build')
 
     depends_on('valgrind~mpi~boost', type='test')

--- a/var/spack/repos/builtin/packages/libsm/package.py
+++ b/var/spack/repos/builtin/packages/libsm/package.py
@@ -37,5 +37,5 @@ class Libsm(AutotoolsPackage):
 
     depends_on('xproto', type='build')
     depends_on('xtrans', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libvorbis/package.py
+++ b/var/spack/repos/builtin/packages/libvorbis/package.py
@@ -38,7 +38,7 @@ class Libvorbis(AutotoolsPackage):
 
     depends_on('libogg')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
 
     # `make check` crashes when run in parallel
     parallel = False

--- a/var/spack/repos/builtin/packages/libwindowswm/package.py
+++ b/var/spack/repos/builtin/packages/libwindowswm/package.py
@@ -43,5 +43,5 @@ class Libwindowswm(AutotoolsPackage):
 
     depends_on('xextproto', type='build')
     depends_on('windowswmproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libx11/package.py
+++ b/var/spack/repos/builtin/packages/libx11/package.py
@@ -41,6 +41,6 @@ class Libx11(AutotoolsPackage):
     depends_on('xtrans', type='build')
     depends_on('kbproto', type=('build', 'link'))
     depends_on('inputproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
     depends_on('perl', type='build')

--- a/var/spack/repos/builtin/packages/libxau/package.py
+++ b/var/spack/repos/builtin/packages/libxau/package.py
@@ -36,5 +36,5 @@ class Libxau(AutotoolsPackage):
     version('1.0.8', 'a85cd601d82bc79c0daa280917572e20')
 
     depends_on('xproto', type=('build', 'link'))
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxaw/package.py
+++ b/var/spack/repos/builtin/packages/libxaw/package.py
@@ -42,5 +42,5 @@ class Libxaw(AutotoolsPackage):
 
     depends_on('xproto', type='build')
     depends_on('xextproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxaw3d/package.py
+++ b/var/spack/repos/builtin/packages/libxaw3d/package.py
@@ -40,5 +40,5 @@ class Libxaw3d(AutotoolsPackage):
     depends_on('libxext')
     depends_on('libxpm')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxcb/package.py
+++ b/var/spack/repos/builtin/packages/libxcb/package.py
@@ -45,7 +45,7 @@ class Libxcb(AutotoolsPackage):
     depends_on('xcb-proto', type='build')
     # TODO: uncomment once build deps can be resolved separately
     # depends_on('python@2:2.8', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def patch(self):

--- a/var/spack/repos/builtin/packages/libxcomposite/package.py
+++ b/var/spack/repos/builtin/packages/libxcomposite/package.py
@@ -38,5 +38,5 @@ class Libxcomposite(AutotoolsPackage):
     depends_on('libxfixes')
 
     depends_on('compositeproto@0.4:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxcursor/package.py
+++ b/var/spack/repos/builtin/packages/libxcursor/package.py
@@ -38,5 +38,5 @@ class Libxcursor(AutotoolsPackage):
     depends_on('libx11')
 
     depends_on('fixesproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxdamage/package.py
+++ b/var/spack/repos/builtin/packages/libxdamage/package.py
@@ -39,5 +39,5 @@ class Libxdamage(AutotoolsPackage):
     depends_on('damageproto@1.1:', type='build')
     depends_on('fixesproto', type='build')
     depends_on('xextproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxdmcp/package.py
+++ b/var/spack/repos/builtin/packages/libxdmcp/package.py
@@ -34,5 +34,5 @@ class Libxdmcp(AutotoolsPackage):
     version('1.1.2', 'ab0d6a38f0344a05d698ec7d48cfa5a8')
 
     depends_on('xproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxevie/package.py
+++ b/var/spack/repos/builtin/packages/libxevie/package.py
@@ -39,5 +39,5 @@ class Libxevie(AutotoolsPackage):
     depends_on('xproto', type='build')
     depends_on('xextproto', type='build')
     depends_on('evieext', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxext/package.py
+++ b/var/spack/repos/builtin/packages/libxext/package.py
@@ -37,5 +37,5 @@ class Libxext(AutotoolsPackage):
 
     depends_on('xproto@7.0.13:', type='build')
     depends_on('xextproto@7.1.99:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxfixes/package.py
+++ b/var/spack/repos/builtin/packages/libxfixes/package.py
@@ -39,5 +39,5 @@ class Libxfixes(AutotoolsPackage):
     depends_on('xproto', type='build')
     depends_on('fixesproto@5.0:', type='build')
     depends_on('xextproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxfont/package.py
+++ b/var/spack/repos/builtin/packages/libxfont/package.py
@@ -44,5 +44,5 @@ class Libxfont(AutotoolsPackage):
     depends_on('xtrans', type='build')
     depends_on('xproto', type='build')
     depends_on('fontsproto@2.1.3:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxfont2/package.py
+++ b/var/spack/repos/builtin/packages/libxfont2/package.py
@@ -44,5 +44,5 @@ class Libxfont2(AutotoolsPackage):
     depends_on('xtrans', type='build')
     depends_on('xproto', type='build')
     depends_on('fontsproto@2.1.3:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxfontcache/package.py
+++ b/var/spack/repos/builtin/packages/libxfontcache/package.py
@@ -38,5 +38,5 @@ class Libxfontcache(AutotoolsPackage):
 
     depends_on('xextproto', type='build')
     depends_on('fontcacheproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxft/package.py
+++ b/var/spack/repos/builtin/packages/libxft/package.py
@@ -42,5 +42,5 @@ class Libxft(AutotoolsPackage):
     depends_on('libx11')
     depends_on('libxrender@0.8.2:')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxinerama/package.py
+++ b/var/spack/repos/builtin/packages/libxinerama/package.py
@@ -38,5 +38,5 @@ class Libxinerama(AutotoolsPackage):
 
     depends_on('xextproto', type='build')
     depends_on('xineramaproto@1.1.99.1:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxkbfile/package.py
+++ b/var/spack/repos/builtin/packages/libxkbfile/package.py
@@ -36,5 +36,5 @@ class Libxkbfile(AutotoolsPackage):
     depends_on('libx11')
 
     depends_on('kbproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxkbui/package.py
+++ b/var/spack/repos/builtin/packages/libxkbui/package.py
@@ -37,5 +37,5 @@ class Libxkbui(AutotoolsPackage):
     depends_on('libxt')
     depends_on('libxkbfile')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -44,7 +44,7 @@ class Libxml2(AutotoolsPackage):
     depends_on('zlib')
     depends_on('xz')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/libxmu/package.py
+++ b/var/spack/repos/builtin/packages/libxmu/package.py
@@ -41,5 +41,5 @@ class Libxmu(AutotoolsPackage):
     depends_on('libx11')
 
     depends_on('xextproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxp/package.py
+++ b/var/spack/repos/builtin/packages/libxp/package.py
@@ -39,5 +39,5 @@ class Libxp(AutotoolsPackage):
 
     depends_on('xextproto', type='build')
     depends_on('printproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxpm/package.py
+++ b/var/spack/repos/builtin/packages/libxpm/package.py
@@ -42,7 +42,7 @@ class Libxpm(AutotoolsPackage):
     depends_on('libx11')
 
     depends_on('xproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def setup_environment(self, spack_env, run_env):

--- a/var/spack/repos/builtin/packages/libxpresent/package.py
+++ b/var/spack/repos/builtin/packages/libxpresent/package.py
@@ -39,5 +39,5 @@ class Libxpresent(AutotoolsPackage):
     depends_on('xproto', type='build')
     depends_on('presentproto@1.0:', type='build')
     depends_on('xextproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxprintapputil/package.py
+++ b/var/spack/repos/builtin/packages/libxprintapputil/package.py
@@ -39,5 +39,5 @@ class Libxprintapputil(AutotoolsPackage):
     depends_on('libxau')
 
     depends_on('printproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxprintutil/package.py
+++ b/var/spack/repos/builtin/packages/libxprintutil/package.py
@@ -39,5 +39,5 @@ class Libxprintutil(AutotoolsPackage):
     depends_on('libxau')
 
     depends_on('printproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxrandr/package.py
+++ b/var/spack/repos/builtin/packages/libxrandr/package.py
@@ -40,5 +40,5 @@ class Libxrandr(AutotoolsPackage):
     depends_on('randrproto@1.5:', type='build')
     depends_on('xextproto', type='build')
     depends_on('renderproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxrender/package.py
+++ b/var/spack/repos/builtin/packages/libxrender/package.py
@@ -37,5 +37,5 @@ class Libxrender(AutotoolsPackage):
     depends_on('libx11@1.6:')
 
     depends_on('renderproto@0.9:', type=('build', 'link'))
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxres/package.py
+++ b/var/spack/repos/builtin/packages/libxres/package.py
@@ -38,5 +38,5 @@ class Libxres(AutotoolsPackage):
 
     depends_on('xextproto', type='build')
     depends_on('resourceproto@1.0:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxscrnsaver/package.py
+++ b/var/spack/repos/builtin/packages/libxscrnsaver/package.py
@@ -38,5 +38,5 @@ class Libxscrnsaver(AutotoolsPackage):
 
     depends_on('xextproto', type='build')
     depends_on('scrnsaverproto@1.2:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxshmfence/package.py
+++ b/var/spack/repos/builtin/packages/libxshmfence/package.py
@@ -38,5 +38,5 @@ class Libxshmfence(AutotoolsPackage):
     version('1.2', 'f0b30c0fc568b22ec524859ee28556f1')
 
     depends_on('xproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxt/package.py
+++ b/var/spack/repos/builtin/packages/libxt/package.py
@@ -39,5 +39,5 @@ class Libxt(AutotoolsPackage):
 
     depends_on('xproto', type='build')
     depends_on('kbproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxtrap/package.py
+++ b/var/spack/repos/builtin/packages/libxtrap/package.py
@@ -48,5 +48,5 @@ class Libxtrap(AutotoolsPackage):
 
     depends_on('trapproto', type='build')
     depends_on('xextproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxtst/package.py
+++ b/var/spack/repos/builtin/packages/libxtst/package.py
@@ -50,5 +50,5 @@ class Libxtst(AutotoolsPackage):
     depends_on('xextproto@7.0.99.3:', type='build')
     depends_on('inputproto', type='build')
     depends_on('fixesproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxv/package.py
+++ b/var/spack/repos/builtin/packages/libxv/package.py
@@ -39,5 +39,5 @@ class Libxv(AutotoolsPackage):
 
     depends_on('xextproto', type='build')
     depends_on('videoproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxvmc/package.py
+++ b/var/spack/repos/builtin/packages/libxvmc/package.py
@@ -39,5 +39,5 @@ class Libxvmc(AutotoolsPackage):
 
     depends_on('xextproto', type='build')
     depends_on('videoproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxxf86dga/package.py
+++ b/var/spack/repos/builtin/packages/libxxf86dga/package.py
@@ -39,5 +39,5 @@ class Libxxf86dga(AutotoolsPackage):
     depends_on('xproto', type='build')
     depends_on('xextproto', type='build')
     depends_on('xf86dgaproto@2.0.99.2:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxxf86misc/package.py
+++ b/var/spack/repos/builtin/packages/libxxf86misc/package.py
@@ -39,5 +39,5 @@ class Libxxf86misc(AutotoolsPackage):
     depends_on('xproto', type='build')
     depends_on('xextproto', type='build')
     depends_on('xf86miscproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxxf86vm/package.py
+++ b/var/spack/repos/builtin/packages/libxxf86vm/package.py
@@ -39,5 +39,5 @@ class Libxxf86vm(AutotoolsPackage):
     depends_on('xproto', type='build')
     depends_on('xextproto', type='build')
     depends_on('xf86vidmodeproto@2.2.99.1:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/listres/package.py
+++ b/var/spack/repos/builtin/packages/listres/package.py
@@ -39,5 +39,5 @@ class Listres(AutotoolsPackage):
     depends_on('libxmu')
 
     depends_on('xproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/lndir/package.py
+++ b/var/spack/repos/builtin/packages/lndir/package.py
@@ -35,4 +35,4 @@ class Lndir(AutotoolsPackage):
     version('1.0.3', '7173b2e4832658d319c2980a7c834205')
 
     depends_on('xproto@7.0.17:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')

--- a/var/spack/repos/builtin/packages/luit/package.py
+++ b/var/spack/repos/builtin/packages/luit/package.py
@@ -39,7 +39,7 @@ class Luit(Package):
     depends_on('libfontenc')
     depends_on('libx11')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/magics/package.py
+++ b/var/spack/repos/builtin/packages/magics/package.py
@@ -68,7 +68,7 @@ class Magics(CMakePackage):
 
     # Build dependencies
     depends_on('cmake@2.8.11:', type='build')
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('python@:2', type='build')
     depends_on('perl', type='build')
     depends_on('perl-xml-parser', type='build')

--- a/var/spack/repos/builtin/packages/makedepend/package.py
+++ b/var/spack/repos/builtin/packages/makedepend/package.py
@@ -34,4 +34,4 @@ class Makedepend(AutotoolsPackage):
     version('1.0.5', 'efb2d7c7e22840947863efaedc175747')
 
     depends_on('xproto@7.0.17:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -54,7 +54,7 @@ class Mesa(AutotoolsPackage):
             description="Use llvm for rendering pipes.")
 
     # General dependencies
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('flex@2.5.35:', type='build')
     depends_on('bison@2.4.1:', type='build')
     depends_on('binutils', type='build')

--- a/var/spack/repos/builtin/packages/mkfontdir/package.py
+++ b/var/spack/repos/builtin/packages/mkfontdir/package.py
@@ -37,5 +37,5 @@ class Mkfontdir(AutotoolsPackage):
 
     depends_on('mkfontscale', type='run')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/mkfontscale/package.py
+++ b/var/spack/repos/builtin/packages/mkfontscale/package.py
@@ -38,5 +38,5 @@ class Mkfontscale(AutotoolsPackage):
     depends_on('freetype')
 
     depends_on('xproto@7.0.25:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/mozjs/package.py
+++ b/var/spack/repos/builtin/packages/mozjs/package.py
@@ -40,7 +40,7 @@ class Mozjs(AutotoolsPackage):
             url="http://ftp.mozilla.org/pub/js/js185-1.0.0.tar.gz")
 
     depends_on('perl@5.6:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('python@2.7.3:2.8', type='build')
     depends_on('nspr', when='@:27')
     depends_on('libffi@3.0.9:')

--- a/var/spack/repos/builtin/packages/nauty/package.py
+++ b/var/spack/repos/builtin/packages/nauty/package.py
@@ -74,7 +74,7 @@ class Nauty(AutotoolsPackage):
     depends_on('autoconf',  type='build', when='@2.6r7')
     depends_on('automake',  type='build', when='@2.6r7')
     depends_on('libtool',  type='build', when='@2.6r7')
-    depends_on('pkg-config',  type='build')
+    depends_on('pkgconfig',  type='build')
     depends_on('help2man', type='build')
     depends_on('zlib')
     depends_on('gmp')

--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -45,7 +45,7 @@ class Ncurses(AutotoolsPackage):
     variant('symlinks', default=False,
             description='Enables symlinks. Needed on AFS filesystem.')
 
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')
 
     patch('patch_gcc_5.txt', when='@6.0%gcc@5.0:')
     patch('sed_pgi.patch',   when='@:6.0')

--- a/var/spack/repos/builtin/packages/node-js/package.py
+++ b/var/spack/repos/builtin/packages/node-js/package.py
@@ -46,7 +46,7 @@ class NodeJs(Package):
     variant('zlib', default=True,  description='Build with Spacks zlib instead of the bundled version')
 
     depends_on('libtool', type='build', when=sys.platform != 'darwin')
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('python@2.7:2.8', type='build')
     # depends_on('bash-completion', when="+bash-completion")
     depends_on('icu4c', when='+icu4c')

--- a/var/spack/repos/builtin/packages/oclock/package.py
+++ b/var/spack/repos/builtin/packages/oclock/package.py
@@ -40,5 +40,5 @@ class Oclock(AutotoolsPackage):
     depends_on('libxt')
     depends_on('libxkbfile')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/octave/package.py
+++ b/var/spack/repos/builtin/packages/octave/package.py
@@ -76,7 +76,7 @@ class Octave(AutotoolsPackage):
     # Octave does not configure with sed from darwin:
     depends_on('sed', when=sys.platform == 'darwin', type='build')
     depends_on('pcre')
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')
 
     # Strongly recommended dependencies
     depends_on('readline',     when='+readline')

--- a/var/spack/repos/builtin/packages/openbabel/package.py
+++ b/var/spack/repos/builtin/packages/openbabel/package.py
@@ -42,7 +42,7 @@ class Openbabel(CMakePackage):
 
     depends_on('python', type=('build', 'run'), when='+python')
     depends_on('cmake@2.4.8:', type='build')
-    depends_on('pkg-config',   type='build')
+    depends_on('pkgconfig',   type='build')
     depends_on('cairo')       # required to support PNG depiction
     depends_on('eigen@3.0:')  # required if using the language bindings
     depends_on('libxml2')     # required to read/write CML files, XML formats

--- a/var/spack/repos/builtin/packages/openexr/package.py
+++ b/var/spack/repos/builtin/packages/openexr/package.py
@@ -43,7 +43,7 @@ class Openexr(Package):
     variant('debug', default=False,
             description='Builds a debug version of the libraries')
 
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('ilmbase')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/pango/package.py
+++ b/var/spack/repos/builtin/packages/pango/package.py
@@ -41,7 +41,7 @@ class Pango(AutotoolsPackage):
 
     variant('X', default=False, description="Enable an X toolkit")
 
-    depends_on("pkg-config", type="build")
+    depends_on("pkgconfig", type="build")
     depends_on("harfbuzz")
     depends_on("cairo")
     depends_on("cairo~X", when='~X')

--- a/var/spack/repos/builtin/packages/pixman/package.py
+++ b/var/spack/repos/builtin/packages/pixman/package.py
@@ -37,7 +37,7 @@ class Pixman(AutotoolsPackage):
     version('0.34.0', 'e80ebae4da01e77f68744319f01d52a3')
     version('0.32.6', '3a30859719a41bd0f5cccffbfefdd4c2')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('libpng')
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/pkg-config/package.py
+++ b/var/spack/repos/builtin/packages/pkg-config/package.py
@@ -36,6 +36,8 @@ class PkgConfig(AutotoolsPackage):
     version('0.29.1', 'f739a28cae4e0ca291f82d1d41ef107d')
     version('0.28',   'aa3c86e67551adc3ac865160e34a2a0d')
 
+    provides('pkgconfig')
+
     variant('internal_glib', default=True,
             description='Builds with internal glib')
 

--- a/var/spack/repos/builtin/packages/pkgconf/package.py
+++ b/var/spack/repos/builtin/packages/pkgconf/package.py
@@ -32,9 +32,12 @@ class Pkgconf(AutotoolsPackage):
     maintaining compatibility."""
 
     homepage = "http://pkgconf.org/"
-    url      = "https://distfiles.dereferenced.org/pkgconf/pkgconf-1.3.8.tar.xz"
+    url      = "https://distfiles.dereferenced.org/pkgconf/pkgconf-1.3.10.tar.xz"
 
+    version('1.3.10', '9b63707bf6f8da6efb3868101d7525fe')
     version('1.3.8', '484ba3360d983ce07416843d5bc916a8')
+
+    provides('pkgconfig')
 
     @run_after('install')
     def link_pkg_config(self):

--- a/var/spack/repos/builtin/packages/pocl/package.py
+++ b/var/spack/repos/builtin/packages/pocl/package.py
@@ -62,7 +62,7 @@ class Pocl(CMakePackage):
     # enabled by default, and also because they fail to build for us
     # (see #1616)
     depends_on("llvm +clang")
-    depends_on("pkg-config", type="build")
+    depends_on("pkgconfig", type="build")
 
     # These are the supported LLVM versions
     depends_on("llvm @3.7:3.9", when="@master")

--- a/var/spack/repos/builtin/packages/presentproto/package.py
+++ b/var/spack/repos/builtin/packages/presentproto/package.py
@@ -33,5 +33,5 @@ class Presentproto(AutotoolsPackage):
 
     version('1.0', '57eaf4bb58e86476ec89cfb42d675961')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/printproto/package.py
+++ b/var/spack/repos/builtin/packages/printproto/package.py
@@ -34,5 +34,5 @@ class Printproto(AutotoolsPackage):
 
     version('1.0.5', '5afeb3a7de8a14b417239a14ea724268')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/proxymngr/package.py
+++ b/var/spack/repos/builtin/packages/proxymngr/package.py
@@ -42,5 +42,5 @@ class Proxymngr(AutotoolsPackage):
 
     depends_on('xproto@7.0.17:', type='build')
     depends_on('xproxymanagementprotocol', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/py-h5py/package.py
+++ b/var/spack/repos/builtin/packages/py-h5py/package.py
@@ -40,7 +40,7 @@ class PyH5py(PythonPackage):
 
     # Build dependencies
     depends_on('py-cython@0.19:', type='build')
-    depends_on('py-pkgconfig', type='build')
+    depends_on('py-pkgconfigig', type='build')
     depends_on('py-setuptools', type='build')
     depends_on('hdf5@1.8.4:+hl')
     depends_on('hdf5+mpi', when='+mpi')

--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -86,7 +86,7 @@ class PyMatplotlib(PythonPackage):
     depends_on('image-magick', when='+animation')
 
     # --------- Optional dependencies
-    depends_on('pkg-config', type='build')    # why not...
+    depends_on('pkgconfig', type='build')    # why not...
     depends_on('pil', when='+image', type=('build', 'run'))
     depends_on('py-ipython', when='+ipython', type=('build', 'run'))
     depends_on('ghostscript', when='+latex', type='run')

--- a/var/spack/repos/builtin/packages/py-pkgconfig/package.py
+++ b/var/spack/repos/builtin/packages/py-pkgconfig/package.py
@@ -36,7 +36,7 @@ class PyPkgconfig(PythonPackage):
     depends_on('python@2.6:')
     depends_on('py-setuptools', type='build')
 
-    depends_on('pkg-config', type=('build', 'run'))
+    depends_on('pkgconfig', type=('build', 'run'))
 
     # TODO: Add a 'test' deptype
     # depends_on('py-nose@1.0:', type='test')

--- a/var/spack/repos/builtin/packages/py-py2cairo/package.py
+++ b/var/spack/repos/builtin/packages/py-py2cairo/package.py
@@ -38,7 +38,7 @@ class PyPy2cairo(WafPackage):
     depends_on('python', type=('build', 'run'))
     depends_on('cairo@1.10.0:')
     depends_on('pixman')
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')
 
     # TODO: Add a 'test' deptype
     # depends_on('py-pytest', type='test')

--- a/var/spack/repos/builtin/packages/randrproto/package.py
+++ b/var/spack/repos/builtin/packages/randrproto/package.py
@@ -37,5 +37,5 @@ class Randrproto(AutotoolsPackage):
 
     version('1.5.0', '863d6ee3e0b2708f75d968470ed31eb9')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/recordproto/package.py
+++ b/var/spack/repos/builtin/packages/recordproto/package.py
@@ -36,5 +36,5 @@ class Recordproto(AutotoolsPackage):
 
     version('1.14.2', '868235e1e150e68916d5a316ebc4ccc4')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/rendercheck/package.py
+++ b/var/spack/repos/builtin/packages/rendercheck/package.py
@@ -38,5 +38,5 @@ class Rendercheck(AutotoolsPackage):
     depends_on('libx11')
 
     depends_on('xproto@7.0.17:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/renderproto/package.py
+++ b/var/spack/repos/builtin/packages/renderproto/package.py
@@ -36,5 +36,5 @@ class Renderproto(AutotoolsPackage):
 
     version('0.11.1', '9b103359123e375bb7760f7dbae3dece')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/resourceproto/package.py
+++ b/var/spack/repos/builtin/packages/resourceproto/package.py
@@ -36,5 +36,5 @@ class Resourceproto(AutotoolsPackage):
 
     version('1.2.0', '33091d5358ec32dd7562a1aa225a70aa')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -53,7 +53,7 @@ class Root(CMakePackage):
     variant('graphviz', default=False, description='Enable graphviz support')
 
     depends_on('cmake@3.4.3:', type='build')
-    depends_on('pkg-config',   type='build')
+    depends_on('pkgconfig',   type='build')
 
     depends_on('binutils')
     depends_on('zlib')

--- a/var/spack/repos/builtin/packages/rr/package.py
+++ b/var/spack/repos/builtin/packages/rr/package.py
@@ -39,7 +39,7 @@ class Rr(CMakePackage):
     depends_on('zlib')
     # depends_on('capnproto', when='@4.6:')  # not yet in spack
     # depends_on('libcapnp')    # needed for future releases
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('py-pexpect', type='build')  # actually tests
 
     # rr needs architecture Nehalem and beyond, how can spack

--- a/var/spack/repos/builtin/packages/rstart/package.py
+++ b/var/spack/repos/builtin/packages/rstart/package.py
@@ -39,5 +39,5 @@ class Rstart(AutotoolsPackage):
     version('1.0.5', '32db3625cb5e841e17d6bc696f21edfb')
 
     depends_on('xproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/rtags/package.py
+++ b/var/spack/repos/builtin/packages/rtags/package.py
@@ -38,7 +38,7 @@ class Rtags(CMakePackage):
     depends_on("openssl")
     depends_on("lua@5.3:")
     depends_on("bash-completion")
-    depends_on("pkg-config", type='build')
+    depends_on("pkgconfig", type='build')
 
     patch("add_string_iterator_erase_compile_check.patch", when='@2.12')
 

--- a/var/spack/repos/builtin/packages/scripts/package.py
+++ b/var/spack/repos/builtin/packages/scripts/package.py
@@ -35,5 +35,5 @@ class Scripts(AutotoolsPackage):
 
     depends_on('libx11')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/scrnsaverproto/package.py
+++ b/var/spack/repos/builtin/packages/scrnsaverproto/package.py
@@ -36,5 +36,5 @@ class Scrnsaverproto(AutotoolsPackage):
 
     version('1.2.2', '21704f1bad472d94abd22fea5704bb48')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/sessreg/package.py
+++ b/var/spack/repos/builtin/packages/sessreg/package.py
@@ -36,7 +36,7 @@ class Sessreg(AutotoolsPackage):
     version('1.1.0', '5d7eb499043c7fdd8d53c5ba43660312')
 
     depends_on('xproto@7.0.25:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def patch(self):

--- a/var/spack/repos/builtin/packages/setxkbmap/package.py
+++ b/var/spack/repos/builtin/packages/setxkbmap/package.py
@@ -38,5 +38,5 @@ class Setxkbmap(AutotoolsPackage):
     depends_on('libxkbfile')
     depends_on('libx11')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/shared-mime-info/package.py
+++ b/var/spack/repos/builtin/packages/shared-mime-info/package.py
@@ -40,7 +40,7 @@ class SharedMimeInfo(AutotoolsPackage):
     depends_on('libxml2')
     depends_on('intltool', type='build')
     depends_on('gettext', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         spack_env.prepend_path("XDG_DATA_DIRS",

--- a/var/spack/repos/builtin/packages/showfont/package.py
+++ b/var/spack/repos/builtin/packages/showfont/package.py
@@ -37,5 +37,5 @@ class Showfont(AutotoolsPackage):
 
     depends_on('libfs')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/slurm/package.py
+++ b/var/spack/repos/builtin/packages/slurm/package.py
@@ -64,7 +64,7 @@ class Slurm(AutotoolsPackage):
     depends_on('lz4')
     depends_on('munge')
     depends_on('openssl')
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('readline')
     depends_on('zlib')
 

--- a/var/spack/repos/builtin/packages/smproxy/package.py
+++ b/var/spack/repos/builtin/packages/smproxy/package.py
@@ -39,5 +39,5 @@ class Smproxy(AutotoolsPackage):
     depends_on('libxt')
     depends_on('libxmu')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/the-silver-searcher/package.py
+++ b/var/spack/repos/builtin/packages/the-silver-searcher/package.py
@@ -38,4 +38,4 @@ class TheSilverSearcher(AutotoolsPackage):
     depends_on('pcre')
     depends_on('xz')
     depends_on('zlib')
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')

--- a/var/spack/repos/builtin/packages/transset/package.py
+++ b/var/spack/repos/builtin/packages/transset/package.py
@@ -36,5 +36,5 @@ class Transset(AutotoolsPackage):
     depends_on('libx11')
 
     depends_on('xproto@7.0.17:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/twm/package.py
+++ b/var/spack/repos/builtin/packages/twm/package.py
@@ -46,5 +46,5 @@ class Twm(AutotoolsPackage):
     depends_on('xproto@7.0.17:', type='build')
     depends_on('bison', type='build')
     depends_on('flex', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/videoproto/package.py
+++ b/var/spack/repos/builtin/packages/videoproto/package.py
@@ -36,5 +36,5 @@ class Videoproto(AutotoolsPackage):
 
     version('2.3.3', 'd984100603ee2420072f27bb491f4b7d')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/viewres/package.py
+++ b/var/spack/repos/builtin/packages/viewres/package.py
@@ -38,5 +38,5 @@ class Viewres(AutotoolsPackage):
     depends_on('libxmu')
     depends_on('libxt')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/wget/package.py
+++ b/var/spack/repos/builtin/packages/wget/package.py
@@ -60,7 +60,7 @@ class Wget(AutotoolsPackage):
     depends_on('pcre', when='+pcre')
 
     depends_on('perl@5.12.0:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
 
     # TODO: Add a 'test' deptype
     # depends_on('valgrind', type='test')

--- a/var/spack/repos/builtin/packages/wx/package.py
+++ b/var/spack/repos/builtin/packages/wx/package.py
@@ -44,7 +44,7 @@ class Wx(AutotoolsPackage):
 
     version('develop', git='https://github.com/wxWidgets/wxWidgets.git', branch='master')
 
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('gtkplus')
 
     @when('@:3.0.2')

--- a/var/spack/repos/builtin/packages/x11perf/package.py
+++ b/var/spack/repos/builtin/packages/x11perf/package.py
@@ -39,5 +39,5 @@ class X11perf(AutotoolsPackage):
     depends_on('libxft')
 
     depends_on('xproto@7.0.17:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xauth/package.py
+++ b/var/spack/repos/builtin/packages/xauth/package.py
@@ -40,7 +40,7 @@ class Xauth(AutotoolsPackage):
     depends_on('libxmu')
 
     depends_on('xproto@7.0.17:')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     # TODO: add package for cmdtest test dependency

--- a/var/spack/repos/builtin/packages/xbacklight/package.py
+++ b/var/spack/repos/builtin/packages/xbacklight/package.py
@@ -39,5 +39,5 @@ class Xbacklight(AutotoolsPackage):
     depends_on('libxcb')
     depends_on('xcb-util')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xbiff/package.py
+++ b/var/spack/repos/builtin/packages/xbiff/package.py
@@ -41,5 +41,5 @@ class Xbiff(AutotoolsPackage):
     depends_on('libx11')
 
     depends_on('xbitmaps', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xbitmaps/package.py
+++ b/var/spack/repos/builtin/packages/xbitmaps/package.py
@@ -34,5 +34,5 @@ class Xbitmaps(AutotoolsPackage):
 
     version('1.1.1', '288bbe310db67280a9e2e5ebc5602595')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xcalc/package.py
+++ b/var/spack/repos/builtin/packages/xcalc/package.py
@@ -39,5 +39,5 @@ class Xcalc(AutotoolsPackage):
     depends_on('libx11')
 
     depends_on('xproto@7.0.17:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xcb-demo/package.py
+++ b/var/spack/repos/builtin/packages/xcb-demo/package.py
@@ -38,7 +38,7 @@ class XcbDemo(AutotoolsPackage):
     depends_on('xcb-util-image')
     depends_on('xcb-util-wm')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
 
     # FIXME: crashes with the following error message
     # X11/XCB/xcb.h: No such file or directory

--- a/var/spack/repos/builtin/packages/xcb-util-cursor/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-cursor/package.py
@@ -42,4 +42,4 @@ class XcbUtilCursor(AutotoolsPackage):
     depends_on('xcb-util-renderutil')
     depends_on('xcb-util-image')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')

--- a/var/spack/repos/builtin/packages/xcb-util-errors/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-errors/package.py
@@ -41,4 +41,4 @@ class XcbUtilErrors(AutotoolsPackage):
     depends_on('libxcb@1.4:')
 
     depends_on('xcb-proto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')

--- a/var/spack/repos/builtin/packages/xcb-util-image/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-image/package.py
@@ -42,4 +42,4 @@ class XcbUtilImage(AutotoolsPackage):
     depends_on('xcb-util')
 
     depends_on('xproto@7.0.8:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')

--- a/var/spack/repos/builtin/packages/xcb-util-keysyms/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-keysyms/package.py
@@ -41,4 +41,4 @@ class XcbUtilKeysyms(AutotoolsPackage):
     depends_on('libxcb@1.4:')
 
     depends_on('xproto@7.0.8:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')

--- a/var/spack/repos/builtin/packages/xcb-util-renderutil/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-renderutil/package.py
@@ -40,4 +40,4 @@ class XcbUtilRenderutil(AutotoolsPackage):
 
     depends_on('libxcb@1.4:')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')

--- a/var/spack/repos/builtin/packages/xcb-util-wm/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-wm/package.py
@@ -40,4 +40,4 @@ class XcbUtilWm(AutotoolsPackage):
 
     depends_on('libxcb@1.4:')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')

--- a/var/spack/repos/builtin/packages/xcb-util/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util/package.py
@@ -40,4 +40,4 @@ class XcbUtil(AutotoolsPackage):
 
     depends_on('libxcb@1.4:')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')

--- a/var/spack/repos/builtin/packages/xclipboard/package.py
+++ b/var/spack/repos/builtin/packages/xclipboard/package.py
@@ -43,5 +43,5 @@ class Xclipboard(AutotoolsPackage):
     depends_on('libxkbfile')
 
     depends_on('xproto@7.0.17:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xclock/package.py
+++ b/var/spack/repos/builtin/packages/xclock/package.py
@@ -44,5 +44,5 @@ class Xclock(AutotoolsPackage):
     depends_on('libxt')
 
     depends_on('xproto@7.0.17:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xcmiscproto/package.py
+++ b/var/spack/repos/builtin/packages/xcmiscproto/package.py
@@ -36,5 +36,5 @@ class Xcmiscproto(AutotoolsPackage):
 
     version('1.2.2', 'ded6cd23fb2800df93ebf2b3f3b01119')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xcmsdb/package.py
+++ b/var/spack/repos/builtin/packages/xcmsdb/package.py
@@ -38,5 +38,5 @@ class Xcmsdb(AutotoolsPackage):
 
     depends_on('libx11')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xcompmgr/package.py
+++ b/var/spack/repos/builtin/packages/xcompmgr/package.py
@@ -41,5 +41,5 @@ class Xcompmgr(AutotoolsPackage):
     depends_on('libxrender')
     depends_on('libxext')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xconsole/package.py
+++ b/var/spack/repos/builtin/packages/xconsole/package.py
@@ -40,5 +40,5 @@ class Xconsole(AutotoolsPackage):
     depends_on('libx11')
 
     depends_on('xproto@7.0.17:')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xcursor-themes/package.py
+++ b/var/spack/repos/builtin/packages/xcursor-themes/package.py
@@ -38,7 +38,7 @@ class XcursorThemes(Package):
     depends_on('libxcursor')
 
     depends_on('xcursorgen', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/xcursorgen/package.py
+++ b/var/spack/repos/builtin/packages/xcursorgen/package.py
@@ -37,5 +37,5 @@ class Xcursorgen(AutotoolsPackage):
     depends_on('libxcursor')
     depends_on('libpng@1.2.0:')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xdbedizzy/package.py
+++ b/var/spack/repos/builtin/packages/xdbedizzy/package.py
@@ -37,5 +37,5 @@ class Xdbedizzy(AutotoolsPackage):
     depends_on('libx11')
     depends_on('libxext')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xditview/package.py
+++ b/var/spack/repos/builtin/packages/xditview/package.py
@@ -38,5 +38,5 @@ class Xditview(AutotoolsPackage):
     depends_on('libxt')
     depends_on('libx11')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xdm/package.py
+++ b/var/spack/repos/builtin/packages/xdm/package.py
@@ -44,5 +44,5 @@ class Xdm(AutotoolsPackage):
     depends_on('libxt')
     depends_on('libxext')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xdpyinfo/package.py
+++ b/var/spack/repos/builtin/packages/xdpyinfo/package.py
@@ -47,5 +47,5 @@ class Xdpyinfo(AutotoolsPackage):
     depends_on('recordproto', type='build')
     depends_on('inputproto', type='build')
     depends_on('fixesproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xdriinfo/package.py
+++ b/var/spack/repos/builtin/packages/xdriinfo/package.py
@@ -42,5 +42,5 @@ class Xdriinfo(AutotoolsPackage):
     depends_on('pcre')
 
     depends_on('glproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xedit/package.py
+++ b/var/spack/repos/builtin/packages/xedit/package.py
@@ -38,5 +38,5 @@ class Xedit(AutotoolsPackage):
     depends_on('libxt@1.0:')
     depends_on('libx11')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xev/package.py
+++ b/var/spack/repos/builtin/packages/xev/package.py
@@ -43,5 +43,5 @@ class Xev(AutotoolsPackage):
     depends_on('libx11')
 
     depends_on('xproto@7.0.17:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xextproto/package.py
+++ b/var/spack/repos/builtin/packages/xextproto/package.py
@@ -33,7 +33,7 @@ class Xextproto(AutotoolsPackage):
 
     version('7.3.0', '37b700baa8c8ea7964702d948dd13821')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     parallel = False

--- a/var/spack/repos/builtin/packages/xeyes/package.py
+++ b/var/spack/repos/builtin/packages/xeyes/package.py
@@ -39,5 +39,5 @@ class Xeyes(AutotoolsPackage):
     depends_on('libxmu')
     depends_on('libxrender@0.4:')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xf86dga/package.py
+++ b/var/spack/repos/builtin/packages/xf86dga/package.py
@@ -36,5 +36,5 @@ class Xf86dga(AutotoolsPackage):
     depends_on('libx11')
     depends_on('libxxf86dga@1.1:')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xf86driproto/package.py
+++ b/var/spack/repos/builtin/packages/xf86driproto/package.py
@@ -37,5 +37,5 @@ class Xf86driproto(AutotoolsPackage):
 
     version('2.1.1', '3ba16a48d8d9f9f746f9bd281ba8fb3f')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xf86vidmodeproto/package.py
+++ b/var/spack/repos/builtin/packages/xf86vidmodeproto/package.py
@@ -36,5 +36,5 @@ class Xf86vidmodeproto(AutotoolsPackage):
 
     version('2.3.1', '99016d0fe355bae0bb23ce00fb4d4a2c')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xfd/package.py
+++ b/var/spack/repos/builtin/packages/xfd/package.py
@@ -42,5 +42,5 @@ class Xfd(AutotoolsPackage):
     depends_on('libxt')
 
     depends_on('xproto@7.0.17:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xfindproxy/package.py
+++ b/var/spack/repos/builtin/packages/xfindproxy/package.py
@@ -43,5 +43,5 @@ class Xfindproxy(AutotoolsPackage):
 
     depends_on('xproto', type='build')
     depends_on('xproxymanagementprotocol', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xfontsel/package.py
+++ b/var/spack/repos/builtin/packages/xfontsel/package.py
@@ -40,5 +40,5 @@ class Xfontsel(AutotoolsPackage):
     depends_on('libxt')
     depends_on('libx11')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xfs/package.py
+++ b/var/spack/repos/builtin/packages/xfs/package.py
@@ -39,5 +39,5 @@ class Xfs(AutotoolsPackage):
     depends_on('xproto@7.0.17:', type='build')
     depends_on('fontsproto', type='build')
     depends_on('xtrans', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xfsinfo/package.py
+++ b/var/spack/repos/builtin/packages/xfsinfo/package.py
@@ -40,5 +40,5 @@ class Xfsinfo(AutotoolsPackage):
     depends_on('libfs')
 
     depends_on('xproto@7.0.17:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xfwp/package.py
+++ b/var/spack/repos/builtin/packages/xfwp/package.py
@@ -37,7 +37,7 @@ class Xfwp(AutotoolsPackage):
 
     depends_on('xproto', type='build')
     depends_on('xproxymanagementprotocol', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     # FIXME: fails with the error message:

--- a/var/spack/repos/builtin/packages/xgamma/package.py
+++ b/var/spack/repos/builtin/packages/xgamma/package.py
@@ -38,5 +38,5 @@ class Xgamma(AutotoolsPackage):
     depends_on('libxxf86vm')
 
     depends_on('xproto@7.0.17:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xgc/package.py
+++ b/var/spack/repos/builtin/packages/xgc/package.py
@@ -39,5 +39,5 @@ class Xgc(AutotoolsPackage):
 
     depends_on('flex', type='build')
     depends_on('bison', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xhost/package.py
+++ b/var/spack/repos/builtin/packages/xhost/package.py
@@ -39,5 +39,5 @@ class Xhost(AutotoolsPackage):
     depends_on('libxau')
 
     depends_on('xproto@7.0.22:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xineramaproto/package.py
+++ b/var/spack/repos/builtin/packages/xineramaproto/package.py
@@ -36,5 +36,5 @@ class Xineramaproto(AutotoolsPackage):
 
     version('1.2.1', 'e0e148b11739e144a546b8a051b17dde')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xinit/package.py
+++ b/var/spack/repos/builtin/packages/xinit/package.py
@@ -38,5 +38,5 @@ class Xinit(AutotoolsPackage):
     depends_on('libx11')
 
     depends_on('xproto@7.0.17:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xinput/package.py
+++ b/var/spack/repos/builtin/packages/xinput/package.py
@@ -43,5 +43,5 @@ class Xinput(AutotoolsPackage):
     depends_on('fixesproto', type='build')
     depends_on('randrproto', type='build')
     depends_on('xineramaproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xkbcomp/package.py
+++ b/var/spack/repos/builtin/packages/xkbcomp/package.py
@@ -43,5 +43,5 @@ class Xkbcomp(AutotoolsPackage):
 
     depends_on('xproto@7.0.17:', type='build')
     depends_on('bison', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xkbevd/package.py
+++ b/var/spack/repos/builtin/packages/xkbevd/package.py
@@ -37,5 +37,5 @@ class Xkbevd(AutotoolsPackage):
     depends_on('libx11')
 
     depends_on('bison', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xkbprint/package.py
+++ b/var/spack/repos/builtin/packages/xkbprint/package.py
@@ -38,5 +38,5 @@ class Xkbprint(AutotoolsPackage):
     depends_on('libx11')
 
     depends_on('xproto@7.0.17:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xkbutils/package.py
+++ b/var/spack/repos/builtin/packages/xkbutils/package.py
@@ -40,5 +40,5 @@ class Xkbutils(AutotoolsPackage):
 
     depends_on('xproto@7.0.17:', type='build')
     depends_on('inputproto', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xkeyboard-config/package.py
+++ b/var/spack/repos/builtin/packages/xkeyboard-config/package.py
@@ -38,7 +38,7 @@ class XkeyboardConfig(AutotoolsPackage):
     depends_on('libx11@1.4.3:')
 
     depends_on('libxslt', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('intltool@0.30:', type='build')
     depends_on('xproto@7.0.20:', type='build')
 

--- a/var/spack/repos/builtin/packages/xkill/package.py
+++ b/var/spack/repos/builtin/packages/xkill/package.py
@@ -39,5 +39,5 @@ class Xkill(AutotoolsPackage):
     depends_on('libxmu')
 
     depends_on('xproto@7.0.22:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xload/package.py
+++ b/var/spack/repos/builtin/packages/xload/package.py
@@ -40,5 +40,5 @@ class Xload(AutotoolsPackage):
     depends_on('libx11')
 
     depends_on('xproto@7.0.17:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xlogo/package.py
+++ b/var/spack/repos/builtin/packages/xlogo/package.py
@@ -43,5 +43,5 @@ class Xlogo(AutotoolsPackage):
     depends_on('libxrender')
     depends_on('libxt')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xlsatoms/package.py
+++ b/var/spack/repos/builtin/packages/xlsatoms/package.py
@@ -36,5 +36,5 @@ class Xlsatoms(AutotoolsPackage):
     depends_on('libxcb', when='@1.1:')
     depends_on('libx11', when='@:1.0')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xlsclients/package.py
+++ b/var/spack/repos/builtin/packages/xlsclients/package.py
@@ -37,5 +37,5 @@ class Xlsclients(AutotoolsPackage):
     depends_on('libxcb@1.6:', when='@1.1:')
     depends_on('libx11', when='@:1.0')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xlsfonts/package.py
+++ b/var/spack/repos/builtin/packages/xlsfonts/package.py
@@ -37,5 +37,5 @@ class Xlsfonts(AutotoolsPackage):
     depends_on('libx11')
 
     depends_on('xproto@7.0.17:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xmag/package.py
+++ b/var/spack/repos/builtin/packages/xmag/package.py
@@ -38,5 +38,5 @@ class Xmag(AutotoolsPackage):
     depends_on('libxt')
     depends_on('libx11')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xman/package.py
+++ b/var/spack/repos/builtin/packages/xman/package.py
@@ -38,5 +38,5 @@ class Xman(AutotoolsPackage):
     depends_on('libxt')
 
     depends_on('xproto@7.0.17:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xmessage/package.py
+++ b/var/spack/repos/builtin/packages/xmessage/package.py
@@ -38,5 +38,5 @@ class Xmessage(AutotoolsPackage):
     depends_on('libxaw')
     depends_on('libxt')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xmh/package.py
+++ b/var/spack/repos/builtin/packages/xmh/package.py
@@ -41,5 +41,5 @@ class Xmh(AutotoolsPackage):
     depends_on('libx11')
 
     depends_on('xbitmaps@1.1.0:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xmodmap/package.py
+++ b/var/spack/repos/builtin/packages/xmodmap/package.py
@@ -40,5 +40,5 @@ class Xmodmap(AutotoolsPackage):
     depends_on('libx11')
 
     depends_on('xproto@7.0.25:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xmore/package.py
+++ b/var/spack/repos/builtin/packages/xmore/package.py
@@ -36,5 +36,5 @@ class Xmore(AutotoolsPackage):
     depends_on('libxaw')
     depends_on('libxt')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xorg-cf-files/package.py
+++ b/var/spack/repos/builtin/packages/xorg-cf-files/package.py
@@ -36,4 +36,4 @@ class XorgCfFiles(AutotoolsPackage):
 
     version('1.0.6', 'c0ce98377c70d95fb48e1bd856109bf8')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')

--- a/var/spack/repos/builtin/packages/xorg-docs/package.py
+++ b/var/spack/repos/builtin/packages/xorg-docs/package.py
@@ -36,7 +36,7 @@ class XorgDocs(AutotoolsPackage):
 
     version('1.7.1', 'ca689ccbf8ebc362afbe5cc5792a4abd')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
     depends_on('xorg-sgml-doctools@1.8:', type='build')
     depends_on('xmlto', type='build')

--- a/var/spack/repos/builtin/packages/xorg-gtest/package.py
+++ b/var/spack/repos/builtin/packages/xorg-gtest/package.py
@@ -38,7 +38,7 @@ class XorgGtest(AutotoolsPackage):
     depends_on('libxi')
     depends_on('xorg-server')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     # TODO: may be missing evemu package?

--- a/var/spack/repos/builtin/packages/xorg-server/package.py
+++ b/var/spack/repos/builtin/packages/xorg-server/package.py
@@ -47,7 +47,7 @@ class XorgServer(AutotoolsPackage):
 
     depends_on('flex', type='build')
     depends_on('bison', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     # TODO: add missing dependencies

--- a/var/spack/repos/builtin/packages/xorg-sgml-doctools/package.py
+++ b/var/spack/repos/builtin/packages/xorg-sgml-doctools/package.py
@@ -35,5 +35,5 @@ class XorgSgmlDoctools(AutotoolsPackage):
 
     version('1.11', '51cf4c6b476e2b98a068fea6975b9b21')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xphelloworld/package.py
+++ b/var/spack/repos/builtin/packages/xphelloworld/package.py
@@ -44,5 +44,5 @@ class Xphelloworld(AutotoolsPackage):
     # It looks like xprint support was removed from libxaw at some point.
     # But even the oldest version of libxaw doesn't build libxaw8.
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xplsprinters/package.py
+++ b/var/spack/repos/builtin/packages/xplsprinters/package.py
@@ -37,5 +37,5 @@ class Xplsprinters(AutotoolsPackage):
     depends_on('libxprintutil')
     depends_on('libx11')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xpr/package.py
+++ b/var/spack/repos/builtin/packages/xpr/package.py
@@ -38,5 +38,5 @@ class Xpr(AutotoolsPackage):
     depends_on('libx11')
 
     depends_on('xproto@7.0.17:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xprehashprinterlist/package.py
+++ b/var/spack/repos/builtin/packages/xprehashprinterlist/package.py
@@ -36,5 +36,5 @@ class Xprehashprinterlist(AutotoolsPackage):
     depends_on('libxp')
     depends_on('libx11')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xprop/package.py
+++ b/var/spack/repos/builtin/packages/xprop/package.py
@@ -37,5 +37,5 @@ class Xprop(AutotoolsPackage):
     depends_on('libx11')
 
     depends_on('xproto@7.0.17:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xproto/package.py
+++ b/var/spack/repos/builtin/packages/xproto/package.py
@@ -41,7 +41,7 @@ class Xproto(AutotoolsPackage):
     version('7.0.31', '04b925bf9e472c80f9212615cd684f1e')
     version('7.0.29', '16a78dd2c5ad73011105c96235f6a0af')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/xrandr/package.py
+++ b/var/spack/repos/builtin/packages/xrandr/package.py
@@ -39,5 +39,5 @@ class Xrandr(AutotoolsPackage):
     depends_on('libx11')
 
     depends_on('xproto@7.0.17:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xrdb/package.py
+++ b/var/spack/repos/builtin/packages/xrdb/package.py
@@ -37,5 +37,5 @@ class Xrdb(AutotoolsPackage):
     depends_on('libx11')
 
     depends_on('xproto@7.0.17:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xrefresh/package.py
+++ b/var/spack/repos/builtin/packages/xrefresh/package.py
@@ -36,5 +36,5 @@ class Xrefresh(AutotoolsPackage):
     depends_on('libx11')
 
     depends_on('xproto@7.0.17:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xrx/package.py
+++ b/var/spack/repos/builtin/packages/xrx/package.py
@@ -47,5 +47,5 @@ class Xrx(AutotoolsPackage):
 
     depends_on('xtrans', type='build')
     depends_on('xproxymanagementprotocol', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xscope/package.py
+++ b/var/spack/repos/builtin/packages/xscope/package.py
@@ -35,5 +35,5 @@ class Xscope(AutotoolsPackage):
 
     depends_on('xproto@7.0.17:', type='build')
     depends_on('xtrans', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xset/package.py
+++ b/var/spack/repos/builtin/packages/xset/package.py
@@ -37,5 +37,5 @@ class Xset(AutotoolsPackage):
     depends_on('libx11')
 
     depends_on('xproto@7.0.17:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xsetmode/package.py
+++ b/var/spack/repos/builtin/packages/xsetmode/package.py
@@ -36,5 +36,5 @@ class Xsetmode(AutotoolsPackage):
     depends_on('libxi')
     depends_on('libx11')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xsetpointer/package.py
+++ b/var/spack/repos/builtin/packages/xsetpointer/package.py
@@ -37,5 +37,5 @@ class Xsetpointer(AutotoolsPackage):
     depends_on('libx11')
 
     depends_on('inputproto@1.4:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xsetroot/package.py
+++ b/var/spack/repos/builtin/packages/xsetroot/package.py
@@ -39,5 +39,5 @@ class Xsetroot(AutotoolsPackage):
 
     depends_on('xbitmaps', type='build')
     depends_on('xproto@7.0.17:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xsm/package.py
+++ b/var/spack/repos/builtin/packages/xsm/package.py
@@ -39,5 +39,5 @@ class Xsm(AutotoolsPackage):
     depends_on('libsm')
     depends_on('libxaw')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xstdcmap/package.py
+++ b/var/spack/repos/builtin/packages/xstdcmap/package.py
@@ -40,5 +40,5 @@ class Xstdcmap(AutotoolsPackage):
     depends_on('libx11')
 
     depends_on('xproto@7.0.17:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xterm/package.py
+++ b/var/spack/repos/builtin/packages/xterm/package.py
@@ -52,4 +52,4 @@ class Xterm(AutotoolsPackage):
     depends_on('libxau')
     depends_on('bzip2')
 
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')

--- a/var/spack/repos/builtin/packages/xtrans/package.py
+++ b/var/spack/repos/builtin/packages/xtrans/package.py
@@ -36,5 +36,5 @@ class Xtrans(AutotoolsPackage):
 
     version('1.3.5', '6e4eac1b7c6591da0753052e1eccfb58')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xtrap/package.py
+++ b/var/spack/repos/builtin/packages/xtrap/package.py
@@ -36,5 +36,5 @@ class Xtrap(AutotoolsPackage):
     depends_on('libx11')
     depends_on('libxtrap')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xvidtune/package.py
+++ b/var/spack/repos/builtin/packages/xvidtune/package.py
@@ -40,5 +40,5 @@ class Xvidtune(AutotoolsPackage):
     depends_on('libxmu')
     depends_on('libx11')
 
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xvinfo/package.py
+++ b/var/spack/repos/builtin/packages/xvinfo/package.py
@@ -38,5 +38,5 @@ class Xvinfo(AutotoolsPackage):
     depends_on('libx11')
 
     depends_on('xproto@7.0.25:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xwd/package.py
+++ b/var/spack/repos/builtin/packages/xwd/package.py
@@ -37,5 +37,5 @@ class Xwd(AutotoolsPackage):
     depends_on('libxkbfile')
 
     depends_on('xproto@7.0.17:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xwininfo/package.py
+++ b/var/spack/repos/builtin/packages/xwininfo/package.py
@@ -38,5 +38,5 @@ class Xwininfo(AutotoolsPackage):
     depends_on('libx11')
 
     depends_on('xproto@7.0.17:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xwud/package.py
+++ b/var/spack/repos/builtin/packages/xwud/package.py
@@ -37,5 +37,5 @@ class Xwud(AutotoolsPackage):
     depends_on('libx11')
 
     depends_on('xproto@7.0.17:', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/zeromq/package.py
+++ b/var/spack/repos/builtin/packages/zeromq/package.py
@@ -47,7 +47,7 @@ class Zeromq(AutotoolsPackage):
     depends_on('autoconf', type='build', when='@develop')
     depends_on('automake', type='build', when='@develop')
     depends_on('libtool', type='build', when='@develop')
-    depends_on('pkg-config', type='build', when='@develop')
+    depends_on('pkgconfig', type='build', when='@develop')
 
     @when('@develop')
     def autoreconf(self, spec, prefix):


### PR DESCRIPTION
This PR is a proposal to migrate from `pkg-config` to `pkgconf`.

pkgconf is a new pkg-config implementation with additional features and no external dependencies. For a detailed comparison, see: http://pkgconf.org/features.html.

I have rebuilt a number of packages with the proposed changes and have not noticed any problems.

Edit: Several distributions have already switched from pkg-config to pkgconf: https://github.com/pkgconf/pkgconf/wiki/Roadmap