### PR TITLE
Remove upper limit of R version dependency

### DIFF
--- a/var/spack/repos/builtin/packages/r-biocgenerics/package.py
+++ b/var/spack/repos/builtin/packages/r-biocgenerics/package.py
@@ -35,4 +35,4 @@ class RBiocgenerics(RPackage):
     version('0.24.0', git='https://git.bioconductor.org/packages/BiocGenerics', commit='3db111e8c1f876267da89f4f0c5406a9d5c31cd1')
     version('0.22.1', git='https://git.bioconductor.org/packages/BiocGenerics', commit='9c90bb8926885289d596a81ff318ee3745cbb6ad')
 
-    depends_on('r@3.4.0:3.4.9', when='@0.22.1:')
+    depends_on('r@3.4.0:', when='@0.22.1:')

--- a/var/spack/repos/builtin/packages/r-biocparallel/package.py
+++ b/var/spack/repos/builtin/packages/r-biocparallel/package.py
@@ -38,4 +38,4 @@ class RBiocparallel(RPackage):
 
     depends_on('r-futile-logger', type=('build', 'run'))
     depends_on('r-snow', type=('build', 'run'))
-    depends_on('r@3.4.0:3.4.9', when='@1.10.1')
+    depends_on('r@3.4.0:', when='@1.10.1')

--- a/var/spack/repos/builtin/packages/r-biostrings/package.py
+++ b/var/spack/repos/builtin/packages/r-biostrings/package.py
@@ -40,4 +40,4 @@ class RBiostrings(RPackage):
     depends_on('r-s4vectors', type=('build', 'run'))
     depends_on('r-iranges', type=('build', 'run'))
     depends_on('r-xvector', type=('build', 'run'))
-    depends_on('r@3.4.0:3.4.9', when='@2.44.2')
+    depends_on('r@3.4.0:', when='@2.44.2')

--- a/var/spack/repos/builtin/packages/r-edger/package.py
+++ b/var/spack/repos/builtin/packages/r-edger/package.py
@@ -42,4 +42,4 @@ class REdger(RPackage):
 
     depends_on('r-limma', type=('build', 'run'))
     depends_on('r-locfit', type=('build', 'run'))
-    depends_on('r@3.4.0:3.4.9', when='@3.18.1')
+    depends_on('r@3.4.0:', when='@3.18.1')

--- a/var/spack/repos/builtin/packages/r-genomeinfodb/package.py
+++ b/var/spack/repos/builtin/packages/r-genomeinfodb/package.py
@@ -43,4 +43,4 @@ class RGenomeinfodb(RPackage):
     depends_on('r-iranges', type=('build', 'run'))
     depends_on('r-rcurl', type=('build', 'run'))
     depends_on('r-genomeinfodbdata', type=('build', 'run'))
-    depends_on('r@3.4.0:3.4.9', when='@1.12.3:')
+    depends_on('r@3.4.0:', when='@1.12.3:')

--- a/var/spack/repos/builtin/packages/r-genomeinfodbdata/package.py
+++ b/var/spack/repos/builtin/packages/r-genomeinfodbdata/package.py
@@ -33,4 +33,4 @@ class RGenomeinfodbdata(RPackage):
     url      = "https://bioconductor.org/packages/3.5/data/annotation/src/contrib/GenomeInfoDbData_0.99.0.tar.gz"
 
     version('0.99.0', '85977b51061dd02a90153db887040d05')
-    depends_on('r@3.4.0:3.4.9', when='@0.99.0')
+    depends_on('r@3.4.0:', when='@0.99.0')

--- a/var/spack/repos/builtin/packages/r-genomicranges/package.py
+++ b/var/spack/repos/builtin/packages/r-genomicranges/package.py
@@ -51,4 +51,4 @@ class RGenomicranges(RPackage):
     depends_on('r-genomeinfodb@1.11.5:', type=('build', 'run'), when='@1.28.6')
     depends_on('r-genomeinfodb@1.13.1:', type=('build', 'run'), when='@1.30.3')
     depends_on('r-xvector', type=('build', 'run'))
