### PR TITLE
lammps: enable default packages

### DIFF
--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -47,11 +47,11 @@ class Lammps(CMakePackage):
 
     supported_packages = ['asphere', 'body', 'class2', 'colloid', 'compress',
                           'coreshell', 'dipole', 'granular', 'kspace', 'latte',
-                          'manybody', 'mc', 'meam', 'misc', 'molecule', 'mpiio',
-                          'peri', 'poems', 'python', 'qeq', 'reax', 'replica',
-                          'rigid', 'shock', 'snap', 'srd', 'user-atc', 'user-h5md',
-                          'user-lb', 'user-misc', 'user-netcdf', 'user-omp',
-                          'voronoi']
+                          'manybody', 'mc', 'meam', 'misc', 'molecule', 
+                          'mpiio', 'peri', 'poems', 'python', 'qeq', 'reax',
+                          'replica', 'rigid', 'shock', 'snap', 'srd', 
+                          'user-atc', 'user-h5md', 'user-lb', 'user-misc', 
+                          'user-netcdf', 'user-omp', 'voronoi']
 
     for pkg in supported_packages:
         variant(pkg, default=False,

--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -45,8 +45,13 @@ class Lammps(CMakePackage):
         return "https://github.com/lammps/lammps/archive/patch_{0}.tar.gz".format(
             vdate.strftime("%d%b%Y").lstrip('0'))
 
-    supported_packages = ['voronoi', 'rigid', 'user-netcdf', 'kspace',
-                          'latte', 'user-atc', 'user-omp', 'meam', 'manybody']
+    supported_packages = ['asphere', 'body', 'class2', 'colloid', 'compress',
+                          'coreshell', 'dipole', 'granular', 'kspace', 'latte',
+                          'manybody', 'mc', 'meam', 'misc', 'molecule', 'mpiio',
+                          'peri', 'poems', 'python', 'qeq', 'reax', 'replica',
+                          'rigid', 'shock', 'snap', 'srd', 'user-atc', 'user-h5md',
+                          'user-lb', 'user-misc', 'user-netcdf', 'user-omp',
+                          'voronoi']
 
     for pkg in supported_packages:
         variant(pkg, default=False,
@@ -57,6 +62,7 @@ class Lammps(CMakePackage):
             description='Build with mpi')
 
     depends_on('mpi', when='+mpi')
+    depends_on('mpi', when='+mpiio')
     depends_on('fftw', when='+kspace')
     depends_on('voropp', when='+voronoi')
     depends_on('netcdf+mpi', when='+user-netcdf')
@@ -65,8 +71,19 @@ class Lammps(CMakePackage):
     depends_on('latte', when='+latte')
     depends_on('blas', when='+latte')
     depends_on('lapack', when='+latte')
+    depends_on('python', when='+python')
+    depends_on('mpi', when='+user-lb')
+    depends_on('mpi', when='+user-h5md')
+    depends_on('hdf5', when='+user-h5md')
 
+    conflicts('+body', when='+poems')
     conflicts('+latte', when='@:20170921')
+    conflicts('+python', when='~lib')
+    conflicts('+qeq', when='~manybody')
+    conflicts('+user-atc', when='~manybody')
+    conflicts('+user-misc', when='~manybody')
+    conflicts('+user-phonon', when='~kspace')
+    conflicts('+user-misc', when='~manybody')
 
     patch("lib.patch", when="@20170901")
     patch("660.patch", when="@20170922")

--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -47,10 +47,10 @@ class Lammps(CMakePackage):
 
     supported_packages = ['asphere', 'body', 'class2', 'colloid', 'compress',
                           'coreshell', 'dipole', 'granular', 'kspace', 'latte',
-                          'manybody', 'mc', 'meam', 'misc', 'molecule', 
+                          'manybody', 'mc', 'meam', 'misc', 'molecule',
                           'mpiio', 'peri', 'poems', 'python', 'qeq', 'reax',
-                          'replica', 'rigid', 'shock', 'snap', 'srd', 
-                          'user-atc', 'user-h5md', 'user-lb', 'user-misc', 
+                          'replica', 'rigid', 'shock', 'snap', 'srd',
+                          'user-atc', 'user-h5md', 'user-lb', 'user-misc',
                           'user-netcdf', 'user-omp', 'voronoi']
 
     for pkg in supported_packages:


### PR DESCRIPTION
Currently there is no way to enable default packages.

1. Could we enable default packages in lammps by default? Building these packages doesn't really take long.
2. Could we enable python embedding/interface whenever `BUILD_SHARED_LIBS` is `ON`? The use case of lammps' shared library typically involves using it with python interface.

`DEFAULT_PACKAGES` include:
```
ASPHERE BODY CLASS2 COLLOID COMPRESS CORESHELL DIPOLE
GRANULAR KSPACE MANYBODY MC MEAM MISC MOLECULE PERI QEQ REAX REPLICA
RIGID SHOCK SNAP SRD
```
cmake variable `ENABLE_ALL` enables all default packages.
(manybody is part of `DEFAULT_PACKAGES`)
@junghans 