### PR TITLE
Add latest version of libjpeg-turbo

### DIFF
--- a/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
+++ b/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
@@ -32,8 +32,9 @@ class LibjpegTurbo(AutotoolsPackage):
        transcoding."""
 
     homepage = "http://libjpeg-turbo.virtualgl.org"
-    url      = "http://downloads.sourceforge.net/libjpeg-turbo/libjpeg-turbo-1.3.1.tar.gz"
+    url      = "https://sourceforge.net/projects/libjpeg-turbo/files/1.5.3/libjpeg-turbo-1.5.3.tar.gz"
 
+    version('1.5.3', '7c82f0f6a3130ec06b8a4d0b321cbca3')
     version('1.5.0', '3fc5d9b6a8bce96161659ae7a9939257')
     version('1.3.1', '2c3a68129dac443a72815ff5bb374b05')
 


### PR DESCRIPTION
Passes all tests on macOS 10.13.3 with Clang 9.0.0.