### PR TITLE
Hwloc add update 2.0.2

### DIFF
--- a/var/spack/repos/builtin/packages/hwloc/package.py
+++ b/var/spack/repos/builtin/packages/hwloc/package.py
@@ -44,10 +44,11 @@ class Hwloc(AutotoolsPackage):
     """
 
     homepage = "http://www.open-mpi.org/projects/hwloc/"
-    url      = "http://www.open-mpi.org/software/hwloc/v1.9/downloads/hwloc-1.9.tar.gz"
+    url      = "https://download.open-mpi.org/release/hwloc/v2.0/hwloc-2.0.2.tar.gz"
     list_url = "http://www.open-mpi.org/software/hwloc/"
     list_depth = 2
 
+    version('2.0.2',  '71d1211eaa4b25ac7ad80cf326784e87')
     version('2.0.1',  '442b2482bb5b81983ed256522aadbf94')
     version('2.0.0',  '027e6928ae0b5b64c821d0a71a61cd82')
     version('1.11.9', '4d5f5da8b1d09731d82e865ecf3fa399')

--- a/var/spack/repos/builtin/packages/libhio/package.py
+++ b/var/spack/repos/builtin/packages/libhio/package.py
@@ -40,6 +40,7 @@ class Libhio(AutotoolsPackage):
     # We don't include older versions since they are missing features
     # needed by current and future consumers of libhio
     #
+    version('1.4.1.2', '38c7d33210155e5796b16d536d1b5cfe')
     version('1.4.1.0', '6ef566fd8cf31fdcd05fab01dd3fae44')
 
     #


### PR DESCRIPTION
## Actions
• Add hwloc@2.0.2
• Change default url (from http) to [https://www.open-mpi.org/software/hwloc/v2.0/](https://www.open-mpi.org/software/hwloc/v2.0/)

## Verification build
`$ spack install hwloc`

```
==> Successfully installed hwloc
  Fetch: 1.57s.  Build: 41.16s.  Total: 42.74s.
[+] /scratch/dantopa/spack.current.ccscs4/opt/spack/linux-rhel7-x86_64/gcc-8.1.0/hwloc-2.0.2-x4lm6czuznjrgfp4onl4xo3ztor52a5y
```
