### PR TITLE
travis: allow Python 2.6 to fail until we figure out why Travis hangs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,6 +116,8 @@ jobs:
   allow_failures:
     - dist: xenial
     - env: TEST_SUITE=docker
+    # temporary Python 2.6 exception while we figure out why Travis is hanging
+    - python: '2.6'
 
 stages:
   - 'style checks'


### PR DESCRIPTION
- Python 2.6 tests are currently failing due to some issue in Travis that we haven't been able to diagnose.
- They run fine locally and when logging into a Travis session, just not in actual Travis
- Allow them to fail until we can fix this in Travis