### PR TITLE
siesta: add netcdf support

### DIFF
--- a/var/spack/repos/builtin/packages/siesta/configure.patch
+++ b/var/spack/repos/builtin/packages/siesta/configure.patch
@@ -1,0 +1,21 @@
+--- a/Src/configure	2017-11-23 12:42:40.909339915 +0100
++++ b/Src/configure	2017-11-23 12:42:59.911416449 +0100
+@@ -6000,7 +6000,7 @@
+   withval="$with_netcdf"
+ 
+ fi;
+-if test x$with_netcdf != xno; then
++if test "x$with_netcdf" != xno; then
+ 
+ tw_netcdf_ok=no
+ ac_ext=${FC_SRCEXT-f}
+@@ -6069,7 +6069,7 @@
+   LIBS="$save_LIBS"
+ fi
+ if test $tw_netcdf_ok = yes; then
+-  DEFS="$DEFS CDF";NETCDF_INTERFACE="libnetcdf_f90.a"
++  DEFS="$DEFS CDF";
+ else
+   NETCDF_LIBS="";tw_netcdf_ok=no;if test ! -z "$with_netcdf"; then { { echo "$as_me:$LINENO: error: Could not find NetCDF library." >&5
+ echo "$as_me: error: Could not find NetCDF library." >&2;}
+

--- a/var/spack/repos/builtin/packages/siesta/package.py
+++ b/var/spack/repos/builtin/packages/siesta/package.py
@@ -35,10 +35,14 @@ class Siesta(Package):
 
     version('4.0.1', '5cb60ce068f2f6e84fa9184ffca94c08')
 
+    patch('configure.patch')
+
     depends_on('mpi')
     depends_on('blas')
     depends_on('lapack')
     depends_on('scalapack')
+    depends_on('netcdf')
+    depends_on('netcdf-fortran')
 
     phases = ['configure', 'build', 'install']
 
@@ -53,6 +57,8 @@ class Siesta(Package):
                           '--with-blacs=%s' % (spec['scalapack'].libs +
                                                spec['blas'].libs),
                           '--with-scalapack=%s' % spec['scalapack'].libs,
+                          '--with-netcdf=%s' % (spec['netcdf-fortran'].libs +
+                                                spec['netcdf'].libs),
                           # need to specify MPIFC explicitly below, otherwise
                           # Intel's mpiifort is not found
                           'MPIFC=%s' % spec['mpi'].mpifc


### PR DESCRIPTION
This is a follow-up to #6346 to add NetCDF support.

While technically it is an optional dependency, the Siesta documentation recommends its use because it makes a number of additional features available and speeds up others. So I decided not to make this a Spack variant but a hard dependency.

The configure script has trouble when multiple libraries are specified with `--with-netcdf`, so I had to include a patch. This patch also removes an outdated reference to `libnetcdf_f90.a` from the generated configuration, which otherwise causes build errors.