### PR TITLE
fix apr pick up of log4cxx

### DIFF
--- a/lib/spack/spack/cmd/activate.py
+++ b/lib/spack/spack/cmd/activate.py
@@ -35,9 +35,6 @@ level = "long"
 
 def setup_parser(subparser):
     subparser.add_argument(
-        '-f', '--force', action='store_true',
-        help="activate without first activating dependencies")
-    subparser.add_argument(
         '-v', '--view', metavar='VIEW', type=str,
         help="the view to operate on")
     subparser.add_argument(

--- a/lib/spack/spack/cmd/activate.py
+++ b/lib/spack/spack/cmd/activate.py
@@ -35,6 +35,9 @@ level = "long"
 
 def setup_parser(subparser):
     subparser.add_argument(
+        '-f', '--force', action='store_true',
+        help="activate without first activating dependencies")
+    subparser.add_argument(
         '-v', '--view', metavar='VIEW', type=str,
         help="the view to operate on")
     subparser.add_argument(

--- a/var/spack/repos/builtin/packages/log4cxx/package.py
+++ b/var/spack/repos/builtin/packages/log4cxx/package.py
@@ -43,10 +43,8 @@ class Log4cxx(AutotoolsPackage):
     patch('log4cxx-0.10.0-narrowing-fixes-from-upstream.patch')
 
     def configure_args(self):
-        args = [
-                '--disable-static',
+        args = ['--disable-static',
                 # 'apr''s 'bin' isn't pulled (via apr-util) into build env
-                '--with-apr={0}'.format(self.spec['apr'].prefix),
-                ]
+                '--with-apr={0}'.format(self.spec['apr'].prefix)]
 
         return args

--- a/var/spack/repos/builtin/packages/log4cxx/package.py
+++ b/var/spack/repos/builtin/packages/log4cxx/package.py
@@ -43,5 +43,10 @@ class Log4cxx(AutotoolsPackage):
     patch('log4cxx-0.10.0-narrowing-fixes-from-upstream.patch')
 
     def configure_args(self):
-        args = ['--disable-static']
+        args = [
+                '--disable-static',
+                # 'apr''s 'bin' isn't pulled (via apr-util) into build env
+                '--with-apr={0}'.format(self.spec['apr'].prefix),
+                ]
+
         return args


### PR DESCRIPTION
While installing `log4cxx` on a minimal ubuntu this patch was needed to make `log4cxx` build. Our current working hypothesis is that it worked previously because the systems `apr` was picked up automatically by configure.

I'm not sure whether this is a more wide-spread issue or not.