### PR TITLE
[bugfix] ipopt: fix lmod global name 'prefix' undefined bug

### DIFF
--- a/var/spack/repos/builtin/packages/ipopt/package.py
+++ b/var/spack/repos/builtin/packages/ipopt/package.py
@@ -78,7 +78,7 @@ class Ipopt(AutotoolsPackage):
         lapack_lib = spec['lapack'].libs.ld_flags
 
         args = [
-            "--prefix=%s" % prefix,
+            "--prefix=%s" % self.prefix,
             "--with-mumps-incdir=%s" % mumps_dir.include,
             "--with-mumps-lib=%s" % mumps_libcmd,
             "--enable-shared",


### PR DESCRIPTION
Running `spack module refresh -m lmod --delete-tree -y` throws the
following warning:

```console
==> Warning: Could not write module file [/Users/oxberry1/spack/share/spack/lmod/darwin-sierra-x86_64/openblas/0.2.20-ibhtl5q/clang/5.0.1/ipopt/3.12.9.lua]
==> Warning:    --> global name 'prefix' is not defined <--
```

This warning arises because the variable expansions in
`spack.modules.BaseFileWriter` occur at module/package scope. Even
though `prefix` is an argument to `install` methods in e.g.,
`MakefilePackage`, so using this argument within package methods is
legal, doing so defeats the introspection logic in
`spack.modules.BaseFileWriter`. Replacing `prefix` with `self.prefix`
resolves the problem, because the introspection logic in
`spack.modules.BaseFileWriter` can use introspection to query IPOPT's
prefix.