### PR TITLE
Added a setter to the Spec.prefix property

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -884,6 +884,9 @@ class SpecBuildInterface(ObjectWrapper):
 @key_ordering
 class Spec(object):
 
+    #: Cache for spec's prefix, computed lazily in the corresponding property
+    _prefix = None
+
     @staticmethod
     def from_literal(spec_dict, normal=True):
         """Builds a Spec from a dictionary containing the spec literal.
@@ -1374,12 +1377,13 @@ class Spec(object):
 
     @property
     def prefix(self):
-        if hasattr(self, 'test_prefix'):
-            return Prefix(self.test_prefix)
-        return Prefix(spack.store.layout.path_for_spec(self))
+        if self._prefix is None:
+            self.prefix = spack.store.layout.path_for_spec(self)
+        return self._prefix
 
-    def _set_test_prefix(self, val):
-        self.test_prefix = val
+    @prefix.setter
+    def prefix(self, value):
+        self._prefix = Prefix(value)
 
     def dag_hash(self, length=None):
         """Return a hash of the entire spec DAG, including connectivity."""

--- a/lib/spack/spack/test/test_activations.py
+++ b/lib/spack/spack/test/test_activations.py
@@ -75,7 +75,7 @@ def python_and_extension_dirs(tmpdir):
 
     python_spec = spack.spec.Spec('python@2.7.12')
     python_spec._concrete = True
-    python_spec.package.spec._set_test_prefix(str(python_prefix))
+    python_spec.package.spec.prefix = str(python_prefix)
 
     ext_dirs = {
         'bin/': {
@@ -115,7 +115,7 @@ def test_python_activation(tmpdir):
     python_prefix = str(tmpdir.join(python_name))
     # Set the prefix on the package's spec reference because that is a copy of
     # the original spec
-    python_spec.package.spec._set_test_prefix(python_prefix)
+    python_spec.package.spec.prefix = python_prefix
 
     ext_name = 'py-extension'
     tmpdir.ensure(ext_name, dir=True)
@@ -130,7 +130,7 @@ def test_python_activation_with_files(tmpdir, python_and_extension_dirs):
 
     python_spec = spack.spec.Spec('python@2.7.12')
     python_spec._concrete = True
-    python_spec.package.spec._set_test_prefix(python_prefix)
+    python_spec.package.spec.prefix = python_prefix
 
     ext_pkg = FakeExtensionPackage('py-extension', ext_prefix)
 
@@ -152,7 +152,7 @@ def test_python_activation_view(tmpdir, python_and_extension_dirs):
 
     python_spec = spack.spec.Spec('python@2.7.12')
     python_spec._concrete = True
-    python_spec.package.spec._set_test_prefix(python_prefix)
+    python_spec.package.spec.prefix = python_prefix
 
     ext_pkg = FakeExtensionPackage('py-extension', ext_prefix)
 
@@ -189,7 +189,7 @@ def perl_and_extension_dirs(tmpdir):
 
     perl_spec = spack.spec.Spec('perl@5.24.1')
     perl_spec._concrete = True
-    perl_spec.package.spec._set_test_prefix(str(perl_prefix))
+    perl_spec.package.spec.prefix = str(perl_prefix)
 
     ext_dirs = {
         'bin/': {
@@ -225,7 +225,7 @@ def test_perl_activation(tmpdir):
     perl_prefix = str(tmpdir.join(perl_name))
     # Set the prefix on the package's spec reference because that is a copy of
     # the original spec
-    perl_spec.package.spec._set_test_prefix(perl_prefix)
+    perl_spec.package.spec.prefix = perl_prefix
 
     ext_name = 'perl-extension'
     tmpdir.ensure(ext_name, dir=True)
@@ -240,7 +240,7 @@ def test_perl_activation_with_files(tmpdir, perl_and_extension_dirs):
 
     perl_spec = spack.spec.Spec('perl@5.24.1')
     perl_spec._concrete = True
-    perl_spec.package.spec._set_test_prefix(perl_prefix)
+    perl_spec.package.spec.prefix = perl_prefix
 
     ext_pkg = FakeExtensionPackage('perl-extension', ext_prefix)
 
@@ -255,7 +255,7 @@ def test_perl_activation_view(tmpdir, perl_and_extension_dirs):
 
     perl_spec = spack.spec.Spec('perl@5.24.1')
     perl_spec._concrete = True
-    perl_spec.package.spec._set_test_prefix(perl_prefix)
+    perl_spec.package.spec.prefix = perl_prefix
 
     ext_pkg = FakeExtensionPackage('perl-extension', ext_prefix)
 


### PR DESCRIPTION
This commit removes logic from Spec that was there only to be used in tests, and allows to set a new prefix cleanly in user's code.