### PR TITLE
gcc: Add patch to build GCC with glibc 2.28 and later

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -168,6 +168,8 @@ class Gcc(AutotoolsPackage):
     patch('stack_t.patch', when='@5.1:5.4,6.1:6.4,7.1')
     # https://bugs.busybox.net/show_bug.cgi?id=10061
     patch('signal.patch', when='@4.9,5.1:5.4')
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85835
+    patch('sys_ustat.h.patch', when='@4:6.4,7:7.3')
 
     build_directory = 'spack-build'
 

--- a/var/spack/repos/builtin/packages/gcc/sys_ustat.h.patch
+++ b/var/spack/repos/builtin/packages/gcc/sys_ustat.h.patch
@@ -1,0 +1,63 @@
+From 9569b61168b963a6cea7b782fd350dee489ad42c Mon Sep 17 00:00:00 2001
+From: "H.J. Lu" <hjl.tools@gmail.com>
+Date: Mon, 21 May 2018 13:17:55 -0700
+Subject: [PATCH] libsanitizer: Use pre-computed size of struct ustat for Linux
+
+Cherry-pick compiler-rt revision 333213:
+
+<sys/ustat.h> has been removed from glibc 2.28 by:
+
+commit cf2478d53ad7071e84c724a986b56fe17f4f4ca7
+Author: Adhemerval Zanella <adhemerval.zanella@linaro.org>
+Date:   Sun Mar 18 11:28:59 2018 +0800
+
+    Deprecate ustat syscall interface
+
+This patch uses pre-computed size of struct ustat for Linux.
+
+	PR sanitizer/85835
+	* sanitizer_common/sanitizer_platform_limits_posix.cc: Don't
+	include <sys/ustat.h> for Linux.
+	(SIZEOF_STRUCT_USTAT): New.
+	(struct_ustat_sz): Use SIZEOF_STRUCT_USTAT for Linux.
+---
+ .../sanitizer_platform_limits_posix.cc            | 15 +++++++++++++--
+ 1 file changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cc b/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cc
+index 858bb218450..de18e56d11c 100644
+--- a/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cc
++++ b/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cc
+@@ -157,7 +157,6 @@ typedef struct user_fpregs elf_fpregset_t;
+ # include <sys/procfs.h>
+ #endif
+ #include <sys/user.h>
+-#include <sys/ustat.h>
+ #include <linux/cyclades.h>
+ #include <linux/if_eql.h>
+ #include <linux/if_plip.h>
+@@ -250,7 +249,19 @@ namespace __sanitizer {
+ #endif // SANITIZER_LINUX || SANITIZER_FREEBSD
+ 
+ #if SANITIZER_LINUX && !SANITIZER_ANDROID
+-  unsigned struct_ustat_sz = sizeof(struct ustat);
++  // Use pre-computed size of struct ustat to avoid <sys/ustat.h> which
++  // has been removed from glibc 2.28.
++#if defined(__aarch64__) || defined(__s390x__) || defined (__mips64) \
++  || defined(__powerpc64__) || defined(__arch64__) || defined(__sparcv9) \
++  || defined(__x86_64__)
++#define SIZEOF_STRUCT_USTAT 32
++#elif defined(__arm__) || defined(__i386__) || defined(__mips__) \
++  || defined(__powerpc__) || defined(__s390__)
++#define SIZEOF_STRUCT_USTAT 20
++#else
++#error Unknown size of struct ustat
++#endif
++  unsigned struct_ustat_sz = SIZEOF_STRUCT_USTAT;
+   unsigned struct_rlimit64_sz = sizeof(struct rlimit64);
+   unsigned struct_statvfs64_sz = sizeof(struct statvfs64);
+ #endif // SANITIZER_LINUX && !SANITIZER_ANDROID
+-- 
+2.17.0
+
+


### PR DESCRIPTION
Fixes #10035