### PR TITLE
Open MPI: add v2.1.5

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -90,6 +90,7 @@ class Openmpi(AutotoolsPackage):
     version('3.0.2', '098fa89646f5b4438d9d8534bc960cd6')  # libmpi.so.40.00.2
     version('3.0.1', '565f5060e080b0871a64b295c3d4426a')  # libmpi.so.40.00.1    
     version('3.0.0', '757d51719efec08f9f1a7f32d58b3305')  # libmpi.so.40.00.0
+    version('2.1.5', '6019c8b67d4975d833801e72ba290918')  # libmpi.so.20.10.3 
     version('2.1.4', '003b356a24a5b7bd1705a23ddc69d9a0')  # libmpi.so.20.10.3
     version('2.1.3', '46079b6f898a412240a0bf523e6cd24b')  # libmpi.so.20.10.2
     version('2.1.2', 'ff2e55cc529802e7b0738cf87acd3ee4')  # libmpi.so.20.10.2


### PR DESCRIPTION
Final fix for v2.1 (hopefully)
Test build on LANL CCSCS4, Desktop

Signed-off-by: Daniel Topa <dantopa@lanl.gov>

## Verification of libmpi.so
dantopa@ccscs4.lanl.gov:spack.log.in.ompi $ cd $(spack location -i openmpi/lrl77yt)
dantopa@ccscs4.lanl.gov:openmpi-**2.1.5**-lrl77ytyucpcld67c6g2bsl7zzolfdyv $ cd lib
dantopa@ccscs4.lanl.gov:lib $ ls -alh
total 20M
drwxr-x--- 4 dantopa dantopa 4.0K Aug 18 14:08 .
drwxr-x--- 8 dantopa dantopa  103 Aug 18 14:07 ..
. . .
lrwxrwxrwx 1 dantopa dantopa   17 Aug 18 14:08 libmpi.so.20 -> l**ibmpi.so.20.10.3**