### PR TITLE
libmesh: tweaked debug option behavior

### DIFF
--- a/var/spack/repos/builtin/packages/libmesh/package.py
+++ b/var/spack/repos/builtin/packages/libmesh/package.py
@@ -180,7 +180,7 @@ class Libmesh(AutotoolsPackage):
 
         # and, finally, other things:
         if '+debug' in self.spec:
-            options.append('--with-methods=dbg')
+            options.append('--with-methods="dbg opt"')
         else:
             options.append('--with-methods=opt')
 


### PR DESCRIPTION
The +debug option should build both the _opt and _dbg libraries. Current behavior is to build _dbg libraries *instead* of _opt when +debug is toggled. Having both provides the option to link against either to turn on/off debug information.

@drwells Do you agree with this? You originally added the +debug option.