### PR TITLE
New repo for advanced packaging tutorial

### DIFF
--- a/lib/spack/docs/tutorial_advanced_packaging.rst
+++ b/lib/spack/docs/tutorial_advanced_packaging.rst
@@ -36,7 +36,7 @@ in a separate package repository, which can be enabled with:
 
 .. code-block:: console
 
-  $ spack repo add --scope=defaults tutorial var/spack/repos/tutorial
+  $ spack repo add --scope=site tutorial var/spack/repos/tutorial
 
 If you are using the tutorial docker image, all dependency packages
 will have been installed. Otherwise, to install these packages you can use

--- a/lib/spack/docs/tutorial_advanced_packaging.rst
+++ b/lib/spack/docs/tutorial_advanced_packaging.rst
@@ -36,7 +36,7 @@ in a separate package repository, which can be enabled with:
 
 .. code-block:: console
 
-  $ spack repo add --scope=site tutorial var/spack/repos/tutorial
+  $ spack repo add --scope=site var/spack/repos/tutorial
 
 If you are using the tutorial docker image, all dependency packages
 will have been installed. Otherwise, to install these packages you can use

--- a/lib/spack/docs/tutorial_advanced_packaging.rst
+++ b/lib/spack/docs/tutorial_advanced_packaging.rst
@@ -25,46 +25,22 @@ dependents in your package.
 Setup for the tutorial
 ----------------------
 
-The simplest way to follow along with this tutorial is to use our Docker image,
-which comes with Spack and various packages pre-installed:
+.. note::
+
+  If you are not using the tutorial docker image, it is recommended that you
+  do this section of the tutorial in a fresh clone of Spack
+
+The tutorial uses custom package definitions with missing sections that
+will be filled in during the tutorial. These package definitions are stored
+in a separate package repository, which can be enabled with:
 
 .. code-block:: console
 
-  $ docker pull alalazo/spack:advanced_packaging_tutorial
-  $ docker run --rm -h advanced-packaging-tutorial -it alalazo/spack:advanced_packaging_tutorial
-  root@advanced-packaging-tutorial:/#
-  root@advanced-packaging-tutorial:/# spack find
-  ==> 20 installed packages.
-  -- linux-ubuntu16.04-x86_64 / gcc@5.4.0 -------------------------
-  arpack-ng@3.5.0  hdf5@1.10.1   libpciaccess@0.13.5  libtool@2.4.6  m4@1.4.18  ncurses@6.0          openblas@0.2.20  openssl@1.0.2k     superlu@5.2.1       xz@5.2.3
-  cmake@3.9.4      hwloc@1.11.8  libsigsegv@2.11      libxml2@2.9.4  mpich@3.2  netlib-lapack@3.6.1  openmpi@3.0.0    pkg-config@0.29.2  util-macros@1.19.1  zlib@1.2.11
+  $ spack repo add --scope=defaults tutorial var/spack/repos/tutorial
 
-If you already started the image, you can set the ``EDITOR`` environment
-variable to your preferred editor (``vi``, ``emacs``, and ``nano`` are included in the image)
-and move directly to :ref:`adv_pkg_tutorial_start`.
-
-If you choose not to use the Docker image, you can clone the Spack repository
-and build the necessary bits yourself:
-
-.. code-block:: console
-
-  $ git clone https://github.com/spack/spack.git
-  Cloning into 'spack'...
-  remote: Counting objects: 92731, done.
-  remote: Compressing objects: 100% (1108/1108), done.
-  remote: Total 92731 (delta 1964), reused 4186 (delta 1637), pack-reused 87932
-  Receiving objects: 100% (92731/92731), 33.31 MiB | 64.00 KiB/s, done.
-  Resolving deltas: 100% (43557/43557), done.
-  Checking connectivity... done.
-
-  $ cd spack
-  $ git checkout tutorials/advanced_packaging
-  Branch tutorials/advanced_packaging set up to track remote branch tutorials/advanced_packaging from origin.
-  Switched to a new branch 'tutorials/advanced_packaging'
-
-At this point you can install the software that will be used
-during the rest of the tutorial (the output of the commands is omitted
-for the sake of brevity):
+If you are using the tutorial docker image, all dependency packages
+will have been installed. Otherwise, to install these packages you can use
+the following commands:
 
 .. code-block:: console
 

--- a/var/spack/repos/tutorial/packages/armadillo/package.py
+++ b/var/spack/repos/tutorial/packages/armadillo/package.py
@@ -1,0 +1,62 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Armadillo(CMakePackage):
+    """Armadillo is a high quality linear algebra library (matrix maths)
+    for the C++ language, aiming towards a good balance between speed and
+    ease of use.
+    """
+
+    homepage = "http://arma.sourceforge.net/"
+    url = "http://sourceforge.net/projects/arma/files/armadillo-7.200.1.tar.xz"
+
+    version('8.100.1', 'd9762d6f097e0451d0cfadfbda295e7c')
+    version('7.950.1', 'c06eb38b12cae49cab0ce05f96147147')
+    version('7.900.1', '5ef71763bd429a3d481499878351f3be')
+    version('7.500.0', '7d316fdf3c3c7ea92b64704180ae315d')
+    version('7.200.2', 'b21585372d67a8876117fd515d8cf0a2')
+    version('7.200.1', 'ed86d6df0058979e107502e1fe3e469e')
+
+    variant('hdf5', default=False, description='Include HDF5 support')
+
+    depends_on('cmake@2.8.12:', type='build')
+    depends_on('arpack-ng')  # old arpack causes undefined symbols
+    depends_on('blas')
+    depends_on('lapack')
+    depends_on('superlu@5.2:')
+    depends_on('hdf5', when='+hdf5')
+
+    patch('undef_linux.patch', when='platform=linux')
+
+    def cmake_args(self):
+        spec = self.spec
+
+        # TUTORIAL: fix the lines below by adding the appropriate query to
+        # the right dependency. To ask a dependency, e.g. `blas`, for the
+        # list of libraries it provides it suffices to access its `libs`
+        # attribute:
+        #
+        #    blas_libs = spec['blas'].libs
+        #
+        # The CMake variables below require a semicolon separated list:
+        #
+        #    blas_libs.joined(';')
+
+        return [
+            # ARPACK support
+            '-DARPACK_LIBRARY={0}'.format('FIXME: arpack-ng'),
+            # BLAS support
+            '-DBLAS_LIBRARY={0}'.format('FIXME: blas'),
+            # LAPACK support
+            '-DLAPACK_LIBRARY={0}'.format('FIXME: lapack'),
+            # SuperLU support
+            '-DSuperLU_INCLUDE_DIR={0}'.format(spec['superlu'].prefix.include),
+            '-DSuperLU_LIBRARY={0}'.format('FIXME: superlu'),
+            # HDF5 support
+            '-DDETECT_HDF5={0}'.format('ON' if '+hdf5' in spec else 'OFF')
+        ]

