### PR TITLE
Add latest versions of libxcb and xcb-proto

### DIFF
--- a/var/spack/repos/builtin/packages/libxcb/package.py
+++ b/var/spack/repos/builtin/packages/libxcb/package.py
@@ -32,19 +32,29 @@ class Libxcb(AutotoolsPackage):
     extensibility."""
 
     homepage = "https://xcb.freedesktop.org/"
-    url      = "https://xcb.freedesktop.org/dist/libxcb-1.11.tar.gz"
+    url      = "https://xcb.freedesktop.org/dist/libxcb-1.13.tar.gz"
 
-    version('1.12', '95eee7c28798e16ba5443f188b27a476')
-    version('1.11', '1698dd837d7e6e94d029dbe8b3a82deb')
+    version('1.13',   '3ba7fe0a7d60650bfb73fbf623aa57cc')
+    version('1.12',   '95eee7c28798e16ba5443f188b27a476')
     version('1.11.1', '118623c15a96b08622603a71d8789bf3')
+    version('1.11',   '1698dd837d7e6e94d029dbe8b3a82deb')
 
     depends_on('libpthread-stubs')
     depends_on('libxau@0.99.2:')
     depends_on('libxdmcp')
 
+    # libxcb 1.X requires xcb-proto >= 1.X
     depends_on('xcb-proto', type='build')
+    depends_on('xcb-proto@1.13:', when='@1.13:1.13.999', type='build')
+    depends_on('xcb-proto@1.12:', when='@1.12:1.12.999', type='build')
+    depends_on('xcb-proto@1.11:', when='@1.11:1.11.999', type='build')
+
     # TODO: uncomment once build deps can be resolved separately
-    # depends_on('python@2:2.8', type='build')
+    # See #7646, #4145, #4063, and #2548 for details
+    # libxcb 1.13 added Python 3 support
+    # depends_on('python', type='build')
+    # depends_on('python@2:2.8', when='@:1.12', type='build')
+
     depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 

--- a/var/spack/repos/builtin/packages/xcb-proto/package.py
+++ b/var/spack/repos/builtin/packages/xcb-proto/package.py
@@ -30,12 +30,14 @@ class XcbProto(AutotoolsPackage):
     generate the majority of its code and API."""
 
     homepage = "http://xcb.freedesktop.org/"
-    url      = "http://xcb.freedesktop.org/dist/xcb-proto-1.11.tar.gz"
+    url      = "http://xcb.freedesktop.org/dist/xcb-proto-1.13.tar.gz"
 
+    version('1.13', '0cc0294eb97e4af3a743e470e6a9d910')
     version('1.12', '5ee1ec124ea8d56bd9e83b8e9e0b84c4')
     version('1.11', 'c8c6cb72c84f58270f4db1f39607f66a')
 
     # TODO: uncomment once build deps can be resolved separately
+    # See #7646, #4145, #4063, and #2548 for details
     # extends('python')
 
     patch('xcb-proto-1.12-schema-1.patch', when='@1.12')


### PR DESCRIPTION
Closes #7646. @thilinarmtb can you test this and see if it works for you?

This PR adds the latest version of `libxcb`, which finally has Python 3 support. I didn't uncomment the Python dependencies because I'm still running into concretization problems when I do, not sure why. We can uncomment them once #2548 is merged.

Also added more specific `xcb-proto` version requirements.

All builds passed their unit tests with Python 3.6.4 and Clang 9.0.0 on macOS 10.13.3.