### PR TITLE
libyogrt: add v1.21 with lsf support

### DIFF
--- a/var/spack/repos/builtin/packages/libyogrt/package.py
+++ b/var/spack/repos/builtin/packages/libyogrt/package.py
@@ -31,8 +31,25 @@ class Libyogrt(AutotoolsPackage):
     homepage = "https://github.com/LLNL/libyogrt"
     url      = "https://github.com/LLNL/libyogrt/archive/1.20-6.tar.gz"
 
+    version('1.21',   '00c282f29109725d272079e49edb4737',
+            url='https://github.com/LLNL/libyogrt/releases/download/1.21/libyogrt-1.21.tar.gz')
     version('1.20-6', '478f27512842cc5f2b74a0c22b851f60')
     version('1.20-5', 'd0fa6526fcd1f56ddb3d93f602ec72f7')
     version('1.20-4', '092bea10de22c505ce92aa07001decbb')
     version('1.20-3', 'd0507717009a5f8e2009e3b63594738f')
     version('1.20-2', '780bda03268324f6b5f72631fff6e6cb')
+
+    # TODO: only want this variant available for v1.21 and greater, how?
+    # @when("libyogrt@1.21:")
+    variant("lsf", default=False,
+            description="Build backend for LSF")
+
+    def configure_args(self):
+        spec = self.spec
+        args = []
+
+        # the lsf variant is only valid for v1.21 and later
+        if "+lsf" in spec and "libyogrt@1.21:" in spec:
+            args.append("--with-lsf=/opt/ibm/spectrumcomputing/lsf/10.1")
+
+        return args


### PR DESCRIPTION
Needs some work:
How to enable +lsf variant only for v1.21 and later?
Probably want user to provide path to LSF directory if this varies across systems.  It's currently hardcoded.