### PR TITLE
Fix compilation of FYBA with GCC 6

### DIFF
--- a/var/spack/repos/builtin/packages/fyba/gcc-6.patch
+++ b/var/spack/repos/builtin/packages/fyba/gcc-6.patch
@@ -1,0 +1,18 @@
+diff -Nuar a/src/FYBA/FYLU.cpp b/src/FYBA/FYLU.cpp
+--- a/src/FYBA/FYLU.cpp	2014-09-22 00:36:49.000000000 -0500
++++ b/src/FYBA/FYLU.cpp	2018-05-24 15:35:43.584181379 -0500
+@@ -4,12 +4,12 @@
+ /*  Innhold: Rutiner for utvalg                                             */
+ /* ======================================================================== */
+ 
+-#include "stdafx.h"
+-
+ #include <ctype.h>
+ #include <math.h>
+ #include <locale>
+ 
++#include "stdafx.h"
++
+ using namespace std;
+ 
+ #define U_PARA_LEN    128     /* Max lengde av parameterstreng */

--- a/var/spack/repos/builtin/packages/fyba/package.py
+++ b/var/spack/repos/builtin/packages/fyba/package.py
@@ -43,6 +43,10 @@ class Fyba(AutotoolsPackage):
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
 
+    # error: macro "min" passed 3 arguments, but takes just 2
+    # https://github.com/kartverket/fyba/issues/21
+    patch('gcc-6.patch')
+
     # fatal error: 'sys/vfs.h' file not found
     # https://github.com/kartverket/fyba/issues/12
     patch('vfs-mount-darwin.patch', when='platform=darwin')


### PR DESCRIPTION
To be honest, I don't know the first thing about C. I could lock it down to only patch when using GCC 6, but I don't know what other versions of GCC or what other compilers might be affected. The change seems pretty innocent, so I'm going to err on the side of "always patch" unless someone else knows better. 

Successfully installed with GCC 6.1.0 on CentOS 6.9.