### PR TITLE
Add more vtk options

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -21,7 +21,7 @@ packages:
       blas: [openblas]
       daal: [intel-daal]
       elf: [elfutils]
-      gl: [opengl]
+      gl: [opengl, mesa]
       golang: [gcc]
       ipp: [intel-ipp]
       java: [jdk]
@@ -37,7 +37,3 @@ packages:
       szip: [libszip, libaec]
       tbb: [intel-tbb]
       jpeg: [libjpeg-turbo, libjpeg]
-  opengl:
-    paths:
-      opengl: /usr
-    buildable: False

--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -21,6 +21,7 @@ packages:
       blas: [openblas]
       daal: [intel-daal]
       elf: [elfutils]
+      gl: [opengl]
       golang: [gcc]
       ipp: [intel-ipp]
       java: [jdk]
@@ -36,3 +37,7 @@ packages:
       szip: [libszip, libaec]
       tbb: [intel-tbb]
       jpeg: [libjpeg-turbo, libjpeg]
+  opengl:
+    paths:
+      opengl: /usr
+    buildable: False

--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -21,7 +21,7 @@ packages:
       blas: [openblas]
       daal: [intel-daal]
       elf: [elfutils]
-      gl: [opengl, mesa]
+      gl: [mesa, opengl]
       golang: [gcc]
       ipp: [intel-ipp]
       java: [jdk]

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -46,7 +46,9 @@ class Mesa(AutotoolsPackage):
     version('12.0.6', '1a3d4fea0656c208db59289e4ed33b3f')
     version('12.0.3', '1113699c714042d8c4df4766be8c57d8')
 
-    provides('gl')
+    provides('gl@:4.5', when='@17:')
+    provides('gl@:4.4', when='@13:')
+    provides('gl@:4.3', when='@12:')
 
     variant('swrender', default=True,
             description="Build with (gallium) software rendering.")

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -46,6 +46,8 @@ class Mesa(AutotoolsPackage):
     version('12.0.6', '1a3d4fea0656c208db59289e4ed33b3f')
     version('12.0.3', '1113699c714042d8c4df4766be8c57d8')
 
