### PR TITLE
Rename variant static to shared

### DIFF
--- a/var/spack/repos/builtin/packages/hwloc/package.py
+++ b/var/spack/repos/builtin/packages/hwloc/package.py
@@ -58,7 +58,7 @@ class Hwloc(AutotoolsPackage):
     variant('libxml2', default=True, description="Build with libxml2")
     variant('pci', default=(sys.platform != 'darwin'),
             description="Support analyzing devices on PCI bus")
-    variant('static', default=False, description="Build static libraries")
+    variant('shared', default=True, description="Build shared libraries")
 
     depends_on('cuda', when='+cuda')
     depends_on('libpciaccess', when='+pci')
@@ -74,7 +74,7 @@ class Hwloc(AutotoolsPackage):
             "--enable-cuda" if '+cuda' in spec else "--disable-cuda",
             "--enable-libxml2" if '+libxml2' in spec else "--disable-libxml2",
             "--enable-pci" if '+pci' in spec else "--disable-pci",
-            "--enable-static" if '+static' in spec else "--disable-static",
+            "--enable-shared" if '+shared' in spec else "--disable-shared",
             # Disable OpenCL, since hwloc might pick up an OpenCL
             # library at build time that is then not found at run time
             # (Alternatively, we could require OpenCL as dependency.)


### PR DESCRIPTION
# Description

Change of variant name from `static` to `shared`. 