### PR TITLE
libunwind: add version 1.3-rc1 and variant xz

### DIFF
--- a/var/spack/repos/builtin/packages/libunwind/package.py
+++ b/var/spack/repos/builtin/packages/libunwind/package.py
@@ -28,13 +28,31 @@ from spack import *
 class Libunwind(AutotoolsPackage):
     """A portable and efficient C programming interface (API) to determine
        the call-chain of a program."""
+
     homepage = "http://www.nongnu.org/libunwind/"
     url      = "http://download.savannah.gnu.org/releases/libunwind/libunwind-1.1.tar.gz"
+
+    version('1.3-rc1', 'f09b670de5db6430a3de666e6aed60e3')
+    version('1.2.1', '06ba9e60d92fd6f55cd9dadb084df19e')
+    version('1.1', 'fb4ea2f6fbbe45bf032cd36e586883ce')
+
+    variant('xz', default=False,
+            description='Support xz (lzma) compressed symbol tables.')
+
+    depends_on('xz', type='link', when='+xz')
 
     conflicts('platform=darwin',
               msg='Non-GNU libunwind needs ELF libraries Darwin does not have')
 
-    version('1.2.1', '06ba9e60d92fd6f55cd9dadb084df19e')
-    version('1.1', 'fb4ea2f6fbbe45bf032cd36e586883ce')
-
     provides('unwind')
+
+    def configure_args(self):
+        spec = self.spec
+        args = []
+
+        if '+xz' in spec:
+            args.append('--enable-minidebuginfo')
+        else:
+            args.append('--disable-minidebuginfo')
+
+        return args


### PR DESCRIPTION
Version 1.3-rc1 is the latest published snapshot from libunwind.

Variant xz adds spack-built support for reading compressed symbol
tables, or else disables this feature.  Without the variant, libunwind
will look for liblzma in /usr/lib.

I'm guessing flake will complain that the url line is too long.
But that line was already there, I didn't add it.

So, there are two options:
1. ignore flake's complaint.
2. split "http:....tar.gz" onto two lines.
