### PR TITLE
Confine the xlf_seacas.patch for trilinos to version 12.12.1

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -313,7 +313,7 @@ class Trilinos(CMakePackage):
     patch('umfpack_from_suitesparse.patch', when='@11.14.1:12.8.1')
     patch('xlf_seacas.patch', when='@12.10.1:12.12.1 %xl')
     patch('xlf_seacas.patch', when='@12.10.1:12.12.1 %xl_r')
-    patch('xlf_seacas.patch', when='@12.12.1 %clang')
+    patch('xlf_seacas.patch', when='@12.10.1:12.12.1 %clang')
     patch('xlf_tpetra.patch', when='@12.12.1:%xl')
     patch('xlf_tpetra.patch', when='@12.12.1:%xl_r')
     patch('xlf_tpetra.patch', when='@12.12.1:%clang')

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -311,11 +311,11 @@ class Trilinos(CMakePackage):
     depends_on('swig', when='+python')
 
     patch('umfpack_from_suitesparse.patch', when='@11.14.1:12.8.1')
-    patch('xlf_seacas.patch', when='@12.10.1:%xl')
-    patch('xlf_seacas.patch', when='@12.10.1:%xl_r')
+    patch('xlf_seacas.patch', when='@12.10.1:12.12.1 %xl')
+    patch('xlf_seacas.patch', when='@12.10.1:12.12.1 %xl_r')
+    patch('xlf_seacas.patch', when='@12.12.1 %clang')
     patch('xlf_tpetra.patch', when='@12.12.1:%xl')
     patch('xlf_tpetra.patch', when='@12.12.1:%xl_r')
-    patch('xlf_seacas.patch', when='@12.12.1:%clang')
     patch('xlf_tpetra.patch', when='@12.12.1:%clang')
 
     def url_for_version(self, version):


### PR DESCRIPTION
@davydden @aprokop I noticed the latest Trilinos `develop` broke the `xlf_seacas.patch` patch so Trilinos fails completely for me when using Clang.