### PR TITLE
Fix vtk 6.1.0 bugs

### DIFF
--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -103,4 +103,15 @@ class Vtk(CMakePackage):
                 '-DCMAKE_CXX_FLAGS=-DGLX_GLXEXT_LEGACY'
             ])
 
+            # VTK 6.1.0 (and possibly earlier) does not use
+            # NETCDF_CXX_ROOT to detect NetCDF C++ bindings, so
+            # NETCDF_CXX_INCLUDE_DIR and NETCDF_CXX_LIBRARY must be
+            # used instead to detect these bindings
+            netcdf_cxx_lib = spec['netcdf-cxx'].libs.joined()
+            cmake_args.extend([
+                '-DNETCDF_CXX_INCLUDE_DIR={0}'.format(
+                    spec['netcdf-cxx'].prefix.include),
+                '-DNETCDF_CXX_LIBRARY={0}'.format(netcdf_cxx_lib),
+            ])
+
         return cmake_args

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -114,4 +114,16 @@ class Vtk(CMakePackage):
                 '-DNETCDF_CXX_LIBRARY={0}'.format(netcdf_cxx_lib),
             ])
 
+            # Garbage collection is unsupported in Xcode starting with
+            # version 5.1; if the Apple clang version of the compiler
+            # is 5.1.0 or later, unset the required Objective-C flags
+            # to remove the garbage collection flags.  Versions of VTK
+            # after 6.1.0 set VTK_REQUIRED_OBJCXX_FLAGS to the empty
+            # string. This fix was recommended on the VTK mailing list
+            # in March 2014 (see
+            # https://public.kitware.com/pipermail/vtkusers/2014-March/083368.html)
+            if (self.compiler.is_apple and
+                self.compiler.version >= Version('5.1.0')):
+                cmake_args.extend(['-DVTK_REQUIRED_OBJCXX_FLAGS=""'])
+
         return cmake_args


### PR DESCRIPTION
Fix bugs in building VTK 6.1.0:

* NetCDF C++ bindings detection failures fixed by specifying header directory in `NETCDF_CXX_IN?CLUDE_DIR` and full library path in `NETCDF_CXX_LIBRARY`

* Makefile bug fixed by disabling garbage collection flags for Objective-C, which have been removed since VTK 6.2.0. XCode 5.1 removed garbage collection for Objective-C binaries, so compiling with garbage collection flags using recent versions of XCode would result in compile-time errors