### PR TITLE
Rmlab: Control PNG

### DIFF
--- a/var/spack/repos/builtin/packages/rmlab/package.py
+++ b/var/spack/repos/builtin/packages/rmlab/package.py
@@ -47,3 +47,12 @@ class Rmlab(CMakePackage):
     conflicts('%pgi@:14')
 
     depends_on('pngwriter@0.6.0:', when='+png')
+
+    def cmake_args(self):
+        spec = self.spec
+
+        args = [
+            '-DRmlab_USE_PNG={0}'.format(
+                'ON' if '+png' in spec else 'OFF')
+        ]
+        return args


### PR DESCRIPTION
Control the find_package of the PNG variant explicitly.

This avoids picking up an "external" PNGwriter install in case `~png` is picked by changing the default "AUTO" search to explicit "ON" (required) of "OFF" (ignore if exists).