### PR TITLE
Fix for nghttp2 installation

### DIFF
--- a/var/spack/repos/builtin/packages/nghttp2/package.py
+++ b/var/spack/repos/builtin/packages/nghttp2/package.py
@@ -33,3 +33,22 @@ class Nghttp2(AutotoolsPackage):
     url      = "https://github.com/nghttp2/nghttp2/releases/download/v1.26.0/nghttp2-1.26.0.tar.gz"
 
     version('1.26.0', '83fa813b22bacbc6ea80dfb24847569f')
+
+    depends_on('python@2.7:', type=('build', 'run'))
+    depends_on('py-cython@0.19:', type=('build', 'run'))
+    depends_on('py-setuptools', type=('build'))
+
+    def setup_environment(self, spack_env, run_env):
+        site_packages_dir = '/'.join(
+            [self.spec.prefix.lib,
+             ('python' + str(self.spec['python'].version.up_to(2))),
+             'site-packages'])
+        spack_env.prepend_path('PYTHONPATH', site_packages_dir)
+
+    @run_before('install')
+    def ensure_install_dir_exists(self):
+        site_packages_dir = '/'.join(
+            [self.spec.prefix.lib,
+             ('python' + str(self.spec['python'].version.up_to(2))),
+             'site-packages'])
+        mkdirp(site_packages_dir)


### PR DESCRIPTION
nghttp2 depends on python, and requires the install directory to exist,
and contain the python module directory which it will eventually
install the python modules into.

These issues were discovered while attempting to implement `lmod` support for `setup-env.sh`