### PR TITLE
nco: Find NetCDF

### DIFF
--- a/var/spack/repos/builtin/packages/nco/package.py
+++ b/var/spack/repos/builtin/packages/nco/package.py
@@ -67,4 +67,3 @@ class Nco(AutotoolsPackage):
         spack_env.set('NETCDF_LIB', spec['netcdf'].prefix.lib)
         spack_env.set('ANTLR_ROOT', spec['antlr'].prefix)
         spack_env.set('UDUNITS2_PATH', spec['udunits2'].prefix)
-

--- a/var/spack/repos/builtin/packages/nco/package.py
+++ b/var/spack/repos/builtin/packages/nco/package.py
@@ -60,3 +60,11 @@ class Nco(AutotoolsPackage):
     def configure_args(self):
         spec = self.spec
         return ['--{0}-doc'.format('enable' if '+doc' in spec else 'disable')]
+
+    def setup_environment(self, spack_env, run_env):
+        spec = self.spec
+        spack_env.set('NETCDF_INC', spec['netcdf'].prefix.include)
+        spack_env.set('NETCDF_LIB', spec['netcdf'].prefix.lib)
+        spack_env.set('ANTLR_ROOT', spec['antlr'].prefix)
+        spack_env.set('UDUNITS2_PATH', spec['udunits2'].prefix)
+


### PR DESCRIPTION
Previously, `nco` was not able to find Spack-installed NetCDF; presumably relying on system-installed NetCDF instead.  If no system-installed NetCDF, this resulted in the error below.  This PR fixes the problem.


```
==> Installing nco
==> Using cached archive: /gpfsm/dnb53/rpfische/spack6/var/spack/cache/nco/nco-4.6.7.tar.gz
==> Staging archive: /gpfsm/dnb53/rpfische/spack6/var/spack/stage/nco-4.6.7-cmbb6euq3cyv25t6t47cu6snbfbrthqz/4.6.7.tar.gz
==> Created stage in /gpfsm/dnb53/rpfische/spack6/var/spack/stage/nco-4.6.7-cmbb6euq3cyv25t6t47cu6snbfbrthqz
==> Applied patch NUL-0-NULL.patch
==> Building nco [AutotoolsPackage]
==> Executing phase: 'autoreconf'
==> Executing phase: 'configure'
==> Error: ProcessError: Command exited with status 1:
    '/gpfsm/dnb53/rpfische/spack6/var/spack/stage/nco-4.6.7-cmbb6euq3cyv25t6t47cu6snbfbrthqz/nco-4.6.7/configure' '--prefix=/gpfsm/dnb53/rpfische/spack6/opt/spack/linux-suse_linux11-x86_64/gcc-5.3.0/nco-4.6.7-cmbb6euq3cyv25t6t47cu6snbfbrthqz' '--disable-doc'

2 errors found in build log:
     168    ################################
     169    checking for /opt/local/include/netcdf.h... no
     170    checking for /opt/local/lib/libnetcdf.a... no
     171    checking netcdf.h usability... no
     172    checking netcdf.h presence... no
     173    checking for netcdf.h... no
  >> 174    configure: error: in `/tmp/rpfische/spack-stage/spack-stage-2Gmopq/nco-4.6.7':
  >> 175    configure: error: cannot find netCDF header
     176    See `config.log' for more details

See build log for details:
```

Note features and influential env variables for the NetCDF build:

