### PR TITLE
Add new package minisign

### DIFF
--- a/var/spack/repos/builtin/packages/minisign/package.py
+++ b/var/spack/repos/builtin/packages/minisign/package.py
@@ -1,0 +1,36 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Minisign(CMakePackage):
+    """Minisign is a dead simple tool to sign files and verify signatures."""
+
+    homepage = "https://jedisct1.github.io/minisign/"
+    url = "https://github.com/jedisct1/minisign/archive/0.7.tar.gz"
+
+    version('0.7', 'd634202555c4f499e8ef9d6848d6f4ca')
+
+    depends_on('libsodium')


### PR DESCRIPTION
A dead simple tool to sign files and verify signatures.

See https://jedisct1.github.io/minisign

Build is confirmed to be working on Debian 9 and latest spack@develop.