### PR TITLE
trf: add version 4.07b and install fixes

### DIFF
--- a/var/spack/repos/builtin/packages/trf/package.py
+++ b/var/spack/repos/builtin/packages/trf/package.py
@@ -26,8 +26,10 @@ class Trf(Package):
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
-        trfname = 'trf{}.linux64'.format(str(spec.version).replace('.',''))
+
+        trfname = 'trf{0}.linux64'.format(self.version.joined)
+
         install(trfname, prefix.bin)
         chmod = which('chmod')
         chmod('+x', os.path.join(prefix.bin, trfname))
-        os.symlink(trfname, os.path.join(prefix.bin, 'trf'))
+        os.symlink(trfname, prefix.bin.trf)

--- a/var/spack/repos/builtin/packages/trf/package.py
+++ b/var/spack/repos/builtin/packages/trf/package.py
@@ -21,9 +21,13 @@ class Trf(Package):
 
     version('4.09', '0c594fe666e0332db1df9d160d7fabc8', expand=False,
             url='file://{0}/trf409.linux64'.format(os.getcwd()))
+    version('4.07b', sha256='a3a760c7b74c9603fbc08d95e8fa696c00f35a2f179b0bd63b2b13757ad3b471', expand=False,
+            url='file://{0}/trf407b.linux64'.format(os.getcwd()))
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
-        install('trf409.linux64', prefix.bin.trf)
+        trfname = 'trf{}.linux64'.format(str(spec.version).replace('.',''))
+        install(trfname, prefix.bin)
         chmod = which('chmod')
-        chmod('+x', prefix.bin.trf)
+        chmod('+x', os.path.join(prefix.bin, trfname))
+        os.symlink(trfname, os.path.join(prefix.bin, 'trf'))


### PR DESCRIPTION
Changes to the installation method are to persist the original filename (a requirement for us) and provide a symlink named trf to maintain backwards compatibility. 