### PR TITLE
Fix inconsistent parsing of specs from 'spack env'

### DIFF
--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -38,10 +38,16 @@ level = "long"
 
 
 def setup_parser(subparser):
+    subparser.epilog = "To run a command with the emulated environment" \
+                       " insert a '--' between the spec and the " \
+                       "command to be executed."
+
     arguments.add_common_arguments(subparser, ['clean', 'dirty'])
     subparser.add_argument(
-        'spec', nargs=argparse.REMAINDER,
-        help="specs of package environment to emulate")
+        'spec',
+        nargs=argparse.REMAINDER,
+        help='spec for which we want to emulate the environment.'
+    )
 
 
 def env(parser, args):
@@ -50,16 +56,12 @@ def env(parser, args):
 
     # Specs may have spaces in them, so if they do, require that the
     # caller put a '--' between the spec and the command to be
-    # executed.  If there is no '--', assume that the spec is the
-    # first argument.
-    sep = '--'
-    if sep in args.spec:
-        s = args.spec.index(sep)
-        spec = args.spec[:s]
-        cmd = args.spec[s + 1:]
-    else:
-        spec = args.spec[0]
-        cmd = args.spec[1:]
+    # executed.  If there is no '--', assume that there is no command
+    try:
+        s = args.spec.index('--')
+        spec, cmd = args.spec[:s], args.spec[s + 1:]
+    except ValueError:
+        spec, cmd = args.spec, None
 
     specs = spack.cmd.parse_specs(spec, concretize=True)
     if len(specs) > 1:

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -31,7 +31,8 @@ info = SpackCommand('env')
 
 @pytest.mark.parametrize('pkg', [
     ('zlib',),
-    ('zlib', '--')
+    ('zlib', ' %gcc'),
+    ('zlib', '--'),
 ])
 @pytest.mark.usefixtures('config')
 def test_it_just_runs(pkg):


### PR DESCRIPTION
fixes #659

Currently the `spack env` command fails if more than one token is given for the spec, like:
```console
$ spack env zlib %gcc
```
This is because the tokens after the first one are interpreted as a command to be executed in the environment.

This PR changes the behavior described above to make it more consistent with that of other commands. Now all of the tokens are interpreted as being part of the spec, and if we want to execute a command in the environment we need to separate it from the spec with '--'.