### PR TITLE
Create custom PATH that texlive requires in its module.

### DIFF
--- a/var/spack/repos/builtin/packages/texlive/package.py
+++ b/var/spack/repos/builtin/packages/texlive/package.py
@@ -46,8 +46,8 @@ class Texlive(Package):
     # itself is stable.  Don't let that fool you though, it's still
     # installing TeX **LIVE** from e.g. ctan.math.... below, which is
     # not reproducible.
-    version('live', '8f8fc301514c08a89a2e97197369c648',
-            url='ftp://tug.org/historic/systems/texlive/2017/install-tl-unx.tar.gz')
+    version('live', '946701aa28ca1f93e55e8310ce63fbf8',
+            url='ftp://tug.org/historic/systems/texlive/2018/install-tl-unx.tar.gz')
 
     # There does not seem to be a complete list of schemes.
     # Examples include:

--- a/var/spack/repos/builtin/packages/texlive/package.py
+++ b/var/spack/repos/builtin/packages/texlive/package.py
@@ -24,7 +24,6 @@
 ##############################################################################
 from spack import *
 import os
-import sys
 import platform
 
 
@@ -68,7 +67,7 @@ class Texlive(Package):
     depends_on('perl', type='build')
 
     def setup_environment(self, spack_env, run_env):
-        suffix = "%s-%s" % (platform.machine(), sys.platform)
+        suffix = "%s-%s" % (platform.machine(), platform.system().lower())
         run_env.prepend_path('PATH', join_path(self.prefix.bin, suffix))
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/texlive/package.py
+++ b/var/spack/repos/builtin/packages/texlive/package.py
@@ -24,6 +24,8 @@
 ##############################################################################
 from spack import *
 import os
+import sys
+import platform
 
 
 class Texlive(Package):
@@ -64,6 +66,10 @@ class Texlive(Package):
     )
 
     depends_on('perl', type='build')
+
+    def setup_environment(self, spack_env, run_env):
+        suffix = "%s-%s" % (platform.machine(), sys.platform)
+        run_env.prepend_path('PATH', join_path(self.prefix.bin, suffix))
 
     def install(self, spec, prefix):
         # Using texlive's mirror system leads to mysterious problems,


### PR DESCRIPTION
Addresses #4811. Note the actual PATH on linux should be `bin/x86_64-linux`. It appears to be in reversed in that issue.

To be honest I haven't had a chance to test this because it seems like something is out of sync with the texlive CTAN servers or whatever. I did test it on another package though and it does what I want. I get this error on all systems I've tried when installing texlive today:
```
./install-tl: The TeX Live versions of the local installation
and the repository being accessed are not compatible:
      local: 2017
 repository: 2018
Perhaps you need to use a different CTAN mirror?
```