### PR TITLE
Fix bug in placeholder spack cd command and add unit tests

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -388,7 +388,7 @@ class SpackCommand(object):
         Returns:
             (str): combined output and error as a string
 
-        On return, if ``fail_on_error`` is False, return value of comman
+        On return, if ``fail_on_error`` is False, return value of command
         is set in ``returncode`` property, and the error is set in the
         ``error`` property.  Otherwise, raise an error.
         """

--- a/lib/spack/spack/test/cmd/cd.py
+++ b/lib/spack/spack/test/cmd/cd.py
@@ -22,21 +22,15 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-from spack.cmd.common import print_module_placeholder_help
-
-import spack.cmd.location
-
-description = "cd to spack directories in the shell"
-section = "environment"
-level = "long"
+from spack.main import SpackCommand
 
 
-def setup_parser(subparser):
-    """This is for decoration -- spack cd is used through spack's
-       shell support.  This allows spack cd to print a descriptive
-       help message when called with -h."""
-    spack.cmd.location.setup_parser(subparser)
+cd = SpackCommand('cd')
 
 
-def cd(parser, args):
-    print_module_placeholder_help()
+def test_cd():
+    """Sanity check the cd command to make sure it works."""
+
+    out = cd()
+
+    assert "To initialize spack's shell commands, you must run one of" in out


### PR DESCRIPTION
### Before

```
$ spack cd
==> Error: module 'spack.modules' has no attribute 'print_help'
```

### After

```
$ spack cd
==> This command requires spack's shell integration.
  
  To initialize spack's shell commands, you must run one of
  the commands below.  Choose the right command for your shell.
  
  For bash and zsh:
      . /Users/Adam/spack/share/spack/setup-env.sh
  
  For csh and tcsh:
      setenv SPACK_ROOT /Users/Adam/spack
      source /Users/Adam/spack/share/spack/setup-env.csh
  
  This exposes a 'spack' shell function, which you can use like
      $ spack load package-foo
  
  Running the Spack executable directly (for example, invoking
  ./bin/spack) will bypass the shell function and print this
  placeholder message, even if you have sourced one of the above
  shell integration scripts.
```

No one else noticed this because they probably use Spack's shell integration.