### PR TITLE
libpfm4: add version 4.10.1

### DIFF
--- a/var/spack/repos/builtin/packages/libpfm4/package.py
+++ b/var/spack/repos/builtin/packages/libpfm4/package.py
@@ -51,7 +51,9 @@ class Libpfm4(MakefilePackage):
 
         return (flags, None, None)
 
-    # Remove -Werror from CFLAGS (too risky).
+    # Remove -Werror from CFLAGS.  Given the large space of platform,
+    # compiler, version, we don't want to fail the build over a stray
+    # warning.
     def patch(self):
         filter_file('-Werror', '', 'config.mk')
 

--- a/var/spack/repos/builtin/packages/libpfm4/package.py
+++ b/var/spack/repos/builtin/packages/libpfm4/package.py
@@ -33,10 +33,27 @@ class Libpfm4(MakefilePackage):
     homepage = "http://perfmon2.sourceforge.net"
     url      = "https://downloads.sourceforge.net/project/perfmon2/libpfm4/libpfm-4.8.0.tar.gz"
 
+    version('4.10.1', 'd8f66cb9bfa7e1434434e0de6409db5b')
+    version('4.9.0', '42ad4a2e5b8e1f015310db8535739c73')
     version('4.8.0', '730383896db92e12fb2cc10f2d41dd43')
 
     # Fails to build libpfm4 with intel compiler version 16 and 17
     conflicts('%intel@16:17')
+
+    # Set default optimization level (-O2) if not specified.
+    def flag_handler(self, name, flags):
+        if name == 'cflags':
+            for flag in flags:
+                if flag.startswith('-O'):
+                    break
+            else:
+                flags.append('-O2')
+
+        return (flags, None, None)
+
+    # Remove -Werror from CFLAGS (too risky).
+    def patch(self):
+        filter_file('-Werror', '', 'config.mk')
 
     @property
     def install_targets(self):


### PR DESCRIPTION
Add libpfm4 version 4.10.1 (latest).

Set default optimization level (-O2) if not specified in cflags.