### PR TITLE
Blitz 1.0.1

### DIFF
--- a/var/spack/repos/builtin/packages/blitz/package.py
+++ b/var/spack/repos/builtin/packages/blitz/package.py
@@ -28,7 +28,7 @@ from spack import *
 class Blitz(AutotoolsPackage):
     """N-dimensional arrays for C++"""
     homepage = "http://github.com/blitzpp/blitz"
-    url = "https://github.com/blitzpp/blitz/tarball/1.0.0"
+    url = "https://github.com/blitzpp/blitz/archive/1.0.1.tar.gz"
 
     version('1.0.1', 'fe43e2cf6c9258bc8b369264dd008971')
     version('1.0.0', '9f040b9827fe22228a892603671a77af')

--- a/var/spack/repos/builtin/packages/blitz/package.py
+++ b/var/spack/repos/builtin/packages/blitz/package.py
@@ -30,6 +30,7 @@ class Blitz(AutotoolsPackage):
     homepage = "http://github.com/blitzpp/blitz"
     url = "https://github.com/blitzpp/blitz/tarball/1.0.0"
 
+    version('1.0.1', 'fe43e2cf6c9258bc8b369264dd008971')
     version('1.0.0', '9f040b9827fe22228a892603671a77af')
 
     build_targets = ['lib']

--- a/var/spack/repos/builtin/packages/blitz/package.py
+++ b/var/spack/repos/builtin/packages/blitz/package.py
@@ -31,7 +31,7 @@ class Blitz(AutotoolsPackage):
     url = "https://github.com/blitzpp/blitz/archive/1.0.1.tar.gz"
 
     version('1.0.1', 'fe43e2cf6c9258bc8b369264dd008971')
-    version('1.0.0', '9f040b9827fe22228a892603671a77af')
+    version('1.0.0', '971c43e22318bbfe8da016e6ef596234')
 
     build_targets = ['lib']
 


### PR DESCRIPTION
`blitz@1.0.0` does not build with `gcc@7`, as explained in https://github.com/blitzpp/blitz/issues/17. The latest release fixes these problems, so I have added the new version of blitz to the spack package (and made it the default).