### PR TITLE
Turn on verbose output for MPICH builds in Travis

### DIFF
--- a/share/spack/qa/run-build-tests
+++ b/share/spack/qa/run-build-tests
@@ -33,8 +33,12 @@ if [ -z "$SPEC" ]; then
     exit 1
 fi
 
+if [ "${SPEC}" = "mpich" ] ; then
+    OPTIONS="-v"
+fi
+
 # Print compiler information
 spack config get compilers
 
 # Run some build smoke tests, potentially with code coverage
-${coverage_run} bin/spack install ${SPEC}
+${coverage_run} bin/spack install ${OPTIONS} ${SPEC}


### PR DESCRIPTION
Lately many CI runs for PRs are failing due to the `mpich` build that times out on Travis (10 mins. without output). As the timeout seems to happen consistently during the build phase, increasing the verbosity of that test can help working around the issue.

