### PR TITLE
mothur: mpi not used

### DIFF
--- a/var/spack/repos/builtin/packages/mothur/package.py
+++ b/var/spack/repos/builtin/packages/mothur/package.py
@@ -36,9 +36,6 @@ class Mothur(MakefilePackage):
     version('1.40.5', 'd57847849fdb961c3f66c9b9fdf3057b')
     version('1.39.5', '1f826ea4420e6822fc0db002c5940b92')
 
-    variant('mpi', default=True, description='Enable MPI parallel support')
-
-    depends_on('mpi', when='+mpi')
     depends_on('boost')
     depends_on('readline')
 


### PR DESCRIPTION
MPI was removed from Mothur in 2015:
https://github.com/mothur/mothur/commit/5e42a11c07231861c58d2fe1626c4a6b78a52918

So, this dependency was not actually being used

