### PR TITLE
Fix version-specific URLs for Python packages

### DIFF
--- a/var/spack/repos/builtin/packages/py-bsddb3/package.py
+++ b/var/spack/repos/builtin/packages/py-bsddb3/package.py
@@ -31,8 +31,8 @@ class PyBsddb3(PythonPackage):
        Sequence and Transaction objects, and each of these is exposed
        as a Python type in the bsddb3.db module."""
 
-    homepage = "://pypi.python.org/pypi/bsddb3/6.2.5"
-    url      = "https://pypi.python.org/packages/ba/a7/131dfd4e3a5002ef30e20bee679d5e6bcb2fcc6af21bd5079dc1707a132c/bsddb3-6.2.5.tar.gz#md5=610267c189964c905a931990e1ba438c"
+    homepage = "https://pypi.python.org/pypi/bsddb3/6.2.5"
+    url      = "https://pypi.io/packages/source/b/bsddb3/bsddb3-6.2.5.tar.gz"
 
     version('6.2.5', '610267c189964c905a931990e1ba438c')
 

--- a/var/spack/repos/builtin/packages/py-pyfasta/package.py
+++ b/var/spack/repos/builtin/packages/py-pyfasta/package.py
@@ -30,7 +30,7 @@ class PyPyfasta(PythonPackage):
        access to fasta sequence files"""
 
     homepage = "https://pypi.python.org/pypi/pyfasta/"
-    url      = "https://pypi.python.org/packages/be/3f/794fbcdaaa2113f0a1d16a962463896c1a6bdab77bd63f33a8f16aae6cdc/pyfasta-0.5.2.tar.gz"
+    url      = "https://pypi.io/packages/source/p/pyfasta/pyfasta-0.5.2.tar.gz"
 
     version('0.5.2', 'bf61ab997dca329675c3eb2ee7cdfcf2')
 


### PR DESCRIPTION
Just noticed 2 Python packages with version-specific URLs. Converted them to the more generic pypi.io URL format. Also confirmed that they can still be downloaded.