### PR TITLE
add opencv@3.4.3

### DIFF
--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -44,6 +44,7 @@ class Opencv(CMakePackage):
     git      = 'https://github.com/opencv/opencv.git'
 
     version('master', branch='master')
+    version('3.4.3',    '712896f5815938c014c199dde142d508')
     version('3.4.1',    'a0b7a47899e67b3490ea31edc4f6e8e6')
     version('3.4.0',    '170732dc760e5f7ddeccbe53ba5d16a6')
     version('3.3.1',    'b1ed9aea030bb5bd9df28524d97de84c')


### PR DESCRIPTION
There were some build failures on 3.4.1 and GCC 7.3.1 but I didn't understand what exactly the problem was.  I'm adding the new version, but don't know what to do about a `conflicts` here because it wasn't clear to me what versions of GCC were actually affected.