### PR TITLE
py-numpy: update

### DIFF
--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -149,11 +149,13 @@ class PyNumpy(PythonPackage):
     def build_args(self, spec, prefix):
         args = []
 
-        # From NumPy 1.10.0 on it's possible to do a parallel build
-        # However, this does not always work in practice.
-        # See https://github.com/spack/spack/issues/7927
-        # if self.version >= Version('1.10.0'):
-        #     args = ['-j', str(make_jobs)]
+        # From NumPy 1.10.0 on it's possible to do a parallel build.
+        if self.version >= Version('1.10.0'):
+            # But Parallel build in Python 3.5+ is broken.  See:
+            # https://github.com/spack/spack/issues/7927
+            # https://github.com/scipy/scipy/issues/7112
+            if spec['python'].version < Version('3.5'):
+                args = ['-j', str(make_jobs)]
 
         return args
 

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -150,8 +150,10 @@ class PyNumpy(PythonPackage):
         args = []
 
         # From NumPy 1.10.0 on it's possible to do a parallel build
-        if self.version >= Version('1.10.0'):
-            args = ['-j', str(make_jobs)]
+        # However, this does not always work in practice.
+        # See https://github.com/spack/spack/issues/7927
+        # if self.version >= Version('1.10.0'):
+        #     args = ['-j', str(make_jobs)]
 
         return args
 

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -77,9 +77,10 @@ class PyScipy(PythonPackage):
         args = []
 
         # Build in parallel
-        # Known problems with Python 3
+        # Known problems with Python 3.5+
+        # https://github.com/spack/spack/issues/7927
         # https://github.com/scipy/scipy/issues/7112
-        if not spec.satisfies('^python@3:'):
+        if not spec.satisfies('^python@3.5:'):
             args.extend(['-j', str(make_jobs)])
 
         return args


### PR DESCRIPTION
Disable parallel build, which can cause problems.
Numpy does not take particularly long even with serial build.