### PR TITLE
fixed -x and -ax options for libint%intel

### DIFF
--- a/var/spack/repos/builtin/packages/libint/package.py
+++ b/var/spack/repos/builtin/packages/libint/package.py
@@ -68,7 +68,7 @@ class Libint(AutotoolsPackage):
         # Optimizations for the Intel compiler, suggested by CP2K
         if '%intel' in self.spec:
             # -xSSE2 will make it usable on old architecture
-            flags += ' -xSSE2 -xAVX -axCORE-AVX2 -ipo'
+            flags += ' -xSSE2 -axAVX,CORE-AVX2 -ipo'
 
         return flags
 


### PR DESCRIPTION
-x and -ax can only be specified once each, otherwise the earlier invocations will get overridden by the last one. The -ax option can accept multiple architectures as a comma separated list.