### PR TITLE
Adding conflict to Trilinos and build Nalu-Wind statically by default on Darwin

### DIFF
--- a/var/spack/repos/builtin/packages/nalu-wind/package.py
+++ b/var/spack/repos/builtin/packages/nalu-wind/package.py
@@ -22,6 +22,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+import sys
 
 
 class NaluWind(CMakePackage):
@@ -32,6 +33,8 @@ class NaluWind(CMakePackage):
 
     maintainers = ['jrood-nrel']
 
+    tags = ['ecp', 'ecp-apps']
+
     version('master', branch='master')
 
     variant('openfast', default=False,
@@ -40,10 +43,15 @@ class NaluWind(CMakePackage):
             description='Compile with Tioga support')
     variant('hypre', default=False,
             description='Compile with Hypre support')
+    variant('shared', default=(sys.platform != 'darwin'),
+            description='Build Trilinos as shared library')
 
     depends_on('mpi')
     depends_on('yaml-cpp@0.5.3:')
-    depends_on('trilinos+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist+superlu+hdf5+zlib+pnetcdf+shards~hypre@master,develop')
+    depends_on('trilinos+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist+superlu+hdf5+zlib+pnetcdf+shards~hypre@master,develop', when='+shared')
+    # Cannot build Trilinos as a shared library with STK on Darwin
+    # https://github.com/trilinos/Trilinos/issues/2994
+    depends_on('trilinos~shared+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist+superlu+hdf5+zlib+pnetcdf+shards~hypre@master,develop', when='~shared')
     depends_on('openfast+cxx', when='+openfast')
     depends_on('tioga', when='+tioga')
     depends_on('hypre+mpi+int64', when='+hypre')

--- a/var/spack/repos/builtin/packages/nalu/package.py
+++ b/var/spack/repos/builtin/packages/nalu/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+import sys
 
 
 class Nalu(CMakePackage):
@@ -34,8 +35,6 @@ class Nalu(CMakePackage):
     homepage = "https://github.com/NaluCFD/Nalu"
     git      = "https://github.com/NaluCFD/Nalu.git"
 
-    tags = ['ecp', 'ecp-apps']
-
     version('master', branch='master')
 
     variant('openfast', default=False,
@@ -44,10 +43,15 @@ class Nalu(CMakePackage):
             description='Compile with Tioga support')
     variant('hypre', default=False,
             description='Compile with Hypre support')
+    variant('shared', default=(sys.platform != 'darwin'),
+            description='Build Trilinos as shared library')
 
     depends_on('mpi')
     depends_on('yaml-cpp@0.5.3:')
-    depends_on('trilinos+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist+superlu+hdf5+zlib+pnetcdf+shards~hypre@master,develop')
+    depends_on('trilinos+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist+superlu+hdf5+zlib+pnetcdf+shards~hypre@master,develop', when='+shared')
+    # Cannot build Trilinos as a shared library with STK on Darwin
+    # https://github.com/trilinos/Trilinos/issues/2994
+    depends_on('trilinos~shared+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist+superlu+hdf5+zlib+pnetcdf+shards~hypre@master,develop', when='~shared')
     depends_on('openfast+cxx', when='+openfast')
     depends_on('tioga', when='+tioga')
     depends_on('hypre+mpi+int64', when='+hypre')

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -274,8 +274,10 @@ class Trilinos(CMakePackage):
     # PnetCDF was only added after v12.10.1
     conflicts('+pnetcdf', when='@0:12.10.1')
     # https://github.com/trilinos/Trilinos/issues/2994
-    conflicts('+shared', when='+stk platform=darwin',
-              msg='Cannot build Trilinos with STK as a shared library on Darwin.')
+    conflicts(
+        '+shared', when='+stk platform=darwin',
+        msg='Cannot build Trilinos with STK as a shared library on Darwin.'
+    )
 
     # ###################### Dependencies ##########################
 

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -273,6 +273,9 @@ class Trilinos(CMakePackage):
     conflicts('+superlu-dist', when='+complex+amesos2')
     # PnetCDF was only added after v12.10.1
     conflicts('+pnetcdf', when='@0:12.10.1')
+    # https://github.com/trilinos/Trilinos/issues/2994
+    conflicts('+shared', when='+stk platform=darwin',
+              msg='Cannot build Trilinos with STK as a shared library on Darwin.')
 
     # ###################### Dependencies ##########################
 
@@ -313,7 +316,7 @@ class Trilinos(CMakePackage):
     depends_on('hypre~internal-superlu~int64', when='+hypre')
     depends_on('hypre@xsdk-0.2.0~internal-superlu', when='@xsdk-0.2.0+hypre')
     depends_on('hypre@develop~internal-superlu', when='@develop+hypre')
-    # FIXME: concretizer bug? 'hl' req by netcdf is affecting this code.
+    # We need hdf5+hl to match with netcdf during concretization
     depends_on('hdf5+hl+mpi', when='+hdf5')
     depends_on('python', when='+python')
     depends_on('py-numpy', when='+python', type=('build', 'run'))


### PR DESCRIPTION
This is almost all a workaround for this issue with Trilinos https://github.com/trilinos/Trilinos/issues/2994 . I had to add a `shared` variant to Nalu-Wind so that I could use `sys.platform != 'darwin'` to turn `shared` on or off for Trilinos automatically since Trilinos won't build with STK as a shared library on Darwin anymore.

I also changed a FIXME comment in Trilinos that doesn't need to be fixed in my opinion and `hdf5+hl` is fine as it is.

Also, Nalu-Wind is the official ECP application and not Nalu, so I updated the tags to reflect this.