### PR TITLE
Improve the Spack command reference 

### DIFF
--- a/lib/spack/docs/command_index.in
+++ b/lib/spack/docs/command_index.in
@@ -1,9 +1,9 @@
-=============
-Command Index
-=============
+=================
+Command Reference
+=================
 
-This is an alphabetical list of commands with links to the places they
-appear in the documentation.
+This is a reference for all commands in the Spack command line interface.
+The same information is available through :ref:`spack-help`.
 
-.. hlist::
-   :columns: 3
+Commands that also have sections in the main documentation have a link to
+"More documentation".

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -163,7 +163,7 @@ compilers`` or ``spack compiler list``:
 Any of these compilers can be used to build Spack packages.  More on
 how this is done is in :ref:`sec-specs`.
 
-.. _spack-compiler-add:
+.. _cmd-spack-compiler-add:
 
 ^^^^^^^^^^^^^^^^^^^^^^
 ``spack compiler add``
@@ -171,7 +171,7 @@ how this is done is in :ref:`sec-specs`.
 
 An alias for ``spack compiler find``.
 
-.. _spack-compiler-find:
+.. _cmd-spack-compiler-find:
 
 ^^^^^^^^^^^^^^^^^^^^^^^
 ``spack compiler find``
@@ -202,7 +202,7 @@ installed, but you know that new compilers have been added to your
 This loads the environment module for gcc-4.9.0 to add it to
 ``PATH``, and then it adds the compiler to Spack.
 
-.. _spack-compiler-info:
+.. _cmd-spack-compiler-info:
 
 ^^^^^^^^^^^^^^^^^^^^^^^
 ``spack compiler info``

--- a/lib/spack/docs/mirrors.rst
+++ b/lib/spack/docs/mirrors.rst
@@ -69,7 +69,7 @@ packages from the internet and checksumming them.
 The other three commands are for managing mirror configuration.  They
 control the URL(s) from which Spack downloads its packages.
 
-.. _spack-mirror-create:
+.. _cmd-spack-mirror-create:
 
 -----------------------
 ``spack mirror create``
@@ -154,7 +154,7 @@ can supply a file with specs in it, one per line:
 This is useful if there is a specific suite of software managed by
 your site.
 
-.. _spack-mirror-add:
+.. _cmd-spack-mirror-add:
 
 --------------------
 ``spack mirror add``
@@ -182,7 +182,7 @@ You can tell your Spack installation to use that mirror like this:
 
 Each mirror has a name so that you can refer to it again later.
 
-.. _spack-mirror-list:
+.. _cmd-spack-mirror-list:
 
 ---------------------
 ``spack mirror list``
@@ -195,7 +195,7 @@ To see all the mirrors Spack knows about, run ``spack mirror list``:
    $ spack mirror list
    local_filesystem    file://~/spack-mirror-2014-06-24
 
-.. _spack-mirror-remove:
+.. _cmd-spack-mirror-remove:
 
 -----------------------
 ``spack mirror remove``

--- a/lib/spack/external/argparse.py
+++ b/lib/spack/external/argparse.py
@@ -356,8 +356,6 @@ class HelpFormatter(object):
                 pos_usage = format(positionals, groups)
                 opt_parts = _re.findall(part_regexp, opt_usage)
                 pos_parts = _re.findall(part_regexp, pos_usage)
-                assert ' '.join(opt_parts) == opt_usage
-                assert ' '.join(pos_parts) == pos_usage
 
                 # helper for wrapping lines
                 def get_lines(parts, indent, prefix=None):

