### PR TITLE
Updating amrvis to allow building with profiling support.

### DIFF
--- a/var/spack/repos/builtin/packages/amrvis/package.py
+++ b/var/spack/repos/builtin/packages/amrvis/package.py
@@ -50,8 +50,10 @@ class Amrvis(MakefilePackage):
         multi=False,
         description='Floating point precision'
     )
-    variant('mpi', default=True, description='Enable MPI parallel support')
+    variant('mpi', default=False, description='Enable MPI parallel support')
     variant('debug', default=False, description='Enable debugging features')
+    variant('profiling', default=False,
+            description='Enable AMReX profiling features')
 
     depends_on('gmake', type='build')
     depends_on('mpi', when='+mpi')
@@ -62,6 +64,17 @@ class Amrvis(MakefilePackage):
     depends_on('libxt')
     depends_on('libxext')
     depends_on('motif')
+    depends_on('flex')
+    depends_on('bison')
+
+    conflicts(
+        '+profiling', when='dims=1',
+        msg='Amrvis profiling support requires a 2D build'
+    )
+    conflicts(
+        '+profiling', when='dims=3',
+        msg='Amrvis profiling support requires a 2D build'
+    )
 
     # Only doing gcc and clang at the moment.
     # Intel currently fails searching for mpiicc, mpiicpc, etc.
@@ -81,7 +94,7 @@ class Amrvis(MakefilePackage):
         # Set all available makefile options to values we want
         makefile = FileFilter('GNUmakefile')
         makefile.filter(
-            r'^AMREX_HOME\s*=.*',
+            r'^AMREX_HOME\s*\?=.*',
             'AMREX_HOME = {0}'.format('./amrex')
         )
         makefile.filter(
@@ -94,15 +107,21 @@ class Amrvis(MakefilePackage):
         )
         makefile.filter(
             r'^PROFILE\s*=.*',
-            'PROFILE = FALSE'
+            'PROFILE = {0}'.format(
+                spec.variants['profiling'].value
+            ).upper()
         )
         makefile.filter(
             r'^TRACE_PROFILE\s*=.*',
-            'TRACE_PROFILE = FALSE'
+            'TRACE_PROFILE = {0}'.format(
+                spec.variants['profiling'].value
+            ).upper()
         )
         makefile.filter(
             r'^COMM_PROFILE\s*=.*',
-            'COMM_PROFILE = FALSE'
+            'COMM_PROFILE = {0}'.format(
+                spec.variants['profiling'].value
+            ).upper()
         )
         makefile.filter(
             r'^COMP\s*=.*',
@@ -134,7 +153,9 @@ class Amrvis(MakefilePackage):
         )
         makefile.filter(
             r'^USE_PROFPARSER\s*=.*',
-            'USE_PROFPARSER = FALSE'
+            'USE_PROFPARSER = {0}'.format(
+                spec.variants['profiling'].value
+            ).upper()
         )
 
         # A bit risky here deleting all /usr and /opt X
@@ -171,6 +192,8 @@ class Amrvis(MakefilePackage):
             file.writelines(contents)
 
     def setup_environment(self, spack_env, run_env):
+        # We don't want an AMREX_HOME the user may have set already
+        spack_env.unset('AMREX_HOME')
         # Help force Amrvis to not pick up random system compilers
         if '+mpi' in self.spec:
             spack_env.set('MPI_HOME', self.spec['mpi'].prefix)

--- a/var/spack/repos/builtin/packages/amrvis/package.py
+++ b/var/spack/repos/builtin/packages/amrvis/package.py
@@ -50,7 +50,7 @@ class Amrvis(MakefilePackage):
         multi=False,
         description='Floating point precision'
     )
-    variant('mpi', default=False, description='Enable MPI parallel support')
+    variant('mpi', default=True, description='Enable MPI parallel support')
     variant('debug', default=False, description='Enable debugging features')
     variant('profiling', default=False,
             description='Enable AMReX profiling features')


### PR DESCRIPTION
Creating a direct dependency on flex and bison were necessary because profiling support requires them. Also turning MPI off as the default since that's generally the first way someone would want to build Amrvis in my opinion.