### PR TITLE
openssl: make 1.1.1 the default version

### DIFF
--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -23,13 +23,18 @@ class Openssl(Package):
     list_url = "https://www.openssl.org/source/old/"
     list_depth = 1
 
+    # Note: Version 1.1.1 is the current long-term support version that will
+    # remain supported until September 2023.
+    version('1.1.1',  '2836875a0f89c03d0fdf483941512613a50cfb421d6fd94b9f41d7279d586a3d')
+    version('1.1.0i', 'ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08c17b2cdadc118253cf99')
     version('1.1.0g', 'ba5f1b8b835b88cadbce9b35ed9531a6')
     version('1.1.0e', '51c42d152122e474754aea96f66928c6')
     version('1.1.0d', '711ce3cd5f53a99c0e12a7d5804f0f63')
     version('1.1.0c', '601e8191f72b18192a937ecf1a800f3f')
-    # Note: Version 1.0.2 is the "long-term support" version that will
-    # remain supported until 2019.
-    version('1.0.2o', '44279b8557c3247cbe324e2322ecd114', preferred=True)
+    # Note: Version 1.0.2 is the previous long-term support version that will
+    # remain supported until December 2019.
+    version('1.0.2p', '50a98e07b1a89eb8f6a99477f262df71c6fa7bef77df4dc83025a2845c827d00', preferred=True)
+    version('1.0.2o', '44279b8557c3247cbe324e2322ecd114')
     version('1.0.2n', '13bdc1b1d1ff39b6fd42a255e74676a4')
     version('1.0.2m', '10e9e37f492094b9ef296f68f24a7666')
     version('1.0.2k', 'f965fc0bf01bf882b31314b61391ae65')

--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -33,7 +33,7 @@ class Openssl(Package):
     version('1.1.0c', '601e8191f72b18192a937ecf1a800f3f')
     # Note: Version 1.0.2 is the previous long-term support version that will
     # remain supported until December 2019.
-    version('1.0.2p', '50a98e07b1a89eb8f6a99477f262df71c6fa7bef77df4dc83025a2845c827d00', preferred=True)
+    version('1.0.2p', '50a98e07b1a89eb8f6a99477f262df71c6fa7bef77df4dc83025a2845c827d00')
     version('1.0.2o', '44279b8557c3247cbe324e2322ecd114')
     version('1.0.2n', '13bdc1b1d1ff39b6fd42a255e74676a4')
     version('1.0.2m', '10e9e37f492094b9ef296f68f24a7666')


### PR DESCRIPTION
As discussed in #9755, this is a separate PR to make openssl@1.1.1 the default version. I have rebuilt all (direct) openssl dependents and filed PRs to update them if necessary.

It depends on the following PRs: #9755, #9777, #9779, #9781, #9782, #9785, #9793