### PR TITLE
fix perl dependent modules, #5900

### DIFF
--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -167,11 +167,11 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
             if d.package.extends(self.spec):
                 perl_lib_dirs.append(d.prefix.lib.perl5)
                 perl_bin_dirs.append(d.prefix.bin)
-        if perl_bin_dirs :
+        if perl_bin_dirs:
             perl_bin_path = ':'.join(perl_bin_dirs)
             spack_env.prepend_path('PATH', perl_bin_path)
             run_env.prepend_path('PATH', perl_bin_path)
-        if perl_lib_dirs :
+        if perl_lib_dirs:
             perl_lib_path = ':'.join(perl_lib_dirs)
             spack_env.prepend_path('PERL5LIB', perl_lib_path)
             run_env.prepend_path('PERL5LIB', perl_lib_path)

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -167,12 +167,17 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
             if d.package.extends(self.spec):
                 perl_lib_dirs.append(d.prefix.lib.perl5)
                 perl_bin_dirs.append(d.prefix.bin)
-        perl_bin_path = ':'.join(perl_bin_dirs)
-        perl_lib_path = ':'.join(perl_lib_dirs)
-        spack_env.prepend_path('PATH', perl_bin_path)
-        spack_env.prepend_path('PERL5LIB', perl_lib_path)
-        run_env.prepend_path('PATH', perl_bin_path)
-        run_env.prepend_path('PERL5LIB', perl_lib_path)
+        print("perl--setup_dependent_environmenti perl_lib_dirs-->",perl_lib_dirs)
+        if perl_bin_dirs :
+            print("#### perl-bin-dirs  ###")
+            perl_bin_path = ':'.join(perl_bin_dirs)
+            spack_env.prepend_path('PATH', perl_bin_path)
+            run_env.prepend_path('PATH', perl_bin_path)
+        if perl_lib_dirs :
+            print("#### perl-lib-dirs  ###")
+            perl_lib_path = ':'.join(perl_lib_dirs)
+            spack_env.prepend_path('PERL5LIB', perl_lib_path)
+            run_env.prepend_path('PERL5LIB', perl_lib_path)
 
     def setup_dependent_package(self, module, dependent_spec):
         """Called before perl modules' install() methods.

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -167,14 +167,11 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
             if d.package.extends(self.spec):
                 perl_lib_dirs.append(d.prefix.lib.perl5)
                 perl_bin_dirs.append(d.prefix.bin)
-        print("perl--setup_dependent_environmenti perl_lib_dirs-->",perl_lib_dirs)
         if perl_bin_dirs :
-            print("#### perl-bin-dirs  ###")
             perl_bin_path = ':'.join(perl_bin_dirs)
             spack_env.prepend_path('PATH', perl_bin_path)
             run_env.prepend_path('PATH', perl_bin_path)
         if perl_lib_dirs :
-            print("#### perl-lib-dirs  ###")
             perl_lib_path = ':'.join(perl_lib_dirs)
             spack_env.prepend_path('PERL5LIB', perl_lib_path)
             run_env.prepend_path('PERL5LIB', perl_lib_path)


### PR DESCRIPTION
remove (Tcl) modules prepend-path empty lines generated in perl dependent packages,
see #5900

On my cluster we use Tcl modules, we have not git installed on all nodes, 
when installing with spack:
module install git

then activating with
module load git

the command fails for empty prepend-path lines added by perl package