### PR TITLE
trf: make executable

### DIFF
--- a/var/spack/repos/builtin/packages/trf/package.py
+++ b/var/spack/repos/builtin/packages/trf/package.py
@@ -44,3 +44,5 @@ class Trf(Package):
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
         install('trf409.linux64', prefix.bin.trf)
+        chmod = which('chmod')
+        chmod('+x', prefix.bin.trf)


### PR DESCRIPTION
repeatmasker install fails without this (and I assume trf itself it not useful without being executable either)