### PR TITLE
Update tutorial on advanced packaging

### DIFF
--- a/lib/spack/docs/tutorial_advanced_packaging.rst
+++ b/lib/spack/docs/tutorial_advanced_packaging.rst
@@ -298,7 +298,7 @@ attach attributes to your dependents. We'll see them next with the help
 of a few real use cases.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Set environment variables in dependents at build-time
+Set environment variables in dependent packages at build-time
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Another common occurrence, particularly for packages like ``r`` and ``python``
@@ -352,7 +352,7 @@ set to the correct value. More complicated examples of the use of this function
 may be found in the ``r`` and ``python`` package.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Set variables at build-time for yourself
+Set environment variables in your own package
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Spack provides a way to manipulate a package's build time and

--- a/lib/spack/docs/tutorial_advanced_packaging.rst
+++ b/lib/spack/docs/tutorial_advanced_packaging.rst
@@ -288,14 +288,15 @@ way to differentiate their answer to the query [#uniforminterface]_.
    With the addition of this interface, the virtual dependency itself tells
    other packages that depend on it where it can find its libraries.
 
----------------------------
-Package's build environment
----------------------------
+---------------------------------------
+Modifying a package's build environment
+---------------------------------------
 
-Besides Spec's build interface, Spack provides means to set environment
-variables, either for yourself or for your dependent packages, and to
-attach attributes to your dependents. We'll see them next with the help
-of a few real use cases.
+Spack sets up several environment variables like PATH by default to aid in
+building a package, but many packages make use of environment variables which
+convey specific information about their dependencies, for example MPICC. This
+section covers how update your Spack packages so that package-specific
+environment variables are defined at build-time.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Set environment variables in dependent packages at build-time

--- a/lib/spack/docs/tutorial_advanced_packaging.rst
+++ b/lib/spack/docs/tutorial_advanced_packaging.rst
@@ -108,6 +108,10 @@ package:
             '-DBLAS_LIBRARIES={0}'.format(blas_libs)
         ], '.')
 
+Note that ``arpack-ng`` is querying virtual dependencies, which Spack
+automatically resolves to the installed implementation (e.g. ``openblas``
+for ``blas``).
+
 We've started work on a package for ``armadillo``. You should open it,
 read through the comment that starts with ``# TUTORIAL:`` and complete
 the ``cmake_args`` section:
@@ -174,7 +178,7 @@ Providing libraries to dependents
 
 Spack provides a default implementation for ``libs`` which often works
 out of the box. A user can write a package definition without having to
-implement a ``libs`` property and dependents can retrieve the libraries
+implement a ``libs`` property and dependents can retrieve its libraries
 as shown in the above section. However, the default implementation assumes that
 libraries follow the naming scheme ``lib<package name>.so`` (or e.g.
 ``lib<package name>.a`` for static libraries). Packages which don't

