### PR TITLE
r-argparse: remove unnecessary r-getopt version

### DIFF
--- a/var/spack/repos/builtin/packages/r-argparse/package.py
+++ b/var/spack/repos/builtin/packages/r-argparse/package.py
@@ -19,5 +19,5 @@ class RArgparse(RPackage):
 
     depends_on('r-proto@1:', type=('build', 'run'))
     depends_on('r-findpython', type=('build', 'run'))
-    depends_on('r-getopt@1.19', type=('build', 'run'))
+    depends_on('r-getopt', type=('build', 'run'))
     depends_on('r-jsonlite', type=('build', 'run'))


### PR DESCRIPTION
no checksum for r-getopt@1.19 and this package is compatible with the latest version anyway