```
Optional Features:
  --disable-option-checking  ignore unrecognized --enable/--with options
  --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
  --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
  --enable-silent-rules   less verbose build output (undo: "make V=1")
  --disable-silent-rules  verbose build output (undo: "make V=0")
  --enable-dependency-tracking
                          do not reject slow dependency extractors
  --disable-dependency-tracking
                          speeds up one-time build
  --enable-shared[=PKGS]  build shared libraries [default=yes]
  --enable-static[=PKGS]  build static libraries [default=yes]
  --enable-fast-install[=PKGS]
                          optimize for fast installation [default=yes]
  --disable-libtool-lock  avoid locking (might break parallel builds)
  --enable-maintainer-mode
                          enable make rules and dependencies not useful (and
                          sometimes confusing) to the casual installer
  --disable-largefile     omit support for large files
  --enable-netcdf4        Enable netCDF Version 4 features (same as
                          enable-netcdf-4) [[default=yes]]
  --enable-netcdf-4       Enable netCDF Version 4 features (same as
                          enable-netcdf4) [[default=yes]]
  --enable-openmp         Build NCO with OpenMP [[default=yes]]
  --disable-openmp        do not use OpenMP
  --enable-dap            Build DAP-enabled NCO with netCDF-provided DAP
                          [[default=yes]]
  --enable-ncoxx          Build libnco++ and ncap2 (same as enable-ncap2)
                          [[default=yes]]
  --enable-ncap2          Build ncap2 and libnco++ (same as enable-ncoxx)
                          [[default=yes]]
  --enable-mpi            Build NCO for Message Passing Interface (NB: Do not
                          use, this is not yet supported) [[default=no]]
  --enable-fortran        Use Fortran arithmetic (deprecated) [[default=no]]
  --enable-i18n           Internationalization (i18n) support (WARNING:
                          Experimental, for future use) [[default=no]]
  --enable-nco_cplusplus  Build NCO C++ interface library [[default=yes]]
  --enable-esmf           Build-in ESMF support for integrated (instead of
                          off-line) regridding. WARNING: Development code =
                          Unsupported (and not necessary for regridding!
                          Dragons lurk here.) [[default=no]]
  --enable-gsl            Build-in GSL support if possible [[default=yes]]
  --enable-regex          Allow extended regular expressions [[default=yes]]
  --enable-udunits        Build-in UDUnits support if possible [[default=no]]
  --enable-udunits2       Build-in UDUnits2 support if possible
                          [[default=yes]]
  --enable-debug-custom   Activate all known, helpful compile-time and
                          run-time debugging checks such as pedantic warnings,
                          bounds checking (slowest execution). Automatically
                          activates --enable-debug-symbols. [[default=no]]
  --enable-debug-symbols  Debugging symbols: Produce symbols for debuggers
                          (e.g., dbx, gdb) [[default=no]]
  --enable-optimize-custom
                          Activate all known, helpful switches for fastest
                          possible run-time performance (slowest compilation)
                          [[default=no]]
  --enable-doc            Build/install NCO TexInfo-based documentation (info
                          hierarchy and PDF/HTML Users Guide)[[default=yes]]

Optional Packages:
  --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
  --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
  --with-pic[=PKGS]       try to use only PIC/non-PIC objects [default=use
                          both]
  --with-gnu-ld           assume the C compiler uses GNU ld [default=no]
  --with-sysroot=DIR Search for dependent libraries within DIR
                        (or the compiler's sysroot if not specified).

Some influential environment variables:
  CC          C compiler command
  CFLAGS      C compiler flags
  LDFLAGS     linker flags, e.g. -L<lib dir> if you have libraries in a
              nonstandard directory <lib dir>
  LIBS        libraries to pass to the linker, e.g. -l<library>
  CPPFLAGS    (Objective) C/C++ preprocessor flags, e.g. -I<include dir> if
              you have headers in a nonstandard directory <include dir>
  CXX         C++ compiler command
  CXXFLAGS    C++ compiler flags
  CPP         C preprocessor
  CXXCPP      C++ preprocessor
  YACC        The `Yet Another Compiler Compiler' implementation to use.
              Defaults to the first program found out of: `bison -y', `byacc',
              `yacc'.
  YFLAGS      The list of arguments that will be passed by default to $YACC.
              This script will default YFLAGS to the empty string to avoid a
              default value of `-d' given by some make applications.
  NETCDF_INC  Location of netCDF headers (compile-time)
  NETCDF_LIB  Location of netCDF library (compile-time)
  NETCDF_ROOT Root of netCDF4 installation (compile-time)
  ANTLR_ROOT  Location of ANTLR version 2.7.x installation (compile-time)
  I18N_SHARE  Root of internationalization (i18n) locale directories
              (run-time)
  ESMF_INC    Location of ESMF headers (compile-time)
  ESMF_LIB    Location of ESMF library (compile-time)
  UDUNITS2_PATH
              Root directory of UDUnits2 (normally contains bin, include, lib,
              share subdirectories)
```
