### PR TITLE
Hadoop: Replace broken url

### DIFF
--- a/var/spack/repos/builtin/packages/hadoop/package.py
+++ b/var/spack/repos/builtin/packages/hadoop/package.py
@@ -32,7 +32,7 @@ class Hadoop(Package):
     """
 
     homepage = "http://hadoop.apache.org/"
-    url      = "http://mirrors.ocf.berkeley.edu/apache/hadoop/common/hadoop-2.6.4/hadoop-2.6.4.tar.gz"
+    url      = "http://mirrors.ocf.berkeley.edu/apache/hadoop/common/hadoop-2.9.0/hadoop-2.9.0.tar.gz"
 
     version('2.9.0', 'b443ead81aa2bd5086f99e62e66a8f64')
 

--- a/var/spack/repos/builtin/packages/hadoop/package.py
+++ b/var/spack/repos/builtin/packages/hadoop/package.py
@@ -34,7 +34,7 @@ class Hadoop(Package):
     homepage = "http://hadoop.apache.org/"
     url      = "http://mirrors.ocf.berkeley.edu/apache/hadoop/common/hadoop-2.6.4/hadoop-2.6.4.tar.gz"
 
-    version('2.6.4', '37019f13d7dcd819727be158440b9442')
+    version('2.9.0', 'b443ead81aa2bd5086f99e62e66a8f64')
 
     depends_on('java', type='run')
 


### PR DESCRIPTION
The url for Hadoop 2.6.4 no longer exists, and the mirror doesn't have a 2.6.4 area anymore. This PR replaces it with the latest stable, 2.9.0.