### PR TITLE
Adding updated URL for package abinit

### DIFF
--- a/var/spack/repos/builtin/packages/abinit/package.py
+++ b/var/spack/repos/builtin/packages/abinit/package.py
@@ -47,9 +47,9 @@ class Abinit(AutotoolsPackage):
     """
 
     homepage = 'http://www.abinit.org'
-    url      = 'http://ftp.abinit.org/abinit-8.0.8b.tar.gz'
+    url      = 'https://www.abinit.org/sites/default/files/packages/abinit-8.2.3.tar.gz'
 
-    version('8.2.2', '5f25250e06fdc0815c224ffd29858860')
+    version('8.2.3', '10f82b260091a95759b9080d5c97749e')
     # Versions before 8.0.8b are not supported.
     version('8.0.8b', 'abc9e303bfa7f9f43f95598f87d84d5d')
 


### PR DESCRIPTION
Abinit's old URL pointing at http://ftp.abinit.org/abinit-8.2.2.tar.gz appears to be timing out now.  Attempting to hit ftp.abinit.org on port 80 results in a timeout, and hitting it on port 443 results in "The provided host name is not valid for this server."

After some quick digging, it seems they (www.abinit.org) are only listening on port 443 and that the location of Abinit has changed to https://www.abinit.org/sites/default/files/packages/

Also - Abinit 8.2.2 has been 'replaced' with 8.2.3.

This PR updates the abinit package with the new URL and version/md5sum.

Please feel free to test my claims about access to the FTP site, but it has failed from more than one network location so I'm assuming it's not just me.

