### PR TITLE
pandaseq: needs bzip and libtool as link

### DIFF
--- a/var/spack/repos/builtin/packages/pandaseq/package.py
+++ b/var/spack/repos/builtin/packages/pandaseq/package.py
@@ -38,10 +38,11 @@ class Pandaseq(AutotoolsPackage):
 
     depends_on('autoconf',    type='build')
     depends_on('automake',    type='build')
-    depends_on('libtool',     type='build')
+    depends_on('libtool',     type=('build', 'link'))
     depends_on('m4',          type='build')
     depends_on('zlib',        type='build')
     depends_on('pkg-config',  type='build')
+    depends_on('bzip2',       type='link')
 
     def autoreconf(self, spec, prefix):
         bash = which('bash')


### PR DESCRIPTION
found more dependencies when trying to install in a clean container
should be the same as #7031 - will see if CI passes on this one