### PR TITLE
Disentangle the fetchers!

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -374,7 +374,7 @@ def download_tarball(spec):
         # stage the tarball into standard place
         stage = Stage(url, name="build_cache", keep=True)
         try:
-            stage.fetch()
+            stage.fetch(validate=False)
             return stage.save_filename
         except fs.FetchError:
             continue

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -374,7 +374,7 @@ def download_tarball(spec):
         # stage the tarball into standard place
         stage = Stage(url, name="build_cache", keep=True)
         try:
-            stage.fetch(validate=False)
+            stage.fetch(validate=False, expand=False)
             return stage.save_filename
         except fs.FetchError:
             continue
@@ -574,7 +574,7 @@ def get_specs(force=False):
                 os.remove(stage.save_filename)
             if not os.path.exists(stage.save_filename):
                 try:
-                    stage.fetch(expand=False)
+                    stage.fetch(validate=False, expand=False)
                 except fs.FetchError:
                     continue
             with open(stage.save_filename, 'r') as f:

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -574,7 +574,7 @@ def get_specs(force=False):
                 os.remove(stage.save_filename)
             if not os.path.exists(stage.save_filename):
                 try:
-                    stage.fetch()
+                    stage.fetch(expand=False)
                 except fs.FetchError:
                     continue
             with open(stage.save_filename, 'r') as f:

--- a/lib/spack/spack/cmd/fetch.py
+++ b/lib/spack/spack/cmd/fetch.py
@@ -70,7 +70,7 @@ def fetch(parser, args):
                 if package.spec.external:
                     continue
 
-                package.do_fetch()
+                package.do_fetch(expand=False)
 
         package = spack.repo.get(spec)
-        package.do_fetch()
+        package.do_fetch(expand=False)

--- a/lib/spack/spack/cmd/fetch.py
+++ b/lib/spack/spack/cmd/fetch.py
@@ -70,7 +70,7 @@ def fetch(parser, args):
                 if package.spec.external:
                     continue
 
-                package.do_fetch(expand=False)
+                package.do_stage(expand=False)
 
         package = spack.repo.get(spec)
-        package.do_fetch(expand=False)
+        package.do_stage(expand=False)

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -219,15 +219,8 @@ class URLFetchStrategy(FetchStrategy):
     #: Overridden by instances to set the curl executable
     _curl = None
 
-    def __init__(self, url=None, digest=None, **kwargs):
-        # TODO: Is this trick used somewhere? If not, it would be cleaner
-        # TODO: not to have the same argument specified twice
-        # If URL or digest are provided in the kwargs, then prefer
-        # those values.
-        self.url = kwargs.get('url', None)
-        if not self.url:
-            self.url = url
-
+    def __init__(self, url, digest=None, **kwargs):
+        self.url = url
         self.digest = next(
             (kwargs[h] for h in crypto.hashes if h in kwargs), None
         )
@@ -236,9 +229,6 @@ class URLFetchStrategy(FetchStrategy):
 
         self.extra_curl_options = kwargs.get('curl_options', [])
         self.extension = kwargs.get('extension', None)
-
-        if not self.url:
-            raise ValueError("URLFetchStrategy requires a url for fetching.")
 
     @property
     def archive_basename(self):

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -56,7 +56,6 @@ import spack.error
 import spack.util.crypto as crypto
 import spack.util.pattern as pattern
 
-from llnl.util.filesystem import *
 from spack.util.compression import decompressor_for, extension
 from spack.util.executable import which
 from spack.util.string import comma_or
@@ -360,7 +359,9 @@ class URLFetchStrategy(FetchStrategy):
         if do_expansion and not et:
             self._expand_archive(self.source_dir)
         elif do_expansion and et:
-            tty.msg('Already staged {0} in {1}'.format(self.name, source_dir))
+            tty.msg('Already staged {0} in {1}'.format(
+                self.name, self.source_dir
+            ))
 
     @property
     def cachable(self):

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -160,7 +160,6 @@ class FetchStrategy(object):
         return any(k in args for k in cls.required_attributes)
 
 
