### PR TITLE
chapel: new package

### DIFF
--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -1,0 +1,72 @@
+#############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Chapel(AutotoolsPackage):
+    """Chapel is a modern programming language that is...
+
+    parallel: contains first-class concepts for concurrent and parallel computation
+    productive: designed with programmability and performance in mind
+    portable: runs on laptops, clusters, the cloud, and HPC systems
+    scalable: supports locality-oriented features for distributed memory systems
+    open-source: hosted on GitHub, permissively licensed"""
+
+    homepage = "https://chapel-lang.org/"
+    url      = "https://github.com/chapel-lang/chapel/releases/download/1.18.0/chapel-1.18.0.tar.gz"
+
+    version('1.18.0', sha256='68471e1f398b074edcc28cae0be26a481078adc3edea4df663f01c6bd3b6ae0d')
+
+    depends_on('tcsh', type='build')
+    depends_on('perl', type='build')
+    depends_on('python', type='build')
+    depends_on('m4', type='build')
+
+    variant('llvm', default=False, description='build with llvm support')
+    variant('mason', default=False, description='build chapel package manager')
+
+    platforms = ('cygwin32',
+                 'cygwin64',
+                 'darwin',
+                 'linux32',
+                 'linux64',
+                 'netbsd32',
+                 'netbsd64',
+                 'pwr6',
+                 'sunos',
+                 'cray-cs',
+                 'cray-xc',
+                 'cray-xe',
+                 'cray-xk')
+
+    variant('chpl_host_platform', 
+            default=None, 
+            description='platform type',
+            values=platforms)
+
+    def setup_environment(self, spack_env, run_env):
+        spack_env.set('CHPL_HOST_PLATFORM', self.spec.variants['chpl_host_platform'].value)
+        run_env.prepend_path('PATH', join_path(prefix.bin, self.spec.variants['chpl_host_platform'].value))
+        run_env.prepend_path('MANPATH', join_path(prefix, 'man'))

--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -43,26 +43,5 @@ class Chapel(AutotoolsPackage):
     depends_on('python', type='build')
     depends_on('m4', type='build')
 
-    platforms = ('cygwin32',
-                 'cygwin64',
-                 'darwin',
-                 'linux32',
-                 'linux64',
-                 'netbsd32',
-                 'netbsd64',
-                 'pwr6',
-                 'sunos',
-                 'cray-cs',
-                 'cray-xc',
-                 'cray-xe',
-                 'cray-xk')
-
-    variant('chpl_host_platform', 
-            default=None, 
-            description='platform type',
-            values=platforms)
-
     def setup_environment(self, spack_env, run_env):
-        spack_env.set('CHPL_HOST_PLATFORM', self.spec.variants['chpl_host_platform'].value)
-        run_env.prepend_path('PATH', join_path(prefix.bin, self.spec.variants['chpl_host_platform'].value))
         run_env.prepend_path('MANPATH', join_path(prefix, 'man'))

--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -26,12 +26,11 @@ from spack import *
 
 
 class Chapel(AutotoolsPackage):
-    """Chapel is a modern programming language that is...
-
-    parallel: contains first-class concepts for concurrent and parallel computation
-    productive: designed with programmability and performance in mind
-    portable: runs on laptops, clusters, the cloud, and HPC systems
-    scalable: supports locality-oriented features for distributed memory systems
+    """Chapel is a modern programming language that is:
+    parallel: contains first-class concepts for concurrent and parallel computation,
+    productive: designed with programmability and performance in mind,
+    portable: runs on laptops, clusters, the cloud, and HPC systems,
+    scalable: supports locality-oriented features for distributed memory systems,
     open-source: hosted on GitHub, permissively licensed"""
 
     homepage = "https://chapel-lang.org/"
@@ -43,9 +42,6 @@ class Chapel(AutotoolsPackage):
     depends_on('perl', type='build')
     depends_on('python', type='build')
     depends_on('m4', type='build')
-
-    variant('llvm', default=False, description='build with llvm support')
-    variant('mason', default=False, description='build chapel package manager')
 
     platforms = ('cygwin32',
                  'cygwin64',


### PR DESCRIPTION
There should be a lot of other variants added (llvm, mason support, etc.). I'm not clear whether some of the dependencies are quite right (e.g. docs say csh is needed for building, but I'm not sure it was actually used).

Anyway, it does build and I'm able to compile basic chapel programs with it. Haven't done anything beyond the examples yet.