### PR TITLE
gearshifft: enable clFFT

### DIFF
--- a/var/spack/repos/builtin/packages/gearshifft/package.py
+++ b/var/spack/repos/builtin/packages/gearshifft/package.py
@@ -35,8 +35,8 @@ class Gearshifft(CMakePackage):
 
     variant('cufft', default=True,
             description='Compile gearshifft_cufft')
-    # variant('clfft', default=True,
-    #         description='Compile gearshifft_clfft')
+    variant('clfft', default=True,
+            description='Compile gearshifft_clfft')
     variant('fftw', default=True,
             description='Compile gearshifft_fftw')
     variant('openmp', default=True,
@@ -48,8 +48,8 @@ class Gearshifft(CMakePackage):
     depends_on('cmake@2.8.0:', type='build')
     depends_on('boost@1.56.0:')
     depends_on('cuda@8.0:', when='+cufft')
-    # depends_on('opencl@1.2:', when='+clfft')
-    # depends_on('clfft@2.12.0:', when='+clfft')
+    depends_on('opencl@1.2:', when='+clfft')
+    depends_on('clfft@2.12.0:', when='+clfft')
     depends_on('fftw@3.3.4:~mpi~openmp', when='+fftw~openmp')
     depends_on('fftw@3.3.4:~mpi+openmp', when='+fftw+openmp')
 
@@ -67,8 +67,8 @@ class Gearshifft(CMakePackage):
             '-DGEARSHIFFT_FFTW_OPENMP:BOOL={0}'.format((
                 'ON' if '+openmp' in spec else 'OFF')),
             '-DGEARSHIFFT_CUFFT:BOOL={0}'.format((
-                'ON' if '+cufft' in spec else 'OFF'))
-            # '-DGEARSHIFFT_CLFFT:BOOL={0}'.format((
-            #     'ON' if '+clfft' in spec else 'OFF'))
+                'ON' if '+cufft' in spec else 'OFF')),
+            '-DGEARSHIFFT_CLFFT:BOOL={0}'.format((
+                'ON' if '+clfft' in spec else 'OFF'))
         ])
         return args


### PR DESCRIPTION
With pocl builds fixed in #6372 and #6440, we can now also use the OpenCL implementations in gearshifft :)

ccing @tdd11235813 @psteinb

### Usage

```bash
spack install gearshifft
spack load gearshifft
```

and instead of the default `+cufft +clfft +fftw +openmp` you can also specify to install and load the arguments `gearshifft ~cufft ~fftw` etc. instead to disable some features.