### PR TITLE
MATIO: New versions

### DIFF
--- a/var/spack/repos/builtin/packages/matio/package.py
+++ b/var/spack/repos/builtin/packages/matio/package.py
@@ -8,11 +8,23 @@ from spack import *
 
 class Matio(AutotoolsPackage):
     """matio is an C library for reading and writing Matlab MAT files"""
-    homepage = "http://sourceforge.net/projects/matio/"
-    url = "http://downloads.sourceforge.net/project/matio/matio/1.5.9/matio-1.5.9.tar.gz"
+    homepage   = "https://sourceforge.net/projects/matio/"
+    url        = "https://sourceforge.net/projects/matio/files/matio/1.5.9/matio-1.5.9.tar.gz"
+    list_url   = "https://sourceforge.net/projects/matio/files/matio"
+    list_depth = 1
 
-    version('1.5.9', 'aab5b4219a3c0262afe7eeb7bdd2f463')
-    version('1.5.2', '85b007b99916c63791f28398f6a4c6f1')
+    version('1.5.13',  sha256='feadb2f54ba7c9db6deba8c994e401d7a1a8e7afd0fe74487691052b8139e5cb')
+    version('1.5.12',  sha256='8695e380e465056afa5b5e20128935afe7d50e03830f9f7778a72e1e1894d8a9')
+    version('1.5.11',  sha256='0ccced0c55c9c2cdc21348b7e16447843402d729ffaadd6135767faad7c9cf0b')
+    version('1.5.10',  sha256='41209918cebd8cc87a4aa815fed553610911be558f027aee54af8b599c78b501')
+    version('1.5.9',   sha256='beb7f965831ec5b4ef43f8830ee1ef1c121cd98e11b0f6e1d98713d9f860c05c')
+    version('1.5.8',   sha256='6e49353d1d9d5127696f2e67b46cf9a1dc639663283c9bc4ce5280489c03e1f0')
+    version('1.5.7',   sha256='84b9a17ada1ee08374fb47cc2d0e10a95b8f7f603b58576239f90b8c576fad48')
+    version('1.5.6',   sha256='39a6e6a40d9fd8d707f4494483b8df30ffd617ba0a19c663e3685ad55ff55878')
+    version('1.5.5',   sha256='72f00cc3cd8f7603c48867887cef886289f1f04a30f1c777aeef0b9ddd7d9c9d')
+    version('1.5.4',   sha256='90d16dfea9070d241ef5818fee2345aee251a3c55b86b5d0314967e61fcd18ef')
+    version('1.5.3',   sha256='85ba46e192331473dc4d8a9d266679f8f81e60c06debdc4b6f9d7906bad46257')
+    version('1.5.2',   sha256='db02d0fb3373c3d766a606309b17e64a5d8da55610e921a9f1a0ec171e911d45')
 
     variant("zlib", default=True,
             description='support for compressed mat files')


### PR DESCRIPTION
Add several new versions so that current functionality can be accessed.  Current version is now 1.5.13.

Update `url`, `list_url`, and `list_depth` so spack can find available versions