### PR TITLE
lighttpd: fix bin directory

### DIFF
--- a/var/spack/repos/builtin/packages/lighttpd/package.py
+++ b/var/spack/repos/builtin/packages/lighttpd/package.py
@@ -34,3 +34,6 @@ class Lighttpd(CMakePackage):
 
     version('1.4.50', sha256='c9a9f175aca6db22ebebbc47de52c54a99bbd1dce8d61bb75103609a3d798235')
     version('1.4.49', sha256='8b744baf9f29c386fff1a6d2e435491e726cb8d29cfdb1fe20ab782ee2fc2ac7')
+
+    def cmake_args(self):
+        return ["-DSBINDIR=bin"]


### PR DESCRIPTION
lighttpd was installing to /sbin by default and not getting included in the path.