### PR TITLE
Fix for nettle failure on OS X 10.13.5

### DIFF
--- a/var/spack/repos/builtin/packages/nettle/package.py
+++ b/var/spack/repos/builtin/packages/nettle/package.py
@@ -24,6 +24,7 @@
 ##############################################################################
 from spack import *
 
+import sys
 
 class Nettle(AutotoolsPackage):
     """The Nettle package contains the low-level cryptographic library
@@ -39,3 +40,9 @@ class Nettle(AutotoolsPackage):
 
     depends_on('gmp')
     depends_on('m4', type='build')
+
+    def configure_args(self):
+        if sys.platform == 'darwin':	
+            return ['--disable-assembler']
+	else:
+            return []


### PR DESCRIPTION
Building nettle (as a prereq for gnutls as a prereq for emacs) failed
on a Mac running OS X 10.13.5 like so:

```
==> Error: ProcessError: Command exited with status 2:
    'make' '-j8'

2 errors found in build log:
     197    1 warning generated.
     198    getopt.c:1188:1: warning: no previous prototype for function 'getopt' [-Wmissing-prototype
            s]
     199    getopt (int argc, char *const *argv, const char *optstring)
     200    ^
     201    /Users/hartzell/tmp/spack-homework/opt/spack/darwin-highsierra-x86_64/clang-9.1.0-apple/m4
            -1.4.18-caxsf7l5yd7qbq2bown6bzi5el3ltfwf/bin/m4 /Users/hartzell/tmp/spack-homework/var/spa
            ck/stage/nettle-3.3-md2iuphdxpnsvj7nrdhczjvrhdgnrq7h/nettle-3.3/asm.m4 machine.m4 config.m
            4 aes-decrypt-internal.asm >aes-decrypt-internal.s
     202    /bin/sh: line 1: 78519 Abort trap: 6           /Users/hartzell/tmp/spack-homework/opt/spac
            k/darwin-highsierra-x86_64/clang-9.1.0-apple/m4-1.4.18-caxsf7l5yd7qbq2bown6bzi5el3ltfwf/bi
            n/m4 /Users/hartzell/tmp/spack-homework/var/spack/stage/nettle-3.3-md2iuphdxpnsvj7nrdhczjv
            rhdgnrq7h/nettle-3.3/asm.m4 machine.m4 config.m4 aes-decrypt-internal.asm > aes-decrypt-in
            ternal.s
  >> 203    make[1]: *** [aes-decrypt-internal.o] Error 134
     204    make[1]: *** Waiting for unfinished jobs....
     205    5 warnings generated.
  >> 206    make: *** [all] Error 2

See build log for details:
  /Users/hartzell/tmp/spack-homework/var/spack/stage/nettle-3.3-md2iuphdxpnsvj7nrdhczjvrhdgnrq7h/nettle-3.3/spack-build.out
```

I'm not up to snuff for exploring OS X assembler and AES libraries.

The only useful thing Google discovered for me was this gist:
https://gist.github.com/morgant/1753095 about building *gnutls* on the
mac.

It didn't directly address my issue, but it pointed out that there was
a `--disable-assembler` flag to nettle's configure.

With this change I was able to build an emacs that was able to make
the necessary https connections to set up my [straight.el](https://github.com/raxod502/straight.el) based emacs config.

It seems that sometimes simply avoiding the issue **is** sufficient.