### PR TITLE
fftw: fix issue #7372/rename config.h in source tree

### DIFF
--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -169,10 +169,10 @@ class Fftw(AutotoolsPackage):
         if '+float' in spec:
             with working_dir('float'):
                 make()
-        if '+long_double' in spec:
+        if spec.satisfies('@3:+long_double'):
             with working_dir('long-double'):
                 make()
-        if '+quad' in spec:
+        if spec.satisfies('@3:+quad'):
             with working_dir('quad'):
                 make()
 
@@ -184,10 +184,10 @@ class Fftw(AutotoolsPackage):
         if '+float' in spec:
             with working_dir('float'):
                 make("check")
-        if '+long_double' in spec:
+        if spec.satisfies('@3:+long_double'):
             with working_dir('long-double'):
                 make("check")
-        if '+quad' in spec:
+        if spec.satisfies('@3:+quad'):
             with working_dir('quad'):
                 make("check")
 
@@ -198,9 +198,9 @@ class Fftw(AutotoolsPackage):
         if '+float' in spec:
             with working_dir('float'):
                 make("install")
-        if '+long_double' in spec:
+        if spec.satisfies('@3:+long_double'):
             with working_dir('long-double'):
                 make("install")
-        if '+quad' in spec:
+        if spec.satisfies('@3:+quad'):
             with working_dir('quad'):
                 make("install")

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -107,6 +107,14 @@ class Fftw(AutotoolsPackage):
 
         return find_libraries(libraries, root=self.prefix, recursive=True)
 
+    def patch(self):
+        # If fftw/config.h exists in the source tree, it will take precedence
+        # over the copy in build dir.  As only the latter has proper config
+        # for our build, this is a problem.  See e.g. issue #7372 on github
+        import os
+        if os.path.isfile('fftw/config.h'):
+            os.rename('fftw/config.h', 'fftw/config.h.SPACK_RENAMED')
+
     def autoreconf(self, spec, prefix):
         if '+pfft_patches' in spec:
             autoreconf = which('autoreconf')

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -6,6 +6,8 @@
 from spack import *
 
 import llnl.util.lang
+# os is used for rename, etc in patch()
+import os
 
 
 class Fftw(AutotoolsPackage):
@@ -111,7 +113,6 @@ class Fftw(AutotoolsPackage):
         # If fftw/config.h exists in the source tree, it will take precedence
         # over the copy in build dir.  As only the latter has proper config
         # for our build, this is a problem.  See e.g. issue #7372 on github
-        import os
         if os.path.isfile('fftw/config.h'):
             os.rename('fftw/config.h', 'fftw/config.h.SPACK_RENAMED')
 


### PR DESCRIPTION
Fixed issue #7372 with building fftw@2

Added patch method which renames config.h in the fftw subdir of the source tree.  fftw 2.1.5 appears to ship with a copy of this file with all defines commented out.  This gets read by the #include directives instead of the version in the build directory with the correct defines.  As a result, many C preprocessor macros left undefined, including F77_FUNC_ which causes the bulk of fttwf77.c to be skipped due to an #ifdef, so fftw_reverse_int_array et al not included in library.

Also fixed some inconsistencies with the handling of quad and long_double in specs between the configure method and the build, check, and install methods.