### PR TITLE
Reduce the calls to the python interpreter during initialization

### DIFF
--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -237,13 +237,11 @@ fi;
 # Set up modules and dotkit search paths in the user environment
 #
 
-_python_command=$(cat << EOCs
-print(\'_sp_sys_type={0}\'.format(spack.architecture.sys_type()))\n
-print(\'_sp_dotkit_root={0}\'.format(spack.util.path.canonicalize_path(spack.config.get_config(\'config\').get(\'module_roots\', {}).get(\'dotkit\'))))\n
-print(\'_sp_tcl_root={0}\'.format(spack.util.path.canonicalize_path(spack.config.get_config(\'config\').get(\'module_roots\', {}).get(\'tcl\'))))
-EOCs
+_python_command=$(printf  "%s\\\n%s\\\n%s" \
+"print(\'_sp_sys_type={0}\'.format(spack.architecture.sys_type()))" \
+"print(\'_sp_dotkit_root={0}\'.format(spack.util.path.canonicalize_path(spack.config.get_config(\'config\').get(\'module_roots\', {}).get(\'dotkit\'))))" \
+"print(\'_sp_tcl_root={0}\'.format(spack.util.path.canonicalize_path(spack.config.get_config(\'config\').get(\'module_roots\', {}).get(\'tcl\'))))"
 )
-_python_command=$(echo ${_python_command} | tr -d ' ')
 
 _assignment_command=$(spack-python -c "exec('${_python_command}')")
 eval ${_assignment_command}

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -237,11 +237,12 @@ fi;
 # Set up modules and dotkit search paths in the user environment
 #
 
-read -r -d 'EOCs' _python_command << EOCs
+_python_command=$(cat << EOCs
 print(\'_sp_sys_type={0}\'.format(spack.architecture.sys_type()))\n
 print(\'_sp_dotkit_root={0}\'.format(spack.util.path.canonicalize_path(spack.config.get_config(\'config\').get(\'module_roots\', {}).get(\'dotkit\'))))\n
 print(\'_sp_tcl_root={0}\'.format(spack.util.path.canonicalize_path(spack.config.get_config(\'config\').get(\'module_roots\', {}).get(\'tcl\'))))
 EOCs
+)
 _python_command=$(echo ${_python_command} | tr -d ' ')
 
 _assignment_command=$(spack-python -c "exec('${_python_command}')")

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -236,9 +236,17 @@ fi;
 #
 # Set up modules and dotkit search paths in the user environment
 #
-_sp_sys_type=$(spack-python -c 'print(spack.architecture.sys_type())')
-_sp_dotkit_root=$(spack-python -c "print(spack.util.path.canonicalize_path(spack.config.get_config('config').get('module_roots', {}).get('dotkit')))")
-_sp_tcl_root=$(spack-python -c "print(spack.util.path.canonicalize_path(spack.config.get_config('config').get('module_roots', {}).get('tcl')))")
+
+read -r -d 'EOCs' _python_command << EOCs
+print(\'_sp_sys_type={0}\'.format(spack.architecture.sys_type()))\n
+print(\'_sp_dotkit_root={0}\'.format(spack.util.path.canonicalize_path(spack.config.get_config(\'config\').get(\'module_roots\', {}).get(\'dotkit\'))))\n
+print(\'_sp_tcl_root={0}\'.format(spack.util.path.canonicalize_path(spack.config.get_config(\'config\').get(\'module_roots\', {}).get(\'tcl\'))))
+EOCs
+_python_command=$(echo ${_python_command} | tr -d ' ')
+
+_assignment_command=$(spack-python -c "exec('${_python_command}')")
+eval ${_assignment_command}
+
 _spack_pathadd DK_NODE    "${_sp_dotkit_root%/}/$_sp_sys_type"
 _spack_pathadd MODULEPATH "${_sp_tcl_root%/}/$_sp_sys_type"
 


### PR DESCRIPTION
This should reduce the delay the users experience when sourcing the setup file to activate shell support. It works by generating at once all the commands that needs to be evaluated (they are stored in a string and later `eval`ed by the shell).

I am not proficient enough with shell scripting to tell if this is portable across shells, so please somebody double check.

@ax3l Does this help with #6302 ?

##### Shell support

- [x] bash
- [x] zsh