### PR TITLE
Esmf fixes for Cray, OSX and mpich

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/darwin_dylib_install_name.patch
+++ b/var/spack/repos/builtin/packages/esmf/darwin_dylib_install_name.patch
@@ -1,0 +1,18 @@
+--- a/build/common.mk	2017-11-25 17:16:31.000000000 +1100
++++ b/build/common.mk	2017-11-25 17:26:20.000000000 +1100
+@@ -3415,11 +3415,11 @@
+ 		    mkdir tmp_$$NEXTLIB ;\
+ 		    cd tmp_$$NEXTLIB  ;\
+ 	                $(ESMF_AREXTRACT) ../$$NEXTLIB.a ;\
+-                    echo $(ESMF_SL_LIBLINKER) $(ESMF_SL_LIBOPTS) -o $(ESMF_LDIR)/$$NEXTLIB.$(ESMF_SL_SUFFIX) *.o $(ESMF_SL_LIBLIBS) ;\
+-		    $(ESMF_SL_LIBLINKER) $(ESMF_SL_LIBOPTS) -o $(ESMF_LDIR)/$$NEXTLIB.$(ESMF_SL_SUFFIX) *.o $(ESMF_SL_LIBLIBS) ;\
++		    echo $(ESMF_SL_LIBLINKER) $(ESMF_SL_LIBOPTS) -Wl,-install_name -Wl,@rpath/$$NEXTLIB.$(ESMF_SL_SUFFIX) -o $(ESMF_LDIR)/$$NEXTLIB.$(ESMF_SL_SUFFIX) *.o $(ESMF_SL_LIBLIBS) ;\
++		    $(ESMF_SL_LIBLINKER) $(ESMF_SL_LIBOPTS) -Wl,-install_name -Wl,@rpath/$$NEXTLIB.$(ESMF_SL_SUFFIX) -o $(ESMF_LDIR)/$$NEXTLIB.$(ESMF_SL_SUFFIX) *.o $(ESMF_SL_LIBLIBS) ;\
+ 		    echo Converting $$NEXTLIB.a to $$NEXTLIB\_fullylinked.$(ESMF_SL_SUFFIX) ;\
+-                    echo $(ESMF_SL_LIBLINKER) $(ESMF_SL_LIBOPTS) -o $(ESMF_LDIR)/$$NEXTLIB\_fullylinked.$(ESMF_SL_SUFFIX) *.o $(ESMF_CXXLINKOPTS) $(ESMF_CXXLINKPATHS) $(ESMF_CXXLINKRPATHS) $(ESMF_CXXLINKLIBS) ;\
+-		    $(ESMF_SL_LIBLINKER) $(ESMF_SL_LIBOPTS) -o $(ESMF_LDIR)/$$NEXTLIB\_fullylinked.$(ESMF_SL_SUFFIX) *.o $(ESMF_CXXLINKOPTS) $(ESMF_CXXLINKPATHS) $(ESMF_CXXLINKRPATHS) $(ESMF_CXXLINKLIBS) ;\
++		    echo $(ESMF_SL_LIBLINKER) $(ESMF_SL_LIBOPTS) -Wl,-install_name -Wl,@rpath/$$NEXTLIB\_fullylinked.$(ESMF_SL_SUFFIX) -o $(ESMF_LDIR)/$$NEXTLIB\_fullylinked.$(ESMF_SL_SUFFIX) *.o $(ESMF_CXXLINKOPTS) $(ESMF_CXXLINKPATHS) $(ESMF_CXXLINKRPATHS) $(ESMF_CXXLINKLIBS) ;\
++		    $(ESMF_SL_LIBLINKER) $(ESMF_SL_LIBOPTS) -Wl,-install_name -Wl,@rpath/$$NEXTLIB\_fullylinked.$(ESMF_SL_SUFFIX) -o $(ESMF_LDIR)/$$NEXTLIB\_fullylinked.$(ESMF_SL_SUFFIX) *.o $(ESMF_CXXLINKOPTS) $(ESMF_CXXLINKPATHS) $(ESMF_CXXLINKRPATHS) $(ESMF_CXXLINKLIBS) ;\
+ 		    cd .. ;\
+ 		    $(ESMF_RM) -r tmp_$$NEXTLIB ;\
+ 		fi ;\

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -69,6 +69,10 @@ class Esmf(MakefilePackage):
     # https://sourceforge.net/p/esmf/esmf/ci/34de0ccf556ba75d35c9687dae5d9f666a1b2a18/
     patch('mvapich2.patch', when='@:7.0.99')
 
