### PR TITLE
patch flann // gcc // cmake@3.11+

### DIFF
--- a/var/spack/repos/builtin/packages/flann/linux-gcc-cmakev3.11-plus.patch
+++ b/var/spack/repos/builtin/packages/flann/linux-gcc-cmakev3.11-plus.patch
@@ -1,0 +1,24 @@
+--- a/src/cpp/CMakeLists.txt
++++ b/src/cpp/CMakeLists.txt
+@@ -29,7 +29,7 @@ if (BUILD_CUDA_LIB)
+ endif()
+ 
+ if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_COMPILER_IS_GNUCC)
+-    add_library(flann_cpp SHARED "")
++    add_library(flann_cpp SHARED "empty.cpp")
+     set_target_properties(flann_cpp PROPERTIES LINKER_LANGUAGE CXX)
+     target_link_libraries(flann_cpp -Wl,-whole-archive flann_cpp_s -Wl,-no-whole-archive)
+ 
+@@ -83,7 +83,7 @@ if (BUILD_C_BINDINGS)
+     set_property(TARGET flann_s PROPERTY COMPILE_DEFINITIONS FLANN_STATIC)
+ 
+     if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_COMPILER_IS_GNUCC)
+-        add_library(flann SHARED "")
++        add_library(flann SHARED "empty.cpp")
+         set_target_properties(flann PROPERTIES LINKER_LANGUAGE CXX)
+         target_link_libraries(flann -Wl,-whole-archive flann_s -Wl,-no-whole-archive)
+     else()
+--- /dev/null
++++ b/src/cpp/empty.cpp
+@@ -0,0 +1 @@
++/* empty */

--- a/var/spack/repos/builtin/packages/flann/package.py
+++ b/var/spack/repos/builtin/packages/flann/package.py
@@ -95,6 +95,9 @@ class Flann(CMakePackage):
     depends_on('hdf5', type='test')
     depends_on('gtest', type='test')
 
+    # See: https://github.com/mariusmuja/flann/issues/369
+    patch('linux-gcc-cmakev3.11-plus.patch', when='%gcc^cmake@3.11:')
+
     def patch(self):
         # Fix up the python setup.py call inside the install(CODE
         filter_file("setup.py install",


### PR DESCRIPTION
See: https://github.com/mariusmuja/flann/issues/369

If a new version is added, maybe they will fix it?  AKA the patch may become irrelevant in the future, but for now it seems valid.  Maybe it would be ok to just wait for the patch to fail and then restrict versions that the patch gets applied to?