### PR TITLE
Mark unsatisfied conditions as visited while normalizing

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2116,8 +2116,10 @@ class Spec(object):
         if dep.name not in self._dependencies:
             self._add_dependency(spec_dependency, dependency.type)
 
+        visited_dependency = set()
         changed |= spec_dependency._normalize_helper(
-            visited, spec_deps, provider_index)
+            visited_dependency, spec_deps, provider_index)
+        visited.update(visited_dependency)
         return changed
 
     def _normalize_helper(self, visited, spec_deps, provider_index):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2147,6 +2147,10 @@ class Spec(object):
                             set(dep.type) - set(['test'])):
                     changed |= self._merge_dependency(
                         dep, visited, spec_deps, provider_index)
+                elif dep is None:
+                    # dep_name didn't satisfy conditions, but we still need
+                    # to mark it as visited
+                    visited.add(dep_name)
             any_change |= changed
 
         return any_change


### PR DESCRIPTION
This should fix #2793 and #3628. I only broke a `module_parsing` test, but that seems unrelated. Nevertheless I'm not really sure of what I'm doing, please review critically

@alalazo 