### PR TITLE
HDF5 : Add compiler flag args for HDF5 build when using MPI

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -27,6 +27,7 @@ import shutil
 import sys
 import os
 
+
 class Hdf5(AutotoolsPackage):
 
     """HDF5 is a data model, library, and file format for storing and managing
@@ -219,7 +220,6 @@ class Hdf5(AutotoolsPackage):
             CXXFLAGS.append(self.compiler.pic_flag)
             FFLAGS.append(self.compiler.pic_flag)
 
-
         if '+mpi' in self.spec:
             # The HDF5 configure script warns if cxx and mpi are enabled
             # together. There doesn't seem to be a real reason for this, except
@@ -240,7 +240,6 @@ class Hdf5(AutotoolsPackage):
             CXXFLAGS.append(os.environ['CXXFLAGS'])
             FFLAGS.append(os.environ['FFLAGS'])
             LDFLAGS.append(os.environ['LDFLAGS'])
-
 
         extra_args.append('CFLAGS=' + (' '.join(CFLAGS)))
         extra_args.append('CXXFLAGS=' + (' '.join(CXXFLAGS)))


### PR DESCRIPTION
This commit modifies the HDF5 package file to explicitly pass in
spack provided compiler flags when a MPI wrapper compiler is being
used.  This commit fixes the issue of spack flags being ignored
when HDF5 is built with `+mpi` and `+pic`.