### PR TITLE
gmp: update

### DIFF
--- a/var/spack/repos/builtin/packages/gmp/package.py
+++ b/var/spack/repos/builtin/packages/gmp/package.py
@@ -38,6 +38,8 @@ class Gmp(AutotoolsPackage):
     version('6.0.0a', 'b7ff2d88cae7f8085bd5006096eed470')
     version('6.0.0',  '6ef5869ae735db9995619135bd856b84')
     version('5.1.3', 'a082867cbca5e898371a97bb27b31fea')
+    # Old version needed for a binary package in ghc-bootstrap
+    version('4.3.2',  'dd60683d7057917e34630b4a787932e8')
 
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')


### PR DESCRIPTION
Add version needed for `ghc-bootstrap`