### PR TITLE
py-flake8 ^python@3.4: :delete enum34 dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-flake8/package.py
+++ b/var/spack/repos/builtin/packages/py-flake8/package.py
@@ -69,7 +69,12 @@ class PyFlake8(PythonPackage):
     # depends_on('py-configparser', when='^python@:3.3', type=('build', 'run'))
     # depends_on('py-enum34', when='^python@:3.1', type=('build', 'run'))
     depends_on('py-configparser', type=('build', 'run'))
-    depends_on('py-enum34', type=('build', 'run'))
+
+    # py-enum34 provides enum module from Python 3.4 for Python
+    # versions 2.4, 2.5, 2.6, 2.7, 3.1, 3.2, and 3.3; use built-in enum
+    # module for Python versions 3.4 and later
+    depends_on('py-enum34', when='^python@2.4:2.7.999,3.1:3.3.999',
+               type=('build', 'run'))
 
     depends_on('py-nose', type='test')
 


### PR DESCRIPTION
The `py-flake8` package currently has an `enum34` dependency for all versions of Python. However, as the name implies, `enum34` backports the `enum` module from Python 3.4 to Python versions 2.4 through 2.7, and versions 3.1 through 3.3. The presence of the `enum` module in Python 3.4 and later implies that `py-flake8` should not depend on `enum34` for this range of Python versions, so this pull request deletes the `enum34` dependency for Python 3.4 and later.

Furthermore, `spack install py-flake8 ^python@3.7.0` yields the following build error on my system:

```console
==> Executing phase: 'build'
==> '/usr/local/Cellar/python/3.7.0/bin/python3.7' '-s' 'setup.py' '--no-user-cfg' 'build'
Error in sitecustomize; set PYTHONVERBOSE for traceback:
AttributeError: module 'enum' has no attribute 'IntFlag'
Traceback (most recent call last):
  File "setup.py", line 8, in <module>
    import setuptools
  File "/Users/oxberry1/spack/opt/spack/darwin-sierra-x86_64/clang-9.0.0-apple/py-setuptools-40.2.0-qfpxfl66jbsssrqzkj3x3nxvu4ee6quk/lib/python3.7/site-packages/setuptools/__init__.py", line 6, in <module>
    import distutils.core
  File "/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/python3.7/distutils/core.py", line 16, in <module>
    from distutils.dist import Distribution
  File "/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/python3.7/distutils/dist.py", line 9, in <module>
    import re
  File "/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/python3.7/re.py", line 143, in <module>
    class RegexFlag(enum.IntFlag):
AttributeError: module 'enum' has no attribute 'IntFlag'
```

This pull request resolves the build error shown above.