### PR TITLE
Add: Py-Plotly

### DIFF
--- a/var/spack/repos/builtin/packages/py-plotly/package.py
+++ b/var/spack/repos/builtin/packages/py-plotly/package.py
@@ -1,0 +1,39 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyPlotly(PythonPackage):
+    """An interactive, browser-based graphing library for Python"""
+
+    homepage = "https://plot.ly/python/"
+    url      = "https://github.com/plotly/plotly.py/archive/v2.2.0.tar.gz"
+
+    version('2.2.0', '835802cdc6743439ff993447dfe47a0e')
+
+    depends_on('py-setuptools', type='build')
+    depends_on('py-requests@2.3.0', type=('build', 'run'))
+    depends_on('py-six@1.8.0', type=('build', 'run'))
+    depends_on('py-pytz@2014.9', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-pytz/package.py
+++ b/var/spack/repos/builtin/packages/py-pytz/package.py
@@ -38,6 +38,7 @@ class PyPytz(PythonPackage):
     version('2016.10',  'cc9f16ba436efabdcef3c4d32ae4919c')
     version('2016.6.1', 'b6c28a3b968bc1d8badfb61b93874e03')
     version('2014.10',  'eb1cb941a20c5b751352c52486aa1dd7')
+    version('2014.9',   'd42bda2f4c1e873e02fbd1e4acfd1b8c')
     version('2015.4',   '417a47b1c432d90333e42084a605d3d8')
     version('2016.3',   'abae92c3301b27bd8a9f56b14f52cb29')
 

--- a/var/spack/repos/builtin/packages/py-requests/package.py
+++ b/var/spack/repos/builtin/packages/py-requests/package.py
@@ -45,6 +45,7 @@ class PyRequests(PythonPackage):
     version('2.14.2', '4c3c169ed67466088a2a6947784fe444')
     version('2.13.0', '921ec6b48f2ddafc8bb6160957baf444')
     version('2.11.1', 'ad5f9c47b5c5dfdb28363ad7546b0763')
+    version('2.3.0',  '7449ffdc8ec9ac37bbcd286003c80f00')
 
     depends_on('py-setuptools', type='build')
 

--- a/var/spack/repos/builtin/packages/py-six/package.py
+++ b/var/spack/repos/builtin/packages/py-six/package.py
@@ -35,6 +35,7 @@ class PySix(PythonPackage):
 
     version('1.10.0', '34eed507548117b2ab523ab14b2f8b55')
     version('1.9.0',  '476881ef4012262dfc8adc645ee786c4')
+    version('1.8.0',  '1626eb24cc889110c38f7e786ec69885')
 
     extends('python', ignore=r'bin/pytest')
 


### PR DESCRIPTION
The requirements of py-plotlit are rather strict fixed to specific versions, so I did not add an "upper versions" `:` to the constrains.

See
  https://github.com/plotly/plotly.py/blob/master/requirements.txt