### PR TITLE
New package pythia6, including optional extra code for compatibility with Root.

### DIFF
--- a/var/spack/repos/builtin/packages/pythia6/CMakeLists.txt
+++ b/var/spack/repos/builtin/packages/pythia6/CMakeLists.txt
@@ -1,0 +1,115 @@
+# ======================================================================
+#  pythia6 main build file
+#
+#  setup cmake
+#  cd .../path/to/build/directory
+#  cmake [-DCMAKE_INSTALL_PREFIX=/install/path]
+#        [-DCMAKE_BUILD_TYPE=<RelWithDebInfo|Debug|Release|MinSizeRel> ]
+#        [-Drun_long_tests:BOOL=ON]
+#        .../path/to/pythia/source
+#  make
+#  make test
+#  make install
+# ======================================================================
+
+# use cmake 2.6 or later
+cmake_minimum_required (VERSION 2.6)
+
+project(pythia6 C Fortran)
+message(STATUS "pythia version is ${PYTHIA6_VERSION}")
+
+enable_testing()
+
+#build all libraries in a single directory to enable testing
+set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
+
+# set compiler flags
+# default GNU compiler flags:
+# DEBUG           -g
+# RELEASE         -O3 -DNDEBUG
+# MINSIZEREL      -Os -DNDEBUG
+# RELWITHDEBINFO  -O2 -g
+set( CMAKE_C_FLAGS_DEBUG "-g -O0" )
+set( CMAKE_C_FLAGS_RELWITHDEBINFO "-O3 -g -DNDEBUG -fno-omit-frame-pointer" )
+set( CMAKE_C_FLAGS_RELEASE "-O3 -DNDEBUG" )
+set( CMAKE_Fortran_FLAGS_DEBUG "-g -O0 -fno-second-underscore" )
+set( CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-O3 -g -DNDEBUG -fno-omit-frame-pointer -fno-second-underscore" )
+set( CMAKE_Fortran_FLAGS_RELEASE "-O3 -DNDEBUG -fno-second-underscore" )
+
+message(STATUS "CMAKE_Fortran_COMPILER_INIT = ${CMAKE_Fortran_COMPILER_INIT}")
+message(STATUS "CMAKE_Fortran_COMPILER_FULLPATH = ${CMAKE_Fortran_COMPILER_FULLPATH}")
+message(STATUS "CMAKE_Fortran_COMPILER = ${CMAKE_Fortran_COMPILER}")
+
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "" FORCE)
+endif()
+message(STATUS "cmake build type set to ${CMAKE_BUILD_TYPE}")
+
+message("ENV_FLAGS = $ENV{FFLAGS}")
+string(TOUPPER ${CMAKE_BUILD_TYPE} BTYPE_UC )
+if( ${BTYPE_UC} MATCHES "DEBUG")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS_DEBUG}")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS_DEBUG}")
+elseif( ${BTYPE_UC} MATCHES "RELEASE")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS_RELEASE}")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS_RELEASE}")
+elseif( ${BTYPE_UC} MATCHES "RELWITHDEBINFO")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS_RELWITHDEBINFO}")
+endif()
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} $ENV{CFLAGS}")
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} $ENV{FFLAGS}")
+message("CMAKE_C_FLAGS = ${CMAKE_C_FLAGS}")
+message("CMAKE_Fortran_FLAGS = ${CMAKE_Fortran_FLAGS}")
+
+# source
+# shared library
+file(GLOB src_files *.c *.F *.f)
+add_library(Pythia6 SHARED ${src_files})
+
+# Installation:
+# Library.
+install(TARGETS Pythia6 DESTINATION lib)
+
+# Include-able file.
+install( FILES example/main60.f
+         DESTINATION include )
+
+# Documentation.
+install(DIRECTORY doc DESTINATION .)
+
+# Examples
+install(DIRECTORY example DESTINATION .)
+
+# tests
+macro( pythia_test testname )
+  set ( package_library_list ${PROJECT_BINARY_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}CLHEP-${PACKAGE}-${VERSION}${CMAKE_STATIC_LIBRARY_SUFFIX} )
+  link_libraries( Pythia6 )
+  message( STATUS "building ${testname} from ${CMAKE_CURRENT_SOURCE_DIR}/example in ${CMAKE_CURRENT_BINARY_DIR}" )
+  add_executable(${testname} example/${testname}.f)
+  add_test( ${testname} ${CMAKE_CURRENT_BINARY_DIR}/${testname} )
+endmacro( pythia_test )
+
+pythia_test( main61 )
+pythia_test( main63 )
+pythia_test( main66 )
+pythia_test( main67 )
+pythia_test( main68 )
+pythia_test( main69 )
+pythia_test( main71 )
+pythia_test( main72 )
+pythia_test( main73 )
+pythia_test( main75 )
+pythia_test( main77 )
+pythia_test( main78 )
+pythia_test( main81 )
+
+# these examples take a while to run
+if( run_long_tests )
+  pythia_test( main62 )
+  pythia_test( main64 )
+  pythia_test( main65 )
+  pythia_test( main70 )
+  pythia_test( main74 )
+  pythia_test( main79 )
+endif( run_long_tests )

