### PR TITLE
petsc: explicitly use python('configure', ...)

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -248,7 +248,7 @@ class Petsc(Package):
                 '--with-superlu_dist=0'
             )
 
-        configure('--prefix=%s' % prefix, *options)
+        python('configure', '--prefix=%s' % prefix, *options)
 
         # PETSc has its own way of doing parallel make.
         make('MAKE_NP=%s' % make_jobs, parallel=False)


### PR DESCRIPTION
This ensures that PETSc configure is invoked using the specified
python@2.6:2.8 (Spack uses "python2") rather than whatever "python" is
found in the environment (might be 2 or 3).