### PR TITLE
plumed: libmatheval support (and dependencies fixes)

### DIFF
--- a/var/spack/repos/builtin/packages/guile/package.py
+++ b/var/spack/repos/builtin/packages/guile/package.py
@@ -18,6 +18,7 @@ class Guile(AutotoolsPackage):
     version('2.0.11', 'e532c68c6f17822561e3001136635ddd')
 
     variant('readline', default=True, description='Use the readline library')
+    variant('threads', default=True, description='Use the thread interface')
 
     depends_on('gmp@4.2:')
     depends_on('gettext')
@@ -30,6 +31,8 @@ class Guile(AutotoolsPackage):
 
     build_directory = 'spack-build'
 
+    conflicts('+threads', when='%intel')
+
     def configure_args(self):
         spec = self.spec
 
@@ -38,8 +41,9 @@ class Guile(AutotoolsPackage):
                 spec['libunistring'].prefix),
             '--with-libltdl-prefix={0}'.format(spec['libtool'].prefix),
             '--with-libgmp-prefix={0}'.format(spec['gmp'].prefix),
-            '--with-libintl-prefix={0}'.format(spec['gettext'].prefix)
+            '--with-libintl-prefix={0}'.format(spec['gettext'].prefix),
         ]
+        config_args += self.with_or_without('threads')
 
         if '+readline' in spec:
             config_args.append('--with-libreadline-prefix={0}'.format(

--- a/var/spack/repos/builtin/packages/libmatheval/package.py
+++ b/var/spack/repos/builtin/packages/libmatheval/package.py
@@ -22,6 +22,8 @@ class Libmatheval(AutotoolsPackage):
     # Only needed for unit tests, but configure crashes without it
     depends_on('guile', type='build')
 
+    depends_on('flex')
+
     # guile 2.0 provides a deprecated interface for the unit test using guile
     patch('guile-2.0.patch', when='^guile@2.0')
 

--- a/var/spack/repos/builtin/packages/plumed/package.py
+++ b/var/spack/repos/builtin/packages/plumed/package.py
@@ -50,6 +50,9 @@ class Plumed(AutotoolsPackage):
     depends_on('zlib')
     depends_on('blas')
     depends_on('lapack')
+    # For libmatheval support through the 'function' module
+    # which is enabled by default (or when optional_modules=all)
+    depends_on('libmatheval')
 
     depends_on('mpi', when='+mpi')
     depends_on('gsl', when='+gsl')


### PR DESCRIPTION
* one of the "default on" plugins of plumed has optional libmatheval support
* added missing flex dependency to libmatheval for it to work for plumed
* fix guile build with intel compiler