### PR TITLE
style: Add pep8-naming plugin to flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -16,6 +16,9 @@
 # These are required to get the package.py files to test clean:
 # - F999: syntax error in doctest
 #
+# Exempt to allow decorator classes to be lowercase, but follow otherwise:
+# - N801: CapWords for class names.
+#
 [flake8]
-ignore = E129,E221,E241,E272,E731,F999
+ignore = E129,E221,E241,E272,E731,F999,N801
 max-line-length = 79

--- a/.travis.yml
+++ b/.travis.yml
@@ -146,6 +146,7 @@ install:
   - pip install --upgrade setuptools
   - pip install --upgrade codecov
   - pip install --upgrade flake8
+  - pip install --upgrade pep8-naming
   - if [[ "$TEST_SUITE" == "doc" ]]; then pip install --upgrade -r lib/spack/docs/requirements.txt; fi
 
 before_script:

--- a/lib/spack/docs/contribution_guide.rst
+++ b/lib/spack/docs/contribution_guide.rst
@@ -189,11 +189,16 @@ to update them.
 
 .. warning::
 
-   Flake8 requires setuptools in order to run. If you installed ``py-flake8``
-   with Spack, make sure to add ``py-setuptools`` to your ``PYTHONPATH``.
-   The easiest way to do this is to run ``spack activate py-flake8`` so that
-   all of the dependencies are symlinked to a central location. If you see an
-   error message like:
+   Flake8 and ``pep8-naming`` require a number of dependencies in order
+   to run.  If you installed ``py-flake8`` and ``py-pep8-naming``, the
+   easiest way to ensure the right packages are on your ``PYTHONPATH`` is
+   to run::
+
+     spack activate py-flake8
+     spack activate pep8-naming
+
+   so that all of the dependencies are symlinked to a central
+   location. If you see an error message like:
 
    .. code-block:: console
 

--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -282,8 +282,8 @@ class HashableMap(collections.MutableMapping):
     def copy(self):
         """Type-agnostic clone method.  Preserves subclass type."""
         # Construct a new dict of my type
-        T = type(self)
-        clone = T()
+        self_type = type(self)
+        clone = self_type()
 
         # Copy everything from this dict into it.
         for key in self:

--- a/lib/spack/llnl/util/multiproc.py
+++ b/lib/spack/llnl/util/multiproc.py
@@ -39,10 +39,10 @@ def spawn(f):
     return fun
 
 
-def parmap(f, X):
-    pipe = [Pipe() for x in X]
+def parmap(f, elements):
+    pipe = [Pipe() for x in elements]
     proc = [Process(target=spawn(f), args=(c, x))
-            for x, (p, c) in zip(X, pipe)]
+            for x, (p, c) in zip(elements, pipe)]
     [p.start() for p in proc]
     [p.join() for p in proc]
     return [p.recv() for (p, c) in pipe]

--- a/lib/spack/llnl/util/tty/__init__.py
+++ b/lib/spack/llnl/util/tty/__init__.py
@@ -246,18 +246,18 @@ def hline(label=None, **kwargs):
 
 def terminal_size():
     """Gets the dimensions of the console: (rows, cols)."""
-    def ioctl_GWINSZ(fd):
+    def ioctl_gwinsz(fd):
         try:
             rc = struct.unpack('hh', fcntl.ioctl(
                 fd, termios.TIOCGWINSZ, '1234'))
         except BaseException:
             return
         return rc
-    rc = ioctl_GWINSZ(0) or ioctl_GWINSZ(1) or ioctl_GWINSZ(2)
+    rc = ioctl_gwinsz(0) or ioctl_gwinsz(1) or ioctl_gwinsz(2)
     if not rc:
         try:
             fd = os.open(os.ctermid(), os.O_RDONLY)
-            rc = ioctl_GWINSZ(fd)
+            rc = ioctl_gwinsz(fd)
             os.close(fd)
         except BaseException:
             pass

--- a/lib/spack/spack/architecture.py
+++ b/lib/spack/spack/architecture.py
@@ -193,14 +193,13 @@ class Platform(object):
         return self.operating_sys.get(name, None)
 
     @classmethod
-    def setup_platform_environment(self, pkg, env):
+    def setup_platform_environment(cls, pkg, env):
         """ Subclass can override this method if it requires any
             platform-specific build environment modifications.
         """
-        pass
 
     @classmethod
-    def detect(self):
+    def detect(cls):
         """ Subclass is responsible for implementing this method.
             Returns True if the Platform class detects that
             it is the current platform

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -203,13 +203,13 @@ def tarball_path_name(spec, ext):
 
 def checksum_tarball(file):
     # calculate sha256 hash of tar file
-    BLOCKSIZE = 65536
+    block_size = 65536
     hasher = hashlib.sha256()
     with open(file, 'rb') as tfile:
-        buf = tfile.read(BLOCKSIZE)
+        buf = tfile.read(block_size)
         while len(buf) > 0:
             hasher.update(buf)
-            buf = tfile.read(BLOCKSIZE)
+            buf = tfile.read(block_size)
     return hasher.hexdigest()
 
 

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -676,8 +676,8 @@ def create(parser, args):
     build_system = get_build_system(args, guesser)
 
     # Create the package template object
-    PackageClass = templates[build_system]
-    package = PackageClass(name, url, versions)
+    package_class = templates[build_system]
+    package = package_class(name, url, versions)
     tty.msg("Created template for {0} package".format(package.name))
 
     # Create a directory for the new package

--- a/lib/spack/spack/compilers/nag.py
+++ b/lib/spack/spack/compilers/nag.py
@@ -72,7 +72,7 @@ class Nag(Compiler):
         return '-Wl,-Wl,,-rpath,,'
 
     @classmethod
-    def default_version(self, comp):
+    def default_version(cls, comp):
         """The ``-V`` option works for nag compilers.
         Output looks like this::
 

--- a/lib/spack/spack/compilers/xl_r.py
+++ b/lib/spack/spack/compilers/xl_r.py
@@ -74,7 +74,7 @@ class XlR(Compiler):
         return "-qzerosize"
 
     @classmethod
-    def default_version(self, comp):
+    def default_version(cls, comp):
         """The '-qversion' is the standard option fo XL compilers.
            Output looks like this::
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -542,9 +542,9 @@ def _validate_section(data, schema):
     """
     import jsonschema
     if not hasattr(_validate_section, 'validator'):
-        DefaultSettingValidator = _extend_with_default(
+        default_setting_validator = _extend_with_default(
             jsonschema.Draft4Validator)
-        _validate_section.validator = DefaultSettingValidator
+        _validate_section.validator = default_setting_validator
 
     try:
         _validate_section.validator(schema).validate(data)

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -80,7 +80,7 @@ class DirectiveMeta(type):
     _directive_names = set()
     _directives_to_be_executed = []
 
-    def __new__(mcs, name, bases, attr_dict):
+    def __new__(cls, name, bases, attr_dict):
         # Initialize the attribute containing the list of directives
         # to be executed. Here we go reversed because we want to execute
         # commands:
@@ -109,8 +109,8 @@ class DirectiveMeta(type):
                 DirectiveMeta._directives_to_be_executed)
             DirectiveMeta._directives_to_be_executed = []
 
-        return super(DirectiveMeta, mcs).__new__(
-            mcs, name, bases, attr_dict)
+        return super(DirectiveMeta, cls).__new__(
+            cls, name, bases, attr_dict)
 
     def __init__(cls, name, bases, attr_dict):
         # The class is being created: if it is a package we must ensure

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -1026,7 +1026,7 @@ class FsCache(object):
     def __init__(self, root):
         self.root = os.path.abspath(root)
 
-    def store(self, fetcher, relativeDst):
+    def store(self, fetcher, relative_dest):
         # skip fetchers that aren't cachable
         if not fetcher.cachable:
             return
@@ -1035,12 +1035,12 @@ class FsCache(object):
         if isinstance(fetcher, CacheURLFetchStrategy):
             return
 
-        dst = os.path.join(self.root, relativeDst)
+        dst = os.path.join(self.root, relative_dest)
         mkdirp(os.path.dirname(dst))
         fetcher.archive(dst)
 
-    def fetcher(self, targetPath, digest, **kwargs):
-        path = os.path.join(self.root, targetPath)
+    def fetcher(self, target_path, digest, **kwargs):
+        path = os.path.join(self.root, target_path)
         return CacheURLFetchStrategy(path, digest, **kwargs)
 
     def destroy(self):

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -44,7 +44,7 @@ from spack.version import VersionList
 from spack.util.compression import allowed_archive
 
 
-def mirror_archive_filename(spec, fetcher, resourceId=None):
+def mirror_archive_filename(spec, fetcher, resource_id=None):
     """Get the name of the spec's archive in the mirror."""
     if not spec.version.concrete:
         raise ValueError("mirror.path requires spec with concrete version.")
@@ -87,18 +87,18 @@ Spack not to expand it with the following syntax:
         # Otherwise we'll make a .tar.gz ourselves
         ext = 'tar.gz'
 
-    if resourceId:
-        filename = "%s-%s" % (resourceId, spec.version) + ".%s" % ext
+    if resource_id:
+        filename = "%s-%s" % (resource_id, spec.version) + ".%s" % ext
     else:
         filename = "%s-%s" % (spec.package.name, spec.version) + ".%s" % ext
 
     return filename
 
 
-def mirror_archive_path(spec, fetcher, resourceId=None):
+def mirror_archive_path(spec, fetcher, resource_id=None):
     """Get the relative path to the spec's archive within a mirror."""
     return os.path.join(
-        spec.name, mirror_archive_filename(spec, fetcher, resourceId))
+        spec.name, mirror_archive_filename(spec, fetcher, resource_id))
 
 
 def get_matching_versions(specs, **kwargs):

--- a/lib/spack/spack/operating_systems/mac_os.py
+++ b/lib/spack/spack/operating_systems/mac_os.py
@@ -29,7 +29,7 @@ from spack.version import Version
 
 
 # FIXME: store versions inside OperatingSystem as a Version instead of string
-def macOS_version():
+def macos_version():
     """temporary workaround to return a macOS version as a Version object
     """
     return Version('.'.join(py_platform.mac_ver()[0].split('.')[:2]))

--- a/lib/spack/spack/platforms/bgq.py
+++ b/lib/spack/spack/platforms/bgq.py
@@ -53,5 +53,5 @@ class Bgq(Platform):
         self.add_operating_system(str(back_distro), back_distro)
 
     @classmethod
-    def detect(self):
+    def detect(cls):
         return os.path.exists('/bgsys')

--- a/lib/spack/spack/platforms/darwin.py
+++ b/lib/spack/spack/platforms/darwin.py
@@ -45,5 +45,5 @@ class Darwin(Platform):
         self.add_operating_system(str(mac_os), mac_os)
 
     @classmethod
-    def detect(self):
+    def detect(cls):
         return 'darwin' in platform.system().lower()

