### PR TITLE
Fix conflict checking for external packages.

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1869,9 +1869,9 @@ class Spec(object):
         matches = []
         for x in self.traverse():
             for conflict_spec, when_list in x.package.conflicts.items():
-                if x.satisfies(conflict_spec):
+                if x.satisfies(conflict_spec, strict=True):
                     for when_spec, msg in when_list:
-                        if x.satisfies(when_spec):
+                        if x.satisfies(when_spec, strict=True):
                             matches.append((x, conflict_spec, when_spec, msg))
         if matches:
             raise ConflictsInSpecError(self, matches)


### PR DESCRIPTION
Fixes #6905

External packages can have unspecified properties, in particular all children of external packages are stripped.

This updates the conflict-checking logic to require that the conflict spec matches exactly and that all fields mentioned in the conflict spec are present in the concretized spec in order to report a conflict. This will automatically skip all conflict checks for dependencies of externals.