### PR TITLE
Fix doxygen package

### DIFF
--- a/var/spack/repos/builtin/packages/doxygen/package.py
+++ b/var/spack/repos/builtin/packages/doxygen/package.py
@@ -13,8 +13,8 @@ class Doxygen(CMakePackage):
     Microsoft, and UNO/OpenOffice flavors), Fortran, VHDL, Tcl, and to some
     extent D.."""
 
-    homepage = "http://www.stack.nl/~dimitri/doxygen/"
-    url      = "http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.10.src.tar.gz"
+    homepage = "http://www.doxygen.nl/"
+    url      = "https://sourceforge.net/projects/doxygen/files/rel-1.8.14/doxygen-1.8.14.src.tar.gz/download"
 
     version('1.8.14', '41d8821133e8d8104280030553e2b42b')
     version('1.8.12', '08e0f7850c4d22cb5188da226b209a96')
@@ -27,6 +27,9 @@ class Doxygen(CMakePackage):
 
     depends_on("cmake@2.8.12:", type='build')
     depends_on("flex", type='build')
+    # code.l just checks subminor version <=2.5.4 or >=2.5.33
+    # but does not recognize 2.6.x as newer...could be patched if needed
+    depends_on("flex@2.5.39", type='build', when='@1.8.10')
     depends_on("bison", type='build')
 
     # optional dependencies


### PR DESCRIPTION
URL to source seems to have changed. 

In addition, I added a new dependency on a fixed flex version if an old doxygen version shall be installed. The problem is that the version checker in code.l does only check subminor version but not minor version. Therefore the version checker thinks that flex@2.6.4 ist older than flex@2.5.33 for example. code.l could be patched but I did not think that it would it is worth the effort since it only affects the oldest doxygen version :-)