### PR TITLE
Binding Python scripts and libraries at build-time

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -223,16 +223,20 @@ class PythonPackage(PackageBase):
 
         self.setup_py('install', *args)
 
+    @run_after('install')
+    def write_rpath_file(self):
+
+        spec = self.spec
+        mkdirp(spec.prefix.bin)
+
         rpaths = []
-        rpaths.append(spec.prefix)
+        rpaths.extend(spec.prefix)
         for d in spec.dependencies(deptype=('link', 'run')):
             if re.match('^py-', d.name):
-                rpaths.append(d.prefix)
+                rpaths.extend(d.prefix)
 
-        mkdirp(spec.prefix.bin)
-        rpaths_file = open(spec.prefix.bin.join(".spack-rpaths"), 'w')
-        rpaths_file.write("\n".join(rpaths) + "\n")
-        rpaths_file.close()
+        with open(spec.prefix.bin.join(".spack-rpaths"), 'w') as rpaths_file:
+            rpaths_file.write("\n".join(rpaths) + "\n")
 
     def install_args(self, spec, prefix):
         """Arguments to pass to install."""

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -31,6 +31,7 @@ from spack.package import PackageBase, run_after
 
 from llnl.util.filesystem import mkdirp, working_dir
 
+
 class PythonPackage(PackageBase):
     """Specialized class for packages that are built using Python
     setup.py files
@@ -223,7 +224,10 @@ class PythonPackage(PackageBase):
 
     @run_after('install')
     def write_python_sitedirs_file(self):
-
+        """Write out a file that contains the prefixes of each depedency that
+        provides a python library.  Code in our Python's
+        sitecustomize.py will add it to sys.path.
+        """
         spec = self.spec
         mkdirp(spec.prefix.bin)
 

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -233,10 +233,10 @@ class PythonPackage(PackageBase):
         sitedirs.append(spec.prefix)
 
         deps = spec.dependencies(deptype=('link', 'run'))
-        python_spec = next( (spec for spec in deps if spec.satisfies('python')), None)
-        if python_spec:
+        my_python = next( (spec for spec in deps if spec.satisfies('python')), None)
+        if my_python:
             for d in spec.dependencies(deptype=('link', 'run')):
-                if d.package.extends(python_spec):
+                if d.package.extends(my_python):
                     sitedirs.append(d.prefix)
 
         with open(spec.prefix.bin.join(".python-sitedirs"), 'w') as sd_file:

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -236,6 +236,9 @@ class PythonPackage(PackageBase):
         sitedirs.append(spec.prefix)
 
         deps = spec.traverse(deptype=('link', 'run'))
+        # grab the first spec that satisfies('python'),
+        # from https://stackoverflow.com/a/2364277
+        # TODO: What happens when both python 2 and 3 can be in the DAG?
         my_python = next((spec for spec in deps if spec.satisfies('python')),
                          None)
         if my_python:

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -30,7 +30,8 @@ from spack.directives import depends_on, extends
 from spack.package import PackageBase, run_after
 
 from llnl.util.filesystem import working_dir
-
+import re
+from llnl.util.filesystem import mkdirp
 
 class PythonPackage(PackageBase):
     """Specialized class for packages that are built using Python
@@ -221,6 +222,17 @@ class PythonPackage(PackageBase):
         args = self.install_args(spec, prefix)
 
         self.setup_py('install', *args)
+
+        rpaths = []
+        rpaths.append(spec.prefix)
+        for d in spec.dependencies(deptype=('link', 'run')):
+            if re.match('^py-', d.name):
+                rpaths.append(d.prefix)
+
+        mkdirp(spec.prefix.bin)
+        rpaths_file = open(spec.prefix.bin.join(".spack-rpaths"), 'w')
+        rpaths_file.write("\n".join(rpaths) + "\n")
+        rpaths_file.close()
 
     def install_args(self, spec, prefix):
         """Arguments to pass to install."""

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -224,23 +224,23 @@ class PythonPackage(PackageBase):
         self.setup_py('install', *args)
 
     @run_after('install')
-    def write_rpath_file(self):
+    def write_python_sitedirs_file(self):
 
         spec = self.spec
         mkdirp(spec.prefix.bin)
 
-        rpaths = []
-        rpaths.append(spec.prefix)
+        sitedirs = []
+        sitedirs.append(spec.prefix)
 
         deps = spec.dependencies(deptype=('link', 'run'))
         python_spec = next( (spec for spec in deps if spec.satisfies('python')), None)
         if python_spec:
             for d in spec.dependencies(deptype=('link', 'run')):
                 if d.package.extends(python_spec):
