### PR TITLE
Fixed a typo in the name of the variables used to set-up modules

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -589,9 +589,9 @@ def print_setup_info(*info):
     if 'modules' in info:
         specs = spack.store.db.query('environment-modules')
         if specs:
-            shell_set('module_prefix', specs[-1].prefix)
+            shell_set('_sp_module_prefix', specs[-1].prefix)
         else:
-            shell_set('module_prefix', 'not_installed')
+            shell_set('_sp_module_prefix', 'not_installed')
 
 
 def main(argv=None):

--- a/lib/spack/spack/test/cmd/print_shell_vars.py
+++ b/lib/spack/spack/test/cmd/print_shell_vars.py
@@ -32,7 +32,7 @@ def test_print_shell_vars_sh(capsys):
     assert "_sp_sys_type=" in out
     assert "_sp_tcl_root=" in out
     assert "_sp_lmod_root=" in out
-    assert "module_prefix" not in out
+    assert "_sp_module_prefix" not in out
 
 
 def test_print_shell_vars_csh(capsys):
@@ -42,7 +42,7 @@ def test_print_shell_vars_csh(capsys):
     assert "set _sp_sys_type = " in out
     assert "set _sp_tcl_root = " in out
     assert "set _sp_lmod_root = " in out
-    assert "set module_prefix = " not in out
+    assert "set _sp_module_prefix = " not in out
 
 
 def test_print_shell_vars_sh_modules(capsys):
@@ -52,7 +52,7 @@ def test_print_shell_vars_sh_modules(capsys):
     assert "_sp_sys_type=" in out
     assert "_sp_tcl_root=" in out
     assert "_sp_lmod_root=" in out
-    assert "module_prefix=" in out
+    assert "_sp_module_prefix=" in out
 
 
 def test_print_shell_vars_csh_modules(capsys):
@@ -62,4 +62,4 @@ def test_print_shell_vars_csh_modules(capsys):
     assert "set _sp_sys_type = " in out
     assert "set _sp_tcl_root = " in out
     assert "set _sp_lmod_root = " in out
-    assert "set module_prefix = " in out
+    assert "set _sp_module_prefix = " in out


### PR DESCRIPTION
fixes #8724

Credits to @xpsair that in #8724 pointed out the issue.