### PR TITLE
Add changes to the Krell packages with version updates and ranges for  the latest release.

### DIFF
--- a/var/spack/repos/builtin/packages/cbtf-argonavis-gui/package.py
+++ b/var/spack/repos/builtin/packages/cbtf-argonavis-gui/package.py
@@ -51,50 +51,44 @@ class CbtfArgonavisGui(QMakePackage):
     url = "https://github.com/OpenSpeedShop/cbtf-argonavis-gui.git"
 
     version('1.3.0.0', branch='1.3.0.0',
-            git='https://github.com/OpenSpeedShop/cbtf-argonavis-gui.git')
+            git='https://github.com/OpenSpeedShop/cbtf-argonavis-gui.git', preferred=True)
 
     version('develop', branch='master',
             git='https://github.com/OpenSpeedShop/cbtf-argonavis-gui.git')
 
-    depends_on("cmake@3.0.2:", when='@develop', type='build')
-    depends_on("cmake@3.11.1", when='@1.3.0.0:', type='build')
-
-    # To specify ^elfutils@0.170 on the command line spack
-    # apparently needs/wants this dependency explicity here
-    # even though it is referenced downstream
-    depends_on("elf", type="link")
+    depends_on("cmake@3.0.2:", type='build')
 
     depends_on('qt@4.8.6:', when='@develop')
-    depends_on('qt@5.10.0', when='@1.3.0.0:')
+    depends_on('qt@5.10.0', when='@1.3.0.0:9999')
 
     depends_on("boost@1.50.0:", when='@develop')
-    depends_on("boost@1.66.0", when='@1.3.0.0:')
+    depends_on("boost@1.66.0", when='@1.3.0.0:9999')
 
     # For MRNet
     depends_on("mrnet@5.0.1-3:+lwthreads", when='@develop')
-    depends_on("mrnet@5.0.1-3+lwthreads", when='@1.3.0.0:')
+    depends_on("mrnet@5.0.1-3+lwthreads", when='@1.3.0.0:9999')
 
     # Dependencies for the openspeedshop cbtf packages.
     depends_on("cbtf@develop", when='@develop')
-    depends_on("cbtf@1.9.1.0:", when='@1.3.0.0:')
+    depends_on("cbtf@1.9.1.0:9999", when='@1.3.0.0:9999')
 
     depends_on("cbtf-krell@develop", when='@develop')
-    depends_on("cbtf-krell@1.9.1.0:", when='@1.3.0.0:')
+    depends_on("cbtf-krell@1.9.1.0:9999", when='@1.3.0.0:9999')
 
     depends_on("cbtf-argonavis@develop", when='@develop')
-    depends_on("cbtf-argonavis@1.9.1.0:", when='@1.3.0.0:')
+    depends_on("cbtf-argonavis@1.9.1.0:9999", when='@1.3.0.0:9999')
 
     depends_on("cuda")
 
     depends_on("openspeedshop-utils+cuda@develop", when='@develop')
-    depends_on("openspeedshop-utils@2.3.1.3:+cuda", when='@1.3.0.0:')
+    depends_on("openspeedshop-utils@2.3.1.3:+cuda", when='@1.3.0.0:9999')
 
     # For Xerces-C
     depends_on("xerces-c@3.1.1:", when='@develop')
-    depends_on("xerces-c@3.1.4", when='@1.3.0.0:')
+    depends_on("xerces-c@3.1.4", when='@1.3.0.0:9999')
 
     depends_on("graphviz@2.40.1:", when='@develop')
-    depends_on("graphviz@2.40.1", when='@1.3.0.0:')
+    depends_on("graphviz@2.40.1", when='@1.3.0.0:9999')
 
     depends_on("qtgraph")
 

--- a/var/spack/repos/builtin/packages/cbtf-argonavis-gui/package.py
+++ b/var/spack/repos/builtin/packages/cbtf-argonavis-gui/package.py
@@ -51,14 +51,14 @@ class CbtfArgonavisGui(QMakePackage):
     url = "https://github.com/OpenSpeedShop/cbtf-argonavis-gui.git"
 
     version('1.3.0.0', branch='1.3.0.0',
-            git='https://github.com/OpenSpeedShop/cbtf-argonavis-gui.git', preferred=True)
+            git='https://github.com/OpenSpeedShop/cbtf-argonavis-gui.git')
 
     version('develop', branch='master',
             git='https://github.com/OpenSpeedShop/cbtf-argonavis-gui.git')
 
     depends_on("cmake@3.0.2:", type='build')
 
