### PR TITLE
Bump ZeroMQ from v4.2.2 to v4.2.5

### DIFF
--- a/var/spack/repos/builtin/packages/zeromq/package.py
+++ b/var/spack/repos/builtin/packages/zeromq/package.py
@@ -32,8 +32,9 @@ class Zeromq(AutotoolsPackage):
 
     version('develop', branch='master',
             git='https://github.com/zeromq/libzmq.git')
-    version('4.2.2', '52499909b29604c1e47a86f1cb6a9115',
-            url='https://github.com/zeromq/libzmq/releases/download/v4.2.2/zeromq-4.2.2.tar.gz')
+    version('4.2.5', 'a1c95b34384257e986842f4d006957b8',
+            url='https://github.com/zeromq/libzmq/releases/download/v4.2.5/zeromq-4.2.5.tar.gz')
+    version('4.2.2', '52499909b29604c1e47a86f1cb6a9115')
     version('4.1.4', 'a611ecc93fffeb6d058c0e6edf4ad4fb')
     version('4.1.2', '159c0c56a895472f02668e692d122685')
     version('4.1.1', '0a4b44aa085644f25c177f79dc13f253')
@@ -48,6 +49,8 @@ class Zeromq(AutotoolsPackage):
     depends_on('automake', type='build', when='@develop')
     depends_on('libtool', type='build', when='@develop')
     depends_on('pkgconfig', type='build')
+
+    conflicts('%gcc@8:', when='@:4.2.2')
 
     @when('@develop')
     def autoreconf(self, spec, prefix):


### PR DESCRIPTION
This addresses some build issues with GCC8