### PR TITLE
Fix missing dependencies and glibc build failures

### DIFF
--- a/var/spack/repos/builtin/packages/bison/package.py
+++ b/var/spack/repos/builtin/packages/bison/package.py
@@ -39,7 +39,10 @@ class Bison(AutotoolsPackage):
     version('3.0.4', 'a586e11cd4aff49c3ff6d3b6a4c9ccf8')
     version('2.7',   'ded660799e76fb1667d594de1f7a0da9')
 
+    # depends_on('diffutils', type='build')
     depends_on('m4', type=('build', 'run'))
+    depends_on('perl', type='build')
+    depends_on('help2man', type='build')
 
     patch('pgi.patch', when='@3.0.4')
 

--- a/var/spack/repos/builtin/packages/bzip2/package.py
+++ b/var/spack/repos/builtin/packages/bzip2/package.py
@@ -42,6 +42,8 @@ class Bzip2(Package):
 
     variant('shared', default=True, description='Enables the build of shared libraries.')
 
+    depends_on('diffutils', type='build')
+
     # override default implementation
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/diffutils/package.py
+++ b/var/spack/repos/builtin/packages/diffutils/package.py
@@ -23,30 +23,15 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from spack.operating_systems.mac_os import macos_version
-import sys
 
 
-class Bison(AutotoolsPackage):
-    """Bison is a general-purpose parser generator that converts
-    an annotated context-free grammar into a deterministic LR or
-    generalized LR (GLR) parser employing LALR(1) parser tables."""
+class Diffutils(AutotoolsPackage):
+    """GNU Diffutils is a package of several programs related to finding
+    differences between files."""
 
-    homepage = "http://www.gnu.org/software/bison/"
-    url      = "https://ftpmirror.gnu.org/bison/bison-3.0.4.tar.gz"
+    homepage = "https://www.gnu.org/software/diffutils/"
+    url      = "https://ftp.gnu.org/gnu/diffutils/diffutils-3.6.tar.xz"
 
-    version('3.0.5', '41ad57813157b61bfa47e33067a9d6f0')
-    version('3.0.4', 'a586e11cd4aff49c3ff6d3b6a4c9ccf8')
-    version('2.7',   'ded660799e76fb1667d594de1f7a0da9')
-
-    depends_on('diffutils', type='build')
-    depends_on('m4', type=('build', 'run'))
-    depends_on('perl', type='build')
-    depends_on('help2man', type='build')
-
-    patch('pgi.patch', when='@3.0.4')
-
-    if sys.platform == 'darwin' and macos_version() >= Version('10.13'):
-        patch('secure_snprintf.patch', level=0, when='@3.0.4')
+    version('3.6', sha256='d621e8bdd4b573918c8145f7ae61817d1be9deb4c8d2328a65cea8e11d783bd6')
 
     build_directory = 'spack-build'

--- a/var/spack/repos/builtin/packages/findutils/package.py
+++ b/var/spack/repos/builtin/packages/findutils/package.py
@@ -51,3 +51,32 @@ class Findutils(AutotoolsPackage):
     version('4.2.15', 'a881b15aa7170aea045bf35cc92d48e7')
     version('4.1.20', 'e90ce7222daadeb8616b8db461e17cbc')
     version('4.1',    '3ea8fe58ef5386da75f6c707713aa059')
