### PR TITLE
Add missing expand=False for v2.18.3

### DIFF
--- a/var/spack/repos/builtin/packages/picard/package.py
+++ b/var/spack/repos/builtin/packages/picard/package.py
@@ -41,7 +41,7 @@ class Picard(Package):
 
     # They started distributing a single jar file at v2.6.0, prior to
     # that it was a .zip file with multiple .jar and .so files
-    version('2.18.3', '181b1b0731fd35f0d8bd44677d8787e9')
+    version('2.18.3', '181b1b0731fd35f0d8bd44677d8787e9', expand=False)
     version('2.18.0', '20045ff141e4a67512365f0b6bbd8229', expand=False)
     version('2.17.0', '72cc527f1e4ca6a799ae0117af60b54e', expand=False)
     version('2.16.0', 'fed8928b03bb36e355656f349e579083', expand=False)


### PR DESCRIPTION
Installing the current version of Picard fails with:

```
==> Error: Unable to parse extension from https://github.com/broadinstitute/picard/releases/download/2.18.3/picard.jar.

If this URL is for a tarball but does not include the file extension
in the name, you can explicitly declare it with the following syntax:

    version('1.2.3', 'hash', extension='tar.gz')

If this URL is for a download like a .jar or .whl that does not need
to be expanded, or an uncompressed installation script, you can tell
Spack not to expand it with the following syntax:

    version('1.2.3', 'hash', expand=False)
```

Fix it, by adding `expand=False`, like the other versions.