### PR TITLE
extend Prefix class with join() member to support dynamic directories

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2763,11 +2763,11 @@ Prefix Attribute        Location
 
 Of course, this only works if your file or directory is a valid Python
 variable name. If your file or directory contains dashes or dots, use
-``join_path`` instead:
+``join`` instead:
 
 .. code-block:: python
 
-   join_path(prefix.lib, 'libz.a')
+   prefix.lib.join('libz.a')
 
 
 .. _spec-objects:

--- a/lib/spack/spack/test/util/prefix.py
+++ b/lib/spack/spack/test/util/prefix.py
@@ -41,6 +41,8 @@ def test_prefix_join():
     prefix = Prefix('/usr')
 
     assert prefix.join('a_{0}'.format(1)).lib64 == '/usr/a_1/lib64'
+    assert prefix.join('a-{0}'.format(1)).lib64 == '/usr/a-1/lib64'
+    assert prefix.join('a.{0}'.format(1)).lib64 == '/usr/a.1/lib64'
 
 
 def test_multilevel_attributes():

--- a/lib/spack/spack/test/util/prefix.py
+++ b/lib/spack/spack/test/util/prefix.py
@@ -44,6 +44,18 @@ def test_prefix_join():
     assert prefix.join('a-{0}'.format(1)).lib64 == '/usr/a-1/lib64'
     assert prefix.join('a.{0}'.format(1)).lib64 == '/usr/a.1/lib64'
 
+    assert prefix.bin.join('executable.sh')               == '/usr/bin/executable.sh'
+    assert prefix.share.join('pkg-config').join('foo.pc') == '/usr/share/pkg-config/foo.pc'
+    assert prefix.join('dashed-directory').foo            == '/usr/dashed-directory/foo'
+
+    assert isinstance(prefix.join('a_{0}'.format(1)).lib64, Prefix)
+    assert isinstance(prefix.join('a-{0}'.format(1)).lib64, Prefix)
+    assert isinstance(prefix.join('a.{0}'.format(1)).lib64, Prefix)
+
+    assert isinstance(prefix.bin.join('executable.sh'), Prefix)
+    assert isinstance(prefix.share.join('pkg-config').join('foo.pc'), Prefix)
+    assert isinstance(prefix.join('dashed-directory').foo, Prefix)
+
 
 def test_multilevel_attributes():
     """Test attributes of attributes, like ``prefix.share.man``"""

--- a/lib/spack/spack/test/util/prefix.py
+++ b/lib/spack/spack/test/util/prefix.py
@@ -36,6 +36,13 @@ def test_prefix_attributes():
     assert prefix.include == '/usr/include'
 
 
+def test_prefix_join():
+    """Test prefix join  ``prefix.join(...)``"""
+    prefix = Prefix('/usr')
+
+    assert prefix.join('a_{0}'.format(1)).lib64 == '/usr/a_1/lib64'
+
+
 def test_multilevel_attributes():
     """Test attributes of attributes, like ``prefix.share.man``"""
     prefix = Prefix('/usr/')

--- a/lib/spack/spack/test/util/prefix.py
+++ b/lib/spack/spack/test/util/prefix.py
@@ -40,21 +40,29 @@ def test_prefix_join():
     """Test prefix join  ``prefix.join(...)``"""
     prefix = Prefix('/usr')
 
-    assert prefix.join('a_{0}'.format(1)).lib64 == '/usr/a_1/lib64'
-    assert prefix.join('a-{0}'.format(1)).lib64 == '/usr/a-1/lib64'
-    assert prefix.join('a.{0}'.format(1)).lib64 == '/usr/a.1/lib64'
+    a1 = prefix.join('a_{0}'.format(1)).lib64
+    a2 = prefix.join('a-{0}'.format(1)).lib64
+    a3 = prefix.join('a.{0}'.format(1)).lib64
 
-    assert prefix.bin.join('executable.sh')               == '/usr/bin/executable.sh'
-    assert prefix.share.join('pkg-config').join('foo.pc') == '/usr/share/pkg-config/foo.pc'
-    assert prefix.join('dashed-directory').foo            == '/usr/dashed-directory/foo'
+    assert a1 == '/usr/a_1/lib64'
+    assert a2 == '/usr/a-1/lib64'
+    assert a3 == '/usr/a.1/lib64'
 
-    assert isinstance(prefix.join('a_{0}'.format(1)).lib64, Prefix)
-    assert isinstance(prefix.join('a-{0}'.format(1)).lib64, Prefix)
-    assert isinstance(prefix.join('a.{0}'.format(1)).lib64, Prefix)
+    assert isinstance(a1, Prefix)
+    assert isinstance(a2, Prefix)
+    assert isinstance(a3, Prefix)
 
-    assert isinstance(prefix.bin.join('executable.sh'), Prefix)
-    assert isinstance(prefix.share.join('pkg-config').join('foo.pc'), Prefix)
-    assert isinstance(prefix.join('dashed-directory').foo, Prefix)
+    p1 = prefix.bin.join('executable.sh')
+    p2 = prefix.share.join('pkg-config').join('foo.pc')
+    p3 = prefix.join('dashed-directory').foo
+
+    assert p1 == '/usr/bin/executable.sh'
+    assert p2 == '/usr/share/pkg-config/foo.pc'
+    assert p3 == '/usr/dashed-directory/foo'
+
+    assert isinstance(p1, Prefix)
+    assert isinstance(p2, Prefix)
+    assert isinstance(p3, Prefix)
 
 
 def test_multilevel_attributes():

--- a/lib/spack/spack/util/prefix.py
+++ b/lib/spack/spack/util/prefix.py
@@ -44,6 +44,8 @@ class Prefix(str):
     /usr/share/man
     >>> prefix.foo.bar.baz
     /usr/foo/bar/baz
+    >>> prefix.join('dashed-directory').bin64
+    /usr/dashed-directory/bin64
 
     Prefix objects behave identically to strings. In fact, they
     subclass ``str``. So operators like ``+`` are legal::

--- a/lib/spack/spack/util/prefix.py
+++ b/lib/spack/spack/util/prefix.py
@@ -55,3 +55,6 @@ class Prefix(str):
     """
     def __getattr__(self, attr):
         return Prefix(os.path.join(self, attr))
+
+    def join(self, string):
+        return Prefix(os.path.join(self, string))

--- a/lib/spack/spack/util/prefix.py
+++ b/lib/spack/spack/util/prefix.py
@@ -57,4 +57,12 @@ class Prefix(str):
         return Prefix(os.path.join(self, attr))
 
     def join(self, string):
+        """Concatenates a string to a prefix.
+
+        Parameters:
+            string (str): the string to append to the prefix
+
+        Returns:
+            Prefix: the newly created installation prefix
+        """
         return Prefix(os.path.join(self, string))


### PR DESCRIPTION
minor follow up to https://github.com/spack/spack/pull/4591

The idea is to support the following syntax:
```
self.prefix.join('compilers_and_libraries_{0}'.format(self.version)).linux.mkl
```