### PR TITLE
elfutils: add --no-as-needed flag for library ordering issue

### DIFF
--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -53,5 +53,5 @@ class Elfutils(AutotoolsPackage):
         # configure doesn't use LIBS correctly
         gettext_lib = self.spec['gettext'].prefix.lib,
         return [
-            'LDFLAGS=-Wl,--no-as-needed -L%s -lintl' % gettext_lib
+            'LDFLAGS=-Wl,--no-as-needed -L%s -lintl' % gettext_lib,
             '--enable-maintainer-mode']

--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -51,6 +51,7 @@ class Elfutils(AutotoolsPackage):
 
     def configure_args(self):
         # configure doesn't use LIBS correctly
+        gettext_lib = self.spec['gettext'].prefix.lib,
         return [
-            'LDFLAGS=-L%s -lintl' % self.spec['gettext'].prefix.lib,
+            'LDFLAGS=-Wl,--no-as-needed -L%s -lintl' % gettext_lib
             '--enable-maintainer-mode']


### PR DESCRIPTION
Resolves an arcane error I found in elfutils on recent ubuntu systems.