### PR TITLE
Mark slow unit tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -35,12 +35,10 @@ def pytest_addoption(parser):
     group = parser.getgroup("Spack specific command line options")
     group.addoption(
         '--fast', action='store_true', default=False,
-        help='runs only "fast" unit tests, instead of the whole suite'
-    )
+        help='runs only "fast" unit tests, instead of the whole suite')
 
 
 def pytest_collection_modifyitems(config, items):
-
     if not config.getoption('--fast'):
         # --fast not given, run all the tests
         return

--- a/conftest.py
+++ b/conftest.py
@@ -22,29 +22,33 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
+
 import pytest
 
-from spack.main import SpackCommand
 
-versions = SpackCommand('versions')
-
-
-@pytest.mark.network
-def test_remote_versions():
-    """Test a package for which remote versions should be available."""
-
-    versions('zlib')
-
-
-@pytest.mark.network
-def test_no_versions():
-    """Test a package for which no remote versions are available."""
-
-    versions('converge')
+# Hooks to add command line options or set other custom behaviors.
+# They must be placed here to be found by pytest. See:
+#
+# https://docs.pytest.org/en/latest/writing_plugins.html
+#
+def pytest_addoption(parser):
+    group = parser.getgroup("Spack specific command line options")
+    group.addoption(
+        '--fast', action='store_true', default=False,
+        help='runs only "fast" unit tests, instead of the whole suite'
+    )
 
 
-@pytest.mark.network
-def test_no_unchecksummed_versions():
-    """Test a package for which no unchecksummed versions are available."""
+def pytest_collection_modifyitems(config, items):
 
-    versions('bzip2')
+    if not config.getoption('--fast'):
+        # --fast not given, run all the tests
+        return
+
+    slow_tests = ['db', 'network', 'maybeslow']
+    skip_as_slow = pytest.mark.skip(
+        reason='skipped slow test [--fast command line option given]'
+    )
+    for item in items:
+        if any(x in item.keywords for x in slow_tests):
+            item.add_marker(skip_as_slow)

--- a/lib/spack/spack/test/cmd/dependencies.py
+++ b/lib/spack/spack/test/cmd/dependencies.py
@@ -24,6 +24,8 @@
 ##############################################################################
 import re
 
+import pytest
+
 from llnl.util.tty.color import color_when
 
 import spack
@@ -50,6 +52,7 @@ def test_transitive_dependencies(builtin_mock):
     assert expected == actual
 
 
+@pytest.mark.slowtest
 def test_immediate_installed_dependencies(builtin_mock, database):
     with color_when(False):
         out = dependencies('--installed', 'mpileaks^mpich')
@@ -63,6 +66,7 @@ def test_immediate_installed_dependencies(builtin_mock, database):
     assert expected == hashes
 
 
+@pytest.mark.slowtest
 def test_transitive_installed_dependencies(builtin_mock, database):
     with color_when(False):
         out = dependencies('--installed', '--transitive', 'mpileaks^zmpi')

--- a/lib/spack/spack/test/cmd/dependencies.py
+++ b/lib/spack/spack/test/cmd/dependencies.py
@@ -52,7 +52,7 @@ def test_transitive_dependencies(builtin_mock):
     assert expected == actual
 
 
-@pytest.mark.slowtest
+@pytest.mark.db
 def test_immediate_installed_dependencies(builtin_mock, database):
     with color_when(False):
         out = dependencies('--installed', 'mpileaks^mpich')
@@ -66,7 +66,7 @@ def test_immediate_installed_dependencies(builtin_mock, database):
     assert expected == hashes
 
 
-@pytest.mark.slowtest
+@pytest.mark.db
 def test_transitive_installed_dependencies(builtin_mock, database):
     with color_when(False):
         out = dependencies('--installed', '--transitive', 'mpileaks^zmpi')

--- a/lib/spack/spack/test/cmd/dependents.py
+++ b/lib/spack/spack/test/cmd/dependents.py
@@ -24,6 +24,8 @@
 ##############################################################################
 import re
 
+import pytest
+
 from llnl.util.tty.color import color_when
 
 import spack
@@ -48,6 +50,7 @@ def test_transitive_dependents(builtin_mock):
          'patch-a-dependency', 'patch-several-dependencies'])
 
 
+@pytest.mark.slowtest
 def test_immediate_installed_dependents(builtin_mock, database):
     with color_when(False):
         out = dependents('--installed', 'libelf')
@@ -64,6 +67,7 @@ def test_immediate_installed_dependents(builtin_mock, database):
     assert expected == hashes
 
 
+@pytest.mark.slowtest
 def test_transitive_installed_dependents(builtin_mock, database):
     with color_when(False):
         out = dependents('--installed', '--transitive', 'fake')

--- a/lib/spack/spack/test/cmd/dependents.py
+++ b/lib/spack/spack/test/cmd/dependents.py
@@ -50,7 +50,7 @@ def test_transitive_dependents(builtin_mock):
          'patch-a-dependency', 'patch-several-dependencies'])
 
 
-@pytest.mark.slowtest
+@pytest.mark.db
 def test_immediate_installed_dependents(builtin_mock, database):
     with color_when(False):
         out = dependents('--installed', 'libelf')
@@ -67,7 +67,7 @@ def test_immediate_installed_dependents(builtin_mock, database):
     assert expected == hashes
 
 
-@pytest.mark.slowtest
+@pytest.mark.db
 def test_transitive_installed_dependents(builtin_mock, database):
     with color_when(False):
         out = dependents('--installed', '--transitive', 'fake')

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -86,26 +86,30 @@ def test_query_arguments():
 
 @pytest.mark.db
 @pytest.mark.usefixtures('database', 'mock_display')
-class TestFindWithTags(object):
+def test_tag1(parser, specs):
 
-    def test_tag1(self, parser, specs):
+    args = parser.parse_args(['--tags', 'tag1'])
+    spack.cmd.find.find(parser, args)
 
-        args = parser.parse_args(['--tags', 'tag1'])
-        spack.cmd.find.find(parser, args)
+    assert len(specs) == 2
+    assert 'mpich' in [x.name for x in specs]
+    assert 'mpich2' in [x.name for x in specs]
 
-        assert len(specs) == 2
-        assert 'mpich' in [x.name for x in specs]
-        assert 'mpich2' in [x.name for x in specs]
 
-    def test_tag2(self, parser, specs):
-        args = parser.parse_args(['--tags', 'tag2'])
-        spack.cmd.find.find(parser, args)
+@pytest.mark.db
+@pytest.mark.usefixtures('database', 'mock_display')
+def test_tag2(parser, specs):
+    args = parser.parse_args(['--tags', 'tag2'])
+    spack.cmd.find.find(parser, args)
 
-        assert len(specs) == 1
-        assert 'mpich' in [x.name for x in specs]
+    assert len(specs) == 1
+    assert 'mpich' in [x.name for x in specs]
 
-    def test_tag2_tag3(self, parser, specs):
-        args = parser.parse_args(['--tags', 'tag2', '--tags', 'tag3'])
-        spack.cmd.find.find(parser, args)
 
-        assert len(specs) == 0
+@pytest.mark.db
+@pytest.mark.usefixtures('database', 'mock_display')
+def test_tag2_tag3(parser, specs):
+    args = parser.parse_args(['--tags', 'tag2', '--tags', 'tag3'])
+    spack.cmd.find.find(parser, args)
+
+    assert len(specs) == 0

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -84,7 +84,7 @@ def test_query_arguments():
     assert q_args['explicit'] is False
 
 
