### PR TITLE
Add a new version and runtime dependency for MotionCor2.

### DIFF
--- a/var/spack/repos/builtin/packages/motioncor2/package.py
+++ b/var/spack/repos/builtin/packages/motioncor2/package.py
@@ -38,11 +38,13 @@ class Motioncor2(Package):
     homepage = "http://msg.ucsf.edu/em/software"
     url      = "http://msg.ucsf.edu/MotionCor2/MotionCor2-1.0.2.tar.gz"
 
+    version('1.0.4',        '5fc0a35d9518b2df17104187dab63fc6')
     version('1.0.2',        'f2f4c5b09170ab8480ca657f14cdba2b')
     version('1.0.1',        '73d94a80abdef9bf37bbc80fbbe76622')
     version('1.0.0',        '490f4df8daa9f5ddb9eec3962ba3ddf5')
 
     depends_on('cuda@8.0:8.99', type='run')
+    depends_on('libtiff@3.0:3.99', type='run')
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin/packages/motioncor2/package.py
+++ b/var/spack/repos/builtin/packages/motioncor2/package.py
@@ -44,6 +44,7 @@ class Motioncor2(Package):
     version('1.0.0',        '490f4df8daa9f5ddb9eec3962ba3ddf5')
 
     depends_on('cuda@8.0:8.99', type='run')
+    # libtiff.so.3 is required
     depends_on('libtiff@3.0:3.99', type='run')
 
     def install(self, spec, prefix):


### PR DESCRIPTION
- Add 1.0.4. 
- Motioncor2 depends on libtiff.so.3 .