### PR TITLE
separate stdout and stderr for module loading

### DIFF
--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -133,7 +133,10 @@ def load_module(mod):
             exec(compile(modulecmd('unload', text[i + 1], output=str,
                                    error=str), '<string>', 'exec'))
     # Load the module now that there are no conflicts
-    load = modulecmd('load', mod, output=str, error=str)
+    # Some module systems use stdout and some use stderr
+    load = modulecmd('load', mod, output=str, error='/dev/null')
+    if not load:
+        load = modulecmd('load', mod, error=str)
     exec(compile(load, '<string>', 'exec'))
 
 


### PR DESCRIPTION
User reported a syntax error when lmod automatically swapped modules on module load.

Problem: Spack previously combined stdout and stderr from modulecmd because some systems use stdout and some use stderr. Systems that use stdout sometimes print messages from modulecmd through stderr

Solution: Check stdout for modulecmd output and use it if present, ignoring stderr. If no stdout, use stderr.