### PR TITLE
wxWidgets: fix GTK builds

### DIFF
--- a/var/spack/repos/builtin/packages/wx/math_include.patch
+++ b/var/spack/repos/builtin/packages/wx/math_include.patch
@@ -1,0 +1,12 @@
+diff --git a/src/stc/scintilla/src/Editor.cxx b/src/stc/scintilla/src/Editor.cxx
+index cd72953ae7..8c19154313 100644
+--- a/src/stc/scintilla/src/Editor.cxx
++++ b/src/stc/scintilla/src/Editor.cxx
+@@ -10,6 +10,7 @@
+ #include <stdio.h>
+ #include <ctype.h>
+ #include <assert.h>
++#include <math.h>
+
+ #include <string>
+ #include <vector>

--- a/var/spack/repos/builtin/packages/wx/package.py
+++ b/var/spack/repos/builtin/packages/wx/package.py
@@ -44,8 +44,10 @@ class Wx(AutotoolsPackage):
 
     version('develop', git='https://github.com/wxWidgets/wxWidgets.git', branch='master')
 
+    patch('math_include.patch', when='@3.0.1:3.0.2')
+
     depends_on('pkgconfig', type='build')
-    depends_on('gtkplus')
+    depends_on('gtkplus+X')
 
     @when('@:3.0.2')
     def build(self, spec, prefix):


### PR DESCRIPTION
- depends on GTK+ with X enabled   (btw, non-X backends are deprecated/removed in GTK+):
```
Installing gtkplus
[...]
configure: error: Package requirements (cairo-xlib >= 1.6) were not met:
     112   
     113   Package 'cairo-xlib', required by 'virtual:world', not found
```

- patch for 3.0.1-3.0.2: missing include caused multiple   `error: call of overloaded ‘abs(XYPOSITION)’ is ambiguous`   (seen in GCC 6.3.0); fixed in 3.0.3+
- ~~`extends('python')`: needed for python bindings it builds, was missing and caused issues when building/distr. depending packages on requirement step~~