### PR TITLE
intel-tbb: Add variant to disable transactional memory.

### DIFF
--- a/var/spack/repos/builtin/packages/intel-tbb/disable-tm.patch
+++ b/var/spack/repos/builtin/packages/intel-tbb/disable-tm.patch
@@ -1,0 +1,15 @@
+Disable transactional memory.  This is needed for some AMD or very old
+Intel systems.  See issue #6090.
+
+diff -Naurb tbb-2018_U4.orig/include/tbb/tbb_config.h tbb-2018_U4/include/tbb/tbb_config.h
+--- tbb-2018_U4.orig/include/tbb/tbb_config.h	2018-05-30 07:35:25.000000000 -0500
++++ tbb-2018_U4/include/tbb/tbb_config.h	2018-07-24 16:26:11.662673434 -0500
+@@ -98,7 +98,7 @@
+ #define __TBB_DEFINE_MIC 1
+ #endif
+ 
+-#define __TBB_TSX_AVAILABLE  ((__TBB_x86_32 || __TBB_x86_64) && !__TBB_DEFINE_MIC)
++#define __TBB_TSX_AVAILABLE  0
+ 
+ /** Presence of compiler features **/
+ 

--- a/var/spack/repos/builtin/packages/intel-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-tbb/package.py
@@ -73,6 +73,10 @@ class IntelTbb(Package):
             multi=False,
             description='Use the specified C++ standard when building.')
 
+    variant('disable-tm', default=False,
+            description='Disable transactional memory, only needed ' +
+                        'for AMD or very old Intel systems.')
+
     # Build and install CMake config files if we're new enough.
     depends_on('cmake@3.0.0:', type='build', when='@2017.0:')
 
@@ -83,6 +87,9 @@ class IntelTbb(Package):
 
     # Patch cmakeConfig.cmake.in to find the libraries where we install them.
     patch("tbb_cmakeConfig.patch", level=0, when='@2017.0:')
+
+    # Some very old systems don't support transactional memory.
+    patch("disable-tm.patch", when='+disable-tm')
 
     def url_for_version(self, version):
         url = 'https://github.com/01org/tbb/archive/{0}.tar.gz'

--- a/var/spack/repos/builtin/packages/intel-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-tbb/package.py
@@ -73,9 +73,8 @@ class IntelTbb(Package):
             multi=False,
             description='Use the specified C++ standard when building.')
 
-    variant('disable-tm', default=False,
-            description='Disable transactional memory, only needed ' +
-                        'for AMD or very old Intel systems.')
+    variant('tm', default=True,
+            description='Enable use of transactional memory on x86')
 
     # Build and install CMake config files if we're new enough.
     depends_on('cmake@3.0.0:', type='build', when='@2017.0:')
@@ -89,7 +88,7 @@ class IntelTbb(Package):
     patch("tbb_cmakeConfig.patch", level=0, when='@2017.0:')
 
     # Some very old systems don't support transactional memory.
-    patch("disable-tm.patch", when='+disable-tm')
+    patch("disable-tm.patch", when='~tm')
 
     def url_for_version(self, version):
         url = 'https://github.com/01org/tbb/archive/{0}.tar.gz'


### PR DESCRIPTION
Fixes #6090.

Some AMD or very old Intel systems don't support transactional memory.
This commit adds a variant (default False) to allow running on those
systems.