### PR TITLE
METIS : Add empty compiler flags for METIS build to use spack flags

### DIFF
--- a/var/spack/repos/builtin/packages/metis/package.py
+++ b/var/spack/repos/builtin/packages/metis/package.py
@@ -94,6 +94,11 @@ class Metis(Package):
         options = ['COPTIONS={0}'.format(self.compiler.pic_flag)]
         if '+debug' in spec:
             options.append('OPTFLAGS=-g -O0')
+        else:
+            # ignore default optimization flags and allow spack compiler
+            # wrapper to inject flags in.
+            options.append('OPTFLAGS= ')
+
         make(*options)
 
         # Compile and install library files


### PR DESCRIPTION
This commit changes the METIS package file to pass in default empty
compiler flags to prevent METIS from using default compiler flags
that can override spack provided flags.