### PR TITLE
fix ruby build on gcc >= 7

### DIFF
--- a/var/spack/repos/builtin/packages/ruby/package.py
+++ b/var/spack/repos/builtin/packages/ruby/package.py
@@ -39,6 +39,7 @@ class Ruby(AutotoolsPackage):
 
     extendable = True
 
+    depends_on('pkgconfig', type=('build'))
     depends_on('libffi')
     depends_on('zlib')
     depends_on('libx11')
@@ -46,6 +47,11 @@ class Ruby(AutotoolsPackage):
     depends_on('tk')
     depends_on('openssl', when='+openssl')
     depends_on('readline', when='+readline')
+
+    # gcc-7-based build requires patches (cf. https://bugs.ruby-lang.org/issues/13150)
+    patch('ruby_23_gcc7.patch', level=0, when='@2.2.0:2.2.999 %gcc@7:')
+    patch('ruby_23_gcc7.patch', level=0, when='@2.3.0:2.3.4 %gcc@7:')
+    patch('ruby_24_gcc7.patch', level=1, when='@2.4.0 %gcc@7:')
 
     resource(
         name='rubygems-updated-ssl-cert',

--- a/var/spack/repos/builtin/packages/ruby/ruby_23_gcc7.patch
+++ b/var/spack/repos/builtin/packages/ruby/ruby_23_gcc7.patch
@@ -1,0 +1,98 @@
+diff --git include/ruby/ruby.h include/ruby/ruby.h
+index 60cfb1174e..dccfdc763a 100644
+--- include/ruby/ruby.h
++++ include/ruby/ruby.h
+@@ -551,27 +551,23 @@ static inline int rb_type(VALUE obj);
+ 	((type) == RUBY_T_FLOAT) ? RB_FLOAT_TYPE_P(obj) : \
+ 	(!RB_SPECIAL_CONST_P(obj) && RB_BUILTIN_TYPE(obj) == (type)))
+ 
+-/* RB_GC_GUARD_PTR() is an intermediate macro, and has no effect by
+- * itself.  don't use it directly */
+ #ifdef __GNUC__
+-#define RB_GC_GUARD_PTR(ptr) \
+-    __extension__ ({volatile VALUE *rb_gc_guarded_ptr = (ptr); rb_gc_guarded_ptr;})
+-#else
+-#ifdef _MSC_VER
++#define RB_GC_GUARD(v) \
++    (*__extension__ ({ \
++	volatile VALUE *rb_gc_guarded_ptr = &(v); \
++	__asm__("" : : "m"(rb_gc_guarded_ptr)); \
++	rb_gc_guarded_ptr; \
++    }))
++#elif defined _MSC_VER
+ #pragma optimize("", off)
+ static inline volatile VALUE *rb_gc_guarded_ptr(volatile VALUE *ptr) {return ptr;}
+ #pragma optimize("", on)
++#define RB_GC_GUARD(v) (*rb_gc_guarded_ptr(&(v)))
+ #else
+ volatile VALUE *rb_gc_guarded_ptr_val(volatile VALUE *ptr, VALUE val);
+ #define HAVE_RB_GC_GUARDED_PTR_VAL 1
+ #define RB_GC_GUARD(v) (*rb_gc_guarded_ptr_val(&(v),(v)))
+ #endif
+-#define RB_GC_GUARD_PTR(ptr) rb_gc_guarded_ptr(ptr)
+-#endif
+-
+-#ifndef RB_GC_GUARD
+-#define RB_GC_GUARD(v) (*RB_GC_GUARD_PTR(&(v)))
+-#endif
+ 
+ #ifdef __GNUC__
+ #define RB_UNUSED_VAR(x) x __attribute__ ((unused))
+diff --git marshal.c marshal.c
+index c56de4af8d..b7274bf3c4 100644
+--- marshal.c
++++ marshal.c
+@@ -1022,7 +1022,7 @@ VALUE
+ rb_marshal_dump_limited(VALUE obj, VALUE port, int limit)
+ {
+     struct dump_arg *arg;
+-    VALUE wrapper; /* used to avoid memory leak in case of exception */
++    volatile VALUE wrapper; /* used to avoid memory leak in case of exception */
+ 
+     wrapper = TypedData_Make_Struct(rb_cData, struct dump_arg, &dump_arg_data, arg);
+     arg->dest = 0;
+@@ -1051,8 +1051,8 @@ rb_marshal_dump_limited(VALUE obj, VALUE port, int limit)
+ 	rb_io_write(arg->dest, arg->str);
+ 	rb_str_resize(arg->str, 0);
+     }
+-    clear_dump_arg(arg);
+-    RB_GC_GUARD(wrapper);
++    free_dump_arg(arg);
++    rb_gc_force_recycle(wrapper);
+ 
+     return port;
+ }
+@@ -2044,7 +2044,7 @@ rb_marshal_load_with_proc(VALUE port, VALUE proc)
+ {
+     int major, minor, infection = 0;
+     VALUE v;
+-    VALUE wrapper; /* used to avoid memory leak in case of exception */
++    volatile VALUE wrapper; /* used to avoid memory leak in case of exception */
+     struct load_arg *arg;
+ 
+     v = rb_check_string_type(port);
+@@ -2090,8 +2090,8 @@ rb_marshal_load_with_proc(VALUE port, VALUE proc)
+ 
+     if (!NIL_P(proc)) arg->proc = proc;
+     v = r_object(arg);
+-    clear_load_arg(arg);
+-    RB_GC_GUARD(wrapper);
++    free_load_arg(arg);
++    rb_gc_force_recycle(wrapper);
+ 
+     return v;
+ }
+diff --git test/ruby/test_marshal.rb test/ruby/test_marshal.rb
+index 6ac5c29991..dc2b8b30dc 100644
+--- test/ruby/test_marshal.rb
++++ test/ruby/test_marshal.rb
+@@ -645,6 +645,9 @@ def test_continuation
+     c = Bug9523.new
+     assert_raise_with_message(RuntimeError, /Marshal\.dump reentered at marshal_dump/) do
+       Marshal.dump(c)
++      GC.start
++      1000.times {"x"*1000}
++      GC.start
+       c.cc.call
+     end
+   end

