### PR TITLE
zoltan: detect metis int64 variant

### DIFF
--- a/var/spack/repos/builtin/packages/zoltan/package.py
+++ b/var/spack/repos/builtin/packages/zoltan/package.py
@@ -81,6 +81,8 @@ class Zoltan(Package):
                                .format(spec['metis'].prefix.lib))
             if '+int64' in spec['metis']:
                 config_args.append('--with-id-type=ulong')
+            if '~int64' in spec['metis']:
+                config_args.append('--with-id-type=uint')
 
         if '+mpi' in spec:
             config_args.append('CC={0}'.format(spec['mpi'].mpicc))

--- a/var/spack/repos/builtin/packages/zoltan/package.py
+++ b/var/spack/repos/builtin/packages/zoltan/package.py
@@ -79,6 +79,8 @@ class Zoltan(Package):
                                .format(spec['metis'].prefix.include))
             config_args.append('--with-ldflags=-L{0}'
                                .format(spec['metis'].prefix.lib))
+            if '+int64' in spec['metis']:
+                config_args.append('--with-id-type=ulong')
 
         if '+mpi' in spec:
             config_args.append('CC={0}'.format(spec['mpi'].mpicc))

--- a/var/spack/repos/builtin/packages/zoltan/package.py
+++ b/var/spack/repos/builtin/packages/zoltan/package.py
@@ -81,7 +81,7 @@ class Zoltan(Package):
                                .format(spec['metis'].prefix.lib))
             if '+int64' in spec['metis']:
                 config_args.append('--with-id-type=ulong')
-            if '~int64' in spec['metis']:
+            else:
                 config_args.append('--with-id-type=uint')
 
         if '+mpi' in spec:


### PR DESCRIPTION
This PR adds logic for zoltan to detect metis with 64b ints and append the necessary configure flag for compatibility.