### PR TITLE
Fix Python3 bug in tut

### DIFF
--- a/var/spack/repos/builtin/packages/tut/package.py
+++ b/var/spack/repos/builtin/packages/tut/package.py
@@ -29,9 +29,9 @@ class Tut(WafPackage):
     """TUT is a small and portable unit test framework for C++."""
 
     homepage = "http://mrzechonek.github.io/tut-framework/"
-    url      = "https://github.com/mrzechonek/tut-framework/archive/2016-12-19.tar.gz"
+    url      = "https://github.com/mrzechonek/tut-framework/tarball/2016-12-19"
 
-    version('2016-12-19', 'a6e58626e25dd3f38e36959b7f46d5b8')
+    version('2016-12-19', '8b1967fa295ae1ce4d4431c2f811e521')
 
     patch('python3-octal.patch', when='@2016-12-19')
 

--- a/var/spack/repos/builtin/packages/tut/package.py
+++ b/var/spack/repos/builtin/packages/tut/package.py
@@ -29,9 +29,11 @@ class Tut(WafPackage):
     """TUT is a small and portable unit test framework for C++."""
 
     homepage = "http://mrzechonek.github.io/tut-framework/"
-    url      = "https://github.com/mrzechonek/tut-framework/tarball/2016-12-19"
+    url      = "https://github.com/mrzechonek/tut-framework/archive/2016-12-19.tar.gz"
 
-    version('2016-12-19', '8b1967fa295ae1ce4d4431c2f811e521')
+    version('2016-12-19', 'a6e58626e25dd3f38e36959b7f46d5b8')
+
+    patch('python3-octal.patch', when='@2016-12-19')
 
     def build_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/tut/python3-octal.patch
+++ b/var/spack/repos/builtin/packages/tut/python3-octal.patch
@@ -1,0 +1,11 @@
+--- a/waftools/gcov.py	2016-12-19 04:55:44.000000000 -0600
++++ b/waftools/gcov.py	2018-03-28 10:42:53.000000000 -0500
+@@ -13,7 +13,7 @@
+     wrapper = NamedTemporaryFile(delete=False)
+     wrapper.write(script)
+     wrapper.close()
+-    os.chmod(wrapper.name, 0777)
++    os.chmod(wrapper.name, 0o777)
+ 
+     yield wrapper.name
+ 


### PR DESCRIPTION
When building `tut` with Python 3, I see the following error message:
```
  File "waftools/gcov.py", line 16
    os.chmod(wrapper.name, 0777)
                              ^
SyntaxError: invalid token
```
In Python 2, integers that start with a leading 0 are interpreted as octals. In Python 3, this is not the case, and the number must start with 0o or else it will be a SyntaxError. This patch allows me to build `tut` with Python 3. I also confirmed that it still works for Python 2. All build tests pass.

I submitted this patch upstream as well: https://github.com/mrzechonek/tut-framework/pull/15