### PR TITLE
Update openspeedshop and cbtf version numbers

### DIFF
--- a/var/spack/repos/builtin/packages/cbtf-argonavis/package.py
+++ b/var/spack/repos/builtin/packages/cbtf-argonavis/package.py
@@ -51,6 +51,7 @@ class CbtfArgonavis(CMakePackage):
     git      = "https://github.com/OpenSpeedShop/cbtf-argonavis.git"
 
     version('develop', branch='master')
+    version('1.9.1.2', branch='1.9.1.2')
     version('1.9.1.1', branch='1.9.1.1')
     version('1.9.1.0', branch='1.9.1.0')
 

--- a/var/spack/repos/builtin/packages/cbtf-krell/package.py
+++ b/var/spack/repos/builtin/packages/cbtf-krell/package.py
@@ -55,6 +55,7 @@ class CbtfKrell(CMakePackage):
     git      = "https://github.com/OpenSpeedShop/cbtf-krell.git"
 
     version('develop', branch='master')
+    version('1.9.1.2', branch='1.9.1.2')
     version('1.9.1.1', branch='1.9.1.1')
     version('1.9.1.0', branch='1.9.1.0')
 
@@ -94,7 +95,8 @@ class CbtfKrell(CMakePackage):
 
     # For Dyninst
     depends_on("dyninst@develop", when='@develop')
-    depends_on("dyninst@9.3.2", when='@1.9.1.0:9999')
+    # This will change to dyninst@10.0 when it is released
+    depends_on("dyninst@develop", when='@1.9.1.0:9999')
 
     # For MRNet
     depends_on("mrnet@5.0.1-3:+cti", when='@develop+cti')

--- a/var/spack/repos/builtin/packages/cbtf-lanl/package.py
+++ b/var/spack/repos/builtin/packages/cbtf-lanl/package.py
@@ -51,6 +51,7 @@ class CbtfLanl(CMakePackage):
     git      = "https://github.com/OpenSpeedShop/cbtf-lanl.git"
 
     version('develop', branch='master')
+    version('1.9.1.2', branch='1.9.1.2')
     version('1.9.1.1', branch='1.9.1.1')
     version('1.9.1.0', branch='1.9.1.0')
 

--- a/var/spack/repos/builtin/packages/cbtf/package.py
+++ b/var/spack/repos/builtin/packages/cbtf/package.py
@@ -54,6 +54,7 @@ class Cbtf(CMakePackage):
     git      = "https://github.com/OpenSpeedShop/cbtf.git"
 
     version('develop', branch='master')
+    version('1.9.1.2', branch='1.9.1.2')
     version('1.9.1.1', branch='1.9.1.1')
     version('1.9.1.0', branch='1.9.1.0')
 

--- a/var/spack/repos/builtin/packages/openspeedshop-utils/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop-utils/package.py
@@ -130,7 +130,8 @@ class OpenspeedshopUtils(CMakePackage):
     depends_on("boost@1.66.0", when='@2.3.1.3:9999')
 
     depends_on("dyninst@develop", when='@develop')
-    depends_on("dyninst@9.3.2", when='@2.3.1.3:9999')
+    # This will change to dyninst@10.0 when it is released
+    depends_on("dyninst@develop", when='@2.3.1.3:9999')
 
     depends_on("python", when='@develop')
     depends_on("python@2.7.14:2.7.15", when='@2.3.1.3:9999')

--- a/var/spack/repos/builtin/packages/openspeedshop/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop/package.py
@@ -66,6 +66,7 @@ class Openspeedshop(CMakePackage):
     git      = "https://github.com/OpenSpeedShop/openspeedshop.git"
 
     version('develop', branch='master')
+    version('2.3.1.5', branch='2.3.1.5')
     version('2.3.1.4', branch='2.3.1.4')
     version('2.3.1.3', branch='2.3.1.3')
 
@@ -128,7 +129,8 @@ class Openspeedshop(CMakePackage):
     depends_on("boost@1.66.0", when='@2.3.1.3:9999')
 
     depends_on("dyninst@develop", when='@develop')
-    depends_on("dyninst@9.3.2", when='@2.3.1.3:9999')
+    # This will change to version dyninst@10.0 when it is released
+    depends_on("dyninst@develop", when='@2.3.1.3:9999')
 
     depends_on("python", when='@develop')
     depends_on("python@2.7.14:2.7.15", when='@2.3.1.3:9999')


### PR DESCRIPTION
Update the version numbers and now depend on
the develop version of dyninst because of a
feature in openspeedshop depends on new code
in the dyninst develop tree.  Without dyninst
develop, openspeedshop will not build.