### PR TITLE
Increase and customize lock timeouts

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -94,3 +94,15 @@ config:
 
   # If set to true, spack will use ccache to cache c compiles.
   ccache: false
+
+  # How long to wait to lock the Spack installation database. This lock is used
+  # when spack needs to manage its own package metadata and all operations are
+  # expected to complete within the default time limit. The timeout should
+  # therefore generally be left untouched.
+  db_lock_timeout: 120
+
+  # How long to wait when attempting to modify a package (e.g. to install it).
+  # This value should typically be 'null' unless the Spack instance only ever
+  # has a single user at a time, and only if the user anticipates that a
+  # significant delay indicates that the lock attempt will never succeed.
+  package_lock_timeout: 120

--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -101,9 +101,9 @@ config:
   # therefore generally be left untouched.
   db_lock_timeout: 120
 
-  # TODO: turn this off by setting it 'null' before merging
   # How long to wait when attempting to modify a package (e.g. to install it).
-  # This value should typically be 'null' unless the Spack instance only ever
-  # has a single user at a time, and only if the user anticipates that a
-  # significant delay indicates that the lock attempt will never succeed.
-  package_lock_timeout: 120
+  # This value should typically be 'null' (never time out) unless the Spack
+  # instance only ever has a single user at a time, and only if the user
+  # anticipates that a significant delay indicates that the lock attempt will
+  # never succeed.
+  package_lock_timeout: null

--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -101,6 +101,7 @@ config:
   # therefore generally be left untouched.
   db_lock_timeout: 120
 
+  # TODO: turn this off by setting it 'null' before merging
   # How long to wait when attempting to modify a package (e.g. to install it).
   # This value should typically be 'null' unless the Spack instance only ever
   # has a single user at a time, and only if the user anticipates that a

--- a/lib/spack/llnl/util/lock.py
+++ b/lib/spack/llnl/util/lock.py
@@ -81,12 +81,17 @@ class Lock(object):
 
     @staticmethod
     def _poll_interval_generator(_wait_times=None):
-        # Poll interval of .1s until 2 seconds have passed
-        # Then poll interval of .2s until 10 seconds have passed
-        # Then poll interval of .5s
-        # This doesn't actually track elapsed time, it estimates the waiting
-        # time as though the caller always waits for the full length of time
-        # suggested by this function.
+        """This implements a backoff scheme for polling a contended resource
+        by suggesting a succession of wait times between polls.
+
+        It suggests a poll interval of .1s until 2 seconds have passed,
+        then a poll interval of .2s until 10 seconds have passed, and finally
+        (for all requests after 10s) suggests a poll interval of .5s.
+
+        This doesn't actually track elapsed time, it estimates the waiting
+        time as though the caller always waits for the full length of time
+        suggested by this function.
+        """
         num_requests = 0
         stage1, stage2, stage3 = _wait_times or (1e-1, 2e-1, 5e-1)
         wait_time = stage1

--- a/lib/spack/llnl/util/lock.py
+++ b/lib/spack/llnl/util/lock.py
@@ -354,10 +354,15 @@ class Lock(object):
 
     def _acquired_debug(self, lock_type, wait_time, nattempts):
         attempts_format = 'attempt' if nattempts == 1 else 'attempt'
+        if nattempts > 1:
+            acquired_attempts_format = ' after {0:0.2f}s and {1:d} {2}'.format(
+                wait_time, nattempts, attempts_format)
+        else:
+            # Dont print anything if we succeeded immediately
+            acquired_attempts_format = ''
         self._debug(
-            '{0}: {1.path}[{1._start}:{1._length}]'
-            ' [Acquired after {2:0.2f}s and {3:d} {4}]'
-            .format(lock_type, self, wait_time, nattempts, attempts_format))
+            '{0}: {1.path}[{1._start}:{1._length}] [Acquired{2}]'
+            .format(lock_type, self, acquired_attempts_format))
 
 
 class LockTransaction(object):

--- a/lib/spack/llnl/util/lock.py
+++ b/lib/spack/llnl/util/lock.py
@@ -110,7 +110,7 @@ class Lock(object):
 
         timeout = timeout or self.default_timeout
 
