### PR TITLE
make symlinking python3->python optional

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -93,6 +93,7 @@ class Python(AutotoolsPackage):
         default=False,
         description='Enable expensive build-time optimizations, if available'
     )
+    # See https://legacy.python.org/dev/peps/pep-0394/
     variant('symlink', default=False,
             description="Symlink 'python3' executable to 'python'")
 

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -94,8 +94,9 @@ class Python(AutotoolsPackage):
         description='Enable expensive build-time optimizations, if available'
     )
     # See https://legacy.python.org/dev/peps/pep-0394/
-    variant('symlink', default=False,
-            description="Symlink 'python3' executable to 'python'")
+    variant('pythoncmd', default=True,
+            description="Symlink 'python3' executable to 'python' "
+            "(not PEP 394 compliant)")
 
     depends_on("openssl")
     depends_on("bzip2")
@@ -234,7 +235,7 @@ class Python(AutotoolsPackage):
                 os.symlink(os.path.join(src, f),
                            os.path.join(dst, f))
 
-        if spec.satisfies('@3:') and spec.satisfies('+symlink'):
+        if spec.satisfies('@3:') and spec.satisfies('+pythoncmd'):
             os.symlink(os.path.join(prefix.bin, 'python3'),
                        os.path.join(prefix.bin, 'python'))
             os.symlink(os.path.join(prefix.bin, 'python3-config'),

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -93,6 +93,8 @@ class Python(AutotoolsPackage):
         default=False,
         description='Enable expensive build-time optimizations, if available'
     )
+    variant('symlink', default=False,
+            description="Symlink 'python3' executable to 'python'")
 
     depends_on("openssl")
     depends_on("bzip2")
@@ -231,7 +233,7 @@ class Python(AutotoolsPackage):
                 os.symlink(os.path.join(src, f),
                            os.path.join(dst, f))
 
-        if spec.satisfies('@3:'):
+        if spec.satisfies('@3:') and spec.satisfies('+symlink'):
             os.symlink(os.path.join(prefix.bin, 'python3'),
                        os.path.join(prefix.bin, 'python'))
             os.symlink(os.path.join(prefix.bin, 'python3-config'),


### PR DESCRIPTION
@adamjstewart @healther 

This PR makes #7103 optional.  I believe #7103 is not a good idea for the following reasons:

1. It is not the way the Python distro does things.   `python3` is the standard name for the Python3 executable, and `python`, according to the standard, always means Python2.  By default, Spack installations should conform to the standard.

2. It does weird things to my Spack.  Consider what I did:
   1. Download Spack, start using it.  (Spack running with my System's /usr/bin/ptyhon).
   2. Install my software stack, which includes Python3
   3. Do a `module load` of my software stack.
   4. All of a sudden, the `spack` command is now running with Python3, not Python2.  What horrible inconsistencies might that cause, AFTER I've built a lot of stuff?  (To be fair, Spack works with Python3 too.  But it still makes me nervous).

3. It breaks some builds.  I have builds that assume, as per the standard, that  "python" means Python2.  (Admittedly, these builds should probably be fixed to use the `python2` executable).

Anyway... I think it's best to leave the symlinking as optional.  So now there's a `python+symlink` variant.