--- a/var/spack/repos/tutorial/packages/armadillo/undef_linux.patch
+++ b/var/spack/repos/tutorial/packages/armadillo/undef_linux.patch
@@ -1,0 +1,4 @@
+--- a/include/armadillo_bits/compiler_setup.hpp
++++ b/include/armadillo_bits/compiler_setup.hpp
+@@ -0,0 +1 @@
++#undef linux

--- a/var/spack/repos/tutorial/packages/elpa/package.py
+++ b/var/spack/repos/tutorial/packages/elpa/package.py
@@ -1,0 +1,78 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Elpa(AutotoolsPackage):
+    """Eigenvalue solvers for Petaflop-Applications (ELPA)"""
+
+    homepage = 'http://elpa.mpcdf.mpg.de/'
+    url = 'http://elpa.mpcdf.mpg.de/elpa-2015.11.001.tar.gz'
+
+    version('2018.05.001.rc1', 'ccd77bd8036988ee624f43c04992bcdd')
+    version('2017.11.001', '4a437be40cc966efb07aaab84c20cd6e', preferred=True)
+    version('2017.05.003', '7c8e5e58cafab212badaf4216695700f')
+    version('2017.05.002', 'd0abc1ac1f493f93bf5e30ec8ab155dc')
+    version('2016.11.001.pre', '5656fd066cf0dcd071dbcaf20a639b37')
+    version('2016.05.004', 'c0dd3a53055536fc3a2a221e78d8b376')
+    version('2016.05.003', '88a9f3f3bfb63e16509dd1be089dcf2c')
+    version('2015.11.001', 'de0f35b7ee7c971fd0dca35c900b87e6')
+
+    variant('openmp', default=False, description='Activates OpenMP support')
+    variant('optflags', default=True, description='Build with optimization flags')
+
+    depends_on('mpi')
+    depends_on('blas')
+    depends_on('lapack')
+    depends_on('scalapack')
+
+    def url_for_version(self, version):
+        t = 'http://elpa.mpcdf.mpg.de/html/Releases/{0}/elpa-{0}.tar.gz'
+        if version < Version('2016.05.003'):
+            t = 'http://elpa.mpcdf.mpg.de/elpa-{0}.tar.gz'
+        return t.format(str(version))
+
+    @property
+    def libs(self):
+        libname = 'libelpa_openmp' if '+openmp' in self.spec else 'libelpa'
+        return find_libraries(
+            libname, root=self.prefix, shared=True, recursive=True
+        )
+
+    build_directory = 'spack-build'
+
+    def setup_environment(self, spack_env, run_env):
+        # TUTORIAL: set the following environment variables:
+        #
+        # CC=spec['mpi'].mpicc
+        # FC=spec['mpi'].mpifc
+        # CXX=spec['mpi'].mpicxx
+        # SCALAPACK_LDFLAGS=spec['scalapack'].libs.joined()
+        #
+        # and append the following flags:
+        #
+        # LDFLAGS -> spec['lapack'].libs.search_flags
+        # LIBS -> spec['lapack'].libs.link_flags
+        pass
+
+    def configure_args(self):
+        # TODO: set optimum flags for platform+compiler combo, see
+        # https://github.com/hfp/xconfigure/tree/master/elpa
+        # also see:
+        # https://src.fedoraproject.org/cgit/rpms/elpa.git/
+        # https://packages.qa.debian.org/e/elpa.html
+        options = []
+        # without -march=native there is configure error for 2017.05.02
+        # Could not compile test program, try with --disable-sse, or
+        # adjust the C compiler or CFLAGS
+        if '+optflags' in self.spec:
+            options.extend([
+                'FCFLAGS=-O2 -march=native -ffree-line-length-none',
+                'CFLAGS=-O2 -march=native'
+            ])
+        if '+openmp' in self.spec:
+            options.append('--enable-openmp')
+        return options

--- a/var/spack/repos/tutorial/packages/hdf5/h5f90global-mult-obj-same-equivalence-same-common-block.patch
+++ b/var/spack/repos/tutorial/packages/hdf5/h5f90global-mult-obj-same-equivalence-same-common-block.patch
@@ -1,0 +1,16 @@
+diff --git a/fortran/src/H5f90global.F90 b/fortran/src/H5f90global.F90
+index dd2b171..629418a 100644
+--- a/fortran/src/H5f90global.F90
++++ b/fortran/src/H5f90global.F90
+@@ -142,10 +142,7 @@ MODULE H5GLOBAL
+
+   INTEGER(HID_T), DIMENSION(PREDEF_TYPES_LEN) :: predef_types
+   EQUIVALENCE (predef_types(1), H5T_NATIVE_INTEGER_KIND(1))
+-  EQUIVALENCE (predef_types(2), H5T_NATIVE_INTEGER_KIND(2))
+-  EQUIVALENCE (predef_types(3), H5T_NATIVE_INTEGER_KIND(3))
+-  EQUIVALENCE (predef_types(4), H5T_NATIVE_INTEGER_KIND(4))
+-  EQUIVALENCE (predef_types(5), H5T_NATIVE_INTEGER_KIND(5))
++  ! EQUIVALENCE predef_types(2:5) are unnecessary and violate the standard
+   EQUIVALENCE (predef_types(6), H5T_NATIVE_INTEGER)
+   EQUIVALENCE (predef_types(7), H5T_NATIVE_REAL)
+   EQUIVALENCE (predef_types(8), H5T_NATIVE_DOUBLE)

--- a/var/spack/repos/tutorial/packages/hdf5/package.py
+++ b/var/spack/repos/tutorial/packages/hdf5/package.py
@@ -169,7 +169,7 @@ class Hdf5(AutotoolsPackage):
         # 
         # shared = '+shared' in self.spec
         # return find_libraries(
-        #     libraries, root=self.prefix, shared=shared, recurse=True
+        #     libraries, root=self.prefix, shared=shared, recursive=True
         # )
         return []
 

