### PR TITLE
libdwarf: fix linking, fix build on Darwin

### DIFF
--- a/var/spack/repos/builtin/packages/libdwarf/package.py
+++ b/var/spack/repos/builtin/packages/libdwarf/package.py
@@ -77,8 +77,8 @@ class Libdwarf(Package):
                 if spec.satisfies('^libelf'):
                     libelf_inc_dir = join_path(spec['libelf'].prefix,
                                                'include/libelf')
-                    extra_config_args.append('CFLAGS=-I{0}'.format(
-                                             libelf_inc_dir))
+                    extra_config_args.append('CFLAGS=-I{0} -Wl,-L{1} -Wl,-lelf'.format(
+                                             libelf_inc_dir, spec['libelf'].prefix.lib))
                 configure("--prefix=" + prefix, "--enable-shared",
                           *extra_config_args)
                 make()

--- a/var/spack/repos/builtin/packages/libdwarf/package.py
+++ b/var/spack/repos/builtin/packages/libdwarf/package.py
@@ -90,8 +90,9 @@ class Libdwarf(Package):
                             'Makefile')
                 make()
 
+                libdwarf_name = 'libdwarf.{0}'.format(dso_suffix)
                 install('libdwarf.a',  prefix.lib)
-                install('libdwarf.so', prefix.lib)
+                install('libdwarf.so', join_path(prefix.lib, libdwarf_name))
                 install('libdwarf.h',  prefix.include)
                 install('dwarf.h',     prefix.include)
 


### PR DESCRIPTION
Prior to this PR, `libdwarf` did not build on Darwin. This PR fixes compilation on Darwin and:

* fixes the dynamic library suffix for the installed `libdwarf` library
* adds the `zlib` dependency so that `libdwarf` links to Spack-installed zlib, instead of the system-installed zlib