### PR TITLE
flex: use 2.6.3. by default

### DIFF
--- a/var/spack/repos/builtin/packages/flex/package.py
+++ b/var/spack/repos/builtin/packages/flex/package.py
@@ -33,7 +33,9 @@ class Flex(AutotoolsPackage):
     url = "https://github.com/westes/flex/releases/download/v2.6.1/flex-2.6.1.tar.gz"
 
     version('2.6.4', '2882e3179748cc9f9c23ec593d6adc8d')
-    version('2.6.3', 'a5f65570cd9107ec8a8ec88f17b31bb1')
+    # 2.6.4 fails to compile with GCC on Ubuntu 18.04LTS
+    # see https://github.com/spack/spack/issues/8152
+    version('2.6.3', 'a5f65570cd9107ec8a8ec88f17b31bb1', preferred=True)
     # Avoid flex '2.6.2' (major bug)
     # See issue #2554; https://github.com/westes/flex/issues/113
     version('2.6.1', '05bcd8fb629e0ae130311e8a6106fa82')

--- a/var/spack/repos/builtin/packages/flex/package.py
+++ b/var/spack/repos/builtin/packages/flex/package.py
@@ -33,7 +33,7 @@ class Flex(AutotoolsPackage):
     url = "https://github.com/westes/flex/releases/download/v2.6.1/flex-2.6.1.tar.gz"
 
     version('2.6.4', '2882e3179748cc9f9c23ec593d6adc8d')
-    # 2.6.4 fails to compile with GCC on Ubuntu 18.04LTS
+    # 2.6.4 fails to compile with gcc@7.2:
     # see https://github.com/spack/spack/issues/8152 and
     # https://github.com/spack/spack/issues/6942
     version('2.6.3', 'a5f65570cd9107ec8a8ec88f17b31bb1', preferred=True)
@@ -56,7 +56,7 @@ class Flex(AutotoolsPackage):
     depends_on('automake', type='build', when='@:2.6.0')
     depends_on('libtool',  type='build', when='@:2.6.0')
 
-    # Build issue for v2.6.4 when gcc 7.2.0 is used on Ubuntu 17.10.
+    # Build issue for v2.6.4 when gcc@7.2.0: is used
     # See issue #219; https://github.com/westes/flex/issues/219
     conflicts('%gcc@7.2.0:', when='@2.6.4')
 

--- a/var/spack/repos/builtin/packages/flex/package.py
+++ b/var/spack/repos/builtin/packages/flex/package.py
@@ -34,7 +34,8 @@ class Flex(AutotoolsPackage):
 
     version('2.6.4', '2882e3179748cc9f9c23ec593d6adc8d')
     # 2.6.4 fails to compile with GCC on Ubuntu 18.04LTS
-    # see https://github.com/spack/spack/issues/8152
+    # see https://github.com/spack/spack/issues/8152 and
+    # https://github.com/spack/spack/issues/6942
     version('2.6.3', 'a5f65570cd9107ec8a8ec88f17b31bb1', preferred=True)
     # Avoid flex '2.6.2' (major bug)
     # See issue #2554; https://github.com/westes/flex/issues/113
@@ -57,7 +58,7 @@ class Flex(AutotoolsPackage):
 
     # Build issue for v2.6.4 when gcc 7.2.0 is used on Ubuntu 17.10.
     # See issue #219; https://github.com/westes/flex/issues/219
-    conflicts('%gcc@7.2.0: os=ubuntu17.10', when='@2.6.4')
+    conflicts('%gcc@7.2.0:', when='@2.6.4')
 
     def url_for_version(self, version):
         url = "https://github.com/westes/flex"


### PR DESCRIPTION
in reference to https://github.com/spack/spack/issues/8152

`2.6.5` is supposed to fix this issue, until then, let's use `2.6.3` by default.