### PR TITLE
libtool: actually do symlinking correctly on darwin

### DIFF
--- a/var/spack/repos/builtin/packages/libtool/package.py
+++ b/var/spack/repos/builtin/packages/libtool/package.py
@@ -56,13 +56,15 @@ class Libtool(AutotoolsPackage):
         for name in executables:
             setattr(module, name, self._make_executable(name))
 
-    @when('platform=darwin')
-    def configure_args(self):
+    @run_after('install')
+    def post_install(self):
         # Some platforms name GNU libtool and GNU libtoolize
         # 'glibtool' and 'glibtoolize', respectively, to differentiate
         # them from BSD libtool and BSD libtoolize. On these BSD
         # platforms, build systems sometimes expect to use the assumed
         # GNU commands glibtool and glibtoolize instead of the BSD
         # variant; this happens frequently, for instance, on Darwin
-        args = ['--program-prefix=g']
-        return args
+        symlink(join_path(self.prefix.bin, 'libtool'),
+                join_path(self.prefix.bin, 'glibtool'))
+        symlink(join_path(self.prefix.bin, 'libtoolize'),
+                join_path(self.prefix.bin, 'glibtoolize'))


### PR DESCRIPTION
Version 4 of the libtool/darwin debacle:

`AutotoolsPackage` hardcodes `libtool` & `libtoolize` into the `autoreconf`
stage, so the commands `libtool` and `libtoolize` MUST be present, and
shimming in `glibtoolize` into `AutotoolsPackage` when `sys.platfrom ==
'darwin'` does not work.

`join_path(spec['libtool'].prefix.bin, 'libtool')` still shadows system
BSD libtool (in `apple-cctools`, see PR #7177), but this shadowing could
be okay, depending on the combination of dependent specs.

Should fix #7140, and hopefully partially address raised in #7172. 