### PR TITLE
Fix missing makefile variable in clapack package

### DIFF
--- a/var/spack/repos/builtin/packages/clapack/package.py
+++ b/var/spack/repos/builtin/packages/clapack/package.py
@@ -50,6 +50,7 @@ class Clapack(MakefilePackage):
             make_inc = FileFilter('make.inc')
             make_inc.filter(r'^BLASLIB.*',
                             'BLASLIB = ../../libcblaswr.a -lcblas -latlas')
+            makefile = FileFilter('Makefile')
             makefile.filter(r'^lib.*',
                             'lib: variants lapacklib tmglib')
 


### PR DESCRIPTION
Fixes #9013 

It looks like this package has been broken since @fanne-stat added it in #7992.

@yrevaz Can you see if this solves your problem?