### PR TITLE
r-genomeinfodbdata: new version

### DIFF
--- a/var/spack/repos/builtin/packages/r-genomeinfodbdata/package.py
+++ b/var/spack/repos/builtin/packages/r-genomeinfodbdata/package.py
@@ -32,5 +32,8 @@ class RGenomeinfodbdata(RPackage):
     homepage = "https://bioconductor.org/packages/GenomeInfoDbData/"
     url      = "https://bioconductor.org/packages/3.5/data/annotation/src/contrib/GenomeInfoDbData_0.99.0.tar.gz"
 
+    version('1.1.0', '6efdca22839c90d455843bdab7c0ecb5d48e3b6c2f7b4882d3210a6bbad4304c',
+            url='https://bioconductor.org/packages/release/data/annotation/src/contrib/GenomeInfoDbData_1.1.0.tar.gz')
     version('0.99.0', '85977b51061dd02a90153db887040d05')
-    depends_on('r@3.4.0:3.4.9', when='@0.99.0')
+    depends_on('r@3.4.0:3.4.9', when='@0.99.0', type=('build', 'run'))
+    depends_on('r@3.5.0:3.5.9', when='@1.1.0', type=('build', 'run'))


### PR DESCRIPTION
not sure why this one doesn't have a git repo like the rest. can't find it listed on bioconductor site.