### PR TITLE
Installing from mirror: don't relocate if old and new paths are identical

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -414,6 +414,8 @@ def relocate_package(workdir, allow_root):
     buildinfo = read_buildinfo_file(workdir)
     new_path = spack.store.layout.root
     old_path = buildinfo['buildpath']
+    if new_path == old_path:
+        return
     rel = buildinfo.get('relative_rpaths', False)
     if rel:
         return

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -414,8 +414,6 @@ def relocate_package(workdir, allow_root):
     buildinfo = read_buildinfo_file(workdir)
     new_path = spack.store.layout.root
     old_path = buildinfo['buildpath']
-    if new_path == old_path:
-        return
     rel = buildinfo.get('relative_rpaths', False)
     if rel:
         return

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -355,6 +355,7 @@ def relocate_binary(path_names, old_dir, new_dir, allow_root):
                                 rpaths, deps, idpath,
                                 new_rpaths, new_deps, new_idpath)
             if (not allow_root and
+                old_dir != new_dir and
                 strings_contains_installroot(path_name, old_dir)):
                     raise InstallRootStringException(path_name, old_dir)
 
@@ -373,6 +374,7 @@ def relocate_binary(path_names, old_dir, new_dir, allow_root):
                                                   old_dir, new_dir)
                 modify_elf_object(path_name, new_rpaths)
                 if (not allow_root and
+                    old_dir != new_dir and
                     strings_contains_installroot(path_name, old_dir)):
                         raise InstallRootStringException(path_name, old_dir)
     else:


### PR DESCRIPTION
Trying to relocate a distribution when the new and old paths are equal
leads to failure, because the test that ensures that no unrelocated
bits are left over always fails.

This simply checks if new and old are identical and returns if so.

Tested that it can/will install from a tarball into the same location
from whence the tarball came and into a different location.

Fixes #8217