### PR TITLE
Uncomment dependencies previously disallowed by concretizer

### DIFF
--- a/var/spack/repos/builtin/packages/cantera/package.py
+++ b/var/spack/repos/builtin/packages/cantera/package.py
@@ -37,9 +37,8 @@ class Cantera(SConsPackage):
     depends_on('py-numpy',  when='+python', type=('build', 'run'))
     depends_on('py-scipy',  when='+python', type=('build', 'run'))
     depends_on('py-3to2',   when='+python', type=('build', 'run'))
-    # TODO: these "when" specs don't actually work
-    # depends_on('py-unittest2',     when='+python^python@2.6', type=('build', 'run'))  # noqa
-    # depends_on('py-unittest2py3k', when='+python^python@3.1', type=('build', 'run'))  # noqa
+    depends_on('py-unittest2',     when='+python^python@2.6.0:2.6.999', type=('build', 'run'))
+    depends_on('py-unittest2py3k', when='+python^python@3.1.0:3.1.999', type=('build', 'run'))
 
     # Matlab toolbox dependencies
     extends('matlab', when='+matlab')

--- a/var/spack/repos/builtin/packages/py-configparser/package.py
+++ b/var/spack/repos/builtin/packages/py-configparser/package.py
@@ -16,7 +16,4 @@ class PyConfigparser(PythonPackage):
     version('3.5.0', 'cfdd915a5b7a6c09917a64a573140538')
 
     depends_on('py-setuptools', type='build')
