### PR TITLE
superlu_dist should be built with 'HAVE_PARMETIS=TRUE'.

### DIFF
--- a/var/spack/repos/builtin/packages/superlu-dist/package.py
+++ b/var/spack/repos/builtin/packages/superlu-dist/package.py
@@ -71,6 +71,7 @@ class SuperluDist(Package):
             'BLASLIB      = %s' % lapack_blas.ld_flags,
             'METISLIB     = %s' % spec['metis'].libs.ld_flags,
             'PARMETISLIB  = %s' % spec['parmetis'].libs.ld_flags,
+            'HAVE_PARMETIS= TRUE',
             'FLIBS        =',
             'LIBS         = $(DSUPERLULIB) $(BLASLIB) $(PARMETISLIB) $(METISLIB)',  # noqa
             'ARCH         = ar',


### PR DESCRIPTION
Fix from @xiaoyeli

Note: currently parmetis is a hard dpependency in spack install of superlu-dist. So fix is to to always add `HAVE_PARMETIS=TRUE` flag to the build 