### PR TITLE
fastx-toolkit builds with newer gcc's

### DIFF
--- a/var/spack/repos/builtin/packages/fastx-toolkit/package.py
+++ b/var/spack/repos/builtin/packages/fastx-toolkit/package.py
@@ -17,4 +17,5 @@ class FastxToolkit(AutotoolsPackage):
 
     depends_on('libgtextutils')
 
-    conflicts('%gcc@7.1.0:')
+    # patch implicit fallthrough
+    patch("pr-22.patch")

--- a/var/spack/repos/builtin/packages/fastx-toolkit/pr-22.patch
+++ b/var/spack/repos/builtin/packages/fastx-toolkit/pr-22.patch
@@ -1,0 +1,11 @@
+diff -ur fastx_toolkit-0.0.14.orig/src/fasta_formatter/fasta_formatter.cpp fastx_toolkit-0.0.14/src/fasta_formatter/fasta_formatter.cpp
+--- fastx_toolkit-0.0.14.orig/src/fasta_formatter/fasta_formatter.cpp	2014-01-05 13:10:49.000000000 -0800
++++ fastx_toolkit-0.0.14/src/fasta_formatter/fasta_formatter.cpp	2018-12-31 09:58:21.923778569 -0800
+@@ -103,6 +103,7 @@
+ 		switch(opt) {
+ 		case 'h':
+ 			usage();
++			break;
+ 		
+ 		case 'i':
+ 			input_filename = optarg;


### PR DESCRIPTION
There's a missing break in a switch statement that newer gcc's
dislike.

Our #4696 simply disallowed newer gcc's.

This fixes the problem instead.

It's been [PR'ed upstream](https://github.com/agordon/fastx_toolkit/pull/22).

Tested with gcc@5.5.0 and gcc@8.2.0 on CentOS.