### PR TITLE
Git's gitk needs TK's wish to be found in PATH

### DIFF
--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -160,6 +160,9 @@ class Git(AutotoolsPackage):
             placement='git-manpages',
             when='@{0}'.format(release['version']))
 
+    variant('tcltk', default=False,
+            description='Gitk: provide Tcl/Tk in the run environment')
+
     depends_on('curl')
     depends_on('expat')
     depends_on('gettext')
@@ -174,7 +177,7 @@ class Git(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
-    depends_on('tk',       type='run')
+    depends_on('tk',       type='run', when='+tcltk')
 
     # See the comment in setup_environment re EXTLIBS.
     def patch(self):
@@ -201,7 +204,8 @@ class Git(AutotoolsPackage):
                 self.spec['gettext'].prefix.include))
 
         # gitk requires tk's wish to be found in $PATH.
-        run_env.prepend_path('PATH', self.spec['tk'].prefix.bin)
+        if '+tcltk' in self.spec:
+            run_env.prepend_path('PATH', self.spec['tk'].prefix.bin)
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -177,7 +177,7 @@ class Git(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
-    depends_on('tk',       type='run', when='+tcltk')
+    depends_on('tk',       type=('build', 'link'), when='+tcltk')
 
     # See the comment in setup_environment re EXTLIBS.
     def patch(self):
@@ -203,14 +203,10 @@ class Git(AutotoolsPackage):
             spack_env.append_flags('CFLAGS', '-I{0}'.format(
                 self.spec['gettext'].prefix.include))
 
-        # gitk requires tk's wish to be found in $PATH.
-        if '+tcltk' in self.spec:
-            run_env.prepend_path('PATH', self.spec['tk'].prefix.bin)
-
     def configure_args(self):
         spec = self.spec
 
-        return [
+        configure_args = [
             '--with-curl={0}'.format(spec['curl'].prefix),
             '--with-expat={0}'.format(spec['expat'].prefix),
             '--with-iconv={0}'.format(spec['libiconv'].prefix),
@@ -219,6 +215,14 @@ class Git(AutotoolsPackage):
             '--with-perl={0}'.format(spec['perl'].command.path),
             '--with-zlib={0}'.format(spec['zlib'].prefix),
         ]
+
+        if '+tcltk' in self.spec:
+            configure_args.append('--with-tcltk={0}'.format(
+                self.spec['tk'].prefix.bin.wish))
+        else:
+            configure_args.append('--without-tcltk')
+
+        return configure_args
 
     @run_after('configure')
     def filter_rt(self):

--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -174,6 +174,7 @@ class Git(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
+    depends_on('tk',       type='run')
 
     # See the comment in setup_environment re EXTLIBS.
     def patch(self):
@@ -198,6 +199,9 @@ class Git(AutotoolsPackage):
                 self.spec['gettext'].prefix.lib))
             spack_env.append_flags('CFLAGS', '-I{0}'.format(
                 self.spec['gettext'].prefix.include))
+
+        # gitk requires tk's wish to be found in $PATH.
+        run_env.prepend_path('PATH', self.spec['tk'].prefix.bin)
 
     def configure_args(self):
         spec = self.spec


### PR DESCRIPTION
### Background

* `gitk` depends on TK at _runtime_. If TK's `wish` program isn't already on the system, `gitk` will fail to launch.
* I've been manually modifying the `git` module file generated by spack to satisfy this requirement.  This PR captures the requirement and automates the installation of `tk` and correct modulefile generation.

### Changes

* Add a _runtime_ build dependency on `tk`
* Add an environment rule to add the path to TK's `wish` program to `$PATH` for  the generated `git` modulefile.

### Impact

* After this PR, `spack install git` must also build `tk`.  This is a somewhat deep tree of dependencies.

```
  ^tk@8.6.8%gcc@4.8.5 arch=linux-rhel7-x86_64 
        ^libx11@1.6.5%gcc@4.8.5 arch=linux-rhel7-x86_64 
            ^inputproto@2.3.2%gcc@4.8.5 arch=linux-rhel7-x86_64 
                ^util-macros@1.19.1%gcc@4.8.5 arch=linux-rhel7-x86_64 
            ^kbproto@1.0.7%gcc@4.8.5 arch=linux-rhel7-x86_64 
            ^libxcb@1.13%gcc@4.8.5 arch=linux-rhel7-x86_64 
                ^libpthread-stubs@0.4%gcc@4.8.5 arch=linux-rhel7-x86_64 
                ^libxau@1.0.8%gcc@4.8.5 arch=linux-rhel7-x86_64 
                    ^xproto@7.0.31%gcc@4.8.5 arch=linux-rhel7-x86_64 
                ^libxdmcp@1.1.2%gcc@4.8.5 arch=linux-rhel7-x86_64 
                ^xcb-proto@1.13%gcc@4.8.5 arch=linux-rhel7-x86_64 
            ^xextproto@7.3.0%gcc@4.8.5 arch=linux-rhel7-x86_64 
            ^xtrans@1.3.5%gcc@4.8.5 arch=linux-rhel7-x86_64 
        ^tcl@8.6.8%gcc@4.8.5 arch=linux-rhel7-x86_64 
```

* After this PR, the `git` modulefile generated by spack will contain the extra line (or similar depending on compiler):

```diff
+ prepend_path("PATH", "${SPACK_ROOT}/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/tk-8.6.8-uaspjhewvbjfgqt54bmzqy33rv5i5zij/bin")
```
