### PR TITLE
Fix python3 compatibility bug in spack edit command

### DIFF
--- a/lib/spack/spack/cmd/edit.py
+++ b/lib/spack/spack/cmd/edit.py
@@ -120,8 +120,8 @@ def edit(parser, args):
             if not os.path.exists(path):
                 files = glob.glob(path + '*')
                 blacklist = ['.pyc', '~']  # blacklist binaries and backups
-                files = filter(lambda x: all(s not in x for s in blacklist),
-                               files)
+                files = list(filter(
+                    lambda x: all(s not in x for s in blacklist), files))
                 if len(files) > 1:
                     m = 'Multiple files exist with the name {0}.'.format(name)
                     m += ' Please specify a suffix. Files are:\n\n'


### PR DESCRIPTION
Fixes a Python 3 compatibility bug introduced by #6416.

When run with Python 3, I get the following error message:
```
$ spack edit -b python
==> Error: object of type 'filter' has no len()
```
In Python 2, `filter()` returns a list, but in Python 3, `filter()` returns an iterator, and iterators have no length.

@becker33 

P.S. Thoughts on how to write unit tests for `spack edit`? We're currently getting 37% coverage...