### PR TITLE
WIP: elftoolchain@0.7.1: new package

### DIFF
--- a/var/spack/repos/builtin/packages/elftoolchain/mk-elftoolchain-inc-mk.patch
+++ b/var/spack/repos/builtin/packages/elftoolchain/mk-elftoolchain-inc-mk.patch
@@ -1,0 +1,11 @@
+--- mk/elftoolchain.inc.mk	2015-08-31 12:54:13.000000000 -0700
++++ mk/elftoolchain.inc.mk	2018-01-30 02:24:26.000000000 -0800
+@@ -24,7 +24,7 @@
+ .PRECIOUS:	${DESTDIR}${INCSDIR}/${inc}
+ ${DESTDIR}${INCSDIR}/${inc}: ${inc}
+ 	cmp -s $> $@ > /dev/null 2>&1 || \
+-		${INSTALL} -c -o ${BINOWN} -g ${BINGRP} -m ${NOBINMODE} $> $@
++		${INSTALL} -c -m ${NOBINMODE} $> $@
+ .endfor
+ .else	
+ 

--- a/var/spack/repos/builtin/packages/elftoolchain/mk-elftoolchain-lib-mk.patch
+++ b/var/spack/repos/builtin/packages/elftoolchain/mk-elftoolchain-lib-mk.patch
@@ -1,0 +1,11 @@
+--- mk/elftoolchain.lib.mk	2014-04-18 09:20:30.000000000 -0700
++++ mk/elftoolchain.lib.mk	2018-01-30 02:24:03.000000000 -0800
+@@ -55,7 +55,7 @@
+ .PRECIOUS:	${DESTDIR}${INCSDIR}/${inc}
+ ${DESTDIR}${INCSDIR}/${inc}: ${inc}
+ 	cmp -s $> $@ > /dev/null 2>&1 || \
+-		${INSTALL} -c -o ${BINOWN} -g ${BINGRP} -m ${NOBINMODE} $> $@
++		${INSTALL} -c -m ${NOBINMODE} $> $@
+ .endfor
+ 
+ .endif	# OpenBSD

--- a/var/spack/repos/builtin/packages/elftoolchain/mk-elftoolchain-tex-mk.patch
+++ b/var/spack/repos/builtin/packages/elftoolchain/mk-elftoolchain-tex-mk.patch
@@ -1,0 +1,11 @@
+--- mk/elftoolchain.tex.mk	2012-08-27 20:39:09.000000000 -0700
++++ mk/elftoolchain.tex.mk	2018-01-30 02:25:07.000000000 -0800
+@@ -79,7 +79,7 @@
+ 
+ install:	all
+ 	@mkdir -p ${DESTDIR}/${DOCDIR}/${DOCSUBDIR}
+-	${INSTALL} -g ${DOCGRP} -o ${DOCOWN} ${DOC}.pdf \
++	${INSTALL} ${DOC}.pdf \
+ 		${DESTDIR}/${DOCDIR}/${DOCSUBDIR}
+ 
+ # Include rules for `make obj`

--- a/var/spack/repos/builtin/packages/elftoolchain/package.py
+++ b/var/spack/repos/builtin/packages/elftoolchain/package.py
@@ -1,0 +1,48 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Elftoolchain(MakefilePackage):
+    """ELF Tool Chain: a BSD-licensed implementation of tools for the ELF format
+
+       ELF Tool Chain is A BSD-licensed implementation of compilation
+       tools (nm, ar, as, ld, etc.) for the ELF object format."""
+
+    homepage = "https://sourceforge.net/p/elftoolchain/wiki/Home/"
+    url      = "https://sourceforge.net/projects/elftoolchain/files/Sources/elftoolchain-0.7.1/elftoolchain-0.7.1.tar.bz2"
+
+    version('0.7.1', '47fe4cedded2edeaf8e429f1f842e23d')
+
+    depends_on('py-pyyaml')
+#    depends_on('libarchive')
+    depends_on('expat')
+    depends_on('bison')
+    depends_on('m4')
+    depends_on('zlib')
+
+    def install(self, spec, prefix):
+        args = ['DESTDIR={0}'.format(self.spec.prefix)]
+        return args

