### PR TITLE
Added OpenMP Variant for Kokkos

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -32,10 +32,21 @@ class Kokkos(Package):
     homepage = "https://github.com/kokkos/kokkos"
     url      = "https://github.com/kokkos/kokkos/archive/2.03.00.tar.gz"
 
+    version('2.5.00',  '2db83c56587cb83b772d0c81a3228a21')
+    version('2.04.11', 'd4849cee6eb9001d61c30f1d9fe74336')
+    version('2.04.04', '2c6d1c2569b91c9fcd4117296438e65c')
+    version('2.04.00', 'd99ac790ff5f29545d8eb53de90c0a85')
+    version('2.03.13', '3874a159a517384541ea5b52f85501ba')
+    version('2.03.05', '8727d783453f719eec392e10a36b49fd')
     version('2.03.00', 'f205d659d4304747759fabfba32d43c3')
+    version('2.02.15', 'de41e38f452a50bb03363c519fe20769')
+    version('2.02.07', 'd5baeea70109249f7dca763074ffb202')
+    version('develop', git='https://github.com/kokkos/kokkos',
+            branch='develop')
 
     variant('qthreads', default=False, description="enable Qthreads backend")
     variant('cuda', default=False, description="enable Cuda backend")
+    variant('openmp', default=True, description="enable OpenMP backend")
 
     # Specify that v1.x is required as v2.x has API changes
     depends_on('hwloc@:1')
@@ -49,9 +60,10 @@ class Kokkos(Package):
             g_args = [
                 '--prefix=%s' % prefix,
                 '--with-hwloc=%s' % spec['hwloc'].prefix,
-                '--with-serial',
-                '--with-openmp',
+                '--with-serial'
             ]
+            if '+openmp' in spec:
+                g_args.append('--with-openmp')
             if 'qthreads' in spec:
                 g_args.append('--with-qthreads=%s' % spec['qthreads'].prefix)
             if 'cuda' in spec:


### PR DESCRIPTION
Fixes #7888

Added OpenMP variant for kokkos that can be disabled to build and test
on platforms where OpenMP is not available or desired. Also updated
version list