### PR TITLE
symlink python3 to python

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -204,8 +204,10 @@ class Python(AutotoolsPackage):
                            os.path.join(dst, f))
 
         if spec.satisfies('@3:'):
-            os.symlink(os.path.join(prefix.bin, 'python3'), os.path.join(prefix.bin, 'python'))
-            os.symlink(os.path.join(prefix.bin, 'python3-config'), os.path.join(prefix.bin, 'python-config'))
+            os.symlink(os.path.join(prefix.bin, 'python3'),
+                       os.path.join(prefix.bin, 'python'))
+            os.symlink(os.path.join(prefix.bin, 'python3-config'),
+                       os.path.join(prefix.bin, 'python-config'))
 
     # TODO: Once better testing support is integrated, add the following tests
     # https://wiki.python.org/moin/TkInter

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -203,6 +203,10 @@ class Python(AutotoolsPackage):
                 os.symlink(os.path.join(src, f),
                            os.path.join(dst, f))
 
+        if spec.satisfies('@3:'):
+            os.symlink(os.path.join(prefix.bin, 'python3'), os.path.join(prefix.bin, 'python'))
+            os.symlink(os.path.join(prefix.bin, 'python3-config'), os.path.join(prefix.bin, 'python-config'))
+
     # TODO: Once better testing support is integrated, add the following tests
     # https://wiki.python.org/moin/TkInter
     #


### PR DESCRIPTION
Otherwise not all autotools are smart enough.

Not sure if this is in general a good idea though. Or whether it is preferable to fix the problem for the offending packages on a case by case basis. 

Unfortunately I don't remember the packages that reacted badly...