### PR TITLE
Add Amrvis package

### DIFF
--- a/var/spack/repos/builtin/packages/amrvis/package.py
+++ b/var/spack/repos/builtin/packages/amrvis/package.py
@@ -183,6 +183,6 @@ class Amrvis(MakefilePackage):
     def install(self, spec, prefix):
         # Install exe manually
         mkdirp(prefix.bin)
-        exes = glob.glob('*.ex')
+        exes = glob.iglob('*.ex')
         for exe in exes:
             install(exe, prefix.bin)

--- a/var/spack/repos/builtin/packages/amrvis/package.py
+++ b/var/spack/repos/builtin/packages/amrvis/package.py
@@ -137,7 +137,7 @@ class Amrvis(MakefilePackage):
             'USE_PROFPARSER = FALSE'
         )
 
-        # Making a big assumption here by deleting all /usr and /opt X
+        # A bit risky here deleting all /usr and /opt X
         # library default search paths in makefile
         makefile.filter(
             r'^.*\b(usr|opt)\b.*$',
@@ -148,10 +148,11 @@ class Amrvis(MakefilePackage):
         with open('GNUmakefile', 'r') as file:
             contents = file.readlines()
 
-        # Edit GNUmakefile INCLUDES and LIBRARIES to use Spack dependencies.
-        # Assuming the default GNUmakefile doesn't change, this is the best
-        # place for LIBRARY_LOCATIONS and INCLUDE_LOCATIONS.
-        line_offset = 64
+        # Edit GNUmakefile includes and libraries to point to Spack
+        # dependencies.
+        # The safest bet is to put the LIBRARY_LOCATIONS and
+        # INCLUDE_LOCATIONS at the beginning of the makefile.
+        line_offset = 0
         count = 0
         for lib in ['libsm', 'libice', 'libxpm', 'libx11',
                     'libxt', 'libxext', 'motif']:

--- a/var/spack/repos/builtin/packages/amrvis/package.py
+++ b/var/spack/repos/builtin/packages/amrvis/package.py
@@ -22,6 +22,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+import glob
 
 
 class Amrvis(MakefilePackage):
@@ -171,37 +172,17 @@ class Amrvis(MakefilePackage):
             file.writelines(contents)
 
     def setup_environment(self, build_env, run_env):
-        if '+mpi' in self.spec:
-            # Set MPI location
-            build_env.set('MPI_HOME', self.spec['mpi'].prefix)
-
-    def install(self, spec, prefix):
         # Help force Amrvis to not pick up random system compilers
         if '+mpi' in self.spec:
+            build_env.set('MPI_HOME', self.spec['mpi'].prefix)
             env['CC'] = spec['mpi'].mpicc
             env['CXX'] = spec['mpi'].mpicxx
             env['F77'] = spec['mpi'].mpif77
             env['FC'] = spec['mpi'].mpifc
 
-        # Set exe name options
-        dim = spec.variants['dims'].value
-        comp = self.compiler.name
-        if spec.satisfies('%gcc'):
-            comp = 'gnu'
-        if spec.satisfies('%clang'):
-            comp = 'llvm'
-        if '+mpi' in self.spec:
-            mpi = '.MPI'
-        else:
-            mpi = ''
-        if '+debug' in self.spec:
-            debug = '.DEBUG'
-        else:
-            debug = ''
-
-        # Construct exe name
-        exe = 'amrvis%sd.%s%s%s.ex' % (dim, comp, debug, mpi)
-
+    def install(self, spec, prefix):
         # Install exe manually
         mkdirp(prefix.bin)
-        install(exe, prefix.bin)
+        exes = glob.iglob('armvis*.ex')
+        for exe in exes:
+            install(exe, prefix.bin)

--- a/var/spack/repos/builtin/packages/amrvis/package.py
+++ b/var/spack/repos/builtin/packages/amrvis/package.py
@@ -204,6 +204,13 @@ class Amrvis(MakefilePackage):
             build_env.set('MPIHOME', self.spec['mpi'].prefix)
 
     def install(self, spec, prefix):
+        # Help force Amrvis to not pick up random system compilers
+        if '+mpi' in self.spec:
+            env['CC'] = spec['mpi'].mpicc
+            env['CXX'] = spec['mpi'].mpicxx
+            env['F77'] = spec['mpi'].mpif77
+            env['FC'] = spec['mpi'].mpifc
+
         # Set exe name options
         dim = spec.variants['dims'].value
         comp = self.compiler.name

--- a/var/spack/repos/builtin/packages/amrvis/package.py
+++ b/var/spack/repos/builtin/packages/amrvis/package.py
@@ -1,0 +1,160 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.  #
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Amrvis(MakefilePackage):
+    """Amrvis is a visualization package specifically designed to
+       read and display output and profiling data from codes built
+       on the AMReX framework.
+    """
+
+    homepage = "https://github.com/AMReX-Codes/Amrvis"
+    url      = "https://github.com/AMReX-Codes/Amrvis.git"
+
+    version('master', git='https://github.com/AMReX-Codes/Amrvis.git', tag='master')
+
+    variant('dims',
+        default='3',
+        values=('1', '2', '3'),
+        multi=False,
+        description='Number of spatial dimensions')
+
+    variant('prec',
+        default='DOUBLE',
+        values=('FLOAT', 'DOUBLE'),
+        multi=False,
+        description='Floating point precision')
+
+    variant('mpi', default=False, description='Enable MPI parallel support')
+    variant('debug', default=False, description='Enable debugging features')
+
+    depends_on('mpi', when='+mpi')
+    depends_on('libsm')
+    depends_on('libice')
+    depends_on('libxpm')
+    depends_on('libx11')
+    depends_on('libxt')
+    depends_on('libxext')
+    depends_on('motif')
+
+    conflicts('%cce', msg='Amrvis is only set to build with gcc currently')
+    conflicts('%clang', msg='Amrvis is only set to build with gcc currently')
+    conflicts('%intel', msg='Amrvis is only set to build with gcc currently')
+    conflicts('%nag', msg='Amrvis is only set to build with gcc currently')
+    conflicts('%pgi', msg='Amrvis is only set to build with gcc currently')
+    conflicts('%xl', msg='Amrvis is only set to build with gcc currently')
+    conflicts('%xl_r', msg='Amrvis is only set to build with gcc currently')
+    conflicts('%intel', msg='Amrvis is only set to build with gcc currently')
+
+    resource(name='amrex',
+             git='https://github.com/AMReX-Codes/amrex.git',
+             tag='master',
+             placement='amrex')
+
+    def edit(self, spec, prefix):
+        filter_file(r'^AMREX_HOME\s*=.*',
+                    'AMREX_HOME = {0}'.format('./amrex'),
+                    'GNUmakefile')
+        filter_file(r'^PRECISION\s*=.*',
+                    'PRECISION = {0}'.format(spec.variants['prec'].value),
+                    'GNUmakefile')
+        filter_file(r'^DIM\s*=.*',
+                    'DIM = {0}'.format(spec.variants['dims'].value),
+                    'GNUmakefile')
+        filter_file(r'^PROFILE\s*=.*',
+                    'PROFILE = FALSE',
+                    'GNUmakefile')
+        filter_file(r'^TRACE_PROFILE\s*=.*',
+                    'TRACE_PROFILE = FALSE',
+                    'GNUmakefile')
+        filter_file(r'^COMM_PROFILE\s*=.*',
+                    'COMM_PROFILE = FALSE',
+                    'GNUmakefile')
+        # Only doing gcc at the moment
+        filter_file(r'^COMP\s*=.*',
+                    'COMP = gnu',
+                    'GNUmakefile')
+        filter_file(r'^DEBUG\s*=.*',
+                    'DEBUG = {0}'.format(spec.variants['debug'].value).upper(),
+                    'GNUmakefile')
+        filter_file(r'^USE_ARRAYVIEW\s*=.*',
+                    'USE_ARRAY_VIEW = FALSE',
+                    'GNUmakefile')
+        filter_file(r'^USE_MPI\s*=.*',
+                    'USE_MPI = {0}'.format(spec.variants['mpi'].value).upper(),
+                    'GNUmakefile')
+        filter_file(r'^USE_CXX11\s*=.*',
+                    'USE_CXX11 = TRUE',
+                    'GNUmakefile')
+        filter_file(r'^USE_VOLRENDER\s*=.*',
+                    'USE_VOLRENDER = FALSE',
+                    'GNUmakefile')
+        filter_file(r'^USE_PARALLELVOLRENDER\s*=.*',
+                    'USE_PARALLELVOLRENDER = FALSE',
+                    'GNUmakefile')
+        filter_file(r'^USE_PROFPARSER\s*=.*',
+                    'USE_PROFPARSER = FALSE',
+                    'GNUmakefile')
+
+        # Delete all /usr and /opt X library default search paths in makefile
+        filter_file(r'^.*\b(usr|opt)\b.*$',
+                    '##### Spack removed all INCLUDE_LOCATIONS and LIBRARY_LOCATIONS',
+                    'GNUmakefile')
+
+        # Read GNUmakefile into array
+        with open('GNUmakefile', 'r') as file:
+            contents = file.readlines()
+        
+        # Edit GNUmakefile INCLUDES and LIBRARIES to use Spack dependencies
+        line_offset = 63
+        contents.insert(line_offset+1, 'LIBRARY_LOCATIONS += {0}\n'.format(spec['libsm'].prefix.lib))
+        contents.insert(line_offset+2, 'INCLUDE_LOCATIONS += {0}\n'.format(spec['libsm'].prefix.include))
+        contents.insert(line_offset+3, 'LIBRARY_LOCATIONS += {0}\n'.format(spec['libice'].prefix.lib))
+        contents.insert(line_offset+4, 'INCLUDE_LOCATIONS += {0}\n'.format(spec['libice'].prefix.include))
+        contents.insert(line_offset+5, 'LIBRARY_LOCATIONS += {0}\n'.format(spec['libxpm'].prefix.lib))
+        contents.insert(line_offset+6, 'INCLUDE_LOCATIONS += {0}\n'.format(spec['libxpm'].prefix.include))
+        contents.insert(line_offset+7, 'LIBRARY_LOCATIONS += {0}\n'.format(spec['libx11'].prefix.lib))
+        contents.insert(line_offset+8, 'INCLUDE_LOCATIONS += {0}\n'.format(spec['libx11'].prefix.include))
+        contents.insert(line_offset+9, 'LIBRARY_LOCATIONS += {0}\n'.format(spec['libxt'].prefix.lib))
+        contents.insert(line_offset+10, 'INCLUDE_LOCATIONS += {0}\n'.format(spec['libxt'].prefix.include))
+        contents.insert(line_offset+11, 'LIBRARY_LOCATIONS += {0}\n'.format(spec['libxext'].prefix.lib))
+        contents.insert(line_offset+12, 'INCLUDE_LOCATIONS += {0}\n'.format(spec['libxext'].prefix.include))
+        contents.insert(line_offset+13, 'LIBRARY_LOCATIONS += {0}\n'.format(spec['motif'].prefix.lib))
+        contents.insert(line_offset+14, 'INCLUDE_LOCATIONS += {0}\n'.format(spec['motif'].prefix.include))
+        
+        # Write GNUmakefile
+        with open('GNUmakefile', 'w') as file:
+            file.writelines(contents)
+
+    def setup_environment(self, build_env, run_env):
+        if '+mpi' in self.spec:
+           # The location of the system MPI tree
+           build_env.set('MPI_HOME', self.spec['mpi'].prefix)
+           build_env.set('MPIHOME', self.spec['mpi'].prefix)
+
+    def install(self, spec, prefix):
+        exe = 'amrvis{0}d.gnu.ex'.format(spec.variants['dims'].value)
+        mkdirp(prefix.bin)
+        install(exe, prefix.bin)

--- a/var/spack/repos/builtin/packages/amrvis/package.py
+++ b/var/spack/repos/builtin/packages/amrvis/package.py
@@ -33,20 +33,23 @@ class Amrvis(MakefilePackage):
     homepage = "https://github.com/AMReX-Codes/Amrvis"
     url      = "https://github.com/AMReX-Codes/Amrvis.git"
 
-    version('master', git='https://github.com/AMReX-Codes/Amrvis.git', tag='master')
+    version('master',
+            git='https://github.com/AMReX-Codes/Amrvis.git', tag='master')
 
-    variant('dims',
+    variant(
+        'dims',
         default='3',
         values=('1', '2', '3'),
         multi=False,
-        description='Number of spatial dimensions')
-
-    variant('prec',
+        description='Number of spatial dimensions'
+    )
+    variant(
+        'prec',
         default='DOUBLE',
         values=('FLOAT', 'DOUBLE'),
         multi=False,
-        description='Floating point precision')
-
+        description='Floating point precision'
+    )
     variant('mpi', default=False, description='Enable MPI parallel support')
     variant('debug', default=False, description='Enable debugging features')
 
@@ -59,11 +62,16 @@ class Amrvis(MakefilePackage):
     depends_on('libxext')
     depends_on('motif')
 
-    conflicts('%cce', msg='Amrvis is only set to build with gcc, clang, and intel currently')
-    conflicts('%nag', msg='Amrvis is only set to build with gcc, clang, and intel currently')
-    conflicts('%pgi', msg='Amrvis is only set to build with gcc, clang, and intel currently')
-    conflicts('%xl', msg='Amrvis is only set to build with gcc, clang, and intel currently')
-    conflicts('%xl_r', msg='Amrvis is only set to build with gcc, clang, and intel currently')
+    conflicts('%cce',
+              msg='Amrvis currently only builds with gcc, clang, and intel')
+    conflicts('%nag',
+              msg='Amrvis currently only builds with gcc, clang, and intel')
+    conflicts('%pgi',
+              msg='Amrvis currently only builds with gcc, clang, and intel')
+    conflicts('%xl',
+              msg='Amrvis currently only builds with gcc, clang, and intel')
+    conflicts('%xl_r',
+              msg='Amrvis currently only builds with gcc, clang, and intel')
 
     resource(name='amrex',
              git='https://github.com/AMReX-Codes/amrex.git',
@@ -117,39 +125,83 @@ class Amrvis(MakefilePackage):
 
         # Delete all /usr and /opt X library default search paths in makefile
         filter_file(r'^.*\b(usr|opt)\b.*$',
-                    '##### Spack removed all INCLUDE_LOCATIONS and LIBRARY_LOCATIONS',
+                    '# Spack removed INCLUDE_LOCATIONS and LIBRARY_LOCATIONS',
                     'GNUmakefile')
 
         # Read GNUmakefile into array
         with open('GNUmakefile', 'r') as file:
             contents = file.readlines()
-        
-        # Edit GNUmakefile INCLUDES and LIBRARIES to use Spack dependencies
-        line_offset = 63 # Assuming the default GNUmakefile doesn't change, this is the best place for LIBRARY_LOCATIONS and INCLUD_LOCATIONS
-        contents.insert(line_offset+1, 'LIBRARY_LOCATIONS += {0}\n'.format(spec['libsm'].prefix.lib))
-        contents.insert(line_offset+2, 'INCLUDE_LOCATIONS += {0}\n'.format(spec['libsm'].prefix.include))
-        contents.insert(line_offset+3, 'LIBRARY_LOCATIONS += {0}\n'.format(spec['libice'].prefix.lib))
-        contents.insert(line_offset+4, 'INCLUDE_LOCATIONS += {0}\n'.format(spec['libice'].prefix.include))
-        contents.insert(line_offset+5, 'LIBRARY_LOCATIONS += {0}\n'.format(spec['libxpm'].prefix.lib))
-        contents.insert(line_offset+6, 'INCLUDE_LOCATIONS += {0}\n'.format(spec['libxpm'].prefix.include))
-        contents.insert(line_offset+7, 'LIBRARY_LOCATIONS += {0}\n'.format(spec['libx11'].prefix.lib))
-        contents.insert(line_offset+8, 'INCLUDE_LOCATIONS += {0}\n'.format(spec['libx11'].prefix.include))
-        contents.insert(line_offset+9, 'LIBRARY_LOCATIONS += {0}\n'.format(spec['libxt'].prefix.lib))
-        contents.insert(line_offset+10, 'INCLUDE_LOCATIONS += {0}\n'.format(spec['libxt'].prefix.include))
-        contents.insert(line_offset+11, 'LIBRARY_LOCATIONS += {0}\n'.format(spec['libxext'].prefix.lib))
-        contents.insert(line_offset+12, 'INCLUDE_LOCATIONS += {0}\n'.format(spec['libxext'].prefix.include))
-        contents.insert(line_offset+13, 'LIBRARY_LOCATIONS += {0}\n'.format(spec['motif'].prefix.lib))
-        contents.insert(line_offset+14, 'INCLUDE_LOCATIONS += {0}\n'.format(spec['motif'].prefix.include))
-        
+
+        # Edit GNUmakefile INCLUDES and LIBRARIES to use Spack dependencies.
+        # Assuming the default GNUmakefile doesn't change, this is the best
+        # place for LIBRARY_LOCATIONS and INCLUDE_LOCATIONS.
+        line_offset = 63
+        contents.insert(
+            line_offset + 1,
+            'LIBRARY_LOCATIONS += {0}\n'.format(spec['libsm'].prefix.lib)
+        )
+        contents.insert(
+            line_offset + 2,
+            'INCLUDE_LOCATIONS += {0}\n'.format(spec['libsm'].prefix.include)
+        )
+        contents.insert(
+            line_offset + 3,
+            'LIBRARY_LOCATIONS += {0}\n'.format(spec['libice'].prefix.lib)
+        )
+        contents.insert(
+            line_offset + 4,
+            'INCLUDE_LOCATIONS += {0}\n'.format(spec['libice'].prefix.include)
+        )
+        contents.insert(
+            line_offset + 5,
+            'LIBRARY_LOCATIONS += {0}\n'.format(spec['libxpm'].prefix.lib)
+        )
+        contents.insert(
+            line_offset + 6,
+            'INCLUDE_LOCATIONS += {0}\n'.format(spec['libxpm'].prefix.include)
+        )
+        contents.insert(
+            line_offset + 7,
+            'LIBRARY_LOCATIONS += {0}\n'.format(spec['libx11'].prefix.lib)
+        )
+        contents.insert(
+            line_offset + 8,
+            'INCLUDE_LOCATIONS += {0}\n'.format(spec['libx11'].prefix.include)
+        )
+        contents.insert(
+            line_offset + 9,
+            'LIBRARY_LOCATIONS += {0}\n'.format(spec['libxt'].prefix.lib)
+        )
+        contents.insert(
+            line_offset + 10,
+            'INCLUDE_LOCATIONS += {0}\n'.format(spec['libxt'].prefix.include)
+        )
+        contents.insert(
+            line_offset + 11,
+            'LIBRARY_LOCATIONS += {0}\n'.format(spec['libxext'].prefix.lib)
+        )
+        contents.insert(
+            line_offset + 12,
+            'INCLUDE_LOCATIONS += {0}\n'.format(spec['libxext'].prefix.include)
+        )
+        contents.insert(
+            line_offset + 13,
+            'LIBRARY_LOCATIONS += {0}\n'.format(spec['motif'].prefix.lib)
+        )
+        contents.insert(
+            line_offset + 14,
+            'INCLUDE_LOCATIONS += {0}\n'.format(spec['motif'].prefix.include)
+        )
+
         # Write GNUmakefile
         with open('GNUmakefile', 'w') as file:
             file.writelines(contents)
 
     def setup_environment(self, build_env, run_env):
         if '+mpi' in self.spec:
-           # The location of the system MPI tree
-           build_env.set('MPI_HOME', self.spec['mpi'].prefix)
-           build_env.set('MPIHOME', self.spec['mpi'].prefix)
+            # Set MPI location
+            build_env.set('MPI_HOME', self.spec['mpi'].prefix)
+            build_env.set('MPIHOME', self.spec['mpi'].prefix)
 
     def install(self, spec, prefix):
         # Set exe name options
@@ -158,16 +210,16 @@ class Amrvis(MakefilePackage):
         if spec.satisfies('%gcc'):
             comp = 'gnu'
         if '+mpi' in self.spec:
-            mpi = '.mpi'
+            mpi = '.MPI'
         else:
             mpi = ''
         if '+debug' in self.spec:
-            debug = '.debug'
+            debug = '.DEBUG'
         else:
             debug = ''
 
         # Construct exe name
-        exe = 'amrvis%sd%s%s.gnu.ex' % (dim,mpi,debug)
+        exe = 'amrvis%sd.%s%s%s.ex' % (dim, comp, debug, mpi)
 
         # Install exe manually
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin/packages/amrvis/package.py
+++ b/var/spack/repos/builtin/packages/amrvis/package.py
@@ -171,18 +171,18 @@ class Amrvis(MakefilePackage):
         with open('GNUmakefile', 'w') as file:
             file.writelines(contents)
 
-    def setup_environment(self, build_env, run_env):
+    def setup_environment(self, spack_env, run_env):
         # Help force Amrvis to not pick up random system compilers
         if '+mpi' in self.spec:
-            build_env.set('MPI_HOME', self.spec['mpi'].prefix)
-            env['CC'] = spec['mpi'].mpicc
-            env['CXX'] = spec['mpi'].mpicxx
-            env['F77'] = spec['mpi'].mpif77
-            env['FC'] = spec['mpi'].mpifc
+            spack_env.set('MPI_HOME', self.spec['mpi'].prefix)
+            spack_env.set('CC', spec['mpi'].mpicc)
+            spack_env.set('CXX', spec['mpi'].mpicxx)
+            spack_env.set('F77', spec['mpi'].mpif77)
+            spack_env.set('FC', spec['mpi'].mpifc)
 
     def install(self, spec, prefix):
         # Install exe manually
         mkdirp(prefix.bin)
-        exes = glob.iglob('armvis*.ex')
+        exes = glob.glob('*.ex')
         for exe in exes:
             install(exe, prefix.bin)

--- a/var/spack/repos/builtin/packages/amrvis/package.py
+++ b/var/spack/repos/builtin/packages/amrvis/package.py
@@ -62,6 +62,8 @@ class Amrvis(MakefilePackage):
     depends_on('libxext')
     depends_on('motif')
 
+    # Only doing gcc and clang at the moment
+    # Intel currently fails searching for mpiicc, mpiicpc, etc
     conflicts('%intel',
               msg='Amrvis currently only builds with gcc and clang')
     conflicts('%cce',
@@ -81,6 +83,7 @@ class Amrvis(MakefilePackage):
              placement='amrex')
 
     def edit(self, spec, prefix):
+        # Set all available makefile options to values we want
         filter_file(r'^AMREX_HOME\s*=.*',
                     'AMREX_HOME = {0}'.format('./amrex'),
                     'GNUmakefile')
@@ -99,8 +102,6 @@ class Amrvis(MakefilePackage):
         filter_file(r'^COMM_PROFILE\s*=.*',
                     'COMM_PROFILE = FALSE',
                     'GNUmakefile')
-        # Only doing gcc and clang at the moment
-        # Intel currently fails searching for mpiicc, mpiicpc, etc
         filter_file(r'^COMP\s*=.*',
                     'COMP = {0}'.format(self.compiler.name),
                     'GNUmakefile')

--- a/var/spack/repos/builtin/packages/amrvis/package.py
+++ b/var/spack/repos/builtin/packages/amrvis/package.py
@@ -51,7 +51,7 @@ class Amrvis(MakefilePackage):
         multi=False,
         description='Floating point precision'
     )
-    variant('mpi', default=False, description='Enable MPI parallel support')
+    variant('mpi', default=True, description='Enable MPI parallel support')
     variant('debug', default=False, description='Enable debugging features')
 
     depends_on('gmake', type='build')
@@ -165,7 +165,7 @@ class Amrvis(MakefilePackage):
                 line_offset + count + 1,
                 'INCLUDE_LOCATIONS += {0}\n'.format(spec[lib].prefix.include)
             )