--- a/lib/spack/llnl/util/argparsewriter.py
+++ b/lib/spack/llnl/util/argparsewriter.py
@@ -1,0 +1,222 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from __future__ import print_function
+import re
+import argparse
+import errno
+import sys
+
+
+class ArgparseWriter(object):
+    """Analyzes an argparse ArgumentParser for easy generation of help."""
+    def __init__(self):
+        self.level = 0
+
+    def _write(self, parser, root=True, level=0):
+        self.parser = parser
+        self.level = level
+        actions = parser._actions
+
+        # allow root level to be flattened with rest of commands
+        if type(root) == int:
+            self.level = root
+            root = True
+
+        # go through actions and split them into optionals, positionals,
+        # and subcommands
+        optionals = []
+        positionals = []
+        subcommands = []
+        for action in actions:
+            if action.option_strings:
+                optionals.append(action)
+            elif isinstance(action, argparse._SubParsersAction):
+                for subaction in action._choices_actions:
+                    subparser = action._name_parser_map[subaction.dest]
+                    subcommands.append(subparser)
+            else:
+                positionals.append(action)
+
+        groups = parser._mutually_exclusive_groups
+        fmt = parser._get_formatter()
+        description = parser.description
+
+        def action_group(function, actions):
+            for action in actions:
+                arg = fmt._format_action_invocation(action)
+                help = action.help if action.help else ''
+                function(arg, re.sub('\n', ' ', help))
+
+        if root:
+            self.begin_command(parser.prog)
+
+            if description:
+                self.description(parser.description)
+
+            usage = fmt._format_usage(None, actions, groups, '').strip()
+            self.usage(usage)
+
+            if positionals:
+                self.begin_positionals()
+                action_group(self.positional, positionals)
+                self.end_positionals()
+
+            if optionals:
+                self.begin_optionals()
+                action_group(self.optional, optionals)
+                self.end_optionals()
+
+        if subcommands:
+            self.begin_subcommands(subcommands)
+            for subparser in subcommands:
+                self._write(subparser, root=True, level=level + 1)
+            self.end_subcommands(subcommands)
+
+        if root:
+            self.end_command(parser.prog)
+
+    def write(self, parser, root=True):
+        """Write out details about an ArgumentParser.
+
+        Args:
+            parser (ArgumentParser): an ``argparse`` parser
+            root (bool or int): if bool, whether to include the root parser;
+                or ``1`` to flatten the root parser with first-level
+                subcommands
+        """
+        try:
+            self._write(parser, root, level=0)
+        except IOError as e:
+            # swallow pipe errors
+            if e.errno != errno.EPIPE:
+                raise
+
+    def begin_command(self, prog):
+        pass
+
+    def end_command(self, prog):
+        pass
+
+    def description(self, description):
+        pass
+
+    def usage(self, usage):
+        pass
+
+    def begin_positionals(self):
+        pass
+
+    def positional(self, name, help):
+        pass
+
+    def end_positionals(self):
+        pass
+
+    def begin_optionals(self):
+        pass
+
+    def optional(self, option, help):
+        pass
+
+    def end_optionals(self):
+        pass
+
+    def begin_subcommands(self, subcommands):
+        pass
+
+    def end_subcommands(self, subcommands):
+        pass
+
+
+_rst_levels = ['=', '-', '^', '~', ':', '`']
+
+
+class ArgparseRstWriter(ArgparseWriter):
+    """Write argparse output as rst sections."""
+
+    def __init__(self, out=sys.stdout, rst_levels=_rst_levels,
+                 strip_root_prog=True):
+        """Create a new ArgparseRstWriter.
+
+        Args:
+            out (file object): file to write to
+            rst_levels (list of str): list of characters
+                for rst section headings
+            strip_root_prog (bool): if ``True``, strip the base command name
+                from subcommands in output
+        """
+        super(ArgparseWriter, self).__init__()
+        self.out = out
+        self.rst_levels = rst_levels
+        self.strip_root_prog = strip_root_prog
+
+    def line(self, string=''):
+        self.out.write('%s\n' % string)
+
+    def begin_command(self, prog):
+        self.line()
+        self.line('----')
+        self.line()
+        self.line('.. _%s:\n' % prog.replace(' ', '-'))
+        self.line('%s' % prog)
+        self.line(self.rst_levels[self.level] * len(prog) + '\n')
+
+    def description(self, description):
+        self.line('%s\n' % description)
+
+    def usage(self, usage):
+        self.line('.. code-block:: console\n')
+        self.line('    %s\n' % usage)
+
+    def begin_positionals(self):
+        self.line()
+        self.line('**Positional arguments**\n')
+
+    def positional(self, name, help):
+        self.line(name)
+        self.line('  %s\n' % help)
+
+    def begin_optionals(self):
+        self.line()
+        self.line('**Optional arguments**\n')
+
+    def optional(self, opts, help):
+        self.line('``%s``' % opts)
+        self.line('  %s\n' % help)
+
+    def begin_subcommands(self, subcommands):
+        self.line()
+        self.line('**Subcommands**\n')
+        self.line('.. hlist::')
+        self.line('   :columns: 4\n')
+
+        for cmd in subcommands:
+            prog = cmd.prog
+            if self.strip_root_prog:
+                prog = re.sub(r'^[^ ]* ', '', prog)
+
+            self.line('   * :ref:`%s <%s>`'
+                      % (prog, cmd.prog.replace(' ', '-')))
+        self.line()

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -45,6 +45,7 @@ import spack.store
 # Commands that modify configuration by default modify the *highest*
 # priority scope.
 default_modify_scope = spack.config.highest_precedence_scope().name
