### PR TITLE
cc: package flags before dependency flags, part 2

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -137,10 +137,12 @@ esac
 # libraries.
 if [[ -z $mode ]] || [[ $mode == ld ]]; then
     for arg in "$@"; do
-        if [[ $arg == -v || $arg == -V || $arg == --version || $arg == -dumpversion ]]; then
-            mode=vcheck
-            break
-        fi
+        case $arg in
+            -v|-V|--version|-dumpversion)
+                mode=vcheck
+                break
+                ;;
+        esac
     done
 fi
 
@@ -164,7 +166,7 @@ fi
 # Set up rpath variable according to language.
 eval rpath=\$SPACK_${comp}_RPATH_ARG
 
-# Dump the version and exit if we're in testing mode.
+# Dump the mode and exit if the command is dump-mode.
 if [[ $SPACK_TEST_COMMAND == dump-mode ]]; then
     echo "$mode"
     exit
@@ -218,9 +220,12 @@ fi
 # It doesn't work with -rpath.
 # This variable controls whether they are added.
 add_rpaths=true
-if [[ ($mode == ld || $mode == ccld) && "$SPACK_SHORT_SPEC" =~ "darwin" ]]; then
+if [[ ($mode == ld || $mode == ccld) && "$SPACK_SHORT_SPEC" =~ "darwin" ]];
+then
     for arg in "$@"; do
-        if [[ ($arg == -r && $mode == ld) || ($arg == -r && $mode == ccld) || ($arg == -Wl,-r && $mode == ccld) ]]; then
+        if [[ ($arg == -r && $mode == ld) ||
+              ($arg == -r && $mode == ccld) ||
+              ($arg == -Wl,-r && $mode == ccld) ]]; then
             add_rpaths=false
             break
         fi
@@ -232,16 +237,21 @@ input_command="$@"
 args=()
 
 #
-# Parse the command line args, trying hard to keep
-# non-rpath linker arguments in the proper order w.r.t. other command
-# line arguments.  This is important for things like groups.
+# Parse the command line arguments.
 #
-# -l arguments are treated as 'other_args' to ensure that they stay in
-# any groups they are a part of. Dependency library -l statements are
-# categorized as 'libs'
+# We extract -L, -I, and -Wl,-rpath arguments from the command line and
+# recombine them with Spack arguments later.  We parse these out so that
+# we can make sure that system paths come last, that package arguments
+# come first, and that Spack arguments are injected properly.
 #
-# The various categories will be recombined with compiler flags into 
-# args variable later.
+# All other arguments, including -l arguments, are treated as
+# 'other_args' and left in their original order.  This ensures that
+# --start-group, --end-group, and other order-sensitive flags continue to
+# work as the caller expects.
+#
+# The libs variable is initialized here for completeness, and it is also
+# used later to inject flags supplied via `ldlibs` on the command
+# line. These come into the wrappers via SPACK_LDLIBS.
 #
 includes=()
 libdirs=()
@@ -271,8 +281,8 @@ while [ -n "$1" ]; do
             if [ -z "$arg" ]; then shift; arg="$1"; fi
             if [[ "$arg" = -rpath=* ]]; then
                 rpaths+=("${arg#-rpath=}")
-	    elif [[ "$arg" = -rpath,* ]]; then
-		rpaths+=("${arg#-rpath,}")
+            elif [[ "$arg" = -rpath,* ]]; then
+                rpaths+=("${arg#-rpath,}")
             elif [[ "$arg" = -rpath ]]; then
                 shift; arg="$1"
                 if [[ "$arg" != -Wl,* ]]; then
@@ -300,11 +310,11 @@ while [ -n "$1" ]; do
             ;;
         -Xlinker)
             if [[ "$2" == "-rpath" ]]; then
-		if [[ "$3" != "-Xlinker" ]]; then
+                if [[ "$3" != "-Xlinker" ]]; then
                     die "-Xlinker,-rpath was not followed by -Xlinker,*"
-		fi
-		shift 3;
-		rpaths+=("$1")
+                fi
+                shift 3;
+                rpaths+=("$1")
             else
                 other_args+=("$1")
             fi
@@ -316,7 +326,10 @@ while [ -n "$1" ]; do
     shift
 done
 
-# Prepend cppflags, cflags, cxxflags, fcflags, fflags, and ldflags
+#
+# Prepend flags from Spack's cppflags, cflags, cxxflags, fcflags, fflags,
+# and ldflags.
+#
 
 # Add ldflags
 case "$mode" in
@@ -324,15 +337,16 @@ case "$mode" in
         args=(${SPACK_LDFLAGS[@]} "${args[@]}") ;;
 esac
 
-# Add compiler flags.
+# Add C, C++, and Fortran flags
 case "$mode" in
     cc|ccld)
-    # Add c, cxx, fc, and f flags
         case $lang_flags in
             C)
                 args=(${SPACK_CFLAGS[@]} "${args[@]}") ;;
             CXX)
                 args=(${SPACK_CXXFLAGS[@]} "${args[@]}") ;;
+            F)
+                args=(${SPACK_FFLAGS[@]} "${args[@]}") ;;
         esac
         ;;
 esac
@@ -343,63 +357,64 @@ case "$mode" in
         args=(${SPACK_CPPFLAGS[@]} "${args[@]}") ;;
 esac
 
-case "$mode" in cc|ccld)
-        # Add fortran flags
-        case $lang_flags in
-            F)
-                args=(${SPACK_FFLAGS[@]} "${args[@]}") ;;
-        esac
+# Include all -L's and prefix/whatever dirs in rpath
+case "$mode" in
+    ld|ccld)
+        $add_rpaths && rpaths+=("$SPACK_PREFIX/lib")
+        $add_rpaths && rpaths+=("$SPACK_PREFIX/lib64")
         ;;
 esac
-
-# Include all -L's and prefix/whatever dirs in rpath
-$add_rpaths && rpaths+=("$SPACK_PREFIX/lib")
-$add_rpaths && rpaths+=("$SPACK_PREFIX/lib64")
 
 # Read spack dependencies from the path environment variable
 IFS=':' read -ra deps <<< "$SPACK_DEPENDENCIES"
 for dep in "${deps[@]}"; do
     # Append include directories
-    if [[ -d $dep/include ]]; then
-        if [[ $mode == cpp || $mode == cc || $mode == as || $mode == ccld ]]; then
-            includes=("${includes[@]}" "$dep/include")
-        fi
-    fi
+    case "$mode" in
+        cpp|cc|as|ccld)
+            if [[ -d $dep/include ]]; then
+                includes=("${includes[@]}" "$dep/include")
+            fi
+            ;;
+    esac
 
-    # Append lib and RPATH directories
-    if [[ -d $dep/lib ]]; then
-        if [[ $SPACK_RPATH_DEPS == *$dep* ]]; then
-            $add_rpaths && rpaths=("${rpaths[@]}" "$dep/lib")
-        fi
-        if [[ $SPACK_LINK_DEPS == *$dep* ]]; then
-            libdirs=("${libdirs[@]}" "$dep/lib")
-        fi
-    fi
+    # Append lib/lib64 and RPATH directories
+    case "$mode" in
+        ld|ccld)
+            if [[ -d $dep/lib ]]; then
+                if [[ $SPACK_RPATH_DEPS == *$dep* ]]; then
+                    $add_rpaths && rpaths=("${rpaths[@]}" "$dep/lib")
+                fi
+                if [[ $SPACK_LINK_DEPS == *$dep* ]]; then
+                    libdirs=("${libdirs[@]}" "$dep/lib")
+                fi
+            fi
 
-    # Append lib64 and RPATH directories
-    if [[ -d $dep/lib64 ]]; then
-        if [[ $SPACK_RPATH_DEPS == *$dep* ]]; then
-            $add_rpaths && rpaths+=("$dep/lib64")
-        fi
-        if [[ $SPACK_LINK_DEPS == *$dep* ]]; then
-            libdirs+=("$dep/lib64")
-        fi
-    fi
+            if [[ -d $dep/lib64 ]]; then
+                if [[ $SPACK_RPATH_DEPS == *$dep* ]]; then
+                    $add_rpaths && rpaths+=("$dep/lib64")
+                fi
+                if [[ $SPACK_LINK_DEPS == *$dep* ]]; then
+                    libdirs+=("$dep/lib64")
+                fi
+            fi
+            ;;
+    esac
 done
 
-# Set extra RPATHs
-IFS=':' read -ra extra_rpaths <<< "$SPACK_COMPILER_EXTRA_RPATHS"
-for extra_rpath in "${extra_rpaths[@]}"; do 
-    $add_rpaths && rpaths+=("$extra_rpath")
-    libdirs+=("$extra_rpath")
-done
-
-# Add SPACK_LDLIBS to args
 case "$mode" in
     ld|ccld)
-	for lib in ${SPACK_LDLIBS[@]}; do
-	    libs+=("${lib#-l}")
-	done
+        # Set extra RPATHs
+        IFS=':' read -ra extra_rpaths <<< "$SPACK_COMPILER_EXTRA_RPATHS"
+        for extra_rpath in "${extra_rpaths[@]}"; do
+            $add_rpaths && rpaths+=("$extra_rpath")
+            libdirs+=("$extra_rpath")
+        done
+
+        # Add SPACK_LDLIBS to args
+        for lib in ${SPACK_LDLIBS[@]}; do
+            libs+=("${lib#-l}")
+        done
+        ;;
 esac
 
 # Filter system locations to the end of each sublist of args
@@ -409,23 +424,28 @@ for sd in ${SPACK_SYSTEM_DIRS[@]}; do
     stripped_libdirs=`echo $libdirs | sed "s#\b$sd/\? \b##g"`
     stripped_rpaths=`echo $rpaths | sed "s#\b$sd/\? \b##g"`
     if [[ "$includes" != "$stripped_includes" ]]; then
-	$includes="$stripped_includes $sd"
+        $includes="$stripped_includes $sd"
     fi
     if [[ "$libdirs" != "$stripped_libdirs" ]]; then
-	$libdirs="$stripped_libdirs $sd"
+        $libdirs="$stripped_libdirs $sd"
     fi
     if [[ "$rpaths" != "$stripped_rpaths" ]]; then
-	$rpaths="$stripped_rpaths $sd"
+        $rpaths="$stripped_rpaths $sd"
     fi
 done
 
-# Put the arguments together into one list
-# Includes come first, then other args, library dirs, and rpaths
-# rpaths get appropriate flag for ld vs ccld mode
-for dir in "${includes[@]}";  do args+=("-I$dir"); done
-args+=("${other_args[@]}")
-for dir in "${libdirs[@]}"; do args+=("-L$dir"); done
-for lib in "${libs[@]}"; do args+=("-l$lib"); done
+# Put the arguments back together in one list
+# Includes first
+for dir in "${includes[@]}";  do
+    args+=("-I$dir");
+done
+
+# Library search paths
+for dir in "${libdirs[@]}"; do
+    args+=("-L$dir");
+done
+
+# RPATHs arguments
 if [ "$mode" = ccld ]; then
     for dir in "${rpaths[@]}"; do
         args+=("$rpath$dir")
@@ -436,10 +456,18 @@ elif [ "$mode" = ld ]; then
     done
 fi
 
+# Other arguments from the input command
+args+=("${other_args[@]}")
+
+# Inject SPACK_LDLIBS, if supplied
+for lib in "${libs[@]}"; do
+    args+=("-l$lib");
+done
+
 full_command=("$command")
 full_command+=("${args[@]}")
 
-# In test command mode, write out full command for Spack tests.
+# dump the full command if the caller supplies SPACK_TEST_COMMAND=dump-args
 if [[ $SPACK_TEST_COMMAND == dump-args ]]; then
     echo "${full_command[@]}"
     exit
@@ -457,4 +485,4 @@ if [[ $SPACK_DEBUG == TRUE ]]; then
     echo "[$mode] ${full_command[@]}" >> "$output_log"
 fi
 
-exec "${full_command[@]}" 
+exec "${full_command[@]}"

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -74,11 +74,14 @@ function die {
     exit 1
 }
 
+# read system directories into an array (delimited by :)
+IFS=':' read -ra SPACK_SYSTEM_DIRS <<< "${SPACK_SYSTEM_DIRS}"
+
 # test whether a path is a system directory
 function system_dir {
     path="$1"
     for sd in ${SPACK_SYSTEM_DIRS[@]}; do
-        if [ "${path}" == "${sd}" -o "${path}" == "${sd}/" ]; then
+        if [ "${path}" == "${sd}" ] || [ "${path}" == "${sd}/" ]; then
             # success if path starts with a system prefix
             return 0
         fi
@@ -130,7 +133,7 @@ case "$command" in
         comp="FC"
         lang_flags=F
         ;;
-    f77|gfortran|flang|ifort|pgfortran|xlf|xlf_r|nagfor|ftn)
+    f77|xlf|xlf_r|pgf77)
         command="$SPACK_F77"
         language="Fortran 77"
         comp="F77"
@@ -198,8 +201,8 @@ fi
 IFS=':' read -ra env_set_varnames <<< "$SPACK_ENV_TO_SET"
 for varname in "${env_set_varnames[@]}"; do
     spack_varname="SPACK_ENV_SET_$varname"
-    export $varname=${!spack_varname}
-    unset $spack_varname
+    export "$varname"="${!spack_varname}"
+    unset "$spack_varname"
 done
 
 #
@@ -209,23 +212,22 @@ done
 IFS=':' read -ra env_path <<< "$PATH"
 IFS=':' read -ra spack_env_dirs <<< "$SPACK_ENV_PATH"
 spack_env_dirs+=("" ".")
-PATH=""
+export PATH=""
 for dir in "${env_path[@]}"; do
     addpath=true
     for env_dir in "${spack_env_dirs[@]}"; do
