### PR TITLE
jags: lapack fix

### DIFF
--- a/var/spack/repos/builtin/packages/jags/package.py
+++ b/var/spack/repos/builtin/packages/jags/package.py
@@ -43,6 +43,6 @@ class Jags(AutotoolsPackage):
     conflicts('^openblas')
 
     def configure_args(self):
-        args = ['--with-blas=-L%s' % self.spec['blas'].prefix.lib,
-                '--with-lapack=-L%s' % self.spec['lapack'].prefix.lib]
+        args = ['--with-blas=%s' % self.spec['blas'].libs.ld_flags,
+                '--with-lapack=%s' % self.spec['lapack'].libs.ld_flags]
         return args

--- a/var/spack/repos/builtin/packages/jags/package.py
+++ b/var/spack/repos/builtin/packages/jags/package.py
@@ -40,7 +40,6 @@ class Jags(AutotoolsPackage):
     depends_on('blas')
     depends_on('lapack')
 
-    conflicts('^openblas')
 
     def configure_args(self):
         args = ['--with-blas=%s' % self.spec['blas'].libs.ld_flags,

--- a/var/spack/repos/builtin/packages/jags/package.py
+++ b/var/spack/repos/builtin/packages/jags/package.py
@@ -30,7 +30,7 @@ class Jags(AutotoolsPackage):
        Bayesian hierarchical models using Markov Chain Monte Carlo (MCMC)
        simulation not wholly unlike BUGS"""
 
-    tags=['mcmc','Gibbs sampler']
+    tags = ['mcmc', 'Gibbs sampler']
 
     homepage = "http://mcmc-jags.sourceforge.net/"
     url = "https://downloads.sourceforge.net/project/mcmc-jags/JAGS/4.x/Source/JAGS-4.2.0.tar.gz"
@@ -39,7 +39,6 @@ class Jags(AutotoolsPackage):
 
     depends_on('blas')
     depends_on('lapack')
-
 
     def configure_args(self):
         args = ['--with-blas=%s' % self.spec['blas'].libs.ld_flags,

--- a/var/spack/repos/builtin/packages/jags/package.py
+++ b/var/spack/repos/builtin/packages/jags/package.py
@@ -30,6 +30,8 @@ class Jags(AutotoolsPackage):
        Bayesian hierarchical models using Markov Chain Monte Carlo (MCMC)
        simulation not wholly unlike BUGS"""
 
+    tags=['mcmc','Gibbs sampler']
+
     homepage = "http://mcmc-jags.sourceforge.net/"
     url = "https://downloads.sourceforge.net/project/mcmc-jags/JAGS/4.x/Source/JAGS-4.2.0.tar.gz"
 
@@ -37,6 +39,8 @@ class Jags(AutotoolsPackage):
 
     depends_on('blas')
     depends_on('lapack')
+
+    conflicts('^openblas')
 
     def configure_args(self):
         args = ['--with-blas=-L%s' % self.spec['blas'].prefix.lib,


### PR DESCRIPTION
openblas gives the following error when installing jags:
`1 error found in build log:
     [ ... ]
     181   checking for sgemm_ in -lcxml... no
     182   checking for sgemm_ in -ldxml... no
     183   checking for sgemm_ in -lscs... no
     184   checking for sgemm_ in -lcomplib.sgimath... no
     185   checking for sgemm_ in -lblas... (cached) no
     186   checking for sgemm_ in -lblas... (cached) no
  >> 187   configure: error: "You need to install the LAPACK library"`

Seems to install fine with atlas.  Might work with other lapack providers, so rather then depend on atlas, I'm adding a conflict for openblas.

Also added tags.

