### PR TITLE
thrift: add missing pkgconfig dependency

### DIFF
--- a/var/spack/repos/builtin/packages/thrift/package.py
+++ b/var/spack/repos/builtin/packages/thrift/package.py
@@ -32,6 +32,7 @@ class Thrift(Package):
     variant('python', default=True,
             description="Build support for python")
 
+    depends_on('pkgconfig', type='build')
     depends_on('java')
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')


### PR DESCRIPTION
Without pkgconfig, Spack's openssl cannot be found.