### PR TITLE
gmap-gsnap: fixing issue caused by lack of value in simd variant

### DIFF
--- a/var/spack/repos/builtin/packages/gmap-gsnap/package.py
+++ b/var/spack/repos/builtin/packages/gmap-gsnap/package.py
@@ -37,6 +37,9 @@ class GmapGsnap(AutotoolsPackage):
     version('2018-02-12', '13152aedeef9ac66be915fc6bf6464f2')
     version('2017-06-16', 'fcc91b8bdd4bf12ae3124de0c00db0c0')
     version('2014-12-28', '1ab07819c9e5b5b8970716165ccaa7da')
+    
+    depends_on('zlib')
+    depends_on('bzip2')
 
     variant(
         'simd',

--- a/var/spack/repos/builtin/packages/gmap-gsnap/package.py
+++ b/var/spack/repos/builtin/packages/gmap-gsnap/package.py
@@ -42,7 +42,8 @@ class GmapGsnap(AutotoolsPackage):
         'simd',
         description='CPU support.',
         values=('avx2', 'sse42', 'avx512', 'sse2'),
-        multi=True
+        multi=True,
+        default='sse2'
     )
 
     def configure(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/gmap-gsnap/package.py
+++ b/var/spack/repos/builtin/packages/gmap-gsnap/package.py
@@ -37,7 +37,7 @@ class GmapGsnap(AutotoolsPackage):
     version('2018-02-12', '13152aedeef9ac66be915fc6bf6464f2')
     version('2017-06-16', 'fcc91b8bdd4bf12ae3124de0c00db0c0')
     version('2014-12-28', '1ab07819c9e5b5b8970716165ccaa7da')
-    
+
     depends_on('zlib')
     depends_on('bzip2')
 


### PR DESCRIPTION
fixes an issue introduced by #8087 where builds with no value supplied for the simd variant would fail in the configure phase.

The easiest way to fix it is to add a default value.