### PR TITLE
spack pkg add: add help message

### DIFF
--- a/lib/spack/spack/cmd/pkg.py
+++ b/lib/spack/spack/cmd/pkg.py
@@ -71,6 +71,7 @@ def list_packages(rev):
 
 
 def pkg_add(args):
+    """Add a package to the git stage."""
     for pkg_name in args.packages:
         filename = spack.repo.path.filename_for_package_name(pkg_name)
         if not os.path.isfile(filename):


### PR DESCRIPTION
### Before

```console
$ spack pkg --help
usage: spack pkg [-h] SUBCOMMAND ...

query packages associated with particular git revisions

positional arguments:
  SUBCOMMAND
    add
    list      List packages associated with a particular spack git revision.
    diff      Compare packages available in two different git revisions.
    added     Show packages added since a commit.
    removed   Show packages removed since a commit.

optional arguments:
  -h, --help  show this help message and exit
```

### After

```console
$ spack pkg --help
usage: spack pkg [-h] SUBCOMMAND ...

query packages associated with particular git revisions

positional arguments:
  SUBCOMMAND
    add       Add a package to the git stage.
    list      List packages associated with a particular spack git revision.
    diff      Compare packages available in two different git revisions.
    added     Show packages added since a commit.
    removed   Show packages removed since a commit.

optional arguments:
  -h, --help  show this help message and exit
```
I had no idea this command existed. This is awesome!