### PR TITLE
CUDA 9.2

### DIFF
--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -60,16 +60,19 @@ class CudaPackage(PackageBase):
     depends_on("cuda@8:", when='cuda_arch=62')
     depends_on("cuda@9:", when='cuda_arch=70')
 
-    depends_on('cuda@:8.99', when='cuda_arch=20')
+    depends_on('cuda@:8', when='cuda_arch=20')
 
     # Compiler conflicts:
     # https://gist.github.com/ax3l/9489132
     conflicts('%gcc@5:', when='+cuda ^cuda@:7.5')
-    conflicts('%gcc@6:', when='+cuda ^cuda@:8.99')
-    conflicts('%gcc@7:', when='+cuda ^cuda@:9.99')
+    conflicts('%gcc@6:', when='+cuda ^cuda@:8')
+    conflicts('%gcc@7:', when='+cuda ^cuda@:9.1')
+    conflicts('%gcc@8:', when='+cuda ^cuda@:9.99')
     if (platform.system() != "Darwin"):
         conflicts('%clang@:3.4,3.7:', when='+cuda ^cuda@7.5')
-        conflicts('%clang@:3.7,4:', when='+cuda ^cuda@8:9')
+        conflicts('%clang@:3.7,4:', when='+cuda ^cuda@8:9.0')
+        conflicts('%clang@:3.7,5:', when='+cuda ^cuda@9.1')
+        conflicts('%clang@:3.7,6:', when='+cuda ^cuda@9.2')
     conflicts('%intel@:14,16:', when='+cuda ^cuda@7.5')
     conflicts('%intel@:14,17:', when='+cuda ^cuda@8.0.44')
     conflicts('%intel@:14,18:', when='+cuda ^cuda@8.0.61:9')

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -33,11 +33,12 @@ class Cuda(Package):
 
     Note: This package does not currently install the drivers necessary
     to run CUDA. These will need to be installed manually. See:
-    http://docs.nvidia.com/cuda/cuda-getting-started-guide-for-linux for
-    details."""
+    https://docs.nvidia.com/cuda/ for details."""
 
-    homepage = "http://www.nvidia.com/object/cuda_home_new.html"
+    homepage = "https://developer.nvidia.com/cuda-zone"
 
+    version('9.2.88', 'dd6e33e10d32a29914b7700c7b3d1ca0', expand=False,
+            url="https://developer.nvidia.com/compute/cuda/9.2/Prod/local_installers/cuda_9.2.88_396.26_linux")
     version('9.1.85', '67a5c3933109507df6b68f80650b4b4a', expand=False,
             url="https://developer.nvidia.com/compute/cuda/9.1/Prod/local_installers/cuda_9.1.85_387.26_linux")
     version('9.0.176', '7a00187b2ce5c5e350e68882f42dd507', expand=False,


### PR DESCRIPTION
Add the latest CUDA release, v9.2

Also updates the [compatibility matrix](https://gist.github.com/ax3l/9489132) for the cuda build package.

Update links to docs (permanent redirects) on the way.