### PR TITLE
Always relocate buildcaches unless they were created with relative paths.

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -415,7 +415,7 @@ def relocate_package(workdir, allow_root):
     new_path = spack.store.layout.root
     old_path = buildinfo['buildpath']
     rel = buildinfo.get('relative_rpaths', False)
-    if new_path == old_path and not rel:
+    if rel:
         return
 
     tty.msg("Relocating package from",


### PR DESCRIPTION
Since placeholders are always used when creating new buildcaches, the placeholder must be replaced even if old and new install path are the same.