### PR TITLE
omega-h: fix dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/omega-h/package.py
+++ b/var/spack/repos/builtin/packages/omega-h/package.py
@@ -45,16 +45,14 @@ class OmegaH(CMakePackage):
     variant('shared', default=True, description='Build shared libraries')
     variant('mpi', default=True, description='Activates MPI support')
     variant('zlib', default=True, description='Activates ZLib support')
-    variant('trilinos', default=True, description='Use Teuchos and Kokkos')
+    variant('trilinos', default=False, description='Use Teuchos and Kokkos')
     variant('build_type', default='')
-    variant('gmodel', default=True, description='Gmsh model generation library')
     variant('throw', default=False, description='Errors throw exceptions instead of abort')
     variant('examples', default=False, description='Compile examples')
     variant('optimize', default=True, description='Compile C++ with optimization')
     variant('symbols', default=True, description='Compile C++ with debug symbols')
     variant('warnings', default=False, description='Compile C++ with warnings')
 
-    depends_on('gmodel', when='+gmodel')
     depends_on('gmsh', when='+examples', type='build')
     depends_on('mpi', when='+mpi')
     depends_on('trilinos +kokkos +teuchos', when='+trilinos')
@@ -83,16 +81,12 @@ class OmegaH(CMakePackage):
             args.append('-DOmega_h_USE_MPI:BOOL=OFF')
         if '+trilinos' in self.spec:
             args.append('-DOmega_h_USE_Trilinos:BOOL=ON')
-        if '+gmodel' in self.spec:
-            args.append('-DOmega_h_USE_Gmodel:BOOL=ON')
         if '+zlib' in self.spec:
-            args.append('-DTPL_ENABLE_ZLIB:BOOL=ON')
-            args.append('-DTPL_ZLIB_INCLUDE_DIRS:STRING={0}'.format(
-                self.spec['zlib'].prefix.include))
-            args.append('-DTPL_ZLIB_LIBRARIES:STRING={0}'.format(
-                self.spec['zlib'].libs))
+            args.append('-DOmega_h_USE_ZLIB:BOOL=ON')
+            args.append('-DZLIB_ROOT:PATH={0}'.format(
+                self.spec['zlib'].prefix))
         else:
-            args.append('-DTPL_ENABLE_ZLIB:BOOL=OFF')
+            args.append('-Omega_h_USE_ZLIB:BOOL=OFF')
         if '+examples' in self.spec:
             args.append('-DOmega_h_EXAMPLES:BOOL=ON')
         else:

--- a/var/spack/repos/builtin/packages/omega-h/package.py
+++ b/var/spack/repos/builtin/packages/omega-h/package.py
@@ -86,7 +86,7 @@ class OmegaH(CMakePackage):
             args.append('-DZLIB_ROOT:PATH={0}'.format(
                 self.spec['zlib'].prefix))
         else:
-            args.append('-Omega_h_USE_ZLIB:BOOL=OFF')
+            args.append('-DOmega_h_USE_ZLIB:BOOL=OFF')
         if '+examples' in self.spec:
             args.append('-DOmega_h_EXAMPLES:BOOL=ON')
         else:


### PR DESCRIPTION
@balay 

1. Remove Gmodel altogether. Omega_h doesn't
   actually call Gmodel for anything, it was
   more or less just doing additional unit
   testing for Gmodel

2. Make Trilinos off by default. Most codes do
   not need the ParameterList interface, and
   Kokkos through Trilinos is not well explored
   in Spack

3. Use modern CMake style to choose the zlib
   dependency