### PR TITLE
Add missing libiconv dependency to libxml2

### DIFF
--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -21,18 +21,24 @@ class Libxml2(AutotoolsPackage):
 
     variant('python', default=False, description='Enable Python support')
 
-    extends('python', when='+python',
-            ignore=r'(bin.*$)|(include.*$)|(share.*$)|(lib/libxml2.*$)|'
-            '(lib/xml2.*$)|(lib/cmake.*$)')
+    depends_on('pkgconfig@0.9.0:', type='build')
+    depends_on('libiconv')
     depends_on('zlib')
     depends_on('xz')
 
-    depends_on('pkgconfig', type='build')
+    extends('python+shared', when='+python',
+            ignore=r'(bin.*$)|(include.*$)|(share.*$)|(lib/libxml2.*$)|'
+            '(lib/xml2.*$)|(lib/cmake.*$)')
+
+    # XML Conformance Test Suites
+    # See http://www.w3.org/XML/Test/ for information
+    resource(name='xmlts', url='http://www.w3.org/XML/Test/xmlts20080827.tar.gz',
+             sha256='96151685cec997e1f9f3387e3626d61e6284d4d6e66e0e440c209286c03e9cc7')
 
     def configure_args(self):
         spec = self.spec
 
-        args = ["--with-lzma=%s" % spec['xz'].prefix]
+        args = ['--with-lzma={0}'.format(spec['xz'].prefix)]
 
         if '+python' in spec:
             args.extend([
@@ -47,3 +53,10 @@ class Libxml2(AutotoolsPackage):
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         spack_env.prepend_path('CPATH', self.prefix.include.libxml2)
         run_env.prepend_path('CPATH', self.prefix.include.libxml2)
+
+    @run_after('install')
+    @on_package_attributes(run_tests=True)
+    def import_module_test(self):
+        if '+python' in self.spec:
+            with working_dir('spack-test', create=True):
+                python('-c', 'import libxml2')


### PR DESCRIPTION
```
$ otool -L /Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.0-apple/libxml2-2.9.8-m6e5jpylv5o4bhxc6ops5oclun3qi52z/lib/libxml2.dylib 
/Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.0-apple/libxml2-2.9.8-m6e5jpylv5o4bhxc6ops5oclun3qi52z/lib/libxml2.dylib:
	/Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.0-apple/libxml2-2.9.8-m6e5jpylv5o4bhxc6ops5oclun3qi52z/lib/libxml2.2.dylib (compatibility version 12.0.0, current version 12.8.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.200.5)
	/Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.0-apple/zlib-1.2.11-uw6agnye4za7cpgyyaaejrzorhbhqno5/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
	/Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.0-apple/xz-5.2.4-i47twa3ynjmijdjvt4nag47wtg65m7jc/lib/liblzma.5.dylib (compatibility version 8.0.0, current version 8.4.0)
	/Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.0-apple/libiconv-1.15-u27q4rowrbactosi7n57ever5q44jddx/lib/libiconv.2.dylib (compatibility version 9.0.0, current version 9.0.0)
```
Also adds `pkg-config` dependency version requirements, fixes a bug on macOS where the Python libraries don't actually work, adds additional compliance unit tests (that all pass), and adds a Python import test.