### PR TITLE
[bugfix] gdbm: fix lmod global name 'spack_cc' undefined

### DIFF
--- a/var/spack/repos/builtin/packages/gdbm/package.py
+++ b/var/spack/repos/builtin/packages/gdbm/package.py
@@ -45,10 +45,12 @@ class Gdbm(AutotoolsPackage):
 
     depends_on("readline")
 
+    def setup_environment(self, spack_env, run_env):
+        spack_env.set('CC', spack_cc)
+
     def configure_args(self):
         config_args = [
             '--enable-libgdbm-compat',
-            'CC=%s' % spack_cc
         ]
 
         return config_args


### PR DESCRIPTION
Prior to this commit, running `spack module refresh` with `gdbm`
installed throws the warning:

```console
==> Warning: Could not write module file [/Users/oxberry1/spack/share/spack/lmod/darwin-sierra-x86_64/Core/gdbm/1.14.1.lua]
==> Warning:    --> global name 'spack_cc' is not defined <--
```

This warning is repeated for every `gdbm` installation in Spack.

The cause of the issue seems to be the same as in spack/spack (#6089):
using `spack_cc`, `spack_cxx`, or similar inside `configure_args`
causes the warnings to throw when module files are generated.

Moving the use of `spack_cc` into `setup_environment` seems to fix the
problem, even though it's a bit of a kludge.

I've tested this commit both on my MacBook Pro with clang@8.1.0-apple and gcc@7.3.0, and on RHEL 7 with intel@16.0.3 (which uses gcc@4.9.3), and #5892 does not recur (it is still fixed).