### PR TITLE
Conflict for cmake 3.11.x and Intel.

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -89,6 +89,9 @@ class Cmake(Package):
 
     conflicts('+qt', when='^qt@5.4.0')  # qt-5.4.0 has broken CMake modules
 
+    # https://gitlab.kitware.com/cmake/cmake/issues/18166
+    conflicts('%intel', when='@3.11.0:3.11.4')
+
     phases = ['bootstrap', 'build', 'install']
 
     def url_for_version(self, version):


### PR DESCRIPTION
The problem described in #8317 is fixed for cmake 3.12.0. Let's just put conflict for cmake 3.11.x and Intel.

fixes https://github.com/spack/spack/issues/8317