--- a/lib/spack/spack/platforms/linux.py
+++ b/lib/spack/spack/platforms/linux.py
@@ -49,5 +49,5 @@ class Linux(Platform):
         self.add_operating_system(str(linux_dist), linux_dist)
 
     @classmethod
-    def detect(self):
+    def detect(cls):
         return 'linux' in platform.system().lower()

--- a/lib/spack/spack/platforms/test.py
+++ b/lib/spack/spack/platforms/test.py
@@ -23,7 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack.architecture import Platform, Target
-from spack.architecture import OperatingSystem as OS
+from spack.architecture import OperatingSystem
 
 
 class Test(Platform):
@@ -41,9 +41,11 @@ class Test(Platform):
         self.add_target(self.default, Target(self.default))
         self.add_target(self.front_end, Target(self.front_end))
 
-        self.add_operating_system(self.default_os, OS('debian', 6))
-        self.add_operating_system(self.front_os, OS('redhat', 6))
+        self.add_operating_system(
+            self.default_os, OperatingSystem('debian', 6))
+        self.add_operating_system(
+            self.front_os, OperatingSystem('redhat', 6))
 
     @classmethod
-    def detect(self):
+    def detect(cls):
         return True

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -432,9 +432,9 @@ class Stage(object):
                 tty.debug(e)
                 continue
         else:
-            errMessage = "All fetchers failed for %s" % self.name
+            err_msg = "All fetchers failed for %s" % self.name
             self.fetcher = self.default_fetcher
-            raise fs.FetchError(errMessage, None)
+            raise fs.FetchError(err_msg, None)
 
     def check(self):
         """Check the downloaded archive against a checksum digest.

--- a/lib/spack/spack/tengine.py
+++ b/lib/spack/spack/tengine.py
@@ -43,10 +43,10 @@ class ContextMeta(type):
     #: by the class that is being defined
     _new_context_properties = []
 
-    def __new__(mcs, name, bases, attr_dict):
+    def __new__(cls, name, bases, attr_dict):
         # Merge all the context properties that are coming from base classes
         # into a list without duplicates.
-        context_properties = list(mcs._new_context_properties)
+        context_properties = list(cls._new_context_properties)
         for x in bases:
             try:
                 context_properties.extend(x.context_properties)
@@ -55,20 +55,20 @@ class ContextMeta(type):
         context_properties = list(llnl.util.lang.dedupe(context_properties))
 
         # Flush the list
-        mcs._new_context_properties = []
+        cls._new_context_properties = []
 
         # Attach the list to the class being created
         attr_dict['context_properties'] = context_properties
 
-        return super(ContextMeta, mcs).__new__(mcs, name, bases, attr_dict)
+        return super(ContextMeta, cls).__new__(cls, name, bases, attr_dict)
 
     @classmethod
-    def context_property(mcs, func):
+    def context_property(cls, func):
         """Decorator that adds a function name to the list of new context
         properties, and then returns a property.
         """
         name = func.__name__
-        mcs._new_context_properties.append(name)
+        cls._new_context_properties.append(name)
         return property(func)
 
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -44,7 +44,7 @@ import spack.platforms.test
 import spack.repo
 import spack.stage
 import spack.util.executable
-import spack.util.pattern
+from spack.util.pattern import Bunch
 from spack.dependency import Dependency
 from spack.package import PackageBase
 from spack.fetch_strategy import FetchStrategyComposite, URLFetchStrategy
@@ -165,10 +165,10 @@ def mock_fetch_cache(monkeypatch):
     and raises on fetch.
     """
     class MockCache(object):
-        def store(self, copyCmd, relativeDst):
+        def store(self, copy_cmd, relative_dest):
             pass
 
-        def fetcher(self, targetPath, digest, **kwargs):
+        def fetcher(self, target_path, digest, **kwargs):
             return MockCacheFetcher()
 
     class MockCacheFetcher(object):
@@ -508,7 +508,6 @@ def mock_git_repository(tmpdir_factory):
         r1 = rev_hash(branch)
         r1_file = branch_file
 
