### PR TITLE
Configurable permissions on installed files

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -40,4 +40,6 @@ packages:
       szip: [libszip, libaec]
       tbb: [intel-tbb]
       unwind: [libunwind]
-
+    permissions:
+      read: world
+      write: user

--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -166,3 +166,32 @@ The syntax for the ``provider`` section differs slightly from other
 concretization rules.  A provider lists a value that packages may
 ``depend_on`` (e.g, mpi) and a list of rules for fulfilling that
 dependency.
+
+.. _package_permissions:
+
+-------------------
+Package Permissions
+-------------------
+
+Spack can be configured to assign file permissions to the files
+installed by a package.
+
+In the ``packages.yaml`` file, the attributes ``readable``,
+``writable``, and ``group`` control the package permissions. These
+attributes can be set under a package name or under ``all``.
+
+The ``readable`` and ``writable`` attributes take the strings
+``user``, ``group``, and ``world``. Those strings describe the
+broadest level of access available for reading or writing the files
+installed by that package, respectively. The execute permissions of
+the file are set to the same level as read permissions for those files
+that are executable. The default setting for ``readable`` is
+``world``, and for ``writable`` is ``user``.
+
+The ``group`` attribute assigns a unix-style group to a package. All
+files installed by the package will be owned by the assigned group,
+and the sticky group bit will be set on the install prefix and all
+directories inside the install prefix. This will ensure that even
+manually placed files within the install prefix are owned by the
+assigned group. If no group is assigned, Spack will allow the OS
+default behavior to go as expected.

--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -180,7 +180,7 @@ In the ``packages.yaml`` file under ``permissions``, the attributes
 ``read``, ``write``, and ``group`` control the package
 permissions. These attributes can be set per-package, or for all
 packages under ``all``. If permissions are set under ``all`` and for a
-specific package, the package settings take precedence.
+specific package, the package-specific settings take precedence.
 
 The ``read`` and ``write`` attributes take one of ``user``, ``group``,
 and ``world``.

--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -173,20 +173,40 @@ dependency.
 Package Permissions
 -------------------
 
-Spack can be configured to assign file permissions to the files
-installed by a package.
+Spack can be configured to assign permissions to the files installed
+by a package.
 
-In the ``packages.yaml`` file, the attributes ``readable``,
-``writable``, and ``group`` control the package permissions. These
-attributes can be set under a package name or under ``all``.
+In the ``packages.yaml`` file under ``permissions``, the attributes
+``read``, ``write``, and ``group`` control the package
+permissions. These attributes can be set per-package, or for all
+packages under ``all``. If permissions are set under ``all`` and for a
+specific package, the package settings take precedence.
 
-The ``readable`` and ``writable`` attributes take the strings
-``user``, ``group``, and ``world``. Those strings describe the
-broadest level of access available for reading or writing the files
-installed by that package, respectively. The execute permissions of
+The ``read`` and ``write`` attributes take one of ``user``, ``group``,
+and ``world``.
+
+.. code-block:: yaml
+
+  packages:
+    all:
+      permissions:
+        write: group
+        group: spack
+    my_app:
+      permissions:
+        read: group
+        group: my_team
+
+The permissions settings describe the broadest level of access to
+installations of the specified packages. The execute permissions of
 the file are set to the same level as read permissions for those files
-that are executable. The default setting for ``readable`` is
-``world``, and for ``writable`` is ``user``.
+that are executable. The default setting for ``read`` is ``world``,
+and for ``write`` is ``user``. In the example above, installations of
+``my_app`` will be installed with user and group permissions but no
+world permissions, and owned by the group ``my_team``. All other
+packages will be installed with user and group write privileges, and
+world read privileges. Those packages will be owned by the group
+``spack``.
 
 The ``group`` attribute assigns a unix-style group to a package. All
 files installed by the package will be owned by the assigned group,

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -242,6 +242,12 @@ def group_ids(uid=None):
     return [g.gr_gid for g in grp.getgrall() if user in g.gr_mem]
 
 
