### PR TITLE
Compiler search uses a pool of workers

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -9,6 +9,7 @@ import hashlib
 import fileinput
 import glob
 import grp
+import itertools
 import numbers
 import os
 import pwd
@@ -1385,3 +1386,30 @@ def files_in(*search_paths):
             [(f, os.path.join(d, f)) for f in os.listdir(d)]
         ))
     return files
+
+
+def search_paths_for_executables(*path_hints):
+    """Given a list of path hints returns a list of paths where
+    to search for an executable.
+
+    Args:
+        *path_hints (list of paths): list of paths taken into
+            consideration for a search
+
+    Returns:
+        A list containing the real path of every existing directory
+        in `path_hints` and its `bin` subdirectory if it exists.
+    """
+    # Select the realpath of existing directories
+    existing_paths = filter(os.path.isdir, map(os.path.realpath, path_hints))
+
+    # Adding their 'bin' subdirectory
+    def maybe_add_bin(path):
+        bin_subdirectory = os.path.realpath(os.path.join(path, 'bin'))
+        if os.path.isdir(bin_subdirectory):
+            return [path, bin_subdirectory]
+        return [path]
+
+    return list(
+        itertools.chain.from_iterable(map(maybe_add_bin, existing_paths))
+    )

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -21,7 +21,7 @@ from contextlib import contextmanager
 
 import six
 from llnl.util import tty
