### PR TITLE
Doc update for SC17

### DIFF
--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -400,6 +400,33 @@ Once your new configuration key is added to the schema, you can add it to
 the appropriate spack configuration file in ``etc/spack/defaults`` without
 spack throwing an error.
 
+-------------------------------
+Executing command line programs
+-------------------------------
+
+Spack offers the :meth:`spack.util.executable.Executable` class to
+facilitate the execution of command line programs easily using the python
+``subprocess`` interface.
+
+To create a function from which to access the ``foo`` command, use the following
+code. Creating the ``Executable`` object will not fail if the command does not
+exist, so you may want to check first or expect to catch errors.
+
+.. code-block:: python
+
+   foo = Executable('foo')
+   foo('-option')
+
+To redirect output to a string which is captured and passed out, use the
+following code. The output is given as a single unbroken string, so you
+will need to split it yourself.
+
+.. code-block:: python
+
+   foo = Executable('foo')
+   output = foo('-option', output=str)
+   lines = output.split('\n')
+
 ----------
 Unit tests
 ----------

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -340,6 +340,66 @@ Whenever you add/remove/rename a command or flags for an existing command,
 make sure to update Spack's `Bash tab completion script
 <https://github.com/adamjstewart/spack/blob/develop/share/spack/spack-completion.bash>`_.
 
+-------------
+Configuration
+-------------
+
+Spack's configuration system allows the dynamic setting of variables to
+influence its operation. Knowing how to change how these configuration
+files are laid out and how to access their values is crucial to writing
+new Spack functionality.
+
+As discussed in :ref:`configuration`, Spack's configuration files are
+written in several YAML files which define a number of scopes. These are
+
+* ``compilers``
+* ``config``
+* ``mirrors``
+* ``modules``
+* ``packages``
+* ``repos``
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Accessing Configuration Settings
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``spack.config.get_config`` function is used to access information in
+a configuration scope:
+
+.. code-block:: python
+
+   config_scope = spack.config.get_config("config")
+
+The resulting object is a dictionary containing the key-value pairs stored in
+the configuration files. For instance, if the following is in a YAML file:
+
+.. code-block:: yaml
+
+   config:
+     verify_ssl: true
+
+Then to access it, use the following code:
+
+.. code-block:: python
+
+   config_scope = spack.config.get_config("config")
+   print(config_scope['verify_ssl'])
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Adding New Configuration Settings
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Occasionally, new configuration options need to be added. To do this, you
+must first add them to the YAML file definitions files which you can find
+in the directory ``lib/spack/spack/schema``. Each config scope has its own
+schema file of the same name. Each file is formatted according to the
+json schema style, and a good tutorial describing the format is
+`Here <https://spacetelescope.github.io/understanding-json-schema/basics.html>`_
+
+Once your new configuration key is added to the schema, you can add it to
+the appropriate spack configuration file in ``etc/spack/defaults`` without
+spack throwing an error.
+
 ----------
 Unit tests
 ----------

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2413,6 +2413,36 @@ the install locations of dependencies, or when you need to do something differen
 depending on the version, compiler, dependencies, etc. that your package is
 built with.  These parameters give you access to this type of information.
 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Techniques for ad-hoc packages building systems
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Some packages do not use common build systems or even any build system
+at all. Here are a few strategies to deal with such packages.
+
+"""""""""""""""""""""""""""""
+Packages with no build system
+"""""""""""""""""""""""""""""
+
+These packages often just need to be copied to their 'installed' location.
+In these cases, it is recommended to use the ``copy_tree`` command from
+the ``distutils.dir_util`` module.
+
+.. code-block:: python
+
+   from distutils.dir_util import copy_tree
+
+   copy_tree(".", prefix)
+
+Beware because some packages use symbolic links. In which case it should be:
+
+.. code-block:: python
+
+   from distutils.dir_util import copy_tree
+
+   copy_tree(".", prefix, preserve_symlinks=1)
+
+
 .. _install-environment:
 
 -----------------------

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -3023,6 +3023,13 @@ the two functions is that ``satisfies()`` tests whether spec
 constraints overlap at all, while ``in`` tests whether a spec or any
 of its dependencies satisfy the provided spec.
 
