### PR TITLE
spack install: restaging is the default

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -71,8 +71,8 @@ the dependencies"""
         '--keep-stage', action='store_true',
         help="don't remove the build stage if installation succeeds")
     subparser.add_argument(
-        '--restage', action='store_true',
-        help="if a partial install is detected, delete prior state")
+        '--dont-restage', action='store_true',
+        help="if a partial install is detected, don't delete prior state")
     subparser.add_argument(
         '--use-cache', action='store_true', dest='use_cache',
         help="check for pre-built Spack packages in mirrors")
@@ -392,7 +392,7 @@ def install(parser, args, **kwargs):
     kwargs.update({
         'keep_prefix': args.keep_prefix,
         'keep_stage': args.keep_stage,
-        'restage': args.restage,
+        'restage': not args.dont_restage,
         'install_source': args.install_source,
         'install_deps': 'dependencies' in args.things_to_install,
         'make_jobs': args.jobs,

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1346,7 +1346,9 @@ class PackageBase(with_metaclass(PackageMeta, object)):
                 # In case the stage directory has already been created,
                 # this ensures it's removed after we checked that the spec
                 # is installed
-                self.stage.destroy()
+                if keep_stage is False:
+                    self.stage.destroy()
+
                 return self._update_explicit_entry_in_db(rec, explicit)
 
         self._do_install_pop_kwargs(kwargs)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1343,6 +1343,10 @@ class PackageBase(with_metaclass(PackageMeta, object)):
                 msg = '{0.name} is already installed in {0.prefix}'
                 tty.msg(msg.format(self))
                 rec = spack.store.db.get_record(self.spec)
+                # In case the stage directory has already been created,
+                # this ensures it's removed after we checked that the spec
+                # is installed
+                self.stage.destroy()
                 return self._update_explicit_entry_in_db(rec, explicit)
 
         self._do_install_pop_kwargs(kwargs)


### PR DESCRIPTION
fixes #5940

This PR changes the option '--restage' of 'spack install' to '--dont-restage', inverting its meaning and the default behavior of the command.