### PR TITLE
Forced Binutils to use PIC with LibIberty

### DIFF
--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -80,6 +80,8 @@ class Binutils(AutotoolsPackage):
 
         if '+libiberty' in spec:
             configure_args.append('--enable-install-libiberty')
+            # Manually add PIC flag for libiberty as we always build shared
+            configure_args.append('CFLAGS={0}'.format(self.compiler.pic_flag))
 
         if '+nls' in spec:
             configure_args.append('--enable-nls')


### PR DESCRIPTION
Manually added PIC flag to binutils configuration when shared libraries and libiberty are enabled.

This is required due to restrictions due to design choices in binutils with respect to libiberty which conflict with how other projects use libiberty

This is not a particularly clean or elegant solution