### PR TITLE
Implementation to jail Spack inside a user chroot using Linux namespaces

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -66,6 +66,12 @@ config:
   checksum: true
 
 
+  # If set to true, Spack will isolate itself in an chroot enviroment.
+  # This option only work in an enviroment created with
+  # ./spack bootstrap --isolate path
+  isolate: false
+
+
   # If set to true, `spack install` and friends will NOT clean
   # potentially harmful variables from the build environment. Use wisely.
   dirty: false

--- a/lib/spack/spack/cmd/isolate.py
+++ b/lib/spack/spack/cmd/isolate.py
@@ -1,0 +1,266 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+import os
+from socket import *
+
+import llnl.util.tty as tty
+import spack
+import spack.cmd
+from spack.util.executable import ProcessError, which
+from llnl.util.filesystem import join_path, mkdirp
+from spack.util.chroot import build_chroot_environment
+from spack.util.chroot import remove_chroot_environment
+from spack.util.chroot import run_command
+
+description = "manages the isolation of spack by a jail"
+section = "admin"
+level = "long"
+
+
+def setup_parser(subparser):
+    subparser.add_argument(
+        '--build-environment', action='store', dest='build_environment',
+        help="create a environment to jail spack")
+    subparser.add_argument(
+        '--remove-environment', action='store_true', dest='remove_environment',
+        help="shutdown the local spack jailed enviroment")
+    subparser.add_argument(
+        '--permanent', action='store_true', dest='permanent',
+        help="""generate a permanent chroot environment to require
+administrator rights when using spack as an user""")
+    subparser.add_argument(
+        '-f', '--force', action='store_true', dest='force',
+        help="force the command (use this with caution!)")
+    subparser.add_argument(
+        '--cli', action='store_true', dest='cli',
+        help="connect to a bash session in the generated environment")
+    subparser.add_argument(
+        '-r', '--remote', action='store', dest='remote',
+        help="name of the remote to bootstrap from",
+        default='origin')
+    subparser.add_argument(
+        '--tarball',
+        help="name of the tar file which contains the operating system")
+    # subparser.add_argument(
+    # '--install-daemon', action='store_true', dest='create_daemon',
+    # help="connect to a bash session in the generated environment"
+    # )
+    # subparser.add_argument(
+    # '--remove-daemon', action='store_false', dest='create_daemon',
+    # help="connect to a bash session in the generated environment"
+    # )
+    subparser.add_argument(
+        '--start-daemon', action='store_true', dest='start_daemon',
+        help="Start a daemon which handles the mount bind process"
+    )
+    subparser.add_argument(
+        '--stop-daemon', action='store_true', dest='stop_daemon',
+        help="Stops the daemon which handles the mount bind process"
+    )
+
+
+def get_origin_info(remote):
+    git_dir = join_path(spack.prefix, '.git')
+    git = which('git', required=True)
+    try:
+        branch = git('symbolic-ref', '--short', 'HEAD', output=str)
+    except ProcessError:
+        branch = 'develop'
+        tty.warn('No branch found; using default branch: %s' % branch)
+    if remote == 'origin' and branch not in ('master', 'develop'):
+        branch = 'develop'
+        tty.warn('Unknown branch found; using default branch: %s' % branch)
+    try:
+        origin_url = git(
+            '--git-dir=%s' % git_dir,
+            'config', '--get', 'remote.%s.url' % remote,
+            output=str)
+    except ProcessError:
+        origin_url = 'https://github.com/LLNL/spack.git'
+        tty.warn('No git repository found; '
+                 'using default upstream URL: %s' % origin_url)
+    return (origin_url.strip(), branch.strip())
+
+
+def adapt_config(install_dir, permanent):
+    """
+    Rewrite the configuration file in the bootstrapped environment to inform
+    the local spack that it is running in a isolated environment.
+    """
+    etc_path = join_path(install_dir, "etc")
+    config_path = join_path(etc_path, "spack")
+
+    # Add the boostrap file to the config list
+    spack.config.ConfigScope('bootstrap', config_path)
+    config = spack.config.get_config('config', 'bootstrap')
+
+    # write to the config
+    config['isolate'] = True
+    config['permanent'] = permanent
+    spack.config.update_config('config', config, 'bootstrap')
+
+
+def check_file_owner(prefix):
+    if os.geteuid() == 0:
+        who = which('who', required=True)
+        chown = which('chown', required=True)
+
+        username = who(output=str).split(' ')[0]
+        group = get_group(username)
+        chown('-R', '%s:%s' % (username, group), '%s' % (prefix))
+
+
+def unpack_environment(path, tarball):
+    tar = which('tar', required=True)
+    tar('-xzf', tarball, '-C', path, '--strip-components=1')
+
+
+def construct_environment(force, permanent):
+    lockFile = os.path.join(spack.spack_root, '.env')
+    if not os.path.exists(lockFile) or force:
+        tty.msg("Startup bootstraped enviroment")
+
+        home = os.path.join(spack.spack_bootstrap_root, 'home')
+        tmp = os.path.join(spack.spack_bootstrap_root, 'tmp')
+        install_dir = os.path.join(home, 'spack')
+
+        mkdirp(home)
+        mkdirp(tmp)
+        mkdirp(install_dir)
+
+        build_chroot_environment(spack.spack_bootstrap_root, permanent)
+
+        # update the config to set the isolation mode active
+        config = spack.config.get_config("config", "site")
+        config['isolate'] = True
+        spack.config.update_config("config", config, "site")
+        with open(lockFile, "w") as out:
+            out.write('please do not remove this file')
+
+
+def destroy_environment(force):
+    lockFile = os.path.join(spack.spack_root, '.env')
+    if os.path.exists(lockFile) or force:
+        tty.msg("Shutdown bootstraped enviroment")
+
+        config = spack.config.get_config("config", "site")
+        config['isolate'] = False
+        wasPermanent = config['permanent']
+        config['permanent'] = False
+        spack.config.update_config("config", config, "site")
+
+        remove_chroot_environment(spack.spack_bootstrap_root, wasPermanent)
+        os.remove(lockFile)
+
+
+def start_daemon():
+    if os.getuid() != 0:
+        tty.die("Starting the daemon require root rights")
+    daemon = MountDaemon(stdout='/tmp/spack-mount.out',
+                         stderr='/tmp/spack-mount.err')
+    daemon.start()
+
+
+def stop_daemon():
+    if os.getuid() != 0:
+        tty.die("Stopping the daemon require root rights")
+    daemon = MountDaemon()
+    daemon.stop()
+
+
+def isolate(parser, args):
+    force = args.force
+    build_enviroment = args.build_environment
+    permanent = args.permanent
+    if build_enviroment:
+        # origin_url, branch = get_origin_info(args.remote)
+        origin_url = "/home/spack/Documents/Projects/spack"
+        branch = "features/bootstrap-final"
+
+        prefix = args.build_environment
+        tarball = args.tarball
+        permanent = args.permanent
+
+        tty.msg("Fetching spack from '%s': %s" % (args.remote, origin_url))
+        if not tarball:
+            tty.die("Require a tarball with the target system")
+
+        if os.path.isfile(prefix):
+            tty.die("There is already a file at %s" % prefix)
+        mkdirp(prefix)
+
+        # TODO remove environment if an error ocurred
+        unpack_environment(prefix, tarball)
+        home = os.path.join(prefix, 'home')
+        install_dir = os.path.join(home, 'spack')
+
+        mkdirp(home)
+        mkdirp(install_dir)
+
+        # generate and remove enviroment
+        build_chroot_environment(prefix, permanent)
+        if not permanent:
+            remove_chroot_environment(prefix, False)
+
+        if os.path.exists(join_path(install_dir, '.git')):
+            tty.die("There already seems to be a git repository in %s" %
+                    prefix)
+
+        files_in_the_way = os.listdir(install_dir)
+        if files_in_the_way:
+            tty.die("There are already files there! "
+                    "Delete these files before boostrapping spack.",
+                    *files_in_the_way)
+
+        tty.msg("Installing:",
+                "%s/bin/spack" % install_dir,
+                "%s/lib/spack/..." % install_dir)
+
+        os.chdir(install_dir)
+        git = which('git', required=True)
+        git('init', '--shared', '-q')
+        git('remote', 'add', 'origin', origin_url)
+        git('fetch', 'origin', '%s:refs/remotes/origin/%s' % (branch, branch),
+                               '-n', '-q')
+        git('reset', '--hard', 'origin/%s' % branch, '-q')
+        git('checkout', '-B', branch, 'origin/%s' % branch, '-q')
+
+        tty.msg("Successfully created a new spack in %s" % prefix,
+                "Run %s/home/spack/bin/spack to use this installation." %
+                prefix)
+
+        adapt_config(install_dir, permanent)
+        check_file_owner(prefix)
+
+    if args.remove_environment:
+        destroy_environment(force)
+    if args.start_daemon:
+        start_daemon()
+    if args.stop_daemon:
+        stop_daemon()
+    if args.cli:
+        construct_environment(False, False)
+        run_command('/bin/bash', None)
+        destroy_environment(False)

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -65,6 +65,8 @@ schema = {
                 'misc_cache': {'type': 'string'},
                 'verify_ssl': {'type': 'boolean'},
                 'checksum': {'type': 'boolean'},
+                'isolate': {'type': 'boolean'},
+                'permanent':  {'type': 'boolean'},
                 'dirty': {'type': 'boolean'},
                 'build_jobs': {'type': 'integer', 'minimum': 1},
             }

