### PR TITLE
Nektar

### DIFF
--- a/var/spack/repos/builtin/packages/nektar/CMakeLists_NekMesh.patch
+++ b/var/spack/repos/builtin/packages/nektar/CMakeLists_NekMesh.patch
@@ -1,0 +1,30 @@
+--- /utilities/NekMesh/CMakeLists.txt	2017-10-13 04:17:24.000000000 +0800
++++ /utilities/NekMesh/CMakeLists_NekMesh.txt	2018-09-04 01:03:02.000000000 +0800
+@@ -110,6 +110,27 @@
+     ENDIF ()
+ ENDIF (NEKTAR_USE_VTK)
+ 
++IF( ${CMAKE_SYSTEM} MATCHES "Linux.*" )
++    # The boost thread library needs pthread on linux.
++    GET_TARGET_PROPERTY(THE_COMPILE_FLAGS NekMesh COMPILE_FLAGS)
++    GET_TARGET_PROPERTY(THE_LINK_FLAGS NekMesh LINK_FLAGS)
++
++    # It is possible these flags have not been set yet.
++    IF(NOT THE_COMPILE_FLAGS)
++        SET(THE_COMPILE_FLAGS "")
++    ENDIF(NOT THE_COMPILE_FLAGS)
++
++    IF(NOT THE_LINK_FLAGS )
++      SET(THE_LINK_FLAGS "")
++    ENDIF(NOT THE_LINK_FLAGS)
++
++    SET_TARGET_PROPERTIES(NekMesh 
++            PROPERTIES COMPILE_FLAGS "${THE_COMPILE_FLAGS} -pthread")
++    SET_TARGET_PROPERTIES(NekMesh 
++            PROPERTIES LINK_FLAGS "${THE_LINK_FLAGS} -pthread")
++
++ENDIF( ${CMAKE_SYSTEM} MATCHES "Linux.*" )
++
+ # Nektar++
+ ADD_NEKTAR_TEST        (Nektar++/InvalidTetFace)
+ ADD_NEKTAR_TEST        (Nektar++/InvalidQuads)

--- a/var/spack/repos/builtin/packages/nektar/CMakeLists_solvers.patch
+++ b/var/spack/repos/builtin/packages/nektar/CMakeLists_solvers.patch
@@ -1,0 +1,30 @@
+--- /solvers/CMakeLists.txt	2017-10-13 04:17:24.000000000 +0800
++++ /solvers/CMakeLists_solvers.txt	2018-09-04 00:24:10.000000000 +0800
+@@ -11,6 +11,27 @@
+ 
+     TARGET_LINK_LIBRARIES(${name} SolverUtils)
+ 
++    IF( ${CMAKE_SYSTEM} MATCHES "Linux.*" )
++        # The boost thread library needs pthread on linux.
++        GET_TARGET_PROPERTY(THE_COMPILE_FLAGS ${name} COMPILE_FLAGS)
++        GET_TARGET_PROPERTY(THE_LINK_FLAGS ${name} LINK_FLAGS)
++
++        # It is possible these flags have not been set yet.
++        IF(NOT THE_COMPILE_FLAGS)
++            SET(THE_COMPILE_FLAGS "")
++        ENDIF(NOT THE_COMPILE_FLAGS)
++
++        IF(NOT THE_LINK_FLAGS )
++	        SET(THE_LINK_FLAGS "")
++        ENDIF(NOT THE_LINK_FLAGS)
++
++        SET_TARGET_PROPERTIES(${name} 
++                PROPERTIES COMPILE_FLAGS "${THE_COMPILE_FLAGS} -pthread")
++        SET_TARGET_PROPERTIES(${name} 
++                PROPERTIES LINK_FLAGS "${THE_LINK_FLAGS} -pthread")
++	
++    ENDIF( ${CMAKE_SYSTEM} MATCHES "Linux.*" )
++
+     SET_PROPERTY(TARGET ${name} PROPERTY FOLDER ${component})
+     INSTALL(TARGETS ${name} 
+             RUNTIME DESTINATION ${NEKTAR_BIN_DIR} COMPONENT ${component} OPTIONAL)

--- a/var/spack/repos/builtin/packages/nektar/package.py
+++ b/var/spack/repos/builtin/packages/nektar/package.py
@@ -32,7 +32,6 @@ class Nektar(CMakePackage):
     url      = "https://gitlab.nektar.info/nektar/nektar/-/archive/v4.4.1/nektar-v4.4.1.tar.bz2"
 
     version('4.4.1', sha256='9faebae290b28cb1fe083627b9cd078c20a9045ac9ec98ed6c60adc876ed2dcd')
-    version('4.3.5', sha256='2b3994416a3c83571e089dad6d802b3b34476884e73f050f83ef2810ed408a5e')
 
     variant('mpi', default=True, description='Builds with mpi support')
     variant('fftw', default=True, description='Builds with fftw support')

--- a/var/spack/repos/builtin/packages/nektar/package.py
+++ b/var/spack/repos/builtin/packages/nektar/package.py
@@ -31,7 +31,7 @@ class Nektar(CMakePackage):
     homepage = "https://www.nektar.info/"
     url      = "https://gitlab.nektar.info/nektar/nektar/-/archive/v4.4.1/nektar-v4.4.1.tar.bz2"
 
-    version('4.4.1', sha256='9faebae290b28cb1fe083627b9cd078c20a9045ac9ec98ed6c60adc876ed2dcd')
+    version('4.4.1', '1be7d061c3cafd9a0f1eb8d281d99b89')
 
     variant('mpi', default=True, description='Builds with mpi support')
     variant('fftw', default=True, description='Builds with fftw support')

