### PR TITLE
use new valgrind repo

### DIFF
--- a/var/spack/repos/builtin/packages/valgrind/package.py
+++ b/var/spack/repos/builtin/packages/valgrind/package.py
@@ -45,7 +45,7 @@ class Valgrind(AutotoolsPackage):
     version('3.11.0', '4ea62074da73ae82e0162d6550d3f129')
     version('3.10.1', '60ddae962bc79e7c95cfc4667245707f')
     version('3.10.0', '7c311a72a20388aceced1aa5573ce970')
-    version('develop', svn='svn://svn.valgrind.org/valgrind/trunk')
+    version('develop', git='git://sourceware.org/git/valgrind.git')
 
     variant('mpi', default=True,
             description='Activates MPI support for valgrind')


### PR DESCRIPTION
valgrind moved from svn to a git repo:

http://valgrind.org/downloads/repository.html

While the svn repo listed in spack still fetches, it's not the latest and greatest. 
I needed the latest develop branch to build on macOS 10.13 w/ xcode 9

The new url uses the `git://` protocol, which worked for me at home -- however this isn't idea b/c since many companies block a wide range of ports and the git protocol uses 9418.  (I can't fetch from it while at work)

I did also try:  https://sourceware.org/git/valgrind.git 

But this hung spack:
 
==> Trying to clone git repository: https://sourceware.org/git/valgrind.git 
fatal: dumb http transport does not support shallow capabilities