### PR TITLE
bugfix: set clang compiler symlink name based on compilers.yaml

### DIFF
--- a/lib/spack/spack/compilers/clang.py
+++ b/lib/spack/spack/compilers/clang.py
@@ -16,6 +16,25 @@ from spack.util.executable import Executable
 from spack.version import ver
 
 
+#: compiler symlink mappings for mixed f77 compilers
+f77_mapping = [
+    ('gfortran', 'clang/gfortran'),
+    ('xlf_r', 'xl_r/xlf_r'),
+    ('xlf', 'xl/xlf'),
+    ('pgfortran', 'pgi/pgfortran'),
+    ('ifort', 'intel/ifort')
+]
+
+#: compiler symlink mappings for mixed f90/fc compilers
+fc_mapping = [
+    ('gfortran', 'clang/gfortran'),
+    ('xlf90_r', 'xl_r/xlf90_r'),
+    ('xlf90', 'xl/xlf90'),
+    ('pgfortran', 'pgi/pgfortran'),
+    ('ifort', 'intel/ifort')
+]
+
+
 class Clang(Compiler):
     # Subclasses use possible names of C compiler
     cc_names = ['clang']
@@ -29,22 +48,31 @@ class Clang(Compiler):
     # Subclasses use possible names of Fortran 90 compiler
     fc_names = ['flang', 'gfortran', 'xlf90_r']
 
-    # Named wrapper links within lib/spack/env
-    link_paths = {'cc': 'clang/clang',
-                  'cxx': 'clang/clang++'}
+    # Clang has support for using different fortran compilers with the
+    # clang executable.
+    @property
+    def link_paths(self):
+        # clang links are always the same
+        link_paths = {'cc': 'clang/clang',
+                      'cxx': 'clang/clang++'}
 
-    if sys.platform == 'darwin':
-        # Use default wrappers for fortran, in case provided in
-        # compilers.yaml
-        link_paths['f77'] = 'clang/gfortran'
-        link_paths['fc'] = 'clang/gfortran'
-    elif spack.architecture.sys_type() == 'linux-rhel7-ppc64le':
-        # This platform uses clang with IBM XL Fortran compiler
-        link_paths['f77'] = 'xl_r/xlf_r'
-        link_paths['fc'] = 'xl_r/xlf90_r'
-    else:
-        link_paths['f77'] = 'clang/flang'
-        link_paths['fc'] = 'clang/flang'
+        # fortran links need to look at the actual compiler names from
+        # compilers.yaml to figure out which named symlink to use
+        for compiler_name, link_path in f77_mapping:
+            if self.f77 and compiler_name in self.f77:
+                link_paths['f77'] = link_path
+                break
+        else:
+            link_paths['f77'] = 'clang/flang'
+
+        for compiler_name, link_path in fc_mapping:
+            if self.fc and compiler_name in self.fc:
+                link_paths['fc'] = link_path
+                break
+        else:
+            link_paths['fc'] = 'clang/flang'
+
+        return link_paths
 
     @property
     def is_apple(self):


### PR DESCRIPTION
- Previously clang used a heuristic here based on the architecture to figure out what the preferred mixed fortran compiler was

- This was wrong in, among other places, Linux with clang/gfortran

- new logic looks at the actual name we got from compilers.yaml to pick the best wrapper name based on the mixed compiler name.

- this still isn't perfect but it's a lot better, and it will hopefully last us until compilers are actual dependencies

Previous discussion in #5503
FYI: @junghans @davydden 