### PR TITLE
Maintain a view for an environment

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -702,10 +702,12 @@ def set_executable(path):
     os.chmod(path, mode)
 
 
-def purge_empty_directories(root):
-    """
-        Ascend up from the leaves accessible from `root`
-        and remove empty directories.
+def remove_empty_directories(root):
+    """Ascend up from the leaves accessible from `root` and remove empty
+    directories.
+
+    Parameters:
+        root (str): path where to search for empty directories
     """
     for dirpath, subdirs, files in os.walk(root, topdown=False):
         for sd in subdirs:

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -702,15 +702,30 @@ def set_executable(path):
     os.chmod(path, mode)
 
 
+def purge_empty_directories(root):
+    """
+        Ascend up from the leaves accessible from `root`
+        and remove empty directories.
+    """
+    for dirpath, subdirs, files in os.walk(root, topdown=False):
+        for sd in subdirs:
+            sdp = os.path.join(dirpath, sd)
+            try:
+                os.rmdir(sdp)
+            except OSError:
+                pass
+
+
 def remove_dead_links(root):
-    """Removes any dead link that is present in root.
+    """Recursively removes any dead link that is present in root.
 
     Parameters:
         root (str): path where to search for dead links
     """
-    for file in os.listdir(root):
-        path = join_path(root, file)
-        remove_if_dead_link(path)
+    for dirpath, subdirs, files in os.walk(root, topdown=False):
+        for f in files:
+            path = join_path(dirpath, f)
+            remove_if_dead_link(path)
 
 
 def remove_if_dead_link(path):

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -181,6 +181,9 @@ def env_create(args):
     elif args.without_view:
         with_view = False
     else:
+        # Note that 'None' means unspecified, in which case the Environment
+        # object could choose to enable a view by default. False means that
+        # the environment should not include a view.
         with_view = None
     if args.envfile:
         with open(args.envfile) as f:

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -313,12 +313,13 @@ def env_view(args):
             env.regenerate_view()
         elif args.action == ViewAction.enable:
             if args.view_path:
-                env._view_path = args.view_path
+                view_path = args.view_path
             else:
-                env._view_path = env.default_view_path
+                view_path = env.default_view_path
+            env.update_view(view_path)
             env.write()
         elif args.action == ViewAction.disable:
-            env._view_path = None
+            env.update_view(None)
             env.write()
     else:
         tty.msg("No active environment")

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -54,12 +54,19 @@ def env_activate_setup_parser(subparser):
         '--csh', action='store_const', dest='shell', const='csh',
         help="print csh commands to activate the environment")
 
+    view_options = subparser.add_mutually_exclusive_group()
+    view_options.add_argument(
+        '-v', '--with-view', action='store_const', dest='with_view',
+        const=True, default=True,
+        help="Update PATH etc. with associated view")
+    view_options.add_argument(
+        '-V', '--without-view', action='store_const', dest='with_view',
+        const=False, default=True,
+        help="Do not update PATH etc. with associated view")
+
     subparser.add_argument(
         '-d', '--dir', action='store_true', default=False,
         help="force spack to treat env as a directory, not a name")
-    subparser.add_argument(
-        '-v', '--with-view', action='store_true', default=False,
-        help="Update PATH etc. with associated view")
     subparser.add_argument(
         '-p', '--prompt', action='store_true', default=False,
         help="decorate the command line prompt when activating")

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -213,11 +213,11 @@ def _env_create(name_or_path, init_file=None, dir=False, with_view=None):
             of a named environment
     """
     if dir:
-        env = ev.Environment(name_or_path, init_file)
+        env = ev.Environment(name_or_path, init_file, with_view)
         env.write()
         tty.msg("Created environment in %s" % env.path)
     else:
-        env = ev.create(name_or_path, init_file)
+        env = ev.create(name_or_path, init_file, with_view)
         env.write()
         tty.msg("Created environment '%s' in %s" % (name_or_path, env.path))
     return env

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -20,8 +20,7 @@ import spack.cmd.modules
 import spack.cmd.common.arguments as arguments
 import spack.environment as ev
 import spack.util.string as string
-from spack.util.environment import (
-    BashShellPathModifications, CshShellPathModifications)
+
 
 description = "manage virtual environments"
 section = "environments"
@@ -115,6 +114,7 @@ def env_activate(args):
     )
     sys.stdout.write(cmds)
 
+
 #
 # env deactivate
 #
@@ -147,9 +147,9 @@ def env_deactivate(args):
     if 'SPACK_ENV' not in os.environ:
         tty.die('No environment is currently active.')
 
-#    active_env = ev.get_env(namedtuple('args', [])(), 'deactivate')
     cmds = ev.deactivate(shell=args.shell)
     sys.stdout.write(cmds)
+
 
 #
 # env create

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -172,16 +172,24 @@ def env_create_setup_parser(subparser):
     subparser.add_argument(
         '-d', '--dir', action='store_true',
         help='create an environment in a specific directory')
-    subparser.add_argument(
+    view_opts = subparser.add_mutually_exclusive_group()
+    view_opts.add_argument(
         '--without-view', action='store_true',
         help='do not maintain a view for this environment')
+    view_opts.add_argument(
+        '--with-view',
+        help='specify that this environment should maintain a view at the'
+             ' specified path (by default the view is maintained in the'
+             ' environment directory)')
     subparser.add_argument(
         'envfile', nargs='?', default=None,
         help='optional init file; can be spack.yaml or spack.lock')
 
 
 def env_create(args):
-    if args.without_view:
+    if args.with_view:
+        with_view = args.with_view
+    elif args.without_view:
         with_view = False
     else:
         with_view = None

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -57,11 +57,11 @@ def env_activate_setup_parser(subparser):
     view_options.add_argument(
         '-v', '--with-view', action='store_const', dest='with_view',
         const=True, default=True,
-        help="Update PATH etc. with associated view")
+        help="update PATH etc. with associated view")
     view_options.add_argument(
         '-V', '--without-view', action='store_const', dest='with_view',
         const=False, default=True,
-        help="Do not update PATH etc. with associated view")
+        help="do not update PATH etc. with associated view")
 
     subparser.add_argument(
         '-d', '--dir', action='store_true', default=False,

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -34,6 +34,7 @@ subcommands = [
     ['list', 'ls'],
     ['status', 'st'],
     'loads',
+    'view',
 ]
 
 
@@ -287,6 +288,39 @@ def env_list(args):
             tty.msg('%d environments' % len(names))
 
     colify(color_names, indent=4)
+
+
+#
+# env view
+#
+def env_view_setup_parser(subparser):
+    """manage a view associated with the environment"""
+    views = subparser.add_mutually_exclusive_group()
+    views.add_argument(
+        '--regenerate', action='store_true',
+        help="regenerate the view for the environment")
+    views.add_argument(
+        '--enable', action='store_true',
+        help="enable a view for the environment")
+    views.add_argument(
+        '--disable', action='store_true',
+        help="disable view for the environment")
+
+
+def env_view(args):
+    env = ev.get_env(args, 'env view')
+
+    if env:
+        if args.regenerate:
+            env.regenerate_view()
+        elif args.enable:
+            env._view_path = True
+            env.write()
+        elif args.disable:
+            env._view_path = False
+            env.write()
+    else:
+        tty.msg("No active environment")
 
 
 #

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -299,6 +299,10 @@ def env_view_setup_parser(subparser):
     subparser.add_argument(
         'action', choices=ViewAction.actions(),
         help="action to take for the environment's view")
+    subparser.add_argument(
+        'view_path', nargs='?',
+        help="when enabling a view, optionally set the path manually"
+    )
 
 
 def env_view(args):
@@ -308,7 +312,10 @@ def env_view(args):
         if args.action == ViewAction.regenerate:
             env.regenerate_view()
         elif args.action == ViewAction.enable:
-            env._view_path = env.default_view_path
+            if args.view_path:
+                env._view_path = args.view_path
+            else:
+                env._view_path = env.default_view_path
             env.write()
         elif args.action == ViewAction.disable:
             env._view_path = None

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -281,34 +281,37 @@ def env_list(args):
     colify(color_names, indent=4)
 
 
+class ViewAction(object):
+    regenerate = 'regenerate'
+    enable = 'enable'
+    disable = 'disable'
+
+    @staticmethod
+    def actions():
+        return [ViewAction.regenerate, ViewAction.enable, ViewAction.disable]
+
+
 #
 # env view
 #
 def env_view_setup_parser(subparser):
     """manage a view associated with the environment"""
-    views = subparser.add_mutually_exclusive_group()
-    views.add_argument(
-        '--regenerate', action='store_true',
-        help="regenerate the view for the environment")
-    views.add_argument(
-        '--enable', action='store_true',
-        help="enable a view for the environment")
-    views.add_argument(
-        '--disable', action='store_true',
-        help="disable view for the environment")
+    subparser.add_argument(
+        'action', choices=ViewAction.actions(),
+        help="action to take for the environment's view")
 
 
 def env_view(args):
     env = ev.get_env(args, 'env view')
 
     if env:
-        if args.regenerate:
+        if args.action == ViewAction.regenerate:
             env.regenerate_view()
-        elif args.enable:
-            env._view_path = True
+        elif args.action == ViewAction.enable:
+            env._view_path = env.default_view_path
             env.write()
-        elif args.disable:
-            env._view_path = False
+        elif args.action == ViewAction.disable:
+            env._view_path = None
             env.write()
     else:
         tty.msg("No active environment")

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -173,19 +173,28 @@ def env_create_setup_parser(subparser):
         '-d', '--dir', action='store_true',
         help='create an environment in a specific directory')
     subparser.add_argument(
+        '--without-view', action='store_true',
+        help='do not maintain a view for this environment')
+    subparser.add_argument(
         'envfile', nargs='?', default=None,
         help='optional init file; can be spack.yaml or spack.lock')
 
 
 def env_create(args):
+    if args.without_view:
+        with_view = False
+    else:
+        with_view = None
     if args.envfile:
         with open(args.envfile) as f:
-            _env_create(args.create_env, f, args.dir)
+            _env_create(args.create_env, f, args.dir,
+                        with_view=with_view)
     else:
-        _env_create(args.create_env, None, args.dir)
+        _env_create(args.create_env, None, args.dir,
+                    with_view=with_view)
 
 
-def _env_create(name_or_path, init_file=None, dir=False):
+def _env_create(name_or_path, init_file=None, dir=False, with_view=None):
     """Create a new environment, with an optional yaml description.
 
     Arguments:

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -216,9 +216,9 @@ def install(parser, args, **kwargs):
         if env:
             if not args.only_concrete:
                 env.concretize()
