### PR TITLE
openmpi: updated package

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -218,6 +218,7 @@ class Openmpi(AutotoolsPackage):
     depends_on('java', when='+java')
     depends_on('sqlite', when='+sqlite3@:1.11')
     depends_on('ucx', when='+ucx')
+    depends_on('zlib', when='@3.0.0:')
 
     conflicts('+cuda', when='@:1.6')  # CUDA support was added in 1.7
     conflicts('fabrics=psm2', when='@:1.8')  # PSM2 support was added in 1.10.0
@@ -319,6 +320,9 @@ class Openmpi(AutotoolsPackage):
         if self.spec.satisfies('@2.0:'):
             # for Open-MPI 2.0:, C++ bindings are disabled by default.
             config_args.extend(['--enable-mpi-cxx'])
+
+        if spec.satisfies('@3.0.0:', strict=True):
+            config_args.append('--with-zlib={0}'.format(spec['zlib'].prefix))
 
         # Fabrics
         config_args.extend(self.with_or_without('fabrics'))

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -421,3 +421,18 @@ class Openmpi(AutotoolsPackage):
             config_args.append('--without-ucx')
 
         return config_args
+
+    @run_after('install')
+    def delete_mpirun_mpiexec(self):
+        # The preferred way to run an application when Slurm is the
+        # scheduler is to let Slurm manage process spawning via PMI.
+        #
+        # Deleting the links to orterun avoids users running their
+        # applications via mpirun or mpiexec, and leaves srun as the
+        # only sensible choice (orterun is still present, but normal
+        # users don't know about that).
+        if '@1.6: schedulers=slurm' in self.spec:
+            os.remove(self.prefix.bin.mpirun)
+            os.remove(self.prefix.bin.mpiexec)
+            os.remove(self.prefix.bin.shmemrun)
+            os.remove(self.prefix.bin.oshrun)


### PR DESCRIPTION
More details are in commits short description. 

The last commit might be controversial. In case people disagree on removing `mpirun` and `mpiexec` links to avoid conflicts with `srun` if `slurm` is the scheduler I'll delete it from the PR. 