### PR TITLE
openPMD-api: ^py-numpy@1.15+

### DIFF
--- a/var/spack/repos/builtin/packages/openpmd-api/package.py
+++ b/var/spack/repos/builtin/packages/openpmd-api/package.py
@@ -63,7 +63,7 @@ class OpenpmdApi(CMakePackage):
     depends_on('adios2@2.1.0: +mpi', when='+mpi +adios2')
     # ideally we want 2.3.0+ for full C++11 CT function signature support
     depends_on('py-pybind11@2.2.3:', when='+python')
-    depends_on('py-numpy', when='+python', type=['test', 'run'])
+    depends_on('py-numpy@1.15.1:', when='+python', type=['test', 'run'])
 
     extends('python', when='+python')
 


### PR DESCRIPTION
Due to an internal bug regarding the handling of scalars (ndim must be 0) in numpy prior to 1.15.0, openPMD-api will require the latest numpy 1.15+.

Since there is a small regression with datetime pickling in 1.15.0 from the required fix and spack only packages 1.15.1 currently, we depend on 1.15.1 in the recipe.