### PR TITLE
Command line scopes

### DIFF
--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -376,15 +376,16 @@ The merged configuration would look like this:
 Config file variables
 ------------------------------
 
-Spack understands several variables which can be used in config file paths
-where ever they appear. There are three sets of these variables, Spack specific
-variables, environment variables, and user path variables. Spack specific
-variables and environment variables both are indicated by prefixing the variable
-name with ``$``. User path variables are indicated at the start of the path with
-``~`` or ``~user``. Let's discuss each in turn.
+Spack understands several variables which can be used in config file
+paths wherever they appear. There are three sets of these variables,
+Spack specific variables, environment variables, and user path
+variables. Spack specific variables and environment variables both are
+indicated by prefixing the variable name with ``$``. User path variables
+are indicated at the start of the path with ``~`` or ``~user``. See below
+for more details.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^
-Spack Specific Variables
+Spack-specific variables
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 Spack understands several special variables. These are:
@@ -398,23 +399,74 @@ Spack understands several special variables. These are:
 
 Note that, as with shell variables, you can write these as ``$varname``
 or with braces to distinguish the variable from surrounding characters:
-``${varname}``. Their names are also case insensitive meaning that ``$SPACK``
-works just as well as ``$spack``. These special variables are also
-substituted first, so any environment variables with the same name will not
-be used.
+``${varname}``. Their names are also case insensitive, meaning that
+``$SPACK`` works just as well as ``$spack``. These special variables are
+substituted first, so any environment variables with the same name will
+not be used.
 
 ^^^^^^^^^^^^^^^^^^^^^
-Environment Variables
+Environment variables
 ^^^^^^^^^^^^^^^^^^^^^
 
-Spack then uses ``os.path.expandvars`` to expand any remaining environment
-variables.
+After spack-specific variables are evaluated, environment variables are
+expanded.  These are formatted like spack-specific variables, e.g.,
+``${varname}``.  You can use this to insert environment variables in your
+Spack configuration.
 
-^^^^^^^^^^^^^^
-User Variables
-^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^
+User home directories
+^^^^^^^^^^^^^^^^^^^^^
 
-Spack also uses the ``os.path.expanduser`` function on the path to expand
-any user tilde paths such as ``~`` or ``~user``. These tilde paths must appear
-at the beginning of the path or ``os.path.expanduser`` will not properly
-expand them.
+Spack performs unix-style tilde expansion on paths in configuration
+files.  This means that tilde (``~``) will expand to the current user's
+home directory, and ``~user`` will expand to a specified user's home
+directory.  The ``~`` must appear at the beginning of the path, or Spack
+will not expand it.
+
+----------------------------
+Seeing Spack's configuration
+----------------------------
+
+With so many scopes overriding each other, it can sometimes be difficult
+to understand what Spack's final configuration looks like.  ``spack
+config get`` shows a fully merged configuration file, taking into account
+all scopes.  For example, to see the fully merged ``config.yaml``, you
+can type:
+
+.. code-block:: console
+
+   $ spack config get config
+   config:
+     debug: false
+     checksum: true
+     verify_ssl: true
+     dirty: false
+     build_jobs: 8
+     install_tree: $spack/opt/spack
+     template_dirs:
+     - $spack/templates
+     directory_layout: ${ARCHITECTURE}/${COMPILERNAME}-${COMPILERVER}/${PACKAGE}-${VERSION}-${HASH}
+     module_roots:
+       tcl: $spack/share/spack/modules
+       lmod: $spack/share/spack/lmod
+       dotkit: $spack/share/spack/dotkit
+     build_stage:
+     - $tempdir
+     - /nfs/tmp2/$user
+     - $spack/var/spack/stage
+     source_cache: $spack/var/spack/cache
+     misc_cache: ~/.spack/cache
+     locks: true
+
+Likewise, this will show the fully merged ``packages.yaml``:
+
+.. code-block:: console
+
+   $ spack config get packages
+
+You can use this in conjunction with the ``-C`` / ``--config-scope`` argument to
+see how your scope will affect Spack's configuration:
+
+.. code-block:: console
+
+   $ spack -C /path/to/my/scope config get packages

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -428,10 +428,20 @@ Seeing Spack's configuration
 ----------------------------
 
 With so many scopes overriding each other, it can sometimes be difficult
