### PR TITLE
Making the SPACK_SHELL variable more robust

### DIFF
--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -199,7 +199,11 @@ _spack_pathadd PATH       "${_sp_prefix%/}/bin"
 export SPACK_ROOT=${_sp_prefix}
 
 #
-# Determine which shell is being used
+# Try to determine which shell is being used if
+# SPACK_SHELL has not already been set by the user.
+# This variable is used for the environment-modules
+# 'module' function/command to envoke 'modulecmd' with
+# the correct shell.
 #
 function _spack_determine_shell() {
         ps -p $$ | tail -n 1 | awk '{print $4}' | sed 's/^-//' | xargs basename

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -201,10 +201,7 @@ export SPACK_ROOT=${_sp_prefix}
 #
 # Determine which shell is being used
 #
-function _spack_determine_shell() {
-	ps -p $$ | tail -n 1 | awk '{print $4}' | sed 's/^-//' | xargs basename
-}
-export SPACK_SHELL=$(_spack_determine_shell)
+export SPACK_SHELL=$(basename $SHELL)
 
 #
 # Check whether a function of the given name is defined

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -201,7 +201,11 @@ export SPACK_ROOT=${_sp_prefix}
 #
 # Determine which shell is being used
 #
-export SPACK_SHELL=$(basename $SHELL)
+function _spack_determine_shell() {
+        ps -p $$ | tail -n 1 | awk '{print $4}' | sed 's/^-//' | xargs basename
+}
+: ${SPACK_SHELL=$(_spack_determine_shell)}
+export SPACK_SHELL
 
 #
 # Check whether a function of the given name is defined

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -208,7 +208,7 @@ export SPACK_ROOT=${_sp_prefix}
 function _spack_determine_shell() {
         ps -p $$ | tail -n 1 | awk '{print $4}' | sed 's/^-//' | xargs basename
 }
-: ${SPACK_SHELL:=$(_spack_determine_shell)}
+SPACK_SHELL=${SPACK_SHELL:-$(_spack_determine_shell)}
 export SPACK_SHELL
 
 #

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -204,7 +204,7 @@ export SPACK_ROOT=${_sp_prefix}
 function _spack_determine_shell() {
         ps -p $$ | tail -n 1 | awk '{print $4}' | sed 's/^-//' | xargs basename
 }
-: ${SPACK_SHELL=$(_spack_determine_shell)}
+: ${SPACK_SHELL:=$(_spack_determine_shell)}
 export SPACK_SHELL
 
 #

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -199,16 +199,6 @@ _spack_pathadd PATH       "${_sp_prefix%/}/bin"
 export SPACK_ROOT=${_sp_prefix}
 
 #
-# Try to determine which shell is being used if
-# SPACK_SHELL has not already been set by the user.
-# This variable is used for the environment-modules
-# 'module' function/command to envoke 'modulecmd' with
-# the correct shell.
-#
-SPACK_SHELL=${SPACK_SHELL:-$(basename ${SHELL})}
-export SPACK_SHELL
-
-#
 # Check whether a function of the given name is defined
 #
 function _spack_fn_exists() {
@@ -231,7 +221,7 @@ if [ "${need_module}" = "yes" ]; then
         #activate it!
         export MODULE_PREFIX=${module_prefix}
         _spack_pathadd PATH "${MODULE_PREFIX}/Modules/bin"
-        module() { eval `${MODULE_PREFIX}/Modules/bin/modulecmd ${SPACK_SHELL} $*`; }
+        module() { eval $(${MODULE_PREFIX}/Modules/bin/modulecmd $(basename ${SHELL}) $*); }
     fi;
 fi;
 

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -205,10 +205,7 @@ export SPACK_ROOT=${_sp_prefix}
 # 'module' function/command to envoke 'modulecmd' with
 # the correct shell.
 #
-function _spack_determine_shell() {
-        ps -p $$ | tail -n 1 | awk '{print $4}' | sed 's/^-//' | xargs basename
-}
-SPACK_SHELL=${SPACK_SHELL:-$(_spack_determine_shell)}
+SPACK_SHELL=${SPACK_SHELL:-$(basename ${SHELL})}
 export SPACK_SHELL
 
 #


### PR DESCRIPTION
This is my proposed solution to solving https://github.com/spack/spack/issues/7441 .

In summary, when using `spack bootstrap` and then `setup-env.sh`, the code currently used to populate `SPACK_SHELL` can resolve to a different process than the shell, for example if you source `setup-env.sh` from a script, then `SPACK_SHELL` will be the name of the script, causing problems.