### PR TITLE
Fix version detection for gcc@8

### DIFF
--- a/lib/spack/spack/compilers/gcc.py
+++ b/lib/spack/spack/compilers/gcc.py
@@ -132,7 +132,7 @@ class Gcc(Compiler):
             return 'unknown'
 
         version = super(Gcc, cls).default_version(cc)
-        if version in ['7']:
+        if ver(version) >= ver('7'):
             version = get_compiler_version(cc, '-dumpfullversion')
         return version
 
@@ -161,7 +161,7 @@ class Gcc(Compiler):
         version = get_compiler_version(
             fc, '-dumpversion',
             r'(?:GNU Fortran \(GCC\) )?([\d.]+)')
-        if version in ['7']:
+        if ver(version) >= ver('7'):
             version = get_compiler_version(fc, '-dumpfullversion')
         return version
 


### PR DESCRIPTION
This is a quick patch to fix gcc@8. Maybe we should come up with something more future-proof. :-)