### PR TITLE
netlib-xblas 1.0.248: new package

### DIFF
--- a/var/spack/repos/builtin/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-lapack/package.py
@@ -67,7 +67,7 @@ class NetlibLapack(Package):
 
     depends_on('cmake', type='build')
     depends_on('blas', when='+external-blas')
-    depends_on('netlib-xblas+fortran+plain-blas', when='+xblas')
+    depends_on('netlib-xblas+fortran+plain_blas', when='+xblas')
 
     def patch(self):
         # Fix cblas CMakeLists.txt -- has wrong case for subdirectory name.

--- a/var/spack/repos/builtin/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-lapack/package.py
@@ -55,6 +55,8 @@ class NetlibLapack(Package):
 
     variant('lapacke', default=True,
             description='Activates the build of the LAPACKE C interface')
+    variant('xblas', default=False,
+            description='Builds extended precision routines using XBLAS')
 
     patch('ibm-xl.patch', when='@3:6%xl')
     patch('ibm-xl.patch', when='@3:6%xl_r')
@@ -65,6 +67,7 @@ class NetlibLapack(Package):
 
     depends_on('cmake', type='build')
     depends_on('blas', when='+external-blas')
+    depends_on('netlib-xblas+fortran+build-plain-blas', when='+xblas')
 
     def patch(self):
         # Fix cblas CMakeLists.txt -- has wrong case for subdirectory name.
@@ -154,6 +157,13 @@ class NetlibLapack(Package):
                 '-DUSE_OPTIMIZED_BLAS:BOOL=ON',
                 '-DBLAS_LIBRARIES:PATH=%s' % spec['blas'].libs.joined(';')
             ])
+
+        if spec.satisfies('+xblas'):
+            xblas_include_dir = spec['netlib-xblas'].prefix.include
+            xblas_library = spec['netlib-xblas'].libs.joined(';')
+            cmake_args.extend([
+                '-DXBLAS_INCLUDE_DIR={0}'.format(xblas_include_dir),
+                '-DXBLAS_LIBRARY={0}'.format(xblas_library)])
 
         cmake_args.extend(std_cmake_args)
 

--- a/var/spack/repos/builtin/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-lapack/package.py
@@ -67,7 +67,7 @@ class NetlibLapack(Package):
 
     depends_on('cmake', type='build')
     depends_on('blas', when='+external-blas')
-    depends_on('netlib-xblas+fortran+build-plain-blas', when='+xblas')
+    depends_on('netlib-xblas+fortran+plain-blas', when='+xblas')
 
     def patch(self):
         # Fix cblas CMakeLists.txt -- has wrong case for subdirectory name.

--- a/var/spack/repos/builtin/packages/netlib-xblas/package.py
+++ b/var/spack/repos/builtin/packages/netlib-xblas/package.py
@@ -22,21 +22,6 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install netlib-xblas
-#
-# You can edit this file again by typing:
-#
-#     spack edit netlib-xblas
-#
-# See the Spack documentation for more information on packaging.
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
 from spack import *
 
 
@@ -59,22 +44,29 @@ class NetlibXblas(AutotoolsPackage):
 
     variant('fortran', default=True,
             description='Build Fortran interfaces')
+    variant('build-plain-blas', default=True,
+            description='As part of XBLAS, build plain BLAS routines')
 
     provides('blas')
 
     def configure_args(self):
-       args = []
+        args = []
 
-       if self.spec.satisfies('~fortran'):
-           args += ['--disable-fortran']
+        if self.spec.satisfies('~fortran'):
+            args += ['--disable-fortran']
 
-       return args
+        if self.spec.satisfies('~build-plain-blas'):
+            args += ['--disable-plain-blas']
+
+        return args
 
     def install(self, spec, prefix):
         mkdirp(prefix.lib)
         install('libxblas.a', prefix.lib)
