### PR TITLE
Ipython > 6 is python 3 only. Update pacakges and dependencies.

### DIFF
--- a/var/spack/repos/builtin/packages/py-backcall/package.py
+++ b/var/spack/repos/builtin/packages/py-backcall/package.py
@@ -29,6 +29,6 @@ class PyBackcall(PythonPackage):
     """Specifications for callback functions passed in to an API"""
 
     homepage = "https://github.com/takluyver/backcall"
-    url = "https://files.pythonhosted.org/packages/84/71/c8ca4f5bb1e08401b916c68003acf0a0655df935d74d93bf3f3364b310e0/backcall-0.1.0.tar.gz"
+    url = "https://pypi.io/packages/source/b/backcall/backcall-0.1.0.tar.gz"
 
     version('0.1.0', '87ce0c7839808e6a3427d57df6a792e7')

--- a/var/spack/repos/builtin/packages/py-backcall/package.py
+++ b/var/spack/repos/builtin/packages/py-backcall/package.py
@@ -29,8 +29,6 @@ class PyBackcall(PythonPackage):
     """Specifications for callback functions passed in to an API"""
 
     homepage = "https://github.com/takluyver/backcall"
-    url      = "https://files.pythonhosted.org/packages/84/71/c8ca4f5bb1e08401b916c68003acf0a0655df935d74d93bf3f3364b310e0/backcall-0.1.0.tar.gz"
+    url = "https://files.pythonhosted.org/packages/84/71/c8ca4f5bb1e08401b916c68003acf0a0655df935d74d93bf3f3364b310e0/backcall-0.1.0.tar.gz"
 
     version('0.1.0', '87ce0c7839808e6a3427d57df6a792e7')
-
-

--- a/var/spack/repos/builtin/packages/py-backcall/package.py
+++ b/var/spack/repos/builtin/packages/py-backcall/package.py
@@ -25,17 +25,12 @@
 from spack import *
 
 
-class PyIpythonGenutils(PythonPackage):
-    """This package shouldn't exist. It contains some common utilities shared by Jupyter and IPython 
-       projects during The Big Split. As soon as possible, those packages will remove their dependency
-       on this, and this repo will go away."""
+class PyBackcall(PythonPackage):
+    """Specifications for callback functions passed in to an API"""
 
-    homepage = "https://github.com/ipython/ipython_genutils"
-    url      = "https://github.com/ipython/ipython_genutils/archive/0.2.0.tar.gz"
+    homepage = "https://github.com/takluyver/backcall"
+    url      = "https://files.pythonhosted.org/packages/84/71/c8ca4f5bb1e08401b916c68003acf0a0655df935d74d93bf3f3364b310e0/backcall-0.1.0.tar.gz"
 
-    version('0.2.0', '477e596a0e6e2f74ec08ec09687eeb6c')
-    version('0.1.0', '2016819d42d8b186aad1eaed2d11b4d2')
+    version('0.1.0', '87ce0c7839808e6a3427d57df6a792e7')
 
-    # FIXME: Add dependencies if required.
-    #depends_on('py-setuptools', type='build')
-    depends_on('py-six',        type=('build', 'run'))    
+

--- a/var/spack/repos/builtin/packages/py-ipython-genutils/package.py
+++ b/var/spack/repos/builtin/packages/py-ipython-genutils/package.py
@@ -26,7 +26,7 @@ from spack import *
 
 
 class PyIpythonGenutils(PythonPackage):
