### PR TITLE
go: Update to 1.10.1

### DIFF
--- a/var/spack/repos/builtin/packages/go-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/go-bootstrap/package.py
@@ -46,12 +46,14 @@ class GoBootstrap(Package):
     # See: https://golang.org/doc/install/source#go14 and
     # https://github.com/golang/go/issues/17545 and
     # https://github.com/golang/go/issues/16352
+    version('1.4-bootstrap-20171003', 'dbf727a4b0e365bf88d97cbfde590016',
+            url='https://dl.google.com/go/go1.4-bootstrap-20171003.tar.gz')
     version('1.4-bootstrap-20170531', 'd2cc61cb9f829b3510ee39c0c5568014',
             url='https://storage.googleapis.com/golang/go1.4-bootstrap-20170531.tar.gz')
     version('1.4-bootstrap-20161024', '76e42c8152e8560ded880a6d1d1f53cb',
             url='https://storage.googleapis.com/golang/go1.4-bootstrap-20161024.tar.gz')
 
-    provides('golang@:1.4-bootstrap-20170531')
+    provides('golang@:1.4-bootstrap-20171003')
 
     depends_on('git', type=('build', 'link', 'run'))
 

--- a/var/spack/repos/builtin/packages/go/package.py
+++ b/var/spack/repos/builtin/packages/go/package.py
@@ -52,19 +52,21 @@ from spack import *
 class Go(Package):
     """The golang compiler and build environment"""
     homepage = "https://golang.org"
-    url = 'https://storage.googleapis.com/golang/go1.7.4.src.tar.gz'
+    url = 'https://dl.google.com/go/go1.10.1.src.tar.gz'
 
     extendable = True
 
-    version('1.9.2', '44105c865a1a810464df79233a05a568')
-    version('1.9.1', '27bce1ffb05f4f6bd90d90081e5d4169')
-    version('1.9',   'da2d44ea384076efec43ee1f8b7d45d2')
-    version('1.8.3', '64e9380e07bba907e26a00cf5fcbe77e')
-    version('1.8.1', '409dd21e7347dd1ea9efe64a700073cc')
-    version('1.8',   '7743960c968760437b6e39093cfe6f67')
-    version('1.7.5', '506de2d870409e9003e1440bcfeb3a65')
-    version('1.7.4', '49c1076428a5d3b5ad7ac65233fcca2f')
-    version('1.6.4', 'b023240be707b34059d2c114d3465c92')
+    version('1.10.1', '589449ff6c3ccbff1d391d4e7ab5bb5d5643a5a41a04c99315e55c16bbf73ddc')
+    version('1.9.5',  'f1c2bb7f32bbd8fa7a19cc1608e0d06582df32ff5f0340967d83fb0017c49fbc')
+    version('1.9.2',  '44105c865a1a810464df79233a05a568')
+    version('1.9.1',  '27bce1ffb05f4f6bd90d90081e5d4169')
+    version('1.9',    'da2d44ea384076efec43ee1f8b7d45d2')
+    version('1.8.3',  '64e9380e07bba907e26a00cf5fcbe77e')
+    version('1.8.1',  '409dd21e7347dd1ea9efe64a700073cc')
+    version('1.8',    '7743960c968760437b6e39093cfe6f67')
+    version('1.7.5',  '506de2d870409e9003e1440bcfeb3a65')
+    version('1.7.4',  '49c1076428a5d3b5ad7ac65233fcca2f')
+    version('1.6.4',  'b023240be707b34059d2c114d3465c92')
 
     provides('golang')
 


### PR DESCRIPTION
Also update go-bootstrap to the 20171003 snapshot.