### PR TITLE
trinity: fixing jdk dependency

### DIFF
--- a/var/spack/repos/builtin/packages/trinity/package.py
+++ b/var/spack/repos/builtin/packages/trinity/package.py
@@ -44,7 +44,7 @@ class Trinity(MakefilePackage):
 
     version('2.6.6', 'b7472e98ab36655a6d9296d965471a56')
 
-    depends_on("jdk@8")
+    depends_on("java@8:")
     depends_on("bowtie2")
     depends_on("jellyfish")
     depends_on("salmon")


### PR DESCRIPTION
due to jdk's goofy version numbers, the minor version parsing seems to break without trailing colon

Also changing to java virtual dependency instead of jdk explicitly