### PR TITLE
Add the ability to build the dyninst master branch under the develop version name.

### DIFF
--- a/var/spack/repos/builtin/packages/dyninst/package.py
+++ b/var/spack/repos/builtin/packages/dyninst/package.py
@@ -57,7 +57,7 @@ class Dyninst(Package):
     # develop is considered newer than all other releases.
     # So, develop is included in the elf@1 line below.
     depends_on("elf@1", type='link', when='@9.3.0:')
-    depends_on("libdwarf", when='@:9.3.2')
+    depends_on("libdwarf", when='@:9')
     depends_on("boost@1.42:")
     depends_on('cmake', type='build')
 
@@ -73,7 +73,7 @@ class Dyninst(Package):
             return
 
         libelf = spec['elf'].prefix
-        if spec.satisfies('@:9.3.2'):
+        if spec.satisfies('@:9'):
             libdwarf = spec['libdwarf'].prefix
 
         with working_dir('spack-build', create=True):
@@ -85,7 +85,7 @@ class Dyninst(Package):
                         libelf.include, 'libelf'),
                     '-DLIBELF_LIBRARIES=%s'     % join_path(
                         libelf.lib, "libelf." + dso_suffix)]
-            if spec.satisfies('@:9.3.2'):
+            if spec.satisfies('@:9'):
                 args.append('-DLIBDWARF_INCLUDE_DIR=%s' % libdwarf.include)
                 args.append('-DLIBDWARF_LIBRARIES=%s'   % join_path(
                     libdwarf.lib, "libdwarf." + dso_suffix))

--- a/var/spack/repos/builtin/packages/dyninst/package.py
+++ b/var/spack/repos/builtin/packages/dyninst/package.py
@@ -33,6 +33,7 @@ class Dyninst(Package):
     url = "https://github.com/dyninst/dyninst/archive/v9.2.0.tar.gz"
     list_url = "http://www.dyninst.org/downloads/dyninst-8.x"
 
+    version('develop', git="https://github.com/dyninst/dyninst.git", branch='master')
     version('9.3.2', git="https://github.com/dyninst/dyninst.git", tag='v9.3.2')
     version('9.3.0', git="https://github.com/dyninst/dyninst.git", tag='v9.3.0')
     version('9.2.0', git="https://github.com/dyninst/dyninst.git", tag='v9.2.0')
@@ -44,9 +45,19 @@ class Dyninst(Package):
     variant('stat_dysect', default=False,
             description="patch for STAT's DySectAPI")
 
+    # Dyninst depends on libelf and libdwarf prior to @9.3.0
+    # Dyninst depends on elfutils and libdwarf from @9.3.0 to but
+    # not including @develop
+    # Dyninst depends on elfutils and elfutils libdw from @develop forward
+    # elf@0 is an abstaction for libelf
+    # elf@1 is an abstaction for elfutils
     depends_on("elf@0", type='link', when='@:9.2.99')
+    # The sorting algorithm puts numbered releases as newer than alphabetic
+    # releases, but spack has special logic in place to ensure that
+    # develop is considered newer than all other releases.
+    # So, develop is included in the elf@1 line below.
     depends_on("elf@1", type='link', when='@9.3.0:')
-    depends_on("libdwarf")
+    depends_on("libdwarf", when='@:9.3.2')
     depends_on("boost@1.42:")
     depends_on('cmake', type='build')
 
@@ -62,7 +73,8 @@ class Dyninst(Package):
             return
 
         libelf = spec['elf'].prefix
-        libdwarf = spec['libdwarf'].prefix
+        if spec.satisfies('@:9.3.2'):
+            libdwarf = spec['libdwarf'].prefix
 
         with working_dir('spack-build', create=True):
             args = ['..',
@@ -72,10 +84,19 @@ class Dyninst(Package):
                     '-DLIBELF_INCLUDE_DIR=%s'   % join_path(
                         libelf.include, 'libelf'),
                     '-DLIBELF_LIBRARIES=%s'     % join_path(
-                        libelf.lib, 'libelf.so'),
-                    '-DLIBDWARF_INCLUDE_DIR=%s' % libdwarf.include,
-                    '-DLIBDWARF_LIBRARIES=%s'   % join_path(
-                        libdwarf.lib, 'libdwarf.so')]
+                        libelf.lib, "libelf." + dso_suffix)]
+            if spec.satisfies('@:9.3.2'):
+                args.append('-DLIBDWARF_INCLUDE_DIR=%s' % libdwarf.include)
+                args.append('-DLIBDWARF_LIBRARIES=%s'   % join_path(
+                    libdwarf.lib, "libdwarf." + dso_suffix))
+            # For @develop + use elfutils libdw, libelf is an abstraction
+            # we are really using elfutils here
+            if spec.satisfies('@develop:'):
+                args.append('-DLIBDWARF_INCLUDE_DIR=%s' % libelf.include)
+                args.append('-DLIBDWARF_LIBRARIES=%s'   % join_path(
+                    libelf.lib, "libdw." + dso_suffix))
+            if spec.satisfies('arch=linux-redhat7-ppc64le'):
+                args.append('-Darch_ppc64_little_endian=1')
             if spec.satisfies('arch=linux-redhat7-ppc64le'):
                 args.append('-Darch_ppc64_little_endian=1')
             args += std_cmake_args

