### PR TITLE
suite-sparse: Use actual Fortran compiler name to determine name mangling

### DIFF
--- a/var/spack/repos/builtin/packages/suite-sparse/package.py
+++ b/var/spack/repos/builtin/packages/suite-sparse/package.py
@@ -120,7 +120,7 @@ class SuiteSparse(Package):
         elif '%pgi' in spec:
             make_args += ['CFLAGS+=--exceptions']
 
-        if '%xl' in spec or '%xl_r' in spec:
+        if spack_f77.endswith('xlf') or spack_f77.endswith('xlf_r'):
             make_args += ['CFLAGS+=-DBLAS_NO_UNDERSCORE']
 
         # Intel TBB in SuiteSparseQR


### PR DESCRIPTION
Use the name of the Fortran compiler to determine what name mangling setting to use, instead of the spack compiler.

%clang can use multiple Fortran compilers with different options (see #8311, #8388, #8389, #8391, #8392, #8394), so we need to know what compiler is used in order to provide the correct options.