### PR TITLE
Make fix_darwin_install_name python3-compatible

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -32,13 +32,13 @@ import os
 import re
 import shutil
 import stat
-import subprocess
 import sys
 import tempfile
 from contextlib import contextmanager
 
 import six
 from llnl.util import tty
+from llnl.util.executable import Executable
 from llnl.util.lang import dedupe
 
 __all__ = [
@@ -583,12 +583,10 @@ def fix_darwin_install_name(path):
     libs = glob.glob(join_path(path, "*.dylib"))
     for lib in libs:
         # fix install name first:
-        subprocess.Popen(
-            ["install_name_tool", "-id", lib, lib],
-            stdout=subprocess.PIPE).communicate()[0]
-        long_deps = subprocess.Popen(
-            ["otool", "-L", lib],
-            stdout=subprocess.PIPE).communicate()[0].split('\n')
+        install_name_tool = Executable('install_name_tool')
+        install_name_tool('-id', lib, lib)
+        otool = Executable('otool')
+        long_deps = otool('-L', lib, output=str).split('\n')
         deps = [dep.partition(' ')[0][1::] for dep in long_deps[2:-1]]
         # fix all dependencies:
         for dep in deps:
@@ -599,9 +597,7 @@ def fix_darwin_install_name(path):
                 # but we don't know builddir (nor how symbolic links look
                 # in builddir). We thus only compare the basenames.
                 if os.path.basename(dep) == os.path.basename(loc):
-                    subprocess.Popen(
-                        ["install_name_tool", "-change", dep, loc, lib],
-                        stdout=subprocess.PIPE).communicate()[0]
+                    install_name_tool('-change', dep, loc, lib)
                     break
 
 

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -38,8 +38,8 @@ from contextlib import contextmanager
 
 import six
 from llnl.util import tty
-from llnl.util.executable import Executable
 from llnl.util.lang import dedupe
+from spack.util.executable import Executable
 
 __all__ = [
     'FileFilter',


### PR DESCRIPTION
This updates the fix_darwin_install_name function to use the Spack
Executable object to run install_name_tool, which ensures that
process output is formatted as a 'str' for python2 and python3.
Originally fix_darwin_install_name was invoking subprocess.Popen
directly.