### PR TITLE
Add unzip runtime dependency to lua package

### DIFF
--- a/var/spack/repos/builtin/packages/lua-luaposix/package.py
+++ b/var/spack/repos/builtin/packages/lua-luaposix/package.py
@@ -34,7 +34,6 @@ class LuaLuaposix(Package):
     version('33.4.0', 'b36ff049095f28752caeb0b46144516c')
 
     extends("lua")
-    depends_on('unzip', type='build')
 
     def install(self, spec, prefix):
         rockspec = glob.glob('luaposix-*.rockspec')

--- a/var/spack/repos/builtin/packages/lua-luaposix/package.py
+++ b/var/spack/repos/builtin/packages/lua-luaposix/package.py
@@ -34,6 +34,7 @@ class LuaLuaposix(Package):
     version('33.4.0', 'b36ff049095f28752caeb0b46144516c')
 
     extends("lua")
+    depends_on('unzip', type='build')
 
     def install(self, spec, prefix):
         rockspec = glob.glob('luaposix-*.rockspec')

--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -49,6 +49,8 @@ class Lua(Package):
 
     depends_on('ncurses')
     depends_on('readline')
+    # luarocks needs unzip for some packages (e.g. lua-luaposix)
+    depends_on('unzip', type='run')
 
     resource(
         name="luarocks",


### PR DESCRIPTION
I ended up on an [Ubuntu] system that hadn't had unzip employed
and discovered lua-luaposix requires it (while buildig Lmod).

Closes #8533