### PR TITLE
fix url and checksum

### DIFF
--- a/var/spack/repos/builtin/packages/hadoop/package.py
+++ b/var/spack/repos/builtin/packages/hadoop/package.py
@@ -32,9 +32,9 @@ class Hadoop(Package):
     """
 
     homepage = "http://hadoop.apache.org/"
-    url      = "http://mirrors.ocf.berkeley.edu/apache/hadoop/common/hadoop-2.9.0/hadoop-2.9.0.tar.gz"
+    url      = "http://mirrors.ocf.berkeley.edu/apache/hadoop/common/hadoop-3.1.1/hadoop-3.1.1.tar.gz"
 
-    version('3.1.0', 'f036ebd3fa0ef66ee1819e351d15b6cb')
+    version('3.1.1', '0b6ab06b59ae75f433de387783f19011')
     version('2.9.0', 'b443ead81aa2bd5086f99e62e66a8f64')
 
     depends_on('java', type='run')


### PR DESCRIPTION
The url for the latest Hadoop was broken (3.1.0 doesn't exist).