### PR TITLE
Spack can be extended with external commands

### DIFF
--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -12,6 +12,8 @@ import collections
 import inspect
 from datetime import datetime, timedelta
 from six import string_types
+import sys
+
 
 # Ignore emacs backups when listing modules
 ignore_modules = [r'^\.#', '~$']
@@ -597,3 +599,33 @@ class LazyReference(object):
 
     def __repr__(self):
         return repr(self.ref_function())
+
+
+def load_module_from_file(module_name, module_path):
+    """Loads a python module from the path of the corresponding file.
+
+    Args:
+        module_name (str): namespace where the python module will be loaded,
+            e.g. ``foo.bar``
+        module_path (str): path of the python file containing the module
+
+    Returns:
+        A valid module object
+
+    Raises:
+        ImportError: when the module can't be loaded
+        FileNotFoundError: when module_path doesn't exist
+    """
+    if sys.version_info[0] == 3 and sys.version_info[1] >= 5:
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(module_name, module_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    elif sys.version_info[0] == 3 and sys.version_info[1] < 5:
+        import importlib.machinery
+        loader = importlib.machinery.SourceFileLoader(module_name, module_path)
+        module = loader.load_module()
+    elif sys.version_info[0] == 2:
+        import imp
+        module = imp.load_source(module_name, module_path)
+    return module

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -101,14 +101,8 @@ def get_module(cmd_name):
                             level=0)
         tty.debug('Imported {0} from built-in commands'.format(pname))
     except ImportError:
-        # If built-in failed the import search the extension
-        # directories in order
-        extensions = spack.config.get('config:extensions') or []
-        for folder in extensions:
-            module = spack.extensions.load_command_extension(cmd_name, folder)
-            if module:
-                break
-        else:
+        module = spack.extensions.get_module(cmd_name)
+        if not module:
             raise
 
     attr_setdefault(module, SETUP_PARSER, lambda *args: None)  # null-op

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -5,6 +5,7 @@
 
 from __future__ import print_function
 
+import itertools
 import os
 import re
 import sys
@@ -17,6 +18,7 @@ from llnl.util.tty.color import colorize
 from llnl.util.filesystem import working_dir
 
 import spack.config
+import spack.extensions
 import spack.paths
 import spack.spec
 import spack.store
@@ -31,9 +33,6 @@ ignore_files = r'^\.|^__init__.py$|^#'
 
 SETUP_PARSER = "setup_parser"
 DESCRIPTION = "description"
-
-#: Names of all commands
-all_commands = []
 
 
 def python_name(cmd_name):
@@ -60,11 +59,18 @@ def all_commands():
     global _all_commands
     if _all_commands is None:
         _all_commands = []
-        for file in os.listdir(spack.paths.command_path):
-            if file.endswith(".py") and not re.search(ignore_files, file):
-                cmd = re.sub(r'.py$', '', file)
-                _all_commands.append(cmd_name(cmd))
-        _all_commands.sort()
+        extensions = spack.config.get('config:extensions') or []
+        command_paths = itertools.chain(
+            [spack.paths.command_path],
+            spack.extensions.command_paths(*extensions)
+        )
+        for path in command_paths:
+            for file in os.listdir(path):
+                if file.endswith(".py") and not re.search(ignore_files, file):
+                    cmd = re.sub(r'.py$', '', file)
+                    _all_commands.append(cmd_name(cmd))
+            _all_commands.sort()
+
     return _all_commands
 
 
