### PR TITLE
petsc: fix compilation with intel

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -240,8 +240,8 @@ class Petsc(Package):
         else:
             options.append('--with-clanguage=C')
 
-        # Help PETSc pick up Scalapack from MKL
-        # 'satisfies' is used to only pick up scalapack when needed
+        # PETSc depends on scalapack when '+mumps+mpi~int64' (see depends())
+        # help PETSc pick up Scalapack from MKL
         if spec.satisfies('+mumps+mpi~int64'):
             scalapack = spec['scalapack'].libs
             options.extend([

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -189,19 +189,9 @@ class Petsc(Package):
                 '--with-fc=%s' % self.spec['mpi'].mpifc,
             ]
             if self.spec.satisfies('%intel'):
-                # "Inspired" by what is done in the elemental package
-                # ifort doesn't automatically link all run-time libraries
-                ifort = env['SPACK_F77']
-                intel_bin = os.path.dirname(ifort)
-                intel_lib_root = os.path.join(
-                    intel_bin, '..', '..', 'compiler', 'lib')
-                libfortran = find_libraries([
-                    'libifport', 'libifcoremt', 'libimf', 'libsvml',
-                    'libipgo', 'libintlc', 'libpthread'
-                ], root=intel_lib_root, recursive=True)
-                compiler_opts.append(
-                    '--FC_LINKER_FLAGS={0}'.format(libfortran.ld_flags)
-                )
+                # mpiifort needs some help to automatically link
+                # all necessary run-time libraries
+                compiler_opts.append('--FC_LINKER_FLAGS=-lintlc')
         return compiler_opts
 
     def install(self, spec, prefix):


### PR DESCRIPTION
* mpiifort doesn't automatically link all run-time libraries
* scalapack was being picked up accidentaly if intel-mkl was in the spec

(With help from @nrichart)

Signed-off-by: Ricardo Silva <ricardo.silva@epfl.ch>