### PR TITLE
likwid: add stable 4.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/likwid/package.py
+++ b/var/spack/repos/builtin/packages/likwid/package.py
@@ -36,9 +36,8 @@ class Likwid(Package):
 
     maintainers = ['davydden']
 
-    # The hash for 4.3.0 changes regularly
-    version('4.3.0', '20541515fdc6d68e82628170e0042485')
-    version('4.2.1', 'c408ddcf0317cdd894af4c580cd74294', preferred=True)
+    version('4.3.0', '7f8f6981d7d341fce2621554323f8c8b')
+    version('4.2.1', 'c408ddcf0317cdd894af4c580cd74294')
     version('4.2.0', 'e41ff334b8f032a323d941ce32907a75')
     version('4.1.2', 'a857ce5bd23e31d96e2963fe81cb38f0')
 


### PR DESCRIPTION
according to the user forum, it's stable now https://groups.google.com/forum/#!topic/likwid-users/FyD38kQ_2JI