### PR TITLE
spack buildcache create and install updates for relative rpath tarballs and macOS tarballs.

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -95,7 +95,7 @@ def read_buildinfo_file(prefix):
     return buildinfo
 
 
-def write_buildinfo_file(prefix):
+def write_buildinfo_file(prefix, rel=False):
     """
     Create a cache file containing information
     required for the relocation
@@ -119,6 +119,7 @@ def write_buildinfo_file(prefix):
 
     # Create buildinfo data and write it to disk
     buildinfo = {}
+    buildinfo['relativerpaths'] = rel
     buildinfo['buildpath'] = spack.store.layout.root
     buildinfo['relocate_textfiles'] = text_to_relocate
     buildinfo['relocate_binaries'] = binary_to_relocate
@@ -246,7 +247,7 @@ def build_tarball(spec, outdir, force=False, rel=False, yes_to_all=False,
     install_tree(spec.prefix, workdir, symlinks=True)
 
     # create info for later relocation and create tar
-    write_buildinfo_file(workdir)
+    write_buildinfo_file(workdir, rel=rel)
 
     # optinally make the paths in the binaries relative to each other
     # in the spack install tree before creating tarball
@@ -346,19 +347,20 @@ def relocate_package(prefix):
     buildinfo = read_buildinfo_file(prefix)
     new_path = spack.store.layout.root
     old_path = buildinfo['buildpath']
-    if new_path == old_path:
+    rel = buildinfo['relativerpaths']
+    if new_path == old_path and not rel:
         return
 
     tty.msg("Relocating package from",
             "%s to %s." % (old_path, new_path))
-    for filename in buildinfo['relocate_binaries']:
-        path_name = os.path.join(prefix, filename)
-        relocate.relocate_binary(path_name, old_path, new_path)
-
     for filename in buildinfo['relocate_textfiles']:
         path_name = os.path.join(prefix, filename)
         relocate.relocate_text(path_name, old_path, new_path)
-
+    # only need to change the rpaths if they were not made relative
+    if not rel:
+        for filename in buildinfo['relocate_binaries']:
+            path_name = os.path.join(prefix, filename)
+            relocate.relocate_binary(path_name, old_path, new_path)
 
 def extract_tarball(spec, filename, yes_to_all=False, force=False):
     """
@@ -391,17 +393,16 @@ def extract_tarball(spec, filename, yes_to_all=False, force=False):
     # get the sha256 checksum of the tarball
     checksum = checksum_tarball(tarfile_path)
 
-    if not yes_to_all:
-        # get the sha256 checksum recorded at creation
-        spec_dict = {}
-        with open(specfile_path, 'r') as inputfile:
-            content = inputfile.read()
-            spec_dict = yaml.load(content)
-        bchecksum = spec_dict['binary_cache_checksum']
+    # get the sha256 checksum recorded at creation
+    spec_dict = {}
+    with open(specfile_path, 'r') as inputfile:
+        content = inputfile.read()
+        spec_dict = yaml.load(content)
+    bchecksum = spec_dict['binary_cache_checksum']
 
