### PR TITLE
atom-dft: new package plus dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/atom-dft/package.py
+++ b/var/spack/repos/builtin/packages/atom-dft/package.py
@@ -41,12 +41,12 @@ class AtomDft(MakefilePackage):
 
     def edit(self, spec, prefix):
         shutil.copyfile('arch.make.sample', 'arch.make')
-        makefile = FileFilter('arch.make')
-        makefile.filter('XMLF90_ROOT=.*', 'XMLF90_ROOT = %s' %
-                        spec['xmlf90'].prefix)
-        makefile.filter('GRIDXC_ROOT=.*', 'GRIDXC_ROOT = %s' %
-                        spec['libgridxc'].prefix)
-        makefile.filter('FC=.*', 'FC = fc')
+
+    @property
+    def build_targets(self):
+        return ['XMLF90_ROOT=%s' % self.spec['xmlf90'].prefix,
+                'GRIDXC_ROOT=%s' % self.spec['libgridxc'].prefix,
+                'FC=fc']
 
     def install(self, spec, prefix):
         mkdir(prefix.bin)

--- a/var/spack/repos/builtin/packages/atom-dft/package.py
+++ b/var/spack/repos/builtin/packages/atom-dft/package.py
@@ -1,0 +1,53 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
+from spack import *
+import shutil
+
+
+class AtomDft(MakefilePackage):
+    """ATOM is a program for DFT calculations in atoms and pseudopotential
+       generation."""
+
+    homepage = "https://departments.icmab.es/leem/siesta/Pseudopotentials/"
+    url      = "https://departments.icmab.es/leem/siesta/Pseudopotentials/Code/atom-4.2.6.tgz"
+
+    version('4.2.6', 'c0c80cf349f951601942ed6c7cb0256b')
+
+    depends_on('libgridxc')
+    depends_on('xmlf90')
+
+    def edit(self, spec, prefix):
+        shutil.copyfile('arch.make.sample', 'arch.make')
+        makefile = FileFilter('arch.make')
+        makefile.filter('XMLF90_ROOT=.*', 'XMLF90_ROOT = %s' %
+                        spec['xmlf90'].prefix)
+        makefile.filter('GRIDXC_ROOT=.*', 'GRIDXC_ROOT = %s' %
+                        spec['libgridxc'].prefix)
+        makefile.filter('FC=.*', 'FC = %s' % self.compiler.fc)
+
+    def install(self, spec, prefix):
+        mkdir(prefix.bin)
+        install('atm', prefix.bin)

--- a/var/spack/repos/builtin/packages/atom-dft/package.py
+++ b/var/spack/repos/builtin/packages/atom-dft/package.py
@@ -46,7 +46,7 @@ class AtomDft(MakefilePackage):
                         spec['xmlf90'].prefix)
         makefile.filter('GRIDXC_ROOT=.*', 'GRIDXC_ROOT = %s' %
                         spec['libgridxc'].prefix)
-        makefile.filter('FC=.*', 'FC = %s' % self.compiler.fc)
+        makefile.filter('FC=.*', 'FC = fc')
 
     def install(self, spec, prefix):
         mkdir(prefix.bin)

--- a/var/spack/repos/builtin/packages/libgridxc/package.py
+++ b/var/spack/repos/builtin/packages/libgridxc/package.py
@@ -43,9 +43,7 @@ class Libgridxc(Package):
         with working_dir('build', create=True):
             sh('../src/config.sh')
             shutil.copyfile('../extra/fortran.mk', 'fortran.mk')
-            makefile = FileFilter('fortran.mk')
-            makefile.filter('FC=.*', 'FC = fc')
 
     def install(self, spec, prefix):
         with working_dir('build'):
-            make('PREFIX=%s' % self.prefix)
+            make('PREFIX=%s' % self.prefix, 'FC=fc')

--- a/var/spack/repos/builtin/packages/libgridxc/package.py
+++ b/var/spack/repos/builtin/packages/libgridxc/package.py
@@ -44,7 +44,7 @@ class Libgridxc(Package):
             sh('../src/config.sh')
             shutil.copyfile('../extra/fortran.mk', 'fortran.mk')
             makefile = FileFilter('fortran.mk')
-            makefile.filter('FC=.*', 'FC = %s' % self.compiler.fc)
+            makefile.filter('FC=.*', 'FC = fc')
 
     def install(self, spec, prefix):
         with working_dir('build'):

--- a/var/spack/repos/builtin/packages/libgridxc/package.py
+++ b/var/spack/repos/builtin/packages/libgridxc/package.py
@@ -1,0 +1,51 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
+from spack import *
+import shutil
+
+
+class Libgridxc(Package):
+    """A library to compute the exchange and correlation energy and potential
+       in spherical (i.e. an atom) or periodic systems."""
+
+    homepage = "https://launchpad.net/libgridxc"
+    url      = "https://launchpad.net/libgridxc/trunk/0.7/+download/libgridxc-0.7.6.tgz"
+
+    version('0.7.6', 'a593f845d7565a168f1cf515a0a89879')
+
+    phases = ['configure', 'install']
+
+    def configure(self, spec, prefix):
+        sh = which('sh')
+        with working_dir('build', create=True):
+            sh('../src/config.sh')
+            shutil.copyfile('../extra/fortran.mk', 'fortran.mk')
+            makefile = FileFilter('fortran.mk')
+            makefile.filter('FC=.*', 'FC = %s' % self.compiler.fc)
+
+    def install(self, spec, prefix):
+       with working_dir('build'):
+            make('PREFIX=%s' % self.prefix)

--- a/var/spack/repos/builtin/packages/libgridxc/package.py
+++ b/var/spack/repos/builtin/packages/libgridxc/package.py
@@ -47,5 +47,5 @@ class Libgridxc(Package):
             makefile.filter('FC=.*', 'FC = %s' % self.compiler.fc)
 
     def install(self, spec, prefix):
-       with working_dir('build'):
+        with working_dir('build'):
             make('PREFIX=%s' % self.prefix)

--- a/var/spack/repos/builtin/packages/xmlf90/package.py
+++ b/var/spack/repos/builtin/packages/xmlf90/package.py
@@ -1,0 +1,54 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
+from spack import *
+
+
+class Xmlf90(AutotoolsPackage):
+    """xmlf90 is a suite of libraries to handle XML in Fortran."""
+
+    homepage = "https://launchpad.net/xmlf90"
+    url      = "https://launchpad.net/xmlf90/trunk/1.5/+download/xmlf90-1.5.2.tgz"
+
+    version('1.5.2', '324fdcba7dafce83db26e72aab9f6656')
+
+    depends_on('autoconf@2.69:', type='build')
+    depends_on('automake@1.14:', type='build')
+    depends_on('libtool@2.4.2:', type='build')
+    depends_on('m4',             type='build')
+
+    def autoreconf(self, spec, prefix):
+        sh = which('sh')
+        sh('autogen.sh')
+
+    def configure_args(self):
+        if self.spec.satisfies('%gcc'):
+            return ['FCFLAGS=-ffree-line-length-none']
+        return []
+
+    @run_after('install')
+    def fix_mk(self):
+        install(join_path(self.prefix, 'share', 'org.siesta-project',
+                          'xmlf90.mk'), prefix)


### PR DESCRIPTION
ATOM is a companion tool to SIESTA (for which there is still an open pull request #6466). I decided to name the package _atom-dft_ as to not confuse people who think of the Atom text editor when they see a package named _atom_.

Two dependency libraries are included in this pull request, though they are probably not useful for anything outside the SIESTA ecosystem.