+def chgrp(path, group):
+    """Implement the bash chgrp function on a single path"""
+    gid = grp.getgrnam(group).gr_gid
+    os.chown(path, -1, gid)
+
+
 def chmod_X(entry, perms):
     """Implements the uppercase X version of the executable permissions as
     default for chmod.

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -413,12 +413,14 @@ def get_filetype(path_name):
     return output.strip()
 
 
-def mkdirp(*paths):
+def mkdirp(*paths, **kwargs):
     """Creates a directory, as well as parent directories if needed."""
+    mode = kwargs.get('mode', stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)
     for path in paths:
         if not os.path.exists(path):
             try:
-                os.makedirs(path)
+                os.makedirs(path, mode)
+                os.chmod(path, mode)  # For systems that ignore makedirs mode
             except OSError as e:
                 if e.errno != errno.EEXIST or not os.path.isdir(path):
                     raise e

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -249,14 +249,15 @@ def chgrp(path, group):
 
 
 def chmod_x(entry, perms):
-    """Implements the uppercase X version of the executable permissions as
-    default for chmod.
+    """Implements chmod, treating all executable bits as set using the chmod
+    utility's `+X` option.
     """
     mode = os.stat(entry).st_mode
-    if not mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH):
-        perms &= ~stat.S_IXUSR
-        perms &= ~stat.S_IXGRP
-        perms &= ~stat.S_IXOTH
+    if os.path.isfile(entry):
+        if not mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH):
+            perms &= ~stat.S_IXUSR
+            perms &= ~stat.S_IXGRP
+            perms &= ~stat.S_IXOTH
     os.chmod(entry, perms)
 
 

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -248,7 +248,7 @@ def chgrp(path, group):
     os.chown(path, -1, gid)
 
 
-def chmod_X(entry, perms):
+def chmod_x(entry, perms):
     """Implements the uppercase X version of the executable permissions as
     default for chmod.
     """

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -242,6 +242,18 @@ def group_ids(uid=None):
     return [g.gr_gid for g in grp.getgrall() if user in g.gr_mem]
 
 
+def chmod_X(entry, perms):
+    """Implements the uppercase X version of the executable permissions as
+    default for chmod.
+    """
+    mode = os.stat(entry).st_mode
+    if not mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH):
+        perms &= ~stat.S_IXUSR
+        perms &= ~stat.S_IXGRP
+        perms &= ~stat.S_IXOTH
+    os.chmod(entry, perms)
+
+
 def copy_mode(src, dest):
     """Set the mode of dest to that of src unless it is a link.
     """

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -265,9 +265,9 @@ class YamlDirectoryLayout(DirectoryLayout):
 
         # Create install directory with properly configured permissions
         # Cannot import at top of file
-        from spack.package_prefs import get_package_permissions_mask
-        mask = get_package_permissions_mask(spec)
-        mkdirp(self.metadata_path(spec), mode=mask)
+        from spack.package_prefs import get_package_permissions
+        perms = get_package_permissions(spec)
+        mkdirp(self.metadata_path(spec), mode=perms)
         self.write_spec(spec, self.spec_file_path(spec))
 
     def check_installed(self, spec):

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -36,7 +36,6 @@ import spack.config
 import spack.spec
 from spack.error import SpackError
 
-
 def _check_concrete(spec):
     """If the spec is not concrete, raise a ValueError"""
     if not spec.concrete:
@@ -263,7 +262,11 @@ class YamlDirectoryLayout(DirectoryLayout):
         if prefix:
             raise InstallDirectoryAlreadyExistsError(prefix)
 
-        mkdirp(self.metadata_path(spec))
+        # Create install directory with properly configured permissions
+        # Cannot import at top of file
+        from spack.package_prefs import get_package_permissions_mask
+        mask = get_package_permissions_mask(spec)
+        mkdirp(self.metadata_path(spec), mode=mask)
         self.write_spec(spec, self.spec_file_path(spec))
 
     def check_installed(self, spec):

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -36,6 +36,7 @@ import spack.config
 import spack.spec
 from spack.error import SpackError
 
+
 def _check_concrete(spec):
     """If the spec is not concrete, raise a ValueError"""
     if not spec.concrete:

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -30,7 +30,7 @@ import re
 
 import ruamel.yaml as yaml
 
-from llnl.util.filesystem import mkdirp
+from llnl.util.filesystem import mkdirp, chgrp
 
 import spack.config
 import spack.spec