-        # if the checksums don't match don't install
-        if bchecksum['hash'] != checksum:
-            raise NoChecksumException()
+    # if the checksums don't match don't install
+    if bchecksum['hash'] != checksum:
+        raise NoChecksumException()
 
     # delay creating installpath until verification is complete
     mkdirp(installpath)

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -334,10 +334,13 @@ def make_package_relative(workdir, prefix):
     """
     buildinfo = read_buildinfo_file(workdir)
     old_path = buildinfo['buildpath']
+    orig_path_names = list()
+    cur_path_names = list()
     for filename in buildinfo['relocate_binaries']:
-        orig_path_name = os.path.join(prefix, filename)
-        cur_path_name = os.path.join(workdir, filename)
-        relocate.make_binary_relative(cur_path_name, orig_path_name, old_path)
+        orig_path_names.append(os.path.join(prefix, filename))
+        cur_path_names.append(os.path.join(workdir, filename))
+        relocate.make_binary_relative(cur_path_names, orig_path_names,
+                                      old_path)
 
 
 def relocate_package(prefix):
@@ -353,14 +356,18 @@ def relocate_package(prefix):
 
     tty.msg("Relocating package from",
             "%s to %s." % (old_path, new_path))
+    path_names = set()
     for filename in buildinfo['relocate_textfiles']:
         path_name = os.path.join(prefix, filename)
-        relocate.relocate_text(path_name, old_path, new_path)
+        path_names.add(path_name)
+    relocate.relocate_text(path_names, old_path, new_path)
     # only need to change the rpaths if they were not made relative
     if not rel:
+        path_names = set()
         for filename in buildinfo['relocate_binaries']:
             path_name = os.path.join(prefix, filename)
-            relocate.relocate_binary(path_name, old_path, new_path)
+            path_names.add(path_name)
+        relocate.relocate_binary(path_names, old_path, new_path)
 
 
 def extract_tarball(spec, filename, yes_to_all=False, force=False):

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -119,7 +119,7 @@ def write_buildinfo_file(prefix, rel=False):
 
     # Create buildinfo data and write it to disk
     buildinfo = {}
-    buildinfo['relativerpaths'] = rel
+    buildinfo['relative_rpaths'] = rel
     buildinfo['buildpath'] = spack.store.layout.root
     buildinfo['relocate_textfiles'] = text_to_relocate
     buildinfo['relocate_binaries'] = binary_to_relocate
@@ -350,7 +350,7 @@ def relocate_package(prefix):
     buildinfo = read_buildinfo_file(prefix)
     new_path = spack.store.layout.root
     old_path = buildinfo['buildpath']
-    rel = buildinfo['relativerpaths']
+    rel = buildinfo['relative_rpaths']
     if new_path == old_path and not rel:
         return
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -362,6 +362,7 @@ def relocate_package(prefix):
             path_name = os.path.join(prefix, filename)
             relocate.relocate_binary(path_name, old_path, new_path)
 
+
 def extract_tarball(spec, filename, yes_to_all=False, force=False):
     """
     extract binary tarball for given package into install area

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -350,9 +350,7 @@ def relocate_package(prefix):
     buildinfo = read_buildinfo_file(prefix)
     new_path = spack.store.layout.root
     old_path = buildinfo['buildpath']
-    rel = False
-    if rel in buildinfo.keys():
-        rel = buildinfo['relative_rpaths']
+    rel = buildinfo.get('relative_rpaths', False)
     if new_path == old_path and not rel:
         return
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -361,7 +361,8 @@ def relocate_package(prefix):
         path_name = os.path.join(prefix, filename)
         path_names.add(path_name)
     relocate.relocate_text(path_names, old_path, new_path)
-    # only need to change the rpaths if they were not made relative
+    # If the binary files in the package were not edited to use
+    # relative RPATHs, then the RPATHs need to be relocated
     if not rel:
         path_names = set()
         for filename in buildinfo['relocate_binaries']:

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -133,7 +133,7 @@ def tarball_directory_name(spec):
     Return name of the tarball directory according to the convention
     <os>-<architecture>/<compiler>/<package>-<version>/
     """
-    return "%s/%s/%s-%s" % (spack.architecture.sys_type(),
+    return "%s/%s/%s-%s" % (spec.architecture,
                             str(spec.compiler).replace("@", "-"),
                             spec.name, spec.version)
 
@@ -143,7 +143,7 @@ def tarball_name(spec, ext):
     Return the name of the tarfile according to the convention
     <os>-<architecture>-<package>-<dag_hash><ext>
     """
