### PR TITLE
scotch%intel: remove restrict

### DIFF
--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -159,7 +159,7 @@ class Scotch(Package):
         if self.compiler.name == 'gcc':
             cflags.append('-Drestrict=__restrict')
         elif self.compiler.name == 'intel':
-            cflags.append('-restrict')
+            cflags.append('-Drestrict=')
 
         mpicc_path = self.spec['mpi'].mpicc if '+mpi' in self.spec else 'mpicc'
         makefile_inc.append('CCS       = $(CC)')


### PR DESCRIPTION
The restrict compilation option with icc causes deadlock when multithreading is used. This issue has already been reported to the Scotch development team, but for current versions it is more reliable not to use the restrict compilation option.