### PR TITLE
Rename py-proj to py-pyproj, consistent with Spack's current naming c…

### DIFF
--- a/var/spack/repos/builtin/packages/py-geopandas/package.py
+++ b/var/spack/repos/builtin/packages/py-geopandas/package.py
@@ -25,6 +25,6 @@ class PyGeopandas(PythonPackage):
     depends_on('py-descartes', type=('build', 'run'), when='+plotting')
     depends_on('py-matplotlib', type=('build', 'run'), when='+plotting')
     depends_on('py-fiona', type=('build', 'run'))
-    depends_on('py-proj', type=('build', 'run'))
+    depends_on('py-pyproj', type=('build', 'run'))
     depends_on('py-shapely', type=('build', 'run'))
     depends_on('py-pandas', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-owslib/package.py
+++ b/var/spack/repos/builtin/packages/py-owslib/package.py
@@ -20,4 +20,4 @@ class PyOwslib(PythonPackage):
     depends_on('py-dateutil@1.5:',  type=('build', 'run'))
     depends_on('py-pytz',           type=('build', 'run'))
     depends_on('py-requests@1.0:',  type=('build', 'run'))
-    depends_on('py-proj',           type=('build', 'run'))
+    depends_on('py-pyproj',           type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-pyproj/package.py
+++ b/var/spack/repos/builtin/packages/py-pyproj/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class PyProj(PythonPackage):
+class PyPyproj(PythonPackage):
     """Python interface to the PROJ.4 Library."""
 
     homepage = "http://jswhit.github.io/pyproj/"
@@ -21,7 +21,7 @@ class PyProj(PythonPackage):
     depends_on('py-cython', type='build')
     depends_on('py-setuptools', type='build')
 
-    # NOTE: py-proj does NOT depends_on('proj').
+    # NOTE: py-pyproj does NOT depends_on('proj').
     # The py-proj git repo actually includes the correct version of PROJ.4,
     # which is built internally as part of the py-proj build.
     # Adding depends_on('proj') will cause mysterious build errors.


### PR DESCRIPTION
…onventions

This change was suggested by @adamjstewart to make it consistent. The underlying package name is pyproj. 

I have also updated the two other packages which refer to this name: py-owslib and py-geopandas. I have made no other changes to any of these packages, so this PR does just the one thing. 
