### PR TITLE
Provide build_type variant for Metis.

### DIFF
--- a/var/spack/repos/builtin/packages/metis/package.py
+++ b/var/spack/repos/builtin/packages/metis/package.py
@@ -95,6 +95,13 @@ class Metis(Package):
         if any('+{0}'.format(v) in spec for v in ['gdb', 'int64', 'real64']):
             raise InstallError('METIS@:4 does not support the following '
                                'variants: gdb, int64, real64.')
+        # This build system only supports 'Release' or 'Debug' build_types.
+        if spec.variants['build_type'].value != 'Release' and \
+                spec.variants['build_type'].value != 'Debug':
+            raise InstallError('METIS@:4 only supports build_type=Release or '
+                               'build_type=Debug, but build_type={0} '
+                               'was specified'.
+                               format(spec.variants['build_type'].value))
 
         options = ['COPTIONS={0}'.format(self.compiler.pic_flag)]
         if spec.variants['build_type'].value == 'Debug':

--- a/var/spack/repos/builtin/packages/metis/package.py
+++ b/var/spack/repos/builtin/packages/metis/package.py
@@ -51,6 +51,11 @@ class Metis(Package):
     variant('int64', default=False, description='Sets the bit width of METIS\'s index type to 64.')
     variant('real64', default=False, description='Sets the bit width of METIS\'s real type to 64.')
 
+    # For Metis version 5:, the build system is CMake, provide the `build_type` variant.
+    variant('build_type', default='RelWithDebInfo',
+            description='The build type to build',
+            values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel'))
+
     depends_on('cmake@2.8:', when='@5:', type='build')
 
     patch('install_gklib_defs_rename.patch', when='@5:')
@@ -184,6 +189,11 @@ class Metis(Package):
         options = std_cmake_args[:]
         options.append('-DGKLIB_PATH:PATH=%s/GKlib' % source_directory)
         options.append('-DCMAKE_INSTALL_NAME_DIR:PATH=%s/lib' % prefix)
+
+        # Normally this is available via the CMakePackage ojbect, but metis IS-A
+        # Package (not a CMakePackage) to support non-cmake metis@:5.
+        build_type = spec.variants['build_type'].value
+        options.extend(['-DCMAKE_BUILD_TYPE:STRING={0}'.format(build_type)])
 
         if '+shared' in spec:
             options.append('-DSHARED:BOOL=ON')

--- a/var/spack/repos/builtin/packages/metis/package.py
+++ b/var/spack/repos/builtin/packages/metis/package.py
@@ -51,7 +51,8 @@ class Metis(Package):
     variant('int64', default=False, description='Sets the bit width of METIS\'s index type to 64.')
     variant('real64', default=False, description='Sets the bit width of METIS\'s real type to 64.')
 
-    # For Metis version 5:, the build system is CMake, provide the `build_type` variant.
+    # For Metis version 5:, the build system is CMake, provide the
+    # `build_type` variant.
     variant('build_type', default='RelWithDebInfo',
             description='The build type to build',
             values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel'))
@@ -190,8 +191,8 @@ class Metis(Package):
         options.append('-DGKLIB_PATH:PATH=%s/GKlib' % source_directory)
         options.append('-DCMAKE_INSTALL_NAME_DIR:PATH=%s/lib' % prefix)
 
-        # Normally this is available via the CMakePackage ojbect, but metis IS-A
-        # Package (not a CMakePackage) to support non-cmake metis@:5.
+        # Normally this is available via the 'CMakePackage' object, but metis
+        # IS-A 'Package' (not a 'CMakePackage') to support non-cmake metis@:5.
         build_type = spec.variants['build_type'].value
         options.extend(['-DCMAKE_BUILD_TYPE:STRING={0}'.format(build_type)])
 
@@ -207,8 +208,9 @@ class Metis(Package):
             for o in rpath_options:
                 options.remove(o)
         if '+debug' in spec:
-            options.extend(['-DDEBUG:BOOL=ON',
-                            '-DCMAKE_BUILD_TYPE:STRING=Debug'])
+            if build_type != 'Debug':
+                raise InstallError("Found +debug but build_type!=Debug.")
+            options.append('-DDEBUG:BOOL=ON')
         if '+gdb' in spec:
             options.append('-DGDB:BOOL=ON')
 

--- a/var/spack/repos/builtin/packages/metis/package.py
+++ b/var/spack/repos/builtin/packages/metis/package.py
@@ -45,7 +45,6 @@ class Metis(Package):
     version('4.0.3', 'd3848b454532ef18dc83e4fb160d1e10')
 
     variant('shared', default=True, description='Enables the build of shared libraries.')
-    variant('debug', default=False, description='Builds the library in debug mode.')
     variant('gdb', default=False, description='Enables gdb support.')
 
     variant('int64', default=False, description='Sets the bit width of METIS\'s index type to 64.')
@@ -53,7 +52,7 @@ class Metis(Package):
 
     # For Metis version 5:, the build system is CMake, provide the
     # `build_type` variant.
-    variant('build_type', default='RelWithDebInfo',
+    variant('build_type', default='Release',
             description='The build type to build',
             values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel'))
 
@@ -98,7 +97,7 @@ class Metis(Package):
                                'variants: gdb, int64, real64.')
 
         options = ['COPTIONS={0}'.format(self.compiler.pic_flag)]
-        if '+debug' in spec:
+        if spec.variants['build_type'].value == 'Debug':
             options.append('OPTFLAGS=-g -O0')
         make(*options)
 
@@ -207,10 +206,6 @@ class Metis(Package):
                     rpath_options.append(o)
             for o in rpath_options:
                 options.remove(o)
-        if '+debug' in spec:
-            if build_type != 'Debug':
-                raise InstallError("Found +debug but build_type!=Debug.")
-            options.append('-DDEBUG:BOOL=ON')
         if '+gdb' in spec:
             options.append('-DGDB:BOOL=ON')
 


### PR DESCRIPTION
+ Ideally, we would make Metis a CMakePackage, but `metis@:5` doesn't use CMake.
+ For now, provide a `build_type=` variant similar what is found in CMakePackage.
+ There is a potential for duplicate specification of `CMAKE_BUILD_TYPE` if both variants `+debug` and `build_type=` are specified. I am looking for advice on how this can be resolved.