### PR TITLE
Adding "dso" and "static" variants to the openmpi package and adding dependencies for lsf and slurm if schedulers variant is set

### DIFF
--- a/var/spack/repos/builtin/packages/lsf/package.py
+++ b/var/spack/repos/builtin/packages/lsf/package.py
@@ -39,4 +39,4 @@ class Lsf(Package):
     #     buildable: False
 
     def install(self, spec, prefix):
-        raise InstallError('IBM Plattform LSF is not installable; it is vendor supplied')
+        raise InstallError('IBM Platform LSF is not installable; it is vendor supplied')

--- a/var/spack/repos/builtin/packages/lsf/package.py
+++ b/var/spack/repos/builtin/packages/lsf/package.py
@@ -39,4 +39,4 @@ class Lsf(Package):
     #     buildable: False
 
     def install(self, spec, prefix):
-        raise InstallError('IBM Platform LSF is not installable; it is vendor supplied')
+        raise InstallError('LSF is not installable; it is vendor supplied')

--- a/var/spack/repos/builtin/packages/lsf/package.py
+++ b/var/spack/repos/builtin/packages/lsf/package.py
@@ -22,21 +22,6 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install lsf
-#
-# You can edit this file again by typing:
-#
-#     spack edit lsf
-#
-# See the Spack documentation for more information on packaging.
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
 from spack import *
 
 

--- a/var/spack/repos/builtin/packages/lsf/package.py
+++ b/var/spack/repos/builtin/packages/lsf/package.py
@@ -1,0 +1,57 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install lsf
+#
+# You can edit this file again by typing:
+#
+#     spack edit lsf
+#
+# See the Spack documentation for more information on packaging.
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+from spack import *
+
+
+class Lsf(Package):
+    """IBM Platform LSF is a batch scheduler for HPC environments"""
+
+    homepage = "https://www.ibm.com/ch-en/marketplace/hpc-workload-management"
+    url      = "https://www.ibm.com/ch-en/marketplace/hpc-workload-management"
+
+    # LSF needs to be added as an external package to SPACK. For this, the
+    # config file packages.yaml needs to be adjusted:
+    #   lsf:
+    #     paths:
+    #       lsf: path_to_the_LSF_directory
+    #     buildable: False
+
+    def install(self, spec, prefix):
+        raise InstallError('IBM Plattform LSF is not installable; it is vendor supplied')

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -342,11 +342,13 @@ class Openmpi(AutotoolsPackage):
         spec = self.spec
         config_args = ['--enable-shared']
 
-        # In DSO mode, OpenMPI is built with plugins, whereas all functions are in the main libraries, then DSO is disabled.
+        # In DSO mode, OpenMPI is built with plugins, whereas all
+        # functions are in the main libraries, then DSO is disabled.
         if not spec.satisfies('+dso'):
             config_args.extend(['--disable-mca-dso'])
 
-        # Enabling the build of static libraries automatically sets --disable-mca-dso, therefore +static conflicts with +dso
+        # Enabling the build of static libraries automatically sets
+        # --disable-mca-dso, therefore +static conflicts with +dso
         if spec.satisfies('+static'):
             config_args.extend(['--enable-static'])
 

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -242,6 +242,7 @@ class Openmpi(AutotoolsPackage):
     depends_on('ucx', when='fabrics=ucx')
     depends_on('libfabric', when='fabrics=libfabric')
     depends_on('lsf', when='schedulers=lsf')
+    depends_on('slurm', when='schedulers=slurm')
 
     conflicts('+cuda', when='@:1.6')  # CUDA support was added in 1.7
     conflicts('fabrics=psm2', when='@:1.8')  # PSM2 support was added in 1.10.0


### PR DESCRIPTION
Based on the discussion in #8445, I created this PR for:

- Making DSO the default build mode for OpenMPI (currently non-DSO is the default)
- Adding a variant for building static library instead of setting the option by default (this is required, as adding --enable-static automatically sets --disable-mca-dso, which leads to a non-DSO build, therefore users should be able to choose if static libraries are enabled or disabled)
- Adding a dependency for lsf, when schedulers=lsf is set
- Adding a dependency for slurm, when schedulers=slurm is set

I only added dependencies for slurm and lsf, as there is already a slurm package in SPACK, and I have created a non-buildable lsf package. If other users come up with other scheduler packages, then it would make to add more dependencies.