### PR TITLE
fix leftover references to spack.<symbol>

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -546,10 +546,10 @@ def get_std_cmake_args(pkg):
 
 def parent_class_modules(cls):
     """
-    Get list of super class modules that are all descend from spack.Package
+    Get list of superclass modules that descend from spack.package.PackageBase
     """
-    if (not issubclass(cls, spack.package.Package) or
-        issubclass(spack.package.Package, cls)):
+    if (not issubclass(cls, spack.package.PackageBase) or
+        issubclass(spack.package.PackageBase, cls)):
         return []
     result = []
     module = sys.modules.get(cls.__module__)

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -25,7 +25,7 @@
 import llnl.util.tty as tty
 
 import spack.repo
-import spack.cmd
+import spack.spec
 import spack.cmd.common.arguments as arguments
 
 description = "Bootstrap packages needed for spack to run smoothly"
@@ -74,7 +74,7 @@ def bootstrap(parser, args, **kwargs):
                     "package %s" % (requirement, installed_specs[0]))
         else:
             # Install requirement
-            spec_to_install = spack.Spec(requirement_dict[requirement])
+            spec_to_install = spack.spec.Spec(requirement_dict[requirement])
             spec_to_install.concretize()
             tty.msg("Installing %s to satisfy requirement for %s" %
                     (spec_to_install, requirement))

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import spack.config
+from spack.util.editor import editor
 
 description = "get and set configuration options"
 section = "config"
@@ -70,7 +71,7 @@ def config_edit(args):
 
     config = spack.config.config
     config_file = config.get_config_filename(args.scope, args.section)
-    spack.editor(config_file)
+    editor(config_file)
 
 
 def config(parser, args):

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -34,6 +34,7 @@ import spack.cmd
 import spack.util.web
 import spack.repo
 from spack.spec import Spec
+from spack.util.editor import editor
 from spack.util.executable import which, ProcessError
 from spack.util.naming import mod_to_class
 from spack.util.naming import simplify_name, valid_fully_qualified_module_name
@@ -693,4 +694,4 @@ def create(parser, args):
     tty.msg("Created package file: {0}".format(pkg_path))
 
     # Open up the new package file in your $EDITOR
-    spack.editor(pkg_path)
+    editor(pkg_path)

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -27,8 +27,9 @@ from __future__ import print_function
 import argparse
 
 import spack.cmd
-import spack.store
+import spack.package
 import spack.repo
+import spack.store
 
 from llnl.util import tty
 
@@ -152,7 +153,7 @@ def do_uninstall(specs, force):
         except spack.repo.UnknownEntityError:
             # The package.py file has gone away -- but still
             # want to uninstall.
-            spack.Package.uninstall_by_spec(item, force=True)
+            spack.package.Package.uninstall_by_spec(item, force=True)
 
     # Sort packages to be uninstalled by the number of installed dependents
     # This ensures we do things in the right order

--- a/lib/spack/spack/operating_systems/cray_frontend.py
+++ b/lib/spack/spack/operating_systems/cray_frontend.py
@@ -61,7 +61,7 @@ class CrayFrontend(LinuxDistro):
             # 'intel', 'cce', 'gcc', etc.) will also be unloaded since they are
             # specified as prerequisites in the PrgEnv-* modulefiles.
             modulecmd = get_module_cmd()
-            exec (compile(
+            exec(compile(
                 modulecmd('unload', prg_env, output=str, error=os.devnull),
                 '<string>', 'exec'))
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -273,10 +273,9 @@ class PackageBase(with_metaclass(PackageMeta, object)):
     packages it depends on, so that dependencies can be installed along
     with the package itself.  Packages are written in pure python.
 
-    Packages are all submodules of spack.packages.  If spack is installed
-    in ``$prefix``, all of its python files are in ``$prefix/lib/spack``.
-    Most of them are in the spack module, so all the packages live in
-    ``$prefix/lib/spack/spack/packages``.
+    Packages live in repositories (see repo.py).  If spack is installed
+    in ``$prefix``, all of its built-in package files are in the builtin
+    repo at ``$prefix/var/spack/repos/builtin/packages``.
 
     All you have to do to create a package is make a new subclass of Package
     in this directory.  Spack automatically scans the python files there
@@ -497,6 +496,7 @@ class PackageBase(with_metaclass(PackageMeta, object)):
 
     Package creators override functions like install() (all of them do this),
     clean() (some of them do this), and others to provide custom behavior.
+
     """
     #
     # These are default values for instance variables.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -183,7 +183,7 @@ hash_color = '@K'              #: color for highlighting package hashes
 
 #: This map determines the coloring of specs when using color output.
 #: We make the fields different colors to enhance readability.
-#: See spack.color for descriptions of the color codes.
+#: See llnl.util.tty.color for descriptions of the color codes.
 color_formats = {'%': compiler_color,
                  '@': version_color,
                  '=': architecture_color,

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -145,10 +145,6 @@ class Stage(object):
         finally:
             stage.destroy()         # Explicitly destroy the stage directory.
 
-    If spack.use_tmp_stage is True, spack will attempt to create
-    stages in a tmp directory.  Otherwise, stages are created directly
-    in spack.paths.stage_path.
-
     There are two kinds of stages: named and unnamed.  Named stages
     can persist between runs of spack, e.g. if you fetched a tarball
     but didn't finish building it, you won't have to fetch it again.
@@ -481,10 +477,6 @@ class Stage(object):
         directly under spack.paths.stage_path, otherwise this will attempt to
         create a stage in a temporary directory and link it into
         spack.paths.stage_path.
-
-        Spack will use the first writable location in spack.tmp_dirs
-        to create a stage. If there is no valid location in tmp_dirs,
-        fall back to making the stage inside spack.paths.stage_path.
 
         """
         # Create the top-level stage directory

--- a/lib/spack/spack/util/spack_json.py
+++ b/lib/spack/spack/util/spack_json.py
@@ -59,7 +59,7 @@ def dump(data, stream=None):
 def _strify(data, ignore_dicts=False):
     # if this is a unicode string in python 2, return its string representation
     if sys.version_info[0] < 3:
-        if isinstance(data, unicode):
+        if isinstance(data, string_types):
             return data.encode('utf-8')
 
     # if this is a list of values, return list of byteified values


### PR DESCRIPTION
Fixes #8196.

Fixes issue mentioned by @adamjstewart at [#8090 (comment)](https://github.com/spack/spack/pull/8090#issuecomment-390375659), along with some other lingering undefined names and flake8 errors.

- there were some leftover spack.* names being used after we removed globals and moved everything in the top-level namespace to spack.pkgkit

- point those references to their new homes