### PR TITLE
Add Caliper 1.7.0 and Gotcha 1.0.2

### DIFF
--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -43,6 +43,8 @@ class Caliper(CMakePackage):
     # version 1.6.0 is broken b/c it downloads the wrong gotcha version
     version('1.6.0',  git='https://github.com/LLNL/Caliper.git', tag='v1.6.0')
 
+    is_linux = sys.platform.startswith('linux')
+
     variant('mpi', default=True, 
             description='Enable MPI wrappers')
     variant('dyninst', default=False, 
@@ -53,12 +55,12 @@ class Caliper(CMakePackage):
     # pthread_self() signature is incompatible with PAPI_thread_init() on Mac
     variant('papi', default=sys.platform != 'darwin',
             description='Enable PAPI service')
-    variant('libpfm', default=sys.platform == 'linux2',
+    variant('libpfm', default=is_linux,
             description='Enable libpfm (perf_events) service')
     # gotcha doesn't work on Mac
     variant('gotcha', default=sys.platform != 'darwin',
             description='Enable GOTCHA support')
-    variant('sampler', default=sys.platform == 'linux2',
+    variant('sampler', default=is_linux,
             description='Enable sampling support on Linux')
     variant('sosflow', default=False,
             description='Enable SOSflow support')

--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -41,7 +41,7 @@ class Caliper(CMakePackage):
     version('master', git='https://github.com/LLNL/Caliper.git')
     version('1.7.0',  git='https://github.com/LLNL/Caliper.git', tag='v1.7.0')
     # version 1.6.0 is broken b/c it downloads the wrong gotcha version
-    # version('1.6.0',  git='https://github.com/LLNL/Caliper.git', tag='v1.6.0')
+    version('1.6.0',  git='https://github.com/LLNL/Caliper.git', tag='v1.6.0')
 
     variant('mpi', default=True, 
             description='Enable MPI wrappers')
@@ -58,6 +58,8 @@ class Caliper(CMakePackage):
     # gotcha doesn't work on Mac
     variant('gotcha', default=sys.platform != 'darwin',
             description='Enable GOTCHA support')
+    variant('sampler', default=sys.platform == 'linux2',
+            description='Enable sampling support on Linux')
     variant('sosflow', default=False,
             description='Enable SOSflow support')
 
@@ -84,6 +86,7 @@ class Caliper(CMakePackage):
             '-DWITH_PAPI=%s'     % ('On' if '+papi'     in spec else 'Off'),
             '-DWITH_LIBPFM=%s'   % ('On' if '+libpfm'   in spec else 'Off'),
             '-DWITH_SOSFLOW=%s'  % ('On' if '+sosflow'  in spec else 'Off'),
+            '-DWITH_SAMPLER=%s'  % ('On' if '+sampler'  in spec else 'Off'),
             '-DWITH_MPI=%s'      % ('On' if '+mpi'      in spec else 'Off'),
             '-DWITH_MPIT=%s' % ('On' if spec.satisfies('^mpi@3:') else 'Off')
         ]

--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -39,6 +39,7 @@ class Caliper(CMakePackage):
     url      = ""
 
     version('master', git='https://github.com/LLNL/Caliper.git')
+    version('1.7.0',  git='https://github.com/LLNL/Caliper.git', tag='v1.7.0')
     version('1.6.0',  git='https://github.com/LLNL/Caliper.git', tag='v1.6.0')
 
     variant('mpi', default=True, 

--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -40,7 +40,8 @@ class Caliper(CMakePackage):
 
     version('master', git='https://github.com/LLNL/Caliper.git')
     version('1.7.0',  git='https://github.com/LLNL/Caliper.git', tag='v1.7.0')
-    version('1.6.0',  git='https://github.com/LLNL/Caliper.git', tag='v1.6.0')
+    # version 1.6.0 is broken b/c it downloads the wrong gotcha version
+    # version('1.6.0',  git='https://github.com/LLNL/Caliper.git', tag='v1.6.0')
 
     variant('mpi', default=True, 
             description='Enable MPI wrappers')
@@ -60,6 +61,7 @@ class Caliper(CMakePackage):
     variant('sosflow', default=False,
             description='Enable SOSflow support')
 
+    depends_on('gotcha@1.0:', when='+gotcha')
     depends_on('dyninst', when='+dyninst')
     depends_on('papi', when='+papi')
     depends_on('libpfm4', when='+libpfm')
@@ -86,6 +88,8 @@ class Caliper(CMakePackage):
             '-DWITH_MPIT=%s' % ('On' if spec.satisfies('^mpi@3:') else 'Off')
         ]
 
+        if '+gotcha' in spec:
+            args.append('-DUSE_EXTERNAL_GOTCHA=True')
         if '+papi' in spec:
             args.append('-DPAPI_PREFIX=%s'    % spec['papi'].prefix)
         if '+libpfm' in spec:

--- a/var/spack/repos/builtin/packages/gotcha/package.py
+++ b/var/spack/repos/builtin/packages/gotcha/package.py
@@ -38,6 +38,7 @@ class Gotcha(CMakePackage):
             branch="develop")
     version('master', git='https://github.com/LLNL/gotcha.git',
             branch="master")
+    version('1.0.2', git='https://github.com/LLNL/gotcha.git', tag="1.0.2")
     version('0.0.2', git='https://github.com/LLNL/gotcha.git', tag="0.0.2")
 
     def configure_args(self):


### PR DESCRIPTION
Add new versions of Caliper and Gotcha. Caliper now uses spack-built gotcha instead of downloading its own.