### PR TITLE
Update xrootd with recent versions through 4.8.3 and add variants.

### DIFF
--- a/var/spack/repos/builtin/packages/xrootd/package.py
+++ b/var/spack/repos/builtin/packages/xrootd/package.py
@@ -32,12 +32,49 @@ class Xrootd(CMakePackage):
     homepage = "http://xrootd.org"
     url      = "http://xrootd.org/download/v4.6.0/xrootd-4.6.0.tar.gz"
 
+    version('4.8.3', 'bb6302703ffc123f7f9141ddb589435e')
+    version('4.8.2', '531b632191b59c2cf76ab8d31af4a866')
+    version('4.8.1', 'a307973f7f43b0cc2688dfe502e17709')
+    version('4.8.0', '4349e7f664e686b72855e894b49063ad')
+    version('4.7.1', '4006422bcf99e0a19996ace4ebb99175')
+    version('4.7.0', '2a92ba483f574c6ba6a9ff061878af22')
+    version('4.6.1', '70c6f6e1f5f2b4eeb3c7d2c41a36bb2c')
     version('4.6.0', '5d60aade2d995b68fe0c46896bc4a5d1')
     version('4.5.0', 'd485df3d4a991e1c35efa4bf9ef663d7')
     version('4.4.1', '72b0842f802ccc94dede4ac5ab2a589e')
     version('4.4.0', '58f55e56801d3661d753ff5fd33dbcc9')
     version('4.3.0', '39c2fab9f632f35e12ff607ccaf9e16c')
 
+    variant('http', default=True,
+            description='Build with HTTP support')
+
+    variant('python', default=False,
+            description='Build pyxroot Python extension')
+
+    variant('readline', default=True,
+            description='Use readline')
+
+    depends_on('bzip2')
     depends_on('cmake@2.6:', type='build')
-    depends_on('zlib')
+    depends_on('libxml2', when='+http')
     depends_on('openssl')
+    depends_on('python', when='+python')
+    depends_on('readline', when='+readline')
+    depends_on('xz')
+    depends_on('zlib')
+
+    extends('python', when='+python')
+    patch('python-support.patch', level=1, when='+python')
+
+    def cmake_args(self):
+        spec = self.spec
+        options = [
+            '-DENABLE_HTTP:BOOL={0}'.
+            format('ON' if '+http' in spec else 'OFF'),
+            '-DENABLE_PYTHON:BOOL={0}'.
+            format('ON' if '+python' in spec else 'OFF'),
+            '-DENABLE_READLINE:BOOL={0}'.
+            format('ON' if '+readline' in spec else 'OFF'),
+            '-DENABLE_CEPH:BOOL=OFF'
+        ]
+        return options

--- a/var/spack/repos/builtin/packages/xrootd/python-support.patch
+++ b/var/spack/repos/builtin/packages/xrootd/python-support.patch
@@ -1,0 +1,30 @@
+diff -Naur xrootd-4.8.0/bindings/python/setup.py.in xrootd-4.8.0/bindings/python/setup.py.in
+--- xrootd-4.8.0/bindings/python/setup.py.in	2017-12-13 11:28:52.000000000 -0600
++++ xrootd-4.8.0/bindings/python/setup.py.in	2017-12-21 17:47:51.378701139 -0600
+@@ -16,6 +16,13 @@
+ py_cflags = cfg_vars["PY_CFLAGS"]
+ cfg_vars["PY_CFLAGS"] = " ".join( flag for flag in py_cflags.split() if flag not in ['-Wstrict-prototypes' ${CLANG_PROHIBITED} ] )
+ 
++ccl=cfg_vars["CC"].split()
++ccl[0]="${CMAKE_C_COMPILER}"
++cfg_vars["CC"] = " ".join(ccl)
++cxxl=cfg_vars["CXX"].split()
++cxxl[0]="${CMAKE_CXX_COMPILER}"
++cfg_vars["CXX"] = " ".join(cxxl)
++cfg_vars["PY_CXXFLAGS"] = "${CMAKE_CXX_FLAGS}"
+ 
+ sources = list()
+ depends = list()
+diff -Naur xrootd-4.8.0/cmake/XRootDFindLibs.cmake xrootd-4.8.0/cmake/XRootDFindLibs.cmake
+--- xrootd-4.8.0/cmake/XRootDFindLibs.cmake	2017-12-13 11:28:52.000000000 -0600
++++ xrootd-4.8.0/cmake/XRootDFindLibs.cmake	2017-12-21 17:47:51.379701131 -0600
+@@ -85,8 +85,8 @@
+ endif()
+ 
+ if( ENABLE_PYTHON AND (Linux OR APPLE) )
+-  find_package( PythonLibs ${XRD_PYTHON_REQ_VERSION} )
+   find_package( PythonInterp ${XRD_PYTHON_REQ_VERSION} )
++  find_package( PythonLibs ${XRD_PYTHON_REQ_VERSION} )
+   if( PYTHONINTERP_FOUND AND PYTHONLIBS_FOUND )
+     set( BUILD_PYTHON TRUE )
+     set( PYTHON_FOUND TRUE )


### PR DESCRIPTION
Add configurable HTTP, Python and readline support.

Add previously missing dependencies.

Minor patch to improve Python support (see https://github.com/xrootd/xrootd/pull/695).