### PR TITLE
googletest: add a shared variant for all supported versions

### DIFF
--- a/var/spack/repos/builtin/packages/googletest/package.py
+++ b/var/spack/repos/builtin/packages/googletest/package.py
@@ -39,7 +39,7 @@ class Googletest(CMakePackage):
 
     variant('pthreads', default=True,
             description='Build multithreaded version with pthreads')
-    variant('shared', default=False,
+    variant('shared', default=True,
             description='Build shared libraries (DLLs)')
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/googletest/package.py
+++ b/var/spack/repos/builtin/packages/googletest/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import sys
 
 
 class Googletest(CMakePackage):
@@ -73,12 +72,8 @@ class Googletest(CMakePackage):
 
             mkdirp(prefix.lib)
             if '+shared' in spec:
-                if sys.platform == 'darwin':
-                    install('libgtest.dylib', prefix.lib)
-                    install('libgtest_main.dylib', prefix.lib)
-                else:
-                    install('libgtest.so', prefix.lib)
-                    install('libgtest_main.so', prefix.lib)
+                install('libgtest.{0}'.format(dso_suffix), prefix.lib)
+                install('libgtest_main.{0}'.format(dso_suffix), prefix.lib)
             else:
                 install('libgtest.a', prefix.lib)
                 install('libgtest_main.a', prefix.lib)

--- a/var/spack/repos/builtin/packages/googletest/package.py
+++ b/var/spack/repos/builtin/packages/googletest/package.py
@@ -39,6 +39,8 @@ class Googletest(CMakePackage):
 
     variant('pthreads', default=True,
             description='Build multithreaded version with pthreads')
+    variant('shared', default=False,
+            description='Build shared libraries (DLLs)')
 
     def cmake_args(self):
         spec = self.spec
@@ -55,6 +57,8 @@ class Googletest(CMakePackage):
 
         options.append('-Dgtest_disable_pthreads={0}'.format(
             'ON' if '+pthreads' in spec else 'OFF'))
+        options.append('-DBUILD_SHARED_LIBS={0}'.format(
+            'ON' if '+shared' in spec else 'OFF'))
         return options
 
     @when('@:1.7.0')
@@ -67,5 +71,7 @@ class Googletest(CMakePackage):
                          prefix.include)
 
             mkdirp(prefix.lib)
-            install('libgtest.a', prefix.lib)
-            install('libgtest_main.a', prefix.lib)
+            install('libgtest.{0}'.format(
+                'so' if '+shared' in spec else 'a'), prefix.lib)
+            install('libgtest_main.{0}'.format(
+                'so' if '+shared' in spec else 'a'), prefix.lib)

--- a/var/spack/repos/builtin/packages/googletest/package.py
+++ b/var/spack/repos/builtin/packages/googletest/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+import sys
 
 
 class Googletest(CMakePackage):
@@ -71,7 +72,13 @@ class Googletest(CMakePackage):
                          prefix.include)
 
             mkdirp(prefix.lib)
-            install('libgtest.{0}'.format(
-                'so' if '+shared' in spec else 'a'), prefix.lib)
-            install('libgtest_main.{0}'.format(
-                'so' if '+shared' in spec else 'a'), prefix.lib)
+            if '+shared' in spec:
+                if sys.platform == 'darwin':
+                    install('libgtest.dylib', prefix.lib)
+                    install('libgtest_main.dylib', prefix.lib)
+                else:
+                    install('libgtest.so', prefix.lib)
+                    install('libgtest_main.so', prefix.lib)
+            else:
+                install('libgtest.a', prefix.lib)
+                install('libgtest_main.a', prefix.lib)


### PR DESCRIPTION
This PR adds a shared variant to all given versions of this package which builds/installs DLLs if requested with '+shared'.  The previous default (static libs) is NOT preserved; the new default is to produce shared libs.