-            count = count + 1
+            count += 1
 
         # Write GNUmakefile
         with open('GNUmakefile', 'w') as file:

--- a/var/spack/repos/builtin/packages/amrvis/package.py
+++ b/var/spack/repos/builtin/packages/amrvis/package.py
@@ -62,16 +62,18 @@ class Amrvis(MakefilePackage):
     depends_on('libxext')
     depends_on('motif')
 
+    conflicts('%intel',
+              msg='Amrvis currently only builds with gcc and clang')
     conflicts('%cce',
-              msg='Amrvis currently only builds with gcc, clang, and intel')
+              msg='Amrvis currently only builds with gcc and clang')
     conflicts('%nag',
-              msg='Amrvis currently only builds with gcc, clang, and intel')
+              msg='Amrvis currently only builds with gcc and clang')
     conflicts('%pgi',
-              msg='Amrvis currently only builds with gcc, clang, and intel')
+              msg='Amrvis currently only builds with gcc and clang')
     conflicts('%xl',
-              msg='Amrvis currently only builds with gcc, clang, and intel')
+              msg='Amrvis currently only builds with gcc and clang')
     conflicts('%xl_r',
-              msg='Amrvis currently only builds with gcc, clang, and intel')
+              msg='Amrvis currently only builds with gcc and clang')
 
     resource(name='amrex',
              git='https://github.com/AMReX-Codes/amrex.git',
@@ -97,7 +99,8 @@ class Amrvis(MakefilePackage):
         filter_file(r'^COMM_PROFILE\s*=.*',
                     'COMM_PROFILE = FALSE',
                     'GNUmakefile')
-        # Only doing gcc, clang, and intel at the moment
+        # Only doing gcc and clang at the moment
+        # Intel currently fails searching for mpiicc, mpiicpc, etc
         filter_file(r'^COMP\s*=.*',
                     'COMP = {0}'.format(self.compiler.name),
                     'GNUmakefile')
@@ -216,6 +219,8 @@ class Amrvis(MakefilePackage):
         comp = self.compiler.name
         if spec.satisfies('%gcc'):
             comp = 'gnu'
+        if spec.satisfies('%clang'):
+            comp = 'llvm'
         if '+mpi' in self.spec:
             mpi = '.MPI'
         else:


### PR DESCRIPTION
This is one of the more difficult applications I've tried to package because it's just makefiles and the makefiles are mostly based on computing sites. I'm open to any better ways to package this thing.

I basically filter all the makefile options that exist to be exactly what I want, using variants where necessary, then remove all the references to `/usr` and `/opt` it searches for libraries in by default, and then I insert lines into the makefile that point the include and library locations to the Spack built libraries. Then I manually install the binary.