### PR TITLE
elfutils: option to install elf.h header file

### DIFF
--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -17,11 +17,11 @@ class Elfutils(AutotoolsPackage):
     version of elfutils."""
 
     homepage = "https://fedorahosted.org/elfutils/"
-
-    url = "https://sourceware.org/elfutils/ftp/0.168/elfutils-0.168.tar.bz2"
+    url      = "https://sourceware.org/elfutils/ftp/0.168/elfutils-0.168.tar.bz2"
     list_url = "https://sourceware.org/elfutils/ftp"
     list_depth = 1
 
+    version('0.175', '9a02b0382b78cc2d515fb950275d4c02')
     version('0.174', '48bec24c0c8b2c16820326956dff9378')
     version('0.173', '35decb1ebfb90d565e4c411bee4185cc')
     version('0.170', '03599aee98c9b726c7a732a2dd0245d5')
@@ -32,7 +32,10 @@ class Elfutils(AutotoolsPackage):
     variant('bzip2', default=False,
             description='Support bzip2 compressed sections.')
     variant('xz', default=False,
-            description='Support xz compressed sections.')
+            description='Support xz (lzma) compressed sections.')
+
+    variant('elfh', default=False,
+            description='Install the elf.h header file.')
 
     # Native language support from libintl.
     variant('nls', default=True,
@@ -86,6 +89,12 @@ class Elfutils(AutotoolsPackage):
             args.append('--disable-nls')
 
         return args
+
+    # Install elf.h to include dir, when +elfh.
+    @run_after('install')
+    def install_elfh(self):
+        if '+elfh' in self.spec:
+            install(join_path('libelf', 'elf.h'), self.prefix.include)
 
     # Provide location of libelf.so to match libelf.
     @property

--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -34,9 +34,6 @@ class Elfutils(AutotoolsPackage):
     variant('xz', default=False,
             description='Support xz (lzma) compressed sections.')
 
-    variant('elfh', default=False,
-            description='Install the elf.h header file.')
-
     # Native language support from libintl.
     variant('nls', default=True,
             description='Enable Native Language Support.')
@@ -90,11 +87,10 @@ class Elfutils(AutotoolsPackage):
 
         return args
 
-    # Install elf.h to include dir, when +elfh.
+    # Install elf.h to include directory.
     @run_after('install')
     def install_elfh(self):
-        if '+elfh' in self.spec:
-            install(join_path('libelf', 'elf.h'), self.prefix.include)
+        install(join_path('libelf', 'elf.h'), self.prefix.include)
 
     # Provide location of libelf.so to match libelf.
     @property


### PR DESCRIPTION
Add variant 'elfh' (default False) to install the elf.h header file to
the include directory.  This provides access to a newer version of
elf.h and allows an elf application to build with the same elf.h that
libelf.so was built with.

Add version 0.175.