-    """This package shouldn't exist. It contains some common utilities 
+    """This package shouldn't exist. It contains some common utilities
        shared by Jupyter and IPython projects during The Big Split. As
        soon as possible, those packages will remove their dependency
        on this, and this repo will go away."""

--- a/var/spack/repos/builtin/packages/py-ipython-genutils/package.py
+++ b/var/spack/repos/builtin/packages/py-ipython-genutils/package.py
@@ -26,9 +26,9 @@ from spack import *
 
 
 class PyIpythonGenutils(PythonPackage):
-    """This package shouldn't exist. It contains some common utilities shared by Jupyter and IPython
-       projects during The Big Split. As soon as possible, those packages will remove their dependency
-       on this, and this repo will go away."""
+    """This package shouldn't exist. It contains some common utilities shared by Jupyter
+       and IPython projects during The Big Split. As soon as possible, those packages
+       will remove their dependency on this, and this repo will go away."""
 
     homepage = "https://github.com/ipython/ipython_genutils"
     url = "https://github.com/ipython/ipython_genutils/archive/0.2.0.tar.gz"
@@ -37,5 +37,5 @@ class PyIpythonGenutils(PythonPackage):
     version('0.1.0', '2016819d42d8b186aad1eaed2d11b4d2')
 
     # FIXME: Add dependencies if required.
-    #depends_on('py-setuptools', type='build')
+    # depends_on('py-setuptools', type='build')
     depends_on('py-six', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-ipython-genutils/package.py
+++ b/var/spack/repos/builtin/packages/py-ipython-genutils/package.py
@@ -26,9 +26,10 @@ from spack import *
 
 
 class PyIpythonGenutils(PythonPackage):
-    """This package shouldn't exist. It contains some common utilities shared by Jupyter
-       and IPython projects during The Big Split. As soon as possible, those packages
-       will remove their dependency on this, and this repo will go away."""
+    """This package shouldn't exist. It contains some common utilities 
+       shared by Jupyter and IPython projects during The Big Split. As
+       soon as possible, those packages will remove their dependency
+       on this, and this repo will go away."""
 
     homepage = "https://github.com/ipython/ipython_genutils"
     url = "https://github.com/ipython/ipython_genutils/archive/0.2.0.tar.gz"

--- a/var/spack/repos/builtin/packages/py-ipython-genutils/package.py
+++ b/var/spack/repos/builtin/packages/py-ipython-genutils/package.py
@@ -26,16 +26,16 @@ from spack import *
 
 
 class PyIpythonGenutils(PythonPackage):
-    """This package shouldn't exist. It contains some common utilities shared by Jupyter and IPython 
+    """This package shouldn't exist. It contains some common utilities shared by Jupyter and IPython
        projects during The Big Split. As soon as possible, those packages will remove their dependency
        on this, and this repo will go away."""
 
     homepage = "https://github.com/ipython/ipython_genutils"
-    url      = "https://github.com/ipython/ipython_genutils/archive/0.2.0.tar.gz"
+    url = "https://github.com/ipython/ipython_genutils/archive/0.2.0.tar.gz"
 
     version('0.2.0', '477e596a0e6e2f74ec08ec09687eeb6c')
     version('0.1.0', '2016819d42d8b186aad1eaed2d11b4d2')
 
     # FIXME: Add dependencies if required.
     #depends_on('py-setuptools', type='build')
