### PR TITLE
Tell R's configure about tcltk config

### DIFF
--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -100,7 +100,9 @@ class R(AutotoolsPackage):
             '--libdir={0}'.format(join_path(prefix, 'rlib')),
             '--enable-R-shlib',
             '--enable-BLAS-shlib',
-            '--enable-R-framework=no'
+            '--enable-R-framework=no',
+            '--with-tcl-config={0}'.format(join_path(spec['tcl'].prefix.lib, 'tclConfig.sh')),
+            '--with-tk-config={0}'.format(join_path(spec['tk'].prefix.lib, 'tkConfig.sh')),
         ]
 
         if '+external-lapack' in spec:

--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -96,13 +96,16 @@ class R(AutotoolsPackage):
         spec   = self.spec
         prefix = self.prefix
 
+        tclConfig_path = join_path(spec['tcl'].prefix.lib, 'tclConfig.sh')
+        tkConfig_path = join_path(spec['tk'].prefix.lib, 'tkConfig.sh')
+
         config_args = [
             '--libdir={0}'.format(join_path(prefix, 'rlib')),
             '--enable-R-shlib',
             '--enable-BLAS-shlib',
             '--enable-R-framework=no',
-            '--with-tcl-config={0}'.format(join_path(spec['tcl'].prefix.lib, 'tclConfig.sh')),
-            '--with-tk-config={0}'.format(join_path(spec['tk'].prefix.lib, 'tkConfig.sh')),
+            '--with-tcl-config={0}'.format(tclConfig_path),
+            '--with-tk-config={0}'.format(tkConfig_path),
         ]
 
         if '+external-lapack' in spec:


### PR DESCRIPTION
Add configure arguments that specify the location of the tcl and tk config scripts.

Tested on Centos7 w/ the system gcc (4.8.x) on a DO droplet.  Both with and without X build.  `capabilities("tcltk")` is `true` for both.  Even when configured with `+X`, `capabilities("X11")` is only true if `DISPLAY` is set (a valid X session).

I'm not entirely certain of the current R, X, Tk, Linux, and MacOS subtleties, so this would benefit from a review by someone who is.

Fixes #7072 
