### PR TITLE
Add pic variants to tioga, openfast, nalu-wind, and nalu

### DIFF
--- a/var/spack/repos/builtin/packages/nalu-wind/package.py
+++ b/var/spack/repos/builtin/packages/nalu-wind/package.py
@@ -45,6 +45,8 @@ class NaluWind(CMakePackage):
             description='Compile with Hypre support')
     variant('shared', default=(sys.platform != 'darwin'),
             description='Build Trilinos as shared library')
+    variant('pic', default=True,
+            description='Position independent code')
 
     depends_on('mpi')
     depends_on('yaml-cpp@0.5.3:')
@@ -68,7 +70,9 @@ class NaluWind(CMakePackage):
             '-DCMAKE_Fortran_COMPILER=%s' % spec['mpi'].mpifc,
             '-DMPI_C_COMPILER=%s' % spec['mpi'].mpicc,
             '-DMPI_CXX_COMPILER=%s' % spec['mpi'].mpicxx,
-            '-DMPI_Fortran_COMPILER=%s' % spec['mpi'].mpifc
+            '-DMPI_Fortran_COMPILER=%s' % spec['mpi'].mpifc,
+            '-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=%s' % (
+                'ON' if '+pic' in spec else 'OFF'),
         ])
 
         if '+openfast' in spec:

--- a/var/spack/repos/builtin/packages/nalu/package.py
+++ b/var/spack/repos/builtin/packages/nalu/package.py
@@ -45,6 +45,8 @@ class Nalu(CMakePackage):
             description='Compile with Hypre support')
     variant('shared', default=(sys.platform != 'darwin'),
             description='Build Trilinos as shared library')
+    variant('pic', default=True,
+            description='Position independent code')
 
     depends_on('mpi')
     depends_on('yaml-cpp@0.5.3:')
@@ -62,7 +64,9 @@ class Nalu(CMakePackage):
 
         options.extend([
             '-DTrilinos_DIR:PATH=%s' % spec['trilinos'].prefix,
-            '-DYAML_DIR:PATH=%s' % spec['yaml-cpp'].prefix
+            '-DYAML_DIR:PATH=%s' % spec['yaml-cpp'].prefix,
+            '-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=%s' % (
+                'ON' if '+pic' in spec else 'OFF'),
         ])
 
         if '+openfast' in spec:

--- a/var/spack/repos/builtin/packages/openfast/package.py
+++ b/var/spack/repos/builtin/packages/openfast/package.py
@@ -36,7 +36,7 @@ class Openfast(CMakePackage):
     version('develop', branch='dev')
     version('master', branch='master')
 
-    variant('shared', default=False,
+    variant('shared', default=True,
             description="Build shared libraries")
     variant('double-precision', default=True,
             description="Treat REAL as double precision")
@@ -44,6 +44,8 @@ class Openfast(CMakePackage):
             description="Enable dynamic library loading interface")
     variant('cxx', default=False,
             description="Enable C++ bindings")
+    variant('pic', default=True,
+            description="Position independent code")
 
     # Dependencies for OpenFAST Fortran
     depends_on('blas')
@@ -73,6 +75,8 @@ class Openfast(CMakePackage):
                 'ON' if '+dll-interface' in spec else 'OFF'),
             '-DBUILD_FAST_CPP_API:BOOL=%s' % (
                 'ON' if '+cxx' in spec else 'OFF'),
+            '-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=%s' % (
+                'ON' if '+pic' in spec else 'OFF'),
         ])
 
         # Make sure we use Spack's blas/lapack:

--- a/var/spack/repos/builtin/packages/tioga/package.py
+++ b/var/spack/repos/builtin/packages/tioga/package.py
@@ -34,8 +34,10 @@ class Tioga(CMakePackage):
     # The master branch doesn't support CMake
     version('develop', branch='nalu-api')
 
-    variant('shared', default=False,
+    variant('shared', default=True,
             description="Enable building shared libraries")
+    variant('pic', default=True,
+            description="Position independent code")
 
     depends_on('mpi')
 
@@ -48,6 +50,8 @@ class Tioga(CMakePackage):
         options = [
             '-DBUILD_SHARED_LIBS:BOOL=%s' % (
                 'ON' if '+shared' in spec else 'OFF'),
+            '-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=%s' % (
+                'ON' if '+pic' in spec else 'OFF'),
             '-DMPI_CXX_COMPILER:PATH=%s' % spec['mpi'].mpicxx,
             '-DMPI_C_COMPILER:PATH=%s' % spec['mpi'].mpicc,
             '-DMPI_Fortran_COMPILER:PATH=%s' % spec['mpi'].mpifc


### PR DESCRIPTION
This is a bit of an addendum to https://github.com/spack/spack/pull/9522 . I originally created all these packages in this PR. I realized some of the optional libraries for Nalu-Wind like Tioga and OpenFAST were still set to build static libraries (Nalu had a previous requirement of all static libraries). So I am defaulting them to shared now, and I also added `pic` variants in case the shared/static mix happens somehow, so then it doesn't fail with "relocatable" errors telling the user to use `-fPIC` if some library winds up static.