### PR TITLE
xrandr: needs randrproto

### DIFF
--- a/var/spack/repos/builtin/packages/xrandr/package.py
+++ b/var/spack/repos/builtin/packages/xrandr/package.py
@@ -37,6 +37,7 @@ class Xrandr(AutotoolsPackage):
     depends_on('libxrandr@1.5:')
     depends_on('libxrender')
     depends_on('libx11')
+    depends_on('xrandrproto')
 
     depends_on('xproto@7.0.17:', type='build')
     depends_on('pkgconfig', type='build')

--- a/var/spack/repos/builtin/packages/xrandr/package.py
+++ b/var/spack/repos/builtin/packages/xrandr/package.py
@@ -37,7 +37,7 @@ class Xrandr(AutotoolsPackage):
     depends_on('libxrandr@1.5:')
     depends_on('libxrender')
     depends_on('libx11')
-    depends_on('xrandrproto')
+    depends_on('randrproto')
 
     depends_on('xproto@7.0.17:', type='build')
     depends_on('pkgconfig', type='build')


### PR DESCRIPTION
Without this dependency I get:

``` 
82    configure: error: Package requirements (xrandr >= 1.5 xrender x11 xproto >= 7.0.17) were not met:
83
84    Package 'randrproto', required by 'xrandr', not found
```