### PR TITLE
Add latest version of cURL

### DIFF
--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -33,6 +33,7 @@ class Curl(AutotoolsPackage):
     # URL must remain http:// so Spack can bootstrap curl
     url      = "http://curl.haxx.se/download/curl-7.54.0.tar.bz2"
 
+    version('7.59.0', 'a2192804f7c2636a09320416afcf888e')
     version('7.56.0', 'e0caf257103e0c77cee5be7e9ac66ca4')
     version('7.54.0', '89bb7ba87384dfbf4f1a3f953da42458')
     version('7.53.1', 'fb1f03a142236840c1a77c035fa4c542')
@@ -49,7 +50,7 @@ class Curl(AutotoolsPackage):
     version('7.42.1', '296945012ce647b94083ed427c1877a8')
 
     variant('nghttp2', default=False, description='build nghttp2 library (requires C++11)')
-    variant('libssh2', default=True, description='enable libssh2 support')
+    variant('libssh2', default=False, description='enable libssh2 support')
 
     depends_on('openssl')
     depends_on('zlib')


### PR DESCRIPTION
Fixes #7777 

In addition to adding the latest version, this PR also disables the `libssh2` variant by default. See #7777 for backstory. I've tried all of the following things to get `curl+libssh2` to build on macOS but with no luck:

1. Explicitly specify `--with-libssh2=PATH`
2. Add `pkg-config` dependency
3. Set `PKG_CONFIG_PATH` to the directory containing `libssh2`'s pkg-config files

@weijianwen you added the `libssh2` variant in #6980. Is this change okay with you? If not, can you figure out how to get `curl+libssh2` to build on macOS? I generally prefer not to enable variants that add dependencies by default.

For comparison, MacPorts disables `libssh2` support by default:
https://github.com/macports/macports-ports/blob/master/net/curl/Portfile#L52
I believe Homebrew does as well:
https://github.com/Homebrew/homebrew-core/blob/master/Formula/curl.rb#L47

Also pinging @JohnWGrove @healther @junghans 