### PR TITLE
Fix #9673 : build fonts on powerpc architecture

### DIFF
--- a/var/spack/repos/builtin/packages/font-adobe-100dpi/package.py
+++ b/var/spack/repos/builtin/packages/font-adobe-100dpi/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class FontAdobe100dpi(Package):
+class FontAdobe100dpi(AutotoolsPackage):
     """X.org adobe-100dpi font."""
 
     homepage = "http://cgit.freedesktop.org/xorg/font/adobe-100dpi"
@@ -23,9 +23,6 @@ class FontAdobe100dpi(Package):
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
-        configure('--prefix={0}'.format(prefix))
-
-        make()
         make('install')
 
         # `make install` copies the files to the font-util installation.

--- a/var/spack/repos/builtin/packages/font-adobe-75dpi/package.py
+++ b/var/spack/repos/builtin/packages/font-adobe-75dpi/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class FontAdobe75dpi(Package):
+class FontAdobe75dpi(AutotoolsPackage):
     """X.org adobe-75dpi font."""
 
     homepage = "http://cgit.freedesktop.org/xorg/font/adobe-75dpi"
@@ -23,9 +23,6 @@ class FontAdobe75dpi(Package):
     depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
-        configure('--prefix={0}'.format(prefix))
-
-        make()
         make('install')
 
         # `make install` copies the files to the font-util installation.


### PR DESCRIPTION
Move  font packages from Package to AutotoolsPackage that update file config.guess with newer arch guess.
Fix #9673