### PR TITLE
Added support for uncrustify 0.67.

### DIFF
--- a/var/spack/repos/builtin/packages/uncrustify/package.py
+++ b/var/spack/repos/builtin/packages/uncrustify/package.py
@@ -48,4 +48,3 @@ class Uncrustify(Package):
         configure('--prefix={}'.format(self.prefix))
         make()
         make('install')
-

--- a/var/spack/repos/builtin/packages/uncrustify/package.py
+++ b/var/spack/repos/builtin/packages/uncrustify/package.py
@@ -45,6 +45,6 @@ class Uncrustify(Package):
 
     @when('@:0.62')
     def install(self, spec, prefix):
-        configure('--prefix={}'.format(self.prefix))
+        configure('--prefix={0}'.format(self.prefix))
         make()
         make('install')

--- a/var/spack/repos/builtin/packages/uncrustify/package.py
+++ b/var/spack/repos/builtin/packages/uncrustify/package.py
@@ -25,10 +25,27 @@
 from spack import *
 
 
-class Uncrustify(AutotoolsPackage):
+class Uncrustify(Package):
     """Source Code Beautifier for C, C++, C#, ObjectiveC, Java, and others."""
 
     homepage = "http://uncrustify.sourceforge.net/"
     url      = "http://downloads.sourceforge.net/project/uncrustify/uncrustify/uncrustify-0.61/uncrustify-0.61.tar.gz"
 
+    version('0.67', '0c9a08366e5c97cd02ae766064e957de41827611')
     version('0.61', 'b6140106e74c64e831d0b1c4b6cf7727')
+
+    depends_on('cmake', type='build', when='@0.64:')
+
+    @when('@0.64:')
+    def install(self, spec, prefix):
+        with working_dir('spack-build', create=True):
+            cmake('..', *std_cmake_args)
+            make()
+            make('install')
+
+    @when('@:0.62')
+    def install(self, spec, prefix):
+        configure('--prefix={}'.format(self.prefix))
+        make()
+        make('install')
+


### PR DESCRIPTION
Since the build system changed for uncrustify at version 0.64,
I had to change the package from an AutotoolsPackage to a plain
Package and use @when annotations to build the packages differently.