### PR TITLE
Use GCC6 by Default

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -44,7 +44,7 @@ class Gcc(AutotoolsPackage):
     version('7.3.0', 'be2da21680f27624f3a87055c4ba5af2')
     version('7.2.0', 'ff370482573133a7fcdd96cd2f552292')
     version('7.1.0', '6bf56a2bca9dac9dbbf8e8d1036964a8')
-    version('6.4.0', '11ba51a0cfb8471927f387c8895fe232')
+    version('6.4.0', '11ba51a0cfb8471927f387c8895fe232', preferred=True)
     version('6.3.0', '677a7623c7ef6ab99881bc4e048debb6')
     version('6.2.0', '9768625159663b300ae4de2f4745fcc4')
     version('6.1.0', '8fb6cb98b8459f5863328380fbf06bd1')

--- a/var/spack/repos/builtin/packages/ibmisc/package.py
+++ b/var/spack/repos/builtin/packages/ibmisc/package.py
@@ -90,6 +90,7 @@ class Ibmisc(CMakePackage):
             '-DBUILD_DOCS=%s' % ('YES' if '+doc' in spec else 'NO')]
 
         if '+python' in spec:
-            args.append('-DCYTHON_EXECUTABLE=%s' % spec['py-cython'].command.path)
+            args.append(
+                '-DCYTHON_EXECUTABLE=%s' % spec['py-cython'].command.path)
 
         return args

--- a/var/spack/repos/builtin/packages/ibmisc/package.py
+++ b/var/spack/repos/builtin/packages/ibmisc/package.py
@@ -29,11 +29,17 @@ class Ibmisc(CMakePackage):
     """Misc. reusable utilities used by IceBin."""
 
     homepage = "https://github.com/citibeth/ibmisc"
-    url      = "https://github.com/citibeth/ibmisc/archive/v0.1.0.tar.gz"
+    url      = "https://codeload.github.com/citibeth/ibmisc/tar.gz/v0.1.0.tar.gz"
 
-    version('0.1.0', '18c63db3e466c5a6fc2db3f903d06ecb')
+    maintainers = ['citibeth']
 
-    variant('everytrace', default=False,
+    version('0.1.3', 'bb1876a8d1f0710c1a031280c0fc3f2e')
+
+    version('develop',
+        git='https://github.com/citibeth/ibmisc.git',
+        branch='develop')
+
+    variant('everytrace', default=True,
             description='Report errors through Everytrace')
     variant('proj', default=True,
             description='Compile utilities for PROJ.4 library')
@@ -49,8 +55,11 @@ class Ibmisc(CMakePackage):
             description='Compile utilities for Google Test library')
     variant('python', default=True,
             description='Compile utilities for use with Python/Cython')
+    variant('doc', default=False,
+            description='Build the documentation')
 
     extends('python')
+    depends_on('python@3:')    # Needed for the build...
 
     depends_on('eigen')
     depends_on('everytrace', when='+everytrace')
@@ -65,14 +74,22 @@ class Ibmisc(CMakePackage):
 
     # Build dependencies
     depends_on('doxygen', type='build')
+    depends_on('doxygen', when='+doc', type='build')
 
     def cmake_args(self):
         spec = self.spec
-        return [
+        args = [
             '-DUSE_EVERYTRACE=%s' % ('YES' if '+everytrace' in spec else 'NO'),
+            '-DBUILD_PYTHON=%s' % ('YES' if '+python' in spec else 'NO'),
             '-DUSE_PROJ4=%s' % ('YES' if '+proj' in spec else 'NO'),
             '-DUSE_BLITZ=%s' % ('YES' if '+blitz' in spec else 'NO'),
             '-DUSE_NETCDF=%s' % ('YES' if '+netcdf' in spec else 'NO'),
             '-DUSE_BOOST=%s' % ('YES' if '+boost' in spec else 'NO'),
             '-DUSE_UDUNITS2=%s' % ('YES' if '+udunits2' in spec else 'NO'),
-            '-DUSE_GTEST=%s' % ('YES' if '+googletest' in spec else 'NO')]
+            '-DUSE_GTEST=%s' % ('YES' if '+googletest' in spec else 'NO'),
+            '-DBUILD_DOCS=%s' % ('YES' if '+doc' in spec else 'NO')]
+
+        if '+python' in spec:
+            args.append('-DCYTHON_EXECUTABLE=%s' % spec['py-cython'].command.path)
+
+        return args