@@ -265,8 +265,16 @@ class YamlDirectoryLayout(DirectoryLayout):
 
         # Create install directory with properly configured permissions
         # Cannot import at top of file
-        from spack.package_prefs import get_package_permissions
-        perms = get_package_permissions(spec)
+        from spack.package_prefs import get_package_dir_permissions
+        from spack.package_prefs import get_package_group
+        group = get_package_group(spec)
+        perms = get_package_dir_permissions(spec)
+        mkdirp(spec.prefix, mode=perms)
+        if group:
+            chgrp(spec.prefix, group)
+            # Need to reset the sticky group bit after chgrp
+            os.chmod(spec.prefix, perms)
+
         mkdirp(self.metadata_path(spec), mode=perms)
         self.write_spec(spec, self.spec_file_path(spec))
 

--- a/lib/spack/spack/hooks/permissions_setters.py
+++ b/lib/spack/spack/hooks/permissions_setters.py
@@ -43,11 +43,12 @@ def chmod_mask(entry, mask):
 
 
 def post_install(spec):
-    perms_mask = get_package_permissions_mask(spec)
-    group = get_package_group(spec)
-
-    forall_files(spec.prefix, chmod_mask, [perms_mask])
-
-    if group:
-        gid = grp.getgrnam(group).gr_gid
-        forall_files(spec.prefix, os.chown, [-1, gid])
+    if not spec.external:
+        perms_mask = get_package_permissions_mask(spec)
+        group = get_package_group(spec)
+        
+        forall_files(spec.prefix, chmod_mask, [perms_mask])
+        
+        if group:
+            gid = grp.getgrnam(group).gr_gid
+            forall_files(spec.prefix, os.chown, [-1, gid])

--- a/lib/spack/spack/hooks/permissions_setters.py
+++ b/lib/spack/spack/hooks/permissions_setters.py
@@ -1,0 +1,55 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+import stat
+import os
+import grp
+import spack
+from spack.package_prefs import get_package_permissions_mask, get_package_group
+
+
+def forall_files(path, fn, args):
+    for root, dirs, files in os.walk(path):  
+        for d in dirs:
+            fn(os.path.join(root, d), *args)
+        for f in files:
+            fn(os.path.join(root, f), *args)
+    fn(path, *args)
+
+
+def chmod_mask(entry, mask):
+    mode = os.stat(entry).st_mode
+    mode &= mask
+    os.chmod(entry, mode)
+
+
+def post_install(spec):
+    perms_mask = get_package_permissions_mask(spec)
+    group = get_package_group(spec)
+
+    forall_files(spec.prefix, chmod_mask, [perms_mask])
+
+    if group:
+        gid = grp.getgrnam(group).gr_gid
+        forall_files(spec.prefix, os.chown, [-1, gid])

--- a/lib/spack/spack/hooks/permissions_setters.py
+++ b/lib/spack/spack/hooks/permissions_setters.py
@@ -22,15 +22,13 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-import stat
 import os
 import grp
-import spack
 from spack.package_prefs import get_package_permissions_mask, get_package_group
 
 
 def forall_files(path, fn, args):
-    for root, dirs, files in os.walk(path):  
+    for root, dirs, files in os.walk(path):
         for d in dirs:
             fn(os.path.join(root, d), *args)
         for f in files:

--- a/lib/spack/spack/hooks/permissions_setters.py
+++ b/lib/spack/spack/hooks/permissions_setters.py
@@ -46,9 +46,9 @@ def post_install(spec):
     if not spec.external:
         perms_mask = get_package_permissions_mask(spec)
         group = get_package_group(spec)
-        
+
         forall_files(spec.prefix, chmod_mask, [perms_mask])
-        
+
         if group:
             gid = grp.getgrnam(group).gr_gid
             forall_files(spec.prefix, os.chown, [-1, gid])

