### PR TITLE
update h5py to 2.9.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-h5py/package.py
+++ b/var/spack/repos/builtin/packages/py-h5py/package.py
@@ -14,7 +14,7 @@ class PyH5py(PythonPackage):
     url      = "https://pypi.io/packages/source/h/h5py/h5py-2.9.0.tar.gz"
 
     import_modules = ['h5py', 'h5py._hl']
-   
+
     version('2.9.0', '9d41ca62daf36d6b6515ab8765e4c8c4388ee18e2a665701fef2b41563821002')
     version('2.8.0', 'ece4f358e69fc8a416f95953b91bc373')
     version('2.7.1', 'da630aebe3ab9fa218ac405a218e95e0')

--- a/var/spack/repos/builtin/packages/py-h5py/package.py
+++ b/var/spack/repos/builtin/packages/py-h5py/package.py
@@ -11,7 +11,7 @@ class PyH5py(PythonPackage):
     HDF5 library from Python."""
 
     homepage = "http://www.h5py.org/"
-    url      = "https://pypi.io/packages/source/h/h5py/h5py-2.8.0.tar.gz"
+    url      = "https://pypi.io/packages/source/h/h5py/h5py-2.9.0.tar.gz"
 
     import_modules = ['h5py', 'h5py._hl']
    

--- a/var/spack/repos/builtin/packages/py-h5py/package.py
+++ b/var/spack/repos/builtin/packages/py-h5py/package.py
@@ -14,7 +14,8 @@ class PyH5py(PythonPackage):
     url      = "https://pypi.io/packages/source/h/h5py/h5py-2.8.0.tar.gz"
 
     import_modules = ['h5py', 'h5py._hl']
-
+   
+    version('2.9.0', '9d41ca62daf36d6b6515ab8765e4c8c4388ee18e2a665701fef2b41563821002')
     version('2.8.0', 'ece4f358e69fc8a416f95953b91bc373')
     version('2.7.1', 'da630aebe3ab9fa218ac405a218e95e0')
     version('2.7.0', 'f62937f40f68d3b128b3941be239dd93')


### PR DESCRIPTION
https://github.com/h5py/h5py/releases/tag/2.9.0