### PR TITLE
fix link to blas libs

### DIFF
--- a/var/spack/repos/builtin/packages/moab/package.py
+++ b/var/spack/repos/builtin/packages/moab/package.py
@@ -124,6 +124,8 @@ class Moab(AutotoolsPackage):
 #       else:
 #           options.append('--without-mpi')
 
+        options.append('--with-blas=%s' % spec['blas'].libs)
+
         if '+hdf5' in spec:
             options.append('--with-hdf5=%s' % spec['hdf5'].prefix)
         else:


### PR DESCRIPTION
Fix linking blas libs and force moab to use spack blas. If conf option not set moab uses host system installed blas libs, or if blas is not on the host system configuration error is generated.