### PR TITLE
Charm: set default backend to netlrts

### DIFF
--- a/var/spack/repos/builtin/packages/charm/package.py
+++ b/var/spack/repos/builtin/packages/charm/package.py
@@ -70,7 +70,7 @@ class Charm(Package):
     # Communication mechanisms (choose exactly one)
     variant(
         "backend",
-        default="mpi",
+        default="netlrts",
         values=("mpi", "multicore", "netlrts", "verbs", "gni",
                 "ofi", "pami", "pamilrts"),
         description="Set the backend to use"


### PR DESCRIPTION
This allows building MPI applications on top of charm/AMPI without
having to specify another backend.