+
+    depends_on('autoconf', type='build', when='@4.6.0')
+    depends_on('automake', type='build', when='@4.6.0')
+    depends_on('libtool', type='build', when='@4.6.0')
+    depends_on('m4', type='build', when='@4.6.0')
+    depends_on('texinfo', type='build', when='@4.6.0')
+
+    # findutils does not build with newer versions of glibc
+    patch('https://src.fedoraproject.org/rpms/findutils/raw/97ba2d7a18d1f9ae761b6ff0b4f1c4d33d7a8efc/f/findutils-4.6.0-gnulib-fflush.patch', sha256='84b916c0bf8c51b7e7b28417692f0ad3e7030d1f3c248ba77c42ede5c1c5d11e', when='@4.6.0')
+    patch('https://src.fedoraproject.org/rpms/findutils/raw/97ba2d7a18d1f9ae761b6ff0b4f1c4d33d7a8efc/f/findutils-4.6.0-gnulib-makedev.patch', sha256='bd9e4e5cc280f9753ae14956c4e4aa17fe7a210f55dd6c84aa60b12d106d47a2', when='@4.6.0')
+
+    build_directory = 'spack-build'
+
+    @property
+    def force_autoreconf(self):
+        # Run autoreconf due to build system patch (gnulib-makedev)
+        return self.spec.satisfies('@4.6.0')
+
+    @when('@4.6.0')
+    def patch(self):
+        # We have to patch out gettext support, otherwise autoreconf tries to
+        # call autopoint, which depends on find, which is part of findutils.
+        filter_file('^AM_GNU_GETTEXT.*',
+                    '',
+                    'configure.ac')
+
+        filter_file(r'^SUBDIRS = (.*) po (.*)',
+                    r'SUBDIRS = \1 \2',
+                    'Makefile.am')

--- a/var/spack/repos/builtin/packages/help2man/package.py
+++ b/var/spack/repos/builtin/packages/help2man/package.py
@@ -35,3 +35,4 @@ class Help2man(AutotoolsPackage):
     version('1.47.4', '544aca496a7d89de3e5d99e56a2f03d3')
 
     depends_on('gettext', type='build')
+    depends_on('perl', type='build')

--- a/var/spack/repos/builtin/packages/m4/package.py
+++ b/var/spack/repos/builtin/packages/m4/package.py
@@ -39,6 +39,8 @@ class M4(AutotoolsPackage):
     # from: https://github.com/Homebrew/homebrew-core/blob/master/Formula/m4.rb
     # Patch credit to Jeremy Huddleston Sequoia <jeremyhu@apple.com>
     patch('secure_snprintf.patch', when='platform_os = highsierra')
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1573342
+    patch('https://src.fedoraproject.org/rpms/m4/raw/5d147168d4b93f38a4833f5dd1d650ad88af5a8a/f/m4-1.4.18-glibc-change-work-around.patch', sha256='fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8', when='@1.4.18')
 
     variant('sigsegv', default=True,
             description="Build the libsigsegv dependency")

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -82,6 +82,8 @@ spack package at this time.''',
     # and https://lists.mpich.org/pipermail/discuss/2016-June/004768.html
     patch('mpich32_clang.patch', when='@3.2:3.2.0%clang')
 
+    depends_on('findutils', type='build')
+
     depends_on('libfabric', when='netmod=ofi')
 
     conflicts('device=ch4', when='@:3.2')

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -117,6 +117,7 @@ class Mvapich2(AutotoolsPackage):
         multi=True
     )
 
+    depends_on('findutils', type='build')
     depends_on('bison', type='build')
     depends_on('libpciaccess', when=(sys.platform != 'darwin'))
     depends_on('cuda', when='+cuda')

--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -68,7 +68,7 @@ class Openssl(Package):
 
     depends_on('zlib')
 
-    depends_on('perl@5.14.0:', type='test')
+    depends_on('perl@5.14.0:', type=('build', 'test'))
 
     parallel = False
 

--- a/var/spack/repos/builtin/packages/texinfo/package.py
+++ b/var/spack/repos/builtin/packages/texinfo/package.py
@@ -42,3 +42,5 @@ class Texinfo(AutotoolsPackage):
     version('5.2', '1b8f98b80a8e6c50422125e07522e8db')
     version('5.1', '54e250014fe698fb4832016158747c03')
     version('5.0', '918432285abe6fe96c98355594c5656a')
+
+    depends_on('perl')


### PR DESCRIPTION
I just started building my default set of packages in a minimal Fedora 29 container and a few packages failed due to missing dependencies or glibc problems.

I have split up the changes into multiple commits to make them easy to revert if necessary.