### PR TITLE
Set default provider for every virtual package

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -17,6 +17,7 @@ packages:
   all:
     compiler: [gcc, intel, pgi, clang, xl, nag]
     providers:
+      D: [ldc]
       awk: [gawk]
       blas: [openblas]
       daal: [intel-daal]
@@ -26,6 +27,7 @@ packages:
       golang: [gcc]
       ipp: [intel-ipp]
       java: [jdk]
+      jpeg: [libjpeg-turbo, libjpeg]
       lapack: [openblas]
       mkl: [intel-mkl]
       mpe: [mpe2]
@@ -37,4 +39,3 @@ packages:
       scalapack: [netlib-scalapack]
       szip: [libszip, libaec]
       tbb: [intel-tbb]
-      jpeg: [libjpeg-turbo, libjpeg]

--- a/lib/spack/spack/test/package_sanity.py
+++ b/lib/spack/spack/test/package_sanity.py
@@ -60,3 +60,13 @@ def test_all_versions_are_lowercase():
             errors.append(name)
 
     assert len(errors) == 0
+
+
+def test_all_virtual_packages_have_default_providers():
+    """All virtual packages must have a default provider explicitly set."""
+    defaults = spack.config.get_config('packages', scope='defaults')
+    default_providers = defaults['all']['providers']
+    providers = spack.repo.provider_index.providers
+
+    for provider in providers:
+        assert provider in default_providers


### PR DESCRIPTION
Every virtual package in Spack should have a default provider explicitly set in `etc/spack/defaults/packages.yaml`. This prevents changes in the concretizer from determining which virtual dependency is chosen by default. Of course, it doesn't prevent changes in the explicitly set defaults, but it should at least prevent unwanted surprises.