--- a/var/spack/repos/builtin/packages/nektar/package.py
+++ b/var/spack/repos/builtin/packages/nektar/package.py
@@ -31,7 +31,8 @@ class Nektar(CMakePackage):
     homepage = "https://www.nektar.info/"
     url      = "https://gitlab.nektar.info/nektar/nektar/-/archive/v4.4.1/nektar-v4.4.1.tar.bz2"
 
-    version('4.4.1', '1be7d061c3cafd9a0f1eb8d281d99b89')
+    version('4.4.1', sha256='9faebae290b28cb1fe083627b9cd078c20a9045ac9ec98ed6c60adc876ed2dcd')
+    version('4.3.5', sha256='2b3994416a3c83571e089dad6d802b3b34476884e73f050f83ef2810ed408a5e')
 
     variant('mpi', default=True, description='Builds with mpi support')
     variant('fftw', default=True, description='Builds with fftw support')

--- a/var/spack/repos/builtin/packages/nektar/package.py
+++ b/var/spack/repos/builtin/packages/nektar/package.py
@@ -72,4 +72,6 @@ class Nektar(CMakePackage):
         args.append('-DNEKTAR_USE_HDF5=%s' % hasfeature('+hdf5'))
         args.append('-DNEKTAR_USE_SCOTCH=%s' % hasfeature('+scotch'))
         args.append('-DNEKTAR_USE_PETSC=OFF')
+        args.append('-DNEKTAR_BUILD_TESTS=OFF')
+        args.append('-DNEKTAR_BUILD_UNIT_TESTS=OFF')
         return args

--- a/var/spack/repos/builtin/packages/nektar/package.py
+++ b/var/spack/repos/builtin/packages/nektar/package.py
@@ -61,9 +61,9 @@ class Nektar(CMakePackage):
     conflicts("+hdf5", when="~mpi",
               msg="Nektar's hdf5 output is for parallel builds only")
 
-    # Add '-pthread' flag for solvers and NekMesh
-    patch('CMakeLists_solvers.patch')
-    patch('CMakeLists_NekMesh.patch')
+    # Add '-pthread' flag for solvers and NekMesh for @4.4.1
+    patch('CMakeLists_solvers.patch', when="@4.4.1")
+    patch('CMakeLists_NekMesh.patch', when="@4.4.1")
 
     def cmake_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/nektar/package.py
+++ b/var/spack/repos/builtin/packages/nektar/package.py
@@ -77,4 +77,6 @@ class Nektar(CMakePackage):
         args.append('-DNEKTAR_USE_HDF5=%s' % hasfeature('+hdf5'))
         args.append('-DNEKTAR_USE_SCOTCH=%s' % hasfeature('+scotch'))
         args.append('-DNEKTAR_USE_PETSC=OFF')
+        args.append('-DNEKTAR_BUILD_TESTS=OFF')
+        args.append('-DNEKTAR_BUILD_UNIT_TESTS=OFF')
         return args

--- a/var/spack/repos/builtin/packages/nektar/package.py
+++ b/var/spack/repos/builtin/packages/nektar/package.py
@@ -40,8 +40,8 @@ class Nektar(CMakePackage):
     variant('scotch', default=False,
             description='Builds with scotch partitioning support')
 
-    depends_on('cmake@2.8.8:', type='build', when="~hdf5")
-    depends_on('cmake@3.2:', type='build', when="+hdf5")
+    depends_on('cmake@2.8.8:3.9.99', type='build', when="~hdf5")
+    depends_on('cmake@3.2:3.9.99', type='build', when="+hdf5")
 
     depends_on('blas')
     depends_on('lapack')

--- a/var/spack/repos/builtin/packages/nektar/package.py
+++ b/var/spack/repos/builtin/packages/nektar/package.py
@@ -77,6 +77,4 @@ class Nektar(CMakePackage):
         args.append('-DNEKTAR_USE_HDF5=%s' % hasfeature('+hdf5'))
         args.append('-DNEKTAR_USE_SCOTCH=%s' % hasfeature('+scotch'))
         args.append('-DNEKTAR_USE_PETSC=OFF')
-        args.append('-DNEKTAR_BUILD_TESTS=OFF')
-        args.append('-DNEKTAR_BUILD_UNIT_TESTS=OFF')
         return args

--- a/var/spack/repos/builtin/packages/nektar/package.py
+++ b/var/spack/repos/builtin/packages/nektar/package.py
@@ -41,8 +41,9 @@ class Nektar(CMakePackage):
     variant('scotch', default=False,
             description='Builds with scotch partitioning support')
 
-    depends_on('cmake@2.8.8:3.9.99', type='build', when="~hdf5")
-    depends_on('cmake@3.2:3.9.99', type='build', when="+hdf5")
+    depends_on('cmake@:3.9.99', type='build')
+    depends_on('cmake@2.8.8:', type='build', when="~hdf5")
+    depends_on('cmake@3.2:', type='build', when="+hdf5")
 
     depends_on('blas')
     depends_on('lapack')

--- a/var/spack/repos/builtin/packages/nektar/package.py
+++ b/var/spack/repos/builtin/packages/nektar/package.py
@@ -60,6 +60,10 @@ class Nektar(CMakePackage):
     conflicts("+hdf5", when="~mpi",
               msg="Nektar's hdf5 output is for parallel builds only")
 
+    # Add '-pthread' flag for solvers and NekMesh
+    patch('CMakeLists_solvers.patch')
+    patch('CMakeLists_NekMesh.patch')
+
     def cmake_args(self):
         args = []
 


### PR DESCRIPTION
This PR fixes #9161 by patching `-pthread` link flag into its CMakeFiles and disabling unit tests. I've successfully built nektar in CentOS 7 against gcc@5.4.0 and openmpi@3.1.2.

Follow-up commits are expected to patch the unit test CMakeFiles and re-enable unit tests.