### PR TITLE
mfem: add valid range of hypre version numbers

### DIFF
--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -164,6 +164,8 @@ class Mfem(Package):
 
     depends_on('mpi', when='+mpi')
     depends_on('hypre', when='+mpi')
+    depends_on('hypre@2.10.0:2.13.999', when='@:3.3.2')
+
     depends_on('metis', when='+metis')
     depends_on('blas', when='+lapack')
     depends_on('lapack', when='+lapack')


### PR DESCRIPTION
This commit fixes #7900.

In short: in the absence of constraints to the contrary, spack will
download the preferred version of a package, which is usually the most
recent non-develop version. On a clean spack installation without
hypre installed, `spack install mfem` will download hypre 2.14.0,
which is API-incompatible with mfem 3.3.2 (and earlier versions of
mfem), so spack will throw compiler errors re: the API mismatch.

This commit fixes that error by restricting mfem release versions
3.3.2 and earlier to hypre version 2.10.0 to 2.13.999 (only 2.13.0
currently exists, but if it has a non-2.14.x maintenance release,
these versions of hypre should also be permitted).