### PR TITLE
Solve macOS High Sierra syslog.h bug in openssl and openmpi.

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -308,6 +308,11 @@ class Openmpi(AutotoolsPackage):
             # for Open-MPI 2.0:, C++ bindings are disabled by default.
             config_args.extend(['--enable-mpi-cxx'])
 
+        arch = self.spec.architecture
+        if (arch.platform == 'darwin' and arch.platform_os == 'highsierra' and
+                '%gcc' in spec):
+            config_args.append('CFLAGS=-mmacosx-version-min=10.12')
+
         # Fabrics and schedulers
         config_args.extend(self.with_or_without('fabrics'))
         config_args.extend(self.with_or_without('schedulers'))

--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -94,6 +94,11 @@ class Openssl(Package):
            'aarch64' in spack.architecture.sys_type():
             options.append('no-asm')
 
+        arch = spec.architecture
+        if (arch.platform == 'darwin' and arch.platform_os == 'highsierra' and
+                '%gcc' in spec):
+            options.append('-mmacosx-version-min=10.12')
+
         config = Executable('./config')
         config('--prefix=%s' % prefix,
                '--openssldir=%s' % join_path(prefix, 'etc', 'openssl'),


### PR DESCRIPTION
macOS High Sierra has a bug in syslog.h described in
https://discussions.apple.com/thread/8127677. Therefore, openssl
failed to build. The solution described in the discussion is
implemented by this commit.