### PR TITLE
Feature/build location

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -218,7 +218,7 @@ class CMakePackage(PackageBase):
 
         :return: directory where to build the package
         """
-        return os.path.join(self.stage.source_path, 'spack-build')
+        return os.path.join(self.stage.path, 'spack-build')
 
     def cmake_args(self):
         """Produces a list containing all the arguments that must be passed to

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -739,17 +739,11 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
 
     @property
     def env_path(self):
-        if self.stage.source_path is None:
-            return None
-        else:
-            return os.path.join(self.stage.source_path, 'spack-build.env')
+        return os.path.join(self.stage.path, 'spack-build.env')
 
     @property
     def log_path(self):
-        if self.stage.source_path is None:
-            return None
-        else:
-            return os.path.join(self.stage.source_path, 'spack-build.out')
+        return os.path.join(self.stage.path, 'spack-build.out')
 
     def _make_fetcher(self):
         # Construct a composite fetcher that always contains at least
@@ -1769,7 +1763,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         if self.installed:
             return spack.store.layout.build_log_path(self.spec)
         else:
-            return os.path.join(self.stage.source_path, 'spack-build.out')
+            return os.path.join(self.stage.path, 'spack-build.out')
 
     @classmethod
     def inject_flags(cls, name, flags):

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1689,7 +1689,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         # Archive the environment used for the build
         install(self.env_path, env_install_path)
         # Finally, archive files that are specific to each package
-        with working_dir(self.stage.source_path):
+        with working_dir(self.stage.path):
             errors = StringIO()
             target_dir = os.path.join(
                 spack.store.layout.metadata_path(self.spec),
@@ -1697,9 +1697,9 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
 
             for glob_expr in self.archive_files:
                 # Check that we are trying to copy things that are
-                # in the source_path tree (not arbitrary files)
+                # in the stage tree (not arbitrary files)
                 abs_expr = os.path.realpath(glob_expr)
-                if os.path.realpath(self.stage.source_path) not in abs_expr:
+                if os.path.realpath(self.stage.path) not in abs_expr:
                     errors.write(
                         '[OUTSIDE SOURCE PATH]: {0}\n'.format(glob_expr)
                     )
@@ -1708,7 +1708,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
                 # folder, make it relative and check for matches
                 if os.path.isabs(glob_expr):
                     glob_expr = os.path.relpath(
-                        glob_expr, self.stage.source_path
+                        glob_expr, self.stage.path
                     )
                 files = glob.glob(glob_expr)
                 for f in files:

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -414,7 +414,7 @@ def test_extra_files_are_archived(mock_packages, mock_archive, mock_fetch,
         spack.store.layout.metadata_path(s), 'archived-files'
     )
     config_log = os.path.join(archive_dir,
-                              mock_archive.repo_name,
+                              mock_archive.expanded_archive_basedir,
                               'config.log')
     assert os.path.exists(config_log)
 

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -413,7 +413,9 @@ def test_extra_files_are_archived(mock_packages, mock_archive, mock_fetch,
     archive_dir = os.path.join(
         spack.store.layout.metadata_path(s), 'archived-files'
     )
-    config_log = os.path.join(archive_dir, 'config.log')
+    config_log = os.path.join(archive_dir,
+                              mock_archive.repo_name,
+                              'config.log')
     assert os.path.exists(config_log)
 
     errors_txt = os.path.join(archive_dir, 'errors.txt')

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -487,12 +487,12 @@ def mock_archive(tmpdir_factory):
     tar = spack.util.executable.which('tar', required=True)
 
     tmpdir = tmpdir_factory.mktemp('mock-archive-dir')
-    repo_name = 'mock-archive-repo'
-    tmpdir.ensure(repo_name, dir=True)
-    repodir = tmpdir.join(repo_name)
+    expanded_archive_basedir = 'mock-archive-repo'
+    tmpdir.ensure(expanded_archive_basedir, dir=True)
+    repodir = tmpdir.join(expanded_archive_basedir)
 
     # Create the configure script
-    configure_path = str(tmpdir.join(repo_name, 'configure'))
+    configure_path = str(tmpdir.join(expanded_archive_basedir, 'configure'))
     with open(configure_path, 'w') as f:
         f.write(
             "#!/bin/sh\n"
@@ -509,12 +509,12 @@ def mock_archive(tmpdir_factory):
 
     # Archive it
     with tmpdir.as_cwd():
-        archive_name = '{0}.tar.gz'.format(repo_name)
-        tar('-czf', archive_name, repo_name)
+        archive_name = '{0}.tar.gz'.format(expanded_archive_basedir)
+        tar('-czf', archive_name, expanded_archive_basedir)
 
     Archive = collections.namedtuple('Archive',
                                      ['url', 'path', 'archive_file',
-                                      'repo_name'])
+                                      'expanded_archive_basedir'])
     archive_file = str(tmpdir.join(archive_name))
 
     # Return the url
@@ -522,7 +522,7 @@ def mock_archive(tmpdir_factory):
         url=('file://' + archive_file),
         archive_file=archive_file,
         path=str(repodir),
-        repo_name=repo_name)
+        expanded_archive_basedir=expanded_archive_basedir)
 
 
 @pytest.fixture(scope='session')
