### PR TITLE
Help newer versions of trilinos/zoltan2 successfully configure.

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -451,8 +451,9 @@ class Trilinos(CMakePackage):
                 '-DParMETIS_LIBRARY_DIRS=%s;%s' % (
                     spec['parmetis'].prefix.lib, spec['metis'].prefix.lib),
                 '-DParMETIS_LIBRARY_NAMES=parmetis;metis',
-                '-DTPL_ParMETIS_INCLUDE_DIRS=%s' % (
-                    spec['parmetis'].prefix.include)
+                '-DTPL_ParMETIS_INCLUDE_DIRS=%s;%s' % (
+                    spec['parmetis'].prefix.include,
+                    spec['metis'].prefix.include)
             ])
         else:
             options.extend([


### PR DESCRIPTION
+ Newer versions of zoltan2 are doing test compiles that link to parmetis.  If these checks don't find `metis.h`, the check fails.
+ This small tweak ensures that the zoltan2 configure step can find `metis.h` that is provided by spack.