### PR TITLE
Remove pmi from the fabric list.

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -280,7 +280,7 @@ class Openmpi(AutotoolsPackage):
         return line
 
     def with_or_without_schedulers(self, activated):
-        spec  = self.spec
+        spec = self.spec
         opts = []
 
         for x in ['alps', 'lsf', 'tm', 'sge', 'loadleveler']:

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -288,7 +288,8 @@ class Openmpi(AutotoolsPackage):
                 opts.append('--with-{0}'.format(x))
 
         if 'schedulers=slurm' in spec:
-            if self.spec.satisfies('@1.5.4:'): # PMI support was added in 1.5.5
+            # PMI support was added in 1.5.5
+            if self.spec.satisfies('@1.5.4:'):
                 # See how SLURM and OpenMPI work together
                 # https://www.open-mpi.org/faq/?category=slurm
                 # https://slurm.schedmd.com/mpi_guide.html#open_mpi

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -215,6 +215,8 @@ class Openmpi(AutotoolsPackage):
     conflicts('fabrics=psm2', when='@:1.8')  # PSM2 support was added in 1.10.0
     conflicts('fabrics=mxm', when='@:1.5.3')  # MXM support was added in 1.5.4
     conflicts('+pmi', when='@:1.5.4')  # PMI support was added in 1.5.5
+    conflicts('schedulers=slurm ~pmi', when='@1.5.4:',
+              msg='+pmi is required for openmpi(>=1.5.5) to work with SLURM.')
 
     def url_for_version(self, version):
         url = "http://www.open-mpi.org/software/ompi/v{0}/downloads/openmpi-{1}.tar.bz2"
@@ -280,20 +282,6 @@ class Openmpi(AutotoolsPackage):
         if (path is not None):
             line += '={0}'.format(path)
         return line
-
-    def with_or_without_slurm(self, activated):
-        # PMI and SLURM
-        # https://www.open-mpi.org/faq/?category=slurm
-        # https://slurm.schedmd.com/mpi_guide.html#open_mpi
-        # TODO: Add PMIx support for openmpi(>2.0.0)
-        spec = self.spec
-        if not activated:
-            return '--without-slurm'
-        elif spec.satisfies('@1.5.4:') and '+pmi' not in spec:
-            raise SpackError(
-                "+pmi is required for openmpi(>=1.5.5) to work with SLURM.")
-        else:
-            return '--with-slurm'
 
     @run_before('autoreconf')
     def die_without_fortran(self):

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -197,7 +197,7 @@ class Openmpi(AutotoolsPackage):
             description='Enable MPI_THREAD_MULTIPLE support')
     variant('cuda', default=False, description='Enable CUDA support')
     variant('ucx', default=False, description='Enable UCX support')
-    variant('pmi', default=False, description='Enable Process Management Interface support')
+    variant('pmi', default=False, description='Enable PMI support')
 
     provides('mpi')
     provides('mpi@:2.2', when='@1.6.5')
@@ -285,10 +285,13 @@ class Openmpi(AutotoolsPackage):
         # https://www.open-mpi.org/faq/?category=slurm
         # https://slurm.schedmd.com/mpi_guide.html#open_mpi
         # TODO: Add PMIx support for openmpi(>2.0.0)
+        version = self.version
+        spec = self.spec
         if not activated:
             return '--without-slurm'
-        elif activated and self.version >= Version('1.5.5') and '+pmi' not in self.spec:
-            raise SpackError("+pmi is required for openmpi(>1.5.5) to work with SLURM.")
+        elif activated and version >= Version('1.5.5') and '+pmi' not in spec:
+            raise SpackError(
+                "+pmi is required for openmpi(>1.5.5) to work with SLURM.")
         else:
             return '--with-slurm'
 

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -26,7 +26,6 @@
 import os
 
 from spack import *
-from spack.error import SpackError
 
 
 def _verbs_dir():

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -26,6 +26,7 @@
 import os
 
 from spack import *
+from spack.error import SpackError
 
 
 def _verbs_dir():

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -1,4 +1,4 @@
-#############################################################################
+##############################################################################
 # Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.
 #

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -1,4 +1,4 @@
-##############################################################################
+#############################################################################
 # Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.
 #
@@ -197,6 +197,7 @@ class Openmpi(AutotoolsPackage):
             description='Enable MPI_THREAD_MULTIPLE support')
     variant('cuda', default=False, description='Enable CUDA support')
     variant('ucx', default=False, description='Enable UCX support')
+    variant('pmi', default=False, description='Enable Process Management Interface support')
 
     provides('mpi')
     provides('mpi@:2.2', when='@1.6.5')
@@ -211,8 +212,8 @@ class Openmpi(AutotoolsPackage):
 
     conflicts('+cuda', when='@:1.6')  # CUDA support was added in 1.7
     conflicts('fabrics=psm2', when='@:1.8')  # PSM2 support was added in 1.10.0
