### PR TITLE
Setup dependent environment for pkgconf.

### DIFF
--- a/var/spack/repos/builtin/packages/pkgconf/package.py
+++ b/var/spack/repos/builtin/packages/pkgconf/package.py
@@ -40,6 +40,19 @@ class Pkgconf(AutotoolsPackage):
 
     provides('pkgconfig')
 
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        """spack built pkg-config on cray's requires adding /usr/local/
+        and /usr/lib64/  to PKG_CONFIG_PATH in order to access cray '.pc'
+        files.
+        Adds the ACLOCAL path for autotools."""
+        spack_env.append_path('ACLOCAL_PATH',
+                              join_path(self.prefix.share, 'aclocal'))
+        if 'platform=cray' in self.spec:
+            spack_env.append_path('PKG_CONFIG_PATH',
+                                  '/usr/lib64/pkgconfig')
+            spack_env.append_path('PKG_CONFIG_PATH',
+                                  '/usr/local/lib64/pkgconfig')
+
     @run_after('install')
     def link_pkg_config(self):
         symlink('pkgconf', '{0}/pkg-config'.format(self.prefix.bin))


### PR DESCRIPTION
This is a copypaste from `pkg-config` package. Should also fix #7006 and related issues on Cray machines.