### PR TITLE
Make builtin flag handlers available in package scope

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2616,13 +2616,13 @@ Here are the definitions of the three built-in flag handlers:
 
 .. code-block:: python
 
-   def inject_flags(self, name, flags):
+   def inject_flags(pkg, name, flags):
        return (flags, None, None)
 
-   def env_flags(self, name, flags):
+   def env_flags(pkg, name, flags):
        return (None, flags, None)
 
-   def build_system_flags(self, name, flags):
+   def build_system_flags(pkg, name, flags):
        return (None, None, flags)
 
 .. note::
@@ -2635,10 +2635,7 @@ the built-in flag handlers,
 
 .. code-block:: python
 
-   flag_handler = <PackageClass>.env_flags
-
-where ``<PackageClass>`` can be any of the subclasses of PackageBase
-discussed in :ref:`installation_procedure`,
+   flag_handler = env_flags
 
 or by implementing the flag_handler method. Suppose for a package
 ``Foo`` we need to pass ``cflags``, ``cxxflags``, and ``cppflags``
@@ -2664,7 +2661,7 @@ method of the ``EnvironmentModifications`` class to append values to a
 list of flags whenever the flag handler is ``env_flags``. If the
 package passes flags through the environment or the build system
 manually (in the install method, for example), we recommend using the
-default flag handler, or removind manual references and implementing a
+default flag handler, or removing manual references and implementing a
 custom flag handler method that adds the desired flags to export as
 environment variables or pass to the build system. Manual flag passing
 is likely to interfere with the ``env_flags`` and

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -308,6 +308,31 @@ class PackageViewMixin(object):
             view.remove_file(src, dst)
 
 
+def inject_flags(pkg, name, flags):
+    """
+    flag_handler that injects all flags through the compiler wrapper.
+    """
+    return (flags, None, None)
+
+
+def env_flags(pkg, name, flags):
+    """
+    flag_handler that adds all flags to canonical environment variables.
+    """
+    return (None, flags, None)
+
+
+def build_system_flags(pkg, name, flags):
+    """
+    flag_handler that passes flags to the build system arguments.  Any
+    package using `build_system_flags` must also implement
+    `flags_to_build_system_args`, or derive from a class that
+    implements it.  Currently, AutotoolsPackage and CMakePackage
+    implement it.
+    """
+    return (None, None, flags)
+
+
 class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
     """This is the superclass for all spack packages.
 
@@ -1913,28 +1938,6 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
                 package's spec is available as ``self.spec``.
         """
         pass
-
-    def inject_flags(self, name, flags):
-        """
-        flag_handler that injects all flags through the compiler wrapper.
-        """
-        return (flags, None, None)
-
-    def env_flags(self, name, flags):
-        """
-        flag_handler that adds all flags to canonical environment variables.
-        """
-        return (None, flags, None)
-
-    def build_system_flags(self, name, flags):
-        """
-        flag_handler that passes flags to the build system arguments.  Any
-        package using `build_system_flags` must also implement
-        `flags_to_build_system_args`, or derive from a class that
-        implements it.  Currently, AutotoolsPackage and CMakePackage
-        implement it.
-        """
-        return (None, None, flags)
 
     flag_handler = inject_flags
     # The flag handler method is called for each of the allowed compiler flags.

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -308,31 +308,6 @@ class PackageViewMixin(object):
             view.remove_file(src, dst)
 
 
-def inject_flags(pkg, name, flags):
-    """
-    flag_handler that injects all flags through the compiler wrapper.
-    """
-    return (flags, None, None)
-
-
-def env_flags(pkg, name, flags):
-    """
-    flag_handler that adds all flags to canonical environment variables.
-    """
-    return (None, flags, None)
-
-
-def build_system_flags(pkg, name, flags):
-    """
-    flag_handler that passes flags to the build system arguments.  Any
-    package using `build_system_flags` must also implement
-    `flags_to_build_system_args`, or derive from a class that
-    implements it.  Currently, AutotoolsPackage and CMakePackage
-    implement it.
-    """
-    return (None, None, flags)
-
-
 class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
     """This is the superclass for all spack packages.
 
@@ -1839,6 +1814,31 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         return __import__(self.__class__.__module__,
                           fromlist=[self.__class__.__name__])
 
+    @classmethod
+    def inject_flags(pkg, name, flags):
+        """
+        flag_handler that injects all flags through the compiler wrapper.
+        """
+        return (flags, None, None)
+
+    @classmethod
+    def env_flags(pkg, name, flags):
+        """
+        flag_handler that adds all flags to canonical environment variables.
+        """
+        return (None, flags, None)
+
+    @classmethod
+    def build_system_flags(pkg, name, flags):
+        """
+        flag_handler that passes flags to the build system arguments.  Any
+        package using `build_system_flags` must also implement
+        `flags_to_build_system_args`, or derive from a class that
+        implements it.  Currently, AutotoolsPackage and CMakePackage
+        implement it.
+        """
+        return (None, None, flags)
+
     def setup_environment(self, spack_env, run_env):
         """Set up the compile and runtime environments for a package.
 
