### PR TITLE
More improvements for CDash reporter

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -141,6 +141,24 @@ packages. If neither are chosen, don't run tests for any packages."""
         default=None,
         help="CDash URL where reports will be uploaded"
     )
+    subparser.add_argument(
+        '--cdash-build',
+        default=None,
+        help="""The name of the build that will be reported to CDash.
+Defaults to spec of the package to install."""
+    )
+    subparser.add_argument(
+        '--cdash-site',
+        default=None,
+        help="""The site name that will be reported to CDash.
+Defaults to current system hostname."""
+    )
+    subparser.add_argument(
+        '--cdash-track',
+        default='Experimental',
+        help="""Results will be reported to this group on CDash.
+Defaults to Experimental."""
+    )
     arguments.add_common_arguments(subparser, ['yes_to_all'])
 
 
@@ -224,9 +242,7 @@ def install(parser, args, **kwargs):
         tty.warn("Deprecated option: --run-tests: use --test=all instead")
 
     # 1. Abstract specs from cli
-    reporter = spack.report.collect_info(args.log_format,
-                                         ' '.join(args.package),
-                                         args.cdash_upload_url)
+    reporter = spack.report.collect_info(args.log_format, args)
     if args.log_file:
         reporter.filename = args.log_file
 

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -228,15 +228,14 @@ class collect_info(object):
 
     Args:
         format_name (str or None): one of the supported formats
-        install_command (str): the command line passed to spack
-        cdash_upload_url (str or None): where to upload the report
+        args (dict): args passed to spack install
 
     Raises:
         ValueError: when ``format_name`` is not in ``valid_formats``
     """
-    def __init__(self, format_name, install_command, cdash_upload_url):
+    def __init__(self, format_name, args):
         self.filename = None
-        if cdash_upload_url:
+        if args.cdash_upload_url:
             self.format_name = 'cdash'
             self.filename = 'cdash_report'
         else:
@@ -245,8 +244,7 @@ class collect_info(object):
         if self.format_name not in valid_formats:
             raise ValueError('invalid report type: {0}'
                              .format(self.format_name))
-        self.report_writer = report_writers[self.format_name](
-            install_command, cdash_upload_url)
+        self.report_writer = report_writers[self.format_name](args)
 
     def concretization_report(self, msg):
         self.report_writer.concretization_report(self.filename, msg)

--- a/lib/spack/spack/reporter.py
+++ b/lib/spack/spack/reporter.py
@@ -10,9 +10,8 @@ __all__ = ['Reporter']
 class Reporter(object):
     """Base class for report writers."""
 
-    def __init__(self, install_command, cdash_upload_url):
-        self.install_command = install_command
-        self.cdash_upload_url = cdash_upload_url
+    def __init__(self, args):
+        self.args = args
 
     def build_report(self, filename, report_data):
         pass

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -77,6 +77,7 @@ class CDash(Reporter):
 
         # Parse output phase-by-phase.
         phase_regexp = re.compile(r"Executing phase: '(.*)'")
+        cdash_phase = ''
         for spec in report_data['specs']:
             for package in spec['packages']:
                 if 'stdout' in package:

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -51,15 +51,17 @@ class CDash(Reporter):
     CDash instance hosted at https://mydomain.com/cdash.
     """
 
-    def __init__(self, install_command, cdash_upload_url):
-        Reporter.__init__(self, install_command, cdash_upload_url)
+    def __init__(self, args):
+        Reporter.__init__(self, args)
         self.template_dir = os.path.join('reports', 'cdash')
-        self.hostname = socket.gethostname()
+        self.cdash_upload_url = args.cdash_upload_url
+        self.install_command = ' '.join(args.package)
+        self.buildname = args.cdash_build or self.install_command
+        self.site = args.cdash_site or socket.gethostname()
         self.osname = platform.system()
         self.starttime = int(time.time())
-        # TODO: remove hardcoded use of Experimental here.
-        #       Make the submission model configurable.
-        self.buildstamp = time.strftime("%Y%m%d-%H%M-Experimental",
+        buildstamp_format = "%Y%m%d-%H%M-{0}".format(args.cdash_track)
+        self.buildstamp = time.strftime(buildstamp_format,
                                         time.localtime(self.starttime))
 
     def build_report(self, filename, report_data):
@@ -176,10 +178,11 @@ class CDash(Reporter):
     def initialize_report(self, filename, report_data):
         if not os.path.exists(filename):
             os.mkdir(filename)
-        report_data['install_command'] = self.install_command
+        report_data['buildname'] = self.buildname
         report_data['buildstamp'] = self.buildstamp
-        report_data['hostname'] = self.hostname
+        report_data['install_command'] = self.install_command
         report_data['osname'] = self.osname
+        report_data['site'] = self.site
 
     def upload(self, filename):
         if not self.cdash_upload_url:

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -63,10 +63,10 @@ class CDash(Reporter):
         self.buildname = args.cdash_build or self.install_command
         self.site = args.cdash_site or socket.gethostname()
         self.osname = platform.system()
-        self.starttime = int(time.time())
+        self.endtime = int(time.time())
         buildstamp_format = "%Y%m%d-%H%M-{0}".format(args.cdash_track)
         self.buildstamp = time.strftime(buildstamp_format,
-                                        time.localtime(self.starttime))
+                                        time.localtime(self.endtime))
         self.buildId = None
         self.revision = ''
         git = which('git')
