### PR TITLE
bugfix: multimethod inheritance

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3528,7 +3528,6 @@ class SpecParser(spack.parse.Parser):
             self.check_identifier(spec_name)
 
         if self._initial is None:
-            # This will init the spec without calling Spec.__init__
             spec = Spec()
         else:
             # this is used by Spec.__init__

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -889,187 +889,70 @@ class Spec(object):
     #: Cache for spec's prefix, computed lazily in the corresponding property
     _prefix = None
 
-    @staticmethod
-    def from_literal(spec_dict, normal=True):
-        """Builds a Spec from a dictionary containing the spec literal.
+    def __init__(self, spec_like=None,
+                 normal=False, concrete=False, external_path=None,
+                 external_module=None, full_hash=None):
+        """Create a new Spec.
 
-        The dictionary must have a single top level key, representing the root,
-        and as many secondary level keys as needed in the spec.
+        Arguments:
+            spec_like (optional string): if not provided, we initialize
+                an anonymous Spec that matches any Spec object; if
+                provided we parse this as a Spec string.
 
-        The keys can be either a string or a Spec or a tuple containing the
-        Spec and the dependency types.
-
-        Args:
-            spec_dict (dict): the dictionary containing the spec literal
-            normal (bool): if True the same key appearing at different levels
-                of the ``spec_dict`` will map to the same object in memory.
-
-        Examples:
-            A simple spec ``foo`` with no dependencies:
-
-            .. code-block:: python
-
-                {'foo': None}
-
-            A spec ``foo`` with a ``(build, link)`` dependency ``bar``:
-
-            .. code-block:: python
-
-                {'foo':
-                    {'bar:build,link': None}}
-
-            A spec with a diamond dependency and various build types:
-
-            .. code-block:: python
-
-                {'dt-diamond': {
-                    'dt-diamond-left:build,link': {
-                        'dt-diamond-bottom:build': None
-                    },
-                    'dt-diamond-right:build,link': {
-                        'dt-diamond-bottom:build,link,run': None
-                    }
-                }}
-
-            The same spec with a double copy of ``dt-diamond-bottom`` and
-            no diamond structure:
-
-            .. code-block:: python
-
-                {'dt-diamond': {
-                    'dt-diamond-left:build,link': {
-                        'dt-diamond-bottom:build': None
-                    },
-                    'dt-diamond-right:build,link': {
-                        'dt-diamond-bottom:build,link,run': None
-                    }
-                }, normal=False}
-
-            Constructing a spec using a Spec object as key:
-
-            .. code-block:: python
-
-                mpich = Spec('mpich')
-                libelf = Spec('libelf@1.8.11')
-                expected_normalized = Spec.from_literal({
-                    'mpileaks': {
-                        'callpath': {
-                            'dyninst': {
-                                'libdwarf': {libelf: None},
-                                libelf: None
-                            },
-                            mpich: None
-                        },
-                        mpich: None
-                    },
-                })
+        Keyword arguments:
+        # assign special fields from constructor
+        self._normal = normal
+        self._concrete = concrete
+        self.external_path = external_path
+        self.external_module = external_module
+        self._full_hash = full_hash
 
         """
 
-        # Maps a literal to a Spec, to be sure we are reusing the same object
-        spec_cache = LazySpecCache()
-
-        def spec_builder(d):
-            # The invariant is that the top level dictionary must have
-            # only one key
-            assert len(d) == 1
-
-            # Construct the top-level spec
-            spec_like, dep_like = next(iter(d.items()))
-
-            # If the requirements was for unique nodes (default)
-            # then re-use keys from the local cache. Otherwise build
-            # a new node every time.
-            if not isinstance(spec_like, Spec):
-                spec = spec_cache[spec_like] if normal else Spec(spec_like)
-            else:
-                spec = spec_like
-
-            if dep_like is None:
-                return spec
-
-            def name_and_dependency_types(s):
-                """Given a key in the dictionary containing the literal,
-                extracts the name of the spec and its dependency types.
-
-                Args:
-                    s (str): key in the dictionary containing the literal
-
-                """
-                t = s.split(':')
-
-                if len(t) > 2:
-                    msg = 'more than one ":" separator in key "{0}"'
-                    raise KeyError(msg.format(s))
-
-                n = t[0]
-                if len(t) == 2:
-                    dtypes = tuple(dt.strip() for dt in t[1].split(','))
-                else:
-                    dtypes = ()
-
-                return n, dtypes
-
-            def spec_and_dependency_types(s):
-                """Given a non-string key in the literal, extracts the spec
-                and its dependency types.
-
-                Args:
-                    s (spec or tuple): either a Spec object or a tuple
-                        composed of a Spec object and a string with the
-                        dependency types
-
-                """
-                if isinstance(s, Spec):
-                    return s, ()
-
-                spec_obj, dtypes = s
-                return spec_obj, tuple(dt.strip() for dt in dtypes.split(','))
-
-            # Recurse on dependencies
-            for s, s_dependencies in dep_like.items():
-
-                if isinstance(s, string_types):
-                    dag_node, dependency_types = name_and_dependency_types(s)
-                else:
-                    dag_node, dependency_types = spec_and_dependency_types(s)
-
-                dependency_spec = spec_builder({dag_node: s_dependencies})
-                spec._add_dependency(dependency_spec, dependency_types)
-
-            return spec
-
-        return spec_builder(spec_dict)
-
-    def __init__(self, spec_like, **kwargs):
         # Copy if spec_like is a Spec.
         if isinstance(spec_like, Spec):
             self._dup(spec_like)
             return
 
-        # Parse if the spec_like is a string.
-        if not isinstance(spec_like, string_types):
+        # init an empty spec that matches anything.
+        self.name = None
+        self.versions = VersionList(':')
+        self.variants = VariantMap(self)
+        self.architecture = None
+        self.compiler = None
+        self.external_path = None
+        self.external_module = None
+        self.compiler_flags = FlagMap(self)
+        self._dependents = DependencyMap()
+        self._dependencies = DependencyMap()
+        self.namespace = None
+
+        self._hash = None
+        self._cmp_key_cache = None
+        self._package = None
+
+        # Most of these are internal implementation details that can be
+        # set by internal Spack calls in the constructor.
+        #
+        # For example, Specs are by default not assumed to be normal, but
+        # in some cases we've read them from a file want to assume
+        # normal.  This allows us to manipulate specs that Spack doesn't
+        # have package.py files for.
+        self._normal = normal
+        self._concrete = concrete
+        self.external_path = external_path
+        self.external_module = external_module
+        self._full_hash = full_hash
+
+        if isinstance(spec_like, string_types):
+            spec_list = SpecParser(self).parse(spec_like)
+            if len(spec_list) > 1:
+                raise ValueError("More than one spec in string: " + spec_like)
+            if len(spec_list) < 1:
+                raise ValueError("String contains no specs: " + spec_like)
+
+        elif spec_like is not None:
             raise TypeError("Can't make spec out of %s" % type(spec_like))
-
-        # parse string types *into* this spec
-        spec_list = SpecParser(self).parse(spec_like)
-        if len(spec_list) > 1:
-            raise ValueError("More than one spec in string: " + spec_like)
-        if len(spec_list) < 1:
-            raise ValueError("String contains no specs: " + spec_like)
-
-        # Specs are by default not assumed to be normal, but in some
-        # cases we've read them from a file want to assume normal.
-        # This allows us to manipulate specs that Spack doesn't have
-        # package.py files for.
-        self._normal = kwargs.get('normal', False)
-        self._concrete = kwargs.get('concrete', False)
-
-        # Allow a spec to be constructed with an external path.
-        self.external_path = kwargs.get('external_path', None)
-        self.external_module = kwargs.get('external_module', None)
-
-        self._full_hash = kwargs.get('full_hash', None)
 
     @property
     def external(self):
@@ -1609,6 +1492,158 @@ class Spec(object):
                 raise SpecError("Couldn't parse dependency types in spec.")
 
             yield dep_name, dag_hash, list(deptypes)
+
+    @staticmethod
+    def from_literal(spec_dict, normal=True):
+        """Builds a Spec from a dictionary containing the spec literal.
+
+        The dictionary must have a single top level key, representing the root,
+        and as many secondary level keys as needed in the spec.
+
+        The keys can be either a string or a Spec or a tuple containing the
+        Spec and the dependency types.
+
+        Args:
+            spec_dict (dict): the dictionary containing the spec literal
+            normal (bool): if True the same key appearing at different levels
+                of the ``spec_dict`` will map to the same object in memory.
+
+        Examples:
+            A simple spec ``foo`` with no dependencies:
+
+            .. code-block:: python
+
+                {'foo': None}
+
+            A spec ``foo`` with a ``(build, link)`` dependency ``bar``:
+
+            .. code-block:: python
+
+                {'foo':
+                    {'bar:build,link': None}}
+
+            A spec with a diamond dependency and various build types:
+
+            .. code-block:: python
+
+                {'dt-diamond': {
+                    'dt-diamond-left:build,link': {
+                        'dt-diamond-bottom:build': None
+                    },
+                    'dt-diamond-right:build,link': {
+                        'dt-diamond-bottom:build,link,run': None
+                    }
+                }}
+
+            The same spec with a double copy of ``dt-diamond-bottom`` and
+            no diamond structure:
+
+            .. code-block:: python
+
+                {'dt-diamond': {
+                    'dt-diamond-left:build,link': {
+                        'dt-diamond-bottom:build': None
+                    },
+                    'dt-diamond-right:build,link': {
+                        'dt-diamond-bottom:build,link,run': None
+                    }
+                }, normal=False}
+
+            Constructing a spec using a Spec object as key:
+
+            .. code-block:: python
+
+                mpich = Spec('mpich')
+                libelf = Spec('libelf@1.8.11')
+                expected_normalized = Spec.from_literal({
+                    'mpileaks': {
+                        'callpath': {
+                            'dyninst': {
+                                'libdwarf': {libelf: None},
+                                libelf: None
+                            },
+                            mpich: None
+                        },
+                        mpich: None
+                    },
+                })
+
+        """
+
+        # Maps a literal to a Spec, to be sure we are reusing the same object
+        spec_cache = LazySpecCache()
+
+        def spec_builder(d):
+            # The invariant is that the top level dictionary must have
+            # only one key
+            assert len(d) == 1
+
+            # Construct the top-level spec
+            spec_like, dep_like = next(iter(d.items()))
+
+            # If the requirements was for unique nodes (default)
+            # then re-use keys from the local cache. Otherwise build
+            # a new node every time.
+            if not isinstance(spec_like, Spec):
+                spec = spec_cache[spec_like] if normal else Spec(spec_like)
+            else:
+                spec = spec_like
+
+            if dep_like is None:
+                return spec
+
+            def name_and_dependency_types(s):
+                """Given a key in the dictionary containing the literal,
+                extracts the name of the spec and its dependency types.
+
+                Args:
+                    s (str): key in the dictionary containing the literal
+
+                """
+                t = s.split(':')
+
+                if len(t) > 2:
+                    msg = 'more than one ":" separator in key "{0}"'
+                    raise KeyError(msg.format(s))
+
+                n = t[0]
+                if len(t) == 2:
+                    dtypes = tuple(dt.strip() for dt in t[1].split(','))
+                else:
+                    dtypes = ()
+
+                return n, dtypes
+
+            def spec_and_dependency_types(s):
+                """Given a non-string key in the literal, extracts the spec
+                and its dependency types.
+
+                Args:
+                    s (spec or tuple): either a Spec object or a tuple
+                        composed of a Spec object and a string with the
+                        dependency types
+
+                """
+                if isinstance(s, Spec):
+                    return s, ()
+
+                spec_obj, dtypes = s
+                return spec_obj, tuple(dt.strip() for dt in dtypes.split(','))
+
+            # Recurse on dependencies
+            for s, s_dependencies in dep_like.items():
+
+                if isinstance(s, string_types):
+                    dag_node, dependency_types = name_and_dependency_types(s)
+                else:
+                    dag_node, dependency_types = spec_and_dependency_types(s)
+
+                dependency_spec = spec_builder({dag_node: s_dependencies})
+                spec._add_dependency(dependency_spec, dependency_types)
+
+            return spec
+
+        return spec_builder(spec_dict)
 
     @staticmethod
     def from_dict(data):
@@ -3484,52 +3519,31 @@ class SpecParser(spack.parse.Parser):
     def spec(self, name):
         """Parse a spec out of the input. If a spec is supplied, initialize
            and return it instead of creating a new one."""
+        spec_namespace = None
+        spec_name = None
         if name:
             spec_namespace, dot, spec_name = name.rpartition('.')
             if not spec_namespace:
                 spec_namespace = None
             self.check_identifier(spec_name)
-        else:
-            spec_namespace = None
-            spec_name = None
 
         if self._initial is None:
             # This will init the spec without calling Spec.__init__
-            spec = Spec.__new__(Spec)
+            spec = Spec()
         else:
             # this is used by Spec.__init__
             spec = self._initial
             self._initial = None
 
-        spec.name = spec_name
-        spec.versions = VersionList()
-        spec.variants = VariantMap(spec)
-        spec.architecture = None
-        spec.compiler = None
-        spec.external_path = None
-        spec.external_module = None
-        spec.compiler_flags = FlagMap(spec)
-        spec._dependents = DependencyMap()
-        spec._dependencies = DependencyMap()
         spec.namespace = spec_namespace
-        spec._hash = None
-        spec._cmp_key_cache = None
-
-        spec._package = None
-        spec._normal = False
-        spec._concrete = False
-        spec._full_hash = None
-
-        # record this so that we know whether version is
-        # unspecified or not.
-        added_version = False
+        spec.name = spec_name
 
         while self.next:
             if self.accept(AT):
                 vlist = self.version_list()
+                spec.versions = VersionList()
                 for version in vlist:
                     spec._add_version(version)
-                added_version = True
 
             elif self.accept(ON):
                 name = self.variant()
@@ -3567,10 +3581,6 @@ class SpecParser(spack.parse.Parser):
 
             else:
                 break
-
-        # If there was no version in the spec, consier it an open range
-        if not added_version and not spec._hash:
-            spec.versions = VersionList(':')
 
         return spec
 

--- a/lib/spack/spack/test/multimethod.py
+++ b/lib/spack/spack/test/multimethod.py
@@ -158,3 +158,9 @@ def test_multimethod_diamond_inheritance():
 
     pkg = spack.repo.get('multimethod-diamond@4.0')
     assert pkg.diamond_inheritance() == 'subclass'
+
+
+def test_multimethod_boolean(pkg_name):
+    pkg = spack.repo.get(pkg_name)
+    assert pkg.boolean_true_first() == 'True'
+    assert pkg.boolean_false_first() == 'True'

--- a/lib/spack/spack/test/multimethod.py
+++ b/lib/spack/spack/test/multimethod.py
@@ -107,3 +107,7 @@ def test_multimethod_with_base_class(mock_packages):
 
     pkg = spack.repo.get('multimethod@1')
     assert pkg.base_method() == "base_method"
+
+def test_multimethod_inheritance(mock_packages):
+    pkg = spack.repo.get('multimethod-inheritor@1.0')
+    assert pkg.no_version_2() == 1

--- a/lib/spack/spack/test/multimethod.py
+++ b/lib/spack/spack/test/multimethod.py
@@ -117,7 +117,44 @@ def test_virtual_dep_match(pkg_name):
 
 def test_multimethod_with_base_class(pkg_name):
     pkg = spack.repo.get(pkg_name + '@3')
-    assert pkg.base_method() == "subclass_method"
+    assert pkg.base_method() == pkg.spec.name
 
     pkg = spack.repo.get(pkg_name + '@1')
     assert pkg.base_method() == "base_method"
+
+
+def test_multimethod_inherited_and_overridden():
+    pkg = spack.repo.get('multimethod-inheritor@1.0')
+    assert pkg.inherited_and_overridden() == 'inheritor@1.0'
+
+    pkg = spack.repo.get('multimethod-inheritor@2.0')
+    assert pkg.inherited_and_overridden() == 'base@2.0'
+
+    pkg = spack.repo.get('multimethod@1.0')
+    assert pkg.inherited_and_overridden() == 'base@1.0'
+
+    pkg = spack.repo.get('multimethod@2.0')
+    assert pkg.inherited_and_overridden() == 'base@2.0'
+
+
+def test_multimethod_diamond_inheritance():
+    pkg = spack.repo.get('multimethod-diamond@1.0')
+    assert pkg.diamond_inheritance() == 'base_package'
+
+    pkg = spack.repo.get('multimethod-base@1.0')
+    assert pkg.diamond_inheritance() == 'base_package'
+
+    pkg = spack.repo.get('multimethod-diamond@2.0')
+    assert pkg.diamond_inheritance() == 'first_parent'
+
+    pkg = spack.repo.get('multimethod-inheritor@2.0')
+    assert pkg.diamond_inheritance() == 'first_parent'
+
+    pkg = spack.repo.get('multimethod-diamond@3.0')
+    assert pkg.diamond_inheritance() == 'second_parent'
+
+    pkg = spack.repo.get('multimethod-diamond-parent@3.0')
+    assert pkg.diamond_inheritance() == 'second_parent'
+
+    pkg = spack.repo.get('multimethod-diamond@4.0')
+    assert pkg.diamond_inheritance() == 'subclass'

--- a/lib/spack/spack/test/multimethod.py
+++ b/lib/spack/spack/test/multimethod.py
@@ -10,69 +10,83 @@ import spack.repo
 from spack.multimethod import NoSuchMethodError
 
 
-def test_no_version_match(mock_packages):
-    pkg = spack.repo.get('multimethod@2.0')
+pytestmark = pytest.mark.usefixtures('mock_packages')
+
+
+@pytest.fixture(scope='module',
+                params=['multimethod', 'multimethod-inheritor'])
+def pkg_name(request):
+    """Make tests run on both multimethod and multimethod-inheritor.
+
+    This means we test all of our @when methods on a class that uses them
+    directly, AND on a class that inherits them.
+    """
+    return request.param
+
+
+def test_no_version_match(pkg_name):
+    pkg = spack.repo.get(pkg_name + '@2.0')
     with pytest.raises(NoSuchMethodError):
         pkg.no_version_2()
 
 
-def test_one_version_match(mock_packages):
-    pkg = spack.repo.get('multimethod@1.0')
+def test_one_version_match(pkg_name):
+    pkg = spack.repo.get(pkg_name + '@1.0')
     assert pkg.no_version_2() == 1
 
-    pkg = spack.repo.get('multimethod@3.0')
+    pkg = spack.repo.get(pkg_name + '@3.0')
     assert pkg.no_version_2() == 3
 
-    pkg = spack.repo.get('multimethod@4.0')
+    pkg = spack.repo.get(pkg_name + '@4.0')
     assert pkg.no_version_2() == 4
 
 
-def test_version_overlap(mock_packages):
-    pkg = spack.repo.get('multimethod@2.0')
+def test_version_overlap(pkg_name):
+    pkg = spack.repo.get(pkg_name + '@2.0')
     assert pkg.version_overlap() == 1
 
-    pkg = spack.repo.get('multimethod@5.0')
+    pkg = spack.repo.get(pkg_name + '@5.0')
     assert pkg.version_overlap() == 2
 
 
-def test_mpi_version(mock_packages):
-    pkg = spack.repo.get('multimethod^mpich@3.0.4')
+def test_mpi_version(pkg_name):
+    pkg = spack.repo.get(pkg_name + '^mpich@3.0.4')
     assert pkg.mpi_version() == 3
 
-    pkg = spack.repo.get('multimethod^mpich2@1.2')
+    pkg = spack.repo.get(pkg_name + '^mpich2@1.2')
     assert pkg.mpi_version() == 2
 
-    pkg = spack.repo.get('multimethod^mpich@1.0')
+    pkg = spack.repo.get(pkg_name + '^mpich@1.0')
     assert pkg.mpi_version() == 1
 
 
-def test_undefined_mpi_version(mock_packages):
-    pkg = spack.repo.get('multimethod^mpich@0.4')
+def test_undefined_mpi_version(pkg_name):
+    pkg = spack.repo.get(pkg_name + '^mpich@0.4')
     assert pkg.mpi_version() == 1
 
-    pkg = spack.repo.get('multimethod^mpich@1.4')
+    pkg = spack.repo.get(pkg_name + '^mpich@1.4')
     assert pkg.mpi_version() == 1
 
 
-def test_default_works(mock_packages):
-    pkg = spack.repo.get('multimethod%gcc')
+def test_default_works(pkg_name):
+    pkg = spack.repo.get(pkg_name + '%gcc')
     assert pkg.has_a_default() == 'gcc'
 
-    pkg = spack.repo.get('multimethod%intel')
+    pkg = spack.repo.get(pkg_name + '%intel')
     assert pkg.has_a_default() == 'intel'
 
-    pkg = spack.repo.get('multimethod%pgi')
+    pkg = spack.repo.get(pkg_name + '%pgi')
     assert pkg.has_a_default() == 'default'
 
 
-def test_target_match(mock_packages):
+def test_target_match(pkg_name):
     platform = spack.architecture.platform()
     targets = list(platform.targets.values())
     for target in targets[:-1]:
-        pkg = spack.repo.get('multimethod target=' + target.name)
+        pkg = spack.repo.get(pkg_name + ' target=' + target.name)
         assert pkg.different_by_target() == target.name
 
-    pkg = spack.repo.get('multimethod target=' + targets[-1].name)
+    pkg = spack.repo.get(pkg_name + ' target=' + targets[-1].name)
     if len(targets) == 1:
         assert pkg.different_by_target() == targets[-1].name
     else:
@@ -80,34 +94,30 @@ def test_target_match(mock_packages):
             pkg.different_by_target()
 
 
-def test_dependency_match(mock_packages):
-    pkg = spack.repo.get('multimethod^zmpi')
+def test_dependency_match(pkg_name):
+    pkg = spack.repo.get(pkg_name + '^zmpi')
     assert pkg.different_by_dep() == 'zmpi'
 
-    pkg = spack.repo.get('multimethod^mpich')
+    pkg = spack.repo.get(pkg_name + '^mpich')
     assert pkg.different_by_dep() == 'mpich'
 
     # If we try to switch on some entirely different dep, it's ambiguous,
     # but should take the first option
-    pkg = spack.repo.get('multimethod^foobar')
+    pkg = spack.repo.get(pkg_name + '^foobar')
     assert pkg.different_by_dep() == 'mpich'
 
 
-def test_virtual_dep_match(mock_packages):
-    pkg = spack.repo.get('multimethod^mpich2')
+def test_virtual_dep_match(pkg_name):
+    pkg = spack.repo.get(pkg_name + '^mpich2')
     assert pkg.different_by_virtual_dep() == 2
 
-    pkg = spack.repo.get('multimethod^mpich@1.0')
+    pkg = spack.repo.get(pkg_name + '^mpich@1.0')
     assert pkg.different_by_virtual_dep() == 1
 
 
-def test_multimethod_with_base_class(mock_packages):
-    pkg = spack.repo.get('multimethod@3')
+def test_multimethod_with_base_class(pkg_name):
+    pkg = spack.repo.get(pkg_name + '@3')
     assert pkg.base_method() == "subclass_method"
 
-    pkg = spack.repo.get('multimethod@1')
+    pkg = spack.repo.get(pkg_name + '@1')
     assert pkg.base_method() == "base_method"
-
-def test_multimethod_inheritance(mock_packages):
-    pkg = spack.repo.get('multimethod-inheritor@1.0')
-    assert pkg.no_version_2() == 1

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -14,7 +14,7 @@ from spack.variant import MultipleValuesInExclusiveVariantError
 
 def target_factory(spec_string, target_concrete):
     spec = Spec(spec_string) if spec_string else Spec()
-    print spec, spec_string, "AAAAA"
+
     if target_concrete:
         spec._mark_concrete()
         substitute_abstract_variants(spec)
@@ -27,18 +27,15 @@ def argument_factory(argument_spec, left):
         # If it's not anonymous, allow it
         right = target_factory(argument_spec, False)
     except Exception:
-        print "HAHA"
         right = parse_anonymous_spec(argument_spec, left.name)
     return right
 
 
 def check_satisfies(target_spec, argument_spec, target_concrete=False):
-    
+
     left = target_factory(target_spec, target_concrete)
     right = argument_factory(argument_spec, left)
 
-    print left, 'left', left.name
-    print right, right.name
     # Satisfies is one-directional.
     assert left.satisfies(right)
     if argument_spec:

--- a/var/spack/repos/builtin.mock/packages/multimethod-base/package.py
+++ b/var/spack/repos/builtin.mock/packages/multimethod-base/package.py
@@ -19,3 +19,6 @@ class MultimethodBase(Package):
 
     def base_method(self):
         return "base_method"
+
+    def diamond_inheritance(self):
+        return "base_package"

--- a/var/spack/repos/builtin.mock/packages/multimethod-diamond-parent/package.py
+++ b/var/spack/repos/builtin.mock/packages/multimethod-diamond-parent/package.py
@@ -18,4 +18,4 @@ class MultimethodDiamondParent(MultimethodBase):
 
     @when('@4.0, 2.0')
     def diamond_inheritance(self):
-        return "should never be reached"
+        return "should never be reached by diamond inheritance test"

--- a/var/spack/repos/builtin.mock/packages/multimethod-diamond-parent/package.py
+++ b/var/spack/repos/builtin.mock/packages/multimethod-diamond-parent/package.py
@@ -3,22 +3,19 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.pkg.builtin.mock.multimethod import Multimethod
+from spack.pkg.builtin.mock.multimethod_base import MultimethodBase
 
 
-class MultimethodInheritor(Multimethod):
+class MultimethodDiamondParent(MultimethodBase):
     """This package is designed for use with Spack's multimethod test.
        It has a bunch of test cases for the @when decorator that the
        test uses.
     """
 
-    @when('@1.0')
-    def inherited_and_overridden(self):
-        return "inheritor@1.0"
+    @when('@3.0')
+    def diamond_inheritance(self):
+        return "second_parent"
 
-    #
-    # Test multi-level inheritance
-    #
-    @when('@2:')
-    def base_method(self):
-        return 'multimethod-inheritor'
+    @when('@4.0, 2.0')
+    def diamond_inheritance(self):
+        return "should never be reached"

--- a/var/spack/repos/builtin.mock/packages/multimethod-diamond/package.py
+++ b/var/spack/repos/builtin.mock/packages/multimethod-diamond/package.py
@@ -3,22 +3,16 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.pkg.builtin.mock.multimethod import Multimethod
+import spack.pkg.builtin.mock.multimethod_inheritor as mi
+import spack.pkg.builtin.mock.multimethod_diamond_parent as mp
 
 
-class MultimethodInheritor(Multimethod):
+class MultimethodDiamond(mi.MultimethodInheritor, mp.MultimethodDiamondParent):
     """This package is designed for use with Spack's multimethod test.
        It has a bunch of test cases for the @when decorator that the
        test uses.
     """
 
-    @when('@1.0')
-    def inherited_and_overridden(self):
-        return "inheritor@1.0"
-
-    #
-    # Test multi-level inheritance
-    #
-    @when('@2:')
-    def base_method(self):
-        return 'multimethod-inheritor'
+    @when('@4.0')
+    def diamond_inheritance(self):
+        return 'subclass'

--- a/var/spack/repos/builtin.mock/packages/multimethod-inheritor/package.py
+++ b/var/spack/repos/builtin.mock/packages/multimethod-inheritor/package.py
@@ -1,0 +1,13 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.pkg.builtin.mock.multimethod import Multimethod
+
+
+class MultimethodInheritor(Multimethod):
+    """This package is designed for use with Spack's multimethod test.
+       It has a bunch of test cases for the @when decorator that the
+       test uses.
+    """

--- a/var/spack/repos/builtin.mock/packages/multimethod/package.py
+++ b/var/spack/repos/builtin.mock/packages/multimethod/package.py
@@ -148,4 +148,23 @@ class Multimethod(MultimethodBase):
 
     @when('@4.0')
     def diamond_inheritance(self):
-        return "should_not_be_reached"
+        return "should_not_be_reached by diamond inheritance test"
+
+    #
+    # Check that multimethods work with boolean values
+    #
+    @when(True)
+    def boolean_true_first(self):
+        return 'True'
+
+    @when(False)
+    def boolean_true_first(self):
+        return 'False'
+
+    @when(False)
+    def boolean_false_first(self):
+        return 'False'
+
+    @when(True)
+    def boolean_false_first(self):
+        return 'True'

--- a/var/spack/repos/builtin.mock/packages/multimethod/package.py
+++ b/var/spack/repos/builtin.mock/packages/multimethod/package.py
@@ -21,7 +21,7 @@ class Multimethod(MultimethodBase):
     url      = 'http://www.example.com/example-1.0.tar.gz'
 
     #
-    # These functions are only valid for versions 1, 2, and 3.
+    # These functions are only valid for versions 1, 3, and 4.
     #
     @when('@1.0')
     def no_version_2(self):

--- a/var/spack/repos/builtin.mock/packages/multimethod/package.py
+++ b/var/spack/repos/builtin.mock/packages/multimethod/package.py
@@ -124,4 +124,28 @@ class Multimethod(MultimethodBase):
     #
     @when("@2:")
     def base_method(self):
-        return "subclass_method"
+        return 'multimethod'
+
+    #
+    # Make sure methods with non-default implementations in a superclass
+    # will invoke those methods when none in the subclass match but one in
+    # the superclass does.
+    #
+    @when("@1.0")
+    def inherited_and_overridden(self):
+        return "base@1.0"
+
+    @when("@2.0")
+    def inherited_and_overridden(self):
+        return "base@2.0"
+
+    #
+    # Make sure that multimethods follow MRO properly with diamond inheritance
+    #
+    @when('@2.0')
+    def diamond_inheritance(self):
+        return 'first_parent'
+
+    @when('@4.0')
+    def diamond_inheritance(self):
+        return "should_not_be_reached"

--- a/var/spack/repos/builtin/packages/zlib/package.py
+++ b/var/spack/repos/builtin/packages/zlib/package.py
@@ -31,6 +31,10 @@ class Zlib(Package):
 
     patch('w_patch.patch', when="@1.2.11%cce")
 
+    @when('%pgi')
+    def patch(self):
+        print "patching"
+
     @property
     def libs(self):
         shared = '+shared' in self.spec

--- a/var/spack/repos/builtin/packages/zlib/package.py
+++ b/var/spack/repos/builtin/packages/zlib/package.py
@@ -31,10 +31,6 @@ class Zlib(Package):
 
     patch('w_patch.patch', when="@1.2.11%cce")
 
-    @when('%pgi')
-    def patch(self):
-        print "patching"
-
     @property
     def libs(self):
         shared = '+shared' in self.spec


### PR DESCRIPTION
Multimethods (using the `@when` decorator) previously did not work with package inheritance.

If package `foo` extended package `bar` and `bar` used multimethods, `spack install foo` would enter an infinite recursion and hit python's maximum recursion depth.

This was due to our reliance on the `super` method to recurse up the method resolution order. The `super` builtin ~uses~ returns a proxy object that delegates method lookup to the superclass but does not change the bound object of methods of the proxy object. This lead to a recursion error when searching for possible matches for a multimethod.

This PR changes the search algorithm for multimethods to use `inspect.getmro()` to search the MRO DAG for the class and uses an iterative instead of recursive algorithm to ensure we follow MRO properly when looking for matching specs in multimethods.

This also includes some refactoring of the Spec object that @tgamblin found convenient to do at the same time. It removes the `parse_anonymous_spec` call from multimethod.py, relying on the newer anonymous spec feature.