### PR TITLE
Added Shim to Support hdf5+mpi in Spack Silo

### DIFF
--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -42,7 +42,7 @@ class Silo(Package):
             description='Builds Silex, a GUI for viewing Silo files')
     variant('pic', default=True,
             description='Produce position-independent code (for shared libs)')
-    variant('mpi', default=False,
+    variant('mpi', default=True,
             description='Compile with MPI Compatibility')
 
     depends_on('hdf5~mpi', when='~mpi')

--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -74,7 +74,7 @@ class Silo(Package):
 
         if '+mpi' in spec:
             config_args.append('CC=%s' % spec['mpi'].mpicc)
-            config_args.append('CXX=%s' %spec['mpi'].mpicxx)
+            config_args.append('CXX=%s' % spec['mpi'].mpicxx)
             config_args.append('FC=%s' % spec['mpi'].mpifc)
 
         configure(

--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -42,8 +42,11 @@ class Silo(Package):
             description='Builds Silex, a GUI for viewing Silo files')
     variant('pic', default=True,
             description='Produce position-independent code (for shared libs)')
+    variant('mpi', default=False,
+            description='Compile with MPI Compatibility')
 
-    depends_on('hdf5~mpi')
+    depends_on('hdf5~mpi', when='~mpi')
+    depends_on('hdf5+mpi', when='+mpi')
     depends_on('qt', when='+silex')
 
     patch('remove-mpiposix.patch', when='@4.8:4.10.2')
@@ -68,6 +71,11 @@ class Silo(Package):
                 'CFLAGS={0}'.format(self.compiler.pic_flag),
                 'CXXFLAGS={0}'.format(self.compiler.pic_flag),
                 'FCFLAGS={0}'.format(self.compiler.pic_flag)]
+
+        if '+mpi' in spec:
+            config_args.append('CC=%s' % spec['mpi'].mpicc)
+            config_args.append('CXX=%s' %spec['mpi'].mpicxx)
+            config_args.append('FC=%s' % spec['mpi'].mpifc)
 
         configure(
             '--prefix=%s' % prefix,


### PR DESCRIPTION
Added compatibility for hdf5+mpi to silo spackage to support spackages
with dependency chains that include silo and hf5+mpi

Fix proxyapps/proxy-ci#16