### PR TITLE
Correct name for install_path_scheme in defaults config.yaml

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -25,7 +25,7 @@ config:
 
 
   # default directory layout
-  directory_layout: "${ARCHITECTURE}/${COMPILERNAME}-${COMPILERVER}/${PACKAGE}-${VERSION}-${HASH}"
+  install_path_scheme: "${ARCHITECTURE}/${COMPILERNAME}-${COMPILERVER}/${PACKAGE}-${VERSION}-${HASH}"
 
 
   # Locations where different types of modules should be installed.


### PR DESCRIPTION
Default config.yaml mis-named `install_path_scheme` as `directory_layout`.

`install_path_scheme` is properly documented and used in the code.