### PR TITLE
Allow combinatorial projections in views

### DIFF
--- a/lib/spack/docs/workflows.rst
+++ b/lib/spack/docs/workflows.rst
@@ -438,8 +438,8 @@ way to assemble packages in a useful way and load them into a user's
 environment.
 
 A filesystem view is a projection of the Spack install space into a
-less combinatorial space. This is generally useful to give users a
-view of the Spack installed packages that they can navigate more
+less combinatorial space, often a single directory. Views give users a
+way to access the Spack installed packages that they can navigate more
 easily. The default projection for a filesystem view is into a single
 prefix.
 
@@ -532,9 +532,10 @@ Controlling View Projections
 """"""""""""""""""""""""""""
 
 The default projection into a view is to link every package into the
-root of the view. This can be changed through the ``projections.yaml``
-file in the view. The projection configuration file for a view located
-at ``/my/view`` is stored in ``/my/view/.spack/projections.yaml``.
+root of the view. This can be changed by adding a ``projections.yaml``
+configuration file to the view. The projection configuration file for
+a view located at ``/my/view`` is stored in
+``/my/view/.spack/projections.yaml``.
 
 When creating a view, the projection configuration file can also be
 specified from the command line using the ``--projection-file`` option
@@ -552,11 +553,13 @@ spec format strings, as shown in the example below.
 
 The entries in the projections configuration file must all be either
 specs or the keyword ``all``. For each spec, the projection used will
-be the first entry that the spec satisfies, and the keyword ``all`` is
-satisfied by any spec. Given the example above, any spec satisfying
-``zlib@1.2.8`` will be linked into ``/my/view/zlib-1.2.8/``, any spec
-satisfying ``hdf5@1.8.10+mpi %gcc@4.9.3 ^mvapich2@2.2`` will be linked
-into ``/my/view/hdf5-1.8.10/mvapich2-2.2-gcc-4.9.3``, and any spec
+be the first non-``all`` entry that the spec satisfies, or ``all`` if
+there is an entry for ``all`` and no other entry is satisfied by the
+spec. Where the keyword ``all`` appears in the file does not
+matter. Given the example above, any spec satisfying ``zlib@1.2.8``
+will be linked into ``/my/view/zlib-1.2.8/``, any spec satisfying
+``hdf5@1.8.10+mpi %gcc@4.9.3 ^mvapich2@2.2`` will be linked into
+``/my/view/hdf5-1.8.10/mvapich2-2.2-gcc-4.9.3``, and any spec
 satisfying ``hdf5@1.8.10~mpi %gcc@4.9.3`` will be linked into
 ``/my/view/hdf5-1.8.10/gcc-4.9.3``.
 
@@ -1497,4 +1500,3 @@ Disadvantages:
 
  2. Although patches of a few lines work OK, large patch files can be
     hard to create and maintain.
-

--- a/lib/spack/docs/workflows.rst
+++ b/lib/spack/docs/workflows.rst
@@ -437,12 +437,6 @@ Filesystem views offer an alternative to environment modules, another
 way to assemble packages in a useful way and load them into a user's
 environment.
 
-A filesystem view is a projection of the Spack install space into a
-less combinatorial space, often a single directory. Views give users a
-way to access the Spack installed packages that they can navigate more
-easily. The default projection for a filesystem view is into a single
-prefix.
-
 A single-prefix filesystem view is a single directory tree that is the
 union of the directory hierarchies of a number of installed packages;
 it is similar to the directory hiearchy that might exist under
@@ -453,7 +447,7 @@ original Spack installation.
 A combinatorial filesystem view can contain more software than a
 single-prefix view. Combinatorial filesystem views are created by
 defining a projection for each spec or set of specs. The syntax for
-this will be discussed in the discussion of the ``spack view`` command
+this will be discussed in the section for the ``spack view`` command
 under `adding_projections_to_views`_.
 
 The projection for a spec or set of specs specifies the naming scheme

--- a/lib/spack/docs/workflows.rst
+++ b/lib/spack/docs/workflows.rst
@@ -437,11 +437,29 @@ Filesystem views offer an alternative to environment modules, another
 way to assemble packages in a useful way and load them into a user's
 environment.
 
-A filesystem view is a single directory tree that is the union of the
-directory hierarchies of a number of installed packages; it is similar
-to the directory hiearchy that might exist under ``/usr/local``.  The
-files of the view's installed packages are brought into the view by
-symbolic or hard links, referencing the original Spack installation.
+A filesystem view is a projection of the Spack install space into a
+less combinatorial space. This is generally useful to give users a
+view of the Spack installed packages that they can navigate more
+easily. The default projection for a filesystem view is into a single
+prefix.
+
+A single-prefix filesystem view is a single directory tree that is the
+union of the directory hierarchies of a number of installed packages;
+it is similar to the directory hiearchy that might exist under
+``/usr/local``.  The files of the view's installed packages are
+brought into the view by symbolic or hard links, referencing the
+original Spack installation.
+
+A combinatorial filesystem view can contain more software than a
+single-prefix view. Combinatorial filesystem views are created by
+defining a projection for each spec or set of specs. The syntax for
+this will be discussed in the discussion of the ``spack view`` command
+under `adding_projections_to_views`_.
+
+The projection for a spec or set of specs specifies the naming scheme
+for the directory structure under the root of the view into which the
+package will be linked. For example, the spec ``zlib@1.2.8%gcc@4.4.7``
+could be projected to ``MYVIEW/zlib-1.2.8-gcc``.
 
 When software is built and installed, absolute paths are frequently
 "baked into" the software, making it non-relocatable.  This happens
@@ -506,6 +524,48 @@ files in the ``cmake`` package while retaining its dependencies.
 
     When packages are removed from a view, empty directories are
     purged.
+
+.. _adding_projections_to_views:
+
+""""""""""""""""""""""""""""
+Controlling View Projections
+""""""""""""""""""""""""""""
+
+The default projection into a view is to link every package into the
+root of the view. This can be changed through the ``projections.yaml``
+file in the view. The projection configuration file for a view located
+at ``/my/view`` is stored in ``/my/view/.spack/projections.yaml``.
+
+When creating a view, the projection configuration file can also be
+specified from the command line using the ``--projection-file`` option
+to the ``spack view`` command.
+
+The projections configuration file is a mapping of partial specs to
+spec format strings, as shown in the example below.
+
+.. code-block:: yaml
+
+   projections:
+     zlib: ${PACKAGE}-${VERSION}
+     ^mpi: ${PACKAGE}-${VERSION}/${DEP:mpi:PACKAGE}-${DEP:mpi:VERSION}-${COMPILERNAME}-${COMPILERVER}
+     all: ${PACKAGE}-${VERSION}/${COMPILERNAME}-${COMPILERVER}
+
+The entries in the projections configuration file must all be either
+specs or the keyword ``all``. For each spec, the projection used will
+be the first entry that the spec satisfies, and the keyword ``all`` is
+satisfied by any spec. Given the example above, any spec satisfying
+``zlib@1.2.8`` will be linked into ``/my/view/zlib-1.2.8/``, any spec
+satisfying ``hdf5@1.8.10+mpi %gcc@4.9.3 ^mvapich2@2.2`` will be linked
+into ``/my/view/hdf5-1.8.10/mvapich2-2.2-gcc-4.9.3``, and any spec
+satisfying ``hdf5@1.8.10~mpi %gcc@4.9.3`` will be linked into
+``/my/view/hdf5-1.8.10/gcc-4.9.3``.
+
+If the keyword ``all`` does not appear in the projections
+configuration file, any spec that does not satisfy any entry in the
+file will be linked into the root of the view as in a single-prefix
+view. Any entries that appear below the keyword ``all`` in the
+projections configuration file will not be used, as all specs will use
+the projection under ``all`` before reaching those entries.
 
 """"""""""""""""""
 Fine-Grain Control

--- a/lib/spack/spack/build_systems/aspell_dict.py
+++ b/lib/spack/spack/build_systems/aspell_dict.py
@@ -26,7 +26,7 @@ class AspellDictPackage(AutotoolsPackage):
 
     def view_destination(self, view):
         aspell_spec = self.spec['aspell']
-        if view.root != aspell_spec.prefix:
+        if view.get_projection_for_spec(aspell_spec) != aspell_spec.prefix:
             raise ExtensionError(
                 'aspell does not support non-global extensions')
         aspell = aspell_spec.command

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -447,14 +447,16 @@ class PythonPackage(PackageBase):
                 ignore_namespace = True
 
         bin_dir = self.spec.prefix.bin
-        globl_view = self.extendee_spec.prefix == view.get_projection_for_spec(
-            self.spec
+        global_view = (
+            self.extendee_spec.prefix == view.get_projection_for_spec(
+                self.spec
+            )
         )
         for src, dst in merge_map.items():
             if ignore_namespace and namespace_init(dst):
                 continue
 
-            if globl_view or not path_contains_subdirectory(src, bin_dir):
+            if global_view or not path_contains_subdirectory(src, bin_dir):
                 view.remove_file(src, dst)
             else:
                 os.remove(dst)

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -414,7 +414,9 @@ class PythonPackage(PackageBase):
     def add_files_to_view(self, view, merge_map):
         bin_dir = self.spec.prefix.bin
         python_prefix = self.extendee_spec.prefix
-        global_view = same_path(python_prefix, view.root)
+        global_view = same_path(python_prefix, view.get_projection_for_spec(
+            self.spec
+        ))
         for src, dst in merge_map.items():
             if os.path.exists(dst):
                 continue
@@ -424,7 +426,9 @@ class PythonPackage(PackageBase):
                 shutil.copy2(src, dst)
                 if 'script' in get_filetype(src):
                     filter_file(
-                        python_prefix, os.path.abspath(view.root), dst)
+                        python_prefix, os.path.abspath(
+                            view.get_projection_for_spec(self.spec)), dst
+                    )
             else:
                 orig_link_target = os.path.realpath(src)
                 new_link_target = os.path.abspath(merge_map[orig_link_target])
@@ -443,12 +447,14 @@ class PythonPackage(PackageBase):
                 ignore_namespace = True
 
         bin_dir = self.spec.prefix.bin
-        global_view = self.extendee_spec.prefix == view.root
+        globl_view = self.extendee_spec.prefix == view.get_projection_for_spec(
+            self.spec
+        )
         for src, dst in merge_map.items():
             if ignore_namespace and namespace_init(dst):
                 continue
 
-            if global_view or not path_contains_subdirectory(src, bin_dir):
+            if globl_view or not path_contains_subdirectory(src, bin_dir):
                 view.remove_file(src, dst)
             else:
                 os.remove(dst)

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -8,6 +8,7 @@ from __future__ import print_function
 import os
 import re
 import sys
+import argparse
 
 import llnl.util.tty as tty
 from llnl.util.lang import attr_setdefault, index_by
@@ -342,3 +343,15 @@ def spack_is_git_repo():
     """Ensure that this instance of Spack is a git clone."""
     with working_dir(spack.paths.prefix):
         return os.path.isdir('.git')
+
+
+########################################
+# argparse types for argument validation
+########################################
+def extant_file(f):
+    """
+    Argparse type for files that exist.
+    """
+    if not os.path.isfile(f):
+        raise argparse.ArgumentTypeError('%s does not exist' % f)
+    return f

--- a/lib/spack/spack/cmd/view.py
+++ b/lib/spack/spack/cmd/view.py
@@ -80,6 +80,7 @@ def relaxed_disambiguate(specs, view):
     # make function always return a list to keep consistency between py2/3
     return list(map(squash, map(spack.store.db.query, specs)))
 
+
 def setup_parser(sp):
     setup_parser.parser = sp
 
@@ -120,8 +121,9 @@ def setup_parser(sp):
     for cmd, act in file_system_view_actions.items():
         act.add_argument('path', nargs=1,
                          help="path to file system view directory")
-        act.add_argument('--projection-file', default='', dest='projection_file',
-                         help="Initialize projection using specification from file.")
+        act.add_argument('--projection-file', default='',
+                         dest='projection_file',
+                         help="Initialize view using projections from file.")
 
         if cmd == "remove":
             grp = act.add_mutually_exclusive_group(required=True)
@@ -175,8 +177,7 @@ def view(parser, args):
         path, spack.store.layout,
         projections=ordered_projections,
         ignore_conflicts=getattr(args, "ignore_conflicts", False),
-        link=os.link if args.action in ["hardlink", "hard"]
-        else os.symlink,
+        link=os.link if args.action in ["hardlink", "hard"] else os.symlink,
         verbose=args.verbose)
 
     # Process common args and specs

--- a/lib/spack/spack/cmd/view.py
+++ b/lib/spack/spack/cmd/view.py
@@ -42,6 +42,8 @@ from llnl.util.tty.color import colorize
 import spack.environment as ev
 import spack.cmd
 import spack.store
+import spack.schema.projections
+from spack.config import validate
 from spack.filesystem_view import YamlFilesystemView
 from spack.util import spack_yaml as s_yaml
 
@@ -166,7 +168,9 @@ def view(parser, args):
     if args.projection_file:
         if os.path.exists(args.projection_file):
             with open(args.projection_file, 'r') as f:
-                ordered_projections = s_yaml.load(f)['projections']
+                projections_data = s_yaml.load(f)
+                validate(projections_data, spack.schema.projections.schema)
+                ordered_projections = projections_data['projections']
         else:
             tty.error('Specified projection file does not exist.')
     else:

--- a/lib/spack/spack/cmd/view.py
+++ b/lib/spack/spack/cmd/view.py
@@ -56,7 +56,7 @@ actions_remove = ["remove", "rm"]
 actions_status = ["statlink", "status", "check"]
 
 
-def relaxed_disambiguate(specs, view):
+def disambiguate_in_view(specs, view):
     """
         When dealing with querying actions (remove/status) we only need to
         disambiguate among specs in the view
