### PR TITLE
make view understand hashes

### DIFF
--- a/lib/spack/spack/cmd/view.py
+++ b/lib/spack/spack/cmd/view.py
@@ -172,6 +172,7 @@ def setup_parser(sp):
 def view(parser, args):
     'Produce a view of a set of packages.'
 
+    specs = spack.cmd.parse_specs(args.specs)
     path = args.path[0]
 
     view = YamlFilesystemView(
@@ -189,18 +190,18 @@ def view(parser, args):
 
     elif args.action in actions_link:
         # only link commands need to disambiguate specs
-        specs = [spack.cmd.disambiguate_spec(s) for s in args.specs]
+        specs = [spack.cmd.disambiguate_spec(s) for s in specs]
 
     elif args.action in actions_status:
         # no specs implies all
-        if len(args.specs) == 0:
+        if len(specs) == 0:
             specs = view.get_all_specs()
         else:
-            specs = relaxed_disambiguate(args.specs, view)
+            specs = relaxed_disambiguate(specs, view)
 
     else:
         # status and remove can map the name to packages in view
-        specs = relaxed_disambiguate(args.specs, view)
+        specs = relaxed_disambiguate(specs, view)
 
     with_dependencies = args.dependencies.lower() in ['true', 'yes']
 


### PR DESCRIPTION
Makes `view` operate on `[Spec, ...]` instead of `[str, ...]`. Should fix #7548. 

We use this patch in production and I simply forgot to bring it upstream, cc: @obreitwi 