### PR TITLE
add OctavePackage

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2240,6 +2240,10 @@ The classes that are currently provided by Spack are:
     | :py:class:`.CMakePackage`     | Specialized class for packages   |
     |                               | built using CMake                |
     +-------------------------------+----------------------------------+
+    | :py:class:`.CudaPackage`      | A helper class for packages that |
+    |                               | use CUDA. It is intended to be   |
+    |                               | used in combination with others  |
+    +-------------------------------+----------------------------------+
     | :py:class:`.QMakePackage`     | Specialized class for packages   |
     |                               | build using QMake                |
     +-------------------------------+----------------------------------+
@@ -2251,6 +2255,9 @@ The classes that are currently provided by Spack are:
     +-------------------------------+----------------------------------+
     | :py:class:`.RPackage`         | Specialized class for            |
     |                               | :py:class:`.R` extensions        |
+    +-------------------------------+----------------------------------+
+    | :py:class:`.OctavePackage`    | Specialized class for            |
+    |                               | :py:class:`.Octave` packages     |
     +-------------------------------+----------------------------------+
     | :py:class:`.PythonPackage`    | Specialized class for            |
     |                               | :py:class:`.Python` extensions   |

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -184,9 +184,11 @@ from spack.build_systems.makefile import MakefilePackage
 from spack.build_systems.aspell_dict import AspellDictPackage
 from spack.build_systems.autotools import AutotoolsPackage
 from spack.build_systems.cmake import CMakePackage
+from spack.build_systems.cuda import CudaPackage
 from spack.build_systems.qmake import QMakePackage
 from spack.build_systems.scons import SConsPackage
 from spack.build_systems.waf import WafPackage
+from spack.build_systems.octave import OctavePackage
 from spack.build_systems.python import PythonPackage
 from spack.build_systems.r import RPackage
 from spack.build_systems.perl import PerlPackage
@@ -201,9 +203,11 @@ __all__ += [
     'AspellDictPackage',
     'AutotoolsPackage',
     'CMakePackage',
+    'CudaPackage',
     'QMakePackage',
     'SConsPackage',
     'WafPackage',
+    'OctavePackage',
     'PythonPackage',
     'RPackage',
     'PerlPackage',

--- a/lib/spack/spack/build_systems/octave.py
+++ b/lib/spack/spack/build_systems/octave.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import inspect
-import os
 
 from spack.directives import depends_on, extends
 from spack.package import PackageBase, run_after
@@ -49,13 +48,15 @@ class OctavePackage(PackageBase):
     extends('octave')
     depends_on('octave', type=('build', 'run'))
 
+    def setup_environment(self, spack_env, run_env):
+        """Set up the compile and runtime environments for a package."""
+        # octave does not like those environment variables to be set:
+        spack_env.unset('CC')
+        spack_env.unset('CXX')
+        spack_env.unset('FC')
+
     def install(self, spec, prefix):
         """Install the package from the archive file"""
-
-        # octave does not like those environment variables to be set:
-        os.environ.pop('CC', '')
-        os.environ.pop('CXX', '')
-        os.environ.pop('FC', '')
         inspect.getmodule(self).octave(
             '--quiet',
             '--norc',

--- a/lib/spack/spack/build_systems/octave.py
+++ b/lib/spack/spack/build_systems/octave.py
@@ -1,0 +1,70 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+import inspect
+import os
+
+from spack.directives import depends_on, extends
+from spack.package import PackageBase, run_after
+
+
+class OctavePackage(PackageBase):
+    """Specialized class for Octave packages. See
+    https://www.gnu.org/software/octave/doc/v4.2.0/Installing-and-Removing-Packages.html
+    for more information.
+
+    This class provides the following phases that can be overridden:
+
+    1. :py:meth:`~.OctavePackage.install`
+
+    """
+    # Default phases
+    phases = ['install']
+
+    # To be used in UI queries that require to know which
+    # build-system class we are using
+    build_system_class = 'OctavePackage'
+
+    extends('octave')
+    depends_on('octave', type=('build', 'run'))
+
+    def install(self, spec, prefix):
+        """Install the package from the archive file"""
+
+        # octave does not like those environment variables to be set:
+        os.environ.pop('CC', '')
+        os.environ.pop('CXX', '')
+        os.environ.pop('FC', '')
+        inspect.getmodule(self).octave(
+            '--quiet',
+            '--norc',
+            '--built-in-docstrings-file=/dev/null',
+            '--texi-macros-file=/dev/null',
+            '--eval', 'pkg prefix %s; pkg install %s' %
+            (prefix, self.stage.archive_file))
+
+    # Testing
+
+    # Check that self.prefix is there after installation
+    run_after('install')(PackageBase.sanity_check_prefix)

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -332,20 +332,13 @@ class PerlbuildPackageTemplate(PerlmakePackageTemplate):
 class OctavePackageTemplate(PackageTemplate):
     """Provides appropriate overrides for octave packages"""
 
+    base_class_name = 'OctavePackage'
+
     dependencies = """\
     extends('octave')
 
     # FIXME: Add additional dependencies if required.
     # depends_on('octave-foo', type=('build', 'run'))"""
-
-    body = """\
-    def install(self, spec, prefix):
-        # FIXME: Add logic to build and install here.
-        octave('--quiet', '--norc',
-               '--built-in-docstrings-file=/dev/null',
-               '--texi-macros-file=/dev/null',
-               '--eval', 'pkg prefix {0}; pkg install {1}'.format(
-                   prefix, self.stage.archive_file))"""
 
     def __init__(self, name, *args):
         # If the user provided `--name octave-splines`, don't rename it
@@ -464,6 +457,7 @@ class BuildSystemGuesser:
             (r'/Makefile\.PL$',       'perlmake'),
             (r'/.*\.pro$',            'qmake'),
             (r'/(GNU)?[Mm]akefile$',  'makefile'),
+            (r'/DESCRIPTION$',        'octave'),
         ]
 
         # Peek inside the compressed file.

--- a/var/spack/repos/builtin/packages/bohrium/package.py
+++ b/var/spack/repos/builtin/packages/bohrium/package.py
@@ -22,7 +22,6 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-from spack.build_systems.cuda import CudaPackage
 from spack import *
 from spack.package_test import compare_output
 from spack.util.executable import Executable

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from spack.build_systems.cuda import CudaPackage
 
 
 class Dealii(CMakePackage, CudaPackage):

--- a/var/spack/repos/builtin/packages/octave-optim/package.py
+++ b/var/spack/repos/builtin/packages/octave-optim/package.py
@@ -23,10 +23,9 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import os
 
 
-class OctaveOptim(Package):
+class OctaveOptim(OctavePackage):
     """Non-linear optimization toolkit for Octave."""
 
     homepage = "https://octave.sourceforge.io/optim/"
@@ -35,16 +34,4 @@ class OctaveOptim(Package):
     version('1.5.2', 'd3d77982869ea7c1807b13b24e044d44')
 
     depends_on('octave-struct@1.0.12:')
-
     extends('octave@3.6.0:')
-
-    def install(self, spec, prefix):
-        os.environ.pop('CC', '')
-        os.environ.pop('CXX', '')
-        os.environ.pop('FC', '')
-        octave('--quiet',
-               '--norc',
-               '--built-in-docstrings-file=/dev/null',
-               '--texi-macros-file=/dev/null',
-               '--eval', 'pkg prefix %s; pkg install %s' %
-               (prefix, self.stage.archive_file))

--- a/var/spack/repos/builtin/packages/octave-splines/package.py
+++ b/var/spack/repos/builtin/packages/octave-splines/package.py
@@ -25,20 +25,11 @@
 from spack import *
 
 
-class OctaveSplines(Package):
+class OctaveSplines(OctavePackage):
     """Additional spline functions."""
 
     homepage = "http://octave.sourceforge.net/splines/index.html"
     url      = "http://downloads.sourceforge.net/octave/splines-1.3.1.tar.gz"
 
     version('1.3.1', 'f9665d780c37aa6a6e17d1f424c49bdeedb89d1192319a4e39c08784122d18f9')
-
     extends('octave@3.6.0:')
-
-    def install(self, spec, prefix):
-        octave('--quiet',
-               '--norc',
-               '--built-in-docstrings-file=/dev/null',
-               '--texi-macros-file=/dev/null',
-               '--eval', 'pkg prefix %s; pkg install %s' %
-               (prefix, self.stage.archive_file))

--- a/var/spack/repos/builtin/packages/octave-struct/package.py
+++ b/var/spack/repos/builtin/packages/octave-struct/package.py
@@ -23,26 +23,13 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import os
 
 
-class OctaveStruct(Package):
+class OctaveStruct(OctavePackage):
     """Additional structure manipulation functions for Octave."""
 
     homepage = "https://octave.sourceforge.io/struct/"
     url      = "https://downloads.sourceforge.net/octave/struct-1.0.14.tar.gz"
 
     version('1.0.14', '3589d5eb8000f18426e2178587eb82f4')
-
     extends('octave@2.9.7:')
-
-    def install(self, spec, prefix):
-        os.environ.pop('CC', '')
-        os.environ.pop('CXX', '')
-        os.environ.pop('FC', '')
-        octave('--quiet',
-               '--norc',
-               '--built-in-docstrings-file=/dev/null',
-               '--texi-macros-file=/dev/null',
-               '--eval', 'pkg prefix %s; pkg install %s' %
-               (prefix, self.stage.archive_file))


### PR DESCRIPTION
EDIT: I think I figure out the installation. 

Overriding `uninstall` is still tricky as I can't get to `octave` executable the same way I did with `install`:
```
    def do_uninstall(self, force=False):
        """Uninstall this package by spec."""
        name = 'spline'
        inspect.getmodule(self).octave('pkg uninstall %s' % name)
        # delegate to instance-less method.
        Package.uninstall_by_spec(self.spec, force)
```
produces
```
==> Error: 'module' object has no attribute 'octave'
```

I guess I leave this for another time unless someone knows an easy fix.

----

~~it's WIP as I am bit confused why `setup_dependent_package()` is not called, defined in `octave` package~~ https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/octave/package.py#L234-L241

Maybe I just need to follow `PythonPackage` which has
```
import inspect
def python(self, *args, **kwargs):
        inspect.getmodule(self).python(*args, **kwargs)
```
and if I understand correctly is being used as `self.python`.

