### PR TITLE
Implemented 'stack' command

### DIFF
--- a/lib/spack/spack/cmd/stack.py
+++ b/lib/spack/spack/cmd/stack.py
@@ -92,9 +92,15 @@ def add_remote_packages(remote, exclude=[], nostack=False, hardlinks=False):
     """
     config = spack.config.get_config("config")
 
+    # try to be intelligent and support both paths with and without
+    # ./opt/spack-suffix
+    remote_path = canonicalize_path(osp.join(remote, 'opt', 'spack'))
+    if not osp.exists(remote_path):
+        remote_path = canonicalize_path(remote)
+
     # NOTE: This has to be kept in sync with spack/store.py!
     layout = spack.directory_layout.YamlDirectoryLayout(
-        canonicalize_path(osp.join(remote, 'opt', 'spack')),
+        remote_path,
         hash_len=config.get('install_hash_length'),
         path_scheme=config.get('install_path_scheme'))
 
@@ -128,6 +134,7 @@ def add_remote_packages(remote, exclude=[], nostack=False, hardlinks=False):
 
 
 def stack(parser, args):
+    "Returns number of packages stacked."
 
     num_packages = sum((
         add_remote_packages(
@@ -145,3 +152,5 @@ def stack(parser, args):
                   "repository does not differ in hash length or path scheme!")
     else:
         tty.info("Added {0} packages in total.".format(num_packages))
+
+    return num_packages

--- a/lib/spack/spack/cmd/stack.py
+++ b/lib/spack/spack/cmd/stack.py
@@ -120,6 +120,7 @@ def add_remote_packages(remote, exclude=[], nostack=False, hardlinks=False):
             else:
                 tty.info("Not stacking {0} because already present.".format(
                     src))
+                continue
         fs.mkdirp(osp.dirname(tgt))
         tty.debug("Linking {0} -> {1}".format(src, tgt))
         if not hardlinks:

--- a/lib/spack/spack/cmd/stack.py
+++ b/lib/spack/spack/cmd/stack.py
@@ -1,0 +1,120 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+""" Stack spack installations - avoiding double-builds
+
+Stack this spack repository on top of an external read-only spack installation
+that already has several packages pre-built.
+
+The installed packages in the remote spack-installation are symlinked into the
+directory_layout of the current repository. Hardlinks make little to no sense
+since the original files need to remain in place because dependencies are found
+via RPATH (which are the old paths in the remote repository).
+"""
+
+from __future__ import print_function
+
+__author__ = "Oliver Breitwieser (UHEI)"
+
+import glob
+import os
+import os.path as osp
+import spack
+import spack.config
+import spack.directory_layout
+import spack.store
+from spack.filesystem_view import filter_exclude
+from spack.util.path import canonicalize_path
+import llnl.util.tty as tty
+import llnl.util.filesystem as fs
+
+description = "integrate packages of remote spack repositories into this one"
+section = "environment"
+level = "short" # TODO: re-check what 'level' is supposed to mean
+
+def setup_parser(sp):
+    setup_parser.parser = sp
+
+    sp.add_argument(
+        '-v', '--verbose', action='store_true', default=False,
+        help="If not verbose only warnings/errors will be printed.")
+    sp.add_argument(
+        '-e', '--exclude', action='append', default=[],
+        help="exclude packages with names matching the given regex pattern")
+
+    sp.add_argument("remotes", nargs="+",
+                    metavar='remote', action='store',
+                    help="one or more remote spack repositories which "
+                         "contain packages to be added as external packages")
+
+
+def add_remote_packages(remote, exclude=[], verbose=False):
+    """
+        Add all installed packages in `remote` to the packages dictionary.
+    """
+    config = spack.config.get_config("config")
+
+    # NOTE: This has to be kept in sync with spack/store.py!
+    layout = spack.directory_layout.YamlDirectoryLayout(
+        canonicalize_path(osp.join(remote, 'opt', 'spack')),
+        hash_len=config.get('install_hash_length'),
+        path_scheme=config.get('install_path_scheme'))
+
+    num_packages = 0
+
+    for spec in filter_exclude(layout.all_specs(), exclude):
+        src = layout.path_for_spec(spec)
+        tgt = spack.store.layout.path_for_spec(spec)
+        if osp.exists(tgt):
+            if osp.islink(tgt):
+                os.remove(tgt)
+            else:
+                tty.warn("Cannot not stack {} because {} exists.".format(
+                    src, tgt))
+                continue
+        fs.mkdirp(osp.dirname(tgt))
+        if verbose:
+            tty.debug("Linking {} -> {}".format(src, tgt))
+        os.symlink(src, tgt)
+        num_packages += 1
+
+    if verbose:
+        tty.info("Added {} packages from {}".format(num_packages, remote))
+
+    return num_packages
+
+
+def stack(parser, args):
+
+    num_packages = sum((add_remote_packages(
+            remote,
+            exclude=args.exclude, verbose=args.verbose)
+        for remote in args.remotes))
+
+    spack.store.db.reindex(spack.store.layout)
+
+    if args.verbose:
+        tty.info("Added {} packages.".format(num_packages))
+
+

--- a/lib/spack/spack/cmd/stack.py
+++ b/lib/spack/spack/cmd/stack.py
@@ -37,7 +37,6 @@ from __future__ import print_function
 
 __author__ = "Oliver Breitwieser (UHEI)"
 
-import glob
 import os
 import os.path as osp
 import spack
@@ -50,8 +49,9 @@ import llnl.util.tty as tty
 import llnl.util.filesystem as fs
 
 description = "integrate packages of remote spack repositories into this one"
-section = "environment"
-level = "short" # TODO: re-check what 'level' is supposed to mean
+section = "admin"
+level = "long"  # TODO: re-check what 'level' is supposed to mean
+
 
 def setup_parser(sp):
     setup_parser.parser = sp
@@ -107,14 +107,14 @@ def add_remote_packages(remote, exclude=[], verbose=False):
 
 def stack(parser, args):
 
-    num_packages = sum((add_remote_packages(
+    num_packages = sum((
+        add_remote_packages(
             remote,
-            exclude=args.exclude, verbose=args.verbose)
+            exclude=args.exclude,
+            verbose=args.verbose)
         for remote in args.remotes))
 
     spack.store.db.reindex(spack.store.layout)
 
     if args.verbose:
         tty.info("Added {} packages.".format(num_packages))
-
-

--- a/lib/spack/spack/test/stack.py
+++ b/lib/spack/spack/test/stack.py
@@ -46,5 +46,11 @@ def test_stack(database, refresh_db_on_exit, install_mockery):
     # have at least one package stacked (i.e. linked)
     assert spack.cmd.stack.stack(None, args) > 0
 
+    # ignore already present symlinks
+    args = arg_t([remote], [], True, False)
+
+    # assert that another addition does not stack packages
+    assert spack.cmd.stack.stack(None, args) == 0
+
     # packages present now in our db
     assert len(spack.store.db.query()) > 0

--- a/lib/spack/spack/test/stack.py
+++ b/lib/spack/spack/test/stack.py
@@ -1,0 +1,50 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
+import collections as c
+import spack.cmd.stack
+import spack.store
+import spack.test.conftest
+
+
+def test_stack(database, refresh_db_on_exit, install_mockery):
+    """Ensure that stacked packages appear in second database.
+    """
+    remote = str(database.mock.path)
+
+    arg_t = c.namedtuple(
+        "Arguments",
+        ["remotes", "exclude", "nostack", "hardlinks"])
+
+    args = arg_t([remote], [], False, False)
+
+    # no packages present now
+    assert len(spack.store.db.query()) == 0
+
+    # have at least one package stacked (i.e. linked)
+    assert spack.cmd.stack.stack(None, args) > 0
+
+    # packages present now in our db
+    assert len(spack.store.db.query()) > 0


### PR DESCRIPTION
Stack the local spack repository on top of a remote repository that contains pre-built packages, thereby avoiding building packages twice.

Essentially, this adds installed packages in remote read-only spack installations (on the same system) to the current spack repository.

*Motivation:*
In our group we have a set of pre-built packages that reside in their own spack repository and are available system-wide in a read-only fashion. Up until now there seemed to be no "proper" way to use these packages as dependencies for locally built specs in a seperate spack repository.

Especially, this is useful when debugging new `package.py`s against the installed set of packages. Previously the whole spack database had to be built a second time.

*Implementation:*
We symlink all installed specs from the remote repository into the local `opt/spack`-path and reindex.
Because everything is linked via `RPATH`s, the remote package will have to reside where they are (hence no option to use hardlinks right now). When compiling packages in the local spack repository, the `RPATH`s might point to symlinks, however, I do not expect this to be an issue.

Comments?