### PR TITLE
Add kealib 1.4.7

### DIFF
--- a/var/spack/repos/builtin/packages/kealib/cmake.patch
+++ b/var/spack/repos/builtin/packages/kealib/cmake.patch
@@ -1,0 +1,73 @@
+# HG changeset patch
+# User Sam Gillingham <gillingham.sam@gmail.com>
+# Date 1526963592 -36000
+# Node ID d103fef327d47ba31826007f9c9ab02c1f354330
+# Parent  a4e63dbb642c83516104ea82cec0e45c4caffd54
+More work on making out of tree builds work
+
+diff --git a/trunk/CMakeLists.txt b/trunk/CMakeLists.txt
+--- a/trunk/CMakeLists.txt
++++ b/trunk/CMakeLists.txt
+@@ -20,14 +20,6 @@
+   set (WINDOWS ${WIN32})
+ endif()
+ 
+-set (PROJECT_BINARY_DIR bin)
+-set (PROJECT_LIBRARY_DIR lib)
+-set (PROJECT_SOURCE_DIR src)
+-set (PROJECT_TEST_DIR tests)
+-set (PROJECT_HEADER_DIR include)
+-set (PROJECT_TOOLS_DIR tools)
+-set (PROJECT_GDAL_DIR gdal)
+-
+ # The version number.
+ set (LIBKEA_HG_VERSION 289)
+ set (LIBKEA_VERSION_MAJOR 1)
+@@ -160,8 +152,8 @@
+ 
+ ###############################################################################
+ # Setup configure file
+-configure_file ( "${PROJECT_HEADER_DIR}/kea-config.h.in" "${PROJECT_HEADER_DIR}/libkea/kea-config.h" )
+-configure_file ( "${PROJECT_TOOLS_DIR}/kea-config.in" "${PROJECT_BINARY_DIR}/kea-config" )
++configure_file ( "${PROJECT_SOURCE_DIR}/include/kea-config.h.in" "${PROJECT_BINARY_DIR}/include/libkea/kea-config.h" )
++configure_file ( "${PROJECT_SOURCE_DIR}/tools/kea-config.in" "${PROJECT_BINARY_DIR}/bin/kea-config" )
+ ###############################################################################
+ 
+ ###############################################################################
+@@ -173,11 +165,12 @@
+ ###############################################################################
+ # Build library
+ 
+-include_directories ("${PROJECT_HEADER_DIR}")
++include_directories ("${PROJECT_SOURCE_DIR}/include")
++include_directories ("${PROJECT_BINARY_DIR}/include") # for kea-config.h
+ include_directories(${HDF5_INCLUDE_DIR})
+-add_subdirectory ("${PROJECT_SOURCE_DIR}")
++add_subdirectory ("${PROJECT_SOURCE_DIR}/src")
+ if (LIBKEA_WITH_GDAL)
+-	add_subdirectory ("${PROJECT_GDAL_DIR}")
++	add_subdirectory ("${PROJECT_SOURCE_DIR}/gdal")
+ endif(LIBKEA_WITH_GDAL)
+ ###############################################################################
+ 
+@@ -191,7 +184,7 @@
+ ###############################################################################
+ # Installation
+ 
+-install (FILES "${PROJECT_BINARY_DIR}/kea-config" DESTINATION bin PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
++install (FILES "${PROJECT_BINARY_DIR}/bin/kea-config" DESTINATION bin PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+ ###############################################################################
+ 
+ ###############################################################################
+diff --git a/trunk/src/CMakeLists.txt b/trunk/src/CMakeLists.txt
+--- a/trunk/src/CMakeLists.txt
++++ b/trunk/src/CMakeLists.txt
+@@ -38,7 +38,7 @@
+ ###############################################################################
+ # Testing
+ # exe needs to be in 'src' otherwise it doesn't work
+-add_executable (test1 ${PROJECT_TEST_DIR}/test1.cpp)
++add_executable (test1 ${PROJECT_SOURCE_DIR}/src/tests/test1.cpp)
+ target_link_libraries (test1 ${LIBKEA_LIB_NAME})
+ if(NOT WIN32)
+     # set rpath so the text exe finds hdf5. Really only needed

--- a/var/spack/repos/builtin/packages/kealib/package.py
+++ b/var/spack/repos/builtin/packages/kealib/package.py
@@ -44,16 +44,15 @@ class Kealib(CMakePackage):
     homepage = "http://www.kealib.org/"
     url      = "https://bitbucket.org/chchrsc/kealib/get/kealib-1.4.7.tar.gz"
 
+    version('develop', hg='https://adamjstewart@bitbucket.org/chchrsc/kealib')
     version('1.4.7', '6139e31e50f552247ddf98f489948893')
-    version('1.4.5', '112e9c42d980b2d2987a3c15d0833a5d')
 
     depends_on('cmake@2.8.10:', type='build')
     depends_on('hdf5+cxx+hl')
 
-    # Out-of-source builds are broken
-    # fatal error: 'libkea/kea-config.h' file not found
-    build_directory = 'trunk'
     root_cmakelists_dir = 'trunk'
+
+    patch('cmake.patch', when='@1.4.7')
 
     def cmake_args(self):
         return [

--- a/var/spack/repos/builtin/packages/kealib/package.py
+++ b/var/spack/repos/builtin/packages/kealib/package.py
@@ -44,7 +44,7 @@ class Kealib(CMakePackage):
     homepage = "http://www.kealib.org/"
     url      = "https://bitbucket.org/chchrsc/kealib/get/kealib-1.4.7.tar.gz"
 
-    version('develop', hg='https://adamjstewart@bitbucket.org/chchrsc/kealib')
+    version('develop', hg='https://bitbucket.org/chchrsc/kealib')
     version('1.4.7', '6139e31e50f552247ddf98f489948893')
 
     depends_on('cmake@2.8.10:', type='build')

--- a/var/spack/repos/builtin/packages/kealib/package.py
+++ b/var/spack/repos/builtin/packages/kealib/package.py
@@ -26,7 +26,7 @@ from spack import *
 
 
 class Kealib(CMakePackage):
-    """An HDF5 Based Raster File Format
+    """An HDF5 Based Raster File Format.
 
     KEALib provides an implementation of the GDAL data model.
     The format supports raster attribute tables, image pyramids,
@@ -41,18 +41,22 @@ class Kealib(CMakePackage):
 
     Development work on this project has been funded by Landcare Research.
     """
-    homepage = "http://kealib.org/"
-    url      = "https://bitbucket.org/chchrsc/kealib/get/kealib-1.4.5.tar.gz"
+    homepage = "http://www.kealib.org/"
+    url      = "https://bitbucket.org/chchrsc/kealib/get/kealib-1.4.7.tar.gz"
 
+    version('1.4.7', '6139e31e50f552247ddf98f489948893')
     version('1.4.5', '112e9c42d980b2d2987a3c15d0833a5d')
 
-    depends_on('hdf5')
     depends_on('cmake@2.8.10:', type='build')
+    depends_on('hdf5+cxx+hl')
 
+    # Out-of-source builds are broken
+    # fatal error: 'libkea/kea-config.h' file not found
+    build_directory = 'trunk'
     root_cmakelists_dir = 'trunk'
 
     def cmake_args(self):
         return [
-            '-DHDF5_INCLUDE_DIR=%s' % self.spec['hdf5'].prefix.include,
-            '-DHDF5_LIB_PATH=%s' % self.spec['hdf5'].prefix.lib,
+            '-DHDF5_INCLUDE_DIR=%s' % self.spec['hdf5'].headers.directories[0],
+            '-DHDF5_LIB_PATH=%s' % self.spec['hdf5'].libs.directories[0],
         ]


### PR DESCRIPTION
Successfully installs and passes all tests on macOS 10.13.4 with Clang 9.0.0.

Took me forever to figure out how to install this package. No matter what I tried, I kept getting the following error:
```
/private/var/folders/21/hwq39zyj4g36x6zjfyl5l8080000gn/T/pytest-of-Adam/pytest-55/test_keep_exceptions0/tmp/spack-stage/spack-stage-pbhblev6/chchrsc-kealib-c8646188a638/trunk/src/libkea/KEAImageIO.cpp:3607:10: fatal error: 'libkea/kea-config.h' file not found
#include "libkea/kea-config.h"
         ^~~~~~~~~~~~~~~~~~~~~
1 error generated.
make[2]: *** [src/CMakeFiles/kea.dir/libkea/KEAImageIO.cpp.o] Error 1
make[1]: *** [src/CMakeFiles/kea.dir/all] Error 2
make: *** [all] Error 2
```
I eventually discovered that this package doesn't support out-of-source builds. I've never seen a CMake package like this. In fact, most CMake packages won't let you build in-source even if you want to.

@gillins Rumor has it that you're the author of `kealib`. For the life of me, I couldn't figure out how to file a bug report on your Bitbucket repo.