-    depends_on('py-six',        type=('build', 'run'))    
+    depends_on('py-six', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-ipython/package.py
+++ b/var/spack/repos/builtin/packages/py-ipython/package.py
@@ -56,16 +56,11 @@ class PyIpython(PythonPackage):
     depends_on('py-decorator', type=('build', 'run'))
     depends_on('py-pexpect', type=('build', 'run'), when="@:6.0")
     depends_on('py-jedi@0.10:', type=('build', 'run'), when="@6.0:")
-    #depends_on('py-setuptools@18.5:',            type=('build'),      when="@6.0:")
+    # depends_on('py-setuptools@18.5:',    type=('build'),   when="@6.0:")
     depends_on('py-backcall', type=('build', 'run'), when="@6.0:")
     depends_on('py-pexpect', type=('build', 'run'), when="@6.0:")
     depends_on('py-ptyprocess', type=('build', 'run'), when="@6.0:")
-    #depends_on('py-qtconsole',                  type=('build', 'run'),when="@6.0:")
-    #depends_on('py-ipykernel',                  type=('build', 'run'),when="@6.0:")
-    #depends_on('py-nbformat',                   type=('build', 'run'),when="@6.0:")
-    #depends_on('py-nbconvert',                  type=('build', 'run'),when="@6.0:")
-    #depends_on('py-ipywidgets',                 type=('build', 'run'),when="@6.0:")
-
+    
     depends_on('py-appnope', type=('build', 'run'),
                when=sys.platform == 'darwin' and
                int(platform.mac_ver()[0].split('.')[1]) >= 9)

--- a/var/spack/repos/builtin/packages/py-ipython/package.py
+++ b/var/spack/repos/builtin/packages/py-ipython/package.py
@@ -31,28 +31,40 @@ class PyIpython(PythonPackage):
     """IPython provides a rich toolkit to help you make the most out of using
        Python interactively."""
     homepage = "https://pypi.python.org/pypi/ipython"
-    url      = "https://pypi.io/packages/source/i/ipython/ipython-2.3.1.tar.gz"
+    url      = "https://pypi.io/packages/source/i/ipython/ipython-6.4.0.tar.gz"
 
+    version('6.4.0', 'c3709c9efe3132b72f1c7c13578d107f')
     version('5.1.0', '47c8122420f65b58784cb4b9b4af35e3')
     version('3.1.0', 'a749d90c16068687b0ec45a27e72ef8f')
     version('2.3.1', '2b7085525dac11190bfb45bb8ec8dcbf')
 
-    depends_on('python@2.7:2.8,3.3:')
+    depends_on('python@2.7:2.8,3.3:',when="@:6.0.0")
+    depends_on('python@3.4:',when="@:6.4.0")
+
 
     # These dependencies breaks concretization
     # See https://github.com/spack/spack/issues/2793
     # depends_on('py-backports-shutil-get-terminal-size', type=('build', 'run'), when="^python@:3.2")  # noqa
     # depends_on('py-pathlib2', type=('build', 'run'), when="^python@:3.3")
-    depends_on('py-backports-shutil-get-terminal-size', type=('build', 'run'))
-    depends_on('py-pathlib2',                   type=('build', 'run'))
-
+    depends_on('py-backports-shutil-get-terminal-size', type=('build', 'run'), when="@:6.0")
+    depends_on('py-pathlib2',                   type=('build', 'run'), when="@:6.0")
     depends_on('py-pygments',                   type=('build', 'run'))
     depends_on('py-pickleshare',                type=('build', 'run'))
     depends_on('py-simplegeneric@0.8:',         type=('build', 'run'))
     depends_on('py-prompt-toolkit@1.0.4:1.999', type=('build', 'run'))
     depends_on('py-traitlets@4.2:',             type=('build', 'run'))
     depends_on('py-decorator',                  type=('build', 'run'))
-    depends_on('py-pexpect',                    type=('build', 'run'))
+    depends_on('py-pexpect',                    type=('build', 'run'),when="@:6.0")
+    depends_on('py-jedi@0.10:',                 type=('build', 'run'),when="@6.0:")
+    #depends_on('py-setuptools@18.5:',            type=('build'),      when="@6.0:")
+    depends_on('py-backcall',                   type=('build', 'run'),when="@6.0:")
+    depends_on('py-pexpect',                    type=('build', 'run'),when="@6.0:")
+    depends_on('py-ptyprocess',                 type=('build', 'run'),when="@6.0:")
+    #depends_on('py-qtconsole',                  type=('build', 'run'),when="@6.0:")
+    #depends_on('py-ipykernel',                  type=('build', 'run'),when="@6.0:")
+    #depends_on('py-nbformat',                   type=('build', 'run'),when="@6.0:")
+    #depends_on('py-nbconvert',                  type=('build', 'run'),when="@6.0:")
+    #depends_on('py-ipywidgets',                 type=('build', 'run'),when="@6.0:")
 
     depends_on('py-appnope', type=('build', 'run'),
                     when=sys.platform == 'darwin' and

--- a/var/spack/repos/builtin/packages/py-ipython/package.py
+++ b/var/spack/repos/builtin/packages/py-ipython/package.py
@@ -31,35 +31,35 @@ class PyIpython(PythonPackage):
     """IPython provides a rich toolkit to help you make the most out of using
        Python interactively."""
     homepage = "https://pypi.python.org/pypi/ipython"
-    url      = "https://pypi.io/packages/source/i/ipython/ipython-6.4.0.tar.gz"
+    url = "https://pypi.io/packages/source/i/ipython/ipython-6.4.0.tar.gz"
 
     version('6.4.0', 'c3709c9efe3132b72f1c7c13578d107f')
     version('5.1.0', '47c8122420f65b58784cb4b9b4af35e3')
     version('3.1.0', 'a749d90c16068687b0ec45a27e72ef8f')
     version('2.3.1', '2b7085525dac11190bfb45bb8ec8dcbf')
 
-    depends_on('python@2.7:2.8,3.3:',when="@:6.0.0")
-    depends_on('python@3.4:',when="@:6.4.0")
-
+    depends_on('python@2.7:2.8,3.3:', when="@:6.0.0")
+    depends_on('python@3.4:', when="@:6.4.0")
 
     # These dependencies breaks concretization
     # See https://github.com/spack/spack/issues/2793
     # depends_on('py-backports-shutil-get-terminal-size', type=('build', 'run'), when="^python@:3.2")  # noqa
     # depends_on('py-pathlib2', type=('build', 'run'), when="^python@:3.3")
-    depends_on('py-backports-shutil-get-terminal-size', type=('build', 'run'), when="@:6.0")
-    depends_on('py-pathlib2',                   type=('build', 'run'), when="@:6.0")
-    depends_on('py-pygments',                   type=('build', 'run'))
-    depends_on('py-pickleshare',                type=('build', 'run'))
-    depends_on('py-simplegeneric@0.8:',         type=('build', 'run'))
+    depends_on('py-backports-shutil-get-terminal-size',
+               type=('build', 'run'), when="@:6.0")
+    depends_on('py-pathlib2', type=('build', 'run'), when="@:6.0")
+    depends_on('py-pygments', type=('build', 'run'))
+    depends_on('py-pickleshare', type=('build', 'run'))
+    depends_on('py-simplegeneric@0.8:', type=('build', 'run'))
     depends_on('py-prompt-toolkit@1.0.4:1.999', type=('build', 'run'))
-    depends_on('py-traitlets@4.2:',             type=('build', 'run'))
-    depends_on('py-decorator',                  type=('build', 'run'))
-    depends_on('py-pexpect',                    type=('build', 'run'),when="@:6.0")
-    depends_on('py-jedi@0.10:',                 type=('build', 'run'),when="@6.0:")
+    depends_on('py-traitlets@4.2:', type=('build', 'run'))
+    depends_on('py-decorator', type=('build', 'run'))
+    depends_on('py-pexpect', type=('build', 'run'), when="@:6.0")
+    depends_on('py-jedi@0.10:', type=('build', 'run'), when="@6.0:")
     #depends_on('py-setuptools@18.5:',            type=('build'),      when="@6.0:")
-    depends_on('py-backcall',                   type=('build', 'run'),when="@6.0:")
-    depends_on('py-pexpect',                    type=('build', 'run'),when="@6.0:")
-    depends_on('py-ptyprocess',                 type=('build', 'run'),when="@6.0:")
+    depends_on('py-backcall', type=('build', 'run'), when="@6.0:")
+    depends_on('py-pexpect', type=('build', 'run'), when="@6.0:")
+    depends_on('py-ptyprocess', type=('build', 'run'), when="@6.0:")
     #depends_on('py-qtconsole',                  type=('build', 'run'),when="@6.0:")
     #depends_on('py-ipykernel',                  type=('build', 'run'),when="@6.0:")
     #depends_on('py-nbformat',                   type=('build', 'run'),when="@6.0:")
@@ -67,5 +67,5 @@ class PyIpython(PythonPackage):
     #depends_on('py-ipywidgets',                 type=('build', 'run'),when="@6.0:")
 
     depends_on('py-appnope', type=('build', 'run'),
-                    when=sys.platform == 'darwin' and
-                            int(platform.mac_ver()[0].split('.')[1]) >= 9)
+               when=sys.platform == 'darwin' and
+               int(platform.mac_ver()[0].split('.')[1]) >= 9)

--- a/var/spack/repos/builtin/packages/py-ipython/package.py
+++ b/var/spack/repos/builtin/packages/py-ipython/package.py
@@ -60,7 +60,6 @@ class PyIpython(PythonPackage):
     depends_on('py-backcall', type=('build', 'run'), when="@6.0:")
     depends_on('py-pexpect', type=('build', 'run'), when="@6.0:")
     depends_on('py-ptyprocess', type=('build', 'run'), when="@6.0:")
-    
     depends_on('py-appnope', type=('build', 'run'),
                when=sys.platform == 'darwin' and
                int(platform.mac_ver()[0].split('.')[1]) >= 9)

--- a/var/spack/repos/builtin/packages/py-testpath/package.py
+++ b/var/spack/repos/builtin/packages/py-testpath/package.py
@@ -22,20 +22,15 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
+
 from spack import *
 
 
-class PyIpythonGenutils(PythonPackage):
-    """This package shouldn't exist. It contains some common utilities shared by Jupyter and IPython 
-       projects during The Big Split. As soon as possible, those packages will remove their dependency
-       on this, and this repo will go away."""
+class PyTestpath(PythonPackage):
+    """Test utilities for Python code working with files and commands"""
 
-    homepage = "https://github.com/ipython/ipython_genutils"
-    url      = "https://github.com/ipython/ipython_genutils/archive/0.2.0.tar.gz"
+    homepage = "https://github.com/jupyter/testpath"
+    url      = "https://files.pythonhosted.org/packages/f4/8b/b71e9ee10e5f751e9d959bc750ab122ba04187f5aa52aabdc4e63b0e31a7/testpath-0.3.1.tar.gz"
 
-    version('0.2.0', '477e596a0e6e2f74ec08ec09687eeb6c')
-    version('0.1.0', '2016819d42d8b186aad1eaed2d11b4d2')
-
-    # FIXME: Add dependencies if required.
-    #depends_on('py-setuptools', type='build')
-    depends_on('py-six',        type=('build', 'run'))    
+    version('0.3.1', '2cd5ed5522fda781bb497c9d80ae2fc9')
+  

--- a/var/spack/repos/builtin/packages/py-testpath/package.py
+++ b/var/spack/repos/builtin/packages/py-testpath/package.py
@@ -30,7 +30,6 @@ class PyTestpath(PythonPackage):
     """Test utilities for Python code working with files and commands"""
 
     homepage = "https://github.com/jupyter/testpath"
-    url      = "https://files.pythonhosted.org/packages/f4/8b/b71e9ee10e5f751e9d959bc750ab122ba04187f5aa52aabdc4e63b0e31a7/testpath-0.3.1.tar.gz"
+    url = "https://files.pythonhosted.org/packages/f4/8b/b71e9ee10e5f751e9d959bc750ab122ba04187f5aa52aabdc4e63b0e31a7/testpath-0.3.1.tar.gz"
 
     version('0.3.1', '2cd5ed5522fda781bb497c9d80ae2fc9')
-  

--- a/var/spack/repos/builtin/packages/py-traitlets/package.py
+++ b/var/spack/repos/builtin/packages/py-traitlets/package.py
@@ -50,4 +50,4 @@ class PyTraitlets(PythonPackage):
     # This dependency breaks concretization
     # See https://github.com/spack/spack/issues/2793
     depends_on('py-enum34', when='^python@2.7', type=('build', 'run'))
-    #depends_on('py-enum34', type=('build', 'run'))
+    # depends_on('py-enum34', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-traitlets/package.py
+++ b/var/spack/repos/builtin/packages/py-traitlets/package.py
@@ -29,8 +29,10 @@ class PyTraitlets(PythonPackage):
     """Traitlets Python config system"""
 
     homepage = "https://pypi.python.org/pypi/traitlets"
-    url      = "https://github.com/ipython/traitlets/archive/master.tar.gz"
-    #their setup.py seems to have changed after the last release, forcing me to install the master.tar.gz to avoid py-enum34 for python@3.5:, which can't be checksummmed :|
+    url = "https://github.com/ipython/traitlets/archive/master.tar.gz"
+    # their setup.py seems to have changed after the last release, forcing me
+    # to install the master.tar.gz to avoid py-enum34 for python@3.5:, which
+    # can't be checksummmed :|
     version('4.3.2', '0b5b7986aef676d12f31a16cbbe3ed92')
     version('4.3.1', '146a4885ea64079f62a33b2049841543')
     version('4.3.0', '17af8d1306a401c42dbc92a080722422')
@@ -39,10 +41,10 @@ class PyTraitlets(PythonPackage):
     version('4.2.0', '53553a10d124e264fd2e234d0571b7d0')
     version('4.1.0', 'd5bc75c7bd529afb40afce86c2facc3a')
     version('4.0.0', 'b5b95ea5941fd9619b4704dfd8201568')
-    version('4.0',   '14544e25ccf8e920ed1cbf833852481f')
+    version('4.0', '14544e25ccf8e920ed1cbf833852481f')
 
-    depends_on('py-decorator', type=('build', 'run'),when="@:4.3.1")
-    depends_on('py-six',       type=('build', 'run'),when="@4.3.2:")
+    depends_on('py-decorator', type=('build', 'run'), when="@:4.3.1")
+    depends_on('py-six', type=('build', 'run'), when="@4.3.2:")
     depends_on('py-ipython-genutils', type=('build', 'run'))
 
     # This dependency breaks concretization

--- a/var/spack/repos/builtin/packages/py-traitlets/package.py
+++ b/var/spack/repos/builtin/packages/py-traitlets/package.py
@@ -29,8 +29,9 @@ class PyTraitlets(PythonPackage):
     """Traitlets Python config system"""
 
     homepage = "https://pypi.python.org/pypi/traitlets"
-    url      = "https://github.com/ipython/traitlets/archive/4.3.1.tar.gz"
-
+    url      = "https://github.com/ipython/traitlets/archive/master.tar.gz"
+    #their setup.py seems to have changed after the last release, forcing me to install the master.tar.gz to avoid py-enum34 for python@3.5:, which can't be checksummmed :|
+    version('4.3.2', '0b5b7986aef676d12f31a16cbbe3ed92')
     version('4.3.1', '146a4885ea64079f62a33b2049841543')
     version('4.3.0', '17af8d1306a401c42dbc92a080722422')
     version('4.2.2', 'ffc03056dc5c8d1fc5dbd6eac76e1e46')
@@ -40,10 +41,11 @@ class PyTraitlets(PythonPackage):
     version('4.0.0', 'b5b95ea5941fd9619b4704dfd8201568')
     version('4.0',   '14544e25ccf8e920ed1cbf833852481f')
 
-    depends_on('py-decorator', type=('build', 'run'))
+    depends_on('py-decorator', type=('build', 'run'),when="@:4.3.1")
+    depends_on('py-six',       type=('build', 'run'),when="@4.3.2:")
     depends_on('py-ipython-genutils', type=('build', 'run'))
 
     # This dependency breaks concretization
     # See https://github.com/spack/spack/issues/2793
-    # depends_on('py-enum34', when='^python@:3.3', type=('build', 'run'))
-    depends_on('py-enum34', type=('build', 'run'))
+    depends_on('py-enum34', when='^python@2.7', type=('build', 'run'))
+    #depends_on('py-enum34', type=('build', 'run'))


### PR DESCRIPTION
```
	modified:   var/spack/repos/builtin/packages/py-ipython-genutils/package.py
	modified:   var/spack/repos/builtin/packages/py-ipython/package.py
	new file:   var/spack/repos/builtin/packages/py-testpath/package.py
	modified:   var/spack/repos/builtin/packages/py-traitlets/package.py
```
I don't understand why ipython doesn't work when py-setuptools is specified as a dependency. Leaving it as is until someone understands how to fix it. 

One package requires master and has to be installed with -n. 