### PR TITLE
CMAKE_INSTALL_RPATH is semicolon-separated

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -144,7 +144,7 @@ class CMakePackage(PackageBase):
 
         # Set up CMake rpath
         args.append('-DCMAKE_INSTALL_RPATH_USE_LINK_PATH:BOOL=FALSE')
-        rpaths = ':'.join(spack.build_environment.get_rpaths(pkg))
+        rpaths = ';'.join(spack.build_environment.get_rpaths(pkg))
         args.append('-DCMAKE_INSTALL_RPATH:STRING={0}'.format(rpaths))
         # CMake's find_package() looks in CMAKE_PREFIX_PATH first, help CMake
         # to find immediate link dependencies in right places:


### PR DESCRIPTION
`CMAKE_INSTALL_RPATH` is [semicolon-separated](https://cmake.org/cmake/help/v3.10/variable/CMAKE_INSTALL_RPATH.html). Otherwise, it is not interpreted as a list. Colons are not a problem in situations when lists of rpaths are stored to the objects as colon-separated lists. It's not the case of MacOS, though.

BTW, I am not sure that we need to set CMAKE_INSTALL_RPATH at all since rpaths are set by the wrappers anyway.