### PR TITLE
Add list_url for r-readr, finding old versions

### DIFF
--- a/var/spack/repos/builtin/packages/r-readr/package.py
+++ b/var/spack/repos/builtin/packages/r-readr/package.py
@@ -14,6 +14,7 @@ class RReadr(RPackage):
 
     homepage = "https://cran.rstudio.com/web/packages/readr/index.html"
     url      = "https://cran.rstudio.com/src/contrib/readr_1.1.1.tar.gz"
+    list_url = "https://cran.r-project.org/src/contrib/Archive/readr/"
 
     version('1.1.1', 'cffb6669664f6a0f6fe172542e64cb47')
 


### PR DESCRIPTION
r-tidyverse needs r-readr@1.1.1.

r-reardr needs a list_url so that it can find the old versions.