### PR TITLE
xsdk-0.4.0: add/update package versions:

### DIFF
--- a/var/spack/repos/builtin/packages/alquimia/package.py
+++ b/var/spack/repos/builtin/packages/alquimia/package.py
@@ -14,6 +14,7 @@ class Alquimia(CMakePackage):
     git      = "https://github.com/LBL-EESA/alquimia-dev.git"
 
     version('develop')
+    version('xsdk-0.4.0', commit='2edad6733106142d014bb6e6a73c2b21d5e3cf2d')
     version('xsdk-0.3.0', tag='xsdk-0.3.0')
     version('xsdk-0.2.0', tag='xsdk-0.2.0')
 
@@ -22,12 +23,14 @@ class Alquimia(CMakePackage):
 
     depends_on('mpi')
     depends_on('hdf5')
+    depends_on('pflotran@xsdk-0.4.0', when='@xsdk-0.4.0')
     depends_on('pflotran@xsdk-0.3.0', when='@xsdk-0.3.0')
     depends_on('pflotran@xsdk-0.2.0', when='@xsdk-0.2.0')
     depends_on('pflotran@develop', when='@develop')
-    depends_on('petsc@3.8.0:', when='@xsdk-0.3.0')
+    depends_on('petsc@3.10.0:3.10.99', when='@xsdk-0.4.0')
+    depends_on('petsc@3.8.0:3.8.99', when='@xsdk-0.3.0')
     depends_on('petsc@xsdk-0.2.0', when='@xsdk-0.2.0')
-    depends_on('petsc@develop', when='@develop')
+    depends_on('petsc@3.10:', when='@develop')
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/pflotran/package.py
+++ b/var/spack/repos/builtin/packages/pflotran/package.py
@@ -16,15 +16,18 @@ class Pflotran(AutotoolsPackage):
     git      = "https://bitbucket.org/pflotran/pflotran.git"
 
     version('develop')
-    version('xsdk-0.2.0', tag='master')
+    version('xsdk-0.4.0', commit='c851cbc94fc56a32cfdb0678f3c24b9936a5584e')
     version('xsdk-0.3.0', branch='release/xsdk-0.3.0')
+    version('xsdk-0.2.0', commit='4da763c6136df57caff43f98c926433958cfdea6')
 
     depends_on('mpi')
     depends_on('hdf5@1.8.12:+mpi+fortran')
-    depends_on('petsc@develop+hdf5+metis', when='@develop')
+    depends_on('petsc@develop:+hdf5+metis', when='@develop')
+    depends_on('petsc@3.10:+hdf5+metis', when='@xsdk-0.4.0')
     depends_on('petsc@xsdk-0.2.0+hdf5+metis', when='@xsdk-0.2.0')
     depends_on('petsc@3.8.0:+hdf5+metis', when='@xsdk-0.3.0')
 
     @property
     def parallel(self):
-        return self.spec.satisfies('@develop')
+        return (self.spec.satisfies('@develop') or
+                self.spec.satisfies('@xsdk-0.4.0'))

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -35,6 +35,7 @@ class Trilinos(CMakePackage):
     version('xsdk-0.2.0', tag='xsdk-0.2.0')
     version('develop', branch='develop')
     version('master', branch='master')
+    version('12.14.0-rc1', commit='dbf41f3b26b0326a1377f219e6e07eab861d181e')  # branch trilinos-release-12-14-branch
     version('12.12.1', 'ecd4606fa332212433c98bf950a69cc7')
     version('12.10.1', '667333dbd7c0f031d47d7c5511fd0810')
     version('12.8.1', '9f37f683ee2b427b5540db8a20ed6b15')
