### PR TITLE
bamutil builds with newer gcc's

### DIFF
--- a/var/spack/repos/builtin/packages/bamutil/libstatgen-issue-17.patch
+++ b/var/spack/repos/builtin/packages/bamutil/libstatgen-issue-17.patch
@@ -1,0 +1,16 @@
+diff --git a/general/Makefile b/general/Makefile
+index ed39442..d828c6b 100755
+--- a/libStatGen/general/Makefile
++++ b/libStatGen/general/Makefile
+@@ -8,7 +8,10 @@ ifeq ($(UNAME), Linux)
+   # an error, but allow unused results and variables for the
+   # time being.
+   #
+-  USER_WARNINGS ?= -Werror $(shell if [ X$(CCVERSION) \> X4.2.0 ] ; then echo " -Wno-strict-overflow" ; fi)
++  # Disable format-truncation check because StringBasics specifically tests
++  # to make sure snprintf truncates as expected.
++  USER_WARNINGS ?= -Werror -Wno-format-truncation $(shell if [ X$(CCVERSION) \> X7.0.0 ] ; then echo " -Wno-strict-overflow -Wno-format-truncation" ; elif [ X$(CCVERSION) \> X4.2.0 ] ; then echo " -Wno-strict-overflow" ; fi)
++#  USER_WARNINGS ?= -Werror $(shell if [ X$(CCVERSION) \> X4.2.0 ] ; then echo " -Wno-strict-overflow" ; fi)
+ #-Wno-strict-overflow
+ # -Wno-unused-variable $(shell if [ X$(CCVERSION) \> X4.2.0 ] ; then echo " -Wno-unused-result" ; fi)
+ endif

--- a/var/spack/repos/builtin/packages/bamutil/libstatgen-issue-19.patch
+++ b/var/spack/repos/builtin/packages/bamutil/libstatgen-issue-19.patch
@@ -1,0 +1,29 @@
+From 3a10afe08c209dbacc3eca7794a5a8c0a42ee566 Mon Sep 17 00:00:00 2001
+From: jonathonl <jonathonl@users.noreply.github.com>
+Date: Thu, 20 Sep 2018 11:57:06 -0400
+Subject: [PATCH] Removes erroneous deletes in Chromosome constructor.
+
+---
+ general/Chromosome.cpp | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/general/Chromosome.cpp b/general/Chromosome.cpp
+index ac2ff5c..2d773e8 100644
+--- a/libStatGen/general/Chromosome.cpp
++++ b/libStatGen/general/Chromosome.cpp
+@@ -27,7 +27,6 @@ Chromosome::Chromosome(GenomeSequence* gs, const char* chromosomeName)
+ Chromosome::Chromosome(const char* genomseSequenceFileName, unsigned int chromosomeIndex, bool isColorSpace) 
+ {
+     std::string s(genomseSequenceFileName);
+-    if (this->gs) delete gs;
+     gs = new GenomeSequence;
+     assert(gs);
+     gs->setReferenceName(s);
+@@ -39,7 +38,6 @@ Chromosome::Chromosome(const char* genomseSequenceFileName, unsigned int chromos
+ 
+ Chromosome::Chromosome(const std::string& genomseSequenceFileName, unsigned int chromosomeIndex, bool isColorSpace) 
+ {
+-    if (this->gs) delete gs;
+     gs = new GenomeSequence;
+     assert(gs);
+     gs->setReferenceName(genomseSequenceFileName);

--- a/var/spack/repos/builtin/packages/bamutil/libstatgen-issue-7.patch
+++ b/var/spack/repos/builtin/packages/bamutil/libstatgen-issue-7.patch
@@ -1,0 +1,22 @@
+From 2f1876e53ac6c31c8e459a4c4543ab801d1dd705 Mon Sep 17 00:00:00 2001
+From: Jonathon LeFaive <jonathonl@users.noreply.github.com>
+Date: Fri, 21 Jul 2017 10:41:10 -0400
+Subject: [PATCH] Fixes #15
+
+---
+ general/Parameters.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/general/Parameters.cpp b/general/Parameters.cpp
+index 1dc4571..ca2c946 100644
+--- a/libStatGen/general/Parameters.cpp
++++ b/libStatGen/general/Parameters.cpp
+@@ -553,7 +553,7 @@ void LongParameters::Status()
+     int  line_len = 0;
+ 
+     bool legacy_parameters = false;
+-    bool legacy_count = 0;
++    int legacy_count = 0;
+ 
+     for (LongParameterList * ptr = list + 1; ptr->description != NULL; ptr++)
+         if (ptr->type == LP_LEGACY_PARAMETERS)

--- a/var/spack/repos/builtin/packages/bamutil/package.py
+++ b/var/spack/repos/builtin/packages/bamutil/package.py
@@ -22,6 +22,12 @@ class Bamutil(MakefilePackage):
     # Looks like this will be fixed in 1.0.14.
     # https://github.com/statgen/libStatGen/issues/9
     patch('libstatgen-issue-9.patch', when='@1.0.13:')
+    # These are fixed in the standalone libStatGen,
+    # but bamutil@1.0.13 embeds its own copy, so fix 'em here.
+    patch('libstatgen-issue-19.patch', when='@1.0.13')
+    patch('libstatgen-issue-17.patch', when='@1.0.13')
+    patch('libstatgen-issue-7.patch', when='@1.0.13')
+    patch('verifybamid-issue-8.patch', when='@1.0.13')
 
     parallel = False
 

--- a/var/spack/repos/builtin/packages/bamutil/verifybamid-issue-8.patch
+++ b/var/spack/repos/builtin/packages/bamutil/verifybamid-issue-8.patch
@@ -1,0 +1,27 @@
+From 29805376613c680dee344726ce5c583daf11872f Mon Sep 17 00:00:00 2001
+From: mktrost <mktrost@umich.edu>
+Date: Tue, 3 Mar 2015 13:30:21 -0500
+Subject: [PATCH] VCF - add missing include for c++11
+
+---
+ vcf/VcfRecordDiscardRules.h | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/vcf/VcfRecordDiscardRules.h b/vcf/VcfRecordDiscardRules.h
+index 1cc6fa7..53d2509 100644
+--- a/libStatGen/vcf/VcfRecordDiscardRules.h
++++ b/libStatGen/vcf/VcfRecordDiscardRules.h
+@@ -19,7 +19,13 @@
+ #define __VCF_RECORD_DISCARD_RULES_H__
+ 
+ #include <vector>
++
++#ifdef __GXX_EXPERIMENTAL_CXX0X__
++#include <unordered_set>
++#else
+ #include <set>
++#endif
++
+ #include <string>
+ #include "VcfHeader.h"
+ 


### PR DESCRIPTION
The most recent release of bamutil that we support uses an embedded
copy of libStatGen that has several issues that keep it from building
with newer releases of gcc.

They've all been fixed upstream and the latest release of bamutil
would pick them up if/when we support it.  The build process has
changed though, plus my team needs *this* version.

This commit backports those fixes.