### PR TITLE
bugfix: fix macos incompatibility in lock test

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -27,8 +27,10 @@ import errno
 import hashlib
 import fileinput
 import glob
+import grp
 import numbers
 import os
+import pwd
 import re
 import shutil
 import stat
@@ -210,6 +212,21 @@ def set_install_permissions(path):
         os.chmod(path, 0o755)
     else:
         os.chmod(path, 0o644)
+
+
+def group_ids(uid=None):
+    """Get group ids that a uid is a member of.
+
+    Arguments:
+        uid (int): id of user, or None for current user
+
+    Returns:
+        (list of int): gids of groups the user is a member of
+    """
+    if uid is None:
+        uid = os.getuid()
+    user = pwd.getpwuid(uid).pw_name
+    return [g.gr_gid for g in grp.getgrall() if user in g.gr_mem]
 
 
 def copy_mode(src, dest):

--- a/lib/spack/spack/test/cmd/debug.py
+++ b/lib/spack/spack/test/cmd/debug.py
@@ -35,8 +35,9 @@ def test_create_db_tarball(tmpdir, database):
     with tmpdir.as_cwd():
         debug('create-db-tarball')
 
+        # get the first non-dotfile to avoid coverage files in the directory
         files = os.listdir(os.getcwd())
-        tarball_name = files[0]
+        tarball_name = next(f for f in files if not f.startswith('.'))
 
         # debug command made an archive
         assert os.path.exists(tarball_name)


### PR DESCRIPTION
Fixes #8225.

- Spack was assuming that a group with gid == current uid would always exist.
- This was breaking the travis build for macos.

- also fixed a bug in the `create_db_tarball` test where `.coverage.*` files weren't properly considered.