### PR TITLE
intel and intel-parallel-studio: fix version 2015

### DIFF
--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -61,6 +61,11 @@ class IntelPackage(PackageBase):
     #: system base class
     build_system_class = 'IntelPackage'
 
+    #: By default, we assume that all Intel software can have a desired
+    #: architecture specified. This can be overridden for packages that do
+    #: not support multiple architectures.
+    arch_required = True
+
     #: By default, we assume that all Intel software requires a license.
     #: This can be overridden for packages that do not require a license.
     license_required = True
@@ -150,11 +155,16 @@ class IntelPackage(PackageBase):
             # Perform validation of digital signatures of RPM files,
             # valid values are: {yes, no}
             'SIGNING_ENABLED': 'no',
-
-            # Select target architecture of your applications,
-            # valid values are: {IA32, INTEL64, ALL}
-            'ARCH_SELECTED': 'ALL',
         }
+
+        # Not all Intel software supports multiple architectures. Trying to
+        # specify one anyway will cause the installation to fail.
+        if self.arch_required:
+            config.update({
+                # Select target architecture of your applications,
+                # valid values are: {IA32, INTEL64, ALL}
+                'ARCH_SELECTED': 'ALL',
+            })
 
         # Not all Intel software requires a license. Trying to specify
         # one anyway will cause the installation to fail.

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -457,11 +457,6 @@ class IntelParallelStudio(IntelPackage):
         """Newer versions of Intel Parallel Studio have a bug in the
         ``psxevars.sh`` script."""
 
-        if self.spec.satisfies('@professional.0:professional.2015.7') or \
-           self.spec.satisfies('@cluster.0:cluster.2015.7') or \
-           self.spec.satisfies('@composer.0:composer.2015.7'):
-            return
-
         bindir = glob.glob(join_path(
             self.prefix, 'parallel_studio*', 'bin'))[0]
 

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -98,6 +98,10 @@ class IntelParallelStudio(IntelPackage):
             url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/8469/parallel_studio_xe_2015_update6.tgz')
     version('composer.2015.6',      'da9f8600c18d43d58fba0488844f79c9',
             url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/8432/l_compxe_2015.6.233.tgz')
+    version('professional.2015.1', '542b78c86beff9d7b01076a7be9c6ddc',
+            url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/4992/parallel_studio_xe_2015_update1.tgz')
+    version('cluster.2015.1',      '542b78c86beff9d7b01076a7be9c6ddc',
+            url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/4992/parallel_studio_xe_2015_update1.tgz')
     version('composer.2015.1',      '85beae681ae56411a8e791a7c44a5c0a',
             url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/4933/l_compxe_2015.1.133.tgz')
 
@@ -409,7 +413,9 @@ class IntelParallelStudio(IntelPackage):
     @property
     def arch_required(self):
         # Composer 2015 doesn't support specifying an architecture
-        if self.spec.satisfies('@composer.0:composer.2015.7'):
+        if self.spec.satisfies('@professional.0:professional.2015.7') or \
+            self.spec.satisfies('@cluster.0:cluster.2015.7') or \
+            self.spec.satisfies('@composer.0:composer.2015.7'):
             return False
         else:
             return True
@@ -451,7 +457,9 @@ class IntelParallelStudio(IntelPackage):
         """Newer versions of Intel Parallel Studio have a bug in the
         ``psxevars.sh`` script."""
 
-        if self.spec.satisfies('@composer.0:composer.2015.7'):
+        if self.spec.satisfies('@professional.0:professional.2015.7') or \
+            self.spec.satisfies('@cluster.0:cluster.2015.7') or \
+            self.spec.satisfies('@composer.0:composer.2015.7'):
             return
 
         bindir = glob.glob(join_path(

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -161,7 +161,12 @@ class IntelParallelStudio(IntelPackage):
     conflicts('+clck',      when='@composer.0:composer.9999')
     conflicts('+inspector', when='@composer.0:composer.9999')
     conflicts('+itac',      when='@composer.0:composer.9999')
+    conflicts('+mpi',       when='@composer.0:composer.9999')
     conflicts('+vtune',     when='@composer.0:composer.9999')
+    # The following components are not available before 2016
+    conflicts('+daal',      when='@professional.0:professional.2015.7')
+    conflicts('+daal',      when='@cluster.0:cluster.2015.7')
+    conflicts('+daal',      when='@composer.0:composer.2015.7')
 
     @property
     def blas_libs(self):

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -412,10 +412,10 @@ class IntelParallelStudio(IntelPackage):
 
     @property
     def arch_required(self):
-        # Composer 2015 doesn't support specifying an architecture
+        # version 2015 doesn't support specifying an architecture
         if self.spec.satisfies('@professional.0:professional.2015.7') or \
-            self.spec.satisfies('@cluster.0:cluster.2015.7') or \
-            self.spec.satisfies('@composer.0:composer.2015.7'):
+           self.spec.satisfies('@cluster.0:cluster.2015.7') or \
+           self.spec.satisfies('@composer.0:composer.2015.7'):
             return False
         else:
             return True
@@ -458,8 +458,8 @@ class IntelParallelStudio(IntelPackage):
         ``psxevars.sh`` script."""
 
         if self.spec.satisfies('@professional.0:professional.2015.7') or \
-            self.spec.satisfies('@cluster.0:cluster.2015.7') or \
-            self.spec.satisfies('@composer.0:composer.2015.7'):
+           self.spec.satisfies('@cluster.0:cluster.2015.7') or \
+           self.spec.satisfies('@composer.0:composer.2015.7'):
             return
 
         bindir = glob.glob(join_path(

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -98,6 +98,8 @@ class IntelParallelStudio(IntelPackage):
             url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/8469/parallel_studio_xe_2015_update6.tgz')
     version('composer.2015.6',      'da9f8600c18d43d58fba0488844f79c9',
             url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/8432/l_compxe_2015.6.233.tgz')
+    version('composer.2015.1',      '85beae681ae56411a8e791a7c44a5c0a',
+            url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/4933/l_compxe_2015.1.133.tgz')
 
     # Generic Variants
     variant('rpath',    default=True,
@@ -274,6 +276,8 @@ class IntelParallelStudio(IntelPackage):
             # Common files
             'intel-comp-',
             'intel-openmp',
+            'intel-compxe',
+            'intel-compilerpro',
 
             # C/C++
             'intel-icc',
@@ -397,6 +401,14 @@ class IntelParallelStudio(IntelPackage):
 
         return [os.path.join(dir, 'license.lic') for dir in directories]
 
+    @property
+    def arch_required(self):
+        # Composer 2015 doesn't support specifying an architecture
+        if self.spec.satisfies('@composer.0:composer.2015.7'):
+            return False
+        else:
+            return True
+
     @run_after('install')
     def filter_compiler_wrappers(self):
         spec = self.spec
@@ -433,6 +445,9 @@ class IntelParallelStudio(IntelPackage):
     def fix_psxevars(self):
         """Newer versions of Intel Parallel Studio have a bug in the
         ``psxevars.sh`` script."""
+
+        if self.spec.satisfies('@composer.0:composer.2015.7'):
+            return
 
         bindir = glob.glob(join_path(
             self.prefix, 'parallel_studio*', 'bin'))[0]

--- a/var/spack/repos/builtin/packages/intel/package.py
+++ b/var/spack/repos/builtin/packages/intel/package.py
@@ -51,6 +51,10 @@ class Intel(IntelPackage):
             url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9063/parallel_studio_xe_2016_composer_edition_update3.tgz')
     version('16.0.2', '1133fb831312eb519f7da897fec223fa',
             url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/8680/parallel_studio_xe_2016_composer_edition_update2.tgz')
+    version('15.0.6', 'da9f8600c18d43d58fba0488844f79c9',
+            url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/8432/l_compxe_2015.6.233.tgz')
+    version('15.0.1', '85beae681ae56411a8e791a7c44a5c0a',
+            url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/4933/l_compxe_2015.1.133.tgz')
 
     variant('rpath', default=True, description='Add rpath to .cfg files')
 
@@ -58,6 +62,8 @@ class Intel(IntelPackage):
         # Common files
         'intel-comp-',
         'intel-openmp',
+        'intel-compxe',
+        'intel-compilerpro',
 
         # C/C++
         'intel-icc',
@@ -68,19 +74,41 @@ class Intel(IntelPackage):
 
     @property
     def license_files(self):
-        return [
-            'Licenses/license.lic',
-            join_path('compilers_and_libraries', 'linux', 'bin',
-                      'intel64', 'license.lic')
-        ]
+        if self.spec.satisfies('@composer.0:composer.2015.7'):
+            icc_path = os.path.realpath(join_path(self.prefix, 'bin', 'icc'))
+            directories = [
+                join_path(os.path.dirname(icc_path), '..', '..', 'Licenses')
+            ]
+        else:
+            directories = [
+                'Licenses',
+                join_path('compilers_and_libraries', 'linux', 'bin',
+                          'intel64')
+            ]
+
+        return [os.path.join(dir, 'license.lic') for dir in directories]
+
+    @property
+    def arch_required(self):
+        # Composer 2015 doesn't support specifying an architecture
+        if self.spec.satisfies('@composer.0:composer.2015.7'):
+            return False
+        else:
+            return True
 
     @run_after('install')
     def rpath_configuration(self):
         if '+rpath' in self.spec:
-            bin_dir = join_path(self.prefix, 'compilers_and_libraries',
-                                'linux', 'bin', 'intel64')
-            lib_dir = join_path(self.prefix, 'compilers_and_libraries',
-                                'linux', 'compiler', 'lib', 'intel64_lin')
+            if self.spec.satisfies('@composer.0:composer.2015.7'):
+                icc_path = os.path.realpath(join_path(self.prefix, 'bin',
+                                                      'icc'))
+                bin_dir = os.path.dirname(icc_path)
+                lib_dir = join_path(self.prefix, 'lib', 'intel64')
+            else:
+                bin_dir = join_path(self.prefix, 'compilers_and_libraries',
+                                    'linux', 'bin', 'intel64')
+                lib_dir = join_path(self.prefix, 'compilers_and_libraries',
+                                    'linux', 'compiler', 'lib', 'intel64_lin')
             for compiler in ['icc', 'icpc', 'ifort']:
                 cfgfilename = join_path(bin_dir, '{0}.cfg'.format(compiler))
                 with open(cfgfilename, 'w') as f:


### PR DESCRIPTION
- The `ARCH_SELECTED` parameter is not supported.
- The components have different names than in newer versions: `intel-compxe`, `intel-compilerproc`, `intel-compilerf`.
- The psxevars.sh fix doesn't apply because the directory doesn't exist.
- The installation path is different and contains version numbers.
- Also, I added version 2015.1.133 because that's what I needed.