### PR TITLE
py-py{gobject,gtk} require pkgconfig for build

### DIFF
--- a/var/spack/repos/builtin/packages/py-pygobject/package.py
+++ b/var/spack/repos/builtin/packages/py-pygobject/package.py
@@ -38,6 +38,7 @@ class PyPygobject(AutotoolsPackage):
 
     extends('python')
 
+    depends_on('pkgconfig', type=('build'))
     depends_on("libffi")
     depends_on('glib')
     depends_on('py-py2cairo', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-pygtk/package.py
+++ b/var/spack/repos/builtin/packages/py-pygtk/package.py
@@ -34,6 +34,8 @@ class PyPygtk(AutotoolsPackage):
     version('2.24.0', 'd27c7f245a9e027f6b6cd9acb7468e36')
 
     extends('python')
+
+    depends_on('pkgconfig', type=('build'))
     depends_on("libffi")
     depends_on('cairo')
     depends_on('glib')


### PR DESCRIPTION
I tried a test-build on a fairly minimal Debian Stretch (minimal + packages `git-core, curl, ca-certificates, python, procps, gcc, g++, file, make, patch, libc6-dev, xz-utils, lbzip2, sudo, ssh, unzip`) and encountered that `py-py{gobjects,gtk}` depend on `pkg-config`.