-    depends_on('qt@4.8.6:', when='@develop')
+    depends_on('qt@5.10.0:', when='@develop')
     depends_on('qt@5.10.0', when='@1.3.0.0:9999')
 
     depends_on("boost@1.50.0:", when='@develop')

--- a/var/spack/repos/builtin/packages/cbtf-argonavis/package.py
+++ b/var/spack/repos/builtin/packages/cbtf-argonavis/package.py
@@ -70,8 +70,7 @@ class CbtfArgonavis(CMakePackage):
     variant('build_type', default='None', values=('None'),
             description='CMake build type')
 
-    depends_on("cmake@3.11.1", when='@1.9.1.0:', type='build')
-    depends_on("cmake@3.0.2:", when='@develop', type='build')
+    depends_on("cmake@3.0.2:", type='build')
 
     # To specify ^elfutils@0.170 on the command line spack
     # apparently needs/wants this dependency explicity here
@@ -80,42 +79,42 @@ class CbtfArgonavis(CMakePackage):
 
     # For boost
     depends_on("boost@1.50.0:", when='@develop')
-    depends_on("boost@1.66.0", when='@1.9.1.0:')
+    depends_on("boost@1.66.0", when='@1.9.1.0:9999')
 
     # For MRNet
     depends_on("mrnet@5.0.1-3:+cti", when='@develop+cti')
     depends_on("mrnet@5.0.1-3:+lwthreads", when='@develop~cti')
-    depends_on("mrnet@5.0.1-3+cti", when='@1.9.1.0:+cti')
-    depends_on("mrnet@5.0.1-3+lwthreads", when='@1.9.1.0:~cti')
+    depends_on("mrnet@5.0.1-3+cti", when='@1.9.1.0:9999+cti')
+    depends_on("mrnet@5.0.1-3+lwthreads", when='@1.9.1.0:9999~cti')
 
     # For CBTF
     depends_on("cbtf@develop", when='@develop')
-    depends_on("cbtf@1.9.1.0:", when='@1.9.1.0:')
+    depends_on("cbtf@1.9.1.0:9999", when='@1.9.1.0:9999')
 
     # For CBTF with cti
     depends_on("cbtf@develop+cti", when='@develop+cti')
-    depends_on("cbtf@1.9.1.0:+cti", when='@1.9.1.0:+cti')
+    depends_on("cbtf@1.9.1.0:9999+cti", when='@1.9.1.0:9999+cti')
 
     # For CBTF with runtime
     depends_on("cbtf@develop+runtime", when='@develop+runtime')
-    depends_on("cbtf@1.9.1.0:+runtime", when='@1.9.1.0:+runtime')
+    depends_on("cbtf@1.9.1.0:9999+runtime", when='@1.9.1.0:9999+runtime')
 
     # For libmonitor
     depends_on("libmonitor+krellpatch")
 
     # For PAPI
     depends_on("papi", when='@develop')
-    depends_on("papi@5.5.1", when='@1.9.1.0:')
+    depends_on("papi@5.5.1", when='@1.9.1.0:9999')
 
     # For CBTF-KRELL
     depends_on("cbtf-krell@develop", when='@develop')
-    depends_on("cbtf-krell@1.9.1.0:", when='@1.9.1.0:')
+    depends_on("cbtf-krell@1.9.1.0:9999", when='@1.9.1.0:9999')
 
     depends_on('cbtf-krell@develop+cti', when='@develop+cti')
-    depends_on('cbtf-krell@1.9.1.0:+cti', when='@1.9.1.0:+cti')
+    depends_on('cbtf-krell@1.9.1.0:9999+cti', when='@1.9.1.0:9999+cti')
 
     depends_on('cbtf-krell@develop+runtime', when='@develop+runtime')
-    depends_on('cbtf-krell@1.9.1.0:+runtime', when='@1.9.1.0:+runtime')
+    depends_on('cbtf-krell@1.9.1.0:9999+runtime', when='@1.9.1.0:9999+runtime')
 
     # For CUDA
     depends_on("cuda")

