### PR TITLE
ant: add tested 1.10.0, switch build target

### DIFF
--- a/var/spack/repos/builtin/packages/ant/package.py
+++ b/var/spack/repos/builtin/packages/ant/package.py
@@ -34,8 +34,7 @@ class Ant(Package):
     homepage = "http://ant.apache.org/"
     url = "https://archive.apache.org/dist/ant/source/apache-ant-1.9.7-src.tar.gz"
 
-    # 1.10.0 requires newer Java, not yet tested....
-    # version('1.10.0', '2260301bb7734e34d8b96f1a5fd7979c')
+    version('1.10.0', '2260301bb7734e34d8b96f1a5fd7979c')
     version('1.9.9',  '22c9d40dabafbec348aaada226581239')
     version('1.9.8',  '16253d516d5c33c4af9ef8fafcf1004b')
     version('1.9.7',  'a2fd9458c76700b7be51ef12f07d4bb1')
@@ -46,4 +45,4 @@ class Ant(Package):
     def install(self, spec, prefix):
         env['ANT_HOME'] = self.prefix
         bash = which('bash')
-        bash('./build.sh', 'install')
+        bash('./build.sh', 'install-lite')


### PR DESCRIPTION
Current version wouldn't build with the latest java.
Building javadocs would fail without all of the optional dependencies as well, switched target to `install-lite` which only builds the program.