### PR TITLE
Minor refactoring of spec.py

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -312,10 +312,13 @@ def display_specs(specs, args=None, **kwargs):
 
         elif mode == 'deps':
             for spec in specs:
-                print(spec.tree(
+                line = spack.spec.tree(
+                    spec,
                     format=format_string,
                     indent=4,
-                    prefix=(lambda s: gray_hash(s, hlen)) if hashes else None))
+                    prefix=(lambda s: gray_hash(s, hlen)) if hashes else None
+                )
+                print(line)
 
         elif mode == 'short':
             # Print columns of output if not printing flags

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -239,7 +239,8 @@ def print_text_info(pkg):
                 inverse_map[when].add(spec)
         for when, specs in reversed(sorted(inverse_map.items())):
             line = "    %s provides %s" % (
-                when.colorized(), ', '.join(s.colorized() for s in specs)
+                spack.spec.colorized(when),
+                ', '.join(spack.spec.colorized(s) for s in specs)
             )
             print(line)
 

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -36,6 +36,7 @@ import spack.cmd
 import spack.cmd.common.arguments as arguments
 import spack.fetch_strategy
 import spack.report
+import spack.spec
 from spack.error import SpackError
 
 
@@ -221,13 +222,13 @@ def install(parser, args, **kwargs):
         with open(file, 'r') as f:
             s = spack.spec.Spec.from_yaml(f)
 
-        if s.concretized().dag_hash() != s.dag_hash():
+        if spack.spec.concretized(s).dag_hash() != s.dag_hash():
             msg = 'skipped invalid file "{0}". '
             msg += 'The file does not contain a concrete spec.'
             tty.warn(msg.format(file))
             continue
 
-        specs.append(s.concretized())
+        specs.append(spack.spec.concretized(s))
 
     if len(specs) == 0:
         tty.die('The `spack install` command requires a spec to install.')

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -77,10 +77,10 @@ def spec(parser, args):
         kwargs['hashes'] = False  # Always False for input spec
         print("Input spec")
         print("--------------------------------")
-        print(spec.tree(**kwargs))
+        print(spack.spec.tree(spec, **kwargs))
 
         kwargs['hashes'] = args.long or args.very_long
         print("Concretized")
         print("--------------------------------")
         spec.concretize()
-        print(spec.tree(**kwargs))
+        print(spack.spec.tree(spec, **kwargs))

--- a/lib/spack/spack/provider_index.py
+++ b/lib/spack/spack/provider_index.py
@@ -153,7 +153,7 @@ class ProviderIndex(object):
         result = {}
         for lspec, rspec in iproduct(lmap, rmap):
             try:
-                constrained = lspec.constrained(rspec)
+                constrained = spack.spec.constrained(lspec, rspec)
             except spack.spec.UnsatisfiableSpecError:
                 continue
 
@@ -161,7 +161,9 @@ class ProviderIndex(object):
             for lp_spec, rp_spec in iproduct(lmap[lspec], rmap[rspec]):
                 if lp_spec.name == rp_spec.name:
                     try:
-                        const = lp_spec.constrained(rp_spec, deps=False)
+                        const = spack.spec.constrained(
+                            lp_spec, rp_spec, deps=False
+                        )
                         result.setdefault(constrained, set()).add(const)
                     except spack.spec.UnsatisfiableSpecError:
                         continue

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -236,13 +236,13 @@ class collect_info(object):
 
             # The file 'junit.xml' is written when exiting
             # the context
-            specs = [Spec('hdf5').concretized()]
+            specs = [spack.spec.concretized(Spec('hdf5'))]
             with collect_info(specs, 'junit', 'junit.xml'):
                 # A report will be generated for these specs...
                 for spec in specs:
                     spec.do_install()
                 # ...but not for this one
-                Spec('zlib').concretized().do_install()
+                spack.spec.concretized(Spec('zlib')).do_install()
 
     Args:
         format_name (str or None): one of the supported formats

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2408,12 +2408,6 @@ class Spec(object):
             s.name for s in other.traverse(root=False))
         return common
 
