### PR TITLE
ruby: fix +openssl & +readline variants

### DIFF
--- a/var/spack/repos/builtin/packages/ruby/package.py
+++ b/var/spack/repos/builtin/packages/ruby/package.py
@@ -50,9 +50,10 @@ class Ruby(AutotoolsPackage):
     def configure_args(self):
         args = []
         if '+openssl' in self.spec:
-            args.append("--with-openssl-dir=%s" % spec['openssl'].prefix)
+            args.append("--with-openssl-dir=%s" % self.spec['openssl'].prefix)
         if '+readline' in self.spec:
-            args.append("--with-readline-dir=%s" % spec['readline'].prefix)
+            args.append("--with-readline-dir=%s"
+                        % self.spec['readline'].prefix)
         args.append('--with-tk=%s' % self.spec['tk'].prefix)
         return args
 

--- a/var/spack/repos/builtin/packages/ruby/package.py
+++ b/var/spack/repos/builtin/packages/ruby/package.py
@@ -34,7 +34,7 @@ class Ruby(AutotoolsPackage):
 
     version('2.2.0', 'cd03b28fd0b555970f5c4fd481700852')
 
-    variant('openssl', default=False, description="Enable OpenSSL support")
+    variant('openssl', default=True, description="Enable OpenSSL support")
     variant('readline', default=False, description="Enable Readline support")
 
     extendable = True


### PR DESCRIPTION
Fix "unqualified variable spec['openssl']" error in the ruby package
that arises when trying to install the `+openssl` variant by
referencing the `spec` field in the `Ruby` class. A similar error
arises when trying to install the `+readline` variant; this error is
also fixed by this patch.