### PR TITLE
wireshark: stop cmake from picking up /usr paths

### DIFF
--- a/var/spack/repos/builtin/packages/wireshark/package.py
+++ b/var/spack/repos/builtin/packages/wireshark/package.py
@@ -50,6 +50,7 @@ class Wireshark(CMakePackage):
     depends_on('gnutls')
     depends_on('libgcrypt@1.4.2:')
     depends_on('libmaxminddb')
+    depends_on('libpcap')
     depends_on('lua')
     depends_on('krb5')
     depends_on('pkg-config', type='build')

--- a/var/spack/repos/builtin/packages/wireshark/package.py
+++ b/var/spack/repos/builtin/packages/wireshark/package.py
@@ -70,7 +70,9 @@ class Wireshark(CMakePackage):
                 '-DENABLE_LUA=ON',
                 '-DENABLE_MAXMINDDB=ON',
                 '-DYACC_EXECUTABLE=' + self.spec['bison'].prefix.bin.yacc,
-                '-DGIT_EXECUTABLE=' + self.spec['git'].prefix.bin.git]
+                '-DGIT_EXECUTABLE=' + self.spec['git'].prefix.bin.git,
+                '-DPCAP_INCLUDE_DIR=' + self.spec['libpcap'].prefix.include,
+                '-DPCAP_LIB=' + self.spec['libpcap'].prefix.lib + '/libpcap.so']
         if self.spec.satisfies('+qt'):
             args.append('-DBUILD_wireshark=ON')
             args.append('-DENABLE_APPLICATION_BUNDLE=ON')

--- a/var/spack/repos/builtin/packages/wireshark/package.py
+++ b/var/spack/repos/builtin/packages/wireshark/package.py
@@ -74,9 +74,9 @@ class Wireshark(CMakePackage):
                 '-DYACC_EXECUTABLE=' + self.spec['bison'].prefix.bin.yacc,
                 '-DGIT_EXECUTABLE=' + self.spec['git'].prefix.bin.git,
                 '-DPCAP_INCLUDE_DIR=' + self.spec['libpcap'].prefix.include,
-                '-DPCAP_LIB=' + self.spec['libpcap'].prefix.libs,
+                '-DPCAP_LIB=' + str(self.spec['libpcap'].libs),
                 '-DLUA_INCLUDE_DIR=' + self.spec['lua'].prefix.include,
-                '-DLUA_LIBRARY=' + self.spec['lua'].prefix.lib + '/liblua.so.5.2'
+                '-DLUA_LIBRARY=' + str(self.spec['lua'].libs)
                 ]
         if self.spec.satisfies('+qt'):
             args.append('-DBUILD_wireshark=ON')

--- a/var/spack/repos/builtin/packages/wireshark/package.py
+++ b/var/spack/repos/builtin/packages/wireshark/package.py
@@ -42,6 +42,7 @@ class Wireshark(CMakePackage):
     variant('gtk',      default=False, description='Build with gtk')
     variant('headers',  default=True, description='Install headers')
 
+    depends_on('bison',     type='build')
     depends_on('cares')
     depends_on('doxygen',   type='build')
     depends_on('flex',      type='build')

--- a/var/spack/repos/builtin/packages/wireshark/package.py
+++ b/var/spack/repos/builtin/packages/wireshark/package.py
@@ -50,6 +50,7 @@ class Wireshark(CMakePackage):
     depends_on('gnutls')
     depends_on('libgcrypt@1.4.2:')
     depends_on('libmaxminddb')
+    depends_on('libtool@2.2.2:', type='build')
     depends_on('libpcap')
     depends_on('lua')
     depends_on('krb5')

--- a/var/spack/repos/builtin/packages/wireshark/package.py
+++ b/var/spack/repos/builtin/packages/wireshark/package.py
@@ -45,12 +45,14 @@ class Wireshark(CMakePackage):
     depends_on('cares')
     depends_on('doxygen',   type='build')
     depends_on('flex',      type='build')
+    depends_on('git',       type='build')
     depends_on('glib')
     depends_on('gnutls')
     depends_on('libgcrypt@1.4.2:')
     depends_on('libmaxminddb')
     depends_on('lua')
     depends_on('krb5')
