### PR TITLE
openssh: add 7.9p1

### DIFF
--- a/var/spack/repos/builtin/packages/openssh/package.py
+++ b/var/spack/repos/builtin/packages/openssh/package.py
@@ -18,6 +18,7 @@ class Openssh(AutotoolsPackage):
     homepage = "https://www.openssh.com/"
     url      = "https://mirrors.sonic.net/pub/OpenBSD/OpenSSH/portable/openssh-7.6p1.tar.gz"
 
+    version('7.9p1',   '6b4b3ba2253d84ed3771c8050728d597c91cfce898713beb7b64a305b6f11aad')
     version('7.6p1',   '06a88699018e5fef13d4655abfed1f63')
     version('7.5p1',   '652fdc7d8392f112bef11cacf7e69e23')
     version('7.4p1',   'b2db2a83caf66a208bb78d6d287cdaa3')
@@ -30,7 +31,15 @@ class Openssh(AutotoolsPackage):
     version('6.7p1',   '3246aa79317b1d23cae783a3bf8275d6')
     version('6.6p1',   '3e9800e6bca1fbac0eea4d41baa7f239')
 
+    depends_on('openssl@:1.0', when='@:7.7p1')
     depends_on('openssl')
     depends_on('libedit')
     depends_on('ncurses')
     depends_on('zlib')
+
+    def configure_args(self):
+        # OpenSSH's privilege separation path defaults to /var/empty. At
+        # least newer versions want to create the directory during the
+        # install step and fail if they cannot do so.
+        args = ['--with-privsep-path={0}'.format(self.prefix.var.empty)]
+        return args


### PR DESCRIPTION
Required for openssl@1.1 compatibility.