### PR TITLE
Use a bot to mark top issues

### DIFF
--- a/.github/topissuebot.yml
+++ b/.github/topissuebot.yml
@@ -1,0 +1,4 @@
+# Configuration for top-issue-bot
+labelName: "Top 10"
+labelColor: "c0c0c0"
+numberOfIssuesToLabel: 10


### PR DESCRIPTION
As a member of the community I want the top issues to be labeled so that I can quickly track which features or bug-fixes are the most requested.

**Rationale**
This can be an effective way for a contributor to select something to work on that can have the most impact on the community. 

**Alternatives**
Github already permits to sort issues by the number of the various reactions. Using a bot can be  nonetheless an improvement as:
- It labels issues, so that we can keep track of historical information e.g. if some issue has been in the top 10 at some point
- We will develop an habit, as a community, to vote for features or bug fixes we care the most

N.B. In case we want to merge the PR, this [bot](https://probot.github.io/apps/topissues/) needs to be activated first by an owner of the repository.