### PR TITLE
add CombinatorialSpecSet class for taking cross-products of Specs.

### DIFF
--- a/lib/spack/docs/example_files/test.yaml
+++ b/lib/spack/docs/example_files/test.yaml
@@ -1,0 +1,22 @@
+---
+test-suite:
+    include: [ ape, atompaw, transset]
+    exclude: [binutils,tk]
+    packages:
+        ape:
+            versions: [2.2.1]
+        atompaw:
+            versions: [3.1.0.3, 4.0.0.13]
+        binutils:
+            versions: [2.20.1, 2.25, 2.23.2, 2.24, 2.27, 2.26]
+        tk:
+            versions: [8.6.5, 8.6.3]
+        transset:
+            versions: [1.0.1]
+    compilers:
+        gcc:
+            versions: [4.9, 4.8, 4.7]
+        clang:
+            versions: [3.5, 3.6]
+
+    dashboard: ["https://spack.io/cdash/submit.php?project=spack"]

--- a/lib/spack/docs/index.rst
+++ b/lib/spack/docs/index.rst
@@ -75,6 +75,12 @@ or refer to the full manual below.
    packaging_guide
    developer_guide
    docker_for_developers
+   testing_guide
+
+.. toctree::
+   :maxdepth: 2
+   :caption: API Docs
+
    Spack API Docs <spack>
    LLNL API Docs <llnl>
 

