### PR TITLE
Download GNU packages from mirrors

### DIFF
--- a/var/spack/repos/builtin/packages/aspell6-de/package.py
+++ b/var/spack/repos/builtin/packages/aspell6-de/package.py
@@ -29,6 +29,6 @@ class Aspell6De(AspellDictPackage):
     """German (de) dictionary for aspell."""
 
     homepage = "http://aspell.net/"
-    url      = "ftp://ftp.gnu.org/gnu/aspell/dict/de/aspell6-de-20030222-1.tar.bz2"
+    url      = "https://ftpmirror.gnu.org/aspell/dict/de/aspell6-de-20030222-1.tar.bz2"
 
     version('6-de-20030222-1', '5950c5c8a36fc93d4d7616591bace6a6')

--- a/var/spack/repos/builtin/packages/aspell6-en/package.py
+++ b/var/spack/repos/builtin/packages/aspell6-en/package.py
@@ -29,6 +29,6 @@ class Aspell6En(AspellDictPackage):
     """English (en) dictionary for aspell."""
 
     homepage = "http://aspell.net/"
-    url      = "ftp://ftp.gnu.org/gnu/aspell/dict/en/aspell6-en-2017.01.22-0.tar.bz2"
+    url      = "https://ftpmirror.gnu.org/aspell/dict/en/aspell6-en-2017.01.22-0.tar.bz2"
 
     version('2017.01.22-0', 'a6e002076574de9dc4915967032a1dab')

--- a/var/spack/repos/builtin/packages/aspell6-es/package.py
+++ b/var/spack/repos/builtin/packages/aspell6-es/package.py
@@ -29,6 +29,6 @@ class Aspell6Es(AspellDictPackage):
     """Spanish (es) dictionary for aspell."""
 
     homepage = "http://aspell.net/"
-    url      = "ftp://ftp.gnu.org/gnu/aspell/dict/es/aspell6-es-1.11-2.tar.bz2"
+    url      = "https://ftpmirror.gnu.org/aspell/dict/es/aspell6-es-1.11-2.tar.bz2"
 
     version('1.11-2', '8406336a89c64e47e96f4153d0af70c4')

--- a/var/spack/repos/builtin/packages/autoconf/package.py
+++ b/var/spack/repos/builtin/packages/autoconf/package.py
@@ -29,7 +29,7 @@ class Autoconf(AutotoolsPackage):
     """Autoconf -- system configuration part of autotools"""
 
     homepage = 'https://www.gnu.org/software/autoconf/'
-    url = 'http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz'
+    url      = 'https://ftpmirror.gnu.org/autoconf/autoconf-2.69.tar.gz'
 
     version('2.69', '82d05e03b93e45f5a39b828dc9c6c29b')
     version('2.62', '6c1f3b3734999035d77da5024aab4fbd')

--- a/var/spack/repos/builtin/packages/autogen/package.py
+++ b/var/spack/repos/builtin/packages/autogen/package.py
@@ -32,7 +32,7 @@ class Autogen(AutotoolsPackage):
     synchronized."""
 
     homepage = "https://www.gnu.org/software/autogen/index.html"
-    url      = "https://ftp.gnu.org/gnu/autogen/rel5.18.12/autogen-5.18.12.tar.gz"
+    url      = "https://ftpmirror.gnu.org/autogen/rel5.18.12/autogen-5.18.12.tar.gz"
     list_url = "https://ftp.gnu.org/gnu/autogen"
     list_depth = 1
 

--- a/var/spack/repos/builtin/packages/automake/package.py
+++ b/var/spack/repos/builtin/packages/automake/package.py
@@ -29,7 +29,7 @@ class Automake(AutotoolsPackage):
     """Automake -- make file builder part of autotools"""
 
     homepage = 'http://www.gnu.org/software/automake/'
-    url      = 'http://ftp.gnu.org/gnu/automake/automake-1.15.tar.gz'
+    url      = 'https://ftpmirror.gnu.org/automake/automake-1.15.tar.gz'
 
     version('1.16.1', '83cc2463a4080efd46a72ba2c9f6b8f5')
     version('1.15.1', '95df3f2d6eb8f81e70b8cb63a93c8853')

--- a/var/spack/repos/builtin/packages/bash/package.py
+++ b/var/spack/repos/builtin/packages/bash/package.py
@@ -29,7 +29,7 @@ class Bash(AutotoolsPackage):
     """The GNU Project's Bourne Again SHell."""
 
     homepage = "https://www.gnu.org/software/bash/"
