### PR TITLE
Added missing dependency

### DIFF
--- a/var/spack/repos/builtin/packages/r-rhtslib/package.py
+++ b/var/spack/repos/builtin/packages/r-rhtslib/package.py
@@ -39,3 +39,4 @@ class RRhtslib(RPackage):
 
     depends_on('r@3.4.0:3.4.9', when='@1.8.0')
     depends_on('r-zlibbioc', type=('build', 'run'))
+    depends_on('autoconf@2.69', type='build')

--- a/var/spack/repos/builtin/packages/r-rhtslib/package.py
+++ b/var/spack/repos/builtin/packages/r-rhtslib/package.py
@@ -39,4 +39,4 @@ class RRhtslib(RPackage):
 
     depends_on('r@3.4.0:3.4.9', when='@1.8.0')
     depends_on('r-zlibbioc', type=('build', 'run'))
-    depends_on('autoconf@2.69', type='build')
+    depends_on('autoconf@2.67:', type='build')


### PR DESCRIPTION
# Description

While installing `r-rhtslib` the following error was reported:

```
     585   aclocal.m4:17: warning: this file was generated for autoconf 2.69.
     586   You have another version of autoconf.  It may work, but is not guaranteed to.
     587   If you have problems, you may need to regenerate the build system entirely.
     588   To do so, use the procedure documented by the package, typically 'autoreconf'.
  >> 589   configure.ac:30: error: Autoconf version 2.67 or higher is required
  >> 590   configure.ac:30: the top level
     591   autom4te: /usr/bin/m4 failed with exit status: 63
     592   WARNING: 'autoconf' is probably too old.
     593            You should only need it if you modified 'configure.ac',
     594            or m4 files included by it.
     595            The 'autoconf' program is part of the GNU Autoconf package:
     596            <http://www.gnu.org/software/autoconf/>
     597            It also requires GNU m4 and Perl in order to run:
     598            <http://www.gnu.org/software/m4/>
     599            <http://www.perl.org/>
```

I assume it was using the system autoconf package initially. After changing the spec the build and install stages completed without errors. 