### PR TITLE
[WIP] Fix git gettext/libintl handling (builds on ubuntu)

### DIFF
--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -165,13 +165,20 @@ class Git(AutotoolsPackage):
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
 
+    def patch(self):
+        filter_file(r'^EXTLIBS =$',
+                    '#EXTLIBS =',
+                    'Makefile')
+
     def setup_environment(self, spack_env, run_env):
         # This is done to avoid failures when git is an external package.
         # In that case the node in the DAG gets truncated and git DOES NOT
         # have a gettext dependency.
         if 'gettext' in self.spec:
-            spack_env.append_flags('LDFLAGS', '-L{0} -lintl'.format(
+            spack_env.append_flags('EXTLIBS', '-L{0} -lintl'.format(
                 self.spec['gettext'].prefix.lib))
+            spack_env.append_flags('CFLAGS', '-I{0}'.format(
+                self.spec['gettext'].prefix.include))
 
     def configure_args(self):
         spec = self.spec


### PR DESCRIPTION
Fixes #6841 
Fixes #1436

[edit, wordsmithing]

Spack needs to pass information about where the linker can find `libintl`.  We're currently using `LDFLAGS` to do so.  The `LDFLAGS` info is pasted into the command line upstream of the a file (`libgit.a`) that includes unresolved symbols that need that library.  This approach fails on Ubuntu, although it seems to work on CentOS (see #6841 for additional background).

This change allows git to build on a Ubuntu 16.04.3 droplet.

TODO:

- [x] test on other platforms...
  - [x] Ubuntu 16.04.03 using system gcc 5.4.1.
  - [x] Ubuntu 14.04 using gcc 5.4.0
  - [x] CentOS 7 using system gcc 4.8.5.
  - [x] CentOS 7 using Spack gcc 5.4.0.
  - [x] CentOS 6 using Spack intel 17.0.2.
  - [x] Debian 9.3 using gcc 6.3.0.
  - [x] macOS 10.13.2 using system clang 9.0.0.
- [x] add commentary to package.py