--- a/var/spack/repos/builtin/packages/cbtf-krell/package.py
+++ b/var/spack/repos/builtin/packages/cbtf-krell/package.py
@@ -55,13 +55,13 @@ class CbtfKrell(CMakePackage):
     homepage = "http://sourceforge.net/p/cbtf/wiki/Home/"
     url = "https://github.com/OpenSpeedShop/cbtf-krell.git"
 
+    version('develop', branch='master',
+            git='https://github.com/OpenSpeedShop/cbtf-krell.git')
+
     version('1.9.1.1', branch='1.9.1.1',
             git='https://github.com/OpenSpeedShop/cbtf-krell.git')
 
     version('1.9.1.0', branch='1.9.1.0',
-            git='https://github.com/OpenSpeedShop/cbtf-krell.git')
-
-    version('develop', branch='master',
             git='https://github.com/OpenSpeedShop/cbtf-krell.git')
 
     # MPI variants
@@ -88,52 +88,51 @@ class CbtfKrell(CMakePackage):
                          to point to target build.")
 
     # Dependencies for cbtf-krell
-    depends_on("cmake@3.11.1", when='@1.9.1.0:', type='build')
-    depends_on("cmake@3.0.2:", when='@develop', type='build')
+    depends_on("cmake@3.0.2:", type='build')
 
     # For binutils
     depends_on("binutils", when='@develop')
-    depends_on("binutils@2.29.1", when='@1.9.1.0:')
+    depends_on("binutils@2.29.1", when='@1.9.1.0:9999')
 
     # For boost
     depends_on("boost@1.50.0:", when='@develop')
-    depends_on("boost@1.66.0", when='@1.9.1.0:')
+    depends_on("boost@1.66.0", when='@1.9.1.0:9999')
 
     # For Dyninst
-    depends_on("dyninst@9.3.2:", when='@develop')
-    depends_on("dyninst@9.3.2", when='@1.9.1.0:')
+    depends_on("dyninst@develop", when='@develop')
+    depends_on("dyninst@9.3.2", when='@1.9.1.0:9999')
 
     # For MRNet
     depends_on("mrnet@5.0.1-3:+cti", when='@develop+cti')
     depends_on("mrnet@5.0.1-3:+lwthreads", when='@develop')
 
-    depends_on("mrnet@5.0.1-3+cti", when='@1.9.1.0:+cti')
-    depends_on("mrnet@5.0.1-3+lwthreads", when='@1.9.1.0:')
+    depends_on("mrnet@5.0.1-3+cti", when='@1.9.1.0:9999+cti')
+    depends_on("mrnet@5.0.1-3+lwthreads", when='@1.9.1.0:9999')
 
     # For Xerces-C
     depends_on("xerces-c@3.1.1:", when='@develop')
-    depends_on("xerces-c@3.1.4", when='@1.9.1.0:')
+    depends_on("xerces-c@3.1.4", when='@1.9.1.0:9999')
 
     # For CBTF
     depends_on("cbtf@develop", when='@develop')
-    depends_on("cbtf@1.9.1.0:", when='@1.9.1.0:')
+    depends_on("cbtf@1.9.1.0:9999", when='@1.9.1.0:9999')
 
     # For CBTF with cti
     depends_on("cbtf@develop+cti", when='@develop+cti')
-    depends_on("cbtf@1.9.1.0:+cti", when='@1.9.1.0:+cti')
+    depends_on("cbtf@1.9.1.0:9999+cti", when='@1.9.1.0:9999+cti')
 
     # For CBTF with runtime
     depends_on("cbtf@develop+runtime", when='@develop+runtime')
-    depends_on("cbtf@1.9.1.0:+runtime", when='@1.9.1.0:+runtime')
+    depends_on("cbtf@1.9.1.0:9999+runtime", when='@1.9.1.0:9999+runtime')
 
     # for services and collectors
     depends_on("libmonitor+krellpatch")
 
     depends_on("libunwind", when='@develop')
-    depends_on("libunwind@1.1", when='@1.9.1.0:')
+    depends_on("libunwind@1.1", when='@1.9.1.0:9999')
 
     depends_on("papi", when='@develop')
