### PR TITLE
spack spec: simplified output

### DIFF
--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -62,7 +62,6 @@ def spec(parser, args):
     name_fmt = '$.' if args.namespaces else '$_'
     kwargs = {'cover': args.cover,
               'format': name_fmt + '$@$%@+$+$=',
-              'hashes': args.long or args.very_long,
               'hashlen': None if args.very_long else 7,
               'show_types': args.types,
               'install_status': args.install_status}
@@ -75,16 +74,12 @@ def spec(parser, args):
             print(spec.to_yaml())
             continue
 
-        # Print some diagnostic info by default.
+        kwargs['hashes'] = False  # Always False for input spec
         print("Input spec")
         print("--------------------------------")
         print(spec.tree(**kwargs))
 
-        print("Normalized")
-        print("--------------------------------")
-        spec.normalize()
-        print(spec.tree(**kwargs))
-
+        kwargs['hashes'] = args.long or args.very_long
         print("Concretized")
         print("--------------------------------")
         spec.concretize()


### PR DESCRIPTION
Showing "Normalized" in the output doesn't give users additional information, as this step is essentially an implementation detail of concretization. This PR skips it and shows just the input spec and the concretized one. Printing partial hashes for input spec has been disabled.

##### Current behavior
```console
$ spack spec -Il hdf5@1.10.1+mpi ^mpich
Input spec
--------------------------------
     hcaag73  hdf5@1.10.1+mpi
     ty5c2nn      ^mpich

Normalized
--------------------------------
     4kdzf64  hdf5@1.10.1+mpi
     ty5c2nn      ^mpich
     j52z7qb      ^zlib@1.1.2:

Concretized
--------------------------------
     7x2qtxi  hdf5@1.10.1%gcc@4.8~cxx~debug~fortran~hl+mpi+pic+shared~szip~threadsafe arch=linux-ubuntu14.04-x86_64 
     i5jrs3r      ^mpich@3.2%gcc@4.8 device=ch3 +hydra netmod=tcp +pmi+romio~verbs arch=linux-ubuntu14.04-x86_64 
[+]  eksallf      ^zlib@1.2.11%gcc@4.8+optimize+pic+shared arch=linux-ubuntu14.04-x86_64 

```

##### After this PR
```console
$ spack spec -Il hdf5@1.10.1+mpi ^mpich
Input spec
--------------------------------
     hdf5@1.10.1+mpi
         ^mpich

Concretized
--------------------------------
     7x2qtxi  hdf5@1.10.1%gcc@4.8~cxx~debug~fortran~hl+mpi+pic+shared~szip~threadsafe arch=linux-ubuntu14.04-x86_64 
     i5jrs3r      ^mpich@3.2%gcc@4.8 device=ch3 +hydra netmod=tcp +pmi+romio~verbs arch=linux-ubuntu14.04-x86_64 
[+]  eksallf      ^zlib@1.2.11%gcc@4.8+optimize+pic+shared arch=linux-ubuntu14.04-x86_64 
```