### PR TITLE
Remove PGI-specific code to use dirent64 in place of dirent in boost

### DIFF
--- a/var/spack/repos/builtin/packages/boost/boost_pgi.patch
+++ b/var/spack/repos/builtin/packages/boost/boost_pgi.patch
@@ -1,0 +1,13 @@
+--- a/libs/filesystem/src/operations.cpp
++++ b/libs/filesystem/src/operations.cpp
+@@ -2056,10 +2056,6 @@
+     return ok;
+   }
+ 
+-#if defined(__PGI) && defined(__USE_FILE_OFFSET64)
+-#define dirent dirent64
+-#endif
+-
+   error_code dir_itr_first(void *& handle, void *& buffer,
+     const char* dir, string& target,
+     fs::file_status &, fs::file_status &)

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -172,6 +172,7 @@ class Boost(Package):
     patch('call_once_variadic.patch', when='@1.54.0:1.55.9999%gcc@5.0:5.9')
 
     # Patch fix for PGI compiler
+    patch('boost_pgi.patch', when='%pgi')
     patch('boost_1.63.0_pgi.patch', when='@1.63.0%pgi')
     patch('boost_1.63.0_pgi_17.4_workaround.patch', when='@1.63.0%pgi@17.4')
 


### PR DESCRIPTION
Removed PGI-specific code in `boost` package that redefined `dirent` to be `dirent64`.  This caused `boost%pgi` to fail as certain function prototypes expected `dirent` instead of `dirent64`.

`dirent` and `dirent64` structures are defined in `/usr/include/bits/dirent.h` and are identical, depending on whether `__USE_FILE_OFFSET64` is defined.  If not defined, `dirent64` doesn't exist, if defined `dirent64` and `dirent` are identical.  I am unsure what advantage explicitly using the `dirent64` type over `dirent` with the pgi compiler, as the only purpose it seems to serve is prevent compilation.