### PR TITLE
OpenJPEG: all version tuples have the same length.

### DIFF
--- a/var/spack/repos/builtin/packages/openjpeg/package.py
+++ b/var/spack/repos/builtin/packages/openjpeg/package.py
@@ -35,11 +35,30 @@ class Openjpeg(CMakePackage):
     ITU-T as a JPEG 2000 Reference Software.
     """
 
-    homepage = "https://github.com/uclouvain/openjpeg"
-    url = "https://github.com/uclouvain/openjpeg/archive/version.2.1.tar.gz"
+    homepage = 'https://github.com/uclouvain/openjpeg'
+    url = 'https://github.com/uclouvain/openjpeg/archive/v2.3.0.tar.gz'
+    list_url = 'https://github.com/uclouvain/openjpeg/releases'
 
-    version('2.1',   '3e1c451c087f8462955426da38aa3b3d')
+    version('2.3.0', '6a1f8aaa1fe55d2088e3a9c942e0f698')
+    version('2.2.0', '269bb0b175476f3addcc0d03bd9a97b6')
+    version('2.1.2', '40a7bfdcc66280b3c1402a0eb1a27624')
+    version('2.1.1', '0cc4b2aee0a9b6e9e21b7abcd201a3ec')
+    version('2.1.0', '3e1c451c087f8462955426da38aa3b3d')
     version('2.0.1', '105876ed43ff7dbb2f90b41b5a43cfa5')
-    version('2.0',   'cdf266530fee8af87454f15feb619609')
+    version('2.0.0', 'cdf266530fee8af87454f15feb619609')
     version('1.5.2', '545f98923430369a6b046ef3632ef95c')
     version('1.5.1', 'd774e4b5a0db5f0f171c4fc0aabfa14e')
+
+    def url_for_version(self, version):
+        if version >= Version('2.1.1'):
+            return super(Openjpeg, self).url_for_version(version)
+
+        # Before version 2.2.0, release tarballs of the versions like x.y.0
+        # did not have the ".0" in their names:
+        if version[2] == 0:
+            version = version.up_to(2)
+
+        url_fmt = \
+            'https://github.com/uclouvain/openjpeg/archive/version.{0}.tar.gz'
+
+        return url_fmt.format(version)


### PR DESCRIPTION
In the beginning, I thought this would be just a workaround for #6524 but actually, all version tuples of OpenJPEG officially have the same length: https://github.com/uclouvain/openjpeg/releases.