### PR TITLE
Do not construct path to perl command manually

### DIFF
--- a/var/spack/repos/builtin/packages/autoconf/package.py
+++ b/var/spack/repos/builtin/packages/autoconf/package.py
@@ -55,12 +55,11 @@ class Autoconf(AutotoolsPackage):
         # We have to do this after install because otherwise the install
         # target will try to rebuild the binaries (filter_file updates the
         # timestamps)
-        perl = join_path(self.spec['perl'].prefix.bin, 'perl')
 
         # Revert sbang, so Spack's sbang hook can fix it up
         filter_file('^#! /usr/bin/env perl',
-                    '#! {0} -w'.format(perl),
-                    '{0}/autom4te'.format(self.prefix.bin),
+                    '#! {0} -w'.format(self.spec['perl'].command.path),
+                    self.prefix.bin.autom4te,
                     backup=False)
 
     def _make_executable(self, name):

--- a/var/spack/repos/builtin/packages/canu/package.py
+++ b/var/spack/repos/builtin/packages/canu/package.py
@@ -42,9 +42,8 @@ class Canu(MakefilePackage):
 
     def patch(self):
         # Use our perl, not whatever is in the environment
-        perl = self.spec['perl'].prefix.bin.perl
         filter_file(r'^#!/usr/bin/env perl',
-                    '#!{0}'.format(perl),
+                    '#!{0}'.format(self.spec['perl'].command.path),
                     'src/pipelines/canu.pl')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/likwid/package.py
+++ b/var/spack/repos/builtin/packages/likwid/package.py
@@ -64,10 +64,11 @@ class Likwid(Package):
     @run_before('install')
     def filter_sbang(self):
         # Filter sbang before install so Spack's sbang hook can fix it up
-        perl = join_path(self.spec['perl'].prefix.bin, 'perl')
         files = ['perl/feedGnuplot'] + glob.glob('filters/*')
 
-        filter_file('^#!/usr/bin/perl', '#!{0}'.format(perl), *files)
+        filter_file('^#!/usr/bin/perl',
+                    '#!{0}'.format(self.spec['perl'].command.path),
+                    *files)
 
     def install(self, spec, prefix):
         if self.compiler.name not in self.supported_compilers:

--- a/var/spack/repos/builtin/packages/repeatmasker/package.py
+++ b/var/spack/repos/builtin/packages/repeatmasker/package.py
@@ -63,7 +63,7 @@ class Repeatmasker(Package):
         #    Repeatmasker? (Y/N)
         # Add a Search Engine: Done
 
-        config_answers = ['\n', '%s\n' % self.spec['perl'].prefix.bin.perl,
+        config_answers = ['\n', '%s\n' % self.spec['perl'].command.path,
                           '%s\n' % self.stage.source_path,
                           '%s\n' % self.spec['trf'].prefix.bin.trf, '2\n',
                           '%s\n' % self.spec['ncbi-rmblastn'].prefix.bin,

--- a/var/spack/repos/builtin/packages/vcftools/package.py
+++ b/var/spack/repos/builtin/packages/vcftools/package.py
@@ -55,8 +55,7 @@ class Vcftools(AutotoolsPackage):
 
         with working_dir('src/perl'):
             match = '^#!/usr/bin/env perl'
-            perl = join_path(self.spec['perl'].prefix.bin, 'perl')
-            substitute = "#!{perl}".format(perl=perl)
+            substitute = "#!{perl}".format(perl=self.spec['perl'].command.path)
             # tab-to-vcf added in 0.1.15
             files = ['fill-aa', 'fill-an-ac', 'fill-fs',
                      'fill-ref-md5', 'tab-to-vcf', 'vcf-annotate',


### PR DESCRIPTION
Instead, use `spec['perl'].command.path`.

Just some cleanup based on the feedback in #6910.