### PR TITLE
Reorder environment cleaning and module loads

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -669,6 +669,8 @@ def setup_package(pkg, dirty):
     # of Spack, can change environment variables that are relevant to the
     # build of packages. To avoid a polluted environment, preserve the
     # value of a few, selected, environment variables
+    # With the current ordering of environment modifications, this is strictly
+    # unnecessary. Modules affecting these variables will be overwritten anyway
     with preserve_environment('CC', 'CXX', 'FC', 'F77'):
         # All module loads that otherwise would belong in previous
         # functions have to occur after the spack_env object has its

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -160,7 +160,7 @@ def clean_environment():
     env.unset('CPATH')
     env.unset('LD_RUN_PATH')
     env.unset('DYLD_LIBRARY_PATH')
-    
+
     # Remove any macports installs from the PATH.  The macports ld can
     # cause conflicts with the built-in linker on el capitan.  Solves
     # assembler issues, e.g.:
@@ -171,6 +171,7 @@ def clean_environment():
             env.remove_path('PATH', p)
 
     env.apply_modifications()
+
 
 def set_compiler_environment_variables(pkg, env):
     assert pkg.spec.concrete

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -146,6 +146,32 @@ class MakeExecutable(Executable):
         return super(MakeExecutable, self).__call__(*args, **kwargs)
 
 
+def clean_environment():
+    # Stuff in here sanitizes the build environment to eliminate
+    # anything the user has set that may interfere. We apply it immediately
+    # unlike the other functions so it doesn't overwrite what the modules load.
+    env = EnvironmentModifications()
+
+    # Remove these vars from the environment during build because they
+    # can affect how some packages find libraries.  We want to make
+    # sure that builds never pull in unintended external dependencies.
+    env.unset('LD_LIBRARY_PATH')
+    env.unset('LIBRARY_PATH')
+    env.unset('CPATH')
+    env.unset('LD_RUN_PATH')
+    env.unset('DYLD_LIBRARY_PATH')
+    
+    # Remove any macports installs from the PATH.  The macports ld can
+    # cause conflicts with the built-in linker on el capitan.  Solves
+    # assembler issues, e.g.:
+    #    suffix or operands invalid for `movq'"
+    path = get_path('PATH')
+    for p in path:
+        if '/macports/' in p:
+            env.remove_path('PATH', p)
+
+    env.apply_modifications()
+
 def set_compiler_environment_variables(pkg, env):
     assert pkg.spec.concrete
     compiler = pkg.compiler
@@ -277,27 +303,6 @@ def set_build_environment_variables(pkg, env, dirty):
 
     # Install root prefix
     env.set(SPACK_INSTALL, spack.store.root)
-
-    # Stuff in here sanitizes the build environment to eliminate
-    # anything the user has set that may interfere.
-    if not dirty:
-        # Remove these vars from the environment during build because they
-        # can affect how some packages find libraries.  We want to make
-        # sure that builds never pull in unintended external dependencies.
-        env.unset('LD_LIBRARY_PATH')
-        env.unset('LIBRARY_PATH')
-        env.unset('CPATH')
-        env.unset('LD_RUN_PATH')
-        env.unset('DYLD_LIBRARY_PATH')
-
-        # Remove any macports installs from the PATH.  The macports ld can
-        # cause conflicts with the built-in linker on el capitan.  Solves
-        # assembler issues, e.g.:
-        #    suffix or operands invalid for `movq'"
-        path = get_path('PATH')
-        for p in path:
-            if '/macports/' in p:
-                env.remove_path('PATH', p)
 
     # Set environment variables if specified for
     # the given compiler
@@ -629,6 +634,30 @@ def setup_package(pkg, dirty):
     spack_env = EnvironmentModifications()
     run_env = EnvironmentModifications()
 
+    if dirty:
+        clean_environment()
+
+    # Loading modules, in particular if they are meant to be used outside
+    # of Spack, can change environment variables that are relevant to the
+    # build of packages. To avoid a polluted environment, preserve the
+    # value of a few, selected, environment variables
+    with preserve_environment('CC', 'CXX', 'FC', 'F77'):
+        # All module loads that otherwise would belong in previous
+        # functions have to occur after the spack_env object has its
+        # modifications applied. Otherwise the environment modifications
+        # could undo module changes, such as unsetting LD_LIBRARY_PATH
+        # after a module changes it.
+        for mod in pkg.compiler.modules:
+            # Fixes issue https://github.com/spack/spack/issues/3153
+            if os.environ.get("CRAY_CPU_TARGET") == "mic-knl":
+                load_module("cce")
+            load_module(mod)
+
+        if pkg.architecture.target.module_name:
+            load_module(pkg.architecture.target.module_name)
+
+        load_external_modules(pkg)
+
     set_compiler_environment_variables(pkg, spack_env)
     set_build_environment_variables(pkg, spack_env, dirty)
     pkg.architecture.platform.setup_platform_environment(pkg, spack_env)
