### PR TITLE
velvet: Add missing zlib dependency to fix installation errors

### DIFF
--- a/var/spack/repos/builtin/packages/velvet/package.py
+++ b/var/spack/repos/builtin/packages/velvet/package.py
@@ -15,6 +15,8 @@ class Velvet(MakefilePackage):
 
     version('1.2.10', '6e28c4b9bedc5f7ab2b947e7266a02f6')
 
+    depends_on('zlib')
+
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
         install('velvetg', prefix.bin)


### PR DESCRIPTION
Fixes `fatal error: zlib.h: No such file or directory` installation errors 