### PR TITLE
Bugfix for compiler schema

### DIFF
--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -145,25 +145,41 @@ def compiler_info(args):
     else:
         for c in compilers:
             print(str(c.spec) + ":")
+            print("\ttarget: " + c.target)
+            print("\toperating_system: " + c.operating_system)
+
             print("\tpaths:")
             for cpath in ['cc', 'cxx', 'f77', 'fc']:
-                print("\t\t%s = %s" % (cpath, getattr(c, cpath, None)))
-            if c.flags:
+                print("\t\t%s: %s" % (cpath, getattr(c, cpath, None)))
+
+            if any(c.flags):
                 print("\tflags:")
                 for flag, flag_value in iteritems(c.flags):
-                    print("\t\t%s = %s" % (flag, flag_value))
-            if len(c.environment) != 0:
-                if len(c.environment['set']) != 0:
-                    print("\tenvironment:")
-                    print("\t    set:")
-                    for key, value in iteritems(c.environment['set']):
-                        print("\t        %s = %s" % (key, value))
-            if c.extra_rpaths:
-                print("\tExtra rpaths:")
+                    print("\t\t%s: %s" % (flag, flag_value))
+            else:
+                print("\tflags: " + str(type(c.flags)()))
+
+            if any(c.environment):
+                print("\tenvironment:")
+                print("\t\tset:")
+                for key, value in iteritems(c.environment['set']):
+                    print("\t\t\t%s: %s" % (key, value))
+            else:
+                print("\tenvironment: " + str(type(c.environment)()))
+
+            if any(c.extra_rpaths):
+                print("\textra_rpaths:")
                 for extra_rpath in c.extra_rpaths:
-                    print("\t\t%s" % extra_rpath)
-            print("\tmodules  = %s" % c.modules)
-            print("\toperating system  = %s" % c.operating_system)
+                    print("\t\t" + extra_rpath)
+            else:
+                print("\textra_rpaths: " + str(type(c.extra_rpaths)()))
+
+            if any(c.modules):
+                print("\tmodules:")
+                for module in c.modules:
+                    print("\t\t" + module)
+            else:
+                print("\tmodules: " + str(type(c.modules)()))
 
 
 def compiler_list(args):

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -478,7 +478,10 @@ class ConfigFileError(ConfigError):
 
 def get_path(path, data):
     if path:
-        return get_path(path[1:], data[path[0]])
+        key = path[0]
+        if isinstance(data, list):
+            key = int(key)
+        return get_path(path[1:], data[key])
     else:
         return data
 

