### PR TITLE
libbeagle: add java dependency so jni hooks get built

### DIFF
--- a/var/spack/repos/builtin/packages/libbeagle/package.py
+++ b/var/spack/repos/builtin/packages/libbeagle/package.py
@@ -49,4 +49,4 @@ class Libbeagle(AutotoolsPackage):
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         prefix = self.prefix
-        spack_env.prepend_path('LD_LIBRARY_PATH', prefix.lib)
+        spack_env.prepend_path('BEAST_LIB', prefix.lib)

--- a/var/spack/repos/builtin/packages/libbeagle/package.py
+++ b/var/spack/repos/builtin/packages/libbeagle/package.py
@@ -41,7 +41,12 @@ class Libbeagle(AutotoolsPackage):
 
     depends_on('subversion', type='build')
     depends_on('pkgconfig', type='build')
+    depends_on('java', type='build')
 
     def url_for_version(self, version):
         url = "https://github.com/beagle-dev/beagle-lib/archive/beagle_release_{0}.tar.gz"
         return url.format(version.underscored)
+
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        prefix = self.prefix
+        spack_env.prepend_path('LD_LIBRARY_PATH', prefix.lib)

--- a/var/spack/repos/builtin/packages/libbeagle/package.py
+++ b/var/spack/repos/builtin/packages/libbeagle/package.py
@@ -47,6 +47,6 @@ class Libbeagle(AutotoolsPackage):
         url = "https://github.com/beagle-dev/beagle-lib/archive/beagle_release_{0}.tar.gz"
         return url.format(version.underscored)
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+    def setup_environment(self, spack_env, run_env):
         prefix = self.prefix
-        spack_env.prepend_path('BEAST_LIB', prefix.lib)
+        run_env.prepend_path('BEAST_LIB', prefix.lib)


### PR DESCRIPTION
also sets ld_library_path so dependents (like beast) can find libbeagle correctly