### PR TITLE
fix intel-mpi package and extend intel-mkl

### DIFF
--- a/var/spack/repos/builtin/packages/intel-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-mkl/package.py
@@ -22,6 +22,7 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
+from spack.util.prefix import Prefix
 import os
 import sys
 
@@ -89,6 +90,47 @@ class IntelMkl(IntelPackage):
         prefix = self.prefix
         shared = '+shared' in spec
 
+        # omp:
+        ver_dir = os.path.join(
+            prefix,
+            'compilers_and_libraries_{0}'.format(self.version),
+            'linux',
+            'lib',
+            'intel64'
+        )
+
+        dirs = [
+            ver_dir,
+            prefix.compilers_and_libraries.linux.lib.intel64,
+            prefix.lib
+        ]
+
+        for d in dirs:
+            if os.path.isdir(d):
+                omp_root = d
+                break
+
+        # mkl_root:
+        ver_dir = os.path.join(
+            prefix,
+            'compilers_and_libraries_{0}'.format(self.version),
+            'linux',
+            'mkl',
+            'lib',
+            'intel64'
+        )
+
+        dirs = [
+            ver_dir,
+            prefix.compilers_and_libraries.linux.mkl.lib.intel64,
+            prefix.mkl.lib
+        ]
+
+        for d in dirs:
+            if os.path.isdir(d):
+                mkl_root = d
+                break
+
         if '+ilp64' in spec:
             mkl_integer = ['libmkl_intel_ilp64']
         else:
@@ -103,10 +145,6 @@ class IntelMkl(IntelPackage):
                 mkl_threading = ['libmkl_intel_thread']
                 omp_threading = ['libiomp5']
 
-                if sys.platform != 'darwin':
-                    omp_root = prefix.compilers_and_libraries.linux.lib.intel64
-                else:
-                    omp_root = prefix.lib
                 omp_libs = find_libraries(
                     omp_threading, root=omp_root, shared=shared)
             elif '%gcc' in spec:
@@ -118,11 +156,6 @@ class IntelMkl(IntelPackage):
                 omp_libs = LibraryList(libgomp)
 
         # TODO: TBB threading: ['libmkl_tbb_thread', 'libtbb', 'libstdc++']
