### PR TITLE
WIP: Install python applications into virtualenvs

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -225,7 +225,7 @@ class PythonPackage(PackageBase):
     def install_args(self, spec, prefix):
         """Arguments to pass to install."""
 
-        if not "VENV_PATH" in os.environ:
+        if "VENV_PATH" not in os.environ:
             args = ['--prefix={0}'.format(prefix)]
         else:
             args = []

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -224,7 +224,11 @@ class PythonPackage(PackageBase):
 
     def install_args(self, spec, prefix):
         """Arguments to pass to install."""
-        args = ['--prefix={0}'.format(prefix)]
+
+        if not "VENV_PATH" in os.environ:
+            args = ['--prefix={0}'.format(prefix)]
+        else:
+            args = []
 
         # This option causes python packages (including setuptools) NOT
         # to create eggs or easy-install.pth files.  Instead, they

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -544,6 +544,14 @@ def resource(**kwargs):
         resources.append(Resource(name, fetcher, destination, placement))
     return _execute_resource
 
+@directive('venv')
+def venv(venv_flag):
+    """
+    """
+    def _execute_venv(pkg):
+        pkg.venv_flag = venv_flag
+    return _execute_venv
+
 
 class DirectiveError(spack.error.SpackError):
     """This is raised when something is wrong with a package directive."""

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -544,6 +544,7 @@ def resource(**kwargs):
         resources.append(Resource(name, fetcher, destination, placement))
     return _execute_resource
 
+
 @directive('venv')
 def venv(venv_flag):
     """

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1429,8 +1429,8 @@ class PackageBase(with_metaclass(PackageMeta, object)):
         restage = kwargs.get('restage', False)
         partial = self.check_for_unfinished_installation(keep_prefix, restage)
         use_virtualenv = ("VENV_PATH" in os.environ and
-                           re.match('^Py', self.__class__.__name__) and
-                           self.__class__.__name__ is not 'Python')
+                          re.match('^Py', self.__class__.__name__) and
+                          self.__class__.__name__ is not 'Python')
 
         # Ensure package is not already installed
         layout = spack.store.layout

--- a/var/spack/repos/builtin/packages/bumpversion/package.py
+++ b/var/spack/repos/builtin/packages/bumpversion/package.py
@@ -34,4 +34,6 @@ class Bumpversion(PythonPackage):
     version('0.5.3', 'c66a3492eafcf5ad4b024be9fca29820')
     version('0.5.0', '222ba619283d6408ce1bfbb0b5b542f3')
 
+    venv(True)
+
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/httpie/package.py
+++ b/var/spack/repos/builtin/packages/httpie/package.py
@@ -37,6 +37,8 @@ class Httpie(PythonPackage):
     variant('socks', default=True,
             description='Enable SOCKS proxy support')
 
+    venv(True)
+
     depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-pygments@2.1.3:', type=('build', 'run'))
     depends_on('py-requests@2.11.0:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-flake8/package.py
+++ b/var/spack/repos/builtin/packages/py-flake8/package.py
@@ -71,6 +71,8 @@ class PyFlake8(PythonPackage):
     depends_on('py-configparser', type=('build', 'run'))
     depends_on('py-enum34', type=('build', 'run'))
 
+    venv(True)
+
     # TODO: Add test dependencies
     # depends_on('py-nose', type='test')
 

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -548,7 +548,7 @@ class Python(AutotoolsPackage):
         # python is found in the build environment. This to prevent cases
         # where a system provided python is run against the standard libraries
         # of a Spack built python. See issue #7128
-        if not "VENV_PATH" in os.environ:
+        if "VENV_PATH" not in os.environ:
             spack_env.set('PYTHONHOME', self.home)
 
         path = os.path.dirname(self.command.path)

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -548,7 +548,8 @@ class Python(AutotoolsPackage):
         # python is found in the build environment. This to prevent cases
         # where a system provided python is run against the standard libraries
         # of a Spack built python. See issue #7128
-        spack_env.set('PYTHONHOME', self.home)
+        if not "VENV_PATH" in os.environ:
+            spack_env.set('PYTHONHOME', self.home)
 
         path = os.path.dirname(self.command.path)
         if not is_system_path(path):
@@ -578,6 +579,14 @@ class Python(AutotoolsPackage):
         setup_py('install', '--prefix={0}'.format(prefix))"""
 
         module.python = self.command
