### PR TITLE
Travis: upload the coverage data as part of the script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -149,10 +149,9 @@ before_script:
 #=============================================================================
 # Building
 #=============================================================================
-script: share/spack/qa/run-$TEST_SUITE-tests
-
-after_success:
-  - codecov --env PY_VERSION
+script:
+  - share/spack/qa/run-$TEST_SUITE-tests
+  - if [[ "$COVERAGE" == "true" ]]; then codecov --env PY_VERSION --required ; fi
 
 #=============================================================================
 # Notifications


### PR DESCRIPTION
According to Travis docs the exit code of `after_success` doesn't affect the build result. Instead, uploading the coverage data as the last step of the script will cause the job to fail if the command exits with non-zero.

https://docs.travis-ci.com/user/customizing-the-build/#Breaking-the-Build

relates to #6872 