### PR TITLE
mpich: fix 3.2 patch

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -80,7 +80,7 @@ spack package at this time.''',
     # fix MPI_Barrier segmentation fault
     # see https://lists.mpich.org/pipermail/discuss/2016-May/004764.html
     # and https://lists.mpich.org/pipermail/discuss/2016-June/004768.html
-    patch('mpich32_clang.patch', when='@3.2%clang')
+    patch('mpich32_clang.patch', when='@3.2:3.2.0%clang')
 
     depends_on('libfabric', when='netmod=ofi')
 


### PR DESCRIPTION
patch does not apply to 3.2.1 (released in late 2017).
Given that it fixes the issue discussed in May 2016, most likely
it shall apply only to 3.2

EDIT: apparently I added the patch in https://github.com/spack/spack/pull/5235, probably the way patches are applied changed