### PR TITLE
Fix for building METIS 4.0.3 with '~shared'.

### DIFF
--- a/var/spack/repos/builtin/packages/metis/package.py
+++ b/var/spack/repos/builtin/packages/metis/package.py
@@ -100,7 +100,9 @@ class Metis(Package):
     @when('@:4')
     def install(self, spec, prefix):
         # Process library spec and options
-        options = ['COPTIONS={0}'.format(self.compiler.pic_flag)]
+        options = []
+        if '+shared' in spec:
+            options.append('COPTIONS={0}'.format(self.compiler.pic_flag))
         if spec.variants['build_type'].value == 'Debug':
             options.append('OPTFLAGS=-g -O0')
         make(*options)
@@ -144,8 +146,8 @@ class Metis(Package):
 
         # Set up and run tests on installation
         ccompile('-I%s' % prefix.include, '-L%s' % prefix.lib,
-                 self.compiler.cc_rpath_arg +
-                 '%s' % (prefix.lib if '+shared' in spec else ''),
+                 (self.compiler.cc_rpath_arg + prefix.lib
+                  if '+shared' in spec else ''),
                  join_path('Programs', 'io.o'), join_path('Test', 'mtest.c'),
                  '-o', '%s/mtest' % prefix.bin, '-lmetis', '-lm')
 


### PR DESCRIPTION
Fix for installing `metis@4.0.3~shared`.