### PR TITLE
Flex v2.6.4 conflicts with gcc@7.2.0

### DIFF
--- a/var/spack/repos/builtin/packages/flex/package.py
+++ b/var/spack/repos/builtin/packages/flex/package.py
@@ -53,6 +53,10 @@ class Flex(AutotoolsPackage):
     depends_on('automake', type='build', when='@:2.6.0')
     depends_on('libtool',  type='build', when='@:2.6.0')
 
+    # Build issue for v2.6.4 when gcc 7.2.0 is used.
+    # See issue #219; https://github.com/westes/flex/issues/219
+    conflicts('%gcc@7.2.0:', when='@2.6.4')
+
     def url_for_version(self, version):
         url = "https://github.com/westes/flex"
         if version >= Version('2.6.1'):


### PR DESCRIPTION
As discussed in issue #6812, this PR documents that there is a build issue when flex v2.6.4 is built with gcc >=7.2.0.