### PR TITLE
ROOT needs to have a consistent version of binutils

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -55,6 +55,7 @@ class Root(CMakePackage):
     depends_on('cmake@3.4.3:', type='build')
     depends_on('pkg-config',   type='build')
 
+    depends_on('binutils')
     depends_on('zlib')
     # depends_on('unuran')
     depends_on('freetype')


### PR DESCRIPTION
ROOT needs to have a consistent version of binutils, as it is sensitive to the version of libopcodes. You can't move the code from one system (with the same OS) as another.