### PR TITLE
Ordered compiler names

### DIFF
--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -251,9 +251,6 @@ class Compiler(object):
         prefixes = [''] + cls.prefixes
         suffixes = [''] + cls.suffixes
 
-        def check_cmp_key(check):
-            return compiler_names.index(check[2])
-
         checks = []
         for directory in path:
             dir_checks = []
@@ -276,7 +273,8 @@ class Compiler(object):
 
             # sort dir_checks by compiler name order
             # this allows us to prioritize compiler names in subclass
-            dir_checks = sorted(dir_checks, key=check_cmp_key)
+            dir_checks = sorted(dir_checks,
+                                key=lambda c: compiler_names.index(c[2]))
             checks.extend(dir_checks)
 
         successful = [k for k in mp.parmap(_get_versioned_tuple, checks)

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -252,7 +252,8 @@ class Compiler(object):
         suffixes = [''] + cls.suffixes
 
         def check_cmp_key(check):
-            idx = compiler_names.index(check[2])
+            name = os.path.basename(check[0])
+            idx = compiler_names.index(name)
             return idx
 
         checks = []
@@ -268,11 +269,11 @@ class Compiler(object):
 
                 prod = itertools.product(prefixes, compiler_names, suffixes)
                 for pre, name, suf in prod:
-                    regex = r'^(%s)(%s)(%s)$' % (pre, re.escape(name), suf)
+                    regex = r'^(%s)%s(%s)$' % (pre, re.escape(name), suf)
 
                     match = re.match(regex, exe)
                     if match:
-                        key = (full_path,) + match.groups()
+                        key = (full_path,) + match.groups() + (detect_version,)
                         dir_checks.append(key)
 
             # sort dir_checks by compiler name order

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -251,8 +251,13 @@ class Compiler(object):
         prefixes = [''] + cls.prefixes
         suffixes = [''] + cls.suffixes
 
+        def check_cmp_key(check):
+            idx = compiler_names.index(check[2])
+            return idx
+
         checks = []
         for directory in path:
+            dir_checks = []
             if not (os.path.isdir(directory) and
                     os.access(directory, os.R_OK | os.X_OK)):
                 continue
@@ -263,12 +268,34 @@ class Compiler(object):
 
                 prod = itertools.product(prefixes, compiler_names, suffixes)
                 for pre, name, suf in prod:
-                    regex = r'^(%s)%s(%s)$' % (pre, re.escape(name), suf)
+                    regex = r'^(%s)(%s)(%s)$' % (pre, re.escape(name), suf)
 
                     match = re.match(regex, exe)
                     if match:
-                        key = (full_path,) + match.groups() + (detect_version,)
-                        checks.append(key)
+                        key = (full_path,) + match.groups()
+                        dir_checks.append(key)
+
+            # sort dir_checks by compiler name order
+            # this allows us to prioritize compiler names in subclass
+            dir_checks = sorted(dir_checks, key=check_cmp_key)
+            checks.extend(dir_checks)
+
+        def check(key):
+            try:
+                full_path, prefix, name, suffix = key
+                version = detect_version(full_path)
+                return (version, prefix, suffix, full_path)
+            except ProcessError as e:
+                tty.debug(
+                    "Couldn't get version for compiler %s" % full_path, e)
+                return None
+            except Exception as e:
+                # Catching "Exception" here is fine because it just
+                # means something went wrong running a candidate executable.
+                tty.debug("Error while executing candidate compiler %s"
+                          % full_path,
+                          "%s: %s" % (e.__class__.__name__, e))
+                return None
 
         successful = [k for k in mp.parmap(_get_versioned_tuple, checks)
                       if k is not None]

--- a/lib/spack/spack/test/cmd/test_compiler_cmd.py
+++ b/lib/spack/spack/test/cmd/test_compiler_cmd.py
@@ -127,7 +127,7 @@ done
     return str(tmpdir)
 
 
-@pytest.mark.usefixtures('config', 'builtin_mock')
+@pytest.mark.usefixtures('config', 'mock_packages')
 class TestCompilerCommand(object):
 
     def test_compiler_remove(self):

--- a/lib/spack/spack/test/cmd/test_compiler_cmd.py
+++ b/lib/spack/spack/test/cmd/test_compiler_cmd.py
@@ -52,7 +52,7 @@ done
 
 @pytest.fixture()
 def mock_two_compiler_dirs(tmpdir):
-    """Return two directory containing a fake, but detectable compiler,
+    """Return two directories containing a fake, but detectable compiler,
     with the same compiler spec."""
 
     tmpdir.ensure('compiler1/bin', dir=True)

--- a/lib/spack/spack/test/cmd/test_compiler_cmd.py
+++ b/lib/spack/spack/test/cmd/test_compiler_cmd.py
@@ -15,7 +15,10 @@ import spack.spec
 import spack.util.pattern
 from spack.version import Version
 
-test_version = '4.5.3'
+test_version = '4.5-spacktest'
+test_multiple_version = '4.8-spacktest'
+test_pgi_version = '0.0'
+test_pgi_version_string = 'pgi 0.0-0 pgi target on pgispacktest'
 
 
 @pytest.fixture()
@@ -47,7 +50,84 @@ done
     return str(tmpdir)
 
 
-@pytest.mark.usefixtures('config', 'mock_packages')
+@pytest.fixture()
+def mock_two_compiler_dirs(tmpdir):
+    """Return two directory containing a fake, but detectable compiler,
+    with the same compiler spec."""
+
+    tmpdir.ensure('compiler1/bin', dir=True)
+    tmpdir1 = tmpdir.join('compiler1')
+    bin_dir1 = tmpdir1.join('bin')
+
+    gcc_path1 = bin_dir1.join('gcc')
+    gxx_path1 = bin_dir1.join('g++')
+    gfortran_path1 = bin_dir1.join('gfortran')
+
+    tmpdir.ensure('compiler2/bin', dir=True)
+    tmpdir2 = tmpdir.join('compiler2')
+    bin_dir2 = tmpdir2.join('bin')
+
+    gcc_path2 = bin_dir2.join('gcc')
+    gxx_path2 = bin_dir2.join('g++')
+    gfortran_path2 = bin_dir2.join('gfortran')
+
+    gcc_path1.write("""\
+#!/bin/sh
+
+for arg in "$@"; do
+    if [ "$arg" = -dumpversion ]; then
+        echo '%s'
+    fi
+done
+""" % test_multiple_version)
+
+    # Create some mock compilers in the temporary directory
+    llnl.util.filesystem.set_executable(str(gcc_path1))
+    gcc_path1.copy(gxx_path1, mode=True)
+    gcc_path1.copy(gfortran_path1, mode=True)
+
+    gcc_path1.copy(gcc_path2, mode=True)
+    gcc_path1.copy(gxx_path2, mode=True)
+    gcc_path1.copy(gfortran_path2, mode=True)
+
+    return [str(tmpdir1), str(tmpdir2)]
+
+
+@pytest.fixture()
+def mock_pgi_dir(tmpdir):
+    """Return a directory containing a fake, but detectable pgi compiler,
+    with both old (pgf77, pgf90) and new (pgfortran) names."""
+
+    tmpdir.ensure('bin', dir=True)
+    bin_dir = tmpdir.join('bin')
+
+    pgcc_path = bin_dir.join('pgcc')
+    pgxx_path = bin_dir.join('pg++')
+    pgfortran_path = bin_dir.join('pgfortran')
+    pgf77_path = bin_dir.join('pgf77')
+    pgf90_path = bin_dir.join('pgf90')
+
+    pgcc_path.write("""\
+#!/bin/sh
+
+for arg in "$@"; do
+    if [ "$arg" = -V ]; then
+        echo '%s'
+    fi
+done
+""" % test_pgi_version_string)
+
+    # Create some mock compilers in the temporary directory
+    llnl.util.filesystem.set_executable(str(pgcc_path))
+    pgcc_path.copy(pgxx_path, mode=True)
+    pgcc_path.copy(pgfortran_path, mode=True)
+    pgcc_path.copy(pgf77_path, mode=True)
+    pgcc_path.copy(pgf90_path, mode=True)
+
+    return str(tmpdir)
+
+
+@pytest.mark.usefixtures('config', 'builtin_mock')
 class TestCompilerCommand(object):
 
     def test_compiler_remove(self):
@@ -79,3 +159,59 @@ class TestCompilerCommand(object):
         new_compilers = set(spack.compilers.all_compiler_specs())
         new_compiler = new_compilers - old_compilers
         assert any(c.version == Version(test_version) for c in new_compiler)
+
+    def test_compiler_add_multiple_in_path(self, mock_two_compiler_dirs):
+        # Compilers available by default.
+        old_compilers = set(spack.compilers.all_compiler_specs())
+
+        args = spack.util.pattern.Bunch(
+            all=None,
+            compiler_spec=None,
+            add_paths=mock_two_compiler_dirs,
+            scope=None
+        )
+        spack.cmd.compiler.compiler_find(args)
+
+        # Ensure new compiler is from the first path passed
+        new_all_compilers = set(spack.compilers.all_compiler_specs())
+        new_compilers = new_all_compilers - old_compilers
+
+        new_comp = spack.compilers.compilers_for_spec('gcc@%s'
+                                                      % test_multiple_version)
+        assert mock_two_compiler_dirs[0] in new_comp[0].cc
+        assert any(c.version == Version(test_multiple_version)
+                   for c in new_compilers)
+
+        # sorting to avoid gcc@4.8 removing gcc@4.8-spacktest and causing error
+        for compiler in sorted(new_compilers, reverse=True):
+            rm_args = spack.util.pattern.Bunch(
+                all=True, compiler_spec=compiler, add_paths=[], scope=None
+            )
+            spack.cmd.compiler.compiler_remove(rm_args)
+
+    def test_compiler_add_multiple_names(self, mock_pgi_dir):
+        old_compilers = set(spack.compilers.all_compiler_specs())
+
+        args = spack.util.pattern.Bunch(
+            all=None,
+            compiler_spec=None,
+            add_paths=[mock_pgi_dir],
+            scope=None
+        )
+        spack.cmd.compiler.compiler_find(args)
+
+        # Ensure new compiler is in there and has newest pgi names
+        new_compilers = set(spack.compilers.all_compiler_specs())
+        n_compiler = new_compilers - old_compilers
+
+        new_comp = spack.compilers.compilers_for_spec('pgi@%s'
+                                                      % test_pgi_version)
+        assert 'pgfortran' in new_comp[0].f77
+        assert 'pgfortran' in new_comp[0].fc
+        assert any(c.version == Version(test_pgi_version) for c in n_compiler)
+
+        for compiler in n_compiler:
+            rm_args = spack.util.pattern.Bunch(
+                all=True, compiler_spec=compiler, add_paths=[], scope=None
+            )
+            spack.cmd.compiler.compiler_remove(rm_args)

--- a/lib/spack/spack/test/compilers.py
+++ b/lib/spack/spack/test/compilers.py
@@ -46,13 +46,13 @@ def test_all_compilers(config):
 
 def test_version_detection_is_empty():
     no_version = lambda x: None
-    compiler_check_tuple = ('/usr/bin/gcc', '', r'\d\d', no_version)
+    compiler_check_tuple = ('/usr/bin/gcc', '', 'gcc', r'\d\d', no_version)
     assert not _get_versioned_tuple(compiler_check_tuple)
 
 
 def test_version_detection_is_successful():
     version = lambda x: '4.9'
-    compiler_check_tuple = ('/usr/bin/gcc', '', r'\d\d', version)
+    compiler_check_tuple = ('/usr/bin/gcc', '', 'gcc', r'\d\d', version)
     assert _get_versioned_tuple(compiler_check_tuple) == (
         '4.9', '', r'\d\d', '/usr/bin/gcc')
 


### PR DESCRIPTION
Fixes #518 

Summary:
Previously, when there were multiple names for a compiler, Spack chose the name that occurs first lexicographically as it searches the directory. This caused problems for the PGI compiler, for which we should choose `pgfortran` when available over `pgf77` and `pgf90`.

@adamjstewart proposed in #518 that a reasonable solution would be to choose compilers in the order they appear in the compiler_names list in Spack. This allows us to set priorities for compiler names using the compiler subclasses in Spack.

This PR implements that solution, and adds a test for it. Also adds a test to ensure Spack chooses the first compiler of a given version in the paths provided to `spack compiler add`.