### PR TITLE
redundans: add 0.14a, cleanup install

### DIFF
--- a/var/spack/repos/builtin/packages/redundans/package.py
+++ b/var/spack/repos/builtin/packages/redundans/package.py
@@ -11,8 +11,11 @@ class Redundans(Package):
 
     homepage = "https://github.com/Gabaldonlab/redundans"
     url      = "https://github.com/Gabaldonlab/redundans/archive/v0.13c.tar.gz"
+    git      = "https://github.com/Gabaldonlab/redundans.git"
 
-    version('0.13c', '2003fb7c70521f5e430553686fd1a594')
+    version('0.14a', commit='a20215a862aed161cbfc79df9133206156a1e9f0')
+    version('0.13c', '2003fb7c70521f5e430553686fd1a594',
+            preferred=True)
 
     depends_on('python', type=('build', 'run'))
     depends_on('py-pyscaf', type=('build', 'run'))
@@ -33,12 +36,16 @@ class Redundans(Package):
         filter_file(r'sspacebin = os.path.join(.*)$',
                     'sspacebin = \'' + sspace_location + '\'',
                     'redundans.py')
-        install('redundans.py', prefix.bin)
+
+        binfiles = ['fasta2homozygous.py', 'fasta2split.py',
+                    'fastq2insert_size.py', 'fastq2mates.py',
+                    'fastq2shuffled.py', 'fastq2sspace.py',
+                    'filterReads.py', 'redundans.py']
+
+        # new internal dep with 0.14a
+        if spec.satisfies('@0.14a:'):
+            binfiles.extend(['denovo.py'])
+
         with working_dir('bin'):
-            install('fasta2homozygous.py', prefix.bin)
-            install('fasta2split.py', prefix.bin)
-            install('fastq2insert_size.py', prefix.bin)
-            install('fastq2mates.py', prefix.bin)
-            install('fastq2shuffled.py', prefix.bin)
-            install('fastq2sspace.py', prefix.bin)
-            install('filterReads.py', prefix.bin)
+            for f in binfiles:
+                install(f, prefix.bin)

--- a/var/spack/repos/builtin/packages/redundans/package.py
+++ b/var/spack/repos/builtin/packages/redundans/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+import glob
 
 
 class Redundans(Package):
@@ -31,20 +32,18 @@ class Redundans(Package):
     def install(self, spec, prefix):
         sspace_location = join_path(spec['sspace-standard'].prefix,
                                     'SSPACE_Standard_v3.0.pl')
-        mkdirp(prefix.bin)
+
         filter_file(r'sspacebin = os.path.join(.*)$',
                     'sspacebin = \'' + sspace_location + '\'',
                     'redundans.py')
 
-        binfiles = ['fasta2homozygous.py', 'fasta2split.py',
-                    'fastq2insert_size.py', 'fastq2mates.py',
-                    'fastq2shuffled.py', 'fastq2sspace.py',
-                    'filterReads.py', 'redundans.py']
+        binfiles = ['redundans.py', 'bin/filterReads.py']
+        binfiles.extend(glob.glob('bin/fast?2*.py'))
 
         # new internal dep with 0.14a
         if spec.satisfies('@0.14a:'):
-            binfiles.extend(['denovo.py'])
+            binfiles.append('bin/denovo.py')
 
-        with working_dir('bin'):
-            for f in binfiles:
-                install(f, prefix.bin)
+        mkdirp(prefix.bin)
+        for f in binfiles:
+            install(f, prefix.bin)

--- a/var/spack/repos/builtin/packages/redundans/package.py
+++ b/var/spack/repos/builtin/packages/redundans/package.py
@@ -14,8 +14,7 @@ class Redundans(Package):
     git      = "https://github.com/Gabaldonlab/redundans.git"
 
     version('0.14a', commit='a20215a862aed161cbfc79df9133206156a1e9f0')
-    version('0.13c', '2003fb7c70521f5e430553686fd1a594',
-            preferred=True)
+    version('0.13c', '2003fb7c70521f5e430553686fd1a594')
 
     depends_on('python', type=('build', 'run'))
     depends_on('py-pyscaf', type=('build', 'run'))


### PR DESCRIPTION
couldn't find an actual release tarball for 0.14a but several commits which seem to indicate it,
cleaned up the install process if new files are added in the future.

older release marked as preferred over the alpha release.