### PR TITLE
Fix version parsing for cistem package

### DIFF
--- a/lib/spack/spack/test/url_parse.py
+++ b/lib/spack/spack/test/url_parse.py
@@ -43,6 +43,8 @@ from spack.version import Version
     ('jpegsrc.v9b', 'jpegsrc.v9b'),
     ('turbolinux702', 'turbolinux702'),
     ('converge_install_2.3.16', 'converge_install_2.3.16'),
+    # Download type - code, source
+    ('cistem-1.0.0-beta-source-code', 'cistem-1.0.0-beta'),
     # Download type - src
     ('apache-ant-1.9.7-src', 'apache-ant-1.9.7'),
     ('go1.7.4.src', 'go1.7.4'),

--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -169,6 +169,7 @@ def strip_version_suffixes(path):
         # Download type
         '[Ii]nstall',
         'all',
+        'code',
         'src(_0)?',
         '[Ss]ources?',
         'file',

--- a/var/spack/repos/builtin/packages/cistem/package.py
+++ b/var/spack/repos/builtin/packages/cistem/package.py
@@ -34,7 +34,7 @@ class Cistem(AutotoolsPackage):
     homepage = "https://cistem.org/"
     url      = "https://cistem.org/system/tdf/upload3/cistem-1.0.0-beta-source-code.tar.gz?file=1&type=cistem_details&id=37&force=0"
 
-    version('1.0.0', '479f395b30ad630df3cbba9c56eb29c2')
+    version('1.0.0-beta', '479f395b30ad630df3cbba9c56eb29c2')
 
     depends_on('wx@3.0.2')
     depends_on('fftw')


### PR DESCRIPTION
Fixes #9259 

### Before
```console
$ spack url parse "https://cistem.org/system/tdf/upload3/cistem-1.0.0-beta-source-code.tar.gz?file=1&type=cistem_details&id=37&force=0"
==> Parsing URL: https://cistem.org/system/tdf/upload3/cistem-1.0.0-beta-source-code.tar.gz?file=1&type=cistem_details&id=37&force=0

==> Matched version regex 10: r'^(?:[a-zA-Z\\d+-]+-)?v?(\\d[\\da-zA-Z.-]*)$'
==> Matched  name   regex  8: r'^([A-Za-z\\d+\\._-]+)$'

==> Detected:
    https://cistem.org/system/tdf/upload3/cistem-1.0.0-beta-source-code.tar.gz?file=1&type=cistem_details&id=37&force=0
                                          ------ ~~~~~~~~~~~~~~~~~~~~~~
    name:    cistem
    version: 1.0.0-beta-source-code

==> Substituting version 9.9.9b:
    https://cistem.org/system/tdf/upload3/cistem-9.9.9b.tar.gz?file=1&type=cistem_details&id=37&force=0
                                          ------ ~~~~~~
$ spack url summary
==> Generating a summary of URL parsing in Spack...

    Total URLs found:          2700
    Names correctly parsed:    2362/2700 (87.48%)
    Versions correctly parsed: 2522/2700 (93.41%)
```

### After
```console
$ spack url parse "https://cistem.org/system/tdf/upload3/cistem-1.0.0-beta-source-code.tar.gz?file=1&type=cistem_details&id=37&force=0"
==> Parsing URL: https://cistem.org/system/tdf/upload3/cistem-1.0.0-beta-source-code.tar.gz?file=1&type=cistem_details&id=37&force=0

==> Matched version regex 10: r'^(?:[a-zA-Z\\d+-]+-)?v?(\\d[\\da-zA-Z.-]*)$'
==> Matched  name   regex  8: r'^([A-Za-z\\d+\\._-]+)$'

==> Detected:
    https://cistem.org/system/tdf/upload3/cistem-1.0.0-beta-source-code.tar.gz?file=1&type=cistem_details&id=37&force=0
                                          ------ ~~~~~~~~~~
    name:    cistem
    version: 1.0.0-beta

==> Substituting version 9.9.9b:
    https://cistem.org/system/tdf/upload3/cistem-9.9.9b-source-code.tar.gz?file=1&type=cistem_details&id=37&force=0
                                          ------ ~~~~~~
$ spack url summary
==> Generating a summary of URL parsing in Spack...

    Total URLs found:          2700
    Names correctly parsed:    2362/2700 (87.48%)
    Versions correctly parsed: 2523/2700 (93.44%)
```

@JusticeForMikeBrown 