@@ -171,7 +171,7 @@ def view(parser, args):
                 validate(projections_data, spack.schema.projections.schema)
                 ordered_projections = projections_data['projections']
         else:
-            tty.error('Specified projection file does not exist.')
+            tty.die('Specified projection file does not exist.')
     else:
         ordered_projections = {}
 
@@ -198,11 +198,11 @@ def view(parser, args):
         if len(specs) == 0:
             specs = view.get_all_specs()
         else:
-            specs = relaxed_disambiguate(specs, view)
+            specs = disambiguate_in_view(specs, view)
 
     else:
         # status and remove can map a partial spec to packages in view
-        specs = relaxed_disambiguate(specs, view)
+        specs = disambiguate_in_view(specs, view)
 
     with_dependencies = args.dependencies.lower() in ['true', 'yes']
 

--- a/lib/spack/spack/cmd/view.py
+++ b/lib/spack/spack/cmd/view.py
@@ -47,7 +47,7 @@ from spack.config import validate
 from spack.filesystem_view import YamlFilesystemView
 from spack.util import spack_yaml as s_yaml
 
-description = "produce a simplified view of spack packages on the filesystem"
+description = "project packages to a compact naming scheme on the filesystem."
 section = "environments"
 level = "short"
 

--- a/lib/spack/spack/cmd/view.py
+++ b/lib/spack/spack/cmd/view.py
@@ -47,7 +47,7 @@ from spack.config import validate
 from spack.filesystem_view import YamlFilesystemView
 from spack.util import spack_yaml as s_yaml
 
-description = "produce a directory-based view of packages"
+description = "produce a simplified view of spack packages on the filesystem"
 section = "environments"
 level = "short"
 
@@ -123,8 +123,7 @@ def setup_parser(sp):
     for cmd, act in file_system_view_actions.items():
         act.add_argument('path', nargs=1,
                          help="path to file system view directory")