-
-        if sys.platform != 'darwin':
-            mkl_root = prefix.compilers_and_libraries.linux.mkl.lib.intel64
-        else:
-            mkl_root = prefix.mkl.lib
 
         mkl_libs = find_libraries(
             mkl_integer + mkl_threading + ['libmkl_core'],
@@ -170,10 +203,28 @@ class IntelMkl(IntelPackage):
         else:
             raise InstallError('No MPI found for scalapack')
 
-        integer = 'ilp64' if '+ilp64' in self.spec else 'lp64'
-        mkl_root = self.prefix.mkl.lib if sys.platform == 'darwin' else \
-            self.prefix.compilers_and_libraries.linux.mkl.lib.intel64
+        # mkl_root:
+        ver_dir = os.path.join(
+            prefix,
+            'compilers_and_libraries_{0}'.format(self.version),
+            'linux',
+            'mkl',
+            'lib',
+            'intel64'
+        )
 
+        dirs = [
+            ver_dir,
+            prefix.compilers_and_libraries.linux.mkl.lib.intel64,
+            prefix.mkl.lib
+        ]
+
+        for d in dirs:
+            if os.path.isdir(d):
+                mkl_root = d
+                break
+
+        integer = 'ilp64' if '+ilp64' in self.spec else 'lp64'
         shared = True if '+shared' in self.spec else False
 
         libs = find_libraries(
@@ -187,23 +238,53 @@ class IntelMkl(IntelPackage):
     @property
     def headers(self):
         prefix = self.spec.prefix
-        if sys.platform != 'darwin':
-            include_dir = prefix.compilers_and_libraries.linux.mkl.include
-        else:
-            include_dir = prefix.include
+        ver_dir = os.path.join(
+            prefix,
+            'compilers_and_libraries_{0}'.format(self.version),
+            'linux',
+            'mkl',
+            'include'
+        )
+
+        dirs = [
+            ver_dir,
+            prefix.compilers_and_libraries.linux.mkl.include,
+            prefix.include
+        ]
+
+        for d in dirs:
+            if os.path.isdir(d):
+                include_dir = d
+                break
 
         cblas_h = join_path(include_dir, 'mkl_cblas.h')
         lapacke_h = join_path(include_dir, 'mkl_lapacke.h')
         return HeaderList([cblas_h, lapacke_h])
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        ver_dir = os.path.join(
+            self.prefix,
+            'compilers_and_libraries_{0}'.format(self.version),
+            'linux',
+            'mkl'
+        )
+
+        dirs = [
+            Prefix(ver_dir),
+            self.prefix.compilers_and_libraries.linux.mkl,
+            self.prefix.mkl
+        ]
+
+        for d in dirs:
+            if os.path.isdir(d):
+                mkl_root = d
+                break
+
         # set up MKLROOT for everyone using MKL package
         if sys.platform == 'darwin':
-            mkl_lib = self.prefix.mkl.lib
-            mkl_root = self.prefix.mkl
+            mkl_lib = mkl_root.lib
         else:
-            mkl_lib = self.prefix.compilers_and_libraries.linux.mkl.lib.intel64
-            mkl_root = self.prefix.compilers_and_libraries.linux.mkl
+            mkl_lib = mkl_root.lib.intel64
 
         spack_env.set('MKLROOT', mkl_root)
         spack_env.append_path('SPACK_COMPILER_EXTRA_RPATHS', mkl_lib)

--- a/var/spack/repos/builtin/packages/intel-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-mkl/package.py
@@ -22,7 +22,6 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-from spack.util.prefix import Prefix
 import os
 import sys
 
@@ -91,18 +90,11 @@ class IntelMkl(IntelPackage):
         shared = '+shared' in spec
 
         # omp:
-        ver_dir = os.path.join(
-            prefix,
-            'compilers_and_libraries_{0}'.format(self.version),
-            'linux',
-            'lib',
-            'intel64'
-        )
-
+        omp_root = prefix.lib   # default
         dirs = [
-            ver_dir,
-            prefix.compilers_and_libraries.linux.lib.intel64,
-            prefix.lib
+            prefix.join('compilers_and_libraries_{0}'.format(
+                self.version)).linux.lib.intel64,
+            prefix.compilers_and_libraries.linux.lib.intel64
         ]
 
         for d in dirs:
@@ -111,19 +103,11 @@ class IntelMkl(IntelPackage):
                 break
 
         # mkl_root:
-        ver_dir = os.path.join(
-            prefix,
-            'compilers_and_libraries_{0}'.format(self.version),
-            'linux',
-            'mkl',
-            'lib',
-            'intel64'
-        )
-
+        mkl_root = prefix.mkl.lib  # default
         dirs = [
-            ver_dir,
-            prefix.compilers_and_libraries.linux.mkl.lib.intel64,
-            prefix.mkl.lib
+            prefix.join('compilers_and_libraries_{0}'.format(
+                self.version)).linux.mkl.lib.intel64,
+            prefix.compilers_and_libraries.linux.mkl.lib.intel64
         ]
 
         for d in dirs:
@@ -204,19 +188,11 @@ class IntelMkl(IntelPackage):
             raise InstallError('No MPI found for scalapack')
 
         # mkl_root:
-        ver_dir = os.path.join(
-            prefix,
-            'compilers_and_libraries_{0}'.format(self.version),
-            'linux',
-            'mkl',
-            'lib',
-            'intel64'
-        )
-
+        mkl_root = prefix.mkl.lib  # default
         dirs = [
-            ver_dir,
-            prefix.compilers_and_libraries.linux.mkl.lib.intel64,
-            prefix.mkl.lib
+            prefix.join('compilers_and_libraries_{0}'.format(
+                self.version)).linux.mkl.lib.intel64,
+            prefix.compilers_and_libraries.linux.mkl.lib.intel64
         ]
 
         for d in dirs:
@@ -238,18 +214,11 @@ class IntelMkl(IntelPackage):
     @property
     def headers(self):
         prefix = self.spec.prefix
-        ver_dir = os.path.join(
-            prefix,
-            'compilers_and_libraries_{0}'.format(self.version),
-            'linux',
-            'mkl',
-            'include'
-        )
-
+        include_dir = prefix.include  # default
         dirs = [
-            ver_dir,
-            prefix.compilers_and_libraries.linux.mkl.include,
-            prefix.include
+            prefix.join('compilers_and_libraries_{0}'.format(
+                self.version)).linux.mkl.include,
+            prefix.compilers_and_libraries.linux.mkl.include
         ]
 
         for d in dirs:
@@ -262,17 +231,11 @@ class IntelMkl(IntelPackage):
         return HeaderList([cblas_h, lapacke_h])
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        ver_dir = os.path.join(
-            self.prefix,
-            'compilers_and_libraries_{0}'.format(self.version),
-            'linux',
-            'mkl'
-        )
-
+        mkl_root = self.prefix.mkl  # default
         dirs = [
-            Prefix(ver_dir),
-            self.prefix.compilers_and_libraries.linux.mkl,
-            self.prefix.mkl
+            self.prefix.join('compilers_and_libraries_{0}'.format(
+                self.version)).linux.mkl,
+            self.prefix.compilers_and_libraries.linux.mkl
         ]
 
         for d in dirs:

--- a/var/spack/repos/builtin/packages/intel-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -22,7 +22,6 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-from spack.util.prefix import Prefix
 import os
 
 from spack import *
@@ -30,12 +29,7 @@ from spack.environment import EnvironmentModifications
 
 
 class IntelMpi(IntelPackage):
-    """Intel MPI
-
-    One of the purposes of this package is to support a stand-alone
-    installation, that is when prefix does not contain
-    compilers_and_libraries folder and alike.
-    """
+    """Intel MPI"""
 
     homepage = "https://software.intel.com/en-us/intel-mpi-library"
 
@@ -70,18 +64,11 @@ class IntelMpi(IntelPackage):
 
     @property
     def mpi_libs(self):
-        ver_dir = os.path.join(
-            self.prefix,
-            'compilers_and_libraries_{0}'.format(self.version),
-            'linux',
-            'mpi',
-            'lib64'
-        )
-
+        mpi_root = self.prefix.lib64   # default
         dirs = [
-            Prefix(ver_dir),
-            self.prefix.compilers_and_libraries.linux.mpi.lib64,
-            self.prefix.lib64
+            self.prefix.join('compilers_and_libraries_{0}'.format(
+                self.version)).linux.mpi.lib64,
+            self.prefix.compilers_and_libraries.linux.mpi.lib64
         ]
 
         for d in dirs:
@@ -103,18 +90,11 @@ class IntelMpi(IntelPackage):
     def mpi_headers(self):
         # recurse from self.prefix will find too many things for all the
         # supported sub-architectures like 'mic'
-        ver_dir = os.path.join(
-            self.prefix,
-            'compilers_and_libraries_{0}'.format(self.version),
-            'linux',
-            'mpi',
-            'include64'
-        )
-
+        mpi_root = self.prefix.include64  # default
         dirs = [
-            Prefix(ver_dir),
-            self.prefix.compilers_and_libraries.linux.mpi.include64,
-            self.prefix.include64
+            self.prefix.join('compilers_and_libraries_{0}'.format(
+                self.version)).linux.mpi.include64,
+            self.prefix.compilers_and_libraries.linux.mpi.include64
         ]
 
         for d in dirs:
@@ -144,20 +124,12 @@ class IntelMpi(IntelPackage):
         # and friends are set to point to the Intel compilers, but in
         # practice, mpicc fails to compile some applications while
         # mpiicc works.
-        ver_dir = os.path.join(
-            self.prefix,
-            'compilers_and_libraries_{0}'.format(self.version),
-            'linux',
-            'mpi',
-            'intel64',
-            'bin'
-        )
-
+        bindir = self.prefix.bin  # default
         dirs = [
-            Prefix(ver_dir),
+            self.prefix.join('compilers_and_libraries_{0}'.format(
+                self.version)).linux.mpi.intel64.bin,
             self.prefix.compilers_and_libraries.linux.mpi.intel64.bin,
-            self.prefix.bin64,
-            self.prefix.bin
+            self.prefix.bin64
         ]
 
         for d in dirs:
@@ -193,20 +165,12 @@ class IntelMpi(IntelPackage):
         # TODO: At some point we should split setup_environment into
         # setup_build_environment and setup_run_environment to get around
         # this problem.
-        ver_dir = os.path.join(
-            self.prefix,
-            'compilers_and_libraries_{0}'.format(self.version),
-            'linux',
-            'mpi',
-            'intel64',
-            'bin'
-        )
-
+        bindir = self.prefix.bin  # default
         dirs = [
-            Prefix(ver_dir),
+            self.prefix.join('compilers_and_libraries_{0}'.format(
+                self.version)).linux.mpi.intel64.bin,
             self.prefix.compilers_and_libraries.linux.mpi.intel64.bin,
-            self.prefix.bin64,
-            self.prefix.bin
+            self.prefix.bin64
         ]
 
         for d in dirs:

--- a/var/spack/repos/builtin/packages/intel-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -69,7 +69,16 @@ class IntelMpi(IntelPackage):
 
     @property
     def mpi_libs(self):
+        ver_dir = os.path.join(
+            self.prefix,
+            'compilers_and_libraries_{0}'.format(self.version),
+            'linux',
+            'mpi',
+            'lib64'
+        )
+
         dirs = [
+            ver_dir,
             self.prefix.compilers_and_libraries.linux.mpi.lib64,
             self.prefix.lib64
         ]
@@ -93,7 +102,16 @@ class IntelMpi(IntelPackage):
     def mpi_headers(self):
         # recurse from self.prefix will find too many things for all the
         # supported sub-architectures like 'mic'
+        ver_dir = os.path.join(
+            self.prefix,
+            'compilers_and_libraries_{0}'.format(self.version),
+            'linux',
+            'mpi',
+            'include64'
+        )
+
         dirs = [
+            ver_dir,
             self.prefix.compilers_and_libraries.linux.mpi.include64,
             self.prefix.include64
         ]
@@ -125,7 +143,17 @@ class IntelMpi(IntelPackage):
         # and friends are set to point to the Intel compilers, but in
         # practice, mpicc fails to compile some applications while
         # mpiicc works.
+        ver_dir = os.path.join(
+            self.prefix,
+            'compilers_and_libraries_{0}'.format(self.version),
+            'linux',
+            'mpi',
+            'intel64',
+            'bin'
+        )
+
         dirs = [
+            ver_dir,
             self.prefix.compilers_and_libraries.linux.mpi.intel64.bin,
             self.prefix.bin64,
             self.prefix.bin
@@ -164,8 +192,29 @@ class IntelMpi(IntelPackage):
         # TODO: At some point we should split setup_environment into
         # setup_build_environment and setup_run_environment to get around
         # this problem.
-        mpivars = os.path.join(
+        ver_dir = os.path.join(
+            self.prefix,
+            'compilers_and_libraries_{0}'.format(self.version),
+            'linux',
+            'mpi',
+            'intel64',
+            'bin'
+        )
+
+        dirs = [
+            ver_dir,
             self.prefix.compilers_and_libraries.linux.mpi.intel64.bin,
+            self.prefix.bin64,
+            self.prefix.bin
+        ]
+
+        for d in dirs:
+            if os.path.isdir(d):
+                bindir = d
+                break
+
+        mpivars = os.path.join(
+            bindir,
             'mpivars.sh')
 
         if os.path.isfile(mpivars):

--- a/var/spack/repos/builtin/packages/intel-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -22,6 +22,7 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
+from spack.util.prefix import Prefix
 import os
 
 from spack import *
@@ -78,7 +79,7 @@ class IntelMpi(IntelPackage):
         )
 
         dirs = [
-            ver_dir,
+            Prefix(ver_dir),
             self.prefix.compilers_and_libraries.linux.mpi.lib64,
             self.prefix.lib64
         ]
@@ -111,7 +112,7 @@ class IntelMpi(IntelPackage):
         )
 
         dirs = [
-            ver_dir,
+            Prefix(ver_dir),
             self.prefix.compilers_and_libraries.linux.mpi.include64,
             self.prefix.include64
         ]
@@ -153,7 +154,7 @@ class IntelMpi(IntelPackage):
         )
 
         dirs = [
-            ver_dir,
+            Prefix(ver_dir),
             self.prefix.compilers_and_libraries.linux.mpi.intel64.bin,
             self.prefix.bin64,
             self.prefix.bin
@@ -202,7 +203,7 @@ class IntelMpi(IntelPackage):
         )
 
         dirs = [
-            ver_dir,
+            Prefix(ver_dir),
             self.prefix.compilers_and_libraries.linux.mpi.intel64.bin,
             self.prefix.bin64,
             self.prefix.bin

--- a/var/spack/repos/builtin/packages/intel-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -29,7 +29,12 @@ from spack.environment import EnvironmentModifications
 
 
 class IntelMpi(IntelPackage):
-    """Intel MPI"""
+    """Intel MPI
+
+    One of the purposes of this package is to support a stand-alone
+    installation, that is when prefix does not contain
+    compilers_and_libraries folder and alike.
+    """
 
     homepage = "https://software.intel.com/en-us/intel-mpi-library"
 
@@ -64,7 +69,16 @@ class IntelMpi(IntelPackage):
 
     @property
     def mpi_libs(self):
-        mpi_root = self.prefix.compilers_and_libraries.linux.mpi.lib64
+        dirs = [
+            self.prefix.compilers_and_libraries.linux.mpi.lib64,
+            self.prefix.lib64
+        ]
+
+        for d in dirs:
+            if os.path.isdir(d):
+                mpi_root = d
+                break
+
         query_parameters = self.spec.last_query.extra_parameters
         libraries = ['libmpifort', 'libmpi']
 
@@ -79,7 +93,16 @@ class IntelMpi(IntelPackage):
     def mpi_headers(self):
         # recurse from self.prefix will find too many things for all the
         # supported sub-architectures like 'mic'
-        mpi_root = self.prefix.compilers_and_libraries.linux.mpi.include64
+        dirs = [
+            self.prefix.compilers_and_libraries.linux.mpi.include64,
+            self.prefix.include64
+        ]
+
+        for d in dirs:
+            if os.path.isdir(d):
+                mpi_root = d
+                break
+
         return find_headers('mpi', root=mpi_root, recursive=False)
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
@@ -102,7 +125,16 @@ class IntelMpi(IntelPackage):
         # and friends are set to point to the Intel compilers, but in
         # practice, mpicc fails to compile some applications while
         # mpiicc works.
-        bindir = self.prefix.compilers_and_libraries.linux.mpi.intel64.bin
+        dirs = [
+            self.prefix.compilers_and_libraries.linux.mpi.intel64.bin,
+            self.prefix.bin64,
+            self.prefix.bin
+        ]
+
+        for d in dirs:
+            if os.path.isdir(d):
+                bindir = d
+                break
 
         if self.compiler.name == 'intel':
             self.spec.mpicc  = bindir.mpiicc


### PR DESCRIPTION
the main reason Intel-MPI was added in https://github.com/spack/spack/pull/3905 was to support a stand-alone installation, i.e. not a part of parallel studio or alike, see https://groups.google.com/forum/#!topic/spack/SDR04CNRoyQ . The intended behaviour got broken during refactoring in https://github.com/spack/spack/pull/4300 . This commit fixes the issue by supporting different directories.

p.s. strangely enough, by the time I was reviewing https://github.com/spack/spack/pull/4300 ( the last comment of mine was "merge it!"), I completely forgot about the intention of `intel-mpi` and have not tested it at that time...