### PR TITLE
elpa: add 2018.05.001.rc1 and 2017.11.001

### DIFF
--- a/var/spack/repos/builtin/packages/elpa/package.py
+++ b/var/spack/repos/builtin/packages/elpa/package.py
@@ -31,6 +31,8 @@ class Elpa(AutotoolsPackage):
     homepage = 'http://elpa.mpcdf.mpg.de/'
     url = 'http://elpa.mpcdf.mpg.de/elpa-2015.11.001.tar.gz'
 
+    version('2018.05.001.rc1', 'ccd77bd8036988ee624f43c04992bcdd')
+    version('2017.11.001', '4a437be40cc966efb07aaab84c20cd6e')
     version('2017.05.003', '7c8e5e58cafab212badaf4216695700f')
     version('2017.05.002', 'd0abc1ac1f493f93bf5e30ec8ab155dc')
     version('2016.11.001.pre', '5656fd066cf0dcd071dbcaf20a639b37')

--- a/var/spack/repos/builtin/packages/elpa/package.py
+++ b/var/spack/repos/builtin/packages/elpa/package.py
@@ -32,11 +32,11 @@ class Elpa(AutotoolsPackage):
     url = 'http://elpa.mpcdf.mpg.de/elpa-2015.11.001.tar.gz'
 
     version('2018.05.001.rc1', 'ccd77bd8036988ee624f43c04992bcdd')
-    version('2017.11.001', '4a437be40cc966efb07aaab84c20cd6e')
+    version('2017.11.001', '4a437be40cc966efb07aaab84c20cd6e', preferred=True)
     version('2017.05.003', '7c8e5e58cafab212badaf4216695700f')
     version('2017.05.002', 'd0abc1ac1f493f93bf5e30ec8ab155dc')
     version('2016.11.001.pre', '5656fd066cf0dcd071dbcaf20a639b37')
-    version('2016.05.004', 'c0dd3a53055536fc3a2a221e78d8b376', preferred=True)
+    version('2016.05.004', 'c0dd3a53055536fc3a2a221e78d8b376')
     version('2016.05.003', '88a9f3f3bfb63e16509dd1be089dcf2c')
     version('2015.11.001', 'de0f35b7ee7c971fd0dca35c900b87e6')
 


### PR DESCRIPTION
absolutely untested as it simply does not configure / build on macOS 😞 