@@ -175,7 +176,7 @@ class Trilinos(CMakePackage):
 
     resource(name='dtk',
              git='https://github.com/ornl-cees/DataTransferKit.git',
-             tag='master',
+             commit='4fe4d9d56cfd4f8a61f392b81d8efd0e389ee764',  # branch dtk-3.0
              placement='DataTransferKit',
              when='+dtk')
     resource(name='fortrilinos',
@@ -236,6 +237,8 @@ class Trilinos(CMakePackage):
     conflicts('+dtk', when='~kokkos')
     conflicts('+dtk', when='~teuchos')
     conflicts('+dtk', when='~tpetra')
+    # Only allow DTK-3.0 with Trilinos 12.14
+    conflicts('+dtk', when='@0:12.12.99,12.16.0:99,master,develop')
     conflicts('+fortrilinos', when='~fortran')
     conflicts('+fortrilinos', when='@:99')
     conflicts('+fortrilinos', when='@master')
@@ -443,7 +446,6 @@ class Trilinos(CMakePackage):
         if '+dtk' in spec:
             options.extend([
                 '-DTrilinos_EXTRA_REPOSITORIES:STRING=DataTransferKit',
-                '-DTpetra_INST_INT_UNSIGNED_LONG:BOOL=ON',
                 '-DTrilinos_ENABLE_DataTransferKit:BOOL=ON'
             ])
 

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -36,7 +36,7 @@ class Trilinos(CMakePackage):
     version('develop', branch='develop')
     version('master', branch='master')
     version('12.14.0-rc1', commit='dbf41f3b26b0326a1377f219e6e07eab861d181e')  # branch trilinos-release-12-14-branch
-    version('12.12.1', 'ecd4606fa332212433c98bf950a69cc7')
+    version('12.12.1', 'ecd4606fa332212433c98bf950a69cc7', preferred=True)
     version('12.10.1', '667333dbd7c0f031d47d7c5511fd0810')
     version('12.8.1', '9f37f683ee2b427b5540db8a20ed6b15')
     version('12.6.4', 'e11fff717d0e4565779f75a47feecbb2')

--- a/var/spack/repos/builtin/packages/xsdk/package.py
+++ b/var/spack/repos/builtin/packages/xsdk/package.py
@@ -21,25 +21,33 @@ class Xsdk(Package):
     url      = 'http://ftp.mcs.anl.gov/pub/petsc/externalpackages/xsdk.tar.gz'
 
     version('develop', 'a52dc710c744afa0b71429b8ec9425bc')
-    version('0.3.0', 'a52dc710c744afa0b71429b8ec9425bc', preferred=True)
+    version('0.4.0', 'a52dc710c744afa0b71429b8ec9425bc')
+    version('0.3.0', 'a52dc710c744afa0b71429b8ec9425bc')
     version('xsdk-0.2.0', 'a52dc710c744afa0b71429b8ec9425bc')
 
     variant('debug', default=False, description='Compile in debug mode')
     variant('cuda', default=False, description='Enable CUDA dependent packages')
+    variant('omega-h', default=True, description='Enable omega-h package build')
+    variant('dealii', default=True, description='Enable dealii package build')
 
     depends_on('hypre@develop~internal-superlu', when='@develop')
+    depends_on('hypre@2.15.1~internal-superlu', when='@0.4.0')
     depends_on('hypre@2.12.1~internal-superlu', when='@0.3.0')
     depends_on('hypre@xsdk-0.2.0~internal-superlu', when='@xsdk-0.2.0')
 
     depends_on('mfem@develop+mpi+hypre+superlu-dist+petsc+sundials+examples+miniapps', when='@develop')
+    depends_on('mfem@3.4.0+mpi+hypre+superlu-dist+petsc+sundials+examples+miniapps', when='@0.4.0')
     depends_on('mfem@3.3.2+mpi+hypre+superlu-dist+petsc+sundials+examples+miniapps', when='@0.3.0')
 
     depends_on('superlu-dist@develop', when='@develop')
+    depends_on('superlu-dist@6.1.0', when='@0.4.0')
     depends_on('superlu-dist@5.2.2', when='@0.3.0')
     depends_on('superlu-dist@xsdk-0.2.0', when='@xsdk-0.2.0')
 
-    depends_on('trilinos@develop+hypre+superlu-dist+metis+hdf5~mumps+boost~suite-sparse+tpetra+nox+ifpack2+zoltan2+amesos2~exodus',
+    depends_on('trilinos@master+hypre+superlu-dist+metis+hdf5~mumps+boost~suite-sparse+tpetra+nox+ifpack2+zoltan2+amesos2~exodus+dtk+intrepid2+shards',
                when='@develop')
+    depends_on('trilinos@12.14.0-rc1+hypre+superlu-dist+metis+hdf5~mumps+boost~suite-sparse+tpetra+nox+ifpack2+zoltan2+amesos2~exodus+dtk+intrepid2+shards',
+               when='@0.4.0')
     depends_on('trilinos@12.12.1+hypre+superlu-dist+metis+hdf5~mumps+boost~suite-sparse~tpetra~ifpack2~zoltan2~amesos2~exodus',
                when='@0.3.0')
     depends_on('trilinos@xsdk-0.2.0+hypre+superlu-dist+metis+hdf5~mumps+boost~suite-sparse~tpetra~ifpack2~zoltan2~amesos2~exodus',
@@ -47,40 +55,66 @@ class Xsdk(Package):
 
     depends_on('petsc@develop+trilinos+mpi+hypre+superlu-dist+metis+hdf5~mumps+double~int64',
                when='@develop')
+    depends_on('petsc@3.10.3+trilinos+mpi+hypre+superlu-dist+metis+hdf5~mumps+double~int64',
+               when='@0.4.0')
     depends_on('petsc@3.8.2+trilinos+mpi+hypre+superlu-dist+metis+hdf5~mumps+double~int64',
                when='@0.3.0')
     depends_on('petsc@xsdk-0.2.0+trilinos+mpi+hypre+superlu-dist+metis+hdf5~mumps+double~int64',
                when='@xsdk-0.2.0')
 
-    depends_on('dealii@develop~assimp~python~doc~slepc~gmsh+petsc+mpi+trilinos~int64+hdf5~netcdf+metis', when='@develop')
+    depends_on('dealii@develop~assimp~python~doc~slepc~gmsh+petsc+mpi+trilinos~int64+hdf5~netcdf+metis', when='@develop +dealii')
+    depends_on('dealii@9.0.1~assimp~python~doc~slepc~gmsh+petsc+mpi+trilinos~int64+hdf5~netcdf+metis', when='@0.4.0 +dealii')
 
     depends_on('pflotran@develop', when='@develop')
+    depends_on('pflotran@xsdk-0.4.0', when='@0.4.0')
     depends_on('pflotran@xsdk-0.3.0', when='@0.3.0')
     depends_on('pflotran@xsdk-0.2.0', when='@xsdk-0.2.0')
 
     depends_on('alquimia@develop', when='@develop')
+    depends_on('alquimia@xsdk-0.4.0', when='@0.4.0')
     depends_on('alquimia@xsdk-0.3.0', when='@0.3.0')
     depends_on('alquimia@xsdk-0.2.0', when='@xsdk-0.2.0')
 
-    depends_on('sundials@3.1.0~int64+hypre', when='@develop')
+    depends_on('sundials@3.2.1~int64+hypre', when='@develop')
+    depends_on('sundials@3.2.1~int64+hypre', when='@0.4.0')
     depends_on('sundials@3.1.0~int64+hypre', when='@0.3.0')
 
-    depends_on('plasma@17.2:', when='@develop %gcc@6.0:')
+    depends_on('plasma@18.11.1:', when='@develop %gcc@6.0:')
+    depends_on('plasma@18.11.1:', when='@0.4.0 %gcc@6.0:')
 
-    depends_on('magma@2.2.0', when='@develop +cuda')
+    depends_on('magma@2.4.0', when='@develop +cuda')
+    depends_on('magma@2.4.0', when='@0.4.0 +cuda')
     depends_on('magma@2.2.0', when='@0.3.0 +cuda')
 
     depends_on('amrex@develop', when='@develop %intel')
     depends_on('amrex@develop', when='@develop %gcc')
+    depends_on('amrex@18.10.1', when='@0.4.0 %intel')
+    depends_on('amrex@18.10.1', when='@0.4.0 %gcc')
 
     depends_on('slepc@develop', when='@develop')
+    depends_on('slepc@3.10.1', when='@0.4.0')
+
+    depends_on('omega-h@develop', when='@develop +omega-h')
+    depends_on('omega-h@9.19.1', when='@0.4.0 +omega-h')
+
+    depends_on('strumpack@master', when='@develop')
+    depends_on('strumpack@3.1.1', when='@0.4.0')
+
+    depends_on('pumi@develop', when='@develop')
+    depends_on('pumi@2.2.0', when='@0.4.0')
+
+    depends_on('tasmanian@develop+xsdkflags+blas~openmp', when='@develop')
+    depends_on('tasmanian@develop+xsdkflags+blas+cuda+magma~openmp', when='@develop +cuda')
+    depends_on('tasmanian@6.0+xsdkflags+blas~openmp', when='@0.4.0')
+    depends_on('tasmanian@6.0+xsdkflags+blas+cuda+magma~openmp', when='@0.4.0 +cuda')
 
     # the Fortran 2003 bindings of phist require python@3:, but this
     # creates a conflict with other packages like petsc@develop. Actually
     # these are type='build' dependencies, but spack reports a conflict anyway.
     # This will be fixed once the new concretizer becomes available
     # (says @adamjsteward)
-    depends_on('phist@develop kernel_lib=tpetra ~fortran ~scamac ~openmp', when='@develop')
+    depends_on('phist@develop kernel_lib=tpetra ~fortran ~scamac ~openmp ~host', when='@develop')
+    depends_on('phist@1.7.5 kernel_lib=tpetra ~fortran ~scamac ~openmp ~host', when='@0.4.0')
 
     # xSDKTrilinos depends on the version of Trilinos built with
     # +tpetra which is turned off for faster xSDK


### PR DESCRIPTION
  hypre@2.15.1
  mfem@3.5.0-rc1
  superlu-dist@6.1.0
  trilinos@12.14.0-rc1
  petsc@3.10.2
  dealii@9.0.1
  pflotran@xsdk-0.4.0
  alquimia@xsdk-0.4.0
  sundials@3.2.1
  plasma@18.11.1
  magma@2.4.0
  amrex@18.10.1
  slepc@3.10.1
  omega-h@9.19.1
  strumpack@3.1.1
  pumi@2.2.0
  tasmanian@6.0
  phist@1.7.4
  dtk-3.0 [via trilinos features '+dtk+intrepid2+shards']

add option to disable omega-h build [wrt gcc-8 conflict]

spack install xsdk~omega-h