### PR TITLE
adol-c: add boost optional dependency

### DIFF
--- a/var/spack/repos/builtin/packages/adol-c/package.py
+++ b/var/spack/repos/builtin/packages/adol-c/package.py
@@ -46,12 +46,25 @@ class AdolC(AutotoolsPackage):
     variant('openmp',   default=False, description='Enable OpenMP support')
     variant('sparse',   default=False, description='Enable sparse drivers')
     variant('examples', default=True,  description='Install examples')
+    variant('boost',    default=False, description='Enable boost')
 
     # Build dependencies
     depends_on('automake', type='build', when='@develop')
     depends_on('autoconf', type='build', when='@develop')
     depends_on('libtool',  type='build', when='@develop')
     depends_on('m4',       type='build', when='@develop')
+
+    # Link dependencies
+    depends_on('boost+system', when='+boost')
+
+    # FIXME: add
+    #  --with-colpack=DIR      path to the colpack library and headers
+    #                       [default=system libraries]
+    #  --with-mpi-root=MPIROOT absolute path to the MPI root directory
+    #  --with-mpicc=MPICC      name of the MPI C++ compiler (default mpicc)
+    #  --with-mpicxx=MPICXX    name of the MPI C++ compiler (default mpicxx)
+    #  --with-ampi=AMPI_DIR    full path to the installation of adjoinable MPI
+    #                           (AMPI)
 
     patch('openmp_exam_261.patch', when='@2.6.1')
 
@@ -60,25 +73,34 @@ class AdolC(AutotoolsPackage):
 
         configure_args = []
 
+        if '+boost' in spec:
+            configure_args.append(
+                '--with-boost={0}'.format(spec['boost'].prefix)
+            )
+        else:
+            configure_args.append(
+                '--with-boost=no'
+            )
+
         if '+advanced_branching' in spec:
-            configure_args.extend([
+            configure_args.append(
                 '--enable-advanced-branching'
-            ])
+            )
 
         if '+atrig_erf' in spec:
-            configure_args.extend([
+            configure_args.append(
                 '--enable-atrig-erf'
-            ])
+            )
 
         if '+openmp' in spec:
-            configure_args.extend([
+            configure_args.append(
                 '--with-openmp-flag={0}'.format(self.compiler.openmp_flag)
-            ])
+            )
 
         if '+sparse' in spec:
-            configure_args.extend([
+            configure_args.append(
                 '--enable-sparse'
-            ])
+            )
 
         # We can simply use the bundled examples to check
         # whether Adol-C works as expected
@@ -88,9 +110,9 @@ class AdolC(AutotoolsPackage):
                 '--enable-addexa'  # Additional examples
             ])
             if '+openmp' in spec:
-                configure_args.extend([
+                configure_args.append(
                     '--enable-parexa'  # Parallel examples
-                ])
+                )
 
         return configure_args
 


### PR DESCRIPTION
importantly, also prevent from picking up system boost.

proofs:
```
$ otool -L /Users/davydden/spack/opt/spack/darwin-highsierra-x86_64/clang-9.1.0-apple/adol-c-2.6.3-oaah6ba3w3jwxtld5we3krrbuuljgkj7/lib64/libadolc.dylib
/Users/davydden/spack/opt/spack/darwin-highsierra-x86_64/clang-9.1.0-apple/adol-c-2.6.3-oaah6ba3w3jwxtld5we3krrbuuljgkj7/lib64/libadolc.dylib:
	/Users/davydden/spack/opt/spack/darwin-highsierra-x86_64/clang-9.1.0-apple/adol-c-2.6.3-oaah6ba3w3jwxtld5we3krrbuuljgkj7/lib64/libadolc.2.dylib (compatibility version 4.0.0, current version 4.0.0)
	/Users/davydden/spack/opt/spack/darwin-highsierra-x86_64/clang-9.1.0-apple/boost-1.67.0.b1-wi73ssw4tozdvzykmqopq7k5dhl2pfr6/lib/libboost_system.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 400.9.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.50.4)
```