### PR TITLE
zlib: add version 1.2.7 for RHEL 7

### DIFF
--- a/var/spack/repos/builtin/packages/zlib/package.py
+++ b/var/spack/repos/builtin/packages/zlib/package.py
@@ -39,6 +39,7 @@ class Zlib(Package):
     # Due to the bug fixes, any installations of 1.2.9 or 1.2.10 should be
     # immediately replaced with 1.2.11.
     version('1.2.8', '44d667c142d7cda120332623eab69f40')
+    version('1.2.7', 'c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1')
     version('1.2.3', 'debc62758716a169df9f62e6ab2bc634')
 
     variant('pic', default=True,


### PR DESCRIPTION
Adds zlib version 1.2.7 so `packages.yaml` can use the zlib version in the RHEL 7 RPM repo.