### PR TITLE
use Package.libs in RPATH with a fallback to prefix.lib/lib64

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -258,7 +258,7 @@ def set_build_environment_variables(pkg, env, dirty):
     build_deps      = set(pkg.spec.dependencies(deptype=('build', 'test')))
     link_deps       = set(pkg.spec.traverse(root=False, deptype=('link')))
     build_link_deps = build_deps | link_deps
-    rpath_deps      = get_rpath_deps(pkg)
+    rpath_deps      = pkg.rpath_deps
 
     link_dirs = []
     include_dirs = []
@@ -579,22 +579,10 @@ def _static_to_shared_library(arch, compiler, static_lib, shared_lib=None,
     return compiler(*compiler_args, output=compiler_output)
 
 
-def get_rpath_deps(pkg):
-    """Return immediate or transitive RPATHs depending on the package."""
-    if pkg.transitive_rpaths:
-        return [d for d in pkg.spec.traverse(root=False, deptype=('link'))]
-    else:
-        return pkg.spec.dependencies(deptype='link')
-
-
 def get_rpaths(pkg):
     """Get a list of all the rpaths for a package."""
-    rpaths = [pkg.prefix.lib, pkg.prefix.lib64]
-    deps = get_rpath_deps(pkg)
-    rpaths.extend(d.prefix.lib for d in deps
-                  if os.path.isdir(d.prefix.lib))
-    rpaths.extend(d.prefix.lib64 for d in deps
-                  if os.path.isdir(d.prefix.lib64))
+    rpaths = pkg.rpath
+
     # Second module is our compiler mod name. We use that to get rpaths from
     # module show output.
     if pkg.compiler.modules and len(pkg.compiler.modules) > 1:

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -58,6 +58,7 @@ from spack.util.environment import (
     env_flag, filter_system_paths, get_path, is_system_path,
     EnvironmentModifications, validate, preserve_environment)
 from spack.util.environment import system_dirs
+from spack.error import NoLibrariesError
 from spack.util.executable import Executable
 from spack.util.module_cmd import load_module, get_path_from_module
 from spack.util.log_parse import parse_log_events, make_log_context
@@ -280,7 +281,7 @@ def set_build_environment_variables(pkg, env, dirty):
         dep_link_dirs = list()
         try:
             dep_link_dirs.extend(query.libs.directories)
-        except spack.spec.NoLibrariesError:
+        except NoLibrariesError:
             tty.debug("No libraries found for {0}".format(dep.name))
 
         for default_lib_dir in ['lib', 'lib64']:

--- a/lib/spack/spack/error.py
+++ b/lib/spack/spack/error.py
@@ -98,6 +98,14 @@ class UnsupportedPlatformError(SpackError):
         super(UnsupportedPlatformError, self).__init__(message)
 
 
+class NoLibrariesError(SpackError):
+    """Raised when package libraries are requested but cannot be found"""
+
+
+class NoHeadersError(SpackError):
+    """Raised when package headers are requested but cannot be found"""
+
+
 class SpecError(SpackError):
     """Superclass for all errors that occur while constructing specs."""
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -53,6 +53,7 @@ from llnl.util.lang import memoized
 from llnl.util.link_tree import LinkTree
 from llnl.util.tty.log import log_output
 from llnl.util.tty.color import colorize
+from spack.error import NoLibrariesError
 from spack.filesystem_view import YamlFilesystemView
 from spack.util.executable import which
 from spack.stage import Stage, ResourceStage, StageComposite
@@ -2156,13 +2157,13 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         """Get the rpath this package links with, as a list of paths."""
         try:
             rpaths = self.spec[self.name].libs.directories
-        except (RuntimeError, AttributeError, InstallError):
+        except (NoLibrariesError):
             rpaths = [self.prefix.lib, self.prefix.lib64]
 
         for d in self.rpath_deps:
             try:
                 rpaths.extend(d[d.name].libs.directories)
-            except (RuntimeError, AttributeError):
+            except (NoLibrariesError):
                 # fallback to prefix.lib/lib64
                 if os.path.isdir(d.prefix.lib64):
                     rpaths.append(d.prefix.lib64)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -107,7 +107,8 @@ import spack.util.spack_yaml as syaml
 
 from spack.dependency import Dependency, all_deptypes, canonical_deptype
 from spack.util.module_cmd import get_path_from_module, load_module
-from spack.error import SpackError, SpecError, UnsatisfiableSpecError
+from spack.error import NoLibrariesError, NoHeadersError
+from spack.error import SpecError, UnsatisfiableSpecError
 from spack.provider_index import ProviderIndex
 from spack.util.crypto import prefix_bits
 from spack.util.executable import Executable
@@ -731,7 +732,8 @@ def _libs_default_handler(descriptor, spec, cls):
     for shared in search_shared:
         for path, recursive in search_paths:
             libs = find_libraries(
-                name, root=path, shared=shared, recursive=recursive
+                name, root=path, shared=shared, recursive=recursive,
+                return_empty=True
             )
             if libs:
                 return libs
@@ -3719,14 +3721,6 @@ class DuplicateDependencyError(SpecError):
 
 class DuplicateCompilerSpecError(SpecError):
     """Raised when the same compiler occurs in a spec twice."""
-
-
-class NoLibrariesError(SpackError):
-    """Raised when package libraries are requested but cannot be found"""
-
-
-class NoHeadersError(SpackError):
-    """Raised when package headers are requested but cannot be found"""
 
 
 class UnsupportedCompilerError(SpecError):

--- a/var/spack/repos/builtin/packages/apple-libunwind/package.py
+++ b/var/spack/repos/builtin/packages/apple-libunwind/package.py
@@ -63,12 +63,9 @@ class AppleLibunwind(Package):
         it will link dynamically to `/usr/lib/system/libunwind.dylib`.
 
         """
-        libs = find_libraries('libSystem',
+        return find_libraries('libSystem',
                               self.prefix.lib,
                               shared=True, recursive=False)
-        if libs:
-            return libs
-        return None
 
     @property
     def headers(self):

--- a/var/spack/repos/builtin/packages/essl/package.py
+++ b/var/spack/repos/builtin/packages/essl/package.py
@@ -52,13 +52,11 @@ class Essl(Package):
                         essl_lib = ['libesslsmp']
 
         essl_root = prefix.lib64
-        essl_libs = find_libraries(
+        return find_libraries(
             essl_lib,
             root=essl_root,
             shared=True
         )
-
-        return essl_libs
 
     def install(self, spec, prefix):
         raise InstallError('IBM ESSL is not installable;'

--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.error import NoLibrariesError
 import os
 import sys
 
@@ -140,7 +141,9 @@ class Hypre(Package):
         is_shared = '+shared' in self.spec
         for path, recursive in search_paths:
             libs = find_libraries('libHYPRE', root=path,
-                                  shared=is_shared, recursive=recursive)
+                                  shared=is_shared, recursive=recursive,
+                                  return_empty=True)
             if libs:
                 return libs
-        return None
+        msg = 'Unable to locate Hypre libraries in {0}'
+        raise NoLibrariesError(msg.format(self.prefix))

--- a/var/spack/repos/builtin/packages/intel-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-mkl/package.py
@@ -65,4 +65,10 @@ class IntelMkl(IntelPackage):
 
     @property
     def libs(self):
-        return self.scalapack_libs + self.lapack_libs + self.blas_libs
+        res = self.lapack_libs + self.blas_libs
+        # we may not have MPI in spec to get correct
+        # ScaLAPACK
+        try:
+            return self.scalapack_libs + res
+        except (InstallError):
+            return res

--- a/var/spack/repos/builtin/packages/intel-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-mkl/package.py
@@ -62,3 +62,7 @@ class IntelMkl(IntelPackage):
     if sys.platform == 'darwin':
         # there is no libmkl_gnu_thread on macOS
         conflicts('threads=openmp', when='%gcc')
+
+    @property
+    def libs(self):
+        return self.scalapack_libs + self.lapack_libs + self.blas_libs

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -194,4 +194,10 @@ class IntelParallelStudio(IntelPackage):
 
     @property
     def libs(self):
-        return self.scalapack_libs + self.lapack_libs + self.blas_libs
+        res = self.lapack_libs + self.blas_libs
+        # we may not have MPI in spec to get correct
+        # ScaLAPACK
+        try:
+            return self.scalapack_libs + res
+        except (InstallError):
+            return res

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -191,3 +191,7 @@ class IntelParallelStudio(IntelPackage):
             'F90':  spack_fc,
             'FC':   spack_fc,
         })
+
+    @property
+    def libs(self):
+        return self.scalapack_libs + self.lapack_libs + self.blas_libs

--- a/var/spack/repos/builtin/packages/libx11/package.py
+++ b/var/spack/repos/builtin/packages/libx11/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.error import NoLibrariesError
 
 
 class Libx11(AutotoolsPackage):
@@ -31,7 +32,9 @@ class Libx11(AutotoolsPackage):
     def libs(self):
         for dir in ['lib64', 'lib']:
             libs = find_libraries('libX11', join_path(self.prefix, dir),
-                                  shared=True, recursive=False)
+                                  shared=True, recursive=False,
+                                  return_empty=True)
             if libs:
                 return libs
-        return None
+        msg = 'Unable to locate Libx11 libraries in {0}'
+        raise NoLibrariesError(msg.format(self.prefix))

--- a/var/spack/repos/builtin/packages/libxsmm/package.py
+++ b/var/spack/repos/builtin/packages/libxsmm/package.py
@@ -52,11 +52,12 @@ class Libxsmm(MakefilePackage):
     @property
     def libs(self):
         result = find_libraries(['libxsmm', 'libxsmmf'], root=self.prefix,
-                                recursive=True)
-        if len(result) == 0:
-            result = find_libraries(['libxsmm', 'libxsmmf'], root=self.prefix,
-                                    shared=False, recursive=True)
-        return result
+                                recursive=True, return_empty=True)
+        if result:
+            return result
+
+        return find_libraries(['libxsmm', 'libxsmmf'], root=self.prefix,
+                              shared=False, recursive=True)
 
     def edit(self, spec, prefix):
         kwargs = {'ignore_absent': False, 'backup': False, 'string': True}

--- a/var/spack/repos/builtin/packages/mesa-glu/package.py
+++ b/var/spack/repos/builtin/packages/mesa-glu/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.error import NoLibrariesError
 
 
 class MesaGlu(AutotoolsPackage):
@@ -24,6 +25,9 @@ class MesaGlu(AutotoolsPackage):
     def libs(self):
         for dir in ['lib64', 'lib']:
             libs = find_libraries('libGLU', join_path(self.prefix, dir),
-                                  shared=True, recursive=False)
+                                  shared=True, recursive=False,
+                                  return_empty=True)
             if libs:
                 return libs
+        msg = 'Unable to locate {0} libraries in {1}'
+        raise NoLibrariesError(msg.format(self.name, self.prefix))

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -5,6 +5,7 @@
 
 import sys
 from spack import *
+from spack.error import NoLibrariesError
 
 
 class Mesa(AutotoolsPackage):
@@ -186,9 +187,12 @@ class Mesa(AutotoolsPackage):
     def libs(self):
         for dir in ['lib64', 'lib']:
             libs = find_libraries('libGL', join_path(self.prefix, dir),
-                                  shared=True, recursive=False)
+                                  shared=True, recursive=False,
+                                  return_empty=True)
             if libs:
                 return libs
+        msg = 'Unable to locate {0} libraries in {1}'
+        raise NoLibrariesError(msg.format(self.name, self.prefix))
 
     @when('^python@3:')
     def setup_environment(self, spack_env, run_env):

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -223,7 +223,8 @@ class Mfem(Package):
             for shared in [True, False]:
                 for path in ['lib64', 'lib']:
                     lib = find_libraries(name, join_path(prefix, path),
-                                         shared=shared, recursive=False)
+                                         shared=shared, recursive=False,
+                                         return_empty=True)
                     if lib:
                         return lib
             return LibraryList([])
@@ -463,9 +464,8 @@ class Mfem(Package):
     def libs(self):
         """Export the mfem library file.
         """
-        libs = find_libraries('libmfem', root=self.prefix.lib,
+        return find_libraries('libmfem', root=self.prefix.lib,
                               shared=('+shared' in self.spec), recursive=False)
-        return libs or None
 
     @property
     def config_mk(self):

--- a/var/spack/repos/builtin/packages/nek5000/package.py
+++ b/var/spack/repos/builtin/packages/nek5000/package.py
@@ -141,14 +141,12 @@ class Nek5000(Package):
                 filter_file(r'^\$FC -c ', '$FC -qextname -c ', 'maketools')
 
             libx11_lib = find_libraries('libX11', spec['libx11'].prefix.lib,
-                                        shared=True, recursive=True)
+                                        shared=True, recursive=True,
+                                        return_empty=True)
             if not libx11_lib:
                 libx11_lib = \
                     find_libraries('libX11', spec['libx11'].prefix.lib64,
                                    shared=True, recursive=True)
-            if not libx11_lib:
-                raise RuntimeError('libX11 not found in %s/{lib,lib64}' %
-                                   spec['libx11'].prefix)
             # There is no other way to set the X11 library path except brute
             # force:
             filter_file(r'-L\$\(X\)', libx11_lib.search_flags,

--- a/var/spack/repos/builtin/packages/opengl/package.py
+++ b/var/spack/repos/builtin/packages/opengl/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.error import NoLibrariesError
 
 
 class Opengl(Package):
@@ -65,6 +66,9 @@ class Opengl(Package):
     def libs(self):
         for dir in ['lib64', 'lib']:
             libs = find_libraries('libGL', join_path(self.prefix, dir),
-                                  shared=True, recursive=False)
+                                  shared=True, recursive=False,
+                                  return_empty=True)
             if libs:
                 return libs
+        msg = 'Unable to locate {0} libraries in {1}'
+        raise NoLibrariesError(msg.format(self.name, self.prefix))

--- a/var/spack/repos/builtin/packages/openglu/package.py
+++ b/var/spack/repos/builtin/packages/openglu/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.error import NoLibrariesError
 
 
 class Openglu(Package):
@@ -61,6 +62,9 @@ class Openglu(Package):
     def libs(self):
         for dir in ['lib64', 'lib']:
             libs = find_libraries('libGLU', join_path(self.prefix, dir),
-                                  shared=True, recursive=False)
+                                  shared=True, recursive=False,
+                                  return_empty=True)
             if libs:
                 return libs
+        msg = 'Unable to locate {0} libraries in {1}'
+        raise NoLibrariesError(msg.format(self.name, self.prefix))

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -18,6 +18,7 @@ import spack.store
 import spack.util.spack_json as sjson
 from spack.util.environment import is_system_path
 from spack.util.prefix import Prefix
+from spack.error import NoLibrariesError
 from spack import *
 
 
@@ -495,6 +496,11 @@ class Python(AutotoolsPackage):
 
     @property
     def libs(self):
+        msg = 'Unable to locate {0} libraries in {1}'
+        # we will call command(), if prefix.bin does not exist,
+        # raise exception soon to make catching easier
+        if not os.path.exists(self.prefix.bin):
+            raise NoLibrariesError(msg.format('Python', self.prefix))
         # Spack installs libraries into lib, except on openSUSE where it
         # installs them into lib64. If the user is using an externally
         # installed package, it may be in either lib or lib64, so we need
@@ -513,8 +519,7 @@ class Python(AutotoolsPackage):
             elif os.path.exists(os.path.join(frameworkprefix, ldlibrary)):
                 return LibraryList(os.path.join(frameworkprefix, ldlibrary))
             else:
-                msg = 'Unable to locate {0} libraries in {1}'
-                raise RuntimeError(msg.format(ldlibrary, libdir))
+                raise NoLibrariesError(msg.format(ldlibrary, libdir))
         else:
             library = self.get_config_var('LIBRARY')
 
@@ -523,8 +528,7 @@ class Python(AutotoolsPackage):
             elif os.path.exists(os.path.join(frameworkprefix, library)):
                 return LibraryList(os.path.join(frameworkprefix, library))
             else:
-                msg = 'Unable to locate {0} libraries in {1}'
-                raise RuntimeError(msg.format(library, libdir))
+                raise NoLibrariesError(msg.format(library, libdir))
 
     @property
     def headers(self):

--- a/var/spack/repos/builtin/packages/suite-sparse/package.py
+++ b/var/spack/repos/builtin/packages/suite-sparse/package.py
@@ -130,7 +130,5 @@ class SuiteSparse(Package):
         comps = all_comps if not query_parameters else query_parameters
         libs = find_libraries(['lib' + c for c in comps], root=self.prefix.lib,
                               shared=True, recursive=False)
-        if not libs:
-            return None
         libs += find_system_libraries('librt')
         return libs

--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.error import NoLibrariesError
 import os
 import sys
 
@@ -504,7 +505,8 @@ class Sundials(CMakePackage):
         is_shared = '+shared' in self.spec
         for path, recursive in search_paths:
             libs = find_libraries(sun_libs, root=path, shared=is_shared,
-                                  recursive=recursive)
+                                  recursive=recursive, return_empty=True)
             if libs:
                 return libs
-        return None  # Raise an error
+        msg = 'Unable to locate Sundials libraries in {0}'
+        raise NoLibrariesError(msg.format(self.prefix))


### PR DESCRIPTION
@tgamblin  [wrote](https://github.com/spack/spack/pull/8994#discussion_r210522026)

> Adding results of libs and headers to the build environment wouldn’t be so hard... that’s something we should do. They just need to be added to the env vars for the wrappers in build_environment.py.

now the problem is what to do with packages that have more than one set of libs like `intel-mkl` with `blas_libs`, `lapack_libs` and `scalapack_libs`? That's actually the primary reason to get away from hard-coding `prefix.lib` in order to avoid surpises in `rpaths` for Intel packages.

The problem comes from the fact that at this stage Spack can't know which libs will actually be used inside a given package. Maybe a package needs just `blas` libs or the full set of `blas+lapack+scalapack`. So perhaps a simple solution is for complicated packages always define the total `libs` property. 