### PR TITLE
kdiff3: Expand dependency on qt to allow qt4

### DIFF
--- a/var/spack/repos/builtin/packages/kdiff3/package.py
+++ b/var/spack/repos/builtin/packages/kdiff3/package.py
@@ -13,7 +13,7 @@ class Kdiff3(Package):
 
     version('0.9.98', 'b52f99f2cf2ea75ed5719315cbf77446')
 
-    depends_on("qt@5.2.0:")
+    depends_on("qt@:4.99,5.2.0:")
 
     def install(self, spec, prefix):
         # make is done inside


### PR DESCRIPTION
The dependency on qt had explicit restriction to qt5. The kdiff3 website explicitly says that both qt4 and qt5 are supported, and building with qt4 works fine for me. So, I have expanded back to all versions of qt4, while keeping the version range for qt5. 
