### PR TITLE
Remove reference to deprecated spack md5 command

### DIFF
--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -54,8 +54,7 @@ def setup_parser(subparser):
 def checksum(parser, args):
     # Make sure the user provided a package and not a URL
     if not valid_fully_qualified_module_name(args.package):
-        tty.die("`spack checksum` accepts package names, not URLs. "
-                "Use `spack md5 <url>` instead.")
+        tty.die("`spack checksum` accepts package names, not URLs.")
 
     # Get the package we're going to generate checksums for
     pkg = spack.repo.get(args.package)


### PR DESCRIPTION
Fixes #6527.