### PR TITLE
Add tags for ECP applications that are in Spack.

### DIFF
--- a/var/spack/repos/builtin/packages/chombo/package.py
+++ b/var/spack/repos/builtin/packages/chombo/package.py
@@ -36,6 +36,8 @@ class Chombo(MakefilePackage):
     homepage = "https://commons.lbl.gov/display/chombo"
     url      = "http://bitbucket.org/drhansj/chombo-xsdk.git"
 
+    tags = ['ecp', 'ecp-apps']
+
     # Use whatever path Brian V. and Terry L. agreed upon, but preserve version
     version('3.2', git='http://bitbucket.org/drhansj/chombo-xsdk.git', commit='71d856c')
     version('develop', git='http://bitbucket.org/drhansj/chombo-xsdk.git', tag='master')

--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -36,6 +36,8 @@ class Lammps(CMakePackage):
     homepage = "http://lammps.sandia.gov/"
     url      = "https://github.com/lammps/lammps/archive/patch_1Sep2017.tar.gz"
 
+    tags = ['ecp', 'ecp-apps']
+
     version('20180316', '25bad35679583e0dd8cb8753665bb84b')
     version('20180222', '4d0513e3183bd57721814d217fdaf957')
     version('20170922', '4306071f919ec7e759bda195c26cfd9a')

--- a/var/spack/repos/builtin/packages/latte/package.py
+++ b/var/spack/repos/builtin/packages/latte/package.py
@@ -32,6 +32,8 @@ class Latte(CMakePackage):
     homepage = "https://github.com/lanl/latte"
     url      = "https://github.com/lanl/latte/tarball/v1.0"
 
+    tags = ['ecp', 'ecp-apps']
+
     version('1.1.1', 'ab11867ba6235189681cf6e50a50cc50')
     version('1.0.1', 'd0b99edbcf7a19abe0a68a192d6f6234')
     version('develop', git='https://github.com/lanl/latte', branch='master')

--- a/var/spack/repos/builtin/packages/nalu/package.py
+++ b/var/spack/repos/builtin/packages/nalu/package.py
@@ -34,6 +34,8 @@ class Nalu(CMakePackage):
     homepage = "https://github.com/NaluCFD/Nalu"
     url      = "https://github.com/NaluCFD/Nalu.git"
 
+    tags = ['ecp', 'ecp-apps']
+
     variant('openfast', default=False,
             description='Compile with OpenFAST support')
     variant('tioga', default=False,

--- a/var/spack/repos/builtin/packages/nek5000/package.py
+++ b/var/spack/repos/builtin/packages/nek5000/package.py
@@ -45,7 +45,7 @@ class Nek5000(Package):
     url      = "https://github.com/Nek5000/Nek5000"
 
     tags = ['cfd', 'flow', 'hpc', 'solver', 'navier-stokes',
-            'spectral-elements', 'fluid']
+            'spectral-elements', 'fluid', 'ecp', 'ecp-apps']
 
     version('17.0', '6a13bfad2ce023897010dd88f54a0a87',
             url="https://github.com/Nek5000/Nek5000/releases/download/"

--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -33,6 +33,8 @@ class Nwchem(Package):
     homepage = "http://www.nwchem-sw.org"
     url      = "http://www.nwchem-sw.org/images/Nwchem-6.6.revision27746-src.2015-10-20.tar.gz"
 
+    tags = ['ecp', 'ecp-apps']
+
     version('6.8', '50b18116319f4c15d1cb7eaa1b433006',
             url='https://github.com/nwchemgit/nwchem/archive/v6.8-release.tar.gz')
     version('6.6', 'c581001c004ea5e5dfacb783385825e3',

--- a/var/spack/repos/builtin/packages/openmc/package.py
+++ b/var/spack/repos/builtin/packages/openmc/package.py
@@ -36,6 +36,8 @@ class Openmc(MakefilePackage):
     homepage = "https://github.com/ANL-CESAR/"
     url = "https://github.com/ANL-CESAR/openmc.git"
 
+    tags = ['ecp', 'ecp-apps']
+
     version('develop', git='https://github.com/ANL-CESAR/openmc.git')
 
     build_directory = 'src'

--- a/var/spack/repos/builtin/packages/parsplice/package.py
+++ b/var/spack/repos/builtin/packages/parsplice/package.py
@@ -32,6 +32,8 @@ class Parsplice(CMakePackage):
     homepage = "https://gitlab.com/exaalt/parsplice"
     url      = "https://gitlab.com/api/v4/projects/exaalt%2Fparsplice/repository/archive.tar.gz?sha=v1.1"
 
+    tags = ['ecp', 'ecp-apps']
+
     version('1.1', '3a72340d49d731a076e8942f2ae2f4e9')
     version('develop', git='https://gitlab.com/exaalt/parsplice', branch='master')
 

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -34,6 +34,8 @@ class Qmcpack(CMakePackage):
     homepage = "http://www.qmcpack.org/"
     url      = "https://github.com/QMCPACK/qmcpack.git"
 
+    tags = ['ecp', 'ecp-apps']
+
     # This download method is untrusted, and is not recommended by the
     # Spack manual. However, it is easier to maintain because github hashes
     # can occasionally change.


### PR DESCRIPTION
- All now have both `ecp` and `ecp-apps` tags.
- ECP ST projects will eventually also have `ecp` and `ecp-software` tags.