### PR TITLE
qt4: Patch configure to allow webkit with recent gcc

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -90,6 +90,10 @@ class Qt(Package):
     patch('qt4-pcre-include-conflict.patch', when='@4')
     patch('qt4-el-capitan.patch', when='@4')
 
+    # Allow Qt's configure script to build the webkit option with more recent versions
+    # of gcc.
+    # https://github.com/spack/spack/issues/9205
+    # https://github.com/spack/spack/issues/9209
     patch('qt4-gcc-and-webkit.patch', when='@4')
 
     # Use system openssl for security.

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -90,8 +90,8 @@ class Qt(Package):
     patch('qt4-pcre-include-conflict.patch', when='@4')
     patch('qt4-el-capitan.patch', when='@4')
 
-    # Allow Qt's configure script to build the webkit option with more recent versions
-    # of gcc.
+    # Allow Qt's configure script to build the webkit option with more
+    # recent versions of gcc.
     # https://github.com/spack/spack/issues/9205
     # https://github.com/spack/spack/issues/9209
     patch('qt4-gcc-and-webkit.patch', when='@4')

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -90,6 +90,8 @@ class Qt(Package):
     patch('qt4-pcre-include-conflict.patch', when='@4')
     patch('qt4-el-capitan.patch', when='@4')
 
+    patch('qt4-gcc-and-webkit.patch', when='@4')
+
     # Use system openssl for security.
     depends_on("openssl")
     depends_on("glib", when='@4:')

--- a/var/spack/repos/builtin/packages/qt/qt4-gcc-and-webkit.patch
+++ b/var/spack/repos/builtin/packages/qt/qt4-gcc-and-webkit.patch
@@ -1,0 +1,20 @@
+--- a/configure.orig	2018-09-18 07:02:33.866633000 +1000
++++ b/configure	2018-09-18 07:05:21.935194000 +1000
+@@ -7708,7 +7708,7 @@
+ 
+ 	# Check gcc's version
+ 	case "$(${QMAKE_CONF_COMPILER} -dumpversion)" in
+-	    4*)
++	    [4-8]*)
+ 		;;
+ 	    3.4*)
+ 		canBuildQtXmlPatterns="no"
+@@ -7729,7 +7729,7 @@
+     *-g++*)
+ 	# Check gcc's version
+ 	case "$(${QMAKE_CONF_COMPILER} -dumpversion)" in
+-	    4*|3.4*)
++	    [4-8]*|3.4*)
+ 		;;
+             3.3*)
+                 canBuildWebKit="no"


### PR DESCRIPTION
It seems that Qt's webkit option would not build with earlier gcc versions, so the Qt configure script had some specific exclusions. However, it was not up to date with recent gcc releases. This patch adds gcc 5, 6, 7 and 8 to those assumed to build webkit. I confess I have only tested this on gcc-7, on Linux SLES-12. 

There is also a specific case for hpux/gcc, and I have added the same extra version numbers there, too, totally untested. 