### PR TITLE
Revert "cc: package search paths come before dependency paths"

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -52,7 +52,6 @@ parameters=(
     SPACK_F77_RPATH_ARG
     SPACK_FC_RPATH_ARG
     SPACK_SHORT_SPEC
-    SPACK_SYSTEM_DIRS
 )
 
 # The compiler input variables are checked for sanity later:
@@ -229,92 +228,7 @@ fi
 
 # Save original command for debug logging
 input_command="$@"
-args=()
-
-#
-# Parse the command line args, trying hard to keep
-# non-rpath linker arguments in the proper order w.r.t. other command
-# line arguments.  This is important for things like groups.
-#
-# -l arguments are treated as 'other_args' to ensure that they stay in
-# any groups they are a part of. Dependency library -l statements are
-# categorized as 'libs'
-#
-# The various categories will be recombined with compiler flags into 
-# args variable later.
-#
-includes=()
-libdirs=()
-libs=()
-rpaths=()
-other_args=()
-
-while [ -n "$1" ]; do
-    case "$1" in
-        -I*)
-            arg="${1#-I}"
-            if [ -z "$arg" ]; then shift; arg="$1"; fi
-            includes+=("$arg")
-            ;;
-        -L*)
-            arg="${1#-L}"
-            if [ -z "$arg" ]; then shift; arg="$1"; fi
-            libdirs+=("$arg")
-            ;;
-        -l*)
-            arg="${1#-l}"
-            if [ -z "$arg" ]; then shift; arg="$1"; fi
-            other_args+=("-l$arg")
-            ;;
-        -Wl,*)
-            arg="${1#-Wl,}"
-            if [ -z "$arg" ]; then shift; arg="$1"; fi
-            if [[ "$arg" = -rpath=* ]]; then
-                rpaths+=("${arg#-rpath=}")
-	    elif [[ "$arg" = -rpath,* ]]; then
-		rpaths+=("${arg#-rpath,}")
-            elif [[ "$arg" = -rpath ]]; then
-                shift; arg="$1"
-                if [[ "$arg" != -Wl,* ]]; then
-                    die "-Wl,-rpath was not followed by -Wl,*"
-                fi
-                rpaths+=("${arg#-Wl,}")
-            else
-                other_args+=("-Wl,$arg")
-            fi
-            ;;
-        -Xlinker,*)
-            arg="${1#-Xlinker,}"
-            if [ -z "$arg" ]; then shift; arg="$1"; fi
-            if [[ "$arg" = -rpath=* ]]; then
-                rpaths+=("${arg#-rpath=}")
-            elif [[ "$arg" = -rpath ]]; then
-                shift; arg="$1"
-                if [[ "$arg" != -Xlinker,* ]]; then
-                    die "-Xlinker,-rpath was not followed by -Xlinker,*"
-                fi
-                rpaths+=("${arg#-Xlinker,}")
-            else
-                other_args+=("-Xlinker,$arg")
-            fi
-            ;;
-        -Xlinker)
-            if [[ "$2" == "-rpath" ]]; then
-		if [[ "$3" != "-Xlinker" ]]; then
-                    die "-Xlinker,-rpath was not followed by -Xlinker,*"
-		fi
-		shift 3;
-		rpaths+=("$1")
-            else
-                other_args+=("$1")
-            fi
-            ;;
-        *)
-            other_args+=("$1")
-            ;;
-    esac
-    shift
-done
+args=("$@")
 
 # Prepend cppflags, cflags, cxxflags, fcflags, fflags, and ldflags
 
@@ -352,92 +266,91 @@ case "$mode" in cc|ccld)
         ;;
 esac
 
-# Include all -L's and prefix/whatever dirs in rpath
-$add_rpaths && rpaths+=("$SPACK_PREFIX/lib")
-$add_rpaths && rpaths+=("$SPACK_PREFIX/lib64")
-
 # Read spack dependencies from the path environment variable
 IFS=':' read -ra deps <<< "$SPACK_DEPENDENCIES"
 for dep in "${deps[@]}"; do
-    # Append include directories
+    # Prepend include directories
     if [[ -d $dep/include ]]; then
         if [[ $mode == cpp || $mode == cc || $mode == as || $mode == ccld ]]; then
