### PR TITLE
Complex variants might use a more declarative style

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -1239,7 +1239,7 @@ other similar operations:
             description='List of the process managers to activate',
             values=disjoint_sets(
                 ('auto',), ('slurm',), ('hydra', 'gforker', 'remshell')
-            ).with_error(
+            ).prohibit_empty_set().with_error(
                 "'slurm' or 'auto' cannot be activated along with "
                 "other process managers"
             ).with_default('auto'),

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -1242,7 +1242,7 @@ other similar operations:
             ).prohibit_empty_set().with_error(
                 "'slurm' or 'auto' cannot be activated along with "
                 "other process managers"
-            ).with_default('auto'),
+            ).with_default('auto').with_non_feature_values('auto'),
         )
 
 ------------------------------------

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -359,9 +359,18 @@ class AutotoolsPackage(PackageBase):
             options = [(name, condition in spec)]
         else:
             condition = '{name}={value}'
+            # If the "values" of a variant are a fully-fledged object with
+            # a "feature_values" attribute, use that list. Otherwise use
+            # "values" directly. This distinction is needed to allow
+            # non-feature values in variants, which convey meaning to the user
+            # but are not translated into a direct feature (see #9481).
+            feature_values = getattr(
+                self.variants[name].values, 'feature_values', None
+            ) or self.variants[name].values
+
             options = [
                 (value, condition.format(name=name, value=value) in spec)
-                for value in self.variants[name].values
+                for value in feature_values
             ]
 
         # For each allowed value in the list of values

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -359,11 +359,10 @@ class AutotoolsPackage(PackageBase):
             options = [(name, condition in spec)]
         else:
             condition = '{name}={value}'
-            # If the "values" of a variant are a fully-fledged object with
-            # a "feature_values" attribute, use that list. Otherwise use
-            # "values" directly. This distinction is needed to allow
-            # non-feature values in variants, which convey meaning to the user
-            # but are not translated into a direct feature (see #9481).
+            # "feature_values" is used to track values which correspond to
+            # features which can be enabled or disabled as understood by the
+            # package's build system. It excludes values which have special
+            # meanings and do not correspond to features (e.g. "none")
             feature_values = getattr(
                 self.variants[name].values, 'feature_values', None
             ) or self.variants[name].values

--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -5,7 +5,10 @@
 
 from spack.package import PackageBase
 from spack.directives import depends_on, variant, conflicts
+
 import platform
+
+import spack.variant
 
 
 class CudaPackage(PackageBase):
@@ -19,11 +22,12 @@ class CudaPackage(PackageBase):
             description='Build with CUDA')
     # see http://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#gpu-feature-list
     # https://developer.nvidia.com/cuda-gpus