--- a/lib/spack/docs/tutorial_advanced_packaging.rst
+++ b/lib/spack/docs/tutorial_advanced_packaging.rst
@@ -225,63 +225,6 @@ Now we can finally install ``armadillo ^netlib-lapack``:
     Fetch: 0.01s.  Build: 3.75s.  Total: 3.76s.
   [+] /usr/local/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/armadillo-8.100.1-sxmpu5an4dshnhickh6ykchyfda7jpyn
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-What happens at subscript time?
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The example above leaves us with a few questions. How could it be that the
-attribute:
-
-.. code-block:: python
-
-  spec['lapack'].libs
-
-stems from a property of the ``netlib-lapack`` package that has a different name?
-How is it even computed for ``openblas``, given that in its package there's no code
-that deals with finding libraries?
-The answer is that ``libs`` is one of the few properties of specs that follow the
-*build-interface protocol*. The others are currently ``command`` and ``headers``.
-These properties exist only on concrete specs that have been retrieved via the
-subscript notation.
-
-What happens is that, whenever you retrieve a spec using subscripts:
-
-.. code-block:: python
-
-  lapack = spec['lapack']
-
-the key that appears in the query (in this case ``'lapack'``) is attached to the
-returned item. When, later on, you access any of the build-interface attributes, this
-key is used to compute the result according to the following algorithm:
-
-.. code-block:: none
-
-  Given any pair of <query-key> and <build-attribute>:
-
-    1. If <query-key> is the name of a virtual spec and the package
-       providing it has an attribute named '<query-key>_<build-attribute>'
-       return it
-
-    2. Otherwise if the package has an attribute named '<build-attribute>'
-       return that
-
-    3. Otherwise use the default handler for <build-attribute>
-
-Going back to our concrete case this means that, if the spec providing LAPACK
-is ``netlib-lapack``, we are returning the value computed in the ``lapack_libs``
-property. If it is ``openblas``, we are instead resorting to the default handler
-for ``libs`` (which searches for the presence of ``libopenblas`` in the
-installation prefix).
-
-.. note::
-
-  Types commonly returned by build-interface attributes
-    Even though there's no enforcement on it, the type of the objects returned most often when
-    asking for the ``libs`` attributes is :py:class:`LibraryList <llnl.util.filesystem.LibraryList>`.
-    Similarly the usual type returned for ``headers`` is :py:class:`HeaderList <llnl.util.filesystem.HeaderList>`,
-    while for ``command`` is :py:class:`Executable <spack.util.executable.Executable>`. You can refer to
-    these objects' API documentation to discover more about them.
-
 ^^^^^^^^^^^^^^^^^^^^^^^
 Extra query parameters
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/spack/docs/tutorial_advanced_packaging.rst
+++ b/lib/spack/docs/tutorial_advanced_packaging.rst
@@ -297,55 +297,6 @@ variables, either for yourself or for your dependent packages, and to
 attach attributes to your dependents. We'll see them next with the help
 of a few real use cases.
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Set variables at build-time for yourself
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Spack provides a way to manipulate a package's build time and
-run time environments using the
-:py:func:`setup_environment <spack.package.PackageBase.setup_environment>` function.
-Let's try to see how it works by completing the ``elpa`` package:
-
-.. code-block:: console
-
-  root@advanced-packaging-tutorial:/# spack edit elpa
-
-In the end your method should look like:
-
-.. code-block:: python
-
-  def setup_environment(self, spack_env, run_env):
-      spec = self.spec
-
-      spack_env.set('CC', spec['mpi'].mpicc)
-      spack_env.set('FC', spec['mpi'].mpifc)
-      spack_env.set('CXX', spec['mpi'].mpicxx)
-      spack_env.set('SCALAPACK_LDFLAGS', spec['scalapack'].libs.joined())
-
-      spack_env.append_flags('LDFLAGS', spec['lapack'].libs.search_flags)
-      spack_env.append_flags('LIBS', spec['lapack'].libs.link_flags)
-
-The two arguments, ``spack_env`` and ``run_env``, are both instances of
-:py:class:`EnvironmentModifications <spack.environment.EnvironmentModifications>` and
-permit you to register modifications to either the build-time or the run-time
-environment of the package, respectively.
-At this point it's possible to proceed with the installation of ``elpa``:
-
-.. code-block:: console
-
-  root@advanced-packaging-tutorial:/# spack install elpa
-  ==> pkg-config is already installed in /usr/local/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/pkg-config-0.29.2-ae2hwm7q57byfbxtymts55xppqwk7ecj
-  ==> ncurses is already installed in /usr/local/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/ncurses-6.0-ukq4tccptm2rxd56d2bumqthnpcjzlez
-  ...
-  ==> Executing phase: 'build'
-  ==> Executing phase: 'install'
-  ==> Successfully installed elpa
-    Fetch: 3.94s.  Build: 41.93s.  Total: 45.87s.
-  [+] /usr/local/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/elpa-2016.05.004-sdbfhwcexg7s2zqf52vssb762ocvklbu
-
-If you had modifications to ``run_env``, those would have appeared e.g. in the module files
-generated for the package.
-
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Set environment variables in dependents at build-time
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -399,6 +350,55 @@ At this point we can, for instance, install ``netlib-scalapack``:
 and double check the environment logs to verify that every variable was
 set to the correct value. More complicated examples of the use of this function
 may be found in the ``r`` and ``python`` package.
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Set variables at build-time for yourself
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Spack provides a way to manipulate a package's build time and
+run time environments using the
+:py:func:`setup_environment <spack.package.PackageBase.setup_environment>` function.
+Let's try to see how it works by completing the ``elpa`` package:
+
+.. code-block:: console
+
+  root@advanced-packaging-tutorial:/# spack edit elpa
+
+In the end your method should look like:
+
+.. code-block:: python
+
+  def setup_environment(self, spack_env, run_env):
+      spec = self.spec
+
+      spack_env.set('CC', spec['mpi'].mpicc)
+      spack_env.set('FC', spec['mpi'].mpifc)
+      spack_env.set('CXX', spec['mpi'].mpicxx)
+      spack_env.set('SCALAPACK_LDFLAGS', spec['scalapack'].libs.joined())
+
+      spack_env.append_flags('LDFLAGS', spec['lapack'].libs.search_flags)
+      spack_env.append_flags('LIBS', spec['lapack'].libs.link_flags)
+
+The two arguments, ``spack_env`` and ``run_env``, are both instances of
+:py:class:`EnvironmentModifications <spack.environment.EnvironmentModifications>` and
+permit you to register modifications to either the build-time or the run-time
+environment of the package, respectively.
+At this point it's possible to proceed with the installation of ``elpa``:
+
+.. code-block:: console
+
+  root@advanced-packaging-tutorial:/# spack install elpa
+  ==> pkg-config is already installed in /usr/local/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/pkg-config-0.29.2-ae2hwm7q57byfbxtymts55xppqwk7ecj
+  ==> ncurses is already installed in /usr/local/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/ncurses-6.0-ukq4tccptm2rxd56d2bumqthnpcjzlez
+  ...
+  ==> Executing phase: 'build'
+  ==> Executing phase: 'install'
+  ==> Successfully installed elpa
+    Fetch: 3.94s.  Build: 41.93s.  Total: 45.87s.
+  [+] /usr/local/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/elpa-2016.05.004-sdbfhwcexg7s2zqf52vssb762ocvklbu
+
+If you had modifications to ``run_env``, those would have appeared e.g. in the module files
+generated for the package.
 
 ----------------------
 Other Packaging Topics

