### PR TITLE
braker: added list_url and list_depth

### DIFF
--- a/var/spack/repos/builtin/packages/braker/package.py
+++ b/var/spack/repos/builtin/packages/braker/package.py
@@ -31,6 +31,8 @@ class Braker(Package):
 
     homepage = "http://exon.gatech.edu/braker1.html"
     url      = "http://bioinf.uni-greifswald.de/augustus/binaries/BRAKER1_v1.11.tar.gz"
+    list_url = "http://bioinf.uni-greifswald.de/augustus/binaries/"
+    list_depth = 2
 
     version('1.11', '297efe4cabdd239b710ac2c45d81f6a5')
 

--- a/var/spack/repos/builtin/packages/braker/package.py
+++ b/var/spack/repos/builtin/packages/braker/package.py
@@ -31,8 +31,7 @@ class Braker(Package):
 
     homepage = "http://exon.gatech.edu/braker1.html"
     url      = "http://bioinf.uni-greifswald.de/augustus/binaries/BRAKER1_v1.11.tar.gz"
-    list_url = "http://bioinf.uni-greifswald.de/augustus/binaries/"
-    list_depth = 2
+    list_url = "http://bioinf.uni-greifswald.de/augustus/binaries/old"
 
     version('1.11', '297efe4cabdd239b710ac2c45d81f6a5')
 


### PR DESCRIPTION
BRAKER1_v1.11.tar.gz is moved to http://bioinf.uni-greifswald.de/augustus/binaries/old. Added list_url and list_depth to fix fetching problem.