### PR TITLE
perl: Fix build on Fedora 28

### DIFF
--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -76,6 +76,10 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
     # https://rt.perl.org/Public/Bug/Display.html?id=126468
     patch('protect-quotes-in-ccflags.patch', when='@5.22.0')
 
+    # Fix build on Fedora 28
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1536752
+    patch('https://src.fedoraproject.org/rpms/perl/raw/004cea3a67df42e92ffdf4e9ac36d47a3c6a05a4/f/perl-5.26.1-guard_old_libcrypt_fix.patch', level=1, sha256='0eac10ed90aeb0459ad8851f88081d439a4e41978e586ec743069e8b059370ac')
+
     # Installing cpanm alongside the core makes it safe and simple for
     # people/projects to install their own sets of perl modules.  Not
     # having it in core increases the "energy of activation" for doing


### PR DESCRIPTION
perl currently fails to build on Fedora 28 due to its glibc version (see https://bugzilla.redhat.com/show_bug.cgi?id=1536752).