### PR TITLE
travis: removed /usr/local/include/c++ before installing gcc on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -130,6 +130,7 @@ cache: pip
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew ls --versions python > /dev/null || brew install python; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rm /usr/local/include/c++ ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew ls --versions gcc    > /dev/null || brew install gcc;    fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew ls --versions gnupg2 > /dev/null || brew install gnupg2; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then virtualenv venv; fi


### PR DESCRIPTION
This is a backport of #6515. I think we need it to set up MacOS correctly for the cron job on `master`, but it does not affect in any way the release from a user's perspective.

Failed build [here](https://travis-ci.org/spack/spack/builds/331480288)