### PR TITLE
glew: adding gl dependency

### DIFF
--- a/var/spack/repos/builtin/packages/glew/package.py
+++ b/var/spack/repos/builtin/packages/glew/package.py
@@ -34,6 +34,7 @@ class Glew(Package):
     version('2.0.0',  '2a2cd7c98f13854d2fcddae0d2b20411')
 
     depends_on("cmake", type='build')
+    depends_on("gl")
 
     def install(self, spec, prefix):
         options = []


### PR DESCRIPTION
glew was looking for opengl dependencies, but no dependency for opengl listed. Since we have a gl provider now, adding that.

guessing this just worked against system opengl previously