### PR TITLE
Binary caching: remove symlinks, copy files instead

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -588,14 +588,14 @@ def get_keys(install=False, trust=False, force=False):
             tty.msg("Finding public keys in %s" % mirror)
             files = os.listdir(mirror)
             for file in files:
-                if re.search('\.key', file):
+                if re.search(r'\.key', file):
                     link = 'file://' + mirror + '/' + file
                     keys.add(link)
         else:
             tty.msg("Finding public keys on %s" % url)
             p, links = spider(url + "/build_cache", depth=1)
             for link in links:
-                if re.search("\.key", link):
+                if re.search(r'\.key', link):
                     keys.add(link)
         for link in keys:
             with Stage(link, name="build_cache", keep=True) as stage:

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -269,7 +269,9 @@ def build_tarball(spec, outdir, force=False, rel=False, unsigned=False,
             raise NoOverwriteException(str(specfile_path))
     # make a copy of the install directory to work with
     workdir = os.path.join(tempfile.mkdtemp(), os.path.basename(spec.prefix))
-    install_tree(spec.prefix, workdir, symlinks=True)
+    # set symlinks=False here to avoid broken symlinks when archiving and
+    # moving the package
+    install_tree(spec.prefix, workdir, symlinks=False)
 
     # create info for later relocation and create tar
     write_buildinfo_file(spec.prefix, workdir, rel=rel)


### PR DESCRIPTION
@scottwittenburg @gartung 

@becker33 this will fix some broken symlinks for bzip2, for example. However, it may not be essential, as from what I can tell most packages don't use the extra symlinks (e.g. `bzegrep`) that are broken.

Binary caches of packages with absolute symlinks had broken symlinks. From what I can tell, tar doesn't support any notion of matching source/destination roots when unpacking an archive with absolute symlinks. Therefore, this commit just makes a copy of any file that is a symlink while creating a binary cache of a package.