### PR TITLE
adding specific version url for augustus 3.3 due to old folder structure

### DIFF
--- a/var/spack/repos/builtin/packages/augustus/package.py
+++ b/var/spack/repos/builtin/packages/augustus/package.py
@@ -32,7 +32,8 @@ class Augustus(MakefilePackage):
     homepage = "http://bioinf.uni-greifswald.de/augustus/"
     url      = "http://bioinf.uni-greifswald.de/augustus/binaries/augustus-3.3.tar.gz"
 
-    version('3.3',   '9ebe494df78ebf6a43091cfc8551050c')
+    version('3.3',   '9ebe494df78ebf6a43091cfc8551050c',
+            url='http://bioinf.uni-greifswald.de/augustus/binaries/augustus-3.3.tar.gz')
     version('3.2.3', 'b8c47ea8d0c45aa7bb9a82626c8ff830',
             url='http://bioinf.uni-greifswald.de/augustus/binaries/old/augustus-3.2.3.tar.gz')
 


### PR DESCRIPTION
Without a url set for the 3.3 version explicitly, spack attempts to fetch the 3.3 package from the binaries/old folder (like 3.2.3), rather than using the url value for the class