### PR TITLE
find: add iterator mode

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -294,7 +294,8 @@ def display_specs(specs, args=None, **kwargs):
         # If they don't have a compiler / architecture attached to them,
         # then skip the header
         if architecture is not None or compiler is not None:
-            tty.hline(colorize(header), char='-')
+            if mode is not "iterator":
+                tty.hline(colorize(header), char='-')
 
         specs = index[(architecture, compiler)]
         specs.sort()
@@ -337,10 +338,14 @@ def display_specs(specs, args=None, **kwargs):
                     hsh = gray_hash(spec, hlen) + ' ' if hashes else ''
                     print(hsh + spec.cformat(format_string) + '\n')
 
+        elif mode == 'iterator':
+                for spec in specs:
+                    hsh = spec.dag_hash(hlen)
+                    print("/" + hsh)
         else:
             raise ValueError(
                 "Invalid mode for display_specs: %s. Must be one of (paths,"
-                "deps, short)." % mode)
+                "deps, short, iterator)." % mode)
 
 
 def spack_is_git_repo():

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -44,6 +44,11 @@ def setup_parser(subparser):
                               const='short',
                               default='short',
                               help='show only specs (default)')
+    format_group.add_argument('-i', '--iterator',
+                              action='store_const',
+                              dest='mode',
+                              const='iterator',
+                              help='show only hashes for matching packages')
     format_group.add_argument('-p', '--paths',
                               action='store_const',
                               dest='mode',
@@ -151,7 +156,7 @@ def find(parser, args):
         query_specs = [x for x in query_specs if x.name in packages_with_tags]
 
     # Display the result
-    if sys.stdout.isatty():
+    if sys.stdout.isatty() and (args.mode != "iterator"):
         tty.msg("%d installed packages." % len(query_specs))
 
     display_specs(query_specs, args)

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -90,6 +90,53 @@ def test_query_arguments():
 
 @pytest.mark.db
 @pytest.mark.usefixtures('database', 'mock_display')
+def test_find_iterator_long(parser, specs, capfd):
+
+    args = parser.parse_args(['-i', '-L', 'mpich', 'mpich2'])
+    spack.cmd.find.find(parser, args)
+
+    # Args Parsed
+    assert args.mode is "iterator"
+    assert args.very_long is True
+
+    # Build hash List
+    hashes = [s.dag_hash() for s in specs]
+
+    # Hash list from output
+    output, _ = capfd.readouterr()
+    output_hashes = [x.replace("/", "") for x in output.split("\n") if x != ""]
+
+    # Make sure hashes were seen in output (partially for -L)
+    for oh in output_hashes:
+        ta = [k.startswith(oh) for k in hashes]
+        assert True in ta
+
+
+@pytest.mark.db
+@pytest.mark.usefixtures('database', 'mock_display')
+def test_find_iterator(parser, specs, capfd):
+
+    args = parser.parse_args(['-i', 'mpich', 'mpich2'])
+    spack.cmd.find.find(parser, args)
+
+    # Args Parsed
+    assert args.mode is "iterator"
+
+    # Build hash List
+    hashes = [s.dag_hash() for s in specs]
+
+    # Hash list from output
+    output, _ = capfd.readouterr()
+    output_hashes = [x.replace("/", "") for x in output.split("\n") if x != ""]
+
+    # Make sure hashes were seen in output (partially for -L)
+    for oh in output_hashes:
+        ta = [k.startswith(oh) for k in hashes]
+        assert True in ta
+
+
+@pytest.mark.db
+@pytest.mark.usefixtures('database', 'mock_display')
 def test_tag1(parser, specs):
 
     args = parser.parse_args(['--tags', 'tag1'])


### PR DESCRIPTION
What
-----

I often iterate over packages version to quickly validate or try different versions of a given package. I've therefore extended the find options to provide me an iterator friendly output.

To do so, this pull requests proposes to add the "-i" option for "--iterator":

```
$ spack find -h
usage: spack find [-h] [-s | -i | -p | -d] [-l] [-L] [-t TAGS] [-f]
                  [--show-full-compiler] [-e | -E] [-u] [-m] [-v] [-M] [-N]
                  ...

list and search installed packages

positional arguments:
  constraint            constraint to select a subset of installed packages

optional arguments:
  -h, --help            show this help message and exit
  -s, --short           show only specs (default)
  -i, --iterator        show only hashes for matching packages
(...)
```

* I'm unsure of the option name (-i ?) 
* Is there is a place where to add corresponding tests.
* Also the "if" to silent out the header and package count are a bit edgy, maybe it would be better combined with a "quiet" mode "-q" (and therefore another option) dedicated to removing them. This extra flag would be enabled for "-i". What do you think? There is also the fact that if you remove the "header" you need to display at least a hash to distinguish between the same version of a given package built with different compilers.

Thanks!

Background
------------

Currently, spack has extra output with regular "find" due to the header:

```
$ for v in `spack find openmpi`; do echo "$v"; done
--
linux-centos7-x86_64
/
gcc@4.8.5
-----------------------------
openmpi@1.5.5
openmpi@1.6
openmpi@1.6.1
(...)
openmpi@2.1.1
openmpi@2.1.2
openmpi@3.0.0
```
With this small addition I can get :

```
$ for v in `spack find -i openmpi`; do echo "$v"; done
/a6tugaf
/z3act6v
/g4bqb3i
(...)
/tnzuyeg
/yb5rzih
/4hctfjb
```

This is how I leverage Spack's power to filter and test over versions:

```
for v in `spack find -i openmpi@2 mpich@3`
do
   spack unload openmpi
   spack unload mpich
   spack find -s $v
   spack load $v
   mpicc t.c
   mpirun -np 2 ./a.out
done
```

Sample output:

```
==> 1 installed packages.
-- linux-centos7-x86_64 / gcc@4.8.5 -----------------------------
mpich@3.0.4
Rank: 0/2
Rank: 1/2
==> 1 installed packages.
-- linux-centos7-x86_64 / gcc@4.8.5 -----------------------------
mpich@3.1
Rank: 0/2
Rank: 1/2
==> 1 installed packages.
-- linux-centos7-x86_64 / gcc@4.8.5 -----------------------------
mpich@3.1.1
Rank: 0/2
Rank: 1/2
(...)
==> 1 installed packages.
-- linux-centos7-x86_64 / gcc@4.8.5 -----------------------------
openmpi@2.1.2
Rank: 0/2
Rank: 1/2
```