### PR TITLE
Add Python 3.7.0

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -49,6 +49,7 @@ class Python(AutotoolsPackage):
     list_url = "https://www.python.org/downloads/"
     list_depth = 1
 
+    version('3.7.0', '41b6595deb4147a1ed517a7d9a580271')
     version('3.6.5', 'ab25d24b1f8cc4990ade979f6dc37883')
     version('3.6.4', '9de6494314ea199e3633211696735f65')
     version('3.6.3', 'e9180c69ed9a878a4a8a3ab221e32fa9')


### PR DESCRIPTION
Successfully builds and prints 'Hello World' on macOS 10.13.5 with Clang 9.0.0.