### PR TITLE
libXi requires pkgconfig and fixesproto

### DIFF
--- a/var/spack/repos/builtin/packages/libxi/package.py
+++ b/var/spack/repos/builtin/packages/libxi/package.py
@@ -33,9 +33,13 @@ class Libxi(AutotoolsPackage):
 
     version('1.7.6', 'f3828f9d7893068f6f6f10fe15b31afa')
 
+    depends_on('pkgconfig', type='build')
     depends_on('libx11@1.6:')
     depends_on('libxext@1.0.99.1:')
     depends_on('libxfixes@5:')
+
+    # transient build dependency (from libxfixes), i.e. shouldn't be needed?
+    depends_on('fixesproto@5.0:', type='build')
 
     depends_on('xproto@7.0.13:', type='build')
     depends_on('xextproto@7.0.3:', type='build')


### PR DESCRIPTION
* `pkgconfig` is needed by the package's build flow
*  `fixesproto` is a transient dependency which cannot be found via `libxfixes` (?)