### PR TITLE
Added Option to disable user configs

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -52,7 +52,7 @@ config:
 
 
   # Whether or not to use configs from the user's home directory ~/.spack.
-  user_configs: false
+  user_configs: true
 
 
   # Cache directory for miscellaneous files, like the package index.

--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -51,6 +51,10 @@ config:
   source_cache: $spack/var/spack/cache
 
 
+  # Whether or not to use configs from the user's home directory ~/.spack.
+  user_configs: false
+
+
   # Cache directory for miscellaneous files, like the package index.
   # This can be purged with `spack purge --misc-cache`
   misc_cache: ~/.spack/cache

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -232,6 +232,7 @@ _site_path = os.path.join(spack.etc_path, 'spack')
 ConfigScope('site', _site_path)
 ConfigScope('site/%s' % _platform, os.path.join(_site_path, _platform))
 
+
 def highest_precedence_scope():
     """Get the scope with highest precedence (prefs will override others)."""
     return list(config_scopes.values())[-1]

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -232,12 +232,6 @@ _site_path = os.path.join(spack.etc_path, 'spack')
 ConfigScope('site', _site_path)
 ConfigScope('site/%s' % _platform, os.path.join(_site_path, _platform))
 
-#: User configuration can override both spack defaults and site config.
-_user_path = spack.user_config_path
-ConfigScope('user', _user_path)
-ConfigScope('user/%s' % _platform, os.path.join(_user_path, _platform))
-
-
 def highest_precedence_scope():
     """Get the scope with highest precedence (prefs will override others)."""
     return list(config_scopes.values())[-1]

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -62,6 +62,7 @@ schema = {
                     },
                 },
                 'source_cache': {'type': 'string'},
+                'user_configs': {'type': 'boolean'},
                 'misc_cache': {'type': 'string'},
                 'verify_ssl': {'type': 'boolean'},
                 'checksum': {'type': 'boolean'},

--- a/var/spack/repos/builtin/packages/branson/package.py
+++ b/var/spack/repos/builtin/packages/branson/package.py
@@ -38,7 +38,7 @@ class Branson(CMakePackage):
     version('develop', git='https://github.com/lanl/branson', branch='develop')
     version('1.01', 'cf7095a887a8dd7d417267615bd0452a')
 
-    depends_on('mpi')
+    depends_on('mpi@2:')
     depends_on('boost')
     depends_on('metis')
     depends_on('parmetis')


### PR DESCRIPTION
For our use case, there should be no user specific configuration to Spack, as the configuration is common to the entire team. Leaving them in place is highly likely to cause problems. As such, I've added a config option to disable them.

The option (default True) is checked in spack __init__, and user configs are added to the ConfigScope there. 
The only complication is the misc_cache directory, which is based on the user config directory. That now defaults to being created in the same parent directory as the normal cache.