### PR TITLE
module_cmd: remove spurious warning

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -33,6 +33,7 @@ class Cmake(Package):
     list_url = 'https://cmake.org/files/'
     list_depth = 1
 
+    version('3.11.1',   '12a3177477e4e2c7bc514193d421dafe')
     version('3.11.0',   'f3ebc79b5dec85b49abe75958ffa1a03')
     version('3.10.2',   '732808e17fc14dc8cee50d51518c34eb')
     version('3.10.1',   '9a726e5ec69618b172aa4b06d18c3998')


### PR DESCRIPTION
When running on systems where `get_module_cmd_from_bash()` fails (e.g. Blue Waters), this warning is printed more than 10 times for each package installation.
See also issue #6954.