### PR TITLE
spack versions: only list safe versions

### DIFF
--- a/lib/spack/spack/cmd/versions.py
+++ b/lib/spack/spack/cmd/versions.py
@@ -9,6 +9,7 @@ from llnl.util.tty.colify import colify
 import llnl.util.tty as tty
 
 import spack.repo
+import sys
 
 description = "list available versions of a package"
 section = "packaging"
@@ -18,32 +19,42 @@ level = "long"
 def setup_parser(subparser):
     subparser.add_argument('package', metavar='PACKAGE',
                            help='package to list versions for')
+    subparser.add_argument('-s', '--safe-only', action='store_true',
+                           help='only list safe versions of the package')
 
 
 def versions(parser, args):
     pkg = spack.repo.get(args.package)
 
-    tty.msg('Safe versions (already checksummed):')
+    if sys.stdout.isatty():
+        tty.msg('Safe versions (already checksummed):')
 
     safe_versions = pkg.versions
 
     if not safe_versions:
-        print('  Found no versions for {0}'.format(pkg.name))
-        tty.debug('Manually add versions to the package.')
+        if sys.stdout.isatty():
+            tty.warn('Found no versions for {0}'.format(pkg.name))
+            tty.debug('Manually add versions to the package.')
     else:
         colify(sorted(safe_versions, reverse=True), indent=2)
 
-    tty.msg('Remote versions (not yet checksummed):')
+    if args.safe_only:
+        return
+
+    if sys.stdout.isatty():
+        tty.msg('Remote versions (not yet checksummed):')
 
     fetched_versions = pkg.fetch_remote_versions()
     remote_versions = set(fetched_versions).difference(safe_versions)
 
     if not remote_versions:
-        if not fetched_versions:
-            print('  Found no versions for {0}'.format(pkg.name))
-            tty.debug('Check the list_url and list_depth attributes of the '
-                      'package to help Spack find versions.')
-        else:
-            print('  Found no unchecksummed versions for {0}'.format(pkg.name))
+        if sys.stdout.isatty():
+            if not fetched_versions:
+                tty.warn('Found no versions for {0}'.format(pkg.name))
+                tty.debug('Check the list_url and list_depth attributes of '
+                          'the package to help Spack find versions.')
+            else:
+                tty.warn('Found no unchecksummed versions for {0}'.format(
+                    pkg.name))
     else:
         colify(sorted(remote_versions, reverse=True), indent=2)

--- a/lib/spack/spack/test/cmd/versions.py
+++ b/lib/spack/spack/test/cmd/versions.py
@@ -10,6 +10,12 @@ from spack.main import SpackCommand
 versions = SpackCommand('versions')
 
 
+def test_safe_versions():
+    """Only test the safe versions of a package."""
+
+    versions('--safe-only', 'zlib')
+
+
 @pytest.mark.network
 def test_remote_versions():
     """Test a package for which remote versions should be available."""

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1027,7 +1027,7 @@ function _spack_use {
 function _spack_versions {
     if $list_options
     then
-        compgen -W "-h --help" -- "$cur"
+        compgen -W "-h --help -s --safe-only" -- "$cur"
     else
         compgen -W "$(_all_packages)" -- "$cur"
     fi


### PR DESCRIPTION
Adds a `--safe-only` flag to the `spack versions` command. Also prevents the printing of tty messages unless printing to the terminal.

The idea for this use case came from @robertmaynard in #10003. With this PR, one can run:
```console
$ spack versions -s cmake | xargs -n 1 spack fetch cmake@
```
or:
```bash
for version in $(spack versions -s cmake)
do
    spack fetch cmake@version
done
```
to test downloads of every version of a package.

We should probably have a more thought out command to do this task, but this is a quick, generic hack to give the same functionality.