### PR TITLE
Add latest version of nasm

### DIFF
--- a/var/spack/repos/builtin/packages/nasm/package.py
+++ b/var/spack/repos/builtin/packages/nasm/package.py
@@ -27,8 +27,12 @@ from spack import *
 
 class Nasm(AutotoolsPackage):
     """NASM (Netwide Assembler) is an 80x86 assembler designed for
-       portability and modularity. It includes a disassembler as well."""
-    homepage = "http://www.nasm.us"
-    url      = "http://www.nasm.us/pub/nasm/releasebuilds/2.11.06/nasm-2.11.06.tar.xz"
+    portability and modularity. It includes a disassembler as well."""
 
+    homepage = "http://www.nasm.us"
+    url      = "http://www.nasm.us/pub/nasm/releasebuilds/2.13.03/nasm-2.13.03.tar.xz"
+    list_url = "http://www.nasm.us/pub/nasm/releasebuilds"
+    list_depth = 1
+
+    version('2.13.03', 'd5ca2ad7121ccbae69dd606b1038532c')
     version('2.11.06', '2b958e9f5d200641e6fc9564977aecc5')


### PR DESCRIPTION
Passes all tests on macOS 10.13.3 with Clang 9.0.0.