### PR TITLE
Fix m4 on OS X highsierra (allows nettle to build)

### DIFF
--- a/var/spack/repos/builtin/packages/m4/package.py
+++ b/var/spack/repos/builtin/packages/m4/package.py
@@ -36,6 +36,9 @@ class M4(AutotoolsPackage):
 
     patch('gnulib-pgi.patch', when='@1.4.18')
     patch('pgi.patch', when='@1.4.17')
+    # from: https://github.com/Homebrew/homebrew-core/blob/master/Formula/m4.rb
+    # Patch credit to Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+    patch('secure_snprintf.patch', when='platform_os = highsierra')
 
     variant('sigsegv', default=True,
             description="Build the libsigsegv dependency")

--- a/var/spack/repos/builtin/packages/m4/secure_snprintf.patch
+++ b/var/spack/repos/builtin/packages/m4/secure_snprintf.patch
@@ -1,0 +1,15 @@
+With format string strictness, High Sierra also enforces that %n isn't used
+in dynamic format strings, but we should just disable its use on darwin in
+general.
+
+--- a/lib/vasnprintf.c.orig	2017-06-22 15:19:15.000000000 -0700
++++ b/lib/vasnprintf.c	2017-06-22 15:20:20.000000000 -0700
+@@ -4869,7 +4869,7 @@ VASNPRINTF (DCHAR_T *resultbuf, size_t *
+ #endif
+                   *fbp = dp->conversion;
+ #if USE_SNPRINTF
+-# if !(((__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)) && !defined __UCLIBC__) || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
++# if !defined(__APPLE__) && !(((__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)) && !defined __UCLIBC__) || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
+                 fbp[1] = '%';
+                 fbp[2] = 'n';
+                 fbp[3] = '\0';


### PR DESCRIPTION
m4 exited immediately (causing the nettle build to fail).

```
(alice)[11:09:46]spack>>/Users/hartzell/tmp/spack-mac/spack/opt/spack/darwin-highsierra-x86_64/clang-9.1.0-apple/m4-1.4.18-caxsf7l5yd7qbq2bown6bzi5el3ltfwf/bin/m4
Abort trap: 6
(alice)[11:10:18]spack>>fg
```

Tracked down a fix via the Homebrew recipe.  I'll send a note to the
`bug-m4@gnu.org` list to ensure that upstream knows about it.

High Sierra does not seem to need the additional args appended that Sierra does so no changes were necessary in `configure_args`.

Tested by building nettle.