-    variant('cuda_arch', default=None,
+    variant('cuda_arch',
             description='CUDA architecture',
-            values=('20', '30', '32', '35', '50', '52', '53', '60', '61',
-                    '62', '70'),
-            multi=True)
+            values=spack.variant.any_combination_of(
+                '20', '30', '32', '35', '50', '52', '53', '60', '61',
+                '62', '70'
+            ))
 
     # see http://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#nvcc-examples
     # and http://llvm.org/docs/CompileCudaWithLLVM.html#compiling-cuda-code

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -478,8 +478,8 @@ def variant(
     for argument in ('default', 'multi', 'validator'):
         if hasattr(values, argument) and locals()[argument] is not None:
             def _raise_argument_error(pkg):
-                msg = "cannot specify '{0}' when passing a variant object " \
-                      "to the argument 'values' of a variant directive"
+                msg = "Remove specification of {0} argument: it is handled " \
+                      "by an attribute of the 'values' argument"
                 raise DirectiveError(format_error(msg.format(argument), pkg))
             return _raise_argument_error
 

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -483,7 +483,11 @@ def variant(
     validator = getattr(values, 'validator', validator)
     multi = getattr(values, 'multi', bool(multi))
 
-    if default is None:
+    # Here we sanitize against a default value being either None
+    # or the empty string, as the former indicates that a default
+    # was not set while the latter will make the variant unparsable
+    # from the command line
+    if default is None or default == '':
         def _raise_default_not_set(pkg):
             msg = "the default value in variant '{0}' from package" \
                   " '{1}' needs to be set explicitly"

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -483,9 +483,6 @@ def variant(
     validator = getattr(values, 'validator', validator)
     multi = getattr(values, 'multi', bool(multi))
 
-    if default is None and values == (True, False):
-        default = False
-
     if default is None:
         def _raise_default_not_set(pkg):
             msg = "the default value in variant '{0}' from package" \

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -476,6 +476,9 @@ def variant(
     # all the other arguments. Ensure we have no conflicting definitions
     # in place.
     for argument in ('default', 'multi', 'validator'):
+        # TODO: we can consider treating 'default' differently from other
+        # TODO: attributes and let a packager decide whether to use the fluent
+        # TODO: interface or the directive argument
         if hasattr(values, argument) and locals()[argument] is not None:
             def _raise_argument_error(pkg):
                 msg = "Remove specification of {0} argument: it is handled " \

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -486,12 +486,12 @@ def variant(
     if default is None and values == (True, False):
         default = False
 
-    # if default is None:
-    #     def _raise_default_not_set(pkg):
-    #         msg = "the default value in variant '{0}' from package" \
-    #               " '{1}' needs to be set explicitly"
-    #         raise DirectiveError(msg.format(name, pkg.name))
-    #     return _raise_default_not_set
+    if default is None:
+        def _raise_default_not_set(pkg):
+            msg = "the default value in variant '{0}' from package" \
+                  " '{1}' needs to be set explicitly"
+            raise DirectiveError(msg.format(name, pkg.name))
+        return _raise_default_not_set
 
     description = str(description).strip()
 

--- a/lib/spack/spack/pkgkit.py
+++ b/lib/spack/spack/pkgkit.py
@@ -47,3 +47,6 @@ from spack.util.executable import *
 from spack.package import \
     install_dependency_symlinks, flatten_dependencies, \
     DependencyConflictError, InstallError, ExternalPackageError
+
+from spack.variant import any_combination_of, auto_or_any_combination_of
+from spack.variant import disjoint_sets

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -123,8 +123,11 @@ class TestAutotoolsPackage(object):
         s.concretize()
         pkg = spack.repo.get(s)
 
-        # Called without parameters
         options = pkg.with_or_without('foo')
+
+        # Ensure that values that are not representing a feature
+        # are not used by with_or_without
+        assert '--without-none' not in options
         assert '--with-bar' in options
         assert '--without-baz' in options
         assert '--no-fee' in options
@@ -133,11 +136,13 @@ class TestAutotoolsPackage(object):
             return 'something'
 
         options = pkg.with_or_without('foo', activation_value=activate)
+        assert '--without-none' not in options
         assert '--with-bar=something' in options
         assert '--without-baz' in options
         assert '--no-fee' in options
 
         options = pkg.enable_or_disable('foo')
+        assert '--disable-none' not in options
         assert '--enable-bar' in options
         assert '--disable-baz' in options
         assert '--disable-fee' in options

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -149,3 +149,17 @@ class TestAutotoolsPackage(object):
 
         options = pkg.with_or_without('bvv')
         assert '--with-bvv' in options
+
+    def test_none_is_allowed(self):
+        s = Spec('a foo=none')
+        s.concretize()
+        pkg = spack.repo.get(s)
+
+        options = pkg.with_or_without('foo')
+
+        # Ensure that values that are not representing a feature
+        # are not used by with_or_without
+        assert '--with-none' not in options
+        assert '--without-bar' in options
+        assert '--without-baz' in options
+        assert '--no-fee' in options

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -820,8 +820,8 @@ class TestSpecSematics(object):
         )
         with pytest.raises(spack.directives.DirectiveError) as exc_info:
             fn(Pkg())
-        assert "cannot specify 'default' when passing a variant object to " \
-               "the argument" in str(exc_info.value)
+        assert " it is handled by an attribute of the 'values' " \
+               "argument" in str(exc_info.value)
 
         # We can't leave None as a default value
         fn = variant('foo', default=None)

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -13,6 +13,9 @@ from spack.variant import UnsatisfiableVariantSpecError
 from spack.variant import InconsistentValidationError
 from spack.variant import MultipleValuesInExclusiveVariantError
 from spack.variant import InvalidVariantValueError, DuplicateVariantError
+from spack.variant import disjoint_sets
+
+import spack.error
 
 
 class TestMultiValuedVariant(object):
@@ -692,3 +695,10 @@ class TestVariantMapTest(object):
         c['feebar'] = SingleValuedVariant('feebar', 'foo')
         c['shared'] = BoolValuedVariant('shared', True)
         assert str(c) == ' feebar=foo foo=bar,baz foobar=fee +shared'
+
+
+def test_disjoint_set_initialization_errors():
+    # Constructing from non-disjoint sets should raise an exception
+    with pytest.raises(spack.error.SpecError) as exc_info:
+        disjoint_sets(('a', 'b'), ('b', 'c'))
+    assert 'sets in input must be disjoint' in str(exc_info.value)

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -714,14 +714,14 @@ def test_disjoint_set_initialization():
     # Test that no error is thrown when the sets are disjoint
     d = disjoint_sets(('a',), ('b', 'c'), ('e', 'f'))
 
-    assert d.default is None
+    assert d.default is 'none'
     assert d.multi is True
-    assert set(x for x in d) == set(['a', 'b', 'c', 'e', 'f'])
+    assert set(x for x in d) == set(['none', 'a', 'b', 'c', 'e', 'f'])
 
 
 def test_disjoint_set_fluent_methods():
     # Construct an object without the empty set
-    d = disjoint_sets(('a',), ('b', 'c'), ('e', 'f'))
+    d = disjoint_sets(('a',), ('b', 'c'), ('e', 'f')).prohibit_empty_set()
     assert set(('none',)) not in d.sets
 
     # Call this 2 times to check that no matter whether

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -702,3 +702,12 @@ def test_disjoint_set_initialization_errors():
     with pytest.raises(spack.error.SpecError) as exc_info:
         disjoint_sets(('a', 'b'), ('b', 'c'))
     assert 'sets in input must be disjoint' in str(exc_info.value)
+
+
+def test_disjoint_set_initialization():
+    # Test that no error is thrown when the sets are disjoint
+    d = disjoint_sets(('a',), ('b', 'c'), ('e', 'f'))
+
+    assert d.default is None
+    assert d.multi is True
+    assert set(x for x in d) == set(['a', 'b', 'c', 'e', 'f'])

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -732,14 +732,15 @@ def test_disjoint_set_fluent_methods():
         assert set(('none',)) in d.sets
         assert 'none' in d
         assert 'none' in [x for x in d]
+        assert 'none' in d.feature_values
 
-    # Marking a value as 'non-feature' means that
-    # the value is in the variant, but iterating over
-    # the variant skips that value. See the originating
-    # class for more insight on this behavior.
+    # Marking a value as 'non-feature' removes it from the
+    # list of feature values, but not for the items returned
+    # when iterating over the object.
     d = d.with_non_feature_values('none')
     assert 'none' in d
-    assert 'none' not in [x for x in d]
+    assert 'none' in [x for x in d]
+    assert 'none' not in d.feature_values
 
     # Call this 2 times to check that no matter whether
     # the empty set was allowed or not before, the state
@@ -749,3 +750,4 @@ def test_disjoint_set_fluent_methods():
         assert set(('none',)) not in d.sets
         assert 'none' not in d
         assert 'none' not in [x for x in d]
+        assert 'none' not in d.feature_values

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -633,6 +633,9 @@ class DisjointSetsOfValues(Sequence):
         if any(s1 & s2 for s1, s2 in itertools.combinations(self.sets, 2)):
             raise error.SpecError('sets in input must be disjoint')
 
+        #: Attribute used to track values which correspond to
+        #: features which can be enabled or disabled as understood by the
+        #: package's build system.
         self.feature_values = tuple(itertools.chain.from_iterable(self.sets))
         self.default = None
         self.multi = True
@@ -677,9 +680,9 @@ class DisjointSetsOfValues(Sequence):
         sets = [s for s in self.sets if s != self._empty_set]
         object_without_empty_set = type(self)(*sets)
         object_without_empty_set.error_fmt = self.error_fmt
-        object_without_empty_set.feature_values = [
+        object_without_empty_set.feature_values = tuple(
             x for x in self.feature_values if x != 'none'
-        ]
+        )
         return object_without_empty_set
 
     def __getitem__(self, idx):
@@ -751,7 +754,21 @@ def auto_or_any_combination_of(*values):
 
 #: Multi-valued variant that allows any combination picking
 #: from one of multiple disjoint sets
-disjoint_sets = DisjointSetsOfValues
+def disjoint_sets(*sets):
+    """Multi-valued variant that allows any combination picking from one
+    of multiple disjoint sets of values, and also allows the user to specify
+    'none' (as a string) to choose none of them.
+
+    It is up to the package implementation to handle the value 'none'
+    specially, if at all.
+
+    Args:
+        *sets:
+
+    Returns:
+        a properly initialized instance of DisjointSetsOfValues
+    """
+    return DisjointSetsOfValues(*sets).allow_empty_set().with_default('none')
 
 
 class DuplicateVariantError(error.SpecError):

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -733,8 +733,12 @@ def _a_single_value_or_a_combination(single_value, *values):
 
 
 def any_combination_of(*values):
-    """Multi-valued variant that allows any combination of a set of
-    values including the empty set.
+    """Multi-valued variant that allows any combination of the specified
+    values, and also allows the user to specify 'none' (as a string) to choose
+    none of them.
+
+    It is up to the package implementation to handle the value 'none'
+    specially, if at all.
 
     Args:
         *values: allowed variant values

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -675,6 +675,11 @@ def _a_single_value_or_a_combination(single_value, *values):
         with_non_feature_values(single_value)
 
 
+# TODO: The factories below are used by package writers to set values of
+# TODO: multi-valued variants. It could be worthwhile to gather them in
+# TODO: a common namespace (like 'multi') in the future.
+
+
 def any_combination_of(*values):
     """Multi-valued variant that allows any combination of a set of
     values or 'none'.

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -78,8 +78,8 @@ class Variant(object):
 
         else:
             # Otherwise assume values is the set of allowed explicit values
-            self.values = tuple(values)
-            allowed = self.values + (self.default,)
+            self.values = values
+            allowed = tuple(self.values) + (self.default,)
             self.single_value_validator = lambda x: x in allowed
 
         self.multi = multi
@@ -682,24 +682,11 @@ class DisjointSetsOfValues(Sequence):
         ]
         return object_without_empty_set
 
-    def __contains__(self, item):
-        # The code taking care of variants uses __contains__ to validate
-        # the values that are parsed, while build systems are often
-        # iterating over "feature" values of a variant to automatically
-        # construct configure options (or similar things) for packagers.
-        #
-        # Here we need to override __contains__ so that we return True
-        # also for values that are marked as "non-feature", while we want
-        # iteration to just return "feature" values so that placeholders
-        # (like 'none') won't interfere with the generation of configure
-        # string.
-        return item in itertools.chain.from_iterable(self.sets)
-
     def __getitem__(self, idx):
-        return tuple(self.feature_values)[idx]
+        return tuple(itertools.chain.from_iterable(self.sets))[idx]
 
     def __len__(self):
-        return len(self.feature_values)
+        return len(itertools.chain.from_iterable(self.sets))
 
     @property
     def validator(self):

--- a/var/spack/repos/builtin.mock/packages/a/package.py
+++ b/var/spack/repos/builtin.mock/packages/a/package.py
@@ -16,11 +16,8 @@ class A(AutotoolsPackage):
     version('2.0', '2.0_a_hash')
 
     variant(
-        'foo',
-        values=('bar', 'baz', 'fee'),
-        default='bar',
-        description='',
-        multi=True
+        'foo', description='',
+        values=any_combination_of('bar', 'baz', 'fee').with_default('bar'),
     )
 
     variant(

--- a/var/spack/repos/builtin.mock/packages/multivalue_variant/package.py
+++ b/var/spack/repos/builtin.mock/packages/multivalue_variant/package.py
@@ -17,10 +17,8 @@ class MultivalueVariant(Package):
 
     variant('debug', default=False, description='Debug variant')
     variant(
-        'foo',
-        description='Multi-valued variant',
-        values=('bar', 'baz', 'barbaz'),
-        multi=True
+        'foo', description='Multi-valued variant',
+        values=any_combination_of('bar', 'baz', 'barbaz'),
     )
 
     variant(

--- a/var/spack/repos/builtin/packages/adios/package.py
+++ b/var/spack/repos/builtin/packages/adios/package.py
@@ -61,10 +61,7 @@ class Adios(AutotoolsPackage):
     variant('netcdf', default=False, description='Enable netcdf support')
 
     variant(
-        'staging',
-        default=None,
-        values=('flexpath', 'dataspaces'),
-        multi=True,
+        'staging', values=any_combination_of('flexpath', 'dataspaces'),
         description='Enable dataspaces and/or flexpath staging transports'
     )
 

--- a/var/spack/repos/builtin/packages/axl/package.py
+++ b/var/spack/repos/builtin/packages/axl/package.py
@@ -7,7 +7,7 @@ from spack import *
 from spack.error import SpackError
 
 
-def async_api_validator(values):
+def async_api_validator(pkg_name, variant_name, values):
     if 'none' in values and len(values) != 1:
         raise SpackError("The value 'none' is not usable"
                          " with other async_api values.")

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -34,10 +34,7 @@ class Glib(AutotoolsPackage):
 
     variant('libmount', default=False, description='Build with libmount support')
     variant(
-        'tracing',
-        default='',
-        values=('dtrace', 'systemtap'),
-        multi=True,
+        'tracing', values=any_combination_of('dtrace', 'systemtap'),
         description='Enable tracing support'
     )
 

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -71,7 +71,7 @@ class Kokkos(Package):
     # Host architecture variant
     variant(
         'host_arch',
-        default=None,
+        default='none',
         values=('AMDAVX', 'ARMv80', 'ARMv81', 'ARMv8-ThunderX',
                 'Power7', 'Power8', 'Power9',
                 'WSM', 'SNB', 'HSW', 'BDW', 'SKX', 'KNC', 'KNL'),
@@ -81,7 +81,7 @@ class Kokkos(Package):
     # GPU architecture variant
     variant(
         'gpu_arch',
-        default=None,
+        default='none',
         values=gpu_values,
         description='Set the GPU architecture to use'
     )
@@ -159,9 +159,9 @@ class Kokkos(Package):
             host_arch = spec.variants['host_arch'].value
             # GPU architectures
             gpu_arch  = spec.variants['gpu_arch'].value
-            if host_arch:
+            if host_arch != 'none':
                 arch_args.append(host_arch)
-            if gpu_arch:
+            if gpu_arch != 'none':
                 arch_args.append(gpu_arch)
             # Combined architecture flags
             if arch_args:

--- a/var/spack/repos/builtin/packages/matlab/package.py
+++ b/var/spack/repos/builtin/packages/matlab/package.py
@@ -35,7 +35,7 @@ class Matlab(Package):
 
     variant(
         'key',
-        default='',
+        default='<installation-key-here>',
         values=lambda x: True,  # Anything goes as a key
         description='The file installation key to use'
     )

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -64,7 +64,7 @@ class Mvapich2(AutotoolsPackage):
         description='List of the process managers to activate',
         values=disjoint_sets(
             ('auto',), ('slurm',), ('hydra', 'gforker', 'remshell')
-        ).with_error(
+        ).prohibit_empty_set().with_error(
             "'slurm' or 'auto' cannot be activated along with "
             "other process managers"
         ).with_default('auto'),

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -67,7 +67,7 @@ class Mvapich2(AutotoolsPackage):
         ).prohibit_empty_set().with_error(
             "'slurm' or 'auto' cannot be activated along with "
             "other process managers"
-        ).with_default('auto'),
+        ).with_default('auto').with_non_feature_values('auto'),
     )
 
     variant(

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -65,8 +65,8 @@ class Mvapich2(AutotoolsPackage):
         values=disjoint_sets(
             ('auto',), ('slurm',), ('hydra', 'gforker', 'remshell')
         ).with_error(
-            "'slurm' or 'auto' cannot be activated along with other process "
-            "managers in the variant '{0}' of package '{1}'"
+            "'slurm' or 'auto' cannot be activated along with "
+            "other process managers"
         ).with_default('auto'),
     )
 

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -6,14 +6,6 @@
 import sys
 
 from spack import *
-from spack.error import SpackError
-
-
-def _process_manager_validator(values):
-    if len(values) > 1 and 'slurm' in values:
-        raise SpackError(
-            'slurm cannot be activated along with other process managers'
-        )
 
 
 class Mvapich2(AutotoolsPackage):
@@ -70,9 +62,12 @@ class Mvapich2(AutotoolsPackage):
     variant(
         'process_managers',
         description='List of the process managers to activate',
-        values=('slurm', 'hydra', 'gforker', 'remshell'),
-        multi=True,
-        validator=_process_manager_validator
+        values=disjoint_sets(
+            ('auto',), ('slurm',), ('hydra', 'gforker', 'remshell')
+        ).with_error(
+            "'slurm' or 'auto' cannot be activated along with other process "
+            "managers in the variant '{0}' of package '{1}'"
+        ).with_default('auto'),
     )
 
     variant(
@@ -94,8 +89,7 @@ class Mvapich2(AutotoolsPackage):
     variant(
         'file_systems',
         description='List of the ROMIO file systems to activate',
-        values=('lustre', 'gpfs', 'nfs', 'ufs'),
-        multi=True
+        values=auto_or_any_combination_of('lustre', 'gpfs', 'nfs', 'ufs'),
     )
 
     depends_on('findutils', type='build')

--- a/var/spack/repos/builtin/packages/omega-h/package.py
+++ b/var/spack/repos/builtin/packages/omega-h/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-
 
 class OmegaH(CMakePackage):
     """Omega_h is a C++11 library providing data structures and algorithms
@@ -28,8 +26,7 @@ class OmegaH(CMakePackage):
     variant('shared', default=True, description='Build shared libraries')
     variant('mpi', default=True, description='Activates MPI support')
     variant('zlib', default=True, description='Activates ZLib support')
-    variant('trilinos', default=False, description='Use Teuchos and Kokkos')
-    variant('build_type', default='')
+    variant('trilinos', default=True, description='Use Teuchos and Kokkos')
     variant('throw', default=False, description='Errors throw exceptions instead of abort')
     variant('examples', default=False, description='Compile examples')
     variant('optimize', default=True, description='Compile C++ with optimization')

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -38,8 +38,8 @@ class Openblas(MakefilePackage):
     variant('ilp64', default=False, description='64 bit integers')
     variant('pic', default=True, description='Build position independent code')
 
-    variant('cpu_target', default='',
-                    description='Set CPU target architecture (leave empty for '
+    variant('cpu_target', default='auto',
+            description='Set CPU target architecture (leave empty for '
                         'autodetection; GENERIC, SSE_GENERIC, NEHALEM, ...)')
 
     variant(
@@ -150,7 +150,7 @@ class Openblas(MakefilePackage):
                 'NUM_THREADS=64',  # OpenBLAS stores present no of CPUs as max
             ]
 
-        if self.spec.variants['cpu_target'].value:
+        if self.spec.variants['cpu_target'].value != 'auto':
             make_defs += [
                 'TARGET={0}'.format(self.spec.variants['cpu_target'].value)
             ]

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -7,8 +7,6 @@
 import os
 import sys
 
-from spack import *
-
 
 def _verbs_dir():
     """Try to find the directory where the OpenFabrics verbs package is
@@ -180,20 +178,17 @@ class Openmpi(AutotoolsPackage):
     patch('btl_vader.patch', when='@3.1.0:3.1.2')
 
     fabrics = ('psm', 'psm2', 'verbs', 'mxm', 'ucx', 'libfabric')
-
     variant(
-        'fabrics',
-        default=None if _verbs_dir() is None else 'verbs',
+        'fabrics', values=auto_or_any_combination_of(*fabrics).with_default(
+            'auto' if _verbs_dir() is None else 'verbs'
+        ),
         description="List of fabrics that are enabled",
-        values=fabrics,
-        multi=True
     )
 
+    schedulers = ('alps', 'lsf', 'tm', 'slurm', 'sge', 'loadleveler')
     variant(
-        'schedulers',
-        description='List of schedulers for which support is enabled',
-        values=('alps', 'lsf', 'tm', 'slurm', 'sge', 'loadleveler'),
-        multi=True
+        'schedulers', values=auto_or_any_combination_of(*schedulers),
+        description='List of schedulers for which support is enabled'
     )
 
     # Additional support options

--- a/var/spack/repos/builtin/packages/py-patsy/package.py
+++ b/var/spack/repos/builtin/packages/py-patsy/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-
 
 class PyPatsy(PythonPackage):
     """A Python package for describing statistical models and for
@@ -15,7 +13,7 @@ class PyPatsy(PythonPackage):
 
     version('0.4.1', '9445f29e3426d1ed30d683a1e1453f84')
 
-    variant('splines', description="Offers spline related functions")
+    variant('splines', default=False, description="Offers spline related functions")
 
     depends_on('py-setuptools',  type='build')
     depends_on('py-numpy',       type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/regcm/package.py
+++ b/var/spack/repos/builtin/packages/regcm/package.py
@@ -25,8 +25,10 @@ class Regcm(AutotoolsPackage):
     # producing a so-called fat binary. Unfortunately, gcc builds only the last
     # architecture provided (in the configure), so we allow a single arch.
     extensions = ('knl', 'skl', 'bdw', 'nhl')
-    variant('extension', default=None, values=extensions, multi=True,
-            description='Build extensions for a specific Intel architecture.')
+    variant(
+        'extension', values=any_combination_of(extensions),
+        description='Build extensions for a specific Intel architecture.'
+    )
 
     depends_on('netcdf')
     depends_on('netcdf-fortran')

--- a/var/spack/repos/builtin/packages/scr/package.py
+++ b/var/spack/repos/builtin/packages/scr/package.py
@@ -130,7 +130,7 @@ class Scr(CMakePackage):
     @run_after('install')
     def copy_config(self):
         spec = self.spec
-        if spec.variants['copy_config'].value:
+        if spec.variants['copy_config'].value != 'none':
             dest_path = self.get_abs_path_rel_prefix(
                 spec.variants['scr_config'].value)
             install(spec.variants['copy_config'].value, dest_path)

--- a/var/spack/repos/builtin/packages/scr/package.py
+++ b/var/spack/repos/builtin/packages/scr/package.py
@@ -47,7 +47,7 @@ class Scr(CMakePackage):
     variant('scr_config', default='scr.conf',
             description='Location for SCR to find its system config file. '
             'May be either absolute or relative to the install prefix')
-    variant('copy_config', default=None,
+    variant('copy_config', default='none',
             description='Location from which to copy SCR system config file. '
             'Must be an absolute path.')
 

--- a/var/spack/repos/builtin/packages/yambo/package.py
+++ b/var/spack/repos/builtin/packages/yambo/package.py
@@ -26,19 +26,13 @@ class Yambo(AutotoolsPackage):
 
     variant('dp', default=False, description='Enable double precision')
     variant(
-        'profile',
-        values=('time', 'memory'),
-        default='',
-        description='Activate profiling of specific sections',
-        multi=True
+        'profile', values=any_combination_of('time', 'memory'),
+        description='Activate profiling of specific sections'
     )
 
     variant(
-        'io',
-        values=('iotk', 'etsf-io'),
-        default='',
+        'io', values=any_combination_of('iotk', 'etsf-io'),
         description='Activate support for different io formats (requires network access)',  # noqa
-        multi=True
     )
 
     # MPI + OpenMP parallelism


### PR DESCRIPTION
fixes #6314 

To sum up the issue: `multi-valued` variants with default set to `None` were not parsable from the command line, as `None` was converted to the empty string.

This PR solves the problem by sanitizing all the packages against having `None` as a default value, and allows for the more declarative syntax discussed in the issue.

The implementation is based on the possibility that the `variant` directive now has to accept as the `values` argument an object that could prescribe its own default value or other settings. A declarative style can be maintained using a [fluent interface](https://en.wikipedia.org/wiki/Fluent_interface) to set these embedded arguments in such an object.

A few packages have been modified to show how the new (optional) syntax looks like.

**Example output with this PR**
```console
# The default value can now be specified explicitly
$ spack spec openmpi fabrics=auto
Input spec
--------------------------------
openmpi fabrics=auto

Concretized
--------------------------------
openmpi@3.1.2%gcc@8.0.1~cuda+cxx_exceptions fabrics=auto ~java~legacylaunchers~memchecker~pmi schedulers=auto ~sqlite3~thread_multiple+vt arch=linux-ubuntu18.04-x86_64
...

# We can easily write a custom error message
$ spack spec openmpi fabrics=auto,psm
Input spec
--------------------------------
openmpi fabrics=auto,psm

Concretized
--------------------------------
==> Error: the value 'auto' is mutually exclusive with any of the other values [openmpi, variant 'fabrics']

$ spack spec mvapich2 process_managers=slurm,gforker
Input spec
--------------------------------
mvapich2 process_managers=gforker,slurm

Concretized
--------------------------------
==> Error: 'slurm' or 'auto' cannot be activated along with other process managers [mvapich2, variant 'process_managers']

# Finally let's suppose I left `default=None` in a new package, here's what happens
# (This will fail the package_sanity unit test on Travis)
$ spack spec mvapich2 
Input spec
--------------------------------
mvapich2

Concretized
--------------------------------
==> Error: either a default was not explicitly set, or 'None' was used [mvapich2, variant 'ch3_rank_bits']
```
