### PR TITLE
Gapfiller 1.10 f01

### DIFF
--- a/var/spack/repos/builtin/packages/gapfiller/package.py
+++ b/var/spack/repos/builtin/packages/gapfiller/package.py
@@ -26,6 +26,7 @@ from spack import *
 import os
 import glob
 
+
 class Gapfiller(Package):
     """GapFiller is a stand-alone program for closing gaps within
        pre-assembled scaffolds.

--- a/var/spack/repos/builtin/packages/gapfiller/package.py
+++ b/var/spack/repos/builtin/packages/gapfiller/package.py
@@ -44,7 +44,18 @@ class Gapfiller(Package):
         return "file://{0}/39GapFiller_v{1}_linux-x86_64.tar.gz".format(
                 os.getcwd(), version.dashed)
 
-    depends_on('perl', type=('build', 'run'))
+    depends_on('perl+threads', type=('build', 'run'))
+
+    def patch(self):
+        with working_dir('src'):
+            files = glob.iglob("*.pl")
+            for file in files:
+                change = FileFilter(file)
+                change.filter('usr/bin/perl', 'usr/bin/env perl')
+                change.filter('require "getopts.pl";', 'use Getopt::Std;')
+                change.filter('&Getopts(', 'getopts(')
+                change.filter('\r', '')
+                set_executable(file)
 
     def install(self, spec, prefix):
         install_tree('bowtie', prefix.bowtie)

--- a/var/spack/repos/builtin/packages/gapfiller/package.py
+++ b/var/spack/repos/builtin/packages/gapfiller/package.py
@@ -24,7 +24,7 @@
 ##############################################################################
 from spack import *
 import os
-
+import glob
 
 class Gapfiller(Package):
     """GapFiller is a stand-alone program for closing gaps within
@@ -47,17 +47,17 @@ class Gapfiller(Package):
     depends_on('perl+threads', type=('build', 'run'))
 
     def patch(self):
-        with working_dir('src'):
+        with working_dir('.'):
             files = glob.iglob("*.pl")
             for file in files:
                 change = FileFilter(file)
                 change.filter('usr/bin/perl', 'usr/bin/env perl')
                 change.filter('require "getopts.pl";', 'use Getopt::Std;')
-                change.filter('&Getopts(', 'getopts(')
+                change.filter('&Getopts', 'getopts')
                 change.filter('\r', '')
                 set_executable(file)
 
     def install(self, spec, prefix):
-        install_tree('bowtie', prefix.bowtie)
-        install_tree('bwa', prefix.bwa)
-        install('GapFiller.pl', prefix)
+        install_tree('bowtie', prefix.bin.bowtie)
+        install_tree('bwa', prefix.bin.bwa)
+        install('GapFiller.pl', prefix.bin)


### PR DESCRIPTION
Various GapFiller fixes including:

    line endings
    /usr/bin/env perl
    getopts.pl to Getopt::Std
    require the threads perl variant
    install into bin.
