### PR TITLE
Hotfix of atk regarding #9099

### DIFF
--- a/var/spack/repos/builtin/packages/atk/package.py
+++ b/var/spack/repos/builtin/packages/atk/package.py
@@ -41,7 +41,9 @@ class Atk(Package):
 
     depends_on('meson', type='build', when='@2.28.0:')
     depends_on('glib')
-    # FIXME: python3-dependency should only apply to 2.28.1 #9099
+    # FIXME: this constraint exists because of the meson dependency.
+    # It should not be required to specify it here, but "spack spec atk" will fail without it.
+    # See: #2632
     depends_on('python@3:')
     depends_on('gettext')
     depends_on('pkgconfig', type='build')

--- a/var/spack/repos/builtin/packages/atk/package.py
+++ b/var/spack/repos/builtin/packages/atk/package.py
@@ -41,8 +41,9 @@ class Atk(Package):
 
     depends_on('meson', type='build', when='@2.28.0:')
     depends_on('glib')
-    #FIXME: python3-dependency should only apply to 2.28.1 #9099
+    # FIXME: python3-dependency should only apply to 2.28.1 #9099
     depends_on('python@3:')
+    depends_on('gettext')
     depends_on('pkgconfig', type='build')
     depends_on('gobject-introspection')
 

--- a/var/spack/repos/builtin/packages/atk/package.py
+++ b/var/spack/repos/builtin/packages/atk/package.py
@@ -42,7 +42,8 @@ class Atk(Package):
     depends_on('meson', type='build', when='@2.28.0:')
     depends_on('glib')
     # FIXME: this constraint exists because of the meson dependency.
-    # It should not be required to specify it here, but "spack spec atk" will fail without it.
+    # It should not be required to specify it here, but "spack spec atk" will
+    # fail without it.
     # See: #2632
     depends_on('python@3:')
     depends_on('gettext')

--- a/var/spack/repos/builtin/packages/atk/package.py
+++ b/var/spack/repos/builtin/packages/atk/package.py
@@ -41,6 +41,8 @@ class Atk(Package):
 
     depends_on('meson', type='build', when='@2.28.0:')
     depends_on('glib')
+    #FIXME: python3-dependency should only apply to 2.28.1 #9099
+    depends_on('python@3:')
     depends_on('pkgconfig', type='build')
     depends_on('gobject-introspection')
 


### PR DESCRIPTION
Currently atk does not build because meson requires python3 and glib python2 by default (fixes #9099). Setting python3 as dependency for atk works as a hot-fix as a start.