### PR TITLE
Julia: new-version

### DIFF
--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -189,9 +189,11 @@ class Julia(Package):
         # Install some commonly used packages
         julia = spec['julia'].command
         # As of Julia 1.0, Pkg is no longer imported by default
+        # and Pkg.init is deprecated
         if version >= Version('1.0.0'):
-            julia("-e", 'using Pkg')
-        julia("-e", 'Pkg.init(); Pkg.update()')
+            julia("-e", 'using Pkg; Pkg.update()')
+        else:
+            julia("-e", 'Pkg.init(); Pkg.update()')
 
         # Install HDF5
         if "+hdf5" in spec:
@@ -201,8 +203,12 @@ class Julia(Package):
                 juliarc.write('push!(Libdl.DL_LOAD_PATH, "%s")\n' %
                               spec["hdf5"].prefix.lib)
                 juliarc.write('\n')
-            julia("-e", 'Pkg.add("HDF5"); using HDF5')
-            julia("-e", 'Pkg.add("JLD"); using JLD')
+            if version >= Version('1.0.0'):
+                julia("-e", 'using Pkg; Pkg.add("HDF5"); using HDF5')
+                julia("-e", 'using Pkg; Pkg.add("JLD"); using JLD')
+            else:
+                julia("-e", 'Pkg.add("HDF5"); using HDF5')
+                julia("-e", 'Pkg.add("JLD"); using JLD')
 
         # Install MPI
         if "+mpi" in spec:
@@ -214,7 +220,10 @@ class Julia(Package):
                 juliarc.write('ENV["JULIA_MPI_Fortran_COMPILER"] = "%s"\n' %
                               join_path(spec["mpi"].prefix.bin, "mpifort"))
                 juliarc.write('\n')
-            julia("-e", 'Pkg.add("MPI"); using MPI')
+            if version >= Version('1.0.0'):
+                julia("-e", 'using Pkg; Pkg.add("MPI"); using MPI')
+            else:
+                julia("-e", 'Pkg.add("MPI"); using MPI')
 
         # Install Python
         if "+python" in spec or "+plot" in spec:
@@ -226,15 +235,28 @@ class Julia(Package):
             # Python's OpenSSL package installer complains:
             # Error: PREFIX too long: 166 characters, but only 128 allowed
             # Error: post-link failed for: openssl-1.0.2g-0
-            julia("-e", 'Pkg.add("PyCall"); using PyCall')
+            if version >= Version('1.0.0'):
+                julia("-e", 'using Pkg; Pkg.add("PyCall"); using PyCall')
+            else:
+                julia("-e", 'Pkg.add("PyCall"); using PyCall')
 
         if "+plot" in spec:
