### PR TITLE
Adding psm as a dependency of mvapich2.

### DIFF
--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -119,6 +119,7 @@ class Mvapich2(AutotoolsPackage):
     depends_on('bison', type='build')
     depends_on('libpciaccess', when=(sys.platform != 'darwin'))
     depends_on('cuda', when='+cuda')
+    depends_on('psm', when='fabrics=psm')
 
     filter_compiler_wrappers(
         'mpicc', 'mpicxx', 'mpif77', 'mpif90', 'mpifort', relative_root='bin'
@@ -163,7 +164,10 @@ class Mvapich2(AutotoolsPackage):
         opts = []
         # From here on I can suppose that only one variant has been selected
         if 'fabrics=psm' in self.spec:
-            opts = ["--with-device=ch3:psm"]
+            opts = [
+                "--with-device=ch3:psm",
+                "--with-psm={0}".format(self.spec['psm'].prefix)
+            ]
         elif 'fabrics=sock' in self.spec:
             opts = ["--with-device=ch3:sock"]
         elif 'fabrics=nemesistcpib' in self.spec:


### PR DESCRIPTION
Probably needs more testing. Only tried this on my laptop so far, but when I set `psm` as an external it seems to do what I expect.