### PR TITLE
Improve docstring of spack.directives.extend

### DIFF
--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -362,13 +362,14 @@ def depends_on(spec, when=None, type=default_deptype, patches=None):
 
 @directive(('extendees', 'dependencies'))
 def extends(spec, **kwargs):
-    """Same as depends_on, but dependency is symlinked into parent prefix.
+    """Same as depends_on, but allows symlinking into dependency's
+    prefix tree.
 
     This is for Python and other language modules where the module
     needs to be installed into the prefix of the Python installation.
     Spack handles this by installing modules into their own prefix,
     but allowing ONE module version to be symlinked into a parent
-    Python install at a time.
+    Python install at a time, using ``spack activate``.
 
     keyword arguments can be passed to extends() so that extension
     packages can pass parameters to the extendee's extension


### PR DESCRIPTION
The original docstring had confusing wording re: what is going to symlinked and where when using the `extend` directive, and how exactly the symlinking is performed (not automatically on install, but using `spack activate`). See #5559.