### PR TITLE
bugfix: stage test no longer modifies ~/.spack/config.yaml

### DIFF
--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -111,7 +111,7 @@ def get_stage_path(stage, stage_name):
 
 
 @pytest.fixture()
-def tmpdir_for_stage(mock_archive):
+def tmpdir_for_stage(mock_archive, mutable_config):
     """Uses a temporary directory for staging"""
     current = spack.paths.stage_path
     spack.config.set(
@@ -123,7 +123,7 @@ def tmpdir_for_stage(mock_archive):
 
 
 @pytest.fixture()
-def mock_archive(tmpdir, monkeypatch):
+def mock_archive(tmpdir, monkeypatch, mutable_config):
     """Creates a mock archive with the structure expected by the tests"""
     # Mock up a stage area that looks like this:
     #


### PR DESCRIPTION
I kept seeing things like this in my `~/.spack/config.yaml`:

```cosole
$ cat config.yaml 
config:
  build_stage:
  - /private/var/folders/0s/q_y0zhfj6xdd5n7rn780zz6h001qr7/T/pytest-of-gamblin2/pytest-842/test_keep_exceptions0/tmp
```

Turns out two tests were modifying the *actual* config rather than a temporary test config.  This fixes the fixtures so that doesn't happen.

- [x] two stage tests weren't properly using the mutable_config fixture.
- [x] this caused running `spack test` to modify the user's config.yaml