### PR TITLE
Added RocksDB package

### DIFF
--- a/var/spack/repos/builtin/packages/rocksdb/package.py
+++ b/var/spack/repos/builtin/packages/rocksdb/package.py
@@ -29,12 +29,15 @@ class Rocksdb(MakefilePackage):
     """RocksDB: A Persistent Key-Value Store for Flash and RAM Storage"""
 
     homepage = "https://github.com/facebook/rocksdb"
-    url      = "https://github.com/facebook/rocksdb.git"
+    url      = 'https://github.com/facebook/rocksdb/archive/v5.17.2.tar.gz'
+    git      = 'https://github.com/facebook/rocksdb.git'
 
-    version('master', git=url, submodules=True)
-    version('v5.17.2', git=url, submodules=True)
-    version('v5.15.10', git=url, submodules=True, preferred=True)
-    version('v5.8.8', git=url, submodules=True)
+    version('develop', git=git, branch='master', submodules=True)
+    version('5.17.2',  sha256='101f05858650a810c90e4872338222a1a3bf3b24de7b7d74466814e6a95c2d28')
+    version('5.16.6',  sha256='f0739edce1707568bdfb36a77638fd5bae287ca21763ce3e56cf0bfae8fff033')
+    version('5.15.10', sha256='26d5d4259fa352ae1604b5b4d275f947cacc006f4f7d2ef0b815056601b807c0')
+
+
 
     variant('static', default=True, description='Build static library')
     variant('zlib', default=True, description='Enable zlib compression support')
@@ -49,7 +52,7 @@ class Rocksdb(MakefilePackage):
     depends_on('zstd', when='+zstd')
     depends_on('gflags')
 
-    def setup_environment(self, spack_env, run_env):
+    def build(self, spec, prefix):
         cflags = []
         ldflags = []
 
@@ -67,11 +70,9 @@ class Rocksdb(MakefilePackage):
         cflags.append(self.spec['gflags'].headers.cpp_flags)
         ldflags.append(self.spec['gflags'].libs.ld_flags)
             
-        spack_env.append_flags('CFLAGS',' '.join(cflags))
-        spack_env.append_flags('PLATFORM_FLAGS',' '.join(ldflags))
-        spack_env.append_flags('INSTALL_PATH', self.spec.prefix)
-    
-    def build(self, spec, prefix):
+        env['CFLAGS'] = ' '.join(cflags)
+        env['PLATFORM_FLAGS'] = ' '.join(ldflags)
+        env['INSTALL_PATH'] = self.spec.prefix
         build_type = ''
         if '+static' in spec: 
             build_type = 'install-static'

--- a/var/spack/repos/builtin/packages/rocksdb/package.py
+++ b/var/spack/repos/builtin/packages/rocksdb/package.py
@@ -1,0 +1,84 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+import os
+
+class Rocksdb(MakefilePackage):
+    """RocksDB: A Persistent Key-Value Store for Flash and RAM Storage"""
+
+    homepage = "https://github.com/facebook/rocksdb"
+    url      = "https://github.com/facebook/rocksdb.git"
+
+    version('master', git=url, submodules=True)
+    version('v5.17.2', git=url, submodules=True)
+    version('v5.15.10', git=url, submodules=True, preferred=True)
+    version('v5.8.8', git=url, submodules=True)
+
+    variant('static', default=True, description='Build static library')
+    variant('zlib', default=True, description='Enable zlib compression support')
+    variant('bz2', default=False, description='Enable bz2 compression support')
+    variant('lz4', default=True, description='Enable lz4 compression support')
+    variant('snappy', default=False, description='Enable snappy compression support')
+    variant('zstd', default=False, description='Enable zstandard compression support')
+    depends_on('zlib', when='+zlib')
+    depends_on('bzip2', when='+bzip2')
+    depends_on('lz4', when='+lz4')
+    depends_on('snappy', when='+snappy')
+    depends_on('zstd', when='+zstd')
+    depends_on('gflags')
+
+    def setup_environment(self, spack_env, run_env):
+        cflags = []
+        ldflags = []
+
+        if '+zlib' in self.spec:
+            cflags.append('-I' + self.spec['zlib'].prefix.include)
+            ldflags.append(self.spec['zlib'].libs.ld_flags)
+        if '+bz2' in self.spec:
+            cflags.append('-I' + self.spec['bz2'].prefix.include)
+            ldflags.append(self.spec['bz2'].libs.ld_flags)
+        for pkg in ['lz4', 'snappy', 'zstd']: 
+            if '+' + pkg in self.spec:
+                cflags.append(self.spec[pkg].headers.cpp_flags)
+                ldflags.append(self.spec[pkg].libs.ld_flags)
+        
+        cflags.append(self.spec['gflags'].headers.cpp_flags)
+        ldflags.append(self.spec['gflags'].libs.ld_flags)
+            
+        spack_env.append_flags('CFLAGS',' '.join(cflags))
+        spack_env.append_flags('PLATFORM_FLAGS',' '.join(ldflags))
+        spack_env.append_flags('INSTALL_PATH', self.spec.prefix)
+    
+    def build(self, spec, prefix):
+        build_type = ''
+        if '+static' in spec: 
+            build_type = 'install-static'
+        else:
+            build_type = 'install-shared'
+        make(build_type)
+
+
+    def install(self, spec, prefix):
+        pass

--- a/var/spack/repos/builtin/packages/rocksdb/package.py
+++ b/var/spack/repos/builtin/packages/rocksdb/package.py
@@ -57,6 +57,5 @@ class Rocksdb(MakefilePackage):
         env['PLATFORM_FLAGS'] = ' '.join(ldflags)
         env['INSTALL_PATH'] = self.spec.prefix
 
-        build_type = 'install-static' if '+static' in spec else 'install-shared'
-        make(build_type)
-
+        buildtype = 'install-static' if '+static' in spec else 'install-shared'
+        make(buildtype)

--- a/var/spack/repos/builtin/packages/rocksdb/package.py
+++ b/var/spack/repos/builtin/packages/rocksdb/package.py
@@ -1,27 +1,8 @@
-##############################################################################
-# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
-# This file is part of Spack.
-# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
-# LLNL-CODE-647188
-#
-# For details, see https://github.com/spack/spack
-# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License (as
-# published by the Free Software Foundation) version 2.1, February 1999.
-#
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
-# conditions of the GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public
-# License along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-##############################################################################
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 from spack import *
 
 
@@ -51,7 +32,9 @@ class Rocksdb(MakefilePackage):
     depends_on('zlib', when='+zlib')
     depends_on('zstd', when='+zstd')
 
-    def build(self, spec, prefix):
+    phases = ['install']
+
+    def install(self, spec, prefix):
         cflags = []
         ldflags = []
 
@@ -77,5 +60,3 @@ class Rocksdb(MakefilePackage):
         build_type = 'install-static' if '+static' in spec else 'install-shared'
         make(build_type)
 
-    def install(self, spec, prefix):
-        pass


### PR DESCRIPTION
This is a spack package for RocksDB, a persistent key-value store for flash and RAM storage. We use the recommended Makefile build process and added variants for all the optional compression library dependencies.

Here's the project repo: https://github.com/facebook/rocksdb/
And here are their build instructions: https://github.com/facebook/rocksdb/blob/master/INSTALL.md