### PR TITLE
pdftk: New package

### DIFF
--- a/var/spack/repos/builtin/packages/eclipse-gcj-parser/package.py
+++ b/var/spack/repos/builtin/packages/eclipse-gcj-parser/package.py
@@ -24,7 +24,6 @@
 ##############################################################################
 from spack import *
 import os
-import llnl.util.filesystem
 
 
 class EclipseGcjParser(Package):

--- a/var/spack/repos/builtin/packages/eclipse-gcj-parser/package.py
+++ b/var/spack/repos/builtin/packages/eclipse-gcj-parser/package.py
@@ -1,0 +1,68 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+import os
+import llnl.util.filesystem
+
+
+class EclipseGcjParser(Package):
+    """GCJ requires the Eclipse Java parser, but does not ship with it.
+    This builds that parser into an executable binary, thereby
+    making GCJ work."""
+
+    homepage = "https://github.com/spack/spack/issues/8165"
+    url = "ftp://sourceware.org/pub/java/ecj-4.8.jar"
+
+    maintainers = ['citibeth']
+
+    version('4.8', 'd7cd6a27c8801e66cbaa964a039ecfdb', expand=False)
+
+    phases = ('build', 'install')
+
+    @property
+    def gcj(self):
+        """Obtain Executable for the gcj included with this GCC,
+        even in the face of GCC binaries with version numbers
+        included in their names."""
+
+        dir, gcc = os.path.split(str(self.compiler.cc))
+        if 'gcc' not in gcc:
+            raise ValueError(
+                'Package {0} requires GCC to build'.format(self.name))
+
+        return Executable(join_path(dir, gcc.replace('gcc', 'gcj')))
+
+    def build(self, spec, prefix):
+        self.gcj(
+            '-o', 'ecj1',
+            '--main=org.eclipse.jdt.internal.compiler.batch.GCCMain',
+            'ecj-4.8.jar')
+
+    def install(self, spec, prefix):
+        mkdirp(spec.prefix.bin)
+        install('ecj1', spec.prefix.bin)
+
+    def setup_environment(self, spack_env, run_env):
+        run_env.prepend_path('PATH', self.prefix.bin)

--- a/var/spack/repos/builtin/packages/pdftk/package.py
+++ b/var/spack/repos/builtin/packages/pdftk/package.py
@@ -24,7 +24,6 @@
 ##############################################################################
 from spack import *
 import os
-import llnl.util.filesystem
 
 
 class Pdftk(MakefilePackage):

--- a/var/spack/repos/builtin/packages/pdftk/package.py
+++ b/var/spack/repos/builtin/packages/pdftk/package.py
@@ -26,6 +26,7 @@ from spack import *
 import os
 import llnl.util.filesystem
 
+
 class Pdftk(MakefilePackage):
     """Parallel Ice Sheet Model"""
 
@@ -40,7 +41,6 @@ class Pdftk(MakefilePackage):
 
     # https://www.pdflabs.com/docs/install-pdftk-on-redhat-or-centos/
     def edit(self, spec, prefix):
-        spec = self.spec
         compiler = self.compiler
 
         gcc_base = os.path.split(os.path.split(compiler.cxx)[0])[0]
@@ -78,7 +78,6 @@ class Pdftk(MakefilePackage):
             mk.write('include Makefile.Base\n')
 
     def build(self, spec, prefix):
-        spec = self.spec
         compiler = self.compiler
         gcc_base = os.path.split(os.path.split(compiler.cxx)[0])[0]
         env = dict(os.environ)

