### PR TITLE
py-h5py: add version 2.8.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-h5py/package.py
+++ b/var/spack/repos/builtin/packages/py-h5py/package.py
@@ -29,9 +29,12 @@ class PyH5py(PythonPackage):
     """The h5py package provides both a high- and low-level interface to the
     HDF5 library from Python."""
 
-    homepage = "https://pypi.python.org/pypi/h5py"
-    url      = "https://pypi.io/packages/source/h/h5py/h5py-2.4.0.tar.gz"
+    homepage = "http://www.h5py.org/"
+    url      = "https://pypi.io/packages/source/h/h5py/h5py-2.8.0.tar.gz"
 
+    import_modules = ['h5py', 'h5py._hl']
+
+    version('2.8.0', 'ece4f358e69fc8a416f95953b91bc373')
     version('2.7.1', 'da630aebe3ab9fa218ac405a218e95e0')
     version('2.7.0', 'f62937f40f68d3b128b3941be239dd93')
     version('2.6.0', 'ec476211bd1de3f5ac150544189b0bf4')
@@ -41,19 +44,21 @@ class PyH5py(PythonPackage):
     variant('mpi', default=True, description='Build with MPI support')
 
     # Build dependencies
-    depends_on('py-cython@0.19:', type='build')
+    depends_on('py-cython@0.23:', type='build')
     depends_on('py-pkgconfig', type='build')
     depends_on('py-setuptools', type='build')
+
+    # Build and runtime dependencies
+    depends_on('py-numpy@1.7:', type=('build', 'run'))
+    depends_on('py-six', type=('build', 'run'))
+
+    # Link dependencies
     depends_on('hdf5@1.8.4:+hl')
+
+    # MPI dependencies
     depends_on('hdf5+mpi', when='+mpi')
     depends_on('mpi', when='+mpi')
     depends_on('py-mpi4py', when='+mpi', type=('build', 'run'))
-
-    # Build and runtime dependencies
-    depends_on('py-numpy@1.6.1:', type=('build', 'run'))
-
-    # Runtime dependencies
-    depends_on('py-six', type=('build', 'run'))
 
     phases = ['configure', 'install']
 


### PR DESCRIPTION
Successfully installed and tested on macOS 10.13.6 with Clang 9.1.0.