### PR TITLE
Siesta: only apply patch to <4.1 and fix Intel compiler

### DIFF
--- a/var/spack/repos/builtin/packages/siesta/configure.patch
+++ b/var/spack/repos/builtin/packages/siesta/configure.patch
@@ -18,4 +18,36 @@
  else
    NETCDF_LIBS="";tw_netcdf_ok=no;if test ! -z "$with_netcdf"; then { { echo "$as_me:$LINENO: error: Could not find NetCDF library." >&5
  echo "$as_me: error: Could not find NetCDF library." >&2;}
-
+--- a/Util/TBTrans_rep/Makefile	2017-12-08 09:49:02.307877000 +0100
++++ b/Util/TBTrans_rep/Makefile	2017-12-08 09:49:44.385288000 +0100
+@@ -14,7 +14,7 @@
+ # Please see note about Linear-Algebra libraries below
+ #
+ 
+-default: what tbtrans 
++default: what tbtrans_rep 
+ 
+ VPATH:=$(shell pwd)/../../Src
+ OBJDIR=Obj
+@@ -91,16 +91,16 @@
+                           "ARCH_MAKE=../$(ARCH_MAKE)" \
+                           "INCFLAGS=$(LINALG_INCFLAGS)" "FFLAGS=$(FFLAGS:$(IPO_FLAG)=)" $(LINALG))
+ 
+-tbtrans: FPPFLAGS+=$(DEFS_PREFIX) -DTBTRANS
+-tbtrans: DEFS+=$(DEFS_PREFIX) -DTBTRANS
+-tbtrans: $(MPI_INTERFACE) $(FDF) $(TBTOBJS) $(SYSOBJ) $(LINALG)
+-	$(FC) $(FFLAGS) $(LDFLAGS) -o tbtrans \
++tbtrans_rep: FPPFLAGS+=$(DEFS_PREFIX) -DTBTRANS
++tbtrans_rep: DEFS+=$(DEFS_PREFIX) -DTBTRANS
++tbtrans_rep: $(MPI_INTERFACE) $(FDF) $(TBTOBJS) $(SYSOBJ) $(LINALG)
++	$(FC) $(FFLAGS) $(LDFLAGS) -o tbtrans_rep \
+               $(TBTOBJS) $(MPI_INTERFACE)  \
+               $(FDF) $(LIBS) $(LINALG)  || echo "***Please see top of Makefile"
+ 
+ clean: 
+ 	@echo "==> Cleaning object, library, and executable files"
+-	rm -f tbtrans *.o *.a *.mod
++	rm -f tbtrans_rep *.o *.a *.mod
+ 	rm -rf ./fdf
+ 	rm -rf ./MPI
+ 	rm -rf ./Libs

--- a/var/spack/repos/builtin/packages/siesta/package.py
+++ b/var/spack/repos/builtin/packages/siesta/package.py
@@ -24,6 +24,7 @@
 ##############################################################################
 
 from spack import *
+import os
 
 
 class Siesta(Package):
@@ -78,6 +79,9 @@ class Siesta(Package):
             make(parallel=False)
         with working_dir('Obj_trans'):
             make('transiesta', parallel=False)
+        with working_dir('Util'):
+            sh = which('sh')
+            sh('build_all.sh')
 
     def install(self, spec, prefix):
         mkdir(prefix.bin)
@@ -85,3 +89,8 @@ class Siesta(Package):
             install('siesta', prefix.bin)
         with working_dir('Obj_trans'):
             install('transiesta', prefix.bin)
+        for root, _, files in os.walk('Util'):
+            for fname in files:
+                fname = join_path(root, fname)
+                if os.access(fname, os.X_OK):
+                    install(fname, prefix.bin)

--- a/var/spack/repos/builtin/packages/siesta/package.py
+++ b/var/spack/repos/builtin/packages/siesta/package.py
@@ -64,12 +64,15 @@ class Siesta(Package):
                           # Intel's mpiifort is not found
                           'MPIFC=%s' % spec['mpi'].mpifc
                           ]
