### PR TITLE
libfabric: Add develop version option.

### DIFF
--- a/var/spack/repos/builtin/packages/libfabric/package.py
+++ b/var/spack/repos/builtin/packages/libfabric/package.py
@@ -31,7 +31,9 @@ class Libfabric(AutotoolsPackage):
 
     homepage = "https://libfabric.org/"
     url      = "https://github.com/ofiwg/libfabric/releases/download/v1.6.1/libfabric-1.6.1.tar.gz"
+    git = "https://github.com/ofiwg/libfabric.git"
 
+    version('develop', branch='master')
     version('1.6.1', 'ff78dc9fcbf273a119c737a4e1df46d1')
     version('1.6.0', '91d63ab3c0b9724a4db660019f928cab')
     version('1.5.3', '1fe07e972fe487c6a3e44c0fb68b49a2')
@@ -62,6 +64,16 @@ class Libfabric(AutotoolsPackage):
     depends_on('opa-psm2', when='fabrics=psm2')
     depends_on('psm', when='fabrics=psm')
     depends_on('ucx', when='fabrics=mlx')
+
+    depends_on('m4', when='@develop', type='build')
+    depends_on('autoconf', when='@develop', type='build')
+    depends_on('automake', when='@develop', type='build')
+    depends_on('libtool', when='@develop', type='build')
+
+    @when('@develop')
+    def autoreconf(self, spec, prefix):
+        bash = which('bash')
+        bash('./autogen.sh')
 
     def configure_args(self):
         args = []


### PR DESCRIPTION
Add develop version option to libfabric, conditionally bringing in
additional build dependencies: m4, autoconf, automake, libtool.