### PR TITLE
spack spec: no extra newline with --yaml; error with no specs

### DIFF
--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -25,7 +25,11 @@
 from __future__ import print_function
 
 import argparse
+import sys
 
+import llnl.util.tty as tty
+
+import spack
 import spack.cmd
 import spack.cmd.common.arguments as arguments
 
@@ -66,12 +70,17 @@ def spec(parser, args):
               'show_types': args.types,
               'install_status': args.install_status}
 
+    if not args.specs:
+        tty.die("spack spec requires at least one spec")
+
     for spec in spack.cmd.parse_specs(args.specs):
         # With -y, just print YAML to output.
         if args.yaml:
             if spec.name in spack.repo.path or spec.virtual:
                 spec.concretize()
-            print(spec.to_yaml())
+
+            # use write because to_yaml already has a newline.
+            sys.stdout.write(spec.to_yaml())
             continue
 
         kwargs['hashes'] = False  # Always False for input spec

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -88,3 +88,9 @@ def test_spec_deptypes_edges():
     assert types['dt-diamond-left']   == ['bl  ']
     assert types['dt-diamond-right']  == ['bl  ']
     assert types['dt-diamond-bottom'] == ['b   ', 'blr ']
+
+
+def test_spec_returncode():
+    with pytest.raises(spack.main.SpackCommandError):
+        spec()
+    assert spec.returncode == 1


### PR DESCRIPTION
Some tweaks to `spack spec` behavior.  The extra newline was driving me nuts.

- [x] `spack spec` now returns an error if given no specs
- [x] removed superfluous trailing newline from `spack spec --yaml` output
      (only one newline now)
