### PR TITLE
Fix docker builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -202,28 +202,6 @@ services:
 
 script:
   - share/spack/qa/run-$TEST_SUITE-tests
-  - if [[ "$TEST_SUITE" == "docker build" ]]; then
-        login_attempted=0; login_success=0;
-        for config in share/spack/docker/config/* ; do
-            source "$config" ;
-            ./share/spack/docker/build-image.sh;
-            if [ "$TRAVIS_EVENT_TYPE" != "pull_request" ]; then
-                if [ "$login_attempted" '=' '0' ]; then
-                    if echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin; then
-                        login_success=1;
-                    fi;
-                    login_attempted=1;
-                fi;
-                if [ "$login_success" '=' '1' ]; then
-                    ./share/spack/docker/push-image.sh;
-                fi
-            fi
-        done;
-    fi
-  - if [[ "$TEST_SUITE" == "unit" || "$TEST_SUITE" == "build" ]]; then
-        codecov --env PYTHON_VERSION
-                --required --flags "${TEST_SUITE}${TRAVIS_OS_NAME}";
-    fi
 
 #=============================================================================
 # Notifications

--- a/share/spack/docker/Dockerfile
+++ b/share/spack/docker/Dockerfile
@@ -31,15 +31,27 @@ RUN pacman -Sy --noconfirm                                     \
         sudo         tcl                                       \
  && echo 'nobody ALL=(ALL) NOPASSWD: ALL' >                    \
         /etc/sudoers.d/nobody-sudo                             \
- && sudo -u nobody git clone --depth 1                         \
-        https://aur.archlinux.org/lua-posix.git /tmp/lua-posix \
- && sudo -u nobody git clone --depth 1                         \
-        https://aur.archlinux.org/lmod.git /tmp/lmod           \
+ && sudo -u nobody git clone                                   \
+        'https://aur.archlinux.org/lua-std-_debug.git'         \
+        '/tmp/lua-std-_debug'                                  \
+ && sudo -u nobody git clone                                   \
+        'https://aur.archlinux.org/lua-std-normalize.git'      \
+        '/tmp/lua-std-normalize'                               \
+ && sudo -u nobody git clone                                   \
+        'https://aur.archlinux.org/lua-posix.git'              \
+        '/tmp/lua-posix'                                       \
+ && (  cd /tmp/lua-std-_debug                                  \
+ &&    sudo -u nobody makepkg -si --asdeps --noconfirm )       \
+ && (  cd /tmp/lua-std-normalize                               \
+ &&    sudo -u nobody makepkg -si --asdeps --noconfirm )       \
  && (  cd /tmp/lua-posix                                       \
-    && sudo -u nobody makepkg -si --asdeps --noconfirm )       \
+ &&    sudo -u nobody makepkg -si --asdeps --noconfirm )       \
+ && sudo -u nobody git clone                                   \
+        'https://aur.archlinux.org/lmod.git' '/tmp/lmod'       \
  && (  cd /tmp/lmod                                            \
-    && sudo -u nobody makepkg -si --noconfirm )                \
- && rm -rf /tmp/lua-posix /tmp/lmod /etc/sudoers.d/nobody-sudo
+ &&    sudo -u nobody makepkg -si --noconfirm )                \
+ && rm -rf /tmp/lua-std-_debug /tmp/lua-std-normalize          \
+           /tmp/lmod /etc/sudoers.d/nobody-sudo
 
 MASK [[ $DISTRO =~ (centos|rhel.*) ]]
 RUN yum update -y

--- a/share/spack/qa/run-docker-tests
+++ b/share/spack/qa/run-docker-tests
@@ -1,0 +1,48 @@
+#!/bin/bash -e
+#
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+#
+# Description:
+#     Runs Spack docker tests.  This builds a docker image for each of the
+#     configurations in share/spack/docker/config.
+#
+# Usage:
+#     run-docker-tests
+#
+
+__login_attempted=0
+__login_success=1
+ensure_docker_login() {
+    if [ "$__login_attempted" '!=' '0' ] ; then
+        return $__login_success
+    fi
+
+    echo "$DOCKER_PASSWORD" | \
+        docker login -u "$DOCKER_USERNAME" --password-stdin
+
+    if [ $? '=' '0' ] ; then
+          __login_success=0
+    fi
+
+    __login_attempted=1
+    return $__login_success
+}
+
+for config in share/spack/docker/config/* ; do
+    source "$config" ;
+    ./share/spack/docker/build-image.sh;
+done
+
+if [ "$TEST_SUITE" '=' "docker build" -a \
+     "$TRAVIS_EVENT_TYPE" != "pull_request" -a \
+     ensure_docker_login ] ; then
+
+    for config in share/spack/docker/config/* ; do
+        source "$config"
+        ./share/spack/docker/push-image.sh
+    done
+fi


### PR DESCRIPTION
Fixes issue from #9658.

This PR should not be merged as-is.  This is because I've included an initial [commit](be179569b89b4cae4d352702b82413ac2dbc16ca) that removes a troublesome section of the travis file.  [Here](https://travis-ci.org/opadron/spack/jobs/453687889) is the log of a travis job that ran on the tip of this branch off of my fork.

These results show that 1 - the original issue from #9658 is not related to docker, and is a distinct issue that needs to be addressed, and 2 - the changes in this PR, other than the initial commit, are all that should be necessary for the `docker` stage to produce working images.  I haven't tested pushing to dockerhub, but I don't think it will be an issue.