### PR TITLE
patches: add a patch cache, allow patches to be looked up by sha256

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,6 +112,8 @@ jobs:
       env: TEST_SUITE=docker
   allow_failures:
     - env: TEST_SUITE=docker
+    # temporary Python 2.6 exception while we figure out why Travis is hanging
+    - python: '2.6'
 
 stages:
   - 'style checks'

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -1422,6 +1422,73 @@ with all packages in Spack, a patched dependency library can coexist with
 other versions of that library.  See the `section on depends_on
 <dependency_dependency_patching_>`_ for more details.
 
+.. _patch_inspecting_patches:
+
+^^^^^^^^^^^^^^^^^^^
+Inspecting patches
+^^^^^^^^^^^^^^^^^^^
+
+If you want to better understand the patches that Spack applies to your
+packages, you can do that using ``spack spec``, ``spack find``, and other
+query commands.  Let's look at ``m4``.  If you run ``spack spec m4``, you
+can see the patches that would be applied to ``m4``::
+
+  $ spack spec m4
+  Input spec
+  --------------------------------
+  m4
+
+  Concretized
+  --------------------------------
+  m4@1.4.18%clang@9.0.0-apple patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,c0a408fbffb7255fcc75e26bd8edab116fc81d216bfd18b473668b7739a4158e,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8 +sigsegv arch=darwin-highsierra-x86_64
+      ^libsigsegv@2.11%clang@9.0.0-apple arch=darwin-highsierra-x86_64
+
+You can also see patches that have been applied to installed packages
+with ``spack find -v``::
+
+  $ spack find -v m4
+  ==> 1 installed package
+  -- darwin-highsierra-x86_64 / clang@9.0.0-apple -----------------
+  m4@1.4.18 patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,c0a408fbffb7255fcc75e26bd8edab116fc81d216bfd18b473668b7739a4158e,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8 +sigsegv
+
+.. _cmd-spack-resource:
+
+In both cases above, you can see that the patches' sha256 hashes are
+stored on the spec as a variant.  As mentioned above, this means that you
+can have multiple, differently-patched versions of a package installed at
+once.
+
+You can look up a patch by its sha256 hash (or a short version of it)
+using the ``spack resource show`` command::
+
+  $ spack resource show 3877ab54
+  3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00
+      path:       /home/spackuser/src/spack/var/spack/repos/builtin/packages/m4/gnulib-pgi.patch
+      applies to: builtin.m4
+
+``spack resource show`` looks up downloadable resources from package
+files by hash and prints out information about them.  Above, we see that
+the ``3877ab54`` patch applies to the ``m4`` package.  The output also
+tells us where to find the patch.
+
+Things get more interesting if you want to know about dependency
+patches. For example, when ``dealii`` is built with ``boost@1.68.0``, it
+has to patch boost to work correctly.  If you didn't know this, you might
+wonder where the extra boost patches are coming from::
+
+  $ spack spec dealii ^boost@1.68.0 ^hdf5+fortran | grep '\^boost'
+      ^boost@1.68.0
+          ^boost@1.68.0%clang@9.0.0-apple+atomic+chrono~clanglibcpp cxxstd=default +date_time~debug+exception+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy patches=2ab6c72d03dec6a4ae20220a9dfd5c8c572c5294252155b85c6874d97c323199,b37164268f34f7133cbc9a4066ae98fda08adf51e1172223f6a969909216870f ~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave arch=darwin-highsierra-x86_64
+  $ spack resource show b37164268
+  b37164268f34f7133cbc9a4066ae98fda08adf51e1172223f6a969909216870f
+      path:       /home/spackuser/src/spack/var/spack/repos/builtin/packages/dealii/boost_1.68.0.patch
+      applies to: builtin.boost
+      patched by: builtin.dealii
+
+Here you can see that the patch is applied to ``boost`` by ``dealii``,
+and that it lives in ``dealii``'s directory in Spack's ``builtin``
+package repository.
+
 .. _handling_rpaths:
 
 ---------------

--- a/lib/spack/spack/cmd/resource.py
+++ b/lib/spack/spack/cmd/resource.py
@@ -1,0 +1,84 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from __future__ import print_function
+import os
+
+import llnl.util.tty as tty
+import llnl.util.tty.color as color
+
+import spack.repo
+
+
+description = "list downloadable resources (tarballs, repos, patches, etc.)"
+section = "basic"
+level = "long"
+
+
+def setup_parser(subparser):
+    sp = subparser.add_subparsers(
+        metavar='SUBCOMMAND', dest='resource_command')
+
+    list_parser = sp.add_parser('list', help=resource_list.__doc__)
+    list_parser.add_argument('--only-hashes', action='store_true',
+                             help='only print sha256 hashes of resources')
+
+    show_parser = sp.add_parser('show', help=resource_show.__doc__)
+    show_parser.add_argument('hash', action='store')
+
+
+def _show_patch(sha256):
+    """Show a record from the patch index."""
+    patches = spack.repo.path.patch_index.index
+    data = patches.get(sha256)
+
+    if not data:
+        candidates = [k for k in patches if k.startswith(sha256)]
+        if not candidates:
+            tty.die('no such resource: %s' % sha256)
+        elif len(candidates) > 1:
+            tty.die('%s: ambiguous hash prefix. Options are:',
+                    *candidates)
+
+        sha256 = candidates[0]
+        data = patches.get(sha256)
+
+    color.cprint('@c{%s}' % sha256)
+    for package, rec in data.items():
+        owner = rec['owner']
+
+        if 'relative_path' in rec:
+            pkg_dir = spack.repo.get(owner).package_dir
+            path = os.path.join(pkg_dir, rec['relative_path'])
+            print("    path:       %s" % path)
+        else:
+            print("    url:        %s" % rec['url'])
+
+        print("    applies to: %s" % package)
+        if owner != package:
+            print("    patched by: %s" % owner)
+
+
+def resource_list(args):
+    """list all resources known to spack (currently just patches)"""
+    patches = spack.repo.path.patch_index.index
+    for sha256 in patches:
+        if args.only_hashes:
+            print(sha256)
+        else:
+            _show_patch(sha256)
+
+
+def resource_show(args):
+    """show a resource, identified by its checksum"""
+    _show_patch(args.hash)
+
+
+def resource(parser, args):
+    action = {
+        'list': resource_list,
+        'show': resource_show
+    }
+    action[args.resource_command](args)

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -395,7 +395,7 @@ def patch(url_or_filename, level=1, when=None, working_dir=".", **kwargs):
     certain conditions (e.g. a particular version).
 
     Args:
