### PR TITLE
R crosstalk

### DIFF
--- a/var/spack/repos/builtin/packages/r-callr/package.py
+++ b/var/spack/repos/builtin/packages/r-callr/package.py
@@ -32,5 +32,7 @@ class RCallr(RPackage):
 
     homepage = "https://github.com/MangoTheCat/callr"
     url      = "https://cran.r-project.org/src/contrib/callr_1.0.0.tar.gz"
+    list_url = "https://cran.r-project.org/src/contrib/Archive/callr/"
 
+    version('3.0.0', sha256='e36361086c65660a6ecbbc09b5ecfcddee6b59caf75e983e48b21d3b8defabe7')
     version('1.0.0', 'd9af99bb95696310fa1e5d1cb7166c91')

--- a/var/spack/repos/builtin/packages/r-crosstalk/package.py
+++ b/var/spack/repos/builtin/packages/r-crosstalk/package.py
@@ -31,8 +31,9 @@ class RCrosstalk(RPackage):
 
     homepage = "https://cran.r-project.org/web/packages/crosstalk/index.html"
     url      = "https://cran.r-project.org/src/contrib/crosstalk_1.0.0.tar.gz"
+    list_url = ""
 
-    version('1.0.0', 'c13c21b81af2154be3f08870fd3a7077')
+    version('1.0.0', sha256='b31eada24cac26f24c9763d9a8cbe0adfd87b264cf57f8725027fe0c7742ca51')
 
     depends_on('r@3.4.0:3.4.9')
     depends_on('r-htmltools', type=('build', 'run'))


### PR DESCRIPTION
Added list_url, although it is empty sine there is no archive folder for previous versions (newest is 1.0)
Changed MD5 to SHA256
Passes flake8 now