### PR TITLE
Fixed gsl issue while building on bg-q architecture

### DIFF
--- a/var/spack/repos/builtin/packages/gsl/package.py
+++ b/var/spack/repos/builtin/packages/gsl/package.py
@@ -41,3 +41,8 @@ class Gsl(AutotoolsPackage):
     version('2.1',   'd8f70abafd3e9f0bae03c52d1f4e8de5')
     version('2.0',   'ae44cdfed78ece40e73411b63a78c375')
     version('1.16',  'e49a664db13d81c968415cd53f62bc8b')
+
+    def configure_args(self):
+        spec = self.spec
+        if 'bgq' in spec.architecture and spec.satisfies('%xl'):
+            return ['LDFLAGS=-qnostaticlink']


### PR DESCRIPTION
Without this:

```
libtool: link: /gpfs/bbp.cscs....../sources/spack/lib/spack/env/xl/xlc -o .libs/gsl-histogram gsl-histogram.o  ./.libs/libgsl.so cblas/.libs/libgslcblas.so -lm -Wl,-rpath -Wl,/gpfs/bbp.cscs.ch/home/kumbhar/workarena/systems/lugviz/softwares/sources/spack/opt/spack/bgq-cnk-ppc64/xl-12.1/gsl-2.3-67yupbqwim25qvsok3zzqhokg2oa5vcc/lib
/bgsys/drivers/ppcfloor/gnu-linux/powerpc64-bgq-linux/bin/ld: attempted static link of dynamic object `./.libs/libgsl.so'
make[2]: *** [gsl-histogram] Error 1
make[2]: *** Waiting for unfinished jobs....
/bgsys/drivers/ppcfloor/gnu-linux/powerpc64-bgq-linux/bin/ld: attempted static link of dynamic object `./.libs/libgsl.so'
make[2]: *** [gsl-randist] Error 1
make[2]: Leaving directory `/tmp/kumbhar/spack-stage/spack-stage-SOq8Sf/gsl-2.3'
```

This fix make sure to build shared as well as static libraries correctly : 

```
$ ls /gpfs/bbp.cscs.....spack/opt/spack/bgq-cnk-ppc64/xl-12.1/gsl-2.3-67yupbqwim25qvsok3zzqhokg2oa5vcc/lib/
libgsl.a  libgslcblas.a  libgslcblas.la  libgslcblas.so  libgslcblas.so.0  libgslcblas.so.0.0.0  libgsl.la  libgsl.so  libgsl.so.19  libgsl.so.19.3.0  pkgconfig
```

EDIT:

`bg-q` XL compilers do `static` linking by default. GSL builds both shared and static libraries and hence we need `qnostaticlink` flag.