--- a/lib/spack/spack/hooks/permissions_setters.py
+++ b/lib/spack/spack/hooks/permissions_setters.py
@@ -33,15 +33,17 @@ from spack.package_prefs import get_package_dir_permissions
 def forall_files(path, fn, args, dir_args=None):
     """Apply function to all files in directory, with file as first arg.
 
-    Does not apply to the root dir."""
+    Does not apply to the root dir. Does not apply to links"""
     for root, dirs, files in os.walk(path):
         for d in dirs:
-            if dir_args:
-                fn(os.path.join(root, d), *dir_args)
-            else:
-                fn(os.path.join(root, d), *args)
+            if not os.path.islink(os.path.join(root, d)):
+                if dir_args:
+                    fn(os.path.join(root, d), *dir_args)
+                else:
+                    fn(os.path.join(root, d), *args)
         for f in files:
-            fn(os.path.join(root, f), *args)
+            if not os.path.islink(os.path.join(root, d)):
+                fn(os.path.join(root, f), *args)
 
 
 def chmod_real_entries(path, perms):

--- a/lib/spack/spack/hooks/permissions_setters.py
+++ b/lib/spack/spack/hooks/permissions_setters.py
@@ -23,9 +23,8 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import os
-import grp
 
-from llnl.util.filesystem import chmod_X, chgrp
+from llnl.util.filesystem import chmod_x, chgrp
 
 from spack.package_prefs import get_package_permissions, get_package_group
 from spack.package_prefs import get_package_dir_permissions
@@ -48,7 +47,7 @@ def forall_files(path, fn, args, dir_args=None):
 def chmod_real_entries(path, perms):
     # Don't follow links so we don't change things outside the prefix
     if not os.path.islink(path):
-        chmod_X(path, perms)
+        chmod_x(path, perms)
 
 
 def post_install(spec):

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -66,7 +66,7 @@ import spack.util.web
 import spack.multimethod
 import spack.binary_distribution as binary_distribution
 
-from llnl.util.filesystem import mkdirp, touch
+from llnl.util.filesystem import mkdirp, touch, chgrp
 from llnl.util.filesystem import working_dir, install_tree, install
 from llnl.util.lang import memoized
 from llnl.util.link_tree import LinkTree
@@ -78,7 +78,7 @@ from spack.stage import Stage, ResourceStage, StageComposite
 from spack.util.environment import dump_environment
 from spack.util.package_hash import package_hash
 from spack.version import Version
-from spack.package_prefs import get_package_permissions
+from spack.package_prefs import get_package_dir_permissions
 
 """Allowed URL schemes for spack packages."""
 _ALLOWED_URL_SCHEMES = ["http", "https", "ftp", "file", "git"]
@@ -1529,9 +1529,15 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             if not os.path.exists(self.prefix):
                 spack.store.layout.create_install_directory(self.spec)
             else:
-                # Check for proper permissions
+                # Set the proper group for the prefix
+                group = get_package_group(self.spec)
+                if group:
+                    chgrp(self.prefix, group)
+                # Set the proper permissions.
+                # This has to be done after group because changing groups blows
+                # away the sticky group bit on the directory
                 mode = os.stat(self.prefix).st_mode
-                perms = get_package_permissions(self.spec)
+                perms = get_package_dir_permissions(self.spec)
                 if mode != perms:
                     os.chmod(self.prefix, perms)
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -78,7 +78,7 @@ from spack.stage import Stage, ResourceStage, StageComposite
 from spack.util.environment import dump_environment
 from spack.util.package_hash import package_hash
 from spack.version import Version
-from spack.package_prefs import get_package_dir_permissions
+from spack.package_prefs import get_package_dir_permissions, get_package_group
 
 """Allowed URL schemes for spack packages."""
 _ALLOWED_URL_SCHEMES = ["http", "https", "ftp", "file", "git"]

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -78,6 +78,7 @@ from spack.stage import Stage, ResourceStage, StageComposite
 from spack.util.environment import dump_environment
 from spack.util.package_hash import package_hash
 from spack.version import Version
+from spack.package_prefs import get_package_permissions_mask
 
 """Allowed URL schemes for spack packages."""
 _ALLOWED_URL_SCHEMES = ["http", "https", "ftp", "file", "git"]
@@ -1527,6 +1528,12 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             # Create the install prefix and fork the build process.
             if not os.path.exists(self.prefix):
                 spack.store.layout.create_install_directory(self.spec)
+            else:
+                # Check for proper permissions
+                mode = os.stat(self.prefix).st_mode
+                mask = get_package_permissions_mask(self.spec)
+                if mode & ~mask:
+                    os.chmod(self.prefix, mode & mask)
 
             # Fork a child to do the actual installation
             # we preserve verbosity settings across installs.

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -78,7 +78,7 @@ from spack.stage import Stage, ResourceStage, StageComposite
 from spack.util.environment import dump_environment
 from spack.util.package_hash import package_hash
 from spack.version import Version
-from spack.package_prefs import get_package_permissions_mask
+from spack.package_prefs import get_package_permissions
 
 """Allowed URL schemes for spack packages."""
 _ALLOWED_URL_SCHEMES = ["http", "https", "ftp", "file", "git"]
@@ -1531,9 +1531,9 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             else:
                 # Check for proper permissions
                 mode = os.stat(self.prefix).st_mode
-                mask = get_package_permissions_mask(self.spec)
-                if mode & ~mask:
-                    os.chmod(self.prefix, mode & mask)
+                perms = get_package_permissions(self.spec)
+                if mode != perms:
+                    os.chmod(self.prefix, perms)
 
             # Fork a child to do the actual installation
             # we preserve verbosity settings across installs.

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -300,14 +300,14 @@ def get_package_permissions(spec):
     if writable in ('world', 'group'):
         if readable == 'user':
             raise ConfigError('Writable permissions may not be more' +
-                             ' permissive than readable permissions.\n' +
-                             '      Violating package is %s' % spec.name)
+                              ' permissive than readable permissions.\n' +
+                              '      Violating package is %s' % spec.name)
         perms |= stat.S_IWGRP
     if writable == 'world':
         if readable != 'world':
             raise ConfigError('Writable permissions may not be more' +
-                             ' permissive than readable permissions.\n' +
-                             '      Violating package is %s' % spec.name)
+                              ' permissive than readable permissions.\n' +
+                              '      Violating package is %s' % spec.name)
         perms |= stat.S_IWOTH
 
     return perms

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -316,9 +316,9 @@ def get_package_permissions(spec):
 def get_package_group(spec):
     """Return the unix group associated with the spec"""
     allpkgs = get_packages_config()
-    if spec.name in allpkgs:
+    if spec.name in allpkgs and 'group' in allpkgs[spec.name]:
         return allpkgs[spec.name]['group']
-    elif 'all' in allpkgs:
+    elif 'all' in allpkgs and 'group' in allpkgs['all']:
         return allpkgs['all']['group']
     else:
         return ''

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -253,6 +253,17 @@ def is_spec_buildable(spec):
     return allpkgs[spec.name]['buildable']
 
 
+def get_package_dir_permissions(spec):
+    """Return the permissions configured for the spec.
+
+    Include the GID bit if group permissions are on. This makes the group
+    attribute sticky for the directory."""
+    perms = get_package_permissions(spec)
+    if perms & stat.S_IRWXG:
+        perms |= stat.S_ISGID
+    return perms
+
+
 def get_package_permissions(spec):
     """Return the permissions configured for the spec"""
     allpkgs = get_packages_config()

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -275,6 +275,7 @@ def get_package_permissions_mask(spec):
 
     return perm_mask
 
+
 def get_package_group(spec):
     """Return the unix group associated with the spec"""
     allpkgs = get_packages_config()
@@ -284,6 +285,7 @@ def get_package_group(spec):
         return allpkgs['all']['group']
     else:
         return ''
+
 
 class VirtualInPackagesYAMLError(spack.error.SpackError):
     """Raised when a disallowed virtual is found in packages.yaml"""

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -22,6 +22,7 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
+import stat
 from six import string_types
 from six import iteritems
 
@@ -251,6 +252,38 @@ def is_spec_buildable(spec):
         return True
     return allpkgs[spec.name]['buildable']
 
+
+def get_package_permissions_mask(spec):
+    """Return the permissions configured for the spec"""
+    allpkgs = get_packages_config()
+    if spec.name in allpkgs:
+        perms = allpkgs[spec.name]['permissions']
+    elif 'all' in allpkgs:
+        perms = allpkgs['all']['permissions']
+    else:
+        perms = 'ugo'
+
+    # rwx permissions set by build_system
+    # Only ugo granularity configurable
+    perm_mask = 0
+    if 'u' in perms:
+        perm_mask |= stat.S_IRWXU
+    if 'g' in perms:
+        perm_mask |= stat.S_IRWXG
+    if 'o' in perms:
+        perm_mask |= stat.S_IRWXO
+
+    return perm_mask
+
+def get_package_group(spec):
+    """Return the unix group associated with the spec"""
+    allpkgs = get_packages_config()
+    if spec.name in allpkgs:
+        return allpkgs[spec.name]['group']
+    elif 'all' in allpkgs:
+        return allpkgs['all']['group']
+    else:
+        return ''
 
 class VirtualInPackagesYAMLError(spack.error.SpackError):
     """Raised when a disallowed virtual is found in packages.yaml"""

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -257,7 +257,8 @@ def get_package_dir_permissions(spec):
     """Return the permissions configured for the spec.
 
     Include the GID bit if group permissions are on. This makes the group
