### PR TITLE
spades: fix build

### DIFF
--- a/var/spack/repos/builtin/packages/spades/package.py
+++ b/var/spack/repos/builtin/packages/spades/package.py
@@ -39,6 +39,6 @@ class Spades(CMakePackage):
     depends_on('zlib')
     depends_on('bzip2')
 
-    conflicts('%gcc@7.1.0:')
+    conflicts('%gcc@7.1.0:', when='@:3.10.1')
 
     root_cmakelists_dir = 'src'


### PR DESCRIPTION
Version 3.11 works with gcc7
see: https://github.com/ablab/spades/issues/26