### PR TITLE
Add url_for_version to pango package

### DIFF
--- a/var/spack/repos/builtin/packages/pango/package.py
+++ b/var/spack/repos/builtin/packages/pango/package.py
@@ -51,6 +51,10 @@ class Pango(AutotoolsPackage):
     depends_on("glib")
     depends_on('gobject-introspection')
 
+    def url_for_version(self, version):
+        url = "http://ftp.gnome.org/pub/GNOME/sources/pango/{0}/pango-{1}.tar.xz"
+        return url.format(version.up_to(2), version)
+
     def configure_args(self):
         args = []
         if self.spec.satisfies('+X'):


### PR DESCRIPTION
### Before

```
Safe versions:  
    1.41.0    http://ftp.gnome.org/pub/GNOME/sources/pango/1.40/pango-1.41.0.tar.xz
    1.40.3    http://ftp.gnome.org/pub/GNOME/sources/pango/1.40/pango-1.40.3.tar.xz
    1.40.1    http://ftp.gnome.org/pub/GNOME/sources/pango/1.40/pango-1.40.1.tar.xz
    1.36.8    http://ftp.gnome.org/pub/GNOME/sources/pango/1.40/pango-1.36.8.tar.xz
```

### After

```
Safe versions:  
    1.41.0    http://ftp.gnome.org/pub/GNOME/sources/pango/1.41/pango-1.41.0.tar.xz
    1.40.3    http://ftp.gnome.org/pub/GNOME/sources/pango/1.40/pango-1.40.3.tar.xz
    1.40.1    http://ftp.gnome.org/pub/GNOME/sources/pango/1.40/pango-1.40.1.tar.xz
    1.36.8    http://ftp.gnome.org/pub/GNOME/sources/pango/1.36/pango-1.36.8.tar.xz
```

@adamryczkowski can you see if this fixes #6938?