### PR TITLE
Explicitly listing the MPI compilers for Cmake configure for Tioga.

### DIFF
--- a/var/spack/repos/builtin/packages/tioga/package.py
+++ b/var/spack/repos/builtin/packages/tioga/package.py
@@ -48,7 +48,10 @@ class Tioga(CMakePackage):
 
         options = [
             '-DBUILD_SHARED_LIBS:BOOL=%s' % (
-                'ON' if '+shared' in spec else 'OFF')
+                'ON' if '+shared' in spec else 'OFF'),
+            '-DMPI_CXX_COMPILER:PATH=%s' % spec['mpi'].mpicxx,
+            '-DMPI_C_COMPILER:PATH=%s' % spec['mpi'].mpicc,
+            '-DMPI_Fortran_COMPILER:PATH=%s' % spec['mpi'].mpifc
         ]
 
         return options


### PR DESCRIPTION
Since I've been implementing Intel MPI I've been needing to add explicit listing of the MPI compilers to Cmake for the packages I'm using.