### PR TITLE
make SPACK_SHELL detection more robust

### DIFF
--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -236,7 +236,18 @@ export SPACK_ROOT=${_sp_prefix}
 # Determine which shell is being used
 #
 function _spack_determine_shell() {
-	PS_FORMAT= ps -p $$ | tail -n 1 | awk '{print $4}' | sed 's/^-//' | xargs basename
+    # This logic is derived from the cea-hpc/modules profile.sh example at
+    # https://github.com/cea-hpc/modules/blob/master/init/profile.sh.in
+    #
+    # The objective is to correctly detect the shell type even when setup-env
+    # is sourced within a script itself rather than a login terminal.
+    if [ -n "${BASH:-}" ]; then
+        echo ${BASH##*/}
+    elif [ -n "${ZSH_NAME:-}" ]; then
+        echo $ZSH_NAME
+    else
+        PS_FORMAT= ps -p $$ | tail -n 1 | awk '{print $4}' | sed 's/^-//' | xargs basename
+    fi
 }
 export SPACK_SHELL=$(_spack_determine_shell)
 


### PR DESCRIPTION
See discussions in #7475 and #8443.  This patch attempts to make setup-env's shell detection work correctly when it is sourced within a shell script environment.  The target use cases are continuous integration environments or job scheduler scripts.

Test case:
```
#!/bin/bash
  
echo step: sourcing setup-env.sh
. /home/pcarns/working/src/spack/share/spack/setup-env.sh
echo step: loading mpich
spack load -r mpich
echo step: listing modules
module list
```
Without this PR, it produces the following output:
```
pcarns@carns-x1:~$ ./foo.sh 
step: sourcing setup-env.sh
step: loading mpich
init.c(379):ERROR:109: Unknown shell type 'foo.sh'
step: listing modules
init.c(379):ERROR:109: Unknown shell type 'foo.sh'
```
With this PR applied, it produces the following output:
```
pcarns@carns-x1:~$ ./foo.sh 
step: sourcing setup-env.sh
step: loading mpich
step: listing modules
Currently Loaded Modulefiles:
  1) mpich-3.2.1-gcc-8.2.0-36v3ogy
```