### PR TITLE
Add opengl package

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -21,7 +21,7 @@ packages:
       blas: [openblas]
       daal: [intel-daal]
       elf: [elfutils]
-      gl: [opengl]
+      gl: [opengl, mesa]
       golang: [gcc]
       ipp: [intel-ipp]
       java: [jdk]
@@ -37,7 +37,3 @@ packages:
       szip: [libszip, libaec]
       tbb: [intel-tbb]
       jpeg: [libjpeg-turbo, libjpeg]
-  opengl:
-    paths:
-      opengl: /usr
-    buildable: False

--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -21,6 +21,7 @@ packages:
       blas: [openblas]
       daal: [intel-daal]
       elf: [elfutils]
+      gl: [opengl]
       golang: [gcc]
       ipp: [intel-ipp]
       java: [jdk]
@@ -36,3 +37,7 @@ packages:
       szip: [libszip, libaec]
       tbb: [intel-tbb]
       jpeg: [libjpeg-turbo, libjpeg]
+  opengl:
+    paths:
+      opengl: /usr
+    buildable: False

--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -21,7 +21,7 @@ packages:
       blas: [openblas]
       daal: [intel-daal]
       elf: [elfutils]
-      gl: [opengl, mesa]
+      gl: [mesa, opengl]
       golang: [gcc]
       ipp: [intel-ipp]
       java: [jdk]

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -46,7 +46,9 @@ class Mesa(AutotoolsPackage):
     version('12.0.6', '1a3d4fea0656c208db59289e4ed33b3f')
     version('12.0.3', '1113699c714042d8c4df4766be8c57d8')
 
-    provides('gl')
+    provides('gl@:4.5', when='@17:')
+    provides('gl@:4.4', when='@13:')
+    provides('gl@:4.3', when='@12:')
 
     variant('swrender', default=True,
             description="Build with (gallium) software rendering.")

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -46,6 +46,8 @@ class Mesa(AutotoolsPackage):
     version('12.0.6', '1a3d4fea0656c208db59289e4ed33b3f')
     version('12.0.3', '1113699c714042d8c4df4766be8c57d8')
 
+    provides('gl')
+
     variant('swrender', default=True,
             description="Build with (gallium) software rendering.")
     variant('hwrender', default=False,

--- a/var/spack/repos/builtin/packages/opengl/package.py
+++ b/var/spack/repos/builtin/packages/opengl/package.py
@@ -1,0 +1,56 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Opengl(Package):
+    """Placeholder for external OpenGL libraries from hardware vendors"""
+
+    homepage = "https://www.opengl.org/"
+    url      = "https://www.opengl.org/"
+
+    version('3.2', 'N/A')
+
+    provides('gl')
+
+    def install(self, spec, prefix):
+        msg = """This package is intended to be a placeholder for
+        system-provided OpenGL libraries from hardware vendors.  Please
+        download and install OpenGL drivers/libraries for your graphics
+        hardware separately, and then set that up as an external package.
+        An example of a working packages.yaml:
+
+        packages:
+          opengl:
+            paths:
+              opengl: /opt/opengl
+            buildable: False
+
+        In that case, /opt/opengl/ should contain these two folders:
+
+        include/GL/       (opengl headers, including "gl.h")
+        lib               (opengl libraries, including "libGL.so")"""
+
+        raise InstallError(msg)

--- a/var/spack/repos/builtin/packages/opengl/package.py
+++ b/var/spack/repos/builtin/packages/opengl/package.py
@@ -33,7 +33,9 @@ class Opengl(Package):
 
     version('3.2', 'N/A')
 
-    provides('gl')
+    provides('gl@:4.5', when='@:4.5')
+    provides('gl@:4.4', when='@:4.4')
+    provides('gl@:4.3', when='@:4.3')
 
     def install(self, spec, prefix):
         msg = """This package is intended to be a placeholder for
@@ -45,7 +47,7 @@ class Opengl(Package):
         packages:
           opengl:
             paths:
-              opengl: /opt/opengl
+              opengl@4.5.0: /opt/opengl
             buildable: False
 
         In that case, /opt/opengl/ should contain these two folders:

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -126,8 +126,7 @@ class Qt(Package):
     depends_on("python", when='@5.7.0:', type='build')
 
     # OpenGL hardware acceleration
-    depends_on("mesa", when='@4:+opengl')
-
+    depends_on("gl@3.2:", when='@4:+opengl')
     depends_on("libxcb", when=sys.platform != 'darwin')
     depends_on("libx11", when=sys.platform != 'darwin')
 


### PR DESCRIPTION
In the absence of some kind of opengl package, VTK and ParaView can end up finding the Mesa opengl implementation when `+qt` is enabled, which results in greatly reduced rendering performance (especially if llvmpipe is not used).  The intent of this PR is to add a package which is not intended to be built, but is rather just a placeholder for system-installed opengl implementation (usually provided by drivers specific to graphics hardware).