### PR TITLE
'spack compiler add' can directly register spack installed compilers

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -463,8 +463,9 @@ class SpackCommand(object):
         fail_on_error = kwargs.get('fail_on_error', True)
 
         out = StringIO()
+        echo = kwargs.get('echo', False)
         try:
-            with log_output(out):
+            with log_output(out, echo=echo):
                 self.returncode = _invoke_spack_command(
                     self.command, self.parser, args, unknown)
 

--- a/lib/spack/spack/test/cmd/test_compiler_cmd.py
+++ b/lib/spack/spack/test/cmd/test_compiler_cmd.py
@@ -80,6 +80,7 @@ class TestCompilerCommand(object):
 
         args = spack.util.pattern.Bunch(
             all=None,
+            specs=[],
             compiler_spec=None,
             add_paths=[mock_compiler_dir],
             scope=None


### PR DESCRIPTION
The command line interface for `spack compiler add` has been extended with an additional flag that adds the prefix of specs to the search paths when registering a compiler.

The logic is such that a basic check is performed to ensure that the specified spec is that of a compiler. By default the compiler must be already installed but, if the `--install-missing` flag is passed, it will be bootstrapped.

### Examples
```console
$ spack compiler add --spec autoconf --spec gcc --spec cmake
==> Error: these packages are not compilers [autoconf, cmake]

$ spack compiler list
==> Available compilers
-- gcc rhel7-x86_64 ---------------------------------------------
gcc@4.8.5

$ spack compiler add --spec 'gcc %gcc@4.8.5' 
==> Error: the following specs need to be installed first [gcc %gcc@4.8.5]

$ spack compiler add --spec 'gcc %gcc@4.8.5' --install-missing
==> Installing missing spec for 'gcc %gcc@4.8.5' (might take a while)
==> Installing libsigsegv
==> Using cached archive: /home/culpo/github/spack-scitas/var/spack/cache/libsigsegv/libsigsegv-2.11.tar.gz
==> Staging archive: /home/culpo/github/spack-scitas/var/spack/stage/libsigsegv-2.11-3byxblkv2nvzumj3wk5cbzyud5hpjdlv/libsigsegv-2.11.tar.gz
==> Created stage in /home/culpo/github/spack-scitas/var/spack/stage/libsigsegv-2.11-3byxblkv2nvzumj3wk5cbzyud5hpjdlv
==> No patches needed for libsigsegv
==> Building libsigsegv [AutotoolsPackage]
==> Executing phase: 'autoreconf'
==> Executing phase: 'configure'
...
==> Successfully installed gcc
  Fetch: 10.95s.  Build: 13m 19.90s.  Total: 13m 30.85s.
[+] /home/culpo/github/spack-scitas/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-7.3.0-qrjpi76aeo4bysagruwwfii6oneh56lj
==> Added 1 new compiler to /home/culpo/.spack/linux/compilers.yaml
    gcc@7.3.0
==> Compilers are defined in the following files:
    /home/culpo/.spack/linux/compilers.yaml
```