### PR TITLE
Explicitly set FC= empty for non-fortran builds

### DIFF
--- a/var/spack/repos/builtin/packages/h5z-zfp/package.py
+++ b/var/spack/repos/builtin/packages/h5z-zfp/package.py
@@ -33,6 +33,8 @@ class H5zZfp(MakefilePackage):
 
         if '+fortran' in self.spec and spack_fc:
             make_defs += ['FC=%s' % spack_fc]
+        else:
+            make_defs += ['FC=']
 
         return make_defs
 


### PR DESCRIPTION
H5Z-ZFP uses non-empty ``FC`` variable to decide whether to build its fortran interface. If ``FC`` is defined in environment, then it will have the effect of causing H5Z-ZFP to build its fortran interface even if, for example, the dependent HDF5 library was not built with its fortran features enabled (which are required by H5Z-ZFP's fortran interface). By explicitly setting ``FC`` to empty on the H5Z-ZFP make command-line, we effectively disable building of its fortran interface.