### PR TITLE
Record installation date and time in DB

### DIFF
--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -442,7 +442,7 @@ def pretty_date(time, now=None):
         return str(diff) + " years ago"
 
 
-def str2date(date_str):
+def pretty_string_to_date(date_str, now=None):
     """Parses a string representing a date and returns a datetime object.
 
     Args:
@@ -456,6 +456,8 @@ def str2date(date_str):
 
     pattern = {}
 
+    now = now or datetime.now()
+
     # datetime formats
     pattern[re.compile('^\d{4}$')] = lambda x: datetime.strptime(x, '%Y')
     pattern[re.compile('^\d{4}-\d{2}$')] = lambda x: datetime.strptime(
@@ -465,33 +467,37 @@ def str2date(date_str):
         x, '%Y-%m-%d'
     )
 
+    pretty_regex = re.compile(
+        r'(a|\d+)\s*(year|month|week|day|hour|minute|second)s?\s*ago')
+
+    def _n_xxx_ago(x):
+        how_many, time_period = pretty_regex.search(x).groups()
+
+        how_many = 1 if how_many == 'a' else int(how_many)
+
+        # timedelta natively supports time periods up to 'weeks'.
+        # To apply month or year we convert to 30 and 365 days
+        if time_period == 'month':
+            how_many *= 30
+            time_period = 'day'
+        elif time_period == 'year':
+            how_many *= 365
+            time_period = 'day'
+
+        kwargs = {(time_period + 's'): how_many}
+        return now - timedelta(**kwargs)
+
+    pattern[pretty_regex] = _n_xxx_ago
+
     # yesterday
-    callback = lambda x: datetime.now() - timedelta(days=1)
+    callback = lambda x: now - timedelta(days=1)
     pattern[re.compile('^yesterday$')] = callback
-
-    # {n} days ago
-    n_days_regexp = re.compile('^(\d*) day[s]? ago')
-
-    def _n_days_ago(x):
-        ndays = n_days_regexp.search(x).group(1)
-        return datetime.now() - timedelta(days=int(ndays))
-
-    pattern[n_days_regexp] = _n_days_ago
-
-    # {n} weeks ago
-    n_weeks_regexp = re.compile('^(\d*) week[s]? ago')
-
-    def _n_weeks_ago(x):
-        nweeks = n_weeks_regexp.search(x).group(1)
-        return datetime.now() - timedelta(weeks=int(nweeks))
-
-    pattern[n_weeks_regexp] = _n_weeks_ago
 
     for regexp, parser in pattern.items():
         if bool(regexp.match(date_str)):
             return parser(date_str)
 
-    msg = 'date {0} does not match any valid format'.format(date_str)
+    msg = 'date "{0}" does not match any valid format'.format(date_str)
     raise ValueError(msg)
 
 

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -129,7 +129,7 @@ def query_arguments(args):
     for attribute in ('start_date', 'end_date'):
         date = getattr(args, attribute)
         if date:
-            q_args[attribute] = llnl.util.lang.str2date(date)
+            q_args[attribute] = llnl.util.lang.pretty_string_to_date(date)
 
     return q_args
 

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -22,10 +22,10 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-import datetime
 import sys
 
 import llnl.util.tty as tty
+import llnl.util.lang
 import spack
 import spack.database
 import spack.cmd.common.arguments as arguments
@@ -129,27 +129,7 @@ def query_arguments(args):
     for attribute in ('start_date', 'end_date'):
         date = getattr(args, attribute)
         if date:
-            # Permits to have different, telescopic, time formats
-            time_formats = [
-                '%Y',
-                '%Y-%m',
-                '%Y-%m-%d',
-            ]
-            datetime_value = None
-            for time_fmt in time_formats:
-                try:
-                    datetime_value = datetime.datetime.strptime(
-                        date, time_fmt
-                    )
-                    break
-                except ValueError:
-                    pass
-
-            if datetime_value is None:
-                msg = 'date {0} does not match any valid format'.format(date)
-                raise ValueError(msg)
-
-            q_args[attribute] = datetime_value
+            q_args[attribute] = llnl.util.lang.str2date(date)
 
     return q_args
 

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -26,6 +26,7 @@ import sys
 
 import llnl.util.tty as tty
 import spack
+import spack.database
 import spack.cmd.common.arguments as arguments
 from spack.cmd import display_specs
 
@@ -96,6 +97,14 @@ def setup_parser(subparser):
                            action='store_true',
                            help='show fully qualified package names')
 
+    subparser.add_argument(
+        '--start-date',
+        help='earliest date of installation [YYYY-MM-DD HH:MM:SS]'
+    )
+    subparser.add_argument(
+        '--end-date', help='latest date of installation [YYYY-MM-DD HH:MM:SS]'
+    )
+
     arguments.add_common_arguments(subparser, ['constraint'])
 
 
@@ -114,6 +123,13 @@ def query_arguments(args):
     if args.implicit:
         explicit = False
     q_args = {'installed': installed, 'known': known, "explicit": explicit}
+
+    # Time window of installation
+    for attribute in ('start_date', 'end_date'):
+        date = getattr(args, attribute)
+        if date:
+            q_args[attribute] = spack.database.str2datetime(date)
+
     return q_args
 
 

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -634,6 +634,22 @@ class Database(object):
         Also ensures dependencies are present and updated in the DB as
         either installed or missing.
 
+        Args:
+            spec: spec to be added
+            directory_layout: layout of the spec installation
+            **kwargs:
+
+                explicit
+                    Possible values: True, False, any
+
+                    A spec that was installed following a specific user
+                    request is marked as explicit. If instead it was
+                    pulled-in as a dependency of a user requested spec
+                    it's considered implicit.
+
+                installation_datetime
+                    Date and time of installation
+
         """
         if not spec.concrete:
             raise NonConcreteSpecAddError(

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -467,7 +467,7 @@ class Database(object):
                     tty.debug(
                         'RECONSTRUCTING FROM SPEC.YAML: {0}'.format(spec))
                     explicit = True
-                    inst_time = _now()
+                    inst_time = os.stat(spec.prefix).st_ctime
                     if old_data is not None:
                         old_info = old_data.get(spec.dag_hash())
                         if old_info is not None:
@@ -611,7 +611,13 @@ class Database(object):
                 self._write(None, None, None)
             self.reindex(spack.store.layout)
 
-    def _add(self, spec, directory_layout=None, **kwargs):
+    def _add(
+            self,
+            spec,
+            directory_layout=None,
+            explicit=False,
+            installation_time=None
+    ):
         """Add an install record for this spec to the database.
 
         Assumes spec is installed in ``layout.path_for_spec(spec)``.
@@ -641,10 +647,7 @@ class Database(object):
                 "Specs added to DB must be concrete.")
 
         # Retrieve optional arguments
-        explicit = kwargs.get('explicit', False)
-        installation_time = kwargs.get(
-            'installation_time', _now()
-        )
+        installation_time = installation_time or _now()
 
         for dep in spec.dependencies(_tracked_deps):
             dkey = dep.dag_hash()
@@ -923,8 +926,7 @@ class Database(object):
 
         """
         concrete_specs = self.query(
-            query_spec, known=known, installed=installed
-        )
+            query_spec, known=known, installed=installed)
         assert len(concrete_specs) <= 1
         return concrete_specs[0] if concrete_specs else None
 

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -62,7 +62,9 @@ def test_query_arguments():
         missing=False,
         unknown=False,
         explicit=False,
