### PR TITLE
Implement opencv libs property

### DIFF
--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -229,3 +229,10 @@ class Opencv(CMakePackage):
             ])
 
         return args
+
+    @property
+    def libs(self):
+        shared = "+shared" in self.spec
+        return find_libraries(
+            "libopencv_*", root=self.prefix, shared=shared, recurse=True
+        )


### PR DESCRIPTION
The libraries in opencv are only prefixed with "opencv_" but not called "opencv.*.so", so the default `libs` handler from `spec.py` does not collect the opencv libraries properly.