### PR TITLE
Updated hash for v1.0 tag of Laghos

### DIFF
--- a/var/spack/repos/builtin/packages/laghos/package.py
+++ b/var/spack/repos/builtin/packages/laghos/package.py
@@ -37,7 +37,7 @@ class Laghos(MakefilePackage):
     git      = "https://github.com/CEED/Laghos"
     url      = "https://github.com/CEED/Laghos/archive/v1.0.tar.gz"
 
-    version('1.0', '107c2f693936723e764a4d404d33d44a')
+    version('1.0', '4c091e115883c79bed81c557ef16baff')
     version('develop', git=git, branch='master')
 
     depends_on('mpi')


### PR DESCRIPTION
We needed to update the v1.0 tag of Laghos and hash has changed (we are not planning to update this tag again).