### PR TITLE
Bump mvapich2 to the latest v2.3 release.

### DIFF
--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -46,7 +46,8 @@ class Mvapich2(AutotoolsPackage):
     version('2.3a', '87c3fbf8a755b53806fa9ecb21453445')
 
     # Prefer the latest stable release
-    version('2.2', '939b65ebe5b89a5bc822cdab0f31f96e', preferred=True)
+    version('2.3', sha256='01d5fb592454ddd9ecc17e91c8983b6aea0e7559aa38f410b111c8ef385b50dd', preferred=True)
+    version('2.2', '939b65ebe5b89a5bc822cdab0f31f96e')
     version('2.1', '0095ceecb19bbb7fb262131cb9c2cdd6')
     version('2.0', '9fbb68a4111a8b6338e476dc657388b4')
 


### PR DESCRIPTION
MVAPICH2 v2.3 has been built sucessfully against GCC 5.4.0 on CentOS 7.