### PR TITLE
TCL Module fix for `module whatis` issue

### DIFF
--- a/templates/modules/modulefile.tcl
+++ b/templates/modules/modulefile.tcl
@@ -23,7 +23,7 @@ proc ModulesHelp { } {
 
 {% block autoloads %}
 {% for module in autoload %}
-if ![ is-loaded {{ module }} ] {{ '{' }}
+if { [ module-info mode load ] && ![ is-loaded {{ module }} ] } {{ '{' }}
 {% if verbose %}
     puts stderr "Autoloading {{ module }}"
 {% endif %}

--- a/templates/modules/modulefile.tcl
+++ b/templates/modules/modulefile.tcl
@@ -23,7 +23,7 @@ proc ModulesHelp { } {
 
 {% block autoloads %}
 {% for module in autoload %}
-if { [ module-info mode load ] && ![ is-loaded {{ module }} ] } {{ '{' }}
+if {{ '{' }} [ module-info mode load ] && ![ is-loaded {{ module }} ] {{ '}' }} {{ '{' }}
 {% if verbose %}
     puts stderr "Autoloading {{ module }}"
 {% endif %}


### PR DESCRIPTION
Adding logic to the 'autoload if statement' so it only fire if the module is being loaded.

Related to https://github.com/spack/spack/issues/7806