-    def constrained(self, other, deps=True):
-        """Return a constrained copy without modifying this spec."""
-        clone = self.copy(deps=deps)
-        clone.constrain(other, deps)
-        return clone
-
     def dep_difference(self, other):
         """Returns dependencies in self that are not in other."""
         mine = set(s.name for s in self.traverse(root=False))
@@ -3244,7 +3238,7 @@ class LazySpecCache(collections.defaultdict):
 
 
 def concretized(spec):
-    """Returns a concretized copy of the argument spec
+    """Returns a concretized copy of a spec
 
     Args:
         spec (Spec): spec to be copied and concretized
@@ -3254,6 +3248,23 @@ def concretized(spec):
     """
     clone = spec.copy(caches=False)
     clone.concretize()
+    return clone
+
+
+def constrained(spec, other, deps=True):
+    """Returns a constrained copy of a spec
+
+    Args:
+        spec (Spec): spec to be copied and constrained
+        other (Spec): spec containing the constraints
+        deps (bool or deptype): specifies which dependency types
+            should be copied
+
+    Returns:
+        constrained copy of ``spec``
+    """
+    clone = spec.copy(deps=deps)
+    clone.constrain(other, deps)
     return clone
 
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1094,13 +1094,6 @@ class Spec(object):
     def external(self):
         return bool(self.external_path) or bool(self.external_module)
 
-    def get_dependency(self, name):
-        dep = self._dependencies.get(name)
-        if dep is not None:
-            return dep
-        raise InvalidDependencyError(
-            self.name + " does not depend on " + comma_or(name))
-
     def _find_deps(self, where, deptype):
         deptype = canonical_deptype(deptype)
 
@@ -2406,7 +2399,7 @@ class Spec(object):
 
         # Update with additional constraints from other spec
         for name in other.dep_difference(self):
-            dep_spec_copy = other.get_dependency(name)
+            dep_spec_copy = other._dependencies[name]
             dep_copy = dep_spec_copy.spec
             deptypes = dep_spec_copy.deptypes
             self._add_dependency(dep_copy.copy(), deptypes)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -143,6 +143,7 @@ from yaml.error import MarkedYAMLError
 
 __all__ = [
     'Spec',
+    'concretized',
     'parse',
     'parse_anonymous_spec',
     'SpecError',
@@ -1937,14 +1938,6 @@ class Spec(object):
             s._normal = value
             s._concrete = value
 
-    def concretized(self):
-        """This is a non-destructive version of concretize().  First clones,
-           then returns a concrete version of this package without modifying
-           this package. """
-        clone = self.copy(caches=False)
-        clone.concretize()
-        return clone
-
     def flat_dependencies(self, **kwargs):
         """Return a DependencyMap containing all of this spec's
            dependencies with their constraints merged.
@@ -3248,6 +3241,20 @@ class LazySpecCache(collections.defaultdict):
         value = self.default_factory(key)
         self[key] = value
         return value
+
+
+def concretized(spec):
+    """Returns a concretized copy of the argument spec
+
+    Args:
+        spec (Spec): spec to be copied and concretized
+
+    Returns:
+        concretized copy of ``spec``
+    """
+    clone = spec.copy(caches=False)
+    clone.concretize()
+    return clone
 
 
 #

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -207,26 +207,6 @@ _any_version = VersionList([':'])
 maxint = 2 ** (ctypes.sizeof(ctypes.c_int) * 8 - 1) - 1
 
 
-def colorize_spec(spec):
-    """Returns a spec colorized according to the colors specified in
-       color_formats."""
-    class insert_color:
-
-        def __init__(self):
-            self.last = None
-
-        def __call__(self, match):
-            # ignore compiler versions (color same as compiler)
-            sep = match.group(0)
-            if self.last == '%' and sep == '@':
-                return cescape(sep)
-            self.last = sep
-
-            return '%s%s' % (color_formats[sep], cescape(sep))
-
-    return colorize(re.sub(_separators, insert_color(), str(spec)) + '@.')
-
-
 @key_ordering
 class ArchSpec(object):
     """ The ArchSpec class represents an abstract architecture specification
@@ -2894,9 +2874,6 @@ class Spec(object):
             self._cmp_key_cache = key
         return key
 
-    def colorized(self):
-        return colorize_spec(self)
-
     def format(self, format_string='$_$@$%@+$+$=', **kwargs):
         """Prints out particular pieces of a spec, depending on what is
         in the format string.
