### PR TITLE
hotfix for rpath/runpath issues on ubuntu 17+

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -380,8 +380,11 @@ case "$mode" in
 esac
 
 # Linker flags
+# SPACK_LD_RPATH_ARG is a hotfix for ubuntu 17+
+# TODO: Find a better way to do this
 case "$mode" in
     ld|ccld)
+        flags=("${flags[@]}" "${SPACK_LD_RPATH_ARG}")
         flags=("${flags[@]}" "${SPACK_LDFLAGS[@]}") ;;
 esac
 

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -195,6 +195,15 @@ def set_compiler_environment_variables(pkg, env):
     env.set('SPACK_F77_RPATH_ARG', compiler.f77_rpath_arg)
     env.set('SPACK_FC_RPATH_ARG',  compiler.fc_rpath_arg)
 
+    # Set linker behavior to use rpaths
+    # necessary for ubuntu 17+
+    # HOTFIX: TODO: Something better
+    rpath_arg = ''
+    pkg_os = pkg.spec.architecture.platform_os
+    if pkg_os.startswith('ubuntu') and int(pkg_os[6:8]) >= 17:
+        rpath_arg = '-Wl,--disable-new-dtags' 
+    env.set('SPACK_LD_RPATH_ARG', rpath_arg)
+    
     # Trap spack-tracked compiler flags as appropriate.
     # env_flags are easy to accidentally override.
     inject_flags = {}


### PR DESCRIPTION
Relocation fails with runpath.

Later PR should clean this up, but it's necessary for proper functionality now and we have a tutorial Monday.