+
 # Commands that list configuration list *all* scopes by default.
 default_list_scope = None
 
@@ -60,7 +61,7 @@ DESCRIPTION = "description"
 command_path = os.path.join(spack.lib_path, "spack", "cmd")
 
 #: Names of all commands
-commands = []
+all_commands = []
 
 
 def python_name(cmd_name):
@@ -76,8 +77,8 @@ def cmd_name(python_name):
 for file in os.listdir(command_path):
     if file.endswith(".py") and not re.search(ignore_files, file):
         cmd = re.sub(r'.py$', '', file)
-        commands.append(cmd_name(cmd))
-commands.sort()
+        all_commands.append(cmd_name(cmd))
+all_commands.sort()
 
 
 def remove_options(parser, *options):

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -35,7 +35,7 @@ level = "long"
 def setup_parser(subparser):
     subparser.add_argument(
         '-j', '--jobs', action='store', type=int,
-        help="explicitly set number of make jobs. default is #cpus")
+        help="explicitly set number of make jobs (default: #cpus)")
     subparser.add_argument(
         '--keep-prefix', action='store_true', dest='keep_prefix',
         help="don't remove the install prefix if installation fails")

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -34,8 +34,8 @@ from spack.binary_distribution import NoOverwriteException, NoGpgException
 from spack.binary_distribution import NoKeyException, PickKeyException
 from spack.binary_distribution import NoVerifyException, NoChecksumException
 
-description = "Create, download and install build cache files."
-section = "caching"
+description = "create, download and install binary packages"
+section = "packaging"
 level = "long"
 
 
@@ -43,7 +43,7 @@ def setup_parser(subparser):
     setup_parser.parser = subparser
     subparsers = subparser.add_subparsers(help='buildcache sub-commands')
 
-    create = subparsers.add_parser('create')
+    create = subparsers.add_parser('create', help=createtarball.__doc__)
     create.add_argument('-r', '--rel', action='store_true',
                         help="make all rpaths relative" +
                              " before creating tarballs.")
@@ -63,7 +63,7 @@ def setup_parser(subparser):
         help="specs of packages to create buildcache for")
     create.set_defaults(func=createtarball)
 
-    install = subparsers.add_parser('install')
+    install = subparsers.add_parser('install', help=installtarball.__doc__)
     install.add_argument('-f', '--force', action='store_true',
                          help="overwrite install directory if it exists.")
     install.add_argument('-y', '--yes-to-all', action='store_true',
@@ -74,7 +74,7 @@ def setup_parser(subparser):
         help="specs of packages to install biuldache for")
     install.set_defaults(func=installtarball)
 
-    listcache = subparsers.add_parser('list')
+    listcache = subparsers.add_parser('list', help=listspecs.__doc__)
     listcache.add_argument('-f', '--force', action='store_true',
                            help="force new download of specs")
     listcache.add_argument(
@@ -82,7 +82,7 @@ def setup_parser(subparser):
         help="specs of packages to search for")
     listcache.set_defaults(func=listspecs)
 
-    dlkeys = subparsers.add_parser('keys')
+    dlkeys = subparsers.add_parser('keys', help=getkeys.__doc__)
     dlkeys.add_argument(
         '-i', '--install', action='store_true',
         help="install Keys pulled from mirror")
@@ -179,6 +179,7 @@ def match_downloaded_specs(pkgs, allow_multiple_matches=False, force=False):
 
 
 def createtarball(args):
