### PR TITLE
Add ignore_conflicts to package activation

### DIFF
--- a/lib/spack/spack/cmd/activate.py
+++ b/lib/spack/spack/cmd/activate.py
@@ -35,6 +35,9 @@ level = "long"
 
 def setup_parser(subparser):
     subparser.add_argument(
+        '-f', '--force', action='store_true',
+        help="activate without first activating dependencies")
+    subparser.add_argument(
         '-v', '--view', metavar='VIEW', type=str,
         help="the view to operate on")
     subparser.add_argument(
@@ -58,4 +61,5 @@ def activate(parser, args):
     if spec.package.is_activated(extensions_layout=layout):
         tty.die("Package %s is already activated." % specs[0].short_spec)
 
-    spec.package.do_activate(extensions_layout=layout)
+    spec.package.do_activate(extensions_layout=layout,
+                             with_dependencies=not args.force)

--- a/lib/spack/spack/cmd/activate.py
+++ b/lib/spack/spack/cmd/activate.py
@@ -35,9 +35,6 @@ level = "long"
 
 def setup_parser(subparser):
     subparser.add_argument(
-        '-f', '--force', action='store_true',
-        help="activate without first activating dependencies")
-    subparser.add_argument(
         '-v', '--view', metavar='VIEW', type=str,
         help="the view to operate on")
     subparser.add_argument(

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -94,7 +94,7 @@ class FilesystemView(object):
 
     def add_extension(self, spec):
         """
-            Add (link) an extension in this view.
+            Add (link) an extension in this view. Does not add dependencies.
         """
         raise NotImplementedError
 
@@ -228,6 +228,9 @@ class YamlFilesystemView(FilesystemView):
         try:
             if not spec.package.is_activated(self.extensions_layout):
                 spec.package.do_activate(
+                    ignore_conflicts=self.ignore_conflicts,
+                    with_dependencies=False,  # already taken care of
+                                              # in add_specs()
                     verbose=self.verbose,
                     extensions_layout=self.extensions_layout)
 


### PR DESCRIPTION
includes:
* with_dependency flag for do_activate
* ignore_conflicts flag for do_activate
* start of cleanup of activate cmd

@scheibelp this is the commit that I was talking in #7159 about. I didn't have much time to look at it again, so take my comments with some care.

Essentially this delegates the ignore-conflicts stuff to `package.activate` and removes the `--force` flag. It also delegates the dependency resolution to the view generator and not on the single extension (this prevents double adding, but feels somewhat hacky).

Feel free to comment and point out errors