### PR TITLE
apply sqlite B0 patch to additional versions

### DIFF
--- a/var/spack/repos/builtin/packages/sqlite/package.py
+++ b/var/spack/repos/builtin/packages/sqlite/package.py
@@ -50,7 +50,7 @@ class Sqlite(AutotoolsPackage):
     # defines a macro B0. Sqlite has a shell.c source file that declares a
     # variable named B0 and will fail to compile when the macro is found. The
     # following patch undefines the macro in shell.c
-    patch('sqlite_b0.patch', when='@3.18.0')
+    patch('sqlite_b0.patch', when='@3.18.0:3.21.0')
 
     # Starting version 3.17.0, SQLite uses compiler built-ins
     # __builtin_sub_overflow(), __builtin_add_overflow(), and


### PR DESCRIPTION
Fix for #6698. The patch needs to be applied to additional versions. The sqlite community had a fix in https://www.sqlite.org/src/info/b9a58daca80a815e, which should have made it into the 3.19.0 version, but a subsequent change in https://www.sqlite.org/src/info/17e0bb12d82b510b did not carry over that change. Hopefully this will get resolved in the next sqlite release, so I am optimistically only applying the patch through the current latest version of sqlite.