### PR TITLE
dealii: update and fix boost dependency

### DIFF
--- a/var/spack/repos/builtin/packages/dealii/boost_1.65.1_singleton.patch
+++ b/var/spack/repos/builtin/packages/dealii/boost_1.65.1_singleton.patch
@@ -1,0 +1,43 @@
+diff --git a/boost/serialization/singleton.hpp b/boost/serialization/singleton.hpp
+index b50afed..e891d55 100644
+--- a/boost/serialization/singleton.hpp
++++ b/boost/serialization/singleton.hpp
+@@ -91,7 +91,7 @@ class BOOST_SYMBOL_VISIBLE singleton_module :
+     public boost::noncopyable
+ {
+ private:
+-    BOOST_SERIALIZATION_DECL BOOST_DLLEXPORT static bool & get_lock() BOOST_USED;
++    BOOST_DLLEXPORT static bool & get_lock() BOOST_USED;
+ public:
+     BOOST_DLLEXPORT static void lock(){
+         get_lock() = true;
+@@ -115,7 +115,7 @@ private:
+         // use a wrapper so that types T with protected constructors
+         // can be used
+         class singleton_wrapper : public T {};
+-        static singleton_wrapper t;
++        static singleton_wrapper* t = new singleton_wrapper;
+         // refer to instance, causing it to be instantiated (and
+         // initialized at startup on working compilers)
+         BOOST_ASSERT(! is_destroyed());
+@@ -125,7 +125,9 @@ private:
+         // our usage/implementation of "locking" and introduce uncertainty into
+         // the sequence of object initializaition.
+         use(& m_instance);
+-        return static_cast<T &>(t);
++        if (!t)
++            t = new singleton_wrapper;
++        return static_cast<T &>(*t);
+     }
+     static bool & get_is_destroyed(){
+         static bool is_destroyed;
+@@ -147,6 +149,9 @@ public:
+         get_is_destroyed() = false;
+     }
+     BOOST_DLLEXPORT ~singleton() {
++        if (!get_is_destroyed()) {
++            delete &(get_instance());
++        }
+         get_is_destroyed() = true;
+     }
+ };

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -89,30 +89,22 @@ class Dealii(CMakePackage, CudaPackage):
 
     # required dependencies, light version
     depends_on('blas')
-    # Boost 1.58 is blacklisted, see
+    # Boost 1.58 is blacklisted, require at least 1.59, see
     # https://github.com/dealii/dealii/issues/1591
-    # Require at least 1.59
-    # There are issues with 1.65.1 but not with 1.65.0:
+    # There are issues with 1.65.1 and 1.65.0:
     # https://github.com/dealii/dealii/issues/5262
-    # +python won't affect @:8.4.2
-    # FIXME: once concretizer can unite unconditional and
-    # conditional dependencies, simplify to:
-    # depends_on('boost@1.59.0+thread+system+serialization+iostreams')
-    # depends_on('boost+mpi', when='+mpi')
-    # depends_on('boost+python', when='+python')
-    depends_on('boost@1.59.0:1.63,1.65.0,1.66:+thread+system+serialization+iostreams',
-               when='@:8.4.2~mpi')
-    depends_on('boost@1.59.0:1.63,1.65.0,1.66:+thread+system+serialization+iostreams+mpi',
-               when='@:8.4.2+mpi')
-    # since @8.5.0: (and @develop) python bindings are introduced:
-    depends_on('boost@1.59.0:1.63,1.65.0,1.66:+thread+system+serialization+iostreams',
-               when='@8.5.0:~mpi~python')
-    depends_on('boost@1.59.0:1.63,1.65.0,1.66:+thread+system+serialization+iostreams+mpi',
-               when='@8.5.0:+mpi~python')
-    depends_on('boost@1.59.0:1.63,1.65.0,1.66:+thread+system+serialization+iostreams+python',
-               when='@8.5.0:~mpi+python')
-    depends_on('boost@1.59.0:1.63,1.65.0,1.66:+thread+system+serialization+iostreams+mpi+python',
-               when='@8.5.0:+mpi+python')
+    # we take the patch from https://github.com/boostorg/serialization/pull/79
+    # more precisely its variation https://github.com/dealii/dealii/pull/5572#issuecomment-349742019
+    depends_on('boost@1.59.0:1.63,1.65.1+thread+system+serialization+iostreams',
+               patches=patch('boost_1.65.1_singleton.patch',
+                       level=1,
+                       when='@1.65.1'),
+               when='~python')
+    depends_on('boost@1.59.0:1.63,1.65.1+thread+system+serialization+iostreams+python',
+               patches=patch('boost_1.65.1_singleton.patch',
+                       level=1,
+                       when='@1.65.1'),
+               when='+python')
     # bzip2 is not needed since 9.0
     depends_on('bzip2', when='@:8.99')
     depends_on('lapack')


### PR DESCRIPTION
(i) blacklst 1.65.0 due to issues on Ubuntu with gcc 5.4.0
(ii) add a patch for 1.65.1 to fix serialization
(iii) simplify boost's depends_on()

p.s. i was wrong about 1.65.0 https://github.com/dealii/dealii/pull/5572#issuecomment-349295859