-                env.write()
             tty.msg("Installing environment %s" % env.name)
             env.install_all(args)
+            env.write()
             return
         else:
             tty.die("install requires a package argument or a spack.yaml file")

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -216,9 +216,9 @@ def install(parser, args, **kwargs):
         if env:
             if not args.only_concrete:
                 env.concretize()
+                env.write()
             tty.msg("Installing environment %s" % env.name)
             env.install_all(args)
-            env.write()
             return
         else:
             tty.die("install requires a package argument or a spack.yaml file")

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -679,10 +679,12 @@ class Environment(object):
 
     def regenerate_view(self):
         if not self._view_path:
-            raise SpackEnvironmentError(
-                "The environment '{0}' does not maintain a view"
-                .format(self.name))
+            tty.debug("Skip view update, this environment does not"
+                      " maintain a view")
+            return
+
         if os.path.exists(self._view_path):
+            tty.msg("Clearing view at {0}".format(self._view_path))
             shutil.rmtree(self._view_path)
         self.update_view()
 

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -674,7 +674,10 @@ class Environment(object):
             # they need to be stripped
             specs_without_build_deps.append(
                 spack.spec.Spec.from_dict(spec.to_dict(all_deps=False)))
-        view.add_specs(*specs_without_build_deps, with_dependencies=False)
+
+        specs_to_add = list(x for x in specs_without_build_deps
+                            if x.package.installed)
+        view.add_specs(*specs_to_add, with_dependencies=False)
 
     def view(self):
         return YamlFilesystemView(

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -346,12 +346,12 @@ class Environment(object):
 
         if init_file:
             with fs.open_if_filename(init_file) as f:
-                if hasattr(f, 'name') and f.name.endswith('.yaml'):
-                    self._read_manifest(f, init=True)
-                else:
+                if hasattr(f, 'name') and f.name.endswith('.lock'):
                     self._read_manifest(default_manifest_yaml, init=True)
                     self._read_lockfile(f)
                     self._set_user_specs_from_lockfile()
+                else:
+                    self._read_manifest(f, init=True)
         else:
             init = not any(os.path.exists(x)
                            for x in (self.lock_path, self.manifest_path))

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -714,6 +714,12 @@ class Environment(object):
         return YamlFilesystemView(
             self._view_path, spack.store.layout, ignore_conflicts=True)
 
+    def update_view(self, view_path):
+        if self._view_path and self._view_path != view_path:
+            shutil.rmtree(self._view_path)
+
+        self._view_path = view_path
+
     def regenerate_view(self):
         if not self._view_path:
             tty.debug("Skip view update, this environment does not"

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -818,7 +818,7 @@ class Environment(object):
             if not spec.external:
                 # Link the resulting log file into logs dir
                 build_log_link = os.path.join(
-                    log_path, '%s-%s.log' % (spec.name, spec.dag_hash(7)))
+                    self.log_path, '%s-%s.log' % (spec.name, spec.dag_hash(7)))
                 if os.path.exists(build_log_link):
                     os.remove(build_log_link)
                 os.symlink(spec.package.build_log_path, build_log_link)

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -670,12 +670,18 @@ class Environment(object):
         view_specs = {}
         for root_hash in self.concretized_order:
             root = self.specs_by_hash[root_hash]
+            # If a spec appears as a root and as a dependency, the root always
+            # overrides the dependency
             view_specs[root.name] = root
             for dep in root.traverse(root=False, deptype=('link', 'run')):
                 if dep.name not in view_specs:
                     view_specs[dep.name] = dep
         view = self.view()
-        view.add_specs(*view_specs.values(), with_dependencies=False)
+        specs_without_build_deps = list()
+        for spec in view_specs.values():
+            specs_without_build_deps.append(
+                spack.spec.Spec.from_dict(spec.to_dict(all_deps=False)))
+        view.add_specs(*specs_without_build_deps, with_dependencies=False)
 
     def view(self):
         return YamlFilesystemView(

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -711,6 +711,10 @@ class Environment(object):
             os.symlink(spec.package.build_log_path, build_log_link)
 
     def view(self):
+        if not self._view_path:
+            raise SpackEnvironmentError(
+                "{0} does not have a view enabled".format(self.name))
+
         return YamlFilesystemView(
             self._view_path, spack.store.layout, ignore_conflicts=True)
 

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -340,6 +340,9 @@ class Environment(object):
             path (str): path to the root directory of this environment
             init_file (str or file object): filename or file object to
                 initialize the environment
+            with_view (str or bool): whether a view should be maintained for
+                the environment. If the value is a string, it specifies the
+                path to the view.
         """
         self.path = os.path.abspath(path)
         self.clear()
@@ -356,11 +359,11 @@ class Environment(object):
             init = not any(os.path.exists(x)
                            for x in (self.lock_path, self.manifest_path))
             default_manifest = not os.path.exists(self.manifest_path)
-            if not default_manifest:
+            if default_manifest:
+                self._read_manifest(default_manifest_yaml, init=init)
+            else:
                 with open(self.manifest_path) as f:
                     self._read_manifest(f, init=init)
-            else:
-                self._read_manifest(default_manifest_yaml, init=init)
 
             if os.path.exists(self.lock_path):
                 with open(self.lock_path) as f:

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -758,7 +758,8 @@ class Environment(object):
         path_updates = list()
         for var, subdirs in updates:
             paths = filter(lambda x: os.path.exists(x),
-                           list(os.path.join(self._view_path, x) for x in subdirs))
+                           list(os.path.join(self._view_path, x)
+                                for x in subdirs))
             path_updates.append((var, paths))
         return path_updates
 

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -662,6 +662,7 @@ class Environment(object):
                       " maintain a view")
             return
 
+        # TODO: this is too verbose: it is printed in the middle of testing
         tty.msg("Updating view at {0}".format(self._view_path))
 
         view_specs = self._get_environment_specs()

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -665,6 +665,8 @@ class Environment(object):
                       " maintain a view")
             return
 
+        tty.msg("Updating view at {0}".format(self._view_path))
+
         view_specs = {}
         for root_hash in self.concretized_order:
             root = self.specs_by_hash[root_hash]

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -405,20 +405,18 @@ class Environment(object):
         if init_file:
             with fs.open_if_filename(init_file) as f:
                 if hasattr(f, 'name') and f.name.endswith('.lock'):
-                    self._read_manifest(default_manifest_yaml, init=True)
+                    self._read_manifest(default_manifest_yaml)
                     self._read_lockfile(f)
                     self._set_user_specs_from_lockfile()
                 else:
-                    self._read_manifest(f, init=True)
+                    self._read_manifest(f)
         else:
-            init = not any(os.path.exists(x)
-                           for x in (self.lock_path, self.manifest_path))
             default_manifest = not os.path.exists(self.manifest_path)
             if default_manifest:
-                self._read_manifest(default_manifest_yaml, init=init)
+                self._read_manifest(default_manifest_yaml)
             else:
                 with open(self.manifest_path) as f:
-                    self._read_manifest(f, init=init)
+                    self._read_manifest(f)
 
             if os.path.exists(self.lock_path):
                 with open(self.lock_path) as f:
@@ -433,7 +431,7 @@ class Environment(object):
         # If with_view is None, then defer to the view settings determined by
         # the manifest file
 
-    def _read_manifest(self, f, init=False):
+    def _read_manifest(self, f):
         """Read manifest file and set up user specs."""
         self.yaml = _read_yaml(f)
         spec_list = config_dict(self.yaml).get('specs')
@@ -443,12 +441,12 @@ class Environment(object):
         enable_view = config_dict(self.yaml).get('view')
         # enable_view can be true/false, a string, or None (if the manifest did
         # not specify it)
-        if enable_view is True or (enable_view is None and init):
+        if enable_view is True or enable_view is None:
             self._view_path = self.default_view_path
         elif isinstance(enable_view, six.string_types):
             self._view_path = enable_view
         else:
-            # enable_view is False, or (enable_view, init) == (None, False)
+            # enable_view is False
             self._view_path = None
 
     def _set_user_specs_from_lockfile(self):

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -685,6 +685,14 @@ class Environment(object):
         return YamlFilesystemView(
             self._view_path, spack.store.layout, ignore_conflicts=True)
 
+    def regenerate_view(self):
+        if not self._view_path:
+            raise SpackEnvironmentError(
+                "The environment '{0}' does not maintain a view"
+                .format(self.name))
+        shutil.rmtree(self._view_path)
+        self.update_view()
+
     def _add_concrete_spec(self, spec, concrete, new=True):
         """Called when a new concretized spec is added to the environment.
 

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -695,13 +695,13 @@ class Environment(object):
         self._install(concrete, **install_args)
 
     def _install(self, spec, **install_args):
+        spec.package.do_install(**install_args)
+
         # Make sure log directory exists
         log_path = self.log_path
         fs.mkdirp(log_path)
 
         with fs.working_dir(self.path):
-            spec.package.do_install(**install_args)
-
             # Link the resulting log file into logs dir
             build_log_link = os.path.join(
                 log_path, '%s-%s.log' % (spec.name, spec.dag_hash(7)))

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -823,7 +823,7 @@ class Environment(object):
                     os.remove(build_log_link)
                 os.symlink(spec.package.build_log_path, build_log_link)
 
-        self.update_view()
+        self.regenerate_view()
 
     def all_specs_by_hash(self):
         """Map of hashes to spec for all specs in this environment."""

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -665,18 +665,11 @@ class Environment(object):
 
         tty.msg("Updating view at {0}".format(self._view_path))
 
-        view_specs = {}
-        for root_hash in self.concretized_order:
-            root = self.specs_by_hash[root_hash]
-            # If a spec appears as a root and as a dependency, the root always
-            # overrides the dependency
-            view_specs[root.name] = root
-            for dep in root.traverse(root=False, deptype=('link', 'run')):
-                if dep.name not in view_specs:
-                    view_specs[dep.name] = dep
+        view_specs = self._get_environment_specs()
+
         view = self.view()
         specs_without_build_deps = list()
-        for spec in view_specs.values():
+        for spec in view_specs:
             specs_without_build_deps.append(
                 spack.spec.Spec.from_dict(spec.to_dict(all_deps=False)))
         view.add_specs(*specs_without_build_deps, with_dependencies=False)
@@ -690,7 +683,8 @@ class Environment(object):
             raise SpackEnvironmentError(
                 "The environment '{0}' does not maintain a view"
                 .format(self.name))
-        shutil.rmtree(self._view_path)
+        if os.path.exists(self._view_path):
+            shutil.rmtree(self._view_path)
         self.update_view()
 
     def _add_concrete_spec(self, spec, concrete, new=True):

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -755,11 +755,19 @@ class Environment(object):
 
     def _shell_vars(self):
         updates = [
-            ('PATH', ['bin'])
+            ('PATH', ['bin']),
+            ('MANPATH', ['man', 'share/man']),
+            ('ACLOCAL_PATH', ['share/aclocal']),
+            ('LD_LIBRARY_PATH', ['lib', 'lib64']),
+            ('LIBRARY_PATH', ['lib', 'lib64']),
+            ('CPATH', ['include']),
+            ('PKG_CONFIG_PATH', ['lib/pkgconfig', 'lib64/pkgconfig']),
+            ('CMAKE_PREFIX_PATH', ['']),
         ]
         path_updates = list()
         for var, subdirs in updates:
-            paths = list(os.path.join(self._view_path, x) for x in subdirs)
+            paths = filter(lambda x: os.path.exists(x),
+                           list(os.path.join(self._view_path, x) for x in subdirs))
             path_updates.append((var, paths))
         return path_updates
 

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -669,6 +669,9 @@ class Environment(object):
         view = self.view()
         specs_without_build_deps = list()
         for spec in view_specs:
+            # The view does not store build deps, so if we want it to
+            # recognize environment specs (which do store build deps), then
+            # they need to be stripped
             specs_without_build_deps.append(
                 spack.spec.Spec.from_dict(spec.to_dict(all_deps=False)))
         view.add_specs(*specs_without_build_deps, with_dependencies=False)

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -719,7 +719,7 @@ class Environment(object):
                       " maintain a view")
             return
 
-        specs_for_view = list()
+        specs_for_view = []
         for spec in self._get_environment_specs():
             # The view does not store build deps, so if we want it to
             # recognize environment specs (which do store build deps), then

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -738,8 +738,7 @@ class Environment(object):
                                        if s.package.installed)
 
         view = self.view()
