### PR TITLE
remove scotch dependency to flex@2.6.4

### DIFF
--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -34,8 +34,8 @@ class Scotch(Package):
     variant('int64', default=False,
             description='Use int64_t for SCOTCH_Num typedef')
 
-    # Does not build with flex 2.6.[23]
-    depends_on('flex@:2.6.1,2.6.4:', type='build')
+    # Does not build with flex 2.6.[23] and flex 2.6.4 conflicts with gcc@7.2:
+    depends_on('flex@:2.6.1', type='build')
     depends_on('bison', type='build')
     depends_on('mpi', when='+mpi')
     depends_on('zlib', when='+compression')


### PR DESCRIPTION
flex 2.6.4 is not compatible with recent compilers, see conflict gcc@7.2:
This conflict impacts all scotch users which have recent compilers