### PR TITLE
glib: disable SELinux explicitly

### DIFF
--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -73,6 +73,8 @@ class Glib(AutotoolsPackage):
                 os.path.basename(self.spec['python'].command.path))
             )
         args.extend(self.enable_or_disable('tracing'))
+        # SELinux is not available in Spack, so glib should not use it.
+        args.append('--disable-selinux')
         # glib should not use the globally installed gtk-doc. Otherwise,
         # gtk-doc can fail with Python errors such as "ImportError: No module
         # named site". This is due to the fact that Spack sets PYTHONHOME,


### PR DESCRIPTION
This can cause build warnings like this:
```
/usr/bin/ld: warning: libpcre.so.3, needed by /usr/lib/x86_64-linux-gnu/libselinux.so, may conflict with libpcre.so.1
```
Additionally, if SELinux is found, this causes `-lselinux` to be included in glib's pkg-config file, which may lead to build failures on nodes where it is not installed globally.