### PR TITLE
Fix Catch2 Single Header

### DIFF
--- a/var/spack/repos/builtin/packages/catch/package.py
+++ b/var/spack/repos/builtin/packages/catch/package.py
@@ -63,6 +63,9 @@ class Catch(CMakePackage):
     @when('+single_header')
     def install(self, spec, prefix):
         mkdirp(prefix.include)
-        install(join_path('single_include', 'catch.hpp'), prefix.include)
+        if spec.satisfies('@2.3.0:'):
+            install_tree('single_include', prefix.include)
+        else:
+            install(join_path('single_include', 'catch.hpp'), prefix.include)
         # fakes out spack so it installs a module file
         mkdirp(join_path(prefix, 'bin'))


### PR DESCRIPTION
Fix the install of the single header amalgate in catch2.

Thanks for @goxberry for noting the broken build! This PR is a simplified fix for the build issue reported in #9876.

Please be aware that the public API for catch <2.3.0 was `#include <catch.hpp>` which is now for 2.3.0+ `#include <catch2/catch.hpp>`: https://github.com/catchorg/Catch2/releases/tag/v2.3.0