### PR TITLE
new package: kitty terminal

### DIFF
--- a/var/spack/repos/builtin/packages/dbus/package.py
+++ b/var/spack/repos/builtin/packages/dbus/package.py
@@ -29,6 +29,7 @@ class Dbus(Package):
 
     depends_on('pkgconfig', type='build')
     depends_on('expat')
+    depends_on('glib')
 
     def install(self, spec, prefix):
         configure(

--- a/var/spack/repos/builtin/packages/harfbuzz/package.py
+++ b/var/spack/repos/builtin/packages/harfbuzz/package.py
@@ -13,7 +13,8 @@ class Harfbuzz(AutotoolsPackage):
 
     version('2.3.1', sha256='f205699d5b91374008d6f8e36c59e419ae2d9a7bb8c5d9f34041b9a5abcae468')
     version('2.1.3', sha256='613264460bb6814c3894e3953225c5357402915853a652d40b4230ce5faf0bee')
-    version('1.4.6', '21a78b81cd20cbffdb04b59ac7edfb410e42141869f637ae1d6778e74928d293')
+    version('1.9.0', sha256='11eca62bf0ac549b8d6be55f4e130946399939cdfe7a562fdaee711190248b00')
+    version('1.4.6', sha256='21a78b81cd20cbffdb04b59ac7edfb410e42141869f637ae1d6778e74928d293')
     version('0.9.37', 'bfe733250e34629a188d82e3b971bc1e')
 
     depends_on("pkgconfig", type="build")

--- a/var/spack/repos/builtin/packages/kitty/package.py
+++ b/var/spack/repos/builtin/packages/kitty/package.py
@@ -1,0 +1,57 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+import sys
+
+
+class Kitty(PythonPackage):
+    """
+    fast, featureful, cross-platform, GPU-based terminal emulator
+    """
+
+    homepage = "https://sw.kovidgoyal.net/kitty/index.html"
+    url      = "https://github.com/kovidgoyal/kitty/archive/v0.12.3.tar.gz"
+    git      = "https://github.com/kovidgoyal/kitty.git"
+
+    version('0.12.3', sha256='8d8a1f9c48519e618ac53b614056cf4589edb02fd1d19aa26d5f478e7067887e')
+    version('0.12.2', sha256='f1ffb3d10adb9532f9591fc0bbeca527dda50d6d2b6b3934f0799300fd4eefc2')
+    version('0.12.1', sha256='a3bf33e3d014635c6951fe4e3f2a0681173a1f44a9fa7a8ed4b60d20de53534a')
+    version('0.12.0', sha256='30db676c55cdee0bfe5ff9a30ba569941ba83376a4bb754c8894c1b59ad9ed19')
+    version('0.11.3', sha256='f0e1f0972fcee141c05caac543ef017ee7c87ddddf5fde636c614a28e45021c3')
+    version('0.11.2', sha256='20d5289732271c33fa4da52c841b8567a2a2b8f514675bb9a2ede9097adb3712')
+    version('0.11.1', sha256='3bbc6b5465d424969b16c5ad7f2f67ffbfe33657fdcb443e1bcc11aa00726841')
+    version('0.11.0', sha256='abba2b93795609810e4c9b5cefbbada57e370722cee8a00f94a78c0c96226432')
+    version('0.10.1', sha256='ef22208497a76e2f88ebe56c176e4608f049b056252cf1bf122c9c1ec711cfa6')
+    version('0.10.0', sha256='056563862c5759b740e95efff44b82c1a4efc370092f22f26aee0b774106bf4d')
+
+    depends_on('python@3.5:', type=('build', 'run'))
+    depends_on('harfbuzz@1.5.0:')
+    depends_on('libxkbcommon@0.5:')
+    depends_on('zlib')
+    depends_on('libpng')
+    depends_on('gl', type=('build', 'link', 'run'))
+    depends_on('pkg-config', type='build')
+    depends_on('py-setuptools', type='build')
+    depends_on('py-sphinx', type='build')
+    depends_on('freetype', when=sys.platform != 'darwin')
+    depends_on('fontconfig', when=sys.platform != 'darwin')
+    depends_on('xrandr', when=sys.platform != 'darwin')
+    depends_on('libxinerama', when=sys.platform != 'darwin')
+    depends_on('xineramaproto', when=sys.platform != 'darwin')
+    depends_on('libxi', when=sys.platform != 'darwin')
+    depends_on('libxcursor', when=sys.platform != 'darwin')
+    depends_on('fixesproto', when=sys.platform != 'darwin')
+    depends_on('dbus', when=sys.platform != 'darwin')
+    depends_on('xkeyboard-config', when=sys.platform != 'darwin')
+
+    phases = ['install']
+
+    def install(self, spec, prefix):
+        # kitty's setup.py does not recognize the '--no-user-cfg' flag that is
+        # used by default in the setup_py method, overriding that behavior here
+        with working_dir(self.build_directory):
+            self.python('-s', 'setup.py', 'linux-package',
+                        '--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libx11/package.py
+++ b/var/spack/repos/builtin/packages/libx11/package.py
@@ -27,6 +27,10 @@ class Libx11(AutotoolsPackage):
     depends_on('util-macros', type='build')
     depends_on('perl', type='build')
 
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        spack_env.prepend_path('XLOCALEDIR', self.prefix.share.X11.locale)
+        run_env.prepend_path('XLOCALEDIR', self.prefix.share.X11.locale)
+
     @property
     def libs(self):
         for dir in ['lib64', 'lib']:

--- a/var/spack/repos/builtin/packages/libxkbcommon/package.py
+++ b/var/spack/repos/builtin/packages/libxkbcommon/package.py
@@ -20,6 +20,7 @@ class Libxkbcommon(AutotoolsPackage):
 
     depends_on('pkgconfig@0.9.0:', type='build')
     depends_on('bison', type='build')
+    depends_on('util-macros')
     depends_on('xkbdata')
     depends_on('libxcb@1.10:')
 

--- a/var/spack/repos/builtin/packages/util-macros/package.py
+++ b/var/spack/repos/builtin/packages/util-macros/package.py
@@ -16,3 +16,8 @@ class UtilMacros(AutotoolsPackage):
 
     version('1.19.1', '6e76e546a4e580f15cebaf8019ef1625')
     version('1.19.0', '1cf984125e75f8204938d998a8b6c1e1')
+
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        """Adds the ACLOCAL path for autotools."""
+        spack_env.append_path('ACLOCAL_PATH',
+                              join_path(self.prefix.share, 'aclocal'))

--- a/var/spack/repos/builtin/packages/xkeyboard-config/package.py
+++ b/var/spack/repos/builtin/packages/xkeyboard-config/package.py
@@ -30,3 +30,7 @@ class XkeyboardConfig(AutotoolsPackage):
     # gmsgfmt
     # perl@5.8.1:
     # perl XML::Parser
+
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        spack_env.prepend_path('XKB_CONFIG_ROOT', self.prefix.share.X11.xkb)
+        run_env.prepend_path('XKB_CONFIG_ROOT', self.prefix.share.X11.xkb)


### PR DESCRIPTION
Adds a package for the kitty terminal.

A few of the dependencies needed `setup_dependent_environment` implemented in order to be detected/used. For example, the `util-macros` package provides several m4 macros, which aren't discovered unless `ACLOCAL_PATH` is properly set.

One of kitty's dependencies, `libxkbcommon`, needed a few dependencies of its own added in order to compile.