### PR TITLE
fetch_strategy: improve GitFetchStrategy

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -571,7 +571,8 @@ class GitFetchStrategy(VCSFetchStrategy):
 
     You can use these three optional attributes in addition to ``git``:
 
-        * ``branch``: Particular branch to build from (default is master)
+        * ``branch``: Particular branch to build from (default is the
+                      repository's default branch)
         * ``tag``: Particular tag to check out
         * ``commit``: Particular commit hash in the repo
     """
@@ -620,20 +621,24 @@ class GitFetchStrategy(VCSFetchStrategy):
         if output:
             return output.split()[0]
 
+    def _repo_info(self):
+        args = ''
+
+        if self.commit:
+            args = ' at commit {0}'.format(self.commit)
+        elif self.tag:
+            args = ' at tag {0}'.format(self.tag)
+        elif self.branch:
+            args = ' on branch {0}'.format(self.branch)
+
+        return '{0}{1}'.format(self.url, args)
+
     def fetch(self):
         if self.stage.source_path:
-            tty.msg("Already fetched %s" % self.stage.source_path)
+            tty.msg("Already fetched {0}".format(self.stage.source_path))
             return
 
-        args = ''
-        if self.commit:
-            args = 'at commit %s' % self.commit
-        elif self.tag:
-            args = 'at tag %s' % self.tag
-        elif self.branch:
-            args = 'on branch %s' % self.branch
-
-        tty.msg("Cloning git repository: %s %s" % (self.url, args))
+        tty.msg("Cloning git repository: {0}".format(self._repo_info()))
 
         git = self.git
         if self.commit:
@@ -722,7 +727,7 @@ class GitFetchStrategy(VCSFetchStrategy):
                 self.git('clean', '--quiet', '-f')
 
     def __str__(self):
-        return "[git] %s" % self.url
+        return '[git] {0}'.format(self._repo_info())
 
 
 class SvnFetchStrategy(VCSFetchStrategy):

--- a/var/spack/repos/builtin/packages/h5z-zfp/package.py
+++ b/var/spack/repos/builtin/packages/h5z-zfp/package.py
@@ -13,7 +13,7 @@ class H5zZfp(MakefilePackage):
     homepage = "http://h5z-zfp.readthedocs.io/en/latest"
     git      = "https://github.com/LLNL/H5Z-ZFP.git"
 
-    version('develop', tag='master')
+    version('develop', branch='master')
     version('0.8.0', commit='af165c4')
     version('0.7.0', commit='58ac811')
 


### PR DESCRIPTION
Currently, only the Git repsository's URL shows up in the `spack info` output, which makes it hard to distinguish different versions:
```
Safe versions:
    develop    [git] https://github.com/LLNL/H5Z-ZFP.git
    0.8.0      [git] https://github.com/LLNL/H5Z-ZFP.git
    0.7.0      [git] https://github.com/LLNL/H5Z-ZFP.git
```

This change adds additional information as shown when cloning a Git repository:
```
Safe versions:
    develop    [git] https://github.com/LLNL/H5Z-ZFP.git on branch master
    0.8.0      [git] https://github.com/LLNL/H5Z-ZFP.git at commit af165c4
    0.7.0      [git] https://github.com/LLNL/H5Z-ZFP.git at commit 58ac811
```