### PR TITLE
Libfabric: updating fabrics & adding deps

### DIFF
--- a/var/spack/repos/builtin/packages/libfabric/package.py
+++ b/var/spack/repos/builtin/packages/libfabric/package.py
@@ -42,12 +42,12 @@ class Libfabric(AutotoolsPackage):
                'sockets',
                'verbs',
                'usnic',
-               'mxm',
                'gni',
                'xpmem',
                'udp',
                'rxm',
-               'rxd')
+               'rxd',
+               'mlx')
 
     variant(
        'fabrics',

--- a/var/spack/repos/builtin/packages/libfabric/package.py
+++ b/var/spack/repos/builtin/packages/libfabric/package.py
@@ -57,6 +57,11 @@ class Libfabric(AutotoolsPackage):
        multi=True
     )
 
+    depends_on('rdma-core', when='fabrics=verbs')
+    depends_on('opa-psm2', when='fabrics=psm2')
+    depends_on('psm', when='fabrics=psm')
+    depends_on('ucx', when='fabrics=mlx')
+
     def configure_args(self):
         args = []
 


### PR DESCRIPTION
Based on #6978 

Adding one new fabric, and removing one very old one.

Adding dependencies that exist in spack.  Anyone currently using this was using system libraries, and can continue to do so via setting dependencies to continue to use system libs via packages.yaml