--- a/var/spack/repos/builtin/packages/pythia6/package.py
+++ b/var/spack/repos/builtin/packages/pythia6/package.py
@@ -1,0 +1,144 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+from spack import *
+import os
+from six import iteritems
+from six.moves.urllib.parse import urlparse
+
+
+class Pythia6(CMakePackage):
+    """PYTHIA is a program for the generation of high-energy physics events,
+    i.e. for the description of collisions at high energies between elementary
+    particles such as e+, e-, p and pbar in various combinations.
+
+    PYTHIA6 is a Fortran package which is no longer maintained: new
+    prospective users should use Pythia8 instead.
+
+    This recipe includes patches required to interoperate with Root.
+    """
+
+    homepage = 'https://pythiasix.hepforge.org/'
+    url = 'http://www.hepforge.org/archive/pythiasix/pythia-6.4.28.tgz'
+
+    version('6.4.28',
+            sha256='01cbff47e99365b5e46f6d62c1735d3cae1932c4710604850d59f538cb758020')
+
+    variant('root', default=False,
+            description='Build extra (non OEM) code to allow use by Root.')
+
+    # In the unlikely event of new versions >6.4.28,
+    # pythia6_common_address.c should be checked for accuracy against
+    # the definitions of the relevant COMMON blocks in the Pythia6
+    # Fortran source, and patched if necessaary.
+    resource(
+        name='root-pythia6-shim',
+        url='https://root.cern.ch/download/pythia6.tar.gz',
+        sha256='d613dcb27c905710e2f13a934913cc5545e3e5d0e477e580107385d9ef260056',
+        when='+root',
+        destination='.',
+        placement={'pythia6_common_address.c': 'pythia6_common_address.c',
+                   'tpythia6_called_from_cc.F': 'tpythia6_called_from_cc.F'}
+    )
+
+    # Download examples separately.
+    examples \
+        = {'main60.f':
+           'd713b8b267c4405cc9d31c58bba267ae3378902a26fa52393003bf35fd56902c',
+           'main61.f':
+           'e2a3d5524e43d16f60d9edc6e7198d41006d1ba127fb7b0e265aa509e13128b4',
+           'main62.f':
+           'dce822a72fe2d6cfb6d43c479ba98928fb0a39290a6ee26fdcacc66229313045',
+           'main63.f':
+           'b2dd343b3cd7969979b80c564d82b92e0d776d66bb19d346b52f2af27adeb62d',
+           'main64.f':
+           'a35f2f232e6e0d68d67fd350d4d46b0a353f5c7811de0c2db47ae16d17ed1843',
+           'main65.f':
+           '03c81e0bbd77710b0461e18265e80e3bd51360b9f416c86013401f882ac39a5e',
+           'main66.f':
+           '50dd9221a7e84ee7c5005db6758e5880d190eab8cce8a52e7c7b29e9fee8d3da',
+           'main67.f':
+           '1984aa90fe4e3d628c3bcceaa6fca1b08231d835158d975fa171337d55ca4a2f',
+           'main68.f':
+           'c8d6def1298477ffec6a1d98c7e02dcee0debe6badc7c63f752f9194b82f212d',
+           'main69.f':
+           'd14399d43f8c4b670907558849d3e5a4d7625d027de3c10002185c58b20b061a',
+           'main71.f':
+           '2e47af778003b0596e8999f0914033c6eda7335211b9e96ac3075d45a3cde12e',
+           'main72.f':
+           'e27ce2af68b40436c51c65767ebb5ff0955ab8dfdfc5fc5c217ae73cd53070da',
+           'main73.f':
+           '567db2d1a66896ce5103ffa7e10742442b0e934088883e91339536e0249772c4',
+           'main75.f':
+           'b850986c43a5af1e7d13b66d22b01584e3c68bb338be32eac39e31f971b80be4',
+           'main77.f':
+           '0679852c4f35719531ad38dc1dbb374b884181eb5e483c36d8867ccb449177a4',
+           'main78.f':
+           '5babc59fe6a0bd57d97ec398cf01745bc9b72ce6ce0711e934d53c7821e21912',
+           'main79.f':
+           '27ca84d6d0877f3605cbc1b865c3e1f571e7d2c9301094a4122e726a903dbead',
+           'main81.f':
+           'b02fecd1cd0f9ba16eaae53e9da0ba602569fdf0e46856cccdfb4c5b7ba33e8b',
+           'ttbar.lhe':
+           'fb0d43175cc392b19c2b6633dcf673d0b56229b60bec92df4aa782c7196b149c'}
+
+    for example, checksum in iteritems(examples):
+        resource(name=example,
+                 url='http://pythiasix.hepforge.org/examples/{0}'.
+                 format(example),
+                 sha256=checksum,
+                 expand=False,
+                 destination='example',
+                 placement={example: example}
+             )
+
+    # Docs.
+    docs \
+        = {'http://www.hepforge.org/archive/pythiasix/update_notes-6.4.28.txt':
+            'a229be4ba9a4eb65a9d53600a5f388b620038d56694c6cb4671c2be224b67751',
+           'http://home.thep.lu.se/~torbjorn/pythia6/lutp0613man2.pdf':
+           '03d637310ea80f0d7aea761492bd38452c602890d8cf913a1ec9edacd79fa43d',
+           'https://pythiasix.hepforge.org/pythia6-announcement.txt':
+           '2a52def41f0c93e32e0db58dbcf072b987ebfbd32e42ccfc1f9382fcf65f1271'}
+
+    for docurl, checksum in iteritems(docs):
+        doc = os.path.basename(urlparse(docurl).path)
+        resource(name=doc,
+                 url=docurl,
+                 sha256=checksum,
+                 expand=False,
+                 destination='doc',
+                 placement={doc: doc}
+             )
+
+    patch('pythia6.patch', level=0)
+
+    def patch(self):
+        # Use our provided CMakeLists.txt
+        llnl.util.filesystem.copy(os.path.join(os.path.dirname(__file__),
+                                               'CMakeLists.txt'),
+                                  self.stage.source_path)
+
+    def cmake_args(self):
+        args = ['-DPYTHIA6_VERSION={0}'.format(self.version.dotted)]
+        return args

