### PR TITLE
dealii: add msg= to conflicts statements

### DIFF
--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -164,26 +164,27 @@ class Dealii(CMakePackage, CudaPackage):
     for p in ['assimp', 'gmsh', 'nanoflann', 'scalapack', 'sundials',
               'adol-c']:
         conflicts('+{0}'.format(p), when='@:8.5.1',
-                  msg='Interface to {0} is supported starting from 9.0.0'
-                      ', please explicitly disable this variant '
+                  msg='The interface to {0} is supported from version 9.0.0 '
+                      'onwards. Please explicitly disable this variant '
                       'via ~{0}'.format(p))
 
     conflicts('+slepc', when='~petsc',
-              msg='It is not possible ot enable slepc interfaces '
+              msg='It is not possible to enable slepc interfaces '
                   'without petsc.')
 
     # interfaces added in 8.5.0:
     for p in ['gsl', 'python']:
         conflicts('+{0}'.format(p), when='@:8.4.2',
-                  msg='Interface to {0} is supported starting from 8.5.0'
-                      ', please explicitly disable this variant '
+                  msg='The interface to {0} is supported from version 8.5.0 '
+                      'onwards. Please explicitly disable this variant '
                       'via ~{0}'.format(p))
 
     # MPI requirements:
     for p in ['arpack', 'hdf5', 'netcdf', 'p4est', 'petsc', 'scalapack',
               'slepc', 'trilinos']:
         conflicts('+{0}'.format(p), when='~mpi',
-                  msg='Can not enable {0} without MPI'.format(p))
+                  msg='To enable {0} it is necessary to build deal.II with '
+                      'MPI support enabled.'.format(p))
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -155,21 +155,41 @@ class Dealii(CMakePackage, CudaPackage):
     depends_on('trilinos@master+amesos+aztec+epetra+ifpack+ml+muelu+rol+sacado+teuchos~hypre~amesos2~ifpack2~intrepid2~kokkos~tpetra~zoltan2', when='+trilinos+mpi+int64+cuda')
 
     # check that the combination of variants makes sense
-    conflicts('^openblas+ilp64', when='@:8.5.1')
-    conflicts('^intel-mkl+ilp64', when='@:8.5.1')
-    conflicts('^intel-parallel-studio+mkl+ilp64', when='@:8.5.1')
-    conflicts('+assimp', when='@:8.5.1')
-    conflicts('+gmsh', when='@:8.5.1')
-    conflicts('+nanoflann', when='@:8.5.1')
-    conflicts('+scalapack', when='@:8.5.1')
-    conflicts('+sundials', when='@:8.5.1')
-    conflicts('+adol-c', when='@:8.5.1')
+    conflicts('^openblas+ilp64', when='@:8.5.1',
+              msg='64bit BLAS is only supported from 9.0.0')
+    conflicts('^intel-mkl+ilp64', when='@:8.5.1',
+              msg='64bit BLAS is only supported from 9.0.0')
+    conflicts('^intel-parallel-studio+mkl+ilp64', when='@:8.5.1',
+              msg='64bit BLAS is only supported from 9.0.0')
+    conflicts('+assimp', when='@:8.5.1',
+              msg='Interface to assim is supported starting from 9.0.0'
+                  ', please explicitly disable this variant via ~assimp')
+    conflicts('+gmsh', when='@:8.5.1',
+              msg='Interface to gmsh is supported starting from 9.0.0'
+                  ', please explicitly disable this variant via ~gmsh')
+    conflicts('+nanoflann', when='@:8.5.1',
+              msg='Interface to gmsh is supported starting from 9.0.0'
+                  ', please explicitly disable this variant via ~nanoflann')
+    conflicts('+scalapack', when='@:8.5.1',
+              msg='Interface to gmsh is supported starting from 9.0.0'
+                  ', please explicitly disable this variant via ~scalapack')
+    conflicts('+sundials', when='@:8.5.1',
+              msg='Interface to gmsh is supported starting from 9.0.0'
+                  ', please explicitly disable this variant via ~sundials')
+    conflicts('+adol-c', when='@:8.5.1',
+              msg='Interface to gmsh is supported starting from 9.0.0'
+                  ', please explicitly disable this variant via ~adol-c')
     conflicts('+slepc', when='~petsc')
