### PR TITLE
libhio: add patch for 1.4.1.2 release

### DIFF
--- a/var/spack/repos/builtin/packages/libhio/0001-spack-fix-for-spack-to-work-on-non-cray-systems.patch
+++ b/var/spack/repos/builtin/packages/libhio/0001-spack-fix-for-spack-to-work-on-non-cray-systems.patch
@@ -1,0 +1,31 @@
+From f6f806c2ea46866c9490d2d2ddc3f119666d26d4 Mon Sep 17 00:00:00 2001
+From: Howard Pritchard <hppritcha@gmail.com>
+Date: Mon, 17 Sep 2018 05:05:01 -0600
+Subject: [PATCH] spack: fix for spack to work on non-cray systems
+
+or when one wants to use Open MPI on a cray system with spack.
+The problem is that when using an MPI with spack, its going to
+use a long value for the CC and CXX variables.  This confused
+the libhio configury, resulting in it being built without mpi
+support, leading to failure of xexec to properly compile, etc.
+
+This commit fixes that problem.
+
+Signed-off-by: Howard Pritchard <hppritcha@gmail.com>
+
+diff --git a/configure.ac b/configure.ac
+index afab5553..62d35c85 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -37,7 +37,7 @@ if ( test -n "$XTOS_VERSION" || test -n "$CRAYPE_DIR" ) && (test -z $CC || test
+     if test ! -n "$LD" ; then
+         LD=ld
+     fi
+-elif test ${MPICC} = "mpicc" ; then
++elif test -n "$MPICC" ; then
+     CC=${MPICC}
+     CXX=${MPICXX}
+     hio_use_mpi=1
+-- 
+1.8.3.1
+

--- a/var/spack/repos/builtin/packages/libhio/package.py
+++ b/var/spack/repos/builtin/packages/libhio/package.py
@@ -64,6 +64,7 @@ class Libhio(AutotoolsPackage):
     #
     patch('0001-configury-fix-a-problem-with-bz2-configury.patch', when="@1.4.1.0")
     patch('0001-hdf5-make-docs-optional.patch', when="@1.4.1.0")
+    patch('0001-spack-fix-for-spack-to-work-on-non-cray-systems.patch', when="@1.4.1.2")
 
     def autoreconf(self, spec, prefix):
         autoreconf = which('autoreconf')
@@ -76,4 +77,5 @@ class Libhio(AutotoolsPackage):
         args.append('--with-external_bz2={0}'.format(spec['bzip2'].prefix))
         if '+hdf5' in spec:
             args.append('--with-hdf5={0}'.format(spec['hdf5'].prefix))
+
         return args


### PR DESCRIPTION
Turns out that there was a configury problem in libhio
which caused issues building the package on non-cray
systems, aka when using mpicc and friends.

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>