-    depends_on('r@3.4.0:3.4.9', when='@1.28.6:')
+    depends_on('r@3.4.0:', when='@1.28.6:')

--- a/var/spack/repos/builtin/packages/r-iranges/package.py
+++ b/var/spack/repos/builtin/packages/r-iranges/package.py
@@ -48,4 +48,4 @@ class RIranges(RPackage):
     depends_on('r-biocgenerics@0.23.3:', type=('build', 'run'), when='@2.12.0')
     depends_on('r-s4vectors@0.13.17:', type=('build', 'run'), when='@2.10.5')
     depends_on('r-s4vectors@0.15.5:', type=('build', 'run'), when='@2.12.0')
-    depends_on('r@3.4.0:3.4.9', when='@2.10.5:')
+    depends_on('r@3.4.0:', when='@2.10.5:')

--- a/var/spack/repos/builtin/packages/r-limma/package.py
+++ b/var/spack/repos/builtin/packages/r-limma/package.py
@@ -37,4 +37,4 @@ class RLimma(RPackage):
     version('3.32.10', git='https://git.bioconductor.org/packages/limma', commit='593edf28e21fe054d64137ae271b8a52ab05bc60')
     version('3.32.6', 'df5dc2b85189a24e939efa3a8e6abc41')
 
-    depends_on('r@3.4.0:3.4.9', when='@3.32.10:')
+    depends_on('r@3.4.0:', when='@3.32.10:')

--- a/var/spack/repos/builtin/packages/r-rsamtools/package.py
+++ b/var/spack/repos/builtin/packages/r-rsamtools/package.py
@@ -47,4 +47,4 @@ class RRsamtools(RPackage):
     depends_on('r-zlibbioc', type=('build', 'run'))
     depends_on('r-bitops', type=('build', 'run'))
     depends_on('r-biocparallel', type=('build', 'run'))
-    depends_on('r@3.4.0:3.4.9', when='@1.28.0')
+    depends_on('r@3.4.0:', when='@1.28.0')

--- a/var/spack/repos/builtin/packages/r-s4vectors/package.py
+++ b/var/spack/repos/builtin/packages/r-s4vectors/package.py
@@ -44,4 +44,4 @@ class RS4vectors(RPackage):
 
     depends_on('r-biocgenerics@0.21.1:', type=('build', 'run'), when='@0.14.7')
     depends_on('r-biocgenerics@0.23.3:', type=('build', 'run'), when='@0.16.0')
-    depends_on('r@3.4.0:3.4.9', when='@0.14.7:')
+    depends_on('r@3.4.0:', when='@0.14.7:')

--- a/var/spack/repos/builtin/packages/r-xvector/package.py
+++ b/var/spack/repos/builtin/packages/r-xvector/package.py
@@ -39,4 +39,4 @@ class RXvector(RPackage):
     depends_on('r-s4vectors', type=('build', 'run'))
     depends_on('r-iranges', type=('build', 'run'))
     depends_on('r-zlibbioc', type=('build', 'run'))
-    depends_on('r@3.4.0:3.4.9', when='@0.16.0')
+    depends_on('r@3.4.0:', when='@0.16.0')

--- a/var/spack/repos/builtin/packages/r-zlibbioc/package.py
+++ b/var/spack/repos/builtin/packages/r-zlibbioc/package.py
@@ -37,4 +37,4 @@ class RZlibbioc(RPackage):
     list_url = homepage
 
     version('1.22.0', git='https://git.bioconductor.org/packages/zlibbioc', commit='30377f830af2bc1ff17bbf3fdd2cb6442015fea5')
-    depends_on('r@3.4.0:3.4.9', when='@1.22.0')
+    depends_on('r@3.4.0:', when='@1.22.0')


### PR DESCRIPTION
Remove upper limit of R 3.4.9 for packages that do not have a specified version dependency listed on their website.  