-    attribute sticky for the directory."""
+    attribute sticky for the directory. Package-specific settings take
+    precedent over settings for ``all``"""
     perms = get_package_permissions(spec)
     if perms & stat.S_IRWXG:
         perms |= stat.S_ISGID
@@ -265,7 +266,9 @@ def get_package_dir_permissions(spec):
 
 
 def get_package_permissions(spec):
-    """Return the permissions configured for the spec"""
+    """Return the permissions configured for the spec.
+
+    Package-specific settings take precedence over settings for ``all``"""
 
     # Get read permissions level
     for name in (spec.name, 'all'):
@@ -310,7 +313,9 @@ def get_package_permissions(spec):
 
 
 def get_package_group(spec):
-    """Return the unix group associated with the spec"""
+    """Return the unix group associated with the spec.
+
+    Package-specific settings take precedence over settings for ``all``"""
     for name in (spec.name, 'all'):
         try:
             group = spack.config.get('packages:%s:permissions:group' % name,

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -274,7 +274,7 @@ def get_package_permissions(spec):
                                         '')
             if readable:
                 break
-        except:
+        except AttributeError:
             readable = 'world'
 
     # Get write permissions level
@@ -284,7 +284,7 @@ def get_package_permissions(spec):
                                         '')
             if writable:
                 break
