### PR TITLE
leveldb: Fix header installation

### DIFF
--- a/var/spack/repos/builtin/packages/leveldb/package.py
+++ b/var/spack/repos/builtin/packages/leveldb/package.py
@@ -46,7 +46,7 @@ class Leveldb(MakefilePackage):
         for library in libraries:
             install(library, prefix.lib)
 
-        install_tree('include/leveldb', prefix.include)
+        install_tree('include', prefix.include)
 
         with open(join_path(prefix.lib, 'pkgconfig', 'leveldb.pc'), 'w') as f:
             f.write('prefix={0}\n'.format(prefix))


### PR DESCRIPTION
leveldb headers are typically included via <leveldb/c.h>. The migration to install_tree in 73c978ddd99973e29f2ba42078b10455c1de5ca8 caused the headers to end up in prefix.include, which breaks existing applications.