--- a/var/spack/repos/builtin/packages/dyninst/package.py
+++ b/var/spack/repos/builtin/packages/dyninst/package.py
@@ -91,7 +91,7 @@ class Dyninst(Package):
                     libdwarf.lib, "libdwarf." + dso_suffix))
             # For @develop + use elfutils libdw, libelf is an abstraction
             # we are really using elfutils here
-            if spec.satisfies('@develop:'):
+            if spec.satisfies('@develop'):
                 args.append('-DLIBDWARF_INCLUDE_DIR=%s' % libelf.include)
                 args.append('-DLIBDWARF_LIBRARIES=%s'   % join_path(
                     libelf.lib, "libdw." + dso_suffix))

--- a/var/spack/repos/builtin/packages/dyninst/package.py
+++ b/var/spack/repos/builtin/packages/dyninst/package.py
@@ -97,8 +97,6 @@ class Dyninst(Package):
                     libelf.lib, "libdw." + dso_suffix))
             if spec.satisfies('arch=linux-redhat7-ppc64le'):
                 args.append('-Darch_ppc64_little_endian=1')
-            if spec.satisfies('arch=linux-redhat7-ppc64le'):
-                args.append('-Darch_ppc64_little_endian=1')
             args += std_cmake_args
             cmake(*args)
             make()

--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -41,7 +41,7 @@ class Elfutils(AutotoolsPackage):
 
     version('0.170', '03599aee98c9b726c7a732a2dd0245d5')
     version('0.168', '52adfa40758d0d39e5d5c57689bf38d6')
-    version('0.163', '77ce87f259987d2e54e4d87b86cbee41', preferred=True)
+    version('0.163', '77ce87f259987d2e54e4d87b86cbee41')
 
     depends_on('flex', type='build')
     depends_on('bison', type='build')

--- a/var/spack/repos/builtin/packages/libdwarf/package.py
+++ b/var/spack/repos/builtin/packages/libdwarf/package.py
@@ -24,6 +24,7 @@
 ##############################################################################
 from spack import *
 import sys
+import os
 
 # Only build certain parts of dwarf because the other ones break.
 dwarf_dirs = ['libdwarf', 'dwarfdump2']
@@ -45,10 +46,12 @@ class Libdwarf(Package):
     url      = "http://www.prevanders.net/libdwarf-20160507.tar.gz"
     list_url = homepage
 
+    version('20180129', 'c5e90fad4640f0d713ae8b986031f959')
     version('20160507', 'ae32d6f9ece5daf05e2d4b14822ea811')
     version('20130729', '4cc5e48693f7b93b7aa0261e63c0e21d')
     version('20130207', '64b42692e947d5180e162e46c689dfbf')
     version('20130126', 'ded74a5e90edb5a12aac3c29d260c5db')
+    depends_on("elfutils@0.163", when='@20160507', type='link')
     depends_on("elf", type='link')
     depends_on('zlib', type='link')
 
@@ -91,8 +94,12 @@ class Libdwarf(Package):
                 make()
 
                 libdwarf_name = 'libdwarf.{0}'.format(dso_suffix)
+                libdwarf1_name = 'libdwarf.{0}'.format(dso_suffix) + ".1"
                 install('libdwarf.a',  prefix.lib)
-                install('libdwarf.so', join_path(prefix.lib, libdwarf_name))
+                install('libdwarf.so', join_path(prefix.lib, libdwarf1_name))
+                if spec.satisfies('@20160507:'):
+                    with working_dir(prefix.lib):
+                        os.symlink(libdwarf1_name, libdwarf_name)
                 install('libdwarf.h',  prefix.include)
                 install('dwarf.h',     prefix.include)
 


### PR DESCRIPTION
@lee218llnl @adamjstewart  
This PR supercedes #8181.  The submission was redone in order to clean-up extra merge commits.
```Summary:
Add access to the master tree for a dyninst@develop version  Also, fix issues related to trying to build dyninst due to dyninst's transition away from libelf and libdwarf as they move to elfutils and elfutils dwarf. From comments I added to the dyninst package.py file:
```
```
+    # Dyninst depends on libelf and libdwarf prior to 9.3.0
+    # Dyninst depends on elfutils and libdwarf from 9.3.0 to but
+    # not including 10.0.alpha
+    # Dyninst depends on elfutils and elfutils libdw from 10.0.alpha onwards
+    # elf@0 is an abstaction for libelf
+    # elf@1 is an abstaction for elfutils
```