--- a/lib/spack/spack/schema/compilers.py
+++ b/lib/spack/spack/schema/compilers.py
@@ -38,67 +38,81 @@ schema = {
         'compilers': {
             'type': 'array',
             'items': {
-                'compiler': {
-                    'type': 'object',
-                    'additionalProperties': False,
-                    'required': [
-                        'paths', 'spec', 'modules', 'operating_system'],
-                    'properties': {
-                        'paths': {
-                            'type': 'object',
-                            'required': ['cc', 'cxx', 'f77', 'fc'],
-                            'additionalProperties': False,
-                            'properties': {
-                                'cc':  {'anyOf': [{'type': 'string'},
-                                                  {'type': 'null'}]},
-                                'cxx': {'anyOf': [{'type': 'string'},
-                                                  {'type': 'null'}]},
-                                'f77': {'anyOf': [{'type': 'string'},
-                                                  {'type': 'null'}]},
-                                'fc':  {'anyOf': [{'type': 'string'},
-                                                  {'type': 'null'}]}}},
-                        'flags': {
-                            'type': 'object',
-                            'additionalProperties': False,
-                            'properties': {
-                                'cflags': {'anyOf': [{'type': 'string'},
-                                                     {'type': 'null'}]},
-                                'cxxflags': {'anyOf': [{'type': 'string'},
-                                                       {'type': 'null'}]},
-                                'fflags': {'anyOf': [{'type': 'string'},
-                                                     {'type': 'null'}]},
-                                'cppflags': {'anyOf': [{'type': 'string'},
-                                                       {'type': 'null'}]},
-                                'ldflags': {'anyOf': [{'type': 'string'},
+                'type': 'object',
+                'additionalProperties': False,
+                'properties': {
+                    'compiler': {
+                        'type': 'object',
+                        'additionalProperties': False,
+                        'required': [
+                            'paths', 'spec', 'operating_system'],
+                        'properties': {
+                            'paths': {
+                                'type': 'object',
+                                'required': ['cc', 'cxx', 'f77', 'fc'],
+                                'additionalProperties': False,
+                                'properties': {
+                                    'cc':  {'anyOf': [{'type': 'string'},
                                                       {'type': 'null'}]},
-                                'ldlibs': {'anyOf': [{'type': 'string'},
-                                                     {'type': 'null'}]}}},
-                        'spec': {'type': 'string'},
-                        'operating_system': {'type': 'string'},
-                        'alias': {'anyOf': [{'type': 'string'},
-                                            {'type': 'null'}]},
-                        'modules': {'anyOf': [{'type': 'string'},
-                                              {'type': 'null'},
-                                              {'type': 'array'}]},
-                        'environment': {
-                            'type': 'object',
-                            'default': {},
-                            'additionalProperties': False,
-                            'properties': {
-                                'set': {
-                                    'type': 'object',
-                                    'patternProperties': {
-                                        r'\w[\w-]*': {  # variable name
-                                            'type': 'string'
+                                    'cxx': {'anyOf': [{'type': 'string'},
+                                                      {'type': 'null'}]},
+                                    'f77': {'anyOf': [{'type': 'string'},
+                                                      {'type': 'null'}]},
+                                    'fc':  {'anyOf': [{'type': 'string'},
+                                                      {'type': 'null'}]}}},
+                            'flags': {
+                                'type': 'object',
+                                'default': {},
+                                'additionalProperties': False,
+                                'properties': {
+                                    'cflags': {'anyOf': [{'type': 'string'},
+                                                         {'type': 'null'}]},
+                                    'cxxflags': {'anyOf': [{'type': 'string'},
+                                                           {'type': 'null'}]},
+                                    'fflags': {'anyOf': [{'type': 'string'},
+                                                         {'type': 'null'}]},
+                                    'cppflags': {'anyOf': [{'type': 'string'},
+                                                           {'type': 'null'}]},
+                                    'ldflags': {'anyOf': [{'type': 'string'},
+                                                          {'type': 'null'}]},
+                                    'ldlibs': {'anyOf': [{'type': 'string'},
+                                                         {'type': 'null'}]}}},
+                            'spec': {'type': 'string'},
+                            'operating_system': {'type': 'string'},
+                            'target': {
+                                'type': 'string',
+                                'default': 'any'
+                            },
+                            'alias': {
+                                'anyOf': [{'type': 'string'},
+                                          {'type': 'null'}],
+                                'default': None
+                            },
+                            'modules': {
+                                'type': 'array',
+                                'default': [],
+                                'items': {'type': 'string'}
+                            },
+                            'environment': {
+                                'type': 'object',
+                                'default': {},
+                                'additionalProperties': False,
+                                'properties': {
+                                    'set': {
+                                        'type': 'object',
+                                        'patternProperties': {
+                                            r'\w[\w-]*': {  # variable name
+                                                'type': 'string'
+                                            }
                                         }
                                     }
                                 }
+                            },
+                            'extra_rpaths': {
+                                'type': 'array',
+                                'default': [],
+                                'items': {'type': 'string'}
                             }
-                        },
-                        'extra_rpaths': {
-                            'type': 'array',
-                            'default': [],
-                            'items': {'type': 'string'}
                         }
                     },
                 },

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -44,7 +44,6 @@ a_comps = {
                 "f77": None,
                 "fc": None
             },
-            'modules': None,
             'spec': 'gcc@4.7.3',
             'operating_system': 'CNL10'
         }},
@@ -55,7 +54,6 @@ a_comps = {
                 "f77": 'gfortran',
                 "fc": 'gfortran'
             },
-            'modules': None,
             'spec': 'gcc@4.5.0',
             'operating_system': 'CNL10'
         }},
@@ -70,7 +68,6 @@ a_comps = {
                 "cppflags": "-O0 -fpic",
                 "fflags": "-f77",
             },
-            'modules': None,
             'spec': 'gcc@4.2.2',
             'operating_system': 'CNL10'
         }},
@@ -80,7 +77,6 @@ a_comps = {
                 "cxx": "<overwritten>",
                 "f77": '<overwritten>',
                 "fc": '<overwritten>'},
-            'modules': None,
             'spec': 'clang@3.3',
             'operating_system': 'CNL10'
         }}
@@ -96,7 +92,6 @@ b_comps = {
                 "f77": None,
                 "fc": None
             },
-            'modules': None,
             'spec': 'icc@10.0',
             'operating_system': 'CNL10'
         }},
@@ -107,7 +102,6 @@ b_comps = {
                 "f77": 'ifort',
                 "fc": 'ifort'
             },
-            'modules': None,
             'spec': 'icc@11.1',
             'operating_system': 'CNL10'
         }},
