### PR TITLE
[WIP] mfem: if using clang, link to llvm libunwind

### DIFF
--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -196,7 +196,15 @@ class Mfem(Package):
     #            when='+petsc')
     depends_on('mpfr', when='+mpfr')
     depends_on('netcdf', when='+netcdf')
-    depends_on('libunwind', when='+libunwind')
+
+    # What I really want to say here is that MFEM should depend on
+    # libunwind when '+libunwind' and the compiler isn't clang; LLVM
+    # includes its own libunwind, and the non-LLVM libunwind
+    # won't build on my Mac with clang@8.1.0-apple or clang@6.0.0
+    depends_on('libunwind', when='+libunwind %gcc')
+    depends_on('libunwind', when='+libunwind %pgi')
+    depends_on('libunwind', when='+libunwind %intel')
+
     depends_on('zlib', when='+gzstream')
     depends_on('gnutls', when='+gnutls')
     depends_on('conduit@0.3.1:', when='+conduit')
@@ -373,15 +381,16 @@ class Mfem(Package):
                 ld_flags_from_dirs([spec['gnutls'].prefix.lib], ['gnutls'])]
 
         if '+libunwind' in spec:
-            libunwind = spec['libunwind']
-            headers = find_headers('libunwind', libunwind.prefix.include)
-            headers.add_macro('-g')
-            libs = find_optional_library('libunwind', libunwind.prefix)
-            # When mfem uses libunwind, it also needs 'libdl'.
-            libs += LibraryList(find_system_libraries('libdl'))
-            options += [
-                'LIBUNWIND_OPT=%s' % headers.cpp_flags,
-                'LIBUNWIND_LIB=%s' % ld_flags_from_LibraryList(libs)]
+            if '%clang' not in spec:
+                libunwind = spec['libunwind']
+                headers = find_headers('libunwind', libunwind.prefix.include)
+                headers.add_macro('-g')
+                libs = find_optional_library('libunwind', libunwind.prefix)
+                # When mfem uses libunwind, it also needs 'libdl'.
+                libs += LibraryList(find_system_libraries('libdl'))
+                options += [
+                    'LIBUNWIND_OPT=%s' % headers.cpp_flags,
+                    'LIBUNWIND_LIB=%s' % ld_flags_from_LibraryList(libs)]
 
         if '+openmp' in spec:
             options += ['OPENMP_OPT=%s' % self.compiler.openmp_flag]


### PR DESCRIPTION
This patch is intended to build MFEM with LLVM's libunwind if the spec contains `+libunwind%clang`; however, I can't find a succinct way of doing that here. Lines 204-206 are supposed to enumerate all compilers other than clang, but I'm sure I'm missing XL, and possibly other compilers; this partial fix is temporary, mainly to PR a patch that almost does what it's supposed to. I'm also pretty sure I need to add a `-g` flag to the compiler commands for `mfem+libunwind%clang`; for now, I've built locally with `mfem+debug+libunwind%clang` because I need the debug info anyway, and I think bigger issues with this PR need to be addressed first, before adding flags.

A related PR is #7263; also see the comment at https://github.com/spack/spack/pull/7263#issuecomment-367258043. I don't think forcing users to add an external `libunwind` using system paths will be any easier, because:

- LLVM's libunwind is definitely different than the https://savannah.nongnu.org/projects/libunwind/ version of libunwind currently built by spack's libunwind package. Although they have a common ABI and some functions that form a common API (see http://lists.llvm.org/pipermail/cfe-dev/2016-September/050649.html), the libraries provide different symbols and the non-GNU version has more features

- The path of the LLVM libunwind header looks like `${LLVM_PREFIX}/lib/clang/${VERSION}/include/unwind.h` (e.g., `/usr/local/opt/llvm/lib/clang/6.0.0/include/unwind.h`), so listing a prefix isn't necessarily helpful for non-Apple LLVM installs. Apple installs have a simpler path (`/usr/include/unwind.h`), and libraries for Apple and non-Apple LLVM installs are in the usual directory (i.e., `$PREFIX/lib`)

- If a user installs LLVM via spack, they might want to use the accompanying libunwind, but it's not clear to me how to encode that information in a `packages.yaml` programmatically; maybe it's worth putting a `provides('llvm-libunwind')` directive in the LLVM spack package

Suggestions to make adding this feature more workable are welcome; I will do what I can to address them.