### PR TITLE
bugfix: fix spack spec --yaml

### DIFF
--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -558,6 +558,12 @@ class Singleton(object):
     def __getitem__(self, name):
         return self.instance[name]
 
+    def __contains__(self, element):
+        return element in self.instance
+
+    def __iter__(self):
+        return iter(self.instance)
+
     def __str__(self):
         return str(self.instance)
 

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -69,7 +69,7 @@ def spec(parser, args):
     for spec in spack.cmd.parse_specs(args.specs):
         # With -y, just print YAML to output.
         if args.yaml:
-            if spec.name in spack.repo or spec.virtual:
+            if spec.name in spack.repo.path or spec.virtual:
                 spec.concretize()
             print(spec.to_yaml())
             continue

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -1,0 +1,51 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+import spack.spec
+from spack.main import SpackCommand
+
+spec = SpackCommand('spec')
+
+
+def test_spec(mock_packages, config):
+    output = spec('mpileaks')
+
+    assert 'mpileaks@2.3' in output
+    assert 'callpath@1.0' in output
+    assert 'dyninst@8.2' in output
+    assert 'libdwarf@20130729' in output
+    assert 'libelf@0.8.1' in output
+    assert 'mpich@3.0.4' in output
+
+
+def test_spec_yaml(mock_packages, config):
+    output = spec('--yaml', 'mpileaks')
+
+    mpileaks = spack.spec.Spec.from_yaml(output)
+    assert 'mpileaks' in mpileaks
+    assert 'callpath' in mpileaks
+    assert 'dyninst' in mpileaks
+    assert 'libdwarf' in mpileaks
+    assert 'libelf' in mpileaks
+    assert 'mpich' in mpileaks


### PR DESCRIPTION
Fixes #8790.

- repo membership test was broken by the refactor of spack/__init__.py
- refactor singleton so that 'spec in repo' works again for `spack.repo.path`
- fix spec command and add basic tests for `spack spec` and `spack spec --yaml`