### PR TITLE
Use python3.6 to test building docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
       language: python
       env: TEST_SUITE=flake8
     - stage: 'flake8 + documentation'
-      python: '2.7'
+      python: '3.6'
       os: linux
       language: python
       env: TEST_SUITE=doc


### PR DESCRIPTION
I think the main issue here is that we ship a custom version of a system library (`argparse`), and this is prone to fail if `argparse` is imported before we hack `sys.path` internally.

Probably a better solution would be not to customize argparse, but instead have a wrapper on top of whatever the system provides.