### PR TITLE
sz: fix checksum for 2.0.2.0

### DIFF
--- a/var/spack/repos/builtin/packages/sz/package.py
+++ b/var/spack/repos/builtin/packages/sz/package.py
@@ -35,7 +35,7 @@ class Sz(AutotoolsPackage):
     git      = "https://github.com/disheng222/SZ.git"
 
     version('develop', branch='master')
-    version('2.0.2.0',  sha256='59d1b51d4461049a67e6390a259549eba37f53e20c2d97e3189f22a46d8e6fd4')
+    version('2.0.2.0',  sha256='176c65b421bdec8e91010ffbc9c7bf7852c799972101d6b66d2a30d9702e59b0')
     version('1.4.13.5', sha256='b5e37bf3c377833eed0a7ca0471333c96cd2a82863abfc73893561aaba5f18b9')
     version('1.4.13.4', sha256='c99b95793c48469cac60e6cf82f921babf732ca8c50545a719e794886289432b')
     version('1.4.13.3', sha256='9d80390f09816bf01b7a817e07339030d596026b00179275616af55ed3c1af98')


### PR DESCRIPTION
It looks like the checksum for SZ 2.0.2.0 has changed.

@disheng222 Can you say something about this? Thanks!