### PR TITLE
openjdk: adding new package openjdk

### DIFF
--- a/var/spack/repos/builtin/packages/openjdk/package.py
+++ b/var/spack/repos/builtin/packages/openjdk/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/var/spack/repos/builtin/packages/openjdk/package.py
+++ b/var/spack/repos/builtin/packages/openjdk/package.py
@@ -1,0 +1,115 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install openjdk
+#
+# You can edit this file again by typing:
+#
+#     spack edit openjdk
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+from spack import *
+import os
+
+
+class Openjdk(Package):
+    """The free and opensource java implementation"""
+
+    homepage = "https://jdk.java.net"
+    url      = "https://download.java.net/java/GA/jdk11/13/GPL/openjdk-11.0.1_linux-x64_bin.tar.gz"
+
+    version('11.0.1', sha256='7a6bb980b9c91c478421f865087ad2d69086a0583aeeb9e69204785e8e97dcfd')
+
+    provides('java')
+    provides('java@11', when='@11.0:11.99')
+
+    # FIXME:
+    # 1. `extends('java')` doesn't work, you need to use `extends('jdk')`
+    # 2. Packages cannot extend multiple packages, see #987
+    # 3. Update `YamlFilesystemView.merge` to allow a Package to completely
+    #    override how it is symlinked into a view prefix. Then, spack activate
+    #    can symlink all *.jar files to `prefix.lib.ext`
+    extendable = True
+
+    @property
+    def home(self):
+        """Most of the time, ``JAVA_HOME`` is simply ``spec['java'].prefix``.
+        However, if the user is using an externally installed JDK, it may be
+        symlinked. For example, on macOS, the ``java`` executable can be found
+        in ``/usr/bin``, but ``JAVA_HOME`` is actually
+        ``/Library/Java/JavaVirtualMachines/jdk-10.0.1.jdk/Contents/Home``.
+        Users may not know the actual installation directory and add ``/usr``
+        to their ``packages.yaml`` unknowingly. Run ``java_home`` if it exists
+        to determine exactly where it is installed. Specify which version we
+        are expecting in case multiple Java versions are installed.
+        See ``man java_home`` for more details."""
+
+        prefix = self.prefix
+        java_home = prefix.libexec.java_home
+        if os.path.exists(java_home):
+            java_home = Executable(java_home)
+            version = str(self.version.up_to(2))
+            prefix = java_home('--version', version, output=str).strip()
+            prefix = Prefix(prefix)
+
+        return prefix
+
+    @property
+    def libs(self):
+        """Depending on the version number and whether the full JDK or just
+        the JRE was installed, Java libraries can be in several locations:
+
+        * ``lib/libjvm.so``
+        * ``jre/lib/libjvm.dylib``
+
+        Search recursively to find the correct library location."""
+
+        return find_libraries(['libjvm'], root=self.home, recursive=True)
+
+    def install(self, spec, prefix):
+        install_tree('.', prefix)
+
+    def setup_environment(self, spack_env, run_env):
+        """Set JAVA_HOME."""
+
+        run_env.set('JAVA_HOME', self.home)
+
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        """Set JAVA_HOME and CLASSPATH.
+
+        CLASSPATH contains the installation prefix for the extension and any
+        other Java extensions it depends on."""
+
+        spack_env.set('JAVA_HOME', self.home)
+
+        class_paths = []
+        for d in dependent_spec.traverse(deptype=('build', 'run', 'test')):
+            if d.package.extends(self.spec):
+                class_paths.extend(find(d.prefix, '*.jar'))
+
+        classpath = os.pathsep.join(class_paths)
+        spack_env.set('CLASSPATH', classpath)
+
+        # For runtime environment set only the path for
+        # dependent_spec and prepend it to CLASSPATH
+        if dependent_spec.package.extends(self.spec):
+            class_paths = find(dependent_spec.prefix, '*.jar')
+            classpath = os.pathsep.join(class_paths)
+            run_env.prepend_path('CLASSPATH', classpath)
+
+    def setup_dependent_package(self, module, dependent_spec):
+        """Allows spec['java'].home to work."""
+
+        self.spec.home = self.home

--- a/var/spack/repos/builtin/packages/openjdk/package.py
+++ b/var/spack/repos/builtin/packages/openjdk/package.py
@@ -3,23 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-# ----------------------------------------------------------------------------
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install openjdk
-#
-# You can edit this file again by typing:
-#
-#     spack edit openjdk
-#
-# See the Spack documentation for more information on packaging.
-# ----------------------------------------------------------------------------
-
 from spack import *
 import os
 
@@ -36,7 +19,7 @@ class Openjdk(Package):
     provides('java@11', when='@11.0:11.99')
 
     # FIXME:
-    # 1. `extends('java')` doesn't work, you need to use `extends('jdk')`
+    # 1. `extends('java')` doesn't work, you need to use `extends('openjdk')`
     # 2. Packages cannot extend multiple packages, see #987
     # 3. Update `YamlFilesystemView.merge` to allow a Package to completely
     #    override how it is symlinked into a view prefix. Then, spack activate


### PR DESCRIPTION
closes #2622

I got annoyed trying to install jdk about 20 min ago.

Anyway, it seems it's much easier to get a binary distribution of openjdk with version 11. 

This is basically entirely copied from the jdk package to hopefully provide similar functionality. There are binaries for windows and macos as well, but I'm not sure how to denote different downloads for different os versions.