### PR TITLE
Lapack/lapacke

### DIFF
--- a/var/spack/repos/builtin/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-lapack/package.py
@@ -136,7 +136,7 @@ class NetlibLapack(Package):
         key = tuple(sorted(query_parameters))
         headers = query2headers[key]
 
-        paths = join_path(self.spec.prefix.include, headers)
+        paths = join_path(self.spec.prefix.include, headers[0])
         if os.path.exists(paths):
             return HeaderList(paths)
         else:

--- a/var/spack/repos/builtin/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-lapack/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+import os
 
 
 class NetlibLapack(Package):
@@ -122,6 +123,24 @@ class NetlibLapack(Package):
         return find_libraries(
             libraries, root=self.prefix, shared=shared, recursive=True
         )
+
+    @property
+    def lapack_headers(self):
+        query_parameters = self.spec.last_query.extra_parameters
+        query2headers = {
+            tuple(): ['lapacke.h'],
+            ('c',): [
+                'lapacke.h',
+            ]
+        }
+        key = tuple(sorted(query_parameters))
+        headers = query2headers[key]
+
+        paths = join_path(self.spec.prefix.include, headers)
+        if os.path.exists(paths):
+            return HeaderList(paths)
+        else:
+            return None
 
     def install_one(self, spec, prefix, shared):
         cmake_args = [


### PR DESCRIPTION
@jthies that's what I had in mind.

p.s. tested that `spec['lapack:c'].headers.directories[0]` returns `/Users/davydden/spack/opt/spack/darwin-highsierra-x86_64/clang-9.0.0-apple/netlib-lapack-3.8.0-3pssuz5tgcnfl674dpl7n3iifgm5jljw/include`.

There are more headers (i.e. `lapacke_config.h`), i have no idea how are they to be used, so that's it's easier for others to improve later on.