### PR TITLE
py-multiqc: needs newer py-spectra

### DIFF
--- a/var/spack/repos/builtin/packages/py-multiqc/package.py
+++ b/var/spack/repos/builtin/packages/py-multiqc/package.py
@@ -48,3 +48,8 @@ class PyMultiqc(PythonPackage):
     depends_on('py-numpy', type=('build', 'run'))
     depends_on('py-pyyaml', type=('build', 'run'))
     depends_on('py-simplejson', type=('build', 'run'))
+
+    # I don't see this dependency in setup.py or anywhere 
+    # in the multiqc source, but it ends up being imported
+    # in lib/python2.7/site-packages/multiqc/utils/megaqc.py
+    depends_on('py-requests', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-multiqc/package.py
+++ b/var/spack/repos/builtin/packages/py-multiqc/package.py
@@ -43,7 +43,7 @@ class PyMultiqc(PythonPackage):
     depends_on('py-jinja2@2.9:', type=('build', 'run'))
     depends_on('py-lzstring', type=('build', 'run'))
     depends_on('py-future@0.14.1:', type=('build', 'run'))
-    depends_on('py-spectra', type=('build', 'run'))
+    depends_on('py-spectra@0.0.10:', type=('build', 'run'))
     depends_on('py-matplotlib', type=('build', 'run'))
     depends_on('py-numpy', type=('build', 'run'))
     depends_on('py-pyyaml', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-multiqc/package.py
+++ b/var/spack/repos/builtin/packages/py-multiqc/package.py
@@ -53,3 +53,4 @@ class PyMultiqc(PythonPackage):
     # in the multiqc source, but it ends up being imported
     # in lib/python2.7/site-packages/multiqc/utils/megaqc.py
     depends_on('py-requests', type=('build', 'run'))
+    depends_on('py-enum34', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-multiqc/package.py
+++ b/var/spack/repos/builtin/packages/py-multiqc/package.py
@@ -56,4 +56,4 @@ class PyMultiqc(PythonPackage):
 
     depends_on('py-requests', type=('build', 'run'))
     depends_on('py-enum34', type=('build', 'run'))
-    depends_on('py-markdown', type('build', 'run'))
+    depends_on('py-markdown', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-multiqc/package.py
+++ b/var/spack/repos/builtin/packages/py-multiqc/package.py
@@ -48,12 +48,6 @@ class PyMultiqc(PythonPackage):
     depends_on('py-numpy', type=('build', 'run'))
     depends_on('py-pyyaml', type=('build', 'run'))
     depends_on('py-simplejson', type=('build', 'run'))
-
-    # I don't see these dependencies in setup.py or anywhere
-    # in the multiqc source, but they end up being imported
-    # e.g.
-    # requests in lib/python2.7/site-packages/multiqc/utils/megaqc.py
-
-    depends_on('py-requests', type=('build', 'run'))
-    depends_on('py-enum34', type=('build', 'run'))
-    depends_on('py-markdown', type=('build', 'run'))
+    depends_on('py-requests', type=('build', 'run'), when='@1.5:')
+    depends_on('py-enum34', type=('build', 'run'), when='@1.5:')
+    depends_on('py-markdown', type=('build', 'run'), when='@1.5:')

--- a/var/spack/repos/builtin/packages/py-multiqc/package.py
+++ b/var/spack/repos/builtin/packages/py-multiqc/package.py
@@ -49,8 +49,11 @@ class PyMultiqc(PythonPackage):
     depends_on('py-pyyaml', type=('build', 'run'))
     depends_on('py-simplejson', type=('build', 'run'))
 
-    # I don't see this dependency in setup.py or anywhere 
-    # in the multiqc source, but it ends up being imported
-    # in lib/python2.7/site-packages/multiqc/utils/megaqc.py
+    # I don't see these dependencies in setup.py or anywhere
+    # in the multiqc source, but they end up being imported
+    # e.g.
+    # requests in lib/python2.7/site-packages/multiqc/utils/megaqc.py
+
     depends_on('py-requests', type=('build', 'run'))
     depends_on('py-enum34', type=('build', 'run'))
+    depends_on('py-markdown', type('build', 'run'))


### PR DESCRIPTION
runtime error states 0.0.10 version of spectra is required 

depends on #9224 