### PR TITLE
fix multiple issues with the docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,11 @@
-.git
-opt/spack
-share/spack/docker/Dockerfile
-share/spack/docker/build-image.sh
-share/spack/docker/run-image.sh
-share/spack/docker/push-image.sh
+.git/*
+opt/spack/*
+
+/etc/spack/*
+!/etc/spack/defaults
+
+share/spack/dotkit/*
+share/spack/lmod/*
+share/spack/modules/*
+lib/spack/spack/test/*
+

--- a/share/spack/docker/Dockerfile
+++ b/share/spack/docker/Dockerfile
@@ -13,6 +13,7 @@ ENV DOCKERFILE_BASE=$BASE                     \
     SPACK_ROOT=/spack                         \
     FORCE_UNSAFE_CONFIGURE=1                  \
     DEBIAN_FRONTEND=noninteractive            \
+    CURRENTLY_BUILDING_DOCKER_IMAGE=1         \
     container=docker
 
 COPY bin   $SPACK_ROOT/bin
@@ -110,7 +111,10 @@ RUN rm -rf $SPACK_ROOT/.git                                          \
  && pip install boto3                                                \
  && (  echo ". /usr/share/lmod/lmod/init/bash"                       \
     && echo ". $SPACK_ROOT/share/spack/setup-env.sh"                 \
-    && echo ". $SPACK_ROOT/share/spack/spack-completion.bash" )      \
+    && echo "if [ \"\$CURRENTLY_BUILDING_DOCKER_IMAGE\" '!=' '1' ]"  \
+    && echo "then"                                                   \
+    && echo "  . $SPACK_ROOT/share/spack/spack-completion.bash"      \
+    && echo "fi"                                                   ) \
         >> /etc/profile.d/spack.sh                                   \
  && ln -s $SPACK_ROOT/share/spack/docker/handle-ssh.sh               \
         /etc/profile.d/handle-ssh.sh                                 \
@@ -126,7 +130,15 @@ MASK [[ $DISTRO_VERSION =~ (centos|fedora|opensuse|rhel.*) ]]
 RUN rm -f /run/nologin
 MASK POP
 
+# [WORKAROUND]
+# https://superuser.com/questions/1241548/
+#     xubuntu-16-04-ttyname-failed-inappropriate-ioctl-for-device#1253889
+RUN [ -f ~/.profile ]                                                   \
+ && sed -i 's/mesg \\-n/( tty -s \\&\\& mesg -n || true )/g' ~/.profile \
+ || true
+
 WORKDIR /root
-ENTRYPOINT ["bash", "/spack/share/spack/docker/entrypoint.bash"]
+SHELL ["/bin/bash", "-l", "-c"]
+ENTRYPOINT ["/bin/bash", "/spack/share/spack/docker/entrypoint.bash"]
 CMD ["docker-shell"]
 

--- a/share/spack/docker/Dockerfile
+++ b/share/spack/docker/Dockerfile
@@ -133,8 +133,8 @@ MASK POP
 # [WORKAROUND]
 # https://superuser.com/questions/1241548/
 #     xubuntu-16-04-ttyname-failed-inappropriate-ioctl-for-device#1253889
-RUN [ -f ~/.profile ]                                                   \
- && sed -i 's/mesg \\-n/( tty -s \\&\\& mesg -n || true )/g' ~/.profile \
+RUN [ -f ~/.profile ]                                               \
+ && sed -i 's/mesg n/( tty -s \\&\\& mesg n || true )/g' ~/.profile \
  || true
 
 WORKDIR /root

--- a/share/spack/docker/entrypoint.bash
+++ b/share/spack/docker/entrypoint.bash
@@ -5,6 +5,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+unset CURRENTLY_BUILDING_DOCKER_IMAGE
+
 if [ "$1" '=' 'docker-shell' ] ; then
     if [ -t 0 ] ; then
         exec bash -il

--- a/share/spack/docker/handle-prompt.sh
+++ b/share/spack/docker/handle-prompt.sh
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+if [ "$CURRENTLY_BUILDING_DOCKER_IMAGE" '!=' '1' ] ; then
+
 if [ x$SPACK_PROMPT '!=' x0 ] ; then
 
 __tmp="`mktemp -d`"
@@ -167,3 +169,5 @@ __update_prompt_main() {
 PROMPT_COMMAND=__update_prompt_main
 
 fi # [ x$SPACK_PROMPT '!=' x0 ]
+
+fi # [ "$CURRENTLY_BUILDING_DOCKER_IMAGE" '!=' '1' ]

--- a/share/spack/docker/handle-ssh.sh
+++ b/share/spack/docker/handle-ssh.sh
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+if [ "$CURRENTLY_BUILDING_DOCKER_IMAGE" '!=' '1' ] ; then
+
 uid="`id -u`"
 if [ "$uid" '=' '0' ] ; then
     for key_type in dsa ecdsa ed25519 rsa ; do
@@ -39,3 +41,5 @@ if [ '!' -f "$HOME/.ssh/id_rsa" ] ; then
     ssh-keyscan -t rsa 127.0.0.1 localhost "$docker_ip" "`hostname`" \
         > "$HOME/.ssh/known_hosts" 2> /dev/null
 fi
+
+fi # [ "$CURRENTLY_BUILDING_DOCKER_IMAGE" '!=' '1' ]


### PR DESCRIPTION
 - fixed an issue where some undesirable parts of
   the spack source tree were being copied into
   the image context.

 - added a workaround for a tty ioctl warning on
   ubuntu

 - adjusted how the main images are built so that
   `RUN spack ...` works automatically for child
   images that base themselves on them.