@@ -85,10 +91,24 @@ def get_module(cmd_name):
             (contains ``-``, not ``_``).
     """
     pname = python_name(cmd_name)
-    module_name = "%s.%s" % (__name__, pname)
-    module = __import__(module_name,
-                        fromlist=[pname, SETUP_PARSER, DESCRIPTION],
-                        level=0)
+
+    try:
+        # Try to import the command from the built-in directory
+        module_name = "%s.%s" % (__name__, pname)
+        module = __import__(module_name,
+                            fromlist=[pname, SETUP_PARSER, DESCRIPTION],
+                            level=0)
+        tty.debug('Imported {0} from built-in commands'.format(pname))
+    except ImportError:
+        # If built-in failed the import search the extension
+        # directories in order
+        extensions = spack.config.get('config:extensions') or []
+        for folder in extensions:
+            module = spack.extensions.load_command_extension(cmd_name, folder)
+            if module:
+                break
+        else:
+            raise
 
     attr_setdefault(module, SETUP_PARSER, lambda *args: None)  # null-op
     attr_setdefault(module, DESCRIPTION, "")

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -5,7 +5,6 @@
 
 from __future__ import print_function
 
-import itertools
 import os
 import re
 import sys
@@ -59,11 +58,8 @@ def all_commands():
     global _all_commands
     if _all_commands is None:
         _all_commands = []
-        extensions = spack.config.get('config:extensions') or []
-        command_paths = itertools.chain(
-            [spack.paths.command_path],
-            spack.extensions.command_paths(*extensions)
-        )
+        command_paths = [spack.paths.command_path]  # Built-in commands
+        command_paths += spack.extensions.get_command_paths()  # Extensions
         for path in command_paths:
             for file in os.listdir(path):
                 if file.endswith(".py") and not re.search(ignore_files, file):

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -69,7 +69,8 @@ def all_commands():
                 if file.endswith(".py") and not re.search(ignore_files, file):
                     cmd = re.sub(r'.py$', '', file)
                     _all_commands.append(cmd_name(cmd))
-            _all_commands.sort()
+
+        _all_commands.sort()
 
     return _all_commands
 

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -35,6 +35,10 @@ def setup_parser(subparser):
         '-L', '--long-list', action='store_true', default=False,
         help="list the entire hierarchy of tests")
     subparser.add_argument(
+        '--extension', default=None,
+        help="run test for a given Spack extension"
+    )
+    subparser.add_argument(
         'tests', nargs=argparse.REMAINDER,
         help="list of tests to run (will be passed to pytest -k)")
 
@@ -77,8 +81,16 @@ def test(parser, args, unknown_args):
         pytest.main(['-h'])
         return
 
-    # pytest.ini lives in lib/spack/spack/test
-    with working_dir(spack.paths.test_path):
+    # The default is to test the core of Spack. If the option `--extension`
+    # has been used, then test that extension.
+    pytest_root = spack.paths.test_path
+    if args.extension:
+        target = args.extension
+        extensions = spack.config.get('config:extensions')
+        pytest_root = spack.extensions.path_for_extension(target, *extensions)
+
+    # pytest.ini lives in the root of the spack repository.
+    with working_dir(pytest_root):
         # --list and --long-list print the test output better.
         if args.list or args.long_list:
             do_list(args, unknown_args)

--- a/lib/spack/spack/extensions.py
+++ b/lib/spack/spack/extensions.py
@@ -114,3 +114,12 @@ def get_module(cmd_name):
             return module
     else:
         return None
+
+
+def get_template_dirs():
+    """Returns the list of directories where to search for templates
+    in extensions.
+    """
+    extension_dirs = spack.config.get('config:extensions') or []
+    extensions = [os.path.join(x, 'templates') for x in extension_dirs]
+    return extensions

--- a/lib/spack/spack/extensions.py
+++ b/lib/spack/spack/extensions.py
@@ -11,6 +11,9 @@ import re
 import llnl.util.lang
 import llnl.util.tty as tty
 
+import spack.config
+
+
 extension_regexp = re.compile(r'spack-([\w]*)')
 
 
@@ -92,3 +95,22 @@ def path_for_extension(target_name, *paths):
             return path
     else:
         raise IOError('extension "{0}" not found'.format(target_name))
+
+
+def get_module(cmd_name):
+    """Imports the extension module for a particular command name
+    and returns it.
+
+    Args:
+        cmd_name (str): name of the command for which to get a module
+            (contains ``-``, not ``_``).
+    """
+    # If built-in failed the import search the extension
+    # directories in order
+    extensions = spack.config.get('config:extensions') or []
+    for folder in extensions:
+        module = load_command_extension(cmd_name, folder)
+        if module:
+            return module
+    else:
+        return None

--- a/lib/spack/spack/extensions.py
+++ b/lib/spack/spack/extensions.py
@@ -74,3 +74,21 @@ def command_paths(*paths):
         extension = extension_name(path)
         if extension:
             yield os.path.join(path, extension, 'cmd')
+
+
+def path_for_extension(target_name, *paths):
+    """Return the test root dir for a given extension.
+
+    Args:
+        target_name (str): name of the extension to test
+        *paths: paths where the extensions reside
+
+    Returns:
+        Root directory where tests should reside or None
+    """
+    for path in paths:
+        name = extension_name(path)
+        if name == target_name:
+            return path
+    else:
+        raise IOError('extension "{0}" not found'.format(target_name))

--- a/lib/spack/spack/extensions.py
+++ b/lib/spack/spack/extensions.py
@@ -64,19 +64,17 @@ def load_command_extension(command, path):
     return module
 
 
-def command_paths(*paths):
-    """Generator that yields paths where to search for command files.
+def get_command_paths():
+    """Return the list of paths where to search for command files."""
+    command_paths = []
+    extension_paths = spack.config.get('config:extensions') or []
 
