### PR TITLE
rtags: add 2.17

### DIFF
--- a/var/spack/repos/builtin/packages/rtags/package.py
+++ b/var/spack/repos/builtin/packages/rtags/package.py
@@ -29,9 +29,10 @@ class Rtags(CMakePackage):
     """RTags is a client/server application that indexes C/C++ code"""
 
     homepage = "https://github.com/Andersbakken/rtags/"
-    url      = "https://andersbakken.github.io/rtags-releases/rtags-2.12.tar.gz"
+    url      = "https://andersbakken.github.io/rtags-releases/rtags-2.17.tar.gz"
 
-    version('2.12', '84988aaff27915a79d4b4b57299f9a51')
+    version('2.17', '95b24d7729678645a027d83be114d624')
+    # version('2.12', '84988aaff27915a79d4b4b57299f9a51')  # no available
 
     depends_on("llvm@3.3: +clang")
     depends_on("zlib")


### PR DESCRIPTION

could not fetch previous `url`:
```
==> Fetching https://andersbakken.github.io/rtags-releases/rtags-2.12.tar.gz

curl: (22) The requested URL returned error: 404
==> Fetching from https://andersbakken.github.io/rtags-releases/rtags-2.12.tar.gz failed.
==> Error: FetchError: All fetchers failed for rtags-2.12-x2xgt54mk2x6qxvog2kxo2dti6yyjzvo
FetchError: FetchError: All fetchers failed for rtags-2.12-x2xgt54mk2x6qxvog2kxo2dti6yyjzvo

/Users/davydden/spack/lib/spack/spack/package.py:993, in do_fetch:
     25                                     self.spec.format('$_$@'), ck_msg)
     26
     27            self.stage.create()
  >> 28            self.stage.fetch(mirror_only)
     29            self._fetch_time = time.time() - start_time
     30
     31            if spack.do_checksum and self.version in self.versions:

```