### PR TITLE
VTK dependency on "mesa" instead of "mesa+llvm"

### DIFF
--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -62,8 +62,9 @@ class Vtk(CMakePackage):
     # drivers is faster, but it must be done externally.
     depends_on('opengl', when='~osmesa')
 
-    # mesa default is software rendering, make it faster with llvm
-    depends_on('mesa+llvm', when='+osmesa')
+    # Note: it is recommended to use mesa+llvm, if possible.
+    # mesa default is software rendering, llvm makes it faster
+    depends_on('mesa', when='+osmesa')
 
     # VTK will need Qt5OpenGL, and qt needs '-opengl' for that
     depends_on('qt+opengl', when='+qt')


### PR DESCRIPTION
`vtk` currently has a dependency on `mesa+llvm` when the option `+osmesa` is activated.
Since `vtk` can actually be built simply with `mesa`, I suggest removing the dependency on `+llvm` and leave it to the user to chose whether to install with `llvm` support or not. I suggest this in particular because calling `spack install vtk+osmesa ^mesa+llvm` works when the `vtk` package depends on just `mesa`, while calling `spack install vtk+osmesa ^mesa~llvm` does not work when `vtk` depends on `mesa+llvm`.

Additionally right now, `mesa+llvm` doesn't seem to compile on a standard Debian machine.
(Error reported by spack is the following:
```
gallivm/lp_bld_misc.cpp: In function ‘LLVMOpaqueBuilder* lp_create_builder(LLVMContextRef, lp_float_mode)’:
gallivm/lp_bld_misc.cpp:833:13: error: ‘class llvm::FastMathFlags’ has no member named ‘setUnsafeAlgebra’
```
)