### PR TITLE
gdbm: Get working on CentOS5 and Other Older Systems

### DIFF
--- a/var/spack/repos/builtin/packages/gdbm/package.py
+++ b/var/spack/repos/builtin/packages/gdbm/package.py
@@ -46,4 +46,13 @@ class Gdbm(AutotoolsPackage):
     depends_on("readline")
 
     def configure_args(self):
-        return ['--enable-libgdbm-compat']
+
+        # GDBM uses some non-standard GNU extensions,
+        # enabled with -D_GNU_SOURCE.  See:
+        #   https://patchwork.ozlabs.org/patch/771300/
+        #   https://stackoverflow.com/questions/5582211/what-does-define-gnu-source-imply?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa
+        #   https://www.gnu.org/software/automake/manual/html_node/Flag-Variables-Ordering.html
+        return [
+            '--enable-libgdbm-compat',
+            'CPPFLAGS=-D_GNU_SOURCE']
+


### PR DESCRIPTION
@Sinan81  Fixes #7691 

GDBM uses some non-standard GNU extensions, enabled with -D_GNU_SOURCE.  See:

https://patchwork.ozlabs.org/patch/771300/
https://stackoverflow.com/questions/5582211/what-does-define-gnu-source-imply?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa
https://www.gnu.org/software/automake/manual/html_node/Flag-Variables-Ordering.html

