### PR TITLE
Fix order of regexes reported by spack url summary

### DIFF
--- a/lib/spack/spack/cmd/url.py
+++ b/lib/spack/spack/cmd/url.py
@@ -227,7 +227,7 @@ def url_summary(args):
 
     print()
     print('    Index  Count  Regular Expression')
-    for ni in name_regex_dict:
+    for ni in sorted(name_regex_dict.keys()):
         print('    {0:>3}: {1:>6}   r{2!r}'.format(
             ni, name_count_dict[ni], name_regex_dict[ni]))
     print()
@@ -236,7 +236,7 @@ def url_summary(args):
 
     print()
     print('    Index  Count  Regular Expression')
-    for vi in version_regex_dict:
+    for vi in sorted(version_regex_dict.keys()):
         print('    {0:>3}: {1:>6}   r{2!r}'.format(
             vi, version_count_dict[vi], version_regex_dict[vi]))
     print()


### PR DESCRIPTION
Because dictionaries aren't sorted in Python 3.

### Before
```console
$ spack url summary
==> Generating a summary of URL parsing in Spack...

    Total URLs found:          2907
    Names correctly parsed:    2522/2907 (86.76%)
    Versions correctly parsed: 2462/2907 (84.69%)

==> Statistics on name regular expressions:

    Index  Count  Regular Expression
      8:   1827   r'^([A-Za-z\\d+\\._-]+)$'
      0:    669   r'github\\.com/[^/]+/([^/]+)'
      3:     28   r'bitbucket\\.org/[^/]+/([^/]+)'
      4:    365   r'pypi\\.(?:python\\.org|io)/packages/source/[A-Za-z\\d]/([^/]+)'
      1:      9   r'gitlab[^/]+/api/v4/projects/[^/]+%2F([^/]+)'
      6:      5   r'\\?package=([A-Za-z\\d+-]+)'
      2:      1   r'gitlab[^/]+/(?!api/v4/projects)[^/]+/([^/]+)'

==> Statistics on version regular expressions:

    Index  Count  Regular Expression
      0:   1883   r'^[a-zA-Z+._-]+[._-]v?(\\d[\\d._-]*)$'
      1:    385   r'^v?(\\d[\\d._-]*)$'
     16:      3   r'^[a-zA-Z+-]+(\\d[\\da-zA-Z._]*)$'
      6:    140   r'^[a-zA-Z\\d+-]+-v?(\\d[\\da-zA-Z.]*)$'
      2:     38   r'^[a-zA-Z+]*(\\d[\\da-zA-Z]*)$'
      5:     46   r'^[a-zA-Z+.]*(\\d[\\da-zA-Z.]*)$'
      3:     11   r'^[a-zA-Z+-]*(\\d[\\da-zA-Z-]*)$'
     10:     25   r'^(?:[a-zA-Z\\d+-]+-)?v?(\\d[\\da-zA-Z.-]*)$'
      8:     19   r'^[a-zA-Z\\d+_]+_v?(\\d[\\da-zA-Z.]*)$'
     19:      8   r'\\?sha=[a-zA-Z+._-]*v?(\\d[\\da-zA-Z._-]*)$'
     14:      1   r'^[a-zA-Z\\d+-]+-v?(\\d[\\da-zA-Z._]*)$'
     11:      3   r'^[a-zA-Z+]+v?(\\d[\\da-zA-Z.-]*)$'
      7:      1   r'^[a-zA-Z\\d+-]+-v?(\\d[\\da-zA-Z_]*)$'
      4:     37   r'^[a-zA-Z+_]*(\\d[\\da-zA-Z_]*)$'
      9:      1   r'^[a-zA-Z\\d+_]+\\.v?(\\d[\\da-zA-Z.]*)$'
     17:      1   r'bzr(\\d[\\da-zA-Z._-]*)$'
     18:      2   r'github\\.com/[^/]+/[^/]+/releases/download/[a-zA-Z+._-]*v?(\\d[\\da-zA-Z._-]*)/'
     13:     12   r'^[a-zA-Z\\d+.]+_v?(\\d[\\da-zA-Z.-]*)$'
     23:      2   r'\\?package=[a-zA-Z\\d+-]+&get=[a-zA-Z\\d+-]+-v?(\\d[\\da-zA-Z.]*)$'
     20:      1   r'\\?ref=[a-zA-Z+._-]*v?(\\d[\\da-zA-Z._-]*)$'
     12:      3   r'^[a-zA-Z\\d+_]+-v?(\\d[\\da-zA-Z.]*)$'
```

