### PR TITLE
resource: fixing a problem with shutil.move and symlinks to dirs

### DIFF
--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -566,7 +566,7 @@ class ResourceStage(Stage):
                          '{stage}\n\tdestination : {destination}'.format(
                              stage=source_path, destination=destination_path
                          ))
-                shutil.move(os.path.realpath(source_path), os.path.realpath(destination_path))
+                shutil.move(os.path.realpath(source_path), destination_path)
 
 
 @pattern.composite(method_list=[

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -566,7 +566,7 @@ class ResourceStage(Stage):
                          '{stage}\n\tdestination : {destination}'.format(
                              stage=source_path, destination=destination_path
                          ))
-                shutil.move(source_path, destination_path)
+                shutil.move(os.path.realpath(source_path), os.path.realpath(destination_path))
 
 
 @pattern.composite(method_list=[


### PR DESCRIPTION
This seems to fix an issue with the rubygems ssl cert resource on the ruby package #7130 

Tested lua and git which also both have resources, and those still seem to work as expected.