### PR TITLE
Adding list_url to r-hms package

### DIFF
--- a/var/spack/repos/builtin/packages/r-hms/package.py
+++ b/var/spack/repos/builtin/packages/r-hms/package.py
@@ -31,5 +31,6 @@ class RHms(RPackage):
 
     homepage = "https://cran.rstudio.com/web/packages/hms/index.html"
     url      = "https://cran.rstudio.com/src/contrib/hms_0.3.tar.gz"
+    list_url = "https://cran.r-project.org/src/contrib/Archive/hms"
 
     version('0.3', '92c4a0cf0c402a35145b5bb57212873e')


### PR DESCRIPTION
Adding a `list_url` for `r-hms`.

Ran into a 404 error due to the version `0.3` being moved to the cran archive with the release of `hms-0.4.0`