-# FIXME: Should be useless after refactoring
 @pattern.composite(interface=FetchStrategy)
 class FetchStrategyComposite(object):
     """Composite for a FetchStrategy object.

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -1054,7 +1054,7 @@ class FsCache(object):
     def __init__(self, root):
         self.root = os.path.abspath(root)
 
-    def store(self, source_dir, fetcher, relativeDst):
+    def store(self, fetcher, relativeDst):
         # skip fetchers that aren't cachable
         if not fetcher.cachable:
             return
@@ -1065,7 +1065,7 @@ class FsCache(object):
 
         dst = os.path.join(self.root, relativeDst)
         mkdirp(os.path.dirname(dst))
-        fetcher.archive(source_dir, dst)
+        fetcher.archive(dst)
 
     def fetcher(self, targetPath, digest, **kwargs):
         path = os.path.join(self.root, targetPath)

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -230,10 +230,6 @@ class URLFetchStrategy(FetchStrategy):
         self.extension = kwargs.get('extension', None)
 
     @property
-    def archive_basename(self):
-        return os.path.basename(self.url)
-
-    @property
     def expected_archive_files(self):
         if self._expected_archive_files is None:
             return [self.archive_basename]

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -217,6 +217,7 @@ def add_single_spec(spec, mirror_root, categories, **kwargs):
             # fetcher.archive(archive_path)
             for ii, stage in enumerate(spec.package.stage):
                 fetcher = stage.fetcher
+                fetcher.source_dir = stage.path
                 if ii == 0:
                     # create a subdirectory for the current package@version
                     archive_path = os.path.abspath(os.path.join(
@@ -237,15 +238,13 @@ def add_single_spec(spec, mirror_root, categories, **kwargs):
                 else:
                     spec_exists_in_mirror = False
                     validate = not kwargs.get('no_checksum', False)
-                    fetcher.search_archive_fn = stage.search_archive_fn
+                    fetcher.expected_archive_files = stage.expected_archive_files # noqa: ignore=E501
                     fetcher.fetch(
-                        stage.path,
-                        validate=validate,
-                        expanded_source_tree=False
+                        validate=validate, expanded_source_tree=False
                     )
                     # Fetchers have to know how to archive their files.  Use
                     # that to move/copy/create an archive in the mirror.
-                    fetcher.archive(stage.path, archive_path)
+                    fetcher.archive(archive_path)
                     tty.msg("{name} : added".format(name=name))
 
         if spec_exists_in_mirror:

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -239,14 +239,12 @@ def add_single_spec(spec, mirror_root, categories, **kwargs):
                     tty.msg("{name} : already added".format(name=name))
                 else:
                     spec_exists_in_mirror = False
-                    fetcher.fetch()
-                    if not kwargs.get('no_checksum', False):
-                        fetcher.check()
-                        tty.msg("{name} : checksum passed".format(name=name))
-
+                    validate = not kwargs.get('no_checksum', False)
+                    fetcher.search_archive_fn = stage.search_archive_fn
+                    fetcher.fetch(stage.path, validate=validate, expand=False)
                     # Fetchers have to know how to archive their files.  Use
                     # that to move/copy/create an archive in the mirror.
-                    fetcher.archive(archive_path)
+                    fetcher.archive(stage.path, archive_path)
                     tty.msg("{name} : added".format(name=name))
 
         if spec_exists_in_mirror:

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -50,22 +50,22 @@ def mirror_archive_filename(spec, fetcher, resourceId=None):
         raise ValueError("mirror.path requires spec with concrete version.")
 
     if isinstance(fetcher, fs.URLFetchStrategy):
-        if fetcher.expand_archive:
-            # If we fetch with a URLFetchStrategy, use URL's archive type
-            ext = url.determine_url_file_extension(fetcher.url)
 
-            # If the filename does not end with a normal suffix,
-            # see if the package explicitly declares the extension
-            if not ext:
-                ext = spec.package.versions[spec.package.version].get(
-                    'extension', None)
+        # If we fetch with a URLFetchStrategy, use URL's archive type
+        ext = url.determine_url_file_extension(fetcher.url)
 
-            if ext:
-                # Remove any leading dots
-                ext = ext.lstrip('.')
+        # If the filename does not end with a normal suffix,
+        # see if the package explicitly declares the extension
+        if not ext:
+            ext = spec.package.versions[spec.package.version].get(
+                'extension', None)
 
-            if not ext:
-                msg = """\
+        if ext:
+            # Remove any leading dots
+            ext = ext.lstrip('.')
+
+        if not ext:
+            msg = """\
 Unable to parse extension from {0}.
 
 If this URL is for a tarball but does not include the file extension
@@ -79,10 +79,7 @@ Spack not to expand it with the following syntax:
 
     version('1.2.3', 'hash', expand=False)
 """