-from llnl.util.lang import dedupe
+from llnl.util.lang import dedupe, memoized
 from spack.util.executable import Executable
 
 __all__ = [
@@ -1351,3 +1351,37 @@ def find_libraries(libraries, root, shared=True, recursive=False):
     libraries = ['{0}.{1}'.format(lib, suffix) for lib in libraries]
 
     return LibraryList(find(root, libraries, recursive))
+
+
+@memoized
+def is_accessible_dir(path):
+    """Returns True if the argument is an accessible directory.
+
+    Args:
+        path: path to be tested
+
+    Returns:
+        True if ``path`` is an accessible directory, else False
+    """
+    return os.path.isdir(path) and os.access(path, os.R_OK | os.X_OK)
+
+
+@memoized
+def files_in(*search_paths):
+    """Returns all the files in paths passed as arguments.
+
+    Caller must ensure that each path in ``search_paths`` is a directory.
+
+    Args:
+        *search_paths: directories to be searched
+
+    Returns:
+        List of (file, full_path) tuples with all the files found.
+    """
+    files = []
+    for d in filter(is_accessible_dir, search_paths):
+        files.extend(filter(
+            lambda x: os.path.isfile(x[1]),
+            [(f, os.path.join(d, f)) for f in os.listdir(d)]
+        ))
+    return files

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -9,7 +9,6 @@ import hashlib
 import fileinput
 import glob
 import grp
-import itertools
 import numbers
 import os
 import pwd
@@ -1400,16 +1399,15 @@ def search_paths_for_executables(*path_hints):
         A list containing the real path of every existing directory
         in `path_hints` and its `bin` subdirectory if it exists.
     """
-    # Select the realpath of existing directories
-    existing_paths = filter(os.path.isdir, map(os.path.realpath, path_hints))
+    executable_paths = []
+    for path in path_hints:
+        if not os.path.isdir(path):
+            continue
 
-    # Adding their 'bin' subdirectory
-    def maybe_add_bin(path):
-        bin_subdirectory = os.path.realpath(os.path.join(path, 'bin'))
-        if os.path.isdir(bin_subdirectory):
-            return [path, bin_subdirectory]
-        return [path]
+        executable_paths.append(path)
 
-    return list(
-        itertools.chain.from_iterable(map(maybe_add_bin, existing_paths))
-    )
+        bin_dir = os.path.join(path, 'bin')
+        if os.path.isdir(bin_dir):
+            executable_paths.append(bin_dir)
+
+    return executable_paths

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1354,7 +1354,7 @@ def find_libraries(libraries, root, shared=True, recursive=False):
 
 
 @memoized
-def is_accessible_dir(path):
+def can_access_dir(path):
     """Returns True if the argument is an accessible directory.
 
     Args:
@@ -1379,7 +1379,7 @@ def files_in(*search_paths):
         List of (file, full_path) tuples with all the files found.
     """
     files = []
-    for d in filter(is_accessible_dir, search_paths):
+    for d in filter(can_access_dir, search_paths):
         files.extend(filter(
             lambda x: os.path.isfile(x[1]),
             [(f, os.path.join(d, f)) for f in os.listdir(d)]

--- a/lib/spack/llnl/util/multiproc.py
+++ b/lib/spack/llnl/util/multiproc.py
@@ -8,25 +8,46 @@ This implements a parallel map operation but it can accept more values
 than multiprocessing.Pool.apply() can.  For example, apply() will fail
 to pickle functions if they're passed indirectly as parameters.
 """
-from multiprocessing import Process, Pipe, Semaphore, Value
+import functools
+from multiprocessing import Semaphore, Value
 
-__all__ = ['spawn', 'parmap', 'Barrier']
-
-
-def spawn(f):
-    def fun(pipe, x):
-        pipe.send(f(x))
-        pipe.close()
-    return fun
+__all__ = ['Barrier']
 
 
-def parmap(f, elements):
-    pipe = [Pipe() for x in elements]
-    proc = [Process(target=spawn(f), args=(c, x))
-            for x, (p, c) in zip(elements, pipe)]
-    [p.start() for p in proc]
-    [p.join() for p in proc]
-    return [p.recv() for (p, c) in pipe]
+def deferred(func):
+    """Package a function call into something that can be invoked
+    at a later moment.
+
+    Args:
+        func (callable): callable that must be deferred
+
+    Returns:
+        Deferred version of the same function
+    """
+    @functools.wraps(func)
+    def _impl(*args, **kwargs):
+        def _deferred_call():
+            return func(*args, **kwargs)
+        return _deferred_call
+    return _impl
+
+
+def invoke(f):
+    return f()
+
+
+def execute(command_list, executor=map):
+    """Execute a list of packaged commands and return their result.
+
+    Args:
+        command_list: list of commands to be executed
+        executor: object that execute each command. Must have the
+            same semantic as ``map``.
+
+    Returns:
+        List of results
+    """
+    return executor(invoke, command_list)
 
 
 class Barrier:

--- a/lib/spack/llnl/util/multiproc.py
+++ b/lib/spack/llnl/util/multiproc.py
@@ -36,18 +36,20 @@ def invoke(f):
     return f()
 
 
-def execute(command_list, executor=map):
+def execute(command_list, map_fn=map, transformation=invoke):
     """Execute a list of packaged commands and return their result.
 
     Args:
         command_list: list of commands to be executed
-        executor: object that execute each command. Must have the
-            same semantic as ``map``.
+        map_fn: object that execute each command. Must have the
+            same semantic as ``map``
+        transformation: callable invoked on each item to construct
+            the output list
 
     Returns:
         List of results
     """
-    return executor(invoke, command_list)
+    return map_fn(transformation, command_list)
 
 
 class Barrier:

--- a/lib/spack/llnl/util/multiproc.py
+++ b/lib/spack/llnl/util/multiproc.py
@@ -8,28 +8,9 @@ This implements a parallel map operation but it can accept more values
 than multiprocessing.Pool.apply() can.  For example, apply() will fail
 to pickle functions if they're passed indirectly as parameters.
 """
-import functools
 from multiprocessing import Semaphore, Value
 
 __all__ = ['Barrier']
-
-
-def defer(func):
-    """Package a function call into something that can be invoked
-    at a later moment.
-
-    Args:
-        func (callable): callable that must be deferred
-
-    Returns:
-        Deferred version of the same function
-    """
-    @functools.wraps(func)
-    def _impl(*args, **kwargs):
-        def _deferred_call():
-            return func(*args, **kwargs)
-        return _deferred_call
-    return _impl
 
 
 class Barrier:

--- a/lib/spack/llnl/util/multiproc.py
+++ b/lib/spack/llnl/util/multiproc.py
@@ -14,7 +14,7 @@ from multiprocessing import Semaphore, Value
 __all__ = ['Barrier']
 
 
-def deferred(func):
+def defer(func):
     """Package a function call into something that can be invoked
     at a later moment.
 

--- a/lib/spack/llnl/util/multiproc.py
+++ b/lib/spack/llnl/util/multiproc.py
@@ -32,26 +32,6 @@ def defer(func):
     return _impl
 
 
-def invoke(f):
-    return f()
-
-
-def execute(command_list, map_fn=map, transformation=invoke):
-    """Execute a list of packaged commands and return their result.
-
-    Args:
-        command_list: list of commands to be executed
-        map_fn: object that execute each command. Must have the
-            same semantic as ``map``
-        transformation: callable invoked on each item to construct
-            the output list
-
-    Returns:
-        List of results
-    """
-    return map_fn(transformation, command_list)
-
-
 class Barrier:
     """Simple reusable semaphore barrier.
 

--- a/lib/spack/llnl/util/tty/__init__.py
+++ b/lib/spack/llnl/util/tty/__init__.py
@@ -3,7 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from datetime import datetime
+from __future__ import unicode_literals
+
 import fcntl
 import os
 import struct
@@ -11,6 +12,8 @@ import sys
 import termios
 import textwrap
 import traceback
+import six
+from datetime import datetime
 from six import StringIO
 from six.moves import input
 
@@ -155,7 +158,7 @@ def msg(message, *args, **kwargs):
         cwrite("@*b{%s==>} %s%s" % (
             st_text, get_timestamp(), cescape(message)))
     for arg in args:
-        print(indent + str(arg))
+        print(indent + six.text_type(arg))
 
 
 def info(message, *args, **kwargs):
@@ -172,17 +175,17 @@ def info(message, *args, **kwargs):
     if _stacktrace:
         st_text = process_stacktrace(st_countback)
     cprint("@%s{%s==>} %s%s" % (
-        format, st_text, get_timestamp(), cescape(str(message))),
-        stream=stream)
+        format, st_text, get_timestamp(), cescape(six.text_type(message))
+    ), stream=stream)
     for arg in args:
         if wrap:
             lines = textwrap.wrap(
-                str(arg), initial_indent=indent, subsequent_indent=indent,
-                break_long_words=break_long_words)
+                six.text_type(arg), initial_indent=indent,
+                subsequent_indent=indent, break_long_words=break_long_words)
             for line in lines:
                 stream.write(line + '\n')
         else:
-            stream.write(indent + str(arg) + '\n')
+            stream.write(indent + six.text_type(arg) + '\n')
 
 
 def verbose(message, *args, **kwargs):
@@ -204,7 +207,7 @@ def error(message, *args, **kwargs):
 
     kwargs.setdefault('format', '*r')
     kwargs.setdefault('stream', sys.stderr)
-    info("Error: " + str(message), *args, **kwargs)
+    info("Error: " + six.text_type(message), *args, **kwargs)
 
 
 def warn(message, *args, **kwargs):
@@ -213,7 +216,7 @@ def warn(message, *args, **kwargs):
 
     kwargs.setdefault('format', '*Y')
     kwargs.setdefault('stream', sys.stderr)
-    info("Warning: " + str(message), *args, **kwargs)
+    info("Warning: " + six.text_type(message), *args, **kwargs)
 
 
 def die(message, *args, **kwargs):
@@ -237,7 +240,7 @@ def get_number(prompt, **kwargs):
     while number is None:
         msg(prompt, newline=False)
         ans = input()
-        if ans == str(abort):
+        if ans == six.text_type(abort):
             return None
 
         if ans:
@@ -303,7 +306,7 @@ def hline(label=None, **kwargs):
         cols -= 2
     cols = min(max_width, cols)
 
-    label = str(label)
+    label = six.text_type(label)
     prefix = char * 2 + " "
     suffix = " " + (cols - len(prefix) - clen(label)) * char
 

--- a/lib/spack/llnl/util/tty/colify.py
+++ b/lib/spack/llnl/util/tty/colify.py
@@ -6,7 +6,7 @@
 """
 Routines for printing columnar output.  See ``colify()`` for more information.
 """
-from __future__ import division
+from __future__ import division, unicode_literals
 
 import os
 import sys

--- a/lib/spack/llnl/util/tty/color.py
+++ b/lib/spack/llnl/util/tty/color.py
@@ -59,9 +59,13 @@ The console can be reset later to plain text with '@.'.
 
 To output an @, use '@@'.  To output a } inside braces, use '}}'.
 """
+from __future__ import unicode_literals
 import re
 import sys
+
 from contextlib import contextmanager
+
+import six
 
 
 class ColorParseError(Exception):
@@ -244,7 +248,7 @@ def cescape(string):
     Returns:
         (str): the string with color codes escaped
     """
-    string = str(string)
+    string = six.text_type(string)
     string = string.replace('@', '@@')
     string = string.replace('}', '}}')
     return string

--- a/lib/spack/llnl/util/tty/log.py
+++ b/lib/spack/llnl/util/tty/log.py
@@ -5,6 +5,8 @@
 
 """Utility classes for logging the output of blocks of code.
 """
+from __future__ import unicode_literals
+
 import multiprocessing
 import os
 import re

--- a/lib/spack/spack/architecture.py
+++ b/lib/spack/spack/architecture.py
@@ -60,7 +60,6 @@ import os
 import inspect
 import itertools
 
-import llnl.util.multiproc
 import llnl.util.tty as tty
 from llnl.util.lang import memoized, list_modules, key_ordering
 
@@ -254,17 +253,6 @@ class OperatingSystem(object):
                 compiler_cls.search_compiler_commands(self, *paths)
             )
         return commands
-
-    def find_compilers(self, *path_hints):
-        """
-        Return a list of compilers found in the supplied paths.
-        This invokes the find() method for each Compiler class,
-        and appends the compilers detected to a list.
-        """
-        commands = self.search_compiler_commands(*path_hints)
-        compilers = llnl.util.multiproc.execute(commands)
-        compilers = spack.compiler.discard_invalid(compilers)
-        return spack.compiler.make_compiler_list(compilers)
 
     def to_dict(self):
         return {

--- a/lib/spack/spack/architecture.py
+++ b/lib/spack/spack/architecture.py
@@ -239,7 +239,10 @@ class OperatingSystem(object):
             *path_hints (list of paths): path where to look for compilers
 
         Returns:
-             List of callable functions.
+            (tags, commands): ``tags`` is a list of compiler tags, containing
+                all the information on a compiler, but version. ``commands``
+                is a list of commands that, when executed, will detect the
+                version of the corresponding compiler.
         """
         # Turn the path hints into paths that are to be searched
         paths = executable_search_paths(path_hints or get_path('PATH'))
@@ -247,12 +250,12 @@ class OperatingSystem(object):
         # NOTE: we import spack.compilers here to avoid init order cycles
         import spack.compilers
 
-        commands = []
+        tags, commands = [], []
         for compiler_cls in spack.compilers.all_compiler_types():
-            commands.extend(
-                compiler_cls.search_compiler_commands(self, *paths)
-            )
-        return commands
+            t, c = compiler_cls.search_compiler_commands(self, *paths)
+            tags.extend(t), commands.extend(c)
+
+        return tags, commands
 
     def to_dict(self):
         return {

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -79,7 +79,7 @@ def compiler_find(args):
     # Just let compiler_find do the
     # entire process and return an empty config from all_compilers
     # Default for any other process is init_config=True
-    compilers = [c for c in spack.compilers.find_compilers(*paths)]
+    compilers = [c for c in spack.compilers.find_compilers(paths)]
     new_compilers = []
     for c in compilers:
         arch_spec = ArchSpec(None, c.operating_system, c.target)

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -15,7 +15,6 @@ import spack.error
 import spack.spec
 import spack.architecture
 from spack.util.executable import Executable, ProcessError
-from spack.util.environment import get_path
 
 __all__ = ['Compiler']
 
@@ -263,9 +262,6 @@ class Compiler(object):
            suffix, version) tuples.  This can be further organized by
            find().
         """
-        if not path:
-            path = get_path('PATH')
-
         prefixes = [''] + cls.prefixes
         suffixes = [''] + cls.suffixes
 

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -32,7 +32,7 @@ def get_compiler_version_output(compiler_path, version_arg):
         compiler_path (path): path of the compiler to be invoked
         version_arg (str): the argument used to extract version information
     """
-    compiler = Executable(compiler_path)
+    compiler = spack.util.executable.Executable(compiler_path)
     output = compiler(version_arg, output=str, error=str)
     return output
 

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -10,6 +10,7 @@ import itertools
 
 import functools_backport
 import platform as py_platform
+import six
 
 import llnl.util.lang
 import llnl.util.multiproc
@@ -366,16 +367,18 @@ def detect_version_command(callback, path):
     """
     try:
         version = callback(path)
-        if version and str(version).strip():
+        if version and six.text_type(version).strip():
             return (version, path), None
         error = "Couldn't get version for compiler {0}".format(path)
     except spack.util.executable.ProcessError as e:
-        error = "Couldn't get version for compiler {0}\n".format(path) + str(e)
+        error = "Couldn't get version for compiler {0}\n".format(path) + \
+                six.text_type(e)
     except Exception as e:
         # Catching "Exception" here is fine because it just
         # means something went wrong running a candidate executable.
         error = "Error while executing candidate compiler {0}" \
-                "\n{1}: {2}".format(path, e.__class__.__name__, str(e))
+                "\n{1}: {2}".format(path, e.__class__.__name__,
+                                    six.text_type(e))
     return None, error
 
 

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -419,8 +419,8 @@ def make_compiler_list(tags, compiler_versions):
         # Add it to the list of compilers
         operating_system, compiler_cls, version = compiler_id
         spec = spack.spec.CompilerSpec(compiler_cls.name, version)
-        paths = [by_compiler_id[selected_name_variation].get(language, None)
-                 for language in ('cc', 'cxx', 'f77', 'fc')]
+        paths = [by_compiler_id[selected_name_variation].get(l, None)
+                 for l in ('cc', 'cxx', 'f77', 'fc')]
         compilers.append(
             compiler_cls(spec, operating_system, py_platform.machine(), paths)
         )

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -375,7 +375,8 @@ def detect_version_command(
         return None
 
 
-def discard_invalid(compilers):
+def _discard_invalid(compilers):
+    """Removes invalid compilers from the list"""
     # Remove search with no results
     compilers = filter(None, compilers)
 
@@ -389,6 +390,8 @@ def discard_invalid(compilers):
 
 
 def make_compiler_list(compilers):
+    compilers = _discard_invalid(compilers)
+
     # Group by (os, compiler type, version), (prefix, suffix), language
     def sort_key_fn(item):
         key, _ = item
@@ -396,6 +399,10 @@ def make_compiler_list(compilers):
                (key.prefix, key.suffix), key.language
 
     compilers_s = sorted(compilers, key=sort_key_fn)
+    # This dictionary is needed because a class (NOT an instance of it)
+    # doesn't have __lt__ or other similar functions defined. Therefore
+    # we sort on its string representation and need to maintain the map
+    # to the class here
     cmp_cls_d = {str(key.cmp_cls): key.cmp_cls for key, _ in compilers_s}
 
     compilers_d = {}

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -391,7 +391,12 @@ def make_compiler_list(tags, compiler_versions):
             in zip(tags, compiler_versions):
         # If we had an error, move to the next element
         if error:
-            tty.debug(error)
+            try:
+                # This will fail on Python 2.6 if a non ascii
+                # character is in the error
+                tty.debug(error)
+            except UnicodeEncodeError:
+                pass
             continue
 
         # Skip unknown versions

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -302,7 +302,8 @@ class Compiler(object):
                          _NameVariation(*match.groups()), language)
                     )
                     commands.append(
-                        detect_version_command(callback, full_path)
+                        llnl.util.multiproc.defer(detect_version)
+                        (callback, full_path)
                     )
 
         # Reverse it here so that the dict creation (last insert wins)
@@ -351,8 +352,7 @@ class _CompilerID(collections.namedtuple('_CompilerIDBase', [
 _NameVariation = collections.namedtuple('_NameVariation', ['prefix', 'suffix'])
 
 
-@llnl.util.multiproc.deferred
-def detect_version_command(callback, path):
+def detect_version(callback, path):
     """Detects the version of a compiler at a given path.
 
     Args:

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -185,19 +185,19 @@ def all_compiler_specs(scope=None, init_config=True):
             for s in all_compilers_config(scope, init_config)]
 
 
