### PR TITLE
Fixing problems with lammps dependencies voropp and latte

### DIFF
--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -59,7 +59,7 @@ class Lammps(CMakePackage):
     depends_on('mpi', when='+mpi')
     depends_on('mpi', when='+mpiio')
     depends_on('fftw', when='+kspace')
-    depends_on('voropp', when='+voronoi')
+    depends_on('voropp+pic', when='+voronoi')
     depends_on('netcdf+mpi', when='+user-netcdf')
     depends_on('blas', when='+user-atc')
     depends_on('lapack', when='+user-atc')

--- a/var/spack/repos/builtin/packages/latte/package.py
+++ b/var/spack/repos/builtin/packages/latte/package.py
@@ -17,7 +17,7 @@ class Latte(CMakePackage):
     tags = ['ecp', 'ecp-apps']
 
     version('develop', branch='master')
-    version('1.2.1', '56db44afaba2a89e6ca62ac565c3c012')
+    version('1.2.1', '9a0690bf4e0e1cab057475a67052b0a8')
     version('1.2.0', 'b9bf8f84a0e0cf7b0e278a1bc7751b3d')
     version('1.1.1', 'ab11867ba6235189681cf6e50a50cc50')
     version('1.0.1', 'd0b99edbcf7a19abe0a68a192d6f6234')

--- a/var/spack/repos/builtin/packages/voropp/package.py
+++ b/var/spack/repos/builtin/packages/voropp/package.py
@@ -14,6 +14,9 @@ class Voropp(MakefilePackage):
     homepage = "http://math.lbl.gov/voro++/about.html"
     url      = "http://math.lbl.gov/voro++/download/dir/voro++-0.4.6.tar.gz"
 
+    variant('pic', default=True,
+            description='Position independent code')
+
     version('0.4.6', '2338b824c3b7b25590e18e8df5d68af9')
 
     def edit(self, spec, prefix):
@@ -23,3 +26,9 @@ class Voropp(MakefilePackage):
         filter_file(r'PREFIX=/usr/local',
                     'PREFIX={0}'.format(self.prefix),
                     'config.mk')
+        if '+pic' in spec:
+            # We can safely replace the default CFLAGS which are:
+            # CFLAGS=-Wall -ansi -pedantic -O3
+            filter_file(r'CFLAGS=.*',
+                        'CFLAGS={0}'.format(self.compiler.pic_flag),
+                        'config.mk')

--- a/var/spack/repos/builtin/packages/voropp/package.py
+++ b/var/spack/repos/builtin/packages/voropp/package.py
@@ -26,9 +26,11 @@ class Voropp(MakefilePackage):
         filter_file(r'PREFIX=/usr/local',
                     'PREFIX={0}'.format(self.prefix),
                     'config.mk')
+        # We can safely replace the default CFLAGS which are:
+        # CFLAGS=-Wall -ansi -pedantic -O3
+        cflags = ''
         if '+pic' in spec:
-            # We can safely replace the default CFLAGS which are:
-            # CFLAGS=-Wall -ansi -pedantic -O3
-            filter_file(r'CFLAGS=.*',
-                        'CFLAGS={0}'.format(self.compiler.pic_flag),
-                        'config.mk')
+            cflags += self.compiler.pic_flag
+        filter_file(r'CFLAGS=.*',
+                    'CFLAGS={0}'.format(cflags),
+                    'config.mk')


### PR DESCRIPTION
When trying to build `lammps`, `latte` had what I assume to be an incorrect checksum, and `voropp` needs to be built with `-fPIC`.

I hate to just update a checksum without verifying it. It looks like @junghans created the md5sum before this.