### PR TITLE
Add PROJ 5.0.1

### DIFF
--- a/var/spack/repos/builtin/packages/proj/package.py
+++ b/var/spack/repos/builtin/packages/proj/package.py
@@ -47,10 +47,10 @@ class Proj(AutotoolsPackage):
         name='proj-datumgrid',
         url='https://download.osgeo.org/proj/proj-datumgrid-1.7.tar.gz',
         md5='6799bd8ac411b8a78724e34850c206c4',
-        placement='share'
+        placement='nad'
     )
 
     def configure_args(self):
         return [
-            'PROJ_LIB={0}'.format(join_path(self.stage.source_path, 'share'))
+            'PROJ_LIB={0}'.format(join_path(self.stage.source_path, 'nad'))
         ]

--- a/var/spack/repos/builtin/packages/proj/package.py
+++ b/var/spack/repos/builtin/packages/proj/package.py
@@ -26,12 +26,31 @@ from spack import *
 
 
 class Proj(AutotoolsPackage):
-    """Cartographic Projections"""
-    homepage = "https://github.com/OSGeo/proj.4/wiki"
-    url      = "http://download.osgeo.org/proj/proj-4.9.2.tar.gz"
+    """PROJ is a generic coordinate transformation software, that transforms
+    geospatial coordinates from one coordinate reference system (CRS) to
+    another. This includes cartographic projections as well as geodetic
+    transformations."""
 
+    homepage = "https://proj4.org/"
+    url      = "http://download.osgeo.org/proj/proj-5.0.1.tar.gz"
+
+    version('5.0.1', '15c8d7d6a8cb945c7878d0ff322a232c')
     version('4.9.2', '9843131676e31bbd903d60ae7dc76cf9')
     version('4.9.1', '3cbb2a964fd19a496f5f4265a717d31c')
     version('4.8.0', 'd815838c92a29179298c126effbb1537')
     version('4.7.0', '927d34623b52e0209ba2bfcca18fe8cd')
     version('4.6.1', '7dbaab8431ad50c25669fd3fb28dc493')
+
+    # https://github.com/OSGeo/proj.4#distribution-files-and-format
+    # https://github.com/OSGeo/proj-datumgrid
+    resource(
+        name='proj-datumgrid',
+        url='https://download.osgeo.org/proj/proj-datumgrid-1.7.tar.gz',
+        md5='6799bd8ac411b8a78724e34850c206c4',
+        placement='share'
+    )
+
+    def configure_args(self):
+        return [
+            'PROJ_LIB={0}'.format(join_path(self.stage.source_path, 'share'))
+        ]


### PR DESCRIPTION
Adds the latest versions of PROJ.4. Successfully installs on macOS 10.13.4 with Clang 9.0.0. Unfortunately, I couldn't get the unit tests to pass. Opened an issue: https://github.com/OSGeo/proj.4/issues/1003