### PR TITLE
libssh: fix fetching and add 0.8.5

### DIFF
--- a/var/spack/repos/builtin/packages/libssh/package.py
+++ b/var/spack/repos/builtin/packages/libssh/package.py
@@ -10,9 +10,15 @@ class Libssh(CMakePackage):
     """libssh: the SSH library"""
 
     homepage = "https://www.libssh.org"
-    url      = "https://red.libssh.org/attachments/download/218/libssh-0.7.5.tar.xz"
+    url      = "https://www.libssh.org/files/0.8/libssh-0.8.5.tar.xz"
 
+    version('0.8.5', '07d2c431240fc88f6b06bcb36ae267f9afeedce2e32f6c42f8844b205ab5a335')
     version('0.7.5', 'd3fc864208bf607ad87cdee836894feb')
 
+    depends_on('openssl@:1.0', when='@:0.7')
     depends_on('openssl')
     depends_on('zlib')
+
+    def url_for_version(self, version):
+        url = "https://www.libssh.org/files/{0}/libssh-{1}.tar.xz"
+        return url.format(version.up_to(2), version)


### PR DESCRIPTION
Required for openssl@1.1 compatibility.