### PR TITLE
kokkos: update kokkos spackage to add current host/gpu architectures.

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -52,8 +52,9 @@ class Kokkos(Package):
     variant(
         'host_arch',
         default='none',
-        values=('none','AMDAVX','ARMv80','ARMv81','ARMv8-ThunderX','Power7','Power8','Power9',
-                'WSM','SNB','HSW','BDW','SKX','KNC','KNL'),
+        values=('none', 'AMDAVX', 'ARMv80', 'ARMv81', 'ARMv8-ThunderX',
+                'Power7', 'Power8', 'Power9',
+                'WSM', 'SNB', 'HSW', 'BDW', 'SKX', 'KNC', 'KNL'),
         description='Set the host architecture to use'
     )
 
@@ -61,8 +62,9 @@ class Kokkos(Package):
     variant(
         'gpu_arch',
         default='none',
-        values=('none','Kepler30','Kepler32','Kepler35','Kepler37','Maxwell50','Maxwell52',
-                'Maxwell53','Pascal60','Pascal61'),
+        values=('none', 'Kepler30', 'Kepler32', 'Kepler35', 'Kepler37',
+                'Maxwell50', 'Maxwell52', 'Maxwell53',
+                'Pascal60', 'Pascal61'),
         description='Set the GPU architecture to use'
     )
 
@@ -97,18 +99,19 @@ class Kokkos(Package):
             gpu_arch_args  = spec.variants['gpu_arch'].value
 
             # only a host architecture
-            if (host_arch_args!="none" AND gpu_arch_args=""):
-                arch_args = '--arch='+host_arch_args
+            if (host_arch_args != 'none' AND gpu_arch_args == ''):
+                arch_args = '--arch=' + host_arch_args
             # only a gpu architecture
-            if (host_arch_args="" AND gpu_arch_args!="none"):
+            if (host_arch_args == '' AND gpu_arch_args != 'none'):
                 if '+cuda' in spec:
-                    arch_args = '--arch='+gpu_arch_args
+                    arch_args = '--arch=' + gpu_arch_args
             # both a host and a gpu architecture
-            if (host_arch_args!="none" AND gpu_arch_args!="none"):
+            if (host_arch_args != 'none' AND gpu_arch_args != 'none'):
                 if '+cuda' in spec:
-                    arch_args = '--arch='+host_arch_args+','+gpu_arch_args
+                    arch_args = '--arch=' + host_arch_args
+                    + ',' + gpu_arch_args
 
-            if arch_args != "":
+            if arch_args != '':
                 g_args += arch_args
 
             generate(*g_args)

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -73,9 +73,14 @@ class Kokkos(Package):
     # Check that we haven't specified a gpu architecture
     # without specifying CUDA
     for p in gpu_values:
