### PR TITLE
Fix GCC 6/7 build on APFS

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -102,13 +102,12 @@ class Gcc(AutotoolsPackage):
     # depends_on('ppl')
     # depends_on('cloog')
 
-    # TODO: Add a 'test' deptype
-    # https://github.com/spack/spack/issues/1279
-    # depends_on('dejagnu@1.4.4', type='test')
-    # depends_on('expect', type='test')
-    # depends_on('tcl', type='test')
-    # depends_on('autogen@5.5.4:', type='test')
-    # depends_on('guile@1.4.1:', type='test')
+    # https://gcc.gnu.org/install/test.html
+    depends_on('dejagnu@1.4.4', type='test')
+    depends_on('expect', type='test')
+    depends_on('tcl', type='test')
+    depends_on('autogen@5.5.4:', type='test')
+    depends_on('guile@1.4.1:', type='test')
 
     # See https://golang.org/doc/install/gccgo#Releases
     provides('golang',        when='languages=go @4.6:')
@@ -158,7 +157,7 @@ class Gcc(AutotoolsPackage):
         # Fix parallel build on APFS filesystem
         # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81797
         if macOS_version() >= Version('10.13'):
-            patch('darwin/apfs.patch', when='@7.2.0')
+            patch('darwin/apfs.patch', when='@6.1:6.4,7.1:7.3')
         patch('darwin/gcc-7.1.0-headerpad.patch', when='@5:')
         patch('darwin/gcc-6.1.0-jit.patch', when='@5:')
         patch('darwin/gcc-4.9.patch1', when='@4.9.0:4.9.3')


### PR DESCRIPTION
Fixes #7689.

@gozwei Can you test this? It should fix your `gcc%clang` problems. I'm not sure if it will fix your `gcc%gcc` problems, but `%gcc` never works great on macOS.

This PR extends the patch added in #5647 to other recent versions of GCC. This patch is also used by [Homebrew](https://github.com/Homebrew/homebrew-core/blob/master/Formula/gcc.rb#L57,L65). According to the [bug report](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81797), this patch is likely necessary for older versions of GCC as well, so we may need to expand this range in the future. It has been fixed upstream for GCC 6.5, 7.4, and 8.1.

Confirmed that the patch applies to GCC 6.1, 6.4, and 7.3. Confirmed that the installation succeeds for GCC 7.3 on macOS 10.13.3 with Clang 9.0.0. I didn't get around to testing other versions as it takes 2 hours and 15 minutes to install.

Also uncommented the test dependencies now that #5132 has been merged.