### PR TITLE
Avoid stat-ing all packages at startup.

### DIFF
--- a/lib/spack/spack/repository.py
+++ b/lib/spack/spack/repository.py
@@ -683,7 +683,7 @@ class Repo(object):
         self._instances = {}
 
         # Maps that goes from package name to corresponding file stat
-        self._fast_package_checker = FastPackageChecker(self.packages_path)
+        self._fast_package_checker = None
 
         # Index of virtual dependencies, computed lazily
         self._provider_index = None
@@ -928,9 +928,15 @@ class Repo(object):
         pkg_dir = self.dirname_for_package_name(spec.name)
         return join_path(pkg_dir, package_file_name)
 
+    @property
+    def _pkg_checker(self):
+        if self._fast_package_checker is None:
+            self._fast_package_checker = FastPackageChecker(self.packages_path)
+        return self._fast_package_checker
+
     def all_package_names(self):
         """Returns a sorted list of all package names in the Repo."""
-        return sorted(self._fast_package_checker.keys())
+        return sorted(self._pkg_checker.keys())
 
     def packages_with_tags(self, *tags):
         v = set(self.all_package_names())
@@ -952,7 +958,7 @@ class Repo(object):
 
     def exists(self, pkg_name):
         """Whether a package with the supplied name exists."""
-        return pkg_name in self._fast_package_checker
+        return pkg_name in self._pkg_checker
 
     def is_virtual(self, pkg_name):
         """True if the package with this name is virtual, False otherwise."""


### PR DESCRIPTION
This further reduces startup time from #7585.  Spack was making many calls to `stat()` at startup, causing the command to run very slowly.

- FastPackageChecker was being called at startup every time Spack runs,
  which takes a long time on networked filesystems.  Startup was taking
  5-7 seconds due to this call.

- The checker was intended to avaoid importing all packages (which is
  really expensive) when all it needs is to stat them.  So it's only
  "fast" for parts of the code that *need* it.

- This commit makes repositories instantiate the checker lazily, so it's
  only constructed when needed.

`strace` of `spack python -c 'exit()'`:

before (up to 5-8s if files fell out of NFS cache):
```
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 42.81    0.440777          36     12151     10992 open
 40.37    0.415704          60      6874      3275 stat
  4.12    0.042386           7      6193         2 lstat
  3.41    0.035127           8      4309           read
  3.21    0.033026           7      4470           fstat
  1.12    0.011498           4      3004        74 lseek
  0.95    0.009780           8      1202           close
  0.89    0.009206          11       838           mmap
```

after (pretty consistently around 1-1.5s on our NFS):
```
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 62.48    0.079934          16      5117      4491 open
 13.25    0.016952          11      1574      1368 stat
  6.60    0.008449          10       860           read
  6.14    0.007858           8       927           fstat
  2.83    0.003614           8       452           mmap
  2.60    0.003323           5       641           close
  2.15    0.002748           9       305           munmap
```
