### PR TITLE
Disallow bcl2fastq2 on OS X

### DIFF
--- a/var/spack/repos/builtin/packages/bcl2fastq2/package.py
+++ b/var/spack/repos/builtin/packages/bcl2fastq2/package.py
@@ -28,6 +28,9 @@ class Bcl2fastq2(Package):
     # mirror/bcl2fastq2/bcl2fastq2-2.17.1.14.zip and go from there.
     version('2.17.1.14', '7426226c6db095862e636b95c38608d3')
 
+    # Various malloc.h and etc requirements break build on macs
+    conflicts('platform=darwin')
+
     depends_on('boost@1.54.0')
     depends_on('cmake@2.8.9:')
     depends_on('libxml2@2.7.8')

--- a/var/spack/repos/builtin/packages/bcl2fastq2/package.py
+++ b/var/spack/repos/builtin/packages/bcl2fastq2/package.py
@@ -28,8 +28,8 @@ class Bcl2fastq2(Package):
     # mirror/bcl2fastq2/bcl2fastq2-2.17.1.14.zip and go from there.
     version('2.17.1.14', '7426226c6db095862e636b95c38608d3')
 
-    # Various malloc.h and etc requirements break build on macs
-    conflicts('platform=darwin')
+    conflicts('platform=darwin',
+              msg='malloc.h/etc requirements break build on macs')
 
     depends_on('boost@1.54.0')
     depends_on('cmake@2.8.9:')


### PR DESCRIPTION
[Illumina's computing requirements][reqs] claim support for RHEL/CentOS and go on to say:

> May be possible to install and run on other 64-bit Linux distributions or Unix variants.

It does not build simply on OS X, the sufficient issue is its reliance of malloc.h.  There may be more.

[reqs]: https://support.illumina.com/sequencing/sequencing_software/bcl2fastq-conversion-software/computing-requirements.html

See #9944 for additional background.