### PR TITLE
vtk: enhance with Xdmf IO.

### DIFF
--- a/var/spack/repos/builtin/packages/lz4/package.py
+++ b/var/spack/repos/builtin/packages/lz4/package.py
@@ -32,7 +32,7 @@ class Lz4(Package):
 
     def install(self, spec, prefix):
         if sys.platform != "darwin":
-            make('LIBS=-lrt')  # fixes make error on CentOS6
+            make('MOREFLAGS=-lrt')  # fixes make error on CentOS6
         else:
             make()
         if self.run_tests:

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -47,6 +47,7 @@ class Mesa(AutotoolsPackage):
     depends_on('binutils', type='build', when=(sys.platform != 'darwin'))
     depends_on('python@2.6.4:', type='build')
     depends_on('py-mako@0.3.4:', type='build')
+    depends_on('py-argparse', type='build')
     depends_on('gettext')
     depends_on('icu4c')
     depends_on('expat')

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -181,9 +181,12 @@ class Vtk(CMakePackage):
             ])
 
         if '+xdmf' in spec:
+            if spec.satisfies('^cmake@3.12:')
+                # This policy exists only for CMake >= 3.12
+                cmake_args.extend(["-DCMAKE_POLICY_DEFAULT_CMP0074=NEW"])
+
             cmake_args.extend([
                 # Enable XDMF Support here
-                "-DCMAKE_POLICY_DEFAULT_CMP0074=NEW",
                 "-DModule_vtkIOXdmf2:BOOL=ON",
                 "-DModule_vtkIOXdmf3:BOOL=ON",
                 "-DModule_vtkIOParallelXdmf3:BOOL=ON",

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -29,7 +29,9 @@ class Vtk(CMakePackage):
     variant('osmesa', default=False, description='Enable OSMesa support')
     variant('python', default=False, description='Enable Python support')
     variant('qt', default=False, description='Build with support for Qt')
-    variant('mpi', default=True, description='Enable MPI support')
+    variant('xdmf', default=False, description='Build XDMF file support')
+    variant('ffmpeg', default=False, description='Build with FFMPEG support')
+    variant('mpi', default=False, description='Enable MPI support')
 
     # Haru causes trouble on Fedora and Ubuntu in v8.1.1
     # See https://bugzilla.redhat.com/show_bug.cgi?id=1460059#c13
@@ -40,6 +42,11 @@ class Vtk(CMakePackage):
     # At the moment, we cannot build with both osmesa and qt, but as of
     # VTK 8.1, that should change
     conflicts('+osmesa', when='+qt')
+
+    # mpi4py calls seem not to work with py37
+    conflicts('+python', when='^python@3.7')
+    depends_on('python', when='+python')
+    extends('python', when='+python')
 
     # The use of the OpenGL2 backend requires at least OpenGL Core Profile
     # version 3.2 or higher.
@@ -60,6 +67,13 @@ class Vtk(CMakePackage):
 
     depends_on('libharu', when='+haru')
 
+    depends_on('boost', when='+xdmf')
+    depends_on('boost+mpi', when='+xdmf+mpi')
+
+    depends_on('mpi', when='+mpi')
+
+    depends_on('ffmpeg', when='+ffmpeg')
+
     depends_on('expat')
     depends_on('freetype')
     depends_on('glew')
@@ -73,8 +87,6 @@ class Vtk(CMakePackage):
     depends_on('libpng')
     depends_on('libtiff')
     depends_on('zlib')
-
-    extends('python', when='+python')
 
     def url_for_version(self, version):
         url = "http://www.vtk.org/files/release/{0}/VTK-{1}.tar.gz"
@@ -99,12 +111,12 @@ class Vtk(CMakePackage):
 
             # In general, we disable use of VTK "ThirdParty" libs, preferring
             # spack-built versions whenever possible
-            '-DVTK_USE_SYSTEM_LIBRARIES=ON',
+            '-DVTK_USE_SYSTEM_LIBRARIES:BOOL=ON',
 
             # However, in a few cases we can't do without them yet
-            '-DVTK_USE_SYSTEM_GL2PS=OFF',
-            '-DVTK_USE_SYSTEM_LIBPROJ4=OFF',
-            '-DVTK_USE_SYSTEM_OGGTHEORA=OFF',
+            '-DVTK_USE_SYSTEM_GL2PS:BOOL=OFF',
+            '-DVTK_USE_SYSTEM_LIBPROJ4:BOOL=OFF',
+            '-DVTK_USE_SYSTEM_OGGTHEORA:BOOL=OFF',
 
             '-DNETCDF_DIR={0}'.format(spec['netcdf'].prefix),
             '-DNETCDF_C_ROOT={0}'.format(spec['netcdf'].prefix),
@@ -114,6 +126,15 @@ class Vtk(CMakePackage):
             '-DVTK_WRAP_JAVA=OFF',
             '-DVTK_WRAP_TCL=OFF',
         ]
+
+        if '+mpi' in spec:
+            cmake_args.extend([
+                '-DVTK_Group_MPI:BOOL=ON',
+                '-DVTK_USE_SYSTEM_DIY2:BOOL=OFF',
+            ])
+
+        if '+ffmpeg' in spec:
+            cmake_args.extend(['-DModule_vtkIOFFMPEG:BOOL=ON'])
 
         # Enable/Disable wrappers for Python.
         if '+python' in spec:
@@ -156,6 +177,30 @@ class Vtk(CMakePackage):
                 '-DVTK_Group_MPI:BOOL=ON',
                 '-DVTK_USE_SYSTEM_DIY2=OFF'
             ])
