### PR TITLE
mvapich2: Use rdma-core for mrail and nemesis*ib* fabrics

### DIFF
--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -121,6 +121,10 @@ class Mvapich2(AutotoolsPackage):
     depends_on('libpciaccess', when=(sys.platform != 'darwin'))
     depends_on('cuda', when='+cuda')
     depends_on('psm', when='fabrics=psm')
+    depends_on('rdma-core', when='fabrics=mrail')
+    depends_on('rdma-core', when='fabrics=nemesisib')
+    depends_on('rdma-core', when='fabrics=nemesistcpib')
+    depends_on('rdma-core', when='fabrics=nemesisibtcp')
 
     filter_compiler_wrappers(
         'mpicc', 'mpicxx', 'mpif77', 'mpif90', 'mpifort', relative_root='bin'
@@ -180,7 +184,8 @@ class Mvapich2(AutotoolsPackage):
         elif 'fabrics=nemesis' in self.spec:
             opts = ["--with-device=ch3:nemesis"]
         elif 'fabrics=mrail' in self.spec:
-            opts = ["--with-device=ch3:mrail", "--with-rdma=gen2"]
+            opts = ["--with-device=ch3:mrail", "--with-rdma=gen2",
+                    "--disable-mcast"]
         return opts
 
     @property


### PR DESCRIPTION
Seems to work but it would be great if someone else could test this. @adamjstewart @alalazo 

Fixes #2200