### PR TITLE
subversion: fix build on darwin

### DIFF
--- a/var/spack/repos/builtin/packages/subversion/package.py
+++ b/var/spack/repos/builtin/packages/subversion/package.py
@@ -42,6 +42,8 @@ class Subversion(Package):
     depends_on('zlib')
     depends_on('sqlite')
     depends_on('serf')
+    depends_on('autoconf', type=('build'))
+    depends_on('libtool', type=('build'))
 
     extends('perl', when='+perl')
     depends_on('swig@1.3.24:3.0.0', when='+perl')

--- a/var/spack/repos/builtin/packages/subversion/package.py
+++ b/var/spack/repos/builtin/packages/subversion/package.py
@@ -69,6 +69,15 @@ class Subversion(Package):
         options.append('--with-sqlite=%s' % spec['sqlite'].prefix)
         options.append('--with-serf=%s' % spec['serf'].prefix)
 
+        # Add options from Homebrew/Linuxbrew to reduce the number of
+        # system libraries Subversion links to. See
+        # https://github.com/Homebrew/homebrew-core/blob/master/Formula/subversion.rb
+        options.append('--with-apxs=no')
+        options.append('--disable-mod-activation')
+        options.append('--disable-nls')
+        options.append('--without-apache-libexecdir')
+        options.append('--without-berkeley-db')
+
         if 'swig' in spec:
             options.append('--with-swig=%s' % spec['swig'].prefix)
         if 'perl' in spec:


### PR DESCRIPTION
Subversion doesn't currently build on darwin; build output suggests that the configure step detects incorrect system Apache paths. Rather than build subversion with system Apache, this commit reduces the number of system dependencies linked to subversion, and enables Subversion to build on Darwin.