### PR TITLE
Fix missing spack.compiler import

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -115,6 +115,7 @@ from llnl.util.lang import check_kwargs
 from llnl.util.tty.color import cwrite, colorize, cescape, get_color_when
 
 import spack.architecture
+import spack.compiler
 import spack.compilers as compilers
 import spack.error
 import spack.parse


### PR DESCRIPTION
Otherwise, specifying compiler flags on the command line fails with:
`Error: 'module' object has no attribute 'compiler'`

Seems to be related to c615d2be06eeaf10058ddece27f69d6e148f44af.