### PR TITLE
netcdf-fortran: add LDFLAGS to fix contents of libnetcdff.la.

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-fortran/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-fortran/package.py
@@ -28,9 +28,16 @@ class NetcdfFortran(AutotoolsPackage):
         if name in ['cflags', 'fflags'] and '+pic' in self.spec:
             flags.append(self.compiler.pic_flag)
         elif name == 'cppflags':
-            flags.append('-I' + self.spec['netcdf'].prefix.include)
+            flags.append(self.spec['netcdf'].headers.cpp_flags)
+        elif name == 'ldflags':
+            # We need to specify LDFLAGS to get correct dependency_libs
+            # in libnetcdff.la, so packages that use libtool for linking
+            # could correctly link to all the dependencies even when the
+            # building takes place outside of Spack environment, i.e.
+            # without Spack's compiler wrappers.
+            flags.append(self.spec['netcdf'].libs.search_flags)
 
-        return (None, None, flags)
+        return None, None, flags
 
     @property
     def libs(self):


### PR DESCRIPTION
We need to specify `LDFLAGS` to get correct `dependency_libs` in `libnetcdff.la`, so packages that use `libtool` for linking could correctly link to all the dependencies even when the building takes place outside of Spack environment, i.e. without Spack's compiler wrappers.