### PR TITLE
migrate: new package starting at 3.6.11

### DIFF
--- a/var/spack/repos/builtin/packages/migrate/package.py
+++ b/var/spack/repos/builtin/packages/migrate/package.py
@@ -53,7 +53,7 @@ class Migrate(AutotoolsPackage):
                     raise InstallError('Failed to update linker command')
 
                 # don't try to install MPI binaries that aren't there
-                if not '+mpi' in spec:
+                if '+mpi' not in spec:
                     line = '$(INSTALL) $(IFLAGS) $(MPINAME) $(INSTALLDIR)'
                     mfc = mfc.replace(line, '')
 

--- a/var/spack/repos/builtin/packages/migrate/package.py
+++ b/var/spack/repos/builtin/packages/migrate/package.py
@@ -1,0 +1,71 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Migrate(AutotoolsPackage):
+    """Migrate estimates effective population sizes and past migration rates
+       between n population assuming a migration matrix model with asymmetric
+       migration rates and different subpopulation sizes"""
+
+    homepage = "http://popgen.sc.fsu.edu/"
+    url      = "http://popgen.sc.fsu.edu/currentversions/migrate-3.6.11.src.tar.gz"
+
+    version('3.6.11', sha256='a9ba06a4e995a45b8d04037f5f2da23e1fe64a2f3565189bdd50c62c6fe01fb8')
+
+    variant('mpi', default=False,
+            description='Build MPI binaries')
+
+    depends_on('autoconf')
+    depends_on('automake')
+    depends_on('libtool')
+    depends_on('m4')
+
+    depends_on('openmpi', type=('build', 'link', 'run'), when='+mpi')
+
+    configure_directory = 'src'
+
+    def build(self, spec, prefix):
+        with working_dir('src'):
+            # this software is written with parts both in C and C++.
+            # it tries to link using gcc which causes problems, so this package
+            # explicitly links with g++ (CXX) instead.
+
+            # spack's FileFilter/filter_file only work per-line (see docs),
+            # so the package uses a custom filter by replacing substrings
+            # in the Makefile.
+
+            mfc = ''
+            with open('Makefile') as m:
+                mfc = mfc_old = m.read()
+
+                # replace linking step
+                mfc = mfc.replace('$(NAME): $(PRODUCT_DEPENDS)\n\t$(CC)',
+                                  '$(NAME): $(PRODUCT_DEPENDS)\n\t$(CXX)')
+                mfc = mfc.replace('$(MPINAME): $(PRODUCT_DEPENDS)\n\t$(CC)',
+                                  '$(MPINAME): $(PRODUCT_DEPENDS)\n\t$(CXX)')
+
+                # make sure the replace worked
+                if (mfc == mfc_old):
+                    raise InstallError('Failed to update linker command')
+
+                # don't try to install MPI binaries that aren't there
+                if not '+mpi' in spec:
+                    line = '$(INSTALL) $(IFLAGS) $(MPINAME) $(INSTALLDIR)'
+                    mfc = mfc.replace(line, '')
+
+            # write modified makefile back
+            with open('Makefile', 'w') as m:
+                m.write(mfc)
+
+            make()
+            if '+mpi' in spec:
+                make('mpis')
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.man)
+        with working_dir('src'):
+            make('install')


### PR DESCRIPTION
spack's filter_file only works line-by-line and this requires a multiline replacement, so i loaded the file in as a string and performed a normal substring replacement