### PR TITLE
Fix coloring of error messages containing '}' symbol

### DIFF
--- a/lib/spack/llnl/util/tty/color.py
+++ b/lib/spack/llnl/util/tty/color.py
@@ -190,7 +190,7 @@ class match_to_ansi(object):
         string = styles[style]
         if color:
             if color not in colors:
-                raise ColorParseError("invalid color specifier: '%s' in '%s'"
+                raise ColorParseError("Invalid color specifier: '%s' in '%s'"
                                       % (color, match.string))
             string += ';' + str(colors[color])
 
@@ -215,7 +215,9 @@ def colorize(string, **kwargs):
             codes, for output to non-console devices.
     """
     color = _color_when_value(kwargs.get('color', get_color_when()))
-    return re.sub(color_re, match_to_ansi(color), string)
+    string = re.sub(color_re, match_to_ansi(color), string)
+    string = string.replace('}}', '}')
+    return string
 
 
 def clen(string):
@@ -224,14 +226,14 @@ def clen(string):
 
 
 def cextra(string):
-    """"Length of extra color characters in a string"""
+    """Length of extra color characters in a string"""
     return len(''.join(re.findall(r'\033[^m]*m', string)))
 
 
 def cwrite(string, stream=sys.stdout, color=None):
     """Replace all color expressions in string with ANSI control
        codes and write the result to the stream.  If color is
-       False, this will write plain text with o color.  If True,
+       False, this will write plain text with no color.  If True,
        then it will always write colored output.  If not supplied,
        then it will be set based on stream.isatty().
     """
@@ -246,8 +248,25 @@ def cprint(string, stream=sys.stdout, color=None):
 
 
 def cescape(string):
-    """Replace all @ with @@ in the string provided."""
-    return str(string).replace('@', '@@')
+    """Escapes special characters needed for color codes.
+
+    Replaces the following symbols with their equivalent literal forms:
+
+    =====  ======
+    ``@``  ``@@``
+    ``}``  ``}}``
+    =====  ======
+
+    Parameters:
+        string (str): the string to escape
+
+    Returns:
+        (str): the string with color codes escaped
+    """
+    string = str(string)
+    string = string.replace('@', '@@')
+    string = string.replace('}', '}}')
+    return string
 
 
 class ColorStream(object):

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -62,7 +62,7 @@ from six import iteritems
 from six import StringIO
 
 import llnl.util.tty as tty
-from llnl.util.tty.color import colorize
+from llnl.util.tty.color import cescape, colorize
 from llnl.util.filesystem import mkdirp, install, install_tree
 
 import spack.build_systems.cmake
@@ -793,7 +793,7 @@ def get_package_context(traceback, context=3):
         mark = ">> " if is_error else "   "
         marked = "  %s%-6d%s" % (mark, start_ctx + i, line.rstrip())
         if is_error:
-            marked = colorize('@R{%s}' % marked)
+            marked = colorize('@R{%s}' % cescape(marked))
         lines.append(marked)
 
     return lines

--- a/lib/spack/spack/util/log_parse.py
+++ b/lib/spack/spack/util/log_parse.py
@@ -30,7 +30,7 @@ from six import StringIO
 from ctest_log_parser import CTestLogParser, BuildError, BuildWarning
 
 import llnl.util.tty as tty
-from llnl.util.tty.color import colorize
+from llnl.util.tty.color import cescape, colorize
 
 __all__ = ['parse_log_events', 'make_log_context']
 
@@ -130,8 +130,8 @@ def make_log_context(log_events, width=None):
             wrapped_line = line_fmt % (i, '\n'.join(lines))
 
             if i in error_lines:
-                out.write(
-                    colorize('  @%s{>> %s}\n' % (color, wrapped_line)))
+                out.write(colorize(
+                    '  @%s{>> %s}\n' % (color, cescape(wrapped_line))))
             else:
                 out.write('     %s\n' % wrapped_line)
 


### PR DESCRIPTION
Okay, I swear this is the last bug I've noticed in our build error messages (so far).

Spack uses its own special color code syntax of the form `@color{text}`. The problem is that if `text` contains the `}` character, Spack prematurely ends the color environment. 

According to the [documentation for the color module](http://spack.readthedocs.io/en/latest/llnl.util.tty.html#module-llnl.util.tty.color), you can escape `}` using `}}` to avoid this problem. This works, however, you end up with `}}` in your output. Also, `color.cescape` doesn't escape this value by default.

My solution was to escape `}` in `color.cescape` and remove it later in `colorize`. I have no idea if this is the right thing to do. According to the docs, escaping `}` should only be necessary when using the `@color{text}` syntax, not when using `@colortext@.`. I wasn't sure how to check for that, so I didn't.

### Before

<img width="947" alt="screen shot 2018-05-25 at 10 45 17 am" src="https://user-images.githubusercontent.com/12021217/40554220-a08da7c6-600a-11e8-8f7a-0a69fad93b53.png">

### After

<img width="956" alt="screen shot 2018-05-25 at 10 45 41 am" src="https://user-images.githubusercontent.com/12021217/40554225-a5cd6000-600a-11e8-9502-b46823d7721c.png">

Note: these screenshots were captured with #8271. Otherwise, the output would highlight the wrong line and you wouldn't even notice this bug.

I've noticed this problem in both package errors (where lines from `package.py` are displayed) and build errors (where lines from `spack-build.out` are displayed). I'm sure this problem occurs elsewhere. Aside from `spack url` where we care about the index of the match, I can't think of anywhere where we _wouldn't_ want to always `cescape`.

P.S. This keeps getting more and more hacky. I'm wondering if we shouldn't use an existing external module for color support with magical things like "unit tests" and "other users to detect bugs". As far as I know, none of this logic is tested anywhere.