### PR TITLE
coverage: use kcov to get coverage for compiler wrappers

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -29,7 +29,6 @@ coverage:
 
 ignore:
   - lib/spack/spack/test/.*
-  - lib/spack/env/.*
   - lib/spack/docs/.*
   - lib/spack/external/.*
 

--- a/.coveragerc
+++ b/.coveragerc
@@ -7,7 +7,6 @@ branch = True
 source = lib
 omit =
      lib/spack/spack/test/*
-     lib/spack/env/*
      lib/spack/docs/*
      lib/spack/external/*
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -133,17 +133,19 @@ addons:
   apt:
     packages:
       - ccache
+      - cmake
       - gfortran
-      - mercurial
       - graphviz
       - gnupg2
-      - cmake
+      - kcov
+      - mercurial
       - ninja-build
+      - perl
+      - perl-base
+      - realpath
       - r-base
       - r-base-core
       - r-base-dev
-      - perl
-      - perl-base
   # for Mac builds, we use Homebrew
   homebrew:
     packages:

--- a/share/spack/qa/bashcov
+++ b/share/spack/qa/bashcov
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# This script acts like bash but runs kcov on the input script. We use it
+# to get coverage for Spack's bash scripts.
+#
+
+if [ -z "$SPACK_ROOT" ]; then
+    echo "ERROR: SPACK_ROOT was not set!"
+    exit 1
+fi
+
+kcov "$SPACK_ROOT/coverage" "$@"

--- a/share/spack/qa/setup.sh
+++ b/share/spack/qa/setup.sh
@@ -11,15 +11,28 @@
 #
 
 QA_DIR="$(dirname ${BASH_SOURCE[0]})"
-SPACK_ROOT="$QA_DIR/../../.."
+export SPACK_ROOT=$(realpath "$QA_DIR/../../..")
 
 # Source the setup script
 . "$SPACK_ROOT/share/spack/setup-env.sh"
 
 # Set up some variables for running coverage tests.
 if [[ "$TEST_SUITE" == "unit" || "$TEST_SUITE" == "build" ]]; then
+    # these set up coverage for Python
     coverage=coverage
     coverage_run="coverage run"
+
+    # make a coverage directory for kcov, and patch cc to use our bashcov
+    # script instead of plain bash
+    if [[ $TEST_SUITE == unit &&   # kcov segfaults for the MPICH build test
+          $TRAVIS_OS_NAME == linux &&
+          $TRAVIS_PYTHON_VERSION != 2.6 ]];
+    then
+        mkdir -p coverage
+        cc_script="$SPACK_ROOT/lib/spack/env/cc"
+        bashcov=$(realpath ${QA_DIR}/bashcov)
+        sed -i~ "s@#\!/bin/bash@#\!${bashcov}@" "$cc_script"
+    fi
 else
     coverage=""
     coverage_run=""


### PR DESCRIPTION
We don't current have coverage information for the `cc` wrapper, though it's an important part of Spack

- [x] Add `kcov` to the dependencies on Linux
- [x] Add a `bashcov` script that acts like `bash` but runs `kcov <output dir> bash <args>`
- [x] Patch `cc` to use `bashcov` during testing on Linux