### PR TITLE
py-ply: fix download url

### DIFF
--- a/var/spack/repos/builtin/packages/py-ply/package.py
+++ b/var/spack/repos/builtin/packages/py-ply/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PyPly(PythonPackage):
     """PLY is nothing more than a straightforward lex/yacc implementation."""
     homepage = "http://www.dabeaz.com/ply"
-    url      = "https://github.com/dabeaz/ply/archive/3.11.tar.gz"
+    url      = "http://www.dabeaz.com/ply/ply-3.11.tar.gz"
 
     version('3.11', '6465f602e656455affcd7c5734c638f8')
-    version('3.8', '94726411496c52c87c2b9429b12d5c50', url='http://www.dabeaz.com/ply/ply-3.8.tar.gz')
+    version('3.8', '94726411496c52c87c2b9429b12d5c50')


### PR DESCRIPTION
Update download URL per #9507.  This primary URL hosts current and all old releases, with only select releases available on Github.