### PR TITLE
bugfix: use OS default permissions for mkdirp when mode is not provided

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -414,13 +414,22 @@ def get_filetype(path_name):
 
 
 def mkdirp(*paths, **kwargs):
-    """Creates a directory, as well as parent directories if needed."""
-    mode = kwargs.get('mode', stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)
+    """Creates a directory, as well as parent directories if needed.
+
+    Arguments:
+        paths (str): paths to create with mkdirp
+
+    Keyword Aguments:
+        mode (permission bits or None, optional): optional permissions to
+            set on the created directory -- use OS default if not provided
+    """
+    mode = kwargs.get('mode', None)
     for path in paths:
         if not os.path.exists(path):
             try:
-                os.makedirs(path, mode)
-                os.chmod(path, mode)  # For systems that ignore makedirs mode
+                os.makedirs(path)
+                if mode is not None:
+                    os.chmod(path, mode)
             except OSError as e:
                 if e.errno != errno.EEXIST or not os.path.isdir(path):
                     raise e


### PR DESCRIPTION
- #8773 made the default mode 0o777, which is what's documented, but mkdirp actually takes the OS default or umask by default
- This was resulting in directories being created with 777 permissions in a lot of places where they should not be.

- [x] revert to the Python default by default, and only set the mode when asked explicitly.