@@ -122,7 +116,6 @@ b_comps = {
                 "cppflags": "-O3",
                 "fflags": "-f77rtl",
             },
-            'modules': None,
             'spec': 'icc@12.3',
             'operating_system': 'CNL10'
         }},
@@ -132,7 +125,6 @@ b_comps = {
                 "cxx": "<overwritten>",
                 "f77": '<overwritten>',
                 "fc": '<overwritten>'},
-            'modules': None,
             'spec': 'clang@3.3',
             'operating_system': 'CNL10'
         }}

--- a/lib/spack/spack/test/data/compilers.yaml
+++ b/lib/spack/spack/test/data/compilers.yaml
@@ -7,7 +7,6 @@ compilers:
       cxx: /path/to/clang++
       f77: None
       fc: None
-    modules: 'None'
 - compiler:
     spec: gcc@4.5.0
     operating_system: {0.name}{0.version}
@@ -16,7 +15,6 @@ compilers:
       cxx: /path/to/g++
       f77: None
       fc: None
-    modules: 'None'
 - compiler:
     spec: clang@3.3
     operating_system: CNL
@@ -25,7 +23,6 @@ compilers:
       cxx: /path/to/clang++
       f77: None
       fc: None
-    modules: 'None'
 - compiler:
     spec: clang@3.3
     operating_system: SuSE11
@@ -34,7 +31,6 @@ compilers:
       cxx: /path/to/clang++
       f77: None
       fc: None
-    modules: 'None'
 - compiler:
     spec: clang@3.3
     operating_system: yosemite
@@ -43,7 +39,6 @@ compilers:
       cxx: /path/to/clang++
       f77: None
       fc: None
-    modules: 'None'
 - compiler:
     paths:
       cc: /path/to/gcc
@@ -52,7 +47,6 @@ compilers:
       fc: /path/to/gfortran
     operating_system: CNL
     spec: gcc@4.5.0
-    modules: 'None'
 - compiler:
     paths:
       cc: /path/to/gcc
@@ -61,7 +55,6 @@ compilers:
       fc: /path/to/gfortran
     operating_system: SuSE11
     spec: gcc@4.5.0
-    modules: 'None'
 - compiler:
     paths:
       cc: /path/to/gcc
@@ -70,7 +63,6 @@ compilers:
       fc: /path/to/gfortran
     operating_system: yosemite
     spec: gcc@4.5.0
-    modules: 'None'
 - compiler:
     paths:
       cc: /path/to/gcc
@@ -79,7 +71,6 @@ compilers:
       fc: /path/to/gfortran
     operating_system: elcapitan
     spec: gcc@4.5.0
-    modules: 'None'
 - compiler:
     spec: clang@3.3
     operating_system: elcapitan
@@ -88,7 +79,6 @@ compilers:
       cxx: /path/to/clang++
       f77: None
       fc: None
-    modules: 'None'
 - compiler:
     spec: gcc@4.7.2
     operating_system: redhat6
@@ -101,7 +91,6 @@ compilers:
       cflags: -O0
       cxxflags: -O0
       fflags: -O0
-    modules: 'None'
 - compiler:
     spec: clang@3.5
     operating_system: redhat6
@@ -113,4 +102,3 @@ compilers:
     flags:
       cflags: -O3
       cxxflags: -O3
-    modules: 'None'

