### PR TITLE
environment shell: fix `spack load`

### DIFF
--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -81,7 +81,7 @@ function spack {
     fi
 
     _sp_subcommand=$1; shift
-    _sp_spec="$@"
+    _sp_spec=("$@")
 
     # Filter out use and unuse.  For any other commands, just run the
     # command.
@@ -113,7 +113,7 @@ function spack {
                 shift
             done
 
-            _sp_spec="$@"
+            _sp_spec=("$@")
 
             # Here the user has run use or unuse with a spec.  Find a matching
             # spec using 'spack module find', then use the appropriate module
@@ -121,19 +121,19 @@ function spack {
             # If spack module command comes back with an error, do nothing.
             case $_sp_subcommand in
                 "use")
-                    if _sp_full_spec=$(command spack $_sp_flags module loads --input-only $_sp_subcommand_args --module-type dotkit $_sp_spec); then
+                    if _sp_full_spec=$(command spack $_sp_flags module loads --input-only $_sp_subcommand_args --module-type dotkit "${_sp_spec[@]}"); then
                         use $_sp_module_args $_sp_full_spec
                     fi ;;
                 "unuse")
-                    if _sp_full_spec=$(command spack $_sp_flags module loads --input-only $_sp_subcommand_args --module-type dotkit $_sp_spec); then
+                    if _sp_full_spec=$(command spack $_sp_flags module loads --input-only $_sp_subcommand_args --module-type dotkit "${_sp_spec[@]}"); then
                         unuse $_sp_module_args $_sp_full_spec
                     fi ;;
                 "load")
-                    if _sp_full_spec=$(command spack $_sp_flags module loads --input-only $_sp_subcommand_args --module-type tcl $_sp_spec); then
+                    if _sp_full_spec=$(command spack $_sp_flags module loads --input-only $_sp_subcommand_args --module-type tcl "${_sp_spec[@]}"); then
                         module load $_sp_module_args $_sp_full_spec
                     fi ;;
                 "unload")
-                    if _sp_full_spec=$(command spack $_sp_flags module loads --input-only $_sp_subcommand_args --module-type tcl $_sp_spec); then
+                    if _sp_full_spec=$(command spack $_sp_flags module loads --input-only $_sp_subcommand_args --module-type tcl "${_sp_spec[@]}"); then
                         module unload $_sp_module_args $_sp_full_spec
                     fi ;;
             esac


### PR DESCRIPTION
Fix `spack load` with extended packet specifications that include spaces.
Solved by using perfect parameter forwarding via temporary array.

To be consistent with the current used shell features in `setup-env.sh` this PR is **not** compatible with the `dash` shell (there are no arrays in `dash`). PR #4048 is adding `dash` compatibility. To be `dash` shell compatible the usage of the temporary array `_sp_spec` must be removed and `"${_sp_spec[@]}"` must be substituted with `"$@"`.

# example
```
$ spack install zlib
$ spack install zlib cppflags='-O3 -march=native'
$ spack install zlib cppflags='-O2 -march=native'

$ spack find -d -L -f zlib
==> 3 installed packages.
-- linux-linuxmint18-x86_64 / gcc@5.4.0 -------------------------
k5hg4kkxiutkfl6n53ogz5wnlbdrsdtf    zlib@1.2.11%gcc

mse2fyzdxciszdhiqi4b5kl6fxkps3fh    zlib@1.2.11%gcc cppflags="-O2 -march=native"

vrnvj2fikcbxqxrymctnlpmud7wbuahk    zlib@1.2.11%gcc cppflags="-O3 -march=native"

$ spack load zlib cppflags='-O3 -march=native'
==> Error: Unexpected token
['zlib', 'cppflags=-O3', '-march=native']
```