### PR TITLE
Add libiconv variant to glib

### DIFF
--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -32,6 +32,7 @@ class Glib(AutotoolsPackage):
     version('2.48.1', '67bd3b75c9f6d5587b457dc01cdcd5bb')
     version('2.42.1', '89c4119e50e767d3532158605ee9121a')
 
+    variant('iconv', default=False, description='Build with iconv support')
     variant('libmount', default=False, description='Build with libmount support')
     variant(
         'tracing',
@@ -49,6 +50,7 @@ class Glib(AutotoolsPackage):
     depends_on('python', type=('build', 'run'), when='@2.53.4:')
     depends_on('pcre+utf', when='@2.48:')
     depends_on('util-linux', when='+libmount')
+    depends_on('libiconv', when='+iconv')
 
     # The following patch is needed for gcc-6.1
     patch('g_date_strftime.patch', when='@2.42.1')
@@ -72,6 +74,10 @@ class Glib(AutotoolsPackage):
             args.append('--with-python={0}'.format(
                 os.path.basename(self.spec['python'].command.path))
             )
+        if self.spec.satisfies('+iconv'):
+            args.append('--with-libiconv=gnu')
+        else:
+            args.append('--with-libiconv=no')
         args.extend(self.enable_or_disable('tracing'))
         # SELinux is not available in Spack, so glib should not use it.
         args.append('--disable-selinux')


### PR DESCRIPTION
Enable explicitly building glib with or without libiconv.

We're seeing something like what was described in #6962.  In our case it seems to be caused by glib depending on libxm2, which in turn has a dependency on libiconv.  This puts the libiconv bits in the build environment and glib trips over them.

Heads up: if you build with `~iconv` but there is something else in the spec that includes libiconv then glib will *still* automagically discover it and the build will fail.

I don't currently have the cycles to dig into glib's configure script and figure out why it's still tripping over the libiconv header when it's explicitly been configured with `--with-libiconv=no`.

In order for our build to succeed, we need to build `glib+iconv`.  I've made the default `~iconv`.  I could make it `+iconv` if that seems preferable.

