### PR TITLE
Use no mangling for all spack compiler definitions that use the XL Fortran compiler.

### DIFF
--- a/var/spack/repos/builtin/packages/superlu-dist/package.py
+++ b/var/spack/repos/builtin/packages/superlu-dist/package.py
@@ -88,7 +88,8 @@ class SuperluDist(Package):
             'LOADER       = {0}'.format(self.spec['mpi'].mpif77),
             'LOADOPTS     =',
             'CDEFS        = %s' % ("-DNoChange"
-                                       if '%xl' in spec or '%xl_r' in spec
+                                       if spack_f77.endswith('xlf') or
+                                          spack_f77.endswith('xlf_r')
                                        else "-DAdd_")
         ])
 


### PR DESCRIPTION
Clang can build with IBM XL Fortran compiler as well, so Fortran name mangling shoud be avoided for that case as well.