### PR TITLE
Fix bug in test_find_with_globbing unit test

### DIFF
--- a/lib/spack/spack/test/llnl/util/file_list.py
+++ b/lib/spack/spack/test/llnl/util/file_list.py
@@ -295,4 +295,4 @@ def test_searching_order(search_fn, search_list, root, kwargs):
 ])
 def test_find_with_globbing(root, search_list, kwargs, expected):
     matches = find(root, search_list, **kwargs)
-    assert matches == expected
+    assert sorted(matches) == sorted(expected)


### PR DESCRIPTION
Okay, I have no idea why I'm the only one who seems to have encountered this bug, but I can reliably reproduce it with Python 3.6.4 on macOS 10.13.3 and with Python 2.7.13 on CentOS 6.9.

I decided to run the full test suite today for the first time in a long time and discovered that the `test_find_with_globbing` unit test doesn't pass for me. After closer inspection, my `matches` and `expected` look like:
```
Matches:  ['/Users/Adam/spack/lib/spack/spack/test/data/directory_search/a/foobar.txt', '/Users/Adam/spack/lib/spack/spack/test/data/directory_search/c/bar.txt', '/Users/Adam/spack/lib/spack/spack/test/data/directory_search/b/bar.txp']
Expected: ['/Users/Adam/spack/lib/spack/spack/test/data/directory_search/a/foobar.txt', '/Users/Adam/spack/lib/spack/spack/test/data/directory_search/b/bar.txp', '/Users/Adam/spack/lib/spack/spack/test/data/directory_search/c/bar.txt']
```
The entries are correct, they are just in different orders. The code for `find` uses a dictionary to store matches, which results in a non-deterministic ordering. Interestingly, the code for `find` contains the following comments:
```python
# The variable here is **on purpose** a defaultdict. The idea is that       
# we want to poke the filesystem as little as possible, but still maintain  
# stability in the order of the answer. Thus we are recording each library  
# found in a key, and reconstructing the stable order later.                
found_files = collections.defaultdict(list)
```
and:
```python
# The variable here is **on purpose** a defaultdict as os.list_dir          
# can return files in any order (does not preserve stability)               
found_files = collections.defaultdict(list)
```
Based on the comment, perhaps the author was mixing up `defaultdict` and `OrderedDict`? This PR gets the unit tests to pass.

P.S. There's a Software Engineering Professor here at UIUC by the name of Darko Marinov. He has a really neat tool called [NonDex](https://github.com/TestingResearchIllinois/NonDex). It's basically a fork of Java where the ordering from hash maps is not only unspecified but actually random. This catches bugs that occur in newer versions of Java where the ordering has changed. According to [his paper](http://mir.cs.illinois.edu/marinov/publications/Gyori17PhD.pdf), a prototype exists for Python as well. It would be interesting to run Spack's unit tests with this to see where things break.