### PR TITLE
add variants and conflicts for curl

### DIFF
--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -49,21 +49,37 @@ class Curl(AutotoolsPackage):
     version('7.43.0', '11bddbb452a8b766b932f859aaeeed39')
     version('7.42.1', '296945012ce647b94083ed427c1877a8')
 
-    variant('nghttp2', default=False, description='build nghttp2 library (requires C++11)')
-    variant('libssh2', default=False, description='enable libssh2 support')
+    variant('nghttp2',    default=False, description='build nghttp2 library (requires C++11)')
+    variant('libssh2',    default=False, description='enable libssh2 support')
+    variant('libssh',     default=False, description='enable libssh support') #, when='7.58:')
+    variant('darwinssl',  default=False, description="use Apple's SSL/TLS implementation")
+
+    conflicts('+libssh', when='@:7.57.99')
+    # on OSX and --with-ssh the configure steps fails with
+    # one or more libs available at link-time are not available run-time
+    # unless the libssh are installed externally (e.g. via homebrew), even though
+    # spack isn't supposed to know about such a libssh installation. For more information
+    # see https://github.com/spack/spack/issues/7777
+    conflicts('platform=darwin', when='+libssh2')
+    conflicts('platform=darwin', when='+libssh')
+    conflicts('platform=linux', when='+darwinssl')
 
     depends_on('openssl')
     depends_on('zlib')
     depends_on('nghttp2', when='+nghttp2')
     depends_on('libssh2', when='+libssh2')
+    depends_on('libssh', when='+libssh')
 
     def configure_args(self):
         spec = self.spec
 
-        args = [
-            '--with-zlib={0}'.format(spec['zlib'].prefix),
-            '--with-ssl={0}'.format(spec['openssl'].prefix)
-        ]
+        args = ['--with-zlib={0}'.format(spec['zlib'].prefix)]
+        if self.satisfies('+darwinssl'):
+            args.append('--with-darwinssl')
+        else:
+            args.append('--with-ssl={0}'.format(spec['openssl'].prefix))
+
         args += self.with_or_without('nghttp2')
         args += self.with_or_without('libssh2')
+        args += self.with_or_without('libssh')
         return args

--- a/var/spack/repos/builtin/packages/libssh/package.py
+++ b/var/spack/repos/builtin/packages/libssh/package.py
@@ -1,0 +1,37 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Libssh(CMakePackage):
+    """libssh: the SSH library"""
+
+    homepage = "https://www.libssh.org"
+    url      = "https://red.libssh.org/attachments/download/218/libssh-0.7.5.tar.xz"
+
+    version('0.7.5', 'd3fc864208bf607ad87cdee836894feb')
+
+    depends_on('openssl')
+    depends_on('zlib')


### PR DESCRIPTION
* darwinssl - Apple's SSL/TLS implementation
* libssh    - use libssh implementation
* add darwin conflict for libssh{,2}
* add linux conflict for darwinssl

This still doesn't actually fix #7777, but is my result from trying to get `curl +libssh{,2}` to build. Now explicitly conflicts with known not-buildable configurations