-    depends_on("papi@5.5.1", when='@1.9.1.0:')
+    depends_on("papi@5.5.1", when='@1.9.1.0:9999')
 
     depends_on("llvm-openmp-ompt@tr6_forwards+standalone")
 
@@ -144,6 +143,8 @@ class CbtfKrell(CMakePackage):
     depends_on("mvapich2", when='+mvapich2')
     depends_on("mvapich", when='+mvapich')
     depends_on("mpt", when='+mpt')
+
+    depends_on("gotcha")
 
     parallel = False
 
@@ -251,6 +252,7 @@ class CbtfKrell(CMakePackage):
             '-DMRNET_DIR=%s' % spec['mrnet'].prefix,
             '-DDYNINST_DIR=%s' % spec['dyninst'].prefix,
             '-DLIBIOMP_DIR=%s' % spec['llvm-openmp-ompt'].prefix,
+            '-DGOTCHA_DIR=%s' % spec['gotcha'].prefix,
             '-DXERCESC_DIR=%s' % spec['xerces-c'].prefix]
 
         if self.spec.satisfies('+runtime'):

--- a/var/spack/repos/builtin/packages/cbtf-lanl/package.py
+++ b/var/spack/repos/builtin/packages/cbtf-lanl/package.py
@@ -67,40 +67,39 @@ class CbtfLanl(CMakePackage):
     variant('cti', default=False,
             description="Build MRNet with the CTI startup option")
 
-    depends_on("cmake@3.0.2:", when='@develop', type='build')
-    depends_on("cmake@3.11.1", when='@1.9.1.0:', type='build')
+    depends_on("cmake@3.0.2:", type='build')
 
     # For MRNet
     depends_on("mrnet@5.0.1-3:+cti", when='@develop+cti')
     depends_on("mrnet@5.0.1-3:+lwthreads", when='@develop')
-    depends_on("mrnet@5.0.1-3+cti", when='@1.9.1.0:+cti')
-    depends_on("mrnet@5.0.1-3+lwthreads", when='@1.9.1.0:')
+    depends_on("mrnet@5.0.1-3+cti", when='@1.9.1.0:9999+cti')
+    depends_on("mrnet@5.0.1-3+lwthreads", when='@1.9.1.0:9999')
 
     # For Xerces-C
     depends_on("xerces-c@3.1.1:", when='@develop')
-    depends_on("xerces-c@3.1.4", when='@1.9.1.0:')
+    depends_on("xerces-c@3.1.4", when='@1.9.1.0:9999')
 
     # For CBTF
     depends_on("cbtf@develop", when='@develop')
-    depends_on("cbtf@1.9.1.0:", when='@1.9.1.0:')
+    depends_on("cbtf@1.9.1.0:9999", when='@1.9.1.0:9999')
 
     # For CBTF with cti
     depends_on("cbtf@develop+cti", when='@develop+cti')
-    depends_on("cbtf@1.9.1.0:+cti", when='@1.9.1.0:+cti')
+    depends_on("cbtf@1.9.1.0:9999+cti", when='@1.9.1.0:9999+cti')
 
     # For CBTF with runtime
     depends_on("cbtf@develop+runtime", when='@develop+runtime')
-    depends_on("cbtf@1.9.1.0:+runtime", when='@1.9.1.0:+runtime')
+    depends_on("cbtf@1.9.1.0:9999+runtime", when='@1.9.1.0:9999+runtime')
 
     # For CBTF-KRELL
     depends_on("cbtf-krell@develop", when='@develop')
-    depends_on("cbtf-krell@1.9.1.0:", when='@1.9.1.0:')
+    depends_on("cbtf-krell@1.9.1.0:9999", when='@1.9.1.0:9999')
 
     depends_on('cbtf-krell@develop+cti', when='@develop+cti')
-    depends_on('cbtf-krell@1.9.1.0:+cti', when='@1.9.1.0:+cti')
+    depends_on('cbtf-krell@1.9.1.0:9999+cti', when='@1.9.1.0:9999+cti')
 
     depends_on('cbtf-krell@develop+runtime', when='@develop+runtime')
-    depends_on('cbtf-krell@1.9.1.0:+runtime', when='@1.9.1.0:+runtime')
+    depends_on('cbtf-krell@1.9.1.0:9999+runtime', when='@1.9.1.0:9999+runtime')
 
     parallel = False
 

