### PR TITLE
Fix package error message line numbers

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -779,19 +779,19 @@ def get_package_context(traceback, context=3):
     # point out the location in the install method where we failed.
     lines = []
     lines.append("%s:%d, in %s:" % (
-        inspect.getfile(frame.f_code), frame.f_lineno, frame.f_code.co_name
+        inspect.getfile(frame.f_code), frame.f_lineno - 1, frame.f_code.co_name
     ))
 
     # Build a message showing context in the install method.
     sourcelines, start = inspect.getsourcelines(frame)
 
-    fl = frame.f_lineno - start
+    fl = frame.f_lineno - start - 1
     start_ctx = max(0, fl - context)
     sourcelines = sourcelines[start_ctx:fl + context + 1]
     for i, line in enumerate(sourcelines):
         is_error = start_ctx + i == fl
         mark = ">> " if is_error else "   "
-        marked = "  %s%-6d%s" % (mark, start_ctx + i, line.rstrip())
+        marked = "  %s%-6d%s" % (mark, start + start_ctx + i, line.rstrip())
         if is_error:
             marked = colorize('@R{%s}' % marked)
         lines.append(marked)

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -775,23 +775,31 @@ def get_package_context(traceback, context=3):
             if isinstance(obj, spack.package.PackageBase):
                 break
 
-    # we found obj, the Package implementation we care about.
-    # point out the location in the install method where we failed.
-    lines = []
-    lines.append("%s:%d, in %s:" % (
-        inspect.getfile(frame.f_code), frame.f_lineno - 1, frame.f_code.co_name
-    ))
+    # We found obj, the Package implementation we care about.
+    # Point out the location in the install method where we failed.
+    lines = [
+        '{0}:{1:d}, in {2}:'.format(
+            inspect.getfile(frame.f_code),
+            frame.f_lineno - 1,  # subtract 1 because f_lineno is 0-indexed
+            frame.f_code.co_name
+        )
+    ]
 
     # Build a message showing context in the install method.
     sourcelines, start = inspect.getsourcelines(frame)
 
-    fl = frame.f_lineno - start - 1
-    start_ctx = max(0, fl - context)
-    sourcelines = sourcelines[start_ctx:fl + context + 1]
+    # Calculate lineno of the error relative to the start of the function.
+    # Subtract 1 because f_lineno is 0-indexed.
+    fun_lineno = frame.f_lineno - start - 1
+    start_ctx = max(0, fun_lineno - context)
+    sourcelines = sourcelines[start_ctx:fun_lineno + context + 1]
+
     for i, line in enumerate(sourcelines):
-        is_error = start_ctx + i == fl
-        mark = ">> " if is_error else "   "
-        marked = "  %s%-6d%s" % (mark, start + start_ctx + i, line.rstrip())
+        is_error = start_ctx + i == fun_lineno
+        mark = '>> ' if is_error else '   '
+        # Add start to get lineno relative to start of file, not function.
+        marked = '  {0}{1:-6d}{2}'.format(
+            mark, start + start_ctx + i, line.rstrip())
         if is_error:
             marked = colorize('@R{%s}' % marked)
         lines.append(marked)


### PR DESCRIPTION
I would love to slap the first person who thought 0-based indexing was a good idea...

Fixes the following bugs:

- [x] `>>` points to the line number _after_ the line where the error actually occurs
- [x] the line number in `package.py:lineno` was off by one
- [x] the line numbers displayed in context were the line numbers of the function, not the line numbers of the file

### Before

```
==> Error: KeyError: 'No spec with name geos in gdal...'

/Users/Adam/spack/var/spack/repos/builtin/packages/gdal/package.py:269, in configure_args:
     126   
     127           if '+geos' in spec:
     128               args.append('--with-geos={0}'.format(spec['geos'].prefix))
  >> 129           else:
     130               args.append('--with-geos=no')
     131   
     132           if '+qhull' in spec:

See build log for details:
  /Users/Adam/spack/var/spack/stage/gdal-2.3.0-2twd2kcvmb6cnvb3ku4y3h5lh7i6vi4j/gdal-2.3.0/spack-build.out
```
For reference, the bug actually occurs on line 268 of the file, not 269 or 129.

### After

```
==> Error: KeyError: 'No spec with name geos in gdal...'

/Users/Adam/spack/var/spack/repos/builtin/packages/gdal/package.py:268, in configure_args:
     265               args.append('--with-pcre=no')
     266   
     267           if '+geos' in spec:
  >> 268               args.append('--with-geos={0}'.format(spec['geos'].prefix))
     269           else:
     270               args.append('--with-geos=no')
     271   

See build log for details:
  /Users/Adam/spack/var/spack/stage/gdal-2.3.0-2twd2kcvmb6cnvb3ku4y3h5lh7i6vi4j/gdal-2.3.0/spack-build.out
```
It now uses the correct line numbers to highlight the bug.