### PR TITLE
Fix spack view hardlink

### DIFF
--- a/lib/spack/spack/cmd/view.py
+++ b/lib/spack/spack/cmd/view.py
@@ -177,7 +177,7 @@ def view(parser, args):
     view = YamlFilesystemView(
         path, spack.store.layout,
         ignore_conflicts=getattr(args, "ignore_conflicts", False),
-        link=os.hardlink if args.action in ["hardlink", "hard"]
+        link=os.link if args.action in ["hardlink", "hard"]
         else os.symlink,
         verbose=args.verbose)
 

--- a/lib/spack/spack/test/cmd/view.py
+++ b/lib/spack/spack/test/cmd/view.py
@@ -24,11 +24,24 @@
 ##############################################################################
 from spack.main import SpackCommand
 import os.path
+import pytest
 
 activate = SpackCommand('activate')
 extensions = SpackCommand('extensions')
 install = SpackCommand('install')
 view = SpackCommand('view')
+
+
+@pytest.mark.parametrize('cmd', ['hardlink', 'symlink', 'hard', 'add'])
+def test_view_link_type(
+        tmpdir, builtin_mock, mock_archive, mock_fetch, config,
+        install_mockery, cmd):
+    install('libdwarf')
+    viewpath = str(tmpdir.mkdir('view_{0}'.format(cmd)))
+    view(cmd, viewpath, 'libdwarf')
+    package_prefix = os.path.join(viewpath, 'libdwarf')
+    assert os.path.exists(package_prefix)
+    assert os.path.islink(package_prefix) == (not cmd.startswith('hard'))
 
 
 def test_view_external(


### PR DESCRIPTION
This fixes a "typo" in `spack view hardlink` as introduced in #3227 / #5415. (`os.hardlink` does not exist)