### PR TITLE
gcc: remove all variant

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -60,12 +60,17 @@ class Gcc(AutotoolsPackage):
     version('4.6.4', 'b407a3d1480c11667f293bfb1f17d1a4')
     version('4.5.4', '27e459c2566b8209ab064570e1b378f7')
 
-    # Builds all default languages by default.
-    # Ada, Go, Jit, and Objective-C++ are not default languages.
+    # We specifically do not add 'all' variant here because:
+    # (i) Ada, Go, Jit, and Objective-C++ are not default languages.
     # In that respect, the name 'all' is rather misleading.
+    # (ii) Languages other than c,c++,fortran are prone to configure bug in GCC
+    # For example, 'java' appears to ignore custom location of zlib
+    # (iii) meaning of 'all' changes with GCC version, i.e. 'java' is not part
+    # of gcc7. Correctly specifying conflicts() and depends_on() in such a
+    # case is a PITA.
     variant('languages',
-            default='all',
-            values=('all', 'ada', 'brig', 'c', 'c++', 'fortran',
+            default='c,c++,fortran',
+            values=('ada', 'brig', 'c', 'c++', 'fortran',
                     'go', 'java', 'jit', 'lto', 'objc', 'obj-c++'),
             multi=True,
             description='Compilers and runtime libraries to build')
@@ -89,7 +94,6 @@ class Gcc(AutotoolsPackage):
     depends_on('gnat', when='languages=ada')
     depends_on('binutils~libiberty', when='+binutils')
     depends_on('zip', type='build', when='languages=java')
-    depends_on('zip', type='build', when='@:6 languages=all')
 
     # TODO: integrate these libraries.
     # depends_on('ppl')


### PR DESCRIPTION
tested on `Ubuntu 16.04`:

- [x] 7.2.0
- [x] 6.4.0
- [x] 5.4.0
- [x] 4.9.4
- [x] 4.8.5 see https://github.com/spack/spack/pull/5283#issuecomment-347826988 p.s. I could not build it due to unrelated build error with `libstdc++.so.6.: version CXXABI_1.3.8 not found (required by /usr/lib/x86_64-linux-gnu/libicuuc.so.55)`, could be related to [this](https://gcc.gnu.org/onlinedocs/libstdc++/faq.html#faq.how_to_set_paths) and most likely [that](https://stackoverflow.com/questions/35392310/error-building-gcc-4-8-3-from-source-libstdc-so-6-version-cxxabi-1-3-8-not). [EasyBuild](https://github.com/easybuilders/easybuild/issues/158) has the same issue. Maybe we simply miss `depends_on('gettext')`
- [ ] 4.7.4 -- first version without `c` language option, conflict is already declared in the package. Unfortunately can't build it with `languages=c++,fortran` due to another build error `cfns.gperf:32.1: error: unknown type name class`