### PR TITLE
travis: skip unit and build tests for package-only PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,11 @@ jobs:
       os: linux
       language: python
       env: TEST_SUITE=flake8
+    - stage: 'no changes in core'
+      python: '2.7'
+      os: linux
+      language: python
+      env: TEST_SUITE=nochangesincore
     - stage: 'unit tests + documentation'
       python: '2.6'
       dist: trusty
@@ -117,8 +122,12 @@ jobs:
 
 stages:
   - 'style checks'
-  - 'unit tests + documentation'
-  - 'build tests'
+  - name: 'no changes in core'
+    if: head_branch =~ ^packages
+  - name: 'unit tests + documentation'
+    if: NOT head_branch =~ ^packages
+  - name: 'build tests'
+    if: NOT head_branch =~ ^packages
   - name: 'docker build'
     if: type = push AND branch IN (develop, master)
 

--- a/lib/spack/spack/cmd/flake8.py
+++ b/lib/spack/spack/cmd/flake8.py
@@ -91,12 +91,12 @@ pattern_exemptions = dict(
     for file_pattern, error_dict in pattern_exemptions.items())
 
 
-def changed_files(args):
+def changed_files(base, untracked, all_files=False):
     """Get list of changed files in the Spack repository."""
 
     git = which('git', required=True)
 
-    range = "{0}...".format(args.base)
+    range = "{0}...".format(base)
 
     git_args = [
         # Add changed files committed since branching off of develop
@@ -108,11 +108,11 @@ def changed_files(args):
     ]
 
     # Add new files that are untracked
-    if args.untracked:
+    if untracked:
         git_args.append(['ls-files', '--exclude-standard', '--other'])
 
     # add everything if the user asked for it
-    if args.all:
+    if all_files:
         git_args.append(['ls-files', '--exclude-standard'])
 
     excludes = [os.path.realpath(f) for f in exclude_directories]
@@ -231,7 +231,7 @@ def flake8(parser, args):
 
         with working_dir(spack.paths.prefix):
             if not file_list:
-                file_list = changed_files(args)
+                file_list = changed_files(args.base, args.untracked, args.all)
 
         print('=======================================================')
         print('flake8: running flake8 code checks on spack.')

--- a/lib/spack/spack/test/cmd/flake8.py
+++ b/lib/spack/spack/test/cmd/flake8.py
@@ -49,7 +49,7 @@ def test_changed_files(parser, flake8_package):
 
     # changed_files returns file paths relative to the root
     # directory of Spack. Convert to absolute file paths.
-    files = changed_files(args)
+    files = changed_files(args.base, args.untracked, args.all)
     files = [os.path.join(spack.paths.prefix, path) for path in files]
 
     # There will likely be other files that have changed

--- a/lib/spack/spack/test/package_sanity.py
+++ b/lib/spack/spack/test/package_sanity.py
@@ -19,6 +19,7 @@ def check_repo():
         spack.repo.get(name)
 
 
+@pytest.mark.packagetest
 @pytest.mark.maybeslow
 def test_get_all_packages():
     """Get all packages once and make sure that works."""
@@ -32,6 +33,7 @@ def test_get_all_mock_packages():
         check_repo()
 
 
+@pytest.mark.packagetest
 def test_all_versions_are_lowercase():
     """Spack package names must be lowercase, and use `-` instead of `_`."""
     errors = []

--- a/lib/spack/spack/test/pytest.ini
+++ b/lib/spack/spack/test/pytest.ini
@@ -4,6 +4,7 @@ addopts = --durations=20 -ra
 testpaths = .
 python_files = *.py
 markers =
+  packagetest: tests that are needed to check the sanity of packages
   db: tests that require creating a DB
   network: tests that require access to the network
   maybeslow: tests that may be slow (e.g. access a lot the filesystem, etc.)

--- a/lib/spack/spack/test/python_version.py
+++ b/lib/spack/spack/test/python_version.py
@@ -147,6 +147,7 @@ def test_core_module_compatibility():
         pyfiles([spack_lib_path], exclude=exclude_paths))
 
 
+@pytest.mark.packagetest
 @pytest.mark.maybeslow
 def test_package_module_compatibility():
     """Test that all spack packages work with supported Python versions."""

--- a/share/spack/qa/no_changes_in_core.py
+++ b/share/spack/qa/no_changes_in_core.py
@@ -15,7 +15,11 @@ import spack.spec
 import spack.cmd.flake8
 
 # Get the complete list of files that changed
-files = spack.cmd.flake8.changed_files(True)
+try:
+    files = spack.cmd.flake8.changed_files(base='develop', untracked=True)
+except Exception:
+    print('ERROR: cannot compute the list of files that changed.')
+    sys.exit(1)
 
 # If something changed in the core libraries we need to test it
 core_path = os.path.join('lib', 'spack')

--- a/share/spack/qa/no_changes_in_core.py
+++ b/share/spack/qa/no_changes_in_core.py
@@ -17,13 +17,15 @@ import spack.cmd.flake8
 # Get the complete list of files that changed
 try:
     files = spack.cmd.flake8.changed_files(base='develop', untracked=True)
+    # Make the path name absolute
+    files = [os.path.abspath(x) for x in files]
 except Exception:
     print('ERROR: cannot compute the list of files that changed.')
     sys.exit(1)
 
 # If something changed in the core libraries we need to test it
-core_path = os.path.join('lib', 'spack')
-changes_in_core = any(core_path in x for x in files)
+core_path = os.path.abspath(os.path.join('lib', 'spack'))
+changes_in_core = any(x.startswith(core_path) for x in files)
 
 # Exit early because polling the repo may be slow
 if changes_in_core:

