### PR TITLE
llvm: replace @when with internal check in @run_before

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -415,9 +415,10 @@ class Llvm(CMakePackage):
     # Github issue #4986
     patch('llvm_gcc7.patch', when='@4.0.0:4.0.1+lldb %gcc@7.0:')
 
-    @when('+lldb platform=darwin')
     @run_before('cmake')
     def check_darwin_lldb_codesign_requirement(self):
+        if not self.spec.satisfies('+lldb platform=darwin'):
+            return
         codesign = which('codesign')
         cp = which('cp')
         mkdir('tmp')


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/8088

https://github.com/spack/spack/pull/7012 added a `@when` condition for a `@run_before` check to constrain that check to only run on Darwin. Spack doesn't appear to support the combination of `@when` and `@run_before` (or `@run_after`). This replaces the external decorator with a check that executes at the beginning of the function.