### PR TITLE
py-pkgconfig: Made nose dependency type=build,test instead of just ty…

### DIFF
--- a/var/spack/repos/builtin/packages/py-pkgconfig/package.py
+++ b/var/spack/repos/builtin/packages/py-pkgconfig/package.py
@@ -38,4 +38,4 @@ class PyPkgconfig(PythonPackage):
 
     depends_on('pkgconfig', type=('build', 'run'))
 
-    depends_on('py-nose@1.0:', type='test')
+    depends_on('py-nose@1.0:', type=('build', 'test'))


### PR DESCRIPTION
…pe=test, to prevent setuptools from silently installing its own copy of nose