-        implicit=False
+        implicit=False,
+        start_date="2018-02-23 14:36:00",
+        end_date=None
     )
 
     q_args = query_arguments(args)
@@ -72,6 +74,8 @@ def test_query_arguments():
     assert q_args['installed'] is True
     assert q_args['known'] is any
     assert q_args['explicit'] is any
+    assert 'start_date' in q_args
+    assert 'end_date' not in q_args
 
     # Check that explicit works correctly
     args.explicit = True

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -63,7 +63,7 @@ def test_query_arguments():
         unknown=False,
         explicit=False,
         implicit=False,
-        start_date="2018-02-23 14:36:00",
+        start_date="2018-02-23",
         end_date=None
     )
 

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -26,6 +26,7 @@
 These tests check the database is functioning properly,
 both in memory and in its file
 """
+import datetime
 import multiprocessing
 import os
 import pytest
@@ -292,6 +293,12 @@ def test_050_basic_query(database):
     assert len(install_db.query('mpileaks ^mpich')) == 1
     assert len(install_db.query('mpileaks ^mpich2')) == 1
     assert len(install_db.query('mpileaks ^zmpi')) == 1
+
+    # Query by date
+    assert len(install_db.query(start_date=datetime.datetime.min)) == 16
+    assert len(install_db.query(start_date=datetime.datetime.max)) == 0
+    assert len(install_db.query(end_date=datetime.datetime.min)) == 0
+    assert len(install_db.query(end_date=datetime.datetime.max)) == 16
 
 
 def test_060_remove_and_add_root_package(database):

--- a/lib/spack/spack/test/llnl/util/lang.py
+++ b/lib/spack/spack/test/llnl/util/lang.py
@@ -23,9 +23,16 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import pytest
+
 from datetime import datetime, timedelta
 
+import llnl.util.lang
 from llnl.util.lang import pretty_date, match_predicate
+
+
+@pytest.fixture()
+def now():
+    return datetime.now()
 
 
 def test_pretty_date():
@@ -73,6 +80,32 @@ def test_pretty_date():
 
     years = now - timedelta(days=365 * 2)
     assert pretty_date(years, now) == "2 years ago"
+
+
+@pytest.mark.parametrize('delta,pretty_string', [
+    (timedelta(days=1), 'a day ago'),
+    (timedelta(days=1), 'yesterday'),
+    (timedelta(days=1), '1 day ago'),
+    (timedelta(weeks=1), '1 week ago'),
+    (timedelta(weeks=3), '3 weeks ago'),
+    (timedelta(days=30), '1 month ago'),
+    (timedelta(days=730), '2 years  ago'),
+])
+def test_pretty_string_to_date_delta(now, delta, pretty_string):
+    t1 = now - delta
+    t2 = llnl.util.lang.pretty_string_to_date(pretty_string, now)
+    assert t1 == t2
+
+
+@pytest.mark.parametrize('format,pretty_string', [
+    ('%Y', '2018'),
+    ('%Y-%m', '2015-03'),
+    ('%Y-%m-%d', '2015-03-28'),
+])
+def test_pretty_string_to_date(format, pretty_string):
+    t1 = datetime.strptime(pretty_string, format)
+    t2 = llnl.util.lang.pretty_string_to_date(pretty_string, now)
+    assert t1 == t2
 
 
 def test_match_predicate():


### PR DESCRIPTION
Information on the date and time of installation of a spec is recorded into the database. The information is retained on reindexing. The DB can now be queried for specs that have been installed in a given time window. This query possibility is exposed to command line via two new options of the `find` command.

##### Examples
With the following command:
```console
$ spack install  hdf5~mpi~cxx~fortran
```
you'll generate a database that contains date and time information. Now you can query from command line based on date and time of installation:
```console
$ spack find
==> 2 installed packages.
-- linux-ubuntu14.04-x86_64 / gcc@4.8 ---------------------------
hdf5@1.10.1  zlib@1.2.11

$ spack find --start-date="2019"
==> 0 installed packages.

$ spack find --start-date="2 days ago" 
==> 1 installed packages.
-- linux-ubuntu14.04-x86_64 / gcc@4.8 ---------------------------
hdf5@1.10.1

$ spack find --end-date="2018-02-23"
==> 1 installed packages.
-- linux-ubuntu14.04-x86_64 / gcc@4.8 ---------------------------
zlib@1.2.11
```

A practical use-case we have in mind at EPFL is to use this feature in a cron job that, based on the result of the query, updates the MOTD on clusters front-end and advertizes the software that has been installed recently (e.g. in the last two weeks).

@nazavode 