### PR TITLE
Expose option to save all dependencies when writing spec.yaml

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1503,9 +1503,9 @@ class Spec(object):
 
         return syaml_dict([('spec', node_list)])
 
-    def to_yaml(self, stream=None):
+    def to_yaml(self, stream=None, all_deps=False):
         return syaml.dump(
-            self.to_dict(), stream=stream, default_flow_style=False)
+            self.to_dict(all_deps), stream=stream, default_flow_style=False)
 
     def to_json(self, stream=None):
         return sjson.dump(self.to_dict(), stream)


### PR DESCRIPTION
As I'm starting to identify cleanups required to merge #8718, I noticed that this is the last remaining difference between the `spec.py` in that branch and the one in develop.  I thought it might be low-hanging fruit, mergeable without too much contention. 