### PR TITLE
WIP: Teach the metis recipe to respect spack's cflags

### DIFF
--- a/var/spack/repos/builtin/packages/metis/package.py
+++ b/var/spack/repos/builtin/packages/metis/package.py
@@ -102,7 +102,7 @@ class Metis(Package):
         # Process library spec and options
         options = ['COPTIONS={0}'.format(self.compiler.pic_flag)]
 
-        # If spack's cflags is set, use it instead of any default flags.  Assume
+        # If spack's cflags is set, use it instead of any default flags. Assume
         # the user knows what they are asking for (e.g.: no '-g' flag unless
         # cflags provides it!)
         if 'SPACK_CFLAGS' in env and env['SPACK_CFLAGS']:


### PR DESCRIPTION
If the spack install command specifies cflags (either on the command line or in `compilers.yaml`), tell CMake to use only spack's cflags and none of its own default values.

fixes #6839

The downside to this approach is that if cflags is set, then setting `build_type=<whatever>` might not do what is expected because the cflags will trump cmake's build_type default compiler flags.