-                raise MirrorError(msg.format(fetcher.url))
-        else:
-            # If the archive shouldn't be expanded, don't check extension.
-            ext = None
+            raise MirrorError(msg.format(fetcher.url))
     else:
         # Otherwise we'll make a .tar.gz ourselves
         ext = 'tar.gz'
@@ -241,7 +238,11 @@ def add_single_spec(spec, mirror_root, categories, **kwargs):
                     spec_exists_in_mirror = False
                     validate = not kwargs.get('no_checksum', False)
                     fetcher.search_archive_fn = stage.search_archive_fn
-                    fetcher.fetch(stage.path, validate=validate, expand=False)
+                    fetcher.fetch(
+                        stage.path,
+                        validate=validate,
+                        expanded_source_tree=False
+                    )
                     # Fetchers have to know how to archive their files.  Use
                     # that to move/copy/create an archive in the mirror.
                     fetcher.archive(stage.path, archive_path)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1021,7 +1021,7 @@ class PackageBase(with_metaclass(PackageMeta, object)):
 
         self.stage.create()
 
-        validate = spack.do_checksum and self.version in self.versions
+        validate = checksum and self.version in self.versions
         self.stage.fetch(mirror_only, validate=validate, expand=expand)
 
         if not os.listdir(self.stage.path):

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -994,11 +994,8 @@ class PackageBase(with_metaclass(PackageMeta, object)):
         """
         spack.store.layout.remove_install_directory(self.spec)
 
-    def do_fetch(self, mirror_only=False):
-        """
-        Creates a stage directory and downloads the tarball for this package.
-        Working directory will be set to the stage directory.
-        """
+    def do_stage(self, mirror_only=False, expand=True):
+
         if not self.spec.concrete:
             raise ValueError("Can only fetch concrete packages.")
 
@@ -1025,20 +1022,26 @@ class PackageBase(with_metaclass(PackageMeta, object)):
         self.stage.create()
 
         validate = spack.do_checksum and self.version in self.versions
-        self.stage.fetch(mirror_only, validate=validate)
-        self._fetch_time = time.time() - start_time
-        self.stage.cache_local()
-
-    def do_stage(self, mirror_only=False):
-        """Unpacks and expands the fetched tarball."""
-        if not self.spec.concrete:
-            raise ValueError("Can only stage concrete packages.")
-
-        self.do_fetch(mirror_only)     # this will create the stage
-        self.stage.expand_archive()
+        self.stage.fetch(mirror_only, validate=validate, expand=expand)
 
         if not os.listdir(self.stage.path):
             raise FetchError("Archive was empty for %s" % self.name)
+
+        self._fetch_time = time.time() - start_time
+        self.stage.cache_local()
+
+    # FIXME: REMOVE
+    # def do_stage(self, expand=True, mirror_only=False):
+    #
+    #     """Unpacks and expands the fetched tarball."""
+    #     if not self.spec.concrete:
+    #         raise ValueError("Can only stage concrete packages.")
+    #
+    #     self.do_fetch(mirror_only)     # this will create the stage
+    #     self.stage.expand_archive()
+    #
+    #     if not os.listdir(self.stage.path):
+    #         raise FetchError("Archive was empty for %s" % self.name)
 
     @classmethod
     def lookup_patch(cls, sha256):

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -783,6 +783,7 @@ class PackageBase(with_metaclass(PackageMeta, object)):
             dynamic_fetcher = fs.from_list_url(self)
             return [dynamic_fetcher] if dynamic_fetcher else []
 
+        # FIXME: This is the only place where search_fn is used
         stage = Stage(fetcher, mirror_path=mp, name=stage_name, path=self.path,
                       search_fn=download_search)
         return stage
@@ -1033,12 +1034,10 @@ class PackageBase(with_metaclass(PackageMeta, object)):
                                  self.spec.format('$_$@'), ck_msg)
 
         self.stage.create()
-        self.stage.fetch(mirror_only)
+
+        validate = spack.do_checksum and self.version in self.versions
+        self.stage.fetch(mirror_only, validate=validate)
         self._fetch_time = time.time() - start_time
-
-        if checksum and self.version in self.versions:
-            self.stage.check()
-
         self.stage.cache_local()
 
     def do_stage(self, mirror_only=False):

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1030,19 +1030,6 @@ class PackageBase(with_metaclass(PackageMeta, object)):
         self._fetch_time = time.time() - start_time
         self.stage.cache_local()
 
-    # FIXME: REMOVE
-    # def do_stage(self, expand=True, mirror_only=False):
-    #
-    #     """Unpacks and expands the fetched tarball."""
-    #     if not self.spec.concrete:
-    #         raise ValueError("Can only stage concrete packages.")
-    #
-    #     self.do_fetch(mirror_only)     # this will create the stage
-    #     self.stage.expand_archive()
-    #
-    #     if not os.listdir(self.stage.path):
-    #         raise FetchError("Archive was empty for %s" % self.name)
-
     @classmethod
     def lookup_patch(cls, sha256):
         """Look up a patch associated with this package by its sha256 sum.

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -159,8 +159,7 @@ class UrlPatch(Patch):
             os.path.basename(self.url))
 
         with spack.stage.Stage(fetcher, mirror_path=mirror) as patch_stage:
-            patch_stage.fetch()
-            patch_stage.check()
+            patch_stage.fetch(validate=True)
             patch_stage.cache_local()
 
             root = patch_stage.path

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -150,8 +150,10 @@ class UrlPatch(Patch):
         """
         # use archive digest for compressed archives
         fetch_digest = self.sha256
+        expand = False
         if self.archive_sha256:
             fetch_digest = self.archive_sha256
+            expand = True
 
         fetcher = fs.URLFetchStrategy(self.url, digest=fetch_digest)
         mirror = os.path.join(
@@ -159,12 +161,11 @@ class UrlPatch(Patch):
             os.path.basename(self.url))
 
         with spack.stage.Stage(fetcher, mirror_path=mirror) as patch_stage:
-            patch_stage.fetch(validate=True)
+            patch_stage.fetch(validate=True, expand=expand)
             patch_stage.cache_local()
 
             root = patch_stage.path
             if self.archive_sha256:
-                patch_stage.expand_archive()
                 root = patch_stage.source_path
 
             files = os.listdir(root)

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -466,7 +466,7 @@ class Stage(object):
         return fetchers
 
     def cache_local(self):
-        spack.caches.fetch_cache.store(self.path, self.fetcher, self.mirror_path)
+        spack.caches.fetch_cache.store(self.fetcher, self.mirror_path)
 
     def restage(self):
         """Removes the expanded archive path if it exists, then re-expands
@@ -566,8 +566,8 @@ class ResourceStage(Stage):
 
 
 @pattern.composite(method_list=[
-    'fetch', 'create', 'created', 'expand_archive', 'restage',
-    'destroy', 'cache_local'])
+    'fetch', 'create', 'created', 'restage', 'destroy', 'cache_local'
+])
 class StageComposite:
     """Composite for Stage type objects. The first item in this composite is
     considered to be the root package, and operations that return a value are
@@ -634,9 +634,6 @@ class DIYStage(object):
 
     def fetch(self, *args, **kwargs):
         tty.msg("No need to fetch for DIY.")
-
-    def expand_archive(self):
-        tty.msg("Using source directory: %s" % self.source_path)
 
     def restage(self):
         tty.die("Cannot restage DIY stage.")

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -524,16 +524,19 @@ class ResourceStage(Stage):
 
     def restage(self):
         super(ResourceStage, self).restage()
-        self._add_to_root_stage()def fetch(self, mirror_only=False, validate=True, expand=True):
+        self._add_to_root_stage()
+
+    def fetch(self, mirror_only=False, validate=True, expand=True):
         super(ResourceStage, self).fetch(mirror_only, validate, expand)
 
         if expand is True:
-        self._add_to_root_stage()
+            self._add_to_root_stage()
 
     def _add_to_root_stage(self):
+        """Move the extracted resource to the root stage
+        (according to placement).
         """
-        Move the extracted resource to the root stage (according to placement).
-        """root_stage = self.root_stage
+        root_stage = self.root_stage
         resource = self.resource
         placement = os.path.basename(self.source_path) \
             if resource.placement is None \
@@ -542,26 +545,27 @@ class ResourceStage(Stage):
             placement = {'': placement}
 
             target_path = os.path.join(
-                root_stage.source_path, resource.destination)
-
+                root_stage.source_path, resource.destination
+            )
 
             try:
                 os.makedirs(target_path)
             except OSError as err:
-                if err.errno == errno.EEXIST and os.path.isdir(target_path):# noqa: ignore=E501
+                if err.errno == errno.EEXIST and os.path.isdir(target_path):  # noqa: ignore=E501
                     pass
                 else:
                     raise
 
         for key, value in iteritems(placement):
             destination_path = os.path.join(target_path, value)