@@ -2262,6 +2262,11 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             except AttributeError:
                 msg = 'RUN-TESTS: method not implemented [{0}]'
                 tty.warn(msg.format(name))
+
+
+inject_flags = PackageBase.inject_flags
+env_flags = PackageBase.env_flags
+build_system_flags = PackageBase.build_system_flags
 
 
 class Package(PackageBase):

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1815,21 +1815,21 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
                           fromlist=[self.__class__.__name__])
 
     @classmethod
-    def inject_flags(pkg, name, flags):
+    def inject_flags(cls, name, flags):
         """
         flag_handler that injects all flags through the compiler wrapper.
         """
         return (flags, None, None)
 
     @classmethod
-    def env_flags(pkg, name, flags):
+    def env_flags(cls, name, flags):
         """
         flag_handler that adds all flags to canonical environment variables.
         """
         return (None, flags, None)
 
     @classmethod
-    def build_system_flags(pkg, name, flags):
+    def build_system_flags(cls, name, flags):
         """
         flag_handler that passes flags to the build system arguments.  Any
         package using `build_system_flags` must also implement

--- a/lib/spack/spack/pkgkit.py
+++ b/lib/spack/spack/pkgkit.py
@@ -31,6 +31,7 @@ import llnl.util.filesystem
 from llnl.util.filesystem import *
 
 from spack.package import Package, run_before, run_after, on_package_attributes
+from spack.package import inject_flags, env_flags, build_system_flags
 from spack.build_systems.makefile import MakefilePackage
 from spack.build_systems.aspell_dict import AspellDictPackage
 from spack.build_systems.autotools import AutotoolsPackage

--- a/lib/spack/spack/test/flag_handlers.py
+++ b/lib/spack/spack/test/flag_handlers.py
@@ -31,6 +31,7 @@ import spack.build_environment
 
 from spack.pkgkit import inject_flags, env_flags, build_system_flags
 
+
 @pytest.fixture()
 def temp_env():
     old_env = os.environ.copy()

--- a/lib/spack/spack/test/flag_handlers.py
+++ b/lib/spack/spack/test/flag_handlers.py
@@ -29,6 +29,7 @@ import spack.spec
 import spack.repo
 import spack.build_environment
 
+from spack.pkgkit import inject_flags, env_flags, build_system_flags
 
 @pytest.fixture()
 def temp_env():
@@ -62,23 +63,11 @@ class TestFlagHandlers(object):
         assert 'SPACK_CPPFLAGS' not in os.environ
         assert 'CPPFLAGS' not in os.environ
 
-    def test_unbound_method(self, temp_env):
-        # Other tests test flag_handlers set as bound methods and functions.
-        # This tests an unbound method in python2 (no change in python3).
-        s = spack.spec.Spec('mpileaks cppflags=-g')
-        s.concretize()
-        pkg = spack.repo.get(s)
-        pkg.flag_handler = pkg.__class__.inject_flags
-        spack.build_environment.setup_package(pkg, False)
-
-        assert os.environ['SPACK_CPPFLAGS'] == '-g'
-        assert 'CPPFLAGS' not in os.environ
-
     def test_inject_flags(self, temp_env):
         s = spack.spec.Spec('mpileaks cppflags=-g')
         s.concretize()
         pkg = spack.repo.get(s)
-        pkg.flag_handler = pkg.inject_flags
+        pkg.flag_handler = inject_flags
         spack.build_environment.setup_package(pkg, False)
 
         assert os.environ['SPACK_CPPFLAGS'] == '-g'
@@ -88,7 +77,7 @@ class TestFlagHandlers(object):
         s = spack.spec.Spec('mpileaks cppflags=-g')
         s.concretize()
         pkg = spack.repo.get(s)
-        pkg.flag_handler = pkg.env_flags
+        pkg.flag_handler = env_flags
         spack.build_environment.setup_package(pkg, False)
 
         assert os.environ['CPPFLAGS'] == '-g'
@@ -98,7 +87,7 @@ class TestFlagHandlers(object):
         s = spack.spec.Spec('callpath cppflags=-g')
         s.concretize()
         pkg = spack.repo.get(s)
-        pkg.flag_handler = pkg.build_system_flags
+        pkg.flag_handler = build_system_flags
         spack.build_environment.setup_package(pkg, False)
 
         assert 'SPACK_CPPFLAGS' not in os.environ
@@ -112,7 +101,7 @@ class TestFlagHandlers(object):
         s = spack.spec.Spec('libelf cppflags=-g')
         s.concretize()
         pkg = spack.repo.get(s)
-        pkg.flag_handler = pkg.build_system_flags
+        pkg.flag_handler = build_system_flags
         spack.build_environment.setup_package(pkg, False)
 
         assert 'SPACK_CPPFLAGS' not in os.environ
@@ -124,7 +113,7 @@ class TestFlagHandlers(object):
         s = spack.spec.Spec('mpileaks cppflags=-g')
         s.concretize()
         pkg = spack.repo.get(s)
-        pkg.flag_handler = pkg.build_system_flags
+        pkg.flag_handler = build_system_flags
 
         # Test the command line flags method raises a NotImplementedError
         try:
@@ -161,7 +150,7 @@ class TestFlagHandlers(object):
         s = spack.spec.Spec('callpath ldflags=-mthreads')
         s.concretize()
         pkg = spack.repo.get(s)
-        pkg.flag_handler = pkg.build_system_flags
+        pkg.flag_handler = build_system_flags
         spack.build_environment.setup_package(pkg, False)
 
         assert 'SPACK_LDFLAGS' not in os.environ
@@ -177,7 +166,7 @@ class TestFlagHandlers(object):
         s = spack.spec.Spec('callpath ldlibs=-lfoo')
         s.concretize()
         pkg = spack.repo.get(s)
-        pkg.flag_handler = pkg.build_system_flags
+        pkg.flag_handler = build_system_flags
         spack.build_environment.setup_package(pkg, False)
 
         assert 'SPACK_LDLIBS' not in os.environ

--- a/lib/spack/spack/test/flag_handlers.py
+++ b/lib/spack/spack/test/flag_handlers.py
@@ -64,6 +64,17 @@ class TestFlagHandlers(object):
         assert 'SPACK_CPPFLAGS' not in os.environ
         assert 'CPPFLAGS' not in os.environ
 
+    def test_unbound_method(self, temp_env):
+        # Other tests test flag_handlers set as bound methods and functions.
+        # This tests an unbound method in python2 (no change in python3).
+        s = spack.spec.Spec('mpileaks cppflags=-g')
+        s.concretize()
+        pkg = spack.repo.get(s)
+        pkg.flag_handler = pkg.__class__.inject_flags
+        spack.build_environment.setup_package(pkg, False)
+        assert os.environ['SPACK_CPPFLAGS'] == '-g'
+        assert 'CPPFLAGS' not in os.environ
+
     def test_inject_flags(self, temp_env):
         s = spack.spec.Spec('mpileaks cppflags=-g')
         s.concretize()

--- a/var/spack/repos/builtin/packages/hiop/package.py
+++ b/var/spack/repos/builtin/packages/hiop/package.py
@@ -49,7 +49,7 @@ class Hiop(CMakePackage):
     depends_on('lapack')
     depends_on('blas')
 
-    flag_handler = CMakePackage.build_system_flags
+    flag_handler = build_system_flags
 
     def cmake_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/ipopt/package.py
+++ b/var/spack/repos/builtin/packages/ipopt/package.py
@@ -56,7 +56,7 @@ class Ipopt(AutotoolsPackage):
 
     patch('ipopt_ppc_build.patch', when='arch=ppc64le')
 
-    flag_handler = AutotoolsPackage.build_system_flags
+    flag_handler = build_system_flags
     build_directory = 'spack-build'
 
     # IPOPT does not build correctly in parallel on OS X


### PR DESCRIPTION
Previously to use the pre-defined flag_handler methods, you needed to type `flag_handler = Package.env_flags` or the equivalent.

Now you can type `flag_handler = env_flags`.

As a reminder, the default flag handler is `inject_flags`. It uses the spack compiler wrappers to inject the flags. The other two builtin flag handlers are `env_flags` and `build_system_flags`. The `env_flags` flag handler puts the flags into the canonical environment variables. The `build_system_flags` flag_handler is only available for `AutotoolsPackage` or `CMakePackage` packages and puts the flags onto either the `configure` or `cmake` line, respectively.