### PR TITLE
[docs] LLVM / modules / mixed toolchains

### DIFF
--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -661,6 +661,44 @@ correct module before trying to compile any packages with it.
 
 Now Spack will load the compiler's module before trying to compile any packages.
 
+.. warning::
+
+   In the above, we assumed the default TCL modules.  If you are using ``lmod``
+   with Spack, although ``lmod`` is capable of reading the TCL modules, it will
+   serve you best to use the Spack generated ``lmod`` modules.  More information
+   on Modules can be found in the :ref:`InstallEnvironmentModules` section.
+
+   In the example above, recall that the compiler that compiled LLVM was
+   ``gcc@6.4.1``, the operating system is ``linux-fedora25-x86_64``, and
+   ``$SPACK_ROOT`` is ``/opt/spack``.  The module files we will want to use,
+   then, are present in
+
+   +----------------+-----------------------+----------------------------+--------------------+
+   | ``SPACK_ROOT`` | Common Prefix         | Operating System           | What Compiled LLVM |
+   +================+=======================+============================+====================+
+   | ``/opt/spack`` | ``/share/spack/lmod`` | ``/linux-fedora25-x86_64`` | ``/gcc/6.4.1``     |
+   +----------------+-----------------------+----------------------------+--------------------+
+
+   For example, in the ``clang@3.9.0`` case, we would use
+
+   .. code-block:: yaml
+
+      - compiler:
+          environment:
+          # First, set the environment variable MODULEPATH
+          set:
+              "MODULEPATH": "/opt/spack/share/spack/lmod/linux-fedora25-x86_64/gcc/6.4.1"
+          extra_rpaths: []
+          flags: {}
+          # $MODULEPATH is now set so this module can be loaded
+          modules:
+          - llvm/3.9.0
+
+   If you have site-specific compiler modules (e.g., for ``gcc/6.4.1``), you
+   want to make sure to **not** load those.  All Spack generated compiler
+   modules use ``family("compiler")``, so as long as yours do as well there
+   would not be conflicts.  But it is safest to only load the module you need.
+
 """""""""""""""""""""""""""""""""
 Step 4: Choose a Fortran Compiler
 """""""""""""""""""""""""""""""""
@@ -1244,6 +1282,10 @@ version 8.5 with whatever version is installed on your system:
               paths:
                   tcl@8.5: /usr
               buildable: False
+
+.. tip::
+
+   Much more information on modules is available on the :ref:`modules` page.
 
 ^^^^^^^^^^^^^^^^^
 Package Utilities


### PR DESCRIPTION
~~**NOT MERGE READY** I figured out an `lmod`ism that needs to get added in here, the TCL modules only worked because `setup-env.sh` addes that to `MODULEPATH`.  Will strike through this after next commit later tonight, see [comment below](https://github.com/LLNL/spack/pull/5861#issuecomment-338484869).~~

Provides an explanation of how to setup a spack installed llvm properly using modules as well as suggestions for choosing a fortran compiler to couple with it.

1. I lack the ability to be succinct / trim down the fat.  Maintainers can edit the branch directly, as well as I'm happy to apply any / all suggestions.
2. Since the docs take eons to build, ~~[here is an `html.zip`](https://github.com/LLNL/spack/files/1403868/html.zip)~~ [here is an LMOD updated `html.zip`](https://github.com/LLNL/spack/files/1405637/html.zip) of the local docs build for viewing convenience.  Extract and `open html/getting_started.html`.  The anchor point is `getting_started.html#case-study-spack-installed-llvm-with-modules-and-mixed-toolchains`.

Fixes #5817.

@davydden I put it just below that section on its own, since it requires both modules and a mixed toolchain.  Does that make sense?

@junghans any special wisdom about `flang` here?  It's talked about in "Step 4".