### PR TITLE
Add recent bohrium version

### DIFF
--- a/var/spack/repos/builtin/packages/bohrium/package.py
+++ b/var/spack/repos/builtin/packages/bohrium/package.py
@@ -41,6 +41,7 @@ class Bohrium(CMakePackage, CudaPackage):
     #
     version("develop", git="https://github.com/bh107/bohrium.git",
             branch="master")
+    version('0.9.0', checksum="6f6379f1555de5a6a19138beac891a470df7df1fc9594e2b9404cf01b6e17d93")
 
     #
     # Variants
@@ -54,7 +55,7 @@ class Bohrium(CMakePackage, CudaPackage):
 
     variant('node', default=True,
             description="Build the node vector engine manager")
-    variant('proxy', default=True,
+    variant('proxy', default=False,
             description="Build the proxy vector engine manager")
     variant('python', default=True,
             description="Build the numpy-like bridge "


### PR DESCRIPTION
- Add most recent Bohrium version.
- Change proxy parameter default to `False` to resemble the defaults used upstream.