### PR TITLE
make py-setuptools a run-time-only dep for py-basemap and patch pytho…

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -237,9 +237,15 @@ class PythonPackage(PackageBase):
         # Spack manages the package directory on its own by symlinking
         # extensions into the site-packages directory, so we don't really
         # need the .pth files or egg directories, anyway.
+        #
+        # We need to make sure this is only for build dependencies. A package
+        # such as py-basemap will not build properly with this flag since
+        # it does not use setuptools to build and those does not recognize
+        # the --single-version-externally-managed flag
         if ('py-setuptools' == spec.name or          # this is setuptools, or
-            'py-setuptools' in spec._dependencies):  # it's an immediate dep
-            args += ['--single-version-externally-managed', '--root=/']
+            'py-setuptools' in spec._dependencies and  # it's an immediate dep
+            'build' in spec._dependencies['py-setuptools'].deptypes):
+                args += ['--single-version-externally-managed', '--root=/']
 
         return args
 

--- a/var/spack/repos/builtin/packages/py-basemap/package.py
+++ b/var/spack/repos/builtin/packages/py-basemap/package.py
@@ -37,7 +37,7 @@ class PyBasemap(PythonPackage):
     # Per Github issue #3813, setuptools is required at runtime in order
     # to make mpl_toolkits a namespace package that can span multiple
     # directories (i.e., matplotlib and basemap)
-    depends_on('py-setuptools', type=('build', 'run'))
+    depends_on('py-setuptools', type=('run'))
     depends_on('py-numpy', type=('build', 'run'))
     depends_on('py-matplotlib', type=('build', 'run'))
     depends_on('pil', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-qtconsole/package.py
+++ b/var/spack/repos/builtin/packages/py-qtconsole/package.py
@@ -35,7 +35,6 @@ class PyQtconsole(PythonPackage):
 
     variant('doc', default=False, description='Build documentation')
 
-    depends_on('py-setuptools',          type='build')
     depends_on('py-ipykernel@4.1:',      type=('build', 'run'))
     depends_on('py-jupyter-client@4.1:', type=('build', 'run'))
     depends_on('py-jupyter-core',        type=('build', 'run'))


### PR DESCRIPTION
py-basemap was failing to build because py-setuptools was listed as a build dependency, even though it does not use it to build, thus causing the --single-version-externally-managed flag to be erroneously added to the installation via setup.py. py-setuptools is a run-time dependency for py-basemap per #3813.

This PR sets py-setuptools as only a run dependency in py-basemap. It also modifies the Python package build system to only supply the --single-version-externally-managed flag for build-time dependences of py-setuptools.