### PR TITLE
Don't run ibv_devices every time packages are loaded

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -88,7 +88,7 @@ class Openmpi(AutotoolsPackage):
 
     # Still supported
     version('3.0.2', '098fa89646f5b4438d9d8534bc960cd6')  # libmpi.so.40.00.2
-    version('3.0.1', '565f5060e080b0871a64b295c3d4426a')  # libmpi.so.40.00.1    
+    version('3.0.1', '565f5060e080b0871a64b295c3d4426a')  # libmpi.so.40.00.1
     version('3.0.0', '757d51719efec08f9f1a7f32d58b3305')  # libmpi.so.40.00.0
     version('2.1.3', '46079b6f898a412240a0bf523e6cd24b')  # libmpi.so.20.10.2
     version('2.1.2', 'ff2e55cc529802e7b0738cf87acd3ee4')  # libmpi.so.20.10.2
@@ -186,7 +186,7 @@ class Openmpi(AutotoolsPackage):
 
     variant(
         'fabrics',
-        default=None if _verbs_dir() is None else 'verbs',
+        default=None,
         description="List of fabrics that are enabled",
         values=fabrics,
         multi=True


### PR DESCRIPTION
While debugging #8954, I discovered that if you are on a system where `ibv_devices` exists, every time you run a command that touches any `package.py` file, the `openmpi` package tries to run `ibv_devices` to set the default variant value. This is true even if you don't reference any package that depends on `openmpi`. You can see this for yourself by running:
```console
$ spack --debug spec zlib
...
==> '/usr/bin/ibv_devices'
...
```
I don't think this is the root cause of #8954, but I also think running this command every time is unnecessary. Convenient, but slow.

This has been in place since @eschnett's #973.