-            includes=("${includes[@]}" "$dep/include")
+            args=("-I$dep/include" "${args[@]}")
         fi
     fi
 
-    # Append lib and RPATH directories
+    # Prepend lib and RPATH directories
     if [[ -d $dep/lib ]]; then
-        if [[ $SPACK_RPATH_DEPS == *$dep* ]]; then
-            $add_rpaths && rpaths=("${rpaths[@]}" "$dep/lib")
-        fi
-        if [[ $SPACK_LINK_DEPS == *$dep* ]]; then
-            libdirs=("${libdirs[@]}" "$dep/lib")
+        if [[ $mode == ccld ]]; then
+            if [[ $SPACK_RPATH_DEPS == *$dep* ]]; then
+                $add_rpaths && args=("$rpath$dep/lib" "${args[@]}")
+            fi
+            if [[ $SPACK_LINK_DEPS == *$dep* ]]; then
+                args=("-L$dep/lib" "${args[@]}")
+            fi
+        elif [[ $mode == ld ]]; then
+            if [[ $SPACK_RPATH_DEPS == *$dep* ]]; then
+                $add_rpaths && args=("-rpath" "$dep/lib" "${args[@]}")
+            fi
+            if [[ $SPACK_LINK_DEPS == *$dep* ]]; then
+                args=("-L$dep/lib" "${args[@]}")
+            fi
         fi
     fi
 
-    # Append lib64 and RPATH directories
+    # Prepend lib64 and RPATH directories
     if [[ -d $dep/lib64 ]]; then
-        if [[ $SPACK_RPATH_DEPS == *$dep* ]]; then
-            $add_rpaths && rpaths+=("$dep/lib64")
-        fi
-        if [[ $SPACK_LINK_DEPS == *$dep* ]]; then
-            libdirs+=("$dep/lib64")
+        if [[ $mode == ccld ]]; then
+            if [[ $SPACK_RPATH_DEPS == *$dep* ]]; then
+                $add_rpaths && args=("$rpath$dep/lib64" "${args[@]}")
+            fi
+            if [[ $SPACK_LINK_DEPS == *$dep* ]]; then
+                args=("-L$dep/lib64" "${args[@]}")
+            fi
+        elif [[ $mode == ld ]]; then
+            if [[ $SPACK_RPATH_DEPS == *$dep* ]]; then
+                $add_rpaths && args=("-rpath" "$dep/lib64" "${args[@]}")
+            fi
+            if [[ $SPACK_LINK_DEPS == *$dep* ]]; then
+                args=("-L$dep/lib64" "${args[@]}")
+            fi
         fi
     fi
 done
 
+# Include all -L's and prefix/whatever dirs in rpath
+if [[ $mode == ccld ]]; then
+    $add_rpaths && args=("$rpath$SPACK_PREFIX/lib64" "${args[@]}")
+    $add_rpaths && args=("$rpath$SPACK_PREFIX/lib"   "${args[@]}")
+elif [[ $mode == ld ]]; then
+    $add_rpaths && args=("-rpath" "$SPACK_PREFIX/lib64" "${args[@]}")
+    $add_rpaths && args=("-rpath" "$SPACK_PREFIX/lib"   "${args[@]}")
+fi
+
 # Set extra RPATHs
 IFS=':' read -ra extra_rpaths <<< "$SPACK_COMPILER_EXTRA_RPATHS"
-for extra_rpath in "${extra_rpaths[@]}"; do 
-    $add_rpaths && rpaths+=("$extra_rpath")
-    libdirs+=("$extra_rpath")
+for extra_rpath in "${extra_rpaths[@]}"; do
+    if [[ $mode == ccld ]]; then
+        $add_rpaths && args=("$rpath$extra_rpath" "${args[@]}")
+        args=("-L$extra_rpath" "${args[@]}")
+    elif [[ $mode == ld ]]; then
+        $add_rpaths && args=("-rpath" "$extra_rpath" "${args[@]}")
+        args=("-L$extra_rpath" "${args[@]}")
+    fi
 done
 
 # Add SPACK_LDLIBS to args
 case "$mode" in
     ld|ccld)
-	for lib in ${SPACK_LDLIBS[@]}; do
-	    libs+=("${lib#-l}")
-	done
+        args=("${args[@]}" ${SPACK_LDLIBS[@]}) ;;
 esac
 
