### PR TITLE
rsem: update version 1.3.0 md5sum

### DIFF
--- a/var/spack/repos/builtin/packages/rsem/package.py
+++ b/var/spack/repos/builtin/packages/rsem/package.py
@@ -32,7 +32,7 @@ class Rsem(MakefilePackage):
     homepage = "http://deweylab.github.io/RSEM/"
     url      = "https://github.com/deweylab/RSEM/archive/v1.3.0.tar.gz"
 
-    version('1.3.0', '9728161625d339d022130e2428604bf5')
+    version('1.3.0', '273fd755e23d349cc38a079b81bb03b6')
 
     depends_on('r', type=('build', 'run'))
     depends_on('perl', type=('build', 'run'))


### PR DESCRIPTION
It looks like the software was re-released requiring a new md5sum.  