### PR TITLE
Update with latest releases from PMIX

### DIFF
--- a/var/spack/repos/builtin/packages/pmix/package.py
+++ b/var/spack/repos/builtin/packages/pmix/package.py
@@ -49,6 +49,12 @@ class Pmix(AutotoolsPackage):
     homepage = "https://pmix.github.io/pmix"
     url      = "https://github.com/pmix/pmix/releases/download/v2.0.1/pmix-2.0.1.tar.bz2"
 
+    version('3.0.2',    sha1='3a1c253cb078a9088e9a0a513f3a40e2f7f29cb8')
+    version('3.0.1',    sha1='5e280770a51df30f4d99160c4985e246df76ab2a')
+    version('3.0.0',    sha1='f81c82d28c744b489303c577b06310ae696404b1')
+    version('2.1.4',    sha1='1bc2bc2572227d52eaea9862643affaa4fd7599a')
+    version('2.1.3',    sha1='838640203a5a92f46a7371fd4224b34437b3d74d')
+    version('2.1.2',    sha1='6b925e3fd563caea029c38e527aa6504f84f19dc')
     version('2.1.1',    'f9f109421661b757245d5e0bd44a38b3')
     version('2.1.0',    'fc97513b601d78fe7c6bb20c6a21df3c')
     version('2.0.3',    'fae199c9fa1d1f1bc20c336f1292f950')


### PR DESCRIPTION
(https://github.com/pmix/pmix/releases)

Test installs
dantopa@tt-fey1:scripts $ uname -a
Linux tt-fey1 4.4.143-94.47.1.16060.2.PTF.1107299-default #1 SMP Tue Sep
11 06:36:34 UTC 2018 (4b33812) x86_64 x86_64 x86_64 GNU/Linux

dantopa@tt-fey1:scripts $ lsb_release -d
Description:    SUSE Linux Enterprise Server 12 SP3

dantopa@tt-fey1:scripts $ date
Thu Oct 11 23:23:18 MDT 2018

dantopa@tt-fey1:scripts $ pwd
/lustre/ttscratch1/dantopa/repos/spack/spack.compute.develop/scripts

dantopa@tt-fey1:scripts $ grep -i 'model name' /proc/cpuinfo | sort | uniq
model name  : Intel(R) Xeon(R) CPU E5-2650 v3 @ 2.30GHz

dantopa@tt-fey1:scripts $ spack find -ldf pmix
==> 6 installed packages.
-- cray-cnl6-haswell / gcc@6.3.0 --------------------------------
etztaq3    pmix@2.1.2%gcc
yh6zwe6        ^libevent@2.0.21%gcc
s3iichk            ^openssl@1.0.2o%gcc

4llwmow    pmix@2.1.3%gcc
yh6zwe6        ^libevent@2.0.21%gcc
s3iichk            ^openssl@1.0.2o%gcc

vmx4cih    pmix@2.1.4%gcc
yh6zwe6        ^libevent@2.0.21%gcc
s3iichk            ^openssl@1.0.2o%gcc

pu7wemz    pmix@3.0.0%gcc
yh6zwe6        ^libevent@2.0.21%gcc
s3iichk            ^openssl@1.0.2o%gcc

fqzgnrw    pmix@3.0.1%gcc
yh6zwe6        ^libevent@2.0.21%gcc
s3iichk            ^openssl@1.0.2o%gcc

tl3xt2y    pmix@3.0.2%gcc
yh6zwe6        ^libevent@2.0.21%gcc
s3iichk            ^openssl@1.0.2o%gcc

Signed-off-by: Daniel Topa <dantopa@lanl.gov>