--- a/lib/spack/docs/tutorial_advanced_packaging.rst
+++ b/lib/spack/docs/tutorial_advanced_packaging.rst
@@ -78,23 +78,19 @@ the rest of the tutorial.
 
 .. _specs_build_interface_tutorial:
 
-----------------------
-Spec's build interface
-----------------------
+------------------------------
+Retrieving library information
+------------------------------
 
-Spack is designed with an emphasis on assigning responsibilities
-to the appropriate entities, as this results in a clearer and more intuitive interface
-for the users.
-When it comes to packaging, one of the most fundamental guideline that
-emerged from this tenet is that:
-
-  *It is a package's responsibility to know
-  every software it directly depends on and to expose to others how to
-  use the services it provides*.
-
-Spec's build interface is a protocol-like implementation of this guideline
-that allows packages to easily query their dependencies,
-and prescribes how they should expose their own build information.
+Although Spack attempts to help packages locate their dependency libraries
+automatically (e.g. by setting PKG_CONFIG_PATH and CMAKE_PREFIX_PATH), a
+package may have unique configuration options that are required to locate
+libraries. When a package needs information about dependency libraries, the
+general approach in Spack is to query the dependencies for the locations of
+their libraries and set configuration options accordingly. By default most
+Spack packages know how to automatically locate their libraries. This section
+covers how to retrieve library information from dependencies and how to locate
+libraries when the default logic doesn't work.
 
 ^^^^^^^^^^^^^^^^^^^^
 A motivating example

--- a/lib/spack/docs/tutorial_advanced_packaging.rst
+++ b/lib/spack/docs/tutorial_advanced_packaging.rst
@@ -4,18 +4,15 @@
 Advanced Topics in Packaging
 ============================
 
