### PR TITLE
'spack install' conflict messages are as verbose as 'spack spec'

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -127,7 +127,12 @@ def parse_specs(args, **kwargs):
         sys.exit(1)
 
     except spack.spec.SpecError as e:
-        tty.error(e.message)
+
+        msgs = [e.message]
+        if e.long_message:
+            msgs.append(e.long_message)
+
+        tty.error(*msgs)
         sys.exit(1)
 
 

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -33,7 +33,7 @@ import llnl.util.filesystem as fs
 import spack
 import spack.cmd.install
 from spack.spec import Spec
-from spack.main import SpackCommand
+from spack.main import SpackCommand, SpackCommandError
 
 install = SpackCommand('install')
 
@@ -234,3 +234,14 @@ def test_install_overwrite(
     assert os.path.exists(spec.prefix)
     assert fs.hash_directory(spec.prefix) == expected_md5
     assert fs.hash_directory(spec.prefix) != bad_md5
+
+
+@pytest.mark.usefixtures(
+    'builtin_mock', 'mock_archive', 'mock_fetch', 'config', 'install_mockery',
+)
+def test_install_conflicts(conflict_spec):
+    # Make sure that spec with conflicts exit with 1
+    with pytest.raises(SpackCommandError):
+        install(conflict_spec)
+
+    assert install.returncode == 1

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -94,19 +94,6 @@ def spec(request):
     return request.param
 
 
-@pytest.fixture(
-    params=[
-        'conflict%clang',
-        'conflict%clang+foo',
-        'conflict-parent%clang',
-        'conflict-parent@0.9^conflict~foo'
-    ]
-)
-def conflict_spec(request):
-    """Spec to be concretized"""
-    return request.param
-
-
 @pytest.mark.usefixtures('config', 'builtin_mock')
 class TestConcretize(object):
     def test_concretize(self, spec):

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -690,3 +690,20 @@ class MockPackageMultiRepo(object):
         import collections
         Repo = collections.namedtuple('Repo', ['namespace'])
         return Repo('mockrepo')
+
+##########
+# Specs of various kind
+##########
+
+
+@pytest.fixture(
+    params=[
+        'conflict%clang',
+        'conflict%clang+foo',
+        'conflict-parent%clang',
+        'conflict-parent@0.9^conflict~foo'
+    ]
+)
+def conflict_spec(request):
+    """Spec that will raise a conflict during concretization."""
+    return request.param

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -705,5 +705,7 @@ class MockPackageMultiRepo(object):
     ]
 )
 def conflict_spec(request):
-    """Spec that will raise a conflict during concretization."""
+    """Specs which violate constraints specified with the "conflicts"
+    directive in the "conflict" package.
+    """
     return request.param


### PR DESCRIPTION
fixes #6430
fixes #6001

With respect to the test case in #6430 :
```console
$ spack install visit
==> Error: Conflicts in concretized spec "visit@2.12.2%gcc@4.8 build_type=RelWithDebInfo arch=linux-ubuntu14.04-x86_64 /os5zygv"

  List of matching conflicts for spec:

    netcdf@4.4.1.1%gcc@4.8~dap~hdf4 maxdims=1024 maxvars=8192 +mpi~parallel-netcdf+shared arch=linux-ubuntu14.04-x86_64 
        ^hdf5@1.10.1%gcc@4.8~cxx~debug~fortran+hl~mpi+pic+shared~szip~threadsafe arch=linux-ubuntu14.04-x86_64 
            ^zlib@1.2.11%gcc@4.8+optimize+pic+shared arch=linux-ubuntu14.04-x86_64 
        ^m4@1.4.18%gcc@4.8 patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00 +sigsegv arch=linux-ubuntu14.04-x86_64 
            ^libsigsegv@2.11%gcc@4.8 arch=linux-ubuntu14.04-x86_64 
        ^openmpi@3.0.0%gcc@4.8~cuda fabrics= ~java schedulers= ~sqlite3~thread_multiple~ucx+vt arch=linux-ubuntu14.04-x86_64 
            ^hwloc@1.11.8%gcc@4.8~cuda+libxml2+pci arch=linux-ubuntu14.04-x86_64 
                ^libpciaccess@0.13.5%gcc@4.8 arch=linux-ubuntu14.04-x86_64 
                    ^libtool@2.4.6%gcc@4.8 arch=linux-ubuntu14.04-x86_64 
                    ^pkgconf@1.3.10%gcc@4.8 arch=linux-ubuntu14.04-x86_64 
                    ^util-macros@1.19.1%gcc@4.8 arch=linux-ubuntu14.04-x86_64 
                ^libxml2@2.9.4%gcc@4.8~python arch=linux-ubuntu14.04-x86_64 
                    ^xz@5.2.3%gcc@4.8 arch=linux-ubuntu14.04-x86_64 

1. "+mpi" conflicts with "netcdf^hdf5~mpi" [netcdf+mpi requires hdf5+mpi]
``` 