### PR TITLE
py-cryptography: add 2.3.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-cryptography/package.py
+++ b/var/spack/repos/builtin/packages/py-cryptography/package.py
@@ -14,6 +14,7 @@ class PyCryptography(PythonPackage):
     homepage = "https://pypi.python.org/pypi/cryptography"
     url      = "https://pypi.io/packages/source/c/cryptography/cryptography-1.8.1.tar.gz"
 
+    version('2.3.1', '8d10113ca826a4c29d5b85b2c4e045ffa8bad74fb525ee0eceb1d38d4c70dfd6')
     version('1.8.1', '9f28a9c141995cd2300d0976b4fac3fb')
 
     # dependencies taken from https://github.com/pyca/cryptography/blob/master/setup.py
@@ -24,4 +25,5 @@ class PyCryptography(PythonPackage):
     depends_on('py-idna@2.1:',          type=('build', 'run'))
     depends_on('py-enum34',             type=('build', 'run'), when='^python@:3.4')
     depends_on('py-ipaddress',          type=('build', 'run'), when='^python@:3.3')
+    depends_on('openssl@:1.0', when='@:1.8.1')
     depends_on('openssl')


### PR DESCRIPTION
Required for openssl@1.1 compatibility.