### PR TITLE
magma: cuda updates [from xsdk-0.3.0 branch]

### DIFF
--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -40,7 +40,8 @@ class Magma(CMakePackage):
             description='Enable Fortran bindings support')
 
     depends_on('lapack')
-
+    depends_on('cuda@9.0:', when='%gcc@6.0:6.9.9')
+    depends_on('cuda@8.0:', when='%gcc@5.0:')
     patch('ibm-xl.patch', when='@2.2:%xl')
     patch('ibm-xl.patch', when='@2.2:%xl_r')
 
@@ -63,5 +64,10 @@ class Magma(CMakePackage):
                 options.extend([
                     '-DCMAKE_Fortran_COMPILER=%s' % self.compiler.f77
                 ])
+
+        if spec.satisfies('^cuda@9.0:'):
+            options.extend([
+                '-DGPU_TARGET=sm30'
+            ])
 
         return options


### PR DESCRIPTION
- add gcc dependency per cuda versions
- Fix for cuda-9.0  as it does not support sm20

    nvcc fatal   : Unsupported gpu architecture 'compute_20'

@luszczek @keitat @tgamblin 