-@pytest.mark.slowtest
+@pytest.mark.db
 @pytest.mark.usefixtures('database', 'mock_display')
 class TestFindWithTags(object):
 

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -84,6 +84,7 @@ def test_query_arguments():
     assert q_args['explicit'] is False
 
 
+@pytest.mark.slowtest
 @pytest.mark.usefixtures('database', 'mock_display')
 class TestFindWithTags(object):
 

--- a/lib/spack/spack/test/cmd/gpg.py
+++ b/lib/spack/spack/test/cmd/gpg.py
@@ -52,6 +52,7 @@ def has_gnupg2():
         return False
 
 
+@pytest.mark.slowtest
 @pytest.mark.skipif(not has_gnupg2(),
                     reason='These tests require gnupg2')
 def test_gpg(gpg, tmpdir, testing_gpg_directory):

--- a/lib/spack/spack/test/cmd/gpg.py
+++ b/lib/spack/spack/test/cmd/gpg.py
@@ -52,7 +52,7 @@ def has_gnupg2():
         return False
 
 
-@pytest.mark.slowtest
+@pytest.mark.maybeslow
 @pytest.mark.skipif(not has_gnupg2(),
                     reason='These tests require gnupg2')
 def test_gpg(gpg, tmpdir, testing_gpg_directory):

--- a/lib/spack/spack/test/cmd/graph.py
+++ b/lib/spack/spack/test/cmd/graph.py
@@ -32,39 +32,48 @@ graph = SpackCommand('graph')
 
 @pytest.mark.db
 @pytest.mark.usefixtures('builtin_mock', 'database')
-class TestGraphCommand(object):
-    def test_graph_ascii(self):
-        """Tests spack graph --ascii"""
+def test_graph_ascii():
+    """Tests spack graph --ascii"""
+    graph('--ascii', 'dt-diamond')
 
-        graph('--ascii', 'dt-diamond')
 
-    def test_graph_dot(self):
-        """Tests spack graph --dot"""
+@pytest.mark.db
+@pytest.mark.usefixtures('builtin_mock', 'database')
+def test_graph_dot():
+    """Tests spack graph --dot"""
+    graph('--dot', 'dt-diamond')
 
-        graph('--dot', 'dt-diamond')
 
-    def test_graph_normalize(self):
-        """Tests spack graph --normalize"""
+@pytest.mark.db
+@pytest.mark.usefixtures('builtin_mock', 'database')
+def test_graph_normalize():
+    """Tests spack graph --normalize"""
+    graph('--normalize', 'dt-diamond')
 
-        graph('--normalize', 'dt-diamond')
 
-    def test_graph_static(self):
-        """Tests spack graph --static"""
+@pytest.mark.db
+@pytest.mark.usefixtures('builtin_mock', 'database')
+def test_graph_static():
+    """Tests spack graph --static"""
+    graph('--static', 'dt-diamond')
 
-        graph('--static', 'dt-diamond')
 
-    def test_graph_installed(self):
-        """Tests spack graph --installed"""
+@pytest.mark.db
+@pytest.mark.usefixtures('builtin_mock', 'database')
+def test_graph_installed():
+    """Tests spack graph --installed"""
 
-        graph('--installed')
+    graph('--installed')
 
-        with pytest.raises(SpackCommandError):
-            graph('--installed', 'dt-diamond')
+    with pytest.raises(SpackCommandError):
+        graph('--installed', 'dt-diamond')
 
-    def test_graph_deptype(self):
-        """Tests spack graph --deptype"""
 
-        graph('--deptype', 'all', 'dt-diamond')
+@pytest.mark.db
+@pytest.mark.usefixtures('builtin_mock', 'database')
+def test_graph_deptype():
+    """Tests spack graph --deptype"""
+    graph('--deptype', 'all', 'dt-diamond')
 
 
 def test_graph_no_specs():

--- a/lib/spack/spack/test/cmd/graph.py
+++ b/lib/spack/spack/test/cmd/graph.py
@@ -30,7 +30,7 @@ import pytest
 graph = SpackCommand('graph')
 
 
-@pytest.mark.slowtest
+@pytest.mark.db
 @pytest.mark.usefixtures('builtin_mock', 'database')
 class TestGraphCommand(object):
     def test_graph_ascii(self):

--- a/lib/spack/spack/test/cmd/graph.py
+++ b/lib/spack/spack/test/cmd/graph.py
@@ -30,43 +30,41 @@ import pytest
 graph = SpackCommand('graph')
 
 
-def test_graph_ascii(builtin_mock, database):
-    """Tests spack graph --ascii"""
+@pytest.mark.slowtest
+@pytest.mark.usefixtures('builtin_mock', 'database')
+class TestGraphCommand(object):
+    def test_graph_ascii(self):
+        """Tests spack graph --ascii"""
 
-    graph('--ascii', 'dt-diamond')
+        graph('--ascii', 'dt-diamond')
 
+    def test_graph_dot(self):
+        """Tests spack graph --dot"""
 
-def test_graph_dot(builtin_mock, database):
-    """Tests spack graph --dot"""
+        graph('--dot', 'dt-diamond')
 
-    graph('--dot', 'dt-diamond')
+    def test_graph_normalize(self):
+        """Tests spack graph --normalize"""
 
+        graph('--normalize', 'dt-diamond')
 
-def test_graph_normalize(builtin_mock, database):
-    """Tests spack graph --normalize"""
+    def test_graph_static(self):
+        """Tests spack graph --static"""
 
-    graph('--normalize', 'dt-diamond')
+        graph('--static', 'dt-diamond')
 
+    def test_graph_installed(self):
+        """Tests spack graph --installed"""
 
-def test_graph_static(builtin_mock, database):
-    """Tests spack graph --static"""
+        graph('--installed')
 
-    graph('--static', 'dt-diamond')
+        with pytest.raises(SpackCommandError):
+            graph('--installed', 'dt-diamond')
 
+    def test_graph_deptype(self):
+        """Tests spack graph --deptype"""
 
-def test_graph_installed(builtin_mock, database):
-    """Tests spack graph --installed"""
-
-    graph('--installed')
-
-    with pytest.raises(SpackCommandError):
-        graph('--installed', 'dt-diamond')
-
-
-def test_graph_deptype(builtin_mock, database):
-    """Tests spack graph --deptype"""
-
-    graph('--deptype', 'all', 'dt-diamond')
+        graph('--deptype', 'all', 'dt-diamond')
 
 
 def test_graph_no_specs():

--- a/lib/spack/spack/test/cmd/list.py
+++ b/lib/spack/spack/test/cmd/list.py
@@ -79,7 +79,7 @@ class TestListCommand(object):
         assert 'py-numpy' in pkg_names
         assert 'perl-file-copy-recursive' in pkg_names
 
-    @pytest.mark.slowtest
+    @pytest.mark.maybeslow
     def test_list_search_description(self, parser, pkg_names):
         args = parser.parse_args(['--search-description', 'xml'])
         spack.cmd.list.list(parser, args)
@@ -95,7 +95,7 @@ class TestListCommand(object):
         assert 'cloverleaf3d' in pkg_names
         assert 'hdf5' not in pkg_names
 
-    @pytest.mark.slowtest
+    @pytest.mark.maybeslow
     def test_list_formatter(self, parser, pkg_names):
         # TODO: Test the output of the commands
         args = parser.parse_args(['--format', 'name_only'])

--- a/lib/spack/spack/test/cmd/list.py
+++ b/lib/spack/spack/test/cmd/list.py
@@ -79,6 +79,7 @@ class TestListCommand(object):
         assert 'py-numpy' in pkg_names
         assert 'perl-file-copy-recursive' in pkg_names
 
+    @pytest.mark.slowtest
     def test_list_search_description(self, parser, pkg_names):
         args = parser.parse_args(['--search-description', 'xml'])
         spack.cmd.list.list(parser, args)
