### PR TITLE
Add latest version of py-setuptools

### DIFF
--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -30,16 +30,14 @@ class PySetuptools(PythonPackage):
        upgrading, installing, and uninstalling Python packages."""
 
     homepage = "https://pypi.python.org/pypi/setuptools"
-    url      = "https://pypi.io/packages/source/s/setuptools/setuptools-25.2.0.tar.gz"
+    url      = "https://pypi.io/packages/source/s/setuptools/setuptools-39.0.1.zip"
 
     import_modules = ['pkg_resources', 'setuptools', 'setuptools.command']
 
-    version('35.0.2', 'c368b4970d3ad3eab5afe4ef4dbe2437',
-            url="https://pypi.io/packages/source/s/setuptools/setuptools-35.0.2.zip")
-    version('34.4.1', '5f9b07aeaafd29eac2548fc0b89a4934',
-            url="https://pypi.io/packages/source/s/setuptools/setuptools-34.4.1.zip")
-    version('34.2.0', '41b630da4ea6cfa5894d9eb3142922be',
-            url="https://pypi.io/packages/source/s/setuptools/setuptools-34.2.0.zip")
+    version('39.0.1', '75310b72ca0ab4e673bf7679f69d7a62')
+    version('35.0.2', 'c368b4970d3ad3eab5afe4ef4dbe2437')
+    version('34.4.1', '5f9b07aeaafd29eac2548fc0b89a4934')
+    version('34.2.0', '41b630da4ea6cfa5894d9eb3142922be')
     version('25.2.0', 'a0dbb65889c46214c691f6c516cf959c')
     version('20.7.0', '5d12b39bf3e75e80fdce54e44b255615')
     version('20.6.7', '45d6110f3ec14924e44c33411db64fe6')
@@ -53,7 +51,21 @@ class PySetuptools(PythonPackage):
 
     # Previously, setuptools vendored all of its dependencies to allow
     # easy bootstrapping. As of version 34.0.0, this is no longer done
-    # and the dependencies need to be installed externally.
-    depends_on('py-packaging@16.8:', when='@34.0.0:', type=('build', 'run'))
-    depends_on('py-six@1.6.0:',      when='@34.0.0:', type=('build', 'run'))
-    depends_on('py-appdirs@1.4.0:',  when='@34.0.0:', type=('build', 'run'))
+    # and the dependencies need to be installed externally. As of version
+    # 36.0.0, setuptools now vendors its dependencies again. See
+    # https://github.com/pypa/setuptools/issues/980 for the reason they
+    # reverted back to vendoring again.
+    depends_on('py-packaging@16.8:', when='@34:35', type=('build', 'run'))
+    depends_on('py-six@1.6.0:',      when='@34:35', type=('build', 'run'))
+    depends_on('py-appdirs@1.4.0:',  when='@34:35', type=('build', 'run'))
+
+    def url_for_version(self, version):
+        url = 'https://pypi.io/packages/source/s/setuptools/setuptools-{0}'
+        url = url.format(version)
+
+        if version > Version('32.1.2'):
+            url += '.zip'
+        else:
+            url += '.tar.gz'
+
+        return url


### PR DESCRIPTION
Newer versions of `py-setuptools` no longer require any dependencies, they are once again vendored.