### PR TITLE
Update .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,11 @@
 .#*
 /.cache
 /bin/spackc
+/cache
+/linux
+compilers.yaml
+config.yaml
+mirrors.yaml
+modules.yaml
+packages.yaml
+repos.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -25,9 +25,9 @@
 /bin/spackc
 /cache
 /linux
-compilers.yaml
-config.yaml
-mirrors.yaml
-modules.yaml
-packages.yaml
-repos.yaml
+/compilers.yaml
+/config.yaml
+/mirrors.yaml
+/modules.yaml
+/packages.yaml
+/repos.yaml


### PR DESCRIPTION
If cloned to ~/.spack the following files/folders showed up as untracked:

* /cache
* /linux
* compilers.yaml
* config.yaml
* mirrors.yaml
* modules.yaml
* packages.yaml
* repos.yaml

Adding them to the .gitignore file prevents this from happening.