### PR TITLE
Fix hydrogen@develop build

### DIFF
--- a/var/spack/repos/builtin/packages/elemental/package.py
+++ b/var/spack/repos/builtin/packages/elemental/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import os
-import sys
 from spack import *
 from spack.spec import UnsupportedCompilerError
 
@@ -143,7 +142,8 @@ class Elemental(CMakePackage):
             intel_bin = os.path.dirname(ifort)
             intel_root = os.path.dirname(intel_bin)
             print('{} {} {}'.format(ifort, intel_bin, intel_root))
-            libfortran = find_libraries('libifcoremt', root=intel_root, recursive=True)
+            libfortran = find_libraries('libifcoremt',
+                                        root=intel_root, recursive=True)
         elif self.spec.satisfies('%gcc'):
             # see <stage_folder>/debian/rules as an example:
             mpif77 = Executable(spec['mpi'].mpif77)
@@ -154,7 +154,8 @@ class Elemental(CMakePackage):
             xl_fort = env['SPACK_F77']
             xl_bin = os.path.dirname(xl_fort)
             xl_root = os.path.dirname(xl_bin)
-            libfortran = find_libraries('libxlf90_r', root=xl_root, recursive=True)
+            libfortran = find_libraries('libxlf90_r',
+                                        root=xl_root, recursive=True)
         else:
             libfortran = None
 