+    provides('gl')
+
     variant('swrender', default=True,
             description="Build with (gallium) software rendering.")
     variant('hwrender', default=False,

--- a/var/spack/repos/builtin/packages/opengl/package.py
+++ b/var/spack/repos/builtin/packages/opengl/package.py
@@ -1,0 +1,56 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Opengl(Package):
+    """Placeholder for external OpenGL libraries from hardware vendors"""
+
+    homepage = "https://www.opengl.org/"
+    url      = "https://www.opengl.org/"
+
+    version('3.2', 'N/A')
+
+    provides('gl')
+
+    def install(self, spec, prefix):
+        msg = """This package is intended to be a placeholder for
+        system-provided OpenGL libraries from hardware vendors.  Please
+        download and install OpenGL drivers/libraries for your graphics
+        hardware separately, and then set that up as an external package.
+        An example of a working packages.yaml:
+
+        packages:
+          opengl:
+            paths:
+              opengl: /opt/opengl
+            buildable: False
+
+        In that case, /opt/opengl/ should contain these two folders:
+
+        include/GL/       (opengl headers, including "gl.h")
+        lib               (opengl libraries, including "libGL.so")"""
+
+        raise InstallError(msg)

--- a/var/spack/repos/builtin/packages/opengl/package.py
+++ b/var/spack/repos/builtin/packages/opengl/package.py
@@ -33,7 +33,9 @@ class Opengl(Package):
 
     version('3.2', 'N/A')
 
-    provides('gl')
+    provides('gl@:4.5', when='@:4.5')
+    provides('gl@:4.4', when='@:4.4')
+    provides('gl@:4.3', when='@:4.3')
 
     def install(self, spec, prefix):
         msg = """This package is intended to be a placeholder for
@@ -45,7 +47,7 @@ class Opengl(Package):
         packages:
           opengl:
             paths:
-              opengl: /opt/opengl
+              opengl@4.5.0: /opt/opengl
             buildable: False
 
         In that case, /opt/opengl/ should contain these two folders:

--- a/var/spack/repos/builtin/packages/opengl/package.py
+++ b/var/spack/repos/builtin/packages/opengl/package.py
@@ -33,9 +33,9 @@ class Opengl(Package):
 
     version('3.2', 'N/A')
 
-    provides('gl@:4.5', when='@:4.5')
-    provides('gl@:4.4', when='@:4.4')
-    provides('gl@:4.3', when='@:4.3')
+    provides('gl@:4.5', when='@4.5:')
+    provides('gl@:4.4', when='@4.4:')
+    provides('gl@:4.3', when='@4.3:')
 
     def install(self, spec, prefix):
         msg = """This package is intended to be a placeholder for

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -126,8 +126,7 @@ class Qt(Package):
     depends_on("python", when='@5.7.0:', type='build')
 
     # OpenGL hardware acceleration
-    depends_on("mesa", when='@4:+opengl')
-
+    depends_on("gl@3.2:", when='@4:+opengl')
     depends_on("libxcb", when=sys.platform != 'darwin')
     depends_on("libx11", when=sys.platform != 'darwin')
 

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 
+import os
 from spack import *
 
 
@@ -32,24 +33,47 @@ class Vtk(CMakePackage):
     processing and visualization. """
 
     homepage = "http://www.vtk.org"
-    url      = "http://www.vtk.org/files/release/7.1/VTK-7.1.0.tar.gz"
+    url      = "http://www.vtk.org/files/release/8.0/VTK-8.0.1.tar.gz"
     list_url = "http://www.vtk.org/download/"
 
+    version('8.0.1', '692d09ae8fadc97b59d35cab429b261a')
     version('7.1.0', 'a7e814c1db503d896af72458c2d0228f')
     version('7.0.0', '5fe35312db5fb2341139b8e4955c367d')
     version('6.3.0', '0231ca4840408e9dd60af48b314c5b6d')
     version('6.1.0', '25e4dfb3bad778722dcaec80cd5dab7d')
 
     # VTK7 defaults to OpenGL2 rendering backend
-    variant('opengl2', default=True, description='Build with OpenGL2 instead of OpenGL as rendering backend')
-    variant('python', default=False, description='Build the python modules')
+    variant('opengl2', default=True, description='Enable OpenGL2 backend')
+    variant('osmesa', default=False, description='Enable OSMesa support')
+    variant('python', default=False, description='Enable Python support')
+    variant('qt', default=False, description='Build with support for Qt')
 
     patch('gcc.patch', when='@6.1.0')
 
-    depends_on('qt')
+    # If you didn't ask for osmesa, then hw rendering using vendor-specific
+    # drivers is faster, but it must be done externally.
+    depends_on('opengl', when='~osmesa')
+
+    # mesa default is software rendering, make it faster with llvm
+    depends_on('mesa+llvm', when='+osmesa')
+
+    # VTK will need Qt5OpenGL, and qt needs '-opengl' for that
+    depends_on('qt+opengl', when='+qt')
+
+    depends_on('expat')
+    depends_on('freetype')
+    depends_on('glew')
     depends_on('hdf5')
+    depends_on('libjpeg')
+    depends_on('jsoncpp')
+    depends_on('libharu')
+    depends_on('libxml2')
+    depends_on('lz4')
     depends_on('netcdf')
     depends_on('netcdf-cxx')
+    depends_on('libpng')
+    depends_on('libtiff')
+    depends_on('zlib')
 
     extends('python', when='+python')
 
@@ -57,18 +81,29 @@ class Vtk(CMakePackage):
         url = "http://www.vtk.org/files/release/{0}/VTK-{1}.tar.gz"
         return url.format(version.up_to(2), version)
 
+    def setup_environment(self, spack_env, run_env):
+        # VTK has some trouble finding freetype unless it is set in
+        # the environment
+        spack_env.set('FREETYPE_DIR', self.spec['freetype'].prefix)
+
     def cmake_args(self):
         spec = self.spec
 
         opengl_ver = 'OpenGL{0}'.format('2' if '+opengl2' in spec else '')
-        qt_ver = spec['qt'].version.up_to(1)
-        qt_bin = spec['qt'].prefix.bin
 
         cmake_args = [
             '-DBUILD_SHARED_LIBS=ON',
             '-DVTK_RENDERING_BACKEND:STRING={0}'.format(opengl_ver),
-            '-DVTK_USE_SYSTEM_HDF5=ON',
-            '-DVTK_USE_SYSTEM_NETCDF=ON',
+
+            # In general, we disable use of VTK "ThirdParty" libs, preferring
+            # spack-built versions whenever possible
+            '-DVTK_USE_SYSTEM_LIBRARIES=ON',
+
+            # However, in a few cases we can't do without them yet
+            '-DVTK_USE_SYSTEM_GL2PS=OFF',
+            '-DVTK_USE_SYSTEM_LIBPROJ4=OFF',
+            '-DVTK_USE_SYSTEM_OGGTHEORA=OFF',
+
             '-DNETCDF_DIR={0}'.format(spec['netcdf'].prefix),
             '-DNETCDF_C_ROOT={0}'.format(spec['netcdf'].prefix),
             '-DNETCDF_CXX_ROOT={0}'.format(spec['netcdf-cxx'].prefix),
@@ -80,21 +115,62 @@ class Vtk(CMakePackage):
             # Disable wrappers for other languages.
             '-DVTK_WRAP_JAVA=OFF',
             '-DVTK_WRAP_TCL=OFF',
-
-            # Enable Qt support here.
-            '-DVTK_QT_VERSION:STRING={0}'.format(qt_ver),
-            '-DQT_QMAKE_EXECUTABLE:PATH={0}/qmake'.format(qt_bin),
-            '-DVTK_Group_Qt:BOOL=ON',
         ]
 
-        # NOTE: The following definitions are required in order to allow
-        # VTK to build with qt~webkit versions (see the documentation for
-        # more info: http://www.vtk.org/Wiki/VTK/Tutorials/QtSetup).
-        if '~webkit' in spec['qt']:
+        if 'darwin' in spec.architecture:
             cmake_args.extend([
-                '-DVTK_Group_Qt:BOOL=OFF',
-                '-DModule_vtkGUISupportQt:BOOL=ON',
-                '-DModule_vtkGUISupportQtOpenGL:BOOL=ON',
+                '-DCMAKE_MACOSX_RPATH=ON'
+            ])
+
+        if '+qt' in spec:
+            qt_ver = spec['qt'].version.up_to(1)
+            qt_bin = spec['qt'].prefix.bin
+            qmake_exe = os.path.join(qt_bin, 'qmake')
+
+            cmake_args.extend([
+                # Enable Qt support here.
+                '-DVTK_QT_VERSION:STRING={0}'.format(qt_ver),
+                '-DQT_QMAKE_EXECUTABLE:PATH={0}'.format(qmake_exe),
+                '-DVTK_Group_Qt:BOOL=ON',
+            ])
+
+            # NOTE: The following definitions are required in order to allow
+            # VTK to build with qt~webkit versions (see the documentation for
+            # more info: http://www.vtk.org/Wiki/VTK/Tutorials/QtSetup).
+            if '~webkit' in spec['qt']:
+                cmake_args.extend([
+                    '-DVTK_Group_Qt:BOOL=OFF',
+                    '-DModule_vtkGUISupportQt:BOOL=ON',
+                    '-DModule_vtkGUISupportQtOpenGL:BOOL=ON',
+                ])
+
+        if '+osmesa' in spec:
+            prefix = spec['mesa'].prefix
+            osmesaIncludeDir = prefix.include
+            osmesaLibrary = os.path.join(prefix.lib, 'libOSMesa.so')
+
+            useParam = 'VTK_USE_X'
+            if 'darwin' in spec.architecture:
+                useParam = 'VTK_USE_COCOA'
+
+            cmake_args.extend([
+                '-D{0}:BOOL=OFF'.format(useParam),
+                '-DVTK_OPENGL_HAS_OSMESA:BOOL=ON',
+                '-DOSMESA_INCLUDE_DIR:PATH={0}'.format(osmesaIncludeDir),
+                '-DOSMESA_LIBRARY:FILEPATH={0}'.format(osmesaLibrary),
+            ])
+        else:
+            prefix = spec['opengl'].prefix
+
+            openglIncludeDir = prefix.include
+            openglLibrary = os.path.join(prefix.lib, 'libGL.so')
+            if 'darwin' in spec.architecture:
+                openglIncludeDir = prefix
+                openglLibrary = prefix
+
+            cmake_args.extend([
+                '-DOPENGL_INCLUDE_DIR:PATH={0}'.format(openglIncludeDir),
+                '-DOPENGL_gl_LIBRARY:FILEPATH={0}'.format(openglLibrary)
             ])
 
         if spec.satisfies('@:6.1.0'):

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -50,6 +50,14 @@ class Vtk(CMakePackage):
 
     patch('gcc.patch', when='@6.1.0')
 
+    # At the moment, we cannot build with both osmesa and qt, but as of
+    # VTK 8.1, that should change
+    conflicts('+osmesa', when='+qt')
+
+    # The use of the OpenGL2 backend requires at least OpenGL Core Profile
+    # version 3.2 or higher.
+    depends_on('gl@3.2:', when='+opengl2')
+
     # If you didn't ask for osmesa, then hw rendering using vendor-specific
     # drivers is faster, but it must be done externally.
     depends_on('opengl', when='~osmesa')


### PR DESCRIPTION
After a lot of experimentation and messing around, I think I have settled on what I think are the goals for the VTK spack package.  Please chime in if you disagree or have different thoughts on the matter.

We need the following four *independent* options:

1. python wrapping (yes or no)
2. qt (yes or no)
** should not imply software rendering by choosing qt
3. hardware vs. software rendering
** if doing software rendering, there is no reason not to use llvm by default to speed it up
** down the road we might like to have offscreen hardware rendering (via EGL) when GPUs supporting it are available
4. rendering backend (opengl1 or opengl2) will become less important as the opengl1 backend will be deprecated soon.

~~I tried to achieve these goals by only changing the `vtk` package, but I'm not sure it's going to work that way.  Maybe changes will be needed to the `qt` and/or `mesa` packages.~~

One of the things this PR does is make qt optional for the VTK package, which was not the case before.

~~This PR also contains a "workaround" commit to get VTK to build correctly.  VTK depends on a specific version of libtiff, and thus includes that specific version in it's ThirdParty directory.  That specific version indicates that it does not have JBIG_SUPPORT, and everything works fine.  When spack builds VTK, the libtiff built by spack is found first, and it *does* seem to have JBIG_SUPPORT, but then during the build process linking fails because the symbols related to JBIG cannot be found (see the commit message for that workaround commit).  In general, how should we make sure that VTK chooses it's own ThirdParty libraries over anything spack built?  I know my workaround probably isn't the way to go, but it let me get a lot of VTK build variants working and tested in the short term.~~

~~Currently this PR attempts to make hardware rendering the default when `qt` and `-osmesa` are in the spec. However, that does not seem to work, as my simple VTK benchmark, which runs at -7K fps on my linux box normally, runs at only 10fps when built against the `vtk+qt` built by spack.  Also, when `+osmesa` is in the spec, it tries to use llvm, but that does not seem to work either.  I'm not sure if the package.py is wrong, or perhaps I just don't understand how the hashing works.  I kind of expected that if I changed a `depends_on` in the package.py, spack would notice that even though I'm asking to install a combination I've installed before, the dependencies are no longer met, and would decide to install again.~~

And finally, I'm having real trouble getting any variants of VTK to build/work on Mac OSX.  This PR doesn't contain any fixes that will help with those issues.  I'm leaving that for a future PR when I've made more progress in that arena.

I'm looking forward to iterate on this PR until everyone is happy with it.

~~EDIT:~~

I have reworked this PR so that VTK gets as many of its dependencies from spack as possible, rather than using it's own ThirdParty copies of them.  This did allow me to remove the "workaround" change reviewed by @davydden. 

~~Also, this PR "punts" on hardware rendering (it works on my system, but only if I *do not* enable `qt`, as VTK needs `qt+opengl`, which brings in mesa).  In the absence of a real hardware rendering solution, `qt` causes VTK to find the libGL provided by mesa and uses that, resulting in terrible rendering performance.~~

~~In my next PR, I plan to create an `opengl` virtual package which the `mesa` package will `provide`.  Then I plan to create a `systemopengl` package (or maybe that's not the right name?), where the plan will be that users will always have to provide that via an external package.  Finally, when VTK is not requested with `osmesa`, it will depend on that `systemopengl` package. ~~

EDIT

This PR should be added after #6662 makes it in, as it now depends on the `opengl` package created in that PR.  Once that is merged and I can rebase on it, this PR will only have a change to the `vtk` package.