### PR TITLE
license: add copyright to MIT license and SPDX in README

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,3 +1,6 @@
+Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+Spack Project Developers. See the top-level COPYRIGHT file for details.
+
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
 to deal in the Software without restriction, including without limitation

--- a/README.md
+++ b/README.md
@@ -122,6 +122,6 @@ See [LICENSE-MIT](https://github.com/spack/spack/blob/develop/LICENSE-MIT),
 [COPYRIGHT](https://github.com/spack/spack/blob/develop/COPYRIGHT), and
 [NOTICE](https://github.com/spack/spack/blob/develop/NOTICE) for details.
 
-``LLNL-CODE-647188``
+`SPDX-License-Identifier: (Apache-2.0 OR MIT)`
 
-![Analytics](https://ga-beacon.appspot.com/UA-101208306-3/welcome-page?pixel)
+``LLNL-CODE-647188``


### PR DESCRIPTION
- Add copyright to MIT license so that the "above copyright statement" wording is correct.

- Add SPDX identifier to top-level README.md file.

- Remove analytics beacon in README, which is not that useful anymore (the site is over quota, we should use something real if we want to do this)