### PR TITLE
Change default elf provider on macOS

### DIFF
--- a/etc/spack/defaults/darwin/packages.yaml
+++ b/etc/spack/defaults/darwin/packages.yaml
@@ -16,3 +16,5 @@
 packages:
   all:
     compiler: [clang, gcc, intel]
+    providers:
+      elf: [libelf]


### PR DESCRIPTION
The default compiler on macOS is Clang. Unfortunately, `elfutils` conflicts with Clang. This PR changes the default `elf` provider on macOS to `libelf` to prevent the default compiler and provider from causing problems.

This conflict was introduced in #7096. Related to #7593 and #7635.