### PR TITLE
Cython only needed for develop version of mpi4py

### DIFF
--- a/var/spack/repos/builtin/packages/py-mpi4py/package.py
+++ b/var/spack/repos/builtin/packages/py-mpi4py/package.py
@@ -43,4 +43,4 @@ class PyMpi4py(PythonPackage):
     depends_on('python@2.7:2.8,3.3:')
     depends_on('py-setuptools', type='build')
     depends_on('mpi')
-    depends_on('py-cython', when='@3.0.0:', type='build')
+    depends_on('py-cython', when='@develop', type='build')


### PR DESCRIPTION
Fixes #6760. Just waiting for an acknowledgement from @shuds13.