### PR TITLE
travis: fix pip install for docker stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,10 +104,11 @@ jobs:
       os: linux
       language: python
       env: [ TEST_SUITE=build, 'SPEC=mpich' ]
-    - stage: 'docker build'
+    - python: '3.6'
+      stage: 'docker build'
       sudo: required
       os: linux
-      language: generic
+      language: python
       env: TEST_SUITE=docker
   allow_failures:
     - env: TEST_SUITE=docker


### PR DESCRIPTION
It looks like `pip install ...` can sometimes [fail](https://travis-ci.org/spack/spack/jobs/470905791) for the docker stage.  I'm guessing that it might have to do with `language: generic` being set instead of `language: python` , so this PR makes that change in the hopes that Travis then runs in an environment where `pip install ...` would "just work".