### PR TITLE
Fix shift warning on zsh

### DIFF
--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -80,14 +80,22 @@ function spack {
         return
     fi
 
-    _sp_subcommand=$1; shift
+    _sp_subcommand=""
+    if [ -n "$1" ]; then
+        _sp_subcommand="$1"
+        shift
+    fi
     _sp_spec=("$@")
 
     # Filter out use and unuse.  For any other commands, just run the
     # command.
     case $_sp_subcommand in
         "cd")
-            _sp_arg="$1"; shift
+            _sp_arg=""
+            if [ -n "$1" ]; then
+                _sp_arg="$1"
+                shift
+            fi
             if [ "$_sp_arg" = "-h" ]; then
                 command spack cd -h
             else


### PR DESCRIPTION
When using zsh, trying to shift when there are no arguments left results in warnings like this: `spack:shift:22: shift count must be <= $#`