-        url_or_filename (str): url or filename of the patch
+        url_or_filename (str): url or relative filename of the patch
         level (int): patch level (as in the patch shell command)
         when (Spec): optional anonymous spec that specifies when to apply
             the patch
@@ -417,13 +417,18 @@ def patch(url_or_filename, level=1, when=None, working_dir=".", **kwargs):
         # patch to the existing list.
         cur_patches = pkg_or_dep.patches.setdefault(when_spec, [])
 
-        # if pkg_or_dep is a Dependency, make it a Package
         pkg = pkg_or_dep
         if isinstance(pkg, Dependency):
             pkg = pkg.pkg
 
-        cur_patches.append(spack.patch.create(
-            pkg, url_or_filename, level, working_dir, **kwargs))
+        if '://' in url_or_filename:
+            patch = spack.patch.UrlPatch(
+                pkg, url_or_filename, level, working_dir, **kwargs)
+        else:
+            patch = spack.patch.FilePatch(
+                pkg, url_or_filename, level, working_dir)
+
+        cur_patches.append(patch)
 
     return _execute_patch
 

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -36,12 +36,12 @@ from six import string_types
 import llnl.util.lang
 
 import spack.error
+import spack.patch
 import spack.spec
 import spack.url
 import spack.variant
 from spack.dependency import Dependency, default_deptype, canonical_deptype
 from spack.fetch_strategy import from_kwargs
-from spack.patch import Patch
 from spack.resource import Resource
 from spack.version import Version
 
@@ -416,9 +416,14 @@ def patch(url_or_filename, level=1, when=None, working_dir=".", **kwargs):
         # if this spec is identical to some other, then append this
         # patch to the existing list.
         cur_patches = pkg_or_dep.patches.setdefault(when_spec, [])
-        cur_patches.append(
-            Patch.create(pkg_or_dep, url_or_filename, level,
-                         working_dir, **kwargs))
+
+        # if pkg_or_dep is a Dependency, make it a Package
+        pkg = pkg_or_dep
+        if isinstance(pkg, Dependency):
+            pkg = pkg.pkg
+
+        cur_patches.append(spack.patch.create(
+            pkg, url_or_filename, level, working_dir, **kwargs))
 
     return _execute_patch
 

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -194,7 +194,7 @@ class DirectiveMeta(type):
                 # Nasty, but it's the best way I can think of to avoid
                 # side effects if directive results are passed as args
                 remove_directives(args)
-                remove_directives(kwargs.values())
+                remove_directives(list(kwargs.values()))
 
                 # A directive returns either something that is callable on a
                 # package or a sequence of them

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -3,41 +3,24 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import abc
+import hashlib
 import os
 import os.path
-import hashlib
+import six
 
 import llnl.util.filesystem
+import llnl.util.lang
 
 import spack.error
 import spack.fetch_strategy as fs
+import spack.repo
 import spack.stage
-from spack.util.crypto import checksum, Checker
+import spack.util.spack_json as sjson
 
-from spack.util.executable import which
 from spack.util.compression import allowed_archive
-
-
-def create(pkg, path_or_url, level=1, working_dir=".", **kwargs):
-    """Make either a FilePatch or a UrlPatch, depending on arguments.
-
-      Args:
-          pkg: package that needs to be patched
-          path_or_url: path or url where the patch is found
-          level: patch level (default 1)
-          working_dir (str): relative path within the package stage;
-              change to this before before applying (default '.')
-
-      Returns:
-          (Patch): a patch object on which ``apply(stage)`` can be called
-    """
-    # Check if we are dealing with a URL (which will be fetched)
-    if '://' in path_or_url:
-        return UrlPatch(path_or_url, level, working_dir, **kwargs)
-
-    # If not, it's a file patch, which is stored within the repo directory.
-    patch_path = os.path.join(pkg.package_dir, path_or_url)
-    return FilePatch(patch_path, level, working_dir)
+from spack.util.crypto import checksum, Checker
+from spack.util.executable import which
 
 
 def apply_patch(stage, patch_path, level=1, working_dir='.'):
@@ -58,40 +41,68 @@ def apply_patch(stage, patch_path, level=1, working_dir='.'):
               '-d', working_dir)
 
 
+@six.add_metaclass(abc.ABCMeta)
 class Patch(object):
     """Base class for patches.
 
-    Defines the interface (basically just ``apply()``, at the moment) and
-    common variables.
+    Arguments:
+        pkg (str): the package that owns the patch
+
+    The owning package is not necessarily the package to apply the patch
+    to -- in the case where a dependent package patches its dependency,
+    it is the dependent's fullname.
+
     """
-    def __init__(self, path_or_url, level, working_dir):
+    def __init__(self, pkg, path_or_url, level, working_dir):
         # validate level (must be an integer >= 0)
         if not isinstance(level, int) or not level >= 0:
             raise ValueError("Patch level needs to be a non-negative integer.")
 
         # Attributes shared by all patch subclasses
+        self.owner = pkg.fullname
         self.path_or_url = path_or_url  # needed for debug output
         self.level = level
         self.working_dir = working_dir
 
-        # path needs to be set by subclasses before calling self.apply()
-        self.path = None
-
+    @abc.abstractmethod
     def apply(self, stage):
