### PR TITLE
Catalyst Package: made Python mandatory at build time

### DIFF
--- a/var/spack/repos/builtin/packages/catalyst/package.py
+++ b/var/spack/repos/builtin/packages/catalyst/package.py
@@ -58,7 +58,8 @@ class Catalyst(CMakePackage):
 
     depends_on('git')
     depends_on('mpi')
-    depends_on('python@2:2.8', when='+python')
+    depends_on('python@2:2.8', when='+python', type=("build", "link", "run"))
+    depends_on('python', when='~python', type=("build"))
     depends_on('mesa', when='+rendering')
     depends_on("libx11", when='+rendering')
     depends_on("libxt", when='+rendering')


### PR DESCRIPTION
The build process of Catalyst requires Python at build time (see line 86) even when the +python variant is not selected.
When the +python variant is selected, Python becomes required at build, link, and run time. There doesn't seem to be any restriction on the version of Python required when +python is not selected.