-to understand what Spack's final configuration looks like.  ``spack
-config get`` shows a fully merged configuration file, taking into account
-all scopes.  For example, to see the fully merged ``config.yaml``, you
-can type:
+to understand what Spack's final configuration looks like.
+
+Spack provides two useful ways to view the final "merged" version of any
+configuration file: ``spack config get`` and ``spack config blame``.
+
+.. _cmd-spack-config-get:
+
+^^^^^^^^^^^^^^^^^^^^
+``spack config get``
+^^^^^^^^^^^^^^^^^^^^
+
+``spack config get`` shows a fully merged configuration file, taking into
+account all scopes.  For example, to see the fully merged
+``config.yaml``, you can type:
 
 .. code-block:: console
 
@@ -470,3 +480,48 @@ see how your scope will affect Spack's configuration:
 .. code-block:: console
 
    $ spack -C /path/to/my/scope config get packages
+
+
+.. _cmd-spack-config-blame:
+
+^^^^^^^^^^^^^^^^^^^^^^
+``spack config blame``
+^^^^^^^^^^^^^^^^^^^^^^
+
+``spack config blame`` functions much like ``spack config get``, but it
+shows exactly which configuration file each preference came from. If you
+do not know why Spack is behaving a certain way, this can help you track
+down the problem:
+
+.. code-block:: console
+
+   $ spack --insecure -C ./my-scope -C ./my-scope-2 config blame config
+   ==> Warning: You asked for --insecure. Will NOT check SSL certificates.
+   ---                                                   config:
+   _builtin                                                debug: False
+   /home/myuser/spack/etc/spack/defaults/config.yaml:72    checksum: True
+   command_line                                            verify_ssl: False
+   ./my-scope-2/config.yaml:2                              dirty: False
+   _builtin                                                build_jobs: 8
+   ./my-scope/config.yaml:2                                install_tree: /path/to/some/tree
+   /home/myuser/spack/etc/spack/defaults/config.yaml:23    template_dirs:
+   /home/myuser/spack/etc/spack/defaults/config.yaml:24    - $spack/templates
+   /home/myuser/spack/etc/spack/defaults/config.yaml:28    directory_layout: ${ARCHITECTURE}/${COMPILERNAME}-${COMPILERVER}/${PACKAGE}-${VERSION}-${HASH}
+   /home/myuser/spack/etc/spack/defaults/config.yaml:32    module_roots:
+   /home/myuser/spack/etc/spack/defaults/config.yaml:33      tcl: $spack/share/spack/modules
+   /home/myuser/spack/etc/spack/defaults/config.yaml:34      lmod: $spack/share/spack/lmod
+   /home/myuser/spack/etc/spack/defaults/config.yaml:35      dotkit: $spack/share/spack/dotkit
+   /home/myuser/spack/etc/spack/defaults/config.yaml:49    build_stage:
+   /home/myuser/spack/etc/spack/defaults/config.yaml:50    - $tempdir
+   /home/myuser/spack/etc/spack/defaults/config.yaml:51    - /nfs/tmp2/$user
+   /home/myuser/spack/etc/spack/defaults/config.yaml:52    - $spack/var/spack/stage
+   /home/myuser/spack/etc/spack/defaults/config.yaml:57    source_cache: $spack/var/spack/cache
+   /home/myuser/spack/etc/spack/defaults/config.yaml:62    misc_cache: ~/.spack/cache
+   /home/myuser/spack/etc/spack/defaults/config.yaml:86    locks: True
+
+You can see above that the ``build_jobs`` and ``debug`` settings are
+built in and are not overridden by a configuration file.  The
+``verify_ssl`` setting comes from the ``--insceure`` option on the
+command line. ``dirty`` and ``install_tree`` come from the command-line
+scopes ``./my-scope`` and ``./my-scope-2``, and all other configuration
+options come from the default configuration files that ship with Spack.

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -22,6 +22,8 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
+from __future__ import print_function
+
 """This module implements Spack's configuration file handling.
 
 This implements Spack's configuration system, which handles merging
@@ -206,6 +208,19 @@ class ConfigScope(object):
         return '<ConfigScope: %s: %s>' % (self.name, self.path)
 
 
+class ImmutableConfigScope(ConfigScope):
+    """A configuration scope that cannot be written to.
+
+    This is used for ConfigScopes passed on the command line.
+    """
+
+    def write_section(self, section):
+        raise ConfigError("Cannot write to immutable scope %s" % self)
+
+    def __repr__(self):
+        return '<ImmutableConfigScope: %s: %s>' % (self.name, self.path)
+
+
 class InternalConfigScope(ConfigScope):
     """An internal configuration scope that is not persisted to a file.
 
