### PR TITLE
Add dependencies for py-dask

### DIFF
--- a/var/spack/repos/builtin/packages/py-cloudpickle/package.py
+++ b/var/spack/repos/builtin/packages/py-cloudpickle/package.py
@@ -25,22 +25,18 @@
 from spack import *
 
 
-class PyAttrs(PythonPackage):
-    """Classes Without Boilerplate"""
+class PyCloudpickle(PythonPackage):
+    """Extended pickling support for Python objects."""
 
-    homepage = "http://attrs.org/"
-    url      = "https://pypi.io/packages/source/a/attrs/attrs-18.1.0.tar.gz"
+    homepage = "https://github.com/cloudpipe/cloudpickle"
+    url      = "https://pypi.io/packages/source/c/cloudpickle/cloudpickle-0.5.2.tar.gz"
 
-    import_modules = ['attr']
+    import_modules = ['cloudpickle']
 
-    version('18.1.0', '3f3f3e0750dab74cfa1dc8b0fd7a5f86')
-    version('16.3.0', '4ec003c49360853cf935113d1ae56151')
+    version('0.5.2', 'd0f6fc27882f865f2eb185fb0a32c84b')
 
     depends_on('py-setuptools', type='build')
 
-    depends_on('py-coverage', type='test')
-    depends_on('py-hypothesis', type='test')
-    depends_on('py-pympler', type='test')
-    depends_on('py-pytest', type='test')
-    depends_on('py-six', type='test')
-    depends_on('py-zope-interface', type='test')
+    def test(self):
+        # PyPI tarball does not come with unit tests
+        pass

--- a/var/spack/repos/builtin/packages/py-dask/package.py
+++ b/var/spack/repos/builtin/packages/py-dask/package.py
@@ -26,10 +26,57 @@ from spack import *
 
 
 class PyDask(PythonPackage):
-    """Minimal task scheduling abstraction"""
+    """Dask is a flexible parallel computing library for analytics."""
+
     homepage = "https://github.com/dask/dask/"
-    url      = "https://pypi.io/packages/source/d/dask/dask-0.8.1.tar.gz"
+    url      = "https://pypi.io/packages/source/d/dask/dask-0.17.4.tar.gz"
 
-    version('0.8.1', '5dd8e3a3823b3bc62c9a6d192e2cb5b4')
+    version('0.17.4', '4a7b9c5d7ddf52639b1c6b9e8a68d146')
+    version('0.8.1',  '5dd8e3a3823b3bc62c9a6d192e2cb5b4')
 
-    depends_on('py-setuptools', type='build')
+    variant('array',       default=True, description='Install requirements for dask.array')
+    variant('bag',         default=True, description='Install requirements for dask.bag')
+    variant('dataframe',   default=True, description='Install requirements for dask.dataframe')
+    variant('delayed',     default=True, description='Install requirements for dask.delayed')
+
+    depends_on('py-setuptools',         type='build')
+    depends_on('py-pytest@3.1.0:',      type='test')
+    depends_on('py-requests',           type='test')
+
+    # Requirements for dask.array
+    depends_on('py-numpy@1.11.0:',      type=('build', 'run'), when='+array')
+    depends_on('py-toolz@0.7.3:',       type=('build', 'run'), when='+array')
+
+    # Requirements for dask.bag
+    depends_on('py-cloudpickle@0.2.1:', type=('build', 'run'), when='+bag')
+    depends_on('py-toolz@0.7.3:',       type=('build', 'run'), when='+bag')
+    depends_on('py-partd@0.3.8:',       type=('build', 'run'), when='+bag')
+
+    # Requirements for dask.dataframe
+    depends_on('py-numpy@1.11.0:',      type=('build', 'run'), when='+dataframe')
+    depends_on('py-pandas@0.19.0:',     type=('build', 'run'), when='+dataframe')
+    depends_on('py-toolz@0.7.3:',       type=('build', 'run'), when='+dataframe')
+    depends_on('py-partd@0.3.8:',       type=('build', 'run'), when='+dataframe')
+    depends_on('py-cloudpickle@0.2.1:', type=('build', 'run'), when='+dataframe')
+
+    # Requirements for dask.delayed
+    depends_on('py-toolz@0.7.3:',       type=('build', 'run'), when='+delayed')
+
+    @property
+    def import_modules(self):
+        modules = [
+            'dask', 'dask.bytes', 'dask.diagnostics', 'dask.store'
+        ]
+
+        if '+array' in self.spec:
+            modules.append('dask.array')
+
+        if '+bag' in self.spec:
+            modules.append('dask.bag')
+
+        if '+dataframe' in self.spec:
+            modules.extend([
+                'dask.dataframe', 'dask.dataframe.io', 'dask.dataframe.tseries'
+            ])
+
+        return modules