-    return "%s-%s-%s-%s-%s%s" % (spack.architecture.sys_type(),
+    return "%s-%s-%s-%s-%s%s" % (spec.architecture,
                                  str(spec.compiler).replace("@", "-"),
                                  spec.name,
                                  spec.version,
@@ -350,7 +350,9 @@ def relocate_package(prefix):
     buildinfo = read_buildinfo_file(prefix)
     new_path = spack.store.layout.root
     old_path = buildinfo['buildpath']
-    rel = buildinfo['relative_rpaths']
+    rel = False
+    if rel in buildinfo.keys():
+        rel = buildinfo['relative_rpaths']
     if new_path == old_path and not rel:
         return
 

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -210,8 +210,7 @@ def createtarball(args):
             specs.add(match)
             tty.msg('recursing dependencies')
             for d, node in match.traverse(order='post',
-                                          depth=True,
-                                          deptype=('link', 'run')):
+                                          depth=True):
                 if node.external or node.virtual:
                     tty.msg('skipping external or virtual dependency %s' %
                             node.format())

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -226,14 +226,14 @@ def createtarball(args):
         except NoOverwriteException as e:
             tty.warn("%s exists, use -f to force overwrite." % e)
         except NoGpgException:
-            tty.warn("gpg2 is not available,"
+            tty.die("gpg2 is not available,"
                      " use -y to create unsigned build caches")
         except NoKeyException:
-            tty.warn("no default key available for signing,"
+            tty.die("no default key available for signing,"
                      " use -y to create unsigned build caches"
                      " or spack gpg init to create a default key")
         except PickKeyException:
-            tty.warn("multi keys available for signing,"
+            tty.die("multi keys available for signing,"
                      " use -y to create unsigned build caches"
                      " or -k <key hash> to pick a key")
 

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -227,15 +227,15 @@ def createtarball(args):
             tty.warn("%s exists, use -f to force overwrite." % e)
         except NoGpgException:
             tty.die("gpg2 is not available,"
-                     " use -y to create unsigned build caches")
+                    " use -y to create unsigned build caches")
         except NoKeyException:
             tty.die("no default key available for signing,"
-                     " use -y to create unsigned build caches"
-                     " or spack gpg init to create a default key")
+                    " use -y to create unsigned build caches"
+                    " or spack gpg init to create a default key")
         except PickKeyException:
             tty.die("multi keys available for signing,"
-                     " use -y to create unsigned build caches"
-                     " or -k <key hash> to pick a key")
+                    " use -y to create unsigned build caches"
+                    " or -k <key hash> to pick a key")
 
 
 def installtarball(args):

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -210,7 +210,8 @@ def createtarball(args):
             specs.add(match)
             tty.msg('recursing dependencies')
             for d, node in match.traverse(order='post',
-                                          depth=True):
+                                          depth=True,
+                                          deptype=('link', 'run')):
                 if node.external or node.virtual:
                     tty.msg('skipping external or virtual dependency %s' %
                             node.format())
@@ -266,7 +267,7 @@ def install_tarball(spec, args):
     force = False
     if args.force:
         force = True
-    for d in s.dependencies():
+    for d in s.dependencies(deptype=('link', 'run')):
         tty.msg("Installing buildcache for dependency spec %s" % d)
         install_tarball(d, args)
     package = spack.repo.get(spec)

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -158,7 +158,8 @@ def macho_replace_paths(old_dir, new_dir, rpaths, deps, idpath):
     return nrpaths, ndeps, nid
 
 
-def modify_macho_object(cur_path_name, rpaths, deps, idpath, nrpaths, ndeps, nid):
+def modify_macho_object(cur_path_name, rpaths, deps, idpath,
+                        nrpaths, ndeps, nid):
     """
     Modify MachO binary path_name by replacing old_dir with new_dir
     or the relative path to spack install root.
@@ -263,8 +264,8 @@ def make_binary_relative(cur_path_name, orig_path_name, old_dir):
         nrpaths = []
         ndeps = []
         nrpaths, ndeps, nid = macho_make_paths_relative(orig_path_name,
-                                                       old_dir, rpaths,
-                                                       deps, idpath)
+                                                        old_dir, rpaths,
+                                                        deps, idpath)
         modify_macho_object(cur_path_name,
                             rpaths, deps, idpath,
                             nrpaths, ndeps, nid)

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -287,7 +287,7 @@ def relocate_text(path_names, old_dir, new_dir):
     Replace old path with new path in text file path_name
     """
     filter_file("r'%s'" % old_dir, "r'%s'" % new_dir,
-                path_names, backup=False)
+                *path_names, backup=False)
 
 
 def substitute_rpath(orig_rpath, topdir, new_root_path):

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -192,7 +192,9 @@ def get_filetype(path_name):
     """
     file = Executable('file')
     file.add_default_env('LC_ALL', 'C')
-    output = file('-bh', '%s' % path_name,
+    file.add_default_arg('-b')
+    file.add_default_arg('-h')
+    output = file('%s' % path_name,
                   output=str, err=str)
     return output.strip()
 
@@ -218,9 +220,9 @@ def needs_binary_relocation(filetype):
     if "relocatable" in filetype:
         return False
     if platform.system() == 'Darwin':
-        return ('Mach-O ' in filetype)
+        return ('Mach-O' in filetype)
     elif platform.system() == 'Linux':
-        return ('ELF ' in filetype)
+        return ('ELF' in filetype)
     else:
         tty.die("Relocation not implemented for %s" % platform.system())
     return retval
@@ -230,7 +232,7 @@ def needs_text_relocation(filetype):
     """
     Check whether the given filetype is text that may need relocation.
     """
-    return (" text" in filetype)
+    return ("text" in filetype)
 
 
 def relocate_binary(path_names, old_dir, new_dir):

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -192,9 +192,7 @@ def get_filetype(path_name):
     """
     file = Executable('file')
     file.add_default_env('LC_ALL', 'C')
