### PR TITLE
Unset CPATH for pkg-config invocations

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -94,6 +94,7 @@ SPACK_DEBUG = 'SPACK_DEBUG'
 SPACK_SHORT_SPEC = 'SPACK_SHORT_SPEC'
 SPACK_DEBUG_LOG_ID = 'SPACK_DEBUG_LOG_ID'
 SPACK_DEBUG_LOG_DIR = 'SPACK_DEBUG_LOG_DIR'
+SPACK_DIRTY = 'SPACK_DIRTY'
 
 
 # Platform-specific library suffix.
@@ -255,6 +256,8 @@ def set_build_environment_variables(pkg, env, dirty):
 
     # Install root prefix
     env.set(SPACK_INSTALL, spack.store.root)
+
+    env.set(SPACK_DIRTY, '1' if dirty else '0')
 
     # Stuff in here sanitizes the build environment to eliminate
     # anything the user has set that may interfere.

--- a/lib/spack/spack/package_extensions.py
+++ b/lib/spack/spack/package_extensions.py
@@ -1,0 +1,22 @@
+import os
+import shutil
+import stat
+
+
+def write_pkgconfig_wrapper(pkg):
+    pkgconf_exe = os.path.join(pkg.prefix.bin, 'pkg-config')
+    pkgconf_relocate = os.path.join(pkg.prefix.bin, 'pkg-config.orig')
+    shutil.move(pkgconf_exe, pkgconf_relocate)
+
+    script = """#!/bin/sh
+if [ "$SPACK_DIRTY" = "1" ]; then
+    cpath_val=$CPATH
+else
+    cpath_val=
+fi
+CPATH=$cpath_val {0} "$@"
+""".format(pkgconf_relocate)
+    with open(pkgconf_exe, 'w') as F:
+        F.write(script)
+    mode = os.stat(pkgconf_exe).st_mode
+    os.chmod(pkgconf_exe, mode | stat.S_IEXEC)

--- a/var/spack/repos/builtin/packages/pkg-config/package.py
+++ b/var/spack/repos/builtin/packages/pkg-config/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+import spack.package_extensions
 
 
 class PkgConfig(AutotoolsPackage):
@@ -61,3 +62,7 @@ class PkgConfig(AutotoolsPackage):
             config_args.append('--with-internal-glib')
 
         return config_args
+
+    @run_after('install')
+    def create_pkgconfig_wrapper(self):
+        spack.package_extensions.write_pkgconfig_wrapper(self)

--- a/var/spack/repos/builtin/packages/pkgconf/package.py
+++ b/var/spack/repos/builtin/packages/pkgconf/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+import spack.package_extensions
 
 
 class Pkgconf(AutotoolsPackage):
@@ -50,22 +51,4 @@ class Pkgconf(AutotoolsPackage):
         symlink('pkgconf', '{0}/pkg-config'.format(self.prefix.bin))
         symlink('pkgconf.1',
                 '{0}/pkg-config.1'.format(self.prefix.share.man.man1))
-        self.write_wrapper()
-
-    def write_wrapper(self):
-        pkgconf_exe = join_path(self.prefix.bin, 'pkg-config')
-        pkgconf_relocate = join_path(self.prefix.bin, 'pkg-config.orig')
-        move(pkgconf_exe, pkgconf_relocate)
-
-        script = """#!/bin/sh
-if [ "$SPACK_DIRTY" = "1" ]; then
-    cpath_val=$CPATH
-else
-    cpath_val=
-fi
-CPATH=$cpath_val {0} "$@"
-""".format(pkgconf_relocate)
-        with open(pkgconf_exe, 'w') as F:
-            F.write(script)
-        chmod = which('chmod')
-        chmod('+x', pkgconf_exe)
+        spack.package_extensions.write_pkgconfig_wrapper(self)

--- a/var/spack/repos/builtin/packages/pkgconf/package.py
+++ b/var/spack/repos/builtin/packages/pkgconf/package.py
@@ -50,3 +50,17 @@ class Pkgconf(AutotoolsPackage):
         symlink('pkgconf', '{0}/pkg-config'.format(self.prefix.bin))
         symlink('pkgconf.1',
                 '{0}/pkg-config.1'.format(self.prefix.share.man.man1))
+        self.write_wrapper()
+
+    def write_wrapper(self):
+        pkgconf_exe = join_path(self.prefix.bin, 'pkg-config')
+        pkgconf_relocate = join_path(self.prefix.bin, 'pkg-config.orig')
+        move(pkgconf_exe, pkgconf_relocate)
+
+        script = """#!/bin/sh
+CPATH= {0} "$@"
+""".format(pkgconf_relocate)
+        with open(pkgconf_exe, 'w') as F:
+            F.write(script)
+        chmod = which('chmod')
+        chmod('+x', pkgconf_exe)

--- a/var/spack/repos/builtin/packages/pkgconf/package.py
+++ b/var/spack/repos/builtin/packages/pkgconf/package.py
@@ -58,7 +58,12 @@ class Pkgconf(AutotoolsPackage):
         move(pkgconf_exe, pkgconf_relocate)
 
         script = """#!/bin/sh
-CPATH= {0} "$@"
+if [ "$SPACK_DIRTY" = "1" ]; then
+    cpath_val=$CPATH
+else
+    cpath_val=
+fi
+CPATH=$cpath_val {0} "$@"
 """.format(pkgconf_relocate)
         with open(pkgconf_exe, 'w') as F:
             F.write(script)


### PR DESCRIPTION
See: https://github.com/spack/spack/issues/7855

Recent versions of pkgconfig (and pkgconf) check `CPATH` as part of system include paths. Generally Spack unsets `CPATH` but allows package-specific updates to `CPATH` after clearing it. https://github.com/spack/spack/pull/7818 updates `CPATH` for `freetype` specifically (presumably to help some other package that isn't `py-matplotlib` build).

This provides a means to ensure that when Spack-built `pkg-config` is invoked that it unsets `CPATH` unless `spack env/install` was invoked with `--dirty`. This requires modifying the `pkgconf`/`pkg-config` providers since they can be invoked indirectly as part of a build.