-        intervals = iter(Lock._poll_interval_generator())
+        poll_intervals = iter(Lock._poll_interval_generator())
         start_time = time.time()
         while (not timeout) or (time.time() - start_time) < timeout:
             # Create file and parent directories if they don't exist.
@@ -161,7 +161,7 @@ class Lock(object):
                 else:
                     raise
 
-            time.sleep(intervals.next())
+            time.sleep(next(poll_intervals))
 
         raise LockTimeoutError("Timed out waiting for lock.")
 

--- a/lib/spack/llnl/util/lock.py
+++ b/lib/spack/llnl/util/lock.py
@@ -40,7 +40,7 @@ __all__ = ['Lock', 'LockTransaction', 'WriteTransaction', 'ReadTransaction',
 _default_timeout = 120
 
 # Sleep time per iteration in spin loop (in seconds)
-_sleep_time = 1e-5
+_sleep_time = 1e-2
 
 
 class Lock(object):

--- a/lib/spack/llnl/util/lock.py
+++ b/lib/spack/llnl/util/lock.py
@@ -151,7 +151,6 @@ class Lock(object):
         num_attempts = 0
         while (not timeout) or (time.time() - start_time) < timeout:
             num_attempts += 1
-
             if self._poll_lock(op):
                 total_wait_time = time.time() - start_time
                 return total_wait_time, num_attempts

--- a/lib/spack/llnl/util/lock.py
+++ b/lib/spack/llnl/util/lock.py
@@ -81,15 +81,15 @@ class Lock(object):
 
     @staticmethod
     def _poll_interval_generator():
-        # Poll interval of .1s until 1 second has passed
-        # Then poll interval of .2s until 1 minute has passed
+        # Poll interval of .1s until 2 seconds have passed
+        # Then poll interval of .2s until 10 seconds have passed
         # Then poll interval of .5s
         wait_time = 1e-1
         total = 0
         while True:
-            if total > 5:
+            if total > 2:
                 wait_time = 2e-1
-            elif total > 60:
+            elif total > 10:
                 wait_time = 5e-1
             total += wait_time
             yield wait_time

--- a/lib/spack/llnl/util/lock.py
+++ b/lib/spack/llnl/util/lock.py
@@ -121,6 +121,26 @@ class Lock(object):
 
         timeout = timeout or self.default_timeout
 
+        poll_intervals = iter(Lock._poll_interval_generator())
+        start_time = time.time()
+        num_attempts = 0
+        while (not timeout) or (time.time() - start_time) < timeout:
+            num_attempts += 1
+
+            if self._poll_lock(op):
+                total_wait_time = time.time() - start_time
+                return total_wait_time, num_attempts
+
+            time.sleep(next(poll_intervals))
+
+        num_attempts += 1
+        if self._poll_lock(op):
+            total_wait_time = time.time() - start_time
+            return total_wait_time, num_attempts
+
+        raise LockTimeoutError("Timed out waiting for lock.")
+
+    def _ensure_lockfile(self, op):
         # Create file and parent directories if they don't exist.
         if self._file is None:
             parent = self._ensure_parent_directory()
@@ -146,29 +166,12 @@ class Lock(object):
             # If the file were writable, we'd have opened it 'r+'
             raise LockROFileError(self.path)
 
-        poll_intervals = iter(Lock._poll_interval_generator())
-        start_time = time.time()
-        num_attempts = 0
-        while (not timeout) or (time.time() - start_time) < timeout:
-            num_attempts += 1
-
-            if self._poll_lock(op):
-                total_wait_time = time.time() - start_time
-                return total_wait_time, num_attempts
-
-            time.sleep(next(poll_intervals))
-
-        num_attempts += 1
-        if self._poll_lock(op):
-            total_wait_time = time.time() - start_time
-            return total_wait_time, num_attempts
-
-        raise LockTimeoutError("Timed out waiting for lock.")
-
     def _poll_lock(self, op):
         """Attempt to acquire the lock in a non-blocking manner. Return whether
         the locking attempt succeeds
         """
+        self._ensure_lockfile(op)
+
         try:
             # Try to get the lock (will raise if not available.)
             fcntl.lockf(self._file, op | fcntl.LOCK_NB,

--- a/lib/spack/llnl/util/lock.py
+++ b/lib/spack/llnl/util/lock.py
@@ -43,6 +43,10 @@ class Lock(object):
     any filesystem implementation that supports locking through the fcntl
     calls.  This includes distributed filesystems like Lustre (when flock
     is enabled) and recent NFS versions.
+
+    Note that this is for managing contention over resources *between*
+    processes and not for managing contention between threads in a process: the
+    functions of this object are not thread-safe.
     """
 
     def __init__(self, path, start=0, length=0, debug=False,

--- a/lib/spack/llnl/util/lock.py
+++ b/lib/spack/llnl/util/lock.py
@@ -46,7 +46,8 @@ class Lock(object):
 
     Note that this is for managing contention over resources *between*
     processes and not for managing contention between threads in a process: the
-    functions of this object are not thread-safe.
+    functions of this object are not thread-safe. A process also must not
+    maintain multiple locks on the same file.
     """
 
     def __init__(self, path, start=0, length=0, debug=False,
@@ -352,10 +353,11 @@ class Lock(object):
         tty.debug(*args)
 
     def _acquired_debug(self, lock_type, wait_time, nattempts):
+        attempts_format = 'attempt' if nattempts == 1 else 'attempt'
         self._debug(
             '{0}: {1.path}[{1._start}:{1._length}]'
-            ' [Acquired after {2:0.2f}s and {3:d} attempts]'
-            .format(lock_type, self, wait_time, nattempts))
+            ' [Acquired after {2:0.2f}s and {3:d} {4}]'
+            .format(lock_type, self, wait_time, nattempts, attempts_format))
 
 
 class LockTransaction(object):

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -205,6 +205,8 @@ class Database(object):
         # initialize rest of state.
         self.default_lock_timeout = (
             spack.config.get('config:file_lock_timeout') or _db_lock_timeout)
+        tty.debug('DEFAULT LOCK TIMEOUT: {0}s'.format(
+                  str(self.default_lock_timeout)))
         self.lock = Lock(self._lock_path,
                          default_timeout=self.default_lock_timeout)
         self._data = {}

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -209,8 +209,8 @@ class Database(object):
             spack.config.get('config:package_lock_timeout') or None)
         tty.debug('DATABASE LOCK TIMEOUT: {0}s'.format(
                   str(self.db_lock_timeout)))
-        timeout_format_str = ('{0}s'.format(str(self.package_lock_timeout)) 
-                             if self.package_lock_timeout else 'No timeout')
+        timeout_format_str = ('{0}s'.format(str(self.package_lock_timeout))
+                              if self.package_lock_timeout else 'No timeout')
         tty.debug('PACKAGE LOCK TIMEOUT: {0}'.format(
                   str(timeout_format_str)))
         self.lock = Lock(self._lock_path,

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -256,7 +256,7 @@ class Database(object):
             yield self
         except LockError:
             raise
-        except Exception, KeyboardInterrupt:
+        except (Exception, KeyboardInterrupt):
             prefix_lock.release_read()
             raise
         else:
@@ -271,7 +271,7 @@ class Database(object):
             yield self
         except LockError:
             raise
-        except Exception, KeyboardInterrupt:
+        except (Exception, KeyboardInterrupt):
             prefix_lock.release_write()
             raise
         else:

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -261,6 +261,8 @@ class Database(object):
         try:
             yield self
         except LockError:
+            # This addresses the case where a nested lock attempt fails inside
+            # of this context manager
             raise
         except (Exception, KeyboardInterrupt):
             prefix_lock.release_read()
@@ -276,6 +278,8 @@ class Database(object):
         try:
             yield self
         except LockError:
+            # This addresses the case where a nested lock attempt fails inside
+            # of this context manager
             raise
         except (Exception, KeyboardInterrupt):
             prefix_lock.release_write()

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -256,7 +256,7 @@ class Database(object):
             yield self
         except LockError:
             raise
-        except:
+        except Exception, KeyboardInterrupt:
             prefix_lock.release_read()
             raise
         else:
@@ -271,7 +271,7 @@ class Database(object):
             yield self
         except LockError:
             raise
-        except:
+        except Exception, KeyboardInterrupt:
             prefix_lock.release_write()
             raise
         else:

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -203,12 +203,18 @@ class Database(object):
             mkdirp(self._db_dir)
 
         # initialize rest of state.
-        self.default_lock_timeout = (
-            spack.config.get('config:file_lock_timeout') or _db_lock_timeout)
-        tty.debug('DEFAULT LOCK TIMEOUT: {0}s'.format(
-                  str(self.default_lock_timeout)))
+        self.db_lock_timeout = (
+            spack.config.get('config:db_lock_timeout') or _db_lock_timeout)
+        self.package_lock_timeout = (
+            spack.config.get('config:package_lock_timeout') or None)
+        tty.debug('DATABASE LOCK TIMEOUT: {0}s'.format(
+                  str(self.db_lock_timeout)))
+        timeout_format_str = ('{0}s'.format(str(self.package_lock_timeout)) 
+                             if self.package_lock_timeout else 'No timeout')
+        tty.debug('PACKAGE LOCK TIMEOUT: {0}'.format(
+                  str(timeout_format_str)))
         self.lock = Lock(self._lock_path,
-                         default_timeout=self.default_lock_timeout)
+                         default_timeout=self.db_lock_timeout)
         self._data = {}
 
         # whether there was an error at the start of a read transaction
@@ -243,7 +249,7 @@ class Database(object):
                 self.prefix_lock_path,
                 start=spec.dag_hash_bit_prefix(bit_length(sys.maxsize)),
                 length=1,
-                default_timeout=self.default_lock_timeout)
+                default_timeout=self.package_lock_timeout)
 
         return self._prefix_locks[prefix]
 

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -70,7 +70,13 @@ schema = {
                 'dirty': {'type': 'boolean'},
                 'build_jobs': {'type': 'integer', 'minimum': 1},
                 'ccache': {'type': 'boolean'},
-                'file_lock_timeout': {'type': 'integer', 'minimum': 1},
+                'db_lock_timeout': {'type': 'integer', 'minimum': 1},
+                'package_lock_timeout': {
+                    'anyOf': [
+                        {'type': 'integer', 'minimum': 1},
+                        {'type': 'null'}
+                    ],
+                },
             }
         },
     },

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -70,6 +70,7 @@ schema = {
                 'dirty': {'type': 'boolean'},
                 'build_jobs': {'type': 'integer', 'minimum': 1},
                 'ccache': {'type': 'boolean'},
+                'file_lock_timeout': {'type': 'integer', 'minimum': 1},
             }
         },
     },

