### PR TITLE
Trilinos: Patch zoltan to suppress PHG warning

### DIFF
--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -146,8 +146,16 @@ class Dealii(CMakePackage, CudaPackage):
     depends_on('slepc@:3.6.3',     when='@:8.4.1+slepc+petsc+mpi')
     depends_on('slepc~arpack',     when='+slepc+petsc+mpi+int64')
     depends_on('sundials~pthread', when='@9.0:+sundials')
-    depends_on('trilinos+amesos+aztec+epetra+ifpack+ml+muelu+rol+sacado+teuchos',       when='+trilinos+mpi~int64')
-    depends_on('trilinos+amesos+aztec+epetra+ifpack+ml+muelu+rol+sacado+teuchos~hypre', when='+trilinos+mpi+int64')
+    depends_on('trilinos+amesos+aztec+epetra+ifpack+ml+muelu+rol+sacado+teuchos+zoltan',
+               patches=patch('trilinos_12.12.1_phg_warning.patch',
+                       level=1,
+                       when='@12.12.1'),
+               when='+trilinos+mpi~int64')
+    depends_on('trilinos+amesos+aztec+epetra+ifpack+ml+muelu+rol+sacado+teuchos+zoltan~hypre',
+               patches=patch('trilinos_12.12.1_phg_warning.patch',
+                       level=1,
+                       when='@12.12.1'),
+               when='+trilinos+mpi+int64')
 
     # check that the combination of variants makes sense
     conflicts('^openblas+ilp64', when='@:8.5.1')

--- a/var/spack/repos/builtin/packages/dealii/trilinos_12.12.1_phg_warning.patch
+++ b/var/spack/repos/builtin/packages/dealii/trilinos_12.12.1_phg_warning.patch
@@ -1,0 +1,17 @@
+diff --git a/packages/zoltan/src/phg/phg_build.c b/packages/zoltan/src/phg/phg_build.c
+index bd46bbd358..5e8db03fa3 100644
+--- a/packages/zoltan/src/phg/phg_build.c
++++ b/packages/zoltan/src/phg/phg_build.c
+@@ -1771,12 +1771,6 @@ MPI_Datatype zoltan_gno_mpi_type;
+ 
+   numGlobalEdges = zhg->globalHedges - global_nremove;
+ 
+-  if ((zhg->globalHedges > zz->Num_Proc) && (numGlobalEdges < zz->Num_Proc)){
+-    if (zz->Proc == 0) fprintf(stderr,
+-     "\nWARNING: PHG_EDGE_SIZE_THRESHOLD is low (%f), resulting in only " ZOLTAN_GNO_SPEC " edges\n remaining.",
+-        esize_threshold, numGlobalEdges);
+-  }
+-
+   *nGlobalEdges = numGlobalEdges;
+   *nEdge = nkeep;
+   *nPins = nkeep_size;


### PR DESCRIPTION
Patch Zoltan to suppress PHG warning. Currently there is no way to suppress PHG warning.