### PR TITLE
Smarter version constraints for packages with mixed versions

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2510,6 +2510,18 @@ class Spec(object):
                 return False
         elif strict and (self.versions or other.versions):
             return False
+        if (not self.virtual) and self.versions.concrete and not strict:
+            version_satisfies = False
+            for v in other.versions:
+                if v in self.package.versions:
+                    if self.version == v:
+                        version_satisfies = True
+                        break
+                elif self.version.satisfies(v):
+                    version_satisfies = True
+                    break
+            if not version_satisfies:
+                return False
 
         # None indicates no constraints when not strict.
         if self.compiler and other.compiler:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2508,20 +2508,25 @@ class Spec(object):
         if self.versions and other.versions:
             if not self.versions.satisfies(other.versions, strict=strict):
                 return False
-        elif strict and (self.versions or other.versions):
-            return False
-        if (not self.virtual) and self.versions.concrete and not strict:
-            version_satisfies = False
-            for v in other.versions:
-                if v in self.package.versions:
-                    if self.version == v:
+
+            # If this package has a mix of x.y and x.y.z versions, and other
+            # specifies an exact x.y version (one that appears in the package
+            # definition), then self should match the version exactly if it
+            # specifies a version
+            if (not self.virtual) and self.versions.concrete and not strict:
+                version_satisfies = False
+                for v in other.versions:
+                    if v in self.package.versions:
+                        if self.version == v:
+                            version_satisfies = True
+                            break
+                    elif self.version.satisfies(v):
                         version_satisfies = True
                         break
-                elif self.version.satisfies(v):
-                    version_satisfies = True
-                    break
-            if not version_satisfies:
-                return False
+                if not version_satisfies:
+                    return False
+        elif strict and (self.versions or other.versions):
+            return False
 
         # None indicates no constraints when not strict.
         if self.compiler and other.compiler:

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -105,8 +105,6 @@ def check_invalid_constraint(spec, constraint):
 
 @pytest.mark.usefixtures('config')
 def test_satisfies_nonstrict_mixed_versions():
-    default = ('build', 'link')
-
     test_versions = [Version('2.1'),
                      Version('2.1.1'),
                      Version('2.2.1')]


### PR DESCRIPTION
(note that although I assert that merging this would close #9281, properly reviewing this PR may take enough time that it makes sense to merge that in the meantime)

Fixes: https://github.com/spack/spack/issues/8432
Closes: https://github.com/spack/spack/pull/9281
Closes: https://github.com/spack/spack/pull/8320

@PDoakORNL @skosukhin 

For a `when` spec which requires `x.y`, Specs with version `x.y.z` were considered to satisfy it even when `x.y` refers to a specific package version and the user intends that the constraint *only* apply to `x.y`.

This updates `Spec.satisfies` so that if a constraint mentions a version which appears exactly in `Spec.package.versions`, that `Spec.version` must match it exactly in order to satisfy the constraint. This is considered reasonable for all constraint checks.

If a package `foo` has versions `2.1` and `2.1.2` and a user wishes to specify that a constraint applies for both, this PR would require that they write `when=@2.1:2.1.2` (where before `when=@2.1` would suffice). I currently don't know whether any package depends on that logic; this PR is not compatible with that sort of inference. I'm inclined to say the inference in this PR is preferable: Without this PR, in the case of `foo` with versions `2.1` and `2.1.2`, the constraint `when=@2.1:2.1.0` is sufficient to include `2.1` and exclude `2.1.2` (regardless of `strict==True`), but IMO that more awkward than what this PR forces on users that want to apply a constraint to `2.1` and `2.1.2` at the same time.

If `when` specifies a version range, this check is not applied, so for example `foo@2.3.1` will satisfy `when=2.1:2.3` even if there is an exact version `2.3` for `foo`.

(note this only changes behavior when `strict=False`, `strict=True` didn't have this issue)