### PR TITLE
Fix for issue #9437 spark+hadoop

### DIFF
--- a/var/spack/repos/builtin/packages/spark/package.py
+++ b/var/spack/repos/builtin/packages/spark/package.py
@@ -68,6 +68,7 @@ class Spark(Package):
     @when('+hadoop')
     def setup_environment(self, spack_env, run_env):
         hadoop = self.spec['hadoop'].command
+        hadoop.add_default_env('JAVA_HOME', self.spec['java'].home)
         hadoop_classpath = hadoop('classpath', output=str)
 
         # Remove whitespaces, as they can compromise syntax in


### PR DESCRIPTION
Fixes #9437

Sets the `JAVA_HOME` in the `hadoop` subprocess called during
`spark.setup_environment`.