### PR TITLE
Add pic variant to cflags in boost.

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -122,8 +122,9 @@ class Boost(Package):
             description='Compile with clang libc++ instead of libstdc++')
     variant('numpy', default=False,
             description='Build the Boost NumPy library (requires +python)')
-    variant('pic', default=True,
-            description='Produce position-independent code (for shared libs)')
+    variant('pic', default=False,
+            description='Generate position-independent code (PIC), useful '
+                        'for building static libraries')
 
     depends_on('icu4c', when='+icu')
     depends_on('python', when='+python')

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -122,6 +122,8 @@ class Boost(Package):
             description='Compile with clang libc++ instead of libstdc++')
     variant('numpy', default=False,
             description='Build the Boost NumPy library (requires +python)')
+    variant('pic', default=True,
+            description='Produce position-independent code (for shared libs)')
 
     depends_on('icu4c', when='+icu')
     depends_on('python', when='+python')
@@ -213,14 +215,12 @@ class Boost(Package):
                                                        spack_cxx))
 
             if '+mpi' in spec:
-
                 # Use the correct mpi compiler.  If the compiler options are
                 # empty or undefined, Boost will attempt to figure out the
                 # correct options by running "${mpicxx} -show" or something
                 # similar, but that doesn't work with the Cray compiler
                 # wrappers.  Since Boost doesn't use the MPI C++ bindings,
                 # that can be used as a compiler option instead.
-
                 mpi_line = 'using mpi : %s' % spec['mpi'].mpicxx
 
                 if 'platform=cray' in spec:
@@ -312,6 +312,9 @@ class Boost(Package):
             flag = self.cxxstd_to_flag(spec.variants['cxxstd'].value)
             if flag:
                 cxxflags.append(flag)
+
+        if '+pic' in self.spec:
+            cxxflags.append(self.compiler.pic_flag)
 
         # clang is not officially supported for pre-compiled headers
         # and at least in clang 3.9 still fails to build


### PR DESCRIPTION
While installing a package depending on the boost library, I've got the following error:
```
     24046    /usr/bin/ld: /opt/cluster/spack/opt/spack/linux-centos7-x86_64/gcc-8.2.0/boost-1.68.0-xkyf5icz7yn62yjvduwrs3mfru4merj4/lib/libboost_serialization-mt.a(archive_exception.o): re
              location R_X86_64_32S against symbol `_ZTVN5boost7archive17archive_exceptionE' can not be used when making a shared object; recompile with -fPIC
     24047    /usr/bin/ld: /opt/cluster/spack/opt/spack/linux-centos7-x86_64/gcc-8.2.0/boost-1.68.0-xkyf5icz7yn62yjvduwrs3mfru4merj4/lib/libboost_serialization-mt.a(basic_archive.o): reloca
              tion R_X86_64_32 against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC
     24048    /usr/bin/ld: /opt/cluster/spack/opt/spack/linux-centos7-x86_64/gcc-8.2.0/boost-1.68.0-xkyf5icz7yn62yjvduwrs3mfru4merj4/lib/libboost_filesystem-mt.a(operations.o): relocation R
              _X86_64_32 against `.rodata.str1.8' can not be used when making a shared object; recompile with -fPIC
     24049    /usr/bin/ld: /opt/cluster/spack/opt/spack/linux-centos7-x86_64/gcc-8.2.0/boost-1.68.0-xkyf5icz7yn62yjvduwrs3mfru4merj4/lib/libboost_filesystem-mt.a(path.o): relocation R_X86_6
              4_32 against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC
     24050    /usr/bin/ld: /opt/cluster/spack/opt/spack/linux-centos7-x86_64/gcc-8.2.0/boost-1.68.0-xkyf5icz7yn62yjvduwrs3mfru4merj4/lib/libboost_date_time-mt.a(greg_month.o): relocation R_
              X86_64_32S against `.rodata' can not be used when making a shared object; recompile with -fPIC
     24051    /usr/bin/ld: /opt/cluster/spack/opt/spack/linux-centos7-x86_64/gcc-8.2.0/boost-1.68.0-xkyf5icz7yn62yjvduwrs3mfru4merj4/lib/libboost_system-mt.a(error_code.o): relocation R_X86
              _64_32S against `.rodata' can not be used when making a shared object; recompile with -fPIC
  >> 24052    /usr/bin/ld: final link failed: Nonrepresentable section on output
  >> 24053    collect2: error: ld returned 1 exit status
  >> 24054    make[2]: *** [Pyext/ecflow.so] Error 1
     24055    make[2]: Leaving directory `/tmp/root/spack-stage/spack-stage-8usvfauy/ecFlow-4.11.1-Source/spack-build'
  >> 24056    make[1]: *** [Pyext/CMakeFiles/ecflow.dir/all] Error 2
     24057    make[1]: *** Waiting for unfinished jobs....
```

Therefore I've added the pic variant, as in #9605.