### PR TITLE
Fix spack package inheritance for module variables

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -650,6 +650,9 @@ def setup_package(pkg, dirty):
         dpkg.setup_dependent_package(pkg.module, spec)
         dpkg.setup_dependent_environment(spack_env, run_env, spec)
 
+    parent_modules = parent_class_modules(pkg.__class__)
+    for mod in parent_modules:
+        set_module_variables_for_package(pkg, mod)
     set_module_variables_for_package(pkg, pkg.module)
     pkg.setup_environment(spack_env, run_env)
 

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -382,7 +382,9 @@ def set_module_variables_for_package(pkg):
     modules = parent_class_modules(pkg.__class__)
     for mod in modules:
         # number of jobs spack will build with.
-        jobs = spack.config.get('config:build_jobs') or multiprocessing.cpu_count()
+        jobs = spack.config.get('config:build_jobs')
+        if not jobs:
+            jobs = multiprocessing.cpu_count()
         if not pkg.parallel:
             jobs = 1
         elif pkg.make_jobs:
@@ -409,8 +411,10 @@ def set_module_variables_for_package(pkg):
         m.ctest = MakeExecutable('ctest', jobs)
 
         # Standard CMake arguments
-        m.std_cmake_args = spack.build_systems.cmake.CMakePackage._std_args(pkg)
-        m.std_meson_args = spack.build_systems.meson.MesonPackage._std_args(pkg)
+        m.std_cmake_args = spack.build_systems.cmake.CMakePackage._std_args(
+            pkg)
+        m.std_meson_args = spack.build_systems.meson.MesonPackage._std_args(
+            pkg)
 
         # Put spack compiler paths in module scope.
         link_dir = spack.paths.build_env_path

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -515,22 +515,13 @@ class BaseContext(tengine.Context):
         # before asking for package-specific modifications
         for item in dependencies(self.spec, 'all'):
             package = self.spec[item.name].package
-            modules = build_environment.parent_class_modules(package.__class__)
-            for mod in modules:
-                build_environment.set_module_variables_for_package(
-                    package, mod
-                )
-            build_environment.set_module_variables_for_package(
-                package, package.module
-            )
+            build_environment.set_module_variables_for_package(package)
             package.setup_dependent_package(
                 self.spec.package.module, self.spec
             )
             package.setup_dependent_environment(_, env, self.spec)
         # Package specific modifications
-        build_environment.set_module_variables_for_package(
-            self.spec.package, self.spec.package.module
-        )
+        build_environment.set_module_variables_for_package(self.spec.package)
         self.spec.package.setup_environment(_, env)
 
         # Modifications required from modules.yaml

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -218,7 +218,7 @@ def test_spack_paths_before_module_paths(config, mock_packages, monkeypatch):
 
 
 def test_package_inheritance_module_setup(config, mock_packages):
-    s = spack.spec.Spec('simple-inheritance')
+    s = spack.spec.Spec('multimodule-inheritance')
     s.concretize()
     pkg = s.package
 

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -215,3 +215,18 @@ def test_spack_paths_before_module_paths(config, mock_packages, monkeypatch):
     paths = os.environ['PATH'].split(':')
 
     assert paths.index(spack_path) < paths.index(module_path)
+
+
+def test_package_inheritance_module_setup(config, mock_packages):
+    s = spack.spec.Spec('simple-inheritance')
+    s.concretize()
+    pkg = s.package
+
+    spack.build_environment.setup_package(pkg, False)
+
+    os.environ['TEST_MODULE_VAR'] = 'failed'
+
+    assert pkg.use_module_variable() == 'test_module_variable'
+    assert os.environ['TEST_MODULE_VAR'] == 'test_module_variable'
+
+    os.environ.pop('TEST_MODULE_VAR')

--- a/var/spack/repos/builtin.mock/packages/multimodule-inheritance/package.py
+++ b/var/spack/repos/builtin.mock/packages/multimodule-inheritance/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import spack.pkg.builtin.mock.simple_inheritance as si
+
+class MultimoduleInheritance(si.BaseWithDirectives):
+    """Simple package which inherits a method and several directives"""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/multimodule-1.0.tar.gz"
+
+    version('1.0', '0123456789abcdef0123456789abcdef')
+
+    depends_on('openblas', when='+openblas')
+
+    def install(self, spec, prefix):
+        pass

--- a/var/spack/repos/builtin.mock/packages/multimodule-inheritance/package.py
+++ b/var/spack/repos/builtin.mock/packages/multimodule-inheritance/package.py
@@ -5,6 +5,7 @@
 
 import spack.pkg.builtin.mock.simple_inheritance as si
 
+
 class MultimoduleInheritance(si.BaseWithDirectives):
     """Simple package which inherits a method and several directives"""
 

--- a/var/spack/repos/builtin.mock/packages/simple-inheritance/package.py
+++ b/var/spack/repos/builtin.mock/packages/simple-inheritance/package.py
@@ -19,6 +19,7 @@ class BaseWithDirectives(Package):
         env['TEST_MODULE_VAR'] = 'test_module_variable'
         return env['TEST_MODULE_VAR']
 
+
 class SimpleInheritance(BaseWithDirectives):
     """Simple package which acts as a build dependency"""
 

--- a/var/spack/repos/builtin.mock/packages/simple-inheritance/package.py
+++ b/var/spack/repos/builtin.mock/packages/simple-inheritance/package.py
@@ -13,6 +13,11 @@ class BaseWithDirectives(Package):
     variant('openblas', description='Activates openblas', default=True)
     provides('service1')
 
+    def use_module_variable(self):
+        """Must be called in build environment. Allows us to test parent class
+         using module variables set up by build_environment."""
+        env['TEST_MODULE_VAR'] = 'test_module_variable'
+        return env['TEST_MODULE_VAR']
 
 class SimpleInheritance(BaseWithDirectives):
     """Simple package which acts as a build dependency"""


### PR DESCRIPTION
Previously, module variables set by the Spack build environment were not available for parent classes when using inheritance to create packages. This was fixed for dependencies previously, but not for the top level package.

More specifically what failed prior to this PR: a Spack package were declared `class Foo(Bar)`, where `Bar` is another Spack package. When `Foo.func()` was called, if `func` is a method defined on `Bar` and inherited by `Foo` that requires module variables from the build environment (like `env['CFLAGS'] = 'baz'`), then Spack would fail with a `NameError`.

This is resolved by this PR, and a regression test is added.