### PR TITLE
Spack guesses lmod core compilers

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -40,26 +40,6 @@ import spack.store
 from spack.error import SpackError
 
 
-#
-# Settings for commands that modify configuration
-#
-def default_modify_scope():
-    """Return the config scope that commands should modify by default.
-
-    Commands that modify configuration by default modify the *highest*
-    priority scope.
-    """
-    return spack.config.config.highest_precedence_scope().name
-
-
-def default_list_scope():
-    """Return the config scope that is listed by default.
-
-    Commands that list configuration list *all* scopes (merged) by default.
-    """
-    return None
-
-
 # cmd has a submodule called "list" so preserve the python list module
 python_list = list
 

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -56,7 +56,7 @@ def setup_parser(subparser):
     find_parser.add_argument('add_paths', nargs=argparse.REMAINDER)
     find_parser.add_argument(
         '--scope', choices=scopes, metavar=scopes_metavar,
-        default=spack.cmd.default_modify_scope(),
+        default=spack.config.default_modify_scope(),
         help="configuration scope to modify")
 
     # Remove
@@ -68,14 +68,14 @@ def setup_parser(subparser):
     remove_parser.add_argument('compiler_spec')
     remove_parser.add_argument(
         '--scope', choices=scopes, metavar=scopes_metavar,
-        default=spack.cmd.default_modify_scope(),
+        default=spack.config.default_modify_scope(),
         help="configuration scope to modify")
 
     # List
     list_parser = sp.add_parser('list', help='list available compilers')
     list_parser.add_argument(
         '--scope', choices=scopes, metavar=scopes_metavar,
-        default=spack.cmd.default_list_scope(),
+        default=spack.config.default_list_scope(),
         help="configuration scope to read from")
 
     # Info
@@ -83,7 +83,7 @@ def setup_parser(subparser):
     info_parser.add_argument('compiler_spec')
     info_parser.add_argument(
         '--scope', choices=scopes, metavar=scopes_metavar,
-        default=spack.cmd.default_list_scope(),
+        default=spack.config.default_list_scope(),
         help="configuration scope to read from")
 
 

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import spack.config
+
 from spack.util.editor import editor
 
 description = "get and set configuration options"
@@ -75,7 +76,7 @@ def config_blame(args):
 def config_edit(args):
     if not args.scope:
         if args.section == 'compilers':
-            args.scope = spack.cmd.default_modify_scope()
+            args.scope = spack.config.default_modify_scope()
         else:
             args.scope = 'user'
     if not args.section:

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -78,7 +78,7 @@ def setup_parser(subparser):
         'url', help="url of mirror directory from 'spack mirror create'")
     add_parser.add_argument(
         '--scope', choices=scopes, metavar=scopes_metavar,
-        default=spack.cmd.default_modify_scope(),
+        default=spack.config.default_modify_scope(),
         help="configuration scope to modify")
 
     # Remove
@@ -87,14 +87,14 @@ def setup_parser(subparser):
     remove_parser.add_argument('name')
     remove_parser.add_argument(
         '--scope', choices=scopes, metavar=scopes_metavar,
-        default=spack.cmd.default_modify_scope(),
+        default=spack.config.default_modify_scope(),
         help="configuration scope to modify")
 
     # List
     list_parser = sp.add_parser('list', help=mirror_list.__doc__)
     list_parser.add_argument(
         '--scope', choices=scopes, metavar=scopes_metavar,
-        default=spack.cmd.default_list_scope(),
+        default=spack.config.default_list_scope(),
         help="configuration scope to read from")
 
 

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -54,7 +54,7 @@ def setup_parser(subparser):
     list_parser = sp.add_parser('list', help=repo_list.__doc__)
     list_parser.add_argument(
         '--scope', choices=scopes, metavar=scopes_metavar,
-        default=spack.cmd.default_list_scope(),
+        default=spack.config.default_list_scope(),
         help="configuration scope to read from")
 
     # Add
@@ -63,7 +63,7 @@ def setup_parser(subparser):
         'path', help="path to a Spack package repository directory")
     add_parser.add_argument(
         '--scope', choices=scopes, metavar=scopes_metavar,
-        default=spack.cmd.default_modify_scope(),
+        default=spack.config.default_modify_scope(),
         help="configuration scope to modify")
 
     # Remove
@@ -74,7 +74,7 @@ def setup_parser(subparser):
         help="path or namespace of a Spack package repository")
     remove_parser.add_argument(
         '--scope', choices=scopes, metavar=scopes_metavar,
-        default=spack.cmd.default_modify_scope(),
+        default=spack.config.default_modify_scope(),
         help="configuration scope to modify")
 
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -752,6 +752,26 @@ def _merge_yaml(dest, source):
         return copy.copy(source)
 
 
