### PR TITLE
Change bzip2 download URL

### DIFF
--- a/var/spack/repos/builtin/packages/bzip2/package.py
+++ b/var/spack/repos/builtin/packages/bzip2/package.py
@@ -32,7 +32,7 @@ class Bzip2(Package):
     compressors), whilst being around twice as fast at compression
     and six times faster at decompression."""
 
-    # FIXME: The bzip2.org domain has expired:
+    # FIXME: The bzip.org domain has expired:
     # https://lwn.net/Articles/762264/
     # This package will need to be updated when a new home is found.
     homepage = "https://sourceware.org/bzip2/"

--- a/var/spack/repos/builtin/packages/bzip2/package.py
+++ b/var/spack/repos/builtin/packages/bzip2/package.py
@@ -32,9 +32,11 @@ class Bzip2(Package):
     compressors), whilst being around twice as fast at compression
     and six times faster at decompression."""
 
-    homepage = "http://www.bzip.org"
-    url      = "http://www.bzip.org/1.0.6/bzip2-1.0.6.tar.gz"
-    list_url = "http://www.bzip.org/downloads.html"
+    # FIXME: The bzip2.org domain has expired:
+    # https://lwn.net/Articles/762264/
+    # This package will need to be updated when a new home is found.
+    homepage = "https://sourceware.org/bzip2/"
+    url      = "https://fossies.org/linux/misc/bzip2-1.0.6.tar.gz"
 
     version('1.0.6', '00b516f4704d4a7cb50a1d97e6e8e15b')
 


### PR DESCRIPTION
Fixes #8924 

The bzip.org domain has expired, and it doesn't sound like it will be restored any time soon (https://lwn.net/Articles/762264/). Switching to a mirror with the same version and checksum for the time being.

@JusticeForMikeBrown @balay @hartzell 