### PR TITLE
CGNS: Allow use of git branch versions

### DIFF
--- a/var/spack/repos/builtin/packages/cgns/package.py
+++ b/var/spack/repos/builtin/packages/cgns/package.py
@@ -13,9 +13,12 @@ class Cgns(CMakePackage):
 
     homepage = "http://cgns.github.io/"
     url      = "https://github.com/CGNS/CGNS/archive/v3.3.0.tar.gz"
+    git      = "https://github.com/CGNS/CGNS"
 
+    version('master', branch='master')
     version('3.3.1', '65c55998270c3e125e28ec5c3742e15d')
     version('3.3.0', '64e5e8d97144c1462bee9ea6b2a81d7f')
+    version('develop', branch='develop')
 
     variant('hdf5', default=True, description='Enable HDF5 interface')
     variant('fortran', default=False, description='Enable Fortran interface')

--- a/var/spack/repos/builtin/packages/cgns/package.py
+++ b/var/spack/repos/builtin/packages/cgns/package.py
@@ -15,10 +15,10 @@ class Cgns(CMakePackage):
     url      = "https://github.com/CGNS/CGNS/archive/v3.3.0.tar.gz"
     git      = "https://github.com/CGNS/CGNS"
 
+    version('develop', branch='develop')
     version('master', branch='master')
     version('3.3.1', '65c55998270c3e125e28ec5c3742e15d')
     version('3.3.0', '64e5e8d97144c1462bee9ea6b2a81d7f')
-    version('develop', branch='develop')
 
     variant('hdf5', default=True, description='Enable HDF5 interface')
     variant('fortran', default=False, description='Enable Fortran interface')


### PR DESCRIPTION
Add ability to use git `master` and `develop` branches of the CGNS library.  The `seacas` package sometimes needs to use the `master` or `develop` branch due to some new changes to the parallel I/O implementation in CGNS which has not yet been released.