### PR TITLE
py-numpy: Fix C{,PLUS}_INCLUDE_PATH in module

### DIFF
--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -28,6 +28,7 @@ import platform
 
 class PyNumpy(PythonPackage):
     """NumPy is the fundamental package for scientific computing with Python.
+
     It contains among other things: a powerful N-dimensional array object,
     sophisticated (broadcasting) functions, tools for integrating C/C++ and
     Fortran code, and useful linear algebra, Fourier transform, and random
@@ -76,14 +77,11 @@ class PyNumpy(PythonPackage):
 
     def setup_dependent_package(self, module, dependent_spec):
         python_version = self.spec['python'].version.up_to(2)
-        arch = '{0}-{1}'.format(platform.system().lower(), platform.machine())
 
         self.spec.include = join_path(
             self.prefix.lib,
             'python{0}'.format(python_version),
             'site-packages',
-            'numpy-{0}-py{1}-{2}.egg'.format(
-                self.spec.version, python_version, arch),
             'numpy/core/include')
 
     def patch(self):
@@ -157,6 +155,18 @@ class PyNumpy(PythonPackage):
                 args = ['-j', str(make_jobs)]
 
         return args
+
+    def setup_environment(self, spack_env, run_env):
+        python_version = self.spec['python'].version.up_to(2)
+
+        include_path = join_path(
+            self.prefix.lib,
+            'python{0}'.format(python_version),
+            'site-packages',
+            'numpy/core/include')
+
+        run_env.prepend_path('C_INCLUDE_PATH', include_path)
+        run_env.prepend_path('CPLUS_INCLUDE_PATH', include_path)
 
     def test(self):
         # `setup.py test` is not supported.  Use one of the following


### PR DESCRIPTION
Also fix setup_dependent_package to include the ".egg-less" include
path.