--- a/lib/spack/docs/testing_guide.rst
+++ b/lib/spack/docs/testing_guide.rst
@@ -1,0 +1,299 @@
+.. _testing-guide:
+
+=======
+Testing
+=======
+
+This guide is intended for developers or administrators who want to
+integrate or test software releases built with Spack.
+
+.. _test-single-build:
+
+-------------------------
+Testing a single build
+-------------------------
+
+Spack's :ref:`install <cmd-spack-install>` command can run a spack build
+as a test and generate output for web dashboards such as `CDash
+<http://www.cdash.org/>`_, `Jenkins <https://jenkins.io/>`_, or `Bamboo
+<https://www.atlassian.com/software/bamboo>`_.
+
+These output formats are enabled using the ``--log-format`` option to
+``spack install``:
+
+.. code-block:: console
+
+   $ spack install --log-format=junit <spec>
+
+By default, the log results will be placed into
+``var/<format>/test-<short_spec>.xml``.  To change the default behaviour,
+use
+
+.. code-block:: console
+
+   $ spack install --log-file report --log-format=junit <spec>
+
+The logs contain one test case per package being built.
+
+^^^^^
+Junit
+^^^^^
+
+To generate logs in `JUnit <http://junit.org/>`_ format, use
+``--log-format=junit``:
+
+.. code-block:: console
+
+   $ spack install --log-format=junit <spec>
+
+The `Jenkins <https://jenkins.io/>`_, `Bamboo
+<https://www.atlassian.com/software/bamboo>`_ and many other tools can
+use JUnit.
+
+^^^^^
+CDash
+^^^^^
+
+`CDash <https://www.cdash.org>`__ is an open source web application from
+`Kitware <https://www.kitware.com>`_ that displays the results of
+software builds and test runs.  Spack can generate output for CDash using
+either of these options to ``spack install``:
+
+  * ``--log-format=cdash-simple``
+  * ``--log-format=cdash-complete``
+
+For example:
+
+.. code-block:: console
+
+   $ spack install --log-file report --log-format=cdash-simple libelf
+
+This will generate a file called ``report.xml`` that contains a
+description of a build of ``libelf``:
+
+.. code-block:: xml
+
+    <?xml version="1.0" ?>
+    <Site BuildName="libelf@0.8.12%gcc@6.2.0 arch darwin-elcapitan-x86_64 /qmbmcez"
+          BuildStamp="20172803-12:00:08-Experimental"
+          CompilerName="gcc"
+          CompilerVersion="6.2.0"
+          Hostname="OS X 10.11.6"
+          Name="atala.llnl.gov"
+          OSName="OS X 10.11.6">
+        <Build>
+            <StartDateTime>Mar 28 12:00 PDT</StartDateTime>
+            <StartBuildTime>1490727615</StartBuildTime>
+            <BuildCommand>spack install</BuildCommand>
+            <Log Encoding="base64">
+                <!-- ... long build log text goes here ... -->
+            </Log>
+            <EndDateTime>Mar 28 12:00 PDT</EndDateTime>
+            <EndBuildTime>1490727615</EndBuildTime>
+            <ElapsedMinutes>0</ElapsedMinutes>
+        </Build>
+    </Site>
+
+Spack uses a short version of each package's spec as the CDash build
+name, which will be shown in the dashboard.
+
+For more detailed output, you can use the ``cdash-complete`` format:
+
+.. code-block:: console
+
+   $ spack install --log-file report --log-format=cdash-complete libelf
+
+This will create separate files: ``report.build.xml``,
+``report.configure.xml``, and ``report.test.xml``, for the build,
+configure, and tests steps, respectively.
+
+If you want to upload these fils to a CDash instance, you can use ``curl``:
+
+.. code-block:: console
+
+   $ curl --upload-file report.build.xml https://example.com/cdash/submit.php?project=<projectname>
+   $ curl --upload-file report.configure.xml https://example.com/cdash/submit.php?project=<projectname>
+   $ curl --upload-file report.test.xml https://example.com/cdash/submit.php?project=<projectname>
+
+Spack can also automate this step for you as part of the ``spack
+test-suite`` command described in the next section.
+
+
+.. _cmd-spack-test-suite:
+
+---------------------
+CDash test suites
+---------------------
+
+The ``spack test-suite`` command reads in a specialy formatted YAML file
+describing a set of combinatorial tests.  It can be used to easily test a
+package or suite of packages with many different compilers and build
+options.
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Test suite YAML format
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Here's an example file:
+
+.. code-block:: yaml
+
+   #
+   # This YAML file describes a Spack test suite
+   #
+   test-suite:
+       #
+       # Optional include/exclude spec lists and upload information.
+       #
+
+       # Only specs that match a spec in this list will be included in
+       # the tests.  If include is missing, all specs are built.
+       include: [bzip2, libelf, libdwarf]
+
+       # Specs that match a spec in this list are excluded.
+       # If exclude is missing or empty, all included packages are built.
+       exclude: []
+
+       # URL of the cdash server where results should be submitted.
+       # Optional. Defaults to https://spack.io/cdash
+       - cdash: ["https://spack.io/cdash"]
+
+       # Project on the cdash server where results should be submitted.
+       # Optional. Defaults to 'spack'.
+       - project: spack
+
+       # Build matrix.  Spack takes the cartesian product of each dimension
+       # in this section to define a set of specs to build.
+       matrix:
+         # List of packages, each with a set of versions to test.
+         - packages:
+             abinit:
+               versions: [8.0.8b]
+             ack:
+               versions: [2.14]
+
+         # List of compiler versions. Each package is tested with all
+         # compiler versions.
+         - compilers:
+             gcc:
+               versions: [4.9.0, 4.7.1, 4.6.3, 4.6.1]
+             clang:
+               versions: [7.3.0, 3.4, 3.1]
+
+
+All fields *except* ``packages`` and ``compilers`` are optional.  The
+``packages`` section contains a list of Spack package names and versions
+to be built.  Similarly, the ``compilers`` section contains a list of
+compilers to test all the packages with.
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Excluding and including builds
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can exclude or include builds that match a particular pattern using
+lists of :ref:`Specs <sec-specs>`.  For example, to include only builds
+of abinit, you could write:
+
+.. code-block:: yaml
+
+   include: [abinit]
+
+To include only builds using some version of gcc, youc could write:
+
+.. code-block:: yaml
+
+   include: ['%gcc']
+
+To add to that and exclude all builds of gcc 4.6, you could write:
+
+.. code-block:: yaml
+
+   include: ['%gcc']
+   exclude: ['%gcc@4.6']
+
+For more information on spec matching semantics, see the section on
+:ref:`Specs <sec-specs>`.
+
+.. note::
+
+   Currently, we only support combinatorial builds with different package
+   and compiler versions.  We are working on adding combinatorial builds
+   on variants, compiler flags, and other spec attributes.
+
+
+^^^^^^^^^^^^^
+Build output
+^^^^^^^^^^^^^
+
+By default, ``spack test-suite`` creates output in a directory called
+``spack-test-YYYY-MM-DD``, where ``YYYY-MM-DD`` is the date on which the
+test suite was run.  For example, consider this ``test.yaml`` file:
+
+.. code-block:: yaml
+
+   test-suite:
+     packages:
+       libelf:
+         versions: [0.8.12]
+       libdwarf:
+         versions: [0.8.12]
+
+     compilers:
+       clang:
+         versions: [7.0.2-apple]
+       gcc:
+         versions: [6.2.0]
+
+Running spack test-suite with this file would produce an output directory
+called, e.g., ``spack-test-2017-03-28``:
+
+.. code-block:: console
+
+   $ spack test-suite ./test.yaml
+
+   # ... output ...
+
+   $ ls spack-test-2017-03-28
+   build-libdwarf-0.8.12-5akzclxk74z44zml43yx767ipxd7wwz4.xml
+   build-libdwarf-0.8.12-e2viv23cr6lih2gn4ap6327qdsz4boyn.xml
+   build-libelf-0.8.12-qmbmcezdqmbwreie3u2cns5zwxvjmzil.xml
+   build-libelf-0.8.12-yroox5qmqvpbrve6bgggxfyyekijundb.xml
+
+These XML files are like the ones described in :ref:`test-single-build`,
+but now there is a file for each parameter combination from the
+``test.yaml`` file.  There are two builds each of ``libelf`` and
+``libdwarf``, one for each compiler version.
+
+``spack test-suite`` produces simple output by default.  To get the CDash
+complete output (whcih shows separate configure, build, and test
+results), use ``--complete`` flag to change the output mode:
+
+.. code-block:: console
+
+  $ spack test-suite --complete ./test.yaml
+
+^^^^^^^^^^^^^^^^^^
+Uploading results
+^^^^^^^^^^^^^^^^^^
+
+In addition to writing XML output to a local directory, ``spack
+test-suite`` can automatically upload build results to a CDash server.
+
+Results will be uploaded if you provide any of these parameters to
+``spack test-suite``:
+
+  * ``--cdash URL`` The URL of a CDash server to which we should upload
+    files.  This defaults to ``https://spack.io/cdash``.
+
+  * ``--project NAME`` The name of a project on the CDash server where
+    the results should be reported.  This defaults to ``spack``.
+
+If either of these options is provided, Spack uploads all test results to
+the server.  For example, this command:
+
+.. code-block:: console
+
+   $ spack test-suite --cdash https://my.cdash.org --project myproject ./test.yaml
+
+will run the test suite described by ``test.yaml`` and upload the results
+to ``https://my.cdash.org/submit.php?project=myproject``.

