### PR TITLE
Fix digest for abyss@1.5.2

### DIFF
--- a/var/spack/repos/builtin/packages/abyss/package.py
+++ b/var/spack/repos/builtin/packages/abyss/package.py
@@ -34,7 +34,7 @@ class Abyss(AutotoolsPackage):
     url      = "https://github.com/bcgsc/abyss/archive/2.0.2.tar.gz"
 
     version('2.0.2', 'bb3f8cebf121312bf81789d963b4ecc5')
-    version('1.5.2', '10d6d72d1a915e618d41a5cbbcf2364c')
+    version('1.5.2', '88400e39592ec69938512e2ad6f35245')
 
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')

--- a/var/spack/repos/builtin/packages/abyss/package.py
+++ b/var/spack/repos/builtin/packages/abyss/package.py
@@ -31,10 +31,10 @@ class Abyss(AutotoolsPackage):
        is useful for assembling genomes up to 100 Mbases in size."""
 
     homepage = "http://www.bcgsc.ca/platform/bioinfo/software/abyss"
-    url      = "https://github.com/bcgsc/abyss/archive/2.0.2.tar.gz"
+    url      = "https://github.com/bcgsc/abyss/releases/download/1.5.2/abyss-1.5.2.tar.gz"
 
-    version('2.0.2', 'bb3f8cebf121312bf81789d963b4ecc5')
-    version('1.5.2', '88400e39592ec69938512e2ad6f35245')
+    version('2.0.2', '1623f55ad7f4586e80f6e74b1f27c798')
+    version('1.5.2', '10d6d72d1a915e618d41a5cbbcf2364c')
 
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')


### PR DESCRIPTION
The digest value for v1.5.2 appears to have changed.  This value works
for me, today.

The existing value v2.0.2 works as is.