### PR TITLE
icu4c: Update to 60.1

### DIFF
--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -35,6 +35,7 @@ class Icu4c(AutotoolsPackage):
     list_url = "http://download.icu-project.org/files/icu4c"
     list_depth = 2
 
+    version('60.1', '3d164a2d1bcebd1464c6160ebb8315ef')
     version('58.2', 'fac212b32b7ec7ab007a12dff1f3aea1')
     version('57.1', '976734806026a4ef8bdd17937c8898b9')
 


### PR DESCRIPTION
Previous versions try to include xlocale.h, which fails on glibc >= 2.26.