### PR TITLE
Add pkgconf 1.4.2

### DIFF
--- a/var/spack/repos/builtin/packages/pkgconf/package.py
+++ b/var/spack/repos/builtin/packages/pkgconf/package.py
@@ -32,13 +32,17 @@ class Pkgconf(AutotoolsPackage):
     maintaining compatibility."""
 
     homepage = "http://pkgconf.org/"
-    url      = "http://distfiles.alpinelinux.org/distfiles/pkgconf-1.3.10.tar.xz"
+    url      = "http://distfiles.alpinelinux.org/distfiles/pkgconf-1.4.2.tar.xz"
 
-    version('1.4.0', 'c509c0dad5a70aa4bc3210557b7eafce')
+    version('1.4.2',  '678d242b4eef1754bba6a58642af10bb')
+    version('1.4.0',  'c509c0dad5a70aa4bc3210557b7eafce')
     version('1.3.10', '9b63707bf6f8da6efb3868101d7525fe')
-    version('1.3.8', '484ba3360d983ce07416843d5bc916a8')
+    version('1.3.8',  '484ba3360d983ce07416843d5bc916a8')
 
     provides('pkgconfig')
+
+    # TODO: Add a package for the kyua testing framework
+    # depends_on('kyua', type='test')
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         """Adds the ACLOCAL path for autotools."""


### PR DESCRIPTION
Successfully installed on SLES 11 (Cray) with CCE 8.5.8.

Unfortunately, I couldn't run the unit tests because of a missing dependency on the kyua testing framework. I started working on a package for kyua but it depends on lutok which depends on lua which depends on ncurses which depends on pkgconf, thereby creating a circular dependency. So I added a note about the missing dependency. I'll "leave this as an exercise for the reader" if you really want to properly test pkgconf.

I did install another package using this pkgconf installation, so I'm confident that it's not too broken.