### PR TITLE
pandaseq: change dependency libtool to the default type (build, link).

### DIFF
--- a/var/spack/repos/builtin/packages/pandaseq/package.py
+++ b/var/spack/repos/builtin/packages/pandaseq/package.py
@@ -38,7 +38,7 @@ class Pandaseq(AutotoolsPackage):
 
     depends_on('autoconf',    type='build')
     depends_on('automake',    type='build')
-    depends_on('libtool',     type='build')
+    depends_on('libtool')
     depends_on('m4',          type='build')
     depends_on('zlib',        type='build')
     depends_on('pkg-config',  type='build')

--- a/var/spack/repos/builtin/packages/pandaseq/package.py
+++ b/var/spack/repos/builtin/packages/pandaseq/package.py
@@ -42,6 +42,7 @@ class Pandaseq(AutotoolsPackage):
     depends_on('m4',          type='build')
     depends_on('zlib',        type='build')
     depends_on('pkg-config',  type='build')
+    depends_on('bzip2')
 
     def autoreconf(self, spec, prefix):
         bash = which('bash')


### PR DESCRIPTION
Installation is not successful with only 'build'. 