### PR TITLE
multithreading update in Open MPI 2.0

### DIFF
--- a/var/spack/repos/builtin/packages/hwloc/package.py
+++ b/var/spack/repos/builtin/packages/hwloc/package.py
@@ -48,7 +48,8 @@ class Hwloc(AutotoolsPackage):
     list_url = "http://www.open-mpi.org/software/hwloc/"
     list_depth = 2
 
-    version('2.0.0', '027e6928ae0b5b64c821d0a71a61cd82')
+    version('2.0.1',  '442b2482bb5b81983ed256522aadbf94')
+    version('2.0.0',  '027e6928ae0b5b64c821d0a71a61cd82')
     version('1.11.9', '4d5f5da8b1d09731d82e865ecf3fa399')
     version('1.11.8', 'a0fa1c9109a4d8b4b6568e62cc9b6e30')
     version('1.11.7', '867a5266675e5bf1ef4ab66c459653f8')

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -382,7 +382,7 @@ class Openmpi(AutotoolsPackage):
                 config_args.append('--enable-contrib-no-build=vt')
 
         # Multithreading support
-        if spec.satisfies('@1.5.4:'):
+        if spec.satisfies('@1.5.4:1.999'):
             if '+thread_multiple' in spec:
                 config_args.append('--enable-mpi-thread-multiple')
             else:


### PR DESCRIPTION
As of Open MPI 2.0.0, the option --enable-mpi-thread-multiple is no longer recognized.