+    """create a binary package from an existing install"""
     if not args.packages:
         tty.die("build cache file creation requires at least one" +
                 " installed package argument")
@@ -240,6 +241,7 @@ def createtarball(args):
 
 
 def installtarball(args):
+    """install from a binary package"""
     if not args.packages:
         tty.die("build cache file installation requires" +
                 " at least one package spec argument")
@@ -296,6 +298,7 @@ def install_tarball(spec, args):
 
 
 def listspecs(args):
+    """list binary packages available from mirrors"""
     specs = bindist.get_specs(args.force)
     if args.packages:
         pkgs = set(args.packages)
@@ -318,6 +321,7 @@ def listspecs(args):
 
 
 def getkeys(args):
+    """get public keys available on mirrors"""
     install = False
     if args.install:
         install = True

--- a/lib/spack/spack/cmd/commands.py
+++ b/lib/spack/spack/cmd/commands.py
@@ -1,0 +1,142 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from __future__ import print_function
+
+import sys
+import re
+import argparse
+
+from llnl.util.argparsewriter import ArgparseWriter, ArgparseRstWriter
+
+import spack.main
+from spack.main import section_descriptions
+
+
+description = "list available spack commands"
+section = "developer"
+level = "long"
+
+
+#: list of command formatters
+formatters = {}
+
+
+def formatter(func):
+    """Decorator used to register formatters"""
+    formatters[func.__name__] = func
+    return func
+
+
+def setup_parser(subparser):
+    subparser.add_argument(
+        '--format', default='names', choices=formatters,
+        help='format to be used to print the output (default: names)')
+    subparser.add_argument(
+        'documented_commands', nargs=argparse.REMAINDER,
+        help='list of documented commands to cross-references')
+
+
+class SpackArgparseRstWriter(ArgparseRstWriter):
+    """RST writer tailored for spack documentation."""
+
+    def __init__(self, documented_commands, out=sys.stdout):
+        super(SpackArgparseRstWriter, self).__init__(out)
+        self.documented = documented_commands if documented_commands else []
+
+    def usage(self, *args):
+        super(SpackArgparseRstWriter, self).usage(*args)
+        cmd = re.sub(' ', '-', self.parser.prog)
+        if cmd in self.documented:
+            self.line()
+            self.line(':ref:`More documentation <cmd-%s>`' % cmd)
+
+
+class SubcommandWriter(ArgparseWriter):
+    def begin_command(self, prog):
+        print('    ' * self.level + prog)
+
+
+@formatter
+def subcommands(args):
+    parser = spack.main.make_argument_parser()
+    spack.main.add_all_commands(parser)
+    SubcommandWriter().write(parser)
+
+
+def rst_index(out=sys.stdout):
+    out.write('\n')
+
+    index = spack.main.index_commands()
+    sections = index['long']
+
+    dmax = max(len(section_descriptions.get(s, s)) for s in sections) + 2
+    cmax = max(len(c) for _, c in sections.items()) + 60
+
+    row = "%s  %s\n" % ('=' * dmax, '=' * cmax)
+    line = '%%-%ds  %%s\n' % dmax
+
+    out.write(row)
+    out.write(line % (" Category ", " Commands "))
+    out.write(row)
+    for section, commands in sorted(sections.items()):
+        description = section_descriptions.get(section, section)
+
+        for i, cmd in enumerate(sorted(commands)):
+            description = description.capitalize() if i == 0 else ''
+            ref = ':ref:`%s <spack-%s>`' % (cmd, cmd)
+            comma = ',' if i != len(commands) - 1 else ''
+            bar = '| ' if i % 8 == 0 else '  '
+            out.write(line % (description, bar + ref + comma))
+    out.write(row)
+
+
+@formatter
+def rst(args):
+    # print an index to each command
+    rst_index()
+    print()
+
+    # create a parser with all commands
+    parser = spack.main.make_argument_parser()
+    spack.main.add_all_commands(parser)
+
+    # get documented commands from the command line
+    documented_commands = set(args.documented_commands)
+
+    # print sections for each command and subcommand
+    SpackArgparseRstWriter(documented_commands).write(parser, root=1)
+
+
+@formatter
+def names(args):
+    for cmd in spack.cmd.all_commands:
+        print(cmd)
+
+
+def commands(parser, args):
+
+    # Print to stdout
+    formatters[args.format](args)
+    return

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -54,7 +54,8 @@ def setup_parser(subparser):
         help='search the system for compilers to add to Spack configuration')
     find_parser.add_argument('add_paths', nargs=argparse.REMAINDER)
     find_parser.add_argument(
-        '--scope', choices=scopes, default=spack.cmd.default_modify_scope,
+        '--scope', choices=scopes, metavar=spack.config.scopes_metavar,
+        default=spack.cmd.default_modify_scope,
         help="configuration scope to modify")
 
     # Remove
