### PR TITLE
contribution guide: tip for running flake8

### DIFF
--- a/lib/spack/docs/contribution_guide.rst
+++ b/lib/spack/docs/contribution_guide.rst
@@ -203,7 +203,17 @@ to update them.
       ImportError: No module named pkg_resources
 
    that means Flake8 couldn't find setuptools in your ``PYTHONPATH``.
+   
+   If running ``spack flake8`` produces the following message
+   
+   .. code-block:: console
 
+      ==> Error: spack requires 'flake8'. Make sure it is in your path.
+   
+   , and you have installed ``py-flake8``, then try loading the ``py-flake8`` module
+   (``module av py-flake8`` to find the suffix on modules name,
+   then ``module load py-flake8<suffix>``), and re-running ``spack flake8``.
+    
 ^^^^^^^^^^^^^^^^^^^
 Documentation Tests
 ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Using ``module load py-flake8`` allowed me to run ``spack flake8`` and I figured this could be useful for others.  

Running ``spack activate py-flake8`` before ``spack flake8`` did not resolve the 

```
==> Error: spack requires 'flake8'. Make sure it is in your path.
```

error on my arch linux system.