### PR TITLE
r-crosstalk: remove unnecessary constraint

### DIFF
--- a/var/spack/repos/builtin/packages/r-crosstalk/package.py
+++ b/var/spack/repos/builtin/packages/r-crosstalk/package.py
@@ -15,7 +15,6 @@ class RCrosstalk(RPackage):
 
     version('1.0.0', 'c13c21b81af2154be3f08870fd3a7077')
 
-    depends_on('r@3.4.0:3.4.9')
     depends_on('r-htmltools', type=('build', 'run'))
     depends_on('r-jsonlite', type=('build', 'run'))
     depends_on('r-lazyeval', type=('build', 'run'))


### PR DESCRIPTION
confirmed this installed fine under r 3.5, and I don't see any mention of a 3.4 constraint in the docs