### PR TITLE
Updated 'nginx' from v1.12.0 to v1.13.8.

### DIFF
--- a/var/spack/repos/builtin/packages/nginx/package.py
+++ b/var/spack/repos/builtin/packages/nginx/package.py
@@ -33,6 +33,7 @@ class Nginx(AutotoolsPackage):
     homepage = "https://nginx.org/en/"
     url      = "https://nginx.org/download/nginx-1.12.0.tar.gz"
 
+    version('1.13.8', 'df4be9294365782dc1349ca33ce8c4ac')
     version('1.12.0', '995eb0a140455cf0cfc497e5bd7f94b3')
 
     depends_on('openssl')


### PR DESCRIPTION
This fixes build issues with most recent gcc versions.
See issue #6252.