### PR TITLE
nwchem: fixed accidental rebinding or `url` name at class level

### DIFF
--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -70,9 +70,9 @@ class Nwchem(Package):
         ]
     }
     # Iterate over patches
-    for condition, urls in urls_for_patches.items():
-        for url, sha256, archive_sha256 in urls:
-            patch(url, when=condition, level=0, sha256=sha256, archive_sha256=archive_sha256)
+    for __condition, __urls in urls_for_patches.items():
+        for __url, __sha256, __archive_sha256 in __urls:
+            patch(__url, when=__condition, level=0, sha256=__sha256, archive_sha256=__archive_sha256)
 
     def install(self, spec, prefix):
         scalapack = spec['scalapack'].libs


### PR DESCRIPTION
Used names with __ in class level constructs to avoid rebinding

fixes #3129