### PR TITLE
Allow docs to be built with Sphinx 1.7.1+

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -42,7 +42,13 @@ import re
 import shutil
 import subprocess
 from glob import glob
-from sphinx.apidoc import main as sphinx_apidoc
+
+# Since Sphinx 1.7, sphinx.apidoc has been moved to sphinx.ext.apidoc
+# sphinx.apidoc is deprecated and will be removed in Sphinx 2.0
+try:
+    from sphinx.ext.apidoc import main as sphinx_apidoc
+except ImportError:
+    from sphinx.apidoc import main as sphinx_apidoc
 
 # -- Spack customizations -----------------------------------------------------
 
@@ -108,8 +114,8 @@ apidoc_args = [
     '--no-toc',        # Don't create a table of contents file
     '--output-dir=.',  # Directory to place all output
 ]
-sphinx_apidoc(argv=apidoc_args + ['../spack'])
-sphinx_apidoc(argv=apidoc_args + ['../llnl'])
+sphinx_apidoc(apidoc_args + ['../spack'])
+sphinx_apidoc(apidoc_args + ['../llnl'])
 
 # Enable todo items
 todo_include_todos = True

--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -108,8 +108,8 @@ apidoc_args = [
     '--no-toc',        # Don't create a table of contents file
     '--output-dir=.',  # Directory to place all output
 ]
-sphinx_apidoc(apidoc_args + ['../spack'])
-sphinx_apidoc(apidoc_args + ['../llnl'])
+sphinx_apidoc(argv=apidoc_args + ['../spack'])
+sphinx_apidoc(argv=apidoc_args + ['../llnl'])
 
 # Enable todo items
 todo_include_todos = True


### PR DESCRIPTION
Fixes an issue reported by @twang15 in #8491.

### Before

If you try to build Spack's documentation with Sphinx 1.7.1+, you encounter the following error message:
```
$ make
sphinx-build -b html -d _build/doctrees  -E . _build/html
Running Sphinx v1.7.5
usage: sphinx-build [OPTIONS] -o <OUTPUT_PATH> <MODULE_PATH> [EXCLUDE_PATTERN, ...]
sphinx-build: error: argument -d/--maxdepth: invalid int value: '_build/doctrees'

Configuration error:
The configuration file (or one of the modules it imports) called sys.exit()
make: *** [html] Error 2
```
This bug was introduced in https://github.com/sphinx-doc/sphinx/pull/4624, which first appears in Sphinx 1.7.1. See https://github.com/sphinx-doc/sphinx/issues/5104 for the nitty-gritty details.

The reason no one has noticed it until now is that we lock down our version of Sphinx to 1.7.0 for the documentation tests.

An alternative fix would be to replace `sphinx.apidoc.main` with `sphinx.ext.apidoc.main`. This solution was not chosen because `sphinx.ext.apidoc` did not exist before 1.7.0. This solution _should_ work for all versions of Sphinx, although testing with older versions would be greatly appreciated.