### PR TITLE
clamr: needs cmake-3.1

### DIFF
--- a/var/spack/repos/builtin/packages/clamr/package.py
+++ b/var/spack/repos/builtin/packages/clamr/package.py
@@ -46,6 +46,7 @@ class Clamr(CMakePackage):
         values=('single', 'mixed', 'full'),
         description='single, mixed, or full double precision values')
 
+    depends_on('cmake@3.1:')
     depends_on('mpi')
     depends_on('mpe', when='graphics=mpe')
 


### PR DESCRIPTION
Found in proxyapps/proxy-ci#2