### PR TITLE
freetype: adding subdir to cpath for deps

### DIFF
--- a/var/spack/repos/builtin/packages/freetype/package.py
+++ b/var/spack/repos/builtin/packages/freetype/package.py
@@ -47,3 +47,4 @@ class Freetype(AutotoolsPackage):
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         spack_env.prepend_path('CPATH', self.prefix.include.freetype2)
+        run_env.prepend_path('CPATH', self.prefix.include.freetype2)

--- a/var/spack/repos/builtin/packages/freetype/package.py
+++ b/var/spack/repos/builtin/packages/freetype/package.py
@@ -44,3 +44,7 @@ class Freetype(AutotoolsPackage):
 
     def configure_args(self):
         return ['--with-harfbuzz=no']
+
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        spack_env.prepend_path('CPATH',
+                               join_path(self.prefix, 'include', 'freetype2'))

--- a/var/spack/repos/builtin/packages/freetype/package.py
+++ b/var/spack/repos/builtin/packages/freetype/package.py
@@ -46,5 +46,4 @@ class Freetype(AutotoolsPackage):
         return ['--with-harfbuzz=no']
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        spack_env.prepend_path('CPATH',
-                               join_path(self.prefix, 'include', 'freetype2'))
+        spack_env.prepend_path('CPATH', self.prefix.include.freetype2)


### PR DESCRIPTION
Headers are a level deeper than usual, and dependent wasn't finding them until I added this.

I'm a little confused why this hasn't been an issue with other dependents, so if I need to adjust for this in the dependent package instead, let me know.