### PR TITLE
charm: Update install script

### DIFF
--- a/var/spack/repos/builtin/packages/charm/package.py
+++ b/var/spack/repos/builtin/packages/charm/package.py
@@ -90,9 +90,6 @@ class Charm(Package):
     variant("production", default=True, description="Build charm++ with all optimizations")
     variant("tracing", default=False, description="Enable tracing modules")
 
-    variant("destination", description="Build charm++ inside DIR, by default the destination is <version>")
-    variant("suffix", description="Append DIR to the destination directory of the Charm++ build")
-
     depends_on("mpi", when="backend=mpi")
     depends_on("papi", when="+papi")
     depends_on("cuda", when="+cuda")
@@ -166,17 +163,9 @@ class Charm(Package):
         # here.
         options = [
             os.path.basename(self.compiler.cc),
-            os.path.basename(self.compiler.fc)
+            os.path.basename(self.compiler.fc),
+            "--destination=%s" % prefix,
         ]
-
-        suffix = spec.variants["suffix"].value
-        if suffix != "":
-            options.append("--suffix={0}".format(suffix))
-        destination = spec.variants["destination"].value
-        if destination != "":
-            options.append("--destination={0}".format(destination))
-        else:
-            options.append("--destination={0}".format(prefix))
 
         if 'backend=mpi' in spec:
             # in intelmpi <prefix>/include and <prefix>/lib fails so --basedir

--- a/var/spack/repos/builtin/packages/charm/package.py
+++ b/var/spack/repos/builtin/packages/charm/package.py
@@ -164,6 +164,7 @@ class Charm(Package):
         options = [
             os.path.basename(self.compiler.cc),
             os.path.basename(self.compiler.fc),
+            "-j%d" % make_jobs,
             "--destination=%s" % prefix,
         ]
 


### PR DESCRIPTION
Updating install script for charm.

Changes:
- Updated latest version
- mpi.patch is not needed in versions 6.8.0+
- Added build targets: AMPI, LIBS
- Added backend variants: gni, ofi, pami, pamilrts
- Removed deprecated net backend
- Added compiler and fortran compiler variants
- Added compile time options
- Added more version combinations
- Added check for tracing when papi is enabled