### PR TITLE
CONFIG: adjust openfoam-org for new version

### DIFF
--- a/var/spack/repos/builtin/packages/openfoam-org/50-etc.patch
+++ b/var/spack/repos/builtin/packages/openfoam-org/50-etc.patch
@@ -1,0 +1,24 @@
+--- OpenFOAM-5.x.org/etc/bashrc	2017-07-25 18:43:40.000000000 +0200
++++ OpenFOAM-5.x/etc/bashrc	2017-12-11 13:36:09.479818186 +0100
+@@ -42,15 +42,17 @@
+ #
+ # Please set to the appropriate path if the default is not correct.
+ #
+-[ ${BASH_SOURCE:-$0} ] && \
+-export FOAM_INST_DIR=$(cd $(dirname ${BASH_SOURCE:-$0})/../.. && pwd -P) || \
+-export FOAM_INST_DIR=$HOME/$WM_PROJECT
+-# export FOAM_INST_DIR=~$WM_PROJECT
++rc="${BASH_SOURCE:-${ZSH_NAME:+$0}}"
++[ -n "$rc" ] && FOAM_INST_DIR=$(\cd $(dirname $rc)/../.. && \pwd -P) || \
++FOAM_INST_DIR=$HOME/$WM_PROJECT
+ # export FOAM_INST_DIR=/opt/$WM_PROJECT
+ # export FOAM_INST_DIR=/usr/local/$WM_PROJECT
+ #
+ # END OF (NORMAL) USER EDITABLE PART
+ ################################################################################
++: # Extra safety - if the user commented out all fallback values
++export FOAM_INST_DIR
++unset rc
+ 
+ # The default environment variables below can be overridden in a prefs.sh file
+ # located in ~/.OpenFOAM/$WM_PROJECT_VERSION, ~/.OpenFOAM,

--- a/var/spack/repos/builtin/packages/openfoam-org/package.py
+++ b/var/spack/repos/builtin/packages/openfoam-org/package.py
@@ -81,7 +81,9 @@ class OpenfoamOrg(Package):
     baseurl  = "https://github.com/OpenFOAM"
     url      = "https://github.com/OpenFOAM/OpenFOAM-4.x/archive/version-4.1.tar.gz"
 
-    version('4.1', '318a446c4ae6366c7296b61184acd37c',
+    version('5.0', 'cd8c5bdd3ff39c34f61747c8e55f59d1',
+            url=baseurl + '/OpenFOAM-5.x/archive/version-5.0.tar.gz')
+    version('4.1', 'afd7d8e66e7db0ffaf519b14f1a8e1d4',
             url=baseurl + '/OpenFOAM-4.x/archive/version-4.1.tar.gz')
     version('develop', git='https://github.com/OpenFOAM/OpenFOAM-dev.git')
 
@@ -107,8 +109,9 @@ class OpenfoamOrg(Package):
     assets = ['bin/foamEtcFile']
 
     # Version-specific patches
+    patch('50-etc.patch', when='@5.0:')
     patch('41-etc.patch', when='@4.1')
-    patch('41-site.patch', when='@4.1')
+    patch('41-site.patch', when='@4.1:')
 
     # Some user config settings
     config = {


### PR DESCRIPTION
- similar to PR https://github.com/spack/spack/pull/6336 but retaining
  and improving the bashrc patch.

  Reuse the settings patch from 41, nothing changed there.

@pkoro