### PR TITLE
Revert the patching of PETSc test cases for IBM XL

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -102,8 +102,6 @@ class Petsc(Package):
         patch('macos-clang-8.1.0.diff',
               when='@3.7.5%clang@8.1.0:')
     patch('pkg-config-3.7.6-3.8.4.diff', when='@3.7.6:3.8.4')
-    patch('xlc-test-3.9.0.diff', when='@3.9: %xl')
-    patch('xlc-test-3.9.0.diff', when='@3.9: %xl_r')
 
     # Virtual dependencies
     # Git repository needs sowing to build Fortran interface


### PR DESCRIPTION
Revert the patching of PETSc test cases.  They are not used for build and sanity check, so the tests should be patched only when somebody wants to build and run them, manually.