### PR TITLE
Make mirrors use spack environment expansions

### DIFF
--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -25,7 +25,7 @@ import spack.error
 import spack.util.lock
 import spack.fetch_strategy as fs
 import spack.util.pattern as pattern
-from spack.util.path import canonicalize_path
+import spack.util.path as sup
 from spack.util.crypto import prefix_bits, bit_length
 
 _source_path_subdir = 'spack-src'
@@ -37,7 +37,7 @@ def _first_accessible_path(paths):
     for path in paths:
         try:
             # try to create the path if it doesn't exist.
-            path = canonicalize_path(path)
+            path = sup.canonicalize_path(path)
             mkdirp(path)
 
             # ensure accessible
@@ -76,7 +76,7 @@ def get_tmp_root():
             raise StageError("No accessible stage paths in:", candidates)
 
         # Return None to indicate we're using a local staging area.
-        if path == canonicalize_path(spack.paths.stage_path):
+        if path == sup.canonicalize_path(spack.paths.stage_path):
             _use_tmp_stage = False
             return None
 
@@ -358,9 +358,11 @@ class Stage(object):
             # Join URLs of mirror roots with mirror paths. Because
             # urljoin() will strip everything past the final '/' in
             # the root, so we add a '/' if it is not present.
-            mirror_roots = [root if root.endswith('/') else root + '/'
-                            for root in mirrors.values()]
-            urls = [urljoin(root, self.mirror_path) for root in mirror_roots]
+            mir_roots = [
+                sup.substitute_path_variables(root) if root.endswith(os.sep)
+                else sup.substitute_path_variables(root) + os.sep
+                for root in mirrors.values()]
+            urls = [urljoin(root, self.mirror_path) for root in mir_roots]
 
             # If this archive is normally fetched from a tarball URL,
             # then use the same digest.  `spack mirror` ensures that

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -17,6 +17,7 @@ import spack.paths
 
 __all__ = [
     'substitute_config_variables',
+    'substitute_path_variables',
     'canonicalize_path']
 
 # Substitutions to perform
@@ -49,11 +50,16 @@ def substitute_config_variables(path):
     return re.sub(r'(\$\w+\b|\$\{\w+\})', repl, path)
 
 
-def canonicalize_path(path):
-    """Substitute config vars, expand environment vars,
-       expand user home, take abspath."""
+def substitute_path_variables(path):
+    """Substitute config vars, expand environment vars, expand user home."""
     path = substitute_config_variables(path)
     path = os.path.expandvars(path)
     path = os.path.expanduser(path)
+    return path
+
+
+def canonicalize_path(path):
+    """Same as substitute_path_variables, but also take absolute path."""
+    path = substitute_path_variables(path)
     path = os.path.abspath(path)
     return path


### PR DESCRIPTION
Previously, it was not possible to use environment variables or spack config variables in mirror paths. With this PR you can.

E.g. `mirrors.yaml`

```
mirrors:
  my_mirror: $spack/../mirror
```