### PR TITLE
Augustus updated to version 3.3.1

### DIFF
--- a/var/spack/repos/builtin/packages/augustus/package.py
+++ b/var/spack/repos/builtin/packages/augustus/package.py
@@ -33,6 +33,10 @@ class Augustus(MakefilePackage):
     url      = "http://bioinf.uni-greifswald.de/augustus/binaries/augustus-3.3.1.tar.gz"
     list_url = "http://bioinf.uni-greifswald.de/augustus/binaries/old"
 
+    version('3.3.1', '8363ece221c799eb169f47e545efb951')
+    version('3.3',   '93691d9aafc7d3d0e1adf31ec308507f')
+    version('3.2.3', 'b8c47ea8d0c45aa7bb9a82626c8ff830')
+
     depends_on('bamtools')
     depends_on('gsl')
     depends_on('boost')

--- a/var/spack/repos/builtin/packages/augustus/package.py
+++ b/var/spack/repos/builtin/packages/augustus/package.py
@@ -31,13 +31,7 @@ class Augustus(MakefilePackage):
 
     homepage = "http://bioinf.uni-greifswald.de/augustus/"
     url      = "http://bioinf.uni-greifswald.de/augustus/binaries/augustus-3.3.1.tar.gz"
-
-    version('3.3.1', '8363ece221c799eb169f47e545efb951',
-            url='http://bioinf.uni-greifswald.de/augustus/binaries/augustus-3.3.1.tar.gz')
-    version('3.3', '93691d9aafc7d3d0e1adf31ec308507f',
-            url='http://bioinf.uni-greifswald.de/augustus/binaries/old/augustus-3.3.tar.gz')
-    version('3.2.3', 'b8c47ea8d0c45aa7bb9a82626c8ff830',
-            url='http://bioinf.uni-greifswald.de/augustus/binaries/old/augustus-3.2.3.tar.gz')
+    list_url = "http://bioinf.uni-greifswald.de/augustus/binaries/old"
 
     depends_on('bamtools')
     depends_on('gsl')

--- a/var/spack/repos/builtin/packages/augustus/package.py
+++ b/var/spack/repos/builtin/packages/augustus/package.py
@@ -30,10 +30,12 @@ class Augustus(MakefilePackage):
        genomic sequences"""
 
     homepage = "http://bioinf.uni-greifswald.de/augustus/"
-    url      = "http://bioinf.uni-greifswald.de/augustus/binaries/augustus-3.3.tar.gz"
+    url      = "http://bioinf.uni-greifswald.de/augustus/binaries/augustus-3.3.1.tar.gz"
 
+    version('3.3.1', '8363ece221c799eb169f47e545efb951',
+            url='http://bioinf.uni-greifswald.de/augustus/binaries/augustus-3.3.1.tar.gz')
     version('3.3', '93691d9aafc7d3d0e1adf31ec308507f',
-            url='http://bioinf.uni-greifswald.de/augustus/binaries/augustus-3.3.tar.gz')
+            url='http://bioinf.uni-greifswald.de/augustus/binaries/old/augustus-3.3.tar.gz')
     version('3.2.3', 'b8c47ea8d0c45aa7bb9a82626c8ff830',
             url='http://bioinf.uni-greifswald.de/augustus/binaries/old/augustus-3.2.3.tar.gz')
 


### PR DESCRIPTION
With the current version of Augustus package.py when trying to install an error message we'll be displayed as the version 3.3 was moved to the directory **old** (same URL), so I've updated the package including the latest version 3.3.1