### PR TITLE
Add new version for ilmbase and openexr, add zlib dependency to openexr

### DIFF
--- a/var/spack/repos/builtin/packages/ilmbase/package.py
+++ b/var/spack/repos/builtin/packages/ilmbase/package.py
@@ -10,10 +10,17 @@ class Ilmbase(AutotoolsPackage):
     """OpenEXR ILM Base libraries (high dynamic-range image file format)"""
 
     homepage = "http://www.openexr.com/"
-    url      = "http://download.savannah.nongnu.org/releases/openexr/ilmbase-2.2.0.tar.gz"
+    url      = "https://github.com/openexr/openexr/releases/download/v2.3.0/ilmbase-2.3.0.tar.gz"
 
-    version('2.2.0', 'b540db502c5fa42078249f43d18a4652')
-    version('2.1.0', 'af1115f4d759c574ce84efcde9845d29')
-    version('2.0.1', '74c0d0d2873960bd0dc1993f8e03f0ae')
-    version('1.0.2', '26c133ee8ca48e1196fbfb3ffe292ab4')
-    version('0.9.0', '4df45f8116cb7a013b286caf6da30a2e')
+    version('2.3.0', sha256='456978d1a978a5f823c7c675f3f36b0ae14dba36638aeaa3c4b0e784f12a3862')
+
+    version('2.2.0', 'b540db502c5fa42078249f43d18a4652',
+            url='http://download.savannah.nongnu.org/releases/openexr/ilmbase-2.2.0.tar.gz')
+    version('2.1.0', 'af1115f4d759c574ce84efcde9845d29',
+            url='http://download.savannah.nongnu.org/releases/openexr/ilmbase-2.1.0.tar.gz')
+    version('2.0.1', '74c0d0d2873960bd0dc1993f8e03f0ae',
+            url='http://download.savannah.nongnu.org/releases/openexr/ilmbase-2.0.1.tar.gz')
+    version('1.0.2', '26c133ee8ca48e1196fbfb3ffe292ab4',
+            url='http://download.savannah.nongnu.org/releases/openexr/ilmbase-1.0.2.tar.gz')
+    version('0.9.0', '4df45f8116cb7a013b286caf6da30a2e',
+            url='http://download.savannah.nongnu.org/releases/openexr/ilmbase-0.9.0.tar.gz')

--- a/var/spack/repos/builtin/packages/openexr/package.py
+++ b/var/spack/repos/builtin/packages/openexr/package.py
@@ -11,7 +11,7 @@ class Openexr(Package):
 
     homepage = "http://www.openexr.com/"
     url = "https://github.com/openexr/openexr/releases/download/v2.3.0/openexr-2.3.0.tar.gz"
-    
+
     # New versions should come from github now
     version('2.3.0', sha256='fd6cb3a87f8c1a233be17b94c74799e6241d50fc5efd4df75c7a4b9cf4e25ea6')
 

--- a/var/spack/repos/builtin/packages/openexr/package.py
+++ b/var/spack/repos/builtin/packages/openexr/package.py
@@ -10,16 +10,27 @@ class Openexr(Package):
     """OpenEXR Graphics Tools (high dynamic-range image file format)"""
 
     homepage = "http://www.openexr.com/"
-    url = "https://savannah.nongnu.org/download/openexr/openexr-2.2.0.tar.gz"
+    url = "https://github.com/openexr/openexr/releases/download/v2.3.0/openexr-2.3.0.tar.gz"
+    
+    # New versions should come from github now
+    version('2.3.0', sha256='fd6cb3a87f8c1a233be17b94c74799e6241d50fc5efd4df75c7a4b9cf4e25ea6')
 
-    version('2.2.0', 'b64e931c82aa3790329c21418373db4e')
-    version('2.1.0', '33735d37d2ee01c6d8fbd0df94fb8b43')
-    version('2.0.1', '4387e6050d2faa65dd5215618ff2ddce')
-    version('1.7.0', '27113284f7d26a58f853c346e0851d7a')
-    version('1.6.1', '11951f164f9c872b183df75e66de145a')
-    version('1.5.0', '55342d2256ab3ae99da16f16b2e12ce9')
-    version('1.4.0a', 'd0a4b9a930c766fa51561b05fb204afe')
-    version('1.3.2', '1522fe69135016c52eb88fc7d8514409')
+    version('2.2.0', 'b64e931c82aa3790329c21418373db4e',
+            url="http://download.savannah.nongnu.org/releases/openexr/openexr-2.2.0.tar.gz")
+    version('2.1.0', '33735d37d2ee01c6d8fbd0df94fb8b43',
+            url="http://download.savannah.nongnu.org/releases/openexr/openexr-2.1.0.tar.gz")
+    version('2.0.1', '4387e6050d2faa65dd5215618ff2ddce',
+            url="http://download.savannah.nongnu.org/releases/openexr/openexr-2.0.1.tar.gz")
+    version('1.7.0', '27113284f7d26a58f853c346e0851d7a',
+            url="http://download.savannah.nongnu.org/releases/openexr/openexr-1.7.0.tar.gz")
+    version('1.6.1', '11951f164f9c872b183df75e66de145a',
+            url="http://download.savannah.nongnu.org/releases/openexr/openexr-1.6.1.tar.gz")
+    version('1.5.0', '55342d2256ab3ae99da16f16b2e12ce9',
+            url="http://download.savannah.nongnu.org/releases/openexr/openexr-1.5.0.tar.gz")
+    version('1.4.0a', 'd0a4b9a930c766fa51561b05fb204afe',
+            url="http://download.savannah.nongnu.org/releases/openexr/openexr-1.4.0a.tar.gz")
+    version('1.3.2', '1522fe69135016c52eb88fc7d8514409',
+            url="http://download.savannah.nongnu.org/releases/openexr/openexr-1.3.2.tar.gz")
 
     variant('debug', default=False,
             description='Builds a debug version of the libraries')

--- a/var/spack/repos/builtin/packages/openexr/package.py
+++ b/var/spack/repos/builtin/packages/openexr/package.py
@@ -26,6 +26,7 @@ class Openexr(Package):
 
     depends_on('pkgconfig', type='build')
     depends_on('ilmbase')
+    depends_on('zlib', type=('build', 'link'))
 
     def install(self, spec, prefix):
         configure_options = ['--prefix={0}'.format(prefix)]


### PR DESCRIPTION
Bump openexr version to 2.3.0 and fix #7274 where compilation can fail due to missing zlib.