### PR TITLE
on error spack view suggests -i option

### DIFF
--- a/lib/spack/spack/cmd/view.py
+++ b/lib/spack/spack/cmd/view.py
@@ -55,11 +55,11 @@ YamlFilesystemView.
 import os
 
 import llnl.util.tty as tty
+from llnl.util.link_tree import MergeConflictError
 
 import spack.cmd
 import spack.store
 from spack.filesystem_view import YamlFilesystemView
-
 
 description = "produce a single-rooted directory view of packages"
 section = "environment"
@@ -208,9 +208,15 @@ def view(parser, args):
 
     # Map action to corresponding functionality
     if args.action in actions_link:
-        view.add_specs(*specs,
-                       with_dependencies=with_dependencies,
-                       exclude=args.exclude)
+        try:
+            view.add_specs(*specs,
+                           with_dependencies=with_dependencies,
+                           exclude=args.exclude)
+        except MergeConflictError:
+            tty.info("Some file blocked the merge, adding the '-i' flag will "
+                     "ignore this conflict. For more information see e.g. "
+                     "https://github.com/spack/spack/issues/9029")
+            raise
 
     elif args.action in actions_remove:
         view.remove_specs(*specs,


### PR DESCRIPTION
After we have now 3 open issues due to merge conflicts in `spack view`, I added a note to the existence of the `-i` (ignore conflicts) option in case of an error.

I'm not sure if I should intercept the error and update the error message or if this should directly be part of the original error message. This is the least invasive solution, nothing more.

Relates to #9029, #7001, #6266 