@@ -94,6 +95,7 @@ class TestListCommand(object):
         assert 'cloverleaf3d' in pkg_names
         assert 'hdf5' not in pkg_names
 
+    @pytest.mark.slowtest
     def test_list_formatter(self, parser, pkg_names):
         # TODO: Test the output of the commands
         args = parser.parse_args(['--format', 'name_only'])

--- a/lib/spack/spack/test/cmd/module.py
+++ b/lib/spack/spack/test/cmd/module.py
@@ -69,59 +69,67 @@ def failure_args(request):
 
 @pytest.mark.db
 @pytest.mark.usefixtures('database')
-class TestModuleCommand(object):
-    def test_exit_with_failure(self, parser, failure_args):
-        args = parser.parse_args(failure_args)
-        with pytest.raises(SystemExit):
-            module.module(parser, args)
-
-    def test_remove_and_add_tcl(self, parser):
-        """Tests adding and removing a tcl module file."""
-
-        # Remove existing modules [tcl]
-        args = parser.parse_args(['rm', '-y', '-m', 'tcl', 'mpileaks'])
-        module_files = _get_module_files(args)
-
-        for item in module_files:
-            assert os.path.exists(item)
-
+def test_exit_with_failure(parser, failure_args):
+    args = parser.parse_args(failure_args)
+    with pytest.raises(SystemExit):
         module.module(parser, args)
 
-        for item in module_files:
-            assert not os.path.exists(item)
 
-        # Add them back [tcl]
-        args = parser.parse_args(['refresh', '-y', '-m', 'tcl', 'mpileaks'])
-        module.module(parser, args)
+@pytest.mark.db
+@pytest.mark.usefixtures('database')
+def test_remove_and_add_tcl(parser):
+    """Tests adding and removing a tcl module file."""
 
-        for item in module_files:
-            assert os.path.exists(item)
+    # Remove existing modules [tcl]
+    args = parser.parse_args(['rm', '-y', '-m', 'tcl', 'mpileaks'])
+    module_files = _get_module_files(args)
 
-    @pytest.mark.parametrize('cli_args', [
-        ['--module-type', 'tcl', 'libelf'],
-        ['--module-type', 'tcl', '--full-path', 'libelf']
-    ])
-    def test_find(self, parser, cli_args):
-        """Tests the 'spack module find' under a few common scenarios."""
+    for item in module_files:
+        assert os.path.exists(item)
 
-        # Try to find it for tcl module files
-        args = parser.parse_args(['find'] + cli_args)
-        module.module(parser, args)
+    module.module(parser, args)
 
-    def test_remove_and_add_dotkit(self, parser):
-        """Tests adding and removing a dotkit module file."""
+    for item in module_files:
+        assert not os.path.exists(item)
 
-        # Remove existing modules [dotkit]
-        args = parser.parse_args(['rm', '-y', '-m', 'dotkit', 'mpileaks'])
-        module_files = _get_module_files(args)
-        for item in module_files:
-            assert os.path.exists(item)
-        module.module(parser, args)
-        for item in module_files:
-            assert not os.path.exists(item)
+    # Add them back [tcl]
+    args = parser.parse_args(['refresh', '-y', '-m', 'tcl', 'mpileaks'])
+    module.module(parser, args)
 
-        # Add them back [dotkit]
-        args = parser.parse_args(['refresh', '-y', '-m', 'dotkit', 'mpileaks'])
-        module.module(parser, args)
-        for item in module_files:
-            assert os.path.exists(item)
+    for item in module_files:
+        assert os.path.exists(item)
+
+
+@pytest.mark.db
+@pytest.mark.usefixtures('database')
+@pytest.mark.parametrize('cli_args', [
+    ['--module-type', 'tcl', 'libelf'],
+    ['--module-type', 'tcl', '--full-path', 'libelf']
+])
+def test_find(parser, cli_args):
+    """Tests the 'spack module find' under a few common scenarios."""
+
+    # Try to find it for tcl module files
+    args = parser.parse_args(['find'] + cli_args)
+    module.module(parser, args)
+
+
+@pytest.mark.db
+@pytest.mark.usefixtures('database')
+def test_remove_and_add_dotkit(parser):
+    """Tests adding and removing a dotkit module file."""
+
+    # Remove existing modules [dotkit]
+    args = parser.parse_args(['rm', '-y', '-m', 'dotkit', 'mpileaks'])
+    module_files = _get_module_files(args)
+    for item in module_files:
+        assert os.path.exists(item)
+    module.module(parser, args)
+    for item in module_files:
+        assert not os.path.exists(item)
+
+    # Add them back [dotkit]
+    args = parser.parse_args(['refresh', '-y', '-m', 'dotkit', 'mpileaks'])
+    module.module(parser, args)
+    for item in module_files:
+        assert os.path.exists(item)

--- a/lib/spack/spack/test/cmd/module.py
+++ b/lib/spack/spack/test/cmd/module.py
@@ -67,7 +67,7 @@ def failure_args(request):
 # TODO : this requires having a separate directory for test modules
 # TODO : add tests for loads and find to check the prompt format
 
-@pytest.mark.slowtest
+@pytest.mark.db
 @pytest.mark.usefixtures('database')
 class TestModuleCommand(object):
     def test_exit_with_failure(self, parser, failure_args):

--- a/lib/spack/spack/test/cmd/module.py
+++ b/lib/spack/spack/test/cmd/module.py
@@ -67,62 +67,61 @@ def failure_args(request):
 # TODO : this requires having a separate directory for test modules
 # TODO : add tests for loads and find to check the prompt format
 
+@pytest.mark.slowtest
+@pytest.mark.usefixtures('database')
+class TestModuleCommand(object):
+    def test_exit_with_failure(self, parser, failure_args):
+        args = parser.parse_args(failure_args)
+        with pytest.raises(SystemExit):
+            module.module(parser, args)
 
-def test_exit_with_failure(database, parser, failure_args):
-    args = parser.parse_args(failure_args)
-    with pytest.raises(SystemExit):
+    def test_remove_and_add_tcl(self, parser):
+        """Tests adding and removing a tcl module file."""
+
+        # Remove existing modules [tcl]
+        args = parser.parse_args(['rm', '-y', '-m', 'tcl', 'mpileaks'])
+        module_files = _get_module_files(args)
+
+        for item in module_files:
+            assert os.path.exists(item)
+
         module.module(parser, args)
 
+        for item in module_files:
+            assert not os.path.exists(item)
 
-def test_remove_and_add_tcl(database, parser):
-    """Tests adding and removing a tcl module file."""
+        # Add them back [tcl]
+        args = parser.parse_args(['refresh', '-y', '-m', 'tcl', 'mpileaks'])
+        module.module(parser, args)
 
-    # Remove existing modules [tcl]
-    args = parser.parse_args(['rm', '-y', '-m', 'tcl', 'mpileaks'])
-    module_files = _get_module_files(args)
+        for item in module_files:
+            assert os.path.exists(item)
 
-    for item in module_files:
-        assert os.path.exists(item)
+    @pytest.mark.parametrize('cli_args', [
+        ['--module-type', 'tcl', 'libelf'],
+        ['--module-type', 'tcl', '--full-path', 'libelf']
+    ])
+    def test_find(self, parser, cli_args):
+        """Tests the 'spack module find' under a few common scenarios."""
 
-    module.module(parser, args)
+        # Try to find it for tcl module files
+        args = parser.parse_args(['find'] + cli_args)
+        module.module(parser, args)
 