-    Args:
-        *paths: paths where the extensions reside
-
-    Returns:
-        Paths where to search for command files.
-    """
-    for path in paths:
+    for path in extension_paths:
         extension = extension_name(path)
         if extension:
-            yield os.path.join(path, extension, 'cmd')
+            command_paths.append(os.path.join(path, extension, 'cmd'))
+
+    return command_paths
 
 
 def path_for_extension(target_name, *paths):

--- a/lib/spack/spack/extensions.py
+++ b/lib/spack/spack/extensions.py
@@ -1,0 +1,76 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Service functions and classes to implement the hooks
+for Spack's command extensions.
+"""
+import os
+import re
+
+import llnl.util.lang
+import llnl.util.tty as tty
+
+extension_regexp = re.compile(r'spack-([\w]*)')
+
+
+def extension_name(path):
+    """Returns the name of the extension in the path passed as argument.
+
+    Args:
+        path (str): path where the extension resides
+
+    Returns:
+        The extension name or None if path doesn't match the format
+        for Spack's extension.
+    """
+    regexp_match = re.search(extension_regexp, os.path.basename(path))
+    if not regexp_match:
+        msg = "[FOLDER NAMING]"
+        msg += " {0} doesn't match the format for Spack's extensions"
+        tty.warn(msg.format(path))
+        return None
+    return regexp_match.group(1)
+
+
+def load_command_extension(command, path):
+    """Loads a command extension from the path passed as argument.
+
+    Args:
+        command (str): name of the command
+        path (str): base path of the command extension
+
+    Returns:
+        A valid module object if the command is found or None
+    """
+    extension = extension_name(path)
+    if not extension:
+        return None
+
+    # Compute the absolute path of the file to be loaded, along with the
+    # name of the python module where it will be stored
+    cmd_path = os.path.join(path, extension, 'cmd', command + '.py')
+    python_name = command.replace('-', '_')
+    module_name = '{0}.{1}'.format(__name__, python_name)
+
+    try:
+        module = llnl.util.lang.load_module_from_file(module_name, cmd_path)
+    except (ImportError, IOError):
+        module = None
+
+    return module
+
+
+def command_paths(*paths):
+    """Generator that yields paths where to search for command files.
+
+    Args:
+        *paths: paths where the extensions reside
+
+    Returns:
+        Paths where to search for command files.
+    """
+    for path in paths:
+        extension = extension_name(path)
+        if extension:
+            yield os.path.join(path, extension, 'cmd')

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -25,6 +25,10 @@ properties = {
                     {'type': 'array',
                      'items': {'type': 'string'}}],
             },
+            'extensions': {
+                'type': 'array',
+                'items': {'type': 'string'}
+            },
             'template_dirs': {
                 'type': 'array',
                 'items': {'type': 'string'}

--- a/lib/spack/spack/tengine.py
+++ b/lib/spack/spack/tengine.py
@@ -2,7 +2,8 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
+import itertools
+import os
 import textwrap
 
 import jinja2
@@ -72,8 +73,12 @@ def make_environment(dirs=None):
     """Returns an configured environment for template rendering."""
     if dirs is None:
         # Default directories where to search for templates
+        builtins = spack.config.get('config:template_dirs')
+        extension_dirs = spack.config.get('config:extensions') or []
+        extensions = [os.path.join(x, 'templates') for x in extension_dirs]
         dirs = [canonicalize_path(d)
-                for d in spack.config.get('config:template_dirs')]
+                for d in itertools.chain(builtins, extensions)]
+
     # Loader for the templates
     loader = jinja2.FileSystemLoader(dirs)
     # Environment of the template engine

