### PR TITLE
ucx: needs numactl and rdma-core

### DIFF
--- a/var/spack/repos/builtin/packages/ucx/package.py
+++ b/var/spack/repos/builtin/packages/ucx/package.py
@@ -38,3 +38,6 @@ class Ucx(AutotoolsPackage):
     # Still supported
     version('1.2.2', 'ff3fe65e4ebe78408fc3151a9ce5d286')
     version('1.2.1', '697c2fd7912614fb5a1dadff3bfa485c')
+
+    depends_on('numactl')
+    depends_on('rdma-core')


### PR DESCRIPTION
breaking up #6978 

depends on #7835 