### PR TITLE
Activation of activated package just msg's

### DIFF
--- a/lib/spack/spack/cmd/activate.py
+++ b/lib/spack/spack/cmd/activate.py
@@ -59,7 +59,8 @@ def activate(parser, args):
         layout = YamlViewExtensionsLayout(args.view, spack.store.layout)
 
     if spec.package.is_activated(extensions_layout=layout):
-        tty.die("Package %s is already activated." % specs[0].short_spec)
+        tty.msg("Package %s is already activated." % specs[0].short_spec)
+        return
 
     spec.package.do_activate(extensions_layout=layout,
                              with_dependencies=not args.force)


### PR DESCRIPTION
Activating a package that is already activated now sends a `tty.msg`
and returns.

```
-bash-4.2$ ~/spack/bin/spack activate aspell6-en
==> Package aspell6-en/lc4v24f is already activated.
```

~TODO: I'm not sure if a naked `return` is sufficient or if I should return a particular value?~

Closes #7750 