### PR TITLE
zoltan: fix building with Intel compilers

### DIFF
--- a/var/spack/repos/builtin/packages/zoltan/package.py
+++ b/var/spack/repos/builtin/packages/zoltan/package.py
@@ -85,6 +85,8 @@ class Zoltan(Package):
             config_cflags.append(self.compiler.pic_flag)
             if spec.satisfies('%gcc'):
                 config_args.append('--with-libs={0}'.format('-lgfortran'))
+            if spec.satisfies('%intel'):
+                config_args.append('--with-libs={0}'.format('-lifcore'))
 
         if '+parmetis' in spec:
             config_args.append('--with-parmetis')

--- a/var/spack/repos/builtin/packages/zoltan/package.py
+++ b/var/spack/repos/builtin/packages/zoltan/package.py
@@ -84,9 +84,9 @@ class Zoltan(Package):
             config_args.append('--with-ar=$(CXX) -shared $(LDFLAGS) -o')
             config_cflags.append(self.compiler.pic_flag)
             if spec.satisfies('%gcc'):
-                config_args.append('--with-libs={0}'.format('-lgfortran'))
+                config_args.append('--with-libs=-lgfortran')
             if spec.satisfies('%intel'):
-                config_args.append('--with-libs={0}'.format('-lifcore'))
+                config_args.append('--with-libs=-lifcore')
 
         if '+parmetis' in spec:
             config_args.append('--with-parmetis')


### PR DESCRIPTION
- building with the Intel compilers requires explicit linking with the Intel Fortran library (libifcore) similarly to the GCC case