-    url      = "https://ftp.gnu.org/gnu/bash/bash-4.4.tar.gz"
+    url      = "https://ftpmirror.gnu.org/bash/bash-4.4.tar.gz"
 
     version('4.4.12', '7c112970cbdcadfc331e10eeb5f6aa41')
     version('4.4', '148888a7c95ac23705559b6f477dfe25')

--- a/var/spack/repos/builtin/packages/bc/package.py
+++ b/var/spack/repos/builtin/packages/bc/package.py
@@ -31,7 +31,7 @@ class Bc(AutotoolsPackage):
     interactive execution of statements."""
 
     homepage = "https://www.gnu.org/software/bc"
-    url = "https://ftp.gnu.org/gnu/bc/bc-1.07.tar.gz"
+    url      = "https://ftpmirror.gnu.org/bc/bc-1.07.tar.gz"
 
     version('1.07', 'e91638a947beadabf4d7770bdbb3d512')
 

--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -29,7 +29,7 @@ class Binutils(AutotoolsPackage):
     """GNU binutils, which contain the linker, assembler, objdump and others"""
 
     homepage = "http://www.gnu.org/software/binutils/"
-    url      = "https://ftp.gnu.org/gnu/binutils/binutils-2.28.tar.bz2"
+    url      = "https://ftpmirror.gnu.org/binutils/binutils-2.28.tar.bz2"
 
     version('2.29.1', '9af59a2ca3488823e453bb356fe0f113')
     version('2.28', '9e8340c96626b469a603c15c9d843727')

--- a/var/spack/repos/builtin/packages/bison/package.py
+++ b/var/spack/repos/builtin/packages/bison/package.py
@@ -33,7 +33,7 @@ class Bison(AutotoolsPackage):
     generalized LR (GLR) parser employing LALR(1) parser tables."""
 
     homepage = "http://www.gnu.org/software/bison/"
-    url      = "http://ftp.gnu.org/gnu/bison/bison-3.0.4.tar.gz"
+    url      = "https://ftpmirror.gnu.org/bison/bison-3.0.4.tar.gz"
 
     version('3.0.4', 'a586e11cd4aff49c3ff6d3b6a4c9ccf8')
     version('2.7',   'ded660799e76fb1667d594de1f7a0da9')

--- a/var/spack/repos/builtin/packages/coreutils/package.py
+++ b/var/spack/repos/builtin/packages/coreutils/package.py
@@ -32,7 +32,7 @@ class Coreutils(AutotoolsPackage):
        operating system.
     """
     homepage = "http://www.gnu.org/software/coreutils/"
-    url      = "http://ftp.gnu.org/gnu/coreutils/coreutils-8.26.tar.xz"
+    url      = "https://ftpmirror.gnu.org/coreutils/coreutils-8.26.tar.xz"
 
     version('8.29', '960cfe75a42c9907c71439f8eb436303')
     version('8.26', 'd5aa2072f662d4118b9f4c63b94601a6')

--- a/var/spack/repos/builtin/packages/cvs/package.py
+++ b/var/spack/repos/builtin/packages/cvs/package.py
@@ -29,7 +29,7 @@ from spack import *
 class Cvs(AutotoolsPackage):
     """CVS a very traditional source control system"""
     homepage = "http://www.nongnu.org/cvs/"
-    url      = "https://ftp.gnu.org/non-gnu/cvs/source/feature/1.12.13/cvs-1.12.13.tar.bz2"
+    url      = "https://ftpmirror.gnu.org/non-gnu/cvs/source/feature/1.12.13/cvs-1.12.13.tar.bz2"
 
     version('1.12.13', '93a8dacc6ff0e723a130835713235863f1f5ada9')
 

--- a/var/spack/repos/builtin/packages/datamash/package.py
+++ b/var/spack/repos/builtin/packages/datamash/package.py
@@ -31,7 +31,7 @@ class Datamash(AutotoolsPackage):
     """
 
     homepage = "https://www.gnu.org/software/datamash/"
-    url      = "http://ftp.gnu.org/gnu/datamash/datamash-1.0.5.tar.gz"
+    url      = "https://ftpmirror.gnu.org/datamash/datamash-1.0.5.tar.gz"
 
     version('1.3',   '47d382090e367ddb4967d640aba77b66')
     version('1.1.0', '79a6affca08107a095e97e4237fc8775')

