### PR TITLE
hypre: add libs method

### DIFF
--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -109,3 +109,9 @@ class Hypre(Package):
                 sstruct('-in', 'test/sstruct.in.default', '-solver', '40',
                         '-rhsone')
             make("install")
+
+    @property
+    def libs(self):
+        is_shared = self.spec.satisfies('+shared')
+        return find_libraries('libHYPRE', root=self.prefix,
+                              shared=is_shared, recursive=True)


### PR DESCRIPTION
Add a libs method to `hypre` to override the default `libs` method
behavior, which will not locate hypre's libraries. Add linkage to
LAPACK & BLAS as recommended in #7165.