### PR TITLE
Better error message for spack providers

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -265,7 +265,8 @@ def display_specs(specs, args=None, **kwargs):
         header = "%s{%s} / %s{%s}" % (spack.spec.architecture_color,
                                       architecture, spack.spec.compiler_color,
                                       compiler)
-        tty.hline(colorize(header), char='-')
+        if architecture is not None or compiler is not None:
+            tty.hline(colorize(header), char='-')
 
         specs = index[(architecture, compiler)]
         specs.sort()

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -265,6 +265,9 @@ def display_specs(specs, args=None, **kwargs):
         header = "%s{%s} / %s{%s}" % (spack.spec.architecture_color,
                                       architecture, spack.spec.compiler_color,
                                       compiler)
+        # Sometimes we want to display specs that are not yet concretized.
+        # If they don't have a compiler / architecture attached to them,
+        # then skip the header
         if architecture is not None or compiler is not None:
             tty.hline(colorize(header), char='-')
 

--- a/lib/spack/spack/cmd/providers.py
+++ b/lib/spack/spack/cmd/providers.py
@@ -22,6 +22,8 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
+import sys
+
 import spack
 import spack.cmd
 
@@ -42,7 +44,8 @@ def setup_parser(subparser):
 
 def providers(parser, args):
     valid_virtuals = sorted(spack.repo.provider_index.providers.keys())
-    valid_virtuals_str = 'Virtual packages:\n\t' + ', '.join(valid_virtuals)
+    valid_virtuals_str = 'Virtual packages:\n\t' if sys.stdout.isatty() else ''
+    valid_virtuals_str += ', '.join(valid_virtuals)
 
     # If called without arguments, list all the virtual packages
     if not args.virtual_package:
@@ -64,6 +67,7 @@ def providers(parser, args):
 
     # Display providers
     for spec in specs:
-        print("{0}:".format(spec))
+        if sys.stdout.isatty():
+            print("{0}:".format(spec))
         spack.cmd.display_specs(sorted(spack.repo.providers_for(spec)))
         print('')

--- a/lib/spack/spack/cmd/providers.py
+++ b/lib/spack/spack/cmd/providers.py
@@ -22,7 +22,10 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
+import six
 import sys
+
+import llnl.util.tty.colify as colify
 
 import spack
 import spack.cmd
@@ -44,8 +47,13 @@ def setup_parser(subparser):
 
 def providers(parser, args):
     valid_virtuals = sorted(spack.repo.provider_index.providers.keys())
-    valid_virtuals_str = 'Virtual packages:\n\t' if sys.stdout.isatty() else ''
-    valid_virtuals_str += ', '.join(valid_virtuals)
+
+    buffer = six.StringIO()
+    isatty = sys.stdout.isatty()
+    if isatty:
+        buffer.write('Virtual packages:\n')
+    colify.colify(valid_virtuals, output=buffer, tty=isatty, indent=4)
+    valid_virtuals_str = buffer.getvalue()
 
     # If called without arguments, list all the virtual packages
     if not args.virtual_package:

--- a/lib/spack/spack/test/cmd/providers.py
+++ b/lib/spack/spack/test/cmd/providers.py
@@ -32,8 +32,9 @@ dependencies = SpackCommand('providers')
 
 @pytest.mark.parametrize('pkg', [
     ('mpi',),
+    ('mpi@2',),
     ('mpi', 'lapack'),
-    ('',)  # argparse seems to print an error message, but doesn't raise
+    ('',)  # Lists all the available virtual packages
 ])
 def test_it_just_runs(pkg):
     dependencies(*pkg)
@@ -41,6 +42,7 @@ def test_it_just_runs(pkg):
 
 @pytest.mark.parametrize('pkg,error_cls', [
     ('zlib', ValueError),
+    ('foo', ValueError)  # Trying to call with a package that does not exist
 ])
 def test_it_just_fails(pkg, error_cls):
     with pytest.raises(error_cls):

--- a/lib/spack/spack/test/cmd/providers.py
+++ b/lib/spack/spack/test/cmd/providers.py
@@ -27,7 +27,7 @@ import pytest
 
 from spack.main import SpackCommand
 
-dependencies = SpackCommand('providers')
+providers = SpackCommand('providers')
 
 
 @pytest.mark.parametrize('pkg', [
@@ -37,7 +37,27 @@ dependencies = SpackCommand('providers')
     ('',)  # Lists all the available virtual packages
 ])
 def test_it_just_runs(pkg):
-    dependencies(*pkg)
+    providers(*pkg)
+
+
+@pytest.mark.parametrize('vpkg,provider_list', [
+    (('mpi',), ['intel-mpi',
+                'intel-parallel-studio',
+                'mpich',
+                'mpich@1:',
+                'mpich@3:',
+                'mvapich2',
+                'openmpi',
+                'openmpi@1.6.5',
+                'openmpi@1.7.5:',
+                'openmpi@2.0.0:',
+                'spectrum-mpi']),
+    (('D', 'awk'), ['ldc', 'gawk', 'mawk'])  # Call 2 virtual packages at once
+])
+def test_provider_lists(vpkg, provider_list):
+    output = providers(*vpkg)
+    for item in provider_list:
+        assert item in output
 
 
 @pytest.mark.parametrize('pkg,error_cls', [
@@ -46,4 +66,4 @@ def test_it_just_runs(pkg):
 ])
 def test_it_just_fails(pkg, error_cls):
     with pytest.raises(error_cls):
-        dependencies(pkg)
+        providers(pkg)


### PR DESCRIPTION
fixes #1355

`spack providers` now outputs a sensible error message if non-virtual specs are provided as arguments:
```console
$ spack providers zlib
==> Error: non-virtual specs cannot be part of the query [zlib]
Virtual packages:
	D, awk, blas, daal, elf, gl, glu, golang, ipp, java, jpeg, lapack, mkl, mpe, mpi, opencl, openfoam, pil, pkgconfig, scalapack, szip, tbb
```

Formatting of the output changed slightly:
```console
$ spack providers mpi lapack
mpi:
intel-mpi  intel-parallel-studio  mpich  mpich@1:  mpich@3:  mvapich2  openmpi  openmpi@1.6.5  openmpi@1.7.5:  openmpi@2.0.0:  spectrum-mpi

lapack:
atlas  intel-mkl  intel-parallel-studio  netlib-lapack  openblas  veclibfort
```
Calling the command without arguments prints the list of valid virtual packages:
```console
$ spack providers 
Virtual packages:
	D, awk, blas, daal, elf, gl, glu, golang, ipp, java, jpeg, lapack, mkl, mpe, mpi, opencl, openfoam, pil, pkgconfig, scalapack, szip, tbb
```