### PR TITLE
cmd: add argument for build environment command

### DIFF
--- a/lib/spack/spack/test/cmd/build_env.py
+++ b/lib/spack/spack/test/cmd/build_env.py
@@ -12,8 +12,7 @@ build_env = SpackCommand('build-env')
 
 
 @pytest.mark.parametrize('pkg', [
-    ('zlib',),
-    ('zlib', '--')
+    ('zlib',)
 ])
 @pytest.mark.usefixtures('config')
 def test_it_just_runs(pkg):


### PR DESCRIPTION
Currently, `build-env` accepts both a spec and a command on the command line. First, this is very hard to discover as the help output does not mention it at all. Second, having to specify `--` to separate the spec and command is not very convenient.

This change introduces a `-c`/`--command` argument that can be used to specify the build environment command. The only downside is that we have to split the command ourselves using `shlex`. The command argument is now clearly documented in the help output, though.

Fixes #659 
Alternative to #7743