### PR TITLE
Change qtgraph and cbtf-argonavis to create proper module file library paths

### DIFF
--- a/var/spack/repos/builtin/packages/cbtf-argonavis-gui/package.py
+++ b/var/spack/repos/builtin/packages/cbtf-argonavis-gui/package.py
@@ -41,6 +41,7 @@
 ##########################################################################
 
 from spack import *
+import os
 
 
 class CbtfArgonavisGui(QMakePackage):
@@ -110,10 +111,17 @@ class CbtfArgonavisGui(QMakePackage):
 
         # The implementor of qtgraph has set up the library and include
         # paths in a non-conventional way.  We reflect that here.
+        # What library suffix should be used based on library existence
+        if os.path.isdir(self.spec['qtgraph'].prefix.lib64):
+            qtgraph_lib_dir = self.spec['qtgraph'].prefix.lib64
+        else:
+            qtgraph_lib_dir = self.spec['qtgraph'].prefix.lib
+
         run_env.prepend_path(
             'LD_LIBRARY_PATH', join_path(
-                self.spec['qtgraph'].prefix.lib64,
+                qtgraph_lib_dir,
                 '{0}'.format(self.spec['qt'].version.up_to(3))))
+
         # The openspeedshop libraries are needed to actually load the
         # performance information into the GUI.
         run_env.prepend_path(

--- a/var/spack/repos/builtin/packages/qtgraph/package.py
+++ b/var/spack/repos/builtin/packages/qtgraph/package.py
@@ -70,22 +70,17 @@ class Qtgraph(QMakePackage):
         spack_env.set('GRAPHVIZ_ROOT', self.spec['graphviz'].prefix)
         spack_env.set('INSTALL_ROOT', self.prefix)
 
-        # NOTE: Spack runs setup_environment twice, once pre-build to set up
-        # the build environment, and once post-installation to determine
-        # the environment variables needed at run-time to add to the module
-        # file. The script we need to source is only present post-installation,
-        # so check for its existence before sourcing.
-        # TODO: At some point we should split setup_environment into
-        # setup_build_environment and setup_run_environment to get around
-        # this problem.
+        # What library suffix should be used based on library existence
+        if os.path.isdir(self.prefix.lib64):
+            lib_dir = self.prefix.lib64
+        else:
+            lib_dir = self.prefix.lib
 
         # The implementor has set up the library and include paths in
         # a non-conventional way.  We reflect that here.
-        qtgraphlibs = join_path(
-            self.spec['qtgraph'].libs,
-            '{0}'.format(self.spec['qt'].version.up_to(3)))
+        run_env.prepend_path(
+            'LD_LIBRARY_PATH', join_path(
+                lib_dir,
+                '{0}'.format(self.spec['qt'].version.up_to(3))))
 
-        if os.path.isfile(qtgraphlibs):
-            run_env.prepend_path(
-                'LD_LIBRARY_PATH', qtgraphlibs)
-            run_env.prepend_path('CPATH', self.prefix.include.QtGraph)
+        run_env.prepend_path('CPATH', self.prefix.include.QtGraph)


### PR DESCRIPTION
Fix bug where we only supported lib64 when we needed to look at lib on some platforms and lib64 on others.  Found when trying to build on Power systems.