### PR TITLE
Percept requires googletest to be static.

### DIFF
--- a/var/spack/repos/builtin/packages/percept/package.py
+++ b/var/spack/repos/builtin/packages/percept/package.py
@@ -38,7 +38,7 @@ class Percept(CMakePackage):
     version('develop',
             git='https://github.com/PerceptTools/percept.git', branch='master')
 
-    depends_on('googletest')
+    depends_on('googletest~shared')
     depends_on('opennurbs@percept')
     depends_on('boost+graph+mpi')
     depends_on('yaml-cpp+pic~shared@0.5.3:')


### PR DESCRIPTION
I originally wrote the percept package file and just noticed that it searches only for a static googletest library.