### PR TITLE
Fixes for Google Test

### DIFF
--- a/var/spack/repos/builtin/packages/googletest/package.py
+++ b/var/spack/repos/builtin/packages/googletest/package.py
@@ -11,9 +11,10 @@ class Googletest(CMakePackage):
     homepage = "https://github.com/google/googletest"
     url      = "https://github.com/google/googletest/tarball/release-1.7.0"
 
-    version('1.8.0', 'd2edffbe844902d942c31db70c7cfec2')
-    version('1.7.0', '5eaf03ed925a47b37c8e1d559eb19bc4')
-    version('1.6.0', '90407321648ab25b067fcd798caf8c78')
+    version('1.8.1', sha256='8e40a005e098b1ba917d64104549e3da274e31261dedc57d6250fe91391b2e84')
+    version('1.8.0', sha256='d8c33605d23d303b08a912eaee7f84c4e091d6e3d90e9a8ec8aaf7450dfe2568')
+    version('1.7.0', sha256='9639cf8b7f37a4d0c6575f52c01ef167c5f11faee65252296b3ffc2d9acd421b')
+    version('1.6.0', sha256='a61e20c65819eb39a2da85c88622bac703b865ca7fe2bfdcd3da734d87d5521a')
 
     variant('gmock', default=False, description='Build with gmock')
     conflicts('+gmock', when='@:1.7.0')


### PR DESCRIPTION
At some point Google moved Google Test to a new GitHub org called "Abseil" (See: https://www.github.com/abseil/googletest). This ended up breaking the tar ball hashes (though I'm honestly not sure why). I've fixed all the existing versions and added the newer release 1.8.1.

It would be nice if this change could be backported to v0.12 if at all possible (googletest installs basically fail right now without using `--no-checksum`), though I'm not totally clear what the philosophy around releases is for Spack.