### PR TITLE
Spades: Add version 3.13.0

### DIFF
--- a/var/spack/repos/builtin/packages/spades/package.py
+++ b/var/spack/repos/builtin/packages/spades/package.py
@@ -13,6 +13,7 @@ class Spades(CMakePackage):
     homepage = "http://cab.spbu.ru/software/spades/"
     url      = "http://cab.spbu.ru/files/release3.10.1/SPAdes-3.10.1.tar.gz"
 
+    version('3.13.0', git='https://github.com/ablab/spades.git', tag='v3.13.0')
     version('3.12.0', '15b48a3bcbbe6a8ad58fd04ba5d3f1015990fbfd9bdf4913042803b171853ac7')
     version('3.11.1', '478677b560e2f98db025e8efd5245cdf')
     version('3.10.1', 'dcab7d145af81b59cc867562f27536c3')
@@ -26,4 +27,9 @@ class Spades(CMakePackage):
 
     conflicts('%gcc@7.1.0:', when='@:3.10.1')
 
-    root_cmakelists_dir = 'src'
+    @property
+    def root_cmakelists_dir(self):
+        if self.spec.satisfies("@:3.12.0"):
+            return "src"
+        else:
+            return "assembler/src"


### PR DESCRIPTION
In version 3.13.0 the CmakeLists.txt dir is at a different location than
in other versions. Versions up to 3.12.0 are located in "src" whereas
3.13.0 is a level deeper at "assemblers/src".