### PR TITLE
Current versions of kokkos conflict with hwloc 2.x

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -37,8 +37,8 @@ class Kokkos(Package):
     variant('qthreads', default=False, description="enable Qthreads backend")
     variant('cuda', default=False, description="enable Cuda backend")
 
-    #Specify that v1.11.9 is required as v2.x has API changes
-    depends_on('hwloc@1.11.9')
+    #Specify that v1.x is required as v2.x has API changes
+    depends_on('hwloc@1:')
     depends_on('qthreads', when='+qthreads')
     depends_on('cuda', when='+cuda')
 

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -38,7 +38,7 @@ class Kokkos(Package):
     variant('cuda', default=False, description="enable Cuda backend")
 
     # Specify that v1.x is required as v2.x has API changes
-    depends_on('hwloc@1:')
+    depends_on('hwloc@:1.11.9')
     depends_on('qthreads', when='+qthreads')
     depends_on('cuda', when='+cuda')
 

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -37,7 +37,7 @@ class Kokkos(Package):
     variant('qthreads', default=False, description="enable Qthreads backend")
     variant('cuda', default=False, description="enable Cuda backend")
 
-    depends_on('hwloc')
+    depends_on('hwloc@1.11.9')
     depends_on('qthreads', when='+qthreads')
     depends_on('cuda', when='+cuda')
 

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -38,7 +38,7 @@ class Kokkos(Package):
     variant('cuda', default=False, description="enable Cuda backend")
 
     # Specify that v1.x is required as v2.x has API changes
-    depends_on('hwloc@:1.11.9')
+    depends_on('hwloc@:1')
     depends_on('qthreads', when='+qthreads')
     depends_on('cuda', when='+cuda')
 

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -37,7 +37,7 @@ class Kokkos(Package):
     variant('qthreads', default=False, description="enable Qthreads backend")
     variant('cuda', default=False, description="enable Cuda backend")
 
-    #Specify that v1.x is required as v2.x has API changes
+    # Specify that v1.x is required as v2.x has API changes
     depends_on('hwloc@1:')
     depends_on('qthreads', when='+qthreads')
     depends_on('cuda', when='+cuda')

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -37,6 +37,7 @@ class Kokkos(Package):
     variant('qthreads', default=False, description="enable Qthreads backend")
     variant('cuda', default=False, description="enable Cuda backend")
 
+    #Specify that v1.11.9 is required as v2.x has API changes
     depends_on('hwloc@1.11.9')
     depends_on('qthreads', when='+qthreads')
     depends_on('cuda', when='+cuda')


### PR DESCRIPTION
Current versions of kokkos cannot build with hwloc v2.x due to changes in the associated structs. Requiring v1.11.9 for the time being until it becomes clear what the kokkos model for support will be.