### PR TITLE
Allow build caches for packages with broken symlinks

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import errno
 import re
 import tarfile
 import shutil
@@ -124,6 +125,15 @@ def write_buildinfo_file(prefix, workdir, rel=False):
         dirs[:] = [d for d in dirs if d not in blacklist]
         for filename in files:
             path_name = os.path.join(root, filename)
+            try:
+                os.stat(path_name)
+            except OSError, e:
+                if e.errno == errno.ENOENT:
+                    tty.warn("{0} does not exist, or is a broken symlink"
+                             .format(path_name))
+                    continue
+                else:
+                    raise e
             #  Check if the file contains a string with the installroot.
             #  This cuts down on the number of files added to the list
             #  of files potentially needing relocation


### PR DESCRIPTION
if a package install generates broken symlinks, avoid doing a 'strings' check on them, as it will fail; print a warning instead

At some level this addresses a symptom rather than a cause: should package be considered installed by Spack if it contains broken symlinks? Probably not.