--- a/var/spack/repos/builtin/packages/pythia6/package.py
+++ b/var/spack/repos/builtin/packages/pythia6/package.py
@@ -31,7 +31,9 @@ from six.moves.urllib.parse import urlparse
 def _is_integral(x):
     """Accepts only integral values."""
     try:
-        return isinstance(int(x), numbers.Integral) and not isinstance(x, bool)
+        return isinstance(int(x), numbers.Integral) and \
+            (not isinstance(x, bool)) and \
+            int(x) == x
     except ValueError:
         return False
 

--- a/var/spack/repos/builtin/packages/pythia6/package.py
+++ b/var/spack/repos/builtin/packages/pythia6/package.py
@@ -22,9 +22,18 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 from spack import *
+import numbers
 import os
 from six import iteritems
 from six.moves.urllib.parse import urlparse
+
+
+def _is_integral(x):
+    """Accepts only integral values."""
+    try:
+        return isinstance(int(x), numbers.Integral) and not isinstance(x, bool)
+    except ValueError:
+        return False
 
 
 class Pythia6(CMakePackage):
@@ -46,6 +55,8 @@ class Pythia6(CMakePackage):
 
     variant('root', default=False,
             description='Build extra (non OEM) code to allow use by Root.')
+
+    variant('nmxhep', default=4000, values=_is_integral, description='Extent of particle arrays in the /HEPEVT/ COMMON block.')
 
     # In the unlikely event of new versions >6.4.28,
     # pythia6_common_address.c should be checked for accuracy against
