### PR TITLE
Add gdb@8.1

### DIFF
--- a/var/spack/repos/builtin/packages/gdb/package.py
+++ b/var/spack/repos/builtin/packages/gdb/package.py
@@ -34,6 +34,7 @@ class Gdb(AutotoolsPackage):
     homepage = "https://www.gnu.org/software/gdb"
     url = "http://ftp.gnu.org/gnu/gdb/gdb-7.10.tar.gz"
 
+    version('8.1', '0c85ecbb43569ec43b1c9230622e84ab')
     version('8.0.1', 'bb45869f8126a84ea2ba13a8c0e7c90e')
     version('8.0', '9bb49d134916e73b2c01d01bf20363df')
     version('7.12.1', '06c8f40521ed65fe36ebc2be29b56942')
@@ -45,12 +46,14 @@ class Gdb(AutotoolsPackage):
     version('7.8.2', '8b0ea8b3559d3d90b3ff4952f0aeafbc')
 
     variant('python', default=True, description='Compile with Python support')
+    variant('xz', default=False, description='Compile with lzma support')
 
     # Required dependency
     depends_on('texinfo', type='build')
 
-    # Optional dependency
+    # Optional dependencies
     depends_on('python', when='+python')
+    depends_on('xz', when='+xz')
 
     def configure_args(self):
         args = []


### PR DESCRIPTION
Also add optional lzma dependency for debug information support. I'm not sure if a specific version of xz is required. (https://stackoverflow.com/questions/43482837/warning-cannot-parse-gnu-debugdata-section-lzma-support-was-disabled-at-compi)