### PR TITLE
xerces-c: add variant for transcoder, rework config flags.

### DIFF
--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -39,6 +39,11 @@ class Icu4c(AutotoolsPackage):
     version('58.2', 'fac212b32b7ec7ab007a12dff1f3aea1')
     version('57.1', '976734806026a4ef8bdd17937c8898b9')
 
+    # The --enable-rpath option is needed on MacOS, but it breaks the
+    # build for xerces-c on Linux.
+    variant('rpath', default=True,
+            description='Configure with --enable-rpath')
+
     configure_directory = 'source'
 
     def url_for_version(self, version):
@@ -46,4 +51,9 @@ class Icu4c(AutotoolsPackage):
         return url.format(version.dotted, version.underscored)
 
     def configure_args(self):
-        return ['--enable-rpath']
+        args = []
+
+        if '+rpath' in self.spec:
+            args.append('--enable-rpath')
+
+        return args

--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -41,8 +41,12 @@ class Icu4c(AutotoolsPackage):
 
     # The --enable-rpath option is needed on MacOS, but it breaks the
     # build for xerces-c on Linux.
-    variant('rpath', default=True,
-            description='Configure with --enable-rpath')
+    variant('rpath', default=False,
+            description='Configure with --enable-rpath. This is '
+            'needed for Darwin but should be avoided on Linux.')
+
+    conflicts('~rpath', when='platform=darwin')
+    conflicts('+rpath', when='platform=linux')
 
     configure_directory = 'source'
 

--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+import sys
 
 
 class Icu4c(AutotoolsPackage):
@@ -41,7 +42,7 @@ class Icu4c(AutotoolsPackage):
 
     # The --enable-rpath option is needed on MacOS, but it breaks the
     # build for xerces-c on Linux.
