### PR TITLE
Generate pkgconfig file in qhull for py-matplotlib

### DIFF
--- a/lib/spack/spack/build_systems/utils.py
+++ b/lib/spack/spack/build_systems/utils.py
@@ -1,0 +1,46 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+import os
+
+
+def generate_pkgconfig_file(spec, destination_dir, fname=None):
+    contents = """prefix={0}
+exec_prefix=${{prefix}}
+libdir=${{exec_prefix}}/lib
+includedir=${{prefix}}/include
+
+Name: {1}
+Description: Spack-generated .pc file for {1}
+Version: {2}
+Cflags: -I${{includedir}}
+Libs: -L${{libdir}}
+""".format(spec.prefix, spec.name, spec.version)
+
+    destination_fname = "{0}.pc".format(fname or spec.name)
+
+    destination_path = os.path.join(destination_dir, destination_fname)
+
+    with open(destination_path, 'w') as F:
+        F.write(contents)

--- a/var/spack/repos/builtin/packages/qhull/package.py
+++ b/var/spack/repos/builtin/packages/qhull/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+from spack.build_systems.utils import generate_pkgconfig_file
 
 
 class Qhull(CMakePackage):
@@ -46,3 +47,9 @@ class Qhull(CMakePackage):
     patch('qhull-unused-intel-17.02.patch', when='@2015.2')
 
     depends_on('cmake@2.6:', type='build')
+
+    @run_after('install')
+    def post_install(self):
+        pkgconfig_dir = join_path(self.prefix.lib, 'pkgconfig')
+        mkdirp(pkgconfig_dir)
+        generate_pkgconfig_file(self.spec, pkgconfig_dir, fname='libqhull')


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/8546

@s-sajid-ali does this help?

The `py-matplotlib` package cannot find the Spack-installed `qhull` package with `pkgconfig`. `qhull` does not generate a `.pc` file itself. This adds a method to generate a `.pc` file from a Spec and makes use of that method for `qhull`.

TODOs:

- [ ] detect the include directory for the package rather than assuming it's always `prefix/include`
- [ ] likewise for `libs/`