### PR TITLE
Improve invalid syntax error message when loading packages

### DIFF
--- a/lib/spack/spack/repository.py
+++ b/lib/spack/spack/repository.py
@@ -994,8 +994,8 @@ class Repo(object):
                 # SyntaxError strips the path from the filename so we need to
                 # manually construct the error message in order to give the
                 # user the correct package.py where the syntax error is located
-                raise SyntaxError('invalid syntax in {0:}, line {1:}'
-                                  ''.format(file_path, e.lineno))
+                raise SyntaxError('{0:} in {1:}, line {2:}'
+                                  ''.format(str(e), file_path, e.lineno))
             module.__package__ = self.full_namespace
             module.__loader__ = self
             self._modules[pkg_name] = module


### PR DESCRIPTION
If a syntax error occurrs no further details are passed to the user.
This can be annoying in edge case errors like encoding issues.
The change will fix this issue by passing the actual error message.

# Example
Before:
```
Error: invalid syntax in /.../package.py, line 56
```

After:
```
Error: invalid syntax Non-ASCII character '\xe2' in file in /.../package.py, line 56
```