### PR TITLE
r-optparse: new package

### DIFF
--- a/var/spack/repos/builtin/packages/r-getopt/package.py
+++ b/var/spack/repos/builtin/packages/r-getopt/package.py
@@ -17,4 +17,5 @@ class RGetopt(RPackage):
     url      = "https://cran.r-project.org/src/contrib/getopt_1.20.1.tar.gz"
     list_url = "https://cran.r-project.org/src/contrib/Archive/getopt"
 
+    version('1.20.2', sha256='3d6c12d32d6cd4b2909be626e570e158b3ed960e4739510e3a251e7f172de38e')
     version('1.20.1', '323cf2846e306f49236b8174bc3d4e47')

--- a/var/spack/repos/builtin/packages/r-optparse/package.py
+++ b/var/spack/repos/builtin/packages/r-optparse/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class ROptparse(RPackage):
+    """A command line parser inspired by Python's 'optparse' library to be used
+       with Rscript to write "#!" shebang scripts that accept short and long
+       flag/options"""
+
+    homepage = "https://cran.r-project.org/package=optparse"
+    url      = "https://cran.r-project.org/src/contrib/optparse_1.6.0.tar.gz"
+    list_url = "https://cran.r-project.org/src/contrib/Archive/optparse"
+
+    version('1.6.0', '8d0bd89b2e25cc1580437cdeeb1faac2')
+
+    depends_on('r@2.9.0:', type=('build', 'run'))
+    depends_on('r-getopt@1.20.2:', type=('build', 'run'))


### PR DESCRIPTION
Also included a new version for the r-getopt package, to satisfy the version requirement listed on CRAN for r-optparse. 