### PR TITLE
libxshmfence: Update to 1.3

### DIFF
--- a/var/spack/repos/builtin/packages/libxshmfence/package.py
+++ b/var/spack/repos/builtin/packages/libxshmfence/package.py
@@ -33,9 +33,10 @@ class Libxshmfence(AutotoolsPackage):
     using file descriptor passing."""
 
     homepage = "https://cgit.freedesktop.org/xorg/lib/libxshmfence/"
-    url      = "http://xorg.freedesktop.org/archive/individual/lib/libxshmfence-1.2.tar.gz"
+    url      = "https://www.x.org/archive/individual/lib/libxshmfence-1.3.tar.bz2"
 
-    version('1.2', 'f0b30c0fc568b22ec524859ee28556f1')
+    version('1.3', '42dda8016943dc12aff2c03a036e0937')
+    version('1.2', '66662e76899112c0f99e22f2fc775a7e')
 
     depends_on('xproto', type='build')
     depends_on('pkgconfig', type='build')


### PR DESCRIPTION
libxshmfence@1.2 does not compile with recent versions of glibc.

I have also updated the URL and switched to bz2 tarballs to save bandwidth.