@@ -3266,6 +3243,33 @@ def constrained(spec, other, deps=True):
     clone = spec.copy(deps=deps)
     clone.constrain(other, deps)
     return clone
+
+
+def colorized(spec):
+    """Returns a spec colorized according to the colors specified in
+    color_formats.
+
+    Args:
+        spec (Spec): spec to be colorized
+
+    Returns:
+        colorized string representation of the spec
+    """
+    class insert_color:
+
+        def __init__(self):
+            self.last = None
+
+        def __call__(self, match):
+            # ignore compiler versions (color same as compiler)
+            sep = match.group(0)
+            if self.last == '%' and sep == '@':
+                return cescape(sep)
+            self.last = sep
+
+            return '%s%s' % (color_formats[sep], cescape(sep))
+
+    return colorize(re.sub(_separators, insert_color(), str(spec)) + '@.')
 
 
 #

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3283,10 +3283,10 @@ def tree(spec, **kwargs):
         if show_types:
             out += '['
             if dep_spec.deptypes:
-                for t in alldeps:
+                for t in all_deptypes:
                     out += ''.join(t[0] if t in dep_spec.deptypes else ' ')
             else:
-                out += ' ' * len(alldeps)
+                    out += ' ' * len(all_deptypes)
             out += ']  '
 
         out += ("    " * d)

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -138,7 +138,7 @@ def test_package_output(tmpdir, capsys, install_mockery, mock_fetch):
     # we can't use output capture here because it interferes with Spack's
     # logging. TODO: see whether we can get multiple log_outputs to work
     # when nested AND in pytest
-    spec = Spec('printing-package').concretized()
+    spec = spack.spec.concretized(Spec('printing-package'))
     pkg = spec.package
     pkg.do_install(verbose=True)
 
@@ -178,7 +178,7 @@ def test_install_with_source(
         mock_packages, mock_archive, mock_fetch, config, install_mockery):
     """Verify that source has been copied into place."""
     install('--source', '--keep-stage', 'trivial-install-test-package')
