### PR TITLE
atk: remove unconditional python@3: constraint

### DIFF
--- a/var/spack/repos/builtin/packages/atk/package.py
+++ b/var/spack/repos/builtin/packages/atk/package.py
@@ -22,11 +22,6 @@ class Atk(Package):
 
     depends_on('meson', type='build', when='@2.28.0:')
     depends_on('glib')
-    # FIXME: this constraint exists because of the meson dependency.
-    # It should not be required to specify it here, but "spack spec atk" will
-    # fail without it.
-    # See: #2632
-    depends_on('python@3:')
     depends_on('gettext')
     depends_on('pkgconfig', type='build')
     depends_on('gobject-introspection')


### PR DESCRIPTION
@lee218llnl @JSquar 

py-gtk needs to build with python@2.7 and also requires atk, so the atk python dependency cannot be unconditionally constrained to @3:

This PR generally undoes the edits of https://github.com/spack/spack/pull/9102 (although it keeps the `gettext` dependency). Therefore, to build newer versions of `atk`, you must specify their version on the command line, e.g. `spack install atk@2.28.1`. More on this at https://github.com/spack/spack/issues/8133#issuecomment-389378055

And this now also allows `spack install py-pygtk to succeed`.

See: https://github.com/spack/spack/pull/9102#issuecomment-431514107