### PR TITLE
install: add --use-cache back so that existing tooling does not break

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -74,9 +74,15 @@ the dependencies"""
     subparser.add_argument(
         '--dont-restage', action='store_true',
         help="if a partial install is detected, don't delete prior state")
-    subparser.add_argument(
-        '--no-cache', action='store_false', dest='use_cache',
+
+    cache_group = subparser.add_mutually_exclusive_group()
+    cache_group.add_argument(
+        '--use-cache', action='store_true', dest='use_cache',
         help="check for pre-built Spack packages in mirrors")
+    cache_group.add_argument(
+        '--no-cache', action='store_false', dest='use_cache',
+        help="do not check for pre-built Spack packages in mirrors")
+
     subparser.add_argument(
         '--show-log-on-error', action='store_true',
         help="print full build log to stderr if build fails")


### PR DESCRIPTION
- default is still to use the cache, but we've added back the `--use-cache` argument so that scripts that used it are still correct.

- `--no-cache` is stil present and is mutually exclusive with `--use-cache`