### PR TITLE
openmpi: libfabric support, ucx cleanup

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -184,7 +184,7 @@ class Openmpi(AutotoolsPackage):
     variant(
         'fabrics',
         default=None if _verbs_dir() is None else 'verbs',
-        description=("List of fabrics that are enabled"),
+        description="List of fabrics that are enabled",
         values=fabrics,
         multi=True
     )


### PR DESCRIPTION
This separates the changes for openmpi from #6978 and integrates with latest changes from develop.

