### PR TITLE
Add sqlite 3.23.1

### DIFF
--- a/var/spack/repos/builtin/packages/sqlite/package.py
+++ b/var/spack/repos/builtin/packages/sqlite/package.py
@@ -33,6 +33,8 @@ class Sqlite(AutotoolsPackage):
     """
     homepage = "www.sqlite.org"
 
+    version('3.23.1', '0edbfd75ececb95e8e6448d6ff33df82774c9646',
+            url='https://www.sqlite.org/2018/sqlite-autoconf-3230100.tar.gz')
     version('3.22.0', '2fb24ec12001926d5209d2da90d252b9825366ac',
             url='https://www.sqlite.org/2018/sqlite-autoconf-3220000.tar.gz')
     version('3.21.0', '7913de4c3126ba3c24689cb7a199ea31',


### PR DESCRIPTION
Successfully installed on macOS 10.13.4 with Clang 9.0.0.