--- a/var/spack/repos/builtin/packages/elftoolchain/package.py
+++ b/var/spack/repos/builtin/packages/elftoolchain/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Elftoolchain(MakefilePackage):
+class Elftoolchain(Package):
     """ELF Tool Chain: a BSD-licensed implementation of tools for the ELF format
 
        ELF Tool Chain is A BSD-licensed implementation of compilation
@@ -36,13 +36,73 @@ class Elftoolchain(MakefilePackage):
 
     version('0.7.1', '47fe4cedded2edeaf8e429f1f842e23d')
 
-    depends_on('py-pyyaml')
-#    depends_on('libarchive')
-    depends_on('expat')
-    depends_on('bison')
-    depends_on('m4')
-    depends_on('zlib')
+    # Package won't link to libdwarf; does this provide enough of the ELF API for tools in spack?
+    # provides('elf@0')
+
+    depends_on('bmake', type='build')
+    depends_on('bison', type='build')
+    depends_on('flex', type='build')
+    depends_on('libarchive')
+
+    # Patches adapted from
+    # https://github.com/macports/macports-ports/blob/master/devel/elftoolchain/files/patch-byteorder-macros.diff
+    # https://github.com/macports/macports-ports/blob/master/devel/elftoolchain/files/patch-mk.diff
+    patch('patch-byteorder-macros.patch', level=0)
+    patch('patch-mk.patch', level=0)
+
+    # Patches to avoid installing files as root user, wheel group; the
+    # flags in the install phase below to disable installing files as
+    # root user must be applied _in addition_ to these
+    # patches. Patches are necessary because undefining BINOWN,
+    # BINGRP, DOCOWN, and DOCGRP is insufficient -- it leads to syntax
+    # errors thrown when `install` is called within the makefile.
+    patch('mk-elftoolchain-inc-mk.patch', level=0)
+    patch('mk-elftoolchain-lib-mk.patch', level=0)
+    patch('mk-elftoolchain-tex-mk.patch', level=0)
 
     def install(self, spec, prefix):
-        args = ['DESTDIR={0}'.format(self.spec.prefix)]
-        return args
+        bmake = which('bmake')
+        mkdirp(self.spec.prefix.bin)
+        mkdirp(self.spec.prefix.lib)
+        mkdirp(self.spec.prefix.include)
+        mkdirp(self.spec.prefix.share.man)
+
+        # Build phase; flags guessed from MacPorts
+        # https://github.com/macports/macports-ports/blob/master/devel/elftoolchain/Portfile
+        # 'prefix={0}'.format(self.spec.prefix),
+        args = ['BINDIR=/bin',
+                'LIBDIR=/lib',
+                'SHLIBDIR=/lib',
+                'INCSDIR=/include',
+                'MANDIR=/{0}'.format(join_path('share', 'man')),
+                'MANTARGET=man',
+                'LIBARCHIVE_PREFIX={0}'.format(spec['libarchive'].prefix),
+                'DESTDIR={0}'.format(prefix)]
+
+        # Exclude tests (large build targets) and docs
+        build_args = args
+        build_args.append('WITH_TESTS=no')
+        build_args.append('MKTEX=no')
+        bmake(*build_args)
+
+        # Install phase
+        install_args = ['install'] + args
+
+        # Do not strip binaries because it leads to errors
+        install_args.append('STRIP=')
+
+        # BSD make has a bunch of default privileges used as arguments
+        # to `install` in '.mk' files in the directory encoded by
+        # `spec['bmake'].prefix.share.mk`. These variables store user
+        # and group flags to install headers, libraries, etc as the
+        # root user. Undefining these flags eliminates permissions
+        # errors during the install phase.
+        install_args.append('LIB_INSTALL_OWN=')
+        install_args.append('INC_INSTALL_OWN=')
+        install_args.append('MAN_INSTALL_OWN=')
+        install_args.append('BIN_INSTALL_OWN=')
+        install_args.append('DOC_INSTALL_OWN=')
+        install_args.append('FILES_INSTALL_OWN=')
+        install_args.append('PROG_INSTALL_OWN=')
+
+        bmake(*install_args)

--- a/var/spack/repos/builtin/packages/elftoolchain/patch-byteorder-macros.patch
+++ b/var/spack/repos/builtin/packages/elftoolchain/patch-byteorder-macros.patch
@@ -1,0 +1,28 @@
+--- ar/write.c	2012-04-24 04:33:40.000000000 +0200
++++ ar/write.c	2012-09-25 11:27:38.000000000 +0200
+@@ -43,6 +43,11 @@
+ 
+ ELFTC_VCSID("$Id: write.c 2496 2012-04-24 02:33:40Z jkoshy $");
+ 
++#ifdef __APPLE__
++#include <libkern/OSByteOrder.h>
++#define htobe32(x) OSSwapHostToBigInt32(x)
++#endif
++
+ #define _ARMAG_LEN 8		/* length of the magic string */
+ #define _ARHDR_LEN 60		/* length of the archive header */
+ #define _INIT_AS_CAP 128	/* initial archive string table size */
+--- elfcopy/archive.c	2012-02-25 01:00:13.000000000 +0100
++++ elfcopy/archive.c	2012-02-25 01:00:27.000000000 +0100
+@@ -42,6 +42,11 @@
+ 
+ ELFTC_VCSID("$Id: archive.c 2370 2011-12-29 12:48:12Z jkoshy $");
+ 
++#ifdef __APPLE__
++#include <libkern/OSByteOrder.h>
++#define htobe32(x) OSSwapHostToBigInt32(x)
++#endif
++
+ #define _ARMAG_LEN 8		/* length of ar magic string */
+ #define _ARHDR_LEN 60		/* length of ar header */
+ #define _INIT_AS_CAP 128	/* initial archive string table size */

--- a/var/spack/repos/builtin/packages/elftoolchain/patch-mk.patch
+++ b/var/spack/repos/builtin/packages/elftoolchain/patch-mk.patch
@@ -1,0 +1,26 @@
+--- mk/elftoolchain.prog.mk.orig	2017-06-11 16:21:28.000000000 +0200
++++ mk/elftoolchain.prog.mk	2017-06-11 16:21:47.000000000 +0200
+@@ -50,6 +50,11 @@
+ LDFLAGS+=	-L/usr/pkg/lib
+ .endif
+ 
++.if ${OS_HOST} == "Darwin"
++CFLAGS+=       -I${LIBARCHIVE_PREFIX}/include
++LDFLAGS+=      -L${LIBARCHIVE_PREFIX}/lib
++.endif
++
+ #
+ # Handle lex(1) and yacc(1) in a portable fashion.
+ #
+--- mk/os.Darwin.mk	(revision 3546)
++++ mk/os.Darwin.mk	(working copy)
+@@ -3,6 +3,6 @@
+ # Build definitions for Darwin
+ 
+ # Apple ships libarchive, but for some reason does not provide the headers.
+-# Build against a homebrew-provided libarchive library and headers.
+-LDFLAGS+=	-L/usr/local/opt/libarchive/lib
+-CFLAGS+=	-I/usr/local/opt/libarchive/include
++# Build against a MacPorts-provided libarchive library and headers.
++# LDFLAGS/CFLAGS for libarchive have to be added in mk/elftoolchain.prog.mk to
++# respect the library search order.

--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -96,11 +96,16 @@ class R(AutotoolsPackage):
         spec   = self.spec
         prefix = self.prefix
 
+        tclConfig_path = join_path(spec['tcl'].prefix.lib, 'tclConfig.sh')
+        tkConfig_path = join_path(spec['tk'].prefix.lib, 'tkConfig.sh')
+
         config_args = [
             '--libdir={0}'.format(join_path(prefix, 'rlib')),
             '--enable-R-shlib',
             '--enable-BLAS-shlib',
-            '--enable-R-framework=no'
+            '--enable-R-framework=no',
+            '--with-tcl-config={0}'.format(tclConfig_path),
+            '--with-tk-config={0}'.format(tkConfig_path),
         ]
 
         if '+external-lapack' in spec:


### PR DESCRIPTION
This PR builds a BSD implementation of the ELF API from [elftoolchain](https://sourceforge.net/p/elftoolchain/wiki/Home/) because elfutils won't build with the Darwin system linker or with LLVM. Using a Darwin non-system linker from `binutils` is theoretically possible, but creates a bunch of linking headaches (namely, trying to debug errors with `ld: warning: file was built for archive which is not the architecture being linked (x86_64)`).

Right now, the package builds and installs correctly. What I can't figure out right now is if this package provides `elf@0`, `elf@1`, or simply isn't usable by other spack packages, partly because some of the packages that depend on `elf` won't build on Darwin without a lot of effort (or at all, possibly).

Once that issue is figured out, I'll rebase to clean up the history.
