### PR TITLE
Add spack to PATH before calling spack in setup-env.csh

### DIFF
--- a/share/spack/setup-env.csh
+++ b/share/spack/setup-env.csh
@@ -40,12 +40,12 @@ if ($?SPACK_ROOT) then
     alias _spack_pathadd 'set _pa_args = (\!*) && source $_spack_share_dir/csh/pathadd.csh'
 
     # Set variables needed by this script
+    _spack_pathadd PATH "$SPACK_ROOT/bin"
     eval `spack --print-shell-vars csh`
 
     # Set up modules and dotkit search paths in the user environment
     _spack_pathadd DK_NODE    "$_sp_dotkit_root/$_sp_sys_type"
     _spack_pathadd MODULEPATH "$_sp_tcl_root/$_sp_sys_type"
-    _spack_pathadd PATH       "$SPACK_ROOT/bin"
 else
     echo "ERROR: Sourcing spack setup-env.csh requires setting SPACK_ROOT to the root of your spack installation"
 endif


### PR DESCRIPTION
Fixes #8734.

It looks like this bug was inadvertently introduced in #8101. Another reason why #7604 would be useful.

@anderson2981 can you test this?