### PR TITLE
mirror create: non-zero return code

### DIFF
--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import sys
 import os
 from datetime import datetime
 
@@ -205,6 +206,7 @@ def mirror_create(args):
         if error:
             tty.error("Failed downloads:")
             colify(s.cformat("{name}{@version}") for s in error)
+            sys.exit(1)
 
 
 def mirror(parser, args):


### PR DESCRIPTION
`mirror create` should return a non-zero return code if errors occurred. In such a case, a user could retry, e.g. with

```bash
while [ $? -ne 0 ]
do
    spack mirror create -d spack-mirror -D mpileaks
done
```