### PR TITLE
netlib-lapack: changed handling of XL and clang compilers for the PPC64LE.

### DIFF
--- a/var/spack/repos/builtin/packages/netlib-lapack/cblas-cmake-fix.patch
+++ b/var/spack/repos/builtin/packages/netlib-lapack/cblas-cmake-fix.patch
@@ -1,0 +1,14 @@
+--- a/CBLAS/CMakeLists.txt
++++ b/CBLAS/CMakeLists.txt
+@@ -12,8 +12,8 @@
+                          SYMBOL_NAMESPACE "F77_")
+ if(NOT FortranCInterface_GLOBAL_FOUND OR NOT FortranCInterface_MODULE_FOUND)
+   message(WARNING "Reverting to pre-defined include/lapacke_mangling.h")
+-  configure_file(include/lapacke_mangling_with_flags.h.in
+-                 ${LAPACK_BINARY_DIR}/include/lapacke_mangling.h)
++  configure_file(include/cblas_mangling_with_flags.h.in
++                 ${LAPACK_BINARY_DIR}/include/cblas_mangling.h)
+ endif()
+ 
+ include_directories(include ${LAPACK_BINARY_DIR}/include)
+

--- a/var/spack/repos/builtin/packages/netlib-lapack/ibm-xl.patch
+++ b/var/spack/repos/builtin/packages/netlib-lapack/ibm-xl.patch
@@ -14,17 +14,3 @@
  # HP Fortran
  elseif( CMAKE_Fortran_COMPILER_ID STREQUAL "HP" )
 
---- a/CBLAS/CMakeLists.txt
-+++ b/CBLAS/CMakeLists.txt
-@@ -12,8 +12,8 @@
-                          SYMBOL_NAMESPACE "F77_")
- if(NOT FortranCInterface_GLOBAL_FOUND OR NOT FortranCInterface_MODULE_FOUND)
-   message(WARNING "Reverting to pre-defined include/lapacke_mangling.h")
--  configure_file(include/lapacke_mangling_with_flags.h.in
--                 ${LAPACK_BINARY_DIR}/include/lapacke_mangling.h)
-+  configure_file(include/cblas_mangling_with_flags.h.in
-+                 ${LAPACK_BINARY_DIR}/include/cblas_mangling.h)
- endif()
- 
- include_directories(include ${LAPACK_BINARY_DIR}/include)
-

--- a/var/spack/repos/builtin/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-lapack/package.py
@@ -133,7 +133,6 @@ class NetlibLapack(Package):
 
     def install_one(self, spec, prefix, shared):
         cmake_args = [
-            '--trace-expand',
             '-DBUILD_SHARED_LIBS:BOOL=%s' % ('ON' if shared else 'OFF'),
             '-DCMAKE_BUILD_TYPE:STRING=%s' % (
                 'Debug' if '+debug' in spec else 'Release'),

--- a/var/spack/repos/builtin/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-lapack/package.py
@@ -156,7 +156,7 @@ class NetlibLapack(Package):
                 self.compiler.name == 'clang'):
                 # use F77 compiler if IBM XL or clang
                 cmake_args.extend([
-                    '-DCMAKE_Fortran_COMPILER=%s' % self.compiler.f77,
+                    '-DCMAKE_Fortran_COMPILER=%s' % spack_f77,
                     '-DCMAKE_Fortran_FLAGS=%s' % (
                         ' '.join(self.spec.compiler_flags['fflags'])),
                 ])


### PR DESCRIPTION
On CORAL, LLVM will use the XL Fortran compiler and I need to apply a change for the xl_r compiler to the clang compiler to make netlib-lapack build w/clang+xlf.

I split the xl_r patch in two: one specific to xl_r, that removes the -qfixed flag from Fortran compile options; and one that fixes the CBLAS use of default mangling definitions.