### PR TITLE
libdwarf: remove use of hide_files()

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -60,7 +60,6 @@ __all__ = [
     'fix_darwin_install_name',
     'force_remove',
     'force_symlink',
-    'hide_files',
     'install',
     'install_tree',
     'is_exe',
@@ -390,18 +389,6 @@ def replace_directory_transaction(directory_name, tmp_root=None):
         # Otherwise delete the temporary directory
         shutil.rmtree(tmp_dir)
         tty.debug('TEMPORARY DIRECTORY DELETED [{0}]'.format(tmp_dir))
-
-
-@contextmanager
-def hide_files(*file_list):
-    try:
-        baks = ['%s.bak' % f for f in file_list]
-        for f, bak in zip(file_list, baks):
-            shutil.move(f, bak)
-        yield
-    finally:
-        for f, bak in zip(file_list, baks):
-            shutil.move(bak, f)
 
 
 def hash_directory(directory):

--- a/var/spack/repos/builtin/packages/libdwarf/package.py
+++ b/var/spack/repos/builtin/packages/libdwarf/package.py
@@ -61,77 +61,69 @@ class Libdwarf(Package):
         filter_file(r'^typedef struct Elf Elf;$', '', 'libdwarf/libdwarf.h.in')
 
     def install(self, spec, prefix):
+        # dwarf build does not set arguments for ar properly
+        make.add_default_arg('ARFLAGS=rcs')
 
-        # elfutils contains a dwarf.h that conflicts with libdwarf's
-        # TODO: we should remove this when we can modify the include order
-        hide_list = []
-        if spec.satisfies('^elfutils'):
-            dwarf_h = join_path(spec['elfutils'].prefix, 'include/dwarf.h')
-            hide_list.append(dwarf_h)
-        with hide_files(*hide_list):
-            # dwarf build does not set arguments for ar properly
-            make.add_default_arg('ARFLAGS=rcs')
+        # Dwarf doesn't provide an install, so we have to do it.
+        mkdirp(prefix.bin, prefix.include, prefix.lib, prefix.man.man1)
 
-            # Dwarf doesn't provide an install, so we have to do it.
-            mkdirp(prefix.bin, prefix.include, prefix.lib, prefix.man.man1)
+        with working_dir('libdwarf'):
+            extra_config_args = []
 
-            with working_dir('libdwarf'):
-                extra_config_args = []
+            # this is to prevent picking up system /usr/include/libelf.h
+            if spec.satisfies('^libelf'):
+                libelf_inc_dir = join_path(spec['libelf'].prefix,
+                                           'include/libelf')
+                extra_config_args.append(
+                    'CFLAGS=-I{0} -Wl,-L{1} -Wl,-lelf'.format(
+                        libelf_inc_dir, spec['libelf'].prefix.lib))
+            configure("--prefix=" + prefix, "--enable-shared",
+                      *extra_config_args)
+            filter_file(r'^dwfzlib\s*=\s*-lz',
+                        'dwfzlib=-L{0} -lz'.format(
+                            self.spec['zlib'].prefix.lib),
+                        'Makefile')
+            make()
 
-                # this is to prevent picking up system /usr/include/libelf.h
-                if spec.satisfies('^libelf'):
-                    libelf_inc_dir = join_path(spec['libelf'].prefix,
-                                               'include/libelf')
-                    extra_config_args.append(
-                        'CFLAGS=-I{0} -Wl,-L{1} -Wl,-lelf'.format(
-                            libelf_inc_dir, spec['libelf'].prefix.lib))
-                configure("--prefix=" + prefix, "--enable-shared",
-                          *extra_config_args)
-                filter_file(r'^dwfzlib\s*=\s*-lz',
-                            'dwfzlib=-L{0} -lz'.format(
-                                self.spec['zlib'].prefix.lib),
-                            'Makefile')
-                make()
+            libdwarf_name = 'libdwarf.{0}'.format(dso_suffix)
+            libdwarf1_name = 'libdwarf.{0}'.format(dso_suffix) + ".1"
+            install('libdwarf.a',  prefix.lib)
+            install('libdwarf.so', join_path(prefix.lib, libdwarf1_name))
+            if spec.satisfies('@20160507:'):
+                with working_dir(prefix.lib):
+                    os.symlink(libdwarf1_name, libdwarf_name)
+            install('libdwarf.h',  prefix.include)
+            install('dwarf.h',     prefix.include)
 
-                libdwarf_name = 'libdwarf.{0}'.format(dso_suffix)
-                libdwarf1_name = 'libdwarf.{0}'.format(dso_suffix) + ".1"
-                install('libdwarf.a',  prefix.lib)
-                install('libdwarf.so', join_path(prefix.lib, libdwarf1_name))
-                if spec.satisfies('@20160507:'):
-                    with working_dir(prefix.lib):
-                        os.symlink(libdwarf1_name, libdwarf_name)
-                install('libdwarf.h',  prefix.include)
-                install('dwarf.h',     prefix.include)
+            # It seems like fix_darwin_install_name can't be used
+            # here directly; the install name of the library in
+            # the stage directory must be fixed in order for dyld
+            # to locate it on Darwin when spack builds dwarfdump
+            if sys.platform == 'darwin':
+                install_name_tool = which('install_name_tool')
+                install_name_tool('-id',
+                                  join_path('..', 'libdwarf',
+                                            'libdwarf.so'),
+                                  'libdwarf.so')
 
-                # It seems like fix_darwin_install_name can't be used
-                # here directly; the install name of the library in
-                # the stage directory must be fixed in order for dyld
-                # to locate it on Darwin when spack builds dwarfdump
-                if sys.platform == 'darwin':
-                    install_name_tool = which('install_name_tool')
-                    install_name_tool('-id',
-                                      join_path('..', 'libdwarf',
-                                                'libdwarf.so'),
-                                      'libdwarf.so')
+        if spec.satisfies('@20130126:20130729'):
+            dwarfdump_dir = 'dwarfdump2'
+        else:
+            dwarfdump_dir = 'dwarfdump'
+        with working_dir(dwarfdump_dir):
+            configure("--prefix=" + prefix)
+            filter_file(r'^dwfzlib\s*=\s*-lz',
+                        'dwfzlib=-L{0} -lz'.format(
+                            self.spec['zlib'].prefix.lib),
+                        'Makefile')
 
-            if spec.satisfies('@20130126:20130729'):
-                dwarfdump_dir = 'dwarfdump2'
-            else:
-                dwarfdump_dir = 'dwarfdump'
-            with working_dir(dwarfdump_dir):
-                configure("--prefix=" + prefix)
-                filter_file(r'^dwfzlib\s*=\s*-lz',
-                            'dwfzlib=-L{0} -lz'.format(
-                                self.spec['zlib'].prefix.lib),
-                            'Makefile')
+            # This makefile has strings of copy commands that
+            # cause a race in parallel
+            make(parallel=False)
 
-                # This makefile has strings of copy commands that
-                # cause a race in parallel
-                make(parallel=False)
-
-                install('dwarfdump',      prefix.bin)
-                install('dwarfdump.conf', prefix.lib)
-                install('dwarfdump.1',    prefix.man.man1)
+            install('dwarfdump',      prefix.bin)
+            install('dwarfdump.conf', prefix.lib)
+            install('dwarfdump.1',    prefix.man.man1)
 
     @run_after('install')
     def darwin_fix(self):


### PR DESCRIPTION
- This was a nasty workaround due to the way our compiler wrappers used
  to work.  We don't want to have to modify our elfutils installation to
  install libdwarf.

- Since cd9691de5 (#4692), we no longer need this because the package will always
  come before dependencies in our include order.