### PR TITLE
Py-fparser: python parser for Fortran code

### DIFF
--- a/var/spack/repos/builtin/packages/py-fparser/package.py
+++ b/var/spack/repos/builtin/packages/py-fparser/package.py
@@ -53,5 +53,8 @@ class PyFparser(PythonPackage):
     @run_after('install')
     @on_package_attributes(run_tests=True)
     def check_build(self):
+         # Ensure that pytest.ini exists inside the source tree,
+         # otherwise an external pytest.ini can cause havoc:
+         touch('pytest.ini')
          with working_dir('src'):
              Executable('py.test')()

--- a/var/spack/repos/builtin/packages/py-fparser/package.py
+++ b/var/spack/repos/builtin/packages/py-fparser/package.py
@@ -41,7 +41,7 @@ class PyFparser(PythonPackage):
 
     depends_on('py-numpy', type=('build', 'run'), when='@0:0.0.5')
     depends_on('py-nose', type='build')
-    depends_on('py-six', type='build')
+    depends_on('py-six', type='build', when='@0.0.6:')
 
     depends_on('py-pytest', type='test')
 

--- a/var/spack/repos/builtin/packages/py-fparser/package.py
+++ b/var/spack/repos/builtin/packages/py-fparser/package.py
@@ -43,7 +43,6 @@ class PyFparser(PythonPackage):
     depends_on('py-nose', type='build')
     depends_on('py-six', type='build')
 
-    # Use type='test' when available:
     depends_on('py-pytest', type='test')
 
     @run_after('install')

--- a/var/spack/repos/builtin/packages/py-fparser/package.py
+++ b/var/spack/repos/builtin/packages/py-fparser/package.py
@@ -46,7 +46,7 @@ class PyFparser(PythonPackage):
     depends_on('py-six', type='build')
 
     # Use type='test' when available:
-    depends_on('py-pytest', type='build')
+    depends_on('py-pytest', type='test')
 
     @run_after('install')
     @on_package_attributes(run_tests=True)

--- a/var/spack/repos/builtin/packages/py-fparser/package.py
+++ b/var/spack/repos/builtin/packages/py-fparser/package.py
@@ -31,8 +31,10 @@ class PyFparser(PythonPackage):
 
     homepage = "https://github.com/stfc/fparser"
     url      = "https://github.com/stfc/fparser/archive/0.0.5.tar.gz"
+    giturl   = "https://github.com/stfc/fparser.git"
 
     version('0.0.5', 'e93d2eae721bf820cf60135473e9c5c7')
+    version('develop', git=giturl, branch='master')
 
     depends_on('py-setuptools', type='build')
 

--- a/var/spack/repos/builtin/packages/py-fparser/package.py
+++ b/var/spack/repos/builtin/packages/py-fparser/package.py
@@ -33,6 +33,8 @@ class PyFparser(PythonPackage):
     url      = "https://github.com/stfc/fparser/archive/0.0.5.tar.gz"
     giturl   = "https://github.com/stfc/fparser.git"
 
+    version('0.0.6', git=giturl,
+            commit='638c51ec57cf17624505b70321c3784e356b8910')
     version('0.0.5', git=giturl,
             commit='a3ff86b635f7bd7bd281ee94cbd3d9455b288fd9')
     version('develop', git=giturl, branch='master')

--- a/var/spack/repos/builtin/packages/py-fparser/package.py
+++ b/var/spack/repos/builtin/packages/py-fparser/package.py
@@ -39,7 +39,7 @@ class PyFparser(PythonPackage):
 
     depends_on('py-setuptools', type='build')
 
-    depends_on('py-numpy', type=('build', 'run'), when='@0:0.0.5')
+    depends_on('py-numpy', type=('build', 'run'), when='@:0.0.5')
     depends_on('py-nose', type='build')
     depends_on('py-six', type='build', when='@0.0.6:')
 

--- a/var/spack/repos/builtin/packages/py-fparser/package.py
+++ b/var/spack/repos/builtin/packages/py-fparser/package.py
@@ -41,18 +41,12 @@ class PyFparser(PythonPackage):
 
     depends_on('py-setuptools', type='build')
 
-    depends_on('py-numpy', type=('build', 'run'))
+    depends_on('py-numpy', type=('build', 'run'), when='@0:0.0.5')
+    depends_on('py-nose', type='build')
+    depends_on('py-six', type='build')
 
     # Use type='test' when available:
-    depends_on('py-nose', type='build')
-    depends_on('py-py', type='build')
     depends_on('py-pytest', type='build')
