### PR TITLE
gcc: fix sys_ustat.h patch for gcc 4.8 and 4.9

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -175,7 +175,8 @@ class Gcc(AutotoolsPackage):
     # https://bugs.busybox.net/show_bug.cgi?id=10061
     patch('signal.patch', when='@4.9,5.1:5.4')
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85835
-    patch('sys_ustat.h.patch', when='@4:6.4,7:7.3')
+    patch('sys_ustat.h.patch', when='@5.0:6.4,7.0:7.3,8.1')
+    patch('sys_ustat-4.9.patch', when='@4.9')
 
     build_directory = 'spack-build'
 

--- a/var/spack/repos/builtin/packages/gcc/sys_ustat-4.9.patch
+++ b/var/spack/repos/builtin/packages/gcc/sys_ustat-4.9.patch
@@ -1,0 +1,34 @@
+The sys_ustat.h patch modified for gcc 4.9.x.
+
+diff -Naurb gcc-4.9.4.orig/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cc gcc-4.9.4/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cc
+--- gcc-4.9.4.orig/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cc	2013-12-19 06:54:11.000000000 -0600
++++ gcc-4.9.4/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cc	2018-12-11 15:57:46.901800462 -0600
+@@ -81,7 +81,6 @@
+ #include <sys/statvfs.h>
+ #include <sys/timex.h>
+ #include <sys/user.h>
+-#include <sys/ustat.h>
+ #include <linux/cyclades.h>
+ #include <linux/if_eql.h>
+ #include <linux/if_plip.h>
+@@ -163,7 +162,19 @@
+   unsigned struct_old_utsname_sz = sizeof(struct old_utsname);
+   unsigned struct_oldold_utsname_sz = sizeof(struct oldold_utsname);
+   unsigned struct_itimerspec_sz = sizeof(struct itimerspec);
+-  unsigned struct_ustat_sz = sizeof(struct ustat);
++  // Use pre-computed size of struct ustat to avoid <sys/ustat.h> which
++  // has been removed from glibc 2.28.
++#if defined(__aarch64__) || defined(__s390x__) || defined (__mips64) \
++  || defined(__powerpc64__) || defined(__arch64__) || defined(__sparcv9) \
++  || defined(__x86_64__)
++#define SIZEOF_STRUCT_USTAT 32
++#elif defined(__arm__) || defined(__i386__) || defined(__mips__) \
++  || defined(__powerpc__) || defined(__s390__)
++#define SIZEOF_STRUCT_USTAT 20
++#else
++#error Unknown size of struct ustat
++#endif
++  unsigned struct_ustat_sz = SIZEOF_STRUCT_USTAT;
+ #endif // SANITIZER_LINUX
+ 
+ #if SANITIZER_LINUX && !SANITIZER_ANDROID


### PR DESCRIPTION
The sys_ustat.h.patch to file sanitizer_platform_limits_posix.cc from
PR #10046 does not apply cleanly to gcc 4.8 or 4.9 (or earlier).

GCC up to 4.8.x either don't have libsanitizer or else don't include
ustat.h in sanitizer_platform_limits_posix.cc.

GCC 4.9.x includes ustat.h, but needs a slightly different patch.

The patch applies to GCC 5.x up to 6.4, and 7.x up to 7.3 and also
8.1.0.

The patch is already included in the tar files for gcc 6.5.0, 7.4.0
and 8.2.0.

----------

It's quite the matrix for what versions of gcc will compile other
versions of gcc.  For example, I was able to use 4.4.7 to compile
4.8.5, but using 7.3.1 to compile the same 4.8.5 falls over.  Blech.
But that's a problem for another day.