### PR TITLE
GATK: Add version 4.0.12.0 and installation fixes

### DIFF
--- a/var/spack/repos/builtin/packages/gatk/package.py
+++ b/var/spack/repos/builtin/packages/gatk/package.py
@@ -49,7 +49,7 @@ class Gatk(Package):
         # explicitly codes the path for java and the jar file.
         script_sh = join_path(os.path.dirname(__file__), "gatk.sh")
         script = join_path(prefix.bin, "gatk")
-        copyfile(script_sh, script)
+        install(script_sh, script)
         set_executable(script)
 
         # Munge the helper script to explicitly point to java and the


### PR DESCRIPTION
* Adds version 4.0.12.0
* Updates 4.0.8.1 to use download location from `url` 
* Updates 4.0.8.1 shasum from new download location
* Reverts installation method now that 4.0.8.1 is fixed and now installs correctly for all versions