### PR TITLE
Fix tclsh command for transitive dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -70,6 +70,15 @@ class Tcl(AutotoolsPackage):
     # ========================================================================
     # Set up environment to make install easy for tcl extensions.
     # ========================================================================
+    @property
+    def command(self):
+        """Returns the tclsh command.
+
+        :returns: The tclsh command
+        :rtype: Executable
+        """
+        path = os.path.realpath(os.path.join(self.prefix.bin, 'tclsh'))
+        return Executable(path)
 
     @property
     def tcl_lib_dir(self):
@@ -94,7 +103,7 @@ class Tcl(AutotoolsPackage):
         # where a system provided tcl is run against the standard libraries
         # of a Spack built tcl. See issue #7128 that relates to python but
         # it boils down to the same situation we have here.
-        spack_env.prepend_path('PATH', os.path.dirname(self.prefix.bin))
+        spack_env.prepend_path('PATH', os.path.dirname(self.command.path))
 
         tcl_paths = [join_path(self.prefix, self.tcl_builtin_lib_dir)]
 

--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -77,8 +77,7 @@ class Tcl(AutotoolsPackage):
         :returns: The tclsh command
         :rtype: Executable
         """
-        path = os.path.realpath(os.path.join(self.prefix.bin, 'tclsh'))
-        return Executable(path)
+        return Executable(os.path.realpath(self.prefix.bin.tclsh))
 
     @property
     def tcl_lib_dir(self):


### PR DESCRIPTION
Fix `tclsh` command found in transitive dependencies' environment. The issue was exactly the same as #7128 but for Tcl and due to human (mine) error this time.