### PR TITLE
Fix no longer existing download url in graphviz

### DIFF
--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -30,7 +30,7 @@ import shutil
 class Graphviz(AutotoolsPackage):
     """Graph Visualization Software"""
     homepage = 'http://www.graphviz.org'
-    url      = 'http://www.graphviz.org/pub/graphviz/stable/SOURCES/graphviz-2.38.0.tar.gz'
+    url      = 'https://src.fedoraproject.org/repo/pkgs/graphviz/graphviz-2.38.0.tar.gz/5b6a829b2ac94efcd5fa3c223ed6d3ae/graphviz-2.38.0.tar.gz'
 
     version('2.38.0', '5b6a829b2ac94efcd5fa3c223ed6d3ae')
 

--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+import os
 import sys
 import shutil
 
@@ -30,9 +31,9 @@ import shutil
 class Graphviz(AutotoolsPackage):
     """Graph Visualization Software"""
     homepage = 'http://www.graphviz.org'
-    url      = 'https://src.fedoraproject.org/repo/pkgs/graphviz/graphviz-2.38.0.tar.gz/5b6a829b2ac94efcd5fa3c223ed6d3ae/graphviz-2.38.0.tar.gz'
 
-    version('2.38.0', '5b6a829b2ac94efcd5fa3c223ed6d3ae')
+    version('2.40.1', git='https://gitlab.com/graphviz/graphviz.git',
+            tag='stable_release_2.40.1')
 
     # We try to leave language bindings enabled if they don't cause
     # build issues or add dependencies.
@@ -78,9 +79,10 @@ class Graphviz(AutotoolsPackage):
             description='Build with pango+cairo support (more output formats)')
     variant('libgd', default=False,
             description='Build with libgd support (more output formats)')
-
     variant('gts', default=False,
             description='Build with GNU Triangulated Surface Library')
+    variant('expat', default=False,
+            description='Build with Expat support (enables HTML-like labels)')
 
     parallel = False
 
@@ -96,28 +98,46 @@ class Graphviz(AutotoolsPackage):
         '+python', '+r', '+ruby', '+tcl')
 
     for b in tested_bindings + untested_bindings:
-        depends_on('swig', when=b)
-
-    depends_on('cairo', when='+pangocairo')
-    depends_on('pango', when='+pangocairo')
-    depends_on('libgd', when='+libgd')
-    depends_on('gts', when='+gts')
-    depends_on('ghostscript')
-    depends_on('freetype')
-    depends_on('expat')
-    depends_on('libtool')
-    depends_on('pkgconfig', type='build')
+        depends_on('swig', type='build', when=b)
 
     depends_on('java', when='+java')
     depends_on('python@2:2.8', when='+python')
 
-    def patch(self):
-        # Fix a few variable names, gs after 9.18 renamed them
-        # See http://lists.linuxfromscratch.org/pipermail/blfs-book/2015-October/056960.html
-        if self.spec.satisfies('^ghostscript@9.18:'):
-            kwargs = {'ignore_absent': False, 'backup': True, 'string': True}
-            filter_file(' e_', ' gs_error_', 'plugin/gs/gvloadimage_gs.c',
-                        **kwargs)
+    # +pangocairo
+    depends_on('cairo', when='+pangocairo')
+    depends_on('pango', when='+pangocairo')
+    depends_on('freetype', when='+pangocairo')
+    depends_on('glib', when='+pangocairo')
+    depends_on('fontconfig', when='+pangocairo')
+    depends_on('freetype', when='+pangocairo')
+    depends_on('libpng', when='+pangocairo')
+    depends_on('zlib', when='+pangocairo')
+    # +libgd
+    depends_on('libgd', when='+libgd')
+    depends_on('fontconfig', when='+libgd')
+    depends_on('freetype', when='+libgd')
+    # +gts
+    depends_on('gts', when='+gts')
+    # +expat
+    depends_on('expat', when='+expat')
+ 
+    # Build dependencies
+    depends_on('pkg-config', type='build')
+    ## The following are needed when building from git
+    depends_on('automake', type='build')
+    depends_on('autoconf', type='build')
+    depends_on('bison', type='build')
+    depends_on('flex', type='build')
+    depends_on('libtool', type='build')
+
+    def autoreconf(self, spec, prefix):
+        # We need to generate 'configure' when checking out sources from git
+        # If configure exists nothing needs to be done
+        if os.path.exists(self.configure_abs_path):
+            return
+        # Else bootstrap (disabling auto-configure with NOCONFIG)
+        bash = which('bash')
+        bash('./autogen.sh', 'NOCONFIG')
 
     def configure_args(self):
         spec = self.spec
@@ -150,7 +170,7 @@ class Graphviz(AutotoolsPackage):
         else:
             options.append('--enable-swig=no')
 
-        for var in ('+pangocairo', '+libgd', '+gts'):
+        for var in ('+pangocairo', '+libgd', '+gts', '+expat'):
             if var in spec:
                 options.append('--with-{0}'.format(var[1:]))
             else:
@@ -162,8 +182,5 @@ class Graphviz(AutotoolsPackage):
         #       include <X11/Xlib.h>
         if sys.platform == 'darwin':
             options.append('CFLAGS=-I/opt/X11/include')
