### PR TITLE
py-snuggs: Added depends_on py-parsing. The build uses setuptools, wh…

### DIFF
--- a/var/spack/repos/builtin/packages/py-snuggs/package.py
+++ b/var/spack/repos/builtin/packages/py-snuggs/package.py
@@ -35,3 +35,4 @@ class PySnuggs(PythonPackage):
 
     depends_on('py-numpy', type=('build', 'run'))
     depends_on('py-click', type=('build', 'run'))
+    depends_on('py-pyparsing', type=('build', 'run'))


### PR DESCRIPTION
…ich would otherwise silently try to install pyparsing itself, presumably into the python home dir (obviously not ideal).