### PR TITLE
add commented test dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -59,7 +59,7 @@ class Esmf(MakefilePackage):
     depends_on('xerces-c@3.1.0:', when='+xerces')
 
     # Testing dependencies
-    # depends_on('perl', type='test')  # TODO: Add a test deptype
+    depends_on('perl', type='test')
 
     # Make esmf build with newer gcc versions
     # https://sourceforge.net/p/esmf/esmf/ci/3706bf758012daebadef83d6575c477aeff9c89b/

--- a/var/spack/repos/builtin/packages/flann/package.py
+++ b/var/spack/repos/builtin/packages/flann/package.py
@@ -92,6 +92,9 @@ class Flann(CMakePackage):
     # Example uses hdf5.
     depends_on("hdf5", when="+examples")
 
+    depends_on('hdf5', type='test')
+    depends_on('gtest', type='test')
+
     def patch(self):
         # Fix up the python setup.py call inside the install(CODE
         filter_file("setup.py install",
@@ -108,10 +111,6 @@ class Flann(CMakePackage):
         filter_file("install( FILES",
                     "# install( FILES",
                     "src/python/CMakeLists.txt", string=True)
-
-    # TODO: revisit after https://github.com/spack/spack/issues/1279
-    # depends_on('hdf5', type='test')
-    # depends_on('gtest', type='test')
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/jsoncpp/package.py
+++ b/var/spack/repos/builtin/packages/jsoncpp/package.py
@@ -42,8 +42,7 @@ class Jsoncpp(CMakePackage):
                     'MinSizeRel', 'Coverage'))
 
     depends_on('cmake@3.1:', type='build')
-    # TODO: Add a 'test' deptype
-    # depends_on('python', type='test')
+    depends_on('python', type='test')
 
     def cmake_args(self):
         return ['-DBUILD_SHARED_LIBS=ON']

--- a/var/spack/repos/builtin/packages/libpipeline/package.py
+++ b/var/spack/repos/builtin/packages/libpipeline/package.py
@@ -35,6 +35,4 @@ class Libpipeline(AutotoolsPackage):
     version('1.4.2', '30cec7bcd6fee723adea6a54389f3da2')
 
     depends_on('pkgconfig', type='build')
-    # TODO: Add a 'test' deptype
-    # See https://github.com/spack/spack/issues/1279
-    # depends_on('check', type='test')
+    depends_on('check', type='test')

--- a/var/spack/repos/builtin/packages/lz4/package.py
+++ b/var/spack/repos/builtin/packages/lz4/package.py
@@ -39,7 +39,7 @@ class Lz4(Package):
     version('1.7.5', 'c9610c5ce97eb431dddddf0073d919b9')
     version('1.3.1', '42b09fab42331da9d3fb33bd5c560de9')
 
-    # depends_on('valgrind', type='test')
+    depends_on('valgrind', type='test')
 
     def url_for_version(self, version):
         url = "https://github.com/lz4/lz4/archive"

--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -108,6 +108,8 @@ class Openssl(Package):
         filter_file(r'-arch x86_64', '', 'Makefile')
 
         make()
+        if self.run_tests:
+            make('test')            # 'VERBOSE=1'
         make('install')
 
     @run_after('install')

--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -67,10 +67,7 @@ class Openssl(Package):
 
     depends_on('zlib')
 
-    # TODO: 'make test' requires Perl module Test::More version 0.96
-    # TODO: uncomment when test dependency types are supported.
-    # TODO: This is commented in the meantime to avoid dependnecy bloat.
-    # depends_on('perl@5.14.0:', type='build', when='+tests')
+    depends_on('perl@5.14.0:', type='test')
 
     parallel = False
 
@@ -111,9 +108,6 @@ class Openssl(Package):
         filter_file(r'-arch x86_64', '', 'Makefile')
 
         make()
-        # TODO: add this back when we have a 'test' dependency type. See above.
-        # if self.run_tests:
-        #     make('test')            # 'VERBOSE=1'
         make('install')
 
     @run_after('install')

