### PR TITLE
don't build mpileaks with clang in unit tests

### DIFF
--- a/share/spack/qa/run-unit-tests
+++ b/share/spack/qa/run-unit-tests
@@ -25,7 +25,7 @@ ${coverage_run} bin/spack -h
 ${coverage_run} bin/spack help -a
 
 # Profile and print top 20 lines for a simple call to spack spec
-${coverage_run} bin/spack -p --lines 20 spec mpileaks
+${coverage_run} bin/spack -p --lines 20 spec mpileaks%gcc
 
 # Run unit tests with code coverage
 ${coverage_run} bin/spack test "$@"


### PR DESCRIPTION
This updates qa script to build mpileaks with gcc (so it doesnt try with clang)

For some reason the nightly mac testing has started concretizing `spec mpileaks` with clang, which fails for `elfutils`. See: https://travis-ci.org/spack/spack/jobs/359536956. This updates the qa script to do `spec mpileaks%gcc`.