### PR TITLE
py-crossmap: needs py-setuptools

### DIFF
--- a/var/spack/repos/builtin/packages/py-crossmap/package.py
+++ b/var/spack/repos/builtin/packages/py-crossmap/package.py
@@ -38,4 +38,4 @@ class PyCrossmap(PythonPackage):
     depends_on('py-cython@0.17:', type='build')
     depends_on('py-pysam', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
-    depends_on('py-bx-python', type='run')
+    depends_on('py-bx-python', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-crossmap/package.py
+++ b/var/spack/repos/builtin/packages/py-crossmap/package.py
@@ -36,5 +36,6 @@ class PyCrossmap(PythonPackage):
 
     depends_on('python@2.7:2.7.999', type=('build', 'run'))
     depends_on('py-cython@0.17:', type='build')
-    depends_on('py-pysam', type='build')
+    depends_on('py-pysam', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
+    depends_on('py-bx-python', type='run')

--- a/var/spack/repos/builtin/packages/py-crossmap/package.py
+++ b/var/spack/repos/builtin/packages/py-crossmap/package.py
@@ -36,4 +36,5 @@ class PyCrossmap(PythonPackage):
 
     depends_on('python@2.7:2.7.999', type=('build', 'run'))
     depends_on('py-cython@0.17:', type='build')
-    depends_on('py-pysam',        type='build')
+    depends_on('py-pysam', type='build')
+    depends_on('py-setuptools', type='build')


### PR DESCRIPTION
Without this, I get: 
```  
File "setup.py", line 3, in <module>
    from setuptools import *
ImportError: No module named setuptools
```