### PR TITLE
kokkos: bugfix for case wherein kokkos backends enabled in spack but not parsed correctly

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -158,13 +158,13 @@ class Kokkos(Package):
             cuda_options_args = []
 
             # Backends
-            if 'serial' in spec:
+            if '+serial' in spec:
                 g_args.append('--with-serial')
             if '+openmp' in spec:
                 g_args.append('--with-openmp')
-            if 'qthreads' in spec:
+            if '+qthreads' in spec:
                 g_args.append('--with-qthreads=%s' % spec['qthreads'].prefix)
-            if 'cuda' in spec:
+            if '+cuda' in spec:
                 g_args.append('--with-cuda=%s' % spec['cuda'].prefix)
             # Host architectures
             host_arch = spec.variants['host_arch'].value


### PR DESCRIPTION
Essentially, 'variant' does not capture correctly, but '+variant' does, for enabling variants. It was possible to in kokkos e.g. "+serial~openmp" and with kokkos spackage checking for 'serial' and not '+serial', and thus backend would be listed in spack spec but not passed to kokkos configuration. If kokkos is built without a backend choice, it defaults to pthreads - which may be undesirable.