### PR TITLE
Add Python/Ruby bindings to GEOS package

### DIFF
--- a/var/spack/repos/builtin/packages/geos/package.py
+++ b/var/spack/repos/builtin/packages/geos/package.py
@@ -59,6 +59,9 @@ class Geos(AutotoolsPackage):
     variant('python', default=False, description='Enable Python support')
 
     extends('ruby', when='+ruby')
+
+    # Python 3 is supposedly supported, but I couldn't get it to work
+    # https://trac.osgeo.org/geos/ticket/774
     extends('python@:2', when='+python')
 
     depends_on('swig', type='build', when='+ruby')

--- a/var/spack/repos/builtin/packages/geos/package.py
+++ b/var/spack/repos/builtin/packages/geos/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Geos(Package):
+class Geos(AutotoolsPackage):
     """GEOS (Geometry Engine - Open Source) is a C++ port of the Java
        Topology Suite (JTS). As such, it aims to contain the complete
        functionality of JTS in C++. This includes all the OpenGIS
@@ -33,15 +33,12 @@ class Geos(Package):
        operators, as well as specific JTS enhanced topology functions."""
 
     homepage = "http://trac.osgeo.org/geos/"
-    url      = "http://download.osgeo.org/geos/geos-3.4.2.tar.bz2"
+    url      = "http://download.osgeo.org/geos/geos-3.6.2.tar.bz2"
 
-    # Versions from 3.5.1 support Autotools and CMake
     version('3.6.2', 'a32142343c93d3bf151f73db3baa651f')
     version('3.6.1', 'c97e338b3bc81f9848656e9d693ca6cc')
     version('3.6.0', '55de5fdf075c608d2d7b9348179ee649')
     version('3.5.1', '2e3e1ccbd42fee9ec427106b65e43dc0')
-
-    # Versions through 3.5.0 have CMake, but only Autotools is supported
     version('3.5.0', '136842690be7f504fba46b3c539438dd')
     version('3.4.3', '77f2c2cca1e9f49bc1bece9037ac7a7a')
     version('3.4.2', 'fc5df2d926eb7e67f988a43a92683bae')
@@ -55,21 +52,36 @@ class Geos(Package):
     version('3.3.4', '1bb9f14d57ef06ffa41cb1d67acb55a1')
     version('3.3.3', '8454e653d7ecca475153cc88fd1daa26')
 
-#    # Python3 is not supported.
-#    variant('python', default=False, description='Enable Python support')
+    # Ruby bindings are fully supported
+    variant('ruby',   default=False, description='Enable Ruby support')
 
-#    extends('python', when='+python')
-#    depends_on('python', when='+python')
-#    depends_on('swig', when='+python')
+    # Since version 3.0, the Python bindings are unsupported
+    variant('python', default=False, description='Enable Python support')
 
-    def install(self, spec, prefix):
-        args = ["--prefix=%s" % prefix]
-#        if '+python' in spec:
-#            os.environ['PYTHON'] = spec['python'].command.path
-#            os.environ['SWIG'] = spec['swig'].command.path
-#
-#            args.append("--enable-python")
+    extends('ruby', when='+ruby')
+    extends('python@:2', when='+python')
 
-        configure(*args)
-        make()
-        make("install")
+    depends_on('swig', type='build', when='+ruby')
+    depends_on('swig', type='build', when='+python')
+
+    # `make check` fails with:
+    # FAIL: geos_unit
+
+    # I wasn't able to get the ruby bindings working.
+    # It resulted in "Undefined symbols for architecture x86_64".
+
+    def configure_args(self):
+        spec = self.spec
+        args = []
+
+        if '+ruby' in spec:
+            args.append('--enable-ruby')
+        else:
+            args.append('--disable-ruby')
+
+        if '+python' in spec:
+            args.append('--enable-python')
+        else:
+            args.append('--disable-python')
+
+        return args


### PR DESCRIPTION
I added variants to enable/disable the Python/Ruby bindings for the GEOS package. I also converted the package to `AutotoolsPackage`.

Unfortunately, I couldn't get the Ruby bindings working. I kept getting:
```
Undefined symbols for architecture x86_64:
  "_rb_ary_entry", referenced from:
      _wrap_create_polygon(int, unsigned long*, unsigned long) in geos_la-geos_wrap.o
  "_rb_big2long", referenced from:
      SWIG_AUX_NUM2LONG(unsigned long*) in geos_la-geos_wrap.o
  "_rb_big2ulong", referenced from:
      SWIG_AUX_NUM2ULONG(unsigned long*) in geos_la-geos_wrap.o
  "_rb_block_given_p", referenced from:
      GeosSTRtree_query_callback(void*, void*) in geos_la-geos_wrap.o
  "_rb_cFalseClass", referenced from:
...
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[5]: *** [geos.la] Error 1
make[4]: *** [all-recursive] Error 1
make[3]: *** [all] Error 2
make[2]: *** [all-recursive] Error 1
make[1]: *** [all-recursive] Error 1
make: *** [all] Error 2
```
Not sure if this is a macOS bug or I'm using the wrong version of swig or what.

The test suite also fails one of its tests.