+
+        if '+xdmf' in spec:
+            cmake_args.extend([
+                # Enable XDMF Support here
+                "-DCMAKE_POLICY_DEFAULT_CMP0074=NEW",
+                "-DModule_vtkIOXdmf2:BOOL=ON",
+                "-DModule_vtkIOXdmf3:BOOL=ON",
+                "-DModule_vtkIOParallelXdmf3:BOOL=ON",
+                "-DBOOST_ROOT={0}".format(spec['boost'].prefix),
+                "-DBOOST_LIBRARY_DIR={0}".format(spec['boost'].prefix.lib),
+                "-DBOOST_INCLUDE_DIR={0}".format(spec['boost'].prefix.include),
+                "-DBOOST_NO_SYSTEM_PATHS:BOOL=ON",
+                # This is needed because VTK has multiple FindBoost
+                # and they stick to system boost if there's a system boost
+                # installed with CMake
+                "-DBoost_NO_BOOST_CMAKE:BOOL=ON",
+                "-DHDF5_ROOT={0}".format(spec['hdf5'].prefix),
+                # The xdmf project does not export any CMake file...
+                "-DVTK_USE_SYSTEM_XDMF3:BOOL=OFF",
+                "-DVTK_USE_SYSTEM_XDMF2:BOOL=OFF"
+            ])
+
+            if '+mpi' in spec:
+                cmake_args.extend(["-DModule_vtkIOParallelXdmf3:BOOL=ON"])
 
         if '+osmesa' in spec:
             prefix = spec['mesa'].prefix

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -47,6 +47,7 @@ class Vtk(CMakePackage):
     depends_on('py-mpi4py', when='+mpi +python', type='run')
     extends('python', when='+python')
     # python3.7 compatibility patch backported from upstream
+    # https://gitlab.kitware.com/vtk/vtk/commit/706f1b397df09a27ab8981ab9464547028d0c322
     patch('python3.7-const-char.patch', when='@:8.1.1 ^python@3.7:')
 
     # The use of the OpenGL2 backend requires at least OpenGL Core Profile

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -181,7 +181,7 @@ class Vtk(CMakePackage):
             ])
 
         if '+xdmf' in spec:
-            if spec.satisfies('^cmake@3.12:')
+            if spec.satisfies('^cmake@3.12:'):
                 # This policy exists only for CMake >= 3.12
                 cmake_args.extend(["-DCMAKE_POLICY_DEFAULT_CMP0074=NEW"])
 

--- a/var/spack/repos/builtin/packages/vtk/python3.7-const-char.patch
+++ b/var/spack/repos/builtin/packages/vtk/python3.7-const-char.patch
@@ -1,0 +1,27 @@
+diff --git a/Wrapping/PythonCore/vtkPythonArgs.cxx b/Wrapping/PythonCore/vtkPythonArgs.cxx
+index 1a82af0802..b733458975 100644
+--- a/Wrapping/PythonCore/vtkPythonArgs.cxx
++++ b/Wrapping/PythonCore/vtkPythonArgs.cxx
+@@ -95,13 +95,21 @@ bool vtkPythonGetStringValue(PyObject *o, T *&a, const char *exctext)
+ {
+   if (PyBytes_Check(o))
+   {
++#if PY_VERSION_HEX >= 0x03070000
++    a = const_cast<char *>(PyBytes_AS_STRING(o));
++    return true;
++#else
+     a = PyBytes_AS_STRING(o);
+     return true;
++#endif
+   }
+ #ifdef Py_USING_UNICODE
+   else if (PyUnicode_Check(o))
+   {
+-#if PY_VERSION_HEX >= 0x03030000
++#if PY_VERSION_HEX >= 0x03070000
++    a = const_cast<char *>(PyUnicode_AsUTF8(o));
++    return true;
++#elif PY_VERSION_HEX >= 0x03030000
+     a = PyUnicode_AsUTF8(o);
+     return true;
+ #else


### PR DESCRIPTION
This PR adds `xdmf` readers and writers to vtk together with `mpi` and `ffmpeg`.

Also fixed minor bugs in `lz4`, that had a wrong `LIBS` variable ovveride in the makefile, `mesa` missing argparse at least on `python@3.7.0`

