### PR TITLE
llvm 6.0.0 released as stable

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -183,16 +183,16 @@ class Llvm(CMakePackage):
             'version': '6.0.0',
             'md5': '788a11a35fa62eb008019b37187d09d2',
             'resources': {
-                'compiler-rt': 'a05f2285e9e3f3698aac35e946de4716',
-                'openmp': 'a24de6873e10f22033fbbf4d37878c19',
-                'polly': 'e41d3f632eff3a71aa4fa4e1db559e00',
-                'libcxx': '0c224e9e2bcf47777005e25c6d754d0f',
-                'libcxxabi': '016237b401f7bb00070b9f2dc7dc2b64',
-                'cfe': 'fa32ed485123115d0cb98658fb3c0f35',
-                'clang-tools-extra': '630655df552201b93e01a377c59ee220',
-                'lldb': 'b02eedaeba00af92259b25c8f7dd5511',
-                'lld': 'c71775bbfc3e1cd6ea9862899533de81',
-                'libunwind': '94fa7ac6bd6080094225dfe79110d706'
+                'compiler-rt': 'ba6368e894b5528e527d86a69d8533c6',
+                'openmp': 'eb6b8d0318a950a8192933a3b500585d',
+                'polly': 'e5808a3a1ed1c23f56dd1854b86689d0',
+                'libcxx': '4ecad7dfd8ea636205d3ffef028df73a',
+                'libcxxabi': '9d06327892fc5d8acec4ef2e2821ab3d',
+                'cfe': '121b3896cb0c7765d690acc5d9495d24',
+                'clang-tools-extra': '6b1d543116dab5a3caba10091d983743',
+                'lldb': '1ec6498066e273b7261270f344b68121',
+                'lld': '7ab2612417477b03538f11cd8b5e12f8',
+                'libunwind': '022a4ee2c3bf7b6d151e0444f66aca64'
             }
         },
         {

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -180,6 +180,22 @@ class Llvm(CMakePackage):
             }
         },
         {
+            'version': '6.0.0',
+            'md5': '788a11a35fa62eb008019b37187d09d2',
+            'resources': {
+                'compiler-rt': 'a05f2285e9e3f3698aac35e946de4716',
+                'openmp': 'a24de6873e10f22033fbbf4d37878c19',
+                'polly': 'e41d3f632eff3a71aa4fa4e1db559e00',
+                'libcxx': '0c224e9e2bcf47777005e25c6d754d0f',
+                'libcxxabi': '016237b401f7bb00070b9f2dc7dc2b64',
+                'cfe': 'fa32ed485123115d0cb98658fb3c0f35',
+                'clang-tools-extra': '630655df552201b93e01a377c59ee220',
+                'lldb': 'b02eedaeba00af92259b25c8f7dd5511',
+                'lld': 'c71775bbfc3e1cd6ea9862899533de81',
+                'libunwind': '94fa7ac6bd6080094225dfe79110d706'
+            }
+        },
+        {
             'version': '5.0.1',
             'md5': '3a4ec6dcbc71579eeaec7cb157fe2168',
             'resources': {


### PR DESCRIPTION
Relase notes: http://releases.llvm.org/6.0.0/docs/ReleaseNotes.html

**Before merge!!!**

- [x] Check these download as expected (@svenevs, on linux)
- [ ] Can we automate this?

For automation, I wrote a really simply bash script (~~fix for linux `md5sum` pending when i switch to that computer~~ fixed, i forgot i already wrote the platform dependent md5 stuff somewhere else xD).  I was thinking of adding a `# NOTE` comment just above `releases`

https://github.com/spack/spack/blob/39bfa12f22b56cd35340bedd92f262ba05f9e125/var/spack/repos/builtin/packages/llvm/package.py#L165

Saying something like

```py
# NOTE: adding a new stable release for LLVM?  Copy-paste the script at
#       the bottom into a shell script and update the VERSION variable
#       at the top, it will download and print the new entry for this variable.
```

and then just include the script at the bottom.  I couldn't figure out how to make `spack checksum` work...

```bash
#!/usr/bin/env bash

# TODO: update the version number!
VERSION="6.0.0"

# Download the files needed
if ! [[ -f "llvm-$VERSION.src.tar.xz" ]]; then
    curl -LO "http://releases.llvm.org/$VERSION/llvm-$VERSION.src.tar.xz"
fi
if ! [[ -f "compiler-rt-$VERSION.src.tar.xz" ]]; then
    curl -LO "http://llvm.org/releases/$VERSION/compiler-rt-$VERSION.src.tar.xz"
fi
if ! [[ -f "openmp-$VERSION.src.tar.xz" ]]; then
    curl -LO "http://llvm.org/releases/$VERSION/openmp-$VERSION.src.tar.xz"
fi
if ! [[ -f "polly-$VERSION.src.tar.xz" ]]; then
    curl -LO "http://llvm.org/releases/$VERSION/polly-$VERSION.src.tar.xz"
fi
if ! [[ -f "libcxx-$VERSION.src.tar.xz" ]]; then
    curl -LO "http://llvm.org/releases/$VERSION/libcxx-$VERSION.src.tar.xz"
fi
if ! [[ -f "libcxxabi-$VERSION.src.tar.xz" ]]; then
    curl -LO "http://llvm.org/releases/$VERSION/libcxxabi-$VERSION.src.tar.xz"
fi
if ! [[ -f "cfe-$VERSION.src.tar.xz" ]]; then
    curl -LO "http://llvm.org/releases/$VERSION/cfe-$VERSION.src.tar.xz"
fi
if ! [[ -f "clang-tools-extra-$VERSION.src.tar.xz" ]]; then
    curl -LO "http://llvm.org/releases/$VERSION/clang-tools-extra-$VERSION.src.tar.xz"
fi
if ! [[ -f "lldb-$VERSION.src.tar.xz" ]]; then
    curl -LO "http://llvm.org/releases/$VERSION/lldb-$VERSION.src.tar.xz"
fi
if ! [[ -f "lld-$VERSION.src.tar.xz" ]]; then
    curl -LO "http://llvm.org/releases/$VERSION/lld-$VERSION.src.tar.xz"
fi
if ! [[ -f "libunwind-$VERSION.src.tar.xz" ]]; then
    curl -LO "http://llvm.org/releases/$VERSION/libunwind-$VERSION.src.tar.xz"
fi

# Acquire the platform dependent md5 command.  Many of these I am unable to test, but
# this is written thanks to http://www-01.ibm.com/support/docview.wss?uid=swg21496703
md5_options=( "md5sum" "md5" "csum" "digest" )
MD5=""
for cmd in "${md5_options[@]}"; do
    if [[ -x $(command -v "$cmd") ]]; then
        if [[ "$cmd" == "csum" ]]; then
            MD5="csum -h MD5"
        elif [[ "$cmd" == "digest" ]]; then
            MD5="digest -a md5 -v"
        else
            # shellcheck disable=SC2034
            MD5="$cmd"
        fi
        break
    fi
done

function strip_md5_hash() {
    egrep -o "[[:alnum:]]{32}"
}

# Get the checksums
md5_src="$($MD5 llvm-$VERSION.src.tar.xz | strip_md5_hash)"
md5_compiler_rt="$($MD5 compiler-rt-$VERSION.src.tar.xz | strip_md5_hash)"
md5_openmp="$($MD5 openmp-$VERSION.src.tar.xz | strip_md5_hash)"
md5_polly="$($MD5 polly-$VERSION.src.tar.xz | strip_md5_hash)"
md5_libcxx="$($MD5 libcxx-$VERSION.src.tar.xz | strip_md5_hash)"
md5_libcxxabi="$($MD5 libcxxabi-$VERSION.src.tar.xz | strip_md5_hash)"
md5_cfe="$($MD5 cfe-$VERSION.src.tar.xz | strip_md5_hash)"
md5_clang_tools_extra="$($MD5 clang-tools-extra-$VERSION.src.tar.xz | strip_md5_hash)"
md5_lldb="$($MD5 lldb-$VERSION.src.tar.xz | strip_md5_hash)"
md5_lld="$($MD5 lld-$VERSION.src.tar.xz | strip_md5_hash)"
md5_libunwind="$($MD5 libunwind-$VERSION.src.tar.xz | strip_md5_hash)"

echo "        {"
echo "            'version': '$VERSION',"
echo "            'md5': '$md5_src',"
echo "            'resources': {"
echo "                'compiler-rt': '$md5_compiler_rt',"
echo "                'openmp': '$md5_openmp',"
echo "                'polly': '$md5_polly',"
echo "                'libcxx': '$md5_libcxx',"
echo "                'libcxxabi': '$md5_libcxxabi',"
echo "                'cfe': '$md5_cfe',"
echo "                'clang-tools-extra': '$md5_clang_tools_extra',"
echo "                'lldb': '$md5_lldb',"
echo "                'lld': '$md5_lld',"
echo "                'libunwind': '$md5_libunwind'"
echo "            }"
echo "        },"
```