### PR TITLE
Suite-sparse: provide patch to fix builts with clang@6.0.0.

### DIFF
--- a/var/spack/repos/builtin/packages/suite-sparse/graphblas_libm_dep.patch
+++ b/var/spack/repos/builtin/packages/suite-sparse/graphblas_libm_dep.patch
@@ -1,0 +1,10 @@
+--- a/GraphBLAS/CMakeLists.txt
++++ b/GraphBLAS/CMakeLists.txt
+@@ -87,6 +87,7 @@
+     C_STANDARD_REQUIRED 11
+     PUBLIC_HEADER "Include/GraphBLAS.h" )
+ set_property ( TARGET graphblas PROPERTY C_STANDARD 11 )
++target_link_libraries ( graphblas m )
+
+ # create the static graphblas library.  Requires ANSI C11
+ add_library ( graphblas_static STATIC ${GRAPHBLAS_SOURCES} )

--- a/var/spack/repos/builtin/packages/suite-sparse/package.py
+++ b/var/spack/repos/builtin/packages/suite-sparse/package.py
@@ -60,6 +60,10 @@ class SuiteSparse(Package):
     # This patch removes unsupported flags for pgi compiler
     patch('pgi.patch', when='%pgi')
 
+    # This patch adds '-lm' when linking libgraphblas and when using clang.
+    # Fixes 'libgraphblas.so.2.0.1: undefined reference to `__fpclassify''
+    patch('graphblas_libm_dep.patch', when='@5.2.0:%clang')
+
     def install(self, spec, prefix):
         # The build system of SuiteSparse is quite old-fashioned.
         # It's basically a plain Makefile which include an header


### PR DESCRIPTION
+ I am unable to build `suite-sparse@5.2.0` with `clang@6.0.0`.  The build fails with the error:

```
     2397    [ 99%] Linking C executable wildtype_demo
     2398    make[4]: Leaving directory
  `/tmp/spack-stage/spack-stage-w0XYhK/SuiteSparse/GraphBLAS/build'
  >> 2399    libgraphblas.so.2.0.1: undefined reference to `__fpclassify'
  >> 2400    clang-6.0: error: linker command failed with exit code 1 (use -v to see invocation)
  >> 2401    make[4]: *** [wildtype_demo] Error 1
```

+ This error appears because libgraphblas.so requires `-lm`, but that link dependency is not explicitly listed in `GraphBLAS\CMakeLists.txt.`
+ A patch file is provided to add this dependency.  The patch is only applied when the compiler is `%clang`.