### PR TITLE
netcdf-cxx4: Update to use CPPFLAGS

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -41,6 +41,18 @@ class NetcdfCxx4(AutotoolsPackage):
 
     force_autoreconf = True
 
+    def configure_args(self):
+        args = []
+
+        CPPFLAGS = []
+
+        netcdf = self.spec['netcdf']
+        CPPFLAGS.append('-I' + netcdf.prefix.include)
+
+        args.append('CPPFLAGS=' + ' '.join(CPPFLAGS))
+        return args
+
+
     @property
     def libs(self):
         shared = True


### PR DESCRIPTION
This PR fixes the build error below.  I don't know why this ever worked; maybe it picked up the wrong `netcdf.h` from the system or something.  In any case, this change is consistent with c9810f8088ad2511ed02e5d3891bd8ed0742adbc:

```
        # Starting version 4.1.3, --with-hdf5= and other such configure options
        # are removed. Variables CPPFLAGS, LDFLAGS, and LD_LIBRARY_PATH must be
        # used instead.
```

Here is the error solved by this PR, which is modeled after the `netcdf` code from the above commit:

```
     36     ==> Executing phase: 'configure'
     37     ==> '/gpfsm/dnb53/rpfische/spack6/var/spack/stage/netcdf-cxx4-4.3.0
            -qyq4acqce4vpm4sxs6cfh6kzo6gtybmw/Unidata-netcdf-cxx4-b87e04b/confi
            gure' '--prefix=/gpfsm/dnb53/rpfische/spack6/opt/spack/linux-suse_l
            inux11-x86_64/gcc-5.3.0/netcdf-cxx4-4.3.0-qyq4acqce4vpm4sxs6cfh6kzo
            6gtybmw'
     38     configure: netCDF-cxx4 4.3.0
     39     checking build system type... x86_64-pc-linux-gnu

     ...

     161    checking for GNU libc compatible malloc... yes
     162    checking for special C compiler options needed for large files... n
            o
     163    checking for _FILE_OFFSET_BITS value needed for large files... no
     164    checking netcdf.h usability... no
     165    checking netcdf.h presence... no
     166    checking for netcdf.h... no
  >> 167    configure: error: netcdf.h could not be found. Please set CPPFLAGS.
```
