### PR TITLE
Remove duplicate declaration of "graph" variant in Boost package

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -132,8 +132,6 @@ class Boost(Package):
             description="Build single-threaded versions of libraries")
     variant('icu', default=False,
             description="Build with Unicode and ICU suport")
-    variant('graph', default=False,
-            description="Build the Boost Graph library")
     variant('taggedlayout', default=False,
             description="Augment library names with build options")
     variant('versionedlayout', default=False,


### PR DESCRIPTION
The "graph" variant is declared twice in the Boost package, with two different defaults. This PR removes the declaration which I identified as being the "wrong" one, as it strays apart from the regular pattern of this package.