--- a/lib/spack/spack/tengine.py
+++ b/lib/spack/spack/tengine.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import itertools
-import os
 import textwrap
 
 import jinja2
@@ -74,8 +73,7 @@ def make_environment(dirs=None):
     if dirs is None:
         # Default directories where to search for templates
         builtins = spack.config.get('config:template_dirs')
-        extension_dirs = spack.config.get('config:extensions') or []
-        extensions = [os.path.join(x, 'templates') for x in extension_dirs]
+        extensions = spack.extensions.get_template_dirs()
         dirs = [canonicalize_path(d)
                 for d in itertools.chain(builtins, extensions)]
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -24,6 +24,7 @@ import spack.caches
 import spack.database
 import spack.directory_layout
 import spack.environment as ev
+import spack.package_prefs
 import spack.paths
 import spack.platforms.test
 import spack.repo
@@ -118,7 +119,7 @@ def mock_stage(tmpdir_factory):
 
 
 @pytest.fixture(scope='session')
-def _ignore_stage_files():
+def ignore_stage_files():
     """Session-scoped helper for check_for_leftover_stage_files.
 
     Used to track which leftover files in the stage have been seen.
@@ -145,7 +146,7 @@ def working_env():
 
 
 @pytest.fixture(scope='function', autouse=True)
-def check_for_leftover_stage_files(request, mock_stage, _ignore_stage_files):
+def check_for_leftover_stage_files(request, mock_stage, ignore_stage_files):
     """Ensure that each test leaves a clean stage when done.
 
     This can be disabled for tests that are expected to dirty the stage
@@ -160,7 +161,7 @@ def check_for_leftover_stage_files(request, mock_stage, _ignore_stage_files):
     files_in_stage = set()
     if os.path.exists(spack.paths.stage_path):
         files_in_stage = set(
-            os.listdir(spack.paths.stage_path)) - _ignore_stage_files
+            os.listdir(spack.paths.stage_path)) - ignore_stage_files
 
     if 'disable_clean_stage_check' in request.keywords:
         # clean up after tests that are expected to be dirty
@@ -168,7 +169,7 @@ def check_for_leftover_stage_files(request, mock_stage, _ignore_stage_files):
             path = os.path.join(spack.paths.stage_path, f)
             remove_whatever_it_is(path)
     else:
-        _ignore_stage_files |= files_in_stage
+        ignore_stage_files |= files_in_stage
         assert not files_in_stage
 
 

--- a/lib/spack/spack/test/llnl/util/lang.py
+++ b/lib/spack/spack/test/llnl/util/lang.py
@@ -5,6 +5,7 @@
 
 import pytest
 
+import os.path
 from datetime import datetime, timedelta
 
 import llnl.util.lang
@@ -14,6 +15,19 @@ from llnl.util.lang import pretty_date, match_predicate
 @pytest.fixture()
 def now():
     return datetime.now()
+
+
+@pytest.fixture()
+def module_path(tmpdir):
+    m = tmpdir.join('foo.py')
+    content = """
+import os.path
+
+value = 1
+path = os.path.join('/usr', 'bin')
+"""
+    m.write(content)
+    return str(m)
 
 
 def test_pretty_date():
@@ -110,3 +124,9 @@ def test_match_predicate():
     with pytest.raises(ValueError):
         matcher = match_predicate(object())
         matcher('foo')
+
+
+def test_load_modules_from_file(module_path):
+    foo = llnl.util.lang.load_module_from_file('foo', module_path)
+    assert foo.value == 1
+    assert foo.path == os.path.join('/usr', 'bin')


### PR DESCRIPTION
fixes #7967 

This PR gives Spack the ability to hook external commands. This is done adding a new keyword (`extensions`) to `config.yaml`, which contains a list of paths pointing to valid extensions.

### Changelist

- [x] Added support to hook external commands
- [ ] Added support to `spack create`, so that it can create a stub structure for extensions
- [ ] Added documentation on external commands

