### PR TITLE
Increment Spack version

### DIFF
--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -96,7 +96,7 @@ from spack.package_prefs import PackageTesting
 # Initialize various data structures & objects at the core of Spack.
 #-----------------------------------------------------------------------------
 # Version information
-spack_version = Version("0.11.0")
+spack_version = Version("0.11.2")
 
 
 # Set up the default packages database.


### PR DESCRIPTION
We've been forgetting to increment Spack's internal version. We should probably push this to the last couple of release branches as well.