### PR TITLE
Glog: make is a function

### DIFF
--- a/var/spack/repos/builtin/packages/glog/package.py
+++ b/var/spack/repos/builtin/packages/glog/package.py
@@ -40,7 +40,7 @@ class Glog(Package):
 
     def install(self, spec, prefix):
         configure('--prefix=%s' % prefix)
-        make
+        make()
         make('install')
 
     @when('@0.3.5:')
@@ -50,5 +50,5 @@ class Glog(Package):
 
         with working_dir('spack-build', create=True):
             cmake('..', *cmake_args)
-            make
+            make()
             make('install')


### PR DESCRIPTION
Miraculously, this didn't break anything, but also doesn't run `make`. The only reason that this worked is that `make install` knows that it has to build the libraries first.

The `trinity` package also makes this mistake, but will be fixed in #8516.