### PR TITLE
switch git to kernel.org source and sha256

### DIFF
--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -35,7 +35,6 @@ class Git(AutotoolsPackage):
 
     homepage = "http://git-scm.com"
     url      = "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.12.0.tar.gz"
-    # url      = "https://github.com/git/git/archive/v2.12.0.tar.gz"
 
     # In order to add new versions here, add a new list entry with:
     # * version: {version}

--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -47,13 +47,13 @@ class Git(AutotoolsPackage):
     releases = [
         {
             'version': '2.17.1',
-            'sha256': 'e04bfbbe5f17a4faa9507c75b8505c13',
-            'sha256_manpages': 'f1d5dfc1459c9f2885f790c5af7473d1'
+            'sha256': '7a0cff35dbb14b77dca6924c33ac9fe510b9de35d5267172490af548ec5ee1b8',
+            'sha256_manpages': '41b58c68e90e4c95265c75955ddd5b68f6491f4d57b2f17c6d68e60bbb07ba6a'
         },
         {
             'version': '2.17.0',
-            'sha256': '8e0f5253eef3abeb76bd9c55386d3bee',
-            'sha256_manpages': '1ce1ae78a559032810af8b455535935f'
+            'sha256': 'ec6452f0c8d5c1f3bcceabd7070b8a8a5eea11d4e2a04955c139b5065fd7d09a',
+            'sha256_manpages': '9732053c1a618d2576c1751d0249e43702f632a571f84511331882beb360677d'
         },
         {
             'version': '2.15.1',

--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -34,129 +34,131 @@ class Git(AutotoolsPackage):
     """
 
     homepage = "http://git-scm.com"
-    url      = "https://github.com/git/git/archive/v2.12.0.tar.gz"
+    url      = "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.12.0.tar.gz"
+    # url      = "https://github.com/git/git/archive/v2.12.0.tar.gz"
 
     # In order to add new versions here, add a new list entry with:
     # * version: {version}
-    # * md5: the md5sum of the v{version}.tar.gz
-    # * md5_manpages: the md5sum of the corresponding manpage from
+    # * sha256: the sha256sum of the git-{version}.tar.gz
+    # * sha256_manpages: the sha256sum of the corresponding manpage from
     #       https://www.kernel.org/pub/software/scm/git/git-manpages-{version}.tar.xz
+    # You can find the source here: https://mirrors.edge.kernel.org/pub/software/scm/git/sha256sums.asc
 
     releases = [
         {
             'version': '2.17.1',
-            'md5': 'e04bfbbe5f17a4faa9507c75b8505c13',
-            'md5_manpages': 'f1d5dfc1459c9f2885f790c5af7473d1'
+            'sha256': 'e04bfbbe5f17a4faa9507c75b8505c13',
+            'sha256_manpages': 'f1d5dfc1459c9f2885f790c5af7473d1'
         },
         {
             'version': '2.17.0',
-            'md5': '8e0f5253eef3abeb76bd9c55386d3bee',
-            'md5_manpages': '1ce1ae78a559032810af8b455535935f'
+            'sha256': '8e0f5253eef3abeb76bd9c55386d3bee',
+            'sha256_manpages': '1ce1ae78a559032810af8b455535935f'
         },
         {
             'version': '2.15.1',
-            'md5': 'da59fc6baa55ab44684011e369af397d',
-            'md5_manpages': '2cb428071c08c7df513cfc103610536e',
+            'sha256': '85fca8781a83c96ba6db384cc1aa6a5ee1e344746bafac1cbe1f0fe6d1109c84',
+            'sha256_manpages': '472454c494c9a7f50ad38060c3eec372f617de654b20f3eb3be59fc17a683fa1',
         },
         {
             'version': '2.14.1',
-            'md5': 'e965a37b3d277f2e7e78f5b04de28e2a',
-            'md5_manpages': 'da2e75ea3972b9e93fb47023e3bf1401',
+            'sha256': '01925349b9683940e53a621ee48dd9d9ac3f9e59c079806b58321c2cf85a4464',
+            'sha256_manpages': '8c5810ce65d44cd333327d3a115c5b462712a2f81225d142e07bd889ad8dc0e0',
         },
         {
             'version': '2.13.0',
-            'md5': 'd0f14da0ef1d22f1ce7f7876fadcb39f',
-            'md5_manpages': 'fda8d6d5314eb5a47e315405830f9970',
+            'sha256': '9f2fa8040ebafc0c2caae4a9e2cb385c6f16c0525bcb0fbd84938bc796372e80',
+            'sha256_manpages': 'e764721796cad175a4cf9a4afe7fb4c4fc57582f6f9a6e214239498e0835355b',
         },
         {
             'version': '2.12.2',
-            'md5': 'f1a50c09ce8b5dd197f3c6c6d5ea8e75',
-            'md5_manpages': '9358777e9a67e57427b03884c82311bd',
+            'sha256': 'd9c6d787a24670d7e5100db2367c250ad9756ef8084fb153a46b82f1d186f8d8',
+            'sha256_manpages': '6e7ed503f1190734e57c9427df356b42020f125fa36ab0478777960a682adf50',
         },
         {
             'version': '2.12.1',
-            'md5': 'a05c614c80ecd41e50699f1562e1130c',
-            'md5_manpages': '8dfba0c9f51c6c23fb135d136c061c78',
+            'sha256': '65d62d10caf317fc1daf2ca9975bdb09dbff874c92d24f9529d29a7784486b43',
+            'sha256_manpages': '35e46b8acd529ea671d94035232b1795919be8f3c3a363ea9698f1fd08d7d061',
         },
         {
             'version': '2.12.0',
-            'md5': '11a440ce0ed02098adf554c797facfd3',
-            'md5_manpages': '4d11e05068231e37d7e42935e9cc43a1',
+            'sha256': '882f298daf582a07c597737eb4bbafb82c6208fe0e73c047defc12169c221a92',
+            'sha256_manpages': '1f7733a44c59f9ae8dd321d68a033499a76c82046025cc2a6792299178138d65',
         },
         {
             'version': '2.11.1',
-            'md5': '2cf960f19e56f27248816809ae896794',
-            'md5_manpages': 'ade1e458a34a89d03dda9a6de85976bd',
+            'sha256': 'a1cdd7c820f92c44abb5003b36dc8cb7201ba38e8744802399f59c97285ca043',
+            'sha256_manpages': 'ee567e7b0f95333816793714bb31c54e288cf8041f77a0092b85e62c9c2974f9',
         },
         {
             'version': '2.11.0',
-            'md5': 'c63fb83b86431af96f8e9722ebb3ca01',
-            'md5_manpages': '72718851626e5b2267877cc2194a1ac9',
+            'sha256': 'd3be9961c799562565f158ce5b836e2b90f38502d3992a115dfb653d7825fd7e',
+            'sha256_manpages': '437a0128acd707edce24e1a310ab2f09f9a09ee42de58a8e7641362012dcfe22',
         },
         {
             'version': '2.9.3',
-            'md5': 'b0edfc0f3cb046aec7ed68a4b7282a75',
-            'md5_manpages': '337165a3b2bbe4814c73075cb6854ca2',
+            'sha256': 'a252b6636b12d5ba57732c8469701544c26c2b1689933bd1b425e603cbb247c0',
+            'sha256_manpages': '8ea1a55b048fafbf0c0c6fcbca4b5b0f5e9917893221fc7345c09051d65832ce',
         },
         {
             'version': '2.9.2',
-            'md5': '3ff8a9b30fd5c99a02e6d6585ab543fc',
-            'md5_manpages': 'c4f415b4fc94cf75a1deb651ba769594',
+            'sha256': '3cb09a3917c2d8150fc1708f3019cf99a8f0feee6cd61bba3797e3b2a85be9dc',
+            'sha256_manpages': 'ac5c600153d1e4a1c6494e250cd27ca288e7667ad8d4ea2f2386f60ba1b78eec',
         },
         {
             'version': '2.9.1',
-            'md5': 'a5d806743a992300b45f734d1667ddd2',
-            'md5_manpages': '2aa797ff70c704a563c910e04c0f620a',
+            'sha256': 'c2230873bf77f93736473e6a06501bf93eed807d011107de6983dc015424b097',
+            'sha256_manpages': '324f5f173f2bd50b0102b66e474b81146ccc078d621efeb86d7f75e3c1de33e6',
         },
         {
             'version': '2.9.0',
-            'md5': 'bf33a13c2adc05bc9d654c415332bc65',
-            'md5_manpages': 'c840c968062251b768ba9852fd29054c',
+            'sha256': 'bff7560f5602fcd8e37669e0f65ef08c6edc996e4f324e4ed6bb8a84765e30bd',
+            'sha256_manpages': '35ba69a8560529aa837e395a6d6c8d42f4d29b40a3c1cc6e3dc69bb1faadb332',
         },
         {
             'version': '2.8.4',
-            'md5': '86afb10254c3803894c9863fb5896bb6',
-            'md5_manpages': '8340e772d60ccd04a5da88fa9c976dad',
+            'sha256': '626e319f8a24fc0866167ea5f6bf3e2f38f69d6cb2e59e150f13709ca3ebf301',
+            'sha256_manpages': '953a8eadaf4ae96dbad2c3ec12384c677416843917ef83d94b98367ffd55afc0',
         },
         {
             'version': '2.8.3',
-            'md5': '0e19f31f96f9364fd247b8dc737dacfd',
-            'md5_manpages': '553827e1b6c422ecc485499c1a1ae28d',
+            'sha256': '2dad50c758339d6f5235309db620e51249e0000ff34aa2f2acbcb84c2123ed09',
+            'sha256_manpages': '2dad50c758339d6f5235309db620e51249e0000ff34aa2f2acbcb84c2123ed09',
         },
         {
             'version': '2.8.2',
-            'md5': '3d55550880af98f6e35c7f1d7c5aecfe',
-            'md5_manpages': '33330463af27eb1238cbc2b4ca100b3a',
+            'sha256': 'a029c37ee2e0bb1efea5c4af827ff5afdb3356ec42fc19c1d40216d99e97e148',
+            'sha256_manpages': '82d322211aade626d1eb3bcf3b76730bfdd2fcc9c189950fb0a8bdd69c383e2f',
         },
         {
             'version': '2.8.1',
-            'md5': '1308448d95afa41a4135903f22262fc8',
-            'md5_manpages': '87bc202c6f6ae32c1c46c2dda3134ed1',
+            'sha256': 'cfc66324179b9ed62ee02833f29d39935f4ab66874125a3ab9d5bb9055c0cb67',
+            'sha256_manpages': 'df46de0c172049f935cc3736361b263c5ff289b77077c73053e63ae83fcf43f4',
         },
         {
             'version': '2.8.0',
-            'md5': 'eca687e46e9750121638f258cff8317b',
-            'md5_manpages': 'd67a7db0f363e8c3b2960cd84ad0373f',
+            'sha256': '2c6eee5506237e0886df9973fd7938a1b2611ec93d07f64ed3447493ebac90d1',
+            'sha256_manpages': '2c48902a69df3bec3b8b8f0350a65fd1b662d2f436f0e64d475ecd1c780767b6',
         },
         {
             'version': '2.7.3',
-            'md5': 'fa1c008b56618c355a32ba4a678305f6',
-            'md5_manpages': '97a525cca7fe38ff6bd7aaa4f0438896',
+            'sha256': '30d067499b61caddedaf1a407b4947244f14d10842d100f7c7c6ea1c288280cd',
+            'sha256_manpages': '84b487c9071857ab0f15f11c4a102a583d59b524831cda0dc0954bd3ab73920b',
         },
         {
             'version': '2.7.1',
-            'md5': 'bf0706b433a8dedd27a63a72f9a66060',
-            'md5_manpages': '19881ca231f73dec91fb456d74943950',
+            'sha256': 'b4ab42798b7fb038eaefabb0c32ce9dbde2919103e5e2a35adc35dd46258a66f',
+            'sha256_manpages': '0313cf4d283336088883d8416692fb6c547512233e11dbf06e5b925b7e762d61',
         },
     ]
 
     for release in releases:
-        version(release['version'], md5=release['md5'])
+        version(release['version'], sha256=release['sha256'])
         resource(
             name='git-manpages',
-            url="https://www.kernel.org/pub/software/scm/git/git-manpages-{0}.tar.xz".format(
+            url="https://www.kernel.org/pub/software/scm/git/git-manpages-{0}.tar.gz".format(
                 release['version']),
-            md5=release['md5_manpages'],
+            sha256=release['sha256_manpages'],
             placement='git-manpages',
             when='@{0}'.format(release['version']))
 


### PR DESCRIPTION
sha256 source here: https://mirrors.edge.kernel.org/pub/software/scm/git/sha256sums.asc 

edit: Maybe I should add a bit of an explanation here. The idea for this PR started, when I added a newer git version and the sha256 that `spack` got wasn't the one from the signed document linked above. kernel.org is kind of anal regarding chain of trust, so I'd prefer using their infrastructure as much as possible rather than github.com's autogenerated tar-balls (where they don't guarantee checksum stability).
I basically replaced all md5sums into sha256s and moved the url to kernel.org