### PR TITLE
docker: allow docker build to fail until it's fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -115,6 +115,7 @@ jobs:
       env: TEST_SUITE=docker
   allow_failures:
     - dist: xenial
+    - env: TEST_SUITE=docker
 
 stages:
   - 'style checks'


### PR DESCRIPTION
- Docker builds are failing on `develop`
- They're not critical for the build to succeed, so allow them to fail until we fix the build

@opadron 