### PR TITLE
Users can decide whether to set RPATH or RUNPATH

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -14,16 +14,6 @@
 #   ~/.spack/config.yaml
 # -------------------------------------------------------------------------
 config:
-  # If 'true' enforces RPATH for ELF binaries, if 'false'
-  # enforces RUNPATH. See:
-  #
-  # http://blog.qt.io/blog/2011/10/28/rpath-and-runpath/
-  # http://xahlee.info/UnixResource_dir/_/ldpath.html
-  # https://gms.tf/ld_library_path-considered-harmful.html
-  #
-  # for more information on the subject.
-  rpath: true
-
   # This is the path to the root of the Spack install tree.
   # You can use $spack here to refer to the root of the spack instance.
   install_tree: $spack/opt/spack
@@ -148,3 +138,23 @@ config:
   # anticipates that a significant delay indicates that the lock attempt will
   # never succeed.
   package_lock_timeout: null
+
+  # Control whether Spack embeds RPATH or RUNPATH attributes in ELF binaries
+  # so that they can find their dependencies. Has no effect on macOS.
+  #
+  # There are two options:
+  #
+  #   1. rpath: use RPATH: force --disable-new-tags flag to be passed to ld
+  #   2. runpath: use RUNPATH: force --enable-new-tags flag to be passed to ld
+  #
+  # RPATH search paths have higher precedence than LD_LIBRARY_PATH
+  # and ld.so will search for libraries in transitive RPATHs of
+  # parent objects.
+  #
+  # RUNPATH search paths have lower precedence than LD_LIBRARRY_PATH,
+  # and ld.so will ONLY search for dependencies in the RUNPATH of
+  # the loading object.
+  #
+  # DO NOT MIX these within the same install tree. See the Spack
+  # documentation for details.
+  shared_linking: 'rpath'

--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -14,6 +14,16 @@
 #   ~/.spack/config.yaml
 # -------------------------------------------------------------------------
 config:
+  # If 'true' enforces RPATH for ELF binaries, if 'false'
+  # enforces RUNPATH. See:
+  #
+  # http://blog.qt.io/blog/2011/10/28/rpath-and-runpath/
+  # http://xahlee.info/UnixResource_dir/_/ldpath.html
+  # https://gms.tf/ld_library_path-considered-harmful.html
+  #
+  # for more information on the subject.
+  rpath: true
+
   # This is the path to the root of the Spack install tree.
   # You can use $spack here to refer to the root of the spack instance.
   install_tree: $spack/opt/spack

--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -139,22 +139,7 @@ config:
   # never succeed.
   package_lock_timeout: null
 
-  # Control whether Spack embeds RPATH or RUNPATH attributes in ELF binaries
-  # so that they can find their dependencies. Has no effect on macOS.
-  #
-  # There are two options:
-  #
-  #   1. rpath: use RPATH: force --disable-new-tags flag to be passed to ld
-  #   2. runpath: use RUNPATH: force --enable-new-tags flag to be passed to ld
-  #
-  # RPATH search paths have higher precedence than LD_LIBRARY_PATH
-  # and ld.so will search for libraries in transitive RPATHs of
-  # parent objects.
-  #
-  # RUNPATH search paths have lower precedence than LD_LIBRARRY_PATH,
-  # and ld.so will ONLY search for dependencies in the RUNPATH of
-  # the loading object.
-  #
-  # DO NOT MIX these within the same install tree. See the Spack
-  # documentation for details.
+  # Control whether Spack embeds RPATH or RUNPATH attributes in ELF binaries.
+  # Has no effect on macOS. DO NOT MIX these within the same install tree.
+  # See the Spack documentation for details.
   shared_linking: 'rpath'

--- a/lib/spack/docs/config_yaml.rst
+++ b/lib/spack/docs/config_yaml.rst
@@ -226,3 +226,24 @@ ccache`` to learn more about the default settings and how to change
 them). Please note that we currently disable ccache's ``hash_dir``
 feature to avoid an issue with the stage directory (see
 https://github.com/LLNL/spack/pull/3761#issuecomment-294352232).
+
+------------------
+``shared_linking``
+------------------
+
+Control whether Spack embeds ``RPATH`` or ``RUNPATH`` attributes in ELF binaries
+so that they can find their dependencies. Has no effect on macOS.
+Two options are allowed:
+
+ 1. ``rpath`` uses ``RPATH`` and forces the ``--disable-new-tags`` flag to be passed to the linker
+ 2. ``runpath`` uses ``RUNPATH`` and forces the ``--enable-new-tags`` flag to be passed to the linker
+
+``RPATH`` search paths have higher precedence than ``LD_LIBRARY_PATH``
+and ld.so will search for libraries in transitive ``RPATHs`` of
+parent objects.
+
+``RUNPATH`` search paths have lower precedence than ``LD_LIBRARY_PATH``,
+and ld.so will ONLY search for dependencies in the ``RUNPATH`` of
+the loading object.
+
+DO NOT MIX the two options within the same install tree.

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -33,6 +33,8 @@ parameters=(
     SPACK_F77_RPATH_ARG
     SPACK_FC_RPATH_ARG
     SPACK_TARGET_ARGS
+    SPACK_DISABLE_NEW_DTAGS
+    SPACK_LINKER_ARG
     SPACK_SHORT_SPEC
     SPACK_SYSTEM_DIRS
 )
@@ -166,6 +168,22 @@ if [[ -z $mode ]]; then
         fi
     done
 fi
+
+# This is needed to ensure we set RPATH instead of RUNPATH.
+# Documentation on this mechanism is lacking at best. A few sources
+# of information are (note that some of them take explicitly the
+# opposite stance that Spack does):
+#
+# http://blog.qt.io/blog/2011/10/28/rpath-and-runpath/
+# https://wiki.debian.org/RpathIssue
+#
+# The only discussion I could find on enabling new dynamic tags by
+# default on ld is the following:
+#
+# https://sourceware.org/ml/binutils/2013-01/msg00307.html
+#
+disable_new_dtags="${SPACK_DISABLE_NEW_DTAGS}"
+linker_arg="${SPACK_LINKER_ARG}"
 
 # Set up rpath variable according to language.
 eval rpath=\$SPACK_${comp}_RPATH_ARG
@@ -381,22 +399,6 @@ esac
 # Linker flags
 case "$mode" in
     ld|ccld)
