### PR TITLE
bzip2: Replace absolute symlink in bin/ with relative ones.

### DIFF
--- a/var/spack/repos/builtin/packages/bzip2/package.py
+++ b/var/spack/repos/builtin/packages/bzip2/package.py
@@ -37,6 +37,13 @@ class Bzip2(Package):
         # bzip2 comes with two separate Makefiles for static and dynamic builds
         # Tell both to use Spack's compiler wrapper instead of GCC
         filter_file(r'^CC=gcc', 'CC={0}'.format(spack_cc), 'Makefile')
+        for f in ["bzegrep", "bzfgrep", "bzcmp", "bzless"]:
+            filter_file(
+                r'^\tln -s -f \$\(PREFIX\)/bin/(.*) \$\(PREFIX\)/bin/%s$'
+                % (f),
+                '\tln -s -f \\1 $(PREFIX)/bin/%s' % (f), 'Makefile'
+            )
+
         filter_file(
             r'^CC=gcc', 'CC={0}'.format(spack_cc), 'Makefile-libbz2_so'
         )


### PR DESCRIPTION
In the /bin directory, bzip2 creates a bunch of symlinks to the bzip2 executable. For 4 of them (bzegrep, bzfgrep, bzcmp and bzless, it creates absolute symlinks instead of relative ones. Which means that when you create a view, the symlink in the view points to the original location of bzip2 instead of the view version of it. 
Would you be open to this patch? 
I'm happy to recode this differently if you have suggestion to make it better.