### PR TITLE
ruby: add 2.5.3

### DIFF
--- a/var/spack/repos/builtin/packages/ruby/package.py
+++ b/var/spack/repos/builtin/packages/ruby/package.py
@@ -15,6 +15,7 @@ class Ruby(AutotoolsPackage):
     list_url = "http://cache.ruby-lang.org/pub/ruby/"
     list_depth = 1
 
+    version('2.5.3', '9828d03852c37c20fa333a0264f2490f07338576734d910ee3fd538c9520846c')
     version('2.2.0', 'cd03b28fd0b555970f5c4fd481700852')
 
     variant('openssl', default=True, description="Enable OpenSSL support")
@@ -28,6 +29,7 @@ class Ruby(AutotoolsPackage):
     depends_on('libx11')
     depends_on('tcl')
     depends_on('tk')
+    depends_on('openssl@:1.0', when='@:2.3+openssl')
     depends_on('openssl', when='+openssl')
     depends_on('readline', when='+readline')
 
@@ -98,7 +100,8 @@ class Ruby(AutotoolsPackage):
                                                'GlobalSignRootCA.pem')
         rubygems_certs_path = join_path(self.spec.prefix.lib,
                                         'ruby',
-                                        '{0}'.format(self.spec.version.dotted),
+                                        '{0}.0'.format(self.spec.version.
+                                                       up_to(2)),
                                         'rubygems',
                                         'ssl_certs')
         install(rubygems_updated_cert_path, rubygems_certs_path)


### PR DESCRIPTION
Required for openssl@1.1 compatibility.