### PR TITLE
Patch for 'netlib-lapack'.

### DIFF
--- a/var/spack/repos/builtin/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-lapack/package.py
@@ -60,6 +60,11 @@ class NetlibLapack(CMakePackage):
     patch('ibm-xl.patch', when='@3.7: %xl')
     patch('ibm-xl.patch', when='@3.7: %xl_r')
 
+    # https://github.com/Reference-LAPACK/lapack/issues/228
+    # TODO: update 'when' once the version of lapack
+    # containing the fix is released and added to Spack.
+    patch('undefined_declarations.patch', when='@3.8.0:')
+
     # virtual dependency
     provides('blas', when='~external-blas')
     provides('lapack')

--- a/var/spack/repos/builtin/packages/netlib-lapack/undefined_declarations.patch
+++ b/var/spack/repos/builtin/packages/netlib-lapack/undefined_declarations.patch
@@ -1,0 +1,26 @@
+diff --git a/SRC/dsytrf_aa_2stage.f b/SRC/dsytrf_aa_2stage.f
+index 2991305..f5f06cc 100644
+--- a/SRC/dsytrf_aa_2stage.f
++++ b/SRC/dsytrf_aa_2stage.f
+@@ -191,7 +191,7 @@
+       EXTERNAL           LSAME, ILAENV
+ *     ..
+ *     .. External Subroutines ..
+-      EXTERNAL           XERBLA, DCOPY, DLACGV, DLACPY,
++      EXTERNAL           XERBLA, DCOPY, DLACPY,
+      $                   DLASET, DGBTRF, DGEMM,  DGETRF, 
+      $                   DSYGST, DSWAP, DTRSM 
+ *     ..
+diff --git a/SRC/ssytrf_aa_2stage.f b/SRC/ssytrf_aa_2stage.f
+index be6809d..a929749 100644
+--- a/SRC/ssytrf_aa_2stage.f
++++ b/SRC/ssytrf_aa_2stage.f
+@@ -191,7 +191,7 @@
+       EXTERNAL           LSAME, ILAENV
+ *     ..
+ *     .. External Subroutines ..
+-      EXTERNAL           XERBLA, SCOPY, SLACGV, SLACPY,
++      EXTERNAL           XERBLA, SCOPY, SLACPY,
+      $                   SLASET, SGBTRF, SGEMM,  SGETRF, 
+      $                   SSYGST, SSWAP, STRSM 
+ *     ..


### PR DESCRIPTION
There is a problem when linking to netlib-lapack 3.8.0 that has already been fixed upstream: https://github.com/Reference-LAPACK/lapack/issues/228

This PR adds that patch for the affected release.