### PR TITLE
Add cudnn@7 .

### DIFF
--- a/var/spack/repos/builtin/packages/cudnn/package.py
+++ b/var/spack/repos/builtin/packages/cudnn/package.py
@@ -6,7 +6,7 @@
 # Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
 # LLNL-CODE-647188
 #
-# For details, see https://github.com/llnl/spack
+# For details, see https://github.com/spack/spack
 # Please also see the NOTICE and LICENSE files for our notice and the LGPL.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/var/spack/repos/builtin/packages/cudnn/package.py
+++ b/var/spack/repos/builtin/packages/cudnn/package.py
@@ -32,11 +32,13 @@ class Cudnn(Package):
 
     homepage = "https://developer.nvidia.com/cudnn"
 
-    version('7.0', '8548a35c8d51c3f8d44b46a79026d18b',
+    version('7.0.cuda9', '6189e05077dbce0bd07059b20306a836',
+            url='http://developer.download.nvidia.com/compute/redist/cudnn/v7.0.3/cudnn-9.0-linux-x64-v7.tgz')
+    version('7.0.cuda8', '8548a35c8d51c3f8d44b46a79026d18b',
             url='http://developer.download.nvidia.com/compute/redist/cudnn/v7.0.3/cudnn-8.0-linux-x64-v7.tgz')
-    version('6.0', 'a08ca487f88774e39eb6b0ef6507451d',
+    version('6.0.cuda8', 'a08ca487f88774e39eb6b0ef6507451d',
             url='http://developer.download.nvidia.com/compute/redist/cudnn/v6.0/cudnn-8.0-linux-x64-v6.0.tgz')
-    version('5.1', '406f4ac7f7ee8aa9e41304c143461a69',
+    version('5.1.cdua8', '406f4ac7f7ee8aa9e41304c143461a69',
             url='http://developer.download.nvidia.com/compute/redist/cudnn/v5.1/cudnn-8.0-linux-x64-v5.1.tgz')
 
     depends_on('cuda@8:')

--- a/var/spack/repos/builtin/packages/cudnn/package.py
+++ b/var/spack/repos/builtin/packages/cudnn/package.py
@@ -41,7 +41,11 @@ class Cudnn(Package):
     version('5.1.cuda8', '406f4ac7f7ee8aa9e41304c143461a69',
             url='http://developer.download.nvidia.com/compute/redist/cudnn/v5.1/cudnn-8.0-linux-x64-v5.1.tgz')
 
-    depends_on('cuda@8:')
+    depends_on('cuda@8', when="@5.1.cuda8", type='run')
+    depends_on('cuda@8', when="@6.0.cuda8", type='run')
+    depends_on('cuda@8', when="@6.0.cuda8", type='run')
+    depends_on('cuda@8', when="@7.0.cuda8", type='run')
+    depends_on('cuda@9', when="@7.0.cuda9", type='run')
 
     def install(self, spec, prefix):
         copy_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/cudnn/package.py
+++ b/var/spack/repos/builtin/packages/cudnn/package.py
@@ -38,7 +38,7 @@ class Cudnn(Package):
             url='http://developer.download.nvidia.com/compute/redist/cudnn/v7.0.3/cudnn-8.0-linux-x64-v7.tgz')
     version('6.0.cuda8', 'a08ca487f88774e39eb6b0ef6507451d',
             url='http://developer.download.nvidia.com/compute/redist/cudnn/v6.0/cudnn-8.0-linux-x64-v6.0.tgz')
-    version('5.1.cdua8', '406f4ac7f7ee8aa9e41304c143461a69',
+    version('5.1.cuda8', '406f4ac7f7ee8aa9e41304c143461a69',
             url='http://developer.download.nvidia.com/compute/redist/cudnn/v5.1/cudnn-8.0-linux-x64-v5.1.tgz')
 
     depends_on('cuda@8:')

--- a/var/spack/repos/builtin/packages/cudnn/package.py
+++ b/var/spack/repos/builtin/packages/cudnn/package.py
@@ -39,7 +39,6 @@ class Cudnn(Package):
     version('5.1', '406f4ac7f7ee8aa9e41304c143461a69',
             url='http://developer.download.nvidia.com/compute/redist/cudnn/v5.1/cudnn-8.0-linux-x64-v5.1.tgz')
 
-
     depends_on('cuda@8:')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/cudnn/package.py
+++ b/var/spack/repos/builtin/packages/cudnn/package.py
@@ -32,10 +32,13 @@ class Cudnn(Package):
 
     homepage = "https://developer.nvidia.com/cudnn"
 
+    version('7.0', '8548a35c8d51c3f8d44b46a79026d18b',
+            url='http://developer.download.nvidia.com/compute/redist/cudnn/v7.0.3/cudnn-8.0-linux-x64-v7.tgz')
     version('6.0', 'a08ca487f88774e39eb6b0ef6507451d',
             url='http://developer.download.nvidia.com/compute/redist/cudnn/v6.0/cudnn-8.0-linux-x64-v6.0.tgz')
     version('5.1', '406f4ac7f7ee8aa9e41304c143461a69',
             url='http://developer.download.nvidia.com/compute/redist/cudnn/v5.1/cudnn-8.0-linux-x64-v5.1.tgz')
+
 
     depends_on('cuda@8:')
 

--- a/var/spack/repos/builtin/packages/cudnn/package.py
+++ b/var/spack/repos/builtin/packages/cudnn/package.py
@@ -32,25 +32,26 @@ class Cudnn(Package):
 
     homepage = "https://developer.nvidia.com/cudnn"
 
-    version('7.0.cuda9', '6189e05077dbce0bd07059b20306a836',
-            url='http://developer.download.nvidia.com/compute/redist/cudnn/v7.0.3/cudnn-9.0-linux-x64-v7.tgz')
-    version('7.0.cuda8', '8548a35c8d51c3f8d44b46a79026d18b',
-            url='http://developer.download.nvidia.com/compute/redist/cudnn/v7.0.3/cudnn-8.0-linux-x64-v7.tgz')
-    version('6.0.cuda8', 'a08ca487f88774e39eb6b0ef6507451d',
-            url='http://developer.download.nvidia.com/compute/redist/cudnn/v6.0/cudnn-8.0-linux-x64-v6.0.tgz')
-    version('6.0.cuda7', '388b32257ad34a9d954e51ea920500e4',
-            url='http://developer.download.nvidia.com/compute/redist/cudnn/v6.0/cudnn-7.5-linux-x64-v6.0.tgz')
-    version('5.1.cuda8', '406f4ac7f7ee8aa9e41304c143461a69',
-            url='http://developer.download.nvidia.com/compute/redist/cudnn/v5.1/cudnn-8.0-linux-x64-v5.1.tgz')
-    version('5.1.cuda7', '114ae87d1b9e96fff5e1353907df7a14',
-            url='http://developer.download.nvidia.com/compute/redist/cudnn/v5.1/cudnn-7.5-linux-x64-v5.1.tgz')
+    version('7.0', '6189e05077dbce0bd07059b20306a836',
+            url='http://developer.download.nvidia.com/compute/redist/cudnn/v7.0.3/cudnn-9.0-linux-x64-v7.tgz',
+            when='^cuda@9')
+    version('7.0', '8548a35c8d51c3f8d44b46a79026d18b',
+            url='http://developer.download.nvidia.com/compute/redist/cudnn/v7.0.3/cudnn-8.0-linux-x64-v7.tgz',
+            when='^cuda@8')
+    version('6.0', 'a08ca487f88774e39eb6b0ef6507451d',
+            url='http://developer.download.nvidia.com/compute/redist/cudnn/v6.0/cudnn-8.0-linux-x64-v6.0.tgz',
+            when='^cuda@8')
+    version('6.0', '388b32257ad34a9d954e51ea920500e4',
+            url='http://developer.download.nvidia.com/compute/redist/cudnn/v6.0/cudnn-7.5-linux-x64-v6.0.tgz',
+            when='^cuda@7.5')
+    version('5.1', '406f4ac7f7ee8aa9e41304c143461a69',
+            url='http://developer.download.nvidia.com/compute/redist/cudnn/v5.1/cudnn-8.0-linux-x64-v5.1.tgz',
+            when='^cuda@8')
+    version('5.1', '114ae87d1b9e96fff5e1353907df7a14',
+            url='http://developer.download.nvidia.com/compute/redist/cudnn/v5.1/cudnn-7.5-linux-x64-v5.1.tgz',
+            when='^cuda@7.5')
 
-    depends_on('cuda@9', type='run', when='@7.0.cuda9')
-    depends_on('cuda@8', type='run', when='@7.0.cuda8')
-    depends_on('cuda@8', type='run', when='@6.0.cuda8')
-    depends_on('cuda@7.5', type='run', when='@6.0.cuda7')
-    depends_on('cuda@8', type='run', when='@5.1.cuda8')
-    depends_on('cuda@7.5', type='run', when='@5.1.cuda7')
+    depends_on('cuda@7.5:', type='run')
 
     def install(self, spec, prefix):
         copy_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/cudnn/package.py
+++ b/var/spack/repos/builtin/packages/cudnn/package.py
@@ -38,10 +38,19 @@ class Cudnn(Package):
             url='http://developer.download.nvidia.com/compute/redist/cudnn/v7.0.3/cudnn-8.0-linux-x64-v7.tgz')
     version('6.0.cuda8', 'a08ca487f88774e39eb6b0ef6507451d',
             url='http://developer.download.nvidia.com/compute/redist/cudnn/v6.0/cudnn-8.0-linux-x64-v6.0.tgz')
+    version('6.0.cuda7', '388b32257ad34a9d954e51ea920500e4',
+            url='http://developer.download.nvidia.com/compute/redist/cudnn/v6.0/cudnn-7.5-linux-x64-v6.0.tgz')
     version('5.1.cuda8', '406f4ac7f7ee8aa9e41304c143461a69',
             url='http://developer.download.nvidia.com/compute/redist/cudnn/v5.1/cudnn-8.0-linux-x64-v5.1.tgz')
+    version('5.1.cuda7', '114ae87d1b9e96fff5e1353907df7a14',
+            url='http://developer.download.nvidia.com/compute/redist/cudnn/v5.1/cudnn-7.5-linux-x64-v5.1.tgz')
 
-    depends_on('cuda', type='run')
+    depends_on('cuda@9', type='run', when='@7.0.cuda9')
+    depends_on('cuda@8', type='run', when='@7.0.cuda8')
+    depends_on('cuda@8', type='run', when='@6.0.cuda8')
+    depends_on('cuda@7.5', type='run', when='@6.0.cuda7')
+    depends_on('cuda@8', type='run', when='@5.1.cuda8')
+    depends_on('cuda@7.5', type='run', when='@5.1.cuda7')
 
     def install(self, spec, prefix):
         copy_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/cudnn/package.py
+++ b/var/spack/repos/builtin/packages/cudnn/package.py
@@ -41,11 +41,7 @@ class Cudnn(Package):
     version('5.1.cuda8', '406f4ac7f7ee8aa9e41304c143461a69',
             url='http://developer.download.nvidia.com/compute/redist/cudnn/v5.1/cudnn-8.0-linux-x64-v5.1.tgz')
 
-    depends_on('cuda@8', when="@5.1.cuda8", type='run')
-    depends_on('cuda@8', when="@6.0.cuda8", type='run')
-    depends_on('cuda@8', when="@6.0.cuda8", type='run')
-    depends_on('cuda@8', when="@7.0.cuda8", type='run')
-    depends_on('cuda@9', when="@7.0.cuda9", type='run')
+    depends_on('cuda', type='run')
 
     def install(self, spec, prefix):
         copy_tree('.', prefix)


### PR DESCRIPTION
@tgamblin CuDNN versrion 7 have seprate packages for CUDA 8 and CUDA 9, namely cudnn-8.0-linux-x64-v7.tgz and cudnn-9.0-linux-x64-v7.tgz. Any sugggestion on handling such issue?