### PR TITLE
flex: restrict GCC conflict to newer Ubuntu releases

### DIFF
--- a/var/spack/repos/builtin/packages/flex/package.py
+++ b/var/spack/repos/builtin/packages/flex/package.py
@@ -53,9 +53,9 @@ class Flex(AutotoolsPackage):
     depends_on('automake', type='build', when='@:2.6.0')
     depends_on('libtool',  type='build', when='@:2.6.0')
 
-    # Build issue for v2.6.4 when gcc 7.2.0 is used.
+    # Build issue for v2.6.4 when gcc 7.2.0 is used on Ubuntu 17.10.
     # See issue #219; https://github.com/westes/flex/issues/219
-    conflicts('%gcc@7.2.0:', when='@2.6.4')
+    conflicts('%gcc@7.2.0: os=ubuntu17.10', when='@2.6.4')
 
     def url_for_version(self, version):
         url = "https://github.com/westes/flex"


### PR DESCRIPTION
I just ran into the same problem as @simoatze in #6942 and was confused because I have been compiling flex 2.6.4 with GCC 7 for quite some time. Some further debugging shows that newer Ubuntu releases seem to cause the problem and not GCC 7 (tested on Ubuntu 16.04, Ubuntu 17.10 and and Fedora 27). There is probably some other underlying problem but I could not find it (Ubuntu 17.10 and Fedora 27 use the same glibc version, for example).

By the way: is it possible to somehow specify `arch=linux-ubuntu17.10-*` or do we only care about `x86_64` anyway?

Edit: Arch and Gentoo also do not carry any GCC7-specific patches (Fedora and Ubuntu still use older flex versions).