### PR TITLE
Add package for the C++ Guideline Support Library

### DIFF
--- a/var/spack/repos/builtin/packages/cppgsl/package.py
+++ b/var/spack/repos/builtin/packages/cppgsl/package.py
@@ -36,11 +36,16 @@ class Cppgsl(CMakePackage):
     version('2.0.0', sha256='6cce6fb16b651e62711a4f58e484931013c33979b795d1b1f7646f640cfa9c8e')
     version('1.0.0', sha256='9694b04cd78e5b1a769868f19fdd9eea2002de3d4c3a81a1b769209364543c36')
 
+    variant('cxxstd',
+            default='14',
+            values=('14', '17'),
+            multi=False,
+            description='Use the specified C++ standard when building.')
+
     depends_on('cmake@3.1.3:', type='build')
 
     def cmake_args(self):
-        # FIXME: Add arguments other than
-        # FIXME: CMAKE_INSTALL_PREFIX and CMAKE_BUILD_TYPE
-        # FIXME: If not needed delete this function
-        args = []
+        args = [
+            '-DGSL_CXX_STANDARD={0}'.format(self.spec.variants['cxxstd'].value)
+        ]
         return args

--- a/var/spack/repos/builtin/packages/cppgsl/package.py
+++ b/var/spack/repos/builtin/packages/cppgsl/package.py
@@ -1,0 +1,46 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Cppgsl(CMakePackage):
+    """C++ Guideline Support Library"""
+
+    homepage = "https://github.com/Microsoft/GSL"
+    url      = "https://github.com/Microsoft/GSL/archive/v2.0.0.tar.gz"
+    git      = "https://github.com/Microsoft/GSL.git"
+
+    version('develop', branch='master')
+    version('2.0.0', sha256='6cce6fb16b651e62711a4f58e484931013c33979b795d1b1f7646f640cfa9c8e')
+    version('1.0.0', sha256='9694b04cd78e5b1a769868f19fdd9eea2002de3d4c3a81a1b769209364543c36')
+
+    depends_on('cmake@3.1.3:', type='build')
+
+    def cmake_args(self):
+        # FIXME: Add arguments other than
+        # FIXME: CMAKE_INSTALL_PREFIX and CMAKE_BUILD_TYPE
+        # FIXME: If not needed delete this function
+        args = []
+        return args


### PR DESCRIPTION
The [GSL](https://github.com/Microsoft/GSL) is meant to help C++ projects at the task of following the [C++ Core Guidelines](https://github.com/isocpp/CppCoreGuidelines). Since "GSL" is a highly overloaded acronym, I decided to name the package "cppgsl".