### PR TITLE
py-h5py: make sure to depend on the hl variant of hdf5

### DIFF
--- a/var/spack/repos/builtin/packages/py-h5py/package.py
+++ b/var/spack/repos/builtin/packages/py-h5py/package.py
@@ -42,7 +42,7 @@ class PyH5py(PythonPackage):
     depends_on('py-cython@0.19:', type='build')
     depends_on('py-pkgconfig', type='build')
     depends_on('py-setuptools', type='build')
-    depends_on('hdf5@1.8.4:')
+    depends_on('hdf5@1.8.4:+hl')
     depends_on('hdf5+mpi', when='+mpi')
     depends_on('mpi', when='+mpi')
     depends_on('py-mpi4py', when='+mpi', type=('build', 'run'))


### PR DESCRIPTION
py-h5py seems to be failing to build due to this error:

fatal error: hdf5_hl.h: No such file or directory

Ensuring that it depends on the hl variant of hdf5 fixes this.