### PR TITLE
update intel compiler version

### DIFF
--- a/var/spack/repos/builtin/packages/intel/package.py
+++ b/var/spack/repos/builtin/packages/intel/package.py
@@ -34,7 +34,7 @@ class Intel(IntelPackage):
     homepage = "https://software.intel.com/en-us/intel-parallel-studio-xe"
 
     version('18.0.3', '234223cc470717c2095456d9f048d690',
-            url = 'http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13002/parallel_studio_xe_2018_update3_composer_edition.tgz' )
+            url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13002/parallel_studio_xe_2018_update3_composer_edition.tgz')
     version('18.0.1', '28cb807126d713350f4aa6f9f167448a',
             url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12381/parallel_studio_xe_2018_update1_composer_edition.tgz')
     version('18.0.0', '31ba768fba6e7322957b03feaa3add28',

--- a/var/spack/repos/builtin/packages/intel/package.py
+++ b/var/spack/repos/builtin/packages/intel/package.py
@@ -33,6 +33,8 @@ class Intel(IntelPackage):
 
     homepage = "https://software.intel.com/en-us/intel-parallel-studio-xe"
 
+    version('18.0.3', '234223cc470717c2095456d9f048d690',
+            url = 'http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13002/parallel_studio_xe_2018_update3_composer_edition.tgz' )
     version('18.0.1', '28cb807126d713350f4aa6f9f167448a',
             url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12381/parallel_studio_xe_2018_update1_composer_edition.tgz')
     version('18.0.0', '31ba768fba6e7322957b03feaa3add28',


### PR DESCRIPTION
This update doesn't install properly with the current ```silent.cfg```. Maybe wait for updates about the installation process to update it with more details before merging.