### PR TITLE
Test Spack on Python 3.7 as part of Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,13 @@ branches:
 #=============================================================================
 # Build matrix
 #=============================================================================
+
+# Adding the keyword dist to permit an `allow_failures` section
+# under `matrix.include`. More information here:
+#
+# https://docs.travis-ci.com/user/customizing-the-build/#Rows-that-are-Allowed-to-Fail
+dist: trusty
+
 jobs:
   fast_finish: true
   include:
@@ -46,6 +53,8 @@ jobs:
       env: [ TEST_SUITE=unit, COVERAGE=true ]
     - python: '3.7'
       os: linux
+      dist: xenial
+      sudo: true
       language: python
       env: [ TEST_SUITE=unit, COVERAGE=true ]
     - python: '3.6'
@@ -93,10 +102,12 @@ jobs:
       language: python
       env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=r-rcpp' ]
 # mpich (AutotoolsPackage)
-    - python: '3.7'
+    - python: '3.6'
       os: linux
       language: python
       env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=mpich' ]
+  allow_failures:
+    - dist: xenial
 
 stages:
   - 'style checks'

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,10 @@ jobs:
       os: linux
       language: python
       env: [ TEST_SUITE=unit, COVERAGE=true ]
+    - python: '3.7'
+      os: linux
+      language: python
+      env: [ TEST_SUITE=unit, COVERAGE=true ]
     - python: '3.6'
       os: linux
       language: python
@@ -89,7 +93,7 @@ jobs:
       language: python
       env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=r-rcpp' ]
 # mpich (AutotoolsPackage)
-    - python: '3.6'
+    - python: '3.7'
       os: linux
       language: python
       env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=mpich' ]


### PR DESCRIPTION
Python 3.7 was released on June 27, 2018. More information [here](https://docs.python.org/3/whatsnew/3.7.html).