-
-    # This dependency breaks concretization
-    # See https://github.com/spack/spack/issues/2793
-    # depends_on('py-ordereddict', when='^python@:2.6', type=('build', 'run'))
+    depends_on('py-ordereddict', when='^python@:2.6', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-enum34/package.py
+++ b/var/spack/repos/builtin/packages/py-enum34/package.py
@@ -16,8 +16,5 @@ class PyEnum34(PythonPackage):
 
     depends_on('python')
     conflicts('python@3.4:')
-
-    # This dependency breaks concretization
-    # See https://github.com/spack/spack/issues/2793
-    # depends_on('py-ordereddict', when='^python@:2.6', type=('build', 'run'))
+    depends_on('py-ordereddict', when='^python@:2.6', type=('build', 'run'))
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-flake8/package.py
+++ b/var/spack/repos/builtin/packages/py-flake8/package.py
@@ -45,11 +45,8 @@ class PyFlake8(PythonPackage):
     # mccabe >= 0.2.1, < 0.5
     depends_on('py-mccabe@0.2.1:0.4.0', when='@2.5.4', type=('build', 'run'))
 
-    # These dependencies breaks concretization
-    # See https://github.com/spack/spack/issues/2793
-    # depends_on('py-configparser', when='^python@:3.3', type=('build', 'run'))
-    # depends_on('py-enum34', when='^python@:3.1', type=('build', 'run'))
-    depends_on('py-configparser', type=('build', 'run'))
+    depends_on('py-configparser', when='^python@:3.3', type=('build', 'run'))
+    depends_on('py-enum34', when='^python@:3.1', type=('build', 'run'))
 
     # py-enum34 provides enum module from Python 3.4 for Python
     # versions 2.4, 2.5, 2.6, 2.7, 3.1, 3.2, and 3.3; use built-in enum

--- a/var/spack/repos/builtin/packages/py-future/package.py
+++ b/var/spack/repos/builtin/packages/py-future/package.py
@@ -16,5 +16,5 @@ class PyFuture(PythonPackage):
     version('0.15.2', 'a68eb3c90b3b76714c5ceb8c09ea3a06')
 
     depends_on('py-setuptools', type='build')
-    # depends_on('py-importlib', type=('build', 'run'), when='^python@2.6')
-    # depends_on('py-argparse', type=('build', 'run'), when='^python@2.6')
+    depends_on('py-importlib', type=('build', 'run'), when='^python@:2.6')
+    depends_on('py-argparse', type=('build', 'run'), when='^python@:2.6')

--- a/var/spack/repos/builtin/packages/py-ipython/package.py
+++ b/var/spack/repos/builtin/packages/py-ipython/package.py
@@ -20,13 +20,8 @@ class PyIpython(PythonPackage):
 
     depends_on('python@2.7:2.8,3.3:')
 
-    # These dependencies breaks concretization
-    # See https://github.com/spack/spack/issues/2793
-    # depends_on('py-backports-shutil-get-terminal-size', type=('build', 'run'), when="^python@:3.2")  # noqa
-    # depends_on('py-pathlib2', type=('build', 'run'), when="^python@:3.3")
-    depends_on('py-backports-shutil-get-terminal-size', type=('build', 'run'))
-    depends_on('py-pathlib2',                   type=('build', 'run'))
-
+    depends_on('py-backports-shutil-get-terminal-size', type=('build', 'run'), when="^python@:3.2")
+    depends_on('py-pathlib2', type=('build', 'run'), when="^python@:3.3")
     depends_on('py-pygments',                   type=('build', 'run'))
     depends_on('py-pickleshare',                type=('build', 'run'))
     depends_on('py-simplegeneric@0.8:',         type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-jsonschema/package.py
+++ b/var/spack/repos/builtin/packages/py-jsonschema/package.py
@@ -16,8 +16,4 @@ class PyJsonschema(PythonPackage):
 
     depends_on('py-setuptools', type='build')
     depends_on('py-vcversioner', type=('build', 'run'))
-
-    # This dependency breaks concretization
-    # See https://github.com/spack/spack/issues/2793
-    # depends_on('py-functools32', when="^python@2.7", type=('build', 'run'))
-    depends_on('py-functools32', type=('build', 'run'))
+    depends_on('py-functools32', when="^python@2.7.0:2.7.999", type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-pybtex/package.py
+++ b/var/spack/repos/builtin/packages/py-pybtex/package.py
@@ -31,6 +31,4 @@ class PyPybtex(PythonPackage):
     depends_on('py-setuptools', type='build')
     depends_on('py-latexcodec@1.0.4:', type=('build', 'run'))
     depends_on('py-pyyaml@3.01:', type=('build', 'run'))
-    # This dependency breaks concretization
-    # See https://github.com/spack/spack/issues/2793
-    # depends_on('py-counter@1:', when='^python@:2.6', type=('build', 'run'))
+    depends_on('py-counter@1:', when='^python@:2.6', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-rasterio/package.py
+++ b/var/spack/repos/builtin/packages/py-rasterio/package.py
@@ -23,10 +23,7 @@ class PyRasterio(PythonPackage):
 
     depends_on('py-setuptools', type='build')
     depends_on('py-cython', type='build')
-
-    # Only use py-enum34 with Python2
-    # depends_on('py-enum34', type='run', when='^python@:2.7')
-
+    depends_on('py-enum34', type='run', when='^python@:2.7')
     depends_on('py-attrs', type=('build', 'run'))
     depends_on('py-numpy', type=('build', 'run'))
     depends_on('py-cligj', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-singledispatch/package.py
+++ b/var/spack/repos/builtin/packages/py-singledispatch/package.py
@@ -16,7 +16,4 @@ class PySingledispatch(PythonPackage):
 
     depends_on('py-setuptools', type='build')
     depends_on('py-six', type=('build', 'run'))
-
-    # This dependency breaks concretization
-    # See https://github.com/spack/spack/issues/2793
-    # depends_on('py-ordereddict', when="^python@:2.6", type=('build', 'run'))
+    depends_on('py-ordereddict', when="^python@:2.6", type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-slurm-pipeline/package.py
+++ b/var/spack/repos/builtin/packages/py-slurm-pipeline/package.py
@@ -18,6 +18,4 @@ class PySlurmPipeline(PythonPackage):
     depends_on('py-setuptools', type='build')
     # using open range although requirements*.txt give explicit versions
     # test dependencies are omitted, see #7681
-    depends_on('py-six@1.10.0:', type=('build', 'run'))
-    # six only required for python 2, change when ^-dependencies work, cf #2793
-    # depends_on('py-six@1.10.0:', type=('build', 'run'), when='^python@:2.8')
+    depends_on('py-six@1.10.0:', type=('build', 'run'), when='^python@:2.8')

--- a/var/spack/repos/builtin/packages/py-sphinx/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx/package.py
@@ -57,13 +57,10 @@ class PySphinx(PythonPackage):
     # http://www.sphinx-doc.org/en/stable/changes.html
     depends_on('py-sphinxcontrib-websupport', when='@1.6:',
                type=('build', 'run'))
-    # TODO: incorporate the proper dependencies when concretizer is capable
     # Build dep for 1.6.1 all python (bug), see:
     # https://github.com/sphinx-doc/sphinx/pull/3789
-    # depends_on('py-typing', when='@1.6.1', type=('build', 'run'))
-    # depends_on('py-typing', when='@1.6.2:^python@2.7:3.4',
-    #            type=('build', 'run'))
-    depends_on('py-typing', when='@1.6:', type=('build', 'run'))
+    depends_on('py-typing', when='@1.6.1', type=('build', 'run'))
+    depends_on('py-typing', when='@1.6.2:^python@2.7:3.4', type=('build', 'run'))
 
     depends_on('py-pytest',     type='test')
     depends_on('py-mock',       type='test')

--- a/var/spack/repos/builtin/packages/py-tornado/package.py
+++ b/var/spack/repos/builtin/packages/py-tornado/package.py
@@ -17,13 +17,7 @@ class PyTornado(PythonPackage):
     depends_on('py-setuptools', type='build')
 
     # requirements from setup.py
-    # These dependencies breaks concretization
-    # See https://github.com/spack/spack/issues/2793
-    # depends_on('py-backports-ssl-match-hostname', when='^python@:2.7.8', type=('build', 'run'))  # noqa
-    # depends_on('py-singledispatch', when='^python@:3.3', type=('build', 'run'))  # noqa
-    # depends_on('py-certifi', when='^python@:3.3', type=('build', 'run'))
-    # depends_on('py-backports-abc@0.4:', when='^python@:3.4', type=('build', 'run'))  # noqa
-    depends_on('py-backports-ssl-match-hostname', type=('build', 'run'))
-    depends_on('py-singledispatch', type=('build', 'run'))
-    depends_on('py-certifi', type=('build', 'run'))
-    depends_on('py-backports-abc@0.4:', type=('build', 'run'))
+    depends_on('py-backports-ssl-match-hostname', when='^python@:2.7.8', type=('build', 'run'))
+    depends_on('py-singledispatch', when='^python@:3.3', type=('build', 'run'))
+    depends_on('py-certifi', when='^python@:3.3', type=('build', 'run'))
+    depends_on('py-backports-abc@0.4:', when='^python@:3.4', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-traitlets/package.py
+++ b/var/spack/repos/builtin/packages/py-traitlets/package.py
@@ -24,7 +24,4 @@ class PyTraitlets(PythonPackage):
     depends_on('py-decorator', type=('build', 'run'))
     depends_on('py-ipython-genutils', type=('build', 'run'))
 
-    # This dependency breaks concretization
-    # See https://github.com/spack/spack/issues/2793
-    # depends_on('py-enum34', when='^python@:3.3', type=('build', 'run'))
-    depends_on('py-enum34', type=('build', 'run'))
+    depends_on('py-enum34', when='^python@:3.3', type=('build', 'run'))


### PR DESCRIPTION
#2793 appears to no longer be present, so uncommenting these dependencies.