### PR TITLE
Remove language-related variables from build environment

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -77,6 +77,14 @@ config:
   dirty: false
 
 
+  # The language the build environment will use. This will produce English
+  # compiler messages by default, so the log parser can highlight errors.
+  # If set to C, it will use English (see man locale).
+  # If set to the empty string (''), it will use the language from the
+  # user's environment.
+  build_language: C
+
+
   # When set to true, concurrent instances of Spack will use locks to
   # avoid modifying the install tree, database file, etc. If false, Spack
   # will disable all locking, but you must NOT run concurrent instances

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -161,6 +161,13 @@ def clean_environment():
     env.unset('LD_RUN_PATH')
     env.unset('DYLD_LIBRARY_PATH')
 
+    build_lang = spack.config.get('config:build_language')
+    if build_lang:
+        # Override language-related variables. This can be used to force
+        # English compiler messages etc., which allows parse_log_events to
+        # show useful matches.
+        env.set('LC_ALL', build_lang)
+
     # Remove any macports installs from the PATH.  The macports ld can
     # cause conflicts with the built-in linker on el capitan.  Solves
     # assembler issues, e.g.:

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -68,6 +68,7 @@ schema = {
                 'checksum': {'type': 'boolean'},
                 'locks': {'type': 'boolean'},
                 'dirty': {'type': 'boolean'},
+                'build_language': {'type': 'string'},
                 'build_jobs': {'type': 'integer', 'minimum': 1},
                 'ccache': {'type': 'boolean'},
                 'db_lock_timeout': {'type': 'integer', 'minimum': 1},


### PR DESCRIPTION
While debugging a rdma-core build failure, I noticed that Spack did not show the errors in the build log. This is because my system is set to German and the log parser does not find any "error" occurrences in the log.