### PR TITLE
repeatmasker: new package

### DIFF
--- a/var/spack/repos/builtin/packages/ncbi-rmblastn/package.py
+++ b/var/spack/repos/builtin/packages/ncbi-rmblastn/package.py
@@ -6,7 +6,7 @@
 # Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
 # LLNL-CODE-647188
 #
-# For details, see https://github.com/llnl/spack
+# For details, see https://github.com/spack/spack
 # Please also see the NOTICE and LICENSE files for our notice and the LGPL.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/var/spack/repos/builtin/packages/ncbi-rmblastn/package.py
+++ b/var/spack/repos/builtin/packages/ncbi-rmblastn/package.py
@@ -1,0 +1,36 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class NcbiRmblastn(AutotoolsPackage):
+    """RMBlast search engine for NCBI"""
+
+    homepage = "https://www.ncbi.nlm.nih.gov/"
+    url      = "ftp://ftp.ncbi.nlm.nih.gov/blast/executables/rmblast/LATEST/ncbi-rmblastn-2.2.28-src.tar.gz"
+
+    version('2.2.28', 'fb5f4e2e02ffcb1b17af2e9f206c5c22')
+
+    configure_directory = 'c++'

--- a/var/spack/repos/builtin/packages/repeatmasker/package.py
+++ b/var/spack/repos/builtin/packages/repeatmasker/package.py
@@ -6,7 +6,7 @@
 # Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
 # LLNL-CODE-647188
 #
-# For details, see https://github.com/llnl/spack
+# For details, see https://github.com/spack/spack
 # Please also see the NOTICE and LICENSE files for our notice and the LGPL.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/var/spack/repos/builtin/packages/repeatmasker/package.py
+++ b/var/spack/repos/builtin/packages/repeatmasker/package.py
@@ -1,0 +1,80 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+import inspect
+import distutils.dir_util
+
+
+class Repeatmasker(Package):
+    """RepeatMasker is a program that screens DNA sequences for interspersed
+       repeats and low complexity DNA sequences."""
+
+    homepage = "http://www.repeatmasker.org"
+    url      = "http://www.repeatmasker.org/RepeatMasker-open-4-0-7.tar.gz"
+
+    version('4.0.7', '4dcbd7c88c5343e02d819f4b3e6527c6')
+
+    depends_on('perl', type=('build', 'run'))
+    depends_on('hmmer')
+    depends_on('ncbi-rmblastn')
+    depends_on('trf')
+
+    def url_for_version(self, version):
+        url = 'http://www.repeatmasker.org/RepeatMasker-open-{0}.tar.gz'
+        return url.format(version.dashed)
+
+    def install(self, spec, prefix):
+        # Config questions consist of:
+        #
+        # <PRESS ENTER TO CONTINUE>
+        # Enter perl path
+        # Enter installation path
+        # Enter trf path
+        # Add a Search Engine:
+        #    1. CrossMatch
+        #    2. RMBlast - NCBI Blast with RepeatMasker extensions
+        #    3. WUBlast/ABBlast (required by DupMasker)
+        #    4. HMMER3.1 & DFAM
+        #    5. Done
+        # Enter RMBlast path
+        # Do you want RMBlast to be your default search engine for
+        #    Repeatmasker? (Y/N)
+        # Add a Search Engine: Done
+
+        config_answers = ['\n', '%s\n' % self.spec['perl'].prefix.bin.perl,
+                          '%s\n' % self.stage.source_path,
+                          '%s\n' % self.spec['trf'].prefix.bin.trf, '2\n',
+                          '%s\n' % self.spec['ncbi-rmblastn'].prefix.bin,
+                          'Y\n', '5\n']
+
+        config_answers_filename = 'spack-config.in'
+
+        with open(config_answers_filename, 'w') as f:
+            f.writelines(config_answers)
+
+        with open(config_answers_filename, 'r') as f:
+            inspect.getmodule(self).perl('configure', input=f)
+
+        distutils.dir_util.copy_tree(".", prefix)

--- a/var/spack/repos/builtin/packages/repeatmasker/package.py
+++ b/var/spack/repos/builtin/packages/repeatmasker/package.py
@@ -50,7 +50,7 @@ class Repeatmasker(Package):
         #
         # <PRESS ENTER TO CONTINUE>
         # Enter perl path
-        # Enter installation path
+        # Enter where repeatmasker is being configured from
         # Enter trf path
         # Add a Search Engine:
         #    1. CrossMatch

--- a/var/spack/repos/builtin/packages/trf/package.py
+++ b/var/spack/repos/builtin/packages/trf/package.py
@@ -6,7 +6,7 @@
 # Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
 # LLNL-CODE-647188
 #
-# For details, see https://github.com/llnl/spack
+# For details, see https://github.com/spack/spack
 # Please also see the NOTICE and LICENSE files for our notice and the LGPL.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/var/spack/repos/builtin/packages/trf/package.py
+++ b/var/spack/repos/builtin/packages/trf/package.py
@@ -1,0 +1,46 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+import os
+
+
+class Trf(Package):
+    """Tandem Repeats Finder is a program to locate and display tandem repeats
+       in DNA sequences.
+
+       Note: A manual download is required for TRF.
+       Spack will search your current directory for the download file.
+       Alternatively, add this file to a mirror so that Spack can find it.
+       For instructions on how to set up a mirror, see
+       http://spack.readthedocs.io/en/latest/mirrors.html"""
+
+    homepage = "https://tandem.bu.edu/trf/trf.html"
+
+    version('4.09', '0c594fe666e0332db1df9d160d7fabc8', expand=False,
+            url='file://{0}/trf409.linux64'.format(os.getcwd()))
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        install('trf409.linux64', prefix.bin.trf)


### PR DESCRIPTION
Adding repeatmasker along with dependency trf, and ncbi-rmblastn search engine, which is what repeatmasker is being configured to use. Other search engine configure options can be added eventually, but I am just adding the one that our group will be using.