### PR TITLE
Openmpi update multithread

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -382,7 +382,7 @@ class Openmpi(AutotoolsPackage):
                 config_args.append('--enable-contrib-no-build=vt')
 
         # Multithreading support
-        if spec.satisfies('@1.5.4:'):
+        if spec.satisfies('@1.5.4:1.999'):
             if '+thread_multiple' in spec:
                 config_args.append('--enable-mpi-thread-multiple')
             else:

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -382,7 +382,7 @@ class Openmpi(AutotoolsPackage):
                 config_args.append('--enable-contrib-no-build=vt')
 
         # Multithreading support
-        if spec.satisfies('@1.5.4:1.999'):
+        if spec.satisfies('@1.5.4:2.999'):
             if '+thread_multiple' in spec:
                 config_args.append('--enable-mpi-thread-multiple')
             else:


### PR DESCRIPTION
MPI_THREAD_MULTIPLE support changed in Open MPI 3.0.