--- a/var/spack/repos/builtin/packages/cbtf/package.py
+++ b/var/spack/repos/builtin/packages/cbtf/package.py
@@ -72,25 +72,23 @@ class Cbtf(CMakePackage):
     variant('build_type', default='None', values=('None'),
             description='CMake build type')
 
-    depends_on("cmake@3.11.1", when='@1.9.1.0:', type='build')
-    depends_on("cmake@3.0.2:", when='@develop', type='build')
+    depends_on("cmake@3.0.2:", type='build')
 
-    depends_on("boost@1.66.0", when='@1.9.1.0:')
+    depends_on("boost@1.66.0", when='@1.9.1.0:9999')
     depends_on("boost@1.50.0:", when='@develop')
 
     # For MRNet
     depends_on("mrnet@5.0.1-3:+cti", when='@develop+cti')
     depends_on("mrnet@5.0.1-3:+lwthreads", when='@develop')
-    depends_on("mrnet@5.0.1-3+cti", when='@1.9.1.0:+cti')
-    depends_on("mrnet@5.0.1-3+lwthreads", when='@1.9.1.0:')
+    depends_on("mrnet@5.0.1-3+cti", when='@1.9.1.0:9999+cti')
+    depends_on("mrnet@5.0.1-3+lwthreads", when='@1.9.1.0:9999')
 
     # For Xerces-C
     depends_on("xerces-c@3.1.1:", when='@develop')
-    depends_on("xerces-c@3.1.4", when='@1.9.1.0:')
+    depends_on("xerces-c@3.1.4:", when='@1.9.1.0:9999')
 
     # For XML2
-    depends_on("libxml2", when='@develop')
-    depends_on("libxml2@2.9.4", when='@1.9.1.0:')
+    depends_on("libxml2")
 
     parallel = False
 

--- a/var/spack/repos/builtin/packages/openspeedshop-utils/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop-utils/package.py
@@ -139,7 +139,7 @@ class OpenspeedshopUtils(CMakePackage):
     depends_on("dyninst@9.3.2", when='@2.3.1.3:9999')
 
     depends_on("python", when='@develop')
-    depends_on("python@2.7.14", when='@2.3.1.3:9999')
+    depends_on("python@2.7.14:2.7.15", when='@2.3.1.3:9999')
 
     depends_on("libxml2")
 

--- a/var/spack/repos/builtin/packages/openspeedshop-utils/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop-utils/package.py
@@ -114,18 +114,17 @@ class OpenspeedshopUtils(CMakePackage):
             description="Build mpi collector for mpich\
                          MPI when variant is enabled.")
 
-    depends_on("cmake@3.11.1", when='@2.3.1.3:', type='build')
-    depends_on("cmake@3.0.2:", when='@develop', type='build')
+    depends_on("cmake@3.0.2:", type='build')
 
     # Dependencies for openspeedshop that are common to all
     # the variants of the OpenSpeedShop build
     depends_on("libtool", type='build')
     depends_on("bison", type='build')
-    depends_on("flex", type='build')
+    depends_on("flex@2.6.1", type='build')
 
     # For binutils
     depends_on("binutils", when='@develop', type='build')
-    depends_on("binutils@2.29.1", when='@2.3.1.3:', type='build')
+    depends_on("binutils@2.29.1", when='@2.3.1.3:9999', type='build')
 
     depends_on("elf", type="link")
     depends_on("libdwarf")
@@ -134,57 +133,56 @@ class OpenspeedshopUtils(CMakePackage):
 
     # For boost
     depends_on("boost@1.50.0:", when='@develop')
-    depends_on("boost@1.66.0", when='@2.3.1.3:')
+    depends_on("boost@1.66.0", when='@2.3.1.3:9999')
 
-    depends_on("dyninst@9.3.2:", when='@develop')
-    depends_on("dyninst@9.3.2", when='@2.3.1.3:')
+    depends_on("dyninst@develop", when='@develop')
+    depends_on("dyninst@9.3.2", when='@2.3.1.3:9999')
 
     depends_on("python", when='@develop')
-    depends_on("python@2.7.14", when='@2.3.1.3:')
+    depends_on("python@2.7.14", when='@2.3.1.3:9999')
 