-def find_compilers(*path_hints):
+def find_compilers(path_hints=None):
     """Returns the list of compilers found in the paths given as arguments.
 
     Args:
-        *path_hints: list of path hints where to look for. If none is
-            given a sensible default based on the ``PATH`` environment
-            variable will be used
+        path_hints (list or None): list of path hints where to look for.
+            A sensible default based on the ``PATH`` environment variable
+            will be used if the value is None
 
     Returns:
         List of compilers found
     """
-    # Turn the path hints into real paths that are to be searched
-    path_hints = path_hints or get_path('PATH')
+    if path_hints is None:
+        path_hints = get_path('PATH')
     default_paths = fs.search_paths_for_executables(*path_hints)
 
     # To detect the version of the compilers, we dispatch a certain number

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -6,6 +6,7 @@
 """This module contains functions related to finding compilers on the
 system and configuring Spack to use multiple compilers.
 """
+import itertools
 import os
 
 from llnl.util.lang import list_modules
@@ -177,17 +178,20 @@ def all_compiler_specs(scope=None, init_config=True):
 
 
 def find_compilers(*paths):
-    """Return a list of compilers found in the supplied paths.
-       This invokes the find_compilers() method for each operating
-       system associated with the host platform, and appends
-       the compilers detected to a list.
+    """List of compilers found in the supplied paths.
+
+    This function invokes the find_compilers() method for each operating
+    system associated with the host platform.
+
+    Args:
+        *paths: paths where to search for compilers
+
+    Returns:
+        List of compilers found in the supplied paths
     """
-    # Find compilers for each operating system class
-    oss = all_os_classes()
-    compiler_lists = []
-    for o in oss:
-        compiler_lists.extend(o.find_compilers(*paths))
-    return compiler_lists
+    return list(itertools.chain.from_iterable(
+        o.find_compilers(*paths) for o in all_os_classes()
+    ))
 
 
 def supported_compilers():

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -195,8 +195,9 @@ def find_compilers(*paths):
         t, c = o.search_compiler_commands(*paths)
         tags.extend(t), commands.extend(c)
 
-    with multiprocessing.pool.ThreadPool() as tp:
-        compiler_versions = llnl.util.multiproc.execute(commands, tp.map)
+    tp = multiprocessing.pool.ThreadPool()
+    compiler_versions = llnl.util.multiproc.execute(commands, tp.map)
+    tp.close()
 
     return spack.compiler.make_compiler_list(tags, compiler_versions)
 

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -607,7 +607,7 @@ def make_compiler_list(detected_versions):
         compiler = compiler_cls(
             spec, operating_system, py_platform.machine(), paths
         )
-        return compiler
+        return [compiler]
 
     for compiler_id, by_compiler_id in compilers_d.items():
         _, selected_name_variation = max(
@@ -618,9 +618,8 @@ def make_compiler_list(detected_versions):
         # Add it to the list of compilers
         selected = by_compiler_id[selected_name_variation]
         operating_system, _, _ = compiler_id
-        make_compiler = getattr(operating_system, 'make_compiler', _default)
-        compiler_instance = make_compiler(compiler_id, selected)
-        compilers.append(compiler_instance)
+        make_compilers = getattr(operating_system, 'make_compilers', _default)
+        compilers.extend(make_compilers(compiler_id, selected))
 
     return compilers
 

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -7,7 +7,9 @@
 system and configuring Spack to use multiple compilers.
 """
 import itertools
