### PR TITLE
cube: Fix qt detection

### DIFF
--- a/var/spack/repos/builtin/packages/cube/package.py
+++ b/var/spack/repos/builtin/packages/cube/package.py
@@ -44,6 +44,8 @@ class Cube(AutotoolsPackage):
 
     variant('gui', default=False, description='Build CUBE GUI')
 
+    patch('qt-version.patch', when='@4.3.0:4.3.999 +gui')
+
     depends_on('zlib')
 
     depends_on('qt@5:', when='@4.3.0:4.3.999 +gui')

--- a/var/spack/repos/builtin/packages/cube/qt-version.patch
+++ b/var/spack/repos/builtin/packages/cube/qt-version.patch
@@ -1,0 +1,24 @@
+diff -ruw cube-4.3.5.orig/build-backend/configure cube-4.3.5/build-backend/configure
+--- cube-4.3.5.orig/build-backend/configure	2017-05-23 13:15:46.121704000 +0200
++++ cube-4.3.5/build-backend/configure	2018-02-14 15:07:27.313842086 +0100
+@@ -5589,7 +5589,7 @@
+ else
+   echo "$as_me:$LINENO: Running $QMAKE --version:" >&5
+   $QMAKE --version >&5 2>&1
+-  qmake_version_sed='/^.*Qt.version.\([0-9]\.[0-9]\.[0-9]\).in.*$/!d;s//\1/'
++  qmake_version_sed='/^.*Qt.version.\([0-9]\.[0-9]\+\.[0-9]\+\).in.*$/!d;s//\1/'
+   at_cv_QT_VERSION=`$QMAKE --version 2>&1 | sed "$qmake_version_sed"`
+ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $at_cv_QT_VERSION" >&5
+diff -ruw cube-4.3.5.orig/build-frontend/configure cube-4.3.5/build-frontend/configure
+--- cube-4.3.5.orig/build-frontend/configure	2017-05-23 13:16:00.499773000 +0200
++++ cube-4.3.5/build-frontend/configure	2018-02-14 15:07:46.349487111 +0100
+@@ -19757,7 +19757,7 @@
+ else
+   echo "$as_me:$LINENO: Running $QMAKE --version:" >&5
+   $QMAKE --version >&5 2>&1
+-  qmake_version_sed='/^.*Qt.version.\([0-9]\.[0-9]\.[0-9]\).in.*$/!d;s//\1/'
++  qmake_version_sed='/^.*Qt.version.\([0-9]\.[0-9]\+\.[0-9]\+\).in.*$/!d;s//\1/'
+   at_cv_QT_VERSION=`$QMAKE --version 2>&1 | sed "$qmake_version_sed"`
+ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $at_cv_QT_VERSION" >&5


### PR DESCRIPTION
cube's configure only recognizes qt versions with single digit version components and breaks with qt 5.10. Patch the configure files directly to avoid having to regenerate them.