### PR TITLE
Fix logo link in README.md to point to the develop branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="https://cdn.rawgit.com/spack/spack/features/svg-logo/share/spack/logo/spack-logo.svg" width="64" valign="middle" alt="Spack"/> Spack
+# <img src="https://cdn.rawgit.com/spack/spack/develop/share/spack/logo/spack-logo.svg" width="64" valign="middle" alt="Spack"/> Spack
 
 [![Build Status](https://travis-ci.org/spack/spack.svg?branch=develop)](https://travis-ci.org/spack/spack)
 [![codecov](https://codecov.io/gh/spack/spack/branch/develop/graph/badge.svg)](https://codecov.io/gh/spack/spack)


### PR DESCRIPTION
The logo link in the main `README.md` accidentally pointed to the `features/svg-logo` branch, and is broken now that that's been deleted.  This fixes it to point to the logo on `develop`.