@@ -65,20 +66,23 @@ def setup_parser(subparser):
         help='remove ALL compilers that match spec')
     remove_parser.add_argument('compiler_spec')
     remove_parser.add_argument(
-        '--scope', choices=scopes, default=spack.cmd.default_modify_scope,
+        '--scope', choices=scopes, metavar=spack.config.scopes_metavar,
+        default=spack.cmd.default_modify_scope,
         help="configuration scope to modify")
 
     # List
     list_parser = sp.add_parser('list', help='list available compilers')
     list_parser.add_argument(
-        '--scope', choices=scopes, default=spack.cmd.default_list_scope,
+        '--scope', choices=scopes, metavar=spack.config.scopes_metavar,
+        default=spack.cmd.default_list_scope,
         help="configuration scope to read from")
 
     # Info
     info_parser = sp.add_parser('info', help='show compiler paths')
     info_parser.add_argument('compiler_spec')
     info_parser.add_argument(
-        '--scope', choices=scopes, default=spack.cmd.default_list_scope,
+        '--scope', choices=scopes, metavar=spack.config.scopes_metavar,
+        default=spack.cmd.default_list_scope,
         help="configuration scope to read from")
 
 

--- a/lib/spack/spack/cmd/compilers.py
+++ b/lib/spack/spack/cmd/compilers.py
@@ -31,8 +31,10 @@ level = "short"
 
 
 def setup_parser(subparser):
-    subparser.add_argument('--scope', choices=spack.config.config_scopes,
-                           help="configuration scope to read/modify")
+    scopes = spack.config.config_scopes
+    subparser.add_argument(
+        '--scope', choices=scopes, metavar=spack.config.scopes_metavar,
+        help="configuration scope to read/modify")
 
 
 def compilers(parser, args):

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -31,8 +31,10 @@ level = "long"
 
 def setup_parser(subparser):
     # User can only choose one
-    subparser.add_argument('--scope', choices=spack.config.config_scopes,
-                           help="configuration scope to read/modify")
+    subparser.add_argument(
+        '--scope', choices=spack.config.config_scopes,
+        metavar=spack.config.scopes_metavar,
+        help="configuration scope to read/modify")
 
     sp = subparser.add_subparsers(metavar='SUBCOMMAND', dest='config_command')
 

--- a/lib/spack/spack/cmd/diy.py
+++ b/lib/spack/spack/cmd/diy.py
@@ -34,7 +34,7 @@ import spack.cmd.common.arguments as arguments
 from spack.stage import DIYStage
 
 description = "do-it-yourself: build from an existing source directory"
-section = "developer"
+section = "build"
 level = "long"
 
 

--- a/lib/spack/spack/cmd/flake8.py
+++ b/lib/spack/spack/cmd/flake8.py
@@ -226,7 +226,7 @@ def setup_parser(subparser):
         help="send filtered files to stdout as well as temp files")
     subparser.add_argument(
         '-r', '--root-relative', action='store_true', default=False,
-        help="print root-relative paths (default is cwd-relative)")
+        help="print root-relative paths (default: cwd-relative)")
     subparser.add_argument(
         '-U', '--no-untracked', dest='untracked', action='store_false',
         default=True, help="exclude untracked files from checks")

--- a/lib/spack/spack/cmd/gpg.py
+++ b/lib/spack/spack/cmd/gpg.py
@@ -28,7 +28,7 @@ import spack
 import os
 
 description = "handle GPG actions for spack"