-# Filter system locations to the end of each sublist of args
-# (includes, library dirs, rpaths)
-for sd in ${SPACK_SYSTEM_DIRS[@]}; do
-    stripped_includes=`echo $includes | sed "s#\b$sd/\? \b##g"`
-    stripped_libdirs=`echo $libdirs | sed "s#\b$sd/\? \b##g"`
-    stripped_rpaths=`echo $rpaths | sed "s#\b$sd/\? \b##g"`
-    if [[ "$includes" != "$stripped_includes" ]]; then
-	$includes="$stripped_includes $sd"
-    fi
-    if [[ "$libdirs" != "$stripped_libdirs" ]]; then
-	$libdirs="$stripped_libdirs $sd"
-    fi
-    if [[ "$rpaths" != "$stripped_rpaths" ]]; then
-	$rpaths="$stripped_rpaths $sd"
-    fi
-done
-
-# Put the arguments together into one list
-# Includes come first, then other args, library dirs, and rpaths
-# rpaths get appropriate flag for ld vs ccld mode
-for dir in "${includes[@]}";  do args+=("-I$dir"); done
-args+=("${other_args[@]}")
-for dir in "${libdirs[@]}"; do args+=("-L$dir"); done
-for lib in "${libs[@]}"; do args+=("-l$lib"); done
-if [ "$mode" = ccld ]; then
-    for dir in "${rpaths[@]}"; do
-        args+=("$rpath$dir")
-    done
-elif [ "$mode" = ld ]; then
-    for dir in "${rpaths[@]}"; do
-        args+=("-rpath" "$dir")
-    done
+#ccache only supports C languages, so filtering out Fortran
+if [[ ( ${lang_flags} = "C" || ${lang_flags} = "CXX" ) && ${SPACK_CCACHE_BINARY} ]]; then
+    full_command=("${SPACK_CCACHE_BINARY}" "$command" "${args[@]}")
+    # #3761#issuecomment-294352232
+    # workaround for stage being a temp folder
+    export CCACHE_NOHASHDIR=yes
+else
+   full_command=("$command" "${args[@]}")
 fi
-
-full_command=("$command")
-full_command+=("${args[@]}")
 
 # In test command mode, write out full command for Spack tests.
 if [[ $SPACK_TEST_COMMAND == dump-args ]]; then
@@ -457,4 +370,4 @@ if [[ $SPACK_DEBUG == TRUE ]]; then
     echo "[$mode] ${full_command[@]}" >> "$output_log"
 fi
 
-exec "${full_command[@]}" 
+exec "${full_command[@]}"

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -73,7 +73,6 @@ import spack.store
 from spack.environment import EnvironmentModifications, validate
 from spack.environment import preserve_environment
 from spack.util.environment import env_flag, filter_system_paths, get_path
-from spack.util.environment import system_dirs
 from spack.util.executable import Executable
 from spack.util.module_cmd import load_module, get_path_from_module
 from spack.util.log_parse import parse_log_events, make_log_context
@@ -100,7 +99,6 @@ SPACK_SHORT_SPEC = 'SPACK_SHORT_SPEC'
 SPACK_DEBUG_LOG_ID = 'SPACK_DEBUG_LOG_ID'
 SPACK_DEBUG_LOG_DIR = 'SPACK_DEBUG_LOG_DIR'
 SPACK_CCACHE_BINARY = 'SPACK_CCACHE_BINARY'
-SPACK_SYSTEM_DIRS = 'SPACK_SYSTEM_DIRS'
 
 
 # Platform-specific library suffix.
@@ -203,8 +201,6 @@ def set_compiler_environment_variables(pkg, env):
     pkg.flags_to_build_system_args(build_system_flags)
 
     env.set('SPACK_COMPILER_SPEC', str(pkg.spec.compiler))
-
-    env.set('SPACK_SYSTEM_DIRS', ' '.join(system_dirs))
 
     compiler.setup_custom_environment(pkg, env)
 

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -58,8 +58,6 @@ def build_environment():
     os.environ['SPACK_F77_RPATH_ARG'] = "-Wl,-rpath,"
     os.environ['SPACK_FC_RPATH_ARG']  = "-Wl,-rpath,"
 