--- a/var/spack/repos/builtin/packages/pdftk/package.py
+++ b/var/spack/repos/builtin/packages/pdftk/package.py
@@ -1,0 +1,111 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+import os
+import llnl.util.filesystem
+
+class Pdftk(MakefilePackage):
+    """Parallel Ice Sheet Model"""
+
+    homepage = "https://www.pdflabs.com/tools/pdftk-server"
+    url      = "https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/pdftk-2.02-src.zip"
+
+    maintainers = ['citibeth']
+
+    version('2.02', '6534365fd6727724f288a556ede33faa')
+
+    build_directory = 'pdftk'
+
+    # https://www.pdflabs.com/docs/install-pdftk-on-redhat-or-centos/
+    def edit(self, spec, prefix):
+        spec = self.spec
+        compiler = self.compiler
+
+        gcc_base = os.path.split(os.path.split(compiler.cxx)[0])[0]
+        gcc_version = compiler.version
+
+        cppflags = (
+            '-DPATH_DELIM=0x2f',
+            '-DASK_ABOUT_WARNINGS=false',
+            '-DUNBLOCK_SIGNALS',
+            '-fdollars-in-identifiers')
+        cxxflags = ('-Wall', '-Wextra', '-Weffc++', '-O2')
+        gcjflags = ('-Wall', '-Wextra', '-O2')
+        vars = [
+            ('VERSUFF', '-%s' % gcc_version),
+            ('CXX', compiler.cxx),
+            ('GCJ', str(compiler.cxx).replace('g++', 'gcj')),
+            ('GCJH', join_path(gcc_base, 'bin', 'gcjh')),
+            ('GJAR', join_path(gcc_base, 'bin', 'gjar')),
+            ('LIBGCJ', join_path(
+                gcc_base, 'share', 'java',
+                'libgcj-{0}.jar'.format(gcc_version))),
+            ('AR', 'ar'),
+            ('RM', 'rm'),
+            ('ARFLAGS', 'rs'),
+            ('RMFLAGS', '-vf'),
+            ('CPPFLAGS', ' '.join(cppflags)),
+            ('CXXFLAGS', ' '.join(cxxflags)),
+            ('GCJFLAGS', ' '.join(gcjflags)),
+            ('GCJHFLAGS', '-force'),
+            ('LDLIBS', '-lgcj')
+        ]
+        with open(join_path('pdftk', 'Makefile.Spack'), 'w') as mk:
+            for var, val in vars:
+                mk.write("export {0}={1}\n".format(var, str(val)))
+            mk.write('include Makefile.Base\n')
+
+    def build(self, spec, prefix):
+        spec = self.spec
+        compiler = self.compiler
+        gcc_base = os.path.split(os.path.split(compiler.cxx)[0])[0]
+        env = dict(os.environ)
+        env['PATH'] = join_path(gcc_base, 'bin') + ':' + env['PATH']
+        os.chdir(self.build_directory)
+        print('build', os.getcwd())
+
+        # Parallel build is known to fail.  But let it get most
+        # of the way there.
+        # (Not sure if this actually saves any time)
+#        try:
+#            make('-f', 'Makefile.Spack')
+#        except:
+#            pass
+
+        # Finish the build in serial
+        make('-f', 'Makefile.Spack', '-j1')
+
+    def install(self, spec, prefix):
+        # "make install" is hardcoded to /usr...
+        llnl.util.filesystem.mkdirp(self.spec.prefix.bin)
+        llnl.util.filesystem.install(
+            join_path(self.stage.source_path, 'pdftk', 'pdftk'),
+            self.spec.prefix.bin)
+
+#    def setup_environment(self, spack_env, run_env):
+#        # This is only needed to solve the ej1 stuff see #8165
+#        compiler = self.compiler
+#        gcc_base = os.path.split(os.path.split(compiler.cxx)[0])[0]
+#        spack_env.prepend_path('PATH', join_path(gcc_base, 'bin'))

--- a/var/spack/repos/builtin/packages/pdftk/package.py
+++ b/var/spack/repos/builtin/packages/pdftk/package.py
@@ -39,6 +39,8 @@ class Pdftk(MakefilePackage):
 
     version('2.02', '6534365fd6727724f288a556ede33faa')
 
+    depends_on('eclipse-gcj-parser', type='build')
+
     # Only takes effect in phases not overridden here
     build_directory = 'pdftk'
 
