### PR TITLE
emacs: on darwin, do not build Cocoa app

### DIFF
--- a/var/spack/repos/builtin/packages/emacs/package.py
+++ b/var/spack/repos/builtin/packages/emacs/package.py
@@ -24,6 +24,8 @@
 ##############################################################################
 from spack import *
 
+import sys
+
 
 class Emacs(AutotoolsPackage):
     """The Emacs programmable text editor."""
@@ -71,5 +73,10 @@ class Emacs(AutotoolsPackage):
             ]
         else:
             args = ['--without-x']
+
+        # On OS X/macOS, do not build "nextstep/Emacs.app", because
+        # doing so throws an error at build-time
+        if sys.platform == 'darwin':
+            args.append('--without-ns')
 
         return args


### PR DESCRIPTION
Building emacs on darwin throws an error when trying to build an Emacs
app in the `nextstep/Emacs.app` path of the build tree. For now, disable
building this app.

It's possible to enable building the app also; Homebrew offers options
to this effect, and also adds Mac-specific options for starting the
emacs daemon. However, for the sake of simplicity and getting a
workable up-to-date emacs installation on my machine as quickly as
possible, this commit focuses on a minimal viable modification.