### PR TITLE
Updated catch to newer version (up to 2.1.0)

### DIFF
--- a/var/spack/repos/builtin/packages/catch/package.py
+++ b/var/spack/repos/builtin/packages/catch/package.py
@@ -28,27 +28,35 @@ from spack import *
 class Catch(Package):
     """Catch tests"""
 
-    homepage = "https://github.com/philsquared/Catch"
-    url = "https://github.com/philsquared/Catch/archive/v1.3.0.tar.gz"
+    homepage = "https://github.com/catchorg/Catch2"
+    url = "https://github.com/catchorg/Catch2/archive/v1.3.0.tar.gz"
 
-    version('1.9.4', '110b9173d7f766487fed5b710836c7216a781568')
-    version('1.9.3', 'dc0cd0b344d8ccb1190ac3447efcb49c9b43d497')
-    version('1.9.2', '0580f57edd2b33ec671488dc7b6151f9e360c8c9')
-    version('1.9.1', '10784fc4c3786dfc3bd222fb3f9b048b6d68f186')
-    version('1.9.0', '62f07506d4a381d1730d494b71cff0396b9eb3d6')
-    version('1.8.2', '45a7598a8e5c47bc09fb73eec205ffe0885983dc')
-    version('1.8.1', 'd4e302f712fb7e75ce6f05b436dbaf21dca40030')
-    version('1.8.0', '26064092b5682c9c997b04015ed1565f0e198827')
-    version('1.7.2', '13018db2f0f0395456f695b0d0fbc490662e3467')
-    version('1.7.1', 'f82e11a5cdfef2d36b5687ff5970d383f9e76490')
-    version('1.7.0', 'fe39f5b3eb07a5dd0e3f84a1335ceca7de8982e6')
-    version('1.6.1', '7d46961a3131655b986123f8a1f439a04a0af623')
-    version('1.6.0', '890a3b21085d796e13c3bfaf4b6c6f1d06e4a52e')
-    version('1.5.9', '8bc32146a5a2789cd3d3ce2893772e32f412f1b1')
-    version('1.5.0', 'c87397846ea5126febd39f513b413e32f9ed552b')
-    version('1.4.0', 'c165406968fbfb46949885da571cd528c62c4d9a')
-    version('1.3.5', '31553ba6e4bd0cc61e0507d6754847e354699284')
-    version('1.3.0', 'e13694aaff72817d02af8ed27d077cd261b6e857')
+    version('2.1.0', '70b44068976d46d48f3cd8796f675691d3bc726b')
+    version('2.0.1', '5c191a031edebd0525640ed2f38cbf64bacb1803')
+    version('1.12.0', '8fb0a64144a2c1572dd930254c7bbdf504ecbe2d')
+    version('1.11.0', '3c03a022d8ba8dbbc931e1ce9fb28faec4890b8d')
+    version('1.10.0', 'c2033ca00b616e7e703623c68220cf5a8e12bba4')
+    version('1.9.7', '7ea41b48a23bd83f377f05a9dfde2be230cfc1b4')
+    version('1.9.6', 'e6ae3a50c6e4da64410979dcd4b2bb3f7ba1c364')
+    version('1.9.5', '7ba2bb12b5398b8b9ab7a7907f4cd345a55e179a')
+    version('1.9.4', 'b48fce35161160def587bd0d8f0e95969b20b786')
+    version('1.9.3', 'c0db82118496a2dd0637aad352f31d9356bffc28')
+    version('1.9.2', '627fd94d466c0f71ba84010adf82771ed3ce85c7')
+    version('1.9.1', '331e4a5cd32fe4c36b4bea15e5198346f18b5c3f')
+    version('1.9.0', '5bb46e99eea39224189a8a0442ec7790c635a7b0')
+    version('1.8.2', '34b8a2da76befeeaeafc393569538222605dda51')
+    version('1.8.1', 'd5f4ae9603fe27c313bc5b5b23c233bdce5c57f7')
+    version('1.8.0', '7fa6bfc50e6dbb6fd1352f41496650d56a86ac1a')
+    version('1.7.2', '45b0ab04b6da75ce56de25a81f0b0de4c7a62179')
+    version('1.7.1', '3a55985aacd5a5ff8a87c1490bbf65f0122647dc')
+    version('1.7.0', '6f9869cc066721d525bb03e8a9423b806c362140')
+    version('1.6.1', 'e88de5b611c07d5d402142d3dc20b63350fdf76c')
+    version('1.6.0', '21273cbed050b8d4785231d04812d5addf5b71b7')
+    version('1.5.9', '341bee0b642f0dc9bb6fb41243a068239468b703')
+    version('1.5.0', '2d14342c72f12b3f4b975cf6aa8594c8ad43d773')
+    version('1.4.0', '3b3b76a842508386be40d73849627bbe12fb5b7f')
+    version('1.3.5', '2cfd78bce21368355c7d3880df88716084df2186')
+    version('1.3.0', '24cd4e6518273fea20becd47a2e1edbee7ec209a')
 
     def install(self, spec, prefix):
         mkdirp(prefix.include)


### PR DESCRIPTION
Also updated all the sums from previous versions. For some reason the old sha1sums were not working, though the files for the old versions doesn't show any new info due to the change on github repository.