### PR TITLE
Allow secondary generators when building with CMake.

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -115,7 +115,8 @@ class CMakePackage(PackageBase):
         if primary_generator not in valid_generators:
             msg  = "Invalid CMake generator: '{0}'\n".format(generator)
             msg += "CMakePackage currently supports the following "
-            msg += "primary generators: '{0}'".format("', '".join(valid_generators))
+            msg += "primary generators: '{0}'".\
+                   format("', '".join(valid_generators))
             raise InstallError(msg)
 
         try:

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -120,12 +120,8 @@ def test_cmake_bad_generator(config, mock_packages):
     s.concretize()
     pkg = spack.repo.get(s)
     pkg.generator = 'Yellow Sticky Notes'
-    try:
+    with pytest.raises(spack.package.InstallError):
         get_std_cmake_args(pkg)
-    except spack.package.InstallError as e:
-        return e
-    else:
-        pytest.fail('InstallError was not raised!')
 
 
 def test_cmake_secondary_generator(config, mock_packages):

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -115,6 +115,27 @@ def test_cmake_std_args(config, mock_packages):
     assert get_std_cmake_args(pkg)
 
 
+def test_cmake_bad_generator(config, mock_packages):
+    s = Spec('cmake-client')
+    s.concretize()
+    pkg = spack.repo.get(s)
+    pkg.generator = 'Yellow Sticky Notes'
+    try:
+        get_std_cmake_args(pkg)
+    except spack.package.InstallError as e:
+        return e
+    else:
+        pytest.fail('InstallError was not raised!')
+
+
+def test_cmake_secondary_generator(config, mock_packages):
+    s = Spec('cmake-client')
+    s.concretize()
+    pkg = spack.repo.get(s)
+    pkg.generator = 'CodeBlocks - Unix Makefiles'
+    assert get_std_cmake_args(pkg)
+
+
 @pytest.mark.usefixtures('config', 'mock_packages')
 class TestAutotoolsPackage(object):
 


### PR DESCRIPTION
CMake supports the notion of secondary generators which provide extra information to (e.g.) IDEs over and above that normally provided by the primary generator.

The list of primary generators ('Unix Makefiles' and 'Ninja') supported by Spack has not changed.

Since the secondary generator is irrelevant to a Spack build, it is passed on to CMake without further validation.