### PR TITLE
Fix list_urls missing trailing slash

### DIFF
--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -286,6 +286,13 @@ def find_versions_of_archive(archive_urls, list_url=None, list_depth=0):
     for aurl in archive_urls:
         list_urls.add(spack.url.find_list_url(aurl))
 
+    # Add '/' to the end of the URL. Some web servers require this.
+    additional_list_urls = set()
+    for lurl in list_urls:
+        if not lurl.endswith('/'):
+            additional_list_urls.add(lurl + '/')
+    list_urls.update(additional_list_urls)
+
     # Grab some web pages to scrape.
     pages = {}
     links = set()


### PR DESCRIPTION
Fixes a bug in `spack versions` detection. By default, if a package does not specify a `list_url` and does not download from a common repository, Spack runs `dirname` on the URL. Given a URL like https://root.cern.ch/download/root_v6.09.02.source.tar.gz, this returns https://root.cern.ch/download. However, https://root.cern.ch/download gives a 404, while https://root.cern.ch/download/ works just fine. I think this is due to the presence or lack of an `index.html` file in the directory on the server? I don't claim to be a web dev expert 😛 

There are dozens of places this could have been fixed. We could have fixed it in the method that runs `dirname`, but I chose not to do this in case someone tries to add their own `list_url` but forgets the slash. We could have also fixed this in `spider`, but I chose not to do this because I don't know if `spider` is only used for directories or if it also accepts files. Let me know if you want me to move it elsewhere.

The only downside of this approach is that most `list_url`s in Spack (resulting from `dirname` or from `find_list_url`) don't have the trailing slash. This means that `spack versions` now spiders twice as many pages, making it twice as slow. Still thinking about ways to improve this.

I'm wondering if it wouldn't be worthwhile to consider adding [requests](http://docs.python-requests.org/en/master/) as an externally vendored package and using that for our HTML parsing. Presumably the [4th most downloaded package on PyPI](https://pythonwheels.com/) can handle something like this. That would require a massive refactor though.

### Before
```console
$ spack versions root
==> Safe versions (already checksummed):
  6.09.02  6.08.06  6.06.08  6.06.06  6.06.04  6.06.02  5.34.36
==> Remote versions (not yet checksummed):
  Found no versions for root
```
### After
```console
$ spack versions root
==> Safe versions (already checksummed):
  6.09.02  6.08.06  6.06.08  6.06.06  6.06.04  6.06.02  5.34.36
==> Remote versions (not yet checksummed):
  6.13.08            6.05.02  6.02.01  5.34.19      5.34.00      5.28.00g          5.26.00d  5.22.00b  5.17.02   5.13.04b  5.10.00a  4.01.04   3.05.05
  6.13.06            6.04.18  6.02.00  5.34.18      5.33.02      5.28.00f          5.26.00c  5.22.00a  5.16.00   5.13.04a  5.10.00   4.01.02   3.05.04
  6.13.04            6.04.16  6.00.02  5.34.17      5.32.04      5.28.00e          5.26.00b  5.22.00   5.15.08   5.13.04   5.09.01   4.00.08f  3.05.03
  6.13.02            6.04.14  6.00.01  5.34.16      5.32.03      5.28.00d          5.26.00a  5.21.06   5.15.06   5.13.03   5.08.00b  4.00.08e  3.04.02
  6.12.06            6.04.12  6.00.00  5.34.15      5.32.02      5.28.00c          5.26.00   5.21.04   5.15.04   5.13.02   5.08.00   4.00.08c  3.03.09b
  6.12.04            6.04.10  5.99.06  5.34.14      5.32.01      5.28.00b          5.25.04   5.21.02   5.15.02   5.12.00g  5.06.00   4.00.08b  3.03.09a
  6.12.02            6.04.08  5.99.05  5.34.13      5.32.00-rc2  5.28.00a          5.25.02   5.20.00   5.14.00i  5.12.00f  5.04.00   4.00.08a  3.03.09
  6.11.02            6.04.06  5.99.04  5.34.12      5.32.00-rc1  5.28.00           5.24.00b  5.19.04   5.14.00h  5.12.00e  5.02.00   4.00.08   3.02.07
  6.10.08            6.04.04  5.34.38  5.34.11      5.32.00      5.27.06d          5.24.00a  5.19.02   5.14.00g  5.12.00d  4.04.02g  4.00.06
  6.10.06            6.04.02  5.34.34  5.34.10      5.30.06      5.27.06c          5.24.00   5.18.00f  5.14.00f  5.12.00c  4.04.02f  4.00.04
  6.10.04            6.04.00  5.34.32  5.34.09      5.30.05      5.27.06b          5.23.04   5.18.00e  5.14.00e  5.12.00a  4.04.02e  4.00.03
  6.10.02            6.03.04  5.34.30  5.34.08      5.30.04      5.27.06a          5.23.02   5.18.00d  5.14.00d  5.12.00   4.04.02d  4.00.02
  6.10.00            6.03.02  5.34.28  5.34.07      5.30.03      5.27.06           5.22.00j  5.18.00c  5.14.00c  5.11.06   4.04.02c  4.00.01
  6.08.04            6.02.12  5.34.26  5.34.06      5.30.02      5.27.04           5.22.00i  5.18.00b  5.14.00b  5.11.04   4.04.02b  4.00.00
  6.08.02            6.02.10  5.34.25  5.34.05      5.30.01      5.27.02           5.22.00h  5.18.00a  5.14.00a  5.11.02   4.04.02   3.10.03
  6.08.00            6.02.08  5.34.24  5.34.04      5.30.00-rc2  5.26.00-proof-04  5.22.00g  5.18.00   5.14.00   5.10.00f  4.04.00   3.10.02
  6.07.06            6.02.05  5.34.23  5.34.03      5.30.00-rc1  5.26.00-proof-02  5.22.00f  5.17.08   5.13.06   5.10.00e  4.03.04   3.10.01
  6.07.02            6.02.04  5.34.22  5.34.02      5.30.00      5.26.00g          5.22.00e  5.17.06   5.13.04e  5.10.00d  4.03.02   3.10.00
  6.07.01-ROOTaaS-1  6.02.03  5.34.21  5.34.01      5.29.02      5.26.00f          5.22.00d  5.17.05   5.13.04d  5.10.00c  4.02.00   3.05.07
  6.06.00            6.02.02  5.34.20  5.34.00-rc1  5.28.00h     5.26.00e          5.22.00c  5.17.04   5.13.04c  5.10.00b  4.01.04a  3.05.06
```
P.S. This bug was uncovered by @JavierCVilla in #8428 and likely affects many packages aside from `root`.