### PR TITLE
replace dash with underscore in os name

### DIFF
--- a/lib/spack/spack/architecture.py
+++ b/lib/spack/spack/architecture.py
@@ -241,7 +241,7 @@ class OperatingSystem(object):
 
     def __init__(self, name, version):
         self.name = name.replace('-', '_')
-        self.version = version
+        self.version = version.replace('-', '_')
 
     def __str__(self):
         return "%s%s" % (self.name, self.version)

--- a/lib/spack/spack/architecture.py
+++ b/lib/spack/spack/architecture.py
@@ -241,7 +241,7 @@ class OperatingSystem(object):
 
     def __init__(self, name, version):
         self.name = name.replace('-', '_')
-        self.version = version.replace('-', '_')
+        self.version = str(version).replace('-', '_')
 
     def __str__(self):
         return "%s%s" % (self.name, self.version)

--- a/lib/spack/spack/architecture.py
+++ b/lib/spack/spack/architecture.py
@@ -240,7 +240,7 @@ class OperatingSystem(object):
     """
 
     def __init__(self, name, version):
-        self.name = name
+        self.name = name.replace('-', '_')
         self.version = version
 
     def __str__(self):


### PR DESCRIPTION
Potential fix for https://github.com/spack/spack/issues/7356

It appears that `OperatingSystem` should be careful to format the provided name, since it looks like that name may contain a `-` (which is used by `ArchSpec` to delineate between platform, os, and target), for example if the `distname` reported by `external.distro.linux_distribution` (as used in `LinuxDistro`) contains a `-` (I should say I'm not 100% sure if `external.distro.linux_distribution` allows `-` but a cursory glance suggests it may be possible).