-        with working_dir('Obj'):
-            sh('../Src/configure', *configure_args)
-            sh('../Src/obj_setup.sh')
-        with working_dir('Obj_trans', create=True):
-            sh('../Src/configure', *configure_args)
-            sh('../Src/obj_setup.sh')
+        for dir, create in [('Obj', False), ('Obj_trans', True)]:
+            with working_dir(dir, create=create):
+                sh('../Src/configure', *configure_args)
+                if spec.satisfies('@:4.0.9%intel'):
+                    with open('arch.make', 'a') as f:
+                        f.write('\natom.o: atom.F\n')
+                        f.write('\t$(FC) -c $(FFLAGS) -O1')
+                        f.write('$(INCFLAGS) $(FPPFLAGS) $<')
+                sh('../Src/obj_setup.sh')
 
     def build(self, spec, prefix):
         with working_dir('Obj'):

--- a/var/spack/repos/builtin/packages/siesta/package.py
+++ b/var/spack/repos/builtin/packages/siesta/package.py
@@ -34,8 +34,9 @@ class Siesta(Package):
     url      = "https://launchpad.net/siesta/4.0/4.0.1/+download/siesta-4.0.1.tar.gz"
 
     version('4.0.1', '5cb60ce068f2f6e84fa9184ffca94c08')
+    version('3.2-pl-5', '27a300c65eb2a25d107d910d26aaf81a', url='http://departments.icmab.es/leem/siesta/CodeAccess/Code/siesta-3.2-pl-5.tgz')
 
-    patch('configure.patch')
+    patch('configure.patch', when='@:4.0.9')
 
     depends_on('mpi')
     depends_on('blas')

--- a/var/spack/repos/builtin/packages/siesta/package.py
+++ b/var/spack/repos/builtin/packages/siesta/package.py
@@ -36,7 +36,7 @@ class Siesta(Package):
     version('4.0.1', '5cb60ce068f2f6e84fa9184ffca94c08', url='https://launchpad.net/siesta/4.0/4.0.1/+download/siesta-4.0.1.tar.gz')
     version('3.2-pl-5', '27a300c65eb2a25d107d910d26aaf81a', url='http://departments.icmab.es/leem/siesta/CodeAccess/Code/siesta-3.2-pl-5.tgz')
 
-    patch('configure.patch', when='@:4.0.9')
+    patch('configure.patch', when='@:4.0')
 
     depends_on('mpi')
     depends_on('blas')
@@ -64,10 +64,10 @@ class Siesta(Package):
                           # Intel's mpiifort is not found
                           'MPIFC=%s' % spec['mpi'].mpifc
                           ]
-        for dir, create in [('Obj', False), ('Obj_trans', True)]:
-            with working_dir(dir, create=create):
+        for d in ['Obj', 'Obj_trans']:
+            with working_dir(d, create=True):
                 sh('../Src/configure', *configure_args)
-                if spec.satisfies('@:4.0.9%intel'):
+                if spec.satisfies('@:4.0%intel'):
                     with open('arch.make', 'a') as f:
                         f.write('\natom.o: atom.F\n')
                         f.write('\t$(FC) -c $(FFLAGS) -O1')

--- a/var/spack/repos/builtin/packages/siesta/package.py
+++ b/var/spack/repos/builtin/packages/siesta/package.py
@@ -31,9 +31,8 @@ class Siesta(Package):
        dynamics simulations of molecules and solids."""
 
     homepage = "https://departments.icmab.es/leem/siesta/"
-    url      = "https://launchpad.net/siesta/4.0/4.0.1/+download/siesta-4.0.1.tar.gz"
 
-    version('4.0.1', '5cb60ce068f2f6e84fa9184ffca94c08')
+    version('4.0.1', '5cb60ce068f2f6e84fa9184ffca94c08', url='https://launchpad.net/siesta/4.0/4.0.1/+download/siesta-4.0.1.tar.gz')
     version('3.2-pl-5', '27a300c65eb2a25d107d910d26aaf81a', url='http://departments.icmab.es/leem/siesta/CodeAccess/Code/siesta-3.2-pl-5.tgz')
 
     patch('configure.patch', when='@:4.0.9')


### PR DESCRIPTION
As requested by @junghans in #6431, I have restricted the patch to specific versions. Since it also applies cleanly to 3.2 and older (the last substantial change to that file was in 2006) and should remain valid for any upcoming 4.0.x version, I used a version range. 4.1, once it's released, won't need the patch anymore, but will require changes to the  `configure` method.