### PR TITLE
spack buildcache: --allow_root -> --allow-root

### DIFF
--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -31,7 +31,7 @@ def setup_parser(subparser):
     create.add_argument('-u', '--unsigned', action='store_true',
                         help="create unsigned buildcache" +
                              " tarballs for testing")
-    create.add_argument('-a', '--allow_root', action='store_true',
+    create.add_argument('-a', '--allow-root', action='store_true',
                         help="allow install root string in binary files " +
                              "after RPATH substitution")
     create.add_argument('-k', '--key', metavar='key',
@@ -50,7 +50,7 @@ def setup_parser(subparser):
                          help="overwrite install directory if it exists.")
     install.add_argument('-m', '--multiple', action='store_true',
                          help="allow all matching packages ")
-    install.add_argument('-a', '--allow_root', action='store_true',
+    install.add_argument('-a', '--allow-root', action='store_true',
                          help="allow install root string in binary files " +
                               "after RPATH substitution")
     install.add_argument('-u', '--unsigned', action='store_true',


### PR DESCRIPTION
This specific flag for this specific command is the only one in Spack containing underscores. Since every Unix command I know of uses [dashes](https://stackoverflow.com/q/1253679/5828163), I switched it to dashes for conformity. No changes are needed for the Bash completion script, as the script already thinks it is `--all-root`.