### PR TITLE
license: exclude ignored files from the license check

### DIFF
--- a/lib/spack/spack/cmd/license.py
+++ b/lib/spack/spack/cmd/license.py
@@ -40,7 +40,7 @@ licensed_files = [
     r'^lib/spack/env/cc$',
 
     # rst files in documentation
-    r'^lib/spack/docs/.*\.rst$',
+    r'^lib/spack/docs/(?!command_index|spack|llnl).*\.rst$',
     r'^lib/spack/docs/.*\.py$',
 
     # 2 files in external


### PR DESCRIPTION
- previously, if you built the docs, you'd get license errors for generated .rst files.
- this removes them from the list of licensed files.