--- a/var/spack/repos/builtin/packages/dejagnu/package.py
+++ b/var/spack/repos/builtin/packages/dejagnu/package.py
@@ -30,7 +30,7 @@ class Dejagnu(AutotoolsPackage):
     is to provide a single front end for all tests."""
 
     homepage = "https://www.gnu.org/software/dejagnu/"
-    url      = "http://mirror.team-cymru.org/gnu/dejagnu/dejagnu-1.6.tar.gz"
+    url      = "https://ftpmirror.gnu.org/dejagnu/dejagnu-1.6.tar.gz"
 
     version('1.6',   '1fdc2eb0d592c4f89d82d24dfdf02f0b')
     version('1.4.4', '053f18fd5d00873de365413cab17a666')

--- a/var/spack/repos/builtin/packages/ed/package.py
+++ b/var/spack/repos/builtin/packages/ed/package.py
@@ -31,7 +31,7 @@ class Ed(AutotoolsPackage):
        interactively and via shell scripts."""
 
     homepage = "https://www.gnu.org/software/ed"
-    url = "https://ftp.gnu.org/gnu/ed/ed-1.4.tar.gz"
+    url      = "https://ftpmirror.gnu.org/ed/ed-1.4.tar.gz"
 
     version('1.4', 'da0ddc0e0b0bec2da4b13b0d0d1bce2b')
 

--- a/var/spack/repos/builtin/packages/emacs/package.py
+++ b/var/spack/repos/builtin/packages/emacs/package.py
@@ -31,7 +31,7 @@ class Emacs(AutotoolsPackage):
     """The Emacs programmable text editor."""
 
     homepage = "https://www.gnu.org/software/emacs"
-    url      = "http://ftp.gnu.org/gnu/emacs/emacs-24.5.tar.gz"
+    url      = "https://ftpmirror.gnu.org/emacs/emacs-24.5.tar.gz"
 
     version('26.1', '544d2ab5eb142e9ca69adb023d17bf4b')
     version('25.3', '74ddd373dc52ac05ca7a8c63b1ddbf58')

--- a/var/spack/repos/builtin/packages/findutils/package.py
+++ b/var/spack/repos/builtin/packages/findutils/package.py
@@ -30,7 +30,7 @@ class Findutils(AutotoolsPackage):
        utilities of the GNU operating system."""
 
     homepage = "https://www.gnu.org/software/findutils/"
-    url      = "http://ftpmirror.gnu.org/findutils/findutils-4.6.0.tar.gz"
+    url      = "https://ftpmirror.gnu.org/findutils/findutils-4.6.0.tar.gz"
 
     version('4.6.0',  '9936aa8009438ce185bea2694a997fc1')
     version('4.4.2',  '351cc4adb07d54877fa15f75fb77d39f')

--- a/var/spack/repos/builtin/packages/gawk/package.py
+++ b/var/spack/repos/builtin/packages/gawk/package.py
@@ -40,7 +40,7 @@ class Gawk(AutotoolsPackage):
     """
 
     homepage = "https://www.gnu.org/software/gawk/"
-    url      = "http://ftp.gnu.org/gnu/gawk/gawk-4.1.4.tar.xz"
+    url      = "https://ftpmirror.gnu.org/gawk/gawk-4.1.4.tar.xz"
 
     version('4.1.4', '4e7dbc81163e60fd4f0b52496e7542c9')
 

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -36,7 +36,7 @@ class Gcc(AutotoolsPackage):
     Fortran, Ada, and Go, as well as libraries for these languages."""
 
     homepage = 'https://gcc.gnu.org'
-    url      = 'http://ftp.gnu.org/gnu/gcc/gcc-7.1.0/gcc-7.1.0.tar.bz2'
+    url      = 'https://ftpmirror.gnu.org/gcc/gcc-7.1.0/gcc-7.1.0.tar.bz2'
     list_url = 'http://ftp.gnu.org/gnu/gcc/'
     list_depth = 1
 

--- a/var/spack/repos/builtin/packages/gdb/package.py
+++ b/var/spack/repos/builtin/packages/gdb/package.py
@@ -32,7 +32,7 @@ class Gdb(AutotoolsPackage):
     """
 
     homepage = "https://www.gnu.org/software/gdb"
-    url = "http://ftp.gnu.org/gnu/gdb/gdb-7.10.tar.gz"
+    url      = "https://ftpmirror.gnu.org/gdb/gdb-7.10.tar.gz"
 
     version('8.1', '0c85ecbb43569ec43b1c9230622e84ab')
     version('8.0.1', 'bb45869f8126a84ea2ba13a8c0e7c90e')

