### PR TITLE
Graphviz : Add a GTS variant

### DIFF
--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -79,6 +79,9 @@ class Graphviz(AutotoolsPackage):
     variant('libgd', default=False,
             description='Build with libgd support (more output formats)')
 
+    variant('gts', default=False,
+            description='Build with GNU Triangulated Surface Library')
+
     parallel = False
 
     # These language bindings have been tested, we know they work.
@@ -98,6 +101,7 @@ class Graphviz(AutotoolsPackage):
     depends_on('cairo', when='+pangocairo')
     depends_on('pango', when='+pangocairo')
     depends_on('libgd', when='+libgd')
+    depends_on('gts', when='+gts')
     depends_on('ghostscript')
     depends_on('freetype')
     depends_on('expat')
@@ -146,7 +150,7 @@ class Graphviz(AutotoolsPackage):
         else:
             options.append('--enable-swig=no')
 
-        for var in ('+pangocairo', '+libgd'):
+        for var in ('+pangocairo', '+libgd', '+gts'):
             if var in spec:
                 options.append('--with-{0}'.format(var[1:]))
             else:


### PR DESCRIPTION
Dear maintainers,

A small patch to support GTS in Graphviz.
Thank you very much for your great work!

Cheers,

Jean-Baptiste.

----------------
Enable support for the GNU Triangulated Surface Library

	- New variant +gts for graphviz
	- Optionnal dependency for GTS (already packaged)