### PR TITLE
Store ccache directory explicitly in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -143,6 +143,8 @@ addons:
       - perl
       - perl-base
 
+# ~/.ccache needs to be cached directly as Travis is not taking care of it
+# (possibly because we use 'language: python' and not 'language: c')
 cache:
   pip: true
   ccache: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -148,6 +148,7 @@ cache:
   ccache: true
   directories:
     - ~/.mirror
+    - ~/.ccache
 
 # Work around Travis's lack of support for Python on OSX
 before_install:


### PR DESCRIPTION
Despite we started using `ccache` on `develop`, it seems the cache itself is not stored from one CI build to the next. This might be due to the fact that our language on Travis is Python and not C nor C++.

Hence here we store the `ccache` directory explicitly.