### PR TITLE
Fix broken unpacking of bcl2fastq2

### DIFF
--- a/var/spack/repos/builtin/packages/bcl2fastq2/package.py
+++ b/var/spack/repos/builtin/packages/bcl2fastq2/package.py
@@ -5,6 +5,7 @@
 
 from spack import *
 import os
+import shutil
 import glob
 import llnl.util.tty as tty
 
@@ -71,11 +72,10 @@ class Bcl2fastq2(Package):
                     tty.msg("The tarball has already been unpacked")
                 else:
                     tty.msg("Unpacking bcl2fastq2 tarball")
-                    tty.msg("cwd sez: {0}".format(os.getcwd()))
                     tarball = glob.glob(join_path('spack-expanded-archive',
                                         'bcl2fastq2*.tar.gz'))[0]
                     copy(tarball, '.')
-                    os.rmdir('spack-expanded-archive')
+                    shutil.rmtree('spack-expanded-archive')
                     tar = which('tar')
                     tarball = os.path.basename(tarball)
                     tar('-xf', tarball)


### PR DESCRIPTION
When "move" was switched to "copy"[1], `os.rmdir` broke.  This commit
switches to using `shutil.rmtree` instead.

[1]: https://github.com/spack/spack/commit/73c978ddd99973e29f2ba42078b10455c1de5ca8#diff-d920b4e38599837ee806323c2b09b3ce

Closes #9944

Note that bcl2fastq2 still doesn't build for me on the mac, but it's a separate issue (can't find malloc.h), I don't know if it *ever* built on the mac....

