### PR TITLE
trilinos: update hdf5 dependency to use 'hdf5+hl'

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -223,7 +223,8 @@ class Trilinos(CMakePackage):
     depends_on('hypre~internal-superlu~int64', when='+hypre')
     depends_on('hypre@xsdk-0.2.0~internal-superlu', when='@xsdk-0.2.0+hypre')
     depends_on('hypre@develop~internal-superlu', when='@develop+hypre')
-    depends_on('hdf5+mpi', when='+hdf5')
+    # FIXME: concretizer bug? Somhow 'hl' requirement by netcdf is affecting this code.
+    depends_on('hdf5+hl+mpi', when='+hdf5')
     depends_on('python', when='+python')
     depends_on('py-numpy', when='+python', type=('build', 'run'))
     depends_on('swig', when='+python')

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -223,7 +223,7 @@ class Trilinos(CMakePackage):
     depends_on('hypre~internal-superlu~int64', when='+hypre')
     depends_on('hypre@xsdk-0.2.0~internal-superlu', when='@xsdk-0.2.0+hypre')
     depends_on('hypre@develop~internal-superlu', when='@develop+hypre')
-    # FIXME: concretizer bug? Somhow 'hl' requirement by netcdf is affecting this code.
+    # FIXME: concretizer bug? 'hl' req by netcdf is affecting this code.
     depends_on('hdf5+hl+mpi', when='+hdf5')
     depends_on('python', when='+python')
     depends_on('py-numpy', when='+python', type=('build', 'run'))


### PR DESCRIPTION
Without this change - I get the following error [triggered by 161dca6d5 c9810f808 changes]


$ ./bin/spack install trilinos+hdf5
==> Error: An unsatisfiable variant constraint has been detected for spec:

    hdf5@1.10.1%gcc@7~cxx~debug~fortran~hl+mpi+pic+shared~szip~threadsafe arch=linux-fedora27-x86_64


while trying to concretize the partial spec:

    netcdf+mpi
        ^m4
        ^mpich@3.3a2%gcc@7 device=ch3 +hydra netmod=tcp +pmi+romio~verbs arch=linux-fedora27-x86_64
        ^zlib@1.2.11%gcc@7+optimize+pic+shared arch=linux-fedora27-x86_64


netcdf requires hdf5 variant +hl, but spec asked for ~hl