### PR TITLE
add patch for gcc@8 for python 2.7.14

### DIFF
--- a/var/spack/repos/builtin/packages/python/gcc-8-2.7.14.patch
+++ b/var/spack/repos/builtin/packages/python/gcc-8-2.7.14.patch
@@ -1,0 +1,44 @@
+diff --git a/Include/objimpl.h b/Include/objimpl.h
+index 5f2868332955..cbf6bc3f8763 100644
+--- a/Include/objimpl.h
++++ b/Include/objimpl.h
+@@ -248,6 +248,20 @@ PyAPI_FUNC(PyVarObject *) _PyObject_GC_Resize(PyVarObject *, Py_ssize_t);
+ /* for source compatibility with 2.2 */
+ #define _PyObject_GC_Del PyObject_GC_Del
+ 
++/*
++ * Former over-aligned definition of PyGC_Head, used to compute the size of the
++ * padding for the new version below.
++ */
++union _gc_head;
++union _gc_head_old {
++    struct {
++        union _gc_head_old *gc_next;
++        union _gc_head_old *gc_prev;
++        Py_ssize_t gc_refs;
++    } gc;
++    long double dummy;
++};
++
+ /* GC information is stored BEFORE the object structure. */
+ typedef union _gc_head {
+     struct {
+@@ -255,7 +269,8 @@ typedef union _gc_head {
+         union _gc_head *gc_prev;
+         Py_ssize_t gc_refs;
+     } gc;
+-    long double dummy;  /* force worst-case alignment */
++    double dummy; /* Force at least 8-byte alignment. */
++    char dummy_padding[sizeof(union _gc_head_old)];
+ } PyGC_Head;
+ 
+ extern PyGC_Head *_PyGC_generation0;
+diff --git a/Misc/NEWS.d/next/Core and Builtins/2018-04-29-12-07-00.bpo-33374.-xegL6.rst b/Misc/NEWS.d/next/Core and Builtins/2018-04-29-12-07-00.bpo-33374.-xegL6.rst
+new file mode 100644
+index 000000000000..9ec1a605c8f2
+--- /dev/null
++++ b/Misc/NEWS.d/next/Core and Builtins/2018-04-29-12-07-00.bpo-33374.-xegL6.rst	
+@@ -0,0 +1,3 @@
++Tweak the definition of PyGC_Head, so compilers do not believe it is always
++16-byte aligned on x86. This prevents crashes with more aggressive
++optimizations present in GCC 8.

--- a/var/spack/repos/builtin/packages/python/gcc-8-2.7.14.patch
+++ b/var/spack/repos/builtin/packages/python/gcc-8-2.7.14.patch
@@ -33,12 +33,3 @@ index 5f2868332955..cbf6bc3f8763 100644
  } PyGC_Head;
  
  extern PyGC_Head *_PyGC_generation0;
-diff --git a/Misc/NEWS.d/next/Core and Builtins/2018-04-29-12-07-00.bpo-33374.-xegL6.rst b/Misc/NEWS.d/next/Core and Builtins/2018-04-29-12-07-00.bpo-33374.-xegL6.rst
-new file mode 100644
-index 000000000000..9ec1a605c8f2
---- /dev/null
-+++ b/Misc/NEWS.d/next/Core and Builtins/2018-04-29-12-07-00.bpo-33374.-xegL6.rst	
-@@ -0,0 +1,3 @@
-+Tweak the definition of PyGC_Head, so compilers do not believe it is always
-+16-byte aligned on x86. This prevents crashes with more aggressive
-+optimizations present in GCC 8.

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -117,6 +117,7 @@ class Python(AutotoolsPackage):
     # Ensure that distutils chooses correct compiler option for RPATH on cray:
     patch('cray-rpath-2.3.patch', when="@2.3:3.0.1 platform=cray")
     patch('cray-rpath-3.1.patch', when="@3.1:3.99  platform=cray")
+    patch('gcc-8-2.7.14.patch', when="@2.7.14 %gcc@8:")
 
     # For more information refer to this bug report:
     # https://bugs.python.org/issue29712

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -117,6 +117,9 @@ class Python(AutotoolsPackage):
     # Ensure that distutils chooses correct compiler option for RPATH on cray:
     patch('cray-rpath-2.3.patch', when="@2.3:3.0.1 platform=cray")
     patch('cray-rpath-3.1.patch', when="@3.1:3.99  platform=cray")
+
+    # Fixes an alignment problem with more aggressive optimization in gcc8
+    # https://github.com/python/cpython/commit/0b91f8a668201fc58fa732b8acc496caedfdbae0
     patch('gcc-8-2.7.14.patch', when="@2.7.14 %gcc@8:")
 
     # For more information refer to this bug report:


### PR DESCRIPTION
This fixes a compile error caused by a more aggressive optimiser in gcc8, fixed in mainline python2 starting at 2.7.15. I have no idea which other versions of python are affected (From the discussion on their mailing list I assume <3.5 and <2.7.14) and don't have the time to test build a lot of python's. I don't think that this will hit a lot of people in practice, but should be included anyway