### PR TITLE
[WIP] fixing python 2.6 unit tests on travis

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -127,7 +127,12 @@ def parse_specs(args, **kwargs):
         sys.exit(1)
 
     except spack.spec.SpecError as e:
-        tty.error(e.message)
+
+        msgs = [e.message]
+        if e.long_message:
+            msgs.append(e.long_message)
+
+        tty.error(*msgs)
         sys.exit(1)
 
 

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -127,12 +127,7 @@ def parse_specs(args, **kwargs):
         sys.exit(1)
 
     except spack.spec.SpecError as e:
-
-        msgs = [e.message]
-        if e.long_message:
-            msgs.append(e.long_message)
-
-        tty.error(*msgs)
+        tty.error(e.message)
         sys.exit(1)
 
 

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -33,7 +33,7 @@ import llnl.util.filesystem as fs
 import spack
 import spack.cmd.install
 from spack.spec import Spec
-from spack.main import SpackCommand
+from spack.main import SpackCommand, SpackCommandError
 
 install = SpackCommand('install')
 
@@ -234,3 +234,14 @@ def test_install_overwrite(
     assert os.path.exists(spec.prefix)
     assert fs.hash_directory(spec.prefix) == expected_md5
     assert fs.hash_directory(spec.prefix) != bad_md5
+
+
+@pytest.mark.usefixtures(
+    'builtin_mock', 'mock_archive', 'mock_fetch', 'config', 'install_mockery',
+)
+def test_install_conflicts(conflict_spec):
+    # Make sure that spec with conflicts exit with 1
+    with pytest.raises(SpackCommandError):
+        install(conflict_spec)
+
+    assert install.returncode == 1

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -33,6 +33,9 @@ import llnl.util.filesystem as fs
 import spack
 import spack.cmd.install
 from spack.spec import Spec
+from spack.main import SpackCommand
+
+install = SpackCommand('install')
 
 
 @pytest.fixture(scope='module')

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -33,7 +33,7 @@ import llnl.util.filesystem as fs
 import spack
 import spack.cmd.install
 from spack.spec import Spec
-from spack.main import SpackCommand, SpackCommandError
+from spack.main import SpackCommand
 
 install = SpackCommand('install')
 
@@ -234,14 +234,3 @@ def test_install_overwrite(
     assert os.path.exists(spec.prefix)
     assert fs.hash_directory(spec.prefix) == expected_md5
     assert fs.hash_directory(spec.prefix) != bad_md5
-
-
-@pytest.mark.usefixtures(
-    'builtin_mock', 'mock_archive', 'mock_fetch', 'config', 'install_mockery',
-)
-def test_install_conflicts(conflict_spec):
-    # Make sure that spec with conflicts exit with 1
-    with pytest.raises(SpackCommandError):
-        install(conflict_spec)
-
-    assert install.returncode == 1

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -33,9 +33,6 @@ import llnl.util.filesystem as fs
 import spack
 import spack.cmd.install
 from spack.spec import Spec
-from spack.main import SpackCommand, SpackCommandError
-
-install = SpackCommand('install')
 
 
 @pytest.fixture(scope='module')

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -234,14 +234,3 @@ def test_install_overwrite(
     assert os.path.exists(spec.prefix)
     assert fs.hash_directory(spec.prefix) == expected_md5
     assert fs.hash_directory(spec.prefix) != bad_md5
-
-
-@pytest.mark.usefixtures(
-    'builtin_mock', 'mock_archive', 'mock_fetch', 'config', 'install_mockery',
-)
-def test_install_conflicts(conflict_spec):
-    # Make sure that spec with conflicts exit with 1
-    with pytest.raises(SpackCommandError):
-        install(conflict_spec)
-
-    assert install.returncode == 1

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -94,19 +94,6 @@ def spec(request):
     return request.param
 
 
-@pytest.fixture(
-    params=[
-        'conflict%clang',
-        'conflict%clang+foo',
-        'conflict-parent%clang',
-        'conflict-parent@0.9^conflict~foo'
-    ]
-)
-def conflict_spec(request):
-    """Spec to be concretized"""
-    return request.param
-
-
 @pytest.mark.usefixtures('config', 'builtin_mock')
 class TestConcretize(object):
     def test_concretize(self, spec):

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -94,6 +94,19 @@ def spec(request):
     return request.param
 
 
+@pytest.fixture(
+    params=[
+        'conflict%clang',
+        'conflict%clang+foo',
+        'conflict-parent%clang',
+        'conflict-parent@0.9^conflict~foo'
+    ]
+)
+def conflict_spec(request):
+    """Spec to be concretized"""
+    return request.param
+
+
 @pytest.mark.usefixtures('config', 'builtin_mock')
 class TestConcretize(object):
     def test_concretize(self, spec):

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -690,3 +690,22 @@ class MockPackageMultiRepo(object):
         import collections
         Repo = collections.namedtuple('Repo', ['namespace'])
         return Repo('mockrepo')
+
+##########
+# Specs of various kind
+##########
+
+
+@pytest.fixture(
+    params=[
+        'conflict%clang',
+        'conflict%clang+foo',
+        'conflict-parent%clang',
+        'conflict-parent@0.9^conflict~foo'
+    ]
+)
+def conflict_spec(request):
+    """Specs which violate constraints specified with the "conflicts"
+    directive in the "conflict" package.
+    """
+    return request.param

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -690,22 +690,3 @@ class MockPackageMultiRepo(object):
         import collections
         Repo = collections.namedtuple('Repo', ['namespace'])
         return Repo('mockrepo')
-
-##########
-# Specs of various kind
-##########
-
-
-@pytest.fixture(
-    params=[
-        'conflict%clang',
-        'conflict%clang+foo',
-        'conflict-parent%clang',
-        'conflict-parent@0.9^conflict~foo'
-    ]
-)
-def conflict_spec(request):
-    """Specs which violate constraints specified with the "conflicts"
-    directive in the "conflict" package.
-    """
-    return request.param


### PR DESCRIPTION
Python 2.6 tests are now failing on travis on develop and all branches.

To start off with I'm reverting https://github.com/spack/spack/pull/6436 which is the first merged PR where the tests on develop failed. Oddly, the branch tests for this succeed although they appear to take significantly longer than usual: 14 minutes vs. 8