### PR TITLE
Adding patch to remove unicode character from pyrope readme file

### DIFF
--- a/var/spack/repos/builtin/packages/py-rope/fix_readme_unicode.patch
+++ b/var/spack/repos/builtin/packages/py-rope/fix_readme_unicode.patch
@@ -1,0 +1,12 @@
+diff -Naru rope-0.10.5.orig/README.rst rope-0.10.5/README.rst
+--- rope-0.10.5.orig/README.rst	2018-11-22 13:47:38.880373715 -0700
++++ rope-0.10.5/README.rst	2018-11-22 13:47:50.484375982 -0700
+@@ -19,7 +19,7 @@
+ ============
+ 
+ * Nick Smith <nicks@fastmail.fm> takes over maintaining rope. Many thanks to
+-  Matěj Cepl for his work maintaining rope for the past few years!!
++  Matej Cepl for his work maintaining rope for the past few years!!
+ * Full python3 support is in progress... stay tuned
+ 
+ Getting Started

--- a/var/spack/repos/builtin/packages/py-rope/package.py
+++ b/var/spack/repos/builtin/packages/py-rope/package.py
@@ -12,8 +12,11 @@ class PyRope(PythonPackage):
     homepage = "https://github.com/python-rope/rope"
     url      = "https://pypi.io/packages/source/r/rope/rope-0.10.5.tar.gz"
 
-    version('0.10.5', '21882fd7c04c29d09f75995d8a088be7')
+    version('0.11.0', sha256='a108c445e1cd897fe19272ab7877d172e7faf3d4148c80e7d20faba42ea8f7b2')
+    version('0.10.7', sha256='a09edfd2034fd50099a67822f9bd851fbd0f4e98d3b87519f6267b60e50d80d1')
+    version('0.10.6', sha256='9700e163f3b05ef4c68133a39d436c253a84b35baf662c2d63407da7bfa08edf')
+    version('0.10.5', sha256='2ff6099e65798f9e27da5026cc7136b4d9b340fc817031ccb4318f61f448127f')
 
-    patch('fix_readme_unicode.patch', when='@0.10.5')
+    patch('fix_readme_unicode.patch', when='@0.10.5:0.11.0')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-rope/package.py
+++ b/var/spack/repos/builtin/packages/py-rope/package.py
@@ -14,4 +14,6 @@ class PyRope(PythonPackage):
 
     version('0.10.5', '21882fd7c04c29d09f75995d8a088be7')
 
+    patch('fix_readme_unicode.patch')
+
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-rope/package.py
+++ b/var/spack/repos/builtin/packages/py-rope/package.py
@@ -14,6 +14,6 @@ class PyRope(PythonPackage):
 
     version('0.10.5', '21882fd7c04c29d09f75995d8a088be7')
 
-    patch('fix_readme_unicode.patch')
+    patch('fix_readme_unicode.patch', when='@0.10.5')
 
     depends_on('py-setuptools', type='build')


### PR DESCRIPTION
I was encountering errors when installing `py-rope` as a dependency of something and this unicode character in its readme file was causing it to fail during install. This patch removes the unicode character.