--- a/var/spack/repos/builtin/packages/elemental/package.py
+++ b/var/spack/repos/builtin/packages/elemental/package.py
@@ -33,11 +33,8 @@ class Elemental(CMakePackage):
        and optimization library."""
 
     homepage = "http://libelemental.org"
-    url      = "https://github.com/elemental/Elemental/archive/v0.87.6.tar.gz"
+    url      = "https://github.com/elemental/Elemental/archive/v0.87.7.tar.gz"
 
-    version('hydrogen-develop', git='https://github.com/LLNL/Elemental.git', branch='hydrogen')
-
-    version('develop', git='https://github.com/elemental/Elemental.git', branch='master')
     version('0.87.7', '6c1e7442021c59a36049e37ea69b8075')
     version('0.87.6', '9fd29783d45b0a0e27c0df85f548abe9')
 
@@ -116,7 +113,6 @@ class Elemental(CMakePackage):
             'libEl', root=self.prefix, shared=shared, recursive=True
         )
 
-    @when('@0.87.6:')
     def cmake_args(self):
         spec = self.spec
 
@@ -146,8 +142,8 @@ class Elemental(CMakePackage):
             ifort = env['SPACK_F77']
             intel_bin = os.path.dirname(ifort)
             intel_root = os.path.dirname(intel_bin)
-            libfortran = LibraryList('{0}/lib/intel64/libifcoremt.{1}'
-                                     .format(intel_root, dso_suffix))
+            print('{} {} {}'.format(ifort, intel_bin, intel_root))
+            libfortran = find_libraries('libifcoremt', root=intel_root, recursive=True)
         elif self.spec.satisfies('%gcc'):
             # see <stage_folder>/debian/rules as an example:
             mpif77 = Executable(spec['mpi'].mpif77)
@@ -158,8 +154,7 @@ class Elemental(CMakePackage):
             xl_fort = env['SPACK_F77']
             xl_bin = os.path.dirname(xl_fort)
             xl_root = os.path.dirname(xl_bin)
-            libfortran = LibraryList('{0}/lib/libxlf90_r.{1}.1'
-                                     .format(xl_root, dso_suffix))
+            libfortran = find_libraries('libxlf90_r', root=xl_root, recursive=True)
         else:
             libfortran = None
 
@@ -189,53 +184,5 @@ class Elemental(CMakePackage):
         if '+python' in spec:
             args.extend([
                 '-DPYTHON_SITE_PACKAGES:STRING={0}'.format(site_packages_dir)])
-
-        return args
-
-    @when('@:0.87.6')
-    def cmake_args(self):
-        spec = self.spec
-
-        if '@:0.87.7' in spec and '%intel@:17.0.2' in spec:
-            raise UnsupportedCompilerError(
-                "Elemental {0} has a known bug with compiler: {1} {2}".format(
-                    spec.version, spec.compiler.name, spec.compiler.version))
-
-        args = [
-            '-DCMAKE_INSTALL_MESSAGE:STRING=LAZY',
-            '-DCMAKE_C_COMPILER=%s' % spec['mpi'].mpicc,
-            '-DCMAKE_CXX_COMPILER=%s' % spec['mpi'].mpicxx,
-            '-DCMAKE_Fortran_COMPILER=%s' % spec['mpi'].mpifc,
-            '-DBUILD_SHARED_LIBS:BOOL=%s'      % ('+shared' in spec),
-            '-DHydrogen_ENABLE_OPENMP:BOOL=%s'       % ('+hybrid' in spec),
-            '-DHydrogen_ENABLE_QUADMATH:BOOL=%s'     % ('+quad' in spec),
-            '-DHydrogen_USE_64BIT_INTS:BOOL=%s'      % ('+int64' in spec),
-            '-DHydrogen_USE_64BIT_BLAS_INTS:BOOL=%s' % ('+int64_blas' in spec),
-            '-DHydrogen_ENABLE_MPC:BOOL=%s'        % ('+mpfr' in spec),
-            '-DHydrogen_GENERAL_LAPACK_FALLBACK=ON',
-        ]
-
-        # Add support for OS X to find OpenMP
-        if (self.spec.satisfies('%clang')):
-            if (sys.platform == 'darwin'):
-                clang = self.compiler.cc
-                clang_bin = os.path.dirname(clang)
-                clang_root = os.path.dirname(clang_bin)
-                args.extend([
-                    '-DOpenMP_DIR={0}'.format(clang_root)])
-
-        if 'blas=openblas' in spec:
-            args.extend([
-                '-DHydrogen_USE_OpenBLAS:BOOL=%s' % ('blas=openblas' in spec),
-                '-DOpenBLAS_DIR:STRING={0}'.format(
-                    spec['elemental'].prefix)])
-        elif 'blas=mkl' in spec:
-            args.extend([
-                '-DHydrogen_USE_MKL:BOOL=%s' % ('blas=mkl' in spec)])
-        elif 'blas=accelerate' in spec:
-            args.extend(['-DHydrogen_USE_ACCELERATE:BOOL=TRUE'])
-        elif 'blas=essl' in spec:
-            args.extend([
-                '-DHydrogen_USE_ESSL:BOOL=%s' % ('blas=essl' in spec)])
 
         return args

--- a/var/spack/repos/builtin/packages/elemental/package.py
+++ b/var/spack/repos/builtin/packages/elemental/package.py
@@ -34,7 +34,6 @@ class Elemental(CMakePackage):
     homepage = "http://libelemental.org"
     url      = "https://github.com/elemental/Elemental/archive/v0.87.7.tar.gz"
 
-
     version('develop', git='https://github.com/elemental/Elemental.git', branch='master')
     version('0.87.7', '6c1e7442021c59a36049e37ea69b8075')
     version('0.87.6', '9fd29783d45b0a0e27c0df85f548abe9')

--- a/var/spack/repos/builtin/packages/elemental/package.py
+++ b/var/spack/repos/builtin/packages/elemental/package.py
@@ -34,6 +34,8 @@ class Elemental(CMakePackage):
     homepage = "http://libelemental.org"
     url      = "https://github.com/elemental/Elemental/archive/v0.87.7.tar.gz"
 
+
+    version('develop', git='https://github.com/elemental/Elemental.git', branch='master')
     version('0.87.7', '6c1e7442021c59a36049e37ea69b8075')
     version('0.87.6', '9fd29783d45b0a0e27c0df85f548abe9')
 

--- a/var/spack/repos/builtin/packages/elemental/package.py
+++ b/var/spack/repos/builtin/packages/elemental/package.py
@@ -141,7 +141,6 @@ class Elemental(CMakePackage):
             ifort = env['SPACK_F77']
             intel_bin = os.path.dirname(ifort)
             intel_root = os.path.dirname(intel_bin)
-            print('{} {} {}'.format(ifort, intel_bin, intel_root))
             libfortran = find_libraries('libifcoremt',
                                         root=intel_root, recursive=True)
         elif self.spec.satisfies('%gcc'):

--- a/var/spack/repos/builtin/packages/elemental/package.py
+++ b/var/spack/repos/builtin/packages/elemental/package.py
@@ -85,7 +85,7 @@ class Elemental(CMakePackage):
 
     depends_on('veclibfort', when='blas=accelerate')
 
-    depends_on('essl -cuda', when='blas=essl -openmp_blas ~int64_blas')
+    depends_on('essl ~cuda', when='blas=essl ~openmp_blas ~int64_blas')
     depends_on('essl threads=openmp', when='blas=essl +openmp_blas ~int64_blas')
 
     # Note that this forces us to use OpenBLAS until #1712 is fixed

--- a/var/spack/repos/builtin/packages/elemental/package.py
+++ b/var/spack/repos/builtin/packages/elemental/package.py
@@ -149,7 +149,7 @@ class Elemental(CMakePackage):
             mpif77 = Executable(spec['mpi'].mpif77)
             libfortran = LibraryList(mpif77('--print-file-name',
                                             'libgfortran.%s' % dso_suffix,
-                                            output=str))
+                                            output=str).strip())
         elif self.spec.satisfies('%xl') or self.spec.satisfies('%xl_r'):
             xl_fort = env['SPACK_F77']
             xl_bin = os.path.dirname(xl_fort)

--- a/var/spack/repos/builtin/packages/hydrogen/package.py
+++ b/var/spack/repos/builtin/packages/hydrogen/package.py
@@ -99,6 +99,9 @@ class Hydrogen(CMakePackage):
     depends_on('cudnn', when='+cuda')
     depends_on('cub', when='+cuda')
 
+    conflicts('@0:0.98', msg="Hydrogen did not exist before v0.99. " +
+              "Did you mean to use Elemental instead?")
+
     @property
     def libs(self):
         shared = True if '+shared' in self.spec else False
@@ -106,12 +109,6 @@ class Hydrogen(CMakePackage):
             'libEl', root=self.prefix, shared=shared, recursive=True
         )
 
-    @when('@:0.98.0')
-    def cmake_args(self):
-        raise InstallError("Hydrogen did not exist before v0.99." +
-                           "Did you mean to use Elemental instead?")
-
-    @when('@0.99:')
     def cmake_args(self):
         spec = self.spec
 

--- a/var/spack/repos/builtin/packages/hydrogen/package.py
+++ b/var/spack/repos/builtin/packages/hydrogen/package.py
@@ -107,14 +107,8 @@ class Hydrogen(CMakePackage):
             'libEl', root=self.prefix, shared=shared, recursive=True
         )
 
-    @when('@:0.84' or '@0.99:')
     def cmake_args(self):
         spec = self.spec
-
-        if '@:0.87.7' in spec and '%intel@:17.0.2' in spec:
-            raise UnsupportedCompilerError(
-                "Elemental {0} has a known bug with compiler: {1} {2}".format(
-                    spec.version, spec.compiler.name, spec.compiler.version))
 
         args = [
             '-DCMAKE_INSTALL_MESSAGE:STRING=LAZY',

--- a/var/spack/repos/builtin/packages/hydrogen/package.py
+++ b/var/spack/repos/builtin/packages/hydrogen/package.py
@@ -59,9 +59,9 @@ class Hydrogen(CMakePackage):
     variant('mpfr', default=False,
             description='Support GNU MPFR\'s'
             'arbitrary-precision floating-point arithmetic')
-    variant('cuda', default=False, 
+    variant('cuda', default=False,
             description='Builds with support for GPUs via CUDA and cuDNN')
-    variant('test', default=False, 
+    variant('test', default=False,
             description='Builds test suite')
 
     # Note that #1712 forces us to enumerate the different blas variants
@@ -106,6 +106,11 @@ class Hydrogen(CMakePackage):
             'libEl', root=self.prefix, shared=shared, recursive=True
         )
 
+    @when('@:0.98.0')
+    def cmake_args(self):
+        raise InstallError("Hydrogen did not exist before v0.99. Did you mean to use Elemental instead?")
+
+    @when('@0.99:')
     def cmake_args(self):
         spec = self.spec
 

--- a/var/spack/repos/builtin/packages/hydrogen/package.py
+++ b/var/spack/repos/builtin/packages/hydrogen/package.py
@@ -25,7 +25,6 @@
 import os
 import sys
 from spack import *
-from spack.spec import UnsupportedCompilerError
 
 
 class Hydrogen(CMakePackage):

--- a/var/spack/repos/builtin/packages/hydrogen/package.py
+++ b/var/spack/repos/builtin/packages/hydrogen/package.py
@@ -108,7 +108,8 @@ class Hydrogen(CMakePackage):
 
     @when('@:0.98.0')
     def cmake_args(self):
-        raise InstallError("Hydrogen did not exist before v0.99. Did you mean to use Elemental instead?")
+        raise InstallError("Hydrogen did not exist before v0.99." +
+                           "Did you mean to use Elemental instead?")
 
     @when('@0.99:')
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -106,7 +106,7 @@ class Lbann(CMakePackage):
 
     # Get any recent versions or non-numeric version
     # Note that develop > numeric and non-develop < numeric
-    @when('@:0.90' or '@0.94:')
+    @when('@:0.90,0.94:')
     def cmake_args(self):
         spec = self.spec
         args = self.common_config_args


### PR DESCRIPTION
~(Use the `elemental` package for older or non-fork versions of elemental)~

~hydrogen version `develop` should have been getting all of the cmake args, however because `develop` is not in `'@:0.84' or '@0.99:'`, this wasn't working.~

~Fixes hydrogen build on systems without cuda.~

EDIT:
TODO:
- [x] fix the `when`
- [x]  talk to Tom/Brian about `conflicts` with elemental
- [x]  make `elemental` only mean elemental/Elemental and `hydrogen` only mean LLNL/Elemental
- [x]  check the find_libraries calls in `elemental`
- ~look into the int64_blas `ar` path issue - no idea what the problem is~ This is going to be a different PR
- [x] test more combinations of arguments