--- a/var/spack/repos/builtin/packages/gdbm/package.py
+++ b/var/spack/repos/builtin/packages/gdbm/package.py
@@ -33,7 +33,7 @@ class Gdbm(AutotoolsPackage):
     manipulate a hashed database."""
 
     homepage = "http://www.gnu.org.ua/software/gdbm/gdbm.html"
-    url      = "http://ftp.gnu.org/gnu/gdbm/gdbm-1.13.tar.gz"
+    url      = "https://ftpmirror.gnu.org/gdbm/gdbm-1.13.tar.gz"
 
     version('1.14.1', 'c2ddcb3897efa0f57484af2bd4f4f848')
     version('1.13',  '8929dcda2a8de3fd2367bdbf66769376')

--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -29,7 +29,7 @@ class Gettext(AutotoolsPackage):
     """GNU internationalization (i18n) and localization (l10n) library."""
 
     homepage = "https://www.gnu.org/software/gettext/"
-    url      = "http://ftpmirror.gnu.org/gettext/gettext-0.19.7.tar.xz"
+    url      = "https://ftpmirror.gnu.org/gettext/gettext-0.19.7.tar.xz"
 
     version('0.19.8.1', 'df3f5690eaa30fd228537b00cb7b7590')
     version('0.19.7',   'f81e50556da41b44c1d59ac93474dca5')

--- a/var/spack/repos/builtin/packages/glpk/package.py
+++ b/var/spack/repos/builtin/packages/glpk/package.py
@@ -33,7 +33,7 @@ class Glpk(AutotoolsPackage):
     """
 
     homepage = "https://www.gnu.org/software/glpk"
-    url = "http://ftp.gnu.org/gnu/glpk/glpk-4.65.tar.gz"
+    url      = "https://ftpmirror.gnu.org/glpk/glpk-4.65.tar.gz"
 
     version('4.65', '470a984a8b1c0e027bdb6d5859063fe8')
     version('4.61', '3ce3e224a8b6e75a1a0b378445830f21')

--- a/var/spack/repos/builtin/packages/gmake/package.py
+++ b/var/spack/repos/builtin/packages/gmake/package.py
@@ -30,7 +30,7 @@ class Gmake(AutotoolsPackage):
     other non-source files of a program from the program's source files."""
 
     homepage = "https://www.gnu.org/software/make/"
-    url      = "https://ftp.gnu.org/gnu/make/make-4.2.1.tar.gz"
+    url      = "https://ftpmirror.gnu.org/make/make-4.2.1.tar.gz"
 
     version('4.2.1', '7d0dcb6c474b258aab4d54098f2cf5a7')
     version('4.0',   'b5e558f981326d9ca1bfdb841640721a')

--- a/var/spack/repos/builtin/packages/gmp/package.py
+++ b/var/spack/repos/builtin/packages/gmp/package.py
@@ -30,7 +30,7 @@ class Gmp(AutotoolsPackage):
     on signed integers, rational numbers, and floating-point numbers."""
 
     homepage = "https://gmplib.org"
-    url      = "https://ftp.gnu.org/gnu/gmp/gmp-6.1.2.tar.bz2"
+    url      = "https://ftpmirror.gnu.org/gmp/gmp-6.1.2.tar.bz2"
 
     version('6.1.2',  '8ddbb26dc3bd4e2302984debba1406a5')
     version('6.1.1',  '4c175f86e11eb32d8bf9872ca3a8e11d')

--- a/var/spack/repos/builtin/packages/gperf/package.py
+++ b/var/spack/repos/builtin/packages/gperf/package.py
@@ -34,7 +34,7 @@ class Gperf(AutotoolsPackage):
     single string comparison only."""
 
     homepage = "https://www.gnu.org/software/gperf/"
-    url      = "http://ftp.gnu.org/pub/gnu/gperf/gperf-3.0.4.tar.gz"
+    url      = "https://ftpmirror.gnu.org/gperf/gperf-3.0.4.tar.gz"
 
     version('3.0.4', 'c1f1db32fb6598d6a93e6e88796a8632')
 

