### PR TITLE
Vim: add version 8.1.0338

### DIFF
--- a/var/spack/repos/builtin/packages/vim/package.py
+++ b/var/spack/repos/builtin/packages/vim/package.py
@@ -35,8 +35,9 @@ class Vim(AutotoolsPackage):
     """
 
     homepage = "http://www.vim.org"
-    url      = "https://github.com/vim/vim/archive/v8.0.1376.tar.gz"
+    url      = "https://github.com/vim/vim/archive/v8.1.0338.tar.gz"
 
+    version('8.1.0338', '94191b4141245a5deb4955c4a80359bb')
     version('8.1.0001', 'edb6f5c67cb3100ea9e3966a43b9c9da')
     version('8.0.1376', '62855881a2d96d48956859d74cfb8a3b')
     version('8.0.0503', '82b77bd5cb38b70514bed47cfe033b8c')
@@ -141,6 +142,10 @@ class Vim(AutotoolsPackage):
             configure_args.append("--enable-cscope")
 
         return configure_args
+
+    # Tests must be run in serial
+    def check(self):
+        make('test', parallel=False)
 
     # Run the install phase with -j 1.  There seems to be a problem with
     # parallel builds that results in the creation of the links (e.g. view)


### PR DESCRIPTION
Builds and passes tests on Blue Waters with GCC 7.3.0.