--- a/var/spack/repos/builtin/packages/ruby/ruby_24_gcc7.patch
+++ b/var/spack/repos/builtin/packages/ruby/ruby_24_gcc7.patch
@@ -1,0 +1,66 @@
+diff --git a/include/ruby/ruby.h b/include/ruby/ruby.h
+index 6144c672346d..4aa388849ba4 100644
+--- a/include/ruby/ruby.h
++++ b/include/ruby/ruby.h
+@@ -536,7 +536,11 @@ static inline int rb_type(VALUE obj);
+ 
+ #ifdef __GNUC__
+ #define RB_GC_GUARD(v) \
+-    (*__extension__ ({volatile VALUE *rb_gc_guarded_ptr = &(v); rb_gc_guarded_ptr;}))
++    (*__extension__ ({ \
++	volatile VALUE *rb_gc_guarded_ptr = &(v); \
++	__asm__("" : : "m"(rb_gc_guarded_ptr)); \
++	rb_gc_guarded_ptr; \
++    }))
+ #elif defined _MSC_VER
+ #pragma optimize("", off)
+ static inline volatile VALUE *rb_gc_guarded_ptr(volatile VALUE *ptr) {return ptr;}
+diff --git a/marshal.c b/marshal.c
+index a9926acf564e..7e16d0b024c4 100644
+--- a/marshal.c
++++ b/marshal.c
+@@ -1026,7 +1026,7 @@ rb_marshal_dump_limited(VALUE obj, VALUE port, int limit)
+     struct dump_arg *arg;
+     VALUE wrapper; /* used to avoid memory leak in case of exception */
+ 
+-    wrapper = TypedData_Make_Struct(rb_cData, struct dump_arg, &dump_arg_data, arg);
++    wrapper = TypedData_Make_Struct(0, struct dump_arg, &dump_arg_data, arg);
+     arg->dest = 0;
+     arg->symbols = st_init_numtable();
+     arg->data    = rb_init_identtable();
+@@ -2053,7 +2053,7 @@ rb_marshal_load_with_proc(VALUE port, VALUE proc)
+     else {
+ 	io_needed();
+     }
+-    wrapper = TypedData_Make_Struct(rb_cData, struct load_arg, &load_arg_data, arg);
++    wrapper = TypedData_Make_Struct(0, struct load_arg, &load_arg_data, arg);
+     arg->infection = infection;
+     arg->src = port;
+     arg->offset = 0;
+diff --git a/test/ruby/test_marshal.rb b/test/ruby/test_marshal.rb
+index bc22b5fd3ab8..bfc3f6df256f 100644
+--- a/test/ruby/test_marshal.rb
++++ b/test/ruby/test_marshal.rb
+@@ -644,6 +644,9 @@ def test_continuation
+     c = Bug9523.new
+     assert_raise_with_message(RuntimeError, /Marshal\.dump reentered at marshal_dump/) do
+       Marshal.dump(c)
++      GC.start
++      1000.times {"x"*1000}
++      GC.start
+       c.cc.call
+     end
+   end
+diff --git a/version.h b/version.h
+index 0a845df84416..39214c474439 100644
+--- a/version.h
++++ b/version.h
+@@ -1,6 +1,6 @@
+ #define RUBY_VERSION "2.4.0"
+ #define RUBY_RELEASE_DATE "2017-03-13"
+-#define RUBY_PATCHLEVEL 99
++#define RUBY_PATCHLEVEL 100
+ 
+ #define RUBY_RELEASE_YEAR 2017
+ #define RUBY_RELEASE_MONTH 3
+


### PR DESCRIPTION
* pkgconfig fixes a "libffi.a requires -fPIC" build error (i.e. unrelated to the gcc issue...)
* the patches solve the mentioned problem on GCC 7.x
* patch for ruby 2.3 (also applies to 2.2) from: https://bugs.ruby-lang.org/issues/13150#note-14
* patch for ruby 2.4 from https://github.com/ruby/ruby/commit/8788489ca967599f83d96083f244f91c83286a88.patch
