### PR TITLE
hypre: patch only @2.13.0 and @2.14.0 on darwin

### DIFF
--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -49,7 +49,7 @@ class Hypre(Package):
 
     # Patch to build shared libraries on Darwin
     patch('darwin-shared-libs-for-hypre-2.13.0.patch', when='+shared@2.13.0 platform=darwin')
-    patch('darwin-shared-libs-for-hypre-2.14.0.patch', when='+shared@2.14.0: platform=darwin')
+    patch('darwin-shared-libs-for-hypre-2.14.0.patch', when='+shared@2.14.0 platform=darwin')
 
     depends_on("mpi", when='+mpi')
     depends_on("blas")


### PR DESCRIPTION
This pull request amends the version range from `@2.14.0:` to `@2.14.0` for the second patch that enables building `hypre` on `darwin` as a shared library because the changes in that patch were incorporated into version 2.15.0.