### PR TITLE
Forgotten Python integration in verrou package

### DIFF
--- a/var/spack/repos/builtin/packages/verrou/package.py
+++ b/var/spack/repos/builtin/packages/verrou/package.py
@@ -41,6 +41,11 @@ class Verrou(AutotoolsPackage):
     depends_on('libtool', type='build')
     depends_on('m4', type='build')
 
+    # Verrou will switch to Python 3 in its next release
+    depends_on('python@:2.99.99', when='@:2.99.99', type=('build', 'run'))
+    depends_on('python@3.0:', when='@3.0.0:', type=('build', 'run'))
+    extends('python')
+
     def patch(self):
         # We start with the verrou source tree and a "valgrind-x.y.z" subdir.
         # But we actually need a valgrind source tree with a "verrou" subdir.


### PR DESCRIPTION
The verrou package provides a couple of python-based tools, which I forgot to take into account. This PR fixes that.