### PR TITLE
Add thread count variant to atlas

### DIFF
--- a/var/spack/repos/builtin/packages/atlas/package.py
+++ b/var/spack/repos/builtin/packages/atlas/package.py
@@ -48,7 +48,8 @@ class Atlas(Package):
 
     variant('tune_cpu', default=-1,
         multi=False,
-        description="Number of threads to tune to, -1 for autodetect, 0 for no threading"
+        description="Number of threads to tune to,\
+                -1 for autodetect, 0 for no threading"
     )
 
     provides('blas')

--- a/var/spack/repos/builtin/packages/atlas/package.py
+++ b/var/spack/repos/builtin/packages/atlas/package.py
@@ -45,7 +45,7 @@ class Atlas(Package):
         values=('pthreads', 'none'),
         multi=False
     )
-    
+
     variant('tune_cpu', default=-1,
         multi=False,
         description="Number of threads to tune to, -1 for autodetect, 0 for no threading"
@@ -81,7 +81,7 @@ class Atlas(Package):
         options.extend([
             '-b', '64'
         ])
-        
+
         # set number of cpu's to tune to
         options.extend([
             '-t', spec.variants['tune_cpu'].value

--- a/var/spack/repos/builtin/packages/atlas/package.py
+++ b/var/spack/repos/builtin/packages/atlas/package.py
@@ -45,6 +45,11 @@ class Atlas(Package):
         values=('pthreads', 'none'),
         multi=False
     )
+    
+    variant('tune_cpu', default=-1,
+        multi=False,
+        description="Number of threads to tune to, -1 for autodetect, 0 for no threading"
+    )
 
     provides('blas')
     provides('lapack')
@@ -75,6 +80,11 @@ class Atlas(Package):
         # configure for 64-bit build
         options.extend([
             '-b', '64'
+        ])
+        
+        # set number of cpu's to tune to
+        options.extend([
+            '-t', spec.variants['tune_cpu'].value
         ])
 
         # set compilers:


### PR DESCRIPTION
Atlas automatically configures itself and optimizes to run with a fixed number of threads. This can be overridden during compile by setting a flag and atlas will tune itself to use the specified number, rather than all system CPUs. 

Default value is the existing logic, autoconfigure.