### PR TITLE
fix missing -lrt for Centos6, issue: #7552

### DIFF
--- a/var/spack/repos/builtin/packages/lz4/lz4_lrt.patch
+++ b/var/spack/repos/builtin/packages/lz4/lz4_lrt.patch
@@ -1,0 +1,11 @@
+diff -Naur lz4-1.8.1.2/programs/Makefile lz4-1.8.1.2x/programs/Makefile
+--- lz4-1.8.1.2/programs/Makefile	2018-01-14 00:21:43.000000000 -0800
++++ lz4-1.8.1.2x/programs/Makefile	2018-03-26 01:13:54.467096931 -0700
+@@ -50,6 +50,7 @@
+             -Wswitch-enum -Wdeclaration-after-statement -Wstrict-prototypes \
+             -Wpointer-arith -Wstrict-aliasing=1
+ CFLAGS   += $(DEBUGFLAGS) $(MOREFLAGS)
++LDFLAGS   = -lrt
+ FLAGS     = $(CFLAGS) $(CPPFLAGS) $(LDFLAGS)
+ 
+ LZ4_VERSION=$(LIBVER)

--- a/var/spack/repos/builtin/packages/lz4/package.py
+++ b/var/spack/repos/builtin/packages/lz4/package.py
@@ -49,6 +49,9 @@ class Lz4(Package):
         else:
             return "{0}/r{1}.tar.gz".format(url, version.joined)
 
+    # This patch found to be necessary for Centos6
+    patch('lz4_lrt.patch', when='@1.8.1.2 platform=linux')
+
     def install(self, spec, prefix):
         make()
         if self.run_tests:


### PR DESCRIPTION
This patch fixes issue #7552. 