### PR TITLE
likwid: Fix hash for 4.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/likwid/package.py
+++ b/var/spack/repos/builtin/packages/likwid/package.py
@@ -36,8 +36,9 @@ class Likwid(Package):
 
     maintainers = ['davydden']
 
-    version('4.3.0', 'f6bdf12513af95bd6eefa9c68644e724')
-    version('4.2.1', 'c408ddcf0317cdd894af4c580cd74294')
+    # The hash for 4.3.0 changes regularly
+    version('4.3.0', '20541515fdc6d68e82628170e0042485')
+    version('4.2.1', 'c408ddcf0317cdd894af4c580cd74294', preferred=True)
     version('4.2.0', 'e41ff334b8f032a323d941ce32907a75')
     version('4.1.2', 'a857ce5bd23e31d96e2963fe81cb38f0')
 


### PR DESCRIPTION
Looks like likwid's hash has changed again. Let's hope this is actually the final release.