### PR TITLE
config: `spack config blame` now colors filenames in config output

### DIFF
--- a/lib/spack/spack/util/spack_yaml.py
+++ b/lib/spack/spack/util/spack_yaml.py
@@ -275,6 +275,8 @@ class LineAnnotationDumper(OrderedLineDumper):
     def __init__(self, *args, **kwargs):
         super(LineAnnotationDumper, self).__init__(*args, **kwargs)
         del _annotations[:]
+        self.colors = 'KgrbmcyGRBMCY'
+        self.filename_colors = {}
 
     def process_scalar(self):
         super(LineAnnotationDumper, self).process_scalar()
@@ -301,7 +303,15 @@ class LineAnnotationDumper(OrderedLineDumper):
         # append annotations at the end of each line
         if self.saved:
             mark = self.saved._start_mark
-            ann = '@K{%s}' % mark.name
+
+            color = self.filename_colors.get(mark.name)
+            if not color:
+                ncolors = len(self.colors)
+                color = self.colors[len(self.filename_colors) % ncolors]
+                self.filename_colors[mark.name] = color
+
+            fmt = '@%s{%%s}' % color
+            ann = fmt % mark.name
             if mark.line is not None:
                 ann += ':@c{%s}' % (mark.line + 1)
             _annotations.append(colorize(ann))


### PR DESCRIPTION
This builds on #8081.

- it was hard to distinguish all-gray filenames
- added rotating colors to `spack config blame`

![screen shot 2018-10-26 at 5 40 03 pm](https://user-images.githubusercontent.com/299842/47597693-4ac28400-d946-11e8-905d-9b187b499a55.png)