### After
```console
$ spack url summary
==> Generating a summary of URL parsing in Spack...

    Total URLs found:          2907
    Names correctly parsed:    2522/2907 (86.76%)
    Versions correctly parsed: 2462/2907 (84.69%)

==> Statistics on name regular expressions:

    Index  Count  Regular Expression
      0:    669   r'github\\.com/[^/]+/([^/]+)'
      1:      9   r'gitlab[^/]+/api/v4/projects/[^/]+%2F([^/]+)'
      2:      1   r'gitlab[^/]+/(?!api/v4/projects)[^/]+/([^/]+)'
      3:     28   r'bitbucket\\.org/[^/]+/([^/]+)'
      4:    365   r'pypi\\.(?:python\\.org|io)/packages/source/[A-Za-z\\d]/([^/]+)'
      6:      5   r'\\?package=([A-Za-z\\d+-]+)'
      8:   1827   r'^([A-Za-z\\d+\\._-]+)$'

==> Statistics on version regular expressions:

    Index  Count  Regular Expression
      0:   1883   r'^[a-zA-Z+._-]+[._-]v?(\\d[\\d._-]*)$'
      1:    385   r'^v?(\\d[\\d._-]*)$'
      2:     38   r'^[a-zA-Z+]*(\\d[\\da-zA-Z]*)$'
      3:     11   r'^[a-zA-Z+-]*(\\d[\\da-zA-Z-]*)$'
      4:     37   r'^[a-zA-Z+_]*(\\d[\\da-zA-Z_]*)$'
      5:     46   r'^[a-zA-Z+.]*(\\d[\\da-zA-Z.]*)$'
      6:    140   r'^[a-zA-Z\\d+-]+-v?(\\d[\\da-zA-Z.]*)$'
      7:      1   r'^[a-zA-Z\\d+-]+-v?(\\d[\\da-zA-Z_]*)$'
      8:     19   r'^[a-zA-Z\\d+_]+_v?(\\d[\\da-zA-Z.]*)$'
      9:      1   r'^[a-zA-Z\\d+_]+\\.v?(\\d[\\da-zA-Z.]*)$'
     10:     25   r'^(?:[a-zA-Z\\d+-]+-)?v?(\\d[\\da-zA-Z.-]*)$'
     11:      3   r'^[a-zA-Z+]+v?(\\d[\\da-zA-Z.-]*)$'
     12:      3   r'^[a-zA-Z\\d+_]+-v?(\\d[\\da-zA-Z.]*)$'
     13:     12   r'^[a-zA-Z\\d+.]+_v?(\\d[\\da-zA-Z.-]*)$'
     14:      1   r'^[a-zA-Z\\d+-]+-v?(\\d[\\da-zA-Z._]*)$'
     16:      3   r'^[a-zA-Z+-]+(\\d[\\da-zA-Z._]*)$'
     17:      1   r'bzr(\\d[\\da-zA-Z._-]*)$'
     18:      2   r'github\\.com/[^/]+/[^/]+/releases/download/[a-zA-Z+._-]*v?(\\d[\\da-zA-Z._-]*)/'
     19:      8   r'\\?sha=[a-zA-Z+._-]*v?(\\d[\\da-zA-Z._-]*)$'
     20:      1   r'\\?ref=[a-zA-Z+._-]*v?(\\d[\\da-zA-Z._-]*)$'
     23:      2   r'\\?package=[a-zA-Z\\d+-]+&get=[a-zA-Z\\d+-]+-v?(\\d[\\da-zA-Z.]*)$'
```