### PR TITLE
Download CMake sources from the Github releases

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -10,9 +10,7 @@ class Cmake(Package):
     """A cross-platform, open-source build system. CMake is a family of
        tools designed to build, test and package software."""
     homepage = 'https://www.cmake.org'
-    url      = 'https://cmake.org/files/v3.4/cmake-3.4.3.tar.gz'
-    list_url = 'https://cmake.org/files/'
-    list_depth = 1
+    url      = 'https://github.com/Kitware/CMake/releases/download/v3.13.0/cmake-3.13.0.tar.gz'
 
     version('3.13.0',   '4058b2f1a53c026564e8936698d56c3b352d90df067b195cb749a97a3d273c90')
     version('3.12.4',   '5255584bfd043eb717562cff8942d472f1c0e4679c4941d84baadaa9b28e3194')
@@ -84,11 +82,6 @@ class Cmake(Package):
     conflicts('%intel', when='@3.11.0:3.11.4')
 
     phases = ['bootstrap', 'build', 'install']
-
-    def url_for_version(self, version):
-        """Handle CMake's version-based custom URLs."""
-        url = 'https://cmake.org/files/v{0}/cmake-{1}.tar.gz'
-        return url.format(version.up_to(2), version)
 
     def bootstrap_args(self):
         spec = self.spec


### PR DESCRIPTION
Now that CMake is providing CMake release artifacts on github,
we should prefer those as they have better download speeds and
uptime.