### PR TITLE
ADIOS: Serial API with Parallel Lib

### DIFF
--- a/var/spack/repos/builtin/packages/adios/nompi.patch
+++ b/var/spack/repos/builtin/packages/adios/nompi.patch
@@ -1,0 +1,16 @@
+diff --git a/src/core/adios_internals_mxml.c b/src/core/adios_internals_mxml.c
+index 513fd45c..b9296050 100644
+--- a/src/core/adios_internals_mxml.c
++++ b/src/core/adios_internals_mxml.c
+@@ -2173,8 +2173,9 @@ int adios_parse_config (const char * config, MPI_Comm comm)
+     char * buffer = NULL;
+     //#if HAVE_MPI
+     int buffer_size = 0;
+-    int rank;
+-    MPI_Comm_rank (comm, &rank);
++    int rank = 0;
++    if (comm != MPI_COMM_NULL)
++        MPI_Comm_rank (comm, &rank);
+     init_comm = comm;
+     if (rank == 0)
+     {

--- a/var/spack/repos/builtin/packages/adios/package.py
+++ b/var/spack/repos/builtin/packages/adios/package.py
@@ -121,6 +121,9 @@ class Adios(AutotoolsPackage):
     #   https://github.com/ornladios/ADIOS/commit/3b21a8a41509
     #   https://github.com/spack/spack/issues/1683
     patch('adios_1100.patch', when='@:1.10.0^hdf5@1.10:')
+    # Fix ADIOS <=1.13.1 serial compile against parallel library
+    #   https://github.com/ornladios/ADIOS/pull/182
+    patch('nompi.patch', when='@1.10.0:1.13.1')
 
     def validate(self, spec):
         """Checks if incompatible variants have been activated at the same time


### PR DESCRIPTION
Provides a patch for the fix in
  https://github.com/ornladios/ADIOS/pull/182

Installed ADIOS MPI-enabled libraries are with that able to also perform serial I/O without the need to start the whole app via `mpiexec`.