### PR TITLE
Add Gaudi and RELAX packages

### DIFF
--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -1,0 +1,68 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Gaudi(CMakePackage):
+    """An experiment-independent HEP event data processing framework"""
+
+    homepage = "http://gaudi.web.cern.ch/gaudi/"
+    git      = "https://gitlab.cern.ch/gaudi/Gaudi.git"
+
+    version('develop', branch='master')
+    version('30.5',    commit='2c70e73ee5b543b26197b90dd59ea4e4d359d230')
+
+    patch('use-xenv-master.diff')
+
+    variant('tests', default=False,
+            description='Prepare to run the test suite')
+    variant('optional', default=False,
+            description='Build most optional components')
+    variant('vtune', default=False,
+            description='Build with Intel VTune profiler support')
+
+    # These dependencies are needed for a minimal Gaudi build
+    depends_on('boost@1.67.0: +python')
+    depends_on('cmake', type='build')
+    depends_on('intel-tbb')
+    depends_on('libuuid')
+    depends_on('python@:2.99.99')
+    depends_on('range-v3')
+    depends_on('root +python +root7 +ssl +tbb +threads')
+    depends_on('zlib')
+
+    # These dependencies are required by the Gaudi test suite
+    depends_on('aida', when='+tests')
+    depends_on('clhep', when='+tests')
+    depends_on('cppunit', when='+tests')
+    depends_on('gdb', when='+tests')
+    depends_on('gperftools', when='+tests')
+    depends_on('heppdt@:2.99.99', when='+tests')
+    depends_on('py-networkx', when='+tests')
+    depends_on('py-nose', when='+tests')
+    depends_on('py-setuptools', when='+tests')
+    depends_on('relax', when='+tests')
+    depends_on('xerces-c', when='+tests')
+
+    # Adding these dependencies triggers the build of most optional components
+    depends_on('aida', when='+optional')
+    depends_on('clhep', when='+optional')
+    depends_on('cppgsl', when='+optional')
+    depends_on('cppunit', when='+optional')
+    depends_on('doxygen +graphviz', when='+optional')
+    depends_on('gperftools', when='+optional')
+    depends_on('gsl', when='+optional')
+    depends_on('heppdt@:2.99.99', when='+optional')
+    depends_on('jemalloc', when='+optional')
+    depends_on('libpng', when='+optional')
+    depends_on('libunwind', when='+optional')
+    depends_on('relax', when='+optional')
+    depends_on('xerces-c', when='+optional')
+    # NOTE: pocl cannot be added as a minimal OpenCL implementation because
+    #       ROOT does not like being exposed to LLVM symbols.
+
+    # The Intel VTune dependency is taken aside because it requires a license
+    depends_on('intel-parallel-studio -mpi +vtune', when='+vtune')

--- a/var/spack/repos/builtin/packages/gaudi/use-xenv-master.diff
+++ b/var/spack/repos/builtin/packages/gaudi/use-xenv-master.diff
@@ -1,0 +1,13 @@
+diff --git a/cmake/GaudiProjectConfig.cmake b/cmake/GaudiProjectConfig.cmake
+index ab1a24e1d..dc938da79 100644
+--- a/cmake/GaudiProjectConfig.cmake
++++ b/cmake/GaudiProjectConfig.cmake
+@@ -410,7 +410,7 @@ macro(gaudi_project project version)
+       # Avoid interference from user environment
+       unset(ENV{GIT_DIR})
+       unset(ENV{GIT_WORK_TREE})
+-      execute_process(COMMAND git clone -b 0.0.1 https://gitlab.cern.ch/gaudi/xenv.git ${CMAKE_BINARY_DIR}/contrib/xenv)
++      execute_process(COMMAND git clone https://gitlab.cern.ch/gaudi/xenv.git ${CMAKE_BINARY_DIR}/contrib/xenv)
+     endif()
+     # I'd like to generate the script with executable permission, but I only
+     # found this workaround: https://stackoverflow.com/a/45515418

--- a/var/spack/repos/builtin/packages/relax/package.py
+++ b/var/spack/repos/builtin/packages/relax/package.py
@@ -1,0 +1,37 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Relax(CMakePackage):
+    """A set of Reflex libraries for the most common used general data types in
+       the LHC Computing Grid"""
+
+    homepage = "https://twiki.cern.ch/twiki/bin/view/LCG/RELAX"
+    url      = "http://lcgpackages.web.cern.ch/lcgpackages/tarFiles/sources/RELAX-1.tar.gz"
+
+    # The RELAX project stopped using a fixed release model since it moved to
+    # ROOT 6, so any package checksum is a lie...
+    version('root6')
+
+    depends_on('clhep')
+    depends_on('gsl')
+    depends_on('hepmc@:2.99.99')
+    depends_on('root@6.0.0:')
+
+    def cmake_args(self):
+        spec = self.spec
+        cxxstd = self.spec['root'].variants['cxxstd'].value
+        hepmc_lib = spec['hepmc'].prefix.lib.join('libHepMC.so')
+
+        args = [
+            '-DCMAKE_CXX_STANDARD={0}'.format(cxxstd),
+            '-DROOT_BINARY_PATH={0}'.format(spec['root'].prefix.bin),
+            '-DHEPMC_INCLUDE_DIR={0}'.format(spec['hepmc'].prefix.include),
+            '-DHEPMC_LIBRARIES={0}'.format(hepmc_lib)
+        ]
+
+        return args


### PR DESCRIPTION
This MR introduces a package for the Gaudi HEP data processing framework, used by the LHCb and ATLAS experiments among other projects.

Gaudi also depends on RELAX, a set of ROOT dictionaries for typical HEP libraries. Since I know of no other package that depend on RELAX, I decided to bundle the two in this MR in order to save administrative/review work, but I can separate the two submissions if you think that is useful.

There is a small part of the RELAX package which I'm not very proud of, so I will highlight it in the MR thread and let you decide if there is a better way to do this.