### PR TITLE
Extract installation of dependencies from PackageBase.do_install

### DIFF
--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -26,6 +26,7 @@ import llnl.util.tty as tty
 import spack
 import spack.cmd
 import spack.cmd.common.arguments as arguments
+import spack.package
 
 description = "Bootstrap packages needed for spack to run smoothly"
 section = "admin"
@@ -86,5 +87,4 @@ def bootstrap(parser, args, **kwargs):
             tty.msg("Installing %s to satisfy requirement for %s" %
                     (spec_to_install, requirement))
             kwargs['explicit'] = True
-            package = spack.repo.get(spec_to_install)
-            package.do_install(**kwargs)
+            spack.package.install(spec_to_install, **kwargs)

--- a/lib/spack/spack/cmd/configure.py
+++ b/lib/spack/spack/cmd/configure.py
@@ -86,7 +86,7 @@ def _stop_at_phase_during_install(args, calling_fn, phase_mapping):
         inst.install(parser, install_args)
         # Install package and stop at the given phase
         cli_args = ['-v'] if args.verbose else []
-        install_args = parser.parse_args(cli_args + ['--only=package'])
+        install_args = parser.parse_args(cli_args + ['--only=root'])
         install_args.package = args.package
         inst.install(parser, install_args, stop_at=phase)
     except IndexError:

--- a/lib/spack/spack/cmd/diy.py
+++ b/lib/spack/spack/cmd/diy.py
@@ -22,7 +22,6 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-import sys
 import os
 import argparse
 
@@ -78,22 +77,23 @@ def diy(self, args):
             "Did you forget a package version number?")
 
     spec.concretize()
-    package = spack.repo.get(spec)
 
-    if package.installed:
-        tty.error("Already installed in %s" % package.prefix)
-        tty.msg("Uninstall or try adding a version suffix for this DIY build.")
-        sys.exit(1)
+    if spec.package.installed:
+        msg = "Already installed in {0}. "
+        msg += "Uninstall or try adding a version suffix for this DIY build."
+        tty.die(msg.format(spec.prefix))
 
     # Forces the build to run out of the current directory.
-    package.stage = DIYStage(os.getcwd())
+    spec.package.stage = DIYStage(os.getcwd())
 
     # TODO: make this an argument, not a global.
     spack.do_checksum = False
 
-    package.do_install(
+    spack.package.install(
+        spec,
         keep_prefix=args.keep_prefix,
         install_deps=not args.ignore_deps,
         verbose=not args.quiet,
         keep_stage=True,   # don't remove source dir for DIY.
-        dirty=args.dirty)
+        dirty=args.dirty
+    )

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -141,8 +141,6 @@ def default_log_file(spec):
 def install_spec(cli_args, kwargs, spec):
     # Do the actual installation
     try:
-        # decorate the install if necessary
-        PackageBase.do_install = decorator(PackageBase.do_install)
         what = cli_args.things_to_install.split(',')
         spack.package.install(spec, what=what, **kwargs)
     except spack.build_environment.InstallError as e:

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -28,6 +28,7 @@ import platform
 import re
 import spack
 import spack.cmd
+import spack.package
 from spack.util.executable import Executable, ProcessError
 from llnl.util.filesystem import filter_file
 import llnl.util.tty as tty
@@ -42,10 +43,9 @@ def get_patchelf():
     # as we may need patchelf, find out where it is
     if platform.system() == 'Darwin':
         return None
-    patchelf_spec = spack.cmd.parse_specs("patchelf", concretize=True)[0]
-    patchelf = spack.repo.get(patchelf_spec)
+    patchelf = spack.cmd.parse_specs("patchelf", concretize=True)[0]
     if not patchelf.installed:
-        patchelf.do_install()
+        spack.package.install(patchelf)
     patchelf_executable = os.path.join(patchelf.prefix.bin, "patchelf")
     return patchelf_executable
 

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -144,6 +144,11 @@ class InfoCollector(object):
 
                 start_time = time.time()
                 value = None
+
+                # If we raise here, we should behave the same out of the
+                # context manager, so check if we need to re-raise at the end
+                exc_val = None
+
                 try:
 
                     value = do_install(pkg, *args, **kwargs)
@@ -158,6 +163,7 @@ class InfoCollector(object):
                     test_case['stdout'] = fetch_package_log(pkg)
                     test_case['message'] = e.message or 'Installation failure'
                     test_case['exception'] = e.traceback
+                    exc_val = e
 
                 except (Exception, BaseException) as e:
                     # Everything else is an error (the installation
@@ -166,6 +172,7 @@ class InfoCollector(object):
                     test_case['stdout'] = fetch_package_log(pkg)
                     test_case['message'] = str(e) or 'Unknown error'
                     test_case['exception'] = traceback.format_exc()
+                    exc_val = e
 
                 finally:
                     test_case['elapsed_time'] = time.time() - start_time
@@ -185,6 +192,9 @@ class InfoCollector(object):
                         item['testcases'].append(test_case)
                     except StopIteration:
                         pass
+
+                if exc_val:
+                    raise exc_val
 
                 return value
 

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -286,7 +286,8 @@ def test_junit_output_with_failures(tmpdir, exc_typename, msg):
             '--log-format=junit', '--log-file=test.xml',
             'raiser',
             'exc_type={0}'.format(exc_typename),
