### PR TITLE
Updating OpenFAST to use explicit lapack and blas libraries from Spack.

### DIFF
--- a/var/spack/repos/builtin/packages/openfast/package.py
+++ b/var/spack/repos/builtin/packages/openfast/package.py
@@ -56,7 +56,7 @@ class Openfast(CMakePackage):
     # Additional dependencies when compiling C++ library
     depends_on('mpi', when='+cxx')
     depends_on('yaml-cpp', when='+cxx')
-    depends_on('hdf5+mpi+cxx', when='+cxx')
+    depends_on('hdf5+mpi+cxx+hl', when='+cxx')
     depends_on('zlib', when='+cxx')
     depends_on('libxml2', when='+cxx')
 
@@ -77,6 +77,15 @@ class Openfast(CMakePackage):
                 'ON' if '+dll-interface' in spec else 'OFF'),
             '-DBUILD_FAST_CPP_API:BOOL=%s' % (
                 'ON' if '+cxx' in spec else 'OFF'),
+        ])
+
+        # Make sure we use Spack's blas/lapack:
+        lapack_libs = spec['lapack'].libs.joined(';')
+        blas_libs = spec['blas'].libs.joined(';')
+
+        options.extend([
+            '-DLAPACK_LIBRARIES=%s;%s' % (lapack_libs,blas_libs),
+            '-DBLAS_LIBRARIES=%s;%s' % (blas_libs,lapack_libs)
         ])
 
         if '+cxx' in spec:

--- a/var/spack/repos/builtin/packages/openfast/package.py
+++ b/var/spack/repos/builtin/packages/openfast/package.py
@@ -80,7 +80,7 @@ class Openfast(CMakePackage):
         ])
 
         # Make sure we use Spack's blas/lapack:
-        blas_libs = spec['blas'].libs + spec['lapack'].libs
+        blas_libs = spec['lapack'].libs + spec['blas'].libs
         options.extend([
             '-DBLAS_LIBRARIES=%s' % blas_libs.joined(';'),
             '-DLAPACK_LIBRARIES=%s' % blas_libs.joined(';')

--- a/var/spack/repos/builtin/packages/openfast/package.py
+++ b/var/spack/repos/builtin/packages/openfast/package.py
@@ -80,12 +80,10 @@ class Openfast(CMakePackage):
         ])
 
         # Make sure we use Spack's blas/lapack:
-        lapack_libs = spec['lapack'].libs.joined(';')
-        blas_libs = spec['blas'].libs.joined(';')
-
+        blas_libs = spec['blas'].libs + spec['lapack'].libs
         options.extend([
-            '-DLAPACK_LIBRARIES=%s;%s' % (lapack_libs,blas_libs),
-            '-DBLAS_LIBRARIES=%s;%s' % (blas_libs,lapack_libs)
+            '-DBLAS_LIBRARIES=%s' % blas_libs.joined(';'),
+            '-DLAPACK_LIBRARIES=%s' % blas_libs.joined(';')
         ])
 
         if '+cxx' in spec:


### PR DESCRIPTION
More issues I'm fixing with my packages as I've been implementing Intel MKL and MPI where I need to explicitly pass the BLAS and LAPACK libraries to OpenFAST so that it uses the libraries Spack administers. OpenFAST also needs `hdf5+hl` since the `+hl` HDF5 variant showed up.