### PR TITLE
openssl: add new version 1.0.2o

### DIFF
--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -48,7 +48,8 @@ class Openssl(Package):
     version('1.1.0c', '601e8191f72b18192a937ecf1a800f3f')
     # Note: Version 1.0.2 is the "long-term support" version that will
     # remain supported until 2019.
-    version('1.0.2n', '13bdc1b1d1ff39b6fd42a255e74676a4', preferred=True)
+    version('1.0.2o', '44279b8557c3247cbe324e2322ecd114', preferred=True)
+    version('1.0.2n', '13bdc1b1d1ff39b6fd42a255e74676a4')
     version('1.0.2m', '10e9e37f492094b9ef296f68f24a7666')
     version('1.0.2k', 'f965fc0bf01bf882b31314b61391ae65')
     version('1.0.2j', '96322138f0b69e61b7212bc53d5e912b')


### PR DESCRIPTION
A new version of openssl was released this week.