### PR TITLE
antlr: Turn off CSharp

### DIFF
--- a/var/spack/repos/builtin/packages/antlr/package.py
+++ b/var/spack/repos/builtin/packages/antlr/package.py
@@ -50,11 +50,9 @@ class Antlr(AutotoolsPackage):
     def configure_args(self):
         spec = self.spec
 
-        E = 'enable'
-        D = 'disable'
         return [
-            '--{0}-cxx'.format(E if '+cxx' in spec else D),
-            '--{0}-java'.format(D if '+java' in spec else D),
-            '--{0}-python'.format(E if '+python' in spec else D),
+            '--{0}-cxx'.format('enable' if '+cxx' in spec else 'disable'),
+            '--{0}-java'.format('enable' if '+java' in spec else 'disable'),
+            '--{0}-python'.format('enable' if '+python' in spec else 'disable'),
             '--disable-csharp'
         ]

--- a/var/spack/repos/builtin/packages/antlr/package.py
+++ b/var/spack/repos/builtin/packages/antlr/package.py
@@ -50,9 +50,11 @@ class Antlr(AutotoolsPackage):
     def configure_args(self):
         spec = self.spec
 
+        E = 'enable'
+        D = 'disable'
         return [
-            '--{0}-cxx'.format('enable' if '+cxx' in spec else 'disable'),
-            '--{0}-java'.format('enable' if '+java' in spec else 'disable'),
-            '--{0}-python'.format('enable' if '+python' in spec else 'disable'),
+            '--{0}-cxx'.format(E if '+cxx' in spec else D),
+            '--{0}-java'.format(D if '+java' in spec else D),
+            '--{0}-python'.format(E if '+python' in spec else D),
             '--disable-csharp'
         ]

--- a/var/spack/repos/builtin/packages/antlr/package.py
+++ b/var/spack/repos/builtin/packages/antlr/package.py
@@ -53,5 +53,6 @@ class Antlr(AutotoolsPackage):
         return [
             '--{0}-cxx'.format('enable' if '+cxx' in spec else 'disable'),
             '--{0}-java'.format('enable' if '+java' in spec else 'disable'),
-            '--{0}-python'.format('enable' if '+python' in spec else 'disable')
+            '--{0}-python'.format('enable' if '+python' in spec else 'disable'),
+            '--disable-csharp'
         ]

--- a/var/spack/repos/builtin/packages/antlr/package.py
+++ b/var/spack/repos/builtin/packages/antlr/package.py
@@ -54,7 +54,7 @@ class Antlr(AutotoolsPackage):
         D = 'disable'
         return [
             '--{0}-cxx'.format(E if '+cxx' in spec else D),
-            '--{0}-java'.format(E if '+java' in spec else D),
+            '--{0}-java'.format(D if '+java' in spec else D),
             '--{0}-python'.format(E if '+python' in spec else D),
             '--disable-csharp'
         ]

--- a/var/spack/repos/builtin/packages/antlr/package.py
+++ b/var/spack/repos/builtin/packages/antlr/package.py
@@ -51,8 +51,8 @@ class Antlr(AutotoolsPackage):
         spec = self.spec
 
         return [
+            '--disable-csharp',
             '--{0}-cxx'.format('enable' if '+cxx' in spec else 'disable'),
             '--{0}-java'.format('enable' if '+java' in spec else 'disable'),
-            '--{0}-python'.format('enable' if '+python' in spec else 'disable'),
-            '--disable-csharp'
+            '--{0}-python'.format('enable' if '+python' in spec else 'disable')
         ]

--- a/var/spack/repos/builtin/packages/antlr/package.py
+++ b/var/spack/repos/builtin/packages/antlr/package.py
@@ -54,7 +54,7 @@ class Antlr(AutotoolsPackage):
         D = 'disable'
         return [
             '--{0}-cxx'.format(E if '+cxx' in spec else D),
-            '--{0}-java'.format(D if '+java' in spec else D),
+            '--{0}-java'.format(E if '+java' in spec else D),
             '--{0}-python'.format(E if '+python' in spec else D),
             '--disable-csharp'
         ]


### PR DESCRIPTION
On my SUSE11 system, ANLTR build of the CSharp bindings was failing due to a lack of system-installed CSharp on the system.  Unless we add csharp support to Spack, we should disable the ANTLR CSharp bindings.

Note the available options for ANTLR's `./configure` script.  This stuff isn't really documented anywhere else:
```
Optional Features:
  --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
  --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
  --enable-java           enable or disable ANTLR for Java (enabled)

  --enable-cxx            enable or disable ANTLR for C++ (enabled)

  --enable-python         enable or disable ANTLR for Python (enabled).

  --enable-csharp         enable or disable ANTLR for C# (enabled)

  --enable-verbose        turn on verbosity when building package.

  --enable-debug          set debug level - any value greater zero enables a
                          debug version

  --enable-examples       include examples into this configuration (enabled)

  --enable-allow-partially-trusted-callers
                          allow partially trusted callers (C#)
```

