### PR TITLE
patch: split up fetch and clean into separate methods

### DIFF
--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -212,7 +212,7 @@ def create(path, specs, **kwargs):
 def add_single_spec(spec, mirror_root, categories, **kwargs):
     tty.msg("Adding package {pkg} to mirror".format(pkg=spec.format("$_$@")))
     try:
-        spec.package.do_patch()
+        spec.package.do_fetch()
         spec.package.do_clean()
 
     except Exception as e:

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -967,6 +967,9 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
 
         self.stage.cache_local()
 
+        for patch in self.spec.patches:
+            patch.fetch(self.stage)
+
     def do_stage(self, mirror_only=False):
         """Unpacks and expands the fetched tarball."""
         if not self.spec.concrete:
@@ -2078,6 +2081,9 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
 
     def do_clean(self):
         """Removes the package's build stage and source tarball."""
+        for patch in self.spec.patches:
+            patch.clean()
+
         self.stage.destroy()
 
     def format_doc(self, **kwargs):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -92,7 +92,7 @@ from six import iteritems
 
 from llnl.util.filesystem import find_headers, find_libraries, is_exe
 from llnl.util.lang import key_ordering, HashableMap, ObjectWrapper, dedupe
-from llnl.util.lang import check_kwargs
+from llnl.util.lang import check_kwargs, memoized
 from llnl.util.tty.color import cwrite, colorize, cescape, get_color_when
 
 import spack.architecture
@@ -2665,6 +2665,7 @@ class Spec(object):
         return [spec for spec in self.traverse() if spec.virtual]
 
     @property
+    @memoized
     def patches(self):
         """Return patch objects for any patch sha256 sums on this Spec.
 
@@ -2674,6 +2675,9 @@ class Spec(object):
         TODO: this only checks in the package; it doesn't resurrect old
         patches from install directories, but it probably should.
         """
+        if not self.concrete:
+            raise SpecError("Spec is not concrete: " + str(self))
+
         if 'patches' not in self.variants:
             return []
 

--- a/lib/spack/spack/test/patch.py
+++ b/lib/spack/spack/test/patch.py
@@ -82,7 +82,9 @@ first line
 third line
 """)
         # apply the patch and compare files
+        patch.fetch(stage)
         patch.apply(stage)
+        patch.clean()
 
         with working_dir(stage.source_path):
             assert filecmp.cmp('foo.txt', 'foo-expected.txt')


### PR DESCRIPTION
Currently, `spack mirror create bzip2` fails with the following error:
```
==> Warning: Error while fetching bzip2@1.0.6
  global name 'spack_cc' is not defined
```

This is due to the fact that `mirror create` invokes `do_patch`, which calls the package's `patch` method. Since `mirror create` does not set up the appropriate environment, variables like `spack_cc` are not set.

This change introduces `fetch` and `clean` methods for patches. They are no-ops for `FilePatch` but perform the appropriate actions for `UrlPatch`. This allows `mirror create` to invoke `do_fetch`, which does not call the package's `patch` method.