### PR TITLE
Actually allow parallel test execution under CMake.

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -60,6 +60,7 @@ import traceback
 import types
 from six import iteritems
 from six import StringIO
+from six import string_types
 
 import llnl.util.tty as tty
 from llnl.util.tty.color import cescape, colorize
@@ -114,7 +115,11 @@ class MakeExecutable(Executable):
        specify parallel or not on a per-invocation basis.  Using
        'parallel' as a kwarg will override whatever the package's
        global setting is, so you can either default to true or false
-       and override particular calls.
+       and override particular calls. Specifying a value for 'jobs_arg'
+       as a kwarg will use that in place of the default '-j{0}' for
+       specifying the desired level of parallelism (specify multiple arguments
+       as a list or tuple). Specifying 'jobs_env' will name an environment
+       variable which will be set to the parallelism level.
 
        Note that if the SPACK_NO_PARALLEL_MAKE env var is set it overrides
        everything.
@@ -129,8 +134,16 @@ class MakeExecutable(Executable):
         parallel = not disable and kwargs.get('parallel', self.jobs > 1)
 
         if parallel:
-            jobs = "-j%d" % self.jobs
-            args = (jobs,) + args
+            jobs = kwargs.pop('jobs_arg', '-j{0}')
+            jobs = (jobs,) if isinstance(jobs, string_types) else jobs
+            args = tuple([j.format(self.jobs) for j in jobs]) + args
+            jobs_env = kwargs.pop('jobs_env', None)
+            if jobs_env:
+                # Caller wants us to set an environment variable to
+                # control the parallelism.
+                make_env = kwargs.pop('env', os.environ).copy()
+                make_env[jobs_env] = str(self.jobs)
+                kwargs['env'] = make_env
 
         return super(MakeExecutable, self).__call__(*args, **kwargs)
 
@@ -388,7 +401,7 @@ def set_module_variables_for_package(pkg, module):
 
     m.meson = Executable('meson')
     m.cmake = Executable('cmake')
-    m.ctest = Executable('ctest')
+    m.ctest = MakeExecutable('ctest', jobs)
 
     # Standard CMake arguments
     m.std_cmake_args = spack.build_systems.cmake.CMakePackage._std_args(pkg)

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -255,10 +255,12 @@ class CMakePackage(PackageBase):
         """
         with working_dir(self.build_directory):
             if self.generator == 'Unix Makefiles':
-                self._if_make_target_execute('test')
+                self._if_make_target_execute('test',
+                                             jobs_env='CTEST_PARALLEL_LEVEL')
                 self._if_make_target_execute('check')
             elif self.generator == 'Ninja':
-                self._if_ninja_target_execute('test')
+                self._if_ninja_target_execute('test',
+                                              jobs_env='CTEST_PARALLEL_LEVEL')
                 self._if_ninja_target_execute('check')
 
     # Check that self.prefix is there after installation

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1191,7 +1191,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
 
         return True
 
-    def _if_make_target_execute(self, target):
+    def _if_make_target_execute(self, target, *args, **kwargs):
         """Runs ``make target`` if 'target' is a valid target in the Makefile.
 
         Parameters:
@@ -1199,7 +1199,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         """
         if self._has_make_target(target):
             # Execute target
-            inspect.getmodule(self).make(target)
+            inspect.getmodule(self).make(target, *args, **kwargs)
 
     def _has_ninja_target(self, target):
         """Checks to see if 'target' is a valid target in a Ninja build script.
@@ -1231,7 +1231,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
 
         return True
 
-    def _if_ninja_target_execute(self, target):
+    def _if_ninja_target_execute(self, target, *args, **kwargs):
         """Runs ``ninja target`` if 'target' is a valid target in the Ninja
         build script.
 
@@ -1240,7 +1240,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         """
         if self._has_ninja_target(target):
             # Execute target
-            inspect.getmodule(self).ninja(target)
+            inspect.getmodule(self).ninja(target, *args, **kwargs)
 
     def _get_needed_resources(self):
         resources = []

--- a/lib/spack/spack/test/make_executable.py
+++ b/lib/spack/spack/test/make_executable.py
@@ -122,3 +122,10 @@ class MakeExecutableTest(unittest.TestCase):
                               output=str).strip(), '-j8 install')
 
         del os.environ['SPACK_NO_PARALLEL_MAKE']
+
+    def test_make_jobs_env(self):
+        make = MakeExecutable('make', 8)
+        dump_env = {}
+        self.assertEqual(make(output=str, jobs_env='MAKE_PARALLELISM',
+                              _dump_env=dump_env).strip(), '-j8')
+        self.assertEqual(dump_env['MAKE_PARALLELISM'], '8')

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -93,7 +93,11 @@ class Executable(object):
             *args (str): Command-line arguments to the executable to run
 
         Keyword Arguments:
+            _dump_env (dict): Dict to be set to the environment actually
+                used (envisaged for testing purposes only)
             env (dict): The environment to run the executable with
+            extra_env (dict): Extra items to add to the environment
+                (neither requires nor precludes env)
             fail_on_error (bool): Raise an exception if the subprocess returns
                 an error. Default is True. The return code is available as
                 ``exe.returncode``
@@ -115,6 +119,7 @@ class Executable(object):
           for ``input``
 
         By default, the subprocess inherits the parent's file descriptors.
+
         """
         # Environment
         env_arg = kwargs.get('env', None)
@@ -124,6 +129,10 @@ class Executable(object):
         else:
             env = self.default_env.copy()
             env.update(env_arg)
+        env.update(kwargs.get('extra_env', {}))
+        if '_dump_env' in kwargs:
+            kwargs['_dump_env'].clear()
+            kwargs['_dump_env'].update(env)
 
         fail_on_error = kwargs.pop('fail_on_error', True)
         ignore_errors = kwargs.pop('ignore_errors', ())


### PR DESCRIPTION
Closes #4503 (implementing the spirit of the request&mdash;parallelism for CMake tests&mdash;rather than the spirit&mdash;using the `ctest` command itself).

The existing implementation of the test target when building a CMake package using the Makefiles generator invokes `make test`, which does not honor the the `-j` option for parallelism. One can either set an environment variable ~~(difficult to handle the overrides currently available)~~ or one can invoke `ctest` instead of `make test`. This implementation (now) does the ~~latter~~ former in order to accommodate packages (see below) for which `make test` runs a set of tests which is distinct from that run by `ctest`.

[Description has been edited from the original due to the evolution of implementation to satisfy issues raised), with some phrases struck through to suggest the original meaning. See the editing history for full details.