### PR TITLE
Fix error caused by missing spack-build.out build log

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -908,7 +908,7 @@ class ChildError(InstallError):
         if (self.module, self.name) in ChildError.build_errors:
             # The error happened in some external executed process. Show
             # the build log with errors highlighted.
-            if self.build_log:
+            if self.build_log and os.path.exists(self.build_log):
                 errors, warnings = parse_log_events(self.build_log)
                 nerr = len(errors)
                 if nerr > 0:
@@ -929,7 +929,7 @@ class ChildError(InstallError):
         if out.getvalue():
             out.write('\n')
 
-        if self.build_log:
+        if self.build_log and os.path.exists(self.build_log):
             out.write('See build log for details:\n')
             out.write('  %s' % self.build_log)
 

--- a/lib/spack/spack/error.py
+++ b/lib/spack/spack/error.py
@@ -63,7 +63,7 @@ class SpackError(Exception):
         """Print extended debug information about this exception.
 
         This is usually printed when the top-level Spack error handler
-        calls ``die()``, but it acn be called separately beforehand if a
+        calls ``die()``, but it can be called separately beforehand if a
         lower-level error handler needs to print error context and
         continue without raising the exception to the top level.
         """


### PR DESCRIPTION
Previously, if an error occurred during untarring, Spack would crash due to a missing `spack-build.out` file. Now, it exits a little more gracefully, revealing the real error message.

### Before

```console
$ spack install gmp
==> Installing gmp
==> Using cached archive: /home/hpc/spack/var/spack/cache/gmp/gmp-6.1.2.tar.bz2
==> Staging archive: /home/hpc/spack/var/spack/stage/gmp-6.1.2-6bsovvkqwx6zscwtbvjj6egrgizbyycm/gmp-6.1.2.tar.bz2
tar (child): lbzip2: Cannot exec: No such file or directory
tar (child): Error is not recoverable: exiting now
/usr/bin/tar: Child returned status 2
/usr/bin/tar: Error is not recoverable: exiting now
==> Error: ProcessError: Command exited with status 2:
   '/usr/bin/tar' '-xf' '/home/hpc/spack/var/spack/stage/gmp-6.1.2-6bsovvkqwx6zscwtbvjj6egrgizbyycm/gmp-6.1.2.tar.bz2'
==> Error: [Errno 2] No such file or directory: '/home/hpc/spack/var/spack/stage/gmp-6.1.2-6bsovvkqwx6zscwtbvjj6egrgizbyycm/spack-expanded-archive/spack-build.out'
```
```console
$ spack --debug install gmp
==> Installing gmp
==> Deprecation warning: md5 checksums will not be supported in future Spack releases.
==> Using cached archive: /home/hpc/spack/var/spack/cache/gmp/gmp-6.1.2.tar.bz2
==> Deprecation warning: md5 checksums will not be supported in future Spack releases.
==> Staging archive: /home/hpc/spack/var/spack/stage/gmp-6.1.2-6bsovvkqwx6zscwtbvjj6egrgizbyycm/gmp-6.1.2.tar.bz2
==> '/usr/bin/tar' '-xf' '/home/hpc/spack/var/spack/stage/gmp-6.1.2-6bsovvkqwx6zscwtbvjj6egrgizbyycm/gmp-6.1.2.tar.bz2'
tar (child): lbzip2: Cannot exec: No such file or directory
tar (child): Error is not recoverable: exiting now
/usr/bin/tar: Child returned status 2
/usr/bin/tar: Error is not recoverable: exiting now
==> Error: ProcessError: Command exited with status 2:
   '/usr/bin/tar' '-xf' '/home/hpc/spack/var/spack/stage/gmp-6.1.2-6bsovvkqwx6zscwtbvjj6egrgizbyycm/gmp-6.1.2.tar.bz2'
Traceback (most recent call last):
 File "/home/hpc/spack/bin/spack", line 61, in <module>
   sys.exit(spack.main.main())
 File "/home/hpc/spack/lib/spack/spack/main.py", line 653, in main
   return _invoke_command(command, parser, args, unknown)
 File "/home/hpc/spack/lib/spack/spack/main.py", line 432, in _invoke_command
   return_val = command(parser, args)
 File "/home/hpc/spack/lib/spack/spack/cmd/install.py", line 273, in install
   install_spec(args, kwargs, spec)
 File "/home/hpc/spack/lib/spack/spack/cmd/install.py", line 154, in install_spec
   spec.package.do_install(**kwargs)
 File "/home/hpc/spack/lib/spack/spack/package.py", line 1495, in do_install
   self, build_process, dirty=dirty, fake=fake)
 File "/home/hpc/spack/lib/spack/spack/build_environment.py", line 776, in fork
   child_result.print_context()
 File "/home/hpc/spack/lib/spack/spack/error.py", line 75, in print_context
   if self.long_message:
 File "/home/hpc/spack/lib/spack/spack/build_environment.py", line 912, in long_message
   errors, warnings = parse_log_events(self.build_log)
 File "/home/hpc/spack/lib/spack/spack/util/log_parse.py", line 58, in parse_log_events
   result = parse_log_events.ctest_parser.parse(stream, context, jobs)
 File "/home/hpc/spack/lib/spack/external/ctest_log_parser.py", line 426, in parse
   with open(stream) as f:
IOError: [Errno 2] No such file or directory: '/home/hpc/spack/var/spack/stage/gmp-6.1.2-6bsovvkqwx6zscwtbvjj6egrgizbyycm/spack-expanded-archive/spack-build.out
```
### After
```console
$ spack install gmp
==> Installing gmp
==> Using cached archive: /home/hpc/spack/var/spack/cache/gmp/gmp-6.1.2.tar.bz2
==> Staging archive: /home/hpc/spack/var/spack/stage/gmp-6.1.2-6bsovvkqwx6zscwtbvjj6egrgizbyycm/gmp-6.1.2.tar.bz2
tar (child): lbzip2: Cannot exec: No such file or directory
tar (child): Error is not recoverable: exiting now
/usr/bin/tar: Child returned status 2
/usr/bin/tar: Error is not recoverable: exiting now
==> Error: ProcessError: Command exited with status 2:
   '/usr/bin/tar' '-xf' '/home/hpc/spack/var/spack/stage/gmp-6.1.2-6bsovvkqwx6zscwtbvjj6egrgizbyycm/gmp-6.1.2.tar.bz2'
```
I'm not sure if there are other places where we try to use `self.build_log` without first checking if it exists.

Reported on Slack by Strahinja Trecakov.