### PR TITLE
zoltan: add optional dependency on parmetis

### DIFF
--- a/var/spack/repos/builtin/packages/zoltan/package.py
+++ b/var/spack/repos/builtin/packages/zoltan/package.py
@@ -53,8 +53,13 @@ class Zoltan(Package):
 
     variant('fortran', default=True, description='Enable Fortran support.')
     variant('mpi', default=True, description='Enable MPI support.')
+    variant('parmetis', default=False, description='Enable ParMETIS support.')
 
     depends_on('mpi', when='+mpi')
+
+    depends_on('parmetis@4:', when='+parmetis')
+
+    conflicts('+parmetis', when='~mpi')
 
     def install(self, spec, prefix):
         # FIXME: The older Zoltan versions fail to compile the F90 MPI wrappers
@@ -79,6 +84,13 @@ class Zoltan(Package):
             config_cflags.append(self.compiler.pic_flag)
             if spec.satisfies('%gcc'):
                 config_args.append('--with-libs={0}'.format('-lgfortran'))
+
+        if '+parmetis' in spec:
+            config_args.append('--with-parmetis')
+            config_args.append('--with-parmetis-libdir={0}'
+                               .format(spec['parmetis'].prefix.lib))
+            config_args.append('--with-parmetis-incdir={0}'
+                               .format(spec['parmetis'].prefix.include))
 
         if '+mpi' in spec:
             config_args.append('CC={0}'.format(spec['mpi'].mpicc))


### PR DESCRIPTION
add parmetis support to zoltan for use of multi-level graph based partitioning procedures