-        act.add_argument('--projection-file', default='',
-                         dest='projection_file',
+        act.add_argument('--projection-file', dest='projection_file',
                          help="Initialize view using projections from file.")
 
         if cmd == "remove":
@@ -175,7 +174,6 @@ def view(parser, args):
             tty.error('Specified projection file does not exist.')
     else:
         ordered_projections = {}
-#        ordered_projections = spack.config.get('projection')
 
     view = YamlFilesystemView(
         path, spack.store.layout,

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -142,12 +142,12 @@ class ConfigScope(object):
     def write_section(self, section):
         filename = self.get_section_filename(section)
         data = self.get_section(section)
-        _validate(data, section_schemas[section])
+        validate(data, section_schemas[section])
 
         try:
             mkdirp(self.path)
             with open(filename, 'w') as f:
-                _validate(data, section_schemas[section])
+                validate(data, section_schemas[section])
                 syaml.dump(data, stream=f, default_flow_style=False)
         except (yaml.YAMLError, IOError) as e:
             raise ConfigFileError(
@@ -233,7 +233,7 @@ class SingleFileScope(ConfigScope):
         return self.sections[section]
 
     def write_section(self, section):
-        _validate(self.sections, self.schema)
+        validate(self.sections, self.schema)
         try:
             parent = os.path.dirname(self.path)
             mkdirp(parent)
@@ -277,7 +277,7 @@ class InternalConfigScope(ConfigScope):
         if data:
             for section in data:
                 dsec = data[section]
-                _validate({section: dsec}, section_schemas[section])
+                validate({section: dsec}, section_schemas[section])
                 self.sections[section] = _mark_internal(
                     syaml.syaml_dict({section: dsec}), name)
 
@@ -295,7 +295,7 @@ class InternalConfigScope(ConfigScope):
         """This only validates, as the data is already in memory."""
         data = self.get_section(section)
         if data is not None:
-            _validate(data, section_schemas[section])
+            validate(data, section_schemas[section])
         self.sections[section] = _mark_internal(data, self.name)
 
     def __repr__(self):
@@ -646,7 +646,7 @@ def _validate_section_name(section):
             % (section, " ".join(section_schemas.keys())))
 
 
-def _validate(data, schema, set_defaults=True):
+def validate(data, schema, set_defaults=True):
     """Validate data read in from a Spack YAML file.
 
     Arguments:
@@ -683,7 +683,7 @@ def _read_config_file(filename, schema):
             data = _mark_overrides(syaml.load(f))
 
         if data:
-            _validate(data, schema)
+            validate(data, schema)
         return data
 
     except MarkedYAMLError as e:

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -309,7 +309,7 @@ class YamlDirectoryLayout(DirectoryLayout):
 class YamlViewExtensionsLayout(ExtensionsLayout):
     """Maintain extensions within a view.
     """
-    def __init__(self, root, layout):
+    def __init__(self, root, layout, projections={}):
         """layout is the corresponding YamlDirectoryLayout object for which
            we implement extensions.
         """
@@ -317,6 +317,8 @@ class YamlViewExtensionsLayout(ExtensionsLayout):
         self.layout = layout
         self.extension_file_name = 'extensions.yaml'
 
+        self.projections = projections
+        
         # Cache of already written/read extension maps.
         self._extension_maps = {}
 
@@ -361,8 +363,16 @@ class YamlViewExtensionsLayout(ExtensionsLayout):
             components = [self.root, self.layout.metadata_dir,
                           self.extension_file_name]
         else:
-            components = [self.root, self.layout.metadata_dir, spec.name,
+            view_prefix = self.root
+            for spec_like, projection in self.projections.items():
+                if spec_like == 'all' or spec.satisfies(spec_like, 
+                                                        strict=True):
+                    view_prefix = os.path.join(self.root, 
+                                               spec.format(projection))
+                    break
+            components = [view_prefix, self.layout.metadata_dir, spec.name,
                           self.extension_file_name]
+
         return os.path.join(*components)
 
     def extension_map(self, spec):

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -318,7 +318,7 @@ class YamlViewExtensionsLayout(ExtensionsLayout):
         self.extension_file_name = 'extensions.yaml'
 
         self.projections = projections
-        
+
         # Cache of already written/read extension maps.
         self._extension_maps = {}
 
@@ -365,9 +365,9 @@ class YamlViewExtensionsLayout(ExtensionsLayout):
         else:
             view_prefix = self.root
             for spec_like, projection in self.projections.items():
-                if spec_like == 'all' or spec.satisfies(spec_like, 
+                if spec_like == 'all' or spec.satisfies(spec_like,
                                                         strict=True):
-                    view_prefix = os.path.join(self.root, 
+                    view_prefix = os.path.join(self.root,
                                                spec.format(projection))
                     break
             components = [view_prefix, self.layout.metadata_dir, spec.name,

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -431,9 +431,13 @@ class YamlFilesystemView(FilesystemView):
            Relies on the ordering of projections to avoid ambiguity.
         """
         spec = spack.spec.Spec(spec)
+        # Extensions are placed by their extendee, not by their own spec
+        locator_spec = spec.package.extendee_spec if spec.package.extendee_spec else spec
+
         for spec_like, fmt_str in self.projections.items():
-            if spec_like == 'all' or spec.satisfies(spec_like, strict=True):
-                return os.path.join(self.root, spec.format(fmt_str))
+            if spec_like == 'all' or locator_spec.satisfies(spec_like, 
+                                                            strict=True):
+                return os.path.join(self.root, locator_spec.format(fmt_str))
         return self.root
 
     def get_all_specs(self):

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -190,6 +190,13 @@ class YamlFilesystemView(FilesystemView):
                 # Read projections file from view
                 with open(projections_path, 'r') as f:
                     self.projections = s_yaml.load(f)['projections']
+            else:
+                # Write projections file to new view
+                # Not strictly necessary as the empty file is the empty projection
+                # But it makes sense for consistency
+                mkdirp(os.path.dirname(projections_path))
+                with open(projections_path, 'w') as f:
+                    f.write(s_yaml.dump({'projections': self.projections}))
         elif not os.path.exists(projections_path):
             # Write projections file to new view
             mkdirp(os.path.dirname(projections_path))

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -20,9 +20,11 @@ import spack.util.spack_yaml as s_yaml
 
 import spack.spec
 import spack.store
+import spack.schema.projections
 from spack.error import SpackError
 from spack.directory_layout import ExtensionAlreadyInstalledError
 from spack.directory_layout import YamlViewExtensionsLayout
+from spack.config import validate
 
 # compatability
 if sys.version_info < (3, 0):
@@ -34,7 +36,6 @@ __all__ = ["FilesystemView", "YamlFilesystemView"]
 
 
 _projections_path = '.spack/projections.yaml'
-
 
 class FilesystemView(object):
     """
@@ -189,7 +190,9 @@ class YamlFilesystemView(FilesystemView):
             if os.path.exists(projections_path):
                 # Read projections file from view
                 with open(projections_path, 'r') as f:
-                    self.projections = s_yaml.load(f)['projections']
+                    projections_data = s_yaml.load(f)
+                    validate(projections_data, spack.schema.projections.schema)
+                    self.projections = projections_data['projections']
             else:
                 # Write projections file to new view
                 # Not strictly necessary as the empty file is the empty

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -21,10 +21,11 @@ import spack.util.spack_yaml as s_yaml
 import spack.spec
 import spack.store
 import spack.schema.projections
+import spack.config
 from spack.error import SpackError
 from spack.directory_layout import ExtensionAlreadyInstalledError
 from spack.directory_layout import YamlViewExtensionsLayout
-from spack.config import validate
+
 
 # compatability
 if sys.version_info < (3, 0):
@@ -192,7 +193,8 @@ class YamlFilesystemView(FilesystemView):
                 # Read projections file from view
                 with open(projections_path, 'r') as f:
                     projections_data = s_yaml.load(f)
-                    validate(projections_data, spack.schema.projections.schema)
+                    spack.config.validate(projections_data,
+                                          spack.schema.projections.schema)
                     self.projections = projections_data['projections']
             else:
                 # Write projections file to new view

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -475,10 +475,14 @@ class YamlFilesystemView(FilesystemView):
         if spec.package.extendee_spec:
             locator_spec = spec.package.extendee_spec
 
+        all_fmt_str = None
         for spec_like, fmt_str in self.projections.items():
-            if spec_like == 'all' or locator_spec.satisfies(spec_like,
-                                                            strict=True):
+            if locator_spec.satisfies(spec_like, strict=True):
                 return os.path.join(self.root, locator_spec.format(fmt_str))
+            elif spec_like == 'all':
+                all_fmt_str = fmt_str
+        if all_fmt_str:
+            return os.path.join(self.root, locator_spec.format(all_fmt_str))
         return self.root
 
     def get_all_specs(self):

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -37,6 +37,7 @@ __all__ = ["FilesystemView", "YamlFilesystemView"]
 
 _projections_path = '.spack/projections.yaml'
 
+
 class FilesystemView(object):
     """
         Governs a filesystem view that is located at certain root-directory.

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -284,7 +284,7 @@ class PackageViewMixin(object):
         """The target root directory: each file is added relative to this
         directory.
         """
-        return view.root
+        return view.get_projection_for_spec(self.spec)
 
     def view_file_conflicts(self, view, merge_map):
         """Report any files which prevent adding this package to the view. The

--- a/lib/spack/spack/schema/projections.py
+++ b/lib/spack/spack/schema/projections.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""Schema for projections.yaml configuration file.
+
+.. literalinclude:: ../spack/schema/projections.py
+   :lines: 13-
+"""
+
+
+#: Properties for inclusion in other schemas
+properties = {
+    'projections': {
+        'type': 'object',
+        'default': {},
+        'patternProperties': {
+            r'all|\w[\w-]*': {
+                'type': 'string'
+            },
+        },
+    },
+}
+
+
+#: Full schema with metadata
+schema = {
+    '$schema': 'http://json-schema.org/schema#',
+    'title': 'Spack view projection configuration file schema',
+    'type': 'object',
+    'additionalProperties': False,
+    'properties': properties,
+}

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3025,6 +3025,8 @@ class Spec(object):
             ${SHA1}          Dependencies 8-char sha1 prefix
             ${HASH:len}      DAG hash with optional length specifier
 
+            ${DEP:name:OPTION} Evaluates as OPTION would for self['name']
+
             ${SPACK_ROOT}    The spack root directory
             ${SPACK_INSTALL} The default spack install directory,
                              ${SPACK_PREFIX}/opt
@@ -3218,6 +3220,10 @@ class Spec(object):
                     out.write(fmt % (self.dag_hash(hashlen)))
                 elif named_str == 'NAMESPACE':
                     out.write(fmt % transform(self.namespace))
+                elif named_str.startswith('DEP:'):
+                    _, dep_name, dep_option = named_str.lower().split(':', 2)
+                    dep_spec = self[dep_name]
+                    out.write(fmt % (dep_spec.format('${%s}' % dep_option)))
 
                 named = False
 

--- a/lib/spack/spack/test/cmd/view.py
+++ b/lib/spack/spack/test/cmd/view.py
@@ -253,3 +253,10 @@ def test_view_extendee_with_global_activations(
     activate('extension1@2.0')
     output = view('symlink', viewpath, 'extension1@1.0')
     assert 'Error: Globally activated extensions cannot be used' in output
+
+
+def test_view_fails_with_missing_projections_file(tmpdir):
+    viewpath = str(tmpdir.mkdir('view'))
+    projection_file = os.path.join(str(tmpdir), 'nonexistent')
+    with pytest.raises(SystemExit):
+        view('symlink', '--projection-file', projection_file, viewpath, 'foo')

--- a/lib/spack/spack/test/cmd/view.py
+++ b/lib/spack/spack/test/cmd/view.py
@@ -21,7 +21,6 @@ def create_projection_file(tmpdir, projection):
 
     projection_file = tmpdir.mkdir('projection').join('projection.yaml')
     projection_file.write(s_yaml.dump(projection))
-    print s_yaml.dump(projection)
     return projection_file
 
 

--- a/lib/spack/spack/test/cmd/view.py
+++ b/lib/spack/spack/test/cmd/view.py
@@ -6,7 +6,6 @@
 from spack.main import SpackCommand
 import os.path
 import pytest
-from collections import OrderedDict
 
 import spack.util.spack_yaml as s_yaml
 
@@ -66,8 +65,10 @@ def test_view_multiple_projections(
     install('extendee@1.0%gcc')
     
     viewpath = str(tmpdir.mkdir('view'))
-    view_projection = OrderedDict([('extendee', '${PACKAGE}-${COMPILERNAME}'),
-                                  ('all', '${PACKAGE}-${VERSION}')])
+    view_projection = s_yaml.syaml_dict(
+        [('extendee', '${PACKAGE}-${COMPILERNAME}'),
+         ('all', '${PACKAGE}-${VERSION}')]
+        )
 
     projection_file = create_projection_file(tmpdir, view_projection)
     view('add', viewpath, '--projection-file={0}'.format(projection_file), 

--- a/lib/spack/spack/test/cmd/view.py
+++ b/lib/spack/spack/test/cmd/view.py
@@ -79,6 +79,28 @@ def test_view_multiple_projections(
     assert os.path.exists(extendee_prefix)
 
 
+def test_view_multiple_projections_all_first(
+        tmpdir, mock_packages, mock_archive, mock_fetch, config,
+        install_mockery):
+    install('libdwarf@20130207')
+    install('extendee@1.0%gcc')
+
+    viewpath = str(tmpdir.mkdir('view'))
+    view_projection = s_yaml.syaml_dict(
+         [('all', '${PACKAGE}-${VERSION}'),
+          ('extendee', '${PACKAGE}-${COMPILERNAME}')]
+    )
+
+    projection_file = create_projection_file(tmpdir, view_projection)
+    view('add', viewpath, '--projection-file={0}'.format(projection_file),
+         'libdwarf', 'extendee')
+
+    libdwarf_prefix = os.path.join(viewpath, 'libdwarf-20130207/libdwarf')
+    extendee_prefix = os.path.join(viewpath, 'extendee-gcc/bin')
+    assert os.path.exists(libdwarf_prefix)
+    assert os.path.exists(extendee_prefix)
+
+
 def test_view_external(
         tmpdir, mock_packages, mock_archive, mock_fetch, config,
         install_mockery):

--- a/lib/spack/spack/test/cmd/view.py
+++ b/lib/spack/spack/test/cmd/view.py
@@ -87,8 +87,8 @@ def test_view_multiple_projections_all_first(
 
     viewpath = str(tmpdir.mkdir('view'))
     view_projection = s_yaml.syaml_dict(
-         [('all', '${PACKAGE}-${VERSION}'),
-          ('extendee', '${PACKAGE}-${COMPILERNAME}')]
+        [('all', '${PACKAGE}-${VERSION}'),
+         ('extendee', '${PACKAGE}-${COMPILERNAME}')]
     )
 
     projection_file = create_projection_file(tmpdir, view_projection)

--- a/lib/spack/spack/test/cmd/view.py
+++ b/lib/spack/spack/test/cmd/view.py
@@ -39,18 +39,18 @@ def test_view_link_type(
 
 @pytest.mark.parametrize('cmd', ['hardlink', 'symlink', 'hard', 'add'])
 def test_view_projections(
-        tmpdir, mock_packages, mock_archive, mock_fetch, config, 
+        tmpdir, mock_packages, mock_archive, mock_fetch, config,
         install_mockery, cmd):
     install('libdwarf@20130207')
-    
+
     viewpath = str(tmpdir.mkdir('view_{0}'.format(cmd)))
     view_projection = {
         'projections': {
             'all': '${PACKAGE}-${VERSION}'
-            }
         }
+    }
     projection_file = create_projection_file(tmpdir, view_projection)
-    view(cmd, viewpath, '--projection-file={0}'.format(projection_file), 
+    view(cmd, viewpath, '--projection-file={0}'.format(projection_file),
          'libdwarf')
 
     package_prefix = os.path.join(viewpath, 'libdwarf-20130207/libdwarf')
@@ -59,19 +59,19 @@ def test_view_projections(
 
 
 def test_view_multiple_projections(
-        tmpdir, mock_packages, mock_archive, mock_fetch, config, 
+        tmpdir, mock_packages, mock_archive, mock_fetch, config,
         install_mockery):
     install('libdwarf@20130207')
     install('extendee@1.0%gcc')
-    
+
     viewpath = str(tmpdir.mkdir('view'))
     view_projection = s_yaml.syaml_dict(
         [('extendee', '${PACKAGE}-${COMPILERNAME}'),
          ('all', '${PACKAGE}-${VERSION}')]
-        )
+    )
 
     projection_file = create_projection_file(tmpdir, view_projection)
-    view('add', viewpath, '--projection-file={0}'.format(projection_file), 
+    view('add', viewpath, '--projection-file={0}'.format(projection_file),
          'libdwarf', 'extendee')
 
     libdwarf_prefix = os.path.join(viewpath, 'libdwarf-20130207/libdwarf')
@@ -144,7 +144,7 @@ def test_view_extension_projection(
     assert 'extension1@2.0' not in view_activated
     assert 'extension2@1.0' not in view_activated
 
-    assert os.path.exists(os.path.join(viewpath, 'extendee-1.0', 
+    assert os.path.exists(os.path.join(viewpath, 'extendee-1.0',
                                        'bin', 'extension1'))
 
 

--- a/lib/spack/spack/test/cmd/view.py
+++ b/lib/spack/spack/test/cmd/view.py
@@ -6,11 +6,24 @@
 from spack.main import SpackCommand
 import os.path
 import pytest
+from collections import OrderedDict
+
+import spack.util.spack_yaml as s_yaml
 
 activate = SpackCommand('activate')
 extensions = SpackCommand('extensions')
 install = SpackCommand('install')
 view = SpackCommand('view')
+
+
+def create_projection_file(tmpdir, projection):
+    if 'projections' not in projection:
+        projection = {'projections': projection}
+
+    projection_file = tmpdir.mkdir('projection').join('projection.yaml')
+    projection_file.write(s_yaml.dump(projection))
+    print s_yaml.dump(projection)
+    return projection_file
 
 
 @pytest.mark.parametrize('cmd', ['hardlink', 'symlink', 'hard', 'add'])
@@ -23,6 +36,47 @@ def test_view_link_type(
     package_prefix = os.path.join(viewpath, 'libdwarf')
     assert os.path.exists(package_prefix)
     assert os.path.islink(package_prefix) == (not cmd.startswith('hard'))
+
+
+@pytest.mark.parametrize('cmd', ['hardlink', 'symlink', 'hard', 'add'])
+def test_view_projections(
+        tmpdir, mock_packages, mock_archive, mock_fetch, config, 
+        install_mockery, cmd):
+    install('libdwarf@20130207')
+    
+    viewpath = str(tmpdir.mkdir('view_{0}'.format(cmd)))
+    view_projection = {
+        'projections': {
+            'all': '${PACKAGE}-${VERSION}'
+            }
+        }
+    projection_file = create_projection_file(tmpdir, view_projection)
+    view(cmd, viewpath, '--projection-file={0}'.format(projection_file), 
+         'libdwarf')
+
+    package_prefix = os.path.join(viewpath, 'libdwarf-20130207/libdwarf')
+    assert os.path.exists(package_prefix)
+    assert os.path.islink(package_prefix) == (not cmd.startswith('hard'))
+
+
+def test_view_multiple_projections(
+        tmpdir, mock_packages, mock_archive, mock_fetch, config, 
+        install_mockery):
+    install('libdwarf@20130207')
+    install('extendee@1.0%gcc')
+    
+    viewpath = str(tmpdir.mkdir('view'))
+    view_projection = OrderedDict([('extendee', '${PACKAGE}-${COMPILERNAME}'),
+                                  ('all', '${PACKAGE}-${VERSION}')])
+
+    projection_file = create_projection_file(tmpdir, view_projection)
+    view('add', viewpath, '--projection-file={0}'.format(projection_file), 
+         'libdwarf', 'extendee')
+
+    libdwarf_prefix = os.path.join(viewpath, 'libdwarf-20130207/libdwarf')
+    extendee_prefix = os.path.join(viewpath, 'extendee-gcc/bin')
+    assert os.path.exists(libdwarf_prefix)
+    assert os.path.exists(extendee_prefix)
 
 
 def test_view_external(
@@ -58,6 +112,39 @@ def test_view_extension(
     assert 'extension1@2.0' not in view_activated
     assert 'extension2@1.0' not in view_activated
     assert os.path.exists(os.path.join(viewpath, 'bin', 'extension1'))
+
+
+def test_view_extension_projection(
+        tmpdir, mock_packages, mock_archive, mock_fetch, config,
+        install_mockery):
+    install('extendee@1.0')
+    install('extension1@1.0')
+    install('extension1@2.0')
+    install('extension2@1.0')
+
+    viewpath = str(tmpdir.mkdir('view'))
+    view_projection = {'all': '${PACKAGE}-${VERSION}'}
+    projection_file = create_projection_file(tmpdir, view_projection)
+    view('symlink', viewpath, '--projection-file={0}'.format(projection_file),
+         'extension1@1.0')
+
+    all_installed = extensions('--show', 'installed', 'extendee')
+    assert 'extension1@1.0' in all_installed
+    assert 'extension1@2.0' in all_installed
+    assert 'extension2@1.0' in all_installed
+    global_activated = extensions('--show', 'activated', 'extendee')
+    assert 'extension1@1.0' not in global_activated
+    assert 'extension1@2.0' not in global_activated
+    assert 'extension2@1.0' not in global_activated
+    view_activated = extensions('--show', 'activated',
+                                '-v', viewpath,
+                                'extendee')
+    assert 'extension1@1.0' in view_activated
+    assert 'extension1@2.0' not in view_activated
+    assert 'extension2@1.0' not in view_activated
+
+    assert os.path.exists(os.path.join(viewpath, 'extendee-1.0', 
+                                       'bin', 'extension1'))
 
 
 def test_view_extension_remove(

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -677,7 +677,7 @@ def check_schema(name, file_contents):
     """Check a Spack YAML schema against some data"""
     f = StringIO(file_contents)
     data = syaml.load(f)
-    spack.config._validate(data, name)
+    spack.config.validate(data, name)
 
 
 def test_good_env_yaml(tmpdir):

--- a/lib/spack/spack/test/test_activations.py
+++ b/lib/spack/spack/test/test_activations.py
@@ -10,15 +10,14 @@ import sys
 import spack.spec
 import spack.package
 from llnl.util.link_tree import MergeConflictError
-from spack.build_systems.python import PythonPackage
 from spack.directory_layout import YamlDirectoryLayout
 from spack.filesystem_view import YamlFilesystemView
-from spack.util.prefix import Prefix
 from spack.repo import RepoPath
 
 """This includes tests for customized activation logic for specific packages
    (e.g. python and perl).
 """
+
 
 def create_ext_pkg(name, prefix, extendee_spec):
     ext_spec = spack.spec.Spec(name)
@@ -152,7 +151,8 @@ def namespace_extensions(tmpdir, builtin_and_mock_packages):
     return str(ext1_prefix), str(ext2_prefix), 'examplenamespace'
 
 
-def test_python_activation_with_files(tmpdir, python_and_extension_dirs, builtin_and_mock_packages):
+def test_python_activation_with_files(tmpdir, python_and_extension_dirs,
+                                      builtin_and_mock_packages):
     # Set mock repo to lower precedence than builtin. We can test builtin
     # python against mock python extensions.
     python_prefix, ext_prefix = python_and_extension_dirs
@@ -162,7 +162,7 @@ def test_python_activation_with_files(tmpdir, python_and_extension_dirs, builtin
     python_spec.package.spec.prefix = python_prefix
 
     ext_pkg = create_python_ext_pkg('py-extension1', ext_prefix, python_spec)
-    
+
     python_pkg = python_spec.package
     python_pkg.activate(ext_pkg, python_pkg.view())
 
@@ -176,7 +176,8 @@ def test_python_activation_with_files(tmpdir, python_and_extension_dirs, builtin
     assert 'setuptools.egg' not in easy_install_contents
 
 
-def test_python_activation_view(tmpdir, python_and_extension_dirs, builtin_and_mock_packages):
+def test_python_activation_view(tmpdir, python_and_extension_dirs,
+                                builtin_and_mock_packages):
     python_prefix, ext_prefix = python_and_extension_dirs
 
     python_spec = spack.spec.Spec('python@2.7.12')
@@ -197,7 +198,8 @@ def test_python_activation_view(tmpdir, python_and_extension_dirs, builtin_and_m
     assert os.path.exists(os.path.join(view_dir, 'bin/py-ext-tool'))
 
 
-def test_python_ignore_namespace_init_conflict(tmpdir, namespace_extensions, builtin_and_mock_packages):
+def test_python_ignore_namespace_init_conflict(tmpdir, namespace_extensions,
+                                               builtin_and_mock_packages):
     """Test the view update logic in PythonPackage ignores conflicting
        instances of __init__ for packages which are in the same namespace.
     """
@@ -207,9 +209,9 @@ def test_python_ignore_namespace_init_conflict(tmpdir, namespace_extensions, bui
     python_spec._concrete = True
 
     ext1_pkg = create_python_ext_pkg('py-extension1', ext1_prefix, python_spec,
-                                    py_namespace)
+                                     py_namespace)
     ext2_pkg = create_python_ext_pkg('py-extension2', ext2_prefix, python_spec,
-                                    py_namespace)
+                                     py_namespace)
 
     view_dir = str(tmpdir.join('view'))
     layout = YamlDirectoryLayout(view_dir)
@@ -230,7 +232,8 @@ def test_python_ignore_namespace_init_conflict(tmpdir, namespace_extensions, bui
     assert os.path.exists(os.path.join(view_dir, init_file))
 
 
-def test_python_keep_namespace_init(tmpdir, namespace_extensions, builtin_and_mock_packages):
+def test_python_keep_namespace_init(tmpdir, namespace_extensions,
+                                    builtin_and_mock_packages):
     """Test the view update logic in PythonPackage keeps the namespace
        __init__ file as long as one package in the namespace still
        exists.
@@ -241,9 +244,9 @@ def test_python_keep_namespace_init(tmpdir, namespace_extensions, builtin_and_mo
     python_spec._concrete = True
 
     ext1_pkg = create_python_ext_pkg('py-extension1', ext1_prefix, python_spec,
-                                    py_namespace)
+                                     py_namespace)
     ext2_pkg = create_python_ext_pkg('py-extension2', ext2_prefix, python_spec,
-                                    py_namespace)
+                                     py_namespace)
 
     view_dir = str(tmpdir.join('view'))
     layout = YamlDirectoryLayout(view_dir)
@@ -271,7 +274,8 @@ def test_python_keep_namespace_init(tmpdir, namespace_extensions, builtin_and_mo
     assert not os.path.exists(os.path.join(view_dir, init_file))
 
 
-def test_python_namespace_conflict(tmpdir, namespace_extensions, builtin_and_mock_packages):
+def test_python_namespace_conflict(tmpdir, namespace_extensions,
+                                   builtin_and_mock_packages):
     """Test the view update logic in PythonPackage reports an error when two
        python extensions with different namespaces have a conflicting __init__
        file.
@@ -283,9 +287,9 @@ def test_python_namespace_conflict(tmpdir, namespace_extensions, builtin_and_moc
     python_spec._concrete = True
 
     ext1_pkg = create_python_ext_pkg('py-extension1', ext1_prefix, python_spec,
-                                    py_namespace)
+                                     py_namespace)
     ext2_pkg = create_python_ext_pkg('py-extension2', ext2_prefix, python_spec,
-                                    other_namespace)
+                                     other_namespace)
 
     view_dir = str(tmpdir.join('view'))
     layout = YamlDirectoryLayout(view_dir)
@@ -365,7 +369,8 @@ def test_perl_activation(tmpdir, builtin_and_mock_packages):
     perl_pkg.activate(ext_pkg, perl_pkg.view())
 
 
-def test_perl_activation_with_files(tmpdir, perl_and_extension_dirs, builtin_and_mock_packages):
+def test_perl_activation_with_files(tmpdir, perl_and_extension_dirs,
+                                    builtin_and_mock_packages):
     perl_prefix, ext_prefix = perl_and_extension_dirs
 
     perl_spec = spack.spec.Spec('perl@5.24.1')
@@ -380,7 +385,8 @@ def test_perl_activation_with_files(tmpdir, perl_and_extension_dirs, builtin_and
     assert os.path.exists(os.path.join(perl_prefix, 'bin/perl-ext-tool'))
 
 
-def test_perl_activation_view(tmpdir, perl_and_extension_dirs, builtin_and_mock_packages):
+def test_perl_activation_view(tmpdir, perl_and_extension_dirs,
+                              builtin_and_mock_packages):
     perl_prefix, ext_prefix = perl_and_extension_dirs
 
     perl_spec = spack.spec.Spec('perl@5.24.1')

--- a/lib/spack/spack/test/test_activations.py
+++ b/lib/spack/spack/test/test_activations.py
@@ -14,60 +14,26 @@ from spack.build_systems.python import PythonPackage
 from spack.directory_layout import YamlDirectoryLayout
 from spack.filesystem_view import YamlFilesystemView
 from spack.util.prefix import Prefix
+from spack.repo import RepoPath
 
 """This includes tests for customized activation logic for specific packages
    (e.g. python and perl).
 """
 
+def create_ext_pkg(name, prefix, extendee_spec):
+    ext_spec = spack.spec.Spec(name)
+    ext_spec._concrete = True
 
-class FakeExtensionPackage(spack.package.PackageViewMixin):
-    def __init__(self, name, prefix):
-        self.name = name
-        self.prefix = Prefix(prefix)
-        self.spec = FakeSpec(self)
-
-
-class FakeSpec(object):
-    def __init__(self, package):
-        self.name = package.name
-        self.prefix = package.prefix
-        self.hash = self.name
-        self.package = package
-        self.concrete = True
-
-    def dag_hash(self):
-        return self.hash
-
-    def __lt__(self, other):
-        return self.name < other.name
+    ext_spec.package.spec.prefix = prefix
+    ext_pkg = ext_spec.package
+    ext_pkg.extends_spec = extendee_spec
+    return ext_pkg
 
 
-class FakePythonExtensionPackage(FakeExtensionPackage):
-    def __init__(self, name, prefix, py_namespace, python_spec):
-        self.py_namespace = py_namespace
-        self.extendee_spec = python_spec
-        super(FakePythonExtensionPackage, self).__init__(name, prefix)
-
-    def add_files_to_view(self, view, merge_map):
-        if sys.version_info >= (3, 0):
-            add_fn = PythonPackage.add_files_to_view
-        else:
-            add_fn = PythonPackage.add_files_to_view.im_func
-        return add_fn(self, view, merge_map)
-
-    def view_file_conflicts(self, view, merge_map):
-        if sys.version_info >= (3, 0):
-            conflicts_fn = PythonPackage.view_file_conflicts
-        else:
-            conflicts_fn = PythonPackage.view_file_conflicts.im_func
-        return conflicts_fn(self, view, merge_map)
-
-    def remove_files_from_view(self, view, merge_map):
-        if sys.version_info >= (3, 0):
-            remove_fn = PythonPackage.remove_files_from_view
-        else:
-            remove_fn = PythonPackage.remove_files_from_view.im_func
-        return remove_fn(self, view, merge_map)
+def create_python_ext_pkg(name, prefix, python_spec, namespace=None):
+    ext_pkg = create_ext_pkg(name, prefix, python_spec)
+    ext_pkg.py_namespace = namespace
+    return ext_pkg
 
 
 def create_dir_structure(tmpdir, dir_structure):
@@ -78,7 +44,23 @@ def create_dir_structure(tmpdir, dir_structure):
 
 
 @pytest.fixture()
-def python_and_extension_dirs(tmpdir):
+def builtin_and_mock_packages():
+    # These tests use mock_repo packages to test functionality of builtin
+    # packages. They therefore put the mock repo UNDER the builtin repo.
+    old_path = spack.repo.path
+    repo_dirs = [spack.paths.packages_path, spack.paths.mock_packages_path]
+    path = RepoPath(*repo_dirs)
+    sys.meta_path.append(path)
+    spack.repo.path = path
+
+    yield
+
+    spack.repo.path = old_path
+    sys.meta_path = sys.meta_path[:-1]
+
+
+@pytest.fixture()
+def python_and_extension_dirs(tmpdir, builtin_and_mock_packages):
     python_dirs = {
         'bin/': {
             'python': None
@@ -105,7 +87,7 @@ def python_and_extension_dirs(tmpdir):
         'lib/': {
             'python2.7/': {
                 'site-packages/': {
-                    'py-extension/': {
+                    'py-extension1/': {
                         'sample.py': None
                     }
                 }
@@ -113,7 +95,7 @@ def python_and_extension_dirs(tmpdir):
         }
     }
 
-    ext_name = 'py-extension'
+    ext_name = 'py-extension1'
     ext_prefix = tmpdir.join(ext_name)
     create_dir_structure(ext_prefix, ext_dirs)
 
@@ -126,7 +108,7 @@ path/to/setuptools.egg""")
 
 
 @pytest.fixture()
-def namespace_extensions(tmpdir):
+def namespace_extensions(tmpdir, builtin_and_mock_packages):
     ext1_dirs = {
         'bin/': {
             'py-ext-tool1': None
@@ -170,15 +152,17 @@ def namespace_extensions(tmpdir):
     return str(ext1_prefix), str(ext2_prefix), 'examplenamespace'
 
 
-def test_python_activation_with_files(tmpdir, python_and_extension_dirs):
+def test_python_activation_with_files(tmpdir, python_and_extension_dirs, builtin_and_mock_packages):
+    # Set mock repo to lower precedence than builtin. We can test builtin
+    # python against mock python extensions.
     python_prefix, ext_prefix = python_and_extension_dirs
 
     python_spec = spack.spec.Spec('python@2.7.12')
     python_spec._concrete = True
     python_spec.package.spec.prefix = python_prefix
 
-    ext_pkg = FakeExtensionPackage('py-extension', ext_prefix)
-
+    ext_pkg = create_python_ext_pkg('py-extension1', ext_prefix, python_spec)
+    
     python_pkg = python_spec.package
     python_pkg.activate(ext_pkg, python_pkg.view())
 
@@ -192,14 +176,14 @@ def test_python_activation_with_files(tmpdir, python_and_extension_dirs):
     assert 'setuptools.egg' not in easy_install_contents
 
 
-def test_python_activation_view(tmpdir, python_and_extension_dirs):
+def test_python_activation_view(tmpdir, python_and_extension_dirs, builtin_and_mock_packages):
     python_prefix, ext_prefix = python_and_extension_dirs
 
     python_spec = spack.spec.Spec('python@2.7.12')
     python_spec._concrete = True
     python_spec.package.spec.prefix = python_prefix
 
-    ext_pkg = FakeExtensionPackage('py-extension', ext_prefix)
+    ext_pkg = create_python_ext_pkg('py-extension1', ext_prefix, python_spec)
 
     view_dir = str(tmpdir.join('view'))
     layout = YamlDirectoryLayout(view_dir)
@@ -213,7 +197,7 @@ def test_python_activation_view(tmpdir, python_and_extension_dirs):
     assert os.path.exists(os.path.join(view_dir, 'bin/py-ext-tool'))
 
 
-def test_python_ignore_namespace_init_conflict(tmpdir, namespace_extensions):
+def test_python_ignore_namespace_init_conflict(tmpdir, namespace_extensions, builtin_and_mock_packages):
     """Test the view update logic in PythonPackage ignores conflicting
        instances of __init__ for packages which are in the same namespace.
     """
@@ -222,10 +206,10 @@ def test_python_ignore_namespace_init_conflict(tmpdir, namespace_extensions):
     python_spec = spack.spec.Spec('python@2.7.12')
     python_spec._concrete = True
 
-    ext1_pkg = FakePythonExtensionPackage(
-        'py-extension1', ext1_prefix, py_namespace, python_spec)
-    ext2_pkg = FakePythonExtensionPackage(
-        'py-extension2', ext2_prefix, py_namespace, python_spec)
+    ext1_pkg = create_python_ext_pkg('py-extension1', ext1_prefix, python_spec,
+                                    py_namespace)
+    ext2_pkg = create_python_ext_pkg('py-extension2', ext2_prefix, python_spec,
+                                    py_namespace)
 
     view_dir = str(tmpdir.join('view'))
     layout = YamlDirectoryLayout(view_dir)
@@ -246,7 +230,7 @@ def test_python_ignore_namespace_init_conflict(tmpdir, namespace_extensions):
     assert os.path.exists(os.path.join(view_dir, init_file))
 
 
-def test_python_keep_namespace_init(tmpdir, namespace_extensions):
+def test_python_keep_namespace_init(tmpdir, namespace_extensions, builtin_and_mock_packages):
     """Test the view update logic in PythonPackage keeps the namespace
        __init__ file as long as one package in the namespace still
        exists.
@@ -256,10 +240,10 @@ def test_python_keep_namespace_init(tmpdir, namespace_extensions):
     python_spec = spack.spec.Spec('python@2.7.12')
     python_spec._concrete = True
 
-    ext1_pkg = FakePythonExtensionPackage(
-        'py-extension1', ext1_prefix, py_namespace, python_spec)
-    ext2_pkg = FakePythonExtensionPackage(
-        'py-extension2', ext2_prefix, py_namespace, python_spec)
+    ext1_pkg = create_python_ext_pkg('py-extension1', ext1_prefix, python_spec,
+                                    py_namespace)
+    ext2_pkg = create_python_ext_pkg('py-extension2', ext2_prefix, python_spec,
+                                    py_namespace)
 
     view_dir = str(tmpdir.join('view'))
     layout = YamlDirectoryLayout(view_dir)
@@ -287,7 +271,7 @@ def test_python_keep_namespace_init(tmpdir, namespace_extensions):
     assert not os.path.exists(os.path.join(view_dir, init_file))
 
 
-def test_python_namespace_conflict(tmpdir, namespace_extensions):
+def test_python_namespace_conflict(tmpdir, namespace_extensions, builtin_and_mock_packages):
     """Test the view update logic in PythonPackage reports an error when two
        python extensions with different namespaces have a conflicting __init__
        file.
@@ -298,10 +282,10 @@ def test_python_namespace_conflict(tmpdir, namespace_extensions):
     python_spec = spack.spec.Spec('python@2.7.12')
     python_spec._concrete = True
 
-    ext1_pkg = FakePythonExtensionPackage(
-        'py-extension1', ext1_prefix, py_namespace, python_spec)
-    ext2_pkg = FakePythonExtensionPackage(
-        'py-extension2', ext2_prefix, other_namespace, python_spec)
+    ext1_pkg = create_python_ext_pkg('py-extension1', ext1_prefix, python_spec,
+                                    py_namespace)
+    ext2_pkg = create_python_ext_pkg('py-extension2', ext2_prefix, python_spec,
+                                    other_namespace)
 
     view_dir = str(tmpdir.join('view'))
     layout = YamlDirectoryLayout(view_dir)
@@ -315,7 +299,7 @@ def test_python_namespace_conflict(tmpdir, namespace_extensions):
 
 
 @pytest.fixture()
-def perl_and_extension_dirs(tmpdir):
+def perl_and_extension_dirs(tmpdir, builtin_and_mock_packages):
     perl_dirs = {
         'bin/': {
             'perl': None
@@ -360,7 +344,7 @@ def perl_and_extension_dirs(tmpdir):
     return str(perl_prefix), str(ext_prefix)
 
 
-def test_perl_activation(tmpdir):
+def test_perl_activation(tmpdir, builtin_and_mock_packages):
     # Note the lib directory is based partly on the perl version
     perl_spec = spack.spec.Spec('perl@5.24.1')
     perl_spec._concrete = True
@@ -375,20 +359,20 @@ def test_perl_activation(tmpdir):
 
     ext_name = 'perl-extension'
     tmpdir.ensure(ext_name, dir=True)
-    ext_pkg = FakeExtensionPackage(ext_name, str(tmpdir.join(ext_name)))
+    ext_pkg = create_ext_pkg(ext_name, str(tmpdir.join(ext_name)), perl_spec)
 
     perl_pkg = perl_spec.package
     perl_pkg.activate(ext_pkg, perl_pkg.view())
 
 
-def test_perl_activation_with_files(tmpdir, perl_and_extension_dirs):
+def test_perl_activation_with_files(tmpdir, perl_and_extension_dirs, builtin_and_mock_packages):
     perl_prefix, ext_prefix = perl_and_extension_dirs
 
     perl_spec = spack.spec.Spec('perl@5.24.1')
     perl_spec._concrete = True
     perl_spec.package.spec.prefix = perl_prefix
 
-    ext_pkg = FakeExtensionPackage('perl-extension', ext_prefix)
+    ext_pkg = create_ext_pkg('perl-extension', ext_prefix, perl_spec)
 
     perl_pkg = perl_spec.package
     perl_pkg.activate(ext_pkg, perl_pkg.view())
@@ -396,14 +380,14 @@ def test_perl_activation_with_files(tmpdir, perl_and_extension_dirs):
     assert os.path.exists(os.path.join(perl_prefix, 'bin/perl-ext-tool'))
 
 
-def test_perl_activation_view(tmpdir, perl_and_extension_dirs):
+def test_perl_activation_view(tmpdir, perl_and_extension_dirs, builtin_and_mock_packages):
     perl_prefix, ext_prefix = perl_and_extension_dirs
 
     perl_spec = spack.spec.Spec('perl@5.24.1')
     perl_spec._concrete = True
     perl_spec.package.spec.prefix = perl_prefix
 
-    ext_pkg = FakeExtensionPackage('perl-extension', ext_prefix)
+    ext_pkg = create_ext_pkg('perl-extension', ext_prefix, perl_spec)
 
     view_dir = str(tmpdir.join('view'))
     layout = YamlDirectoryLayout(view_dir)

--- a/lib/spack/spack/test/test_activations.py
+++ b/lib/spack/spack/test/test_activations.py
@@ -5,7 +5,6 @@
 
 import os
 import pytest
-import sys
 
 import spack.spec
 import spack.package

--- a/lib/spack/spack/test/test_activations.py
+++ b/lib/spack/spack/test/test_activations.py
@@ -46,16 +46,11 @@ def create_dir_structure(tmpdir, dir_structure):
 def builtin_and_mock_packages():
     # These tests use mock_repo packages to test functionality of builtin
     # packages. They therefore put the mock repo UNDER the builtin repo.
-    old_path = spack.repo.path
     repo_dirs = [spack.paths.packages_path, spack.paths.mock_packages_path]
     path = RepoPath(*repo_dirs)
-    sys.meta_path.append(path)
-    spack.repo.path = path
 
-    yield
-
-    spack.repo.path = old_path
-    sys.meta_path = sys.meta_path[:-1]
+    with spack.repo.swap(path):
+        yield
 
 
 @pytest.fixture()
@@ -153,8 +148,6 @@ def namespace_extensions(tmpdir, builtin_and_mock_packages):
 
 def test_python_activation_with_files(tmpdir, python_and_extension_dirs,
                                       builtin_and_mock_packages):
-    # Set mock repo to lower precedence than builtin. We can test builtin
-    # python against mock python extensions.
     python_prefix, ext_prefix = python_and_extension_dirs
 
     python_spec = spack.spec.Spec('python@2.7.12')

--- a/lib/spack/spack/test/test_activations.py
+++ b/lib/spack/spack/test/test_activations.py
@@ -44,7 +44,9 @@ def create_dir_structure(tmpdir, dir_structure):
 @pytest.fixture()
 def builtin_and_mock_packages():
     # These tests use mock_repo packages to test functionality of builtin
-    # packages. They therefore put the mock repo UNDER the builtin repo.
+    # packages for python and perl. To test this we put the mock repo at lower
+    # precedence than the builtin repo, so we test builtin.perl against
+    # builtin.mock.perl-extension.
     repo_dirs = [spack.paths.packages_path, spack.paths.mock_packages_path]
     path = RepoPath(*repo_dirs)
 

--- a/var/spack/repos/builtin.mock/packages/perl-extension/package.py
+++ b/var/spack/repos/builtin.mock/packages/perl-extension/package.py
@@ -1,27 +1,7 @@
-##############################################################################
-# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
-# This file is part of Spack.
-# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
-# LLNL-CODE-647188
-#
-# For details, see https://github.com/spack/spack
-# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License (as
-# published by the Free Software Foundation) version 2.1, February 1999.
-#
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
-# conditions of the GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public
-# License along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-##############################################################################
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from spack import *
 import os.path
 

--- a/var/spack/repos/builtin.mock/packages/perl-extension/package.py
+++ b/var/spack/repos/builtin.mock/packages/perl-extension/package.py
@@ -32,7 +32,6 @@ class PerlExtension(PerlPackage):
     homepage = "http://www.example.com"
     url      = "http://www.example.com/extension1-1.0.tar.gz"
 
-
     version('1.0', 'hash-extension-1.0')
     version('2.0', 'hash-extension-2.0')
 
@@ -43,6 +42,7 @@ class PerlExtension(PerlPackage):
 
     # Give the package a hook to set the extendee spec
     extends_spec = 'perl'
+
     @property
     def extendee_spec(self):
         return self.extends_spec

--- a/var/spack/repos/builtin.mock/packages/perl-extension/package.py
+++ b/var/spack/repos/builtin.mock/packages/perl-extension/package.py
@@ -1,0 +1,48 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+import os.path
+
+
+class PerlExtension(PerlPackage):
+    """A package which extends perl"""
+
+    homepage = "http://www.example.com"
+    url      = "http://www.example.com/extension1-1.0.tar.gz"
+
+
+    version('1.0', 'hash-extension-1.0')
+    version('2.0', 'hash-extension-2.0')
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        with open(os.path.join(prefix.bin, 'perl-extension'), 'w+') as fout:
+            fout.write(str(spec.version))
+
+    # Give the package a hook to set the extendee spec
+    extends_spec = 'perl'
+    @property
+    def extendee_spec(self):
+        return self.extends_spec

--- a/var/spack/repos/builtin.mock/packages/perl/package.py
+++ b/var/spack/repos/builtin.mock/packages/perl/package.py
@@ -1,0 +1,38 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Perl(Package):
+    """Dummy Perl package to allow a dummy perl-extension in repo."""
+    homepage = "http://www.python.org"
+    url      = "http://www.python.org/ftp/python/2.7.8/Python-2.7.8.tgz"
+
+    extendable = True
+
+    version('0.0.0', 'hash')
+
+    def install(self, spec, prefix):
+        pass

--- a/var/spack/repos/builtin.mock/packages/perl/package.py
+++ b/var/spack/repos/builtin.mock/packages/perl/package.py
@@ -1,27 +1,7 @@
-##############################################################################
-# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
-# This file is part of Spack.
-# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
-# LLNL-CODE-647188
-#
-# For details, see https://github.com/spack/spack
-# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License (as
-# published by the Free Software Foundation) version 2.1, February 1999.
-#
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
-# conditions of the GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public
-# License along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-##############################################################################
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from spack import *
 
 

--- a/var/spack/repos/builtin.mock/packages/py-extension1/package.py
+++ b/var/spack/repos/builtin.mock/packages/py-extension1/package.py
@@ -32,7 +32,6 @@ class PyExtension1(PythonPackage):
     homepage = "http://www.example.com"
     url      = "http://www.example.com/extension1-1.0.tar.gz"
 
-
     version('1.0', 'hash-extension1-1.0')
     version('2.0', 'hash-extension1-2.0')
 
@@ -43,6 +42,7 @@ class PyExtension1(PythonPackage):
 
     # Give the package a hook to set the extendee spec
     extends_spec = 'python'
+
     @property
     def extendee_spec(self):
         return self.extends_spec

--- a/var/spack/repos/builtin.mock/packages/py-extension1/package.py
+++ b/var/spack/repos/builtin.mock/packages/py-extension1/package.py
@@ -1,27 +1,7 @@
-##############################################################################
-# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
-# This file is part of Spack.
-# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
-# LLNL-CODE-647188
-#
-# For details, see https://github.com/spack/spack
-# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License (as
-# published by the Free Software Foundation) version 2.1, February 1999.
-#
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
-# conditions of the GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public
-# License along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-##############################################################################
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from spack import *
 import os.path
 

--- a/var/spack/repos/builtin.mock/packages/py-extension1/package.py
+++ b/var/spack/repos/builtin.mock/packages/py-extension1/package.py
@@ -1,0 +1,48 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+import os.path
+
+
+class PyExtension1(PythonPackage):
+    """A package which extends python"""
+
+    homepage = "http://www.example.com"
+    url      = "http://www.example.com/extension1-1.0.tar.gz"
+
+
+    version('1.0', 'hash-extension1-1.0')
+    version('2.0', 'hash-extension1-2.0')
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        with open(os.path.join(prefix.bin, 'py-extension1'), 'w+') as fout:
+            fout.write(str(spec.version))
+
+    # Give the package a hook to set the extendee spec
+    extends_spec = 'python'
+    @property
+    def extendee_spec(self):
+        return self.extends_spec

--- a/var/spack/repos/builtin.mock/packages/py-extension2/package.py
+++ b/var/spack/repos/builtin.mock/packages/py-extension2/package.py
@@ -1,27 +1,7 @@
-##############################################################################
-# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
-# This file is part of Spack.
-# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
-# LLNL-CODE-647188
-#
-# For details, see https://github.com/spack/spack
-# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License (as
-# published by the Free Software Foundation) version 2.1, February 1999.
-#
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
-# conditions of the GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public
-# License along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-##############################################################################
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from spack import *
 import os.path
 

--- a/var/spack/repos/builtin.mock/packages/py-extension2/package.py
+++ b/var/spack/repos/builtin.mock/packages/py-extension2/package.py
@@ -44,6 +44,7 @@ class PyExtension2(PythonPackage):
 
     # Give the package a hook to set the extendee spec
     extends_spec = 'python'
+
     @property
     def extendee_spec(self):
         return self.extends_spec

--- a/var/spack/repos/builtin.mock/packages/py-extension2/package.py
+++ b/var/spack/repos/builtin.mock/packages/py-extension2/package.py
@@ -1,0 +1,49 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+import os.path
+
+
+class PyExtension2(PythonPackage):
+    """A package which extends python. It also depends on another
+       package which extends the same package."""
+
+    homepage = "http://www.example.com"
+    url      = "http://www.example.com/extension2-1.0.tar.gz"
+
+    depends_on('py-extension1', type=('build', 'run'))
+
+    version('1.0', 'hash-extension2-1.0')
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        with open(os.path.join(prefix.bin, 'py-extension2'), 'w+') as fout:
+            fout.write(str(spec.version))
+
+    # Give the package a hook to set the extendee spec
+    extends_spec = 'python'
+    @property
+    def extendee_spec(self):
+        return self.extends_spec

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -717,7 +717,8 @@ class Python(AutotoolsPackage):
                 copy(src, dst)
                 if 'script' in get_filetype(src):
                     filter_file(
-                        self.spec.prefix, os.path.abspath(view.root), dst)
+                        self.spec.prefix, os.path.abspath(view.root), dst,
+                        backup=False)
             else:
                 orig_link_target = os.path.realpath(src)
                 new_link_target = os.path.abspath(merge_map[orig_link_target])

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -694,7 +694,9 @@ class Python(AutotoolsPackage):
         exts = extensions_layout.extension_map(self.spec)
         exts[ext_pkg.name] = ext_pkg.spec
 
-        self.write_easy_install_pth(exts, prefix=view.root)
+        self.write_easy_install_pth(exts, prefix=view.get_projection_for_spec(
+            self.spec
+        ))
 
     def deactivate(self, ext_pkg, view, **args):
         args.update(ignore=self.python_ignore(ext_pkg, args))
@@ -706,7 +708,10 @@ class Python(AutotoolsPackage):
         # Make deactivate idempotent
         if ext_pkg.name in exts:
             del exts[ext_pkg.name]
-            self.write_easy_install_pth(exts, prefix=view.root)
+            self.write_easy_install_pth(exts,
+                                        prefix=view.get_projection_for_spec(
+                                            self.spec
+                                        ))
 
     def add_files_to_view(self, view, merge_map):
         bin_dir = self.spec.prefix.bin
@@ -717,8 +722,13 @@ class Python(AutotoolsPackage):
                 copy(src, dst)
                 if 'script' in get_filetype(src):
                     filter_file(
-                        self.spec.prefix, os.path.abspath(view.root), dst,
-                        backup=False)
+                        self.spec.prefix,
+                        os.path.abspath(
+                            view.get_projection_for_spec(self.spec)
+                        ),
+                        dst,
+                        backup=False
+                    )
             else:
                 orig_link_target = os.path.realpath(src)
                 new_link_target = os.path.abspath(merge_map[orig_link_target])


### PR DESCRIPTION
Allow views to specify projections more complicated than merging every package into a shared prefix. This will allow sites to configure a view for the way they want to present packages to their users.

- [x] Create a yaml schema for specifying projections of packages into a view (based on spec.format strings)
- [x] Formalize the schema and check for adherence
- [x] Ensure that extensions work with combinatorial views
- [x] Update spec.format to allow dependency information in format strings
- [x] Add testing for combinatorial views
- [x] Update documentation for views with options for specifying projections

From the new documentation for views:

The default projection into a view is to link every package into the
root of the view. This can be changed through the ``projections.yaml``
file in the view. The projection configuration file for a view located
at ``/my/view`` is stored in ``/my/view/.spack/projections.yaml``.

When creating a view, the projection configuration file can also be
specified from the command line using the ``--projection-file`` option
to the ``spack view`` command.

The projections configuration file is a mapping of partial specs to
spec format strings, as shown in the example below.

```
projections:
    zlib: ${PACKAGE}-${VERSION}
    ^mpi: ${PACKAGE}-${VERSION}/${DEP:mpi:PACKAGE}-${DEP:mpi:VERSION}-${COMPILERNAME}-${COMPILERVER}
    all: ${PACKAGE}-${VERSION}/${COMPILERNAME}-${COMPILERVER}
```

The entries in the projections configuration file must all be either
specs or the keyword ``all``. ~~For each spec, the projection used will
be the first **non-``all``** entry that the spec satisfies, or the projection for the 
``all`` entry if one exists and the spec satisfies no other entries ~~and the keyword ``all`` is
satisfied by any spec~~. Given the example above, any spec satisfying
``zlib@1.2.8`` will be linked into ``/my/view/zlib-1.2.8/``, any spec
satisfying ``hdf5@1.8.10+mpi %gcc@4.9.3 ^mvapich2@2.2`` will be linked
into ``/my/view/hdf5-1.8.10/mvapich2-2.2-gcc-4.9.3``, and any spec
satisfying ``hdf5@1.8.10~mpi %gcc@4.9.3`` will be linked into
``/my/view/hdf5-1.8.10/gcc-4.9.3``.

If the keyword ``all`` does not appear in the projections
configuration file, any spec that does not satisfy any entry in the
file will be linked into the root of the view as in a single-prefix
view. ~~Any entries that appear below the keyword ``all`` in the
projections configuration file will not be used, as all specs will use
the projection under ``all`` before reaching those entries.~~