-    conflicts('+gsl',    when='@:8.4.2')
-    conflicts('+python', when='@:8.4.2')
+    conflicts('+gsl',    when='@:8.4.2',
+              msg='Interface to gsl is supported starting from 8.5.0'
+                  ', please explicitly disable this variant via ~gsl')
+    conflicts('+python', when='@:8.4.2',
+              msg='Interface to python is supported starting from 8.5.0'
+                  ', please explicitly disable this variant via ~python')
     for p in ['+arpack', '+hdf5', '+netcdf', '+p4est', '+petsc', '+scalapack',
               '+slepc', '+trilinos']:
-        conflicts(p, when='~mpi')
+        conflicts(p, when='~mpi',
+                  msg='Can not enable {0} without MPI'.format(p))
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -155,40 +155,34 @@ class Dealii(CMakePackage, CudaPackage):
     depends_on('trilinos@master+amesos+aztec+epetra+ifpack+ml+muelu+rol+sacado+teuchos~hypre~amesos2~ifpack2~intrepid2~kokkos~tpetra~zoltan2', when='+trilinos+mpi+int64+cuda')
 
     # check that the combination of variants makes sense
-    conflicts('^openblas+ilp64', when='@:8.5.1',
-              msg='64bit BLAS is only supported from 9.0.0')
-    conflicts('^intel-mkl+ilp64', when='@:8.5.1',
-              msg='64bit BLAS is only supported from 9.0.0')
-    conflicts('^intel-parallel-studio+mkl+ilp64', when='@:8.5.1',
-              msg='64bit BLAS is only supported from 9.0.0')
-    conflicts('+assimp', when='@:8.5.1',
-              msg='Interface to assim is supported starting from 9.0.0'
-                  ', please explicitly disable this variant via ~assimp')
-    conflicts('+gmsh', when='@:8.5.1',
-              msg='Interface to gmsh is supported starting from 9.0.0'
-                  ', please explicitly disable this variant via ~gmsh')
-    conflicts('+nanoflann', when='@:8.5.1',
-              msg='Interface to gmsh is supported starting from 9.0.0'
-                  ', please explicitly disable this variant via ~nanoflann')
-    conflicts('+scalapack', when='@:8.5.1',
-              msg='Interface to gmsh is supported starting from 9.0.0'
-                  ', please explicitly disable this variant via ~scalapack')
-    conflicts('+sundials', when='@:8.5.1',
-              msg='Interface to gmsh is supported starting from 9.0.0'
-                  ', please explicitly disable this variant via ~sundials')
-    conflicts('+adol-c', when='@:8.5.1',
-              msg='Interface to gmsh is supported starting from 9.0.0'
-                  ', please explicitly disable this variant via ~adol-c')
-    conflicts('+slepc', when='~petsc')
-    conflicts('+gsl',    when='@:8.4.2',
-              msg='Interface to gsl is supported starting from 8.5.0'
-                  ', please explicitly disable this variant via ~gsl')
-    conflicts('+python', when='@:8.4.2',
-              msg='Interface to python is supported starting from 8.5.0'
-                  ', please explicitly disable this variant via ~python')
-    for p in ['+arpack', '+hdf5', '+netcdf', '+p4est', '+petsc', '+scalapack',
-              '+slepc', '+trilinos']:
-        conflicts(p, when='~mpi',
+    # 64-bit BLAS:
+    for p in ['openblas', 'intel-mkl', 'intel-parallel-studio+mkl']:
+        conflicts('^{0}+ilp64'.format(p), when='@:8.5.1',
+                  msg='64bit BLAS is only supported from 9.0.0')
+
+    # interfaces added in 9.0.0:
+    for p in ['assimp', 'gmsh', 'nanoflann', 'scalapack', 'sundials',
+              'adol-c']:
+        conflicts('+{0}'.format(p), when='@:8.5.1',
+                  msg='Interface to {0} is supported starting from 9.0.0'
+                      ', please explicitly disable this variant '
+                      'via ~{0}'.format(p))
+
+    conflicts('+slepc', when='~petsc',
+              msg='It is not possible ot enable slepc interfaces '
+                  'without petsc.')
+
+    # interfaces added in 8.5.0:
+    for p in ['gsl', 'python']:
+        conflicts('+{0}'.format(p), when='@:8.4.2',
+                  msg='Interface to {0} is supported starting from 8.5.0'
+                      ', please explicitly disable this variant '
+                      'via ~{0}'.format(p))
+
+    # MPI requirements:
+    for p in ['arpack', 'hdf5', 'netcdf', 'p4est', 'petsc', 'scalapack',
+              'slepc', 'trilinos']:
+        conflicts('+{0}'.format(p), when='~mpi',
                   msg='Can not enable {0} without MPI'.format(p))
 
     def cmake_args(self):


### PR DESCRIPTION
@jppelteret this is as much as we can do now to help users. Let me know if you prefer to reword anything. Although it's not a fix to the issue, I marking it as such as right now we can't do more.

fixes https://github.com/spack/spack/issues/8504

@christianbaensch would the following error be more helpful (see the bottom of this message, which is more descriptive now) :
```
$ spack spec dealii@8.4.2~mpi~petsc^openblas+ilp64
Input spec
--------------------------------
dealii@8.4.2~mpi~petsc
    ^openblas+ilp64

Concretized
--------------------------------
==> Error: Conflicts in concretized spec "dealii@8.4.2%clang@9.1.0-apple+adol-c+arpack+assimp build_type=DebugRelease ~cuda cuda_arch= +doc+gmsh+gsl+hdf5~int64+metis~mpi+nanoflann+netcdf+oce+optflags+p4est~petsc~python+scalapack+slepc+sundials+trilinos arch=darwin-highsierra-x86_64 /c5hwxhx"

List of matching conflicts for spec:

    dealii@8.4.2%clang@9.1.0-apple+adol-c+arpack+assimp build_type=DebugRelease ~cuda cuda_arch= +doc+gmsh+gsl+hdf5~int64+metis~mpi+nanoflann+netcdf+oce+optflags+p4est~petsc~python+scalapack+slepc+sundials+trilinos arch=darwin-highsierra-x86_64
        ^boost@1.67.0%clang@9.1.0-apple+atomic+chrono~clanglibcpp cxxstd=default +date_time~debug+exception+filesystem~graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy+program_options+python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave arch=darwin-highsierra-x86_64
            ^bzip2@1.0.6%clang@9.1.0-apple+shared arch=darwin-highsierra-x86_64
            ^python@2.7.15%clang@9.1.0-apple+dbm~optimizations patches=123082ab3483ded78e86d7c809e98a804b3465b4683c96bd79a2fd799f572244 +pic+pythoncmd~shared~tk~ucs4 arch=darwin-highsierra-x86_64
                ^gdbm@1.14.1%clang@9.1.0-apple arch=darwin-highsierra-x86_64
                    ^readline@7.0%clang@9.1.0-apple arch=darwin-highsierra-x86_64
                        ^ncurses@6.1%clang@9.1.0-apple~symlinks~termlib arch=darwin-highsierra-x86_64
                            ^pkg-config@0.29.2%clang@9.1.0-apple+internal_glib arch=darwin-highsierra-x86_64
                ^openssl@1.0.2n%clang@9.1.0-apple+systemcerts arch=darwin-highsierra-x86_64
                    ^zlib@1.2.11%clang@9.1.0-apple+optimize+pic+shared arch=darwin-highsierra-x86_64
                ^sqlite@3.23.1%clang@9.1.0-apple~functions arch=darwin-highsierra-x86_64
        ^cmake@3.9.4%clang@9.1.0-apple~doc+ncurses+openssl+ownlibs~qt arch=darwin-highsierra-x86_64
        ^doxygen@1.8.12%clang@9.1.0-apple build_type=RelWithDebInfo +graphviz arch=darwin-highsierra-x86_64
            ^bison@3.0.4%clang@9.1.0-apple patches=57f972940a10d448efbd3d5ba46e65979ae4eea93681a85e1d998060b356e0d2,b72914fe38e54a6fc25f29019e0a0786705c4f61ce20d414cc2010c8d62448c7 arch=darwin-highsierra-x86_64
                ^m4@1.4.18%clang@9.1.0-apple patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00 +sigsegv arch=darwin-highsierra-x86_64
                    ^libsigsegv@2.11%clang@9.1.0-apple arch=darwin-highsierra-x86_64
            ^flex@2.6.3%clang@9.1.0-apple+lex arch=darwin-highsierra-x86_64
                ^gettext@0.19.8.1%clang@9.1.0-apple+bzip2+curses+git~libunistring+libxml2 patches=9acdb4e73f67c241b5ef32505c9ddf7cf6884ca8ea661692f21dca28483b04b8 +tar+xz arch=darwin-highsierra-x86_64
                    ^libxml2@2.9.8%clang@9.1.0-apple~python arch=darwin-highsierra-x86_64
                        ^xz@5.2.4%clang@9.1.0-apple arch=darwin-highsierra-x86_64
                    ^tar@1.30%clang@9.1.0-apple arch=darwin-highsierra-x86_64
                ^help2man@1.47.4%clang@9.1.0-apple arch=darwin-highsierra-x86_64
            ^graphviz@2.40.1%clang@9.1.0-apple~expat~ghostscript~go~gtkplus~gts~guile~io~java~libgd~lua~ocaml~pangocairo~perl~php~python~qt~r~ruby~sharp~tcl arch=darwin-highsierra-x86_64
                ^autoconf@2.69%clang@9.1.0-apple arch=darwin-highsierra-x86_64
                    ^perl@5.26.2%clang@9.1.0-apple+cpanm patches=0eac10ed90aeb0459ad8851f88081d439a4e41978e586ec743069e8b059370ac +shared+threads arch=darwin-highsierra-x86_64
                ^automake@1.16.1%clang@9.1.0-apple arch=darwin-highsierra-x86_64
                ^libtool@2.4.6%clang@9.1.0-apple arch=darwin-highsierra-x86_64
        ^intel-tbb@2018.4%clang@9.1.0-apple cxxstd=default patches=ca08c28bdb15582c30777f9303d1986e4c09b3d514776494f3fbf5f19381bfda +shared arch=darwin-highsierra-x86_64
        ^metis@5.1.0%clang@9.1.0-apple build_type=Release ~gdb~int64 patches=4991da938c1d3a1d3dea78e49bbebecba00273f98df2a656e38b83d55b281da1 +real64+shared arch=darwin-highsierra-x86_64
        ^muparser@2.2.5%clang@9.1.0-apple patches=68686ba5ec4df3691264f8ac04d1f1eb3e4585cc2dfefa1dc460c5ba2e096934 arch=darwin-highsierra-x86_64
        ^oce@0.18.3%clang@9.1.0-apple~X11+tbb arch=darwin-highsierra-x86_64
        ^openblas@0.3.0%clang@9.1.0-apple cpu_target= +ilp64 patches=47cfa7a952ac7b2e4632c73ae199d69fb54490627b66a62c681e21019c4ddc9d +pic+shared threads=none ~virtual_machine arch=darwin-highsierra-x86_64
        ^suite-sparse@5.2.0%clang@9.1.0-apple~cuda~openmp patches=d2df9294f7667f75172e71d50af738fc283bf6b4891298ca7a253eaa8bcdd7e6 +pic~tbb arch=darwin-highsierra-x86_64

1. "+hdf5" conflicts with "dealii~mpi" [Can not enable hdf5 without MPI]
2. "+arpack" conflicts with "dealii~mpi" [Can not enable arpack without MPI]
3. "+slepc" conflicts with "dealii~petsc" [It is not possible ot enable slepc interfaces without petsc.]
4. "+slepc" conflicts with "dealii~mpi" [Can not enable slepc without MPI]
5. "+gmsh" conflicts with "dealii@:8.5.1" [Interface to gmsh is supported starting from 9.0.0, please explicitly disable this variant via ~gmsh]
6. "+gsl" conflicts with "dealii@:8.4.2" [Interface to gsl is supported starting from 8.5.0, please explicitly disable this variant via ~gsl]
7. "+assimp" conflicts with "dealii@:8.5.1" [Interface to assimp is supported starting from 9.0.0, please explicitly disable this variant via ~assimp]
8. "+adol-c" conflicts with "dealii@:8.5.1" [Interface to adol-c is supported starting from 9.0.0, please explicitly disable this variant via ~adol-c]
9. "+trilinos" conflicts with "dealii~mpi" [Can not enable trilinos without MPI]
10. "+nanoflann" conflicts with "dealii@:8.5.1" [Interface to nanoflann is supported starting from 9.0.0, please explicitly disable this variant via ~nanoflann]
11. "^openblas+ilp64" conflicts with "dealii@:8.5.1" [64bit BLAS is only supported from 9.0.0]
12. "+netcdf" conflicts with "dealii~mpi" [Can not enable netcdf without MPI]
13. "+scalapack" conflicts with "dealii@:8.5.1" [Interface to scalapack is supported starting from 9.0.0, please explicitly disable this variant via ~scalapack]
14. "+scalapack" conflicts with "dealii~mpi" [Can not enable scalapack without MPI]
15. "+sundials" conflicts with "dealii@:8.5.1" [Interface to sundials is supported starting from 9.0.0, please explicitly disable this variant via ~sundials]
16. "+p4est" conflicts with "dealii~mpi" [Can not enable p4est without MPI]
```