### PR TITLE
dealii: workaround concretization issue with PETSc

### DIFF
--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -117,7 +117,9 @@ class Dealii(CMakePackage, CudaPackage):
     depends_on('graphviz',         when='+doc')
     depends_on('gmsh+tetgen+netgen+oce', when='@9.0:+gmsh', type=('build', 'run'))
     depends_on('gsl',              when='@8.5.0:+gsl')
-    depends_on('hdf5+mpi+hl',      when='+hdf5+mpi')
+    # FIXME: next line fixes concretization with petsc
+    depends_on('hdf5+mpi+hl+fortran', when='+hdf5+mpi+petsc')
+    depends_on('hdf5+mpi+hl', when='+hdf5+mpi~petsc')
     depends_on('cuda@8:',          when='+cuda')
     depends_on('cmake@3.9:',       when='+cuda')
     # older version of deal.II do not build with Cmake 3.10, see


### PR DESCRIPTION
otherwise

```
==> Error: An unsatisfiable variant constraint has been detected for spec:

    hdf5@1.10.4%clang@10.0.0-apple~cxx~debug~fortran+hl+mpi+pic+shared~szip~threadsafe arch=darwin-mojave-x86_64
        ^openmpi@3.1.3%clang@10.0.0-apple~cuda+cxx_exceptions fabrics= ~java~legacylaunchers~memchecker~pmi schedulers= ~sqlite3~thread_multiple+vt arch=darwin-mojave-x86_64
            ^hwloc@:1.999
                ^pkgconf@1.5.4%clang@10.0.0-apple arch=darwin-mojave-x86_64
            ^zlib@1.2.11%clang@10.0.0-apple+optimize+pic+shared arch=darwin-mojave-x86_64


while trying to concretize the partial spec:

    petsc@3.10.3%clang@10.0.0-apple~X clanguage=C ~complex~debug+double+hdf5+hypre~int64+metis+mpi+mumps+shared~suite-sparse+superlu-dist~trilinos arch=darwin-mojave-x86_64
        ^hypre@2.14:~int64~internal-superlu
            ^openblas@0.3.4%clang@10.0.0-apple cpu_target= ~ilp64+pic+shared threads=none ~virtual_machine arch=darwin-mojave-x86_64
        ^superlu-dist@6.1:6.1.99~int64
            ^cmake@3.13.2%clang@10.0.0-apple~doc+ncurses+openssl+ownlibs~qt arch=darwin-mojave-x86_64
                ^ncurses@6.1%clang@10.0.0-apple~symlinks~termlib arch=darwin-mojave-x86_64
                    ^pkgconf@1.5.4%clang@10.0.0-apple arch=darwin-mojave-x86_64
                ^openssl@1.1.1%clang@10.0.0-apple+systemcerts arch=darwin-mojave-x86_64
                    ^perl@5.26.2%clang@10.0.0-apple+cpanm+shared+threads arch=darwin-mojave-x86_64
                        ^gdbm@1.18.1%clang@10.0.0-apple arch=darwin-mojave-x86_64
                            ^readline@7.0%clang@10.0.0-apple arch=darwin-mojave-x86_64
                    ^zlib@1.2.11%clang@10.0.0-apple+optimize+pic+shared arch=darwin-mojave-x86_64
            ^metis@5.1.0%clang@10.0.0-apple build_type=Release ~gdb~int64+real64+shared arch=darwin-mojave-x86_64
            ^openmpi@3.1.3%clang@10.0.0-apple~cuda+cxx_exceptions fabrics= ~java~legacylaunchers~memchecker~pmi schedulers= ~sqlite3~thread_multiple+vt arch=darwin-mojave-x86_64
                ^hwloc@:1.999
            ^parmetis


petsc requires hdf5 variant +fortran, but spec asked for ~fortran
```