### PR TITLE
freetype: Add 2.9.1

### DIFF
--- a/var/spack/repos/builtin/packages/freetype/package.py
+++ b/var/spack/repos/builtin/packages/freetype/package.py
@@ -34,6 +34,7 @@ class Freetype(AutotoolsPackage):
     homepage = "https://www.freetype.org/index.html"
     url      = "http://download.savannah.gnu.org/releases/freetype/freetype-2.7.1.tar.gz"
 
+    version('2.9.1', 'ec391504e55498adceb30baceebd147a6e963f636eb617424bcfc47a169898ce')
     version('2.7.1', '78701bee8d249578d83bb9a2f3aa3616')
     version('2.7',   '337139e5c7c5bd645fe130608e0fa8b5')
     version('2.5.3', 'cafe9f210e45360279c730d27bf071e9')


### PR DESCRIPTION
I have not rebuilt all dependents but at least fontconfig and poppler seem to build fine.