### PR TITLE
trilinos: update dtk dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -251,6 +251,9 @@ class Trilinos(CMakePackage):
     conflicts('+zoltan2', when='~xpetra')
     conflicts('+zoltan2', when='~zoltan')
 
+    conflicts('+dtk', when='~intrepid2')
+    conflicts('+dtk', when='~kokkos')
+    conflicts('+dtk', when='~teuchos')
     conflicts('+dtk', when='~tpetra')
     conflicts('+fortrilinos', when='~fortran')
     conflicts('+fortrilinos', when='@:99')


### PR DESCRIPTION
This updates the dependencies of DataTransferKit to follow recent changes.