### PR TITLE
Introduce templates for specific issue types

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,16 +1,13 @@
-If you want to report a build error for some package, or a bug in core please use the following template as a guideline:
+---
+name: Bug report 
+about: Report a bug in the core of Spack (command not working as expected, etc.) 
 
------
+---
 
-Summary
 
-### Expected Result
-
-What you expected
-
-### Actual Result
-
-What happened instead
+*Summarize in a couple of lines the bug you encountered. Ideally it 
+should be enough to give core developers an idea what might be happening 
+in the code. Try your best to be clear and concise.* :wink:
 
 ### Steps to reproduce the issue
 
@@ -19,6 +16,16 @@ $ spack <command1> <spec>
 $ spack <command2> <spec>
 ...
 ```
+
+### Expected Result
+
+What you expected before running the command or performing the steps 
+described above.
+
+### Actual Result
+
+What happened instead
+
 
 ### Information on your system
 

--- a/.github/ISSUE_TEMPLATE/build_error.md
+++ b/.github/ISSUE_TEMPLATE/build_error.md
@@ -1,0 +1,51 @@
+---
+name: Build error 
+about: Some package in Spack didn't build correctly  
+
+---
+
+*Thanks for taking the time to report this build failure. To proceed with the
+report please:*
+1. Title the issue "Installation issue: <name-of-the-package>".
+1. Provide the information required below.
+1. Clean the issue from these template instructions.
+
+### Steps to reproduce the issue
+
+```console
+$ spack install <spec> # Fill in the exact spec you are using
+... # and the relevant part of the error message
+```
+
+### Platform and user environment
+
+Please report here your OS:
+```commandline
+$ uname -a 
+Linux nuvolari 4.15.0-29-generic #31-Ubuntu SMP Tue Jul 17 15:39:52 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
+$ lsb_release -d
+Description:	Ubuntu 18.04.1 LTS
+``` 
+and, if relevant, post or attach:
+
+- `packages.yaml`
+- `compilers.yaml`
+
+to the issue
+
+### Additional information
+
+If you think this report would benefit from additional details, e.g. extracts 
+from the logs in `<stage>/spack-build.out`, or the output of some other:
+```console
+$ spack <command>
+```   
+please insert those things here. 
+
+-----
+
+We encourage you to try, as much as possible, to reduce your problem to the minimal example that still reproduces the issue. That would help us a lot in fixing it quickly and effectively!
+
+If you want to ask a question about the tool (how to use it, what it can currently do, etc.), try the `#general` channel on our Slack first. We have a welcoming community and chances are you'll get your reply faster and without opening an issue.
+
+Other than that, thanks for taking the time to contribute to Spack!

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request 
+about: Suggest adding a feature that is not yet in Spack  
+
+---
+
+*Please add a concise summary of your suggestion here.*
+
+### Rationale
+
+*Is your feature request related to a problem? Please describe it!*
+
+### Description
+
+*Describe the solution you'd like and the alternatives you have considered.*
+
+
+### Additional information
+*Add any other context about the feature request here.*
+
+
+-----
+
+
+If you want to ask a question about the tool (how to use it, what it can currently do, etc.), try the `#general` channel on our Slack first. We have a welcoming community and chances are you'll get your reply faster and without opening an issue.
+
+Other than that, thanks for taking the time to contribute to Spack!


### PR DESCRIPTION
refers #8811 

As a user contributing to Spack I want to be guided when reporting a bug or requesting a feature so that it's clear which kind of information is needed for maintainers to triage my issue and start working on it.

### Rationale

@scheibelp raised a fair point in #8811 

>The overall theme of this response is that we should put more effort into prioritization, and specifically that it's worth discussing ways to make it easier to prioritize issues, and that this may involve categorizing issues (some categories of issues may be easier to prioritize, and in some cases may benefit from a documented approach).

While I disagree with the fact that a bot could not help, I am also convinced (as Peter is) that a better categorization of issues and PRs will improve our response time. This PR is an attempt to use [this feature](https://help.github.com/articles/about-issue-and-pull-request-templates/) of Github to that aim.

### Description
The single issue template we had before has now been substituted by three more specialized templates, which account for:
- Feature requests
- Bug reports
- Build errors

*The idea* is, instead of categorizing issues ourselves, to let a contributor decide which kind of issue he's about to open and help him provide the maintainers with all the necessary information. *The hope* is that this will help categorizing and prioritizing reports.

### Additional information

There are a few things worth remarking:
- The wording in the templates is tentative. Suggestions to improve it are welcome.
- I was looking for ways to auto-label issues based on templates, but couldn't find any. Will investigate more and report back.

If you want to see the mechanism live, try open an issue repository in this [toy-repository](https://github.com/forthelols/ubimaior/issues) of mine.