### PR TITLE
Fix AstroPy: Missing Markupsafe

### DIFF
--- a/var/spack/repos/builtin/packages/py-astropy/package.py
+++ b/var/spack/repos/builtin/packages/py-astropy/package.py
@@ -50,6 +50,7 @@ class PyAstropy(PythonPackage):
     depends_on('py-pytz', type=('build', 'run'))
     depends_on('py-scikit-image', type=('build', 'run'))
     depends_on('py-pandas', type=('build', 'run'))
+    depends_on('py-markupsafe', type=('build', 'run'))
 
     # System dependencies
     depends_on('cfitsio')


### PR DESCRIPTION
`py-markupsafe` was missing during `spack install` as a build error.