### PR TITLE
Catch2: 2.3.0+

### DIFF
--- a/var/spack/repos/builtin/packages/catch/package.py
+++ b/var/spack/repos/builtin/packages/catch/package.py
@@ -39,6 +39,9 @@ class Catch(CMakePackage):
     # - CMake config package was added in 2.1.2
     conflicts('~single_header', when='@:1.6.1')
 
+    version('2.4.0', sha256='ab176de36b886a33aa745fcf34642eac853bf677bda518a88655dc750c72d756')
+    version('2.3.0', sha256='aaf6bbf81ce8522131bae2ea4d013a77b003bbb2017614f5872d5787687f8f5f')
+    # releases 2.3.0+ changed to "catch2/catch.hpp" header
     version('2.2.1', '54e56803c84890636bd7fe6c3856b104')
     version('2.1.0', '70b44068976d46d48f3cd8796f675691d3bc726b')
     version('2.0.1', '5c191a031edebd0525640ed2f38cbf64bacb1803')

--- a/var/spack/repos/builtin/packages/openpmd-api/package.py
+++ b/var/spack/repos/builtin/packages/openpmd-api/package.py
@@ -50,7 +50,7 @@ class OpenpmdApi(CMakePackage):
 
     depends_on('cmake@3.10.0:', type='build')
     depends_on('mpark-variant@1.3.0:')
-    depends_on('catch@2.2.1: ~single_header', type='test')
+    depends_on('catch@2.3.0: ~single_header', type='test')
     depends_on('mpi@2.3:', when='+mpi')  # might become MPI 3.0+
     depends_on('hdf5@1.8.13:', when='+hdf5')
     depends_on('hdf5@1.8.13: ~mpi', when='~mpi +hdf5')


### PR DESCRIPTION
Add the latest two releases of Catch2. In 2.3.0+, the include changed to a future-proof `<catch2/catch.hpp>` path which dependent projects will break upon.

In Spack mainline, `openPMD-api` is the only project that depends on Catch2. Dependencies have been updated accordingly in it: https://github.com/openPMD/openPMD-api/pull/367