### PR TITLE
added py-matplotlib version 3.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -34,6 +34,7 @@ class PyMatplotlib(PythonPackage):
     homepage = "https://pypi.python.org/pypi/matplotlib"
     url      = "https://pypi.io/packages/source/m/matplotlib/matplotlib-2.0.2.tar.gz"
 
+    version('3.0.0', '39c7f44c8fa0f24cbf684137371ce4ae')
     version('2.2.3', '403b0bddd751d71187416f20d4cff100')
     version('2.2.2', 'dd1e49e041309a7fd4e32be8bf17c3b6')
     version('2.0.2', '061111784278bde89b5d4987014be4ca')
@@ -67,6 +68,7 @@ class PyMatplotlib(PythonPackage):
     # directories (i.e., matplotlib and basemap)
     depends_on('py-setuptools', type=('build', 'run'))
 
+    depends_on('python@3.5:', when='@3:')
     depends_on('libpng@1.2:')
     depends_on('freetype@2.3:')
     patch('freetype-include-path.patch', when='@2.2.2:2.9.9')  # Patch to pick up correct freetype headers


### PR DESCRIPTION
Matplotlib 3.0+ does not support Python 2.x, 3.0, 3.1, 3.2, 3.3, or 3.4.
Beginning with Matplotlib 3.0, Python 3.5 and above is required. 