### PR TITLE
pybind11: test functionality

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -256,8 +256,10 @@ class CMakePackage(PackageBase):
         with working_dir(self.build_directory):
             if self.generator == 'Unix Makefiles':
                 self._if_make_target_execute('test')
+                self._if_make_target_execute('check')
             elif self.generator == 'Ninja':
                 self._if_ninja_target_execute('test')
+                self._if_ninja_target_execute('check')
 
     # Check that self.prefix is there after installation
     run_after('install')(PackageBase.sanity_check_prefix)

--- a/var/spack/repos/builtin/packages/py-pybind11/package.py
+++ b/var/spack/repos/builtin/packages/py-pybind11/package.py
@@ -46,7 +46,7 @@ class PyPybind11(CMakePackage):
     version('2.1.1', '5518988698df937ccee53fb6ba91d12a')
     version('2.1.0', '3cf07043d677d200720c928569635e12')
 
-    depends_on('py-pytest', type=('build'))
+    depends_on('py-pytest', type='test')
 
     extends('python')
 
@@ -59,4 +59,8 @@ class PyPybind11(CMakePackage):
         args = []
         args.append('-DPYTHON_EXECUTABLE:FILEPATH=%s'
                     % self.spec['python'].command.path)
+        args += [
+            '-DPYBIND11_TEST:BOOL={0}'.format(
+                'ON' if self.run_tests else 'OFF')
+        ]
         return args


### PR DESCRIPTION
Add test functionality to pybind11.
Without tests, this will skip the build and dependencies of the tests.

Also adds a check in CMake for targets `check` in `make/ninja check` for tests. This is now the same as in the build systems `Makefile` and `Autotools` and can be useful for manually added CMake targets for projects that do not (yet) use `CTest`.