### PR TITLE
Binary caching bugfix: symlink relocation

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -125,12 +125,10 @@ def write_buildinfo_file(prefix, workdir, rel=False):
         dirs[:] = [d for d in dirs if d not in blacklist]
         for filename in files:
             path_name = os.path.join(root, filename)
-            #  Check if the file contains a string with the installroot.
-            #  This cuts down on the number of files added to the list
-            #  of files potentially needing relocation
             if os.path.islink(path_name):
                 link = os.readlink(path_name)
                 if os.path.isabs(link):
+                    # Relocate absolute links into the spack tree
                     if link.startswith(spack.store.layout.root):
                         rel_path_name = os.path.relpath(path_name, prefix)
                         link_to_relocate.append(rel_path_name)
@@ -139,6 +137,10 @@ def write_buildinfo_file(prefix, workdir, rel=False):
                         msg += 'outside of stage %s ' % prefix
                         msg += 'cannot be relocated.'
                         tty.warn(msg)
+
+            #  Check if the file contains a string with the installroot.
+            #  This cuts down on the number of files added to the list
+            #  of files potentially needing relocation
             elif relocate.strings_contains_installroot(
                     path_name, spack.store.layout.root):
                 filetype = get_filetype(path_name)

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -145,8 +145,7 @@ def write_buildinfo_file(prefix, workdir, rel=False):
                         msg = 'Absolute link %s to %s ' % (path_name, link)
                         msg += 'outside of stage %s ' % prefix
                         msg += 'cannot be relocated.'
-                        msg += '\n\n prefix=%s \n workdir=%s \n spack_prefix=%s' % (prefix, workdir, spack_prefix)
-                        raise UnrelocatableLinkException(msg)
+                        tty.warn(msg)
             elif relocate.strings_contains_installroot(
                     path_name, spack.store.layout.root):
                 filetype = get_filetype(path_name)

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -82,12 +82,6 @@ class NewLayoutException(spack.error.SpackError):
     pass
 
 
-class UnrelocatableLinkException(spack.error.SpackError):
-    """
-    Raised if the package has absolute symlinks outside of the prefix
-    """
-
-
 def has_gnupg2():
     try:
         gpg_util.Gpg.gpg()('--version', output=os.devnull)
@@ -383,7 +377,8 @@ def download_tarball(spec):
 
 def make_package_relative(workdir, prefix, allow_root):
     """
-    Change paths in binaries to relative paths
+    Change paths in binaries to relative paths. Change absolute symlinks
+    to relative symlinks.
     """
     buildinfo = read_buildinfo_file(workdir)
     old_path = buildinfo['buildpath']

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -306,7 +306,7 @@ def build_tarball(spec, outdir, force=False, rel=False, unsigned=False,
             tty.die(str(e))
     else:
         try:
-            make_package_placeholder(workdir, allow_root)
+            make_package_placeholder(workdir, spec.prefix, allow_root)
         except Exception as e:
             shutil.rmtree(workdir)
             shutil.rmtree(tarfile_dir)
@@ -404,7 +404,7 @@ def make_package_relative(workdir, prefix, allow_root):
     relocate.make_link_relative(cur_path_names, orig_path_names)
 
 
-def make_package_placeholder(workdir, allow_root):
+def make_package_placeholder(workdir, prefix, allow_root):
     """
     Change paths in binaries to placeholder paths
     """
@@ -413,6 +413,11 @@ def make_package_placeholder(workdir, allow_root):
     for filename in buildinfo['relocate_binaries']:
         cur_path_names.append(os.path.join(workdir, filename))
     relocate.make_binary_placeholder(cur_path_names, allow_root)
+
+    cur_path_names = list()
+    for filename in buildinfo['relocate_links']:
+        cur_path_names.append(os.path.join(workdir, filename))
+    relocate.make_link_placeholder(cur_path_names, workdir, prefix)
 
 
 def relocate_package(workdir, allow_root):

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -396,7 +396,7 @@ def make_package_relative(workdir, prefix, allow_root):
                                   old_path, allow_root)
     orig_path_names = list()
     cur_path_names = list()
-    for filename in buildinfo['relocate_links']:
+    for filename in buildinfo.get('relocate_links', []):
         orig_path_names.append(os.path.join(prefix, filename))
         cur_path_names.append(os.path.join(workdir, filename))
     relocate.make_link_relative(cur_path_names, orig_path_names)
