### PR TITLE
gdb: add lzma support by default

### DIFF
--- a/var/spack/repos/builtin/packages/gdb/package.py
+++ b/var/spack/repos/builtin/packages/gdb/package.py
@@ -46,7 +46,7 @@ class Gdb(AutotoolsPackage):
     version('7.8.2', '8b0ea8b3559d3d90b3ff4952f0aeafbc')
 
     variant('python', default=True, description='Compile with Python support')
-    variant('xz', default=False, description='Compile with lzma support')
+    variant('xz', default=True, description='Compile with lzma support')
 
     # Required dependency
     depends_on('texinfo', type='build')


### PR DESCRIPTION
This is required at least on RedHat/Fedora.

Many (most?) other people distribute gdb with this support enabled:
http://tomszilagyi.github.io/2018/03/Remote-gdb-with-stl-pp
https://bugzilla.redhat.com/show_bug.cgi?id=1596490