### PR TITLE
Use GitHub URL for pigz, supports > 1 release

### DIFF
--- a/var/spack/repos/builtin/packages/pigz/package.py
+++ b/var/spack/repos/builtin/packages/pigz/package.py
@@ -30,9 +30,10 @@ class Pigz(MakefilePackage):
        multi-core machines."""
 
     homepage = "http://zlib.net/pigz/"
-    url      = "http://zlib.net/pigz/pigz-2.3.4.tar.gz"
+    url      = "https://github.com/madler/pigz/archive/v2.3.4.tar.gz"
 
-    version('2.3.4', '08e6b2e682bbf65ccf12c8966d633fc6')
+    version('2.4', '3c8a601db141d3013ef9fe5f2daaf73f')
+    version('2.3.4', 'c109057050b15edf3eb9bb4d0805235e')
 
     depends_on('zlib')
 


### PR DESCRIPTION
The URL that we were using for pigz only provides the current
version.  When the author released v2.4 the package became
uninstallable (unless you have the tarball cached).

It turns out that their are tarballs of the tagged source tree
available on GitHub and they're sufficient to build things (no
additional bits needed).

This commit switches the URL to the GitHub archive URL.

Sadly, this changes the v2.3.4 digest, but that version was no longer
available/install-able anyway, so "net-net we're still in positive
territory".