-            source_path = os.path.join(self.source_path, key)    if not os.path.exists(destination_path):
-
-                tty.info('Moving resource stage\n '
-                         '\tsource :{stage}\n'
-                        '\tdestination : {destination}'.format(
-                             stage=source_path, destination=destination_path)
-                         )
+            source_path = os.path.join(self.source_path, key)
+            if not os.path.exists(destination_path):
+                tty.info(
+                    'Moving resource stage\n '
+                    '\tsource :{stage}\n'
+                    '\tdestination : {destination}'.format(
+                        stage=source_path, destination=destination_path)
+                )
                 shutil.move(os.path.realpath(source_path), destination_path)
 
 

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -184,8 +184,6 @@ class Stage(object):
                  Pass True to keep the stage intact even if no
                  exceptions are raised.
         """
-        # TODO: fetch/stage coupling needs to be reworked -- the logic
-        # TODO: here is convoluted and not modular enough.
         if isinstance(url_or_fetch_strategy, string_types):
             self.fetcher = fs.from_url(url_or_fetch_strategy)
         elif isinstance(url_or_fetch_strategy, fs.FetchStrategy):
@@ -378,9 +376,6 @@ class Stage(object):
         if not mirror_only:
             fetchers.append(self.default_fetcher)
 
-        # TODO: move mirror logic out of here and clean it up!
-        # TODO: Or @alalazo may have some ideas about how to use a
-        # TODO: CompositeFetchStrategy here.
         if self.mirror_path:
             fetchers = self._insert_mirrors(fetchers)
 

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -595,9 +595,6 @@ class StageComposite:
     """Composite for Stage type objects. The first item in this composite is
     considered to be the root package, and operations that return a value are
     forwarded to it."""
-    #
-    # __enter__ and __exit__ delegate to all stages in the composite.
-    #
 
     def __enter__(self):
         for item in self:
@@ -608,6 +605,19 @@ class StageComposite:
         for item in reversed(self):
             item.keep = getattr(self, 'keep', False)
             item.__exit__(exc_type, exc_val, exc_tb)
+
+    @property
+    def fetcher(self):
+        """Computes and returns a fetcher for the composite stage.
+
+        The value of the fetcher is dynamic (may vary between calls
+        to the same object), and depends on the state of the various
+        ``fetcher`` attributes for all the items in the composite.
+        """
+        fetcher_composite = fs.FetchStrategyComposite()
+        for stage in self:
+            fetcher_composite.append(stage.fetcher)
+        return fetcher_composite
 
     #
     # Below functions act only on the *first* stage in the composite.

--- a/lib/spack/spack/test/build_system_guess.py
+++ b/lib/spack/spack/test/build_system_guess.py
@@ -66,7 +66,7 @@ def url_and_build_system(request, tmpdir):
 def test_build_systems(url_and_build_system):
     url, build_system = url_and_build_system
     with spack.stage.Stage(url) as stage:
-        stage.fetch()
+        stage.fetch(validate=False)
         guesser = spack.cmd.create.BuildSystemGuesser()
         guesser(stage, url)
         assert build_system == guesser.build_system

--- a/lib/spack/spack/test/build_system_guess.py
+++ b/lib/spack/spack/test/build_system_guess.py
@@ -66,7 +66,7 @@ def url_and_build_system(request, tmpdir):
 def test_build_systems(url_and_build_system):
     url, build_system = url_and_build_system
     with spack.stage.Stage(url) as stage:
-        stage.fetch(validate=False)
+        stage.fetch(validate=False, expand=False)
         guesser = spack.cmd.create.BuildSystemGuesser()
         guesser(stage, url)
         assert build_system == guesser.build_system

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -138,16 +138,13 @@ def mock_fetch_cache(monkeypatch):
     and raises on fetch.
     """
     class MockCache(object):
-        def store(self, source_dir, copyCmd, relativeDst):
+        def store(self, copyCmd, relativeDst):
             pass
 
         def fetcher(self, targetPath, digest, **kwargs):
             return MockCacheFetcher()
 
     class MockCacheFetcher(object):
-        def set_stage(self, stage):
-            pass
-
         def fetch(self, validate=True, expanded_source_tree=True):
             raise FetchError('Mock cache always fails for tests')
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -46,7 +46,7 @@ import spack.stage
 import spack.util.executable
 import spack.util.pattern
 from spack.dependency import Dependency
