### PR TITLE
mvapich2: add registration cache and file systems variants

### DIFF
--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -58,6 +58,9 @@ class Mvapich2(AutotoolsPackage):
     variant('cuda', default=False,
             description='Enable CUDA extension')
 
+    variant('regcache', default=True,
+            description='Enable memory registration cache')
+
     # Accepted values are:
     #   single      - No threads (MPI_THREAD_SINGLE)
     #   funneled    - Only the main thread calls MPI (MPI_THREAD_FUNNELED)
@@ -105,6 +108,13 @@ class Mvapich2(AutotoolsPackage):
         description='Use alloca to allocate temporary memory if available'
     )
 
+    variant(
+        'file_systems',
+        description='List of the ROMIO file systems to activate',
+        values=('lustre', 'gpfs', 'nfs', 'ufs'),
+        multi=True
+    )
+
     depends_on('bison', type='build')
     depends_on('libpciaccess', when=(sys.platform != 'darwin'))
     depends_on('cuda', when='+cuda')
@@ -121,7 +131,10 @@ class Mvapich2(AutotoolsPackage):
         for x in ('hydra', 'gforker', 'remshell'):
             if 'process_managers={0}'.format(x) in spec:
                 other_pms.append(x)
-        opts = ['--with-pm=%s' % ':'.join(other_pms)]
+
+        opts = []
+        if len(other_pms) > 0:
+          opts = ['--with-pm=%s' % ':'.join(other_pms)]
 
         # See: http://slurm.schedmd.com/mpi_guide.html#mvapich2
         if 'process_managers=slurm' in spec:
@@ -150,6 +163,21 @@ class Mvapich2(AutotoolsPackage):
             opts = ["--with-device=ch3:nemesis"]
         elif 'fabrics=mrail' in self.spec:
             opts = ["--with-device=ch3:mrail", "--with-rdma=gen2"]
+        return opts
+
+    @property
+    def file_system_options(self):
+        spec = self.spec
+
+        fs = []
+        for x in ('lustre', 'gpfs', 'nfs', 'ufs'):
+            if 'file_systems={0}'.format(x) in spec:
+                fs.append(x)
+
+        opts = []
+        if len(fs) > 0:
+          opts.append('--with-file-system=%s' % '+'.join(fs))
+
         return opts
 
     def setup_environment(self, spack_env, run_env):
@@ -194,7 +222,7 @@ class Mvapich2(AutotoolsPackage):
         args = [
             '--enable-shared',
             '--enable-romio',
-            '-disable-silent-rules',
+            '--disable-silent-rules',
             '--disable-new-dtags',
             '--enable-fortran=all',
             "--enable-threads={0}".format(spec.variants['threads'].value),
@@ -224,6 +252,12 @@ class Mvapich2(AutotoolsPackage):
         else:
             args.append('--disable-cuda')
 
+        if '+regcache' in self.spec:
+            args.append('--enable-registration-cache')
+        else:
+            args.append('--disable-registration-cache')
+
         args.extend(self.process_manager_options)
         args.extend(self.network_options)
+        args.extend(self.file_system_options)
         return args

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -134,7 +134,7 @@ class Mvapich2(AutotoolsPackage):
 
         opts = []
         if len(other_pms) > 0:
-          opts = ['--with-pm=%s' % ':'.join(other_pms)]
+            opts = ['--with-pm=%s' % ':'.join(other_pms)]
 
         # See: http://slurm.schedmd.com/mpi_guide.html#mvapich2
         if 'process_managers=slurm' in spec:
@@ -176,7 +176,7 @@ class Mvapich2(AutotoolsPackage):
 
         opts = []
         if len(fs) > 0:
-          opts.append('--with-file-system=%s' % '+'.join(fs))
+            opts.append('--with-file-system=%s' % '+'.join(fs))
 
         return opts
 


### PR DESCRIPTION
- add regcache variant to enable/disable memory registration cache
- add file_systems variant to list ROMIO file system components to be built
- avoid empty --with-pm= option if user specifies no process_managers value
- fix missing leading dash in --disable-silent-rules