### PR TITLE
elpa: make compatible with intel

### DIFF
--- a/var/spack/repos/builtin/packages/elpa/package.py
+++ b/var/spack/repos/builtin/packages/elpa/package.py
@@ -55,9 +55,11 @@ class Elpa(AutotoolsPackage):
     # override default implementation which returns static lib
     @property
     def libs(self):
+        shared = (False if 'static' in self.spec.last_query.extra_parameters
+                  else True)
         libname = 'libelpa_openmp' if '+openmp' in self.spec else 'libelpa'
         return find_libraries(
-            libname, root=self.prefix, shared=True, recurse=True
+            libname, root=self.prefix, shared=shared, recurse=True
         )
 
     build_directory = 'spack-build'


### PR DESCRIPTION
[UPDATE]
Revamped this PR to base on the latest repository. The choice of compiler flags are based on ELPA's [wiki page](https://gitlab.mpcdf.mpg.de/elpa/elpa/wikis/INSTALL) (apart from `-funsafe-math-optimizations` and architecture-specific settings). Tested working on the latest five versions of this package using both GCC and Intel.

Setting `SCALAPACK_LDFLAGS` in the build environment does not seem to be sufficient for Intel, so I have it (along with two other dependencies) passed to the `configure` script per its INSTALL instructions.

---
Tentative fix for issues with GCC 6.4.0/7.2.0 (#6143) and Intel 2018.0 (#6144). Before, in the second call to `setup_environment()`, `spec['mpi'].mpicc` somehow became undefined.
  
  
  