+        if "VENV_PATH" in os.environ:
+            venv_path = os.environ["VENV_PATH"]
+            if not os.path.isdir(venv_path):
+                module.python('-m', 'virtualenv', venv_path)
+            newp = venv_path + '/bin/' + module.python.name
+            tty.warn("MY PYTHON IS: {0}".format(newp))
+            module.python = Executable(newp)
+
         module.setup_py = Executable(
             self.command.path + ' setup.py --no-user-cfg')
 


### PR DESCRIPTION
[I hit the green "submit" button too quickly and had to edit this comment to add, well, all of it...]

I'd like to explore adding the option of installing Python applications into Python virtualenvs, making their Python dependencies "build" only and giving them some of the robustness that rpath's bring to compiled applications (no need to depend on environment variables to find what they need at runtime).

I've [mentioned this][1] on the Spack google group and gotten some feedback from @healther and @citibeth, but most of what the bits they discussed involved ways to set up the environment.  I believe that installing into virtualenvs is orthogonal to the work they pointed me at.

I was recently exposed to [Homebrew's use of virtualenvs][2] when I submitted a Formula for `bumpversion`. 

This PR/branch is a **hack** to demonstrate how it might behave.  It is **not** a final implementation.

With that said, in a clone with this branch checked out and nothing else installed, one can (tested on CentOS 7):

```
spack install py-virtualenv
spack activate py-virtualenv
spack install py-flake8
spack install httpie
spack install bumpversion
```

The final 3 installations don't complete happily, but they finish the important POC bits.  In each prefix there will be a `libexec` directory (e.g. `.../spack-virtualenv/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/py-flake8-3.5.0-yqduo7ftn2ucmnamrn3lrlwkdsx7d4a7/libexec/`) that has a `bin` subdir that contains the application.  E.g.

```
/home/hartzell/tmp/spack-virtualenv/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/py-flake8-3.5.0-yqduo7ftn2ucmnamrn3lrlwkdsx7d4a7/libexec/bin/flake8
```

That `flake8` will run with no special environment settings, in fact, adding that `bin` directory to the `PATH` is enough to run `spack flake8` (and then fix the uglies...).

A final implementation (stealing from Homebrew) would link the applications into `prefix/bin`, keeping the `libexec` dir private.

I had trouble finding a pleasant way to pass the fact that a virtualenv was being used from the top level item (e.g. `py-flake8`) into the other layers.  

One clean idea would be for the top level app to depend on Python and specify a variant to Python that included the name of the virtualenv.  I'm not sure how to get that to concretize cleanly with all of the dependencies, which are simply depending on Python.  Perhaps a virtual dependency?

Alternatively, setting a boolean in the top-level application and figuring out how to pass the info down through its `do_install` and into the layers below seems to be the best bet.  Perhaps there's a way to adjust the `spec`'s or to pass alone the extra info.  It's tempting to do something with the Python package's `set_dependent_package`, but I couldn't figure it out nicely.

I would *love* feedback on how this might happen.

I think that python packages being installed into virtualenvs should have their prefix adjusted to point into the top level app's prefix (so that they don't clash with any real installs), they should be recorded in the db as part of a virtualenv install (or perhaps not as all).

**In conclusion:** if this works, then applications can be self-contained and more reliable (avoiding e.g. the py-flake8 module loading issue).   The resulting packages will play nicely with Environments and etc....  It's complementary to Spack's other methods for handling add-on packages (environment modification, activation, views) and would still use Spack's package definitions, preserving reproducibility and etc...

**Feedback?**



[1]: https://groups.google.com/forum/#!topic/spack/FKWH-N02cEQ
[2]: https://github.com/Homebrew/brew/blob/master/Library/Homebrew/language/python.rb