### PR TITLE
Add prepend-path to environment options in compilers configuration file

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -215,6 +215,18 @@ for varname in "${env_set_varnames[@]}"; do
 done
 
 #
+# Prepend paths as defined in the 'environment' section of the compiler config
+#   names are stored in SPACK_ENV_TO_PREPEND
+#   values are stored in SPACK_ENV_PREPEND_<varname>
+#
+IFS=':' read -ra env_prepend_varnames <<< "$SPACK_ENV_TO_PREPEND"
+for varname in "${env_set_varnames[@]}"; do
+    spack_varname="SPACK_ENV_SET_$varname"
+    export "$varname"="${!spack_varname}:$varname"
+    unset "$spack_varname"
+done
+
+#
 # Filter '.' and Spack environment directories out of PATH so that
 # this script doesn't just call itself
 #

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -300,6 +300,15 @@ def set_build_environment_variables(pkg, env, dirty):
         env_variables = ":".join(env_to_set.keys())
         env.set('SPACK_ENV_TO_SET', env_variables)
 
+    if 'prepend-path' in environment:
+        env_to_prepend = environment['prepend-path']
+        for key, value in iteritems(env_to_prepend):
+            env.set('SPACK_ENV_PREPEND_%s' % key, value)
+            env.prepend_path('%s' % key, value)
+        # Let shell know which variables to set
+        env_variables = ":".join(env_to_prepend.keys())
+        env.set('SPACK_ENV_TO_PREPEND', env_variables)
+
     if compiler.extra_rpaths:
         extra_rpaths = ':'.join(compiler.extra_rpaths)
         env.set('SPACK_COMPILER_EXTRA_RPATHS', extra_rpaths)

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -160,11 +160,12 @@ def compiler_info(args):
                 for flag, flag_value in iteritems(c.flags):
                     print("\t\t%s = %s" % (flag, flag_value))
             if len(c.environment) != 0:
-                if len(c.environment['set']) != 0:
+                if any(len(c.environment[key]) != 0 for key in c.environment):
                     print("\tenvironment:")
-                    print("\t    set:")
-                    for key, value in iteritems(c.environment['set']):
-                        print("\t        %s = %s" % (key, value))
+                    for key in c.environment:
+                        print("\t    %s:" % key)
+                        for var, value in iteritems(c.environment[key]):
+                            print("\t        %s = %s" % (var, value))
             if c.extra_rpaths:
                 print("\tExtra rpaths:")
                 for extra_rpath in c.extra_rpaths:

--- a/lib/spack/spack/schema/compilers.py
+++ b/lib/spack/spack/schema/compilers.py
@@ -92,7 +92,15 @@ schema = {
                                             'type': 'string'
                                         }
                                     }
-                                }
+                                },
+                                'prepend-path': {
+                                    'type': 'object',
+                                    'patternProperties': {
+                                        r'\w[\w-]*': {  # variable name
+                                            'type': 'string'
+                                        }
+                                    }
+                                },
                             }
                         },
                         'extra_rpaths': {


### PR DESCRIPTION
Currently we can only set environment variables from the compiler config file. This allows us to prepend to paths.

E.G.
```
compilers:
- compiler:
  spec: gcc@7.3.0
  environment:
    prepend-path:
      PATH: /usr/bin/gnu/extra_bin
...
```

This appears to be particularly relevant for PGI compilers.