### PR TITLE
libSplash 1.7.0: Root Fix

### DIFF
--- a/var/spack/repos/builtin/packages/libsplash/package.py
+++ b/var/spack/repos/builtin/packages/libsplash/package.py
@@ -57,6 +57,8 @@ class Libsplash(CMakePackage):
     depends_on('hdf5@1.8.6: +mpi', when='+mpi')
     depends_on('mpi', when='+mpi')
 
+    patch('root_cmake_1.7.0.patch', when='@1.7.0')
+
     def cmake_args(self):
         spec = self.spec
         args = []

--- a/var/spack/repos/builtin/packages/libsplash/root_cmake_1.7.0.patch
+++ b/var/spack/repos/builtin/packages/libsplash/root_cmake_1.7.0.patch
@@ -1,0 +1,15 @@
+diff --git CMakeLists.txt CMakeLists.txt
+index 4846ff7..5e102ce 100644
+--- libSplash-1.7.0/CMakeLists.txt
++++ libSplash-1.7.0/CMakeLists.txt
+@@ -392,7 +392,8 @@ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/tools/splash2xdmf.py DESTINATION bin)
+ #
+ enable_testing()
+ 
+-if($ENV{USER} STREQUAL root)
++# OpenMPI root guard: https://github.com/open-mpi/ompi/issues/4451
++if("$ENV{USER}" STREQUAL "root")
+     set(MPI_ALLOW_ROOT --allow-run-as-root)
+ endif()
+ set(MPI_TEST_EXE ${MPIEXEC_EXECUTABLE} ${MPI_ALLOW_ROOT} ${MPIEXEC_NUMPROC_FLAG})
+


### PR DESCRIPTION
Fix installs as "root" user for the last libSplash release.

Missing quoting of string compares resulted in a CMake error when run as root (e.g. in a Docker build).

Reference: https://github.com/ComputationalRadiationPhysics/libSplash/pull/277