### PR TITLE
add patch to get aspell to build on OSX

### DIFF
--- a/var/spack/repos/builtin/packages/aspell/darwin.patch
+++ b/var/spack/repos/builtin/packages/aspell/darwin.patch
@@ -1,0 +1,20 @@
++++ a/interfaces/cc/aspell.h
+--- b/interfaces/cc/aspell.h
+@@ -236,7 +236,7 @@
+ 
+ /******************************** errors ********************************/
+ 
+-
++#ifndef __cplusplus
+ extern const struct AspellErrorInfo * const aerror_other;
+ extern const struct AspellErrorInfo * const aerror_operation_not_supported;
+ extern const struct AspellErrorInfo * const   aerror_cant_copy;
+@@ -322,7 +322,7 @@
+ extern const struct AspellErrorInfo * const   aerror_bad_magic;
+ extern const struct AspellErrorInfo * const aerror_expression;
+ extern const struct AspellErrorInfo * const   aerror_invalid_expression;
+-
++#endif
+ 
+ /******************************* speller *******************************/
+ 

--- a/var/spack/repos/builtin/packages/aspell/package.py
+++ b/var/spack/repos/builtin/packages/aspell/package.py
@@ -40,6 +40,8 @@ class Aspell(AutotoolsPackage):
 
     version('0.60.6.1', 'e66a9c9af6a60dc46134fdacf6ce97d7')
 
+    patch('darwin.patch', when='platform=darwin')
+
     # The dictionaries install all their bits into their prefix.lib dir,
     # we want to link them into aspell's dict-dir.
     # These are identical to what's in spack/package.py except


### PR DESCRIPTION
I have no idea how it builds with homebrew, but without this patch I get a lot of redefinition errors on OSX.