### PR TITLE
The vendored ruamel.yaml is imported under the namespace 'external'

### DIFF
--- a/lib/spack/external/ruamel/yaml/__init__.py
+++ b/lib/spack/external/ruamel/yaml/__init__.py
@@ -82,4 +82,4 @@ except (ImportError, ValueError):  # for Jython
 try:
     from .main import *                               # NOQA
 except ImportError:
-    from ruamel.yaml.main import *                               # NOQA
+    from external.ruamel.yaml.main import *                               # NOQA

--- a/lib/spack/external/ruamel/yaml/comments.py
+++ b/lib/spack/external/ruamel/yaml/comments.py
@@ -18,7 +18,7 @@ __all__ = ["CommentedSeq", "CommentedMap", "CommentedOrderedMap",
 try:
     from .compat import ordereddict
 except ImportError:
-    from ruamel.yaml.compat import ordereddict
+    from external.ruamel.yaml.compat import ordereddict
 
 comment_attrib = '_yaml_comment'
 format_attrib = '_yaml_format'

--- a/lib/spack/external/ruamel/yaml/compat.py
+++ b/lib/spack/external/ruamel/yaml/compat.py
@@ -9,7 +9,7 @@ import os
 import types
 
 try:
-    from ruamel.ordereddict import ordereddict
+    from external.ruamel.ordereddict import ordereddict
 except:
     try:
         from collections import OrderedDict  # nopyqver

--- a/lib/spack/external/ruamel/yaml/composer.py
+++ b/lib/spack/external/ruamel/yaml/composer.py
@@ -8,14 +8,14 @@ try:
     from .error import MarkedYAMLError
     from .compat import utf8
 except (ImportError, ValueError):  # for Jython
-    from ruamel.yaml.error import MarkedYAMLError
-    from ruamel.yaml.compat import utf8
+    from external.ruamel.yaml.error import MarkedYAMLError
+    from external.ruamel.yaml.compat import utf8
 
-from ruamel.yaml.events import (
+from external.ruamel.yaml.events import (
     StreamStartEvent, StreamEndEvent, MappingStartEvent, MappingEndEvent,
     SequenceStartEvent, SequenceEndEvent, AliasEvent, ScalarEvent,
 )
-from ruamel.yaml.nodes import (
+from external.ruamel.yaml.nodes import (
     MappingNode, ScalarNode, SequenceNode,
 )
 

--- a/lib/spack/external/ruamel/yaml/configobjwalker.py
+++ b/lib/spack/external/ruamel/yaml/configobjwalker.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 import warnings
-from ruamel.yaml.util import configobj_walker as new_configobj_walker
+from external.ruamel.yaml.util import configobj_walker as new_configobj_walker
 
 
 def configobj_walker(cfg):

--- a/lib/spack/external/ruamel/yaml/constructor.py
+++ b/lib/spack/external/ruamel/yaml/constructor.py
@@ -18,12 +18,12 @@ try:
     from .comments import *                               # NOQA
     from .scalarstring import *                           # NOQA
 except (ImportError, ValueError):  # for Jython
-    from ruamel.yaml.error import *                               # NOQA
-    from ruamel.yaml.nodes import *                               # NOQA
-    from ruamel.yaml.compat import (utf8, builtins_module, to_str, PY2, PY3,
+    from external.ruamel.yaml.error import *                               # NOQA
+    from external.ruamel.yaml.nodes import *                               # NOQA
+    from external.ruamel.yaml.compat import (utf8, builtins_module, to_str, PY2, PY3,
                                     ordereddict, text_type)
-    from ruamel.yaml.comments import *                               # NOQA
-    from ruamel.yaml.scalarstring import *                           # NOQA
+    from external.ruamel.yaml.comments import *                               # NOQA
+    from external.ruamel.yaml.scalarstring import *                           # NOQA
 
 
 __all__ = ['BaseConstructor', 'SafeConstructor', 'Constructor',
@@ -864,7 +864,7 @@ class RoundTripConstructor(SafeConstructor):
             if len(node.comment) > 2:
                 seqtyp.yaml_end_comment_extend(node.comment[2], clear=True)
         if node.anchor:
-            from ruamel.yaml.serializer import templated_id
+            from external.ruamel.yaml.serializer import templated_id
             if not templated_id(node.anchor):
                 seqtyp.yaml_set_anchor(node.anchor)
         for idx, child in enumerate(node.value):
@@ -952,7 +952,7 @@ class RoundTripConstructor(SafeConstructor):
             if len(node.comment) > 2:
                 maptyp.yaml_end_comment_extend(node.comment[2], clear=True)
         if node.anchor:
-            from ruamel.yaml.serializer import templated_id
+            from external.ruamel.yaml.serializer import templated_id
             if not templated_id(node.anchor):
                 maptyp.yaml_set_anchor(node.anchor)
         for key_node, value_node in node.value:
@@ -996,7 +996,7 @@ class RoundTripConstructor(SafeConstructor):
             if len(node.comment) > 2:
                 typ.yaml_end_comment_extend(node.comment[2], clear=True)
         if node.anchor:
-            from ruamel.yaml.serializer import templated_id
+            from external.ruamel.yaml.serializer import templated_id
             if not templated_id(node.anchor):
                 typ.yaml_set_anchor(node.anchor)
         for key_node, value_node in node.value:

--- a/lib/spack/external/ruamel/yaml/dumper.py
+++ b/lib/spack/external/ruamel/yaml/dumper.py
@@ -10,10 +10,10 @@ try:
     from .representer import *                               # NOQA
     from .resolver import *                               # NOQA
 except (ImportError, ValueError):  # for Jython
-    from ruamel.yaml.emitter import *                               # NOQA
-    from ruamel.yaml.serializer import *                               # NOQA
-    from ruamel.yaml.representer import *                               # NOQA
-    from ruamel.yaml.resolver import *                               # NOQA
+    from external.ruamel.yaml.emitter import *                               # NOQA
+    from external.ruamel.yaml.serializer import *                               # NOQA
+    from external.ruamel.yaml.representer import *                               # NOQA
+    from external.ruamel.yaml.resolver import *                               # NOQA
 
 
 class BaseDumper(Emitter, Serializer, BaseRepresenter, BaseResolver):

--- a/lib/spack/external/ruamel/yaml/emitter.py
+++ b/lib/spack/external/ruamel/yaml/emitter.py
@@ -17,9 +17,9 @@ try:
     from .events import *                                                # NOQA
     from .compat import utf8, text_type, PY2, nprint, dbg, DBG_EVENT
 except (ImportError, ValueError):  # for Jython
-    from ruamel.yaml.error import YAMLError
-    from ruamel.yaml.events import *                                     # NOQA
-    from ruamel.yaml.compat import utf8, text_type, PY2, nprint, dbg, DBG_EVENT
+    from external.ruamel.yaml.error import YAMLError
+    from external.ruamel.yaml.events import *                                     # NOQA
+    from external.ruamel.yaml.compat import utf8, text_type, PY2, nprint, dbg, DBG_EVENT
 
 
 class EmitterError(YAMLError):

--- a/lib/spack/external/ruamel/yaml/error.py
+++ b/lib/spack/external/ruamel/yaml/error.py
@@ -7,7 +7,7 @@ __all__ = ['Mark', 'YAMLError', 'MarkedYAMLError']
 try:
     from .compat import utf8
 except (ImportError, ValueError):  # for Jython
-    from ruamel.yaml.compat import utf8
+    from external.ruamel.yaml.compat import utf8
 
 
 class Mark(object):

--- a/lib/spack/external/ruamel/yaml/loader.py
+++ b/lib/spack/external/ruamel/yaml/loader.py
@@ -12,12 +12,12 @@ try:
     from .constructor import *                           # NOQA
     from .resolver import *                              # NOQA
 except (ImportError, ValueError):  # for Jython
-    from ruamel.yaml.reader import *                                # NOQA
-    from ruamel.yaml.scanner import *                               # NOQA
-    from ruamel.yaml.parser import *                                # NOQA
-    from ruamel.yaml.composer import *                              # NOQA
-    from ruamel.yaml.constructor import *                           # NOQA
-    from ruamel.yaml.resolver import *                              # NOQA
+    from external.ruamel.yaml.reader import *                                # NOQA
+    from external.ruamel.yaml.scanner import *                               # NOQA
+    from external.ruamel.yaml.parser import *                                # NOQA
+    from external.ruamel.yaml.composer import *                              # NOQA
+    from external.ruamel.yaml.constructor import *                           # NOQA
+    from external.ruamel.yaml.resolver import *                              # NOQA
 
 
 class BaseLoader(Reader, Scanner, Parser, Composer, BaseConstructor, BaseResolver):

--- a/lib/spack/external/ruamel/yaml/main.py
+++ b/lib/spack/external/ruamel/yaml/main.py
@@ -3,15 +3,15 @@
 from __future__ import absolute_import
 
 
-from ruamel.yaml.error import *                                # NOQA
+from external.ruamel.yaml.error import *                                # NOQA
 
-from ruamel.yaml.tokens import *                               # NOQA
-from ruamel.yaml.events import *                               # NOQA
-from ruamel.yaml.nodes import *                                # NOQA
+from external.ruamel.yaml.tokens import *                               # NOQA
+from external.ruamel.yaml.events import *                               # NOQA
+from external.ruamel.yaml.nodes import *                                # NOQA
 
-from ruamel.yaml.loader import *                               # NOQA
-from ruamel.yaml.dumper import *                               # NOQA
-from ruamel.yaml.compat import StringIO, BytesIO, with_metaclass, PY3
+from external.ruamel.yaml.loader import *                               # NOQA
+from external.ruamel.yaml.dumper import *                               # NOQA
+from external.ruamel.yaml.compat import StringIO, BytesIO, with_metaclass, PY3
 
 # import io
 

--- a/lib/spack/external/ruamel/yaml/parser.py
+++ b/lib/spack/external/ruamel/yaml/parser.py
@@ -76,11 +76,11 @@ __all__ = ['Parser', 'RoundTripParser', 'ParserError']
 # need to have full path, as pkg_resources tries to load parser.py in __init__.py
 # only to not do anything with the package afterwards
 # and for Jython too
-from ruamel.yaml.error import MarkedYAMLError                  # NOQA
-from ruamel.yaml.tokens import *                               # NOQA
-from ruamel.yaml.events import *                               # NOQA
-from ruamel.yaml.scanner import *                              # NOQA
-from ruamel.yaml.compat import utf8                            # NOQA
+from external.ruamel.yaml.error import MarkedYAMLError                  # NOQA
+from external.ruamel.yaml.tokens import *                               # NOQA
+from external.ruamel.yaml.events import *                               # NOQA
+from external.ruamel.yaml.scanner import *                              # NOQA
+from external.ruamel.yaml.compat import utf8                            # NOQA
 
 
 class ParserError(MarkedYAMLError):

--- a/lib/spack/external/ruamel/yaml/reader.py
+++ b/lib/spack/external/ruamel/yaml/reader.py
@@ -27,8 +27,8 @@ try:
     from .error import YAMLError, Mark
     from .compat import text_type, binary_type, PY3
 except (ImportError, ValueError):  # for Jython
-    from ruamel.yaml.error import YAMLError, Mark
-    from ruamel.yaml.compat import text_type, binary_type, PY3
+    from external.ruamel.yaml.error import YAMLError, Mark
+    from external.ruamel.yaml.compat import text_type, binary_type, PY3
 
 __all__ = ['Reader', 'ReaderError']
 

--- a/lib/spack/external/ruamel/yaml/representer.py
+++ b/lib/spack/external/ruamel/yaml/representer.py
@@ -9,10 +9,10 @@ try:
     from .compat import text_type, binary_type, to_unicode, PY2, PY3, ordereddict
     from .scalarstring import *                           # NOQA
 except (ImportError, ValueError):  # for Jython
-    from ruamel.yaml.error import *                       # NOQA
-    from ruamel.yaml.nodes import *                       # NOQA
-    from ruamel.yaml.compat import text_type, binary_type, to_unicode, PY2, PY3, ordereddict
-    from ruamel.yaml.scalarstring import *                # NOQA
+    from external.ruamel.yaml.error import *                       # NOQA
+    from external.ruamel.yaml.nodes import *                       # NOQA
+    from external.ruamel.yaml.compat import text_type, binary_type, to_unicode, PY2, PY3, ordereddict
+    from external.ruamel.yaml.scalarstring import *                # NOQA
 
 
 import datetime
@@ -582,7 +582,7 @@ try:
     from .comments import CommentedMap, CommentedOrderedMap, CommentedSeq, \
         CommentedSet, comment_attrib, merge_attrib
 except ImportError:  # for Jython
-    from ruamel.yaml.comments import CommentedMap, CommentedOrderedMap, \
+    from external.ruamel.yaml.comments import CommentedMap, CommentedOrderedMap, \
         CommentedSeq, CommentedSet, comment_attrib, merge_attrib
 
 

--- a/lib/spack/external/ruamel/yaml/resolver.py
+++ b/lib/spack/external/ruamel/yaml/resolver.py
@@ -9,9 +9,9 @@ try:
     from .nodes import *                               # NOQA
     from .compat import string_types
 except (ImportError, ValueError):  # for Jython
-    from ruamel.yaml.error import *                               # NOQA
-    from ruamel.yaml.nodes import *                               # NOQA
-    from ruamel.yaml.compat import string_types
+    from external.ruamel.yaml.error import *                               # NOQA
+    from external.ruamel.yaml.nodes import *                               # NOQA
+    from external.ruamel.yaml.compat import string_types
 
 __all__ = ['BaseResolver', 'Resolver', 'VersionedResolver']
 

--- a/lib/spack/external/ruamel/yaml/scalarstring.py
+++ b/lib/spack/external/ruamel/yaml/scalarstring.py
@@ -9,7 +9,7 @@ __all__ = ["ScalarString", "PreservedScalarString", "SingleQuotedScalarString",
 try:
     from .compat import text_type
 except (ImportError, ValueError):  # for Jython
-    from ruamel.yaml.compat import text_type
+    from external.ruamel.yaml.compat import text_type
 
 
 class ScalarString(text_type):
@@ -42,7 +42,7 @@ def walk_tree(base):
     dict values and list items) and converts strings that
     have multiple lines to literal scalars
     """
-    from ruamel.yaml.compat import string_types
+    from external.ruamel.yaml.compat import string_types
 
     if isinstance(base, dict):
         for k in base:

--- a/lib/spack/external/ruamel/yaml/scanner.py
+++ b/lib/spack/external/ruamel/yaml/scanner.py
@@ -38,9 +38,9 @@ try:
     from .tokens import *                           # NOQA
     from .compat import utf8, unichr, PY3
 except (ImportError, ValueError):  # for Jython
-    from ruamel.yaml.error import MarkedYAMLError
-    from ruamel.yaml.tokens import *                # NOQA
-    from ruamel.yaml.compat import utf8, unichr, PY3
+    from external.ruamel.yaml.error import MarkedYAMLError
+    from external.ruamel.yaml.tokens import *                # NOQA
+    from external.ruamel.yaml.compat import utf8, unichr, PY3
 
 
 class ScannerError(MarkedYAMLError):

--- a/lib/spack/external/ruamel/yaml/serializer.py
+++ b/lib/spack/external/ruamel/yaml/serializer.py
@@ -8,15 +8,15 @@ try:
     from .error import YAMLError
     from .compat import nprint, DBG_NODE, dbg, string_types
 except (ImportError, ValueError):  # for Jython
-    from ruamel.yaml.error import YAMLError
-    from ruamel.yaml.compat import nprint, DBG_NODE, dbg, string_types
+    from external.ruamel.yaml.error import YAMLError
+    from external.ruamel.yaml.compat import nprint, DBG_NODE, dbg, string_types
 
-from ruamel.yaml.events import (
+from external.ruamel.yaml.events import (
     StreamStartEvent, StreamEndEvent, MappingStartEvent, MappingEndEvent,
     SequenceStartEvent, SequenceEndEvent, AliasEvent, ScalarEvent,
     DocumentStartEvent, DocumentEndEvent,
 )
-from ruamel.yaml.nodes import (
+from external.ruamel.yaml.nodes import (
     MappingNode, ScalarNode, SequenceNode,
 )
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -12,7 +12,7 @@ import tempfile
 import hashlib
 from contextlib import closing
 
-import ruamel.yaml as yaml
+import external.ruamel.yaml as yaml
 
 import llnl.util.tty as tty
 from llnl.util.filesystem import mkdirp, install_tree, get_filetype
@@ -586,14 +586,14 @@ def get_keys(install=False, trust=False, force=False):
             tty.msg("Finding public keys in %s" % mirror)
             files = os.listdir(mirror)
             for file in files:
-                if re.search('\.key', file):
+                if re.search(r'\.key', file):
                     link = 'file://' + mirror + '/' + file
                     keys.add(link)
         else:
             tty.msg("Finding public keys on %s" % url)
             p, links = spider(url + "/build_cache", depth=1)
             for link in links:
-                if re.search("\.key", link):
+                if re.search(r"\.key", link):
                     keys.add(link)
         for link in keys:
             with Stage(link, name="build_cache", keep=True) as stage:

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -42,8 +42,8 @@ from six import string_types
 from six import iteritems
 from ordereddict_backport import OrderedDict
 
-import ruamel.yaml as yaml
-from ruamel.yaml.error import MarkedYAMLError
+import external.ruamel.yaml as yaml
+from external.ruamel.yaml.error import MarkedYAMLError
 
 import llnl.util.lang
 import llnl.util.tty as tty

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -29,7 +29,7 @@ import contextlib
 from six import string_types
 from six import iteritems
 
-from ruamel.yaml.error import MarkedYAMLError, YAMLError
+from external.ruamel.yaml.error import MarkedYAMLError, YAMLError
 
 import llnl.util.tty as tty
 from llnl.util.filesystem import mkdirp

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -9,7 +9,7 @@ import glob
 import tempfile
 import re
 
-import ruamel.yaml as yaml
+import external.ruamel.yaml as yaml
 
 from llnl.util.filesystem import mkdirp, chgrp
 
@@ -171,7 +171,7 @@ class YamlDirectoryLayout(DirectoryLayout):
             "${COMPILERNAME}-${COMPILERVER}/"
             "${PACKAGE}-${VERSION}-${HASH}")
         if self.hash_len is not None:
-            if re.search('\${HASH:\d+}', self.path_scheme):
+            if re.search(r'\${HASH:\d+}', self.path_scheme):
                 raise InvalidDirectoryLayoutParametersError(
                     "Conflicting options for installation layout hash length")
             self.path_scheme = self.path_scheme.replace(

--- a/lib/spack/spack/provider_index.py
+++ b/lib/spack/spack/provider_index.py
@@ -12,7 +12,7 @@ from pprint import pformat
 
 import spack.error
 import spack.util.spack_yaml as syaml
-from ruamel.yaml.error import MarkedYAMLError
+from external.ruamel.yaml.error import MarkedYAMLError
 
 
 class ProviderIndex(object):

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -23,7 +23,7 @@ except ImportError:
 
 from types import ModuleType
 
-import ruamel.yaml as yaml
+import external.ruamel.yaml as yaml
 
 import llnl.util.lang
 import llnl.util.tty as tty

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -120,7 +120,7 @@ from spack.variant import VariantMap, UnknownVariantError
 from spack.variant import DuplicateVariantError
 from spack.variant import UnsatisfiableVariantSpecError
 from spack.version import VersionList, VersionRange, Version, ver
-from ruamel.yaml.error import MarkedYAMLError
+from external.ruamel.yaml.error import MarkedYAMLError
 
 __all__ = [
     'Spec',

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -11,7 +11,7 @@ import tempfile
 from llnl.util.filesystem import touch, mkdirp
 
 import pytest
-import ruamel.yaml as yaml
+import external.ruamel.yaml as yaml
 
 import spack.paths
 import spack.config

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -14,7 +14,7 @@ import re
 import ordereddict_backport
 import py
 import pytest
-import ruamel.yaml as yaml
+import external.ruamel.yaml as yaml
 
 from llnl.util.filesystem import remove_linked_tree
 
@@ -285,7 +285,7 @@ def mutable_config(tmpdir_factory, configuration_dir, config):
 
 
 def _populate(mock_db):
-    """Populate a mock database with packages.
+    r"""Populate a mock database with packages.
 
     Here is what the mock DB looks like:
 

--- a/lib/spack/spack/test/modules/conftest.py
+++ b/lib/spack/spack/test/modules/conftest.py
@@ -8,7 +8,7 @@ import collections
 import contextlib
 import inspect
 
-import ruamel.yaml as yaml
+import external.ruamel.yaml as yaml
 import pytest
 from six import StringIO
 

--- a/lib/spack/spack/util/spack_yaml.py
+++ b/lib/spack/spack/util/spack_yaml.py
@@ -15,10 +15,10 @@
 from ordereddict_backport import OrderedDict
 from six import string_types, StringIO
 
-import ruamel.yaml as yaml
-from ruamel.yaml import Loader, Dumper
-from ruamel.yaml.nodes import MappingNode, SequenceNode, ScalarNode
-from ruamel.yaml.constructor import ConstructorError
+import external.ruamel.yaml as yaml
+from external.ruamel.yaml import Loader, Dumper
+from external.ruamel.yaml.nodes import MappingNode, SequenceNode, ScalarNode
+from external.ruamel.yaml.constructor import ConstructorError
 
 from llnl.util.tty.color import colorize, clen, cextra
 


### PR DESCRIPTION
fixes #9619
fixes #9206

closes #9261 (alternative solution to the same issue)
closes #9725 (alternative solution to the same issue)

`ruamel.yaml` generates a `.pth` file when installed via pip that has the effect of always preferring the version of this package installed at site scope (effectively preventing us from vendoring it). Here we work around the issue by putting our vendored version of the package under an additional namespace.

Note that we do this only for `ruamel.yaml` rather than consistently for every vendored dependency to avoid extensive changes in their source code, see https://github.com/spack/spack/issues/9206#issuecomment-435041643