### PR TITLE
sosflow: add missing dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/sosflow/package.py
+++ b/var/spack/repos/builtin/packages/sosflow/package.py
@@ -37,6 +37,8 @@ class Sosflow(CMakePackage):
 
     depends_on('libevpath')
     depends_on('sqlite@3:')
+    depends_on('pkgconfig')
+    depends_on('mpi')
 
     def setup_environment(self, spack_env, run_env):
         spack_env.set('SOS_HOST_KNOWN_AS', 'SPACK-SOS-BUILD')


### PR DESCRIPTION
SOSflow depends on MPI and pkg-config, but neither of these
dependencies are currently in the spack package, so this commit adds
them.