### PR TITLE
Delete references to ruamel.yaml at Spack start-up, if they are present

### DIFF
--- a/bin/spack
+++ b/bin/spack
@@ -31,6 +31,20 @@ if sys.version_info[:2] == (2, 6):
 
 sys.path.insert(0, spack_external_libs)
 
+# Here we delete ruamel.yaml if it has been imported on the system
+# (see #9206 for a description of the issue).
+#
+# Deleting the entry from sys.modules is the fastest way to solve our
+# issues with ruamel.yaml .pth file, but could leave pre-existing references
+# to the "site" installed module still in place. This should be a rare
+# occurrence happening only if spack is run from another external command
+# that also imports ruamel.yaml before reaching the lines below.
+if 'ruamel.yaml' in sys.modules:
+    del sys.modules['ruamel.yaml']
+
+if 'ruamel' in sys.modules:
+    del sys.modules['ruamel']
+
 # Once we've set up the system path, run the spack main method
 import spack.main  # noqa
 sys.exit(spack.main.main())

--- a/bin/spack
+++ b/bin/spack
@@ -31,14 +31,12 @@ if sys.version_info[:2] == (2, 6):
 
 sys.path.insert(0, spack_external_libs)
 
-# Here we delete ruamel.yaml if it has been imported on the system
-# (see #9206 for a description of the issue).
+# Here we delete ruamel.yaml in case it has been already imported from site
+# (see #9206 for a broader description of the issue).
 #
-# Deleting the entry from sys.modules is the fastest way to solve our
-# issues with ruamel.yaml .pth file, but could leave pre-existing references
-# to the "site" installed module still in place. This should be a rare
-# occurrence happening only if spack is run from another external command
-# that also imports ruamel.yaml before reaching the lines below.
+# Briefly: ruamel.yaml produces a .pth file when installed with pip that
+# makes the site installed package the preferred one, even tough sys.path
+# is modified to point to another version of ruamel.yaml.
 if 'ruamel.yaml' in sys.modules:
     del sys.modules['ruamel.yaml']
 


### PR DESCRIPTION
fixes #9619
fixes #9206

closes #9702 (alternative solution to the same issue)
closes #9261 (alternative solution to the same issue)

`ruamel.yaml` generates a `.pth` file when installed via pip that has the effect of always preferring the version of this package installed at site scope (effectively preventing us from vendoring it).

This mechanism triggers when implicitly importing the `site` module when the python interpreter is started. In this PR we explicitly delete references to `ruamel.yaml` and `ruamel` in `sys.modules`, if any, after we set `sys.path` to search from the directory where we store vendored packages. This ensures that the imports after those statements will be done from our vendored version.