### PR TITLE
new version SZ 1.4.13.5

### DIFF
--- a/var/spack/repos/builtin/packages/sz/package.py
+++ b/var/spack/repos/builtin/packages/sz/package.py
@@ -30,10 +30,11 @@ class Sz(AutotoolsPackage):
     """Error-bounded Lossy Compressor for HPC Data."""
 
     homepage = "https://collab.cels.anl.gov/display/ESR/SZ"
-    url      = "https://github.com/disheng222/SZ/archive/v1.4.13.4.tar.gz"
+    url      = "https://github.com/disheng222/SZ/archive/v1.4.13.5.tar.gz"
 
     version('develop', git='https://github.com/disheng222/SZ.git',
             branch='master')
+    version('1.4.13.5', 'a2f6147c3c74d74c938dd17d914a4cb8')
     version('1.4.13.4', '1c47170a9eebeadbf0f7e9b675d68d76')
     version('1.4.12.3', '5f51be8530cdfa5280febb410ac6dd94')
     version('1.4.11.0', '10dee28b3503821579ce35a50e352cc6')


### PR DESCRIPTION
I removed pwrType from the interface SZ_compress_args() which will be convenient for ADIOS developers to use SZ's API. 
This change will be consistent with our future version because pwrType will be deprecated in the later version. 
Please use this version in Spack and I'll notify the corresponding users such as ADIOS for the changes. 

Thanks.