--- a/var/spack/repos/builtin/packages/py-locket/package.py
+++ b/var/spack/repos/builtin/packages/py-locket/package.py
@@ -25,22 +25,12 @@
 from spack import *
 
 
-class PyAttrs(PythonPackage):
-    """Classes Without Boilerplate"""
+class PyLocket(PythonPackage):
+    """File-based locks for Python for Linux and Windows."""
 
-    homepage = "http://attrs.org/"
-    url      = "https://pypi.io/packages/source/a/attrs/attrs-18.1.0.tar.gz"
+    homepage = "http://github.com/mwilliamson/locket.py"
+    url      = "https://pypi.io/packages/source/l/locket/locket-0.2.0.tar.gz"
 
-    import_modules = ['attr']
+    import_modules = ['locket']
 
-    version('18.1.0', '3f3f3e0750dab74cfa1dc8b0fd7a5f86')
-    version('16.3.0', '4ec003c49360853cf935113d1ae56151')
-
-    depends_on('py-setuptools', type='build')
-
-    depends_on('py-coverage', type='test')
-    depends_on('py-hypothesis', type='test')
-    depends_on('py-pympler', type='test')
-    depends_on('py-pytest', type='test')
-    depends_on('py-six', type='test')
-    depends_on('py-zope-interface', type='test')
+    version('0.2.0', 'fe870949c513d8f7079ba352463833ca')

--- a/var/spack/repos/builtin/packages/py-partd/package.py
+++ b/var/spack/repos/builtin/packages/py-partd/package.py
@@ -25,22 +25,16 @@
 from spack import *
 
 
-class PyAttrs(PythonPackage):
-    """Classes Without Boilerplate"""
+class PyPartd(PythonPackage):
+    """Key-value byte store with appendable values."""
 
-    homepage = "http://attrs.org/"
-    url      = "https://pypi.io/packages/source/a/attrs/attrs-18.1.0.tar.gz"
+    homepage = "http://github.com/dask/partd/"
+    url      = "https://pypi.io/packages/source/p/partd/partd-0.3.8.tar.gz"
 
-    import_modules = ['attr']
+    import_modules = ['partd']
 
-    version('18.1.0', '3f3f3e0750dab74cfa1dc8b0fd7a5f86')
-    version('16.3.0', '4ec003c49360853cf935113d1ae56151')
+    version('0.3.8', '554d0e6511c0df4c907f034858be847f')
 
     depends_on('py-setuptools', type='build')