--- a/var/spack/repos/tutorial/packages/hdf5/package.py
+++ b/var/spack/repos/tutorial/packages/hdf5/package.py
@@ -1,0 +1,306 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import shutil
+import sys
+
+from spack import *
+
+
+class Hdf5(AutotoolsPackage):
+    """HDF5 is a data model, library, and file format for storing and managing
+    data. It supports an unlimited variety of datatypes, and is designed for
+    flexible and efficient I/O and for high volume and complex data.
+    """
+
+    homepage = "https://support.hdfgroup.org/HDF5/"
+    url      = "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.1/src/hdf5-1.10.1.tar.gz"
+    list_url = "https://support.hdfgroup.org/ftp/HDF5/releases"
+    list_depth = 3
+
+    version('1.10.4', '8f60dc4dd6ab5fcd23c750d1dc5bca3d0453bdce5c8cdaf0a4a61a9d1122adb2')
+    version('1.10.3', 'b600d7c914cfa80ae127cd1a1539981213fee9994ac22ebec9e3845e951d9b39')
+    version('1.10.2', '8d4eae84e533efa57496638fd0dca8c3')
+    version('1.10.1', '43a2f9466702fb1db31df98ae6677f15')
+    version('1.10.0-patch1', '9180ff0ef8dc2ef3f61bd37a7404f295')
+    version('1.10.0', 'bdc935337ee8282579cd6bc4270ad199')
+    version('1.8.19', '7f568e2464d4ab0a74d16b23956d900b')
+    version('1.8.18', 'dd2148b740713ca0295442ec683d7b1c')
+    version('1.8.17', '7d572f8f3b798a628b8245af0391a0ca')
+    version('1.8.16', 'b8ed9a36ae142317f88b0c7ef4b9c618')
+    version('1.8.15', '03cccb5b33dbe975fdcd8ae9dc021f24')
+    version('1.8.14', 'a482686e733514a51cde12d6fe5c5d95')
+    version('1.8.13', 'c03426e9e77d7766944654280b467289')
+    version('1.8.12', 'd804802feb99b87fc668a90e6fa34411')
+    version('1.8.10', '710aa9fb61a51d61a7e2c09bf0052157')
+
+    variant('debug', default=False,
+            description='Builds a debug version of the library')
+    variant('shared', default=True,
+            description='Builds a shared version of the library')
+
+    variant('hl', default=False, description='Enable the high-level library')
+    variant('cxx', default=False, description='Enable C++ support')
+    variant('fortran', default=False, description='Enable Fortran support')
+    variant('threadsafe', default=False,
+            description='Enable thread-safe capabilities')
+
+    variant('mpi', default=True, description='Enable MPI support')
+    variant('szip', default=False, description='Enable szip support')
+    variant('pic', default=True,
+            description='Produce position-independent code (for shared libs)')
+
+    depends_on('mpi', when='+mpi')
+    # numactl does not currently build on darwin
+    if sys.platform != 'darwin':
+        depends_on('numactl', when='+mpi+fortran')
+    depends_on('szip', when='+szip')
+    depends_on('zlib@1.1.2:')
+
+    # There are several officially unsupported combinations of the features:
+    # 1. Thread safety is not guaranteed via high-level C-API but in some cases
+    #    it works.
+    # conflicts('+threadsafe+hl')
+
+    # 2. Thread safety is not guaranteed via Fortran (CXX) API, but it's
+    #    possible for a dependency tree to contain a package that uses Fortran
+    #    (CXX) API in a single thread and another one that uses low-level C-API
+    #    in multiple threads. To allow for such scenarios, we don't specify the
+    #    following conflicts.
+    # conflicts('+threadsafe+cxx')
+    # conflicts('+threadsafe+fortran')
+
+    # 3. Parallel features are not supported via CXX API, but for the reasons
+    #    described in #2 we allow for such combination.
+    # conflicts('+mpi+cxx')
+
+    # There are known build failures with intel@18.0.1. This issue is
+    # discussed and patch is provided at
+    # https://software.intel.com/en-us/forums/intel-fortran-compiler-for-linux-and-mac-os-x/topic/747951.
+    patch('h5f90global-mult-obj-same-equivalence-same-common-block.patch',
+          when='@1.10.1%intel@18')
+
+    # Turn line comments into block comments to conform with pre-C99 language
+    # standards. Versions of hdf5 after 1.8.10 don't require this patch,
+    # either because they conform to pre-C99 or neglect to ask for pre-C99
+    # language standards from their compiler. The hdf5 build system adds
+    # the -ansi cflag (run 'man gcc' for info on -ansi) for some versions
+    # of some compilers (see hdf5-1.8.10/config/gnu-flags). The hdf5 build
+    # system does not provide an option to disable -ansi, but since the
+    # pre-C99 code is restricted to just five lines of line comments in
+    # three src files, this patch accomplishes the simple task of patching the
+    # three src files and leaves the hdf5 build system alone.
+    patch('pre-c99-comments.patch', when='@1.8.10')
+
+    # There are build errors with GCC 8, see
+    # https://forum.hdfgroup.org/t/1-10-2-h5detect-compile-error-gcc-8-1-0-on-centos-7-2-solved/4441
+    patch('https://salsa.debian.org/debian-gis-team/hdf5/raw/bf94804af5f80f662cad80a5527535b3c6537df6/debian/patches/gcc-8.patch', sha256='57cee5ff1992b4098eda079815c36fc2da9b10e00a9056df054f2384c4fc7523', when='@1.10.2%gcc@8:')
+
+    filter_compiler_wrappers('h5cc', 'h5c++', 'h5fc', relative_root='bin')
+
+    def url_for_version(self, version):
+        url = "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-{0}/hdf5-{1}/src/hdf5-{1}.tar.gz"
+        return url.format(version.up_to(2), version)
+
+    @property
+    def libs(self):
+        """HDF5 can be queried for the following parameters:
+
+        - "hl": high-level interface
+        - "cxx": C++ APIs
+        - "fortran": Fortran APIs
+
+        :return: list of matching libraries
+        """
+        # This map contains a translation from query_parameters
+        # to the libraries needed
+        query2libraries = {
+            tuple(): ['libhdf5'],
+            ('cxx', 'fortran', 'hl'): [
+                'libhdf5hl_fortran',
+                'libhdf5_hl_cpp',
+                'libhdf5_hl',
+                'libhdf5_fortran',
+                'libhdf5',
+            ],
+            ('cxx', 'hl'): [
+                'libhdf5_hl_cpp',
+                'libhdf5_hl',
+                'libhdf5',
+            ],
+            ('fortran', 'hl'): [
+                'libhdf5hl_fortran',
+                'libhdf5_hl',
+                'libhdf5_fortran',
+                'libhdf5',
+            ],
+            ('hl',): [
+                'libhdf5_hl',
+                'libhdf5',
+            ],
+            ('cxx', 'fortran'): [
+                'libhdf5_fortran',
+                'libhdf5_cpp',
+                'libhdf5',
+            ],
+            ('cxx',): [
+                'libhdf5_cpp',
+                'libhdf5',
+            ],
+            ('fortran',): [
+                'libhdf5_fortran',
+                'libhdf5',
+            ]
+        }
+
+        # TUTORIAL: you need to fix the implementation below, and
+        # return the correct list of libraries according to the
+        # query parameters your dependency has used.
+        #
+        # You can retrieve the query parameters by doing
+        #
+        # query_parameters = self.spec.last_query.extra_parameters
+        #
+        # and use the map above to query the list of libraries you need to search.
+        #
+        # Finally uncomment the lines below to return a LibraryList
+        # 
+        # shared = '+shared' in self.spec
+        # return find_libraries(
+        #     libraries, root=self.prefix, shared=shared, recurse=True
+        # )
+        return []
+
+    @run_before('configure')
+    def fortran_check(self):
+        if '+fortran' in self.spec and not self.compiler.fc:
+            msg = 'cannot build a Fortran variant without a Fortran compiler'
+            raise RuntimeError(msg)
+
+    def configure_args(self):
+        # Always enable this option. This does not actually enable any
+        # features: it only *allows* the user to specify certain
+        # combinations of other arguments. Enabling it just skips a
+        # sanity check in configure, so this doesn't merit a variant.
+        extra_args = ['--enable-unsupported']
+        extra_args += self.enable_or_disable('threadsafe')
+        extra_args += self.enable_or_disable('cxx')
+        extra_args += self.enable_or_disable('hl')
+        extra_args += self.enable_or_disable('fortran')
+
+        if '+szip' in self.spec:
+            extra_args.append('--with-szlib=%s' % self.spec['szip'].prefix)
+        else:
+            extra_args.append('--without-szlib')
+
+        if self.spec.satisfies('@1.10:'):
+            if '+debug' in self.spec:
+                extra_args.append('--enable-build-mode=debug')
+            else:
+                extra_args.append('--enable-build-mode=production')
+        else:
+            if '+debug' in self.spec:
+                extra_args.append('--enable-debug=all')
+            else:
+                extra_args.append('--enable-production')
+
+            # '--enable-fortran2003' no longer exists as of version 1.10.0
+            if '+fortran' in self.spec:
+                extra_args.append('--enable-fortran2003')
+            else:
+                extra_args.append('--disable-fortran2003')
+
+        if '+shared' in self.spec:
+            extra_args.append('--enable-shared')
+        else:
+            extra_args.append('--disable-shared')
+            extra_args.append('--enable-static-exec')
+
+        if '+pic' in self.spec:
+            extra_args += ['%s=%s' % (f, self.compiler.pic_flag)
+                           for f in ['CFLAGS', 'CXXFLAGS', 'FCFLAGS']]
+
+        if '+mpi' in self.spec:
+            # The HDF5 configure script warns if cxx and mpi are enabled
+            # together. There doesn't seem to be a real reason for this, except
+            # that parts of the MPI interface are not accessible via the C++
+            # interface. Since they are still accessible via the C interface,
+            # this is not actually a problem.
+            extra_args += ['--enable-parallel',
+                           'CC=%s' % self.spec['mpi'].mpicc]
+
+            if '+cxx' in self.spec:
+                extra_args.append('CXX=%s' % self.spec['mpi'].mpicxx)
+
+            if '+fortran' in self.spec:
+                extra_args.append('FC=%s' % self.spec['mpi'].mpifc)
+
+        extra_args.append('--with-zlib=%s' % self.spec['zlib'].prefix)
+
+        return extra_args
+
+    @run_after('configure')
+    def patch_postdeps(self):
+        if '@:1.8.14' in self.spec:
+            # On Ubuntu14, HDF5 1.8.12 (and maybe other versions)
+            # mysteriously end up with "-l -l" in the postdeps in the
+            # libtool script.  Patch this by removing the spurious -l's.
+            filter_file(
+                r'postdeps="([^"]*)"',
+                lambda m: 'postdeps="%s"' % ' '.join(
+                    arg for arg in m.group(1).split(' ') if arg != '-l'),
+                'libtool')
+
+    @run_after('install')
+    @on_package_attributes(run_tests=True)
+    def check_install(self):
+        # Build and run a small program to test the installed HDF5 library
+        spec = self.spec
+        print("Checking HDF5 installation...")
+        checkdir = "spack-check"
+        with working_dir(checkdir, create=True):
+            source = r"""
+#include <hdf5.h>
+#include <assert.h>
+#include <stdio.h>
+int main(int argc, char **argv) {
+  unsigned majnum, minnum, relnum;
+  herr_t herr = H5get_libversion(&majnum, &minnum, &relnum);
+  assert(!herr);
+  printf("HDF5 version %d.%d.%d %u.%u.%u\n", H5_VERS_MAJOR, H5_VERS_MINOR,
+         H5_VERS_RELEASE, majnum, minnum, relnum);
+  return 0;
+}
+"""
+            expected = """\
+HDF5 version {version} {version}
+""".format(version=str(spec.version.up_to(3)))
+            with open("check.c", 'w') as f:
+                f.write(source)
+            if '+mpi' in spec:
+                cc = Executable(spec['mpi'].mpicc)
+            else:
+                cc = Executable(self.compiler.cc)
+            cc(*(['-c', "check.c"] + spec['hdf5'].headers.cpp_flags.split()))
+            cc(*(['-o', "check",
+                  "check.o"] + spec['hdf5'].libs.ld_flags.split()))
+            try:
+                check = Executable('./check')
+                output = check(output=str)
+            except ProcessError:
+                output = ""
+            success = output == expected
+            if not success:
+                print("Produced output does not match expected output.")
+                print("Expected output:")
+                print('-' * 80)
+                print(expected)
+                print('-' * 80)
+                print("Produced output:")
+                print('-' * 80)
+                print(output)
+                print('-' * 80)
+                raise RuntimeError("HDF5 install check failed")
+        shutil.rmtree(checkdir)

