### PR TITLE
llvm+python +lldbdepnds on py-six

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -87,6 +87,7 @@ class Llvm(CMakePackage):
     depends_on('ncurses', when='+lldb')
     depends_on('swig', when='+lldb')
     depends_on('libedit', when='+lldb')
+    depends_on('py-six', when='@5.0.0: +lldb +python')
 
     # gold support
     depends_on('binutils+gold', when='+gold')
@@ -404,6 +405,8 @@ class Llvm(CMakePackage):
                                '-DLLVM_POLLY_BUILD:Bool=OFF',
                                '-DLLVM_POLLY_LINK_INTO_TOOLS:Bool=OFF'])
 
+        if '+python' in spec and '+lldb' in spec and spec.satisfies('@5.0.0:'):
+            cmake_args.append('-DLLDB_USE_SYSTEM_SIX:Bool=TRUE')
         if '+clang' not in spec:
             cmake_args.append('-DLLVM_EXTERNAL_CLANG_BUILD:Bool=OFF')
         if '+lldb' not in spec:


### PR DESCRIPTION
LLVM + LLDB requires py-six. we also need to specify that we want to use the Spack-installed py-six, rather than have lldb use its own version. (this replaces my backwards merge in #7052).