### PR TITLE
update rdma-core package to specify rundir

### DIFF
--- a/var/spack/repos/builtin/packages/rdma-core/package.py
+++ b/var/spack/repos/builtin/packages/rdma-core/package.py
@@ -40,7 +40,12 @@ class RdmaCore(CMakePackage):
     conflicts('platform=darwin', msg='rdma-core requires FreeBSD or Linux')
     conflicts('%intel', msg='rdma-core cannot be built with intel (use gcc instead)')
 
+# NOTE: specify CMAKE_INSTALL_RUNDIR explicitly to prevent rdma-core from
+#       using the spack staging build dir (which may be a very long file
+#       system path) as a component in compile-time static strings such as
+#       IBACM_SERVER_PATH.
     def cmake_args(self):
         cmake_args = ["-DCMAKE_INSTALL_SYSCONFDIR=" +
-                      self.spec.prefix.etc]
+                      self.spec.prefix.etc,
+                      "-DCMAKE_INSTALL_RUNDIR=/var/run"]
         return cmake_args


### PR DESCRIPTION
The rdma-core code base will use the build path to construct string constants at cmake time (see https://github.com/linux-rdma/rdma-core/blob/master/CMakeLists.txt#L102), which can then trigger the failure of compile time string length safety checks in the code base (see https://github.com/linux-rdma/rdma-core/blob/master/librdmacm/acm.c#L170) if the path is too deep.

This problem is relatively easy to trigger in spack if your staging path is something like "/gpfs/mira-home/carns/working/src/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/rdma-core-20-jseuuuvggown67ufiu74quv64aopa2xp/"

This PR explicitly sets a cmake option to override the rundir and set it to a fixed absolute path (/var/run) so that the rdma-core spack package will build reliably regardless of spack staging path.