### PR TITLE
libunwind: make it a virtual package

### DIFF
--- a/etc/spack/defaults/darwin/packages.yaml
+++ b/etc/spack/defaults/darwin/packages.yaml
@@ -18,3 +18,10 @@ packages:
     compiler: [clang, gcc, intel]
     providers:
       elf: [libelf]
+      unwind: [apple-libunwind]
+  apple-libunwind:
+    paths:
+    # Apple bundles libunwind version 35.3 with macOS 10.9 and later,
+    # although the version number used here isn't critical
+      apple-libunwind@35.3: /usr
+    buildable: False

--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -39,3 +39,5 @@ packages:
       scalapack: [netlib-scalapack]
       szip: [libszip, libaec]
       tbb: [intel-tbb]
+      unwind: [libunwind]
+

--- a/var/spack/repos/builtin/packages/apple-libunwind/package.py
+++ b/var/spack/repos/builtin/packages/apple-libunwind/package.py
@@ -1,0 +1,84 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class AppleLibunwind(Package):
+    """Placeholder package for Apple's analogue to non-GNU libunwind"""
+
+    homepage = "https://opensource.apple.com/source/libunwind/libunwind-35.3/"
+
+    provides('unwind')
+
+    # The 'conflicts' directive only accepts valid spack specs;
+    # platforms cannot be negated -- 'platform!=darwin' is not a valid
+    # spec -- so expressing a conflict for any platform that isn't
+    # Darwin must be expressed by listing a conflict with every
+    # platform that isn't Darwin/macOS
+    conflicts('platform=linux')
+    conflicts('platform=bgq')
+    conflicts('platform=cray')
+
+    # Override the fetcher method to throw a useful error message;
+    # avoids GitHub issue (#7061) in which the opengl placeholder
+    # package threw a generic, uninformative error during the `fetch`
+    # step,
+    @property
+    def fetcher(self):
+        msg = """This package is intended to be a placeholder for Apple's
+        system-provided, non-GNU-compatible libunwind library.
+
+        Add to your packages.yaml:
+
+        packages:
+          apple-libunwind:
+            paths:
+              apple-libunwind@35.3: /usr
+            buildable: False
+
+        """
+        raise InstallError(msg)
+
+    def install(self, spec, prefix):
+        pass
+
+    @property
+    def libs(self):
+        """ Export the Apple libunwind library
+        """
+        libs = find_libraries('libunwind',
+                              join_path(self.prefix.lib, 'system'),
+                              shared=True, recursive=False)
+        if libs:
+            return libs
+        return None
+
+    @property
+    def headers(self):
+        """ Export the Apple libunwind header
+        """
+        hdrs = HeaderList(find(self.prefix.include, 'libunwind.h',
+                               recursive=False))
+        return hdrs or None

--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -70,7 +70,7 @@ class Caliper(CMakePackage):
     depends_on('papi', when='+papi')
     depends_on('libpfm4', when='+libpfm')
     depends_on('mpi', when='+mpi')
-    depends_on('libunwind', when='+callpath')
+    depends_on('unwind', when='+callpath')
     depends_on('sosflow', when='+sosflow')
 
     depends_on('cmake', type='build')

--- a/var/spack/repos/builtin/packages/gperftools/package.py
+++ b/var/spack/repos/builtin/packages/gperftools/package.py
@@ -39,4 +39,4 @@ class Gperftools(AutotoolsPackage):
     version('2.3', 'f54dd119f0e46ac1f13264f8d97adf90',
             url="https://googledrive.com/host/0B6NtGsLhIcf7MWxMMF9JdTN3UVk/gperftools-2.3.tar.gz")
 
-    depends_on("libunwind")
+    depends_on("unwind")

--- a/var/spack/repos/builtin/packages/libunwind/package.py
+++ b/var/spack/repos/builtin/packages/libunwind/package.py
@@ -36,3 +36,5 @@ class Libunwind(AutotoolsPackage):
 
     version('1.2.1', '06ba9e60d92fd6f55cd9dadb084df19e')
     version('1.1', 'fb4ea2f6fbbe45bf032cd36e586883ce')
+
+    provides('unwind')

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -194,7 +194,7 @@ class Mfem(Package):
     #            when='+petsc')
     depends_on('mpfr', when='+mpfr')
     depends_on('netcdf', when='+netcdf')
-    depends_on('libunwind', when='+libunwind')
+    depends_on('unwind', when='+libunwind')
     depends_on('zlib', when='+gzstream')
     depends_on('gnutls', when='+gnutls')
     depends_on('conduit@0.3.1:', when='+conduit')
@@ -373,7 +373,7 @@ class Mfem(Package):
                 ld_flags_from_dirs([spec['gnutls'].prefix.lib], ['gnutls'])]
 
         if '+libunwind' in spec:
-            libunwind = spec['libunwind']
+            libunwind = spec['unwind']
             headers = find_headers('libunwind', libunwind.prefix.include)
             headers.add_macro('-g')
             libs = find_optional_library('libunwind', libunwind.prefix)


### PR DESCRIPTION
This pull request attempts to implement the suggested steps outlined in #8823 to make `libunwind` a virtual package.