### PR TITLE
Cblas and lapacke includes

### DIFF
--- a/var/spack/repos/builtin/packages/ghost/package.py
+++ b/var/spack/repos/builtin/packages/ghost/package.py
@@ -64,8 +64,9 @@ class Ghost(CMakePackage):
 
     def cmake_args(self):
         spec = self.spec
-        # note: we require the cblas_include_dir property from the blas provider,
-        # this is implemented at least for intel-mkl and netlib-lapack
+        # note: we require the cblas_include_dir property from the blas
+        # provider, this is implemented at least for intel-mkl and
+        # netlib-lapack
         args = ['-DGHOST_ENABLE_MPI:BOOL=%s'
                 % ('ON' if '+mpi' in spec else 'OFF'),
                 '-DGHOST_USE_CUDA:BOOL=%s'

--- a/var/spack/repos/builtin/packages/ghost/package.py
+++ b/var/spack/repos/builtin/packages/ghost/package.py
@@ -64,11 +64,8 @@ class Ghost(CMakePackage):
 
     def cmake_args(self):
         spec = self.spec
-        cblas_include_dir = ''
-        if '^mkl' not in spec:
-            cblas_include_dir = '-DCBLAS_INCLUDE_DIR=' + \
-                spec['blas'].prefix.include
-
+        # note: we require the cblas_include_dir property from the blas provider,
+        # this is implemented at least for intel-mkl and netlib-lapack
         args = ['-DGHOST_ENABLE_MPI:BOOL=%s'
                 % ('ON' if '+mpi' in spec else 'OFF'),
                 '-DGHOST_USE_CUDA:BOOL=%s'
@@ -78,9 +75,12 @@ class Ghost(CMakePackage):
                 '-DGHOST_USE_ZOLTAN:BOOL=%s'
                 % ('ON' if '+zoltan' in spec else 'OFF'),
                 '-DBUILD_SHARED_LIBS:BOOL=%s'
-                % ('ON' if '+shared' in spec else 'OFF'), cblas_include_dir
+                % ('ON' if '+shared' in spec else 'OFF'),
+                '-DCBLAS_INCLUDE_DIR:STRING=%s'
+                % format(spec['blas:c'].headers.directories[0]),
+                '-DBLAS_LIBRARIES=%s'
+                % spec['blas:c'].libs.joined(';')
                 ]
-
         return args
 
     def check(self):

--- a/var/spack/repos/builtin/packages/ghost/package.py
+++ b/var/spack/repos/builtin/packages/ghost/package.py
@@ -77,7 +77,7 @@ class Ghost(CMakePackage):
                 '-DBUILD_SHARED_LIBS:BOOL=%s'
                 % ('ON' if '+shared' in spec else 'OFF'),
                 '-DCBLAS_INCLUDE_DIR:STRING=%s'
-                % format(spec['blas:c'].headers.directories[0]),
+                % format(spec['blas'].headers.directories[0]),
                 '-DBLAS_LIBRARIES=%s'
                 % spec['blas:c'].libs.joined(';')
                 ]

--- a/var/spack/repos/builtin/packages/intel-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-mkl/package.py
@@ -190,9 +190,9 @@ class IntelMkl(IntelPackage):
         else:
             include_dir = prefix.include
 
-        cblas_h = 'mkl_cblas.h'
-        lapacke_h = 'mkl_lapacke.h'
-        return HeaderList([include_dir.cblas_h, include_dir.lapacke_h])
+        cblas_h = join_path(include_dir,'mkl_cblas.h')
+        lapacke_h = join_path(include_dir,'mkl_lapacke.h')
+        return HeaderList([cblas_h, lapacke_h])
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         # set up MKLROOT for everyone using MKL package

--- a/var/spack/repos/builtin/packages/intel-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-mkl/package.py
@@ -190,8 +190,8 @@ class IntelMkl(IntelPackage):
         else:
             include_dir = prefix.include
 
-        cblas_h = join_path(include_dir,'mkl_cblas.h')
-        lapacke_h = join_path(include_dir,'mkl_lapacke.h')
+        cblas_h = join_path(include_dir, 'mkl_cblas.h')
+        lapacke_h = join_path(include_dir, 'mkl_lapacke.h')
         return HeaderList([cblas_h, lapacke_h])
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):

--- a/var/spack/repos/builtin/packages/intel-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-mkl/package.py
@@ -182,6 +182,18 @@ class IntelMkl(IntelPackage):
 
         return libs
 
+    @property
+    def headers(self):
+        prefix = self.spec.prefix
+        if sys.platform != 'darwin':
+            include_dir = prefix.compilers_and_libraries.linux.mkl.include
+        else:
+            include_dir = prefix.include
+
+        cblas_h = 'mkl_cblas.h'
+        lapacke_h = 'mkl_lapacke.h'
+        return HeaderList([include_dir.cblas_h, include_dir.lapacke_h])
+
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         # set up MKLROOT for everyone using MKL package
         if sys.platform == 'darwin':

--- a/var/spack/repos/builtin/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-lapack/package.py
@@ -127,8 +127,8 @@ class NetlibLapack(Package):
     @property
     def headers(self):
         include_dir = self.spec.prefix.include
-        cblas_h = join_path(include_dir,'cblas.h')
-        lapacke_h = join_path(include_dir,'lapacke.h')
+        cblas_h = join_path(include_dir, 'cblas.h')
+        lapacke_h = join_path(include_dir, 'lapacke.h')
         return HeaderList([cblas_h, lapacke_h])
 
     def install_one(self, spec, prefix, shared):

--- a/var/spack/repos/builtin/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-lapack/package.py
@@ -127,8 +127,8 @@ class NetlibLapack(Package):
     @property
     def headers(self):
         include_dir = self.spec.prefix.include
-        cblas_h = include_dir + 'cblas.h'
-        lapacke_h = include_dir + 'lapacke.h'
+        cblas_h = join_path(include_dir,'cblas.h')
+        lapacke_h = join_path(include_dir,'lapacke.h')
         return HeaderList([cblas_h, lapacke_h])
 
     def install_one(self, spec, prefix, shared):

--- a/var/spack/repos/builtin/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-lapack/package.py
@@ -48,7 +48,8 @@ class NetlibLapack(Package):
     version('3.4.0', '02d5706ec03ba885fc246e5fa10d8c70')
     version('3.3.1', 'd0d533ec9a5b74933c2a1e84eedc58b4')
 
-    variant('debug', default=False, description='Activates the Debug build type')
+    variant('debug', default=False,
+            description='Activates the Debug build type')
     variant('shared', default=True, description="Build shared library version")
     variant('external-blas', default=False,
             description='Build lapack with an external blas')
@@ -122,6 +123,13 @@ class NetlibLapack(Package):
         return find_libraries(
             libraries, root=self.prefix, shared=shared, recursive=True
         )
+
+    @property
+    def headers(self):
+        include_dir = self.spec.prefix.include
+        cblas_h = include_dir + 'cblas.h'
+        lapacke_h = include_dir + 'lapacke.h'
+        return HeaderList([cblas_h, lapacke_h])
 
     def install_one(self, spec, prefix, shared):
         cmake_args = [


### PR DESCRIPTION
C users may want to know where to find the cblas.h and lapacke.h headers, so I added the headers property to two blas/lapack providers (Intel-mkl and netlib-blas), as suggested by @davydden. Also adjusted the recently added ghost package to make use of this.