### PR TITLE
OpenSSL: https

### DIFF
--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -36,7 +36,7 @@ class Openssl(Package):
     homepage = "http://www.openssl.org"
 
     # URL must remain http:// so Spack can bootstrap curl
-    url = "http://www.openssl.org/source/openssl-1.0.2m.tar.gz"
+    url = "https://www.openssl.org/source/openssl-1.0.2m.tar.gz"
     list_url = "https://www.openssl.org/source/old/"
     list_depth = 1
 


### PR DESCRIPTION
Fetching OpenSSL without a TLS URL feels wrong.

Just kidding.
Although we check hashsums, https should be preferred over http links for e.g. privacy reasons.
(An observer on the wire will still see you visit openssl.org but not which resources you access.)