### PR TITLE
Set DYLD_LIBRARY_PATH on macOS

### DIFF
--- a/etc/spack/defaults/darwin/modules.yaml
+++ b/etc/spack/defaults/darwin/modules.yaml
@@ -14,31 +14,10 @@
 #   ~/.spack/modules.yaml
 # -------------------------------------------------------------------------
 modules:
-  enable:
-    - tcl
-    - dotkit
   prefix_inspections:
-    bin:
-      - PATH
-    man:
-      - MANPATH
-    share/man:
-      - MANPATH
-    share/aclocal:
-      - ACLOCAL_PATH
     lib:
-      - LIBRARY_PATH
+      - DYLD_LIBRARY_PATH
+      - DYLD_FALLBACK_LIBRARY_PATH
     lib64:
-      - LIBRARY_PATH
-    include:
-      - CPATH
-    lib/pkgconfig:
-      - PKG_CONFIG_PATH
-    lib64/pkgconfig:
-      - PKG_CONFIG_PATH
-    '':
-      - CMAKE_PREFIX_PATH
-
-  lmod:
-    hierarchy:
-      - mpi
+      - DYLD_LIBRARY_PATH
+      - DYLD_FALLBACK_LIBRARY_PATH

--- a/etc/spack/defaults/linux/modules.yaml
+++ b/etc/spack/defaults/linux/modules.yaml
@@ -14,31 +14,8 @@
 #   ~/.spack/modules.yaml
 # -------------------------------------------------------------------------
 modules:
-  enable:
-    - tcl
-    - dotkit
   prefix_inspections:
-    bin:
-      - PATH
-    man:
-      - MANPATH
-    share/man:
-      - MANPATH
-    share/aclocal:
-      - ACLOCAL_PATH
     lib:
-      - LIBRARY_PATH
+      - LD_LIBRARY_PATH
     lib64:
-      - LIBRARY_PATH
-    include:
-      - CPATH
-    lib/pkgconfig:
-      - PKG_CONFIG_PATH
-    lib64/pkgconfig:
-      - PKG_CONFIG_PATH
-    '':
-      - CMAKE_PREFIX_PATH
-
-  lmod:
-    hierarchy:
-      - mpi
+      - LD_LIBRARY_PATH


### PR DESCRIPTION
Fixes #9066 

Are there any other macOS-specific environment variables we should be setting? Are there any other OSes that we support aside from `darwin` and `linux`?

@goxberry 