### PR TITLE
add restriction to py-setuptools dependency on py-flake8

### DIFF
--- a/var/spack/repos/builtin/packages/py-flake8/package.py
+++ b/var/spack/repos/builtin/packages/py-flake8/package.py
@@ -40,7 +40,7 @@ class PyFlake8(PythonPackage):
 
     # Most Python packages only require py-setuptools as a build dependency.
     # However, py-flake8 requires py-setuptools during runtime as well.
-    depends_on('py-setuptools', type=('build', 'run'))
+    depends_on('py-setuptools@30:', type=('build', 'run'))
 
     # pyflakes >= 0.8.1, != 1.2.0, != 1.2.1, != 1.2.2, < 1.3.0
     depends_on('py-pyflakes@0.8.1:1.1.0,1.2.3:1.2.3', when='@3.0.4', type=('build', 'run'))


### PR DESCRIPTION
Note: This exposes a compatibility issue with `py-ipython` which depends on `py-backports-shutil-get-terminal-size` which depends (as build dependency only) on `py-setuptools:30.99.99`. 

Currently it is not possible to concretize a spec that has conflicting build and run dependencies. All other packages (in all of spack) depend on `py-setuptools@x.y:` so I'm not sure if that adds to much pressure on a concretizer that is able to handle such cases, but for our meta-package it results in a broken `py-flake8` build and after this is merged will result in a failure to concretize.

Is there an estimate on when the new concretizer will be implemented? @scheibelp @tgamblin @adamjstewart 