### PR TITLE
Updates to Google Benchmark package:

### DIFF
--- a/var/spack/repos/builtin/packages/benchmark/package.py
+++ b/var/spack/repos/builtin/packages/benchmark/package.py
@@ -36,6 +36,8 @@ class Benchmark(CMakePackage):
 
     # first properly installed CMake config packages in
     # 1.2.0 release: https://github.com/google/benchmark/issues/363
+    version('1.4.0', 'ccfaf2cd93ae20191b94f730b945423e')
+    version('1.3.0', '19ce86516ab82d6ad3b17173cf307aac')
     version('1.2.0', '48d0b090cd7a84af2c4a28c8dc963c74')
     version('1.1.0', '66b2a23076cf70739525be0092fc3ae3')
     version('1.0.0', '1474ff826f8cd68067258db75a0835b8')
@@ -44,6 +46,14 @@ class Benchmark(CMakePackage):
             description='The build type to build',
             values=('Debug', 'Release', 'RelWithDebInfo',
                     'MinSizeRel', 'Coverage'))
+
+    depends_on("cmake@2.8.11:", type="build", when="@:1.1.0")
+    depends_on("cmake@2.8.12:", type="build", when="@1.2.0:")
+
+    def cmake_args(self):
+        # No need for testing for the install
+        args = ["-DBENCHMARK_ENABLE_TESTING=OFF"]
+        return args
 
     def patch(self):
         filter_file(


### PR DESCRIPTION
- Adds v1.3.0 and v1.4.0
- List explicit CMake version dependency (from Benchmark CMake files)
- Disable the building of tests. Starting in v1.4.0 this introduced a dependency on GoogleTest

Tested by building all versions on macOS High Sierra