--- a/var/spack/repos/builtin/packages/groff/package.py
+++ b/var/spack/repos/builtin/packages/groff/package.py
@@ -32,7 +32,7 @@ class Groff(AutotoolsPackage):
     ASCII/UTF8 for display at the terminal."""
 
     homepage = "https://www.gnu.org/software/groff/"
-    url      = "http://ftp.gnu.org/gnu/groff/groff-1.22.3.tar.gz"
+    url      = "https://ftpmirror.gnu.org/groff/groff-1.22.3.tar.gz"
 
     # TODO: add html variant, spack doesn't have netpbm and its too
     # complicated for me to find out at this point in time.

--- a/var/spack/repos/builtin/packages/gsl/package.py
+++ b/var/spack/repos/builtin/packages/gsl/package.py
@@ -34,7 +34,7 @@ class Gsl(AutotoolsPackage):
     over 1000 functions in total with an extensive test suite."""
 
     homepage = "http://www.gnu.org/software/gsl"
-    url      = "http://mirror.switch.ch/ftp/mirror/gnu/gsl/gsl-2.3.tar.gz"
+    url      = "https://ftpmirror.gnu.org/gsl/gsl-2.3.tar.gz"
 
     version('2.5', sha256='0460ad7c2542caaddc6729762952d345374784100223995eb14d614861f2258d')
     version('2.4',   'dba736f15404807834dc1c7b93e83b92')

--- a/var/spack/repos/builtin/packages/guile/package.py
+++ b/var/spack/repos/builtin/packages/guile/package.py
@@ -30,7 +30,7 @@ class Guile(AutotoolsPackage):
     the official extension language for the GNU operating system."""
 
     homepage = "https://www.gnu.org/software/guile/"
-    url      = "https://ftp.gnu.org/gnu/guile/guile-2.2.0.tar.gz"
+    url      = "https://ftpmirror.gnu.org/guile/guile-2.2.0.tar.gz"
 
     version('2.2.0',  '0d5de8075b965f9ee5ea04399b60a3f9')
     version('2.0.14', '333b6eec83e779935a45c818f712484e')

--- a/var/spack/repos/builtin/packages/help2man/package.py
+++ b/var/spack/repos/builtin/packages/help2man/package.py
@@ -30,7 +30,7 @@ class Help2man(AutotoolsPackage):
     output of other commands."""
 
     homepage = "https://www.gnu.org/software/help2man/"
-    url      = "http://gnu.askapache.com/help2man/help2man-1.47.4.tar.xz"
+    url      = "https://ftpmirror.gnu.org/help2man/help2man-1.47.4.tar.xz"
 
     version('1.47.4', '544aca496a7d89de3e5d99e56a2f03d3')
 

--- a/var/spack/repos/builtin/packages/libiberty/package.py
+++ b/var/spack/repos/builtin/packages/libiberty/package.py
@@ -35,7 +35,7 @@ class Libiberty(AutotoolsPackage):
     demangling and support functions for the GNU toolchain."""
 
     homepage = "https://www.gnu.org/software/binutils/"
-    url = "https://ftp.gnu.org/gnu/binutils/binutils-2.31.1.tar.xz"
+    url      = "https://ftpmirror.gnu.org/binutils/binutils-2.31.1.tar.xz"
 
     version('2.31.1', '5b7c9d4ce96f507d95c1b9a255e52418')
     version('2.30',   'ffc476dd46c96f932875d1b2e27e929f')

--- a/var/spack/repos/builtin/packages/libiconv/package.py
+++ b/var/spack/repos/builtin/packages/libiconv/package.py
@@ -30,7 +30,7 @@ class Libiconv(AutotoolsPackage):
     and the iconv program for character set conversion."""
 
     homepage = "https://www.gnu.org/software/libiconv/"
-    url      = "http://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.15.tar.gz"
+    url      = "https://ftpmirror.gnu.org/libiconv/libiconv-1.15.tar.gz"
 
     version('1.15', 'ace8b5f2db42f7b3b3057585e80d9808')
     version('1.14', 'e34509b1623cec449dfeb73d7ce9c6c6')

