### PR TITLE
add necessary dependence on lapack, and fix ld_flags for blas

### DIFF
--- a/var/spack/repos/builtin/packages/moab/package.py
+++ b/var/spack/repos/builtin/packages/moab/package.py
@@ -80,6 +80,7 @@ class Moab(AutotoolsPackage):
     # depends_on('vtk', when='+vtk')
 
     depends_on('blas')
+    depends_on('lapack')
     depends_on('mpi', when='+mpi')
     depends_on('hdf5', when='+hdf5')
     depends_on('hdf5+mpi', when='+hdf5+mpi')
@@ -124,7 +125,8 @@ class Moab(AutotoolsPackage):
 #       else:
 #           options.append('--without-mpi')
 
-        options.append('--with-blas=%s' % spec['blas'].libs)
+        options.append('--with-blas=%s' % spec['blas'].libs.ld_flags)
+        options.append('--with-lapack=%s' % spec['lapack'].libs.ld_flags)
 
         if '+hdf5' in spec:
             options.append('--with-hdf5=%s' % spec['hdf5'].prefix)


### PR DESCRIPTION
Dependence on Lapack is necessary for MoAB. MoAB installation had been working because the specific implementation of Blas, i.e. OpenBlas provided Lapacak. However virtual package Lapack and Blas could have a separate implementation, and for such case MoAB install would not work.

Moreover, PR fixes flags for Blas. The previous fix will not work on the same platforms, and MoAB install will throw linking errors for blas and lapack functions.