### PR TITLE
py-pillow : update version and fix jpeg dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-pillow/package.py
+++ b/var/spack/repos/builtin/packages/py-pillow/package.py
@@ -87,7 +87,7 @@ class PyPillow(PythonPackage):
         if '+jpeg' in spec:
             setup.filter('JPEG_ROOT = None',
                          'JPEG_ROOT=("{0}","{1}")'.format(
-                             spec['jpeg'].prefix.lib64,
+                             spec['jpeg'].libs.directories[0],
                              spec['jpeg'].prefix.include))
         if '+zlib' in spec:
             setup.filter('ZLIB_ROOT = None',

--- a/var/spack/repos/builtin/packages/py-pillow/package.py
+++ b/var/spack/repos/builtin/packages/py-pillow/package.py
@@ -33,17 +33,10 @@ class PyPillow(PythonPackage):
     capabilities."""
 
     homepage = "https://python-pillow.org/"
-    url = "https://pypi.io/packages/source/P/Pillow/Pillow-3.0.0.tar.gz"
+    url = "https://pypi.io/packages/source/P/Pillow/Pillow-5.1.0.tar.gz"
 
-    # TODO: This version should be deleted once the next release comes out.
-    # TODO: It fixes a bug that prevented us from linking to Tk/Tcl.
-    # TODO: Tk/Tcl support is necessary for tkinter bitmap and photo images.
-    # TODO: If you require this support, run the following command:
-    # TODO:     `spack install py-pillow@3.3.0.dev0 ^python+tk`
-    version('3.3.0.dev0', git='https://github.com/python-pillow/Pillow.git',
-            commit='30eced62868141a6c859a4370efd40b9434a7c3f')
-
-    version('3.2.0', '7cfd093c11205d9e2ebe3c51dfcad510', preferred=True)
+    version('5.1.0', '04d2b1d1ce8b9f6831e33fb85b34316d')
+    version('3.2.0', '7cfd093c11205d9e2ebe3c51dfcad510')
     version('3.0.0', 'fc8ac44e93da09678eac7e30c9b7377d')
 
     provides('pil')
@@ -54,8 +47,7 @@ class PyPillow(PythonPackage):
     variant('tiff', default=False, description='Access to TIFF files')
     variant('freetype', default=False, description='Font related services')
     variant('lcms', default=False, description='Color management')
-    variant('jpeg2000', default=False,
-            description='Provide JPEG 2000 functionality')
+    variant('jpeg2000', default=False, description='Provide JPEG 2000 functionality')
 
     # Spack does not (yet) support these modes of building
     # variant('webp', default=False, description='Provide the WebP format')
@@ -94,8 +86,8 @@ class PyPillow(PythonPackage):
 
         if '+jpeg' in spec:
             setup.filter('JPEG_ROOT = None',
-                         'JPEG_ROOT = ("{0}", "{1}")'.format(
-                             spec['jpeg'].prefix.lib,
+                         'JPEG_ROOT=("{0}","{1}")'.format(
+                             spec['jpeg'].prefix.lib64,
                              spec['jpeg'].prefix.include))
         if '+zlib' in spec:
             setup.filter('ZLIB_ROOT = None',


### PR DESCRIPTION
Closes #8290.
The newer version of libjpeg-turbo installs the relevant libraries in lib64 and not lib. Since the newer version of libjpeg-turbo is now the preferred version, this will work. If someone wants to install an older libjpeg-turbo and install py-pillow, this won't work. 

While one can set up an if statement for dependencies in spack, I'm unsure about how one would check where jpeg is getting picked up from and if it is coming from libjpeg-turbo<1.5.90, then change the lib64 to lib. 