### PR TITLE
Dyninst links broken, everything switched to github

### DIFF
--- a/var/spack/repos/builtin/packages/dyninst/package.py
+++ b/var/spack/repos/builtin/packages/dyninst/package.py
@@ -33,18 +33,13 @@ class Dyninst(Package):
     url = "https://github.com/dyninst/dyninst/archive/v9.2.0.tar.gz"
     list_url = "http://www.dyninst.org/downloads/dyninst-8.x"
 
-    version('9.3.2', 'a2bf03b6d1d424853e80d39b13e9c229')
-    version('9.3.0', 'edde7847dc673ca69bd59412af572450')
-    version('9.2.0', 'ad023f85e8e57837ed9de073b59d6bab',
-            url="https://github.com/dyninst/dyninst/archive/v9.2.0.tar.gz")
-    version('9.1.0', '5c64b77521457199db44bec82e4988ac',
-            url="http://www.paradyn.org/release9.1.0/DyninstAPI-9.1.0.tgz")
-    version('8.2.1', 'abf60b7faabe7a2e4b54395757be39c7',
-            url="http://www.paradyn.org/release8.2/DyninstAPI-8.2.1.tgz")
-    version('8.1.2', 'bf03b33375afa66fe0efa46ce3f4b17a',
-            url="http://www.paradyn.org/release8.1.2/DyninstAPI-8.1.2.tgz")
-    version('8.1.1', 'd1a04e995b7aa70960cd1d1fac8bd6ac',
-            url="http://www.paradyn.org/release8.1/DyninstAPI-8.1.1.tgz")
+    version('9.3.2', git="https://github.com/dyninst/dyninst.git", tag='v9.3.2')
+    version('9.3.0', git="https://github.com/dyninst/dyninst.git", tag='v9.3.0')
+    version('9.2.0', git="https://github.com/dyninst/dyninst.git", tag='v9.2.0')
+    version('9.1.0', git="https://github.com/dyninst/dyninst.git", tag='v9.1.0')
+    version('8.2.1', git="https://github.com/dyninst/dyninst.git", tag='v8.2.1')
+    version('8.1.2', git="https://github.com/dyninst/dyninst.git", tag='v8.1.2')
+    version('8.1.1', git="https://github.com/dyninst/dyninst.git", tag='v8.1.1')
 
     variant('stat_dysect', default=False,
             description="patch for STAT's DySectAPI")


### PR DESCRIPTION
Not sure if there's a nice way to specify a single git URL, rather than have the same one per version...