### PR TITLE
CGNS: Add setting of RPATH on Darwin

### DIFF
--- a/var/spack/repos/builtin/packages/cgns/package.py
+++ b/var/spack/repos/builtin/packages/cgns/package.py
@@ -64,9 +64,10 @@ class Cgns(CMakePackage):
         else:
             options.extend(['-DCGNS_ENABLE_HDF5=OFF'])
 
-        if sys.platform == 'darwin':
-            options.extend([
-                '-DCMAKE_MACOSX_RPATH:BOOL=ON'
-            ])
+        if self.version <= Version('3.3.1'):
+            if sys.platform == 'darwin':
+                options.extend([
+                    '-DCMAKE_MACOSX_RPATH:BOOL=ON'
+                ])
 
         return options

--- a/var/spack/repos/builtin/packages/cgns/package.py
+++ b/var/spack/repos/builtin/packages/cgns/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import sys
 from spack import *
 
 
@@ -62,5 +63,10 @@ class Cgns(CMakePackage):
                 ])
         else:
             options.extend(['-DCGNS_ENABLE_HDF5=OFF'])
+
+        if sys.platform == 'darwin':
+            options.extend([
+                '-DCMAKE_MACOSX_RPATH:BOOL=ON'
+            ])
 
         return options


### PR DESCRIPTION
This should go in the CGNS CMakeLists.txt, but it isn't there yet and won't be in previous versions, so best to handle it here.  
If building on darwin/MacOSX, need to set the RPATH so applications can find shared library correctly.