### PR TITLE
Less sensitive error detection in build logs

### DIFF
--- a/lib/spack/external/ctest_log_parser.py
+++ b/lib/spack/external/ctest_log_parser.py
@@ -124,7 +124,7 @@ _error_matches = [
     ":.*[Pp]ermission [Dd]enied",
     "^Error ([0-9]+):",
     "^Fatal",
-    "^Error: ",
+    "^[Ee]rror: ",
     "^Error ",
     "[0-9] ERROR: ",
     "^\"[^\"]+\", line [0-9]+: [^Ww]",

--- a/lib/spack/external/ctest_log_parser.py
+++ b/lib/spack/external/ctest_log_parser.py
@@ -116,11 +116,8 @@ _error_matches = [
             'Error:', 'error', 'undefined reference', 'multiply defined')),
         "([^:]+): error[ \\t]*[0-9]+[ \\t]*:",
         "([^:]+): (Error:|error|undefined reference|multiply defined)",
-        "([^ :]+) : (error|fatal error|catastrophic error)",
+        "([^ :]+) ?: (error|fatal error|catastrophic error)",
         "([^:]+)\\(([^\\)]+)\\) ?: (error|fatal error|catastrophic error)"),
-    prefilter(
-        lambda s: s.count(':') >= 2,
-        "[^ :]+:[0-9]+: [^ \\t]"),
     "^[Bb]us [Ee]rror",
     "^[Ss]egmentation [Vv]iolation",
     "^[Ss]egmentation [Ff]ault",


### PR DESCRIPTION
Fixes #8199 

Spack's build log error parser is a direct port of CTest's. The regexes it uses may work well for CMake, but they often trigger false positives for Autotools-based packages (see #8199). To reproduce this, uncomment any patches for the `fyba` package and try installing on macOS or with GCC 6.

Previously, any line containing `text:number: ` was matched. This regex has been removed. This resulted in the following error message no longer being caught:
```
INQTID.cpp:18:11: fatal error: 'sys/vfs.h' file not found
```
I removed the requirement for `: fatal error` to be preceded by a space to solve this. _Is the line after this now redundant?_

### Pros

Fewer false positives for Autotools-based packages.

### Cons

More false negatives?