### PR TITLE
Injected flags have a well defined order.

### DIFF
--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -380,13 +380,12 @@ class Concretizer(object):
                                if (compiler_match(p) and
                                    (p is not spec) and
                                    flag in p.compiler_flags))
-                nearest_flags = set(nearest.compiler_flags.get(flag, []))
-                flags = set(spec.compiler_flags.get(flag, []))
-                if (nearest_flags - flags):
-                    # TODO: these set operations may reorder the flags, which
-                    # for some orders of flags can be invalid. See:
-                    # https://github.com/spack/spack/issues/6154#issuecomment-342365573
-                    spec.compiler_flags[flag] = list(nearest_flags | flags)
+                nearest_flags = nearest.compiler_flags.get(flag, [])
+                flags = spec.compiler_flags.get(flag, [])
+                if set(nearest_flags) - set(flags):
+                    spec.compiler_flags[flag] = list(
+                        llnl.util.lang.dedupe(nearest_flags + flags)
+                    )
                     ret = True
             except StopIteration:
                 pass
@@ -402,10 +401,12 @@ class Concretizer(object):
                 raise
             return ret
         for flag in compiler.flags:
-            config_flags = set(compiler.flags.get(flag, []))
-            flags = set(spec.compiler_flags.get(flag, []))
-            spec.compiler_flags[flag] = list(config_flags | flags)
-            if (config_flags - flags):
+            config_flags = compiler.flags.get(flag, [])
+            flags = spec.compiler_flags.get(flag, [])
+            spec.compiler_flags[flag] = list(
+                llnl.util.lang.dedupe(config_flags + flags)
+            )
+            if set(config_flags) - set(flags):
                 ret = True
 
         return ret

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -179,9 +179,9 @@ class TestConcretize(object):
                       ' ^cmake %clang@3.5 platform=test os=fe target=fe')
         client.concretize()
         cmake = client['cmake']
-        assert set(client.compiler_flags['cflags']) == set(['-O0'])
+        assert set(client.compiler_flags['cflags']) == set(['-O0', '-g'])
         assert set(cmake.compiler_flags['cflags']) == set(['-O3'])
-        assert set(client.compiler_flags['fflags']) == set(['-O0'])
+        assert set(client.compiler_flags['fflags']) == set(['-O0', '-g'])
         assert not set(cmake.compiler_flags['fflags'])
 
     def test_architecture_inheritance(self):

--- a/lib/spack/spack/test/data/compilers.yaml
+++ b/lib/spack/spack/test/data/compilers.yaml
@@ -98,9 +98,9 @@ compilers:
       f77: /path/to/gfortran472
       fc: /path/to/gfortran472
     flags:
-      cflags: -O0
-      cxxflags: -O0
-      fflags: -O0
+      cflags: -O0 -g
+      cxxflags: -O0 -g
+      fflags: -O0 -g
     modules: 'None'
 - compiler:
     spec: clang@3.5

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -746,12 +746,13 @@ class TestSpecSematics(object):
 
     @pytest.mark.regression('9908')
     def test_spec_flags_maintain_order(self):
+        # Spack was assembling flags in a manner that could result in
+        # different orderings for repeated concretizations of the same
+        # spec and config
         spec_str = 'libelf %gcc@4.7.2 os=redhat6'
-        hashes = set(
-            Spec(spec_str).concretized().dag_hash() for _ in range(100)
-        )
-
-        # The hash has been precomputed and should be the same
-        # on every architecture.
-        assert len(hashes) == 1
-        assert hashes.pop() == 'h76g3noivss5gdrs2il2ghaqw3fba22m'
+        for _ in range(25):
+            s = Spec(spec_str).concretized()
+            assert all(
+                s.compiler_flags[x] == ['-O0', '-g']
+                for x in ('cflags', 'cxxflags', 'fflags')
+            )

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -743,3 +743,15 @@ class TestSpecSematics(object):
             expected = getattr(arch, prop, "")
             actual = spec.format(named_str)
             assert str(expected) == actual
+
+    @pytest.mark.regression('9908')
+    def test_spec_flags_maintain_order(self):
+        spec_str = 'libelf %gcc@4.7.2 os=redhat6'
+        hashes = set(
+            Spec(spec_str).concretized().dag_hash() for _ in range(100)
+        )
+
+        # The hash has been precomputed and should be the same
+        # on every architecture.
+        assert len(hashes) == 1
+        assert hashes.pop() == 'h76g3noivss5gdrs2il2ghaqw3fba22m'


### PR DESCRIPTION
fixes #9908

The fastest way to solve the random order of compiler flags, which causes a randomization of the hashes for the same spec, is to employ deduplicated lists instead of sets.