### PR TITLE
Ucx add latest v 1.3.1

### DIFF
--- a/var/spack/repos/builtin/packages/hwloc/package.py
+++ b/var/spack/repos/builtin/packages/hwloc/package.py
@@ -44,10 +44,11 @@ class Hwloc(AutotoolsPackage):
     """
 
     homepage = "http://www.open-mpi.org/projects/hwloc/"
-    url      = "http://www.open-mpi.org/software/hwloc/v1.9/downloads/hwloc-1.9.tar.gz"
+    url      = "https://download.open-mpi.org/release/hwloc/v2.0/hwloc-2.0.2.tar.gz"
     list_url = "http://www.open-mpi.org/software/hwloc/"
     list_depth = 2
 
+    version('2.0.2',  '71d1211eaa4b25ac7ad80cf326784e87')
     version('2.0.1',  '442b2482bb5b81983ed256522aadbf94')
     version('2.0.0',  '027e6928ae0b5b64c821d0a71a61cd82')
     version('1.11.9', '4d5f5da8b1d09731d82e865ecf3fa399')

--- a/var/spack/repos/builtin/packages/libhio/package.py
+++ b/var/spack/repos/builtin/packages/libhio/package.py
@@ -40,6 +40,7 @@ class Libhio(AutotoolsPackage):
     # We don't include older versions since they are missing features
     # needed by current and future consumers of libhio
     #
+    version('1.4.1.2', '38c7d33210155e5796b16d536d1b5cfe')
     version('1.4.1.0', '6ef566fd8cf31fdcd05fab01dd3fae44')
 
     #

--- a/var/spack/repos/builtin/packages/ucx/package.py
+++ b/var/spack/repos/builtin/packages/ucx/package.py
@@ -30,12 +30,12 @@ class Ucx(AutotoolsPackage):
     MPI/PGAS frameworks"""
 
     homepage = "http://www.openucx.org"
-    url      = "https://github.com/openucx/ucx/releases/download/v1.2.1/ucx-1.2.1.tar.gz"
-
+    url      = "https://github.com/openucx/ucx/releases/download/v1.3.1/ucx-1.3.1.tar.gz"
     # Current
-    version('1.3.0', '2fdc3028eac3ef3ee1b1b523d170c071')
+    version('1.3.1', '443ffdd64dc0e912b672a0ccb37ff666')
 
     # Still supported
+    version('1.3.0', '2fdc3028eac3ef3ee1b1b523d170c071')
     version('1.2.2', 'ff3fe65e4ebe78408fc3151a9ce5d286')
     version('1.2.1', '697c2fd7912614fb5a1dadff3bfa485c')
 


### PR DESCRIPTION
## Update latest version to 1.3.1
https://github.com/openucx/ucx/releases

## Test builds

### linux-rhel7-x86_64
==> Successfully installed ucx
  Fetch: 1.61s.  Build: 1m 6.61s.  Total: 1m 8.22s.
[+] /scratch/dantopa/spack.current.ccscs4/opt/spack/linux-rhel7-x86_64/gcc-8.1.0/ucx-1.3.1-vsxug5oqz7nnrl5swj4orqosaovq5cvo
dantopa@ccscs4.lanl.gov:spack.current.ccscs4 $ cd var/spack/repos/builtin/packages/ucx/

### linux-rhel7-aarch64 - ARM Clang @ 18.4.1
==> Successfully installed ucx
  Fetch: 0.01s.  Build: 1m 7.85s.  Total: 1m 7.86s.
[+] /scratch/users/dantopa/new-spack/spack.arm.hypre/opt/spack/linux-rhel7-aarch64/clang-18.4.1/ucx-1.3.1-aec6oopelqajhialgpwxlikgaaa5ahkq

### linux-rhel7-aarch64 - gcc @ 7.3.0
==> Successfully installed ucx
  Fetch: 1.84s.  Build: 1m 26.20s.  Total: 1m 28.04s.
[+] /scratch/users/dantopa/new-spack/spack.arm.hypre/opt/spack/linux-rhel7-aarch64/gcc-8.2.0/ucx-1.3.1-vdt34p5xoj6jhuytj3eievin6hd5fuof
