### PR TITLE
patch for OF.com@18.06 to correctly find KAHIP

### DIFF
--- a/var/spack/repos/builtin/packages/openfoam-com/1806-have-kahip.patch
+++ b/var/spack/repos/builtin/packages/openfoam-com/1806-have-kahip.patch
@@ -1,0 +1,17 @@
+--- OpenFOAM-v1806/wmake/scripts/have_kahip-ORIG	2018-06-28 16:39:32.000000000 +0200
++++ OpenFOAM-v1806/wmake/scripts/have_kahip	2018-08-11 13:37:18.250219013 +0200
+@@ -83,10 +83,10 @@
+         # FOAM_EXT_LIBBIN is allowed to be unset
+         library=$(findFirstFile \
+             $FOAM_EXT_LIBBIN/$library \
+-            $METIS_ARCH_PATH/lib/$static \
+-            $METIS_ARCH_PATH/lib/$library \
+-            $METIS_ARCH_PATH/lib$WM_COMPILER_LIB_ARCH/$static \
+-            $METIS_ARCH_PATH/lib$WM_COMPILER_LIB_ARCH/$library \
++            $KAHIP_ARCH_PATH/lib/$static \
++            $KAHIP_ARCH_PATH/lib/$library \
++            $KAHIP_ARCH_PATH/lib$WM_COMPILER_LIB_ARCH/$static \
++            $KAHIP_ARCH_PATH/lib$WM_COMPILER_LIB_ARCH/$library \
+         )
+     elif isSystem "$KAHIP_ARCH_PATH"
+     then

--- a/var/spack/repos/builtin/packages/openfoam-com/package.py
+++ b/var/spack/repos/builtin/packages/openfoam-com/package.py
@@ -356,6 +356,7 @@ class OpenfoamCom(Package):
 
     # Version-specific patches
     patch('1612-spack-patches.patch', when='@1612')
+    patch('1806-have-kahip.patch', when='@1806')
 
     # Some user config settings
     # default: 'compile-option': 'RpathOpt',


### PR DESCRIPTION
- OpenFOAM-v1806/wmake/scripts/have_kahip must check $KAHIP_ARCH_PATH
  instead of $METIS_ARCH_PATH to detect the KAHIB library
- use a local patch file until the issue is hopefully fixed upstream