### PR TITLE
improve spack load error

### DIFF
--- a/lib/spack/spack/cmd/modules/__init__.py
+++ b/lib/spack/spack/cmd/modules/__init__.py
@@ -336,7 +336,7 @@ def modules_cmd(parser, args, module_type, callbacks=callbacks):
     except MultipleSpecsMatch:
         msg = "the constraint '{query}' matches multiple packages:\n"
         for s in specs:
-            msg += '\t' + s.cformat() + '\n'
+            msg += '\t' + s.cformat(format_string='$/ $_$@$+$%@+$+$=') + '\n'
         tty.error(msg.format(query=args.constraint))
         tty.die('In this context exactly **one** match is needed: please specify your constraints better.')  # NOQA: ignore=E501
 


### PR DESCRIPTION
addresses #9077 (at least it improves the situation)

* now additionally prints hash and options
 