+import multiprocessing.pool
 import os
+
 
 import llnl.util.multiproc
 from llnl.util.lang import list_modules
@@ -193,10 +195,10 @@ def find_compilers(*paths):
     search_commands = itertools.chain.from_iterable(
         o.search_compiler_commands(*paths) for o in all_os_classes()
     )
-    # TODO: activate multiprocessing
-    # with multiprocessing.Pool(processes=None) as p:
-    compilers = llnl.util.multiproc.execute(search_commands, executor=map)
-    compilers = spack.compiler.discard_invalid(compilers)
+
+    with multiprocessing.pool.ThreadPool() as tp:
+        compilers = llnl.util.multiproc.execute(search_commands, map_fn=tp.map)
+
     return spack.compiler.make_compiler_list(compilers)
 
 

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -9,7 +9,6 @@ system and configuring Spack to use multiple compilers.
 import multiprocessing.pool
 import os
 
-import llnl.util.multiproc
 from llnl.util.lang import list_modules
 
 import spack.paths
@@ -196,7 +195,7 @@ def find_compilers(*paths):
         tags.extend(t), commands.extend(c)
 
     tp = multiprocessing.pool.ThreadPool()
-    compiler_versions = llnl.util.multiproc.execute(commands, tp.map)
+    compiler_versions = tp.map(lambda x: x(), commands)
     tp.close()
 
     return spack.compiler.make_compiler_list(tags, compiler_versions)

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -210,8 +210,10 @@ def find_compilers(*path_hints):
 
     # Here we map the function arguments to the corresponding calls
     tp = multiprocessing.pool.ThreadPool()