--- a/var/spack/repos/builtin/packages/libmatheval/package.py
+++ b/var/spack/repos/builtin/packages/libmatheval/package.py
@@ -34,7 +34,7 @@ class Libmatheval(AutotoolsPackage):
     compute symbolic derivatives and output expressions to strings."""
 
     homepage = "https://www.gnu.org/software/libmatheval/"
-    url      = "https://ftp.gnu.org/gnu/libmatheval/libmatheval-1.1.11.tar.gz"
+    url      = "https://ftpmirror.gnu.org/libmatheval/libmatheval-1.1.11.tar.gz"
 
     version('1.1.11', '595420ea60f6ddd75623847f46ca45c4')
 

--- a/var/spack/repos/builtin/packages/libsigsegv/package.py
+++ b/var/spack/repos/builtin/packages/libsigsegv/package.py
@@ -29,7 +29,7 @@ class Libsigsegv(AutotoolsPackage):
     """GNU libsigsegv is a library for handling page faults in user mode."""
 
     homepage = "https://www.gnu.org/software/libsigsegv/"
-    url      = "https://ftp.gnu.org/gnu/libsigsegv/libsigsegv-2.11.tar.gz"
+    url      = "https://ftpmirror.gnu.org/libsigsegv/libsigsegv-2.11.tar.gz"
 
     patch('patch.new_config_guess', when='@2.10')
 

--- a/var/spack/repos/builtin/packages/libtool/package.py
+++ b/var/spack/repos/builtin/packages/libtool/package.py
@@ -29,7 +29,7 @@ class Libtool(AutotoolsPackage):
     """libtool -- library building part of autotools."""
 
     homepage = 'https://www.gnu.org/software/libtool/'
-    url = 'http://ftpmirror.gnu.org/libtool/libtool-2.4.2.tar.gz'
+    url      = 'https://ftpmirror.gnu.org/libtool/libtool-2.4.2.tar.gz'
 
     version('develop', git='https://git.savannah.gnu.org/git/libtool.git',
             branch='master', submodules=True)

--- a/var/spack/repos/builtin/packages/libunistring/package.py
+++ b/var/spack/repos/builtin/packages/libunistring/package.py
@@ -30,7 +30,7 @@ class Libunistring(AutotoolsPackage):
     and for manipulating C strings according to the Unicode standard."""
 
     homepage = "https://www.gnu.org/software/libunistring/"
-    url      = "http://ftp.gnu.org/gnu/libunistring/libunistring-0.9.7.tar.xz"
+    url      = "https://ftpmirror.gnu.org/libunistring/libunistring-0.9.7.tar.xz"
 
     version('0.9.7', '82e0545363d111bfdfec2ddbfe62ffd3')
     version('0.9.6', 'cb09c398020c27edac10ca590e9e9ef3')

--- a/var/spack/repos/builtin/packages/m4/package.py
+++ b/var/spack/repos/builtin/packages/m4/package.py
@@ -29,7 +29,7 @@ class M4(AutotoolsPackage):
     """GNU M4 is an implementation of the traditional Unix macro processor."""
 
     homepage = "https://www.gnu.org/software/m4/m4.html"
-    url      = "https://ftp.gnu.org/gnu/m4/m4-1.4.18.tar.gz"
+    url      = "https://ftpmirror.gnu.org/m4/m4-1.4.18.tar.gz"
 
     version('1.4.18', 'a077779db287adf4e12a035029002d28')
     version('1.4.17', 'a5e9954b1dae036762f7b13673a2cf76')

--- a/var/spack/repos/builtin/packages/mpc/package.py
+++ b/var/spack/repos/builtin/packages/mpc/package.py
@@ -31,7 +31,7 @@ class Mpc(AutotoolsPackage):
        result."""
 
     homepage = "http://www.multiprecision.org"
-    url      = "https://ftp.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz"
+    url      = "https://ftpmirror.gnu.org/mpc/mpc-1.1.0.tar.gz"
     list_url = "http://www.multiprecision.org/mpc/download.html"
 
     version('1.1.0', '4125404e41e482ec68282a2e687f6c73')

--- a/var/spack/repos/builtin/packages/mpfr/package.py
+++ b/var/spack/repos/builtin/packages/mpfr/package.py
@@ -30,7 +30,7 @@ class Mpfr(AutotoolsPackage):
        floating-point computations with correct rounding."""
 
     homepage = "http://www.mpfr.org"
-    url      = "https://ftp.gnu.org/gnu/mpfr/mpfr-4.0.1.tar.bz2"
+    url      = "https://ftpmirror.gnu.org/mpfr/mpfr-4.0.1.tar.bz2"
 
     version('4.0.1', '8c21d8ac7460493b2b9f3ef3cc610454')
     version('4.0.0', 'ef619f3bb68039e35c4a219e06be72d0')

