### PR TITLE
Add latest version of bdw-gc

### DIFF
--- a/var/spack/repos/builtin/packages/bdw-gc/package.py
+++ b/var/spack/repos/builtin/packages/bdw-gc/package.py
@@ -10,9 +10,10 @@ class BdwGc(AutotoolsPackage):
     """The Boehm-Demers-Weiser conservative garbage collector is a garbage
     collecting replacement for C malloc or C++ new."""
 
-    homepage = "http://www.hboehm.info/gc/"
-    url      = "http://www.hboehm.info/gc/gc_source/gc-7.6.0.tar.gz"
+    homepage = "https://www.hboehm.info/gc/"
+    url      = "https://www.hboehm.info/gc/gc_source/gc-8.0.0.tar.gz"
 
+    version('8.0.0', sha256='8f23f9a20883d00af2bff122249807e645bdf386de0de8cbd6cce3e0c6968f04')
     version('7.6.0', 'bf46ccbdaccfa3186c2ab87191c8855a')
     version('7.4.4', '96d18b0448a841c88d56e4ab3d180297')
 
@@ -25,6 +26,7 @@ class BdwGc(AutotoolsPackage):
         spec = self.spec
 
         config_args = [
+            '--enable-static',
             '--with-libatomic-ops={0}'.format(
                 'yes' if '+libatomic-ops' in spec else 'no')
         ]


### PR DESCRIPTION
Successfully builds and passes all tests on macOS 10.14.2 with Clang 10.0.0.