### PR TITLE
Pack dlang's stdlib into dmd.

### DIFF
--- a/var/spack/repos/builtin/packages/dmd/package.py
+++ b/var/spack/repos/builtin/packages/dmd/package.py
@@ -56,7 +56,7 @@ class Dmd(MakefilePackage):
         run_env.prepend_path('LIBRARY_PATH', self.prefix.linux.lib64)
         run_env.prepend_path('LD_LIBRARY_PATH', self.prefix.linux.lib64)
 
-    def build(self, spec, prefix):
+    def edit(self, spec, prefix):
         # Move contents to dmd/
         mkdir = which('mkdir')
         mkdir('dmd')
@@ -73,7 +73,8 @@ class Dmd(MakefilePackage):
         pb_makefile.filter('INSTALL_DIR = .*', 'INSTALL_DIR = {0}'.format(prefix))
         tools_makefile = FileFilter('tools/posix.mak')
         tools_makefile.filter('INSTALL_DIR = .*', 'INSTALL_DIR = {0}'.format(prefix))
-        # Build
+
+    def build(self, spec, prefix):
         with working_dir('dmd'):
             make('-f', 'posix.mak', 'AUTO_BOOTSTRAP=1')
         with working_dir('phobos'):

--- a/var/spack/repos/builtin/packages/dmd/package.py
+++ b/var/spack/repos/builtin/packages/dmd/package.py
@@ -53,6 +53,8 @@ class Dmd(MakefilePackage):
 
     def setup_environment(self, spack_env, run_env):
         run_env.prepend_path('PATH', self.prefix.linux.bin64)
+        run_env.prepend_path('LIBRARY_PATH', self.prefix.linux.lib64)
+        run_env.prepend_path('LD_LIBRARY_PATH', self.prefix.linux.lib64)
 
     def build(self, spec, prefix):
         # Move contents to dmd/
@@ -67,6 +69,10 @@ class Dmd(MakefilePackage):
         dmd_makefile.filter('$(PWD)/../install', prefix, string=True)
         dr_makefile = FileFilter('druntime/posix.mak')
         dr_makefile.filter('INSTALL_DIR=.*', 'INSTALL_DIR={0}'.format(prefix))
+        pb_makefile = FileFilter('phobos/posix.mak')
+        pb_makefile.filter('INSTALL_DIR = .*', 'INSTALL_DIR = {0}'.format(prefix))
+        tools_makefile = FileFilter('tools/posix.mak')
+        tools_makefile.filter('INSTALL_DIR = .*', 'INSTALL_DIR = {0}'.format(prefix))
         # Build
         with working_dir('dmd'):
             make('-f', 'posix.mak', 'AUTO_BOOTSTRAP=1')
@@ -77,4 +83,8 @@ class Dmd(MakefilePackage):
         with working_dir('dmd'):
             make('-f', 'posix.mak', 'install', 'AUTO_BOOTSTRAP=1')
         with working_dir('phobos'):
+            make('-f', 'posix.mak', 'install')
+        with working_dir('tools'):
+            make('-f', 'posix.mak', 'install')
+        with working_dir('druntime'):
             make('-f', 'posix.mak', 'install')

--- a/var/spack/repos/builtin/packages/dmd/package.py
+++ b/var/spack/repos/builtin/packages/dmd/package.py
@@ -61,18 +61,23 @@ class Dmd(MakefilePackage):
         mkdir = which('mkdir')
         mkdir('dmd')
         mv = which('mv')
-        dmd_files = [f for f in os.listdir('.') if not f.startswith(('dmd', 'druntime', 'phobos', 'tools', 'spack-build'))]
+        dmd_files = [f for f in os.listdir('.')
+                     if not f.startswith(('dmd',
+                                          'druntime',
+                                          'phobos',
+                                          'tools',
+                                          'spack-build'))]
         for f in dmd_files:
             mv(f, 'dmd')
         # Edit
