### PR TITLE
Minor upgrades to `spack diy`:

### DIFF
--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -145,3 +145,7 @@ _arguments['very_long'] = Args(
 _arguments['tags'] = Args(
     '-t', '--tags', action='append',
     help='filter a package query by tags')
+
+_arguments['jobs'] = Args(
+    '-j', '--jobs', action='store', type=int, dest="jobs",
+    help="explicitly set number of make jobs, default is #cpus.")


### PR DESCRIPTION
Small changes to DIY, hopefully they can be merged quickly.

1. Add source_path option to specify where the downloaded source is found.  (Defaults to '.', previously hardcoded to '.')

2. Add missing `-j` option to match `spack install`