### PR TITLE
Add line in trilinos/stk configuration to enable stk_ngp package.

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -431,6 +431,7 @@ class Trilinos(CMakePackage):
             # They can likely change when necessary in the future
             options.extend([
                 '-DTrilinos_ENABLE_STKMesh:BOOL=ON',
+                '-DTrilinos_ENABLE_STKNGP:BOOL=ON',
                 '-DTrilinos_ENABLE_STKSimd:BOOL=ON',
                 '-DTrilinos_ENABLE_STKIO:BOOL=ON',
                 '-DTrilinos_ENABLE_STKTransfer:BOOL=ON',


### PR DESCRIPTION
The Trilinos/stk configuration is pretty Nalu specific right
now (and is acknowledged as such in a comment in this package.py file), and
this commit enables a module that Nalu will be needing.

Jon Rood suggests tagging him and Andrey: @jrood-nrel @aprokop 