### PR TITLE
Small patch for netlib-lapack.

### DIFF
--- a/var/spack/repos/builtin/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-lapack/package.py
@@ -65,6 +65,11 @@ class NetlibLapack(CMakePackage):
     # containing the fix is released and added to Spack.
     patch('undefined_declarations.patch', when='@3.8.0:')
 
+    # https://github.com/Reference-LAPACK/lapack/pull/268
+    # TODO: update 'when' once the version of lapack
+    # containing the fix is released and added to Spack.
+    patch('testing.patch', when='@3.7.0:')
+
     # virtual dependency
     provides('blas', when='~external-blas')
     provides('lapack')

--- a/var/spack/repos/builtin/packages/netlib-lapack/testing.patch
+++ b/var/spack/repos/builtin/packages/netlib-lapack/testing.patch
@@ -1,0 +1,13 @@
+diff --git a/TESTING/LIN/alahd.f b/TESTING/LIN/alahd.f
+index 8f4cd58d..6a4946e0 100644
+--- a/TESTING/LIN/alahd.f
++++ b/TESTING/LIN/alahd.f
+@@ -1036,7 +1036,7 @@
+  9929 FORMAT( ' Test ratios (1-3: ', A1, 'TZRZF):' )
+  9920 FORMAT( 3X, ' 7-10: same as 3-6', 3X, ' 11-14: same as 3-6' )
+  9921 FORMAT( ' Test ratios:', / '    (1-2: ', A1, 'GELS, 3-6: ', A1,
+-     $      'GELSY, 7-10: ', A1, 'GELSS, 11-14: ', A1, 'GELSD, 15-16: '
++     $      'GELSY, 7-10: ', A1, 'GELSS, 11-14: ', A1, 'GELSD, 15-16: ',
+      $        A1, 'GETSLS)')
+  9928 FORMAT( 7X, 'where ALPHA = ( 1 + SQRT( 17 ) ) / 8' )
+  9927 FORMAT( 3X, I2, ': ABS( Largest element in L )', / 12X,


### PR DESCRIPTION
I am not sure if this PR should be merged because this file is compiled only when testing is enabled and AFAIK only NAG compiler complains about the missing comma. Since some of the tests fail anyway (when compiled with NAG), it doesn't really solve much right now but maybe this will help someone in the future to get the tests run without failures.