### PR TITLE
Add package for fasta

### DIFF
--- a/var/spack/repos/builtin/packages/fasta/package.py
+++ b/var/spack/repos/builtin/packages/fasta/package.py
@@ -49,9 +49,9 @@ class Fasta(MakefilePackage):
     def makefile_name(self):
         if self.spec.satisfies('platform=darwin'):
             name = 'Makefile.os_x86_64'
-        elif self.spec.satisfies('platform=linux'):
-            if self.spec.satisfies('target=x86_64'):
-                name = 'Makefile.linux64_sse2'
+        elif (self.spec.satisfies('platform=linux') and
+              self.spec.satisfies('target=x86_64')):
+            name = 'Makefile.linux64_sse2'
         else:
             tty.die('''Unsupported platform/target, must be
 Darwin (assumes 64-bit)

--- a/var/spack/repos/builtin/packages/fasta/package.py
+++ b/var/spack/repos/builtin/packages/fasta/package.py
@@ -65,7 +65,7 @@ Linux x86_64
 
     def edit(self, spec, prefix):
         makefile = FileFilter(self.makefile_path)
-        makefile.filter('XDIR = .*', 'XDIR = {}'.format(prefix.bin))
+        makefile.filter('XDIR = .*', 'XDIR = {0}'.format(prefix.bin))
 
     def build(self, spec, prefix):
         with working_dir('src'):

--- a/var/spack/repos/builtin/packages/fasta/package.py
+++ b/var/spack/repos/builtin/packages/fasta/package.py
@@ -1,0 +1,70 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Fasta(Package):
+    """The FASTA programs find regions of local or global similarity
+between Protein or DNA sequences, either by searching Protein or DNA
+databases, or by identifying local duplications within a
+sequence. Other programs provide information on the statistical
+significance of an alignment. Like BLAST, FASTA can be used to infer
+functional and evolutionary relationships between sequences as well as
+help identify members of gene families."""
+
+    homepage = "https://fasta.bioch.virginia.edu/fasta_www2/fasta_list2.shtml"
+    url      = "https://github.com/wrpearson/fasta36/archive/fasta-v36.3.8g.tar.gz"
+
+    version('36.3.8g', sha256='fa5318b6f8d6a3cfdef0d29de530eb005bfd3ca05835faa6ad63663f8dce7b2e')
+
+    depends_on('zlib')
+
+    # The src tree includes a plethora of variant Makefiles and the
+    # builder is expected to choose one that's appropriate.  This'll
+    # do for a first cut.  I can't test anything else....
+    @property
+    def makefile_name(self):
+        if self.spec.satisfies('platform=darwin'):
+            name = 'Makefile.os_x86_64'
+        elif self.spec.satisfies('platform=linux'):
+            if self.spec.satisfies('target=x86_64'):
+                name = 'Makefile.linux64_sse2'
+        else:
+            tty.die('''Unsupported platform/target, must be
+Darwin (assumes 64-bit)
+Linux x86_64
+''')
+        return name
+
+    def install(self, spec, prefix):
+        with working_dir('make'):
+            makefile = FileFilter(self.makefile_name)
+            makefile.filter('XDIR = .*', 'XDIR = {}'.format(prefix.bin))
+
+        with working_dir('src'):
+            makefile_path = join_path('..', 'make', self.makefile_name)
+            make('-f', makefile_path)
+            mkdir(prefix.bin)
+            make('-f', makefile_path, 'install')

--- a/var/spack/repos/builtin/packages/fasta/package.py
+++ b/var/spack/repos/builtin/packages/fasta/package.py
@@ -25,14 +25,15 @@
 from spack import *
 
 
-class Fasta(Package):
+class Fasta(MakefilePackage):
     """The FASTA programs find regions of local or global similarity
-between Protein or DNA sequences, either by searching Protein or DNA
-databases, or by identifying local duplications within a
-sequence. Other programs provide information on the statistical
-significance of an alignment. Like BLAST, FASTA can be used to infer
-functional and evolutionary relationships between sequences as well as
-help identify members of gene families."""
+    between Protein or DNA sequences, either by searching Protein or
+    DNA databases, or by identifying local duplications within a
+    sequence. Other programs provide information on the statistical
+    significance of an alignment. Like BLAST, FASTA can be used to
+    infer functional and evolutionary relationships between sequences
+    as well as help identify members of gene families.
+    """
 
     homepage = "https://fasta.bioch.virginia.edu/fasta_www2/fasta_list2.shtml"
     url      = "https://github.com/wrpearson/fasta36/archive/fasta-v36.3.8g.tar.gz"
@@ -58,13 +59,19 @@ Linux x86_64
 ''')
         return name
 
-    def install(self, spec, prefix):
-        with working_dir('make'):
-            makefile = FileFilter(self.makefile_name)
-            makefile.filter('XDIR = .*', 'XDIR = {}'.format(prefix.bin))
+    @property
+    def makefile_path(self):
+        return join_path(self.stage.source_path, 'make', self.makefile_name)
 
+    def edit(self, spec, prefix):
+        makefile = FileFilter(self.makefile_path)
+        makefile.filter('XDIR = .*', 'XDIR = {}'.format(prefix.bin))
+
+    def build(self, spec, prefix):
         with working_dir('src'):
-            makefile_path = join_path('..', 'make', self.makefile_name)
-            make('-f', makefile_path)
+            make('-f', self.makefile_path)
+
+    def install(self, spec, prefix):
+        with working_dir('src'):
             mkdir(prefix.bin)
-            make('-f', makefile_path, 'install')
+            make('-f', self.makefile_path, 'install')


### PR DESCRIPTION
Add a package for the fasta sequence alignment tools.

The build system is novel (fasta is "venerable", so...).  The source tree includes nearly 50 variant Makefiles, the installer is expected to pick one that's appropriate and then edit the "XDIR" variable to specify the installation path.  I can only test 64 bit darwin and linux, so that's all I've included.  I'm also assuming that every 64bit x86 system we'll see supports the SSE2 extensions.  Other situations can be dealt with when someone has a test case.

I looked at using MakefilePackage but I didn't see how to specify the name of the Makefile that it used so this seemed cleaner.

Tested on a RHEL7 linux box and a High Sierra Mac by running the author's suggested test case:

```
fasta36 -q seq/mgstm1.aa seq/prot_test.lseg
```
