### PR TITLE
[WIP] update "spack clean" with "--locks" option

### DIFF
--- a/lib/spack/spack/cmd/clean.py
+++ b/lib/spack/spack/cmd/clean.py
@@ -110,3 +110,8 @@ def clean(parser, args):
                         dname = os.path.join(root, d)
                         tty.debug('Removing {0}'.format(dname))
                         shutil.rmtree(dname)
+
+    if args.locks:
+        itertools.chain(spack.db._lock_files(),
+                        spack.caches.misc_cache._lock_files(),
+                        [os.path.join(spack.paths.stage_path, '.lock')])

--- a/lib/spack/spack/cmd/clean.py
+++ b/lib/spack/spack/cmd/clean.py
@@ -62,7 +62,8 @@ def setup_parser(subparser):
         help="remove .pyc, .pyo files and __pycache__ folders")
     subparser.add_argument(
         '-l', '--locks', action='store_true',
-        help="remove lock files (typically unnecessary)")
+        help="remove lock files (WARNING: this is only safe if no other"
+             " Spack process is running)")
     subparser.add_argument(
         '-a', '--all', action=AllClean, help="equivalent to -sdmp", nargs=0
     )
@@ -76,7 +77,7 @@ def setup_parser(subparser):
 def clean(parser, args):
     # If nothing was set, activate the default
     if not any([args.specs, args.stage, args.downloads, args.misc_cache,
-                args.python_cache]):
+                args.python_cache, args.locks]):
         args.stage = True
 
     # Then do the cleaning falling through the cases

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -217,6 +217,9 @@ class Database(object):
         """Get a read lock context manager for use in a `with` block."""
         return ReadTransaction(self.lock, self._read, timeout=timeout)
 
+    def _lock_files(self):
+        return [self._lock_path, self.prefix_lock_path]
+
     def prefix_lock(self, spec):
         """Get a lock on a particular spec's installation directory.
 

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -225,16 +225,19 @@ class Stage(object):
             if self.name not in Stage.stage_locks:
                 sha1 = hashlib.sha1(self.name.encode('utf-8')).digest()
                 lock_id = prefix_bits(sha1, bit_length(sys.maxsize))
-                stage_lock_path = os.path.join(spack.paths.stage_path, '.lock')
 
                 Stage.stage_locks[self.name] = spack.util.lock.Lock(
-                    stage_lock_path, lock_id, 1)
+                    Stage.lock_path(), lock_id, 1)
 
             self._lock = Stage.stage_locks[self.name]
 
         # When stages are reused, we need to know whether to re-create
         # it.  This marks whether it has been created/destroyed.
         self.created = False
+
+    @staticmethod
+    def lock_path():
+        return os.path.join(spack.paths.stage_path, '.lock')
 
     def __enter__(self):
         """

--- a/lib/spack/spack/util/file_cache.py
+++ b/lib/spack/spack/util/file_cache.py
@@ -80,6 +80,14 @@ class FileCache(object):
             self._locks[key] = Lock(self._lock_path(key))
         return self._locks[key]
 
+    def _lock_files(self):
+        lock_files = []
+        for root, dirs, files in os.walk(self.root):
+            for fname in files:
+                if fname.endswith('.lock'):
+                    lock_files.append(os.path.join(root, fname))
+        return lock_files
+
     def init_entry(self, key):
         """Ensure we can access a cache file. Create a lock for it if needed.
 


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/8915

As noted in https://github.com/spack/spack/issues/8915#issuecomment-418166162 there are conditions where Spack may crash and when restarted attempt to acquire filesystem locks that its previous incarnation held and have not yet been cleaned up. It was observed that removing the lock files releases the associated filesystem locks.

This is only safe if the user knows that a single instance of Spack is running, so it is not included in `spack clean -a`. It is anticipated to be useful in the case that Spack is running in a script and the script restarts Spack automatically.

Generally my hypothesis is that waiting would also resolve the issue but that doesn't apply for scripting, and it doesn't make sense to force the user to wait if they are running a single Spack instance.