### PR TITLE
Fix missing dependency in ghostscript

### DIFF
--- a/var/spack/repos/builtin/packages/ghostscript/package.py
+++ b/var/spack/repos/builtin/packages/ghostscript/package.py
@@ -43,6 +43,7 @@ class Ghostscript(AutotoolsPackage):
     depends_on('libpng')
     depends_on('libtiff')
     depends_on('zlib')
+    depends_on('libxext')
 
     def url_for_version(self, version):
         baseurl = "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs{0}/ghostscript-{1}.tar.gz"


### PR DESCRIPTION
Added `libxext` dependency to `ghostscript`. The package build fails on vanilla `​​linux-ubuntu16.04-x86_64​` (clean install inside a `Docker` image), while on *regular* desktop systems it looked like the system-shipped `libxext` was masking this issue.