-    os.environ['SPACK_SYSTEM_DIRS'] = '/usr/include /usr/lib'
-
     if 'SPACK_DEPENDENCIES' in os.environ:
         del os.environ['SPACK_DEPENDENCIES']
 
@@ -69,8 +67,7 @@ def build_environment():
                  'SPACK_ENV_PATH', 'SPACK_DEBUG_LOG_DIR',
                  'SPACK_COMPILER_SPEC', 'SPACK_SHORT_SPEC',
                  'SPACK_CC_RPATH_ARG', 'SPACK_CXX_RPATH_ARG',
-                 'SPACK_F77_RPATH_ARG', 'SPACK_FC_RPATH_ARG',
-                 'SPACK_SYSTEM_DIRS'):
+                 'SPACK_F77_RPATH_ARG', 'SPACK_FC_RPATH_ARG'):
         del os.environ[name]
 
 
@@ -99,8 +96,8 @@ def test_static_to_shared_library(build_environment):
                 shared_lib = '{0}.{1}'.format(
                     os.path.splitext(static_lib)[0], dso_suffix)
 
-            assert set(output.split()) == set(expected[arch].format(
-                static_lib, shared_lib, os.path.basename(shared_lib)).split())
+            assert output == expected[arch].format(
+                static_lib, shared_lib, os.path.basename(shared_lib))
 
 
 @pytest.mark.regression('8345')

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -166,71 +166,50 @@ class CompilerWrapperTest(unittest.TestCase):
 
         # Test ldflags added properly in ld mode
         self.check_ld('dump-args', test_command,
-                      'ld -L foo ' +
-                      '-I/test/include -I/other/include arg1 ' +
-                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
-                      '-Wl,--end-group ' +
-                      '-llib3 -llib4 arg5 arg6 ' +
-                      '-L/test/lib -L/other/lib ' +
-                      '-lfoo ' +
-                      '-rpath /first/rpath -rpath /second/rpath ' +
-                      '-rpath /third/rpath -rpath /fourth/rpath ' +
-                      '-rpath /spack-test-prefix/lib ' +
-                      '-rpath /spack-test-prefix/lib64')
+                      "ld " +
+                      '-rpath ' + self.prefix + '/lib ' +
+                      '-rpath ' + self.prefix + '/lib64 ' +
+                      '-L foo ' +
+                      ' '.join(test_command) + ' ' +
+                      '-lfoo')
 
         # Test cppflags added properly in cpp mode
         self.check_cpp('dump-args', test_command,
                        "cpp " +
                        '-g -O1 ' +
-                       '-I/test/include -I/other/include arg1 ' +
-                       '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
-                       '-Wl,--end-group ' +
-                       '-llib3 -llib4 arg5 arg6 ' +
-                       '-L/test/lib -L/other/lib')
+                       ' '.join(test_command))
 
         # Test ldflags, cppflags, and language specific flags are added in
         # proper order
         self.check_cc('dump-args', test_command,
                       self.realcc + ' ' +
-                      '-g -O1 -Wall -L foo ' +
-                      '-I/test/include -I/other/include arg1 ' +
-                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
-                      '-Wl,--end-group ' +
-                      '-llib3 -llib4 arg5 arg6 ' +
-                      '-L/test/lib -L/other/lib ' +
-                      '-lfoo ' +
-                      '-Wl,-rpath,/first/rpath -Wl,-rpath,/second/rpath ' +
-                      '-Wl,-rpath,/third/rpath -Wl,-rpath,/fourth/rpath ' +
-                      '-Wl,-rpath,/spack-test-prefix/lib ' +
-                      '-Wl,-rpath,/spack-test-prefix/lib64')
+                      '-Wl,-rpath,' + self.prefix + '/lib ' +
+                      '-Wl,-rpath,' + self.prefix + '/lib64 ' +
+                      '-g -O1 ' +
+                      '-Wall ' +
+                      '-L foo ' +
+                      ' '.join(test_command) + ' ' +
+                      '-lfoo')
 
         self.check_cxx('dump-args', test_command,
                        self.realcc + ' ' +
-                       '-g -O1 -Werror -L foo ' +
-                       '-I/test/include -I/other/include arg1 ' +
-                       '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
-                       '-Wl,--end-group ' +
-                       '-llib3 -llib4 arg5 arg6 ' +
-                       '-L/test/lib -L/other/lib ' +
-                       '-lfoo ' +
-                       '-Wl,-rpath,/first/rpath -Wl,-rpath,/second/rpath ' +
-                       '-Wl,-rpath,/third/rpath -Wl,-rpath,/fourth/rpath ' +
-                       '-Wl,-rpath,/spack-test-prefix/lib ' +
-                       '-Wl,-rpath,/spack-test-prefix/lib64')
+                       '-Wl,-rpath,' + self.prefix + '/lib ' +
+                       '-Wl,-rpath,' + self.prefix + '/lib64 ' +
+                       '-g -O1 ' +
+                       '-Werror ' +
+                       '-L foo ' +
+                       ' '.join(test_command) + ' ' +
+                       '-lfoo')
 
         self.check_fc('dump-args', test_command,
                       self.realcc + ' ' +
-                      '-w -g -O1 -L foo ' +
-                      '-I/test/include -I/other/include arg1 ' +
-                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
-                      '-Wl,--end-group ' +
-                      '-llib3 -llib4 arg5 arg6 ' +
-                      '-L/test/lib -L/other/lib ' +
-                      '-lfoo ' +
-                      '-Wl,-rpath,/first/rpath -Wl,-rpath,/second/rpath ' +
-                      '-Wl,-rpath,/third/rpath -Wl,-rpath,/fourth/rpath ' +
-                      '-Wl,-rpath,/spack-test-prefix/lib ' +
-                      '-Wl,-rpath,/spack-test-prefix/lib64')
+                      '-Wl,-rpath,' + self.prefix + '/lib ' +
+                      '-Wl,-rpath,' + self.prefix + '/lib64 ' +
+                      '-w ' +
+                      '-g -O1 ' +
+                      '-L foo ' +
+                      ' '.join(test_command) + ' ' +
+                      '-lfoo')
 
         del os.environ['SPACK_CFLAGS']
         del os.environ['SPACK_CXXFLAGS']
