### PR TITLE
Update globus-toolkit package version and hash

### DIFF
--- a/var/spack/repos/builtin/packages/globus-toolkit/package.py
+++ b/var/spack/repos/builtin/packages/globus-toolkit/package.py
@@ -30,6 +30,6 @@ class GlobusToolkit(AutotoolsPackage):
        grids"""
 
     homepage = "http://toolkit.globus.org"
-    url      = "http://toolkit.globus.org/ftppub/gt6/installers/src/globus_toolkit-6.0.1470089956.tar.gz"
+    url      = "http://toolkit.globus.org/ftppub/gt6/installers/src/globus_toolkit-6.0.1506371041.tar.gz"
 
-    version('6.0.1470089956', 'b77fe3cc5a5844df995688b0e630d077')
+    version('6.0.1506371041', 'e17146f68e03b3482aaea3874d4087a5')


### PR DESCRIPTION
Looks like globus removes old versions from their source tree, so I propose to replace it by the currently last version. I tested it in my spack env and this version downloads and builds without a problem.

Not sure how future-proof this package is (since iirc the support of the globus toolkit will drop soon), but updating the version isn't really much work and it still seems to be in quite a bit of use.