-    file.add_default_arg('-b')
-    file.add_default_arg('-h')
-    output = file('%s' % path_name,
+    output = file('-b', '-h', '%s' % path_name,
                   output=str, err=str)
     return output.strip()
 

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -219,6 +219,8 @@ def needs_binary_relocation(filetype):
     retval = False
     if "relocatable" in filetype:
         return False
+    if "link" in filetype:
+        return False
     if platform.system() == 'Darwin':
         return ('Mach-O' in filetype)
     elif platform.system() == 'Linux':
@@ -232,6 +234,8 @@ def needs_text_relocation(filetype):
     """
     Check whether the given filetype is text that may need relocation.
     """
+    if "link" in filetype:
+        return False
     return ("text" in filetype)
 
 

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -192,7 +192,7 @@ def get_filetype(path_name):
     """
     file = Executable('file')
     file.add_default_env('LC_ALL', 'C')
-    output = file('-b', '-h', '%s' % path_name,
+    output = file('-bh', '%s' % path_name,
                   output=str, err=str)
     return output.strip()
 
@@ -218,9 +218,9 @@ def needs_binary_relocation(filetype):
     if "relocatable" in filetype:
         return False
     if platform.system() == 'Darwin':
-        return ('Mach-O' in filetype)
+        return ('Mach-O ' in filetype)
     elif platform.system() == 'Linux':
-        return ('ELF' in filetype)
+        return ('ELF ' in filetype)
     else:
         tty.die("Relocation not implemented for %s" % platform.system())
     return retval
@@ -230,7 +230,7 @@ def needs_text_relocation(filetype):
     """
     Check whether the given filetype is text that may need relocation.
     """
-    return ("text" in filetype)
+    return (" text" in filetype)
 
 
 def relocate_binary(path_names, old_dir, new_dir):

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -303,20 +303,44 @@ def test_relocate_macho(tmpdir):
         get_patchelf()
         assert (needs_binary_relocation('Mach-O') is True)
 
-        macho_get_paths('/bin/bash')
+        rpaths, deps, idpath = macho_get_paths('/bin/bash')
+        nrpaths, ndeps, nid = macho_make_paths_relative('/bin/bash', '/usr',
+                                                   rpaths, deps, idpath)
         shutil.copyfile('/bin/bash', 'bash')
+        modify_macho_object('bash',
+            rpaths, deps, idpath,
+            nrpaths, ndeps, nid)
 
-        modify_macho_object('bash', '/bin/bash', '/usr', '/opt', False)
-        modify_macho_object('bash', '/bin/bash', '/usr', '/opt', True)
+        rpaths, deps, idpath = macho_get_paths('/bin/bash')
+        nrpaths, ndeps, nid = macho_replace_paths('/usr', '/opt',
+                                                   rpaths, deps, idpath)
+        shutil.copyfile('/bin/bash', 'bash')
+        modify_macho_object('bash',
+            rpaths, deps, idpath,
+            nrpaths, ndeps, nid)
 
+        path = '/usr/lib/libncurses.5.4.dylib'
+        rpaths, deps, idpath = macho_get_paths(path)
+        nrpaths, ndeps, nid = macho_make_paths_relative(path,
+                                                       '/usr',
+                                                       rpaths, deps, idpath)
         shutil.copyfile(
             '/usr/lib/libncurses.5.4.dylib', 'libncurses.5.4.dylib')
         modify_macho_object(
             'libncurses.5.4.dylib',
-            '/usr/lib/libncurses.5.4.dylib', '/usr', '/opt', False)
+            rpaths, deps, idpath,
+            nrpaths, ndeps, nid)
+
+        rpaths, deps, idpath = macho_get_paths(path)
+        nrpaths, ndeps, nid = macho_replace_paths(
+                                                 '/usr', '/opt',
+                                                 rpaths, deps, idpath)
+        shutil.copyfile(
+            '/usr/lib/libncurses.5.4.dylib', 'libncurses.5.4.dylib')
         modify_macho_object(
             'libncurses.5.4.dylib',
-            '/usr/lib/libncurses.5.4.dylib', '/usr', '/opt', True)
+            rpaths, deps, idpath,
+            nrpaths, ndeps, nid)
 
 
 @pytest.mark.skipif(sys.platform != 'linux2',

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -305,36 +305,34 @@ def test_relocate_macho(tmpdir):
 
         rpaths, deps, idpath = macho_get_paths('/bin/bash')
         nrpaths, ndeps, nid = macho_make_paths_relative('/bin/bash', '/usr',
-                                                   rpaths, deps, idpath)
+                                                        rpaths, deps, idpath)
         shutil.copyfile('/bin/bash', 'bash')
         modify_macho_object('bash',
-            rpaths, deps, idpath,
-            nrpaths, ndeps, nid)
+                            rpaths, deps, idpath,
+                            nrpaths, ndeps, nid)
 
         rpaths, deps, idpath = macho_get_paths('/bin/bash')
         nrpaths, ndeps, nid = macho_replace_paths('/usr', '/opt',
-                                                   rpaths, deps, idpath)
+                                                  rpaths, deps, idpath)
         shutil.copyfile('/bin/bash', 'bash')
         modify_macho_object('bash',
-            rpaths, deps, idpath,
-            nrpaths, ndeps, nid)
+                            rpaths, deps, idpath,
+                            nrpaths, ndeps, nid)
 
         path = '/usr/lib/libncurses.5.4.dylib'
         rpaths, deps, idpath = macho_get_paths(path)
         nrpaths, ndeps, nid = macho_make_paths_relative(path,
-                                                       '/usr',
-                                                       rpaths, deps, idpath)
+                                                        '/usr',
+                                                        rpaths, deps, idpath)
         shutil.copyfile(
             '/usr/lib/libncurses.5.4.dylib', 'libncurses.5.4.dylib')
-        modify_macho_object(
-            'libncurses.5.4.dylib',
-            rpaths, deps, idpath,
-            nrpaths, ndeps, nid)
+        modify_macho_object('libncurses.5.4.dylib',
+                            rpaths, deps, idpath,
+                            nrpaths, ndeps, nid)
 
         rpaths, deps, idpath = macho_get_paths(path)
-        nrpaths, ndeps, nid = macho_replace_paths(
-                                                 '/usr', '/opt',
-                                                 rpaths, deps, idpath)
+        nrpaths, ndeps, nid = macho_replace_paths('/usr', '/opt',
+                                                  rpaths, deps, idpath)
         shutil.copyfile(
             '/usr/lib/libncurses.5.4.dylib', 'libncurses.5.4.dylib')
         modify_macho_object(

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -43,7 +43,7 @@ from spack.fetch_strategy import URLFetchStrategy, FetchStrategyComposite
 from spack.util.executable import ProcessError
 from spack.relocate import needs_binary_relocation, get_patchelf
 from spack.relocate import substitute_rpath, get_relative_rpaths
-from spack.relocate import macho_replace_paths, macho_make_paths_rel
+from spack.relocate import macho_replace_paths, macho_make_paths_relative
 from spack.relocate import modify_macho_object, macho_get_paths
 
 
@@ -219,15 +219,15 @@ echo $PATH"""
 def test_relocate():
     assert (needs_binary_relocation('relocatable') is False)
 
-    out = macho_make_paths_rel('/Users/Shares/spack/pkgC/lib/libC.dylib',
-                               '/Users/Shared/spack',
-                               ('/Users/Shared/spack/pkgA/lib',
-                                '/Users/Shared/spack/pkgB/lib',
-                                '/usr/local/lib'),
-                               ('/Users/Shared/spack/pkgA/libA.dylib',
-                                   '/Users/Shared/spack/pkgB/libB.dylib',
-                                   '/usr/local/lib/libloco.dylib'),
-                               '/Users/Shared/spack/pkgC/lib/libC.dylib')
+    out = macho_make_paths_relative('/Users/Shares/spack/pkgC/lib/libC.dylib',
+                                    '/Users/Shared/spack',
+                                    ('/Users/Shared/spack/pkgA/lib',
+                                     '/Users/Shared/spack/pkgB/lib',
+                                     '/usr/local/lib'),
+                                    ('/Users/Shared/spack/pkgA/libA.dylib',
+                                     '/Users/Shared/spack/pkgB/libB.dylib',
+                                     '/usr/local/lib/libloco.dylib'),
+                                    '/Users/Shared/spack/pkgC/lib/libC.dylib')
     assert out == (['@loader_path/../../../../Shared/spack/pkgA/lib',
                     '@loader_path/../../../../Shared/spack/pkgB/lib',
                     '/usr/local/lib'],
@@ -236,14 +236,14 @@ def test_relocate():
                     '/usr/local/lib/libloco.dylib'],
                    '@rpath/libC.dylib')
 