-    conflicts('fabrics=pmi', when='@:1.5.4')  # PMI support was added in 1.5.5
     conflicts('fabrics=mxm', when='@:1.5.3')  # MXM support was added in 1.5.4
+    conflicts('+pmi', when='@:1.5.4')  # PMI support was added in 1.5.5
 
     def url_for_version(self, version):
         url = "http://www.open-mpi.org/software/ompi/v{0}/downloads/openmpi-{1}.tar.bz2"
@@ -279,26 +280,17 @@ class Openmpi(AutotoolsPackage):
             line += '={0}'.format(path)
         return line
 
-    def with_or_without_schedulers(self, activated):
-        spec = self.spec
-        opts = []
-
-        for x in ['alps', 'lsf', 'tm', 'sge', 'loadleveler']:
-            if 'schedulers={0}'.format(x) in spec:
-                opts.append('--with-{0}'.format(x))
-
-        if 'schedulers=slurm' in spec:
-            # PMI support was added in 1.5.5
-            if self.spec.satisfies('@1.5.4:'):
-                # See how SLURM and OpenMPI work together
-                # https://www.open-mpi.org/faq/?category=slurm
-                # https://slurm.schedmd.com/mpi_guide.html#open_mpi
-                # TODO: Add PMIx support since OpenMPI 2.0
-                opts.append('--with-slurm')
-                opts.append('--with-pmi')
-            else:
-                opts.append('--with-slurm')
-        return opts
+    def with_or_without_slurm(self, activated):
+        # PMI and SLURM
+        # https://www.open-mpi.org/faq/?category=slurm
+        # https://slurm.schedmd.com/mpi_guide.html#open_mpi
+        # TODO: Add PMIx support for openmpi(>2.0.0)
+        if not activated:
+            return '--without-slurm'
+        elif activated and self.version >= Version('1.5.5') and '+pmi' not in self.spec:
+            raise SpackError("+pmi is required for openmpi(>1.5.5) to work with SLURM.")
+        else:
+            return '--with-slurm'
 
     @run_before('autoreconf')
     def die_without_fortran(self):
@@ -320,9 +312,12 @@ class Openmpi(AutotoolsPackage):
             # for Open-MPI 2.0:, C++ bindings are disabled by default.
             config_args.extend(['--enable-mpi-cxx'])
 
-        # Fabrics and schedulers
+        # Fabrics
         config_args.extend(self.with_or_without('fabrics'))
+        # Schedulers
         config_args.extend(self.with_or_without('schedulers'))
+        # PMI
+        config_args.extend(self.with_or_without('pmi'))
 
         # Hwloc support
         if spec.satisfies('@1.5.2:'):

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -285,13 +285,11 @@ class Openmpi(AutotoolsPackage):
         # https://www.open-mpi.org/faq/?category=slurm
         # https://slurm.schedmd.com/mpi_guide.html#open_mpi
         # TODO: Add PMIx support for openmpi(>2.0.0)
-        version = self.version
-        spec = self.spec
         if not activated:
             return '--without-slurm'
-        elif activated and version >= Version('1.5.5') and '+pmi' not in spec:
+        elif self.stisfies('@1.5.4:') and '+pmi' not in self.spec:
             raise SpackError(
-                "+pmi is required for openmpi(>1.5.5) to work with SLURM.")
+                "+pmi is required for openmpi(>=1.5.5) to work with SLURM.")
         else:
             return '--with-slurm'
 

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -285,9 +285,10 @@ class Openmpi(AutotoolsPackage):
         # https://www.open-mpi.org/faq/?category=slurm
         # https://slurm.schedmd.com/mpi_guide.html#open_mpi
         # TODO: Add PMIx support for openmpi(>2.0.0)
+        spec = self.spec
         if not activated:
             return '--without-slurm'
-        elif self.satisfies('@1.5.4:') and '+pmi' not in self.spec:
+        elif spec.satisfies('@1.5.4:') and '+pmi' not in spec:
             raise SpackError(
                 "+pmi is required for openmpi(>=1.5.5) to work with SLURM.")
         else:

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -287,7 +287,7 @@ class Openmpi(AutotoolsPackage):
         # TODO: Add PMIx support for openmpi(>2.0.0)
         if not activated:
             return '--without-slurm'
-        elif self.stisfies('@1.5.4:') and '+pmi' not in self.spec:
+        elif self.satisfies('@1.5.4:') and '+pmi' not in self.spec:
             raise SpackError(
                 "+pmi is required for openmpi(>=1.5.5) to work with SLURM.")
         else:


### PR DESCRIPTION
This commit intents to:

1. Remove `pmi` from the `fabrics` list since Process Manager Interface is not a fabric.
2. Add configuration flags `--with-slurm --with-pmi` for OpenMPI (>1.5.4) when `schedulers=slurm` is specified.