-        view.purge_broken_links()
-        view.purge_empty_directories()
+        view.clean()
         specs_in_view = set(view.get_all_specs())
         tty.msg("Updating view at {0}".format(self._view_path))
 

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -177,7 +177,8 @@ def deactivate(shell='sh'):
         cmds += 'unset SPACK_OLD_PS1; export SPACK_OLD_PS1;\n'
         cmds += 'fi;\n'
 
-    cmds += _active_environment.rm_view_from_shell(shell)
+    if _active_environment._view_path:
+        cmds += _active_environment.rm_view_from_shell(shell)
 
     tty.debug("Deactivated environmennt '%s'" % _active_environment.name)
     _active_environment = None

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -640,7 +640,6 @@ class Environment(object):
                 self._add_concrete_spec(spec, concrete)
 
         self._install(concrete, **install_args)
-        self.update_view()
 
     def _install(self, spec, **install_args):
         # Make sure log directory exists
@@ -934,6 +933,10 @@ class Environment(object):
         # if all that worked, write out the manifest file at the top level
         with fs.write_tmp_and_move(self.manifest_path) as f:
             _write_yaml(self.yaml, f)
+
+        # TODO: for operations that just add to the env (install etc.) this
+        # could just call update_view
+        self.regenerate_view()
 
     def __enter__(self):
         self._previous_active = _active_environment

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -374,15 +374,12 @@ class Environment(object):
                 # if there's no manifest or lockfile, use the default
                 self._read_manifest(default_manifest_yaml)
 
