### PR TITLE
Add CFITSIO 3.450

### DIFF
--- a/var/spack/repos/builtin/packages/cfitsio/package.py
+++ b/var/spack/repos/builtin/packages/cfitsio/package.py
@@ -31,8 +31,9 @@ class Cfitsio(AutotoolsPackage):
     """
 
     homepage = 'http://heasarc.gsfc.nasa.gov/fitsio/'
-    url      = 'http://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio3420.tar.gz'
+    url      = 'http://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio3450.tar.gz'
 
+    version('3.450', 'f470849bb43561d9a9b1925eeb7f7f0d')
     version('3.420', '26e5c0dfb85b8d00f536e706305caa13')
     version('3.410', '8a4a66fcdd816aae41768baa0b025552')
     version('3.370', 'abebd2d02ba5b0503c633581e3bfa116')


### PR DESCRIPTION
Builds and passes tests on macOS 10.13.5 with Clang 9.0.0.