### PR TITLE
--with-included-whatever didn't mean what someone thought

### DIFF
--- a/var/spack/repos/builtin/packages/emacs/package.py
+++ b/var/spack/repos/builtin/packages/emacs/package.py
@@ -59,7 +59,7 @@ class Emacs(AutotoolsPackage):
     depends_on('libxaw', when='+X toolkit=athena')
     depends_on('gtkplus+X', when='+X toolkit=gtk')
     depends_on('gnutls', when='+tls')
-    depends_on('libxpm ^gettext+libunistring', when='+tls')
+    depends_on('libxpm ^gettext+libunistring+libxml2', when='+tls')
     depends_on('ncurses+termlib', when='+tls')
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/emacs/package.py
+++ b/var/spack/repos/builtin/packages/emacs/package.py
@@ -59,7 +59,7 @@ class Emacs(AutotoolsPackage):
     depends_on('libxaw', when='+X toolkit=athena')
     depends_on('gtkplus+X', when='+X toolkit=gtk')
     depends_on('gnutls', when='+tls')
-    depends_on('libxpm ^gettext+libunistring+libxml2', when='+tls')
+    depends_on('libxpm ^gettext+libunistring', when='+tls')
     depends_on('ncurses+termlib', when='+tls')
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -86,7 +86,6 @@ class Gettext(AutotoolsPackage):
         if '+libxml2' in spec:
             config_args.append('--with-libxml2-prefix={0}'.format(
                 spec['libxml2'].prefix))
-        else:
             config_args.append('--with-included-libxml')
 
         if '+bzip2' not in spec:
@@ -98,7 +97,6 @@ class Gettext(AutotoolsPackage):
         if '+libunistring' in spec:
             config_args.append('--with-libunistring-prefix={0}'.format(
                 spec['libunistring'].prefix))
-        else:
             config_args.append('--with-included-libunistring')
 
         return config_args


### PR DESCRIPTION
on crays linux the system libxml2 is not build with functions gettext expects.  Not including the --with-included-libxml2 configure arg results in picking up system libxml2 instead of the behavior one would expect.  Its clear from reading configure --help that you need both the --with-blah-prefix and --with-blah-included.