-    depends_on('py-six', type='build')
-    depends_on('py-appdirs', type='build')
-    depends_on('py-enum34', type='build')
-    depends_on('py-hypothesis', type='build')
-    depends_on('py-packaging', type='build')
-    depends_on('py-pyparsing', type='build')
 
     @run_after('install')
     @on_package_attributes(run_tests=True)

--- a/var/spack/repos/builtin/packages/py-fparser/package.py
+++ b/var/spack/repos/builtin/packages/py-fparser/package.py
@@ -41,7 +41,6 @@ class PyFparser(PythonPackage):
 
     depends_on('py-setuptools', type='build')
 
-    depends_on('python', type=('build', 'run'))
     depends_on('py-numpy', type=('build', 'run'))
 
     # Use type='test' when available:

--- a/var/spack/repos/builtin/packages/py-fparser/package.py
+++ b/var/spack/repos/builtin/packages/py-fparser/package.py
@@ -33,7 +33,8 @@ class PyFparser(PythonPackage):
     url      = "https://github.com/stfc/fparser/archive/0.0.5.tar.gz"
     giturl   = "https://github.com/stfc/fparser.git"
 
-    version('0.0.5', 'e93d2eae721bf820cf60135473e9c5c7')
+    version('0.0.5', git=giturl,
+            commit='a3ff86b635f7bd7bd281ee94cbd3d9455b288fd9')
     version('develop', git=giturl, branch='master')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-fparser/package.py
+++ b/var/spack/repos/builtin/packages/py-fparser/package.py
@@ -58,8 +58,8 @@ class PyFparser(PythonPackage):
     @run_after('install')
     @on_package_attributes(run_tests=True)
     def check_build(self):
-         # Ensure that pytest.ini exists inside the source tree,
-         # otherwise an external pytest.ini can cause havoc:
-         touch('pytest.ini')
-         with working_dir('src'):
-             Executable('py.test')()
+        # Ensure that pytest.ini exists inside the source tree,
+        # otherwise an external pytest.ini can cause havoc:
+        touch('pytest.ini')
+        with working_dir('src'):
+            Executable('py.test')()

--- a/var/spack/repos/builtin/packages/py-fparser/package.py
+++ b/var/spack/repos/builtin/packages/py-fparser/package.py
@@ -33,10 +33,8 @@ class PyFparser(PythonPackage):
     url      = "https://github.com/stfc/fparser/archive/0.0.5.tar.gz"
     giturl   = "https://github.com/stfc/fparser.git"
 
-    version('0.0.6', git=giturl,
-            commit='638c51ec57cf17624505b70321c3784e356b8910')
-    version('0.0.5', git=giturl,
-            commit='a3ff86b635f7bd7bd281ee94cbd3d9455b288fd9')
+    version('0.0.6', '15553fde76b4685fa8edb0a5472b1b53d308c3b8')
+    version('0.0.5', '14630afdb8c8bd025e5504c5ab19d133aa8cf8c7')
     version('develop', git=giturl, branch='master')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-fparser/package.py
+++ b/var/spack/repos/builtin/packages/py-fparser/package.py
@@ -1,0 +1,57 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+#
+from spack import *
+
+
+class PyFparser(PythonPackage):
+    """Parser for Fortran 77..2003 code."""
+
+    homepage = "https://github.com/stfc/fparser"
+    url      = "https://github.com/stfc/fparser/archive/0.0.5.tar.gz"
+
+    version('0.0.5', 'e93d2eae721bf820cf60135473e9c5c7')
+
+    depends_on('py-setuptools', type='build')
+
+    depends_on('python', type=('build', 'run'))
+    depends_on('py-numpy', type=('build', 'run'))
+
+    # Use type='test' when available:
+    depends_on('py-nose', type='build')
+    depends_on('py-py', type='build')
+    depends_on('py-pytest', type='build')
+    depends_on('py-six', type='build')
+    depends_on('py-appdirs', type='build')
+    depends_on('py-enum34', type='build')
+    depends_on('py-hypothesis', type='build')
+    depends_on('py-packaging', type='build')
+    depends_on('py-pyparsing', type='build')
+
+    @run_after('install')
+    @on_package_attributes(run_tests=True)
+    def check_build(self):
+         with working_dir('src'):
+             Executable('py.test')()


### PR DESCRIPTION
Python implementation of a Fortran 66/77/90/95/2003 language parser.

This package can be used as a basis for tools that analyse, optimise and parallelise Fortran software. See, for example, https://github.com/stfc/PSyclone.