### PR TITLE
likwid: Fix build

### DIFF
--- a/var/spack/repos/builtin/packages/likwid/package.py
+++ b/var/spack/repos/builtin/packages/likwid/package.py
@@ -24,6 +24,7 @@
 ##############################################################################
 from spack import *
 import glob
+import os
 
 
 class Likwid(Package):
@@ -105,5 +106,6 @@ class Likwid(Package):
                             spec['lua'].prefix.bin),
                         'config.mk')
 
+        env['PWD'] = os.getcwd()
         make()
         make('install')


### PR DESCRIPTION
likwid uses the current directory when building the paths to its internal libraries. Spack overwrites `PWD`, causing likwid to not find `hwloc.h`.

Does it make sense to fix Spack to not overwrite `PWD`? I found at least one more package where this seems to be a problem (cp2k).