### PR TITLE
ncl: Check for ncl binary after installation

### DIFF
--- a/var/spack/repos/builtin/packages/ncl/package.py
+++ b/var/spack/repos/builtin/packages/ncl/package.py
@@ -106,6 +106,8 @@ class Ncl(Package):
         placement='triangle_src',
         when='+triangle')
 
+    sanity_check_is_file = ['bin/ncl']
+
     def patch(self):
         # Make configure scripts use Spack's tcsh
         files = ['Configure'] + glob.glob('config/*')


### PR DESCRIPTION
ncl's build system will happily continue in case of errors, which might result in the ncl binary not being built.