--- a/lib/spack/spack/test/schema/compilers.py
+++ b/lib/spack/spack/test/schema/compilers.py
@@ -1,0 +1,155 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from copy import deepcopy
+
+import pytest
+import spack
+from spack import compilers
+from spack.config import validate_section, ConfigFormatError
+from spack.spec import FlagMap
+from spack.util.spack_yaml import syaml_dict
+
+
+@pytest.fixture()
+def minimal_config():
+    return syaml_dict({
+        'paths': syaml_dict((c, None) for c in compilers._path_instance_vars),
+        'spec': '',
+        'operating_system': ''
+    })
+
+
+optional_with_default = {
+    'environment': {},
+    'modules': [],
+    'flags': {},
+    'extra_rpaths': [],
+    'target': 'any',
+    'alias': None
+}
+
+
+def wrap_for_validation(single_compiler_config):
+    return syaml_dict(
+        {'compilers': [syaml_dict({'compiler': single_compiler_config})]}
+    )
+
+
+def unwrap_after_validation(compilers_config):
+    return compilers_config['compilers'][0]['compiler']
+
+
+def test_minimal_and_defaults(minimal_config):
+    """Checks that the minimal configuration is accepted and the optional
+    fields are initialized with expected values."""
+
+    config = wrap_for_validation(minimal_config)
+
+    validate_section(config, spack.schema.compilers.schema)
+
+    config = unwrap_after_validation(config)
+
+    for name, value in optional_with_default.items():
+        assert name in config
+        assert config[name] == value
+
+
+def test_minimal_is_minimal(minimal_config):
+    """Checks that the minimal configuration is really minimal."""
+
+    def deep_copy_without_field(d):
+        for field_name, field_value in d.items():
+            result = deepcopy(d)
+            del result[field_name]
+            yield field_name, result
+            if isinstance(field_value, dict):
+                for sub_name, sub_result in deep_copy_without_field(
+                        field_value):
+                    result[field_name] = sub_result
+                    yield sub_name, result
+
+    for deleted_field, wrong_config in deep_copy_without_field(
+            minimal_config):
+        with pytest.raises(ConfigFormatError) as e:
+            validate_section(wrap_for_validation(wrong_config),
+                             spack.schema.compilers.schema)
+        expected_message_substring = \
+            '\'' + deleted_field + '\' is a required property'
+        assert expected_message_substring in e.value.message
+
+
+def test_full_accepted(minimal_config):
+    """Checks that config with all possible fields is accepted."""
+    config = minimal_config
+    config.update(dict((n, t) for n, t in optional_with_default.items()))
+    validate_section(wrap_for_validation(config),
+                     spack.schema.compilers.schema)
+
+
+def test_additional_not_allowed(minimal_config):
+    """Checks that configs with unexpected fields are not accepted."""
+
+    def deep_copy_with_additional_field(d, add_name, add_value):
+        result = deepcopy(d)
+        result[add_name] = add_value
+        yield result
+        for field_name, field_value in d.items():
+            if isinstance(field_value, dict):
+                for sub_result in deep_copy_with_additional_field(field_value,
+                                                                  add_name,
+                                                                  add_value):
+                    result = deepcopy(d)
+                    result[field_name] = sub_result
+                    yield result
+
+    config = minimal_config
+    config.update(dict((n, t) for n, t in optional_with_default.items()))
+
+    for wrong_config in deep_copy_with_additional_field(
+            config, 'ADDITIONAL_FIELD', 'ADDITIONAL_VALUE'):
+        with pytest.raises(ConfigFormatError) as e:
+            validate_section(wrap_for_validation(wrong_config),
+                             spack.schema.compilers.schema)
+        expected_message_if_dict = '\'ADDITIONAL_FIELD\' was unexpected'
+        assert expected_message_if_dict in e.value.message
+
+
+def test_compiler_flags(minimal_config):
+    """Checks that the supported set of compiler flags is accepted."""
+
+    config = minimal_config
+    config['flags'] = dict((flag, '') for flag
+                           in FlagMap.valid_compiler_flags())
+
+    validate_section(wrap_for_validation(config),
+                     spack.schema.compilers.schema)
+
+    config['flags']['UNSUPPORTED_FLAG'] = ''
+
+    with pytest.raises(ConfigFormatError) as e:
+        validate_section(wrap_for_validation(config),
+                         spack.schema.compilers.schema)
+    expected_message_if_dict = '\'UNSUPPORTED_FLAG\' was unexpected'
+    assert expected_message_if_dict in e.value.message


### PR DESCRIPTION
- Fix for `ConfigFormatError`. It doesn't fail to initialize anymore if the validated schema contains an array:  `TypeError: list indices must be integers, not str`.
- Fixes for `schema/compilers.py`:
  - it doesn't allow for almost an arbitrary set of properties anymore;
  - property `modules` is not mandatory anymore and can be only an array;
  - ~~property `target` becomes mandatory.~~
  - property `target` gets default value `'any'`.
- Tests to check that the fixes work.