-
-        # A hack to patch config.guess in the libltdl sub directory
-        shutil.copyfile('./config/config.guess', 'libltdl/config/config.guess')
 
         return options

--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -34,6 +34,10 @@ class Graphviz(AutotoolsPackage):
     version('2.40.1', git='https://gitlab.com/graphviz/graphviz.git',
             tag='stable_release_2.40.1')
 
+    version('2.40.1', git='https://gitlab.com/graphviz/graphviz.git',
+            commit='67cd2e5121379a38e0801cc05cce5033f8a2a609')
+            # this hash refers to tag='stable_release_2.40.1'
+
     # We try to leave language bindings enabled if they don't cause
     # build issues or add dependencies.
     variant('sharp', default=False,
@@ -108,7 +112,6 @@ class Graphviz(AutotoolsPackage):
     depends_on('freetype', when='+pangocairo')
     depends_on('glib', when='+pangocairo')
     depends_on('fontconfig', when='+pangocairo')
-    depends_on('freetype', when='+pangocairo')
     depends_on('libpng', when='+pangocairo')
     depends_on('zlib', when='+pangocairo')
     # +libgd

--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -32,9 +32,6 @@ class Graphviz(AutotoolsPackage):
     homepage = 'http://www.graphviz.org'
 
     version('2.40.1', git='https://gitlab.com/graphviz/graphviz.git',
-            tag='stable_release_2.40.1')
-
-    version('2.40.1', git='https://gitlab.com/graphviz/graphviz.git',
             commit='67cd2e5121379a38e0801cc05cce5033f8a2a609')
 
     # We try to leave language bindings enabled if they don't cause

--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -25,7 +25,6 @@
 from spack import *
 import os
 import sys
-import shutil
 
 
 class Graphviz(AutotoolsPackage):
@@ -120,10 +119,10 @@ class Graphviz(AutotoolsPackage):
     depends_on('gts', when='+gts')
     # +expat
     depends_on('expat', when='+expat')
- 
+
     # Build dependencies
     depends_on('pkg-config', type='build')
-    ## The following are needed when building from git
+    # The following are needed when building from git
     depends_on('automake', type='build')
     depends_on('autoconf', type='build')
     depends_on('bison', type='build')

--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -31,6 +31,7 @@ class Graphviz(AutotoolsPackage):
     """Graph Visualization Software"""
     homepage = 'http://www.graphviz.org'
 
+    # This commit hash is tag='stable_release_2.40.1'
     version('2.40.1', git='https://gitlab.com/graphviz/graphviz.git',
             commit='67cd2e5121379a38e0801cc05cce5033f8a2a609')
 
@@ -82,6 +83,12 @@ class Graphviz(AutotoolsPackage):
             description='Build with GNU Triangulated Surface Library')
     variant('expat', default=False,
             description='Build with Expat support (enables HTML-like labels)')
+    variant('ghostscript', default=False,
+            description='Build with Ghostscript support')
+    variant('qt', default=False,
+            description='Build with Qt support')
+    variant('gtkplus', default=False,
+            description='Build with GTK+ support')
 
     parallel = False
 
@@ -118,6 +125,12 @@ class Graphviz(AutotoolsPackage):
     depends_on('gts', when='+gts')
     # +expat
     depends_on('expat', when='+expat')
+    # +ghostscript
+    depends_on('ghostscript', when='+ghostscript')
+    # +qt
+    depends_on('qt', when='+qt')
+    # +gtkplus
+    depends_on('gtkplus', when='+gtkplus')
 
     # Build dependencies
     depends_on('pkg-config', type='build')
@@ -168,11 +181,17 @@ class Graphviz(AutotoolsPackage):
         else:
             options.append('--enable-swig=no')
 
-        for var in ('+pangocairo', '+libgd', '+gts', '+expat'):
+        for var in ('+pangocairo', '+libgd', '+gts', '+expat', '+ghostscript',
+                    '+qt', '+gtkplus'):
+            feature = var[1:]
+            if feature == 'gtkplus':
+                # In spack terms, 'gtk+' is 'gtkplus' while
+                # the relative configure option is 'gtk'
+                feature = 'gtk'
             if var in spec:
-                options.append('--with-{0}'.format(var[1:]))
+                options.append('--with-{0}'.format(feature))
             else:
-                options.append('--without-{0}'.format(var[1:]))
+                options.append('--without-{0}'.format(feature))
 
         # On OSX fix the compiler error:
         # In file included from tkStubLib.c:15:

--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -36,7 +36,6 @@ class Graphviz(AutotoolsPackage):
 
     version('2.40.1', git='https://gitlab.com/graphviz/graphviz.git',
             commit='67cd2e5121379a38e0801cc05cce5033f8a2a609')
-            # this hash refers to tag='stable_release_2.40.1'
 
     # We try to leave language bindings enabled if they don't cause
     # build issues or add dependencies.


### PR DESCRIPTION
It looks like the Graphviz guys migrated their repo to a brand new platform that broke all the previously working download URLs. They are now providing source packages for version `2.40.1` only. After lurking around the web, I've found the missing package (`graphviz-2.38.0.tar.gz`) on the Fedora package repo. The file hash is the same.
  
  