### PR TITLE
package nccl: Fix install_targets for verison 2.3.5-5:

### DIFF
--- a/var/spack/repos/builtin/packages/nccl/package.py
+++ b/var/spack/repos/builtin/packages/nccl/package.py
@@ -26,4 +26,7 @@ class Nccl(MakefilePackage):
 
     @property
     def install_targets(self):
-        return ['PREFIX={0}'.format(self.prefix), 'install']
+        if self.version >= Version('2.3.5-5'):
+            return ['PREFIX={0}'.format(self.prefix), 'src.install']
+        else:
+            return ['PREFIX={0}'.format(self.prefix), 'install']


### PR DESCRIPTION
There is not install target in the top-level Makefile in this version, it moved to src/Makefile.