### PR TITLE
Package.provides accounts for v deps that are provided conditionally

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -949,7 +949,10 @@ class PackageBase(with_metaclass(PackageMeta, object)):
         """
         True if this package provides a virtual package with the specified name
         """
-        return any(s.name == vpkg_name for s in self.provided)
+        return any(
+            any(self.spec.satisfies(c) for c in constraints)
+            for s, constraints in self.provided.items() if s.name == vpkg_name
+        )
 
     @property
     def installed(self):

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -515,3 +515,12 @@ class TestConcretize(object):
         # Mimics asking the build interface from a build interface
         build_interface = s['mpileaks']['mpileaks']
         assert llnl.util.lang.ObjectWrapper in type(build_interface).__mro__
+
+    @pytest.mark.regression('7705')
+    def test_regression_issue_7705(self):
+        # spec.package.provides(name) doesn't account for conditional
+        # constraints in the concretized spec
+        s = Spec('simple-inheritance~openblas')
+        s.concretize()
+
+        assert not s.package.provides('lapack')


### PR DESCRIPTION
fixes #7705

`Package.provides` now checks constraints to ensure that a spec provides a given virtual package. Note that `strict=True` is not passed to satisfies as this function is also used during concretization.