### PR TITLE
LLVM + LLDB requires py-six

### DIFF
--- a/var/spack/repos/builtin/packages/argp-standalone/argp-fmtstream.h.patch
+++ b/var/spack/repos/builtin/packages/argp-standalone/argp-fmtstream.h.patch
@@ -1,0 +1,11 @@
+--- argp-fmtstream.h.orig	2003-12-11 09:37:05.000000000 +0100
++++ argp-fmtstream.h	2011-08-12 11:56:43.000000000 +0200
+@@ -192,7 +192,7 @@
+ extern int _argp_fmtstream_ensure (argp_fmtstream_t __fs, size_t __amount);
+ extern int __argp_fmtstream_ensure (argp_fmtstream_t __fs, size_t __amount);
+ 
+-#ifdef __OPTIMIZE__
++#if defined(__OPTIMIZE__) && !defined(__clang__)
+ /* Inline versions of above routines.  */
+
+ #if !_LIBC

--- a/var/spack/repos/builtin/packages/argp-standalone/package.py
+++ b/var/spack/repos/builtin/packages/argp-standalone/package.py
@@ -1,0 +1,50 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
+from spack import *
+
+
+class ArgpStandalone(AutotoolsPackage):
+    """Standalone version of the argp interface from glibc for parsing
+       unix-style arguments. """
+
+    homepage = "https://www.lysator.liu.se/~nisse/misc"
+    url      = "https://www.lysator.liu.se/~nisse/misc/argp-standalone-1.3.tar.gz"
+
+    version('1.3', '720704bac078d067111b32444e24ba69')
+
+    # Homebrew (https://github.com/Homebrew/homebrew-core) patches
+    # argp-standalone to work on Darwin; the patchfile below was taken
+    # from
+    # https://raw.githubusercontent.com/Homebrew/formula-patches/b5f0ad3/argp-standalone/patch-argp-fmtstream.h
+    patch('argp-fmtstream.h.patch', 0, 'platform=darwin', '.')
+
+    def install(self, spec, prefix):
+        make('install')
+        make('check')
+        mkdirp(self.spec.prefix.lib)
+        install('libargp.a', join_path(self.spec.prefix.lib, 'libargp.a'))
+        mkdirp(self.spec.prefix.include)
+        install('argp.h', join_path(self.spec.prefix.include, 'argp.h'))

--- a/var/spack/repos/builtin/packages/dia/package.py
+++ b/var/spack/repos/builtin/packages/dia/package.py
@@ -33,7 +33,7 @@ class Dia(Package):
     version('0.97.3',    '0e744a0f6a6c4cb6a089e4d955392c3c')
 
     depends_on('intltool', type='build')
-    depends_on('gtkplus@2.6.0:+X')
+    depends_on('gtkplus@2.6.0:')
     depends_on('libxslt')
     depends_on('python')
     depends_on('swig')

--- a/var/spack/repos/builtin/packages/elemental/package.py
+++ b/var/spack/repos/builtin/packages/elemental/package.py
@@ -34,6 +34,8 @@ class Elemental(CMakePackage):
     homepage = "http://libelemental.org"
     url      = "https://github.com/elemental/Elemental/archive/v0.87.6.tar.gz"
 
+    version('hydrogen-develop', git='https://github.com/LLNL/Elemental.git', branch='hydrogen')
+
     version('develop', git='https://github.com/elemental/Elemental.git', branch='master')
     version('0.87.7', '6c1e7442021c59a36049e37ea69b8075')
     version('0.87.6', '9fd29783d45b0a0e27c0df85f548abe9')
@@ -105,6 +107,7 @@ class Elemental(CMakePackage):
             'libEl', root=self.prefix, shared=shared, recurse=True
         )
 
+    @when('@0.87.6:')
     def cmake_args(self):
         spec = self.spec
 
@@ -168,5 +171,39 @@ class Elemental(CMakePackage):
         if '+python' in spec:
             args.extend([
                 '-DPYTHON_SITE_PACKAGES:STRING={0}'.format(site_packages_dir)])
