### PR TITLE
py-psycopg2: new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-psycopg2/package.py
+++ b/var/spack/repos/builtin/packages/py-psycopg2/package.py
@@ -14,4 +14,5 @@ class PyPsycopg2(PythonPackage):
 
     version('2.7.5', '9e7d6f695fc7f8d1c42a7905449246c9')
 
+    depends_on('py-setuptools', type='build')
     depends_on('postgresql', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-psycopg2/package.py
+++ b/var/spack/repos/builtin/packages/py-psycopg2/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyPsycopg2(PythonPackage):
+    """Python interface to PostgreSQL databases"""
+
+    homepage = "http://initd.org/psycopg/"
+    url = "http://initd.org/psycopg/tarballs/PSYCOPG-2-7/psycopg2-2.7.5.tar.gz"
+
+    version('2.7.5', '9e7d6f695fc7f8d1c42a7905449246c9')
+
+    depends_on('postgresql', type=('build', 'run'))


### PR DESCRIPTION
I note that there is an old PR https://github.com/spack/spack/pull/7728 for this package, bundled in with a server-less subset of postgresql. That seems to have stalled, with a lot of complexity. This PR is simpler, and depends on the full postgresql package, even though the same arguments could apply. 

I also note that I have recently put in a PR https://github.com/spack/spack/pull/9922, which is a different package for a similar Python PostgreSQL client. Other (currently non-spack) software require one or other of them, so it seemed easiest to keep them independent. 
