### PR TITLE
trinity: full dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/trinity/package.py
+++ b/var/spack/repos/builtin/packages/trinity/package.py
@@ -52,6 +52,36 @@ class Trinity(MakefilePackage):
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
 
+    # There is no documented list of these deps, but they're in the Dockerfile
+    #  and we have runtime errors without them
+    # https://github.com/trinityrnaseq/trinityrnaseq/blob/master/Docker/Dockerfile
+    depends_on("blast-plus", type="run")
+    depends_on("bowtie", type="run")
+    depends_on("r", type="run")
+    depends_on("r-tidyverse", type="run")
+    depends_on("r-edger", type="run")
+    depends_on("r-deseq2", type="run")
+    depends_on("r-ape", type="run")
+    depends_on("r-gplots", type="run")
+    depends_on("r-biobase", type="run")
+    depends_on("r-qvalue", type="run")
+    depends_on("rsem", type="run")
+    depends_on("kallisto", type="run")
+    depends_on("fastqc", type="run")
+    depends_on("samtools", type="run")
+    depends_on("py-numpy", type="run")
+    depends_on("express", type="run")
+    depends_on("perl-dbfile", type="run")
+    depends_on("perl-uri-escape", type="run")
+    depends_on("r-fastcluster", type="run")
+    depends_on("r-ctc", type="run")
+    depends_on("r-goseq", type="run")
+    depends_on("r-glimma", type="run")
+    depends_on("r-rots", type="run")
+    depends_on("r-goplot", type="run")
+    depends_on("r-argparse", type="run")
+    depends_on("r-sm", type="run")
+
     def build(self, spec, prefix):
         make()
         make("trinity_essentials")
@@ -76,4 +106,5 @@ class Trinity(MakefilePackage):
 
     def setup_environment(self, spack_env, run_env):
         run_env.set('TRINITY_HOME', self.prefix.bin)
+        run_env.prepend_path('PATH', self.prefix.bin.util)
         spack_env.append_flags('CXXFLAGS', self.compiler.openmp_flag)


### PR DESCRIPTION
Depends on #8939 and #9048 - #9063 (others too, but just listing the open PRs)

We were still having runtime issues with Trinity, and I've been having several users run with these individual modules loaded for the last few weeks, and that seems to have done the trick so I'm adding as dependencies. 