-While you can quickly accomplish most common tasks with what
-was covered in :ref:`packaging-tutorial`, there are times when such
-knowledge won't suffice. Usually this happens for libraries that provide
-more than one API and need to let dependents decide which one to use
-or for packages that provide tools that are invoked at build-time,
-or in other similar situations.
+Spack tries to automatically configure packages with information from
+dependencies such that all you need to do is to list the dependencies
+(i.e. with the ``depends_on`` directive) and the build system (for example
+by deriving from :code:``CmakePackage``).
 
-In the following we'll dig into some of the details of package
-implementation that help us deal with these rare, but important,
-occurrences. You can rest assured that in every case Spack remains faithful to
-its philosophy: keep simple things simple, but be flexible enough when
-complex requests arise!
+However, there are many special cases. Often you need to retrieve details
+about dependencies to set package-specific configuration options, this tutorial
+covers how to retrieve build information from dependencies, and how you
+can automatically provide important information to dependents in your package.
 
 ----------------------
 Setup for the tutorial
@@ -37,7 +34,7 @@ which comes with Spack and various packages pre-installed:
 
 If you already started the image, you can set the ``EDITOR`` environment
 variable to your preferred editor (``vi``, ``emacs``, and ``nano`` are included in the image)
-and move directly to :ref:`specs_build_interface_tutorial`.
+and move directly to :ref:`adv_pkg_tutorial_start`.
 
 If you choose not to use the Docker image, you can clone the Spack repository
 and build the necessary bits yourself:
@@ -76,7 +73,7 @@ Now, you are ready to set your preferred ``EDITOR`` and continue with
 the rest of the tutorial.
 
 
-.. _specs_build_interface_tutorial:
+.. _adv_pkg_tutorial_start:
 
 ------------------------------
 Retrieving library information

--- a/lib/spack/docs/tutorial_advanced_packaging.rst
+++ b/lib/spack/docs/tutorial_advanced_packaging.rst
@@ -10,9 +10,11 @@ dependencies such that all you need to do is to list the dependencies
 by deriving from :code:`CmakePackage`).
 
 However, there are many special cases. Often you need to retrieve details
-about dependencies to set package-specific configuration options, this tutorial
-covers how to retrieve build information from dependencies, and how you
-can automatically provide important information to dependents in your package.
+about dependencies to set package-specific configuration options, or to
+define package-specific environment variables used by the package's build
+system. This tutorial covers how to retrieve build information from
+dependencies, and how you can automatically provide important information to
+dependents in your package.
 
 ----------------------
 Setup for the tutorial

--- a/lib/spack/docs/tutorial_advanced_packaging.rst
+++ b/lib/spack/docs/tutorial_advanced_packaging.rst
@@ -297,9 +297,9 @@ variables, either for yourself or for your dependent packages, and to
 attach attributes to your dependents. We'll see them next with the help
 of a few real use cases.
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Set environment variables in dependent packages at build-time
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Another common occurrence, particularly for packages like ``r`` and ``python``
 that support extensions and for packages that provide build tools,
@@ -351,9 +351,9 @@ and double check the environment logs to verify that every variable was
 set to the correct value. More complicated examples of the use of this function
 may be found in the ``r`` and ``python`` package.
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Set environment variables in your own package
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Spack provides a way to manipulate a package's build time and
 run time environments using the

--- a/lib/spack/docs/tutorial_advanced_packaging.rst
+++ b/lib/spack/docs/tutorial_advanced_packaging.rst
@@ -225,82 +225,6 @@ Now we can finally install ``armadillo ^netlib-lapack``:
     Fetch: 0.01s.  Build: 3.75s.  Total: 3.76s.
   [+] /usr/local/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/armadillo-8.100.1-sxmpu5an4dshnhickh6ykchyfda7jpyn
 
