### PR TITLE
r-rmarkdown: add r-catools dependency

### DIFF
--- a/var/spack/repos/builtin/packages/r-rmarkdown/package.py
+++ b/var/spack/repos/builtin/packages/r-rmarkdown/package.py
@@ -45,4 +45,5 @@ class RRmarkdown(RPackage):
     depends_on('r-rprojroot', type=('build', 'run'))
     depends_on('r-mime', type=('build', 'run'))
     depends_on('r-stringr@1.2.0:', type=('build', 'run'))
+    depends_on('r-catools', type=('build', 'run'))
     depends_on('r@3.0:')


### PR DESCRIPTION
#9453 added this to the wrong package -- it it required by this one although not mentioned in the dependencies for some reason.