### PR TITLE
Fix gfortran 7 detection

### DIFF
--- a/lib/spack/spack/compilers/clang.py
+++ b/lib/spack/spack/compilers/clang.py
@@ -126,14 +126,14 @@ class Clang(Compiler):
 
     @classmethod
     def default_version(cls, comp):
-        """The '--version' option works for clang compilers.
+        """The ``--version`` option works for clang compilers.
         On most platforms, output looks like this::
 
             clang version 3.1 (trunk 149096)
             Target: x86_64-unknown-linux-gnu
             Thread model: posix
 
-        On Mac OS X, it looks like this::
+        On macOS, it looks like this::
 
             Apple LLVM version 7.0.2 (clang-700.1.81)
             Target: x86_64-apple-darwin15.2.0

--- a/lib/spack/spack/compilers/gcc.py
+++ b/lib/spack/spack/compilers/gcc.py
@@ -91,6 +91,21 @@ class Gcc(Compiler):
 
     @classmethod
     def default_version(cls, cc):
+        """Older versions of gcc use the ``-dumpversion`` option.
+        Output looks like this::
+
+            4.4.7
+
+        In GCC 7, this option was changed to only return the major
+        version of the compiler::
+
+            7
+
+        A new ``-dumpfullversion`` option was added that gives us
+        what we want::
+
+            7.2.0
+        """
         # Skip any gcc versions that are actually clang, like Apple's gcc.
         # Returning "unknown" makes them not detected by default.
         # Users can add these manually to compilers.yaml at their own risk.
@@ -104,10 +119,32 @@ class Gcc(Compiler):
 
     @classmethod
     def fc_version(cls, fc):
-        return get_compiler_version(
+        """Older versions of gfortran use the ``-dumpversion`` option.
+        Output looks like this::
+
+            GNU Fortran (GCC) 4.4.7 20120313 (Red Hat 4.4.7-18)
+            Copyright (C) 2010 Free Software Foundation, Inc.
+
+        or::
+
+            4.8.5
+
+        In GCC 7, this option was changed to only return the major
+        version of the compiler::
+
+            7
+
+        A new ``-dumpfullversion`` option was added that gives us
+        what we want::
+
+            7.2.0
+        """
+        version = get_compiler_version(
             fc, '-dumpversion',
-            # older gfortran versions don't have simple dumpversion output.
-            r'(?:GNU Fortran \(GCC\))?(\d+\.\d+(?:\.\d+)?)')
+            r'(?:GNU Fortran \(GCC\) )?([\d.]+)')
+        if version in ['7']:
+            version = get_compiler_version(fc, '-dumpfullversion')
+        return version
 
     @classmethod
     def f77_version(cls, f77):

--- a/lib/spack/spack/compilers/intel.py
+++ b/lib/spack/spack/compilers/intel.py
@@ -82,7 +82,7 @@ class Intel(Compiler):
 
     @classmethod
     def default_version(cls, comp):
-        """The '--version' option seems to be the most consistent one
+        """The ``--version`` option seems to be the most consistent one
         for intel compilers.  Output looks like this::
 
             icpc (ICC) 12.1.5 20120612

--- a/lib/spack/spack/compilers/nag.py
+++ b/lib/spack/spack/compilers/nag.py
@@ -73,7 +73,7 @@ class Nag(Compiler):
 
     @classmethod
     def default_version(self, comp):
-        """The '-V' option works for nag compilers.
+        """The ``-V`` option works for nag compilers.
         Output looks like this::
 
             NAG Fortran Compiler Release 6.0(Hibiya) Build 1037


### PR DESCRIPTION
Fixes #7016.

In GCC 7, `-dumpversion` was changed to return the major version, not the full version. Use `-dumpfullversion` to get around this. This change was already made for `gcc` and `g++` in #6111, but not for `gfortran`, resulting in the issue reported in #7016. This PR fixes that.

Tested on:

- [x] macOS 10.13.2 with GCC 7.2.0
- [x] CentOS 6.9 with GCC 4.4.7
- [x] CentOS 7.4 with GCC 4.8.5
- [x] Ubuntu 17.10 with GCC 4.8, 5.4.1, 6.4.0, and 7.2.0

@hfp 