--- a/var/spack/repos/builtin/packages/icebin/package.py
+++ b/var/spack/repos/builtin/packages/icebin/package.py
@@ -1,0 +1,96 @@
+##############################################################################
+# Copyright (c) 2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Icebin(CMakePackage):
+    """Regridding/Coupling library for GCM + Ice Sheet Model"""
+
+    homepage = "https://github.com/citibeth/icebin"
+    url         = "https://github.com/citibeth/icebin/tarball/v0.1.0"
+
+    maintainers = ['citibeth']
+
+    version('0.1.5', 'a209c4cd4502b9ded7525ebaa7c6107f')
+    version('0.1.4', '5c8ecd778255f2972c0caa3a9f5d82ea')
+    version('0.1.3', '98d9b28ef8f8a145a7eed2cb1e92e7e4')
+    version('0.1.2', '68673158b46b6e88aea6bc4595444adb')
+    version('0.1.1', '986b8b51a2564f9c52156a11642e596c')
+    version('0.1.0', '1c2769a0cb3531e4086b885dc7a6fd27')
+
+    version('develop',
+        git='https://github.com/citibeth/icebin.git',
+        branch='develop')
+
+    variant('python', default=True, description='Build Python extension (requires Python, Numpy)')
+    variant('gridgen', default=True, description='Build grid generators (requires CGAL, GMP, MPFR)')
+    variant('coupler', default=False, description='Build the GCM couplers (requires MPI)')
+    variant('pism', default=False, description='Build coupling link with PISM (requires PISM, PETSc)')
+    variant('modele', default=False, description='Build coupling link with ModelE (no exta requirements')
+    variant('doc', default=False, description='Build documentation')
+
+    extends('python', when='+python')
+
+    depends_on('everytrace')
+
+    depends_on('python@3:', when='+python')
+    depends_on('py-cython', when='+python')
+    depends_on('py-numpy', when='+python')
+
+    depends_on('cgal', when='+gridgen')
+    depends_on('gmp', when='+gridgen')
+    depends_on('mpfr', when='+gridgen')
+
+    depends_on('mpi', when='+coupler')
+    depends_on('pism~python', when='+coupler+pism')
+    depends_on('petsc', when='+coupler+pism')
+
+    depends_on('boost+filesystem+date_time+mpi')
+    depends_on('blitz')
+    depends_on('netcdf-cxx4')
+    depends_on('ibmisc+proj+blitz+netcdf+boost+udunits2+python')
+    depends_on('proj')
+    depends_on('eigen')
+
+    depends_on('cmake@3.1:', type='build')
+    depends_on('doxygen', type='build', when='+doc')
+
+    # Command line parsing
+    depends_on('tclap', when='+modele')
+
+    def cmake_args(self):
+        spec = self.spec
+        return [
+            '-DBUILD_PYTHON=%s' % ('YES' if '+python' in spec else 'NO'),
+            '-DBUILD_GRIDGEN=%s' % ('YES' if '+gridgen' in spec else 'NO'),
+            '-DBUILD_COUPLER=%s' % ('YES' if '+coupler' in spec else 'NO'),
+            '-DBUILD_MODELE=%s' % ('YES' if '+modele' in spec else 'NO'),
+            '-DUSE_PISM=%s' % ('YES' if '+pism' in spec else 'NO'),
+            '-DBUILD_DOCS=%s' % ('YES' if '+doc' in spec else 'NO')]
+
+    def setup_environment(self, spack_env, run_env):
+        """Add <prefix>/bin to the module; this is not the default if we
+        extend python."""
+        run_env.prepend_path('PATH', join_path(self.prefix, 'bin'))

--- a/var/spack/repos/builtin/packages/icebin/package.py
+++ b/var/spack/repos/builtin/packages/icebin/package.py
@@ -1,13 +1,13 @@
 ##############################################################################
-# Copyright (c) 2016, Lawrence Livermore National Security, LLC.
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.
 #
 # This file is part of Spack.
 # Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
 # LLNL-CODE-647188
 #