@@ -243,15 +222,9 @@ class CompilerWrapperTest(unittest.TestCase):
         """Ensure RPATHs for root package are added."""
         self.check_cc('dump-args', test_command,
                       self.realcc + ' ' +
-                      '-I/test/include -I/other/include arg1 ' +
-                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
-                      '-Wl,--end-group ' +
-                      '-llib3 -llib4 arg5 arg6 ' +
-                      '-L/test/lib -L/other/lib ' +
-                      '-Wl,-rpath,/first/rpath -Wl,-rpath,/second/rpath ' +
-                      '-Wl,-rpath,/third/rpath -Wl,-rpath,/fourth/rpath ' +
-                      '-Wl,-rpath,/spack-test-prefix/lib ' +
-                      '-Wl,-rpath,/spack-test-prefix/lib64')
+                      '-Wl,-rpath,' + self.prefix + '/lib ' +
+                      '-Wl,-rpath,' + self.prefix + '/lib64 ' +
+                      ' '.join(test_command))
 
     def test_dep_include(self):
         """Ensure a single dependency include directory is added."""
@@ -260,16 +233,10 @@ class CompilerWrapperTest(unittest.TestCase):
         os.environ['SPACK_LINK_DEPS'] = os.environ['SPACK_DEPENDENCIES']
         self.check_cc('dump-args', test_command,
                       self.realcc + ' ' +
-                      '-I/test/include -I/other/include ' +
-                      '-I' + self.dep4 + '/include arg1 ' +
-                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
-                      '-Wl,--end-group ' +
-                      '-llib3 -llib4 arg5 arg6 ' +
-                      '-L/test/lib -L/other/lib ' +
-                      '-Wl,-rpath,/first/rpath -Wl,-rpath,/second/rpath ' +
-                      '-Wl,-rpath,/third/rpath -Wl,-rpath,/fourth/rpath ' +
-                      '-Wl,-rpath,/spack-test-prefix/lib ' +
-                      '-Wl,-rpath,/spack-test-prefix/lib64')
+                      '-Wl,-rpath,' + self.prefix + '/lib ' +
+                      '-Wl,-rpath,' + self.prefix + '/lib64 ' +
+                      '-I' + self.dep4 + '/include ' +
+                      ' '.join(test_command))
 
     def test_dep_lib(self):
         """Ensure a single dependency RPATH is added."""
