### PR TITLE
OpenCoarrays: update v2.2.0

### DIFF
--- a/var/spack/repos/builtin/packages/opencoarrays/CMakeLists.patch
+++ b/var/spack/repos/builtin/packages/opencoarrays/CMakeLists.patch
@@ -1,0 +1,27 @@
+diff --git a/src/mpi/CMakeLists.txt b/src/mpi/CMakeLists.txt
+index 590d646..3f2bded 100644
+--- a/src/mpi/CMakeLists.txt
++++ b/src/mpi/CMakeLists.txt
+@@ -8,22 +8,6 @@ if (NOT MPI_C_FOUND)
+   include_directories(BEFORE ${MPI_C_INCLUDE_PATH} ${MPI_Fortran_INCLUDE_PATH})
+    endif()
+
+    -#----------------------------------
+    -# Determine if we're using Open MPI
+    -#----------------------------------
+    -cmake_host_system_information(RESULT N_CPU QUERY NUMBER_OF_LOGICAL_CORES)
+    -set(N_CPU ${N_CPU} PARENT_SCOPE)
+    -cmake_host_system_information(RESULT HOST_NAME QUERY HOSTNAME)
+    -set(HOSTNAME ${HOSTNAME} PARENT_SCOPE)
+    -execute_process(COMMAND ${MPIEXEC} --version
+    -  OUTPUT_VARIABLE mpi_version_out)
+    -if (mpi_version_out MATCHES "[Oo]pen[ -][Mm][Pp][Ii]")
+    -  message( STATUS "OpenMPI detected")
+    -  set ( openmpi true PARENT_SCOPE)
+    -  # Write out a host file because OMPI's mpiexec is dumb
+    -  file(WRITE ${CMAKE_BINARY_DIR}/hostfile "${HOST_NAME} slots=${N_CPU}\n")
+    -endif ()
+    -
+     if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU")
+           set(gfortran_compiler true)
+            elseif("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Cray")

--- a/var/spack/repos/builtin/packages/opencoarrays/package.py
+++ b/var/spack/repos/builtin/packages/opencoarrays/package.py
@@ -34,8 +34,9 @@ class Opencoarrays(CMakePackage):
     """
 
     homepage = "http://www.opencoarrays.org/"
-    url      = "https://github.com/sourceryinstitute/OpenCoarrays/releases/download/1.8.4/OpenCoarrays-1.8.4.tar.gz"
+    url      = "https://github.com/sourceryinstitute/OpenCoarrays/releases/download/2.2.0/OpenCoarrays-2.2.0.tar.gz"
 
+    version('2.2.0', '9311547a85a21853111f1e8555ceab4593731c6fd9edb64cfb9588805f9d1a0d')
     version('1.8.10', '9ba1670647db4d986634abf743abfd6a')
     version('1.8.4', '7c9eaffc3a0b5748d0d840e52ec9d4ad')
     version('1.8.0', 'ca78d1507b2a118c75128c6c2e093e27')
@@ -48,6 +49,9 @@ class Opencoarrays(CMakePackage):
                     'MinSizeRel', 'CodeCoverage'))
 
     depends_on('mpi')
+    # This patch removes a bunch of checks for the version of MPI available on
+    # the system. They make the Crays hang.
+    patch('CMakeLists.patch', when='platform=cray')
 
     def cmake_args(self):
         args = []


### PR DESCRIPTION
On behalf of Brian Friesen at NERSC. This commit adds a patch that
prevents the package from hanging. The package would hang because
CMakeLists would look for a system MPI. This patch changes the behavior. Also updates the version.