-        if [[ $dir == $env_dir ]]; then
+        if [[ "$dir" == "$env_dir" ]]; then
             addpath=false
             break
         fi
     done
     if $addpath; then
-        PATH="${PATH:+$PATH:}$dir"
+        export PATH="${PATH:+$PATH:}$dir"
     fi
 done
-export PATH
 
 if [[ $mode == vcheck ]]; then
-    exec ${command} "$@"
+    exec "${command}" "$@"
 fi
 
 # Darwin's linker has a -r argument that merges object files together.
@@ -245,7 +247,7 @@ then
 fi
 
 # Save original command for debug logging
-input_command="$@"
+input_command="$*"
 args=()
 
 #
@@ -497,7 +499,7 @@ if [[ $SPACK_DEBUG == TRUE ]]; then
     input_log="$SPACK_DEBUG_LOG_DIR/spack-cc-$SPACK_DEBUG_LOG_ID.in.log"
     output_log="$SPACK_DEBUG_LOG_DIR/spack-cc-$SPACK_DEBUG_LOG_ID.out.log"
     echo "[$mode] $command $input_command" >> "$input_log"
-    echo "[$mode] ${full_command[@]}" >> "$output_log"
+    echo "[$mode] ${full_command[*]}" >> "$output_log"
 fi
 
 exec "${full_command[@]}"

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -74,6 +74,18 @@ function die {
     exit 1
 }
 
+# test whether a path is a system directory
+function system_dir {
+    path="$1"
+    for sd in ${SPACK_SYSTEM_DIRS[@]}; do
+        if [ "${path}" == "${sd}" -o "${path}" == "${sd}/" ]; then
+            # success if path starts with a system prefix
+            return 0
+        fi
+    done
+    return 1  # fail if path starts no system prefix
+}
+
 for param in ${parameters[@]}; do
     if [[ -z ${!param} ]]; then
         die "Spack compiler must be run from Spack! Input '$param' is missing."
@@ -255,21 +267,33 @@ args=()
 #
 includes=()
 libdirs=()
-libs=()
 rpaths=()
+system_includes=()
+system_libdirs=()
+system_rpaths=()
+libs=()
 other_args=()
 
 while [ -n "$1" ]; do
+    rp=""
     case "$1" in
         -I*)
             arg="${1#-I}"
             if [ -z "$arg" ]; then shift; arg="$1"; fi
-            includes+=("$arg")
+            if system_dir "$arg"; then
+                system_includes+=("$arg")
+            else
+                includes+=("$arg")
+            fi
             ;;
         -L*)
             arg="${1#-L}"
             if [ -z "$arg" ]; then shift; arg="$1"; fi
-            libdirs+=("$arg")
+            if system_dir "$arg"; then
+                system_libdirs+=("$arg")
+            else
+                libdirs+=("$arg")
+            fi
             ;;
         -l*)
             arg="${1#-l}"
@@ -280,15 +304,15 @@ while [ -n "$1" ]; do
             arg="${1#-Wl,}"
             if [ -z "$arg" ]; then shift; arg="$1"; fi
             if [[ "$arg" = -rpath=* ]]; then
-                rpaths+=("${arg#-rpath=}")
+                rp="${arg#-rpath=}"
             elif [[ "$arg" = -rpath,* ]]; then
-                rpaths+=("${arg#-rpath,}")
+                rp="${arg#-rpath,}"
             elif [[ "$arg" = -rpath ]]; then
                 shift; arg="$1"
                 if [[ "$arg" != -Wl,* ]]; then
                     die "-Wl,-rpath was not followed by -Wl,*"
                 fi
-                rpaths+=("${arg#-Wl,}")
+                rp="${arg#-Wl,}"
             else
                 other_args+=("-Wl,$arg")
             fi
@@ -297,13 +321,13 @@ while [ -n "$1" ]; do
             arg="${1#-Xlinker,}"
             if [ -z "$arg" ]; then shift; arg="$1"; fi
             if [[ "$arg" = -rpath=* ]]; then
-                rpaths+=("${arg#-rpath=}")
+                rp="${arg#-rpath=}"
             elif [[ "$arg" = -rpath ]]; then
                 shift; arg="$1"
                 if [[ "$arg" != -Xlinker,* ]]; then
                     die "-Xlinker,-rpath was not followed by -Xlinker,*"
                 fi
-                rpaths+=("${arg#-Xlinker,}")
+                rp="${arg#-Xlinker,}"
             else
                 other_args+=("-Xlinker,$arg")
             fi
@@ -314,7 +338,7 @@ while [ -n "$1" ]; do
                     die "-Xlinker,-rpath was not followed by -Xlinker,*"
                 fi
                 shift 3;
-                rpaths+=("$1")
+                rp="$1"
             else
                 other_args+=("$1")
             fi
@@ -323,6 +347,15 @@ while [ -n "$1" ]; do
             other_args+=("$1")
             ;;
     esac
+
+    # test rpaths against system directories in one place.
+    if [ -n "$rp" ]; then
+        if system_dir "$rp"; then
+            system_rpaths+=("$rp")
+        else
+            rpaths+=("$rp")
+        fi
+    fi
     shift
 done
 
@@ -417,44 +450,26 @@ case "$mode" in
         ;;
 esac
 
-# Filter system locations to the end of each sublist of args
-# (includes, library dirs, rpaths)
-for sd in ${SPACK_SYSTEM_DIRS[@]}; do
-    stripped_includes=`echo $includes | sed "s#\b$sd/\? \b##g"`
-    stripped_libdirs=`echo $libdirs | sed "s#\b$sd/\? \b##g"`
-    stripped_rpaths=`echo $rpaths | sed "s#\b$sd/\? \b##g"`
-    if [[ "$includes" != "$stripped_includes" ]]; then
-        $includes="$stripped_includes $sd"
-    fi
-    if [[ "$libdirs" != "$stripped_libdirs" ]]; then
-        $libdirs="$stripped_libdirs $sd"
-    fi
-    if [[ "$rpaths" != "$stripped_rpaths" ]]; then
-        $rpaths="$stripped_rpaths $sd"
-    fi
-done
-
 # Put the arguments back together in one list
-# Includes first
-for dir in "${includes[@]}";  do
-    args+=("-I$dir");
-done
+# Includes and system includes first
+for dir in "${includes[@]}";         do args+=("-I$dir"); done
+for dir in "${system_includes[@]}";  do args+=("-I$dir"); done
 
 # Library search paths
-for dir in "${libdirs[@]}"; do
-    args+=("-L$dir");
-done
+for dir in "${libdirs[@]}";          do args+=("-L$dir"); done
+for dir in "${system_libdirs[@]}";   do args+=("-L$dir"); done
 
 # RPATHs arguments
-if [ "$mode" = ccld ]; then
-    for dir in "${rpaths[@]}"; do
-        args+=("$rpath$dir")
-    done
-elif [ "$mode" = ld ]; then
-    for dir in "${rpaths[@]}"; do
-        args+=("-rpath" "$dir")
-    done
-fi
+case "$mode" in
+    ccld)
+        for dir in "${rpaths[@]}";        do args+=("$rpath$dir"); done
+        for dir in "${system_rpaths[@]}"; do args+=("$rpath$dir"); done
+        ;;
+    ld)
+        for dir in "${rpaths[@]}";        do args+=("-rpath" "$dir"); done
+        for dir in "${system_rpaths[@]}"; do args+=("-rpath" "$dir"); done
+        ;;
+esac
 
 # Other arguments from the input command
 args+=("${other_args[@]}")

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -80,7 +80,7 @@ IFS=':' read -ra SPACK_SYSTEM_DIRS <<< "${SPACK_SYSTEM_DIRS}"
 # test whether a path is a system directory
 function system_dir {
     path="$1"
-    for sd in ${SPACK_SYSTEM_DIRS[@]}; do
+    for sd in "${SPACK_SYSTEM_DIRS[@]}"; do
         if [ "${path}" == "${sd}" ] || [ "${path}" == "${sd}/" ]; then
             # success if path starts with a system prefix
             return 0
@@ -89,7 +89,7 @@ function system_dir {
     return 1  # fail if path starts no system prefix
 }
 
-for param in ${parameters[@]}; do
+for param in "${parameters[@]}"; do
     if [[ -z ${!param} ]]; then
         die "Spack compiler must be run from Spack! Input '$param' is missing."
     fi
@@ -248,7 +248,6 @@ fi
 
 # Save original command for debug logging
 input_command="$*"
-args=()
 
 #
 # Parse the command line arguments.
@@ -277,7 +276,9 @@ libs=()
 other_args=()
 
 while [ -n "$1" ]; do
+    # an RPATH to be added after the case statement.
     rp=""
+
     case "$1" in
         -I*)
             arg="${1#-I}"
@@ -362,37 +363,53 @@ while [ -n "$1" ]; do
 done
 
 #
-# Prepend flags from Spack's cppflags, cflags, cxxflags, fcflags, fflags,
-# and ldflags.
+# Add flags from Spack's cppflags, cflags, cxxflags, fcflags, fflags, and
+# ldflags. We stick to the order that gmake puts the flags in by default.
 #
+# See the gmake manual on implicit rules for details:
+# https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html
+#
+flags=()
 
-# Add ldflags
-case "$mode" in
-    ld|ccld)
-        args=(${SPACK_LDFLAGS[@]} "${args[@]}") ;;
-esac
-
-# Add C, C++, and Fortran flags
+# Fortran flags come before CPPFLAGS
 case "$mode" in
     cc|ccld)
         case $lang_flags in
-            C)
-                args=(${SPACK_CFLAGS[@]} "${args[@]}") ;;
-            CXX)
-                args=(${SPACK_CXXFLAGS[@]} "${args[@]}") ;;
             F)
-                args=(${SPACK_FFLAGS[@]} "${args[@]}") ;;
+                flags=("${flags[@]}" "${SPACK_FFLAGS[@]}") ;;
         esac
         ;;
 esac
 
-# Add cppflags
+# C preprocessor flags come before any C/CXX flags
 case "$mode" in
     cpp|as|cc|ccld)
-        args=(${SPACK_CPPFLAGS[@]} "${args[@]}") ;;
+        flags=("${flags[@]}" "${SPACK_CPPFLAGS[@]}") ;;
 esac
 
-# Include all -L's and prefix/whatever dirs in rpath
+
+# Add C and C++ flags
+case "$mode" in
+    cc|ccld)
+        case $lang_flags in
+            C)
+                flags=("${flags[@]}" "${SPACK_CFLAGS[@]}") ;;
+            CXX)
+                flags=("${flags[@]}" "${SPACK_CXXFLAGS[@]}") ;;
+        esac
+        ;;
+esac
+
+# Linker flags
+case "$mode" in
+    ld|ccld)
+        flags=("${flags[@]}" "${SPACK_LDFLAGS[@]}") ;;
+esac
+
+
+# Include the package's prefix/lib[64] dirs in rpath. We don't know until
+# *after* installation which one's correct, so we include both lib and
+# lib64, assuming that only one will be present.
 case "$mode" in
     ld|ccld)
         $add_rpaths && rpaths+=("$SPACK_PREFIX/lib")
@@ -400,10 +417,10 @@ case "$mode" in
         ;;
 esac
 
-# Read spack dependencies from the path environment variable
+# Read spack dependencies from the environment. This is a list of prefixes.
 IFS=':' read -ra deps <<< "$SPACK_DEPENDENCIES"
 for dep in "${deps[@]}"; do
-    # Append include directories
+    # Append include directories in any compilation mode
     case "$mode" in
         cpp|cc|as|ccld)
             if [[ -d $dep/include ]]; then
@@ -412,7 +429,7 @@ for dep in "${deps[@]}"; do
             ;;
     esac
 
-    # Append lib/lib64 and RPATH directories
+    # Append lib/lib64 and RPATH directories, but only if we're linking
     case "$mode" in
         ld|ccld)
             if [[ -d $dep/lib ]]; then
@@ -436,6 +453,7 @@ for dep in "${deps[@]}"; do
     esac
 done
 
+# add RPATHs if we're in in any linking mode
 case "$mode" in
     ld|ccld)
         # Set extra RPATHs
@@ -446,14 +464,23 @@ case "$mode" in
         done
 
         # Add SPACK_LDLIBS to args
-        for lib in ${SPACK_LDLIBS[@]}; do
+        for lib in "${SPACK_LDLIBS[@]}"; do
             libs+=("${lib#-l}")
         done
         ;;
 esac
 
-# Put the arguments back together in one list
+#
+# Finally, reassemble the command line.
+#
+
 # Includes and system includes first
+args=()
+
+# flags assembled earlier
+args+=("${flags[@]}")
+
+# include directory search paths
 for dir in "${includes[@]}";         do args+=("-I$dir"); done
 for dir in "${system_includes[@]}";  do args+=("-I$dir"); done
 

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -481,8 +481,19 @@ for lib in "${libs[@]}"; do
     args+=("-l$lib");
 done
 
-full_command=("$command")
-full_command+=("${args[@]}")
+full_command=("$command" "${args[@]}")
+
+# prepend the ccache binary if we're using ccache
+if [ -n "$SPACK_CCACHE_BINARY" ]; then
+    case "$lang_flags" in
+        C|CXX)  # ccache only supports C languages
+            full_command=("${SPACK_CCACHE_BINARY}" "${full_command[@]}")
+            # workaround for stage being a temp folder
+            # see #3761#issuecomment-294352232
+            export CCACHE_NOHASHDIR=yes
+            ;;
+    esac
+fi
 
 # dump the full command if the caller supplies SPACK_TEST_COMMAND=dump-args
 if [[ $SPACK_TEST_COMMAND == dump-args ]]; then

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -52,6 +52,7 @@ parameters=(
     SPACK_F77_RPATH_ARG
     SPACK_FC_RPATH_ARG
     SPACK_SHORT_SPEC
+    SPACK_SYSTEM_DIRS
 )
 
 # The compiler input variables are checked for sanity later:
@@ -228,7 +229,92 @@ fi
 
 # Save original command for debug logging
 input_command="$@"
-args=("$@")
+args=()
+
+#
+# Parse the command line args, trying hard to keep
+# non-rpath linker arguments in the proper order w.r.t. other command
+# line arguments.  This is important for things like groups.
+#
+# -l arguments are treated as 'other_args' to ensure that they stay in
+# any groups they are a part of. Dependency library -l statements are
+# categorized as 'libs'
+#
+# The various categories will be recombined with compiler flags into 
+# args variable later.
+#
+includes=()
+libdirs=()
+libs=()
+rpaths=()
+other_args=()
+
+while [ -n "$1" ]; do
+    case "$1" in
+        -I*)
+            arg="${1#-I}"
+            if [ -z "$arg" ]; then shift; arg="$1"; fi
+            includes+=("$arg")
+            ;;
+        -L*)
+            arg="${1#-L}"
+            if [ -z "$arg" ]; then shift; arg="$1"; fi
+            libdirs+=("$arg")
+            ;;
+        -l*)
+            arg="${1#-l}"
+            if [ -z "$arg" ]; then shift; arg="$1"; fi
+            other_args+=("-l$arg")
+            ;;
+        -Wl,*)
+            arg="${1#-Wl,}"
+            if [ -z "$arg" ]; then shift; arg="$1"; fi
+            if [[ "$arg" = -rpath=* ]]; then
+                rpaths+=("${arg#-rpath=}")
+	    elif [[ "$arg" = -rpath,* ]]; then
+		rpaths+=("${arg#-rpath,}")
+            elif [[ "$arg" = -rpath ]]; then
+                shift; arg="$1"
+                if [[ "$arg" != -Wl,* ]]; then
+                    die "-Wl,-rpath was not followed by -Wl,*"
+                fi
+                rpaths+=("${arg#-Wl,}")
+            else
+                other_args+=("-Wl,$arg")
+            fi
+            ;;
+        -Xlinker,*)
+            arg="${1#-Xlinker,}"
+            if [ -z "$arg" ]; then shift; arg="$1"; fi
+            if [[ "$arg" = -rpath=* ]]; then
+                rpaths+=("${arg#-rpath=}")
+            elif [[ "$arg" = -rpath ]]; then
+                shift; arg="$1"
+                if [[ "$arg" != -Xlinker,* ]]; then
+                    die "-Xlinker,-rpath was not followed by -Xlinker,*"
+                fi
+                rpaths+=("${arg#-Xlinker,}")
+            else
+                other_args+=("-Xlinker,$arg")
+            fi
+            ;;
+        -Xlinker)
+            if [[ "$2" == "-rpath" ]]; then
+		if [[ "$3" != "-Xlinker" ]]; then
+                    die "-Xlinker,-rpath was not followed by -Xlinker,*"
+		fi
+		shift 3;
+		rpaths+=("$1")
+            else
+                other_args+=("$1")
+            fi
+            ;;
+        *)
+            other_args+=("$1")
+            ;;
+    esac
+    shift
+done
 
 # Prepend cppflags, cflags, cxxflags, fcflags, fflags, and ldflags
 
@@ -266,91 +352,92 @@ case "$mode" in cc|ccld)
         ;;
 esac
 
+# Include all -L's and prefix/whatever dirs in rpath
+$add_rpaths && rpaths+=("$SPACK_PREFIX/lib")
+$add_rpaths && rpaths+=("$SPACK_PREFIX/lib64")
+
 # Read spack dependencies from the path environment variable
 IFS=':' read -ra deps <<< "$SPACK_DEPENDENCIES"
 for dep in "${deps[@]}"; do
-    # Prepend include directories
+    # Append include directories
     if [[ -d $dep/include ]]; then
         if [[ $mode == cpp || $mode == cc || $mode == as || $mode == ccld ]]; then
-            args=("-I$dep/include" "${args[@]}")
+            includes=("${includes[@]}" "$dep/include")
         fi
     fi
 
-    # Prepend lib and RPATH directories
+    # Append lib and RPATH directories
     if [[ -d $dep/lib ]]; then
-        if [[ $mode == ccld ]]; then
-            if [[ $SPACK_RPATH_DEPS == *$dep* ]]; then
-                $add_rpaths && args=("$rpath$dep/lib" "${args[@]}")
-            fi
-            if [[ $SPACK_LINK_DEPS == *$dep* ]]; then
-                args=("-L$dep/lib" "${args[@]}")
-            fi
-        elif [[ $mode == ld ]]; then
-            if [[ $SPACK_RPATH_DEPS == *$dep* ]]; then
-                $add_rpaths && args=("-rpath" "$dep/lib" "${args[@]}")
-            fi
-            if [[ $SPACK_LINK_DEPS == *$dep* ]]; then
-                args=("-L$dep/lib" "${args[@]}")
-            fi
+        if [[ $SPACK_RPATH_DEPS == *$dep* ]]; then
+            $add_rpaths && rpaths=("${rpaths[@]}" "$dep/lib")
+        fi
+        if [[ $SPACK_LINK_DEPS == *$dep* ]]; then
+            libdirs=("${libdirs[@]}" "$dep/lib")
         fi
     fi
 
-    # Prepend lib64 and RPATH directories
+    # Append lib64 and RPATH directories
     if [[ -d $dep/lib64 ]]; then
-        if [[ $mode == ccld ]]; then
-            if [[ $SPACK_RPATH_DEPS == *$dep* ]]; then
-                $add_rpaths && args=("$rpath$dep/lib64" "${args[@]}")
-            fi
-            if [[ $SPACK_LINK_DEPS == *$dep* ]]; then
-                args=("-L$dep/lib64" "${args[@]}")
-            fi
-        elif [[ $mode == ld ]]; then
-            if [[ $SPACK_RPATH_DEPS == *$dep* ]]; then
-                $add_rpaths && args=("-rpath" "$dep/lib64" "${args[@]}")
-            fi
-            if [[ $SPACK_LINK_DEPS == *$dep* ]]; then
-                args=("-L$dep/lib64" "${args[@]}")
-            fi
+        if [[ $SPACK_RPATH_DEPS == *$dep* ]]; then
+            $add_rpaths && rpaths+=("$dep/lib64")
+        fi
+        if [[ $SPACK_LINK_DEPS == *$dep* ]]; then
+            libdirs+=("$dep/lib64")
         fi
     fi
 done
 
-# Include all -L's and prefix/whatever dirs in rpath
-if [[ $mode == ccld ]]; then
-    $add_rpaths && args=("$rpath$SPACK_PREFIX/lib64" "${args[@]}")
-    $add_rpaths && args=("$rpath$SPACK_PREFIX/lib"   "${args[@]}")
-elif [[ $mode == ld ]]; then
-    $add_rpaths && args=("-rpath" "$SPACK_PREFIX/lib64" "${args[@]}")
-    $add_rpaths && args=("-rpath" "$SPACK_PREFIX/lib"   "${args[@]}")
-fi
-
 # Set extra RPATHs
 IFS=':' read -ra extra_rpaths <<< "$SPACK_COMPILER_EXTRA_RPATHS"
-for extra_rpath in "${extra_rpaths[@]}"; do
-    if [[ $mode == ccld ]]; then
-        $add_rpaths && args=("$rpath$extra_rpath" "${args[@]}")
-        args=("-L$extra_rpath" "${args[@]}")
-    elif [[ $mode == ld ]]; then
-        $add_rpaths && args=("-rpath" "$extra_rpath" "${args[@]}")
-        args=("-L$extra_rpath" "${args[@]}")
-    fi
+for extra_rpath in "${extra_rpaths[@]}"; do 
+    $add_rpaths && rpaths+=("$extra_rpath")
+    libdirs+=("$extra_rpath")
 done
 
 # Add SPACK_LDLIBS to args
 case "$mode" in
     ld|ccld)
-        args=("${args[@]}" ${SPACK_LDLIBS[@]}) ;;
+	for lib in ${SPACK_LDLIBS[@]}; do
+	    libs+=("${lib#-l}")
+	done
 esac
 
-#ccache only supports C languages, so filtering out Fortran
-if [[ ( ${lang_flags} = "C" || ${lang_flags} = "CXX" ) && ${SPACK_CCACHE_BINARY} ]]; then
-    full_command=("${SPACK_CCACHE_BINARY}" "$command" "${args[@]}")
-    # #3761#issuecomment-294352232
-    # workaround for stage being a temp folder
-    export CCACHE_NOHASHDIR=yes
-else
-   full_command=("$command" "${args[@]}")
+# Filter system locations to the end of each sublist of args
+# (includes, library dirs, rpaths)
+for sd in ${SPACK_SYSTEM_DIRS[@]}; do
+    stripped_includes=`echo $includes | sed "s#\b$sd/\? \b##g"`
+    stripped_libdirs=`echo $libdirs | sed "s#\b$sd/\? \b##g"`
+    stripped_rpaths=`echo $rpaths | sed "s#\b$sd/\? \b##g"`
+    if [[ "$includes" != "$stripped_includes" ]]; then
+	$includes="$stripped_includes $sd"
+    fi
+    if [[ "$libdirs" != "$stripped_libdirs" ]]; then
+	$libdirs="$stripped_libdirs $sd"
+    fi
+    if [[ "$rpaths" != "$stripped_rpaths" ]]; then
+	$rpaths="$stripped_rpaths $sd"
+    fi
+done
+
+# Put the arguments together into one list
+# Includes come first, then other args, library dirs, and rpaths
+# rpaths get appropriate flag for ld vs ccld mode
+for dir in "${includes[@]}";  do args+=("-I$dir"); done
+args+=("${other_args[@]}")
+for dir in "${libdirs[@]}"; do args+=("-L$dir"); done
+for lib in "${libs[@]}"; do args+=("-l$lib"); done
+if [ "$mode" = ccld ]; then
+    for dir in "${rpaths[@]}"; do
+        args+=("$rpath$dir")
+    done
+elif [ "$mode" = ld ]; then
+    for dir in "${rpaths[@]}"; do
+        args+=("-rpath" "$dir")
+    done
 fi
+
+full_command=("$command")
+full_command+=("${args[@]}")
 
 # In test command mode, write out full command for Spack tests.
 if [[ $SPACK_TEST_COMMAND == dump-args ]]; then
@@ -370,4 +457,4 @@ if [[ $SPACK_DEBUG == TRUE ]]; then
     echo "[$mode] ${full_command[@]}" >> "$output_log"
 fi
 
-exec "${full_command[@]}"
+exec "${full_command[@]}" 

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -73,6 +73,7 @@ import spack.store
 from spack.environment import EnvironmentModifications, validate
 from spack.environment import preserve_environment
 from spack.util.environment import env_flag, filter_system_paths, get_path
+from spack.util.environment import system_dirs
 from spack.util.executable import Executable
 from spack.util.module_cmd import load_module, get_path_from_module
 from spack.util.log_parse import parse_log_events, make_log_context
@@ -99,6 +100,7 @@ SPACK_SHORT_SPEC = 'SPACK_SHORT_SPEC'
 SPACK_DEBUG_LOG_ID = 'SPACK_DEBUG_LOG_ID'
 SPACK_DEBUG_LOG_DIR = 'SPACK_DEBUG_LOG_DIR'
 SPACK_CCACHE_BINARY = 'SPACK_CCACHE_BINARY'
+SPACK_SYSTEM_DIRS = 'SPACK_SYSTEM_DIRS'
 
 
 # Platform-specific library suffix.
@@ -201,6 +203,8 @@ def set_compiler_environment_variables(pkg, env):
     pkg.flags_to_build_system_args(build_system_flags)
 
     env.set('SPACK_COMPILER_SPEC', str(pkg.spec.compiler))
+
+    env.set('SPACK_SYSTEM_DIRS', ' '.join(system_dirs))
 
     compiler.setup_custom_environment(pkg, env)
 

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -204,7 +204,7 @@ def set_compiler_environment_variables(pkg, env):
 
     env.set('SPACK_COMPILER_SPEC', str(pkg.spec.compiler))
 
-    env.set('SPACK_SYSTEM_DIRS', ' '.join(system_dirs))
+    env.set('SPACK_SYSTEM_DIRS', ':'.join(system_dirs))
 
     compiler.setup_custom_environment(pkg, env)
 

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -58,6 +58,8 @@ def build_environment():
     os.environ['SPACK_F77_RPATH_ARG'] = "-Wl,-rpath,"
     os.environ['SPACK_FC_RPATH_ARG']  = "-Wl,-rpath,"
 
+    os.environ['SPACK_SYSTEM_DIRS'] = '/usr/include /usr/lib'
+
     if 'SPACK_DEPENDENCIES' in os.environ:
         del os.environ['SPACK_DEPENDENCIES']
 
@@ -67,7 +69,8 @@ def build_environment():
                  'SPACK_ENV_PATH', 'SPACK_DEBUG_LOG_DIR',
                  'SPACK_COMPILER_SPEC', 'SPACK_SHORT_SPEC',
                  'SPACK_CC_RPATH_ARG', 'SPACK_CXX_RPATH_ARG',
-                 'SPACK_F77_RPATH_ARG', 'SPACK_FC_RPATH_ARG'):
+                 'SPACK_F77_RPATH_ARG', 'SPACK_FC_RPATH_ARG',
+                 'SPACK_SYSTEM_DIRS'):
         del os.environ[name]
 
 
@@ -96,8 +99,8 @@ def test_static_to_shared_library(build_environment):
                 shared_lib = '{0}.{1}'.format(
                     os.path.splitext(static_lib)[0], dso_suffix)
 