@@ -659,27 +688,6 @@ def setup_package(pkg, dirty):
     # Make sure nothing's strange about the Spack environment.
     validate(spack_env, tty.warn)
     spack_env.apply_modifications()
-
-    # Loading modules, in particular if they are meant to be used outside
-    # of Spack, can change environment variables that are relevant to the
-    # build of packages. To avoid a polluted environment, preserve the
-    # value of a few, selected, environment variables
-    with preserve_environment('CC', 'CXX', 'FC', 'F77'):
-        # All module loads that otherwise would belong in previous
-        # functions have to occur after the spack_env object has its
-        # modifications applied. Otherwise the environment modifications
-        # could undo module changes, such as unsetting LD_LIBRARY_PATH
-        # after a module changes it.
-        for mod in pkg.compiler.modules:
-            # Fixes issue https://github.com/spack/spack/issues/3153
-            if os.environ.get("CRAY_CPU_TARGET") == "mic-knl":
-                load_module("cce")
-            load_module(mod)
-
-        if pkg.architecture.target.module_name:
-            load_module(pkg.architecture.target.module_name)
-
-        load_external_modules(pkg)
 
 
 def fork(pkg, function, dirty, fake):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1478,7 +1478,7 @@ class Spec(object):
         if self.external:
             d['external'] = {
                 'path': self.external_path,
-                'module': bool(self.external_module)
+                'module': self.external_module
             }
 
         # TODO: restore build dependencies here once we have less picky
@@ -1916,7 +1916,7 @@ class Spec(object):
                     dedupe(p + patches))
 
         for s in self.traverse():
-            if s.external_module:
+            if s.external_module and not s.external_path:
                 compiler = spack.compilers.compiler_for_spec(
                     s.compiler, s.architecture)
                 for mod in compiler.modules:

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -233,5 +233,4 @@ def test_spack_paths_before_module_paths(config, mock_packages, monkeypatch):
     spack_path = os.path.join(spack.paths.prefix, 'lib/spack/env')
     paths = os.environ['PATH'].split(':')
 
-    assert paths[0] == spack_path
-    assert module_path in paths
+    assert paths.index(spack_path) < paths.index(module_path)

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -131,7 +131,6 @@ def test_cc_not_changed_by_modules(monkeypatch):
 
 @pytest.mark.usefixtures('config', 'mock_packages')
 def test_compiler_config_modifications(monkeypatch):
-
     s = spack.spec.Spec('cmake')
     s.concretize()
     pkg = s.package
@@ -209,3 +208,30 @@ def test_compiler_config_modifications(monkeypatch):
     os.environ.pop('PATH_LIST', None)
     os.environ.pop('EMPTY_PATH_LIST', None)
     os.environ.pop('NEW_PATH_LIST', None)
+
+
+@pytest.mark.regression('9107')
+def test_spack_paths_before_module_paths(config, mock_packages, monkeypatch):
+    s = spack.spec.Spec('cmake')
+    s.concretize()
+    pkg = s.package
+
+    module_path = '/path/to/module'
+
+    def _set_wrong_cc(x):
+        os.environ['PATH'] = module_path + ':' + os.environ['PATH']
+
+    monkeypatch.setattr(
+        spack.build_environment, 'load_module', _set_wrong_cc
+    )
+    monkeypatch.setattr(
+        pkg.compiler, 'modules', ['some_module']
+    )
+
+    spack.build_environment.setup_package(pkg, False)
+
+    spack_path = os.path.join(spack.paths.prefix, 'lib/spack/env')
+    paths = os.environ['PATH'].split(':')
+
+    assert paths[0] == spack_path
+    assert module_path in paths


### PR DESCRIPTION
Fixes #9084 
Fixes #8632 

Fixes a bug that appeared on some Cray systems:
modules that prepended to the `PATH` variable were putting their paths ahead of the spack compiler wrappers. For compiler modules, this was a major problem.

This PR separates the environment sanitation from the environment changes, and moves the module loading operations to between the environment sanitation and the environment changes.