### PR TITLE
openmpi: add package-specific 'headers' property

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -221,6 +221,11 @@ class Openmpi(AutotoolsPackage):
         return url.format(version.up_to(2), version)
 
     @property
+    def headers(self):
+        hdrs = HeaderList(find(self.prefix.include, 'mpi.h', recursive=False))
+        return hdrs or None
+
+    @property
     def libs(self):
         query_parameters = self.spec.last_query.extra_parameters
         libraries = ['libmpi']

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -223,6 +223,8 @@ class Openmpi(AutotoolsPackage):
     @property
     def headers(self):
         hdrs = HeaderList(find(self.prefix.include, 'mpi.h', recursive=False))
+        if not hdrs:
+            hdrs = HeaderList(find(self.prefix, 'mpi.h', recursive=True))
         return hdrs or None
 
     @property


### PR DESCRIPTION
This removes some redundant headers from sub-directories, returned by the default `.headers` handler.

Needs #7277 