### PR TITLE
Support *.TAR.gz extension.

### DIFF
--- a/lib/spack/spack/util/compression.py
+++ b/lib/spack/spack/util/compression.py
@@ -28,7 +28,7 @@ from itertools import product
 from spack.util.executable import which
 
 # Supported archive extensions.
-PRE_EXTS = ["tar"]
+PRE_EXTS = ["tar", "TAR"]
 EXTS     = ["gz", "bz2", "xz", "Z", "zip", "tgz"]
 
 # Add PRE_EXTS and EXTS last so that .tar.gz is matched *before* .tar or .gz


### PR DESCRIPTION
Add support *.TAR.gz extension. For example, `http://www2.mmm.ucar.edu/wrf/src/WRFV3.9.1.1.TAR.gz`. 