### PR TITLE
change recurse into recursive in a few places

### DIFF
--- a/var/spack/repos/builtin/packages/bzip2/package.py
+++ b/var/spack/repos/builtin/packages/bzip2/package.py
@@ -45,7 +45,7 @@ class Bzip2(Package):
     def libs(self):
         shared = '+shared' in self.spec
         return find_libraries(
-            'libbz2', root=self.prefix, shared=shared, recurse=True
+            'libbz2', root=self.prefix, shared=shared, recursive=True
         )
 
     def patch(self):

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -118,7 +118,7 @@ class Fftw(AutotoolsPackage):
 
             libraries.append('libfftw3' + sfx)
 
-        return find_libraries(libraries, root=self.prefix, recurse=True)
+        return find_libraries(libraries, root=self.prefix, recursive=True)
 
     def autoreconf(self, spec, prefix):
         if '+pfft_patches' in spec:

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -258,7 +258,7 @@ class IntelParallelStudio(IntelPackage):
             libraries = ['libmpicxx'] + libraries
 
         return find_libraries(
-            libraries, root=mpi_root, shared=True, recurse=True
+            libraries, root=mpi_root, shared=True, recursive=True
         )
 
     @property
@@ -266,7 +266,7 @@ class IntelParallelStudio(IntelPackage):
         # recurse from self.prefix will find too many things for all the
         # supported sub-architectures like 'mic'
         mpi_root = self.prefix.compilers_and_libraries.linux.mpi.include64
-        return find_headers('mpi', root=mpi_root, recurse=False)
+        return find_headers('mpi', root=mpi_root, recursive=False)
 
     @property
     def components(self):

--- a/var/spack/repos/builtin/packages/libxsmm/package.py
+++ b/var/spack/repos/builtin/packages/libxsmm/package.py
@@ -68,10 +68,10 @@ class Libxsmm(MakefilePackage):
     @property
     def libs(self):
         result = find_libraries(['libxsmm', 'libxsmmf'], root=self.prefix,
-                                recurse=True)
+                                recursive=True)
         if len(result) == 0:
             result = find_libraries(['libxsmm', 'libxsmmf'], root=self.prefix,
-                                    shared=False, recurse=True)
+                                    shared=False, recursive=True)
         return result
 
     def edit(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/netcdf-cxx/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx/package.py
@@ -42,5 +42,5 @@ class NetcdfCxx(AutotoolsPackage):
     def libs(self):
         shared = True
         return find_libraries(
-            'libnetcdf_c++', root=self.prefix, shared=shared, recurse=True
+            'libnetcdf_c++', root=self.prefix, shared=shared, recursive=True
         )

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -45,5 +45,5 @@ class NetcdfCxx4(AutotoolsPackage):
     def libs(self):
         shared = True
         return find_libraries(
-            'libnetcdf_c++4', root=self.prefix, shared=shared, recurse=True
+            'libnetcdf_c++4', root=self.prefix, shared=shared, recursive=True
         )

--- a/var/spack/repos/builtin/packages/netlib-xblas/package.py
+++ b/var/spack/repos/builtin/packages/netlib-xblas/package.py
@@ -54,7 +54,7 @@ class NetlibXblas(AutotoolsPackage):
     @property
     def libs(self):
         return find_libraries(['libxblas'], root=self.prefix,
-                              shared=False, recurse=True)
+                              shared=False, recursive=True)
 
     def configure_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -234,5 +234,5 @@ class Opencv(CMakePackage):
     def libs(self):
         shared = "+shared" in self.spec
         return find_libraries(
-            "libopencv_*", root=self.prefix, shared=shared, recurse=True
+            "libopencv_*", root=self.prefix, shared=shared, recursive=True
         )


### PR DESCRIPTION
i introduced those in https://github.com/spack/spack/pull/6552 and I don't understand how it worked as `find_libraries` seem to have `recursive` for at least 7 months https://github.com/spack/spack/blame/develop/lib/spack/llnl/util/filesystem.py#L1069