-
-    depends_on('py-coverage', type='test')
-    depends_on('py-hypothesis', type='test')
-    depends_on('py-pympler', type='test')
-    depends_on('py-pytest', type='test')
-    depends_on('py-six', type='test')
-    depends_on('py-zope-interface', type='test')
+    depends_on('py-locket', type=('build', 'run'))
+    depends_on('py-toolz', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-pluggy/package.py
+++ b/var/spack/repos/builtin/packages/py-pluggy/package.py
@@ -25,22 +25,16 @@
 from spack import *
 
 
-class PyAttrs(PythonPackage):
-    """Classes Without Boilerplate"""
+class PyPluggy(PythonPackage):
+    """Plugin and hook calling mechanisms for python."""
 
-    homepage = "http://attrs.org/"
-    url      = "https://pypi.io/packages/source/a/attrs/attrs-18.1.0.tar.gz"
+    homepage = "https://github.com/pytest-dev/pluggy"
+    url      = "https://pypi.io/packages/source/p/pluggy/pluggy-0.6.0.tar.gz"
 
-    import_modules = ['attr']
+    import_modules = ['pluggy']
 
-    version('18.1.0', '3f3f3e0750dab74cfa1dc8b0fd7a5f86')
-    version('16.3.0', '4ec003c49360853cf935113d1ae56151')
+    version('0.6.0', 'ffdde7c3a5ba9a440404570366ffb6d5')
+
+    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
 
     depends_on('py-setuptools', type='build')
-
-    depends_on('py-coverage', type='test')
-    depends_on('py-hypothesis', type='test')
-    depends_on('py-pympler', type='test')
-    depends_on('py-pytest', type='test')
-    depends_on('py-six', type='test')
-    depends_on('py-zope-interface', type='test')

--- a/var/spack/repos/builtin/packages/py-py/package.py
+++ b/var/spack/repos/builtin/packages/py-py/package.py
@@ -26,16 +26,19 @@ from spack import *
 
 
 class PyPy(PythonPackage):
-    """library with cross-python path, ini-parsing, io, code, log facilities"""
+    """Library with cross-python path, ini-parsing, io, code, log facilities"""
 
     homepage = "http://pylib.readthedocs.io/en/latest/"
-    url      = "https://pypi.io/packages/source/p/py/py-1.4.33.tar.gz"
+    url      = "https://pypi.io/packages/source/p/py/py-1.5.3.tar.gz"
 
     import_modules = [
         'py', 'py._code', 'py._io', 'py._log', 'py._path', 'py._process',
     ]
 
+    version('1.5.3',  '667d37a148ad9fb81266492903f2d880')
     version('1.4.33', '15d7107cbb8b86593bf9afa16e56da65')
     version('1.4.31', '5d2c63c56dc3f2115ec35c066ecd582b')
+
+    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-pytest/package.py
+++ b/var/spack/repos/builtin/packages/py-pytest/package.py
@@ -29,23 +29,29 @@ class PyPytest(PythonPackage):
     """pytest: simple powerful testing with Python."""
 
     homepage = "http://pytest.org/"
-    url      = "https://pypi.io/packages/source/p/pytest/pytest-3.0.7.tar.gz"
+    url      = "https://pypi.io/packages/source/p/pytest/pytest-3.5.1.tar.gz"
 
     import_modules = [
         '_pytest', '_pytest.assertion', '_pytest._code',
-        '_pytest.vendored_packages', 'pytest'
+        '_pytest.mark', 'pytest'
     ]
 
+    version('3.5.1', 'ffd870ee3ca561695d2f916f0f0f3c0b')
     version('3.0.7', '89c60546507dc7eb6e9e40a6e9f720bd')
     version('3.0.2', '61dc36e65a6f6c11c53b1388e043a9f5')
+
+    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
 
     # Most Python packages only require setuptools as a build dependency.
     # However, pytest requires setuptools during runtime as well.
     depends_on('py-setuptools', type=('build', 'run'))
-    depends_on('py-py@1.4.29:', type=('build', 'run'))
-    depends_on('py-hypothesis@3.5.2:', type=('build', 'run'))
+    depends_on('py-py@1.5.0:', type=('build', 'run'))
+    depends_on('py-six@1.10.0:', type=('build', 'run'))
+    depends_on('py-attrs@17.4.0:', type=('build', 'run'))
+    depends_on('py-more-itertools@4.0.0:', type=('build', 'run'))
+    depends_on('py-pluggy@0.5:0.6', type=('build', 'run'))
+    depends_on('py-funcsigs', type=('build', 'run'), when='^python@:2')
 
-    # TODO: Add a 'test' deptype
-    # depends_on('py-nose', type='test')
-    # depends_on('py-mock', type='test')
-    # depends_on('py-requests', type='test')
+    depends_on('py-nose', type='test')
+    depends_on('py-mock', type='test')
+    depends_on('py-requests', type='test')

--- a/var/spack/repos/builtin/packages/py-toolz/package.py
+++ b/var/spack/repos/builtin/packages/py-toolz/package.py
@@ -25,22 +25,14 @@
 from spack import *
 
 
-class PyAttrs(PythonPackage):
-    """Classes Without Boilerplate"""
+class PyToolz(PythonPackage):
+    """A set of utility functions for iterators, functions, and dictionaries"""
 
-    homepage = "http://attrs.org/"
-    url      = "https://pypi.io/packages/source/a/attrs/attrs-18.1.0.tar.gz"
+    homepage = "http://github.com/pytoolz/toolz/"
+    url      = "https://pypi.io/packages/source/t/toolz/toolz-0.9.0.tar.gz"
 
-    import_modules = ['attr']
+    import_modules = ['toolz', 'tlz', 'toolz.curried', 'toolz.sandbox']
 
-    version('18.1.0', '3f3f3e0750dab74cfa1dc8b0fd7a5f86')
-    version('16.3.0', '4ec003c49360853cf935113d1ae56151')
+    version('0.9.0', '6fd07249389dd0b3bfe71d4282314328')
 
     depends_on('py-setuptools', type='build')
-
-    depends_on('py-coverage', type='test')
-    depends_on('py-hypothesis', type='test')
-    depends_on('py-pympler', type='test')
-    depends_on('py-pytest', type='test')
-    depends_on('py-six', type='test')
-    depends_on('py-zope-interface', type='test')

--- a/var/spack/repos/builtin/packages/py-zope-event/package.py
+++ b/var/spack/repos/builtin/packages/py-zope-event/package.py
@@ -25,22 +25,16 @@
 from spack import *
 
 
-class PyAttrs(PythonPackage):
-    """Classes Without Boilerplate"""
+class PyZopeEvent(PythonPackage):
+    """Very basic event publishing system."""
 
-    homepage = "http://attrs.org/"
-    url      = "https://pypi.io/packages/source/a/attrs/attrs-18.1.0.tar.gz"
+    homepage = "http://github.com/zopefoundation/zope.event"
+    url      = "https://pypi.io/packages/source/z/zope.event/zope.event-4.3.0.tar.gz"
 
-    import_modules = ['attr']
+    # FIXME: No idea why this import test fails.
+    # Maybe some kind of namespace issue?
+    # import_modules = ['zope.event']
 
-    version('18.1.0', '3f3f3e0750dab74cfa1dc8b0fd7a5f86')
-    version('16.3.0', '4ec003c49360853cf935113d1ae56151')
+    version('4.3.0', '8ca737960741c6fd112972f3313303bd')
 
     depends_on('py-setuptools', type='build')
-
-    depends_on('py-coverage', type='test')
-    depends_on('py-hypothesis', type='test')
-    depends_on('py-pympler', type='test')
-    depends_on('py-pytest', type='test')
-    depends_on('py-six', type='test')
-    depends_on('py-zope-interface', type='test')

--- a/var/spack/repos/builtin/packages/py-zope-interface/package.py
+++ b/var/spack/repos/builtin/packages/py-zope-interface/package.py
@@ -25,22 +25,24 @@
 from spack import *
 
 
-class PyAttrs(PythonPackage):
-    """Classes Without Boilerplate"""
+class PyZopeInterface(PythonPackage):
+    """This package provides an implementation of "object interfaces" for
+    Python. Interfaces are a mechanism for labeling objects as conforming to a
+    given API or contract. So, this package can be considered as implementation
+    of the Design By Contract methodology support in Python."""
 
-    homepage = "http://attrs.org/"
-    url      = "https://pypi.io/packages/source/a/attrs/attrs-18.1.0.tar.gz"
+    homepage = "https://github.com/zopefoundation/zope.interface"
+    url      = "https://pypi.io/packages/source/z/zope.interface/zope.interface-4.5.0.tar.gz"
 
-    import_modules = ['attr']
+    # FIXME: No idea why these import tests fail.
+    # Maybe some kind of namespace issue?
+    # import_modules = ['zope.interface', 'zope.interface.common']
 
-    version('18.1.0', '3f3f3e0750dab74cfa1dc8b0fd7a5f86')
-    version('16.3.0', '4ec003c49360853cf935113d1ae56151')
+    version('4.5.0', '7b669cd692d817772c61d2e3ad0f1e71')
+
+    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
 
     depends_on('py-setuptools', type='build')
-
+    depends_on('py-zope-event', type='test')
+    depends_on('py-nose', type='test')
     depends_on('py-coverage', type='test')
-    depends_on('py-hypothesis', type='test')
-    depends_on('py-pympler', type='test')
-    depends_on('py-pytest', type='test')
-    depends_on('py-six', type='test')
-    depends_on('py-zope-interface', type='test')


### PR DESCRIPTION
Fixes #8108. Closes #8110.

This PR adds missing dependencies to `py-dask`. Although these dependencies aren't required for the core library, they are used by most of the `dask` modules.

Successfully installed everything on macOS 10.13.4 with Clang 9.0.0. Most of the unit tests passed, although the unit tests for `dask` hung for some reason.

@s-sajid-ali @healther 