### PR TITLE
Adding patch to Opencv (3.3.0-3.4.1) for fixing conflict between CUDA and OpenCV dnn header file

### DIFF
--- a/var/spack/repos/builtin/packages/opencv/dnn_cuda.patch
+++ b/var/spack/repos/builtin/packages/opencv/dnn_cuda.patch
@@ -1,0 +1,44 @@
+--- opencv-3.4.1/modules/dnn/src/layers/mvn_layer.cpp.orig	2018-06-14 10:46:28.025703093 +0200
++++ opencv-3.4.1/modules/dnn/src/layers/mvn_layer.cpp	2018-06-14 10:40:56.266069123 +0200
+@@ -43,7 +43,7 @@
+ #include "../precomp.hpp"
+ #include "layers_common.hpp"
+ #include <opencv2/dnn/shape_utils.hpp>
+-#include "math_functions.hpp"
++#include "../ocl4dnn/include/math_functions.hpp"
+ #include "opencl_kernels_dnn.hpp"
+ 
+ namespace cv
+--- opencv-3.4.1/modules/dnn/src/ocl4dnn/src/math_functions.cpp.orig	2018-06-14 10:45:23.565162940 +0200
++++ opencv-3.4.1/modules/dnn/src/ocl4dnn/src/math_functions.cpp	2018-06-14 10:44:48.513412965 +0200
+@@ -42,7 +42,7 @@
+ 
+ #include "../../precomp.hpp"
+ #include "common.hpp"
+-#include "math_functions.hpp"
++#include "../include/math_functions.hpp"
+ #include <vector>
+ #include "opencl_kernels_dnn.hpp"
+ 
+--- opencv-3.4.1/modules/dnn/src/ocl4dnn/src/ocl4dnn_conv_spatial.cpp.orig	2018-06-14 10:42:11.319534007 +0200
++++ opencv-3.4.1/modules/dnn/src/ocl4dnn/src/ocl4dnn_conv_spatial.cpp	2018-06-14 10:42:52.988236879 +0200
+@@ -52,7 +52,7 @@
+ #include "common.hpp"
+ #include "ocl4dnn.hpp"
+ #include "opencl_kernels_dnn.hpp"
+-#include "math_functions.hpp"
++#include "../include/math_functions.hpp"
+ #include "default_kernel_config.hpp"
+ 
+ #if defined WIN32 || defined _WIN32
+--- opencv-3.4.1/modules/dnn/src/ocl4dnn/src/ocl4dnn_inner_product.cpp.orig	2018-06-14 10:45:41.245036822 +0200
++++ opencv-3.4.1/modules/dnn/src/ocl4dnn/src/ocl4dnn_inner_product.cpp	2018-06-14 10:45:55.543934818 +0200
+@@ -43,7 +43,7 @@
+ #include "../../precomp.hpp"
+ #include "common.hpp"
+ #include "ocl4dnn.hpp"
+-#include "math_functions.hpp"
++#include "../include/math_functions.hpp"
+ 
+ #ifdef HAVE_OPENCL
+ namespace cv { namespace dnn { namespace ocl4dnn {

--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -105,6 +105,10 @@ class Opencv(CMakePackage):
     variant('vtk', default=True, description='Activates support for VTK')
     variant('zlib', default=True, description='Build zlib from source')
 
+    # Patch to fix conflict between CUDA and OpenCV 3.4.1 header file that have the same name.
+    # Problem is fixed in the current development branch of OpenCV. See #8461 for more information.
+    patch('dnn_cuda.patch', when='@3.4.1+cuda+dnn')
+
     depends_on('eigen~mpfr', when='+eigen', type='build')
 
     depends_on('zlib', when='+zlib')

--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -105,8 +105,9 @@ class Opencv(CMakePackage):
     variant('vtk', default=True, description='Activates support for VTK')
     variant('zlib', default=True, description='Build zlib from source')
 
-    # Patch to fix conflict between CUDA and OpenCV (reproduced with 3.3.0 and 3.4.1) header file that have the same name.
-    # Problem is fixed in the current development branch of OpenCV. See #8461 for more information.
+    # Patch to fix conflict between CUDA and OpenCV (reproduced with 3.3.0
+    # and 3.4.1) header file that have the same name.Problem is fixed in
+    # the current development branch of OpenCV. See #8461 for more information.
     patch('dnn_cuda.patch', when='@3.3.0:3.4.1+cuda+dnn')
 
     depends_on('eigen~mpfr', when='+eigen', type='build')

--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -105,9 +105,9 @@ class Opencv(CMakePackage):
     variant('vtk', default=True, description='Activates support for VTK')
     variant('zlib', default=True, description='Build zlib from source')
 
-    # Patch to fix conflict between CUDA and OpenCV 3.4.1 header file that have the same name.
+    # Patch to fix conflict between CUDA and OpenCV (reproduced with 3.3.0 and 3.4.1) header file that have the same name.
     # Problem is fixed in the current development branch of OpenCV. See #8461 for more information.
-    patch('dnn_cuda.patch', when='@3.4.1+cuda+dnn')
+    patch('dnn_cuda.patch', when='@3.3.0:3.4.1+cuda+dnn')
 
     depends_on('eigen~mpfr', when='+eigen', type='build')
 


### PR DESCRIPTION
Fixes #8461

When installing OpenCV 3.4.1 or older versions (I could reproduce the same behavior also with version 3.3.0) with +cuda and +dnn, then the compilation failed, because one of the header files from the OpenCV dnn module has the same name as a cuda header file and the cuda header file is included instead of the OpenCV one.

Issue #8461 contains more information on the problem.