### PR TITLE
Caliper: some nonconformant function type conversion needs -fpermissive to compile (#8549)

### DIFF
--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -97,7 +97,8 @@ class Caliper(CMakePackage):
             args.append('-DMPI_CXX_COMPILER=%s' % spec['mpi'].mpicxx)
 
         # allow some nonconforming code to compile
-        compile_flags = "-O3 -fpermissive"
-        args.append('-DCMAKE_CXX_FLAGS=%s' % compile_flags)
+        if spec.satisfies('%gcc'):
+            compile_flags = "-O3 -fpermissive"
+            args.append('-DCMAKE_CXX_FLAGS=%s' % compile_flags)
 
         return args

--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -99,5 +99,5 @@ class Caliper(CMakePackage):
         # allow some nonconforming code to compile
         compile_flags = "-O3 -fpermissive"
         args.append('-DCMAKE_CXX_FLAGS=%s' % compile_flags)
-        
+
         return args

--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -96,9 +96,10 @@ class Caliper(CMakePackage):
             args.append('-DMPI_C_COMPILER=%s' % spec['mpi'].mpicc)
             args.append('-DMPI_CXX_COMPILER=%s' % spec['mpi'].mpicxx)
 
-        # allow some nonconforming code to compile
-        if spec.satisfies('%gcc'):
-            compile_flags = "-O3 -fpermissive"
-            args.append('-DCMAKE_CXX_FLAGS=%s' % compile_flags)
-
         return args
+
+    # allow some nonconforming code to compile
+    def flag_handler(self, name, flags):
+        if self.spec.satisfies('%gcc') and name in ['cxxflags', 'cppflags']:
+            flags.append('-fpermissive')
+        return (None, None, flags)

--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -96,4 +96,8 @@ class Caliper(CMakePackage):
             args.append('-DMPI_C_COMPILER=%s' % spec['mpi'].mpicc)
             args.append('-DMPI_CXX_COMPILER=%s' % spec['mpi'].mpicxx)
 
+        # allow some nonconforming code to compile
+        compile_flags = "-O3 -fpermissive"
+        args.append('-DCMAKE_CXX_FLAGS=%s' % compile_flags)
+        
         return args


### PR DESCRIPTION
Fixes #8549 