### PR TITLE
superlu_dist: fix 'spack install superlu-dist@develop'

### DIFF
--- a/var/spack/repos/builtin/packages/superlu-dist/package.py
+++ b/var/spack/repos/builtin/packages/superlu-dist/package.py
@@ -86,6 +86,7 @@ class SuperluDist(Package):
             'FORTRAN      = {0}'.format(self.spec['mpi'].mpif77),
             'F90FLAGS     = -O2',
             'LOADER       = {0}'.format(self.spec['mpi'].mpif77),
+            'INCLUDEDIR   = $(SuperLUroot)/include',
             'LOADOPTS     =',
             'CDEFS        = %s' % ("-DNoChange"
                                        if '%xl' in spec or '%xl_r' in spec


### PR DESCRIPTION
Latest superlu_dist sources now use INCLUDEDIR.
This change should not affect older superlu_dist version builds

cc: @jwillenbring @xiaoyeli