@@ -274,9 +289,8 @@ class Configuration(object):
 
     @property
     def file_scopes(self):
-        """List of scopes with an associated file (non-internal scopes)."""
-        return [s for s in self.scopes.values()
-                if not isinstance(s, InternalConfigScope)]
+        """List of writable scopes with an associated file."""
+        return [s for s in self.scopes.values() if type(s) == ConfigScope]
 
     def highest_precedence_scope(self):
         """Non-internal scope with highest precedence."""
@@ -455,17 +469,65 @@ class Configuration(object):
 
 
 @contextmanager
-def override(path, value):
-    """Simple way to override config settings within a context."""
-    overrides = InternalConfigScope('overrides')
+def override(path_or_scope, value=None):
+    """Simple way to override config settings within a context.
 
-    config.push_scope(overrides)
-    config.set(path, value, scope='overrides')
+    Arguments:
+        path_or_scope (ConfigScope or str): scope or single option to override
+        value (object, optional): value for the single option
 
-    yield config
+    Temporarily push a scope on the current configuration, then remove it
+    after the context completes. If a single option is provided, create
+    an internal config scope for it and push/pop that scope.
 
-    scope = config.pop_scope()
-    assert scope is overrides
+    """
+    if isinstance(path_or_scope, ConfigScope):
+        config.push_scope(path_or_scope)
+        yield config
+        config.pop_scope(path_or_scope)
+
+    else:
+        overrides = InternalConfigScope('overrides')
+
+        config.push_scope(overrides)
+        config.set(path_or_scope, value, scope='overrides')
+
+        yield config
+
+        scope = config.pop_scope()
+        assert scope is overrides
+
+
+#: configuration scopes added on the command line
+#: set by ``spack.main.main()``.
+command_line_scopes = []
+
+
+def _add_platform_scope(cfg, scope_type, name, path):
+    """Add a platform-specific subdirectory for the current platform."""
+    platform = spack.architecture.platform().name
+    plat_name = '%s/%s' % (name, platform)
+    plat_path = os.path.join(path, platform)
+    cfg.push_scope(scope_type(plat_name, plat_path))
+
+
+def _add_command_line_scopes(cfg, command_line_scopes):
+    """Add additional scopes from the --config-scope argument.
+
+    Command line scopes are named after their position in the arg list.
+    """
+    for i, path in enumerate(command_line_scopes):
+        # We ensure that these scopes exist and are readable, as they are
+        # provided on the command line by the user.
+        if not os.path.isdir(path):
+            raise ConfigError("config scope is not a directory: '%s'" % path)
+        elif not os.access(path, os.R_OK):
+            raise ConfigError("config scope is not readable: '%s'" % path)
+
+        # name based on order on the command line
+        name = 'cmd_scope_%d' % i
+        cfg.push_scope(ImmutableConfigScope(name, path))
+        _add_platform_scope(cfg, ImmutableConfigScope, name, path)
 
 
 def _config():
@@ -485,16 +547,15 @@ def _config():
     defaults = InternalConfigScope('_builtin', config_defaults)
     cfg.push_scope(defaults)
 
-    # Each scope can have per-platfom overrides in subdirectories
-    platform = spack.architecture.platform().name
-
     # add each scope and its platform-specific directory
     for name, path in configuration_paths:
         cfg.push_scope(ConfigScope(name, path))
 
-        plat_name = '%s/%s' % (name, platform)
-        plat_path = os.path.join(path, platform)
-        cfg.push_scope(ConfigScope(plat_name, plat_path))
+        # Each scope can have per-platfom overrides in subdirectories
+        _add_platform_scope(cfg, ConfigScope, name, path)
+
+    # add command-line scopes
+    _add_command_line_scopes(cfg, command_line_scopes)
 
     # we make a special scope for spack commands so that they can
     # override configuration options.

--- a/lib/spack/spack/error.py
+++ b/lib/spack/spack/error.py
@@ -30,6 +30,11 @@ import inspect
 import llnl.util.tty as tty
 
 
