### PR TITLE
build lapacke with tmg

### DIFF
--- a/var/spack/repos/builtin/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-lapack/package.py
@@ -119,10 +119,12 @@ class NetlibLapack(Package):
     def install_one(self, spec, prefix, shared):
         cmake_args = [
             '-DBUILD_SHARED_LIBS:BOOL=%s' % ('ON' if shared else 'OFF'),
-            '-DCMAKE_BUILD_TYPE:STRING=%s' % (
-                'Debug' if '+debug' in spec else 'Release'),
-            '-DLAPACKE:BOOL=%s'          % ('ON' if '+lapacke' in spec else 'OFF'),
-            '-DLAPACKE_WITH_TMG:BOOL=%s' % ('ON' if '+lapacke' in spec else 'OFF')]
+            '-DCMAKE_BUILD_TYPE:STRING=%s' %
+                ('Debug' if '+debug' in spec else 'Release'),
+            '-DLAPACKE:BOOL=%s' %
+                ('ON' if '+lapacke' in spec else 'OFF'),
+            '-DLAPACKE_WITH_TMG:BOOL=%s' %
+                ('ON' if '+lapacke' in spec else 'OFF')]
         if spec.satisfies('@3.6.0:'):
             cmake_args.extend(['-DCBLAS=ON'])  # always build CBLAS
 

--- a/var/spack/repos/builtin/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-lapack/package.py
@@ -121,7 +121,8 @@ class NetlibLapack(Package):
             '-DBUILD_SHARED_LIBS:BOOL=%s' % ('ON' if shared else 'OFF'),
             '-DCMAKE_BUILD_TYPE:STRING=%s' % (
                 'Debug' if '+debug' in spec else 'Release'),
-            '-DLAPACKE:BOOL=%s' % ('ON' if '+lapacke' in spec else 'OFF')]
+            '-DLAPACKE:BOOL=%s'          % ('ON' if '+lapacke' in spec else 'OFF'),
+            '-DLAPACKE_WITH_TMG:BOOL=%s' % ('ON' if '+lapacke' in spec else 'OFF')]
         if spec.satisfies('@3.6.0:'):
             cmake_args.extend(['-DCBLAS=ON'])  # always build CBLAS
 

--- a/var/spack/repos/builtin/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-lapack/package.py
@@ -119,12 +119,12 @@ class NetlibLapack(Package):
     def install_one(self, spec, prefix, shared):
         cmake_args = [
             '-DBUILD_SHARED_LIBS:BOOL=%s' % ('ON' if shared else 'OFF'),
-            '-DCMAKE_BUILD_TYPE:STRING=%s' %
-                ('Debug' if '+debug' in spec else 'Release'),
-            '-DLAPACKE:BOOL=%s' %
-                ('ON' if '+lapacke' in spec else 'OFF'),
-            '-DLAPACKE_WITH_TMG:BOOL=%s' %
-                ('ON' if '+lapacke' in spec else 'OFF')]
+            '-DCMAKE_BUILD_TYPE:STRING=%s' % (
+                'Debug' if '+debug' in spec else 'Release'),
+            '-DLAPACKE:BOOL=%s' % (
+                'ON' if '+lapacke' in spec else 'OFF'),
+            '-DLAPACKE_WITH_TMG:BOOL=%s' % (
+                'ON' if '+lapacke' in spec else 'OFF')]
         if spec.satisfies('@3.6.0:'):
             cmake_args.extend(['-DCBLAS=ON'])  # always build CBLAS
 


### PR DESCRIPTION
Build the LAPACKE interface with TMG routines to get a more complete liblapacke.
Functions like LAPACKE_zlatms* are currently missing.