### PR TITLE
Add latest version of ISL

### DIFF
--- a/var/spack/repos/builtin/packages/isl/package.py
+++ b/var/spack/repos/builtin/packages/isl/package.py
@@ -30,8 +30,9 @@ class Isl(AutotoolsPackage):
     sets and relations of integer points bounded by affine constraints."""
 
     homepage = "http://isl.gforge.inria.fr"
-    url      = "http://isl.gforge.inria.fr/isl-0.18.tar.bz2"
+    url      = "http://isl.gforge.inria.fr/isl-0.19.tar.bz2"
 
+    version('0.19', '7850d46a96e5ea31e34913190895e154')
     version('0.18', '11436d6b205e516635b666090b94ab32')
     version('0.14', 'acd347243fca5609e3df37dba47fd0bb')
 


### PR DESCRIPTION
Builds and passes all tests on macOS 10.13.3 with Clang 9.0.0.