### PR TITLE
Fix mis-spelt attribute name.

### DIFF
--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -102,7 +102,7 @@ class Lua(Package):
                 deptypes=('build', 'run'), deptype_query='run'):
             if d.package.extends(self.spec):
                 lua_paths.append(os.path.join(d.prefix, self.lua_lib_dir))
-                lua_paths.append(os.path.join(d.prefix, self.lua64_lib_dir))
+                lua_paths.append(os.path.join(d.prefix, self.lua_lib64_dir))
                 lua_paths.append(os.path.join(d.prefix, self.lua_share_dir))
 
         lua_patterns = []


### PR DESCRIPTION
`self.lua64_lib_dir` should be `self.lua_lib64_dir`

Fixes #7449 