-section = "developer"
+section = "packaging"
 level = "long"
 
 

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -56,7 +56,7 @@ the dependencies"""
     )
     subparser.add_argument(
         '-j', '--jobs', action='store', type=int,
-        help="explicitly set number of make jobs. default is #cpus")
+        help="explicitly set number of make jobs (default: #cpus)")
     subparser.add_argument(
         '--overwrite', action='store_true',
         help="reinstall an existing spec, even if it has dependents")

--- a/lib/spack/spack/cmd/log_parse.py
+++ b/lib/spack/spack/cmd/log_parse.py
@@ -49,8 +49,8 @@ def setup_parser(subparser):
         help="wrap width: auto-size to terminal by default; 0 for no wrap")
     subparser.add_argument(
         '-j', '--jobs', action='store', type=int, default=None,
-        help="number of jobs to parse log file; default is 1 for short logs, "
-        "ncpus for long logs")
+        help="number of jobs to parse log file (default: 1 for short logs, "
+        "ncpus for long logs)")
 
     subparser.add_argument(
         'file', help="a log file containing build output, or - for stdin")

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -75,7 +75,8 @@ def setup_parser(subparser):
     add_parser.add_argument(
         'url', help="url of mirror directory from 'spack mirror create'")
     add_parser.add_argument(
-        '--scope', choices=scopes, default=spack.cmd.default_modify_scope,
+        '--scope', choices=scopes, metavar=spack.config.scopes_metavar,
+        default=spack.cmd.default_modify_scope,
         help="configuration scope to modify")
 
     # Remove
@@ -83,13 +84,15 @@ def setup_parser(subparser):
                                   help=mirror_remove.__doc__)
     remove_parser.add_argument('name')
     remove_parser.add_argument(
-        '--scope', choices=scopes, default=spack.cmd.default_modify_scope,
+        '--scope', choices=scopes, metavar=spack.config.scopes_metavar,
+        default=spack.cmd.default_modify_scope,
         help="configuration scope to modify")
 
     # List
     list_parser = sp.add_parser('list', help=mirror_list.__doc__)
     list_parser.add_argument(
-        '--scope', choices=scopes, default=spack.cmd.default_list_scope,
+        '--scope', choices=scopes, metavar=spack.config.scopes_metavar,
+        default=spack.cmd.default_list_scope,
         help="configuration scope to read from")
 
 

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -52,7 +52,8 @@ def setup_parser(subparser):
     # List
     list_parser = sp.add_parser('list', help=repo_list.__doc__)
     list_parser.add_argument(
-        '--scope', choices=scopes, default=spack.cmd.default_list_scope,
+        '--scope', choices=scopes, metavar=spack.config.scopes_metavar,
+        default=spack.cmd.default_list_scope,
         help="configuration scope to read from")
 
     # Add
@@ -60,7 +61,8 @@ def setup_parser(subparser):
     add_parser.add_argument(
         'path', help="path to a Spack package repository directory")
     add_parser.add_argument(
-        '--scope', choices=scopes, default=spack.cmd.default_modify_scope,
+        '--scope', choices=scopes, metavar=spack.config.scopes_metavar,
+        default=spack.cmd.default_modify_scope,
         help="configuration scope to modify")
 
     # Remove
@@ -70,7 +72,8 @@ def setup_parser(subparser):
         'path_or_namespace',
         help="path or namespace of a Spack package repository")
     remove_parser.add_argument(
-        '--scope', choices=scopes, default=spack.cmd.default_modify_scope,
+        '--scope', choices=scopes, metavar=spack.config.scopes_metavar,
+        default=spack.cmd.default_modify_scope,
         help="configuration scope to modify")
 
 

--- a/lib/spack/spack/cmd/setup.py
+++ b/lib/spack/spack/cmd/setup.py
@@ -39,7 +39,7 @@ from spack import which
 from spack.stage import DIYStage
 
 description = "create a configuration script and module, but don't build"
-section = "developer"
+section = "build"
 level = "long"
 
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -88,6 +88,10 @@ section_schemas = {
 #: Later scopes will override earlier scopes.
 config_scopes = OrderedDict()
 
+#: metavar to use for commands that accept scopes
+#: this is shorter and more readable than listing all choices
+scopes_metavar = '{defaults,system,site,user}[/PLATFORM]'
+
 
 def validate_section_name(section):
     """Exit if the section is not a valid section."""

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -278,7 +278,7 @@ def make_argument_parser():
                         help="show this help message and exit")
     parser.add_argument('--color', action='store', default='auto',
                         choices=('always', 'never', 'auto'),
-                        help="when to colorize output; default is auto")
+                        help="when to colorize output (default: auto)")
     parser.add_argument('-d', '--debug', action='store_true',
                         help="write out debug logs during compile")
     parser.add_argument('-D', '--pdb', action='store_true',
@@ -294,7 +294,7 @@ def make_argument_parser():
                         help="profile and sort by one or more of:\n[%s]" %
                         ',\n '.join([', '.join(line) for line in stat_lines]))
     parser.add_argument('--lines', default=20, action='store',
-                        help="lines of profile output; default 20; or 'all'")
+                        help="lines of profile output or 'all' (default: 20)")
     parser.add_argument('-v', '--verbose', action='store_true',
                         help="print additional output during builds")
     parser.add_argument('-s', '--stacktrace', action='store_true',

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -80,7 +80,8 @@ section_descriptions = {
 section_order = {
     'basic': ['list', 'info', 'find'],
     'build': ['fetch', 'stage', 'patch', 'configure', 'build', 'restage',
-              'install', 'uninstall', 'clean']
+              'install', 'uninstall', 'clean'],
+    'packaging': ['create', 'edit']
 }
 
 # Properties that commands are required to set.

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -30,6 +30,7 @@ after the system path is set up.
 from __future__ import print_function
 
 import sys
+import re
 import os
 import inspect
 import pstats
@@ -127,6 +128,22 @@ def index_commands():
     return index
 
 
+class SpackHelpFormatter(argparse.RawTextHelpFormatter):
+    def _format_actions_usage(self, actions, groups):
+        """Formatter with more concise usage strings."""
+        usage = super(
+            SpackHelpFormatter, self)._format_actions_usage(actions, groups)
+
+        # compress single-character flags that are not mutually exclusive
+        # at the beginning of the usage string
+        chars = ''.join(re.findall(r'\[-(.)\]', usage))
+        usage = re.sub(r'\[-.\] ?', '', usage)
+        if chars:
+            return '[-%s] %s' % (chars, usage)
+        else:
+            return usage
+
+
 class SpackArgumentParser(argparse.ArgumentParser):
     def format_help_sections(self, level):
         """Format help on sections for a particular verbosity level.
