### PR TITLE
config.py: fixed comments that refer to variables following them

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -74,7 +74,7 @@ import spack.schema
 import spack.util.spack_yaml as syaml
 
 
-"""Dict from section names -> schema for that section."""
+#: Dict from section names -> schema for that section
 section_schemas = {
     'compilers': spack.schema.compilers.schema,
     'mirrors': spack.schema.mirrors.schema,
@@ -84,9 +84,8 @@ section_schemas = {
     'config': spack.schema.config.schema,
 }
 
-"""OrderedDict of config scopes keyed by name.
-   Later scopes will override earlier scopes.
-"""
+#: OrderedDict of config scopes keyed by name.
+#: Later scopes will override earlier scopes.
 config_scopes = OrderedDict()
 
 
@@ -211,25 +210,25 @@ class ConfigScope(object):
 #
 _platform = spack.architecture.platform().name
 
-"""Default configuration scope is the lowest-level scope. These are
-   versioned with Spack and can be overridden by systems, sites or users."""
+#: Default configuration scope is the lowest-level scope. These are
+#: versioned with Spack and can be overridden by systems, sites or users.
 _defaults_path = os.path.join(spack.etc_path, 'spack', 'defaults')
 ConfigScope('defaults', _defaults_path)
 ConfigScope('defaults/%s' % _platform, os.path.join(_defaults_path, _platform))
 
-"""System configuration is per machine.
-   No system-level configs should be checked into spack by default"""
+#: System configuration is per machine.
+#: No system-level configs should be checked into spack by default
 _system_path = os.path.join(spack.system_etc_path, 'spack')
 ConfigScope('system', _system_path)
 ConfigScope('system/%s' % _platform, os.path.join(_system_path, _platform))
 
-"""Site configuration is per spack instance, for sites or projects.
-   No site-level configs should be checked into spack by default."""
+#: Site configuration is per spack instance, for sites or projects.
+#: No site-level configs should be checked into spack by default.
 _site_path = os.path.join(spack.etc_path, 'spack')
 ConfigScope('site', _site_path)
 ConfigScope('site/%s' % _platform, os.path.join(_site_path, _platform))
 
-"""User configuration can override both spack defaults and site config."""
+#: User configuration can override both spack defaults and site config.
 _user_path = spack.user_config_path
 ConfigScope('user', _user_path)
 ConfigScope('user/%s' % _platform, os.path.join(_user_path, _platform))


### PR DESCRIPTION
According to the documentation here:

  http://www.sphinx-doc.org/en/stable/ext/autodoc.html

> For module data members and class attributes, documentation can either be put into a comment with special formatting (using a #: to start the comment instead of just #), or in a docstring after the definition.