### PR TITLE
Nekbone: Installing data files for example runs

### DIFF
--- a/var/spack/repos/builtin/packages/nekbone/package.py
+++ b/var/spack/repos/builtin/packages/nekbone/package.py
@@ -32,7 +32,7 @@ class Nekbone(Package):
        Nek5000 is a high order, incompressible Navier-Stokes solver based on
        the spectral element method."""
 
-    homepage = "hhttps://github.com/Nek5000/Nekbone"
+    homepage = "https://github.com/Nek5000/Nekbone"
     url = "https://github.com/Nek5000/Nekbone/tarball/v17.0"
 
     tags = ['proxy-app', 'ecp-proxy-app']

--- a/var/spack/repos/builtin/packages/nekbone/package.py
+++ b/var/spack/repos/builtin/packages/nekbone/package.py
@@ -59,3 +59,6 @@ class Nekbone(Package):
                 mkdir(path)
                 install('nekbone', path)
                 install('nekpmpi', path)
+                install('data.rea', path)
+                install('SIZE', path)
+                install('README', path)


### PR DESCRIPTION
The examples installed require the `data.rea` and `SIZE` files to run.  The individual `README` files are just short explanations of the test. ex: `example1/README`
```
This example will run a
series of tests from:

1 to 50 elements per process
with polynomial order = 8

and


1 to 50 elements per process
with polynomial order = 10

The multi-grid preconditioner
is turn off.
```