-                    rpaths.append(d.prefix)
+                    sitedirs.append(d.prefix)
 
-        with open(spec.prefix.bin.join(".spack-rpaths"), 'w') as rpaths_file:
-            rpaths_file.write("\n".join(rpaths) + "\n")
+        with open(spec.prefix.bin.join(".python-sitedirs"), 'w') as sd_file:
+            sd_file.write("\n".join(sitedirs) + "\n")
 
     def install_args(self, spec, prefix):
         """Arguments to pass to install."""

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -230,10 +230,10 @@ class PythonPackage(PackageBase):
         mkdirp(spec.prefix.bin)
 
         rpaths = []
-        rpaths.extend(spec.prefix)
+        rpaths.append(spec.prefix)
         for d in spec.dependencies(deptype=('link', 'run')):
-            if re.match('^py-', d.name):
-                rpaths.extend(d.prefix)
+            if d.package.provides_python_libs:
+                rpaths.append(d.prefix)
 
         with open(spec.prefix.bin.join(".spack-rpaths"), 'w') as rpaths_file:
             rpaths_file.write("\n".join(rpaths) + "\n")

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -230,10 +230,11 @@ class PythonPackage(PackageBase):
         sitedirs = []
         sitedirs.append(spec.prefix)
 
-        deps = spec.dependencies(deptype=('link', 'run'))
-        my_python = next( (spec for spec in deps if spec.satisfies('python')), None)
+        deps = spec.traverse(deptype=('link', 'run'))
+        my_python = next((spec for spec in deps if spec.satisfies('python')),
+                         None)
         if my_python:
-            for d in spec.dependencies(deptype=('link', 'run')):
+            for d in spec.traverse(deptype=('link', 'run')):
                 if d.package.extends(my_python):
                     sitedirs.append(d.prefix)
 

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -231,9 +231,13 @@ class PythonPackage(PackageBase):
 
         rpaths = []
         rpaths.append(spec.prefix)
-        for d in spec.dependencies(deptype=('link', 'run')):
-            if d.package.provides_python_libs:
-                rpaths.append(d.prefix)
+
+        deps = spec.dependencies(deptype=('link', 'run'))
+        python_spec = next( (spec for spec in deps if spec.satisfies('python')), None)
+        if python_spec:
+            for d in spec.dependencies(deptype=('link', 'run')):
+                if d.package.extends(python_spec):
+                    rpaths.append(d.prefix)
 
         with open(spec.prefix.bin.join(".spack-rpaths"), 'w') as rpaths_file:
             rpaths_file.write("\n".join(rpaths) + "\n")

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -229,7 +229,8 @@ class PythonPackage(PackageBase):
         sitecustomize.py will add it to sys.path.
         """
         spec = self.spec
-        mkdirp(spec.prefix.bin)
+        output_dir = spec.prefix.join(".spack")
+        mkdirp(output_dir)
 
         sitedirs = []
         sitedirs.append(spec.prefix)
@@ -242,7 +243,7 @@ class PythonPackage(PackageBase):
                 if d.package.extends(my_python):
                     sitedirs.append(d.prefix)
 
-        with open(spec.prefix.bin.join(".python-sitedirs"), 'w') as sd_file:
+        with open(output_dir.join("python-sitedirs"), 'w') as sd_file:
             sd_file.write("\n".join(sitedirs) + "\n")
 
     def install_args(self, spec, prefix):

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -29,9 +29,7 @@ import os
 from spack.directives import depends_on, extends
 from spack.package import PackageBase, run_after
 
-from llnl.util.filesystem import working_dir
-import re
-from llnl.util.filesystem import mkdirp
+from llnl.util.filesystem import mkdirp, working_dir
 
 class PythonPackage(PackageBase):
     """Specialized class for packages that are built using Python

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -501,6 +501,8 @@ class PackageBase(with_metaclass(PackageMeta, object)):
     # These are default values for instance variables.
     #
 
+    provides_python_libs = True
+
     #: By default we build in parallel.  Subclasses can override this.
     parallel = True
 
@@ -578,6 +580,8 @@ class PackageBase(with_metaclass(PackageMeta, object)):
     #: List of attributes which affect do not affect a package's content.
     metadata_attrs = ['homepage', 'url', 'list_url', 'extendable', 'parallel',
                       'make_jobs']
