### PR TITLE
Propagate architecture information during concretization

### DIFF
--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -239,6 +239,9 @@ class DefaultConcretizer(object):
                 setattr(spec.architecture, field, getattr(arch, field))
                 spec_changed = True
 
+        if not spec.architecture.concrete:
+            raise InsufficientArchitectureInfoError(spec, default_archs)
+
         return spec_changed
 
     def concretize_variants(self, spec):

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -231,7 +231,8 @@ class DefaultConcretizer(object):
             spec_changed = True
 
         # replace each of the fields (platform, os, target) separately
-        replacement_fields = [k for k, v in iteritems(nearest_arch.to_cmp_dict())
+        nearest_dict = nearest_arch.to_cmp_dict()
+        replacement_fields = [k for k, v in iteritems(nearest_dict)
                               if v and not getattr(spec.architecture, k)]
         for field in replacement_fields:
             setattr(spec.architecture, field, getattr(nearest_arch, field))

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -29,7 +29,7 @@ from spack.concretize import find_spec
 from spack.spec import Spec, CompilerSpec
 from spack.spec import ConflictsInSpecError, SpecError
 from spack.version import ver
-
+from spack.concretize import UnavailableCompilerVersionError
 
 def check_spec(abstract, concrete):
     if abstract.versions.concrete:

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -203,9 +203,6 @@ class TestConcretize(object):
         """Make sure that indirect dependencies receive architecture
         information from the root even when partial architecture information
         is provided by an intermediate dependency.
-
-        test_architecture_deep_inheritance will fail on a regression
-        of git commit f2cb582f10aaa5c78031ca5f2c20d7eed0db4208.
         """
         saved_repo = spack.repo
 

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -31,6 +31,7 @@ from spack.spec import ConflictsInSpecError, SpecError
 from spack.version import ver
 from spack.test.conftest import MockPackage, MockPackageMultiRepo
 
+
 def check_spec(abstract, concrete):
     if abstract.versions.concrete:
         assert abstract.versions == concrete.versions

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -29,7 +29,6 @@ from spack.concretize import find_spec
 from spack.spec import Spec, CompilerSpec
 from spack.spec import ConflictsInSpecError, SpecError
 from spack.version import ver
-from spack.concretize import UnavailableCompilerVersionError
 
 
 def check_spec(abstract, concrete):

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -192,20 +192,22 @@ class TestConcretize(object):
         assert not set(cmake.compiler_flags['fflags'])
 
     def test_architecture_inheritance(self):
+        """test_architecture_inheritance is likely to fail with an
+        UnavailableCompilerVersionError if the architecture is concretized
+        incorrectly.
+        """
         spec = Spec('cmake-client %gcc@4.7.2 os=fe ^ cmake')
-        try:
-            spec.concretize()
-        except UnavailableCompilerVersionError:
-            # Concretization will fail with an UnavailableCompilerVersionError
-            # if the architecture is concretized incorrectly.
-            assert False
+        spec.concretize()
         assert spec['cmake'].architecture == spec.architecture
 
     def test_architecture_deep_inheritance(self):
-        # This test is dependent on traversal towards the root from mpich
-        # reaching callpath before mpileaks despite both depending on mpi.
-        # May only work because mpi is virtual, or because of artifacts of
-        # the ordering.
+        """test_architecture_deep_inheritance will fail on a regression of
+        f2cb582f10aaa5c78031ca5f2c20d7eed0db4208. If the dependency structure
+        in the mock repo changes such that a DAG traversal towards the root of
+        the spec from mpi reaches mpileaks before callpath, it will no longer
+        fail on that regression. This could be caused by either a change in
+        virtual traversal or alphanumeric sorting among parents nodes.
+        """
         spec = Spec('mpileaks %clang@3.3 os=CNL target=foo' +
                     ' ^callpath os=SuSE11 ^mpich os=be')
         spec.concretize()
@@ -225,6 +227,7 @@ class TestConcretize(object):
         assert s['mpi'].version == ver('1.10.3')
 
     def test_concretize_two_virtuals(self):
+
         """Test a package with multiple virtual dependencies."""
         Spec('hypre').concretize()
 

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1,4 +1,4 @@
-##############################################################################
+#############################################################################
 # Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.
 #
@@ -206,13 +206,15 @@ class TestConcretize(object):
         is provided by an intermediate dependency.
 
         test_architecture_deep_inheritance will fail on a regression
-        of git commit f2cb582f10aaa5c78031ca5f2c20d7eed0db4208. If the
-        dependency structure in the mock repo changes such that a DAG
-        traversal towards the root of the spec from mpi reaches
-        mpileaks before callpath, it will no longer fail on that
-        regression. This could be caused by either a change in virtual
-        traversal or alphanumeric sorting among parents nodes.
+        of git commit f2cb582f10aaa5c78031ca5f2c20d7eed0db4208.
+
+        This test is slightly fragile. If DAG traversal changes such
+        that DAG traversal towards the root of the spec from mpi
+        reaches mpileaks before callpath, it will no longer fail on
+        that regression. This could be caused by either a change in
+        virtual traversal or alphanumeric sorting among parents nodes.
         """
+
         spec = Spec('mpileaks %clang@3.3 os=CNL target=foo' +
                     ' ^callpath os=SuSE11 ^mpich os=be')
         spec.concretize()

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -31,6 +31,7 @@ from spack.spec import ConflictsInSpecError, SpecError
 from spack.version import ver
 from spack.concretize import UnavailableCompilerVersionError
 
+
 def check_spec(abstract, concrete):
     if abstract.versions.concrete:
         assert abstract.versions == concrete.versions

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -201,12 +201,17 @@ class TestConcretize(object):
         assert spec['cmake'].architecture == spec.architecture
 
     def test_architecture_deep_inheritance(self):
-        """test_architecture_deep_inheritance will fail on a regression of
-        f2cb582f10aaa5c78031ca5f2c20d7eed0db4208. If the dependency structure
-        in the mock repo changes such that a DAG traversal towards the root of
-        the spec from mpi reaches mpileaks before callpath, it will no longer
-        fail on that regression. This could be caused by either a change in
-        virtual traversal or alphanumeric sorting among parents nodes.
+        """Make sure that indirect dependencies receive architecture
+        information from the root even when partial architecture information
+        is provided by an intermediate dependency.
+
+        test_architecture_deep_inheritance will fail on a regression
+        of git commit f2cb582f10aaa5c78031ca5f2c20d7eed0db4208. If the
+        dependency structure in the mock repo changes such that a DAG
+        traversal towards the root of the spec from mpi reaches
+        mpileaks before callpath, it will no longer fail on that
+        regression. This could be caused by either a change in virtual
+        traversal or alphanumeric sorting among parents nodes.
         """
         spec = Spec('mpileaks %clang@3.3 os=CNL target=foo' +
                     ' ^callpath os=SuSE11 ^mpich os=be')

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -194,7 +194,7 @@ class TestConcretize(object):
         spec = Spec('cmake-client %gcc@4.7.2 os=fe ^ cmake')
         try:
             spec.concretize()
-        except:
+        except UnavailableCompilerVersionError:
             # Concretization will fail with an UnavailableCompilerVersionError
             # if the architecture is concretized incorrectly.
             assert False


### PR DESCRIPTION
Currently, if you request a non-default architecture, that only applies to the root spec where it was specified. This PR changes that behavior to propagate the architecture change down the dag (in the same way that we propagate compilers to maintain ABI compatibility).

This fixes a bug reported out of channel by Anthony Agelastos, whose github handle I don't know.