### PR TITLE
PARALLEL-NETCDF: Update new version and location

### DIFF
--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -7,19 +7,32 @@ from spack import *
 
 
 class ParallelNetcdf(AutotoolsPackage):
-    """Parallel netCDF (PnetCDF) is a library providing high-performance
-    parallel I/O while still maintaining file-format compatibility with
-    Unidata's NetCDF."""
+    """PnetCDF (Parallel netCDF) is a high-performance parallel I/O
+    library for accessing files in format compatibility with Unidata's
+    NetCDF, specifically the formats of CDF-1, 2, and 5. The CDF-5
+    file format, an extension of CDF-2, supports unsigned data types
+    and uses 64-bit integers to allow users to define large
+    dimensions, attributes, and variables (> 2B array elements).
+    In addition to the conventional netCDF read and write APIs,
+    PnetCDF also provides a set of nonblocking APIs which 
+    allow users to post multiple read and write requests first,
+    and later let PnetCDF aggregate the requests into a large
+    MPI-IO request to achieve better performance."""
 
-    homepage = "https://trac.mcs.anl.gov/projects/parallel-netcdf"
+    homepage = "https://parallel-netcdf.github.io/"
     git      = "https://github.com/Parallel-NetCDF/PnetCDF"
-    url      = "https://parallel-netcdf.github.io/Release/parallel-netcdf-1.11.0.tar.gz"
-    list_url = "https://parallel-netcdf.github.io/wiki/Download.html"
+
+    def url_for_version(self, version):
+        if version >= Version('1.11.0'):
+            url = "https://parallel-netcdf.github.io/Release/pnetcdf-{0}.tar.gz"
+        else:
+            url = "https://parallel-netcdf.github.io/Release/parallel-netcdf-{0}.tar.gz"
+
+        return url.format(version.dotted)
 
     version('develop', branch='develop')
     version('master', branch='master')
-    version('1.11.0', sha256='a18a1a43e6c4fd7ef5827dbe90e9dcf1363b758f513af1f1356ed6c651195a9f',
-            url="https://parallel-netcdf.github.io/Release/pnetcdf-1.11.0.tar.gz")
+    version('1.11.0', sha256='a18a1a43e6c4fd7ef5827dbe90e9dcf1363b758f513af1f1356ed6c651195a9f')
     version('1.10.0', sha256='ed189228b933cfeac3b7b4f8944eb00e4ff2b72cf143365b1a77890980663a09')
     version('1.9.0',  sha256='356e1e1fae14bc6c4236ec11435cfea0ff6bde2591531a4a329f9508a01fbe98')
     version('1.8.1',  sha256='8d7d4c9c7b39bb1cbbcf087e0d726551c50f0cc30d44aed3df63daf3772c9043')

--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -9,18 +9,13 @@ from spack import *
 class ParallelNetcdf(AutotoolsPackage):
     """PnetCDF (Parallel netCDF) is a high-performance parallel I/O
     library for accessing files in format compatibility with Unidata's
-    NetCDF, specifically the formats of CDF-1, 2, and 5. The CDF-5
-    file format, an extension of CDF-2, supports unsigned data types
-    and uses 64-bit integers to allow users to define large
-    dimensions, attributes, and variables (> 2B array elements).
-    In addition to the conventional netCDF read and write APIs,
-    PnetCDF also provides a set of nonblocking APIs which 
-    allow users to post multiple read and write requests first,
-    and later let PnetCDF aggregate the requests into a large
-    MPI-IO request to achieve better performance."""
+    NetCDF, specifically the formats of CDF-1, 2, and 5.
+    """
 
     homepage = "https://parallel-netcdf.github.io/"
     git      = "https://github.com/Parallel-NetCDF/PnetCDF"
+    url      = "https://parallel-netcdf.github.io/Release/pnetcdf-1.11.0.tar.gz"
+    list_url = "https://parallel-netcdf.github.io/wiki/Download.html"
 
     def url_for_version(self, version):
         if version >= Version('1.11.0'):

--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -12,9 +12,14 @@ class ParallelNetcdf(AutotoolsPackage):
     Unidata's NetCDF."""
 
     homepage = "https://trac.mcs.anl.gov/projects/parallel-netcdf"
-    url      = "http://cucis.ece.northwestern.edu/projects/PnetCDF/Release/parallel-netcdf-1.6.1.tar.gz"
-    list_url = "http://cucis.ece.northwestern.edu/projects/PnetCDF/download.html"
+    git      = "https://github.com/Parallel-NetCDF/PnetCDF"
+    url      = "https://parallel-netcdf.github.io/Release/parallel-netcdf-1.11.0.tar.gz"
+    list_url = "https://parallel-netcdf.github.io/wiki/Download.html"
 
+    version('develop', branch='develop')
+    version('master', branch='master')
+    version('1.11.0', sha256='a18a1a43e6c4fd7ef5827dbe90e9dcf1363b758f513af1f1356ed6c651195a9f',
+            url="https://parallel-netcdf.github.io/Release/pnetcdf-1.11.0.tar.gz")
     version('1.10.0', sha256='ed189228b933cfeac3b7b4f8944eb00e4ff2b72cf143365b1a77890980663a09')
     version('1.9.0',  sha256='356e1e1fae14bc6c4236ec11435cfea0ff6bde2591531a4a329f9508a01fbe98')
     version('1.8.1',  sha256='8d7d4c9c7b39bb1cbbcf087e0d726551c50f0cc30d44aed3df63daf3772c9043')


### PR DESCRIPTION
PnetCDF-1.11.0 is released.

Also, the canonical download area has been changed and they are now using git, so can also provide a develop and master checkout.
One issue is that they changed the name of the tar files, so 1.11.0 needs special handling (and future versions will also).

All checksums at new location match the checksums from the old location.