### PR TITLE
openssl: Update to 1.0.2n

### DIFF
--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -46,7 +46,8 @@ class Openssl(Package):
     version('1.1.0c', '601e8191f72b18192a937ecf1a800f3f')
     # Note: Version 1.0.2 is the "long-term support" version that will
     # remain supported until 2019.
-    version('1.0.2m', '10e9e37f492094b9ef296f68f24a7666', preferred=True)
+    version('1.0.2n', '13bdc1b1d1ff39b6fd42a255e74676a4', preferred=True)
+    version('1.0.2m', '10e9e37f492094b9ef296f68f24a7666')
     version('1.0.2k', 'f965fc0bf01bf882b31314b61391ae65')
     version('1.0.2j', '96322138f0b69e61b7212bc53d5e912b')
     version('1.0.2i', '678374e63f8df456a697d3e5e5a931fb')


### PR DESCRIPTION
From 07.12.2017, fixes CVE-2017-3737

This issue does not affect OpenSSL 1.1.0.

OpenSSL 1.0.2 users should upgrade to 1.0.2n.