### PR TITLE
Fix libxml2+python and libxslt+python import tests

### DIFF
--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -26,7 +26,8 @@ class Libxml2(AutotoolsPackage):
     depends_on('zlib')
     depends_on('xz')
 
-    extends('python+shared', when='+python',
+    depends_on('python+shared', when='+python')
+    extends('python', when='+python',
             ignore=r'(bin.*$)|(include.*$)|(share.*$)|(lib/libxml2.*$)|'
             '(lib/xml2.*$)|(lib/cmake.*$)')
 

--- a/var/spack/repos/builtin/packages/libxslt/package.py
+++ b/var/spack/repos/builtin/packages/libxslt/package.py
@@ -32,7 +32,8 @@ class Libxslt(AutotoolsPackage):
     depends_on('zlib')
     depends_on('libgcrypt', when='+crypto')
 
-    extends('python+shared', when='+python')
+    depends_on('python+shared', when='+python')
+    extends('python', when='+python')
 
     def configure_args(self):
         args = []


### PR DESCRIPTION
See #10195.

With this PR, I am able to install `libxml2+python` and `libxslt+python` on macOS 10.14.2 with Clang 10.0.0 and all tests pass with flying colors.