+#
+# Settings for commands that modify configuration
+#
+def default_modify_scope():
+    """Return the config scope that commands should modify by default.
+
+    Commands that modify configuration by default modify the *highest*
+    priority scope.
+    """
+    return spack.config.config.highest_precedence_scope().name
+
+
+def default_list_scope():
+    """Return the config scope that is listed by default.
+
+    Commands that list configuration list *all* scopes (merged) by default.
+    """
+    return None
+
+
 class ConfigError(SpackError):
     """Superclass for all Spack config related errors."""
 

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -65,6 +65,42 @@ def make_context(spec):
     return LmodContext(conf)
 
 
+def guess_core_compilers(store=False):
+    """Guesses the list of core compilers installed in the system.
+
+    Args:
+        store (bool): if True writes the core compilers to the
+            modules.yaml configuration file
+
+    Returns:
+        List of core compilers, if found, or None
+    """
+    core_compilers = []
+    for compiler_config in spack.compilers.all_compilers_config():
+        try:
+            compiler = compiler_config['compiler']
+            # A compiler is considered to be a core compiler if any of the
+            # C, C++ or Fortran compilers reside in a system directory
+            is_system_compiler = any(
+                os.path.dirname(x) in spack.util.environment.system_dirs
+                for x in compiler['paths'].values() if x is not None
+            )
+            if is_system_compiler:
+                core_compilers.append(str(compiler['spec']))
+        except (KeyError, TypeError, AttributeError):
+            continue
+
+    if store and core_compilers:
+        # If we asked to store core compilers, update the entry
+        # at 'site' scope (i.e. within the directory hierarchy
+        # of Spack itself)
+        modules_cfg = spack.config.get('modules', scope='site')
+        modules_cfg.setdefault('lmod', {})['core_compilers'] = core_compilers
+        spack.config.set('modules', modules_cfg, scope='site')
+
+    return core_compilers or None
+
+
 class LmodConfiguration(BaseConfiguration):
     """Configuration class for lmod module files."""
 
@@ -77,12 +113,12 @@ class LmodConfiguration(BaseConfiguration):
                 specified in the configuration file or the sequence
                 is empty
         """
-        value = configuration.get('core_compilers')
-        if value is None:
-            msg = "'core_compilers' key not found in configuration file"
-            raise CoreCompilersNotFoundError(msg)
+        value = configuration.get(
+            'core_compilers'
+        ) or guess_core_compilers(store=True)
+
         if not value:
-            msg = "'core_compilers' list cannot be empty"
+            msg = 'the key "core_compilers" must be set in modules.yaml'
             raise CoreCompilersNotFoundError(msg)
         return value
 

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -92,11 +92,15 @@ def guess_core_compilers(store=False):
 
     if store and core_compilers:
         # If we asked to store core compilers, update the entry
-        # at 'site' scope (i.e. within the directory hierarchy
+        # in the default modify scope (i.e. within the directory hierarchy
         # of Spack itself)
-        modules_cfg = spack.config.get('modules', scope='site')
+        modules_cfg = spack.config.get(
+            'modules', scope=spack.config.default_modify_scope()
+        )
         modules_cfg.setdefault('lmod', {})['core_compilers'] = core_compilers
-        spack.config.set('modules', modules_cfg, scope='site')
+        spack.config.set(
+            'modules', modules_cfg, scope=spack.config.default_modify_scope()
+        )
 
     return core_compilers or None
 

--- a/lib/spack/spack/test/modules/lmod.py
+++ b/lib/spack/spack/test/modules/lmod.py
@@ -258,3 +258,26 @@ class TestLmod(object):
         writer, spec = factory('externaltool')
 
         assert 'unknown' in writer.context.configure_options
+
+    def test_guess_core_compilers(
+            self, factory, module_configuration, monkeypatch
+    ):
+        """Check that we can guess core compilers."""
+
+        # In this case we miss the entry completely
+        module_configuration('missing_core_compilers')
+
+        # Our mock paths must be detected as system paths
+        monkeypatch.setattr(
+            spack.util.environment, 'system_dirs', ['/path/to']
+        )
+
+        # We don't want to really write into user configuration
+        # when running tests
+        def no_op_set(*args, **kwargs):
+            pass
+        monkeypatch.setattr(spack.config, 'set', no_op_set)
+
+        # Assert we have core compilers now
+        writer, _ = factory(mpileaks_spec_string)
+        assert writer.conf.core_compilers


### PR DESCRIPTION
closes #8916

Currently Spack ends with an error if asked to write lmod modules files and the 'core_compilers' entry is not found in `modules.yaml`. After this PR an attempt will be made to guess that entry and the site configuration file will be updated accordingly.

This is similar to what Spack already does to guess compilers on first run.

@svenevs @SteVwonder 