### PR TITLE
Add -d option to diy to specify source path move -j to common args

### DIFF
--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -142,6 +142,10 @@ _arguments['very_long'] = Args(
     '-L', '--very-long', action='store_true',
     help='show full dependency hashes as well as versions')
 
+_arguments['jobs'] = Args(
+    '-j', '--jobs', action='store', type=int, dest='jobs',
+    help="explicitely set number of make jobs. default is #cpus")
+
 _arguments['tags'] = Args(
     '-t', '--tags', action='append',
     help='filter a package query by tags')

--- a/lib/spack/spack/cmd/diy.py
+++ b/lib/spack/spack/cmd/diy.py
@@ -39,6 +39,10 @@ level = "long"
 
 
 def setup_parser(subparser):
+    arguments.add_common_arguments(subparser, ['jobs'])
+    subparser.add_argument(
+        '-d', '--source-path', dest='source_path', default=None,
+        help="path to source directory. defaults to the current directory")
     subparser.add_argument(
         '-i', '--ignore-dependencies', action='store_true', dest='ignore_deps',
         help="don't try to install dependencies of requested packages")
@@ -63,6 +67,10 @@ def diy(self, args):
     if not args.spec:
         tty.die("spack diy requires a package spec argument.")
 
+    if args.jobs is not None:
+        if args.jobs <= 0:
+            tty.die("the -j option must be a positive integer")
+
     specs = spack.cmd.parse_specs(args.spec)
     if len(specs) > 1:
         tty.die("spack diy only takes one spec.")
@@ -85,13 +93,19 @@ def diy(self, args):
         tty.msg("Uninstall or try adding a version suffix for this DIY build.")
         sys.exit(1)
 
+    source_path = args.source_path
+    if source_path is None:
+        source_path = os.getcwd()
+    source_path = os.path.abspath(source_path)
+
     # Forces the build to run out of the current directory.
-    package.stage = DIYStage(os.getcwd())
+    package.stage = DIYStage(source_path)
 
     # TODO: make this an argument, not a global.
     spack.do_checksum = False
 
     package.do_install(
+        make_jobs=args.jobs,
         keep_prefix=args.keep_prefix,
         install_deps=not args.ignore_deps,
         verbose=not args.quiet,

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -54,9 +54,7 @@ the default is to install the package along with all its dependencies.
 alternatively one can decide to install only the package or only
 the dependencies"""
     )
-    subparser.add_argument(
-        '-j', '--jobs', action='store', type=int,
-        help="explicitly set number of make jobs (default: #cpus)")
+    arguments.add_common_arguments(subparser, ['jobs'])
     subparser.add_argument(
         '--overwrite', action='store_true',
         help="reinstall an existing spec, even if it has dependents")


### PR DESCRIPTION
It seems that #5043 is currently stalled which was the primary location changes from #2771 were supposed to go.

Rather than continue this, I've made a new PR with these changes adopted to the current `develop` branch.

Once this is merged, I'll close #2771.