-            assert output == expected[arch].format(
-                static_lib, shared_lib, os.path.basename(shared_lib))
+            assert set(output.split()) == set(expected[arch].format(
+                static_lib, shared_lib, os.path.basename(shared_lib)).split())
 
 
 @pytest.mark.regression('8345')

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -27,16 +27,16 @@ This test checks that the Spack cc compiler wrapper is parsing
 arguments correctly.
 """
 import os
-import unittest
-import tempfile
-import shutil
+import pytest
 
 from spack.paths import build_env_path
-from llnl.util.filesystem import mkdirp
+from spack.util.environment import system_dirs, set_env
 from spack.util.executable import Executable
 
+#
 # Complicated compiler test command
-test_command = [
+#
+test_args = [
     '-I/test/include', '-L/test/lib', '-L/other/lib', '-I/other/include',
     'arg1',
     '-Wl,--start-group',
@@ -45,422 +45,482 @@ test_command = [
     '-llib1', '-llib2',
     'arg4',
     '-Wl,--end-group',
-    '-Xlinker', '-rpath', '-Xlinker', '/third/rpath', '-Xlinker',
-    '-rpath', '-Xlinker', '/fourth/rpath',
+    '-Xlinker', '-rpath', '-Xlinker', '/third/rpath',
+    '-Xlinker', '-rpath', '-Xlinker', '/fourth/rpath',
     '-llib3', '-llib4',
     'arg5', 'arg6']
 
+#
+# Pieces of the test command above, as they should be parsed out.
+#
+# `_wl_rpaths` are for the compiler (with -Wl,), and `_rpaths` are raw
+# -rpath arguments for the linker.
+#
+test_include_paths = [
+    '-I/test/include', '-I/other/include']
 
-class CompilerWrapperTest(unittest.TestCase):
+test_library_paths = [
+    '-L/test/lib', '-L/other/lib']
 
-    def setUp(self):
-        self.cc = Executable(os.path.join(build_env_path, "cc"))
-        self.ld = Executable(os.path.join(build_env_path, "ld"))
-        self.cpp = Executable(os.path.join(build_env_path, "cpp"))
-        self.cxx = Executable(os.path.join(build_env_path, "c++"))
-        self.fc = Executable(os.path.join(build_env_path, "fc"))
+test_wl_rpaths = [
+    '-Wl,-rpath,/first/rpath', '-Wl,-rpath,/second/rpath',
+    '-Wl,-rpath,/third/rpath', '-Wl,-rpath,/fourth/rpath']
 
-        self.realcc = "/bin/mycc"
-        self.prefix = "/spack-test-prefix"
+test_rpaths = [
+    '-rpath', '/first/rpath', '-rpath', '/second/rpath',
+    '-rpath', '/third/rpath', '-rpath', '/fourth/rpath']
 
-        os.environ['SPACK_CC'] = self.realcc
-        os.environ['SPACK_CXX'] = self.realcc
-        os.environ['SPACK_FC'] = self.realcc
+test_args_without_paths = [
+    'arg1',
+    '-Wl,--start-group',
+    'arg2', 'arg3', '-llib1', '-llib2', 'arg4',
+    '-Wl,--end-group',
+    '-llib3', '-llib4', 'arg5', 'arg6']
 
-        os.environ['SPACK_PREFIX'] = self.prefix
-        os.environ['SPACK_ENV_PATH'] = "test"
-        os.environ['SPACK_DEBUG_LOG_DIR'] = "."
-        os.environ['SPACK_DEBUG_LOG_ID'] = "foo-hashabc"
-        os.environ['SPACK_COMPILER_SPEC'] = "gcc@4.4.7"
-        os.environ['SPACK_SHORT_SPEC'] = (
-            "foo@1.2 arch=linux-rhel6-x86_64 /hashabc")
+#: The prefix of the package being mock installed
+pkg_prefix = '/spack-test-prefix'
 
-        os.environ['SPACK_CC_RPATH_ARG']  = "-Wl,-rpath,"
-        os.environ['SPACK_CXX_RPATH_ARG'] = "-Wl,-rpath,"
-        os.environ['SPACK_F77_RPATH_ARG'] = "-Wl,-rpath,"
-        os.environ['SPACK_FC_RPATH_ARG']  = "-Wl,-rpath,"
+#
+# Expected RPATHs for the package itself.  The package is expected to
+# have only one of /lib or /lib64, but we add both b/c we can't know
+# before installing.
+#
+pkg_wl_rpaths = [
+    '-Wl,-rpath,' + pkg_prefix + '/lib',
+    '-Wl,-rpath,' + pkg_prefix + '/lib64']
 
-        # Make some fake dependencies
-        self.tmp_deps = tempfile.mkdtemp()
-        self.dep1 = os.path.join(self.tmp_deps, 'dep1')
-        self.dep2 = os.path.join(self.tmp_deps, 'dep2')
-        self.dep3 = os.path.join(self.tmp_deps, 'dep3')
-        self.dep4 = os.path.join(self.tmp_deps, 'dep4')
+pkg_rpaths = [
+    '-rpath', '/spack-test-prefix/lib',
+    '-rpath', '/spack-test-prefix/lib64']
 
-        mkdirp(os.path.join(self.dep1, 'include'))
-        mkdirp(os.path.join(self.dep1, 'lib'))
+# Compilers to use during tests
+cc = Executable(os.path.join(build_env_path, "cc"))
+ld = Executable(os.path.join(build_env_path, "ld"))
+cpp = Executable(os.path.join(build_env_path, "cpp"))
+cxx = Executable(os.path.join(build_env_path, "c++"))
+fc = Executable(os.path.join(build_env_path, "fc"))
 
-        mkdirp(os.path.join(self.dep2, 'lib64'))
+#: the "real" compiler the wrapper is expected to invoke
+real_cc = '/bin/mycc'
 
-        mkdirp(os.path.join(self.dep3, 'include'))
-        mkdirp(os.path.join(self.dep3, 'lib64'))
+# mock flags to use in the wrapper environment
+spack_cppflags = ['-g', '-O1', '-DVAR=VALUE']
+spack_cflags   = ['-Wall']
+spack_cxxflags = ['-Werror']
+spack_fflags   = ['-w']
+spack_ldflags  = ['-L', 'foo']
+spack_ldlibs   = ['-lfoo']
 
-        mkdirp(os.path.join(self.dep4, 'include'))
 
-        if 'SPACK_DEPENDENCIES' in os.environ:
-            del os.environ['SPACK_DEPENDENCIES']
+@pytest.fixture(scope='session')
+def wrapper_environment():
+    with set_env(
+            SPACK_CC=real_cc,
+            SPACK_CXX=real_cc,
+            SPACK_FC=real_cc,
+            SPACK_PREFIX=pkg_prefix,
+            SPACK_ENV_PATH='test',
+            SPACK_DEBUG_LOG_DIR='.',
+            SPACK_DEBUG_LOG_ID='foo-hashabc',
+            SPACK_COMPILER_SPEC='gcc@4.4.7',
+            SPACK_SHORT_SPEC='foo@1.2 arch=linux-rhel6-x86_64 /hashabc',
+            SPACK_SYSTEM_DIRS=' '.join(system_dirs),
+            SPACK_CC_RPATH_ARG='-Wl,-rpath,',
+            SPACK_CXX_RPATH_ARG='-Wl,-rpath,',
+            SPACK_F77_RPATH_ARG='-Wl,-rpath,',
+            SPACK_FC_RPATH_ARG='-Wl,-rpath,',
+            SPACK_DEPENDENCIES=None):
+        yield
 
-    def tearDown(self):
-        shutil.rmtree(self.tmp_deps, True)
 
-    def check_cc(self, command, args, expected):
-        os.environ['SPACK_TEST_COMMAND'] = command
-        self.assertEqual(self.cc(*args, output=str).strip(), expected)
+@pytest.fixture()
+def wrapper_flags():
+    with set_env(
+            SPACK_CPPFLAGS=' '.join(spack_cppflags),
+            SPACK_CFLAGS=' '.join(spack_cflags),
+            SPACK_CXXFLAGS=' '.join(spack_cxxflags),
+            SPACK_FFLAGS=' '.join(spack_fflags),
+            SPACK_LDFLAGS=' '.join(spack_ldflags),
+            SPACK_LDLIBS=' '.join(spack_ldlibs)):
+        yield
 
-    def check_cxx(self, command, args, expected):
-        os.environ['SPACK_TEST_COMMAND'] = command
-        self.assertEqual(self.cxx(*args, output=str).strip(), expected)
 
-    def check_fc(self, command, args, expected):
-        os.environ['SPACK_TEST_COMMAND'] = command
-        self.assertEqual(self.fc(*args, output=str).strip(), expected)
+@pytest.fixture(scope='session')
+def dep1(tmpdir_factory):
+    path = tmpdir_factory.mktemp('cc-dep1')
+    path.mkdir('include')
+    path.mkdir('lib')
+    yield str(path)
 
-    def check_ld(self, command, args, expected):
-        os.environ['SPACK_TEST_COMMAND'] = command
-        self.assertEqual(self.ld(*args, output=str).strip(), expected)
 
-    def check_cpp(self, command, args, expected):
-        os.environ['SPACK_TEST_COMMAND'] = command
-        self.assertEqual(self.cpp(*args, output=str).strip(), expected)
+@pytest.fixture(scope='session')
+def dep2(tmpdir_factory):
+    path = tmpdir_factory.mktemp('cc-dep2')
+    path.mkdir('lib64')
+    yield str(path)
 
-    def test_vcheck_mode(self):
-        self.check_cc('dump-mode', ['-I/include', '--version'], "vcheck")
-        self.check_cc('dump-mode', ['-I/include', '-V'], "vcheck")
-        self.check_cc('dump-mode', ['-I/include', '-v'], "vcheck")
-        self.check_cc('dump-mode', ['-I/include', '-dumpversion'], "vcheck")
-        self.check_cc('dump-mode', ['-I/include', '--version', '-c'], "vcheck")
-        self.check_cc('dump-mode', ['-I/include',
-                                    '-V', '-o', 'output'], "vcheck")
 
-    def test_cpp_mode(self):
-        self.check_cc('dump-mode', ['-E'], "cpp")
-        self.check_cpp('dump-mode', [], "cpp")
+@pytest.fixture(scope='session')
+def dep3(tmpdir_factory):
+    path = tmpdir_factory.mktemp('cc-dep3')
+    path.mkdir('include')
+    path.mkdir('lib64')
+    yield str(path)
 
-    def test_as_mode(self):
-        self.check_cc('dump-mode', ['-S'], "as")
 
-    def test_ccld_mode(self):
-        self.check_cc('dump-mode', [], "ccld")
-        self.check_cc('dump-mode', ['foo.c', '-o', 'foo'], "ccld")
-        self.check_cc('dump-mode', ['foo.c', '-o',
-                                    'foo', '-Wl,-rpath,foo'], "ccld")
-        self.check_cc(
-            'dump-mode',
-            ['foo.o', 'bar.o', 'baz.o', '-o', 'foo', '-Wl,-rpath,foo'],
-            "ccld")
+@pytest.fixture(scope='session')
+def dep4(tmpdir_factory):
+    path = tmpdir_factory.mktemp('cc-dep4')
+    path.mkdir('include')
+    yield str(path)
 
-    def test_ld_mode(self):
-        self.check_ld('dump-mode', [], "ld")
-        self.check_ld(
-            'dump-mode',
-            ['foo.o', 'bar.o', 'baz.o', '-o', 'foo', '-Wl,-rpath,foo'],
-            "ld")
 
-    def test_flags(self):
-        os.environ['SPACK_LDFLAGS'] = '-L foo'
-        os.environ['SPACK_LDLIBS'] = '-lfoo'
-        os.environ['SPACK_CPPFLAGS'] = '-g -O1'
-        os.environ['SPACK_CFLAGS'] = '-Wall'
-        os.environ['SPACK_CXXFLAGS'] = '-Werror'
-        os.environ['SPACK_FFLAGS'] = '-w'
+pytestmark = pytest.mark.usefixtures('wrapper_environment')
 
-        # Test ldflags added properly in ld mode
-        self.check_ld('dump-args', test_command,
-                      'ld -L foo ' +
-                      '-I/test/include -I/other/include arg1 ' +
-                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
-                      '-Wl,--end-group ' +
-                      '-llib3 -llib4 arg5 arg6 ' +
-                      '-L/test/lib -L/other/lib ' +
-                      '-lfoo ' +
-                      '-rpath /first/rpath -rpath /second/rpath ' +
-                      '-rpath /third/rpath -rpath /fourth/rpath ' +
-                      '-rpath /spack-test-prefix/lib ' +
-                      '-rpath /spack-test-prefix/lib64')
 
-        # Test cppflags added properly in cpp mode
-        self.check_cpp('dump-args', test_command,
-                       "cpp " +
-                       '-g -O1 ' +
-                       '-I/test/include -I/other/include arg1 ' +
-                       '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
-                       '-Wl,--end-group ' +
-                       '-llib3 -llib4 arg5 arg6 ' +
-                       '-L/test/lib -L/other/lib')
+def check_cc(command, args, expected):
+    with set_env(SPACK_TEST_COMMAND=command):
+        assert cc(*args, output=str).strip().split() == expected
 
-        # Test ldflags, cppflags, and language specific flags are added in
-        # proper order
-        self.check_cc('dump-args', test_command,
-                      self.realcc + ' ' +
-                      '-g -O1 -Wall -L foo ' +
-                      '-I/test/include -I/other/include arg1 ' +
-                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
-                      '-Wl,--end-group ' +
-                      '-llib3 -llib4 arg5 arg6 ' +
-                      '-L/test/lib -L/other/lib ' +
-                      '-lfoo ' +
-                      '-Wl,-rpath,/first/rpath -Wl,-rpath,/second/rpath ' +
-                      '-Wl,-rpath,/third/rpath -Wl,-rpath,/fourth/rpath ' +
-                      '-Wl,-rpath,/spack-test-prefix/lib ' +
-                      '-Wl,-rpath,/spack-test-prefix/lib64')
 
-        self.check_cxx('dump-args', test_command,
-                       self.realcc + ' ' +
-                       '-g -O1 -Werror -L foo ' +
-                       '-I/test/include -I/other/include arg1 ' +
-                       '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
-                       '-Wl,--end-group ' +
-                       '-llib3 -llib4 arg5 arg6 ' +
-                       '-L/test/lib -L/other/lib ' +
-                       '-lfoo ' +
-                       '-Wl,-rpath,/first/rpath -Wl,-rpath,/second/rpath ' +
-                       '-Wl,-rpath,/third/rpath -Wl,-rpath,/fourth/rpath ' +
-                       '-Wl,-rpath,/spack-test-prefix/lib ' +
-                       '-Wl,-rpath,/spack-test-prefix/lib64')
+def check_cxx(command, args, expected):
+    with set_env(SPACK_TEST_COMMAND=command):
+        assert cxx(*args, output=str).strip().split() == expected
 
-        self.check_fc('dump-args', test_command,
-                      self.realcc + ' ' +
-                      '-w -g -O1 -L foo ' +
-                      '-I/test/include -I/other/include arg1 ' +
-                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
-                      '-Wl,--end-group ' +
-                      '-llib3 -llib4 arg5 arg6 ' +
-                      '-L/test/lib -L/other/lib ' +
-                      '-lfoo ' +
-                      '-Wl,-rpath,/first/rpath -Wl,-rpath,/second/rpath ' +
-                      '-Wl,-rpath,/third/rpath -Wl,-rpath,/fourth/rpath ' +
-                      '-Wl,-rpath,/spack-test-prefix/lib ' +
-                      '-Wl,-rpath,/spack-test-prefix/lib64')
 
-        del os.environ['SPACK_CFLAGS']
-        del os.environ['SPACK_CXXFLAGS']
-        del os.environ['SPACK_FFLAGS']
-        del os.environ['SPACK_CPPFLAGS']
-        del os.environ['SPACK_LDFLAGS']
-        del os.environ['SPACK_LDLIBS']
+def check_fc(command, args, expected):
+    with set_env(SPACK_TEST_COMMAND=command):
+        assert fc(*args, output=str).strip().split() == expected
 
-    def test_dep_rpath(self):
-        """Ensure RPATHs for root package are added."""
-        self.check_cc('dump-args', test_command,
-                      self.realcc + ' ' +
-                      '-I/test/include -I/other/include arg1 ' +
-                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
-                      '-Wl,--end-group ' +
-                      '-llib3 -llib4 arg5 arg6 ' +
-                      '-L/test/lib -L/other/lib ' +
-                      '-Wl,-rpath,/first/rpath -Wl,-rpath,/second/rpath ' +
-                      '-Wl,-rpath,/third/rpath -Wl,-rpath,/fourth/rpath ' +
-                      '-Wl,-rpath,/spack-test-prefix/lib ' +
-                      '-Wl,-rpath,/spack-test-prefix/lib64')
 
-    def test_dep_include(self):
-        """Ensure a single dependency include directory is added."""
-        os.environ['SPACK_DEPENDENCIES'] = self.dep4
-        os.environ['SPACK_RPATH_DEPS'] = os.environ['SPACK_DEPENDENCIES']
-        os.environ['SPACK_LINK_DEPS'] = os.environ['SPACK_DEPENDENCIES']
-        self.check_cc('dump-args', test_command,
-                      self.realcc + ' ' +
-                      '-I/test/include -I/other/include ' +
-                      '-I' + self.dep4 + '/include arg1 ' +
-                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
-                      '-Wl,--end-group ' +
-                      '-llib3 -llib4 arg5 arg6 ' +
-                      '-L/test/lib -L/other/lib ' +
-                      '-Wl,-rpath,/first/rpath -Wl,-rpath,/second/rpath ' +
-                      '-Wl,-rpath,/third/rpath -Wl,-rpath,/fourth/rpath ' +
-                      '-Wl,-rpath,/spack-test-prefix/lib ' +
-                      '-Wl,-rpath,/spack-test-prefix/lib64')
+def check_ld(command, args, expected):
+    with set_env(SPACK_TEST_COMMAND=command):
+        assert ld(*args, output=str).strip().split() == expected
 
-    def test_dep_lib(self):
-        """Ensure a single dependency RPATH is added."""
-        os.environ['SPACK_DEPENDENCIES'] = self.dep2
-        os.environ['SPACK_RPATH_DEPS'] = os.environ['SPACK_DEPENDENCIES']
-        os.environ['SPACK_LINK_DEPS'] = os.environ['SPACK_DEPENDENCIES']
-        self.check_cc('dump-args', test_command,
-                      self.realcc + ' ' +
-                      '-I/test/include -I/other/include arg1 ' +
-                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
-                      '-Wl,--end-group ' +
-                      '-llib3 -llib4 arg5 arg6 ' +
-                      '-L/test/lib -L/other/lib ' +
-                      '-L' + self.dep2 + '/lib64 ' +
-                      '-Wl,-rpath,/first/rpath -Wl,-rpath,/second/rpath ' +
-                      '-Wl,-rpath,/third/rpath -Wl,-rpath,/fourth/rpath ' +
-                      '-Wl,-rpath,/spack-test-prefix/lib ' +
-                      '-Wl,-rpath,/spack-test-prefix/lib64 ' +
-                      '-Wl,-rpath,' + self.dep2 + '/lib64')
 
-    def test_dep_lib_no_rpath(self):
-        """Ensure a single dependency link flag is added with no dep RPATH."""
-        os.environ['SPACK_DEPENDENCIES'] = self.dep2
-        os.environ['SPACK_LINK_DEPS'] = os.environ['SPACK_DEPENDENCIES']
-        self.check_cc('dump-args', test_command,
-                      self.realcc + ' ' +
-                      '-I/test/include -I/other/include arg1 ' +
-                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
-                      '-Wl,--end-group ' +
-                      '-llib3 -llib4 arg5 arg6 ' +
-                      '-L/test/lib -L/other/lib ' +
-                      '-L' + self.dep2 + '/lib64 ' +
-                      '-Wl,-rpath,/first/rpath -Wl,-rpath,/second/rpath ' +
-                      '-Wl,-rpath,/third/rpath -Wl,-rpath,/fourth/rpath ' +
-                      '-Wl,-rpath,/spack-test-prefix/lib ' +
-                      '-Wl,-rpath,/spack-test-prefix/lib64')
+def check_cpp(command, args, expected):
+    with set_env(SPACK_TEST_COMMAND=command):
+        assert cpp(*args, output=str).strip().split() == expected
 
-    def test_dep_lib_no_lib(self):
-        """Ensure a single dependency RPATH is added with no -L."""
-        os.environ['SPACK_DEPENDENCIES'] = self.dep2
-        os.environ['SPACK_RPATH_DEPS'] = os.environ['SPACK_DEPENDENCIES']
-        self.check_cc('dump-args', test_command,
-                      self.realcc + ' ' +
-                      '-I/test/include -I/other/include arg1 ' +
-                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
-                      '-Wl,--end-group ' +
-                      '-llib3 -llib4 arg5 arg6 ' +
-                      '-L/test/lib -L/other/lib ' +
-                      '-Wl,-rpath,/first/rpath -Wl,-rpath,/second/rpath ' +
-                      '-Wl,-rpath,/third/rpath -Wl,-rpath,/fourth/rpath ' +
-                      '-Wl,-rpath,/spack-test-prefix/lib ' +
-                      '-Wl,-rpath,/spack-test-prefix/lib64 ' +
-                      '-Wl,-rpath,' + self.dep2 + '/lib64')
 
-    def test_all_deps(self):
-        """Ensure includes and RPATHs for all deps are added. """
-        os.environ['SPACK_DEPENDENCIES'] = ':'.join([
-            self.dep1, self.dep2, self.dep3, self.dep4])
-        os.environ['SPACK_RPATH_DEPS'] = os.environ['SPACK_DEPENDENCIES']
-        os.environ['SPACK_LINK_DEPS'] = os.environ['SPACK_DEPENDENCIES']
+def test_vcheck_mode():
+    check_cc(
+        'dump-mode', ['-I/include', '--version'], ['vcheck'])
+    check_cc(
+        'dump-mode', ['-I/include', '-V'], ['vcheck'])
+    check_cc(
+        'dump-mode', ['-I/include', '-v'], ['vcheck'])
+    check_cc(
+        'dump-mode', ['-I/include', '-dumpversion'], ['vcheck'])
+    check_cc(
+        'dump-mode', ['-I/include', '--version', '-c'], ['vcheck'])
+    check_cc(
+        'dump-mode', ['-I/include', '-V', '-o', 'output'], ['vcheck'])
 
-        # This is probably more constrained than it needs to be; it
-        # checks order within prepended args and doesn't strictly have
-        # to.  We could loosen that if it becomes necessary
-        self.check_cc('dump-args', test_command,
-                      self.realcc + ' ' +
-                      '-I/test/include -I/other/include ' +
-                      '-I' + self.dep1 + '/include ' +
-                      '-I' + self.dep3 + '/include ' +
-                      '-I' + self.dep4 + '/include ' +
-                      'arg1 ' +
-                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
-                      '-Wl,--end-group ' +
-                      '-llib3 -llib4 arg5 arg6 ' +
-                      '-L/test/lib -L/other/lib ' +
-                      '-L' + self.dep1 + '/lib ' +
-                      '-L' + self.dep2 + '/lib64 ' +
-                      '-L' + self.dep3 + '/lib64 ' +
-                      '-Wl,-rpath,/first/rpath -Wl,-rpath,/second/rpath ' +
-                      '-Wl,-rpath,/third/rpath -Wl,-rpath,/fourth/rpath ' +
-                      '-Wl,-rpath,/spack-test-prefix/lib ' +
-                      '-Wl,-rpath,/spack-test-prefix/lib64 ' +
-                      '-Wl,-rpath,' + self.dep1 + '/lib ' +
-                      '-Wl,-rpath,' + self.dep2 + '/lib64 ' +
-                      '-Wl,-rpath,' + self.dep3 + '/lib64')
 
-    def test_ld_deps(self):
-        """Ensure no (extra) -I args or -Wl, are passed in ld mode."""
-        os.environ['SPACK_DEPENDENCIES'] = ':'.join([
-            self.dep1, self.dep2, self.dep3, self.dep4])
-        os.environ['SPACK_RPATH_DEPS'] = os.environ['SPACK_DEPENDENCIES']
-        os.environ['SPACK_LINK_DEPS'] = os.environ['SPACK_DEPENDENCIES']
+def test_cpp_mode():
+    check_cc('dump-mode', ['-E'], ['cpp'])
+    check_cpp('dump-mode', [], ['cpp'])
 
-        self.check_ld('dump-args', test_command,
-                      'ld ' +
-                      '-I/test/include -I/other/include ' +
-                      'arg1 ' +
-                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
-                      '-Wl,--end-group ' +
-                      '-llib3 -llib4 arg5 arg6 ' +
-                      '-L/test/lib -L/other/lib ' +
-                      '-L' + self.dep1 + '/lib ' +
-                      '-L' + self.dep2 + '/lib64 ' +
-                      '-L' + self.dep3 + '/lib64 ' +
-                      '-rpath /first/rpath -rpath /second/rpath ' +
-                      '-rpath /third/rpath -rpath /fourth/rpath ' +
-                      '-rpath /spack-test-prefix/lib ' +
-                      '-rpath /spack-test-prefix/lib64 ' +
-                      '-rpath ' + self.dep1 + '/lib ' +
-                      '-rpath ' + self.dep2 + '/lib64 ' +
-                      '-rpath ' + self.dep3 + '/lib64')
 
-    def test_ld_deps_no_rpath(self):
-        """Ensure SPACK_RPATH_DEPS controls RPATHs for ld."""
-        os.environ['SPACK_DEPENDENCIES'] = ':'.join([
-            self.dep1, self.dep2, self.dep3, self.dep4])
-        os.environ['SPACK_LINK_DEPS'] = os.environ['SPACK_DEPENDENCIES']
+def test_as_mode():
+    check_cc('dump-mode', ['-S'], ['as'])
 
-        self.check_ld('dump-args', test_command,
-                      'ld ' +
-                      '-I/test/include -I/other/include ' +
-                      'arg1 ' +
-                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
-                      '-Wl,--end-group ' +
-                      '-llib3 -llib4 arg5 arg6 ' +
-                      '-L/test/lib -L/other/lib ' +
-                      '-L' + self.dep1 + '/lib ' +
-                      '-L' + self.dep2 + '/lib64 ' +
-                      '-L' + self.dep3 + '/lib64 ' +
-                      '-rpath /first/rpath -rpath /second/rpath ' +
-                      '-rpath /third/rpath -rpath /fourth/rpath ' +
-                      '-rpath /spack-test-prefix/lib ' +
-                      '-rpath /spack-test-prefix/lib64')
 
-    def test_ld_deps_no_link(self):
-        """Ensure SPACK_LINK_DEPS controls -L for ld."""
-        os.environ['SPACK_DEPENDENCIES'] = ':'.join([
-            self.dep1, self.dep2, self.dep3, self.dep4])
-        os.environ['SPACK_RPATH_DEPS'] = os.environ['SPACK_DEPENDENCIES']
+def test_ccld_mode():
+    check_cc(
+        'dump-mode', [], ['ccld'])
+    check_cc(
+        'dump-mode', ['foo.c', '-o', 'foo'], ['ccld'])
+    check_cc(
+        'dump-mode', ['foo.c', '-o', 'foo', '-Wl,-rpath,foo'], ['ccld'])
+    check_cc(
+        'dump-mode',
+        ['foo.o', 'bar.o', 'baz.o', '-o', 'foo', '-Wl,-rpath,foo'], ['ccld'])
 
-        self.check_ld('dump-args', test_command,
-                      'ld ' +
-                      '-I/test/include -I/other/include ' +
-                      'arg1 ' +
-                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
-                      '-Wl,--end-group ' +
-                      '-llib3 -llib4 arg5 arg6 ' +
-                      '-L/test/lib -L/other/lib ' +
-                      '-rpath /first/rpath -rpath /second/rpath ' +
-                      '-rpath /third/rpath -rpath /fourth/rpath ' +
-                      '-rpath /spack-test-prefix/lib ' +
-                      '-rpath /spack-test-prefix/lib64 ' +
-                      '-rpath ' + self.dep1 + '/lib ' +
-                      '-rpath ' + self.dep2 + '/lib64 ' +
-                      '-rpath ' + self.dep3 + '/lib64')
 
-    def test_ld_deps_reentrant(self):
-        """Make sure ld -r is handled correctly on OS's where it doesn't
-           support rpaths."""
-        os.environ['SPACK_DEPENDENCIES'] = ':'.join([self.dep1])
-        os.environ['SPACK_RPATH_DEPS'] = os.environ['SPACK_DEPENDENCIES']
-        os.environ['SPACK_LINK_DEPS'] = os.environ['SPACK_DEPENDENCIES']
+def test_ld_mode():
+    check_ld('dump-mode', [], ['ld'])
+    check_ld(
+        'dump-mode',
+        ['foo.o', 'bar.o', 'baz.o', '-o', 'foo', '-Wl,-rpath,foo'], ['ld'])
 
+
+def test_ld_flags(wrapper_flags):
+    check_ld(
+        'dump-args', test_args,
+        ['ld'] +
+        spack_ldflags +
+        test_include_paths +
+        test_library_paths +
+        test_rpaths +
+        pkg_rpaths +
+        test_args_without_paths +
+        spack_ldlibs)
+
+
+def test_cpp_flags(wrapper_flags):
+    check_cpp(
+        'dump-args', test_args,
+        ['cpp'] +
+        spack_cppflags +
+        test_include_paths +
+        test_library_paths +
+        test_args_without_paths)
+
+
+def test_cc_flags(wrapper_flags):
+    check_cc(
+        'dump-args', test_args,
+        [real_cc] +
+        spack_cppflags +
+        spack_cflags +
+        spack_ldflags +
+        test_include_paths +
+        test_library_paths +
+        test_wl_rpaths +
+        pkg_wl_rpaths +
+        test_args_without_paths +
+        spack_ldlibs)
+
+
+def test_cxx_flags(wrapper_flags):
+    check_cxx(
+        'dump-args', test_args,
+        [real_cc] +
+        spack_cppflags +
+        spack_cxxflags +
+        spack_ldflags +
+        test_include_paths +
+        test_library_paths +
+        test_wl_rpaths +
+        pkg_wl_rpaths +
+        test_args_without_paths +
+        spack_ldlibs)
+
+
+def test_fc_flags(wrapper_flags):
+    check_fc(
+        'dump-args', test_args,
+        [real_cc] +
+        spack_cppflags +
+        spack_fflags +
+        spack_ldflags +
+        test_include_paths +
+        test_library_paths +
+        test_wl_rpaths +
+        pkg_wl_rpaths +
+        test_args_without_paths +
+        spack_ldlibs)
+
+
+def test_dep_rpath():
+    """Ensure RPATHs for root package are added."""
+    check_cc(
+        'dump-args', test_args,
+        [real_cc] +
+        test_include_paths +
+        test_library_paths +
+        test_wl_rpaths +
+        pkg_wl_rpaths +
+        test_args_without_paths)
+
+
+def test_dep_include(dep4):
+    """Ensure a single dependency include directory is added."""
+    with set_env(SPACK_DEPENDENCIES=dep4,
+                 SPACK_RPATH_DEPS=dep4,
+                 SPACK_LINK_DEPS=dep4):
+        check_cc(
+            'dump-args', test_args,
+            [real_cc] +
+            test_include_paths +
+            ['-I' + dep4 + '/include'] +
+            test_library_paths +
+            test_wl_rpaths +
+            pkg_wl_rpaths +
+            test_args_without_paths)
+
+
+def test_dep_lib(dep2):
+    """Ensure a single dependency RPATH is added."""
+    with set_env(SPACK_DEPENDENCIES=dep2,
+                 SPACK_RPATH_DEPS=dep2,
+                 SPACK_LINK_DEPS=dep2):
+        check_cc(
+            'dump-args', test_args,
+            [real_cc] +
+            test_include_paths +
+            test_library_paths +
+            ['-L' + dep2 + '/lib64'] +
+            test_wl_rpaths +
+            pkg_wl_rpaths +
+            ['-Wl,-rpath,' + dep2 + '/lib64'] +
+            test_args_without_paths)
+
+
+def test_dep_lib_no_rpath(dep2):
+    """Ensure a single dependency link flag is added with no dep RPATH."""
+    with set_env(SPACK_DEPENDENCIES=dep2,
+                 SPACK_LINK_DEPS=dep2):
+        check_cc(
+            'dump-args', test_args,
+            [real_cc] +
+            test_include_paths +
+            test_library_paths +
+            ['-L' + dep2 + '/lib64'] +
+            test_wl_rpaths +
+            pkg_wl_rpaths +
+            test_args_without_paths)
+
+
+def test_dep_lib_no_lib(dep2):
+    """Ensure a single dependency RPATH is added with no -L."""
+    with set_env(SPACK_DEPENDENCIES=dep2,
+                 SPACK_RPATH_DEPS=dep2):
+        check_cc(
+            'dump-args', test_args,
+            [real_cc] +
+            test_include_paths +
+            test_library_paths +
+            test_wl_rpaths +
+            pkg_wl_rpaths +
+            ['-Wl,-rpath,' + dep2 + '/lib64'] +
+            test_args_without_paths)
+
+
+def test_ccld_deps(dep1, dep2, dep3, dep4):
+    """Ensure all flags are added in ccld mode."""
+    deps = ':'.join((dep1, dep2, dep3, dep4))
+    with set_env(SPACK_DEPENDENCIES=deps,
+                 SPACK_RPATH_DEPS=deps,
+                 SPACK_LINK_DEPS=deps):
+        check_cc(
+            'dump-args', test_args,
+            [real_cc] +
+            test_include_paths +
+            ['-I' + dep1 + '/include',
+             '-I' + dep3 + '/include',
+             '-I' + dep4 + '/include'] +
+            test_library_paths +
+            ['-L' + dep1 + '/lib',
+             '-L' + dep2 + '/lib64',
+             '-L' + dep3 + '/lib64'] +
+            test_wl_rpaths +
+            pkg_wl_rpaths +
+            ['-Wl,-rpath,' + dep1 + '/lib',
+             '-Wl,-rpath,' + dep2 + '/lib64',
+             '-Wl,-rpath,' + dep3 + '/lib64'] +
+            test_args_without_paths)
+
+
+def test_cc_deps(dep1, dep2, dep3, dep4):
+    """Ensure -L and RPATHs are not added in cc mode."""
+    deps = ':'.join((dep1, dep2, dep3, dep4))
+    with set_env(SPACK_DEPENDENCIES=deps,
+                 SPACK_RPATH_DEPS=deps,
+                 SPACK_LINK_DEPS=deps):
+        check_cc(
+            'dump-args', ['-c'] + test_args,
+            [real_cc] +
+            test_include_paths +
+            ['-I' + dep1 + '/include',
+             '-I' + dep3 + '/include',
+             '-I' + dep4 + '/include'] +
+            test_library_paths +
+            ['-c'] +
+            test_args_without_paths)
+
+
+def test_ld_deps(dep1, dep2, dep3, dep4):
+    """Ensure no (extra) -I args or -Wl, are passed in ld mode."""
+    deps = ':'.join((dep1, dep2, dep3, dep4))
+    with set_env(SPACK_DEPENDENCIES=deps,
+                 SPACK_RPATH_DEPS=deps,
+                 SPACK_LINK_DEPS=deps):
+        check_ld(
+            'dump-args', test_args,
+            ['ld'] +
+            test_include_paths +
+            test_library_paths +
+            ['-L' + dep1 + '/lib',
+             '-L' + dep2 + '/lib64',
+             '-L' + dep3 + '/lib64'] +
+            test_rpaths +
+            pkg_rpaths +
+            ['-rpath', dep1 + '/lib',
+             '-rpath', dep2 + '/lib64',
+             '-rpath', dep3 + '/lib64'] +
+            test_args_without_paths)
+
+
+def test_ld_deps_no_rpath(dep1, dep2, dep3, dep4):
+    """Ensure SPACK_LINK_DEPS controls -L for ld."""
+    deps = ':'.join((dep1, dep2, dep3, dep4))
+    with set_env(SPACK_DEPENDENCIES=deps,
+                 SPACK_LINK_DEPS=deps):
+        check_ld(
+            'dump-args', test_args,
+            ['ld'] +
+            test_include_paths +
+            test_library_paths +
+            ['-L' + dep1 + '/lib',
+             '-L' + dep2 + '/lib64',
+             '-L' + dep3 + '/lib64'] +
+            test_rpaths +
+            pkg_rpaths +
+            test_args_without_paths)
+
+
+def test_ld_deps_no_link(dep1, dep2, dep3, dep4):
+    """Ensure SPACK_RPATH_DEPS controls -rpath for ld."""
+    deps = ':'.join((dep1, dep2, dep3, dep4))
+    with set_env(SPACK_DEPENDENCIES=deps,
+                 SPACK_RPATH_DEPS=deps):
+        check_ld(
+            'dump-args', test_args,
+            ['ld'] +
+            test_include_paths +
+            test_library_paths +
+            test_rpaths +
+            pkg_rpaths +
+            ['-rpath', dep1 + '/lib',
+             '-rpath', dep2 + '/lib64',
+             '-rpath', dep3 + '/lib64'] +
+            test_args_without_paths)
+
+
+def test_ld_deps_partial(dep1):
+    """Make sure ld -r (partial link) is handled correctly on OS's where it
+       doesn't accept rpaths.
+    """
+    with set_env(SPACK_DEPENDENCIES=dep1,
+                 SPACK_RPATH_DEPS=dep1,
+                 SPACK_LINK_DEPS=dep1):
+        # TODO: do we need to add RPATHs on other platforms like Linux?
+        # TODO: Can't we treat them the same?
         os.environ['SPACK_SHORT_SPEC'] = "foo@1.2=linux-x86_64"
-        reentrant_test_command = ['-r'] + test_command
-        self.check_ld('dump-args', reentrant_test_command,
-                      'ld ' +
-                      '-I/test/include -I/other/include ' +
-                      '-r arg1 ' +
-                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
-                      '-Wl,--end-group ' +
-                      '-llib3 -llib4 arg5 arg6 ' +
-                      '-L/test/lib -L/other/lib ' +
-                      '-L' + self.dep1 + '/lib ' +
-                      '-rpath /first/rpath -rpath /second/rpath ' +
-                      '-rpath /third/rpath -rpath /fourth/rpath ' +
-                      '-rpath /spack-test-prefix/lib ' +
-                      '-rpath /spack-test-prefix/lib64 ' +
-                      '-rpath ' + self.dep1 + '/lib')
+        check_ld(
+            'dump-args', ['-r'] + test_args,
+            ['ld'] +
+            test_include_paths +
+            test_library_paths +
+            ['-L' + dep1 + '/lib'] +
+            test_rpaths +
+            pkg_rpaths +
+            ['-rpath', dep1 + '/lib'] +
+            ['-r'] +
+            test_args_without_paths)
 
         # rpaths from the underlying command will still appear
         # Spack will not add its own rpaths.
         os.environ['SPACK_SHORT_SPEC'] = "foo@1.2=darwin-x86_64"
-        self.check_ld('dump-args', reentrant_test_command,
-                      'ld ' +
-                      '-I/test/include -I/other/include ' +
-                      '-r arg1 ' +
-                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
-                      '-Wl,--end-group ' +
-                      '-llib3 -llib4 arg5 arg6 ' +
-                      '-L/test/lib -L/other/lib ' +
-                      '-L' + self.dep1 + '/lib ' +
-                      '-rpath /first/rpath -rpath /second/rpath ' +
-                      '-rpath /third/rpath -rpath /fourth/rpath')
+        check_ld(
+            'dump-args', ['-r'] + test_args,
+            ['ld'] +
+            test_include_paths +
+            test_library_paths +
+            ['-L' + dep1 + '/lib'] +
+            test_rpaths +
+            ['-r'] +
+            test_args_without_paths)

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -432,6 +432,42 @@ def test_cc_deps(dep1, dep2, dep3, dep4):
             test_args_without_paths)
 
 
+def test_ccld_with_system_dirs(dep1, dep2, dep3, dep4):
+    """Ensure all flags are added in ccld mode."""
+    deps = ':'.join((dep1, dep2, dep3, dep4))
+    with set_env(SPACK_DEPENDENCIES=deps,
+                 SPACK_RPATH_DEPS=deps,
+                 SPACK_LINK_DEPS=deps):
+
+        sys_path_args = ['-I/usr/include',
+                         '-L/usr/local/lib',
+                         '-Wl,-rpath,/usr/lib64',
+                         '-I/usr/local/include',
+                         '-L/lib64/']
+        check_cc(
+            'dump-args', sys_path_args + test_args,
+            [real_cc] +
+            test_include_paths +
+            ['-I' + dep1 + '/include',
+             '-I' + dep3 + '/include',
+             '-I' + dep4 + '/include'] +
+            ['-I/usr/include',
+             '-I/usr/local/include'] +
+            test_library_paths +
+            ['-L' + dep1 + '/lib',
+             '-L' + dep2 + '/lib64',
+             '-L' + dep3 + '/lib64'] +
+            ['-L/usr/local/lib',
+             '-L/lib64/'] +
+            test_wl_rpaths +
+            pkg_wl_rpaths +
+            ['-Wl,-rpath,' + dep1 + '/lib',
+             '-Wl,-rpath,' + dep2 + '/lib64',
+             '-Wl,-rpath,' + dep3 + '/lib64'] +
+            ['-Wl,-rpath,/usr/lib64'] +
+            test_args_without_paths)
+
+
 def test_ld_deps(dep1, dep2, dep3, dep4):
     """Ensure no (extra) -I args or -Wl, are passed in ld mode."""
     deps = ':'.join((dep1, dep2, dep3, dep4))

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -124,7 +124,7 @@ def wrapper_environment():
             SPACK_DEBUG_LOG_ID='foo-hashabc',
             SPACK_COMPILER_SPEC='gcc@4.4.7',
             SPACK_SHORT_SPEC='foo@1.2 arch=linux-rhel6-x86_64 /hashabc',
-            SPACK_SYSTEM_DIRS=' '.join(system_dirs),
+            SPACK_SYSTEM_DIRS=':'.join(system_dirs),
             SPACK_CC_RPATH_ARG='-Wl,-rpath,',
             SPACK_CXX_RPATH_ARG='-Wl,-rpath,',
             SPACK_F77_RPATH_ARG='-Wl,-rpath,',
@@ -180,27 +180,27 @@ pytestmark = pytest.mark.usefixtures('wrapper_environment')
 
 def check_cc(command, args, expected):
     with set_env(SPACK_TEST_COMMAND=command):
-        assert cc(*args, output=str).strip().split() == expected
+        assert expected == cc(*args, output=str).strip().split()
 
 
 def check_cxx(command, args, expected):
     with set_env(SPACK_TEST_COMMAND=command):
-        assert cxx(*args, output=str).strip().split() == expected
+        assert expected == cxx(*args, output=str).strip().split()
 
 
 def check_fc(command, args, expected):
     with set_env(SPACK_TEST_COMMAND=command):
-        assert fc(*args, output=str).strip().split() == expected
+        assert expected == fc(*args, output=str).strip().split()
 
 
 def check_ld(command, args, expected):
     with set_env(SPACK_TEST_COMMAND=command):
-        assert ld(*args, output=str).strip().split() == expected
+        assert expected == ld(*args, output=str).strip().split()
 
 
 def check_cpp(command, args, expected):
     with set_env(SPACK_TEST_COMMAND=command):
-        assert cpp(*args, output=str).strip().split() == expected
+        assert expected == cpp(*args, output=str).strip().split()
 
 
 def test_vcheck_mode():
@@ -303,8 +303,8 @@ def test_fc_flags(wrapper_flags):
     check_fc(
         'dump-args', test_args,
         [real_cc] +
-        spack_cppflags +
         spack_fflags +
+        spack_cppflags +
         spack_ldflags +
         test_include_paths +
         test_library_paths +

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -560,3 +560,28 @@ def test_ld_deps_partial(dep1):
             test_rpaths +
             ['-r'] +
             test_args_without_paths)
+
+
+def test_ccache_prepend_for_cc():
+    with set_env(SPACK_CCACHE_BINARY='ccache'):
+        check_cc(
+            'dump-args', test_args,
+            ['ccache'] +  # ccache prepended in cc mode
+            [real_cc] +
+            test_include_paths +
+            test_library_paths +
+            test_wl_rpaths +
+            pkg_wl_rpaths +
+            test_args_without_paths)
+
+
+def test_no_ccache_prepend_for_fc():
+    check_fc(
+        'dump-args', test_args,
+        # no ccache for Fortran
+        [real_cc] +
+        test_include_paths +
+        test_library_paths +
+        test_wl_rpaths +
+        pkg_wl_rpaths +
+        test_args_without_paths)

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -166,50 +166,71 @@ class CompilerWrapperTest(unittest.TestCase):
 
         # Test ldflags added properly in ld mode
         self.check_ld('dump-args', test_command,
-                      "ld " +
-                      '-rpath ' + self.prefix + '/lib ' +
-                      '-rpath ' + self.prefix + '/lib64 ' +
-                      '-L foo ' +
-                      ' '.join(test_command) + ' ' +
-                      '-lfoo')
+                      'ld -L foo ' +
+                      '-I/test/include -I/other/include arg1 ' +
+                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
+                      '-Wl,--end-group ' +
+                      '-llib3 -llib4 arg5 arg6 ' +
+                      '-L/test/lib -L/other/lib ' +
+                      '-lfoo ' +
+                      '-rpath /first/rpath -rpath /second/rpath ' +
+                      '-rpath /third/rpath -rpath /fourth/rpath ' +
+                      '-rpath /spack-test-prefix/lib ' +
+                      '-rpath /spack-test-prefix/lib64')
 
         # Test cppflags added properly in cpp mode
         self.check_cpp('dump-args', test_command,
                        "cpp " +
                        '-g -O1 ' +
-                       ' '.join(test_command))
+                       '-I/test/include -I/other/include arg1 ' +
+                       '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
+                       '-Wl,--end-group ' +
+                       '-llib3 -llib4 arg5 arg6 ' +
+                       '-L/test/lib -L/other/lib')
 
         # Test ldflags, cppflags, and language specific flags are added in
         # proper order
         self.check_cc('dump-args', test_command,
                       self.realcc + ' ' +
-                      '-Wl,-rpath,' + self.prefix + '/lib ' +
-                      '-Wl,-rpath,' + self.prefix + '/lib64 ' +
-                      '-g -O1 ' +
-                      '-Wall ' +
-                      '-L foo ' +
-                      ' '.join(test_command) + ' ' +
-                      '-lfoo')
+                      '-g -O1 -Wall -L foo ' +
+                      '-I/test/include -I/other/include arg1 ' +
+                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
+                      '-Wl,--end-group ' +
+                      '-llib3 -llib4 arg5 arg6 ' +
+                      '-L/test/lib -L/other/lib ' +
+                      '-lfoo ' +
+                      '-Wl,-rpath,/first/rpath -Wl,-rpath,/second/rpath ' +
+                      '-Wl,-rpath,/third/rpath -Wl,-rpath,/fourth/rpath ' +
+                      '-Wl,-rpath,/spack-test-prefix/lib ' +
+                      '-Wl,-rpath,/spack-test-prefix/lib64')
 
         self.check_cxx('dump-args', test_command,
                        self.realcc + ' ' +
-                       '-Wl,-rpath,' + self.prefix + '/lib ' +
-                       '-Wl,-rpath,' + self.prefix + '/lib64 ' +
-                       '-g -O1 ' +
-                       '-Werror ' +
-                       '-L foo ' +
-                       ' '.join(test_command) + ' ' +
-                       '-lfoo')
+                       '-g -O1 -Werror -L foo ' +
+                       '-I/test/include -I/other/include arg1 ' +
+                       '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
+                       '-Wl,--end-group ' +
+                       '-llib3 -llib4 arg5 arg6 ' +
+                       '-L/test/lib -L/other/lib ' +
+                       '-lfoo ' +
+                       '-Wl,-rpath,/first/rpath -Wl,-rpath,/second/rpath ' +
+                       '-Wl,-rpath,/third/rpath -Wl,-rpath,/fourth/rpath ' +
+                       '-Wl,-rpath,/spack-test-prefix/lib ' +
+                       '-Wl,-rpath,/spack-test-prefix/lib64')
 
         self.check_fc('dump-args', test_command,
                       self.realcc + ' ' +
-                      '-Wl,-rpath,' + self.prefix + '/lib ' +
-                      '-Wl,-rpath,' + self.prefix + '/lib64 ' +
-                      '-w ' +
-                      '-g -O1 ' +
-                      '-L foo ' +
-                      ' '.join(test_command) + ' ' +
-                      '-lfoo')
+                      '-w -g -O1 -L foo ' +
+                      '-I/test/include -I/other/include arg1 ' +
+                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
+                      '-Wl,--end-group ' +
+                      '-llib3 -llib4 arg5 arg6 ' +
+                      '-L/test/lib -L/other/lib ' +
+                      '-lfoo ' +
+                      '-Wl,-rpath,/first/rpath -Wl,-rpath,/second/rpath ' +
+                      '-Wl,-rpath,/third/rpath -Wl,-rpath,/fourth/rpath ' +
+                      '-Wl,-rpath,/spack-test-prefix/lib ' +
+                      '-Wl,-rpath,/spack-test-prefix/lib64')
 
         del os.environ['SPACK_CFLAGS']
         del os.environ['SPACK_CXXFLAGS']
@@ -222,9 +243,15 @@ class CompilerWrapperTest(unittest.TestCase):
         """Ensure RPATHs for root package are added."""
         self.check_cc('dump-args', test_command,
                       self.realcc + ' ' +
-                      '-Wl,-rpath,' + self.prefix + '/lib ' +
-                      '-Wl,-rpath,' + self.prefix + '/lib64 ' +
-                      ' '.join(test_command))
+                      '-I/test/include -I/other/include arg1 ' +
+                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
+                      '-Wl,--end-group ' +
+                      '-llib3 -llib4 arg5 arg6 ' +
+                      '-L/test/lib -L/other/lib ' +
+                      '-Wl,-rpath,/first/rpath -Wl,-rpath,/second/rpath ' +
+                      '-Wl,-rpath,/third/rpath -Wl,-rpath,/fourth/rpath ' +
+                      '-Wl,-rpath,/spack-test-prefix/lib ' +
+                      '-Wl,-rpath,/spack-test-prefix/lib64')
 
     def test_dep_include(self):
         """Ensure a single dependency include directory is added."""
@@ -233,10 +260,16 @@ class CompilerWrapperTest(unittest.TestCase):
         os.environ['SPACK_LINK_DEPS'] = os.environ['SPACK_DEPENDENCIES']
         self.check_cc('dump-args', test_command,
                       self.realcc + ' ' +
-                      '-Wl,-rpath,' + self.prefix + '/lib ' +
-                      '-Wl,-rpath,' + self.prefix + '/lib64 ' +
-                      '-I' + self.dep4 + '/include ' +
-                      ' '.join(test_command))
+                      '-I/test/include -I/other/include ' +
+                      '-I' + self.dep4 + '/include arg1 ' +
+                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
+                      '-Wl,--end-group ' +
+                      '-llib3 -llib4 arg5 arg6 ' +
+                      '-L/test/lib -L/other/lib ' +
+                      '-Wl,-rpath,/first/rpath -Wl,-rpath,/second/rpath ' +
+                      '-Wl,-rpath,/third/rpath -Wl,-rpath,/fourth/rpath ' +
+                      '-Wl,-rpath,/spack-test-prefix/lib ' +
+                      '-Wl,-rpath,/spack-test-prefix/lib64')
 
     def test_dep_lib(self):
         """Ensure a single dependency RPATH is added."""
@@ -245,11 +278,17 @@ class CompilerWrapperTest(unittest.TestCase):
         os.environ['SPACK_LINK_DEPS'] = os.environ['SPACK_DEPENDENCIES']
         self.check_cc('dump-args', test_command,
                       self.realcc + ' ' +
-                      '-Wl,-rpath,' + self.prefix + '/lib ' +
-                      '-Wl,-rpath,' + self.prefix + '/lib64 ' +
+                      '-I/test/include -I/other/include arg1 ' +
+                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
+                      '-Wl,--end-group ' +
+                      '-llib3 -llib4 arg5 arg6 ' +
+                      '-L/test/lib -L/other/lib ' +
                       '-L' + self.dep2 + '/lib64 ' +
-                      '-Wl,-rpath,' + self.dep2 + '/lib64 ' +
-                      ' '.join(test_command))
+                      '-Wl,-rpath,/first/rpath -Wl,-rpath,/second/rpath ' +
+                      '-Wl,-rpath,/third/rpath -Wl,-rpath,/fourth/rpath ' +
+                      '-Wl,-rpath,/spack-test-prefix/lib ' +
+                      '-Wl,-rpath,/spack-test-prefix/lib64 ' +
+                      '-Wl,-rpath,' + self.dep2 + '/lib64')
 
     def test_dep_lib_no_rpath(self):
         """Ensure a single dependency link flag is added with no dep RPATH."""
@@ -257,10 +296,16 @@ class CompilerWrapperTest(unittest.TestCase):
         os.environ['SPACK_LINK_DEPS'] = os.environ['SPACK_DEPENDENCIES']
         self.check_cc('dump-args', test_command,
                       self.realcc + ' ' +
-                      '-Wl,-rpath,' + self.prefix + '/lib ' +
-                      '-Wl,-rpath,' + self.prefix + '/lib64 ' +
+                      '-I/test/include -I/other/include arg1 ' +
+                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
+                      '-Wl,--end-group ' +
+                      '-llib3 -llib4 arg5 arg6 ' +
+                      '-L/test/lib -L/other/lib ' +
                       '-L' + self.dep2 + '/lib64 ' +
-                      ' '.join(test_command))
+                      '-Wl,-rpath,/first/rpath -Wl,-rpath,/second/rpath ' +
+                      '-Wl,-rpath,/third/rpath -Wl,-rpath,/fourth/rpath ' +
+                      '-Wl,-rpath,/spack-test-prefix/lib ' +
+                      '-Wl,-rpath,/spack-test-prefix/lib64')
 
     def test_dep_lib_no_lib(self):
         """Ensure a single dependency RPATH is added with no -L."""
@@ -268,10 +313,16 @@ class CompilerWrapperTest(unittest.TestCase):
         os.environ['SPACK_RPATH_DEPS'] = os.environ['SPACK_DEPENDENCIES']
         self.check_cc('dump-args', test_command,
                       self.realcc + ' ' +
-                      '-Wl,-rpath,' + self.prefix + '/lib ' +
-                      '-Wl,-rpath,' + self.prefix + '/lib64 ' +
-                      '-Wl,-rpath,' + self.dep2 + '/lib64 ' +
-                      ' '.join(test_command))
+                      '-I/test/include -I/other/include arg1 ' +
+                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
+                      '-Wl,--end-group ' +
+                      '-llib3 -llib4 arg5 arg6 ' +
+                      '-L/test/lib -L/other/lib ' +
+                      '-Wl,-rpath,/first/rpath -Wl,-rpath,/second/rpath ' +
+                      '-Wl,-rpath,/third/rpath -Wl,-rpath,/fourth/rpath ' +
+                      '-Wl,-rpath,/spack-test-prefix/lib ' +
+                      '-Wl,-rpath,/spack-test-prefix/lib64 ' +
+                      '-Wl,-rpath,' + self.dep2 + '/lib64')
 
     def test_all_deps(self):
         """Ensure includes and RPATHs for all deps are added. """
@@ -285,23 +336,25 @@ class CompilerWrapperTest(unittest.TestCase):
         # to.  We could loosen that if it becomes necessary
         self.check_cc('dump-args', test_command,
                       self.realcc + ' ' +
-                      '-Wl,-rpath,' + self.prefix + '/lib ' +
-                      '-Wl,-rpath,' + self.prefix + '/lib64 ' +
-
-                      '-I' + self.dep4 + '/include ' +
-
-                      '-L' + self.dep3 + '/lib64 ' +
-                      '-Wl,-rpath,' + self.dep3 + '/lib64 ' +
-                      '-I' + self.dep3 + '/include ' +
-
-                      '-L' + self.dep2 + '/lib64 ' +
-                      '-Wl,-rpath,' + self.dep2 + '/lib64 ' +
-
-                      '-L' + self.dep1 + '/lib ' +
-                      '-Wl,-rpath,' + self.dep1 + '/lib ' +
+                      '-I/test/include -I/other/include ' +
                       '-I' + self.dep1 + '/include ' +
-
-                      ' '.join(test_command))
+                      '-I' + self.dep3 + '/include ' +
+                      '-I' + self.dep4 + '/include ' +
+                      'arg1 ' +
+                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
+                      '-Wl,--end-group ' +
+                      '-llib3 -llib4 arg5 arg6 ' +
+                      '-L/test/lib -L/other/lib ' +
+                      '-L' + self.dep1 + '/lib ' +
+                      '-L' + self.dep2 + '/lib64 ' +
+                      '-L' + self.dep3 + '/lib64 ' +
+                      '-Wl,-rpath,/first/rpath -Wl,-rpath,/second/rpath ' +
+                      '-Wl,-rpath,/third/rpath -Wl,-rpath,/fourth/rpath ' +
+                      '-Wl,-rpath,/spack-test-prefix/lib ' +
+                      '-Wl,-rpath,/spack-test-prefix/lib64 ' +
+                      '-Wl,-rpath,' + self.dep1 + '/lib ' +
+                      '-Wl,-rpath,' + self.dep2 + '/lib64 ' +
+                      '-Wl,-rpath,' + self.dep3 + '/lib64')
 
     def test_ld_deps(self):
         """Ensure no (extra) -I args or -Wl, are passed in ld mode."""
@@ -312,19 +365,22 @@ class CompilerWrapperTest(unittest.TestCase):
 
         self.check_ld('dump-args', test_command,
                       'ld ' +
-                      '-rpath ' + self.prefix + '/lib ' +
-                      '-rpath ' + self.prefix + '/lib64 ' +
-
-                      '-L' + self.dep3 + '/lib64 ' +
-                      '-rpath ' + self.dep3 + '/lib64 ' +
-
-                      '-L' + self.dep2 + '/lib64 ' +
-                      '-rpath ' + self.dep2 + '/lib64 ' +
-
+                      '-I/test/include -I/other/include ' +
+                      'arg1 ' +
+                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
+                      '-Wl,--end-group ' +
+                      '-llib3 -llib4 arg5 arg6 ' +
+                      '-L/test/lib -L/other/lib ' +
                       '-L' + self.dep1 + '/lib ' +
+                      '-L' + self.dep2 + '/lib64 ' +
+                      '-L' + self.dep3 + '/lib64 ' +
+                      '-rpath /first/rpath -rpath /second/rpath ' +
+                      '-rpath /third/rpath -rpath /fourth/rpath ' +
+                      '-rpath /spack-test-prefix/lib ' +
+                      '-rpath /spack-test-prefix/lib64 ' +
                       '-rpath ' + self.dep1 + '/lib ' +
-
-                      ' '.join(test_command))
+                      '-rpath ' + self.dep2 + '/lib64 ' +
+                      '-rpath ' + self.dep3 + '/lib64')
 
     def test_ld_deps_no_rpath(self):
         """Ensure SPACK_RPATH_DEPS controls RPATHs for ld."""
@@ -334,14 +390,19 @@ class CompilerWrapperTest(unittest.TestCase):
 
         self.check_ld('dump-args', test_command,
                       'ld ' +
-                      '-rpath ' + self.prefix + '/lib ' +
-                      '-rpath ' + self.prefix + '/lib64 ' +
-
-                      '-L' + self.dep3 + '/lib64 ' +
-                      '-L' + self.dep2 + '/lib64 ' +
+                      '-I/test/include -I/other/include ' +
+                      'arg1 ' +
+                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
+                      '-Wl,--end-group ' +
+                      '-llib3 -llib4 arg5 arg6 ' +
+                      '-L/test/lib -L/other/lib ' +
                       '-L' + self.dep1 + '/lib ' +
-
-                      ' '.join(test_command))
+                      '-L' + self.dep2 + '/lib64 ' +
+                      '-L' + self.dep3 + '/lib64 ' +
+                      '-rpath /first/rpath -rpath /second/rpath ' +
+                      '-rpath /third/rpath -rpath /fourth/rpath ' +
+                      '-rpath /spack-test-prefix/lib ' +
+                      '-rpath /spack-test-prefix/lib64')
 
     def test_ld_deps_no_link(self):
         """Ensure SPACK_LINK_DEPS controls -L for ld."""
@@ -351,14 +412,19 @@ class CompilerWrapperTest(unittest.TestCase):
 
         self.check_ld('dump-args', test_command,
                       'ld ' +
-                      '-rpath ' + self.prefix + '/lib ' +
-                      '-rpath ' + self.prefix + '/lib64 ' +
-
-                      '-rpath ' + self.dep3 + '/lib64 ' +
-                      '-rpath ' + self.dep2 + '/lib64 ' +
+                      '-I/test/include -I/other/include ' +
+                      'arg1 ' +
+                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
+                      '-Wl,--end-group ' +
+                      '-llib3 -llib4 arg5 arg6 ' +
+                      '-L/test/lib -L/other/lib ' +
+                      '-rpath /first/rpath -rpath /second/rpath ' +
+                      '-rpath /third/rpath -rpath /fourth/rpath ' +
+                      '-rpath /spack-test-prefix/lib ' +
+                      '-rpath /spack-test-prefix/lib64 ' +
                       '-rpath ' + self.dep1 + '/lib ' +
-
-                      ' '.join(test_command))
+                      '-rpath ' + self.dep2 + '/lib64 ' +
+                      '-rpath ' + self.dep3 + '/lib64')
 
     def test_ld_deps_reentrant(self):
         """Make sure ld -r is handled correctly on OS's where it doesn't
