### PR TITLE
Fix libjpeg library finding and opencv build with nonstandard library directories (#8160)

### DIFF
--- a/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
+++ b/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
@@ -49,6 +49,10 @@ class LibjpegTurbo(Package):
     depends_on("nasm", type='build')
     depends_on('cmake', type='build', when="@1.5.90:")
 
+    @property
+    def libs(self):
+        return find_libraries("libjpeg*", root=self.prefix, recursive=True)
+
     @when('@:1.5.3')
     def install(self, spec, prefix):
         configure('--prefix=%s' % prefix)

--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -219,7 +219,7 @@ class Opencv(CMakePackage):
             zlib = spec['zlib']
             args.extend([
                 '-DZLIB_LIBRARY_{0}:FILEPATH={1}'.format((
-                    'DEBUG' if '+debug' in spec else 'RELEASE'),
+                    'DEBUG' if 'build_type=Debug' in spec else 'RELEASE'),
                     zlib.libs[0]),
                 '-DZLIB_INCLUDE_DIR:PATH={0}'.format(
                     zlib.headers.directories[0])
@@ -229,7 +229,7 @@ class Opencv(CMakePackage):
             libpng = spec['libpng']
             args.extend([
                 '-DPNG_LIBRARY_{0}:FILEPATH={1}'.format((
-                    'DEBUG' if '+debug' in spec else 'RELEASE'),
+                    'DEBUG' if 'build_type=Debug' in spec else 'RELEASE'),
                     libpng.libs[0]),
                 '-DPNG_INCLUDE_DIR:PATH={0}'.format(
                     libpng.headers.directories[0])
@@ -248,7 +248,7 @@ class Opencv(CMakePackage):
             libtiff = spec['libtiff']
             args.extend([
                 '-DTIFF_LIBRARY_{0}:FILEPATH={1}'.format((
-                    'DEBUG' if '+debug' in spec else 'RELEASE'),
+                    'DEBUG' if 'build_type=Debug' in spec else 'RELEASE'),
                     libtiff.libs[0]),
                 '-DTIFF_INCLUDE_DIR:PATH={0}'.format(
                     libtiff.headers.directories[0])
@@ -258,7 +258,7 @@ class Opencv(CMakePackage):
             jasper = spec['jasper']
             args.extend([
                 '-DJASPER_LIBRARY_{0}:FILEPATH={1}'.format((
-                    'DEBUG' if '+debug' in spec else 'RELEASE'),
+                    'DEBUG' if 'build_type=Debug' in spec else 'RELEASE'),
                     jasper.libs[0]),
                 '-DJASPER_INCLUDE_DIR:PATH={0}'.format(
                     jasper.headers.directories[0])

--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -220,9 +220,9 @@ class Opencv(CMakePackage):
             args.extend([
                 '-DZLIB_LIBRARY_{0}:FILEPATH={1}'.format((
                     'DEBUG' if '+debug' in spec else 'RELEASE'),
-                    join_path(zlib.prefix.lib,
-                              'libz.{0}'.format(dso_suffix))),
-                '-DZLIB_INCLUDE_DIR:PATH={0}'.format(zlib.prefix.include)
+                    zlib.libs[0]),
+                '-DZLIB_INCLUDE_DIR:PATH={0}'.format(
+                    zlib.headers.directories[0])
             ])
 
         if '+png' in spec:
@@ -230,19 +230,18 @@ class Opencv(CMakePackage):
             args.extend([
                 '-DPNG_LIBRARY_{0}:FILEPATH={1}'.format((
                     'DEBUG' if '+debug' in spec else 'RELEASE'),
-                    join_path(libpng.prefix.lib,
-                              'libpng.{0}'.format(dso_suffix))),
-                '-DPNG_INCLUDE_DIR:PATH={0}'.format(libpng.prefix.include)
+                    libpng.libs[0]),
+                '-DPNG_INCLUDE_DIR:PATH={0}'.format(
+                    libpng.headers.directories[0])
             ])
 
         if '+jpeg' in spec:
             libjpeg = spec['jpeg']
             args.extend([
                 '-DBUILD_JPEG:BOOL=OFF',
-                '-DJPEG_LIBRARY:FILEPATH={0}'.format(
-                    join_path(libjpeg.prefix.lib,
-                              'libjpeg.{0}'.format(dso_suffix))),
-                '-DJPEG_INCLUDE_DIR:PATH={0}'.format(libjpeg.prefix.include)
+                '-DJPEG_LIBRARY:FILEPATH={0}'.format(libjpeg.libs[0]),
+                '-DJPEG_INCLUDE_DIR:PATH={0}'.format(
+                    libjpeg.headers.directories[0])
             ])
 
         if '+tiff' in spec:
@@ -250,9 +249,9 @@ class Opencv(CMakePackage):
             args.extend([
                 '-DTIFF_LIBRARY_{0}:FILEPATH={1}'.format((
                     'DEBUG' if '+debug' in spec else 'RELEASE'),
-                    join_path(libtiff.prefix.lib,
-                              'libtiff.{0}'.format(dso_suffix))),
-                '-DTIFF_INCLUDE_DIR:PATH={0}'.format(libtiff.prefix.include)
+                    libtiff.libs[0]),
+                '-DTIFF_INCLUDE_DIR:PATH={0}'.format(
+                    libtiff.headers.directories[0])
             ])
 
         if '+jasper' in spec:
@@ -260,9 +259,9 @@ class Opencv(CMakePackage):
             args.extend([
                 '-DJASPER_LIBRARY_{0}:FILEPATH={1}'.format((
                     'DEBUG' if '+debug' in spec else 'RELEASE'),
-                    join_path(jasper.prefix.lib,
-                              'libjasper.{0}'.format(dso_suffix))),
-                '-DJASPER_INCLUDE_DIR:PATH={0}'.format(jasper.prefix.include)
+                    jasper.libs[0]),
+                '-DJASPER_INCLUDE_DIR:PATH={0}'.format(
+                    jasper.headers.directories[0])
             ])
 
         # GUI


### PR DESCRIPTION
I'm a little concerned about the `format(dso_suffix)` removal as I have no way to test on osx.

Tested with +zlib+png+jpeg+tiff+jasper.