### PR TITLE
bugfix: `spack module -m` error message is correct with no `-m`

### DIFF
--- a/lib/spack/spack/cmd/module.py
+++ b/lib/spack/spack/cmd/module.py
@@ -62,14 +62,13 @@ def handle_deprecated_command(args, unknown_args):
     command = args.module_command
     unknown = ' '.join(unknown_args)
 
-    module_types = args.module_type or 'tcl'
+    module_types = args.module_type or ['tcl']
 
-    msg = '`spack module {0} {1} ...` has been moved. Try this instead:\n'
+    msg = '`spack module {0} {1}` has moved. Use these commands instead:\n'
     msg = msg.format(command, ' '.join('-m ' + x for x in module_types))
     for x in module_types:
         msg += '\n\t$ spack module {0} {1} {2}'.format(x, command, unknown)
     msg += '\n'
-
     tty.die(msg)
 
 


### PR DESCRIPTION
Fix this output error:

```
$ spack -m module loads mpileaks
==> Error: `spack module loads -m t -m c -m l ...` has been moved. Try this instead:

    $ spack module t loads mpileaks
    $ spack module c loads mpileaks
    $ spack module l loads mpileaks
```