### PR TITLE
apple-libunwind: update path to library

### DIFF
--- a/var/spack/repos/builtin/packages/apple-libunwind/package.py
+++ b/var/spack/repos/builtin/packages/apple-libunwind/package.py
@@ -66,10 +66,24 @@ class AppleLibunwind(Package):
 
     @property
     def libs(self):
-        """ Export the Apple libunwind library
+        """Export the Apple libunwind library. The Apple libunwind library
+        cannot be linked to directly using an absolute path; doing so
+        will cause the linker to throw an error 'cannot link directly
+        with /usr/lib/system/libunwind.dylib' and the linker will
+        suggest linking with System.framework instead. Linking to this
+        framework is equivalent to linking with libSystem.dylib, which
+        can be confirmed on a macOS system by executing at a terminal
+        the command `ls -l
+        /System/Library/Frameworks/System.Framework` -- the file
+        "System" is a symlink to `/usr/lib/libSystem.B.dylib`, and
+        `/usr/lib/libSystem.dylib` also symlinks to this file.
+
+        Running `otool -L /usr/lib/libSystem.dylib` confirms that
+        it will link dynamically to `/usr/lib/system/libunwind.dylib`.
+
         """
-        libs = find_libraries('libunwind',
-                              join_path(self.prefix.lib, 'system'),
+        libs = find_libraries('libSystem',
+                              self.prefix.lib,
                               shared=True, recursive=False)
         if libs:
             return libs


### PR DESCRIPTION
This commit fixes the absolute path of Apple's `libunwind` library. The current version of the apple-libunwind package will link successfully if the libunwind linking flags are passed using `-L/usr/lib/system -lunwind`, but fail if passed as `/usr/lib/system/libunwind.dylib` with an error `cannot link directly with /usr/lib/system/libunwind.dylib`. The linker will suggest linking with `System.framework` instead; the path used in this commit is equivalent to linking with `System.framework`.  This linker error came up in a project that used CMake and attempted to pass an absolute path to libunwind to the system linker.