### PR TITLE
Do not call sys.exit() in except block

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -38,6 +38,7 @@ import spack
 import spack.config
 import spack.spec
 import spack.store
+from spack.error import SpackError
 
 #
 # Settings for commands that modify configuration
@@ -141,18 +142,18 @@ def parse_specs(args, **kwargs):
 
         return specs
 
-    except spack.parse.ParseError as e:
-        tty.error(e.message, e.string, e.pos * " " + "^")
-        sys.exit(1)
+    except spack.spec.SpecParseError as e:
+        msg = e.message + "\n" + str(e.string) + "\n"
+        msg += (e.pos + 2) * " " + "^"
+        raise SpackError(msg)
 
     except spack.spec.SpecError as e:
 
-        msgs = [e.message]
+        msg = e.message
         if e.long_message:
-            msgs.append(e.long_message)
+            msg += e.long_message
 
-        tty.error(*msgs)
-        sys.exit(1)
+        raise SpackError(msg)
 
 
 def elide_list(line_list, max_num=10):

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -33,6 +33,7 @@ import llnl.util.filesystem as fs
 import spack
 import spack.cmd.install
 import spack.package
+from spack.error import SpackError
 from spack.spec import Spec
 from spack.main import SpackCommand, SpackCommandError
 
@@ -238,11 +239,9 @@ def test_install_overwrite(
     'builtin_mock', 'mock_archive', 'mock_fetch', 'config', 'install_mockery',
 )
 def test_install_conflicts(conflict_spec):
-    # Make sure that spec with conflicts exit with 1
-    with pytest.raises(SpackCommandError):
+    # Make sure that spec with conflicts raises a SpackError
+    with pytest.raises(SpackError):
         install(conflict_spec)
-
-    assert install.returncode == 1
 
 
 @pytest.mark.usefixtures('noop_install', 'config')


### PR DESCRIPTION
When an invalid spec is encountered by parse_specs() we now raise a SpackError instead of calling sys.exit()