### PR TITLE
New environment manipulation functions for system path deprioritization and duplicate removal.

### DIFF
--- a/lib/spack/spack/test/util/environment.py
+++ b/lib/spack/spack/test/util/environment.py
@@ -1,0 +1,106 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""Test Spack's environment utility functions."""
+import os
+import spack.util.environment as envutil
+
+
+def test_is_system_path():
+    assert(envutil.is_system_path('/usr/bin'))
+    assert(not envutil.is_system_path('/nonsense_path/bin'))
+
+
+test_paths = ['/usr/bin',
+              '/nonsense_path/lib',
+              '/usr/local/lib',
+              '/bin',
+              '/nonsense_path/extra/bin',
+              '/usr/lib64']
+
+
+def test_filter_system_paths():
+    expected = [p for p in test_paths if p.startswith('/nonsense_path')]
+    filtered = envutil.filter_system_paths(test_paths)
+    assert(expected == filtered)
+
+
+def test_system_paths():
+    expected = [p for p in test_paths if not p.startswith('/nonsense_path')]
+    filtered = envutil.system_paths(test_paths)
+    assert(expected == filtered)
+
+
+def deprioritize_system_paths():
+    expected = [p for p in test_paths if p.startswith('/nonsense_path')]
+    expected.extend([p for p in test_paths
+                     if not p.startswith('/nonsense_path')])
+    filtered = envutil.deprioritize_system_paths(test_paths)
+    assert(expected == filtered)
+
+
+def test_prune_duplicate_paths():
+    test_paths = ['/a/b', '/a/c', '/a/b', '/a/a', '/a/c', '/a/a/..']
+    expected = ['/a/b', '/a/c', '/a/a', '/a/a/..']
+    assert(expected == envutil.prune_duplicate_paths(test_paths))
+
+
+def test_get_path():
+    os.environ['TEST_ENV_VAR'] = '/a:/b:/c/d'
+    expected = ['/a', '/b', '/c/d']
+    assert(envutil.get_path('TEST_ENV_VAR') == expected)
+    del os.environ['TEST_ENV_VAR']
+
+
+def test_env_flag():
+    assert(not envutil.env_flag('TEST_NO_ENV_VAR'))
+    os.environ['TEST_ENV_VAR'] = '1'
+    assert(envutil.env_flag('TEST_ENV_VAR'))
+    os.environ['TEST_ENV_VAR'] = 'TRUE'
+    assert(envutil.env_flag('TEST_ENV_VAR'))
+    os.environ['TEST_ENV_VAR'] = 'True'
+    assert(envutil.env_flag('TEST_ENV_VAR'))
+    os.environ['TEST_ENV_VAR'] = 'TRue'
+    assert(envutil.env_flag('TEST_ENV_VAR'))
+    os.environ['TEST_ENV_VAR'] = 'true'
+    assert(envutil.env_flag('TEST_ENV_VAR'))
+    os.environ['TEST_ENV_VAR'] = '27'
+    assert(not envutil.env_flag('TEST_ENV_VAR'))
+    os.environ['TEST_ENV_VAR'] = '-2.3'
+    assert(not envutil.env_flag('TEST_ENV_VAR'))
+    os.environ['TEST_ENV_VAR'] = '0'
+    assert(not envutil.env_flag('TEST_ENV_VAR'))
+    os.environ['TEST_ENV_VAR'] = 'False'
+    assert(not envutil.env_flag('TEST_ENV_VAR'))
+    os.environ['TEST_ENV_VAR'] = 'false'
+    assert(not envutil.env_flag('TEST_ENV_VAR'))
+    os.environ['TEST_ENV_VAR'] = 'garbage'
+    assert(not envutil.env_flag('TEST_ENV_VAR'))
+    del os.environ['TEST_ENV_VAR']
+
+
+def test_path_set():
+    envutil.path_set('TEST_ENV_VAR', ['/a', '/a/b', '/a/a'])
+    assert(os.environ['TEST_ENV_VAR'] == '/a:/a/b:/a/a')
+    del os.environ['TEST_ENV_VAR']
+
+
+def test_path_put_first():
+    envutil.path_set('TEST_ENV_VAR', test_paths)
+    expected = ['/usr/bin', '/new_nonsense_path/a/b']
+    expected.extend([p for p in test_paths if p != '/usr/bin'])
+    envutil.path_put_first('TEST_ENV_VAR', expected)
+    assert(envutil.get_path('TEST_ENV_VAR') == expected)
+
+
+def test_dump_environment(tmpdir):
+    test_paths = '/a:/b/x:/b/c'
+    os.environ['TEST_ENV_VAR'] = test_paths
+    dumpfile_path = str(tmpdir.join('envdump.txt'))
+    envutil.dump_environment(dumpfile_path)
+    with open(dumpfile_path, 'r') as dumpfile:
+        assert('TEST_ENV_VAR={0}; export TEST_ENV_VAR\n'.format(test_paths)
+               in list(dumpfile))
+    del os.environ['TEST_ENV_VAR']

