### PR TITLE
Update `spack install` to use cache by default

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -536,11 +536,12 @@ def get_specs(force=False):
         if url.startswith('file'):
             mirror = url.replace('file://', '') + '/build_cache'
             tty.msg("Finding buildcaches in %s" % mirror)
-            files = os.listdir(mirror)
-            for file in files:
-                if re.search('spec.yaml', file):
-                    link = 'file://' + mirror + '/' + file
-                    urls.add(link)
+            if os.path.exists(mirror):
+                files = os.listdir(mirror)
+                for file in files:
+                    if re.search('spec.yaml', file):
+                        link = 'file://' + mirror + '/' + file
+                        urls.add(link)
         else:
             tty.msg("Finding buildcaches on %s" % url)
             p, links = spider(url + "/build_cache")

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -50,7 +50,7 @@ the dependencies"""
         '--dont-restage', action='store_true',
         help="if a partial install is detected, don't delete prior state")
     subparser.add_argument(
-        '--use-cache', action='store_true', dest='use_cache',
+        '--no-cache', action='store_false', dest='use_cache',
         help="check for pre-built Spack packages in mirrors")
     subparser.add_argument(
         '--show-log-on-error', action='store_true',

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1403,7 +1403,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
 
         tty.msg(colorize('@*{Installing} @*g{%s}' % self.name))
 
-        if kwargs.get('use_cache', False):
+        if kwargs.get('use_cache', True):
             if self.try_install_from_binary_cache(explicit):
                 tty.msg('Successfully installed %s from binary cache'
                         % self.name)

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -198,6 +198,9 @@ echo $PATH"""
     shutil.rmtree(mirror_path)
     stage.destroy()
 
+    # Remove cached binary specs since we deleted the mirror
+    bindist._cached_specs = None
+
 
 def test_relocate_text(tmpdir):
     with tmpdir.as_cwd():


### PR DESCRIPTION
Turns on binary cache installs by default.

Binary caches can be ignored using the `--no-cache` option to `spack install`.

Binary packaging test also updated to not pollute the test environment with cached available specs for binary packages.