--- a/lib/spack/spack/test/llnl/util/lock.py
+++ b/lib/spack/spack/test/llnl/util/lock.py
@@ -220,6 +220,13 @@ def lock_path(lock_dir):
         os.unlink(lock_file)
 
 
+def test_poll_interval_generator():
+    interval_iter = iter(
+        lk.Lock._poll_interval_generator(_wait_times=[1, 2, 3]))
+    intervals = list(next(interval_iter) for i in xrange(100))
+    assert intervals == [1] * 20 + [2] * 40 + [3] * 40
+
+
 def local_multiproc_test(*functions, **kwargs):
     """Order some processes using simple barrier synchronization."""
     b = mp.Barrier(len(functions), timeout=barrier_timeout)

--- a/lib/spack/spack/test/llnl/util/lock.py
+++ b/lib/spack/spack/test/llnl/util/lock.py
@@ -223,7 +223,7 @@ def lock_path(lock_dir):
 def test_poll_interval_generator():
     interval_iter = iter(
         lk.Lock._poll_interval_generator(_wait_times=[1, 2, 3]))
-    intervals = list(next(interval_iter) for i in xrange(100))
+    intervals = list(next(interval_iter) for i in range(100))
     assert intervals == [1] * 20 + [2] * 40 + [3] * 40
 
 

