### PR TITLE
xsdk: fix 'ChecksumError: md5 checksum failed'

### DIFF
--- a/var/spack/repos/builtin/packages/xsdk/package.py
+++ b/var/spack/repos/builtin/packages/xsdk/package.py
@@ -37,7 +37,7 @@ class Xsdk(Package):
 
     # Dummy url since Spack complains if I don't list something, will be
     # removed when metapackage is available
-    url      = 'https://bitbucket.org/saws/saws/get/master.tar.gz'
+    url      = 'http://ftp.mcs.anl.gov/pub/petsc/externalpackages/xsdk.tar.gz'
 
     version('develop', 'a52dc710c744afa0b71429b8ec9425bc')
     version('0.3.0', 'a52dc710c744afa0b71429b8ec9425bc', preferred=True)


### PR DESCRIPTION
[error came up with the  prior url pointing to a 'master' branch. so fixing with a switch to a fixed tarball]

cc: @jwillenbring