### PR TITLE
Add sqlite 3.22.0

### DIFF
--- a/var/spack/repos/builtin/packages/sqlite/package.py
+++ b/var/spack/repos/builtin/packages/sqlite/package.py
@@ -33,6 +33,8 @@ class Sqlite(AutotoolsPackage):
     """
     homepage = "www.sqlite.org"
 
+    version('3.22.0', '2fb24ec12001926d5209d2da90d252b9825366ac',
+            url='https://www.sqlite.org/2018/sqlite-autoconf-3220000.tar.gz')
     version('3.21.0', '7913de4c3126ba3c24689cb7a199ea31',
             url='https://www.sqlite.org/2017/sqlite-autoconf-3210000.tar.gz')
     version('3.20.0', 'e262a28b73cc330e7e83520c8ce14e4d',


### PR DESCRIPTION
This commit adds sqlite 3.22.0 to the spack repository