### PR TITLE
Add PETSc 3.10.1 to PETSc's spackage file

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -43,6 +43,7 @@ class Petsc(Package):
     version('develop', branch='master')
     version('xsdk-0.2.0', tag='xsdk-0.2.0')
 
+    version('3.10.1', '2d0d5a9bd8112a4147a2a23f7f62a906')
     version('3.9.3', '7b71d705f66f9961cb0e2da3f9da79a1')
     version('3.9.2', '8bedc0cd8c8603d54bfd99a6e8f77b3d')
     version('3.9.1', 'd3a229a188dbeef9b3f29b9a63622fad')

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -44,6 +44,8 @@ class Petsc(Package):
     version('xsdk-0.2.0', tag='xsdk-0.2.0')
 
     version('3.10.1', '2d0d5a9bd8112a4147a2a23f7f62a906')
+    version('3.10.0', '0240c2ce8c54e47b3531a743ee844d41')
+    version('3.9.4', 'c98eb67573efb2f91c6f239368259e44')
     version('3.9.3', '7b71d705f66f9961cb0e2da3f9da79a1')
     version('3.9.2', '8bedc0cd8c8603d54bfd99a6e8f77b3d')
     version('3.9.1', 'd3a229a188dbeef9b3f29b9a63622fad')

--- a/var/spack/repos/builtin/packages/petsc/xlc-test-3.10.1.diff
+++ b/var/spack/repos/builtin/packages/petsc/xlc-test-3.10.1.diff
@@ -1,0 +1,19 @@
+--- a/gmakefile.test
++++ b/gmakefile.test
+@@ -127,11 +127,14 @@
+ endif
+ 	-@$(GFORTRAN_DEP_CLEANUP)
+ 
++#add xlf2003 flags
++XLF2003FLAGS = "-qxlf2003=polymorphic:bozlitargs:stopexcept:volatile:autorealloc"
++
+ $(TESTDIR)/%.o : $(EXAMPLESDIR)/%.F90 | $$(@D)/.DIR
+ ifeq ($(FC_MODULE_OUTPUT_FLAG),)
+ 	$(call quiet,FCMOD) $(MODDIR) && $(FC) -c $(FC_FLAGS) $(FFLAGS) $(FCPPFLAGS) $(FC_DEPFLAGS) -I$(dir $<) $(abspath $<) -o $(abspath $@)
+ else
+-	$(PETSC_COMPILE.F) -I$(dir $<) $(abspath $<) -o $@ $(FC_MODULE_OUTPUT_FLAG)$(MODDIR) $(FC_MODULE_FLAG)$(MODDIR)
++	$(PETSC_COMPILE.F) ${XLF2003FLAGS} -I$(dir $<) $(abspath $<) -o $@ $(FC_MODULE_OUTPUT_FLAG)$(MODDIR) $(FC_MODULE_FLAG)$(MODDIR)
+ endif
+ 	-@$(GFORTRAN_DEP_CLEANUP)
+ 
+


### PR DESCRIPTION
Adding version 3.10.1 to PETSc's spackage file.

PETSc version 3.9.3 does not build the native test framework correctly, so users will need to build version 3.10.1.