### PR TITLE
Allow len(Version) to return number of split components.

### DIFF
--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -488,6 +488,14 @@ def test_repr_and_str():
     check_repr_and_str('R2016a.2-3_4')
 
 
+def test_len():
+    a = Version('1.2.3.4')
+    assert len(a) == len(a.version)
+    assert(len(a) == 4)
+    b = Version('2018.0')
+    assert(len(b) == 2)
+
+
 def test_get_item():
     a = Version('0.1_2-3')
     assert isinstance(a[1], int)

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -253,6 +253,9 @@ class Version(object):
     def __iter__(self):
         return iter(self.version)
 
+    def __len__(self):
+        return len(self.version)
+
     def __getitem__(self, idx):
         cls = type(self)
 


### PR DESCRIPTION
Simple addition to avoid having to type `len(version.version)` to check the number of components a version has, with test.

Use case:  
```python
    def url_for_version(self, version):
        url = 'https://github.com/01org/tbb/archive/{0}.tar.gz'
        if (version[0] >= 2017) and len(version) > 1:
            return url.format('{0}_U{1}'.format(version[0], version[1]))
        else:
            return url.format(version)
```

Currently, `len(version.version)` must be used instead.