--- a/lib/spack/spack/schema/test_suite.py
+++ b/lib/spack/spack/schema/test_suite.py
@@ -1,0 +1,129 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+"""Schema for Spack test-suite configuration file.
+
+.. literalinclude:: ../spack/schema/test_suite.py
+   :lines: 32-
+"""
+
+
+schema = {
+    '$schema': 'http://json-schema.org/schema#',
+    'title': 'Spack test configuration file schema',
+    'definitions': {
+        # used for include/exclude
+        'list_of_specs': {
+            'type': 'array',
+            'items': {'type': 'string'}
+        },
+        # used for compilers and for packages
+        'objects_with_version_list': {
+            'type': 'object',
+            'additionalProperties': False,
+            'patternProperties': {
+                r'\w[\w-]*': {
+                    'type': 'object',
+                    'additionalProperties': False,
+                    'required': ['versions'],
+                    'properties': {
+                        'versions': {
+                            'type': 'array',
+                            'items': {
+                                'oneOf': [
+                                    {'type': 'string'},
+                                    {'type': 'number'},
+                                ],
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        'packages': {
+            'type': 'object',
+            'additionalProperties': False,
+            'properties': {
+                'packages': {
+                    '$ref': '#/definitions/objects_with_version_list'
+                },
+            }
+        },
+        'compilers': {
+            'type': 'object',
+            'additionalProperties': False,
+            'properties': {
+                'compilers': {
+                    '$ref': '#/definitions/objects_with_version_list'
+                },
+            }
+        },
+        'specs': {
+            'type': 'object',
+            'additionalProperties': False,
+            'properties': {
+                'specs': {'$ref': '#/definitions/list_of_specs'},
+            }
+        },
+    },
+    # this is the actual top level object
+    'type': 'object',
+    'additionalProperties': False,
+    'properties': {
+        'test-suite': {
+            'type': 'object',
+            'additionalProperties': False,
+            'required': ['matrix'],
+            'properties': {
+                # top-level settings are keys and need to be unique
+                'include': {'$ref': '#/definitions/list_of_specs'},
+                'exclude': {'$ref': '#/definitions/list_of_specs'},
+                'cdash': {
+                    'oneOf': [
+                        {'type': 'string'},
+                        {'type': 'array',
+                         'items': {'type': 'string'}
+                        },
+                    ],
+                },
+                'project': {
+                    'type': 'string',
+                },
+                # things under matrix (packages, compilers, etc.)  are a
+                # list so that we can potentiall have multiple of them.
+                'matrix': {
+                    'type': 'array',
+                    'items': {
+                        'type': 'object',
+                        'oneOf': [
+                            {'$ref': '#/definitions/specs'},
+                            {'$ref': '#/definitions/packages'},
+                            {'$ref': '#/definitions/compilers'},
+                        ],
+                    },
+                },
+            },
+        },
+    },
+}

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2340,6 +2340,9 @@ class Spec(object):
                     self.variants[v], other.variants[v]
                 )
 
+        if self.name is None and other.name is not None:
+            self.name = other.name
+
         # TODO: Check out the logic here
         sarch, oarch = self.architecture, other.architecture
         if sarch is not None and oarch is not None:

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -561,6 +561,11 @@ class TestSpecSematics(object):
     # ========================================================================
     # Constraints
     # ========================================================================
+    def test_constrain_name(self):
+        """Ensure anonymous specs can be constrained."""
+        check_constrain('libelf@0.8.13%gcc@4.5', '%gcc@4.5', 'libelf@0.8.13')
+        check_constrain('libelf@4.6:4.7', '@4.5:4.7', 'libelf@4.6:4.8')
+
     def test_constrain_variants(self):
         check_constrain('libelf@2.1:2.5', 'libelf@0:2.5', 'libelf@2.1:3')
         check_constrain(

--- a/lib/spack/spack/test/spec_set.py
+++ b/lib/spack/spack/test/spec_set.py
@@ -1,0 +1,305 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+import pytest
+
+from spack.spec import Spec
+from spack.schema import FileFormatError
+from spack.util.spec_set import CombinatorialSpecSet
+
+
+pytestmark = pytest.mark.usefixtures('config')
+
+
+basic_yaml_file = {
+    'test-suite': {
+        'include': ['gmake'],
+        'matrix': [
+            {'packages': {
+                'gmake': {
+                    'versions': ['4.0']
+                }
+            }},
+            {'compilers': {
+                'gcc': {
+                    'versions': ['4.2.1', '6.3.0']
+                }, 'clang': {
+                    'versions': ['8.0', '3.8']
+                }
+            }},
+        ]
+    }
+}
+
+
+def test_spec_set_basic():
+    spec_set = CombinatorialSpecSet(basic_yaml_file, False)
+    specs = list(spec for spec in spec_set)
+    assert len(specs) == 4
+
+
+def test_spec_set_no_include():
+    yaml_file = {
+        'test-suite': {
+            'matrix': [
+                {'packages': {
+                    'gmake': {
+                        'versions': ['4.0']
+                    }
+                }},
+                {'compilers': {
+                    'gcc': {
+                        'versions': ['4.2.1', '6.3.0']
+                    }, 'clang': {
+                        'versions': ['8.0', '3.8']
+                    }
+                }},
+            ]
+        }
+    }
+    spec_set = CombinatorialSpecSet(yaml_file, False)
+    specs = list(spec for spec in spec_set)
+    assert len(specs) == 4
+
+
+def test_spec_set_exclude():
+    yaml_file = {
+        'test-suite': {
+            'include': ['gmake'],
+            'exclude': ['gmake'],
+            'matrix': [
+                {'packages': {
+                    'gmake': {
+                        'versions': ['4.0']
+                    }
+                }},
+                {'compilers': {
+                    'gcc': {
+                        'versions': ['4.2.1', '6.3.0']
+                    }, 'clang': {
+                        'versions': ['8.0', '3.8']
+                    }
+                }},
+            ]
+        }
+    }
+    spec_set = CombinatorialSpecSet(yaml_file, False)
+    specs = list(spec for spec in spec_set)
+    assert len(specs) == 0
+
+
+def test_spec_set_include_limited_packages():
+    yaml_file = {
+        'test-suite': {
+            'include': ['gmake'],
+            'matrix': [
+                {'packages': {
+                    'gmake': {
+                        'versions': ['4.0']
+                    },
+                    'appres': {
+                        'versions': ['1.0.4']
+                    },
+                    'allinea-reports': {
+                        'versions': ['6.0.4']
+                    }
+                }},
+                {'compilers': {
+                    'gcc': {
+                        'versions': ['4.2.1', '6.3.0']
+                    }, 'clang': {
+                        'versions': ['8.0', '3.8']
+                    }
+                }},
+            ]
+        }
+    }
+    spec_set = CombinatorialSpecSet(yaml_file, False)
+    specs = list(spec for spec in spec_set)
+    assert len(specs) == 4
+
+
+def test_spec_set_simple_spec_list():
+    yaml_file = {
+        'test-suite': {
+            'matrix': [
+                {'specs': [
+                    'gmake@4.0',
+                    'appres@1.0.4',
+                    'allinea-reports@6.0.4'
+                ]},
+            ]
+        }
+    }
+    spec_set = CombinatorialSpecSet(yaml_file, False)
+    specs = list(spec for spec in spec_set)
+    assert len(specs) == 3
+
+
+def test_spec_set_with_specs():
+    yaml_file = {
+        'test-suite': {
+            'include': ['gmake', 'appres'],
+            'matrix': [
+                {'specs': [
+                    'gmake@4.0',
+                    'appres@1.0.4',
+                    'allinea-reports@6.0.4'
+                ]},
+                {'compilers': {
+                    'gcc': {
+                        'versions': ['4.2.1', '6.3.0']
+                    }, 'clang': {
+                        'versions': ['8.0', '3.8']
+                    }
+                }},
+            ]
+        }
+    }
+    spec_set = CombinatorialSpecSet(yaml_file, False)
+    specs = list(spec for spec in spec_set)
+    assert len(specs) == 8
+
+
+def test_spec_set_compilers_bad_property():
+    yaml_file = {
+        'test-suite': {
+            'foobar': ['gmake'],
+            'matrix': [
+                {'packages': {
+                    'gmake': {'versions': ['4.0']},
+                }},
+                {'compilers': {
+                    'gcc': {'versions': ['4.2.1', '6.3.0']},
+                    'clang': {'versions': ['8.0', '3.8']},
+                }},
+            ]
+        }
+    }
+    with pytest.raises(FileFormatError):
+        CombinatorialSpecSet(yaml_file)
+
+
+def test_spec_set_packages_no_matrix():
+    yaml_file = {
+        'test-suite': {
+            'include': ['gmake'],
+            'packages': {
+                'gmake': {
+                    'versions': ['4.0']
+                },
+                'appres': {
+                    'versions': ['1.0.4']
+                },
+                'allinea-reports': {
+                    'versions': ['6.0.4']
+                }
+            },
+        }
+    }
+    with pytest.raises(FileFormatError):
+        CombinatorialSpecSet(yaml_file)
+
+
+def test_spec_set_get_cdash_string():
+    yaml_file = {
+        'test-suite': {
+            'cdash': 'http://example.com/cdash',
+            'project': 'testproj',
+            'matrix': [
+                {'packages': {
+                    'gmake': {'versions': ['4.0']},
+                }},
+                {'compilers': {
+                    'gcc': {'versions': ['4.2.1', '6.3.0']},
+                    'clang': {'versions': ['8.0', '3.8']},
+                }},
+            ]
+        }
+    }
+
+    spec_set = CombinatorialSpecSet(yaml_file)
+    assert spec_set.cdash == ['http://example.com/cdash']
+    assert spec_set.project == 'testproj'
+
+
+def test_spec_set_get_cdash_array():
+    yaml_file = {
+        'test-suite': {
+            'cdash': ['http://example.com/cdash', 'http://example.com/cdash2'],
+            'project': 'testproj',
+            'matrix': [
+                {'packages': {
+                    'gmake': {'versions': ['4.0']},
+                }},
+                {'compilers': {
+                    'gcc': {'versions': ['4.2.1', '6.3.0']},
+                    'clang': {'versions': ['8.0', '3.8']},
+                }},
+            ]
+        }
+    }
+
+    spec_set = CombinatorialSpecSet(yaml_file)
+    assert spec_set.cdash == [
+        'http://example.com/cdash', 'http://example.com/cdash2']
+    assert spec_set.project == 'testproj'
+
+
+def test_compiler_specs():
+    spec_set = CombinatorialSpecSet(basic_yaml_file, False)
+    compilers = spec_set._compiler_specs({
+        'gcc': {
+            'versions': ['4.2.1', '6.3.0']
+        }, 'clang': {
+            'versions': ['8.0', '3.8']
+        }})
+
+    assert Spec('%gcc@4.2.1') in compilers
+    assert Spec('%gcc@6.3.0') in compilers
+    assert Spec('%clang@8.0') in compilers
+    assert Spec('%clang@3.8') in compilers
+
+
+def test_package_specs():
+    spec_set = CombinatorialSpecSet(basic_yaml_file, False)
+
+    packages = spec_set._package_specs({
+        'gmake': {
+            'versions': ['4.0', '5.0']
+        },
+        'appres': {
+            'versions': ['1.0.4']
+        },
+        'allinea-reports': {
+            'versions': ['6.0.1', '6.0.3', '6.0.4']
+        }
+    })
+
+    assert Spec('gmake@4.0') in packages
+    assert Spec('gmake@5.0') in packages
+    assert Spec('appres@1.0.4') in packages
+    assert Spec('allinea-reports@6.0.1') in packages
+    assert Spec('allinea-reports@6.0.3') in packages
+    assert Spec('allinea-reports@6.0.4') in packages

--- a/lib/spack/spack/util/spec_set.py
+++ b/lib/spack/spack/util/spec_set.py
@@ -1,0 +1,189 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+import itertools
+
+import llnl.util.tty as tty
+from llnl.util.tty.colify import colify
+
+import spack
+import spack.compilers
+import spack.architecture as sarch
+import spack.schema as schema
+import spack.util.spack_yaml as syaml
+
+from spack.spec import Spec, ArchSpec
+
+
+class CombinatorialSpecSet:
+    """Set of combinatorial Specs constructed from YAML file."""
+
+    def __init__(self, yaml_like, ignore_invalid=True):
+        """Construct a combinatorial Spec set.
+
+        Args:
+            yaml_like: either raw YAML data as a dict, a file-like object
+                to read the YAML from, or a string containing YAML.  * A
+                file-like object to read YAML from. In the first case, we
+                assume already-parsed YAML data.  In the second two
+                cases, we just run yaml.load() on the data.
+            ignore_invalid (bool): whether to ignore invalid specs when
+                expanding the values of this spec set.
+        """
+        self.ignore_invalid = ignore_invalid
+
+        if isinstance(yaml_like, dict):
+            # if it's raw data, just assign it to self.data
+            self.data = yaml_like
+        else:
+            # otherwise try to load it.
+            self.data = syaml.load(yaml_like)
+
+        # validate against the test suite schema
+        schema.validate(self.data, schema.test_suite.schema)
+
+        # chop off the initial test-suite label after valiation.
+        self.data = self.data['test-suite']
+
+        # initialize these from data.
+        self.cdash = self.data.get('cdash', None)
+        if isinstance(self.cdash, str):
+            self.cdash = [self.cdash]
+        self.project = self.data.get('project', None)
+
+        # _spec_lists is a list of lists of specs, to be combined as a
+        # cartesian product when we iterate over all specs in the set.
+        # it's initialized lazily.
+        self._spec_lists = None
+        self._include = []
+        self._exclude = []
+
+    def all_package_versions(self):
+        """Get package/version combinations for all spack packages."""
+        for name in spack.repo.all_package_names():
+            pkg = spack.repo.get(name)
+            for v in pkg.versions:
+                yield Spec('{0}@{1}'.format(name, v))
+
+    def _specs(self, data):
+        """Read a list of specs from YAML data"""
+        return [Spec(s) for s in data]
+
+    def _compiler_specs(self, data):
+        """Read compiler specs from YAML data.
+        Example YAML:
+            gcc:
+                versions: [4.4.8, 4.9.3]
+            clang:
+                versions: [3.6.1, 3.7.2, 3.8]
+
+        Optionally, data can be 'all', in which case all compilers for
+        the current platform are returned.
+        """
+        # get usable compilers for current platform.
+        arch = ArchSpec(str(sarch.platform()), 'default_os', 'default_target')
+        available_compilers = [
+            c.spec for c in spack.compilers.compilers_for_arch(arch)]
+
+        # return compilers for this platform if asked for everything.
+        if data == 'all':
+            return [cspec.copy() for cspec in available_compilers]
+
+        # otherwise create specs from the YAML file.
+        cspecs = set([
+            Spec('%{0}@{1}'.format(compiler, version))
+            for compiler in data for version in data[compiler]['versions']])
+
+        # filter out invalid specs if caller said to ignore them.
+        if self.ignore_invalid:
+            missing = [c for c in cspecs if not any(
+                c.compiler.satisfies(comp) for comp in available_compilers)]
+            tty.warn("The following compilers were unavailable:")
+            colify(sorted(m.compiler for m in missing))
+            cspecs -= set(missing)
+
+        return cspecs
+
+    def _package_specs(self, data):
+        """Read package/version specs from YAML data.
+        Example YAML:
+            gmake:
+                versions: [4.0, 4.1, 4.2]
+            qt:
+                versions: [4.8.6, 5.2.1, 5.7.1]
+
+        Optionally, data can be 'all', in which case all packages and
+        versions from the package repository are returned.
+        """
+        if data == 'all':
+            return set(self.all_package_versions())
+
+        return set([
+            Spec('{0}@{1}'.format(name, version))
+            for name in data for version in data[name]['versions']])
+
+    def _get_specs(self, matrix_dict):
+        """Parse specs out of an element in the build matrix."""
+        readers = {
+            'packages': self._package_specs,
+            'compilers': self._compiler_specs,
+            'specs': self._specs
+        }
+
+        key = next(iter(matrix_dict), None)
+        assert key in readers
+        return readers[key](matrix_dict[key])
+
+    def __iter__(self):
+        # read in data from YAML file lazily.
+        if self._spec_lists is None:
+            self._spec_lists = [self._get_specs(spec_list)
+                                for spec_list in self.data['matrix']]
+
+            if 'include' in self.data:
+                self._include = [Spec(s) for s in self.data['include']]
+            if 'exclude' in self.data:
+                self._exclude = [Spec(s) for s in self.data['exclude']]
+
+        for spec_list in itertools.product(*self._spec_lists):
+            # if there is an empty array in spec_lists, we'll get this.
+            if not spec_list:
+                yield spec_list
+                continue
+
+            # merge all the constraints in spec_list with each other
+            spec = spec_list[0].copy()
+            for s in spec_list[1:]:
+                spec.constrain(s)
+
+            # test each spec for include/exclude
+            if (self._include and
+                not any(spec.satisfies(s) for s in self._include)):
+                continue
+
+            if any(spec.satisfies(s) for s in self._exclude):
+                continue
+
+            # we now know we can include this spec in the set
+            yield spec


### PR DESCRIPTION
@scottwittenburg: this is the class for specifying products of specs that I was mentioning.  There are some docs in here; some parts need a lot of refactoring, but other parts describe the file format and what it does.  

Take a look at those and see if you can work this into your PR to specify what releases should look like.  currently, the format has two ways to specify the same thing.  You can use `packages` and `compilers` sections, or you can just have lists of `spec`s.  I think the latter should be sufficient so I'm tempted to take out the packages/compilers sections. The `include` and `exclude` lines would still be useful (for including/excluding by matching).

The schema format should probably should be renamed to something other than `test-suite` as it's useful for both releases and for tests.  If you can come up with a generic name that would be great.

I think the way to start with this would be to have a YAML file that describes what is to be released, so that you can get an initial list of specs to check against in #8451.

@zackgalbreath: there are some docs in here on how to use `spack install --log-format` that should probably be separated out, as well.  Maybe we could have a separate doc PR on CDash support?

- add `CombinatorialSpecSet` in `spack.util.spec_set` module.
  - class is iterable and encaspulated YAML parsing and validation.

- Add a schema format for test-suites (which you can instantiate `CombinatorialSpecSet`s from)

- YAML format supports:
  - test-suite format has a `matrix` section, which can contain multiple lists of specs, generated different ways. Including:
    - specs: a raw list of specs.
    - packages: a list of package names and versions
    - compilers: a list of compiler names and versions

  - All of the elements of `matrix` are dimensions for the build matrix;
    we take the cartesian product of these lists of specs to generate a
    build matrix.  This means we can add things like [^mpich, ^openmpi]
    to get builds with different MPI versions.  It also means we can
    multiply the build matrix out with lots of different parameters.

- Bug fixes:
  - [x] fix bug with constraining an anonymous spec by name, add a test.