### PR TITLE
detect failed python %intel installs and error with fix

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -248,6 +248,30 @@ class Python(AutotoolsPackage):
             os.symlink(os.path.join(prefix.bin, 'python3-config'),
                        os.path.join(prefix.bin, 'python-config'))
 
+        # Check for silent hashlib install problem on Intel compilers.
+        if spec.satisfies('%intel'):
+            # Interestingly, this is an un-catchable exception with an
+            # exit code of 0, so doing something like
+            #
+            #     import sys
+            #     try:
+            #         import hashlib
+            #     except:
+            #         sys.exit(1)
+            #
+            # will not actually exit with `1`, it will be `0`.  The failed
+            # `import hashlib` will print the traceback to stderr though,
+            # so we check that `stderr` is the empty string.  If it is not,
+            # the installation failed.
+            import_error = self.command('-c', 'import hashlib', error=str)
+            if import_error:
+                raise InstallError(
+                    'Could not `import hashlib`:\n\n{0}'.format(import_error) +
+                    '\n\nYou must set `ulimit -s unlimited` and install '     +
+                    'again.  See the bug report for more information: '       +
+                    'https://bugs.python.org/issue33174.'
+                )
+
     # TODO: Once better testing support is integrated, add the following tests
     # https://wiki.python.org/moin/TkInter
     #


### PR DESCRIPTION
User just needs to `ulimit -s unlimited` and re-install.

This was definitely an interesting one to find.  I included an extended comment as to what _exactly_ is being done to check for this error and why because at first glance it seems really odd to not just `try-except` the import.  But you can't.

According to the bug report it's fixed in Intel 2018 Update 3, but I see no reason not to perform the check always `%intel` -- it's very lightweight.

Sample run-through to show the error message (the `>>` even points to the bugs.python.org issue lol).  It's verbose, which is why I'm including it, maybe we don't want it all in there?  I decided to keep it because raising the `InstallError` means the installation gets deleted so they have no other way to know exactly what happened.

