### PR TITLE
express: new version, use tags and fix gcc@6.0.0:

### DIFF
--- a/var/spack/repos/builtin/packages/express/gcc-6.patch
+++ b/var/spack/repos/builtin/packages/express/gcc-6.patch
@@ -1,0 +1,21 @@
+Description: Fix compilation with gcc-6
+Author: Gert Wollny <gw.fossdev@gmail.com>
+Bug-Debian: https://bugs.debian.org/811859
+
+--- a/src/targets.cpp
++++ b/src/targets.cpp
+@@ -113,12 +113,12 @@
+
+   double ll = LOG_1;
+   double tot_mass = mass(with_pseudo);
+-  double tot_eff_len = cached_effective_length(lib.bias_table);
++  double tot_eff_len = cached_effective_length(static_cast<bool>(lib.bias_table));
+   if (neighbors) {
+     foreach (const Target* neighbor, *neighbors) {
+       tot_mass = log_add(tot_mass, neighbor->mass(with_pseudo));
+       tot_eff_len = log_add(tot_eff_len,
+-                            neighbor->cached_effective_length(lib.bias_table));
++                            neighbor->cached_effective_length(static_cast<bool>(lib.bias_table)));
+     }
+   }
+   ll += tot_mass - tot_eff_len;

--- a/var/spack/repos/builtin/packages/express/package.py
+++ b/var/spack/repos/builtin/packages/express/package.py
@@ -13,15 +13,20 @@ class Express(CMakePackage):
        target sequences from sampled subsequences."""
 
     homepage = "http://bio.math.berkeley.edu/eXpress/"
-    git      = "https://github.com/adarob/eXpress.git"
+    url      = "https://github.com/adarob/eXpress/archive/1.5.2.zip"
 
-    version('2015-11-29', commit='f845cab2c7f2d9247b35143e4aa05869cfb10e79')
+    # 1.5.1 used to be known as 2015-11-29 (same commit), but they've
+    # added tags, so lets use 'em
+    version('1.5.2', sha256='25a63cca3dac6bd0daf04d2f0b2275e47d2190c90522bd231b1d7a875a59a52e')
+    version('1.5.1', sha256='fa3522de9cc25f1ede22fa196928912a6da2a2038681911115ec3e4da3d61293')
 
     depends_on('boost')
     depends_on('bamtools')
     depends_on('zlib')
 
-    conflicts('%gcc@6.0.0:', when='@2015-11-29')
+    # patch from the debian package repo:
+    # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=811859
+    patch('gcc-6.patch', when='%gcc@6.0.0:')
 
     def patch(self):
         with working_dir('src'):


### PR DESCRIPTION
Express fails to build with gcc@6.0.0:.

The debian project [has a fix](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=811859) but they don't seem to have pushed it upstream.

I've opened an issue and a PR in eXpress repo, but eXpress isn't actively developed, so I'm fixing it here too.

Since the Spack package was created, the eXpress team tagged their releases.  I've updated the package to use the tags.

Version 1.5.1 used to be known as 2015-11-29 (same commit).  1.5.2 is new(er).

@odoublewen 