### PR TITLE
Add back help placeholder for "spack load"

### DIFF
--- a/lib/spack/spack/cmd/common/__init__.py
+++ b/lib/spack/spack/cmd/common/__init__.py
@@ -37,4 +37,10 @@ def print_module_placeholder_help():
             "", "For bash and zsh:",
             "    . %s/setup-env.sh" % spack.share_path, "",
             "For csh and tcsh:", "    setenv SPACK_ROOT %s" % spack.prefix,
-            "    source %s/setup-env.csh" % spack.share_path, "")
+            "    source %s/setup-env.csh" % spack.share_path, "",
+            "This exposes a 'spack' shell function, which you can use like",
+            "    $ spack load package-foo", "",
+            "Running the Spack executable directly (for example, invoking",
+            "./bin/spack) will bypass the shell function and print this",
+            "placeholder message, even if you have sourced one of the above",
+            "shell integration scripts.")

--- a/lib/spack/spack/cmd/common/__init__.py
+++ b/lib/spack/spack/cmd/common/__init__.py
@@ -22,3 +22,19 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
+
+import spack
+from llnl.util import tty
+
+
+def print_module_placeholder_help():
+    """
+    For use by commands to tell user how to activate shell support.
+    """
+    tty.msg("This command requires spack's shell integration.", "",
+            "To initialize spack's shell commands, you must run one of",
+            "the commands below.  Choose the right command for your shell.",
+            "", "For bash and zsh:",
+            "    . %s/setup-env.sh" % spack.share_path, "",
+            "For csh and tcsh:", "    setenv SPACK_ROOT %s" % spack.prefix,
+            "    source %s/setup-env.csh" % spack.share_path, "")

--- a/lib/spack/spack/cmd/load.py
+++ b/lib/spack/spack/cmd/load.py
@@ -23,7 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import argparse
-import spack.modules
+from spack.cmd.common import print_module_placeholder_help
 
 description = "add package to environment using `module load`"
 section = "environment"
@@ -40,4 +40,4 @@ def setup_parser(subparser):
 
 
 def load(parser, args):
-    spack.modules.print_help()
+    print_module_placeholder_help()

--- a/lib/spack/spack/cmd/unload.py
+++ b/lib/spack/spack/cmd/unload.py
@@ -23,7 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import argparse
-import spack.modules
+from spack.cmd.common import print_module_placeholder_help
 
 description = "remove package from environment using `module unload`"
 section = "environment"
@@ -39,4 +39,4 @@ def setup_parser(subparser):
 
 
 def unload(parser, args):
-    spack.modules.print_help()
+    print_module_placeholder_help()

--- a/lib/spack/spack/cmd/unuse.py
+++ b/lib/spack/spack/cmd/unuse.py
@@ -23,7 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import argparse
-import spack.modules
+from spack.cmd.common import print_module_placeholder_help
 
 description = "remove package from environment using dotkit"
 section = "environment"
@@ -39,4 +39,4 @@ def setup_parser(subparser):
 
 
 def unuse(parser, args):
-    spack.modules.print_help()
+    print_module_placeholder_help()

--- a/lib/spack/spack/cmd/use.py
+++ b/lib/spack/spack/cmd/use.py
@@ -23,7 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import argparse
-import spack.modules
+from spack.cmd.common import print_module_placeholder_help
 
 description = "add package to environment using dotkit"
 section = "environment"
@@ -39,4 +39,4 @@ def setup_parser(subparser):
 
 
 def use(parser, args):
-    spack.modules.print_help()
+    print_module_placeholder_help()


### PR DESCRIPTION
@alalazo would you prefer this was done in a different manner?

Fixes #6126

#3183 removed the print_help function from the "modules" module.
This adds it back so that if a user invokes 'spack load foo' without
having sourced an environment setup script, they will be prompted
to do so.