### PR TITLE
Fix class name in build system tutorials

### DIFF
--- a/lib/spack/docs/tutorial/examples/Autotools/0.package.py
+++ b/lib/spack/docs/tutorial/examples/Autotools/0.package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Mpileaks(AutoToolsPackage):
+class Mpileaks(AutotoolsPackage):
     """Tool to detect and report leaked MPI objects like MPI_Requests and
        MPI_Datatypes."""
 

--- a/lib/spack/docs/tutorial/examples/Autotools/1.package.py
+++ b/lib/spack/docs/tutorial/examples/Autotools/1.package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Mpileaks(AutoToolsPackage):
+class Mpileaks(AutotoolsPackage):
     """Tool to detect and report leaked MPI objects like MPI_Requests and
        MPI_Datatypes."""
 


### PR DESCRIPTION
AutoTools -> Autotools
Fix for #7249