### PR TITLE
fix qt@5.8: build on systems without wayland

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -359,7 +359,7 @@ class Qt(Package):
                   '-{0}gtkstyle'.format('' if '+gtk' in self.spec else 'no-'),
                   *(webkit_args + self.common_config_args))
 
-    @when('@5.7:')
+    @when('@5.7:5.7.999')
     def configure(self):
         config_args = self.common_config_args
 
@@ -377,6 +377,33 @@ class Qt(Package):
             config_args.extend([
                 '-skip', 'webglplugin',
             ])
+
+        configure('-no-eglfs',
+                  '-no-directfb',
+                  '-{0}gtk'.format('' if '+gtk' in self.spec else 'no-'),
+                  *config_args)
+
+    @when('@5.8:')
+    def configure(self):
+        config_args = self.common_config_args
+
+        if not sys.platform == 'darwin':
+            config_args.extend([
+                '-qt-xcb',
+            ])
+
+        if '~webkit' in self.spec:
+            config_args.extend([
+                '-skip', 'webengine',
+            ])
+
+        if '~opengl' in self.spec and self.spec.satisfies('@5.10:'):
+            config_args.extend([
+                '-skip', 'webglplugin',
+            ])
+
+        # relies on a system installed wayland, i.e. no spack package yet
+        config_args.extend(['-skip', 'wayland'])
 
         configure('-no-eglfs',
                   '-no-directfb',

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -403,6 +403,8 @@ class Qt(Package):
             ])
 
         # relies on a system installed wayland, i.e. no spack package yet
+        # https://wayland.freedesktop.org/ubuntu16.04.html
+        # https://wiki.qt.io/QtWayland
         config_args.extend(['-skip', 'wayland'])
 
         configure('-no-eglfs',

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -359,7 +359,7 @@ class Qt(Package):
                   '-{0}gtkstyle'.format('' if '+gtk' in self.spec else 'no-'),
                   *(webkit_args + self.common_config_args))
 
-    @when('@5.7:5.7.999')
+    @when('@5.7:')
     def configure(self):
         config_args = self.common_config_args
 
@@ -378,34 +378,11 @@ class Qt(Package):
                 '-skip', 'webglplugin',
             ])
 
-        configure('-no-eglfs',
-                  '-no-directfb',
-                  '-{0}gtk'.format('' if '+gtk' in self.spec else 'no-'),
-                  *config_args)
-
-    @when('@5.8:')
-    def configure(self):
-        config_args = self.common_config_args
-
-        if not sys.platform == 'darwin':
-            config_args.extend([
-                '-qt-xcb',
-            ])
-
-        if '~webkit' in self.spec:
-            config_args.extend([
-                '-skip', 'webengine',
-            ])
-
-        if '~opengl' in self.spec and self.spec.satisfies('@5.10:'):
-            config_args.extend([
-                '-skip', 'webglplugin',
-            ])
-
-        # relies on a system installed wayland, i.e. no spack package yet
-        # https://wayland.freedesktop.org/ubuntu16.04.html
-        # https://wiki.qt.io/QtWayland
-        config_args.extend(['-skip', 'wayland'])
+        if self.version > Version('5.8'):
+            # relies on a system installed wayland, i.e. no spack package yet
+            # https://wayland.freedesktop.org/ubuntu16.04.html
+            # https://wiki.qt.io/QtWayland
+            config_args.extend(['-skip', 'wayland'])
 
         configure('-no-eglfs',
                   '-no-directfb',


### PR DESCRIPTION
I finally managed to track down the build failure of newer qt's on our system. This PR adds the `-skip wayland` to the qt build for newer qt's. Wayland seems to be a replacement for `x` but wasn't shipped with our (fairly minimal) Ubuntu so the qt-build fails a couple of minutes in.

This is a fairly brutal solution, but I prefer it over adding a variant would only work on some systems. If someone needs it I'll add the links to the qtwayland documentation 

https://wiki.qt.io/QtWayland
https://wayland.freedesktop.org/ubuntu16.04.html