### PR TITLE
Recover the old patching order for packages.

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1162,7 +1162,7 @@ class PackageBase(with_metaclass(PackageMeta, object)):
             patch_list
             for spec, patch_list in self.patches.items()
             if self.spec.satisfies(spec))
-        return sorted(patchesToApply, key=lambda p: p.path_or_url)
+        return list(patchesToApply)
 
     def content_hash(self, content=None):
         """Create a hash based on the sources and logic used to build the


### PR DESCRIPTION
fixes #7543

This is very likely an hot-fix, while a more permanent solution is needed. See this comment for more insight:

 https://github.com/spack/spack/pull/7193#discussion_r176448831

on the problem.