### PR TITLE
py-biopython: remove py-mx dependency for recent versions

### DIFF
--- a/var/spack/repos/builtin/packages/py-biopython/package.py
+++ b/var/spack/repos/builtin/packages/py-biopython/package.py
@@ -37,5 +37,4 @@ class PyBiopython(PythonPackage):
     version('1.70', 'feff7a3e2777e43f9b13039b344e06ff')
     version('1.65', '143e7861ade85c0a8b5e2bbdd1da1f67')
 
-    depends_on('py-mx', type=('build', 'run'))
     depends_on('py-numpy', type=('build', 'run'))


### PR DESCRIPTION
[http://biopython.org/DIST/docs/install/Installation.html#htoc21](http://biopython.org/DIST/docs/install/Installation.html#htoc21)

> as of Biopython 1.50, mxTextTools is no longer used at all.