### PR TITLE
Remove all imports from __init__.py

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -111,28 +111,6 @@ apidoc_args = [
 sphinx_apidoc(apidoc_args + ['../spack'])
 sphinx_apidoc(apidoc_args + ['../llnl'])
 
-#
-# Exclude everything in spack.__all__ from indexing.  All of these
-# symbols are imported from elsewhere in spack; their inclusion in
-# __all__ simply allows package authors to use `from spack import *`.
-# Excluding them ensures they're only documented in their "real" module.
-#
-# This also avoids issues where some of these symbols shadow core spack
-# modules.  Sphinx will complain about duplicate docs when this happens.
-#
-import fileinput
-handling_spack = False
-for line in fileinput.input('spack.rst', inplace=1):
-    if handling_spack:
-        if not line.startswith('    :noindex:'):
-            print('    :noindex: %s' % ' '.join(spack.__all__))
-        handling_spack = False
-
-    if line.startswith('.. automodule::'):
-        handling_spack = (line == '.. automodule:: spack\n')
-
-    sys.stdout.write(line)
-
 # Enable todo items
 todo_include_todos = True
 

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 ##############################################################################
 # Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.
@@ -30,78 +29,4 @@ spack_version_info = (0, 11, 2)
 #: String containing Spack version joined with .'s
 spack_version = '.'.join(str(v) for v in spack_version_info)
 
-
-#-----------------------------------------------------------------------------
-# When packages call 'from spack import *', we import a set of things that
-# should be useful for builds.
-#-----------------------------------------------------------------------------
-__all__ = []
-
-from spack.package import Package, run_before, run_after, on_package_attributes
-from spack.build_systems.makefile import MakefilePackage
-from spack.build_systems.aspell_dict import AspellDictPackage
-from spack.build_systems.autotools import AutotoolsPackage
-from spack.build_systems.cmake import CMakePackage
-from spack.build_systems.cuda import CudaPackage
-from spack.build_systems.qmake import QMakePackage
-from spack.build_systems.scons import SConsPackage
-from spack.build_systems.waf import WafPackage
-from spack.build_systems.octave import OctavePackage
-from spack.build_systems.python import PythonPackage
-from spack.build_systems.r import RPackage
-from spack.build_systems.perl import PerlPackage
-from spack.build_systems.intel import IntelPackage
-
-__all__ += [
-    'run_before',
-    'run_after',
-    'on_package_attributes',
-    'Package',
-    'MakefilePackage',
-    'AspellDictPackage',
-    'AutotoolsPackage',
-    'CMakePackage',
-    'CudaPackage',
-    'QMakePackage',
-    'SConsPackage',
-    'WafPackage',
-    'OctavePackage',
-    'PythonPackage',
-    'RPackage',
-    'PerlPackage',
-    'IntelPackage',
-]
-
-from spack.mixins import filter_compiler_wrappers
-__all__ += ['filter_compiler_wrappers']
-
-from spack.version import Version, ver
-__all__ += ['Version', 'ver']
-
-from spack.spec import Spec
-__all__ += ['Spec']
-
-from spack.dependency import all_deptypes
-__all__ += ['all_deptypes']
-
-from spack.multimethod import when
-__all__ += ['when']
-
-import llnl.util.filesystem
-from llnl.util.filesystem import *
-__all__ += llnl.util.filesystem.__all__
-
-import spack.directives
-from spack.directives import *
-__all__ += spack.directives.__all__
-
-import spack.util.executable
-from spack.util.executable import *
-__all__ += spack.util.executable.__all__
-
-from spack.package import \
-    install_dependency_symlinks, flatten_dependencies, \
-    DependencyConflictError, InstallError, ExternalPackageError
-__all__ += [
-    'install_dependency_symlinks', 'flatten_dependencies',
-    'DependencyConflictError', 'InstallError', 'ExternalPackageError']
+__all__ = ['spack_version_info', 'spack_version']

--- a/lib/spack/spack/abi.py
+++ b/lib/spack/spack/abi.py
@@ -26,7 +26,6 @@ import os
 
 from llnl.util.lang import memoized
 
-import spack
 import spack.spec
 from spack.build_environment import dso_suffix
 from spack.spec import CompilerSpec

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -22,7 +22,6 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-
 import os
 import re
 import tarfile
@@ -37,7 +36,6 @@ import yaml
 import llnl.util.tty as tty
 from llnl.util.filesystem import mkdirp, install_tree
 
-import spack
 import spack.cmd
 import spack.fetch_strategy as fs
 import spack.util.gpg as gpg_util

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -65,6 +65,7 @@ import llnl.util.tty as tty
 from llnl.util.tty.color import colorize
 from llnl.util.filesystem import mkdirp, install, install_tree
 
+import spack.build_systems.cmake
 import spack.config
 import spack.main
 import spack.paths
@@ -374,7 +375,7 @@ def set_module_variables_for_package(pkg, module):
     m.ctest = Executable('ctest')
 
     # Standard CMake arguments
-    m.std_cmake_args = spack.CMakePackage._std_args(pkg)
+    m.std_cmake_args = spack.build_systems.cmake.CMakePackage._std_args(pkg)
 
     # Put spack compiler paths in module scope.
     link_dir = spack.paths.build_env_path
@@ -540,7 +541,7 @@ def get_std_cmake_args(pkg):
     Returns:
         list of str: arguments for cmake
     """
-    return spack.CMakePackage._std_args(pkg)
+    return spack.build_systems.cmake.CMakePackage._std_args(pkg)
 
 
 def parent_class_modules(cls):

--- a/lib/spack/spack/cmd/activate.py
+++ b/lib/spack/spack/cmd/activate.py
@@ -23,8 +23,9 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import argparse
+
 import llnl.util.tty as tty
-import spack
+
 import spack.cmd
 from spack.directory_layout import YamlViewExtensionsLayout
 

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -28,10 +28,10 @@ import os
 import re
 
 import llnl.util.tty as tty
-import spack
+from llnl.util.filesystem import mkdirp
+
 import spack.cmd
 import spack.util.web
-from llnl.util.filesystem import mkdirp
 import spack.repo
 from spack.spec import Spec
 from spack.util.executable import which, ProcessError

--- a/lib/spack/spack/cmd/deactivate.py
+++ b/lib/spack/spack/cmd/deactivate.py
@@ -25,7 +25,6 @@
 import argparse
 import llnl.util.tty as tty
 
-import spack
 import spack.cmd
 import spack.store
 from spack.directory_layout import YamlViewExtensionsLayout

--- a/lib/spack/spack/cmd/python.py
+++ b/lib/spack/spack/cmd/python.py
@@ -30,7 +30,6 @@ import platform
 
 import spack
 
-
 description = "launch an interpreter as spack would launch a command"
 section = "developer"
 level = "long"

--- a/lib/spack/spack/cmd/reindex.py
+++ b/lib/spack/spack/cmd/reindex.py
@@ -22,10 +22,9 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-import spack
 import spack.store
-description = "rebuild Spack's package database"
 
+description = "rebuild Spack's package database"
 section = "admin"
 level = "long"
 

--- a/lib/spack/spack/cmd/setup.py
+++ b/lib/spack/spack/cmd/setup.py
@@ -33,6 +33,7 @@ from llnl.util.filesystem import set_executable
 
 import spack.repo
 import spack.store
+import spack.build_systems.cmake
 import spack.cmd
 import spack.cmd.install as install
 import spack.cmd.common.arguments as arguments
@@ -147,7 +148,7 @@ def setup(self, args):
 
         spec.concretize()
         package = spack.repo.get(spec)
-        if not isinstance(package, spack.CMakePackage):
+        if not isinstance(package, spack.build_systems.cmake.CMakePackage):
             tty.die(
                 'Support for {0} derived packages not yet implemented'.format(
                     package.build_system_class))

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -25,7 +25,7 @@
 from __future__ import print_function
 
 import argparse
-import spack
+
 import spack.cmd
 import spack.cmd.common.arguments as arguments
 

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -26,7 +26,6 @@ from __future__ import print_function
 
 import argparse
 
-import spack
 import spack.cmd
 import spack.store
 import spack.repo

--- a/lib/spack/spack/cmd/view.py
+++ b/lib/spack/spack/cmd/view.py
@@ -52,13 +52,14 @@ All operations on views are performed via proxy objects such as
 YamlFilesystemView.
 
 '''
-
 import os
-import spack
+
+import llnl.util.tty as tty
+
 import spack.cmd
 import spack.store
 from spack.filesystem_view import YamlFilesystemView
-import llnl.util.tty as tty
+
 
 description = "produce a single-rooted directory view of packages"
 section = "environment"

--- a/lib/spack/spack/dependency.py
+++ b/lib/spack/spack/dependency.py
@@ -26,7 +26,7 @@
 """
 from six import string_types
 
-import spack
+import spack.spec
 
 
 #: The types of dependency relationships that Spack understands.

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -55,16 +55,14 @@ from six import string_types
 
 import llnl.util.lang
 
-import spack
 import spack.error
 import spack.spec
 import spack.url
+import spack.variant
 from spack.dependency import Dependency, default_deptype, canonical_deptype
 from spack.fetch_strategy import from_kwargs
 from spack.patch import Patch
 from spack.resource import Resource
-from spack.spec import Spec, parse_anonymous_spec
-from spack.variant import Variant
 from spack.version import Version
 
 __all__ = []
@@ -265,9 +263,9 @@ def _depends_on(pkg, spec, when=None, type=default_deptype, patches=None):
     # If when is None or True make sure the condition is always satisfied
     if when is None or when is True:
         when = pkg.name
-    when_spec = parse_anonymous_spec(when, pkg.name)
+    when_spec = spack.spec.parse_anonymous_spec(when, pkg.name)
 
-    dep_spec = Spec(spec)
+    dep_spec = spack.spec.Spec(spec)
     if pkg.name == dep_spec.name:
         raise CircularReferenceError(
             "Package '%s' cannot depend on itself." % pkg.name)
@@ -328,7 +326,7 @@ def conflicts(conflict_spec, when=None, msg=None):
     def _execute_conflicts(pkg):
         # If when is not specified the conflict always holds
         condition = pkg.name if when is None else when
-        when_spec = parse_anonymous_spec(condition, pkg.name)
+        when_spec = spack.spec.parse_anonymous_spec(condition, pkg.name)
 
         # Save in a list the conflicts and the associated custom messages
         when_spec_list = pkg.conflicts.setdefault(conflict_spec, [])
@@ -382,7 +380,7 @@ def extends(spec, **kwargs):
 
         when = kwargs.get('when', pkg.name)
         _depends_on(pkg, spec, when=when)
-        pkg.extendees[spec] = (Spec(spec), kwargs)
+        pkg.extendees[spec] = (spack.spec.Spec(spec), kwargs)
     return _execute_extends
 
 
@@ -394,7 +392,7 @@ def provides(*specs, **kwargs):
     """
     def _execute_provides(pkg):
         spec_string = kwargs.get('when', pkg.name)
-        provider_spec = parse_anonymous_spec(spec_string, pkg.name)
+        provider_spec = spack.spec.parse_anonymous_spec(spec_string, pkg.name)
 
         for string in specs:
             for provided_spec in spack.spec.parse(string):
@@ -431,7 +429,8 @@ def patch(url_or_filename, level=1, when=None, working_dir=".", **kwargs):
     """
     def _execute_patch(pkg_or_dep):
         constraint = pkg_or_dep.name if when is None else when
-        when_spec = parse_anonymous_spec(constraint, pkg_or_dep.name)
+        when_spec = spack.spec.parse_anonymous_spec(
+            constraint, pkg_or_dep.name)
 
         # if this spec is identical to some other, then append this
         # patch to the existing list.
@@ -491,7 +490,7 @@ def variant(
             msg = "Invalid variant name in {0}: '{1}'"
             raise DirectiveError(directive, msg.format(pkg.name, name))
 
-        pkg.variants[name] = Variant(
+        pkg.variants[name] = spack.variant.Variant(
             name, default, description, values, multi, validator
         )
     return _execute_variant
@@ -538,7 +537,7 @@ def resource(**kwargs):
             message += "\tdestination : '{dest}'\n".format(dest=destination)
             raise RuntimeError(message)
 
-        when_spec = parse_anonymous_spec(when, pkg.name)
+        when_spec = spack.spec.parse_anonymous_spec(when, pkg.name)
         resources = pkg.resources.setdefault(when_spec, [])
         name = kwargs.get('name')
         fetcher = from_kwargs(**kwargs)

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -31,7 +31,6 @@ import sys
 from llnl.util.link_tree import LinkTree
 from llnl.util import tty
 
-import spack
 import spack.spec
 import spack.store
 from spack.directory_layout import ExtensionAlreadyInstalledError

--- a/lib/spack/spack/hooks/licensing.py
+++ b/lib/spack/spack/hooks/licensing.py
@@ -24,9 +24,10 @@
 ##############################################################################
 import os
 
-import spack
 import llnl.util.tty as tty
 from llnl.util.filesystem import mkdirp
+
+from spack.util.editor import editor
 
 
 def pre_install(spec):
@@ -55,7 +56,7 @@ def set_up_license(pkg):
             # Create a new license file
             write_license_file(pkg, license_path)
             # Open up file in user's favorite $EDITOR for editing
-            spack.editor(license_path)
+            editor(license_path)
             tty.msg("Added global license file %s" % license_path)
         else:
             # Use already existing license file

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -42,6 +42,8 @@ from llnl.util.tty.log import log_output
 
 import spack
 import spack.config
+import spack.cmd
+import spack.hooks
 import spack.paths
 import spack.repo
 import spack.util.debug

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -58,6 +58,7 @@ import spack.paths
 import spack.store
 import spack.compilers
 import spack.directives
+import spack.directory_layout
 import spack.error
 import spack.fetch_strategy as fs
 import spack.hooks
@@ -75,7 +76,6 @@ from llnl.util.lang import memoized
 from llnl.util.link_tree import LinkTree
 from llnl.util.tty.log import log_output
 from llnl.util.tty.color import colorize
-from spack import directory_layout
 from spack.util.executable import which
 from spack.stage import Stage, ResourceStage, StageComposite
 from spack.util.environment import dump_environment
@@ -1581,7 +1581,7 @@ class PackageBase(with_metaclass(PackageMeta, object)):
             spack.store.db.add(
                 self.spec, spack.store.layout, explicit=explicit
             )
-        except directory_layout.InstallDirectoryAlreadyExistsError:
+        except spack.directory_layout.InstallDirectoryAlreadyExistsError:
             # Abort install if install directory exists.
             # But do NOT remove it (you'd be overwriting someone else's stuff)
             tty.warn("Keeping existing install prefix in place.")

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -27,7 +27,6 @@ import os.path
 import inspect
 import hashlib
 
-import spack
 import spack.error
 import spack.fetch_strategy as fs
 import spack.stage

--- a/lib/spack/spack/pkgkit.py
+++ b/lib/spack/spack/pkgkit.py
@@ -1,0 +1,66 @@
+# flake8: noqa: F401
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+"""pkgkit is a set of useful build tools and directives for packages.
+
+Everything in this module is automatically imported into Spack package files.
+"""
+import llnl.util.filesystem
+from llnl.util.filesystem import *
+
+from spack.package import Package, run_before, run_after, on_package_attributes
+from spack.build_systems.makefile import MakefilePackage
+from spack.build_systems.aspell_dict import AspellDictPackage
+from spack.build_systems.autotools import AutotoolsPackage
+from spack.build_systems.cmake import CMakePackage
+from spack.build_systems.cuda import CudaPackage
+from spack.build_systems.qmake import QMakePackage
+from spack.build_systems.scons import SConsPackage
+from spack.build_systems.waf import WafPackage
+from spack.build_systems.octave import OctavePackage
+from spack.build_systems.python import PythonPackage
+from spack.build_systems.r import RPackage
+from spack.build_systems.perl import PerlPackage
+from spack.build_systems.intel import IntelPackage
+
+from spack.mixins import filter_compiler_wrappers
+
+from spack.version import Version, ver
+
+from spack.spec import Spec
+
+from spack.dependency import all_deptypes
+
+from spack.multimethod import when
+
+import spack.directives
+from spack.directives import *
+
+import spack.util.executable
+from spack.util.executable import *
+
+from spack.package import \
+    install_dependency_symlinks, flatten_dependencies, \
+    DependencyConflictError, InstallError, ExternalPackageError

--- a/lib/spack/spack/provider_index.py
+++ b/lib/spack/spack/provider_index.py
@@ -29,11 +29,9 @@ from itertools import product as iproduct
 from six import iteritems
 from pprint import pformat
 
+import spack.error
 import spack.util.spack_yaml as syaml
 from yaml.error import MarkedYAMLError
-
-import spack
-import spack.error
 
 
 class ProviderIndex(object):

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -50,7 +50,6 @@ import llnl.util.lang
 import llnl.util.tty as tty
 from llnl.util.filesystem import mkdirp, install
 
-import spack
 import spack.config
 import spack.caches
 import spack.error

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -32,6 +32,7 @@ import inspect
 import imp
 import re
 import traceback
+import tempfile
 import json
 from contextlib import contextmanager
 from six import string_types
@@ -59,10 +60,8 @@ from spack.util.path import canonicalize_path
 from spack.util.naming import NamespaceTrie, valid_module_name
 from spack.util.naming import mod_to_class, possible_spack_module_names
 
-#
-# Super-namespace for all packages.
-# Package modules are imported as spack.pkg.<namespace>.<pkg-name>.
-#
+#: Super-namespace for all packages.
+#: Package modules are imported as spack.pkg.<namespace>.<pkg-name>.
 repo_namespace     = 'spack.pkg'
 
 #
@@ -73,8 +72,24 @@ repo_index_name    = 'index.yaml'  # Top-level filename for repository index.
 packages_dir_name  = 'packages'    # Top-level repo directory containing pkgs.
 package_file_name  = 'package.py'  # Filename for packages in a repository.
 
-# Guaranteed unused default value for some functions.
+#: Guaranteed unused default value for some functions.
 NOT_PROVIDED = object()
+
+#: Code in ``_package_prepend`` is prepended to imported packages.
+#:
+#: Spack packages were originally expected to call `from spack import *`
+#: themselves, but it became difficult to manage and imports in the Spack
+#: core the top-level namespace polluted by package symbols this way.  To
+#: solve this, the top-level ``spack`` package contains very few symbols
+#: of its own, and importing ``*`` is essentially a no-op.  The common
+#: routines and directives that packages need are now in ``spack.pkgkit``,
+#: and the import system forces packages to automatically include
+#: this. This way, old packages that call ``from spack import *`` will
+#: continue to work without modification, but it's no longer required.
+#:
+#: TODO: At some point in the future, consider removing ``from spack import *``
+#: TODO: from packages and shifting to from ``spack.pkgkit import *``
+_package_prepend = 'from spack.pkgkit import *'
 
 
 def _autospec(function):
@@ -118,8 +133,7 @@ class FastPackageChecker(Mapping):
     _paths_cache = {}
 
     def __init__(self, packages_path):
-
-        #: The path of the repository managed by this instance
+        # The path of the repository managed by this instance
         self.packages_path = packages_path
 
         # If the cache we need is not there yet, then build it appropriately
@@ -976,7 +990,9 @@ class Repo(object):
             fullname = "%s.%s" % (self.full_namespace, pkg_name)
 
             try:
-                module = imp.load_source(fullname, file_path)
+                with import_lock():
+                    with prepend_open(file_path, text=_package_prepend) as f:
+                        module = imp.load_source(fullname, file_path, f)
             except SyntaxError as e:
                 # SyntaxError strips the path from the filename so we need to
                 # manually construct the error message in order to give the
@@ -1124,6 +1140,31 @@ def set_path(repo):
     if append:
         sys.meta_path.append(repo)
     return append
+
+
+@contextmanager
+def import_lock():
+    imp.acquire_lock()
+    yield
+    imp.release_lock()
+
+
+@contextmanager
+def prepend_open(f, *args, **kwargs):
+    """Open a file for reading, but prepend with some text prepended
+
+    Arguments are same as for ``open()``, with one keyword argument,
+    ``text``, specifying the text to prepend.
+    """
+    text = kwargs.get('text', None)
+
+    with open(f, *args) as f:
+        with tempfile.NamedTemporaryFile(mode='w+') as tf:
+            if text:
+                tf.write(text + '\n')
+            tf.write(f.read())
+            tf.seek(0)
+            yield tf.file
 
 
 @contextmanager

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -28,7 +28,7 @@
 import itertools
 import os
 import platform as py_platform
-import spack
+
 import spack.architecture
 from spack.spec import Spec
 from spack.platforms.cray import Cray

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -22,8 +22,6 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-
-import spack
 import pytest
 
 import spack.repo

--- a/lib/spack/spack/test/cmd/dependencies.py
+++ b/lib/spack/spack/test/cmd/dependencies.py
@@ -23,12 +23,11 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import re
-
 import pytest
 
 from llnl.util.tty.color import color_when
 
-import spack
+import spack.store
 from spack.main import SpackCommand
 
 dependencies = SpackCommand('dependencies')

--- a/lib/spack/spack/test/cmd/dependents.py
+++ b/lib/spack/spack/test/cmd/dependents.py
@@ -28,7 +28,7 @@ import pytest
 
 from llnl.util.tty.color import color_when
 
-import spack
+import spack.store
 from spack.main import SpackCommand
 
 dependents = SpackCommand('dependents')

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -31,7 +31,6 @@ import pytest
 
 import llnl.util.filesystem as fs
 
-import spack
 import spack.config
 import spack.package
 import spack.cmd.install

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -26,7 +26,6 @@
 These tests check Spec DAG operations using dummy packages.
 """
 import pytest
-import spack
 import spack.architecture
 import spack.package
 

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -25,7 +25,7 @@
 import pytest
 import shlex
 
-import spack
+import spack.store
 import spack.spec as sp
 from spack.parse import Token
 from spack.spec import Spec, parse, parse_anonymous_spec

--- a/lib/spack/spack/test/test_activations.py
+++ b/lib/spack/spack/test/test_activations.py
@@ -25,7 +25,7 @@
 import os
 import pytest
 
-import spack
+import spack.spec
 from spack.directory_layout import YamlDirectoryLayout
 from spack.filesystem_view import YamlFilesystemView
 

--- a/lib/spack/spack/util/package_hash.py
+++ b/lib/spack/spack/util/package_hash.py
@@ -22,14 +22,15 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-import spack.repo
-from spack import directives
-from spack.error import SpackError
-from spack.spec import Spec
-from spack.util.naming import mod_to_class
-
 import ast
 import hashlib
+
+import spack.repo
+import spack.package
+import spack.directives
+import spack.error
+import spack.spec
+import spack.util.naming
 
 
 class RemoveDocstrings(ast.NodeTransformer):
@@ -61,15 +62,15 @@ class RemoveDirectives(ast.NodeTransformer):
     def is_directive(self, node):
         return (isinstance(node, ast.Expr) and
                 node.value and isinstance(node.value, ast.Call) and
-                node.value.func.id in directives.__all__)
+                node.value.func.id in spack.directives.__all__)
 
     def is_spack_attr(self, node):
         return (isinstance(node, ast.Assign) and
                 node.targets and isinstance(node.targets[0], ast.Name) and
-                node.targets[0].id in spack.Package.metadata_attrs)
+                node.targets[0].id in spack.package.Package.metadata_attrs)
 
     def visit_ClassDef(self, node):
-        if node.name == mod_to_class(self.spec.name):
+        if node.name == spack.util.naming.mod_to_class(self.spec.name):
             node.body = [
                 c for c in node.body
                 if (not self.is_directive(c) and not self.is_spack_attr(c))]
@@ -129,7 +130,7 @@ def package_hash(spec, content=None):
 
 
 def package_ast(spec):
-    spec = Spec(spec)
+    spec = spack.spec.Spec(spec)
 
     filename = spack.repo.path.filename_for_package_name(spec.name)
     with open(filename) as f:
@@ -147,5 +148,5 @@ def package_ast(spec):
     return root
 
 
-class PackageHashError(SpackError):
+class PackageHashError(spack.error.SpackError):
     """Raised for all errors encountered during package hashing."""

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -29,11 +29,12 @@ variants both in packages and in specs.
 import functools
 import inspect
 import re
+from six import StringIO
 
 import llnl.util.lang as lang
-import spack
+
+import spack.directives
 import spack.error as error
-from six import StringIO
 
 
 class Variant(object):


### PR DESCRIPTION
This is based on and depends on #7774.  Merge it after.

This removes all imports from `__init__.py`, allowing the Spack core to be more modular.

Spack packages were originally expected to call `from spack import *` themselves, but it has become difficult to manage imports in the core.

- The top-level namespace polluted by package symbols, and it's not possible to avoid circular dependencies and unnecessary module loads in the core, given all the stuff the packages need.

- This makes the top-level `spack` package essentially empty, save for a version tuple and a version string, and `from spack import *` is now essentially a no-op.  That means when you import `spack.repo`, you _aren't_ importing a bunch of other things from `spack` that you don't need.

- The imports formerly in `spack` are now in `spack.pkgkit`, and the import system (in `spack.repo`) forces packages to automatically include this so that old packages that call `from spack import *` will continue to work without modification.

This basically means that packages *do not* need to write `from spack import *` at the top anymore.  It's a no-op.  We could consider removing ``from spack import *`` from packages in the future and shifting to ``from spack.pkgkit import *``, but we can wait a while to do this.