### PR TITLE
nag: fix NAG Fortran Compiler MD5 checksum for 6.1; add 6.2 checksum

### DIFF
--- a/var/spack/repos/builtin/packages/nag/package.py
+++ b/var/spack/repos/builtin/packages/nag/package.py
@@ -11,6 +11,7 @@ class Nag(Package):
     """The NAG Fortran Compiler."""
     homepage = "http://www.nag.com/nagware/np.asp"
 
+    version('6.2', '8b119cc3296969bbd68b781f625de272')
     version('6.1', '9b3cc0f8703c79f6231ae12359535119')
     version('6.0', '3fa1e7f7b51ef8a23e6c687cdcad9f96')
 

--- a/var/spack/repos/builtin/packages/nag/package.py
+++ b/var/spack/repos/builtin/packages/nag/package.py
@@ -11,7 +11,7 @@ class Nag(Package):
     """The NAG Fortran Compiler."""
     homepage = "http://www.nag.com/nagware/np.asp"
 
-    version('6.1', '0040d2254258223c78a6a4ab4829d7e0')
+    version('6.1', '9b3cc0f8703c79f6231ae12359535119')
     version('6.0', '3fa1e7f7b51ef8a23e6c687cdcad9f96')
 
     # Licensing


### PR DESCRIPTION
MD5 checksums verified by downloading installer over HTTPS:
```
$ curl -sL https://www.nag.com/downloads/impl/npl6a61na_amd64.tgz | md5sum 
9b3cc0f8703c79f6231ae12359535119  -
$ curl -sL https://www.nag.com/downloads/impl/npl6a62na_amd64.tgz | md5sum 
8b119cc3296969bbd68b781f625de272  -
```