### PR TITLE
Add latest version of eigen

### DIFF
--- a/var/spack/repos/builtin/packages/eigen/find-ptscotch.patch
+++ b/var/spack/repos/builtin/packages/eigen/find-ptscotch.patch
@@ -1,0 +1,27 @@
+Version 3.3.4 contained a bug that prevented it from finding scotch~mpi.
+
+diff --git a/tmp/FindPTSCOTCH.cmake b/cmake/FindPTSCOTCH.cmake
+index 1396d05..23451b1 100644
+--- a/tmp/FindPTSCOTCH.cmake
++++ b/cmake/FindPTSCOTCH.cmake
+@@ -167,11 +167,11 @@ endif()
+
+ # If found, add path to cmake variable
+ # ------------------------------------
++unset(PTSCOTCH_INCLUDE_DIRS)
+ foreach(ptscotch_hdr ${PTSCOTCH_hdrs_to_find})
+   if (PTSCOTCH_${ptscotch_hdr}_DIRS)
+     list(APPEND PTSCOTCH_INCLUDE_DIRS "${PTSCOTCH_${ptscotch_hdr}_DIRS}")
+   else ()
+-    set(PTSCOTCH_INCLUDE_DIRS "PTSCOTCH_INCLUDE_DIRS-NOTFOUND")
+     if (NOT PTSCOTCH_FIND_QUIETLY)
+       message(STATUS "Looking for ptscotch -- ${ptscotch_hdr} not found")
+     endif()
+@@ -255,7 +255,6 @@ foreach(ptscotch_lib ${PTSCOTCH_libs_to_find})
+     list(APPEND PTSCOTCH_LIBRARIES "${PTSCOTCH_${ptscotch_lib}_LIBRARY}")
+     list(APPEND PTSCOTCH_LIBRARY_DIRS "${${ptscotch_lib}_lib_path}")
+   else ()
+-    list(APPEND PTSCOTCH_LIBRARIES "${PTSCOTCH_${ptscotch_lib}_LIBRARY}")
+     if (NOT PTSCOTCH_FIND_QUIETLY)
+       message(STATUS "Looking for ptscotch -- lib ${ptscotch_lib} not found")
+     endif()

--- a/var/spack/repos/builtin/packages/eigen/package.py
+++ b/var/spack/repos/builtin/packages/eigen/package.py
@@ -54,8 +54,10 @@ class Eigen(CMakePackage):
 
     # TODO : dependency on googlehash, superlu, adolc missing
     depends_on('metis@5:', when='+metis')
-    depends_on('scotch+mpi', when='+scotch')
+    depends_on('scotch', when='+scotch')
     depends_on('fftw', when='+fftw')
     depends_on('suite-sparse', when='+suitesparse')
     depends_on('mpfr@2.3.0:', when='+mpfr')
     depends_on('gmp', when='+mpfr')
+
+    patch('find-ptscotch.patch', when='@3.3.4')

