### PR TITLE
Add new package signify

### DIFF
--- a/var/spack/repos/builtin/packages/signify/package.py
+++ b/var/spack/repos/builtin/packages/signify/package.py
@@ -1,0 +1,39 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Signify(MakefilePackage):
+    """OpenBSD tool to signs and verify signatures on files."""
+
+    homepage = "https://github.com/aperezdc/signify"
+    url      = "https://github.com/aperezdc/signify/archive/v23.tar.gz"
+
+    version('23', '0552295572a172740ae8427eb018ede8')
+
+    depends_on('libbsd@0.8:')
+
+    def setup_environment(self, spack_env, run_env):
+        spack_env.set('PREFIX', self.prefix)


### PR DESCRIPTION
OpenBSD tool to sign and verify signatures on files.

See https://github.com/aperezdc/signify

Build is confirmed to be working on Debian 9 and spack@95a384f05107cc80e0da7d5e7a5b75380ebf76f3.