### PR TITLE
updates to conduit and ascent packages

### DIFF
--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -99,7 +99,7 @@ class Ascent(Package):
     extends("python", when="+python")
     # TODO: blas and lapack are disabled due to build
     # issues Cyrus experienced on OSX 10.11.6
-    depends_on("py-numpy~blas~lapack", when="+python", type=('build', 'run'))
+    depends_on("py-numpy", when="+python", type=('build', 'run'))
 
     #######################
     # MPI
@@ -298,8 +298,14 @@ class Ascent(Package):
                                         spec['mpi'].mpifc))
             mpiexe_bin = join_path(spec['mpi'].prefix.bin, 'mpiexec')
             if os.path.isfile(mpiexe_bin):
-                cfg.write(cmake_cache_entry("MPIEXEC",
-                                            mpiexe_bin))
+                # starting with cmake 3.10, FindMPI expects MPIEXEC_EXECUTABLE
+                # vs the older versions which expect MPIEXEC
+                if self.spec["cmake"].satisfies('@3.10:'):
+                    cfg.write(cmake_cache_entry("MPIEXEC_EXECUTABLE",
+                                                mpiexe_bin))
+                else:
+                    cfg.write(cmake_cache_entry("MPIEXEC",
+                                                mpiexe_bin))
         else:
             cfg.write(cmake_cache_entry("ENABLE_MPI", "OFF"))
 

--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -97,8 +97,6 @@ class Ascent(Package):
     # causes duplicate state issues when running compiled python modules.
     depends_on("python+shared")
     extends("python", when="+python")
-    # TODO: blas and lapack are disabled due to build
-    # issues Cyrus experienced on OSX 10.11.6
     depends_on("py-numpy", when="+python", type=('build', 'run'))
 
     #######################

--- a/var/spack/repos/builtin/packages/conduit/package.py
+++ b/var/spack/repos/builtin/packages/conduit/package.py
@@ -97,8 +97,6 @@ class Conduit(Package):
     # causes duplicate state issues when running compiled python modules.
     depends_on("python+shared")
     extends("python", when="+python")
-    # TODO: blas and lapack are disabled due to build
-    # issues Cyrus experienced on OSX 10.11.6
     depends_on("py-numpy", when="+python", type=('build', 'run'))
 
     #######################

--- a/var/spack/repos/builtin/packages/conduit/package.py
+++ b/var/spack/repos/builtin/packages/conduit/package.py
@@ -99,7 +99,7 @@ class Conduit(Package):
     extends("python", when="+python")
     # TODO: blas and lapack are disabled due to build
     # issues Cyrus experienced on OSX 10.11.6
-    depends_on("py-numpy~blas~lapack", when="+python", type=('build', 'run'))
+    depends_on("py-numpy", when="+python", type=('build', 'run'))
 
     #######################
     # I/O Packages
@@ -311,8 +311,14 @@ class Conduit(Package):
                                         spec['mpi'].mpifc))
             mpiexe_bin = join_path(spec['mpi'].prefix.bin, 'mpiexec')
             if os.path.isfile(mpiexe_bin):
-                cfg.write(cmake_cache_entry("MPIEXEC",
-                                            mpiexe_bin))
+                # starting with cmake 3.10, FindMPI expects MPIEXEC_EXECUTABLE
+                # vs the older versions which expect MPIEXEC
+                if self.spec["cmake"].satisfies('@3.10:'):
+                    cfg.write(cmake_cache_entry("MPIEXEC_EXECUTABLE",
+                                                mpiexe_bin))
+                else:
+                    cfg.write(cmake_cache_entry("MPIEXEC",
+                                                mpiexe_bin))
         else:
             cfg.write(cmake_cache_entry("ENABLE_MPI", "OFF"))
 


### PR DESCRIPTION
* remove variants disabling blas and lapack for py-numpy, issues building these have been resolved
* for CMake greater than 3.10, FindMPI changed, so use MPIEXE_EXECUTABLE instead of MPIEXE for 3.10 and newer