### PR TITLE
setup-env.sh support for lmod and dotkit

### DIFF
--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -65,7 +65,7 @@ This automatically adds Spack to your ``PATH`` and allows the ``spack``
 command to be used to execute spack :ref:`commands <shell-support>` and
 :ref:`useful packaging commands <packaging-shell-support>`.
 
-If :ref:`environment-modules or dotkit <InstallEnvironmentModules>` is
+If :ref:`environment-modules, lmod, or dotkit <ModuleSystems>` is
 installed and available, the ``spack`` command can also load and unload
 :ref:`modules <modules>`.
 
@@ -891,7 +891,7 @@ environment module that may be loaded.  Either way works.
 
 If you find that you are missing some of these programs, ``spack`` can
 build some of them for you with ``spack bootstrap``. Currently supported
-programs are ``environment-modules``.
+programs are ``environment-modules``, ``lmod``, and ``dotkit``.
 
 A few notes on specific programs in this list:
 
@@ -920,43 +920,40 @@ other programs will also not work, because they also rely on OpenSSL.
 Once ``curl`` has been installed, you can similarly install the others.
 
 
-.. _InstallEnvironmentModules:
+.. _ModuleSystems:
 
-"""""""""""""""""""
-Environment Modules
-"""""""""""""""""""
+^^^^^^^^^^^^^^
+Module Systems
+^^^^^^^^^^^^^^
 
-In order to use Spack's generated module files, you must have
-installed ``environment-modules`` or ``lmod``. The simplest way
-to get the latest version of either of these tools is installing
-it as part of Spack's bootstrap procedure:
+In order to use Spack's generated environment modules, you must have
+installed at least one of three supported module systems,
+``environment-modules``, ``lmod``, and ``dotkit``. Spack offers the option
+to install and manage any of these systems with ``spack bootstrap``.
+By looking at the contents of the `enabled` configuration key defined in
+`modules.yaml`, ``spack bootstrap`` installs the requested module systems.
+These systems can then be seemlessly activated by sourcing Spack's shell
+integration script ``setup-env.sh`` for ``bash``-like shell users.
 
-.. code-block:: console
-
-   $ spack bootstrap
-
-.. warning::
-   At the moment ``spack bootstrap`` is only able to install ``environment-modules``.
-   Extending its capabilities to prefer ``lmod`` where possible is in the roadmap,
-   and likely to happen before the next release.
-
-Alternatively, on many Linux distributions, you can install a pre-built binary
-from the vendor's repository. On Fedora/RHEL/CentOS, for example, this can be
-done with the command:
+On many Linux distributions, you can install a pre-built binary
+from the vendor's repository. Some users may want to use such a system-wide
+installation of one of these module systems or may wish to install and
+manage it manually. On Fedora/RHEL/CentOS, for example,
+``environment-modules`` can be done with the command:
 
 .. code-block:: console
 
    $ yum install environment-modules
 
-Once you have the tool installed and available in your path, you can source
-Spack's setup file:
+When manually managing in this way, all that is necessary is making sure
+the appropriate command is available. ``module`` for ``environment-modules``
+and ``lmod``, and ``use`` for ``dotkit``.
 
-.. code-block:: console
+While Spack supports all three module systems, we recommend you use either
+``environment-modules`` or ``lmod``.
 
-   $ source share/spack/setup-env.sh
-
-This activates :ref:`shell support <shell-support>` and makes commands like
-``spack load`` available for use.
+See :ref:`modules` and :ref:`modules-tutorial` for detailed information
+about modules and how to use and maintain them.
 
 
 ^^^^^^^^^^^^^^^^^

--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -15,7 +15,7 @@ providing post-install hooks that generate module files and commands to manipula
 .. note::
 
    If your machine does not already have a module system installed,
-   we advise you to use either Environment Modules or LMod. See :ref:`InstallEnvironmentModules`
+   we advise you to use either Environment Modules or LMod. See :ref:`ModuleSystems`
    for more details.
 
 .. _shell-support:
@@ -88,7 +88,7 @@ Note that in the latter case it is necessary to explicitly set ``SPACK_ROOT``
 before sourcing the setup file (you will get a meaningful error message
 if you don't).
 
-When ``bash`` and ``ksh`` users update their environment with ``setup-env.sh``, it will check for spack-installed environment modules and add the ``module`` command to their environment; This only occurs if the module command is not already available. You can install ``environment-modules`` with ``spack bootstrap`` as described in :ref:`InstallEnvironmentModules`.
+When ``bash`` and ``ksh`` users update their environment with ``setup-env.sh``, it will check for spack-installed modules systems and add appropriate command to their environment (``module`` for ``environment-modules`` and ``lmod``, and ``use`` for ``dotkit``); This only occurs if said command is not already available. You can install any of the three module systems with ``spack bootstrap`` as described in :ref:`ModuleSystems`.
 
 Finally, if you want to have Spack's shell support available on the command line at
 any login you can put this source line in one of the files that are sourced

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -80,6 +80,8 @@ def bootstrap(parser, args, **kwargs):
         requirement_dict['environment-modules'] = 'environment-modules~X'
     if 'lmod' in module_systems:
         requirement_dict['lmod'] = 'lmod'
+    if 'dotkit' in module_systems:
+        requirement_dict['dotkit'] = 'dotkit'
 
     for requirement in requirement_dict:
         installed_specs = spack.store.db.query(requirement)

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -26,6 +26,7 @@ import llnl.util.tty as tty
 import spack
 import spack.cmd
 import spack.cmd.common.arguments as arguments
+import spack.config
 
 description = "Bootstrap packages needed for spack to run smoothly"
 section = "admin"
@@ -72,7 +73,13 @@ def bootstrap(parser, args, **kwargs):
     # Define requirement dictionary defining general specs which need
     # to be satisfied, and the specs to install when the general spec
     # isn't satisfied.
-    requirement_dict = {'environment-modules': 'environment-modules~X'}
+    requirement_dict = {}
+
+    module_systems = spack.config.get_config('modules')['enable']
+    if 'tcl' in module_systems:
+        requirement_dict['environment-modules'] = 'environment-modules~X'
+    if 'lmod' in module_systems:
+        requirement_dict['lmod'] = 'lmod'
 
     for requirement in requirement_dict:
         installed_specs = spack.store.db.query(requirement)

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -30,6 +30,7 @@ import spack.modules
 import spack.spec
 import spack.store
 from spack.util.pattern import Args
+import spack.config
 
 __all__ = ['add_common_arguments']
 
@@ -106,8 +107,10 @@ _arguments['constraint'] = Args(
 _arguments['module_type'] = Args(
     '-m', '--module-type',
     choices=spack.modules.module_types.keys(),
+    default=spack.config.get_config('modules')['enable'][0],
     action='append',
-    help='type of module file. More than one choice is allowed [default: tcl]')  # NOQA: ignore=E501
+    help="type of module file. More than one choice is allowed" +
+         " [default: %s]" % spack.config.get_config('modules')['enable'][0])
 
 _arguments['yes_to_all'] = Args(
     '-y', '--yes-to-all', action='store_true', dest='yes_to_all',

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -107,7 +107,7 @@ _arguments['constraint'] = Args(
 _arguments['module_type'] = Args(
     '-m', '--module-type',
     choices=spack.modules.module_types.keys(),
-    default=spack.config.get_config('modules')['enable'][0],
+    default=[spack.config.get_config('modules')['enable'][0]],
     action='append',
     help="type of module file. More than one choice is allowed" +
          " [default: %s]" % spack.config.get_config('modules')['enable'][0])

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -36,12 +36,21 @@ def setup_parser(subparser):
 
     sp = subparser.add_subparsers(metavar='SUBCOMMAND', dest='config_command')
 
-    get_parser = sp.add_parser('get', help='print configuration values')
+    get_parser = sp.add_parser('get', help='print formatted configuration values')
     get_parser.add_argument('section',
                             help="configuration section to print. "
                                  "options: %(choices)s",
                             metavar='SECTION',
                             choices=spack.config.section_schemas)
+
+    getraw_parser = sp.add_parser('getraw', help='print raw configuration values.')
+    getraw_parser.add_argument('sections',
+                            help="configuration section to print. "
+                                 "each additional option selects a subsection. "
+                                 "use LEN to get the length of a list",
+                            metavar='SECTIONS',
+                            nargs="*")
+                           
 
     edit_parser = sp.add_parser('edit', help='edit configuration file')
     edit_parser.add_argument('section',
@@ -53,6 +62,9 @@ def setup_parser(subparser):
 
 def config_get(args):
     spack.config.print_section(args.section)
+
+def config_getraw(args):
+    spack.config.print_raw_sections(args.sections)
 
 
 def config_edit(args):
@@ -69,5 +81,6 @@ def config_edit(args):
 
 def config(parser, args):
     action = {'get': config_get,
+              'getraw': config_getraw,
               'edit': config_edit}
     action[args.config_command](args)

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -36,21 +36,23 @@ def setup_parser(subparser):
 
     sp = subparser.add_subparsers(metavar='SUBCOMMAND', dest='config_command')
 
-    get_parser = sp.add_parser('get', help='print formatted configuration values')
+    get_parser = sp.add_parser('get',
+                               help='print formatted configuration values')
     get_parser.add_argument('section',
                             help="configuration section to print. "
                                  "options: %(choices)s",
                             metavar='SECTION',
                             choices=spack.config.section_schemas)
 
-    getraw_parser = sp.add_parser('getraw', help='print raw configuration values.')
+    getraw_parser = sp.add_parser('getraw',
+                                  help='print raw configuration values.')
     getraw_parser.add_argument('sections',
-                            help="configuration section to print. "
-                                 "each additional option selects a subsection. "
-                                 "use LEN to get the length of a list",
-                            metavar='SECTIONS',
-                            nargs="*")
-                           
+                               help="configuration section to print. "
+                                    "each additional option selects a "
+                                    "subsection. use LEN to get the length "
+                                    "of a list",
+                               metavar='SECTIONS',
+                               nargs="*")
 
     edit_parser = sp.add_parser('edit', help='edit configuration file')
     edit_parser.add_argument('section',
@@ -62,6 +64,7 @@ def setup_parser(subparser):
 
 def config_get(args):
     spack.config.print_section(args.section)
+
 
 def config_getraw(args):
     spack.config.print_raw_sections(args.sections)

--- a/lib/spack/spack/cmd/module.py
+++ b/lib/spack/spack/cmd/module.py
@@ -179,7 +179,7 @@ def loads(module_types, specs, args):
     module_commands = {
         'tcl': 'module load ',
         'lmod': 'module load ',
-        'dotkit': 'dotkit use '
+        'dotkit': 'use '
     }
 
     d = {

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -460,6 +460,30 @@ def print_section(section):
         raise ConfigError("Error reading configuration: %s" % section)
 
 
+def print_raw_sections(sections):
+    """Print a configuration to stdout."""
+    try:
+        first = True
+        total_config = ""
+        conf = None
+        for sec in sections:
+            if first:
+                conf = get_config(sec)
+                total_config = "%s" % sec
+                first = False
+            else:
+                if sec == "LEN":
+                    print(len(conf))
+                    return
+                if sec.isdigit():
+                    sec = int(sec)
+                conf = conf[sec]
+                total_config = "%s %s" % (total_config, sec)
+        print(conf)
+    except (yaml.YAMLError, IOError):
+        raise ConfigError("Error reading configuration: %s" % total_config)
+
+
 class ConfigError(SpackError):
     pass
 

--- a/lib/spack/spack/test/cmd/module.py
+++ b/lib/spack/spack/test/cmd/module.py
@@ -30,6 +30,8 @@ import spack.cmd.module as module
 import spack.modules as modules
 import spack.config
 
+NO_TCL = 'tcl' not in spack.config.get_config('modules')['enable']
+
 
 def _get_module_files(args):
 
@@ -75,8 +77,6 @@ def test_exit_with_failure(parser, failure_args):
     with pytest.raises(SystemExit):
         module.module(parser, args)
 
-
-NO_TCL = 'tcl' not in spack.config.get_config('modules')['enable']
 
 @pytest.mark.db
 @pytest.mark.usefixtures('database')

--- a/lib/spack/spack/test/cmd/module.py
+++ b/lib/spack/spack/test/cmd/module.py
@@ -28,6 +28,7 @@ import os.path
 import pytest
 import spack.cmd.module as module
 import spack.modules as modules
+import spack.config
 
 
 def _get_module_files(args):
@@ -75,8 +76,11 @@ def test_exit_with_failure(parser, failure_args):
         module.module(parser, args)
 
 
+NO_TCL = 'tcl' not in spack.config.get_config('modules')['enable']
+
 @pytest.mark.db
 @pytest.mark.usefixtures('database')
+@pytest.mark.skipif(NO_TCL, reason='TCL module system is not enabled')
 def test_remove_and_add_tcl(parser):
     """Tests adding and removing a tcl module file."""
 
@@ -101,6 +105,7 @@ def test_remove_and_add_tcl(parser):
 
 
 @pytest.mark.db
+@pytest.mark.skipif(NO_TCL, reason='TCL module system is not enabled')
 @pytest.mark.usefixtures('database')
 @pytest.mark.parametrize('cli_args', [
     ['--module-type', 'tcl', 'libelf'],

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -217,7 +217,7 @@ function _spack_fn_exists() {
 # Create array of modules
 #
 _spack_mod_N="$(spack config getraw modules enable LEN)"
-_spack_mod_N="$(expr ${_spack_mod_N} - 1)"
+_spack_mod_N="$(expr ${_spack_mod_N} - 1 | head -n 1)"
 _spack_mod_array=()
 for ((i=0;i<=${_spack_mod_N};i++)); do
     mod_i="$(spack config getraw modules enable ${i})"

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -228,10 +228,10 @@ done;
 # Set up modules and dotkit search paths in the user environment
 #
 
-_python_command=$(printf  "%s\\\n%s\\\n%s" \
+_python_command=$(printf  "%s\\\n%s\\\n%s\\\n%s" \
 "print(\'_sp_sys_type={0}\'.format(spack.architecture.sys_type()))" \
 "print(\'_sp_dotkit_root={0}\'.format(spack.util.path.canonicalize_path(spack.config.get_config(\'config\').get(\'module_roots\', {}).get(\'dotkit\'))))" \
-"print(\'_sp_tcl_root={0}\'.format(spack.util.path.canonicalize_path(spack.config.get_config(\'config\').get(\'module_roots\', {}).get(\'tcl\'))))"
+"print(\'_sp_tcl_root={0}\'.format(spack.util.path.canonicalize_path(spack.config.get_config(\'config\').get(\'module_roots\', {}).get(\'tcl\'))))" \
 "print(\'_sp_lmod_root={0}\'.format(spack.util.path.canonicalize_path(spack.config.get_config(\'config\').get(\'module_roots\', {}).get(\'lmod\'))))"
 )
 

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -238,7 +238,6 @@ _python_command=$(printf  "%s\\\n%s\\\n%s" \
 _assignment_command=$(spack-python -c "exec('${_python_command}')")
 eval ${_assignment_command}
 
-_spack_pathadd DK_NODE    "${_sp_dotkit_root%/}/$_sp_sys_type"
 
 #
 # make module command available if an appropriate module system
@@ -275,6 +274,31 @@ if ! _spack_fn_exists module; then
         lmod_prefix=$(echo "${lmod_prefix}" | tail -n 1)
         if [ "${lmod_prefix}" != "not_installed" ]; then
             source "${lmod_prefix}/lmod/lmod/init/${SPACK_SHELL}"
+        fi;
+    fi;
+fi;
+
+#
+# make use command available if dotkit is installed
+# and the use command is not defined
+#
+if ! _spack_fn_exists use; then
+    # check whether dotkit is asked for
+    mod=""
+    for mod_i in ${_spack_mod_array[@]}; do
+        if [[ "${mod_i}" == "dotkit" ]]; then
+            mod="${mod_i}"
+        fi;
+    done;
+    # dotkit is installed
+    if [[ "${mod}" == "dotkit" ]]; then
+        _spack_pathadd DK_NODE "${_sp_dotkit_root%/}/$_sp_sys_type"
+        # check if dotkit is installed
+        dotkit_prefix="$(spack location -i "dotkit" 2>&1 || echo "not_installed")"
+        dotkit_prefix=$(echo "${dotkit_prefix}" | tail -n 1)
+        if [ "${dotkit_prefix}" != "not_installed" ]; then
+	     export DK_ROOT="${dotkit_prefix}"
+             eval `${DK_ROOT}/init`
         fi;
     fi;
 fi;

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -298,7 +298,7 @@ if ! _spack_fn_exists use; then
         dotkit_prefix=$(echo "${dotkit_prefix}" | tail -n 1)
         if [ "${dotkit_prefix}" != "not_installed" ]; then
 	     export DK_ROOT="${dotkit_prefix}"
-             eval `${DK_ROOT}/init`
+             eval `${DK_ROOT}/init` >& /dev/null
         fi;
     fi;
 fi;

--- a/var/spack/repos/builtin/packages/dotkit/package.py
+++ b/var/spack/repos/builtin/packages/dotkit/package.py
@@ -1,0 +1,39 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+from distutils.dir_util import copy_tree
+
+
+class Dotkit(Package):
+    """A set of shell scripts to help you setup, modify, and maintain a working
+       Unix environment."""
+
+    homepage = "https://sourceforge.net/projects/dotkit/"
+    url      = "https://downloads.sourceforge.net/project/dotkit/dotkit/dotkit080521/dotkit080521.tar.gz?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fdotkit%2F&ts=1508871919&use_mirror=ayera"
+
+    version('080521', '3e8b8bb37082214927443ebd27d3dab4')
+
+    def install(self, spec, prefix):
+        copy_tree(".", prefix, preserve_symlinks=1)


### PR DESCRIPTION
This PR introduces support for the lmod and dotkit module systems. This completes setup-env.sh's support for all three module systems. Towards this end, the following had to be done:

- A new subcommand `getraw` was added to the `config` command. This allows the user to query spack's configuration from the command line. This also includes the ability to find the lengths of lists using the `LEN` special keyword and use integers to access list elements by index. This was necessary to help `setup-env.sh` figure out which module systems where enabled, and more importantly, which were at the top of the list to establish whether `environemnt-modules` or `lmod` have priority for definition of the `module` function.
- The `dotkit` package was created.
- `setup-env.sh` logic was updated in order to more seamlessly handle the multiple module systems. First an array is filled with the enabled module systems, Then `module` or `use` is defined depending on which module systems are enabled and whether these functions are already defined.
- `spack bootstrap` logic was changed slightly to only install a module system's package if it is enabled.
- `spack module` logic was changed to set the default module type to that at the top of the modules enabled list. This means users no longer have to specify `-m` for the majority of cases.
- `spack module loads` dotkit usage command was corrected.
- Two tests depending on `tcl` modules being enabled have been given skip statements if `tcl` is not enabled. This prevents test failures when the user has disabled `tcl`.
- Documentation was updated detailing these new features. I do not believe that this documentation is totally complete, and I'm currently looking for outside opinions on it.

This PR depends on #5904 to be merged for `lmod` to build properly on at least some systems.