### PR TITLE
Fix support for test dependencies which are python extensions

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -581,7 +581,8 @@ def setup_package(pkg, dirty):
 
     # traverse in postorder so package can use vars from its dependencies
     spec = pkg.spec
-    for dspec in pkg.spec.traverse(order='post', root=False, deptype='build'):
+    for dspec in pkg.spec.traverse(order='post', root=False,
+                                   deptype=('build', 'test')):
         # If a user makes their own package repo, e.g.
         # spack.repos.mystuff.libelf.Libelf, and they inherit from
         # an existing class like spack.repos.original.libelf.Libelf,

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -509,7 +509,7 @@ class Python(AutotoolsPackage):
 
         python_paths = []
         for d in dependent_spec.traverse(
-                deptype=('build', 'run'), deptype_query='run'):
+                deptype=('build', 'run', 'test')):
             if d.package.extends(self.spec):
                 python_paths.append(join_path(d.prefix,
                                               self.site_packages_dir))


### PR DESCRIPTION
Test dependencies which were python extensions were not being set up. This updates the python package definition to understand the 'test' deptype.