### PR TITLE
trilinos: use 'branch' option to specify branches such as develop/mas…

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -53,9 +53,9 @@ class Trilinos(CMakePackage):
     version('xsdk-0.2.0',
             git='https://github.com/trilinos/Trilinos.git', tag='xsdk-0.2.0')
     version('develop',
-            git='https://github.com/trilinos/Trilinos.git', tag='develop')
+            git='https://github.com/trilinos/Trilinos.git', branch='develop')
     version('master',
-            git='https://github.com/trilinos/Trilinos.git', tag='master')
+            git='https://github.com/trilinos/Trilinos.git', branch='master')
     version('12.12.1', 'ecd4606fa332212433c98bf950a69cc7')
     version('12.10.1', '667333dbd7c0f031d47d7c5511fd0810')
     version('12.8.1', '9f37f683ee2b427b5540db8a20ed6b15')


### PR DESCRIPTION
…ter [they are not tags]

Fixes the following problem:

==> Installing trilinos
==> Warning: Suspicious requests to set or unset 'LD_LIBRARY_PATH' found
==> Warning: 	    	env.unset('LD_LIBRARY_PATH') at /home/balay/spack.new/lib/spack/spack/build_environment.py:269
==> Warning: 	--->	env.set('%s' % key, value) at /home/balay/spack.new/lib/spack/spack/build_environment.py:292
==> Trying to clone git repository: https://github.com/trilinos/Trilinos.git at tag develop
Fetching tags only, you probably meant:
  git fetch --tags
error: pathspec 'develop' did not match any file(s) known to git.
==> Fetching from [git] https://github.com/trilinos/Trilinos.git failed.
==> Error: FetchError: All fetchers failed for trilinos-develop-tgkpnctp6nn4imoizxlw4ymqyztcie4n


cc: @jwillenbring 