### PR TITLE
dyninst: overhaul package.py to CMakePackage

### DIFF
--- a/var/spack/repos/builtin/packages/dyninst/package.py
+++ b/var/spack/repos/builtin/packages/dyninst/package.py
@@ -64,21 +64,20 @@ class Dyninst(CMakePackage):
     def cmake_args(self):
         spec = self.spec
 
-        # Elf -- the directory containing libelf.h, and the path to
-        # libelf.so.  Elfutils puts the headers in include, but libelf
-        # uses include/libelf.
+        # Elf -- the directory containing libelf.h, either
+        # prefix/include (elfutils), or prefix/include/libelf
+        # (libelf).
         elf = spec['elf'].prefix
         if spec.satisfies('@9.3.0:'):
             elf_include = elf.include
         else:
             elf_include = join_path(elf.include, 'libelf')
-        elf_lib = join_path(elf.lib, 'libelf.' + dso_suffix)
 
         # Dwarf -- the directory containing elfutils/libdw.h or
         # libdwarf.h, and the path to libdw.so or libdwarf.so.
         if spec.satisfies('@10.0.0:'):
             dwarf_include = elf.include
-            dwarf_lib = join_path(elf.lib, 'libdw.' + dso_suffix)
+            dwarf_lib = find_libraries('libdw', elf, recursive=True)
         else:
             dwarf_include = spec['libdwarf'].prefix.include
             dwarf_lib = spec['libdwarf'].libs
@@ -88,7 +87,7 @@ class Dyninst(CMakePackage):
             '-DIBERTY_LIBRARIES=%s' % spec['libiberty'].libs,
 
             '-DLIBELF_INCLUDE_DIR=%s' % elf_include,
-            '-DLIBELF_LIBRARIES=%s' % elf_lib,
+            '-DLIBELF_LIBRARIES=%s' % spec['elf'].libs,
 
             '-DLIBDWARF_INCLUDE_DIR=%s' % dwarf_include,
             '-DLIBDWARF_LIBRARIES=%s' % dwarf_lib,

--- a/var/spack/repos/builtin/packages/dyninst/package.py
+++ b/var/spack/repos/builtin/packages/dyninst/package.py
@@ -92,14 +92,14 @@ class Dyninst(CMakePackage):
 
             '-DLIBDWARF_INCLUDE_DIR=%s' % dwarf_include,
             '-DLIBDWARF_LIBRARIES=%s' % dwarf_lib,
-            ]
+        ]
 
         # TBB include and lib directories, version 10.x or later.
         if spec.satisfies('@10.0.0:'):
             args.extend([
                 '-DTBB_INCLUDE_DIRS=%s' % spec['tbb'].prefix.include,
                 '-DTBB_LIBRARY=%s' % spec['tbb'].prefix.lib,
-                ])
+            ])
 
         # Openmp applies to version 10.x or later.
         if spec.satisfies('@10.0.0:'):

--- a/var/spack/repos/builtin/packages/dyninst/package.py
+++ b/var/spack/repos/builtin/packages/dyninst/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+import os.path
 
 
 class Dyninst(CMakePackage):
@@ -64,14 +65,10 @@ class Dyninst(CMakePackage):
     def cmake_args(self):
         spec = self.spec
 
-        # Elf -- the directory containing libelf.h, either
-        # prefix/include (elfutils), or prefix/include/libelf
-        # (libelf).
+        # Elf -- the directory containing libelf.h.
         elf = spec['elf'].prefix
-        if spec.satisfies('@9.3.0:'):
-            elf_include = elf.include
-        else:
-            elf_include = join_path(elf.include, 'libelf')
+        elf_include = os.path.dirname(
+            find_headers('libelf', elf.include, recursive=True)[0])
 
         # Dwarf -- the directory containing elfutils/libdw.h or
         # libdwarf.h, and the path to libdw.so or libdwarf.so.

--- a/var/spack/repos/builtin/packages/dyninst/package.py
+++ b/var/spack/repos/builtin/packages/dyninst/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class Dyninst(Package):
+class Dyninst(CMakePackage):
     """API for dynamic binary instrumentation.  Modify programs while they
     are executing without recompiling, re-linking, or re-executing."""
 
@@ -20,78 +20,99 @@ class Dyninst(Package):
     version('9.2.0', tag='v9.2.0')
     version('9.1.0', tag='v9.1.0')
     version('8.2.1', tag='v8.2.1')
