### PR TITLE
xtensor, xtl, xsimd

### DIFF
--- a/var/spack/repos/builtin/packages/xsimd/package.py
+++ b/var/spack/repos/builtin/packages/xsimd/package.py
@@ -1,0 +1,44 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xsimd(CMakePackage):
+    """C++ wrappers for SIMD intrinsics"""
+
+    homepage = "http://quantstack.net/xsimd"
+    url      = "https://github.com/QuantStack/xsimd/archive/3.1.0.tar.gz"
+
+    version('develop', branch='master',
+            git='https://github.com/QuantStack/xsimd.git')
+    version('3.1.0', '29c1c525116cbda28f610e2bf24a827e')
+
+    depends_on('googletest')
+
+    # C++14 support
+    conflicts('%gcc@:4.8')
+    conflicts('%clang@:3.6')
+    # untested: conflicts('%intel@:15')
+    # untested: conflicts('%pgi@:14')

--- a/var/spack/repos/builtin/packages/xtensor/package.py
+++ b/var/spack/repos/builtin/packages/xtensor/package.py
@@ -1,0 +1,50 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xtensor(CMakePackage):
+    """Multi-dimensional arrays with broadcasting and lazy computing"""
+
+    homepage = "http://quantstack.net/xtensor"
+    url      = "https://github.com/QuantStack/xtensor/archive/0.13.1.tar.gz"
+
+    version('develop', branch='master',
+            git='https://github.com/QuantStack/xtensor.git')
+    version('0.13.1', '80e7e33f05066d17552bf0f8b582dcc5')
+
+    variant('xsimd', default=True,
+            description='Enable SIMD intrinsics')
+
+    depends_on('xtl')
+    depends_on('xtl@0.3.4:', when='@develop')
+    depends_on('xtl@0.3.3:', when='@0.13.1')
+    depends_on('xsimd@3.1.0', when='+xsimd')
+
+    # C++14 support
+    conflicts('%gcc@:4.8')
+    conflicts('%clang@:3.5')
+    # untested: conflicts('%intel@:15')
+    # untested: conflicts('%pgi@:14')

--- a/var/spack/repos/builtin/packages/xtl/package.py
+++ b/var/spack/repos/builtin/packages/xtl/package.py
@@ -1,0 +1,43 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xtl(CMakePackage):
+    """QuantStack tools library"""
+
+    homepage = "https://github.com/QuantStack/xtl"
+    url      = "https://github.com/QuantStack/xtl/archive/0.3.4.tar.gz"
+
+    version('develop', branch='master',
+            git='https://github.com/QuantStack/xtl.git')
+    version('0.3.4', 'b76548a55f1e171a9c849e5ed543e8b3')
+    version('0.3.3', '09b6d9611e460d9280bf1156bcca20f5')
+
+    # C++14 support
+    conflicts('%gcc@:4.8')
+    conflicts('%clang@:3.6')
+    # untested: conflicts('%intel@:15')
+    # untested: conflicts('%pgi@:14')


### PR DESCRIPTION
Adds the QuantStack libs (C++, header-only) needed for [xtensor](https://github.com/QuantStack/xtensor).