### PR TITLE
Fix when_spec inheritance for extensions

### DIFF
--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -381,7 +381,7 @@ def extends(spec, **kwargs):
         #     msg = 'Packages can extend at most one other package.'
         #     raise DirectiveError(directive, msg)
 
-        when = kwargs.pop('when', pkg.name)
+        when = kwargs.get('when', pkg.name)
         _depends_on(pkg, spec, when=when)
         pkg.extendees[spec] = (Spec(spec), kwargs)
     return _execute_extends


### PR DESCRIPTION
Popping the when spec from kwargs in the extends directive breaks
class inheritance. Inheriting classes do not find their when spec.

We now get the when spec from kwargs instead, leaving it to be found
by any downstream package classes.

As an example suppose two packages foo and bar

```
$ cat foo/package.py
...
class Foo(Package):
    ...
    variant('python', default=False, description="")
    extends('python', when='+python')
    ...

$ cat bar/package.py
...
class Bar(Foo):
    ...

$ spack spec foo
Input spec
--------------------------------
foo

Concretized
--------------------------------
foo@1.2.11%clang@6.1~python arch=darwin-sierra-x86_64 

$ spack spec bar
Input spec
--------------------------------
bar

Concretized
--------------------------------
bar@1.2.11%clang@6.1~python arch=darwin-sierra-x86_64 
    ^python@2.7.14%clang@6.1 patches=123082ab3483ded78e86d7c809e98a804b3465b4683c96bd79a2fd799f572244 +pic~shared~tk~ucs4 arch=darwin-sierra-x86_64 
        ^bzip2@1.0.6%clang@6.1~shared arch=darwin-sierra-x86_64 
        ^ncurses@6.0%clang@6.1 patches=f84b2708a42777aadcc7f502a261afe10ca5646a51c1ef8b5e60d2070d926b57 ~symlinks~termlib arch=darwin-sierra-x86_64 
            ^pkgconf@1.4.0%clang@6.1 arch=darwin-sierra-x86_64 
        ^openssl@1.0.2n%clang@6.1 arch=darwin-sierra-x86_64 
            ^zlib@1.2.11%clang@6.1+optimize+pic~shared arch=darwin-sierra-x86_64 
        ^readline@7.0%clang@6.1 arch=darwin-sierra-x86_64 
        ^sqlite@3.21.0%clang@6.1 patches=5bbcba091045e547eb550e6e9b9372009c41be0a9de8a5c030d03361c11ff939  arch=darwin-sierra-x86_64
```

Obviously this is a problem, as `bar~python` should not build python. Note this is NOT fixed by specifying `bar~python` from the command-line.

Under the new behavior:

```
$ spack spec bar
Input spec
--------------------------------
bar

Concretized
--------------------------------
bar@1.2.11%clang@6.1~python arch=darwin-sierra-x86_64
```

Thanks to @mclarsen for bringing this bug to my attention.