-    version('8.1.2', tag='v8.1.2')
-    version('8.1.1', tag='v8.1.1')
+
+    variant('openmp', default=True,
+            description='Enable OpenMP support for ParseAPI '
+            '(version 10.0.0 or later)')
+
+    variant('static', default=False,
+            description='Build static libraries')
 
     variant('stat_dysect', default=False,
-            description="patch for STAT's DySectAPI")
+            description="Patch for STAT's DySectAPI")
 
-    # Dyninst depends on libelf and libdwarf prior to @9.3.0
-    # Dyninst depends on elfutils and libdwarf from @9.3.0 to but
-    # not including @develop
-    # Dyninst depends on elfutils and elfutils libdw from @develop forward
-    # elf@0 is an abstaction for libelf
-    # elf@1 is an abstaction for elfutils
-    depends_on("elf@0", type='link', when='@:9.2.99')
-    # The sorting algorithm puts numbered releases as newer than alphabetic
-    # releases, but spack has special logic in place to ensure that
-    # develop is considered newer than all other releases.
-    # So, develop is included in the elf@1 line below.
-    depends_on("elf@1", type='link', when='@9.3.0:')
-    depends_on("libdwarf", when='@:9')
-    depends_on("boost@1.42:")
+    boost_libs = '+atomic+chrono+date_time+filesystem+system+thread+timer'
+
+    depends_on('boost@1.61.0:' + boost_libs)
     depends_on('libiberty+pic')
-    depends_on("tbb@2018.6:", when='@develop')
-    depends_on("tbb@2018.6:", when='@10:')
-    depends_on('cmake', type='build')
+
+    # Dyninst uses elf@1 (elfutils) starting with 9.3.0, and used
+    # elf@0 (libelf) before that.
+    depends_on('elf@1', type='link', when='@9.3.0:')
+    depends_on('elf@0', type='link', when='@:9.2.99')
+
+    # Dyninst uses libdw from elfutils (same elf@1) starting with
+    # 10.x, and used libdwarf before that.
+    depends_on('libdwarf', when='@:9.99')
+
+    depends_on('tbb@2018.6:', when='@10.0:')
+
+    depends_on('cmake@3.0:', type='build', when='@10.0:')
+    depends_on('cmake@2.8:', type='build', when='@:9.99')
 
     patch('stat_dysect.patch', when='+stat_dysect')
     patch('stackanalysis_h.patch', when='@9.2.0')
 
-    # new version uses cmake
-    def install(self, spec, prefix):
-        if spec.satisfies('@:8.1'):
-            configure("--prefix=" + prefix)
-            make()
-            make("install")
-            return
+    # Versions 9.3.x used cotire, but have no knob to turn it off.
+    # Cotire has no real use for one-time builds and can break
+    # parallel builds with both static and shared libs.
+    @when('@9.3.0:9.3.99')
+    def patch(self):
+        filter_file('USE_COTIRE true', 'USE_COTIRE false',
+                    'cmake/shared.cmake')
 
-        libelf = spec['elf'].prefix
-        if spec.satisfies('@:9'):
-            libdwarf = spec['libdwarf'].prefix
+    def cmake_args(self):
+        spec = self.spec
 
