### PR TITLE
llvm+lldb plaform=darwin: check for lldb_codesign certificate

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -397,8 +397,6 @@ class Llvm(CMakePackage):
                            '.txt for details on how to create this identity.')
             raise RuntimeError(explanation)
 
-        return
-
     def setup_environment(self, spack_env, run_env):
         spack_env.append_flags('CXXFLAGS', self.compiler.cxx11_flag)
 

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -377,6 +377,28 @@ class Llvm(CMakePackage):
     # Github issue #4986
     patch('llvm_gcc7.patch', when='@4.0.0:4.0.1+lldb %gcc@7.0:')
 
+    @when('+lldb platform=darwin')
+    @run_before('cmake')
+    def check_darwin_lldb_codesign_requirement(self):
+        codesign = which('codesign')
+        cp = which('cp')
+        mkdir('tmp')
+        llvm_check_file = join_path('tmp', 'llvm_check')
+        cp('/usr/bin/false', llvm_check_file)
+
+        try:
+            codesign('-f', '-s', 'lldb_codesign', '--dryrun',
+                     llvm_check_file)
+
+        except ProcessError:
+            explanation = ('The "lldb_codesign" identity must be available'
+                           ' to build LLVM with LLDB. See https://llvm.org/'
+                           'svn/llvm-project/lldb/trunk/docs/code-signing'
+                           '.txt for details on how to create this identity.')
+            raise RuntimeError(explanation)
+
+        return
+
     def setup_environment(self, spack_env, run_env):
         spack_env.append_flags('CXXFLAGS', self.compiler.cxx11_flag)
 


### PR DESCRIPTION
Building LLVM with LLDB requires that the "lldb_codesign" code
certificate be created (see
https://llvm.org/svn/llvm-project/lldb/trunk/docs/code-signing.txt for
details). This commit checks for this certificate on Darwin if LLDB is
to be built, and returns an informative error message if this
certificate is unavailable.

Should address #4985.