--- a/var/spack/repos/builtin/packages/eigen/package.py
+++ b/var/spack/repos/builtin/packages/eigen/package.py
@@ -31,8 +31,9 @@ class Eigen(CMakePackage):
     """
 
     homepage = 'http://eigen.tuxfamily.org/'
-    url      = 'https://bitbucket.org/eigen/eigen/get/3.3.3.tar.bz2'
+    url      = 'https://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2'
 
+    version('3.3.4', 'a7aab9f758249b86c93221ad417fbe18')
     version('3.3.3', 'b2ddade41040d9cf73b39b4b51e8775b')
     version('3.3.1', 'edb6799ef413b0868aace20d2403864c')
     version('3.2.10', 'a85bb68c82988648c3d53ba9768d7dcbcfe105f8')
@@ -53,7 +54,7 @@ class Eigen(CMakePackage):
 
     # TODO : dependency on googlehash, superlu, adolc missing
     depends_on('metis@5:', when='+metis')
-    depends_on('scotch', when='+scotch')
+    depends_on('scotch+mpi', when='+scotch')
     depends_on('fftw', when='+fftw')
     depends_on('suite-sparse', when='+suitesparse')
     depends_on('mpfr@2.3.0:', when='+mpfr')


### PR DESCRIPTION
Ran into some weird build problems with `eigen` when I added this new version.

The following specs build just fine:

- `eigen@3.3.4 +scotch ^scotch+mpi`
- `eigen@3.3.4 ~scotch`
- `eigen@3.3.3 +scotch ^scotch~mpi`

But I can't get the following configuration to build:

- `eigen@3.3.4 +scotch ^scotch~mpi`

The result is:
```
2 errors found in build log:
     110    -- Performing Test SCOTCH_Num_4 - Success
     111    -- Could NOT find MPI_C (missing: MPI_C_LIB_NAMES MPI_C_HEADER_DIR MPI_C_WORKS)
     112    -- Could NOT find MPI_CXX (missing: MPI_CXX_LIB_NAMES MPI_CXX_HEADER_DIR MPI_CXX_WORKS)
     113    -- Could NOT find MPI_Fortran (missing: MPI_Fortran_LIB_NAMES MPI_Fortran_F77_HEADER_DIR MPI_Fortran_MODULE_DIR MPI_Fortran_WORKS)
     114    -- Could NOT find MPI (missing: MPI_C_FOUND MPI_CXX_FOUND MPI_Fortran_FOUND)
     115    -- Looking for SCOTCH_dgraphInit
  >> 116    CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
     117    Please set them or make sure they are set and tested correctly in the CMake files:
     118    PTSCOTCH_INCLUDE_DIRS
     119       used as include directory in directory /private/var/folders/21/hwq39zyj4g36x6zjfyl5l8080000gn/T/pytest-of-Adam/pytest-33/test_keep_exceptions0
            /tmp/spack-stage/spack-stage-_gd66eiv/eigen-eigen-5a0156e40feb/spack-build/CMakeFiles/CMakeTmp
     120       used as include directory in directory /private/var/folders/21/hwq39zyj4g36x6zjfyl5l8080000gn/T/pytest-of-Adam/pytest-33/test_keep_exceptions0
            /tmp/spack-stage/spack-stage-_gd66eiv/eigen-eigen-5a0156e40feb/spack-build/CMakeFiles/CMakeTmp
     121       used as include directory in directory /private/var/folders/21/hwq39zyj4g36x6zjfyl5l8080000gn/T/pytest-of-Adam/pytest-33/test_keep_exceptions0
            /tmp/spack-stage/spack-stage-_gd66eiv/eigen-eigen-5a0156e40feb/spack-build/CMakeFiles/CMakeTmp
     122    PTSCOTCH_ptscotch_LIBRARY
     123        linked by target "cmTC_569dc" in directory /private/var/folders/21/hwq39zyj4g36x6zjfyl5l8080000gn/T/pytest-of-Adam/pytest-33/test_keep_except
            ions0/tmp/spack-stage/spack-stage-_gd66eiv/eigen-eigen-5a0156e40feb/spack-build/CMakeFiles/CMakeTmp
     124    PTSCOTCH_ptscotcherr_LIBRARY
     125        linked by target "cmTC_569dc" in directory /private/var/folders/21/hwq39zyj4g36x6zjfyl5l8080000gn/T/pytest-of-Adam/pytest-33/test_keep_except
            ions0/tmp/spack-stage/spack-stage-_gd66eiv/eigen-eigen-5a0156e40feb/spack-build/CMakeFiles/CMakeTmp
     126    
  >> 127    CMake Error at /Users/Adam/spack/opt/spack/darwin-highsierra-x86_64/clang-9.0.0-apple/cmake-3.10.2-5of7akvqwifyrejpf46up5fbi44vrfdg/share/cmake-3
            .10/Modules/CheckFunctionExists.cmake:70 (try_compile):
     128      Failed to configure test project build system.
     129    Call Stack (most recent call first):
     130      cmake/FindPTSCOTCH.cmake:335 (check_function_exists)
     131      cmake/FindPASTIX.cmake:306 (find_package)
     132      test/CMakeLists.txt:83 (find_package)
```

Perhaps the `scotch` requirement has changed with this latest release and it now requires `ptscotch`? I didn't see anything enlightening in the Changelog. I don't know much about `eigen` so pinging some people who have contributed to this package in the past.

@svenevs @alalazo @mdavezac @jppelteret @goxberry @davydden 