+
+    provide_python_libs = False
 
     def __init__(self, spec):
         # this determines how the package should be built.

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -501,8 +501,6 @@ class PackageBase(with_metaclass(PackageMeta, object)):
     # These are default values for instance variables.
     #
 
-    provides_python_libs = True
-
     #: By default we build in parallel.  Subclasses can override this.
     parallel = True
 
@@ -580,8 +578,6 @@ class PackageBase(with_metaclass(PackageMeta, object)):
     #: List of attributes which affect do not affect a package's content.
     metadata_attrs = ['homepage', 'url', 'list_url', 'extendable', 'parallel',
                       'make_jobs']
-
-    provide_python_libs = False
 
     def __init__(self, spec):
         # this determines how the package should be built.

--- a/var/spack/repos/builtin/packages/bumpversion/package.py
+++ b/var/spack/repos/builtin/packages/bumpversion/package.py
@@ -34,4 +34,4 @@ class Bumpversion(PythonPackage):
     version('0.5.3', 'c66a3492eafcf5ad4b024be9fca29820')
     version('0.5.0', '222ba619283d6408ce1bfbb0b5b542f3')
 
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-pylint/package.py
+++ b/var/spack/repos/builtin/packages/py-pylint/package.py
@@ -43,7 +43,7 @@ class PyPylint(PythonPackage):
     depends_on('py-isort@4.2.5:')
     depends_on('py-mccabe')
     depends_on('py-editdistance')
-    depends_on('py-setuptools@17.1:', type='build')
+    depends_on('py-setuptools@17.1:', type=('build', 'run'))
     # depends_on('py-setuptools-scm@1.15.0:', type='build')
     depends_on('py-configparser', when='^python@:2.8')
     depends_on('py-backports-functools-lru-cache', when='^python@:2.8')

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -208,6 +208,8 @@ class Python(AutotoolsPackage):
         spec = self.spec
         prefix = self.prefix
 
+        install(os.path.join(self.package_dir, 'sitecustomize.py'), os.path.join(prefix.lib, 'python2.7', 'site-packages'))
+
         self.sysconfigfilename = '_sysconfigdata.py'
         if spec.satisfies('@3.6:'):
             # Python 3.6.0 renamed the sys config file

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -208,7 +208,11 @@ class Python(AutotoolsPackage):
         spec = self.spec
         prefix = self.prefix
 
-        install(os.path.join(self.package_dir, 'sitecustomize.py'), os.path.join(prefix.lib, 'python2.7', 'site-packages'))
+        # TODO, hardcoding the version number is silly.  Could grab it
+        # from the spec, but need to understand if/how this is all
+        # going to work for python3.
+        install(os.path.join(self.package_dir, 'sitecustomize.py'),
+                os.path.join(prefix.lib, 'python2.7', 'site-packages'))
 
         self.sysconfigfilename = '_sysconfigdata.py'
         if spec.satisfies('@3.6:'):

--- a/var/spack/repos/builtin/packages/python/sitecustomize.py
+++ b/var/spack/repos/builtin/packages/python/sitecustomize.py
@@ -7,32 +7,45 @@ import site
 
 ## Need to find the `.python-sitedirs` file.
 ## But, sys.argv hasn't been set up yet.
+## Need to do something cute/sneaky/clever (sigh...)
+
 # Here's one way, from :
 # https://bugs.python.org/issue2972
 # WTD on things w/out `/proc/self/cmdline` (e.g. OS X)?
-cmdline = open("/proc/self/cmdline").read()
-cmd = cmdline.split('\x00')[1]
+# cmdline = open("/proc/self/cmdline").read()
+# cmd = cmdline.split('\x00')[1]
+#
+# try:
+#     sd_file = os.path.join(os.path.dirname(cmd), ".python-sitedirs")
+#     sitedirs = open(sd_file).read()
+#
+#     for d in sitedirs.split():
+#         site.addsitedir(os.path.join(d, 'lib', 'python2.7', 'site-packages'))
+# except:
+#     # no IO available, there's nothing to be done
+#     pass
+
 
 ## # Here's an alternative
 ## # from here: https://stackoverflow.com/questions/6485678/how-can-i-get-the-name-file-of-the-script-from-sitecustomize-py
 ## # Create a little class with a destructor, assign it to sys.argv
 ## # and the destructor will be called when sys.argv gets its real value
 ## # (SHUDDER...)
