### PR TITLE
Update to latest version of pytest and dependencies

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -400,7 +400,7 @@ class PythonPackage(PackageBase):
 
         # Make sure we are importing the installed modules,
         # not the ones in the current directory
-        with working_dir('..'):
+        with working_dir('spack-test', create=True):
             for module in self.import_modules:
                 self.python('-c', 'import {0}'.format(module))
 

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -440,7 +440,7 @@ class Gdal(AutotoolsPackage):
     @on_package_attributes(run_tests=True)
     def import_module_test(self):
         if '+python' in self.spec:
-            with working_dir('..'):
+            with working_dir('spack-test', create=True):
                 for module in self.import_modules:
                     python('-c', 'import {0}'.format(module))
 

--- a/var/spack/repos/builtin/packages/py-atomicwrites/package.py
+++ b/var/spack/repos/builtin/packages/py-atomicwrites/package.py
@@ -25,15 +25,14 @@
 from spack import *
 
 
-class PyScandir(PythonPackage):
-    """scandir, a better directory iterator and faster os.walk()."""
+class PyAtomicwrites(PythonPackage):
+    """Atomic file writes."""
 
-    homepage = "https://github.com/benhoyt/scandir"
-    url      = "https://pypi.io/packages/source/s/scandir/scandir-1.9.0.tar.gz"
+    homepage = "https://github.com/untitaker/python-atomicwrites"
+    url      = "https://pypi.io/packages/source/a/atomicwrites/atomicwrites-1.1.5.tar.gz"
 
-    import_modules = ['scandir']
+    import_modules = ['atomicwrites']
 
-    version('1.9.0', '506c4cc5f38c00b301642a9cb0433910')
-    version('1.6',   '0180ddb97c96cbb2d4f25d2ae11c64ac')
+    version('1.1.5', sha256='240831ea22da9ab882b551b31d4225591e5e447a68c5e188db5b89ca1d487585')
 
-    depends_on('py-setuptools', type=('build'))
+    depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-funcsigs/package.py
+++ b/var/spack/repos/builtin/packages/py-funcsigs/package.py
@@ -27,9 +27,14 @@ from spack import *
 
 class PyFuncsigs(PythonPackage):
     """Python function signatures from PEP362 for Python 2.6, 2.7 and 3.2."""
+
     homepage = "https://pypi.python.org/pypi/funcsigs"
-    url      = "https://pypi.io/packages/source/f/funcsigs/funcsigs-0.4.tar.gz"
+    url      = "https://pypi.io/packages/source/f/funcsigs/funcsigs-1.0.2.tar.gz"
 
-    version('0.4', 'fb1d031f284233e09701f6db1281c2a5')
+    import_modules = ['funcsigs']
 
-    depends_on('py-setuptools', type='build')
+    version('1.0.2', '7e583285b1fb8a76305d6d68f4ccc14e')
+    version('0.4',   'fb1d031f284233e09701f6db1281c2a5')
+
+    depends_on('py-setuptools@17.1:', type='build')
+    depends_on('py-unittest2', type='test')

--- a/var/spack/repos/builtin/packages/py-more-itertools/package.py
+++ b/var/spack/repos/builtin/packages/py-more-itertools/package.py
@@ -29,10 +29,13 @@ class PyMoreItertools(PythonPackage):
     """Additions to the standard Python itertools package."""
 
     homepage = "https://github.com/erikrose/more-itertools"
-    url      = "https://pypi.io/packages/source/m/more-itertools/more-itertools-4.1.0.tar.gz"
+    url      = "https://pypi.io/packages/source/m/more-itertools/more-itertools-4.3.0.tar.gz"
 
+    import_modules = ['more_itertools', 'more_itertools.tests']
+
+    version('4.3.0', '42157ef9b677bdf6d3609ed6eadcbd4a')
     version('4.1.0', '246f46686d95879fbad37855c115dc52')
