### PR TITLE
Add ncurses 6.1

### DIFF
--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -37,8 +37,9 @@ class Ncurses(AutotoolsPackage):
     SYSV-curses enhancements over BSD curses."""
 
     homepage = "http://invisible-island.net/ncurses/ncurses.html"
-    url      = "http://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.0.tar.gz"
+    url      = "http://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.1.tar.gz"
 
+    version('6.1', '98c889aaf8d23910d2b92d65be2e737a')
     version('6.0', 'ee13d052e1ead260d7c28071f46eefb1')
     version('5.9', '8cb9c412e5f2d96bc6f459aa8c6282a1')
 


### PR DESCRIPTION
Successfully installed on SLES 11 (Cray) with CCE 8.5.8. `ncurses` doesn't have any unit tests, but I was able to install vim with it, so I think it's fine.