-    for item in module_files:
-        assert not os.path.exists(item)
+    def test_remove_and_add_dotkit(self, parser):
+        """Tests adding and removing a dotkit module file."""
 
-    # Add them back [tcl]
-    args = parser.parse_args(['refresh', '-y', '-m', 'tcl', 'mpileaks'])
-    module.module(parser, args)
+        # Remove existing modules [dotkit]
+        args = parser.parse_args(['rm', '-y', '-m', 'dotkit', 'mpileaks'])
+        module_files = _get_module_files(args)
+        for item in module_files:
+            assert os.path.exists(item)
+        module.module(parser, args)
+        for item in module_files:
+            assert not os.path.exists(item)
 
-    for item in module_files:
-        assert os.path.exists(item)
-
-
-@pytest.mark.parametrize('cli_args', [
-    ['--module-type', 'tcl', 'libelf'],
-    ['--module-type', 'tcl', '--full-path', 'libelf']
-])
-def test_find(database, parser, cli_args):
-    """Tests the 'spack module find' under a few common scenarios."""
-
-    # Try to find it for tcl module files
-    args = parser.parse_args(['find'] + cli_args)
-    module.module(parser, args)
-
-
-def test_remove_and_add_dotkit(database, parser):
-    """Tests adding and removing a dotkit module file."""
-
-    # Remove existing modules [dotkit]
-    args = parser.parse_args(['rm', '-y', '-m', 'dotkit', 'mpileaks'])
-    module_files = _get_module_files(args)
-    for item in module_files:
-        assert os.path.exists(item)
-    module.module(parser, args)
-    for item in module_files:
-        assert not os.path.exists(item)
-
-    # Add them back [dotkit]
-    args = parser.parse_args(['refresh', '-y', '-m', 'dotkit', 'mpileaks'])
-    module.module(parser, args)
-    for item in module_files:
-        assert os.path.exists(item)
+        # Add them back [dotkit]
+        args = parser.parse_args(['refresh', '-y', '-m', 'dotkit', 'mpileaks'])
+        module.module(parser, args)
+        for item in module_files:
+            assert os.path.exists(item)

--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -41,28 +41,33 @@ class MockArgs(object):
 
 @pytest.mark.db
 @pytest.mark.usefixtures('database')
-class TestUninstallCommand(object):
-    def test_multiple_matches(self):
-        """Test unable to uninstall when multiple matches."""
-        with pytest.raises(SpackCommandError):
-            uninstall('-y', 'mpileaks')
+def test_multiple_matches():
+    """Test unable to uninstall when multiple matches."""
+    with pytest.raises(SpackCommandError):
+        uninstall('-y', 'mpileaks')
 
-    def test_installed_dependents(self):
-        """Test can't uninstall when ther are installed dependents."""
-        with pytest.raises(SpackCommandError):
-            uninstall('-y', 'libelf')
 
-    def test_recursive_uninstall(self):
-        """Test recursive uninstall."""
-        uninstall('-y', '-a', '--dependents', 'callpath')
+@pytest.mark.db
+@pytest.mark.usefixtures('database')
+def test_installed_dependents():
+    """Test can't uninstall when ther are installed dependents."""
+    with pytest.raises(SpackCommandError):
+        uninstall('-y', 'libelf')
 
-        all_specs = spack.store.layout.all_specs()
-        assert len(all_specs) == 8
-        # query specs with multiple configurations
-        mpileaks_specs = [s for s in all_specs if s.satisfies('mpileaks')]
-        callpath_specs = [s for s in all_specs if s.satisfies('callpath')]
-        mpi_specs = [s for s in all_specs if s.satisfies('mpi')]
 
-        assert len(mpileaks_specs) == 0
-        assert len(callpath_specs) == 0
-        assert len(mpi_specs) == 3
+@pytest.mark.db
+@pytest.mark.usefixtures('database')
+def test_recursive_uninstall():
+    """Test recursive uninstall."""
+    uninstall('-y', '-a', '--dependents', 'callpath')
+
+    all_specs = spack.store.layout.all_specs()
+    assert len(all_specs) == 8
+    # query specs with multiple configurations
+    mpileaks_specs = [s for s in all_specs if s.satisfies('mpileaks')]
+    callpath_specs = [s for s in all_specs if s.satisfies('callpath')]
+    mpi_specs = [s for s in all_specs if s.satisfies('mpi')]
+
+    assert len(mpileaks_specs) == 0
+    assert len(callpath_specs) == 0
+    assert len(mpi_specs) == 3

--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -39,7 +39,7 @@ class MockArgs(object):
         self.yes_to_all = True
 
 
-@pytest.mark.slowtest
+@pytest.mark.db
 @pytest.mark.usefixtures('database')
 class TestUninstallCommand(object):
     def test_multiple_matches(self):

--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -39,29 +39,30 @@ class MockArgs(object):
         self.yes_to_all = True
 
 
-def test_multiple_matches(database):
-    """Test unable to uninstall when multiple matches."""
-    with pytest.raises(SpackCommandError):
-        uninstall('-y', 'mpileaks')
+@pytest.mark.slowtest
+@pytest.mark.usefixtures('database')
+class TestUninstallCommand(object):
+    def test_multiple_matches(self):
+        """Test unable to uninstall when multiple matches."""
+        with pytest.raises(SpackCommandError):
+            uninstall('-y', 'mpileaks')
 
+    def test_installed_dependents(self):
+        """Test can't uninstall when ther are installed dependents."""
+        with pytest.raises(SpackCommandError):
+            uninstall('-y', 'libelf')
 
-def test_installed_dependents(database):
-    """Test can't uninstall when ther are installed dependents."""
-    with pytest.raises(SpackCommandError):
-        uninstall('-y', 'libelf')
+    def test_recursive_uninstall(self):
+        """Test recursive uninstall."""
+        uninstall('-y', '-a', '--dependents', 'callpath')
 
+        all_specs = spack.store.layout.all_specs()
+        assert len(all_specs) == 8
+        # query specs with multiple configurations
+        mpileaks_specs = [s for s in all_specs if s.satisfies('mpileaks')]
+        callpath_specs = [s for s in all_specs if s.satisfies('callpath')]
+        mpi_specs = [s for s in all_specs if s.satisfies('mpi')]
 
-def test_recursive_uninstall(database):
-    """Test recursive uninstall."""
-    uninstall('-y', '-a', '--dependents', 'callpath')
-
-    all_specs = spack.store.layout.all_specs()
-    assert len(all_specs) == 8
-    # query specs with multiple configurations
-    mpileaks_specs = [s for s in all_specs if s.satisfies('mpileaks')]
-    callpath_specs = [s for s in all_specs if s.satisfies('callpath')]
-    mpi_specs = [s for s in all_specs if s.satisfies('mpi')]
-
-    assert len(mpileaks_specs) == 0
-    assert len(callpath_specs) == 0
-    assert len(mpi_specs) == 3
+        assert len(mpileaks_specs) == 0
+        assert len(callpath_specs) == 0
+        assert len(mpi_specs) == 3

--- a/lib/spack/spack/test/cmd/url.py
+++ b/lib/spack/spack/test/cmd/url.py
@@ -83,7 +83,7 @@ def test_url_with_no_version_fails():
         url('parse', 'http://www.netlib.org/voronoi/triangle.zip')
 
 
-@pytest.mark.slowtest
+@pytest.mark.network
 def test_url_list():
     out = url('list')
     total_urls = len(out.split('\n'))
@@ -113,7 +113,7 @@ def test_url_list():
     assert 0 < correct_version_urls < total_urls
 
 
-@pytest.mark.slowtest
+@pytest.mark.network
 def test_url_summary():
     """Test the URL summary command."""
     # test url_summary, the internal function that does the work

