### PR TITLE
set dependency type of gcc's binutils dependency to 'run'

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -97,7 +97,7 @@ class Gcc(AutotoolsPackage):
     depends_on('isl@0.15:', when='@6:')
     depends_on('zlib', when='@6:')
     depends_on('gnat', when='languages=ada')
-    depends_on('binutils~libiberty', when='+binutils')
+    depends_on('binutils~libiberty', when='+binutils', type='run')
     depends_on('zip', type='build', when='languages=java')
 
     # TODO: integrate these libraries.


### PR DESCRIPTION
See: https://github.com/spack/spack/issues/8852

Specifically, https://github.com/spack/spack/issues/8852#issuecomment-411261877 mentions that no binutils libraries appear in Spack compiler wrapper invocations (i.e. in the log written when using the `-d` option), and `spack install gcc+binutils` only succeeds on my RHEL7 system when I update the dependency type of binutils.

`gcc -m64 -Xlinker --verbose` outputs the Spack-build binutils loader as desired.

My interpretation is that this means that adding `-L`/`-I` entries to binutils lib & include directories interferes with the `gcc` compilation somehow, but I don't know exactly how; I think that would be worthwhile. As of now building `gcc+binutils` appears to be generally unsuccessful: https://github.com/spack/spack/issues/8852#issuecomment-409560587.