### PR TITLE
Fixed duplicated handling of PKG_CONFIG_PATH for crays

### DIFF
--- a/var/spack/repos/builtin/packages/pkg-config/package.py
+++ b/var/spack/repos/builtin/packages/pkg-config/package.py
@@ -47,10 +47,7 @@ class PkgConfig(AutotoolsPackage):
     parallel = False
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        """spack built pkg-config on cray's requires adding /usr/local/
-        and /usr/lib64/  to PKG_CONFIG_PATH in order to access cray '.pc'
-        files.
-        Adds the ACLOCAL path for autotools."""
+        """Adds the ACLOCAL path for autotools."""
         spack_env.append_path('ACLOCAL_PATH',
                               join_path(self.prefix.share, 'aclocal'))
 

--- a/var/spack/repos/builtin/packages/pkgconf/package.py
+++ b/var/spack/repos/builtin/packages/pkgconf/package.py
@@ -41,17 +41,9 @@ class Pkgconf(AutotoolsPackage):
     provides('pkgconfig')
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        """spack built pkg-config on cray's requires adding /usr/local/
-        and /usr/lib64/  to PKG_CONFIG_PATH in order to access cray '.pc'
-        files.
-        Adds the ACLOCAL path for autotools."""
+        """Adds the ACLOCAL path for autotools."""
         spack_env.append_path('ACLOCAL_PATH',
                               join_path(self.prefix.share, 'aclocal'))
-        if 'platform=cray' in self.spec:
-            spack_env.append_path('PKG_CONFIG_PATH',
-                                  '/usr/lib64/pkgconfig')
-            spack_env.append_path('PKG_CONFIG_PATH',
-                                  '/usr/local/lib64/pkgconfig')
 
     @run_after('install')
     def link_pkg_config(self):


### PR DESCRIPTION
https://github.com/spack/spack/pull/7171 and https://github.com/spack/spack/pull/7102 were both merged recently and duplicate some logic to update `PKG_CONFIG_PATH` on the cray platform.

Based on the feedback in #7171 this keeps the cray-specific `PKG_CONFIG_PATH` modifications in the `Cray` platform definition but keeps the `ACLOCAL` modification for `pkgconf` from #7102.

@skosukhin @mamelara @alalazo 