### PR TITLE
py-bsddb3: update

### DIFF
--- a/var/spack/repos/builtin/packages/py-bsddb3/package.py
+++ b/var/spack/repos/builtin/packages/py-bsddb3/package.py
@@ -38,3 +38,7 @@ class PyBsddb3(PythonPackage):
 
     depends_on('python@2.6:')
     depends_on('py-setuptools')
+    depends_on('berkeley-db')
+
+    # For testing... see here for an example that uses BerkeleyDB
+    # http://code.activestate.com/recipes/189060-using-berkeley-db-database/


### PR DESCRIPTION
Depend on `berkeley-db`, which did not previously exist in Spack but now does.