### PR TITLE
Make setup use all environment changes from build_environment

### DIFF
--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -662,6 +662,9 @@ class DIYStage(object):
     def restage(self):
         tty.die("Cannot restage DIY stage.")
 
+    def create(self):
+        self.created = True
+
     def destroy(self):
         # No need to destroy DIY stage.
         pass


### PR DESCRIPTION
Resolves an issue with compiler flags and the spack setup command reported by @bvanessen. 

Still working on testing this with @bvanessen 