### PR TITLE
Force CMake to pick libraries installed with Spack.

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2021,6 +2021,16 @@ class PackageBase(with_metaclass(PackageMeta, object)):
                 msg = 'RUN-TESTS: method not implemented [{0}]'
                 tty.warn(msg.format(name))
 
+    def dependent_cmake_args(self):
+        """Returns a list of command line arguments that help standard
+        cmake Find<Package>.cmake scripts of a dependent CMakePackage to
+        locate this package.
+
+        Default implementation returns an empty list, but this can be
+        overridden by an extendable package.
+        """
+        return []
+
 
 class Package(PackageBase):
     """General purpose class with a single ``install``

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -378,3 +378,7 @@ class Boost(Package):
         # on Darwin; correct this
         if (sys.platform == 'darwin') and ('+shared' in spec):
             fix_darwin_install_name(prefix.lib)
+
+    def dependent_cmake_args(self):
+        return ['-DBOOST_ROOT=' + self.spec.prefix,
+                '-DBoost_NO_SYSTEM_PATHS=ON']

--- a/var/spack/repos/builtin/packages/libpng/package.py
+++ b/var/spack/repos/builtin/packages/libpng/package.py
@@ -61,3 +61,12 @@ class Libpng(AutotoolsPackage):
             'LDFLAGS={0}'.format(self.spec['zlib'].libs.search_flags)
         ]
         return args
+
+    def dependent_cmake_args(self):
+        # FindPNG.cmake does not have an argument that could be set to enforce
+        # usage of the library in a particular directory but as long as Spack
+        # sets CMAKE_PREFIX_PATH, libpng's 'make install' creates libpng.*
+        # symlink to the library, and the script starts with searching for
+        # names 'png.*' and 'libpng.*', the correct installation of the library
+        # is used in most of the cases.
+        return []

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -659,3 +659,8 @@ class Python(AutotoolsPackage):
             self.write_easy_install_pth(
                 exts,
                 prefix=extensions_layout.extendee_target_directory(self))
+
+    def dependent_cmake_args(self):
+        # Both FindPythonInterp.cmake and FindPythonLibs.cmake locate python
+        # correctly if variable PYTHON_EXECUTABLE is set."""
+        return ['-DPYTHON_EXECUTABLE:FILEPATH=' + self.command.path]

--- a/var/spack/repos/builtin/packages/zlib/package.py
+++ b/var/spack/repos/builtin/packages/zlib/package.py
@@ -73,3 +73,6 @@ class Zlib(Package):
         if self.run_tests:
             make('check')
         make('install')
+
+    def dependent_cmake_args(self):
+        return ['-DZLIB_ROOT=' + self.spec.prefix]


### PR DESCRIPTION
Spack sets `CMAKE_PREFIX_PATH`. Unfortunately, it's not always enough to make sure that the version of the library from spec is used. Usually, this happens because many cmake scripts search for a list of filenames in a list of paths and the priority is given to the names, i.e. if the first name in the list was not found in `CMAKE_PREFIX_PATH`, cmake will continue to look for that name in the system directories. For example, `FindPythonInterp.cmake` fails to locate Python3 that is installed with Spack because there is no `python` symlink to the executable in the `<prefix>/bin` directory. Another example is `FindBoost.cmake`, which uses a list of version-dependent filenames, and if the version in the spec is older than the version in the system directories, the latter will be used.

The idea is to add a method to `PackageBase`, which would provide a dependent `CMakePackage` with flags that would help cmake to pick the right version of the library.