### PR TITLE
Docker Docs: MPI as Root

### DIFF
--- a/lib/spack/docs/workflows.rst
+++ b/lib/spack/docs/workflows.rst
@@ -1208,6 +1208,9 @@ MPI
 Due to the dependency on Fortran for OpenMPI, which is the spack default
 implementation, consider adding ``gfortran`` to the ``apt-get install`` list.
 
+Recent versions of OpenMPI will require you to pass ``--allow-run-as-root``
+to your ``mpirun`` calls if started as root user inside Docker.
+
 For execution on HPC clusters, it can be helpful to import the docker
 image into Singularity in order to start a program with an *external*
 MPI. Otherwise, also add ``openssh-server`` to the ``apt-get install`` list.


### PR DESCRIPTION
New versions of OpenMPI need `--allow-run-as-root` for running as root:
  http://www.open-mpi.de/doc/v2.0/man1/mpirun.1.php#toc22

This is important in Docker containers, which usually run as root.