-        # This is needed to ensure we set RPATH instead of RUNPATH.
-        # Documentation on this mechanism is lacking at best. A few sources
-        # of information are (note that some of them take explicitly the
-        # opposite stance that Spack does):
-        #
-        # http://blog.qt.io/blog/2011/10/28/rpath-and-runpath/
-        # https://wiki.debian.org/RpathIssue
-        #
-        # The only discussion I could find on enabling new dynamic tags by
-        # default on ld is the following:
-        #
-        # https://sourceware.org/ml/binutils/2013-01/msg00307.html
-        #
-        flags+=('-Wl,--disable-new-dtags')
-
-        # Add other flags
         flags=("${flags[@]}" "${SPACK_LDFLAGS[@]}") ;;
 esac
 
@@ -478,10 +480,12 @@ for dir in "${system_libdirs[@]}";   do args+=("-L$dir"); done
 # RPATHs arguments
 case "$mode" in
     ccld)
+        if [ ! -z "$disable_new_dtags" ] ; then args+=("$linker_arg$disable_new_dtags") ; fi
         for dir in "${rpaths[@]}";        do args+=("$rpath$dir"); done
         for dir in "${system_rpaths[@]}"; do args+=("$rpath$dir"); done
         ;;
     ld)
+        if [ ! -z "$disable_new_dtags" ] ; then args+=("$disable_new_dtags") ; fi
         for dir in "${rpaths[@]}";        do args+=("-rpath" "$dir"); done
         for dir in "${system_rpaths[@]}"; do args+=("-rpath" "$dir"); done
         ;;

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -311,6 +311,8 @@ while [ -n "$1" ]; do
                     die "-Wl,-rpath was not followed by -Wl,*"
                 fi
                 rp="${arg#-Wl,}"
+            elif [[ "$arg" = --enable-new-dtags ]] ; then
+                :  # We want to remove explicitly this flag
             else
                 other_args+=("-Wl,$arg")
             fi
@@ -342,7 +344,11 @@ while [ -n "$1" ]; do
             fi
             ;;
         *)
-            other_args+=("$1")
+            if [[ "$1" = --enable-new-dtags ]] ; then
+                :  # We want to remove explicitly this flag
+            else
+                other_args+=("$1")
+            fi
             ;;
     esac
 

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -33,7 +33,8 @@ parameters=(
     SPACK_F77_RPATH_ARG
     SPACK_FC_RPATH_ARG
     SPACK_TARGET_ARGS
-    SPACK_DISABLE_NEW_DTAGS
+    SPACK_DTAGS_TO_ENABLE
+    SPACK_DTAGS_TO_DISABLE
     SPACK_LINKER_ARG
     SPACK_SHORT_SPEC
     SPACK_SYSTEM_DIRS
@@ -169,7 +170,9 @@ if [[ -z $mode ]]; then
     done
 fi
 
-# This is needed to ensure we set RPATH instead of RUNPATH.
+# This is needed to ensure we set RPATH instead of RUNPATH
+# (or the opposite, depending on the configuration in config.yaml)
+#
 # Documentation on this mechanism is lacking at best. A few sources
 # of information are (note that some of them take explicitly the
 # opposite stance that Spack does):
@@ -182,7 +185,8 @@ fi
 #
 # https://sourceware.org/ml/binutils/2013-01/msg00307.html
 #
-disable_new_dtags="${SPACK_DISABLE_NEW_DTAGS}"
+dtags_to_enable="${SPACK_DTAGS_TO_ENABLE}"
+dtags_to_disable="${SPACK_DTAGS_TO_DISABLE}"
 linker_arg="${SPACK_LINKER_ARG}"
 
 # Set up rpath variable according to language.
@@ -311,7 +315,7 @@ while [ -n "$1" ]; do
                     die "-Wl,-rpath was not followed by -Wl,*"
                 fi
                 rp="${arg#-Wl,}"
-            elif [[ "$arg" = --enable-new-dtags ]] ; then
+            elif [[ "$arg" = "$dtags_to_disable" ]] ; then
                 :  # We want to remove explicitly this flag
             else
                 other_args+=("-Wl,$arg")
@@ -344,7 +348,7 @@ while [ -n "$1" ]; do
             fi
             ;;
         *)
-            if [[ "$1" = --enable-new-dtags ]] ; then
+            if [[ "$1" = "$dtags_to_disable" ]] ; then
                 :  # We want to remove explicitly this flag
             else
                 other_args+=("$1")
@@ -486,12 +490,12 @@ for dir in "${system_libdirs[@]}";   do args+=("-L$dir"); done
 # RPATHs arguments
 case "$mode" in
     ccld)
-        if [ ! -z "$disable_new_dtags" ] ; then args+=("$linker_arg$disable_new_dtags") ; fi
+        if [ ! -z "$dtags_to_enable" ] ; then args+=("$linker_arg$dtags_to_enable") ; fi
         for dir in "${rpaths[@]}";        do args+=("$rpath$dir"); done
         for dir in "${system_rpaths[@]}"; do args+=("$rpath$dir"); done
         ;;
     ld)
