### PR TITLE
NuT: Add Installation of libnut.a and demo app

### DIFF
--- a/var/spack/repos/builtin/packages/nut/package.py
+++ b/var/spack/repos/builtin/packages/nut/package.py
@@ -44,8 +44,6 @@ class Nut(CMakePackage):
 
     depends_on('random123')
 
-    # serial must be built with clang
-    conflicts('%gcc', when='@serial')
     conflicts('%intel', when='@serial')
     conflicts('%pgi', when='@serial')
     conflicts('%xl', when='@serial')
@@ -59,4 +57,9 @@ class Nut(CMakePackage):
     def install(self, spec, prefix):
         install('README.md', prefix)
         mkdirp(prefix.bin)
+        mkdirp(prefix.lib)
         install('spack-build/test/nut_unittests', prefix.bin)
+        install('spack-build/apps/bh-3', prefix.bin)
+        install('spack-build/lib/libnut.a', prefix.lib)
+        install_tree('test/data', prefix.data)
+        install_tree('lib', prefix.include)


### PR DESCRIPTION
Install libnut.a and bh-3 (small application that demonstrates the library).  

I had no issues building serial with gcc@4.8.5 or gcc@7.2.0 so I removed the conflict (didn't test the others).  I did have an issue with the openmp version with gcc@7.2.0, but its the same outside of spack.  