@@ -64,7 +66,7 @@ class Pdftk(MakefilePackage):
         vars = [
             ('VERSUFF', '-%s' % gcc_version),
             ('CXX', compiler.cxx),
-            ('GCJ', str(compiler.cxx).replace('g++', 'gcj')),
+            ('GCJ', spec['eclipse-gcj-parser'].package.gcj),
             ('GCJH', join_path(gcc_base, 'bin', 'gcjh')),
             ('GJAR', join_path(gcc_base, 'bin', 'gjar')),
             ('LIBGCJ', join_path(

--- a/var/spack/repos/builtin/packages/pdftk/package.py
+++ b/var/spack/repos/builtin/packages/pdftk/package.py
@@ -28,7 +28,9 @@ import llnl.util.filesystem
 
 
 class Pdftk(MakefilePackage):
-    """Parallel Ice Sheet Model"""
+    """PDFtk Server is a command-line tool for working with PDFs. It is
+    commonly used for client-side scripting or server-side processing
+    of PDFs."""
 
     homepage = "https://www.pdflabs.com/tools/pdftk-server"
     url      = "https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/pdftk-2.02-src.zip"
@@ -37,12 +39,18 @@ class Pdftk(MakefilePackage):
 
     version('2.02', '6534365fd6727724f288a556ede33faa')
 
+    # Only takes effect in phases not overridden here
     build_directory = 'pdftk'
 
     # https://www.pdflabs.com/docs/install-pdftk-on-redhat-or-centos/
     def edit(self, spec, prefix):
-        compiler = self.compiler
 
+        # ------ Fix install directory in main Makefile
+        makefile = FileFilter(join_path('pdftk', 'Makefile.Base'))
+        makefile.filter('/usr/local/bin', spec.prefix.bin)
+
+        # ------ Create new config file
+        compiler = self.compiler
         gcc_base = os.path.split(os.path.split(compiler.cxx)[0])[0]
         gcc_version = compiler.version
 
@@ -80,31 +88,11 @@ class Pdftk(MakefilePackage):
     def build(self, spec, prefix):
         compiler = self.compiler
         gcc_base = os.path.split(os.path.split(compiler.cxx)[0])[0]
-        env = dict(os.environ)
         env['PATH'] = join_path(gcc_base, 'bin') + ':' + env['PATH']
-        os.chdir(self.build_directory)
-        print('build', os.getcwd())
-
-        # Parallel build is known to fail.  But let it get most
-        # of the way there.
-        # (Not sure if this actually saves any time)
-#        try:
-#            make('-f', 'Makefile.Spack')
-#        except:
-#            pass
-
-        # Finish the build in serial
-        make('-f', 'Makefile.Spack', '-j1')
+        with working_dir(self.build_directory):
+            make('-f', 'Makefile.Spack', parallel=False)
 
     def install(self, spec, prefix):
-        # "make install" is hardcoded to /usr...
-        llnl.util.filesystem.mkdirp(self.spec.prefix.bin)
-        llnl.util.filesystem.install(
-            join_path(self.stage.source_path, 'pdftk', 'pdftk'),
-            self.spec.prefix.bin)
-
-#    def setup_environment(self, spack_env, run_env):
-#        # This is only needed to solve the ej1 stuff see #8165
-#        compiler = self.compiler
-#        gcc_base = os.path.split(os.path.split(compiler.cxx)[0])[0]
-#        spack_env.prepend_path('PATH', join_path(gcc_base, 'bin'))
+        mkdirp(self.spec.prefix.bin)
+        with working_dir(self.build_directory):
+            make('-f', 'Makefile.Spack', 'install', parallel=False)


### PR DESCRIPTION
pdftk is a nifty command-line utility to pull apart and rearrange PDFs.  And one I rely on, so that's why I'm putting it into Spack.

This is a unique package (from Spack's point of view) because it is written in a combination of Java and C++, and REQUIRES GCJ to build.  This package works, but I'm not sure how to best do a lot of the unique things it needs to do.  I'm looking for feedback.

Notes:

1. It requires a compiler other than C/C++/Fortran/Fortran77.  So I'm not sure how this would best fit into Spack's compiler infrastructure.

2. It ONLY builds with GCC.  There's no compatiblity with Intel or anything else, because GCC is the only compiler that provides GCJ.

3. GCJ has been removed from GCC as of version 7, so this requires an "older" version of GCC.

4. There are some problems getting GCJ working properly (see #8165).  Those issues could be addressed in the `gcc` package, or in an auxiliary package that would be needed for anything requiring `gcj` --- this package is likely the only thing that will ever need that.