-        if [ ! -z "$disable_new_dtags" ] ; then args+=("$disable_new_dtags") ; fi
+        if [ ! -z "$dtags_to_enable" ] ; then args+=("$dtags_to_enable") ; fi
         for dir in "${rpaths[@]}";        do args+=("-rpath" "$dir"); done
         for dir in "${system_rpaths[@]}"; do args+=("-rpath" "$dir"); done
         ;;

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -381,6 +381,22 @@ esac
 # Linker flags
 case "$mode" in
     ld|ccld)
+        # This is needed to ensure we set RPATH instead of RUNPATH.
+        # Documentation on this mechanism is lacking at best. A few sources
+        # of information are (note that some of them take explicitly the
+        # opposite stance that Spack does):
+        #
+        # http://blog.qt.io/blog/2011/10/28/rpath-and-runpath/
+        # https://wiki.debian.org/RpathIssue
+        #
+        # The only discussion I could find on enabling new dynamic tags by
+        # default on ld is the following:
+        #
+        # https://sourceware.org/ml/binutils/2013-01/msg00307.html
+        #
+        flags+=('-Wl,--disable-new-dtags')
+
+        # Add other flags
         flags=("${flags[@]}" "${SPACK_LDFLAGS[@]}") ;;
 esac
 

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -33,8 +33,8 @@ parameters=(
     SPACK_F77_RPATH_ARG
     SPACK_FC_RPATH_ARG
     SPACK_TARGET_ARGS
-    SPACK_DTAGS_TO_ENABLE
-    SPACK_DTAGS_TO_DISABLE
+    SPACK_DTAGS_TO_ADD
+    SPACK_DTAGS_TO_STRIP
     SPACK_LINKER_ARG
     SPACK_SHORT_SPEC
     SPACK_SYSTEM_DIRS
@@ -185,8 +185,8 @@ fi
 #
 # https://sourceware.org/ml/binutils/2013-01/msg00307.html
 #
-dtags_to_enable="${SPACK_DTAGS_TO_ENABLE}"
-dtags_to_disable="${SPACK_DTAGS_TO_DISABLE}"
+dtags_to_add="${SPACK_DTAGS_TO_ADD}"
+dtags_to_strip="${SPACK_DTAGS_TO_STRIP}"
 linker_arg="${SPACK_LINKER_ARG}"
 
 # Set up rpath variable according to language.
@@ -315,7 +315,7 @@ while [ -n "$1" ]; do
                     die "-Wl,-rpath was not followed by -Wl,*"
                 fi
                 rp="${arg#-Wl,}"
-            elif [[ "$arg" = "$dtags_to_disable" ]] ; then
+            elif [[ "$arg" = "$dtags_to_strip" ]] ; then
                 :  # We want to remove explicitly this flag
             else
                 other_args+=("-Wl,$arg")
@@ -343,14 +343,14 @@ while [ -n "$1" ]; do
                 fi
                 shift 3;
                 rp="$1"
-            elif [[ "$2" = "$dtags_to_disable" ]] ; then
+            elif [[ "$2" = "$dtags_to_strip" ]] ; then
                 shift  # We want to remove explicitly this flag
             else
                 other_args+=("$1")
             fi
             ;;
         *)
-            if [[ "$1" = "$dtags_to_disable" ]] ; then
+            if [[ "$1" = "$dtags_to_strip" ]] ; then
                 :  # We want to remove explicitly this flag
             else
                 other_args+=("$1")
@@ -492,12 +492,12 @@ for dir in "${system_libdirs[@]}";   do args+=("-L$dir"); done
 # RPATHs arguments
 case "$mode" in
     ccld)
-        if [ ! -z "$dtags_to_enable" ] ; then args+=("$linker_arg$dtags_to_enable") ; fi
+        if [ ! -z "$dtags_to_add" ] ; then args+=("$linker_arg$dtags_to_add") ; fi
         for dir in "${rpaths[@]}";        do args+=("$rpath$dir"); done
         for dir in "${system_rpaths[@]}"; do args+=("$rpath$dir"); done
         ;;
     ld)
-        if [ ! -z "$dtags_to_enable" ] ; then args+=("$dtags_to_enable") ; fi
+        if [ ! -z "$dtags_to_add" ] ; then args+=("$dtags_to_add") ; fi
         for dir in "${rpaths[@]}";        do args+=("-rpath" "$dir"); done
         for dir in "${system_rpaths[@]}"; do args+=("-rpath" "$dir"); done
         ;;

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -343,6 +343,8 @@ while [ -n "$1" ]; do
                 fi
                 shift 3;
                 rp="$1"
+            elif [[ "$2" = "$dtags_to_disable" ]] ; then
+                shift  # We want to remove explicitly this flag
             else
                 other_args+=("$1")
             fi

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -203,11 +203,11 @@ def set_compiler_environment_variables(pkg, env):
 
     # Check whether we want to force RPATH or RUNPATH
     if spack.config.get('config:shared_linking') == 'rpath':
-        env.set('SPACK_DTAGS_TO_DISABLE', compiler.enable_new_dtags)
-        env.set('SPACK_DTAGS_TO_ENABLE', compiler.disable_new_dtags)
+        env.set('SPACK_DTAGS_TO_STRIP', compiler.enable_new_dtags)
+        env.set('SPACK_DTAGS_TO_ADD', compiler.disable_new_dtags)
     else:
-        env.set('SPACK_DTAGS_TO_DISABLE', compiler.disable_new_dtags)
-        env.set('SPACK_DTAGS_TO_ENABLE', compiler.enable_new_dtags)
+        env.set('SPACK_DTAGS_TO_STRIP', compiler.disable_new_dtags)
+        env.set('SPACK_DTAGS_TO_ADD', compiler.enable_new_dtags)
 
     # Set the target parameters that the compiler will add
     isa_arg = spec.architecture.target.optimization_flags(compiler)

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -200,7 +200,14 @@ def set_compiler_environment_variables(pkg, env):
     env.set('SPACK_F77_RPATH_ARG', compiler.f77_rpath_arg)
     env.set('SPACK_FC_RPATH_ARG',  compiler.fc_rpath_arg)
     env.set('SPACK_LINKER_ARG', compiler.linker_arg)
-    env.set('SPACK_DISABLE_NEW_DTAGS', compiler.disable_new_dtags)
+
+    # Check whether we want to force RPATH or RUNPATH
+    if spack.config.get('config:rpath'):
+        env.set('SPACK_DTAGS_TO_DISABLE', compiler.enable_new_dtags)
+        env.set('SPACK_DTAGS_TO_ENABLE', compiler.disable_new_dtags)
+    else:
+        env.set('SPACK_DTAGS_TO_DISABLE', compiler.disable_new_dtags)
+        env.set('SPACK_DTAGS_TO_ENABLE', compiler.enable_new_dtags)
 
     # Set the target parameters that the compiler will add
     isa_arg = spec.architecture.target.optimization_flags(compiler)

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -199,6 +199,8 @@ def set_compiler_environment_variables(pkg, env):
     env.set('SPACK_CXX_RPATH_ARG', compiler.cxx_rpath_arg)
     env.set('SPACK_F77_RPATH_ARG', compiler.f77_rpath_arg)
     env.set('SPACK_FC_RPATH_ARG',  compiler.fc_rpath_arg)
+    env.set('SPACK_LINKER_ARG', compiler.linker_arg)
+    env.set('SPACK_DISABLE_NEW_DTAGS', compiler.disable_new_dtags)
 
     # Set the target parameters that the compiler will add
     isa_arg = spec.architecture.target.optimization_flags(compiler)

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -202,7 +202,7 @@ def set_compiler_environment_variables(pkg, env):
     env.set('SPACK_LINKER_ARG', compiler.linker_arg)
 
     # Check whether we want to force RPATH or RUNPATH
-    if spack.config.get('config:rpath'):
+    if spack.config.get('config:shared_linking') == 'rpath':
         env.set('SPACK_DTAGS_TO_DISABLE', compiler.enable_new_dtags)
         env.set('SPACK_DTAGS_TO_ENABLE', compiler.disable_new_dtags)
     else:

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -230,13 +230,13 @@ class Compiler(object):
 
     @property
     def disable_new_dtags(self):
-        if platform.platform().lower() == 'macos':
+        if platform.system() == 'Darwin':
             return ''
         return '--disable-new-dtags'
 
     @property
     def enable_new_dtags(self):
-        if platform.platform().lower() == 'macos':
+        if platform.system() == 'Darwin':
             return ''
         return '--enable-new-dtags'
 

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import platform
 import re
 import itertools
 import shutil
@@ -221,6 +222,17 @@ class Compiler(object):
     @property
     def fc_rpath_arg(self):
         return '-Wl,-rpath,'
+
+    @property
+    def linker_arg(self):
+        """Flag that need to be used to pass an argument to the linker."""
+        return '-Wl,'
+
+    @property
+    def disable_new_dtags(self):
+        if platform.platform().lower() == 'macos':
+            return ''
+        return '--disable-new-dtags'
 
     # Cray PrgEnv name that can be used to load this compiler
     PrgEnv = None

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -234,6 +234,12 @@ class Compiler(object):
             return ''
         return '--disable-new-dtags'
 
+    @property
+    def enable_new_dtags(self):
+        if platform.platform().lower() == 'macos':
+            return ''
+        return '--enable-new-dtags'
+
     # Cray PrgEnv name that can be used to load this compiler
     PrgEnv = None
     # Name of module used to switch versions of this compiler

--- a/lib/spack/spack/compilers/nag.py
+++ b/lib/spack/spack/compilers/nag.py
@@ -54,3 +54,7 @@ class Nag(spack.compiler.Compiler):
     @property
     def fc_rpath_arg(self):
         return '-Wl,-Wl,,-rpath,,'
