### PR TITLE
ENH: Building OpenFOAM sub-packages (issue #8579)

### DIFF
--- a/var/spack/repos/builtin/packages/openfoam-com/common/spack-Allwmake
+++ b/var/spack/repos/builtin/packages/openfoam-com/common/spack-Allwmake
@@ -5,7 +5,15 @@ export FOAM_INST_DIR=$(cd .. && pwd -L)
 mkdir -p $FOAM_APPBIN $FOAM_LIBBIN 2>/dev/null  # Allow interrupt
 echo "Build openfoam with SPACK ($@)"
 echo WM_PROJECT_DIR = $WM_PROJECT_DIR
-./Allwmake $@                                   # Pass arguments
+
+# Prefer spack-specific Allwmake if it exists
+if [ -f Allwmake-spack ]
+then
+    ./Allwmake-spack $@   # Pass arguments
+else
+    ./Allwmake $@         # Pass arguments
+fi
+
 
 # Link non-dummy MPI_FOAM type to parent-dir, where rpath can find it
 if [ "${FOAM_MPI:=dummy}" != dummy -a -d "$FOAM_LIBBIN/$FOAM_MPI" ]

--- a/var/spack/repos/builtin/packages/openfoam-com/common/spack-derived-Allwmake
+++ b/var/spack/repos/builtin/packages/openfoam-com/common/spack-derived-Allwmake
@@ -1,6 +1,7 @@
 #!/bin/bash
 # The openfoam providers must export 'FOAM_PROJECT_DIR'
-# The package is expected to supply an appropriate Allwmake file.
+# The derived package is expected to supply an appropriate
+# <Allwmake> or <Allwmake-spack> file.
 
 [ -d "$FOAM_PROJECT_DIR" -a -f "$FOAM_PROJECT_DIR/etc/bashrc" ] || {
     echo "Error: no PROJECT=$FOAM_PROJECT_DIR" 1>&2
@@ -22,5 +23,12 @@ echo "  $WM_COMPILER $WM_COMPILER_TYPE compiler"
 echo "  $WM_OPTIONS - with $WM_MPLIB $FOAM_MPI"
 echo
 
-./Allwmake $@  # Pass arguments
+# Prefer spack-specific Allwmake if it exists
+if [ -f Allwmake-spack ]
+then
+    ./Allwmake-spack $@   # Pass arguments
+else
+    ./Allwmake $@         # Pass arguments
+fi
+
 # -----------------------------------------------------------------------------

--- a/var/spack/repos/builtin/packages/openfoam-com/package.py
+++ b/var/spack/repos/builtin/packages/openfoam-com/package.py
@@ -281,6 +281,7 @@ class OpenfoamCom(Package):
     list_url = "https://sourceforge.net/projects/openfoamplus/files/"
     list_depth = 2
 
+    version('1806', 'bb244a3bde7048a03edfccffc46c763f')
     version('1712', '6ad92df051f4d52c7d0ec34f4b8eb3bc')
     version('1706', '630d30770f7b54d6809efbf94b7d7c8f')
     version('1612', 'ca02c491369150ab127cbb88ec60fbdf')

--- a/var/spack/repos/builtin/packages/openfoam-com/package.py
+++ b/var/spack/repos/builtin/packages/openfoam-com/package.py
@@ -303,8 +303,10 @@ class OpenfoamCom(Package):
     # TODO?# variant('scalasca', default=False,
     # TODO?#         description='With scalasca profiling')
     variant('mgridgen', default=False, description='With mgridgen support')
-    variant('paraview', default=True,
+    variant('paraview', default=False,
             description='Build paraview plugins and runtime post-processing')
+    variant('vtk', default=False,
+            description='With VTK runTimePostProcessing')
     variant('source', default=True,
             description='Install library/application sources and tutorials')
 
@@ -319,7 +321,9 @@ class OpenfoamCom(Package):
     depends_on('fftw')
     depends_on('boost')
     depends_on('cgal')
-    depends_on('flex',  type='build')
+    # The flex restriction is ONLY to deal with a spec resolution clash
+    # introduced by the restriction within scotch!
+    depends_on('flex@:2.6.1,2.6.4:', type='build')
     depends_on('cmake', type='build')
 
     # Require scotch with ptscotch - corresponds to standard OpenFOAM setup
@@ -331,6 +335,8 @@ class OpenfoamCom(Package):
     # mgridgen is statically linked
     depends_on('parmgridgen',  when='+mgridgen', type='build')
     depends_on('zoltan',       when='+zoltan')
+    depends_on('vtk',          when='+vtk')
+
     # TODO?# depends_on('scalasca',     when='+scalasca')
 
     # For OpenFOAM plugins and run-time post-processing this should just be
@@ -568,6 +574,7 @@ class OpenfoamCom(Package):
             'ensight': {},     # Disable settings
             'paraview': [],
             'gperftools': [],  # Currently unused
+            'vtk': [],
         }
 
         if '+scotch' in spec:
@@ -594,6 +601,13 @@ class OpenfoamCom(Package):
                 ('ParaView_INCLUDE_DIR', '${ParaView_DIR}/include/' + pvMajor),
                 ('PV_PLUGIN_PATH', '$FOAM_LIBBIN/' + pvMajor),
                 ('PATH', foamAddPath('${ParaView_DIR}/bin')),
+            ]
+
+        if '+vtk' in spec:
+            self.etc_config['vtk'] = [
+                ('VTK_DIR', spec['vtk'].prefix),
+                ('LD_LIBRARY_PATH',
+                 foamAddLib(pkglib(spec['vtk'], '${VTK_DIR}'))),
             ]
 
         # Optional

--- a/var/spack/repos/builtin/packages/openfoam-org/assets/bin/foamEtcFile
+++ b/var/spack/repos/builtin/packages/openfoam-org/assets/bin/foamEtcFile
@@ -4,7 +4,7 @@
 # \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
 #  \\    /   O peration     |
 #   \\  /    A nd           | Copyright (C) 2011-2016 OpenFOAM Foundation
-#    \\/     M anipulation  | Copyright (C) 2017 OpenCFD Ltd.
+#    \\/     M anipulation  | Copyright (C) 2017-2018 OpenCFD Ltd.
 #-------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM, licensed under GNU General Public License
@@ -46,7 +46,7 @@
 printHelp() {
     cat<<USAGE
 
-Usage: foamEtcFile [OPTION] fileName
+Usage: foamEtcFile [OPTION] fileName [-- args]
        foamEtcFile [OPTION] [-list|-list-test] [fileName]
 
 options:
@@ -56,10 +56,13 @@ options:
   -mode=MODE        Any combination of u(user), g(group), o(other)
   -prefix=DIR       Specify an alternative installation prefix
   -version=VER      Specify alternative OpenFOAM version (eg, 3.0, 1612, ...)
-  -csh              Produce output suitable for a csh or sh 'eval'
-  -csh-verbose      As per -csh with additional verbosity
-  -sh               Produce output suitable for a csh or sh 'eval'
-  -sh-verbose       As per -sh  with additional verbosity
+  -csh              Produce 'source FILE' output for a csh eval
+  -sh               Produce '. FILE' output for a sh eval
+  -csh-verbose      As per -csh, with additional verbosity
+  -sh-verbose       As per -sh,  with additional verbosity
+  -config           Add config directory prefix for shell type:
+                        with -csh* for a config.csh/ prefix
+                        with -sh*  for a config.sh/ prefix
   -quiet (-q)       Suppress all normal output
   -silent (-s)      Suppress stderr, except -csh-verbose, -sh-verbose output
   -help             Print the usage
@@ -80,7 +83,6 @@ Exit status
 USAGE
     exit 0  # A clean exit
 }
-
 
 unset optQuiet optSilent
 # Report error and exit
@@ -183,7 +185,8 @@ setVersion()
 
 
 optMode=ugo         # Default mode is always 'ugo'
-unset optAll optList optShell optVersion
+unset shellOutput verboseOutput
+unset optAll optConfig optList optVersion
 
 # Parse options
 while [ "$#" -gt 0 ]
@@ -194,19 +197,24 @@ do
         ;;
     -a | -all)
         optAll=true
