### PR TITLE
Support version 4.10.2-bsd

### DIFF
--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -32,7 +32,9 @@ class Silo(Package):
     homepage = "http://wci.llnl.gov/simulation/computer-codes/silo"
     url      = "https://wci.llnl.gov/content/assets/docs/simulation/computer-codes/silo/silo-4.10.2/silo-4.10.2.tar.gz"
 
-    version('4.10.2', '9ceac777a2f2469ac8cef40f4fab49c8')
+    version('4.10.2', '9ceac777a2f2469ac8cef40f4fab49c8', preferred=True)
+    version('4.10.2-bsd', '60fef9ce373daf1e9cc8320cfa509bc5',
+            url="https://wci.llnl.gov/content/assets/docs/simulation/computer-codes/silo/silo-4.10.2/silo-4.10.2-bsd.tar.gz")
     version('4.9', 'a83eda4f06761a86726e918fc55e782a')
     version('4.8', 'b1cbc0e7ec435eb656dc4b53a23663c9')
 


### PR DESCRIPTION
This pull request adds support for the version of Silo that our code team uses.  Since Spack sorts this version to become the new preferred default, I list "preferred=True" on version 4.10.2 so that the original default is kept.  Note that the URL specification is necessary because this version of Silo is not kept in a standard location that the others are :(