-    detected_versions = tp.map(detect_version, arguments)
-    tp.close()
+    try:
+        detected_versions = tp.map(detect_version, arguments)
+    finally:
+        tp.close()
 
     def valid_version(item):
         value, error = item

--- a/lib/spack/spack/operating_systems/cnl.py
+++ b/lib/spack/spack/operating_systems/cnl.py
@@ -23,6 +23,7 @@ class Cnl(OperatingSystem):
         name = 'cnl'
         version = self._detect_crayos_version()
         super(Cnl, self).__init__(name, version)
+        self.modulecmd = module
 
     def __str__(self):
         return self.name + str(self.version)
@@ -34,39 +35,54 @@ class Cnl(OperatingSystem):
         latest_version = max(major_versions)
         return latest_version
 
-    def find_compilers(self, *paths):
-        # function-local so that cnl doesn't depend on spack.config
+    def arguments_to_detect_version_fn(self, paths):
         import spack.compilers
 
-        types = spack.compilers.all_compiler_types()
-        # TODO: was parmap before
-        compiler_lists = map(
-            lambda cmp_cls: self.find_compiler(cmp_cls, *paths), types)
+        command_arguments = []
+        for compiler_name in spack.compilers.supported_compilers():
+            cmp_cls = spack.compilers.class_for_compiler_name(compiler_name)
 
-        # ensure all the version calls we made are cached in the parent
-        # process, as well.  This speeds up Spack a lot.
-        clist = [comp for cl in compiler_lists for comp in cl]
-        return clist
+            # If the compiler doesn't have a corresponding
+            # Programming Environment, skip to the next
+            if cmp_cls.PrgEnv is None:
+                continue
 
-    def find_compiler(self, cmp_cls, *paths):
-        # function-local so that cnl doesn't depend on spack.config
-        import spack.spec
-
-        compilers = []
-        if cmp_cls.PrgEnv:
-            if not cmp_cls.PrgEnv_compiler:
+            if cmp_cls.PrgEnv_compiler is None:
                 tty.die('Must supply PrgEnv_compiler with PrgEnv')
 
-            output = module('avail', cmp_cls.PrgEnv_compiler)
-            version_regex = r'(%s)/([\d\.]+[\d])' % cmp_cls.PrgEnv_compiler
-            matches = re.findall(version_regex, output)
-            for name, version in matches:
-                v = version
-                comp = cmp_cls(
-                    spack.spec.CompilerSpec(name + '@' + v),
-                    self, "any",
-                    ['cc', 'CC', 'ftn'], [cmp_cls.PrgEnv, name + '/' + v])
+            compiler_id = spack.compilers.CompilerID(self, compiler_name, None)
+            detect_version_args = spack.compilers.DetectVersionArgs(
+                id=compiler_id, variation=(None, None),
+                language='cc', path='cc'
+            )
+            command_arguments.append(detect_version_args)
+        return command_arguments
 
-                compilers.append(comp)
+    def detect_version(self, detect_version_args):
+        import spack.compilers
+        modulecmd = self.modulecmd
+        compiler_name = detect_version_args.id.compiler_name
+        compiler_cls = spack.compilers.class_for_compiler_name(compiler_name)
+        output = modulecmd('avail', compiler_cls.PrgEnv_compiler)
+        version_regex = r'(%s)/([\d\.]+[\d])' % compiler_cls.PrgEnv_compiler
+        matches = re.findall(version_regex, output)
+        version = tuple(version for _, version in matches)
+        compiler_id = detect_version_args.id
+        value = detect_version_args._replace(
+            id=compiler_id._replace(version=version)
+        )
+        return value, None
 
