### PR TITLE
Report clean results to CDash

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -232,7 +232,7 @@ def install(parser, args, **kwargs):
     if len(specs) == 0:
         tty.die('The `spack install` command requires a spec to install.')
 
-    if not args.log_file:
+    if not args.log_file and not reporter.filename:
         reporter.filename = default_log_file(specs[0])
     reporter.specs = specs
     with reporter:

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -154,6 +154,7 @@ class InfoCollector(object):
 
                     value = do_install(pkg, *args, **kwargs)
                     package['result'] = 'success'
+                    package['stdout'] = fetch_package_log(pkg)
                     if installed_on_entry:
                         return
 

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -107,17 +107,14 @@ class CDash(Reporter):
                             if current_phase not in map_phases_to_cdash:
                                 current_phase = ''
                                 continue
-                            beginning_of_phase = True
+                            cdash_phase = \
+                                map_phases_to_cdash[current_phase]
+                            if cdash_phase not in phases_encountered:
+                                phases_encountered.append(cdash_phase)
+                            report_data[cdash_phase]['log'] += \
+                                text_type("{0} output for {1}:\n".format(
+                                    cdash_phase, package['name']))
                         else:
-                            if beginning_of_phase:
-                                cdash_phase = \
-                                    map_phases_to_cdash[current_phase]
-                                if cdash_phase not in phases_encountered:
-                                    phases_encountered.append(cdash_phase)
-                                report_data[cdash_phase]['log'] += \
-                                    text_type("{0} output for {1}:\n".format(
-                                        cdash_phase, package['name']))
-                                beginning_of_phase = False
                             report_data[cdash_phase]['log'] += \
                                 xml.sax.saxutils.escape(line) + "\n"
 

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -100,6 +100,7 @@ class CDash(Reporter):
             for package in spec['packages']:
                 if 'stdout' in package:
                     current_phase = ''
+                    cdash_phase = ''
                     for line in package['stdout'].splitlines():
                         match = phase_regexp.search(line)
                         if match:
@@ -114,7 +115,7 @@ class CDash(Reporter):
                             report_data[cdash_phase]['log'] += \
                                 text_type("{0} output for {1}:\n".format(
                                     cdash_phase, package['name']))
-                        else:
+                        elif cdash_phase:
                             report_data[cdash_phase]['log'] += \
                                 xml.sax.saxutils.escape(line) + "\n"
 

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -118,6 +118,13 @@ class CDash(Reporter):
                             report_data[cdash_phase]['log'] += \
                                 xml.sax.saxutils.escape(line) + "\n"
 
+        # Move the build phase to the front of the list if it occurred.
+        # This supports older versions of CDash that expect this phase
+        # to be reported before all others.
+        if "build" in phases_encountered:
+            build_pos = phases_encountered.index("build")
+            phases_encountered.insert(0, phases_encountered.pop(build_pos))
+
         for phase in phases_encountered:
             errors, warnings = parse_log_events(
                 report_data[phase]['log'].splitlines())

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -432,6 +432,26 @@ def test_cdash_upload_build_error(tmpdir, mock_fetch, install_mockery,
 
 
 @pytest.mark.disable_clean_stage_check
+def test_cdash_upload_clean_build(tmpdir, mock_fetch, install_mockery,
+                                  capfd):
+    # capfd interferes with Spack's capturing
+    with capfd.disabled():
+        with tmpdir.as_cwd():
+            with pytest.raises((HTTPError, URLError)):
+                install(
+                    '--log-file=cdash_reports',
+                    '--cdash-upload-url=http://localhost/fakeurl/submit.php?project=Spack',
+                    'a')
+            report_dir = tmpdir.join('cdash_reports')
+            assert report_dir in tmpdir.listdir()
+            report_file = report_dir.join('Build.xml')
+            assert report_file in report_dir.listdir()
+            content = report_file.open().read()
+            assert '</Build>' in content
+            assert '<Text>' not in content
+
+
+@pytest.mark.disable_clean_stage_check
 def test_build_error_output(tmpdir, mock_fetch, install_mockery, capfd):
     with capfd.disabled():
         msg = ''


### PR DESCRIPTION
Update the CDash reporter to generate results when nothing goes wrong.  Previously it would only generate and upload a report when errors occured during `spack install`.