### PR TITLE
Add latest version of libbsd

### DIFF
--- a/var/spack/repos/builtin/packages/libbsd/package.py
+++ b/var/spack/repos/builtin/packages/libbsd/package.py
@@ -14,8 +14,9 @@ class Libbsd(AutotoolsPackage):
     """
 
     homepage = "https://libbsd.freedesktop.org/wiki/"
-    url      = "https://libbsd.freedesktop.org/releases/libbsd-0.8.6.tar.xz"
+    url      = "https://libbsd.freedesktop.org/releases/libbsd-0.9.1.tar.xz"
 
+    version('0.9.1', sha256='56d835742327d69faccd16955a60b6dcf30684a8da518c4eca0ac713b9e0a7a4')
     version('0.8.6', '4ab7bec639af17d0aacb50222b479110')
 
     patch('cdefs.h.patch', when='%gcc@:4')


### PR DESCRIPTION
Successfully builds and passes all unit tests on Cray CNL5 (Blue Waters) with GCC 7.3.0.