### PR TITLE
openfoam-org: add v2.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/openfoam-org/240-etc.patch
+++ b/var/spack/repos/builtin/packages/openfoam-org/240-etc.patch
@@ -1,0 +1,88 @@
+--- OpenFOAM-2.4.x.orig/etc/bashrc	2016-10-16 16:11:45.000000000 +0200
++++ OpenFOAM-2.4.x/etc/bashrc	2017-03-24 12:41:25.233267894 +0100
+@@ -55,6 +55,8 @@
+ # overridden from the prefs.sh file or from command-line specification
+ #
+ #- note the location for later use (eg, in job scripts)
++rc="${BASH_SOURCE:-${ZSH_NAME:+$0}}"
++[ -n "$rc" ] && FOAM_INST_DIR=$(\cd $(dirname $rc)/../.. && \pwd -L) || \
+ : ${FOAM_INST_DIR:=$foamInstall}; export FOAM_INST_DIR
+ 
+ #- Compiler location:
+--- OpenFOAM-2.4.x.orig/applications/utilities/mesh/conversion/ansysToFoam/ansysToFoam.L	2018-04-05 14:18:12.112228183 +0100
++++ OpenFOAM-2.4.x/applications/utilities/mesh/conversion/ansysToFoam/ansysToFoam.L	2018-04-05 14:19:20.795393577 +0100
+@@ -77,7 +77,7 @@
+ // Dummy yywrap to keep yylex happy at compile time.
+ // It is called by yylex but is not used as the mechanism to change file.
+ // See <<EOF>>
+-#if YY_FLEX_SUBMINOR_VERSION < 34
++#if YY_FLEX_MINOR_VERSION < 6 && YY_FLEX_SUBMINOR_VERSION < 34
+ extern "C" int yywrap()
+ #else
+ int yyFlexLexer::yywrap()
+--- OpenFOAM-2.4.x.orig/src/thermophysicalModels/reactionThermo/chemistryReaders/chemkinReader/chemkinLexer.L	2018-04-05 14:18:19.137347383 +0100
++++ OpenFOAM-2.4.x/src/thermophysicalModels/reactionThermo/chemistryReaders/chemkinReader/chemkinLexer.L	2018-04-05 14:19:27.556508297 +0100
+@@ -54,7 +54,7 @@
+ // It is called by yylex but is not used as the mechanism to change file.
+ // See <<EOF>>
+ //! \cond dummy
+-#if YY_FLEX_SUBMINOR_VERSION < 34
++#if YY_FLEX_MINOR_VERSION < 6 && YY_FLEX_SUBMINOR_VERSION < 34
+ extern "C" int yywrap()
+ #else
+ int yyFlexLexer::yywrap()
+--- OpenFOAM-2.4.x.orig/applications/utilities/mesh/conversion/gambitToFoam/gambitToFoam.L	2018-04-05 14:18:45.689797916 +0100
++++ OpenFOAM-2.4.x/applications/utilities/mesh/conversion/gambitToFoam/gambitToFoam.L	2018-04-05 14:19:43.195773659 +0100
+@@ -80,7 +80,7 @@
+ // Dummy yywrap to keep yylex happy at compile time.
+ // It is called by yylex but is not used as the mechanism to change file.
+ // See <<EOF>>
+-#if YY_FLEX_SUBMINOR_VERSION < 34
++#if YY_FLEX_MINOR_VERSION < 6 && YY_FLEX_SUBMINOR_VERSION < 34
+ extern "C" int yywrap()
+ #else
+ int yyFlexLexer::yywrap()
+--- OpenFOAM-2.4.x.orig/src/triSurface/triSurface/interfaces/STL/readSTLASCII.L	2018-04-05 14:18:50.432878396 +0100
++++ OpenFOAM-2.4.x/src/triSurface/triSurface/interfaces/STL/readSTLASCII.L	2018-04-05 14:19:46.299826328 +0100
+@@ -55,7 +55,7 @@
+ // It is called by yylex but is not used as the mechanism to change file.
+ // See <<EOF>>
+ //! \cond dummy
+-#if YY_FLEX_SUBMINOR_VERSION < 34
++#if YY_FLEX_MINOR_VERSION < 6 && YY_FLEX_SUBMINOR_VERSION < 34
+ extern "C" int yywrap()
+ #else
+ int yyFlexLexer::yywrap()
+--- OpenFOAM-2.4.x.orig/src/surfMesh/surfaceFormats/stl/STLsurfaceFormatASCII.L	2018-04-05 14:18:57.064990927 +0100
++++ OpenFOAM-2.4.x/src/surfMesh/surfaceFormats/stl/STLsurfaceFormatASCII.L	2018-04-05 14:19:49.258876536 +0100
+@@ -50,7 +50,7 @@
+ // It is called by yylex but is not used as the mechanism to change file.
+ // See <<EOF>>
+ //! \cond dummy
+-#if YY_FLEX_SUBMINOR_VERSION < 34
++#if YY_FLEX_MINOR_VERSION < 6 && YY_FLEX_SUBMINOR_VERSION < 34
+ extern "C" int yywrap()
+ #else
+ int yyFlexLexer::yywrap()
+--- OpenFOAM-2.4.x.orig/applications/utilities/mesh/conversion/fluent3DMeshToFoam/fluent3DMeshToFoam.L	2018-04-05 14:18:27.152483381 +0100
++++ OpenFOAM-2.4.x/applications/utilities/mesh/conversion/fluent3DMeshToFoam/fluent3DMeshToFoam.L	2018-04-05 14:19:32.180586757 +0100
+@@ -123,7 +123,7 @@
+ // Dummy yywrap to keep yylex happy at compile time.
+ // It is called by yylex but is not used as the mechanism to change file.
+ // See <<EOF>>
+-#if YY_FLEX_SUBMINOR_VERSION < 34
++#if YY_FLEX_MINOR_VERSION < 6 && YY_FLEX_SUBMINOR_VERSION < 34
+ extern "C" int yywrap()
+ #else
+ int yyFlexLexer::yywrap()
+--- OpenFOAM-2.4.x.orig/applications/utilities/mesh/conversion/fluentMeshToFoam/fluentMeshToFoam.L.	2018-04-05 14:18:35.049617377 +0100
++++ OpenFOAM-2.4.x/applications/utilities/mesh/conversion/fluentMeshToFoam/fluentMeshToFoam.L	2018-04-05 14:19:38.493693876 +0100
+@@ -100,7 +100,7 @@
+ // Dummy yywrap to keep yylex happy at compile time.
+ // It is called by yylex but is not used as the mechanism to change file.
+ // See <<EOF>>
+-#if YY_FLEX_SUBMINOR_VERSION < 34
++#if YY_FLEX_MINOR_VERSION < 6 && YY_FLEX_SUBMINOR_VERSION < 34
+ extern "C" int yywrap()
+ #else
+ int yyFlexLexer::yywrap()int yyFlexLexer::yywrap()

