### PR TITLE
New Package: jchronoss

### DIFF
--- a/var/spack/repos/builtin/packages/jchronoss/package.py
+++ b/var/spack/repos/builtin/packages/jchronoss/package.py
@@ -1,0 +1,76 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install jchronoss
+#
+# You can edit this file again by typing:
+#
+#     spack edit jchronoss
+#
+# See the Spack documentation for more information on packaging.
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+from spack import *
+
+
+class Jchronoss(CMakePackage):
+    """ JCHRONOSS aims to help HPC application testing process to scale as much as the application does. """
+
+    # FIXME: Add a proper url for your package's homepage here.
+    homepage = "http://jchronoss.hpcframework.com"
+    url      = "http://fs.paratools.com/mpc/contrib/apps/jchronoss/JCHRONOSS-1.2.tar.gz"
+
+    version('1.2',   'f083ca453537e4f60ad17d266bbab1f1')
+    version('1.1.1', '2d78a0998efec20e7726af19fff76a72')
+    version('1.1',   'a8ba0b21b18548874b8ab2a6ca6e1081')
+    version('1.0',   '78d81e00248e21f4adea4a1ccfd6156b')
+
+    variant("realtime", default=False, description="Enable Real-Time support")
+    variant("openmp", default=False, description="Enable OpenMP constructs")
+    variant("ncurses", default=False, description="Enable ncurses-based tool")
+    variant('color', default=False, description='Enable colour-themed output')
+
+    depends_on("libxml2")
+    depends_on("libwebsockets", when="+realtime")
+    depends_on("libev", when="+realtime")
+
+    def cmake_args(self):
+        args = ["-DSPACK_DRIVEN=ON"]
+        
+        if '+color' in self.spec:
+            args.append("-DENABLE_COLOR=yes")
+        if '+openmp' in self.spec:
+            args.append("-DENABLE_OPENMP=yes")
+        if '+ncurses' in self.spec:
+            args.append("-DENABLE_PLUGIN_NCURSES=yes")
+        if '+realtime' in self.spec:
+            args.append("-DENABLE_PLUGIN_SERVER=yes")
+
+        return args

--- a/var/spack/repos/builtin/packages/jchronoss/package.py
+++ b/var/spack/repos/builtin/packages/jchronoss/package.py
@@ -22,23 +22,8 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install jchronoss
-#
-# You can edit this file again by typing:
-#
-#     spack edit jchronoss
-#
-# See the Spack documentation for more information on packaging.
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
 
 from spack import *
-
 
 class Jchronoss(CMakePackage):
     """ JCHRONOSS aims to help HPC application testing process

--- a/var/spack/repos/builtin/packages/jchronoss/package.py
+++ b/var/spack/repos/builtin/packages/jchronoss/package.py
@@ -25,6 +25,7 @@
 
 from spack import *
 
+
 class Jchronoss(CMakePackage):
     """ JCHRONOSS aims to help HPC application testing process
      to scale as much as the application does. """

--- a/var/spack/repos/builtin/packages/jchronoss/package.py
+++ b/var/spack/repos/builtin/packages/jchronoss/package.py
@@ -36,7 +36,7 @@
 # See the Spack documentation for more information on packaging.
 # If you submit this package back to Spack as a pull request,
 # please first remove this boilerplate and all FIXME comments.
-#
+
 from spack import *
 
 
@@ -44,7 +44,6 @@ class Jchronoss(CMakePackage):
     """ JCHRONOSS aims to help HPC application testing process
      to scale as much as the application does. """
 
-    # FIXME: Add a proper url for your package's homepage here.
     homepage = "http://jchronoss.hpcframework.com"
     url      = "http://fs.paratools.com/mpc/contrib/apps/jchronoss/JCHRONOSS-1.2.tar.gz"
 
@@ -61,6 +60,7 @@ class Jchronoss(CMakePackage):
     depends_on("libxml2")
     depends_on("libwebsockets", when="+realtime")
     depends_on("libev", when="+realtime")
+    depends_on("ncurses", when="+ncurses")
 
     def cmake_args(self):
         args = ["-DSPACK_DRIVEN=ON"]

--- a/var/spack/repos/builtin/packages/jchronoss/package.py
+++ b/var/spack/repos/builtin/packages/jchronoss/package.py
@@ -41,7 +41,8 @@ from spack import *
 
 
 class Jchronoss(CMakePackage):
-    """ JCHRONOSS aims to help HPC application testing process to scale as much as the application does. """
+    """ JCHRONOSS aims to help HPC application testing process
+     to scale as much as the application does. """
 
     # FIXME: Add a proper url for your package's homepage here.
     homepage = "http://jchronoss.hpcframework.com"
@@ -63,7 +64,7 @@ class Jchronoss(CMakePackage):
 
     def cmake_args(self):
         args = ["-DSPACK_DRIVEN=ON"]
-        
+
         if '+color' in self.spec:
             args.append("-DENABLE_COLOR=yes")
         if '+openmp' in self.spec:


### PR DESCRIPTION
JCHRONOSS is a validation process, designed to scale in HPC environments, to increase time to test result.
This tool is aware of cluster users & admins, to adapt the workload according to needs, to keep in mind the shortest time between coding and validating step.

The software is compliant with batch managers like SLURM or Torque and can produce multiple output format (JSON, JUNIT, YAML,...) that can then be directly uploaded in any reporting platform (like Jenkins). When people can't have a fully-integrated reviewing interface, JCHRONOSS provides a lightweight result viewer, to check results trends without leaving the cluster.

You can find Doxygen-based documentation and more information on the website: [http://jchronoss.hpcframework.com](http://jchronoss.hpcframework.com)

Please let me know about any issue about this pull-request.
Thanks.