### PR TITLE
tcl: Install sources

### DIFF
--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -52,6 +52,12 @@ class Tcl(AutotoolsPackage):
 
     configure_directory = 'unix'
 
+#    def configure_args(self):
+#        spec = self.spec
+#        # https://github.com/spack/spack/issues/8151
+#        # https://groups.google.com/forum/#!topic/comp.lang.tcl/VJ1vFhcPmVg
+#        return ['--exec-prefix={0}'.format(self.spec.prefix)]
+
     def setup_environment(self, spack_env, run_env):
         # When using Tkinter from within spack provided python+tk, python
         # will not be able to find Tcl/Tk unless TCL_LIBRARY is set.
@@ -61,8 +67,31 @@ class Tcl(AutotoolsPackage):
         with working_dir(self.build_directory):
             make('install')
 
+            # http://wiki.tcl.tk/17463
+            if self.spec.satisfies('@8.6:'):
+                make('install-headers')
+
             # Some applications like Expect require private Tcl headers.
             make('install-private-headers')
+
+            # Copy source to install tree
+            # A user-provided install option might re-do this
+            # https://github.com/spack/spack/pull/4102/files
+            installed_src = join_path(
+                self.spec.prefix, 'share', self.name, 'src')
+            stage_src = os.path.realpath(self.stage.source_path)
+            install_tree(stage_src, installed_src)
+
+            # Replace stage dir -> installed src dir in tclConfig
+            filter_file(
+                stage_src, installed_src,
+                join_path(self.spec.prefix, 'lib', 'tclConfig.sh'))
+
+        # Don't install binaries in src/ tree
+        with working_dir(join_path(installed_src, self.configure_directory)):
+            make('clean')
+
+
 
     @run_after('install')
     def symlink_tclsh(self):

--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -85,8 +85,6 @@ class Tcl(AutotoolsPackage):
         with working_dir(join_path(installed_src, self.configure_directory)):
             make('clean')
 
-
-
     @run_after('install')
     def symlink_tclsh(self):
         with working_dir(self.prefix.bin):

--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -52,12 +52,6 @@ class Tcl(AutotoolsPackage):
 
     configure_directory = 'unix'
 
-#    def configure_args(self):
-#        spec = self.spec
-#        # https://github.com/spack/spack/issues/8151
-#        # https://groups.google.com/forum/#!topic/comp.lang.tcl/VJ1vFhcPmVg
-#        return ['--exec-prefix={0}'.format(self.spec.prefix)]
-
     def setup_environment(self, spack_env, run_env):
         # When using Tkinter from within spack provided python+tk, python
         # will not be able to find Tcl/Tk unless TCL_LIBRARY is set.


### PR DESCRIPTION
This fixes a bug in the Tcl/Tk installation #8151.  Previously, the recipe for `tk` would erroneously pick up the system-installed `tcl.h` file.  This "worked" for newer systems that had TCL 8.6 installed.  The bug was unmasked building on SLES 11, which comes with an older version of TCL.

Long story short, the `tcl` build references the original sources upon install, and the `tk` build requires the `tcl` sources.  TCL sources were installed following the example of #4102.  If the user installs with `spack install --source`, then the sources would be copied twice.  This should not be a serious problem.


@junghans @davydden @tgamblin from #4083:
> Do we need a global variant, which modifies the hash for no reason related to the artifact, or would it make sense to just make this an install option

Note that this is a case in which the presence of the source is structural, not an install option.  If it were optional (it's not), then a `+source` variant would be warranted here.


*** In addition, a `make install-headers` was added, as per advice for TCL 8.6

#