### PR TITLE
📦 Update openSSL to 1.0.2m/1.1.0g

### DIFF
--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -36,16 +36,18 @@ class Openssl(Package):
     homepage = "http://www.openssl.org"
 
     # URL must remain http:// so Spack can bootstrap curl
-    url = "http://www.openssl.org/source/openssl-1.0.1h.tar.gz"
+    url = "http://www.openssl.org/source/openssl-1.0.2m.tar.gz"
     list_url = "https://www.openssl.org/source/old/"
     list_depth = 1
 
+    version('1.1.0g', 'ba5f1b8b835b88cadbce9b35ed9531a6')
     version('1.1.0e', '51c42d152122e474754aea96f66928c6')
     version('1.1.0d', '711ce3cd5f53a99c0e12a7d5804f0f63')
     version('1.1.0c', '601e8191f72b18192a937ecf1a800f3f')
     # Note: Version 1.0.2 is the "long-term support" version that will
     # remain supported until 2019.
-    version('1.0.2k', 'f965fc0bf01bf882b31314b61391ae65', preferred=True)
+    version('1.0.2m', '10e9e37f492094b9ef296f68f24a7666', preferred=True)
+    version('1.0.2k', 'f965fc0bf01bf882b31314b61391ae65')
     version('1.0.2j', '96322138f0b69e61b7212bc53d5e912b')
     version('1.0.2i', '678374e63f8df456a697d3e5e5a931fb')
     version('1.0.2h', '9392e65072ce4b614c1392eefc1f23d0')


### PR DESCRIPTION
I think a critical piece of software like openSSL should _always_ be kept as up-to-date as possible.