### PR TITLE
Ignore flake8 W503 and W504 

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -20,5 +20,5 @@
 # - N801: CapWords for class names.
 #
 [flake8]
-ignore = E129,E221,E241,E272,E731,F999,N801
+ignore = E129,E221,E241,E272,E731,F999,N801,W503,W504
 max-line-length = 79

--- a/.flake8_packages
+++ b/.flake8_packages
@@ -18,5 +18,5 @@
 # - F821: undefined name `name` (needed for cmake, configure, etc.)
 #
 [flake8]
-ignore = E129,E221,E241,E272,E731,F999,F405,F821
+ignore = E129,E221,E241,E272,E731,F999,F405,F821,W503,W504
 max-line-length = 79


### PR DESCRIPTION
It seems they are activated by default since since flake8 3.6.0, and they already caused a few packages to fail CI (see #9622).