--- a/var/spack/repos/builtin/packages/openfoam-org/package.py
+++ b/var/spack/repos/builtin/packages/openfoam-org/package.py
@@ -85,6 +85,8 @@ class OpenfoamOrg(Package):
             url=baseurl + '/OpenFOAM-5.x/archive/version-5.0.tar.gz')
     version('4.1', 'afd7d8e66e7db0ffaf519b14f1a8e1d4',
             url=baseurl + '/OpenFOAM-4.x/archive/version-4.1.tar.gz')
+    version('2.4.0', 'ad7d8b7b0753655b2b6fd9e92eefa92a',
+            url=baseurl + '/OpenFOAM-2.4.x/archive/version-2.4.0.tar.gz')
     version('develop', git='https://github.com/OpenFOAM/OpenFOAM-dev.git')
 
     variant('int64', default=False,
@@ -112,13 +114,7 @@ class OpenfoamOrg(Package):
     patch('50-etc.patch', when='@5.0:')
     patch('41-etc.patch', when='@4.1')
     patch('41-site.patch', when='@4.1:')
-
-    # Some user config settings
-    config = {
-        'mplib': 'SYSTEMMPI',   # Use system mpi for spack
-        # Add links into bin/, lib/ (eg, for other applications)
-        'link': False
-    }
+    patch('240-etc.patch', when='@2.4.0')
 
     # The openfoam architecture, compiler information etc
     _foam_arch = None
@@ -135,6 +131,21 @@ class OpenfoamOrg(Package):
     #
     # - End of definitions / setup -
     #
+
+    # Some user config settings
+    @property
+    def config(self):
+        settings = {
+            # Use system mpi for spack
+            'mplib': 'SYSTEMMPI',
+
+            # Add links into bin/, lib/ (eg, for other applications)
+            'link': False,
+        }
+        # OpenFOAM v2.4 and earlier lacks WM_LABEL_OPTION
+        if self.spec.satisfies('@:2.4'):
+            settings['label-size'] = False
+        return settings
 
     def setup_environment(self, spack_env, run_env):
         # This should be similar to the openfoam-com package,
@@ -266,10 +277,18 @@ class OpenfoamOrg(Package):
 
         # Adjust components to use SPACK variants
         for component, subdict in self.etc_config.items():
-            write_environ(
-                subdict,
-                posix=join_path('etc', 'config.sh',  component),
-                cshell=join_path('etc', 'config.csh', component))
+            # Versions up to 3.0 used an etc/config/component.sh naming
+            # convention instead of etc/config.sh/component
+            if spec.satisfies('@:3.0'):
+                write_environ(
+                    subdict,
+                    posix=join_path('etc', 'config',  component) + '.sh',
+                    cshell=join_path('etc', 'config', component) + '.csh')
+            else:
+                write_environ(
+                    subdict,
+                    posix=join_path('etc', 'config.sh',  component),
+                    cshell=join_path('etc', 'config.csh', component))
 
     def build(self, spec, prefix):
         """Build using the OpenFOAM Allwmake script, with a wrapper to source


### PR DESCRIPTION
@olesenm 
Following suggestions/feedback from #7706 for v2.3.1 I switched to 2.4 which is much simpler to add and should be backwards compatible to 2.3.1.

 #7706 was closed unintentionally when creating a new branch and better organising my fork. 
