### PR TITLE
pocl: fix link to libtool

### DIFF
--- a/var/spack/repos/builtin/packages/pocl/package.py
+++ b/var/spack/repos/builtin/packages/pocl/package.py
@@ -57,7 +57,7 @@ class Pocl(CMakePackage):
 
     depends_on("cmake @2.8.12:", type="build")
     depends_on("hwloc")
-    depends_on("libtool", type=("build", "run"))
+    depends_on("libtool", type=("build", "link", "run"))
     # We don't request LLVM's shared libraries because these are not
     # enabled by default, and also because they fail to build for us
     # (see #1616)


### PR DESCRIPTION
Follow-up to #6372: `libtool` is also needed for linking, otherwise downstream dependencies such as `clfft` will fail linking against pocl's libOpenCL.so with errors such as:

```
  >> 182   /usr/bin/ld: warning: libltdl.so.7, needed by /usr/local/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/pocl-0.14-rwo73qzkcxfupndxoz3pcl2s34o5pt6i/lib/libOpenCL.so, not found (try using -rpath or -rpath-link)
  >> 183   /usr/local/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/pocl-0.14-rwo73qzkcxfupndxoz3pcl2s34o5pt6i/lib/libOpenCL.so: undefined reference to `lt_dlinit'
  >> 184   /usr/local/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/pocl-0.14-rwo73qzkcxfupndxoz3pcl2s34o5pt6i/lib/libOpenCL.so: undefined reference to `lt_dlerror'
  >> 185   /usr/local/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/pocl-0.14-rwo73qzkcxfupndxoz3pcl2s34o5pt6i/lib/libOpenCL.so: undefined reference to `lt_dlopen'
  >> 186   /usr/local/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/pocl-0.14-rwo73qzkcxfupndxoz3pcl2s34o5pt6i/lib/libOpenCL.so: undefined reference to `lt_dlsym'
  >> 187   collect2: error: ld returned 1 exit status
```

ccing @mfherbst