### PR TITLE
Add 2019.1 and 2018.4 version of the Intel performance libraries.

### DIFF
--- a/var/spack/repos/builtin/packages/intel-daal/package.py
+++ b/var/spack/repos/builtin/packages/intel-daal/package.py
@@ -11,8 +11,11 @@ class IntelDaal(IntelPackage):
 
     homepage = "https://software.intel.com/en-us/daal"
 
+    version('2019.1.144', '1672afac568c93e185283cf7e044d511381092ebc95d7204c4dccb83cc493197',
+            url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/14869/l_daal_2019.1.144.tgz")
     version('2019.0.117', 'd42fb6c3e8b31b1288049e89df37f2e8',
             url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13577/l_daal_2019.0.117.tgz")
+    # Doesn't appear to be a 2018.4 update yet
     version('2018.3.222', 'e688825c563e357b7b626ece610d6a85',
             url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13007/l_daal_2018.3.222.tgz")
     version('2018.2.199', 'd015ff34a87a18922736b5fba0d0b0e0',

--- a/var/spack/repos/builtin/packages/intel-ipp/package.py
+++ b/var/spack/repos/builtin/packages/intel-ipp/package.py
@@ -11,8 +11,12 @@ class IntelIpp(IntelPackage):
 
     homepage = "https://software.intel.com/en-us/intel-ipp"
 
+    version('2019.1.144', '1eb7cd0fba74615aeafa4e314c645414497eb73f1705200c524fe78f00620db3',
+            url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/14887/l_ipp_2019.1.144.tgz')
     version('2019.0.117', 'c96be6e138d32bf9b8abc789d25db71d',
             url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13576/l_ipp_2019.0.117.tgz')
+    version('2018.4.274', 'bdc6082c65410c98ccf6daf239e0a6625d15ec5e0ddc1c0563aad42b6ba9063c',
+            url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13726/l_ipp_2018.4.274.tgz')
     version('2018.3.222', '2ccc16ec002466e52f1e6e1bfe9b1149',
             url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13006/l_ipp_2018.3.222.tgz')
     version('2018.2.199', 'f87276b485d2f6ec070c1b41ac1ed871',

--- a/var/spack/repos/builtin/packages/intel-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-mkl/package.py
@@ -17,7 +17,7 @@ class IntelMkl(IntelPackage):
             url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/14895/l_mkl_2019.1.144.tgz")
     version('2019.0.117', 'd9e1b6b96fbffd4b306c7e8291f141a2',
             url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13575/l_mkl_2019.0.117.tgz")
-    version('2018.4.274', '18eb3cde3e6a61a88f25afff25df762a560013f650aaf363f7d3d516a0d0488',
+    version('2018.4.274', '18eb3cde3e6a61a88f25afff25df762a560013f650aaf363f7d3d516a0d04881',
             url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13725/l_mkl_2018.4.274.tgz")
     version('2018.3.222', '3e63646a4306eff95e8d0aafd53a2983',
             url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13005/l_mkl_2018.3.222.tgz")

--- a/var/spack/repos/builtin/packages/intel-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-mkl/package.py
@@ -13,8 +13,12 @@ class IntelMkl(IntelPackage):
 
     homepage = "https://software.intel.com/en-us/intel-mkl"
 
+    version('2019.1.144', '5205a460a9c685f7a442868367389b2d0c25e1455346bc6a37c5b8ff90a20fbb',
+            url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/14895/l_mkl_2019.1.144.tgz")
     version('2019.0.117', 'd9e1b6b96fbffd4b306c7e8291f141a2',
             url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13575/l_mkl_2019.0.117.tgz")
+    version('2018.4.274', '18eb3cde3e6a61a88f25afff25df762a560013f650aaf363f7d3d516a0d0488',
+            url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13725/l_mkl_2018.4.274.tgz")
     version('2018.3.222', '3e63646a4306eff95e8d0aafd53a2983',
             url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13005/l_mkl_2018.3.222.tgz")
     version('2018.2.199', 'fd31b656a8eb859c89495b9cc41230b4',

--- a/var/spack/repos/builtin/packages/intel-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -11,8 +11,12 @@ class IntelMpi(IntelPackage):
 
     homepage = "https://software.intel.com/en-us/intel-mpi-library"
 
+    version('2019.1.144', 'dac86a5db6b86503313742b17535856a432955604f7103cb4549a9bfc256c3cd',
+            url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/14879/l_mpi_2019.1.144.tgz')
     version('2019.0.117', '8572d5fa1f26a7de8edc8b64653b0955',
             url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13584/l_mpi_2019.0.117.tgz')
+    version('2018.4.274', 'a1114b3eb4149c2f108964b83cad02150d619e50032059d119ac4ffc9d5dd8e0',
+            url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13741/l_mpi_2018.4.274.tgz')
     version('2018.3.222', 'df92593818fadff63c57418669c6083b',
             url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13112/l_mpi_2018.3.222.tgz')
     version('2018.2.199', '6ffeab59c83a8842537484d53e180520',

--- a/var/spack/repos/builtin/packages/intel-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-tbb/package.py
@@ -18,6 +18,8 @@ class IntelTbb(Package):
     homepage = "http://www.threadingbuildingblocks.org/"
 
     # See url_for_version() below.
+    version('2019.2', '1245aa394a92099e23ce2f60cdd50c90eb3ddcd61d86cae010ef2f1de61f32d9')
+    version('2019.1', 'a4875c6b6853213083e52ecd303546bdf424568ec67cfc7e51d132a7c037c66a')
     version('2019',   '2119f1db2f905dc5b423482d7689b7d6')
     version('2018.6', '9a0f78db4f72356068b00f29f54ee6bc')
     version('2018.5', 'ff3ae09f8c23892fbc3008c39f78288f')


### PR DESCRIPTION
Sorry for making two pull requests regarding Intel version updates, but I just found out how to get the download links for the free performance libraries. I still don't know how to get all the compiler links without being a paid and registered user though.