### PR TITLE
Fix pkgconf on Crays

### DIFF
--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -108,6 +108,9 @@ class Cray(Platform):
         if os.path.isdir(cray_wrapper_names):
             env.prepend_path('PATH', cray_wrapper_names)
             env.prepend_path('SPACK_ENV_PATH', cray_wrapper_names)
+        # Makes spack installed pkg-config work on Crays
+        env.append_path("PKG_CONFIG_PATH", "/usr/lib64/pkgconfig")
+        env.append_path("PKG_CONFIG_PATH", "/usr/local/lib64/pkgconfig")
 
     @classmethod
     def detect(cls):

--- a/var/spack/repos/builtin/packages/pkg-config/package.py
+++ b/var/spack/repos/builtin/packages/pkg-config/package.py
@@ -53,11 +53,6 @@ class PkgConfig(AutotoolsPackage):
         Adds the ACLOCAL path for autotools."""
         spack_env.append_path('ACLOCAL_PATH',
                               join_path(self.prefix.share, 'aclocal'))
-        if 'platform=cray' in self.spec:
-            spack_env.append_path('PKG_CONFIG_PATH',
-                                  '/usr/lib64/pkgconfig')
-            spack_env.append_path('PKG_CONFIG_PATH',
-                                  '/usr/local/lib64/pkgconfig')
 
     def configure_args(self):
         config_args = ['--enable-shared']

--- a/var/spack/repos/builtin/packages/pkgconf/package.py
+++ b/var/spack/repos/builtin/packages/pkgconf/package.py
@@ -40,12 +40,6 @@ class Pkgconf(AutotoolsPackage):
 
     provides('pkgconfig')
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        if 'platform=cray' in self.spec:
-            spack_env.append_path('PKG_CONFIG_PATH', '/usr/lib64/pkgconfig')
-            spack_env.append_path('PKG_CONFIG_PATH',
-                                  '/usr/local/lib64/pkgconfig')
-
     @run_after('install')
     def link_pkg_config(self):
         symlink('pkgconf', '{0}/pkg-config'.format(self.prefix.bin))

--- a/var/spack/repos/builtin/packages/pkgconf/package.py
+++ b/var/spack/repos/builtin/packages/pkgconf/package.py
@@ -40,6 +40,15 @@ class Pkgconf(AutotoolsPackage):
 
     provides('pkgconfig')
 
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        #  Is this required for other systems?
+        #  spack_env.append_path("ACLOCAL_PATH",
+                              #  join_path(self.prefix.share, "aclocal"))
+        if 'platform=cray' in self.spec:
+            spack_env.append_path('PKG_CONFIG_PATH', '/usr/lib64/pkgconfig')
+            spack_env.append_path('PKG_CONFIG_PATH',
+                                  '/usr/local/lib64/pkgconfig')
+
     @run_after('install')
     def link_pkg_config(self):
         symlink('pkgconf', '{0}/pkg-config'.format(self.prefix.bin))

--- a/var/spack/repos/builtin/packages/pkgconf/package.py
+++ b/var/spack/repos/builtin/packages/pkgconf/package.py
@@ -41,9 +41,6 @@ class Pkgconf(AutotoolsPackage):
     provides('pkgconfig')
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        #  Is this required for other systems?
-        #  spack_env.append_path("ACLOCAL_PATH",
-                              #  join_path(self.prefix.share, "aclocal"))
         if 'platform=cray' in self.spec:
             spack_env.append_path('PKG_CONFIG_PATH', '/usr/lib64/pkgconfig')
             spack_env.append_path('PKG_CONFIG_PATH',


### PR DESCRIPTION
Was breaking on Cray machines because it did not include the cray
pkgconfig paths. This adds the same lines from pkg-config to pkgconf.

Apologies for the sin of copy pasted code but since it's only two lines I think it's okay.

I'm also not sure if we need to add AC_LOCAL_PATH as well. It works on Crays without it.