### PR TITLE
Fix spack versions behavior when no URL

### DIFF
--- a/lib/spack/spack/cmd/versions.py
+++ b/lib/spack/spack/cmd/versions.py
@@ -42,20 +42,27 @@ def setup_parser(subparser):
 def versions(parser, args):
     pkg = spack.repo.get(args.package)
 
+    tty.msg('Safe versions (already checksummed):')
+
     safe_versions = pkg.versions
+
+    if not safe_versions:
+        print('  Found no versions for {0}'.format(pkg.name))
+        tty.debug('Manually add versions to the package.')
+    else:
+        colify(sorted(safe_versions, reverse=True), indent=2)
+
+    tty.msg('Remote versions (not yet checksummed):')
+
     fetched_versions = pkg.fetch_remote_versions()
     remote_versions = set(fetched_versions).difference(safe_versions)
 
-    tty.msg("Safe versions (already checksummed):")
-    colify(sorted(safe_versions, reverse=True), indent=2)
-
-    tty.msg("Remote versions (not yet checksummed):")
     if not remote_versions:
         if not fetched_versions:
-            print("  Found no versions for %s" % pkg.name)
-            tty.debug("Check the list_url and list_depth attribute on the "
-                      "package to help Spack find versions.")
+            print('  Found no versions for {0}'.format(pkg.name))
+            tty.debug('Check the list_url and list_depth attributes of the '
+                      'package to help Spack find versions.')
         else:
-            print("  Found no unchecksummed versions for %s" % pkg.name)
+            print('  Found no unchecksummed versions for {0}'.format(pkg.name))
     else:
         colify(sorted(remote_versions, reverse=True), indent=2)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2063,8 +2063,15 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
 
     @property
     def all_urls(self):
+        """A list of all URLs in a package.
+
+        Check both class-level and version-specific URLs.
+
+        Returns:
+            list: a list of URLs
+        """
         urls = []
-        if self.url:
+        if hasattr(self, 'url') and self.url:
             urls.append(self.url)
 
         for args in self.versions.values():
@@ -2073,10 +2080,15 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         return urls
 
     def fetch_remote_versions(self):
-        """Try to find remote versions of this package using the
-           list_url and any other URLs described in the package file."""
+        """Find remote versions of this package.
+
+        Uses ``list_url`` and any other URLs listed in the package file.
+
+        Returns:
+            dict: a dictionary mapping versions to URLs
+        """
         if not self.all_urls:
-            raise spack.util.web.VersionFetchError(self.__class__)
+            return {}
 
         try:
             return spack.util.web.find_versions_of_archive(

--- a/lib/spack/spack/test/cmd/versions.py
+++ b/lib/spack/spack/test/cmd/versions.py
@@ -48,3 +48,17 @@ def test_no_unchecksummed_versions():
     """Test a package for which no unchecksummed versions are available."""
 
     versions('bzip2')
+
+
+@pytest.mark.network
+def test_versions_no_url():
+    """Test a package with versions but without a ``url`` attribute."""
+
+    versions('graphviz')
+
+
+@pytest.mark.network
+def test_no_versions_no_url():
+    """Test a package without versions or a ``url`` attribute."""
+
+    versions('opengl')


### PR DESCRIPTION
This fixes a bug introduced by #3161 and generally improves the behavior of `spack versions` when URLs or versions are not present in a package.

### Before #3161 

Package with URL but no versions:
```console
$ spack versions zlib
==> Safe versions (already checksummed):
==> Remote versions (not yet checksummed):
  1.2.11  1.2.7.3  1.2.6.1  1.2.5.1  1.2.4.3  1.2.3.9  1.2.3.5  1.2.3.1  1.2.2.2  1.2.1.1  1.2.0.6  1.2.0.2  1.1.3  1.0.9  1.0.5  1.0-pre  0.93  0.71
  1.2.10  1.2.7.2  1.2.6    1.2.5    1.2.4.2  1.2.3.8  1.2.3.4  1.2.3    1.2.2.1  1.2.1    1.2.0.5  1.2.0.1  1.1.2  1.0.8  1.0.4  0.99     0.92  0.9
  1.2.9   1.2.7.1  1.2.5.3  1.2.4.5  1.2.4.1  1.2.3.7  1.2.3.3  1.2.2.4  1.2.2    1.2.0.8  1.2.0.4  1.2.0    1.1.1  1.0.7  1.0.2  0.95     0.91  0.8
  1.2.8   1.2.7    1.2.5.2  1.2.4.4  1.2.4    1.2.3.6  1.2.3.2  1.2.2.3  1.2.1.2  1.2.0.7  1.2.0.3  1.1.4    1.1.0  1.0.6  1.0.1  0.94     0.79
```
Package with versions but no URL:
```console
$ spack versions intel
==> Safe versions (already checksummed):
  18.0.1  18.0.0  17.0.4  17.0.3  17.0.2  17.0.1  17.0.0  16.0.4  16.0.3  16.0.2
==> Remote versions (not yet checksummed):
  Found no versions for intel
```
Package with no versions or URL:
```console
$ spack versions opengl
==> Error: <class 'spack.pkg.builtin.opengl.Opengl'>
```
### After #3161 

Package with URL but no versions:
```console
$ spack versions zlib
==> Safe versions (already checksummed):
==> Remote versions (not yet checksummed):
  1.2.11  1.2.7.3  1.2.6.1  1.2.5.1  1.2.4.3  1.2.3.9  1.2.3.5  1.2.3.1  1.2.2.2  1.2.1.1  1.2.0.6  1.2.0.2  1.1.3  1.0.9  1.0.5  1.0-pre  0.93  0.71
  1.2.10  1.2.7.2  1.2.6    1.2.5    1.2.4.2  1.2.3.8  1.2.3.4  1.2.3    1.2.2.1  1.2.1    1.2.0.5  1.2.0.1  1.1.2  1.0.8  1.0.4  0.99     0.92  0.9
  1.2.9   1.2.7.1  1.2.5.3  1.2.4.5  1.2.4.1  1.2.3.7  1.2.3.3  1.2.2.4  1.2.2    1.2.0.8  1.2.0.4  1.2.0    1.1.1  1.0.7  1.0.2  0.95     0.91  0.8
  1.2.8   1.2.7    1.2.5.2  1.2.4.4  1.2.4    1.2.3.6  1.2.3.2  1.2.2.3  1.2.1.2  1.2.0.7  1.2.0.3  1.1.4    1.1.0  1.0.6  1.0.1  0.94     0.79
```
Package with versions but no URL:
```console
$ spack versions intel
==> Error: 'Intel' object has no attribute 'url'
```
Package with no versions or URL:
```console
$ spack versions opengl
==> Error: 'Opengl' object has no attribute 'url'
```

### With this PR

Package with URL but no versions:
```console
$ spack versions zlib
==> Safe versions (already checksummed):
  Found no versions for zlib
==> Remote versions (not yet checksummed):
  1.2.11  1.2.7.3  1.2.6.1  1.2.5.1  1.2.4.3  1.2.3.9  1.2.3.5  1.2.3.1  1.2.2.2  1.2.1.1  1.2.0.6  1.2.0.2  1.1.3  1.0.9  1.0.5  1.0-pre  0.93  0.71
  1.2.10  1.2.7.2  1.2.6    1.2.5    1.2.4.2  1.2.3.8  1.2.3.4  1.2.3    1.2.2.1  1.2.1    1.2.0.5  1.2.0.1  1.1.2  1.0.8  1.0.4  0.99     0.92  0.9
  1.2.9   1.2.7.1  1.2.5.3  1.2.4.5  1.2.4.1  1.2.3.7  1.2.3.3  1.2.2.4  1.2.2    1.2.0.8  1.2.0.4  1.2.0    1.1.1  1.0.7  1.0.2  0.95     0.91  0.8
  1.2.8   1.2.7    1.2.5.2  1.2.4.4  1.2.4    1.2.3.6  1.2.3.2  1.2.2.3  1.2.1.2  1.2.0.7  1.2.0.3  1.1.4    1.1.0  1.0.6  1.0.1  0.94     0.79
```
Package with versions but no URL:
```console
$ spack versions intel
==> Safe versions (already checksummed):
  18.0.1  18.0.0  17.0.4  17.0.3  17.0.2  17.0.1  17.0.0  16.0.4  16.0.3  16.0.2
==> Remote versions (not yet checksummed):
  Found no versions for intel
```
Package with no versions or URL:
```console
$ spack versions opengl
==> Safe versions (already checksummed):
  Found no versions for opengl
==> Remote versions (not yet checksummed):
  Found no versions for opengl
```

Previously, Spack would spend several seconds spidering the web searching for new versions before anything was printed. Now, Spack immediately prints a list of safe versions and lets the user know that it is now searching for remote versions.

Feedback on error messages is welcome.

First reported by @ssergien 