### PR TITLE
Add patch to fix windows.h include in freetype

### DIFF
--- a/var/spack/repos/builtin/packages/freetype/package.py
+++ b/var/spack/repos/builtin/packages/freetype/package.py
@@ -24,6 +24,8 @@ class Freetype(AutotoolsPackage):
     depends_on('bzip2')
     depends_on('pkgconfig', type='build')
 
+    patch('windows.patch', when='@2.9.1')
+
     def configure_args(self):
         args = ['--with-harfbuzz=no']
         if self.spec.satisfies('@2.9.1:'):

--- a/var/spack/repos/builtin/packages/freetype/package.py
+++ b/var/spack/repos/builtin/packages/freetype/package.py
@@ -13,9 +13,9 @@ class Freetype(AutotoolsPackage):
     of most vector and bitmap font formats."""
 
     homepage = "https://www.freetype.org/index.html"
-    url      = "http://download.savannah.gnu.org/releases/freetype/freetype-2.7.1.tar.gz"
+    url      = "https://download.savannah.gnu.org/releases/freetype/freetype-2.9.1.tar.gz"
 
-    version('2.9.1', 'ec391504e55498adceb30baceebd147a6e963f636eb617424bcfc47a169898ce')
+    version('2.9.1', sha256='ec391504e55498adceb30baceebd147a6e963f636eb617424bcfc47a169898ce')
     version('2.7.1', '78701bee8d249578d83bb9a2f3aa3616')
     version('2.7',   '337139e5c7c5bd645fe130608e0fa8b5')
     version('2.5.3', 'cafe9f210e45360279c730d27bf071e9')

--- a/var/spack/repos/builtin/packages/freetype/windows.patch
+++ b/var/spack/repos/builtin/packages/freetype/windows.patch
@@ -1,36 +1,27 @@
---- a/builds/unix/configure	2018-05-01 16:34:47.000000000 -0500
-+++ b/builds/unix/configure	2018-12-10 23:15:30.000000000 -0600
-@@ -13268,32 +13268,7 @@
- _ACEOF
+https://github.com/spack/spack/issues/9729
+https://savannah.nongnu.org/bugs/index.php?54967
+http://git.savannah.gnu.org/cgit/freetype/freetype2.git/commit/?id=3b6e65f7bf674601b9419d02ce0aa633e2e882fb
+--- a/builds/unix/configure     2018-12-14 22:08:30.000000000 -0600
++++ b/builds/unix/configure     2018-12-14 22:07:56.000000000 -0600
+@@ -11853,7 +11853,9 @@
+ # Only expand once:
  
  
--  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for munmap's first parameter type" >&5
--$as_echo_n "checking for munmap's first parameter type... " >&6; }
--   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
--/* end confdefs.h.  */
--
--
--
--#include <unistd.h>
--#include <sys/mman.h>
--int munmap(void *, size_t);
--
--
--
--_ACEOF
--if ac_fn_c_try_compile "$LINENO"; then :
--  { $as_echo "$as_me:${as_lineno-$LINENO}: result: void *" >&5
--$as_echo "void *" >&6; }
--
--$as_echo "#define MUNMAP_USES_VOIDP /**/" >>confdefs.h
--
--else
--  { $as_echo "$as_me:${as_lineno-$LINENO}: result: char *" >&5
--$as_echo "char *" >&6; }
--fi
--rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
--
-+  FT_MUNMAP_PARAM
- fi
+-if test -n "$ac_tool_prefix"; then
++ac_fn_c_check_header_mongrel "$LINENO" "windows.h" "ac_cv_header_windows_h" "$ac_includes_default"
++if test "x$ac_cv_header_windows_h" = xyes; then :
++  if test -n "$ac_tool_prefix"; then
+   # Extract the first word of "${ac_tool_prefix}windres", so it can be a program name with args.
+ set dummy ${ac_tool_prefix}windres; ac_word=$2
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+@@ -12022,6 +12024,9 @@
+ CC=$lt_save_CC
+ CFLAGS=$lt_save_CFLAGS
+ 
++fi
++
++
  
  
+ # checks for native programs to generate building tool
+

--- a/var/spack/repos/builtin/packages/freetype/windows.patch
+++ b/var/spack/repos/builtin/packages/freetype/windows.patch
@@ -1,0 +1,36 @@
+--- a/builds/unix/configure	2018-05-01 16:34:47.000000000 -0500
++++ b/builds/unix/configure	2018-12-10 23:15:30.000000000 -0600
+@@ -13268,32 +13268,7 @@
+ _ACEOF
+ 
+ 
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for munmap's first parameter type" >&5
+-$as_echo_n "checking for munmap's first parameter type... " >&6; }
+-   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-
+-
+-
+-#include <unistd.h>
+-#include <sys/mman.h>
+-int munmap(void *, size_t);
+-
+-
+-
+-_ACEOF
+-if ac_fn_c_try_compile "$LINENO"; then :
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: void *" >&5
+-$as_echo "void *" >&6; }
+-
+-$as_echo "#define MUNMAP_USES_VOIDP /**/" >>confdefs.h
+-
+-else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: char *" >&5
+-$as_echo "char *" >&6; }
+-fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+-
++  FT_MUNMAP_PARAM
+ fi
+ 
+ 


### PR DESCRIPTION
Fixes #9729.

I took the patch from https://savannah.nongnu.org/bugs/index.php?54967, generated a new `configure` script, and produced a new patch of the relevant changes. This way, we don't need to add `m4`, `libtool`, `autoconf`, and `automake` dependencies needed by the previous patch.

With this patch, I was able to successfully install freetype with GCC 4.9.3 on Cray CNL5 (Blue Waters).

@jrood-nrel 