### PR TITLE
Add missing X-libs dependencies to vim+x

### DIFF
--- a/var/spack/repos/builtin/packages/vim/package.py
+++ b/var/spack/repos/builtin/packages/vim/package.py
@@ -66,6 +66,11 @@ class Vim(AutotoolsPackage):
     # support for auto/no/gtk2/gnome2/gtk3/motif/athena/neXtaw/photon/carbon
     variant('gui', default=False, description="build with gui (gvim)")
     variant('x', default=False, description="use the X Window System")
+    depends_on('libx11', when="+x")
+    depends_on('libsm', when="+x")
+    depends_on('libxpm', when="+x")
+    depends_on('libxt', when="+x")
+    depends_on('libxtst', when="+x")
 
     depends_on('ncurses', when="@7.4:")
 


### PR DESCRIPTION
This seems to be the minimal set of X-related libraries needed for vim+x build (btw. vim's `configure` step does NOT break if `--with-x` is specified but no X libs are found).