### PR TITLE
Fix missing ip command in spack_ubuntu Dockerfile

### DIFF
--- a/share/spack/docker/spack_ubuntu/Dockerfile
+++ b/share/spack/docker/spack_ubuntu/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get -yqq update && apt-get -yqq install \
         gfortran            \
         git                 \
         gnupg2              \
+        iproute2            \
         lmod                \
         make                \
         openssh-server      \


### PR DESCRIPTION
The Ubuntu image has been updated to 18.04 resulting in a missing ip command.   