### PR TITLE
Add Abinit 8.6.3

### DIFF
--- a/var/spack/repos/builtin/packages/abinit/package.py
+++ b/var/spack/repos/builtin/packages/abinit/package.py
@@ -47,8 +47,9 @@ class Abinit(AutotoolsPackage):
     """
 
     homepage = 'http://www.abinit.org'
-    url      = 'http://ftp.abinit.org/abinit-8.0.8b.tar.gz'
+    url      = 'https://www.abinit.org/sites/default/files/packages/abinit-8.6.3.tar.gz'
 
+    version('8.6.3', '6c34d2cec0cf0008dd25b8ec1b6d3ee8')
     version('8.2.2', '5f25250e06fdc0815c224ffd29858860')
     # Versions before 8.0.8b are not supported.
     version('8.0.8b', 'abc9e303bfa7f9f43f95598f87d84d5d')


### PR DESCRIPTION
The old URL for Abinit 8.2.2 does not work anymore. This PR makes it work for Abinit 8.6.3, I tested it. But I haven't tested the older versions.