### PR TITLE
Fix tests for git package

### DIFF
--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -208,6 +208,9 @@ class Git(AutotoolsPackage):
             # Don't link with -lrt; the system has no (and needs no) librt
             filter_file(r' -lrt$', '', 'Makefile')
 
+    def check(self):
+        make('test')
+
     @run_after('install')
     def install_completions(self):
         copy_tree('contrib/completion', self.prefix.share)


### PR DESCRIPTION
The git Makefile comes with two targets, `check` and `test`. However, these targets are completely different. `make test` runs the unit tests, while `make check` runs a static analysis tool called `sparse`. Instead of adding a new dependency to `git`, I decided to override the default `check` phase and only run `make test`. I have a feeling `make check` is intended for developers only.