### PR TITLE
spack.directives.patch: add ignore_whitespace option

### DIFF
--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -411,7 +411,8 @@ def provides(*specs, **kwargs):
 
 
 @directive('patches')
-def patch(url_or_filename, level=1, when=None, working_dir=".", **kwargs):
+def patch(url_or_filename, level=1, when=None, working_dir=".",
+          ignore_whitespace=False, **kwargs):
     """Packages can declare patches to apply to source.  You can
     optionally provide a when spec to indicate that a particular
     patch should only be applied when the package's spec meets
@@ -423,6 +424,8 @@ def patch(url_or_filename, level=1, when=None, working_dir=".", **kwargs):
         when (Spec): optional anonymous spec that specifies when to apply
             the patch
         working_dir (str): dir to change to before applying
+        ignore_whitespace (bool): if True, ignore whitespace differences
+            in patch
 
     Keyword Args:
         sha256 (str): sha256 sum of the patch, used to verify the patch
@@ -440,7 +443,7 @@ def patch(url_or_filename, level=1, when=None, working_dir=".", **kwargs):
         cur_patches = pkg_or_dep.patches.setdefault(when_spec, [])
         cur_patches.append(
             Patch.create(pkg_or_dep, url_or_filename, level,
-                         working_dir, **kwargs))
+                         working_dir, ignore_whitespace, **kwargs))
 
     return _execute_patch
 

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -99,10 +99,11 @@ class Patch(object):
             stage: stage for the package that needs to be patched
         """
         patch = which("patch", required=True)
+        args = ['-s', '-p', str(self.level), '-i', self.path, "-d",
+                self.working_dir]
         with working_dir(stage.source_path):
             # Use -N to allow the same patches to be applied multiple times.
-            patch('-s', '-p', str(self.level), '-i', self.path,
-                  "-d", self.working_dir)
+            patch(*args)
 
 
 class FilePatch(Patch):

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -56,7 +56,8 @@ class Patch(object):
     """
 
     @staticmethod
-    def create(pkg, path_or_url, level=1, working_dir=".", **kwargs):
+    def create(pkg, path_or_url, level=1, working_dir=".",
+               ignore_whitespace=False, **kwargs):
         """
         Factory method that creates an instance of some class derived from
         Patch
@@ -66,17 +67,20 @@ class Patch(object):
             path_or_url: path or url where the patch is found
             level: patch level (default 1)
             working_dir (str): dir to change to before applying (default '.')
+            ignore_whitespace (bool): if True, ignore whitespace differences
 
         Returns:
             instance of some Patch class
         """
         # Check if we are dealing with a URL
         if '://' in path_or_url:
-            return UrlPatch(path_or_url, level, working_dir, **kwargs)
+            return UrlPatch(path_or_url, level, working_dir,
+                            ignore_whitespace, **kwargs)
         # Assume patches are stored in the repository
-        return FilePatch(pkg, path_or_url, level, working_dir)
+        return FilePatch(pkg, path_or_url, level, working_dir,
+                         ignore_whitespace)
 
-    def __init__(self, path_or_url, level, working_dir):
+    def __init__(self, path_or_url, level, working_dir, ignore_whitespace):
         # Check on level (must be an integer > 0)
         if not isinstance(level, int) or not level >= 0:
             raise ValueError("Patch level needs to be a non-negative integer.")
@@ -84,6 +88,7 @@ class Patch(object):
         self.path_or_url = path_or_url
         self.level = level
         self.working_dir = working_dir
+        self.ignore_whitespace = ignore_whitespace
         # self.path needs to be computed by derived classes
         # before a call to apply
         self.path = None
@@ -101,6 +106,8 @@ class Patch(object):
         patch = which("patch", required=True)
         args = ['-s', '-p', str(self.level), '-i', self.path, "-d",
                 self.working_dir]
+        if self.ignore_whitespace:
+            args += ['--ignore-whitespace']
         with working_dir(stage.source_path):
             # Use -N to allow the same patches to be applied multiple times.
             patch(*args)
@@ -108,8 +115,10 @@ class Patch(object):
 
 class FilePatch(Patch):
     """Describes a patch that is retrieved from a file in the repository"""
-    def __init__(self, pkg, path_or_url, level, working_dir):
-        super(FilePatch, self).__init__(path_or_url, level, working_dir)
+    def __init__(self, pkg, path_or_url, level, working_dir,
+                 ignore_whitespace):
+        super(FilePatch, self).__init__(path_or_url, level,
+                                        working_dir, ignore_whitespace)
 
         pkg_dir = os.path.dirname(absolute_path_for_package(pkg))
         self.path = os.path.join(pkg_dir, path_or_url)
@@ -127,8 +136,10 @@ class FilePatch(Patch):
 
 class UrlPatch(Patch):
     """Describes a patch that is retrieved from a URL"""
-    def __init__(self, path_or_url, level, working_dir, **kwargs):
-        super(UrlPatch, self).__init__(path_or_url, level, working_dir)
+    def __init__(self, path_or_url, level, working_dir,
+                 ignore_whitespace, **kwargs):
+        super(UrlPatch, self).__init__(path_or_url, level,
+                                       working_dir, ignore_whitespace)
         self.url = path_or_url
 
         self.archive_sha256 = None


### PR DESCRIPTION
Add an option to ignore whitespace when applying patches. While experimenting with patch files in spack, I created a patch file that failed to apply, and the issue turned out to be differences in whitespace. Correcting whitespace can be easy for small patches, but tedious for larger ones, so adding this option seemed like a proposal worth putting forward.