### PR TITLE
Add unit tests for spack arch command

### DIFF
--- a/lib/spack/spack/test/cmd/arch.py
+++ b/lib/spack/spack/test/cmd/arch.py
@@ -28,7 +28,7 @@ from spack.main import SpackCommand
 arch = SpackCommand('arch')
 
 
-def test_arch(builtin_mock):
+def test_arch():
     """Sanity check the arch command to make sure it works."""
 
     arch()

--- a/lib/spack/spack/test/cmd/arch.py
+++ b/lib/spack/spack/test/cmd/arch.py
@@ -1,0 +1,34 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack.main import SpackCommand
+
+
+arch = SpackCommand('arch')
+
+
+def test_arch(builtin_mock):
+    """Sanity check the arch command to make sure it works."""
+
+    arch()


### PR DESCRIPTION
There isn't an easy way of confirming that the output of the `spack arch` command is correct without duplicating the code itself, but if that seems like a good idea to others I can do that.