--- a/lib/spack/spack/test/cmd/url.py
+++ b/lib/spack/spack/test/cmd/url.py
@@ -83,6 +83,7 @@ def test_url_with_no_version_fails():
         url('parse', 'http://www.netlib.org/voronoi/triangle.zip')
 
 
+@pytest.mark.slowtest
 def test_url_list():
     out = url('list')
     total_urls = len(out.split('\n'))
@@ -112,6 +113,7 @@ def test_url_list():
     assert 0 < correct_version_urls < total_urls
 
 
+@pytest.mark.slowtest
 def test_url_summary():
     """Test the URL summary command."""
     # test url_summary, the internal function that does the work

--- a/lib/spack/spack/test/cmd/versions.py
+++ b/lib/spack/spack/test/cmd/versions.py
@@ -22,24 +22,28 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-from spack.main import SpackCommand
+import pytest
 
+from spack.main import SpackCommand
 
 versions = SpackCommand('versions')
 
 
+@pytest.mark.slowtest
 def test_remote_versions():
     """Test a package for which remote versions should be available."""
 
     versions('zlib')
 
 
+@pytest.mark.slowtest
 def test_no_versions():
     """Test a package for which no remote versions are available."""
 
     versions('converge')
 
 
+@pytest.mark.slowtest
 def test_no_unchecksummed_versions():
     """Test a package for which no unchecksummed versions are available."""
 

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -105,156 +105,6 @@ def _check_db_sanity(install_db):
     _check_merkleiness()
 
 
-def _mock_install(spec):
-    s = spack.spec.Spec(spec)
-    s.concretize()
-    pkg = spack.repo.get(s)
-    pkg.do_install(fake=True)
-
-
-def _mock_remove(spec):
-    specs = spack.store.db.query(spec)
-    assert len(specs) == 1
-    spec = specs[0]
-    spec.package.do_uninstall(spec)
-
-
-def test_default_queries(database):
-    install_db = database.mock.db
-    rec = install_db.get_record('zmpi')
-
-    spec = rec.spec
-
-    libraries = spec['zmpi'].libs
-    assert len(libraries) == 1
-
-    headers = spec['zmpi'].headers
-    assert len(headers) == 1
-
-    command = spec['zmpi'].command
-    assert isinstance(command, Executable)
-    assert command.name == 'zmpi'
-    assert os.path.exists(command.path)
-
-
-def test_005_db_exists(database):
-    """Make sure db cache file exists after creating."""
-    install_path = database.mock.path
-    index_file = install_path.join('.spack-db', 'index.json')
-    lock_file = install_path.join('.spack-db', 'lock')
-    assert os.path.exists(str(index_file))
-    assert os.path.exists(str(lock_file))
-
-
-def test_010_all_install_sanity(database):
-    """Ensure that the install layout reflects what we think it does."""
-    all_specs = spack.store.layout.all_specs()
-    assert len(all_specs) == 14
-
-    # Query specs with multiple configurations
-    mpileaks_specs = [s for s in all_specs if s.satisfies('mpileaks')]
-    callpath_specs = [s for s in all_specs if s.satisfies('callpath')]
-    mpi_specs = [s for s in all_specs if s.satisfies('mpi')]
-
-    assert len(mpileaks_specs) == 3
-    assert len(callpath_specs) == 3
-    assert len(mpi_specs) == 3
-
-    # Query specs with single configurations
-    dyninst_specs = [s for s in all_specs if s.satisfies('dyninst')]
-    libdwarf_specs = [s for s in all_specs if s.satisfies('libdwarf')]
-    libelf_specs = [s for s in all_specs if s.satisfies('libelf')]
-
-    assert len(dyninst_specs) == 1
-    assert len(libdwarf_specs) == 1
-    assert len(libelf_specs) == 1
-
-    # Query by dependency
-    assert len([s for s in all_specs if s.satisfies('mpileaks ^mpich')]) == 1
-    assert len([s for s in all_specs if s.satisfies('mpileaks ^mpich2')]) == 1
-    assert len([s for s in all_specs if s.satisfies('mpileaks ^zmpi')]) == 1
-
-
-def test_015_write_and_read(database):
-    # write and read DB
-    with spack.store.db.write_transaction():
-        specs = spack.store.db.query()
-        recs = [spack.store.db.get_record(s) for s in specs]
-
-    for spec, rec in zip(specs, recs):
-        new_rec = spack.store.db.get_record(spec)
-        assert new_rec.ref_count == rec.ref_count
-        assert new_rec.spec == rec.spec
-        assert new_rec.path == rec.path
-        assert new_rec.installed == rec.installed
-
-
-def test_020_db_sanity(database):
-    """Make sure query() returns what's actually in the db."""
-    install_db = database.mock.db
-    _check_db_sanity(install_db)
-
-
-def test_025_reindex(database):
-    """Make sure reindex works and ref counts are valid."""
-    install_db = database.mock.db
-    spack.store.db.reindex(spack.store.layout)
-    _check_db_sanity(install_db)
-
-
-def test_030_db_sanity_from_another_process(database, refresh_db_on_exit):
-    install_db = database.mock.db
-
-    def read_and_modify():
-        _check_db_sanity(install_db)  # check that other process can read DB
-        with install_db.write_transaction():
-            _mock_remove('mpileaks ^zmpi')
-
-    p = multiprocessing.Process(target=read_and_modify, args=())
-    p.start()
-    p.join()
-
-    # ensure child process change is visible in parent process
-    with install_db.read_transaction():
-        assert len(install_db.query('mpileaks ^zmpi')) == 0
-
-
-def test_040_ref_counts(database):
-    """Ensure that we got ref counts right when we read the DB."""
-    install_db = database.mock.db
-    install_db._check_ref_counts()
-
-
-def test_050_basic_query(database):
-    """Ensure querying database is consistent with what is installed."""
-    install_db = database.mock.db
-    # query everything
-    assert len(spack.store.db.query()) == 16
-
-    # query specs with multiple configurations
-    mpileaks_specs = install_db.query('mpileaks')
-    callpath_specs = install_db.query('callpath')
-    mpi_specs = install_db.query('mpi')
-
-    assert len(mpileaks_specs) == 3
-    assert len(callpath_specs) == 3
-    assert len(mpi_specs) == 3
-
-    # query specs with single configurations
-    dyninst_specs = install_db.query('dyninst')
-    libdwarf_specs = install_db.query('libdwarf')
-    libelf_specs = install_db.query('libelf')
-
-    assert len(dyninst_specs) == 1
-    assert len(libdwarf_specs) == 1
-    assert len(libelf_specs) == 1
-
-    # Query by dependency
-    assert len(install_db.query('mpileaks ^mpich')) == 1
-    assert len(install_db.query('mpileaks ^mpich2')) == 1
-    assert len(install_db.query('mpileaks ^zmpi')) == 1
-
-
 def _check_remove_and_add_package(install_db, spec):
     """Remove a spec from the DB, then add it and make sure everything's
     still ok once it is added.  This checks that it was
@@ -285,140 +135,286 @@ def _check_remove_and_add_package(install_db, spec):
     install_db._check_ref_counts()
 
 
-def test_060_remove_and_add_root_package(database):
-    install_db = database.mock.db
-    _check_remove_and_add_package(install_db, 'mpileaks ^mpich')
+def _mock_install(spec):
+    s = spack.spec.Spec(spec)
+    s.concretize()
+    pkg = spack.repo.get(s)
+    pkg.do_install(fake=True)
 
 
-def test_070_remove_and_add_dependency_package(database):
-    install_db = database.mock.db
-    _check_remove_and_add_package(install_db, 'dyninst')
+def _mock_remove(spec):
+    specs = spack.store.db.query(spec)
+    assert len(specs) == 1
+    spec = specs[0]
+    spec.package.do_uninstall(spec)
 
 
-def test_080_root_ref_counts(database):
-    install_db = database.mock.db
-    rec = install_db.get_record('mpileaks ^mpich')
+@pytest.mark.slowtest
+class TestDatabase(object):
+    def test_default_queries(self, database):
+        install_db = database.mock.db
+        rec = install_db.get_record('zmpi')
 
-    # Remove a top-level spec from the DB
-    install_db.remove('mpileaks ^mpich')
+        spec = rec.spec
 
-    # record no longer in DB
-    assert install_db.query('mpileaks ^mpich', installed=any) == []
+        libraries = spec['zmpi'].libs
+        assert len(libraries) == 1
 
-    # record's deps have updated ref_counts
-    assert install_db.get_record('callpath ^mpich').ref_count == 0
-    assert install_db.get_record('mpich').ref_count == 1
+        headers = spec['zmpi'].headers
+        assert len(headers) == 1
 
-    # Put the spec back
-    install_db.add(rec.spec, spack.store.layout)
+        command = spec['zmpi'].command
+        assert isinstance(command, Executable)
+        assert command.name == 'zmpi'
+        assert os.path.exists(command.path)
 
-    # record is present again
-    assert len(install_db.query('mpileaks ^mpich', installed=any)) == 1
+    def test_005_db_exists(self, database):
+        """Make sure db cache file exists after creating."""
+        install_path = database.mock.path
+        index_file = install_path.join('.spack-db', 'index.json')
+        lock_file = install_path.join('.spack-db', 'lock')
+        assert os.path.exists(str(index_file))
+        assert os.path.exists(str(lock_file))
 
-    # dependencies have ref counts updated
-    assert install_db.get_record('callpath ^mpich').ref_count == 1
-    assert install_db.get_record('mpich').ref_count == 2
+    def test_010_all_install_sanity(self, database):
+        """Ensure that the install layout reflects what we think it does."""
+        all_specs = spack.store.layout.all_specs()
+        assert len(all_specs) == 14
 
+        # Query specs with multiple configurations
+        mpileaks_specs = [s for s in all_specs if s.satisfies('mpileaks')]
+        callpath_specs = [s for s in all_specs if s.satisfies('callpath')]
+        mpi_specs = [s for s in all_specs if s.satisfies('mpi')]
 
-def test_090_non_root_ref_counts(database):
-    install_db = database.mock.db
+        assert len(mpileaks_specs) == 3
+        assert len(callpath_specs) == 3
+        assert len(mpi_specs) == 3
 
-    install_db.get_record('mpileaks ^mpich')
-    install_db.get_record('callpath ^mpich')
+        # Query specs with single configurations
+        dyninst_specs = [s for s in all_specs if s.satisfies('dyninst')]
+        libdwarf_specs = [s for s in all_specs if s.satisfies('libdwarf')]
+        libelf_specs = [s for s in all_specs if s.satisfies('libelf')]
 
-    # "force remove" a non-root spec from the DB
-    install_db.remove('callpath ^mpich')
+        assert len(dyninst_specs) == 1
+        assert len(libdwarf_specs) == 1
+        assert len(libelf_specs) == 1
 
-    # record still in DB but marked uninstalled
-    assert install_db.query('callpath ^mpich', installed=True) == []
-    assert len(install_db.query('callpath ^mpich', installed=any)) == 1
+        # Query by dependency
+        assert len(
+            [s for s in all_specs if s.satisfies('mpileaks ^mpich')]
+        ) == 1
+        assert len(
+            [s for s in all_specs if s.satisfies('mpileaks ^mpich2')]
+        ) == 1
+        assert len(
+            [s for s in all_specs if s.satisfies('mpileaks ^zmpi')]
+        ) == 1
 
-    # record and its deps have same ref_counts
-    assert install_db.get_record(
-        'callpath ^mpich', installed=any
-    ).ref_count == 1
-    assert install_db.get_record('mpich').ref_count == 2
+    def test_015_write_and_read(self, database):
+        # write and read DB
+        with spack.store.db.write_transaction():
+            specs = spack.store.db.query()
+            recs = [spack.store.db.get_record(s) for s in specs]
 
-    # remove only dependent of uninstalled callpath record
-    install_db.remove('mpileaks ^mpich')
+        for spec, rec in zip(specs, recs):
+            new_rec = spack.store.db.get_record(spec)
+            assert new_rec.ref_count == rec.ref_count
+            assert new_rec.spec == rec.spec
+            assert new_rec.path == rec.path
+            assert new_rec.installed == rec.installed
 
-    # record and parent are completely gone.
-    assert install_db.query('mpileaks ^mpich', installed=any) == []
-    assert install_db.query('callpath ^mpich', installed=any) == []
+    def test_020_db_sanity(self, database):
+        """Make sure query() returns what's actually in the db."""
+        install_db = database.mock.db
+        _check_db_sanity(install_db)
 
