### PR TITLE
Improve log parsing performance

### DIFF
--- a/lib/spack/external/ctest_log_parser.py
+++ b/lib/spack/external/ctest_log_parser.py
@@ -71,7 +71,7 @@ from __future__ import division
 import re
 import math
 import multiprocessing
-from datetime import datetime
+import time
 from contextlib import contextmanager
 
 from six import StringIO
@@ -110,7 +110,7 @@ class prefilter(object):
         return self.pre(text) and any(p.match(text) for p in self.patterns)
 
 
-error_matches = [
+_error_matches = [
     prefilter(
         lambda x: any(s in x for s in (
             'Error:', 'error', 'undefined reference', 'multiply defined')),
@@ -173,7 +173,7 @@ error_matches = [
     "^Command .* failed with exit code",
 ]
 
-error_exceptions = [
+_error_exceptions = [
     "instantiated from ",
     "candidates are:",
     ": warning",
@@ -188,7 +188,7 @@ error_exceptions = [
 ]
 
 #: Regexes to match file/line numbers in error/warning messages
-warning_matches = [
+_warning_matches = [
     prefilter(
         lambda x: 'warning' in x,
         "([^ :]+):([0-9]+): warning:",
@@ -219,7 +219,7 @@ warning_matches = [
 ]
 
 #: Regexes to match file/line numbers in error/warning messages
-warning_exceptions = [
+_warning_exceptions = [
     "/usr/.*/X11/Xlib\\.h:[0-9]+: war.*: ANSI C\\+\\+ forbids declaration",
     "/usr/.*/X11/Xutil\\.h:[0-9]+: war.*: ANSI C\\+\\+ forbids declaration",
     "/usr/.*/X11/XResource\\.h:[0-9]+: war.*: ANSI C\\+\\+ forbids declaration",
@@ -239,7 +239,7 @@ warning_exceptions = [
 ]
 
 #: Regexes to match file/line numbers in error/warning messages
-file_line_matches = [
+_file_line_matches = [
     "^Warning W[0-9]+ ([a-zA-Z.\\:/0-9_+ ~-]+) ([0-9]+):",
     "^([a-zA-Z./0-9_+ ~-]+):([0-9]+):",
     "^([a-zA-Z.\\:/0-9_+ ~-]+)\\(([0-9]+)\\)",
@@ -307,80 +307,114 @@ def chunks(l, n):
     return [l[i:i + chunksize] for i in range(0, len(l), chunksize)]
 
 
+@contextmanager
+def _time(times, i):
+    start = time.time()
+    yield
+    end = time.time()
+    times[i] += end - start
+
+
+def _match(matches, exceptions, line):
+    """True if line matches a regex in matches and none in exceptions."""
+    return (any(m.search(line) for m in matches) and
+            not any(e.search(line) for e in exceptions))
+
+
+def _profile_match(matches, exceptions, line, match_times, exc_times):
+    """Profiled version of match().
+
+    Timing is expensive so we have two whole functions.  This is much
+    longer because we have to break up the ``any()`` calls.
+
+    """
+    for i, m in enumerate(matches):
+        with _time(match_times, i):
+            if m.search(line):
+                break
+    else:
+        return False
+
+    for i, m in enumerate(exceptions):
+        with _time(exc_times, i):
+            if m.search(line):
+                return False
+    else:
+        return True
+
+
+def _parse(lines, offset, profile):
+    def compile(regex_array):
+        return [regex if isinstance(regex, prefilter) else re.compile(regex)
+                for regex in regex_array]
+
+    error_matches      = compile(_error_matches)
+    error_exceptions   = compile(_error_exceptions)
+    warning_matches    = compile(_warning_matches)
+    warning_exceptions = compile(_warning_exceptions)
+    file_line_matches  = compile(_file_line_matches)
+
+    matcher, args = _match, []
+    timings = []
+    if profile:
+        matcher = _profile_match
+        timings = [
+            [0.0] * len(error_matches), [0.0] * len(error_exceptions),
+            [0.0] * len(warning_matches), [0.0] * len(warning_exceptions)]
+
+    errors = []
+    warnings = []
+    for i, line in enumerate(lines):
+        # use CTest's regular expressions to scrape the log for events
+        if matcher(error_matches, error_exceptions, line, *timings[:2]):
+            event = BuildError(line.strip(), offset + i + 1)
+            errors.append(event)
+        elif matcher(warning_matches, warning_exceptions, line, *timings[2:]):
+            event = BuildWarning(line.strip(), offset + i + 1)
+            warnings.append(event)
+        else:
+            continue
+
+        # get file/line number for each event, if possible
+        for flm in file_line_matches:
+            match = flm.search(line)
+            if match:
+                event.source_file, source_line_no = match.groups()
+
+    return errors, warnings, timings
+
+
+def _parse_unpack(args):
+    return _parse(*args)
+
+
 class CTestLogParser(object):
     """Log file parser that extracts errors and warnings."""
     def __init__(self, profile=False):
-        def compile(regex_array):
-            return [regex if isinstance(regex, prefilter) else re.compile(regex)
-                    for regex in regex_array]
-
-        self.error_matches      = compile(error_matches)
-        self.error_exceptions   = compile(error_exceptions)
-        self.warning_matches    = compile(warning_matches)
-        self.warning_exceptions = compile(warning_exceptions)
-        self.file_line_matches  = compile(file_line_matches)
-
         # whether to record timing information
-        if profile:
-            self._match = self._profile_match
-        self.timings = {}
-
-    @contextmanager
-    def _time(self, arr, i):
-        if id(arr) not in self.timings:
-            self.timings[id(arr)] = [0.0] * len(arr)
-
-        start = datetime.now()
-        yield
-        end = datetime.now()
-        self.timings[id(arr)][i] += (end - start).total_seconds()
-
-
-    def _match(self, matches, exceptions, line):
-        """True if line matches a regex in matches and none in exceptions."""
-        return (any(m.search(line) for m in matches) and
-                not any(e.search(line) for e in exceptions))
-
-
-    def _profile_match(self, matches, exceptions, line):
-        """Profiled version of match().
-
-        Timing is expensive so we have two whole functions.  This is much
-        longer because we have to break up the ``any()`` calls.
-
-        """
-        for i, m in enumerate(matches):
-            with self._time(matches, i):
-                if m.search(line):
-                    break
-        else:
-            return False
-
-        for i, m in enumerate(exceptions):
-            with self._time(exceptions, i):
-                if m.search(line):
-                    return False
-        else:
-            return True
-
+        self.timings = []
+        self.profile = profile
 
     def print_timings(self):
         """Print out profile of time spent in different regular expressions."""
-        for name, arr in [
-                ('error_matches',      self.error_matches),
-                ('error_exceptions',   self.error_exceptions),
-                ('warning_matches',    self.warning_matches),
-                ('warning_exceptions', self.warning_exceptions)]:
+        def stringify(elt):
+            return elt if isinstance(elt, str) else elt.pattern
+
+        index = 0
+        for name, arr in [('error_matches', _error_matches),
+                          ('error_exceptions', _error_exceptions),
+                          ('warning_matches', _warning_matches),
+                          ('warning_exceptions', _warning_exceptions)]:
+
             print()
             print(name)
             for i, elt in enumerate(arr):
-                if id(arr) not in self.timings:
-                    continue
-                t = self.timings[id(arr)]
-                print("%16.2f        %s" % (t[i] * 1e6, elt.pattern))
+                print("%16.2f        %s" % (
+                    self.timings[index][i] * 1e6, stringify(elt)))
+            index += 1
 
 
-    def parse(self, stream, context=6):
+    def parse(self, stream, context=6, jobs=None):
         """Parse a log file by searching each line for errors and warnings.
 
         Args:
@@ -393,31 +427,45 @@ class CTestLogParser(object):
         """
         if isinstance(stream, string_types):
             with open(stream) as f:
-                return self.parse(f, context)
+                return self.parse(f, context, jobs)
 
         lines = [line for line in stream]
 
-        errors = []
-        warnings = []
-        for i, line in enumerate(lines):
-            # use CTest's regular expressions to scrape the log for events
-            if self._match(self.error_matches, self.error_exceptions, line):
-                event = BuildError(line.strip(), i + 1)
-                errors.append(event)
-            elif self._match(
-                    self.warning_matches, self.warning_exceptions, line):
-                event = BuildWarning(line.strip(), i + 1)
-                warnings.append(event)
-            else:
-                continue
+        if jobs is None:
+            jobs = multiprocessing.cpu_count()
 
-            # get file/line number for each event, if possible
-            for flm in self.file_line_matches:
-                match = flm.search(line)
-                if match:
-                    event.source_file, source_line_no = match.groups()
+        # single-thread small logs
+        if len(lines) < 10 * jobs:
+            errors, warnings, self.timings = _parse(lines, 0, self.profile)
 
-            # add log context, as well
+        else:
+            # Build arguments for parallel jobs
+            args = []
+            offset = 0
+            for chunk in chunks(lines, jobs):
+                args.append((chunk, offset, self.profile))
+                offset += len(chunk)
+
+            # create a pool and farm out the matching job
+            pool = multiprocessing.Pool(jobs)
+            try:
+                # this is a workaround for a Python bug in Pool with ctrl-C
+                results = pool.map_async(_parse_unpack, args, 1).get(9999999)
+                errors, warnings, timings = zip(*results)
+            finally:
+                pool.terminate()
+
+            # merge results
+            errors = sum(errors, [])
+            warnings = sum(warnings, [])
+
+            if self.profile:
+                self.timings = [
+                    [sum(i) for i in zip(*t)] for t in zip(*timings)]
+
+        # add log context to all events
+        for event in (errors + warnings):
+            i = event.line_no - 1
             event.pre_context = [
                 l.rstrip() for l in lines[i - context:i]]
             event.post_context = [

--- a/lib/spack/spack/cmd/edit.py
+++ b/lib/spack/spack/cmd/edit.py
@@ -116,6 +116,10 @@ def edit(parser, args):
     if args.path:
         path = args.path
         if name:
+            # convert command names to python module name
+            if path == spack.cmd.command_path:
+                name = spack.cmd.python_name(name)
+
             path = os.path.join(path, name)
             if not os.path.exists(path):
                 files = glob.glob(path + '*')

--- a/lib/spack/spack/cmd/log_parse.py
+++ b/lib/spack/spack/cmd/log_parse.py
@@ -25,8 +25,6 @@
 import sys
 
 import llnl.util.tty as tty
-from ctest_log_parser import CTestLogParser
-
 from spack.util.log_parse import parse_log_events, make_log_context
 
 description = "filter errors and warnings from build logs"
@@ -49,6 +47,10 @@ def setup_parser(subparser):
     subparser.add_argument(
         '-w', '--width', action='store', type=int, default=None,
         help="wrap width: auto-size to terminal by default; 0 for no wrap")
+    subparser.add_argument(
+        '-j', '--jobs', action='store', type=int, default=None,
+        help="number of jobs to parse log file; default is 1 for short logs, "
+        "ncpus for long logs")
 
     subparser.add_argument(
         'file', help="a log file containing build output, or - for stdin")
@@ -59,13 +61,10 @@ def log_parse(parser, args):
     if args.file == '-':
         input = sys.stdin
 
+    errors, warnings = parse_log_events(
+        input, args.context, args.jobs, args.profile)
     if args.profile:
-        parser = CTestLogParser(profile=True)
-        parser.parse(input, args.context)
-        parser.print_timings()
-        sys.exit(0)
-
-    errors, warnings = parse_log_events(input, args.context)
+        return
 
     types = [s.strip() for s in args.show.split(',')]
     for e in types:

--- a/lib/spack/spack/cmd/log_parse.py
+++ b/lib/spack/spack/cmd/log_parse.py
@@ -1,0 +1,83 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+import sys
+
+import llnl.util.tty as tty
+from ctest_log_parser import CTestLogParser
+
+from spack.util.log_parse import parse_log_events, make_log_context
+
+description = "filter errors and warnings from build logs"
+section = "build"
+level = "long"
+
+event_types = ('errors', 'warnings')
+
+
+def setup_parser(subparser):
+    subparser.add_argument(
+        '--show', action='store', default='errors',
+        help="comma-separated list of what to show; options: errors, warnings")
+    subparser.add_argument(
+        '-c', '--context', action='store', type=int, default=3,
+        help="lines of context to show around lines of interest")
+    subparser.add_argument(
+        '-p', '--profile', action='store_true',
+        help="print out a profile of time spent in regexes during parse")
+    subparser.add_argument(
+        '-w', '--width', action='store', type=int, default=None,
+        help="wrap width: auto-size to terminal by default; 0 for no wrap")
+
+    subparser.add_argument(
+        'file', help="a log file containing build output, or - for stdin")
+
+
+def log_parse(parser, args):
+    input = args.file
+    if args.file == '-':
+        input = sys.stdin
+
+    if args.profile:
+        parser = CTestLogParser(profile=True)
+        parser.parse(input, args.context)
+        parser.print_timings()
+        sys.exit(0)
+
+    errors, warnings = parse_log_events(input, args.context)
+
+    types = [s.strip() for s in args.show.split(',')]
+    for e in types:
+        if e not in event_types:
+            tty.die('Invalid event type: %s' % e)
+
+    events = []
+    if 'errors' in types:
+        events.extend(errors)
+        print('%d errors' % len(errors))
+    if 'warnings' in types:
+        events.extend(warnings)
+        print('%d warnings' % len(warnings))
+
+    print(make_log_context(events, args.width))

--- a/lib/spack/spack/util/log_parse.py
+++ b/lib/spack/spack/util/log_parse.py
@@ -32,13 +32,17 @@ from ctest_log_parser import CTestLogParser, BuildError, BuildWarning
 import llnl.util.tty as tty
 from llnl.util.tty.color import colorize
 
+__all__ = ['parse_log_events', 'make_log_context']
 
-def parse_log_events(stream, context=6):
+
+def parse_log_events(stream, context=6, jobs=None, profile=False):
     """Extract interesting events from a log file as a list of LogEvent.
 
     Args:
         stream (str or fileobject): build log name or file object
         context (int): lines of context to extract around each log event
+        jobs (int): number of jobs to parse with; default ncpus
+        profile (bool): print out profile information for parsing
 
     Returns:
         (tuple): two lists containig ``BuildError`` and
@@ -49,9 +53,12 @@ def parse_log_events(stream, context=6):
     that all the regex compilation is only done once.
     """
     if parse_log_events.ctest_parser is None:
-        parse_log_events.ctest_parser = CTestLogParser()
+        parse_log_events.ctest_parser = CTestLogParser(profile=profile)
 
-    return parse_log_events.ctest_parser.parse(stream, context)
+    result = parse_log_events.ctest_parser.parse(stream, context, jobs)
+    if profile:
+        parse_log_events.ctest_parser.print_timings()
+    return result
 
 
 #: lazily constructed CTest log parser


### PR DESCRIPTION
When a build errors out, Spack goes through the build log and scrapes it for errors and warnings (see #5016, #5561).  We found that this was taking forever (like an hour) on large logs.  It turns out that [Python regular expressions are slow](https://swtch.com/~rsc/regexp/regexp1.html), and this affects our log scraping in bad ways.

This PR does several things:

- [x] Add a profile mode to the parser that tells you which regexes take the most time.  A number of regular expressions from `ctest_log_parser` have really poor performance, mostly due to "untethered" `*` and `+` (i.e., they don't start with `^`, so Python's backtracking regex implementation checks for repetition at every position in the string).  I can't verify that CTest's regexes work as intended with an initial `^` (which would be an obvious solution), so I don't really want to touch them.  This fear was borne out when I tried just adding `^` and some tests broke.

- [x] Instead of using only "efficient" regular expressions, added a `prefilter()` class that allows the parser to quickly check a precondition before evaluating any of the expensive ones. Preconditions do things like test whether the string contains "error" or "warning" (linear time things) before evaluating regexes.   Some simple preconditions speed things up by about **200x** for the log file I tested.

- [x] Parallelize the log parsing.  Files are now divided up and parsed by all CPUs.  This gets you another speedup approximately equal to the number of physical cores you've got.

- [x] Add a `spack log-parse` command that you can run on any file.  This let me test things, and it's handy because you can run it on build logs that aren't even from Spack.

Here's `spack log-parse`:

```
$ spack log-parse -h
usage: spack log-parse [-h] [--show SHOW] [-c CONTEXT] [-p] [-w WIDTH]
                       [-j JOBS]
                       file

filter errors and warnings from build logs

positional arguments:
  file                  a log file containing build output, or - for stdin

optional arguments:
  -h, --help            show this help message and exit
  --show SHOW           comma-separated list of what to show; options: errors,
                        warnings
  -c CONTEXT, --context CONTEXT
                        lines of context to show around lines of interest
  -p, --profile         print out a profile of time spent in regexes during
                        parse
  -w WIDTH, --width WIDTH
                        wrap width: auto-size to terminal by default; 0 for no
                        wrap
  -j JOBS, --jobs JOBS  number of jobs to parse log file; default is 1 for
                        short logs, ncpus for long logs
```

Try it -- it'll find errors (and optionally warnings) from your builds.

Finally, this PR cleans up the log output a bit so that long lines wrap better with the line numbers.  i.e., we now indent wrapped lines so you can still see the line numbers.  I find this makes things more readable for really nasty build logs.