### PR TITLE
Enable install of multiple specs from yaml files

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -92,7 +92,8 @@ the dependencies"""
         '--fake', action='store_true',
         help="fake install for debug purposes.")
     subparser.add_argument(
-        '-f', '--file', action='store_true',
+        '-f', '--file',
+        action='append', dest='specfiles', metavar='SPEC_YAML_FILE', default=[],
         help="install from file. Read specs to install from .yaml files")
 
     cd_group = subparser.add_mutually_exclusive_group()
@@ -377,8 +378,8 @@ def install_spec(cli_args, kwargs, spec):
 
 
 def install(parser, args, **kwargs):
-    if not args.package:
-        tty.die("install requires at least one package argument")
+    if not args.package and not args.specfiles:
+        tty.die("install requires at least one package argument or yaml file")
 
     if args.jobs is not None:
         if args.jobs <= 0:
@@ -405,6 +406,7 @@ def install(parser, args, **kwargs):
     if args.run_tests:
         tty.warn("Deprecated option: --run-tests: use --test=all instead")
 
+    # 1. Abstract specs from cli
     specs = spack.cmd.parse_specs(args.package)
     if args.test == 'all' or args.run_tests:
         spack.package_testing.test_all()
@@ -412,23 +414,21 @@ def install(parser, args, **kwargs):
         for spec in specs:
             spack.package_testing.test(spec.name)
 
-    # Spec from cli
-    specs = []
-    if args.file:
-        for file in args.package:
-            with open(file, 'r') as f:
-                s = spack.spec.Spec.from_yaml(f)
+    specs = spack.cmd.parse_specs(args.package, concretize=True)
 
-            if s.concretized().dag_hash() != s.dag_hash():
-                msg = 'skipped invalid file "{0}". '
-                msg += 'The file does not contain a concrete spec.'
-                tty.warn(msg.format(file))
-                continue
+    # 2. Concrete specs from yaml files
+    for file in args.specfiles:
+        with open(file, 'r') as f:
+            s = spack.spec.Spec.from_yaml(f)
 
-            specs.append(s.concretized())
+        if s.concretized().dag_hash() != s.dag_hash():
+            msg = 'skipped invalid file "{0}". '
+            msg += 'The file does not contain a concrete spec.'
+            tty.warn(msg.format(file))
+            continue
 
-    else:
-        specs = spack.cmd.parse_specs(args.package, concretize=True)
+        specs.append(s.concretized())
+
     if len(specs) == 0:
         tty.die('The `spack install` command requires a spec to install.')
 

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -92,8 +92,8 @@ the dependencies"""
         '--fake', action='store_true',
         help="fake install for debug purposes.")
     subparser.add_argument(
-        '-f', '--file',
-        action='append', dest='specfiles', metavar='SPEC_YAML_FILE', default=[],
+        '-f', '--file', action='append', default=[],
+        dest='specfiles', metavar='SPEC_YAML_FILE',
         help="install from file. Read specs to install from .yaml files")
 
     cd_group = subparser.add_mutually_exclusive_group()

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -273,3 +273,29 @@ def test_install_from_file(spec, concretize, error_code, tmpdir):
     # Absolute path to specfile (regression for #????)
     install('-f', str(specfile), fail_on_error=False)
     assert install.returncode == error_code
+
+
+@pytest.mark.usefixtures('noop_install', 'config')
+@pytest.mark.parametrize('clispecs,filespecs', [
+    [[],                  ['mpi']],
+    [[],                  ['mpi', 'boost']],
+    [['cmake'],           ['mpi']],
+    [['cmake', 'libelf'], []],
+    [['cmake', 'libelf'], ['mpi', 'boost']],
+])
+def test_install_mix_cli_and_files(clispecs, filespecs, tmpdir):
+
+    args = clispecs
+
+    for spec in filespecs:
+        filepath = tmpdir.join(spec + '.yaml')
+        args = ['-f', str(filepath)] + args
+        with filepath.open('w') as f:
+            s = Spec(spec)
+            s.concretize()
+            s.to_yaml(f)
+
+    print(args)
+
+    install(*args, fail_on_error=False)
+    assert install.returncode == 0

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -259,10 +259,17 @@ def test_install_from_file(spec, concretize, error_code, tmpdir):
     if concretize:
         spec.concretize()
 
-    with fs.working_dir(str(tmpdir)):
-        # A non-concrete spec will fail to be installed
-        with open('spec.yaml', 'w') as f:
-            spec.to_yaml(f)
-        install('-f', 'spec.yaml', fail_on_error=False)
+    specfile = tmpdir.join('spec.yaml')
 
+    with specfile.open('w') as f:
+        spec.to_yaml(f)
+
+    # Relative path to specfile (regression for #6906)
+    with fs.working_dir(specfile.dirname):
+        # A non-concrete spec will fail to be installed
+        install('-f', specfile.basename, fail_on_error=False)
+    assert install.returncode == error_code
+
+    # Absolute path to specfile (regression for #????)
+    install('-f', str(specfile), fail_on_error=False)
     assert install.returncode == error_code

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -270,7 +270,7 @@ def test_install_from_file(spec, concretize, error_code, tmpdir):
         install('-f', specfile.basename, fail_on_error=False)
     assert install.returncode == error_code
 
-    # Absolute path to specfile (regression for #????)
+    # Absolute path to specfile (regression for #6983)
     install('-f', str(specfile), fail_on_error=False)
     assert install.returncode == error_code
 
@@ -294,8 +294,6 @@ def test_install_mix_cli_and_files(clispecs, filespecs, tmpdir):
             s = Spec(spec)
             s.concretize()
             s.to_yaml(f)
-
-    print(args)
 
     install(*args, fail_on_error=False)
     assert install.returncode == 0

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -290,9 +290,9 @@ def test_install_mix_cli_and_files(clispecs, filespecs, tmpdir):
     for spec in filespecs:
         filepath = tmpdir.join(spec + '.yaml')
         args = ['-f', str(filepath)] + args
+        s = Spec(spec)
+        s.concretize()
         with filepath.open('w') as f:
-            s = Spec(spec)
-            s.concretize()
             s.to_yaml(f)
 
     install(*args, fail_on_error=False)


### PR DESCRIPTION
This enables multiple `--file` options for `install`:

```
$ spack install -f spec1.yaml  -f spec2.yaml -f spec3.yaml
```

Allows to mix specs from cli and `yaml` files at the same time:

```
$ spack install -f spec1.yaml  -f spec2.yaml qt mpi graphviz
```

During the streamlining of arguments handling logic in `install`, #6983 has been fixed. Added regressions for it, and tests for the new feature.