### PR TITLE
Abyss: added variant maxk

### DIFF
--- a/var/spack/repos/builtin/packages/abyss/package.py
+++ b/var/spack/repos/builtin/packages/abyss/package.py
@@ -40,7 +40,6 @@ class Abyss(AutotoolsPackage):
         description='''set the maximum k-mer length. 
 	This value must be a multiple of 32''')
 
-
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
 

--- a/var/spack/repos/builtin/packages/abyss/package.py
+++ b/var/spack/repos/builtin/packages/abyss/package.py
@@ -36,6 +36,11 @@ class Abyss(AutotoolsPackage):
     version('2.0.2', '1623f55ad7f4586e80f6e74b1f27c798')
     version('1.5.2', '10d6d72d1a915e618d41a5cbbcf2364c')
 
+    variant('maxk', values=int, default=0,
+        description='''set the maximum k-mer length. 
+	This value must be a multiple of 32''')
+
+
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
 
@@ -52,9 +57,12 @@ class Abyss(AutotoolsPackage):
     conflicts('^spectrum-mpi')
 
     def configure_args(self):
+	maxk = int(self.spec.variants['maxk'].value)
         args = ['--with-boost=%s' % self.spec['boost'].prefix,
                 '--with-sqlite=%s' % self.spec['sqlite'].prefix,
                 '--with-mpi=%s' % self.spec['mpi'].prefix]
+	if maxk:
+		args.append('--enable-maxk=%s' % maxk)
         if self.spec['mpi'].name == 'mpich':
                 args.append('--enable-mpich')
         return args

--- a/var/spack/repos/builtin/packages/abyss/package.py
+++ b/var/spack/repos/builtin/packages/abyss/package.py
@@ -36,9 +36,9 @@ class Abyss(AutotoolsPackage):
     version('2.0.2', '1623f55ad7f4586e80f6e74b1f27c798')
     version('1.5.2', '10d6d72d1a915e618d41a5cbbcf2364c')
 
-    variant('maxk', values=int, default=0,
-        description='''set the maximum k-mer length. 
-	This value must be a multiple of 32''')
+    variant('maxk', values=int, default=0, 
+            description='''set the maximum k-mer length.
+            This value must be a multiple of 32''')
 
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
@@ -56,12 +56,12 @@ class Abyss(AutotoolsPackage):
     conflicts('^spectrum-mpi')
 
     def configure_args(self):
-	maxk = int(self.spec.variants['maxk'].value)
+        maxk = int(self.spec.variants['maxk'].value)
         args = ['--with-boost=%s' % self.spec['boost'].prefix,
                 '--with-sqlite=%s' % self.spec['sqlite'].prefix,
                 '--with-mpi=%s' % self.spec['mpi'].prefix]
-	if maxk:
-		args.append('--enable-maxk=%s' % maxk)
+        if maxk:
+                args.append('--enable-maxk=%s' % maxk)
         if self.spec['mpi'].name == 'mpich':
                 args.append('--enable-mpich')
         return args


### PR DESCRIPTION
Configuration option `--enable-maxk` is used to modify the maximum value of `k` parameter which is useful in some cases according to [ABySS documentation](https://github.com/bcgsc/abyss/blob/master/README.md#optimizing-the-parameter-k)