### PR TITLE
travis: require sudo in an attempt to avoid build timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,37 +23,44 @@ jobs:
   include:
     - stage: 'style checks'
       python: '2.7'
+      sudo: required
       os: linux
       language: python
       env: TEST_SUITE=flake8
     - stage: 'unit tests + documentation'
       python: '2.6'
+      sudo: required
       os: linux
       language: python
       env: TEST_SUITE=unit
     - python: '2.7'
+      sudo: required
       os: linux
       language: python
       env: TEST_SUITE=unit
     - python: '3.4'
+      sudo: required
       os: linux
       language: python
       env: TEST_SUITE=unit
     - python: '3.5'
+      sudo: required
       os: linux
       language: python
       env: TEST_SUITE=unit
     - python: '3.6'
+      sudo: required
       os: linux
       language: python
       env: TEST_SUITE=unit
     - python: '3.7'
+      sudo: required
       os: linux
       dist: xenial
-      sudo: true
       language: python
       env: TEST_SUITE=unit
     - python: '3.6'
+      sudo: required
       os: linux
       language: python
       env: TEST_SUITE=doc

--- a/share/spack/qa/run-unit-tests
+++ b/share/spack/qa/run-unit-tests
@@ -28,4 +28,8 @@ ${coverage_run} bin/spack help -a
 ${coverage_run} bin/spack -p --lines 20 spec mpileaks%gcc ^elfutils@0.170
 
 # Run unit tests with code coverage
-${coverage_run} bin/spack test "$@"
+extra_args=""
+if [[ -n "$@" ]]; then
+    extra_args="-k $@"
+fi
+${coverage_run} bin/spack test --verbose "$extra_args"


### PR DESCRIPTION
- Many container builds are timing out frequently during Spack tests in Travis CI.

- Travis recommends adding `sudo: required` to see whether this is an infrastructure issue or something else.

- added `sudo: required` to all Linux builds.