### PR TITLE
Add info for bedops@v2.4.35

### DIFF
--- a/var/spack/repos/builtin/packages/bedops/package.py
+++ b/var/spack/repos/builtin/packages/bedops/package.py
@@ -34,6 +34,7 @@ class Bedops(MakefilePackage):
     homepage = "https://bedops.readthedocs.io"
     url      = "https://github.com/bedops/bedops/archive/v2.4.30.tar.gz"
 
+    version('2.4.35', 'b425b3e05fd4cd1024ef4dd8bf04b4e5')
     version('2.4.34', 'fc467d96134a0efe8b134e638af87a1a')
     version('2.4.30', '4e5d9f7b7e5432b28aef8d17a22cffab')
 


### PR DESCRIPTION
Builds on CentOS 7, executables work.

(this is not a change, but...) It statically links it's executables, so you need the libstdc++-static and glibc-static packages in place.  Simple on CentOS, [trickier](https://stackoverflow.com/questions/44275897/no-package-glibc-static-available) on RHEL.