-    out = macho_make_paths_rel('/Users/Shared/spack/pkgC/bin/exeC',
-                               '/Users/Shared/spack',
-                               ('/Users/Shared/spack/pkgA/lib',
-                                '/Users/Shared/spack/pkgB/lib',
-                                '/usr/local/lib'),
-                               ('/Users/Shared/spack/pkgA/libA.dylib',
-                                '/Users/Shared/spack/pkgB/libB.dylib',
-                                '/usr/local/lib/libloco.dylib'), None)
+    out = macho_make_paths_relative('/Users/Shared/spack/pkgC/bin/exeC',
+                                    '/Users/Shared/spack',
+                                    ('/Users/Shared/spack/pkgA/lib',
+                                     '/Users/Shared/spack/pkgB/lib',
+                                     '/usr/local/lib'),
+                                    ('/Users/Shared/spack/pkgA/libA.dylib',
+                                     '/Users/Shared/spack/pkgB/libB.dylib',
+                                     '/usr/local/lib/libloco.dylib'), None)
 
     assert out == (['@loader_path/../../pkgA/lib',
                     '@loader_path/../../pkgB/lib',
@@ -304,8 +304,8 @@ def test_relocate_macho(tmpdir):
         assert (needs_binary_relocation('Mach-O ') is True)
 
         rpaths, deps, idpath = macho_get_paths('/bin/bash')
-        nrpaths, ndeps, nid = macho_make_paths_rel('/bin/bash', '/usr',
-                                                   rpaths, deps, idpath)
+        nrpaths, ndeps, nid = macho_make_paths_relative('/bin/bash', '/usr',
+                                                        rpaths, deps, idpath)
         shutil.copyfile('/bin/bash', 'bash')
         modify_macho_object('bash',
                             rpaths, deps, idpath,
@@ -321,8 +321,8 @@ def test_relocate_macho(tmpdir):
 
         path = '/usr/lib/libncurses.5.4.dylib'
         rpaths, deps, idpath = macho_get_paths(path)
-        nrpaths, ndeps, nid = macho_make_paths_rel(path, '/usr',
-                                                   rpaths, deps, idpath)
+        nrpaths, ndeps, nid = macho_make_paths_relative(path, '/usr',
+                                                        rpaths, deps, idpath)
         shutil.copyfile(
             '/usr/lib/libncurses.5.4.dylib', 'libncurses.5.4.dylib')
         modify_macho_object('libncurses.5.4.dylib',

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -41,7 +41,8 @@ import spack.cmd.buildcache as buildcache
 from spack.spec import Spec
 from spack.fetch_strategy import URLFetchStrategy, FetchStrategyComposite
 from spack.util.executable import ProcessError
-from spack.relocate import needs_binary_relocation, get_patchelf
+from spack.relocate import needs_binary_relocation, needs_text_relocation
+from spack.relocate import get_patchelf
 from spack.relocate import substitute_rpath, get_relative_rpaths
 from spack.relocate import macho_replace_paths, macho_make_paths_relative
 from spack.relocate import modify_macho_object, macho_get_paths
@@ -218,6 +219,8 @@ echo $PATH"""
 
 def test_relocate():
     assert (needs_binary_relocation('relocatable') is False)
+    assert (needs_binary_relocation('link') is False)
+    assert (needs_text_relocation('link') is False)
 
     out = macho_make_paths_relative('/Users/Shares/spack/pkgC/lib/libC.dylib',
                                     '/Users/Shared/spack',

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -43,7 +43,7 @@ from spack.fetch_strategy import URLFetchStrategy, FetchStrategyComposite
 from spack.util.executable import ProcessError
 from spack.relocate import needs_binary_relocation, get_patchelf
 from spack.relocate import substitute_rpath, get_relative_rpaths
-from spack.relocate import macho_replace_paths, macho_make_paths_relative
+from spack.relocate import macho_replace_paths, macho_make_paths_rel
 from spack.relocate import modify_macho_object, macho_get_paths
 
 
@@ -219,15 +219,15 @@ echo $PATH"""
 def test_relocate():
     assert (needs_binary_relocation('relocatable') is False)
 
-    out = macho_make_paths_relative('/Users/Shares/spack/pkgC/lib/libC.dylib',
-                                    '/Users/Shared/spack',
-                                    ('/Users/Shared/spack/pkgA/lib',
-                                     '/Users/Shared/spack/pkgB/lib',
-                                     '/usr/local/lib'),
-                                    ('/Users/Shared/spack/pkgA/libA.dylib',
-                                        '/Users/Shared/spack/pkgB/libB.dylib',
-                                        '/usr/local/lib/libloco.dylib'),
-                                    '/Users/Shared/spack/pkgC/lib/libC.dylib')
+    out = macho_make_paths_rel('/Users/Shares/spack/pkgC/lib/libC.dylib',
+                               '/Users/Shared/spack',
+                               ('/Users/Shared/spack/pkgA/lib',
+                                '/Users/Shared/spack/pkgB/lib',
+                                '/usr/local/lib'),
+                               ('/Users/Shared/spack/pkgA/libA.dylib',
+                                   '/Users/Shared/spack/pkgB/libB.dylib',
+                                   '/usr/local/lib/libloco.dylib'),
+                               '/Users/Shared/spack/pkgC/lib/libC.dylib')
     assert out == (['@loader_path/../../../../Shared/spack/pkgA/lib',
                     '@loader_path/../../../../Shared/spack/pkgB/lib',
                     '/usr/local/lib'],
@@ -236,14 +236,14 @@ def test_relocate():
                     '/usr/local/lib/libloco.dylib'],
                    '@rpath/libC.dylib')
 
-    out = macho_make_paths_relative('/Users/Shared/spack/pkgC/bin/exeC',
-                                    '/Users/Shared/spack',
-                                    ('/Users/Shared/spack/pkgA/lib',
-                                     '/Users/Shared/spack/pkgB/lib',
-                                     '/usr/local/lib'),
-                                    ('/Users/Shared/spack/pkgA/libA.dylib',
-                                        '/Users/Shared/spack/pkgB/libB.dylib',
-                                        '/usr/local/lib/libloco.dylib'), None)
+    out = macho_make_paths_rel('/Users/Shared/spack/pkgC/bin/exeC',
+                               '/Users/Shared/spack',
+                               ('/Users/Shared/spack/pkgA/lib',
+                                '/Users/Shared/spack/pkgB/lib',
+                                '/usr/local/lib'),
+                               ('/Users/Shared/spack/pkgA/libA.dylib',
+                                '/Users/Shared/spack/pkgB/libB.dylib',
+                                '/usr/local/lib/libloco.dylib'), None)
 
     assert out == (['@loader_path/../../pkgA/lib',
                     '@loader_path/../../pkgB/lib',
@@ -258,8 +258,8 @@ def test_relocate():
                                '/Users/Shared/spack/pkgB/lib',
                                '/usr/local/lib'),
                               ('/Users/Shared/spack/pkgA/libA.dylib',
-                                  '/Users/Shared/spack/pkgB/libB.dylib',
-                                  '/usr/local/lib/libloco.dylib'),
+                               '/Users/Shared/spack/pkgB/libB.dylib',
+                               '/usr/local/lib/libloco.dylib'),
                               '/Users/Shared/spack/pkgC/lib/libC.dylib')
     assert out == (['/Applications/spack/pkgA/lib',
                     '/Applications/spack/pkgB/lib',
@@ -275,8 +275,8 @@ def test_relocate():
                                '/Users/Shared/spack/pkgB/lib',
                                '/usr/local/lib'),
                               ('/Users/Shared/spack/pkgA/libA.dylib',
-                                  '/Users/Shared/spack/pkgB/libB.dylib',
-                                  '/usr/local/lib/libloco.dylib'),
+                               '/Users/Shared/spack/pkgB/libB.dylib',
+                               '/usr/local/lib/libloco.dylib'),
                               None)
     assert out == (['/Applications/spack/pkgA/lib',
                     '/Applications/spack/pkgB/lib',
@@ -304,8 +304,8 @@ def test_relocate_macho(tmpdir):
         assert (needs_binary_relocation('Mach-O') is True)
 
         rpaths, deps, idpath = macho_get_paths('/bin/bash')
-        nrpaths, ndeps, nid = macho_make_paths_relative('/bin/bash', '/usr',
-                                                        rpaths, deps, idpath)
+        nrpaths, ndeps, nid = macho_make_paths_rel('/bin/bash', '/usr',
+                                                   rpaths, deps, idpath)
         shutil.copyfile('/bin/bash', 'bash')
         modify_macho_object('bash',
                             rpaths, deps, idpath,
@@ -321,9 +321,8 @@ def test_relocate_macho(tmpdir):
 
         path = '/usr/lib/libncurses.5.4.dylib'
         rpaths, deps, idpath = macho_get_paths(path)
-        nrpaths, ndeps, nid = macho_make_paths_relative(path,
-                                                        '/usr',
-                                                        rpaths, deps, idpath)
+        nrpaths, ndeps, nid = macho_make_paths_rel(path, '/usr',
+                                                   rpaths, deps, idpath)
         shutil.copyfile(
             '/usr/lib/libncurses.5.4.dylib', 'libncurses.5.4.dylib')
         modify_macho_object('libncurses.5.4.dylib',

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -301,7 +301,7 @@ def test_relocate():
 def test_relocate_macho(tmpdir):
     with tmpdir.as_cwd():
         get_patchelf()
-        assert (needs_binary_relocation('Mach-O') is True)
+        assert (needs_binary_relocation('Mach-O ') is True)
 
         rpaths, deps, idpath = macho_get_paths('/bin/bash')
         nrpaths, ndeps, nid = macho_make_paths_rel('/bin/bash', '/usr',
@@ -343,4 +343,4 @@ def test_relocate_macho(tmpdir):
 @pytest.mark.skipif(sys.platform != 'linux2',
                     reason="only works with Elf objects")
 def test_relocate_elf():
-    assert (needs_binary_relocation('ELF') is True)
+    assert (needs_binary_relocation('ELF ') is True)

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -301,7 +301,7 @@ def test_relocate():
 def test_relocate_macho(tmpdir):
     with tmpdir.as_cwd():
         get_patchelf()
-        assert (needs_binary_relocation('Mach-O ') is True)
+        assert (needs_binary_relocation('Mach-O'))
 
         rpaths, deps, idpath = macho_get_paths('/bin/bash')
         nrpaths, ndeps, nid = macho_make_paths_relative('/bin/bash', '/usr',
@@ -343,4 +343,4 @@ def test_relocate_macho(tmpdir):
 @pytest.mark.skipif(sys.platform != 'linux2',
                     reason="only works with Elf objects")
 def test_relocate_elf():
-    assert (needs_binary_relocation('ELF ') is True)
+    assert (needs_binary_relocation('ELF'))


### PR DESCRIPTION
Testing showed that buildcache install wants to download build dependencies as well and link and run dependencies. Changed buildcache install  to only install tarballs for link and run dependencies.

Testing of relative rpath tarballs installation showed the relative rpaths were being replaced with absolute rpaths. Reworked the relative rpath tarball creation and installation to add and check for relativerpath flag in buildcache info file. 

Reworked the macho object modification to be more like the elf object modification.

Changed some warnings to failures when pgp2 is not avaiable or a key isn't available. The create command would complete making one think that the .spack files were created when only the .tar.gz files were created.

Fixed bug where files (and links) with with text in filename (eg libmathtext.a) were added to the list of text file to be relocated