### PR TITLE
fix: adapt junit template to escape std{out,err}

### DIFF
--- a/share/spack/templates/reports/junit.xml
+++ b/share/spack/templates/reports/junit.xml
@@ -24,23 +24,23 @@
                   time="{{ package.elapsed_time }}">
 {% if package.result == 'failure' %}
             <failure message="{{ package.message }}">
-{{ package.exception }}
+{{ package.exception|e }}
             </failure>
 {% elif package.result == 'error' %}
             <error message="{{ package.message }}">
-{{ package.exception }}
+{{ package.exception|e }}
             </error>
 {% elif package.result == 'skipped' %}
             <skipped />
 {% endif %}
 {% if package.stdout %}
             <system-out>
-{{ package.stdout }}
+{{ package.stdout|e }}
             </system-out>
 {% endif %}
 {% if package.stderr %}
             <system-err>
-{{ package.stderr }}
+{{ package.stderr|e }}
             </system-err>
 {% endif %}
         </testcase>


### PR DESCRIPTION
Some error messages in the junit file may contain output that looks like tags, i.e., `<module>`, and cause Jenkins to fail parsing the files. Escape relevant output.