### PR TITLE
package libharu: Add build deps

### DIFF
--- a/var/spack/repos/builtin/packages/libharu/package.py
+++ b/var/spack/repos/builtin/packages/libharu/package.py
@@ -40,6 +40,9 @@ class Libharu(AutotoolsPackage):
     version('master', branch='master',
             git='https://github.com/libharu/libharu.git')
 
+    depends_on('libtool', type=('build'))
+    depends_on('autoconf', type=('build'))
+    depends_on('automake', type=('build'))
     depends_on('libpng')
     depends_on('zlib')
 


### PR DESCRIPTION
I found, that libharu would not build on the current develop branch of spack, due to missing commands at build time. This is fixed by adding libtool, autoconf and automake as build-time dependencies.

However, I doubt that this is the correct approach. The package class inherits from AutotoolsPackage, should it thus not also inherit these dependencies?