### PR TITLE
compiler: fix _verify_executables

### DIFF
--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -109,7 +109,8 @@ def compiler_find(args):
 
 def compiler_remove(args):
     cspec = CompilerSpec(args.compiler_spec)
-    compilers = spack.compilers.compilers_for_spec(cspec, scope=args.scope)
+    compilers = spack.compilers.compilers_for_spec(cspec, scope=args.scope,
+                                                   check_paths=False)
     if not compilers:
         tty.die("No compilers match spec %s" % cspec)
     elif not args.all and len(compilers) > 1:
@@ -127,7 +128,8 @@ def compiler_remove(args):
 def compiler_info(args):
     """Print info about all compilers matching a spec."""
     cspec = CompilerSpec(args.compiler_spec)
-    compilers = spack.compilers.compilers_for_spec(cspec, scope=args.scope)
+    compilers = spack.compilers.compilers_for_spec(cspec, scope=args.scope,
+                                                   check_paths=False)
 
     if not compilers:
         tty.error("No compilers match spec %s" % cspec)
@@ -157,7 +159,8 @@ def compiler_info(args):
 
 def compiler_list(args):
     tty.msg("Available compilers")
-    index = index_by(spack.compilers.all_compilers(scope=args.scope),
+    index = index_by(spack.compilers.all_compilers(scope=args.scope,
+                     check_paths=False),
                      lambda c: (c.spec.name, c.operating_system, c.target))
     ordered_sections = sorted(index.items(), key=lambda item: item[0])
     for i, (key, compilers) in enumerate(ordered_sections):

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -25,10 +25,10 @@ from spack.util.environment import filter_system_paths
 __all__ = ['Compiler']
 
 
-def _verify_executables(*paths):
+def _verify_executables(spec, operating_system, *paths):
     for path in paths:
         if not (os.path.isfile(path) and os.access(path, os.X_OK)):
-            raise CompilerAccessError(path)
+            raise CompilerAccessError(str(spec), operating_system, path)
 
 
 @llnl.util.lang.memoized
@@ -264,7 +264,7 @@ class Compiler(object):
         def check(exe):
             if exe is None:
                 return None
-            _verify_executables(exe)
+            _verify_executables(self.spec, self.operating_system, exe)
             return exe
 
         self.cc  = check(paths[0])
@@ -476,16 +476,11 @@ class Compiler(object):
 
 class CompilerAccessError(spack.error.SpackError):
 
-    def __init__(self, path):
+    def __init__(self, spec, operating_system, path):
         super(CompilerAccessError, self).__init__(
-            "'%s' is not a valid compiler." % path)
-
-
-class InvalidCompilerError(spack.error.SpackError):
-
-    def __init__(self):
-        super(InvalidCompilerError, self).__init__(
-            "Compiler has no executables.")
+            "'{0}' is not a valid path for compiler '{1}'"
+            "on operating system '{2}'.".format(path, spec, operating_system),
+            "Please use 'spack compiler' to diagnose and fix the problem.")
 
 
 class UnsupportedCompilerFlag(spack.error.SpackError):

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -27,7 +27,7 @@ __all__ = ['Compiler']
 
 def _verify_executables(*paths):
     for path in paths:
-        if not os.path.isfile(path) and os.access(path, os.X_OK):
+        if not (os.path.isfile(path) and os.access(path, os.X_OK)):
             raise CompilerAccessError(path)
 
 

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -252,7 +252,7 @@ class Compiler(object):
     def __init__(self, cspec, operating_system, target,
                  paths, modules=[], alias=None, environment=None,
                  extra_rpaths=None, enable_implicit_rpaths=None,
-                 **kwargs):
+                 check_paths=True, **kwargs):
         self.spec = cspec
         self.operating_system = str(operating_system)
         self.target = target
@@ -264,7 +264,8 @@ class Compiler(object):
         def check(exe):
             if exe is None:
                 return None
-            _verify_executables(self.spec, self.operating_system, exe)
+            if check_paths:
+                _verify_executables(self.spec, self.operating_system, exe)
             return exe
 
         self.cc  = check(paths[0])

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -6,6 +6,7 @@
 import os
 import platform
 import re