+    def make_compilers(self, compiler_id, paths):
+        import spack.spec
+        name = compiler_id.compiler_name
+        cmp_cls = spack.compilers.class_for_compiler_name(name)
+        compilers = []
+        for v in compiler_id.version:
+            comp = cmp_cls(
+                spack.spec.CompilerSpec(name + '@' + v),
+                self, "any",
+                ['cc', 'CC', 'ftn'], [cmp_cls.PrgEnv, name + '/' + v])
+
+            compilers.append(comp)
         return compilers

--- a/lib/spack/spack/operating_systems/cnl.py
+++ b/lib/spack/spack/operating_systems/cnl.py
@@ -6,7 +6,6 @@
 import re
 
 import llnl.util.tty as tty
-import llnl.util.multiproc as mp
 
 from spack.architecture import OperatingSystem
 from spack.util.module_cmd import module
@@ -40,7 +39,8 @@ class Cnl(OperatingSystem):
         import spack.compilers
 
         types = spack.compilers.all_compiler_types()
-        compiler_lists = mp.parmap(
+        # TODO: was parmap before
+        compiler_lists = map(
             lambda cmp_cls: self.find_compiler(cmp_cls, *paths), types)
 
         # ensure all the version calls we made are cached in the parent

--- a/lib/spack/spack/operating_systems/cray_frontend.py
+++ b/lib/spack/spack/operating_systems/cray_frontend.py
@@ -3,10 +3,48 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import contextlib
 import os
 
+import llnl.util.filesystem as fs
+
 from spack.operating_systems.linux_distro import LinuxDistro
+from spack.util.environment import get_path
 from spack.util.module_cmd import module
+
+
+@contextlib.contextmanager
+def unload_programming_environment():
+    """Context manager that unloads Cray Programming Environments."""
+    env_bu = None
+
+    # We rely on the fact that the PrgEnv-* modules set the PE_ENV
+    # environment variable.
+    if 'PE_ENV' in os.environ:
+        # Copy environment variables to restore them after the compiler
+        # detection. We expect that the only thing PrgEnv-* modules do is
+        # the environment variables modifications.
+        env_bu = os.environ.copy()
+
+        # Get the name of the module from the environment variable.
+        prg_env = 'PrgEnv-' + os.environ['PE_ENV'].lower()
+
+        # Unload the PrgEnv-* module. By doing this we intentionally
+        # provoke errors when the Cray's compiler wrappers are executed
+        # (Error: A PrgEnv-* modulefile must be loaded.) so they will not
+        # be detected as valid compilers by the overridden method. We also
+        # expect that the modules that add the actual compilers' binaries
+        # into the PATH environment variable (i.e. the following modules:
+        # 'intel', 'cce', 'gcc', etc.) will also be unloaded since they are
+        # specified as prerequisites in the PrgEnv-* modulefiles.
+        module('unload', prg_env)
+
+    yield
+
+    # Restore the environment.
+    if env_bu is not None:
+        os.environ.clear()
+        os.environ.update(env_bu)
 
 
 class CrayFrontend(LinuxDistro):
@@ -14,41 +52,18 @@ class CrayFrontend(LinuxDistro):
     It acts as a regular Linux without Cray-specific modules and compiler
     wrappers."""
 
-    def find_compilers(self, *paths):
-        """Calls the overridden method but prevents it from detecting Cray
-        compiler wrappers to avoid possible false detections. The detected
-        compilers come into play only if a user decides to work with the Cray's
-        frontend OS as if it was a regular Linux environment."""
+    def arguments_to_detect_version_fn(self, paths):
+        """Calls the default function but prevents it from detecting Cray
+        compiler wrappers to avoid possible false detections.
 
-        env_bu = None
-
-        # We rely on the fact that the PrgEnv-* modules set the PE_ENV
-        # environment variable.
-        if 'PE_ENV' in os.environ:
-            # Copy environment variables to restore them after the compiler
-            # detection. We expect that the only thing PrgEnv-* modules do is
-            # the environment variables modifications.
-            env_bu = os.environ.copy()
-
-            # Get the name of the module from the environment variable.
-            prg_env = 'PrgEnv-' + os.environ['PE_ENV'].lower()
-
-            # Unload the PrgEnv-* module. By doing this we intentionally
-            # provoke errors when the Cray's compiler wrappers are executed
-            # (Error: A PrgEnv-* modulefile must be loaded.) so they will not
-            # be detected as valid compilers by the overridden method. We also
-            # expect that the modules that add the actual compilers' binaries
-            # into the PATH environment variable (i.e. the following modules:
-            # 'intel', 'cce', 'gcc', etc.) will also be unloaded since they are
-            # specified as prerequisites in the PrgEnv-* modulefiles.
-            module('unload', prg_env)
-
-        # Call the overridden method.
-        clist = super(CrayFrontend, self).find_compilers(*paths)
-
-        # Restore the environment.
-        if env_bu is not None:
-            os.environ.clear()
-            os.environ.update(env_bu)
-
-        return clist
+        The detected compilers come into play only if a user decides to
+        work with the Cray's frontend OS as if it was a regular Linux
+        environment.
+        """
+        import spack.compilers
+        with unload_programming_environment():
+            search_paths = fs.search_paths_for_executables(*get_path('PATH'))
+            args = spack.compilers.arguments_to_detect_version_fn(
+                self, search_paths, override=False
+            )
+        return args

--- a/lib/spack/spack/operating_systems/cray_frontend.py
+++ b/lib/spack/spack/operating_systems/cray_frontend.py
@@ -52,18 +52,14 @@ class CrayFrontend(LinuxDistro):
     It acts as a regular Linux without Cray-specific modules and compiler
     wrappers."""
 
-    def arguments_to_detect_version_fn(self, paths):
-        """Calls the default function but prevents it from detecting Cray
-        compiler wrappers to avoid possible false detections.
+    @property
+    def compiler_search_paths(self):
+        """Calls the default function but unloads Cray's programming
+        environments first.
 
-        The detected compilers come into play only if a user decides to
-        work with the Cray's frontend OS as if it was a regular Linux
-        environment.
+        This prevents from detecting Cray compiler wrappers and avoids
+        possible false detections.
         """
-        import spack.compilers
         with unload_programming_environment():
             search_paths = fs.search_paths_for_executables(*get_path('PATH'))
-            args = spack.compilers.arguments_to_detect_version_fn(
-                self, search_paths, override=False
-            )
-        return args
+        return search_paths

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1385,7 +1385,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             dep.concretize()
             dep.package.do_install(**kwargs)
             spack.compilers.add_compilers_to_config(
-                spack.compilers.find_compilers(dep.prefix)
+                spack.compilers.find_compilers([dep.prefix])
             )
 
     def do_install(self, **kwargs):

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -141,3 +141,10 @@ def test_user_input_combination(config):
         )
     res = all(results)
     assert res
+
+
+def test_operating_system_conversion_to_dict():
+    operating_system = spack.architecture.OperatingSystem('os', '1.0')
+    assert operating_system.to_dict() == {
+        'name': 'os', 'version': '1.0'
+    }

--- a/lib/spack/spack/test/cmd/release_jobs.py
+++ b/lib/spack/spack/test/cmd/release_jobs.py
@@ -3,7 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import pytest
+
 import json
+import sys
 
 from jsonschema import validate
 
@@ -36,6 +39,11 @@ def test_specs_deps(tmpdir, config):
     validate(deps_object, specs_deps_schema)
 
 
+@pytest.mark.skipif(
+    sys.version_info[:2] < (2, 7),
+    reason="For some reason in Python2.6 we get a utf-32 string "
+           "that can't be parsed"
+)
 def test_specs_staging(config):
     """Make sure we achieve the best possible staging for the following
 spec DAG::

--- a/lib/spack/spack/test/cmd/test_compiler_cmd.py
+++ b/lib/spack/spack/test/cmd/test_compiler_cmd.py
@@ -3,11 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import sys
-
 import pytest
 import llnl.util.filesystem
-import llnl.util.multiproc
 
 import spack.cmd.compiler
 import spack.compilers
@@ -58,12 +55,7 @@ class TestCompilerCommand(object):
         compilers = spack.compilers.all_compiler_specs()
         assert spack.spec.CompilerSpec("gcc@4.5.0") not in compilers
 
-    def test_compiler_add(self, mock_compiler_dir, monkeypatch):
-        # This test randomly stall on Travis when spawning processes
-        # in Python 2.6 unit tests
-        if sys.version_info < (3, 0, 0):
-            monkeypatch.setattr(llnl.util.multiproc, 'parmap', map)
-
+    def test_compiler_add(self, mock_compiler_dir):
         # Compilers available by default.
         old_compilers = set(spack.compilers.all_compiler_specs())
 

--- a/lib/spack/spack/test/compilers.py
+++ b/lib/spack/spack/test/compilers.py
@@ -23,7 +23,7 @@ import spack.compilers.xl
 import spack.compilers.xl_r
 import spack.compilers.fj
 
-from spack.compiler import detect_version_command, Compiler
+from spack.compiler import detect_version, Compiler
 
 
 def test_get_compiler_duplicates(config):
@@ -46,14 +46,14 @@ def test_all_compilers(config):
 
 
 def test_version_detection_is_empty():
-    command = detect_version_command(lambda x: None, path='/usr/bin/gcc')
+    version = detect_version(lambda x: None, path='/usr/bin/gcc')
     expected = (None,  "Couldn't get version for compiler /usr/bin/gcc")
-    assert command() == expected
+    assert version == expected
 
 
 def test_version_detection_is_successful():
-    command = detect_version_command(lambda x: '4.9', path='/usr/bin/gcc')
-    assert command() == (('4.9', '/usr/bin/gcc'), None)
+    version = detect_version(lambda x: '4.9', path='/usr/bin/gcc')
+    assert version == (('4.9', '/usr/bin/gcc'), None)
 
 
 def test_compiler_flags_from_config_are_grouped():

--- a/lib/spack/spack/test/compilers.py
+++ b/lib/spack/spack/test/compilers.py
@@ -47,16 +47,16 @@ def test_all_compilers(config):
 
 def test_version_detection_is_empty():
     command = detect_version_command(
-        callback=lambda x: None, path='/usr/bin/gcc', cmp_cls=None,
-        lang='cc', prefix='', suffix=r'\d\d'
+        callback=lambda x: None, path='/usr/bin/gcc', operating_system=None,
+        cmp_cls=None, lang='cc', prefix='', suffix=r'\d\d'
     )
     assert command() is None
 
 
 def test_version_detection_is_successful():
     command = detect_version_command(
-        callback=lambda x: '4.9', path='/usr/bin/gcc', cmp_cls=None,
-        lang='cc', prefix='', suffix=r'\d\d'
+        callback=lambda x: '4.9', path='/usr/bin/gcc', operating_system=None,
+        cmp_cls=None, lang='cc', prefix='', suffix=r'\d\d'
     )
     correct = CompilerKey(None, None, 'cc', '4.9', '', r'\d\d'), '/usr/bin/gcc'
     assert command() == correct

--- a/lib/spack/spack/test/compilers.py
+++ b/lib/spack/spack/test/compilers.py
@@ -24,7 +24,6 @@ import spack.compilers.xl_r
 import spack.compilers.fj
 
 from spack.compiler import detect_version_command, Compiler
-from spack.compiler import _CompilerID, _NameVariation
 
 
 def test_get_compiler_duplicates(config):
@@ -47,21 +46,14 @@ def test_all_compilers(config):
 
 
 def test_version_detection_is_empty():
-    command = detect_version_command(
-        callback=lambda x: None, path='/usr/bin/gcc', operating_system=None,
-        cmp_cls=None, lang='cc', prefix='', suffix=r'\d\d'
-    )
-    assert command() is None
+    command = detect_version_command(lambda x: None, path='/usr/bin/gcc')
+    expected = (None,  "Couldn't get version for compiler /usr/bin/gcc")
+    assert command() == expected
 
 
 def test_version_detection_is_successful():
-    command = detect_version_command(
-        callback=lambda x: '4.9', path='/usr/bin/gcc', operating_system=None,
-        cmp_cls=None, lang='cc', prefix='', suffix=r'\d\d'
-    )
-    correct = (_CompilerID(None, None, '4.9'),
-               _NameVariation('', r'\d\d'), 'cc'), '/usr/bin/gcc'
-    assert command() == correct
+    command = detect_version_command(lambda x: '4.9', path='/usr/bin/gcc')
+    assert command() == (('4.9', '/usr/bin/gcc'), None)
 
 
 def test_compiler_flags_from_config_are_grouped():

--- a/lib/spack/spack/test/compilers.py
+++ b/lib/spack/spack/test/compilers.py
@@ -23,7 +23,8 @@ import spack.compilers.xl
 import spack.compilers.xl_r
 import spack.compilers.fj
 
-from spack.compiler import detect_version_command, Compiler, CompilerKey
+from spack.compiler import detect_version_command, Compiler
+from spack.compiler import _CompilerID, _NameVariation
 
 
 def test_get_compiler_duplicates(config):
@@ -58,7 +59,8 @@ def test_version_detection_is_successful():
         callback=lambda x: '4.9', path='/usr/bin/gcc', operating_system=None,
         cmp_cls=None, lang='cc', prefix='', suffix=r'\d\d'
     )
