### PR TITLE
buildcache install: add modules

### DIFF
--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -254,6 +254,7 @@ def install_tarball(spec, args):
             tty.msg('Installing buildcache for spec %s' % spec.format())
             bindist.extract_tarball(spec, tarball, args.allow_root,
                                     args.unsigned, args.force)
+            spack.hooks.post_install(spec)
             spack.store.store.reindex()
         else:
             tty.die('Download of binary cache file for spec %s failed.' %


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/9375

@gartung (FYI)

Spack packages installed using `spack buildcache` were not running post-install hooks, which create module files and managing licenses (if necessary).

This was already occurring for Spack packages installed with `spack install --use-cache`