### PR TITLE
Update PMIX with releases 2.1.2-4 and 3.0.0-2

### DIFF
--- a/var/spack/repos/builtin/packages/pmix/package.py
+++ b/var/spack/repos/builtin/packages/pmix/package.py
@@ -49,6 +49,12 @@ class Pmix(AutotoolsPackage):
     homepage = "https://pmix.github.io/pmix"
     url      = "https://github.com/pmix/pmix/releases/download/v2.0.1/pmix-2.0.1.tar.bz2"
 
+    version('3.0.2',    'dc2e501605dde93ab459a5e060e01500')
+    version('3.0.1',    'ffe6bc08ab600173ea6e7d4509777629')
+    version('3.0.0',    '396969979a36d45bd292908e4bcec5c8')
+    version('2.1.4',    'edcfd7d1e2c2bcbb3e9852b66b57120e')
+    version('2.1.3',    '9320a4f3aef305fab4f7ac3520153160')
+    version('2.1.2',    '9f99fd893be49c2cb0cd8926cf6fcc78')
     version('2.1.1',    'f9f109421661b757245d5e0bd44a38b3')
     version('2.1.0',    'fc97513b601d78fe7c6bb20c6a21df3c')
     version('2.0.3',    'fae199c9fa1d1f1bc20c336f1292f950')


### PR DESCRIPTION
Replaces closed PR: Update with latest releases from PMIX #9512 (https://github.com/spack/spack/pull/9512)

dantopa@nid00018:spack.current.pmix $ date
Mon Oct 15 13:44:42 MDT 2018

dantopa@nid00018:spack.current.pmix $ pwd
/lustre/ttscratch1/dantopa/repos/spack/spack.current.pmix

dantopa@nid00018:spack.current.pmix $ uname -a
Linux nid00018 4.4.73-5.1_4.0.146-cray_ari_c #1 SMP Mon Oct 8 18:57:59 UTC 2018 (4.0.146) x86_64 x86_64 x86_64 GNU/Linux

dantopa@nid00018:spack.current.pmix $ lsb_release -d
Description:    SUSE Linux Enterprise Server 12 SP3

dantopa@nid00018:spack.current.pmix $ grep -i 'model name' /proc/cpuinfo | sort | uniq
model name      : Intel(R) Xeon(R) CPU E5-2698 v3 @ 2.30GHz

dantopa@nid00018:spack.current.pmix $ echo $HOSTNAME
tt-fey1

spack install pmix @ 3.0.2 % gcc @ 6.3.0
==> Successfully installed pmix
  Fetch: 0.04s.  Build: 1m 40.62s.  Total: 1m 40.66s.
[+] /lustre/ttscratch1/dantopa/repos/spack/spack.current.pmix/opt/spack/cray-cnl6-haswell/gcc-6.3.0/pmix-3.0.2-tl3xt2yrrus5nxwptquocznzkciyopwx

spack install pmix @ 3.0.1 % gcc @ 6.3.0
==> Successfully installed pmix
  Fetch: 0.04s.  Build: 1m 39.52s.  Total: 1m 39.55s.
[+] /lustre/ttscratch1/dantopa/repos/spack/spack.current.pmix/opt/spack/cray-cnl6-haswell/gcc-6.3.0/pmix-3.0.1-fqzgnrwtjncrc4gldaqsxe2d365xkck5

spack install pmix @ 3.0.0 % gcc @ 6.3.0
==> Successfully installed pmix
  Fetch: 0.04s.  Build: 1m 36.37s.  Total: 1m 36.41s.
[+] /lustre/ttscratch1/dantopa/repos/spack/spack.current.pmix/opt/spack/cray-cnl6-haswell/gcc-6.3.0/pmix-3.0.0-pu7wemzofbmgpwdrninonmh5jnzfh62j

spack install pmix @ 2.1.4 % gcc @ 6.3.0
==> Successfully installed pmix
  Fetch: 0.04s.  Build: 1m 26.27s.  Total: 1m 26.31s.
[+] /lustre/ttscratch1/dantopa/repos/spack/spack.current.pmix/opt/spack/cray-cnl6-haswell/gcc-6.3.0/pmix-2.1.4-vmx4cihuuf2mgoxnmg65gftm4q42pfow

spack install pmix @ 2.1.3 % gcc @ 6.3.0
==> Successfully installed pmix
  Fetch: 0.04s.  Build: 1m 26.17s.  Total: 1m 26.21s.
[+] /lustre/ttscratch1/dantopa/repos/spack/spack.current.pmix/opt/spack/cray-cnl6-haswell/gcc-6.3.0/pmix-2.1.3-4llwmowhzspe2meps4wsuwrj32ppfzjk

spack install pmix @ 2.1.2 % gcc @ 6.3.0
==> Successfully installed pmix
  Fetch: 0.04s.  Build: 1m 22.99s.  Total: 1m 23.03s.
[+] /lustre/ttscratch1/dantopa/repos/spack/spack.current.pmix/opt/spack/cray-cnl6-haswell/gcc-6.3.0/pmix-2.1.2-etztaq3px6zbrovrwxerwgfeipbt362h

Signed-off-by: Daniel Topa <dantopa@lanl.gov>