### PR TITLE
add python cache removal to `spack clean`

### DIFF
--- a/lib/spack/spack/cmd/clean.py
+++ b/lib/spack/spack/cmd/clean.py
@@ -32,6 +32,7 @@ import spack.caches
 import spack.cmd
 import spack.repo
 import spack.stage
+from spack.paths import spack_root
 
 description = "remove temporary build files and/or downloaded archives"
 section = "build"
@@ -95,15 +96,15 @@ def clean(parser, args):
         spack.caches.misc_cache.destroy()
 
     if args.python_cache:
-        tty.msg('Removing python cache files.')
-        for root, dirs, files in os.walk(os.environ['SPACK_ROOT']):
+        tty.msg('Removing python cache files')
+        for root, dirs, files in os.walk(spack_root):
             for f in files:
                 if f.endswith('.pyc') or f.endswith('.pyo'):
                     fname = os.path.join(root, f)
-                    tty.debug('removing {0}'.format(fname))
+                    tty.debug('Removing {0}'.format(fname))
                     os.remove(fname)
             for d in dirs:
                 if d == '__pycache__':
                     dname = os.path.join(root, d)
-                    tty.debug('removing {0}'.format(dname))
+                    tty.debug('Removing {0}'.format(dname))
                     shutil.rmtree(dname)

--- a/lib/spack/spack/cmd/clean.py
+++ b/lib/spack/spack/cmd/clean.py
@@ -23,6 +23,8 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import argparse
+import os
+import shutil
 
 import llnl.util.tty as tty
 
@@ -37,9 +39,9 @@ level = "long"
 
 
 class AllClean(argparse.Action):
-    """Activates flags -s -d and -m simultaneously"""
+    """Activates flags -s -d -m and -p simultaneously"""
     def __call__(self, parser, namespace, values, option_string=None):
-        parser.parse_args(['-sdm'], namespace=namespace)
+        parser.parse_args(['-sdmp'], namespace=namespace)
 
 
 def setup_parser(subparser):
@@ -53,6 +55,9 @@ def setup_parser(subparser):
         '-m', '--misc-cache', action='store_true',
         help="remove long-lived caches, like the virtual package index")
     subparser.add_argument(
+        '-p', '--python-cache', action='store_true',
+        help="remove .pyc, .pyo files and __pycache__ folders")
+    subparser.add_argument(
         '-a', '--all', action=AllClean, help="equivalent to -sdm", nargs=0
     )
     subparser.add_argument(
@@ -63,9 +68,9 @@ def setup_parser(subparser):
 
 
 def clean(parser, args):
-
     # If nothing was set, activate the default
-    if not any([args.specs, args.stage, args.downloads, args.misc_cache]):
+    if not any([args.specs, args.stage, args.downloads, args.misc_cache,
+                args.python_cache]):
         args.stage = True
 
     # Then do the cleaning falling through the cases
@@ -88,3 +93,17 @@ def clean(parser, args):
     if args.misc_cache:
         tty.msg('Removing cached information on repositories')
         spack.caches.misc_cache.destroy()
+
+    if args.python_cache:
+        tty.msg('Removing python cache files.')
+        for root, dirs, files in os.walk(os.environ['SPACK_ROOT']):
+            for f in files:
+                if f.endswith('.pyc') or f.endswith('.pyo'):
+                    fname = os.path.join(root, f)
+                    tty.debug('removing {0}'.format(fname))
+                    os.remove(fname)
+            for d in dirs:
+                if d == '__pycache__':
+                    dname = os.path.join(root, d)
+                    tty.debug('removing {0}'.format(dname))
+                    shutil.rmtree(dname)


### PR DESCRIPTION
Continuing the discussion from #8090, this is a quick way to clean up spack's python caches.

Would have probably been helpful to have this ability in #8248, #8267, #8240, #8292