### PR TITLE
py-yt: Yt-project is moved. Add new version.

### DIFF
--- a/var/spack/repos/builtin/packages/py-yt/package.py
+++ b/var/spack/repos/builtin/packages/py-yt/package.py
@@ -53,7 +53,7 @@ class PyYt(PythonPackage):
             tag="yt-3.0.2", commit="511887af4c995a78fe606e58ce8162c88380ecdc")
     version("2.6.3", hg="https://bitbucket.org/yt_analysis/yt",
             tag="yt-2.6.3", commit="816186f16396a16853810ac9ebcde5057d8d5b1a")
-    version("development", git="https://github.com/yt-project/yt.git",
+    version("develop", git="https://github.com/yt-project/yt.git",
             branch="master")
 
     variant("astropy", default=True, description="enable astropy support")

--- a/var/spack/repos/builtin/packages/py-yt/package.py
+++ b/var/spack/repos/builtin/packages/py-yt/package.py
@@ -35,8 +35,10 @@ class PyYt(PythonPackage):
        interdisciplinary community.
     """
     homepage = "http://yt-project.org"
-    url = "https://bitbucket.org/yt_analysis/yt"
+    url = "https://github.com/yt-project/yt.git"
 
+    version("3.4.0", "413b835f1b0e2a0bd26f1044ff7dbc94",
+            url="https://github.com/yt-project/yt/archive/yt-3.4.0.tar.gz")
     version("3.3.5", "2ad314ff3d3261e41825d15db027b0e7",
             url="https://bitbucket.org/yt_analysis/yt/get/yt-3.3.5.tar.gz")
     version("3.3.4", "3a84e56dfd82f9dd923f3fb8490e679c",
@@ -51,8 +53,8 @@ class PyYt(PythonPackage):
             tag="yt-3.0.2", commit="511887af4c995a78fe606e58ce8162c88380ecdc")
     version("2.6.3", hg="https://bitbucket.org/yt_analysis/yt",
             tag="yt-2.6.3", commit="816186f16396a16853810ac9ebcde5057d8d5b1a")
-    version("development", hg="https://bitbucket.org/yt_analysis/yt",
-            branch="yt")
+    version("development", git="https://github.com/yt-project/yt.git",
+            branch="master")
 
     variant("astropy", default=True, description="enable astropy support")
     variant("h5py", default=True, description="enable h5py support")


### PR DESCRIPTION
Yt-Project is now on Github instead of Bitbucket. 
- Change url and development url.
- Add v3.4.0