### PR TITLE
Rsync: Fix Src Link

### DIFF
--- a/var/spack/repos/builtin/packages/rsync/package.py
+++ b/var/spack/repos/builtin/packages/rsync/package.py
@@ -28,7 +28,7 @@ from spack import *
 class Rsync(AutotoolsPackage):
     """An open source utility that provides fast incremental file transfer."""
     homepage = "https://rsync.samba.org"
-    url      = "https://download.samba.org/pub/rsync/rsync-3.1.1.tar.gz"
+    url      = "https://download.samba.org/pub/rsync/src/rsync-3.1.2.tar.gz"
 
     version('3.1.2', '0f758d7e000c0f7f7d3792610fad70cb')
     version('3.1.1', '43bd6676f0b404326eee2d63be3cdcfe')


### PR DESCRIPTION
Fix the source link to rsync downloads.

The old link only contained the latest release, the new link contains all.