--- a/lib/spack/spack/util/file_cache.py
+++ b/lib/spack/spack/util/file_cache.py
@@ -42,7 +42,7 @@ class FileCache(object):
 
     """
 
-    def __init__(self, root):
+    def __init__(self, root, default_timeout=120):
         """Create a file cache object.
 
         This will create the cache directory if it does not exist yet.
@@ -53,6 +53,7 @@ class FileCache(object):
             mkdirp(self.root)
 
         self._locks = {}
+        self.default_timeout = default_timeout
 
     def destroy(self):
         """Remove all files under the cache root."""
@@ -77,7 +78,8 @@ class FileCache(object):
     def _get_lock(self, key):
         """Create a lock for a key, if necessary, and return a lock object."""
         if key not in self._locks:
-            self._locks[key] = Lock(self._lock_path(key))
+            self._locks[key] = Lock(self._lock_path(key),
+                                    default_timeout=self.default_timeout)
         return self._locks[key]
 
     def init_entry(self, key):

--- a/lib/spack/spack/util/file_cache.py
+++ b/lib/spack/spack/util/file_cache.py
@@ -42,18 +42,24 @@ class FileCache(object):
 
     """
 
-    def __init__(self, root, default_timeout=120):
+    def __init__(self, root, timeout=120):
         """Create a file cache object.
 
         This will create the cache directory if it does not exist yet.
 