-^^^^^^^^^^^^^^^^^^^^^^^
-Extra query parameters
-^^^^^^^^^^^^^^^^^^^^^^^
-
-An advanced feature of the Spec's build-interface protocol is the support
-for extra parameters after the subscript key. In fact, any of the keys used in the query
-can be followed by a comma separated list of extra parameters which can be
-inspected by the package receiving the request to fine-tune a response.
-
-Let's look at an example and try to install ``netcdf``:
-
-.. code-block:: console
-
-  root@advanced-packaging-tutorial:/# spack install netcdf
-  ==> libsigsegv is already installed in /usr/local/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/libsigsegv-2.11-fypapcprssrj3nstp6njprskeyynsgaz
-  ==> m4 is already installed in /usr/local/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/m4-1.4.18-r5envx3kqctwwflhd4qax4ahqtt6x43a
-  ...
-  ==> Error: AttributeError: 'list' object has no attribute 'search_flags'
-  AttributeError: AttributeError: 'list' object has no attribute 'search_flags'
-
-  /usr/local/var/spack/repos/builtin/packages/netcdf/package.py:207, in configure_args:
-       50            # used instead.
-       51            hdf5_hl = self.spec['hdf5:hl']
-       52            CPPFLAGS.append(hdf5_hl.headers.cpp_flags)
-    >> 53            LDFLAGS.append(hdf5_hl.libs.search_flags)
-       54
-       55            if '+parallel-netcdf' in self.spec:
-       56                config_args.append('--enable-pnetcdf')
-
-  See build log for details:
-    /usr/local/var/spack/stage/netcdf-4.4.1.1-gk2xxhbqijnrdwicawawcll4t3c7dvoj/netcdf-4.4.1.1/spack-build.out
-
-We can see from the error that ``netcdf`` needs to know how to link the *high-level interface*
-of ``hdf5``, and thus passes the extra parameter ``hl`` after the request to retrieve it.
-Clearly the implementation in the ``hdf5`` package is not complete, and we need to fix it:
-
-.. code-block:: console
-
-  root@advanced-packaging-tutorial:/# spack edit hdf5
-
-If you followed the instructions correctly, the code added to the
-``lib`` property should be similar to:
-
-.. code-block:: python
-  :emphasize-lines: 1
-
-  query_parameters = self.spec.last_query.extra_parameters
-  key = tuple(sorted(query_parameters))
-  libraries = query2libraries[key]
-  shared = '+shared' in self.spec
-  return find_libraries(
-      libraries, root=self.prefix, shared=shared, recurse=True
-  )
-
-where we highlighted the line retrieving  the extra parameters. Now we can successfully
-complete the installation of ``netcdf``:
-
-.. code-block:: console
-
-  root@advanced-packaging-tutorial:/# spack install netcdf
-  ==> libsigsegv is already installed in /usr/local/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/libsigsegv-2.11-fypapcprssrj3nstp6njprskeyynsgaz
-  ==> m4 is already installed in /usr/local/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/m4-1.4.18-r5envx3kqctwwflhd4qax4ahqtt6x43a
-  ...
-  ==> Installing netcdf
-  ==> Using cached archive: /usr/local/var/spack/cache/netcdf/netcdf-4.4.1.1.tar.gz
-  ==> Already staged netcdf-4.4.1.1-gk2xxhbqijnrdwicawawcll4t3c7dvoj in /usr/local/var/spack/stage/netcdf-4.4.1.1-gk2xxhbqijnrdwicawawcll4t3c7dvoj
-  ==> Already patched netcdf
-  ==> Building netcdf [AutotoolsPackage]
-  ==> Executing phase: 'autoreconf'
-  ==> Executing phase: 'configure'
-  ==> Executing phase: 'build'
-  ==> Executing phase: 'install'
-  ==> Successfully installed netcdf
-    Fetch: 0.01s.  Build: 24.61s.  Total: 24.62s.
-  [+] /usr/local/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/netcdf-4.4.1.1-gk2xxhbqijnrdwicawawcll4t3c7dvoj
-
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Single package providing multiple virtual specs
@@ -476,6 +400,10 @@ and double check the environment logs to verify that every variable was
 set to the correct value. More complicated examples of the use of this function
 may be found in the ``r`` and ``python`` package.
 
