### PR TITLE
Add f18 package

### DIFF
--- a/var/spack/repos/builtin/packages/f18/package.py
+++ b/var/spack/repos/builtin/packages/f18/package.py
@@ -37,3 +37,7 @@ class F18(CMakePackage):
     version('develop', branch='master')
 
     depends_on('llvm@6.0.0+clang', when='@develop')
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        install("tools/f18/f18", prefix.bin)

--- a/var/spack/repos/builtin/packages/f18/package.py
+++ b/var/spack/repos/builtin/packages/f18/package.py
@@ -24,13 +24,11 @@
 ##############################################################################
 
 from spack import *
-import os
 
 
 class F18(CMakePackage):
     """F18 is a front-end for Fortran intended to replace the existing front-end
     in the Flang compiler"""
-
 
     homepage = "https://github.com/flang-compiler/f18"
 

--- a/var/spack/repos/builtin/packages/f18/package.py
+++ b/var/spack/repos/builtin/packages/f18/package.py
@@ -40,4 +40,4 @@ class F18(CMakePackage):
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
-        install("tools/f18/f18", prefix.bin)
+        install("spack-build/tools/f18/f18", prefix.bin)

--- a/var/spack/repos/builtin/packages/f18/package.py
+++ b/var/spack/repos/builtin/packages/f18/package.py
@@ -1,0 +1,41 @@
+##############################################################################
+# Copyright (c) 2017, Los Alamos National Security, LLC
+# Produced at the Los Alamos National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
+from spack import *
+import os
+
+
+class F18(CMakePackage):
+    """F18 is a front-end for Fortran intended to replace the existing front-end
+    in the Flang compiler"""
+
+
+    homepage = "https://github.com/flang-compiler/f18"
+
+    git      = "https://github.com/flang-compiler/f18"
+
+    version('develop', branch='master')
+
+    depends_on('llvm@6.0.0+clang', when='@develop')

--- a/var/spack/repos/builtin/packages/f18/package.py
+++ b/var/spack/repos/builtin/packages/f18/package.py
@@ -1,27 +1,7 @@
-##############################################################################
-# Copyright (c) 2017, Los Alamos National Security, LLC
-# Produced at the Los Alamos National Laboratory.
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
-# This file is part of Spack.
-# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
-# LLNL-CODE-647188
-#
-# For details, see https://github.com/spack/spack
-# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License (as
-# published by the Free Software Foundation) version 2.1, February 1999.
-#
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
-# conditions of the GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public
-# License along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-##############################################################################
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
 


### PR DESCRIPTION
The package builds, but fails to install, since `make install` is not implemented:
```
==> Executing phase: 'install'
==> 'make' '-j4' 'install'
make: *** No rule to make target 'install'.  Stop.
==> Error: ProcessError: Command exited with status 2:
    'make' '-j4' 'install'

1 error found in build log:
     300    make[2]: Leaving directory '/home/certik/tmp/spack-stage/spack-stag
            e-qO1Uea/f18/spack-build'
     301    [100%] Built target f18
     302    make[1]: Leaving directory '/home/certik/tmp/spack-stage/spack-stag
            e-qO1Uea/f18/spack-build'
     303    /home/certik/repos/spack/opt/spack/linux-ubuntu16.04-x86_64/gcc-7.2
            .0/cmake-3.12.1-dclg53ocmggeudruqobureixod4ohaeb/bin/cmake -E cmake
            _progress_start /home/certik/tmp/spack-stage/spack-stage-qO1Uea/f18
            /spack-build/CMakeFiles 0
     304    ==> Executing phase: 'install'
     305    ==> 'make' '-j4' 'install'
  >> 306    make: *** No rule to make target 'install'.  Stop.
```

The binary is in `spack-build/tools/f18/f18` and that needs to be copied into the installation directory by hand.