### PR TITLE
python: Fix Bug in get_config_var()

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -460,7 +460,7 @@ class Python(AutotoolsPackage):
         pythoncmd = self.command('-c', cmd, output=str).strip()
         pythoncmd.add_default_env('PYTHONPATH', '')
         return pythoncmd
-        
+
     def get_config_h_filename(self):
         """Returns the full path name of the configuration header.
         Wrapper around ``distutils.sysconfig.get_config_h_filename()``."""

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -67,7 +67,6 @@ class Python(AutotoolsPackage):
     version('2.7.10', 'd7547558fd673bd9d38e2108c6b42521')
     version('2.7.9', '5eebcaa0030dc4061156d3429657fb83')
     version('2.7.8', 'd4bca0159acb0b44a781292b5231936f')
-    version('2.7.5', 'b4f01a1d0ba0b46b05c73b2ac909b1df')
 
     extendable = True
 

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -235,7 +235,8 @@ class Python(AutotoolsPackage):
                 os.symlink(os.path.join(src, f),
                            os.path.join(dst, f))
 
-        if spec.satisfies('@3:') and spec.satisfies('+pythoncmd'):
+        if spec.satisfies('@3:') and spec.satisfies('+
+                                                    '):
             os.symlink(os.path.join(prefix.bin, 'python3'),
                        os.path.join(prefix.bin, 'python'))
             os.symlink(os.path.join(prefix.bin, 'python3-config'),
@@ -459,8 +460,7 @@ class Python(AutotoolsPackage):
         # https://askubuntu.com/questions/640010
         self.command.add_default_env('PYTHONPATH', '')
         return self.command('-c', cmd, output=str).strip()
-    
-    
+
     def get_config_h_filename(self):
         """Returns the full path name of the configuration header.
         Wrapper around ``distutils.sysconfig.get_config_h_filename()``."""

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -454,10 +454,13 @@ class Python(AutotoolsPackage):
         cmd = 'from distutils.sysconfig import get_config_var; '
         cmd += self.print_string("get_config_var('{0}')".format(key))
 
-        # Spack-installed Python works best without other env vars polluting it.
-        # https://askubuntu.com/questions/640010/fatal-python-error-py-initialize-unable-to-get-the-locale-encoding-syntaxe?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa
-        return self.command('-c', cmd, output=str, env={}).strip()
-
+        # Spack-installed Python works best
+        # without other env vars polluting it.
+        # https://askubuntu.com/questions/640010
+        pythoncmd = self.command('-c', cmd, output=str).strip()
+        pythoncmd.add_default_env('PYTHONPATH', '')
+        return pythoncmd
+        
     def get_config_h_filename(self):
         """Returns the full path name of the configuration header.
         Wrapper around ``distutils.sysconfig.get_config_h_filename()``."""

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -457,10 +457,10 @@ class Python(AutotoolsPackage):
         # Spack-installed Python works best
         # without other env vars polluting it.
         # https://askubuntu.com/questions/640010
-        pythoncmd = self.command('-c', cmd, output=str).strip()
-        pythoncmd.add_default_env('PYTHONPATH', '')
-        return pythoncmd
-
+        self.command.add_default_env('PYTHONPATH', '')
+        return self.command('-c', cmd, output=str).strip()
+    
+    
     def get_config_h_filename(self):
         """Returns the full path name of the configuration header.
         Wrapper around ``distutils.sysconfig.get_config_h_filename()``."""

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -419,8 +419,14 @@ class Python(AutotoolsPackage):
         # location of libraries and headers based on the path,
         # return the realpath
         path = os.path.realpath(os.path.join(self.prefix.bin, command))
+        cmd = Executable(path)
 
-        return Executable(path)
+        # Spack-installed Python works best
+        # without other env vars polluting it.
+        # https://askubuntu.com/questions/640010
+        cmd.add_default_env('PYTHONPATH', '')
+
+        return cmd
 
     def print_string(self, string):
         """Returns the appropriate print string depending on the
@@ -454,10 +460,6 @@ class Python(AutotoolsPackage):
         cmd = 'from distutils.sysconfig import get_config_var; '
         cmd += self.print_string("get_config_var('{0}')".format(key))
 
-        # Spack-installed Python works best
-        # without other env vars polluting it.
-        # https://askubuntu.com/questions/640010
-        self.command.add_default_env('PYTHONPATH', '')
         return self.command('-c', cmd, output=str).strip()
 
     def get_config_h_filename(self):

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -235,8 +235,7 @@ class Python(AutotoolsPackage):
                 os.symlink(os.path.join(src, f),
                            os.path.join(dst, f))
 
-        if spec.satisfies('@3:') and spec.satisfies('+
-                                                    '):
+        if spec.satisfies('@3:') and spec.satisfies('+pythoncmd'):
             os.symlink(os.path.join(prefix.bin, 'python3'),
                        os.path.join(prefix.bin, 'python'))
             os.symlink(os.path.join(prefix.bin, 'python3-config'),

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -67,6 +67,7 @@ class Python(AutotoolsPackage):
     version('2.7.10', 'd7547558fd673bd9d38e2108c6b42521')
     version('2.7.9', '5eebcaa0030dc4061156d3429657fb83')
     version('2.7.8', 'd4bca0159acb0b44a781292b5231936f')
+    version('2.7.5', 'b4f01a1d0ba0b46b05c73b2ac909b1df')
 
     extendable = True
 
@@ -454,7 +455,9 @@ class Python(AutotoolsPackage):
         cmd = 'from distutils.sysconfig import get_config_var; '
         cmd += self.print_string("get_config_var('{0}')".format(key))
 
-        return self.command('-c', cmd, output=str).strip()
+        # Spack-installed Python works best without other env vars polluting it.
+        # https://askubuntu.com/questions/640010/fatal-python-error-py-initialize-unable-to-get-the-locale-encoding-syntaxe?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa
+        return self.command('-c', cmd, output=str, env={}).strip()
 
     def get_config_h_filename(self):
         """Returns the full path name of the configuration header.


### PR DESCRIPTION
New version 2.7.5
Keep clean environment when getting Python configuration; solves a bug.