### PR TITLE
fetch_strategy: add support for wget

### DIFF
--- a/var/spack/repos/builtin/packages/jdk/package.py
+++ b/var/spack/repos/builtin/packages/jdk/package.py
@@ -40,20 +40,20 @@ class Jdk(Package):
     # commandline options.
     #
     # See http://stackoverflow.com/questions/10268583/how-to-automate-download-and-installation-of-java-jdk-on-linux
-    headers = ['Cookie: oraclelicense=accept-securebackup-cookie']
+    cookies = {'oraclelicense': 'accept-securebackup-cookie'}
 
     # For instructions on how to find the magic URL, see:
     # https://gist.github.com/P7h/9741922
     # https://linuxconfig.org/how-to-install-java-se-development-kit-on-debian-linux
-    version('8u172-b11', 'eda2945e8c02b84adbf78f46c37b71c1', headers=headers,
+    version('8u172-b11', 'eda2945e8c02b84adbf78f46c37b71c1', cookies=cookies,
             url='http://download.oracle.com/otn-pub/java/jdk/8u172-b11/a58eab1ec242421181065cdc37240b08/jdk-8u172-linux-x64.tar.gz')
-    version('8u141-b15', '8cf4c4e00744bfafc023d770cb65328c', headers=headers,
+    version('8u141-b15', '8cf4c4e00744bfafc023d770cb65328c', cookies=cookies,
             url='http://download.oracle.com/otn-pub/java/jdk/8u141-b15/336fa29ff2bb4ef291e347e091f7f4a7/jdk-8u141-linux-x64.tar.gz')
-    version('8u131-b11', '75b2cb2249710d822a60f83e28860053', headers=headers,
+    version('8u131-b11', '75b2cb2249710d822a60f83e28860053', cookies=cookies,
             url='http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.tar.gz')
-    version('8u92-b14',  '65a1cc17ea362453a6e0eb4f13be76e4', headers=headers)
-    version('8u73-b02',  '1b0120970aa8bc182606a16bf848a686', headers=headers)
-    version('8u66-b17',  '88f31f3d642c3287134297b8c10e61bf', headers=headers)
+    version('8u92-b14',  '65a1cc17ea362453a6e0eb4f13be76e4', cookies=cookies)
+    version('8u73-b02',  '1b0120970aa8bc182606a16bf848a686', cookies=cookies)
+    version('8u66-b17',  '88f31f3d642c3287134297b8c10e61bf', cookies=cookies)
     # The 7u80 tarball is not readily available from Oracle.  If you have
     # the tarball, add it to your mirror as mirror/jdk/jdk-7u80.tar.gz and
     # away you go.

--- a/var/spack/repos/builtin/packages/jdk/package.py
+++ b/var/spack/repos/builtin/packages/jdk/package.py
@@ -40,23 +40,20 @@ class Jdk(Package):
     # commandline options.
     #
     # See http://stackoverflow.com/questions/10268583/how-to-automate-download-and-installation-of-java-jdk-on-linux
-    curl_options = [
-        '-j',  # junk cookies
-        '-H',  # specify required License Agreement cookie
-        'Cookie: oraclelicense=accept-securebackup-cookie']
+    headers = ['Cookie: oraclelicense=accept-securebackup-cookie']
 
     # For instructions on how to find the magic URL, see:
     # https://gist.github.com/P7h/9741922
     # https://linuxconfig.org/how-to-install-java-se-development-kit-on-debian-linux
-    version('8u172-b11', 'eda2945e8c02b84adbf78f46c37b71c1', curl_options=curl_options,
+    version('8u172-b11', 'eda2945e8c02b84adbf78f46c37b71c1', headers=headers,
             url='http://download.oracle.com/otn-pub/java/jdk/8u172-b11/a58eab1ec242421181065cdc37240b08/jdk-8u172-linux-x64.tar.gz')
-    version('8u141-b15', '8cf4c4e00744bfafc023d770cb65328c', curl_options=curl_options,
+    version('8u141-b15', '8cf4c4e00744bfafc023d770cb65328c', headers=headers,
             url='http://download.oracle.com/otn-pub/java/jdk/8u141-b15/336fa29ff2bb4ef291e347e091f7f4a7/jdk-8u141-linux-x64.tar.gz')
-    version('8u131-b11', '75b2cb2249710d822a60f83e28860053', curl_options=curl_options,
+    version('8u131-b11', '75b2cb2249710d822a60f83e28860053', headers=headers,
             url='http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.tar.gz')
-    version('8u92-b14',  '65a1cc17ea362453a6e0eb4f13be76e4', curl_options=curl_options)
-    version('8u73-b02',  '1b0120970aa8bc182606a16bf848a686', curl_options=curl_options)
-    version('8u66-b17',  '88f31f3d642c3287134297b8c10e61bf', curl_options=curl_options)
+    version('8u92-b14',  '65a1cc17ea362453a6e0eb4f13be76e4', headers=headers)
+    version('8u73-b02',  '1b0120970aa8bc182606a16bf848a686', headers=headers)
+    version('8u66-b17',  '88f31f3d642c3287134297b8c10e61bf', headers=headers)
     # The 7u80 tarball is not readily available from Oracle.  If you have
     # the tarball, add it to your mirror as mirror/jdk/jdk-7u80.tar.gz and
     # away you go.


### PR DESCRIPTION
Some minimal operating system images only have wget installed (for example, Ubuntu). This adds support for wget to URLFetchStrategy and falls back to it if curl is not found.

This also removes support for the `curl_options` parameter and replaces it with a more generic `headers` parameter.

(I have also replaced the curl arguments with their long versions to make the code easier to understand.)