### PR TITLE
Make the full_hash look like the dag_hash

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1440,8 +1440,13 @@ class Spec(object):
                 self.to_node_dict(hash_function=lambda s: s.full_hash()),
                 default_flow_style=True, width=maxint)
             package_hash = self.package.content_hash()
-            sha = hashlib.sha256(yaml_text.encode('utf-8') + package_hash)
-            self._full_hash = base64.b32encode(sha.digest()).lower()
+            sha = hashlib.sha1(yaml_text.encode('utf-8') + package_hash)
+
+            b32_hash = base64.b32encode(sha.digest()).lower()
+            if sys.version_info[0] >= 3:
+                b32_hash = b32_hash.decode('utf-8')
+
+            self._full_hash = b32_hash
 
         return self._full_hash[:length]
 


### PR DESCRIPTION
As requested in the review of #8718, this change makes the format/length of the `full_hash` match that of the `dag_hash`. 