### PR TITLE
version list missing?!

### DIFF
--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -89,6 +89,7 @@ be:
 
    packages:
      openmpi:
+       version: [1.4.3, 1.6.5]
        paths:
          openmpi@1.4.3%gcc@4.4.7 arch=linux-x86_64-debian7: /opt/openmpi-1.4.3
          openmpi@1.4.3%gcc@4.4.7 arch=linux-x86_64-debian7+debug: /opt/openmpi-1.4.3-debug


### PR DESCRIPTION
I am just a beginner but I guess spack was not able to pick up my openssl and cmake (from brew) because I initially did not have the version list ready. I am not sure if I did the right thing with adding the two versions in the open-mpi example.
My packages.yaml now looks like this:
packages:
  openssl:
    version: [2.2.7]
    paths:
      openssl@2.2.7: /usr/bin/openssl
    buildable: False
  cmake:
    version: [2.9.5]
    paths:
      cmake@3.9.5: /usr/local/bin/cmake
and spack is now finding these!