-from spack.fetch_strategy import FetchStrategyComposite, URLFetchStrategy
+from spack.fetch_strategy import URLFetchStrategy
 from spack.fetch_strategy import FetchError
 from spack.spec import Spec
 from spack.version import Version

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -148,7 +148,7 @@ def mock_fetch_cache(monkeypatch):
         def set_stage(self, stage):
             pass
 
-        def fetch(self, destination, validate=True, expanded_source_tree=True):
+        def fetch(self, validate=True, expanded_source_tree=True):
             raise FetchError('Mock cache always fails for tests')
 
         def __str__(self):

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -46,7 +46,6 @@ import spack.stage
 import spack.util.executable
 import spack.util.pattern
 from spack.dependency import Dependency
-from spack.package import PackageBase
 from spack.fetch_strategy import FetchStrategyComposite, URLFetchStrategy
 from spack.fetch_strategy import FetchError
 from spack.spec import Spec
@@ -363,20 +362,17 @@ def install_mockery(tmpdir, config, mock_packages):
 
 
 @pytest.fixture()
-def mock_fetch(mock_archive):
-    """Fake the URL for a package so it downloads from a file."""
-    fetcher = FetchStrategyComposite()
-    fetcher.append(URLFetchStrategy(mock_archive.url))
+def mock_fetch(mock_archive, monkeypatch):
+    """Substitutes the function used to construct a fetcher for a package
+    at a given version, with one that always fetch the mock archive.
+    """
 
-    @property
-    def fake_fn(self):
-        return fetcher
+    def always_mock_archive(pkg, version):
+        return URLFetchStrategy(mock_archive.url)
 
-    orig_fn = PackageBase.fetcher
-    PackageBase.fetcher = fake_fn
-    yield
-    PackageBase.fetcher = orig_fn
-
+    monkeypatch.setattr(
+        spack.fetch_strategy, 'for_package_version', always_mock_archive
+    )
 
 ##########
 # Fake archives and repositories

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -149,7 +149,7 @@ def mock_fetch_cache(monkeypatch):
         def set_stage(self, stage):
             pass
 