-## class Yikes(object):
-##     def __del__(self):
-##         # e.g.
-##         # commandline = " ".join(sys.argv)
-##         # grab the script name from the newly populated sys.argv
-##         # find the .python-sitedirs file and add its contents to sys.path
-##         # with site.addsitedir(...).
-## sys.argv = Yikes()
+class SetSysArgvTrigger(object):
+    def __del__(self):
+        # commandline = " ".join(sys.argv)
+        # grab the script name from the newly populated sys.argv
+        # find the .python-sitedirs file and add its contents to sys.path
+        # with site.addsitedir(...).
+        cmd = sys.argv[0]
+        try:
+            sd_file = os.path.join(os.path.dirname(cmd), ".python-sitedirs")
+            sitedirs = open(sd_file).read()
 
-try:
-    sd_file = os.path.join(os.path.dirname(cmd), ".python-sitedirs")
-    sitedirs = open(sd_file).read()
+            for d in sitedirs.split():
+                site.addsitedir(os.path.join(d, 'lib', 'python2.7', 'site-packages'))
+        except:
+            # no IO available, there's nothing to be done
+            pass
 
-    for d in sitedirs.split():
-        site.addsitedir(os.path.join(d, 'lib', 'python2.7', 'site-packages'))
-except:
-    # no IO available, there's nothing to be done
-    pass
+sys.argv = SetSysArgvTrigger()

--- a/var/spack/repos/builtin/packages/python/sitecustomize.py
+++ b/var/spack/repos/builtin/packages/python/sitecustomize.py
@@ -40,7 +40,9 @@ class SetSysArgvTrigger(object):
         # with site.addsitedir(...).
         cmd = sys.argv[0]
         try:
-            sd_file = os.path.join(os.path.dirname(cmd), ".python-sitedirs")
+            bin_dir = os.path.dirname(cmd)
+            prefix = os.path.dirname(bin_dir)
+            sd_file = os.path.join(prefix, ".spack", "python-sitedirs")
             sitedirs = open(sd_file).read()
 
             for d in sitedirs.split():

--- a/var/spack/repos/builtin/packages/python/sitecustomize.py
+++ b/var/spack/repos/builtin/packages/python/sitecustomize.py
@@ -4,6 +4,7 @@ Hack a bunch of directories onto the front of sys.path
 
 import os
 import site
+import sys
 
 ## Need to find the `.python-sitedirs` file.
 ## But, sys.argv hasn't been set up yet.

--- a/var/spack/repos/builtin/packages/python/sitecustomize.py
+++ b/var/spack/repos/builtin/packages/python/sitecustomize.py
@@ -5,7 +5,7 @@ Hack a bunch of directories onto the front of sys.path
 import os
 import site
 
-## Need to find the `.spack-rpaths`file.
+## Need to find the `.python-sitedirs` file.
 ## But, sys.argv hasn't been set up yet.
 # Here's one way, from :
 # https://bugs.python.org/issue2972
@@ -23,15 +23,15 @@ cmd = cmdline.split('\x00')[1]
 ##         # e.g.
 ##         # commandline = " ".join(sys.argv)
 ##         # grab the script name from the newly populated sys.argv
-##         # find the .spack-rpaths file and add its contents to sys.path
+##         # find the .python-sitedirs file and add its contents to sys.path
 ##         # with site.addsitedir(...).
 ## sys.argv = Yikes()
 
 try:
-    rpaths_file = os.path.join(os.path.dirname(cmd), ".spack-rpaths")
-    rpaths = open(rpaths_file).read()
+    sd_file = os.path.join(os.path.dirname(cmd), ".python-sitedirs")
+    sitedirs = open(sd_file).read()
 
-    for d in rpaths.split():
+    for d in sitedirs.split():
         site.addsitedir(os.path.join(d, 'lib', 'python2.7', 'site-packages'))
 except:
     # no IO available, there's nothing to be done

