### PR TITLE
Specified Maximum Matplotlib for Candle

### DIFF
--- a/var/spack/repos/builtin/packages/candle-benchmarks/package.py
+++ b/var/spack/repos/builtin/packages/candle-benchmarks/package.py
@@ -41,7 +41,7 @@ class CandleBenchmarks(Package):
     extends('python@2.7:')
     depends_on('py-theano +gpu', type=('build', 'run'))
     depends_on('py-keras', type=('build', 'run'))
-    depends_on('py-matplotlib +image', type=('build', 'run'))
+    depends_on('py-matplotlib +image@:2.2.3', type=('build', 'run'))
     depends_on('py-tqdm', type=('build', 'run'))
     depends_on('py-scikit-learn', type=('build', 'run'))
     depends_on('opencv@3.2.0: +core +highgui +imgproc +jpeg +png +tiff +zlib +python -dnn ~eigen')


### PR DESCRIPTION
Specifying that Candle-benchmarks requires matplotlib 2.x due to
matplotlib 3.x requiring python 3.x

Candle still seems to have quite a few concretization issues due to how virtual dependencies are handled and further discussion will be required to determine which workarounds are environment specific and which aren't. But the py-matplotlib case is fairly simple