### PR TITLE
Provide a patch to allow hdf5@1.10.1 to build with intel/18.0.1.

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/h5f90global-mult-obj-same-equivalence-same-common-block.patch
+++ b/var/spack/repos/builtin/packages/hdf5/h5f90global-mult-obj-same-equivalence-same-common-block.patch
@@ -1,0 +1,16 @@
+diff --git a/fortran/src/H5f90global.F90 b/fortran/src/H5f90global.F90
+index dd2b171..629418a 100644
+--- a/fortran/src/H5f90global.F90
++++ b/fortran/src/H5f90global.F90
+@@ -142,10 +142,7 @@ MODULE H5GLOBAL
+
+   INTEGER(HID_T), DIMENSION(PREDEF_TYPES_LEN) :: predef_types
+   EQUIVALENCE (predef_types(1), H5T_NATIVE_INTEGER_KIND(1))
+-  EQUIVALENCE (predef_types(2), H5T_NATIVE_INTEGER_KIND(2))
+-  EQUIVALENCE (predef_types(3), H5T_NATIVE_INTEGER_KIND(3))
+-  EQUIVALENCE (predef_types(4), H5T_NATIVE_INTEGER_KIND(4))
+-  EQUIVALENCE (predef_types(5), H5T_NATIVE_INTEGER_KIND(5))
++  ! EQUIVALENCE predef_types(2:5) are unnecessary and violate the standard
+   EQUIVALENCE (predef_types(6), H5T_NATIVE_INTEGER)
+   EQUIVALENCE (predef_types(7), H5T_NATIVE_REAL)
+   EQUIVALENCE (predef_types(8), H5T_NATIVE_DOUBLE)

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -74,6 +74,9 @@ class Hdf5(AutotoolsPackage):
     conflicts('+threadsafe', when='+cxx')
     conflicts('+threadsafe', when='+fortran')
 
+    patch('h5f90global-mult-obj-same-equivalence-same-common-block.patch',
+          when='@1.10.1%intel@18')
+
     def url_for_version(self, version):
         url = "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-{0}/hdf5-{1}/src/hdf5-{1}.tar.gz"
         return url.format(version.up_to(2), version)

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -74,6 +74,9 @@ class Hdf5(AutotoolsPackage):
     conflicts('+threadsafe', when='+cxx')
     conflicts('+threadsafe', when='+fortran')
 
+    # There are known build failures with intel@18.0.1. This issue is
+    # discussed and patch is provided at
+    # https://software.intel.com/en-us/forums/intel-fortran-compiler-for-linux-and-mac-os-x/topic/747951.
     patch('h5f90global-mult-obj-same-equivalence-same-common-block.patch',
           when='@1.10.1%intel@18')
 


### PR DESCRIPTION
This is known issue.  See
https://software.intel.com/en-us/forums/intel-fortran-compiler-for-linux-and-mac-os-x/topic/747951.

Without this patch, hdf5 fails to build with Intel 18 due to the error:

```
    PPFC     H5f90global.lo
libtool: compile:
    /usr/projects/hpcsoft/toss3/snow/openmpi/2.1.2-intel-18.0.1/bin/mpif90
    -I. -I../../src -O3 -I../../src -I../../fortran/src -fPIC -c H5f90global.F90
    -fPIC -o .libs/H5f90global.o
/yellow/usr/projects/user_contrib/spack.20170926/lib/spack/env/intel/ifort: line
    358:
    /yellow/users/kellyt/spack-cc-hdf5@1.10.1%intel@18.0.1+cxx~debug+fortran+mpi+pic+shared~szip~threadsafe
    arch=linux-rhel7-x86_64 /v3lut6o.in.log: No such file or directory
/yellow/usr/projects/user_contrib/spack.20170926/lib/spack/env/intel/ifort: line
    359:
    /yellow/users/kellyt/spack-cc-hdf5@1.10.1%intel@18.0.1+cxx~debug+fortran+mpi+pic+shared~szip~threadsafe
    arch=linux-rhel7-x86_64 /v3lut6o.out.log: No such file or directory
H5f90global.F90(145): error #7615: Multiple objects from the same EQUIVALENCE
    set may not appear in a COMMON block.   [H5T_NATIVE_INTEGER_KIND]
  EQUIVALENCE (predef_types(2), H5T_NATIVE_INTEGER_KIND(2))
--------------------------------^
H5f90global.F90(146): error #7615: Multiple objects from the same EQUIVALENCE
    set may not appear in a COMMON block.   [H5T_NATIVE_INTEGER_KIND]
  EQUIVALENCE (predef_types(3), H5T_NATIVE_INTEGER_KIND(3))
--------------------------------^
H5f90global.F90(147): error #7615: Multiple objects from the same EQUIVALENCE
    set may not appear in a COMMON block.   [H5T_NATIVE_INTEGER_KIND]
  EQUIVALENCE (predef_types(4), H5T_NATIVE_INTEGER_KIND(4))
--------------------------------^
H5f90global.F90(148): error #7615: Multiple objects from the same EQUIVALENCE
    set may not appear in a COMMON block.   [H5T_NATIVE_INTEGER_KIND]
  EQUIVALENCE (predef_types(5), H5T_NATIVE_INTEGER_KIND(5))
--------------------------------^
compilation aborted for H5f90global.F90 (code 1)
make[3]: *** [H5f90global.lo] Error 1
```

@junghans This patch was tested on snow/grizzly with intel/18.0.1.