@@ -138,6 +149,9 @@ class Pythia6(CMakePackage):
         llnl.util.filesystem.copy(os.path.join(os.path.dirname(__file__),
                                                'CMakeLists.txt'),
                                   self.stage.source_path)
+        filter_file(r'^(\s+PARAMETER\s*\(\s*NMXHEP\s*=\s*)\d+',
+                    r'\1{0}'.format(self.spec.variants['nmxhep'].value),
+                    'pyhepc.f')
 
     def cmake_args(self):
         args = ['-DPYTHIA6_VERSION={0}'.format(self.version.dotted)]

--- a/var/spack/repos/builtin/packages/pythia6/pythia6.patch
+++ b/var/spack/repos/builtin/packages/pythia6/pythia6.patch
@@ -1,0 +1,278 @@
+diff -Naur pytime.f pytime.f
+--- pytime.f	2018-08-23 11:24:27.000000000 -0500
++++ pytime.f	2018-08-23 11:46:08.189999826 -0500
+@@ -1,4 +1,3 @@
+- 
+ C*********************************************************************
+  
+ C...PYTIME
+@@ -59,17 +58,18 @@
+ C      IDATI(6)=ISEC
+  
+ C...Example 4: GNU LINUX libU77, SunOS.
+-C      CALL IDATE(IDTEMP)
+-C      IDATI(1)=IDTEMP(3)
+-C      IDATI(2)=IDTEMP(2)
+-C      IDATI(3)=IDTEMP(1)
+-C      CALL ITIME(IDTEMP)
+-C      IDATI(4)=IDTEMP(1)
+-C      IDATI(5)=IDTEMP(2)
+-C      IDATI(6)=IDTEMP(3)
++      CALL IDATE(IDTEMP)
++      IDATI(1)=IDTEMP(3)
++      IDATI(2)=IDTEMP(2)
++      IDATI(3)=IDTEMP(1)
++      CALL ITIME(IDTEMP)
++      IDATI(4)=IDTEMP(1)
++      IDATI(5)=IDTEMP(2)
++      IDATI(6)=IDTEMP(3)
+  
+ C...Common code to ensure right century.
+       IDATI(1)=2000+MOD(IDATI(1),100)
+  
+       RETURN
+       END
++ 
+diff -Naur upevnt.f upevnt.f
+--- upevnt.f	2018-08-23 11:24:27.000000000 -0500
++++ upevnt.f	2018-08-23 11:46:08.189999826 -0500
+@@ -1,56 +1,3 @@
+-
+-C...Old example: handles a simple Pythia 6.4 initialization file.
+- 
+-c      SUBROUTINE UPINIT
+- 
+-C...Double precision and integer declarations.
+-c      IMPLICIT DOUBLE PRECISION(A-H, O-Z)
+-c      IMPLICIT INTEGER(I-N)
+- 
+-C...Commonblocks.
+-c      COMMON/PYDAT1/MSTU(200),PARU(200),MSTJ(200),PARJ(200)
+-c      COMMON/PYPARS/MSTP(200),PARP(200),MSTI(200),PARI(200)
+-c      SAVE /PYDAT1/,/PYPARS/
+- 
+-C...User process initialization commonblock.
+-c      INTEGER MAXPUP
+-c      PARAMETER (MAXPUP=100)
+-c      INTEGER IDBMUP,PDFGUP,PDFSUP,IDWTUP,NPRUP,LPRUP
+-c      DOUBLE PRECISION EBMUP,XSECUP,XERRUP,XMAXUP
+-c      COMMON/HEPRUP/IDBMUP(2),EBMUP(2),PDFGUP(2),PDFSUP(2),
+-c     &IDWTUP,NPRUP,XSECUP(MAXPUP),XERRUP(MAXPUP),XMAXUP(MAXPUP),
+-c     &LPRUP(MAXPUP)
+-c      SAVE /HEPRUP/
+- 
+-C...Read info from file.
+-c      IF(MSTP(161).GT.0) THEN
+-c        READ(MSTP(161),*,END=110,ERR=110) IDBMUP(1),IDBMUP(2),EBMUP(1),
+-c     &  EBMUP(2),PDFGUP(1),PDFGUP(2),PDFSUP(1),PDFSUP(2),IDWTUP,NPRUP
+-c        DO 100 IPR=1,NPRUP
+-c          READ(MSTP(161),*,END=110,ERR=110) XSECUP(IPR),XERRUP(IPR),
+-c     &    XMAXUP(IPR),LPRUP(IPR)
+-c  100   CONTINUE
+-c        RETURN
+-C...Error or prematurely reached end of file.
+-c  110   WRITE(MSTU(11),5000)
+-c        STOP
+- 
+-C...Else not implemented.
+-c      ELSE
+-c        WRITE(MSTU(11),5100)
+-c        STOP
+-c      ENDIF
+- 
+-C...Format for error printout.
+-c 5000 FORMAT(1X,'Error: UPINIT routine failed to read information'/
+-c     &1X,'Execution stopped!')
+-c 5100 FORMAT(1X,'Error: You have not implemented UPINIT routine'/
+-c     &1X,'Dummy routine in PYTHIA file called instead.'/
+-c     &1X,'Execution stopped!')
+- 
+-c      RETURN
+-c      END
+- 
+ C*********************************************************************
+  
+ C...UPEVNT
+@@ -120,3 +67,54 @@
+  
+       RETURN
+       END
++
++C...Old example: handles a simple Pythia 6.4 event file.
++ 
++c      SUBROUTINE UPEVNT
++ 
++C...Double precision and integer declarations.
++c      IMPLICIT DOUBLE PRECISION(A-H, O-Z)
++c      IMPLICIT INTEGER(I-N)
++ 
++C...Commonblocks.
++c      COMMON/PYDAT1/MSTU(200),PARU(200),MSTJ(200),PARJ(200)
++c      COMMON/PYPARS/MSTP(200),PARP(200),MSTI(200),PARI(200)
++c      SAVE /PYDAT1/,/PYPARS/
++ 
++C...User process event common block.
++c      INTEGER MAXNUP
++c      PARAMETER (MAXNUP=500)
++c      INTEGER NUP,IDPRUP,IDUP,ISTUP,MOTHUP,ICOLUP
++c      DOUBLE PRECISION XWGTUP,SCALUP,AQEDUP,AQCDUP,PUP,VTIMUP,SPINUP
++c      COMMON/HEPEUP/NUP,IDPRUP,XWGTUP,SCALUP,AQEDUP,AQCDUP,IDUP(MAXNUP),
++c     &ISTUP(MAXNUP),MOTHUP(2,MAXNUP),ICOLUP(2,MAXNUP),PUP(5,MAXNUP),
++c     &VTIMUP(MAXNUP),SPINUP(MAXNUP)
++c      SAVE /HEPEUP/
++ 
++C...Read info from file.
++c      IF(MSTP(162).GT.0) THEN
++c        READ(MSTP(162),*,END=110,ERR=110) NUP,IDPRUP,XWGTUP,SCALUP,
++c     &  AQEDUP,AQCDUP
++c        DO 100 I=1,NUP
++c          READ(MSTP(162),*,END=110,ERR=110) IDUP(I),ISTUP(I),
++c     &    MOTHUP(1,I),MOTHUP(2,I),ICOLUP(1,I),ICOLUP(2,I),
++c     &    (PUP(J,I),J=1,5),VTIMUP(I),SPINUP(I)
++c  100   CONTINUE
++c        RETURN
++C...Special when reached end of file or other error.
++c  110   NUP=0
++ 
++C...Else not implemented.
++c      ELSE
++c        WRITE(MSTU(11),5000)
++c        STOP
++c      ENDIF
++ 
++C...Format for error printout.
++c 5000 FORMAT(1X,'Error: You have not implemented UPEVNT routine'/
++c     &1X,'Dummy routine in PYTHIA file called instead.'/
++c     &1X,'Execution stopped!')
++ 
++c      RETURN
++c      END
++ 
+diff -Naur upinit.f upinit.f
+--- upinit.f	2018-08-23 11:24:27.000000000 -0500
++++ upinit.f	2018-08-23 11:46:08.190999819 -0500
+@@ -1,4 +1,3 @@
+- 
+ C*********************************************************************
+  
+ C...UPINIT
+@@ -64,3 +63,56 @@
+  
+       RETURN
+       END
++
++C...Old example: handles a simple Pythia 6.4 initialization file.
++ 
++c      SUBROUTINE UPINIT
++ 
++C...Double precision and integer declarations.
++c      IMPLICIT DOUBLE PRECISION(A-H, O-Z)
++c      IMPLICIT INTEGER(I-N)
++ 
++C...Commonblocks.
++c      COMMON/PYDAT1/MSTU(200),PARU(200),MSTJ(200),PARJ(200)
++c      COMMON/PYPARS/MSTP(200),PARP(200),MSTI(200),PARI(200)
++c      SAVE /PYDAT1/,/PYPARS/
++ 
++C...User process initialization commonblock.
++c      INTEGER MAXPUP
++c      PARAMETER (MAXPUP=100)
++c      INTEGER IDBMUP,PDFGUP,PDFSUP,IDWTUP,NPRUP,LPRUP
++c      DOUBLE PRECISION EBMUP,XSECUP,XERRUP,XMAXUP
++c      COMMON/HEPRUP/IDBMUP(2),EBMUP(2),PDFGUP(2),PDFSUP(2),
++c     &IDWTUP,NPRUP,XSECUP(MAXPUP),XERRUP(MAXPUP),XMAXUP(MAXPUP),
++c     &LPRUP(MAXPUP)
++c      SAVE /HEPRUP/
++ 
++C...Read info from file.
++c      IF(MSTP(161).GT.0) THEN
++c        READ(MSTP(161),*,END=110,ERR=110) IDBMUP(1),IDBMUP(2),EBMUP(1),
++c     &  EBMUP(2),PDFGUP(1),PDFGUP(2),PDFSUP(1),PDFSUP(2),IDWTUP,NPRUP
++c        DO 100 IPR=1,NPRUP
++c          READ(MSTP(161),*,END=110,ERR=110) XSECUP(IPR),XERRUP(IPR),
++c     &    XMAXUP(IPR),LPRUP(IPR)
++c  100   CONTINUE
++c        RETURN
++C...Error or prematurely reached end of file.
++c  110   WRITE(MSTU(11),5000)
++c        STOP
++ 
++C...Else not implemented.
++c      ELSE
++c        WRITE(MSTU(11),5100)
++c        STOP
++c      ENDIF
++ 
++C...Format for error printout.
++c 5000 FORMAT(1X,'Error: UPINIT routine failed to read information'/
++c     &1X,'Execution stopped!')
++c 5100 FORMAT(1X,'Error: You have not implemented UPINIT routine'/
++c     &1X,'Dummy routine in PYTHIA file called instead.'/
++c     &1X,'Execution stopped!')
++ 
++c      RETURN
++c      END
++ 
+diff -Naur upveto.f upveto.f
+--- upveto.f	2018-08-23 11:24:27.000000000 -0500
++++ upveto.f	2018-08-23 11:46:08.190999819 -0500
+@@ -1,54 +1,3 @@
+-
+-C...Old example: handles a simple Pythia 6.4 event file.
+- 
+-c      SUBROUTINE UPEVNT
+- 
+-C...Double precision and integer declarations.
+-c      IMPLICIT DOUBLE PRECISION(A-H, O-Z)
+-c      IMPLICIT INTEGER(I-N)
+- 
+-C...Commonblocks.
+-c      COMMON/PYDAT1/MSTU(200),PARU(200),MSTJ(200),PARJ(200)
+-c      COMMON/PYPARS/MSTP(200),PARP(200),MSTI(200),PARI(200)
+-c      SAVE /PYDAT1/,/PYPARS/
+- 
+-C...User process event common block.
+-c      INTEGER MAXNUP
+-c      PARAMETER (MAXNUP=500)
+-c      INTEGER NUP,IDPRUP,IDUP,ISTUP,MOTHUP,ICOLUP
+-c      DOUBLE PRECISION XWGTUP,SCALUP,AQEDUP,AQCDUP,PUP,VTIMUP,SPINUP
+-c      COMMON/HEPEUP/NUP,IDPRUP,XWGTUP,SCALUP,AQEDUP,AQCDUP,IDUP(MAXNUP),
+-c     &ISTUP(MAXNUP),MOTHUP(2,MAXNUP),ICOLUP(2,MAXNUP),PUP(5,MAXNUP),
+-c     &VTIMUP(MAXNUP),SPINUP(MAXNUP)
+-c      SAVE /HEPEUP/
+- 
+-C...Read info from file.
+-c      IF(MSTP(162).GT.0) THEN
+-c        READ(MSTP(162),*,END=110,ERR=110) NUP,IDPRUP,XWGTUP,SCALUP,
+-c     &  AQEDUP,AQCDUP
+-c        DO 100 I=1,NUP
+-c          READ(MSTP(162),*,END=110,ERR=110) IDUP(I),ISTUP(I),
+-c     &    MOTHUP(1,I),MOTHUP(2,I),ICOLUP(1,I),ICOLUP(2,I),
+-c     &    (PUP(J,I),J=1,5),VTIMUP(I),SPINUP(I)
+-c  100   CONTINUE
+-c        RETURN
+-C...Special when reached end of file or other error.
+-c  110   NUP=0
+- 
+-C...Else not implemented.
+-c      ELSE
+-c        WRITE(MSTU(11),5000)
+-c        STOP
+-c      ENDIF
+- 
+-C...Format for error printout.
+-c 5000 FORMAT(1X,'Error: You have not implemented UPEVNT routine'/
+-c     &1X,'Dummy routine in PYTHIA file called instead.'/
+-c     &1X,'Execution stopped!')
+- 
+-c      RETURN
+-c      END
+- 
+ C*********************************************************************
+  
+ C...UPVETO
+@@ -98,3 +47,4 @@
+  
+       RETURN
+       END
++ 


### PR DESCRIPTION
This packaging of Pythia6 pulls the pre-split sources from HepForge. With the `+root` variant, two extra source files are pulled from https://root.cern.ch/ to enable compatibility with `root`.
