### PR TITLE
py-matplotlib: Add patch to fix FreeType library detection

### DIFF
--- a/var/spack/repos/builtin/packages/py-matplotlib/freetype-include-path.patch
+++ b/var/spack/repos/builtin/packages/py-matplotlib/freetype-include-path.patch
@@ -1,0 +1,16 @@
+diff --git a/setupext.py b/setupext.py
+index 6d363012eb4..00ef3fe5a3d 100644
+--- a/setupext.py
++++ b/setupext.py
+@@ -162,8 +162,10 @@ def get_include_dirs():
+     """
+     include_dirs = [os.path.join(d, 'include') for d in get_base_dirs()]
+     if sys.platform != 'win32':
+-        # gcc includes this dir automatically, so also look for headers in
++        # gcc includes these dirs automatically, so also look for headers in
+         # these dirs
++        include_dirs.extend(
++            os.environ.get('CPATH', '').split(os.pathsep))
+         include_dirs.extend(
+             os.environ.get('CPLUS_INCLUDE_PATH', '').split(os.pathsep))
+     return include_dirs

--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -68,6 +68,7 @@ class PyMatplotlib(PythonPackage):
 
     depends_on('libpng@1.2:')
     depends_on('freetype@2.3:')
+    patch('freetype-include-path.patch', when='@2.2.2:') # Patch to pick up correct freetype headers
 
     depends_on('py-numpy@1.6:', type=('build', 'run'))
     depends_on('py-dateutil@1.1:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -68,7 +68,7 @@ class PyMatplotlib(PythonPackage):
 
     depends_on('libpng@1.2:')
     depends_on('freetype@2.3:')
-    patch('freetype-include-path.patch', when='@2.2.2:') # Patch to pick up correct freetype headers
+    patch('freetype-include-path.patch', when='@2.2.2')  # Patch to pick up correct freetype headers
 
     depends_on('py-numpy@1.6:', type=('build', 'run'))
     depends_on('py-dateutil@1.1:', type=('build', 'run'))


### PR DESCRIPTION
Adds patch to add $CPATH to locations searched for FreeType header file

Patch has been upstreamed:
https://github.com/matplotlib/matplotlib/pull/11457