### PR TITLE
Package VisIt: updated visit package

### DIFF
--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -38,7 +38,7 @@ class Visit(CMakePackage):
     version('2.10.2', '253de0837a9d69fb689befc98ea4d068')
     version('2.10.1', '3cbca162fdb0249f17c4456605c4211e')
 
-    variant('gui',    default=True, description="Enable VisIt's GUI")
+    variant('gui',    default=True, description='Enable VisIt\'s GUI')
     variant('hdf5',   default=True, description='Enable HDF5 file format')
     variant('silo',   default=True, description='Enable Silo file format')
     variant('python', default=True, description='Enable Python support')
@@ -51,7 +51,7 @@ class Visit(CMakePackage):
     depends_on('python', when='+python')
     depends_on('silo+shared', when='+silo')
     depends_on('hdf5', when='+hdf5')
-    depends_on('mpi', when='+parallel')
+    depends_on('mpi', when='+mpi')
 
     conflicts('+hdf5', when='~gui')
     conflicts('+silo', when='~gui')
@@ -93,7 +93,7 @@ class Visit(CMakePackage):
             args.append(
                 '-DVISIT_SILO_DIR:PATH={0}'.format(spec['silo'].prefix))
 
-        if(spec.variants['parallel'].value):
+        if(spec.variants['mpi'].value):
             args.append('-DVISIT_PARALLEL=ON')
             args.append('-DVISIT_C_COMPILER={0}'.format(spec['mpi'].mpicc))
             args.append('-DVISIT_CXX_COMPILER={0}'.format(spec['mpi'].mpicxx))

--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -42,7 +42,7 @@ class Visit(CMakePackage):
     variant('hdf5',   default=True, description='Enable HDF5 file format')
     variant('silo',   default=True, description='Enable Silo file format')
     variant('python', default=True, description='Enable Python support')
-    variant('parallel', default=False, description='Enable parallel engine')
+    variant('mpi',    default=True, description='Enable parallel engine')
 
     depends_on('cmake@3.0:', type='build')
     depends_on('vtk@6.1.0~opengl2')

--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -38,33 +38,62 @@ class Visit(CMakePackage):
     version('2.10.2', '253de0837a9d69fb689befc98ea4d068')
     version('2.10.1', '3cbca162fdb0249f17c4456605c4211e')
 
+    variant('gui',    default=True, description="Enable VisIt's GUI")
+    variant('hdf5',   default=True, description='Enable HDF5 file format')
+    variant('silo',   default=True, description='Enable Silo file format')
+    variant('python', default=True, description='Enable Python support')
+    variant('parallel', default=False, description='Enable parallel engine')
+
     depends_on('cmake@3.0:', type='build')
     depends_on('vtk@6.1.0~opengl2')
-    depends_on('qt@4.8.6')
-    depends_on('qwt')
-    depends_on('python')
-    depends_on('silo+shared')
-    depends_on('hdf5')
+    depends_on('qt@4.8.6', when='+gui')
+    depends_on('qwt', when='+gui')
+    depends_on('python', when='+python')
+    depends_on('silo+shared', when='+silo')
+    depends_on('hdf5', when='+hdf5')
+    depends_on('mpi', when='+parallel')
 
     root_cmakelists_dir = 'src'
 
     def cmake_args(self):
         spec = self.spec
-        qt_bin = spec['qt'].prefix.bin
+
         args = [
             '-DVTK_MAJOR_VERSION={0}'.format(spec['vtk'].version[0]),
             '-DVTK_MINOR_VERSION={0}'.format(spec['vtk'].version[1]),
             '-DVISIT_VTK_DIR:PATH={0}'.format(spec['vtk'].prefix),
             '-DVISIT_USE_GLEW=OFF',
-            '-DVISIT_LOC_QMAKE_EXE:FILEPATH={0}/qmake-qt4'.format(qt_bin),
-            '-DPYTHON_DIR:PATH={0}'.format(spec['python'].home),
-            '-DVISIT_SILO_DIR:PATH={0}'.format(spec['silo'].prefix),
-            '-DVISIT_HDF5_DIR:PATH={0}'.format(spec['hdf5'].prefix),
-            '-DVISIT_QWT_DIR:PATH={0}'.format(spec['qwt'].prefix)
+            '-DCMAKE_CXX_FLAGS=-fPIC',
+            '-DCMAKE_C_FLAGS=-fPIC'
         ]
 
-        if spec.satisfies('^hdf5+mpi', strict=True):
-            args.append('-DVISIT_HDF5_MPI_DIR:PATH={0}'.format(
-                spec['hdf5'].prefix))
+        if(spec.variants['python'].value):
+            args.append('-DPYTHON_DIR:PATH={0}'.format(spec['python'].home))
+
+        if(spec.variants['gui'].value):
+            qt_bin = spec['qt'].prefix.bin
+            args.append(
+                '-DVISIT_LOC_QMAKE_EXE:FILEPATH={0}/qmake-qt4'.format(qt_bin))
+            args.append('-DVISIT_QWT_DIR:PATH={0}'.format(spec['qwt'].prefix))
+        else:
+            args.append('-DVISIT_SERVER_COMPONENTS_ONLY=ON')
+            args.append('-DVISIT_ENGINE_ONLY=ON')
+
+        if(spec.variants['hdf5'].value):
+            args.append(
+                '-DVISIT_HDF5_DIR:PATH={0}'.format(spec['hdf5'].prefix))
+            if spec.satisfies('^hdf5+mpi', strict=True):
+                args.append('-DVISIT_HDF5_MPI_DIR:PATH={0}'.format(
+                    spec['hdf5'].prefix))
+
+        if(spec.variants['silo'].value):
+            args.append(
+                '-DVISIT_SILO_DIR:PATH={0}'.format(spec['silo'].prefix))
+
+        if(spec.variants['parallel'].value):
+            args.append('-DVISIT_PARALLEL=ON')
+            args.append('-DVISIT_C_COMPILER={0}'.format(spec['mpi'].mpicc))
+            args.append('-DVISIT_CXX_COMPILER={0}'.format(spec['mpi'].mpicxx))
+            args.append('-DVISIT_MPI_COMPILER={0}'.format(spec['mpi'].mpicxx))
 
         return args

--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -53,6 +53,9 @@ class Visit(CMakePackage):
     depends_on('hdf5', when='+hdf5')
     depends_on('mpi', when='+parallel')
 
+    conflicts('+hdf5', when='~gui')
+    conflicts('+silo', when='~gui')
+
     root_cmakelists_dir = 'src'
 
     def cmake_args(self):


### PR DESCRIPTION
This PR updates the VisIt package with the following additions:

- HDF5 is now an option that can be disabled
- SILO is now an option that can be disabled
- Python is now an option that can be disabled
- GUI is now an option that can be disabled
- Can enable "parallel" to compile the parallel engine

This allows to better select the needed dependencies and in particular to compile just the engine by disabling the gui, hdf5, and silo variants. This is useful when one wants to compile just the libsim in situ visualization interface (i.e. just the engine).