### PR TITLE
Fixes conflicts in OSX nightly tests

### DIFF
--- a/share/spack/qa/run-unit-tests
+++ b/share/spack/qa/run-unit-tests
@@ -25,7 +25,7 @@ ${coverage_run} bin/spack -h
 ${coverage_run} bin/spack help -a
 
 # Profile and print top 20 lines for a simple call to spack spec
-${coverage_run} bin/spack -p --lines 20 spec mpileaks%gcc
+${coverage_run} bin/spack -p --lines 20 spec mpileaks%gcc ^elfutils@0.170
 
 # Run unit tests with code coverage
 ${coverage_run} bin/spack test "$@"


### PR DESCRIPTION
fixes #7593

Unit tests on OSX are trying to concretize `mpileaks`, and they fail due to a conflict in the package:
```console
"%gcc@7.2.0:" conflicts with "elfutils@0.163"
```
This solves the issue asking explicitly to concretize against `elfutils@1.170`