### PR TITLE
Scotch: fix compilation of 6.0.5a

### DIFF
--- a/var/spack/repos/builtin/packages/scotch/libscotchmetis-return-6.0.5a.patch
+++ b/var/spack/repos/builtin/packages/scotch/libscotchmetis-return-6.0.5a.patch
@@ -1,0 +1,10 @@
+--- a/src/libscotchmetis/metis_graph_part.c	2018-07-13 14:25:50.000000000 -0500
++++ b/src/libscotchmetis/metis_graph_part.c	2018-07-13 14:21:08.000000000 -0500
+@@ -298,7 +298,7 @@
+
+     edgenbr = xadj[vertnbr] - baseval;
+     if ((edlotax = memAlloc (edgenbr * sizeof (SCOTCH_Num))) == NULL)
+-      return;
++      return (METIS_ERROR);
+     edlotax -= baseval;                           /* Base access to edlotax */
+     vsiztax  = vsize2 - baseval;

--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -63,6 +63,8 @@ class Scotch(Package):
     patch('esmumps-ldflags-6.0.4.patch', when='@6.0.4')
     patch('metis-headers-6.0.4.patch', when='@6.0.4')
 
+    patch('libscotchmetis-return-6.0.5a.patch', when='@6.0.5a')
+
     # NOTE: In cross-compiling environment parallel build
     # produces weird linker errors.
     parallel = False


### PR DESCRIPTION
Prevent this error:

metis_graph_part.c:301:7: error: non-void function 'METIS_PartGraphVKway' should return a value
      [-Wreturn-type]