### PR TITLE
mfem+dependencies update

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -698,6 +698,19 @@ def _headers_default_handler(descriptor, spec, cls):
         raise RuntimeError(msg.format(spec.name, spec.prefix.include))
 
 
+def _all_headers_default_handler(descriptor, spec, cls):
+    """Default handler when looking for the 'all_headers' attribute.
+
+       The default behavior is to combine the 'headers' attributes of spec and
+       all its dependencies.
+    """
+    headers = spec.headers
+    # Use the link dependencies to define the header dependencies.
+    for dep in spec.dependencies(deptype='link'):
+        headers += spec[dep.name].headers
+    return headers
+
+
 def _libs_default_handler(descriptor, spec, cls):
     """Default handler when looking for the 'libs' attribute.
 
@@ -754,6 +767,18 @@ def _libs_default_handler(descriptor, spec, cls):
     else:
         msg = 'Unable to recursively locate {0} libraries in {1}'
         raise RuntimeError(msg.format(spec.name, spec.prefix))
+
+
+def _all_libs_default_handler(descriptor, spec, cls):
+    """Default handler when looking for the 'all_libs' attribute.
+
+       The default behavior is to combine the 'libs' attributes of spec and
+       all its dependencies.
+    """
+    libs = spec.libs
+    for dep in spec.dependencies(deptype='link'):
+        libs += spec[dep.name].libs
+    return libs
 
 
 class ForwardQueryToPackage(object):
@@ -860,9 +885,19 @@ class SpecBuildInterface(ObjectWrapper):
         default_handler=_headers_default_handler
     )
 
+    all_headers = ForwardQueryToPackage(
+        'all_headers',
+        default_handler=_all_headers_default_handler
+    )
+
     libs = ForwardQueryToPackage(
         'libs',
         default_handler=_libs_default_handler
+    )
+
+    all_libs = ForwardQueryToPackage(
+        'all_libs',
+        default_handler=_all_libs_default_handler
     )
 
     def __init__(self, spec, name, query_parameters):

--- a/var/spack/repos/builtin/packages/gnutls/package.py
+++ b/var/spack/repos/builtin/packages/gnutls/package.py
@@ -88,3 +88,11 @@ class Gnutls(AutotoolsPackage):
             ])
 
         return args
+
+    @property
+    def headers(self):
+        # GnuTLS headers are located inside prefix.include.gnutls and included
+        # as <gnutls/gnutls.h>, so we return a fake header in prefix.include.
+        hdr = find(self.prefix.include.gnutls, 'gnutls.h', recursive=False)
+        return HeaderList(join_path(self.prefix.include, 'fake.h')) if hdr \
+               else None

--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -111,7 +111,19 @@ class Hypre(Package):
             make("install")
 
     @property
+    def headers(self):
+        """Export the main hypre header, HYPRE.h; all other headers can be found
+        in the same directory.
+        Sample usage: spec['hypre'].headers.cpp_flags
+        """
+        hdrs = HeaderList(find(self.prefix.include, 'HYPRE.h', recursive=False))
+        return hdrs or None
+
+    @property
     def libs(self):
-        is_shared = self.spec.satisfies('+shared')
-        return find_libraries('libHYPRE', root=self.prefix,
-                              shared=is_shared, recursive=True)
+        """Export the hypre library.
+        Sample usage: spec['hypre'].libs.ld_flags
+        """
+        libs = find_libraries('libHYPRE', root=self.prefix.lib,
+                              shared=('+shared' in self.spec), recursive=False)
+        return libs or None

--- a/var/spack/repos/builtin/packages/laghos/package.py
+++ b/var/spack/repos/builtin/packages/laghos/package.py
@@ -40,8 +40,12 @@ class Laghos(MakefilePackage):
     version('1.0', '4c091e115883c79bed81c557ef16baff')
     version('develop', git=git, branch='master')
 
-    depends_on('mpi')
-    depends_on('mfem@laghos-v1.0', when='@1.0')
+    variant('metis', default=True, description='Enable/disable METIS support')
+
+    depends_on('mfem@develop+mpi+metis', when='@develop+metis')
+    depends_on('mfem@develop+mpi~metis', when='@develop~metis')
+    depends_on('mfem@3.3.1-laghos-v1.0+mpi+metis', when='@1.0+metis')
+    depends_on('mfem@3.3.1-laghos-v1.0+mpi~metis', when='@1.0~metis')
 
     @property
     def build_targets(self):
@@ -49,10 +53,8 @@ class Laghos(MakefilePackage):
         spec = self.spec
 
         targets.append('MFEM_DIR=%s' % spec['mfem'].prefix)
-        targets.append('CONFIG_MK=%s' % join_path(spec['mfem'].prefix,
-                       'share/mfem/config.mk'))
-        targets.append('TEST_MK=%s' % join_path(spec['mfem'].prefix,
-                       'share/mfem/test.mk'))
+        targets.append('CONFIG_MK=%s' % spec['mfem'].package.config_mk)
+        targets.append('TEST_MK=%s' % spec['mfem'].package.test_mk)
         targets.append('CXX=%s' % spec['mpi'].mpicxx)
 
         return targets

--- a/var/spack/repos/builtin/packages/libunwind/package.py
+++ b/var/spack/repos/builtin/packages/libunwind/package.py
@@ -23,6 +23,8 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+import sys
+import os
 
 
 class Libunwind(AutotoolsPackage):
@@ -32,3 +34,22 @@ class Libunwind(AutotoolsPackage):
     url      = "http://download.savannah.gnu.org/releases/libunwind/libunwind-1.1.tar.gz"
 
     version('1.1', 'fb4ea2f6fbbe45bf032cd36e586883ce')
+
+    # On Darwin, libunwind is available without any additional include paths and
+    # libraries. In order to support that, we allow configuring libunwind as an
+    # extrnal library with a prefix that does not exist.
+
+    @property
+    def headers(self):
+        if sys.platform == 'darwin' and not os.access(self.prefix, os.F_OK):
+            return HeaderList([])
+        return HeaderList(find(self.prefix.include, 'libunwind.h',
+                               recursive=False)) or None
+
+    @property
+    def libs(self):
+        if sys.platform == 'darwin' and not os.access(self.prefix, os.F_OK):
+            return LibraryList([])
+        return find_libraries('libunwind', root=self.prefix.lib,
+                              shared=('+shared' in self.spec), recursive=False)\
+               or None

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -22,7 +22,8 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-import re
+import os
+import sys
 from spack import *
 
 
@@ -31,6 +32,9 @@ class Mfem(Package):
 
     homepage = 'http://www.mfem.org'
     url      = 'https://github.com/mfem/mfem'
+
+    maintainers = ['goxberry', 'tzanio', 'markcmiller86', 'acfisher',
+                   'v-dobrev']
 
     # mfem is downloaded from a URL shortener at request of upstream
     # author Tzanio Kolev <tzanio@llnl.gov>.  See here:
@@ -51,12 +55,20 @@ class Mfem(Package):
     # If this quick verification procedure fails, additional discussion
     # will be required to verify the new version.
 
+    # 'develop' is a special version that is always larger (or newer) than any
+    # other version.
+    version('develop',
+            git='https://github.com/mfem/mfem', branch='master')
+
     version('3.3.2',
             '01a762a5d0a2bc59ce4e2f59009045a4',
             url='https://goo.gl/Kd7Jk8', extension='.tar.gz',
             preferred=True)
 
-    version('laghos-v1.0', git='https://github.com/mfem/mfem',
+    # To properly order the 'laghos-v1.0' tagged version, we give it the version
+    # number it reports (3.3.1, a development version) with the tag string
+    # appended at the end.
+    version('3.3.1-laghos-v1.0', git='https://github.com/mfem/mfem',
             tag='laghos-v1.0')
 
     version('3.3',
@@ -71,10 +83,15 @@ class Mfem(Package):
             '841ea5cf58de6fae4de0f553b0e01ebaab9cd9c67fa821e8a715666ecf18fc57',
             url='http://goo.gl/xrScXn', extension='.tar.gz')
 
+    variant('static', default=True,
+        description='Build static library')
+    variant('shared', default=False,
+        description='Build shared library')
     variant('mpi', default=True,
         description='Enable MPI parallelism')
-    variant('hypre', default=True,
-        description='Required for MPI parallelism')
+    # Can we make the default value for 'metis' to depend on the 'mpi' value?
+    variant('metis', default=True,
+        description='Enable METIS support')
     variant('openmp', default=False,
         description='Enable OpenMP parallelism')
     variant('threadsafe', default=False,
@@ -83,6 +100,9 @@ class Mfem(Package):
             ' May cause minor performance issues.'))
     variant('superlu-dist', default=False,
         description='Enable MPI parallel, sparse direct solvers')
+    # Placeholder for STRUMPACK, support added in v3.3.2:
+    # variant('strumpack', default=False,
+    #     description='Enable support for STRUMPACK')
     variant('suite-sparse', default=False,
         description='Enable serial, sparse direct solvers')
     variant('petsc', default=False,
@@ -99,41 +119,67 @@ class Mfem(Package):
         description='Enable Cubit/Genesis reader')
     variant('gzstream', default=True,
         description='Support zip\'d streams for I/O')
+    variant('gnutls', default=False,
+        description='Enable secure sockets using GnuTLS')
+    variant('libunwind', default=False,
+        description='Enable backtrace on error support using Libunwind')
+    variant('timer', default='auto',
+        values=('auto','std','posix','mac','mpi'),
+        description='Timing functions to use in mfem::StopWatch')
     variant('examples', default=False,
         description='Build and install examples')
     variant('miniapps', default=False,
         description='Build and install miniapps')
 
-    conflicts('+mpi', when='~hypre')
-    conflicts('+suite-sparse', when='~lapack')
-    conflicts('+superlu-dist', when='@:3.1')
-    conflicts('+netcdf', when='@:3.1')
+    conflicts('+shared', when='@:3.3.2')
+    conflicts('~static~shared')
+    conflicts('~threadsafe', when='+openmp')
 
-    depends_on('hypre', when='+hypre')
-    depends_on('blas', when='+lapack')
-    depends_on('blas', when='+suite-sparse')
-    depends_on('lapack', when='+lapack')
-    depends_on('lapack', when='+suite-sparse')
+    conflicts('+netcdf', when='@:3.1')
+    conflicts('+superlu-dist', when='@:3.1')
+    conflicts('+gnutls', when='@:3.1')
+    conflicts('+gzstream', when='@:3.2')
+    conflicts('+mpfr', when='@:3.2')
+    conflicts('+petsc', when='@:3.2')
+    conflicts('+sundials', when='@:3.2')
+    conflicts('timer=mac', when='@:3.3.0')
+    conflicts('timer=mpi', when='@:3.3.0')
+    conflicts('~metis+mpi', when='@:3.3.0')
+    conflicts('+metis~mpi', when='@:3.3.0')
+
+    conflicts('+superlu-dist', when='~mpi')
+    conflicts('+petsc', when='~mpi')
+    conflicts('timer=mpi', when='~mpi')
 
     depends_on('mpi', when='+mpi')
-    depends_on('metis')
-    depends_on('parmetis', when='+superlu-dist')
-    depends_on('metis@5:', when='+superlu-dist')
-    depends_on('metis@5:', when='+suite-sparse ^suite-sparse@4.5:')
+    depends_on('hypre', when='+mpi')
+    depends_on('metis', when='+metis')
+    # Avoid disabling variants:
+    # depends_on('hypre~internal-superlu', when='+mpi')
+    depends_on('blas', when='+lapack')
+    depends_on('lapack', when='+lapack')
 
-    depends_on('sundials@2.7:+hypre', when='+sundials')
+    depends_on('sundials@2.7.0', when='@:3.3.1+sundials~mpi')
+    depends_on('sundials@2.7.0+mpi+hypre', when='@:3.3.1+sundials+mpi')
+    depends_on('sundials@2.7.0:', when='@3.3.2:+sundials~mpi')
+    depends_on('sundials@2.7.0:+mpi+hypre', when='@3.3.2:+sundials+mpi')
     depends_on('suite-sparse', when='+suite-sparse')
-    depends_on('superlu-dist', when='@3.2: +superlu-dist')
-    depends_on('petsc@3.8:', when='+petsc')
-
+    depends_on('superlu-dist', when='+superlu-dist')
+    # The PETSc tests in MFEM will fail if PETSc is not configured with
+    # SuiteSparse and MUMPS. On the other hand, if we require the variants
+    # '+suite-sparse+mumps' of PETSc, the xsdk concretization fails.
+    depends_on('petsc@3.8:+mpi+double+hypre', when='+petsc')
+    # Recommended when building outside of xsdk:
+    # depends_on('petsc@3.8:+mpi+double+hypre+suite-sparse+mumps', when='+petsc')
     depends_on('mpfr', when='+mpfr')
-    depends_on('netcdf', when='@3.2: +netcdf')
-    depends_on('zlib', when='@3.2: +netcdf')
-    depends_on('hdf5', when='@3.2: +netcdf')
-    depends_on('libunwind', when='+debug')
+    depends_on('netcdf', when='+netcdf')
+    depends_on('libunwind', when='+libunwind')
     depends_on('zlib', when='+gzstream')
+    depends_on('gnutls', when='+gnutls')
 
     patch('mfem_ppc_build.patch', when='@3.2:3.3 arch=ppc64le')
+
+    phases = ['configure', 'build', 'install']
 
     #
     # Note: Although MFEM does support CMake configuration, MFEM
@@ -142,30 +188,25 @@ class Mfem(Package):
     # likely to be up to date in supporting *all* of MFEM's
     # configuration options. So, don't use CMake
     #
-    def install(self, spec, prefix):
+    def configure(self, spec, prefix):
 
         def yes_no(varstr):
             return 'YES' if varstr in self.spec else 'NO'
 
         metis5_str = 'NO'
-        if '+superlu-dist' in spec or  \
-            spec.satisfies('+suite-sparse ^suite-sparse@4.5:') or \
-                spec['metis'].satisfies('@5:'):
-                metis5_str = 'YES'
-
-        threadsafe_str = 'NO'
-        if '+openmp' in spec or '+threadsafe' in spec:
-            threadsafe_str = 'YES'
+        if ('+metis' in spec) and spec['metis'].satisfies('@5:'):
+            metis5_str = 'YES'
 
         options = [
             'PREFIX=%s' % prefix,
             'MFEM_USE_MEMALLOC=YES',
             'MFEM_DEBUG=%s' % yes_no('+debug'),
             'CXX=%s' % env['CXX'],
-            'MFEM_USE_LIBUNWIND=%s' % yes_no('+debug'),
+            'MFEM_USE_LIBUNWIND=%s' % yes_no('+libunwind'),
             'MFEM_USE_GZSTREAM=%s' % yes_no('+gzstream'),
+            'MFEM_USE_METIS=%s' % yes_no('+metis'),
             'MFEM_USE_METIS_5=%s' % metis5_str,
-            'MFEM_THREAD_SAFE=%s' % threadsafe_str,
+            'MFEM_THREAD_SAFE=%s' % yes_no('+threadsafe'),
             'MFEM_USE_MPI=%s' % yes_no('+mpi'),
             'MFEM_USE_LAPACK=%s' % yes_no('+lapack'),
             'MFEM_USE_SUPERLU=%s' % yes_no('+superlu-dist'),
@@ -174,115 +215,108 @@ class Mfem(Package):
             'MFEM_USE_PETSC=%s' % yes_no('+petsc'),
             'MFEM_USE_NETCDF=%s' % yes_no('+netcdf'),
             'MFEM_USE_MPFR=%s' % yes_no('+mpfr'),
+            'MFEM_USE_GNUTLS=%s' % yes_no('+gnutls'),
             'MFEM_USE_OPENMP=%s' % yes_no('+openmp')]
+
+        if '~static' in spec:
+            options += ['STATIC=NO']
+        if '+shared' in spec:
+            options += ['SHARED=YES', 'PICFLAG=%s' % self.compiler.pic_flag]
 
         if '+mpi' in spec:
             options += ['MPICXX=%s' % spec['mpi'].mpicxx]
+            options += [
+                'HYPRE_OPT=%s' % spec['hypre'].all_headers.cpp_flags,
+                'HYPRE_LIB=%s' % spec['hypre'].all_libs.ld_flags]
 
-        if '+hypre' in spec:
-            hypre = spec['hypre']
-            hypre_flag_list = (hypre.libs +
-                               hypre['lapack'].libs +
-                               hypre['blas'].libs)
-            options += ['HYPRE_DIR=%s' % hypre.prefix,
-                        'HYPRE_OPT=-I%s' % hypre.prefix.include,
-                        'HYPRE_LIB=%s' % hypre_flag_list.ld_flags]
+        if '+metis' in spec:
+            options += [
+                'METIS_OPT=%s' % spec['metis'].all_headers.cpp_flags,
+                'METIS_LIB=%s' % spec['metis'].all_libs.ld_flags]
 
         if '+lapack' in spec:
             lapack_lib = (spec['lapack'].libs + spec['blas'].libs).ld_flags  # NOQA: ignore=E501
             options += [
-                'LAPACK_OPT=-I%s' % spec['lapack'].prefix.include,
+                # LAPACK_OPT is not used
                 'LAPACK_LIB=%s' % lapack_lib]
 
         if '+superlu-dist' in spec:
-            metis_lib = '-L%s -lparmetis -lmetis' % spec['parmetis'].prefix.lib
             options += [
-                'METIS_DIR=%s' % spec['parmetis'].prefix,
-                'METIS_OPT=-I%s' % spec['parmetis'].prefix.include,
-                'METIS_LIB=%s' % metis_lib]
-            superlu_lib = '-L%s' % spec['superlu-dist'].prefix.lib
-            superlu_lib += ' -lsuperlu_dist'
-            options += [
-                'SUPERLU_DIR=%s' % spec['superlu-dist'].prefix,
-                'SUPERLU_OPT=-I%s' % spec['superlu-dist'].prefix.include,
-                'SUPERLU_LIB=%s' % superlu_lib]
-        else:
-            metis_lib = '-L%s -lmetis' % spec['metis'].prefix.lib
-            options += [
-                'METIS_DIR=%s' % spec['metis'].prefix,
-                'METIS_OPT=-I%s' % spec['metis'].prefix.include,
-                'METIS_LIB=%s' % metis_lib]
+                'SUPERLU_OPT=%s' % spec['superlu-dist'].all_headers.cpp_flags,
+                'SUPERLU_LIB=%s' % spec['superlu-dist'].all_libs.ld_flags]
 
         if '+suite-sparse' in spec:
-            ssp = spec['suite-sparse'].prefix
-            ss_lib = '-L%s' % ssp.lib
-            if '@3.2:' in spec:
-                ss_lib += ' -lklu -lbtf'
-            ss_lib += (' -lumfpack -lcholmod -lcolamd' +
-                       ' -lamd -lcamd -lccolamd -lsuitesparseconfig')
-            no_rt = spec.satisfies('platform=darwin')
-            if not no_rt:
-                ss_lib += ' -lrt'
-            ss_lib += (' ' + metis_lib + ' ' + lapack_lib)
+            ss_spec = 'suite-sparse:' + self.suitesparse_components
             options += [
-                'SUITESPARSE_DIR=%s' % ssp,
-                'SUITESPARSE_OPT=-I%s' % ssp.include,
-                'SUITESPARSE_LIB=%s' % ss_lib]
+                'SUITESPARSE_OPT=%s' % spec[ss_spec].all_headers.cpp_flags,
+                'SUITESPARSE_LIB=%s' % spec[ss_spec].all_libs.ld_flags]
 
         if '+sundials' in spec:
-            sundials_libs = (
-                '-lsundials_arkode -lsundials_cvode'
-                ' -lsundials_nvecserial -lsundials_kinsol')
-            if '+mpi' in spec:
-                sundials_libs += (
-                    ' -lsundials_nvecparhyp -lsundials_nvecparallel')
+            sun_spec = 'sundials:' + self.sundials_components
             options += [
-                'SUNDIALS_DIR=%s' % spec['sundials'].prefix,
-                'SUNDIALS_OPT=-I%s' % spec['sundials'].prefix.include,
-                'SUNDIALS_LIB=-L%s %s' % (spec['sundials'].prefix.lib,
-                                          sundials_libs)]
+                'SUNDIALS_OPT=%s' % spec[sun_spec].all_headers.cpp_flags,
+                'SUNDIALS_LIB=%s' % spec[sun_spec].all_libs.ld_flags]
 
         if '+petsc' in spec:
-            f = open('%s/lib/pkgconfig/PETSc.pc' % spec['petsc'].prefix, 'r')
-            for line in f:
-                if re.search('^\s*Cflags: ', line):
-                    petsc_opts = re.sub('^\s*Cflags: (.*)', '\\1', line)
-                elif re.search('^\s*Libs.*: ', line):
-                    petsc_libs = re.sub('^\s*Libs.*: (.*)', '\\1', line)
-            f.close()
-            options += [
-                'PETSC_DIR=%s' % spec['petsc'].prefix,
-                'PETSC_OPT=%s' % petsc_opts,
-                'PETSC_LIB=-L%s -lpetsc %s' %
-                (spec['petsc'].prefix.lib, petsc_libs)]
+            options += ['PETSC_DIR=%s' % spec['petsc'].prefix]
 
         if '+netcdf' in spec:
-            np = spec['netcdf'].prefix
-            zp = spec['zlib'].prefix
-            h5p = spec['hdf5'].prefix
-            nlib = '-L%s -lnetcdf ' % np.lib
-            nlib += '-L%s -lhdf5_hl -lhdf5 ' % h5p.lib
-            nlib += '-L%s -lz' % zp.lib
             options += [
-                'NETCDF_DIR=%s' % np,
-                'HDF5_DIR=%s' % h5p,
-                'ZLIB_DIR=%s' % zp,
-                'NETCDF_OPT=-I%s' % np.include,
-                'NETCDF_LIB=%s' % nlib]
+                'NETCDF_OPT=%s' % spec['netcdf'].all_headers.cpp_flags,
+                'NETCDF_LIB=%s' % spec['netcdf'].all_libs.ld_flags]
+
+        if '+gzstream' in spec:
+            options += [
+                'ZLIB_OPT=%s' % spec['zlib'].all_headers.cpp_flags,
+                'ZLIB_LIB=%s' % spec['zlib'].all_libs.ld_flags]
 
         if '+mpfr' in spec:
-            options += ['MPFR_LIB=-L%s -lmpfr' % spec['mpfr'].prefix.lib]
+            options += [
+                'MPFR_OPT=%s' % spec['mpfr'].all_headers.cpp_flags,
+                'MPFR_LIB=%s' % spec['mpfr'].all_libs.ld_flags]
+
+        if '+gnutls' in spec:
+            options += [
+                'GNUTLS_OPT=%s' % spec['gnutls'].all_headers.cpp_flags,
+                'GNUTLS_LIB=%s' % spec['gnutls'].all_libs.ld_flags]
+
+        if '+libunwind' in spec:
+            options += [
+                'LIBUNWIND_OPT=-g %s' % spec['libunwind'].all_headers.cpp_flags,
+                'LIBUNWIND_OPT=%s' % spec['libunwind'].all_libs.ld_flags]
 
         if '+openmp' in spec:
-            options += ['OPENMP_OPT = %s' % self.compiler.openmp_flag]
+            options += ['OPENMP_OPT=%s' % self.compiler.openmp_flag]
 
-        make('config', *options)
+        timer_ids = {'std': '0', 'posix': '2', 'mac': '4', 'mpi': '6'}
+        timer = spec.variants['timer'].value
+        if timer != 'auto':
+            options += ['MFEM_TIMER_TYPE=%s' % timer_ids[timer]]
+
+        make('config', *options, parallel=False)
+        make('info', parallel=False)
+
+    def build(self, spec, prefix):
         make('lib')
 
-        if self.run_tests:
-            make('check')
+    @run_after('build')
+    def check_or_test(self):
+        # Running 'make check' or 'make test' may fail if MFEM_MPIEXEC or
+        # MFEM_MPIEXEC_NP are not set appropriately.
+        if not self.run_tests:
+            # check we can build ex1 (~mpi) or ex1p (+mpi).
+            make('-C', 'examples', 'ex1p' if ('+mpi' in self.spec) else 'ex1',
+                 parallel=False)
+            # make('check', parallel=False)
+        else:
+            make('all')
+            make('test', parallel=False)
 
-        make('install')
+    def install(self, spec, prefix):
+        make('install', parallel=False)
+
+        # TODO: The way the examples and miniapps are being installed is not
+        # perfect. For example, the makefiles do not work.
 
         if '+examples' in spec:
             make('examples')
@@ -291,3 +325,113 @@ class Mfem(Package):
         if '+miniapps' in spec:
             make('miniapps')
             install_tree('miniapps', join_path(prefix, 'miniapps'))
+
+        if ('+examples' in spec) or ('+miniapps' in spec):
+            install_tree('data', join_path(prefix, 'data'))
+
+    @property
+    def suitesparse_components(self):
+        """Return the SuiteSparse components needed by MFEM."""
+        ss_comps = 'umfpack,cholmod,colamd,amd,camd,ccolamd,suitesparseconfig'
+        if self.spec.satisfies('@3.2:'):
+            ss_comps = 'klu,btf,' + ss_comps
+        return ss_comps
+
+    @property
+    def sundials_components(self):
+        """Return the SUNDIALS components needed by MFEM."""
+        sun_comps = 'arkode,cvode,nvecserial,kinsol'
+        if '+mpi' in self.spec:
+            sun_comps += ',nvecparhyp,nvecparallel'
+        return sun_comps
+
+    @property
+    def headers(self):
+        """Export the main mfem header, mfem.hpp.
+        """
+        hdrs = HeaderList(find(self.prefix.include, 'mfem.hpp',
+                               recursive=False))
+        return hdrs or None
+
+    @property
+    def all_headers(self):
+        """Export all headers needed for compiling with mfem.
+           This property can be accessed with spec['mfem'].all_headers and used
+           in compilation with spec['mfem'].all_headers.cpp_flags.
+        """
+        spec = self.spec
+        hdrs = self.headers
+        # Package headers that are not needed: metis, superlu-dist, mpfr,
+        # netcdf, lapack, blas, libunwind.
+        pkgs = ['petsc', 'suite-sparse', 'sundials', 'gnutls']
+        for pkg in pkgs:
+            if '+'+pkg in spec:
+                hdrs += spec[pkg].all_headers
+        if '+mpi' in spec:
+            hdrs += spec['hypre'].all_headers
+        if '+gzstream' in spec:
+            hdrs += spec['zlib'].all_headers
+        return hdrs
+
+    @property
+    def libs(self):
+        """Export the mfem library file.
+        """
+        libs = find_libraries('libmfem', root=self.prefix.lib,
+                   shared=('+shared' in self.spec), recursive=False)
+        return libs or None
+
+    @property
+    def all_libs(self):
+        """Export all libraries that are needed when linking with mfem.
+           This property can be accessed with spec['mfem'].all_libs and used for
+           linking with spec['mfem'].all_libs.ld_flags.
+        """
+        spec = self.spec
+        libs = self.libs
+        if '+mpi' in spec:
+            libs += spec['hypre'].all_libs
+        if '+lapack' in spec:
+            libs += spec['lapack'].all_libs + spec['blas'].all_libs
+        pkgs = ['petsc', 'superlu-dist', 'netcdf', 'mpfr', 'gnutls',
+                'libunwind', 'metis']
+        for pkg in pkgs:
+            if '+'+pkg in spec:
+                libs += spec[pkg].all_libs
+        if '+sundials' in spec:
+            sun_spec = 'sundials:' + self.sundials_components
+            libs += spec[sun_spec].all_libs
+        if '+suite-sparse' in spec:
+            ss_spec = 'suite-sparse:' + self.suitesparse_components
+            libs += spec[ss_spec].all_libs
+        if '+gzstream' in spec:
+            libs += spec['zlib'].all_libs
+        if spec.variants['timer'].value == 'posix':
+            libs += find_system_libraries('librt')
+        return libs
+
+    @property
+    def config_mk(self):
+        """Export the location of the config.mk file.
+           This property can be accessed using spec['mfem'].package.config_mk
+        """
+        dirs = [self.prefix, self.prefix.share.mfem]
+        for d in dirs:
+           f = join_path(d, 'config.mk')
+           if os.access(f, os.R_OK):
+              return FileList(f)
+        return FileList(find(self.prefix, 'config.mk', recursive=True))
+
+    @property
+    def test_mk(self):
+        """Export the location of the test.mk file.
+           This property can be accessed using spec['mfem'].package.test_mk.
+           In version 3.3.2 and newer, the location of test.mk is also defined
+           inside config.mk, variable MFEM_TEST_MK.
+        """
+        dirs = [self.prefix, self.prefix.share.mfem]
+        for d in dirs:
+           f = join_path(d, 'test.mk')
+           if os.access(f, os.R_OK):
+              return FileList(f)
+        return FileList(find(self.prefix, 'test.mk', recursive=True))

--- a/var/spack/repos/builtin/packages/mumps/package.py
+++ b/var/spack/repos/builtin/packages/mumps/package.py
@@ -262,3 +262,11 @@ class Mumps(Package):
                 os.system('./dsimpletest < input_simpletest_real')
                 if '+complex' in spec:
                     os.system('./zsimpletest < input_simpletest_cmplx')
+
+    @property
+    def libs(self):
+        component_libs = ['*mumps*', 'pord']
+        return find_libraries(['lib'+comp for comp in component_libs],
+                              root=self.prefix.lib,
+                              shared=('+shared' in self.spec), recursive=False)\
+               or None

--- a/var/spack/repos/builtin/packages/netlib-scalapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-scalapack/package.py
@@ -67,6 +67,10 @@ class NetlibScalapack(CMakePackage):
             'libscalapack', root=self.prefix, shared=shared, recursive=True
         )
 
+    @property
+    def libs(self):
+        return self.scalapack_libs
+
     def cmake_args(self):
         spec = self.spec
 

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -220,3 +220,20 @@ class Openblas(MakefilePackage):
             source_file, [include_flags], link_flags.split()
         )
         compare_output_file(output, blessed_file)
+
+    @property
+    def blas_libs(self):
+        shared = '+shared' in self.spec
+        prefix = self.prefix
+        search_paths = [[prefix.lib, False], [prefix.lib64, False],
+                        [prefix, True]]
+        for path,recursive in search_paths:
+            libs = find_libraries('libopenblas', root=path, shared=shared,
+                                  recursive=recursive)
+            if libs:
+                return libs
+        return None  # Raise error
+
+    @property
+    def lapack_libs(self):
+        return self.blas_libs

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -221,6 +221,11 @@ class Openmpi(AutotoolsPackage):
         return url.format(version.up_to(2), version)
 
     @property
+    def headers(self):
+        hdrs = HeaderList(find(self.prefix.include, 'mpi.h', recursive=False))
+        return hdrs or None
+
+    @property
     def libs(self):
         query_parameters = self.spec.last_query.extra_parameters
         libraries = ['libmpi']

--- a/var/spack/repos/builtin/packages/suite-sparse/package.py
+++ b/var/spack/repos/builtin/packages/suite-sparse/package.py
@@ -95,7 +95,7 @@ class SuiteSparse(Package):
             # with the TCOV path of SparseSuite 4.5.1's Suitesparse_config.mk,
             # even though this fix is ugly
             'BLAS=%s' % (spec['blas'].libs.ld_flags + (
-                '-lstdc++' if '@4.5.1' in spec else '')),
+                ' -lstdc++' if '@4.5.1' in spec else '')),
             'LAPACK=%s' % spec['lapack'].libs.ld_flags,
         ]
 
@@ -125,3 +125,22 @@ class SuiteSparse(Package):
             ]
 
         make('install', *make_args)
+
+    @property
+    def libs(self):
+        """Export the libraies of SuiteSparse.
+        Sample usage: spec['suite-sparse'].libs.ld_flags
+                      spec['suite-sparse:klu,btf'].libs.ld_flags
+        """
+        # Component libraries, ordered by dependency. Any missing components?
+        all_comps = ['klu', 'btf', 'umfpack', 'cholmod', 'colamd', 'amd',
+            'camd', 'ccolamd', 'cxsparse', 'ldl', 'rbio', 'spqr',
+            'suitesparseconfig']
+        query_parameters = self.spec.last_query.extra_parameters
+        comps = all_comps if not query_parameters else query_parameters
+        libs = find_libraries(['lib' + c for c in comps], root=self.prefix.lib,
+                              shared=True, recursive=False)
+        if not libs:
+            return None
+        libs += find_system_libraries('librt')
+        return libs

--- a/var/spack/repos/builtin/packages/superlu-dist/package.py
+++ b/var/spack/repos/builtin/packages/superlu-dist/package.py
@@ -114,3 +114,24 @@ class SuperluDist(Package):
         superludist_lib = join_path(self.stage.source_path,
                                     'lib/libsuperlu_dist.a')
         install(superludist_lib, self.prefix.lib)
+
+    @property
+    def headers(self):
+        """Export the headers and defines of SuperLU_DIST.
+           Sample usage: spec['superlu-dist'].headers.cpp_flags
+        """
+        return find_headers('*', root=self.prefix.include, recursive=False) \
+               or None
+
+    @property
+    def all_headers(self):
+        return self.headers  # Headers of dependent libraries are not needed.
+
+    @property
+    def libs(self):
+        """Export the SuperLU_DIST library.
+           Sample usage: spec['superlu-dist'].libs.ld_flags
+        """
+        return find_libraries('libsuperlu_dist', root=self.prefix.lib,
+                              shared=False, recursive=False) \
+               or None

--- a/var/spack/repos/builtin/packages/xsdk/package.py
+++ b/var/spack/repos/builtin/packages/xsdk/package.py
@@ -50,8 +50,10 @@ class Xsdk(Package):
     depends_on('hypre@xsdk-0.2.0~internal-superlu', when='@xsdk-0.2.0')
     depends_on('hypre@develop~internal-superlu', when='@develop')
 
-    depends_on('mfem@3.3.2+mpi+hypre+superlu-dist+petsc+sundials+examples+miniapps', when='@0.3.0')
-    depends_on('mfem@3.3.2+mpi+hypre+superlu-dist+petsc+sundials+examples+miniapps', when='@develop')
+    depends_on('mfem@3.3.2+mpi+superlu-dist+petsc+sundials+examples+miniapps',
+               when='@0.3.0')
+    depends_on('mfem@develop+mpi+superlu-dist+petsc+sundials+examples+miniapps',
+               when='@develop')
 
     depends_on('superlu-dist@5.2.2', when='@0.3.0')
     depends_on('superlu-dist@xsdk-0.2.0', when='@xsdk-0.2.0')

--- a/var/spack/repos/builtin/packages/zlib/package.py
+++ b/var/spack/repos/builtin/packages/zlib/package.py
@@ -51,11 +51,29 @@ class Zlib(Package):
     patch('w_patch.patch', when="@1.2.11%cce")
 
     @property
+    def headers(self):
+        # If zlib is configured as external package, e.g. in /usr, searching the
+        # whole prefix.include recursively could be slow and returns a ton of
+        # headers, so we override this default behavior.
+        hdr = find_headers('zlib', root=self.prefix.include, recursive=False)
+        return hdr or None
+
+    @property
     def libs(self):
         shared = '+shared' in self.spec
-        return find_libraries(
-            ['libz'], root=self.prefix, recursive=True, shared=shared
-        )
+        # If zlib is configured as external package, e.g. in /usr, searching the
+        # whole prefix recursively is slow, so we first try a search in
+        # prefix.lib and prefix.lib64 and if that fails, then we search prefix
+        # recursively.
+        prefix = self.prefix
+        search_paths = [[prefix.lib, False], [prefix.lib64, False],
+                        [prefix, True]]
+        for path,recursive in search_paths:
+            libs = find_libraries('libz', root=path, shared=shared,
+                                  recursive=recursive)
+            if libs:
+                return libs
+        return None  # Raise error
 
     def setup_environment(self, spack_env, run_env):
         if '+pic' in self.spec:


### PR DESCRIPTION
Update the `mfem` package with more variants while extending some of the packages it (optionally) depends on.

In addition, the properties `headers` and `libs` are defined for a number of related packages and the proposed new properties `all_headers` and `all_libs` (in PR #7256) are defined and used.

CC: (package maintainers of affected packages)
- mfem: @goxberry, @tzanio, @markcmiller86, @acfisher
- hypre: @tgamblin ?
- sundials: @cswoodward, @gardner48
- petsc: @balay, @BarrySmith
- mumps: ?
- netlib-scalapack: ?
- suite-sparse: ?
- laghos: @bhatele ?
- superlu-dist: @goxberry ?
- xsdk: @balay, @BarrySmith
- gnutls, libunwind, openblas, openmpi, zlib: ?
