### PR TITLE
Another fix to Candle-benchmark Spec

### DIFF
--- a/var/spack/repos/builtin/packages/candle-benchmarks/package.py
+++ b/var/spack/repos/builtin/packages/candle-benchmarks/package.py
@@ -44,7 +44,7 @@ class CandleBenchmarks(Package):
     depends_on('py-matplotlib +image@:2.2.3', type=('build', 'run'))
     depends_on('py-tqdm', type=('build', 'run'))
     depends_on('py-scikit-learn', type=('build', 'run'))
-    depends_on('opencv@3.2.0: +core +highgui +imgproc +jpeg +png +tiff +zlib +python -dnn ~eigen')
+    depends_on('opencv@3.2.0: +core +highgui +imgproc +jpeg +png +tiff +zlib +python -dnn ~eigen ~gtk')
     depends_on('py-mdanalysis', type=('build', 'run'))
     depends_on('py-mpi4py', when='+mpi', type=('build', 'run'))
     depends_on('py-h5py~mpi', when='~mpi', type=('build', 'run'))


### PR DESCRIPTION
After talks with candle dev, removed unsatisfiable conflict with
candle-benchmark and opencv by disabling gtk in the candle spec

Candle-benchmarks still have issue with multiple providers for virtual dependencies, but that is a larger spack issue