### PR TITLE
clp: add build_directory, remove old hack

### DIFF
--- a/var/spack/repos/builtin/packages/clp/package.py
+++ b/var/spack/repos/builtin/packages/clp/package.py
@@ -15,4 +15,4 @@ class Clp(AutotoolsPackage):
 
     version('1.16.11', sha256='b525451423a9a09a043e6a13d9436e13e3ee7a7049f558ad41a110742fa65f39')
 
-    build_directory = '.'
+    build_directory = 'spack-build'

--- a/var/spack/repos/builtin/packages/clp/package.py
+++ b/var/spack/repos/builtin/packages/clp/package.py
@@ -15,7 +15,4 @@ class Clp(AutotoolsPackage):
 
     version('1.16.11', sha256='b525451423a9a09a043e6a13d9436e13e3ee7a7049f558ad41a110742fa65f39')
 
-    def configure_args(self):
-        return [
-            '--with-clp-datadir={0}/Data'.format(self.build_directory),
-        ]
+    build_directory = '.'


### PR DESCRIPTION
#10109 seemed to fix the build at first but later stopped working. I suspect this may be a bug in spack but adding build_directory has worked for another package `time` with the same issue.