### PR TITLE
debugging unicode decode error on py2

### DIFF
--- a/lib/spack/llnl/util/tty/colify.py
+++ b/lib/spack/llnl/util/tty/colify.py
@@ -13,6 +13,7 @@ import sys
 from six import StringIO, text_type
 
 from llnl.util.tty import terminal_size
+import llnl.util.tty as tty
 from llnl.util.tty.color import clen, cextra
 
 
@@ -137,7 +138,14 @@ def colify(elts, **options):
             % next(options.iterkeys()))
 
     # elts needs to be an array of strings so we can count the elements
-    elts = [text_type(elt) for elt in elts]
+    converted_elts = []
+    for elt in elts:
+        try:
+            converted_elts.append(text_type(elt))
+        except UnicodeDecodeError, e:
+            msg = "Failed conversion: {0}\n{1}".format(elt, e.message)
+            raise ValueError(msg)
+    elts = converted_elts
     if not elts:
         return (0, ())
 

--- a/lib/spack/llnl/util/tty/colify.py
+++ b/lib/spack/llnl/util/tty/colify.py
@@ -141,7 +141,7 @@ def colify(elts, **options):
     for elt in elts:
         try:
             converted_elts.append(text_type(elt))
-        except UnicodeDecodeError, e:
+        except UnicodeDecodeError as e:
             msg = "Failed conversion: {0}\n{1}".format(elt, e.message)
             raise ValueError(msg)
     elts = converted_elts

--- a/lib/spack/llnl/util/tty/colify.py
+++ b/lib/spack/llnl/util/tty/colify.py
@@ -140,7 +140,7 @@ def colify(elts, **options):
     converted_elts = []
     for elt in elts:
         try:
-            converted_elts.append(text_type(elt))
+            converted_elts.append(text_type(elt, 'utf-8'))
         except UnicodeDecodeError as e:
             msg = "Failed conversion: {0}\n{1}".format(elt, e.message)
             raise ValueError(msg)

--- a/lib/spack/llnl/util/tty/colify.py
+++ b/lib/spack/llnl/util/tty/colify.py
@@ -13,7 +13,6 @@ import sys
 from six import StringIO, text_type
 
 from llnl.util.tty import terminal_size
-import llnl.util.tty as tty
 from llnl.util.tty.color import clen, cextra
 
 

--- a/lib/spack/llnl/util/tty/colify.py
+++ b/lib/spack/llnl/util/tty/colify.py
@@ -141,9 +141,9 @@ def colify(elts, **options):
     for elt in elts:
         try:
             if isinstance(elt, string_types):
-                converted_elts.append(text_type(elt, 'utf-8'))
+                converted_elts.append(elt)
             else:
-                converted_elts.append(str(elt))
+                converted_elts.append(text_type(elt))
         except UnicodeDecodeError as e:
             msg = "Failed conversion: {0}\n{1}".format(elt, e.message)
             raise ValueError(msg)

--- a/lib/spack/llnl/util/tty/colify.py
+++ b/lib/spack/llnl/util/tty/colify.py
@@ -10,7 +10,7 @@ from __future__ import division
 
 import os
 import sys
-from six import StringIO, text_type
+from six import StringIO, text_type, string_types
 
 from llnl.util.tty import terminal_size
 from llnl.util.tty.color import clen, cextra
@@ -140,7 +140,10 @@ def colify(elts, **options):
     converted_elts = []
     for elt in elts:
         try:
-            converted_elts.append(text_type(elt, 'utf-8'))
+            if isinstance(elt, string_types):
+                converted_elts.append(text_type(elt, 'utf-8'))
+            else:
+                converted_elts.append(str(elt))
         except UnicodeDecodeError as e:
             msg = "Failed conversion: {0}\n{1}".format(elt, e.message)
             raise ValueError(msg)


### PR DESCRIPTION
Looking into what is causing this error (currently cannot reproduce outside travis): https://travis-ci.org/spack/spack/jobs/464724898

```
        # elts needs to be an array of strings so we can count the elements
>       elts = [text_type(elt) for elt in elts]
E       UnicodeDecodeError: 'ascii' codec can't decode byte 0xc5 in position 3: ordinal not in range(128)
```