### PR TITLE
fix compilation glog's compilation for <= 0.3.4 and added 0.3.5

### DIFF
--- a/var/spack/repos/builtin/packages/glog/package.py
+++ b/var/spack/repos/builtin/packages/glog/package.py
@@ -25,16 +25,30 @@
 from spack import *
 
 
-class Glog(CMakePackage):
+class Glog(Package):
     """C++ implementation of the Google logging module."""
 
     homepage = "https://github.com/google/glog"
-    url      = "https://github.com/google/glog/archive/v0.3.4.tar.gz"
+    url      = "https://github.com/google/glog/archive/v0.3.5.tar.gz"
 
+    version('0.3.5', '5df6d78b81e51b90ac0ecd7ed932b0d4')
     version('0.3.4', 'df92e05c9d02504fb96674bc776a41cb')
     version('0.3.3', 'c1f86af27bd9c73186730aa957607ed0')
 
     depends_on('gflags')
+    depends_on('cmake', when="@0.3.5:")
 
-    def cmake_args(self):
-        return ['-DBUILD_SHARED_LIBS=TRUE']
+    def install(self, spec, prefix):
+        configure('--prefix=%s' % prefix)
+        make
+        make('install')
+
+    @when('@0.3.5:')
+    def install(self, spec, prefix):
+        cmake_args = ['-DBUILD_SHARED_LIBS=TRUE']
+        cmake_args.extend(std_cmake_args)
+
+        with working_dir('spack-build', create=True):
+            cmake('..', *cmake_args)
+            make
+            make('install')


### PR DESCRIPTION
glog < 0.3.5 can't be compiled with CMake as it was only introduced in version 0.3.5. This pull requests supports classic Makefile with version < 0.3.5 and CMake for version >= 0.3.5