### PR TITLE
FTGL package workarounds

### DIFF
--- a/var/spack/repos/builtin/packages/ftgl/package.py
+++ b/var/spack/repos/builtin/packages/ftgl/package.py
@@ -56,7 +56,7 @@ class Ftgl(AutotoolsPackage):
     # FIXME: Can someone with autotools experience fix the build system
     #        so that it doesn't fail when that happens?
     #
-    depends_on('doxygen')
+    depends_on('doxygen', type='build')
 
     @property
     @when('@2.1.2')

--- a/var/spack/repos/builtin/packages/ftgl/package.py
+++ b/var/spack/repos/builtin/packages/ftgl/package.py
@@ -37,6 +37,10 @@ class Ftgl(AutotoolsPackage):
 
     version('2.1.2', 'f81c0a7128192ba11e036186f9a968f2')
 
+    # There is an unnecessary qualifier around, which makes modern GCC sad
+    patch('remove-extra-qualifier.diff')
+
+
     # Ftgl does not come with a configure script
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
@@ -47,6 +51,13 @@ class Ftgl(AutotoolsPackage):
     depends_on('gl')
     depends_on('glu')
     depends_on('freetype@2.0.9:')
+
+    # Currently, "make install" will fail if the docs weren't built
+    #
+    # FIXME: Can someone with autotools experience fix the build system
+    #        so that it doesn't fail when that happens?
+    #
+    depends_on('doxygen')
 
     @property
     @when('@2.1.2')

--- a/var/spack/repos/builtin/packages/ftgl/package.py
+++ b/var/spack/repos/builtin/packages/ftgl/package.py
@@ -40,7 +40,6 @@ class Ftgl(AutotoolsPackage):
     # There is an unnecessary qualifier around, which makes modern GCC sad
     patch('remove-extra-qualifier.diff')
 
-
     # Ftgl does not come with a configure script
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')

--- a/var/spack/repos/builtin/packages/ftgl/remove-extra-qualifier.diff
+++ b/var/spack/repos/builtin/packages/ftgl/remove-extra-qualifier.diff
@@ -1,0 +1,11 @@
+--- FTGL/include/FTTextureGlyph.h   2018-07-26 08:30:55.144488976 +0000
++++ FTGL/include/FTTextureGlyph.h   2018-07-26 08:29:42.072489186 +0000
+@@ -52,7 +52,7 @@
+          * Reset the currently active texture to zero to get into a known state before
+          * drawing a string. This is to get round possible threading issues.
+          */
+-        static void FTTextureGlyph::ResetActiveTexture(){ activeTextureID = 0;}
++        static void ResetActiveTexture(){ activeTextureID = 0;}
+         
+     private:
+         /**


### PR DESCRIPTION
Trying to build FTGL in a GCC 8.1-based Docker image, I found two issues:

- There is an unnecessary qualifier in a C++ header, which leads to a warning in GCC 8, and for some reason someone thought that enabling -Werror in production builds was a good idea...
- Although the package will build if Doxygen is not present, it will not install because the installer unconditionally assumes that the docs folder is present.

This PR provides two basic workarounds for these issues. However, if someone with autotools experience can have a look at the FTGL source and tell me how to 1/remove this silly -Werror compilation flag and 2/make sure that the absence of docs does not make installation fail, I think better fixes can probably be devised.