### PR TITLE
Specify Python executable in VTK package

### DIFF
--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -116,14 +116,19 @@ class Vtk(CMakePackage):
             '-DNETCDF_C_ROOT={0}'.format(spec['netcdf'].prefix),
             '-DNETCDF_CXX_ROOT={0}'.format(spec['netcdf-cxx'].prefix),
 
-            # Enable/Disable wrappers for Python.
-            '-DVTK_WRAP_PYTHON={0}'.format(
-                'ON' if '+python' in spec else 'OFF'),
-
             # Disable wrappers for other languages.
             '-DVTK_WRAP_JAVA=OFF',
             '-DVTK_WRAP_TCL=OFF',
         ]
+
+        # Enable/Disable wrappers for Python.
+        if '+python' in spec:
+            cmake_args.extend([
+                '-DVTK_WRAP_PYTHON=ON',
+                '-DPYTHON_EXECUTABLE={0}'.format(spec['python'].command.path)
+            ])
+        else:
+            cmake_args.append('-DVTK_WRAP_PYTHON=OFF')
 
         if 'darwin' in spec.architecture:
             cmake_args.extend([


### PR DESCRIPTION
Fixes #8997 

This PR fixes a bug where the system Python 2 gets picked up if Python 3 is in the DAG. By explicitly specifying the Python executable, the build succeeds.

@bassenj Can you test this?