@@ -371,18 +437,30 @@ class CompilerWrapperTest(unittest.TestCase):
         reentrant_test_command = ['-r'] + test_command
         self.check_ld('dump-args', reentrant_test_command,
                       'ld ' +
-                      '-rpath ' + self.prefix + '/lib ' +
-                      '-rpath ' + self.prefix + '/lib64 ' +
-
+                      '-I/test/include -I/other/include ' +
+                      '-r arg1 ' +
+                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
+                      '-Wl,--end-group ' +
+                      '-llib3 -llib4 arg5 arg6 ' +
+                      '-L/test/lib -L/other/lib ' +
                       '-L' + self.dep1 + '/lib ' +
-                      '-rpath ' + self.dep1 + '/lib ' +
+                      '-rpath /first/rpath -rpath /second/rpath ' +
+                      '-rpath /third/rpath -rpath /fourth/rpath ' +
+                      '-rpath /spack-test-prefix/lib ' +
+                      '-rpath /spack-test-prefix/lib64 ' +
+                      '-rpath ' + self.dep1 + '/lib')
 
-                      '-r ' +
-                      ' '.join(test_command))
-
+        # rpaths from the underlying command will still appear
+        # Spack will not add its own rpaths.
         os.environ['SPACK_SHORT_SPEC'] = "foo@1.2=darwin-x86_64"
         self.check_ld('dump-args', reentrant_test_command,
                       'ld ' +
+                      '-I/test/include -I/other/include ' +
+                      '-r arg1 ' +
+                      '-Wl,--start-group arg2 arg3 -llib1 -llib2 arg4 ' +
+                      '-Wl,--end-group ' +
+                      '-llib3 -llib4 arg5 arg6 ' +
+                      '-L/test/lib -L/other/lib ' +
                       '-L' + self.dep1 + '/lib ' +
-                      '-r ' +
-                      ' '.join(test_command))
+                      '-rpath /first/rpath -rpath /second/rpath ' +
+                      '-rpath /third/rpath -rpath /fourth/rpath')

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -22,7 +22,9 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
+import contextlib
 import os
