### PR TITLE
openmpi: add c++ exceptions cfg option variant

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -207,6 +207,7 @@ class Openmpi(AutotoolsPackage):
             description='Enable MPI_THREAD_MULTIPLE support')
     variant('cuda', default=False, description='Enable CUDA support')
     variant('pmi', default=False, description='Enable PMI support')
+    variant('cxx_exceptions', default=True, description='Enable C++ Exception support')
     # Adding support to build a debug version of OpenMPI that activates
     # Memchecker, as described here:
     #
@@ -434,6 +435,8 @@ class Openmpi(AutotoolsPackage):
             else:
                 config_args.append('--without-cuda')
 
+        if '+cxx_exceptions' in spec:
+                config_args.append('--enable-cxx-exceptions')
         return config_args
 
     @run_after('install')

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -436,7 +436,9 @@ class Openmpi(AutotoolsPackage):
                 config_args.append('--without-cuda')
 
         if '+cxx_exceptions' in spec:
-                config_args.append('--enable-cxx-exceptions')
+            config_args.append('--enable-cxx-exceptions')
+        else:
+            config_args.append('--disable-cxx-exceptions')
         return config_args
 
     @run_after('install')


### PR DESCRIPTION
This adds variant `cxx_exceptions`, to the openmpi package. When on, this passes `--enable-cxx-exceptions` as a config argument to openmpi. The variant defaults to `True`. 

This option avoids outright openmpi crashes when C++ MPI programs throw exceptions, and allows you to actually see c++ exception messages. 
 