-        with working_dir('spack-build', create=True):
-            args = ['..',
-                    '-DBoost_INCLUDE_DIR=%s'    % spec['boost'].prefix.include,
-                    '-DBoost_LIBRARY_DIR=%s'    % spec['boost'].prefix.lib,
-                    '-DBoost_NO_SYSTEM_PATHS=TRUE',
-                    '-DLIBELF_INCLUDE_DIR=%s'   % join_path(
-                        libelf.include, 'libelf'),
-                    '-DLIBELF_LIBRARIES=%s'     % join_path(
-                        libelf.lib, "libelf." + dso_suffix)]
-            if spec.satisfies('@:9'):
-                args.append('-DLIBDWARF_INCLUDE_DIR=%s' % libdwarf.include)
-                args.append('-DLIBDWARF_LIBRARIES=%s'   % join_path(
-                    libdwarf.lib, "libdwarf." + dso_suffix))
-            # For @develop + use elfutils libdw, libelf is an abstraction
-            # we are really using elfutils here
-            if spec.satisfies('@develop') or spec.satisfies('@10:'):
-                tbb = spec['tbb'].prefix
-                args.append('-DTBB_INCLUDE_DIRS=%s' % tbb.include)
-                args.append('-DTBB_LIBRARIES=%s'    % join_path(
-                    tbb.lib, "libtbb." + dso_suffix))
-                args.append('-DLIBDWARF_INCLUDE_DIR=%s' % libelf.include)
-                args.append('-DLIBDWARF_LIBRARIES=%s'   % join_path(
-                    libelf.lib, "libdw." + dso_suffix))
-            if spec.satisfies('arch=linux-redhat7-ppc64le'):
-                args.append('-Darch_ppc64_little_endian=1')
-            args += std_cmake_args
-            cmake(*args)
-            make()
-            make("install")
+        # Elf -- the directory containing libelf.h, and the path to
+        # libelf.so.  Elfutils puts the headers in include, but libelf
+        # uses include/libelf.
+        elf = spec['elf'].prefix
+        if spec.satisfies('@9.3.0:'):
+            elf_include = elf.include
+        else:
+            elf_include = join_path(elf.include, 'libelf')
+        elf_lib = join_path(elf.lib, 'libelf.' + dso_suffix)
 
-    @when('@:8.1')
-    def install(self, spec, prefix):
-        configure("--prefix=" + prefix)
-        make()
-        make("install")
+        # Dwarf -- the directory containing elfutils/libdw.h or
+        # libdwarf.h, and the path to libdw.so or libdwarf.so.
+        if spec.satisfies('@10.0.0:'):
+            dwarf_include = elf.include
+            dwarf_lib = join_path(elf.lib, 'libdw.' + dso_suffix)
+        else:
+            dwarf_include = spec['libdwarf'].prefix.include
+            dwarf_lib = spec['libdwarf'].libs
+
+        args = [
+            '-DPATH_BOOST=%s' % spec['boost'].prefix,
+            '-DIBERTY_LIBRARIES=%s' % spec['libiberty'].libs,
+
+            '-DLIBELF_INCLUDE_DIR=%s' % elf_include,
+            '-DLIBELF_LIBRARIES=%s' % elf_lib,
+
+            '-DLIBDWARF_INCLUDE_DIR=%s' % dwarf_include,
+            '-DLIBDWARF_LIBRARIES=%s' % dwarf_lib,
+            ]
+
+        # TBB include and lib directories, version 10.x or later.
+        if spec.satisfies('@10.0.0:'):
+            args.extend([
+                '-DTBB_INCLUDE_DIRS=%s' % spec['tbb'].prefix.include,
+                '-DTBB_LIBRARY=%s' % spec['tbb'].prefix.lib,
+                ])
+
+        # Openmp applies to version 10.x or later.
+        if spec.satisfies('@10.0.0:'):
+            if '+openmp' in spec:
+                args.append('-DUSE_OpenMP=ON')
+            else:
+                args.append('-DUSE_OpenMP=OFF')
+
+        # Static libs started with version 9.1.0.
+        if spec.satisfies('@9.1.0:'):
+            if '+static' in spec:
+                args.append('-DENABLE_STATIC_LIBS=1')
+            else:
+                args.append('-DENABLE_STATIC_LIBS=NO')
+
+        return args

--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -86,3 +86,8 @@ class Elfutils(AutotoolsPackage):
             args.append('--disable-nls')
 
         return args
+
+    # Provide location of libelf.so to match libelf.
+    @property
+    def libs(self):
+        return find_libraries('libelf', self.prefix, recursive=True)


### PR DESCRIPTION
Drop versions 8.1.x.  These were > 5 years old, no other spack package
uses them, and they used autotools.  Packages 'stat' and 'mitos' still
use 8.2.1, so we keep that.

Switch class Dyninst to CMakePackage.

Clean up how the versions depend on various packages.  For example,
Dyninst used libelf up to 9.2, and then elfutils starting with 9.3.
This makes things easier going forward.

Add variant 'openmp' (default True) to enable openmp support for
ParseAPI.  This was added in 10.0.0.

Add variant 'static' (default False) to also build static libraries.
This goes back to 9.1.0.

Disable cotire for the 9.3.x versions.  Cotire has no real use in a
one-time build and can break parallel builds with both static and
shared libs.

@mplegendre  @bwelton  @jgalarowicz  @mxz297  comments?