--- a/lib/spack/spack/util/chroot.py
+++ b/lib/spack/spack/util/chroot.py
@@ -1,0 +1,157 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+import os
+import sys
+import spack
+import llnl.util.tty as tty
+from spack.util.executable import which
+from spack.util.user_chroot import user_chroot
+
+# Files or paths which need to be binded with mount --bind
+BIND_PATHS = [
+    '/dev',
+    '/sys',
+    '/proc'
+]
+
+# Files or paths which need to be copied
+COPY_PATHS = [
+    '/etc/resolv.conf'
+]
+
+
+def mount_bind_path(realpath, chrootpath, permanent):
+        mount = True
+        if os.path.isfile(realpath):
+            if not os.path.exists(os.path.dirname(chrootpath)):
+                os.makedirs(os.path.dirname(chrootpath))
+
+            if not os.path.exists(chrootpath):
+                open(chrootpath, "w").close()
+        else:
+            # Don't include empty directories
+            if os.listdir(realpath):
+                if not os.path.exists(chrootpath):
+                    os.makedirs(chrootpath)
+            else:
+                mount = False
+
+        if mount:
+            os.system("sudo mount --bind %s %s" % (realpath, chrootpath))
+
+
+def umount_bind_path(chrootpath, permanent):
+    # remove permanent mount point
+    if permanent:
+        Fstab.remove_by_mountpoint(chrootpath)
+
+    # Don't unmount no existing directories
+    if os.path.exists(chrootpath):
+        os.system("sudo umount -l %s" % (chrootpath))
+
+
+def copy_path(realpath, chrootpath):
+    if os.path.exists(realpath):
+        os.system("cp %s %s" % (realpath, chrootpath))
+
+
+def copy_environment(dir):
+    for lib in COPY_PATHS:
+        copy_path(lib, os.path.join(dir, lib[1:]))
+
+
+def build_chroot_environment(dir, permanent):
+    if os.path.ismount(dir):
+        tty.die("The path is already a bootstraped enviroment")
+
+    # only mount bind when user is root
+    if os.getpid() == 0:
+        lockFile = os.path.join(spack.spack_root, '.env')
+        open(lockFile, 'w').close()
+
+        for lib in BIND_PATHS:
+            mount_bind_path(lib, os.path.join(dir, lib[1:]), permanent)
+
+    copy_environment(dir)
+
+
+def remove_chroot_environment(dir, permanent):
+    if os.getpid() == 0:
+        lockFile = os.path.join(spack.spack_root, '.env')
+        if os.path.exists(lockFile):
+            os.remove(lockFile)
+        for lib in BIND_PATHS:
+            umount_bind_path(os.path.join(dir, lib[1:]), permanent)
+
+
+def get_group(username):
+    groups = which("groups", required=True)
+
+    # just use the first group
+    group = groups(username, output=str).split(':')[1].strip().split(' ')[0]
+    return group
+
+
+def get_username_and_group():
+    whoami = which("whoami", required=True)
+    username = whoami(output=str).replace('\n', '')
+    return username, get_group(username)
+
+
+def run_command(command, arguments):
+    if os.getuid() != 0:
+        user_chroot(spack.spack_bootstrap_root + "/", command, arguments)
+    else:
+        chroot = which('chroot', required=True)
+        name, group = get_username_and_group()
+        chroot("--userspec=%s:%s" % (name, group),
+               spack.spack_bootstrap_root,
+               "%s %s" % (command, ' '.join(arguments[1:])))
+
+
+def isolate_environment():
+    if os.getpid() != 0:
+        tty.msg("Isolate spack through namespaces")
+    else:
+        tty.msg("Isolate spack through mount bind")
+
+    lockFile = os.path.join(spack.spack_root, '.env')
+    existed = True
+
+    # check if the environment has to be generated
+    config = spack.config.get_config("config", "site")
+    permanent = config['permanent']
+
+    if not os.path.exists(lockFile) and not permanent:
+        build_chroot_environment(spack.spack_bootstrap_root, False)
+        existed = False
+    else:
+        # copy necessary files
+        copy_environment(spack.spack_bootstrap_root)
+
+    run_command('/home/spack/bin/spack', sys.argv)
+
+    if not existed:
+        remove_chroot_environment(spack.spack_bootstrap_root, False)

