### PR TITLE
tcoffee: adding checksum for local archive

### DIFF
--- a/var/spack/repos/builtin/packages/tcoffee/package.py
+++ b/var/spack/repos/builtin/packages/tcoffee/package.py
@@ -31,7 +31,7 @@ class Tcoffee(MakefilePackage):
     homepage = "http://www.tcoffee.org/"
     url      = "https://github.com/cbcrg/tcoffee"
 
-    version('2017-08-17', 'a9dd7e5cf3bf71128cbe44daf71dd283', git='https://github.com/cbcrg/tcoffee.git', commit='f389b558e91d0f82e7db934d9a79ce285f853a71')
+    version('2017-08-17', '571cdc4920d9f3e07954193d2ca7a579', git='https://github.com/cbcrg/tcoffee.git', commit='f389b558e91d0f82e7db934d9a79ce285f853a71')
 
     depends_on('perl', type=('build', 'run'))
     depends_on('blast-plus')

--- a/var/spack/repos/builtin/packages/tcoffee/package.py
+++ b/var/spack/repos/builtin/packages/tcoffee/package.py
@@ -31,7 +31,10 @@ class Tcoffee(MakefilePackage):
     homepage = "http://www.tcoffee.org/"
     url      = "https://github.com/cbcrg/tcoffee"
 
-    version('2017-08-17', git='https://github.com/cbcrg/tcoffee.git', commit='f389b558e91d0f82e7db934d9a79ce285f853a71')
+    version('2017-08-17',
+        'a9dd7e5cf3bf71128cbe44daf71dd283',
+        git='https://github.com/cbcrg/tcoffee.git',
+	commit='f389b558e91d0f82e7db934d9a79ce285f853a71')
 
     depends_on('perl', type=('build', 'run'))
     depends_on('blast-plus')

--- a/var/spack/repos/builtin/packages/tcoffee/package.py
+++ b/var/spack/repos/builtin/packages/tcoffee/package.py
@@ -31,10 +31,7 @@ class Tcoffee(MakefilePackage):
     homepage = "http://www.tcoffee.org/"
     url      = "https://github.com/cbcrg/tcoffee"
 
-    version('2017-08-17',
-        'a9dd7e5cf3bf71128cbe44daf71dd283',
-        git='https://github.com/cbcrg/tcoffee.git',
-	commit='f389b558e91d0f82e7db934d9a79ce285f853a71')
+    version('2017-08-17', 'a9dd7e5cf3bf71128cbe44daf71dd283', git='https://github.com/cbcrg/tcoffee.git', commit='f389b558e91d0f82e7db934d9a79ce285f853a71')
 
     depends_on('perl', type=('build', 'run'))
     depends_on('blast-plus')


### PR DESCRIPTION
I have to use spack on a system with restricted access to the internet.  Having a local mirror is absolutely essential.  However, there are some packages that are defined as only available via git download; tcoffee is one of these.  However, when a md5sum is added to the definition, spack pulls from the mirror when available.   The only issue is that spack adds a potentially confusing warning message to the log.  For instance:

==> Installing tcoffee
==> Fetching file://my-mirror-dir/mirror/tcoffee/tcoffee-2017-08-17.tar.gz
######################################################################## 100.0%
==> Warning: Fetching from mirror without a checksum!
  This package is normally checked out from a version control system, but it has been archived on a spack mirror.  This means we cannot know a checksum for the tarball in advance. Be sure that your connection to this mirror is secure!
==> Staging archive: my-working-dir/spack/var/spack/stage/tcoffee-2017-08-17-zu53shzvl4e3fplz5wjtwzrwqqmiuzlg/tcoffee-2017-08-17.tar.gz