### PR TITLE
Allow `spack install --overwrite` for nonexistent or multiple packages

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -313,7 +313,7 @@ def install(parser, args, **kwargs):
                     tty.die('Reinstallation aborted.')
 
             for abstract, concrete in zip(abstract_specs, specs):
-                if installed:
+                if concrete in installed:
                     with fs.replace_directory_transaction(concrete.prefix):
                         install_spec(args, kwargs, abstract, concrete)
                 else:

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -283,36 +283,40 @@ def install(parser, args, **kwargs):
     reporter.specs = specs
     with reporter:
         if args.overwrite:
-            # If we asked to overwrite an existing spec we must ensure that:
-            # 1. We have only one spec
-            # 2. The spec is already installed
-            assert len(specs) == 1, \
-                "only one spec is allowed when overwriting an installation"
 
-            spec = specs[0]
-            t = spack.store.db.query(spec)
-            assert len(t) == 1, "to overwrite a spec you must install it first"
-
-            # Give the user a last chance to think about overwriting an already
-            # existing installation
+            installed = filter(lambda x: x,
+                               map(spack.store.db.query_one, specs))
             if not args.yes_to_all:
-                tty.msg('The following package will be reinstalled:\n')
-
                 display_args = {
                     'long': True,
                     'show_flags': True,
                     'variants': True
                 }
 
-                spack.cmd.display_specs(t, **display_args)
+                if installed:
+                    tty.msg('The following package specs will be reinstalled:\n')
+                    spack.cmd.display_specs(installed, **display_args)
+
+                not_installed = filter(lambda x: x not in installed, specs)
+                if not_installed:
+                    tty.msg('The following package specs are not installed and'
+                            ' the --overwrite flag was given. The package spec'
+                            ' will be newly installed.')
+                    spack.cmd.display_specs(not_installed, **display_args)
+
+                # We have some specs, so one of the above must have been true
                 answer = tty.get_yes_or_no(
                     'Do you want to proceed?', default=False
                 )
                 if not answer:
                     tty.die('Reinstallation aborted.')
 
-            with fs.replace_directory_transaction(specs[0].prefix):
-                install_spec(args, kwargs, abstract_specs[0], specs[0])
+            for abstract, concrete in zip(abstract_specs, specs):
+                if installed:
+                    with fs.replace_directory_transaction(concrete.prefix):
+                        install_spec(args, kwargs, abstract, concrete)
+                else:
+                    install_spec(args, kwargs, abstract, concrete)
 
         else:
             for abstract, concrete in zip(abstract_specs, specs):

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -294,14 +294,15 @@ def install(parser, args, **kwargs):
                 }
 
                 if installed:
-                    tty.msg('The following package specs will be reinstalled:\n')
+                    tty.msg('The following package specs will be '
+                            'reinstalled:\n')
                     spack.cmd.display_specs(installed, **display_args)
 
                 not_installed = filter(lambda x: x not in installed, specs)
                 if not_installed:
                     tty.msg('The following package specs are not installed and'
                             ' the --overwrite flag was given. The package spec'
-                            ' will be newly installed.')
+                            ' will be newly installed:\n')
                     spack.cmd.display_specs(not_installed, **display_args)
 
                 # We have some specs, so one of the above must have been true

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -284,8 +284,8 @@ def install(parser, args, **kwargs):
     with reporter:
         if args.overwrite:
 
-            installed = filter(lambda x: x,
-                               map(spack.store.db.query_one, specs))
+            installed = list(filter(lambda x: x,
+                                    map(spack.store.db.query_one, specs)))
             if not args.yes_to_all:
                 display_args = {
                     'long': True,
@@ -298,7 +298,8 @@ def install(parser, args, **kwargs):
                             'reinstalled:\n')
                     spack.cmd.display_specs(installed, **display_args)
 
-                not_installed = filter(lambda x: x not in installed, specs)
+                not_installed = list(filter(lambda x: x not in installed,
+                                            specs))
                 if not_installed:
                     tty.msg('The following package specs are not installed and'
                             ' the --overwrite flag was given. The package spec'


### PR DESCRIPTION
Previously, the `--overwrite` flag to the `install` command required a single, previously installed spec.

Now, it can accept multiple specs.
Now, it can accept specs that are not already installed.

It will warn/prompt the user before installing a spec top-level spec that was not previously installed (can be suppressed with the `-y` option)