### PR TITLE
xbraid: add libs method

### DIFF
--- a/var/spack/repos/builtin/packages/xbraid/package.py
+++ b/var/spack/repos/builtin/packages/xbraid/package.py
@@ -66,3 +66,8 @@ class Xbraid(MakefilePackage):
         install_tree('test', prefix.share.test)
         install_tree('user_utils', prefix.share.user_utils)
         install_tree('docs', prefix.share.docs)
+
+    @property
+    def libs(self):
+        return find_libraries('libbraid', root=self.prefix,
+                              shared=False, recursive=True)


### PR DESCRIPTION
XBraid installs `libbraid.a`, but the default `libs` method
implementation will search for `libxbraid`, which does not exist. This
commit fixes the behavior of the `libs` method for the `xbraid`
package by overriding package's `libs` method.