+^^^^^^^^^^^^^^^^
+Hash Calculation
+^^^^^^^^^^^^^^^^
+
+From a concretized spec, it's hash is calculated using the function
+``spec.dag_hash``. Have a look at it to see how this calculation is
+performed.
 
 .. _multimethods:
 

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2567,6 +2567,45 @@ if you want to run commands in that environment to test them out, you
 can use the :ref:`cmd-spack-env` command, documented
 below.
 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Methods for changing the Environment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Spack offers three functions which are automatically executed to change
+the environment in various situations. These can be useful for setting
+environment variables for an install procedure, or for dependents of a
+package to use. Each function is used in different situations. The links
+below go to the API documentation where details about what each function
+is for is listed.
+
+* ``setup_environment``: :meth:`spack.package.PackageBase.setup_environment`
+* ``setup_dependent_environment``: :meth:`spack.package.PackageBase.setup_dependent_environment`
+* ``setup_dependent_package``: :meth:`spack.package.PackageBase.setup_dependent_package`
+
+Two of the functions (``setup_environment`` and ``setup_dependent_environment``)
+take two arguments ``spack_env`` and ``run_env`` which are of type
+:meth:`spack.environment.EnvironmentModifications` which are used to store
+the environment modifications.
+
+To set a variable:
+
+.. code-block:: python
+
+   env.set('var_name', var_value)
+
+To prepend to a path to a variable:
+
+.. code-block:: python
+
+   env.prepend_path('var_name', path)
+
+To append to a path to a variable:
+
+.. code-block:: python
+
+   env.append_path('var_name', path)
+
+
 ^^^^^^^^^^^^^^^^^^^^^
 Failing the build
 ^^^^^^^^^^^^^^^^^^^^^

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2413,6 +2413,26 @@ the install locations of dependencies, or when you need to do something differen
 depending on the version, compiler, dependencies, etc. that your package is
 built with.  These parameters give you access to this type of information.
 
+^^^^^^^^^^^^^^^^^
+Adding new phases
+^^^^^^^^^^^^^^^^^
+
+Phases can be added before or after existing phases by using the ``run_before``
+and ``run_after`` decorators. Say you want to include some kind of build test
+or install test to be performed before or after installation of the package.
+You can declare a function you want to be run and then decorate it with one of
+these functions mentioning the phase you want the function to run before or
+after.
+
+.. code-block:: python
+
+   @run_after('install')
+   def check_install(self):
+        # Custom implementation goes here
+        pass
+
+:ref:`build-time-tests` Mentions this as well. See it for additional details.
+
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Techniques for ad-hoc packages building systems
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -3363,6 +3383,8 @@ Now, after ``install()`` runs, Spack will check whether
 the build will fail and the install prefix will be removed.  If they
 succeed, Spack considers the build successful and keeps the prefix in
 place.
+
+.. _build-time-tests:
 
 ^^^^^^^^^^^^^^^^
 Build-time tests

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -253,6 +253,17 @@ The ``gmp`` package actually lives in
 but ``spack edit`` provides a much simpler shortcut and saves you the
 trouble of typing the full path.
 
+As examples for your inspiration, here are some packages which require some
+of the techniques discussed here to be properly installed. They should
+help instruct you how to solve problems you may encounter when you are
+creating a new package.
+
+* ``python``
+* ``py-yt``
+* ``rockstar``
+* ``node-js``
+* ``npm``
+
 ----------------------------
 Naming & directory structure
 ----------------------------

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2413,16 +2413,16 @@ the install locations of dependencies, or when you need to do something differen
 depending on the version, compiler, dependencies, etc. that your package is
 built with.  These parameters give you access to this type of information.
 
-^^^^^^^^^^^^^^^^^
-Adding new phases
-^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Adding arbitrary code to the install procedure
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Phases can be added before or after existing phases by using the ``run_before``
-and ``run_after`` decorators. Say you want to include some kind of build test
-or install test to be performed before or after installation of the package.
-You can declare a function you want to be run and then decorate it with one of
-these functions mentioning the phase you want the function to run before or
-after.
+Arbitrary code  can be added before or after existing phases by using the
+``run_before`` and ``run_after`` decorators. Say you want to include some
+kind of build test or install test to be performed before or after
+installation of the package. You can declare a function you want to be run
+and then decorate it with one of these functions mentioning the phase you
+want the function to run before or after.
 
 .. code-block:: python
 

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -447,6 +447,9 @@ Alternately, you might use a hybrid release-version / date scheme.
 For example, ``@1.3.2016.08.31`` would mean the version from the
 ``1.3`` branch, as of August 31, 2016.
 