@@ -182,14 +199,11 @@ class SpackArgumentParser(argparse.ArgumentParser):
             new_actions = [opts[letter] for letter in show_options]
             self._optionals._group_actions = new_actions
 
-        options = ''.join(opt.option_strings[0].strip('-')
-                          for opt in self._optionals._group_actions)
-
-        index = index_commands()
-
-        # usage
-        formatter.add_text(
-            "usage: %s [-%s] <command> [...]" % (self.prog, options))
+        # custom, more concise usage for top level
+        help_options = self._optionals._group_actions
+        help_options = help_options + [self._positionals._group_actions[-1]]
+        formatter.add_usage(
+            self.usage, help_options, self._mutually_exclusive_groups)
 
         # description
         formatter.add_text(self.description)
@@ -198,7 +212,9 @@ class SpackArgumentParser(argparse.ArgumentParser):
         formatter.add_text(intro_by_level[level])
 
         # add argument groups based on metadata in commands
+        index = index_commands()
         sections = index[level]
+
         for section in sorted(sections):
             if section == 'help':
                 continue   # Cover help in the epilog.
@@ -235,6 +251,18 @@ class SpackArgumentParser(argparse.ArgumentParser):
         # determine help from format above
         return formatter.format_help()
 
+    def add_subparsers(self, **kwargs):
+        """Ensure that sensible defaults are propagated to subparsers"""
+        kwargs.setdefault('metavar', 'SUBCOMMAND')
+        sp = super(SpackArgumentParser, self).add_subparsers(**kwargs)
+        old_add_parser = sp.add_parser
+
+        def add_parser(name, **kwargs):
+            kwargs.setdefault('formatter_class', SpackHelpFormatter)
+            return old_add_parser(name, **kwargs)
+        sp.add_parser = add_parser
+        return sp
+
     def add_command(self, cmd_name):
         """Add one subcommand to this parser."""
         # lazily initialize any subparsers
