### PR TITLE
Fix readline variant handling in slurm

### DIFF
--- a/var/spack/repos/builtin/packages/slurm/package.py
+++ b/var/spack/repos/builtin/packages/slurm/package.py
@@ -65,7 +65,7 @@ class Slurm(AutotoolsPackage):
     depends_on('munge')
     depends_on('openssl')
     depends_on('pkgconfig', type='build')
-    depends_on('readline')
+    depends_on('readline', when='+readline')
     depends_on('zlib')
 
     depends_on('gtkplus+X', when='+gtk')
@@ -89,9 +89,7 @@ class Slurm(AutotoolsPackage):
         if '~gtk' in spec:
             args.append('--disable-gtktest')
 
-        if '+readline' in spec:
-            args.append('--with-readline={0}'.format(spec['readline'].prefix))
-        else:
+        if '~readline' in spec:
             args.append('--without-readline')
 
         if '+hdf5' in spec:


### PR DESCRIPTION
The `configure` in `slurm` assumes `readline` support by default and omits the corresponding `--with-readline` option, only the opposite `--without-readline` is recognized, any attempt to specify `--with-readline` is treated as `without`:

```console
$ spack stage slurm
$ spack cd slurm
$ ./configure --with-readline=/usr/lib
[...]
checking for whether to include readline suport... doh!
configure: error: bad value "/usr/lib" for --without-readline
```