### PR TITLE
Bump vtkm to version 1.3 and add new features

### DIFF
--- a/var/spack/repos/builtin/packages/vtkm/package.py
+++ b/var/spack/repos/builtin/packages/vtkm/package.py
@@ -8,7 +8,7 @@ from spack import *
 import os
 
 
-class Vtkm(Package):
+class Vtkm(CMakePackage, CudaPackage):
     """VTK-m is a toolkit of scientific visualization algorithms for emerging
     processor architectures. VTK-m supports the fine-grained concurrency for
     data analysis and visualization algorithms required to drive extreme scale
@@ -17,46 +17,102 @@ class Vtkm(Package):
     architectures."""
 
     homepage = "https://m.vtk.org/"
-    url      = "https://gitlab.kitware.com/api/v4/projects/vtk%2Fvtk-m/repository/archive.tar.gz?sha=v1.1.0"
+    url      = "https://gitlab.kitware.com/api/v4/projects/vtk%2Fvtk-m/repository/archive.tar.gz?sha=v1.3.0"
     git      = "https://gitlab.kitware.com/vtk/vtk-m.git"
 
     version('master', branch='master')
+    version('1.3.0', "d9f6e274dec2ea01273cccaba356d23ca88c5a25")
+    version('1.2.0', "3295fed86012226c107e1f2605ca7cc583586b63")
     version('1.1.0', "6aab1c0885f6ffaaffcf07930873d0df")
 
+    # use release, instead of release with debug symbols b/c vtkm libs
+    # can overwhelm compilers with too many symbols
+    variant('build_type', default='Release', description='CMake build type',
+            values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel'))
     variant("cuda", default=False, description="build cuda support")
+    variant("logging", default=False, description="build logging support")
+    variant("mpi", default=True, description="build mpi support")
+    variant("openmp", default=False, description="build openmp support")
+    variant("rendering", default=True, description="build rendering support")
     variant("tbb", default=True, description="build TBB support")
 
     depends_on("cmake")
     depends_on("tbb", when="+tbb")
     depends_on("cuda", when="+cuda")
+    depends_on("mpi", when="+mpi")
 
-    def install(self, spec, prefix):
+    def cmake_args(self):
+        spec = self.spec
+        options = []
         with working_dir('spack-build', create=True):
-            cmake_args = ["../",
-                          "-DVTKm_ENABLE_TESTING=OFF",
-                          "-DVTKm_BUILD_RENDERING=ON",
-                          "-DVTKm_USE_64BIT_IDS=OFF",
-                          "-DVTKm_USE_DOUBLE_PRECISION=ON"]
+            options = ["../",
+                       "-DVTKm_ENABLE_TESTING:BOOL=OFF",
+                       "-DVTKm_USE_64BIT_IDS:BOOL=OFF",
+                       "-DVTKm_USE_DOUBLE_PRECISION:BOOL=ON"]
+
+            # cuda support
+            if "+cuda" in spec:
+                options.append("-DVTKm_ENABLE_CUDA:BOOL=ON")
+                if 'cuda_arch' in spec.variants:
+                    cuda_arch = spec.variants['cuda_arch'].value
+                    options.append(
+                        '-DVTKm_CUDA_Architecture={0}'.format(cuda_arch[0]))
+                else:
+                    # this fix is necessary if compiling platform has cuda, but
+                    # no devices (this's common for front end nodes on hpc clus
+                    # ters)
+                    # we choose kepler as a lowest common denominator
+                    options.append("-DVTKm_CUDA_Architecture=kepler")
+            else:
+                options.append("-DVTKm_ENABLE_CUDA:BOOL=OFF")
+
+            # logging support
+            if "+logging" in spec:
+                if spec.satisfies('@:1.2.0') and \
+                        spec['vtkm'].version.string != 'master':
+                    raise InstallError('logging is not supported for\
+                            vtkm version lower than 1.3')
+                options.append("-DVTKm_ENABLE_LOGGING:BOOL=ON")
+            else:
+                options.append("-DVTKm_ENABLE_LOGGING:BOOL=OFF")
+
+            # mpi support
+            if "+mpi" in spec:
+                if spec.satisfies('@:1.2.0') and \
+                        spec['vtkm'].version.string != 'master':
+                    raise InstallError('mpi is not supported for\
+                            vtkm version lower than 1.3')
+                options.append("-DVTKm_ENABLE_MPI:BOOL=ON")
+            else:
+                options.append("-DVTKm_ENABLE_MPI:BOOL=OFF")
+
+            # openmp support
+            if "+openmp" in spec:
+                # openmp is added since version 1.3.0
+                if spec.satisfies('@:1.2.0') and \
+                        spec['vtkm'].version.string != 'master':
+                    raise InstallError('OpenMP is not supported for\
+                            vtkm version lower than 1.3')
+                # vtkm requires openmp no less than 4.0.0
+                if not spec.compiler.satisfies('gcc'):
+                    raise InstallError('Enabling OpenMP in vtkm requires gcc\
+                            compiler')
+                conflicts('%gcc@:4.8.9', None, 'The required OpenMP 4.0.0 is only supported with gcc no less than 4.9')
+                options.append("-DVTKm_ENABLE_OPENMP:BOOL=ON")
+            else:
+                options.append("-DVTKm_ENABLE_OPENMP:BOOL=OFF")
+
+            # rendering support
+            if "+rendering" in spec:
+                options.append("-DVTKm_ENABLE_RENDERING:BOOL=ON")
+            else:
+                options.append("-DVTKm_ENABLE_RENDERING:BOOL=OFF")
+
             # tbb support
             if "+tbb" in spec:
                 # vtk-m detectes tbb via TBB_ROOT env var
                 os.environ["TBB_ROOT"] = spec["tbb"].prefix
-                cmake_args.append("-DVTKm_ENABLE_TBB=ON")
-
-            # cuda support
-            if "+cuda" in spec:
-                cmake_args.append("-DVTKm_ENABLE_CUDA=ON")
-                # this fix is necessary if compiling platform has cuda, but
-                # no devices (this common for front end nodes on hpc clusters)
-                # we choose kepler as a lowest common denominator
-                cmake_args.append("-DVTKm_CUDA_Architecture=kepler")
-
-            # use release, instead of release with debug symbols b/c vtkm libs
-            # can overwhelm compilers with too many symbols
-            for arg in std_cmake_args:
-                if arg.count("CMAKE_BUILD_TYPE") == 0:
-                    cmake_args.extend(std_cmake_args)
-            cmake_args.append("-DCMAKE_BUILD_TYPE=Release")
-            cmake(*cmake_args)
-            make()
-            make("install")
+                options.append("-DVTKm_ENABLE_TBB:BOOL=ON")
+            else:
+                options.append("-DVTKm_ENABLE_TBB:BOOL=OFF")
+            return options


### PR DESCRIPTION
This commit allows users to enable openmp, rendering, logging and mpi
in vtkm. Meanwhile, it adds support for cuda architecture selection.

[VTK-m 1.3 Release notes](https://gitlab.kitware.com/vtk/vtk-m/tags/v1.3.0)