### PR TITLE
conflicts directives extended to accept a predicate

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -205,6 +205,12 @@ _any_version = VersionList([':'])
 maxint = 2 ** (ctypes.sizeof(ctypes.c_int) * 8 - 1) - 1
 
 
+def no_fortran_compilers_available(spec):
+    """Returns true if the spec doesn't have Fortran compilers available."""
+    compiler = spec.package.compiler
+    return compiler.f77 is None or compiler.fc is None
+
+
 def colorize_spec(spec):
     """Returns a spec colorized according to the colors specified in
        color_formats."""
@@ -1905,9 +1911,11 @@ class Spec(object):
         for x in self.traverse():
             for conflict_spec, when_list in x.package_class.conflicts.items():
                 if x.satisfies(conflict_spec, strict=True):
-                    for when_spec, msg in when_list:
-                        if x.satisfies(when_spec, strict=True):
-                            matches.append((x, conflict_spec, when_spec, msg))
+                    for is_constraint_met, description, msg in when_list:
+                        if is_constraint_met(x):
+                            matches.append(
+                                (x, conflict_spec, description, msg)
+                            )
         if matches:
             raise ConflictsInSpecError(self, matches)
 

--- a/var/spack/repos/builtin/packages/adios/package.py
+++ b/var/spack/repos/builtin/packages/adios/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+from spack.spec import no_fortran_compilers_available
 
 
 class Adios(AutotoolsPackage):
@@ -120,18 +121,11 @@ class Adios(AutotoolsPackage):
     #   https://github.com/spack/spack/issues/1683
     patch('adios_1100.patch', when='@:1.10.0^hdf5@1.10:')
 
-    def validate(self, spec):
-        """Checks if incompatible variants have been activated at the same time
-
-        Args:
-            spec: spec of the package
-
-        Raises:
-            RuntimeError: in case of inconsistencies
-        """
-        if '+fortran' in spec and not self.compiler.fc:
-            msg = 'cannot build a fortran variant without a fortran compiler'
-            raise RuntimeError(msg)
+    conflicts(
+        '+fortran',
+        when=no_fortran_compilers_available,
+        msg='+fortran needs a Fortran compiler available'
+    )
 
     def with_or_without_hdf5(self, activated):
 

--- a/var/spack/repos/builtin/packages/bohrium/package.py
+++ b/var/spack/repos/builtin/packages/bohrium/package.py
@@ -29,6 +29,12 @@ import llnl.util.tty as tty
 import os
 
 
+def has_cuda_arch_variant_set(spec):
+    # Sanity check
+    cuda_arch = spec.variants['cuda_arch'].value
+    return "+cuda" in spec and len(cuda_arch) >= 1 and cuda_arch[0]
+
+
 class Bohrium(CMakePackage, CudaPackage):
     """Library for automatic acceleration of array operations"""
 
@@ -112,6 +118,12 @@ class Bohrium(CMakePackage, CudaPackage):
 
     depends_on('zlib', when="+proxy")
 
+    conflicts(
+        'bohrium',
+        when=has_cuda_arch_variant_set,
+        msg="Bohrium does not support setting the CUDA architecture yet."
+    )
+
     @property
     def config_file(self):
         """Return the path of the Bohrium system-wide configuration file"""
@@ -122,15 +134,6 @@ class Bohrium(CMakePackage, CudaPackage):
     #
     def cmake_args(self):
         spec = self.spec
-
-        # Sanity check
-        cuda_arch = spec.variants['cuda_arch'].value
-        if "+cuda" in spec and len(cuda_arch) >= 1 and cuda_arch[0]:
-            # TODO Add cuda_arch support to Bohrium once the basic setup
-            #      via Spack works.
-            raise InstallError(
-                "Bohrium does not support setting the CUDA architecture yet."
-            )
 
         args = [
             # Choose a particular python version

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -22,8 +22,10 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-from spack import *
 import os
+
+from spack import *
+from spack.spec import no_fortran_compilers_available
 
 
 class Mpich(AutotoolsPackage):
@@ -90,6 +92,9 @@ spack package at this time.''',
     conflicts('netmod=mxm', when='@:3.1.3')
     conflicts('netmod=tcp', when='device=ch4')
 
+    conflicts('mpich', when=no_fortran_compilers_available,
+              msg='Mpich requires both C and Fortran compilers!')
+
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         # On Cray, the regular compiler wrappers *are* the MPI wrappers.
         if 'platform=cray' in self.spec:
@@ -134,16 +139,6 @@ spack package at this time.''',
         # Else bootstrap with autotools
         bash = which('bash')
         bash('./autogen.sh')
-
-    @run_before('autoreconf')
-    def die_without_fortran(self):
-        # Until we can pass variants such as +fortran through virtual
-        # dependencies depends_on('mpi'), require Fortran compiler to
-        # avoid delayed build errors in dependents.
-        if (self.compiler.f77 is None) or (self.compiler.fc is None):
-            raise InstallError(
-                'Mpich requires both C and Fortran compilers!'
-            )
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -26,6 +26,7 @@ import sys
 
 from spack import *
 from spack.error import SpackError
+from spack.spec import no_fortran_compilers_available
 
 
 def _process_manager_validator(values):
@@ -113,6 +114,9 @@ class Mvapich2(AutotoolsPackage):
         'mpicc', 'mpicxx', 'mpif77', 'mpif90', 'mpifort', relative_root='bin'
     )
 
