### PR TITLE
Add multiprocessing to buildcache command

### DIFF
--- a/lib/spack/llnl/util/multiproc.py
+++ b/lib/spack/llnl/util/multiproc.py
@@ -28,8 +28,9 @@ than multiprocessing.Pool.apply() can.  For example, apply() will fail
 to pickle functions if they're passed indirectly as parameters.
 """
 from multiprocessing import Process, Pipe, Semaphore, Value
+from multiprocessing.pool import Pool
 
-__all__ = ['spawn', 'parmap', 'Barrier']
+__all__ = ['spawn', 'parmap', 'Barrier', 'NoDaemonPool']
 
 
 def spawn(f):
@@ -94,3 +95,24 @@ class Barrier:
 
 class BarrierTimeoutError(Exception):
     pass
+
+
+class NoDaemonProcess(Process):
+    """Daemon processes are not allowed to create child processes.
+    Yet Sometimes that feature is needed."""
+    # make 'daemon' attribute always return False
+    def _get_daemon(self):
+        return False
+
+    def _set_daemon(self, value):
+        pass
+
+    daemon = property(_get_daemon, _set_daemon)
+
+
+# We sub-class multiprocessing.pool.Pool instead of multiprocessing.Pool
+# because the latter is only a wrapper function, not a proper class.
+class NoDaemonPool(Pool):
+    """Daemon processes are not allowed to create child processes.
+    Yet Sometimes that feature is needed."""
+    Process = NoDaemonProcess


### PR DESCRIPTION
* Add `-w/--without-dependencies` to suppress dependency resolution.

* Add `-j/--jobs` to install/create several package from/to buildcache in parallel (defaults to 1).

* Applied some flake8-fixes

* Added (and compressed) tests

### Reasoning:
The current buildcache implementation lacks the ability to install packages/create tarballs en bulk:

* Dependencies are *always* checked for and included
* the package index is updated after EVERY installed package instead of   once after everything is installed

In order to reduce build time of our spack-based singularity container we want to pre-compute all hashes to be installed from buildcache in advance (i.e. we do not want spack to perform additional checks) and we want this installation to be possible with more than one core (decompressing is cpu-intensive and therefore not completely IO-bound).

The same goes for creating tarballs that are put into the buildcache after container creation.

Hence this commit introduces these two possibilities.

By default the behavior remains the same, i.e. spack fails after encountering its first error. When using several cores we gather all occurred errors and print them afterwards.

In theory parallelization could also be achieved by using tools such as `xargs` and spawning multiple python processes, but I think it would be nicer to have this possibility out of the box in spack (in the same way as you can install packages with multiple cores).

_Note:_ We [already use](https://github.com/electronicvisions/spack/commit/837974be138a08dab3e712734d1866a28dcc1f3) the proposed modifications without problems. I only got around to porting the modifications to the current `develop`-branch now and added some tests while I was at it.