### PR TITLE
Don't duplicate Python error messages

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -875,8 +875,8 @@ class ChildError(InstallError):
         else:
             # The error happened in in the Python code, so try to show
             # some context from the Package itself.
-            out.write('%s: %s\n\n' % (self.name, self.message))
             if self.context:
+                out.write('\n')
                 out.write('\n'.join(self.context))
                 out.write('\n')
 


### PR DESCRIPTION
### Before

```
==> Error: NameError: name 'foobar' is not defined
NameError: NameError: name 'foobar' is not defined

/Users/Adam/spack/var/spack/repos/builtin/packages/zstd/package.py:41, in install:
     0         def install(self, spec, prefix):
     1             make('install', 'PREFIX={0}'.format(foobar))

See build log for details:
  /Users/Adam/spack/var/spack/stage/zstd-1.3.0-6bt7wh3xgg242a4saz3oojkcxbixoqar/zstd-1.3.0/spack-build.out
```

### After

```
==> Error: NameError: name 'foobar' is not defined

/Users/Adam/spack/var/spack/repos/builtin/packages/zstd/package.py:41, in install:
     0         def install(self, spec, prefix):
     1             make('install', 'PREFIX={0}'.format(foobar))

See build log for details:
  /Users/Adam/spack/var/spack/stage/zstd-1.3.0-6bt7wh3xgg242a4saz3oojkcxbixoqar/zstd-1.3.0/spack-build.out
```