### PR TITLE
[WIP] detect pch output and set mode=cpp in that case

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -143,6 +143,20 @@ if [[ -z $mode ]] || [[ $mode == ld ]]; then
     done
 fi
 
+prev_arg=""
+for arg in "$@"; do
+    if [[ $prev_arg == -o ]]; then
+        # Rudimentary check to see if this compilation is intended to produce
+        # a precompiled header. This is not guaranteed to always succeed -
+        # see #8640
+        if [[ $arg == *.pch || $arg == *.gch ]]; then
+            mode=cpp
+            break
+        fi
+    fi
+    prev_arg=$arg
+done
+
 # Finish setting up the mode.
 if [[ -z $mode ]]; then
     mode=ccld


### PR DESCRIPTION
See: https://github.com/spack/spack/issues/8640

Spack should operate in cpp mode (vs. ld/ccld mode) when creating .pch files (precompiled headers). This adds a rudimentary check based on the presence of `-o`. This doesn't detect all cases of creating precompiled headers but doing that 100%-accurately requires parsing the input file from the command which would take significantly more effort.

Note that I have tried building WxPython (mentioned in #8640, the current only test case for this) and it still fails but as far as I can tell right now it is not related to doing the wrong thing for precompiled headers (i.e. adding this patch gets past the original failure).