### PR TITLE
[Spec] Extend the default spec query handlers

### DIFF
--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -110,26 +110,12 @@ class Hypre(Package):
                         '-rhsone')
             make("install")
 
-    @property
-    def headers(self):
-        """Export the main hypre header, HYPRE.h; all other headers can be found
-        in the same directory.
-        Sample usage: spec['hypre'].headers.cpp_flags
-        """
-        hdrs = find_headers('HYPRE', self.prefix.include, recursive=False)
-        return hdrs or None
+    # The following attribute is used by the default 'headers' handler.
+    # Search and return only the main hypre header, HYPRE.h, since all other
+    # headers are in the same directory.
+    # Sample usage: spec['hypre'].headers.cpp_flags
+    headers_names = ['HYPRE.h']
 
-    @property
-    def libs(self):
-        """Export the hypre library.
-        Sample usage: spec['hypre'].libs.ld_flags
-        """
-        search_paths = [[self.prefix.lib, False], [self.prefix.lib64, False],
-                        [self.prefix, True]]
-        is_shared = '+shared' in self.spec
-        for path, recursive in search_paths:
-            libs = find_libraries('libHYPRE', root=path,
-                                  shared=is_shared, recursive=recursive)
-            if libs:
-                return libs
-        return None
+    # The following attribute is used by the default 'libs' handler.
+    # Sample usage: spec['hypre'].libs.ld_flags
+    libs_names = ['HYPRE']

--- a/var/spack/repos/builtin/packages/zlib/package.py
+++ b/var/spack/repos/builtin/packages/zlib/package.py
@@ -50,12 +50,11 @@ class Zlib(Package):
 
     patch('w_patch.patch', when="@1.2.11%cce")
 
-    @property
-    def libs(self):
-        shared = '+shared' in self.spec
-        return find_libraries(
-            ['libz'], root=self.prefix, recursive=True, shared=shared
-        )
+    # The following attribute is used by the default 'headers' handler.
+    headers_names = ['zlib.h']
+
+    # The following attribute is used by the default 'libs' handler.
+    libs_names = ['libz']
 
     def setup_environment(self, spack_env, run_env):
         if '+pic' in self.spec:


### PR DESCRIPTION
This PR extends the default spec query handlers, `_headers_default_handler` and `_libs_default_handler`, to support an easy way for packages to define what headers and libraries they provide - just the file names - that information is then used by the default handlers to search for the exact locations, verifying that those files actually exist.

The new functionality is described in the handlers' help strings and it is illustrated in the packages `zlib` and `hypre`.

This PR supersedes #7261.