### PR TITLE
Skip external specs when creating mirrors

### DIFF
--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -192,6 +192,14 @@ def mirror_create(args):
                     new_specs.add(s)
             specs = list(new_specs)
 
+        # Skip external specs, as they are already installed
+        external_specs = [s for s in specs if s.external]
+        specs = [s for s in specs if not s.external]
+
+        for spec in external_specs:
+            msg = 'Skipping {0} as it is an external spec.'
+            tty.msg(msg.format(spec.cshort_spec))
+
         # Default name for directory is spack-mirror-<DATESTAMP>
         directory = args.directory
         if not directory:
@@ -199,11 +207,7 @@ def mirror_create(args):
             directory = 'spack-mirror-' + timestamp
 
         # Make sure nothing is in the way.
-        existed = False
-        if os.path.isfile(directory):
-            tty.error("%s already exists and is a file." % directory)
-        elif os.path.isdir(directory):
-            existed = True
+        existed = os.path.isdir(directory)
 
         # Actually do the work to create the mirror
         present, mirrored, error = spack.mirror.create(

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -1,0 +1,38 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+import pytest
+
+from spack.main import SpackCommand
+
+mirror = SpackCommand('mirror')
+
+
+@pytest.mark.disable_clean_stage_check
+@pytest.mark.regression('8083')
+def test_regression_8083(tmpdir, capfd, mock_packages, mock_fetch, config):
+    with capfd.disabled():
+        output = mirror('create', '-d', str(tmpdir), 'externaltool')
+    assert 'Skipping' in output
+    assert 'as it is an external spec' in output


### PR DESCRIPTION
fixes #8083

External specs are supposed to be already installed somewhere, so there's no need to try to download a tarball for them.