### PR TITLE
py-cython: update

### DIFF
--- a/var/spack/repos/builtin/packages/py-cython/package.py
+++ b/var/spack/repos/builtin/packages/py-cython/package.py
@@ -38,3 +38,8 @@ class PyCython(PythonPackage):
     # These versions contain illegal Python3 code...
     version('0.22', '1ae25add4ef7b63ee9b4af697300d6b6')
     version('0.21.2', 'd21adb870c75680dc857cd05d41046a4')
+
+    @property
+    def command(self):
+        """Returns the Cython command"""
+        return Executable(self.prefix.bin.cython)


### PR DESCRIPTION
Following the example of `python`, add a `spec.command` property, to be used by other packages.