### PR TITLE
Add cURL 7.60.0

### DIFF
--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -32,8 +32,9 @@ class Curl(AutotoolsPackage):
 
     homepage = "http://curl.haxx.se"
     # URL must remain http:// so Spack can bootstrap curl
-    url      = "http://curl.haxx.se/download/curl-7.54.0.tar.bz2"
+    url      = "http://curl.haxx.se/download/curl-7.60.0.tar.bz2"
 
+    version('7.60.0', 'bd2aabf78ded6a9aec8a54532fd6b5d7')
     version('7.59.0', 'a2192804f7c2636a09320416afcf888e')
     version('7.56.0', 'e0caf257103e0c77cee5be7e9ac66ca4')
     version('7.54.0', '89bb7ba87384dfbf4f1a3f953da42458')


### PR DESCRIPTION
Successfully installed on macOS 10.13.4 with Clang 9.0.0. Passed 924 out of 925 unit tests, not sure why 1 failed. But Homebrew is also using 7.60.0, so I'm not too worried.