### PR TITLE
EXODUS: Update version and dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/exodusii/package.py
+++ b/var/spack/repos/builtin/packages/exodusii/package.py
@@ -32,7 +32,7 @@ class Exodusii(CMakePackage):
     # https://github.com/gsjaardema/seacas/blob/master/NetCDF-Mapping.md
     depends_on('netcdf@4.6.1:+mpi', when='+mpi')
     depends_on('netcdf@4.6.1:~mpi', when='~mpi')
-    
+
     def cmake_args(self):
         spec = self.spec
 

--- a/var/spack/repos/builtin/packages/exodusii/package.py
+++ b/var/spack/repos/builtin/packages/exodusii/package.py
@@ -22,6 +22,7 @@ class Exodusii(CMakePackage):
     git      = "https://github.com/gsjaardema/seacas.git"
 
     version('2016-08-09', commit='2ffeb1b')
+    version('master', branch='master')
 
     variant('mpi', default=True, description='Enables MPI parallelism.')
 
@@ -29,11 +30,9 @@ class Exodusii(CMakePackage):
     depends_on('mpi', when='+mpi')
 
     # https://github.com/gsjaardema/seacas/blob/master/NetCDF-Mapping.md
-    depends_on('netcdf+mpi maxdims=65536 maxvars=524288', when='+mpi')
-    depends_on('netcdf~mpi maxdims=65536 maxvars=524288', when='~mpi')
-    depends_on('hdf5+shared+mpi', when='+mpi')
-    depends_on('hdf5+shared~mpi', when='~mpi')
-
+    depends_on('netcdf@4.6.1:+mpi', when='+mpi')
+    depends_on('netcdf@4.6.1:~mpi', when='~mpi')
+    
     def cmake_args(self):
         spec = self.spec
 
@@ -50,7 +49,6 @@ class Exodusii(CMakePackage):
             '-DSEACASProj_SKIP_FORTRANCINTERFACE_VERIFY_TEST:BOOL=ON',
             '-DSEACASProj_ENABLE_CXX11:BOOL=OFF',
             '-DSEACASProj_ENABLE_Zoltan:BOOL=OFF',
-            '-DHDF5_ROOT:PATH={0}'.format(spec['hdf5'].prefix),
             '-DNetCDF_DIR:PATH={0}'.format(spec['netcdf'].prefix),
 
             # MPI Flags #


### PR DESCRIPTION
Allow pulling master version from git.  Note that I hope to have better versioning "soon"

Add requirement to use Netcdf-4.6.1 or later as those versions no longer require changing the `maxdims` or `maxvars` defines in the netcdf.h include file.  With these versions, Exodus can use an unmodified NetCDF.  These versions of NetCDF are also better than previous versions (code quality, performance, robustness).

It is still possible to run exodusII with previous NetCDF versions, but I don't know how to specify that the dependency where maxdims/maxvars variants are only needed for versions prior to 4.6.0.  

I also removed the explicit dependency on HDF5 as that dependency should be applied through the NetCDF dependency.