### PR TITLE
Add unit tests for spack versions command

### DIFF
--- a/lib/spack/spack/test/cmd/versions.py
+++ b/lib/spack/spack/test/cmd/versions.py
@@ -1,0 +1,46 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack.main import SpackCommand
+
+
+versions = SpackCommand('versions')
+
+
+def test_remote_versions():
+    """Test a package for which remote versions should be available."""
+
+    versions('zlib')
+
+
+def test_no_versions():
+    """Test a package for which no remote versions are available."""
+
+    versions('converge')
+
+
+def test_no_unchecksummed_versions():
+    """Test a package for which no unchecksummed versions are available."""
+
+    versions('bzip2')

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -196,7 +196,7 @@ def _spider(url, visited, root, depth, max_depth, raise_on_error):
     except URLError as e:
         tty.debug(e)
 
-        if isinstance(e.reason, ssl.SSLError):
+        if hasattr(e, 'reason') and isinstance(e.reason, ssl.SSLError):
             tty.warn("Spack was unable to fetch url list due to a certificate "
                      "verification problem. You can try running spack -k, "
                      "which will not check SSL certificates. Use this at your "


### PR DESCRIPTION
Fixes #6690.

This is an attempt to get better coverage of the `spack versions` command.

Not sure how people feel about tests that require internet access. Even with internet access, these tests sometimes get results and sometimes don't, so I was hesitant to require a certain output for any of these packages. This is more of a "I can run this command and it doesn't crash" test than a "spack versions is actually working correctly" test.