### PR TITLE
Update and Bugfix for pexsi/package.py

### DIFF
--- a/var/spack/repos/builtin/packages/pexsi/package.py
+++ b/var/spack/repos/builtin/packages/pexsi/package.py
@@ -84,7 +84,7 @@ class Pexsi(MakefilePackage):
         ]
 
         if '@0.9.2' in self.spec:
-            substitutions['@FLDFLAGS'] = '-Wl,--allow-multiple-definition'
+            substitutions.append(('@FLDFLAGS', '-Wl,--allow-multiple-definition'))
 
         template = join_path(
             os.path.dirname(inspect.getmodule(self).__file__),

--- a/var/spack/repos/builtin/packages/pexsi/package.py
+++ b/var/spack/repos/builtin/packages/pexsi/package.py
@@ -79,12 +79,17 @@ class Pexsi(MakefilePackage):
             ('@LAPACK_LIBS', self.spec['lapack'].libs.joined()),
             ('@BLAS_LIBS', self.spec['blas'].libs.joined()),
             # FIXME : what to do with compiler provided libraries ?
-            ('@STDCXX_LIB', ' '.join(self.compiler.stdcxx_libs)),
-            ('@FLDFLAGS', '')
+            ('@STDCXX_LIB', ' '.join(self.compiler.stdcxx_libs))
         ]
 
         if '@0.9.2' in self.spec:
-            substitutions.append(('@FLDFLAGS', '-Wl,--allow-multiple-definition'))
+            substitutions.append(
+                ('@FLDFLAGS', '-Wl,--allow-multiple-definition')
+            )
+        else:
+            substitutions.append(
+                ('@FLDFLAGS', '')
+            )
 
         template = join_path(
             os.path.dirname(inspect.getmodule(self).__file__),

--- a/var/spack/repos/builtin/packages/pexsi/package.py
+++ b/var/spack/repos/builtin/packages/pexsi/package.py
@@ -54,7 +54,7 @@ class Pexsi(MakefilePackage):
     depends_on('parmetis')
     depends_on('superlu-dist@3.3:3.999', when='@:0.9.0')
     depends_on('superlu-dist@4.3:4.999', when='@0.9.2')
-    depends_on('superlu-dist@5.1.2:', when='@0.10.2:')
+    depends_on('superlu-dist@5.1.2:5.3.999', when='@0.10.2:')
 
     variant(
         'fortran', default=False, description='Builds the Fortran interface'
@@ -95,7 +95,7 @@ class Pexsi(MakefilePackage):
             'make.inc'
         )
         shutil.copy(template, makefile)
-        for key, value in substitutions.items():
+        for key, value in sorted(substitutions.items(), reverse=True):
             filter_file(key, value, makefile)
 
     def build(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/pexsi/package.py
+++ b/var/spack/repos/builtin/packages/pexsi/package.py
@@ -64,24 +64,24 @@ class Pexsi(MakefilePackage):
 
     def edit(self, spec, prefix):
 
-        substitutions = {
-            '@MPICC': self.spec['mpi'].mpicc,
-            '@MPICXX': self.spec['mpi'].mpicxx,
-            '@MPIFC': self.spec['mpi'].mpifc,
-            '@MPICXX_LIB': self.spec['mpi:cxx'].libs.joined(),
-            '@RANLIB': 'ranlib',
-            '@PEXSI_STAGE': self.stage.source_path,
-            '@SUPERLU_PREFIX': self.spec['superlu-dist'].prefix,
-            '@METIS_PREFIX': self.spec['metis'].prefix,
-            '@PARMETIS_PREFIX': self.spec['parmetis'].prefix,
-            '@LAPACK_PREFIX': self.spec['lapack'].prefix,
-            '@BLAS_PREFIX': self.spec['blas'].prefix,
-            '@LAPACK_LIBS': self.spec['lapack'].libs.joined(),
-            '@BLAS_LIBS': self.spec['blas'].libs.joined(),
+        substitutions = [
+            ('@MPICC', self.spec['mpi'].mpicc),
+            ('@MPICXX_LIB', self.spec['mpi:cxx'].libs.joined()),
+            ('@MPICXX', self.spec['mpi'].mpicxx),
+            ('@MPIFC', self.spec['mpi'].mpifc),
+            ('@RANLIB', 'ranlib'),
+            ('@PEXSI_STAGE', self.stage.source_path),
+            ('@SUPERLU_PREFIX', self.spec['superlu-dist'].prefix),
+            ('@METIS_PREFIX', self.spec['metis'].prefix),
+            ('@PARMETIS_PREFIX', self.spec['parmetis'].prefix),
+            ('@LAPACK_PREFIX', self.spec['lapack'].prefix),
+            ('@BLAS_PREFIX', self.spec['blas'].prefix),
+            ('@LAPACK_LIBS', self.spec['lapack'].libs.joined()),
+            ('@BLAS_LIBS', self.spec['blas'].libs.joined()),
             # FIXME : what to do with compiler provided libraries ?
-            '@STDCXX_LIB': ' '.join(self.compiler.stdcxx_libs),
-            '@FLDFLAGS': ''
-        }
+            ('@STDCXX_LIB', ' '.join(self.compiler.stdcxx_libs)),
+            ('@FLDFLAGS', '')
+        ]
 
         if '@0.9.2' in self.spec:
             substitutions['@FLDFLAGS'] = '-Wl,--allow-multiple-definition'
@@ -95,7 +95,7 @@ class Pexsi(MakefilePackage):
             'make.inc'
         )
         shutil.copy(template, makefile)
-        for key, value in sorted(substitutions.items(), reverse=True):
+        for key, value in substitutions:
             filter_file(key, value, makefile)
 
     def build(self, spec, prefix):


### PR DESCRIPTION
I found that pexsi@0.10.2 cannot be installed due to the following two reasons.

1. pexsi@0.10.2 is not compatible with superlu-dist@5.4.0 due to [Change LargeDiag to LargeDiag_MC64; Add LargeDiag_AWPM](https://github.com/xiaoyeli/superlu_dist/commit/d7dce5a3488f80645023ab8431d82399e5546ebf).

2. In the 'edit' phase, '@MPICXX_LIB' must be substituted before '@MPICXX' is substituted.