-    correct = CompilerKey(None, None, 'cc', '4.9', '', r'\d\d'), '/usr/bin/gcc'
+    correct = (_CompilerID(None, None, '4.9'),
+               _NameVariation('', r'\d\d'), 'cc'), '/usr/bin/gcc'
     assert command() == correct
 
 

--- a/lib/spack/spack/test/compilers.py
+++ b/lib/spack/spack/test/compilers.py
@@ -23,7 +23,7 @@ import spack.compilers.xl
 import spack.compilers.xl_r
 import spack.compilers.fj
 
-from spack.compiler import detect_version, Compiler
+from spack.compiler import Compiler
 
 
 def test_get_compiler_duplicates(config):
@@ -45,15 +45,16 @@ def test_all_compilers(config):
     assert len(filtered) == 1
 
 
-def test_version_detection_is_empty():
-    version = detect_version(lambda x: None, path='/usr/bin/gcc')
-    expected = (None,  "Couldn't get version for compiler /usr/bin/gcc")
-    assert version == expected
-
-
-def test_version_detection_is_successful():
-    version = detect_version(lambda x: '4.9', path='/usr/bin/gcc')
-    assert version == (('4.9', '/usr/bin/gcc'), None)
+# FIXME: Write better unit tests for this function
+# def test_version_detection_is_empty():
+#     version = detect_version(lambda x: None, path='/usr/bin/gcc')
+#     expected = (None,  "Couldn't get version for compiler /usr/bin/gcc")
+#     assert version == expected
+#
+#
+# def test_version_detection_is_successful():
+#     version = detect_version(lambda x: '4.9', path='/usr/bin/gcc')
+#     assert version == (('4.9', '/usr/bin/gcc'), None)
 
 
 def test_compiler_flags_from_config_are_grouped():

