### PR TITLE
dyninst: patch to build dyninst with older gcc

### DIFF
--- a/var/spack/repos/builtin/packages/dyninst/package.py
+++ b/var/spack/repos/builtin/packages/dyninst/package.py
@@ -53,6 +53,7 @@ class Dyninst(CMakePackage):
 
     patch('stat_dysect.patch', when='+stat_dysect')
     patch('stackanalysis_h.patch', when='@9.2.0')
+    patch('v9.3.2-auto.patch', when='@9.3.2')
 
     # Versions 9.3.x used cotire, but have no knob to turn it off.
     # Cotire has no real use for one-time builds and can break

--- a/var/spack/repos/builtin/packages/dyninst/v9.3.2-auto.patch
+++ b/var/spack/repos/builtin/packages/dyninst/v9.3.2-auto.patch
@@ -1,0 +1,73 @@
+Change some 'for (const auto& t: type)' usage to the older but
+equivalent 'for (auto t = type.begin(); ...)'.  This patch allows
+dyninst 9.3.2 to build with gcc 4.4 which doesn't support the newer
+syntax.
+
+
+diff --git a/dyninstAPI/src/BPatch.C b/dyninstAPI/src/BPatch.C
+index ebf7db0..49fe69f 100644
+--- a/dyninstAPI/src/BPatch.C
++++ b/dyninstAPI/src/BPatch.C
+@@ -166,16 +166,16 @@ BPatch::BPatch()
+     stdTypes = BPatch_typeCollection::getGlobalTypeCollection();
+     vector<Type *> *sTypes = Symtab::getAllstdTypes();
+     BPatch_type* type = NULL;
+-    for(const auto& t: *sTypes) {
+-        stdTypes->addType(type = new BPatch_type(t));
++    for(auto t = sTypes->begin(); t != sTypes->end(); ++t) {
++        stdTypes->addType(type = new BPatch_type(*t));
+         type->decrRefCount();
+     }
+     delete sTypes;
+ 
+     builtInTypes = new BPatch_builtInTypeCollection;
+     sTypes = Symtab::getAllbuiltInTypes();
+-    for(const auto& t: *sTypes) {
+-        builtInTypes->addBuiltInType(type = new BPatch_type(t));
++    for(auto t = sTypes->begin(); t != sTypes->end(); ++t) {
++        builtInTypes->addBuiltInType(type = new BPatch_type(*t));
+         type->decrRefCount();
+     }
+     delete sTypes;
+diff --git a/dyninstAPI/src/BPatch_collections.C b/dyninstAPI/src/BPatch_collections.C
+index f4e2986..9a7ca39 100644
+--- a/dyninstAPI/src/BPatch_collections.C
++++ b/dyninstAPI/src/BPatch_collections.C
+@@ -172,12 +172,12 @@ BPatch_typeCollection::~BPatch_typeCollection()
+     assert(refcount == 0 ||
+            refcount == 1);
+ 
+-    for(const auto& t: typesByName) {
+-        t.second->decrRefCount();
++    for(auto t = typesByName.begin(); t != typesByName.end(); ++t) {
++        t->second->decrRefCount();
+     }
+ 
+-    for(const auto& t: typesByID) {
+-        t.second->decrRefCount();
++    for(auto t = typesByName.begin(); t != typesByName.end(); ++t) {
++        t->second->decrRefCount();
+     }
+ }
+ 
+diff --git a/symtabAPI/src/Collections.C b/symtabAPI/src/Collections.C
+index 7431dd6..43c339f 100644
+--- a/symtabAPI/src/Collections.C
++++ b/symtabAPI/src/Collections.C
+@@ -318,12 +318,12 @@ typeCollection::typeCollection() :
+ typeCollection::~typeCollection()
+ {
+     // delete all of the types
+-    for(const auto& t: typesByName) {
+-        t.second->decrRefCount();
++    for(auto t = typesByName.begin(); t != typesByName.end(); ++t) {
++        t->second->decrRefCount();
+     }
+ 
+-    for(const auto& t: typesByID) {
+-        t.second->decrRefCount();
++    for(auto t = typesByID.begin(); t != typesByID.end(); ++t) {
++        t->second->decrRefCount();
+     }
+ }
+ 


### PR DESCRIPTION
Add 'v9.3.2-auto.patch'.  This patch changes some 'auto t: type' usage
to the older but equivalent 'type.begin()'.  This allows building
dyninst 9.3.2 with gcc 4.4 which doesn't support the newer syntax.
This patch is harmless with newer gcc.

----------

This patch allows building dyninst 9.3.2 on Blue Gene with the default
gcc 4.4 compiler (which is why I care).

I can make dyninst 10.0.0 build on Blue Gene, but it requires a patch
to elfutils and the 4.8 compiler.
