### PR TITLE
mpifileutils: roll back to dtcmp v1.0.3, add option to build master branch

### DIFF
--- a/var/spack/repos/builtin/packages/mpifileutils/package.py
+++ b/var/spack/repos/builtin/packages/mpifileutils/package.py
@@ -38,13 +38,14 @@ class Mpifileutils(AutotoolsPackage):
     homepage = "https://github.com/hpc/mpifileutils"
     url      = "https://github.com/hpc/mpifileutils/releases/download/v0.6/mpifileutils-0.6.tar.gz"
 
+    version('master', git='https://github.com/hpc/mpifileutils.git', branch='master')
     version('0.7', 'c081f7f72c4521dddccdcf9e087c5a2b')
     version('0.6', '620bcc4966907481f1b1a965b28fc9bf')
 
     depends_on('mpi')
     depends_on('libcircle')
     depends_on('lwgrp')
-    depends_on('dtcmp')
+    depends_on('dtcmp@1.0.3')
     depends_on('libarchive')
 
     variant('xattr', default=True,

--- a/var/spack/repos/builtin/packages/mpifileutils/package.py
+++ b/var/spack/repos/builtin/packages/mpifileutils/package.py
@@ -47,8 +47,8 @@ class Mpifileutils(AutotoolsPackage):
     depends_on('lwgrp')
 
     # need precise version of dtcmp, since DTCMP_Segmented_exscan added
-    # in v1.0.2 but renamed in v1.1.0 and later
-    depends_on('dtcmp@1.0.2:1.0.3')
+    # in v1.0.3 but renamed in v1.1.0 and later
+    depends_on('dtcmp@1.0.3')
 
     depends_on('libarchive')
 

--- a/var/spack/repos/builtin/packages/mpifileutils/package.py
+++ b/var/spack/repos/builtin/packages/mpifileutils/package.py
@@ -38,14 +38,18 @@ class Mpifileutils(AutotoolsPackage):
     homepage = "https://github.com/hpc/mpifileutils"
     url      = "https://github.com/hpc/mpifileutils/releases/download/v0.6/mpifileutils-0.6.tar.gz"
 
-    version('master', git='https://github.com/hpc/mpifileutils.git', branch='master')
+    version('develop', git='https://github.com/hpc/mpifileutils.git')
     version('0.7', 'c081f7f72c4521dddccdcf9e087c5a2b')
     version('0.6', '620bcc4966907481f1b1a965b28fc9bf')
 
     depends_on('mpi')
     depends_on('libcircle')
     depends_on('lwgrp')
-    depends_on('dtcmp@1.0.3')
+
+    # need precise version of dtcmp, since DTCMP_Segmented_exscan added
+    # in v1.0.2 but renamed in v1.1.0 and later
+    depends_on('dtcmp@1.0.2:1.0.3')
+
     depends_on('libarchive')
 
     variant('xattr', default=True,


### PR DESCRIPTION
- roll back to dtcmp v1.0.3 due to API change on DTCMP_Segmented_exscan
- add option to build master branch from github