### PR TITLE
openblas: add `headers` property

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -171,6 +171,15 @@ class Openblas(MakefilePackage):
         return make_defs
 
     @property
+    def headers(self):
+        # As in netlib-lapack, the only public headers for cblas and lapacke in
+        # openblas are cblas.h and lapacke.h. The remaining headers are private
+        # headers either included in one of these two headers, or included in
+        # one of the source files implementing functions declared in these
+        # headers.
+        return find_headers(['cblas', 'lapacke'], self.prefix.include)
+
+    @property
     def build_targets(self):
         targets = ['libs', 'netlib']
 


### PR DESCRIPTION
These commits add the `blas_libs`, `lapack_libs`, and `headers` properties to `openblas`.

I was running into some issues configuring `hypre`, and one of the errors I encountered was that `hypre`'s `configure` script could not find `lapack`. Adding the `lapack_libs` method fixed the error, and I added the `blas_libs` and `headers` methods for consistency with `netlib-lapack`.