### PR TITLE
relion - changed 'cuda_arch' conditional

### DIFF
--- a/var/spack/repos/builtin/packages/relion/package.py
+++ b/var/spack/repos/builtin/packages/relion/package.py
@@ -78,7 +78,7 @@ class Relion(CMakePackage):
 
         carch = self.spec.variants['cuda_arch'].value
 
-        if carch is not None:
+        if '+cuda_arch' in self.spec:
             args += [
                 '-DCUDA_ARCH=%s' % (carch),
             ]


### PR DESCRIPTION
Hi

Without this change ```-DCUDA_ARCH``` will be defined even when no value's set.  This causes it to be used as cmake argument which then makes relion think it's compiling with ```+cuda``` when that's not the case.

The latest change will only use ```cuda_arch``` variant when it's explicitly used like ```cuda_arch=6.0```.