### PR TITLE
Add missing dependency to py-matplotlib

### DIFF
--- a/var/spack/repos/builtin/packages/py-kiwisolver/package.py
+++ b/var/spack/repos/builtin/packages/py-kiwisolver/package.py
@@ -1,0 +1,36 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyKiwisolver(PythonPackage):
+    """A fast implementation of the Cassowary constraint solver"""
+
+    homepage = "https://github.com/nucleic/kiwi"
+    url      = "https://pypi.io/packages/source/k/kiwisolver/kiwisolver-1.0.1.tar.gz"
+
+    version('1.0.1', 'e2a1718b837e2cd001f7c06934616fcd')
+
+    depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -76,6 +76,7 @@ class PyMatplotlib(PythonPackage):
     depends_on('py-cycler@0.9:', type=('build', 'run'))
     depends_on('py-subprocess32', type=('build', 'run'), when='^python@:2.7')
     depends_on('py-functools32', type=('build', 'run'), when='^python@2.7')
+    depends_on('py-kiwisolver', type=('build', 'run'), when='@2.2.0:')
 
     # ------ Optional GUI frameworks
     depends_on('tk@8.3:', when='+tk')  # not 8.6.0 or 8.6.1


### PR DESCRIPTION
kiwisolver is a required dependency as of [2.2.0](https://github.com/matplotlib/matplotlib/releases/tag/v2.2.0)

This only turns up when actually trying to import matplotlib... Build goes through without and their dependency management is abyssal... (read: I gave up trying to understand it)