### PR TITLE
CMake: patch for NAG.

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/nag-response-files.patch
+++ b/var/spack/repos/builtin/packages/cmake/nag-response-files.patch
@@ -1,0 +1,9 @@
+diff --git a/Modules/Compiler/NAG-Fortran.cmake b/Modules/Compiler/NAG-Fortran.cmake
+index 39aae1883..9973febc3 100644
+--- a/Modules/Compiler/NAG-Fortran.cmake
++++ b/Modules/Compiler/NAG-Fortran.cmake
+@@ -34,3 +34,4 @@ set(CMAKE_Fortran_FORMAT_FIXED_FLAG "-fixed")
+ set(CMAKE_Fortran_FORMAT_FREE_FLAG "-free")
+ set(CMAKE_Fortran_COMPILE_OPTIONS_PIC "-PIC")
+ set(CMAKE_Fortran_COMPILE_OPTIONS_PIE "-PIC")
++set(CMAKE_Fortran_RESPONSE_FILE_LINK_FLAG "-Wl,@")

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -87,6 +87,9 @@ class Cmake(Package):
     # https://gitlab.kitware.com/cmake/cmake/issues/16226
     patch('intel-c-gnu11.patch', when='@3.6.0:3.6.1')
 
+    # https://gitlab.kitware.com/cmake/cmake/issues/18232
+    patch('nag-response-files.patch', when='@3.7:3.12')
+
     conflicts('+qt', when='^qt@5.4.0')  # qt-5.4.0 has broken CMake modules
 
     # https://gitlab.kitware.com/cmake/cmake/issues/18166


### PR DESCRIPTION
The problem is described here: https://gitlab.kitware.com/cmake/cmake/issues/18232

At first, I was going to add something like this to the package I need:
```python
depends_on('cmake', patches=patch('cmake_nag.patch', when='@:3.12'),
           type='build', when='%nag+shared')
```

But then I decided that it makes sense to patch CMake.