@@ -533,9 +533,9 @@ def mock_git_repository(tmpdir_factory):
     git = spack.util.executable.which('git', required=True)
 
     tmpdir = tmpdir_factory.mktemp('mock-git-repo-dir')
-    repo_name = 'mock-git-repo'
-    tmpdir.ensure(repo_name, dir=True)
-    repodir = tmpdir.join(repo_name)
+    expanded_archive_basedir = 'mock-git-repo'
+    tmpdir.ensure(expanded_archive_basedir, dir=True)
+    repodir = tmpdir.join(expanded_archive_basedir)
 
     # Initialize the repository
     with repodir.as_cwd():
@@ -607,9 +607,9 @@ def mock_hg_repository(tmpdir_factory):
     hg = spack.util.executable.which('hg', required=True)
 
     tmpdir = tmpdir_factory.mktemp('mock-hg-repo-dir')
-    repo_name = 'mock-hg-repo'
-    tmpdir.ensure(repo_name, dir=True)
-    repodir = tmpdir.join(repo_name)
+    expanded_archive_basedir = 'mock-hg-repo'
+    tmpdir.ensure(expanded_archive_basedir, dir=True)
+    repodir = tmpdir.join(expanded_archive_basedir)
 
     get_rev = lambda: hg('id', '-i', output=str).strip()
 
@@ -653,9 +653,9 @@ def mock_svn_repository(tmpdir_factory):
     svnadmin = spack.util.executable.which('svnadmin', required=True)
 
     tmpdir = tmpdir_factory.mktemp('mock-svn-stage')
-    repo_name = 'mock-svn-repo'
-    tmpdir.ensure(repo_name, dir=True)
-    repodir = tmpdir.join(repo_name)
+    expanded_archive_basedir = 'mock-svn-repo'
+    tmpdir.ensure(expanded_archive_basedir, dir=True)
+    repodir = tmpdir.join(expanded_archive_basedir)
     url = 'file://' + str(repodir)
 
     # Initialize the repository

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -513,14 +513,16 @@ def mock_archive(tmpdir_factory):
         tar('-czf', archive_name, repo_name)
 
     Archive = collections.namedtuple('Archive',
-                                     ['url', 'path', 'archive_file'])
+                                     ['url', 'path', 'archive_file',
+                                      'repo_name'])
     archive_file = str(tmpdir.join(archive_name))
 
     # Return the url
     yield Archive(
         url=('file://' + archive_file),
         archive_file=archive_file,
-        path=str(repodir))
+        path=str(repodir),
+        repo_name=repo_name)
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
Change the location of the CMake build area from the staged source directory to the stage directory.

This change addresses an unfortunate consequence of the original choice combined with the case where a recipe needs to have information about the build directory in the environment set by `setup_environment()` (_e.g._ if tests need to have a directory in `PATH`). Specifically, staging happens _after_ the call to `setup_environment()`, and if the stage area does not exist, then `spec.stage.source_path` returns, `None`.

It should be noted that in the core Spack code, the destination of `out` and `env` files has been changed to the top level stage area, and the "base" directory for archiving has also been set to the stage area. In the latter case this is necessary to allow the archiving of build products when the build area is outside the source tree, but one consequence is that the expanded source directory now appears in the archive tree when a source file is saved, the name of which could be arbitrary and possibly confusing to an onlooker. A resolution for this would likely be dispersed throughout the Spack code and would require significant thought and discussion.

I have not changed the definition of `build_directory` for any other build system than CMake, so if any non-CMake spec needs `spec.stage.build_directory` to be resolved earlier than source expansion in the future, an accommodation will have to be made within the support for that build system. 
