### PR TITLE
Add url_for_version and list_url to Ruby package

### DIFF
--- a/var/spack/repos/builtin/packages/ruby/package.py
+++ b/var/spack/repos/builtin/packages/ruby/package.py
@@ -30,11 +30,10 @@ class Ruby(AutotoolsPackage):
     simplicity and productivity."""
 
     homepage = "https://www.ruby-lang.org/"
-    url      = "http://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.1.tar.gz"
+    url      = "http://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0.tar.gz"
     list_url = "http://cache.ruby-lang.org/pub/ruby/"
     list_depth = 1
 
-    version('2.5.1', '23867bc8c16c55e43b14dfe0614bcfa8')
     version('2.2.0', 'cd03b28fd0b555970f5c4fd481700852')
 
     variant('openssl', default=True, description="Enable OpenSSL support")

--- a/var/spack/repos/builtin/packages/ruby/package.py
+++ b/var/spack/repos/builtin/packages/ruby/package.py
@@ -30,8 +30,11 @@ class Ruby(AutotoolsPackage):
     simplicity and productivity."""
 
     homepage = "https://www.ruby-lang.org/"
-    url      = "http://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0.tar.gz"
+    url      = "http://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.1.tar.gz"
+    list_url = "http://cache.ruby-lang.org/pub/ruby/"
+    list_depth = 1
 
+    version('2.5.1', '23867bc8c16c55e43b14dfe0614bcfa8')
     version('2.2.0', 'cd03b28fd0b555970f5c4fd481700852')
 
     variant('openssl', default=True, description="Enable OpenSSL support")
@@ -62,6 +65,10 @@ class Ruby(AutotoolsPackage):
         placement='rubygems-updated-ssl-cert',
         expand=False
     )
+
+    def url_for_version(self, version):
+        url = "http://cache.ruby-lang.org/pub/ruby/{0}/ruby-{1}.tar.gz"
+        return url.format(version.up_to(2), version)
 
     def configure_args(self):
         args = []


### PR DESCRIPTION
I can successfully build this, but it currently crashes during the `post_install` step.

@goxberry It looks like you wrote this logic in #6935. Can you take a look? It seems like the problem is that the destination directory no longer exists. This isn't hard to fix, but I'm wondering if this resource is even needed anymore, or if we are missing a new resource.