### PR TITLE
Add important variants to MOAB and Geant4

### DIFF
--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -50,6 +50,7 @@ class Geant4(CMakePackage):
     variant('opengl', default=False, description='Optional OpenGL support')
     variant('x11', default=False, description='Optional X11 support')
     variant('motif', default=False, description='Optional motif support')
+    variant('threads', default=True, description='Build with multithreading')
 
     depends_on('cmake@3.5:', type='build')
 
@@ -86,7 +87,6 @@ class Geant4(CMakePackage):
             '-DGEANT4_USE_G3TOG4=ON',
             '-DGEANT4_INSTALL_DATA=ON',
             '-DGEANT4_BUILD_TLS_MODEL=global-dynamic',
-            '-DGEANT4_BUILD_MULTITHREADED=ON',
             '-DGEANT4_USE_SYSTEM_EXPAT=ON',
             '-DGEANT4_USE_SYSTEM_ZLIB=ON',
             '-DXERCESC_ROOT_DIR:STRING=%s' %
@@ -116,6 +116,9 @@ class Geant4(CMakePackage):
             options.append('-DGEANT4_USE_USOLIDS=ON')
             options.append('-DUSolids_DIR=%s' % spec[
                 'vecgeom'].prefix.lib.CMake.USolids)
+
+        if '+threads' in spec:
+            options.append('-DGEANT4_BUILD_MULTITHREADED=ON')
 
         return options
 

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -54,6 +54,9 @@ class Geant4(CMakePackage):
 
     depends_on('cmake@3.5:', type='build')
 
+    conflicts('+cxx14', when='+cxx11')
+    conflicts('+cxx11', when='+cxx14')
+
     # C++11 support
     depends_on("clhep@2.4.0.0+cxx11~cxx14", when="@10.04+cxx11~cxx14")
     depends_on("clhep@2.3.4.3+cxx11~cxx14", when="@10.03.p03+cxx11~cxx14")
@@ -103,7 +106,7 @@ class Geant4(CMakePackage):
 
         if '+cxx11' in spec:
             options.append('-DGEANT4_BUILD_CXXSTD=c++11')
-        if '+cxx14' or '+cxx1y' in spec:
+        if '+cxx14' in spec:
             options.append('-DGEANT4_BUILD_CXXSTD=c++14')
 
         if '+qt' in spec:

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -117,8 +117,8 @@ class Geant4(CMakePackage):
             options.append('-DUSolids_DIR=%s' % spec[
                 'vecgeom'].prefix.lib.CMake.USolids)
 
-        if '+threads' in spec:
-            options.append('-DGEANT4_BUILD_MULTITHREADED=ON')
+        on_or_off = lambda opt: 'ON' if '+' + opt in spec else 'OFF'
+        options.append('-DGEANT4_BUILD_MULTITHREADED=' + on_or_off('threads'))
 
         return options
 

--- a/var/spack/repos/builtin/packages/moab/package.py
+++ b/var/spack/repos/builtin/packages/moab/package.py
@@ -60,6 +60,7 @@ class Moab(AutotoolsPackage):
     variant('irel', default=False, description='Enable irel interface')
     variant('fbigeom', default=False, description='Enable fbigeom interface')
     variant('coupler', default=True, description='Enable mbcoupler tool')
+    variant('dagmc', default=False, description='Enable dagmc tool')
 
     variant("debug", default=False, description='enable debug symbols')
     variant('shared', default=False,
@@ -161,6 +162,11 @@ class Moab(AutotoolsPackage):
             options.append('--enable-mbcoupler')
         else:
             options.append('--disable-mbcoupler')
+
+        if '+dagmc' in spec:
+            options.append('--enable-dagmc')
+        else:
+            options.append('--disable-dagmc')
 
         if '+metis' in spec:
             options.append('--with-metis=%s' % spec['metis'].prefix)


### PR DESCRIPTION
In order to build the software stack for Exnihilo (part of the ExaSMR ECP project), we need more granularity over the options provided by these two packages.