--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -36,7 +36,7 @@ class Ncurses(AutotoolsPackage):
     SYSV-curses enhancements over BSD curses."""
 
     homepage = "http://invisible-island.net/ncurses/ncurses.html"
-    url      = "http://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.1.tar.gz"
+    url      = "https://ftpmirror.gnu.org/ncurses/ncurses-6.1.tar.gz"
 
     version('6.1', '98c889aaf8d23910d2b92d65be2e737a')
     version('6.0', 'ee13d052e1ead260d7c28071f46eefb1')

--- a/var/spack/repos/builtin/packages/nettle/package.py
+++ b/var/spack/repos/builtin/packages/nettle/package.py
@@ -30,7 +30,7 @@ class Nettle(AutotoolsPackage):
     that is designed to fit easily in many contexts."""
 
     homepage = "https://www.lysator.liu.se/~nisse/nettle/"
-    url      = "http://ftp.gnu.org/gnu/nettle/nettle-3.3.tar.gz"
+    url      = "https://ftpmirror.gnu.org/nettle/nettle-3.3.tar.gz"
 
     version('3.4',   'dc0f13028264992f58e67b4e8915f53d')
     version('3.3',   '10f969f78a463704ae73529978148dbe')

--- a/var/spack/repos/builtin/packages/octave/package.py
+++ b/var/spack/repos/builtin/packages/octave/package.py
@@ -34,7 +34,7 @@ class Octave(AutotoolsPackage):
     Matlab. It may also be used as a batch-oriented language."""
 
     homepage = "https://www.gnu.org/software/octave/"
-    url      = "https://ftp.gnu.org/gnu/octave/octave-4.0.0.tar.gz"
+    url      = "https://ftpmirror.gnu.org/octave/octave-4.0.0.tar.gz"
 
     extendable = True
 

--- a/var/spack/repos/builtin/packages/parallel/package.py
+++ b/var/spack/repos/builtin/packages/parallel/package.py
@@ -32,7 +32,7 @@ class Parallel(AutotoolsPackage):
     """
 
     homepage = "http://www.gnu.org/software/parallel/"
-    url      = "http://ftp.gnu.org/gnu/parallel/parallel-20170122.tar.bz2"
+    url      = "https://ftpmirror.gnu.org/parallel/parallel-20170122.tar.bz2"
 
     version('20170322', '4fe1b8d2e3974d26c77f0b514988214d')
     version('20170122', 'c9f0ec01463dc75dbbf292fd8be5f1eb')

--- a/var/spack/repos/builtin/packages/patch/package.py
+++ b/var/spack/repos/builtin/packages/patch/package.py
@@ -32,7 +32,7 @@ class Patch(AutotoolsPackage):
     """
 
     homepage = "http://savannah.gnu.org/projects/patch/"
-    url      = "http://ftp.gnu.org/gnu/patch/patch-2.7.6.tar.xz"
+    url      = "https://ftpmirror.gnu.org/patch/patch-2.7.6.tar.xz"
 
     version('2.7.6', '78ad9937e4caadcba1526ef1853730d5')
     version('2.7.5', 'e3da7940431633fb65a01b91d3b7a27a')

--- a/var/spack/repos/builtin/packages/readline/package.py
+++ b/var/spack/repos/builtin/packages/readline/package.py
@@ -34,7 +34,7 @@ class Readline(AutotoolsPackage):
     csh-like history expansion on previous commands."""
 
     homepage = "http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html"
-    url      = "https://ftp.gnu.org/gnu/readline/readline-7.0.tar.gz"
+    url      = "https://ftpmirror.gnu.org/readline/readline-7.0.tar.gz"
 
     version('7.0', '205b03a87fc83dab653b628c59b9fc91')
     version('6.3', '33c8fb279e981274f485fd91da77e94a')

--- a/var/spack/repos/builtin/packages/screen/package.py
+++ b/var/spack/repos/builtin/packages/screen/package.py
@@ -31,7 +31,7 @@ class Screen(AutotoolsPackage):
     """
 
     homepage = "https://www.gnu.org/software/screen/"
-    url      = "http://ftp.gnu.org/gnu/screen/screen-4.3.1.tar.gz"
+    url      = "https://ftpmirror.gnu.org/screen/screen-4.3.1.tar.gz"
 
     version('4.6.2', 'a0f529d3333b128dfaa324d978ba73a8')
     version('4.3.1', '5bb3b0ff2674e29378c31ad3411170ad')

--- a/var/spack/repos/builtin/packages/sed/package.py
+++ b/var/spack/repos/builtin/packages/sed/package.py
@@ -28,6 +28,6 @@ from spack import *
 class Sed(AutotoolsPackage):
     """GNU implementation of the famous stream editor."""
     homepage = "http://www.gnu.org/software/sed/"
-    url      = "http://ftpmirror.gnu.org/sed/sed-4.2.2.tar.bz2"
+    url      = "https://ftpmirror.gnu.org/sed/sed-4.2.2.tar.bz2"
 
     version('4.2.2', '7ffe1c7cdc3233e1e0c4b502df253974')

--- a/var/spack/repos/builtin/packages/stow/package.py
+++ b/var/spack/repos/builtin/packages/stow/package.py
@@ -34,7 +34,7 @@ class Stow(AutotoolsPackage):
        installed in the same place."""
 
     homepage = "https://www.gnu.org/software/stow/"
