### PR TITLE
Updated sbt to point to github. Added versions 1.1.4, 0.13.17.

### DIFF
--- a/var/spack/repos/builtin/packages/sbt/package.py
+++ b/var/spack/repos/builtin/packages/sbt/package.py
@@ -29,10 +29,11 @@ import shutil
 class Sbt(Package):
     """Scala Build Tool"""
 
-    homepage = "http://www.scala-sbt.org"
-    url      = "https://dl.bintray.com/sbt/native-packages/sbt/0.13.12/sbt-0.13.12.tgz"
+    homepage = 'http://www.scala-sbt.org'
+    url = 'https://github.com/sbt/sbt/releases/download/v1.1.4/sbt-1.1.4.tgz'
 
-    version('0.13.12', 'cec3071d46ef13334c8097cc3467ff28')
+    version('1.1.4', 'c71e5fa846164d14d4cd450520d66c6a')
+    version('0.13.17', 'c52c6152cc7aadfd1f0736a1a5d0a5b8')
 
     depends_on('java')
 


### PR DESCRIPTION
I can restore version `0.13.2` if anybody knows how to have a second `url` that doesn't compromise `spack checksum`.