### PR TITLE
Fix download URL for SCons and add latest version

### DIFF
--- a/var/spack/repos/builtin/packages/scons/package.py
+++ b/var/spack/repos/builtin/packages/scons/package.py
@@ -29,10 +29,14 @@ class Scons(PythonPackage):
     """SCons is a software construction tool"""
 
     homepage = "http://scons.org"
-    url      = "https://pypi.io/packages/source/s/scons/scons-2.5.1.tar.gz"
+    url      = "https://pypi.io/packages/source/s/scons/scons-3.0.1.tar.gz"
 
-    version('2.5.1', '3eac81e5e8206304a9b4683c57665aa4')
-    version('2.5.0', 'bda5530a70a41a7831d83c8b191c021e')
+    version('3.0.1', 'b6a292e251b34b82c203b56cfa3968b3',
+            url="https://pypi.python.org/packages/c1/0a/520a3c86ce5cff36e81af5e91d4dcd741ebc189c2f0f42d54cc12a8a7519/scons-3.0.1.tar.gz")
+    version('2.5.1', '3eac81e5e8206304a9b4683c57665aa4',
+            url="https://pypi.python.org/packages/2c/ee/a9601b958c94e93410e635a5d67ed95300998ffdc36127b16d322b054ff0/scons-2.5.1.tar.gz")
+    version('2.5.0', 'bda5530a70a41a7831d83c8b191c021e',
+            url="https://pypi.python.org/packages/17/f0/60464796a3fd16899a2cf54e22615c38bbe8124386cf3763c17ff367c2af/scons-2.5.0.tar.gz")
 
-    # Python 3 is not supported
-    depends_on('python@:2.8', type=('build', 'run'))
+    # Python 3 support was added in SCons 3.0.0
+    depends_on('python@:2', when='@:2', type=('build', 'run'))


### PR DESCRIPTION
Fixes #7613. @ch741

@alalazo @lee218llnl @tgamblin we might have a problem on our hands. The once venerable https://pypi.io links are no longer working for the SCons package. There is currently no evidence that this affects any other Python package, but we might need to consider alternative download methods in the future. This may require #2718. If done correctly, a `PyPIFetchStrategy` could also allow us to hook into `spack versions` and provide a list of available versions.

Also added the latest version of SCons. It looks like they finally support Python 3. Successfully installed with Python 3.6.4 and Clang 9.0.0 on macOS 10.13.3.