### PR TITLE
Fix giflib unit tests on macOS/BSD

### DIFF
--- a/var/spack/repos/builtin/packages/giflib/bsd-head.patch
+++ b/var/spack/repos/builtin/packages/giflib/bsd-head.patch
@@ -1,0 +1,19 @@
+The BSD version of head does not accept the --bytes option,
+nor does it accept negative integers. Use dd instead for
+BSD support.
+
+--- a/tests/makefile	2014-05-16 05:46:53.000000000 -0500
++++ b/tests/makefile	2018-03-18 18:29:47.000000000 -0500
+@@ -103,10 +103,10 @@
+ 
+ giffix-rebuild:
+ 	@echo "Rebuilding giffix test."
+-	@head --bytes=-20 <$(PICS)/treescap.gif | $(UTILS)/giffix 2>/dev/null | $(UTILS)/gifbuild -d >giffixed.ico
++	@dd if=$(PICS)/treescap.gif bs=1 count=387 | $(UTILS)/giffix 2>/dev/null | $(UTILS)/gifbuild -d >giffixed.ico
+ giffix-regress:
+ 	@echo "giffix: Testing giffix behavior"
+-	@head --bytes=-20 <$(PICS)/treescap.gif | $(UTILS)/giffix 2>/dev/null | $(UTILS)/gifbuild -d | diff -u giffixed.ico -
++	@dd if=$(PICS)/treescap.gif bs=1 count=387 | $(UTILS)/giffix 2>/dev/null | $(UTILS)/gifbuild -d | diff -u giffixed.ico -
+ 
+ gifinto-regress:
+ 	@echo "gifinto: Checking behavior on short files."

--- a/var/spack/repos/builtin/packages/giflib/package.py
+++ b/var/spack/repos/builtin/packages/giflib/package.py
@@ -35,3 +35,6 @@ class Giflib(AutotoolsPackage):
     version('5.1.4', '2c171ced93c0e83bb09e6ccad8e3ba2b')
 
     patch('bsd-head.patch')
+
+    def check(self):
+        make('check', parallel=False)

--- a/var/spack/repos/builtin/packages/giflib/package.py
+++ b/var/spack/repos/builtin/packages/giflib/package.py
@@ -33,3 +33,5 @@ class Giflib(AutotoolsPackage):
     url      = "https://downloads.sourceforge.net/project/giflib/giflib-5.1.4.tar.bz2"
 
     version('5.1.4', '2c171ced93c0e83bb09e6ccad8e3ba2b')
+
+    patch('bsd-head.patch')


### PR DESCRIPTION
Contributed this patch upstream to the developers. We'll see what they say.

With this patch, unit tests pass on macOS 10.13.3 and CentOS 6.9.