### PR TITLE
 ViennaRNA: adding version 2.4.3 + disable swig

### DIFF
--- a/var/spack/repos/builtin/packages/viennarna/package.py
+++ b/var/spack/repos/builtin/packages/viennarna/package.py
@@ -55,7 +55,7 @@ class Viennarna(AutotoolsPackage):
         args = self.enable_or_disable('sse')
         args += self.with_or_without('python')
         args += self.with_or_without('perl')
-        args.append('--without-swig')
+        args.append('--without-swig', when='@2.4.3')
 
         if 'python@3:' in self.spec:
             args.append('--with-python3')

--- a/var/spack/repos/builtin/packages/viennarna/package.py
+++ b/var/spack/repos/builtin/packages/viennarna/package.py
@@ -55,7 +55,7 @@ class Viennarna(AutotoolsPackage):
         args = self.enable_or_disable('sse')
         args += self.with_or_without('python')
         args += self.with_or_without('perl')
-	args.append('--without-swig')
+        args.append('--without-swig')
 
         if 'python@3:' in self.spec:
             args.append('--with-python3')

--- a/var/spack/repos/builtin/packages/viennarna/package.py
+++ b/var/spack/repos/builtin/packages/viennarna/package.py
@@ -32,8 +32,9 @@ class Viennarna(AutotoolsPackage):
     """
 
     homepage = "https://www.tbi.univie.ac.at/RNA/"
-    url      = "https://www.tbi.univie.ac.at/RNA/download/sourcecode/2_3_x/ViennaRNA-2.3.5.tar.gz"
+    url      = "https://www.tbi.univie.ac.at/RNA/download/sourcecode/2_4_x/ViennaRNA-2.4.3.tar.gz"
 
+    version('2.4.3', '41be2fd36a5323a35ed50debfc7bd118')
     version('2.3.5', '4542120adae9b7abb605e2304c2a1326')
 
     variant('sse', default=True, description='Enable SSE in order to substantially speed up execution')
@@ -54,6 +55,7 @@ class Viennarna(AutotoolsPackage):
         args = self.enable_or_disable('sse')
         args += self.with_or_without('python')
         args += self.with_or_without('perl')
+	args.append('--without-swig')
 
         if 'python@3:' in self.spec:
             args.append('--with-python3')

--- a/var/spack/repos/builtin/packages/viennarna/package.py
+++ b/var/spack/repos/builtin/packages/viennarna/package.py
@@ -55,7 +55,8 @@ class Viennarna(AutotoolsPackage):
         args = self.enable_or_disable('sse')
         args += self.with_or_without('python')
         args += self.with_or_without('perl')
-        args.append('--without-swig', when='@2.4.3')
+        if self.spec.satisfies('@2.4.3:'):
+            args.append('--without-swig')
 
         if 'python@3:' in self.spec:
             args.append('--with-python3')


### PR DESCRIPTION
Adding a later version of ViennaRNA package.

I did have to disable the swig bits, due to missing file dependencies.