### PR TITLE
Use the raw compiler path for the preprocessing pass in CLAW driver

### DIFF
--- a/var/spack/repos/builtin/packages/claw/package.py
+++ b/var/spack/repos/builtin/packages/claw/package.py
@@ -30,4 +30,7 @@ class Claw(CMakePackage):
         args.append('-DOMNI_CONF_OPTION=--with-libxml2={0}'.
                     format(spec['libxml2'].prefix))
 
+        args.append('-DCMAKE_Fortran_COMPILER={0}'.
+                   format(self.compiler.fc))
+
         return args


### PR DESCRIPTION
* The CLAW compiler uses the native compiler preprocessing capabilities therefore, the raw path of the compiler is needed to configure the CLAW Compiler and not the Spack wrapper. 

Thanks @jrood-nrel to point out this problem