### PR TITLE
metasv: add required dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/metasv/package.py
+++ b/var/spack/repos/builtin/packages/metasv/package.py
@@ -34,6 +34,8 @@ class Metasv(PythonPackage):
 
     version('0.5.4', 'de2e21ac4f86bc4d1830bdfff95d8391')
 
-    depends_on('py-pybedtools@0.6.9', type=('build', 'run'))
-    depends_on('py-pysam@0.7.7', type=('build', 'run'))
-    depends_on('py-pyvcf@0.6.7', type=('build', 'run'))
+    depends_on('py-pybedtools@0.6.9:', type=('build', 'run'))
+    depends_on('py-pysam@0.7.7:', type=('build', 'run'))
+    depends_on('py-pyvcf@0.6.7:', type=('build', 'run'))
+    depends_on('py-setuptools', type=('build', 'run'))
+    depends_on('py-cython', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/metasv/package.py
+++ b/var/spack/repos/builtin/packages/metasv/package.py
@@ -34,8 +34,8 @@ class Metasv(PythonPackage):
 
     version('0.5.4', 'de2e21ac4f86bc4d1830bdfff95d8391')
 
-    depends_on('py-pybedtools@0.6.9:', type=('build', 'run'))
-    depends_on('py-pysam@0.7.7:', type=('build', 'run'))
-    depends_on('py-pyvcf@0.6.7:', type=('build', 'run'))
+    depends_on('py-pybedtools@0.6.9', type=('build', 'run'))
+    depends_on('py-pysam@0.7.7', type=('build', 'run'))
+    depends_on('py-pyvcf@0.6.7', type=('build', 'run'))
     depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-cython', type=('build', 'run'))


### PR DESCRIPTION
these aren't mentioned on the homepage but are required to the run the tool.