### PR TITLE
Avoid hdf5+mpi dependency for py-h5py~mpi

### DIFF
--- a/var/spack/repos/builtin/packages/py-h5py/package.py
+++ b/var/spack/repos/builtin/packages/py-h5py/package.py
@@ -53,10 +53,10 @@ class PyH5py(PythonPackage):
     depends_on('py-six', type=('build', 'run'))
 
     # Link dependencies
-    depends_on('hdf5@1.8.4:+hl')
+    depends_on('hdf5@1.8.4:+hl~mpi', when='~mpi')
 
     # MPI dependencies
-    depends_on('hdf5+mpi', when='+mpi')
+    depends_on('hdf5@1.8.4:+hl+mpi', when='+mpi')
     depends_on('mpi', when='+mpi')
     depends_on('py-mpi4py', when='+mpi', type=('build', 'run'))
 


### PR DESCRIPTION
Before this:

```
→ spack spec py-h5py~mpi
Input spec
--------------------------------
py-h5py~mpi

Concretized
--------------------------------
py-h5py@2.8.0%clang@9.0.0-apple~mpi arch=darwin-sierra-x86_64
    ^hdf5@1.10.3%clang@9.0.0-apple~cxx~debug~fortran+hl+mpi+pic+shared~szip~threadsafe arch=darwin-sierra-x86_64
        ^openmpi@3.1.2%clang@9.0.0-apple~cuda+cxx_exceptions fabrics= ~java~memchecker~pmi schedulers= ~sqlite3~thread_multiple+vt arch=darwin-sierra-x86_64
            ^hwloc@1.11.9%clang@9.0.0-apple~cairo~cuda+libxml2~pci+shared arch=darwin-sierra-x86_64
                ^libxml2@2.9.8%clang@9.0.0-apple~python arch=darwin-sierra-x86_64
                    ^pkgconf@1.4.2%clang@9.0.0-apple arch=darwin-sierra-x86_64
                    ^xz@5.2.4%clang@9.0.0-apple arch=darwin-sierra-x86_64
                    ^zlib@1.2.11%clang@9.0.0-apple+optimize+pic+shared arch=darwin-sierra-x86_64
    ^py-cython@0.28.3%clang@9.0.0-apple arch=darwin-sierra-x86_64
        ^python@2.7.15%clang@9.0.0-apple+dbm~optimizations patches=123082ab3483ded78e86d7c809e98a804b3465b4683c96bd79a2fd799f572244 +pic+pythoncmd~shared~tk~ucs4 arch=darwin-sierra-x86_64
            ^bzip2@1.0.6%clang@9.0.0-apple+shared arch=darwin-sierra-x86_64
            ^gdbm@1.14.1%clang@9.0.0-apple arch=darwin-sierra-x86_64
                ^readline@7.0%clang@9.0.0-apple arch=darwin-sierra-x86_64
                    ^ncurses@6.1%clang@9.0.0-apple~symlinks~termlib arch=darwin-sierra-x86_64
            ^openssl@1.0.2o%clang@9.0.0-apple+systemcerts arch=darwin-sierra-x86_64
            ^sqlite@3.23.1%clang@9.0.0-apple~functions arch=darwin-sierra-x86_64
    ^py-numpy@1.15.1%clang@9.0.0-apple+blas+lapack arch=darwin-sierra-x86_64
        ^openblas@0.3.3%clang@9.0.0-apple cpu_target= ~ilp64 patches=47cfa7a952ac7b2e4632c73ae199d69fb54490627b66a62c681e21019c4ddc9d +pic+shared threads=none ~virtual_machine arch=darwin-sierra-x86_64
        ^py-setuptools@40.2.0%clang@9.0.0-apple arch=darwin-sierra-x86_64
    ^py-pkgconfig@1.2.2%clang@9.0.0-apple arch=darwin-sierra-x86_64
 + ~/.s/d/packages.yaml
        ^py-nose@1.3.7%clang@9.0.0-apple arch=darwin-sierra-x86_64
    ^py-six@1.11.0%clang@9.0.0-apple arch=darwin-sierra-x86_64
```

After this:

```
→ spack spec py-h5py~mpi
Input spec
--------------------------------
py-h5py~mpi

Concretized
--------------------------------
py-h5py@2.8.0%clang@9.0.0-apple~mpi arch=darwin-sierra-x86_64
    ^hdf5@1.10.3%clang@9.0.0-apple~cxx~debug~fortran+hl~mpi+pic+shared~szip~threadsafe arch=darwin-sierra-x86_64
        ^zlib@1.2.11%clang@9.0.0-apple+optimize+pic+shared arch=darwin-sierra-x86_64
    ^py-cython@0.28.3%clang@9.0.0-apple arch=darwin-sierra-x86_64
        ^python@2.7.15%clang@9.0.0-apple+dbm~optimizations patches=123082ab3483ded78e86d7c809e98a804b3465b4683c96bd79a2fd799f572244 +pic+pythoncmd~shared~tk~ucs4 arch=darwin-sierra-x86_64
            ^bzip2@1.0.6%clang@9.0.0-apple+shared arch=darwin-sierra-x86_64
            ^gdbm@1.14.1%clang@9.0.0-apple arch=darwin-sierra-x86_64
                ^readline@7.0%clang@9.0.0-apple arch=darwin-sierra-x86_64
                    ^ncurses@6.1%clang@9.0.0-apple~symlinks~termlib arch=darwin-sierra-x86_64
                        ^pkgconf@1.4.2%clang@9.0.0-apple arch=darwin-sierra-x86_64
            ^openssl@1.0.2o%clang@9.0.0-apple+systemcerts arch=darwin-sierra-x86_64
            ^sqlite@3.23.1%clang@9.0.0-apple~functions arch=darwin-sierra-x86_64
    ^py-numpy@1.15.1%clang@9.0.0-apple+blas+lapack arch=darwin-sierra-x86_64
        ^openblas@0.3.3%clang@9.0.0-apple cpu_target= ~ilp64 patches=47cfa7a952ac7b2e4632c73ae199d69fb54490627b66a62c681e21019c4ddc9d +pic+shared threads=none ~virtual_machine arch=darwin-sierra-x86_64
        ^py-setuptools@40.2.0%clang@9.0.0-apple arch=darwin-sierra-x86_64
    ^py-pkgconfig@1.2.2%clang@9.0.0-apple arch=darwin-sierra-x86_64
        ^py-nose@1.3.7%clang@9.0.0-apple arch=darwin-sierra-x86_64
    ^py-six@1.11.0%clang@9.0.0-apple arch=darwin-sierra-x86_64
```