### PR TITLE
Pin Sphinx version to v1.7.0

### DIFF
--- a/lib/spack/docs/requirements.txt
+++ b/lib/spack/docs/requirements.txt
@@ -1,5 +1,5 @@
 # These dependencies should be installed using pip in order
 # to build the documentation.
 
-sphinx
+sphinx==1.7.0
 sphinxcontrib-programoutput


### PR DESCRIPTION
Later versions of Sphinx fail due to possible clashes with our custom `argparse`.