-    depends_on("libxml2", when='@develop')
-    depends_on("libxml2@2.9.4", when='@2.3.1.3:')
+    depends_on("libxml2")
 
     # Dependencies for the openspeedshop cbtf packages.
     depends_on("cbtf@develop", when='@develop')
-    depends_on("cbtf@1.9.1.0:", when='@2.3.1.3:')
+    depends_on("cbtf@1.9.1.0:9999", when='@2.3.1.3:9999')
 
     depends_on("cbtf-krell@develop", when='@develop')
-    depends_on("cbtf-krell@1.9.1.0:", when='@2.3.1.3:')
+    depends_on("cbtf-krell@1.9.1.0:9999", when='@2.3.1.3:9999')
 
     depends_on('cbtf-krell@develop+crayfe', when='@develop+crayfe')
-    depends_on('cbtf-krell@1.9.1.0:+crayfe', when='@2.3.1.3:+crayfe')
+    depends_on('cbtf-krell@1.9.1.0:9999+crayfe', when='@2.3.1.3:9999+crayfe')
 
     depends_on('cbtf-krell@develop+cti', when='@develop+cti')
-    depends_on('cbtf-krell@1.9.1.0:+cti', when='@2.3.1.3:+cti')
+    depends_on('cbtf-krell@1.9.1.0:9999+cti', when='@2.3.1.3:9999+cti')
 
     depends_on('cbtf-krell@develop+mpich', when='@develop+mpich')
-    depends_on('cbtf-krell@1.9.1.0:+mpich', when='@2.3.1.3:+mpich')
+    depends_on('cbtf-krell@1.9.1.0:9999+mpich', when='@2.3.1.3:9999+mpich')
 
     depends_on('cbtf-krell@develop+mpich2', when='@develop+mpich2')
-    depends_on('cbtf-krell@1.9.1.0:+mpich2', when='@2.3.1.3:+mpich2')
+    depends_on('cbtf-krell@1.9.1.0:9999+mpich2', when='@2.3.1.3:9999+mpich2')
 
     depends_on('cbtf-krell@develop+mpt', when='@develop+mpt')
-    depends_on('cbtf-krell@1.9.1.0:+mpt', when='@2.3.1.3:+mpt')
+    depends_on('cbtf-krell@1.9.1.0:9999+mpt', when='@2.3.1.3:9999+mpt')
 
     depends_on('cbtf-krell@develop+mvapich', when='@develop+mvapich')
-    depends_on('cbtf-krell@1.9.1.0:+mvapich', when='@2.3.1.3:+mvapich')
+    depends_on('cbtf-krell@1.9.1.0:9999+mvapich', when='@2.3.1.3:9999+mvapich')
 
     depends_on('cbtf-krell@develop+mvapich2', when='@develop+mvapich2')
-    depends_on('cbtf-krell@1.9.1.0:+mvapich2', when='@2.3.1.3:+mvapich2')
+    depends_on('cbtf-krell@1.9.1.0:9999+mvapich2', when='@2.3.1.3:9999+mvapich2')
 
     depends_on('cbtf-krell@develop+openmpi', when='@develop+openmpi')
-    depends_on('cbtf-krell@1.9.1.0:+openmpi', when='@2.3.1.3:+openmpi')
+    depends_on('cbtf-krell@1.9.1.0:9999+openmpi', when='@2.3.1.3:9999+openmpi')
 
     depends_on("cbtf-argonavis@develop", when='@develop+cuda')
-    depends_on("cbtf-argonavis@1.9.1.0:", when='@2.3.1.3:+cuda')
+    depends_on("cbtf-argonavis@1.9.1.0:9999", when='@2.3.1.3:9999+cuda')
 
     # For MRNet
     depends_on("mrnet@5.0.1-3:+cti", when='@develop+cti')
     depends_on("mrnet@5.0.1-3:+lwthreads", when='@develop')
 
-    depends_on("mrnet@5.0.1-3:+cti", when='@2.3.1.3:+cti')
-    depends_on("mrnet@5.0.1-3:+lwthreads", when='@2.3.1.3:')
+    depends_on("mrnet@5.0.1-3:+cti", when='@2.3.1.3:9999+cti')
+    depends_on("mrnet@5.0.1-3:+lwthreads", when='@2.3.1.3:9999')
 
     parallel = False
 

