### PR TITLE
Bazel updates

### DIFF
--- a/var/spack/repos/builtin/packages/bazel/fix_env_handling-0.13.0.patch
+++ b/var/spack/repos/builtin/packages/bazel/fix_env_handling-0.13.0.patch
@@ -1,6 +1,6 @@
 --- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelConfiguration.java.orig	2018-05-23 12:11:29.319402761 +0200
 +++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelConfiguration.java	2018-05-23 12:35:21.817904301 +0200
-@@ -150,6 +150,121 @@
+@@ -150,6 +150,126 @@
        builder.put("PATH", null);
        builder.put("LD_LIBRARY_PATH", null);
      }
@@ -53,6 +53,11 @@
 +      String spack_short_spec = System.getenv("SPACK_SHORT_SPEC");
 +      if (spack_short_spec != null) {
 +          builder.put("SPACK_SHORT_SPEC", spack_short_spec);
++      }
++
++      String spack_system_dirs = System.getenv("SPACK_SYSTEM_DIRS");
++      if (spack_system_dirs != null) {
++          builder.put("SPACK_SYSTEM_DIRS", spack_system_dirs);
 +      }
 +
 +      String spack_cc = System.getenv("SPACK_CC");

--- a/var/spack/repos/builtin/packages/bazel/fix_env_handling-0.17.2.patch
+++ b/var/spack/repos/builtin/packages/bazel/fix_env_handling-0.17.2.patch
@@ -1,0 +1,131 @@
+diff --git a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
+index 72c40ac..2e73530 100755
+--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
++++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
+@@ -168,6 +168,126 @@ public class BazelRuleClassProvider {
+       env.put("PATH", null);
+     }
+ 
++    String spack_prefix = System.getenv("SPACK_PREFIX");
++    if (spack_prefix != null) {
++      env.put("SPACK_PREFIX", spack_prefix);
++    }
++
++    String spack_env_path = System.getenv("SPACK_ENV_PATH");
++    if (spack_env_path != null) {
++        env.put("SPACK_ENV_PATH", spack_env_path);
++    }
++
++    String spack_debug_log_id = System.getenv("SPACK_DEBUG_LOG_ID");
++    if (spack_debug_log_id != null) {
++        env.put("SPACK_DEBUG_LOG_ID", spack_debug_log_id);
++    }
++
++    String spack_debug_log_dir = System.getenv("SPACK_DEBUG_LOG_DIR");
++    if (spack_debug_log_dir != null) {
++        env.put("SPACK_DEBUG_LOG_DIR", spack_debug_log_dir);
++    }
++
++    String spack_compiler_spec = System.getenv("SPACK_COMPILER_SPEC");
++    if (spack_compiler_spec != null) {
++        env.put("SPACK_COMPILER_SPEC", spack_compiler_spec);
++    }
++
++    String spack_cc_rpath_arg = System.getenv("SPACK_CC_RPATH_ARG");
++    if (spack_cc_rpath_arg != null) {
++        env.put("SPACK_CC_RPATH_ARG", spack_cc_rpath_arg);
++    }
++
++    String spack_cxx_rpath_arg = System.getenv("SPACK_CXX_RPATH_ARG");
++    if (spack_cxx_rpath_arg != null) {
++        env.put("SPACK_CXX_RPATH_ARG", spack_cxx_rpath_arg);
++    }
++
++    String spack_f77_rpath_arg = System.getenv("SPACK_F77_RPATH_ARG");
++    if (spack_f77_rpath_arg != null) {
++        env.put("SPACK_F77_RPATH_ARG", spack_f77_rpath_arg);
++    }
++
++    String spack_fc_rpath_arg = System.getenv("SPACK_FC_RPATH_ARG");
++    if (spack_fc_rpath_arg != null) {
++        env.put("SPACK_FC_RPATH_ARG", spack_fc_rpath_arg);
++    }
++
++    String spack_short_spec = System.getenv("SPACK_SHORT_SPEC");
++    if (spack_short_spec != null) {
++        env.put("SPACK_SHORT_SPEC", spack_short_spec);
++    }
++
++    String spack_system_dirs = System.getenv("SPACK_SYSTEM_DIRS");
++    if (spack_system_dirs != null) {
++        env.put("SPACK_SYSTEM_DIRS", spack_system_dirs);
++    }
++
++    String spack_cc = System.getenv("SPACK_CC");
++    if (spack_cc != null) {
++        env.put("SPACK_CC", spack_cc);
++    }
++
++    String spack_cxx = System.getenv("SPACK_CXX");
++    if (spack_cxx != null) {
++        env.put("SPACK_CXX", spack_cxx);
++    }
++
++    String spack_f77 = System.getenv("SPACK_F77");
++    if (spack_f77 != null) {
++        env.put("SPACK_F77", spack_f77);
++    }
++
++    String spack_fc = System.getenv("SPACK_FC");
++    if (spack_fc != null) {
++        env.put("SPACK_FC", spack_fc);
++    }
++
++    String spack_cflags = System.getenv("SPACK_CFLAGS");
++    if (spack_cflags != null) {
++        env.put("SPACK_CFLAGS", spack_cflags);
++    }
++
++    String spack_cxxflags = System.getenv("SPACK_CXXFLAGS");
++    if (spack_cxxflags != null) {
++        env.put("SPACK_CXXFLAGS", spack_cxxflags);
++    }
++
++    String spack_fcflags = System.getenv("SPACK_FCFLAGS");
++    if (spack_fcflags != null) {
++        env.put("SPACK_FCFLAGS", spack_fcflags);
++    }
++
++    String spack_fflags = System.getenv("SPACK_FFLAGS");
++    if (spack_fflags != null) {
++        env.put("SPACK_FFLAGS", spack_fflags);
++    }
++
++    String spack_ldflags = System.getenv("SPACK_LDFLAGS");
++    if (spack_ldflags != null) {
++        env.put("SPACK_LDFLAGS", spack_ldflags);
++    }
++
++    String spack_ldlibs = System.getenv("SPACK_LDLIBS");
++    if (spack_ldlibs != null) {
++        env.put("SPACK_LDLIBS", spack_ldlibs);
++    }
++
++    String spack_debug = System.getenv("SPACK_DEBUG");
++    if (spack_debug != null) {
++        env.put("SPACK_DEBUG", spack_debug);
++    }
++
++    String spack_test_command = System.getenv("SPACK_TEST_COMMAND");
++    if (spack_test_command != null) {
++        env.put("SPACK_TEST_COMMAND", spack_test_command);
++    }
++
++    String spack_dependencies = System.getenv("SPACK_DEPENDENCIES");
++    if (spack_dependencies != null) {
++        env.put("SPACK_DEPENDENCIES", spack_dependencies);
++    }
++
+     // Shell environment variables specified via options take precedence over the
+     // ones inherited from the fragments. In the long run, these fragments will
+     // be replaced by appropriate default rc files anyway.