+        Args:
+            root: specifies the root directory where the cache stores files
+
+            timeout: when there is contention among multiple Spack processes
+                for cache files, this specifies how long Spack should wait
+                before assuming that there is a deadlock.
         """
         self.root = root.rstrip(os.path.sep)
         if not os.path.exists(self.root):
             mkdirp(self.root)
 
         self._locks = {}
-        self.default_timeout = default_timeout
+        self.lock_timeout = timeout
 
     def destroy(self):
         """Remove all files under the cache root."""
@@ -79,7 +85,7 @@ class FileCache(object):
         """Create a lock for a key, if necessary, and return a lock object."""
         if key not in self._locks:
             self._locks[key] = Lock(self._lock_path(key),
-                                    default_timeout=self.default_timeout)
+                                    default_timeout=self.lock_timeout)
         return self._locks[key]
 
     def init_entry(self, key):

--- a/lib/spack/spack/util/lock.py
+++ b/lib/spack/spack/util/lock.py
@@ -47,7 +47,9 @@ class Lock(llnl.util.lock.Lock):
 
     def _lock(self, op, timeout=0):
         if self._enable:
-            super(Lock, self)._lock(op, timeout)
+            return super(Lock, self)._lock(op, timeout)
+        else:
+            return 0, 0
 
     def _unlock(self):
         """Unlock call that always succeeds."""


### PR DESCRIPTION
See https://github.com/spack/spack/issues/9166
See https://github.com/spack/spack/issues/8915

This is intended to reduce errors related to lock timeouts by making the following changes

* (new 9/18) locks (those created using `spack.llnl.util.lock.Lock`) now have no timeout by default
* (updated 9/18) increases the default timeout *for database locks*
* (new 9/18) by default locks taken on individual packages do not have a timeout. A timeout can be added by setting `package_lock_timeout` in `config.yaml`
* ~allows users to set `file_lock_timeout` in `config.yaml`~ (update 9/18, this is replaced with two separate configurable timeout parameters)
* (new 9/18) users can configure the whole-database lock timeout using the `db_lock_timout` setting in `config.yaml`
* (updated 9/18) Reduces the amount of spinning on the spin lock, to reduce impact in the case where NFS is overtaxed (~at the moment this simply increases the sleep time between polls, it could be smarter than that~ as of 9/18 there is a slightly-more-sophisticated backoff strategy)

It would not address implementations of NFS that do not support file locking, or detect cases where services that may be required (nfslock/statd) aren't running.

Users may want to be able to more-aggressively release locks when they know they are the only one using their Spack instance, and they encounter lock errors after a crash (e.g. a remote terminal disconnect like https://github.com/spack/spack/issues/8915#issuecomment-417728118).