### PR TITLE
libfabric: Version bumps and provider additions

### DIFF
--- a/var/spack/repos/builtin/packages/libfabric/package.py
+++ b/var/spack/repos/builtin/packages/libfabric/package.py
@@ -33,6 +33,7 @@ class Libfabric(AutotoolsPackage):
     url      = "https://github.com/ofiwg/libfabric/releases/download/v1.6.0/libfabric-1.6.0.tar.gz"
 
     version('1.6.0', '91d63ab3c0b9724a4db660019f928cab')
+    version('1.5.3', '1fe07e972fe487c6a3e44c0fb68b49a2')
     version('1.5.0', 'fda3e9b31ebe184f5157288d059672d6')
     version('1.4.2', '2009c8e0817060fb99606ddbf6c5ccf8')
 

--- a/var/spack/repos/builtin/packages/libfabric/package.py
+++ b/var/spack/repos/builtin/packages/libfabric/package.py
@@ -30,8 +30,9 @@ class Libfabric(AutotoolsPackage):
        fabric communication services to applications."""
 
     homepage = "https://libfabric.org/"
-    url      = "https://github.com/ofiwg/libfabric/releases/download/v1.5.0/libfabric-1.5.0.tar.gz"
+    url      = "https://github.com/ofiwg/libfabric/releases/download/v1.6.0/libfabric-1.6.0.tar.gz"
 
+    version('1.6.0', '91d63ab3c0b9724a4db660019f928cab')
     version('1.5.0', 'fda3e9b31ebe184f5157288d059672d6')
     version('1.4.2', '2009c8e0817060fb99606ddbf6c5ccf8')
 


### PR DESCRIPTION
Making the latest stable version of libfabric (v1.6) the default version, bumping up the bugfix version of the 1.5 series, and adding the TCP and SHM core providers.