### PR TITLE
Update blaze package with new releases 3.3 and 3.4

### DIFF
--- a/var/spack/repos/builtin/packages/blaze/package.py
+++ b/var/spack/repos/builtin/packages/blaze/package.py
@@ -35,8 +35,10 @@ class Blaze(Package):
     """
 
     homepage = "https://bitbucket.org/blaze-lib/blaze/overview"
-    url      = "https://bitbucket.org/blaze-lib/blaze/downloads/blaze-3.1.tar.gz"
+    url      = "https://bitbucket.org/blaze-lib/blaze/downloads/blaze-3.4.tar.gz"
 
+    version('3.4', sha256='fd474ab479e81d31edf27d4a529706b418f874caa7b046c67489128c20dda66f')
+    version('3.3', sha256='138cbb7b95775c10bf56a5ab3596a32205751299b19699984b6ed55b1bf989d0')
     version('3.2', '47bd4a4f1b6292f5a6f71ed9d5287480')
     version('3.1', '2938e015f0d274e8d62ee5c4c0c1e9f3')
     version('3.0', '0c4cefb0be7b5a27ed8a377941be1ab1')


### PR DESCRIPTION
Add two new version lines, along with sha256 hashes.