### PR TITLE
zeromq: fix build

### DIFF
--- a/var/spack/repos/builtin/packages/zeromq/package.py
+++ b/var/spack/repos/builtin/packages/zeromq/package.py
@@ -47,7 +47,7 @@ class Zeromq(AutotoolsPackage):
     depends_on('autoconf', type='build', when='@develop')
     depends_on('automake', type='build', when='@develop')
     depends_on('libtool', type='build', when='@develop')
-    depends_on('pkgconfig', type='build', when='@develop')
+    depends_on('pkgconfig', type='build')
 
     @when('@develop')
     def autoreconf(self, spec, prefix):


### PR DESCRIPTION
pkg-config is also required for release versions.