### PR TITLE
Add cray-libsci package

### DIFF
--- a/var/spack/repos/builtin/packages/cray-libsci/package.py
+++ b/var/spack/repos/builtin/packages/cray-libsci/package.py
@@ -26,7 +26,10 @@ from spack import *
 from spack.concretize import NoBuildError
 from spack.util.module_cmd import load_module
 
+<<<<<<< HEAD
 
+=======
+>>>>>>> Add cray-libsci package
 class CrayLibsci(Package):
     """The Cray Scientific Libraries package, LibSci, is a collection of
     numerical routines optimized for best performance on Cray systems."""
@@ -69,6 +72,7 @@ class CrayLibsci(Package):
 
         return find_libraries(lib, root=self.prefix.lib, shared=shared,
                               recursive=True)
+                recursive=True)
 
     @property
     def lapack_libs(self):

--- a/var/spack/repos/builtin/packages/cray-libsci/package.py
+++ b/var/spack/repos/builtin/packages/cray-libsci/package.py
@@ -1,0 +1,85 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+from spack.concretize import NoBuildError
+from spack.util.module_cmd import load_module
+
+class CrayLibsci(Package):
+    """The Cray Scientific Libraries package, LibSci, is a collection of
+    numerical routines optimized for best performance on Cray systems."""
+
+    homepage = "http://www.nersc.gov/users/software/programming-libraries/math-libraries/libsci"
+    url      = "http://www.nersc.gov/users/software/programming-libraries/math-libraries/libsci"
+
+    variant("shared", default=True, description="enable shared libs")
+    variant("openmp", default=False, description="link with openmp")
+    variant("mpi", default=False, description="link with mpi libs")
+
+    version('1.2.3', '0123456789abcdef0123456789abcdef')
+
+    provides("blas")
+    provides("lapack")
+    provides("scalapack")
+
+    @property
+    def blas_libs(self):
+
+        shared = True if "+shared" in self.spec else False
+        compiler = self.spec.compiler.name
+
+        # libs use intel in their name but for others need to convert
+        if compiler == "gcc":
+            compiler = "gnu"
+        elif compiler == "cce":
+            compiler = "cray"
+
+        if "+openmp" in self.spec and "+mpi" in self.spec:
+            lib = "libsci_{0}_mpi_mp"
+        elif "+openmp" in self.spec:
+            lib = "libsci_{0}_mp"
+        elif "+mpi" in self.spec:
+            lib = "libsci_{0}_mpi"
+        else:
+            lib = "libsci_{0}"
+
+        lib = lib.format(compiler)
+
+        return find_libraries(lib, root=self.prefix.lib, shared=shared,
+                recursive=True)
+
+    @property
+    def lapack_libs(self):
+        return self.blas_libs
+
+    @property
+    def scalapack_libs(self):
+        return self.blas_libs
+
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        """ Load the module into the environment for dependents """
+        load_module('cray-libsci')
+
+    def install(self, spec, prefix):
+        raise NoBuildError(spec)

--- a/var/spack/repos/builtin/packages/cray-libsci/package.py
+++ b/var/spack/repos/builtin/packages/cray-libsci/package.py
@@ -26,10 +26,6 @@ from spack import *
 from spack.concretize import NoBuildError
 from spack.util.module_cmd import load_module
 
-<<<<<<< HEAD
-
-=======
->>>>>>> Add cray-libsci package
 class CrayLibsci(Package):
     """The Cray Scientific Libraries package, LibSci, is a collection of
     numerical routines optimized for best performance on Cray systems."""
@@ -72,7 +68,6 @@ class CrayLibsci(Package):
 
         return find_libraries(lib, root=self.prefix.lib, shared=shared,
                               recursive=True)
-                recursive=True)
 
     @property
     def lapack_libs(self):

--- a/var/spack/repos/builtin/packages/cray-libsci/package.py
+++ b/var/spack/repos/builtin/packages/cray-libsci/package.py
@@ -42,12 +42,13 @@ class CrayLibsci(Package):
     provides("blas")
     provides("lapack")
     provides("scalapack")
-    
+
     def _find_gnu_lib_version(self, compiler_ver):
-        """Cray-libsci names its gnu libs in the following form: gnu_XX. Depending on the
-        version of the compiler the suffix will change. Note that the suffix does not directly match
-        the compiler version, so instead we parse the module file and parse out the available versions and
-        try to make a match with the first number."""
+        """Cray-libsci names its gnu libs in the following form: gnu_XX.
+        Depending on the version of the compiler the suffix will change. Note
+        that the suffix does not directly match the compiler version, so
+        instead we parse the module file and parse out the available versions
+        and try to make a match with the first number."""
         ver = str(compiler_ver)
         mod = "cray-libsci/{0}".format(self.version)
         libsci_module = module("show", mod).split()
@@ -64,7 +65,8 @@ class CrayLibsci(Package):
         compiler = self.spec.compiler.name
 
         # libs use intel in their name but for others need to convert
-        canonical_names = {'gcc': "gnu_{0}".format(self._find_gnu_lib_version(self.compiler.version[0])),
+        gnu_lib_ver = self._find_gnu_lib_version(self.compiler.version[0])
+        canonical_names = {'gcc': "gnu_{0}".format(gnu_lib_ver),
                            'cce': 'cray'}
 
         compiler = canonical_names[compiler]

--- a/var/spack/repos/builtin/packages/cray-libsci/package.py
+++ b/var/spack/repos/builtin/packages/cray-libsci/package.py
@@ -26,6 +26,7 @@ from spack import *
 from spack.concretize import NoBuildError
 from spack.util.module_cmd import load_module
 
+
 class CrayLibsci(Package):
     """The Cray Scientific Libraries package, LibSci, is a collection of
     numerical routines optimized for best performance on Cray systems."""
@@ -67,7 +68,7 @@ class CrayLibsci(Package):
         lib = lib.format(compiler)
 
         return find_libraries(lib, root=self.prefix.lib, shared=shared,
-                recursive=True)
+                              recursive=True)
 
     @property
     def lapack_libs(self):


### PR DESCRIPTION
Cray-libsci is a "dummy" package. It throws an error if the user attempts to install it since
this package will most likely be externally provided.

~~Note: This doesn't work at the moment because of an issue with get_path_from_module where it finds the first appearance of the string lib. This truncates the path to /opt/cray/pe whereas the actual path is /opt/cray/pe/libsci/<VERSION>/...~~