+
+    @property
+    def linker_arg(self):
+        return '-Wl,-Wl,,'

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -16,7 +16,10 @@ properties = {
         'type': 'object',
         'default': {},
         'properties': {
-            'rpath': {'type': 'boolean'},
+            'shared_linking': {
+                'type': 'string',
+                'enum': ['rpath', 'runpath']
+            },
             'install_tree': {'type': 'string'},
             'install_hash_length': {'type': 'integer', 'minimum': 1},
             'install_path_scheme': {'type': 'string'},

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -16,6 +16,7 @@ properties = {
         'type': 'object',
         'default': {},
         'properties': {
+            'rpath': {'type': 'boolean'},
             'install_tree': {'type': 'string'},
             'install_hash_length': {'type': 'integer', 'minimum': 1},
             'install_path_scheme': {'type': 'string'},

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -42,6 +42,8 @@ def build_environment(working_env):
     os.environ['SPACK_CXX_RPATH_ARG'] = "-Wl,-rpath,"
     os.environ['SPACK_F77_RPATH_ARG'] = "-Wl,-rpath,"
     os.environ['SPACK_FC_RPATH_ARG']  = "-Wl,-rpath,"
+    os.environ['SPACK_LINKER_ARG'] = '-Wl,'
+    os.environ['SPACK_DISABLE_NEW_DTAGS'] = '--disable-new-dtags'
     os.environ['SPACK_SYSTEM_DIRS'] = '/usr/include /usr/lib'
     os.environ['SPACK_TARGET_ARGS'] = ''
 

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import platform
+
 import pytest
 
 import spack.build_environment
@@ -313,7 +315,8 @@ def test_parallel_false_is_not_propagating(config, mock_packages):
 
 
 @pytest.mark.parametrize('config_setting,expected_flag', [
-    ('runpath', '--enable-new-dtags'), ('rpath', '--disable-new-dtags')
+    ('runpath', '' if platform.system() == 'Darwin' else '--enable-new-dtags'),
+    ('rpath', '' if platform.system() == 'Darwin' else '--disable-new-dtags'),
 ])
 def test_setting_dtags_based_on_config(
         config_setting, expected_flag, config, mock_packages

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -64,9 +64,11 @@ def test_static_to_shared_library(build_environment):
 
     expected = {
         'linux': ('/bin/mycc -shared'
+                  ' -Wl,--disable-new-dtags'
                   ' -Wl,-soname,{2} -Wl,--whole-archive {0}'
                   ' -Wl,--no-whole-archive -o {1}'),
         'darwin': ('/bin/mycc -dynamiclib'
+                   ' -Wl,--disable-new-dtags'
                    ' -install_name {1} -Wl,-force_load,{0} -o {1}')
     }
 

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -43,8 +43,8 @@ def build_environment(working_env):
     os.environ['SPACK_F77_RPATH_ARG'] = "-Wl,-rpath,"
     os.environ['SPACK_FC_RPATH_ARG']  = "-Wl,-rpath,"
     os.environ['SPACK_LINKER_ARG'] = '-Wl,'
-    os.environ['SPACK_DTAGS_TO_ENABLE'] = '--disable-new-dtags'
-    os.environ['SPACK_DTAGS_TO_DISABLE'] = '--enable-new-dtags'
+    os.environ['SPACK_DTAGS_TO_ADD'] = '--disable-new-dtags'
+    os.environ['SPACK_DTAGS_TO_STRIP'] = '--enable-new-dtags'
     os.environ['SPACK_SYSTEM_DIRS'] = '/usr/include /usr/lib'
     os.environ['SPACK_TARGET_ARGS'] = ''
 

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -43,7 +43,8 @@ def build_environment(working_env):
     os.environ['SPACK_F77_RPATH_ARG'] = "-Wl,-rpath,"
     os.environ['SPACK_FC_RPATH_ARG']  = "-Wl,-rpath,"
     os.environ['SPACK_LINKER_ARG'] = '-Wl,'
-    os.environ['SPACK_DISABLE_NEW_DTAGS'] = '--disable-new-dtags'
+    os.environ['SPACK_DTAGS_TO_ENABLE'] = '--disable-new-dtags'
+    os.environ['SPACK_DTAGS_TO_DISABLE'] = '--enable-new-dtags'
     os.environ['SPACK_SYSTEM_DIRS'] = '/usr/include /usr/lib'
     os.environ['SPACK_TARGET_ARGS'] = ''
 

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -103,7 +103,9 @@ def wrapper_environment():
             SPACK_LINK_DIRS=None,
             SPACK_INCLUDE_DIRS=None,
             SPACK_RPATH_DIRS=None,
-            SPACK_TARGET_ARGS=''):
+            SPACK_TARGET_ARGS='',
+            SPACK_LINKER_ARG='-Wl,',
+            SPACK_DISABLE_NEW_DTAGS='--disable-new-dtags'):
         yield
 
 
@@ -176,10 +178,11 @@ def test_ld_mode():
 def test_ld_flags(wrapper_flags):
     check_args(
         ld, test_args,
-        ['ld', '-Wl,--disable-new-dtags'] +
+        ['ld'] +
         spack_ldflags +
         test_include_paths +
         test_library_paths +
+        ['--disable-new-dtags'] +
         test_rpaths +
         test_args_without_paths +
         spack_ldlibs)
@@ -200,10 +203,11 @@ def test_cc_flags(wrapper_flags):
         cc, test_args,
         [real_cc] +
         spack_cppflags +
-        spack_cflags + ['-Wl,--disable-new-dtags'] +
+        spack_cflags +
         spack_ldflags +
         test_include_paths +
         test_library_paths +
+        ['-Wl,--disable-new-dtags'] +
         test_wl_rpaths +
         test_args_without_paths +
         spack_ldlibs)
@@ -214,10 +218,11 @@ def test_cxx_flags(wrapper_flags):
         cxx, test_args,
         [real_cc] +
         spack_cppflags +
-        spack_cxxflags + ['-Wl,--disable-new-dtags'] +
+        spack_cxxflags +
         spack_ldflags +
         test_include_paths +
         test_library_paths +
+        ['-Wl,--disable-new-dtags'] +
         test_wl_rpaths +
         test_args_without_paths +
         spack_ldlibs)
@@ -228,10 +233,11 @@ def test_fc_flags(wrapper_flags):
         fc, test_args,
         [real_cc] +
         spack_fflags +
-        spack_cppflags + ['-Wl,--disable-new-dtags'] +
+        spack_cppflags +
         spack_ldflags +
         test_include_paths +
         test_library_paths +
+        ['-Wl,--disable-new-dtags'] +
         test_wl_rpaths +
         test_args_without_paths +
         spack_ldlibs)
@@ -241,9 +247,10 @@ def test_dep_rpath():
     """Ensure RPATHs for root package are added."""
     check_args(
         cc, test_args,
-        [real_cc, '-Wl,--disable-new-dtags'] +
+        [real_cc] +
         test_include_paths +
         test_library_paths +
+        ['-Wl,--disable-new-dtags'] +
         test_wl_rpaths +
         test_args_without_paths)
 
