### PR TITLE
Fix HTML detection

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -276,7 +276,8 @@ class URLFetchStrategy(FetchStrategy):
         # Check if we somehow got an HTML file rather than the archive we
         # asked for.  We only look at the last content type, to handle
         # redirects properly.
-        content_types = re.findall(r'Content-Type:[^\r\n]+', headers)
+        content_types = re.findall(r'Content-Type:[^\r\n]+', headers,
+                                   flags=re.IGNORECASE)
         if content_types and 'text/html' in content_types[-1]:
             tty.warn("The contents of ",
                      (self.archive_file if self.archive_file is not None


### PR DESCRIPTION
Some servers report a `content-type` header instead of `Content-Type`:

```
HTTP/1.1 302 Found
Server: nginx/1.12.2
Date: Tue, 21 Nov 2017 09:32:49 GMT
Content-Type: text/html; charset=iso-8859-1
Content-Length: 325
Connection: keep-alive
Location: https://www.open-mpi.org/software/ompi/v3.0/downloads/openmpi-3.0.0.tar.bz2

HTTP/2 200 
server: nginx/1.12.2
date: Tue, 21 Nov 2017 09:32:50 GMT
content-type: application/x-tar
content-length: 9267606
last-modified: Wed, 13 Sep 2017 03:15:44 GMT
accept-ranges: bytes
```

Should fix #6347.