### PR TITLE
Track multiple processes on Travis only for build tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,7 +2,6 @@
 # .coveragerc to control coverage.py
 [run]
 parallel = True
-concurrency = multiprocessing
 branch = True
 source = lib
 omit =

--- a/share/spack/qa/setup.sh
+++ b/share/spack/qa/setup.sh
@@ -11,9 +11,13 @@ SPACK_ROOT="$QA_DIR/../../.."
 . "$SPACK_ROOT/share/spack/setup-env.sh"
 
 # Set up some variables for running coverage tests.
-if [[ "$COVERAGE" == true ]]; then
+if [[ "$COVERAGE" == "true" && "$TEST_SUITE" == "unit" ]]; then
     coverage=coverage
     coverage_run="coverage run"
+    coverage_combine="coverage combine"
+elif [[ "$COVERAGE" == "true" && "$TEST_SUITE" == "build" ]]; then
+    coverage=coverage
+    coverage_run="coverage run --concurrency=multiprocessing"
     coverage_combine="coverage combine"
 else
     coverage=""


### PR DESCRIPTION
On a local workstation, it seems that tracking multiple processes during coverage may result in malformed coverage reports for unit tests and not for build tests.

Given that multiple processes make a difference in coverage mainly for build tests, try to disable the tracking for unit tests to see if we get more stable coverage results.