-            julia("-e", 'Pkg.add("PyPlot"); using PyPlot')
-            julia("-e", 'Pkg.add("Colors"); using Colors')
-            # These require maybe gtk and image-magick
-            julia("-e", 'Pkg.add("Plots"); using Plots')
-            julia("-e", 'Pkg.add("PlotRecipes"); using PlotRecipes')
-            julia("-e", 'Pkg.add("UnicodePlots"); using UnicodePlots')
+            if version >= Version('1.0.0'):
+                julia("-e", 'using Pkg; Pkg.add("PyPlot"); using PyPlot')
+                julia("-e", 'using Pkg; Pkg.add("Colors"); using Colors')
+                # These require maybe gtk and image-magick
+                julia("-e", 'using Pkg; Pkg.add("Plots"); using Plots')
+                julia("-e",
+                      'using Pkg; Pkg.add("PlotRecipes"); using PlotRecipes')
+                julia("-e",
+                      'using Pkg; Pkg.add("UnicodePlots"); using UnicodePlots')
+            else:
+                julia("-e", 'Pkg.add("PyPlot"); using PyPlot')
+                julia("-e", 'Pkg.add("Colors"); using Colors')
+                # These require maybe gtk and image-magick
+                julia("-e", 'Pkg.add("Plots"); using Plots')
+                julia("-e", 'Pkg.add("PlotRecipes"); using PlotRecipes')
+                julia("-e", 'Pkg.add("UnicodePlots"); using UnicodePlots')
             julia("-e", """\
 using Plots
 using UnicodePlots
@@ -244,6 +266,11 @@ plot(x->sin(x)*cos(x), linspace(0, 2pi))
 
         # Install SIMD
         if "+simd" in spec:
-            julia("-e", 'Pkg.add("SIMD"); using SIMD')
-
-        julia("-e", 'Pkg.status()')
+            if version >= Version('1.0.0'):
+                julia("-e", 'using Pkg; Pkg.add("SIMD"); using SIMD')
+            else:
+                julia("-e", 'Pkg.add("SIMD"); using SIMD')
+        if version >= Version('1.0.0'):
+            julia("-e", 'using Pkg; Pkg.status()')
+        else:
+            julia("-e", 'Pkg.status()')

--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -36,6 +36,7 @@ class Julia(Package):
     git      = "https://github.com/JuliaLang/julia.git"
 
     version('master', branch='master')
+    version('1.0.0',     sha256='1a2497977b1d43bb821a5b7475b4054b29938baae8170881c6b8dd4099d133f1')
     version('0.6.2', '255d80bc8d56d5f059fe18f0798e32f6')
     version('release-0.5', branch='release-0.5')
     version('0.5.2', '8c3fff150a6f96cf0536fb3b4eaa5cbb')

--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -190,7 +190,7 @@ class Julia(Package):
         julia = spec['julia'].command
         # As of Julia 1.0, Pkg is no longer imported by default
         # and Pkg.init is deprecated
-        if version >= Version('1.0.0'):
+        if self.spec.version >= Version('1.0.0'):
             julia("-e", 'using Pkg; Pkg.update()')
         else:
             julia("-e", 'Pkg.init(); Pkg.update()')
@@ -203,7 +203,7 @@ class Julia(Package):
                 juliarc.write('push!(Libdl.DL_LOAD_PATH, "%s")\n' %
                               spec["hdf5"].prefix.lib)
                 juliarc.write('\n')
-            if version >= Version('1.0.0'):
+            if self.spec.version >= Version('1.0.0'):
                 julia("-e", 'using Pkg; Pkg.add("HDF5"); using HDF5')
                 julia("-e", 'using Pkg; Pkg.add("JLD"); using JLD')
             else:
@@ -220,7 +220,7 @@ class Julia(Package):
                 juliarc.write('ENV["JULIA_MPI_Fortran_COMPILER"] = "%s"\n' %
                               join_path(spec["mpi"].prefix.bin, "mpifort"))
                 juliarc.write('\n')
-            if version >= Version('1.0.0'):
+            if self.spec.version >= Version('1.0.0'):
                 julia("-e", 'using Pkg; Pkg.add("MPI"); using MPI')
             else:
                 julia("-e", 'Pkg.add("MPI"); using MPI')
@@ -235,13 +235,13 @@ class Julia(Package):
             # Python's OpenSSL package installer complains:
             # Error: PREFIX too long: 166 characters, but only 128 allowed
             # Error: post-link failed for: openssl-1.0.2g-0
-            if version >= Version('1.0.0'):
+            if self.spec.version >= Version('1.0.0'):
                 julia("-e", 'using Pkg; Pkg.add("PyCall"); using PyCall')
             else:
                 julia("-e", 'Pkg.add("PyCall"); using PyCall')
 
         if "+plot" in spec:
-            if version >= Version('1.0.0'):
+            if self.spec.version >= Version('1.0.0'):
                 julia("-e", 'using Pkg; Pkg.add("PyPlot"); using PyPlot')
                 julia("-e", 'using Pkg; Pkg.add("Colors"); using Colors')
                 # These require maybe gtk and image-magick
@@ -266,11 +266,11 @@ plot(x->sin(x)*cos(x), linspace(0, 2pi))
 
         # Install SIMD
         if "+simd" in spec:
-            if version >= Version('1.0.0'):
+            if self.spec.version >= Version('1.0.0'):
                 julia("-e", 'using Pkg; Pkg.add("SIMD"); using SIMD')
             else:
                 julia("-e", 'Pkg.add("SIMD"); using SIMD')
-        if version >= Version('1.0.0'):
+        if self.spec.version >= Version('1.0.0'):
             julia("-e", 'using Pkg; Pkg.status()')
         else:
             julia("-e", 'Pkg.status()')

--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -212,8 +212,11 @@ class Julia(Package):
 
         # Install MPI
         if "+mpi" in spec:
-            with open(join_path(prefix, "etc", "julia", "juliarc.jl"),
-                      "a") as juliarc:
+            if self.spec.version >= Version('1.0.0'):
+                julia_config = join_path(prefix, "etc", "julia", "startup.jl")
+            else:
+                julia_config = join_path(prefix, "etc", "julia", "juliarc.jl")
+            with open(julia_config, "a") as juliarc:
                 juliarc.write('# MPI\n')
                 juliarc.write('ENV["JULIA_MPI_C_COMPILER"] = "%s"\n' %
                               join_path(spec["mpi"].prefix.bin, "mpicc"))

--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -36,7 +36,7 @@ class Julia(Package):
     git      = "https://github.com/JuliaLang/julia.git"
 
     version('master', branch='master')
-    version('1.0.0',     sha256='1a2497977b1d43bb821a5b7475b4054b29938baae8170881c6b8dd4099d133f1')
+    version('1.0.0', sha256='1a2497977b1d43bb821a5b7475b4054b29938baae8170881c6b8dd4099d133f1')
     version('0.6.2', '255d80bc8d56d5f059fe18f0798e32f6')
     version('release-0.5', branch='release-0.5')
     version('0.5.2', '8c3fff150a6f96cf0536fb3b4eaa5cbb')
@@ -188,6 +188,9 @@ class Julia(Package):
 
         # Install some commonly used packages
         julia = spec['julia'].command
+        # As of Julia 1.0, Pkg is no longer imported by default
+        if version >= Version('1.0.0'):
+            julia("-e", 'using Pkg')
         julia("-e", 'Pkg.init(); Pkg.update()')
 
         # Install HDF5


### PR DESCRIPTION
not ready for merge quite yet

It installs, but the MPI variant (which is on by default) does not work for me, I'm not sure yet if this is due to something in my environment or something changed in the 1.0.0 package. I don't think I got the older version to install with mpi successfully either.

Also, I'm open to suggestions on a better way to handle the Pkg import that's required on 1.0.0. My solution feels clunky.

Will do some more testing & post back if/when ready for merge.