--- a/var/spack/repos/builtin/packages/bazel/package.py
+++ b/var/spack/repos/builtin/packages/bazel/package.py
@@ -34,6 +34,10 @@ class Bazel(Package):
     homepage = "https://www.bazel.io"
     url = "https://github.com/bazelbuild/bazel/releases/download/0.11.1/bazel-0.11.1-dist.zip"
 
+    version('0.17.2', '9805c0593e781295126af6b8be8cc7a9')
+    version('0.16.1', 'c333d903c5275286e79316eb19dd742d')
+    version('0.15.0', 'fb6b928b62f068697bd66ad6d13aad53')
+    version('0.14.1', '841900316b3ec9b996babe1c5b0b92e1')
     version('0.13.0', '64a5124025c1618b550faec64a9b6fa3')
     version('0.12.0', 'b5d67564ceecfe2005a885fe2ffe0da3')
     version('0.11.1', '80daac6b100b7f8e2b17d133150eba44')
@@ -54,11 +58,13 @@ class Bazel(Package):
 
     patch('fix_env_handling.patch', when='@:0.4.5')
     patch('fix_env_handling-0.9.0.patch', when='@0.9.0:0.12.0')
-    patch('fix_env_handling-0.13.0.patch', when='@0.13.0:')
+    patch('fix_env_handling-0.13.0.patch', when='@0.13.0:0.13.999')
+    patch('fix_env_handling-0.17.2.patch', when='@0.14.0:')
     patch('link.patch')
     patch('cc_configure.patch', when='@:0.4.5')
     patch('unix_cc_configure.patch', when='@0.9.0')
-    patch('unix_cc_configure-0.10.0.patch', when='@0.10.0:')
+    patch('unix_cc_configure-0.10.0.patch', when='@0.10.0:0.14.999')
+    patch('unix_cc_configure-0.17.2.patch', when='@0.15.0:')
 
     def url_for_version(self, version):
         if version >= Version('0.4.1'):

--- a/var/spack/repos/builtin/packages/bazel/unix_cc_configure-0.17.2.patch
+++ b/var/spack/repos/builtin/packages/bazel/unix_cc_configure-0.17.2.patch
@@ -1,0 +1,25 @@
+diff --git a/tools/cpp/unix_cc_configure.bzl b/tools/cpp/unix_cc_configure.bzl
+index 361931b..a79129b 100755
+--- a/tools/cpp/unix_cc_configure.bzl
++++ b/tools/cpp/unix_cc_configure.bzl
+@@ -145,11 +145,19 @@ def get_escaped_cxx_inc_directories(repository_ctx, cc, lang_flag, additional_fl
+     else:
+         inc_dirs = result.stderr[index1 + 1:index2].strip()
+ 
+-    return [
++    default_inc_directories = [
+         _prepare_include_path(repository_ctx, _cxx_inc_convert(p))
+         for p in inc_dirs.split("\n")
+     ]
+ 
++    env = repository_ctx.os.environ
++    if "SPACK_DEPENDENCIES" in env:
++        for dep in env["SPACK_DEPENDENCIES"].split(":"):
++            path = dep + "/include"
++            default_inc_directories.append(path)
++
++    return default_inc_directories
++
+ def _is_compiler_option_supported(repository_ctx, cc, option):
+     """Checks that `option` is supported by the C compiler. Doesn't %-escape the option."""
+     result = repository_ctx.execute([


### PR DESCRIPTION
Building bazel yielded errors since commit cd9691de5314fcfaf17d47a63264acef5716c0b6. The first commit fixes the build for older bazel versions, the second commit adds new versions and ports the patches to these versions. 