@@ -413,7 +413,7 @@ def make_package_placeholder(workdir, prefix, allow_root):
     relocate.make_binary_placeholder(cur_path_names, allow_root)
 
     cur_path_names = list()
-    for filename in buildinfo['relocate_links']:
+    for filename in buildinfo.get('relocate_links', []):
         cur_path_names.append(os.path.join(workdir, filename))
     relocate.make_link_placeholder(cur_path_names, workdir, prefix)
 
@@ -448,7 +448,7 @@ def relocate_package(workdir, allow_root):
         relocate.relocate_binary(path_names, old_path, new_path,
                                  allow_root)
         path_names = set()
-        for filename in buildinfo['relocate_links']:
+        for filename in buildinfo.get('relocate_links', []):
             path_name = os.path.join(workdir, filename)
             path_names.add(path_name)
         relocate.relocate_links(path_names, old_path, new_path)

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -136,9 +136,8 @@ def write_buildinfo_file(prefix, workdir, rel=False):
             #  of files potentially needing relocation
             if os.path.islink(path_name):
                 link = os.readlink(path_name)
-                spack_prefix = spack.store.layout.root
                 if os.path.isabs(link):
-                    if link.startswith(prefix):
+                    if link.startswith(spack.store.layout.root):
                         rel_path_name = os.path.relpath(path_name, prefix)
                         link_to_relocate.append(rel_path_name)
                     else:

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -390,7 +390,7 @@ def make_package_relative(workdir, prefix, allow_root):
         orig_path_names.append(os.path.join(prefix, filename))
         cur_path_names.append(os.path.join(workdir, filename))
     relocate.make_link_relative(cur_path_names, orig_path_names,
-                                  old_path, allow_root)
+                                  old_path)
 
 
 def make_package_placeholder(workdir, allow_root):

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -130,7 +130,8 @@ def write_buildinfo_file(prefix, workdir, rel=False):
             #  of files potentially needing relocation
             if os.path.islink(path_name):
                 # If the destination starts with the old prefix
-                if os.path.realpath(path_name).find(spack.store.layout.root) == 0:
+                realpath = os.path.realpath(path_name)
+                if realpath.find(spack.store.layout.root) == 0:
                     rel_path_name = os.path.relpath(path_name, prefix)
                     link_to_relocate.append(rel_path_name)
             elif relocate.strings_contains_installroot(
@@ -390,7 +391,7 @@ def make_package_relative(workdir, prefix, allow_root):
         orig_path_names.append(os.path.join(prefix, filename))
         cur_path_names.append(os.path.join(workdir, filename))
     relocate.make_link_relative(cur_path_names, orig_path_names,
-                                  old_path)
+                                old_path)
 
 
 def make_package_placeholder(workdir, allow_root):

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -138,13 +138,15 @@ def write_buildinfo_file(prefix, workdir, rel=False):
                 link = os.readlink(path_name)
                 spack_prefix = spack.store.layout.root
                 if os.path.isabs(link):
-                    if os.readlink(path_name).startswith(spack_prefix):
+                    if link.startswith(prefix):
                         rel_path_name = os.path.relpath(path_name, prefix)
                         link_to_relocate.append(rel_path_name)
-                else:
-                    msg = 'Absolute link %s to %s ' % (path_name, link)
-                    msg += 'outside of spack cannot be relocated.'
-                    raise UnrelocatableLinkException(msg)
+                    else:
+                        msg = 'Absolute link %s to %s ' % (path_name, link)
+                        msg += 'outside of stage %s ' % prefix
+                        msg += 'cannot be relocated.'
+                        msg += '\n\n prefix=%s \n workdir=%s \n spack_prefix=%s' % (prefix, workdir, spack_prefix)
+                        raise UnrelocatableLinkException(msg)
             elif relocate.strings_contains_installroot(
                     path_name, spack.store.layout.root):
                 filetype = get_filetype(path_name)

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -353,11 +353,10 @@ def relocate_binary(path_names, old_dir, new_dir, allow_root):
 
 def make_link_relative(cur_path_names, orig_path_names):
     """
-    Change absolute links to be relative to old_dir
+    Change absolute links to be relative.
     """
     for cur_path, orig_path in zip(cur_path_names, orig_path_names):