@@ -278,17 +245,11 @@ class CompilerWrapperTest(unittest.TestCase):
         os.environ['SPACK_LINK_DEPS'] = os.environ['SPACK_DEPENDENCIES']
         self.check_cc('dump-args', test_command,
                       self.realcc + ' ' +
-                      '-I/test/include -I/other/include arg1 ' +
-                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
-                      '-Wl,--end-group ' +
-                      '-llib3 -llib4 arg5 arg6 ' +
-                      '-L/test/lib -L/other/lib ' +
+                      '-Wl,-rpath,' + self.prefix + '/lib ' +
+                      '-Wl,-rpath,' + self.prefix + '/lib64 ' +
                       '-L' + self.dep2 + '/lib64 ' +
-                      '-Wl,-rpath,/first/rpath -Wl,-rpath,/second/rpath ' +
-                      '-Wl,-rpath,/third/rpath -Wl,-rpath,/fourth/rpath ' +
-                      '-Wl,-rpath,/spack-test-prefix/lib ' +
-                      '-Wl,-rpath,/spack-test-prefix/lib64 ' +
-                      '-Wl,-rpath,' + self.dep2 + '/lib64')
+                      '-Wl,-rpath,' + self.dep2 + '/lib64 ' +
+                      ' '.join(test_command))
 
     def test_dep_lib_no_rpath(self):
         """Ensure a single dependency link flag is added with no dep RPATH."""
@@ -296,16 +257,10 @@ class CompilerWrapperTest(unittest.TestCase):
         os.environ['SPACK_LINK_DEPS'] = os.environ['SPACK_DEPENDENCIES']
         self.check_cc('dump-args', test_command,
                       self.realcc + ' ' +
-                      '-I/test/include -I/other/include arg1 ' +
-                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
-                      '-Wl,--end-group ' +
-                      '-llib3 -llib4 arg5 arg6 ' +
-                      '-L/test/lib -L/other/lib ' +
+                      '-Wl,-rpath,' + self.prefix + '/lib ' +
+                      '-Wl,-rpath,' + self.prefix + '/lib64 ' +
                       '-L' + self.dep2 + '/lib64 ' +
-                      '-Wl,-rpath,/first/rpath -Wl,-rpath,/second/rpath ' +
-                      '-Wl,-rpath,/third/rpath -Wl,-rpath,/fourth/rpath ' +
-                      '-Wl,-rpath,/spack-test-prefix/lib ' +
-                      '-Wl,-rpath,/spack-test-prefix/lib64')
+                      ' '.join(test_command))
 
     def test_dep_lib_no_lib(self):
         """Ensure a single dependency RPATH is added with no -L."""
@@ -313,16 +268,10 @@ class CompilerWrapperTest(unittest.TestCase):
         os.environ['SPACK_RPATH_DEPS'] = os.environ['SPACK_DEPENDENCIES']
         self.check_cc('dump-args', test_command,
                       self.realcc + ' ' +
-                      '-I/test/include -I/other/include arg1 ' +
-                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
-                      '-Wl,--end-group ' +
-                      '-llib3 -llib4 arg5 arg6 ' +
-                      '-L/test/lib -L/other/lib ' +
-                      '-Wl,-rpath,/first/rpath -Wl,-rpath,/second/rpath ' +
-                      '-Wl,-rpath,/third/rpath -Wl,-rpath,/fourth/rpath ' +
-                      '-Wl,-rpath,/spack-test-prefix/lib ' +
-                      '-Wl,-rpath,/spack-test-prefix/lib64 ' +
-                      '-Wl,-rpath,' + self.dep2 + '/lib64')
+                      '-Wl,-rpath,' + self.prefix + '/lib ' +
+                      '-Wl,-rpath,' + self.prefix + '/lib64 ' +
+                      '-Wl,-rpath,' + self.dep2 + '/lib64 ' +
+                      ' '.join(test_command))
 
     def test_all_deps(self):
         """Ensure includes and RPATHs for all deps are added. """
