### PR TITLE
Add Tophat v2.1.2, fixes automake issues

### DIFF
--- a/var/spack/repos/builtin/packages/tophat/package.py
+++ b/var/spack/repos/builtin/packages/tophat/package.py
@@ -31,10 +31,15 @@ class Tophat(AutotoolsPackage):
     homepage = "http://ccb.jhu.edu/software/tophat/index.shtml"
     url      = "https://github.com/infphilo/tophat/archive/v2.1.1.tar.gz"
 
+    version('2.1.2', 'db844fd7f53c519e716cd6222e6195b2')
     version('2.1.1', 'ffd18de2f893a95eb7e9d0c5283d241f')
 
     depends_on('autoconf', type='build')
-    depends_on('automake', type='build')
+    # 2.1.1 only builds with automake@1.15.1.  There's a patch here:
+    # https://github.com/spack/spack/pull/8244, which was incorporated
+    # upstream in 2.1.2, which is known to build with 1.16.1 and 1.15.1.
+    depends_on('automake',        when='@2.1.2:', type='build')
+    depends_on('automake@1.15.1', when='@:2.1.1', type='build')
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
 

--- a/var/spack/repos/builtin/packages/tophat/package.py
+++ b/var/spack/repos/builtin/packages/tophat/package.py
@@ -38,7 +38,7 @@ class Tophat(AutotoolsPackage):
     # 2.1.1 only builds with automake@1.15.1.  There's a patch here:
     # https://github.com/spack/spack/pull/8244, which was incorporated
     # upstream in 2.1.2, which is known to build with 1.16.1 and 1.15.1.
-    depends_on('automake',        when='@2.1.2:', type='build')
+    depends_on('automake',                        type='build')
     depends_on('automake@1.15.1', when='@:2.1.1', type='build')
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')


### PR DESCRIPTION
The Tophat team merged the patch from
https://github.com/spack/spack/pull/8244 and release v2.1.2

This change requires the old automake if you're building the older
release and is relaxed about the automake it requires if you're
building the v2.1.2 release.

Building v2.1.1 and v2.1.2 works on a CentOS 7 system, I don't have
the necessary bit to actually test the resulting binaries.

Here's the commit note from the change that was ultimately merged
upstream.

Fixes #8025

> Tophat was failing to build with automake@1.16.1, it worked with the
> older automake@1.15.1. This commit adds a patch to Tophat's
> src/Makefile.am which cleans up a few things. The result builds
> successfully with both automake@1.15.1 and automake@1.16.1. I have no
> way to check that the resulting builds Do The Right Thing.
>
> It changes two things:
>
> the original Makefile.am had a rule for $(SAMPROG) with no
> actions, and since there was a directory there with a tempting name
> the newer automake was trying to do something with it, but lacked
> the appropriate clues. Since that target is actually made as a side
> effect of making the library (sigh...), it seems to work to just
> give that rule something harmless to do (the Peter Principle
> triumphs again...).
>
> a bunch of the targets need a libtophat.a and libgc.a; the older
> automake was probably able to guess what to do given the list of
> sources but the newer automake apparently won't make the necessary
> assumptions. This patch wires up a simple rule and cleans up the
> appropriate dependencies so that things work.
>
> While it may appear that I'm someone who understands automake, keep in
> mind that I only play such a person on a TV reality show. YMMV.