+    # Allow different directories for creation and
+    # installation of dynamic libraries on OSX:
+    patch('darwin_dylib_install_name.patch', when='platform=darwin')
+
     # Make script from mvapich2.patch executable
     @run_before('build')
     @when('@:7.0.99')

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -149,7 +149,9 @@ class Esmf(MakefilePackage):
         # ESMF_COMM must be set to indicate which MPI implementation
         # is used to build the ESMF library.
         if '+mpi' in spec:
-            if '^mvapich2' in spec:
+            if 'platform=cray' in self.spec:
+                os.environ['ESMF_COMM'] = 'mpi'
+            elif '^mvapich2' in spec:
                 os.environ['ESMF_COMM'] = 'mvapich2'
             elif '^mpich' in spec:
                 # FIXME: mpich or mpich2?

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -104,7 +104,7 @@ class Esmf(MakefilePackage):
         # bin/binO/Linux.gfortran.64.default.default
         os.environ['ESMF_INSTALL_BINDIR'] = 'bin'
         os.environ['ESMF_INSTALL_LIBDIR'] = 'lib'
-        os.environ['ESMF_INSTALL_MODDIR'] = 'mod'
+        os.environ['ESMF_INSTALL_MODDIR'] = 'include'
 
         ############
         # Compiler #

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -158,8 +158,12 @@ class Esmf(MakefilePackage):
             elif '^mvapich2' in spec:
                 os.environ['ESMF_COMM'] = 'mvapich2'
             elif '^mpich' in spec:
-                # FIXME: mpich or mpich2?
+                # esmf@7.0.1 does not include configs for mpich3,
+                # so we start with the configs for mpich2:
                 os.environ['ESMF_COMM'] = 'mpich2'
+                # The mpich 3 series split apart the Fortran and C bindings,
+                # so we link the Fortran libraries when building C programs:
+                os.environ['ESMF_CXXLINKLIBS'] = '-lmpifort'
             elif '^openmpi' in spec:
                 os.environ['ESMF_COMM'] = 'openmpi'
             elif '^intel-parallel-studio+mpi' in spec:


### PR DESCRIPTION
This PR contains fixes that I found necessary to install and use esmf on several platforms.

When using spack to build fortran programs that depend on esmf modules, the esmf `.mod` files are not found unless they are installed in the `include` directory of the esmf package (https://github.com/spack/spack/commit/bd816fe05ebf04c11f0b122dac5e25788c08aac0).

On Cray XC40 platforms, esmf needs a nudge (https://github.com/spack/spack/commit/1a5e0c10f03c6605b0f8bcbae786f537c0edc364) to use the mpi configuration instead of mpiuni (i.e. single process).

On OSX platforms, esmf executables attempt to load the esmf libraries from the build directory, which is removed after installation. Special linker commands are needed to create libraries that are loaded via rpath instead of their absolute path at link-time (https://github.com/spack/spack/commit/8520f8c006da383a69bb838b9792865eb032c6c4).

When building with mpich, linking of executables failed because mpich3 uses separate Fortran and C libraries (unlike mpich2). The esmf release notes suggest a workaround, which is implemented in https://github.com/spack/spack/commit/c4587870e4be008642cc571655dac7ec2d21506d.
