### PR TITLE
[WIP] Fix and update verrou

### DIFF
--- a/var/spack/repos/builtin/packages/verrou/package.py
+++ b/var/spack/repos/builtin/packages/verrou/package.py
@@ -41,6 +41,10 @@ class Verrou(AutotoolsPackage):
     depends_on('libtool', type='build')
     depends_on('m4', type='build')
 
+    depends_on('python@:2.99.99', when='@1.1.0:2.0.99', type=('build', 'run'))
+    depends_on('python@3.0:', when='@2.1.0:', type=('build', 'run'))
+    extends('python')
+
     def patch(self):
         # We start with the verrou source tree and a "valgrind-x.y.z" subdir.
         # But we actually need a valgrind source tree with a "verrou" subdir.

--- a/var/spack/repos/builtin/packages/verrou/package.py
+++ b/var/spack/repos/builtin/packages/verrou/package.py
@@ -25,13 +25,18 @@ class Verrou(AutotoolsPackage):
     git      = "https://github.com/edf-hpc/verrou.git"
 
     version('develop', branch='master')
+    version('2.1.0', 'b1ba49f84aebab15b8ab5649946c9c31b53ad1499f6ffb681c98db41ed28566d')
     version('2.0.0', '388d493df3f253c9b049ce0ceae55fd6')
     version('1.1.0', '9752d776fb534890e5e29f9721ee6125')
 
+    resource(name='valgrind-3.14.0',
+             url='https://sourceware.org/pub/valgrind/valgrind-3.14.0.tar.bz2',
+             sha256='037c11bfefd477cc6e9ebe8f193bb237fe397f7ce791b4a4ce3fa1c6a520baa5',
+             when='@2.1.0:')
     resource(name='valgrind-3.13.0',
              url='https://sourceware.org/pub/valgrind/valgrind-3.13.0.tar.bz2',
              sha256='d76680ef03f00cd5e970bbdcd4e57fb1f6df7d2e2c071635ef2be74790190c3b',
-             when='@1.1.0:')
+             when='@1.1.0:2.0.99')
 
     variant('fma', default=True,
             description='Activates fused multiply-add support for Verrou')


### PR DESCRIPTION
This PR adds a forgotten dependency of Verrou on Python, and integrates support for the new 2.1.0 release.

It is WIP because my tests are still running, but a nearly final development version of 2.1.0 has been previously tested so I do not expect any problem.