### PR TITLE
spack option -C/--config to add dir to config search path

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -33,6 +33,7 @@ configuration system behaves.  The scopes are:
   #. ``system``
   #. ``site``
   #. ``user``
+  #. ``command-line``  (optional)
 
 And corresponding :ref:`per-platform scopes <platform-scopes>`. Important
 functions in this module are:
@@ -232,6 +233,12 @@ ConfigScope('site/%s' % _platform, os.path.join(_site_path, _platform))
 _user_path = spack.user_config_path
 ConfigScope('user', _user_path)
 ConfigScope('user/%s' % _platform, os.path.join(_user_path, _platform))
+
+# Optional configuration from the command-line (-C/--config).
+_cmd_path = spack.cmd_line_config_path
+if _cmd_path:
+    ConfigScope('command-line', _cmd_path)
+    ConfigScope('command-line/%s' % _platform, os.path.join(_cmd_path, _platform))
 
 
 def highest_precedence_scope():

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -238,7 +238,8 @@ ConfigScope('user/%s' % _platform, os.path.join(_user_path, _platform))
 _cmd_path = spack.cmd_line_config_path
 if _cmd_path:
     ConfigScope('command-line', _cmd_path)
-    ConfigScope('command-line/%s' % _platform, os.path.join(_cmd_path, _platform))
+    ConfigScope('command-line/%s' % _platform,
+                os.path.join(_cmd_path, _platform))
 
 
 def highest_precedence_scope():

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -58,7 +58,7 @@ intro_by_level = {
 
 # control top-level spack options shown in basic vs. advanced help
 options_by_level = {
-    'short': ['h', 'k', 'V', 'color'],
+    'short': ['h', 'C', 'k', 'V', 'color'],
     'long': 'all'
 }
 
@@ -283,6 +283,8 @@ def make_argument_parser():
     parser.add_argument('--color', action='store', default='auto',
                         choices=('always', 'never', 'auto'),
                         help="when to colorize output; default is auto")
+    parser.add_argument('-C', '--config', action='store', metavar="DIR",
+                        help="additional directory for config files")
     parser.add_argument('-d', '--debug', action='store_true',
                         help="write out debug logs during compile")
     parser.add_argument('-D', '--pdb', action='store_true',


### PR DESCRIPTION
This patch adds the spack option '-C/--config DIR' to add an extra
directory (DIR) from the command line to the configuration scope
search path.  If specified, DIR has the highest priority in the search
path.

repo:  https://github.com/mwkrentel/spack
branch:  config-patch

This option adds extra flexibility in maintaining multiple different
configurations.  For example, issue #6204 asks how to specify a
different install_tree.  But the best (only) option is to edit
~/.spack/config.yaml for each choice.  This patch allows specifying
these options from the command line.

Also, I may want to run spack from a common directory for which I
don't have write access.  With a command-line option, I can specify a
config.yaml file that moves all the writeable parts of the spack tree
to an alternate location.

Theoretically, it would be possible to add separate options for
everything in config.yaml and packages.yaml (install_tree, cache dirs,
etc).  But instead of adding a bazillion new options, it's cleaner to
add one option for an extra config directory.

Everything in the patch is simple and straightforward, except for one
thing.  There are already 4 directories (8 with platform subdirs) in
the config search path, so adding a 5th fits naturally.

However, there is one controversial but necessary part.  The -C option
needs to be known very early, before main.py creates the argument
parser.

Spack starts up in __init__.py by setting some global constants.
Then, it imports config.py and immediately reads the .yaml files and
squirrels away values from config.yaml, things like cache dirs, etc.
All this happens before main.py creates the argument parser.

Unfortunately, it's necessary to do an early scan of the command-line
options in __init__.py, at least until spack startup is reworked to
read the command-line options before reading the .yaml files.

But the early parsing is very low impact.  It doesn't change anything,
only reads one value.  The worst that could possibly happen is that it
fails to find the argument for -C (and I'm not worried about that).
So, for now ....

Thanks,

--Mark Krentel
