### PR TITLE
Update gnupg to 2.2.3

### DIFF
--- a/var/spack/repos/builtin/packages/gnupg/package.py
+++ b/var/spack/repos/builtin/packages/gnupg/package.py
@@ -30,8 +30,9 @@ class Gnupg(AutotoolsPackage):
        standard as defined by RFC4880 """
 
     homepage = "https://gnupg.org/index.html"
-    url = "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.1.21.tar.bz2"
+    url = "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.3.tar.bz2"
 
+    version('2.2.3', '6911c0127e4231ce52d60f26029dba68')
     version('2.1.21', '685ebf4c3a7134ba0209c96b18b2f064')
 
     depends_on('libgcrypt')

--- a/var/spack/repos/builtin/packages/libassuan/package.py
+++ b/var/spack/repos/builtin/packages/libassuan/package.py
@@ -30,8 +30,9 @@ class Libassuan(AutotoolsPackage):
        protocol."""
 
     homepage = "https://gnupg.org/software/libassuan/index.html"
-    url = "https://gnupg.org/ftp/gcrypt/libassuan/libassuan-2.4.3.tar.bz2"
+    url = "https://gnupg.org/ftp/gcrypt/libassuan/libassuan-2.4.5.tar.bz2"
 
+    version('2.4.5', '4f22bdb70d424cfb41b64fd73b7e1e45')
     version('2.4.3', '8e01a7c72d3e5d154481230668e6eb5a')
 
     depends_on('libgpg-error')

--- a/var/spack/repos/builtin/packages/libgcrypt/package.py
+++ b/var/spack/repos/builtin/packages/libgcrypt/package.py
@@ -32,8 +32,9 @@ class Libgcrypt(AutotoolsPackage):
        key algorithms, large integer functions, random numbers and a lot
        of supporting functions. """
     homepage = "http://www.gnu.org/software/libgcrypt/"
-    url = "https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.7.6.tar.bz2"
+    url = "https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.8.1.tar.bz2"
 
+    version('1.8.1', 'b21817f9d850064d2177285f1073ec55')
     version('1.7.6', '54e180679a7ae4d090f8689ca32b654c')
     version('1.6.2', 'b54395a93cb1e57619943c082da09d5f')
 

--- a/var/spack/repos/builtin/packages/npth/package.py
+++ b/var/spack/repos/builtin/packages/npth/package.py
@@ -30,6 +30,7 @@ class Npth(AutotoolsPackage):
        non-preemptive threads implementation."""
 
     homepage = "https://gnupg.org/software/npth/index.html"
-    url = "https://gnupg.org/ftp/gcrypt/npth/npth-1.4.tar.bz2"
+    url = "https://gnupg.org/ftp/gcrypt/npth/npth-1.5.tar.bz2"
 
+    version('1.5', '9ba2dc4302d2f32c66737c43ed191b1b')
     version('1.4', '76cef5542e0db6a339cf960641ed86f8')


### PR DESCRIPTION
I updated gnupg to the most recent version `2.2.3`. 

Updated dependencies:

* libassuan 2.4.5
* libgcrypt 1.8.1
* npth 1.5

I did not find any note if this kind of PR is wanted or not?