### PR TITLE
Relion 2.1 - Now Using CudaPackage class 

### DIFF
--- a/var/spack/repos/builtin/packages/relion/package.py
+++ b/var/spack/repos/builtin/packages/relion/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from spack.build_systems.cuda import CudaPackage
 
 
 class Relion(CMakePackage, CudaPackage):

--- a/var/spack/repos/builtin/packages/relion/package.py
+++ b/var/spack/repos/builtin/packages/relion/package.py
@@ -34,8 +34,8 @@ class Relion(CMakePackage):
     homepage = "http://http://www2.mrc-lmb.cam.ac.uk/relion"
     url      = "https://github.com/3dem/relion"
 
-    version('2.0.3', git='https://github.com/3dem/relion.git', tag='2.0.3')
     version('2.1', git='https://github.com/3dem/relion.git', tag='2.1')
+    version('2.0.3', git='https://github.com/3dem/relion.git', tag='2.0.3')
     version('develop', git='https://github.com/3dem/relion.git')
 
     variant('gui', default=True, description="build the gui")

--- a/var/spack/repos/builtin/packages/relion/package.py
+++ b/var/spack/repos/builtin/packages/relion/package.py
@@ -23,9 +23,10 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+from spack.build_systems.cuda import CudaPackage
 
 
-class Relion(CMakePackage):
+class Relion(CMakePackage, CudaPackage):
     """RELION (for REgularised LIkelihood OptimisatioN, pronounce rely-on) is a
     stand-alone computer program that employs an empirical Bayesian approach to
     refinement of (multiple) 3D reconstructions or 2D class averages in
@@ -40,10 +41,6 @@ class Relion(CMakePackage):
 
     variant('gui', default=True, description="build the gui")
     variant('cuda', default=True, description="enable compute on gpu")
-    variant('cuda_arch', default=None, description='CUDA architecture',
-           values=('20', '30', '32', '35', '50', '52', '53', '60', '61', '62'
-               '70'),
-           multi=True)
     variant('double', default=True, description="double precision (cpu) code")
     variant('double-gpu', default=False, description="double precision (gpu) code")
     variant('build_type', default='RelWithDebInfo',
@@ -68,15 +65,15 @@ class Relion(CMakePackage):
             '-DDoublePrec_CPU=%s' % ('+double' in self.spec),
             '-DDoublePrec_GPU=%s' % ('+double-gpu' in self.spec),
         ]
+
+        carch = self.spec.variants['cuda_arch'].value
+
         if '+cuda' in self.spec:
             args += [
                 '-DCUDA=on',
             ]
-
-        carch = self.spec.variants['cuda_arch'].value
-
-        if carch is not None:
-            args += [
-                '-DCUDA_ARCH=%s' % (carch),
-            ]
+            if carch is not None:
+                args += [
+                    '-DCUDA_ARCH=%s' % (carch),
+                ]
         return args

--- a/var/spack/repos/builtin/packages/relion/package.py
+++ b/var/spack/repos/builtin/packages/relion/package.py
@@ -35,8 +35,7 @@ class Relion(CMakePackage):
     url      = "https://github.com/3dem/relion"
 
     version('2.0.3', git='https://github.com/3dem/relion.git', tag='2.0.3')
-    version('2.1', git='https://github.com/3dem/relion.git', tag='2.1',
-        preferred='true')
+    version('2.1', git='https://github.com/3dem/relion.git', tag='2.1')
     version('develop', git='https://github.com/3dem/relion.git')
 
     variant('gui', default=True, description="build the gui")

--- a/var/spack/repos/builtin/packages/relion/package.py
+++ b/var/spack/repos/builtin/packages/relion/package.py
@@ -34,11 +34,9 @@ class Relion(CMakePackage):
     homepage = "http://http://www2.mrc-lmb.cam.ac.uk/relion"
     url      = "https://github.com/3dem/relion"
 
-    version('2.1-beta-1', git='https://github.com/3dem/relion.git',
-            commit='e7607a869687b636d3c39e0d5b6a9cba930fc3b2')
-    version('2.0.3', git='https://github.com/3dem/relion.git',
-            preferred='true')
-
+    version('2.0.3', git='https://github.com/3dem/relion.git', tag='2.0.3')
+    version('2.1', git='https://github.com/3dem/relion.git', tag='2.1',
+        preferred='true')
     version('develop', git='https://github.com/3dem/relion.git')
 
     variant('gui', default=True, description="build the gui")


### PR DESCRIPTION
Though per #6070 should this auto-detect hardware?  I still have to do:

```spack install relion@2.1+cuda cuda_arch=62```

Otherwise ```-DCUDA_ARCH``` will be used as cmake argument but contain no value.
