### PR TITLE
Update compile flags for netlib-lapack when building with the XL compiler.

### DIFF
--- a/var/spack/repos/builtin/packages/netlib-lapack/ibm-xl.patch
+++ b/var/spack/repos/builtin/packages/netlib-lapack/ibm-xl.patch
@@ -1,3 +1,15 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -62,7 +62,7 @@
+     set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fp-model strict")
+   endif()
+   if("${CMAKE_Fortran_COMPILER}" MATCHES "xlf")
+-    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -qnosave -qstrict=none")
++    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -qnosave -qstrict")
+   endif()
+ # Delete libmtsk in linking sequence for Sun/Oracle Fortran Compiler.
+ # This library is not present in the Sun package SolarisStudio12.3-linux-x86-bin
+
 --- a/CMAKE/CheckLAPACKCompilerFlags.cmake
 +++ b/CMAKE/CheckLAPACKCompilerFlags.cmake
 @@ -43,12 +43,6 @@

--- a/var/spack/repos/builtin/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-lapack/package.py
@@ -178,7 +178,8 @@ class NetlibLapack(CMakePackage):
             # use F77 compiler if IBM XL
             args.extend(['-DCMAKE_Fortran_COMPILER=' + self.compiler.f77,
                          '-DCMAKE_Fortran_FLAGS=' +
-                         (' '.join(self.spec.compiler_flags['fflags']))])
+                         (' '.join(self.spec.compiler_flags['fflags'])) +
+                         " -O3 -qnohot"])
 
         # deprecated routines are commonly needed by, for example, suitesparse
         # Note that OpenBLAS spack is built with deprecated routines


### PR DESCRIPTION
Need to use -O3 -qstrict -qnohot, the combination that allows most tests to run.
Modified ibm-xl.patch and netlib-lapack spackage file.