### PR TITLE
Don't spawn processes during python 2.6 'test_compiler_add' unit test

### DIFF
--- a/lib/spack/spack/test/cmd/test_compiler_cmd.py
+++ b/lib/spack/spack/test/cmd/test_compiler_cmd.py
@@ -3,8 +3,11 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import sys
+
 import pytest
 import llnl.util.filesystem
+import llnl.util.multiproc
 
 import spack.cmd.compiler
 import spack.compilers
@@ -55,7 +58,13 @@ class TestCompilerCommand(object):
         compilers = spack.compilers.all_compiler_specs()
         assert spack.spec.CompilerSpec("gcc@4.5.0") not in compilers
 
-    def test_compiler_add(self, mock_compiler_dir):
+    def test_compiler_add(self, mock_compiler_dir, monkeypatch):
+        # This test randomly stall on Travis when spawning processes
+        # in Python 2.6 unit tests
+        if sys.version_info < (2, 7):
+            serial_map = lambda f, elements: [f(x) for x in elements]
+            monkeypatch.setattr(llnl.util.multiproc, 'parmap', serial_map)
+
         # Compilers available by default.
         old_compilers = set(spack.compilers.all_compiler_specs())
 

--- a/lib/spack/spack/test/cmd/test_compiler_cmd.py
+++ b/lib/spack/spack/test/cmd/test_compiler_cmd.py
@@ -61,9 +61,8 @@ class TestCompilerCommand(object):
     def test_compiler_add(self, mock_compiler_dir, monkeypatch):
         # This test randomly stall on Travis when spawning processes
         # in Python 2.6 unit tests
-        if sys.version_info < (2, 7):
-            serial_map = lambda f, elements: [f(x) for x in elements]
-            monkeypatch.setattr(llnl.util.multiproc, 'parmap', serial_map)
+        if sys.version_info < (3, 0, 0):
+            monkeypatch.setattr(llnl.util.multiproc, 'parmap', map)
 
         # Compilers available by default.
         old_compilers = set(spack.compilers.all_compiler_specs())


### PR DESCRIPTION
The unit test `test_compiler_add` stalls frequently on Travis in the Python 2.6 runner. As this test spawns multiple processes and waits for them to join, here we try to see if without spawning the test is more reliable.