### PR TITLE
Remove /nfs/tmp2 option

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -48,7 +48,6 @@ config:
   # The build stage can be purged with `spack clean --stage`.
   build_stage:
     - $tempdir
-    - /nfs/tmp2/$user
     - $spack/var/spack/stage
 
 

--- a/lib/spack/docs/config_yaml.rst
+++ b/lib/spack/docs/config_yaml.rst
@@ -96,7 +96,6 @@ By default, Spack's ``build_stage`` is configured like this:
 
    build_stage:
     - $tempdir
-    - /nfs/tmp2/$user
     - $spack/var/spack/stage
 
 This is an ordered list of paths that Spack should search when trying to
@@ -106,11 +105,10 @@ See :ref:`config-file-variables` for more on ``$tempdir`` and ``$spack``.
 
 When Spack builds a package, it creates a temporary directory within the
 ``build_stage``, and it creates a symbolic link to that directory in
-``$spack/var/spack/stage``. This is used to track the stage.
-
-After a package is successfully installed, Spack deletes the temporary
-directory it used to build.  Unsuccessful builds are not deleted, but you
-can manually purge them with :ref:`spack clean --stage
+``$spack/var/spack/stage``. This is used to track the temporary
+directory.  After the package is successfully installed, Spack deletes
+the temporary directory it used to build.  Unsuccessful builds are not
+deleted, but you can manually purge them with :ref:`spack clean --stage
 <cmd-spack-clean>`.
 
 .. note::


### PR DESCRIPTION
/nfs/tmp2 is going away from LC... and doesn’t exist for the world. Why have it here???