### PR TITLE
openmpi: don't build static libraries if slurm is activated

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -336,8 +336,11 @@ class Openmpi(AutotoolsPackage):
         spec = self.spec
         config_args = [
             '--enable-shared',
-            '--enable-static'
         ]
+
+        if not spec.satisfies('schedulers=slurm'):
+            config_args.append('--enable-static')
+
         if spec.satisfies('@2.0:'):
             # for Open-MPI 2.0:, C++ bindings are disabled by default.
             config_args.extend(['--enable-mpi-cxx'])

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -338,6 +338,11 @@ class Openmpi(AutotoolsPackage):
             '--enable-shared',
         ]
 
+        # According to this comment on github:
+        #
+        # https://github.com/open-mpi/ompi/issues/4338#issuecomment-383982008
+        #
+        # adding --enable-static silently disables slurm support via pmi/pmi2
         if not spec.satisfies('schedulers=slurm'):
             config_args.append('--enable-static')
 


### PR DESCRIPTION
According to this comment:

    https://github.com/open-mpi/ompi/issues/4338#issuecomment-383982008

on an OpenMPI issue, using `--enable-static` silently disables slurm support.