@@ -253,10 +260,11 @@ def test_dep_include():
     with set_env(SPACK_INCLUDE_DIRS='x'):
         check_args(
             cc, test_args,
-            [real_cc, '-Wl,--disable-new-dtags'] +
+            [real_cc] +
             test_include_paths +
             ['-Ix'] +
             test_library_paths +
+            ['-Wl,--disable-new-dtags'] +
             test_wl_rpaths +
             test_args_without_paths)
 
@@ -267,10 +275,11 @@ def test_dep_lib():
                  SPACK_RPATH_DIRS='x'):
         check_args(
             cc, test_args,
-            [real_cc, '-Wl,--disable-new-dtags'] +
+            [real_cc] +
             test_include_paths +
             test_library_paths +
             ['-Lx'] +
+            ['-Wl,--disable-new-dtags'] +
             test_wl_rpaths +
             ['-Wl,-rpath,x'] +
             test_args_without_paths)
@@ -281,10 +290,11 @@ def test_dep_lib_no_rpath():
     with set_env(SPACK_LINK_DIRS='x'):
         check_args(
             cc, test_args,
-            [real_cc, '-Wl,--disable-new-dtags'] +
+            [real_cc] +
             test_include_paths +
             test_library_paths +
             ['-Lx'] +
+            ['-Wl,--disable-new-dtags'] +
             test_wl_rpaths +
             test_args_without_paths)
 
@@ -294,9 +304,10 @@ def test_dep_lib_no_lib():
     with set_env(SPACK_RPATH_DIRS='x'):
         check_args(
             cc, test_args,
-            [real_cc, '-Wl,--disable-new-dtags'] +
+            [real_cc] +
             test_include_paths +
             test_library_paths +
+            ['-Wl,--disable-new-dtags'] +
             test_wl_rpaths +
             ['-Wl,-rpath,x'] +
             test_args_without_paths)
