### PR TITLE
libexpat: Fix for older systems, move to GitHub

### DIFF
--- a/var/spack/repos/builtin/packages/expat/package.py
+++ b/var/spack/repos/builtin/packages/expat/package.py
@@ -44,12 +44,13 @@ class Expat(AutotoolsPackage):
             description="Use libbsd (for high quality randomness)")
     depends_on('libbsd', when="@2.2.1:+libbsd")
 
-    version('2.2.5', '789e297f547980fc9ecc036f9a070d49',
-        url='https://github.com/libexpat/libexpat/releases/download/R_2_2_5/expat-2.2.5.tar.bz2')
-    version('2.2.2', '1ede9a41223c78528b8c5d23e69a2667',
-        url='https://github.com/libexpat/libexpat/releases/download/R_2_2_2/expat-2.2.2.tar.bz2')
-    version('2.2.0', '2f47841c829facb346eb6e3fab5212e2',
-        url='https://github.com/libexpat/libexpat/releases/download/R_2_2_0/expat-2.2.0.tar.bz2')
+    version('2.2.5', '789e297f547980fc9ecc036f9a070d49')
+    version('2.2.2', '1ede9a41223c78528b8c5d23e69a2667')
+    version('2.2.0', '2f47841c829facb346eb6e3fab5212e2')
+
+    def url_for_version(self, version):
+        url = 'https://github.com/libexpat/libexpat/releases/download/R_{0}/expat-{1}.tar.bz2'
+        return url.format(version.underscored, version.dotted)
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/expat/package.py
+++ b/var/spack/repos/builtin/packages/expat/package.py
@@ -29,8 +29,8 @@ import sys
 class Expat(AutotoolsPackage):
     """Expat is an XML parser library written in C."""
 
-    homepage = "http://expat.sourceforge.net/"
-    url      = "https://sourceforge.net/projects/expat/files/expat/2.2.2/expat-2.2.2.tar.bz2"
+    homepage = "https://libexpat.github.io/"
+    url      = "https://github.com/libexpat/libexpat/releases/download/R_2_2_2/expat-2.2.2.tar.bz2"
 
     # Version 2.2.2 introduced a requirement for a high quality
     # entropy source.  "Older" linux systems (aka CentOS 7) do not
@@ -44,8 +44,14 @@ class Expat(AutotoolsPackage):
             description="Use libbsd (for high quality randomness)")
     depends_on('libbsd', when="@2.2.1:+libbsd")
 
-    version('2.2.2', '1ede9a41223c78528b8c5d23e69a2667')
-    version('2.2.0', '2f47841c829facb346eb6e3fab5212e2')
+
+    version('2.2.5', '789e297f547980fc9ecc036f9a070d49',
+        url='https://github.com/libexpat/libexpat/releases/download/R_2_2_5/expat-2.2.5.tar.bz2')
+
+    version('2.2.2', '1ede9a41223c78528b8c5d23e69a2667',
+        url='https://github.com/libexpat/libexpat/releases/download/R_2_2_2/expat-2.2.2.tar.bz2')
+    version('2.2.0', '2f47841c829facb346eb6e3fab5212e2',
+        url='https://github.com/libexpat/libexpat/releases/download/R_2_2_0/expat-2.2.0.tar.bz2')
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/expat/package.py
+++ b/var/spack/repos/builtin/packages/expat/package.py
@@ -44,10 +44,8 @@ class Expat(AutotoolsPackage):
             description="Use libbsd (for high quality randomness)")
     depends_on('libbsd', when="@2.2.1:+libbsd")
 
-
     version('2.2.5', '789e297f547980fc9ecc036f9a070d49',
         url='https://github.com/libexpat/libexpat/releases/download/R_2_2_5/expat-2.2.5.tar.bz2')
-
     version('2.2.2', '1ede9a41223c78528b8c5d23e69a2667',
         url='https://github.com/libexpat/libexpat/releases/download/R_2_2_2/expat-2.2.2.tar.bz2')
     version('2.2.0', '2f47841c829facb346eb6e3fab5212e2',


### PR DESCRIPTION
On SuSE (SLES) 11, I got the following error, in spite of using `--with-libbsd` as added in #4945:
```
lib/xmlparse.c:56:3: error: #error You do not have support for any sources of high quality entropy enabled...
```
[spack-build.out.txt](https://github.com/spack/spack/files/2003247/spack-build.out.txt)

An update to the latest version of `libexpat` solved the problem.  In the meantime, I'm moving this package to GitHub, as per instructions on the upstream website https://sourceforge.net/projects/expat/

> PLEASE NOTE that we are in the process of moving to GitHub: https://github.com/libexpat/libexpat