-    # mpich ref count updated properly.
-    mpich_rec = install_db.get_record('mpich')
-    assert mpich_rec.ref_count == 0
-
-
-def test_100_no_write_with_exception_on_remove(database):
-    install_db = database.mock.db
-
-    def fail_while_writing():
-        with install_db.write_transaction():
-            _mock_remove('mpileaks ^zmpi')
-            raise Exception()
-
-    with install_db.read_transaction():
-        assert len(install_db.query('mpileaks ^zmpi', installed=any)) == 1
-
-    with pytest.raises(Exception):
-        fail_while_writing()
-
-    # reload DB and make sure zmpi is still there.
-    with install_db.read_transaction():
-        assert len(install_db.query('mpileaks ^zmpi', installed=any)) == 1
-
-
-def test_110_no_write_with_exception_on_install(database):
-    install_db = database.mock.db
-
-    def fail_while_writing():
-        with install_db.write_transaction():
-            _mock_install('cmake')
-            raise Exception()
-
-    with install_db.read_transaction():
-        assert install_db.query('cmake', installed=any) == []
-
-    with pytest.raises(Exception):
-        fail_while_writing()
-
-    # reload DB and make sure cmake was not written.
-    with install_db.read_transaction():
-        assert install_db.query('cmake', installed=any) == []
-
-
-def test_115_reindex_with_packages_not_in_repo(database, refresh_db_on_exit):
-    install_db = database.mock.db
-
-    saved_repo = spack.repo
-    # Dont add any package definitions to this repository, the idea is that
-    # packages should not have to be defined in the repository once they are
-    # installed
-    mock_repo = MockPackageMultiRepo([])
-    try:
-        spack.repo = mock_repo
+    def test_025_reindex(self, database):
+        """Make sure reindex works and ref counts are valid."""
+        install_db = database.mock.db
         spack.store.db.reindex(spack.store.layout)
         _check_db_sanity(install_db)
-    finally:
-        spack.repo = saved_repo
 
+    def test_030_db_sanity_from_another_process(
+            self, database, refresh_db_on_exit
+    ):
+        install_db = database.mock.db
 
-def test_external_entries_in_db(database):
-    install_db = database.mock.db
+        def read_and_modify():
+            _check_db_sanity(install_db)  # check other processes can read DB
+            with install_db.write_transaction():
+                _mock_remove('mpileaks ^zmpi')
 
-    rec = install_db.get_record('mpileaks ^zmpi')
-    assert rec.spec.external_path is None
-    assert rec.spec.external_module is None
+        p = multiprocessing.Process(target=read_and_modify, args=())
+        p.start()
+        p.join()
 
