### PR TITLE
Add cmor version 3.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/cmor/package.py
+++ b/var/spack/repos/builtin/packages/cmor/package.py
@@ -34,6 +34,7 @@ class Cmor(AutotoolsPackage):
     homepage = "http://cmor.llnl.gov"
     url = "https://github.com/PCMDI/cmor/archive/3.1.2.tar.gz"
 
+    version('3.3.0', 'cfdeeddab1aedb823e26ec38723bd67e')
     version('3.2.0', 'b48105105d4261012c19cd65e89ff7a6')
     version('3.1.2', '72f7227159c901e4bcf80d2c73a8ce77')
 
@@ -43,7 +44,7 @@ class Cmor(AutotoolsPackage):
     depends_on('uuid')
     depends_on('netcdf')
     depends_on('udunits2')
-    depends_on('hdf5@:1.8')
+    depends_on('hdf5@:1.8.19')
 
     extends('python', when='+python')
     depends_on('python@:2.8', when='+python')


### PR DESCRIPTION
# Description 

This adds version `3.3.0` of package cmor and fixes a dependency issue. 

The dependency of hdf5 is changed because of a conflict it created together with the dependency of netcdf (which is also a dep for cmor). Before the change the dependency was like this: 

cmor depends on hdf5<1.8
cmor depends on netcdf
netcdf depends on hdf5>1.8.9

So this could not be resolved. The exact error was:

```
$ spack install cmor
==> Error: Invalid Version range: 1.8.9:1.8
```

I am not sure if my change is ok. Let me know. 

Also, the error message would be more helpful if it would include the package name. In this case it was easy to spot it, but in cases where there are lots of dependencies it may be trickier. I don't know if this is something worth looking into. 