-        def fetch(self):
+        def fetch(self, destination, validate=True, expand=True):
             raise FetchError('Mock cache always fails for tests')
 
         def __str__(self):

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -138,7 +138,7 @@ def mock_fetch_cache(monkeypatch):
     and raises on fetch.
     """
     class MockCache(object):
-        def store(self, copyCmd, relativeDst):
+        def store(self, source_dir, copyCmd, relativeDst):
             pass
 
         def fetcher(self, targetPath, digest, **kwargs):
@@ -148,7 +148,7 @@ def mock_fetch_cache(monkeypatch):
         def set_stage(self, stage):
             pass
 
-        def fetch(self, destination, validate=True, expand=True):
+        def fetch(self, destination, validate=True, expanded_source_tree=True):
             raise FetchError('Mock cache always fails for tests')
 
         def __str__(self):

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -48,6 +48,7 @@ import spack.util.pattern
 from spack.dependency import Dependency
 from spack.fetch_strategy import URLFetchStrategy
 from spack.fetch_strategy import FetchError
+from spack.package import PackageBase
 from spack.spec import Spec
 from spack.version import Version
 

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -40,7 +40,7 @@ import spack.binary_distribution as bindist
 import spack.cmd.buildcache as buildcache
 from spack.spec import Spec
 from spack.paths import mock_gpg_keys_path
-from spack.fetch_strategy import URLFetchStrategy, FetchStrategyComposite
+from spack.fetch_strategy import URLFetchStrategy
 from spack.util.executable import ProcessError
 from spack.relocate import needs_binary_relocation, needs_text_relocation
 from spack.relocate import strings_contains_installroot
@@ -68,9 +68,8 @@ def has_gnupg2():
 
 def fake_fetchify(url, pkg):
     """Fake the URL for a package so it downloads from a file."""
-    fetcher = FetchStrategyComposite()
-    fetcher.append(URLFetchStrategy(url))
-    pkg.fetcher = fetcher
+    root_stage = pkg.stage[0]
+    root_stage.fetcher = root_stage.default_fetcher = URLFetchStrategy(url)
 
 
 @pytest.mark.usefixtures('install_mockery', 'testing_gpg_directory')

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -178,7 +178,7 @@ def failing_search_fn():
 def failing_fetch_strategy():
     """Returns a fetch strategy that fails."""
     class FailingFetchStrategy(spack.fetch_strategy.FetchStrategy):
-        def fetch(self, source_dir, validate=True, expanded_source_tree=True):
+        def fetch(self, validate=True, expanded_source_tree=True):
             raise spack.fetch_strategy.FailedDownloadError(
                 "<non-existent URL>",
                 "This implementation of FetchStrategy always fails"

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -178,7 +178,7 @@ def failing_search_fn():
 def failing_fetch_strategy():
     """Returns a fetch strategy that fails."""
     class FailingFetchStrategy(spack.fetch_strategy.FetchStrategy):
-        def fetch(self, source_dir, validate=True, expand=True):
+        def fetch(self, source_dir, validate=True, expanded_source_tree=True):
             raise spack.fetch_strategy.FailedDownloadError(
                 "<non-existent URL>",
                 "This implementation of FetchStrategy always fails"
@@ -268,17 +268,15 @@ class TestStage(object):
 
     def test_expand_archive(self, mock_archive):
         with Stage(mock_archive.url, name=self.stage_name) as stage:
-            stage.fetch(validate=False)
+            stage.fetch(validate=False, expand=True)
             check_setup(stage, self.stage_name, mock_archive)
             check_fetch(stage, self.stage_name)
-            stage.expand_archive()
             check_expand_archive(stage, self.stage_name, mock_archive)
         check_destroy(stage, self.stage_name)
 
     def test_restage(self, mock_archive):
         with Stage(mock_archive.url, name=self.stage_name) as stage:
-            stage.fetch(validate=False)
-            stage.expand_archive()
+            stage.fetch(validate=False, expand=True)
 
             with working_dir(stage.source_path):
                 check_expand_archive(stage, self.stage_name, mock_archive)

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -178,7 +178,7 @@ def failing_search_fn():
 def failing_fetch_strategy():
     """Returns a fetch strategy that fails."""
     class FailingFetchStrategy(spack.fetch_strategy.FetchStrategy):
-        def fetch(self):
+        def fetch(self, source_dir, validate=True, expand=True):
             raise spack.fetch_strategy.FailedDownloadError(
                 "<non-existent URL>",
                 "This implementation of FetchStrategy always fails"
@@ -228,7 +228,7 @@ class TestStage(object):
 
     def test_fetch(self, mock_archive):
         with Stage(mock_archive.url, name=self.stage_name) as stage:
-            stage.fetch()
+            stage.fetch(validate=False)
             check_setup(stage, self.stage_name, mock_archive)
             check_fetch(stage, self.stage_name)
         check_destroy(stage, self.stage_name)
@@ -239,7 +239,7 @@ class TestStage(object):
                       name=self.stage_name,
                       search_fn=failing_search_fn)
         with stage:
-            stage.fetch()
+            stage.fetch(validate=False)
         check_destroy(stage, self.stage_name)
 
     def test_no_search_mirror_only(
@@ -249,7 +249,7 @@ class TestStage(object):
                       search_fn=failing_search_fn)
         with stage:
             try:
-                stage.fetch(mirror_only=True)
+                stage.fetch(mirror_only=True, validate=False)
             except spack.fetch_strategy.FetchError:
                 pass
         check_destroy(stage, self.stage_name)
@@ -260,7 +260,7 @@ class TestStage(object):
                       search_fn=search_fn)
         with stage:
             try:
-                stage.fetch(mirror_only=False)
+                stage.fetch(mirror_only=False, validate=False)
             except spack.fetch_strategy.FetchError:
                 pass
         check_destroy(stage, self.stage_name)
@@ -268,7 +268,7 @@ class TestStage(object):
 
     def test_expand_archive(self, mock_archive):
         with Stage(mock_archive.url, name=self.stage_name) as stage:
-            stage.fetch()
+            stage.fetch(validate=False)
             check_setup(stage, self.stage_name, mock_archive)
             check_fetch(stage, self.stage_name)
             stage.expand_archive()
@@ -277,7 +277,7 @@ class TestStage(object):
 
     def test_restage(self, mock_archive):
         with Stage(mock_archive.url, name=self.stage_name) as stage:
-            stage.fetch()
+            stage.fetch(validate=False)
             stage.expand_archive()
 
             with working_dir(stage.source_path):

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -228,7 +228,7 @@ class TestStage(object):
 
     def test_fetch(self, mock_archive):
         with Stage(mock_archive.url, name=self.stage_name) as stage:
-            stage.fetch(validate=False)
+            stage.fetch(validate=False, expand=False)
             check_setup(stage, self.stage_name, mock_archive)
             check_fetch(stage, self.stage_name)
         check_destroy(stage, self.stage_name)
@@ -239,7 +239,7 @@ class TestStage(object):
                       name=self.stage_name,
                       search_fn=failing_search_fn)
         with stage:
-            stage.fetch(validate=False)
+            stage.fetch(validate=False, expand=False)
         check_destroy(stage, self.stage_name)
 
     def test_no_search_mirror_only(
@@ -249,7 +249,7 @@ class TestStage(object):
                       search_fn=failing_search_fn)
         with stage:
             try:
-                stage.fetch(mirror_only=True, validate=False)
+                stage.fetch(mirror_only=True, validate=False, expand=False)
             except spack.fetch_strategy.FetchError:
                 pass
         check_destroy(stage, self.stage_name)

--- a/var/spack/repos/builtin/packages/turbomole/package.py
+++ b/var/spack/repos/builtin/packages/turbomole/package.py
@@ -59,7 +59,7 @@ class Turbomole(Package):
         if '+mpi' in self.spec and '+smp' in self.spec:
             raise InstallError('Can not have both SMP and MPI enabled in the '
                                'same build.')
-        super(Turbomole, self).do_fetch(mirror_only)
+        super(Turbomole, self).do_stage(mirror_only, expand=False)
 
     def get_tm_arch(self):
         if 'TURBOMOLE' in os.getcwd():


### PR DESCRIPTION
It's a while that I want to break the tight coupling between fetchers and stages, and here it is.

The main gain from this PR is that now fetch strategies are completely decoupled from stages. Their API changed a bit, and can be driven by setting a couple of paths prior to any relevant method call. The most important path to be set is:
```python
fetcher.source_dir = path
```
which in most cases is set to `stage.path` within Spack. Another relevant path attribute is `expected_archive_files`. In any case all the computations a fetcher does now should depend only on its current state (while before they were also depending on other fetchers states via stage).

The three methods of `FetchStrategy`:
```python
def fetch(self):
    pass

def check(self):
    pass

def expand(self):
    pass
```
have been merged in the single method:
```python
def fetch(self, validate=True, expanded_source_tree=any):
    pass
```
to simplify the logic in the code. Upstream classes followed (so e.g. `Stage.fetch` now has an `expand` argument and so does `PackageBase.do_stage`).

The convoluted logic in `PackageBase` to construct 2 composites (one for stages, one for fetchers) has been removed. As fetchers don't need a stage reference anymore, a `StageComposite` instance is now built in the simplest way possible (first the root stage, then the resources). This object can return on demand a `FetchStrategyComposite`.

For other minor details the commit messages should be of help.

##### Mandatory todo list

- [x] Decouple classes in `fetch_stretegy.py` from stages
- [x] Simplify the construction of composite objects in `PackageBase`
- [ ] Improve coverage for fetchers (refactor their unit tests?)
- [ ] Improve docstrings for fetchers and stages

##### Other changes on the wishlist

I refrained from doing a couple of changes that I thought should be discussed beforehand. The first one is a change in the `FetchStrategy.fetch` method which is not strictly needed to maintain the current behavior and pass tests. I would like the final signature to look like:
```python
    def fetch(self, validate=True, expanded_source_tree=any, archive=any):
        """Fetches the source code archive or repository.

        Args:
            validate (bool): if True, try to validate downloaded files whenever
                possible
            expanded_source_tree (bool or any): if True, the source tree is
                expanded, if False the source tree is granted not to be there.
                If 'any' it depends on the defaults of the derived class
            archive (bool or any): if True, the archive is present in the source
                directory. If false it's not. If 'any' it depends on the defaults of 
                the derived class

        Returns:
            absolute path of the archive file if any, else None

        Raises:
            FetchError: if anything goes wrong

        """
```
basically I would like to add an extra argument to drive the presence (or absence) or the archive. If implemented this will permit to ask for a specific state in the working directory, regardless of the fetcher we are using. I would do this more to have an interface that is not biased towards archive fetchers, rather then for an immediate need to implement some features.

The other change is just structural. I think `fetch_strategy.py` has enough code to be split into:
```console
fetch_strategy
├── vcs.py
├── url.py
├── __init__.py
└── exceptions.py
```
while maintaining the same interface to the outside.

Well, I'll be waiting for comments on the code!