### PR TITLE
Fix pkg-config dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/fluxbox/package.py
+++ b/var/spack/repos/builtin/packages/fluxbox/package.py
@@ -38,7 +38,7 @@ class Fluxbox(AutotoolsPackage):
 
     version('1.3.7', 'd99d7710f9daf793e0246dae5304b595')
 
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('freetype')
     depends_on('libxrender')
     depends_on('libxext')

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -93,7 +93,7 @@ class Gdal(AutotoolsPackage):
     # GDAL depends on GNUmake on Unix platforms.
     # https://trac.osgeo.org/gdal/wiki/BuildingOnUnix
     depends_on('gmake', type='build')
-    depends_on('pkg-config@0.25:', type='build')
+    depends_on('pkgconfig', type='build')
 
     # Required dependencies
     depends_on('libtiff@3.6.0:')  # 3.9.0+ needed to pass testsuite

--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -133,7 +133,7 @@ class Graphviz(AutotoolsPackage):
     depends_on('gtkplus', when='+gtkplus')
 
     # Build dependencies
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')
     # The following are needed when building from git
     depends_on('automake', type='build')
     depends_on('autoconf', type='build')

--- a/var/spack/repos/builtin/packages/i3/package.py
+++ b/var/spack/repos/builtin/packages/i3/package.py
@@ -36,11 +36,11 @@ class I3(AutotoolsPackage):
 
     version('4.14.1', 'bdbb6d7bb5a647c8b7b53ed10de84cc5')
 
-    depends_on('autoconf', type='build')
-    depends_on('automake', type='build')
-    depends_on('libtool',  type='build')
-    depends_on('m4',       type='build')
-    depends_on('pkg-config', type='build')
+    depends_on('autoconf',  type='build')
+    depends_on('automake',  type='build')
+    depends_on('libtool',   type='build')
+    depends_on('m4',        type='build')
+    depends_on('pkgconfig', type='build')
 
     depends_on('libev')
     depends_on('startup-notification')

--- a/var/spack/repos/builtin/packages/mc/package.py
+++ b/var/spack/repos/builtin/packages/mc/package.py
@@ -34,7 +34,7 @@ class Mc(AutotoolsPackage):
     version('4.8.20', 'dcfc7aa613c62291a0f71f6b698d8267')
 
     depends_on('ncurses')
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('glib@2.14:')
     depends_on('libssh2@1.2.5:')
 

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -59,7 +59,7 @@ class Neuron(Package):
     depends_on('automake',   type='build')
     depends_on('autoconf',   type='build')
     depends_on('libtool',    type='build')
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig',  type='build')
 
     depends_on('mpi',         when='+mpi')
     depends_on('python@2.6:', when='+python')
@@ -87,7 +87,7 @@ class Neuron(Package):
 
     def patch(self):
         # aclocal need complete include path (especially on os x)
-        pkgconf_inc = '-I %s/share/aclocal/' % (self.spec['pkg-config'].prefix)
+        pkgconf_inc = '-I %s/share/aclocal/' % (self.spec['pkgconfig'].prefix)
         libtool_inc = '-I %s/share/aclocal/' % (self.spec['libtool'].prefix)
         newpath = 'aclocal -I m4 %s %s' % (pkgconf_inc, libtool_inc)
         filter_file(r'aclocal -I m4', r'%s' % newpath, "build.sh")

--- a/var/spack/repos/builtin/packages/pandaseq/package.py
+++ b/var/spack/repos/builtin/packages/pandaseq/package.py
@@ -41,7 +41,7 @@ class Pandaseq(AutotoolsPackage):
     depends_on('libtool',     type=('build', 'link'))
     depends_on('m4',          type='build')
     depends_on('zlib',        type='build')
-    depends_on('pkg-config',  type='build')
+    depends_on('pkgconfig',   type='build')
     depends_on('bzip2',       type='link')
 
     def autoreconf(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/perl-extutils-pkgconfig/package.py
+++ b/var/spack/repos/builtin/packages/perl-extutils-pkgconfig/package.py
@@ -33,4 +33,4 @@ class PerlExtutilsPkgconfig(PerlPackage):
 
     version('1.16', 'b86318f2b6ac6af3ee985299e1e38fe5')
 
-    depends_on('pkg-config', type=('build', 'run'))
+    depends_on('pkgconfig', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/wireshark/package.py
+++ b/var/spack/repos/builtin/packages/wireshark/package.py
@@ -55,7 +55,7 @@ class Wireshark(CMakePackage):
     depends_on('libpcap')
     depends_on('lua@5.0.0:5.2.99')
     depends_on('krb5')
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('libsmi',    when='+smi')
     depends_on('libssh',    when='+libssh')
     depends_on('nghttp2',   when='+nghttp2')


### PR DESCRIPTION
pkgconfig is the correct virtual provider. This fixes strange problems during concretization when both pkg-config and pkgconf are requested.

To be precise, I have the following `packages.yaml`:
```yaml
packages:
  ncl:
    variants: +gdal
```

This causes the following error during concretization for ncl (see #4119):
```console
$ spack spec ncl
Input spec
--------------------------------
ncl

Concretized
--------------------------------
==> Error: There are no valid versions for spectrum-mpi that match ':'
```

Trying to force mvapich2 results in the following error:
```console
$ spack spec -I ncl ^mvapich2
Input spec
--------------------------------
     ncl
         ^mvapich2

Concretized
--------------------------------
==> Error: Multiple providers found for 'pkgconfig': ['pkg-config@0.29.2%gcc@7.3.0+internal_glib arch=linux-ubuntu16.04-x86_64', 'pkgconf@1.4.2%gcc@7.3.0 arch=linux-ubuntu16.04-x86_64']
```

`spack spec ncl+gdal` works correctly, however.

I am sure there is some underlying issue but this tapes over the problem for now.