### PR TITLE
Add latest version of libxkbcommon

### DIFF
--- a/var/spack/repos/builtin/packages/libxkbcommon/package.py
+++ b/var/spack/repos/builtin/packages/libxkbcommon/package.py
@@ -13,20 +13,17 @@ class Libxkbcommon(AutotoolsPackage):
     applications."""
 
     homepage = "https://xkbcommon.org/"
-    url      = "https://github.com/xkbcommon/libxkbcommon/archive/xkbcommon-0.8.0.tar.gz"
+    url      = "https://xkbcommon.org/download/libxkbcommon-0.8.2.tar.xz"
 
-    version('0.8.0', '0d9738fb2ed2dcc6e2c6920d94e135ce')
+    version('0.8.2', sha256='7ab8c4b3403d89d01898066b72cb6069bddeb5af94905a65368f671a026ed58c')
+    version('0.8.0', sha256='e829265db04e0aebfb0591b6dc3377b64599558167846c3f5ee5c5e53641fe6d')
 
-    depends_on('autoconf', type='build')
-    depends_on('automake', type='build')
-    depends_on('libtool',  type='build')
-    depends_on('m4',       type='build')
-    depends_on('bison',    type='build')
+    depends_on('pkgconfig@0.9.0:', type='build')
+    depends_on('bison', type='build')
     depends_on('xkbdata')
+    depends_on('libxcb@1.10:')
 
     def configure_args(self):
-        spec = self.spec
-        args = []
-        args.append('--with-xkb-config-root={0}'
-                    .format(spec['xkbdata'].prefix))
-        return args
+        return [
+            '--with-xkb-config-root={0}'.format(self.spec['xkbdata'].prefix)
+        ]


### PR DESCRIPTION
Also switches from GitHub to an official release tarball that already contains the `configure` script. This means that all of the Autotools dependencies are no longer necessary. I was having trouble running autoreconf:
```
2 errors found in build log:
     11    libtoolize: linking file 'm4/libtool.m4'
     12    libtoolize: linking file 'm4/ltoptions.m4'
     13    libtoolize: linking file 'm4/ltsugar.m4'
     14    libtoolize: linking file 'm4/ltversion.m4'
     15    libtoolize: linking file 'm4/lt~obsolete.m4'
     16    ==> '/mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/automake-1.16.1-naycnhp73c3qdhtlwjwb5nksmbl3mcdd/bin/aclocal'
  >> 17    configure.ac:44: error: must install xorg-macros 1.16 or later before running autoconf/autogen
     18    configure.ac:44: the top level
     19    autom4te: /mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/m4-1.4.18-h44epmk6ya5djlx55s7kbbx44tl26ttr/bin/m4 failed with e
           xit status: 1
  >> 20    aclocal: error: echo failed with exit status: 1
```
This PR fixes that. Also adds a missing dependency on `libxcb`.

### Before

```
1 error found in build log:
     150    checking whether the linker accepts -Wl,--version-script="/mnt/a/u/sciteam/stewart1/spack/var/spack/stage/libxkbcommon-0.8.2-zljeyykh62n2qjefzu2v
            52lqktil7fhn/libxkbcommon-0.8.2/xkbcommon.map"... no
     151    Package xkeyboard-config was not found in the pkg-config search path.
     152    Perhaps you should add the directory containing `xkeyboard-config.pc'
     153    to the PKG_CONFIG_PATH environment variable
     154    No package 'xkeyboard-config' found
     155    checking for XCB_XKB... no
  >> 156    configure: error: xkbcommon-x11 requires xcb-xkb >= 1.10 which was not found. You can disable X11 support with --disable-x11.
```

### After
```
$ ldd -r ~/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/libxkbcommon-0.8.2-s6nebbmmsrpztggshoniypytusadycay/lib/libxkbcommon-x11.so
	linux-vdso.so.1 =>  (0x00002aaaaaaab000)
	libxkbcommon.so.0 => /mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/libxkbcommon-0.8.2-s6nebbmmsrpztggshoniypytusadycay/lib/libxkbcommon.so.0 (0x00002aaaaacb6000)
	libxcb-xkb.so.1 => /mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/libxcb-1.13-sq3kf5ciich35zupj6gzbrfydeoowcv3/lib/libxcb-xkb.so.1 (0x00002aaaaaef5000)
	libxcb.so.1 => /mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/libxcb-1.13-sq3kf5ciich35zupj6gzbrfydeoowcv3/lib/libxcb.so.1 (0x00002aaaab114000)
	libXau.so.6 => /mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/libxau-1.0.8-lvi5jkfa2o2e4zj6gzrxrs4j65gflewj/lib/libXau.so.6 (0x00002aaaab33a000)
	libXdmcp.so.6 => /mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/libxdmcp-1.1.2-7himptjvbwcqej32qgrxlamssvzteiny/lib/libXdmcp.so.6 (0x00002aaaab53f000)
	libbsd.so.0 => /mnt/a/u/sciteam/stewart1/spack/opt/spack/cray-cnl5-interlagos/gcc-7.3.0/libbsd-0.9.1-a5womix7sgzat5etdlaoabpne7o5l3cl/lib/libbsd.so.0 (0x00002aaaab745000)
	librca.so.0 => /opt/cray/rca/default/lib64/librca.so.0 (0x00002aaaab9f3000)
	libc.so.6 => /lib64/libc.so.6 (0x00002aaaabbf8000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00002aaaabf74000)
	librt.so.1 => /lib64/librt.so.1 (0x00002aaaac192000)
	/lib64/ld-linux-x86-64.so.2 (0x0000555555554000)
```