### PR TITLE
remove setuptools version requirement for py-backports-shutil

### DIFF
--- a/var/spack/repos/builtin/packages/py-backports-shutil-get-terminal-size/package.py
+++ b/var/spack/repos/builtin/packages/py-backports-shutil-get-terminal-size/package.py
@@ -36,5 +36,7 @@ class PyBackportsShutilGetTerminalSize(PythonPackage):
 
     # newer setuptools version mess with "namespace" packages in an
     # incompatible way cf. https://github.com/pypa/setuptools/issues/900
-    depends_on('py-setuptools@:30.999.999', type='build')
+    # We previously depends_on('py-setuptools@:30.999.999', type='build')
+    # but found this raised more problems than the namespace issue.
+    depends_on('py-setuptools', type='build')
     depends_on('python@:3.2')


### PR DESCRIPTION
Removing the setuputils version requirement to address #7370.