--- a/share/spack/qa/no_changes_in_core.py
+++ b/share/spack/qa/no_changes_in_core.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env spack-python
+#
+# Description:
+#     Helper script that returns 0 if any file in core
+#     has been changed, 1 otherwise
+#
+# Usage:
+#     nochanges_in_core.py && [command run if there are no changes in core]
+#
+
+import sys
+import os.path
+
+import spack.spec
+import spack.cmd.flake8
+
+# Get the complete list of files that changed
+files = spack.cmd.flake8.changed_files(True)
+
+# If something changed in the core libraries we need to test it
+core_path = os.path.join('lib', 'spack')
+changes_in_core = any(core_path in x for x in files)
+
+# Exit early because polling the repo may be slow
+if changes_in_core:
+    print('FAILURE: at least one core file has been modified.')
+    print('Rename your branch to something that does not start with "packages"')  # noqa: ignore=E501
+    sys.exit(1)
+
+# If we changed any of the packages that are under build tests
+# we consider it a change in core
+
+build_tests = (
+    'mpich',
+    'astyle',
+    'tut',
+    'py-setuptools',
+    'openjpeg',
+    'r-rcpp'
+)
+
+specs = [spack.spec.Spec(x) for x in build_tests]
+for s in specs:
+    s.concretize()
+
+names = []
+for s in specs:
+    names.extend([d.name for d in s.traverse()])
+
+names = [os.path.join(x, 'package.py') for x in names]
+names = sorted(set(names))
+
+changes_in_relevant_packages = any(name in x for x in files for name in names)
+
+if changes_in_relevant_packages:
+    print('FAILURE: at least one of the packages in the "Build tests" stage has been modified.')  # noqa: ignore=E501
+    print('Rename your branch to something that does not start with "packages"')  # noqa: ignore=E501
+    sys.exit(1)
+
+sys.exit(0)

--- a/share/spack/qa/run-nochangesincore-tests
+++ b/share/spack/qa/run-nochangesincore-tests
@@ -1,5 +1,11 @@
 #!/bin/bash -e
 #
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+#
 # Description:
 #     Exits 1 if there are changes in core, otherwise exits 0
 #

--- a/share/spack/qa/run-nochangesincore-tests
+++ b/share/spack/qa/run-nochangesincore-tests
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+#
+# Description:
+#     Exits 1 if there are changes in core, otherwise exits 0
+#
+# Usage:
+#     run-nochangesincore-tests
+#
+. "$(dirname $0)/setup.sh"
+
+# Move to root directory of Spack
+# Allows script to be run from anywhere
+cd "$SPACK_ROOT"
+
+# Run the spack-python script
+share/spack/qa/no_changes_in_core.py

--- a/share/spack/qa/run-nochangesincore-tests
+++ b/share/spack/qa/run-nochangesincore-tests
@@ -14,3 +14,7 @@ cd "$SPACK_ROOT"
 
 # Run the spack-python script
 share/spack/qa/no_changes_in_core.py
+
+# Run unit tests that are checking the sanity
+# of Spack packages
+bin/spack test -m "packagetest"

--- a/var/spack/repos/builtin/packages/ldc-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/ldc-bootstrap/package.py
@@ -21,6 +21,7 @@ class LdcBootstrap(CMakePackage):
     homepage = "https://dlang.org/"
     url = "https://github.com/ldc-developers/ldc/releases/download/v0.17.4/ldc-0.17.4-src.tar.gz"
 
+    version('0.17.5', '9c8057a11ddd7a8f456d63860b51c133')
     # This is the last version that does not require a D compiler to bootstrap
     version('0.17.4', '000e006426d6094fabd2a2bdab0ff0b7')
 
@@ -30,6 +31,8 @@ class LdcBootstrap(CMakePackage):
     depends_on('curl')
     depends_on('libedit')
     depends_on('binutils')
+
+    depends_on('llvm@:4.0.1', when='@0.17.4')
 
     def setup_dependent_environment(self, build_env, run_env, dep_spec):
 

--- a/var/spack/repos/builtin/packages/ldc/package.py
+++ b/var/spack/repos/builtin/packages/ldc/package.py
@@ -19,6 +19,7 @@ class Ldc(CMakePackage):
     homepage = "https://dlang.org/"
     url      = "https://github.com/ldc-developers/ldc/releases/download/v1.3.0/ldc-1.3.0-src.tar.gz"
 
+    version('1.4.0', '2e863186094eda83d2ba7a247c7ec732')
     version('1.3.0', '537d992a361b0fd0440b24a5145c9107')
 
     variant(


### PR DESCRIPTION
#### TLDR

With this PR all the branches whose name starts with `packages` will skip unit tests and build tests, on the promise that there are no modifications to core files. This promise is checked by an additional test that is run after flake8 and documentation.

Documentation on the new Travis features [here](https://blog.travis-ci.com/2017-09-12-build-stages-order-and-conditions).

#### Example

~You can check that Travis in this PR run all the tests as it did before. In #5840 the modifications are basically the same but the branch is named `packages/ldc_and_faster_ci`. The resulting CI is [here](https://travis-ci.org/LLNL/spack/builds/290369213?utm_source=github_status&utm_medium=notification) and it fails as expected.~

closes #5180
closes #5822
closes #5840 

-----

For #5822: I started with the idea of fixing that issue and skipping unit + build tests. I ended up modifying part of core, hence the current status. If the 2 lines change in `ldc` + `ldc-bootstrap` bother people I can extract them.