### PR TITLE
binutils: add variant 'nls' for native language support

### DIFF
--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -55,8 +55,8 @@ class Binutils(AutotoolsPackage):
 
     # Prior to 2.30, gold did not distribute the generated files and
     # thus needs bison, even for a one-time build.
-    depends_on('m4', type='build', when='+gold')
-    depends_on('bison', type='build', when='+gold')
+    depends_on('m4', type='build', when='@:2.29.99 +gold')
+    depends_on('bison', type='build', when='@:2.29.99 +gold')
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -45,29 +45,30 @@ class Binutils(AutotoolsPackage):
             description="enable plugins, needed for gold linker")
     variant('gold', default=True, description="build the gold linker")
     variant('libiberty', default=False, description='Also install libiberty.')
+    variant('nls', default=True, description='Enable Native Language Support')
 
     patch('cr16.patch', when='@:2.29.1')
     patch('update_symbol-2.26.patch', when='@2.26')
 
     depends_on('zlib')
+    depends_on('gettext', when='+nls')
 
-    depends_on('m4', type='build')
-    depends_on('flex', type='build')
-    depends_on('bison', type='build')
-    depends_on('gettext')
+    # Prior to 2.30, gold did not distribute the generated files and
+    # thus needs bison, even for a one-time build.
+    depends_on('m4', type='build', when='+gold')
+    depends_on('bison', type='build', when='+gold')
 
     def configure_args(self):
         spec = self.spec
 
         configure_args = [
-            '--with-system-zlib',
             '--disable-dependency-tracking',
             '--disable-werror',
-            '--enable-interwork',
             '--enable-multilib',
             '--enable-shared',
             '--enable-64-bit-bfd',
             '--enable-targets=all',
+            '--with-system-zlib',
             '--with-sysroot=/',
         ]
 
@@ -79,6 +80,11 @@ class Binutils(AutotoolsPackage):
 
         if '+libiberty' in spec:
             configure_args.append('--enable-install-libiberty')
+
+        if '+nls' in spec:
+            configure_args.append('--enable-nls')
+        else:
+            configure_args.append('--disable-nls')
 
         # To avoid namespace collisions with Darwin/BSD system tools,
         # prefix executables with "g", e.g., gar, gnm; see Homebrew


### PR DESCRIPTION
Add variant 'nls' for native language support with default True.
The default inside binutils was always on, but this gives a way of
turning it off, if desired.

Adjust the dependencies.  Flex is never used for a one-time build.
Bison and m4 should not be needed, except that prior to rev 2.30, gold
did not include its generated files, so bison is needed when +gold.

Drop configure option --enable-interwork.  This option does not exist.