### PR TITLE
bzip2: switch to gentoo mirror

### DIFF
--- a/var/spack/repos/builtin/packages/bzip2/package.py
+++ b/var/spack/repos/builtin/packages/bzip2/package.py
@@ -33,7 +33,7 @@ class Bzip2(Package):
     and six times faster at decompression."""
 
     homepage = "http://www.bzip.org"
-    url      = "http://www.bzip.org/1.0.6/bzip2-1.0.6.tar.gz"
+    url      = "http://distfiles.gentoo.org/distfiles/bzip2-1.0.6.tar.gz"
     list_url = "http://www.bzip.org/downloads.html"
 
     version('1.0.6', '00b516f4704d4a7cb50a1d97e6e8e15b')


### PR DESCRIPTION
http://www.bzip.org/ didn't get extended, so tarball cannot be downloaded.

Switch to Gentoo mirror.