### PR TITLE
Dia has build dependencies on gettext and pkg-config.

### DIFF
--- a/var/spack/repos/builtin/packages/dia/package.py
+++ b/var/spack/repos/builtin/packages/dia/package.py
@@ -33,6 +33,8 @@ class Dia(Package):
     version('0.97.3',    '0e744a0f6a6c4cb6a089e4d955392c3c')
 
     depends_on('intltool', type='build')
+    depends_on('gettext', type='build')
+    depends_on('pkg-config', type='build')
     depends_on('gtkplus@2.6.0:')
     depends_on('libxslt')
     depends_on('python')


### PR DESCRIPTION
When using spack on a ubuntu baseline system, I was unable to build dia without adding these build dependencies on _gettext_ and _pkg-config_.