### PR TITLE
Restore multiprocessing in unit tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 # .coveragerc to control coverage.py
 [run]
 parallel = True
+concurrency = multiprocessing
 branch = True
 source = lib
 omit =

--- a/share/spack/qa/run-build-tests
+++ b/share/spack/qa/run-build-tests
@@ -26,4 +26,3 @@ spack config get compilers
 
 # Run some build smoke tests, potentially with code coverage
 ${coverage_run} bin/spack install ${SPEC}
-${coverage_combine}

--- a/share/spack/qa/run-unit-tests
+++ b/share/spack/qa/run-unit-tests
@@ -29,4 +29,3 @@ ${coverage_run} bin/spack -p --lines 20 spec mpileaks
 
 # Run unit tests with code coverage
 ${coverage_run} bin/spack test "$@"
-${coverage_combine}

--- a/share/spack/qa/setup.sh
+++ b/share/spack/qa/setup.sh
@@ -14,11 +14,9 @@ SPACK_ROOT="$QA_DIR/../../.."
 if [[ "$COVERAGE" == true ]]; then
     coverage=coverage
     coverage_run="coverage run"
-    coverage_combine="coverage combine"
 else
     coverage=""
     coverage_run=""
-    coverage_combine=""
 fi
 
 #

--- a/share/spack/qa/setup.sh
+++ b/share/spack/qa/setup.sh
@@ -11,13 +11,9 @@ SPACK_ROOT="$QA_DIR/../../.."
 . "$SPACK_ROOT/share/spack/setup-env.sh"
 
 # Set up some variables for running coverage tests.
-if [[ "$COVERAGE" == "true" && "$TEST_SUITE" == "unit" ]]; then
+if [[ "$COVERAGE" == true ]]; then
     coverage=coverage
     coverage_run="coverage run"
-    coverage_combine="coverage combine"
-elif [[ "$COVERAGE" == "true" && "$TEST_SUITE" == "build" ]]; then
-    coverage=coverage
-    coverage_run="coverage run --concurrency=multiprocessing"
     coverage_combine="coverage combine"
 else
     coverage=""


### PR DESCRIPTION
According to what was discovered in #6887, one of the problems is calling 'coverage combine' twice without the '-a' flag. This removes the first call within our test scripts.