-        dmd_makefile = FileFilter('dmd/posix.mak')
-        dmd_makefile.filter('$(PWD)/../install', prefix, string=True)
-        dr_makefile = FileFilter('druntime/posix.mak')
-        dr_makefile.filter('INSTALL_DIR=.*', 'INSTALL_DIR={0}'.format(prefix))
-        pb_makefile = FileFilter('phobos/posix.mak')
-        pb_makefile.filter('INSTALL_DIR = .*', 'INSTALL_DIR = {0}'.format(prefix))
-        tools_makefile = FileFilter('tools/posix.mak')
-        tools_makefile.filter('INSTALL_DIR = .*', 'INSTALL_DIR = {0}'.format(prefix))
+        dmd_mak = FileFilter('dmd/posix.mak')
+        dmd_mak.filter('$(PWD)/../install', prefix, string=True)
+        dr_mak = FileFilter('druntime/posix.mak')
+        dr_mak.filter('INSTALL_DIR=.*', 'INSTALL_DIR={0}'.format(prefix))
+        pb_mak = FileFilter('phobos/posix.mak')
+        pb_mak.filter('INSTALL_DIR = .*', 'INSTALL_DIR = {0}'.format(prefix))
+        tl_mak = FileFilter('tools/posix.mak')
+        tl_mak.filter('INSTALL_DIR = .*', 'INSTALL_DIR = {0}'.format(prefix))
 
     def build(self, spec, prefix):
         with working_dir('dmd'):

--- a/var/spack/repos/builtin/packages/dmd/package.py
+++ b/var/spack/repos/builtin/packages/dmd/package.py
@@ -23,6 +23,8 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+import shutil
+import glob
 
 
 class Dmd(MakefilePackage):
@@ -36,16 +38,51 @@ class Dmd(MakefilePackage):
     depends_on('openssl')
     depends_on('curl')
 
+    # https://wiki.dlang.org/Building_under_Posix
+    resource(name='druntime',
+             url='https://github.com/dlang/druntime/archive/v2.081.1.tar.gz',
+             md5='49c8ba48fcb1e53d553a52d8ed7f9164',
+             placement='druntime')
+    resource(name='phobos',
+             url='https://github.com/dlang/phobos/archive/v2.081.1.tar.gz',
+             md5='ccf4787275b490eb2ddfc6713f9e9882',
+             placement='phobos')
+    resource(name='tools',
+             url='https://github.com/dlang/tools/archive/v2.081.1.tar.gz',
+             md5='a3bc7ed3d60b39712ef011bf19b3d427',
+             placement='tools')
+
     def setup_environment(self, spack_env, run_env):
         run_env.prepend_path('PATH', self.prefix.linux.bin64)
 
+    def do_stage(self, mirror_only=False):
+        # wrap (decorate) the standard expand_archive step with a
+        # helper, then call the real do_stage().
+        self.stage.expand_archive = self.unpack_dmd(self.stage.expand_archive)
+        super(Dmd, self).do_stage(mirror_only)
+
+    def unpack_dmd(self, f):
+        def wrap():
+            f() # call the original expand_archive()
+            with working_dir(self.stage.path):
+                dir_dmd = glob.glob(join_path('dmd*'))[0]
+                # mkdir = which('mkdir')
+                # mkdir('dmd')
+                # mv =  which('mv')
+                # mv(join_path(dir_dmd, '*'), 'dmd')
+                # shutil.move(join_path(dir_dmd, '*'), 'dmd')
+        return wrap
+
     def edit(self, spec, prefix):
-        makefile = FileFilter('posix.mak')
+        makefile = FileFilter('dmd/posix.mak')
         makefile.filter('$(PWD)/../install', prefix, string=True)
 
     def build(self, spec, prefix):
-        make('-f', 'posix.mak', 'AUTO_BOOTSTRAP=1')
+        with working_dir('dmd'):
+            make('-f', 'posix.mak', 'AUTO_BOOTSTRAP=1')
+        with working_dir('phobos'):
+            make('-f', 'posix.mak')
 
     def install(self, spec, prefix):
-        make('-f', 'posix.mak', 'install', 'AUTO_BOOTSTRAP=1')
-        install_tree('src', prefix.src)
+        with working_dir('dmd'):
+            make('-f', 'posix.mak', 'install', 'AUTO_BOOTSTRAP=1')


### PR DESCRIPTION
Pack dlang's stdlib into dmd according to https://wiki.dlang.org/Building_under_Posix . After that, `hello.d` and `skilion-onedrive` #9130 have been built succesfully.