### PR TITLE
python: updated versions + enable default optimizations

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -86,6 +86,11 @@ class Python(AutotoolsPackage):
             description='Produce position-independent code (for shared libs)')
 
     variant('dbm', default=True, description='Provide support for dbm')
+    variant(
+        'optimizations',
+        default=False,
+        description='Enable expensive build-time optimizations, if available'
+    )
 
     depends_on("openssl")
     depends_on("bzip2")
@@ -125,7 +130,6 @@ class Python(AutotoolsPackage):
 
     def setup_environment(self, spack_env, run_env):
         spec = self.spec
-        prefix = self.prefix
 
         # TODO: The '--no-user-cfg' option for Python installation is only in
         # Python v2.7 and v3.4+ (see https://bugs.python.org/issue1180) and
@@ -136,8 +140,6 @@ class Python(AutotoolsPackage):
                       'user configurations are present.').format(self.version))
 
         # Need this to allow python build to find the Python installation.
-        spack_env.set('PYTHONHOME', prefix)
-        spack_env.set('PYTHONPATH', prefix)
         spack_env.set('MACOSX_DEPLOYMENT_TARGET', platform.mac_ver()[0])
 
     def configure_args(self):
@@ -152,7 +154,7 @@ class Python(AutotoolsPackage):
             'LDFLAGS=-L{0}'.format(' -L'.join(dp.lib for dp in dep_pfxs)),
         ]
 
-        if '@2.7.13:2.8,3.5.3:' in spec:
+        if '@2.7.13:2.8,3.5.3:' in spec and '+optimizations' in spec:
             config_args.append('--enable-optimizations')
 
         if spec.satisfies('%gcc platform=darwin'):

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -108,6 +108,9 @@ class Python(AutotoolsPackage):
     _DISTUTIL_CACHE_FILENAME = 'sysconfig.json'
     _distutil_vars = None
 
+    # An in-source build with --enable-optimizations fails for python@3.X
+    build_directory = 'spack-build'
+
     @when('@2.7:2.8,3.4:')
     def patch(self):
         # NOTE: Python's default installation procedure makes it possible for a

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -154,13 +154,15 @@ class Python(AutotoolsPackage):
             'LDFLAGS=-L{0}'.format(' -L'.join(dp.lib for dp in dep_pfxs)),
         ]
 
-        if '@2.7.13:2.8,3.5.3:' in spec and '+optimizations' in spec:
+        if spec.satisfies('@2.7.13:2.8,3.5.3:', strict=True) \
+                and '+optimizations' in spec:
             config_args.append('--enable-optimizations')
 
         if spec.satisfies('%gcc platform=darwin'):
             config_args.append('--disable-toolbox-glue')
 
-        if '%intel' in spec and '@2.7.12:2.8,3.5.2:' in spec:
+        if spec.satisfies('%intel', strict=True) and \
+                spec.satisfies('@2.7.12:2.8,3.5.2:', strict=True):
             config_args.append('--with-icc')
 
         if '+shared' in spec:

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -109,6 +109,14 @@ class Python(AutotoolsPackage):
     patch('cray-rpath-2.3.patch', when="@2.3:3.0.1 platform=cray")
     patch('cray-rpath-3.1.patch', when="@3.1:3.99  platform=cray")
 
+    # For more information refer to this bug report:
+    # https://bugs.python.org/issue29712
+    conflicts(
+        '@:2.8 +shared',
+        when='+optimizations',
+        msg='+optimizations is incompatible with +shared in python@2.X'
+    )
+
     _DISTUTIL_VARS_TO_SAVE = ['LDSHARED']
     _DISTUTIL_CACHE_FILENAME = 'sysconfig.json'
     _distutil_vars = None

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -145,11 +145,15 @@ class Python(AutotoolsPackage):
         dep_pfxs = [dspec.prefix for dspec in spec.dependencies('link')]
         config_args = [
             '--with-threads',
+            '--enable-optimizations',
             'CPPFLAGS=-I{0}'.format(' -I'.join(dp.include for dp in dep_pfxs)),
             'LDFLAGS=-L{0}'.format(' -L'.join(dp.lib for dp in dep_pfxs)),
         ]
         if spec.satisfies('%gcc platform=darwin'):
             config_args.append('--disable-toolbox-glue')
+
+        if '%intel' in spec:
+            config_args.append('--with-icc')
 
         if '+shared' in spec:
             config_args.append('--enable-shared')

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -145,14 +145,17 @@ class Python(AutotoolsPackage):
         dep_pfxs = [dspec.prefix for dspec in spec.dependencies('link')]
         config_args = [
             '--with-threads',
-            '--enable-optimizations',
             'CPPFLAGS=-I{0}'.format(' -I'.join(dp.include for dp in dep_pfxs)),
             'LDFLAGS=-L{0}'.format(' -L'.join(dp.lib for dp in dep_pfxs)),
         ]
+
+        if '@2.7.13:2.8,3.5.3:' in spec:
+            config_args.append('--enable-optimizations')
+
         if spec.satisfies('%gcc platform=darwin'):
             config_args.append('--disable-toolbox-glue')
 
-        if '%intel' in spec:
+        if '%intel' in spec and '@2.7.12:2.8,3.5.2:' in spec:
             config_args.append('--with-icc')
 
         if '+shared' in spec:


### PR DESCRIPTION
Enable default optimizations for production builds. Uses `--with-icc` if built with Intel compilers.