### PR TITLE
py-gpaw package with variants for MPI, FFTW and ScaLAPACK

### DIFF
--- a/var/spack/repos/builtin/packages/py-ase/package.py
+++ b/var/spack/repos/builtin/packages/py-ase/package.py
@@ -33,6 +33,7 @@ class PyAse(PythonPackage):
     homepage = "https://wiki.fysik.dtu.dk/ase/"
     url      = "https://pypi.io/packages/source/a/ase/ase-3.13.0.tar.gz"
 
+    version('3.15.0', '65a0143753517c2df157e53bd29a18e3')
     version('3.13.0', 'e946a0addc5b61e5e2e75857e0f99b89')
 
     depends_on('python@2.6:')

--- a/var/spack/repos/builtin/packages/py-gpaw/package.py
+++ b/var/spack/repos/builtin/packages/py-gpaw/package.py
@@ -26,7 +26,7 @@ from spack import *
 
 
 class PyGpaw(PythonPackage):
-    """GPAW is a density-functional theory (DFT) Python code based on the 
+    """GPAW is a density-functional theory (DFT) Python code based on the
     projector-augmented wave (PAW) method and the atomic simulation environment
     (ASE)."""
 
@@ -40,7 +40,7 @@ class PyGpaw(PythonPackage):
             description='Build with ScaLAPACK support')
     variant('fftw', default=True, description='Build with FFTW support')
 
-    depends_on('mpi',when='+mpi', type=('build','link','run'))
+    depends_on('mpi', when='+mpi', type=('build', 'link', 'run'))
     depends_on('python@2.6:')
     depends_on('py-ase@3.13.0:', type=('build', 'run'))
     depends_on('py-numpy +blas +lapack', type=('build', 'run'))
@@ -62,10 +62,10 @@ class PyGpaw(PythonPackage):
 
         libs = blas.libs + lapack.libs + libxc.libs
         include_dirs = [
-                        blas.prefix.include,
-                        lapack.prefix.include,
-                        libxc.prefix.include
-                        ]
+            blas.prefix.include,
+            lapack.prefix.include,
+            libxc.prefix.include
+        ]
         if '+mpi' in spec:
             libs += spec['mpi'].libs
             mpi_include_dirs = repr([spec['mpi'].prefix.include])
@@ -74,21 +74,25 @@ class PyGpaw(PythonPackage):
         if '+scalapack' in spec:
             libs += spec['scalapack'].libs
             include_dirs.append(spec['scalapack'].prefix.include)
-            scalapack_macros=[('GPAW_NO_UNDERSCORE_CBLACS','1'),
-                             ('GPAW_NO_UNDERSCORE_CSCALAPACK', '1')]
+            scalapack_macros = repr([
+                ('GPAW_NO_UNDERSCORE_CBLACS', '1'),
+                ('GPAW_NO_UNDERSCORE_CSCALAPACK', '1')
+            ])
         if '+fftw' in spec:
             libs += spec['fftw'].libs
             include_dirs.append(spec['fftw'].prefix.include)
 
         lib_dirs = list(libs.directories)
         libs = list(libs.names)
-        rpath_str=':'.join(self.rpath)
+        rpath_str = ':'.join(self.rpath)
 
         with open('customize.py', 'w') as f:
             f.write("libraries = {0}\n".format(repr(libs)))
             f.write("include_dirs = {0}\n".format(repr(include_dirs)))
             f.write("library_dirs = {0}\n".format(repr(lib_dirs)))
-            f.write("extra_link_args += ['-Wl,-rpath={0}']\n".format(rpath_str))
+            f.write(
+                "extra_link_args += ['-Wl,-rpath={0}']\n".format(rpath_str)
+            )
             if '+mpi' in spec:
                 f.write("define_macros += [('PARALLEL', '1')]\n")
                 f.write("compiler='{0}'\n".format(spec['mpi'].mpicc))
@@ -100,4 +104,4 @@ class PyGpaw(PythonPackage):
                 f.write("mpicompiler = None\n")
             if '+scalapack' in spec:
                 f.write("scalapack = True\n")
-                f.write("define_macros += {0}\n".format(repr(scalapack_macros)))
+                f.write("define_macros += {0}\n".format(scalapack_macros))

--- a/var/spack/repos/builtin/packages/py-gpaw/package.py
+++ b/var/spack/repos/builtin/packages/py-gpaw/package.py
@@ -1,0 +1,95 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyGpaw(PythonPackage):
+    """GPAW is a density-functional theory (DFT) Python code based on the projector-augmented wave (PAW) method and the atomic simulation environment (ASE)."""
+
+    homepage = "https://wiki.fysik.dtu.dk/gpaw/index.html"
+    url      = "https://pypi.io/packages/source/g/gpaw/gpaw-1.3.0.tar.gz"
+
+    version('1.3.0', '82e8c80e637696248db00b5713cdffd1')
+
+    variant('mpi', default=True, description='Build with MPI support')
+    variant('scalapack', default=False, description='Build with ScaLAPACK support')
+    variant('fftw', default=True, description='Build with FFTW support')
+
+    depends_on('mpi',when='+mpi',type=('build','link','run'))
+    depends_on('python@2.6:')
+    depends_on('py-ase',        type=('build', 'run'))
+    depends_on('py-numpy +blas +lapack', type=('build', 'run'))
+    depends_on('py-scipy',      type=('build', 'run'))
+    depends_on('libxc',type=('build','link','run'))
+    depends_on('blas',type=('build','link','run'))
+    depends_on('lapack',type=('build','link','run'))
+    depends_on('fftw+mpi',when='+fftw +mpi')
+    depends_on('fftw~mpi',when='+fftw ~mpi')
+    depends_on('scalapack',when='+scalapack')
+
+    def patch(self):
+        spec = self.spec
+        compiler = self.compiler
+        # For build notes see https://wiki.fysik.dtu.dk/gpaw/install.html
+
+        libxc = spec['libxc']
+        blas = spec['blas']
+        lapack = spec['lapack']
+
+        libs = blas.libs + lapack.libs + libxc.libs
+        include_dirs = [blas.prefix.include,lapack.prefix.include,libxc.prefix.include]
+        lib_dirs = [blas.prefix.lib,lapack.prefix.lib,libxc.prefix.lib]
+        if '+mpi' in spec:
+            libs += spec['mpi'].libs
+            include_dirs.append(spec['mpi'].prefix.include)
+            lib_dirs.append(spec['mpi'].prefix.lib)
+        if '+scalapack' in spec:
+            libs += spec['scalapack'].libs
+            include_dirs.append(spec['scalapack'].prefix.include)
+            lib_dirs.append(spec['scalapack'].prefix.lib)
+        if '+fftw' in spec:
+            libs += spec['fftw'].libs
+            include_dirs.append(spec['fftw'].prefix.include)
+            lib_dirs.append(spec['fftw'].prefix.lib)
+        libs = list(libs.names)
+
+        with open('customize.py', 'w') as f:
+            f.write("libraries = {0}\n".format(repr(libs)))
+            f.write("include_dirs = {0}\n".format(repr(include_dirs)))
+            f.write("library_dirs = {0}\n".format(repr(lib_dirs)))
+            f.write("extra_link_args += ['-Wl,-rpath={0}']\n".format(':'.join(self.rpath)))
+            if '+mpi' in spec:
+                f.write("define_macros += [('PARALLEL', '1')]\n")
+                f.write("compiler='{0}'\n".format(spec['mpi'].mpicc))
+                f.write("mpicompiler = '{0}'\n".format(spec['mpi'].mpicc))
+                f.write("mpi_include_dirs = {0}\n".format(repr([spec['mpi'].prefix.include])))
+                f.write("mpi_library_dirs = {0}\n".format(repr([spec['mpi'].prefix.lib])))
+            else:
+                f.write("compiler='{0}'\n".format(self.compiler.cc))
+                f.write("mpicompiler = None\n")
+            if '+scalapack' in spec:
+              f.write("scalapack = True\n")
+              f.write("define_macros += [('GPAW_NO_UNDERSCORE_CBLACS', '1')]\n")
+              f.write("define_macros += [('GPAW_NO_UNDERSCORE_CSCALAPACK', '1')]\n")

--- a/var/spack/repos/builtin/packages/py-gpaw/package.py
+++ b/var/spack/repos/builtin/packages/py-gpaw/package.py
@@ -42,9 +42,9 @@ class PyGpaw(PythonPackage):
     depends_on('py-ase',        type=('build', 'run'))
     depends_on('py-numpy +blas +lapack', type=('build', 'run'))
     depends_on('py-scipy',      type=('build', 'run'))
-    depends_on('libxc',type=('build','link','run'))
-    depends_on('blas',type=('build','link','run'))
-    depends_on('lapack',type=('build','link','run'))
+    depends_on('libxc')
+    depends_on('blas')
+    depends_on('lapack')
     depends_on('fftw+mpi',when='+fftw +mpi')
     depends_on('fftw~mpi',when='+fftw ~mpi')
     depends_on('scalapack',when='+scalapack')
@@ -60,19 +60,16 @@ class PyGpaw(PythonPackage):
 
         libs = blas.libs + lapack.libs + libxc.libs
         include_dirs = [blas.prefix.include,lapack.prefix.include,libxc.prefix.include]
-        lib_dirs = [blas.prefix.lib,lapack.prefix.lib,libxc.prefix.lib]
         if '+mpi' in spec:
             libs += spec['mpi'].libs
             include_dirs.append(spec['mpi'].prefix.include)
-            lib_dirs.append(spec['mpi'].prefix.lib)
         if '+scalapack' in spec:
             libs += spec['scalapack'].libs
             include_dirs.append(spec['scalapack'].prefix.include)
-            lib_dirs.append(spec['scalapack'].prefix.lib)
         if '+fftw' in spec:
             libs += spec['fftw'].libs
             include_dirs.append(spec['fftw'].prefix.include)
-            lib_dirs.append(spec['fftw'].prefix.lib)
+        lib_dirs = list(libs.directories)
         libs = list(libs.names)
 
         with open('customize.py', 'w') as f:

--- a/var/spack/repos/builtin/packages/py-gpaw/package.py
+++ b/var/spack/repos/builtin/packages/py-gpaw/package.py
@@ -26,7 +26,9 @@ from spack import *
 
 
 class PyGpaw(PythonPackage):
-    """GPAW is a density-functional theory (DFT) Python code based on the projector-augmented wave (PAW) method and the atomic simulation environment (ASE)."""
+    """GPAW is a density-functional theory (DFT) Python code based on the 
+    projector-augmented wave (PAW) method and the atomic simulation environment
+    (ASE)."""
 
     homepage = "https://wiki.fysik.dtu.dk/gpaw/index.html"
     url      = "https://pypi.io/packages/source/g/gpaw/gpaw-1.3.0.tar.gz"
@@ -34,24 +36,24 @@ class PyGpaw(PythonPackage):
     version('1.3.0', '82e8c80e637696248db00b5713cdffd1')
 
     variant('mpi', default=True, description='Build with MPI support')
-    variant('scalapack', default=False, description='Build with ScaLAPACK support')
+    variant('scalapack', default=False,
+            description='Build with ScaLAPACK support')
     variant('fftw', default=True, description='Build with FFTW support')
 
-    depends_on('mpi',when='+mpi',type=('build','link','run'))
+    depends_on('mpi',when='+mpi', type=('build','link','run'))
     depends_on('python@2.6:')
-    depends_on('py-ase',        type=('build', 'run'))
+    depends_on('py-ase@3.13.0:', type=('build', 'run'))
     depends_on('py-numpy +blas +lapack', type=('build', 'run'))
-    depends_on('py-scipy',      type=('build', 'run'))
+    depends_on('py-scipy', type=('build', 'run'))
     depends_on('libxc')
     depends_on('blas')
     depends_on('lapack')
-    depends_on('fftw+mpi',when='+fftw +mpi')
-    depends_on('fftw~mpi',when='+fftw ~mpi')
-    depends_on('scalapack',when='+scalapack')
+    depends_on('fftw+mpi', when='+fftw +mpi')
+    depends_on('fftw~mpi', when='+fftw ~mpi')
+    depends_on('scalapack', when='+scalapack')
 
     def patch(self):
         spec = self.spec
-        compiler = self.compiler
         # For build notes see https://wiki.fysik.dtu.dk/gpaw/install.html
 
         libxc = spec['libxc']
@@ -59,34 +61,43 @@ class PyGpaw(PythonPackage):
         lapack = spec['lapack']
 
         libs = blas.libs + lapack.libs + libxc.libs
-        include_dirs = [blas.prefix.include,lapack.prefix.include,libxc.prefix.include]
+        include_dirs = [
+                        blas.prefix.include,
+                        lapack.prefix.include,
+                        libxc.prefix.include
+                        ]
         if '+mpi' in spec:
             libs += spec['mpi'].libs
+            mpi_include_dirs = repr([spec['mpi'].prefix.include])
+            mpi_library_dirs = repr(list(spec['mpi'].libs.directories))
             include_dirs.append(spec['mpi'].prefix.include)
         if '+scalapack' in spec:
             libs += spec['scalapack'].libs
             include_dirs.append(spec['scalapack'].prefix.include)
+            scalapack_macros=[('GPAW_NO_UNDERSCORE_CBLACS','1'),
+                             ('GPAW_NO_UNDERSCORE_CSCALAPACK', '1')]
         if '+fftw' in spec:
             libs += spec['fftw'].libs
             include_dirs.append(spec['fftw'].prefix.include)
+
         lib_dirs = list(libs.directories)
         libs = list(libs.names)
+        rpath_str=':'.join(self.rpath)
 
         with open('customize.py', 'w') as f:
             f.write("libraries = {0}\n".format(repr(libs)))
             f.write("include_dirs = {0}\n".format(repr(include_dirs)))
             f.write("library_dirs = {0}\n".format(repr(lib_dirs)))
-            f.write("extra_link_args += ['-Wl,-rpath={0}']\n".format(':'.join(self.rpath)))
+            f.write("extra_link_args += ['-Wl,-rpath={0}']\n".format(rpath_str))
             if '+mpi' in spec:
                 f.write("define_macros += [('PARALLEL', '1')]\n")
                 f.write("compiler='{0}'\n".format(spec['mpi'].mpicc))
                 f.write("mpicompiler = '{0}'\n".format(spec['mpi'].mpicc))
-                f.write("mpi_include_dirs = {0}\n".format(repr([spec['mpi'].prefix.include])))
-                f.write("mpi_library_dirs = {0}\n".format(repr([spec['mpi'].prefix.lib])))
+                f.write("mpi_include_dirs = {0}\n".format(mpi_include_dirs))
+                f.write("mpi_library_dirs = {0}\n".format(mpi_library_dirs))
             else:
                 f.write("compiler='{0}'\n".format(self.compiler.cc))
                 f.write("mpicompiler = None\n")
             if '+scalapack' in spec:
-              f.write("scalapack = True\n")
-              f.write("define_macros += [('GPAW_NO_UNDERSCORE_CBLACS', '1')]\n")
-              f.write("define_macros += [('GPAW_NO_UNDERSCORE_CSCALAPACK', '1')]\n")
+                f.write("scalapack = True\n")
+                f.write("define_macros += {0}\n".format(repr(scalapack_macros)))


### PR DESCRIPTION
Hi,

There is an existing PR for py-gpaw [#4554](https://github.com/spack/spack/pull/4554), but I did not notice it before I had already written an implementation of `py-gpaw`-package.

This implementation takes into account the various dependencies of GPAW. We have this version in production in our cluster environment.

This implementation has:
- variant for MPI
- variant for FFTW
- variant for ScaLAPACK

All of the combinations have been tested in practice with

```sh
mpirun -np 2 gpaw-python $(which gpaw) test
```
for MPI variant and
```sh
python $(which gpaw) test
```
for non-MPI variant.

The script is missing tests during installation as gpaw-setups would need to be loaded.

To test:

1. `git clone https://github.com/simo-tuomisto/spack.git`
2. `source spack/share/spack/setup-env.sh`
3. `spack build py-gpaw +scalapack +mpi +fftw`

So far I have only build it with gcc / openmpi / openblas . In future I will test icc / mkl .