### PR TITLE
Updating VTK PYTHONPATH changes for latest Paraview versions

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -113,6 +113,9 @@ class Paraview(CMakePackage):
                 run_env.prepend_path('PYTHONPATH', join_path(lib_dir,
                                      paraview_version, 'site-packages', 'vtk'))
         elif self.spec.satisfies('@5.5.0:'):
+            # Note the python2.7 directory likely needs to be smarter if the
+            # strict python 2:2.8 dependency goes away for Paraview in the
+            # future
             if '+python' in self.spec:
                 run_env.prepend_path('PYTHONPATH',
                                      join_path(lib_dir,

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -104,7 +104,7 @@ class Paraview(CMakePackage):
             run_env.prepend_path('LIBRARY_PATH', join_path(lib_dir,
                                  paraview_version))
             run_env.prepend_path('LD_LIBRARY_PATH', join_path(lib_dir,
-                             paraview_version))
+                                 paraview_version))
             if '+python' in self.spec:
                 run_env.prepend_path('PYTHONPATH', join_path(lib_dir,
                                      paraview_version))
@@ -114,8 +114,11 @@ class Paraview(CMakePackage):
                                      paraview_version, 'site-packages', 'vtk'))
         elif self.spec.satisfies('@5.5.0:'):
             if '+python' in self.spec:
-                run_env.prepend_path('PYTHONPATH', join_path(lib_dir,
-                                     'python2.7', 'site-packages', 'vtkmodules'))
+                run_env.prepend_path('PYTHONPATH',
+                                     join_path(lib_dir,
+                                               'python2.7',
+                                               'site-packages',
+                                               'vtkmodules'))
 
     def cmake_args(self):
         """Populate cmake arguments for ParaView."""

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -96,19 +96,26 @@ class Paraview(CMakePackage):
         else:
             lib_dir = self.prefix.lib
         paraview_version = 'paraview-%s' % self.spec.version.up_to(2)
-        run_env.prepend_path('LIBRARY_PATH', join_path(lib_dir,
-                             paraview_version))
-        run_env.prepend_path('LD_LIBRARY_PATH', join_path(lib_dir,
-                             paraview_version))
         run_env.set('PARAVIEW_VTK_DIR',
                     join_path(lib_dir, 'cmake', paraview_version))
-        if '+python' in self.spec:
-            run_env.prepend_path('PYTHONPATH', join_path(lib_dir,
+        # Some python locations changed from 5.4 to 5.5
+        if self.spec.satisfies('@:5.4.99'):
+            # Only need this nonstandard library path in <= 5.4
+            run_env.prepend_path('LIBRARY_PATH', join_path(lib_dir,
                                  paraview_version))
-            run_env.prepend_path('PYTHONPATH', join_path(lib_dir,
-                                 paraview_version, 'site-packages'))
-            run_env.prepend_path('PYTHONPATH', join_path(lib_dir,
-                                 paraview_version, 'site-packages', 'vtk'))
+            run_env.prepend_path('LD_LIBRARY_PATH', join_path(lib_dir,
+                             paraview_version))
+            if '+python' in self.spec:
+                run_env.prepend_path('PYTHONPATH', join_path(lib_dir,
+                                     paraview_version))
+                run_env.prepend_path('PYTHONPATH', join_path(lib_dir,
+                                     paraview_version, 'site-packages'))
+                run_env.prepend_path('PYTHONPATH', join_path(lib_dir,
+                                     paraview_version, 'site-packages', 'vtk'))
+        elif self.spec.satisfies('@5.5.0:'):
+            if '+python' in self.spec:
+                run_env.prepend_path('PYTHONPATH', join_path(lib_dir,
+                                     'python2.7', 'site-packages', 'vtkmodules'))
 
     def cmake_args(self):
         """Populate cmake arguments for ParaView."""


### PR DESCRIPTION
Paraview has some different python related directories between 5.4.1 and 5.5.0. This fixes the module file to account for these changes.