### PR TITLE
Added labels in github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report 
 about: Report a bug in the core of Spack (command not working as expected, etc.) 
-
+labels: bug
 ---
 
 

--- a/.github/ISSUE_TEMPLATE/build_error.md
+++ b/.github/ISSUE_TEMPLATE/build_error.md
@@ -1,7 +1,7 @@
 ---
 name: Build error 
 about: Some package in Spack didn't build correctly  
-
+labels: "build-error"
 ---
 
 *Thanks for taking the time to report this build failure. To proceed with the

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,7 @@
 ---
 name: Feature request 
 about: Suggest adding a feature that is not yet in Spack  
+labels: feature, proposal
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request 
 about: Suggest adding a feature that is not yet in Spack  
-labels: feature, proposal
+labels: feature
 
 ---
 


### PR DESCRIPTION
These labels are applied automatically when the issues are created. See [this request](https://github.community/t5/How-to-use-Git-and-GitHub/Apply-labels-automatically-at-issue-creation/td-p/10719) and the corresponding [docs](https://help.github.com/articles/manually-creating-a-single-issue-template-for-your-repository/).