### PR TITLE
libxml2: adding subdir to cpath for deps

### DIFF
--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -62,5 +62,4 @@ class Libxml2(AutotoolsPackage):
         return args
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        spack_env.prepend_path('CPATH',
-                               join_path(self.prefix, 'include', 'libxml2'))
+        spack_env.prepend_path('CPATH', self.prefix.include.libxml2)

--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -60,3 +60,7 @@ class Libxml2(AutotoolsPackage):
             args.append('--without-python')
 
         return args
+
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        spack_env.prepend_path('CPATH',
+                               join_path(self.prefix, 'include', 'libxml2'))

--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -63,3 +63,4 @@ class Libxml2(AutotoolsPackage):
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         spack_env.prepend_path('CPATH', self.prefix.include.libxml2)
+        run_env.prepent_path('CPATH', self.prefix.include.libxml2)

--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -63,4 +63,4 @@ class Libxml2(AutotoolsPackage):
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         spack_env.prepend_path('CPATH', self.prefix.include.libxml2)
-        run_env.prepent_path('CPATH', self.prefix.include.libxml2)
+        run_env.prepend_path('CPATH', self.prefix.include.libxml2)


### PR DESCRIPTION
Like the change for freetype #7818 , headers are a level deeper than usual, and dependent wasn't finding them until I added this.

I'm a little confused why this hasn't been an issue with other dependents, so if I need to adjust for this in the dependent package instead, let me know.