### PR TITLE
octave: add optim and struct packages

### DIFF
--- a/var/spack/repos/builtin/packages/octave-optim/package.py
+++ b/var/spack/repos/builtin/packages/octave-optim/package.py
@@ -1,0 +1,50 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+import os
+
+
+class OctaveOptim(Package):
+    """Non-linear optimization toolkit for Octave."""
+
+    homepage = "https://octave.sourceforge.io/optim/"
+    url      = "https://downloads.sourceforge.net/octave/optim-1.5.2.tar.gz"
+
+    version('1.5.2', 'd3d77982869ea7c1807b13b24e044d44')
+
+    depends_on('octave-struct@1.0.12:')
+
+    extends('octave@3.6.0:')
+
+    def install(self, spec, prefix):
+        os.environ.pop('CC', '')
+        os.environ.pop('CXX', '')
+        os.environ.pop('FC', '')
+        octave('--quiet',
+               '--norc',
+               '--built-in-docstrings-file=/dev/null',
+               '--texi-macros-file=/dev/null',
+               '--eval', 'pkg prefix %s; pkg install %s' %
+               (prefix, self.stage.archive_file))

--- a/var/spack/repos/builtin/packages/octave-struct/package.py
+++ b/var/spack/repos/builtin/packages/octave-struct/package.py
@@ -1,0 +1,48 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+import os
+
+
+class OctaveStruct(Package):
+    """Additional structure manipulation functions for Octave."""
+
+    homepage = "https://octave.sourceforge.io/struct/"
+    url      = "https://downloads.sourceforge.net/octave/struct-1.0.14.tar.gz"
+
+    version('1.0.14', '3589d5eb8000f18426e2178587eb82f4')
+
+    extends('octave@2.9.7:')
+
+    def install(self, spec, prefix):
+        os.environ.pop('CC', '')
+        os.environ.pop('CXX', '')
+        os.environ.pop('FC', '')
+        octave('--quiet',
+               '--norc',
+               '--built-in-docstrings-file=/dev/null',
+               '--texi-macros-file=/dev/null',
+               '--eval', 'pkg prefix %s; pkg install %s' %
+               (prefix, self.stage.archive_file))


### PR DESCRIPTION
```
$octave
> pkg list
Package Name  | Version | Installation directory
--------------+---------+-----------------------
       optim  |   1.5.2 | /spack/opt/spack/darwin-highsierra-x86_64/clang-9.0.0-apple/octave-optim-1.5.2-4z4rlp2l7z4xa4qejacp2mm25wt3xtol/optim-1.5.2
     splines  |   1.3.1 | /spack/opt/spack/darwin-elcapitan-x86_64/clang-7.3.0-apple/octave-splines-1.3.1-gixlgu2uljonbdqoddq4yodo6mvyzagc/splines-1.3.1
      struct  |  1.0.14 | /spack/opt/spack/darwin-highsierra-x86_64/clang-9.0.0-apple/octave-struct-1.0.14-fiab2zsdhyzus6uhksi5uj3pesaxz6na/struct-1.0.14
```

**A general comment**: I think we need some custom `uninstall` for packages that extend `octave`. If I understand [documentation](https://www.gnu.org/software/octave/doc/v4.2.0/Installing-and-Removing-Packages.html) right, from `octave` we need to call `pkg uninstall <name>` to de-register a package.

p.s. Travis error appear to be un-related.