### PR TITLE
libtool, binutils: fix darwin linking

### DIFF
--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -79,4 +79,10 @@ class Binutils(AutotoolsPackage):
         if '+libiberty' in spec:
             configure_args.append('--enable-install-libiberty')
 
+        # To avoid namespace collisions with Darwin/BSD system tools,
+        # prefix executables with "g", e.g., gar, gnm; see Homebrew
+        # https://github.com/Homebrew/homebrew-core/blob/master/Formula/binutils.rb
+        if spec.satisfies('platform=darwin'):
+            configure_args.append('--program-prefix=g')
+
         return configure_args

--- a/var/spack/repos/builtin/packages/libtool/package.py
+++ b/var/spack/repos/builtin/packages/libtool/package.py
@@ -63,7 +63,7 @@ class Libtool(AutotoolsPackage):
         # platforms, build systems sometimes expect to use the assumed
         # GNU commands glibtool and glibtoolize instead of the BSD
         # variant; this happens frequently, for instance, on Darwin
-        symlink(join_path(self.prefix.bin, 'libtoolize'),
-                join_path(self.prefix.bin, 'glibtoolize'))
-        symlink(join_path(self.prefix.bin, 'libtoolize'),
-                join_path(self.prefix.bin, 'glibtoolize'))
+        symlink(join_path(self.spec.prefix.bin, 'libtoolize'),
+                join_path(self.spec.prefix.bin, 'glibtoolize'))
+        symlink(join_path(self.spec.prefix.bin, 'libtoolize'),
+                join_path(self.spec.prefix.bin, 'glibtoolize'))

--- a/var/spack/repos/builtin/packages/libtool/package.py
+++ b/var/spack/repos/builtin/packages/libtool/package.py
@@ -50,20 +50,19 @@ class Libtool(AutotoolsPackage):
         # the tools it provides to the dependent module. Some build
         # systems differentiate between BSD libtool (e.g., Darwin) and
         # GNU libtool, so also add 'glibtool' and 'glibtoolize' to the
-        # list of executables.
+        # list of executables. See Homebrew:
+        # https://github.com/Homebrew/homebrew-core/blob/master/Formula/libtool.rb
         executables = ['libtoolize', 'libtool', 'glibtoolize', 'glibtool']
         for name in executables:
             setattr(module, name, self._make_executable(name))
 
-    @run_after('install')
-    def post_install(self):
+    @when('platform=darwin')
+    def configure_args(self):
         # Some platforms name GNU libtool and GNU libtoolize
         # 'glibtool' and 'glibtoolize', respectively, to differentiate
         # them from BSD libtool and BSD libtoolize. On these BSD
         # platforms, build systems sometimes expect to use the assumed
         # GNU commands glibtool and glibtoolize instead of the BSD
         # variant; this happens frequently, for instance, on Darwin
-        symlink(join_path(self.spec.prefix.bin, 'libtoolize'),
-                join_path(self.spec.prefix.bin, 'glibtoolize'))
-        symlink(join_path(self.spec.prefix.bin, 'libtoolize'),
-                join_path(self.spec.prefix.bin, 'glibtoolize'))
+        args = ['--program-prefix=g']
+        return args


### PR DESCRIPTION
Packages with binutils dependencies (e.g., LLVM) will add binutils to the spack environment path during builds, which causes build systems to preferentially use spack's `ar` and `ld` over the system `ar` and `ld`. This namespace resolution is problematic because it results in warnings from the linker stating that the static libraries built are for the wrong architecture.

The fix is to follow Homebrew's convention of prepending 'g' to the GNU versions of any native BSD system utility. This PR also fixes the error I made in #7060.

It's possible that more packages need this sort of fix (e.g., `tar`, `sed`), but I haven't yet run into issues with those tools yet.