### PR TITLE
Remove unnecessary version-specific URL overrides

### DIFF
--- a/var/spack/repos/builtin/packages/bwa/package.py
+++ b/var/spack/repos/builtin/packages/bwa/package.py
@@ -31,14 +31,10 @@ class Bwa(Package):
     homepage = "http://github.com/lh3/bwa"
     url      = "https://github.com/lh3/bwa/releases/download/v0.7.15/bwa-0.7.15.tar.bz2"
 
-    version('0.7.17', '82cba7ef695538e6a38b9d4156837381',
-            url="https://github.com/lh3/bwa/releases/download/v0.7.17/bwa-0.7.17.tar.bz2")
-    version('0.7.16a', 'c5115c9a5ea0406848500e4b23a7708c',
-            url="https://github.com/lh3/bwa/releases/download/v0.7.16/bwa-0.7.16a.tar.bz2")
-    version('0.7.15', 'fcf470a46a1dbe2f96a1c5b87c530554',
-            url="https://github.com/lh3/bwa/releases/download/v0.7.15/bwa-0.7.15.tar.bz2")
-    version('0.7.13', 'f094f609438511766c434178a3635ab4',
-            url="https://github.com/lh3/bwa/releases/download/v0.7.13/bwa-0.7.13.tar.bz2")
+    version('0.7.17', '82cba7ef695538e6a38b9d4156837381')
+    version('0.7.16a', 'c5115c9a5ea0406848500e4b23a7708c')
+    version('0.7.15', 'fcf470a46a1dbe2f96a1c5b87c530554')
+    version('0.7.13', 'f094f609438511766c434178a3635ab4')
     version('0.7.12', 'e24a587baaad411d5da89516ad7a261a',
             url='https://github.com/lh3/bwa/archive/0.7.12.tar.gz')
 

--- a/var/spack/repos/builtin/packages/jellyfish/package.py
+++ b/var/spack/repos/builtin/packages/jellyfish/package.py
@@ -33,8 +33,7 @@ class Jellyfish(AutotoolsPackage):
     url      = "https://github.com/gmarcais/Jellyfish/releases/download/v2.2.7/jellyfish-2.2.7.tar.gz"
     list_url = "http://www.cbcb.umd.edu/software/jellyfish/"
 
-    version('2.2.7', 'f741192d9061f28e34cb67c86a1027ab',
-            url='https://github.com/gmarcais/Jellyfish/releases/download/v2.2.7/jellyfish-2.2.7.tar.gz')
+    version('2.2.7', 'f741192d9061f28e34cb67c86a1027ab')
     version('1.1.11', 'dc994ea8b0896156500ea8c648f24846',
             url='http://www.cbcb.umd.edu/software/jellyfish/jellyfish-1.1.11.tar.gz')
 

--- a/var/spack/repos/builtin/packages/py-backports-functools-lru-cache/package.py
+++ b/var/spack/repos/builtin/packages/py-backports-functools-lru-cache/package.py
@@ -31,12 +31,11 @@ class PyBackportsFunctoolsLruCache(PythonPackage):
     homepage = "https://github.com/jaraco/backports.functools_lru_cache"
     url = "https://pypi.io/packages/source/b/backports.functools_lru_cache/backports.functools_lru_cache-1.4.tar.gz"
 
-    version('1.5', '20f53f54cd3f04b3346ce75a54959754',
-            url="https://pypi.io/packages/source/b/backports.functools_lru_cache/backports.functools_lru_cache-1.5.tar.gz")
-    version('1.4', 'b954e7d5e2ca0f0f66ad2ed12ba800e5',
-            url="https://pypi.io/packages/source/b/backports.functools_lru_cache/backports.functools_lru_cache-1.4.tar.gz")
+    version('1.5', '20f53f54cd3f04b3346ce75a54959754')
+    version('1.4', 'b954e7d5e2ca0f0f66ad2ed12ba800e5')
     version('1.0.1', 'c789ef439d189330b99872746a6d9e85',
             url="https://pypi.io/packages/source/b/backports.functools_lru_cache/backports.functools_lru_cache-1.0.1.zip")
+
     depends_on('py-setuptools', type='build')
     depends_on('py-setuptools-scm@1.15.0:', type='build')
     depends_on('python@2.6.0:3.3.99',        type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -51,9 +51,7 @@ class PyScipy(PythonPackage):
 
     version('1.1.0', 'aa6bcc85276b6f25e17bcfc4dede8718')
     version('1.0.0', '53fa34bd3733a9a4216842b6000f7316')
-    # See https://github.com/spack/spack/issues/2737
-    version('0.19.1', '6b4d91b62f1926282b127194a06b72b3',
-            url="https://pypi.io/packages/source/s/scipy/scipy-0.19.1.tar.gz")
+    version('0.19.1', '6b4d91b62f1926282b127194a06b72b3')
     version('0.19.0', '91b8396231eec780222a57703d3ec550',
             url="https://pypi.io/packages/source/s/scipy/scipy-0.19.0.zip")
     version('0.18.1', '5fb5fb7ccb113ab3a039702b6c2f3327')

--- a/var/spack/repos/builtin/packages/star/package.py
+++ b/var/spack/repos/builtin/packages/star/package.py
@@ -31,8 +31,7 @@ class Star(Package):
     homepage = "https://github.com/alexdobin/STAR"
     url      = "https://github.com/alexdobin/STAR/archive/2.5.3a.tar.gz"
 
-    version('2.5.3a', 'baf8d1b62a50482cfa13acb7652dc391',
-            url='https://github.com/alexdobin/STAR/archive/2.5.3a.tar.gz')
+    version('2.5.3a', 'baf8d1b62a50482cfa13acb7652dc391')
     version('2.4.2a', '8b9345f2685a5ec30731e0868e86d506',
             url='https://github.com/alexdobin/STAR/archive/STAR_2.4.2a.tar.gz')
 


### PR DESCRIPTION
Now that #2737 has been closed thanks to @alalazo's #8565, these version-specific URL overrides are no longer necessary.

Confirmed that `spack info` reports the same URLs before and after this change.