### PR TITLE
Add py-docopt package

### DIFF
--- a/var/spack/repos/builtin/packages/py-docopt/package.py
+++ b/var/spack/repos/builtin/packages/py-docopt/package.py
@@ -1,0 +1,38 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyDocopt(PythonPackage):
+    """Command-line interface description language."""
+
+    homepage = "http://docopt.org/"
+    url      = "https://pypi.io/packages/source/d/docopt/docopt-0.6.2.tar.gz"
+
+    import_modules = ['docopt']
+
+    version('0.6.2', '4bc74561b37fad5d3e7d037f82a4c3b1')
+
+    depends_on('py-setuptools', type='build')


### PR DESCRIPTION
Successfully installs and passes import tests on CentOS 6 with GCC 6.1.0.