### PR TITLE
More consistent colored messages from activate/deactivate

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1956,7 +1956,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         """
         if verbose:
             tty.msg('Activating extension {0} for {1}'.format(
-                self.spec.cshort_spec, self.extendee_spec.cshort_spec)
+                self.spec.cshort_spec, self.extendee_spec.cshort_spec))
 
         self._sanity_check_extension()
         if not view:
@@ -1983,7 +1983,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
 
         if verbose:
             tty.debug('Activated extension {0} for {1}'.format(
-                self.spec.cshort_spec, self.extendee_spec.cshort_spec)
+                self.spec.cshort_spec, self.extendee_spec.cshort_spec))
 
     def dependency_activations(self):
         return (spec for spec in self.spec.traverse(root=False, deptype='run')
@@ -2009,14 +2009,14 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         `remove_dependents=True` deactivates extensions depending on this
         package instead of raising an error.
         """
-        if verbose:
-            tty.msg('Deactivating extension {0} for {1}'.format(
-                self.spec.cshort_spec, self.extendee_spec.cshort_spec)
-
         self._sanity_check_extension()
         force = kwargs.get('force', False)
         verbose = kwargs.get('verbose', True)
         remove_dependents = kwargs.get('remove_dependents', False)
+
+        if verbose:
+            tty.msg('Deactivating extension {0} for {1}'.format(
+                self.spec.cshort_spec, self.extendee_spec.cshort_spec))
 
         if not view:
             view = YamlFilesystemView(
@@ -2055,7 +2055,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
 
         if verbose:
             tty.debug('Deactivated extension {0} for {1}'.format(
-                self.spec.cshort_spec, self.extendee_spec.cshort_spec)
+                self.spec.cshort_spec, self.extendee_spec.cshort_spec))
 
     def deactivate(self, extension, view, **kwargs):
         """

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1954,10 +1954,6 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         Commands should call this routine, and should not call
         activate() directly.
         """
-        if verbose:
-            tty.msg("Activating extension %s for %s" %
-                    (self.spec.cshort_spec, self.extendee_spec.cshort_spec))
-
         self._sanity_check_extension()
         if not view:
             view = YamlFilesystemView(
@@ -1984,8 +1980,8 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         if verbose:
             tty.msg(
                 "Activated extension %s for %s" %
-                (self.spec.short_spec,
-                 self.extendee_spec.cformat("$_$@$+$%@")))
+                (self.spec.cshort_spec,
+                 self.extendee_spec.cshort_spec))
 
     def dependency_activations(self):
         return (spec for spec in self.spec.traverse(root=False, deptype='run')
@@ -2055,8 +2051,8 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         if verbose:
             tty.msg(
                 "Deactivated extension %s for %s" %
-                (self.spec.short_spec,
-                 self.extendee_spec.cformat("$_$@$+$%@")))
+                (self.spec.cshort_spec,
+                 self.extendee_spec.cshort_spec))
 
     def deactivate(self, extension, view, **kwargs):
         """

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1954,6 +1954,10 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         Commands should call this routine, and should not call
         activate() directly.
         """
+        if verbose:
+            tty.msg('Activating extension {0} for {1}'.format(
+                self.spec.cshort_spec, self.extendee_spec.cshort_spec)
+
         self._sanity_check_extension()
         if not view:
             view = YamlFilesystemView(
@@ -1978,10 +1982,8 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         extensions_layout.add_extension(self.extendee_spec, self.spec)
 
         if verbose:
-            tty.msg(
-                "Activated extension %s for %s" %
-                (self.spec.cshort_spec,
-                 self.extendee_spec.cshort_spec))
+            tty.debug('Activated extension {0} for {1}'.format(
+                self.spec.cshort_spec, self.extendee_spec.cshort_spec)
 
     def dependency_activations(self):
         return (spec for spec in self.spec.traverse(root=False, deptype='run')
@@ -2007,10 +2009,14 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         `remove_dependents=True` deactivates extensions depending on this
         package instead of raising an error.
         """
+        if verbose:
+            tty.msg('Deactivating extension {0} for {1}'.format(
+                self.spec.cshort_spec, self.extendee_spec.cshort_spec)
+
         self._sanity_check_extension()
         force = kwargs.get('force', False)
-        verbose = kwargs.get("verbose", True)
-        remove_dependents = kwargs.get("remove_dependents", False)
+        verbose = kwargs.get('verbose', True)
+        remove_dependents = kwargs.get('remove_dependents', False)
 
         if not view:
             view = YamlFilesystemView(
@@ -2033,11 +2039,10 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
                         if remove_dependents:
                             aspec.package.do_deactivate(**kwargs)
                         else:
-                            msg = ("Cannot deactivate %s because %s is "
-                                   "activated and depends on it.")
-                            raise ActivationError(
-                                msg % (self.spec.cshort_spec,
-                                       aspec.cshort_spec))
+                            msg = ('Cannot deactivate {0} because {1} is '
+                                   'activated and depends on it')
+                            raise ActivationError(msg.format(
+                                self.spec.cshort_spec, aspec.cshort_spec))
 
         self.extendee_spec.package.deactivate(
             self, view, **self.extendee_args)
@@ -2049,10 +2054,8 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
                 self.extendee_spec, self.spec)
 
         if verbose:
-            tty.msg(
-                "Deactivated extension %s for %s" %
-                (self.spec.cshort_spec,
-                 self.extendee_spec.cshort_spec))
+            tty.debug('Deactivated extension {0} for {1}'.format(
+                self.spec.cshort_spec, self.extendee_spec.cshort_spec)
 
     def deactivate(self, extension, view, **kwargs):
         """


### PR DESCRIPTION
Previously, the following discrepancies existed in the messages printed by `spack activate` and `spack deactivate`:

* `spack activate` would print twice (once before "activating" and once when "activated"), while `spack deactivate` would only print once (when "deactivate")
* Specs when "activating" and when "activated" were colored differently
* Extendee spec was colored but extension spec was not

This PR removes those discrepancies.

### Before

<img width="651" alt="screen shot 2018-08-21 at 11 01 17 am" src="https://user-images.githubusercontent.com/12021217/44413877-04aa0800-a532-11e8-8543-e5c90a5ff22a.png">

### After

<img width="650" alt="screen shot 2018-08-21 at 11 00 21 am" src="https://user-images.githubusercontent.com/12021217/44413894-0a9fe900-a532-11e8-83ca-4f1b7e38fab3.png">


