### PR TITLE
Fix issue with miniconda attempting to install the incorrect version

### DIFF
--- a/var/spack/repos/builtin/packages/miniconda2/package.py
+++ b/var/spack/repos/builtin/packages/miniconda2/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from six.moves.urllib.parse import urlparse
 from os.path import split
 
 
@@ -14,14 +13,15 @@ class Miniconda2(Package):
     homepage = "https://conda.io/miniconda.html"
     url      = "https://repo.continuum.io/miniconda/Miniconda2-4.3.11-Linux-x86_64.sh"
 
+    version('4.5.11', sha256='0e23e8d0a1a14445f78960a66b363b464b889ee3b0e3f275b7ffb836df1cb0c6', expand=False)
     version('4.5.4', '8a1c02f6941d8778f8afad7328265cf5', expand=False)
     version('4.3.30', 'bd1655b4b313f7b2a1f2e15b7b925d03', expand=False)
     version('4.3.14', '8cb075cf5462480980ef2373ad9fad38', expand=False)
     version('4.3.11', 'd573980fe3b5cdf80485add2466463f5', expand=False)
 
     def install(self, spec, prefix):
-        # peel the name of the script out of the url
-        result = urlparse(self.url)
-        dir, script = split(result.path)
+        # peel the name of the script out of the pathname of the
+        # downloaded file
+        dir, script = split(self.stage.archive_file)
         bash = which('bash')
         bash(script, '-b', '-f', '-p', self.prefix)

--- a/var/spack/repos/builtin/packages/miniconda3/package.py
+++ b/var/spack/repos/builtin/packages/miniconda3/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from six.moves.urllib.parse import urlparse
 from os.path import split
 
 
@@ -14,14 +13,15 @@ class Miniconda3(Package):
     homepage = "https://conda.io/miniconda.html"
     url      = "https://repo.continuum.io/miniconda/Miniconda3-4.3.11-Linux-x86_64.sh"
 
+    version('4.5.11', sha256='ea4594241e13a2671c5b158b3b813f0794fe58d514795fbf72a1aad24db918cf', expand=False)
     version('4.5.4', 'a946ea1d0c4a642ddf0c3a26a18bb16d', expand=False)
     version('4.3.30', '0b80a152332a4ce5250f3c09589c7a81', expand=False)
     version('4.3.14', 'fc6fc37479e3e3fcf3f9ba52cae98991', expand=False)
     version('4.3.11', '1924c8d9ec0abf09005aa03425e9ab1a', expand=False)
 
     def install(self, spec, prefix):
-        # peel the name of the script out of the url
-        result = urlparse(self.url)
-        dir, script = split(result.path)
+        # peel the name of the script out of the pathname of the
+        # downloaded file
+        dir, script = split(self.stage.archive_file)
         bash = which('bash')
         bash(script, '-b', '-f', '-p', self.prefix)


### PR DESCRIPTION
The install() function in the miniconda2 & 3 package.py files referenced
self.url, which is hard-coded to 4.3.11.  That's not necessarily the
version that the user requested, though.  Changed the install() function
to reference self.stage.archive_file.  Also added a version string for
4.5.11.