### PR TITLE
Python 2.6 is not allowed to fail on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,8 +116,6 @@ jobs:
   allow_failures:
     - dist: xenial
     - env: TEST_SUITE=docker
-    # temporary Python 2.6 exception while we figure out why Travis is hanging
-    - python: '2.6'
 
 stages:
   - 'style checks'


### PR DESCRIPTION
closes #9815

It's ~10 days that python 2.6 tests don't fail anymore on Travis - so #9815 is not reproducible and we didn't figure out the cause of the failures. This PR just closes the issue by reverting the commit where we were allowing python 2.6 to fail on Travis.