-    spec = Spec('trivial-install-test-package').concretized()
+    spec = spack.spec.concretized(Spec('trivial-install-test-package'))
     src = os.path.join(
         spec.prefix.share, 'trivial-install-test-package', 'src')
     assert filecmp.cmp(os.path.join(mock_archive.path, 'configure'),

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -66,7 +66,7 @@ def check_spec(abstract, concrete):
 
 def check_concretize(abstract_spec):
     abstract = Spec(abstract_spec)
-    concrete = abstract.concretized()
+    concrete = spack.spec.concretized(abstract)
     assert not abstract.concrete
     assert concrete.concrete
     check_spec(abstract, concrete)

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -46,7 +46,7 @@ def concretize_scope(config, tmpdir):
 
 
 def concretize(abstract_spec):
-    return Spec(abstract_spec).concretized()
+    return spack.spec.concretized(Spec(abstract_spec))
 
 
 def update_packages(pkgname, section, value):

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -276,7 +276,7 @@ def _populate(mock_db):
       o  libelf
     """
     def _install(spec):
-        s = spack.spec.Spec(spec).concretized()
+        s = spack.spec.concretized(spack.spec.Spec(spec))
         pkg = spack.repo.get(s)
         pkg.do_install(fake=True)
 

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -158,7 +158,9 @@ def test_read_and_write_spec(
         assert norm.eq_dag(spec_from_file)
 
         # TODO: revise this when build deps are in dag_hash
-        conc = read_separately.concretized().copy(deps=stored_deptypes)
+        conc = spack.spec.concretized(read_separately).copy(
+            deps=stored_deptypes
+        )
         assert conc == spec_from_file
         assert conc.eq_dag(spec_from_file)
 
@@ -232,7 +234,7 @@ def test_find(layout_and_dir, config, mock_packages):
         if pkg.name.startswith('external'):
             # External package tests cannot be installed
             continue
-        spec = pkg.spec.concretized()
+        spec = spack.spec.concretized(pkg.spec)
         installed_specs[spec.name] = spec
         layout.create_install_directory(spec)
 

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -88,7 +88,7 @@ class MockStage(object):
 
 
 def test_partial_install_delete_prefix_and_stage(install_mockery, mock_fetch):
-    spec = Spec('canfail').concretized()
+    spec = spack.spec.concretized(Spec('canfail'))
     pkg = spack.repo.get(spec)
     remove_prefix = spack.package.Package.remove_prefix
     instance_rm_prefix = pkg.remove_prefix
@@ -146,7 +146,7 @@ def test_installed_dependency_request_conflicts(
 
 @pytest.mark.disable_clean_stage_check
 def test_partial_install_keep_prefix(install_mockery, mock_fetch):
-    spec = Spec('canfail').concretized()
+    spec = spack.spec.concretized(Spec('canfail'))
     pkg = spack.repo.get(spec)
 
     # Normally the stage should start unset, but other tests set it
@@ -172,7 +172,7 @@ def test_partial_install_keep_prefix(install_mockery, mock_fetch):
 
 
 def test_second_install_no_overwrite_first(install_mockery, mock_fetch):
-    spec = Spec('canfail').concretized()
+    spec = spack.spec.concretized(Spec('canfail'))
     pkg = spack.repo.get(spec)
     remove_prefix = spack.package.Package.remove_prefix
     try:
@@ -191,14 +191,14 @@ def test_second_install_no_overwrite_first(install_mockery, mock_fetch):
 
 
 def test_store(install_mockery, mock_fetch):
-    spec = Spec('cmake-client').concretized()
+    spec = spack.spec.concretized(Spec('cmake-client'))
     pkg = spec.package
     pkg.do_install()
 
 
 @pytest.mark.disable_clean_stage_check
 def test_failing_build(install_mockery, mock_fetch):
-    spec = Spec('failing-build').concretized()
+    spec = spack.spec.concretized(Spec('failing-build'))
     pkg = spec.package
 
     with pytest.raises(spack.build_environment.ChildError):

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -83,7 +83,7 @@ def check_mirror():
 
             # Now try to fetch each package.
             for name, mock_repo in repos.items():
-                spec = Spec(name).concretized()
+                spec = spack.spec.concretized(Spec(name))
                 pkg = spec.package
 
                 with spack.config.override('config:checksum', False):

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -493,7 +493,7 @@ class TestSpecSematics(object):
 
     def test_satisfies_same_spec_with_different_hash(self):
         """Ensure that concrete specs are matched *exactly* by hash."""
-        s1 = Spec('mpileaks').concretized()
+        s1 = spack.spec.concretized(Spec('mpileaks'))
         s2 = s1.copy()
 
         assert s1.satisfies(s2)


### PR DESCRIPTION
This PR applies a trivial refactoring technique (extract a method from a class) to `spec.py`. The aim is to prepare the stage for bigger refactoring later on, in case they are needed, and give a more modular structure to the code.

The rationale is to extract from the `Spec` class methods that don't modify `self` and return a value as a result of the call. In certain cases, like `concretized`, changing the code from:
```python
spec = ...
s = spec.concretized()  # Returns a new object
spec.concretize()  # Modifies self
```
to:
```python
spec = ...
s = concretized(spec)  # Returns a new object
spec.concretize()  # Modifies self
```
mimics what built-in do for `l.sort()` vs. `s = sorted(l)`.

In principle extracting methods this way should ease mocking in unit tests, even though - to be fair - it's not probably the case for the four methods extracted here.

The long-term idea is that, whenever we feel like time has come to split `spec.py` into smaller pieces, it should be easy to re-organize the code as a sub-package:
```console
spec
├── __init__.py
├── exceptions.py
├── format.py # This 'import .spec' and contains `tree`, `colorized`, maybe `format`
└── spec.py  # Core classes, like Spec.
└── ...
```
and still maintain the same interface to the clients that `import spack.spec`.

##### Modifications in details
- [x] removed method `Spec.get_dependency` as it was used only one time in another method of `Spec`
- [x] removed method `Spec._install_status` for the same reason as above
- [x] made `Spec.concretized` a free-standing function
- [x] made `Spec.constrained` a free-standing function
- [x] made `Spec.colorized` a free-standing function
- [x] made `Spec.tree` a free-standing function
- [x] extended docstrings in the process
