### PR TITLE
[WIP] install_tree can install into an existing directory structure

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import collections
+import distutils.dir_util
 import errno
 import hashlib
 import fileinput
@@ -250,9 +251,13 @@ def install(src, dest):
 
 
 def install_tree(src, dest, **kwargs):
-    """Manually install a directory tree to a particular location."""
+    """Manually install a directory tree to a particular location.
+
+    See https://docs.python.org/3.6/distutils/apiref.html#distutils.dir_util.copy_tree
+    for a list of accepted kwargs.
+    """
     tty.debug("Installing %s to %s" % (src, dest))
-    shutil.copytree(src, dest, **kwargs)
+    distutils.dir_util.copy_tree(src, dest, **kwargs)
 
     for s, d in traverse_tree(src, dest, follow_nonexisting=False):
         set_install_permissions(d)

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -524,7 +524,7 @@ def extract_tarball(spec, filename, allow_root=False, unsigned=False,
     # Delay creating spec.prefix until verification is complete
     # and any relocation has been done.
     else:
-        install_tree(workdir, spec.prefix, preserve_symlinks=True)
+        shutil.copytree(workdir, spec.prefix, symlinks=True)
     finally:
         shutil.rmtree(tmpdir)
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -288,7 +288,7 @@ def build_tarball(spec, outdir, force=False, rel=False, unsigned=False,
             raise NoOverwriteException(str(specfile_path))
     # make a copy of the install directory to work with
     workdir = os.path.join(tempfile.mkdtemp(), os.path.basename(spec.prefix))
-    install_tree(spec.prefix, workdir, symlinks=True)
+    install_tree(spec.prefix, workdir, preserve_symlinks=True)
 
     # create info for later relocation and create tar
     write_buildinfo_file(spec.prefix, workdir, rel=rel)
@@ -524,7 +524,7 @@ def extract_tarball(spec, filename, allow_root=False, unsigned=False,
     # Delay creating spec.prefix until verification is complete
     # and any relocation has been done.
     else:
-        install_tree(workdir, spec.prefix, symlinks=True)
+        install_tree(workdir, spec.prefix, preserve_symlinks=True)
     finally:
         shutil.rmtree(tmpdir)
 

--- a/var/spack/repos/builtin/packages/alglib/package.py
+++ b/var/spack/repos/builtin/packages/alglib/package.py
@@ -26,7 +26,6 @@ from spack import *
 import glob
 import os
 import sys
-import shutil
 
 
 class Alglib(MakefilePackage):
@@ -48,7 +47,7 @@ class Alglib(MakefilePackage):
         make_file_src = join_path(os.path.dirname(self.module.__file__),
                                   'Makefile')
         make_file = join_path(self.stage.source_path, 'src', 'Makefile')
-        shutil.copy(make_file_src, make_file)
+        install(make_file_src, make_file)
         filter_file(r'so', dso_suffix, make_file)
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/arlecore/package.py
+++ b/var/spack/repos/builtin/packages/arlecore/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import distutils.dir_util
 
 
 class Arlecore(Package):
@@ -37,4 +36,4 @@ class Arlecore(Package):
     depends_on('r', type=('build', 'run'))
 
     def install(self, spec, prefix):
-        distutils.dir_util.copy_tree(".", prefix)
+        install_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/atom-dft/package.py
+++ b/var/spack/repos/builtin/packages/atom-dft/package.py
@@ -22,9 +22,7 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-
 from spack import *
-import shutil
 
 
 class AtomDft(MakefilePackage):
@@ -40,7 +38,7 @@ class AtomDft(MakefilePackage):
     depends_on('xmlf90')
 
     def edit(self, spec, prefix):
-        shutil.copyfile('arch.make.sample', 'arch.make')
+        install('arch.make.sample', 'arch.make')
 
     @property
     def build_targets(self):

--- a/var/spack/repos/builtin/packages/autodock-vina/package.py
+++ b/var/spack/repos/builtin/packages/autodock-vina/package.py
@@ -23,8 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from shutil import copyfile
-from shutil import copymode
 import sys
 
 
@@ -66,7 +64,5 @@ class AutodockVina(MakefilePackage):
     def install(self, spec, prefix):
         with working_dir(self.build_directory):
             mkdirp(prefix.bin)
-            copyfile("vina", join_path(prefix.bin, "vina"))
-            copymode("vina", join_path(prefix.bin, "vina"))
-            copyfile("vina_split", join_path(prefix.bin, "vina_split"))
-            copymode("vina_split", join_path(prefix.bin, "vina_split"))
+            install('vina', prefix.bin.vina)
+            install('vina_split', prefix.bin.vina_split)

--- a/var/spack/repos/builtin/packages/bcl2fastq2/package.py
+++ b/var/spack/repos/builtin/packages/bcl2fastq2/package.py
@@ -24,7 +24,6 @@
 ##############################################################################
 from spack import *
 import os
-import shutil
 import glob
 import llnl.util.tty as tty
 
@@ -94,7 +93,7 @@ class Bcl2fastq2(Package):
                     tty.msg("cwd sez: {0}".format(os.getcwd()))
                     tarball = glob.glob(join_path('spack-expanded-archive',
                                         'bcl2fastq2*.tar.gz'))[0]
-                    shutil.move(tarball, '.')
+                    install(tarball, '.')
                     os.rmdir('spack-expanded-archive')
                     tar = which('tar')
                     tarball = os.path.basename(tarball)

--- a/var/spack/repos/builtin/packages/bioawk/package.py
+++ b/var/spack/repos/builtin/packages/bioawk/package.py
@@ -23,8 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from shutil import copyfile
-from shutil import copymode
 
 
 class Bioawk(MakefilePackage):
@@ -45,7 +43,5 @@ class Bioawk(MakefilePackage):
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
-        copyfile("bioawk", join_path(prefix.bin, "bioawk"))
-        copymode("bioawk", join_path(prefix.bin, "bioawk"))
-        copyfile("maketab", join_path(prefix.bin, "maketab"))
-        copymode("maketab", join_path(prefix.bin, "maketab"))
+        install('bioawk',  prefix.bin.bioawk)
+        install('maketab', prefix.bin.maketab)

--- a/var/spack/repos/builtin/packages/biopieces/package.py
+++ b/var/spack/repos/builtin/packages/biopieces/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import distutils.dir_util
 
 
 class Biopieces(Package):
@@ -79,7 +78,7 @@ class Biopieces(Package):
     depends_on('scan-for-matches')
 
     def install(self, spec, prefix):
-        distutils.dir_util.copy_tree(".", prefix)
+        install_tree('.', prefix)
 
     def setup_environment(self, spack_env, run_env):
         # Note: user will need to set environment variables on their own,

--- a/var/spack/repos/builtin/packages/casper/package.py
+++ b/var/spack/repos/builtin/packages/casper/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import distutils.dir_util
 
 
 class Casper(MakefilePackage):
@@ -43,7 +42,7 @@ class Casper(MakefilePackage):
     conflicts('%gcc@7.1.0')
 
     def install(self, spec, prefix):
-        distutils.dir_util.copy_tree(".", prefix)
+        install_tree('.', prefix)
 
     def setup_environment(self, spack_env, run_env):
         run_env.prepend_path('PATH', self.spec.prefix)

--- a/var/spack/repos/builtin/packages/charm/package.py
+++ b/var/spack/repos/builtin/packages/charm/package.py
@@ -229,7 +229,7 @@ class Charm(Package):
                     tmppath = filepath + ".tmp"
                     # Skip dangling symbolic links
                     try:
-                        shutil.copy2(filepath, tmppath)
+                        install(filepath, tmppath)
                         os.remove(filepath)
                         os.rename(tmppath, filepath)
                     except (IOError, OSError):

--- a/var/spack/repos/builtin/packages/chlorop/package.py
+++ b/var/spack/repos/builtin/packages/chlorop/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import distutils.dir_util
 import os
 
 
@@ -47,7 +46,7 @@ class Chlorop(Package):
 
     def install(self, spec, prefix):
         os.rename('chlorop', 'bin/chlorop')
-        distutils.dir_util.copy_tree(".", prefix)
+        install_tree('.', prefix)
 
     def setup_environment(self, spack_env, run_env):
         run_env.set('CHLOROP', self.prefix)

--- a/var/spack/repos/builtin/packages/chombo/package.py
+++ b/var/spack/repos/builtin/packages/chombo/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from shutil import copyfile
 import glob
 
 
@@ -70,8 +69,8 @@ class Chombo(MakefilePackage):
         # Set remaining variables in Make.defs.local
         # Make.defs.local.template.patch ensures lines for USE_TIMER,
         # USE_LAPACK and lapackincflags are present
-        copyfile('./lib/mk/Make.defs.local.template',
-                 './lib/mk/Make.defs.local')
+        install('./lib/mk/Make.defs.local.template',
+                './lib/mk/Make.defs.local')
 
         defs_file = FileFilter('./lib/mk/Make.defs.local')
 

--- a/var/spack/repos/builtin/packages/codar-cheetah/package.py
+++ b/var/spack/repos/builtin/packages/codar-cheetah/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from distutils.dir_util import copy_tree
 
 
 class CodarCheetah(Package):
@@ -42,4 +41,4 @@ class CodarCheetah(Package):
     depends_on('savanna')
 
     def install(self, spec, prefix):
-        copy_tree('.', prefix)
+        install_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/comd/package.py
+++ b/var/spack/repos/builtin/packages/comd/package.py
@@ -22,9 +22,7 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-
 from spack import *
-import shutil
 
 
 class Comd(MakefilePackage):
@@ -57,7 +55,7 @@ class Comd(MakefilePackage):
 
     def edit(self, spec, prefix):
         with working_dir('src-mpi') or working_dir('src-openmp'):
-            shutil.copy('Makefile.vanilla', 'Makefile')
+            install('Makefile.vanilla', 'Makefile')
 
     @property
     def build_targets(self):

--- a/var/spack/repos/builtin/packages/cosp2/package.py
+++ b/var/spack/repos/builtin/packages/cosp2/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import shutil
 
 
 class Cosp2(MakefilePackage):
@@ -63,7 +62,7 @@ class Cosp2(MakefilePackage):
             if '+double' in spec:
                 filter_file('DOUBLE_PRECISION = O.*', 'DOUBLE_PRECISION = OFF',
                             'Makefile.vanilla')
-            shutil.copy('Makefile.vanilla', 'Makefile')
+            install('Makefile.vanilla', 'Makefile')
 
     def install(self, spec, prefix):
         install_tree('bin/', prefix.bin)

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import os
-import shutil
 import copy
 
 from spack import *
@@ -266,8 +265,7 @@ class Cp2k(Package):
                 lib_dir = join_path('lib', cp2k_architecture, cp2k_version)
                 mkdirp(lib_dir)
                 try:
-                    shutil.copy(env['LIBSMM_PATH'],
-                                join_path(lib_dir, 'libsmm.a'))
+                    install(env['LIBSMM_PATH'], join_path(lib_dir, 'libsmm.a'))
                 except KeyError:
                     raise KeyError('Point environment variable LIBSMM_PATH to '
                                    'the absolute path of the libsmm.a file')
@@ -315,4 +313,4 @@ class Cp2k(Package):
                  'VERSION={0}'.format(cp2k_version))
             env['PWD'] = pwd_backup
         exe_dir = join_path('exe', cp2k_architecture)
-        shutil.copytree(exe_dir, self.prefix.bin)
+        install_tree(exe_dir, self.prefix.bin)

--- a/var/spack/repos/builtin/packages/cppcheck/package.py
+++ b/var/spack/repos/builtin/packages/cppcheck/package.py
@@ -23,11 +23,9 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import os
-import shutil
 
 
-class Cppcheck(Package):
+class Cppcheck(MakefilePackage):
     """A tool for static C/C++ code analysis."""
     homepage = "http://cppcheck.sourceforge.net/"
     url      = "https://downloads.sourceforge.net/project/cppcheck/cppcheck/1.78/cppcheck-1.78.tar.bz2"
@@ -41,12 +39,13 @@ class Cppcheck(Package):
 
     depends_on('py-pygments', when='+htmlreport', type='run')
 
+    def build(self, spec, prefix):
+        make('CFGDIR={0}'.format(prefix.cfg))
+
     def install(self, spec, prefix):
-        # cppcheck does not have a configure script
-        make("CFGDIR=%s" % os.path.join(prefix, 'cfg'))
-        # manually install the final cppcheck binary
+        # Manually install the final cppcheck binary
         mkdirp(prefix.bin)
         install('cppcheck', prefix.bin)
-        shutil.copytree('cfg', os.path.join(prefix, 'cfg'))
+        install_tree('cfg', prefix.cfg)
         if spec.satisfies('+htmlreport'):
             install('htmlreport/cppcheck-htmlreport', prefix.bin)

--- a/var/spack/repos/builtin/packages/cudnn/package.py
+++ b/var/spack/repos/builtin/packages/cudnn/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from distutils.dir_util import copy_tree
 
 
 class Cudnn(Package):
@@ -40,4 +39,4 @@ class Cudnn(Package):
     depends_on('cuda@8:')
 
     def install(self, spec, prefix):
-        copy_tree('.', prefix)
+        install_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/docbook-xml/package.py
+++ b/var/spack/repos/builtin/packages/docbook-xml/package.py
@@ -38,7 +38,7 @@ class DocbookXml(Package):
             src = os.path.abspath(item)
             dst = os.path.join(prefix, item)
             if os.path.isdir(item):
-                install_tree(src, dst, symlinks=True)
+                install_tree(src, dst, preserve_symlinks=True)
             else:
                 install(src, dst)
 

--- a/var/spack/repos/builtin/packages/docbook-xsl/package.py
+++ b/var/spack/repos/builtin/packages/docbook-xsl/package.py
@@ -40,7 +40,7 @@ class DocbookXsl(Package):
             src = os.path.abspath(item)
             dst = os.path.join(prefix, item)
             if os.path.isdir(item):
-                install_tree(src, dst, symlinks=True)
+                install_tree(src, dst, preserve_symlinks=True)
             else:
                 install(src, dst)
 

--- a/var/spack/repos/builtin/packages/farmhash/package.py
+++ b/var/spack/repos/builtin/packages/farmhash/package.py
@@ -24,7 +24,6 @@
 ##############################################################################
 from spack import *
 import os.path
-from shutil import copyfile
 
 
 class Farmhash(CMakePackage):
@@ -34,9 +33,9 @@ class Farmhash(CMakePackage):
 
     homepage = "https://github.com/google/farmhash"
 
-    version('92e897', git='https://github.com/google/farmhash.git', 
+    version('92e897', git='https://github.com/google/farmhash.git',
             commit='92e897b282426729f4724d91a637596c7e2fe28f')
 
     def patch(self):
-        copyfile(join_path(os.path.dirname(__file__), "CMakeLists.txt"),
-                 "CMakeLists.txt")
+        install(join_path(os.path.dirname(__file__), "CMakeLists.txt"),
+                "CMakeLists.txt")

--- a/var/spack/repos/builtin/packages/fastqc/package.py
+++ b/var/spack/repos/builtin/packages/fastqc/package.py
@@ -23,8 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from distutils.dir_util import copy_tree, mkpath
-from distutils.file_util import copy_file
 
 
 class Fastqc(Package):
@@ -42,15 +40,15 @@ class Fastqc(Package):
     patch('fastqc.patch', level=0)
 
     def install(self, spec, prefix):
-        mkpath(self.prefix.bin)
-        mkpath(self.prefix.lib)
-        copy_file('fastqc', self.prefix.bin)
+        mkdir(prefix.bin)
+        mkdir(prefix.lib)
+        install('fastqc', prefix.bin)
         for j in ['cisd-jhdf5.jar', 'jbzip2-0.9.jar', 'sam-1.103.jar']:
-            copy_file(j, self.prefix.lib)
+            install(j, prefix.lib)
         for d in ['Configuration', 'net', 'org', 'Templates', 'uk']:
-            copy_tree(d, join_path(self.prefix.lib, d))
+            install_tree(d, join_path(prefix.lib, d))
         chmod = which('chmod')
-        chmod('+x', join_path(self.prefix.bin, 'fastqc'))
+        chmod('+x', prefix.bin.fastqc)
 
     # In theory the 'run' dependency on 'jdk' above should take
     # care of this for me. In practice, it does not.
@@ -58,5 +56,4 @@ class Fastqc(Package):
         """Add <prefix> to the path; the package has a script at the
            top level.
         """
-        run_env.prepend_path('PATH', join_path(self.spec['java'].prefix,
-                             'bin'))
+        run_env.prepend_path('PATH', self.spec['java'].prefix.bin)

--- a/var/spack/repos/builtin/packages/fsl/package.py
+++ b/var/spack/repos/builtin/packages/fsl/package.py
@@ -25,7 +25,6 @@
 from spack import *
 from spack.environment import EnvironmentModifications
 import os
-import distutils.dir_util
 
 
 class Fsl(Package):
@@ -68,7 +67,7 @@ class Fsl(Package):
         build = Executable('./build')
         build()
 
-        distutils.dir_util.copy_tree(".", prefix)
+        install_tree('.', prefix)
 
     def setup_environment(self, spack_env, run_env):
         if not self.stage.source_path:

--- a/var/spack/repos/builtin/packages/gatk/package.py
+++ b/var/spack/repos/builtin/packages/gatk/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from shutil import copyfile
 import glob
 import os.path
 import re
@@ -62,7 +61,7 @@ class Gatk(Package):
         # explicitly codes the path for java and the jar file.
         script_sh = join_path(os.path.dirname(__file__), "gatk.sh")
         script = join_path(prefix.bin, "gatk")
-        copyfile(script_sh, script)
+        install(script_sh, script)
         set_executable(script)
 
         # Munge the helper script to explicitly point to java and the

--- a/var/spack/repos/builtin/packages/gaussian/package.py
+++ b/var/spack/repos/builtin/packages/gaussian/package.py
@@ -24,7 +24,6 @@
 ##############################################################################
 from spack import *
 import os
-import shutil
 
 
 class Gaussian(Package):
@@ -36,7 +35,7 @@ class Gaussian(Package):
     version('09', '7d4c95b535e68e48af183920df427e4e')
 
     def install(self, spec, prefix):
-        shutil.copytree(os.getcwd(), prefix.bin)
+        install_tree('.', prefix.bin)
         patch_install_files = ['flc',
                                'linda8.2/opteron-linux/bin/flc',
                                'linda8.2/opteron-linux/bin/LindaLauncher',

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -28,7 +28,6 @@ from llnl.util import tty
 
 import glob
 import os
-import shutil
 import sys
 
 
@@ -192,7 +191,7 @@ class Gcc(AutotoolsPackage):
                 new_dispatch_dir = join_path(prefix, 'include', 'dispatch')
                 mkdirp(new_dispatch_dir)
                 new_header = join_path(new_dispatch_dir, 'object.h')
-                shutil.copyfile('/usr/include/dispatch/object.h', new_header)
+                install('/usr/include/dispatch/object.h', new_header)
                 filter_file(r'typedef void \(\^dispatch_block_t\)\(void\)',
                             'typedef void* dispatch_block_t',
                             new_header)

--- a/var/spack/repos/builtin/packages/genomefinisher/package.py
+++ b/var/spack/repos/builtin/packages/genomefinisher/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from shutil import copyfile
 import os
 
 
@@ -49,13 +48,13 @@ class Genomefinisher(Package):
         # Set up a helper script to call java on the jar file,
         # explicitly codes the path for java and the jar file.
         script_sh = join_path(os.path.dirname(__file__), "genomefinisher.sh")
-        script = join_path(prefix.bin, "genomefinisher")
-        copyfile(script_sh, script)
+        script = prefix.bin.genomefinisher
+        install(script_sh, script)
         set_executable(script)
 
         # Munge the helper script to explicitly point to java and the jar file
         # jar file.
-        java = join_path(self.spec['jdk'].prefix, 'bin', 'java')
+        java = spec['jdk'].prefix.bin.java
         kwargs = {'ignore_absent': False, 'backup': False, 'string': False}
         filter_file('^java', java, script, **kwargs)
         filter_file(jar_file, join_path(prefix.bin, jar_file),

--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -24,7 +24,6 @@
 ##############################################################################
 import sys
 from spack import *
-from distutils.dir_util import copy_tree
 
 
 class Git(AutotoolsPackage):
@@ -218,7 +217,7 @@ class Git(AutotoolsPackage):
 
     @run_after('install')
     def install_completions(self):
-        copy_tree('contrib/completion', self.prefix.share)
+        install_tree('contrib/completion', self.prefix.share)
 
     @run_after('install')
     def install_manpages(self):

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -25,7 +25,6 @@
 from spack import *
 
 import os.path
-import shutil
 
 
 class Glib(AutotoolsPackage):
@@ -116,7 +115,7 @@ class Glib(AutotoolsPackage):
         dtrace_copy = join_path(self.dtrace_copy_path, 'dtrace')
 
         with working_dir(self.dtrace_copy_path, create=True):
-            shutil.copy(dtrace, dtrace_copy)
+            install(dtrace, dtrace_copy)
             filter_file(
                 '^#!/usr/bin/python',
                 '#!/usr/bin/env python',

--- a/var/spack/repos/builtin/packages/go-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/go-bootstrap/package.py
@@ -22,9 +22,6 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-import os
-import shutil
-import glob
 from spack import *
 
 # THIS PACKAGE SHOULD NOT EXIST
@@ -75,15 +72,7 @@ class GoBootstrap(Package):
         with working_dir('src'):
             bash('{0}.bash'.format('all' if self.run_tests else 'make'))
 
-        try:
-            os.makedirs(prefix)
-        except OSError:
-            pass
-        for f in glob.glob('*'):
-            if os.path.isdir(f):
-                shutil.copytree(f, os.path.join(prefix, f))
-            else:
-                shutil.copy2(f, os.path.join(prefix, f))
+        install_tree('.', prefix)
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         spack_env.set('GOROOT_BOOTSTRAP', self.spec.prefix)

--- a/var/spack/repos/builtin/packages/go/package.py
+++ b/var/spack/repos/builtin/packages/go/package.py
@@ -23,8 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import os
-import shutil
-import glob
 import llnl.util.tty as tty
 from spack import *
 
@@ -100,15 +98,7 @@ class Go(Package):
         with working_dir('src'):
             bash('{0}.bash'.format('all' if self.run_tests else 'make'))
 
-        try:
-            os.makedirs(prefix)
-        except OSError:
-            pass
-        for f in glob.glob('*'):
-            if os.path.isdir(f):
-                shutil.copytree(f, os.path.join(prefix, f))
-            else:
-                shutil.copy2(f, os.path.join(prefix, f))
+        install_tree('.', prefix)
 
     def setup_environment(self, spack_env, run_env):
         spack_env.set('GOROOT_FINAL', self.spec.prefix)
@@ -122,10 +112,9 @@ class Go(Package):
 
         In most cases, extensions will only need to set GOPATH and use go::
 
-        env = os.environ
         env['GOPATH'] = self.source_path + ':' + env['GOPATH']
         go('get', '<package>', env=env)
-        shutil.copytree('bin', os.path.join(prefix, '/bin'))
+        install_tree('bin', prefix.bin)
         """
         #  Add a go command/compiler for extensions
         module.go = self.spec['go'].command

--- a/var/spack/repos/builtin/packages/grackle/package.py
+++ b/var/spack/repos/builtin/packages/grackle/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import os.path
-import shutil
 import inspect
 
 from spack import *
@@ -78,7 +77,7 @@ class Grackle(Package):
             'clib',
             'Make.mach.{0}'.format(grackle_architecture)
         )
-        shutil.copy(template, makefile)
+        install(template, makefile)
         for key, value in substitutions.items():
             filter_file(key, value, makefile)
 

--- a/var/spack/repos/builtin/packages/gradle/package.py
+++ b/var/spack/repos/builtin/packages/gradle/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from distutils.dir_util import copy_tree
 
 
 class Gradle(Package):
@@ -80,4 +79,4 @@ class Gradle(Package):
     depends_on('java')
 
     def install(self, spec, prefix):
-        copy_tree('.', prefix)
+        install_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/gurobi/package.py
+++ b/var/spack/repos/builtin/packages/gurobi/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from distutils.dir_util import copy_tree
 import os
 
 
@@ -58,5 +57,4 @@ class Gurobi(Package):
         run_env.set('GUROBI_HOME', self.prefix)
 
     def install(self, spec, prefix):
-        with working_dir('linux64'):
-            copy_tree('.', prefix)
+        install_tree('linux64', prefix)

--- a/var/spack/repos/builtin/packages/hdf5-blosc/package.py
+++ b/var/spack/repos/builtin/packages/hdf5-blosc/package.py
@@ -34,13 +34,13 @@ def _install_shlib(name, src, dst):
     if sys.platform == "darwin":
         shlib0 = name + ".0.dylib"
         shlib = name + ".dylib"
-        shutil.copyfile(join_path(src, shlib0), join_path(dst, shlib0))
+        install(join_path(src, shlib0), join_path(dst, shlib0))
         os.symlink(shlib0, join_path(dst, shlib))
     else:
         shlib000 = name + ".so.0.0.0"
         shlib0 = name + ".so.0"
         shlib = name + ".dylib"
-        shutil.copyfile(join_path(src, shlib000), join_path(dst, shlib000))
+        install(join_path(src, shlib000), join_path(dst, shlib000))
         os.symlink(shlib000, join_path(dst, shlib0))
         os.symlink(shlib0, join_path(dst, shlib))
 

--- a/var/spack/repos/builtin/packages/igvtools/package.py
+++ b/var/spack/repos/builtin/packages/igvtools/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from shutil import copyfile
 import os
 
 
@@ -47,13 +46,13 @@ class Igvtools(Package):
         # Set up a helper script to call java on the jar file,
         # explicitly codes the path for java and the jar file.
         script_sh = join_path(os.path.dirname(__file__), "igvtools.sh")
-        script = join_path(prefix.bin, "igvtools")
-        copyfile(script_sh, script)
+        script = prefix.bin.igvtools
+        install(script_sh, script)
         set_executable(script)
 
         # Munge the helper script to explicitly point to java and the
         # jar file.
-        java = join_path(self.spec['jdk'].prefix, 'bin', 'java')
+        java = spec['jdk'].prefix.bin.java
         kwargs = {'ignore_absent': False, 'backup': False, 'string': False}
         filter_file('^java', java, script, **kwargs)
         filter_file(jar_file, join_path(prefix.bin, jar_file),

--- a/var/spack/repos/builtin/packages/jdk/package.py
+++ b/var/spack/repos/builtin/packages/jdk/package.py
@@ -25,7 +25,6 @@
 #
 # Author: Justin Too <too1@llnl.gov>
 #
-import distutils.dir_util
 from spack import *
 
 
@@ -72,7 +71,7 @@ class Jdk(Package):
         return url.format(version, minor_version)
 
     def install(self, spec, prefix):
-        distutils.dir_util.copy_tree(".", prefix)
+        install_tree('.', prefix)
 
     def setup_environment(self, spack_env, run_env):
         run_env.set('JAVA_HOME', self.spec.prefix)

--- a/var/spack/repos/builtin/packages/jmol/package.py
+++ b/var/spack/repos/builtin/packages/jmol/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from distutils.dir_util import copy_tree
 
 
 class Jmol(Package):
@@ -38,7 +37,7 @@ class Jmol(Package):
     depends_on('java', type='run')
 
     def install(self, spec, prefix):
-        copy_tree('jmol-{0}'.format(self.version), prefix)
+        install_tree('jmol-{0}'.format(self.version), prefix)
 
     def setup_environment(self, spack_env, run_env):
         run_env.prepend_path('PATH', self.prefix)

--- a/var/spack/repos/builtin/packages/kaldi/package.py
+++ b/var/spack/repos/builtin/packages/kaldi/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from distutils.dir_util import copy_tree
 from os.path import join
 from fnmatch import fnmatch
 import os
@@ -107,7 +106,7 @@ class Kaldi(Package):    # Does not use Autotools
                         install(join(root, name), prefix.bin)
 
             mkdir(prefix.lib)
-            copy_tree('lib', prefix.lib)
+            install_tree('lib', prefix.lib)
 
             for root, dirs, files in os.walk('.'):
                 for name in files:

--- a/var/spack/repos/builtin/packages/libgridxc/package.py
+++ b/var/spack/repos/builtin/packages/libgridxc/package.py
@@ -22,9 +22,7 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-
 from spack import *
-import shutil
 
 
 class Libgridxc(Package):
@@ -42,7 +40,7 @@ class Libgridxc(Package):
         sh = which('sh')
         with working_dir('build', create=True):
             sh('../src/config.sh')
-            shutil.copyfile('../extra/fortran.mk', 'fortran.mk')
+            install('../extra/fortran.mk', 'fortran.mk')
 
     def install(self, spec, prefix):
         with working_dir('build'):

--- a/var/spack/repos/builtin/packages/libiconv/package.py
+++ b/var/spack/repos/builtin/packages/libiconv/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import shutil
 
 
 class Libiconv(AutotoolsPackage):
@@ -46,6 +45,6 @@ class Libiconv(AutotoolsPackage):
         args = ['--enable-extra-encodings']
 
         # A hack to patch config.guess in the libcharset sub directory
-        shutil.copyfile('./build-aux/config.guess',
-                        'libcharset/build-aux/config.guess')
+        install('./build-aux/config.guess',
+                'libcharset/build-aux/config.guess')
         return args

--- a/var/spack/repos/builtin/packages/masurca/package.py
+++ b/var/spack/repos/builtin/packages/masurca/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import distutils.dir_util
 
 
 class Masurca(Package):
@@ -44,4 +43,4 @@ class Masurca(Package):
     def install(self, spec, prefix):
         installer = Executable('./install.sh')
         installer()
-        distutils.dir_util.copy_tree(".", prefix)
+        install_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/maven/package.py
+++ b/var/spack/repos/builtin/packages/maven/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from distutils.dir_util import copy_tree
 
 
 class Maven(Package):
@@ -39,4 +38,4 @@ class Maven(Package):
 
     def install(self, spec, prefix):
         # install pre-built distribution
-        copy_tree('.', prefix)
+        install_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/mefit/package.py
+++ b/var/spack/repos/builtin/packages/mefit/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import distutils.dir_util
 
 
 class Mefit(Package):
@@ -41,7 +40,7 @@ class Mefit(Package):
     depends_on('casper %gcc@4.8.5')
 
     def install(self, spec, prefix):
-        distutils.dir_util.copy_tree(".", prefix)
+        install_tree('.', prefix)
 
     def setup_environment(self, spack_env, run_env):
         run_env.prepend_path('PATH', self.prefix)

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -417,7 +417,7 @@ class Mfem(Package):
             # installed shared mfem library:
             with working_dir('config'):
                 os.rename('config.mk', 'config.mk.orig')
-                shutil.copyfile(str(self.config_mk), 'config.mk')
+                install(str(self.config_mk), 'config.mk')
                 shutil.copystat('config.mk.orig', 'config.mk')
 
         if '+examples' in spec:

--- a/var/spack/repos/builtin/packages/mpix-launch-swift/package.py
+++ b/var/spack/repos/builtin/packages/mpix-launch-swift/package.py
@@ -23,10 +23,9 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from distutils.dir_util import copy_tree
 
 
-class MpixLaunchSwift(Package):
+class MpixLaunchSwift(MakefilePackage):
     """Library that allows a child MPI application to be launched
     inside a subset of processes in a parent MPI application.
     """
@@ -43,5 +42,4 @@ class MpixLaunchSwift(Package):
     depends_on('swig', type='build')
 
     def install(self, spec, prefix):
-        make()
-        copy_tree('.', prefix)
+        install_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/mrtrix3/package.py
+++ b/var/spack/repos/builtin/packages/mrtrix3/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import distutils.dir_util
 
 
 class Mrtrix3(Package):
@@ -56,7 +55,7 @@ class Mrtrix3(Package):
         build()
         # install_tree('.', prefix) does not work since the prefix
         # directory already exists by this point
-        distutils.dir_util.copy_tree('.', prefix)
+        install_tree('.', prefix)
 
     def setup_environment(self, spac_env, run_env):
         run_env.prepend_path('PATH', self.prefix)

--- a/var/spack/repos/builtin/packages/namd/package.py
+++ b/var/spack/repos/builtin/packages/namd/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import platform
-import shutil
 import sys
 import os
 from spack import *
@@ -58,8 +57,8 @@ class Namd(MakefilePackage):
 
     def _copy_arch_file(self, lib):
         config_filename = 'arch/{0}.{1}'.format(self.arch, lib)
-        shutil.copy('arch/Linux-x86_64.{0}'.format(lib),
-                    config_filename)
+        install('arch/Linux-x86_64.{0}'.format(lib),
+                config_filename)
         if lib == 'tcl':
             filter_file(r'-ltcl8\.5',
                         '-ltcl{0}'.format(self.spec['tcl'].version.up_to(2)),

--- a/var/spack/repos/builtin/packages/ncl/package.py
+++ b/var/spack/repos/builtin/packages/ncl/package.py
@@ -25,7 +25,6 @@
 from spack import *
 import glob
 import os
-import shutil
 import tempfile
 
 
@@ -263,8 +262,8 @@ class Ncl(Package):
             triangle_src = join_path(self.stage.source_path, 'triangle_src')
             triangle_dst = join_path(self.stage.source_path, 'ni', 'src',
                                      'lib', 'hlu')
-            shutil.copy(join_path(triangle_src, 'triangle.h'), triangle_dst)
-            shutil.copy(join_path(triangle_src, 'triangle.c'), triangle_dst)
+            install(join_path(triangle_src, 'triangle.h'), triangle_dst)
+            install(join_path(triangle_src, 'triangle.c'), triangle_dst)
 
     @staticmethod
     def delete_files(*filenames):

--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -26,7 +26,6 @@ from spack import *
 from glob import glob
 from os.path import exists, join
 from os import makedirs
-from shutil import copy
 
 
 class Ncurses(AutotoolsPackage):
@@ -109,7 +108,7 @@ class Ncurses(AutotoolsPackage):
             if not exists(path):
                 makedirs(path)
             for header in headers:
-                copy(header, path)
+                install(header, path)
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/occa/package.py
+++ b/var/spack/repos/builtin/packages/occa/package.py
@@ -23,8 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import os
-import shutil
 
 
 class Occa(Package):
@@ -64,12 +62,7 @@ class Occa(Package):
     def install(self, spec, prefix):
         # The build environment is set by the 'setup_environment' method.
         # Copy the source to the installation directory and build OCCA there.
-        for file in os.listdir('.'):
-            dest = join_path(prefix, os.path.basename(file))
-            if os.path.isdir(file):
-                shutil.copytree(file, dest)
-            else:
-                shutil.copy2(file, dest)
+        install_tree('.', prefix)
         make('-C', prefix)
 
         if self.run_tests:

--- a/var/spack/repos/builtin/packages/pexsi/package.py
+++ b/var/spack/repos/builtin/packages/pexsi/package.py
@@ -25,7 +25,6 @@
 
 import inspect
 import os.path
-import shutil
 
 from spack import *
 
@@ -94,7 +93,7 @@ class Pexsi(MakefilePackage):
             self.stage.source_path,
             'make.inc'
         )
-        shutil.copy(template, makefile)
+        install(template, makefile)
         for key, value in substitutions.items():
             filter_file(key, value, makefile)
 

--- a/var/spack/repos/builtin/packages/picard/package.py
+++ b/var/spack/repos/builtin/packages/picard/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from shutil import copyfile
 import glob
 import os.path
 import re
@@ -69,13 +68,13 @@ class Picard(Package):
         # Set up a helper script to call java on the jar file,
         # explicitly codes the path for java and the jar file.
         script_sh = join_path(os.path.dirname(__file__), "picard.sh")
-        script = join_path(prefix.bin, "picard")
-        copyfile(script_sh, script)
+        script = prefix.bin.picard
+        install(script_sh, script)
         set_executable(script)
 
         # Munge the helper script to explicitly point to java and the
         # jar file.
-        java = join_path(self.spec['java'].prefix, 'bin', 'java')
+        java = self.spec['java'].prefix.bin.java
         kwargs = {'ignore_absent': False, 'backup': False, 'string': False}
         filter_file('^java', java, script, **kwargs)
         filter_file('picard.jar', join_path(prefix.bin, 'picard.jar'),

--- a/var/spack/repos/builtin/packages/pilon/package.py
+++ b/var/spack/repos/builtin/packages/pilon/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from shutil import copyfile
 import os.path
 
 
@@ -47,13 +46,13 @@ class Pilon(Package):
         # Set up a helper script to call java on the jar file,
         # explicitly codes the path for java and the jar file.
         script_sh = join_path(os.path.dirname(__file__), "pilon.sh")
-        script = join_path(prefix.bin, "pilon")
-        copyfile(script_sh, script)
+        script = prefix.bin.pilon
+        install(script_sh, script)
         set_executable(script)
 
         # Munge the helper script to explicitly point to java and the
         # jar file.
-        java = join_path(self.spec['java'].prefix, 'bin', 'java')
+        java = self.spec['java'].prefix.bin.java
         kwargs = {'ignore_absent': False, 'backup': False, 'string': False}
         filter_file('^java', java, script, **kwargs)
         filter_file('pilon-{0}.jar', join_path(prefix.bin, jar_file),

--- a/var/spack/repos/builtin/packages/pindel/package.py
+++ b/var/spack/repos/builtin/packages/pindel/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from shutil import copytree, copyfile
 
 
 class Pindel(MakefilePackage):
@@ -51,9 +50,8 @@ class Pindel(MakefilePackage):
     #
 
     def edit(self, spec, prefix):
-        makefile2 = join_path(self.build_directory, 'Makefile2')
-        copyfile(join_path(self.build_directory, 'Makefile'), makefile2)
-        myedit = FileFilter(makefile2)
+        install('Makefile', 'Makefile2')
+        myedit = FileFilter('Makefile2')
         myedit.filter('-include Makefile.local', '#removed include')
         myedit.filter('@false', '#removed autofailure')
 
@@ -69,6 +67,4 @@ class Pindel(MakefilePackage):
         install('src/pindel2vcf', prefix.bin)
         install('src/sam2pindel', prefix.bin)
         install('src/pindel2vcf4tcga', prefix.bin)
-        copytree(join_path(self.build_directory, 'demo'),
-                 prefix.doc,
-                 symlinks=True)
+        install_tree('demo', prefix.doc, preserve_symlinks=True)

--- a/var/spack/repos/builtin/packages/qbox/package.py
+++ b/var/spack/repos/builtin/packages/qbox/package.py
@@ -22,8 +22,6 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-
-import shutil
 from spack import *
 
 
@@ -88,6 +86,6 @@ class Qbox(MakefilePackage):
     def install(self, spec, prefix):
         mkdir(prefix.src)
         install('src/qb', prefix.src)
-        shutil.move('test', prefix)
-        shutil.move('xml', prefix)
-        shutil.move('util', prefix)
+        install_tree('test', prefix)
+        install_tree('xml', prefix)
+        install_tree('util', prefix)

--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import os
-import shutil
 
 from spack import *
 
@@ -136,7 +135,7 @@ class R(AutotoolsPackage):
         # dependencies in Spack.
         src_makeconf = join_path(self.etcdir, 'Makeconf')
         dst_makeconf = join_path(self.etcdir, 'Makeconf.spack')
-        shutil.copy(src_makeconf, dst_makeconf)
+        install(src_makeconf, dst_makeconf)
 
     # ========================================================================
     # Set up environment to make install easy for R extensions.

--- a/var/spack/repos/builtin/packages/repeatmasker/package.py
+++ b/var/spack/repos/builtin/packages/repeatmasker/package.py
@@ -24,7 +24,6 @@
 ##############################################################################
 from spack import *
 import inspect
-import distutils.dir_util
 
 
 class Repeatmasker(Package):
@@ -78,4 +77,4 @@ class Repeatmasker(Package):
         with open(config_answers_filename, 'r') as f:
             inspect.getmodule(self).perl('configure', input=f)
 
-        distutils.dir_util.copy_tree(".", prefix.bin)
+        install_tree('.', prefix.bin)

--- a/var/spack/repos/builtin/packages/rna-seqc/package.py
+++ b/var/spack/repos/builtin/packages/rna-seqc/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from shutil import copyfile
 import os.path
 
 
@@ -51,12 +50,12 @@ class RnaSeqc(Package):
         # explicitly codes the path for java and the jar file.
         script_sh = join_path(os.path.dirname(__file__), "rna-seqc.sh")
         script = join_path(prefix.bin, "rna-seqc")
-        copyfile(script_sh, script)
+        install(script_sh, script)
         set_executable(script)
 
         # Munge the helper script to explicitly point to java and the
         # jar file.
-        java = join_path(self.spec['jdk'].prefix, 'bin', 'java')
+        java = self.spec['jdk'].prefix.bin.java
         kwargs = {'ignore_absent': False, 'backup': False, 'string': False}
         filter_file('^java', java, script, **kwargs)
         filter_file('RNA-SeQC_v{0}.jar', join_path(prefix.bin, jar_file),

--- a/var/spack/repos/builtin/packages/rockstar/package.py
+++ b/var/spack/repos/builtin/packages/rockstar/package.py
@@ -22,10 +22,8 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-
 import os
 from spack import *
-from distutils.dir_util import copy_tree
 
 
 class Rockstar(MakefilePackage):
@@ -60,7 +58,7 @@ class Rockstar(MakefilePackage):
 
     def install(self, spec, prefix):
         # Install all files and directories
-        copy_tree(".", prefix)
+        install_tree('.', prefix)
 
         mkdir(prefix.bin)
         mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/savanna/package.py
+++ b/var/spack/repos/builtin/packages/savanna/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from distutils.dir_util import copy_tree
 
 
 class Savanna(MakefilePackage):
@@ -48,4 +47,4 @@ class Savanna(MakefilePackage):
     depends_on('tau', when='+tau')
 
     def install(self, spec, prefix):
-        copy_tree('.', prefix)
+        install_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/sbt/package.py
+++ b/var/spack/repos/builtin/packages/sbt/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import shutil
 
 
 class Sbt(Package):
@@ -38,5 +37,5 @@ class Sbt(Package):
     depends_on('java')
 
     def install(self, spec, prefix):
-        shutil.copytree('bin', join_path(prefix, 'bin'), symlinks=True)
-        shutil.copytree('conf', join_path(prefix, 'conf'), symlinks=True)
+        install_tree('bin',  prefix.bin,  preserve_symlinks=True)
+        install_tree('conf', prefix.conf, preserve_symlinks=True)

--- a/var/spack/repos/builtin/packages/scr/package.py
+++ b/var/spack/repos/builtin/packages/scr/package.py
@@ -25,7 +25,6 @@
 from spack import *
 
 import os
-import shutil
 
 
 class Scr(CMakePackage):
@@ -150,4 +149,4 @@ class Scr(CMakePackage):
         if spec.variants['copy_config'].value:
             dest_path = self.get_abs_path_rel_prefix(
                 spec.variants['scr_config'].value)
-            shutil.copyfile(spec.variants['copy_config'].value, dest_path)
+            install(spec.variants['copy_config'].value, dest_path)

--- a/var/spack/repos/builtin/packages/sctk/package.py
+++ b/var/spack/repos/builtin/packages/sctk/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from distutils.dir_util import copy_tree
 
 
 class Sctk(Package):
@@ -50,4 +49,4 @@ class Sctk(Package):
         make('all')
         make('install')
         mkdirp(prefix.bin)
-        copy_tree('bin', prefix.bin)
+        install_tree('bin', prefix.bin)

--- a/var/spack/repos/builtin/packages/snpeff/package.py
+++ b/var/spack/repos/builtin/packages/snpeff/package.py
@@ -24,7 +24,6 @@
 ##############################################################################
 from spack import *
 import os.path
-from shutil import copyfile
 
 
 class Snpeff(Package):
@@ -45,13 +44,13 @@ class Snpeff(Package):
         # Set up a helper script to call java on the jar file,
         # explicitly codes the path for java and the jar file.
         script_sh = join_path(os.path.dirname(__file__), "snpEff.sh")
-        script = join_path(prefix.bin, "snpEff")
-        copyfile(script_sh, script)
+        script = prefix.bin.snpEff
+        install(script_sh, script)
         set_executable(script)
 
         # Munge the helper script to explicitly point to java and the
         # jar file.
-        java = join_path(self.spec['java'].prefix.bin, 'java')
+        java = self.spec['java'].prefix.bin.java
         kwargs = {'backup': False}
         filter_file('^java', java, script, **kwargs)
         filter_file('snpEff.jar', join_path(prefix.bin, 'snpEff.jar'),

--- a/var/spack/repos/builtin/packages/snphylo/package.py
+++ b/var/spack/repos/builtin/packages/snphylo/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import distutils.dir_util
 
 
 class Snphylo(Package):
@@ -51,7 +50,7 @@ class Snphylo(Package):
         with open(install_answer_input, 'r') as f:
             bash = which('bash')
             bash('./setup.sh', input=f)
-            distutils.dir_util.copy_tree(".", prefix)
+            install_tree('.', prefix)
 
     def setup_environment(self, spack_env, run_env):
         run_env.prepend_path('PATH', self.spec.prefix)

--- a/var/spack/repos/builtin/packages/spark/package.py
+++ b/var/spack/repos/builtin/packages/spark/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import re
-import shutil
 
 from spack import *
 
@@ -64,7 +63,7 @@ class Spark(Package):
         install_dir('yarn')
 
         # required for spark to recognize binary distribution
-        shutil.copy('RELEASE', prefix)
+        install('RELEASE', prefix)
 
     @when('+hadoop')
     def setup_environment(self, spack_env, run_env):

--- a/var/spack/repos/builtin/packages/sublime-text/package.py
+++ b/var/spack/repos/builtin/packages/sublime-text/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from distutils.dir_util import copy_tree
 
 
 class SublimeText(Package):
@@ -56,4 +55,4 @@ class SublimeText(Package):
 
     def install(self, spec, prefix):
         # Sublime text comes as a pre-compiled binary.
-        copy_tree('.', prefix)
+        install_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/supernova/package.py
+++ b/var/spack/repos/builtin/packages/supernova/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from distutils.dir_util import copy_tree
 import os
 
 
@@ -62,4 +61,4 @@ class Supernova(Package):
         # remove the broken symlinks
         rm('anaconda-cs/2.2.0-anaconda-cs-c7/lib/libtcl.so',
             'anaconda-cs/2.2.0-anaconda-cs-c7/lib/libtk.so')
-        copy_tree('.', prefix, preserve_symlinks=1)
+        install_tree('.', prefix, preserve_symlinks=1)

--- a/var/spack/repos/builtin/packages/the-platinum-searcher/package.py
+++ b/var/spack/repos/builtin/packages/the-platinum-searcher/package.py
@@ -23,8 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import os
-import shutil
 
 
 class ThePlatinumSearcher(Package):
@@ -39,7 +37,6 @@ class ThePlatinumSearcher(Package):
     extends("go", deptypes='build')
 
     def install(self, spec, prefix):
-        env = os.environ
         env['GOPATH'] = self.stage.source_path + ':' + env['GOPATH']
         go('install', self.package, env=env)
-        shutil.copytree('bin', os.path.join(prefix, 'bin'))
+        install_tree('bin', prefix.bin)

--- a/var/spack/repos/builtin/packages/tinyxml/package.py
+++ b/var/spack/repos/builtin/packages/tinyxml/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from shutil import copyfile
 import os.path
 
 
@@ -42,8 +41,8 @@ class Tinyxml(CMakePackage):
         return url.format(version.dotted, version.underscored)
 
     def patch(self):
-        copyfile(join_path(os.path.dirname(__file__),
-                           "CMakeLists.txt"), "CMakeLists.txt")
+        install(join_path(os.path.dirname(__file__),
+                "CMakeLists.txt"), "CMakeLists.txt")
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/trimmomatic/package.py
+++ b/var/spack/repos/builtin/packages/trimmomatic/package.py
@@ -23,8 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from distutils.dir_util import copy_tree
-from shutil import copyfile
 import os.path
 
 
@@ -47,18 +45,18 @@ class Trimmomatic(Package):
         install(jar_file, prefix.bin)
 
         # Put the adapter files someplace sensible
-        copy_tree('adapters', join_path(self.prefix.share, 'adapters'))
+        install_tree('adapters', join_path(self.prefix.share, 'adapters'))
 
         # Set up a helper script to call java on the jar file,
         # explicitly codes the path for java and the jar file.
         script_sh = join_path(os.path.dirname(__file__), "trimmomatic.sh")
-        script = join_path(prefix.bin, "trimmomatic")
-        copyfile(script_sh, script)
+        script = prefix.bin.trimmomatic
+        install(script_sh, script)
         set_executable(script)
 
         # Munge the helper script to explicitly point to java and the
         # jar file.
-        java = join_path(self.spec['java'].prefix, 'bin', 'java')
+        java = self.spec['java'].prefix.bin.java
         kwargs = {'ignore_absent': False, 'backup': False, 'string': False}
         filter_file('^java', java, script, **kwargs)
         filter_file('trimmomatic.jar', join_path(prefix.bin, jar_file),

--- a/var/spack/repos/builtin/packages/trinity/package.py
+++ b/var/spack/repos/builtin/packages/trinity/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from distutils.dir_util import copy_tree
 
 
 class Trinity(MakefilePackage):
@@ -55,7 +54,7 @@ class Trinity(MakefilePackage):
         make("plugins")
 
     def install(self, spec, prefix):
-        copy_tree('.', prefix.bin, preserve_symlinks=1)
+        install_tree('.', prefix.bin, preserve_symlinks=1)
         force_remove(join_path(prefix.bin, '.gitmodules'))
         force_remove(join_path(prefix.bin, 'Butterfly', '.err'))
         force_remove(join_path(prefix.bin, 'Butterfly', 'src', '.classpath'))

--- a/var/spack/repos/builtin/packages/wannier90/package.py
+++ b/var/spack/repos/builtin/packages/wannier90/package.py
@@ -24,7 +24,6 @@
 ##############################################################################
 import inspect
 import os.path
-import shutil
 
 from spack import *
 
@@ -77,7 +76,7 @@ class Wannier90(MakefilePackage):
             'make.sys'
         )
 
-        shutil.copy(template, self.makefile_name)
+        install(template, self.makefile_name)
         for key, value in substitutions.items():
             filter_file(key, value, self.makefile_name)
 

--- a/var/spack/repos/builtin/packages/yorick/package.py
+++ b/var/spack/repos/builtin/packages/yorick/package.py
@@ -24,8 +24,6 @@
 ##############################################################################
 from spack import *
 import os
-import shutil
-import glob
 
 
 class Yorick(Package):
@@ -75,13 +73,4 @@ class Yorick(Package):
         make()
         make("install")
 
-        try:
-            os.makedirs(prefix)
-        except OSError:
-            pass
-        os.chdir("relocate")
-        for f in glob.glob('*'):
-            if os.path.isdir(f):
-                shutil.copytree(f, os.path.join(prefix, f))
-            else:
-                shutil.copy2(f, os.path.join(prefix, f))
+        install_tree('relocate', prefix)


### PR DESCRIPTION
I've been meaning to do this for years, but kept forgetting.

Spack has these really useful `install` and `install_tree` commands for copying files and directories to the installation directory. The only problem is that `install_tree` crashed if the directory you were trying to install to already existed (for example, if you wanted to copy everything in the current directory to `prefix`). See https://github.com/spack/spack/pull/8126/files#r188393176 for an example error message.

This PR replaces the call to [`shutil.copytree`](https://docs.python.org/3/library/shutil.html#shutil.copytree) with a call to [`distutils.dir_util.copy_tree`](https://docs.python.org/3.6/distutils/apiref.html#distutils.dir_util.copy_tree). As far as I can tell, these functions are largely the same, except that `distutils.dir_util.copy_tree` works when the destination directory already exists and `shutil.copytree` does not. If you know of any other important differences, please let me know.

Also replaced dozens of calls to `shutil` and `distutils.dir_util` with `install` and `install_tree`. Note that I didn't test any of these package installations, so a careful review would be appreciated.