### PR TITLE
 Patch trilinos for xlf when using clang

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -102,6 +102,8 @@ class Petsc(Package):
         patch('macos-clang-8.1.0.diff',
               when='@3.7.5%clang@8.1.0:')
     patch('pkg-config-3.7.6-3.8.4.diff', when='@3.7.6:3.8.4')
+    patch('xlc-test-3.9.0.diff', when='@3.9: %xl')
+    patch('xlc-test-3.9.0.diff', when='@3.9: %xl_r')
 
     # Virtual dependencies
     # Git repository needs sowing to build Fortran interface

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -102,8 +102,6 @@ class Petsc(Package):
         patch('macos-clang-8.1.0.diff',
               when='@3.7.5%clang@8.1.0:')
     patch('pkg-config-3.7.6-3.8.4.diff', when='@3.7.6:3.8.4')
-    patch('xlc-test-3.9.0.diff', when='@3.9: %xl')
-    patch('xlc-test-3.9.0.diff', when='@3.9: %xl_r')
 
     # Virtual dependencies
     # Git repository needs sowing to build Fortran interface

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -255,6 +255,8 @@ class Trilinos(CMakePackage):
     patch('xlf_seacas.patch', when='@12.10.1:%xl_r')
     patch('xlf_tpetra.patch', when='@12.12.1:%xl')
     patch('xlf_tpetra.patch', when='@12.12.1:%xl_r')
+    patch('xlf_seacas.patch', when='@12.10.1:%clang')
+    patch('xlf_tpetra.patch', when='@12.12.1:%clang')
 
     def url_for_version(self, version):
         url = "https://github.com/trilinos/Trilinos/archive/trilinos-release-{0}.tar.gz"

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -255,7 +255,7 @@ class Trilinos(CMakePackage):
     patch('xlf_seacas.patch', when='@12.10.1:%xl_r')
     patch('xlf_tpetra.patch', when='@12.12.1:%xl')
     patch('xlf_tpetra.patch', when='@12.12.1:%xl_r')
-    patch('xlf_seacas.patch', when='@12.10.1:%clang')
+    patch('xlf_seacas.patch', when='@12.12.1:%clang')
     patch('xlf_tpetra.patch', when='@12.12.1:%clang')
 
     def url_for_version(self, version):


### PR DESCRIPTION
Apply IBM XL patches for `trilinos` when using the llvm compiler suite, for when llvm is using xlf as its Fortran compiler.  Related to #8311, #8388, #8389, #8392, #8393, #8394.