### PR TITLE
Fix to allow installing pocl 0.14 again

### DIFF
--- a/var/spack/repos/builtin/packages/pocl/package.py
+++ b/var/spack/repos/builtin/packages/pocl/package.py
@@ -91,7 +91,7 @@ class Pocl(CMakePackage):
 
     @run_after('install')
     def symlink_opencl(self):
-        os.symlink("CL", os.path.join(self.prefix.include, "OpenCL"))
+        os.symlink("CL", self.prefix.include.OpenCL)
 
     @run_after('install')
     @on_package_attributes(run_tests=True)

--- a/var/spack/repos/builtin/packages/pocl/package.py
+++ b/var/spack/repos/builtin/packages/pocl/package.py
@@ -91,8 +91,7 @@ class Pocl(CMakePackage):
 
     @run_after('install')
     def symlink_opencl(self):
-        with working_dir(self.build_directory):
-            os.symlink("OpenCL", join_path(self.prefix.include, "CL"))
+        os.symlink("CL", os.path.join(self.prefix.include, "OpenCL"))
 
     @run_after('install')
     @on_package_attributes(run_tests=True)


### PR DESCRIPTION
This PR fixes issue #4669 by properly arranging source and destination of the symlink which is generated and hence makes a pocl 0.14 installation possible again.