### PR TITLE
Package 'gdbm': do not set CC.

### DIFF
--- a/var/spack/repos/builtin/packages/gdbm/package.py
+++ b/var/spack/repos/builtin/packages/gdbm/package.py
@@ -45,12 +45,5 @@ class Gdbm(AutotoolsPackage):
 
     depends_on("readline")
 
-    def setup_environment(self, spack_env, run_env):
-        spack_env.set('CC', spack_cc)
-
     def configure_args(self):
-        config_args = [
-            '--enable-libgdbm-compat',
-        ]
-
-        return config_args
+        return ['--enable-libgdbm-compat']


### PR DESCRIPTION
A funny story, actually.

Tired of strange warnings that Spack generated each time I installed `gdbm`, I decided to figure out what was the reason for them. The warnings were the following:

```
==> Installing gdbm
==> Warning: Suspicious requests to set or unset 'CC' found
==> Warning:            env.set('CC', join_path(link_dir, compiler.link_paths['cc'])) at /scratch/local1/spack/lib/spack/spack/build_environment.py:146
==> Warning:    --->    spack_env.set('CC', spack_cc) at /scratch/local1/spack/var/spack/repos/builtin/packages/gdbm/package.py:49
```

The strange thing about these warnings is that the two referenced lines of code do the same thing: they set `CC` to Spack's wrapper. Setting `CC` in the package script is redundant, isn't it? But why did this line appear in the code?

This line was introduced in #7225. I assume that it was a compromise between solving another problem and keeping the special treatment for the building system of `gdbm`, which allegedly couldn't find Spack's wrapper without additional help. The special treatment was introduced in #5893. The fact that the compromise (which, in fact, consisted of removing the special treatment and adding a redundant line of code) worked means either that, starting version `1.14.1` (which was added to Spack after #5893 was merged), the building system of `gdbm` "learned" to respect the environment variable `CC`, or that the building system didn't need any special treatment at all. It turned out that the latter is true (it's a standard Automake system after all). So, this PR reverts both of the mentioned changes.

The last question to answer is what was the real reason for the problem described in #5892 and fixed in #5893. I think that it's related to the order, in which Spack performs modifications to the building environment (see https://github.com/spack/spack/issues/5019#issuecomment-341356757). My assumption is that `compilers.yaml` that @certik used instructed Spack to load an environment module in order to enable Intel compiler. The module, in turn, set `CC` to the path of the real compiler. Since Spack loads compiler modules after setting `CC` to the path of the wrapper, the package script used the real compiler instead of the wrapper. Setting `CC` back to the wrapper in `setup_environment()` of the package helps in this case, and this PR breaks the installation of `gdbm` in all similar situations, but the problem is bigger and needs a general solution.