@@ -263,13 +291,14 @@ class SpackArgumentParser(argparse.ArgumentParser):
             return super(SpackArgumentParser, self).format_help()
 
 
-def make_argument_parser():
+def make_argument_parser(**kwargs):
     """Create an basic argument parser without any subcommands added."""
     parser = SpackArgumentParser(
-        formatter_class=argparse.RawTextHelpFormatter, add_help=False,
+        formatter_class=SpackHelpFormatter, add_help=False,
         description=(
             "A flexible package manager that supports multiple versions,\n"
-            "configurations, platforms, and compilers."))
+            "configurations, platforms, and compilers."),
+        **kwargs)
 
     # stat names in groups of 7, for nice wrapping.
     stat_lines = list(zip(*(iter(stat_names),) * 7))

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -100,14 +100,14 @@ def set_working_dir():
 
 def add_all_commands(parser):
     """Add all spack subcommands to the parser."""
-    for cmd in spack.cmd.commands:
+    for cmd in spack.cmd.all_commands:
         parser.add_command(cmd)
 
 
 def index_commands():
     """create an index of commands by section for this help level"""
     index = {}
-    for command in spack.cmd.commands:
+    for command in spack.cmd.all_commands:
         cmd_module = spack.cmd.get_module(command)
 
         # make sure command modules have required properties
@@ -166,7 +166,7 @@ class SpackArgumentParser(argparse.ArgumentParser):
             self.actions = self._subparsers._actions[-1]._get_subactions()
 
         # make a set of commands not yet added.
-        remaining = set(spack.cmd.commands)
+        remaining = set(spack.cmd.all_commands)
 
         def add_group(group):
             formatter.start_section(group.title)

--- a/lib/spack/spack/test/cmd/commands.py
+++ b/lib/spack/spack/test/cmd/commands.py
@@ -1,0 +1,70 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+import re
+
+from llnl.util.argparsewriter import ArgparseWriter
+
+import spack.cmd
+import spack.main
+from spack.main import SpackCommand
+
+commands = SpackCommand('commands')
+
+parser = spack.main.make_argument_parser()
+spack.main.add_all_commands(parser)
+
+
+def test_commands_by_name():
+    """Test default output of spack commands."""
+    out = commands()
+    assert out.strip().split('\n') == sorted(spack.cmd.all_commands)
+
+
+def test_subcommands():
+    """Test subcommand traversal."""
+    out = commands('--format=subcommands')
+    assert 'spack mirror create' in out
+    assert 'spack buildcache list' in out
+    assert 'spack repo add' in out
+    assert 'spack pkg diff' in out
+    assert 'spack url parse' in out
+    assert 'spack view symlink' in out
+
+    class Subcommands(ArgparseWriter):
+        def begin_command(self, prog):
+            assert prog in out
+
+    Subcommands().write(parser)
+
+
+def test_rst():
+    """Do some simple sanity checks of the rst writer."""
+    out = commands('--format=rst')
+
+    class Subcommands(ArgparseWriter):
+        def begin_command(self, prog):
+            assert prog in out
+            assert re.sub(r' ', '-', prog) in out
+    Subcommands().write(parser)


### PR DESCRIPTION
This improves the command reference in the docs. Previously, the command reference listed only commands for which we explicitly wrote documentation.  Now it lists all Spack commands and shows their usage.  This was sort of inspired by the [Docker CLI reference](https://docs.docker.com/engine/reference/commandline/docker/).

This also contains a number of improvements to `spack <cmd> -h` output.

- [x] Add a `spack commands` command to list commands in various formats (including RST)
- [x] Rework the docs to use `spack commands` to generate the command reference. Docs now have an index by type of command and show full usage.
- [x] Add proper help for `spack buildcache` subcommands
- [x] Fix some bugs with `spack -h` argument display
- [x] Display options in help output as `[-abc]`, not `[-a] [-b] [-c]`
- [x] Clean up the metavar for `--scope` arguments in configuration commands like `mirror`, `repo`, etc. (it's now much shorter)

You can [look at a preview here](https://spack.readthedocs.io/en/features-better-command-index/command_index.html).

@JusticeForMikeBrown: you might like this, as it would've saved you a few issue submissions.