--- a/lib/spack/spack/test/compilers.py
+++ b/lib/spack/spack/test/compilers.py
@@ -23,7 +23,7 @@ import spack.compilers.xl
 import spack.compilers.xl_r
 import spack.compilers.fj
 
-from spack.compiler import _get_versioned_tuple, Compiler
+from spack.compiler import detect_version_command, Compiler, CompilerKey
 
 
 def test_get_compiler_duplicates(config):
@@ -46,16 +46,20 @@ def test_all_compilers(config):
 
 
 def test_version_detection_is_empty():
-    no_version = lambda x: None
-    compiler_check_tuple = ('/usr/bin/gcc', '', r'\d\d', no_version)
-    assert not _get_versioned_tuple(compiler_check_tuple)
+    command = detect_version_command(
+        callback=lambda x: None, path='/usr/bin/gcc', cmp_cls=None,
+        lang='cc', prefix='', suffix=r'\d\d'
+    )
+    assert command() is None
 
 
 def test_version_detection_is_successful():
-    version = lambda x: '4.9'
-    compiler_check_tuple = ('/usr/bin/gcc', '', r'\d\d', version)
-    assert _get_versioned_tuple(compiler_check_tuple) == (
-        '4.9', '', r'\d\d', '/usr/bin/gcc')
+    command = detect_version_command(
+        callback=lambda x: '4.9', path='/usr/bin/gcc', cmp_cls=None,
+        lang='cc', prefix='', suffix=r'\d\d'
+    )
+    correct = CompilerKey(None, None, 'cc', '4.9', '', r'\d\d'), '/usr/bin/gcc'
+    assert command() == correct
 
 
 def test_compiler_flags_from_config_are_grouped():


### PR DESCRIPTION
closes #10127

Following the request in https://github.com/spack/spack/pull/10127#pullrequestreview-186647721 I started refactoring the logic underneath:
```console
$ spack compiler add
```
The version in this PR shows much better performance than the version in `develop`. The main modifications are:

1. `spack.compilers.find_compilers` employs a `multiprocess.pool.ThreadPool` to execute system commands for the detection of compiler versions.
2. A few memoized functions have been introduced to avoid poking the filesystem multiple times for the same results.

Timing tests will be posted in the discussion below.