### PR TITLE
os.path.realpath instead of os.readlink for checking gcc libstdcxx version

### DIFF
--- a/lib/spack/spack/abi.py
+++ b/lib/spack/spack/abi.py
@@ -74,7 +74,7 @@ class ABI(object):
             return None
         if not output:
             return None
-        libpath = os.readlink(output.strip())
+        libpath = os.path.realpath(output.strip())
         if not libpath:
             return None
         return os.path.basename(libpath)


### PR DESCRIPTION
I am getting the following issue on scientific linux 6 when using spack with gcc 7
```
$ spack spec heppy
Input spec
--------------------------------
heppy

Concretized
--------------------------------
==> Error: [Errno 22] Invalid argument: '/path/to/lib64/libstdc++.so'
```
Running with -d shows this stack trace
```
Traceback (most recent call last):
  File "/build/paul/spack/bin/spack", line 61, in <module>
    sys.exit(spack.main.main())
  File "/var/build/paul/spack/lib/spack/spack/main.py", line 653, in main
    return _invoke_command(command, parser, args, unknown)
  File "/var/build/paul/spack/lib/spack/spack/main.py", line 432, in _invoke_command
    return_val = command(parser, args)
  File "/var/build/paul/spack/lib/spack/spack/cmd/spec.py", line 85, in spec
    spec.concretize()
  File "/var/build/paul/spack/lib/spack/spack/spec.py", line 1841, in concretize
    self._expand_virtual_packages(),
  File "/var/build/paul/spack/lib/spack/spack/spec.py", line 1749, in _expand_virtual_packages
    candidates = concretizer.choose_virtual_or_external(spec)
  File "/var/build/paul/spack/lib/spack/spack/concretize.py", line 149, in choose_virtual_or_external
    key=lambda spec: (
  File "/var/build/paul/spack/lib/spack/spack/concretize.py", line 151, in <lambda>
    _abi.compatible(spec, abi_exemplar)))
  File "/var/build/paul/spack/lib/spack/spack/abi.py", line 133, in compatible
    self.compiler_compatible(parent, child, loose=loosematch)
  File "/var/build/paul/spack/lib/spack/spack/abi.py", line 122, in compiler_compatible
    self._gcc_compiler_compare(pversion, cversion)):
  File "/var/build/paul/spack/lib/spack/llnl/util/lang.py", line 182, in __call__
    self.cache[args] = self.func(*args)
  File "/var/build/paul/spack/lib/spack/spack/abi.py", line 86, in _gcc_compiler_compare
    plib = self._gcc_get_libstdcxx_version(pversion)
  File "/var/build/paul/spack/lib/spack/llnl/util/lang.py", line 182, in __call__
    self.cache[args] = self.func(*args)
  File "/var/build/paul/spack/lib/spack/spack/abi.py", line 77, in _gcc_get_libstdcxx_version
    libpath = os.readlink(output.strip())
OSError: [Errno 22] Invalid argument: '/path/to/lib64/libstdc++.so'
```

Switching the read method to os.path.realpath instead of os.readlink seems to fix this problem.