### PR TITLE
Avoid double 'lib' for packages whose name already starts with lib

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -201,9 +201,9 @@ def change_sed_delimiter(old_delim, new_delim, *filenames):
 
 def set_install_permissions(path):
     """Set appropriate permissions on the installed file."""
-# If this points to a file maintained in a Spack prefix, it is assumed that
-# this function will be invoked on the target. If the file is outside a
-# Spack-maintained prefix, the permissions should not be modified.
+    # If this points to a file maintained in a Spack prefix, it is assumed that
+    # this function will be invoked on the target. If the file is outside a
+    # Spack-maintained prefix, the permissions should not be modified.
     if os.path.islink(path):
         return
     if os.path.isdir(path):

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1201,22 +1201,32 @@ class PackageBase(with_metaclass(PackageMeta, object)):
         """Make a fake install directory containing fake executables,
         headers, and libraries."""
 
-        name = self.name
-        library_name = 'lib' + self.name
+        command = self.name
+        header = self.name
+        library = self.name
+
+        # Avoid double 'lib' for packages whose name already starts with lib
+        if not self.name.startswith('lib'):
+            library = 'lib' + library
+
         dso_suffix = '.dylib' if sys.platform == 'darwin' else '.so'
         chmod = which('chmod')
 
+        # Install fake command
         mkdirp(self.prefix.bin)
-        touch(join_path(self.prefix.bin, name))
-        chmod('+x', join_path(self.prefix.bin, name))
+        touch(join_path(self.prefix.bin, command))
+        chmod('+x', join_path(self.prefix.bin, command))
 
+        # Install fake header file
         mkdirp(self.prefix.include)
-        touch(join_path(self.prefix.include, name + '.h'))
+        touch(join_path(self.prefix.include, header + '.h'))
 
+        # Install fake shared and static libraries
         mkdirp(self.prefix.lib)
-        touch(join_path(self.prefix.lib, library_name + dso_suffix))
-        touch(join_path(self.prefix.lib, library_name + '.a'))
+        for suffix in [dso_suffix, '.a']:
+            touch(join_path(self.prefix.lib, library + suffix))
 
+        # Install fake man page
         mkdirp(self.prefix.man.man1)
 
         packages_dir = spack.store.layout.build_packages_path(self.spec)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1205,7 +1205,7 @@ class PackageBase(with_metaclass(PackageMeta, object)):
         header = self.name
         library = self.name
 
-        # Avoid double 'lib' for packages whose name already starts with lib
+        # Avoid double 'lib' for packages whose names already start with lib
         if not self.name.startswith('lib'):
             library = 'lib' + library
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -702,7 +702,8 @@ def _libs_default_handler(descriptor, spec, cls):
     """Default handler when looking for the 'libs' attribute.
 
     Tries to search for ``lib{spec.name}`` recursively starting from
-    ``spec.prefix``.
+    ``spec.prefix``. If ``spec.name`` starts with ``lib``, searches for
+    ``{spec.name}`` instead.
 
     Parameters:
         descriptor (ForwardQueryToPackage): descriptor that triggered the call
@@ -727,7 +728,11 @@ def _libs_default_handler(descriptor, spec, cls):
     # depending on which one exists (there is a possibility, of course, to
     # get something like 'libabcXabc.so, but for now we consider this
     # unlikely).
-    name = 'lib' + spec.name.replace('-', '?')
+    name = spec.name.replace('-', '?')
+
+    # Avoid double 'lib' for packages whose name already starts with lib
+    if not name.startswith('lib'):
+        name = 'lib' + name
 
     # To speedup the search for external packages configured e.g. in /usr,
     # perform first non-recursive search in prefix.lib then in prefix.lib64 and

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -730,7 +730,7 @@ def _libs_default_handler(descriptor, spec, cls):
     # unlikely).
     name = spec.name.replace('-', '?')
 
-    # Avoid double 'lib' for packages whose name already starts with lib
+    # Avoid double 'lib' for packages whose names already start with lib
     if not name.startswith('lib'):
         name = 'lib' + name
 

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -154,6 +154,8 @@ def _mock_remove(spec):
 
 
 def test_default_queries(database):
+    # Testing a package whose name *doesn't* start with 'lib'
+    # to ensure the library has 'lib' prepended to the name
     install_db = database.mock.db
     rec = install_db.get_record('zmpi')
 
@@ -172,6 +174,8 @@ def test_default_queries(database):
     assert command.name == 'zmpi'
     assert os.path.exists(command.path)
 
+    # Testing a package whose name *does* start with 'lib'
+    # to ensure the library doesn't have a double 'lib' prefix
     install_db = database.mock.db
     rec = install_db.get_record('libelf')
 

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -161,13 +161,33 @@ def test_default_queries(database):
 
     libraries = spec['zmpi'].libs
     assert len(libraries) == 1
+    assert libraries.names[0] == 'zmpi'
 
     headers = spec['zmpi'].headers
     assert len(headers) == 1
+    assert headers.names[0] == 'zmpi'
 
     command = spec['zmpi'].command
     assert isinstance(command, Executable)
     assert command.name == 'zmpi'
+    assert os.path.exists(command.path)
+
+    install_db = database.mock.db
+    rec = install_db.get_record('libelf')
+
+    spec = rec.spec
+
+    libraries = spec['libelf'].libs
+    assert len(libraries) == 1
+    assert libraries.names[0] == 'elf'
+
+    headers = spec['libelf'].headers
+    assert len(headers) == 1
+    assert headers.names[0] == 'libelf'
+
+    command = spec['libelf'].command
+    assert isinstance(command, Executable)
+    assert command.name == 'libelf'
     assert os.path.exists(command.path)
 
 


### PR DESCRIPTION
This bug was first reported by @muffgaga in https://github.com/spack/spack/pull/7611#discussion_r177663583. This PR implements his suggested fix.

The problem is that the default libs handler always added `lib` to the start of the package name, even when the package name already started with `lib`. This would result in `spec['libiconv'].libs` searching for `liblibiconv.so`. The solution is to only add `lib` when the package name doesn't start with `lib`.