### PR TITLE
nwchem: add link type to python dep

### DIFF
--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -45,7 +45,7 @@ class Nwchem(Package):
     depends_on('mpi')
     depends_on('scalapack')
 
-    depends_on('python@2.7:2.8', type=('build', 'run'))
+    depends_on('python@2.7:2.8', type=('build', 'link', 'run'))
 
     # first hash is sha256 of the patch (required for URL patches),
     # second is sha256 for the archive.


### PR DESCRIPTION
without link type specified, I could not install nwchem.  I would get a linking error like so:

```
gfortran  -Wl,--export-dynamic  -L/opt/spack/var/spack/stage/nwchem-6.8-fdlc5rncsvahrf26hbuueahg6byx6nt5/nwchem-6.8-release/lib/LINUX64 -L/opt/spack/var/spack/stage/nwchem-6.8-fdlc5rncsvahrf26hbuueahg6byx6nt5/nw
chem-6.8-release/src/tools/install/lib   -o /opt/spack/var/spack/stage/nwchem-6.8-fdlc5rncsvahrf26hbuueahg6byx6nt5/nwchem-6.8-release/bin/LINUX64/nwchem nwchem.o stubs.o -lnwctask -lccsd -lmcscf -lselci -lmp2 -l
moints -lstepper -ldriver -loptim -lnwdft -lgradients -lcphf -lesp -lddscf -ldangchang -lguess -lhessian -lvib -lnwcutil -lrimp2 -lproperty -lsolvation -lnwints -lprepar -lnwmd -lnwpw -lofpw -lpaw -lpspw -lband 
-lnwpwlib -lcafe -lspace -lanalyze -lqhop -lpfft -ldplot -lnwpython -ldrdy -lvscf -lqmmm -lqmd -letrans -lpspw -ltce -lbq -lmm -lcons -lperfm -ldntmc -lccca -ldimqm -lnwcutil -lga -larmci -lpeigs -lperfm -lcons 
-lbq -lnwcutil  -L/opt/rit/spack-app/linux-rhel7-x86_64/gcc-4.8.5/netlib-scalapack-2.0.2-sakcdletgobmppuxysmgpnrwnoxutosl/lib -lscalapack  -l64to32 -L/opt/rit/spack-app/linux-rhel7-x86_64/gcc-4.8.5/openblas-0.2.
20-zp4k2ficko2rvgkkoce4ickfzpebkhp7/lib -lopenblas  -L/opt/rit/spack-app/linux-rhel7-x86_64/gcc-4.8.5/openblas-0.2.20-zp4k2ficko2rvgkkoce4ickfzpebkhp7/lib -lopenblas -L/opt/rit/spack-app/linux-rhel7-x86_64/gcc-4
.8.5/openblas-0.2.20-zp4k2ficko2rvgkkoce4ickfzpebkhp7/lib -lopenblas  -L/opt/rit/spack-app/linux-rhel7-x86_64/gcc-4.8.5/hwloc-1.11.9-gold4447lbyzvnxhxnbbzzo7zw6ijcof/lib -L/opt/rit/spack-app/linux-rhel7-x86_64/g
cc-4.8.5/openmpi-3.1.0-athyebf66bybb6al2kcplnkbx5mjtujd/lib -lmpi_usempi -lmpi_mpifh -lmpi     -lrt -lpthread -lm  -lpthread  -lnwcutil -lpython2.7 -lpthread -ldl -lutil -lm  -lpython2.7 -lpthread -ldl -lutil -l
m -Xlinker -export-dynamic
/usr/bin/ld: cannot find -lpython2.7
collect2: error: ld returned 1 exit status
make: *** [all] Error 1
==> Error: ProcessError: Command exited with status 2:
    'make' '-j24' 'NWCHEM_TOP=/opt/spack/var/spack/stage/nwchem-6.8-fdlc5rncsvahrf26hbuueahg6byx6nt5/nwchem-6.8-release' 'CC=gcc' 'FC=gfortran' 'USE_MPI=y' 'MPI_LOC=/opt/rit/spack-app/linux-rhel7-x86_64/gcc-4.8.
5/openmpi-3.1.0-athyebf66bybb6al2kcplnkbx5mjtujd' 'USE_PYTHONCONFIG=y' 'PYTHONVERSION=2.7' 'PYTHONHOME=/opt/rit/spack-app/linux-rhel7-x86_64/gcc-4.8.5/python-2.7.14-ljwrzcsrq75kt2lkm5k52mkvk3aiacip' 'BLASOPT=-L/
opt/rit/spack-app/linux-rhel7-x86_64/gcc-4.8.5/openblas-0.2.20-zp4k2ficko2rvgkkoce4ickfzpebkhp7/lib -lopenblas' 'BLAS_LIB=-L/opt/rit/spack-app/linux-rhel7-x86_64/gcc-4.8.5/openblas-0.2.20-zp4k2ficko2rvgkkoce4ick
fzpebkhp7/lib -lopenblas' 'LAPACK_LIB=-L/opt/rit/spack-app/linux-rhel7-x86_64/gcc-4.8.5/openblas-0.2.20-zp4k2ficko2rvgkkoce4ickfzpebkhp7/lib -lopenblas' 'USE_SCALAPACK=y' 'SCALAPACK=-L/opt/rit/spack-app/linux-rh
el7-x86_64/gcc-4.8.5/netlib-scalapack-2.0.2-sakcdletgobmppuxysmgpnrwnoxutosl/lib -lscalapack' 'NWCHEM_MODULES=all python' 'NWCHEM_LONG_PATHS=Y' 'USE_64TO32=y' 'BLAS_SIZE=4' 'LAPACK_SIZE=4' 'SCALAPACK_SIZE=4' 'NW
CHEM_TARGET=LINUX64'
```
This was on latest develop, with spack built python

Adding the link type fixed the error, and install succeeded