### PR TITLE
openfoam-com: correctly use foam_add_lib()

### DIFF
--- a/var/spack/repos/builtin/packages/openfoam-com/package.py
+++ b/var/spack/repos/builtin/packages/openfoam-com/package.py
@@ -608,7 +608,7 @@ class OpenfoamCom(Package):
             self.etc_config['vtk'] = [
                 ('VTK_DIR', spec['vtk'].prefix),
                 ('LD_LIBRARY_PATH',
-                 foamAddLib(pkglib(spec['vtk'], '${VTK_DIR}'))),
+                 foam_add_lib(pkglib(spec['vtk'], '${VTK_DIR}'))),
             ]
 
         # Optional


### PR DESCRIPTION
- foam_add_lib() must be used instead of the undefined foamAddLib()
  for adding VTK