### PR TITLE
pkgconf: use alpine linux mirror to avoid ssl error

### DIFF
--- a/var/spack/repos/builtin/packages/pkgconf/package.py
+++ b/var/spack/repos/builtin/packages/pkgconf/package.py
@@ -32,7 +32,7 @@ class Pkgconf(AutotoolsPackage):
     maintaining compatibility."""
 
     homepage = "http://pkgconf.org/"
-    url      = "https://distfiles.dereferenced.org/pkgconf/pkgconf-1.3.10.tar.xz"
+    url      = "http://distfiles.alpinelinux.org/distfiles/pkgconf-1.3.10.tar.xz"
 
     version('1.4.0', 'c509c0dad5a70aa4bc3210557b7eafce')
     version('1.3.10', '9b63707bf6f8da6efb3868101d7525fe')


### PR DESCRIPTION
Fix #8037