-    rec = install_db.get_record('externaltool')
-    assert rec.spec.external_path == '/path/to/external_tool'
-    assert rec.spec.external_module is None
-    assert rec.explicit is False
+        # ensure child process change is visible in parent process
+        with install_db.read_transaction():
+            assert len(install_db.query('mpileaks ^zmpi')) == 0
 
-    rec.spec.package.do_install(fake=True, explicit=True)
-    rec = install_db.get_record('externaltool')
-    assert rec.spec.external_path == '/path/to/external_tool'
-    assert rec.spec.external_module is None
-    assert rec.explicit is True
+    def test_040_ref_counts(self, database):
+        """Ensure that we got ref counts right when we read the DB."""
+        install_db = database.mock.db
+        install_db._check_ref_counts()
+
+    def test_050_basic_query(self, database):
+        """Ensure querying database is consistent with what is installed."""
+        install_db = database.mock.db
+        # query everything
+        assert len(spack.store.db.query()) == 16
+
+        # query specs with multiple configurations
+        mpileaks_specs = install_db.query('mpileaks')
+        callpath_specs = install_db.query('callpath')
+        mpi_specs = install_db.query('mpi')
+
+        assert len(mpileaks_specs) == 3
+        assert len(callpath_specs) == 3
+        assert len(mpi_specs) == 3
+
+        # query specs with single configurations
+        dyninst_specs = install_db.query('dyninst')
+        libdwarf_specs = install_db.query('libdwarf')
+        libelf_specs = install_db.query('libelf')
+
+        assert len(dyninst_specs) == 1
+        assert len(libdwarf_specs) == 1
+        assert len(libelf_specs) == 1
+
+        # Query by dependency
+        assert len(install_db.query('mpileaks ^mpich')) == 1
+        assert len(install_db.query('mpileaks ^mpich2')) == 1
+        assert len(install_db.query('mpileaks ^zmpi')) == 1
+
+    def test_060_remove_and_add_root_package(self, database):
+        install_db = database.mock.db
+        _check_remove_and_add_package(install_db, 'mpileaks ^mpich')
+
+    def test_070_remove_and_add_dependency_package(self, database):
+        install_db = database.mock.db
+        _check_remove_and_add_package(install_db, 'dyninst')
+
+    def test_080_root_ref_counts(self, database):
+        install_db = database.mock.db
+        rec = install_db.get_record('mpileaks ^mpich')
+
+        # Remove a top-level spec from the DB
+        install_db.remove('mpileaks ^mpich')
+
+        # record no longer in DB
+        assert install_db.query('mpileaks ^mpich', installed=any) == []
+
+        # record's deps have updated ref_counts
+        assert install_db.get_record('callpath ^mpich').ref_count == 0
+        assert install_db.get_record('mpich').ref_count == 1
+
+        # Put the spec back
+        install_db.add(rec.spec, spack.store.layout)
+
+        # record is present again
+        assert len(install_db.query('mpileaks ^mpich', installed=any)) == 1
+
+        # dependencies have ref counts updated
+        assert install_db.get_record('callpath ^mpich').ref_count == 1
+        assert install_db.get_record('mpich').ref_count == 2
+
+    def test_090_non_root_ref_counts(self, database):
+        install_db = database.mock.db
+
+        install_db.get_record('mpileaks ^mpich')
+        install_db.get_record('callpath ^mpich')
+
+        # "force remove" a non-root spec from the DB
+        install_db.remove('callpath ^mpich')
+
+        # record still in DB but marked uninstalled
+        assert install_db.query('callpath ^mpich', installed=True) == []
+        assert len(install_db.query('callpath ^mpich', installed=any)) == 1
+
+        # record and its deps have same ref_counts
+        assert install_db.get_record(
+            'callpath ^mpich', installed=any
+        ).ref_count == 1
+        assert install_db.get_record('mpich').ref_count == 2
+
+        # remove only dependent of uninstalled callpath record
+        install_db.remove('mpileaks ^mpich')
+
+        # record and parent are completely gone.
+        assert install_db.query('mpileaks ^mpich', installed=any) == []
+        assert install_db.query('callpath ^mpich', installed=any) == []
+
+        # mpich ref count updated properly.
+        mpich_rec = install_db.get_record('mpich')
+        assert mpich_rec.ref_count == 0
+
+    def test_100_no_write_with_exception_on_remove(self, database):
+        install_db = database.mock.db
+
+        def fail_while_writing():
+            with install_db.write_transaction():
+                _mock_remove('mpileaks ^zmpi')
+                raise Exception()
+
+        with install_db.read_transaction():
+            assert len(install_db.query('mpileaks ^zmpi', installed=any)) == 1
+
+        with pytest.raises(Exception):
+            fail_while_writing()
+
+        # reload DB and make sure zmpi is still there.
+        with install_db.read_transaction():
+            assert len(install_db.query('mpileaks ^zmpi', installed=any)) == 1
+
+    def test_110_no_write_with_exception_on_install(self, database):
+        install_db = database.mock.db
+
+        def fail_while_writing():
+            with install_db.write_transaction():
+                _mock_install('cmake')
+                raise Exception()
+
+        with install_db.read_transaction():
+            assert install_db.query('cmake', installed=any) == []
+
+        with pytest.raises(Exception):
+            fail_while_writing()
+
+        # reload DB and make sure cmake was not written.
+        with install_db.read_transaction():
+            assert install_db.query('cmake', installed=any) == []
+
+    def test_115_reindex_with_packages_not_in_repo(
+            self, database, refresh_db_on_exit
+    ):
+        install_db = database.mock.db
+
+        saved_repo = spack.repo
+        # Dont add any package definitions to this repository, the idea is that
+        # packages should not have to be defined in the repository once they
+        # are installed
+        mock_repo = MockPackageMultiRepo([])
+        try:
+            spack.repo = mock_repo
+            spack.store.db.reindex(spack.store.layout)
+            _check_db_sanity(install_db)
+        finally:
+            spack.repo = saved_repo
+
+    def test_external_entries_in_db(self, database):
+        install_db = database.mock.db
+
+        rec = install_db.get_record('mpileaks ^zmpi')
+        assert rec.spec.external_path is None
+        assert rec.spec.external_module is None
+
+        rec = install_db.get_record('externaltool')
+        assert rec.spec.external_path == '/path/to/external_tool'
+        assert rec.spec.external_module is None
+        assert rec.explicit is False
+
+        rec.spec.package.do_install(fake=True, explicit=True)
+        rec = install_db.get_record('externaltool')
+        assert rec.spec.external_path == '/path/to/external_tool'
+        assert rec.spec.external_module is None
+        assert rec.explicit is True

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -149,7 +149,7 @@ def _mock_remove(spec):
     spec.package.do_uninstall(spec)
 
 
-@pytest.mark.slowtest
+@pytest.mark.db
 class TestDatabase(object):
     def test_default_queries(self, database):
         install_db = database.mock.db

--- a/lib/spack/spack/test/package_sanity.py
+++ b/lib/spack/spack/test/package_sanity.py
@@ -38,7 +38,7 @@ def check_db():
         spack.repo.get(name)
 
 
-@pytest.mark.slowtest
+@pytest.mark.maybeslow
 def test_get_all_packages():
     """Get all packages once and make sure that works."""
     check_db()

--- a/lib/spack/spack/test/package_sanity.py
+++ b/lib/spack/spack/test/package_sanity.py
@@ -26,6 +26,8 @@
 
 import re
 
+import pytest
+
 import spack
 from spack.repository import RepoPath
 
@@ -36,6 +38,7 @@ def check_db():
         spack.repo.get(name)
 
 
+@pytest.mark.slowtest
 def test_get_all_packages():
     """Get all packages once and make sure that works."""
     check_db()

