### PR TITLE
mumps: add the libs property

### DIFF
--- a/var/spack/repos/builtin/packages/mumps/package.py
+++ b/var/spack/repos/builtin/packages/mumps/package.py
@@ -266,7 +266,7 @@ class Mumps(Package):
     @property
     def libs(self):
         component_libs = ['*mumps*', 'pord']
-        return find_libraries(['lib'+comp for comp in component_libs],
+        return find_libraries(['lib' + comp for comp in component_libs],
                               root=self.prefix.lib,
-                              shared=('+shared' in self.spec), recursive=False)\
-               or None
+                              shared=('+shared' in self.spec),
+                              recursive=False) or None

--- a/var/spack/repos/builtin/packages/mumps/package.py
+++ b/var/spack/repos/builtin/packages/mumps/package.py
@@ -262,3 +262,11 @@ class Mumps(Package):
                 os.system('./dsimpletest < input_simpletest_real')
                 if '+complex' in spec:
                     os.system('./zsimpletest < input_simpletest_cmplx')
+
+    @property
+    def libs(self):
+        component_libs = ['*mumps*', 'pord']
+        return find_libraries(['lib'+comp for comp in component_libs],
+                              root=self.prefix.lib,
+                              shared=('+shared' in self.spec), recursive=False)\
+               or None


### PR DESCRIPTION
The default behaviour of the `.libs` property is not appropriate for mumps.