### PR TITLE
Fix performance issue when compiling.

### DIFF
--- a/lib/spack/llnl/util/tty/log.py
+++ b/lib/spack/llnl/util/tty/log.py
@@ -446,10 +446,9 @@ class log_output(object):
         try:
             with keyboard_input(stdin):
                 while True:
-                    # Without the last parameter (timeout) select will
-                    # wait until at least one of the two streams are
-                    # ready. This may cause the function to hang.
-                    rlist, _, xlist = select.select(istreams, [], [])
+                    # No need to set any timeout for select.select
+                    # Wait until a key press or an event on in_pipe.
+                    rlist, _, _ = select.select(istreams, [], [])
 
                     # Allow user to toggle echo with 'v' key.
                     # Currently ignores other chars.

--- a/lib/spack/llnl/util/tty/log.py
+++ b/lib/spack/llnl/util/tty/log.py
@@ -449,7 +449,7 @@ class log_output(object):
                     # Without the last parameter (timeout) select will
                     # wait until at least one of the two streams are
                     # ready. This may cause the function to hang.
-                    rlist, _, xlist = select.select(istreams, [], [], 0)
+                    rlist, _, xlist = select.select(istreams, [], [])
 
                     # Allow user to toggle echo with 'v' key.
                     # Currently ignores other chars.


### PR DESCRIPTION
Spack was doing active wait when compiling, spoiling one core.
My fix consists in not setting any timeout for select, instead of
the previous 0 second.

On a two cores machine, that results in a x2 boost for compilation.