### PR TITLE
GSL: 2.5 is a new version.

### DIFF
--- a/var/spack/repos/builtin/packages/gsl/package.py
+++ b/var/spack/repos/builtin/packages/gsl/package.py
@@ -36,6 +36,7 @@ class Gsl(AutotoolsPackage):
     homepage = "http://www.gnu.org/software/gsl"
     url      = "http://mirror.switch.ch/ftp/mirror/gnu/gsl/gsl-2.3.tar.gz"
 
+    version('2.5', sha256='0460ad7c2542caaddc6729762952d345374784100223995eb14d614861f2258d')
     version('2.4',   'dba736f15404807834dc1c7b93e83b92')
     version('2.3',   '905fcbbb97bc552d1037e34d200931a0')
     version('2.2.1', '3d90650b7cfe0a6f4b29c2d7b0f86458')


### PR DESCRIPTION
GSL-2.5 is out.  Notes for the version are at https://git.savannah.gnu.org/cgit/gsl.git/tree/NEWS.