### PR TITLE
Switch from md5 to sha256 checksums for most recent PMIX versions

### DIFF
--- a/var/spack/repos/builtin/packages/pmix/package.py
+++ b/var/spack/repos/builtin/packages/pmix/package.py
@@ -30,16 +30,12 @@ class Pmix(AutotoolsPackage):
     homepage = "https://pmix.github.io/pmix"
     url      = "https://github.com/pmix/pmix/releases/download/v2.0.1/pmix-2.0.1.tar.bz2"
 
-    version('3.0.2',    'dc2e501605dde93ab459a5e060e01500')
-    version('3.0.1',    'ffe6bc08ab600173ea6e7d4509777629')
-    version('3.0.0',    '396969979a36d45bd292908e4bcec5c8')
-    version('2.1.4',    'edcfd7d1e2c2bcbb3e9852b66b57120e')
-    version('2.1.3',    '9320a4f3aef305fab4f7ac3520153160')
-    version('2.1.2',    '9f99fd893be49c2cb0cd8926cf6fcc78')
-    version('2.1.1',    'f9f109421661b757245d5e0bd44a38b3')
-    version('2.1.0',    'fc97513b601d78fe7c6bb20c6a21df3c')
-    version('2.0.3',    'fae199c9fa1d1f1bc20c336f1292f950')
-    version('2.0.2',    'e3ed1deed87c84f9b43da2621c6ad689')
+    version('3.0.2',    sha256='df68f35a3ed9517eeade80b13855cebad8fde2772b36a3f6be87559b6d430670')
+    version('3.0.1',    sha256='b81055d2c0d61ef5a451b63debc39c820bcd530490e2e4dcb4cdbacb618c157c')
+    version('3.0.0',    sha256='ee8f68107c24b706237a53333d832445315ae37de6773c5413d7fda415a6e2ee')
+    version('2.1.4',    sha256='eb72d292e76e200f02cf162a477eecea2559ef3ac2edf50ee95b3fe3983d033e')
+    version('2.1.3',    sha256='281283133498e7e5999ed5c6557542c22408bc9eb51ecbcf7696160616782a41')
+    version('2.1.2',    sha256='94bb9c801c51a6caa1b8cef2b85ecf67703a5dfa4d79262e6668c37c744bb643')
     version('2.0.1',    'ba3193b485843516e6b4e8641e443b1e')
     version('2.0.0',    '3e047c2ea0ba8ee9925ed92b205fd92e')
     version('1.2.5',    'c3d20cd9d365a813dc367afdf0f41c37')


### PR DESCRIPTION
VERIFICATION:

$ uname -a
Darwin pn1249300.lanl.gov 16.7.0 Darwin Kernel Version 16.7.0: Thu Jun 21 20:07:39 PDT 2018; root:xnu-3789.73.14~1/RELEASE_X86_64 x86_64

$ echo $HOSTNAME
Cauchy.Schwarz

$ sysctl -n machdep.cpu.brand_string
Intel(R) Xeon(R) CPU E5-2697 v2 @ 2.70GHz

$ system_profiler | grep Processor
      Processor Name: 12-Core Intel Xeon E5
      Processor Speed: 2.7 GHz

+++   +++   +++   +++   +++   +++

==> Successfully installed pmix
[+] /Volumes/Tlaltecuhtli/spack/spack.macpro.openmpi/opt/spack/darwin-sierra-x86_64/gcc-8.2.0/pmix-3.0.2-gm3kbt7kryd5o4aey23calasquc2b4fr

==> Successfully installed pmix
[+] /Volumes/Tlaltecuhtli/spack/spack.macpro.openmpi/opt/spack/darwin-sierra-x86_64/gcc-8.2.0/pmix-3.0.1-kgau46xsnavggzjwwzvjkrii3qk2g5uc

==> Successfully installed pmix
[+] /Volumes/Tlaltecuhtli/spack/spack.macpro.openmpi/opt/spack/darwin-sierra-x86_64/gcc-8.2.0/pmix-3.0.0-toqtuvmmdf3ikgs3i33cwa7ycwoznodw

==> Successfully installed pmix
[+] /Volumes/Tlaltecuhtli/spack/spack.macpro.openmpi/opt/spack/darwin-sierra-x86_64/gcc-8.2.0/pmix-2.1.4-bdmwlrv6soecg57gzj756vymjgg4our6

==> Successfully installed pmix
[+] /Volumes/Tlaltecuhtli/spack/spack.macpro.openmpi/opt/spack/darwin-sierra-x86_64/gcc-8.2.0/pmix-2.1.3-n3cfhcmx2wbh2wf37fdciyuzxcghj6gr

==> Successfully installed pmix
[+] /Volumes/Tlaltecuhtli/spack/spack.macpro.openmpi/opt/spack/darwin-sierra-x86_64/gcc-8.2.0/pmix-2.1.2-uk6qppajdsypqdbxnj6bs3e4ttpcetuj

+++   +++   +++   +++   +++   +++

$ spack checksum pmix
==> Found 10 versions of pmix:
==> How many would you like to checksum? (default is 1, q to abort) 10
==> Downloading...
==> Checksummed 10 versions of pmix

    version('3.0.2',    sha256='df68f35a3ed9517eeade80b13855cebad8fde2772b36a3f6be87559b6d430670')
    version('3.0.1',    sha256='b81055d2c0d61ef5a451b63debc39c820bcd530490e2e4dcb4cdbacb618c157c')
    version('3.0.0rc2', sha256='3ff2aa7bb08138a6f5830e72f80dc12df746e9eb0d6574d175b41119d3f45392')
    version('3.0.0rc1', sha256='f0b1c96cf1d71b3962534aacdbe4ac96be47bec4bd0d89b9679ca73d7c3b242d')
    version('3.0.0',    sha256='ee8f68107c24b706237a53333d832445315ae37de6773c5413d7fda415a6e2ee')
    version('2.1.4',    sha256='eb72d292e76e200f02cf162a477eecea2559ef3ac2edf50ee95b3fe3983d033e')
    version('2.1.3',    sha256='281283133498e7e5999ed5c6557542c22408bc9eb51ecbcf7696160616782a41')
    version('2.1.2rc2', sha256='6671b0aa7da6f7edefcff3b733a77884b5d34ae67f0a934b032121293ee382b8')
    version('2.1.2rc1', sha256='c4ac1267a53883130f72284bbf947150a8e14e5b99e24f828beeaf2836d5357c')
    version('2.1.2',    sha256='94bb9c801c51a6caa1b8cef2b85ecf67703a5dfa4d79262e6668c37c744bb643')

Signed-off-by: Daniel Topa <dantopa@lanl.gov>