-        # XBLAS should be a drop-in BLAS replacement
-        install('libxblas.a', join_path(prefix.lib, 'libblas.a'))
+
+        if self.spec.satisfies('+build-plain-blas'):
+            # XBLAS should be a drop-in BLAS replacement
+            install('libxblas.a', join_path(prefix.lib, 'libblas.a'))
 
         headers = ['f2c-bridge.h',
                    'blas_dense_proto.h',

--- a/var/spack/repos/builtin/packages/netlib-xblas/package.py
+++ b/var/spack/repos/builtin/packages/netlib-xblas/package.py
@@ -44,10 +44,10 @@ class NetlibXblas(AutotoolsPackage):
 
     variant('fortran', default=True,
             description='Build Fortran interfaces')
-    variant('build-plain-blas', default=True,
+    variant('plain-blas', default=True,
             description='As part of XBLAS, build plain BLAS routines')
 
-    provides('blas', when='+build-plain-blas')
+    provides('blas', when='+plain-blas')
 
     @property
     def libs(self):
@@ -60,7 +60,7 @@ class NetlibXblas(AutotoolsPackage):
         if self.spec.satisfies('~fortran'):
             args += ['--disable-fortran']
 
-        if self.spec.satisfies('~build-plain-blas'):
+        if self.spec.satisfies('~plain-blas'):
             args += ['--disable-plain-blas']
 
         return args
@@ -69,7 +69,7 @@ class NetlibXblas(AutotoolsPackage):
         mkdirp(prefix.lib)
         install('libxblas.a', prefix.lib)
 
-        if self.spec.satisfies('+build-plain-blas'):
+        if self.spec.satisfies('+plain-blas'):
             # XBLAS should be a drop-in BLAS replacement
             install('libxblas.a', join_path(prefix.lib, 'libblas.a'))
 

--- a/var/spack/repos/builtin/packages/netlib-xblas/package.py
+++ b/var/spack/repos/builtin/packages/netlib-xblas/package.py
@@ -57,7 +57,18 @@ class NetlibXblas(AutotoolsPackage):
 
     version('1.0.248', '990c680fb5e446bb86c10936e4cd7f88')
 
+    variant('fortran', default=True,
+            description='Build Fortran interfaces')
+
     provides('blas')
+
+    def configure_args(self):
+       args = []
+
+       if self.spec.satisfies('~fortran'):
+           args += ['--disable-fortran']
+
+       return args
 
     def install(self, spec, prefix):
         mkdirp(prefix.lib)

--- a/var/spack/repos/builtin/packages/netlib-xblas/package.py
+++ b/var/spack/repos/builtin/packages/netlib-xblas/package.py
@@ -44,10 +44,10 @@ class NetlibXblas(AutotoolsPackage):
 
     variant('fortran', default=True,
             description='Build Fortran interfaces')
-    variant('plain-blas', default=True,
+    variant('plain_blas', default=True,
             description='As part of XBLAS, build plain BLAS routines')
 
-    provides('blas', when='+plain-blas')
+    provides('blas', when='+plain_blas')
 
     @property
     def libs(self):
@@ -60,7 +60,7 @@ class NetlibXblas(AutotoolsPackage):
         if self.spec.satisfies('~fortran'):
             args += ['--disable-fortran']
 
-        if self.spec.satisfies('~plain-blas'):
+        if self.spec.satisfies('~plain_blas'):
             args += ['--disable-plain-blas']
 
         return args
@@ -69,7 +69,7 @@ class NetlibXblas(AutotoolsPackage):
         mkdirp(prefix.lib)
         install('libxblas.a', prefix.lib)
 
-        if self.spec.satisfies('+plain-blas'):
+        if self.spec.satisfies('+plain_blas'):
             # XBLAS should be a drop-in BLAS replacement
             install('libxblas.a', join_path(prefix.lib, 'libblas.a'))
 

--- a/var/spack/repos/builtin/packages/netlib-xblas/package.py
+++ b/var/spack/repos/builtin/packages/netlib-xblas/package.py
@@ -26,7 +26,9 @@ from spack import *
 
 
 class NetlibXblas(AutotoolsPackage):
-    """XBLAS is a reference implementation for the dense and banded BLAS
+    """XBLAS is a reference implementation for extra precision BLAS.
+
+       XBLAS is a reference implementation for the dense and banded BLAS
        routines, along with extended and mixed precision version. Extended
        precision is only used internally; input and output arguments remain
        the same as in the existing BLAS. Extra precisions is implemented as

--- a/var/spack/repos/builtin/packages/netlib-xblas/package.py
+++ b/var/spack/repos/builtin/packages/netlib-xblas/package.py
@@ -47,7 +47,7 @@ class NetlibXblas(AutotoolsPackage):
     variant('build-plain-blas', default=True,
             description='As part of XBLAS, build plain BLAS routines')
 
-    provides('blas')
+    provides('blas', when='+build-plain-blas')
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/netlib-xblas/package.py
+++ b/var/spack/repos/builtin/packages/netlib-xblas/package.py
@@ -49,6 +49,11 @@ class NetlibXblas(AutotoolsPackage):
 
     provides('blas')
 
+    @property
+    def libs(self):
+        return find_libraries(['libxblas'], root=self.prefix,
+                              shared=False, recurse=True)
+
     def configure_args(self):
         args = []
 

--- a/var/spack/repos/builtin/packages/netlib-xblas/package.py
+++ b/var/spack/repos/builtin/packages/netlib-xblas/package.py
@@ -1,0 +1,80 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install netlib-xblas
+#
+# You can edit this file again by typing:
+#
+#     spack edit netlib-xblas
+#
+# See the Spack documentation for more information on packaging.
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+from spack import *
+
+
+class NetlibXblas(AutotoolsPackage):
+    """XBLAS is a reference implementation for the dense and banded BLAS
+       routines, along with extended and mixed precision version. Extended
+       precision is only used internally; input and output arguments remain
+       the same as in the existing BLAS. Extra precisions is implemented as
+       double-double (i.e., 128-bit total, 106-bit significand). Mixed
+       precision permits some input/output arguments of different types
+       (mixing real and complex) or precisions (mixing single and
+       double). This implementation is proof of concept, and no attempt was
+       made to optimize performance; performance should be as good as
+       straightforward but careful code written by hand."""
+
+    homepage = "http://www.netlib.org/xblas"
+    url      = "http://www.netlib.org/xblas/xblas.tar.gz"
+
+    version('1.0.248', '990c680fb5e446bb86c10936e4cd7f88')
+
+    provides('blas')
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.lib)
+        install('libxblas.a', prefix.lib)
+        # XBLAS should be a drop-in BLAS replacement
+        install('libxblas.a', join_path(prefix.lib, 'libblas.a'))
+
+        headers = ['f2c-bridge.h',
+                   'blas_dense_proto.h',
+                   'blas_enum.h',
+                   'blas_extended.h',
+                   'blas_extended_private.h',
+                   'blas_extended_proto.h',
+                   'blas_fpu.h',
+                   'blas_malloc.h']
+        mkdirp(prefix.include)
+        for h in headers:
+            install(join_path('src', h), prefix.include)
+
+        return


### PR DESCRIPTION
* add new package: netlib-xblas
* add variants to disable building Fortran interfaces, disable building plain BLAS routines as part of XBLAS
* add XBLAS option to netlib-lapack