### PR TITLE
CGNS: Add option for 64-bit integers

### DIFF
--- a/var/spack/repos/builtin/packages/cgns/package.py
+++ b/var/spack/repos/builtin/packages/cgns/package.py
@@ -21,7 +21,8 @@ class Cgns(CMakePackage):
     variant('fortran', default=False, description='Enable Fortran interface')
     variant('scoping', default=True, description='Enable scoping')
     variant('mpi', default=True, description='Enable parallel cgns')
-
+    variant('int64', default=False, description='Build with 64-bit integers')    
+    
     depends_on('hdf5', when='+hdf5~mpi')
     depends_on('hdf5+mpi', when='+hdf5+mpi')
     depends_on('mpi', when='+mpi')
@@ -46,6 +47,11 @@ class Cgns(CMakePackage):
                 '-DCMAKE_C_COMPILER=%s'       % spec['mpi'].mpicc,
                 '-DCMAKE_CXX_COMPILER=%s'     % spec['mpi'].mpicxx,
                 '-DCMAKE_Fortran_COMPILER=%s' % spec['mpi'].mpifc
+            ])
+
+        if '+int64' in spec:
+            options.extend([
+                '-DCGNS_ENABLE_64BIT:BOOL=ON'
             ])
 
         if '+hdf5' in spec:

--- a/var/spack/repos/builtin/packages/cgns/package.py
+++ b/var/spack/repos/builtin/packages/cgns/package.py
@@ -50,8 +50,8 @@ class Cgns(CMakePackage):
             ])
 
         options.append(
-        '-DCGNS_ENABLE_64BIT:BOOL={0}'.format(
-            'ON' if '+int64' in spec else 'OFF'))
+            '-DCGNS_ENABLE_64BIT:BOOL={0}'.format(
+                'ON' if '+int64' in spec else 'OFF'))
 
         if '+hdf5' in spec:
             options.extend([

--- a/var/spack/repos/builtin/packages/cgns/package.py
+++ b/var/spack/repos/builtin/packages/cgns/package.py
@@ -49,10 +49,9 @@ class Cgns(CMakePackage):
                 '-DCMAKE_Fortran_COMPILER=%s' % spec['mpi'].mpifc
             ])
 
-        if '+int64' in spec:
-            options.extend([
-                '-DCGNS_ENABLE_64BIT:BOOL=ON'
-            ])
+        options.append(
+        '-DCGNS_ENABLE_64BIT:BOOL={0}'.format(
+            'ON' if '+int64' in spec else 'OFF'))
 
         if '+hdf5' in spec:
             options.extend([

--- a/var/spack/repos/builtin/packages/cgns/package.py
+++ b/var/spack/repos/builtin/packages/cgns/package.py
@@ -22,7 +22,7 @@ class Cgns(CMakePackage):
     variant('scoping', default=True, description='Enable scoping')
     variant('mpi', default=True, description='Enable parallel cgns')
     variant('int64', default=False, description='Build with 64-bit integers')    
-    
+
     depends_on('hdf5', when='+hdf5~mpi')
     depends_on('hdf5+mpi', when='+hdf5+mpi')
     depends_on('mpi', when='+mpi')


### PR DESCRIPTION
Added the `int64` variant which will build the library using 64-bit integers for certain values.  This gives the capability to have models with more than 2 billion cells and/or nodes.  

Beginning with CGNS-3.1.0, two new typedef variables have been introduced to support 64-bit mode. The `cglong_t` typedef is always a 64-bit integer, and `cgsize_t` will be either a 32-bit or 64-bit integer depending on how the library was built. Many of the C functions in the MLL have been changed to to use `cgsize_t` instead of `int` in the arguments. These functions include any that may exceed the 2Gb limit of an` int`, e.g. zone dimensions, element data, boundary conditions, and connectivity. In Fortran, all integer data is taken to be `integer*4` for 32-bit and `integer*8` for 64-bit builds.