### PR TITLE
make dependency satisfaction check more strict

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2493,7 +2493,7 @@ class Spec(object):
 
             selfdeps = self.traverse(root=False)
             otherdeps = other.traverse(root=False)
-            if not all(any(d.satisfies(dep) for d in selfdeps)
+            if not all(any(d.satisfies(dep, strict=strict) for d in selfdeps)
                        for dep in otherdeps):
                 return False
 


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/6231

This updates `Spec.satisfies_dependencies` to strictly check satisfaction on dependencies when it is called with `strict=True`. Without this, condition specs in `package.py` files that set variants on dependencies are not checked.