### PR TITLE
Camellia: add version restriction for HDF5.

### DIFF
--- a/var/spack/repos/builtin/packages/camellia/package.py
+++ b/var/spack/repos/builtin/packages/camellia/package.py
@@ -40,6 +40,7 @@ class Camellia(CMakePackage):
 
     depends_on('trilinos+amesos+amesos2+belos+epetra+epetraext+exodus+ifpack+ifpack2+intrepid+intrepid2+kokkos+ml+muelu+sacado+shards+teuchos+tpetra+zoltan+mumps+superlu-dist+hdf5+zlib+pnetcdf@master,12.12.1:')
     depends_on('moab@:4', when='+moab')
+    depends_on('hdf5@:1.8')
     depends_on('mpi')
 
     def cmake_args(self):


### PR DESCRIPTION
HDF5 1.10.x is incompatible with Camellia, at least right now, so adding dependency to versions up to 1.8.x.