### PR TITLE
trilinos: disable xlf_tpetra.patch for trilinos@develop

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -314,9 +314,9 @@ class Trilinos(CMakePackage):
     patch('xlf_seacas.patch', when='@12.10.1:12.12.1 %xl')
     patch('xlf_seacas.patch', when='@12.10.1:12.12.1 %xl_r')
     patch('xlf_seacas.patch', when='@12.10.1:12.12.1 %clang')
-    patch('xlf_tpetra.patch', when='@12.12.1:%xl')
-    patch('xlf_tpetra.patch', when='@12.12.1:%xl_r')
-    patch('xlf_tpetra.patch', when='@12.12.1:%clang')
+    patch('xlf_tpetra.patch', when='@12.12.1%xl')
+    patch('xlf_tpetra.patch', when='@12.12.1%xl_r')
+    patch('xlf_tpetra.patch', when='@12.12.1%clang')
 
     def url_for_version(self, version):
         url = "https://github.com/trilinos/Trilinos/archive/trilinos-release-{0}.tar.gz"


### PR DESCRIPTION
This patch does not apply cleanly anymore and breaks clang/Mac builds
```
balay@asterix /home/balay/git-repo/github/trilinos (develop=)
$ patch -Np1 < /home/balay/git-repo/github/spack/var/spack/repos/builtin/packages/trilinos/xlf_tpetra.patch
can't find file to patch at input line 3
Perhaps you used the wrong -p or --strip option?
The text leading up to this was:
--------------------------
|--- a/packages/tpetra/core/src/Tpetra_Details_libGemm.cpp
|+++ b/packages/tpetra/core/src/Tpetra_Details_libGemm.cpp
--------------------------
File to patch:
```

cc: @jwillenbring @keitat

This was previously changed at 54aab585c4 so cc: @djfitzgerald
