### PR TITLE
gdk-pixbuf: explicitly disable building of gtk-docs

### DIFF
--- a/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
+++ b/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
@@ -32,3 +32,14 @@ class GdkPixbuf(AutotoolsPackage):
                                self.prefix.share)
         run_env.prepend_path("XDG_DATA_DIRS",
                              self.prefix.share)
+
+    def configure_args(self):
+        args = []
+        # disable building of gtk-doc files following #9771
+        args.append('--disable-gtk-doc-html')
+        true = which('true')
+        args.append('GTKDOC_CHECK={0}'.format(true))
+        args.append('GTKDOC_CHECK_PATH={0}'.format(true))
+        args.append('GTKDOC_MKPDF={0}'.format(true))
+        args.append('GTKDOC_REBASE={0}'.format(true))
+        return args


### PR DESCRIPTION
disable docs by default.
resolves #9879 which prevents building of dependencies of packages like opencv
Recently gtk-docs were also disabled at #9771 for glib package.