### PR TITLE
core: make `spack.util.crypto` initialization less complicated

### DIFF
--- a/lib/spack/spack/test/url_fetch.py
+++ b/lib/spack/spack/test/url_fetch.py
@@ -52,7 +52,7 @@ def test_fetch(
     mock_archive.url
     mock_archive.path
 
-    algo = crypto.hashes[checksum_type]()
+    algo = crypto.hash_fun_for_algo(checksum_type)()
     with open(mock_archive.archive_file, 'rb') as f:
         algo.update(f.read())
     checksum = algo.hexdigest()
@@ -96,7 +96,7 @@ def test_from_list_url(mock_packages, config):
 
 
 def test_hash_detection(checksum_type):
-    algo = crypto.hashes[checksum_type]()
+    algo = crypto.hash_fun_for_algo(checksum_type)()
     h = 'f' * (algo.digest_size * 2)  # hex -> bytes
     checker = crypto.Checker(h)
     assert checker.hash_name == checksum_type


### PR DESCRIPTION
I did this as part of other PRs but it turned out not to be necessary.  It's still useful, so here's a separate PR.

- [x] hard-code the hash lengths rather than computing them on import.
- [x] clean up the code in `spack.util.crypto` to make it easier to understand.