--- a/var/spack/repos/builtin/packages/openspeedshop/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop/package.py
@@ -67,7 +67,7 @@ class Openspeedshop(CMakePackage):
 
     # Use when the git repository is available
     version('2.3.1.4', branch='2.3.1.4',
-            git='https://github.com/OpenSpeedShop/openspeedshop.git', preferred=True)
+            git='https://github.com/OpenSpeedShop/openspeedshop.git')
 
     version('2.3.1.3', branch='2.3.1.3',
             git='https://github.com/OpenSpeedShop/openspeedshop.git')
@@ -137,7 +137,7 @@ class Openspeedshop(CMakePackage):
     depends_on("dyninst@9.3.2", when='@2.3.1.3:9999')
 
     depends_on("python", when='@develop')
-    depends_on("python@2.7.14", when='@2.3.1.3:9999')
+    depends_on("python@2.7.14:2.7.15", when='@2.3.1.3:9999')
 
     depends_on("libxml2")
 

--- a/var/spack/repos/builtin/packages/openspeedshop/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop/package.py
@@ -227,7 +227,6 @@ class Openspeedshop(CMakePackage):
         if spec.satisfies('+runtime'):
             # Appends base options to cmake_args
             self.set_defaultbase_cmakeOptions(spec, cmake_args)
-
             cmake_args.extend(
                 ['-DCMAKE_CXX_FLAGS=%s'  % compile_flags,
                  '-DCMAKE_C_FLAGS=%s'    % compile_flags,

--- a/var/spack/repos/builtin/packages/openspeedshop/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop/package.py
@@ -67,7 +67,7 @@ class Openspeedshop(CMakePackage):
 
     # Use when the git repository is available
     version('2.3.1.4', branch='2.3.1.4',
-            git='https://github.com/OpenSpeedShop/openspeedshop.git')
+            git='https://github.com/OpenSpeedShop/openspeedshop.git', preferred=True)
 
     version('2.3.1.3', branch='2.3.1.3',
             git='https://github.com/OpenSpeedShop/openspeedshop.git')
@@ -112,18 +112,17 @@ class Openspeedshop(CMakePackage):
             description="Build mpi collector for mpich\
                          MPI when variant is enabled.")
 
-    depends_on("cmake@3.11.1", when='@2.3.1.3:', type='build')
-    depends_on("cmake@3.0.2:", when='@develop', type='build')
+    depends_on("cmake@3.0.2:", type='build')
 
     # Dependencies for openspeedshop that are common to all
     # the variants of the OpenSpeedShop build
     depends_on("libtool", type='build')
     depends_on("bison", type='build')
-    depends_on("flex", type='build')
+    depends_on("flex@2.6.1", type='build')
 
     # For binutils
     depends_on("binutils", when='@develop', type='build')
-    depends_on("binutils@2.29.1", when='@2.3.1.3:', type='build')
+    depends_on("binutils@2.29.1", when='@2.3.1.3:9999', type='build')
 
     depends_on("elf", type="link")
     depends_on("libdwarf")
@@ -132,59 +131,58 @@ class Openspeedshop(CMakePackage):
 
     # For boost
     depends_on("boost@1.50.0:", when='@develop')
-    depends_on("boost@1.66.0", when='@2.3.1.3:')
+    depends_on("boost@1.66.0", when='@2.3.1.3:9999')
 
-    depends_on("dyninst@9.3.2:", when='@develop')
-    depends_on("dyninst@9.3.2", when='@2.3.1.3:')
+    depends_on("dyninst@develop", when='@develop')
+    depends_on("dyninst@9.3.2", when='@2.3.1.3:9999')
 
     depends_on("python", when='@develop')
-    depends_on("python@2.7.14", when='@2.3.1.3:')
+    depends_on("python@2.7.14", when='@2.3.1.3:9999')
 
-    depends_on("libxml2", when='@develop')
-    depends_on("libxml2@2.9.4", when='@2.3.1.3:')
+    depends_on("libxml2")
 
     depends_on("qt@3.3.8b+krellpatch", when='gui=qt3')
 
     # Dependencies for the openspeedshop cbtf packages.
     depends_on("cbtf@develop", when='@develop')
