### PR TITLE
Ignore log files that appear in root dir with "spack -d install ..."

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@
 .#*
 /.cache
 /bin/spackc
+*.in.log
+*.out.log


### PR DESCRIPTION
I noticed recently that when I install packages with the `-d` option, I have started getting a bunch of log files in the root directory of the repository:

```console
$ git status
On branch develop
Your branch is up-to-date with 'origin/develop'.
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	spack-cc-binutils-4an3yhe.in.log
	spack-cc-binutils-4an3yhe.out.log
        ...
```

This PR make sure that git ignores those to avoid cluttering up status output.