### PR TITLE
Add 3.5.2; Add optional cpp implementation enable for py-protobuf

### DIFF
--- a/var/spack/repos/builtin/packages/protobuf/package.py
+++ b/var/spack/repos/builtin/packages/protobuf/package.py
@@ -34,6 +34,7 @@ class Protobuf(CMakePackage):
     url      = "https://github.com/google/protobuf/archive/v3.2.0.tar.gz"
     root_cmakelists_dir = "cmake"
 
+    version('3.5.2', 'ff6742018c172c66ecc627029ad54280')
     version('3.5.1.1', '5005003ae6b94773c4bbca87a644b131')
     version('3.5.1',   '710f1a75983092c9b45ecef207236104')
     version('3.5.0.1', 'b3ed2401acf167207277b254fd7f9638')

--- a/var/spack/repos/builtin/packages/py-protobuf/package.py
+++ b/var/spack/repos/builtin/packages/py-protobuf/package.py
@@ -36,7 +36,6 @@ class PyProtobuf(PythonPackage):
     homepage = 'https://developers.google.com/protocol-buffers/'
     url      = 'https://pypi.io/packages/source/p/protobuf/protobuf-3.0.0b2.tar.gz'
 
-
     variant('cpp', default=False,
             description='Enable the cpp implementation')
 

--- a/var/spack/repos/builtin/packages/py-protobuf/package.py
+++ b/var/spack/repos/builtin/packages/py-protobuf/package.py
@@ -36,6 +36,13 @@ class PyProtobuf(PythonPackage):
     homepage = 'https://developers.google.com/protocol-buffers/'
     url      = 'https://pypi.io/packages/source/p/protobuf/protobuf-3.0.0b2.tar.gz'
 
+
+    variant('cpp', default=False,
+            description='Enable the cpp implementation')
+
+    version('3.5.2.post1', '3b60685732bd0cbdc802dfcb6071efbcf5d927ce3127c13c33ea1a8efae3aa76')
+    version('3.5.2', '09879a295fd7234e523b62066223b128c5a8a88f682e3aff62fb115e4a0d8be0')
+    version('3.5.1', '95b78959572de7d7fafa3acb718ed71f482932ddddddbd29ba8319c10639d863')
     version('3.0.0b2', 'f0d3bd2394345a9af4a277cd0302ae83')
     version('2.6.1', '6bf843912193f70073db7f22e2ea55e2')
     version('2.5.0', '338813f3629d59e9579fed9035ecd457')
@@ -43,3 +50,12 @@ class PyProtobuf(PythonPackage):
     version('2.3.0', 'bb020c962f252fe81bfda8fb433bafdd')
 
     depends_on('py-setuptools', type='build')
+    depends_on('protobuf', when='+cpp')
+
+    @when('+cpp')
+    def build_args(self, spec, prefix):
+        return ['--cpp_implementation']
+
+    @when('+cpp')
+    def install_args(self, spec, prefix):
+        return ['--cpp_implementation']

--- a/var/spack/repos/builtin/packages/py-protobuf/package.py
+++ b/var/spack/repos/builtin/packages/py-protobuf/package.py
@@ -57,4 +57,5 @@ class PyProtobuf(PythonPackage):
 
     @when('+cpp')
     def install_args(self, spec, prefix):
-        return ['--cpp_implementation']
+        args = super(PyProtobuf, self).install_args(spec, prefix)
+        return args + ['--cpp_implementation']


### PR DESCRIPTION
Work in progress: see below

~To actually enable the c++ implementation, these flags need to be set:
PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=cpp
PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION_VERSION=2
[Reason, I think](https://github.com/google/protobuf/blob/ed4321d1cb33199984118d801956822842771e7e/python/google/protobuf/internal/api_implementation.py#L69)~
EDIT: nope. The c++ stuff gets picked up or not [here](https://github.com/google/protobuf/blob/ed4321d1cb33199984118d801956822842771e7e/python/google/protobuf/internal/api_implementation.py#L40)

~However, I can't figure out how to do that. I'm not seeing any way to set additional runtime environment variables in the docs (I might have missed them). Even if I found those, if I `spack activate py-protobuf` and then `module load python-[...]` but don't `module load py-protobuf-[...]`, that doesn't seem like it will pick up the flags?~