### PR TITLE
tasmanian: fix unzip dependency error

### DIFF
--- a/var/spack/repos/builtin/packages/tasmanian/package.py
+++ b/var/spack/repos/builtin/packages/tasmanian/package.py
@@ -34,3 +34,4 @@ class Tasmanian(CMakePackage):
     url      = "http://tasmanian.ornl.gov/documents/Tasmanian_v5.0.zip"
 
     version('5.0', '4bf131841d786033863d271739be0f7a')
+    depends_on('unzip')


### PR DESCRIPTION
```
==> Installing tasmanian
==> Fetching http://tasmanian.ornl.gov/documents/Tasmanian_v5.0.zip
######################################################################## 100.0%
==> Staging archive: /home/balay/spack/var/spack/stage/tasmanian-5.0-sfa7smmito7cdxkcpa6oahdabzibhvcq/Tasmanian_v5.0.zip
==> Error: spack requires 'unzip'. Make sure it is in your path.
==> Error: SystemExit: 1
```
cc: @mkstoyanov