+#: whether we should write stack traces or short error messages
+#: this is module-scoped because it needs to be set very early
+debug = False
+
+
 class SpackError(Exception):
     """This is the superclass for all Spack errors.
        Subclasses can be found in the modules they have to do with.
@@ -72,8 +77,7 @@ class SpackError(Exception):
             sys.stderr.write('\n')
 
         # stack trace, etc. in debug mode.
-        import spack.config
-        if spack.config.get('config:debug'):
+        if debug:
             if self.traceback:
                 # exception came from a build child, already got
                 # traceback in child, so print it.

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -292,7 +292,9 @@ class SpackArgumentParser(argparse.ArgumentParser):
         subparser = self.subparsers.add_parser(
             cmd_name, help=module.description, description=module.description)
         module.setup_parser(subparser)
-        return module
+
+        # return the callable function for the command
+        return spack.cmd.get_command(cmd_name)
 
     def format_help(self, level='short'):
         if self.prog == 'spack':
@@ -328,6 +330,9 @@ def make_argument_parser(**kwargs):
         '--color', action='store', default='auto',
         choices=('always', 'never', 'auto'),
         help="when to colorize output (default: auto)")
+    parser.add_argument(
+        '-C', '--config-scope', dest='config_scopes', action='append',
+        metavar='DIRECTORY', help="use an additional configuration scope")
     parser.add_argument(
         '-d', '--debug', action='store_true',
         help="write out debug logs during compile")
@@ -379,14 +384,17 @@ def setup_main_options(args):
     tty.set_debug(args.debug)
     tty.set_stacktrace(args.stacktrace)
 
+    # debug must be set first so that it can even affect behvaior of
+    # errors raised by spack.config.
+    if args.debug:
+        spack.error.debug = True
+        spack.util.debug.register_interrupt_handler()
+        spack.config.set('config:debug', True, scope='command_line')
+
     # override lock configuration if passed on command line
     if args.locks is not None:
         spack.util.lock.check_lock_safety(spack.paths.prefix)
         spack.config.set('config:locks', False, scope='command_line')
-
-    if args.debug:
-        spack.util.debug.register_interrupt_handler()
-        spack.config.set('config:debug', True, scope='command_line')
 
     if args.mock:
         rp = spack.repo.RepoPath(spack.paths.mock_packages_path)
@@ -414,7 +422,7 @@ def allows_unknown_args(command):
     return (argcount == 3 and varnames[2] == 'unknown_args')
 
 
-def _invoke_spack_command(command, parser, args, unknown_args):
+def _invoke_command(command, parser, args, unknown_args):
     """Run a spack command *without* setting spack global options."""
     if allows_unknown_args(command):
         return_val = command(parser, args, unknown_args)
@@ -438,16 +446,15 @@ class SpackCommand(object):
     Use this to invoke Spack commands directly from Python and check
     their output.
     """
-    def __init__(self, command):
-        """Create a new SpackCommand that invokes ``command`` when called.
+    def __init__(self, command_name):
+        """Create a new SpackCommand that invokes ``command_name`` when called.
 
         Args:
-            command (str): name of the command to invoke
+            command_name (str): name of the command to invoke
         """
         self.parser = make_argument_parser()
-        self.parser.add_command(command)
-        self.command_name = command
-        self.command = spack.cmd.get_command(command)
+        self.command = self.parser.add_command(command_name)
+        self.command_name = command_name
 
     def __call__(self, *argv, **kwargs):
         """Invoke this SpackCommand.
@@ -477,7 +484,7 @@ class SpackCommand(object):
         out = StringIO()
         try:
             with log_output(out):
-                self.returncode = _invoke_spack_command(
+                self.returncode = _invoke_command(
                     self.command, self.parser, args, unknown)
 
         except SystemExit as e:
@@ -495,30 +502,6 @@ class SpackCommand(object):
                     ', '.join("'%s'" % a for a in argv)))
 
         return out.getvalue()
-
-
-def _main(command, parser, args, unknown_args):
-    """Run a spack command *and* set spack globaloptions."""
-    # many operations will fail without a working directory.
-    set_working_dir()
-
-    # only setup main options in here, after the real parse (we'll get it
-    # wrong if we do it after the initial, partial parse)
-    setup_main_options(args)
-    spack.hooks.pre_run()
-
-    # Now actually execute the command
-    try:
-        return _invoke_spack_command(command, parser, args, unknown_args)
-    except SpackError as e:
-        e.die()  # gracefully die on any SpackErrors
-    except Exception as e:
-        if spack.config.get('config:debug'):
-            raise
-        tty.die(str(e))
-    except KeyboardInterrupt:
-        sys.stderr.write('\n')
-        tty.die("Keyboard interrupt.")
 
 
 def _profile_wrapper(command, parser, args, unknown_args):
