### PR TITLE
Added OpenMPI 3.1.3 and a patch

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/btl_vader.patch
+++ b/var/spack/repos/builtin/packages/openmpi/btl_vader.patch
@@ -1,0 +1,24 @@
+diff --git a/opal/mca/btl/vader/btl_vader_fbox.h b/opal/mca/btl/vader/btl_vader_fbox.h
+index 17239ce8ef..ee5c913551 100644
+--- a/opal/mca/btl/vader/btl_vader_fbox.h
++++ b/opal/mca/btl/vader/btl_vader_fbox.h
+@@ -138,9 +138,6 @@ static inline bool mca_btl_vader_fbox_sendi (mca_btl_base_endpoint_t *ep, unsign
+         memcpy (data + header_size, payload, payload_size);
+     }
+ 
+-    /* write out part of the header now. the tag will be written when the data is available */
+-    mca_btl_vader_fbox_set_header (MCA_BTL_VADER_FBOX_HDR(dst), tag, ep->fbox_out.seq++, data_size);
+-
+     end += size;
+ 
+     if (OPAL_UNLIKELY(fbox_size == end)) {
+@@ -152,6 +149,9 @@ static inline bool mca_btl_vader_fbox_sendi (mca_btl_base_endpoint_t *ep, unsign
+         MCA_BTL_VADER_FBOX_HDR(ep->fbox_out.buffer + end)->ival = 0;
+     }
+ 
++    /* write out part of the header now. the tag will be written when the data is available */
++    mca_btl_vader_fbox_set_header (MCA_BTL_VADER_FBOX_HDR(dst), tag, ep->fbox_out.seq++, data_size);
++
+     /* align the buffer */
+     ep->fbox_out.end = ((uint32_t) hbs << 31) | end;
+     opal_atomic_wmb ();

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -64,6 +64,7 @@ class Openmpi(AutotoolsPackage):
     list_url = "http://www.open-mpi.org/software/ompi/"
 
     # Current
+    version('3.1.3', sha256='8be04307c00f51401d3fb9d837321781ea7c79f2a5a4a2e5d4eaedc874087ab6')
     version('3.1.2', '210df69fafd964158527e7f37e333239')  # libmpi.so.40.10.2
     version('3.1.1', '493f1db2f75afaab1c8ecba78d2f5aab')  # libmpi.so.40.10.1
     version('3.1.0', '0895e268ca27735d7654bf64cee6c256')  # libmpi.so.40.10.0
@@ -165,6 +166,14 @@ class Openmpi(AutotoolsPackage):
     patch('llnl-platforms.patch', when="@1.6.5")
     patch('configure.patch', when="@1.10.1")
     patch('fix_multidef_pmi_class.patch', when="@2.0.0:2.0.1")
+
+    # Vader Bug: https://github.com/open-mpi/ompi/issues/5375
+    # Haven't release fix for 2.1.x
+    patch('btl_vader.patch', when='@2.1.3:2.1.5')
+
+    # Fixed in 3.0.3 and 3.1.3
+    patch('btl_vader.patch', when='@3.0.1:3.0.2')
+    patch('btl_vader.patch', when='@3.1.0:3.1.2')
 
     fabrics = ('psm', 'psm2', 'verbs', 'mxm', 'ucx', 'libfabric')
 


### PR DESCRIPTION
Vader bug causes some MPI codes to sporadically segfault.