-        # We can safely call realpath, all links absolute
-        old_src = os.path.realpath(orig_path)
+        old_src = os.readlink(orig_path)
         new_src = os.path.relpath(old_src, orig_path)
 
         os.unlink(cur_path)

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -430,17 +430,17 @@ def make_binary_placeholder(cur_path_names, allow_root):
 
 def make_link_placeholder(cur_path_names, cur_dir, old_dir):
     """
-    Replace old install path with placeholder in absolute links
+    Replace old install path with placeholder in absolute links.
+
+    Links in ``cur_path_names`` must link to absolute paths.
     """
-    cur_dir = os.path.realpath(cur_dir)
     for cur_path in cur_path_names:
-        # realpath is safe, previously ensured absolute
         placeholder = set_placeholder(spack.store.layout.root)
         placeholder_prefix = old_dir.replace(spack.store.layout.root,
                                              placeholder)
-        cur_src = os.path.realpath(cur_path)
-        suffix = cur_src[len(cur_dir):]
-        new_src = placeholder_prefix + suffix
+        cur_src = os.readlink(cur_path)
+        rel_src = os.path.relpath(cur_src, cur_dir)
+        new_src = os.path.join(placeholder_prefix, rel_src)
 
         os.unlink(cur_path)
         os.symlink(new_src, cur_path)
@@ -448,11 +448,12 @@ def make_link_placeholder(cur_path_names, cur_dir, old_dir):
 
 def relocate_links(path_names, old_dir, new_dir):
     """
-    Replace old path with new path in link sources
+    Replace old path with new path in link sources.
+
+    Links in ``path_names`` must link to absolute paths or placeholders.
     """
     placeholder = set_placeholder(old_dir)
     for path_name in path_names:
-        # readlink is safe, previously ensured absolute
         old_src = os.readlink(path_name)
         # replace either placeholder or old_dir
         new_src = old_src.replace(placeholder, new_dir, 1)

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -359,6 +359,7 @@ def make_link_relative(cur_path_names, orig_path_names):
         # We can safely call realpath, all links absolute
         old_src = os.path.realpath(orig_path)
         new_src = os.path.relpath(old_src, orig_path)
+
         os.unlink(cur_path)
         os.symlink(new_src, cur_path)
 
@@ -427,14 +428,35 @@ def make_binary_placeholder(cur_path_names, allow_root):
         tty.die("Placeholder not implemented for %s" % platform.system())
 
 
+def make_link_placeholder(cur_path_names, cur_dir, old_dir):
+    """
+    Replace old install path with placeholder in absolute links
+    """
+    cur_dir = os.path.realpath(cur_dir)
+    for cur_path in cur_path_names:
+        # realpath is safe, previously ensured absolute
+        placeholder = set_placeholder(spack.store.layout.root)
+        placeholder_prefix = old_dir.replace(spack.store.layout.root, placeholder)
+        cur_src = os.path.realpath(cur_path)
+        suffix = cur_path[len(cur_dir):]
+        new_src = placeholder_prefix + suffix
+
+        os.unlink(cur_path)
+        os.symlink(new_src, cur_path)
+
+
 def relocate_links(path_names, old_dir, new_dir):
     """
     Replace old path with new path in link sources
     """
+    placeholder = set_placeholder(old_dir)
     for path_name in path_names:
-        # realpath is safe, previously ensured absolute
-        old_src = os.path.realpath(path_name)
-        new_src = old_src.replace(old_dir, new_dir, 1)
+        # readlink is safe, previously ensured absolute
+        old_src = os.readlink(path_name)
+        # replace either placeholder or old_dir
+        new_src = old_src.replace(placeholder, new_dir, 1)
+        new_src = new_src.replace(old_dir, new_dir, 1)
+
         os.unlink(path_name)
         os.symlink(new_src, path_name)
 

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -120,7 +120,7 @@ def macho_get_paths(path_name):
         if match:
             lhs = match.group(1).lstrip().rstrip()
             rhs = match.group(2)
-            match2 = re.search('(.*) \(.*\)', rhs)
+            match2 = re.search(r'(.*) \(.*\)', rhs)
             if match2:
                 rhs = match2.group(1)
             if lhs == 'cmd':

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -436,9 +436,10 @@ def make_link_placeholder(cur_path_names, cur_dir, old_dir):
     for cur_path in cur_path_names:
         # realpath is safe, previously ensured absolute
         placeholder = set_placeholder(spack.store.layout.root)