+
+.. _VersionURLs:
+
 ^^^^^^^^^^^^
 Version URLs
 ^^^^^^^^^^^^
@@ -2809,9 +2812,59 @@ special parameters to ``configure``, like
 need to supply special compiler flags depending on the compiler.  All
 of this information is available in the spec.
 
-^^^^^^^^^^^^^^^^^^^^^^^^
-Testing spec constraints
-^^^^^^^^^^^^^^^^^^^^^^^^
+Spec objects contain a number of useful members which can be accessed from
+every concretized spec, we detail a few of them here.
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Installation Location (``spec.prefix``)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This is the prefix in which the spec is or will be installed. You can
+access common sub-directories in this prefix like ``bin`` and ``lib`` by
+access the member of the same name.
+
+.. code-block:: python
+
+   spec.prefix
+   spec.prefix.bin
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Spec Version (``spec.version``)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This is the version of the spec if it has been concretized. You can
+manipulate this version object as described in section :ref:`VersionURLs`.
+This is useful for install procedures which change depending on which
+version of the spec you're using.
+
+^^^^^^^^^^^^^^^^^^^^^^
+Accessing Dependencies
+^^^^^^^^^^^^^^^^^^^^^^
+
+You may need to get at some file or binary that's in the installation
+prefix of one of your dependencies. You can do that by sub-scripting
+the spec:
+
+.. code-block:: python
+
+   spec['mpi']
+
+The value in the brackets needs to be some package name, and spec
+needs to depend on that package, or the operation will fail.  For
+example, the above code will fail if the ``spec`` doesn't depend on
+``mpi``.  The value returned is itself just another ``Spec`` object,
+so you can do all the same things you would do with the package's
+own spec:
+
+.. code-block:: python
+
+   spec['mpi'].prefix.bin
+   spec['mpi'].version
+
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Testing spec constraints (``spec.satisfies``)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can test whether your spec is configured a certain way by using
 the ``satisfies`` method.  For example, if you want to check whether
@@ -2881,35 +2934,12 @@ the two functions is that ``satisfies()`` tests whether spec
 constraints overlap at all, while ``in`` tests whether a spec or any
 of its dependencies satisfy the provided spec.
 
-^^^^^^^^^^^^^^^^^^^^^^
-Accessing Dependencies
-^^^^^^^^^^^^^^^^^^^^^^
-
-You may need to get at some file or binary that's in the installation
-prefix of one of your dependencies. You can do that by sub-scripting
-the spec:
-
-.. code-block:: python
-
-   spec['mpi']
-
-The value in the brackets needs to be some package name, and spec
-needs to depend on that package, or the operation will fail.  For
-example, the above code will fail if the ``spec`` doesn't depend on
-``mpi``.  The value returned is itself just another ``Spec`` object,
-so you can do all the same things you would do with the package's
-own spec:
-
-.. code-block:: python
-
-   spec['mpi'].prefix.bin
-   spec['mpi'].version
 
 .. _multimethods:
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+--------------------------
 Multimethods and ``@when``
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+--------------------------
 
 Spack allows you to make multiple versions of instance functions in
 packages, based on whether the package's spec satisfies particular


### PR DESCRIPTION
Hey folks,

I've updated a few sections of the documentation for SC17. I've rearranged one section, and added sections on topics which aren't much discussed elsewhere. These are all things I had trouble figuring out on my own, and I think the documentation would benefit from having them in there.

Topics include:
- Better enumeration of a spec objects abilities
- Examples of packages to use for inspiration
- Another mention of using the `run_before` and `run_after` decorators
- How to get configuration variables within spack
- How to change or add configuration variables to spack
- How to execute command line programs
- A small mention about how hashes are calculated.

Give me feedback on formatting and content.