### PR TITLE
boost: 1.68 also needs `boost_1.67.0_pgi.patch`

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -151,7 +151,7 @@ class Boost(Package):
     patch('call_once_variadic.patch', when='@1.54.0:1.55.9999%gcc@5.0:5.9')
 
     # Patch fix for PGI compiler
-    patch('boost_1.67.0_pgi.patch', when='@1.67.0%pgi')
+    patch('boost_1.67.0_pgi.patch', when='@1.67.0:1.68.9999%pgi')
     patch('boost_1.63.0_pgi.patch', when='@1.63.0%pgi')
     patch('boost_1.63.0_pgi_17.4_workaround.patch', when='@1.63.0%pgi@17.4')
 


### PR DESCRIPTION
Its in upstream with the upcoming 1.69 release though.