### PR TITLE
gmp: add oldish version 5.1.3 with checksum

### DIFF
--- a/var/spack/repos/builtin/packages/gmp/package.py
+++ b/var/spack/repos/builtin/packages/gmp/package.py
@@ -37,6 +37,7 @@ class Gmp(AutotoolsPackage):
     version('6.1.0',  '86ee6e54ebfc4a90b643a65e402c4048')
     version('6.0.0a', 'b7ff2d88cae7f8085bd5006096eed470')
     version('6.0.0',  '6ef5869ae735db9995619135bd856b84')
+    version('5.1.3', 'a082867cbca5e898371a97bb27b31fea')
 
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')


### PR DESCRIPTION
On some SLED12 systems I could not compile gmp 6.x and subsequently no newer gcc