### PR TITLE
Add kealib 1.4.8

### DIFF
--- a/var/spack/repos/builtin/packages/kealib/package.py
+++ b/var/spack/repos/builtin/packages/kealib/package.py
@@ -45,6 +45,7 @@ class Kealib(CMakePackage):
     url      = "https://bitbucket.org/chchrsc/kealib/get/kealib-1.4.7.tar.gz"
 
     version('develop', hg='https://bitbucket.org/chchrsc/kealib')
+    version('1.4.8', '1af2514c908f9168ff6665cc012815ad')
     version('1.4.7', '6139e31e50f552247ddf98f489948893')
 
     depends_on('cmake@2.8.10:', type='build')


### PR DESCRIPTION
Adds the latest version of kealib. Successfully installed and passed all tests on macOS 10.13.4 with Clang 9.0.0.

@gillins