### PR TITLE
fix for mpifileutils package

### DIFF
--- a/var/spack/repos/builtin/packages/mpifileutils/package.py
+++ b/var/spack/repos/builtin/packages/mpifileutils/package.py
@@ -26,6 +26,8 @@ class Mpifileutils(AutotoolsPackage):
     version('0.7', 'c081f7f72c4521dddccdcf9e087c5a2b')
     version('0.6', '620bcc4966907481f1b1a965b28fc9bf')
 
+    conflicts('platform=darwin')
+
     depends_on('mpi')
     depends_on('libcircle')
     depends_on('lwgrp')

--- a/var/spack/repos/builtin/packages/mpifileutils/package.py
+++ b/var/spack/repos/builtin/packages/mpifileutils/package.py
@@ -54,10 +54,16 @@ class Mpifileutils(AutotoolsPackage):
     def configure_args(self):
         args = []
         args.append("CPPFLAGS=-I%s/src/common" % pwd())
-        args.append("libarchive_CFLAGS=-I%s" % self.spec['libarchive'].prefix.include)
-        args.append("libarchive_LIBS=%s %s" % (self.spec['libarchive'].libs.search_flags, self.spec['libarchive'].libs.link_flags))
-        args.append("libcircle_CFLAGS=-I%s" % self.spec['libcircle'].prefix.include)
-        args.append("libcircle_LIBS=%s %s" % (self.spec['libcircle'].libs.search_flags, self.spec['libcircle'].libs.link_flags))
+        args.append("libarchive_CFLAGS=-I%s"
+                    % self.spec['libarchive'].prefix.include)
+        args.append("libarchive_LIBS=%s %s"
+                    % (self.spec['libarchive'].libs.search_flags,
+                       self.spec['libarchive'].libs.link_flags))
+        args.append("libcircle_CFLAGS=-I%s"
+                    % self.spec['libcircle'].prefix.include)
+        args.append("libcircle_LIBS=%s %s"
+                    % (self.spec['libcircle'].libs.search_flags,
+                       self.spec['libcircle'].libs.link_flags))
         args.append("--with-dtcmp=%s" % self.spec['dtcmp'].prefix)
 
         if '+xattr' in self.spec:

--- a/var/spack/repos/builtin/packages/mpifileutils/package.py
+++ b/var/spack/repos/builtin/packages/mpifileutils/package.py
@@ -54,9 +54,9 @@ class Mpifileutils(AutotoolsPackage):
     def configure_args(self):
         args = []
         args.append("libarchive_CFLAGS=-I%s" % self.spec['libarchive'].prefix.include)
-        args.append("libarchive_LIBS=%s" % self.spec['libarchive'].libs.search_flags)
+        args.append("libarchive_LIBS=%s %s" % (self.spec['libarchive'].libs.search_flags, self.spec['libarchive'].libs.link_flags))
         args.append("libcircle_CFLAGS=-I%s" % self.spec['libcircle'].prefix.include)
-        args.append("libcircle_LIBS=%s" % self.spec['libcircle'].libs.search_flags)
+        args.append("libcircle_LIBS=%s %s" % (self.spec['libcircle'].libs.search_flags, self.spec['libcircle'].libs.link_flags))
         args.append("--with-dtcmp=%s" % self.spec['dtcmp'].prefix)
 
         if '+xattr' in self.spec:

--- a/var/spack/repos/builtin/packages/mpifileutils/package.py
+++ b/var/spack/repos/builtin/packages/mpifileutils/package.py
@@ -53,6 +53,7 @@ class Mpifileutils(AutotoolsPackage):
 
     def configure_args(self):
         args = []
+        args.append("CPPFLAGS=-I%s/src/common" % pwd())
         args.append("libarchive_CFLAGS=-I%s" % self.spec['libarchive'].prefix.include)
         args.append("libarchive_LIBS=%s %s" % (self.spec['libarchive'].libs.search_flags, self.spec['libarchive'].libs.link_flags))
         args.append("libcircle_CFLAGS=-I%s" % self.spec['libcircle'].prefix.include)

--- a/var/spack/repos/builtin/packages/mpifileutils/package.py
+++ b/var/spack/repos/builtin/packages/mpifileutils/package.py
@@ -58,6 +58,10 @@ class Mpifileutils(AutotoolsPackage):
         args.append("libcircle_CFLAGS=-I%s" % self.spec['libcircle'].prefix.include)
         args.append("libcircle_LIBS=%s" % self.spec['libcircle'].libs.search_flags)
         args.append("--with-dtcmp=%s" % self.spec['dtcmp'].prefix)
+
+        if '+xattr' in self.spec:
+            args.append('CFLAGS=-DDCOPY_USE_XATTRS')
+
         if '+lustre' in self.spec:
             args.append('--enable-lustre')
         else:
@@ -68,12 +72,4 @@ class Mpifileutils(AutotoolsPackage):
                 args.append('--enable-experimental')
             else:
                 args.append('--disable-experimental')
-
         return args
-
-    @property
-    def build_targets(self):
-        targets = []
-        if '+xattr' in self.spec:
-            targets.append('CFLAGS=-DDCOPY_USE_XATTRS')
-        return targets

--- a/var/spack/repos/builtin/packages/mpifileutils/package.py
+++ b/var/spack/repos/builtin/packages/mpifileutils/package.py
@@ -55,6 +55,9 @@ class Mpifileutils(AutotoolsPackage):
         args = []
         args.append("libarchive_CFLAGS=-I%s" % self.spec['libarchive'].prefix.include)
         args.append("libarchive_LIBS=%s" % self.spec['libarchive'].libs.search_flags)
+        args.append("libcircle_CFLAGS=-I%s" % self.spec['libcircle'].prefix.include)
+        args.append("libcircle_LIBS=%s" % self.spec['libcircle'].libs.search_flags)
+        args.append("--with-dtcmp=%s" % self.spec['dtcmp'].prefix)
         if '+lustre' in self.spec:
             args.append('--enable-lustre')
         else:

--- a/var/spack/repos/builtin/packages/mpifileutils/package.py
+++ b/var/spack/repos/builtin/packages/mpifileutils/package.py
@@ -51,7 +51,8 @@ class Mpifileutils(AutotoolsPackage):
 
     def configure_args(self):
         args = []
-
+        args.append("libarchive_CFLAGS=-I%s" % self.spec['libarchive'].prefix.include)
+        args.append("libarchive_LIBS=%s" % self.spec['libarchive'].libs.search_flags)
         if '+lustre' in self.spec:
             args.append('--enable-lustre')
         else:


### PR DESCRIPTION
I'm not sure the mpifileutils package ever properly built, especially if trying to use a system libarchive. In any case, I have a bunch of fixes here:
- this package will not work on macs
- all dependency paths are set on the `./configure` line, rather than relying on pkg-config
- the mfu sub tools need to include `src/common`