+    depends_on('pkg-config', type='build')
     depends_on('libsmi',    when='+smi')
     depends_on('libssh',    when='+libssh')
     depends_on('nghttp2',   when='+nghttp2')
@@ -65,7 +67,9 @@ class Wireshark(CMakePackage):
         args = ['-DENEABLE_CARES=ON',
                 '-DENABLE_GNUTLS=ON',
                 '-DENABLE_LUA=ON',
-                '-DENABLE_MAXMINDDB=ON']
+                '-DENABLE_MAXMINDDB=ON',
+                '-DYACC_EXECUTABLE=' + self.spec['bison'].prefix.bin.yacc,
+                '-DGIT_EXECUTABLE=' + self.spec['git'].prefix.bin.git]
         if self.spec.satisfies('+qt'):
             args.append('-DBUILD_wireshark=ON')
             args.append('-DENABLE_APPLICATION_BUNDLE=ON')

--- a/var/spack/repos/builtin/packages/wireshark/package.py
+++ b/var/spack/repos/builtin/packages/wireshark/package.py
@@ -73,7 +73,7 @@ class Wireshark(CMakePackage):
                 '-DYACC_EXECUTABLE=' + self.spec['bison'].prefix.bin.yacc,
                 '-DGIT_EXECUTABLE=' + self.spec['git'].prefix.bin.git,
                 '-DPCAP_INCLUDE_DIR=' + self.spec['libpcap'].prefix.include,
-                '-DPCAP_LIB=' + self.spec['libpcap'].prefix.lib + '/libpcap.so']
+                '-DPCAP_LIB=' + self.spec['libpcap'].prefix.libs]
         if self.spec.satisfies('+qt'):
             args.append('-DBUILD_wireshark=ON')
             args.append('-DENABLE_APPLICATION_BUNDLE=ON')

--- a/var/spack/repos/builtin/packages/wireshark/package.py
+++ b/var/spack/repos/builtin/packages/wireshark/package.py
@@ -53,7 +53,7 @@ class Wireshark(CMakePackage):
     depends_on('libmaxminddb')
     depends_on('libtool@2.2.2:', type='build')
     depends_on('libpcap')
-    depends_on('lua@:5.2.99')
+    depends_on('lua@5.0.0:5.2.99')
     depends_on('krb5')
     depends_on('pkg-config', type='build')
     depends_on('libsmi',    when='+smi')

--- a/var/spack/repos/builtin/packages/wireshark/package.py
+++ b/var/spack/repos/builtin/packages/wireshark/package.py
@@ -53,7 +53,7 @@ class Wireshark(CMakePackage):
     depends_on('libmaxminddb')
     depends_on('libtool@2.2.2:', type='build')
     depends_on('libpcap')
-    depends_on('lua')
+    depends_on('lua@:5.2.99')
     depends_on('krb5')
     depends_on('pkg-config', type='build')
     depends_on('libsmi',    when='+smi')
@@ -74,7 +74,10 @@ class Wireshark(CMakePackage):
                 '-DYACC_EXECUTABLE=' + self.spec['bison'].prefix.bin.yacc,
                 '-DGIT_EXECUTABLE=' + self.spec['git'].prefix.bin.git,
                 '-DPCAP_INCLUDE_DIR=' + self.spec['libpcap'].prefix.include,
-                '-DPCAP_LIB=' + self.spec['libpcap'].prefix.libs]
+                '-DPCAP_LIB=' + self.spec['libpcap'].prefix.libs,
+                '-DLUA_INCLUDE_DIR=' + self.spec['lua'].prefix.include,
+                '-DLUA_LIBRARY=' + self.spec['lua'].prefix.lib + '/liblua.so.5.2'
+                ]
         if self.spec.satisfies('+qt'):
             args.append('-DBUILD_wireshark=ON')
             args.append('-DENABLE_APPLICATION_BUNDLE=ON')


### PR DESCRIPTION
Trying to build `wireshark` on a system w/o `bison` led to the error
```
...
     346     Could NOT find YACC (missing: YACC_EXECUTABLE)
...
```
This PR fixes YACC pick up and removes fallback to system `libpcap`, `pkgconfig` and `git` installations (from the cmake log). Remaining `/usr` things is `libm`

@adamjstewart is there a way to get at the library file of `libpcap` directly?