-        placeholder_prefix = old_dir.replace(spack.store.layout.root, placeholder)
+        placeholder_prefix = old_dir.replace(spack.store.layout.root,
+                                             placeholder)
         cur_src = os.path.realpath(cur_path)
-        suffix = cur_path[len(cur_dir):]
+        suffix = cur_src[len(cur_dir):]
         new_src = placeholder_prefix + suffix
 
         os.unlink(cur_path)

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -351,11 +351,12 @@ def relocate_binary(path_names, old_dir, new_dir, allow_root):
         tty.die("Relocation not implemented for %s" % platform.system())
 
 
-def make_link_relative(cur_path_names, orig_path_names, old_dir):
+def make_link_relative(cur_path_names, orig_path_names):
     """
-    Change links to be relative to old_dir
+    Change absolute links to be relative to old_dir
     """
     for cur_path, orig_path in zip(cur_path_names, orig_path_names):
+        # We can safely call realpath, all links absolute
         old_src = os.path.realpath(orig_path)
         new_src = os.path.relpath(old_src, orig_path)
         os.unlink(cur_path)
@@ -426,11 +427,12 @@ def make_binary_placeholder(cur_path_names, allow_root):
         tty.die("Placeholder not implemented for %s" % platform.system())
 
 
-def relocate_link(path_names, old_dir, new_dir):
+def relocate_links(path_names, old_dir, new_dir):
     """
     Replace old path with new path in link sources
     """
     for path_name in path_names:
+        # realpath is safe, previously ensured absolute
         old_src = os.path.realpath(path_name)
         new_src = old_src.replace(old_dir, new_dir, 1)
         os.unlink(path_name)

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -432,7 +432,7 @@ def relocate_link(path_names, old_dir, new_dir):
     """
     for path_name in path_names:
         old_src = os.path.realpath(path_name)
-        new_src = old_dest.replace(old_dir, new_dir, 1)
+        new_src = old_src.replace(old_dir, new_dir, 1)
         os.unlink(path_name)
         os.symlink(new_src, path_name)
 

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -351,6 +351,17 @@ def relocate_binary(path_names, old_dir, new_dir, allow_root):
         tty.die("Relocation not implemented for %s" % platform.system())
 
 
+def make_link_relative(cur_path_names, orig_path_names, old_dir):
+    """
+    Change links to be relative to old_dir
+    """
+    for cur_path, orig_path in zip(cur_path_names, orig_path_names):
+        old_src = os.path.realpath(orig_path)
+        new_src = os.path.relpath(old_src, orig_path)
+        os.unlink(cur_path)
+        os.symlink(new_src, cur_path)
+
+
 def make_binary_relative(cur_path_names, orig_path_names, old_dir, allow_root):
     """
     Replace old RPATHs with paths relative to old_dir in binary files
@@ -413,6 +424,17 @@ def make_binary_placeholder(cur_path_names, allow_root):
                         cur_path, spack.store.layout.root)
     else:
         tty.die("Placeholder not implemented for %s" % platform.system())
+
+
+def relocate_link(path_names, old_dir, new_dir):
+    """
+    Replace old path with new path in link sources
+    """
+    for path_name in path_names:
+        old_src = os.path.realpath(path_name)
+        new_src = old_dest.replace(old_dir, new_dir, 1)
+        os.unlink(path_name)
+        os.symlink(new_src, path_name)
 
 
 def relocate_text(path_names, old_dir, new_dir):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1054,6 +1054,8 @@ class Spec(object):
     def _add_dependency(self, spec, deptypes):
         """Called by the parser to add another spec as a dependency."""
         if spec.name in self._dependencies:
+            for dep in self.traverse(root=True):
+                print dep
             raise DuplicateDependencyError(
                 "Cannot depend on '%s' twice" % spec)
 
@@ -2780,7 +2782,8 @@ class Spec(object):
                 deptypes = deps
             self._dup_deps(other, deptypes, caches)
 
