### PR TITLE
Updated the Travis environment to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ jobs:
       env: TEST_SUITE=flake8
     - stage: 'unit tests + documentation'
       python: '2.6'
+      dist: trusty
       sudo: required
       os: linux
       language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,7 @@ branches:
 # Build matrix
 #=============================================================================
 
-# Adding the keyword dist to permit an `allow_failures` section
-# under `matrix.include`. More information here:
-#
-# https://docs.travis-ci.com/user/customizing-the-build/#Rows-that-are-Allowed-to-Fail
-dist: trusty
+dist: xenial
 
 jobs:
   fast_finish: true
@@ -56,7 +52,6 @@ jobs:
     - python: '3.7'
       sudo: required
       os: linux
-      dist: xenial
       language: python
       env: TEST_SUITE=unit
     - python: '3.6'
@@ -114,10 +109,7 @@ jobs:
       language: generic
       env: TEST_SUITE=docker
   allow_failures:
-    - dist: xenial
     - env: TEST_SUITE=docker
-    # temporary Python 2.6 exception while we figure out why Travis is hanging
-    - python: '2.6'
 
 stages:
   - 'style checks'


### PR DESCRIPTION
closes #9947 
closes #9815

According to this [post](https://blog.travis-ci.com/2018-11-08-xenial-release) `xenial` has been officially released on Travis since a month or so. This PR moves all the CI tests to `xenial` and removes allowed failures for it and python 2.6.