+
+        return args
+
+    @when('@:0.87.6')
+    def cmake_args(self):
+        spec = self.spec
+
+        if '@:0.87.7' in spec and '%intel@:17.0.2' in spec:
+            raise UnsupportedCompilerError(
+                "Elemental {0} has a known bug with compiler: {1} {2}".format(
+                    spec.version, spec.compiler.name, spec.compiler.version))
+
+        args = [
+            '-DCMAKE_INSTALL_MESSAGE:STRING=LAZY',
+            '-DCMAKE_C_COMPILER=%s' % spec['mpi'].mpicc,
+            '-DCMAKE_CXX_COMPILER=%s' % spec['mpi'].mpicxx,
+            '-DCMAKE_Fortran_COMPILER=%s' % spec['mpi'].mpifc,
+            '-DBUILD_SHARED_LIBS:BOOL=%s'      % ('+shared' in spec),
+            '-DHydrogen_ENABLE_OPENMP:BOOL=%s'       % ('+hybrid' in spec),
+            '-DHydrogen_ENABLE_QUADMATH:BOOL=%s'     % ('+quad' in spec),
+            '-DHydrogen_USE_64BIT_INTS:BOOL=%s'      % ('+int64' in spec),
+            '-DHydrogen_USE_64BIT_BLAS_INTS:BOOL=%s' % ('+int64_blas' in spec),
+            '-DHydrogen_ENABLE_MPC:BOOL=%s'        % ('+mpfr' in spec),
+            '-DHydrogen_GENERAL_LAPACK_FALLBACK=ON',
+        ]
+
+        if 'blas=openblas' in spec:
+            args.extend([
+                '-DHydrogen_USE_OpenBLAS:BOOL=%s' % ('blas=openblas' in spec),
+                '-DOpenBLAS_DIR:STRING={0}'.format(
+                    spec['elemental'].prefix)])
+        elif 'blas=mkl' in spec:
+            args.extend([
+                '-DHydrogen_USE_MKL:BOOL=%s' % ('blas=mkl' in spec)])
 
         return args

--- a/var/spack/repos/builtin/packages/emacs/package.py
+++ b/var/spack/repos/builtin/packages/emacs/package.py
@@ -57,7 +57,7 @@ class Emacs(AutotoolsPackage):
     depends_on('giflib', when='+X')
     depends_on('libx11', when='+X')
     depends_on('libxaw', when='+X toolkit=athena')
-    depends_on('gtkplus+X', when='+X toolkit=gtk')
+    depends_on('gtkplus', when='+X toolkit=gtk')
     depends_on('gnutls', when='+tls')
     depends_on('libxpm ^gettext+libunistring', when='+tls')
     depends_on('ncurses+termlib', when='+tls')

--- a/var/spack/repos/builtin/packages/gtkplus/package.py
+++ b/var/spack/repos/builtin/packages/gtkplus/package.py
@@ -35,18 +35,16 @@ class Gtkplus(AutotoolsPackage):
     version('2.24.31', '68c1922732c7efc08df4656a5366dcc3afdc8791513400dac276009b40954658')
     version('2.24.25', '38af1020cb8ff3d10dda2c8807f11e92af9d2fa4045de61c62eedb7fbc7ea5b3')
 
-    variant('X', default=False, description="Enable an X toolkit")
-
     depends_on('pkgconfig', type='build')
 
-    depends_on("atk")
-    depends_on("gdk-pixbuf")
-    depends_on("glib")
-    depends_on("pango")
-    depends_on("pango~X", when='~X')
-    depends_on("pango+X", when='+X')
-    depends_on('gobject-introspection', when='+X')
+    depends_on('atk')
+    depends_on('gdk-pixbuf')
+    depends_on('glib')
     depends_on('shared-mime-info')
+    # Hardcode X11 support (former +X variant),
+    # see #6940 for rationale:
+    depends_on('pango+X')
+    depends_on('gobject-introspection')
 
     patch('no-demos.patch')
 

--- a/var/spack/repos/builtin/packages/icedtea/package.py
+++ b/var/spack/repos/builtin/packages/icedtea/package.py
@@ -58,7 +58,7 @@ class Icedtea(AutotoolsPackage):
     depends_on('libxcomposite', when='~X', type='build')
     depends_on('libxau', when='~X', type='build')
     depends_on('libxdmcp', when='~X', type='build')
-    depends_on('gtkplus+X', when='~X', type='build')
+    depends_on('gtkplus', when='~X', type='build')
 
     depends_on('libx11', when='+X')
     depends_on('xproto', when='+X')
@@ -71,7 +71,7 @@ class Icedtea(AutotoolsPackage):
     depends_on('libxcomposite', when='+X')
     depends_on('libxau', when='+X')
     depends_on('libxdmcp', when='+X')
-    depends_on('gtkplus+X', when='+X')
+    depends_on('gtkplus', when='+X')
 
     depends_on('freetype@2:')
     depends_on('wget', type='build')

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -62,16 +62,27 @@ class Lbann(CMakePackage):
     depends_on('cnpy')
     depends_on('nccl', when='+gpu +nccl')
 
-    @when('@0.94:')
-    def cmake_args(self):
+    @property
+    def common_config_args(self):
         spec = self.spec
         # Environment variables
         CPPFLAGS = []
-        CPPFLAGS.append('-DLBANN_SET_EL_RNG')
+        CPPFLAGS.append('-DLBANN_SET_EL_RNG -ldl')
 
