### PR TITLE
flang, llvm, pgmath: Add release for 2018-09-21

### DIFF
--- a/var/spack/repos/builtin/packages/flang/package.py
+++ b/var/spack/repos/builtin/packages/flang/package.py
@@ -17,15 +17,19 @@ class Flang(CMakePackage):
     git      = "https://github.com/flang-compiler/flang.git"
 
     version('develop', branch='master')
+    version('20180921', '4440ed5fdc390e4b7a085fb77b44ac54')
     version('20180612', '62284e26214eaaff261a922c67f6878c')
 
     depends_on('llvm@flang-develop', when='@develop')
+    depends_on('llvm@flang-20180921', when='@20180921 target=x86_64')
     depends_on('llvm@flang-20180612', when='@20180612 target=x86_64')
 
     # LLVM version specific to OpenPOWER.
+    depends_on('llvm@flang-ppc64le-20180921', when='@20180921 target=ppc64le')
     depends_on('llvm@flang-ppc64le-20180612', when='@20180612 target=ppc64le')
 
     depends_on('pgmath@develop', when='@develop')
+    depends_on('pgmath@20180921', when='@20180921')
     depends_on('pgmath@20180612', when='@20180612')
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -441,6 +441,22 @@ class Llvm(CMakePackage):
             }
         },
         {
+            'version': '20180921',
+            'commit': 'd8b30082648dc869eba68f9e539605f437d7760c',
+            'resources': {
+                'flang-driver': 'dd7587310ae498c22514a33e1a2546b86af9cf25',
+                'openmp': 'd5aa29cb3bcf51289d326b4e565613db8aff65ef'
+            }
+        },
+        {
+            'version': 'ppc64le-20180921',
+            'commit': 'd8b30082648dc869eba68f9e539605f437d7760c',
+            'resources': {
+                'flang-driver': 'dd7587310ae498c22514a33e1a2546b86af9cf25',
+                'openmp': '29b515e1e6d26b5b0d32d47d28dcdb4b8a11470d'
+            }
+        },
+        {
             'version': '20180612',
             'commit': 'f26a3ece4ccd68a52f5aa970ec42837ee0743296',
             'resources': {

--- a/var/spack/repos/builtin/packages/pgmath/package.py
+++ b/var/spack/repos/builtin/packages/pgmath/package.py
@@ -15,6 +15,7 @@ class Pgmath(CMakePackage):
     git      = "https://github.com/flang-compiler/flang.git"
 
     version('develop', branch='master')
+    version('20180921', '4440ed5fdc390e4b7a085fb77b44ac54')
     version('20180612', '62284e26214eaaff261a922c67f6878c')
 
     depends_on("awk", type="build")


### PR DESCRIPTION
This is my first attempt to take over managing the spack package for Flang.

We did a binary release for Flang on GitHub in September, and uploaded corresponding source files and binary files to the Flang repository. Left undone was creating the equivalent spack releases for this.

So, this is a simple pull request to define the new release in the same was as the old ones were.

This is in preparation for me adding the release for December 2018.

Please let me know anything i'm not doing right here (obviously); I read the contribution guide and think I did the necessary, but I can't be certain.

Thanks.