### PR TITLE
kallisto: updated checksum

### DIFF
--- a/var/spack/repos/builtin/packages/kallisto/package.py
+++ b/var/spack/repos/builtin/packages/kallisto/package.py
@@ -13,7 +13,7 @@ class Kallisto(CMakePackage):
     homepage = "http://pachterlab.github.io/kallisto"
     url      = "https://github.com/pachterlab/kallisto/archive/v0.43.1.tar.gz"
 
-    version('0.43.1', '54fc9b70ca44e4633f02c962cbc59737')
+    version('0.43.1', '071e6bfb62be06fd76552298d4cf8144')
 
     depends_on('zlib')
     depends_on('hdf5')


### PR DESCRIPTION
[Per kallisto package maintainer](https://github.com/pachterlab/kallisto/issues/195#issuecomment-448542235):

> The md5sum is `071e6bfb62be06fd76552298d4cf8144`.  I've checked the file that I downloaded on March 20th 2017 on the machine where I build the binaries as well as the file served from github.

This fixes #10118

FYI @adamjstewart  