### PR TITLE
Version specific URL overrides won't propagate to newer versions

### DIFF
--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -165,3 +165,19 @@ class TestPackage(object):
         import spack.pkg.builtin.mock                   # noqa
         import spack.pkg.builtin.mock as m              # noqa
         from spack.pkg.builtin import mock              # noqa
+
+    @pytest.mark.regression('2737')
+    def test_urls_for_versions(self):
+        # Checks that a version directive without a 'url' argument
+        # specified uses the default url, or one that is specific
+        # to the closest newer version found.
+        for spec_str in ('url_override@0.9.0', 'url_override@1.0.0'):
+            s = Spec(spec_str).concretized()
+            url = s.package.url_for_version('0.9.0')
+            assert url == 'http://www.anothersite.org/uo-0.9.0.tgz'
+
+            url = s.package.url_for_version('1.0.0')
+            assert url == 'http://www.doesnotexist.org/url_override-1.0.0.tar.gz'
+
+            url = s.package.url_for_version('0.8.1')
+            assert url == 'http://www.anothersite.org/uo-0.8.1.tgz'

--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -169,8 +169,7 @@ class TestPackage(object):
     @pytest.mark.regression('2737')
     def test_urls_for_versions(self):
         # Checks that a version directive without a 'url' argument
-        # specified uses the default url, or one that is specific
-        # to the closest newer version found.
+        # specified uses the default url
         for spec_str in ('url_override@0.9.0', 'url_override@1.0.0'):
             s = Spec(spec_str).concretized()
             url = s.package.url_for_version('0.9.0')
@@ -180,4 +179,4 @@ class TestPackage(object):
             assert url == 'http://www.doesnotexist.org/url_override-1.0.0.tar.gz'
 
             url = s.package.url_for_version('0.8.1')
-            assert url == 'http://www.anothersite.org/uo-0.8.1.tgz'
+            assert url == 'http://www.doesnotexist.org/url_override-0.8.1.tar.gz'

--- a/var/spack/repos/builtin.mock/packages/url_override/package.py
+++ b/var/spack/repos/builtin.mock/packages/url_override/package.py
@@ -1,0 +1,34 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class UrlOverride(Package):
+    homepage = 'http://www.doesnotexist.org'
+    url      = 'http://www.doesnotexist.org/url_override-1.0.0.tar.gz'
+
+    version('1.0.0', 'cxyzab')
+    version('0.9.0', 'bcxyza', url='http://www.anothersite.org/uo-0.9.0.tgz')
+    version('0.8.1', 'cxyzab')


### PR DESCRIPTION
fixes #2737

The issue with #2737 was due to the logic with which the nearest URL of a version was computed. This commit changes that logic, so that overrides are local to the versions declaring them.

A unit test has been added to avoid regressions on this issue.