### PR TITLE
add pumi version docstring

### DIFF
--- a/var/spack/repos/builtin/packages/pumi/package.py
+++ b/var/spack/repos/builtin/packages/pumi/package.py
@@ -38,6 +38,12 @@ class Pumi(CMakePackage):
     homepage = "https://www.scorec.rpi.edu/pumi"
     git      = "https://github.com/SCOREC/core.git"
 
+    # We will use the scorec/core master branch as the 'nightly' version
+    # of pumi in spack.  The master branch is more stable than the
+    # scorec/core develop branch and we perfer not to expose spack users
+    # to the added instability. The spack version string is 'develop' since
+    # it compares greater than a numbered version (e.g., 2.1.0). The spack
+    #version string 'master' compares less than a numbered version.
     version('develop', branch='master')
     version('2.1.0', commit='840fbf6ec49a63aeaa3945f11ddb224f6055ac9f')
 

--- a/var/spack/repos/builtin/packages/pumi/package.py
+++ b/var/spack/repos/builtin/packages/pumi/package.py
@@ -43,7 +43,7 @@ class Pumi(CMakePackage):
     # scorec/core develop branch and we perfer not to expose spack users
     # to the added instability. The spack version string is 'develop' since
     # it compares greater than a numbered version (e.g., 2.1.0). The spack
-    #version string 'master' compares less than a numbered version.
+    # version string 'master' compares less than a numbered version.
     version('develop', branch='master')
     version('2.1.0', commit='840fbf6ec49a63aeaa3945f11ddb224f6055ac9f')
 


### PR DESCRIPTION
This PR documents why the spack version string 'develop' is used with the scorec/core master branch.  Discussion on this topic is here: https://github.com/SCOREC/core/issues/188#issuecomment-430299432