### PR TITLE
Fix build of xerces-c

### DIFF
--- a/var/spack/repos/builtin/packages/xerces-c/package.py
+++ b/var/spack/repos/builtin/packages/xerces-c/package.py
@@ -37,5 +37,10 @@ class XercesC(AutotoolsPackage):
 
     version('3.1.4', 'd04ae9d8b2dee2157c6db95fa908abfd')
 
+    depends_on('libiconv')
+
+    def setup_environment(self, spack_env, run_env):
+        spack_env.append_flags('LDFLAGS', self.spec['libiconv'].libs.ld_flags)
+
     def configure_args(self):
         return ['--disable-network']


### PR DESCRIPTION
The build requires libiconv (but still it doesn't find it when not providing LDFLAGS).

Regarding the LDFLAGS: A patch to the configure flow would be the better solution…