### PR TITLE
Cray clean environment

### DIFF
--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -31,7 +31,7 @@ from spack.architecture import Platform, Target, NoPlatformError
 from spack.operating_systems.cray_frontend import CrayFrontend
 from spack.operating_systems.cnl import Cnl
 from llnl.util.filesystem import join_path
-from spack.util.module_cmd import get_module_cmd
+from spack.util.module_cmd import get_module_cmd, unload_module
 
 
 def _get_modules_in_modulecmd_output(output):
@@ -103,11 +103,19 @@ class Cray(Platform):
         """ Change the linker to default dynamic to be more
             similar to linux/standard linker behavior
         """
+        # Unload these modules to prevent any silent linking or unnecessary
+        # I/O profiling in the case of darshan.
+        modules_to_unload = ["cray-mpich", "darshan", "cray-libsci"]
+        for module in modules_to_unload:
+            unload_module(module)
+
         env.set('CRAYPE_LINK_TYPE', 'dynamic')
         cray_wrapper_names = join_path(build_env_path, 'cray')
+
         if os.path.isdir(cray_wrapper_names):
             env.prepend_path('PATH', cray_wrapper_names)
             env.prepend_path('SPACK_ENV_PATH', cray_wrapper_names)
+
         # Makes spack installed pkg-config work on Crays
         env.append_path("PKG_CONFIG_PATH", "/usr/lib64/pkgconfig")
         env.append_path("PKG_CONFIG_PATH", "/usr/local/lib64/pkgconfig")

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -120,7 +120,7 @@ def unload_module(mod):
     not check whether conflicts arise from the unloaded module"""
     modulecmd = get_module_cmd()
     exec(compile(modulecmd('unload', mod, output=str, error=str), '<string>',
-        'exec'))
+                           'exec'))
 
 
 def load_module(mod):

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -120,7 +120,7 @@ def unload_module(mod):
     not check whether conflicts arise from the unloaded module"""
     modulecmd = get_module_cmd()
     exec(compile(modulecmd('unload', mod, output=str, error=str), '<string>',
-                           'exec'))
+                 'exec'))
 
 
 def load_module(mod):

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -115,6 +115,14 @@ def get_module_cmd_from_bash(bashopts=''):
     return module_cmd
 
 
+def unload_module(mod):
+    """Takes a module name and unloads the module from the environment. It does
+    not check whether conflicts arise from the unloaded module"""
+    modulecmd = get_module_cmd()
+    exec(compile(modulecmd('unload', mod, output=str, error=str), '<string>',
+        'exec'))
+
+
 def load_module(mod):
     """Takes a module name and removes modules until it is possible to
     load that module. It then loads the provided module. Depends on the
@@ -130,8 +138,8 @@ def load_module(mod):
     text = modulecmd('show', mod, output=str, error=str).split()
     for i, word in enumerate(text):
         if word == 'conflict':
-            exec(compile(modulecmd('unload', text[i + 1], output=str,
-                                   error=str), '<string>', 'exec'))
+            unload_module(text[i + 1])
+
     # Load the module now that there are no conflicts
     # Some module systems use stdout and some use stderr
     load = modulecmd('load', mod, output=str, error='/dev/null')


### PR DESCRIPTION
Unload modules cray-mpich, darshan, and cray-libsci from the environment. This prevents any silent linking of mpich and cray-libsci. Also for compilation, it is recommended that darshan be unloaded.