### PR TITLE
Use long flag in spack help message

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -226,7 +226,7 @@ class SpackArgumentParser(argparse.ArgumentParser):
         # epilog
         formatter.add_text("""\
 {help}:
-  spack help -a          list all available commands
+  spack help --all       list all available commands
   spack help <command>   help on a specific command
   spack help --spec      help on the spec syntax
   spack docs             open http://spack.rtfd.io/ in a browser"""


### PR DESCRIPTION
This has been bothering me more than I'd like to admit. We use the long flag for `spack help --spec` but the short flag for `spack help -a`. This PR fixes that.