### PR TITLE
Generalized ExaSP2 Install

### DIFF
--- a/var/spack/repos/builtin/packages/exasp2/package.py
+++ b/var/spack/repos/builtin/packages/exasp2/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+import glob
 
 
 class Exasp2(MakefilePackage):
@@ -88,9 +89,7 @@ class Exasp2(MakefilePackage):
     def install(self, spec, prefix):
         mkdir(prefix.bin)
         mkdir(prefix.doc)
-        if '+mpi' in self.spec:
-            install('bin/ExaSP2-parallel', prefix.bin)
-        else:
-            install('bin/ExaSP2-serial', prefix.bin)
+        for files in glob.glob('bin/ExaSP2-*'):
+            install(files, prefix.bin)
         install('LICENSE.md', prefix.doc)
         install('README.md', prefix.doc)


### PR DESCRIPTION
Generalized ExaSP2 Install to use glob due to changes in naming
convention between previous release and current development branch