### PR TITLE
Fix macOS support in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -142,13 +142,18 @@ cache:
 
 # Work around Travis's lack of support for Python on OSX
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew ls --versions python > /dev/null || brew install python; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rm /usr/local/include/c++ ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew ls --versions gcc    > /dev/null || brew install gcc;    fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew ls --versions gnupg2 > /dev/null || brew install gnupg2; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then virtualenv venv; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source venv/bin/activate; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+        brew update;
+        export HOMEBREW_NO_AUTO_UPDATE=1;
+        rm /usr/local/include/c++ ;
+        brew ls --versions gcc    > /dev/null || brew install gcc;
+        brew ls --versions gnupg2 > /dev/null || brew install gnupg2;
+        brew install python@2;
+        pip2 install --upgrade pip;
+        pip2 install virtualenv;
+        virtualenv venv;
+        source venv/bin/activate;
+    fi
 
 # Install various dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -146,9 +146,9 @@ before_install:
         brew update;
         export HOMEBREW_NO_AUTO_UPDATE=1;
         rm /usr/local/include/c++ ;
-        brew ls --versions gcc    > /dev/null || brew install gcc;
-        brew ls --versions gnupg2 > /dev/null || brew install gnupg2;
-        brew install python@2;
+        brew ls --versions python@2 > /dev/null || brew install python@2;
+        brew ls --versions gcc      > /dev/null || brew install gcc;
+        brew ls --versions gnupg2   > /dev/null || brew install gnupg2;
         pip2 install --upgrade pip;
         pip2 install virtualenv;
         virtualenv venv;
@@ -163,7 +163,9 @@ install:
   - pip install --upgrade codecov
   - pip install --upgrade flake8
   - pip install --upgrade pep8-naming
-  - if [[ "$TEST_SUITE" == "doc" ]]; then pip install --upgrade -r lib/spack/docs/requirements.txt; fi
+  - if [[ "$TEST_SUITE" == "doc" ]]; then
+        pip install --upgrade -r lib/spack/docs/requirements.txt;
+    fi
 
 before_script:
   # Need this for the git tests to succeed.
@@ -173,15 +175,20 @@ before_script:
   # Need this to be able to compute the list of changed files
   - git fetch origin develop:develop
 
-  # Set up external dependencies for build tests, because the take too long to compile
-  - if [[ "$TEST_SUITE" == "build" ]]; then cp share/spack/qa/configuration/packages.yaml etc/spack/packages.yaml; fi
+  # Set up external deps for build tests, b/c they take too long to compile
+  - if [[ "$TEST_SUITE" == "build" ]]; then cp
+        share/spack/qa/configuration/packages.yaml etc/spack/packages.yaml;
+    fi
 
 #=============================================================================
 # Building
 #=============================================================================
 script:
   - share/spack/qa/run-$TEST_SUITE-tests
-  - if [[ "$TEST_SUITE" == "unit" || "$TEST_SUITE" == "build" ]]; then codecov --env PYTHON_VERSION --required --flags "${TEST_SUITE}${TRAVIS_OS_NAME}"; fi
+  - if [[ "$TEST_SUITE" == "unit" || "$TEST_SUITE" == "build" ]]; then
+        codecov --env PYTHON_VERSION
+                --required --flags "${TEST_SUITE}${TRAVIS_OS_NAME}";
+    fi
 
 #=============================================================================
 # Notifications

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,8 +57,7 @@ jobs:
       os: linux
       language: python
       env: TEST_SUITE=doc
-    - stage: 'unit tests - osx'
-      os: osx
+    - os: osx
       language: generic
       env: [ TEST_SUITE=unit, PYTHON_VERSION=2.7 ]
 # mpich (AutotoolsPackage)
@@ -109,8 +108,6 @@ stages:
   - 'style checks'
   - 'unit tests + documentation'
   - 'build tests'
-  - name: 'unit tests - osx'
-    if: type IN (cron)
 
 
 #=============================================================================


### PR DESCRIPTION
Fixes #9031.

This cleans up `.travis.yml` (yes you can do multi-line scripts) and brings back macOS in the unit test stage.  Let's see if it's more reliable now.