### PR TITLE
Bug fix: Module PATH check

### DIFF
--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -144,11 +144,6 @@ def get_path_arg_from_module_line(line):
         path_arg = words_and_symbols[-2]
     else:
         path_arg = line.split()[2]
-
-    if not os.path.exists(path_arg):
-        tty.warn("Extracted path from module does not exist:"
-                 "\n\tExtracted path: " + path_arg +
-                 "\n\tFull line: " + line)
     return path_arg
 
 
@@ -162,8 +157,11 @@ def get_path_from_module(mod):
     # Read the module
     text = modulecmd('show', mod, output=str, error=str).split('\n')
 
-    return get_path_from_module_contents(text, mod)
-
+    p = get_path_from_module_contents(text, mod)
+    if not os.path.exists(p):
+        tty.warn("Extracted path from module does not exist:"
+                 "\n\tExtracted path: " + p)
+    return p
 
 def get_path_from_module_contents(text, module_name):
     tty.debug("Module name: " + module_name)

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -163,6 +163,7 @@ def get_path_from_module(mod):
                  "\n\tExtracted path: " + p)
     return p
 
+
 def get_path_from_module_contents(text, module_name):
     tty.debug("Module name: " + module_name)
     pkg_var_prefix = module_name.replace('-', '_').upper()

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -158,7 +158,7 @@ def get_path_from_module(mod):
     text = modulecmd('show', mod, output=str, error=str).split('\n')
 
     p = get_path_from_module_contents(text, mod)
-    if not os.path.exists(p):
+    if p and not os.path.exists(p):
         tty.warn("Extracted path from module does not exist:"
                  "\n\tExtracted path: " + p)
     return p


### PR DESCRIPTION
introduced in #9100

Correctly process PATHs of type "path1:path2"

Fixes the following incorrect warning on cori @ nersc

```
balay@cori10:~/spack.x> spack env m4 >/dev/null
==> Warning: Extracted path from module does not exist:
        Extracted path: /opt/intel/compilers_and_libraries_2018.2.199/linux/compiler/lib/intel64:/opt/intel/compilers_and_libraries_2018.2.199/linux/mkl/lib/intel64
        Full line: prepend-path  LD_LIBRARY_PATH /opt/intel/compilers_and_libraries_2018.2.199/linux/compiler/lib/intel64:/opt/intel/compilers_and_libraries_2018.2.199/linux/mkl/lib/intel64 
balay@cori10:~/spack.x> ls -d  /opt/intel/compilers_and_libraries_2018.2.199/linux/compiler/lib/intel64
/opt/intel/compilers_and_libraries_2018.2.199/linux/compiler/lib/intel64
balay@cori10:~/spack.x> ls -d /opt/intel/compilers_and_libraries_2018.2.199/linux/mkl/lib/intel64
/opt/intel/compilers_and_libraries_2018.2.199/linux/mkl/lib/intel64
balay@cori10:~/spack.x> 
```