@@ -309,7 +320,7 @@ def test_ccld_deps():
                  SPACK_LINK_DIRS='xlib:ylib:zlib'):
         check_args(
             cc, test_args,
-            [real_cc, '-Wl,--disable-new-dtags'] +
+            [real_cc] +
             test_include_paths +
             ['-Ixinc',
              '-Iyinc',
@@ -318,6 +329,7 @@ def test_ccld_deps():
             ['-Lxlib',
              '-Lylib',
              '-Lzlib'] +
+            ['-Wl,--disable-new-dtags'] +
             test_wl_rpaths +
             ['-Wl,-rpath,xlib',
              '-Wl,-rpath,ylib',
@@ -355,7 +367,7 @@ def test_ccld_with_system_dirs():
                          '-L/lib64/']
         check_args(
             cc, sys_path_args + test_args,
-            [real_cc, '-Wl,--disable-new-dtags'] +
+            [real_cc] +
             test_include_paths +
             ['-Ixinc',
              '-Iyinc',
@@ -368,6 +380,7 @@ def test_ccld_with_system_dirs():
              '-Lzlib'] +
             ['-L/usr/local/lib',
              '-L/lib64/'] +
+            ['-Wl,--disable-new-dtags'] +
             test_wl_rpaths +
             ['-Wl,-rpath,xlib',
              '-Wl,-rpath,ylib',
@@ -383,12 +396,13 @@ def test_ld_deps():
                  SPACK_LINK_DIRS='xlib:ylib:zlib'):
         check_args(
             ld, test_args,
-            ['ld', '-Wl,--disable-new-dtags'] +
+            ['ld'] +
             test_include_paths +
             test_library_paths +
             ['-Lxlib',
              '-Lylib',
              '-Lzlib'] +
+            ['--disable-new-dtags'] +
             test_rpaths +
             ['-rpath', 'xlib',
              '-rpath', 'ylib',
@@ -402,12 +416,13 @@ def test_ld_deps_no_rpath():
                  SPACK_LINK_DIRS='xlib:ylib:zlib'):
         check_args(
             ld, test_args,
-            ['ld', '-Wl,--disable-new-dtags'] +
+            ['ld'] +
             test_include_paths +
             test_library_paths +
             ['-Lxlib',
              '-Lylib',
              '-Lzlib'] +
+            ['--disable-new-dtags'] +
             test_rpaths +
             test_args_without_paths)
 
@@ -418,9 +433,10 @@ def test_ld_deps_no_link():
                  SPACK_RPATH_DIRS='xlib:ylib:zlib'):
         check_args(
             ld, test_args,
-            ['ld', '-Wl,--disable-new-dtags'] +
+            ['ld'] +
             test_include_paths +
             test_library_paths +
+            ['--disable-new-dtags'] +
             test_rpaths +
             ['-rpath', 'xlib',
              '-rpath', 'ylib',
@@ -440,10 +456,11 @@ def test_ld_deps_partial():
         os.environ['SPACK_SHORT_SPEC'] = "foo@1.2=linux-x86_64"
         check_args(
             ld, ['-r'] + test_args,
-            ['ld', '-Wl,--disable-new-dtags'] +
+            ['ld'] +
             test_include_paths +
             test_library_paths +
             ['-Lxlib'] +
+            ['--disable-new-dtags'] +
             test_rpaths +
             ['-rpath', 'xlib'] +
             ['-r'] +
@@ -454,11 +471,12 @@ def test_ld_deps_partial():
         os.environ['SPACK_SHORT_SPEC'] = "foo@1.2=darwin-x86_64"
         check_args(
             ld, ['-r'] + test_args,
-            ['ld', '-Wl,--disable-new-dtags'] +
+            ['ld'] +
             headerpad +
             test_include_paths +
             test_library_paths +
             ['-Lxlib'] +
+            ['--disable-new-dtags'] +
             test_rpaths +
             ['-r'] +
             test_args_without_paths)
@@ -479,10 +497,11 @@ def test_ccache_prepend_for_cc():
         check_args(
             cc, test_args,
             ['ccache'] +  # ccache prepended in cc mode
-            [real_cc, '-Wl,--disable-new-dtags'] +
+            [real_cc] +
             lheaderpad +
             test_include_paths +
             test_library_paths +
+            ['-Wl,--disable-new-dtags'] +
             test_wl_rpaths +
             test_args_without_paths)
 
@@ -501,10 +520,11 @@ def test_no_ccache_prepend_for_fc():
     check_args(
         fc, test_args,
         # no ccache for Fortran
-        [real_cc, '-Wl,--disable-new-dtags'] +
+        [real_cc] +
         lheaderpad +
         test_include_paths +
         test_library_paths +
+        ['-Wl,--disable-new-dtags'] +
         test_wl_rpaths +
         test_args_without_paths)
 
@@ -513,4 +533,6 @@ def test_no_ccache_prepend_for_fc():
 def test_disable_new_dtags(wrapper_flags):
     with set_env(SPACK_TEST_COMMAND='dump-args'):
         result = ld(*test_args, output=str).strip().split('\n')
+        assert '--disable-new-dtags' in result
+        result = cc(*test_args, output=str).strip().split('\n')
         assert '-Wl,--disable-new-dtags' in result

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -536,3 +536,15 @@ def test_disable_new_dtags(wrapper_flags):
         assert '--disable-new-dtags' in result
         result = cc(*test_args, output=str).strip().split('\n')
         assert '-Wl,--disable-new-dtags' in result
+
+
+@pytest.mark.regression('9160')
+def test_filter_enable_new_dtags(wrapper_flags):
+    with set_env(SPACK_TEST_COMMAND='dump-args'):
+        result = ld(*(test_args + ['--enable-new-dtags']), output=str)
+        result = result.strip().split('\n')
+        assert '--enable-new-dtags' not in result
+
+        result = cc(*(test_args + ['-Wl,--enable-new-dtags']), output=str)
+        result = result.strip().split('\n')
+        assert '-Wl,--enable-new-dtags' not in result

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -105,8 +105,8 @@ def wrapper_environment():
             SPACK_RPATH_DIRS=None,
             SPACK_TARGET_ARGS='',
             SPACK_LINKER_ARG='-Wl,',
-            SPACK_DTAGS_TO_ENABLE='--disable-new-dtags',
-            SPACK_DTAGS_TO_DISABLE='--enable-new-dtags'):
+            SPACK_DTAGS_TO_ADD='--disable-new-dtags',
+            SPACK_DTAGS_TO_STRIP='--enable-new-dtags'):
         yield
 
 

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -105,7 +105,8 @@ def wrapper_environment():
             SPACK_RPATH_DIRS=None,
             SPACK_TARGET_ARGS='',
             SPACK_LINKER_ARG='-Wl,',
-            SPACK_DISABLE_NEW_DTAGS='--disable-new-dtags'):
+            SPACK_DTAGS_TO_ENABLE='--disable-new-dtags',
+            SPACK_DTAGS_TO_DISABLE='--enable-new-dtags'):
         yield
 
 
@@ -488,9 +489,10 @@ def test_ccache_prepend_for_cc():
         check_args(
             cc, test_args,
             ['ccache'] +  # ccache prepended in cc mode
-            [real_cc, '-Wl,--disable-new-dtags'] +
+            [real_cc] +
             test_include_paths +
             test_library_paths +
+            ['-Wl,--disable-new-dtags'] +
             test_wl_rpaths +
             test_args_without_paths)
         os.environ['SPACK_SHORT_SPEC'] = "foo@1.2=darwin-x86_64"
@@ -511,9 +513,10 @@ def test_no_ccache_prepend_for_fc():
     check_args(
         fc, test_args,
         # no ccache for Fortran
-        [real_cc, '-Wl,--disable-new-dtags'] +
+        [real_cc] +
         test_include_paths +
         test_library_paths +
+        ['-Wl,--disable-new-dtags'] +
         test_wl_rpaths +
         test_args_without_paths)
     os.environ['SPACK_SHORT_SPEC'] = "foo@1.2=darwin-x86_64"

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -176,7 +176,7 @@ def test_ld_mode():
 def test_ld_flags(wrapper_flags):
     check_args(
         ld, test_args,
-        ['ld'] +
+        ['ld', '-Wl,--disable-new-dtags'] +
         spack_ldflags +
         test_include_paths +
         test_library_paths +
@@ -200,7 +200,7 @@ def test_cc_flags(wrapper_flags):
         cc, test_args,
         [real_cc] +
         spack_cppflags +
-        spack_cflags +
+        spack_cflags + ['-Wl,--disable-new-dtags'] +
         spack_ldflags +
         test_include_paths +
         test_library_paths +
@@ -214,7 +214,7 @@ def test_cxx_flags(wrapper_flags):
         cxx, test_args,
         [real_cc] +
         spack_cppflags +
-        spack_cxxflags +
+        spack_cxxflags + ['-Wl,--disable-new-dtags'] +
         spack_ldflags +
         test_include_paths +
         test_library_paths +
@@ -228,7 +228,7 @@ def test_fc_flags(wrapper_flags):
         fc, test_args,
         [real_cc] +
         spack_fflags +
-        spack_cppflags +
+        spack_cppflags + ['-Wl,--disable-new-dtags'] +
         spack_ldflags +
         test_include_paths +
         test_library_paths +
@@ -241,7 +241,7 @@ def test_dep_rpath():
     """Ensure RPATHs for root package are added."""
     check_args(
         cc, test_args,
-        [real_cc] +
+        [real_cc, '-Wl,--disable-new-dtags'] +
         test_include_paths +
         test_library_paths +
         test_wl_rpaths +
@@ -253,7 +253,7 @@ def test_dep_include():
     with set_env(SPACK_INCLUDE_DIRS='x'):
         check_args(
             cc, test_args,
-            [real_cc] +
+            [real_cc, '-Wl,--disable-new-dtags'] +
             test_include_paths +
             ['-Ix'] +
             test_library_paths +
@@ -267,7 +267,7 @@ def test_dep_lib():
                  SPACK_RPATH_DIRS='x'):
         check_args(
             cc, test_args,
-            [real_cc] +
+            [real_cc, '-Wl,--disable-new-dtags'] +
             test_include_paths +
             test_library_paths +
             ['-Lx'] +
@@ -281,7 +281,7 @@ def test_dep_lib_no_rpath():
     with set_env(SPACK_LINK_DIRS='x'):
         check_args(
             cc, test_args,
-            [real_cc] +
+            [real_cc, '-Wl,--disable-new-dtags'] +
             test_include_paths +
             test_library_paths +
             ['-Lx'] +
@@ -294,7 +294,7 @@ def test_dep_lib_no_lib():
     with set_env(SPACK_RPATH_DIRS='x'):
         check_args(
             cc, test_args,
-            [real_cc] +
+            [real_cc, '-Wl,--disable-new-dtags'] +
             test_include_paths +
             test_library_paths +
             test_wl_rpaths +
@@ -309,7 +309,7 @@ def test_ccld_deps():
                  SPACK_LINK_DIRS='xlib:ylib:zlib'):
         check_args(
             cc, test_args,
-            [real_cc] +
+            [real_cc, '-Wl,--disable-new-dtags'] +
             test_include_paths +
             ['-Ixinc',
              '-Iyinc',
@@ -355,7 +355,7 @@ def test_ccld_with_system_dirs():
                          '-L/lib64/']
         check_args(
             cc, sys_path_args + test_args,
-            [real_cc] +
+            [real_cc, '-Wl,--disable-new-dtags'] +
             test_include_paths +
             ['-Ixinc',
              '-Iyinc',
@@ -383,7 +383,7 @@ def test_ld_deps():
                  SPACK_LINK_DIRS='xlib:ylib:zlib'):
         check_args(
             ld, test_args,
-            ['ld'] +
+            ['ld', '-Wl,--disable-new-dtags'] +
             test_include_paths +
             test_library_paths +
             ['-Lxlib',
@@ -402,7 +402,7 @@ def test_ld_deps_no_rpath():
                  SPACK_LINK_DIRS='xlib:ylib:zlib'):
         check_args(
             ld, test_args,
-            ['ld'] +
+            ['ld', '-Wl,--disable-new-dtags'] +
             test_include_paths +
             test_library_paths +
             ['-Lxlib',
@@ -418,7 +418,7 @@ def test_ld_deps_no_link():
                  SPACK_RPATH_DIRS='xlib:ylib:zlib'):
         check_args(
             ld, test_args,
-            ['ld'] +
+            ['ld', '-Wl,--disable-new-dtags'] +
             test_include_paths +
             test_library_paths +
             test_rpaths +
@@ -440,7 +440,7 @@ def test_ld_deps_partial():
         os.environ['SPACK_SHORT_SPEC'] = "foo@1.2=linux-x86_64"
         check_args(
             ld, ['-r'] + test_args,
-            ['ld'] +
+            ['ld', '-Wl,--disable-new-dtags'] +
             test_include_paths +
             test_library_paths +
             ['-Lxlib'] +
@@ -454,7 +454,7 @@ def test_ld_deps_partial():
         os.environ['SPACK_SHORT_SPEC'] = "foo@1.2=darwin-x86_64"
         check_args(
             ld, ['-r'] + test_args,
-            ['ld'] +
+            ['ld', '-Wl,--disable-new-dtags'] +
             headerpad +
             test_include_paths +
             test_library_paths +
@@ -470,7 +470,7 @@ def test_ccache_prepend_for_cc():
         check_args(
             cc, test_args,
             ['ccache'] +  # ccache prepended in cc mode
-            [real_cc] +
+            [real_cc, '-Wl,--disable-new-dtags'] +
             test_include_paths +
             test_library_paths +
             test_wl_rpaths +
@@ -479,7 +479,7 @@ def test_ccache_prepend_for_cc():
         check_args(
             cc, test_args,
             ['ccache'] +  # ccache prepended in cc mode
-            [real_cc] +
+            [real_cc, '-Wl,--disable-new-dtags'] +
             lheaderpad +
             test_include_paths +
             test_library_paths +
@@ -492,7 +492,7 @@ def test_no_ccache_prepend_for_fc():
     check_args(
         fc, test_args,
         # no ccache for Fortran
-        [real_cc] +
+        [real_cc, '-Wl,--disable-new-dtags'] +
         test_include_paths +
         test_library_paths +
         test_wl_rpaths +
@@ -501,9 +501,16 @@ def test_no_ccache_prepend_for_fc():
     check_args(
         fc, test_args,
         # no ccache for Fortran
-        [real_cc] +
+        [real_cc, '-Wl,--disable-new-dtags'] +
         lheaderpad +
         test_include_paths +
         test_library_paths +
         test_wl_rpaths +
         test_args_without_paths)
+
+
+@pytest.mark.regression('9160')
+def test_disable_new_dtags(wrapper_flags):
+    with set_env(SPACK_TEST_COMMAND='dump-args'):
+        result = ld(*test_args, output=str).strip().split('\n')
+        assert '-Wl,--disable-new-dtags' in result


### PR DESCRIPTION
fixes #9160 
fixes #909 
fixes #639

This PR adds a new entry in `config.yaml`:
```yaml
config:
   shared_linking: 'rpath'
```
If this variable is set to `rpath` (the default) Spack will set RPATH in ELF binaries. If set to `runpath` it will set RUNPATH.