### PR TITLE
Build Python 3.7 with external libffi.

### DIFF
--- a/var/spack/repos/builtin/packages/libffi/package.py
+++ b/var/spack/repos/builtin/packages/libffi/package.py
@@ -37,3 +37,8 @@ class Libffi(AutotoolsPackage):
     # version('3.1', 'f5898b29bbfd70502831a212d9249d10',url =
     # "ftp://sourceware.org/pub/libffi/libffi-3.1.tar.gz") # Has a bug
     # $(lib64) instead of ${lib64} in libffi.pc
+
+    @property
+    def headers(self):
+        # The headers are probably in self.prefix.lib but we search everywhere
+        return find_headers('ffi', self.prefix, recursive=True)

--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -72,6 +72,10 @@ class Openssl(Package):
 
     parallel = False
 
+    @property
+    def libs(self):
+        return find_libraries(['libssl', 'libcrypto'], root=self.prefix.lib)
+
     def handle_fetch_error(self, error):
         tty.warn("Fetching OpenSSL failed. This may indicate that OpenSSL has "
                  "been updated, and the version in your instance of Spack is "

--- a/var/spack/repos/builtin/packages/sqlite/package.py
+++ b/var/spack/repos/builtin/packages/sqlite/package.py
@@ -76,6 +76,10 @@ class Sqlite(AutotoolsPackage):
                         'extension-functions.c'},
              when='+functions')
 
+    @property
+    def libs(self):
+        return find_libraries('libsqlite3', root=self.prefix.lib)
+
     def get_arch(self):
         arch = architecture.Arch()
         arch.platform = architecture.platform()


### PR DESCRIPTION
There are some building changes for Python 3.7.0: https://docs.python.org/3/whatsnew/3.7.html#build-changes

It's not allowed anymore to build Python with the bundled `libffi` on non-OSX UNIX. Since I don't know a nice way to express this in the `when` condition (is it possible to negate the condition `platform=darwin`?), I suggest that we build with an external `libffi` on MacOS too.