### PR TITLE
Add latest version of ghostscript

### DIFF
--- a/var/spack/repos/builtin/packages/ghostscript/package.py
+++ b/var/spack/repos/builtin/packages/ghostscript/package.py
@@ -11,8 +11,9 @@ class Ghostscript(AutotoolsPackage):
     """An interpreter for the PostScript language and for PDF."""
 
     homepage = "http://ghostscript.com/"
-    url = "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs921/ghostscript-9.21.tar.gz"
+    url = "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs926/ghostscript-9.26.tar.gz"
 
+    version('9.26', sha256='831fc019bd477f7cc2d481dc5395ebfa4a593a95eb2fe1eb231a97e450d7540d')
     version('9.21', '5f213281761d2750fcf27476c404d17f')
     version('9.18', '33a47567d7a591c00a253caddd12a88a')
 
@@ -25,6 +26,7 @@ class Ghostscript(AutotoolsPackage):
     depends_on('libtiff')
     depends_on('zlib')
     depends_on('libxext')
+    depends_on('gtkplus')
 
     def url_for_version(self, version):
         baseurl = "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs{0}/ghostscript-{1}.tar.gz"


### PR DESCRIPTION
Also adds missing GTK+ dependency.

### Before

```
4 errors found in build log:
     4645       /bin/sh <./soobj/ldt.tr
     4646    make[2]: Leaving directory `/mnt/c/scratch/sciteam/stewart1/spack-stage/spack-stage-6gi4ajdt/ghostscript-9.21'
     4647    make -f Makefile DISPLAY_DEV=./soobj/display.dev STDIO_IMPLEMENTATION=c BUILDDIRPREFIX=so GENOPT='' LDFLAGS=' '\
     4648        CFLAGS='-fPIC  -O2 -Wall -Wstrict-prototypes -Wundef -Wmissing-declarations -Wmissing-prototypes -Wwrite-strings -Wno-strict-aliasing -Werror=declaration-after-statement -fno-builtin -fno-common -Werror=return-type -DHAVE_STDINT_H=1 -DHAVE_DIRENT_H=1 -DHAVE_SYS_DIR_H=1 -DHAVE_SYS_TIME_H=1 -DHAVE_SYS_TIMES_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_LIBDL=1 -DGX_COLOR_INDEX_TYPE="unsigned long long" -D__USE_UNIX98=1   -I/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/libtiff-4.0.9-blyinx3drvmz3mwlkx6gvmu6gipzhjaz/include  -DGS_DEVS_SHARED -DGS_DEVS_SHARED_DIR=\"/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/ghostscript-9.21-rytylslut6ql6ortwwsqktdcufqq5hpl/lib/ghostscript/9.21\" ' prefix=/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/ghostscript-9.21-rytylslut6ql6ortwwsqktdcufqq5hpl\
     4649        ./sobin/gsc ./sobin/gsx -so-loader -so-loader -so-loader
     4650    make[2]: Entering directory `/mnt/c/scratch/sciteam/stewart1/spack-stage/spack-stage-6gi4ajdt/ghostscript-9.21'
  >> 4651    /mnt/a/u/sciteam/stewart1/spack/var/spack/stage/ghostscript-9.21-rytylslut6ql6ortwwsqktdcufqq5hpl/ghostscript-9.21/psi/dxmain.c:35:10: fatal error: gtk/gtk.h: No such file or directory
     4652     #include <gtk/gtk.h>
     4653              ^~~~~~~~~~~
     4654    compilation terminated.
  >> 4655    make[2]: *** [sobin/gsx] Error 1
     4656    make[2]: *** Waiting for unfinished jobs....
     4657    make[2]: Leaving directory `/mnt/c/scratch/sciteam/stewart1/spack-stage/spack-stage-6gi4ajdt/ghostscript-9.21'
  >> 4658    make[1]: *** [so-subtarget] Error 2
     4659    make[1]: Leaving directory `/mnt/c/scratch/sciteam/stewart1/spack-stage/spack-stage-6gi4ajdt/ghostscript-9.21'
  >> 4660    make: *** [so] Error 2
```

### After

Still trying to get GTK+ to build to confirm this fix.