### PR TITLE
openblas: add @0.3.1, patch CMake export bug in @0.3.1:0.3.2

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/openblas-0.3.2-cmake.patch
+++ b/var/spack/repos/builtin/packages/openblas/openblas-0.3.2-cmake.patch
@@ -1,0 +1,43 @@
+From 8ebf541e97e7c0573cde6a51353a47e3c509ca00 Mon Sep 17 00:00:00 2001
+From: Scott Thornton <wsttiger@gmail.com>
+Date: Mon, 30 Jul 2018 15:18:29 -0500
+Subject: [PATCH 1/2] Set EXPORT_NAME to match OpenBLASConfig.cmake
+
+---
+ CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 97f8adeda..4dc18da99 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -169,6 +169,7 @@ endif()
+ # Set output for libopenblas
+ set_target_properties( ${OpenBLAS_LIBNAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
+ set_target_properties( ${OpenBLAS_LIBNAME} PROPERTIES LIBRARY_OUTPUT_NAME_DEBUG "${OpenBLAS_LIBNAME}_d")
++set_target_properties( ${OpenBLAS_LIBNAME} PROPERTIES EXPORT_NAME "OpenBLAS")
+ 
+ foreach (OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES})
+   string( TOUPPER ${OUTPUTCONFIG} OUTPUTCONFIG )
+
+From 2a9a9389ef6c3da56fda859c9586becc41a2e780 Mon Sep 17 00:00:00 2001
+From: Scott Thornton <wsttiger@gmail.com>
+Date: Thu, 2 Aug 2018 14:58:52 -0500
+Subject: [PATCH 2/2] Added target_include_directories()
+
+---
+ CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4dc18da99..20ce02e87 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -150,6 +150,7 @@ endif()
+ 
+ # add objects to the openblas lib
+ add_library(${OpenBLAS_LIBNAME} ${LA_SOURCES} ${LAPACKE_SOURCES} ${RELA_SOURCES} ${TARGET_OBJS} ${OpenBLAS_DEF_FILE})
++target_include_directories(${OpenBLAS_LIBNAME} INTERFACE $<INSTALL_INTERFACE:include>)
+ 
+ # Android needs to explicitly link against libm
+ if(ANDROID)

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -92,6 +92,10 @@ class Openblas(MakefilePackage):
     # https://github.com/xianyi/OpenBLAS/pull/982
     patch('openblas0.2.19.diff', when='@0.2.19')
 
+    # Fix CMake export symbol error
+    # https://github.com/xianyi/OpenBLAS/pull/1703
+    patch('openblas-0.3.2-cmake.patch', when='@0.3.1:0.3.2')
+
     parallel = False
 
     conflicts('%intel@16', when='@0.2.15:0.2.19')

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -38,6 +38,7 @@ class Openblas(MakefilePackage):
 
     version('develop', branch='develop')
     version('0.3.2', sha256='e8ba64f6b103c511ae13736100347deb7121ba9b41ba82052b1a018a65c0cb15')
+    version('0.3.1', sha256='1f5e956f35f3acdd3c74516e955d797a320c2e0135e31d838cbdb3ea94d0eb33')
     version('0.3.0',  '42cde2c1059a8a12227f1e6551c8dbd2')
     version('0.2.20', '48637eb29f5b492b91459175dcc574b1')
     version('0.2.19', '28c998054fd377279741c6f0b9ea7941')


### PR DESCRIPTION
* Adds OpenBLAS version 0.3.1
* Adds a patch for OpenBLAS versions 0.3.1 and 0.3.2 that fixes `find_package(OpenBLAS)` in CMake. See https://github.com/xianyi/OpenBLAS/pull/1703 for the patch. The patch has already landed upstream and will be released with OpenBLAS 0.3.3.