-        unset optShell
+        unset shellOutput verboseOutput
         ;;
     -l | -list)
         optList=true
-        unset optShell
         ;;
     -list-test)
         optList='test'
-        unset optShell
         ;;
-    -csh | -sh | -csh-verbose | -sh-verbose)
-        optShell="${1#-}"
-        unset optAll
+    -csh | -sh)
+        shellOutput="${1#-}"
+        unset verboseOutput
+        ;;
+    -csh-verbose | -sh-verbose)
+        shellOutput="${1#-}"
+        verboseOutput="source "         # Report: "source FILE"
+        ;;
+    -config)
+        optConfig=true
         ;;
     -mode=[ugo]*)
         optMode="${1#*=}"
@@ -260,9 +268,33 @@ do
     shift
 done
 
-
 #-------------------------------------------------------------------------------
 
+# Split arguments into filename (for searching) and trailing bits for shell eval
+# Silently remove leading ~OpenFOAM/ (as per Foam::findEtcFile)
+nArgs=$#
+fileName="${1#~OpenFOAM/}"
+unset evalArgs
+
+if [ "$nArgs" -eq 1 ]
+then
+    if [ "$1" = "--" ]
+    then
+        nArgs=0
+        unset fileName
+    fi
+elif [ "$nArgs" -ge 2 ]
+then
+    if [ "$2" = "--" ]
+    then
+        nArgs=1
+        shift 2
+        evalArgs="$@"
+    fi
+fi
+
+
+# Get version information
 if [ -n "$optVersion" ]
 then
     setVersion $optVersion
@@ -285,12 +317,6 @@ groupDir="${WM_PROJECT_SITE:-$prefixDir/site}"
 #     eval echo "$i=\$$i" 1>&2
 # done
 
-
-# Save the essential bits of information
-# silently remove leading ~OpenFOAM/ (used in Foam::findEtcFile)
-nArgs=$#
-fileName="${1#~OpenFOAM/}"
-
 # Define the various places to be searched:
 unset dirList
 case "$optMode" in (*u*) # (U)ser
