### PR TITLE
qt: fix dbus builds

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -281,7 +281,6 @@ class Qt(Package):
             config_args.append('-I%s/dbus-1.0/include' % dbus.lib)
             config_args.append('-I%s/dbus-1.0' % dbus.include)
             config_args.append('-L%s' % dbus.lib)
-            config_args.append('-ldbus-1')
         else:
             config_args.append('-no-dbus')
 


### PR DESCRIPTION
"-ldbus-1" was being passed as a configure arg and was breaking builds with dbus. I couldn't find any reference to this option in the Qt docs.