### PR TITLE
Augustus update hash

### DIFF
--- a/var/spack/repos/builtin/packages/augustus/package.py
+++ b/var/spack/repos/builtin/packages/augustus/package.py
@@ -50,7 +50,7 @@ class Augustus(MakefilePackage):
             makefile.filter('INCLUDES = *',
                             'INCLUDES = -I$(BAMTOOLS)/include/bamtools ')
             makefile.filter('LIBS = -lbamtools -lz',
-                            'LIBS = $(BAMTOOLS)/lib/bamtools'
+                            'LIBS = $(BAMTOOLS)/lib64/'
                             '/libbamtools.a -lz')
         with working_dir(join_path('auxprogs', 'bam2hints')):
             makefile = FileFilter('Makefile')
@@ -59,7 +59,7 @@ class Augustus(MakefilePackage):
             makefile.filter('INCLUDES = /usr/include/bamtools',
                             'INCLUDES = $(BAMTOOLS)/include/bamtools')
             makefile.filter('LIBS = -lbamtools -lz',
-                            'LIBS = $(BAMTOOLS)/lib/bamtools'
+                            'LIBS = $(BAMTOOLS)/lib64/'
                             '/libbamtools.a -lz')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/augustus/package.py
+++ b/var/spack/repos/builtin/packages/augustus/package.py
@@ -32,7 +32,7 @@ class Augustus(MakefilePackage):
     homepage = "http://bioinf.uni-greifswald.de/augustus/"
     url      = "http://bioinf.uni-greifswald.de/augustus/binaries/augustus-3.3.tar.gz"
 
-    version('3.3',   '9ebe494df78ebf6a43091cfc8551050c',
+    version('3.3', '93691d9aafc7d3d0e1adf31ec308507f',
             url='http://bioinf.uni-greifswald.de/augustus/binaries/augustus-3.3.tar.gz')
     version('3.2.3', 'b8c47ea8d0c45aa7bb9a82626c8ff830',
             url='http://bioinf.uni-greifswald.de/augustus/binaries/old/augustus-3.2.3.tar.gz')


### PR DESCRIPTION
The package archive was updated on 2018-01-26, but the version number was not incremented.

I contacted the developers, and was told:
"No functionality has changed. In this update only some object files were removed, that could theoretically interfere with compilation"

While installing, also found that the bamtools libraries now seem to be in lib64, so updated the makefile filter. Installed successfully.