-        #a. read the default (it is set), user enabled with cmd line
-        #b. read the default (it is set), user disabled with cmd line
-        #b. read explicit and it was set False, user enabled with cmd-line
-        #c. read explicit and it was set True, user disabled with cmd-line
-        #c. read explicit and it was not set, and user did not specify
-        #d. read explicit and it was set False, and user did not specify
-        #(on account of [d], you must distinguish true, false, and None)
         if with_view is False:
-            self._vew_path = None
+            self._view_path = None
+        elif isinstance(with_view, six.string_types):
+            self._view_path = with_view
+        # If with_view is None, then defer to the view settings determined by
+        # the manifest file
 
     def _read_manifest(self, f):
         """Read manifest file and set up user specs."""
@@ -397,6 +394,8 @@ class Environment(object):
         elif isinstance(enable_view, six.string_types):
             self._view_path = enable_view
         else:
+            # If this option is not specified, it is treated as if it was
+            # enabled
             self._view_path = self.default_view_path
 
     def _set_user_specs_from_lockfile(self):

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -688,6 +688,26 @@ class Environment(object):
             shutil.rmtree(self._view_path)
         self.update_view()
 
+    def _shell_vars(self):
+        updates = [
+            ('PATH', ['bin'])
+        ]
+        path_updates = list()
+        for var, subdirs in updates:
+            paths = list(os.path.join(self._view_path, x) for x in subdirs)
+            path_updates.append((var, paths))
+        return path_updates
+
+    def add_view_to_shell(self, shell_modifications):
+        for var, paths in self._shell_vars():
+            for path in paths:
+                shell_modifications.prepend_path(var, path)
+
+    def rm_view_from_shell(self, shell_modifications):
+        for var, paths in self._shell_vars():
+            for path in paths:
+                shell_modifications.remove_path(var, path)
+
     def _add_concrete_spec(self, spec, concrete, new=True):
         """Called when a new concretized spec is added to the environment.
 

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -707,7 +707,7 @@ class Environment(object):
             # Link the resulting log file into logs dir
             build_log_link = os.path.join(
                 log_path, '%s-%s.log' % (spec.name, spec.dag_hash(7)))
-            if os.path.exists(build_log_link):
+            if os.path.lexists(build_log_link):
                 os.remove(build_log_link)
             os.symlink(spec.package.build_log_path, build_log_link)
 
@@ -819,7 +819,7 @@ class Environment(object):
                 # Link the resulting log file into logs dir
                 build_log_link = os.path.join(
                     self.log_path, '%s-%s.log' % (spec.name, spec.dag_hash(7)))
-                if os.path.exists(build_log_link):
+                if os.path.lexists(build_log_link):
                     os.remove(build_log_link)
                 os.symlink(spec.package.build_log_path, build_log_link)
 

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -14,8 +14,8 @@ from llnl.util.link_tree import LinkTree, MergeConflictError
 from llnl.util import tty
 from llnl.util.lang import match_predicate, index_by
 from llnl.util.tty.color import colorize
-from llnl.util.filesystem import mkdirp
-import llnl.util.filesystem
+from llnl.util.filesystem import (
+    mkdirp, remove_dead_links, remove_empty_directories)
 
 import spack.util.spack_yaml as s_yaml
 
@@ -408,7 +408,7 @@ class YamlFilesystemView(FilesystemView):
         set(map(remove_extension, extensions))
         set(map(self.remove_standalone, standalones))
 
-        self.purge_empty_directories()
+        self._purge_empty_directories()
 
     def remove_extension(self, spec, with_dependents=True):
         """