-    depends_on("cbtf@1.9.1.0:", when='@2.3.1.3:')
+    depends_on("cbtf@1.9.1.0:9999", when='@2.3.1.3:9999')
 
     depends_on("cbtf-krell@develop", when='@develop')
-    depends_on("cbtf-krell@1.9.1.0:", when='@2.3.1.3:')
+    depends_on("cbtf-krell@1.9.1.0:9999", when='@2.3.1.3:9999')
 
     depends_on('cbtf-krell@develop+crayfe', when='@develop+crayfe')
-    depends_on('cbtf-krell@1.9.1.0:+crayfe', when='@2.3.1.3:+crayfe')
+    depends_on('cbtf-krell@1.9.1.0:9999+crayfe', when='@2.3.1.3:9999+crayfe')
 
     depends_on('cbtf-krell@develop+cti', when='@develop+cti')
-    depends_on('cbtf-krell@1.9.1.0:+cti', when='@2.3.1.3:+cti')
+    depends_on('cbtf-krell@1.9.1.0:9999+cti', when='@2.3.1.3:9999+cti')
 
     depends_on('cbtf-krell@develop+mpich', when='@develop+mpich')
-    depends_on('cbtf-krell@1.9.1.0:+mpich', when='@2.3.1.3:+mpich')
+    depends_on('cbtf-krell@1.9.1.0:9999+mpich', when='@2.3.1.3:9999+mpich')
 
     depends_on('cbtf-krell@develop+mpich2', when='@develop+mpich2')
-    depends_on('cbtf-krell@1.9.1.0:+mpich2', when='@2.3.1.3:+mpich2')
+    depends_on('cbtf-krell@1.9.1.0:9999+mpich2', when='@2.3.1.3:9999+mpich2')
 
     depends_on('cbtf-krell@develop+mpt', when='@develop+mpt')
-    depends_on('cbtf-krell@1.9.1.0:+mpt', when='@2.3.1.3:+mpt')
+    depends_on('cbtf-krell@1.9.1.0:9999+mpt', when='@2.3.1.3:9999+mpt')
 
     depends_on('cbtf-krell@develop+mvapich', when='@develop+mvapich')
-    depends_on('cbtf-krell@1.9.1.0:+mvapich', when='@2.3.1.3:+mvapich')
+    depends_on('cbtf-krell@1.9.1.0:9999+mvapich', when='@2.3.1.3:9999+mvapich')
 
     depends_on('cbtf-krell@develop+mvapich2', when='@develop+mvapich2')
-    depends_on('cbtf-krell@1.9.1.0:+mvapich2', when='@2.3.1.3:+mvapich2')
+    depends_on('cbtf-krell@1.9.1.0:9999+mvapich2', when='@2.3.1.3:9999+mvapich2')
 
     depends_on('cbtf-krell@develop+openmpi', when='@develop+openmpi')
-    depends_on('cbtf-krell@1.9.1.0:+openmpi', when='@2.3.1.3:+openmpi')
+    depends_on('cbtf-krell@1.9.1.0:9999+openmpi', when='@2.3.1.3:9999+openmpi')
 
     depends_on("cbtf-argonavis@develop", when='@develop+cuda')
-    depends_on("cbtf-argonavis@1.9.1.0:", when='@2.3.1.3:+cuda')
+    depends_on("cbtf-argonavis@1.9.1.0:9999", when='@2.3.1.3:9999+cuda')
 
     # For MRNet
     depends_on("mrnet@5.0.1-3:+cti", when='@develop+cti')
     depends_on("mrnet@5.0.1-3:+lwthreads", when='@develop')
 
-    depends_on("mrnet@5.0.1-3:+cti", when='@2.3.1.3:+cti')
-    depends_on("mrnet@5.0.1-3:+lwthreads", when='@2.3.1.3:')
+    depends_on("mrnet@5.0.1-3:+cti", when='@2.3.1.3:9999+cti')
+    depends_on("mrnet@5.0.1-3:+lwthreads", when='@2.3.1.3:9999')
 
     parallel = False
 


### PR DESCRIPTION
Add changes to the Krell packages with version updates and ranges for  the latest release.   Change the ranges on versions, so the packages don't have to change as much when a new release is made.  Also, the changes allows the development version of OpenSpeedShop to use the develop version of Dyninst.