### PR TITLE
Show external path for external packages

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -308,7 +308,10 @@ def display_specs(specs, args=None, **kwargs):
 
             for abbrv, spec in zip(abbreviated, specs):
                 prefix = gray_hash(spec, hlen) if hashes else ''
-                print(prefix + (format % (abbrv, spec.prefix)))
+                if spec.external_path:
+                    print(format % (abbrv, spec.external_path))
+                else:
+                    print(prefix + (format % (abbrv, spec.prefix)))
 
         elif mode == 'deps':
             for spec in specs:


### PR DESCRIPTION
Currently, spack does not show installation paths for external packages when running `spack find -p`. This will show the path for external packages as well, instead of displaying `None`.