### PR TITLE
Fix gcc + binutils compilation.

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -115,7 +115,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
     depends_on('zstd', when='@10:')
     depends_on('iconv', when='platform=darwin')
     depends_on('gnat', when='languages=ada')
-    depends_on('binutils~libiberty', when='+binutils')
+    depends_on('binutils~libiberty', when='+binutils', type=('build', 'run'))
     depends_on('zip', type='build', when='languages=java')
     depends_on('cuda', when='+nvptx')
 

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -373,8 +373,6 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
         # enable appropriate bootstrapping flags
         stage1_ldflags = str(self.rpath_args)
         boot_ldflags = stage1_ldflags + ' -static-libstdc++ -static-libgcc'
-        if '%gcc' in spec:
-            stage1_ldflags = boot_ldflags
         options.append('--with-stage1-ldflags=' + stage1_ldflags)
         options.append('--with-boot-ldflags=' + boot_ldflags)
 

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -115,7 +115,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
     depends_on('zstd', when='@10:')
     depends_on('iconv', when='platform=darwin')
     depends_on('gnat', when='languages=ada')
-    depends_on('binutils~libiberty', when='+binutils', type=('build', 'run'))
+    depends_on('binutils~libiberty', when='+binutils', type=('build', 'link', 'run'))
     depends_on('zip', type='build', when='languages=java')
     depends_on('cuda', when='+nvptx')
 


### PR DESCRIPTION
On Centos (RHEL) 7, a static libstdc++ is not available by default and
was required to compile stage1.

Now we use static libstdc++ only for stage > 1.

Almost like in PR #8972 binutils dependency has been modified to 'run', but also to 'build' instead of 'link'.

Fixes #17294
Fixes #17325