### PR TITLE
Add PCRE2 10.31

### DIFF
--- a/var/spack/repos/builtin/packages/pcre2/package.py
+++ b/var/spack/repos/builtin/packages/pcre2/package.py
@@ -29,7 +29,9 @@ class Pcre2(AutotoolsPackage):
     """The PCRE2 package contains Perl Compatible Regular Expression
        libraries. These are useful for implementing regular expression
        pattern matching using the same syntax and semantics as Perl 5."""
-    homepage = "http://www.pcre.org"""
-    url      = "https://ftp.pcre.org/pub/pcre/pcre2-10.20.tar.bz2"
 
+    homepage = "http://www.pcre.org"""
+    url      = "https://ftp.pcre.org/pub/pcre/pcre2-10.31.tar.bz2"
+
+    version('10.31', 'e0b91c891a3c49050f7fd15de33d0ba4')
     version('10.20', 'dcd027c57ecfdc8a6c3af9d0acf5e3f7')


### PR DESCRIPTION
Successfully built and passed all unit tests on macOS 10.13.4 with Clang 9.0.0.