--- a/lib/spack/spack/test/python_version.py
+++ b/lib/spack/spack/test/python_version.py
@@ -156,13 +156,13 @@ def check_python_versions(files):
     assert not all_issues
 
 
-@pytest.mark.slowtest
+@pytest.mark.maybeslow
 def test_core_module_compatibility():
     """Test that all core spack modules work with supported Python versions."""
     check_python_versions(pyfiles([spack.lib_path], exclude=exclude_paths))
 
 
-@pytest.mark.slowtest
+@pytest.mark.maybeslow
 def test_package_module_compatibility():
     """Test that all spack packages work with supported Python versions."""
     check_python_versions(pyfiles([spack.packages_path]))

--- a/lib/spack/spack/test/python_version.py
+++ b/lib/spack/spack/test/python_version.py
@@ -37,6 +37,8 @@ import os
 import sys
 import re
 
+import pytest
+
 import llnl.util.tty as tty
 import spack
 
@@ -154,11 +156,13 @@ def check_python_versions(files):
     assert not all_issues
 
 
+@pytest.mark.slowtest
 def test_core_module_compatibility():
     """Test that all core spack modules work with supported Python versions."""
     check_python_versions(pyfiles([spack.lib_path], exclude=exclude_paths))
 
 
+@pytest.mark.slowtest
 def test_package_module_compatibility():
     """Test that all spack packages work with supported Python versions."""
     check_python_versions(pyfiles([spack.packages_path]))

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -253,6 +253,7 @@ class TestSpecSyntax(object):
             str(spec), spec.name + '@' + str(spec.version) +
             ' /' + spec.dag_hash()[:6])
 
+    @pytest.mark.slowtest
     def test_spec_by_hash(self, database):
         specs = database.mock.db.query()
         assert len(specs)  # make sure something's in the DB
@@ -260,6 +261,7 @@ class TestSpecSyntax(object):
         for spec in specs:
             self._check_hash_parse(spec)
 
+    @pytest.mark.slowtest
     def test_dep_spec_by_hash(self, database):
         mpileaks_zmpi = database.mock.db.query_one('mpileaks ^zmpi')
         zmpi = database.mock.db.query_one('zmpi')
@@ -287,6 +289,7 @@ class TestSpecSyntax(object):
         assert 'fake' in mpileaks_hash_fake_and_zmpi
         assert mpileaks_hash_fake_and_zmpi['fake'] == fake
 
+    @pytest.mark.slowtest
     def test_multiple_specs_with_hash(self, database):
         mpileaks_zmpi = database.mock.db.query_one('mpileaks ^zmpi')
         callpath_mpich2 = database.mock.db.query_one('callpath ^mpich2')
@@ -319,6 +322,7 @@ class TestSpecSyntax(object):
                          ' / ' + callpath_mpich2.dag_hash())
         assert len(specs) == 2
 
+    @pytest.mark.slowtest
     def test_ambiguous_hash(self, database):
         x1 = Spec('a')
         x1._hash = 'xy'
@@ -335,6 +339,7 @@ class TestSpecSyntax(object):
         # ambiguity in first hash character AND spec name
         self._check_raises(AmbiguousHashError, ['a/x'])
 
+    @pytest.mark.slowtest
     def test_invalid_hash(self, database):
         mpileaks_zmpi = database.mock.db.query_one('mpileaks ^zmpi')
         zmpi = database.mock.db.query_one('zmpi')
@@ -352,6 +357,7 @@ class TestSpecSyntax(object):
             'mpileaks ^mpich /' + mpileaks_zmpi.dag_hash(),
             'mpileaks ^zmpi /' + mpileaks_mpich.dag_hash()])
 
+    @pytest.mark.slowtest
     def test_nonexistent_hash(self, database):
         """Ensure we get errors for nonexistant hashes."""
         specs = database.mock.db.query()
@@ -365,6 +371,7 @@ class TestSpecSyntax(object):
             '/' + no_such_hash,
             'mpileaks /' + no_such_hash])
 
+    @pytest.mark.slowtest
     def test_redundant_spec(self, database):
         """Check that redundant spec constraints raise errors.
 

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -253,7 +253,7 @@ class TestSpecSyntax(object):
             str(spec), spec.name + '@' + str(spec.version) +
             ' /' + spec.dag_hash()[:6])
 
-    @pytest.mark.slowtest
+    @pytest.mark.db
     def test_spec_by_hash(self, database):
         specs = database.mock.db.query()
         assert len(specs)  # make sure something's in the DB
@@ -261,7 +261,7 @@ class TestSpecSyntax(object):
         for spec in specs:
             self._check_hash_parse(spec)
 
-    @pytest.mark.slowtest
+    @pytest.mark.db
     def test_dep_spec_by_hash(self, database):
         mpileaks_zmpi = database.mock.db.query_one('mpileaks ^zmpi')
         zmpi = database.mock.db.query_one('zmpi')
@@ -289,7 +289,7 @@ class TestSpecSyntax(object):
         assert 'fake' in mpileaks_hash_fake_and_zmpi
         assert mpileaks_hash_fake_and_zmpi['fake'] == fake
 
-    @pytest.mark.slowtest
+    @pytest.mark.db
     def test_multiple_specs_with_hash(self, database):
         mpileaks_zmpi = database.mock.db.query_one('mpileaks ^zmpi')
         callpath_mpich2 = database.mock.db.query_one('callpath ^mpich2')
@@ -322,7 +322,7 @@ class TestSpecSyntax(object):
                          ' / ' + callpath_mpich2.dag_hash())
         assert len(specs) == 2
 
-    @pytest.mark.slowtest
+    @pytest.mark.db
     def test_ambiguous_hash(self, database):
         x1 = Spec('a')
         x1._hash = 'xy'
@@ -339,7 +339,7 @@ class TestSpecSyntax(object):
         # ambiguity in first hash character AND spec name
         self._check_raises(AmbiguousHashError, ['a/x'])
 
-    @pytest.mark.slowtest
+    @pytest.mark.db
     def test_invalid_hash(self, database):
         mpileaks_zmpi = database.mock.db.query_one('mpileaks ^zmpi')
         zmpi = database.mock.db.query_one('zmpi')
@@ -357,7 +357,7 @@ class TestSpecSyntax(object):
             'mpileaks ^mpich /' + mpileaks_zmpi.dag_hash(),
             'mpileaks ^zmpi /' + mpileaks_mpich.dag_hash()])
 
-    @pytest.mark.slowtest
+    @pytest.mark.db
     def test_nonexistent_hash(self, database):
         """Ensure we get errors for nonexistant hashes."""
         specs = database.mock.db.query()
@@ -371,7 +371,7 @@ class TestSpecSyntax(object):
             '/' + no_such_hash,
             'mpileaks /' + no_such_hash])
 
-    @pytest.mark.slowtest
+    @pytest.mark.db
     def test_redundant_spec(self, database):
         """Check that redundant spec constraints raise errors.
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,7 @@
 addopts = --durations=20 -ra
 testpaths = lib/spack/spack/test
 python_files = *.py
+markers =
+  db: tests that require creating a DB
+  network: tests that require access to the network
+  maybeslow: tests that may be slow (e.g. access a lot the filesystem, etc.)


### PR DESCRIPTION
This PR marks the slowest unit tests in our suite, so if you run:
```console
$ spack test -m "not slowtest"
```
you'll deselect them. On my laptop this runs in ~70 sec. instead of ~230 sec. for the full suite. Can be quite useful to integrate testing in development workflow (for instance having the IDE running  `spack test -m "not slowtest"` for you in the background).

@nazavode 