### PR TITLE
Reduce verbosity of build tests

### DIFF
--- a/share/spack/qa/run-build-tests
+++ b/share/spack/qa/run-build-tests
@@ -25,5 +25,5 @@ fi
 spack config get compilers
 
 # Run some build smoke tests, potentially with code coverage
-${coverage_run} bin/spack install -v ${SPEC}
+${coverage_run} bin/spack install ${SPEC}
 ${coverage_combine}


### PR DESCRIPTION
Currently, when a build test fails, there isn't an easy way to see what caused it. Instead, Travis gives us the error message:

> This log is too long to be displayed. Please reduce the verbosity of your build or download the raw log.

This PR reduces the verbosity of our build. I think our error parsing of the build log is good enough that we no longer need the full output.