### PR TITLE
gcta: new package

### DIFF
--- a/var/spack/repos/builtin/packages/gcta/package.py
+++ b/var/spack/repos/builtin/packages/gcta/package.py
@@ -1,0 +1,48 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Gcta(Package):
+
+    """GCTA (Genome-wide Complex Trait Analysis) was originally designed to
+    estimate the proportion of phenotypic variance explained by all genome-wide
+    SNPs for complex traits (the GREML method), and has subsequently extended
+    for many other analyses to better understand the genetic architecture of
+    complex traits. GCTA currently supports the following analyses."""
+
+    homepage = "http://cnsgenomics.com/software/gcta/#Overview"
+    url      = "http://cnsgenomics.com/software/gcta/gcta_1.91.2beta.zip"
+
+    version('1.91.2beta_mac', 'ce0882ad35dd9474ffe40911da369274700af1ecb9916c0a355b7bad14850234')
+    version('1.91.2beta', '192efb767be1c7ca9c2dac5d2c2317a97c7a9db1f801168d19ad2a51b98d9b10', preferred=True)
+
+    conflicts('@1.91.2beta', when='platform=darwin')
+    conflicts('@1.91.2beta_mac', when='platform=linux')
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        install('gcta64', join_path(prefix.bin, 'gcta64'))
+        set_executable(join_path(prefix.bin, 'gcta64'))


### PR DESCRIPTION
This uses the statically compiled binary release provided by the developer. The source they make available is 2 years out of date. Not sure if the conflicts are the best way to handle the different binary releases.