### PR TITLE
Correcting position independent code setting for boxlib and amrex.

### DIFF
--- a/var/spack/repos/builtin/packages/amrex/package.py
+++ b/var/spack/repos/builtin/packages/amrex/package.py
@@ -61,7 +61,7 @@ class Amrex(CMakePackage):
         spec = self.spec
 
         cmake_args = [
-            '-DENABLE_POSITION_INDEPENDENT_CODE=ON',
+            '-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON',
             '-DBL_SPACEDIM:INT=%d' % int(spec.variants['dims'].value),
             '-DBL_PRECISION:STRING=%s' % spec.variants['prec'].value,
             '-DENABLE_FMG=%s' % ('+fortran' in spec),

--- a/var/spack/repos/builtin/packages/boxlib/package.py
+++ b/var/spack/repos/builtin/packages/boxlib/package.py
@@ -49,7 +49,7 @@ class Boxlib(CMakePackage):
 
         options.extend([
             '-DBL_SPACEDIM=%d' % int(spec.variants['dims'].value),
-            '-DENABLE_POSITION_INDEPENDENT_CODE=ON',
+            '-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON',
             '-DENABLE_FBASELIB=ON',
             '-DCMAKE_C_COMPILER=%s' % spec['mpi'].mpicc,
             '-DCMAKE_CXX_COMPILER=%s' % spec['mpi'].mpicxx,


### PR DESCRIPTION
Boxlib and AMReX both build static libraries, but the CMake PIC option was wrong. I have verified that this adds in `-fPIC` to the compile lines where it wasn't before.