### PR TITLE
some missing X11  "*proto" dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/libxtst/package.py
+++ b/var/spack/repos/builtin/packages/libxtst/package.py
@@ -49,5 +49,6 @@ class Libxtst(AutotoolsPackage):
     depends_on('recordproto@1.13.99.1:', type='build')
     depends_on('xextproto@7.0.99.3:', type='build')
     depends_on('inputproto', type='build')
+    depends_on('fixesproto', type='build')
     depends_on('pkg-config@0.9.0:', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xdpyinfo/package.py
+++ b/var/spack/repos/builtin/packages/xdpyinfo/package.py
@@ -44,5 +44,8 @@ class Xdpyinfo(AutotoolsPackage):
     depends_on('libxcb')
 
     depends_on('xproto@7.0.22:', type='build')
+    depends_on('recordproto', type='build')
+    depends_on('inputproto', type='build')
+    depends_on('fixesproto', type='build')
     depends_on('pkg-config@0.9.0:', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xfs/package.py
+++ b/var/spack/repos/builtin/packages/xfs/package.py
@@ -37,6 +37,7 @@ class Xfs(AutotoolsPackage):
     depends_on('font-util')
 
     depends_on('xproto@7.0.17:', type='build')
+    depends_on('fontsproto', type='build')
     depends_on('xtrans', type='build')
     depends_on('pkg-config@0.9.0:', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/xinput/package.py
+++ b/var/spack/repos/builtin/packages/xinput/package.py
@@ -40,5 +40,8 @@ class Xinput(AutotoolsPackage):
     depends_on('libxinerama')
 
     depends_on('inputproto@2.1.99.1:', type='build')
+    depends_on('fixesproto', type='build')
+    depends_on('randrproto', type='build')
+    depends_on('xineramaproto', type='build')
     depends_on('pkg-config@0.9.0:', type='build')
     depends_on('util-macros', type='build')


### PR DESCRIPTION
On some X11 packages there are similar configure step errors that can be fixed by adding "*proto" dependencies.
This is fixes #6157 and is similar to  already merged #6112 which closed #5936