### PR TITLE
perl-extutils-pkgconfig: Add pkg-config dependency

### DIFF
--- a/var/spack/repos/builtin/packages/perl-extutils-pkgconfig/package.py
+++ b/var/spack/repos/builtin/packages/perl-extutils-pkgconfig/package.py
@@ -32,3 +32,5 @@ class PerlExtutilsPkgconfig(PerlPackage):
     url      = "http://search.cpan.org/CPAN/authors/id/X/XA/XAOC/ExtUtils-PkgConfig-1.16.tar.gz"
 
     version('1.16', 'b86318f2b6ac6af3ee985299e1e38fe5')
+
+    depends_on('pkg-config', type='run')

--- a/var/spack/repos/builtin/packages/perl-extutils-pkgconfig/package.py
+++ b/var/spack/repos/builtin/packages/perl-extutils-pkgconfig/package.py
@@ -33,4 +33,4 @@ class PerlExtutilsPkgconfig(PerlPackage):
 
     version('1.16', 'b86318f2b6ac6af3ee985299e1e38fe5')
 
-    depends_on('pkg-config', type='run')
+    depends_on('pkg-config', type=('build', 'run')

--- a/var/spack/repos/builtin/packages/perl-extutils-pkgconfig/package.py
+++ b/var/spack/repos/builtin/packages/perl-extutils-pkgconfig/package.py
@@ -33,4 +33,4 @@ class PerlExtutilsPkgconfig(PerlPackage):
 
     version('1.16', 'b86318f2b6ac6af3ee985299e1e38fe5')
 
-    depends_on('pkg-config', type=('build', 'run')
+    depends_on('pkg-config', type=('build', 'run'))


### PR DESCRIPTION
Fixes error build error

```     
     4     *** ExtUtils::PkgConfig requires the pkg-config utility, but it doesn't
     5     *** seem to be in your PATH.  Is it correctly installed?
```