### PR TITLE
sspace-standard: fix to use Getopt::Std instead of getopts.pl

### DIFF
--- a/var/spack/repos/builtin/packages/sspace-standard/package.py
+++ b/var/spack/repos/builtin/packages/sspace-standard/package.py
@@ -55,6 +55,9 @@ class SspaceStandard(Package):
         for s in scripts:
             filter_file('/usr/bin/perl', '/usr/bin/env perl',
                         s, string=True)
+            filter_file('require "getopts.pl";', 'use Getopt::Std;',
+                        s, string=True)
+            filter_file('&Getopts(', 'getopts(', s, string=True)
 
         install_tree('bin', prefix.bin)
         install_tree('bowtie', prefix.bowtie)


### PR DESCRIPTION
Missed this with my last PR for sspace-standard as I was testing on a box where getopts.pl was installed.