### PR TITLE
mosh build depends on pkg-config

### DIFF
--- a/var/spack/repos/builtin/packages/mosh/package.py
+++ b/var/spack/repos/builtin/packages/mosh/package.py
@@ -44,6 +44,7 @@ class Mosh(AutotoolsPackage):
     depends_on('zlib')
     depends_on('openssl')
 
+    depends_on('pkgconfig', type='build')
     depends_on('perl', type='run')
 
     build_directory = 'spack-build'


### PR DESCRIPTION
I tried a test-build on a fairly minimal debian stretch and encountered that `mosh` depends on some `pkg-config` (also mentioned here: https://github.com/mobile-shell/mosh/wiki/Build-Instructions).