### What is a valid extension?
A valid extension is any path in your filesystem which respect a certain naming and layout for files:
```console
$ tree spack-scripting/
spack-scripting/ # The top level directory must match the format 'spack-{extension_name}'
├── pytest.ini # Optional file if the extension ships its own tests
├── scripting # Folder that may contain modules that are needed for the extension commands
│   └── cmd # Folder containing extension commands
│       └── filter.py # A new command that will be available 
└── tests # Tests for this extension
    ├── conftest.py 
    └── test_filter.py
└── templates # Templates that may be needed by the extension
```
Both naming and layout are tentative at the moment, so comments to improve them are welcome.

### Example
To try out a sample extension:
1. Clone spack somewhere. 
2. Clone [this repository](https://github.com/alalazo/spack-scripting):
```console
$ pwd
/home/user

$ mkdir tmp && cd tmp
$ git clone https://github.com/alalazo/spack-scripting.git
Cloning into 'spack-scripting'...
remote: Counting objects: 11, done.
remote: Compressing objects: 100% (7/7), done.
remote: Total 11 (delta 0), reused 11 (delta 0), pack-reused 0
Receiving objects: 100% (11/11), done.
```
3. Add the following line to `config.yaml`:
```yaml
config:
  extensions:
    -  /home/user/tmp/spack-scripting
```
4. To check that everything is hooked properly, try looking for the filter command:
```console
$ spack filter --help
usage: spack filter [-h] [--installed | --not-installed]
                    [--explicit | --implicit] [--output OUTPUT]
                    ...

filter specs based on their properties

positional arguments:
  specs            specs to be filtered

optional arguments:
  -h, --help       show this help message and exit
  --installed      select installed specs
  --not-installed  select specs that are not yet installed
  --explicit       select specs that were installed explicitly
  --implicit       select specs that are not installed or were installed implicitly
  --output OUTPUT  where to dump the result
```
5. You can also run the unit tests that are shipped with an extension:
```console
$ spack test --extension=scripting
============================================================== test session starts ===============================================================
platform linux -- Python 3.6.5, pytest-3.2.5, py-1.4.34, pluggy-0.4.0
rootdir: /home/mculpo/tmp/spack-scripting, inifile: pytest.ini
collected 5 items                                                                                                                                 

tests/test_filter.py ...xx
============================================================ short test summary info =============================================================
XFAIL tests/test_filter.py::test_filtering_specs[flags3-specs3-expected3]
XFAIL tests/test_filter.py::test_filtering_specs[flags4-specs4-expected4]

=========================================================== slowest 20 test durations ============================================================
4.82s setup    tests/test_filter.py::test_filtering_specs[flags0-specs0-expected0]
0.20s teardown tests/test_filter.py::test_filtering_specs[flags4-specs4-expected4]
0.17s call     tests/test_filter.py::test_filtering_specs[flags4-specs4-expected4]
0.14s call     tests/test_filter.py::test_filtering_specs[flags2-specs2-expected2]
0.13s call     tests/test_filter.py::test_filtering_specs[flags3-specs3-expected3]
0.13s call     tests/test_filter.py::test_filtering_specs[flags1-specs1-expected1]
0.11s call     tests/test_filter.py::test_filtering_specs[flags0-specs0-expected0]
0.00s setup    tests/test_filter.py::test_filtering_specs[flags3-specs3-expected3]
0.00s setup    tests/test_filter.py::test_filtering_specs[flags2-specs2-expected2]
0.00s setup    tests/test_filter.py::test_filtering_specs[flags4-specs4-expected4]
0.00s setup    tests/test_filter.py::test_filtering_specs[flags1-specs1-expected1]
0.00s teardown tests/test_filter.py::test_filtering_specs[flags2-specs2-expected2]
0.00s teardown tests/test_filter.py::test_filtering_specs[flags0-specs0-expected0]
0.00s teardown tests/test_filter.py::test_filtering_specs[flags3-specs3-expected3]
0.00s teardown tests/test_filter.py::test_filtering_specs[flags1-specs1-expected1]
====================================================== 3 passed, 2 xfailed in 5.78 seconds =======================================================
```