+    conflicts('mvapich2', when=no_fortran_compilers_available,
+              msg='Mvapich2 requires both C and Fortran compilers!')
+
     @property
     def process_manager_options(self):
         spec = self.spec
@@ -178,16 +182,6 @@ class Mvapich2(AutotoolsPackage):
             join_path(self.prefix.lib, 'libmpicxx.{0}'.format(dso_suffix)),
             join_path(self.prefix.lib, 'libmpi.{0}'.format(dso_suffix))
         ]
-
-    @run_before('configure')
-    def die_without_fortran(self):
-        # Until we can pass variants such as +fortran through virtual
-        # dependencies depends_on('mpi'), require Fortran compiler to
-        # avoid delayed build errors in dependents.
-        if (self.compiler.f77 is None) or (self.compiler.fc is None):
-            raise InstallError(
-                'Mvapich2 requires both C and Fortran compilers!'
-            )
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -26,6 +26,7 @@
 import os
 
 from spack import *
+from spack.spec import no_fortran_compilers_available
 
 
 def _verbs_dir():
@@ -240,6 +241,9 @@ class Openmpi(AutotoolsPackage):
     conflicts('schedulers=slurm ~pmi', when='@1.5.4:',
               msg='+pmi is required for openmpi(>=1.5.5) to work with SLURM.')
 
+    conflicts('openmpi', when=no_fortran_compilers_available,
+              msg='OpenMPI requires both C and Fortran compilers!')
+
     filter_compiler_wrappers('openmpi/*-wrapper-data*', relative_root='share')
 
     def url_for_version(self, version):
@@ -313,16 +317,6 @@ class Openmpi(AutotoolsPackage):
         if (path is not None):
             line += '={0}'.format(path)
         return line
-
-    @run_before('autoreconf')
-    def die_without_fortran(self):
-        # Until we can pass variants such as +fortran through virtual
-        # dependencies depends_on('mpi'), require Fortran compiler to
-        # avoid delayed build errors in dependents.
-        if (self.compiler.f77 is None) or (self.compiler.fc is None):
-            raise InstallError(
-                'OpenMPI requires both C and Fortran compilers!'
-            )
 
     def configure_args(self):
         spec = self.spec


### PR DESCRIPTION
`conflicts` directives have been modified to accept a predicate. This should largely extend the range of 
 checks that can be used to issue a conflict.

All the MPI packages have been modified to use this new feature, and raise a conflict after concretization if Fortran compilers are not found.

Examples of use:
```console
$ spack spec mvapich2
Input spec
--------------------------------
mvapich2

Concretized
--------------------------------
==> Error: Conflicts in concretized spec "mvapich2@2.2%gcc@4.8 ch3_rank_bits=32 ~cuda~debug fabrics=psm process_managers= threads=multiple arch=linux-ubuntu14.04-x86_64 /uwp6cqd"

List of matching conflicts for spec:

    mvapich2@2.2%gcc@4.8 ch3_rank_bits=32 ~cuda~debug fabrics=psm process_managers= threads=multiple arch=linux-ubuntu14.04-x86_64 
        ^bison@3.0.4%gcc@4.8 patches=b72914fe38e54a6fc25f29019e0a0786705c4f61ce20d414cc2010c8d62448c7 arch=linux-ubuntu14.04-x86_64 
            ^m4@1.4.18%gcc@4.8 patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00 +sigsegv arch=linux-ubuntu14.04-x86_64 
                ^libsigsegv@2.11%gcc@4.8 arch=linux-ubuntu14.04-x86_64 
        ^libpciaccess@0.13.5%gcc@4.8 arch=linux-ubuntu14.04-x86_64 
            ^libtool@2.4.6%gcc@4.8 arch=linux-ubuntu14.04-x86_64 
            ^pkgconf@1.4.0%gcc@4.8 arch=linux-ubuntu14.04-x86_64 
            ^util-macros@1.19.1%gcc@4.8 arch=linux-ubuntu14.04-x86_64 

1. "mvapich2" conflicts with "no_fortran_compilers_available" [Mvapich2 requires both C and Fortran compilers!]
```