### PR TITLE
OpenMPI: Prefer Last 3.X

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -67,7 +67,7 @@ class Openmpi(AutotoolsPackage):
     version('4.0.0', sha256='2f0b8a36cfeb7354b45dda3c5425ef8393c9b04115570b615213faaa3f97366b')  # libmpi.so.40.20.0
 
     # Still supported
-    version('3.1.3', sha256='8be04307c00f51401d3fb9d837321781ea7c79f2a5a4a2e5d4eaedc874087ab6')  # libmpi.so.40.10.3
+    version('3.1.3', preferred=True, sha256='8be04307c00f51401d3fb9d837321781ea7c79f2a5a4a2e5d4eaedc874087ab6')  # libmpi.so.40.10.3
     version('3.1.2', sha256='c654ed847f34a278c52a15c98add40402b4a90f0c540779f1ae6c489af8a76c5')  # libmpi.so.40.10.2
     version('3.1.1', sha256='3f11b648dd18a8b878d057e9777f2c43bf78297751ad77ae2cef6db0fe80c77c')  # libmpi.so.40.10.1
     version('3.1.0', sha256='b25c044124cc859c0b4e6e825574f9439a51683af1950f6acda1951f5ccdf06c')  # libmpi.so.40.10.0


### PR DESCRIPTION
The latest OpenMPI release, v4.0.0, does not build with many GCC/GFortran variants. Since `+mpi` and `+fortran` are our defaults, a lot of users get hit.

Let's wait for some point releases. cc @jrood-nrel 

References:
- #9888
- #9917
- https://github.com/open-mpi/ompi/issues/6105
- https://github.com/open-mpi/ompi/issues/6106