### PR TITLE
Add missing libbsd dependency to libxdmcp

### DIFF
--- a/var/spack/repos/builtin/packages/libxdmcp/package.py
+++ b/var/spack/repos/builtin/packages/libxdmcp/package.py
@@ -17,3 +17,4 @@ class Libxdmcp(AutotoolsPackage):
     depends_on('xproto', type='build')
     depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
+    depends_on('libbsd')


### PR DESCRIPTION
### Before

```
4 errors found in build log:
     163      CC       Key.lo
     164      CC       Read.lo
     165      CC       Unwrap.lo
     166      CC       Wrap.lo
     167      CC       Write.lo
     168      CC       Wraphelp.lo
  >> 169    Key.c:36:10: fatal error: bsd/stdlib.h: No such file or directory
     170     #include <bsd/stdlib.h> /* for arc4random_buf() */
     171              ^~~~~~~~~~~~~~
     172    compilation terminated.
  >> 173    make[2]: *** [Key.lo] Error 1
     174    make[2]: *** Waiting for unfinished jobs....
     175    make[2]: Leaving directory `/mnt/c/scratch/sciteam/stewart1/spack-stage/spack-stage-392119gc/libXdmcp-1.1.2'
  >> 176    make[1]: *** [all-recursive] Error 1
     177    make[1]: Leaving directory `/mnt/c/scratch/sciteam/stewart1/spack-stage/spack-stage-392119gc/libXdmcp-1.1.2'
  >> 178    make: *** [all] Error 2
```

### After

```
$ ldd -r ~/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/libxdmcp-1.1.2-7himptjvbwcqej32qgrxlamssvzteiny/lib/libXdmcp.so
	linux-vdso.so.1 =>  (0x00002aaaaaaab000)
	libbsd.so.0 => /mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/libbsd-0.9.1-a5womix7sgzat5etdlaoabpne7o5l3cl/lib/libbsd.so.0 (0x00002aaaaacb4000)
	libpthread.so.0 => /lib/../lib64/libpthread.so.0 (0x00002aaaaaecb000)
	libc.so.6 => /lib/../lib64/libc.so.6 (0x00002aaaab0e9000)
	librt.so.1 => /lib64/librt.so.1 (0x00002aaaab4fc000)
	librca.so.0 => /opt/cray/rca/default/lib64/librca.so.0 (0x00002aaaab706000)
	/lib64/ld-linux-x86-64.so.2 (0x0000555555554000)
```