### PR TITLE
Added a new target message to comply with newer versions of GNU Make

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1166,11 +1166,13 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         #
         # GNU Make:
         #     make: *** No rule to make target `test'.  Stop.
+        #           *** No rule to make target 'test'.  Stop.
         #
         # BSD Make:
         #     make: don't know how to make test. Stop
         missing_target_msgs = [
             "No rule to make target `{0}'.  Stop.",
+            "No rule to make target '{0}'.  Stop.",
             "don't know how to make {0}. Stop",
         ]
 

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -59,6 +59,7 @@ def test_affirmative_make_check(directory, config, mock_packages):
     'directory',
     glob.iglob(os.path.join(DATA_PATH, 'make', 'negative', '*'))
 )
+@pytest.mark.regression('9067')
 def test_negative_make_check(directory, config, mock_packages):
     """Tests that Spack correctly ignores false positives in a Makefile."""
 


### PR DESCRIPTION
fixes #9028
fixes #9067

Unit tests were failing on a system with GNU Make v 4.1