-    url      = "https://mirrors.kernel.org/gnu/stow/stow-2.2.2.tar.bz2"
+    url      = "https://ftpmirror.gnu.org/stow/stow-2.2.2.tar.bz2"
 
     version('2.2.2', 'af1e1de9d973c835bee80c745b5ee849')
     version('2.2.0', '5bb56592eff9aaf9dfb6c975b3004240')

--- a/var/spack/repos/builtin/packages/tar/package.py
+++ b/var/spack/repos/builtin/packages/tar/package.py
@@ -30,7 +30,7 @@ class Tar(AutotoolsPackage):
     other kinds of manipulation."""
 
     homepage = "https://www.gnu.org/software/tar/"
-    url = "https://ftp.gnu.org/gnu/tar/tar-1.29.tar.gz"
+    url      = "https://ftpmirror.gnu.org/tar/tar-1.29.tar.gz"
 
     version('1.30', 'e0c5ed59e4dd33d765d6c90caadd3c73')
     version('1.29', 'cae466e6e58c7292355e7080248f244db3a4cf755f33f4fa25ca7f9a7ed09af0')

--- a/var/spack/repos/builtin/packages/texinfo/package.py
+++ b/var/spack/repos/builtin/packages/texinfo/package.py
@@ -34,7 +34,7 @@ class Texinfo(AutotoolsPackage):
     of the time. It is used by many non-GNU projects as well."""
 
     homepage = "https://www.gnu.org/software/texinfo/"
-    url      = "http://ftp.gnu.org/gnu/texinfo/texinfo-6.0.tar.gz"
+    url      = "https://ftpmirror.gnu.org/texinfo/texinfo-6.0.tar.gz"
 
     version('6.5', '94e8f7149876793030e5518dd8d6e956')
     version('6.3', '9b08daca9bf8eccae9b0f884aba41f9e')

--- a/var/spack/repos/builtin/packages/units/package.py
+++ b/var/spack/repos/builtin/packages/units/package.py
@@ -29,7 +29,7 @@ class Units(AutotoolsPackage):
     """GNU units converts between different systems of units"""
 
     homepage = "https://www.gnu.org/software/units/"
-    url      = "https://ftp.gnu.org/gnu/units/units-2.13.tar.gz"
+    url      = "https://ftpmirror.gnu.org/units/units-2.13.tar.gz"
 
     version('2.13', '5cbf2a6af76e94ba0ac55fc8d99d5a3e')
 

--- a/var/spack/repos/builtin/packages/wget/package.py
+++ b/var/spack/repos/builtin/packages/wget/package.py
@@ -32,7 +32,7 @@ class Wget(AutotoolsPackage):
     cron jobs, terminals without X-Windows support, etc."""
 
     homepage = "http://www.gnu.org/software/wget/"
-    url      = "http://ftp.gnu.org/gnu/wget/wget-1.19.1.tar.gz"
+    url      = "https://ftpmirror.gnu.org/wget/wget-1.19.1.tar.gz"
 
     version('1.19.1', '87cea36b7161fd43e3fd51a4e8b89689')
     version('1.17',   'c4c4727766f24ac716936275014a0536')


### PR DESCRIPTION
Fixes #8983 

Although https://ftp.gnu.org/ is back online now, we should still be downloading all GNU software from the officially recommended mirror URL. According to https://www.gnu.org/server/mirror.en.html:

> First, for users/downloaders: the address http://ftpmirror.gnu.org/ multiplexes between the mirrors, trying to choose one that is nearby and up to date. E.g., http://ftpmirror.gnu.org/emacs/ goes to a mirror's directory of GNU Emacs. We recommend using this generic ftpmirror.gnu.org address wherever possible in links, documentation, etc., to reduce load on the main GNU server.

Hopefully http://ftpmirror.gnu.org/ is more stable than https://ftp.gnu.org/. This PR also changes many URLs from http to https, further improving security. I purged my downloads cache and confirmed that I can download all of these packages with the new URLs.

@healther @bassenj @tz-rrze 