### PR TITLE
trilinos: disable superlu-dist by default

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -113,7 +113,7 @@ class Trilinos(CMakePackage):
             description='Compile with parallel-netcdf')
     variant('suite-sparse', default=True,
             description='Compile with SuiteSparse solvers')
-    variant('superlu-dist', default=True,
+    variant('superlu-dist', default=False,
             description='Compile with SuperluDist solvers')
     variant('superlu',      default=False,
             description='Compile with SuperLU solvers')


### PR DESCRIPTION
current stable releases of PETSc and Trilinos have non-overlapping
requirements on Superlu-dist. For now turn it off by default in
Trilinos, which requires older versions. Otherwise, any package which use both will fail to concretize by default.