--- a/var/spack/repos/builtin/packages/py-brian2/package.py
+++ b/var/spack/repos/builtin/packages/py-brian2/package.py
@@ -44,7 +44,5 @@ class PyBrian2(PythonPackage):
     depends_on('py-pyparsing',      type=('build', 'run'))
     depends_on('py-jinja2@2.7:',    type=('build', 'run'))
     depends_on('py-cpuinfo@0.1.6:', type=('build', 'run'))
-
-    # TODO: Add a 'test' deptype
-    # depends_on('py-nosetests@1.0:', type='test')
     depends_on('py-sphinx@1.4.2:',  type=('build', 'run'), when='+docs')
+    depends_on('py-nosetests@1.0:', type='test')

--- a/var/spack/repos/builtin/packages/py-elephant/package.py
+++ b/var/spack/repos/builtin/packages/py-elephant/package.py
@@ -46,4 +46,4 @@ class PyElephant(PythonPackage):
     depends_on('py-pandas@0.14.1:',     type=('build', 'run'), when='+pandas')
     depends_on('py-numpydoc@0.5:',      type=('build', 'run'), when='+docs')
     depends_on('py-sphinx@1.2.2:',      type=('build', 'run'), when='+docs')
-    # depends_on('py-nose@1.3.3:',        type=('build', 'run')) # tests
+    depends_on('py-nose@1.3.3:',        type='test')

--- a/var/spack/repos/builtin/packages/py-fiscalyear/package.py
+++ b/var/spack/repos/builtin/packages/py-fiscalyear/package.py
@@ -43,6 +43,5 @@ class PyFiscalyear(PythonPackage):
     depends_on('python@2.5:')
     depends_on('py-setuptools', type='build')
 
-    # TODO: Add a 'test' deptype
-    # depends_on('py-pytest', type='test')
-    # depends_on('py-pytest-runner', type='test')
+    depends_on('py-pytest', type='test')
+    depends_on('py-pytest-runner', type='test')

--- a/var/spack/repos/builtin/packages/py-flake8/package.py
+++ b/var/spack/repos/builtin/packages/py-flake8/package.py
@@ -71,8 +71,7 @@ class PyFlake8(PythonPackage):
     depends_on('py-configparser', type=('build', 'run'))
     depends_on('py-enum34', type=('build', 'run'))
 
-    # TODO: Add test dependencies
-    # depends_on('py-nose', type='test')
+    depends_on('py-nose', type='test')
 
     def patch(self):
         """Filter pytest-runner requirement out of setup.py."""

--- a/var/spack/repos/builtin/packages/py-mako/package.py
+++ b/var/spack/repos/builtin/packages/py-mako/package.py
@@ -36,6 +36,6 @@ class PyMako(PythonPackage):
     version('1.0.1', '9f0aafd177b039ef67b90ea350497a54')
 
     depends_on('py-setuptools', type='build')
