### PR TITLE
Add cmake for newer version of libjpeg-turbo

### DIFF
--- a/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
+++ b/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
@@ -52,9 +52,9 @@ class LibjpegTurbo(Package):
     
     @when('@:1.5.3')	
     def install(self, spec, prefix):
-         configure('--prefix=%s' % prefix)
-         make
-	 make('install')
+	configure('--prefix=%s' % prefix)
+        make
+	make('install')
 
     @when('@1.5.90:')
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
+++ b/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
@@ -24,6 +24,7 @@
 ##############################################################################
 from spack import *
 
+#https://github.com/libjpeg-turbo/libjpeg-turbo/blob/master/BUILDING.md
 
 class LibjpegTurbo(Package):
     """libjpeg-turbo is a fork of the original IJG libjpeg which uses SIMD to
@@ -63,4 +64,3 @@ class LibjpegTurbo(Package):
     		cmake('..', *cmake_args)
     	        make
 		make('install')
-

--- a/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
+++ b/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
@@ -24,21 +24,20 @@
 ##############################################################################
 from spack import *
 
-#https://github.com/libjpeg-turbo/libjpeg-turbo/blob/master/BUILDING.md
 
 class LibjpegTurbo(Package):
     """libjpeg-turbo is a fork of the original IJG libjpeg which uses SIMD to
        accelerate baseline JPEG compression and decompression. libjpeg is a
        library that implements JPEG image encoding, decoding and
        transcoding."""
-
+    #https://github.com/libjpeg-turbo/libjpeg-turbo/blob/master/BUILDING.md
     homepage = "https://github.com/libjpeg-turbo/libjpeg-turbo"
     url      = "https://github.com/libjpeg-turbo/libjpeg-turbo/archive/1.5.90.tar.gz"
 
     version('1.5.90', '85f7f9c377b70cbf48e61726097d4efa')
-    version('1.5.3' , '7c82f0f6a3130ec06b8a4d0b321cbca3')
-    version('1.5.0' , '3fc5d9b6a8bce96161659ae7a9939257')
-    version('1.3.1' , '2c3a68129dac443a72815ff5bb374b05')
+    version('1.5.3', '7c82f0f6a3130ec06b8a4d0b321cbca3')
+    version('1.5.0', '3fc5d9b6a8bce96161659ae7a9939257')
+    version('1.3.1', '2c3a68129dac443a72815ff5bb374b05')
 
     provides('jpeg')
 
@@ -48,12 +47,13 @@ class LibjpegTurbo(Package):
     # TODO: Implement the selection between two supported assemblers.
     # depends_on("yasm", type='build')
     depends_on("nasm", type='build')
-    depends_on('cmake',type= 'build', when="@1.5.90:")
+    depends_on('cmake',type='build',when="@1.5.90:")
     
-    @when('@:1.5.3')	
+
+    @when('@:1.5.3')
     def install(self, spec, prefix):
 	configure('--prefix=%s' % prefix)
-        make
+	make
 	make('install')
 
     @when('@1.5.90:')
@@ -63,4 +63,4 @@ class LibjpegTurbo(Package):
     	with working_dir('spack-build', create=True):
     		cmake('..', *cmake_args)
     	        make
-		make('install')
+		make('install')			

--- a/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
+++ b/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
@@ -52,7 +52,7 @@ class LibjpegTurbo(Package):
     @when('@:1.5.3')
     def install(self, spec, prefix):
         configure('--prefix=%s' % prefix)
-        make
+        make()
         make('install')
 
     @when('@1.5.90:')
@@ -61,5 +61,5 @@ class LibjpegTurbo(Package):
         cmake_args.extend(std_cmake_args)
         with working_dir('spack-build', create=True):
             cmake('..', *cmake_args)
-            make
+            make()
             make('install')

--- a/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
+++ b/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
@@ -51,15 +51,15 @@ class LibjpegTurbo(Package):
 
     @when('@:1.5.3')
     def install(self, spec, prefix):
-	configure('--prefix=%s' % prefix)
-	make
-	make('install')
-	
+        configure('--prefix=%s' % prefix)
+        make
+        make('install')
+
     @when('@1.5.90:')
     def install(self, spec, prefix):
-    	cmake_args = ['-GUnix Makefiles']
-    	cmake_args.extend(std_cmake_args)
-    	with working_dir('spack-build', create=True):
-    		cmake('..', *cmake_args)
-    	        make
-		make('install')
+        cmake_args = ['-GUnix Makefiles']
+        cmake_args.extend(std_cmake_args)
+        with working_dir('spack-build', create=True):
+            cmake('..', *cmake_args)
+            make
+            make('install')

--- a/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
+++ b/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
@@ -31,7 +31,7 @@ class LibjpegTurbo(Package):
        library that implements JPEG image encoding, decoding and
        transcoding."""
     # https://github.com/libjpeg-turbo/libjpeg-turbo/blob/master/BUILDING.md