--- a/var/spack/repos/builtin/packages/python/sitecustomize.py
+++ b/var/spack/repos/builtin/packages/python/sitecustomize.py
@@ -1,0 +1,38 @@
+"""
+Hack a bunch of directories onto the front of sys.path
+"""
+
+import os
+import site
+
+## Need to find the `.spack-rpaths`file.
+## But, sys.argv hasn't been set up yet.
+# Here's one way, from :
+# https://bugs.python.org/issue2972
+# WTD on things w/out `/proc/self/cmdline` (e.g. OS X)?
+cmdline = open("/proc/self/cmdline").read()
+cmd = cmdline.split('\x00')[1]
+
+## # Here's an alternative
+## # from here: https://stackoverflow.com/questions/6485678/how-can-i-get-the-name-file-of-the-script-from-sitecustomize-py
+## # Create a little class with a destructor, assign it to sys.argv
+## # and the destructor will be called when sys.argv gets its real value
+## # (SHUDDER...)
+## class Yikes(object):
+##     def __del__(self):
+##         # e.g.
+##         # commandline = " ".join(sys.argv)
+##         # grab the script name from the newly populated sys.argv
+##         # find the .spack-rpaths file and add its contents to sys.path
+##         # with site.addsitedir(...).
+## sys.argv = Yikes()
+
+try:
+    rpaths_file = os.path.join(os.path.dirname(cmd), ".spack-rpaths")
+    rpaths = open(rpaths_file).read()
+
+    for d in rpaths.split():
+        site.addsitedir(os.path.join(d, 'lib', 'python2.7', 'site-packages'))
+except:
+    # no IO available, there's nothing to be done
+    pass


### PR DESCRIPTION
[Edited in response to feedback]

### Binding Python scripts and libraries at build-time

This PR is a Proof of Concept, exploring an approach to enabling Python to find the additional packages Spack installs without depending on `PYTHONPATH`.  Issue #8343 (a flake8 failure) is an example of problems caused by using `PYTHONPATH`.  This is an alternative approach to solving the problem to the one presented in PR #8364.

You can test drive the idea by starting in a clean Spack tree and installing a python-only module, you should be able to run its script without any additional modules or ....

```console
spack install py-flake8
(module purge; /home/hartzell/tmp/spack-rpath.py/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/py-flake8-3.5.0-4gkbvq2u3si6jxsmlapdeolds4wgwzdx/bin/flake8 --help)
```

The task is to add the various directories into which we've installed an application's python prerequisites onto its `sys.path`.

**The implementation is a proof of concept hack, don't get too hung up on the code itself.**  If the idea gets general support I'll work on the implementation.

When I was developing this I was struck by the similarity to RPATHS and shared libraries, hence the names I used for various things.  On further consideration, the name might be confusing and perhaps I should use something distinct.

### The current approach

The current approach is to either:

- `activate` the prereq's, which links them into the Python tree, which is on `sys.path` by default; or

  The problem with this approach is that only one version can be activated at a time and everyone using that Spack tree is stuck with it.

- add them via `PYTHONPATH` (using modulefiles or ...).

  The problem with this approach is that directories added via `PYTHONPATH` are second class citizens, the directories themselves are searched **BUT** the `*.pth` files they contain are not processed.  Lesser problems with this approach include `PYTHONPATH`'s global nature, its availability for finger poking and the complexity of juggling the modulefiles (e.g recursively loading prerequisites).

### The proposed solution

This solution sets from whence an application loads its libraries *at build time*, not at run time.  

There are two parts:

1. When Python packages are installed, they install a file containing the paths to all of the their python prerequisites (`.spack-rpaths`) within their `prefix`.

2. The Python package installs a `sitecustomize.py` script, which Python runs very early in the interpreter's startup.

   The `sitecustomize.py` code checks for a `.spack-rpaths` file.  If it finds one it uses `site.addsitedir` to add the directories it contains to `sys.path`.

   Directories that are added to `sys.path` via `site.addsitedir` *do* process `*.pth** files, so the magic they contain is invoked as expected.

This solution parallels what rpath does for shared libraries.

### Issues and sticky bits

Potentially sticky bits include:

- The biggest roadblock to this approach is that `sitecustomize.py` is processed *so* early that `sys.argv` has not been created yet, so discovering the path to the directory in which the script lives is magical.  This prototype grabs it from `/proc/self/cmdline`.  I've included an alternate solution that is either really elegant or too-cute-by-half (or both...), see the comments in `sitecustomize.py` for the gory details.
- Dealing with deployments that use the system python.  They might need to install our `sitecustomize.py`, they *might* be able to leverage *usercustomize*, or they might need to use one of the other techniques.
- I haven't played with Python3 yet.
- I suspect that a sufficiently determined user could break things by setting `PYTHONPATH`.

Beyond that, there's a bit of engineering to be done.

Something similar might be workable for Perl using its `sitecustomize` support.  Perhaps R and ... too.
