### PR TITLE
Fix gettext: Problem with libxml2

### DIFF
--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -86,8 +86,8 @@ class Gettext(AutotoolsPackage):
         if '+libxml2' in spec:
             config_args.append('CPPFLAGS=-I{0}/include'.format(
                 spec['libxml2'].prefix))
-            config_args.append('LDFLAGS=-L{0}/lib -Wl,-rpath,{0}/lib'.format(
-                spec['libxml2'].prefix))
+            config_args.append('LDFLAGS=-L{0} -Wl,-rpath,{0}'.format(
+                spec['libxml2'].libs))
         else:
             config_args.append('--with-included-libxml')
 

--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -87,7 +87,7 @@ class Gettext(AutotoolsPackage):
             config_args.append('CPPFLAGS=-I{0}/include'.format(
                 spec['libxml2'].prefix))
             config_args.append('LDFLAGS=-L{0} -Wl,-rpath,{0}'.format(
-                spec['libxml2'].libs))
+                spec['libxml2'].libs.directories[0]))
         else:
             config_args.append('--with-included-libxml')
 

--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -84,7 +84,9 @@ class Gettext(AutotoolsPackage):
             config_args.append('--disable-curses')
 
         if '+libxml2' in spec:
-            config_args.append('--with-libxml2-prefix={0}'.format(
+            config_args.append('CPPFLAGS=-I{0}/include'.format(
+                spec['libxml2'].prefix))
+            config_args.append('LDFLAGS=-L{0}/lib -Wl,-rpath,{0}/lib'.format(
                 spec['libxml2'].prefix))
         else:
             config_args.append('--with-included-libxml')


### PR DESCRIPTION
Verified that this fixes #2882 without the `~libxml2` workaround.  Thank you @dlukes 