-    homepage = "https://github.com/libjpeg-turbo/libjpeg-turbo"
+    homepage = "https://libjpeg-turbo.org/"
     url      = "https://github.com/libjpeg-turbo/libjpeg-turbo/archive/1.5.90.tar.gz"
 
     version('1.5.90', '85f7f9c377b70cbf48e61726097d4efa')

--- a/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
+++ b/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
@@ -25,18 +25,19 @@
 from spack import *
 
 
-class LibjpegTurbo(AutotoolsPackage):
+class LibjpegTurbo(Package):
     """libjpeg-turbo is a fork of the original IJG libjpeg which uses SIMD to
        accelerate baseline JPEG compression and decompression. libjpeg is a
        library that implements JPEG image encoding, decoding and
        transcoding."""
 
-    homepage = "http://libjpeg-turbo.virtualgl.org"
-    url      = "https://sourceforge.net/projects/libjpeg-turbo/files/1.5.3/libjpeg-turbo-1.5.3.tar.gz"
+    homepage = "https://github.com/libjpeg-turbo/libjpeg-turbo"
+    url      = "https://github.com/libjpeg-turbo/libjpeg-turbo/archive/1.5.90.tar.gz"
 
-    version('1.5.3', '7c82f0f6a3130ec06b8a4d0b321cbca3')
-    version('1.5.0', '3fc5d9b6a8bce96161659ae7a9939257')
-    version('1.3.1', '2c3a68129dac443a72815ff5bb374b05')
+    version('1.5.90', '85f7f9c377b70cbf48e61726097d4efa')
+    version('1.5.3' , '7c82f0f6a3130ec06b8a4d0b321cbca3')
+    version('1.5.0' , '3fc5d9b6a8bce96161659ae7a9939257')
+    version('1.3.1' , '2c3a68129dac443a72815ff5bb374b05')
 
     provides('jpeg')
 
@@ -46,3 +47,20 @@ class LibjpegTurbo(AutotoolsPackage):
     # TODO: Implement the selection between two supported assemblers.
     # depends_on("yasm", type='build')
     depends_on("nasm", type='build')
+    depends_on('cmake',type= 'build', when="@1.5.90:")
+    
+    @when('@:1.5.3')	
+    def install(self, spec, prefix):
+         configure('--prefix=%s' % prefix)
+         make
+	 make('install')
+
+    @when('@1.5.90:')
+    def install(self, spec, prefix):
+    	cmake_args = ['-GUnix Makefiles']
+    	cmake_args.extend(std_cmake_args)
+    	with working_dir('spack-build', create=True):
+    		cmake('..', *cmake_args)
+    	        make
+		make('install')
+

--- a/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
+++ b/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
@@ -30,7 +30,7 @@ class LibjpegTurbo(Package):
        accelerate baseline JPEG compression and decompression. libjpeg is a
        library that implements JPEG image encoding, decoding and
        transcoding."""
-    #https://github.com/libjpeg-turbo/libjpeg-turbo/blob/master/BUILDING.md
+    # https://github.com/libjpeg-turbo/libjpeg-turbo/blob/master/BUILDING.md
     homepage = "https://github.com/libjpeg-turbo/libjpeg-turbo"
     url      = "https://github.com/libjpeg-turbo/libjpeg-turbo/archive/1.5.90.tar.gz"
 
@@ -47,15 +47,14 @@ class LibjpegTurbo(Package):
     # TODO: Implement the selection between two supported assemblers.
     # depends_on("yasm", type='build')
     depends_on("nasm", type='build')
-    depends_on('cmake',type='build',when="@1.5.90:")
-    
+    depends_on('cmake', type='build', when="@1.5.90:")
 
     @when('@:1.5.3')
     def install(self, spec, prefix):
 	configure('--prefix=%s' % prefix)
 	make
 	make('install')
-
+	
     @when('@1.5.90:')
     def install(self, spec, prefix):
     	cmake_args = ['-GUnix Makefiles']
@@ -63,4 +62,4 @@ class LibjpegTurbo(Package):
     	with working_dir('spack-build', create=True):
     		cmake('..', *cmake_args)
     	        make
-		make('install')			
+		make('install')


### PR DESCRIPTION
Newer version uses of libjpeg-turbo uses cmake. 