### PR TITLE
py-espresso: apply patch to v4.0.0 only

### DIFF
--- a/var/spack/repos/builtin/packages/py-espresso/package.py
+++ b/var/spack/repos/builtin/packages/py-espresso/package.py
@@ -44,8 +44,8 @@ class PyEspresso(CMakePackage):
     version('develop', branch='python')
     version('4.0.0', sha256='8e128847447eebd843de24be9b4ad14aa19c028ae48879a5a4535a9683836e6b')
 
-    # https://github.com/espressomd/espresso/pull/2244
-    patch('2244.patch')
+    # espressomd/espresso#2244 merge upstream
+    patch('2244.patch', when="@4.0.0")
 
     depends_on("cmake@3.0:", type='build')
     depends_on("mpi")


### PR DESCRIPTION
/cc @KaiSzuttor

See https://github.com/espressomd/espresso/pull/2244