### PR TITLE
Adding Parallel NetCDF as explicit dependency to Trilinos

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -280,6 +280,7 @@ class Trilinos(CMakePackage):
     depends_on('mpi')
     depends_on('netcdf+mpi', when="~pnetcdf")
     depends_on('netcdf+mpi+parallel-netcdf', when="+pnetcdf@master,12.12.1:")
+    depends_on('parallel-netcdf', when="+pnetcdf@master,12.12.1:")
     depends_on('parmetis', when='+metis')
     depends_on('cgns', when='+cgns')
     # Trilinos' Tribits config system is limited which makes it very tricky to


### PR DESCRIPTION
I have found that if NetCDF is specified as an external, I get concretization errors with `trilinos+pnetcdf`. This is because `parallel-netcdf` is only satisfied as a dependency through `netcdf+parallel-netcdf` when in fact, `parallel-netcdf` is a direct dependency of `trilinos+pnetcdf`. This makes `parallel-netcdf` a direct dependency of Trilinos when `trilinos+pnetcdf`.