### PR TITLE
Fix two dependencies with silo.

### DIFF
--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -48,8 +48,10 @@ class Silo(AutotoolsPackage):
             description='Compile with MPI Compatibility')
 
     depends_on('hdf5~mpi', when='~mpi')
+    depends_on('mpi', when='+mpi')
     depends_on('hdf5+mpi', when='+mpi')
     depends_on('qt', when='+silex')
+    depends_on('zlib')
 
     patch('remove-mpiposix.patch', when='@4.8:4.10.2')
 


### PR DESCRIPTION
1. I presently get errors of the sort
```
==> Error: KeyError: 'No spec with name mpi in silo@4.10.2%gcc@8.1.0+fortran+mpi
[...]
$HOME/spack/var/spack/repos/builtin/packages/silo/package.py:84, in configure_args:
         81                'FCFLAGS={0}'.format(self.compiler.pic_flag)]
         82
         83        if '+mpi' in self.spec:
  >>     84            config_args.append('CC=%s' % self.spec['mpi'].mpicc)
         85            config_args.append('CXX=%s' % self.spec['mpi'].mpicxx)
         86            config_args.append('FC=%s' % self.spec['mpi'].mpifc)
```
without the extra explicit MPI dependency. I am a bit of a spack novice; I don't really understand why we need to explicitly write out the dependency when `+mpi` is in the spec, though a lot of other packages (e.g., Zoltan) do it.

2. Silo uses zlib, so we should explicitly depend on it.

Edit: clarify the MPI error message