### PR TITLE
Packages/candle benchmarks

### DIFF
--- a/var/spack/repos/builtin/packages/candle-benchmarks/package.py
+++ b/var/spack/repos/builtin/packages/candle-benchmarks/package.py
@@ -33,7 +33,8 @@ class CandleBenchmarks(Package):
 
     tags = ['proxy-app', 'ecp-proxy-app']
 
-    version('1.0', '6eced30dc15374bc9f90a86d0396e470')
+    version('0.1', sha256='767f74f43ee3a5d4e0f26750f2a96b8433e25a9cd4f2d29938ac8acf263ab58d')
+    version('0.0', '6eced30dc15374bc9f90a86d0396e470')
 
     variant('mpi', default=True, description='Build with MPI support')
 

--- a/var/spack/repos/builtin/packages/ecp-proxy-apps/package.py
+++ b/var/spack/repos/builtin/packages/ecp-proxy-apps/package.py
@@ -47,7 +47,7 @@ class EcpProxyApps(Package):
     depends_on('examinimd@1.0', when='@1.1:')
 
     depends_on('amg@1.0', when='@1.0:')
-    depends_on('candle-benchmarks@1.0', when='@1.0:')
+    depends_on('candle-benchmarks@0.0', when='@1.0:')
     depends_on('laghos@1.0', when='@1.0:')
     depends_on('macsio@1.0', when='@1.0:')
     depends_on('miniamr@1.4.0', when='@1.0:')


### PR DESCRIPTION
Not sure why @brettin renamed version 1.0 to 0.0, but now we have to rename it in spack, too, as the old tag is gone.