### PR TITLE
openblas: add the 'lapack_libs' and 'blas_libs' properties

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -220,3 +220,20 @@ class Openblas(MakefilePackage):
             source_file, [include_flags], link_flags.split()
         )
         compare_output_file(output, blessed_file)
+
+    @property
+    def blas_libs(self):
+        shared = '+shared' in self.spec
+        prefix = self.prefix
+        search_paths = [[prefix.lib, False], [prefix.lib64, False],
+                        [prefix, True]]
+        for path,recursive in search_paths:
+            libs = find_libraries('libopenblas', root=path, shared=shared,
+                                  recursive=recursive)
+            if libs:
+                return libs
+        return None  # Raise error
+
+    @property
+    def lapack_libs(self):
+        return self.blas_libs

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -227,7 +227,7 @@ class Openblas(MakefilePackage):
         prefix = self.prefix
         search_paths = [[prefix.lib, False], [prefix.lib64, False],
                         [prefix, True]]
-        for path,recursive in search_paths:
+        for path, recursive in search_paths:
             libs = find_libraries('libopenblas', root=path, shared=shared,
                                   recursive=recursive)
             if libs:


### PR DESCRIPTION
This is a tweak to avoid the recursive search of `prefix` in the most common cases - improves the search speed when using external installation, e.g. in `/usr`.