+----------------------
+Other Packaging Topics
+----------------------
+
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Attach attributes to other packages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -504,3 +432,79 @@ and ``automake`` with the usual function call syntax of :py:class:`Executable <s
 .. code-block:: python
 
   aclocal('--force')
+
+^^^^^^^^^^^^^^^^^^^^^^^
+Extra query parameters
+^^^^^^^^^^^^^^^^^^^^^^^
+
+An advanced feature of the Spec's build-interface protocol is the support
+for extra parameters after the subscript key. In fact, any of the keys used in the query
+can be followed by a comma separated list of extra parameters which can be
+inspected by the package receiving the request to fine-tune a response.
+
+Let's look at an example and try to install ``netcdf``:
+
+.. code-block:: console
+
+  root@advanced-packaging-tutorial:/# spack install netcdf
+  ==> libsigsegv is already installed in /usr/local/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/libsigsegv-2.11-fypapcprssrj3nstp6njprskeyynsgaz
+  ==> m4 is already installed in /usr/local/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/m4-1.4.18-r5envx3kqctwwflhd4qax4ahqtt6x43a
+  ...
+  ==> Error: AttributeError: 'list' object has no attribute 'search_flags'
+  AttributeError: AttributeError: 'list' object has no attribute 'search_flags'
+
+  /usr/local/var/spack/repos/builtin/packages/netcdf/package.py:207, in configure_args:
+       50            # used instead.
+       51            hdf5_hl = self.spec['hdf5:hl']
+       52            CPPFLAGS.append(hdf5_hl.headers.cpp_flags)
+    >> 53            LDFLAGS.append(hdf5_hl.libs.search_flags)
+       54
+       55            if '+parallel-netcdf' in self.spec:
+       56                config_args.append('--enable-pnetcdf')
+
+  See build log for details:
+    /usr/local/var/spack/stage/netcdf-4.4.1.1-gk2xxhbqijnrdwicawawcll4t3c7dvoj/netcdf-4.4.1.1/spack-build.out
+
+We can see from the error that ``netcdf`` needs to know how to link the *high-level interface*
+of ``hdf5``, and thus passes the extra parameter ``hl`` after the request to retrieve it.
+Clearly the implementation in the ``hdf5`` package is not complete, and we need to fix it:
+
+.. code-block:: console
+
+  root@advanced-packaging-tutorial:/# spack edit hdf5
+
+If you followed the instructions correctly, the code added to the
+``lib`` property should be similar to:
+
+.. code-block:: python
+  :emphasize-lines: 1
+
+  query_parameters = self.spec.last_query.extra_parameters
+  key = tuple(sorted(query_parameters))
+  libraries = query2libraries[key]
+  shared = '+shared' in self.spec
+  return find_libraries(
+      libraries, root=self.prefix, shared=shared, recurse=True
+  )
+
+where we highlighted the line retrieving  the extra parameters. Now we can successfully
+complete the installation of ``netcdf``:
+
+.. code-block:: console
+
+  root@advanced-packaging-tutorial:/# spack install netcdf
+  ==> libsigsegv is already installed in /usr/local/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/libsigsegv-2.11-fypapcprssrj3nstp6njprskeyynsgaz
+  ==> m4 is already installed in /usr/local/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/m4-1.4.18-r5envx3kqctwwflhd4qax4ahqtt6x43a
+  ...
+  ==> Installing netcdf
+  ==> Using cached archive: /usr/local/var/spack/cache/netcdf/netcdf-4.4.1.1.tar.gz
+  ==> Already staged netcdf-4.4.1.1-gk2xxhbqijnrdwicawawcll4t3c7dvoj in /usr/local/var/spack/stage/netcdf-4.4.1.1-gk2xxhbqijnrdwicawawcll4t3c7dvoj
+  ==> Already patched netcdf
+  ==> Building netcdf [AutotoolsPackage]
+  ==> Executing phase: 'autoreconf'
+  ==> Executing phase: 'configure'
+  ==> Executing phase: 'build'
+  ==> Executing phase: 'install'
+  ==> Successfully installed netcdf
+    Fetch: 0.01s.  Build: 24.61s.  Total: 24.62s.
+  [+] /usr/local/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/netcdf-4.4.1.1-gk2xxhbqijnrdwicawawcll4t3c7dvoj

--- a/lib/spack/docs/tutorial_advanced_packaging.rst
+++ b/lib/spack/docs/tutorial_advanced_packaging.rst
@@ -358,6 +358,28 @@ Set variables at build-time for yourself
 Spack provides a way to manipulate a package's build time and
 run time environments using the
 :py:func:`setup_environment <spack.package.PackageBase.setup_environment>` function.
+For ``qt`` this looks like:
+
+.. code-block:: python
+
+    def setup_environment(self, spack_env, run_env):
+        spack_env.set('MAKEFLAGS', '-j{0}'.format(make_jobs))
+        run_env.set('QTDIR', self.prefix)
+
+The two arguments, ``spack_env`` and ``run_env``, are both instances of
+:py:class:`EnvironmentModifications <spack.environment.EnvironmentModifications>` and
+permit you to register modifications to either the build-time or the run-time
+environment of the package, respectively. Modifications to ``run_env`` will
+appear in the module files generated for the package.
+
+To contrast with ``qt``'s :py:func:`setup_dependent_environment <spack.package.PackageBase.setup_dependent_environment>`
+function:
+
+.. code-block:: python
+
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        spack_env.set('QTDIR', self.prefix)
+
 Let's try to see how it works by completing the ``elpa`` package:
 
 .. code-block:: console
@@ -379,26 +401,7 @@ In the end your method should look like:
       spack_env.append_flags('LDFLAGS', spec['lapack'].libs.search_flags)
       spack_env.append_flags('LIBS', spec['lapack'].libs.link_flags)
 
-The two arguments, ``spack_env`` and ``run_env``, are both instances of
-:py:class:`EnvironmentModifications <spack.environment.EnvironmentModifications>` and
-permit you to register modifications to either the build-time or the run-time
-environment of the package, respectively.
-At this point it's possible to proceed with the installation of ``elpa``:
-
-.. code-block:: console
-
-  root@advanced-packaging-tutorial:/# spack install elpa
-  ==> pkg-config is already installed in /usr/local/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/pkg-config-0.29.2-ae2hwm7q57byfbxtymts55xppqwk7ecj
-  ==> ncurses is already installed in /usr/local/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/ncurses-6.0-ukq4tccptm2rxd56d2bumqthnpcjzlez
-  ...
-  ==> Executing phase: 'build'
-  ==> Executing phase: 'install'
-  ==> Successfully installed elpa
-    Fetch: 3.94s.  Build: 41.93s.  Total: 45.87s.
-  [+] /usr/local/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/elpa-2016.05.004-sdbfhwcexg7s2zqf52vssb762ocvklbu
-
-If you had modifications to ``run_env``, those would have appeared e.g. in the module files
-generated for the package.
+At this point it's possible to proceed with the installation of ``elpa``.
 
 ----------------------
 Other Packaging Topics

--- a/lib/spack/docs/tutorial_advanced_packaging.rst
+++ b/lib/spack/docs/tutorial_advanced_packaging.rst
@@ -423,7 +423,7 @@ If you had modifications to ``run_env``, those would have appeared e.g. in the m
 generated for the package.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Set variables in dependencies at build-time
+Set environment variables in dependents at build-time
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Another common occurrence, particularly for packages like ``r`` and ``python``


### PR DESCRIPTION
So far most edits are organization. One section was removed. 

* Remove the section "What happens at subscript time?" - this is overly-detailed for the tutorial (perhaps it should move somewhere @alalazo do you have a thought on where?)
* Move the sections "Extra query parameters" and "Attach attributes to other packages" into the section group "Other Packaging Topics". The goal was to organize so that the following sections (considered most interesting) come first:
  * A motivating example (`cmake_args` using `.libs` and implementation of `netlib-lapack.lapack_libs`)
  * Single package providing multiple virtual specs
  * Set environment variables in dependent packages at build-time (updated section title)
  * Set environment variables in your own package (updated section title)
* Updated section title "Set environment variables in your own package" to start with `qt` as an example: it sets the build environment and the run environment. Include `elpa` example after that.

TODOs:

- [x] The section "Set environment variables in dependent packages at build-time" was reordered before "Set environment variables in your own package" but I still need to update the introductions
- [x] additional title rewording (e.g. "Package's build environment")
- [x] reword the section "Spec's build interface"
