### PR TITLE
metis: Fix issues with gcc6 and misleading indentation

### DIFF
--- a/var/spack/repos/builtin/packages/metis/gklib_nomisleadingindentation_warning.patch
+++ b/var/spack/repos/builtin/packages/metis/gklib_nomisleadingindentation_warning.patch
@@ -1,0 +1,12 @@
+diff -Naur metis-5.1.0/GKlib/GKlibSystem.cmake metis-5.1.0.patched/GKlib/GKlibSystem.cmake
+--- metis-5.1.0/GKlib/GKlibSystem.cmake	2013-03-30 12:24:45.000000000 -0400
++++ metis-5.1.0.patched/GKlib/GKlibSystem.cmake	2018-12-07 16:22:58.491427261 -0500
+@@ -33,7 +33,7 @@
+       set(GKlib_COPTIONS "${GKlib_COPTIONS} -fPIC")
+   endif(NOT MINGW)
+ # GCC warnings.
+-  set(GKlib_COPTIONS "${GKlib_COPTIONS} -Wall -pedantic -Wno-unused-but-set-variable -Wno-unused-variable -Wno-unknown-pragmas")
++  set(GKlib_COPTIONS "${GKlib_COPTIONS} -Wall -pedantic -Wno-misleading-indentation -Wno-unused-but-set-variable -Wno-unused-variable -Wno-unknown-pragmas")
+ elseif(${CMAKE_C_COMPILER_ID} MATCHES "Sun")
+ # Sun insists on -xc99.
+   set(GKlib_COPTIONS "${GKlib_COPTIONS} -xc99")

--- a/var/spack/repos/builtin/packages/metis/package.py
+++ b/var/spack/repos/builtin/packages/metis/package.py
@@ -48,6 +48,7 @@ class Metis(Package):
     depends_on('cmake@2.8:', when='@5:', type='build')
 
     patch('install_gklib_defs_rename.patch', when='@5:')
+    patch('gklib_nomisleadingindentation_warning.patch', when='@5: %gcc@6:')
 
     def url_for_version(self, version):
         url = "http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis"


### PR DESCRIPTION
Added patch to GKlibSystem.cmake to disable warnings (which get
promoted to errors) due to -Wmisleading-indentation being added
to -Wall in gcc 6