### PR TITLE
Add latest version of MPC

### DIFF
--- a/var/spack/repos/builtin/packages/mpc/package.py
+++ b/var/spack/repos/builtin/packages/mpc/package.py
@@ -29,20 +29,28 @@ class Mpc(AutotoolsPackage):
     """Gnu Mpc is a C library for the arithmetic of complex numbers
        with arbitrarily high precision and correct rounding of the
        result."""
-    homepage = "http://www.multiprecision.org"
-    url      = "https://ftp.gnu.org/gnu/mpc/mpc-1.0.2.tar.gz"
 
+    homepage = "http://www.multiprecision.org"
+    url      = "https://ftp.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz"
+    list_url = "http://www.multiprecision.org/mpc/download.html"
+
+    version('1.1.0', '4125404e41e482ec68282a2e687f6c73')
     version('1.0.3', 'd6a1d5f8ddea3abd2cc3e98f58352d26')
     version('1.0.2', '68fadff3358fb3e7976c7a398a0af4c3')
 
-    depends_on('gmp@4.3.2:')   # mpir is a drop-in replacement for this
-    depends_on('mpfr@2.4.2:')  # Could also be built against mpir
+    # Could also be built against mpir instead
+    depends_on('gmp@4.3.2:')
+    depends_on('gmp@5.0.0:', when='@1.1.0:')
+    depends_on('mpfr@2.4.2:')
+    depends_on('mpfr@3.0.0:', when='@1.1.0:')
 
     def url_for_version(self, version):
         if version < Version("1.0.1"):
-            return "http://www.multiprecision.org/mpc/download/mpc-%s.tar.gz" % version
+            url = "http://www.multiprecision.org/mpc/download/mpc-{0}.tar.gz"
         else:
-            return "https://ftp.gnu.org/gnu/mpc/mpc-%s.tar.gz" % version
+            url = "https://ftp.gnu.org/gnu/mpc/mpc-{0}.tar.gz"
+
+        return url.format(version)
 
     def configure_args(self):
         spec = self.spec


### PR DESCRIPTION
Builds and passes all tests on macOS 10.13.3 with Clang 9.0.0.