### PR TITLE
salmon: adding in version restriction for boost

### DIFF
--- a/var/spack/repos/builtin/packages/salmon/package.py
+++ b/var/spack/repos/builtin/packages/salmon/package.py
@@ -36,7 +36,7 @@ class Salmon(CMakePackage):
     version('0.8.2', 'ee512697bc44b13661a16d4e14cf0a00')
 
     depends_on('tbb')
-    depends_on('boost')
+    depends_on('boost@:1.66.0')
 
     def cmake_args(self):
         args = ['-DBOOST_ROOT=%s' % self.spec['boost'].prefix]


### PR DESCRIPTION
1.67 results in compile errors:
``error: ‘next’ is not a member of ‘boost’``