### PR TITLE
Trilinos: Update rules for superlu-dist version compatibility.

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -295,6 +295,7 @@ class Trilinos(CMakePackage):
     depends_on('scalapack', when='+mumps')
     depends_on('superlu-dist', when='+superlu-dist')
     depends_on('superlu-dist@:4.3', when='@:12.6.1+superlu-dist')
+    depends_on('superlu-dist@4.4:5.3', when='@12.6.2:12.12.1+superlu-dist')
     depends_on('superlu-dist@develop', when='@develop+superlu-dist')
     depends_on('superlu-dist@xsdk-0.2.0', when='@xsdk-0.2.0+superlu-dist')
     depends_on('superlu+pic@4.3', when='+superlu')


### PR DESCRIPTION
# Background

* `superlu-dist@5.4.0` introduced an API change that is not backward compatible.  This causes the spackage for `trilinos@12.12.1` to fail with the error:

```
     6109    $HOME/spack/var/spack/stage/trilinos-12.12.1-2n3hngka6s5cigudpk5o5ojykzl4mtyz/Trilinos-trilinos-release-12-12-1/packages/amesos/src/Amesos_Superludist.cpp: In member function ‘int Amesos_Superludist::Factor()’:
  >> 6110    $HOME/spack/var/spack/stage/trilinos-12.12.1-2n3hngka6s5cigudpk5o5ojykzl4mtyz/Trilinos-trilinos-release-12-12-1/packages/amesos/src/Amesos_Superludist.cpp:475:75: error: ‘LargeDiag’ was not declared in this scope
     6111         if( RowPerm_ == "LargeDiag" ) PrivateSuperluData_->options_.RowPerm = LargeDiag;
     6112                                                                               ^~~~~~~~~
     6113    $HOME/spack/var/spack/stage/trilinos-12.12.1-2n3hngka6s5cigudpk5o5ojykzl4mtyz/Trilinos-trilinos-release-12-12-1/packages/amesos/src/Amesos_Superludist.cpp:475:75: note: suggested alternative: ‘LargeDiag_AWPM’
     6114         if( RowPerm_ == "LargeDiag" ) PrivateSuperluData_->options_.RowPerm = LargeDiag;
     6115                                                                               ^~~~~~~~~
     6116                                                                               LargeDiag_AWPM                                                                           ^~~~~~~~~
```

# Changes

* Limit the version of `superlu-dist` used when building `trilinos`

```python
    depends_on('superlu-dist@4.4:5.3', when='@12.6.2:12.12.1+superlu-dist')
```