### PR TITLE
hoomd-blue: fixing issue during build with newer cmakes

### DIFF
--- a/var/spack/repos/builtin/packages/hoomd-blue/package.py
+++ b/var/spack/repos/builtin/packages/hoomd-blue/package.py
@@ -59,11 +59,8 @@ class HoomdBlue(CMakePackage):
 
     def cmake_args(self):
         spec = self.spec
-        python_maj, python_min = (
-            str(spec['python'].version.dotted).split('.')[:2]
-        )
-        install_path = '{0}/lib/python{1}.{2}/site-packages'.format(
-            spec.prefix, python_maj, python_min)
+        install_dir = spec['python'].package.site_packages_dir
+        install_path = os.path.join(spec.prefix, install_dir)
 
         cmake_args = [
             '-DPYTHON_EXECUTABLE={0}'.format(spec['python'].command.path),

--- a/var/spack/repos/builtin/packages/hoomd-blue/package.py
+++ b/var/spack/repos/builtin/packages/hoomd-blue/package.py
@@ -51,7 +51,7 @@ class HoomdBlue(CMakePackage):
     extends('python')
     depends_on('python@2.7:')
     depends_on('py-numpy@1.7:', type=('build', 'run'))
-    depends_on('cmake@2.8.0:', type='build')
+    depends_on('cmake@2.8.0:3.9.6', type='build')
     depends_on('pkgconfig', type='build')
     depends_on('mpi', when='+mpi')
     depends_on('cuda@7.0:', when='+cuda')
@@ -59,9 +59,15 @@ class HoomdBlue(CMakePackage):
 
     def cmake_args(self):
         spec = self.spec
+        python_maj, python_min = (
+            str(spec['python'].version.dotted).split('.')[:2]
+        )
+        install_path = '{0}/lib/python{1}.{2}/site-packages'.format(
+            spec.prefix, python_maj, python_min)
 
         cmake_args = [
             '-DPYTHON_EXECUTABLE={0}'.format(spec['python'].command.path),
+            '-DCMAKE_INSTALL_PREFIX={0}'.format(install_path)
         ]
 
         # MPI support


### PR DESCRIPTION
newer cmake versions cause the build to fail. Also changing install
prefix for cmake to follow the path structure that python expects.