### PR TITLE
Grab Cray os version from PrgEnv module versions

### DIFF
--- a/lib/spack/spack/operating_systems/cnl.py
+++ b/lib/spack/spack/operating_systems/cnl.py
@@ -42,12 +42,20 @@ class Cnl(OperatingSystem):
     """
 
     def __init__(self):
-        name = 'CNL'
-        version = '10'
+        name = 'cnl'
+        version = self._detect_crayos_version()
         super(Cnl, self).__init__(name, version)
 
     def __str__(self):
-        return self.name
+        return self.name + str(self.version)
+
+    def _detect_crayos_version(self):
+        modulecmd = get_module_cmd()
+        output = modulecmd("avail", "PrgEnv-", output=str, error=str)
+        matches = re.findall(r'PrgEnv-\w+/(\d+).\d+.\d+', output)
+        major_versions = set(matches)
+        latest_version = max(major_versions)
+        return latest_version
 
     def find_compilers(self, *paths):
         types = spack.compilers.all_compiler_types()


### PR DESCRIPTION
Previously we defaulted all Cray OS versions to 10.

Part of my work with @mamelara to upstream as much as possible of his NERSC-specific logic.