### PR TITLE
zoltan: depends on metis.h and libmetis

### DIFF
--- a/var/spack/repos/builtin/packages/zoltan/package.py
+++ b/var/spack/repos/builtin/packages/zoltan/package.py
@@ -58,6 +58,7 @@ class Zoltan(Package):
     depends_on('mpi', when='+mpi')
 
     depends_on('parmetis@4:', when='+parmetis')
+    depends_on('metis', when='+parmetis')
 
     conflicts('+parmetis', when='~mpi')
 
@@ -91,6 +92,10 @@ class Zoltan(Package):
                                .format(spec['parmetis'].prefix.lib))
             config_args.append('--with-parmetis-incdir={0}'
                                .format(spec['parmetis'].prefix.include))
+            config_args.append('--with-incdirs=-I{0}'
+                               .format(spec['metis'].prefix.include))
+            config_args.append('--with-ldflags=-L{0}'
+                               .format(spec['metis'].prefix.lib))
 
         if '+mpi' in spec:
             config_args.append('CC={0}'.format(spec['mpi'].mpicc))


### PR DESCRIPTION
The parmetis build system does not install metis.h and libmetis.  This PR specifies those dependencies via configure arguments.