-    # depends_on('py-mock',   type='test')  # TODO: Add test deptype
-    # depends_on('py-pytest', type='test')  # TODO: Add test deptype
+    depends_on('py-mock',   type='test')
+    depends_on('py-pytest', type='test')
     depends_on('py-markupsafe@0.9.2:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -95,9 +95,8 @@ class PyMatplotlib(PythonPackage):
     depends_on('texlive', when='+latex', type='run')
 
     # Testing dependencies
-    # TODO: Add a 'test' deptype
-    # depends_on('py-nose', type='test')
-    # depends_on('py-mock', type='test')
+    depends_on('py-nose', type='test')
+    depends_on('py-mock', type='test')
 
     # Required libraries that ship with matplotlib
     # depends_on('agg@2.4:')

--- a/var/spack/repos/builtin/packages/py-mccabe/package.py
+++ b/var/spack/repos/builtin/packages/py-mccabe/package.py
@@ -47,9 +47,7 @@ class PyMccabe(PythonPackage):
     depends_on('python@2.7:2.8,3.3:')
 
     depends_on('py-setuptools', type='build')
-
-    # TODO: Add test dependencies
-    # depends_on('py-pytest', type='test')
+    depends_on('py-pytest', type='test')
 
     def patch(self):
         """Filter pytest-runner requirement out of setup.py."""

--- a/var/spack/repos/builtin/packages/py-patsy/package.py
+++ b/var/spack/repos/builtin/packages/py-patsy/package.py
@@ -41,5 +41,4 @@ class PyPatsy(PythonPackage):
     depends_on('py-scipy',       type=('build', 'run'), when="+splines")
     depends_on('py-six',         type=('build', 'run'))
 
-    # TODO: Add a 'test' deptype
-    # depends_on('py-nose', type='test')
+    depends_on('py-nose', type='test')

--- a/var/spack/repos/builtin/packages/py-pkgconfig/package.py
+++ b/var/spack/repos/builtin/packages/py-pkgconfig/package.py
@@ -38,5 +38,4 @@ class PyPkgconfig(PythonPackage):
 
     depends_on('pkgconfig', type=('build', 'run'))
 
-    # TODO: Add a 'test' deptype
-    # depends_on('py-nose@1.0:', type='test')
+    depends_on('py-nose@1.0:', type='test')

--- a/var/spack/repos/builtin/packages/py-psyclone/package.py
+++ b/var/spack/repos/builtin/packages/py-psyclone/package.py
@@ -39,8 +39,6 @@ class PyPsyclone(PythonPackage):
     version('develop', git=giturl, branch='master')
 
     depends_on('py-setuptools', type='build')
-
-    depends_on('python', type=('build', 'run'))
     depends_on('py-pyparsing', type=('build', 'run'))
 
     # Test cases fail without compatible versions of py-fparser:
@@ -48,8 +46,8 @@ class PyPsyclone(PythonPackage):
     depends_on('py-fparser', type=('build', 'run'), when='@1.5.2:')
 
     # Dependencies only required for tests:
-    depends_on('py-numpy', type='test')
-    depends_on('py-nose', type='test')
+    depends_on('py-numpy',  type='test')
+    depends_on('py-nose',   type='test')
     depends_on('py-pytest', type='test')
 
     @run_after('install')

--- a/var/spack/repos/builtin/packages/py-py2cairo/package.py
+++ b/var/spack/repos/builtin/packages/py-py2cairo/package.py
@@ -40,8 +40,7 @@ class PyPy2cairo(WafPackage):
     depends_on('pixman')
     depends_on('pkgconfig', type='build')
 
-    # TODO: Add a 'test' deptype
-    # depends_on('py-pytest', type='test')
+    depends_on('py-pytest', type='test')
 
     def installtest(self):
         with working_dir('test'):

--- a/var/spack/repos/builtin/packages/py-pynn/package.py
+++ b/var/spack/repos/builtin/packages/py-pynn/package.py
@@ -50,5 +50,4 @@ class PyPynn(PythonPackage):
     depends_on('py-neo@0.3:0.4.1',      type=('build', 'run'), when="@:0.8.3")
     depends_on('py-neo@0.5.0:',         type=('build', 'run'), when="@0.9.0:")
 
-    # TODO: Add a 'test' deptype
-    # depends_on('py-mock@1.0:', type='test')
+    depends_on('py-mock@1.0:', type='test')

--- a/var/spack/repos/builtin/packages/py-qtconsole/package.py
+++ b/var/spack/repos/builtin/packages/py-qtconsole/package.py
@@ -42,5 +42,4 @@ class PyQtconsole(PythonPackage):
     depends_on('py-traitlets',           type=('build', 'run'))
     depends_on('py-sphinx@1.3:',         type=('build', 'run'), when='+docs')
 
-    # TODO: Add a 'test' deptype
-    # depends_on('py-mock', type='test', when='^python@2.7:2.8')
+    depends_on('py-mock', type='test', when='^python@2.7:2.8')

--- a/var/spack/repos/builtin/packages/py-requests/package.py
+++ b/var/spack/repos/builtin/packages/py-requests/package.py
@@ -49,8 +49,7 @@ class PyRequests(PythonPackage):
 
     depends_on('py-setuptools', type='build')
 
-    # TODO: Add a 'test' deptype
-    # depends_on('py-pytest@2.8.0:',        type='test')
-    # depends_on('py-pytest-cov',           type='test')
-    # depends_on('py-pytest-httpbin@0.0.7', type='test')
-    # depends_on('py-pytest-mock',          type='test')
+    depends_on('py-pytest@2.8.0:',        type='test')
+    depends_on('py-pytest-cov',           type='test')
+    depends_on('py-pytest-httpbin@0.0.7', type='test')
+    depends_on('py-pytest-mock',          type='test')

--- a/var/spack/repos/builtin/packages/py-sphinx/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx/package.py
@@ -84,8 +84,7 @@ class PySphinx(PythonPackage):
     #            type=('build', 'run'))
     depends_on('py-typing', when='@1.6:', type=('build', 'run'))
 
-    # TODO: Add a 'test' deptype
-    # depends_on('py-pytest',     type='test')
-    # depends_on('py-mock',       type='test')
-    # depends_on('py-simplejson', type='test')
-    # depends_on('py-html5lib',   type='test')
+    depends_on('py-pytest',     type='test')
+    depends_on('py-mock',       type='test')
+    depends_on('py-simplejson', type='test')
+    depends_on('py-html5lib',   type='test')

--- a/var/spack/repos/builtin/packages/py-sphinxcontrib-websupport/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinxcontrib-websupport/package.py
@@ -42,6 +42,5 @@ class PySphinxcontribWebsupport(PythonPackage):
 
     depends_on('py-setuptools', type='build')
 
-    # TODO: Add a 'test' deptype
-    # depends_on('py-pytest', type='test')
-    # depends_on('py-mock',   type='test')
+    depends_on('py-pytest', type='test')
+    depends_on('py-mock',   type='test')

--- a/var/spack/repos/builtin/packages/py-theano/package.py
+++ b/var/spack/repos/builtin/packages/py-theano/package.py
@@ -54,6 +54,5 @@ class PyTheano(PythonPackage):
     depends_on('py-pygpu', when='+gpu', type=('build', 'run'))
     depends_on('libgpuarray', when='+gpu')
 
-    # TODO: Add a 'test' deptype
-    # depends_on('py-nose@1.3.0:', type='test')
-    # depends_on('py-nose-parameterized@0.5.0:', type='test')
+    depends_on('py-nose@1.3.0:', type='test')
+    depends_on('py-nose-parameterized@0.5.0:', type='test')

--- a/var/spack/repos/builtin/packages/rr/package.py
+++ b/var/spack/repos/builtin/packages/rr/package.py
@@ -40,7 +40,7 @@ class Rr(CMakePackage):
     # depends_on('capnproto', when='@4.6:')  # not yet in spack
     # depends_on('libcapnp')    # needed for future releases
     depends_on('pkgconfig', type='build')
-    depends_on('py-pexpect', type='build')  # actually tests
+    depends_on('py-pexpect', type='test')
 
     # rr needs architecture Nehalem and beyond, how can spack
     # test this?

--- a/var/spack/repos/builtin/packages/wget/package.py
+++ b/var/spack/repos/builtin/packages/wget/package.py
@@ -62,8 +62,7 @@ class Wget(AutotoolsPackage):
     depends_on('perl@5.12.0:', type='build')
     depends_on('pkgconfig', type='build')
 
-    # TODO: Add a 'test' deptype
-    # depends_on('valgrind', type='test')
+    depends_on('valgrind', type='test')
 
     build_directory = 'spack-build'
 


### PR DESCRIPTION
This PR mass-uncomments all `type='test'` dependencies. There are also a couple of other drive-by's (like removing an unnecessary python dependency or so). Note: I haven't tested any of these, and I'm not too sure if doing this en masse is really a good idea. 

Feel free to close if you don't think it is a good idea at all, then I'll take this branch as a source for future work for me. Otherwise I'll point out the packages that I actually mange to get around to build and take it from there