### PR TITLE
Add missing dependencies and variants to wcslib

### DIFF
--- a/var/spack/repos/builtin/packages/wcslib/package.py
+++ b/var/spack/repos/builtin/packages/wcslib/package.py
@@ -38,9 +38,9 @@ class Wcslib(AutotoolsPackage):
     variant('x',       default=False, description='Use the X Window System')
 
     depends_on('gmake', type='build')
-    depends_on('flex',  type='build')
+    depends_on('flex@2.5.9:', type='build')
     depends_on('cfitsio', when='+cfitsio')
-    depends_on('libx11',  when='+x')
+    depends_on('libx11', when='+x')
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/wcslib/package.py
+++ b/var/spack/repos/builtin/packages/wcslib/package.py
@@ -29,7 +29,39 @@ class Wcslib(AutotoolsPackage):
     """WCSLIB a C implementation of the coordinate transformations
     defined in the FITS WCS papers."""
 
-    homepage = "http://www.atnf.csiro.au/people/mcalabre/WCS/"
-    url      = "ftp://ftp.atnf.csiro.au/pub/software/wcslib/wcslib.tar.bz2"
+    homepage = "http://www.atnf.csiro.au/people/mcalabre/WCS/wcslib/"
+    url      = "ftp://ftp.atnf.csiro.au/pub/software/wcslib/wcslib-5.18.tar.bz2"
 
     version('5.18', '67a78354be74eca4f17d3e0853d5685f')
+
+    variant('cfitsio', default=False, description='Include CFITSIO support')
+    variant('x',       default=False, description='Use the X Window System')
+
+    depends_on('gmake', type='build')
+    depends_on('flex',  type='build')
+    depends_on('cfitsio', when='+cfitsio')
+    depends_on('libx11',  when='+x')
+
+    def configure_args(self):
+        spec = self.spec
+
+        # TODO: Add PGPLOT package
+        args = ['--without-pgplot']
+
+        if '+cfitsio' in spec:
+            args.extend([
+                '--with-cfitsio',
+                '--with-cfitsiolib={0}'.format(
+                    spec['cfitsio'].libs.directories[0]),
+                '--with-cfitsioinc={0}'.format(
+                    spec['cfitsio'].headers.directories[0]),
+            ])
+        else:
+            args.append('--without-cfitsio')
+
+        if '+x' in spec:
+            args.append('--with-x')
+        else:
+            args.append('--without-x')
+
+        return args


### PR DESCRIPTION
Also adds a version-specific URL so that the checksum doesn't fail when a new release is added.

The default variants build in parallel fine for me on macOS 10.13.5 with Clang 9.0.0, but the package fails when I try to build `+cfitsio`.