+import sys
 import itertools
 import shutil
 import tempfile
@@ -26,6 +27,10 @@ __all__ = ['Compiler']
 
 
 def _verify_executables(spec, operating_system, *paths):
+    # Disable path verification if running within tests as they typically use
+    # fake paths.
+    if 'pytest' in sys.modules:
+        return
     for path in paths:
         if not (os.path.isfile(path) and os.access(path, os.X_OK)):
             raise CompilerAccessError(str(spec), operating_system, path)

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -274,18 +274,18 @@ def find_specs_by_arch(compiler_spec, arch_spec, scope=None, init_config=True):
                                                init_config)]
 
 
-def all_compilers(scope=None):
+def all_compilers(scope=None, check_paths=True):
     config = get_compiler_config(scope)
     compilers = list()
     for items in config:
         items = items['compiler']
-        compilers.append(_compiler_from_config_entry(items))
+        compilers.append(_compiler_from_config_entry(items, check_paths))
     return compilers
 
 
 @_auto_compiler_spec
 def compilers_for_spec(compiler_spec, arch_spec=None, scope=None,
-                       use_cache=True, init_config=True):
+                       use_cache=True, init_config=True, check_paths=True):
     """This gets all compilers that satisfy the supplied CompilerSpec.
        Returns an empty list if none are found.
     """
@@ -297,7 +297,7 @@ def compilers_for_spec(compiler_spec, arch_spec=None, scope=None,
     matches = set(find(compiler_spec, scope, init_config))
     compilers = []
     for cspec in matches:
-        compilers.extend(get_compilers(config, cspec, arch_spec))
+        compilers.extend(get_compilers(config, cspec, arch_spec, check_paths))
     return compilers
 
 
@@ -324,7 +324,7 @@ class CacheReference(object):
         return isinstance(other, CacheReference) and self.id == other.id
 
 
-def compiler_from_dict(items):
+def compiler_from_dict(items, check_paths=True):
     cspec = spack.spec.CompilerSpec(items['spec'])
     os = items.get('operating_system', None)
     target = items.get('target', None)
@@ -362,10 +362,11 @@ def compiler_from_dict(items):
     return cls(cspec, os, target, compiler_paths, mods, alias,
                environment, extra_rpaths,
                enable_implicit_rpaths=implicit_rpaths,
+               check_paths=check_paths,
                **compiler_flags)
 
 
-def _compiler_from_config_entry(items):
+def _compiler_from_config_entry(items, check_paths=True):
     """Note this is intended for internal use only. To avoid re-parsing
        the same config dictionary this keeps track of its location in
        memory. If you provide the same dictionary twice it will return
@@ -376,13 +377,13 @@ def _compiler_from_config_entry(items):
     compiler = _compiler_cache.get(config_id, None)
 
     if compiler is None:
-        compiler = compiler_from_dict(items)
+        compiler = compiler_from_dict(items, check_paths)
         _compiler_cache[config_id] = compiler
 
     return compiler
 
 
-def get_compilers(config, cspec=None, arch_spec=None):
+def get_compilers(config, cspec=None, arch_spec=None, check_paths=True):
     compilers = []
 
     for items in config:
@@ -415,7 +416,7 @@ def get_compilers(config, cspec=None, arch_spec=None):
         if arch_spec and target and (target != family and target != 'any'):
             continue
 
-        compilers.append(_compiler_from_config_entry(items))
+        compilers.append(_compiler_from_config_entry(items, check_paths))
 
     return compilers
 


### PR DESCRIPTION
`not` has a higher precedence than `and`, which caused this check to always return `False`.

This is pretty easy to reproduce: Change `~/.spack/*/compilers.yaml` to contain some invalid paths and try to install some package. Without this PR, the package will most likely fail with something like this:
```
configure: error: C compiler cannot create executables
```
With this PR, Spack will check beforehand:
```
==> Error: '/usr/bin/gcc123' is not a valid path for compiler 'gcc@9.2.1'on operating system 'fedora31'.
Please use 'spack compiler' to diagnose and fix the problem.
```