@@ -336,25 +285,23 @@ class CompilerWrapperTest(unittest.TestCase):
         # to.  We could loosen that if it becomes necessary
         self.check_cc('dump-args', test_command,
                       self.realcc + ' ' +
-                      '-I/test/include -I/other/include ' +
-                      '-I' + self.dep1 + '/include ' +
-                      '-I' + self.dep3 + '/include ' +
+                      '-Wl,-rpath,' + self.prefix + '/lib ' +
+                      '-Wl,-rpath,' + self.prefix + '/lib64 ' +
+
                       '-I' + self.dep4 + '/include ' +
-                      'arg1 ' +
-                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
-                      '-Wl,--end-group ' +
-                      '-llib3 -llib4 arg5 arg6 ' +
-                      '-L/test/lib -L/other/lib ' +
-                      '-L' + self.dep1 + '/lib ' +
-                      '-L' + self.dep2 + '/lib64 ' +
+
                       '-L' + self.dep3 + '/lib64 ' +
-                      '-Wl,-rpath,/first/rpath -Wl,-rpath,/second/rpath ' +
-                      '-Wl,-rpath,/third/rpath -Wl,-rpath,/fourth/rpath ' +
-                      '-Wl,-rpath,/spack-test-prefix/lib ' +
-                      '-Wl,-rpath,/spack-test-prefix/lib64 ' +
-                      '-Wl,-rpath,' + self.dep1 + '/lib ' +
+                      '-Wl,-rpath,' + self.dep3 + '/lib64 ' +
+                      '-I' + self.dep3 + '/include ' +
+
+                      '-L' + self.dep2 + '/lib64 ' +
                       '-Wl,-rpath,' + self.dep2 + '/lib64 ' +
-                      '-Wl,-rpath,' + self.dep3 + '/lib64')
+
+                      '-L' + self.dep1 + '/lib ' +
+                      '-Wl,-rpath,' + self.dep1 + '/lib ' +
+                      '-I' + self.dep1 + '/include ' +
+
+                      ' '.join(test_command))
 
     def test_ld_deps(self):
         """Ensure no (extra) -I args or -Wl, are passed in ld mode."""
@@ -365,22 +312,19 @@ class CompilerWrapperTest(unittest.TestCase):
 
         self.check_ld('dump-args', test_command,
                       'ld ' +
-                      '-I/test/include -I/other/include ' +
-                      'arg1 ' +
-                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
-                      '-Wl,--end-group ' +
-                      '-llib3 -llib4 arg5 arg6 ' +
-                      '-L/test/lib -L/other/lib ' +
-                      '-L' + self.dep1 + '/lib ' +
-                      '-L' + self.dep2 + '/lib64 ' +
+                      '-rpath ' + self.prefix + '/lib ' +
+                      '-rpath ' + self.prefix + '/lib64 ' +
+
                       '-L' + self.dep3 + '/lib64 ' +
-                      '-rpath /first/rpath -rpath /second/rpath ' +
-                      '-rpath /third/rpath -rpath /fourth/rpath ' +
-                      '-rpath /spack-test-prefix/lib ' +
-                      '-rpath /spack-test-prefix/lib64 ' +
-                      '-rpath ' + self.dep1 + '/lib ' +
+                      '-rpath ' + self.dep3 + '/lib64 ' +
+
+                      '-L' + self.dep2 + '/lib64 ' +
                       '-rpath ' + self.dep2 + '/lib64 ' +
-                      '-rpath ' + self.dep3 + '/lib64')
+
+                      '-L' + self.dep1 + '/lib ' +
+                      '-rpath ' + self.dep1 + '/lib ' +
+
+                      ' '.join(test_command))
 
     def test_ld_deps_no_rpath(self):
         """Ensure SPACK_RPATH_DEPS controls RPATHs for ld."""
