### PR TITLE
Binary_distribution error messages managed by the exceptions that raise them

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -44,29 +44,42 @@ from spack.util.executable import ProcessError
 import spack.relocate as relocate
 
 
-class NoOverwriteException(Exception):
-    pass
+class NoOverwriteException(spack.error.SpackError):
+    def __init__(self, filepath):
+        super(NoOverwriteException, self).__init__(
+            "%s exists, use -f to force overwrite." % filepath)
 
+class NoGpgException(spack.error.SpackError):
+    def __init__(self):
+        super(NoGpgException, self).__init__(
+            "gpg2 is not available,"
+            " use -y to create unsigned build caches")
 
-class NoGpgException(Exception):
-    pass
+class PickKeyException(spack.error.SpackError):
+    def __init__(self):
+        super(PickKeyException, self).__init__(
+            "no default key available for signing,"
+            " use -y to create unsigned build caches"
+            " or spack gpg init to create a default key")
 
+class NoKeyException(spack.error.SpackError):
+    def __init__(self):
+        super(NoKeyException, self).__init__(
+            "multi keys available for signing,"
+            " use -y to create unsigned build caches"
+            " or -k <key hash> to pick a key")
 
-class PickKeyException(Exception):
-    pass
+class NoVerifyException(spack.error.SpackError):
+    def __init__(self):
+        super(NoVerifyException, self).__init__(
+            "Package spec file failed signature verification,"
+            " use -y flag to install build cache")
 
-
-class NoKeyException(Exception):
-    pass
-
-
-class NoVerifyException(Exception):
-    pass
-
-
-class NoChecksumException(Exception):
-    pass
-
+class NoChecksumException(spack.error.SpackError):
+    def __init__(self):
+        super(NoChecksumException, self).__init__(
+            "Package tarball failed checksum verification,"
+            " use -y flag to install build cache")
 
 def has_gnupg2():
     try:
@@ -277,15 +290,9 @@ def build_tarball(spec, outdir, force=False, rel=False, yes_to_all=False,
     signed = False
     if not yes_to_all:
         # sign the tarball and spec file with gpg
-        try:
-            sign_tarball(yes_to_all, key, force, specfile_path)
-            signed = True
-        except NoGpgException:
-            raise NoGpgException()
-        except PickKeyException:
-            raise PickKeyException()
-        except NoKeyException():
-            raise NoKeyException()
+        sign_tarball(yes_to_all, key, force, specfile_path)
+        signed = True
+
     # put tarball, spec and signature files in .spack archive
     with closing(tarfile.open(spackfile_path, 'w')) as tar:
         tar.add(name='%s' % tarfile_path, arcname='%s' % tarfile_name)

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -221,22 +221,8 @@ def createtarball(args):
 
     for spec in specs:
         tty.msg('creating binary cache file for package %s ' % spec.format())
-        try:
-            bindist.build_tarball(spec, outdir, force,
-                                  relative, yes_to_all, signkey)
-        except NoOverwriteException as e:
-            tty.warn("%s exists, use -f to force overwrite." % e)
-        except NoGpgException:
-            tty.die("gpg2 is not available,"
-                    " use -y to create unsigned build caches")
-        except NoKeyException:
-            tty.die("no default key available for signing,"
-                    " use -y to create unsigned build caches"
-                    " or spack gpg init to create a default key")
-        except PickKeyException:
-            tty.die("multi keys available for signing,"
-                    " use -y to create unsigned build caches"
-                    " or -k <key hash> to pick a key")
+        bindist.build_tarball(spec, outdir, force,
+                              relative, yes_to_all, signkey)
 
 
 def installtarball(args):
@@ -278,18 +264,8 @@ def install_tarball(spec, args):
         tarball = bindist.download_tarball(spec)
         if tarball:
             tty.msg('Installing buildcache for spec %s' % spec.format())
-            try:
-                bindist.extract_tarball(spec, tarball, yes_to_all, force)
-            except NoOverwriteException as e:
-                tty.warn("%s exists. use -f to force overwrite." % e.args)
-            except NoVerifyException:
-                tty.die("Package spec file failed signature verification,"
-                        " use -y flag to install build cache")
-            except NoChecksumException:
-                tty.die("Package tarball failed checksum verification,"
-                        " use -y flag to install build cache")
-            finally:
-                spack.store.db.reindex(spack.store.layout)
+            bindist.extract_tarball(spec, tarball, yes_to_all, force)
+            spack.store.db.reindex(spack.store.layout)
         else:
             tty.die('Download of binary cache file for spec %s failed.' %
                     spec.format())


### PR DESCRIPTION
Extracts error messages from the implementation of `buildcache.py` and moves them to the exception itself. Otherwise, using `spack install --use-cache` may hit an exception without reporting any error message. Example:

```
spack install --use-cache python
```

It tries to install python from binaries, if no gpg key was used it raises a `NoVerificationException` and the user just getsan error message without description: `==> Error: `

This PR avoids to handle these exceptions also when using `--use-cache` during the `install` command and makes them consistent with the rest of exceptions.

@gartung