### PR TITLE
bugfix EnvironmentModifications:from_sourcing_file

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -458,6 +458,7 @@ class EnvironmentModifications(object):
                     search = sep.join(after_list[start:end + 1])
                 except IndexError:
                     env.prepend_path(x, after)
+                    continue
 
                 if search not in before:
                     # We just need to set the variable to the new value


### PR DESCRIPTION
- directly continue with next loop iteration if 'start', 'end', or
  'search' could not successfully be defined within try/except block