--- a/lib/spack/spack/test/util/environment.py
+++ b/lib/spack/spack/test/util/environment.py
@@ -27,12 +27,6 @@ def test_filter_system_paths():
     assert(expected == filtered)
 
 
-def test_system_paths():
-    expected = [p for p in test_paths if not p.startswith('/nonsense_path')]
-    filtered = envutil.system_paths(test_paths)
-    assert(expected == filtered)
-
-
 def deprioritize_system_paths():
     expected = [p for p in test_paths if p.startswith('/nonsense_path')]
     expected.extend([p for p in test_paths

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -262,24 +262,24 @@ class RemovePath(NameValueModifier):
 
 class DeprioritizeSystemPaths(NameModifier):
 
-    def execute(self):
-        environment_value = os.environ.get(self.name, '')
+    def execute(self, env):
+        environment_value = env.get(self.name, '')
         directories = environment_value.split(
             self.separator) if environment_value else []
         directories = deprioritize_system_paths([os.path.normpath(x)
                                                  for x in directories])
-        os.environ[self.name] = self.separator.join(directories)
+        env[self.name] = self.separator.join(directories)
 
 
 class PruneDuplicatePaths(NameModifier):
 
-    def execute(self):
-        environment_value = os.environ.get(self.name, '')
+    def execute(self, env):
+        environment_value = env.get(self.name, '')
         directories = environment_value.split(
             self.separator) if environment_value else []
         directories = prune_duplicate_paths([os.path.normpath(x)
                                              for x in directories])
-        os.environ[self.name] = self.separator.join(directories)
+        env[self.name] = self.separator.join(directories)
 
 
 class EnvironmentModifications(object):

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -18,12 +18,8 @@ import llnl.util.tty as tty
 
 from llnl.util.lang import dedupe
 
-import itertools
-from six import iteritems
-from six.moves import zip as iterzip
 from six.moves import shlex_quote as cmd_quote
 from six.moves import cPickle
-from operator import itemgetter
 
 system_paths = ['/', '/usr', '/usr/local']
 suffixes = ['bin', 'bin64', 'include', 'lib', 'lib64']
@@ -61,28 +57,16 @@ def filter_system_paths(paths):
     return [p for p in paths if not is_system_path(p)]
 
 
-def system_paths(paths):
-    """Return only paths that are system paths."""
-    return [p for p in paths if is_system_path(p)]
-
-
 def deprioritize_system_paths(paths):
     """Put system paths at the end of paths, otherwise preserving order."""
-    return filter_system_paths(paths) + system_paths(paths)
-
-
-# Necessary to accommodate Python 2.6. When support is dropped, replace
-# _count with with itertools.count().
-def _count(start=0, step=1):
-    for i in itertools.count():
-        yield start + i * step
+    filtered_paths = filter_system_paths(paths)
+    fp = set(filtered_paths)
+    return filtered_paths + [p for p in paths if p not in fp]
 
 
 def prune_duplicate_paths(paths):
     """Returns the paths with duplicates removed, order preserved."""
-    return [key for key, value in
-            sorted(iteritems(dict(iterzip(reversed(paths), _count(0, -1)))),
-                   key=itemgetter(1))]
+    return list(dedupe(paths))
 
 
 def get_path(name):
@@ -123,11 +107,13 @@ bash_function_finder = re.compile(r'BASH_FUNC_(.*?)\(\)')
 
 
 def env_var_to_source_line(var, val):
-    source_line = 'function {fname}{decl}; export -f {fname}'.\
-                  format(fname=bash_function_finder.sub(r'\1', var),
-                         decl=val) if var.startswith('BASH_FUNC') else \
-                  '{var}={val}; export {var}'.format(var=var,
-                                                     val=cmd_quote(val))
+    if var.startswith('BASH_FUNC'):
+        source_line = 'function {fname}{decl}; export -f {fname}'.\
+                      format(fname=bash_function_finder.sub(r'\1', var),
+                             decl=val)
+    else:
+        source_line = '{var}={val}; export {var}'.format(var=var,
+                                                         val=cmd_quote(val))
     return source_line
 
 


### PR DESCRIPTION
New functions `deprioritize_system_paths()` and `prune_duplicate_paths()` have been added to `util/environment.py` with tests, and functionality to use them from `EnvironmentModifications` has been added, along with tests. In addition, all functions in `util/environment.py` have tests in `test/util/environment.py` and one now-redundant test in `test/environment.py` has been removed in favor of an equivalent test in the more appropriate `test/util/environment.py`.

The new functions are particularly useful in recipes using `PATH`-like variables where entries in `packages.yaml` might cause issues by putting (_e.g._) `/usr/include` ahead of paths from specific spack-installed packages.

`deprioritize_system_paths(name)` will move identified system paths to the end of the `name` `PATH`-like variable (preserving the original relative order of same), while `prune_duplicate_paths(name)` will remove the second and subsequent mentions of any given path.
