### PR TITLE
fix what is installed under prefix: make sure the main target "libxgb…

### DIFF
--- a/var/spack/repos/builtin/packages/xgboost/package.py
+++ b/var/spack/repos/builtin/packages/xgboost/package.py
@@ -20,3 +20,10 @@ class Xgboost(CMakePackage, CudaPackage):
         return [
             '-DUSE_CUDA={0}'.format('YES' if '+cuda' in self.spec else 'NO')
         ]
+
+    def install(self, spec, prefix):
+        install_tree(str(self.stage.source_path), prefix)
+        # create a bin directory for executable "xgboost" which is possibly
+        # used in functional testing of the compilation target "libxgboost"
+        mkdirp(prefix.bin)
+        install('xgboost', prefix.bin)


### PR DESCRIPTION
fixes #10207 
based on my overall impression of how xgboost files are organized, it makes sense to put the whole staging stuff under prefix hence the main target "libxgboost.so" will be available under prefix/lib.