### PR TITLE
spack buildcache command : add options for testing with unsigned tarballs on macOS

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -254,8 +254,8 @@ def generate_index(outdir, indexfile_path):
     f.close()
 
 
-def build_tarball(spec, outdir, force=False, rel=False, allow_root=False,
-                  key=None):
+def build_tarball(spec, outdir, force=False, rel=False, unsigned=False,
+                  allow_root=False, key=None):
     """
     Build a tarball from given spec and put it into the directory structure
     used at the mirror (following <tarball_directory_name>).
@@ -337,17 +337,19 @@ def build_tarball(spec, outdir, force=False, rel=False, allow_root=False,
     with open(specfile_path, 'w') as outfile:
         outfile.write(yaml.dump(spec_dict))
     # sign the tarball and spec file with gpg
-    sign_tarball(key, force, specfile_path)
+    if not unsigned:
+        sign_tarball(key, force, specfile_path)
     # put tarball, spec and signature files in .spack archive
     with closing(tarfile.open(spackfile_path, 'w')) as tar:
         tar.add(name='%s' % tarfile_path, arcname='%s' % tarfile_name)
         tar.add(name='%s' % specfile_path, arcname='%s' % specfile_name)
-        tar.add(name='%s.asc' % specfile_path,
-                arcname='%s.asc' % specfile_name)
+        if not unsigned:
+            tar.add(name='%s.asc' % specfile_path,
+                    arcname='%s.asc' % specfile_name)
 
     # cleanup file moved to archive
     os.remove(tarfile_path)
-    os.remove('%s.asc' % specfile_path)
+    if not unsigned: os.remove('%s.asc' % specfile_path)
 
     # create an index.html for the build_cache directory so specs can be found
     if os.path.exists(indexfile_path):
@@ -435,7 +437,7 @@ def relocate_package(workdir, allow_root):
                                  allow_root)
 
 
-def extract_tarball(spec, filename, allow_root=False, force=False):
+def extract_tarball(spec, filename, allow_root=False, unsigned=False, force=False):
     """
     extract binary tarball for given package into install area
     """
@@ -456,19 +458,19 @@ def extract_tarball(spec, filename, allow_root=False, force=False):
 
     with closing(tarfile.open(spackfile_path, 'r')) as tar:
         tar.extractall(tmpdir)
-
-    if os.path.exists('%s.asc' % specfile_path):
-        try:
-            Gpg.verify('%s.asc' % specfile_path, specfile_path)
-        except Exception as e:
+    if not unsigned:
+        if os.path.exists('%s.asc' % specfile_path):
+            try:
+                Gpg.verify('%s.asc' % specfile_path, specfile_path)
+            except Exception as e:
+                shutil.rmtree(tmpdir)
+                tty.die(str(e))
+        else:
             shutil.rmtree(tmpdir)
-            tty.die(str(e))
-    else:
-        shutil.rmtree(tmpdir)
-        raise NoVerifyException(
-            "Package spec file failed signature verification.\n"
-            "Use spack buildcache keys to download "
-            "and install a key for verification from the mirror.")
+            raise NoVerifyException(
+                "Package spec file failed signature verification.\n"
+                "Use spack buildcache keys to download "
+                "and install a key for verification from the mirror.")
     # get the sha256 checksum of the tarball
     checksum = checksum_tarball(tarfile_path)
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -584,7 +584,7 @@ def get_specs(force=False):
     return specs
 
 
-def get_keys(install=False, yes_to_all=False, force=False):
+def get_keys(install=False, trust=False, force=False):
     """
     Get pgp public keys available on mirror
     """
@@ -621,9 +621,9 @@ def get_keys(install=False, yes_to_all=False, force=False):
                         continue
             tty.msg('Found key %s' % link)
             if install:
-                if yes_to_all:
+                if trust:
                     Gpg.trust(stage.save_filename)
                     tty.msg('Added this key to trusted keys.')
                 else:
                     tty.msg('Will not add this key to trusted keys.'
-                            'Use -y to override')
+                            'Use -t to install all downloaded keys')

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -349,7 +349,8 @@ def build_tarball(spec, outdir, force=False, rel=False, unsigned=False,
 
     # cleanup file moved to archive
     os.remove(tarfile_path)
-    if not unsigned: os.remove('%s.asc' % specfile_path)
+    if not unsigned:
+        os.remove('%s.asc' % specfile_path)
 
     # create an index.html for the build_cache directory so specs can be found
     if os.path.exists(indexfile_path):
@@ -437,7 +438,8 @@ def relocate_package(workdir, allow_root):
                                  allow_root)
 
 
-def extract_tarball(spec, filename, allow_root=False, unsigned=False, force=False):
+def extract_tarball(spec, filename, allow_root=False, unsigned=False,
+                    force=False):
     """
     extract binary tarball for given package into install area
     """

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -264,7 +264,7 @@ def install_tarball(spec, args):
     force = False
     if args.force:
         force = True
-    unsigned = True
+    unsigned = False
     if args.unsigned:
         unsigned = True
     for d in s.dependencies(deptype=('link', 'run')):

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -71,8 +71,8 @@ def setup_parser(subparser):
                          help="allow install root string in binary files " +
                               "after RPATH substitution")
     install.add_argument('-u', '--unsigned', action='store_true',
-                        help="install unsigned buildcache" +
-                             " tarballs for testing")
+                         help="install unsigned buildcache" +
+                              " tarballs for testing")
     install.add_argument(
         'packages', nargs=argparse.REMAINDER,
         help="specs of packages to install biuldache for")

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1288,7 +1288,7 @@ class PackageBase(with_metaclass(PackageMeta, object)):
         tty.msg('Installing %s from binary cache' % self.name)
         tarball = binary_distribution.download_tarball(binary_spec)
         binary_distribution.extract_tarball(
-            binary_spec, tarball, allow_root=False, force=False)
+            binary_spec, tarball, allow_root=False, unsigned=False, force=False)
         spack.store.db.add(self.spec, spack.store.layout, explicit=explicit)
         return True
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1288,7 +1288,8 @@ class PackageBase(with_metaclass(PackageMeta, object)):
         tty.msg('Installing %s from binary cache' % self.name)
         tarball = binary_distribution.download_tarball(binary_spec)
         binary_distribution.extract_tarball(
-            binary_spec, tarball, allow_root=False, unsigned=False, force=False)
+            binary_spec, tarball, allow_root=False,
+            unsigned=False, force=False)
         spack.store.db.add(self.spec, spack.store.layout, explicit=explicit)
         return True
 

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -157,34 +157,34 @@ echo $PATH"""
     else:
         # create build cache without signing
         args = parser.parse_args(
-            ['create', '-d', mirror_path, '-y', str(spec)])
+            ['create', '-d', mirror_path, '-u', str(spec)])
         buildcache.buildcache(parser, args)
 
         # Uninstall the package
         pkg.do_uninstall(force=True)
 
         # install build cache without verification