@@ -390,19 +334,14 @@ class CompilerWrapperTest(unittest.TestCase):
 
         self.check_ld('dump-args', test_command,
                       'ld ' +
-                      '-I/test/include -I/other/include ' +
-                      'arg1 ' +
-                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
-                      '-Wl,--end-group ' +
-                      '-llib3 -llib4 arg5 arg6 ' +
-                      '-L/test/lib -L/other/lib ' +
-                      '-L' + self.dep1 + '/lib ' +
-                      '-L' + self.dep2 + '/lib64 ' +
+                      '-rpath ' + self.prefix + '/lib ' +
+                      '-rpath ' + self.prefix + '/lib64 ' +
+
                       '-L' + self.dep3 + '/lib64 ' +
-                      '-rpath /first/rpath -rpath /second/rpath ' +
-                      '-rpath /third/rpath -rpath /fourth/rpath ' +
-                      '-rpath /spack-test-prefix/lib ' +
-                      '-rpath /spack-test-prefix/lib64')
+                      '-L' + self.dep2 + '/lib64 ' +
+                      '-L' + self.dep1 + '/lib ' +
+
+                      ' '.join(test_command))
 
     def test_ld_deps_no_link(self):
         """Ensure SPACK_LINK_DEPS controls -L for ld."""
@@ -412,19 +351,14 @@ class CompilerWrapperTest(unittest.TestCase):
 
         self.check_ld('dump-args', test_command,
                       'ld ' +
-                      '-I/test/include -I/other/include ' +
-                      'arg1 ' +
-                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
-                      '-Wl,--end-group ' +
-                      '-llib3 -llib4 arg5 arg6 ' +
-                      '-L/test/lib -L/other/lib ' +
-                      '-rpath /first/rpath -rpath /second/rpath ' +
-                      '-rpath /third/rpath -rpath /fourth/rpath ' +
-                      '-rpath /spack-test-prefix/lib ' +
-                      '-rpath /spack-test-prefix/lib64 ' +
-                      '-rpath ' + self.dep1 + '/lib ' +
+                      '-rpath ' + self.prefix + '/lib ' +
+                      '-rpath ' + self.prefix + '/lib64 ' +
+
+                      '-rpath ' + self.dep3 + '/lib64 ' +
                       '-rpath ' + self.dep2 + '/lib64 ' +
-                      '-rpath ' + self.dep3 + '/lib64')
+                      '-rpath ' + self.dep1 + '/lib ' +
+
+                      ' '.join(test_command))
 
     def test_ld_deps_reentrant(self):
         """Make sure ld -r is handled correctly on OS's where it doesn't
@@ -437,30 +371,18 @@ class CompilerWrapperTest(unittest.TestCase):
         reentrant_test_command = ['-r'] + test_command
         self.check_ld('dump-args', reentrant_test_command,
                       'ld ' +
-                      '-I/test/include -I/other/include ' +
-                      '-r arg1 ' +
-                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
-                      '-Wl,--end-group ' +
-                      '-llib3 -llib4 arg5 arg6 ' +
-                      '-L/test/lib -L/other/lib ' +
-                      '-L' + self.dep1 + '/lib ' +
-                      '-rpath /first/rpath -rpath /second/rpath ' +
-                      '-rpath /third/rpath -rpath /fourth/rpath ' +
-                      '-rpath /spack-test-prefix/lib ' +
-                      '-rpath /spack-test-prefix/lib64 ' +
-                      '-rpath ' + self.dep1 + '/lib')
+                      '-rpath ' + self.prefix + '/lib ' +
+                      '-rpath ' + self.prefix + '/lib64 ' +
 
-        # rpaths from the underlying command will still appear
-        # Spack will not add its own rpaths.
+                      '-L' + self.dep1 + '/lib ' +
+                      '-rpath ' + self.dep1 + '/lib ' +
+
+                      '-r ' +
+                      ' '.join(test_command))
+
         os.environ['SPACK_SHORT_SPEC'] = "foo@1.2=darwin-x86_64"
         self.check_ld('dump-args', reentrant_test_command,
                       'ld ' +
-                      '-I/test/include -I/other/include ' +
-                      '-r arg1 ' +
-                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
-                      '-Wl,--end-group ' +
-                      '-llib3 -llib4 arg5 arg6 ' +
-                      '-L/test/lib -L/other/lib ' +
                       '-L' + self.dep1 + '/lib ' +
-                      '-rpath /first/rpath -rpath /second/rpath ' +
-                      '-rpath /third/rpath -rpath /fourth/rpath')
+                      '-r ' +
+                      ' '.join(test_command))


### PR DESCRIPTION
Fixes #8882.
Fixes #8887.

Reverts spack/spack#4692 while @becker33 and I work on a fix.