### PR TITLE
add sqlitebrowser

### DIFF
--- a/var/spack/repos/builtin/packages/sqlite/package.py
+++ b/var/spack/repos/builtin/packages/sqlite/package.py
@@ -72,7 +72,8 @@ class Sqlite(AutotoolsPackage):
              url='https://sqlite.org/contrib/download/extension-functions.c/download/extension-functions.c?get=25',
              md5='3a32bfeace0d718505af571861724a43',
              expand=False,
-             placement={'extension-functions.c?get=25': 'extension-functions.c'},
+             placement={'extension-functions.c?get=25':
+                        'extension-functions.c'},
              when='+functions')
 
     def get_arch(self):
@@ -92,5 +93,6 @@ class Sqlite(AutotoolsPackage):
     def build_libsqlitefunctions(self):
         if '+functions' in self.spec:
             gcc = which('gcc')
-            gcc('-fPIC', '-lm', '-shared', 'extension-functions.c', '-o', 'libsqlitefunctions.so')
+            gcc('-fPIC', '-lm', '-shared', 'extension-functions.c', '-o',
+                'libsqlitefunctions.so')
             install('libsqlitefunctions.so', self.prefix.lib)

--- a/var/spack/repos/builtin/packages/sqlite/package.py
+++ b/var/spack/repos/builtin/packages/sqlite/package.py
@@ -24,6 +24,7 @@
 ##############################################################################
 from spack import *
 from spack import architecture
+from spack.build_environment import dso_suffix
 
 
 class Sqlite(AutotoolsPackage):
@@ -92,7 +93,8 @@ class Sqlite(AutotoolsPackage):
     @run_after('install')
     def build_libsqlitefunctions(self):
         if '+functions' in self.spec:
-            gcc = which('gcc')
-            gcc('-fPIC', '-lm', '-shared', 'extension-functions.c', '-o',
-                'libsqlitefunctions.so')
-            install('libsqlitefunctions.so', self.prefix.lib)
+            libraryname = 'libsqlitefunctions.' + dso_suffix
+            cc = Executable(spack_cc)
+            cc(self.compiler.pic_flag, '-lm', '-shared',
+                'extension-functions.c', '-o', libraryname)
+            install(libraryname, self.prefix.lib)

--- a/var/spack/repos/builtin/packages/sqlite/package.py
+++ b/var/spack/repos/builtin/packages/sqlite/package.py
@@ -24,7 +24,6 @@
 ##############################################################################
 from spack import *
 from spack import architecture
-from spack.build_environment import dso_suffix
 
 
 class Sqlite(AutotoolsPackage):

--- a/var/spack/repos/builtin/packages/sqlite/package.py
+++ b/var/spack/repos/builtin/packages/sqlite/package.py
@@ -63,6 +63,15 @@ class Sqlite(AutotoolsPackage):
     # compiler is used.
     patch('remove_overflow_builtins.patch', when='@3.17.0:3.20%intel')
 
+    variant('functions', default=False)
+
+    resource(name='extension-functions',
+             url='https://sqlite.org/contrib/download/extension-functions.c/download/extension-functions.c?get=25',
+             md5='3a32bfeace0d718505af571861724a43',
+             expand=False,
+             placement={'extension-functions.c?get=25': 'extension-functions.c'},
+             when='+functions')
+
     def get_arch(self):
         arch = architecture.Arch()
         arch.platform = architecture.platform()
@@ -75,3 +84,10 @@ class Sqlite(AutotoolsPackage):
             args.append('--build=powerpc64le-redhat-linux-gnu')
 
         return args
+
+    @run_after('install')
+    def build_libsqlitefunctions(self):
+        if '+functions' in self.spec:
+            gcc = which('gcc')
+            gcc('-fPIC', '-lm', '-shared', 'extension-functions.c', '-o', 'libsqlitefunctions.so')
+            install('libsqlitefunctions.so', self.prefix.lib)

--- a/var/spack/repos/builtin/packages/sqlite/package.py
+++ b/var/spack/repos/builtin/packages/sqlite/package.py
@@ -63,7 +63,10 @@ class Sqlite(AutotoolsPackage):
     # compiler is used.
     patch('remove_overflow_builtins.patch', when='@3.17.0:3.20%intel')
 
-    variant('functions', default=False)
+    variant('functions', default=False,
+            description='Provide mathematical and string extension functions '
+                        'for SQL queries using the loadable extensions '
+                        'mechanism.')
 
     resource(name='extension-functions',
              url='https://sqlite.org/contrib/download/extension-functions.c/download/extension-functions.c?get=25',

--- a/var/spack/repos/builtin/packages/sqlitebrowser/package.py
+++ b/var/spack/repos/builtin/packages/sqlitebrowser/package.py
@@ -1,0 +1,51 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Sqlitebrowser(CMakePackage):
+    """DB Browser for SQLite (DB4S) is a high quality, visual,
+    open source tool to create, design, and edit database files
+    compatible with SQLite."""
+
+    homepage = "https://sqlitebrowser.org"
+    url      = "https://github.com/sqlitebrowser/sqlitebrowser/archive/v3.10.1.tar.gz"
+
+    version('3.10.1', '66cbe41f9da5be80067942ed3816576c')
+
+    # depends_on('c++11')
+    msg = 'sqlitebrowser requires C++11 support'
+    conflicts('%gcc@:4.8.0', msg=msg)
+    conflicts('%clang@:3.2', msg=msg)
+    conflicts('%intel@:12',  msg=msg)
+    conflicts('%xl@:13.0',   msg=msg)
+    conflicts('%xl_r@:13.0', msg=msg)
+
+    depends_on('sqlite@3:+functions')
+    depends_on('qt@5.5:')
+
+    def cmake_args(self):
+        args = []
+        return args

--- a/var/spack/repos/builtin/packages/sqlitebrowser/package.py
+++ b/var/spack/repos/builtin/packages/sqlitebrowser/package.py
@@ -35,7 +35,6 @@ class Sqlitebrowser(CMakePackage):
 
     version('3.10.1', '66cbe41f9da5be80067942ed3816576c')
 
-    # depends_on('c++11')
     msg = 'sqlitebrowser requires C++11 support'
     conflicts('%gcc@:4.8.0', msg=msg)
     conflicts('%clang@:3.2', msg=msg)
@@ -45,7 +44,3 @@ class Sqlitebrowser(CMakePackage):
 
     depends_on('sqlite@3:+functions')
     depends_on('qt@5.5:')
-
-    def cmake_args(self):
-        args = []
-        return args


### PR DESCRIPTION
Add `functions` variant to `sqlite`. Modelled largely after the homebrew [recipe](https://searchcode.com/codesearch/view/99133946/)