### PR TITLE
add required module import

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -116,6 +116,7 @@ from llnl.util.tty.color import cwrite, colorize, cescape, get_color_when
 
 import spack.architecture
 import spack.compilers as compilers
+import spack.compiler
 import spack.error
 import spack.parse
 import spack.repo


### PR DESCRIPTION
Fixes: https://github.com/spack/spack/issues/8258

https://github.com/spack/spack/pull/8090 altered import behavior so that `import spack` no longer provides access to many other Spack modules. This addresses a case which depended on the prior behavior and was not updated as part of #8090. This particular import error only came up when users were setting compiler flags on specs.

See also: https://github.com/spack/spack/pull/8194