### PR TITLE
Catch NameErrors in module generation

### DIFF
--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -505,7 +505,7 @@ class BaseContext(tengine.Context):
             try:
                 configure_args = getattr(pkg, attr)()
                 return ' '.join(configure_args)
-            except (AttributeError, IOError, KeyError):
+            except (AttributeError, IOError, KeyError, NameError):
                 # The method doesn't exist in the current spec,
                 # or it's not usable
                 pass


### PR DESCRIPTION
Module generation catches a few types of errors in configure_args. This PR adds NameError to that list. This catches errors due to fields populated by setup_package being unavailable at module generation time.