### PR TITLE
Shared libraries for yaml-cpp

### DIFF
--- a/var/spack/repos/builtin/packages/yaml-cpp/package.py
+++ b/var/spack/repos/builtin/packages/yaml-cpp/package.py
@@ -41,13 +41,21 @@ class YamlCpp(CMakePackage):
 
     depends_on('boost', when='@:0.5.3')
 
+    # run cmake flow twice to build/install shared/static into same prefix
+    # FIXME: how avoid second build when shared is False?
+    phases = ['patch_cmake_args'] + CMakePackage.phases + \
+             ['patch_cmake_args'] + CMakePackage.phases
+
+    def patch_cmake_args(self, spec, prefix):
+        self.first_run = not hasattr(self, 'first_run')
+
     def cmake_args(self):
         spec = self.spec
         options = []
 
         options.extend([
             '-DBUILD_SHARED_LIBS:BOOL=%s' % (
-                'ON' if '+shared' in spec else 'OFF'),
+                'ON' if ('+shared' in spec and self.first_run) else 'OFF'),
             '-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=%s' % (
                 'ON' if '+pic' in spec else 'OFF'),
         ])


### PR DESCRIPTION
We would like the `+shared` variant to build the shared libraries in addition to the static libraries for `yaml-cpp`. In essence we need to run `cmake && make && make install` series twice with different `cmake_args`. 
This PR overrides the CMakePackage steps in order to do that. It's not really a very elegant solution but it just works:tm: