### PR TITLE
WarpX: Added dependency on fftw when +psatd

### DIFF
--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -34,6 +34,8 @@ class Warpx(MakefilePackage):
     variant('tprof', default=False, description='Enable tiny profiling features')
     variant('openmp', default=True, description='Enable OpenMP features')
 
+    depends_on('fftw@3:', when='+psatd')
+
     resource(name='amrex',
              git='https://github.com/AMReX-Codes/amrex.git',
              tag='development',


### PR DESCRIPTION
A small fix. WarpX needs fftw3 installed when using psatd.