### PR TITLE
static_to_shared_library: breaks with lua build on osx with brew/gcc

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -497,16 +497,16 @@ def _static_to_shared_library(arch, compiler, static_lib, shared_lib=None,
 
         compiler_args = [
             '-dynamiclib',
-            '-install_name {0}'.format(install_name),
+            '-install_name', '{0}'.format(install_name),
             '-Wl,-force_load,{0}'.format(static_lib)
         ]
 
         if compat_version:
-            compiler_args.append('-compatibility_version {0}'.format(
-                compat_version))
+            compiler_args.extend(['-compatibility_version', '{0}'.format(
+                compat_version)])
 
         if version:
-            compiler_args.append('-current_version {0}'.format(version))
+            compiler_args.extend(['-current_version', '{0}'.format(version)])
 
     if len(arguments) > 0:
         compiler_args.extend(arguments)


### PR DESCRIPTION
```
==> '/Users/balay/spack.x/lib/spack/env/gcc/gcc' '-dynamiclib' '-install_name /Users/balay/spack.x/opt/spack/darwin-mojave-x86_64/gcc-8.2.0/lua-5.3.4-2vmbxjspno7oax3fmnxhohptbnxmfa4y/lib/liblua.dylib.5.3' '-Wl,\
-force_load,/Users/balay/spack.x/opt/spack/darwin-mojave-x86_64/gcc-8.2.0/lua-5.3.4-2vmbxjspno7oax3fmnxhohptbnxmfa4y/lib/liblua.a' '-compatibility_version 5.3' '-current_version 5.3.4' '-lm' '-o' '/Users/balay/\
spack.x/opt/spack/darwin-mojave-x86_64/gcc-8.2.0/lua-5.3.4-2vmbxjspno7oax3fmnxhohptbnxmfa4y/lib/liblua.dylib.5.3.4'
gcc-8: error: unrecognized command line option '-install_name /Users/balay/spack.x/opt/spack/darwin-mojave-x86_64/gcc-8.2.0/lua-5.3.4-2vmbxjspno7oax3fmnxhohptbnxmfa4y/lib/liblua.dylib.5.3'
gcc-8: error: unrecognized command line option '-compatibility_version 5.3'; did you mean '-compatibility_version'?
gcc-8: error: unrecognized command line option '-current_version 5.3.4'; did you mean '-current_version'?
```

cc: @luszczek