### PR TITLE
darwin: cut DYLD_LIBRARY_PATH from default modules

### DIFF
--- a/etc/spack/defaults/darwin/modules.yaml
+++ b/etc/spack/defaults/darwin/modules.yaml
@@ -16,8 +16,6 @@
 modules:
   prefix_inspections:
     lib:
-      - DYLD_LIBRARY_PATH
       - DYLD_FALLBACK_LIBRARY_PATH
     lib64:
-      - DYLD_LIBRARY_PATH
       - DYLD_FALLBACK_LIBRARY_PATH


### PR DESCRIPTION
This commit removes the `DYLD_LIBRARY_PATH` variable from the default
`modules.yaml` for darwin. The rationale behind deleting this
environment variable is that paths in this environment variable take
precedence over the default locations of libraries (usually the
install path of the library), which can lead to linking errors in some
circumstances. For example, executables intended to link with Apple's
system BLAS and LAPACK will instead link to a spack-installed
implementation (e.g., OpenBLAS), causing runtime errors.

These errors are resolved by instead relying on paths set in
`DYLD_FALLBACK_LIBRARY_PATH`, which is lower in precedence than default
locations of libraries.