-        self._concrete = other._concrete
+        if hasattr(other, '_concrete'):
+            self._concrete = other._concrete
 
         if caches:
             self._hash = other._hash

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1054,8 +1054,6 @@ class Spec(object):
     def _add_dependency(self, spec, deptypes):
         """Called by the parser to add another spec as a dependency."""
         if spec.name in self._dependencies:
-            for dep in self.traverse(root=True):
-                print dep
             raise DuplicateDependencyError(
                 "Cannot depend on '%s' twice" % spec)
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2780,8 +2780,7 @@ class Spec(object):
                 deptypes = deps
             self._dup_deps(other, deptypes, caches)
 
-        if hasattr(other, '_concrete'):
-            self._concrete = other._concrete
+        self._concrete = other._concrete
 
         if caches:
             self._hash = other._hash

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -91,7 +91,6 @@ echo $PATH"""
 
     # Create the build cache  and
     # put it directly into the mirror
-
     mirror_path = os.path.join(str(tmpdir), 'test-mirror')
     spack.mirror.create(
         mirror_path, specs=[], no_checksum=True
@@ -104,6 +103,7 @@ echo $PATH"""
     stage = spack.stage.Stage(
         mirrors['spack-mirror-test'], name="build_cache", keep=True)
     stage.create()
+
     # setup argument parser
     parser = argparse.ArgumentParser()
     buildcache.setup_parser(parser)

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -233,7 +233,6 @@ echo $PATH"""
 
     # Remove cached binary specs since we deleted the mirror
     bindist._cached_specs = None
-    assert False
 
 
 def test_relocate_text(tmpdir):

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -123,6 +123,13 @@ echo $PATH"""
         # test overwrite install
         args = parser.parse_args(['install', '-f', str(pkghash)])
         buildcache.buildcache(parser, args)
