### PR TITLE
patching p4est to select the proper openmp lib

### DIFF
--- a/var/spack/repos/builtin/packages/p4est/package.py
+++ b/var/spack/repos/builtin/packages/p4est/package.py
@@ -45,9 +45,22 @@ class P4est(AutotoolsPackage):
     depends_on('mpi')
     depends_on('zlib')
 
+    # from sc upstream, correct the default libraries
+    patch('https://github.com/cburstedde/libsc/commit/b506aab224b988fec210cc212469f2c4f58b2d04.patch',
+          sha256='e9418b1a9347a409be241cd185519b31950e42a7f55b6fb80ce53097657098ee',
+          working_dir='sc')
+    patch('https://github.com/cburstedde/libsc/commit/b45a51a7ef97883a3d4dcbd05cb2c77890a76f75.patch',
+          sha256='8fb829e34e3a1e28afdd6e56e0bdc1d377af569b7ccb9e9d8da0eeb5829ed27e',
+          working_dir='sc')
+
+    def autoreconf(self, spec, prefix):
+        bootstrap = Executable('./bootstrap')
+        bootstrap()
+
     def configure_args(self):
         return [
             '--enable-mpi',
+            '--enable-openmp={0}'.format(self.compiler.openmp_flag),
             '--enable-shared',
             '--disable-vtk-binary',
             '--without-blas',

--- a/var/spack/repos/builtin/packages/p4est/package.py
+++ b/var/spack/repos/builtin/packages/p4est/package.py
@@ -58,9 +58,8 @@ class P4est(AutotoolsPackage):
         bootstrap()
 
     def configure_args(self):
-        return [
+        args = [
             '--enable-mpi',
-            '--enable-openmp={0}'.format(self.compiler.openmp_flag),
             '--enable-shared',
             '--disable-vtk-binary',
             '--without-blas',
@@ -71,3 +70,11 @@ class P4est(AutotoolsPackage):
             'FC=%s'  % self.spec['mpi'].mpifc,
             'F77=%s' % self.spec['mpi'].mpif77
         ]
+
+        try:
+            args.append(
+                '--enable-openmp={0}'.format(self.compiler.openmp_flag))
+        except UnsupportedCompilerFlag:
+            pass
+
+        return args

--- a/var/spack/repos/builtin/packages/p4est/package.py
+++ b/var/spack/repos/builtin/packages/p4est/package.py
@@ -36,6 +36,8 @@ class P4est(AutotoolsPackage):
     version('2.0', 'c522c5b69896aab39aa5a81399372a19a6b03fc6200d2d5d677d9a22fe31029a')
     version('1.1', '37ba7f4410958cfb38a2140339dbf64f')
 
+    variant('openmp', default=False, description='Enable OpenMP')
+
     # build dependencies
     depends_on('automake', type='build')
     depends_on('autoconf', type='build')
@@ -71,10 +73,13 @@ class P4est(AutotoolsPackage):
             'F77=%s' % self.spec['mpi'].mpif77
         ]
 
-        try:
-            args.append(
-                '--enable-openmp={0}'.format(self.compiler.openmp_flag))
-        except UnsupportedCompilerFlag:
-            pass
+        if '+openmp' in self.spec:
+            try:
+                args.append(
+                    '--enable-openmp={0}'.format(self.compiler.openmp_flag))
+            except UnsupportedCompilerFlag:
+                args.append('--enable-openmp')
+        else:
+            args.append('--disable-openmp')
 
         return args


### PR DESCRIPTION
The version of libsc bundled with p4est will by default always link with '-lgomp' even when the openmp flag is specified. This was fixed in the upstream libsc by two commits which are used to patch.