-        args = parser.parse_args(['install', '-y', str(spec)])
+	args = parser.parse_args(['install', '-u', str(spec)])
         buildcache.install_tarball(spec, args)
 
         # test overwrite install without verification
-        args = parser.parse_args(['install', '-f', '-y', str(pkghash)])
+        args = parser.parse_args(['install', '-f', '-u', str(pkghash)])
         buildcache.buildcache(parser, args)
 
         # create build cache with relative path
         args = parser.parse_args(
-            ['create', '-d', mirror_path, '-f', '-r', '-y', str(pkghash)])
+            ['create', '-d', mirror_path, '-f', '-r', '-u', str(pkghash)])
         buildcache.buildcache(parser, args)
 
         # Uninstall the package
         pkg.do_uninstall(force=True)
 
         # install build cache
-        args = parser.parse_args(['install', '-y', str(spec)])
+        args = parser.parse_args(['install', '-u', str(spec)])
         buildcache.install_tarball(spec, args)
 
         # test overwrite install
-        args = parser.parse_args(['install', '-f', '-y', str(pkghash)])
+        args = parser.parse_args(['install', '-f', '-u', str(pkghash)])
         buildcache.buildcache(parser, args)
 
     # Validate the relocation information

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -164,7 +164,7 @@ echo $PATH"""
         pkg.do_uninstall(force=True)
 
         # install build cache without verification
-	args = parser.parse_args(['install', '-u', str(spec)])
+        args = parser.parse_args(['install', '-u', str(spec)])
         buildcache.install_tarball(spec, args)
 
         # test overwrite install without verification


### PR DESCRIPTION
    buildcache command add options
    Add create -u --unsigned option to replace -y --yes_to_all to allow tests on macOS when gpg2 is unavailable.
    Add keys -t --trust option to replace -y yes_to_all to allow installation of all downloaded keys.
