### PR TITLE
intel-xed: new package

### DIFF
--- a/var/spack/repos/builtin/packages/intel-xed/package.py
+++ b/var/spack/repos/builtin/packages/intel-xed/package.py
@@ -47,6 +47,9 @@ class IntelXed(Package):
 
     depends_on('python@2.7.0:', type='build')
 
+    opt_map = {'-O0': '0', '-O': '1', '-O1': '1', '-O2': '2', '-O3': '3'}
+    default_opt = '2'
+
     mycflags = []
 
     # Save CFLAGS for use in install.
@@ -59,18 +62,11 @@ class IntelXed(Package):
         mfile = Executable('./mfile.py')
 
         # Translate CFLAGS '-O2' to mbuild syntax.
-        if '-O0' in self.mycflags:
-            opt = '0'
-        elif '-O' in self.mycflags:
-            opt = '1'
-        elif '-O1' in self.mycflags:
-            opt = '1'
-        elif '-O2' in self.mycflags:
-            opt = '2'
-        elif '-O3' in self.mycflags:
-            opt = '3'
-        else:
-            opt = '2'
+        opt = self.default_opt
+        for flag in self.mycflags:
+            if flag in self.opt_map:
+                opt = self.opt_map[flag]
+                break
 
         args = ['-j', str(make_jobs),
                 '--cc=%s' % spack_cc,

--- a/var/spack/repos/builtin/packages/intel-xed/package.py
+++ b/var/spack/repos/builtin/packages/intel-xed/package.py
@@ -1,0 +1,98 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+import glob
+
+
+class IntelXed(Package):
+    """The Intel X86 Encoder Decoder library for encoding and decoding x86
+    machine instructions (64- and 32-bit).  Also includes libxed-ild,
+    a lightweight library for decoding the length of an instruction."""
+
+    homepage = "https://intelxed.github.io/"
+    url = "https://github.com/intelxed/xed"
+
+    version('2018.01.12',
+            git = 'https://github.com/intelxed/xed',
+            commit = '5c538047876feecf080d9441110f81d0e67b5de8')
+
+    resource(name = 'mbuild',
+             git = 'https://github.com/intelxed/mbuild',
+             commit = 'bb9123152a330c7fa1ff1a502950dc199c83e177',
+             destination = '')
+
+    variant('debug', default=False, description='enable debug symbols')
+
+    depends_on('python@2.7.0:', type='build')
+
+    mycflags = []
+
+    # Save CFLAGS for use in install.
+    def flag_handler(self, name, flags):
+        if name == 'cflags': self.mycflags = flags
+        return (flags, None, None)
+
+    def install(self, spec, prefix):
+        mfile = Executable('./mfile.py')
+
+        # Translate CFLAGS '-O2' to mbuild syntax.
+        if '-O0' in self.mycflags: opt = '0'
+        elif '-O' in self.mycflags: opt = '1'
+        elif '-O1' in self.mycflags: opt = '1'
+        elif '-O2' in self.mycflags: opt = '2'
+        elif '-O3' in self.mycflags: opt = '3'
+        else: opt = '2'
+
+        args = ['-j', str(make_jobs),
+                '--cc=%s' % spack_cc,
+                '--opt=%s' % opt,
+                '--no-werror']
+
+        if '+debug' in spec: args.append('--debug')
+
+        # Build and install static libxed.a.
+        mfile('--clean')
+        mfile(*args)
+
+        mkdirp(prefix.include)
+        mkdirp(prefix.lib)
+
+        libs = glob.glob(join_path('obj', 'lib*.a'))
+        for lib in libs:
+            install(lib, prefix.lib)
+
+        # Build and install shared libxed.so.
+        mfile('--clean')
+        mfile('--shared', *args)
+
+        libs = glob.glob(join_path('obj', 'lib*.so'))
+        for lib in libs:
+            install(lib, prefix.lib)
+
+        # Install header files.
+        hdrs = glob.glob(join_path('include', 'public', 'xed', '*.h'))  \
+            + glob.glob(join_path('obj', '*.h'))
+        for hdr in hdrs:
+            install(hdr, prefix.include)

--- a/var/spack/repos/builtin/packages/intel-xed/package.py
+++ b/var/spack/repos/builtin/packages/intel-xed/package.py
@@ -35,13 +35,13 @@ class IntelXed(Package):
     url = "https://github.com/intelxed/xed"
 
     version('2018.01.12',
-            git = 'https://github.com/intelxed/xed',
-            commit = '5c538047876feecf080d9441110f81d0e67b5de8')
+            git='https://github.com/intelxed/xed',
+            commit='5c538047876feecf080d9441110f81d0e67b5de8')
 
-    resource(name = 'mbuild',
-             git = 'https://github.com/intelxed/mbuild',
-             commit = 'bb9123152a330c7fa1ff1a502950dc199c83e177',
-             destination = '')
+    resource(name='mbuild',
+             git='https://github.com/intelxed/mbuild',
+             commit='bb9123152a330c7fa1ff1a502950dc199c83e177',
+             destination='')
 
     variant('debug', default=False, description='enable debug symbols')
 
@@ -51,26 +51,34 @@ class IntelXed(Package):
 
     # Save CFLAGS for use in install.
     def flag_handler(self, name, flags):
-        if name == 'cflags': self.mycflags = flags
+        if name == 'cflags':
+            self.mycflags = flags
         return (flags, None, None)
 
     def install(self, spec, prefix):
         mfile = Executable('./mfile.py')
 
         # Translate CFLAGS '-O2' to mbuild syntax.
-        if '-O0' in self.mycflags: opt = '0'
-        elif '-O' in self.mycflags: opt = '1'
-        elif '-O1' in self.mycflags: opt = '1'
-        elif '-O2' in self.mycflags: opt = '2'
-        elif '-O3' in self.mycflags: opt = '3'
-        else: opt = '2'
+        if '-O0' in self.mycflags:
+            opt = '0'
+        elif '-O' in self.mycflags:
+            opt = '1'
+        elif '-O1' in self.mycflags:
+            opt = '1'
+        elif '-O2' in self.mycflags:
+            opt = '2'
+        elif '-O3' in self.mycflags:
+            opt = '3'
+        else:
+            opt = '2'
 
         args = ['-j', str(make_jobs),
                 '--cc=%s' % spack_cc,
                 '--opt=%s' % opt,
                 '--no-werror']
 
-        if '+debug' in spec: args.append('--debug')
+        if '+debug' in spec:
+            args.append('--debug')
 
         # Build and install static libxed.a.
         mfile('--clean')


### PR DESCRIPTION
This patch adds the 'intel-xed' package, the Intel X86 Encoder Decoder
library for encoding and decoding x86 machine instructions.

XED was previously closed source inside Intel, but is now available on
GitHub (yeah!) at github.com/intelxed.

XED homepage: https://intelxed.github.io/

There is one small point I was unsure how to do.  XED only runs on
x86.  It won't even build on powerpc.

I'm guessing you'd want to handle this by adding a conflict().
I want to say, conflict('arch != x86'), but I was unsure of the
correct syntax for that.

This is probably a 1-line change, if someone can show me what the
correct spec for that is.

Mark Krentel
