### PR TITLE
Fix bug where patches specified by dependents were not applied

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1176,6 +1176,11 @@ class PackageBase(with_metaclass(PackageMeta, object)):
         """Create a hash based on the sources and logic used to build the
         package. This includes the contents of all applied patches and the
         contents of applicable functions in the package subclass."""
+        if not self.spec.concrete:
+            err_msg = ("Cannot invoke content_hash on a package"
+                       " if the associated spec is not concrete")
+            raise spack.error.SpackError(err_msg)
+
         hashContent = list()
         source_id = fs.for_package_version(self, self.version).source_id()
         if not source_id:

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1098,6 +1098,14 @@ class PackageBase(with_metaclass(PackageMeta, object)):
         # Package can add its own patch function.
         has_patch_fun = hasattr(self, 'patch') and callable(self.patch)
 
+        # Get the patches from the spec (this is a shortcut for the MV-variant)
+        patches = self.spec.patches
+
+        # If there are no patches, note it.
+        if not patches and not has_patch_fun:
+            tty.msg("No patches needed for %s" % self.name)
+            return
+
         # Construct paths to special files in the archive dir used to
         # keep track of whether patches were successfully applied.
         archive_dir = self.stage.source_path
@@ -1119,17 +1127,9 @@ class PackageBase(with_metaclass(PackageMeta, object)):
             tty.msg("No patches needed for %s" % self.name)
             return
 
-        # Get the patches from the spec (this is a shortcut for the MV-variant)
-        file_patches = self.spec.patches
-
-        # If there are no patches, note it.
-        if not file_patches and not has_patch_fun:
-            tty.msg("No patches needed for %s" % self.name)
-            return
-
         # Apply all the patches for specs that match this one
         patched = False
-        for patch in file_patches:
+        for patch in patches:
             try:
                 with working_dir(self.stage.source_path):
                     patch.apply(self.stage)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1120,7 +1120,7 @@ class PackageBase(with_metaclass(PackageMeta, object)):
             return
 
         # Get the patches from the spec (this is a shortcut for the MV-variant)
-        file_patches = self.patches_to_apply()
+        file_patches = self.spec.patches
 
         # If there are no patches, note it.
         if not file_patches and not has_patch_fun:
@@ -1173,16 +1173,6 @@ class PackageBase(with_metaclass(PackageMeta, object)):
         else:
             touch(no_patches_file)
 
-    def patches_to_apply(self):
-        """If the patch set does not change between two invocations of spack,
-           then all patches in the set will be applied in the same order"""
-        patchesToApply = itertools.chain.from_iterable(
-            patch_list
-            for spec, patch_list in self.patches.items()
-            if self.spec.satisfies(spec))
-        patchesToApply = list(patchesToApply) + list(self.spec.patches)
-        return patchesToApply
-
     def content_hash(self, content=None):
         """Create a hash based on the sources and logic used to build the
         package. This includes the contents of all applied patches and the
@@ -1200,7 +1190,7 @@ class PackageBase(with_metaclass(PackageMeta, object)):
         else:
             hashContent.append(source_id.encode('utf-8'))
         hashContent.extend(':'.join((p.sha256, str(p.level))).encode('utf-8')
-                           for p in self.patches_to_apply())
+                           for p in self.spec.patches)
         hashContent.append(package_hash(self.spec, content))
         return base64.b32encode(
             hashlib.sha256(bytes().join(sorted(hashContent))).digest()).lower()

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -40,7 +40,6 @@ import functools
 import glob
 import hashlib
 import inspect
-import itertools
 import os
 import re
 import shutil

--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -83,6 +83,8 @@ class TestPackage(object):
     def test_content_hash_different_variants(self):
         spec1 = Spec("hash-test1@1.2 +variantx")
         spec2 = Spec("hash-test2@1.2 ~variantx")
+        spec1.concretize()
+        spec2.concretize()
         content1 = package_content(spec1)
         content1 = content1.replace(spec1.package.__class__.__name__, '')
         content2 = package_content(spec2)
@@ -93,6 +95,8 @@ class TestPackage(object):
     def test_all_same_but_archive_hash(self):
         spec1 = Spec("hash-test1@1.3")
         spec2 = Spec("hash-test2@1.3")
+        spec1.concretize()
+        spec2.concretize()
         content1 = package_content(spec1)
         content1 = content1.replace(spec1.package.__class__.__name__, '')
         content2 = package_content(spec2)

--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -71,6 +71,8 @@ class TestPackage(object):
     def test_content_hash_all_same_but_patch_contents(self):
         spec1 = Spec("hash-test1@1.1")
         spec2 = Spec("hash-test2@1.1")
+        spec1.concretize()
+        spec2.concretize()
         content1 = package_content(spec1)
         content1 = content1.replace(spec1.package.__class__.__name__, '')
         content2 = package_content(spec2)


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/7885

https://github.com/spack/spack/pull/7193 added the `patches_to_apply` function to collect patches which are then applied in `Package.do_patch`. However this only collects patches that are associated with the `Package` object and does not include `Spec`-related patches (which are applied by dependents, added in https://github.com/spack/spack/pull/5476). ~This updates the `Package.patches_to_apply` function to add `Spec` patches.~

EDIT: turns out `Spec.patches` already collects patches from the package so the `Package.patches_to_apply` function isn't necessary. All uses of `Package.patches_to_apply` are replaced with `Package.spec.patches`.