### PR TITLE
enh: allow time like HH:MM in date strings.

### DIFF
--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -448,7 +448,8 @@ def pretty_string_to_date(date_str, now=None):
 
     Args:
         date_str (str): string representing a date. This string might be
-            in different format (like ``YYYY``, ``YYYY-MM``, ``YYYY-MM-DD``)
+            in different format (like ``YYYY``, ``YYYY-MM``, ``YYYY-MM-DD``,
+            ``YYYY-MM-DD HH:MM``, ``YYYY-MM-DD HH:MM:SS``)
             or be a *pretty date* (like ``yesterday`` or ``two months ago``)
 
     Returns:
@@ -467,6 +468,10 @@ def pretty_string_to_date(date_str, now=None):
     pattern[re.compile(r'^\d{4}-\d{2}-\d{2}$')] = lambda x: datetime.strptime(
         x, '%Y-%m-%d'
     )
+    pattern[re.compile(r'^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$')] = \
+        lambda x: datetime.strptime(x, '%Y-%m-%d %H:%M')
+    pattern[re.compile(r'^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$')] = \
+        lambda x: datetime.strptime(x, '%Y-%m-%d %H:%M:%S')
 
     pretty_regex = re.compile(
         r'(a|\d+)\s*(year|month|week|day|hour|minute|second)s?\s*ago')

--- a/lib/spack/spack/test/llnl/util/lang.py
+++ b/lib/spack/spack/test/llnl/util/lang.py
@@ -82,6 +82,8 @@ def test_pretty_string_to_date_delta(now, delta, pretty_string):
     ('%Y', '2018'),
     ('%Y-%m', '2015-03'),
     ('%Y-%m-%d', '2015-03-28'),
+    ('%Y-%m-%d %H:%M', '2015-03-28 11:12'),
+    ('%Y-%m-%d %H:%M:%S', '2015-03-28 23:34:45'),
 ])
 def test_pretty_string_to_date(format, pretty_string):
     t1 = datetime.strptime(pretty_string, format)


### PR DESCRIPTION
Spack allows to specify precise relative dates/times:
```bash
spack find --start-date "23 seconds ago"
```
but has only a very coarse precision when using absolute dates:
```bash
spack find --start-date 2018-12-25
```

I would like to add `HH:MM(:SS)?` to this for feature parity and allow:
```bash
spack find --start-date 2018-12-25\ 23:59
```