### PR TITLE
moltemplate: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-moltemplate/package.py
+++ b/var/spack/repos/builtin/packages/py-moltemplate/package.py
@@ -1,0 +1,38 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyMoltemplate(PythonPackage):
+    """Moltemplate is a general cross-platform text-based molecule builder for
+    LAMMPS."""
+
+    homepage = "http://moltemplate.org"
+    url      = "https://github.com/jewettaij/moltemplate/archive/v2.5.8.tar.gz"
+
+    version('2.5.8', '9e127a254a206222e8a31684780f8dba')
+
+    depends_on('python@2.7:',   type=('build', 'run'))
+    depends_on('py-setuptools', type=('build', 'run'))


### PR DESCRIPTION
[README](https://github.com/jewettaij/moltemplate/blob/master/README.md#installation-example) suggest using `pip`, but `PythonPackage` worked just fine. The package is mostly python, but the main usage AFAICT is from the bash script `moltemplate.sh`.

EDIT: `spack activate py-setuptools@35.0.2` fixed issue below.

~~WIP as I currently have~~

```
$ spack load python
$ spack load py-moltemplate@2.5.8
// run script:
moltemplate.sh v2.5.8 2017-11-06

Traceback (most recent call last):
  File ".../spack/opt/spack/darwin-highsierra-x86_64/clang-9.0.0-apple/py-moltemplate-2.5.8-xi3ehimlchbhrb6jbcatb6fdnipeeg6c/bin/lttree.py", line 7, in <module>
    from pkg_resources import load_entry_point
ImportError: No module named pkg_resources
```

any hints are more than welcome.

@vishalkenchan any ideas?