### PR TITLE
Add latest version of atk

### DIFF
--- a/var/spack/repos/builtin/packages/atk/package.py
+++ b/var/spack/repos/builtin/packages/atk/package.py
@@ -11,16 +11,19 @@ class Atk(Package):
        implemented by other toolkits and applications. Using the ATK
        interfaces, accessibility tools have full access to view and
        control running applications."""
+
     homepage = "https://developer.gnome.org/atk/"
-    url      = "http://ftp.gnome.org/pub/gnome/sources/atk/2.28/atk-2.28.1.tar.xz"
-    list_url = "http://ftp.gnome.org/pub/gnome/sources/atk"
+    url      = "https://ftp.gnome.org/pub/gnome/sources/atk/2.30/atk-2.30.0.tar.xz"
+    list_url = "https://ftp.gnome.org/pub/gnome/sources/atk"
     list_depth = 1
 
+    version('2.30.0', sha256='dd4d90d4217f2a0c1fee708a555596c2c19d26fef0952e1ead1938ab632c027b')
     version('2.28.1', 'dfb5e7474220afa3f4ca7e45af9f3a11')
     version('2.20.0', '5187b0972f4d3905f285540b31395e20')
     version('2.14.0', 'ecb7ca8469a5650581b1227d78051b8b')
 
-    depends_on('meson', type='build', when='@2.28.0:')
+    depends_on('meson@0.40.1:', type='build', when='@2.28:')
+    depends_on('meson@0.46.0:', type='build', when='@2.29:')
     depends_on('glib')
     depends_on('gettext')
     depends_on('pkgconfig', type='build')


### PR DESCRIPTION
Also adds minimum version requirements for meson. Successfully builds on Cray CNL5 (Blue Waters) with GCC 7.3.0.