### PR TITLE
py-pybedtools: fix hash for 0.6.9

### DIFF
--- a/var/spack/repos/builtin/packages/py-pybedtools/package.py
+++ b/var/spack/repos/builtin/packages/py-pybedtools/package.py
@@ -33,7 +33,7 @@ class PyPybedtools(PythonPackage):
     url      = "https://pypi.io/packages/source/p/pybedtools/pybedtools-0.7.10.tar.gz"
 
     version('0.7.10', 'f003c67e22c48b77f070538368ece70c')
-    version('0.6.9',  'a24e4bcd0c89beb9535295db964f6a4a')
+    version('0.6.9',  'b7df049036422d8c6951412a90e83dca')
 
     depends_on('py-setuptools', type='build')
     depends_on('bedtools2',     type=('build', 'run'))


### PR DESCRIPTION
Trying to install metasv, which depends on this version.

Pypi says the hash is different than what's listed in this package.py :
https://pypi.python.org/pypi/pybedtools/0.6.9

@peetsv - I see you just recently added this older version for the same reason (metasv) - would like you to review before this is merged.