-        """Apply this patch to code in a stage."""
-        assert self.path, "self.path must be set before Patch.apply()"
-        apply_patch(stage, self.path, self.level, self.working_dir)
+        """Apply a patch to source in a stage.
+
+        Arguments:
+            stage (spack.stage.Stage): stage where source code lives
+        """
+
+    def to_dict(self):
+        """Partial dictionary -- subclases should add to this."""
+        return {
+            'owner': self.owner,
+            'sha256': self.sha256,
+            'level': self.level,
+            'working_dir': self.working_dir,
+        }
 
 
 class FilePatch(Patch):
-    """Describes a patch that is retrieved from a file in the repository"""
-    def __init__(self, path, level, working_dir):
-        super(FilePatch, self).__init__(path, level, working_dir)
+    """Describes a patch that is retrieved from a file in the repository.
 
-        if not os.path.isfile(path):
-            raise NoSuchPatchError("No such patch: %s" % path)
-        self.path = path
+    Arguments:
+        pkg (str): the class object for the package that owns the patch
+        relative_path (str): path to patch, relative to the repository
+            directory for a package.
+        level (int): level to pass to patch command
+        working_dir (str): path within the source directory where patch
+            should be applied
+    """
+    def __init__(self, pkg, relative_path, level, working_dir):
+        self.relative_path = relative_path
+        self.path = os.path.join(pkg.package_dir, self.relative_path)
+        super(FilePatch, self).__init__(pkg, self.path, level, working_dir)
         self._sha256 = None
+
+    def apply(self, stage):
+        if not os.path.isfile(self.path):
+            raise NoSuchPatchError("No such patch: %s" % self.path)
+        apply_patch(stage, self.path, self.level, self.working_dir)
 
     @property
     def sha256(self):
@@ -99,13 +110,27 @@ class FilePatch(Patch):
             self._sha256 = checksum(hashlib.sha256, self.path)
         return self._sha256
 
+    def to_dict(self):
+        return llnl.util.lang.union_dicts(
+            super(FilePatch, self).to_dict(),
+            {'relative_path': self.relative_path})
+
 
 class UrlPatch(Patch):
-    """Describes a patch that is retrieved from a URL"""
-    def __init__(self, url, level, working_dir, **kwargs):
-        super(UrlPatch, self).__init__(url, level, working_dir)
+    """Describes a patch that is retrieved from a URL.
+
+    Arguments:
+        pkg (str): the package that owns the patch
+        url (str): URL where the patch can be fetched
+        level (int): level to pass to patch command
+        working_dir (str): path within the source directory where patch
+            should be applied
+    """
+    def __init__(self, pkg, url, level=1, working_dir='.', **kwargs):
+        super(UrlPatch, self).__init__(pkg, url, level, working_dir)
 
         self.url = url
+        self.path = None  # this is set in apply
 
         self.archive_sha256 = kwargs.get('archive_sha256')
         if allowed_archive(self.url) and not self.archive_sha256:
@@ -153,6 +178,7 @@ class UrlPatch(Patch):
                     raise NoSuchPatchError(
                         "Patch failed to download: %s" % self.url)
 
+            # set this here so that path is accessible after
             self.path = os.path.join(root, files.pop())
 
             if not os.path.isfile(self.path):
@@ -168,7 +194,170 @@ class UrlPatch(Patch):
                         "sha256 checksum failed for %s" % self.path,
                         "Expected %s but got %s" % (self.sha256, checker.sum))
 
