### PR TITLE
Add latest version of docbook-xsl

### DIFF
--- a/var/spack/repos/builtin/packages/docbook-xsl/docbook-xsl-1.79.2-stack_fix-1.patch
+++ b/var/spack/repos/builtin/packages/docbook-xsl/docbook-xsl-1.79.2-stack_fix-1.patch
@@ -1,0 +1,39 @@
+Submitted By:            Bruce Dubbs <bdubbs at linuxfromscratch dot org>
+Date:                    2018-01-01
+Initial Package Version: 1.78.1
+Upstream Status:         Unsure
+Origin:                  Peter De Wachter <pdewacht@gmail.com>
+Description: use EXSLT "replace" function when available
+ A recursive implementation  of string.subst is problematic,
+ long strings with many matches will cause stack overflows.
+Author: Peter De Wachter <pdewacht@gmail.com>
+Bug-Debian: https://bugs.debian.org/750593
+
+Rediffed for 1.79.2 by Bruce Dubbs
+
+diff -Naur docbook-xsl-1.79.2.orig/lib/lib.xsl docbook-xsl-1.79.2/lib/lib.xsl
+--- docbook-xsl-1.79.2.orig/lib/lib.xsl	2016-12-09 16:41:39.000000000 -0600
++++ docbook-xsl-1.79.2/lib/lib.xsl	2018-01-01 12:54:52.507332514 -0600
+@@ -6,7 +6,11 @@
+ 
+      This module implements DTD-independent functions
+ 
+-     ******************************************************************** --><xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
++     ******************************************************************** -->
++<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
++                xmlns:str="http://exslt.org/strings"
++                exclude-result-prefixes="str"
++                version="1.0">
+ 
+ <xsl:template name="dot.count">
+   <!-- Returns the number of "." characters in a string -->
+@@ -52,6 +56,9 @@
+   <xsl:param name="replacement"/>
+ 
+   <xsl:choose>
++    <xsl:when test="function-available('str:replace')">
++      <xsl:value-of select="str:replace($string, string($target), string($replacement))"/>
++    </xsl:when>
+     <xsl:when test="contains($string, $target)">
+       <xsl:variable name="rest">
+         <xsl:call-template name="string.subst">

--- a/var/spack/repos/builtin/packages/docbook-xsl/package.py
+++ b/var/spack/repos/builtin/packages/docbook-xsl/package.py
@@ -8,23 +8,20 @@ from spack import *
 
 
 class DocbookXsl(Package):
-    """Docbook XSL vocabulary."""
-    homepage = "http://docbook.sourceforge.net/"
-    url = "https://downloads.sourceforge.net/project/docbook/docbook-xsl/1.79.1/docbook-xsl-1.79.1.tar.bz2"
+    """DocBook XSLT 1.0 Stylesheets."""
 
-    version('1.79.1', 'b48cbf929a2ad85e6672f710777ca7bc')
+    homepage = "https://github.com/docbook/xslt10-stylesheets"
+    url      = "https://github.com/docbook/xslt10-stylesheets/releases/download/release%2F1.79.2/docbook-xsl-1.79.2.tar.bz2"
+
+    version('1.79.2', sha256='316524ea444e53208a2fb90eeb676af755da96e1417835ba5f5eb719c81fa371')
 
     depends_on('docbook-xml')
 
+    patch('docbook-xsl-1.79.2-stack_fix-1.patch', when='@1.79.2')
+
     def install(self, spec, prefix):
-        for item in os.listdir('.'):
-            src = os.path.abspath(item)
-            dst = os.path.join(prefix, item)
-            if os.path.isdir(item):
-                install_tree(src, dst, symlinks=True)
-            else:
-                install(src, dst)
+        install_tree('.', prefix)
 
     def setup_environment(self, spack_env, run_env):
-        catalog = os.path.join(self.spec.prefix, 'catalog.xml')
+        catalog = os.path.join(self.prefix, 'catalog.xml')
         run_env.set('XML_CATALOG_FILES', catalog, separator=' ')


### PR DESCRIPTION
Also adds a patch courtesy of [Linux from Scratch](http://www.linuxfromscratch.org/blfs/view/8.3-systemd/pst/docbook-xsl.html), and simplifies the install method. The SourceForge download no longer works for me. It seems like they've moved to GitHub.