@@ -543,7 +526,7 @@ def _profile_wrapper(command, parser, args, unknown_args):
         # make a profiler and run the code.
         pr = cProfile.Profile()
         pr.enable()
-        return _main(command, parser, args, unknown_args)
+        return _invoke_command(command, parser, args, unknown_args)
 
     finally:
         pr.disable()
@@ -609,6 +592,10 @@ def main(argv=None):
     parser.add_argument('command', nargs=argparse.REMAINDER)
     args, unknown = parser.parse_known_args(argv)
 
+    # make spack.config aware of any command line configuration scopes
+    if args.config_scopes:
+        spack.config.command_line_scopes = args.config_scopes
+
     if args.print_shell_vars:
         print_setup_info(*args.print_shell_vars.split(','))
         return 0
@@ -631,31 +618,51 @@ def main(argv=None):
         parser.print_help()
         return 1
 
-    # Try to load the particular command the caller asked for.  If there
-    # is no module for it, just die.
-    cmd_name = args.command[0]
     try:
-        parser.add_command(cmd_name)
-    except ImportError:
-        if spack.config.get('config:debug'):
-            raise
-        tty.die("Unknown command: %s" % args.command[0])
+        # ensure options on spack command come before everything
+        setup_main_options(args)
 
-    # Re-parse with the proper sub-parser added.
-    args, unknown = parser.parse_known_args()
+        # Try to load the particular command the caller asked for.  If there
+        # is no module for it, just die.
+        cmd_name = args.command[0]
+        try:
+            command = parser.add_command(cmd_name)
+        except ImportError:
+            if spack.config.get('config:debug'):
+                raise
+            tty.die("Unknown command: %s" % args.command[0])
 
-    # now we can actually execute the command.
-    command = spack.cmd.get_command(cmd_name)
-    try:
+        # Re-parse with the proper sub-parser added.
+        args, unknown = parser.parse_known_args()
+
+        # many operations will fail without a working directory.
+        set_working_dir()
+
+        # pre-run hooks happen after we know we have a valid working dir
+        spack.hooks.pre_run()
+
+        # now we can actually execute the command.
         if args.spack_profile or args.sorted_profile:
             _profile_wrapper(command, parser, args, unknown)
         elif args.pdb:
             import pdb
-            pdb.runctx('_main(command, parser, args, unknown)',
+            pdb.runctx('_invoke_command(command, parser, args, unknown)',
                        globals(), locals())
             return 0
         else:
-            return _main(command, parser, args, unknown)
+            return _invoke_command(command, parser, args, unknown)
+
+    except SpackError as e:
+        e.die()  # gracefully die on any SpackErrors
+
+    except Exception as e:
+        if spack.config.get('config:debug'):
+            raise
+        tty.die(str(e))
+
+    except KeyboardInterrupt:
+        sys.stderr.write('\n')
+        tty.die("Keyboard interrupt.")
 
     except SystemExit as e:
         return e.code


### PR DESCRIPTION
This is a slight rework of the very nice #2686 that @citibeth wrote a while ago.  Key differences:

* it accounts for the changes in #7774 
* it improves the way initialization works in `spack.main`
* the argument for passing a configuration scope is `-C` / `--config-scope`

The last one leaves room for a future `-c` / `--config` option that would adjust *one* configuration setting (like `git`'s `-c`).

Basically, this PR lets you do this:

```
spack -C /path/to/special-config install package
```

Where `path/to/special-config` can contain `packages.yaml`, `config.yaml`, etc.

There is more fancy stuff coming in #8231, but we have some users who need to make use of this feature now, and it's still useful even with #8231.  People would like to keep several different configurations in version control, and this enables them to do that easily.

@cyrush @mwkrentel @stephdempsey: this should help you out.  I think others will also be interested.

- [x] add command-line scopes
- [x] rework `spack.main.main` to handle exceptions raised by the config system gracefully
- [x] docs for command-line scopes
- [x] docs for `spack config blame` (added in #8081)