-            'msg="{0}"'.format(msg)
+            'msg="{0}"'.format(msg),
+            fail_on_error=False
         )
 
     files = tmpdir.listdir()

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -137,8 +137,7 @@ def test_package_output(tmpdir, capsys, install_mockery, mock_fetch):
     # logging. TODO: see whether we can get multiple log_outputs to work
     # when nested AND in pytest
     spec = Spec('printing-package').concretized()
-    pkg = spec.package
-    pkg.do_install(verbose=True)
+    spack.package.install(spec, verbose=True)
 
     log_file = os.path.join(spec.prefix, '.spack', 'build.out')
     with open(log_file) as f:

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -40,12 +40,12 @@ import spack.architecture
 import spack.database
 import spack.directory_layout
 import spack.platforms.test
+import spack.package
 import spack.repository
 import spack.stage
 import spack.util.executable
 import spack.util.pattern
 from spack.dependency import Dependency
-from spack.package import PackageBase
 from spack.fetch_strategy import FetchStrategyComposite, URLFetchStrategy
 from spack.fetch_strategy import FetchError
 from spack.spec import Spec
@@ -306,8 +306,7 @@ def database(tmpdir_factory, builtin_mock, config):
     def _install(spec):
         s = spack.spec.Spec(spec)
         s.concretize()
-        pkg = spack.repo.get(s)
-        pkg.do_install(fake=True)
+        spack.package.install(s, fake=True)
 
     def _uninstall(spec):
         spec.package.do_uninstall(spec)
@@ -393,10 +392,10 @@ def mock_fetch(mock_archive):
     def fake_fn(self):
         return fetcher
 
-    orig_fn = PackageBase.fetcher
-    PackageBase.fetcher = fake_fn
+    orig_fn = spack.package.PackageBase.fetcher
+    spack.package.PackageBase.fetcher = fake_fn
     yield
-    PackageBase.fetcher = orig_fn
+    spack.package.PackageBase.fetcher = orig_fn
 
 
 ##########

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -33,6 +33,7 @@ import pytest
 from llnl.util.tty.colify import colify
 
 import spack
+import spack.package
 import spack.store
 from spack.test.conftest import MockPackageMultiRepo
 from spack.util.executable import Executable
@@ -141,8 +142,7 @@ def _check_remove_and_add_package(install_db, spec):
 def _mock_install(spec):
     s = spack.spec.Spec(spec)
     s.concretize()
-    pkg = spack.repo.get(s)
-    pkg.do_install(fake=True)
+    spack.package.install(s, fake=True)
 
 
 def _mock_remove(spec):
@@ -426,7 +426,7 @@ def test_external_entries_in_db(database):
     assert rec.spec.external_module is None
     assert rec.explicit is False
 
-    rec.spec.package.do_install(fake=True, explicit=True)
+    spack.package.install(rec.spec, fake=True)
     rec = install_db.get_record('externaltool')
     assert rec.spec.external_path == '/path/to/external_tool'
     assert rec.spec.external_module is None

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -145,7 +145,7 @@ def test_installed_dependency_request_conflicts(
 @pytest.mark.disable_clean_stage_check
 def test_partial_install_keep_prefix(install_mockery, mock_fetch):
     spec = Spec('canfail').concretized()
-    pkg = spack.repo.get(spec)
+    pkg = spec.package
 
     # Normally the stage should start unset, but other tests set it
     pkg._stage = None

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -95,7 +95,7 @@ echo $PATH"""
     assert spec.concrete
     pkg = spec.package
     fake_fetchify(mock_archive.url, pkg)
-    pkg.do_install()
+    spack.package.install(spec)
     pkghash = '/' + spec.dag_hash(7)
 
     # Put some non-relocatable file in there

--- a/var/spack/repos/builtin.mock/packages/canfail/package.py
+++ b/var/spack/repos/builtin.mock/packages/canfail/package.py
@@ -33,9 +33,17 @@ class Canfail(Package):
 
     version('1.0', '0123456789abcdef0123456789abcdef')
 
-    succeed = False
+    _succeed = False
+
+    @property
+    def succeed(self):
+        return Canfail._succeed
+
+    @succeed.setter
+    def succeed(self, value):
+        Canfail._succeed = value
 
     def install(self, spec, prefix):
-        if not self.succeed:
+        if not self._succeed:
             raise InstallError("'succeed' was false")
         touch(join_path(prefix, 'an_installation_file'))


### PR DESCRIPTION
Up to this commit `PackageBase.do_install` was installing the root package of a DAG unconditionally and its dependencies conditionally (depending on the value of the boolean argument `install_deps`).

However, a sensible operation in many contexts is to install *only* the dependencies. This was not possible via API, and the code to do that was replicated in the implementation of `PackageBase.do_install` and of the `spack install` command. Further, the code in those two places was not doing *exactly* the same thing.

This commit extracts a new function that is used in both places, and is external to `PackageBase`. This choice has been preferred over extending `PackageBase.do_install` API because:
- the method was already complex enough (10-15 arguments) and needed to be simplified 
- having a method on an instance that installs anything but that instance spec didn't seem a sensible choice