### PR TITLE
Fftw issue 7372

### DIFF
--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -107,6 +107,14 @@ class Fftw(AutotoolsPackage):
 
         return find_libraries(libraries, root=self.prefix, recursive=True)
 
+    def patch(self):
+        #If fftw/config.h exists in the source tree, it will take precedence 
+        #over the copy in build dir.  As only the latter has proper config 
+        #for our build, this is a problem.  See e.g. issue #7372 on github
+        import os
+        if os.path.isfile('fftw/config.h'):
+            os.rename('fftw/config.h','fftw/config.h.SPACK_RENAMED')
+
     def autoreconf(self, spec, prefix):
         if '+pfft_patches' in spec:
             autoreconf = which('autoreconf')
@@ -147,12 +155,6 @@ class Fftw(AutotoolsPackage):
                 opts += self.enable_or_disable('fma')
 
         configure = Executable('../configure')
-        #If fftw/config.h exists in the source tree, it will take precedence over
-        #the copy in build dir.  As only the latter has proper config for our build,
-        #this is a problem.  See e.g. issue #7372 on github
-        import os
-        if os.path.isfile('fftw/config.h'):
-             os.rename('fftw/config.h','fftw/config.h.SPACK_RENAMED')
 
         # Build double/float/long double/quad variants
         if '+double' in spec:

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -147,6 +147,12 @@ class Fftw(AutotoolsPackage):
                 opts += self.enable_or_disable('fma')
 
         configure = Executable('../configure')
+        #If fftw/config.h exists in the source tree, it will take precedence over
+        #the copy in build dir.  As only the latter has proper config for our build,
+        #this is a problem.  See e.g. issue #7372 on github
+        import os
+        if os.path.isfile('fftw/config.h'):
+             os.rename('fftw/config.h','fftw/config.h.SPACK_RENAMED')
 
         # Build double/float/long double/quad variants
         if '+double' in spec:

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -169,10 +169,10 @@ class Fftw(AutotoolsPackage):
         if '+float' in spec:
             with working_dir('float'):
                 make()
-        if '+long_double' in spec:
+        if spec.satisfies('@3:+long_double'):
             with working_dir('long-double'):
                 make()
-        if '+quad' in spec:
+        if spec.satisfies('@3:+quad'):
             with working_dir('quad'):
                 make()
 
@@ -184,10 +184,10 @@ class Fftw(AutotoolsPackage):
         if '+float' in spec:
             with working_dir('float'):
                 make("check")
-        if '+long_double' in spec:
+        if spec.satisfies('@3:+long_double'):
             with working_dir('long-double'):
                 make("check")
-        if '+quad' in spec:
+        if spec.satisfies('@3:+quad'):
             with working_dir('quad'):
                 make("check")
 
@@ -198,9 +198,9 @@ class Fftw(AutotoolsPackage):
         if '+float' in spec:
             with working_dir('float'):
                 make("install")
-        if '+long_double' in spec:
+        if spec.satisfies('@3:+long_double'):
             with working_dir('long-double'):
                 make("install")
-        if '+quad' in spec:
+        if spec.satisfies('@3:+quad'):
             with working_dir('quad'):
                 make("install")

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -108,12 +108,12 @@ class Fftw(AutotoolsPackage):
         return find_libraries(libraries, root=self.prefix, recursive=True)
 
     def patch(self):
-        #If fftw/config.h exists in the source tree, it will take precedence 
-        #over the copy in build dir.  As only the latter has proper config 
+        #If fftw/config.h exists in the source tree, it will take precedence
+        #over the copy in build dir.  As only the latter has proper config
         #for our build, this is a problem.  See e.g. issue #7372 on github
         import os
         if os.path.isfile('fftw/config.h'):
-            os.rename('fftw/config.h','fftw/config.h.SPACK_RENAMED')
+            os.rename('fftw/config.h', 'fftw/config.h.SPACK_RENAMED')
 
     def autoreconf(self, spec, prefix):
         if '+pfft_patches' in spec:

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -108,9 +108,9 @@ class Fftw(AutotoolsPackage):
         return find_libraries(libraries, root=self.prefix, recursive=True)
 
     def patch(self):
-        #If fftw/config.h exists in the source tree, it will take precedence
-        #over the copy in build dir.  As only the latter has proper config
-        #for our build, this is a problem.  See e.g. issue #7372 on github
+        # If fftw/config.h exists in the source tree, it will take precedence
+        # over the copy in build dir.  As only the latter has proper config
+        # for our build, this is a problem.  See e.g. issue #7372 on github
         import os
         if os.path.isfile('fftw/config.h'):
             os.rename('fftw/config.h', 'fftw/config.h.SPACK_RENAMED')


### PR DESCRIPTION
This is to address https://github.com/spack/spack/issues/7372

Basically, fftw 2.1.5 ships with a config.h in source tree with all options commented out.  The #includes in other source files will pick up this incorrect config.h instead of the one in the build directory and therefore have bad defines.  In particular, F77_FUNC_ does not get defined, causing the bulk of fftwf77.c to be skipped due to an #ifdef so functions are missing in libdfftw.so

To fix, the configure method now renames fftw/config.h in source tree if it is found.

Also encountered some errors due to inconsistent handling of quad/long-double variant flags between configure and the build, check, and install methods.  Made consistent.