### PR TITLE
Adds license test [donotmerge]

### DIFF
--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 ##############################################################################
 # Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.

--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -7,7 +7,7 @@
 # LLNL-CODE-647188
 #
 # For details, see https://github.com/spack/spack
-# Please also see the LICENSE file for our notice and the LGPL.
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License (as

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -3,24 +3,24 @@
 # Produced at the Lawrence Livermore National Laboratory.
 #
 # This file is part of Spack.
-# Written by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
 # LLNL-CODE-647188
 #
 # For details, see https://github.com/spack/spack
-# Please also see the LICENSE file for our notice and the LGPL.
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
 #
 # This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License (as published by
-# the Free Software Foundation) version 2.1 dated February 1999.
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
 #
 # This program is distributed in the hope that it will be useful, but
 # WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
-# conditions of the GNU General Public License for more details.
+# conditions of the GNU Lesser General Public License for more details.
 #
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import argparse
 

--- a/lib/spack/spack/cmd/clone.py
+++ b/lib/spack/spack/cmd/clone.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.
 #
 # This file is part of Spack.
@@ -7,7 +7,7 @@
 # LLNL-CODE-647188
 #
 # For details, see https://github.com/spack/spack
-# Please also see the LICENSE file for our notice and the LGPL.
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License (as

--- a/lib/spack/spack/cmd/dependencies.py
+++ b/lib/spack/spack/cmd/dependencies.py
@@ -7,7 +7,7 @@
 # LLNL-CODE-647188
 #
 # For details, see https://github.com/spack/spack
-# Please also see the LICENSE file for our notice and the LGPL.
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License (as

--- a/lib/spack/spack/compilers/xl_r.py
+++ b/lib/spack/spack/compilers/xl_r.py
@@ -1,10 +1,9 @@
 ##############################################################################
-# Copyright (c) 2016, International Business Machines Corporation
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
 #
 # This file is part of Spack.
-# Created by Serban Maerean, serban@us.ibm.com based on a similar file,
-# spack/lib/spack/spack/compilers/xl.py, produced by Todd Gamblin,
-# tgamblin@llnl.gov, All rights reserved.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
 # LLNL-CODE-647188
 #
 # For details, see https://github.com/spack/spack

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -1,4 +1,4 @@
-#
+##############################################################################
 # Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.
 #
@@ -21,7 +21,7 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-#
+##############################################################################
 """
 Fetch strategies are used to download source code into a staging area
 in order to build it.  They need to define the following methods:

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.
 #
 # This file is part of Spack.
@@ -7,7 +7,7 @@
 # LLNL-CODE-647188
 #
 # For details, see https://github.com/spack/spack
-# Please also see the LICENSE file for our notice and the LGPL.
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License (as

--- a/lib/spack/spack/repository.py
+++ b/lib/spack/spack/repository.py
@@ -987,7 +987,14 @@ class Repo(object):
             # e.g., spack.pkg.builtin.mpich
             fullname = "%s.%s" % (self.full_namespace, pkg_name)
 
-            module = imp.load_source(fullname, file_path)
+            try:
+                module = imp.load_source(fullname, file_path)
+            except SyntaxError as e:
+                # SyntaxError strips the path from the filename so we need to
+                # manually construct the error message in order to give the
+                # user the correct package.py where the syntax error is located
+                raise SyntaxError('invalid syntax in {0:}, line {1:}'
+                                  ''.format(file_path, e.lineno))
             module.__package__ = self.full_namespace
             module.__loader__ = self
             self._modules[pkg_name] = module

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -18,9 +18,9 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
 # conditions of the GNU Lesser General Public License for more details.
 #
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 """
 Spack allows very fine-grained control over how packages are installed and

--- a/lib/spack/spack/test/licenses.py
+++ b/lib/spack/spack/test/licenses.py
@@ -43,8 +43,8 @@ def check_license(filepath):
         return f.read().startswith(license)
 
 
-def test_check_licenses():
-    """Check the licenses in all packages"""
+def test_check_licenses_lib():
+    """Check the licenses in all spack files"""
     spack_lib_root = os.path.dirname(inspect.getfile(spack))
     failed_licenses = []
     for root, _, filenames in os.walk(spack_lib_root):
@@ -53,6 +53,18 @@ def test_check_licenses():
                 filepath = os.path.join(root, filename)
                 if not check_license(filepath):
                     failed_licenses.append(filepath)
+    for fl in failed_licenses:
+        tty.msg("{0:} has a changed license, compared to {1:}"
+                "".format(fl, thisfile))
+    assert failed_licenses == []
+
+
+def test_check_licenses_package():
+    """Check the licenses in all packages"""
+    failed_licenses = []
+    for name in spack.repo.all_package_names():
+        if not check_license(spack.repo.filename_for_package_name(name)):
+            failed_licenses.append(spack.repo.filename_for_package_name(name))
     for fl in failed_licenses:
         tty.msg("{0:} has a changed license, compared to {1:}"
                 "".format(fl, thisfile))

--- a/lib/spack/spack/test/licenses.py
+++ b/lib/spack/spack/test/licenses.py
@@ -1,0 +1,59 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+# --- #
+"""This test does checks the license text on all files in spack to be 
+identical to this one here."""
+
+import inspect
+import os
+
+import spack
+import llnl.util.tty as tty
+
+
+thisfile = inspect.getfile(inspect.currentframe())
+with open(thisfile, 'r') as f:
+    license = f.read().split('# --- #')[0]
+
+
+def check_license(filepath):
+    with open(filepath, 'r') as f:
+        return f.read().startswith(license)
+
+
+def test_check_licenses():
+    """Check the licenses in all packages"""
+    spack_lib_root = os.path.dirname(inspect.getfile(spack))
+    failed_licenses = []
+    for root, _, filenames in os.walk(spack_lib_root):
+        for filename in filenames:
+            if filename.endswith('.py'):
+                filepath = os.path.join(root, filename)
+                if not check_license(filepath):
+                    failed_licenses.append(filepath)
+    for fl in failed_licenses:
+        tty.msg("{0:} has a changed license, compared to {1:}"
+                "".format(fl, thisfile))
+    assert failed_licenses == []


### PR DESCRIPTION
This PR would add a check that every file in ```lib/spack``` and every ```package.py``` starts with the same license. The idea came when @junghans fixed the licenses in #6323 and similar which were generated by an older spack (see also #6345 )
Currently there are a lot of packages that have different licenses, I'm not sure whether this is intentional or just a side effect of the development history. The only references to "license" that I could find on readthedocs was to compiler licenses and not spack's own. So I really don't know what the target state should be. If this is completely unwanted feel free to close the PR.

Current state:

- [x] changed all licenses in ```lib/spack```
- [ ] yet to change the ```package.py```

cc: @tgamblin 