--- a/lib/spack/spack/util/user_chroot.py
+++ b/lib/spack/spack/util/user_chroot.py
@@ -1,0 +1,625 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+import os
+import sys
+import signal
+import ctypes
+import platform
+import ctypes.util
+import llnl.util.tty as tty
+
+libc_so = ctypes.util.find_library('c')
+libc = ctypes.CDLL(libc_so, use_errno=True)
+
+# defines
+PR_CAP_AMBIENT = 47
+PR_CAP_AMBIENT_RAISE = 2
+PR_CAPBSET_DROP = 24
+PR_SET_PDEATHSIG = 1
+PR_SET_NO_NEW_PRIVS = 38
+
+
+LINUX_CAPABILITY_VERSION_3 = 0x20080522
+
+
+CAP_SETGID = 6
+CAP_SETUID = 7
+CAP_NET_ADMIN = 12
+CAP_SYS_CHROOT = 18
+CAP_SYS_ADMIN = 21
+
+
+AT_FDCWD = -100
+
+
+O_PATH = 0o10000000
+O_CLOEXEC = 0o2000000
+
+
+MS_NOSUID = 2
+MS_NODEV = 4
+MS_BIND = 4096
+MS_REC = 16384
+MS_PRIVATE = 262144
+MS_SLAVE = 524288
+
+
+MNT_DETACH = 2
+
+
+EFD_SEMAPHORE = 0o0000001
+EFD_CLOEXEC = 0o2000000
+EFD_NONBLOCK = 0o0004000
+
+
+SFD_CLOEXEC = 0o2000000
+SFD_NONBLOCK = 0o0004000
+
+
+SIG_BLOCK = 0
+SIG_UNBLOCK = 1
+SIG_SETMASK = 2
+
+
+CLONE_NEWNS = 0x00020000
+CLONE_NEWUSER = 0x10000000
+CLONE_NEWPID = 0x20000000
+
+
+POLLIN = 0x001
+
+
+WNOHANG = 1
+
+# path of the new root
+base_path = None
+
+
+def cap_to_mask0(x):
+    return 1 << (x & 31)
+
+
+def cap_to_mask1(x):
+    return cap_to_mask0(x - 32)
+
+
+REQUIRED_CAPS_1 = 0
+REQUIRED_CAPS_0 = \
+    cap_to_mask0(CAP_SETGID) | \
+    cap_to_mask0(CAP_SETUID) | \
+    cap_to_mask0(CAP_NET_ADMIN) | \
+    cap_to_mask0(CAP_SYS_CHROOT) | \
+    cap_to_mask0(CAP_SYS_ADMIN)
+
+
+if platform.architecture()[0] == '64bit':
+    NR_CLONE = 56
+elif platform.architecture()[0] == '32bit':
+    NR_CLONE = 120
+
+if platform.architecture()[0] == '64bit':
+    NR_PIVOT_ROOT = 155
+elif platform.architecture()[0] == '32bit':
+    NR_PIVOT_ROOT = 217
+
+
+# structures
+class User_Cap_Header(ctypes.Structure):
+    _fields_ = [
+        ("version", ctypes.c_uint32),
+        ("pid", ctypes.c_int)]
+
+
+class User_Cap_Data(ctypes.Structure):
+    _fields_ = [
+        ("effective0", ctypes.c_uint32),
+        ("permitted0", ctypes.c_uint32),
+        ("inheritable0", ctypes.c_uint32),
+        ("effective1", ctypes.c_uint32),
+        ("permitted1", ctypes.c_uint32),
+        ("inheritable1", ctypes.c_uint32)]
+
+
+class PollFd2(ctypes.Structure):
+    _fields_ = [("fd0", ctypes.c_int),
+                ("events0", ctypes.c_short),
+                ("revents0", ctypes.c_short),
+                ("fd1", ctypes.c_int),
+                ("events1", ctypes.c_short),
+                ("revents1", ctypes.c_short)]
+
+
+def die(reason):
+    if base_path:
+        os.rmdir(base_path)
+    tty.die(reason)
+
+
+def get_cap_count():
+    with open('/proc/sys/kernel/cap_last_cap') as f:
+        return int(f.read())
+    return -1
+
+
+def eventfd(initval, flags):
+    return libc.eventfd(ctypes.c_uint(initval),
+                        ctypes.c_int(flags))
+
+
+def waitpid(id, flags):
+    status = ctypes.c_int(0)
+    return libc.waitpid(ctypes.c_ulong(id),
+                        ctypes.byref(status),
+                        ctypes.c_int(flags))
+
+
+def prctl(option, arg2, arg3, arg4, arg5):
+    return libc.prctl(ctypes.c_int(option),
+                      ctypes.c_ulong(arg2),
+                      ctypes.c_ulong(arg3),
+                      ctypes.c_ulong(arg4),
+                      ctypes.c_ulong(arg5))
+
+
+def pivot_syscall(new_root, old_root):
+    clone = ctypes.CDLL(None).syscall
+    return clone(NR_PIVOT_ROOT,
+                 ctypes.c_char_p(new_root),
+                 ctypes.c_char_p(old_root))
+
+
+def clone_syscall(flags, stack):
+    clone = ctypes.CDLL(None).syscall
+    return clone(NR_CLONE,
+                 ctypes.c_ulong(flags),
+                 ctypes.c_void_p(stack))
+
+
+def mount(source, dest, type, flags, data):
+    return libc.mount(ctypes.c_char_p(source),
+                      ctypes.c_char_p(dest),
+                      ctypes.c_char_p(type),
+                      ctypes.c_ulong(flags),
+                      ctypes.c_void_p(data))
+
+
+def umount(target, flags):
+    return libc.umount2(ctypes.c_char_p(target), ctypes.c_int(flags))
+
+
+def setfsuid(fsuid):
+    """Set user identity used for filesystem checks. See setfsuid(2)."""
+    libc.setfsuid(ctypes.c_int(fsuid))
+    new_fsuid = libc.setfsuid(ctypes.c_int(fsuid))
+    err = errno.EPERM if new_fsuid != fsuid else ctypes.get_errno()
+    if err:
+        raise OSError(err, os.strerror(err))
+    return new_fsuid
+
+
+def get_caps():
+    header = User_Cap_Header()
+    header.version = LINUX_CAPABILITY_VERSION_3
+    header.pid = 0
+
+    data = User_Cap_Data()
+    if (libc.capget(ctypes.byref(header), ctypes.byref(data)) < 0):
+        die("capset failed")
+    return data
+
+
+def prctl_caps(caps, do_cap_bounding, do_set_ambient):
+    cap_count = get_cap_count()
+    for cap in range(0, cap_count + 1):
+        keep = False
+        if cap < 32:
+            if cap_to_mask0(cap) & caps[0]:
+                keep = True
+        else:
+            if cap_to_mask1(cap) & caps[1]:
+                keep = True
+
+        if keep and do_set_ambient:
+            result = prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE, cap, 0, 0)
+            if (result == -1):
+                die("Error while setting ambient capability")
+        if not keep and do_cap_bounding:
+            result = prctl(PR_CAPBSET_DROP, cap, 0, 0, 0)
+            if (result == -1):
+                die("Error while dropping ambient capability")
+
+
+def drop_cap_set(requested_caps=None):
+    if requested_caps:
+        prctl_caps(requested_caps, True, False)
+    else:
+        prctl_caps([0, 0], True, False)
+
+
+def drop_all_caps(keep_requested_caps):
+    if keep_requested_caps:
+        return
+    else:
+        header = User_Cap_Header()
+        header.version = LINUX_CAPABILITY_VERSION_3
+        header.pid = 0
+
+        data = User_Cap_Data()
+        data.effective0 = 0
+        data.permitted0 = 0
+        data.inheritable0 = 0
+        data.effective1 = 0
+        data.permitted1 = 0
+        data.inheritable1 = 0
+
+        if libc.capset(ctypes.byref(header), ctypes.byref(data)) < 0:
+            die('Could not drop caps')
+
+
+def set_required_caps():
+    header = User_Cap_Header()
+    header.version = LINUX_CAPABILITY_VERSION_3
+    header.pid = 0
+
+    data = User_Cap_Data()
+    data.effective0 = REQUIRED_CAPS_0
+    data.permitted0 = REQUIRED_CAPS_0
+    data.inheritable0 = 0
+    data.effective1 = REQUIRED_CAPS_1
+    data.permitted1 = REQUIRED_CAPS_1
+    data.inheritable1 = 0
+    if (libc.capset(ctypes.byref(header), ctypes.byref(data)) < 0):
+        die("capset failed")
+
+
+def die_with_parent():
+    if prctl(PR_SET_PDEATHSIG, signal.SIGKILL, 0, 0, 0) != 0:
+        die('Could not die with parent')
+
+
+def drop_privileges(new_uid, keep_requested_caps):
+    if os.getuid() == 0:
+        os.setuid(new_uid)
+    drop_all_caps(keep_requested_caps)
+
+
+def block_sigchild():
+    mask = ctypes.pointer(ctypes.c_ulong(0))
+    libc.sigemptyset(mask)
+    libc.sigaddset(mask, signal.SIGCHLD)
+    if libc.sigprocmask(SIG_BLOCK, mask, ctypes.c_void_p(0)) < 0:
+        die('sigprocmask')
+    while (waitpid(-1, WNOHANG) > 0):
+        pass
+
+
+def check_privileges(real_uid):
+    privileged = False
+    euid = os.geteuid()
+
+    caps = get_caps()
+    if euid != real_uid:
+        if euid == 0:
+            privileged = True
+        else:
+            die("Unexpected user should be 0")
+
+        if setfsuid(real_uid) < 0:
+            die("Unable to set fsuid")
+
+        new_fsuid = setfsuid(-1)
+        if (new_fsuid != real_uid):
+            die("Unable to set fsuid")
+
+        drop_cap_set()
+        set_required_caps()
+    elif real_uid != 0 and (caps.permitted0 != 0 or caps.permitted1 != 0):
+        die("Unexpected capabilities")
+    elif real_uid == 0:
+        privileged = True
+    return privileged, caps
+
+
+def create_dir(path, mode):
+    try:
+        os.mkdir(path, mode)
+        return True
+    except Exception:
+        return False
+
+
+def monitor_child(proc_fd, child_pid, base_path):
+    while True:
+        died_pid = waitpid(-1, WNOHANG)
+        while died_pid > 0:
+            if died_pid == child_pid:
+                os.rmdir(base_path)
+                sys.exit(0)
+            died_pid = waitpid(-1, WNOHANG)
+
+
+def create_file(path, mode):
+    if os.path.exists(path):
+        return 0
+
+    fd = libc.creat(ctypes.c_char_p(path), ctypes.c_int(mode))
+    if fd == -1:
+        return -1
+
+    libc.close(fd)
+    return 0
+
+
+def write_file_at(dir_fd, path, content):
+    fd = libc.openat(dir_fd, ctypes.c_char_p(path),
+                     ctypes.c_int(os.O_RDWR | O_CLOEXEC),
+                     ctypes.c_int(0))
+    if fd == -1:
+        return -1
+
+    if content:
+        os.write(fd, content)
+
+    libc.close(fd)
+    return 0
+
+
+def read_file_at(dir_fd, path):
+    fd = libc.openat(dir_fd, path, O_CLOEXEC | os.O_RDONLY)
+    if fd == -1:
+        return None
+
+    data = ""
+    tmp = os.read(fd, 1)
+    while tmp:
+        data += tmp
+        tmp = os.read(fd, 1)
+
+    libc.close(fd)
+    return data
+
+
+def switch_to_user_with_privs(priv, caps):
+    drop_cap_set()
+    if not priv:
+        return 0
+    else:
+        die('Program is not supposed to be root')
+
+
+def read_overflow_ids():
+    uid_data = read_file_at(AT_FDCWD, b'/proc/sys/kernel/overflowuid')
+    if not uid_data:
+        die('Could not read overflowuid')
+
+    gid_data = read_file_at(AT_FDCWD, b'/proc/sys/kernel/overflowgid')
+    if not gid_data:
+        die('Could not read overflowuid')
+    return int(uid_data), int(gid_data)
+
+
+def write_uid_gid_map(proc_fd,
+                      chroot_uid, parent_uid,
+                      chroot_gid, parent_gid,
+                      pid, deny_groups, map_root):
+    if pid == -1:
+        dir = b'self'
+
+    dir_fd = libc.openat(proc_fd, ctypes.c_char_p(dir),
+                         ctypes.c_int(os.O_RDONLY | O_PATH))
+    if dir_fd < 0:
+        die('could not open proc/self')
+
+    if map_root and parent_uid != 0 and chroot_uid != 0:
+        uid_map = "0 %s 1\n%d %d 1\n" % (overflow_uid, chroot_uid, parent_uid)
+    else:
+        uid_map = "%s %s 1\n" % (chroot_uid, parent_uid)
+    gid_map = "%s %s 1\n" % (chroot_gid, parent_gid)
+
+    if write_file_at(dir_fd, b'uid_map', uid_map.encode()) != 0:
+        die('Error setting uid map')
+
+    if deny_groups:
+        if write_file_at(dir_fd, b'setgroups', b'deny\n') != 0:
+            die('Error writing to setgroups')
+
+    if write_file_at(dir_fd, b'gid_map', gid_map.encode()) != 0:
+        die('Error setting gid map')
+
+
+def setup_newroot(location):
+    # Mount new home as /
+    if mount(('/oldroot/%s' % location).encode(), b'/newroot/', None,
+             MS_BIND | MS_REC, None) != 0:
+        die('Could not mount home')
+
+    # TODO maybe allow only a few files to be mounted
+    if mount(b'/oldroot/dev', b'/newroot/dev', None,
+             MS_BIND | MS_REC, None) != 0:
+        die('Could not mount dev')
+
+    if mount(b'/oldroot/sys', b'/newroot/sys', None,
+             MS_BIND | MS_REC, None) != 0:
+        die('Could not mount sys')
+
+    if mount(b'/oldroot/proc', b'/newroot/proc', None,
+             MS_BIND | MS_REC, None) != 0:
+        die('Could not mount proc')
+
+
+def user_chroot(location, command, arguments):
+    """
+    The command allows the use of chroot while being user.
+    This is possible because, it creates a new namespace for the
+    user, like unshare but allows to change the uid and gid, as well
+    as mount bind files via the namespace.
+
+    The implementation is based on bubblewrap:
+    https://github.com/projectatomic/bubblewrap
+
+    But is simplified to work with python, without the need
+    for c modules. Therefore this implementation does not allow to
+    create a pid or net newspace. It also maps dev, sys and proc automatically.
+    """
+
+    real_uid, real_gid = os.getuid(), os.getgid()
+    chroot_uid, chroot_gid = real_uid, real_gid
+
+    if real_uid == 0:
+        die('User namespaces must be called without root privileges')
+
+    priv, caps = check_privileges(real_uid)
+
+    # dont let the process get any new privileges to avoid
+    # utilization of setuid and setguid to become root or leave the jail
+    if prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) < 0:
+        die('Could not set PR_SET_NO_NEW_PRIVS')
+
+    # overflow_uid, overflow_gid = read_overflow_ids()
+
+    # open the proc directory
+    proc_fd = os.open('/proc', os.O_RDONLY | O_PATH)
+    if proc_fd == -1:
+        die('could not open proc')
+
+    # check for execution path
+    base_path = "/usr/run/%d/userchroot" % (real_uid)
+    if (not create_dir(base_path, 755)):
+        base_path = "/tmp/userchroot-%d" % (real_uid)
+        if (not create_dir(base_path, 755)):
+            die('Could not create mount root')
+
+    child_event_fd = eventfd(0, EFD_CLOEXEC)
+    if child_event_fd == -1:
+        die('Could not create a child event file discriptor')
+
+    # call clone manually to clone the program without
+    # an extra function and predefined stack
+    clone_flags = signal.SIGCHLD | CLONE_NEWNS | CLONE_NEWUSER
+    pid = clone_syscall(clone_flags, None)
+    if pid == -1:
+        die('Could not create new namespace')
+
+    # This gets executed by the initially called process
+    if pid != 0:
+        drop_privileges(chroot_uid, False)
+        die_with_parent()
+
+        # inform the child process after all privileges got
+        # dropped to continue running
+        val = ctypes.pointer(ctypes.c_ulong(1))
+        if libc.write(child_event_fd, val, 8) < 0:
+            die('Could not write to child event file discriptor')
+        os.close(child_event_fd)
+        monitor_child(proc_fd, pid, base_path)
+        sys.exit(0)
+
+    # wait for parent to drop privileges
+    os.read(child_event_fd, 8)
+    os.close(child_event_fd)
+
+    # drop all privileges
+    switch_to_user_with_privs(priv, caps)
+
+    ns_uid, ns_gid = chroot_uid, chroot_gid
+
+    # rewrite the mapping from the namespace id to the real user id
+    write_uid_gid_map(proc_fd,
+                      ns_uid, real_uid,
+                      ns_gid, real_gid,
+                      -1, True, False)
+
+    # mount everything as slave to recive bind calls
+    # but to avoid the propergation of bind calls
+    if mount(None, b'/', None, MS_SLAVE | MS_REC, None) < 0:
+        die('failed to mount /')
+
+    # create a temporary file system mount as the / path for
+    # all other mount calls
+    if mount(b'', base_path.encode(), b'tmpfs',
+             MS_NODEV | MS_NOSUID, None) != 0:
+        die('failed to mount tmpfs')
+
+    # change dir to new mounted base path
+    if libc.chdir(ctypes.c_char_p(base_path.encode())) != 0:
+        die('Could not change dir')
+
+    # Create a second root to allow the user to mount something
+    # at /
+    if libc.mkdir(ctypes.c_char_p(b'newroot'), ctypes.c_uint32(0o755)) < 0:
+        die('Could not create new root dir')
+
+    # Create the old root path
+    if libc.mkdir(ctypes.c_char_p(b'oldroot'), ctypes.c_uint32(0o755)) < 0:
+        die('Could not create old root dir')
+
+    # Switch the current root to old root
+    if pivot_syscall(base_path.encode(), b'oldroot') != 0:
+        die('Could not pivot root')
+
+    # change to the root which contains oldroot and newroot
+    if libc.chdir(ctypes.c_char_p(b'/')) != 0:
+        die('Could not change to new root')
+
+    # mount everything which isrequired to bootstrap an environment
+    setup_newroot(location)
+
+    # Set oldroot as private to allow to unmount in the current
+    # namespace without unmouting oldroot in the parent namespace
+    if mount(b'oldroot', b'oldroot', None, MS_REC | MS_PRIVATE, None) != 0:
+        die('Could not mount oldroot')
+
+    # Unmount the old root
+    if umount(b'oldroot', MNT_DETACH) != 0:
+        die('Could not unmount old root')
+
+    if libc.chdir(ctypes.c_char_p(b'/newroot')) != 0:
+        die('Could not change to new root')
+
+    if libc.chroot(ctypes.c_char_p(b'/newroot')) != 0:
+        die('Could not chroot into new root')
+
+    if libc.chdir(ctypes.c_char_p(b'/')) != 0:
+        die('Could not change to /')
+
+    die_with_parent()
+
+    # Execute the specified command with arguments
+    # and convert them to char*[]
+    if arguments:
+        args = (ctypes.c_char_p * (len(arguments) + 1))()
+        args[0] = ctypes.c_char_p(command.encode())
+        for i in range(1, len(arguments)):
+            args[i] = ctypes.c_char_p(arguments[i].encode())
+    else:
+        args = (ctypes.c_char_p * 1)()
+        args[0] = ctypes.c_char_p(command.encode())
+
+    if libc.execvp(ctypes.c_char_p(command.encode()), args) == -1:
+        die('Could not start %s %s' % (command, arguments))
+
+
+# example usage
+# user_chroot('/home/spack/Documents/Spack-Test/', '/bin/bash', None)


### PR DESCRIPTION
This feature support to jail Spack inside a chroot (see #5193 approach 3 for details),
but without the requirements of the pull request #5489.
This allows to find potentially missing depends_on calls.

It introduces the commands:

./spack isolate --build-environment path/to/jail/dir --tarball path/to/tarball
To create a jail for Spack and mount bind /dev, /sys and /proc to be available inside the jail.

./spack isolate --remove-environment
To unmount the mounted /dev, /sys and /proc directories.

./spack isolate --cli
To start a shell inside the jail.

To create a bootstrap environment it is possible to use an already generated tarball from OpenStack or by using mkosi. A restriction is, that the root directory of the tarball must be a directory which contains the distribution.

To generate the mount bind and chroot calls in uses namespaces.
Unfortunately it does not support the separation of the PID namespace, due to the fact, that Python cannot read C defines and structs.