-            super(UrlPatch, self).apply(stage)
+            apply_patch(stage, self.path, self.level, self.working_dir)
+
+    def to_dict(self):
+        data = super(UrlPatch, self).to_dict()
+        data['url'] = self.url
+        if self.archive_sha256:
+            data['archive_sha256'] = self.archive_sha256
+        return data
+
+
+def from_dict(dictionary):
+    """Create a patch from json dictionary."""
+    owner = dictionary.get('owner')
+    if 'owner' not in dictionary:
+        raise ValueError('Invalid patch dictionary: %s' % dictionary)
+    pkg = spack.repo.get(owner)
+
+    if 'url' in dictionary:
+        return UrlPatch(
+            pkg,
+            dictionary['url'],
+            dictionary['level'],
+            dictionary['working_dir'],
+            sha256=dictionary['sha256'],
+            archive_sha256=dictionary.get('archive_sha256'))
+
+    elif 'relative_path' in dictionary:
+        patch = FilePatch(
+            pkg,
+            dictionary['relative_path'],
+            dictionary['level'],
+            dictionary['working_dir'])
+
+        # If the patch in the repo changes, we cannot get it back, so we
+        # just check it and fail here.
+        # TODO: handle this more gracefully.
+        sha256 = dictionary['sha256']
+        checker = Checker(sha256)
+        if not checker.check(patch.path):
+            raise fs.ChecksumError(
+                "sha256 checksum failed for %s" % patch.path,
+                "Expected %s but got %s" % (sha256, checker.sum),
+                "Patch may have changed since concretization.")
+        return patch
+    else:
+        raise ValueError("Invalid patch dictionary: %s" % dictionary)
+
+
+class PatchCache(object):
+    """Index of patches used in a repository, by sha256 hash.
+
+    This allows us to look up patches without loading all packages.  It's
+    also needed to properly implement dependency patching, as need a way
+    to look up patches that come from packages not in the Spec sub-DAG.
+
+    The patch index is structured like this in a file (this is YAML, but
+    we write JSON)::
+
+        patches:
+            sha256:
+                namespace1.package1:
+                    <patch json>
+                namespace2.package2:
+                    <patch json>
+                ... etc. ...
+
+    """
+    def __init__(self, data=None):
+        if data is None:
+            self.index = {}
+        else:
+            if 'patches' not in data:
+                raise IndexError('invalid patch index; try `spack clean -m`')
+            self.index = data['patches']
+
+    @classmethod
+    def from_json(cls, stream):
+        return PatchCache(sjson.load(stream))
+
+    def to_json(self, stream):
+        sjson.dump({'patches': self.index}, stream)
+
+    def patch_for_package(self, sha256, pkg):
+        """Look up a patch in the index and build a patch object for it.
+
+        Arguments:
+            sha256 (str): sha256 hash to look up
+            pkg (spack.package.Package): Package object to get patch for.
+
+        We build patch objects lazily because building them requires that
+        we have information about the package's location in its repo.
+
+        """
+        sha_index = self.index.get(sha256)
+        if not sha_index:
+            raise NoSuchPatchError(
+                "Couldn't find patch with sha256: %s" % sha256)
+
+        patch_dict = sha_index.get(pkg.fullname)
+        if not patch_dict:
+            raise NoSuchPatchError(
+                "Couldn't find patch for package %s with sha256: %s"
+                % (pkg.fullname, sha256))
+
+        # add the sha256 back (we take it out on write to save space,
+        # because it's the index key)
+        patch_dict = dict(patch_dict)
+        patch_dict['sha256'] = sha256
+        return from_dict(patch_dict)
+
+    def update_package(self, pkg_fullname):
+        # remove this package from any patch entries that reference it.
+        empty = []
+        for sha256, package_to_patch in self.index.items():
+            remove = []
+            for fullname, patch_dict in package_to_patch.items():
+                if patch_dict['owner'] == pkg_fullname:
+                    remove.append(fullname)
+
+            for fullname in remove:
+                package_to_patch.pop(fullname)
+
+            if not package_to_patch:
+                empty.append(sha256)
+
+        # remove any entries that are now empty
+        for sha256 in empty:
+            del self.index[sha256]
+
+        # update the index with per-package patch indexes
+        pkg = spack.repo.get(pkg_fullname)
+        partial_index = self._index_patches(pkg)
+        for sha256, package_to_patch in partial_index.items():
+            p2p = self.index.setdefault(sha256, {})
+            p2p.update(package_to_patch)
+
+    def update(self, other):
+        """Update this cache with the contents of another."""
+        for sha256, package_to_patch in other.index.items():
+            p2p = self.index.setdefault(sha256, {})
+            p2p.update(package_to_patch)
+
+    @staticmethod
+    def _index_patches(pkg_class):
+        index = {}
+
+        # Add patches from the class
+        for cond, patch_list in pkg_class.patches.items():
+            for patch in patch_list:
+                patch_dict = patch.to_dict()
+                patch_dict.pop('sha256')  # save some space
+                index[patch.sha256] = {pkg_class.fullname: patch_dict}
+
+        # and patches on dependencies
+        for name, conditions in pkg_class.dependencies.items():
+            for cond, dependency in conditions.items():
+                for pcond, patch_list in dependency.patches.items():
+                    for patch in patch_list:
+                        dspec = spack.repo.get(dependency.spec.name)
+                        patch_dict = patch.to_dict()
+                        patch_dict.pop('sha256')  # save some space
+                        index[patch.sha256] = {dspec.fullname: patch_dict}
+
+        return index
 
 
 class NoSuchPatchError(spack.error.SpackError):

--- a/lib/spack/spack/provider_index.py
+++ b/lib/spack/spack/provider_index.py
@@ -6,13 +6,13 @@
 """
 The ``virtual`` module contains utility classes for virtual dependencies.
 """
+
 from itertools import product as iproduct
 from six import iteritems
 from pprint import pformat
 
 import spack.error
-import spack.util.spack_yaml as syaml
-from ruamel.yaml.error import MarkedYAMLError
+import spack.util.spack_json as sjson
 
 
 class ProviderIndex(object):
@@ -169,31 +169,26 @@ class ProviderIndex(object):
 
         return all(c in result for c in common)
 
-    def to_yaml(self, stream=None):
+    def to_json(self, stream=None):
         provider_list = self._transform(
             lambda vpkg, pset: [
                 vpkg.to_node_dict(), [p.to_node_dict() for p in pset]], list)
 
-        syaml.dump({'provider_index': {'providers': provider_list}},
-                   stream=stream)
+        sjson.dump({'provider_index': {'providers': provider_list}}, stream)
 
     @staticmethod
-    def from_yaml(stream):
-        try:
-            yfile = syaml.load(stream)
-        except MarkedYAMLError as e:
-            raise spack.spec.SpackYAMLError(
-                "error parsing YAML ProviderIndex cache:", str(e))
+    def from_json(stream):
+        data = sjson.load(stream)
 
-        if not isinstance(yfile, dict):
-            raise ProviderIndexError("YAML ProviderIndex was not a dict.")
+        if not isinstance(data, dict):
+            raise ProviderIndexError("JSON ProviderIndex data was not a dict.")
 
-        if 'provider_index' not in yfile:
+        if 'provider_index' not in data:
             raise ProviderIndexError(
                 "YAML ProviderIndex does not start with 'provider_index'")
 
         index = ProviderIndex()