@@ -576,11 +576,15 @@ class YamlFilesystemView(FilesystemView):
         else:
             tty.warn(self._croot + "No packages found.")
 
-    def purge_empty_directories(self):
-        llnl.util.filesystem.purge_empty_directories(self._root)
+    def _purge_empty_directories(self):
+        remove_empty_directories(self._root)
 
-    def purge_broken_links(self):
-        llnl.util.filesystem.remove_dead_links(self._root)
+    def _purge_broken_links(self):
+        remove_dead_links(self._root)
+
+    def clean(self):
+        self._purge_broken_links()
+        self._purge_empty_directories()
 
     def unlink_meta_folder(self, spec):
         path = self.get_path_meta_folder(spec)

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -15,6 +15,7 @@ from llnl.util import tty
 from llnl.util.lang import match_predicate, index_by
 from llnl.util.tty.color import colorize
 from llnl.util.filesystem import mkdirp
+import llnl.util.filesystem
 
 import spack.util.spack_yaml as s_yaml
 
@@ -576,28 +577,10 @@ class YamlFilesystemView(FilesystemView):
             tty.warn(self._croot + "No packages found.")
 
     def purge_empty_directories(self):
-        """
-            Ascend up from the leaves accessible from `path`
-            and remove empty directories.
-        """
-        for dirpath, subdirs, files in os.walk(self._root, topdown=False):
-            for sd in subdirs:
-                sdp = os.path.join(dirpath, sd)
-                try:
-                    os.rmdir(sdp)
-                except OSError:
-                    pass
+        llnl.util.filesystem.purge_empty_directories(self._root)
 
     def purge_broken_links(self):
-        """
-            Ascend up from the leaves accessible from `path`
-            and remove broken links (uninstalled packages).
-        """
-        for dirpath, subdirs, files in os.walk(self._root, topdown=False):
-            for f in files:
-                filename = os.path.join(dirpath, f)
-                if not os.path.exists(filename):  # filename is broken link
-                    os.unlink(filename)
+        llnl.util.filesystem.remove_dead_links(self._root)
 
     def unlink_meta_folder(self, spec):
         path = self.get_path_meta_folder(spec)

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -588,6 +588,17 @@ class YamlFilesystemView(FilesystemView):
                 except OSError:
                     pass
 
