### PR TITLE
libpng: CPPFLAGS for -I

### DIFF
--- a/var/spack/repos/builtin/packages/libpng/package.py
+++ b/var/spack/repos/builtin/packages/libpng/package.py
@@ -57,7 +57,7 @@ class Libpng(AutotoolsPackage):
             # not honored, see
             #   https://sourceforge.net/p/libpng/bugs/210/#33f1
             # '--with-zlib=' + self.spec['zlib'].prefix,
-            'CFLAGS={0}'.format(self.spec['zlib'].headers.include_flags),
+            'CPPFLAGS={0}'.format(self.spec['zlib'].headers.include_flags),
             'LDFLAGS={0}'.format(self.spec['zlib'].libs.search_flags)
         ]
         return args


### PR DESCRIPTION
Recent versions of `libpng` (e.g. 1.6.34) warn/abort that includes for `zlib` need to be passed properly via `CPPFLAGS`. This fixes it.

This was already pointed out in the [original post](https://sourceforge.net/p/libpng/bugs/210/#33f1) also linked in the package.

Follow-up to #5656 and #5581