### PR TITLE
New package: ecFlow, a work flow manager.

### DIFF
--- a/var/spack/repos/builtin/packages/ecflow/package.py
+++ b/var/spack/repos/builtin/packages/ecflow/package.py
@@ -7,7 +7,7 @@ from spack import *
 
 
 class Ecflow(CMakePackage):
-    '''ecFlow is a work flow package that enables users to run a large number 
+    '''ecFlow is a work flow package that enables users to run a large number
     of programs (with dependencies on each other and on time) in a controlled
     environment.
 
@@ -25,5 +25,6 @@ class Ecflow(CMakePackage):
     depends_on('cmake@2.8.11:', type='build')
 
     def cmake_args(self):
-        args = ['-DBoost_PYTHON_LIBRARY_RELEASE=' + self.spec['boost'].prefix.lib]
+        boost_lib = self.spec['boost'].prefix.lib
+        args = ['-DBoost_PYTHON_LIBRARY_RELEASE=' + boost_lib]
         return args

--- a/var/spack/repos/builtin/packages/ecflow/package.py
+++ b/var/spack/repos/builtin/packages/ecflow/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Ecflow(CMakePackage):
+    '''ecFlow is a work flow package that enables users to run a large number 
+    of programs (with dependencies on each other and on time) in a controlled
+    environment.
+
+    It provides tolerance for hardware and software failures, combined with
+    good restart capabilities.
+    '''
+
+    homepage = 'https://confluence.ecmwf.int/display/ECFLOW/'
+    url      = 'https://confluence.ecmwf.int/download/attachments/8650755/ecFlow-4.11.1-Source.tar.gz'
+
+    version('4.11.1', sha256='b3bcc1255939f87b9ba18d802940e08c0cf6379ca6aeec1fef7bd169b0085d6c')
+
+    depends_on('boost+python+pic')
+    depends_on('qt')
+    depends_on('cmake@2.8.11:', type='build')
+
+    def cmake_args(self):
+        args = ['-DBoost_PYTHON_LIBRARY_RELEASE=' + self.spec['boost'].prefix.lib]
+        return args


### PR DESCRIPTION
Hi,
I wrote a package script for ecFlow, a work flow manager: https://confluence.ecmwf.int/display/ECFLOW/.

The package requires boost being built with `+pic` (#9750), because it links some its libraries to boost static libraries.
I've opened an issue on the upstream platform: https://jira.ecmwf.int/projects/SUP/issues/SUP-2641