### PR TITLE
boost: added the +numpy variant which enables building libboost_numpy

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -152,7 +152,7 @@ class Boost(Package):
     depends_on('mpi', when='+mpi')
     depends_on('bzip2', when='+iostreams')
     depends_on('zlib', when='+iostreams')
-    depends_on('py-numpy', when='+numpy')
+    depends_on('py-numpy', when='+numpy', type=('build', 'run'))
 
     conflicts('+taggedlayout', when='+versionedlayout')
     conflicts('+numpy', when='~python')

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -144,14 +144,18 @@ class Boost(Package):
             description="Augment library layout with versioned subdirs")
     variant('clanglibcpp', default=False,
             description='Compile with clang libc++ instead of libstdc++')
+    variant('numpy', default=False,
+            description='Build the Boost NumPy library (requires +python)')
 
     depends_on('icu4c', when='+icu')
     depends_on('python', when='+python')
     depends_on('mpi', when='+mpi')
     depends_on('bzip2', when='+iostreams')
     depends_on('zlib', when='+iostreams')
+    depends_on('py-numpy', when='+numpy')
 
     conflicts('+taggedlayout', when='+versionedlayout')
+    conflicts('+numpy', when='~python')
 
     # Patch fix from https://svn.boost.org/trac/boost/ticket/11856
     patch('boost_11856.patch', when='@1.60.0%gcc@4.4.7')


### PR DESCRIPTION
This PR adds the +numpy variant in the boost package.

The Boost.NumPy library is particular: it is not enabled by a build flag when building boost; it is instead enabled automatically when Boost.Python is built and boost detects that Numpy is present on the targeted Python installation. Hence the `+numpy` variant needs the `+python` variant to be active, and it depends on the `py-numpy` package.