### PR TITLE
Add MDB driver support to GDAL

### DIFF
--- a/var/spack/repos/builtin/packages/commons-lang/package.py
+++ b/var/spack/repos/builtin/packages/commons-lang/package.py
@@ -1,0 +1,50 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class CommonsLang(Package):
+    """The standard Java libraries fail to provide enough methods for
+    manipulation of its core classes. Apache Commons Lang provides these
+    extra methods.
+
+    Lang provides a host of helper utilities for the java.lang API, notably
+    String manipulation methods, basic numerical methods, object reflection,
+    concurrency, creation and serialization and System properties. Additionally
+    it contains basic enhancements to java.util.Date and a series of utilities
+    dedicated to help with building methods, such as hashCode, toString and
+    equals."""
+
+    homepage = "http://commons.apache.org/proper/commons-lang/"
+    url      = "https://archive.apache.org/dist/commons/lang/binaries/commons-lang-2.6-bin.tar.gz"
+
+    version('2.6', '444075803459bffebfb5e28877861d23')
+    version('2.4', '5ff5d890e46021a2dbd77caba80f90f2')
+
+    extends('jdk')
+    depends_on('java@2:', type='run')
+
+    def install(self, spec, prefix):
+        install('commons-lang-{0}.jar'.format(self.version), prefix)

--- a/var/spack/repos/builtin/packages/commons-lang3/package.py
+++ b/var/spack/repos/builtin/packages/commons-lang3/package.py
@@ -1,0 +1,49 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class CommonsLang3(Package):
+    """The standard Java libraries fail to provide enough methods for
+    manipulation of its core classes. Apache Commons Lang provides these
+    extra methods.
+
+    Lang provides a host of helper utilities for the java.lang API, notably
+    String manipulation methods, basic numerical methods, object reflection,
+    concurrency, creation and serialization and System properties. Additionally
+    it contains basic enhancements to java.util.Date and a series of utilities
+    dedicated to help with building methods, such as hashCode, toString and
+    equals."""
+
+    homepage = "http://commons.apache.org/proper/commons-lang/"
+    url      = "https://archive.apache.org/dist/commons/lang/binaries/commons-lang3-3.7-bin.tar.gz"
+
+    version('3.7', 'c7577443639dc6efadc80f1cbc7fced5')
+
+    extends('jdk')
+    depends_on('java@7:', type='run')
+
+    def install(self, spec, prefix):
+        install('commons-lang3-{0}.jar'.format(self.version), prefix)

--- a/var/spack/repos/builtin/packages/commons-logging/package.py
+++ b/var/spack/repos/builtin/packages/commons-logging/package.py
@@ -1,0 +1,51 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class CommonsLogging(Package):
+    """When writing a library it is very useful to log information. However
+    there are many logging implementations out there, and a library cannot
+    impose the use of a particular one on the overall application that the
+    library is a part of.
+
+    The Logging package is an ultra-thin bridge between different logging
+    implementations. A library that uses the commons-logging API can be used
+    with any logging implementation at runtime. Commons-logging comes with
+    support for a number of popular logging implementations, and writing
+    adapters for others is a reasonably simple task."""
+
+    homepage = "http://commons.apache.org/proper/commons-logging/"
+    url      = "http://archive.apache.org/dist/commons/logging/binaries/commons-logging-1.2-bin.tar.gz"
+
+    version('1.2',   'ac043ce7ab3374eb4ed58354a6b2c3de')
+    version('1.1.3', 'b132f9a1e875677ae6b449406cff2a78')
+    version('1.1.1', 'e5de09672af9b386c30a311654d8541a')
+
+    extends('jdk')
+    depends_on('java', type='run')
+
+    def install(self, spec, prefix):
+        install('commons-logging-{0}.jar'.format(self.version), prefix)

--- a/var/spack/repos/builtin/packages/jackcess/package.py
+++ b/var/spack/repos/builtin/packages/jackcess/package.py
@@ -1,0 +1,46 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Jackcess(Package):
+    """Jackcess is a pure Java library for reading from and writing to
+    MS Access databases (currently supporting versions 2000-2016)."""
+
+    homepage = "http://jackcess.sourceforge.net/"
+    url      = "https://sourceforge.net/projects/jackcess/files/jackcess/2.1.12/jackcess-2.1.12.jar"
+
+    version('2.1.12',   '7d051d8dd93f2fe7e5e86389ea380619', expand=False)
+    version('1.2.14.3', 'ef778421c1385ac9ab4aa7edfb954caa', expand=False)
+
+    extends('jdk')
+    depends_on('java', type='run')
+    depends_on('commons-lang@2.6', when='@2.1.12', type='run')
+    depends_on('commons-lang@2.4', when='@1.2.14.3', type='run')
+    depends_on('commons-logging@1.1.3', when='@2.1.12', type='run')
+    depends_on('commons-logging@1.1.1', when='@1.2.14.3', type='run')
+
+    def install(self, spec, prefix):
+        install('jackcess-{0}.jar'.format(self.version), prefix)


### PR DESCRIPTION
I had an old Microsoft Access Database file that I wanted to use, but QGIS doesn't support `.mdb` files. Apparently ArcGIS does, but ArcGIS doesn't support macOS/Linux. This driver allowed me to use `ogr2ogr` to convert it to a shapefile.

GDAL also supports MDB Tools for this purpose, but it sounds like MDB Tools has been unmaintained for quite some time.

Depends on #8613.

@michaelkuhn @neilflood @citibeth may be interested in this.