### PR TITLE
Add latest version of cairo

### DIFF
--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -9,9 +9,11 @@ from spack import *
 class Cairo(AutotoolsPackage):
     """Cairo is a 2D graphics library with support for multiple output
     devices."""
-    homepage = "http://cairographics.org"
-    url      = "http://cairographics.org/releases/cairo-1.14.8.tar.xz"
 
+    homepage = "http://cairographics.org"
+    url      = "http://cairographics.org/releases/cairo-1.16.0.tar.xz"
+
+    version('1.16.0', sha256='5e7b29b3f113ef870d1e3ecf8adf21f923396401604bda16d44be45e66052331')
     version('1.14.12', '490025a0ba0622a853010f49fb6343f29fb70b9b')
     version('1.14.8', 'c6f7b99986f93c9df78653c3e6a3b5043f65145e')
     version('1.14.0', '53cf589b983412ea7f78feee2e1ba9cea6e3ebae')


### PR DESCRIPTION
Successfully builds on macOS 10.14.2 with Clang 10.0.0.