-        providers = yfile['provider_index']['providers']
+        providers = data['provider_index']['providers']
         index.providers = _transform(
             providers,
             lambda vpkg, plist: (

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -276,14 +276,14 @@ class ProviderIndexer(Indexer):
         return ProviderIndex()
 
     def read(self, stream):
-        self.index = ProviderIndex.from_yaml(stream)
+        self.index = ProviderIndex.from_json(stream)
 
     def update(self, pkg_fullname):
         self.index.remove_provider(pkg_fullname)
         self.index.update(pkg_fullname)
 
     def write(self, stream):
-        self.index.to_yaml(stream)
+        self.index.to_json(stream)
 
 
 class RepoIndex(object):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2677,24 +2677,16 @@ class Spec(object):
         if 'patches' not in self.variants:
             return []
 
-        patches = []
-
-        # FIXME: The private attribute below is attached after
+        # FIXME: _patches_in_order_of_appearance is attached after
         # FIXME: concretization to store the order of patches somewhere.
         # FIXME: Needs to be refactored in a cleaner way.
+
+        # translate patch sha256sums to patch objects by consulting the index
+        patches = []
         for sha256 in self.variants['patches']._patches_in_order_of_appearance:
-            patch = self.package_class.lookup_patch(sha256)
-            if patch:
-                patches.append(patch)
-                continue
-
-            # if not found in this package, check immediate dependents
-            # for dependency patches
-            for dep_spec in self._dependents.values():
-                patch = dep_spec.parent.package_class.lookup_patch(sha256)
-
-                if patch:
-                    patches.append(patch)
+            index = spack.repo.path.patch_index
+            patch = index.patch_for_package(sha256, self.package)
+            patches.append(patch)
 
         return patches
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -232,7 +232,7 @@ def test_env_repo():
 
     package = e.repo.get('mpileaks')
     assert package.name == 'mpileaks'
-    assert package.namespace == 'spack.pkg.builtin.mock'
+    assert package.namespace == 'builtin.mock'
 
 
 def test_user_removed_spec():

--- a/lib/spack/spack/test/cmd/providers.py
+++ b/lib/spack/spack/test/cmd/providers.py
@@ -22,11 +22,13 @@ def test_it_just_runs(pkg):
 
 
 @pytest.mark.parametrize('vpkg,provider_list', [
-    (('mpi',), ['intel-mpi',
+    (('mpi',), ['charmpp@6.7.1:',
+                'intel-mpi',
                 'intel-parallel-studio',
                 'mpich',
                 'mpich@1:',
                 'mpich@3:',
+                'mpilander',
                 'mvapich2',
                 'openmpi',
                 'openmpi@1.6.5',

--- a/lib/spack/spack/test/cmd/resource.py
+++ b/lib/spack/spack/test/cmd/resource.py
@@ -1,0 +1,60 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.main import SpackCommand
+
+
+resource = SpackCommand('resource')
+
+#: these are hashes used in mock packages
+mock_hashes = [
+    'abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234',
+    '1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd',
+    'b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c',
+    'c45c1564f70def3fc1a6e22139f62cb21cd190cc3a7dbe6f4120fa59ce33dcb8',
+    '24eceabef5fe8f575ff4b438313dc3e7b30f6a2d1c78841fbbe3b9293a589277',
+    '689b8f9b32cb1d2f9271d29ea3fca2e1de5df665e121fca14e1364b711450deb',
+    'ebe27f9930b99ebd8761ed2db3ea365142d0bafd78317efb4baadf62c7bf94d0',
+    '208fcfb50e5a965d5757d151b675ca4af4ce2dfd56401721b6168fae60ab798f',
+    'bf07a7fbb825fc0aae7bf4a1177b2b31fcf8a3feeaf7092761e18c859ee52a9c',
+    '7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730',
+]
+
+
+def test_resource_list(mock_packages, capfd):
+    with capfd.disabled():
+        out = resource('list')
+
+    for h in mock_hashes:
+        assert h in out
+
+    assert 'url:' in out
+    assert 'applies to:' in out
+    assert 'patched by:' in out
+    assert 'path:' in out
+
+    assert 'repos/builtin.mock/packages/patch-a-dependency/libelf.patch' in out
+    assert 'applies to: builtin.mock.libelf' in out
+    assert 'patched by: builtin.mock.patch-a-dependency' in out
+
+
+def test_resource_list_only_hashes(mock_packages, capfd):
+    with capfd.disabled():
+        out = resource('list', '--only-hashes')
+
+    for h in mock_hashes:
+        assert h in out
+
+
+def test_resource_show(mock_packages, capfd):
+    with capfd.disabled():
+        out = resource('show', 'c45c1564f70def3fc1a6e22139f62cb21cd190cc3a7dbe6f4120fa59ce33dcb8')
+
+    assert out.startswith('c45c1564f70def3fc1a6e22139f62cb21cd190cc3a7dbe6f4120fa59ce33dcb8')
+    assert 'repos/builtin.mock/packages/patch-a-dependency/libelf.patch' in out
+    assert 'applies to: builtin.mock.libelf' in out
+    assert 'patched by: builtin.mock.patch-a-dependency' in out
+
+    assert len(out.strip().split('\n')) == 4

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -101,12 +101,13 @@ def test_dont_add_patches_to_installed_package(install_mockery, mock_fetch):
     dependency.concretize()
     dependency.package.do_install()
 
-    dependency.package.patches['dependency-install'] = [
-        spack.patch.create(None, 'file://fake.patch', sha256='unused-hash')]
-
     dependency_hash = dependency.dag_hash()
     dependent = Spec('dependent-install ^/' + dependency_hash)
     dependent.concretize()
+
+    dependency.package.patches['dependency-install'] = [
+        spack.patch.UrlPatch(
+            dependent.package, 'file://fake.patch', sha256='unused-hash')]
 
     assert dependent['dependency-install'] == dependency
 

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -6,6 +6,7 @@
 import os
 import pytest
 
+import spack.patch
 import spack.repo
 import spack.store
 from spack.spec import Spec
@@ -96,14 +97,12 @@ def test_partial_install_delete_prefix_and_stage(install_mockery, mock_fetch):
 
 
 def test_dont_add_patches_to_installed_package(install_mockery, mock_fetch):
-    import sys
     dependency = Spec('dependency-install')
     dependency.concretize()
     dependency.package.do_install()
 
     dependency.package.patches['dependency-install'] = [
-        sys.modules['spack.patch'].Patch.create(
-            None, 'file://fake.patch', sha256='unused-hash')]
+        spack.patch.create(None, 'file://fake.patch', sha256='unused-hash')]
 
     dependency_hash = dependency.dag_hash()
     dependent = Spec('dependent-install ^/' + dependency_hash)

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -160,7 +160,7 @@ def test_mirror_with_url_patches(mock_packages, config, monkeypatch):
         with open(os.path.join(expanded_path, 'test.patch'), 'w'):
             pass
 
-    def successful_apply(_class, stage):
+    def successful_apply(*args, **kwargs):
         pass
 
     with Stage('spack-mirror-test') as stage:
@@ -170,7 +170,7 @@ def test_mirror_with_url_patches(mock_packages, config, monkeypatch):
                             successful_fetch)
         monkeypatch.setattr(spack.fetch_strategy.URLFetchStrategy,
                             'expand', successful_expand)
-        monkeypatch.setattr(spack.patch.Patch, 'apply', successful_apply)
+        monkeypatch.setattr(spack.patch, 'apply_patch', successful_apply)
         monkeypatch.setattr(spack.caches.MirrorCache, 'store', record_store)
 
         with spack.config.override('config:checksum', False):

--- a/lib/spack/spack/test/patch.py
+++ b/lib/spack/spack/test/patch.py
@@ -41,8 +41,9 @@ data_path = os.path.join(spack.paths.test_path, 'data', 'patch')
 def test_url_patch(mock_stage, filename, sha256, archive_sha256):
     # Make a patch object
     url = 'file://' + filename
-    patch = spack.patch.create(
-        None, url, sha256=sha256, archive_sha256=archive_sha256)
+    pkg = spack.repo.get('patch')
+    patch = spack.patch.UrlPatch(
+        pkg, url, sha256=sha256, archive_sha256=archive_sha256)
 
     # make a stage
     with Stage(url) as stage:  # TODO: url isn't used; maybe refactor Stage

--- a/lib/spack/spack/test/patch.py
+++ b/lib/spack/spack/test/patch.py
@@ -16,6 +16,18 @@ from spack.util.executable import Executable
 from spack.stage import Stage
 from spack.spec import Spec
 
+# various sha256 sums (using variables for legibility)
+
+# files with contents 'foo', 'bar', and 'baz'
+foo_sha256 = 'b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c'
+bar_sha256 = '7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730'
+baz_sha256 = 'bf07a7fbb825fc0aae7bf4a1177b2b31fcf8a3feeaf7092761e18c859ee52a9c'
+
+# url patches
+url1_sha256 = 'abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234'
+url2_sha256 = '1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd'
+url2_archive_sha256 = 'abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd'
+
 
 @pytest.fixture()
 def mock_stage(tmpdir, monkeypatch):
@@ -84,9 +96,9 @@ def test_patch_in_spec(mock_packages, config):
     # Here the order is bar, foo, baz. Note that MV variants order
     # lexicographically based on the hash, not on the position of the
     # patch directive.
-    assert (('7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730',
-             'b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c',
-             'bf07a7fbb825fc0aae7bf4a1177b2b31fcf8a3feeaf7092761e18c859ee52a9c') ==
+    assert ((bar_sha256,
+             foo_sha256,
+             baz_sha256) ==
             spec.variants['patches'].value)
 
 
@@ -125,15 +137,14 @@ def test_multiple_patched_dependencies(mock_packages, config):
     # basic patch on libelf
     assert 'patches' in list(spec['libelf'].variants.keys())
     # foo
-    assert (('b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c',) ==
+    assert ((foo_sha256,) ==
             spec['libelf'].variants['patches'].value)
 
     # URL patches
     assert 'patches' in list(spec['fake'].variants.keys())
     # urlpatch.patch, urlpatch.patch.gz
-    assert (('1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd',
-             'abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234') ==
-            spec['fake'].variants['patches'].value)
+    assert (
+        (url2_sha256, url1_sha256) == spec['fake'].variants['patches'].value)
 
 
 def test_conditional_patched_dependencies(mock_packages, config):
@@ -144,24 +155,77 @@ def test_conditional_patched_dependencies(mock_packages, config):
     # basic patch on libelf
     assert 'patches' in list(spec['libelf'].variants.keys())
     # foo
-    assert (('b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c',) ==
+    assert ((foo_sha256,) ==
             spec['libelf'].variants['patches'].value)
 
     # conditional patch on libdwarf
     assert 'patches' in list(spec['libdwarf'].variants.keys())
     # bar
-    assert (('7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730',) ==
+    assert ((bar_sha256,) ==
             spec['libdwarf'].variants['patches'].value)
     # baz is conditional on libdwarf version
-    assert ('bf07a7fbb825fc0aae7bf4a1177b2b31fcf8a3feeaf7092761e18c859ee52a9c'
+    assert (baz_sha256
             not in spec['libdwarf'].variants['patches'].value)
 
     # URL patches
     assert 'patches' in list(spec['fake'].variants.keys())
     # urlpatch.patch, urlpatch.patch.gz
-    assert (('1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd',
-             'abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234') ==
-            spec['fake'].variants['patches'].value)
+    assert (
+        (url2_sha256, url1_sha256) == spec['fake'].variants['patches'].value)
+
+
+def check_multi_dependency_patch_specs(
+        libelf, libdwarf, fake,  # specs
+        owner, package_dir):     # parent spec properties
+    """Validate patches on dependencies of patch-several-dependencies."""
+    # basic patch on libelf
+    assert 'patches' in list(libelf.variants.keys())
+    # foo
+    assert (foo_sha256 in libelf.variants['patches'].value)
+
+    # conditional patch on libdwarf
+    assert 'patches' in list(libdwarf.variants.keys())
+    # bar
+    assert (bar_sha256 in libdwarf.variants['patches'].value)
+    # baz is conditional on libdwarf version (no guarantee on order w/conds)
+    assert (baz_sha256 in libdwarf.variants['patches'].value)
+
+    def get_patch(spec, ending):
+        return next(p for p in spec.patches if p.path_or_url.endswith(ending))
+
+    # make sure file patches are reconstructed properly
+    foo_patch = get_patch(libelf, 'foo.patch')
+    bar_patch = get_patch(libdwarf, 'bar.patch')
+    baz_patch = get_patch(libdwarf, 'baz.patch')
+
+    assert foo_patch.owner == owner
+    assert foo_patch.path == os.path.join(package_dir, 'foo.patch')
+    assert foo_patch.sha256 == foo_sha256
+
+    assert bar_patch.owner == 'builtin.mock.patch-several-dependencies'
+    assert bar_patch.path == os.path.join(package_dir, 'bar.patch')
+    assert bar_patch.sha256 == bar_sha256
+
+    assert baz_patch.owner == 'builtin.mock.patch-several-dependencies'
+    assert baz_patch.path == os.path.join(package_dir, 'baz.patch')
+    assert baz_patch.sha256 == baz_sha256
+
+    # URL patches
+    assert 'patches' in list(fake.variants.keys())
+    # urlpatch.patch, urlpatch.patch.gz
+    assert (url2_sha256, url1_sha256) == fake.variants['patches'].value
+
+    url1_patch = get_patch(fake, 'urlpatch.patch')
+    url2_patch = get_patch(fake, 'urlpatch2.patch.gz')
+
+    assert url1_patch.owner == 'builtin.mock.patch-several-dependencies'
+    assert url1_patch.url == 'http://example.com/urlpatch.patch'
+    assert url1_patch.sha256 == url1_sha256
+
+    assert url2_patch.owner == 'builtin.mock.patch-several-dependencies'
+    assert url2_patch.url == 'http://example.com/urlpatch2.patch.gz'
+    assert url2_patch.sha256 == url2_sha256
+    assert url2_patch.archive_sha256 == url2_archive_sha256
 
 
 def test_conditional_patched_deps_with_conditions(mock_packages, config):
@@ -169,24 +233,31 @@ def test_conditional_patched_deps_with_conditions(mock_packages, config):
     spec = Spec('patch-several-dependencies @1.0 ^libdwarf@20111030')
     spec.concretize()
 
-    # basic patch on libelf
-    assert 'patches' in list(spec['libelf'].variants.keys())
-    # foo
-    assert ('b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c'
-            in spec['libelf'].variants['patches'].value)
+    libelf = spec['libelf']
+    libdwarf = spec['libdwarf']
+    fake = spec['fake']
 
-    # conditional patch on libdwarf
-    assert 'patches' in list(spec['libdwarf'].variants.keys())
-    # bar
-    assert ('7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730'
-            in spec['libdwarf'].variants['patches'].value)
-    # baz is conditional on libdwarf version (no guarantee on order w/conds)
-    assert ('bf07a7fbb825fc0aae7bf4a1177b2b31fcf8a3feeaf7092761e18c859ee52a9c'
-            in spec['libdwarf'].variants['patches'].value)
+    check_multi_dependency_patch_specs(
+        libelf, libdwarf, fake,
+        'builtin.mock.patch-several-dependencies',
+        spec.package.package_dir)
 
-    # URL patches
-    assert 'patches' in list(spec['fake'].variants.keys())
-    # urlpatch.patch, urlpatch.patch.gz
-    assert (('1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd',
-             'abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234') ==
-            spec['fake'].variants['patches'].value)
+
+def test_write_and_read_sub_dags_with_patched_deps(mock_packages, config):
+    """Test whether patched dependencies are still correct after writing and
+       reading a sub-DAG of a concretized Spec.
+    """
+    spec = Spec('patch-several-dependencies @1.0 ^libdwarf@20111030')
+    spec.concretize()
+
+    # write to YAML and read back in -- new specs will *only* contain
+    # their sub-DAGs, and won't contain the dependent that patched them
+    libelf = spack.spec.Spec.from_yaml(spec['libelf'].to_yaml())
+    libdwarf = spack.spec.Spec.from_yaml(spec['libdwarf'].to_yaml())
+    fake = spack.spec.Spec.from_yaml(spec['fake'].to_yaml())
+
+    # make sure we can still read patches correctly for these specs
+    check_multi_dependency_patch_specs(
+        libelf, libdwarf, fake,
+        'builtin.mock.patch-several-dependencies',
+        spec.package.package_dir)

--- a/lib/spack/spack/test/patch.py
+++ b/lib/spack/spack/test/patch.py
@@ -4,12 +4,12 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import sys
 import filecmp
 import pytest
 
 from llnl.util.filesystem import working_dir, mkdirp
 
+import spack.patch
 import spack.paths
 import spack.util.compression
 from spack.util.executable import Executable
@@ -41,8 +41,7 @@ data_path = os.path.join(spack.paths.test_path, 'data', 'patch')
 def test_url_patch(mock_stage, filename, sha256, archive_sha256):
     # Make a patch object
     url = 'file://' + filename
-    m = sys.modules['spack.patch']
-    patch = m.Patch.create(
+    patch = spack.patch.create(
         None, url, sha256=sha256, archive_sha256=archive_sha256)
 
     # make a stage

--- a/lib/spack/spack/test/provider_index.py
+++ b/lib/spack/spack/test/provider_index.py
@@ -25,14 +25,14 @@ from spack.provider_index import ProviderIndex
 from spack.spec import Spec
 
 
-def test_yaml_round_trip(mock_packages):
+def test_provider_index_round_trip(mock_packages):
     p = ProviderIndex(spack.repo.all_package_names())
 
     ostream = StringIO()
-    p.to_yaml(ostream)
+    p.to_json(ostream)
 
     istream = StringIO(ostream.getvalue())
-    q = ProviderIndex.from_yaml(istream)
+    q = ProviderIndex.from_json(istream)
 
     assert p == q
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1041,6 +1041,28 @@ function _spack_repo_rm {
     _spack_repo_remove
 }
 
+function _spack_resource {
+    if $list_options
+    then
+        compgen -W "-h --help" -- "$cur"
+    else
+        compgen -W "list show" -- "$cur"
+    fi
+}
+
+function _spack_resource_list {
+    compgen -W "-h --help --only-hashes" -- "$cur"
+}
+
+function _spack_resource_show {
+    if $list_options
+    then
+        compgen -W "-h --help" -- "$cur"
+    else
+        compgen -W "$(_all_resource_hashes)" -- "$cur"
+    fi
+}
+
 function _spack_restage {
     if $list_options
     then
@@ -1242,6 +1264,10 @@ function _subcommands {
 
 function _all_packages {
     spack list
+}
+
+function _all_resource_hashes {
+    spack resource list --only-hashes
 }
 
 function _installed_packages {

--- a/var/spack/repos/builtin/packages/catalyst/package.py
+++ b/var/spack/repos/builtin/packages/catalyst/package.py
@@ -7,7 +7,6 @@ from spack import *
 import os
 import subprocess
 import llnl.util.tty as tty
-from spack.patch import absolute_path_for_package
 
 
 class Catalyst(CMakePackage):
@@ -18,7 +17,7 @@ class Catalyst(CMakePackage):
     homepage = 'http://www.paraview.org'
     url      = "http://www.paraview.org/files/v5.5/ParaView-v5.5.2.tar.gz"
     _urlfmt_gz = 'http://www.paraview.org/files/v{0}/ParaView-v{1}{2}.tar.gz'
-    _urlfmt_xz = 'http://www.paraview.org/files/v{0}/ParaView-v{1}{2}.tar.xz' 
+    _urlfmt_xz = 'http://www.paraview.org/files/v{0}/ParaView-v{1}{2}.tar.xz'
 
     version('5.5.2', '7eb93c31a1e5deb7098c3b4275e53a4a')
     version('5.5.1', 'a7d92a45837b67c3371006cc45163277')
@@ -52,11 +51,10 @@ class Catalyst(CMakePackage):
         at the package dir to the source code in
         root_cmakelists_dir."""
         patch_name = 'vtkm-catalyst-pv551.patch'
-        pkg_dir = os.path.dirname(absolute_path_for_package(self))
         patch = which("patch", required=True)
         with working_dir(self.root_cmakelists_dir):
             patch('-s', '-p', '1', '-i',
-                  join_path(pkg_dir, patch_name),
+                  join_path(self.package_dir, patch_name),
                   "-d", '.')
 
     def url_for_version(self, version):


### PR DESCRIPTION
This fixes some bugs with dependency patching discovered by @scottwittenburg, and it makes the patch system a more robust.  The previous logic for getting patches from a `Spec` assumed that all dependents were still in the DAG.  If you extracted a sub-DAG like this:

```python
dealii = Spec('dealii').concretized()
boost_yaml = dealii['boost'].to_yaml()
boost = Spec.from_yaml(boost_yaml)
boost.package.do_install()
```

And then attempted to build the `boost` spec, you'd find that `dealii`'s patches on `boost` would not be applied properly, because Spack couldn't find them anymore.  The prior logic assumed that `dealii` was concretized and built immediately, that `dealii` was an ancestor of `boost` in the DAG, and that `dealii.patches()` was called sometime before `dealii['boost']` was built.

This is bad, because it means we can't reliably write out a sub-DAG and farm it out to another node (or GitLab runner) to build.

To fix this, we're adding a patch index, much like the existing virtual provider index and tag index.  This means we can look up patches by `sha256` even if they're in the DAG, so builds like the one above will work.

Since we now have 3 different repo indexes, this PR also reworks them so they're all part of a `RepoIndex` that generates all indices at once.  This is good, because each index requires us to read in all the packages, which takes the bulk of the time (~10s on my macbook), and building and writing the indexes takes essentially no time.  Doing them all at once avoids multiple read-ins.  This also consolidates the index-building code a bit so that maybe we can parallelize it in a future PR (which would eliminate the latency).

To enable better debugging of `Specs` that have patches on them, this PR also adds a new `spack resource` command for looking up artifacts (like downloads, resources, and patches) by hash.  Right now it just handles patches, but eventually it will handle tarballs and other things with checksums in packages.  It lets you see what the `sha256`'s on your spec mean:

```console
$ spack resource show b37164
b37164268f34f7133cbc9a4066ae98fda08adf51e1172223f6a969909216870f
    path:       /Users/gamblin2/src/spack/var/spack/repos/builtin/packages/dealii/boost_1.68.0.patch
    applies to: builtin.boost
    patched by: builtin.dealii
```

Or, if you just want to see all the patches:

```console
$ spack resource list | head
333e111ed39f7452f904590b47b996812590b8818f1c51ad68407dc05a1b18b0
    url:        https://src.fedoraproject.org/rpms/tcsh/raw/8a6066c901fb4fc75013dd488ba958387f00c74d/f/tcsh-6.20.00-004-do-not-use-old-pointer-tricks.patch
    applies to: builtin.tcsh
f994ac84634f2f833a7a4d3179c5bf9a06f14349ef67aacba39d08837ffab004
    path:       /Users/gamblin2/src/spack/var/spack/repos/builtin/packages/boost/python_jam_pre156.patch
    applies to: builtin.boost
c9cfecb1f7a623418590cf4e00ae7d308d1c3faeb15046c2e5090e38221da7cd
    path:       /Users/gamblin2/src/spack/var/spack/repos/builtin/packages/snappy/link_gtest.patch
    applies to: builtin.snappy
...
```

Like the other repo caches, you can blow away the patch cache with `spack clean -m`.

- [x] Fix bugs with building packages with dependency patches from read-in specs
- [x] Change the way patches are looked up at build time (global cache instead of per-package cache)
- [x] Refactor logic for various repository caches (tags, providers, patches) to use a single `RepoIndex` class and a number of `Indexer` objects.
- [x] Add `spack resource` command for dealing with downloadable resources like tarballs from `version()` and `resource()` and patches.