-# For details, see https://github.com/llnl/spack
-# Please also see the LICENSE file for our notice and the LGPL.
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License (as
@@ -29,7 +29,7 @@ class Icebin(CMakePackage):
     """Regridding/Coupling library for GCM + Ice Sheet Model"""
 
     homepage = "https://github.com/citibeth/icebin"
-    url         = "https://github.com/citibeth/icebin/tarball/v0.1.0"
+    url = "https://codeland.github.com/citibeth/icebin/tar.gz/v0.1.0.tar.gz"
 
     maintainers = ['citibeth']
 

--- a/var/spack/repos/builtin/packages/issm/package.py
+++ b/var/spack/repos/builtin/packages/issm/package.py
@@ -1,0 +1,93 @@
+##############################################################################
+# Copyright (c) 2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+# TODO:
+# 1. I don't have MATLAB, so no way to test MATLAB version.
+
+
+class Issm(Package):
+    """Issm is a free and open source distributed version control
+       system designed to handle everything from small to very large
+       projects with speed and efficiency."""
+    homepage = "https://issm.jpl.nasa.gov"
+    url      = "https://github.com/issm/issm/tarball/v2.7.1"
+
+    maintainers = ['citibeth']
+
+    version('svn-head', svn='http://issm.ess.uci.edu/svn/issm/issm/trunk')
+
+    variant('python', default=True, description='Build Python extension (requires Python, Numpy, etc)')
+    variant('matlab', default=False, description='Build MATLAB extension')
+
+    extends('python', when='+python')
+
+    depends_on("autoconf")
+    depends_on("mpi")
+    depends_on("petsc")
+    depends_on("scalapack")
+    depends_on("mumps")
+    depends_on("metis")
+
+    # depends_on("m1qn3")
+    # depends_on("triangle")
+
+    depends_on("python@2:", when="+python")
+    depends_on("py-nose", when="+python")
+    depends_on("py-numpy", when="+python")
+    depends_on("py-scipy", when="+python")
+    # depends_on("py-netcdf", when="+python")
+
+    depends_on("matlab", when="+matlab")
+
+    def install(self, spec, prefix):
+        mpi_dir = spec['mpi'].prefix
+        os.environ['CC'] = os.path.join(mpi_dir, 'bin', 'mpicc')
+        os.environ['CXX'] = os.path.join(mpi_dir, 'bin', 'mpicxx')
+        os.environ['F77'] = os.path.join(mpi_dir, 'bin', 'mpif77')
+
+        configure_args = [
+            "--prefix=%s" % prefix,
+            "--with-triangle-dir=%s" % spec['triangle'].prefix,
+            "--with-petsc-dir=%s" % spec['petsc'].prefix,
+            "--with-scalapack-dir=%s" % spec['scalapack'].prefix,
+            "--with-mumps-dir=%s" % spec['mumps'].prefix,
+            "--with-metis-dir=%s" % spec['metis'].prefix,
+            "--with-m1qn3-dir=%s" % spec['m1qn3'].prefix]
+
+        if '+python' in spec:
+            config_args.append(
+                "--with-python-dir=%s" % spec['python'].prefix)
+            config_args.append(
+                "--with-python-numpy-dir=%s" % spec['py-numpy'].prefix)
+
+        if '+matlab' in spec:
+            configure_args.append(
+                "--with-matlab-dir=%s" % spec['matlab'].prefix)
+
+        autoreconf('-iv')
+        configure(*configure_args)
+        make()
+        make("install")

--- a/var/spack/repos/builtin/packages/issm/package.py
+++ b/var/spack/repos/builtin/packages/issm/package.py
@@ -33,7 +33,7 @@ class Issm(Package):
        system designed to handle everything from small to very large
        projects with speed and efficiency."""
     homepage = "https://issm.jpl.nasa.gov"
-    url      = "https://github.com/issm/issm/tarball/v2.7.1"
+    url      = "https://codeland.github.com/issm/issm/tar.gz/v2.7.1.tar.gz"
 
     maintainers = ['citibeth']
 

--- a/var/spack/repos/builtin/packages/issm/package.py
+++ b/var/spack/repos/builtin/packages/issm/package.py
@@ -1,13 +1,13 @@
 ##############################################################################
-# Copyright (c) 2016, Lawrence Livermore National Security, LLC.
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.
 #
 # This file is part of Spack.
 # Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
 # LLNL-CODE-647188
 #
-# For details, see https://github.com/llnl/spack
-# Please also see the LICENSE file for our notice and the LGPL.
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License (as

--- a/var/spack/repos/builtin/packages/modele-control/package.py
+++ b/var/spack/repos/builtin/packages/modele-control/package.py
@@ -1,3 +1,27 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
 from spack import *
 
 

--- a/var/spack/repos/builtin/packages/modele-control/package.py
+++ b/var/spack/repos/builtin/packages/modele-control/package.py
@@ -29,7 +29,7 @@ class ModeleControl(Package):
     """Misc. Python Stuff."""
 
     homepage = "https://github.com/citibeth/modele-control"
-    url      = "https://github.com/citibeth/modele-control/tarball/v0.1.0"
+    url      = "https://codeland.github.com/citibeth/modele-control/tar.tz/v0.1.0.tar.gz"
 
     maintainers = ['citibeth']
 

--- a/var/spack/repos/builtin/packages/modele-control/package.py
+++ b/var/spack/repos/builtin/packages/modele-control/package.py
@@ -1,5 +1,6 @@
 from spack import *
 
+
 class ModeleControl(Package):
     """Misc. Python Stuff."""
 
@@ -13,7 +14,7 @@ class ModeleControl(Package):
     extends('python')
     depends_on('python@3:')
     depends_on('py-six', type=('build', 'run'))
-    depends_on('py-giss', type=('build','run'))
+    depends_on('py-giss', type=('build', 'run'))
     depends_on('netcdf', type='run')        # ncdump executable
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/modele-control/package.py
+++ b/var/spack/repos/builtin/packages/modele-control/package.py
@@ -16,7 +16,5 @@ class ModeleControl(Package):
     depends_on('py-giss', type=('build','run'))
     depends_on('netcdf', type='run')        # ncdump executable
 
-    # depends_on('binutils', type='run')    # ldd; assume already installed on system
-
     def install(self, spec, prefix):
         setup_py('install', '--prefix=%s' % prefix)

--- a/var/spack/repos/builtin/packages/modele-control/package.py
+++ b/var/spack/repos/builtin/packages/modele-control/package.py
@@ -1,0 +1,22 @@
+from spack import *
+
+class ModeleControl(Package):
+    """Misc. Python Stuff."""
+
+    homepage = "https://github.com/citibeth/modele-control"
+    url      = "https://github.com/citibeth/modele-control/tarball/v0.1.0"
+
+    maintainers = ['citibeth']
+
+    version('develop', git='https://github.com/citibeth/modele-control.git', branch='develop')
+
+    extends('python')
+    depends_on('python@3:')
+    depends_on('py-six', type=('build', 'run'))
+    depends_on('py-giss', type=('build','run'))
+    depends_on('netcdf', type='run')        # ncdump executable
+
+    # depends_on('binutils', type='run')    # ldd; assume already installed on system
+
+    def install(self, spec, prefix):
+        setup_py('install', '--prefix=%s' % prefix)

--- a/var/spack/repos/builtin/packages/modele-tests/package.py
+++ b/var/spack/repos/builtin/packages/modele-tests/package.py
@@ -1,13 +1,13 @@
 ##############################################################################
-# Copyright (c) 2016, Lawrence Livermore National Security, LLC.
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.
 #
 # This file is part of Spack.
 # Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
 # LLNL-CODE-647188
 #
-# For details, see https://github.com/llnl/spack
-# Please also see the LICENSE file for our notice and the LGPL.
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License (as

--- a/var/spack/repos/builtin/packages/modele-tests/package.py
+++ b/var/spack/repos/builtin/packages/modele-tests/package.py
@@ -1,0 +1,44 @@
+##############################################################################
+# Copyright (c) 2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class ModeleTests(CMakePackage):
+    """Tests for ModelE."""
+
+    homepage = "https://github.com/citibeth/modele-tests"
+
+    version('develop',
+            git='git@github.com:citibeth/modele-tests.git',
+            branch='develop')
+
+    maintainers = ['citibeth']
+
+    depends_on('pfunit')
+    depends_on('everytrace')
+    # Does not depend on ModelE; that will be provided later
+
+    def configure_args(self):
+        return []

--- a/var/spack/repos/builtin/packages/modele-utils/package.py
+++ b/var/spack/repos/builtin/packages/modele-utils/package.py
@@ -1,13 +1,13 @@
 ##############################################################################
-# Copyright (c) 2016, Lawrence Livermore National Security, LLC.
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.
 #
 # This file is part of Spack.
 # Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
 # LLNL-CODE-647188
 #
-# For details, see https://github.com/llnl/spack
-# Please also see the LICENSE file for our notice and the LGPL.
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License (as

--- a/var/spack/repos/builtin/packages/modele-utils/package.py
+++ b/var/spack/repos/builtin/packages/modele-utils/package.py
@@ -1,0 +1,76 @@
+##############################################################################
+# Copyright (c) 2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class ModeleUtils(CMakePackage):
+    """Utities for GISS GCM"""
+
+    homepage = "http://www.giss.nasa.gov/tools/modelE"
+
+    # This must be built a user with access to simplex.
+    version('develop',
+            git='simplex.giss.nasa.gov:/giss/gitrepo/modelE.git',
+            branch='landice',
+            preferred=True)
+
+    maintainers = ['citibeth']
+
+    variant('ic', default=False,
+            description='Build init_cond directory')
+    variant('diags', default=True,
+            description='Build mk_diags directory.')
+    variant('aux', default=False,
+            description='Build aux directory')
+
+    # Build dependencies
+    depends_on('m4', type='build')
+    depends_on('cmake@3.2:', type='build')
+
+    # Link dependencies
+    depends_on('netcdf-fortran')
+
+    # depends_on('netcdf-cxx', when='+pnetcdf')
+
+    # Run dependencies
+
+    def cmake_args(self):
+        spec = self.spec
+        return [
+            '-DCMAKE_BUILD_TYPE=%s' %
+            ('Debug' if '+debug' in spec else 'Release'),
+            '-DBUILD_MODEL=NO',
+            '-DBUILD_IC=%s' % ('YES' if '+ic' in spec else 'NO'),
+            '-DBUILD_DIAGS=%s' % ('YES' if '+diags' in spec else 'NO'),
+            '-DBUILD_AUX=%s' % ('YES' if '+aux' in spec else 'NO'),
+            '-DMPI=NO',
+            '-DUSE_PNETCDF=NO',
+            '-DUSE_FEXCEPTION=NO',
+            '-DUSE_EVERYTRACE=NO',
+            '-DUSE_ICEBIN=NO']
+
+    def setup_environment(self, spack_env, env):
+        """Add <prefix>/bin to the module"""
+        env.prepend_path('PATH', join_path(self.prefix, 'bin'))

--- a/var/spack/repos/builtin/packages/modele/package.py
+++ b/var/spack/repos/builtin/packages/modele/package.py
@@ -1,0 +1,115 @@
+##############################################################################
+# Copyright (c) 2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Modele(CMakePackage):
+    """GISS GCM"""
+
+    homepage = "http://www.giss.nasa.gov/tools/modelE"
+    url = "http://none"
+
+    maintainers = ['citibeth']
+
+    # ModelE has no valid versions.
+    # This must be built with "spack spconfig" in a local repo
+    version('landice',
+            git='simplex.giss.nasa.gov:/giss/gitrepo/modelE.git',
+            branch='landice')
+
+    version('master',
+            git='simplex.giss.nasa.gov:/giss/gitrepo/modelE.git',
+            branch='master',
+            preferred=True)
+
+
+    # --- Variants controlling dependencies
+    variant('everytrace', default=True,
+            description='Link to enhanced staktrace capabilities')
+    variant('pnetcdf', default=True, description=''
+            'Link with the PNetCDF library; required for some rundecks.')
+    variant('icebin', default=False,
+            description='Link with the Icebin Ice Model Coupler')
+    variant('mpi', default=True,
+            description='Build parallel version with MPI')
+    variant('fexception', default=False, description=''
+            'Use the FException library, for getting good stack traces.')
+
+    # --- Variants controlling what we build
+    variant('model', default=True,
+            description='Build main model')
+    variant('tests', default=False,
+        description='Build unit tests')
+    variant('aux', default=False,
+            description='Build aux directory')
+    variant('diags', default=False,
+            description='Build mk_diags directory.')
+    variant('ic', default=False,
+            description='Build init_cond directory')
+
+    # --- Variants controlling how we build
+    variant('debug', default=False,
+            description='Use Debug for CMAKE_BUILD_TYPE')
+    variant('mods', default=False,
+            description='Install .mod files')
+
+    # ----------------------------------------
+    # Build dependencies
+    depends_on('m4', type='build')
+    depends_on('cmake@3.2:', type='build')
+
+    # Link dependencies
+    depends_on('everytrace+fortran+mpi', when='+everytrace')
+    depends_on('parallel-netcdf+fortran', when='+pnetcdf')
+    depends_on('icebin+coupler', when='+icebin')
+    depends_on('mpi', when='+mpi')
+    depends_on('fexception', when='+fexception')
+    depends_on('pfunit+mpi', when='+tests')
+    depends_on('netcdf-fortran')
+
+    def cmake_args(self):
+        spec = self.spec
+        return [
+            '-DUSE_EVERYTRACE=%s' % ('YES' if '+everytrace' in spec else 'NO'),
+            '-DUSE_PNETCDF=%s' % ('YES' if '+pnetcdf' in spec else 'NO'),
+            '-DUSE_ICEBIN=%s' % ('YES' if '+icebin' in spec else 'NO'),
+            '-DUSE_MPI=%s' % ('YES' if '+mpi' in spec else 'NO'),
+            '-DUSE_FEXCEPTION=%s' % ('YES' if '+fexception' in spec else 'NO'),
+
+            '-DBUILD_MODEL=%s' % ('YES' if '+model' in spec else 'NO'),
+            '-DBUILD_TESTS=%s' % ('YES' if '+tests' in spec else 'NO'),
+            '-DBUILD_AUX=%s' % ('YES' if '+aux' in spec else 'NO'),
+            '-DBUILD_DIAGS=%s' % ('YES' if '+diags' in spec else 'NO'),
+            '-DBUILD_IC=%s' % ('YES' if '+ic' in spec else 'NO'),
+
+
+            '-DCMAKE_BUILD_TYPE=%s' %
+            ('Debug' if '+debug' in spec else 'Release'),
+            '-DINSTALL_MODS=%s' % ('YES' if '+mods' in spec else 'NO')]
+
+    def setup_environment(self, spack_env, env):
+        """Add <prefix>/bin to the module; this is not the default if we
+        extend python."""
+        env.prepend_path('PATH', join_path(self.prefix, 'bin'))

--- a/var/spack/repos/builtin/packages/modele/package.py
+++ b/var/spack/repos/builtin/packages/modele/package.py
@@ -1,13 +1,13 @@
 ##############################################################################
-# Copyright (c) 2016, Lawrence Livermore National Security, LLC.
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.
 #
 # This file is part of Spack.
 # Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
 # LLNL-CODE-647188
 #
-# For details, see https://github.com/llnl/spack
-# Please also see the LICENSE file for our notice and the LGPL.
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License (as

--- a/var/spack/repos/builtin/packages/modele/package.py
+++ b/var/spack/repos/builtin/packages/modele/package.py
@@ -29,7 +29,6 @@ class Modele(CMakePackage):
     """GISS GCM"""
 
     homepage = "http://www.giss.nasa.gov/tools/modelE"
-    url = "http://none"
 
     maintainers = ['citibeth']
 

--- a/var/spack/repos/builtin/packages/modele/package.py
+++ b/var/spack/repos/builtin/packages/modele/package.py
@@ -44,7 +44,6 @@ class Modele(CMakePackage):
             branch='master',
             preferred=True)
 
-
     # --- Variants controlling dependencies
     variant('everytrace', default=True,
             description='Link to enhanced staktrace capabilities')

--- a/var/spack/repos/builtin/packages/modelex/package.py
+++ b/var/spack/repos/builtin/packages/modelex/package.py
@@ -43,5 +43,4 @@ class Modelex(CMakePackage):
     depends_on('cmake', type='build')
 
     def cmake_args(self):
-        spec = self.spec
         return []

--- a/var/spack/repos/builtin/packages/modelex/package.py
+++ b/var/spack/repos/builtin/packages/modelex/package.py
@@ -29,7 +29,7 @@ class Modelex(CMakePackage):
     """Compiled utitiles related to ModelE"""
 
     homepage = "https://github.com/citibeth/modelex"
-    url      = "https://github.com/citibeth/modelex/tarball/v0.1.0"
+    url      = "https://codeland.github.com/citibeth/modelex/tar.gz/v0.1.0.tar.gz"
 
     maintainers = ['citibeth']
 

--- a/var/spack/repos/builtin/packages/modelex/package.py
+++ b/var/spack/repos/builtin/packages/modelex/package.py
@@ -1,13 +1,13 @@
 ##############################################################################
-# Copyright (c) 2016, Lawrence Livermore National Security, LLC.
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.
 #
 # This file is part of Spack.
 # Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
 # LLNL-CODE-647188
 #
-# For details, see https://github.com/llnl/spack
-# Please also see the LICENSE file for our notice and the LGPL.
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License (as

--- a/var/spack/repos/builtin/packages/modelex/package.py
+++ b/var/spack/repos/builtin/packages/modelex/package.py
@@ -1,0 +1,47 @@
+##############################################################################
+# Copyright (c) 2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Modelex(CMakePackage):
+    """Compiled utitiles related to ModelE"""
+
+    homepage = "https://github.com/citibeth/modelex"
+    url      = "https://github.com/citibeth/modelex/tarball/v0.1.0"
+
+    maintainers = ['citibeth']
+
+    version('develop',
+        git='https://github.com/citibeth/modelex.git',
+        branch='develop')
+
+#    depends_on('netcdf-fortran')
+#    depends_on('netcdf-cxx4')
+#    depends_on('ibmisc')
+    depends_on('cmake', type='build')
+
+    def cmake_args(self):
+        spec = self.spec
+        return []

--- a/var/spack/repos/builtin/packages/pism/package.py
+++ b/var/spack/repos/builtin/packages/pism/package.py
@@ -64,12 +64,15 @@ class Pism(CMakePackage):
             description='Enables parallel HDF5 I/O.')
     # variant('tao', default=False,
     #         description='Use TAO in inverse solvers.')
-    variant('doc', default=False,
-            description='Build PISM documentation (requires LaTeX and Doxygen)')
+
+    description = 'Build PISM documentation (requires LaTeX and Doxygen)'
+    variant('doc', default=False, description=description)
+
     variant('examples', default=False,
             description='Install examples directory')
-    variant('everytrace', default=False,
-            description='Report errors through Everytrace (requires Everytrace)')
+
+    description = 'Report errors through Everytrace (requires Everytrace)'
+    variant('everytrace', default=False, description=description)
 
     # CMake build options not transferred to Spack variants
     # (except from CMakeLists.txt)
@@ -96,9 +99,7 @@ class Pism(CMakePackage):
     depends_on('gsl')
     depends_on('mpi')
     depends_on('netcdf')    # Only the C interface is used, no netcdf-cxx4
-#    depends_on('petsc', when='@0:')
     depends_on('petsc')
-#    depends_on('petsc@3.4.5~superlu-dist', when='@glint2')
     depends_on('udunits2')
     depends_on('proj')
     depends_on('everytrace', when='+everytrace')

--- a/var/spack/repos/builtin/packages/pism/package.py
+++ b/var/spack/repos/builtin/packages/pism/package.py
@@ -1,0 +1,176 @@
+##############################################################################
+# Copyright (c) 2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Pism(CMakePackage):
+    """Parallel Ice Sheet Model"""
+
+    homepage = "http://pism-docs.org/wiki/doku.php:="
+    url      = "https://github.com/pism/pism/tarball/v123"
+    # https://github.com/pism/pism/archive/v0.7.3.tar.gz
+
+    maintainers = ['citibeth']
+
+    version('0.7.3', '7cfb034100d99d5c313c4ac06b7f17b6')
+
+    version('0.7.x', git='https://github.com/pism/pism.git',
+        branch='stable0.7')
+
+    version('glint2', git='https://github.com/pism/pism.git',
+        branch='efischer/glint2')
+
+    version('dev', git='https://github.com/pism/pism.git',
+        branch='dev')
+
+    variant('extra', default=False,
+            description='Build extra executables (testing/verification)')
+    variant('shared', default=True,
+            description='Build shared Pism libraries')
+    variant('python', default=False,
+            description='Build python bindings')
+    variant('icebin', default=False,
+            description='Build classes needed by IceBin')
+    variant('proj', default=True,
+            description='Use Proj.4 to compute cell areas, '
+            'longitudes, and latitudes.')
+    variant('parallel-netcdf4', default=False,
+            description='Enables parallel NetCDF-4 I/O.')
+    variant('parallel-netcdf3', default=False,
+            description='Enables parallel NetCDF-3 I/O using PnetCDF.')
+    variant('parallel-hdf5', default=False,
+            description='Enables parallel HDF5 I/O.')
+    # variant('tao', default=False,
+    #         description='Use TAO in inverse solvers.')
+    variant('doc', default=False, description=
+            'Build PISM documentation (requires LaTeX and Doxygen)')
+    variant('examples', default=False, description=
+            'Install examples directory')
+    variant('everytrace', default=False, description=
+            'Report errors through Everytrace (requires Everytrace)')
+
+    # CMake build options not transferred to Spack variants
+    # (except from CMakeLists.txt)
+    #
+    # option (Pism_TEST_USING_VALGRIND "Add extra regression tests
+    #         using valgrind" OFF)
+    # mark_as_advanced (Pism_TEST_USING_VALGRIND)
+    #
+    # option (Pism_ADD_FPIC "Add -fPIC to C++ compiler flags
+    #         (CMAKE_CXX_FLAGS). Try turning it off if it does not work." ON)
+    # option (Pism_LINK_STATICALLY
+    #         "Set CMake flags to try to ensure that everything is
+    #         linked statically")
+    # option (Pism_LOOK_FOR_LIBRARIES
+    #         "Specifies whether PISM should look for libraries. (Disable
+    #         this on Crays.)" ON)
+    # option (Pism_USE_TR1
+    #        "Use the std::tr1 namespace to access shared pointer
+    #        definitions. Disable to get shared pointers from the std
+    #        namespace (might be needed with some compilers)." ON)
+    # option (Pism_USE_TAO "Use TAO in inverse solvers." OFF)
+
+    depends_on('fftw')
+    depends_on('gsl')
+    depends_on('mpi')
+    depends_on('netcdf')    # Only the C interface is used, no netcdf-cxx4
+#    depends_on('petsc', when='@0:')
+    depends_on('petsc')
+#    depends_on('petsc@3.4.5~superlu-dist', when='@glint2')
+    depends_on('udunits2')
+    depends_on('proj')
+    depends_on('everytrace', when='+everytrace')
+
+    extends('python', when='+python')
+    depends_on('python@2.7', when='+python')
+    depends_on('py-matplotlib', when='+python')  # Implies py-numpy too
+
+    depends_on('cmake', type='build')
+
+    def cmake_args(self):
+        spec = self.spec
+
+        return [
+            '-DPism_BUILD_EXTRA_EXECS=%s' %
+            ('YES' if '+extra' in spec else 'NO'),
+            '-DBUILD_SHARED_LIBS=%s' %
+            ('YES' if '+shared' in spec else 'NO'),
+            '-DPism_BUILD_PYTHON_BINDINGS=%s' %
+            ('YES' if '+python' in spec else 'NO'),
+            '-DPism_BUILD_ICEBIN=%s' %
+            ('YES' if '+icebin' in spec else 'NO'),
+            '-DPism_USE_PROJ4=%s' %
+            ('YES' if '+proj' in spec else 'NO'),
+            '-DPism_USE_PARALLEL_NETCDF4=%s' %
+            ('YES' if '+parallel-netcdf4' in spec else 'NO'),
+            '-DPism_USE_PNETCDF=%s' %
+            ('YES' if '+parallel-netcdf3' in spec else 'NO'),
+            '-DPism_USE_PARALLEL_HDF5=%s' %
+            ('YES' if '+parallel-hdf5' in spec else 'NO'),
+            '-DPism_BUILD_PDFS=%s' %
+            ('YES' if '+doc' in spec else 'NO'),
+            '-DPism_INSTALL_EXAMPLES=%s' %
+            ('YES' if '+examples' in spec else 'NO'),
+            '-DPism_USE_EVERYTRACE=%s' %
+            ('YES' if '+everytrace' in spec else 'NO')]
+
+    def install_install(self):
+        make = self.make_make()
+        with working_dir(self.build_directory, create=False):
+            make('install')
+
+    def setup_environment(self, spack_env, env):
+        """Add <prefix>/bin to the module; this is not the default if we
+        extend python."""
+        env.prepend_path('PATH', join_path(self.prefix, 'bin'))
+        env.set('PISM_PREFIX', self.prefix)
+        env.set('PISM_BIN', join_path(self.prefix, 'bin', ''))
+
+
+# From email correspondence with Constantine Khroulev:
+#
+# > Do you have handy a table of which versions of PETSc are required
+# > for which versions of PISM?
+#
+# We don't. The installation manual [1] specifies the minimum PETSc
+# version for the latest "stable" release (currently PETSc 3.3). The
+# stable PISM version should support all PETSc versions starting from the
+# one specified in the manual and up to the latest PETSc release.
+#
+# The current development PISM version should be built with the latest
+# PETSc release at the time (the "maint" branch of PETSc).
+#
+# Thanks to Git it is relatively easy to find this info, though:
+#
+# | PISM version | PETSc version |
+# |--------------+---------------|
+# |          0.7 | 3.3 and later |
+# |          0.6 | 3.3           |
+# |       new_bc | 3.4.4         |
+# |          0.5 | 3.2           |
+# |          0.4 | 3.1           |
+# |          0.3 | 2.3.3 to 3.1  |
+# |          0.2 | 2.3.3 to 3.0  |
+# |          0.1 | 2.3.3-p2      |

--- a/var/spack/repos/builtin/packages/pism/package.py
+++ b/var/spack/repos/builtin/packages/pism/package.py
@@ -1,13 +1,13 @@
 ##############################################################################
-# Copyright (c) 2016, Lawrence Livermore National Security, LLC.
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.
 #
 # This file is part of Spack.
 # Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
 # LLNL-CODE-647188
 #
-# For details, see https://github.com/llnl/spack
-# Please also see the LICENSE file for our notice and the LGPL.
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License (as

--- a/var/spack/repos/builtin/packages/pism/package.py
+++ b/var/spack/repos/builtin/packages/pism/package.py
@@ -29,8 +29,7 @@ class Pism(CMakePackage):
     """Parallel Ice Sheet Model"""
 
     homepage = "http://pism-docs.org/wiki/doku.php:="
-    url      = "https://github.com/pism/pism/tarball/v123"
-    # https://github.com/pism/pism/archive/v0.7.3.tar.gz
+    url      = "https://codeland.github.com/pism/pism/tar.gz/v0.7.3.tar.gz"
 
     maintainers = ['citibeth']
 

--- a/var/spack/repos/builtin/packages/pism/package.py
+++ b/var/spack/repos/builtin/packages/pism/package.py
@@ -64,12 +64,12 @@ class Pism(CMakePackage):
             description='Enables parallel HDF5 I/O.')
     # variant('tao', default=False,
     #         description='Use TAO in inverse solvers.')
-    variant('doc', default=False, description=
-            'Build PISM documentation (requires LaTeX and Doxygen)')
-    variant('examples', default=False, description=
-            'Install examples directory')
-    variant('everytrace', default=False, description=
-            'Report errors through Everytrace (requires Everytrace)')
+    variant('doc', default=False,
+            description='Build PISM documentation (requires LaTeX and Doxygen)')
+    variant('examples', default=False,
+            description='Install examples directory')
+    variant('everytrace', default=False,
+            description='Report errors through Everytrace (requires Everytrace)')
 
     # CMake build options not transferred to Spack variants
     # (except from CMakeLists.txt)

--- a/var/spack/repos/builtin/packages/py-giss/package.py
+++ b/var/spack/repos/builtin/packages/py-giss/package.py
@@ -1,13 +1,13 @@
 ##############################################################################
-# Copyright (c) 2016, Lawrence Livermore National Security, LLC.
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.
 #
 # This file is part of Spack.
 # Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
 # LLNL-CODE-647188
 #
-# For details, see https://github.com/llnl/spack
-# Please also see the LICENSE file for our notice and the LGPL.
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License (as

--- a/var/spack/repos/builtin/packages/py-giss/package.py
+++ b/var/spack/repos/builtin/packages/py-giss/package.py
@@ -29,7 +29,7 @@ class PyGiss(Package):
     """Misc. Python Stuff."""
 
     homepage = "https://github.com/citibeth/pygiss"
-    url      = "https://github.com/citibeth/pygiss/tarball/v0.1.0"
+    url      = "https://codeland.github.com/citibeth/pygiss/tar.gz/v0.1.0.tar.gz"
 
     version('0.1.2', '1c1c745c2818a6930c29c6ec7f835943')
     version('0.1.1', '172d468690a8b8f474884d7a60064bc7')

--- a/var/spack/repos/builtin/packages/py-giss/package.py
+++ b/var/spack/repos/builtin/packages/py-giss/package.py
@@ -1,0 +1,55 @@
+##############################################################################
+# Copyright (c) 2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyGiss(Package):
+    """Misc. Python Stuff."""
+
+    homepage = "https://github.com/citibeth/pygiss"
+    url      = "https://github.com/citibeth/pygiss/tarball/v0.1.0"
+
+    version('0.1.2', '1c1c745c2818a6930c29c6ec7f835943')
+    version('0.1.1', '172d468690a8b8f474884d7a60064bc7')
+    version('develop', git='https://github.com/citibeth/pygiss.git', branch='develop')
+    version('glint2', git='https://github.com/citibeth/pygiss.git', branch='glint2')
+
+    maintainers = ['citibeth']
+
+    # Requires python@3:
+    extends('python')
+
+    depends_on('python@3:')
+    depends_on('py-numpy+blas+lapack')
+    depends_on('py-netcdf')
+    depends_on('py-matplotlib')
+    depends_on('py-basemap')
+    depends_on('py-proj')
+    depends_on('py-scipy')
+    depends_on('py-six')
+    depends_on('py-udunits')
+
+    def install(self, spec, prefix):
+        setup_py('install', '--prefix=%s' % prefix)


### PR DESCRIPTION
Spack users have encountered known problems with GCC7 not building certain things.  Setting GCC6 as the default will make life easier for everybody here.  See #7803