### PR TITLE
cbench set its environment using `setup_environment`

### DIFF
--- a/var/spack/repos/builtin/packages/cbench/package.py
+++ b/var/spack/repos/builtin/packages/cbench/package.py
@@ -50,27 +50,27 @@ class Cbench(MakefilePackage):
     conflicts('%xl')
     conflicts('%xl_r')
 
-    def edit(self, spec, prefix):
+    def setup_environment(self, build_env, run_env):
         # The location of the Cbench source tree
-        env['CBENCHOME'] = self.stage.source_path
+        build_env.set('CBENCHOME', self.stage.source_path)
 
         # The location that will contain all of your tests and their results
-        env['CBENCHTEST'] = prefix
+        build_env.set('CBENCHTEST', self.prefix)
 
         # The location of the system MPI tree
-        env['MPIHOME'] = spec['mpi'].prefix
+        build_env.set('MPIHOME', self.spec['mpi'].prefix)
 
         # Pick the compiler collection/chain you want to compile with.
         # Examples include: intel, gcc, pgi.
-        env['COMPILERCOLLECTION'] = self.compiler.name
+        build_env.set('COMPILERCOLLECTION', self.compiler.name)
 
         # Linking flags for BLAS/LAPACK and FFTW
-        env['BLASLIB']   = spec['blas'].libs.ld_flags
-        env['LAPACKLIB'] = spec['lapack'].libs.ld_flags
-        env['FFTWLIB']   = spec['fftw'].libs.ld_flags
+        build_env.set('BLASLIB', self.spec['blas'].libs.ld_flags)
+        build_env.set('LAPACKLIB', self.spec['lapack'].libs.ld_flags)
+        build_env.set('FFTWLIB', self.spec['fftw'].libs.ld_flags)
 
         # The number of make jobs (commands) to run simultaneously
-        env['JOBS'] = str(make_jobs)
+        build_env.set('JOBS', str(make_jobs))
 
     @run_before('build')
     @on_package_attributes(run_tests=True)


### PR DESCRIPTION
The edit phase of `cbench` was used to set environment variables. Though this works, the variables set this way are not dumped to `build.env`. This commit fixes the issue by setting those variables in the
`setup_environment` function.