### PR TITLE
cpu_features

### DIFF
--- a/var/spack/repos/builtin/packages/cpu-features/package.py
+++ b/var/spack/repos/builtin/packages/cpu-features/package.py
@@ -1,0 +1,43 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class CpuFeatures(CMakePackage):
+    """A cross platform C99 library to get cpu features at runtime."""
+
+    homepage = "https://github.com/google/cpu_features"
+    url      = "https://github.com/google/cpu_features/archive/v0.1.0.tar.gz"
+
+    version('develop', branch='master',
+            git='https://github.com/google/cpu_features.git')
+
+    depends_on('cmake@3.0.0:', type='build')
+
+    def cmake_args(self):
+        args = [
+            '-DBUILD_TESTING:BOOL=OFF'
+        ]
+        return args


### PR DESCRIPTION
Adds Google's new [`cpu_features`](https://github.com/google/cpu_features) library.

Install was added [recently](https://github.com/google/cpu_features/issues/18), so don't take the `0.1.0` release but the current `master` until a new version is published.