### PR TITLE
feature: add option to retain .vcs

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -812,7 +812,10 @@ from VCS repositories. Currently, Spack supports fetching with `Git
 To fetch a package from a source repository, Spack needs to know which
 VCS to use and where to download from. Much like with ``url``, package
 authors can specify a class-level ``git``, ``hg``, ``svn``, or ``go``
-attribute containing the correct download location.
+attribute containing the correct download location.  Spack will remove the
+version control information when :ref:`caching <caching>` the package
+sources during installation unless ``clean=False`` is passed to
+``version``.
 
 Many packages developed with Git have both a Git repository as well as
 release tarballs available for download. Packages can define both a

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -478,6 +478,7 @@ class VCSFetchStrategy(FetchStrategy):
 
         # Set a URL based on the type of fetch strategy.
         self.url = kwargs.get(self.url_attr, None)
+        self.clean = kwargs.get("clean", True)
         if not self.url:
             raise ValueError(
                 "%s requires %s argument." % (self.__class__, self.url_attr))
@@ -502,7 +503,7 @@ class VCSFetchStrategy(FetchStrategy):
         tar = which('tar', required=True)
 
         patterns = kwargs.get('exclude', None)
-        if patterns is not None:
+        if patterns is not None and self.clean:
             if isinstance(patterns, string_types):
                 patterns = [patterns]
             for p in patterns:


### PR DESCRIPTION
Some packages require version control information to build, e.g., python
packages depending on `setuptools-scm`.  Spack will remove any VCS
directory when caching hashable stages like tags, this patch will
provide a parameter `clean=False` to the `version` function that will
retain `.git` etc.

Should fix #8746.