-    version('2.2', 'b8d328a33f966bf40bb829bcf8da35ce')
+    version('2.2',   'b8d328a33f966bf40bb829bcf8da35ce')
 
     depends_on('py-setuptools', type='build')
     depends_on('py-six@1.0.0:1.999', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -181,5 +181,5 @@ class PyNumpy(PythonPackage):
         # ImportError: Error importing numpy: you should not try to import
         #       numpy from its source directory; please exit the numpy
         #       source tree, and relaunch your python interpreter from there.
-        with working_dir('..'):
+        with working_dir('spack-test', create=True):
             python('-c', 'import numpy; numpy.test("full", verbose=2)')

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -34,7 +34,7 @@ class PyNumpy(PythonPackage):
     number capabilities"""
 
     homepage = "http://www.numpy.org/"
-    url      = "https://pypi.io/packages/source/n/numpy/numpy-1.13.1.zip"
+    url      = "https://pypi.io/packages/source/n/numpy/numpy-1.15.1.zip"
 
     install_time_test_callbacks = ['install_test', 'import_module_test']
 
@@ -45,9 +45,7 @@ class PyNumpy(PythonPackage):
         'numpy.distutils.command', 'numpy.distutils.fcompiler'
     ]
 
-    # FIXME: numpy._build_utils and numpy.core.code_generators failed to import
-    # FIXME: Is this expected?
-
+    version('1.15.1', '898004d5be091fde59ae353e3008fe9b')
     version('1.14.3', '97416212c0a172db4bc6b905e9c4634b')
     version('1.14.2', '080f01a19707cf467393e426382c7619')
     version('1.14.1', 'b8324ef90ac9064cd0eac46b8b388674')
@@ -67,12 +65,13 @@ class PyNumpy(PythonPackage):
     variant('blas',   default=True, description='Build with BLAS support')
     variant('lapack', default=True, description='Build with LAPACK support')
 
-    depends_on('python@2.7:2.8,3.4:')
+    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
     depends_on('blas',   when='+blas')
     depends_on('lapack', when='+lapack')
 
-    depends_on('py-nose@1.0.0:', type='test')
+    depends_on('py-nose@1.0.0:', when='@:1.14', type='test')
+    depends_on('py-pytest', when='@1.15:', type='test')
 
     def setup_dependent_package(self, module, dependent_spec):
         python_version = self.spec['python'].version.up_to(2)

--- a/var/spack/repos/builtin/packages/py-pathlib2/package.py
+++ b/var/spack/repos/builtin/packages/py-pathlib2/package.py
@@ -29,9 +29,13 @@ class PyPathlib2(PythonPackage):
     """Backport of pathlib from python 3.4"""
 
     homepage = "https://pypi.python.org/pypi/pathlib2"
-    url      = "https://pypi.io/packages/source/p/pathlib2/pathlib2-2.1.0.tar.gz"
+    url      = "https://pypi.io/packages/source/p/pathlib2/pathlib2-2.3.2.tar.gz"
 
+    import_modules = ['pathlib2']
+
+    version('2.3.2', 'fd76fb5d0baa798bfe12fb7965da97f8')
     version('2.1.0', '38e4f58b4d69dfcb9edb49a54a8b28d2')
 
     depends_on('py-setuptools', type='build')
-    depends_on('python@:3.3')
+    depends_on('py-six', type=('build', 'run'))
+    depends_on('py-scandir', when='^python@:3.4', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-pluggy/package.py
+++ b/var/spack/repos/builtin/packages/py-pluggy/package.py
@@ -29,12 +29,14 @@ class PyPluggy(PythonPackage):
     """Plugin and hook calling mechanisms for python."""
 
     homepage = "https://github.com/pytest-dev/pluggy"
-    url      = "https://pypi.io/packages/source/p/pluggy/pluggy-0.6.0.tar.gz"
+    url      = "https://pypi.io/packages/source/p/pluggy/pluggy-0.7.1.tar.gz"
 
     import_modules = ['pluggy']
 
+    version('0.7.1', 'cd5cc1003143f86dd6e2a865a20f8837')
     version('0.6.0', 'ffdde7c3a5ba9a440404570366ffb6d5')
 
     depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
 
     depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools-scm', type='build')

--- a/var/spack/repos/builtin/packages/py-py/package.py
+++ b/var/spack/repos/builtin/packages/py-py/package.py
@@ -29,12 +29,14 @@ class PyPy(PythonPackage):
     """Library with cross-python path, ini-parsing, io, code, log facilities"""
 
     homepage = "http://pylib.readthedocs.io/en/latest/"
-    url      = "https://pypi.io/packages/source/p/py/py-1.5.3.tar.gz"
+    url      = "https://pypi.io/packages/source/p/py/py-1.5.4.tar.gz"
 
     import_modules = [
-        'py', 'py._code', 'py._io', 'py._log', 'py._path', 'py._process',
+        'py', 'py._process', 'py._vendored_packages', 'py._path',
+        'py._log', 'py._code', 'py._io'
     ]
 
+    version('1.5.4',  '7502d66fa68ea4ae5b61c511cd177d6a')
     version('1.5.3',  '667d37a148ad9fb81266492903f2d880')
     version('1.4.33', '15d7107cbb8b86593bf9afa16e56da65')
     version('1.4.31', '5d2c63c56dc3f2115ec35c066ecd582b')
@@ -42,3 +44,8 @@ class PyPy(PythonPackage):
     depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
 
     depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools-scm', type='build')
+
+    def test(self):
+        # Tests require pytest, creating a circular dependency
+        pass

--- a/var/spack/repos/builtin/packages/py-pytest/package.py
+++ b/var/spack/repos/builtin/packages/py-pytest/package.py
@@ -29,13 +29,14 @@ class PyPytest(PythonPackage):
     """pytest: simple powerful testing with Python."""
 
     homepage = "http://pytest.org/"
-    url      = "https://pypi.io/packages/source/p/pytest/pytest-3.7.1.tar.gz"
+    url      = "https://pypi.io/packages/source/p/pytest/pytest-3.7.2.tar.gz"
 
     import_modules = [
         '_pytest', '_pytest.assertion', '_pytest._code',
         '_pytest.mark', 'pytest'
     ]
 
+    version('3.7.2', 'd12d0d556a21fd8633e105f1a8d5a0f9')
     version('3.7.1', '2704e16bb2c11af494167f80a7cd37c4')
     version('3.5.1', 'ffd870ee3ca561695d2f916f0f0f3c0b')
     version('3.0.7', '89c60546507dc7eb6e9e40a6e9f720bd')
@@ -51,9 +52,8 @@ class PyPytest(PythonPackage):
     depends_on('py-six@1.10.0:', type=('build', 'run'))
     depends_on('py-attrs@17.4.0:', type=('build', 'run'))
     depends_on('py-more-itertools@4.0.0:', type=('build', 'run'))
-    depends_on('py-pluggy@0.5:0.6', type=('build', 'run'))
-    depends_on('py-funcsigs', type=('build', 'run'), when='^python@:2')
-
-    depends_on('py-nose', type='test')
-    depends_on('py-mock', type='test')
-    depends_on('py-requests', type='test')
+    depends_on('py-atomicwrites@1.0:', type=('build', 'run'))
+    depends_on('py-pluggy@0.7:', when='@3.7:', type=('build', 'run'))
+    depends_on('py-pluggy@0.5:0.6', when='@:3.6', type=('build', 'run'))
+    depends_on('py-funcsigs', when='^python@:2', type=('build', 'run'))
+    depends_on('py-pathlib2@2.2.0:', when='^python@:3.5', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -97,5 +97,5 @@ class PyScipy(PythonPackage):
         # ImportError: Error importing scipy: you should not try to import
         #       scipy from its source directory; please exit the scipy
         #       source tree, and relaunch your python interpreter from there.
-        with working_dir('..'):
+        with working_dir('spack-test', create=True):
             python('-c', 'import scipy; scipy.test("full", verbose=2)')

--- a/var/spack/repos/builtin/packages/py-setuptools-scm/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools-scm/package.py
@@ -26,11 +26,15 @@ from spack import *
 
 
 class PySetuptoolsScm(PythonPackage):
-    """the blessed package to manage your versions by scm tags"""
+    """The blessed package to manage your versions by scm tags."""
 
     homepage = "https://github.com/pypa/setuptools_scm"
-    url      = "https://pypi.io/packages/source/s/setuptools_scm/setuptools_scm-1.15.6.tar.gz"
+    url      = "https://pypi.io/packages/source/s/setuptools_scm/setuptools_scm-3.1.0.tar.gz"
 
+    import_modules = ['setuptools_scm']
+
+    version('3.1.0',  '52a8dee23c9e5f7d7d18094563db516c')
     version('1.15.6', 'f17493d53f0d842bb0152f214775640b')
 
     depends_on('py-setuptools', type='build')
+    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -29,11 +29,18 @@ class PySetuptools(PythonPackage):
     """A Python utility that aids in the process of downloading, building,
        upgrading, installing, and uninstalling Python packages."""
 
-    homepage = "https://pypi.python.org/pypi/setuptools"
-    url      = "https://pypi.io/packages/source/s/setuptools/setuptools-39.0.1.zip"
+    homepage = "https://github.com/pypa/setuptools"
+    url      = "https://pypi.io/packages/source/s/setuptools/setuptools-40.2.0.zip"
 
-    import_modules = ['pkg_resources', 'setuptools', 'setuptools.command']
+    import_modules = [
+        'setuptools', 'pkg_resources', 'setuptools._vendor',
+        'setuptools.command', 'setuptools.extern',
+        'setuptools._vendor.packaging', 'pkg_resources._vendor',
+        'pkg_resources.extern', 'pkg_resources._vendor.packaging',
+        'easy_install'
+    ]
 
+    version('40.2.0', '592efabea3a65d8e97a025ed52f69b12')
     version('39.2.0', 'dd4e3fa83a21bf7bf9c51026dc8a4e59')
     version('39.0.1', '75310b72ca0ab4e673bf7679f69d7a62')
     version('35.0.2', 'c368b4970d3ad3eab5afe4ef4dbe2437')
@@ -48,7 +55,7 @@ class PySetuptools(PythonPackage):
     version('16.0',   '0ace0b96233516fc5f7c857d086aa3ad')
     version('11.3.1', '01f69212e019a2420c1693fb43593930')
 
-    depends_on('python@2.6:2.8,3.3:')
+    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
 
     # Previously, setuptools vendored all of its dependencies to allow
     # easy bootstrapping. As of version 34.0.0, this is no longer done
@@ -70,3 +77,7 @@ class PySetuptools(PythonPackage):
             url += '.tar.gz'
 
         return url
+
+    def test(self):
+        # Unit tests require pytest, creating a circular dependency
+        pass


### PR DESCRIPTION
Fixes #9037.

However, this also uncovers another bug. When I try to build the latest version of numpy, all of the tests pass, but right before the installation finishes, I see the following error message:
```
==> Error: FileNotFoundError: [Errno 2] No such file or directory: '/Users/Adam/spack/var/spack/stage/py-numpy-1.15.1-axflucalynpnnr5camla655764dpyvqz/.pytest_cache/spack-build.out'

/Users/Adam/spack/lib/spack/spack/package.py:1652, in log:
       1649            # FIXME : this potentially catches too many things...
       1650            pass
       1651
  >>   1652        # Archive the whole stdout + stderr for the package
       1653        install(self.log_path, log_install_path)
       1654        # Archive the environment used for the build
       1655        install(self.env_path, env_install_path)
```
The correct `spack-build.out` is in `numpy-1.15.1`, not `.pytest_cache`. Does anyone have any idea why the `log_path` is being overwritten? This doesn't happen if I install without `--test=root`.

P.S. I could've sworn I fixed the error message off-by-one line number bug.