### PR TITLE
netlib-scalapack: add the libs property

### DIFF
--- a/var/spack/repos/builtin/packages/netlib-scalapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-scalapack/package.py
@@ -67,6 +67,10 @@ class NetlibScalapack(CMakePackage):
             'libscalapack', root=self.prefix, shared=shared, recursive=True
         )
 
+    @property
+    def libs(self):
+        return self.scalapack_libs
+
     def cmake_args(self):
         spec = self.spec
 

--- a/var/spack/repos/builtin/packages/netlib-scalapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-scalapack/package.py
@@ -59,17 +59,13 @@ class NetlibScalapack(CMakePackage):
     depends_on('cmake', when='@2.0.0:', type='build')
 
     @property
-    def scalapack_libs(self):
+    def libs(self):
         # Note that the default will be to search
         # for 'libnetlib-scalapack.<suffix>'
         shared = True if '+shared' in self.spec else False
         return find_libraries(
             'libscalapack', root=self.prefix, shared=shared, recursive=True
         )
-
-    @property
-    def libs(self):
-        return self.scalapack_libs
 
     def cmake_args(self):
         spec = self.spec


### PR DESCRIPTION
This is useful when traversing a concretized dag for link dependencies, e.g. in the `.all_libs` property proposed in PR #7256.