@@ -309,27 +335,61 @@ case "$optMode" in (*o*) # (O)ther == shipped
 esac
 set -- $dirList
 
+[ "$#" -ge 1 ] || die "No directories to scan. Programming error?"
+exitCode=2  # Fallback is a FileNotFound error
+
+
+#
+# Preliminaries
+#
+
+# Special handling of config.sh/ , config.csh/ directories
+if [ -n "$optConfig" -a -n "$shellOutput" -a -n "$fileName" ]
+then
+    case "$shellOutput" in
+    csh*)
+        optConfig="config.csh/"
+        ;;
+    sh*)
+        optConfig="config.sh/"
+        ;;
+    *)
+        unset optConfig
+        ;;
+    esac
+
+    if [ -n "$optConfig" ]
+    then
+        case "$fileName" in
+        /* | config.csh* | config.sh*)
+            # Does not need or cannot add a prefix
+            unset optConfig
+            ;;
+        *)
+            fileName="$optConfig$fileName"
+            ;;
+        esac
+    fi
+fi
+
 
 #
 # The main routine
 #
 
-exitCode=0
 if [ -n "$optList" ]
 then
 
     # List directories, or potential file locations
     [ "$nArgs" -le 1 ] || \
-    die "-list expects 0 or 1 filename, but $nArgs provided"
+        die "-list options expect 0 or 1 filename, but $nArgs provided"
 
-    # A silly combination, but -quiet does have precedence
+    # A silly combination, but -quiet has absolute precedence
     [ -n "$optQuiet" ] && exit 0
 
     # Test for directory or file too?
     if [ "$optList" = "test" ]
     then
-        exitCode=2  # Fallback to a general error (file not found)
-
         if [ "$nArgs" -eq 1 ]
         then
             for dir
@@ -352,6 +412,7 @@ then
             done
         fi
     else
+        exitCode=0  # OK, already verified that $# != 0
         for dir
         do
             echo "$dir${fileName:+/}$fileName"
@@ -362,35 +423,44 @@ else
 
     [ "$nArgs" -eq 1 ] || die "One filename expected - $nArgs provided"
 
-    exitCode=2  # Fallback to a general error (file not found)
+    # Output for sourcing files ("source" for csh, "." for POSIX shell)
+    # Only allow sourcing a single file (disallow combination with -all)
+    case "$shellOutput" in
+    csh*)
+        shellOutput="source "   # eg, "source FILE"
+        ;;
+    sh*)
+        shellOutput=". "        # eg, ". FILE"
+        ;;
+    esac
+
+    # Anti-pattern: -all disables shell commands
+    if [ -n "$optAll" ]
+    then
+        unset shellOutput verboseOutput
+    fi
 
     for dir
     do
-        if [ -f "$dir/$fileName" ]
+        resolved="$dir/$fileName"
+        if [ -f "$resolved" ]
         then
-            exitCode=0
-            [ -n "$optQuiet" ] && break
-
-            case "$optShell" in
-            (*verbose)
-                echo "Using: $dir/$fileName" 1>&2
-                ;;
-            esac
-
-            case "$optShell" in
-            csh*)
-                echo "source $dir/$fileName"
+            exitCode=0  # OK
+            if [ -n "$optQuiet" ]
+            then
                 break
-                ;;
-            sh*)
-                echo ". $dir/$fileName"
-                break
-                ;;
-            *)
-                echo "$dir/$fileName"
-                [ -n "$optAll" ] || break
-                ;;
-            esac
+            elif [ -n "$verboseOutput" ]
+            then
+                echo "$verboseOutput$resolved" 1>&2
+            fi
+
+            if [ -n "$shellOutput" ]
+            then
+                echo "$shellOutput$resolved $evalArgs"
+            else
+                echo "$resolved"
+            fi
+            [ -n "$optAll" ] || break
         fi
     done
 


### PR DESCRIPTION
* Some support for packages building with OpenFOAM

- Adjust the wrappers calling the OpenFOAM Allwmake script. Have them
  look for a Allwmake-spack file first, which is assumed to contain
  special adjustments for compiling with spack.

  This file could be delivered as part of a tarball (which is unlikely)
  or generated on the fly by the spack sub-package as part of its
  patch or configure stage.

CONFIG: change the default paraview variant for openfoam to be False

- the different combinations of paraview backends, off-screen etc
  make it difficult to suggest that building with paraview as
  a standard dependency makes much sense.
  Additionally, building paraview with qt can become quite an issue.
  So it makes much more sense to only enable that upon request.

ENH: add a +vtk variant.

- for VTK with off-screen rendering to be used by the runTimePostProcessing
  function object, which is a fairly simple framework for generating images of
  some OpenFOAM derived objects (eg, sampling planes).

SPACK spec problem:

- reflect the flex restriction impose by the scotch dependency within
  the openfoam spec as well, as partial workaround for buggy or annoying
  spec resolution.

OTHER:

- updated the backstop foamEtcFile file to include args handling
  as per the OpenFOAM-v1806 updates.