-    Bunch = spack.util.pattern.Bunch
     checks = {
         'master': Bunch(
             revision='master', file=r0_file, args={'git': str(repodir)}
@@ -561,7 +560,6 @@ def mock_hg_repository(tmpdir_factory):
         hg('commit', '-m' 'revision 1', '-u', 'test')
         r1 = get_rev()
 
-    Bunch = spack.util.pattern.Bunch
     checks = {
         'default': Bunch(
             revision=r1, file=r1_file, args={'hg': str(repodir)}
@@ -618,7 +616,6 @@ def mock_svn_repository(tmpdir_factory):
         r0 = '1'
         r1 = '2'
 
-    Bunch = spack.util.pattern.Bunch
     checks = {
         'default': Bunch(
             revision=r1, file=r1_file, args={'svn': url}),

--- a/lib/spack/spack/test/flag_handlers.py
+++ b/lib/spack/spack/test/flag_handlers.py
@@ -37,7 +37,7 @@ def temp_env():
     os.environ = old_env
 
 
-def add_O3_to_build_system_cflags(pkg, name, flags):
+def add_o3_to_build_system_cflags(pkg, name, flags):
     build_system_flags = []
     if name == 'cflags':
         build_system_flags.append('-O3')
@@ -137,7 +137,7 @@ class TestFlagHandlers(object):
         s = spack.spec.Spec('libelf cppflags=-g')
         s.concretize()
         pkg = spack.repo.get(s)
-        pkg.flag_handler = add_O3_to_build_system_cflags
+        pkg.flag_handler = add_o3_to_build_system_cflags
         spack.build_environment.setup_package(pkg, False)
 
         assert '-g' in os.environ['SPACK_CPPFLAGS']
@@ -149,7 +149,7 @@ class TestFlagHandlers(object):
         s = spack.spec.Spec('callpath cppflags=-g')
         s.concretize()
         pkg = spack.repo.get(s)
-        pkg.flag_handler = add_O3_to_build_system_cflags
+        pkg.flag_handler = add_o3_to_build_system_cflags
         spack.build_environment.setup_package(pkg, False)
 
         assert '-g' in os.environ['SPACK_CPPFLAGS']

--- a/lib/spack/spack/test/llnl/util/file_list.py
+++ b/lib/spack/spack/test/llnl/util/file_list.py
@@ -263,7 +263,7 @@ def test_searching_order(search_fn, search_list, root, kwargs):
     # Now reverse the result and start discarding things
     # as soon as you have matches. In the end the list should
     # be emptied.
-    L = list(reversed(result))
+    rlist = list(reversed(result))
 
     # At this point make sure the search list is a sequence
     if isinstance(search_list, six.string_types):
@@ -272,14 +272,14 @@ def test_searching_order(search_fn, search_list, root, kwargs):
     # Discard entries in the order they appear in search list
     for x in search_list:
         try:
-            while fnmatch.fnmatch(L[-1], x) or x in L[-1]:
-                L.pop()
+            while fnmatch.fnmatch(rlist[-1], x) or x in rlist[-1]:
+                rlist.pop()
         except IndexError:
             # List is empty
             pass
 
     # List should be empty here
-    assert len(L) == 0
+    assert len(rlist) == 0
 
 
 @pytest.mark.parametrize('root,search_list,kwargs,expected', [

--- a/lib/spack/spack/test/module_parsing.py
+++ b/lib/spack/spack/test/module_parsing.py
@@ -42,13 +42,13 @@ MODULE_NOT_DEFINED = b'not found' in typeset
 
 @pytest.fixture
 def save_env():
-    old_PATH = os.environ.get('PATH', None)
+    old_path = os.environ.get('PATH', None)
     old_bash_func = os.environ.get('BASH_FUNC_module()', None)
 
     yield
 
-    if old_PATH:
-        os.environ['PATH'] = old_PATH
+    if old_path:
+        os.environ['PATH'] = old_path
     if old_bash_func:
         os.environ['BASH_FUNC_module()'] = old_bash_func
 

--- a/lib/spack/spack/test/modules/lmod.py
+++ b/lib/spack/spack/test/modules/lmod.py
@@ -171,11 +171,11 @@ class TestLmod(object):
         path = module.layout.filename
         mpi_spec = spec['mpi']
 
-        mpiElement = "{0}/{1}-{2}/".format(
+        mpi_element = "{0}/{1}-{2}/".format(
             mpi_spec.name, mpi_spec.version, mpi_spec.dag_hash(length=7)
         )
 
-        assert mpiElement in path
+        assert mpi_element in path
 
         mpileaks_spec = spec
         mpileaks_element = "{0}/{1}.lua".format(

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -42,8 +42,8 @@ def extra_repo(tmpdir_factory):
     repo_dir = tmpdir_factory.mktemp(repo_namespace)
     repo_dir.ensure('packages', dir=True)
 
-    with open(str(repo_dir.join('repo.yaml')), 'w') as F:
-        F.write("""
+    with open(str(repo_dir.join('repo.yaml')), 'w') as f:
+        f.write("""
 repo:
   namespace: extra_test_repo
 """)

--- a/lib/spack/spack/test/test_activations.py
+++ b/lib/spack/spack/test/test_activations.py
@@ -137,8 +137,8 @@ def python_and_extension_dirs(tmpdir):
     create_dir_structure(ext_prefix, ext_dirs)
 
     easy_install_location = 'lib/python2.7/site-packages/easy-install.pth'
-    with open(str(ext_prefix.join(easy_install_location)), 'w') as F:
-        F.write("""path/to/ext1.egg
+    with open(str(ext_prefix.join(easy_install_location)), 'w') as f:
+        f.write("""path/to/ext1.egg
 path/to/setuptools.egg""")
 
     return str(python_prefix), str(ext_prefix)
@@ -204,8 +204,8 @@ def test_python_activation_with_files(tmpdir, python_and_extension_dirs):
     assert os.path.exists(os.path.join(python_prefix, 'bin/py-ext-tool'))
 
     easy_install_location = 'lib/python2.7/site-packages/easy-install.pth'
-    with open(os.path.join(python_prefix, easy_install_location), 'r') as F:
-        easy_install_contents = F.read()
+    with open(os.path.join(python_prefix, easy_install_location), 'r') as f:
+        easy_install_contents = f.read()
 
     assert 'ext1.egg' in easy_install_contents
     assert 'setuptools.egg' not in easy_install_contents

--- a/lib/spack/spack/util/file_cache.py
+++ b/lib/spack/spack/util/file_cache.py
@@ -130,7 +130,7 @@ class FileCache(object):
         """
         class WriteContextManager(object):
 
-            def __enter__(cm):
+            def __enter__(cm):  # noqa
                 cm.orig_filename = self.cache_path(key)
                 cm.orig_file = None
                 if os.path.exists(cm.orig_filename):
@@ -141,7 +141,7 @@ class FileCache(object):
 
                 return cm.orig_file, cm.tmp_file
 
-            def __exit__(cm, type, value, traceback):
+            def __exit__(cm, type, value, traceback):  # noqa
                 if cm.orig_file:
                     cm.orig_file.close()
                 cm.tmp_file.close()

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -194,9 +194,9 @@ def get_path_from_module(mod):
 
     # If it lists a -L instruction, use that
     for line in text:
-        L = line.find('-L/')
-        if L >= 0:
-            return line[L + 2:line.find('/lib')]
+        lib_paths = line.find('-L/')
+        if lib_paths >= 0:
+            return line[lib_paths + 2:line.find('/lib')]
 
     # If it sets the PATH, use it
     for line in text:

--- a/lib/spack/spack/util/package_hash.py
+++ b/lib/spack/spack/util/package_hash.py
@@ -44,13 +44,13 @@ class RemoveDocstrings(ast.NodeTransformer):
         self.generic_visit(node)
         return node
 
-    def visit_FunctionDef(self, node):
+    def visit_FunctionDef(self, node):  # noqa
         return self.remove_docstring(node)
 
-    def visit_ClassDef(self, node):
+    def visit_ClassDef(self, node):  # noqa
         return self.remove_docstring(node)
 
-    def visit_Module(self, node):
+    def visit_Module(self, node):  # noqa
         return self.remove_docstring(node)
 
 
@@ -69,7 +69,7 @@ class RemoveDirectives(ast.NodeTransformer):
                 node.targets and isinstance(node.targets[0], ast.Name) and
                 node.targets[0].id in spack.package.Package.metadata_attrs)
 
-    def visit_ClassDef(self, node):
+    def visit_ClassDef(self, node):  # noqa
         if node.name == spack.util.naming.mod_to_class(self.spec.name):
             node.body = [
                 c for c in node.body
@@ -83,7 +83,7 @@ class TagMultiMethods(ast.NodeVisitor):
         self.spec = spec
         self.methods = {}
 
-    def visit_FunctionDef(self, node):
+    def visit_FunctionDef(self, node):  # noqa
         nodes = self.methods.setdefault(node.name, [])
         if node.decorator_list:
             dec = node.decorator_list[0]
@@ -112,7 +112,7 @@ class ResolveMultiMethods(ast.NodeTransformer):
                 result = n
         return result
 
-    def visit_FunctionDef(self, node):
+    def visit_FunctionDef(self, node):  # noqa
         if self.resolve(node) is node:
             node.decorator_list = []
             return node

--- a/var/spack/repos/builtin/packages/bison/package.py
+++ b/var/spack/repos/builtin/packages/bison/package.py
@@ -23,7 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from spack.operating_systems.mac_os import macOS_version
+from spack.operating_systems.mac_os import macos_version
 import sys
 
 
@@ -42,7 +42,7 @@ class Bison(AutotoolsPackage):
 
     patch('pgi.patch', when='@3.0.4')
 
-    if sys.platform == 'darwin' and macOS_version() >= Version('10.13'):
+    if sys.platform == 'darwin' and macos_version() >= Version('10.13'):
         patch('secure_snprintf.patch', level=0, when='@3.0.4')
 
     build_directory = 'spack-build'

--- a/var/spack/repos/builtin/packages/cbtf-krell/package.py
+++ b/var/spack/repos/builtin/packages/cbtf-krell/package.py
@@ -150,46 +150,46 @@ class CbtfKrell(CMakePackage):
 
     build_directory = 'build_cbtf_krell'
 
-    def set_RTOnly_cmakeOptions(self, spec, cmakeOptions):
-        # Appends to cmakeOptions the options that will enable the appropriate
+    def set_rt_only_cmake_options(self, spec, cmake_options):
+        # Appends to cmake_options the options that will enable the appropriate
         # MPI implementations
 
-        RTOnlyOptions = []
-        RTOnlyOptions.append('-DRUNTIME_ONLY=true')
-        cmakeOptions.extend(RTOnlyOptions)
+        rt_only_options = []
+        rt_only_options.append('-DRUNTIME_ONLY=true')
+        cmake_options.extend(rt_only_options)
 
-    def set_mpi_cmakeOptions(self, spec, cmakeOptions):
-        # Appends to cmakeOptions the options that will enable the appropriate
+    def set_mpi_cmake_options(self, spec, cmake_options):
+        # Appends to cmake_options the options that will enable the appropriate
         # MPI implementations
 
-        MPIOptions = []
+        mpi_options = []
 
         # openmpi
         if spec.satisfies('+openmpi'):
-            MPIOptions.append('-DOPENMPI_DIR=%s' % spec['openmpi'].prefix)
+            mpi_options.append('-DOPENMPI_DIR=%s' % spec['openmpi'].prefix)
         # mpich
         if spec.satisfies('+mpich'):
-            MPIOptions.append('-DMPICH_DIR=%s' % spec['mpich'].prefix)
+            mpi_options.append('-DMPICH_DIR=%s' % spec['mpich'].prefix)
         # mpich2
         if spec.satisfies('+mpich2'):
-            MPIOptions.append('-DMPICH2_DIR=%s' % spec['mpich2'].prefix)
+            mpi_options.append('-DMPICH2_DIR=%s' % spec['mpich2'].prefix)
         # mvapich
         if spec.satisfies('+mvapich'):
-            MPIOptions.append('-DMVAPICH_DIR=%s' % spec['mvapich'].prefix)
+            mpi_options.append('-DMVAPICH_DIR=%s' % spec['mvapich'].prefix)
         # mvapich2
         if spec.satisfies('+mvapich2'):
-            MPIOptions.append('-DMVAPICH2_DIR=%s' % spec['mvapich2'].prefix)
+            mpi_options.append('-DMVAPICH2_DIR=%s' % spec['mvapich2'].prefix)
         # mpt
         if spec.satisfies('+mpt'):
-            MPIOptions.append('-DMPT_DIR=%s' % spec['mpt'].prefix)
+            mpi_options.append('-DMPT_DIR=%s' % spec['mpt'].prefix)
 
-        cmakeOptions.extend(MPIOptions)
+        cmake_options.extend(mpi_options)
 
-    def set_CrayLoginNode_cmakeOptions(self, spec, cmakeOptions):
-        # Appends to cmakeOptions the options that will enable
+    def set_cray_login_node_cmake_options(self, spec, cmake_options):
+        # Appends to cmake_options the options that will enable
         # the appropriate Cray login node libraries
 
-        CrayLoginNodeOptions = []
+        cray_login_node_options = []
         rt_platform = "cray"
         # How do we get the compute node (CNL) cbtf package
         # install directory path. spec['cbtf'].prefix is the
@@ -207,31 +207,31 @@ class CbtfKrell(CMakePackage):
         be_dyn = spack.store.db.query_one('dyninst arch=cray-CNL-haswell')
         be_mrnet = spack.store.db.query_one('mrnet arch=cray-CNL-haswell')
 
-        CrayLoginNodeOptions.append('-DCN_RUNTIME_PLATFORM=%s'
-                                    % rt_platform)
+        cray_login_node_options.append(
+            '-DCN_RUNTIME_PLATFORM=%s' % rt_platform)
 
         # Use install directories as CMAKE args for the building
         # of login cbtf-krell
-        CrayLoginNodeOptions.append('-DCBTF_CN_RUNTIME_DIR=%s'
-                                    % be_cbtf.prefix)
-        CrayLoginNodeOptions.append('-DCBTF_KRELL_CN_RUNTIME_DIR=%s'
-                                    % be_cbtfk.prefix)
-        CrayLoginNodeOptions.append('-DPAPI_CN_RUNTIME_DIR=%s'
-                                    % be_papi.prefix)
-        CrayLoginNodeOptions.append('-DBOOST_CN_RUNTIME_DIR=%s'
-                                    % be_boost.prefix)
-        CrayLoginNodeOptions.append('-DLIBMONITOR_CN_RUNTIME_DIR=%s'
-                                    % be_mont.prefix)
-        CrayLoginNodeOptions.append('-DLIBUNWIND_CN_RUNTIME_DIR=%s'
-                                    % be_unw.prefix)
-        CrayLoginNodeOptions.append('-DXERCESC_CN_RUNTIME_DIR=%s'
-                                    % be_xer.prefix)
-        CrayLoginNodeOptions.append('-DDYNINST_CN_RUNTIME_DIR=%s'
-                                    % be_dyn.prefix)
-        CrayLoginNodeOptions.append('-DMRNET_CN_RUNTIME_DIR=%s'
-                                    % be_mrnet.prefix)
+        cray_login_node_options.append(
+            '-DCBTF_CN_RUNTIME_DIR=%s' % be_cbtf.prefix)
+        cray_login_node_options.append(
+            '-DCBTF_KRELL_CN_RUNTIME_DIR=%s' % be_cbtfk.prefix)
+        cray_login_node_options.append(
+            '-DPAPI_CN_RUNTIME_DIR=%s' % be_papi.prefix)
+        cray_login_node_options.append(
+            '-DBOOST_CN_RUNTIME_DIR=%s' % be_boost.prefix)
+        cray_login_node_options.append(
+            '-DLIBMONITOR_CN_RUNTIME_DIR=%s' % be_mont.prefix)
+        cray_login_node_options.append(
+            '-DLIBUNWIND_CN_RUNTIME_DIR=%s' % be_unw.prefix)
+        cray_login_node_options.append(
+            '-DXERCESC_CN_RUNTIME_DIR=%s' % be_xer.prefix)
+        cray_login_node_options.append(
+            '-DDYNINST_CN_RUNTIME_DIR=%s' % be_dyn.prefix)
+        cray_login_node_options.append(
+            '-DMRNET_CN_RUNTIME_DIR=%s' % be_mrnet.prefix)
 
-        cmakeOptions.extend(CrayLoginNodeOptions)
+        cmake_options.extend(cray_login_node_options)
 
     def cmake_args(self):
         spec = self.spec
@@ -256,14 +256,14 @@ class CbtfKrell(CMakePackage):
             '-DXERCESC_DIR=%s' % spec['xerces-c'].prefix]
 
         if self.spec.satisfies('+runtime'):
-            self.set_RTOnly_cmakeOptions(spec, cmake_args)
+            self.set_rt_only_cmake_options(spec, cmake_args)
 
         # Add any MPI implementations coming from variant settings
-        self.set_mpi_cmakeOptions(spec, cmake_args)
+        self.set_mpi_cmake_options(spec, cmake_args)
 
         if self.spec.satisfies('+crayfe'):
             # We need to build target/compute node components/libraries first
             # then pass those libraries to the cbtf-krell login node build
-            self.set_CrayLoginNode_cmakeOptions(spec, cmake_args)
+            self.set_cray_login_node_cmake_options(spec, cmake_args)
 
         return cmake_args

--- a/var/spack/repos/builtin/packages/dataspaces/package.py
+++ b/var/spack/repos/builtin/packages/dataspaces/package.py
@@ -70,7 +70,7 @@ class Dataspaces(AutotoolsPackage):
     depends_on('libtool', type='build')
     depends_on('mpi', when='+mpi')
 
-    def autoreconf(spec, prefix, self):
+    def autoreconf(self, spec, prefix):
         bash = which('bash')
         bash('./autogen.sh')
 

--- a/var/spack/repos/builtin/packages/dislin/package.py
+++ b/var/spack/repos/builtin/packages/dislin/package.py
@@ -70,7 +70,7 @@ class Dislin(Package):
         run_env.prepend_path('LD_LIBRARY_PATH', self.prefix)
 
     def install(self, spec, prefix):
-        INSTALL = Executable('./INSTALL')
-        INSTALL()
+        install = Executable('./INSTALL')
+        install()
         with working_dir('examples'):
             install('dislin_d.h', prefix)

--- a/var/spack/repos/builtin/packages/exasp2/package.py
+++ b/var/spack/repos/builtin/packages/exasp2/package.py
@@ -81,8 +81,8 @@ class Exasp2(MakefilePackage):
         math_includes += " -I" + spec['blas'].prefix.include
         targets.append('SPACKBLASINCLUDES=' + math_includes)
         # And BML
-        bmlLibDirs = spec['bml'].libs.directories[0]
-        targets.append('BML_PATH=' + bmlLibDirs)
+        bml_lib_dirs = spec['bml'].libs.directories[0]
+        targets.append('BML_PATH=' + bml_lib_dirs)
         targets.append('--file=Makefile.vanilla')
         return targets
 

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -23,7 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from spack.operating_systems.mac_os import macOS_version
+from spack.operating_systems.mac_os import macos_version
 from llnl.util import tty
 
 import glob
@@ -157,7 +157,7 @@ class Gcc(AutotoolsPackage):
     if sys.platform == 'darwin':
         # Fix parallel build on APFS filesystem
         # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81797
-        if macOS_version() >= Version('10.13'):
+        if macos_version() >= Version('10.13'):
             patch('darwin/apfs.patch', when='@5.5.0,6.1:6.4,7.1:7.3')
             # from homebrew via macports
             # https://trac.macports.org/ticket/56502#no1

--- a/var/spack/repos/builtin/packages/gslib/package.py
+++ b/var/spack/repos/builtin/packages/gslib/package.py
@@ -46,44 +46,44 @@ class Gslib(Package):
     conflicts('~mpi', when='+mpiio')
 
     def install(self, spec, prefix):
-        srcDir = 'src'
-        libDir = 'lib'
+        src_dir = 'src'
+        lib_dir = 'lib'
         libname = 'libgs.a'
 
         if self.version == Version('1.0.1'):
-            makeFile = 'Makefile'
+            makefile = 'Makefile'
         else:
-            makeFile = 'src/Makefile'
+            makefile = 'src/Makefile'
 
-        CC  = self.compiler.cc
+        cc  = self.compiler.cc
 
         if '+mpiio' not in spec:
-            filter_file(r'MPIIO.*?=.*1', 'MPIIO = 0', makeFile)
+            filter_file(r'MPIIO.*?=.*1', 'MPIIO = 0', makefile)
 
         if '+mpi' in spec:
-            CC  = spec['mpi'].mpicc
+            cc  = spec['mpi'].mpicc
         else:
-            filter_file(r'MPI.*?=.*1', 'MPI = 0', makeFile)
-            filter_file(r'MPIIO.*?=.*1', 'MPIIO = 0', makeFile)
+            filter_file(r'MPI.*?=.*1', 'MPI = 0', makefile)
+            filter_file(r'MPIIO.*?=.*1', 'MPIIO = 0', makefile)
 
-        makeCmd = "CC=" + CC
+        make_cmd = "CC=" + cc
 
         if '+blas' in spec:
-            filter_file(r'BLAS.*?=.*0', 'BLAS = 1', makeFile)
+            filter_file(r'BLAS.*?=.*0', 'BLAS = 1', makefile)
             blas = spec['blas'].libs
-            ldFlags = blas.ld_flags
-            filter_file(r'\$\(LDFLAGS\)', ldFlags, makeFile)
+            ld_flags = blas.ld_flags
+            filter_file(r'\$\(LDFLAGS\)', ld_flags, makefile)
 
         if self.version == Version('1.0.1'):
-            make(makeCmd)
+            make(make_cmd)
             make('install')
-            install_tree(libDir, prefix.lib)
+            install_tree(lib_dir, prefix.lib)
         elif self.version == Version('1.0.0'):
-            with working_dir(srcDir):
-                make(makeCmd)
+            with working_dir(src_dir):
+                make(make_cmd)
                 mkdir(prefix.lib)
                 install(libname, prefix.lib)
 
         # Should only install the headers (this will be fixed in gslib on
         # future releases).
-        install_tree(srcDir, prefix.include)
+        install_tree(src_dir, prefix.include)

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -58,9 +58,9 @@ class Lbann(CMakePackage):
                when=('build_type=Debug' '@0.95:'))
     depends_on('hydrogen +openmp_blas +shared +int64 build_type=Debug',
                when=('build_type=Debug' '@:0.90'))
-    depends_on('hydrogen +openmp_blas +shared +int64 +cuda', 
+    depends_on('hydrogen +openmp_blas +shared +int64 +cuda',
                when=('+gpu' '@0.95:'))
-    depends_on('hydrogen +openmp_blas +shared +int64 +cuda', 
+    depends_on('hydrogen +openmp_blas +shared +int64 +cuda',
                when=('+gpu' '@:0.90'))
     depends_on('hydrogen +openmp_blas +shared +int64 +cuda build_type=Debug',
                when=('build_type=Debug' '@0.95:' '+gpu'))
@@ -94,12 +94,12 @@ class Lbann(CMakePackage):
     def common_config_args(self):
         spec = self.spec
         # Environment variables
-        CPPFLAGS = []
-        CPPFLAGS.append('-DLBANN_SET_EL_RNG -ldl')
+        cppflags = []
+        cppflags.append('-DLBANN_SET_EL_RNG -ldl')
 
         return [
             '-DCMAKE_INSTALL_MESSAGE=LAZY',
-            '-DCMAKE_CXX_FLAGS=%s' % ' '.join(CPPFLAGS),
+            '-DCMAKE_CXX_FLAGS=%s' % ' '.join(cppflags),
             '-DLBANN_VERSION=spack',
             '-DCNPY_DIR={0}'.format(spec['cnpy'].prefix),
         ]

--- a/var/spack/repos/builtin/packages/matlab/package.py
+++ b/var/spack/repos/builtin/packages/matlab/package.py
@@ -80,15 +80,15 @@ class Matlab(Package):
         }
 
         # Store values requested by the installer in a file
-        with open('spack_installer_input.txt', 'w') as inputFile:
+        with open('spack_installer_input.txt', 'w') as input_file:
             for key in config:
-                inputFile.write('{0}={1}\n'.format(key, config[key]))
+                input_file.write('{0}={1}\n'.format(key, config[key]))
 
     def install(self, spec, prefix):
         self.configure(spec, prefix)
 
         # Run silent installation script
         # Full path required
-        inputFile = join_path(self.stage.source_path,
-                              'spack_installer_input.txt')
-        subprocess.call(['./install', '-inputFile', inputFile])
+        input_file = join_path(
+            self.stage.source_path, 'spack_installer_input.txt')
+        subprocess.call(['./install', '-inputFile', input_file])

--- a/var/spack/repos/builtin/packages/metis/package.py
+++ b/var/spack/repos/builtin/packages/metis/package.py
@@ -221,11 +221,11 @@ class Metis(Package):
             make('install')
 
             # install GKlib headers, which will be needed for ParMETIS
-            GKlib_dist = join_path(prefix.include, 'GKlib')
-            mkdirp(GKlib_dist)
+            gklib_dist = join_path(prefix.include, 'GKlib')
+            mkdirp(gklib_dist)
             hfiles = glob.glob(join_path(source_directory, 'GKlib', '*.h'))
             for hfile in hfiles:
-                install(hfile, GKlib_dist)
+                install(hfile, gklib_dist)
 
         if self.run_tests:
             # FIXME: On some systems, the installed binaries for METIS cannot

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -229,7 +229,7 @@ class Mfem(Package):
         # from within MFEM.
 
         # Similar to spec[pkg].libs.ld_flags but prepends rpath flags too.
-        def ld_flags_from_LibraryList(libs_list):
+        def ld_flags_from_library_list(libs_list):
             flags = ['-Wl,-rpath,%s' % dir for dir in libs_list.directories]
             flags += [libs_list.ld_flags]
             return ' '.join(flags)
@@ -298,7 +298,7 @@ class Mfem(Package):
                 hypre['blas'].libs
             options += [
                 'HYPRE_OPT=-I%s' % hypre.prefix.include,
-                'HYPRE_LIB=%s' % ld_flags_from_LibraryList(all_hypre_libs)]
+                'HYPRE_LIB=%s' % ld_flags_from_library_list(all_hypre_libs)]
 
         if '+metis' in spec:
             options += [
@@ -310,7 +310,7 @@ class Mfem(Package):
             lapack_blas = spec['lapack'].libs + spec['blas'].libs
             options += [
                 # LAPACK_OPT is not used
-                'LAPACK_LIB=%s' % ld_flags_from_LibraryList(lapack_blas)]
+                'LAPACK_LIB=%s' % ld_flags_from_library_list(lapack_blas)]
 
         if '+superlu-dist' in spec:
             lapack_blas = spec['lapack'].libs + spec['blas'].libs
@@ -321,28 +321,28 @@ class Mfem(Package):
                 'SUPERLU_LIB=-L%s -L%s -lsuperlu_dist -lparmetis %s' %
                 (spec['superlu-dist'].prefix.lib,
                  spec['parmetis'].prefix.lib,
-                 ld_flags_from_LibraryList(lapack_blas))]
+                 ld_flags_from_library_list(lapack_blas))]
 
         if '+suite-sparse' in spec:
             ss_spec = 'suite-sparse:' + self.suitesparse_components
             options += [
                 'SUITESPARSE_OPT=-I%s' % spec[ss_spec].prefix.include,
                 'SUITESPARSE_LIB=%s' %
-                ld_flags_from_LibraryList(spec[ss_spec].libs)]
+                ld_flags_from_library_list(spec[ss_spec].libs)]
 
         if '+sundials' in spec:
             sun_spec = 'sundials:' + self.sundials_components
             options += [
                 'SUNDIALS_OPT=%s' % spec[sun_spec].headers.cpp_flags,
                 'SUNDIALS_LIB=%s' %
-                ld_flags_from_LibraryList(spec[sun_spec].libs)]
+                ld_flags_from_library_list(spec[sun_spec].libs)]
 
         if '+petsc' in spec:
             # options += ['PETSC_DIR=%s' % spec['petsc'].prefix]
             options += [
                 'PETSC_OPT=%s' % spec['petsc'].headers.cpp_flags,
                 'PETSC_LIB=%s' %
-                ld_flags_from_LibraryList(spec['petsc'].libs)]
+                ld_flags_from_library_list(spec['petsc'].libs)]
 
         if '+pumi' in spec:
             options += ['PUMI_DIR=%s' % spec['pumi'].prefix]
@@ -360,7 +360,7 @@ class Mfem(Package):
                 options += [
                     'ZLIB_OPT=-I%s' % spec['zlib'].prefix.include,
                     'ZLIB_LIB=%s' %
-                    ld_flags_from_LibraryList(spec['zlib'].libs)]
+                    ld_flags_from_library_list(spec['zlib'].libs)]
 
         if '+mpfr' in spec:
             options += [
@@ -383,7 +383,7 @@ class Mfem(Package):
             libs += LibraryList(find_system_libraries('libdl'))
             options += [
                 'LIBUNWIND_OPT=%s' % headers.cpp_flags,
-                'LIBUNWIND_LIB=%s' % ld_flags_from_LibraryList(libs)]
+                'LIBUNWIND_LIB=%s' % ld_flags_from_library_list(libs)]
 
         if '+openmp' in spec:
             options += ['OPENMP_OPT=%s' % self.compiler.openmp_flag]
@@ -408,7 +408,7 @@ class Mfem(Package):
                 libs += hdf5.libs
             options += [
                 'CONDUIT_OPT=%s' % headers.cpp_flags,
-                'CONDUIT_LIB=%s' % ld_flags_from_LibraryList(libs)]
+                'CONDUIT_LIB=%s' % ld_flags_from_library_list(libs)]
 
         make('config', *options, parallel=False)
         make('info', parallel=False)

--- a/var/spack/repos/builtin/packages/ncbi-toolkit/package.py
+++ b/var/spack/repos/builtin/packages/ncbi-toolkit/package.py
@@ -58,8 +58,8 @@ class NcbiToolkit(AutotoolsPackage):
                         'image_io_jpeg.cpp', string=True)
 
     def build(self, spec, prefix):
-        CompilerVersion = self.compiler.version.joined
+        compiler_version = self.compiler.version.joined
 
         with working_dir(join_path(
-                'GCC{0}-DebugMT64'.format(CompilerVersion), 'build')):
+                'GCC{0}-DebugMT64'.format(compiler_version), 'build')):
             make('all_r')

--- a/var/spack/repos/builtin/packages/nekbone/package.py
+++ b/var/spack/repos/builtin/packages/nekbone/package.py
@@ -54,11 +54,11 @@ class Nekbone(Package):
     def install(self, spec, prefix):
         mkdir(prefix.bin)
 
-        FC = self.compiler.fc
-        CC = self.compiler.cc
+        fc = self.compiler.fc
+        cc = self.compiler.cc
         if '+mpi' in spec:
-            FC = spec['mpi'].mpif77
-            CC = spec['mpi'].mpicc
+            fc = spec['mpi'].mpif77
+            cc = spec['mpi'].mpicc
 
         # Install Nekbone in prefix.bin
         install_tree("../Nekbone", prefix.bin.Nekbone)
@@ -73,8 +73,8 @@ class Nekbone(Package):
         with working_dir(prefix.bin):
             filter_file(r'^SOURCE_ROOT\s*=.*', 'SOURCE_ROOT=\"' +
                         prefix.bin.Nekbone + '/src\"', 'makenek')
-            filter_file(r'^CC\s*=.*', 'CC=\"' + CC + '\"', 'makenek')
-            filter_file(r'^F77\s*=.*', 'F77=\"' + FC + '\"', 'makenek')
+            filter_file(r'^CC\s*=.*', 'CC=\"' + cc + '\"', 'makenek')
+            filter_file(r'^F77\s*=.*', 'F77=\"' + fc + '\"', 'makenek')
 
             if '+mpi' not in spec:
                 filter_file(r'^#IFMPI=\"false\"', 'IFMPI=\"false\"', 'makenek')

--- a/var/spack/repos/builtin/packages/nekcem/package.py
+++ b/var/spack/repos/builtin/packages/nekcem/package.py
@@ -56,32 +56,32 @@ class Nekcem(Package):
 
     @run_after('install')
     def test_install(self):
-        NekCEM_test = join_path(self.prefix.bin, 'NekCEM', 'tests', '2dboxpec')
-        with working_dir(NekCEM_test):
+        nekcem_test = join_path(self.prefix.bin, 'NekCEM', 'tests', '2dboxpec')
+        with working_dir(nekcem_test):
             makenek = Executable(join_path(self.prefix.bin, 'makenek'))
-            makenek(os.path.basename(NekCEM_test))
+            makenek(os.path.basename(nekcem_test))
             if not os.path.isfile('nekcem'):
-                msg = 'Cannot build example: %s' % NekCEM_test
+                msg = 'Cannot build example: %s' % nekcem_test
                 raise RuntimeError(msg)
 
     def install(self, spec, prefix):
-        binDir = 'bin'
+        bin_dir = 'bin'
         nek = 'nek'
-        cNek = 'configurenek'
-        mNek = 'makenek'
+        configurenek = 'configurenek'
+        makenek = 'makenek'
 
-        FC = self.compiler.f77
-        CC = self.compiler.cc
+        fc = self.compiler.f77
+        cc = self.compiler.cc
 
         fflags = spec.compiler_flags['fflags']
         cflags = spec.compiler_flags['cflags']
         ldflags = spec.compiler_flags['ldflags']
 
         if '+mpi' in spec:
-            FC = spec['mpi'].mpif77
-            CC = spec['mpi'].mpicc
+            fc = spec['mpi'].mpif77
+            cc = spec['mpi'].mpicc
 
-        with working_dir(binDir):
+        with working_dir(bin_dir):
             fflags = ['-O3'] + fflags
             cflags = ['-O3'] + cflags
             fflags += ['-I.']
@@ -104,14 +104,14 @@ class Nekcem(Package):
             if '+mpi' in spec:
                 fflags += ['-DMPI', '-DMPIIO']
                 cflags += ['-DMPI', '-DMPIIO']
-            blasLapack = spec['lapack'].libs + spec['blas'].libs
+            blas_lapack = spec['lapack'].libs + spec['blas'].libs
             pthread_lib = find_system_libraries('libpthread')
-            ldflags += (blasLapack + pthread_lib).ld_flags.split()
+            ldflags += (blas_lapack + pthread_lib).ld_flags.split()
             all_arch = {
                 'spack-arch': {
-                    'FC': FC, 'FFLAGS': fflags,
-                    'CC': CC, 'CFLAGS': cflags,
-                    'LD': FC, 'LDFLAGS': ldflags
+                    'FC': fc, 'FFLAGS': fflags,
+                    'CC': cc, 'CFLAGS': cflags,
+                    'LD': fc, 'LDFLAGS': ldflags
                 }
             }
             os.rename('arch.json', 'arch.json.orig')
@@ -125,6 +125,7 @@ class Nekcem(Package):
         install_tree('../NekCEM', prefix.bin.NekCEM)
         # Create symlinks to makenek, nek and configurenek scripts
         with working_dir(prefix.bin):
-            os.symlink(os.path.join('NekCEM', binDir, mNek), mNek)
-            os.symlink(os.path.join('NekCEM', binDir, cNek), cNek)
-            os.symlink(os.path.join('NekCEM', binDir, nek), nek)
+            os.symlink(os.path.join('NekCEM', bin_dir, makenek), makenek)
+            os.symlink(
+                os.path.join('NekCEM', bin_dir, configurenek), configurenek)
+            os.symlink(os.path.join('NekCEM', bin_dir, nek), nek)

--- a/var/spack/repos/builtin/packages/netcdf/package.py
+++ b/var/spack/repos/builtin/packages/netcdf/package.py
@@ -153,10 +153,10 @@ class Netcdf(AutotoolsPackage):
                   r'\1{0}\2'.format(max_vars))
 
     def configure_args(self):
-        CFLAGS = []
-        CPPFLAGS = []
-        LDFLAGS = []
-        LIBS = []
+        cflags = []
+        cppflags = []
+        ldflags = []
+        libs = []
 
         config_args = ['--enable-v2',
                        '--enable-utilities',
@@ -177,7 +177,7 @@ class Netcdf(AutotoolsPackage):
         if '~shared' in self.spec:
             # We don't have shared libraries but we still want it to be
             # possible to use this library in shared builds
-            CFLAGS.append(self.compiler.pic_flag)
+            cflags.append(self.compiler.pic_flag)
 
         config_args += self.enable_or_disable('dap')
         # config_args += self.enable_or_disable('cdmremote')
@@ -189,10 +189,10 @@ class Netcdf(AutotoolsPackage):
             # undefined reference to `SSL_CTX_use_certificate_chain_file
             curl = self.spec['curl']
             curl_libs = curl.libs
-            LIBS.append(curl_libs.link_flags)
-            LDFLAGS.append(curl_libs.search_flags)
+            libs.append(curl_libs.link_flags)
+            ldflags.append(curl_libs.search_flags)
             # TODO: figure out how to get correct flags via headers.cpp_flags
-            CPPFLAGS.append('-I' + curl.prefix.include)
+            cppflags.append('-I' + curl.prefix.include)
 
         if self.spec.satisfies('@4.4:'):
             if '+mpi' in self.spec:
@@ -204,16 +204,16 @@ class Netcdf(AutotoolsPackage):
         # are removed. Variables CPPFLAGS, LDFLAGS, and LD_LIBRARY_PATH must be
         # used instead.
         hdf5_hl = self.spec['hdf5:hl']
-        CPPFLAGS.append(hdf5_hl.headers.cpp_flags)
-        LDFLAGS.append(hdf5_hl.libs.search_flags)
+        cppflags.append(hdf5_hl.headers.cpp_flags)
+        ldflags.append(hdf5_hl.libs.search_flags)
 
         if '+parallel-netcdf' in self.spec:
             config_args.append('--enable-pnetcdf')
             pnetcdf = self.spec['parallel-netcdf']
-            CPPFLAGS.append(pnetcdf.headers.cpp_flags)
+            cppflags.append(pnetcdf.headers.cpp_flags)
             # TODO: change to pnetcdf.libs.search_flags once 'parallel-netcdf'
             # package gets custom implementation of 'libs'
-            LDFLAGS.append('-L' + pnetcdf.prefix.lib)
+            ldflags.append('-L' + pnetcdf.prefix.lib)
         else:
             config_args.append('--disable-pnetcdf')
 
@@ -223,26 +223,26 @@ class Netcdf(AutotoolsPackage):
         config_args += self.enable_or_disable('hdf4')
         if '+hdf4' in self.spec:
             hdf4 = self.spec['hdf']
-            CPPFLAGS.append(hdf4.headers.cpp_flags)
+            cppflags.append(hdf4.headers.cpp_flags)
             # TODO: change to hdf4.libs.search_flags once 'hdf'
             # package gets custom implementation of 'libs' property.
-            LDFLAGS.append('-L' + hdf4.prefix.lib)
+            ldflags.append('-L' + hdf4.prefix.lib)
             # TODO: change to self.spec['jpeg'].libs.link_flags once the
             # implementations of 'jpeg' virtual package get 'jpeg_libs'
             # property.
-            LIBS.append('-ljpeg')
+            libs.append('-ljpeg')
             if '+szip' in hdf4:
                 # This should also come from hdf4.libs
-                LIBS.append('-lsz')
+                libs.append('-lsz')
 
         # Fortran support
         # In version 4.2+, NetCDF-C and NetCDF-Fortran have split.
         # Use the netcdf-fortran package to install Fortran support.
 
-        config_args.append('CFLAGS=' + ' '.join(CFLAGS))
-        config_args.append('CPPFLAGS=' + ' '.join(CPPFLAGS))
-        config_args.append('LDFLAGS=' + ' '.join(LDFLAGS))
-        config_args.append('LIBS=' + ' '.join(LIBS))
+        config_args.append('CFLAGS=' + ' '.join(cflags))
+        config_args.append('CPPFLAGS=' + ' '.join(cppflags))
+        config_args.append('LDFLAGS=' + ' '.join(ldflags))
+        config_args.append('LIBS=' + ' '.join(libs))
 
         return config_args
 

--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -107,9 +107,9 @@ class Nwchem(Package):
         # TODO: query if blas/lapack/scalapack uses 64bit Ints
         # A flag to distinguish between 32bit and 64bit integers in linear
         # algebra (Blas, Lapack, Scalapack)
-        use32bitLinAlg = True
+        use_32_bit_lin_alg = True
 
-        if use32bitLinAlg:
+        if use_32_bit_lin_alg:
             args.extend([
                 'USE_64TO32=y',
                 'BLAS_SIZE=4',
@@ -135,7 +135,7 @@ class Nwchem(Package):
 
         with working_dir('src'):
             make('nwchem_config', *args)
-            if use32bitLinAlg:
+            if use_32_bit_lin_alg:
                 make('64_to_32', *args)
             make(*args)
 

--- a/var/spack/repos/builtin/packages/oce/package.py
+++ b/var/spack/repos/builtin/packages/oce/package.py
@@ -23,7 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from spack.operating_systems.mac_os import macOS_version
+from spack.operating_systems.mac_os import macos_version
 import platform
 
 
@@ -68,7 +68,7 @@ class Oce(Package):
     # fix build with Xcode 8 "previous definition of CLOCK_REALTIME"
     # reported 27 Sep 2016 https://github.com/tpaviot/oce/issues/643
     if (platform.system() == "Darwin") and (
-       macOS_version() == Version('10.12')):
+       macos_version() == Version('10.12')):
         patch('sierra.patch', when='@0.17.2:0.18.0')
 
     def install(self, spec, prefix):
@@ -99,7 +99,7 @@ class Oce(Package):
             ])
 
         if platform.system() == 'Darwin' and (
-           macOS_version() >= Version('10.12')):
+           macos_version() >= Version('10.12')):
             # use @rpath on Sierra due to limit of dynamic loader
             options.append('-DCMAKE_MACOSX_RPATH=ON')
         else:

--- a/var/spack/repos/builtin/packages/openfoam-com/package.py
+++ b/var/spack/repos/builtin/packages/openfoam-com/package.py
@@ -74,8 +74,8 @@ __all__ = [
     'write_environ',
     'rewrite_environ_files',
     'mplib_content',
-    'foamAddPath',
-    'foamAddLib',
+    'foam_add_path',
+    'foam_add_lib',
     'OpenfoamArch',
 ]
 
@@ -204,12 +204,12 @@ def rewrite_environ_files(environ, **kwargs):
             filter_file(regex, replace, rcfile, backup=False)
 
 
-def foamAddPath(*args):
+def foam_add_path(*args):
     """A string with args prepended to 'PATH'"""
     return '"' + ':'.join(args) + ':${PATH}"'
 
 
-def foamAddLib(*args):
+def foam_add_lib(*args):
     """A string with args prepended to 'LD_LIBRARY_PATH'"""
     return '"' + ':'.join(args) + ':${LD_LIBRARY_PATH}"'
 
@@ -553,21 +553,21 @@ class OpenfoamCom(Package):
                 ('BOOST_ARCH_PATH', spec['boost'].prefix),
                 ('CGAL_ARCH_PATH',  spec['cgal'].prefix),
                 ('LD_LIBRARY_PATH',
-                 foamAddLib(
+                 foam_add_lib(
                      pkglib(spec['boost'], '${BOOST_ARCH_PATH}'),
                      pkglib(spec['cgal'], '${CGAL_ARCH_PATH}'))),
             ],
             'FFTW': [
                 ('FFTW_ARCH_PATH', spec['fftw'].prefix),  # Absolute
                 ('LD_LIBRARY_PATH',
-                 foamAddLib(
+                 foam_add_lib(
                      pkglib(spec['fftw'], '${BOOST_ARCH_PATH}'))),
             ],
             # User-defined MPI
             'mpi-user': [
                 ('MPI_ARCH_PATH', spec['mpi'].prefix),  # Absolute
-                ('LD_LIBRARY_PATH', foamAddLib(user_mpi['libdir'])),
-                ('PATH', foamAddPath(user_mpi['bindir'])),
+                ('LD_LIBRARY_PATH', foam_add_lib(user_mpi['libdir'])),
+                ('PATH', foam_add_path(user_mpi['bindir'])),
             ],
             'scotch': {},
             'kahip': {},
@@ -596,12 +596,12 @@ class OpenfoamCom(Package):
             }
 
         if '+paraview' in spec:
-            pvMajor = 'paraview-{0}'.format(spec['paraview'].version.up_to(2))
+            pvmajor = 'paraview-{0}'.format(spec['paraview'].version.up_to(2))
             self.etc_config['paraview'] = [
                 ('ParaView_DIR', spec['paraview'].prefix),
-                ('ParaView_INCLUDE_DIR', '${ParaView_DIR}/include/' + pvMajor),
-                ('PV_PLUGIN_PATH', '$FOAM_LIBBIN/' + pvMajor),
-                ('PATH', foamAddPath('${ParaView_DIR}/bin')),
+                ('ParaView_INCLUDE_DIR', '${ParaView_DIR}/include/' + pvmajor),
+                ('PV_PLUGIN_PATH', '$FOAM_LIBBIN/' + pvmajor),
+                ('PATH', foam_add_path('${ParaView_DIR}/bin')),
             ]
 
         if '+vtk' in spec:

--- a/var/spack/repos/builtin/packages/openspeedshop-utils/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop-utils/package.py
@@ -188,11 +188,11 @@ class OpenspeedshopUtils(CMakePackage):
 
     build_directory = 'build_openspeedshop'
 
-    def set_CrayLoginNode_cmakeOptions(self, spec, cmakeOptions):
-        # Appends to cmakeOptions the options that will enable the appropriate
+    def set_cray_login_node_cmake_options(self, spec, cmake_options):
+        # Appends to cmake_options the options that will enable the appropriate
         # Cray login node libraries
 
-        CrayLoginNodeOptions = []
+        cray_login_node_options = []
         rt_platform = "cray"
 
         # How do we get the compute node (CNL) cbtf package install
@@ -205,12 +205,12 @@ class OpenspeedshopUtils(CMakePackage):
         # Equivalent to install-tool cmake arg:
         # '-DCBTF_KRELL_CN_RUNTIME_DIR=%s'
         #               % <base dir>/cbtf_v2.3.1.release/compute)
-        CrayLoginNodeOptions.append('-DCBTF_KRELL_CN_RUNTIME_DIR=%s'
-                                    % be_ck.prefix)
-        CrayLoginNodeOptions.append('-DRUNTIME_PLATFORM=%s'
-                                    % rt_platform)
+        cray_login_node_options.append('-DCBTF_KRELL_CN_RUNTIME_DIR=%s'
+                                       % be_ck.prefix)
+        cray_login_node_options.append('-DRUNTIME_PLATFORM=%s'
+                                       % rt_platform)
 
-        cmakeOptions.extend(CrayLoginNodeOptions)
+        cmake_options.extend(cray_login_node_options)
 
     def cmake_args(self):
         # Appends base options to cmake_args
@@ -224,7 +224,7 @@ class OpenspeedshopUtils(CMakePackage):
         instrumentor_setting = "cbtf"
 
         if spec.satisfies('+runtime'):
-            self.set_defaultbase_cmakeOptions(spec, cmake_args)
+            self.set_defaultbase_cmake_options(spec, cmake_args)
 
             cmake_args.extend(
                 ['-DCMAKE_CXX_FLAGS=%s'  % compile_flags,
@@ -237,7 +237,7 @@ class OpenspeedshopUtils(CMakePackage):
         else:
 
             # Appends base options to cmake_args
-            self.set_defaultbase_cmakeOptions(spec, cmake_args)
+            self.set_defaultbase_cmake_options(spec, cmake_args)
             cmake_args.extend(
                 ['-DCMAKE_CXX_FLAGS=%s' % compile_flags,
                  '-DCMAKE_C_FLAGS=%s' % compile_flags,
@@ -252,63 +252,63 @@ class OpenspeedshopUtils(CMakePackage):
                 # components/libraries first then pass
                 # those libraries to the openspeedshop
                 # login node build
-                self.set_CrayLoginNode_cmakeOptions(spec, cmake_args)
+                self.set_cray_login_node_cmake_options(spec, cmake_args)
 
         cmake_args.extend(['-DBUILD_QT3_GUI=FALSE'])
 
         return cmake_args
 
-    def set_defaultbase_cmakeOptions(self, spec, cmakeOptions):
-        # Appends to cmakeOptions the options that will enable
+    def set_defaultbase_cmake_options(self, spec, cmake_options):
+        # Appends to cmake_options the options that will enable
         # the appropriate base level options to the openspeedshop
         # cmake build.
         python_exe = spec['python'].command.path
         python_library = spec['python'].libs[0]
         python_include = spec['python'].headers.directories[0]
 
-        BaseOptions = []
+        base_options = []
 
-        BaseOptions.append('-DBINUTILS_DIR=%s' % spec['binutils'].prefix)
-        BaseOptions.append('-DLIBELF_DIR=%s' % spec['elf'].prefix)
-        BaseOptions.append('-DLIBDWARF_DIR=%s' % spec['libdwarf'].prefix)
-        BaseOptions.append('-DPYTHON_EXECUTABLE=%s' % python_exe)
-        BaseOptions.append('-DPYTHON_INCLUDE_DIR=%s' % python_include)
-        BaseOptions.append('-DPYTHON_LIBRARY=%s' % python_library)
-        BaseOptions.append('-DBoost_NO_SYSTEM_PATHS=TRUE')
-        BaseOptions.append('-DBoost_NO_BOOST_CMAKE=TRUE')
-        BaseOptions.append('-DBOOST_ROOT=%s' % spec['boost'].prefix)
-        BaseOptions.append('-DBoost_DIR=%s' % spec['boost'].prefix)
-        BaseOptions.append('-DBOOST_LIBRARYDIR=%s' % spec['boost'].prefix.lib)
-        BaseOptions.append('-DDYNINST_DIR=%s' % spec['dyninst'].prefix)
+        base_options.append('-DBINUTILS_DIR=%s' % spec['binutils'].prefix)
+        base_options.append('-DLIBELF_DIR=%s' % spec['elf'].prefix)
+        base_options.append('-DLIBDWARF_DIR=%s' % spec['libdwarf'].prefix)
+        base_options.append('-DPYTHON_EXECUTABLE=%s' % python_exe)
+        base_options.append('-DPYTHON_INCLUDE_DIR=%s' % python_include)
+        base_options.append('-DPYTHON_LIBRARY=%s' % python_library)
+        base_options.append('-DBoost_NO_SYSTEM_PATHS=TRUE')
+        base_options.append('-DBoost_NO_BOOST_CMAKE=TRUE')
+        base_options.append('-DBOOST_ROOT=%s' % spec['boost'].prefix)
+        base_options.append('-DBoost_DIR=%s' % spec['boost'].prefix)
+        base_options.append('-DBOOST_LIBRARYDIR=%s' % spec['boost'].prefix.lib)
+        base_options.append('-DDYNINST_DIR=%s' % spec['dyninst'].prefix)
 
-        cmakeOptions.extend(BaseOptions)
+        cmake_options.extend(base_options)
 
-    def set_mpi_cmakeOptions(self, spec, cmakeOptions):
-        # Appends to cmakeOptions the options that will enable
+    def set_mpi_cmake_options(self, spec, cmake_options):
+        # Appends to cmake_options the options that will enable
         # the appropriate MPI implementations
 
-        MPIOptions = []
+        mpi_options = []
 
         # openmpi
         if spec.satisfies('+openmpi'):
-            MPIOptions.append('-DOPENMPI_DIR=%s' % spec['openmpi'].prefix)
+            mpi_options.append('-DOPENMPI_DIR=%s' % spec['openmpi'].prefix)
         # mpich
         if spec.satisfies('+mpich'):
-            MPIOptions.append('-DMPICH_DIR=%s' % spec['mpich'].prefix)
+            mpi_options.append('-DMPICH_DIR=%s' % spec['mpich'].prefix)
         # mpich2
         if spec.satisfies('+mpich2'):
-            MPIOptions.append('-DMPICH2_DIR=%s' % spec['mpich2'].prefix)
+            mpi_options.append('-DMPICH2_DIR=%s' % spec['mpich2'].prefix)
         # mvapich
         if spec.satisfies('+mvapich'):
-            MPIOptions.append('-DMVAPICH_DIR=%s' % spec['mvapich'].prefix)
+            mpi_options.append('-DMVAPICH_DIR=%s' % spec['mvapich'].prefix)
         # mvapich2
         if spec.satisfies('+mvapich2'):
-            MPIOptions.append('-DMVAPICH2_DIR=%s' % spec['mvapich2'].prefix)
+            mpi_options.append('-DMVAPICH2_DIR=%s' % spec['mvapich2'].prefix)
         # mpt
         if spec.satisfies('+mpt'):
-            MPIOptions.append('-DMPT_DIR=%s' % spec['mpt'].prefix)
+            mpi_options.append('-DMPT_DIR=%s' % spec['mpt'].prefix)
 
-        cmakeOptions.extend(MPIOptions)
+        cmake_options.extend(mpi_options)
 
     def setup_environment(self, spack_env, run_env):
         """Set up the compile and runtime environments for a package."""

--- a/var/spack/repos/builtin/packages/openspeedshop/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop/package.py
@@ -188,11 +188,11 @@ class Openspeedshop(CMakePackage):
 
     build_directory = 'build_openspeedshop'
 
-    def set_CrayLoginNode_cmakeOptions(self, spec, cmakeOptions):
-        # Appends to cmakeOptions the options that will enable the appropriate
+    def set_cray_login_node_cmake_options(self, spec, cmake_options):
+        # Appends to cmake_options the options that will enable the appropriate
         # Cray login node libraries
 
-        CrayLoginNodeOptions = []
+        cray_login_node_options = []
         rt_platform = "cray"
 
         # How do we get the compute node (CNL) cbtf package install
@@ -206,12 +206,12 @@ class Openspeedshop(CMakePackage):
         # Equivalent to install-tool cmake arg:
         # '-DCBTF_KRELL_CN_RUNTIME_DIR=%s'
         #               % <base dir>/cbtf_v2.3.1.release/compute)
-        CrayLoginNodeOptions.append('-DCBTF_KRELL_CN_RUNTIME_DIR=%s'
-                                    % be_ck.prefix)
-        CrayLoginNodeOptions.append('-DRUNTIME_PLATFORM=%s'
-                                    % rt_platform)
+        cray_login_node_options.append('-DCBTF_KRELL_CN_RUNTIME_DIR=%s'
+                                       % be_ck.prefix)
+        cray_login_node_options.append('-DRUNTIME_PLATFORM=%s'
+                                       % rt_platform)
 
-        cmakeOptions.extend(CrayLoginNodeOptions)
+        cmake_options.extend(cray_login_node_options)
 
     def cmake_args(self):
 
@@ -226,7 +226,7 @@ class Openspeedshop(CMakePackage):
 
         if spec.satisfies('+runtime'):
             # Appends base options to cmake_args
-            self.set_defaultbase_cmakeOptions(spec, cmake_args)
+            self.set_defaultbase_cmake_options(spec, cmake_args)
             cmake_args.extend(
                 ['-DCMAKE_CXX_FLAGS=%s'  % compile_flags,
                  '-DCMAKE_C_FLAGS=%s'    % compile_flags,
@@ -238,7 +238,7 @@ class Openspeedshop(CMakePackage):
         else:
 
             # Appends base options to cmake_args
-            self.set_defaultbase_cmakeOptions(spec, cmake_args)
+            self.set_defaultbase_cmake_options(spec, cmake_args)
             guitype = self.spec.variants['gui'].value
             cmake_args.extend(
                 ['-DCMAKE_CXX_FLAGS=%s' % compile_flags,
@@ -265,61 +265,61 @@ class Openspeedshop(CMakePackage):
                 # components/libraries first then pass
                 # those libraries to the openspeedshop
                 # login node build
-                self.set_CrayLoginNode_cmakeOptions(spec, cmake_args)
+                self.set_cray_login_node_cmake_options(spec, cmake_args)
 
         return cmake_args
 
-    def set_defaultbase_cmakeOptions(self, spec, cmakeOptions):
-        # Appends to cmakeOptions the options that will enable
+    def set_defaultbase_cmake_options(self, spec, cmake_options):
+        # Appends to cmake_options the options that will enable
         # the appropriate base level options to the openspeedshop
         # cmake build.
         python_exe = spec['python'].command.path
         python_library = spec['python'].libs[0]
         python_include = spec['python'].headers.directories[0]
 
-        BaseOptions = []
+        base_options = []
 
-        BaseOptions.append('-DBINUTILS_DIR=%s' % spec['binutils'].prefix)
-        BaseOptions.append('-DLIBELF_DIR=%s' % spec['elf'].prefix)
-        BaseOptions.append('-DLIBDWARF_DIR=%s' % spec['libdwarf'].prefix)
-        BaseOptions.append('-DPYTHON_EXECUTABLE=%s' % python_exe)
-        BaseOptions.append('-DPYTHON_INCLUDE_DIR=%s' % python_include)
-        BaseOptions.append('-DPYTHON_LIBRARY=%s' % python_library)
-        BaseOptions.append('-DBoost_NO_SYSTEM_PATHS=TRUE')
-        BaseOptions.append('-DBoost_NO_BOOST_CMAKE=TRUE')
-        BaseOptions.append('-DBOOST_ROOT=%s' % spec['boost'].prefix)
-        BaseOptions.append('-DBoost_DIR=%s' % spec['boost'].prefix)
-        BaseOptions.append('-DBOOST_LIBRARYDIR=%s' % spec['boost'].prefix.lib)
-        BaseOptions.append('-DDYNINST_DIR=%s' % spec['dyninst'].prefix)
+        base_options.append('-DBINUTILS_DIR=%s' % spec['binutils'].prefix)
+        base_options.append('-DLIBELF_DIR=%s' % spec['elf'].prefix)
+        base_options.append('-DLIBDWARF_DIR=%s' % spec['libdwarf'].prefix)
+        base_options.append('-DPYTHON_EXECUTABLE=%s' % python_exe)
+        base_options.append('-DPYTHON_INCLUDE_DIR=%s' % python_include)
+        base_options.append('-DPYTHON_LIBRARY=%s' % python_library)
+        base_options.append('-DBoost_NO_SYSTEM_PATHS=TRUE')
+        base_options.append('-DBoost_NO_BOOST_CMAKE=TRUE')
+        base_options.append('-DBOOST_ROOT=%s' % spec['boost'].prefix)
+        base_options.append('-DBoost_DIR=%s' % spec['boost'].prefix)
+        base_options.append('-DBOOST_LIBRARYDIR=%s' % spec['boost'].prefix.lib)
+        base_options.append('-DDYNINST_DIR=%s' % spec['dyninst'].prefix)
 
-        cmakeOptions.extend(BaseOptions)
+        cmake_options.extend(base_options)
 
-    def set_mpi_cmakeOptions(self, spec, cmakeOptions):
-        # Appends to cmakeOptions the options that will enable
+    def set_mpi_cmake_options(self, spec, cmake_options):
+        # Appends to cmake_options the options that will enable
         # the appropriate MPI implementations
 
-        MPIOptions = []
+        mpi_options = []
 
         # openmpi
         if spec.satisfies('+openmpi'):
-            MPIOptions.append('-DOPENMPI_DIR=%s' % spec['openmpi'].prefix)
+            mpi_options.append('-DOPENMPI_DIR=%s' % spec['openmpi'].prefix)
         # mpich
         if spec.satisfies('+mpich'):
-            MPIOptions.append('-DMPICH_DIR=%s' % spec['mpich'].prefix)
+            mpi_options.append('-DMPICH_DIR=%s' % spec['mpich'].prefix)
         # mpich2
         if spec.satisfies('+mpich2'):
-            MPIOptions.append('-DMPICH2_DIR=%s' % spec['mpich2'].prefix)
+            mpi_options.append('-DMPICH2_DIR=%s' % spec['mpich2'].prefix)
         # mvapich
         if spec.satisfies('+mvapich'):
-            MPIOptions.append('-DMVAPICH_DIR=%s' % spec['mvapich'].prefix)
+            mpi_options.append('-DMVAPICH_DIR=%s' % spec['mvapich'].prefix)
         # mvapich2
         if spec.satisfies('+mvapich2'):
-            MPIOptions.append('-DMVAPICH2_DIR=%s' % spec['mvapich2'].prefix)
+            mpi_options.append('-DMVAPICH2_DIR=%s' % spec['mvapich2'].prefix)
         # mpt
         if spec.satisfies('+mpt'):
-            MPIOptions.append('-DMPT_DIR=%s' % spec['mpt'].prefix)
+            mpi_options.append('-DMPT_DIR=%s' % spec['mpt'].prefix)
 
-        cmakeOptions.extend(MPIOptions)
+        cmake_options.extend(mpi_options)
 
     def setup_environment(self, spack_env, run_env):
         """Set up the compile and runtime environments for a package."""

--- a/var/spack/repos/builtin/packages/planck-likelihood/package.py
+++ b/var/spack/repos/builtin/packages/planck-likelihood/package.py
@@ -141,8 +141,8 @@ class PlanckLikelihood(Package):
     @on_package_attributes(run_tests=True)
     def check_install(self):
         prefix = self.prefix
-        clik_example_C = Executable(join_path(prefix.bin, 'clik_example_C'))
+        clik_example_c = Executable(join_path(prefix.bin, 'clik_example_C'))
         with working_dir('spack-check', create=True):
-            clik_example_C(join_path(prefix, 'share', 'clik',
+            clik_example_c(join_path(prefix, 'share', 'clik',
                                      'plc_2.0', 'hi_l', 'plik',
                                      'plik_dx11dr2_HM_v18_TT.clik'))

--- a/var/spack/repos/builtin/packages/platypus/package.py
+++ b/var/spack/repos/builtin/packages/platypus/package.py
@@ -38,6 +38,6 @@ class Platypus(Package):
     depends_on('htslib')
 
     def install(self, spec, prefix):
-        buildPlatypus = Executable('./buildPlatypus.sh')
-        buildPlatypus()
+        build_platypus = Executable('./buildPlatypus.sh')
+        build_platypus()
         install_tree('.', prefix.bin)

--- a/var/spack/repos/builtin/packages/py-flake8-polyfill/package.py
+++ b/var/spack/repos/builtin/packages/py-flake8-polyfill/package.py
@@ -1,0 +1,45 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyFlake8Polyfill(PythonPackage):
+    """flake8-polyfill is a package that provides some compatibility helpers
+       for Flake8 plugins that intend to support Flake8 2.x and 3.x
+       simultaneously.
+    """
+    homepage = "https://pypi.org/project/flake8-polyfill/"
+    url      = "https://files.pythonhosted.org/packages/e6/67/1c26634a770db5c442e361311bee73cb3a177adb2eb3f7af8953cfd9f553/flake8-polyfill-1.0.2.tar.gz"
+
+    version('1.0.2', 'e44b087597f6da52ec6393a709e7108b2905317d0c0b744cdca6208e670d8eda')
+
+    extends('python', ignore='bin/(flake8|pyflakes|pycodestyle)')
+    depends_on('py-flake8', type='run')
+
+    def build_args(self, spec, prefix):
+        # FIXME: Add arguments other than --prefix
+        # FIXME: If not needed delete this function
+        args = []
+        return args

--- a/var/spack/repos/builtin/packages/py-pep8-naming/package.py
+++ b/var/spack/repos/builtin/packages/py-pep8-naming/package.py
@@ -1,0 +1,37 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyPep8Naming(PythonPackage):
+    """Check PEP-8 naming conventions, plugin for flake8."""
+
+    homepage = "https://pypi.org/project/pep8-naming/"
+    url      = "https://files.pythonhosted.org/packages/3e/4a/125425d6b1e017f48dfc9c961f4bb9510168db7a090618906c750184ed03/pep8-naming-0.7.0.tar.gz"
+
+    extends('python', ignore='bin/(flake8|pyflakes|pycodestyle)')
+    version('0.7.0', '624258e0dd06ef32a9daf3c36cc925ff7314da7233209c5b01f7e5cdd3c34826')
+
+    depends_on('py-flake8-polyfill', type='run')

--- a/var/spack/repos/builtin/packages/r-rmpi/package.py
+++ b/var/spack/repos/builtin/packages/r-rmpi/package.py
@@ -51,13 +51,13 @@ class RRmpi(RPackage):
         # The type of MPI. Supported values are:
         # OPENMPI, LAM, MPICH, MPICH2, or CRAY
         if mpi_name == 'openmpi':
-            Rmpi_type = 'OPENMPI'
+            rmpi_type = 'OPENMPI'
         elif mpi_name == 'mpich':
-            Rmpi_type = 'MPICH2'
+            rmpi_type = 'MPICH2'
         else:
             raise InstallError('Unsupported MPI type')
 
         return [
-            '--with-Rmpi-type={0}'.format(Rmpi_type),
+            '--with-Rmpi-type={0}'.format(rmpi_type),
             '--with-mpi={0}'.format(spec['mpi'].prefix),
         ]

--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -107,16 +107,16 @@ class R(AutotoolsPackage):
         spec   = self.spec
         prefix = self.prefix
 
-        tclConfig_path = join_path(spec['tcl'].prefix.lib, 'tclConfig.sh')
-        tkConfig_path = join_path(spec['tk'].prefix.lib, 'tkConfig.sh')
+        tcl_config_path = join_path(spec['tcl'].prefix.lib, 'tclConfig.sh')
+        tk_config_path = join_path(spec['tk'].prefix.lib, 'tkConfig.sh')
 
         config_args = [
             '--libdir={0}'.format(join_path(prefix, 'rlib')),
             '--enable-R-shlib',
             '--enable-BLAS-shlib',
             '--enable-R-framework=no',
-            '--with-tcl-config={0}'.format(tclConfig_path),
-            '--with-tk-config={0}'.format(tkConfig_path),
+            '--with-tcl-config={0}'.format(tcl_config_path),
+            '--with-tk-config={0}'.format(tk_config_path),
         ]
 
         if '+external-lapack' in spec:

--- a/var/spack/repos/builtin/packages/tcptrace/package.py
+++ b/var/spack/repos/builtin/packages/tcptrace/package.py
@@ -48,8 +48,8 @@ class Tcptrace(AutotoolsPackage):
     @run_after('configure')
     def patch_makefile(self):
         # see https://github.com/blitz/tcptrace/blob/master/README.linux
-        Makefile = FileFilter('Makefile')
-        Makefile.filter(
+        makefile = FileFilter('Makefile')
+        makefile.filter(
             "PCAP_LDLIBS = -lpcap",
             "DEFINES += -D_BSD_SOURCE\nPCAP_LDLIBS = -lpcap")
 

--- a/var/spack/repos/builtin/packages/tcsh/package.py
+++ b/var/spack/repos/builtin/packages/tcsh/package.py
@@ -38,7 +38,7 @@ class Tcsh(AutotoolsPackage):
 
     version('6.20.00', '59d40ef40a68e790d95e182069431834')
 
-    def fedora_patch(commit, file, **kwargs):
+    def fedora_patch(commit, file, **kwargs):  # noqa
         prefix = 'https://src.fedoraproject.org/rpms/tcsh/raw/{0}/f/'.format(commit)
         patch('{0}{1}'.format(prefix, file), **kwargs)
 

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -25,7 +25,7 @@
 import os
 import sys
 from spack import *
-from spack.operating_systems.mac_os import macOS_version
+from spack.operating_systems.mac_os import macos_version
 
 # Trilinos is complicated to build, as an inspiration a couple of links to
 # other repositories which build it:
@@ -703,7 +703,7 @@ class Trilinos(CMakePackage):
                 '-DTrilinos_ENABLE_FEI=OFF'
             ])
 
-        if sys.platform == 'darwin' and macOS_version() >= Version('10.12'):
+        if sys.platform == 'darwin' and macos_version() >= Version('10.12'):
             # use @rpath on Sierra due to limit of dynamic loader
             options.append('-DCMAKE_MACOSX_RPATH=ON')
         else:

--- a/var/spack/repos/builtin/packages/verilator/package.py
+++ b/var/spack/repos/builtin/packages/verilator/package.py
@@ -74,7 +74,7 @@ class Verilator(AutotoolsPackage):
     # we need to fix the CXX and LINK paths, as they point to the spack
     # wrapper scripts which aren't usable without spack
     @run_after('install')
-    def patch_CXX(self):
+    def patch_cxx(self):
         filter_file(r'^CXX\s*=.*', 'CXX = {0}'.format(self.compiler.cxx),
                     join_path(self.prefix.include, 'verilated.mk'))
         filter_file(r'^LINK\s*=.*', 'LINK = {0}'.format(self.compiler.cxx),

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -154,31 +154,31 @@ class Vtk(CMakePackage):
 
         if '+osmesa' in spec:
             prefix = spec['mesa'].prefix
-            osmesaIncludeDir = prefix.include
-            osmesaLibrary = os.path.join(prefix.lib, 'libOSMesa.so')
+            osmesa_include_dir = prefix.include
+            osmesa_library = os.path.join(prefix.lib, 'libOSMesa.so')
 
-            useParam = 'VTK_USE_X'
+            use_param = 'VTK_USE_X'
             if 'darwin' in spec.architecture:
-                useParam = 'VTK_USE_COCOA'
+                use_param = 'VTK_USE_COCOA'
 
             cmake_args.extend([
-                '-D{0}:BOOL=OFF'.format(useParam),
+                '-D{0}:BOOL=OFF'.format(use_param),
                 '-DVTK_OPENGL_HAS_OSMESA:BOOL=ON',
-                '-DOSMESA_INCLUDE_DIR:PATH={0}'.format(osmesaIncludeDir),
-                '-DOSMESA_LIBRARY:FILEPATH={0}'.format(osmesaLibrary),
+                '-DOSMESA_INCLUDE_DIR:PATH={0}'.format(osmesa_include_dir),
+                '-DOSMESA_LIBRARY:FILEPATH={0}'.format(osmesa_library),
             ])
         else:
             prefix = spec['opengl'].prefix
 
-            openglIncludeDir = prefix.include
-            openglLibrary = os.path.join(prefix.lib, 'libGL.so')
+            opengl_include_dir = prefix.include
+            opengl_library = os.path.join(prefix.lib, 'libGL.so')
             if 'darwin' in spec.architecture:
-                openglIncludeDir = prefix
-                openglLibrary = prefix
+                opengl_include_dir = prefix
+                opengl_library = prefix
 
             cmake_args.extend([
-                '-DOPENGL_INCLUDE_DIR:PATH={0}'.format(openglIncludeDir),
-                '-DOPENGL_gl_LIBRARY:FILEPATH={0}'.format(openglLibrary)
+                '-DOPENGL_INCLUDE_DIR:PATH={0}'.format(opengl_include_dir),
+                '-DOPENGL_gl_LIBRARY:FILEPATH={0}'.format(opengl_library)
             ])
 
         if spec.satisfies('@:6.1.0'):


### PR DESCRIPTION
Enforce PEP8 naming conventions for things like variables, methods, classes, etc.

See the table here:

https://pypi.org/project/pep8-naming/

...for error codes emitted, in case some should be added as exceptions in the flake8 configuration files.