### PR TITLE
Install headers and lib files to destination for legacy apps

### DIFF
--- a/var/spack/repos/builtin/packages/samtools/package.py
+++ b/var/spack/repos/builtin/packages/samtools/package.py
@@ -64,4 +64,5 @@ class Samtools(Package):
         mkdir(prefix.include)
         mkdir(prefix.lib)
         install('sam.h', prefix.include)
+        install('bam.h', prefix.include)
         install('libbam.a', prefix.lib)

--- a/var/spack/repos/builtin/packages/samtools/package.py
+++ b/var/spack/repos/builtin/packages/samtools/package.py
@@ -59,3 +59,9 @@ class Samtools(Package):
         else:
             make("prefix=%s" % prefix)
             make("prefix=%s" % prefix, "install")
+        # Install dev headers and libs for legacy apps depending on them
+        mkdir = which('mkdir')
+        mkdir(prefix.include)
+        mkdir(prefix.lib)
+        install('sam.h', prefix.include)
+        install('libbam.a', prefix.lib)

--- a/var/spack/repos/builtin/packages/samtools/package.py
+++ b/var/spack/repos/builtin/packages/samtools/package.py
@@ -60,7 +60,6 @@ class Samtools(Package):
             make("prefix=%s" % prefix)
             make("prefix=%s" % prefix, "install")
         # Install dev headers and libs for legacy apps depending on them
-        mkdir = which('mkdir')
         mkdir(prefix.include)
         mkdir(prefix.lib)
         install('sam.h', prefix.include)


### PR DESCRIPTION
Install samtools headers and lib files to destination for legacy apps, like #8959 .