### PR TITLE
msgpack-c, snappy: explicitly depend on googletest

### DIFF
--- a/var/spack/repos/builtin/packages/msgpack-c/package.py
+++ b/var/spack/repos/builtin/packages/msgpack-c/package.py
@@ -34,10 +34,13 @@ class MsgpackC(CMakePackage):
     version('1.4.1', 'e2fd3a7419b9bc49e5017fdbefab87e0')
 
     depends_on('cmake@2.8.12:', type='build')
+    depends_on('googletest', type='test')
 
     def cmake_args(self):
         args = [
             "-DCMAKE_CXX_FLAGS=-Wno-implicit-fallthrough",
-            "-DCMAKE_C_FLAGS=-Wno-implicit-fallthrough"
+            "-DCMAKE_C_FLAGS=-Wno-implicit-fallthrough",
+            '-DMSGPACK_BUILD_TESTS:BOOL={0}'.format(
+                'ON' if self.run_tests else 'OFF')
         ]
         return args

--- a/var/spack/repos/builtin/packages/snappy/link_gtest.patch
+++ b/var/spack/repos/builtin/packages/snappy/link_gtest.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt	2018-09-03 14:25:32.390110709 +0200
++++ b/CMakeLists.txt	2018-09-03 14:24:16.198182317 +0200
+@@ -118,7 +118,7 @@
+       "${PROJECT_SOURCE_DIR}/snappy-test.cc"
+   )
+   target_compile_definitions(snappy_unittest PRIVATE -DHAVE_CONFIG_H)
+-  target_link_libraries(snappy_unittest snappy ${GFLAGS_LIBRARIES})
++  target_link_libraries(snappy_unittest snappy ${GFLAGS_LIBRARIES} ${GTEST_LIBRARIES})
+ 
+   if(HAVE_LIBZ)
+     target_link_libraries(snappy_unittest z)

--- a/var/spack/repos/builtin/packages/snappy/package.py
+++ b/var/spack/repos/builtin/packages/snappy/package.py
@@ -36,6 +36,10 @@ class Snappy(CMakePackage):
     variant('shared', default=True, description='Build shared libraries')
     variant('pic', default=True, description='Build position independent code')
 
+    depends_on('googletest', type='test')
+
+    patch('link_gtest.patch')
+
     def cmake_args(self):
         spec = self.spec
 
@@ -43,7 +47,9 @@ class Snappy(CMakePackage):
             '-DCMAKE_INSTALL_LIBDIR:PATH={0}'.format(
                 self.prefix.lib),
             '-DBUILD_SHARED_LIBS:BOOL={0}'.format(
-                'ON' if '+shared' in spec else 'OFF')
+                'ON' if '+shared' in spec else 'OFF'),
+            '-DSNAPPY_BUILD_TESTS:BOOL={0}'.format(
+                'ON' if self.run_tests else 'OFF')
         ]
 
         return args


### PR DESCRIPTION
At least two patches have been filed upstream for the linking issue regarding snappy (the patch in this PR). Issues discovered when `googletest` was installed on one of the systems I work on.