--- a/var/spack/repos/tutorial/packages/hdf5/package.py
+++ b/var/spack/repos/tutorial/packages/hdf5/package.py
@@ -116,7 +116,7 @@ class Hdf5(AutotoolsPackage):
         """
         # This map contains a translation from query_parameters
         # to the libraries needed
-        query2libraries = {
+        query2libraries = {  # noqa: F841
             tuple(): ['libhdf5'],
             ('cxx', 'fortran', 'hl'): [
                 'libhdf5hl_fortran',
@@ -163,10 +163,11 @@ class Hdf5(AutotoolsPackage):
         #
         # query_parameters = self.spec.last_query.extra_parameters
         #
-        # and use the map above to query the list of libraries you need to search.
+        # and use the map above to query the list of libraries you need
+        # to search.
         #
         # Finally uncomment the lines below to return a LibraryList
-        # 
+        #
         # shared = '+shared' in self.spec
         # return find_libraries(
         #     libraries, root=self.prefix, shared=shared, recursive=True

--- a/var/spack/repos/tutorial/packages/hdf5/pre-c99-comments.patch
+++ b/var/spack/repos/tutorial/packages/hdf5/pre-c99-comments.patch
@@ -1,0 +1,43 @@
+diff --git a/test/th5s.c b/test/th5s.c
+index 462bc36..8e18fad 100644
+--- a/test/th5s.c
++++ b/test/th5s.c
+@@ -730,8 +730,8 @@ test_h5s_zero_dim(void)
+         ret = H5Pset_chunk(plist_id, SPACE1_RANK, chunk_dims);
+         CHECK(ret, FAIL, "H5Pset_chunk");
+ 
+-        // ret = H5Pset_alloc_time(plist_id, alloc_time);
+-        // CHECK(ret, FAIL, "H5Pset_alloc_time");
++        /* ret = H5Pset_alloc_time(plist_id, alloc_time); */
++        /* CHECK(ret, FAIL, "H5Pset_alloc_time"); */
+ 
+         dset1 = H5Dcreate2(fid1, BASICDATASET1, H5T_NATIVE_INT, sid_chunk, H5P_DEFAULT, plist_id, H5P_DEFAULT);
+         CHECK(dset1, FAIL, "H5Dcreate2");
+diff --git a/tools/h5dump/h5dump_ddl.c b/tools/h5dump/h5dump_ddl.c
+index ee6de5e..3ed6045 100644
+--- a/tools/h5dump/h5dump_ddl.c
++++ b/tools/h5dump/h5dump_ddl.c
+@@ -1341,8 +1341,8 @@ handle_attributes(hid_t fid, const char *attr, void UNUSED * data, int UNUSED pe
+     string_dataformat.do_escape = display_escape;
+     outputformat = &string_dataformat;
+ 
+-    //attr_name = attr + j + 1;
+-	// need to replace escape characters
++    /* attr_name = attr + j + 1; */
++	/* need to replace escape characters */
+ 	attr_name = h5tools_str_replace(attr + j + 1, "\\/", "/");
+ 
+ 
+diff --git a/tools/lib/h5tools_str.c b/tools/lib/h5tools_str.c
+index 9ce3524..3b4e5e7 100644
+--- a/tools/lib/h5tools_str.c
++++ b/tools/lib/h5tools_str.c
+@@ -632,7 +632,7 @@ h5tools_str_indent(h5tools_str_t *str, const h5tool_format_t *info,
+         h5tools_str_append(str, "%s", OPT(info->line_indent, ""));
+     }
+ 
+-//    ctx->need_prefix = 0;
++/*    ctx->need_prefix = 0; */
+ }
+ 
+ /*-------------------------------------------------------------------------

--- a/var/spack/repos/tutorial/packages/mpich/mpich32_clang.patch
+++ b/var/spack/repos/tutorial/packages/mpich/mpich32_clang.patch
@@ -1,0 +1,13 @@
+diff --git a/src/include/mpiimpl.h b/src/include/mpiimpl.h
+index e705e5d..3bfcbee 100644
+--- a/src/include/mpiimpl.h
++++ b/src/include/mpiimpl.h
+@@ -1528,7 +1528,7 @@ typedef struct MPID_Request {
+ #ifdef MPID_DEV_REQUEST_DECL
+     MPID_DEV_REQUEST_DECL
+ #endif
+-} MPID_Request ATTRIBUTE((__aligned__(32)));
++} ATTRIBUTE((__aligned__(32))) MPID_Request;
+ 
+ extern MPIU_Object_alloc_t MPID_Request_mem;
+ /* Preallocated request objects */

--- a/var/spack/repos/tutorial/packages/mpich/package.py
+++ b/var/spack/repos/tutorial/packages/mpich/package.py
@@ -1,0 +1,155 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+import os
+
+
+class Mpich(AutotoolsPackage):
+    """MPICH is a high performance and widely portable implementation of
+    the Message Passing Interface (MPI) standard."""
+
+    homepage = "http://www.mpich.org"
+    url      = "http://www.mpich.org/static/downloads/3.0.4/mpich-3.0.4.tar.gz"
+    git      = "https://github.com/pmodels/mpich.git"
+    list_url = "http://www.mpich.org/static/downloads/"
+    list_depth = 1
+
+    version('develop', submodules=True)
+    version('3.2.1', 'e175452f4d61646a52c73031683fc375')
+    version('3.2',   'f414cfa77099cd1fa1a5ae4e22db508a')
+    version('3.1.4', '2ab544607986486562e076b83937bba2')
+    version('3.1.3', '93cb17f91ac758cbf9174ecb03563778')
+    version('3.1.2', '7fbf4b81dcb74b07ae85939d1ceee7f1')
+    version('3.1.1', '40dc408b1e03cc36d80209baaa2d32b7')
+    version('3.1',   '5643dd176499bfb7d25079aaff25f2ec')
+    version('3.0.4', '9c5d5d4fe1e17dd12153f40bc5b6dbc0')
+
+    variant('hydra', default=True,  description='Build the hydra process manager')
+    variant('pmi',   default=True,  description='Build with PMI support')
+    variant('romio', default=True,  description='Enable ROMIO MPI I/O implementation')
+    variant('verbs', default=False, description='Build support for OpenFabrics verbs.')
+    variant(
+        'device',
+        default='ch3',
+        description='''Abstract Device Interface (ADI)
+implementation. The ch4 device is currently in experimental state''',
+        values=('ch3', 'ch4'),
+        multi=False
+    )
+    variant(
+        'netmod',
+        default='tcp',
+        description='''Network module. Only single netmod builds are
+supported. For ch3 device configurations, this presumes the
+ch3:nemesis communication channel. ch3:sock is not supported by this
+spack package at this time.''',
+        values=('tcp', 'mxm', 'ofi', 'ucx'),
+        multi=False
+    )
+
+    provides('mpi')
+    provides('mpi@:3.0', when='@3:')
+    provides('mpi@:1.3', when='@1:')
+
+    filter_compiler_wrappers(
+        'mpicc', 'mpicxx', 'mpif77', 'mpif90', 'mpifort', relative_root='bin'
+    )
+
+    # fix MPI_Barrier segmentation fault
+    # see https://lists.mpich.org/pipermail/discuss/2016-May/004764.html
+    # and https://lists.mpich.org/pipermail/discuss/2016-June/004768.html
+    patch('mpich32_clang.patch', when='@3.2:3.2.0%clang')
+
+    depends_on('findutils', type='build')
+
+    depends_on('libfabric', when='netmod=ofi')
+
+    conflicts('device=ch4', when='@:3.2')
+    conflicts('netmod=ofi', when='@:3.1.4')
+    conflicts('netmod=ucx', when='device=ch3')
+    conflicts('netmod=mxm', when='device=ch4')
+    conflicts('netmod=mxm', when='@:3.1.3')
+    conflicts('netmod=tcp', when='device=ch4')
+
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        # TUTORIAL: set the following variables for dependents:
+        #
+        # MPICC=join_path(self.prefix.bin, 'mpicc')
+        # MPICXX=join_path(self.prefix.bin, 'mpic++')
+        # MPIF77=join_path(self.prefix.bin, 'mpif77')
+        # MPIF90=join_path(self.prefix.bin, 'mpif90')
+        # MPICH_CC=spack_cc
+        # MPICH_CXX=spack_cxx
+        # MPICH_F77=spack_f77
+        # MPICH_F90=spack_fc
+        # MPICH_FC=spack_fc
+        pass
+
+    def setup_dependent_package(self, module, dependent_spec):
+        if 'platform=cray' in self.spec:
+            self.spec.mpicc = spack_cc
+            self.spec.mpicxx = spack_cxx
+            self.spec.mpifc = spack_fc
+            self.spec.mpif77 = spack_f77
+        else:
+            self.spec.mpicc = join_path(self.prefix.bin, 'mpicc')
+            self.spec.mpicxx = join_path(self.prefix.bin, 'mpic++')
+            self.spec.mpifc = join_path(self.prefix.bin, 'mpif90')
+            self.spec.mpif77 = join_path(self.prefix.bin, 'mpif77')
+
+        self.spec.mpicxx_shared_libs = [
+            join_path(self.prefix.lib, 'libmpicxx.{0}'.format(dso_suffix)),
+            join_path(self.prefix.lib, 'libmpi.{0}'.format(dso_suffix))
+        ]
+
+    def autoreconf(self, spec, prefix):
+        """Not needed usually, configure should be already there"""
+        # If configure exists nothing needs to be done
+        if os.path.exists(self.configure_abs_path):
+            return
+        # Else bootstrap with autotools
+        bash = which('bash')
+        bash('./autogen.sh')
+
+    @run_before('autoreconf')
+    def die_without_fortran(self):
+        # Until we can pass variants such as +fortran through virtual
+        # dependencies depends_on('mpi'), require Fortran compiler to
+        # avoid delayed build errors in dependents.
+        if (self.compiler.f77 is None) or (self.compiler.fc is None):
+            raise InstallError(
+                'Mpich requires both C and Fortran compilers!'
+            )
+
+    def configure_args(self):
+        spec = self.spec
+        config_args = [
+            '--enable-shared',
+            '--with-pm={0}'.format('hydra' if '+hydra' in spec else 'no'),
+            '--with-pmi={0}'.format('yes' if '+pmi' in spec else 'no'),
+            '--{0}-romio'.format('enable' if '+romio' in spec else 'disable'),
+            '--{0}-ibverbs'.format('with' if '+verbs' in spec else 'without')
+        ]
+
+        # setup device configuration
+        device_config = ''
+        if 'device=ch4' in spec:
+            device_config = '--with-device=ch4:'
+        elif 'device=ch3' in spec:
+            device_config = '--with-device=ch3:nemesis:'
+
+        if 'netmod=ucx' in spec:
+            device_config += 'ucx'
+        elif 'netmod=ofi' in spec:
+            device_config += 'ofi'
+        elif 'netmod=mxm' in spec:
+            device_config += 'mxm'
+        elif 'netmod=tcp' in spec:
+            device_config += 'tcp'
+
+        config_args.append(device_config)
+
+        return config_args

--- a/var/spack/repos/tutorial/packages/netlib-lapack/ibm-xl.patch
+++ b/var/spack/repos/tutorial/packages/netlib-lapack/ibm-xl.patch
@@ -1,0 +1,42 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -62,7 +62,7 @@
+     set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fp-model strict")
+   endif()
+   if("${CMAKE_Fortran_COMPILER}" MATCHES "xlf")
+-    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -qnosave -qstrict=none")
++    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -qnosave -qstrict")
+   endif()
+ # Delete libmtsk in linking sequence for Sun/Oracle Fortran Compiler.
+ # This library is not present in the Sun package SolarisStudio12.3-linux-x86-bin
+
+--- a/CMAKE/CheckLAPACKCompilerFlags.cmake
++++ b/CMAKE/CheckLAPACKCompilerFlags.cmake
+@@ -43,12 +43,6 @@
+   if( "${CMAKE_Fortran_FLAGS}" MATCHES "-qflttrap=[a-zA-Z:]:enable" )
+     set( FPE_EXIT TRUE )
+   endif()
+-
+-  if( NOT ("${CMAKE_Fortran_FLAGS}" MATCHES "-qfixed") )
+-    message( STATUS "Enabling fixed format F90/F95 with -qfixed" )
+-    set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -qfixed"
+-         CACHE STRING "Flags for Fortran compiler." FORCE )
+-  endif()
+ 
+ # HP Fortran
+ elseif( CMAKE_Fortran_COMPILER_ID STREQUAL "HP" )
+
+--- a/CBLAS/CMakeLists.txt
++++ b/CBLAS/CMakeLists.txt
+@@ -12,8 +12,8 @@
+                          SYMBOL_NAMESPACE "F77_")
+ if(NOT FortranCInterface_GLOBAL_FOUND OR NOT FortranCInterface_MODULE_FOUND)
+   message(WARNING "Reverting to pre-defined include/lapacke_mangling.h")
+-  configure_file(include/lapacke_mangling_with_flags.h.in
+-                 ${LAPACK_BINARY_DIR}/include/lapacke_mangling.h)
++  configure_file(include/cblas_mangling_with_flags.h.in
++                 ${LAPACK_BINARY_DIR}/include/cblas_mangling.h)
+ endif()
+ 
+ include_directories(include ${LAPACK_BINARY_DIR}/include)
+

--- a/var/spack/repos/tutorial/packages/netlib-lapack/package.py
+++ b/var/spack/repos/tutorial/packages/netlib-lapack/package.py
@@ -103,9 +103,9 @@ class NetlibLapack(CMakePackage):
         )
 
     # TUTORIAL: add a proper `lapack_lib` property, along the lines
-    # of the `blas_lib` property above. The library that provides 
+    # of the `blas_lib` property above. The library that provides
     # the lapack API is called `liblapack`.
-    
+
     @property
     def headers(self):
         include_dir = self.spec.prefix.include

--- a/var/spack/repos/tutorial/packages/netlib-lapack/package.py
+++ b/var/spack/repos/tutorial/packages/netlib-lapack/package.py
@@ -1,0 +1,186 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class NetlibLapack(CMakePackage):
+    """LAPACK version 3.X is a comprehensive FORTRAN library that does
+    linear algebra operations including matrix inversions, least squared
+    solutions to linear sets of equations, eigenvector analysis, singular
+    value decomposition, etc. It is a very comprehensive and reputable
+    package that has found extensive use in the scientific community.
+
+    """
+    homepage = "http://www.netlib.org/lapack/"
+    url = "http://www.netlib.org/lapack/lapack-3.5.0.tgz"
+
+    version('3.8.0', '96591affdbf58c450d45c1daa540dbd2',
+            url='http://www.netlib.org/lapack/lapack-3.8.0.tar.gz')
+    version('3.7.1', 'dcdeeed73de152c4643ccc5b1aeb453c')
+    version('3.7.0', '697bb8d67c7d336a0f339cc9dd0fa72f')
+    version('3.6.1', '421b2cb72e15f237e144428f9c460ee0')
+    version('3.6.0', 'f2f6c67134e851fe189bb3ca1fbb5101')
+    version('3.5.0', 'b1d3e3e425b2e44a06760ff173104bdf')
+    version('3.4.2', '61bf1a8a4469d4bdb7604f5897179478')
+    version('3.4.1', '44c3869c38c8335c2b9c2a8bb276eb55')
+    version('3.4.0', '02d5706ec03ba885fc246e5fa10d8c70')
+    version('3.3.1', 'd0d533ec9a5b74933c2a1e84eedc58b4')
+
+    variant('shared', default=True, description="Build shared library version")
+    variant('external-blas', default=False,
+            description='Build lapack with an external blas')
+
+    variant('lapacke', default=True,
+            description='Activates the build of the LAPACKE C interface')
+    variant('xblas', default=False,
+            description='Builds extended precision routines using XBLAS')
+
+    patch('ibm-xl.patch', when='@3.7: %xl')
+    patch('ibm-xl.patch', when='@3.7: %xl_r')
+
+    # https://github.com/Reference-LAPACK/lapack/issues/228
+    # TODO: update 'when' once the version of lapack
+    # containing the fix is released and added to Spack.
+    patch('undefined_declarations.patch', when='@3.8.0:')
+
+    # https://github.com/Reference-LAPACK/lapack/pull/268
+    # TODO: update 'when' once the version of lapack
+    # containing the fix is released and added to Spack.
+    patch('testing.patch', when='@3.7.0:')
+
+    # virtual dependency
+    provides('blas', when='~external-blas')
+    provides('lapack')
+
+    depends_on('blas', when='+external-blas')
+    depends_on('netlib-xblas+fortran+plain_blas', when='+xblas')
+    depends_on('python@2.7:', type='test')
+
+    # We need to run every phase twice in order to get static and shared
+    # versions of the libraries. When ~shared, we run the default
+    # implementations of the CMakePackage's phases and get only one building
+    # directory 'spack-build-static' with -DBUILD_SHARED_LIBS:BOOL=OFF (see
+    # implementations of self.build_directory and self.cmake_args() below).
+    # When +shared, we run the overridden methods for the phases, each
+    # running the default implementation twice with different values for
+    # self._building_shared. As a result, we get two building directories:
+    # 'spack-build-static' with -DBUILD_SHARED_LIBS:BOOL=OFF and
+    # 'spack-build-shared' with -DBUILD_SHARED_LIBS:BOOL=ON.
+    _building_shared = False
+
+    def patch(self):
+        # Fix cblas CMakeLists.txt -- has wrong case for subdirectory name.
+        if self.spec.satisfies('@3.6.0:'):
+            filter_file(
+                '${CMAKE_CURRENT_SOURCE_DIR}/CMAKE/',
+                '${CMAKE_CURRENT_SOURCE_DIR}/cmake/',
+                'CBLAS/CMakeLists.txt', string=True)
+
+    @property
+    def blas_libs(self):
+        shared = True if '+shared' in self.spec else False
+        query_parameters = self.spec.last_query.extra_parameters
+        query2libraries = {
+            tuple(): ['libblas'],
+            ('c', 'fortran'): [
+                'libcblas',
+                'libblas',
+            ],
+            ('c',): [
+                'libcblas',
+            ],
+            ('fortran',): [
+                'libblas',
+            ]
+        }
+        key = tuple(sorted(query_parameters))
+        libraries = query2libraries[key]
+        return find_libraries(
+            libraries, root=self.prefix, shared=shared, recursive=True
+        )
+
+    # TUTORIAL: add a proper `lapack_lib` property, along the lines
+    # of the `blas_lib` property above. The library that provides 
+    # the lapack API is called `liblapack`.
+    
+    @property
+    def headers(self):
+        include_dir = self.spec.prefix.include
+        cblas_h = join_path(include_dir, 'cblas.h')
+        lapacke_h = join_path(include_dir, 'lapacke.h')
+        return HeaderList([cblas_h, lapacke_h])
+
+    @property
+    def build_directory(self):
+        return join_path(self.stage.source_path,
+                         'spack-build-shared' if self._building_shared
+                         else 'spack-build-static')
+
+    def cmake_args(self):
+        args = ['-DBUILD_SHARED_LIBS:BOOL=' +
+                ('ON' if self._building_shared else 'OFF')]
+
+        if self.spec.satisfies('+lapacke'):
+            args.extend(['-DLAPACKE:BOOL=ON', '-DLAPACKE_WITH_TMG:BOOL=ON'])
+        else:
+            args.extend(['-DLAPACKE:BOOL=OFF', '-DLAPACKE_WITH_TMG:BOOL=OFF'])
+
+        if self.spec.satisfies('@3.6.0:'):
+            args.append('-DCBLAS=ON')  # always build CBLAS
+
+        if self.spec.satisfies('%intel'):
+            # Intel compiler finds serious syntax issues when trying to
+            # build CBLAS and LapackE
+            args.extend(['-DCBLAS=OFF', '-DLAPACKE:BOOL=OFF'])
+
+        if self.spec.satisfies('%xl') or self.spec.satisfies('%xl_r'):
+            # use F77 compiler if IBM XL
+            args.extend(['-DCMAKE_Fortran_COMPILER=' + self.compiler.f77,
+                         '-DCMAKE_Fortran_FLAGS=' +
+                         (' '.join(self.spec.compiler_flags['fflags'])) +
+                         " -O3 -qnohot"])
+
+        # deprecated routines are commonly needed by, for example, suitesparse
+        # Note that OpenBLAS spack is built with deprecated routines
+        args.append('-DBUILD_DEPRECATED:BOOL=ON')
+
+        if self.spec.satisfies('+external-blas'):
+            args.extend(['-DUSE_OPTIMIZED_BLAS:BOOL=ON',
+                         '-DBLAS_LIBRARIES:PATH=' +
+                         self.spec['blas'].libs.joined(';')])
+
+        if self.spec.satisfies('+xblas'):
+            args.extend(['-DXBLAS_INCLUDE_DIR=' +
+                         self.spec['netlib-xblas'].prefix.include,
+                         '-DXBLAS_LIBRARY=' +
+                         self.spec['netlib-xblas'].libs.joined(';')])
+
+        args.append('-DBUILD_TESTING:BOOL=' +
+                    ('ON' if self.run_tests else 'OFF'))
+
+        return args
+
+    # Build, install, and check both static and shared versions of the
+    # libraries when +shared
+    @when('+shared')
+    def cmake(self, spec, prefix):
+        for self._building_shared in (False, True):
+            super(NetlibLapack, self).cmake(spec, prefix)
+
+    @when('+shared')
+    def build(self, spec, prefix):
+        for self._building_shared in (False, True):
+            super(NetlibLapack, self).build(spec, prefix)
+
+    @when('+shared')
+    def install(self, spec, prefix):
+        for self._building_shared in (False, True):
+            super(NetlibLapack, self).install(spec, prefix)
+
+    @when('+shared')
+    def check(self):
+        for self._building_shared in (False, True):
+            super(NetlibLapack, self).check()

--- a/var/spack/repos/tutorial/packages/netlib-lapack/testing.patch
+++ b/var/spack/repos/tutorial/packages/netlib-lapack/testing.patch
@@ -1,0 +1,13 @@
+diff --git a/TESTING/LIN/alahd.f b/TESTING/LIN/alahd.f
+index 8f4cd58d..6a4946e0 100644
+--- a/TESTING/LIN/alahd.f
++++ b/TESTING/LIN/alahd.f
+@@ -1036,7 +1036,7 @@
+  9929 FORMAT( ' Test ratios (1-3: ', A1, 'TZRZF):' )
+  9920 FORMAT( 3X, ' 7-10: same as 3-6', 3X, ' 11-14: same as 3-6' )
+  9921 FORMAT( ' Test ratios:', / '    (1-2: ', A1, 'GELS, 3-6: ', A1,
+-     $      'GELSY, 7-10: ', A1, 'GELSS, 11-14: ', A1, 'GELSD, 15-16: '
++     $      'GELSY, 7-10: ', A1, 'GELSS, 11-14: ', A1, 'GELSD, 15-16: ',
+      $        A1, 'GETSLS)')
+  9928 FORMAT( 7X, 'where ALPHA = ( 1 + SQRT( 17 ) ) / 8' )
+  9927 FORMAT( 3X, I2, ': ABS( Largest element in L )', / 12X,

--- a/var/spack/repos/tutorial/packages/netlib-lapack/undefined_declarations.patch
+++ b/var/spack/repos/tutorial/packages/netlib-lapack/undefined_declarations.patch
@@ -1,0 +1,26 @@
+diff --git a/SRC/dsytrf_aa_2stage.f b/SRC/dsytrf_aa_2stage.f
+index 2991305..f5f06cc 100644
+--- a/SRC/dsytrf_aa_2stage.f
++++ b/SRC/dsytrf_aa_2stage.f
+@@ -191,7 +191,7 @@
+       EXTERNAL           LSAME, ILAENV
+ *     ..
+ *     .. External Subroutines ..
+-      EXTERNAL           XERBLA, DCOPY, DLACGV, DLACPY,
++      EXTERNAL           XERBLA, DCOPY, DLACPY,
+      $                   DLASET, DGBTRF, DGEMM,  DGETRF, 
+      $                   DSYGST, DSWAP, DTRSM 
+ *     ..
+diff --git a/SRC/ssytrf_aa_2stage.f b/SRC/ssytrf_aa_2stage.f
+index be6809d..a929749 100644
+--- a/SRC/ssytrf_aa_2stage.f
++++ b/SRC/ssytrf_aa_2stage.f
+@@ -191,7 +191,7 @@
+       EXTERNAL           LSAME, ILAENV
+ *     ..
+ *     .. External Subroutines ..
+-      EXTERNAL           XERBLA, SCOPY, SLACGV, SLACPY,
++      EXTERNAL           XERBLA, SCOPY, SLACPY,
+      $                   SLASET, SGBTRF, SGEMM,  SGETRF, 
+      $                   SSYGST, SSWAP, STRSM 
+ *     ..

--- a/var/spack/repos/tutorial/repo.yaml
+++ b/var/spack/repos/tutorial/repo.yaml
@@ -1,0 +1,2 @@
+repo:
+  namespace: tutorial


### PR DESCRIPTION
@becker33 

This creates a new repository for package installations which are used in https://spack.readthedocs.io/en/latest/tutorial_advanced_packaging.html. It is placed alongside builtin, and disabled by default (you must do `spack repo add --scope=defaults var/spack/repos/tutorial` to enable it).

Thoughts so far on this approach:

* I haven't checked this with the intended docker image (Ubuntu 18.04) but I have completed the advanced packaging tutorial with this on a different system (I intend to test with the target OS by the end of 11/5)
* users will want to do this in a separate Spack repo clone if they aren't using the tutorial docker image, and will also want to be careful when adding the repo (the updated docs suggest using `--scope=defaults` to avoid modifying config under `~`).
* users may get confused jumping into `var/spack/repos/tutorial` vs. `var/spack/repos/builtin` to edit packages
* one advantage of having a separate branch vs. a separate Spack repo is that this branch could include a commit which fills in all the blanks