+        files = os.listdir(spec.prefix)
+        assert 'link_to_dummy.txt' in files
+        assert 'dummy.txt' in files
+        assert os.path.realpath(
+            os.path.join(spec.prefix, 'link_to_dummy.txt')
+
+        ) == os.path.realpath(os.path.join(spec.prefix, 'dummy.txt'))
 
         # create build cache with relative path and signing
         args = parser.parse_args(
@@ -140,6 +147,13 @@ echo $PATH"""
         args = parser.parse_args(['install', '-f', str(pkghash)])
         buildcache.buildcache(parser, args)
 
+        assert 'link_to_dummy.txt' in files
+        assert 'dummy.txt' in files
+        assert os.path.realpath(
+            os.path.join(spec.prefix, 'link_to_dummy.txt')
+
+        ) == os.path.realpath(os.path.join(spec.prefix, 'dummy.txt'))
+
     else:
         # create build cache without signing
         args = parser.parse_args(
@@ -152,6 +166,13 @@ echo $PATH"""
         # install build cache without verification
         args = parser.parse_args(['install', '-u', str(spec)])
         buildcache.install_tarball(spec, args)
+
+        assert 'link_to_dummy.txt' in files
+        assert 'dummy.txt' in files
+        assert os.path.realpath(
+            os.path.join(spec.prefix, 'link_to_dummy.txt')
+
+        ) == os.path.realpath(os.path.join(spec.prefix, 'dummy.txt'))
 
         # test overwrite install without verification
         args = parser.parse_args(['install', '-f', '-u', str(pkghash)])
@@ -172,6 +193,13 @@ echo $PATH"""
         # test overwrite install
         args = parser.parse_args(['install', '-f', '-u', str(pkghash)])
         buildcache.buildcache(parser, args)
+
+        assert 'link_to_dummy.txt' in files
+        assert 'dummy.txt' in files
+        assert os.path.realpath(
+            os.path.join(spec.prefix, 'link_to_dummy.txt')
+
+        ) == os.path.realpath(os.path.join(spec.prefix, 'dummy.txt'))
 
     # Validate the relocation information
     buildinfo = bindist.read_buildinfo_file(spec.prefix)
@@ -205,6 +233,7 @@ echo $PATH"""
 
     # Remove cached binary specs since we deleted the mirror
     bindist._cached_specs = None
+    assert False
 
 
 def test_relocate_text(tmpdir):

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -147,6 +147,7 @@ echo $PATH"""
         args = parser.parse_args(['install', '-f', str(pkghash)])
         buildcache.buildcache(parser, args)
 
+        files = os.listdir(spec.prefix)
         assert 'link_to_dummy.txt' in files
         assert 'dummy.txt' in files
         assert os.path.realpath(
@@ -167,6 +168,7 @@ echo $PATH"""
         args = parser.parse_args(['install', '-u', str(spec)])
         buildcache.install_tarball(spec, args)
 
+        files = os.listdir(spec.prefix)
         assert 'link_to_dummy.txt' in files
         assert 'dummy.txt' in files
         assert os.path.realpath(
@@ -194,6 +196,7 @@ echo $PATH"""
         args = parser.parse_args(['install', '-f', '-u', str(pkghash)])
         buildcache.buildcache(parser, args)
 
+        files = os.listdir(spec.prefix)
         assert 'link_to_dummy.txt' in files
         assert 'dummy.txt' in files
         assert os.path.realpath(

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -123,12 +123,12 @@ echo $PATH"""
         # test overwrite install
         args = parser.parse_args(['install', '-f', str(pkghash)])
         buildcache.buildcache(parser, args)
+
         files = os.listdir(spec.prefix)
         assert 'link_to_dummy.txt' in files
         assert 'dummy.txt' in files
         assert os.path.realpath(
             os.path.join(spec.prefix, 'link_to_dummy.txt')
-
         ) == os.path.realpath(os.path.join(spec.prefix, 'dummy.txt'))
 
         # create build cache with relative path and signing
@@ -152,7 +152,6 @@ echo $PATH"""
         assert 'dummy.txt' in files
         assert os.path.realpath(
             os.path.join(spec.prefix, 'link_to_dummy.txt')
-
         ) == os.path.realpath(os.path.join(spec.prefix, 'dummy.txt'))
 
     else:
@@ -173,7 +172,6 @@ echo $PATH"""
         assert 'dummy.txt' in files
         assert os.path.realpath(
             os.path.join(spec.prefix, 'link_to_dummy.txt')
-
         ) == os.path.realpath(os.path.join(spec.prefix, 'dummy.txt'))
 
         # test overwrite install without verification
@@ -201,7 +199,6 @@ echo $PATH"""
         assert 'dummy.txt' in files
         assert os.path.realpath(
             os.path.join(spec.prefix, 'link_to_dummy.txt')
-
         ) == os.path.realpath(os.path.join(spec.prefix, 'dummy.txt'))
 
     # Validate the relocation information

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -25,7 +25,7 @@ from spack.fetch_strategy import URLFetchStrategy, FetchStrategyComposite
 from spack.util.executable import ProcessError
 from spack.relocate import needs_binary_relocation, needs_text_relocation
 from spack.relocate import strings_contains_installroot
-from spack.relocate import get_patchelf, relocate_text
+from spack.relocate import get_patchelf, relocate_text, relocate_link
 from spack.relocate import substitute_rpath, get_relative_rpaths
 from spack.relocate import macho_replace_paths, macho_make_paths_relative
 from spack.relocate import modify_macho_object, macho_get_paths
@@ -217,6 +217,18 @@ def test_relocate_text(tmpdir):
             for line in script:
                 assert(new_dir in line)
         assert(strings_contains_installroot(filename, old_dir) is False)
+
+
+def test_relocate_link(tmpdir):
+    with tmpdir.as_cwd():
+        old_dir = '/home/spack/opt/spack'
+        filename = 'link.ln'
+        old_src = os.path.join(old_dir, filename)
+        os.symlink(old_src, filename)
+        filenames = [filename]
+        new_dir = '/opt/rh/devtoolset/'
+        relocate_link(filenames, old_dir, new_dir)
+        assert os.path.realpath(filename) == os.path.join(new_dir, filename)
 
 
 def test_needs_relocation():


### PR DESCRIPTION
From #9747:

> Binary caches of packages with absolute symlinks had broken symlinks. From what I can tell, tar doesn't support any notion of matching source/destination roots when unpacking an archive with absolute symlinks. Therefore, this commit just makes a copy of any file that is a symlink while creating a binary cache of a package.

#9747 caused other binary relocation bugs and was reverted for v0.12.0. This is an alternative solution that avoids the bugs from #9747.

Instead of copying files for absolute symlinks, we relocate the source path of the symlink. This involves computing the new path, removing the link, and creating a new link with the new path.

@scottwittenburg @gartung @scheibelp @tgamblin 