-        conflicts('--arch={0}'.format(p), when='~cuda',
+        conflicts('gpu_arch={0}'.format(p), when='~cuda',
             msg='Must specify CUDA backend to use a GPU architecture.')
 
+    # conflicts on kokkos version and cuda enabled
+    # see kokkos issue #1296
+    # https://github.com/kokkos/kokkos/issues/1296
+    conflicts('+cuda',when='@2.5.00:develop')
+    
     # Specify that v1.x is required as v2.x has API changes
     depends_on('hwloc@:1')
     depends_on('qthreads', when='+qthreads')

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -71,8 +71,6 @@ class Kokkos(Package):
     depends_on('qthreads', when='+qthreads')
     depends_on('cuda', when='+cuda')
 
-    # Conflicts
-    conflicts()
     def install(self, spec, prefix):
         generate = which(join_path(self.stage.source_path,
                                    'generate_makefile.bash'))
@@ -93,62 +91,20 @@ class Kokkos(Package):
             if 'cuda' in spec:
                 g_args.append('--with-cuda=%s' % spec['cuda'].prefix)
             # host architectures
-            if 'host_arch=AMDAVX' in spec:
-                host_arch_args = 'AMDAVX'
-            if 'host_arch=ARMv80' in spec:
-                host_arch_args = 'ARMv80'
-            if 'host_arch=ARMv81' in spec:
-                host_arch_args = 'ARMv81'
-            if 'host_arch=ARMv8-ThunderX' in spec:
-                host_arch_args = 'ARMv8-ThunderX'
-            if 'host_arch=Power7' in spec:
-                host_arch_args = 'Power7'
-            if 'host_arch=Power8' in spec:
-                host_arch_args = 'Power8'
-            if 'host_arch=Power9' in spec:
-                host_arch_args = 'Power9'
-            if 'host_arch=WSM' in spec:
-                host_arch_args = 'WSM'
-            if 'host_arch=SNB' in spec:
-                host_arch_args = 'SNB'
-            if 'host_arch=HSW' in spec:
-                host_arch_args = 'HSW'
-            if 'host_arch=BDW' in spec:
-                host_arch_args = 'BDW'
-            if 'host_arch=SKX' in spec:
-                host_arch_args = 'SKX'
-            if 'host_arch=KNC' in spec:
-                host_arch_args = 'KNC'
-            if 'host_arch=KNL' in spec:
-                host_arch_args = 'KNL'
+            host_arch_args = spec.variants['host_arch'].value
+
             # gpu architectures
-            if 'gpu_arch=Kepler30' in spec:
-                gpu_arch_args = 'Kepler30'
-            if 'gpu_arch=Kepler32' in spec:
-                gpu_arch_args = 'Kepler32'
-            if 'gpu_arch=Kepler35' in spec:
-                gpu_arch_args = 'Kepler35'
-            if 'gpu_arch=Kepler37' in spec:
-                gpu_arch_args = 'Kepler37'
-            if 'gpu_arch=Maxwell50' in spec:
-                gpu_arch_args = 'Maxwell50'
-            if 'gpu_arch=Maxwell52' in spec:
-                gpu_arch_args = 'Maxwell52'
-            if 'gpu_arch=Maxwell53' in spec:
-                gpu_arch_args = 'Maxwell53'
-            if 'gpu_arch=Pascal60' in spec:
-                gpu_arch_args = 'Pascal60'
-            if 'gpu_arch=Pascal61' in spec:
-                gpu_arch_args = 'Pascal61'
+            gpu_arch_args  = spec.variants['gpu_arch'].value
+
             # only a host architecture
-            if (host_arch_args!="" AND gpu_arch_args=""):
+            if (host_arch_args!="none" AND gpu_arch_args=""):
                 arch_args = '--arch='+host_arch_args
             # only a gpu architecture
-            if (host_arch_args="" AND gpu_arch_args!=""):
+            if (host_arch_args="" AND gpu_arch_args!="none"):
                 if '+cuda' in spec:
                     arch_args = '--arch='+gpu_arch_args
             # both a host and a gpu architecture
-            if (host_arch_args!="" AND gpu_arch_args!=""):
+            if (host_arch_args!="none" AND gpu_arch_args!="none"):
                 if '+cuda' in spec:
                     arch_args = '--arch='+host_arch_args+','+gpu_arch_args
 

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -79,7 +79,10 @@ class Kokkos(Package):
     # conflicts on kokkos version and cuda enabled
     # see kokkos issue #1296
     # https://github.com/kokkos/kokkos/issues/1296
-    conflicts('+cuda', when='@2.5.00:develop')
+    conflicts('+cuda', when='@2.5.00:develop',
+        msg='Kokkos build system has issue when CUDA enabled'
+        ' in version 2.5.00, and develop until '
+        'issue #1296 is resolved.')
 
     # Specify that v1.x is required as v2.x has API changes
     depends_on('hwloc@:1')

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -79,8 +79,8 @@ class Kokkos(Package):
     # conflicts on kokkos version and cuda enabled
     # see kokkos issue #1296
     # https://github.com/kokkos/kokkos/issues/1296
-    conflicts('+cuda',when='@2.5.00:develop')
-    
+    conflicts('+cuda', when='@2.5.00:develop')
+
     # Specify that v1.x is required as v2.x has API changes
     depends_on('hwloc@:1')
     depends_on('qthreads', when='+qthreads')

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -55,7 +55,7 @@ class Kokkos(Package):
     # Host architecture variant
     variant(
         'host_arch',
-        default='None',
+        default=None,
         values=('AMDAVX', 'ARMv80', 'ARMv81', 'ARMv8-ThunderX',
                 'Power7', 'Power8', 'Power9',
                 'WSM', 'SNB', 'HSW', 'BDW', 'SKX', 'KNC', 'KNL'),
@@ -65,7 +65,7 @@ class Kokkos(Package):
     # GPU architecture variant
     variant(
         'gpu_arch',
-        default='None',
+        default=None,
         values=gpu_values,
         description='Set the GPU architecture to use'
     )

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -46,13 +46,33 @@ class Kokkos(Package):
 
     variant('qthreads', default=False, description="enable Qthreads backend")
     variant('cuda', default=False, description="enable Cuda backend")
-    variant('openmp', default=True, description="enable OpenMP backend")
+    variant('openmp', default=False, description="enable OpenMP backend")
+
+    # host architecture variant
+    variant(
+        'host_arch',
+        default='none',
+        values=('none','AMDAVX','ARMv80','ARMv81','ARMv8-ThunderX','Power7','Power8','Power9',
+                'WSM','SNB','HSW','BDW','SKX','KNC','KNL'),
+        description='Set the host architecture to use'
+    )
+
+    # gpu architecture variant
+    variant(
+        'gpu_arch',
+        default='none',
+        values=('none','Kepler30','Kepler32','Kepler35','Kepler37','Maxwell50','Maxwell52',
+                'Maxwell53','Pascal60','Pascal61'),
+        description='Set the GPU architecture to use'
+    )
 
     # Specify that v1.x is required as v2.x has API changes
     depends_on('hwloc@:1')
     depends_on('qthreads', when='+qthreads')
     depends_on('cuda', when='+cuda')
 
+    # Conflicts
+    conflicts()
     def install(self, spec, prefix):
         generate = which(join_path(self.stage.source_path,
                                    'generate_makefile.bash'))
@@ -62,12 +82,78 @@ class Kokkos(Package):
                 '--with-hwloc=%s' % spec['hwloc'].prefix,
                 '--with-serial'
             ]
+            arch_args = []
+            host_arch_args = []
+            gpu_arch_args = []
+            # backends
             if '+openmp' in spec:
                 g_args.append('--with-openmp')
             if 'qthreads' in spec:
                 g_args.append('--with-qthreads=%s' % spec['qthreads'].prefix)
             if 'cuda' in spec:
                 g_args.append('--with-cuda=%s' % spec['cuda'].prefix)
+            # host architectures
+            if 'host_arch=AMDAVX' in spec:
+                host_arch_args = 'AMDAVX'
+            if 'host_arch=ARMv80' in spec:
+                host_arch_args = 'ARMv80'
+            if 'host_arch=ARMv81' in spec:
+                host_arch_args = 'ARMv81'
+            if 'host_arch=ARMv8-ThunderX' in spec:
+                host_arch_args = 'ARMv8-ThunderX'
+            if 'host_arch=Power7' in spec:
+                host_arch_args = 'Power7'
+            if 'host_arch=Power8' in spec:
+                host_arch_args = 'Power8'
+            if 'host_arch=Power9' in spec:
+                host_arch_args = 'Power9'
+            if 'host_arch=WSM' in spec:
+                host_arch_args = 'WSM'
+            if 'host_arch=SNB' in spec:
+                host_arch_args = 'SNB'
+            if 'host_arch=HSW' in spec:
+                host_arch_args = 'HSW'
+            if 'host_arch=BDW' in spec:
+                host_arch_args = 'BDW'
+            if 'host_arch=SKX' in spec:
+                host_arch_args = 'SKX'
+            if 'host_arch=KNC' in spec:
+                host_arch_args = 'KNC'
+            if 'host_arch=KNL' in spec:
+                host_arch_args = 'KNL'
+            # gpu architectures
+            if 'gpu_arch=Kepler30' in spec:
+                gpu_arch_args = 'Kepler30'
+            if 'gpu_arch=Kepler32' in spec:
+                gpu_arch_args = 'Kepler32'
+            if 'gpu_arch=Kepler35' in spec:
+                gpu_arch_args = 'Kepler35'
+            if 'gpu_arch=Kepler37' in spec:
+                gpu_arch_args = 'Kepler37'
+            if 'gpu_arch=Maxwell50' in spec:
+                gpu_arch_args = 'Maxwell50'
+            if 'gpu_arch=Maxwell52' in spec:
+                gpu_arch_args = 'Maxwell52'
+            if 'gpu_arch=Maxwell53' in spec:
+                gpu_arch_args = 'Maxwell53'
+            if 'gpu_arch=Pascal60' in spec:
+                gpu_arch_args = 'Pascal60'
+            if 'gpu_arch=Pascal61' in spec:
+                gpu_arch_args = 'Pascal61'
+            # only a host architecture
+            if (host_arch_args!="" AND gpu_arch_args=""):
+                arch_args = '--arch='+host_arch_args
+            # only a gpu architecture
+            if (host_arch_args="" AND gpu_arch_args!=""):
+                if '+cuda' in spec:
+                    arch_args = '--arch='+gpu_arch_args
+            # both a host and a gpu architecture
+            if (host_arch_args!="" AND gpu_arch_args!=""):
+                if '+cuda' in spec:
+                    arch_args = '--arch='+host_arch_args+','+gpu_arch_args
+
+            if arch_args != "":
+                g_args += arch_args
 
             generate(*g_args)
             make()


### PR DESCRIPTION
Supersedes #8169 . Adds multi-valued variants for current host and gpu architectures. Includes logic that allows for only one host and one gpu architecture, and populates build arguments appropriately.