### PR TITLE
Create symlink for 'swig' binary after installation.

### DIFF
--- a/var/spack/repos/builtin/packages/swig/package.py
+++ b/var/spack/repos/builtin/packages/swig/package.py
@@ -22,6 +22,9 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
+import os
+
+
 from spack import *
 
 
@@ -50,3 +53,8 @@ class Swig(AutotoolsPackage):
     depends_on('pcre')
 
     build_directory = 'spack-build'
+
+    @run_after('install')
+    def create_symlink(self):
+        with working_dir(self.prefix.bin):
+            os.symlink('swig', 'swig%i.0' % self.spec.version[0])


### PR DESCRIPTION
FindSWIG.cmake provided with cmake tries to find the swig binary under the following names and in the following order: `swig3.0`, `swig2.0`, `swig`. Swig installs only a binary called `swig`, which can get overriden by an external version. The symlink prevents that from happening.