+
 
 system_paths = ['/', '/usr', '/usr/local']
 suffixes = ['bin', 'bin64', 'include', 'lib', 'lib64']
@@ -86,3 +88,30 @@ def dump_environment(path):
     with open(path, 'w') as env_file:
         for key, val in sorted(os.environ.items()):
             env_file.write('export %s="%s"\n' % (key, val))
+
+
+@contextlib.contextmanager
+def set_env(**kwargs):
+    """Temporarily sets and restores environment variables.
+
+    Variables can be set as keyword arguments to this function.
+    """
+    saved = {}
+    for var, value in kwargs.items():
+        if var in os.environ:
+            saved[var] = os.environ[var]
+
+        if value is None:
+            if var in os.environ:
+                del os.environ[var]
+        else:
+            os.environ[var] = value
+
+    yield
+
+    for var, value in kwargs.items():
+        if var in saved:
+            os.environ[var] = saved[var]
+        else:
+            if var in os.environ:
+                del os.environ[var]


### PR DESCRIPTION
Restoring the features from #4692.

**WIP because this is a placeholder. There are no fixes yet.**

@becker33: this is a branch to revert #8888 (or to un-revert #4692, I guess).

There are a few remaining things to do before we can merge this back to `develop`:
- [x] FIx the issue found in #8882.
- [x] Fix the issue found in #8887.
- [x] Make sure `openmpi` builds ok on Mac OS X (I got duplicate symbol issues there with the changes in #4692).
- [x] Make sure this does not blow away `ccache` support (currently it does).
- [x] Make sure this doesn't slow down builds using the new wrappers.

I am not sure what's causing the two issues above yet.

The OpenMPI issues I mentioned came from trying to build `petsc` -- OpenMPI won't build with the changes as it gets symbol errors linking `libopen-pal.40.dylib`.  I also noticed that there are warnings in the OpenMPI `clang` build that don't show up without the changes in #4692.  Specifically, stuff like this shows up for all the Spack `-L` arguments:

```
  CC       base/btl_base_error.lo
clang: warning: argument unused during compilation: '-L/Users/gamblin2/src/spack/opt/spack/darwin-highsierra-x86_64/clang-8.1.0-apple/zlib-1.2.11-oasmkjnms36btaqqiyefr6mprbg2ebgv/lib' [-Wunused-command-line-argument]
clang: warning: argument unused during compilation: '-L/Users/gamblin2/src/spack/opt/spack/darwin-highsierra-x86_64/clang-8.1.0-apple/hwloc-1.11.9-xtrbltqpraetc5jgae3as2rqtwdhdcrx/lib' [-Wunused-command-line-argument]
clang: warning: argument unused during compilation: '-L/Users/gamblin2/src/spack/opt/spack/darwin-highsierra-x86_64/clang-8.1.0-apple/libxml2-2.9.8-vrtvvruz4fsrvtaww7pazkjvkojjuvsr/lib' [-Wunused-command-line-argument]
clang: warning: argument unused during compilation: '-L/Users/gamblin2/src/spack/opt/spack/darwin-highsierra-x86_64/clang-8.1.0-apple/zlib-1.2.11-oasmkjnms36btaqqiyefr6mprbg2ebgv/lib' [-Wunused-command-line-argument]
clang: warning: argument unused during compilation: '-L/Users/gamblin2/src/spack/opt/spack/darwin-highsierra-x86_64/clang-8.1.0-apple/hwloc-1.11.9-xtrbltqpraetc5jgae3as2rqtwdhdcrx/lib' [-Wunused-command-line-argument]
clang: warning: argument unused during compilation: '-L/Users/gamblin2/src/spack/opt/spack/darwin-highsierra-x86_64/clang-8.1.0-apple/libxml2-2.9.8-vrtvvruz4fsrvtaww7pazkjvkojjuvsr/lib' [-Wunused-command-line-argument]
clang: warning: argument unused during compilation: '-L/Users/gamblin2/src/spack/opt/spack/darwin-highsierra-x86_64/clang-8.1.0-apple/xz-5.2.4-osadmc6b5ynkbhavfngeeuamph67zbc6/lib' [-Wunused-command-line-argument]
```

That makes me think they should be first or they won't get used.

