### PR TITLE
Add missing gettext dependency to at-spi2-core

### DIFF
--- a/var/spack/repos/builtin/packages/at-spi2-core/package.py
+++ b/var/spack/repos/builtin/packages/at-spi2-core/package.py
@@ -20,6 +20,7 @@ class AtSpi2Core(MesonPackage):
 
     depends_on('glib@2.56.1:')
     depends_on('dbus@1.12.8:')
+    depends_on('gettext')
     depends_on('libx11')
     depends_on('libxi')
     depends_on('libxtst', type='build')


### PR DESCRIPTION
### Before

```
6 errors found in build log:
     225    [46/53] /mnt/a/u/sciteam/stewart1/spack/lib/spack/env/gcc/gcc -Iatspi/f291f98@@atspi@sha -Iatspi -I../atspi -I. -I../ -Iregistryd -I../registryd -I/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/dbus-1.12.8-m6jcirtiqk3gha3padz5e5c6etlpfqgm/include/dbus-1.0 -I/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/dbus-1.12.8-m6jcirtiqk3gha3padz5e5c6etlpfqgm/lib/dbus-1.0/include -I/mnt/bwpy/single/usr/include/glib-2.0 -I/mnt/bwpy/single/usr/lib/glib-2.0/include -I/mnt/bwpy/single/usr/include -I/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/libx11-1.6.5-pmbsh6qks353k7ldwkcjzy3ox3k3wdfh/include -I/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/xproto-7.0.31-56jxwgqslxtjejkghfpjkzkmtzfwktnx/include -I/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/libxau-1.0.8-lvi5jkfa2o2e4zj6gzrxrs4j65gflewj/include -I/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/libxtst-1.2.2-pry5nwwz4ocgevpiiu5if52jsinsopbv/include -I/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/recordproto-1.14.2-nn2vcxyl6ivkvb743nwhez3mr74tnhbq/include -I/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/xextproto-7.3.0-367tgxmpqlwxro2kvgofd6uogpujcwx2/include -I/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/libxfixes-5.0.2-yz7p3ivbkl42bh6qtgtkzprwuze44xof/include -I/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/fixesproto-5.0-xmwf6btus3yoqp2sy2elcmubynkce2m5/include -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c99 -O3 -D_POSIX_C_SOURCE=200809L -D_DEFAULT_SOURCE -fPIC '-DG_LOG_DOMAIN="dbind"'  -MD -MQ 'atspi/f291f98@@atspi@sha/atspi-misc.c.o' -MF 'atspi/f291f98@@atspi@sha/atspi-misc.c.o.d' -o 'atspi/f291f98@@atspi@sha/atspi-misc.c.o' -c ../atspi/atspi-misc.c
     226    [47/53] /mnt/a/u/sciteam/stewart1/spack/lib/spack/env/gcc/gcc -Iregistryd/ef35e93@@at-spi2-registryd@exe -Iregistryd -I../registryd -I. -I../ -Iatspi -I/mnt/bwpy/single/usr/include/glib-2.0 -I/mnt/bwpy/single/usr/lib/glib-2.0/include -I/mnt/bwpy/single/usr/include -I/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/dbus-1.12.8-m6jcirtiqk3gha3padz5e5c6etlpfqgm/include/dbus-1.0 -I/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/dbus-1.12.8-m6jcirtiqk3gha3padz5e5c6etlpfqgm/lib/dbus-1.0/include -I/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/libx11-1.6.5-pmbsh6qks353k7ldwkcjzy3ox3k3wdfh/include -I/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/xproto-7.0.31-56jxwgqslxtjejkghfpjkzkmtzfwktnx/include -I/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/libxau-1.0.8-lvi5jkfa2o2e4zj6gzrxrs4j65gflewj/include -I/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/libxtst-1.2.2-pry5nwwz4ocgevpiiu5if52jsinsopbv/include -I/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/recordproto-1.14.2-nn2vcxyl6ivkvb743nwhez3mr74tnhbq/include -I/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/xextproto-7.3.0-367tgxmpqlwxro2kvgofd6uogpujcwx2/include -I/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/libxfixes-5.0.2-yz7p3ivbkl42bh6qtgtkzprwuze44xof/include -I/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/fixesproto-5.0-xmwf6btus3yoqp2sy2elcmubynkce2m5/include -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c99 -O3 -D_POSIX_C_SOURCE=200809L -D_DEFAULT_SOURCE -pthread  -MD -MQ 'registryd/ef35e93@@at-spi2-registryd@exe/deviceeventcontroller.c.o' -MF 'registryd/ef35e93@@at-spi2-registryd@exe/deviceeventcontroller.c.o.d' -o 'registryd/ef35e93@@at-spi2-registryd@exe/deviceeventcontroller.c.o' -c ../registryd/deviceeventcontroller.c
     227    [48/53] /mnt/a/u/sciteam/stewart1/spack/lib/spack/env/gcc/gcc  -o atspi/libatspi.so.0.0.1 'atspi/f291f98@@atspi@sha/meson-generated_.._atspi-enum-types.c.o' 'atspi/f291f98@@atspi@sha/atspi-accessible.c.o' 'atspi/f291f98@@atspi@sha/atspi-action.c.o' 'atspi/f291f98@@atspi@sha/atspi-application.c.o' 'atspi/f291f98@@atspi@sha/atspi-collection.c.o' 'atspi/f291f98@@atspi@sha/atspi-component.c.o' 'atspi/f291f98@@atspi@sha/atspi-device-listener.c.o' 'atspi/f291f98@@atspi@sha/atspi-document.c.o' 'atspi/f291f98@@atspi@sha/atspi-editabletext.c.o' 'atspi/f291f98@@atspi@sha/atspi-event-listener.c.o' 'atspi/f291f98@@atspi@sha/atspi-gmain.c.o' 'atspi/f291f98@@atspi@sha/atspi-hyperlink.c.o' 'atspi/f291f98@@atspi@sha/atspi-hypertext.c.o' 'atspi/f291f98@@atspi@sha/atspi-image.c.o' 'atspi/f291f98@@atspi@sha/atspi-matchrule.c.o' 'atspi/f291f98@@atspi@sha/atspi-misc.c.o' 'atspi/f291f98@@atspi@sha/atspi-object.c.o' 'atspi/f291f98@@atspi@sha/atspi-registry.c.o' 'atspi/f291f98@@atspi@sha/atspi-relation.c.o' 'atspi/f291f98@@atspi@sha/atspi-selection.c.o' 'atspi/f291f98@@atspi@sha/atspi-stateset.c.o' 'atspi/f291f98@@atspi@sha/atspi-table.c.o' 'atspi/f291f98@@atspi@sha/atspi-table-cell.c.o' 'atspi/f291f98@@atspi@sha/atspi-text.c.o' 'atspi/f291f98@@atspi@sha/atspi-value.c.o' 'atspi/f291f98@@atspi@sha/.._dbind_dbind.c.o' 'atspi/f291f98@@atspi@sha/.._dbind_dbind-any.c.o' -Wl,--no-undefined -Wl,--as-needed -Wl,-O1 -shared -fPIC -Wl,--start-group -Wl,-soname,libatspi.so.0 /mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/dbus-1.12.8-m6jcirtiqk3gha3padz5e5c6etlpfqgm/lib/libdbus-1.so /mnt/bwpy/single/usr/lib/libgobject-2.0.so /mnt/bwpy/single/usr/lib/libglib-2.0.so /mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/libx11-1.6.5-pmbsh6qks353k7ldwkcjzy3ox3k3wdfh/lib/libX11.so /mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/libxtst-1.2.2-pry5nwwz4ocgevpiiu5if52jsinsopbv/lib/libXtst.so /mnt/bwpy/single/usr/lib/libXi.so -Wl,--end-group -Wl,-rpath,/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/dbus-1.12.8-m6jcirtiqk3gha3padz5e5c6etlpfqgm/lib:/mnt/bwpy/single/usr/lib:/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/libx11-1.6.5-pmbsh6qks353k7ldwkcjzy3ox3k3wdfh/lib:/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/libxtst-1.2.2-pry5nwwz4ocgevpiiu5if52jsinsopbv/lib -Wl,-rpath-link,/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/dbus-1.12.8-m6jcirtiqk3gha3padz5e5c6etlpfqgm/lib:/mnt/bwpy/single/usr/lib:/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/libx11-1.6.5-pmbsh6qks353k7ldwkcjzy3ox3k3wdfh/lib:/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/libxtst-1.2.2-pry5nwwz4ocgevpiiu5if52jsinsopbv/lib
     228    FAILED: atspi/libatspi.so.0.0.1
     229    /mnt/a/u/sciteam/stewart1/spack/lib/spack/env/gcc/gcc  -o atspi/libatspi.so.0.0.1 'atspi/f291f98@@atspi@sha/meson-generated_.._atspi-enum-types.c.o' 'atspi/f291f98@@atspi@sha/atspi-accessible.c.o' 'atspi/f291f98@@atspi@sha/atspi-action.c.o' 'atspi/f291f98@@atspi@sha/atspi-application.c.o' 'atspi/f291f98@@atspi@sha/atspi-collection.c.o' 'atspi/f291f98@@atspi@sha/atspi-component.c.o' 'atspi/f291f98@@atspi@sha/atspi-device-listener.c.o' 'atspi/f291f98@@atspi@sha/atspi-document.c.o' 'atspi/f291f98@@atspi@sha/atspi-editabletext.c.o' 'atspi/f291f98@@atspi@sha/atspi-event-listener.c.o' 'atspi/f291f98@@atspi@sha/atspi-gmain.c.o' 'atspi/f291f98@@atspi@sha/atspi-hyperlink.c.o' 'atspi/f291f98@@atspi@sha/atspi-hypertext.c.o' 'atspi/f291f98@@atspi@sha/atspi-image.c.o' 'atspi/f291f98@@atspi@sha/atspi-matchrule.c.o' 'atspi/f291f98@@atspi@sha/atspi-misc.c.o' 'atspi/f291f98@@atspi@sha/atspi-object.c.o' 'atspi/f291f98@@atspi@sha/atspi-registry.c.o' 'atspi/f291f98@@atspi@sha/atspi-relation.c.o' 'atspi/f291f98@@atspi@sha/atspi-selection.c.o' 'atspi/f291f98@@atspi@sha/atspi-stateset.c.o' 'atspi/f291f98@@atspi@sha/atspi-table.c.o' 'atspi/f291f98@@atspi@sha/atspi-table-cell.c.o' 'atspi/f291f98@@atspi@sha/atspi-text.c.o' 'atspi/f291f98@@atspi@sha/atspi-value.c.o' 'atspi/f291f98@@atspi@sha/.._dbind_dbind.c.o' 'atspi/f291f98@@atspi@sha/.._dbind_dbind-any.c.o' -Wl,--no-undefined -Wl,--as-needed -Wl,-O1 -shared -fPIC -Wl,--start-group -Wl,-soname,libatspi.so.0 /mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/dbus-1.12.8-m6jcirtiqk3gha3padz5e5c6etlpfqgm/lib/libdbus-1.so /mnt/bwpy/single/usr/lib/libgobject-2.0.so /mnt/bwpy/single/usr/lib/libglib-2.0.so /mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/libx11-1.6.5-pmbsh6qks353k7ldwkcjzy3ox3k3wdfh/lib/libX11.so /mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/libxtst-1.2.2-pry5nwwz4ocgevpiiu5if52jsinsopbv/lib/libXtst.so /mnt/bwpy/single/usr/lib/libXi.so -Wl,--end-group -Wl,-rpath,/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/dbus-1.12.8-m6jcirtiqk3gha3padz5e5c6etlpfqgm/lib:/mnt/bwpy/single/usr/lib:/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/libx11-1.6.5-pmbsh6qks353k7ldwkcjzy3ox3k3wdfh/lib:/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/libxtst-1.2.2-pry5nwwz4ocgevpiiu5if52jsinsopbv/lib -Wl,-rpath-link,/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/dbus-1.12.8-m6jcirtiqk3gha3padz5e5c6etlpfqgm/lib:/mnt/bwpy/single/usr/lib:/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/libx11-1.6.5-pmbsh6qks353k7ldwkcjzy3ox3k3wdfh/lib:/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/libxtst-1.2.2-pry5nwwz4ocgevpiiu5if52jsinsopbv/lib
     230    atspi/f291f98@@atspi@sha/atspi-component.c.o: In function `atspi_component_set_extents':
  >> 231    atspi-component.c:(.text+0x678): undefined reference to `libintl_gettext'
     232    atspi/f291f98@@atspi@sha/atspi-misc.c.o: In function `_atspi_dbus_call_partial_va':
  >> 233    atspi-misc.c:(.text+0x26a0): undefined reference to `libintl_gettext'
     234    atspi/f291f98@@atspi@sha/atspi-misc.c.o: In function `_atspi_set_error_no_sync':
  >> 235    atspi-misc.c:(.text+0x3201): undefined reference to `libintl_gettext'
     236    atspi/f291f98@@atspi@sha/atspi-misc.c.o: In function `_atspi_dbus_call':
  >> 237    atspi-misc.c:(.text+0x3463): undefined reference to `libintl_gettext'
     238    atspi/f291f98@@atspi@sha/atspi-misc.c.o: In function `_atspi_dbus_get_property':
  >> 239    atspi-misc.c:(.text+0x3788): undefined reference to `libintl_gettext'
     240    atspi/f291f98@@atspi@sha/atspi-value.c.o:atspi-value.c:(.text+0x250): more undefined references to `libintl_gettext' follow
  >> 241    collect2: error: ld returned 1 exit status
     242    ninja: build stopped: subcommand failed.
```

### After

Still trying to rebuild to make sure it worked. I think it's still missing several other X11 dependencies.