### PR TITLE
Add package for "bumpversion"

### DIFF
--- a/var/spack/repos/builtin/packages/bumpversion/package.py
+++ b/var/spack/repos/builtin/packages/bumpversion/package.py
@@ -31,6 +31,7 @@ class Bumpversion(PythonPackage):
     homepage = "https://pypi.python.org/pypi/bumpversion"
     url      = "https://pypi.io/packages/source/b/bumpversion/bumpversion-0.5.0.tar.gz"
 
+    version('0.5.3', 'c66a3492eafcf5ad4b024be9fca29820')
     version('0.5.0', '222ba619283d6408ce1bfbb0b5b542f3')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/bumpversion/package.py
+++ b/var/spack/repos/builtin/packages/bumpversion/package.py
@@ -25,13 +25,12 @@
 from spack import *
 
 
-class PyBumpversion(PythonPackage):
+class Bumpversion(PythonPackage):
     """Version-bump your software with a single command."""
 
     homepage = "https://pypi.python.org/pypi/bumpversion"
-    url      = "https://github.com/peritus/bumpversion"
+    url      = "https://pypi.io/packages/source/b/bumpversion/bumpversion-0.5.0.tar.gz"
 
-    version('0.5.0', git='https://github.com/peritus/bumpversion',
-            commit='8cb123237fbe2b13a1108fa7b876c9ad0c12a3b1')
+    version('0.5.0', '222ba619283d6408ce1bfbb0b5b542f3')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-bumpversion/package.py
+++ b/var/spack/repos/builtin/packages/py-bumpversion/package.py
@@ -1,0 +1,37 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyBumpversion(PythonPackage):
+    """Version-bump your software with a single command."""
+
+    homepage = "https://pypi.python.org/pypi/bumpversion"
+    url      = "https://github.com/peritus/bumpversion"
+
+    version('0.5.0', git='https://github.com/peritus/bumpversion',
+            commit='8cb123237fbe2b13a1108fa7b876c9ad0c12a3b1')
+
+    depends_on('py-setuptools', type='build')


### PR DESCRIPTION
`bumpversion` is a tool that automagically increments version numbers for projects.  It can update files and do other magic along the way.

I was uncertain whether the package should be called `bumpversion` or `py-bumpversion`.  Is being written in python and/or using the python build system really all it takes to earn a `py-` prefix?

Thoughts?
