### PR TITLE
py-pyvcf: new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyvcf/package.py
+++ b/var/spack/repos/builtin/packages/py-pyvcf/package.py
@@ -22,32 +22,12 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install py-pyvcf
-#
-# You can edit this file again by typing:
-#
-#     spack edit py-pyvcf
-#
-# See the Spack documentation for more information on packaging.
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
 from spack import *
-
 
 class PyPyvcf(PythonPackage):
     """PyVCF - A Variant Call Format Parser for Python"""
 
-    # FIXME: Add a proper url for your package's homepage here.
     homepage = "https://github.com/jamescasbon/PyVCF"
     url      = "https://github.com/jamescasbon/PyVCF/archive/v0.6.0.tar.gz"
 
     version('0.6.0', '5e38a610b1bf837e5e74a748e281cec7')
-
-    # depends_on('py-setuptools', type='build')
-    # depends_on('py-foo',        type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-pyvcf/package.py
+++ b/var/spack/repos/builtin/packages/py-pyvcf/package.py
@@ -1,0 +1,53 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install py-pyvcf
+#
+# You can edit this file again by typing:
+#
+#     spack edit py-pyvcf
+#
+# See the Spack documentation for more information on packaging.
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+from spack import *
+
+
+class PyPyvcf(PythonPackage):
+    """PyVCF - A Variant Call Format Parser for Python"""
+
+    # FIXME: Add a proper url for your package's homepage here.
+    homepage = "https://github.com/jamescasbon/PyVCF"
+    url      = "https://github.com/jamescasbon/PyVCF/archive/v0.6.0.tar.gz"
+
+    version('0.6.0', '5e38a610b1bf837e5e74a748e281cec7')
+
+    # depends_on('py-setuptools', type='build')
+    # depends_on('py-foo',        type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-pyvcf/package.py
+++ b/var/spack/repos/builtin/packages/py-pyvcf/package.py
@@ -31,4 +31,5 @@ class PyPyvcf(PythonPackage):
     homepage = "https://github.com/jamescasbon/PyVCF"
     url      = "https://github.com/jamescasbon/PyVCF/archive/v0.6.0.tar.gz"
 
+    version('0.6.7', '51b57ce99e0c2f7be2a18d08d8f87734')
     version('0.6.0', '5e38a610b1bf837e5e74a748e281cec7')

--- a/var/spack/repos/builtin/packages/py-pyvcf/package.py
+++ b/var/spack/repos/builtin/packages/py-pyvcf/package.py
@@ -24,6 +24,7 @@
 ##############################################################################
 from spack import *
 
+
 class PyPyvcf(PythonPackage):
     """PyVCF - A Variant Call Format Parser for Python"""
 


### PR DESCRIPTION
A VCFv4.0 and 4.1 parser for Python.

Prerequisite for MetaSV.