### PR TITLE
Add variant to ecflow to choose whether to use static boost libraries.

### DIFF
--- a/var/spack/repos/builtin/packages/ecflow/package.py
+++ b/var/spack/repos/builtin/packages/ecflow/package.py
@@ -20,11 +20,20 @@ class Ecflow(CMakePackage):
 
     version('4.11.1', sha256='b3bcc1255939f87b9ba18d802940e08c0cf6379ca6aeec1fef7bd169b0085d6c')
 
-    depends_on('boost+python+pic')
+    variant('static_boost', default=False,
+            description='Use also static boost libraries when compiling')
+
+    depends_on('boost+python')
+    depends_on('boost+pic', when='+static_boost')
     depends_on('qt')
     depends_on('cmake@2.8.11:', type='build')
 
     def cmake_args(self):
         boost_lib = self.spec['boost'].prefix.lib
         args = ['-DBoost_PYTHON_LIBRARY_RELEASE=' + boost_lib]
+
+        # https://jira.ecmwf.int/browse/SUP-2641#comment-208943
+        use_static_boost = 'ON' if '+static_boost' in self.spec else 'OFF'
+        args.append('-DENABLE_STATIC_BOOST_LIBS=' + use_static_boost)
+
         return args


### PR DESCRIPTION
When the variant is set, it requires boost to be built with the +pic variant.

The flag was suggested by upstream: https://jira.ecmwf.int/browse/SUP-2641#comment-208943