@@ -80,16 +80,18 @@ class CDash(Reporter):
             report_data[phase] = {}
             report_data[phase]['log'] = ""
             report_data[phase]['status'] = 0
-            report_data[phase]['starttime'] = self.starttime
-            report_data[phase]['endtime'] = self.starttime
+            report_data[phase]['endtime'] = self.endtime
 
         # Track the phases we perform so we know what reports to create.
         phases_encountered = []
+        total_duration = 0
 
         # Parse output phase-by-phase.
         phase_regexp = re.compile(r"Executing phase: '(.*)'")
         cdash_phase = ''
         for spec in report_data['specs']:
+            if 'time' in spec:
+                total_duration += int(spec['time'])
             for package in spec['packages']:
                 if 'stdout' in package:
                     current_phase = ''
@@ -121,7 +123,9 @@ class CDash(Reporter):
             build_pos = phases_encountered.index("build")
             phases_encountered.insert(0, phases_encountered.pop(build_pos))
 
+        self.starttime = self.endtime - total_duration
         for phase in phases_encountered:
+            report_data[phase]['starttime'] = self.starttime
             errors, warnings = parse_log_events(
                 report_data[phase]['log'].splitlines())
             nerrors = len(errors)
@@ -182,8 +186,8 @@ class CDash(Reporter):
         report_data = {}
         self.initialize_report(filename, report_data)
         report_data['update'] = {}
-        report_data['update']['starttime'] = self.starttime
-        report_data['update']['endtime'] = self.starttime
+        report_data['update']['starttime'] = self.endtime
+        report_data['update']['endtime'] = self.endtime
         report_data['update']['revision'] = self.revision
         report_data['update']['log'] = msg
 

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -78,7 +78,7 @@ class CDash(Reporter):
 
         for phase in cdash_phases:
             report_data[phase] = {}
-            report_data[phase]['log'] = ""
+            report_data[phase]['loglines'] = []
             report_data[phase]['status'] = 0
             report_data[phase]['endtime'] = self.endtime
 
@@ -97,7 +97,9 @@ class CDash(Reporter):
                     current_phase = ''
                     cdash_phase = ''
                     for line in package['stdout'].splitlines():
-                        match = phase_regexp.search(line)
+                        match = None
+                        if line.find("Executing phase: '") != -1:
+                            match = phase_regexp.search(line)
                         if match:
                             current_phase = match.group(1)
                             if current_phase not in map_phases_to_cdash:
@@ -107,12 +109,12 @@ class CDash(Reporter):
                                 map_phases_to_cdash[current_phase]
                             if cdash_phase not in phases_encountered:
                                 phases_encountered.append(cdash_phase)
-                            report_data[cdash_phase]['log'] += \
-                                text_type("{0} output for {1}:\n".format(
-                                    cdash_phase, package['name']))
+                            report_data[cdash_phase]['loglines'].append(
+                                text_type("{0} output for {1}:".format(
+                                    cdash_phase, package['name'])))
                         elif cdash_phase:
-                            report_data[cdash_phase]['log'] += \
-                                xml.sax.saxutils.escape(line) + "\n"
+                            report_data[cdash_phase]['loglines'].append(
+                                xml.sax.saxutils.escape(line))
 
         phases_encountered.append('update')
 
@@ -126,8 +128,9 @@ class CDash(Reporter):
         self.starttime = self.endtime - total_duration
         for phase in phases_encountered:
             report_data[phase]['starttime'] = self.starttime
-            errors, warnings = parse_log_events(
-                report_data[phase]['log'].splitlines())
+            report_data[phase]['log'] = \
+                '\n'.join(report_data[phase]['loglines'])
+            errors, warnings = parse_log_events(report_data[phase]['loglines'])
             nerrors = len(errors)
 
             if phase == 'configure' and nerrors > 0:

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -14,6 +14,7 @@ import time
 import xml.sax.saxutils
 from six import text_type
 from six.moves.urllib.request import build_opener, HTTPHandler, Request
+from six.moves.urllib.parse import urlencode
 
 import spack.build_environment
 import spack.fetch_strategy
@@ -197,9 +198,14 @@ class CDash(Reporter):
         buildid_regexp = re.compile("<buildId>([0-9]+)</buildId>")
         opener = build_opener(HTTPHandler)
         with open(filename, 'rb') as f:
-            url = "{0}&build={1}&site={2}&stamp={3}&MD5={4}".format(
-                self.cdash_upload_url, self.buildname, self.site,
-                self.buildstamp, md5sum)
+            params_dict = {
+                'build': self.buildname,
+                'site': self.site,
+                'stamp': self.buildstamp,
+                'MD5': md5sum,
+            }
+            encoded_params = urlencode(params_dict)
+            url = "{0}&{1}".format(self.cdash_upload_url, encoded_params)
             request = Request(url, data=f)
             request.add_header('Content-Type', 'text/xml')
             request.add_header('Content-Length', os.path.getsize(filename))

--- a/lib/spack/spack/reporters/junit.py
+++ b/lib/spack/spack/reporters/junit.py
@@ -17,8 +17,8 @@ __all__ = ['JUnit']
 class JUnit(Reporter):
     """Generate reports of spec installations for JUnit."""
 
-    def __init__(self, install_command, cdash_upload_url):
-        Reporter.__init__(self, install_command, cdash_upload_url)
+    def __init__(self, args):
+        Reporter.__init__(self, args)
         self.template_file = os.path.join('reports', 'junit.xml')
 
     def build_report(self, filename, report_data):

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -433,6 +433,29 @@ def test_cdash_upload_clean_build(tmpdir, mock_fetch, install_mockery,
 
 
 @pytest.mark.disable_clean_stage_check
+def test_cdash_upload_extra_params(tmpdir, mock_fetch, install_mockery, capfd):
+    # capfd interferes with Spack's capturing
+    with capfd.disabled():
+        with tmpdir.as_cwd():
+            with pytest.raises((HTTPError, URLError)):
+                install(
+                    '--log-file=cdash_reports',
+                    '--cdash-build=my_custom_build',
+                    '--cdash-site=my_custom_site',
+                    '--cdash-track=my_custom_track',
+                    '--cdash-upload-url=http://localhost/fakeurl/submit.php?project=Spack',
+                    'a')
+            report_dir = tmpdir.join('cdash_reports')
+            assert report_dir in tmpdir.listdir()
+            report_file = report_dir.join('Build.xml')
+            assert report_file in report_dir.listdir()
+            content = report_file.open().read()
+            assert 'Site BuildName="my_custom_build"' in content
+            assert 'Name="my_custom_site"' in content
+            assert '-my_custom_track' in content
+
+
+@pytest.mark.disable_clean_stage_check
 def test_build_error_output(tmpdir, mock_fetch, install_mockery, capfd):
     with capfd.disabled():
         msg = ''

--- a/share/spack/templates/reports/cdash/Site.xml
+++ b/share/spack/templates/reports/cdash/Site.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Site BuildName="{{ install_command }}"
+<Site BuildName="{{ buildname }}"
       BuildStamp="{{ buildstamp }}"
-      Name="{{ hostname }}"
+      Name="{{ site }}"
       OSName="{{ osname }}"
 >
 

--- a/share/spack/templates/reports/cdash/Update.xml
+++ b/share/spack/templates/reports/cdash/Update.xml
@@ -3,9 +3,12 @@
   <Site>{{ site }}</Site>
   <BuildName>{{ buildname }}</BuildName>
   <BuildStamp>{{ buildstamp }}</BuildStamp>
-  <StartTime>{{ starttime }}</StartTime>
-  <EndTime>{{ endtime }}</EndTime>
-{% if msg %}
-  <UpdateReturnStatus>{{ msg }}</UpdateReturnStatus>
+  <StartTime>{{ update.starttime }}</StartTime>
+  <UpdateCommand></UpdateCommand>
+  <UpdateType>GIT</UpdateType>
+  <Revision>{{ update.revision }}</Revision>
+  <EndTime>{{ update.endtime }}</EndTime>
+{% if update.log %}
+  <UpdateReturnStatus>{{ update.log }}</UpdateReturnStatus>
 {% endif %}
 </Update>

--- a/share/spack/templates/reports/cdash/Update.xml
+++ b/share/spack/templates/reports/cdash/Update.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Update>
-  <Site>{{ hostname }}</Site>
-  <BuildName>{{ install_command }}</BuildName>
+  <Site>{{ site }}</Site>
+  <BuildName>{{ buildname }}</BuildName>
   <BuildStamp>{{ buildstamp }}</BuildStamp>
   <StartTime>{{ starttime }}</StartTime>
   <EndTime>{{ endtime }}</EndTime>


### PR DESCRIPTION
* More customization options: allow user to specify the build name, site name, and/or track to report to CDash
* Check for a buildId in the response for CDash.  If one is found, print out a link to view the results in CDash
* Record and report the current git commit SHA1 of Spack to CDash
* Report more accurate build time information to CDash (#9590)
* Improve performance of report generation when lots of build output is generated