### PR TITLE
Using self.prefix in Trilinos to avoid global name prefix undefined bug

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -610,7 +610,7 @@ class Trilinos(CMakePackage):
             # use @rpath on Sierra due to limit of dynamic loader
             options.append('-DCMAKE_MACOSX_RPATH=ON')
         else:
-            options.append('-DCMAKE_INSTALL_NAME_DIR:PATH=%s' % prefix.lib)
+            options.append('-DCMAKE_INSTALL_NAME_DIR:PATH=%s' % self.prefix.lib)
 
         if spec.satisfies('%intel') and spec.satisfies('@12.6.2'):
             # Panzer uses some std:chrono that is not recognized by Intel

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -610,7 +610,8 @@ class Trilinos(CMakePackage):
             # use @rpath on Sierra due to limit of dynamic loader
             options.append('-DCMAKE_MACOSX_RPATH=ON')
         else:
-            options.append('-DCMAKE_INSTALL_NAME_DIR:PATH=%s' % self.prefix.lib)
+            options.append('-DCMAKE_INSTALL_NAME_DIR:PATH=%s' %
+                           self.prefix.lib)
 
         if spec.satisfies('%intel') and spec.satisfies('@12.6.2'):
             # Panzer uses some std:chrono that is not recognized by Intel


### PR DESCRIPTION
I saw the same behavior as in https://github.com/spack/spack/pull/7224 for Trilinos so I changed a `prefix.lib` to `self.prefix.lib` and it seems to allow me to refresh modules for Trilinos correctly.