+    def purge_broken_links(self):
+        """
+            Ascend up from the leaves accessible from `path`
+            and remove broken links (uninstalled packages).
+        """
+        for dirpath, subdirs, files in os.walk(self.root, topdown=False):
+            for f in files:
+                filename = os.path.join(dirpath, f)
+                if not os.path.exists(filename):  # filename is broken link
+                    os.unlink(filename)
+
     def unlink_meta_folder(self, spec):
         path = self.get_path_meta_folder(spec)
         assert os.path.exists(path)

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -593,7 +593,7 @@ class YamlFilesystemView(FilesystemView):
             Ascend up from the leaves accessible from `path`
             and remove broken links (uninstalled packages).
         """
-        for dirpath, subdirs, files in os.walk(self.root, topdown=False):
+        for dirpath, subdirs, files in os.walk(self._root, topdown=False):
             for f in files:
                 filename = os.path.join(dirpath, f)
                 if not os.path.exists(filename):  # filename is broken link

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -47,6 +47,9 @@ schema = {
                                 {'type': 'object'},
                             ]
                         }
+                    },
+                    'view': {
+                        'type': ['boolean', 'string']
                     }
                 }
             )

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -735,33 +735,3 @@ def test_env_activate_view_fails(
     """Sanity check on env activate to make sure it requires shell support"""
     out = env('activate', 'test')
     assert "To initialize spack's shell commands:" in out
-
-
-def test_env_activate_deactivate_in_shell(
-    tmpdir, mock_stage, mock_fetch, install_mockery
-):
-    base_dir = tmpdir.mkdir('base')
-    env_dir = base_dir.join('env')
-    view_dir = base_dir.join('view')
-
-    setup_script = os.path.join(spack.paths.share_path, 'setup-env.sh')
-
-    cmds = ''
-    cmds += 'cd %s;' % base_dir
-    cmds += '. %s;' % setup_script
-    cmds += 'spack env create -d %s --with-view %s;' % (env_dir, view_dir)
-    cmds += 'spack -E %s install --fake mpileaks;' % env_dir
-    cmds += 'spack env activate -pd %s;' % env_dir
-    cmds += 'echo "PATH is $PATH";'
-    cmds += 'spack env deactivate;'
-    cmds += 'echo "PATH is $PATH";'
-
-    subshell = sp.Popen(cmds, stdout=sp.PIPE, stderr=sp.STDOUT,
-                        executable='/bin/bash', shell=True)
-    subshell.wait()
-    output, _ = subshell.communicate()
-    lines = filter(lambda x: x.startswith('PATH is'), output.split('\n'))
-
-    assert len(lines) == 2
-    assert str(view_dir) in lines[0]
-    assert str(view_dir) not in lines[1]

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -642,6 +642,28 @@ def test_env_without_view_install(
     assert os.path.exists(str(view_dir.join('.spack/mpileaks')))
     assert os.path.exists(str(view_dir.join('.spack/libdwarf')))
 
+
+def test_env_config_view_default(
+    tmpdir, mock_stage, mock_fetch, install_mockery
+):
+    # This config doesn't mention whether a view is enabled
+    test_config = """\
+env:
+  specs:
+  - mpileaks
+"""
+
+    _env_create('test', StringIO(test_config))
+
+    with ev.read('test'):
+        install('--fake')
+
+    e = ev.read('test')
+    # Try retrieving the view object
+    view = e.view()
+    assert view.get_spec('mpileaks')
+
+
 def test_env_updates_view_install_package(
     tmpdir, mock_stage, mock_fetch, install_mockery
 ):

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import subprocess as sp
 from six import StringIO
 
 import pytest

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -605,7 +605,9 @@ def test_uninstall_removes_from_env(mock_stage, mock_fetch, install_mockery):
     assert not test.user_specs
 
 
-def test_env_updates_view_install(tmpdir, mock_stage, mock_fetch, install_mockery):
+def test_env_updates_view_install(
+    tmpdir, mock_stage, mock_fetch, install_mockery
+):
     view_dir = tmpdir.mkdir('view')
     env('create', '--with-view=%s' % view_dir, 'test')
     with ev.read('test'):
@@ -617,7 +619,9 @@ def test_env_updates_view_install(tmpdir, mock_stage, mock_fetch, install_mocker
     assert os.path.exists(str(view_dir.join('.spack/libdwarf')))
 
 
-def test_env_updates_view_install_package(tmpdir, mock_stage, mock_fetch, install_mockery):
+def test_env_updates_view_install_package(
+    tmpdir, mock_stage, mock_fetch, install_mockery
+):
     view_dir = tmpdir.mkdir('view')
     env('create', '--with-view=%s' % view_dir, 'test')
     with ev.read('test'):
@@ -628,7 +632,9 @@ def test_env_updates_view_install_package(tmpdir, mock_stage, mock_fetch, instal
     assert os.path.exists(str(view_dir.join('.spack/libdwarf')))
 
 
-def test_env_updates_view_add_concretize(tmpdir, mock_stage, mock_fetch, install_mockery):
+def test_env_updates_view_add_concretize(
+    tmpdir, mock_stage, mock_fetch, install_mockery
+):
     view_dir = tmpdir.mkdir('view')
     env('create', '--with-view=%s' % view_dir, 'test')
     install('--fake', 'mpileaks')
@@ -641,7 +647,9 @@ def test_env_updates_view_add_concretize(tmpdir, mock_stage, mock_fetch, install
     assert os.path.exists(str(view_dir.join('.spack/libdwarf')))
 
 
-def test_env_updates_view_uninstall(tmpdir, mock_stage, mock_fetch, install_mockery):
+def test_env_updates_view_uninstall(
+    tmpdir, mock_stage, mock_fetch, install_mockery
+):
     view_dir = tmpdir.mkdir('view')
     env('create', '--with-view=%s' % view_dir, 'test')
     with ev.read('test'):
@@ -658,7 +666,9 @@ def test_env_updates_view_uninstall(tmpdir, mock_stage, mock_fetch, install_mock
             os.listdir(str(view_dir.join('.spack'))) == [])
 
 
-def test_env_updates_view_uninstall_referenced_elsewhere(tmpdir, mock_stage, mock_fetch, install_mockery):
+def test_env_updates_view_uninstall_referenced_elsewhere(
+    tmpdir, mock_stage, mock_fetch, install_mockery
+):
     view_dir = tmpdir.mkdir('view')
     env('create', '--with-view=%s' % view_dir, 'test')
     install('--fake', 'mpileaks')
@@ -677,7 +687,9 @@ def test_env_updates_view_uninstall_referenced_elsewhere(tmpdir, mock_stage, moc
             os.listdir(str(view_dir.join('.spack'))) == [])
 
 
-def test_env_updates_view_remove_concretize(tmpdir, mock_stage, mock_fetch, install_mockery):
+def test_env_updates_view_remove_concretize(
+    tmpdir, mock_stage, mock_fetch, install_mockery
+):
     view_dir = tmpdir.mkdir('view')
     env('create', '--with-view=%s' % view_dir, 'test')
     install('--fake', 'mpileaks')
@@ -697,7 +709,9 @@ def test_env_updates_view_remove_concretize(tmpdir, mock_stage, mock_fetch, inst
             os.listdir(str(view_dir.join('.spack'))) == [])
 
 
-def test_env_updates_view_force_remove(tmpdir, mock_stage, mock_fetch, install_mockery):
+def test_env_updates_view_force_remove(
+    tmpdir, mock_stage, mock_fetch, install_mockery
+):
     view_dir = tmpdir.mkdir('view')
     env('create', '--with-view=%s' % view_dir, 'test')
     with ev.read('test'):

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -663,7 +663,7 @@ def test_env_updates_view_uninstall(
         uninstall('-ay')
 
     assert (not os.path.exists(str(view_dir.join('.spack'))) or
-            os.listdir(str(view_dir.join('.spack'))) == [])
+            os.listdir(str(view_dir.join('.spack'))) == ['projections.yaml'])
 
 
 def test_env_updates_view_uninstall_referenced_elsewhere(
@@ -684,7 +684,7 @@ def test_env_updates_view_uninstall_referenced_elsewhere(
         uninstall('-ay')
 
     assert (not os.path.exists(str(view_dir.join('.spack'))) or
-            os.listdir(str(view_dir.join('.spack'))) == [])
+            os.listdir(str(view_dir.join('.spack'))) == ['projections.yaml'])
 
 
 def test_env_updates_view_remove_concretize(
@@ -706,7 +706,7 @@ def test_env_updates_view_remove_concretize(
         concretize()
 
     assert (not os.path.exists(str(view_dir.join('.spack'))) or
-            os.listdir(str(view_dir.join('.spack'))) == [])
+            os.listdir(str(view_dir.join('.spack'))) == ['projections.yaml'])
 
 
 def test_env_updates_view_force_remove(
@@ -725,7 +725,7 @@ def test_env_updates_view_force_remove(
         remove('-f', 'mpileaks')
 
     assert (not os.path.exists(str(view_dir.join('.spack'))) or
-            os.listdir(str(view_dir.join('.spack'))) == [])
+            os.listdir(str(view_dir.join('.spack'))) == ['projections.yaml'])
 
 
 def test_env_activate_view_fails(

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -619,6 +619,29 @@ def test_env_updates_view_install(
     assert os.path.exists(str(view_dir.join('.spack/libdwarf')))
 
 
+def test_env_without_view_install(
+    tmpdir, mock_stage, mock_fetch, install_mockery
+):
+    # Test enabling a view after installing specs
+    env('create', '--without-view', 'test')
+
+    test_env = ev.read('test')
+    with pytest.raises(spack.environment.SpackEnvironmentError):
+        test_env.view()
+
+    view_dir = tmpdir.mkdir('view')
+
+    with ev.read('test'):
+        add('mpileaks')
+        install('--fake')
+
+        env('view', 'enable', str(view_dir))
+
+    # After enabling the view, the specs should be linked into the environment
+    # view dir
+    assert os.path.exists(str(view_dir.join('.spack/mpileaks')))
+    assert os.path.exists(str(view_dir.join('.spack/libdwarf')))
+
 def test_env_updates_view_install_package(
     tmpdir, mock_stage, mock_fetch, install_mockery
 ):

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -603,3 +603,112 @@ def test_uninstall_removes_from_env(mock_stage, mock_fetch, install_mockery):
     assert not test.specs_by_hash
     assert not test.concretized_order
     assert not test.user_specs
+
+
+def test_env_updates_view_install(tmpdir, mock_stage, mock_fetch, install_mockery):
+    view_dir = tmpdir.mkdir('view')
+    env('create', '--with-view=%s' % view_dir, 'test')
+    with ev.read('test'):
+        add('mpileaks')
+        install('--fake')
+
+    assert os.path.exists(str(view_dir.join('.spack/mpileaks')))
+    # Check that dependencies got in too
+    assert os.path.exists(str(view_dir.join('.spack/libdwarf')))
+
+
+def test_env_updates_view_install_package(tmpdir, mock_stage, mock_fetch, install_mockery):
+    view_dir = tmpdir.mkdir('view')
+    env('create', '--with-view=%s' % view_dir, 'test')
+    with ev.read('test'):
+        install('--fake', 'mpileaks')
+
+    assert os.path.exists(str(view_dir.join('.spack/mpileaks')))
+    # Check that dependencies got in too
+    assert os.path.exists(str(view_dir.join('.spack/libdwarf')))
+
+
+def test_env_updates_view_add_concretize(tmpdir, mock_stage, mock_fetch, install_mockery):
+    view_dir = tmpdir.mkdir('view')
+    env('create', '--with-view=%s' % view_dir, 'test')
+    install('--fake', 'mpileaks')
+    with ev.read('test'):
+        add('mpileaks')
+        concretize()
+
+    assert os.path.exists(str(view_dir.join('.spack/mpileaks')))
+    # Check that dependencies got in too
+    assert os.path.exists(str(view_dir.join('.spack/libdwarf')))
+
+
+def test_env_updates_view_uninstall(tmpdir, mock_stage, mock_fetch, install_mockery):
+    view_dir = tmpdir.mkdir('view')
+    env('create', '--with-view=%s' % view_dir, 'test')
+    with ev.read('test'):
+        install('--fake', 'mpileaks')
+
+    assert os.path.exists(str(view_dir.join('.spack/mpileaks')))
+    # Check that dependencies got in too
+    assert os.path.exists(str(view_dir.join('.spack/libdwarf')))
+
+    with ev.read('test'):
+        uninstall('-ay')
+
+    assert (not os.path.exists(str(view_dir.join('.spack'))) or
+            os.listdir(str(view_dir.join('.spack'))) == [])
+
+
+def test_env_updates_view_uninstall_referenced_elsewhere(tmpdir, mock_stage, mock_fetch, install_mockery):
+    view_dir = tmpdir.mkdir('view')
+    env('create', '--with-view=%s' % view_dir, 'test')
+    install('--fake', 'mpileaks')
+    with ev.read('test'):
+        add('mpileaks')
+        concretize()
+
+    assert os.path.exists(str(view_dir.join('.spack/mpileaks')))
+    # Check that dependencies got in too
+    assert os.path.exists(str(view_dir.join('.spack/libdwarf')))
+
+    with ev.read('test'):
+        uninstall('-ay')
+
+    assert (not os.path.exists(str(view_dir.join('.spack'))) or
+            os.listdir(str(view_dir.join('.spack'))) == [])
+
+
+def test_env_updates_view_remove_concretize(tmpdir, mock_stage, mock_fetch, install_mockery):
+    view_dir = tmpdir.mkdir('view')
+    env('create', '--with-view=%s' % view_dir, 'test')
+    install('--fake', 'mpileaks')
+    with ev.read('test'):
+        add('mpileaks')
+        concretize()
+
+    assert os.path.exists(str(view_dir.join('.spack/mpileaks')))
+    # Check that dependencies got in too
+    assert os.path.exists(str(view_dir.join('.spack/libdwarf')))
+
+    with ev.read('test'):
+        remove('mpileaks')
+        concretize()
+
+    assert (not os.path.exists(str(view_dir.join('.spack'))) or
+            os.listdir(str(view_dir.join('.spack'))) == [])
+
+
+def test_env_updates_view_force_remove(tmpdir, mock_stage, mock_fetch, install_mockery):
+    view_dir = tmpdir.mkdir('view')
+    env('create', '--with-view=%s' % view_dir, 'test')
+    with ev.read('test'):
+        install('--fake', 'mpileaks')
+
+    assert os.path.exists(str(view_dir.join('.spack/mpileaks')))
+    # Check that dependencies got in too
+    assert os.path.exists(str(view_dir.join('.spack/libdwarf')))
+
+    with ev.read('test'):
+        remove('-f', 'mpileaks')
+
+    assert (not os.path.exists(str(view_dir.join('.spack'))) or
+            os.listdir(str(view_dir.join('.spack'))) == [])

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -729,7 +729,9 @@ def test_env_updates_view_force_remove(
             os.listdir(str(view_dir.join('.spack'))) == [])
 
 
-def test_env_activate_view_fails(tmpdir, mock_stage, mock_fetch, install_mockery):
+def test_env_activate_view_fails(
+    tmpdir, mock_stage, mock_fetch, install_mockery
+):
     """Sanity check on env activate to make sure it requires shell support"""
     out = env('activate', 'test')
     assert "To initialize spack's shell commands:" in out
@@ -749,7 +751,7 @@ def test_env_activate_deactivate_in_shell(
     cmds += '. %s;' % setup_script
     cmds += 'spack env create -d %s --with-view %s;' % (env_dir, view_dir)
     cmds += 'spack -E %s install --fake mpileaks;' % env_dir
-    cmds += 'spack env activate -vpd %s;' % env_dir
+    cmds += 'spack env activate -pd %s;' % env_dir
     cmds += 'echo "PATH is $PATH";'
     cmds += 'spack env deactivate;'
     cmds += 'echo "PATH is $PATH";'

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -31,7 +31,7 @@ _shell_set_strings = {
 }
 
 
-_shell__unset_strings = {
+_shell_unset_strings = {
     'sh': 'unset {};\n',
     'csh': 'unsetenv {};\n',
 }
@@ -208,48 +208,6 @@ class RemovePath(NameValueModifier):
         env[self.name] = self.separator.join(directories)
 
 
-class ShellPathModifications(object):
-    def __init__(self, env=None):
-        self.vars_to_set = {}
-        self.env = env or os.environ
-
-    def read_var(self, var):
-        val = list(self.env.get(var, '').split(':'))
-        if var not in self.vars_to_set:
-            self.vars_to_set[var] = val
-
-    def prepend_path(self, var, path):
-        self.read_var(var)
-        self.vars_to_set[var].insert(0, path)
-
-    def remove_path(self, var, path):
-        self.read_var(var)
-        vals = self.vars_to_set[var]
-        norm_vals = list(os.path.normpath(x) for x in vals)
-        norm_path = os.path.normpath(path)
-        new_vals = list(x for x in norm_vals if not (x == norm_path))
-        self.vars_to_set[var] = new_vals
-
-    def set_cmd(self, var, val):
-        raise NotImplementedError()
-
-    def as_shell_commands(self):
-        cmds = list()
-        for var, paths in self.vars_to_set.items():
-            cmds.append(self.set_cmd(var, ':'.join(paths)))
-        return cmds
-
-
-class CshShellPathModifications(ShellPathModifications):
-    def set_cmd(self, var, val):
-        return 'setenv {0} {1}'.format(var, val)
-
-
-class BashShellPathModifications(ShellPathModifications):
-    def set_cmd(self, var, val):
-        return 'export {0}={1}'.format(var, val)
-
-
 class EnvironmentModifications(object):
     """Keeps track of requests to modify the current environment.
 
