### PR TITLE
qrupdate: fix blas/lapack and compilation of macOS

### DIFF
--- a/var/spack/repos/builtin/packages/qrupdate/package.py
+++ b/var/spack/repos/builtin/packages/qrupdate/package.py
@@ -22,10 +22,12 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
+import os
+import sys
 from spack import *
 
 
-class Qrupdate(Package):
+class Qrupdate(MakefilePackage):
     """qrupdate is a Fortran library for fast updates of QR and
     Cholesky decompositions."""
 
@@ -37,7 +39,30 @@ class Qrupdate(Package):
     depends_on("blas")
     depends_on("lapack")
 
+    def edit(self, spec, prefix):
+        # BSD "install" does not understand GNU -D flag.
+        # We will create the parent directory ourselves.
+        makefile = FileFilter('src/Makefile')
+        if (sys.platform == 'darwin'):
+            makefile.filter('-D', '')
+        return
+
     def install(self, spec, prefix):
+        lapack_blas = spec['lapack'].libs + spec['blas'].libs
         # Build static and dynamic libraries
-        make("lib", "solib")
+        make('lib', 'solib',
+             'BLAS={0}'.format(lapack_blas.ld_flags),
+             'LAPACK={0}'.format(lapack_blas.ld_flags))
+        # "INSTALL" confuses "make install" on case-insensitive filesystems
+        if os.path.isfile("INSTALL"):
+            os.remove("INSTALL")
+        # create lib folder:
+        if (sys.platform == 'darwin'):
+            mkdirp(prefix.lib)
         make("install", "PREFIX=%s" % prefix)
+
+    @run_after('install')
+    def fix_darwin_install(self):
+        # The shared libraries are not installed correctly on Darwin:
+        if (sys.platform == 'darwin'):
+            fix_darwin_install_name(self.spec.prefix.lib)


### PR DESCRIPTION
```
$ otool -L /Users/davydden/spack/opt/spack/darwin-highsierra-x86_64/clang-9.0.0-apple/qrupdate-1.1.2-t55vinef7373d5raoagedhrasf2kfnst/lib/libqrupdate.dylib
/Users/davydden/spack/opt/spack/darwin-highsierra-x86_64/clang-9.0.0-apple/qrupdate-1.1.2-t55vinef7373d5raoagedhrasf2kfnst/lib/libqrupdate.dylib:
	/Users/davydden/spack/opt/spack/darwin-highsierra-x86_64/clang-9.0.0-apple/qrupdate-1.1.2-t55vinef7373d5raoagedhrasf2kfnst/lib/libqrupdate.1.1.dylib (compatibility version 0.0.0, current version 0.0.0)
	/Users/davydden/spack/opt/spack/darwin-highsierra-x86_64/clang-9.0.0-apple/openblas-0.2.20-a2w7heujstxj3l65sbcbonk4yh6ta55z/lib/libopenblas_sandybridge-r0.2.20.dylib (compatibility version 0.0.0, current version 0.0.0)
	/Users/davydden/spack/opt/spack/darwin-highsierra-x86_64/clang-9.0.0-apple/gcc-7.2.0-e53qfxjc74d75oxruzukyozsscuzvzt7/lib/libgfortran.4.dylib (compatibility version 5.0.0, current version 5.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.0.0)
	/Users/davydden/spack/opt/spack/darwin-highsierra-x86_64/clang-9.0.0-apple/gcc-7.2.0-e53qfxjc74d75oxruzukyozsscuzvzt7/lib/libgcc_s.1.dylib (compatibility version 1.0.0, current version 1.0.0)
	/Users/davydden/spack/opt/spack/darwin-highsierra-x86_64/clang-9.0.0-apple/gcc-7.2.0-e53qfxjc74d75oxruzukyozsscuzvzt7/lib/libquadmath.0.dylib (compatibility version 1.0.0, current version 1.0.0)
```

fixes are from https://github.com/Homebrew/homebrew-core/blob/master/Formula/qrupdate.rb