-        except:
+        except AttributeError:
             writable = 'user'
 
     perms = stat.S_IRWXU
@@ -317,7 +317,7 @@ def get_package_group(spec):
                                      '')
             if group:
                 break
-        except:
+        except AttributeError:
             group = ''
     return group
 

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -59,9 +59,13 @@ schema = {
                             'type':  'boolean',
                             'default': True,
                         },
-                        'permissions': {
+                        'readable': {
                             'type':  'string',
-                            'default': 'ugo',
+                            'default': 'world',
+                        },
+                        'writable': {
+                            'type':  'string',
+                            'default': 'user',
                         },
                         'group': {
                             'type':  'string',

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -61,15 +61,12 @@ schema = {
                         },
                         'readable': {
                             'type':  'string',
-                            'default': 'world',
                         },
                         'writable': {
                             'type':  'string',
-                            'default': 'user',
                         },
                         'group': {
                             'type':  'string',
-                            'default': '',
                         },
                         'modules': {
                             'type': 'object',

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -59,6 +59,14 @@ schema = {
                             'type':  'boolean',
                             'default': True,
                         },
+                        'permissions': {
+                            'type':  'string',
+                            'default': 'ugo',
+                        },
+                        'group': {
+                            'type':  'string',
+                            'default': '',
+                        },
                         'modules': {
                             'type': 'object',
                             'default': {},

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -59,14 +59,22 @@ schema = {
                             'type':  'boolean',
                             'default': True,
                         },
-                        'readable': {
-                            'type':  'string',
-                        },
-                        'writable': {
-                            'type':  'string',
-                        },
-                        'group': {
-                            'type':  'string',
+                        'permissions': {
+                            'type': 'object',
+                            'additionalProperties': False,
+                            'properties': {
+                                'read': {
+                                    'type':  'string',
+                                    'enum': ['user', 'group', 'world'],
+                                },
+                                'write': {
+                                    'type':  'string',
+                                    'enum': ['user', 'group', 'world'],
+                                },
+                                'group': {
+                                    'type':  'string',
+                                },
+                            },
                         },
                         'modules': {
                             'type': 'object',

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import os
+import stat
 import sys
 import errno
 import hashlib

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -488,11 +488,13 @@ class Stage(object):
         if self._need_to_create_path():
             tmp_root = get_tmp_root()
             if tmp_root is not None:
+                # tempfile.mkdtemp already sets mode 0700
                 tmp_dir = tempfile.mkdtemp('', _stage_prefix, tmp_root)
                 tty.debug('link %s -> %s' % (self.path, tmp_dir))
                 os.symlink(tmp_dir, self.path)
             else:
-                mkdirp(self.path)
+                # emulate file permissions for tempfile.mkdtemp
+                mkdirp(self.path, mode=stat.S_IRWXU)
         # Make sure we can actually do something with the stage we made.
         ensure_access(self.path)
         self.created = True

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -23,11 +23,12 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import pytest
+import stat
 
 import spack.package_prefs
 import spack.repo
 import spack.util.spack_yaml as syaml
-from spack.config import ConfigScope
+from spack.config import ConfigScope, ConfigError
 from spack.spec import Spec
 
 
@@ -174,3 +175,69 @@ mpich:
         spec = Spec('mpi')
         spec.concretize()
         assert spec['mpich'].external_path == '/dummy/path'
+
+    def test_config_permissions(self):
+        # Although these aren't strictly about concretization, they are
+        # configured in the same file and therefore convenient to test here.
+        # Make sure we can configure readable and writable
+        conf = syaml.load("""\
+all:
+    readable: group
+    writable: group
+    group: all
+mpich:
+    readable: user
+    writable: user
+mpileaks:
+    writable: user
+    group: mpileaks
+callpath:
+    writable: world
+zlib:
+    readable: test
+""")
+        spack.config.set('packages', conf, scope='concretize')
+
+        # Test inheriting from 'all'
+        spec = Spec('zmpi')
+        perms = spack.package_prefs.get_package_permissions(spec)
+        assert perms == stat.S_IRWXU | stat.S_IRWXG
+
+        dir_perms = spack.package_prefs.get_package_dir_permissions(spec)
+        assert dir_perms == stat.S_IRWXU | stat.S_IRWXG | stat.S_ISGID
+
+        group = spack.package_prefs.get_package_group(spec)
+        assert group == 'all'
+
+        # Test overriding 'all'
+        spec = Spec('mpich')
+        perms = spack.package_prefs.get_package_permissions(spec)
+        assert perms == stat.S_IRWXU
+
+        dir_perms = spack.package_prefs.get_package_dir_permissions(spec)
+        assert dir_perms == stat.S_IRWXU
+
+        group = spack.package_prefs.get_package_group(spec)
+        assert group == 'all'
+
+        # Test overriding group from 'all' and different readable/writable
+        spec = Spec('mpileaks')
+        perms = spack.package_prefs.get_package_permissions(spec)
+        assert perms == stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP
+
+        dir_perms = spack.package_prefs.get_package_dir_permissions(spec)
+        expected = stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_ISGID
+        assert dir_perms == expected
+
+        group = spack.package_prefs.get_package_group(spec)
+        assert group == 'mpileaks'
+
+        # Test failure for writable more permissive than readable
+        spec = Spec('callpath')
+        with pytest.raises(ConfigError):
+            spack.package_prefs.get_package_permissions(spec)
+
+        # Test failure for readable/writable not in (user, group, world)
+        spec = Spec('zlib')
+        with pytest.raises(ConfigError):
+            spack.package_prefs.get_package_permissions(spec)


### PR DESCRIPTION
Added three entries to the packages.yaml schema:

`readable`: Takes a string `user`, `group`, or `world`. This describes the highest level of read permissions for the install directory.

`writable`: Takes a string `user`, `group`, or `world`. This describes the highest level of write permissions for the install directory. Note that having `writable` more permissive than `readable` is an error

`group`: All files in the prefix will be owned by this group.

This allows users to configure user/group/other granularity permissions to their installed packages. It does not allow configuration of executable permissions, as those are handled by the build system appropriately for each file. Executable permissions for files that the build system sets as executable are set to the level of `readable`.

The sticky group bit (gid bit) is set on all directories in the install prefix (but not on files, as it doubles as the setgid bit for files).

TODO: 
- [x] Write unit tests