### PR TITLE
{,py-py}spark: add 2.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyspark/package.py
+++ b/var/spack/repos/builtin/packages/py-pyspark/package.py
@@ -12,7 +12,8 @@ class PyPyspark(PythonPackage):
     homepage = "http://spark.apache.org"
     url      = "https://pypi.org/packages/source/p/pyspark/pyspark-2.3.0.tar.gz"
 
-    version('2.3.0', sha256='0b3536910e154c36a94239f0ba0a201f476aadc72006409e5787198ffd01986e')
+    version('2.4.0', 'c9d7b7c5e91b13488b657e364ff392a80b2e374b182138e5ec8702a1822bffdc')
+    version('2.3.0', '0b3536910e154c36a94239f0ba0a201f476aadc72006409e5787198ffd01986e')
 
     depends_on('py-setuptools', type='build')
-    depends_on('py-py4j', type=('build', 'run'))
+    depends_on('py-py4j@0.10.7', when='@2.3.0:2.4.0', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/spark/package.py
+++ b/var/spack/repos/builtin/packages/spark/package.py
@@ -14,14 +14,14 @@ class Spark(Package):
     """
 
     homepage = "http://spark.apache.org"
-    url = "http://archive.apache.org/dist/spark/spark-2.0.0/spark-2.0.0-bin-without-hadoop.tgz"
 
     variant('hadoop', default=False,
             description='Build with Hadoop')
 
-    depends_on('java', type=('build', 'run'))
+    depends_on('java@8', type=('build', 'run'))
     depends_on('hadoop', when='+hadoop', type=('build', 'run'))
 
+    version('2.4.0', 'b1d6d6cb49d8253b36df8372a722292bb323bd16315d83f0b0bafb66a4154ef2')
     version('2.3.0', 'db21021b8e877b219ab886097ef42344')
     version('2.1.0', '21d4471e78250775b1fa7c0e6c3a1326')
     version('2.0.2', '32110c1bb8f081359738742bd26bced1')
@@ -29,6 +29,16 @@ class Spark(Package):
     version('1.6.2', '304394fbe2899211217f0cd9e9b2b5d9')
     version('1.6.1', 'fcf4961649f15af1fea78c882e65b001')
     version('1.6.0', '2c28edc89ca0067e63e525c04f7b1d89')
+
+    def url_for_version(self, version):
+        url = "http://archive.apache.org/dist/spark/spark-{0}/spark-{0}-bin-{1}.tgz"
+        if self.spec.satisfies('@2.4.0: +hadoop'):
+            checksums = {
+                Version('2.4.0'): 'c93c096c8d64062345b26b34c85127a6848cff95a4bb829333a06b83222a5cfa'
+            }
+            self.versions[version] = {'checksum': checksums[version]}
+            return url.format(version, 'hadoop2.7')
+        return url.format(version, 'without-hadoop')
 
     def install(self, spec, prefix):
 
@@ -54,6 +64,6 @@ class Spark(Package):
 
         # Remove whitespaces, as they can compromise syntax in
         # module files
-        hadoop_classpath = re.sub('[\s+]', '', hadoop_classpath)
+        hadoop_classpath = re.sub(r'[\s+]', '', hadoop_classpath)
 
         run_env.set('SPARK_DIST_CLASSPATH', hadoop_classpath)


### PR DESCRIPTION
This update treats the hadoop variant a little different:

* for older versions: keep the external hadoop dependency
* for newer versions: download a different tarball containing both
                      hadoop and additional JARs

We require the latter, as the tarball including hadoop also provides
hive support specific to Spark. See also #9910.