### PR TITLE
libtool: symlink libtool{ize} to glibtool{ize}

### DIFF
--- a/var/spack/repos/builtin/packages/libtool/package.py
+++ b/var/spack/repos/builtin/packages/libtool/package.py
@@ -46,8 +46,24 @@ class Libtool(AutotoolsPackage):
                               join_path(self.prefix.share, 'aclocal'))
 
     def setup_dependent_package(self, module, dependent_spec):
-        # Automake is very likely to be a build dependency,
-        # so we add the tools it provides to the dependent module
-        executables = ['libtoolize', 'libtool']
+        # Automake is very likely to be a build dependency, so we add
+        # the tools it provides to the dependent module. Some build
+        # systems differentiate between BSD libtool (e.g., Darwin) and
+        # GNU libtool, so also add 'glibtool' and 'glibtoolize' to the
+        # list of executables.
+        executables = ['libtoolize', 'libtool', 'glibtoolize', 'glibtool']
         for name in executables:
             setattr(module, name, self._make_executable(name))
+
+    @run_after('install')
+    def post_install(self):
+        # Some platforms name GNU libtool and GNU libtoolize
+        # 'glibtool' and 'glibtoolize', respectively, to differentiate
+        # them from BSD libtool and BSD libtoolize. On these BSD
+        # platforms, build systems sometimes expect to use the assumed
+        # GNU commands glibtool and glibtoolize instead of the BSD
+        # variant; this happens frequently, for instance, on Darwin
+        symlink(join_path(self.prefix.bin, 'libtoolize'),
+                join_path(self.prefix.bin, 'glibtoolize'))
+        symlink(join_path(self.prefix.bin, 'libtoolize'),
+                join_path(self.prefix.bin, 'glibtoolize'))


### PR DESCRIPTION
On Darwin and other BSD systems, the system 'libtool' and 'libtoolize'
are BSD libtool and libtoolize, respectively. Some build systems
require the GNU versions of these commands, so BSD package systems
tend to name the GNU versions 'glibtool' and 'glibtoolize',
respectively, to avoid namespace collisions.

A problem with the current libtool package is that it installs the GNU
libtool commands as 'libtool' and 'libtoolize', respectively, but
build systems on BSD platforms will attempt to run 'glibtool' and
'glibtoolize'. The expedient solution to this problem is to symlink
'libtool' to 'glibtool' and 'libtoolize' to 'glibtoolize', because
attempting to patch the detection logic one build system at a time
seems impractical.

The motivation for this patch came when trying to run `spack install
libharu` on a macOS/OS X Sierra 10.12.6 system (i.e., Darwin 16.7.0),
which fails in the `configure` step because the build system attempts
to run `join_path(spec['libtool'].prefix.bin, 'glibtoolize')`, resulting in an
error because this command doesn't currently exist when spack installs
`libtool`.