```console
sven:~> ulimit -s
8192
sven:~> spack install python@3.6.5 %intel@17.0.0
==> bzip2 is already installed in /opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/bzip2-1.0.6-eqxm6xppjn3u3ukmvfivikvmxvbmeuue
==> pkgconf is already installed in /opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/pkgconf-1.4.2-hdxccn65b53g56fxfki7vvk5vfjcr7x7
==> ncurses is already installed in /opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/ncurses-6.1-mawc2r7etqg3o3v43v64lcdxqgmysaa6
==> readline is already installed in /opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/readline-7.0-pt7djal6oczwkm3t2ouhmcr33nvam47k
==> gdbm is already installed in /opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/gdbm-1.14.1-5pyhdhcqxl7zvoyilsrl6bw3glpmyt5f
==> zlib is already installed in /opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/zlib-1.2.11-6lz46pcyl7bpa5gxjbwjiyzmgbwbp2y5
==> openssl is already installed in /opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/openssl-1.0.2o-h26sragxglbyhz25l3nej5fem5towlro
==> sqlite is already installed in /opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/sqlite-3.23.1-ld7xjo5wfoasnqgs4m2lkot7uygllvjv
==> Installing python
==> Using cached archive: /opt/spack/var/spack/cache/python/python-3.6.5.tgz
==> Staging archive: /opt/spack/var/spack/stage/python-3.6.5-mivcb3gczlneubw6442wtfmyw3clfxgz/Python-3.6.5.tgz
==> Created stage in /opt/spack/var/spack/stage/python-3.6.5-mivcb3gczlneubw6442wtfmyw3clfxgz
==> Applied patch ncurses.patch
==> Ran patch() for python
==> Building python [AutotoolsPackage]
==> Executing phase: 'autoreconf'
==> Executing phase: 'configure'
==> Executing phase: 'build'
==> Executing phase: 'install'
==> Error: InstallError: Could not `import hashlib`:

ERROR:root:code for hash sha3_224 was not found.
Traceback (most recent call last):
  File "/opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/python-3.6.5-mivcb3gczlneubw6442wtfmyw3clfxgz/lib/python3.6/hashlib.py", line 121, in __get_openssl_construct
or
    f = getattr(_hashlib, 'openssl_' + name)
AttributeError: module '_hashlib' has no attribute 'openssl_sha3_224'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/python-3.6.5-mivcb3gczlneubw6442wtfmyw3clfxgz/lib/python3.6/hashlib.py", line 243, in <module>
    globals()[__func_name] = __get_hash(__func_name)
  File "/opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/python-3.6.5-mivcb3gczlneubw6442wtfmyw3clfxgz/lib/python3.6/hashlib.py", line 128, in __get_openssl_construct
or
    return __get_builtin_constructor(name)
  File "/opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/python-3.6.5-mivcb3gczlneubw6442wtfmyw3clfxgz/lib/python3.6/hashlib.py", line 113, in __get_builtin_construct
or
    raise ValueError('unsupported hash type ' + name)
ValueError: unsupported hash type sha3_224
ERROR:root:code for hash sha3_256 was not found.
Traceback (most recent call last):
  File "/opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/python-3.6.5-mivcb3gczlneubw6442wtfmyw3clfxgz/lib/python3.6/hashlib.py", line 121, in __get_openssl_construct
or
    f = getattr(_hashlib, 'openssl_' + name)
AttributeError: module '_hashlib' has no attribute 'openssl_sha3_256'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/python-3.6.5-mivcb3gczlneubw6442wtfmyw3clfxgz/lib/python3.6/hashlib.py", line 243, in <module>
    globals()[__func_name] = __get_hash(__func_name)
  File "/opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/python-3.6.5-mivcb3gczlneubw6442wtfmyw3clfxgz/lib/python3.6/hashlib.py", line 128, in __get_openssl_construct
or
    return __get_builtin_constructor(name)
  File "/opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/python-3.6.5-mivcb3gczlneubw6442wtfmyw3clfxgz/lib/python3.6/hashlib.py", line 113, in __get_builtin_construct
or
    raise ValueError('unsupported hash type ' + name)
ValueError: unsupported hash type sha3_256
ERROR:root:code for hash sha3_384 was not found.
Traceback (most recent call last):
  File "/opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/python-3.6.5-mivcb3gczlneubw6442wtfmyw3clfxgz/lib/python3.6/hashlib.py", line 121, in __get_openssl_construct
or
    f = getattr(_hashlib, 'openssl_' + name)
AttributeError: module '_hashlib' has no attribute 'openssl_sha3_384'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/python-3.6.5-mivcb3gczlneubw6442wtfmyw3clfxgz/lib/python3.6/hashlib.py", line 243, in <module>
    globals()[__func_name] = __get_hash(__func_name)
  File "/opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/python-3.6.5-mivcb3gczlneubw6442wtfmyw3clfxgz/lib/python3.6/hashlib.py", line 128, in __get_openssl_construct
or
    return __get_builtin_constructor(name)
  File "/opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/python-3.6.5-mivcb3gczlneubw6442wtfmyw3clfxgz/lib/python3.6/hashlib.py", line 113, in __get_builtin_construct
or
    raise ValueError('unsupported hash type ' + name)
ValueError: unsupported hash type sha3_384
ERROR:root:code for hash sha3_512 was not found.
Traceback (most recent call last):
  File "/opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/python-3.6.5-mivcb3gczlneubw6442wtfmyw3clfxgz/lib/python3.6/hashlib.py", line 121, in __get_openssl_construct
or
    f = getattr(_hashlib, 'openssl_' + name)
AttributeError: module '_hashlib' has no attribute 'openssl_sha3_512'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/python-3.6.5-mivcb3gczlneubw6442wtfmyw3clfxgz/lib/python3.6/hashlib.py", line 243, in <module>
    globals()[__func_name] = __get_hash(__func_name)
  File "/opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/python-3.6.5-mivcb3gczlneubw6442wtfmyw3clfxgz/lib/python3.6/hashlib.py", line 128, in __get_openssl_construct
or
    return __get_builtin_constructor(name)
  File "/opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/python-3.6.5-mivcb3gczlneubw6442wtfmyw3clfxgz/lib/python3.6/hashlib.py", line 113, in __get_builtin_construct
or
    raise ValueError('unsupported hash type ' + name)
ValueError: unsupported hash type sha3_512
ERROR:root:code for hash shake_128 was not found.
Traceback (most recent call last):
  File "/opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/python-3.6.5-mivcb3gczlneubw6442wtfmyw3clfxgz/lib/python3.6/hashlib.py", line 121, in __get_openssl_construct
or
    f = getattr(_hashlib, 'openssl_' + name)
AttributeError: module '_hashlib' has no attribute 'openssl_shake_128'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/python-3.6.5-mivcb3gczlneubw6442wtfmyw3clfxgz/lib/python3.6/hashlib.py", line 243, in <module>
    globals()[__func_name] = __get_hash(__func_name)
  File "/opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/python-3.6.5-mivcb3gczlneubw6442wtfmyw3clfxgz/lib/python3.6/hashlib.py", line 128, in __get_openssl_constructor
    return __get_builtin_constructor(name)
  File "/opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/python-3.6.5-mivcb3gczlneubw6442wtfmyw3clfxgz/lib/python3.6/hashlib.py", line 113, in __get_builtin_constructor
    raise ValueError('unsupported hash type ' + name)
ValueError: unsupported hash type shake_128
ERROR:root:code for hash shake_256 was not found.
Traceback (most recent call last):
  File "/opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/python-3.6.5-mivcb3gczlneubw6442wtfmyw3clfxgz/lib/python3.6/hashlib.py", line 121, in __get_openssl_constructor
    f = getattr(_hashlib, 'openssl_' + name)
AttributeError: module '_hashlib' has no attribute 'openssl_shake_256'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/python-3.6.5-mivcb3gczlneubw6442wtfmyw3clfxgz/lib/python3.6/hashlib.py", line 243, in <module>
    globals()[__func_name] = __get_hash(__func_name)
  File "/opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/python-3.6.5-mivcb3gczlneubw6442wtfmyw3clfxgz/lib/python3.6/hashlib.py", line 128, in __get_openssl_constructor
    return __get_builtin_constructor(name)
  File "/opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/python-3.6.5-mivcb3gczlneubw6442wtfmyw3clfxgz/lib/python3.6/hashlib.py", line 113, in __get_builtin_constructor
    raise ValueError('unsupported hash type ' + name)
ValueError: unsupported hash type shake_256


You must set `ulimit -s unlimited` and install again.  See the bug report for more information: https://bugs.python.org/issue33174.

/opt/spack/var/spack/repos/builtin/packages/python/package.py:272, in post_install:
        269                    'Could not `import hashlib`:\n\n{0}'.format(import_error) +
        270                    '\n\nYou must set `ulimit -s unlimited` and install '     +
        271                    'again.  See the bug report for more information: '       +
  >>    272                    'https://bugs.python.org/issue33174.'
        273                )

See build log for details:
  /opt/spack/var/spack/stage/python-3.6.5-mivcb3gczlneubw6442wtfmyw3clfxgz/Python-3.6.5/spack-build.out
sven:~> ulimit -s unlimited
sven:~> spack install python@3.6.5 %intel@17.0.0
==> bzip2 is already installed in /opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/bzip2-1.0.6-eqxm6xppjn3u3ukmvfivikvmxvbmeuue
==> pkgconf is already installed in /opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/pkgconf-1.4.2-hdxccn65b53g56fxfki7vvk5vfjcr7x7
==> ncurses is already installed in /opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/ncurses-6.1-mawc2r7etqg3o3v43v64lcdxqgmysaa6
==> readline is already installed in /opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/readline-7.0-pt7djal6oczwkm3t2ouhmcr33nvam47k
==> gdbm is already installed in /opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/gdbm-1.14.1-5pyhdhcqxl7zvoyilsrl6bw3glpmyt5f
==> zlib is already installed in /opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/zlib-1.2.11-6lz46pcyl7bpa5gxjbwjiyzmgbwbp2y5
==> openssl is already installed in /opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/openssl-1.0.2o-h26sragxglbyhz25l3nej5fem5towlro
==> sqlite is already installed in /opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/sqlite-3.23.1-ld7xjo5wfoasnqgs4m2lkot7uygllvjv
==> Installing python
==> Using cached archive: /opt/spack/var/spack/cache/python/python-3.6.5.tgz
==> Staging archive: /opt/spack/var/spack/stage/python-3.6.5-mivcb3gczlneubw6442wtfmyw3clfxgz/Python-3.6.5.tgz
==> Created stage in /opt/spack/var/spack/stage/python-3.6.5-mivcb3gczlneubw6442wtfmyw3clfxgz
==> Applied patch ncurses.patch
==> Ran patch() for python
==> Building python [AutotoolsPackage]
==> Executing phase: 'autoreconf'
==> Executing phase: 'configure'
==> Executing phase: 'build'
==> Executing phase: 'install'
==> Successfully installed python
  Fetch: 0.04s.  Build: 1m 30.17s.  Total: 1m 30.21s.
[+] /opt/spack/opt/spack/linux-fedora27-x86_64/intel-17.0.0/python-3.6.5-mivcb3gczlneubw6442wtfmyw3clfxgz

```