### PR TITLE
Constructing a SpecBuildInterface from another gives no inconsistent MRO

### DIFF
--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -458,5 +458,17 @@ class ObjectWrapper(object):
     def __init__(self, wrapped_object):
         wrapped_cls = type(wrapped_object)
         wrapped_name = wrapped_cls.__name__
-        self.__class__ = type(wrapped_name, (type(self), wrapped_cls), {})
+
+        # If the wrapped object is already an ObjectWrapper, or a derived class
+        # of it, adding type(self) in front of type(wrapped_object)
+        # results in an inconsistent MRO.
+        #
+        # TODO: the implementation below doesn't account for the case where we
+        # TODO: have different base classes of ObjectWrapper, say A and B, and
+        # TODO: we want to wrap an instance of A with B.
+        if type(self) not in wrapped_cls.__mro__:
+            self.__class__ = type(wrapped_name, (type(self), wrapped_cls), {})
+        else:
+            self.__class__ = type(wrapped_name, (wrapped_cls,), {})
+
         self.__dict__ = wrapped_object.__dict__


### PR DESCRIPTION
fixes #7239 
fixes #7452

@jrood-nrel @goxberry 