### PR TITLE
Don't invoke do_patch when archiving patches in mirrors

### DIFF
--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -212,7 +212,10 @@ def create(path, specs, **kwargs):
 def add_single_spec(spec, mirror_root, categories, **kwargs):
     tty.msg("Adding package {pkg} to mirror".format(pkg=spec.format("$_$@")))
     try:
-        spec.package.do_patch()
+        spec.package.do_stage()
+        for p in spec.patches:
+            if hasattr(p, 'archive'):
+                p.archive(spec.package.stage)
         spec.package.do_clean()
 
     except Exception as e:


### PR DESCRIPTION
See: https://github.com/spack/spack/issues/10139

This doesn't actually fix #10139 as it is presented (which is a matter of invoking `spack mirror create` using a complete spec version), but rather addresses an error that comes up for packages which have UrlPatches and a `patch` function; more specifically, this applies for implementations of `patch` which access state (e.g. environment variables like `spack_cc`) that only exist when the package is ready to be installed (e.g. when all of its dependencies are installed).

https://github.com/spack/spack/pull/8993 made use of `Package.do_patch` to ensure that all `UrlPatches` in a package were collected and archived in a mirror; this also calls a `.patch()` function if it is implemented. This PR adds an `archive` function to `UrlPatch` and calls that in favor of `Package.do_patch` in `mirror.add_single_spec`.