### PR TITLE
spack mirror: removing a mirror is not a no-op anymore

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -445,16 +445,8 @@ def update_config(section, update_data, scope=None):
     validate_section_name(section)  # validate section name
     scope = validate_scope(scope)  # get ConfigScope object from string.
 
-    # read in the config to ensure we've got current data
-    configuration = get_config(section)
-
-    if isinstance(update_data, list):
-        configuration = update_data
-    else:
-        configuration.update(update_data)
-
     # read only the requested section's data.
-    scope.sections[section] = {section: configuration}
+    scope.sections[section] = {section: update_data}
     scope.write_section(section)
 
 


### PR DESCRIPTION
fixes #4573 

This PR is a quick fix for #4573. It seems that for some reasons there's a type check within the `update_config` function that permits to reassign objects only if they are instances of `list`. Here I work around the issue modifying the minimum number of lines possible.

I plan having a closer look at the `spack.config` module in the near future and see if I can propose an improvement of the API.

@pramodk 