### PR TITLE
Fix python dependencies of llvm and remove broken backend

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -80,7 +80,8 @@ class Llvm(CMakePackage):
     depends_on('cmake@3.4.3:', type='build')
 
     # Universal dependency
-    depends_on('python@2.7:2.8')  # Seems not to support python 3.X.Y
+    depends_on('python@2.7:2.8', when='@:4.999')
+    depends_on('python')
     depends_on('py-lit', type=('build', 'run'))
 
     # lldb dependencies

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -427,7 +427,7 @@ class Llvm(CMakePackage):
             cmake_args.append('-DLLVM_LINK_LLVM_DYLIB:Bool=ON')
 
         if '+all_targets' not in spec:  # all is default on cmake
-            targets = ['CppBackend', 'NVPTX', 'AMDGPU']
+            targets = ['NVPTX', 'AMDGPU']
             if 'x86' in spec.architecture.target.lower():
                 targets.append('X86')
             elif 'arm' in spec.architecture.target.lower():

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -428,7 +428,7 @@ class Llvm(CMakePackage):
             cmake_args.append('-DLLVM_LINK_LLVM_DYLIB:Bool=ON')
 
         if '+all_targets' not in spec:  # all is default on cmake
-            targets = ['NVPTX', 'AMDGPU']
+            targets = ['CppBackend', 'NVPTX', 'AMDGPU']
             if 'x86' in spec.architecture.target.lower():
                 targets.append('X86')
             elif 'arm' in spec.architecture.target.lower():


### PR DESCRIPTION
Restricting python dependency, so that it works with py3 in compatible versions (@5:) and removing broken target see https://reviews.llvm.org/D19942 ("Remove bit-rotten CppBackend.")