-        args = [
+        return [
             '-DCMAKE_INSTALL_MESSAGE=LAZY',
             '-DCMAKE_CXX_FLAGS=%s' % ' '.join(CPPFLAGS),
+            '-DLBANN_VERSION=spack',
+            '-DCNPY_DIR={0}'.format(spec['cnpy'].prefix),
+        ]
+
+    # Get any recent versions or non-numeric version
+    # Note that develop > numeric and non-develop < numeric
+    @when('@:0.91' or '@0.94:')
+    def cmake_args(self):
+        spec = self.spec
+        args = self.common_config_args
+        args.extend([
             '-DLBANN_WITH_TOPO_AWARE:BOOL=%s' % ('+gpu +nccl' in spec),
             '-DLBANN_SEQUENTIAL_INITIALIZATION:BOOL=%s' %
             ('+seq_init' in spec),
@@ -79,10 +90,8 @@ class Lbann(CMakePackage):
             '-DLBANN_WITH_VTUNE=OFF',
             '-DElemental_DIR={0}/CMake/elemental'.format(
                 spec['elemental'].prefix),
-            '-DCNPY_DIR={0}'.format(spec['cnpy'].prefix),
             '-DLBANN_DATATYPE={0}'.format(spec.variants['dtype'].value),
-            '-DLBANN_VERBOSE=0',
-            '-DLBANN_VERSION=spack']
+            '-DLBANN_VERBOSE=0'])
 
         if '+opencv' in spec:
             args.extend(['-DOpenCV_DIR:STRING={0}'.format(
@@ -108,16 +117,11 @@ class Lbann(CMakePackage):
 
         return args
 
-    @when('@:0.93')
+    @when('@0.91:0.93')
     def cmake_args(self):
         spec = self.spec
-        # Environment variables
-        CPPFLAGS = []
-        CPPFLAGS.append('-DLBANN_SET_EL_RNG')
-
-        args = [
-            '-DCMAKE_INSTALL_MESSAGE=LAZY',
-            '-DCMAKE_CXX_FLAGS=%s' % ' '.join(CPPFLAGS),
+        args = self.common_config_args
+        args.extend([
             '-DWITH_CUDA:BOOL=%s' % ('+gpu' in spec),
             '-DWITH_CUDNN:BOOL=%s' % ('+gpu' in spec),
             '-DELEMENTAL_USE_CUBLAS:BOOL=%s' % (
@@ -125,13 +129,11 @@ class Lbann(CMakePackage):
             '-DWITH_TBINF=OFF',
             '-DWITH_VTUNE=OFF',
             '-DElemental_DIR={0}'.format(spec['elemental'].prefix),
-            '-DCNPY_DIR={0}'.format(spec['cnpy'].prefix),
             '-DELEMENTAL_MATH_LIBS={0}'.format(
                 spec['elemental'].libs),
             '-DSEQ_INIT:BOOL=%s' % ('+seq_init' in spec),
             '-DVERBOSE=0',
-            '-DLBANN_HOME=.',
-            '-DLBANN_VER=spack']
+            '-DLBANN_HOME=.'])
 
         if spec.variants['dtype'].value == 'float':
             args.extend(['-DDATATYPE=4'])

--- a/var/spack/repos/builtin/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-lapack/package.py
@@ -55,6 +55,8 @@ class NetlibLapack(Package):
 
     variant('lapacke', default=True,
             description='Activates the build of the LAPACKE C interface')
+    variant('xblas', default=False,
+            description='Builds extended precision routines using XBLAS')
 
     patch('ibm-xl.patch', when='@3:6%xl')
     patch('ibm-xl.patch', when='@3:6%xl_r')
@@ -65,6 +67,7 @@ class NetlibLapack(Package):
 
     depends_on('cmake', type='build')
     depends_on('blas', when='+external-blas')
+    depends_on('netlib-xblas+fortran+plain_blas', when='+xblas')
 
     def patch(self):
         # Fix cblas CMakeLists.txt -- has wrong case for subdirectory name.
@@ -154,6 +157,13 @@ class NetlibLapack(Package):
                 '-DUSE_OPTIMIZED_BLAS:BOOL=ON',
                 '-DBLAS_LIBRARIES:PATH=%s' % spec['blas'].libs.joined(';')
             ])
+
+        if spec.satisfies('+xblas'):
+            xblas_include_dir = spec['netlib-xblas'].prefix.include
+            xblas_library = spec['netlib-xblas'].libs.joined(';')
+            cmake_args.extend([
+                '-DXBLAS_INCLUDE_DIR={0}'.format(xblas_include_dir),
+                '-DXBLAS_LIBRARY={0}'.format(xblas_library)])
 
         cmake_args.extend(std_cmake_args)
 

--- a/var/spack/repos/builtin/packages/netlib-xblas/package.py
+++ b/var/spack/repos/builtin/packages/netlib-xblas/package.py
@@ -1,0 +1,90 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class NetlibXblas(AutotoolsPackage):
+    """XBLAS is a reference implementation for extra precision BLAS.
+
+       XBLAS is a reference implementation for the dense and banded BLAS
+       routines, along with extended and mixed precision version. Extended
+       precision is only used internally; input and output arguments remain
+       the same as in the existing BLAS. Extra precisions is implemented as
+       double-double (i.e., 128-bit total, 106-bit significand). Mixed
+       precision permits some input/output arguments of different types
+       (mixing real and complex) or precisions (mixing single and
+       double). This implementation is proof of concept, and no attempt was
+       made to optimize performance; performance should be as good as
+       straightforward but careful code written by hand."""
+
+    homepage = "http://www.netlib.org/xblas"
+    url      = "http://www.netlib.org/xblas/xblas.tar.gz"
+
+    version('1.0.248', '990c680fb5e446bb86c10936e4cd7f88')
+
+    variant('fortran', default=True,
+            description='Build Fortran interfaces')
+    variant('plain_blas', default=True,
+            description='As part of XBLAS, build plain BLAS routines')
+
+    provides('blas', when='+plain_blas')
+
+    @property
+    def libs(self):
+        return find_libraries(['libxblas'], root=self.prefix,
+                              shared=False, recurse=True)
+
+    def configure_args(self):
+        args = []
+
+        if self.spec.satisfies('~fortran'):
+            args += ['--disable-fortran']
+
+        if self.spec.satisfies('~plain_blas'):
+            args += ['--disable-plain-blas']
+
+        return args
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.lib)
+        install('libxblas.a', prefix.lib)
+
+        if self.spec.satisfies('+plain_blas'):
+            # XBLAS should be a drop-in BLAS replacement
+            install('libxblas.a', join_path(prefix.lib, 'libblas.a'))
+
+        headers = ['f2c-bridge.h',
+                   'blas_dense_proto.h',
+                   'blas_enum.h',
+                   'blas_extended.h',
+                   'blas_extended_private.h',
+                   'blas_extended_proto.h',
+                   'blas_fpu.h',
+                   'blas_malloc.h']
+        mkdirp(prefix.include)
+        for h in headers:
+            install(join_path('src', h), prefix.include)
+
+        return

--- a/var/spack/repos/builtin/packages/py-pygtk/package.py
+++ b/var/spack/repos/builtin/packages/py-pygtk/package.py
@@ -38,7 +38,7 @@ class PyPygtk(AutotoolsPackage):
     depends_on('cairo')
     depends_on('glib')
     # for GTK 3.X use pygobject 3.X instead of pygtk
-    depends_on('gtkplus+X@2.24:2.99')
+    depends_on('gtkplus@2.24:2.99')
     depends_on('py-pygobject@2.28:2.99', type=('build', 'run'))
     depends_on('py-py2cairo', type=('build', 'run'))
 

--- a/var/spack/repos/builtin/packages/slurm/package.py
+++ b/var/spack/repos/builtin/packages/slurm/package.py
@@ -68,7 +68,7 @@ class Slurm(AutotoolsPackage):
     depends_on('readline', when='+readline')
     depends_on('zlib')
 
-    depends_on('gtkplus+X', when='+gtk')
+    depends_on('gtkplus', when='+gtk')
     depends_on('hdf5', when='+hdf5')
     depends_on('hwloc', when='+hwloc')
     depends_on('mariadb', when='+mariadb')

--- a/var/spack/repos/builtin/packages/slurm/package.py
+++ b/var/spack/repos/builtin/packages/slurm/package.py
@@ -65,7 +65,7 @@ class Slurm(AutotoolsPackage):
     depends_on('munge')
     depends_on('openssl')
     depends_on('pkgconfig', type='build')
-    depends_on('readline')
+    depends_on('readline', when='+readline')
     depends_on('zlib')
 
     depends_on('gtkplus+X', when='+gtk')
@@ -89,9 +89,7 @@ class Slurm(AutotoolsPackage):
         if '~gtk' in spec:
             args.append('--disable-gtktest')
 
-        if '+readline' in spec:
-            args.append('--with-readline={0}'.format(spec['readline'].prefix))
-        else:
+        if '~readline' in spec:
             args.append('--without-readline')
 
         if '+hdf5' in spec:

--- a/var/spack/repos/builtin/packages/wx/package.py
+++ b/var/spack/repos/builtin/packages/wx/package.py
@@ -47,7 +47,7 @@ class Wx(AutotoolsPackage):
     patch('math_include.patch', when='@3.0.1:3.0.2')
 
     depends_on('pkgconfig', type='build')
-    depends_on('gtkplus+X')
+    depends_on('gtkplus')
 
     @when('@:3.0.2')
     def build(self, spec, prefix):


### PR DESCRIPTION
LLVM + LLDB requires py-six. we also need to specify that we want to use the Spack-installed py-six, rather than have lldb use its own version.