@@ -418,7 +376,7 @@ class EnvironmentModifications(object):
                 x.execute(os.environ)
 
     def shell_modifications(self, shell='sh'):
-        """returns shell code to apply the modifications and clears the list."""
+        """Return shell code to apply the modifications and clears the list."""
         modifications = self.group_by_name()
         new_env = os.environ.copy()
 
@@ -434,7 +392,8 @@ class EnvironmentModifications(object):
                 if new is None:
                     cmds += _shell_unset_strings[shell].format(name)
                 else:
-                    cmds += _shell_set_strings[shell].format(name, new_env[name])
+                    cmds += _shell_set_strings[shell].format(name,
+                                                             new_env[name])
         return cmds
 
     @staticmethod

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -25,6 +25,18 @@ system_dirs = [os.path.join(p, s) for s in suffixes for p in system_paths] + \
     system_paths
 
 
+_shell_set_strings = {
+    'sh': 'export {}={};\n',
+    'csh': 'setenv {} {};\n',
+}
+
+
+_shell__unset_strings = {
+    'sh': 'unset {};\n',
+    'csh': 'unsetenv {};\n',
+}
+
+
 def is_system_path(path):
     """Predicate that given a path returns True if it is a system path,
     False otherwise.
@@ -138,62 +150,62 @@ class NameValueModifier(object):
 
 class SetEnv(NameValueModifier):
 
-    def execute(self):
-        os.environ[self.name] = str(self.value)
+    def execute(self, env):
+        env[self.name] = str(self.value)
 
 
 class AppendFlagsEnv(NameValueModifier):
 
-    def execute(self):
-        if self.name in os.environ and os.environ[self.name]:
-            os.environ[self.name] += self.separator + str(self.value)
+    def execute(self, env):
+        if self.name in env and env[self.name]:
+            env[self.name] += self.separator + str(self.value)
         else:
-            os.environ[self.name] = str(self.value)
+            env[self.name] = str(self.value)
 
 
 class UnsetEnv(NameModifier):
 
-    def execute(self):
+    def execute(self, env):
         # Avoid throwing if the variable was not set
-        os.environ.pop(self.name, None)
+        env.pop(self.name, None)
 
 
 class SetPath(NameValueModifier):
 
-    def execute(self):
+    def execute(self, env):
         string_path = concatenate_paths(self.value, separator=self.separator)
-        os.environ[self.name] = string_path
+        env[self.name] = string_path
 
 
 class AppendPath(NameValueModifier):
 
-    def execute(self):
-        environment_value = os.environ.get(self.name, '')
+    def execute(self, env):
+        environment_value = env.get(self.name, '')
         directories = environment_value.split(
             self.separator) if environment_value else []
         directories.append(os.path.normpath(self.value))
-        os.environ[self.name] = self.separator.join(directories)
+        env[self.name] = self.separator.join(directories)
 
 
 class PrependPath(NameValueModifier):
 
-    def execute(self):
-        environment_value = os.environ.get(self.name, '')
+    def execute(self, env):
+        environment_value = env.get(self.name, '')
         directories = environment_value.split(
             self.separator) if environment_value else []
         directories = [os.path.normpath(self.value)] + directories
-        os.environ[self.name] = self.separator.join(directories)
+        env[self.name] = self.separator.join(directories)
 
 
 class RemovePath(NameValueModifier):
 
-    def execute(self):
-        environment_value = os.environ.get(self.name, '')
+    def execute(self, env):
+        environment_value = env.get(self.name, '')
         directories = environment_value.split(
             self.separator) if environment_value else []
         directories = [os.path.normpath(x) for x in directories
                        if x != os.path.normpath(self.value)]
-        os.environ[self.name] = self.separator.join(directories)
+        env[self.name] = self.separator.join(directories)
 
 
 class ShellPathModifications(object):
@@ -403,7 +415,27 @@ class EnvironmentModifications(object):
         # Apply modifications one variable at a time
         for name, actions in sorted(modifications.items()):
             for x in actions:
-                x.execute()
+                x.execute(os.environ)
+
+    def shell_modifications(self, shell='sh'):
+        """returns shell code to apply the modifications and clears the list."""
+        modifications = self.group_by_name()
+        new_env = os.environ.copy()
+
+        for name, actions in sorted(modifications.items()):
+            for x in actions:
+                x.execute(new_env)
+
+        cmds = ''
+        for name in set(new_env) & set(os.environ):
+            new = new_env.get(name, None)
+            old = os.environ.get(name, None)
+            if new != old:
+                if new is None:
+                    cmds += _shell_unset_strings[shell].format(name)
+                else:
+                    cmds += _shell_set_strings[shell].format(name, new_env[name])
+        return cmds
 
     @staticmethod
     def from_sourcing_file(filename, *args, **kwargs):

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -26,14 +26,14 @@ system_dirs = [os.path.join(p, s) for s in suffixes for p in system_paths] + \
 
 
 _shell_set_strings = {
-    'sh': 'export {}={};\n',
-    'csh': 'setenv {} {};\n',
+    'sh': 'export {0}={1};\n',
+    'csh': 'setenv {0} {1};\n',
 }
 
 
 _shell_unset_strings = {
-    'sh': 'unset {};\n',
-    'csh': 'unsetenv {};\n',
+    'sh': 'unset {0};\n',
+    'csh': 'unsetenv {0};\n',
 }
 
 


### PR DESCRIPTION
This PR updates environments so that by default they are created with views. Currently my goal is to show how it works and get agreement on it. There are still tests etc. which are needed to complete it.

```
spack env create e1 #by default this will maintain a view in the directory Spack maintains for the env
spack env create e1 --with-view=/abs/path/to/anywhere
spack env create e1 --without-view
```

The `manifest.yaml` file now looks like:

```
spack:
  specs:
  - python
  view: true #or false, or a string
```

Existing environments will not automatically maintain views. I propose adding the following command to manipulate whether an env maintains a view (these commands aren't yet available):

~`spack env view --enable #by default create the view`~
~`spack env view --enable /abs/path/to/anywhere`~
~`spack env view --disable`~
~`spack env view --show #show where the view is maintained`~

(EDIT 4/8/19) The commands for managing a view for an environment have been added and have a slightly different syntax:

```
spack env view enable
spack env view envable /abs/path/to/anywhere
spack env view disable
```

Views are automatically updated when specs are installed to an environment. A view only maintains one copy of any package. An environment may refer to a package multiple times, in particular if it appears as a dependency. This PR establishes a prioritization for which environment specs are added to views: a spec has higher priority if it was concretized first. This does not necessarily exactly match the order in which specs were added, for example, given `X->Z` and `Y->Z'`:

```
spack env activate e1
spack add X
spack install Y #immediately concretizes and installs Y and Z'
spack install #concretizes X and Z
```

In this case `Z'` will be favored over `Z`. 

Specs in the environment must be concrete and installed to be added to the view, so there is another minor ordering effect: by default the view maintained for the environment ignores file conflicts between packages. If packages are not installed in order, and there are file conflicts, then the version chosen depends on the order.

Both ordering issues are avoided if `spack install`/`spack add` and `spack install <spec>` are not mixed.

(UPDATE 4/8/19) When activated, if an environment includes a view, this view will be added to `PATH`, `CPATH`, and other shell variables to expose the Spack environment in the user's shell.