### PR TITLE
glib: A patch to enable Red Hat 6 users to be able to compile the current version

### DIFF
--- a/var/spack/repos/builtin/packages/glib/old-kernels.patch
+++ b/var/spack/repos/builtin/packages/glib/old-kernels.patch
@@ -1,0 +1,16 @@
+--- a/gio/gfile.c     2018-06-11 15:28:30.527667202 -0500
++++ b/gio/gfile.c     2018-03-12 11:23:37.000000000 -0500
+@@ -3014,11 +3014,11 @@
+ 
+   /* Try a 1MiB buffer for improved throughput. If that fails, use the default
+    * pipe size. See: https://bugzilla.gnome.org/791457 */
+-  buffer_size = fcntl (buffer[1], F_SETPIPE_SZ, 1024 * 1024);
++  buffer_size = 65536;
+   if (buffer_size <= 0)
+     {
+       int errsv;
+-      buffer_size = fcntl (buffer[1], F_GETPIPE_SZ);
++      buffer_size = 65536;
+       errsv = errno;
+ 
+       if (buffer_size <= 0)

--- a/var/spack/repos/builtin/packages/glib/old-kernels.patch
+++ b/var/spack/repos/builtin/packages/glib/old-kernels.patch
@@ -5,7 +5,7 @@
    /* Try a 1MiB buffer for improved throughput. If that fails, use the default
     * pipe size. See: https://bugzilla.gnome.org/791457 */
 -  buffer_size = fcntl (buffer[1], F_SETPIPE_SZ, 1024 * 1024);
-+  buffer_size = 65536;
++  buffer_size = -1;
    if (buffer_size <= 0)
      {
        int errsv;

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -58,6 +58,7 @@ class Glib(AutotoolsPackage):
         multi=True,
         description='Enable tracing support'
     )
+    variant('oldkernel', default=False, description='Fix for kernels older than 2.6.35 and glib 2.56+')
 
     depends_on('pkgconfig', type='build')
     depends_on('libffi')
@@ -73,6 +74,8 @@ class Glib(AutotoolsPackage):
     # Clang doesn't seem to acknowledge the pragma lines to disable the -Werror
     # around a legitimate usage.
     patch('no-Werror=format-security.patch')
+    # Patch to prevent compiler errors in kernels older than 2.6.35
+    patch('old-kernels.patch', spec='+oldkernel')
 
     def url_for_version(self, version):
         """Handle glib's version-based custom URLs."""

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -75,7 +75,7 @@ class Glib(AutotoolsPackage):
     # around a legitimate usage.
     patch('no-Werror=format-security.patch')
     # Patch to prevent compiler errors in kernels older than 2.6.35
-    patch('old-kernels.patch', spec='+oldkernel')
+    patch('old-kernels.patch', when='+oldkernel')
 
     def url_for_version(self, version):
         """Handle glib's version-based custom URLs."""

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -58,7 +58,6 @@ class Glib(AutotoolsPackage):
         multi=True,
         description='Enable tracing support'
     )
-    variant('oldkernel', default=False, description='Fix for kernels older than 2.6.35 and glib 2.56+')
 
     depends_on('pkgconfig', type='build')
     depends_on('libffi')
@@ -75,7 +74,9 @@ class Glib(AutotoolsPackage):
     # around a legitimate usage.
     patch('no-Werror=format-security.patch')
     # Patch to prevent compiler errors in kernels older than 2.6.35
-    patch('old-kernels.patch', when='+oldkernel')
+    patch('old-kernels.patch', when='@2.56: os=rhel6')
+    patch('old-kernels.patch', when='@2.56: os=centos6')
+    patch('old-kernels.patch', when='@2.56: os=sl6')
 
     def url_for_version(self, version):
         """Handle glib's version-based custom URLs."""


### PR DESCRIPTION
Red Hat/Centos 6 users get undefined variables when compiling at 2.56.  This patch removes the undefined variables and puts in the normal value for the buffer size.