### PR TITLE
boost@1.54 also needs the call_once patch

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -158,7 +158,7 @@ class Boost(Package):
     patch('xl_1_62_0_le.patch', when='@1.62.0%xl')
 
     # Patch fix from https://svn.boost.org/trac/boost/ticket/10125
-    patch('call_once_variadic.patch', when='@1.55.0:1.55.9999%gcc@5.0:5.9')
+    patch('call_once_variadic.patch', when='@1.54.0:1.55.9999%gcc@5.0:5.9')
 
     # Patch fix for PGI compiler
     patch('boost_1.63.0_pgi.patch', when='@1.63.0%pgi')


### PR DESCRIPTION
boost@1.54.0 won't build with gcc@5.4.0 without the same bit of patchery that fixes 1.55.0.

e.g. (from around line 40046 of my build.out)

```
[...]
libs/thread/src/pthread/thread.cpp: In function ‘boost::detail::thread_data_base* boost::detail::get_current_thread_data()’:
libs/thread/src/pthread/thread.cpp:140:88: error: no matching function for call to ‘call_once(boost::once_flag&, void (&)())’
             boost::call_once(current_thread_tls_init_flag,create_current_thread_tls_key);
[...]
```

This PR just changes a 5 to a 4 ("You're not paying me to change one character, you paying me to know what character to change.  Wait, you're not paying me at all...").

boost@1.54.0 and boost@1.55.0 both build with gcc@5.4.0 on a CentOS 7 DO droplet.