### PR TITLE
add conflicts to py-enum34

### DIFF
--- a/var/spack/repos/builtin/packages/py-enum34/package.py
+++ b/var/spack/repos/builtin/packages/py-enum34/package.py
@@ -34,6 +34,7 @@ class PyEnum34(PythonPackage):
     version('1.1.6', '5f13a0841a61f7fc295c514490d120d0')
 
     depends_on('python')
+    conflicts('python@3.4:')
 
     # This dependency breaks concretization
     # See https://github.com/spack/spack/issues/2793


### PR DESCRIPTION
I'm not sure whether this kind of conflict and dependency statements are generally usable yet. In our use case we didn't see anything break. If this is not yet ready feel free to close this PR and we will track this for now in our fork only