-    variant('rpath', default=False,
+    variant('rpath', default=sys.platform == 'darwin',
             description='Configure with --enable-rpath. This is '
             'needed for Darwin but should be avoided on Linux.')
 

--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import sys
 
 
 class Icu4c(AutotoolsPackage):
@@ -40,15 +39,6 @@ class Icu4c(AutotoolsPackage):
     version('58.2', 'fac212b32b7ec7ab007a12dff1f3aea1')
     version('57.1', '976734806026a4ef8bdd17937c8898b9')
 
-    # The --enable-rpath option is needed on MacOS, but it breaks the
-    # build for xerces-c on Linux.
-    variant('rpath', default=sys.platform == 'darwin',
-            description='Configure with --enable-rpath. This is '
-            'needed for Darwin but should be avoided on Linux.')
-
-    conflicts('~rpath', when='platform=darwin')
-    conflicts('+rpath', when='platform=linux')
-
     configure_directory = 'source'
 
     def url_for_version(self, version):
@@ -58,7 +48,9 @@ class Icu4c(AutotoolsPackage):
     def configure_args(self):
         args = []
 
-        if '+rpath' in self.spec:
+        # The --enable-rpath option is only needed on MacOS, and it
+        # breaks the build for xerces-c on Linux.
+        if 'platform=darwin' in self.spec:
             args.append('--enable-rpath')
 
         return args

--- a/var/spack/repos/builtin/packages/xerces-c/package.py
+++ b/var/spack/repos/builtin/packages/xerces-c/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+import sys
 
 
 class XercesC(AutotoolsPackage):
@@ -39,7 +40,16 @@ class XercesC(AutotoolsPackage):
     version('3.2.1', '8f98a81a3589bbc2dad9837452f7d319')
     version('3.1.4', 'd04ae9d8b2dee2157c6db95fa908abfd')
 
-    variant('transcoder', default='gnuiconv',
+    # It's best to be explicit about the transcoder or else xerces may
+    # choose another value.
+    if sys.platform == 'darwin':
+        default_transcoder = 'macos'
+    elif sys.platform.startswith('win') or sys.platform == 'cygwin':
+        default_transcoder = 'windows'
+    else:
+        default_transcoder = 'gnuiconv'
+
+    variant('transcoder', default=default_transcoder,
             values=('gnuiconv', 'iconv', 'icu', 'macos', 'windows'),
             multi=False,
             description='Use the specified transcoder')

--- a/var/spack/repos/builtin/packages/xerces-c/package.py
+++ b/var/spack/repos/builtin/packages/xerces-c/package.py
@@ -35,13 +35,47 @@ class XercesC(AutotoolsPackage):
     homepage = "https://xerces.apache.org/xerces-c"
     url      = "https://archive.apache.org/dist/xerces/c/3/sources/xerces-c-3.2.1.tar.bz2"
 
+    version('3.2.2', '4c395216ecbef3c88a756ff4090e6f7e')
     version('3.2.1', '8f98a81a3589bbc2dad9837452f7d319')
     version('3.1.4', 'd04ae9d8b2dee2157c6db95fa908abfd')
 
-    depends_on('libiconv')
+    variant('transcoder', default='gnuiconv',
+            values=('gnuiconv', 'iconv', 'icu', 'macos', 'windows'),
+            multi=False,
+            description='Use the specified transcoder')
 
-    def setup_environment(self, spack_env, run_env):
-        spack_env.append_flags('LDFLAGS', self.spec['libiconv'].libs.ld_flags)
+    depends_on('libiconv',    type='link', when='transcoder=gnuiconv')
+    depends_on('icu4c~rpath', type='link', when='transcoder=icu')
+
+    # Pass flags to configure.  This is necessary for CXXFLAGS or else
+    # the xerces default will override the spack wrapper.
+    def flag_handler(self, name, flags):
+        spec = self.spec
+
+        # There is no --with-pkg for gnuiconv.
+        if name == 'ldflags' and 'transcoder=gnuiconv' in spec:
+            flags.append(spec['libiconv'].libs.ld_flags)
+
+        return (None, None, flags)
 
     def configure_args(self):
-        return ['--disable-network']
+        spec = self.spec
+        args = ['--disable-network']
+
+        if 'transcoder=gnuiconv' in spec:
+            args.append('--enable-transcoder-gnuiconv')
+
+        if 'transcoder=iconv' in spec:
+            args.append('--enable-transcoder-iconv')
+
+        if 'transcoder=icu' in spec:
+            args.append('--enable-transcoder-icu')
+            args.append('--with-icu=%s' % spec['icu4c'].prefix)
+
+        if 'transcoder=macos' in spec:
+            args.append('--enable-transcoder-macosunicodeconverter')
+
+        if 'transcoder=windows' in spec:
+            args.append('--enable-transcoder-windows')
+
+        return args

--- a/var/spack/repos/builtin/packages/xerces-c/package.py
+++ b/var/spack/repos/builtin/packages/xerces-c/package.py
@@ -54,8 +54,8 @@ class XercesC(AutotoolsPackage):
             multi=False,
             description='Use the specified transcoder')
 
-    depends_on('libiconv',    type='link', when='transcoder=gnuiconv')
-    depends_on('icu4c~rpath', type='link', when='transcoder=icu')
+    depends_on('libiconv', type='link', when='transcoder=gnuiconv')
+    depends_on('icu4c',    type='link', when='transcoder=icu')
 
     # Pass flags to configure.  This is necessary for CXXFLAGS or else
     # the xerces default will override the spack wrapper.


### PR DESCRIPTION
xerces-c: Add variant for choice of transcoder (gnuiconv, iconv, icu,
macos, windows).  It's important to specify a --enable-transcoder
option on the configure line or else xerces may make a different
choice when multiple transcoders are available.

Pass the compile flags to configure.  For cflags and cxxflags, this is
necessary to respect the value from the spack install line.
Otherwise, xerces (and any autotools package) will choose a default
value that overrides the spack compiler wrapper.

Add xerces version 3.2.2.

icu4c: Move --enable-rpath to a variant.  This is needed on MacOS, but
it breaks the build for xerces on Linux.