### PR TITLE
Add latest version of libatomic-ops

### DIFF
--- a/var/spack/repos/builtin/packages/libatomic-ops/package.py
+++ b/var/spack/repos/builtin/packages/libatomic-ops/package.py
@@ -10,9 +10,10 @@ class LibatomicOps(AutotoolsPackage):
     """This package provides semi-portable access to hardware-provided
     atomic memory update operations on a number architectures."""
 
-    homepage = "https://github.com/ivmai/libatomic_ops"
-    url      = "http://www.hboehm.info/gc/gc_source/libatomic_ops-7.4.4.tar.gz"
+    homepage = "https://www.hboehm.info/gc/"
+    url      = "https://www.hboehm.info/gc/gc_source/libatomic_ops-7.6.6.tar.gz"
 
+    version('7.6.6', sha256='99feabc5f54877f314db4fadeb109f0b3e1d1a54afb6b4b3dfba1e707e38e074')
     version('7.4.4', '426d804baae12c372967a6d183e25af2')
 
     def configure_args(self):


### PR DESCRIPTION
Successfully builds and passes all tests on macOS 10.14.2 with Clang 10.0.0.