### PR TITLE
Module parsing: improve checking of path variables based on package name

### DIFF
--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -185,25 +185,25 @@ def get_path_from_module(mod):
 
 
 def get_path_from_module_contents(text, module_name):
-    tty.debug("Original module name: " + module_name)
-
-    module_name = module_name.replace('-', '_').upper()
-    components = module_name.split('/')
+    tty.debug("Module name: " + module_name)
+    pkg_var_prefix = module_name.replace('-', '_').upper()
+    components = pkg_var_prefix.split('/')
+    # For modules with multiple components like foo/1.0.1, retrieve the package
+    # name "foo" from the module name
     if len(components) > 1:
-        module_name = components[-2]
-
-    tty.debug("Formatted module name: " + module_name)
+        pkg_var_prefix = components[-2]
+    tty.debug("Package directory variable prefix: " + pkg_var_prefix)
 
     # If it sets the LD_LIBRARY_PATH or CRAY_LD_LIBRARY_PATH, use that
     for line in text:
-        pattern = r'\WLD_LIBRARY_PATH'
+        pattern = r'\W(CRAY_)?LD_LIBRARY_PATH'
         if re.search(pattern, line):
             path = get_path_arg_from_module_line(line)
             return path[:path.find('/lib')]
 
     # If it lists its package directory, return that
     for line in text:
-        pattern = r'\W{0}_DIR'.format(module_name.upper())
+        pattern = r'\W{0}_DIR'.format(pkg_var_prefix)
         if re.search(pattern, line):
             return get_path_arg_from_module_line(line)
 

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -185,6 +185,15 @@ def get_path_from_module(mod):
 
 
 def get_path_from_module_contents(text, module_name):
+    tty.debug("Original module name: " + module_name)
+
+    module_name = module_name.replace('-', '_').upper()
+    components = module_name.split('/')
+    if len(components) > 1:
+        module_name = components[-2]
+
+    tty.debug("Formatted module name: " + module_name)
+
     # If it sets the LD_LIBRARY_PATH or CRAY_LD_LIBRARY_PATH, use that
     for line in text:
         pattern = r'\WLD_LIBRARY_PATH'


### PR DESCRIPTION
Module parsing (to extract package paths from associated module files of Spack external packages) was potentially missing cases where a module named something like `foo-bar/1.0.0` set an environment variable like `FOO_BAR_DIR`, and in that case not finding the package.

This adds some formatting steps when checking the contents of `module show` for a variable set by the module based on the package name.

This is related to https://github.com/spack/spack/issues/9232 but technically this type of parsing would be required for either strategy (in the case of #9232 it's a matter of checking for the right environment variable).