### PR TITLE
add dso_suffix to __all__ for lmod generation

### DIFF
--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -229,6 +229,9 @@ __all__ += ['all_deptypes']
 from spack.multimethod import when
 __all__ += ['when']
 
+from spack.build_environment import dso_suffix
+__all__ += ['dso_suffix']
+
 import llnl.util.filesystem
 from llnl.util.filesystem import *
 __all__ += llnl.util.filesystem.__all__


### PR DESCRIPTION
Fixes  #5864.

@alalazo this makes `dso_suffix` available for all packages.  I can add it to just the OpenCV package instead if being more conservative (seeing the TODO's surrounding `__all__`).  I just don't understand why it's available in other packages and not OpenCV.  The packages that use `dso_suffix` (as far as `grep` is concerned):

- alglib
- cp2k
- elemental
- flex
- intel-mkl
- intel-parallel-studio
- libdwarf
- mpich
- mvapich2
- opencv
- openmpi
- openscenegraph
- py-rtree
- scotch
- zoltan

I looked at a couple and none of them seem to need to import `dso_suffix` directly...