### PR TITLE
Packages can tune the list of files to be archived at the end of install

### DIFF
--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -94,6 +94,9 @@ class AutotoolsPackage(PackageBase):
     #: Options to be passed to autoreconf when using the default implementation
     autoreconf_extra_args = []
 
+    #: Files to archive for packages based on autotools
+    archive_files = ['config.log']
+
     @run_after('autoreconf')
     def _do_patch_config_guess(self):
         """Some packages ship with an older config.guess and need to have

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -94,8 +94,10 @@ class AutotoolsPackage(PackageBase):
     #: Options to be passed to autoreconf when using the default implementation
     autoreconf_extra_args = []
 
-    #: Files to archive for packages based on autotools
-    archive_files = ['config.log']
+    @property
+    def archive_files(self):
+        """Files to archive for packages based on autotools"""
+        return [os.path.join(self.build_directory, 'config.log')]
 
     @run_after('autoreconf')
     def _do_patch_config_guess(self):

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -73,9 +73,6 @@ class CMakePackage(PackageBase):
 
     build_time_test_callbacks = ['check']
 
-    #: Files to archive for packages based on CMake
-    archive_files = [os.path.join('spack-build', 'CMakeCache.txt')]
-
     #: The build system generator to use.
     #:
     #: See ``cmake --help`` for a list of valid generators.
@@ -92,6 +89,11 @@ class CMakePackage(PackageBase):
             values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel'))
 
     depends_on('cmake', type='build')
+
+    @property
+    def archive_files(self):
+        """Files to archive for packages based on CMake"""
+        return [os.path.join(self.build_directory, 'CMakeCache.txt')]
 
     @property
     def root_cmakelists_dir(self):

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -73,6 +73,9 @@ class CMakePackage(PackageBase):
 
     build_time_test_callbacks = ['check']
 
+    #: Files to archive for packages based on CMake
+    archive_files = [os.path.join('spack-build', 'CMakeCache.txt')]
+
     #: The build system generator to use.
     #:
     #: See ``cmake --help`` for a list of valid generators.

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -530,9 +530,10 @@ class PackageBase(with_metaclass(PackageMeta, object)):
     #: directories, sanity checks will fail.
     sanity_check_is_dir = []
 
-    #: List of glob expressions relative to the package source path.
+    #: List of glob expressions. Each expression must either be
+    #: absolute or relative to the package source path.
     #: Matching artifacts found at the end of the build process will
-    #: be copied in the same directory as build.env and build.out.
+    #: be copied in the same directory tree as build.env and build.out.
     archive_files = []
 
     #
@@ -1659,24 +1660,46 @@ class PackageBase(with_metaclass(PackageMeta, object)):
         install(self.env_path, env_install_path)
         # Finally, archive files that are specific to each package
         with working_dir(self.stage.source_path):
+            errors = StringIO()
+            target_dir = os.path.join(
+                spack.store.layout.metadata_path(self.spec), 'archived-files'
+            )
             for glob_expr in self.archive_files:
+                # Check that we are trying to copy things that are
+                # in the source_path tree (not arbitrary files)
+                abs_expr = os.path.realpath(glob_expr)
+                if os.path.realpath(self.stage.source_path) not in abs_expr:
+                    errors.write(
+                        '[OUTSIDE SOURCE PATH]: {0}\n'.format(glob_expr)
+                    )
+                    continue
+                # Now that we are sure that the path is within the correct
+                # folder, make it relative and check for matches
+                if os.path.isabs(glob_expr):
+                    glob_expr = os.path.relpath(
+                        glob_expr, self.stage.source_path
+                    )
                 files = glob.glob(glob_expr)
-                for file in files:
+                for f in files:
                     try:
-                        target = os.path.join(
-                            spack.store.layout.metadata_path(self.spec),
-                            'archived-files',
-                            file
-                        )
+                        target = os.path.join(target_dir, f)
                         # We must ensure that the directory exists before
                         # copying a file in
                         mkdirp(os.path.dirname(target))
-                        install(file, target)
+                        install(f, target)
                     except Exception:
                         # Here try to be conservative, and avoid discarding
                         # the whole install procedure because of copying a
                         # single file failed
-                        tty.warn("FAILED ARCHIVE: {0}".format(file))
+                        errors.write('[FAILED TO ARCHIVE]: {0}'.format(f))
+
+            if errors.getvalue():
+                error_file = os.path.join(target_dir, 'errors.txt')
+                mkdirp(target_dir)
+                with open(error_file, 'w') as err:
+                    err.write(errors.getvalue())
+                tty.warn('Errors occurred when archiving files.\n\t'
+                         'See: {0}'.format(error_file))
 
         dump_packages(self.spec, packages_dir)
 

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -382,10 +382,10 @@ def test_install_mix_cli_and_files(clispecs, filespecs, tmpdir):
     'builtin_mock', 'mock_archive', 'mock_fetch', 'config', 'install_mockery'
 )
 def test_extra_files_are_archived():
-    s = Spec('a foobar=baz')
+    s = Spec('archive-files')
     s.concretize()
 
-    install('a foobar=baz')
+    install('archive-files')
 
     archive_dir = os.path.join(
         spack.store.layout.metadata_path(s), 'archived-files'

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -387,7 +387,11 @@ def test_extra_files_are_archived():
 
     install('a foobar=baz')
 
-    config_log = os.path.join(
-        s.prefix, '.spack', 'archived-files', 'config.log'
+    archive_dir = os.path.join(
+        spack.store.layout.metadata_path(s), 'archived-files'
     )
+    config_log = os.path.join(archive_dir, 'config.log')
     assert os.path.exists(config_log)
+
+    errors_txt = os.path.join(archive_dir, 'errors.txt')
+    assert os.path.exists(errors_txt)

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -376,3 +376,18 @@ def test_install_mix_cli_and_files(clispecs, filespecs, tmpdir):
 
     install(*args, fail_on_error=False)
     assert install.returncode == 0
+
+
+@pytest.mark.usefixtures(
+    'builtin_mock', 'mock_archive', 'mock_fetch', 'config', 'install_mockery'
+)
+def test_extra_files_are_archived():
+    s = Spec('a foobar=baz')
+    s.concretize()
+
+    install('a foobar=baz')
+
+    config_log = os.path.join(
+        s.prefix, '.spack', 'archived-files', 'config.log'
+    )
+    assert os.path.exists(config_log)

--- a/var/spack/repos/builtin.mock/packages/a/package.py
+++ b/var/spack/repos/builtin.mock/packages/a/package.py
@@ -66,7 +66,9 @@ class A(AutotoolsPackage):
         pass
 
     def build(self, spec, prefix):
-        pass
+        mkdirp(self.build_directory)
+        config_log = join_path(self.build_directory, 'config.log')
+        touch(config_log)
 
     def install(self, spec, prefix):
-        pass
+        touch(join_path(prefix, 'deleteme'))

--- a/var/spack/repos/builtin.mock/packages/a/package.py
+++ b/var/spack/repos/builtin.mock/packages/a/package.py
@@ -54,6 +54,10 @@ class A(AutotoolsPackage):
 
     depends_on('b', when='foobar=bar')
 
+    @property
+    def archive_files(self):
+        return super(A, self).archive_files + ['../../outside.log']
+
     def with_or_without_fee(self, activated):
         if not activated:
             return '--no-fee'

--- a/var/spack/repos/builtin.mock/packages/archive-files/package.py
+++ b/var/spack/repos/builtin.mock/packages/archive-files/package.py
@@ -25,39 +25,18 @@
 from spack import *
 
 
-class A(AutotoolsPackage):
+class ArchiveFiles(AutotoolsPackage):
     """Simple package with one optional dependency"""
 
     homepage = "http://www.example.com"
-    url      = "http://www.example.com/a-1.0.tar.gz"
+    url = "http://www.example.com/a-1.0.tar.gz"
 
     version('1.0', '0123456789abcdef0123456789abcdef')
     version('2.0', '2.0_a_hash')
 
-    variant(
-        'foo',
-        values=('bar', 'baz', 'fee'),
-        default='bar',
-        description='',
-        multi=True
-    )
-
-    variant(
-        'foobar',
-        values=('bar', 'baz', 'fee'),
-        default='bar',
-        description='',
-        multi=False
-    )
-
-    variant('bvv', default=True, description='The good old BV variant')
-
-    depends_on('b', when='foobar=bar')
-
-    def with_or_without_fee(self, activated):
-        if not activated:
-            return '--no-fee'
-        return '--fee-all-the-time'
+    @property
+    def archive_files(self):
+        return super(ArchiveFiles, self).archive_files + ['../../outside.log']
 
     def autoreconf(self, spec, prefix):
         pass
@@ -66,7 +45,9 @@ class A(AutotoolsPackage):
         pass
 
     def build(self, spec, prefix):
-        pass
+        mkdirp(self.build_directory)
+        config_log = join_path(self.build_directory, 'config.log')
+        touch(config_log)
 
     def install(self, spec, prefix):
-        pass
+        touch(join_path(prefix, 'deleteme'))


### PR DESCRIPTION
fixes #2781

This PR introduces a new attribute for packages that contains a list of glob expressions. Any file that matches will be archived in the `<prefix>/.spack/archived-files` directory.

`AutotoolsPackage` and `CMakePackage` provide a sensible default override for this attribute.