### PR TITLE
Replace previous bash command to new one

### DIFF
--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -111,24 +111,13 @@ class Cray(Platform):
         A bash subshell is launched with a wiped environment and the list of
         loaded modules is parsed for the first acceptable CrayPE target.
         '''
-        # Based on the incantation:
-        # echo "$(env - USER=$USER /bin/bash -l -c 'module list -lt')"
+        # env -i /bin/bash -lc echo $CRAY_CPU_TARGET 2> /dev/null
         if getattr(self, 'default', None) is None:
             env = which('env')
-            env.add_default_arg('-')
-            # CAUTION - $USER is generally needed in the sub-environment.
-            # There may be other variables needed for general success.
-            output = env('USER=%s' % os.environ['USER'],
-                         'HOME=%s' % os.environ['HOME'],
-                         '/bin/bash', '--noprofile', '--norc', '-c',
-                         '. /etc/profile; module list -lt',
-                         output=str, error=str)
-            self._defmods = _get_modules_in_modulecmd_output(output)
-            targets = []
-            _fill_craype_targets_from_modules(targets, self._defmods)
-            self.default = targets[0] if targets else None
-            tty.debug("Found default modules:",
-                      *["     %s" % mod for mod in self._defmods])
+            output = env("-i", "/bin/bash", "-lc", "echo $CRAY_CPU_TARGET",
+                         output=str, error=os.devnull)
+            self.default = output.strip()
+            tty.debug("Found default module:%s" % self.default)
         return self.default
 
     def _avail_targets(self):


### PR DESCRIPTION
Prevents infinite recursion caused by sourcing setup-env.sh in bashrc on Cray machines. Works fine on my system. Let me know if it works well on yours.