### PR TITLE
Add missing module environment variable setting causing OpenSpeedShop to fail at runtime

### DIFF
--- a/var/spack/repos/builtin/packages/openspeedshop/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop/package.py
@@ -6,6 +6,7 @@
 from spack import *
 
 import spack.store
+import os
 
 
 class Openspeedshop(CMakePackage):
@@ -290,6 +291,16 @@ class Openspeedshop(CMakePackage):
         run_env.set('DYNINSTAPI_RT_LIB', dyninst_libdir)
 
         run_env.set('OPENSS_RAWDATA_DIR', '.')
+
+        # Set the openspeedshop plugin path
+        if os.path.isdir(self.prefix.lib64):
+            lib_dir = self.prefix.lib64
+        else:
+            lib_dir = self.prefix.lib
+        plugin_path = '/openspeedshop'
+        oss_plugin_path = lib_dir + plugin_path
+        run_env.set('OPENSS_PLUGIN_PATH', oss_plugin_path)
+
         cbtf_mc = '/sbin/cbtf_mrnet_commnode'
         cbtf_lmb = '/sbin/cbtf_libcbtf_mrnet_backend'
         run_env.set('XPLAT_RSH', 'ssh')


### PR DESCRIPTION
Set the OPENSS_PLUGIN_PATH environment variable.  Users have sent in issues where OpenSpeedShop can't find the analyst plugin when trying to run OpenSpeedShop on their applications.  This mod fixes that issue by setting the variable to the proper path.