### PR TITLE
bzip2 now uses 'spack_cc' as a compiler

### DIFF
--- a/var/spack/repos/builtin/packages/bzip2/package.py
+++ b/var/spack/repos/builtin/packages/bzip2/package.py
@@ -51,8 +51,10 @@ class Bzip2(Package):
     def patch(self):
         # bzip2 comes with two separate Makefiles for static and dynamic builds
         # Tell both to use Spack's compiler wrapper instead of GCC
-        filter_file(r'^CC=gcc', 'CC=cc', 'Makefile')
-        filter_file(r'^CC=gcc', 'CC=cc', 'Makefile-libbz2_so')
+        filter_file(r'^CC=gcc', 'CC={0}'.format(spack_cc), 'Makefile')
+        filter_file(
+            r'^CC=gcc', 'CC={0}'.format(spack_cc), 'Makefile-libbz2_so'
+        )
 
         # The Makefiles use GCC flags that are incompatible with PGI
         if self.compiler.name == 'pgi':


### PR DESCRIPTION
Looking at build logs, it seems that prior to this commit `bzip2` was using `cc`, and relying on the PATH to be set correctly to find Spack wrappers. This commit improves the robustness of the recipe, by using the absolute path of the wrapper.