### PR TITLE
Libtool: version 'develop'

### DIFF
--- a/var/spack/repos/builtin/packages/libtool/flag_space.patch
+++ b/var/spack/repos/builtin/packages/libtool/flag_space.patch
@@ -1,0 +1,19 @@
+diff --git a/m4/libtool.m4 b/m4/libtool.m4
+index b55a6e57..26febc87 100644
+--- a/m4/libtool.m4
++++ b/m4/libtool.m4
+@@ -7557,10 +7557,11 @@ if AC_TRY_EVAL(ac_compile); then
+     case $prev$p in
+ 
+     -L* | -R* | -l*)
+-       # Some compilers place space between "-{L,R}" and the path.
++       # Some compilers place space between "-{L,R,l}" and the path (value).
+        # Remove the space.
+-       if test x-L = "$p" ||
+-          test x-R = "$p"; then
++       if test x-L = x"$p" ||
++          test x-R = x"$p" ||
++          test x-l = x"$p"; then
+ 	 prev=$p
+ 	 continue
+        fi

--- a/var/spack/repos/builtin/packages/libtool/package.py
+++ b/var/spack/repos/builtin/packages/libtool/package.py
@@ -43,6 +43,10 @@ class Libtool(AutotoolsPackage):
     depends_on('xz', type='build', when='@develop')
     depends_on('texinfo', type='build', when='@develop')
 
+    # Fix parsing of compiler output when collecting predeps and postdeps
+    # http://lists.gnu.org/archive/html/bug-libtool/2016-03/msg00003.html
+    patch('flag_space.patch', when='@develop')
+
     build_directory = 'spack-build'
 
     @when('@develop')

--- a/var/spack/repos/builtin/packages/libtool/package.py
+++ b/var/spack/repos/builtin/packages/libtool/package.py
@@ -31,12 +31,23 @@ class Libtool(AutotoolsPackage):
     homepage = 'https://www.gnu.org/software/libtool/'
     url = 'http://ftpmirror.gnu.org/libtool/libtool-2.4.2.tar.gz'
 
+    version('develop', git='https://git.savannah.gnu.org/git/libtool.git',
+            branch='master')
     version('2.4.6', 'addf44b646ddb4e3919805aa88fa7c5e')
     version('2.4.2', 'd2f3b7d4627e69e13514a40e72a24d50')
 
     depends_on('m4@1.4.6:', type='build')
+    depends_on('autoconf', type='build', when='@develop')
+    depends_on('automake', type='build', when='@develop')
+    depends_on('help2man', type='build', when='@develop')
+    depends_on('xz', type='build', when='@develop')
+    depends_on('texinfo', type='build', when='@develop')
 
     build_directory = 'spack-build'
+
+    @when('@develop')
+    def autoreconf(self, spec, prefix):
+        Executable('./bootstrap')()
 
     def _make_executable(self, name):
         return Executable(join_path(self.prefix.bin, name))


### PR DESCRIPTION
It takes ages for any patches for libtool to get accepted, merged and released (if at all). This PR introduces version `@develop` with all prerequisites for bootstrapping. It should be noted that the releases can be and must be bootstrapped (with flag `--force`) if any patches are applied to them. So, I suggest that we have only one version `@develop` for any patches that we would like to have. This will also be easier to maintain them: no need to check if a patch works for any other version.

The first patch, which is included in this PR, fixes incorrect parsing of additional linking flags appended by a compiler. The comment in `libtool.m4` says that 

> Some  compilers place space between "-{L,R}" and the path.

but the logic implemented after the comment doesn't actually work. The patch fixes that as well as extends it for the flag `-l` too. For example, Cray's compiler wrapper `ftn` adds `-l gfortran` (instead of `-lgfortran`), which confuses `libtool`.