### PR TITLE
Added opengl enabled qt variant as dep for vtk

### DIFF
--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -46,7 +46,7 @@ class Vtk(CMakePackage):
 
     patch('gcc.patch', when='@6.1.0')
 
-    depends_on('qt')
+    depends_on('qt+opengl')
     depends_on('hdf5')
     depends_on('netcdf')
     depends_on('netcdf-cxx')


### PR DESCRIPTION
# Description

While installing `vtk` I received the following error:

```
CMake Error at /mnt/grsoftfs3/spaghetti/linux-centos6-x86_64/gcc-7.2.0/qt-5.9.1-falmiei4h7qf6dbe4pu3kbypxnflo645/lib/cmake/Qt5/Qt5Config.cmake:28 (find_package):
  Could not find a package configuration file provided by "Qt5OpenGL" with
  any of the following names:

    Qt5OpenGLConfig.cmake
    qt5opengl-config.cmake

  Add the installation prefix of "Qt5OpenGL" to CMAKE_PREFIX_PATH or set
  "Qt5OpenGL_DIR" to a directory containing one of the above files.  If
  "Qt5OpenGL" provides a separate development package or SDK, be sure it has
  been installed.
Call Stack (most recent call first):
  GUISupport/QtOpenGL/CMakeLists.txt:17 (find_package)


-- Configuring incomplete, errors occurred!
```

After changing the dependency to include the opengl enabled variant for `qt` the configuration proceeds and concludes without errors. 