### PR TITLE
bowtie: new versions and %gcc@8.0.0: fix

### DIFF
--- a/var/spack/repos/builtin/packages/bowtie/issue-87.patch
+++ b/var/spack/repos/builtin/packages/bowtie/issue-87.patch
@@ -1,0 +1,22 @@
+From 58c6ac97b1938909881877ef83167f5eff0e8ab1 Mon Sep 17 00:00:00 2001
+From: Rone Charles <rone_charles@fastmail.com>
+Date: Tue, 4 Sep 2018 21:06:39 -0400
+Subject: [PATCH] Fix isa return type
+
+---
+ ebwt.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ebwt.h b/ebwt.h
+index fe6300cc..8f886b8d 100644
+--- a/ebwt.h
++++ b/ebwt.h
+@@ -862,7 +862,7 @@ class Ebwt {
+ 	TIndexOffU*   ftab() const         { return _ftab; }
+ 	TIndexOffU*   eftab() const        { return _eftab; }
+ 	TIndexOffU*   offs() const         { return _offs; }
+-	uint32_t*   isa() const          { return _isa; } /* check */
++	TIndexOffU*   isa() const          { return _isa; } /* check */
+ 	TIndexOffU*   plen() const         { return _plen; }
+ 	TIndexOffU*   rstarts() const      { return _rstarts; }
+ 	uint8_t*    ebwt() const         { return _ebwt; }

--- a/var/spack/repos/builtin/packages/bowtie/package.py
+++ b/var/spack/repos/builtin/packages/bowtie/package.py
@@ -13,19 +13,19 @@ class Bowtie(MakefilePackage):
     homepage = "https://sourceforge.net/projects/bowtie-bio/"
     url      = "https://github.com/BenLangmead/bowtie/archive/v1.2.0.tar.gz"
 
-    # Release 1.2.2 fails to build with gcc@8.2.0
     # Note that release 1.2.2 is tagged as v1.2.2_p1, so the URL is "odd".
     version('1.2.2', sha256='e1b02b2e77a0d44a3dd411209fa1f44f0c4ee304ef5cc83f098275085740d5a1', url="https://github.com/BenLangmead/bowtie/archive/v1.2.2_p1.tar.gz")
     version('1.2.1.1', sha256='1b38408b88f61d18d7ff28b2470a8cfeefccb3fc59fd46e4cc62e23874e52c20')
     version('1.2.1', sha256='b2a7c8c879cb08f00a82665bee43e1d4861de44a87912c54d168e44c90869728')
     version('1.2.0', sha256='dc4e7951b8eca56ce7714c47fd4e84f72badd5312ee9546c912af1963570f894')
+    # Keeping the old 1.2 version around for reproducibility, it's not
+    # clearly identical to 1.2.0.
     version('1.2', md5='6d97f0ea1a65af11d17cc270cfac4af9', url='https://downloads.sourceforge.net/project/bowtie-bio/bowtie/1.2.0/bowtie-1.2-source.zip')
 
-    # Feel free to tighten this.  I know that
-    # - 1.2 -> 1.2.2 work with %gcc@5.5.0;
-    # - 1.2 -> 1.2.1.1 work with %gcc@8.2.0; and
-    # - 1.2.2 fails with %gcc@8.2.0
-    conflicts('%gcc@6.0.0:', when='@1.2.2')
+    # Feel free to tighten this.  I know that v1.2.2 builds with
+    # %gcc@5.5.5 and fails to build with %gcc@8.2.0.  I'm not sure
+    # whether or not it works with other versions in the interval.
+    conflicts('%gcc@8:', when='@1.2.2')
 
     variant('tbb', default=False, description='Use Intel thread building block')
 

--- a/var/spack/repos/builtin/packages/bowtie/package.py
+++ b/var/spack/repos/builtin/packages/bowtie/package.py
@@ -13,7 +13,14 @@ class Bowtie(MakefilePackage):
     homepage = "https://sourceforge.net/projects/bowtie-bio/"
     url      = "https://github.com/BenLangmead/bowtie/archive/v1.2.0.tar.gz"
 
-    # Note that release 1.2.2 is tagged as v1.2.2_p1, so the URL is "odd".
+    # The bowtie project git tagged and GitHub released a v1.2.2,
+    # discovered/fixed a bug, git tagged a v1.2.2_p1 and moved the
+    # 1.2.2 release to use it rather than making a new `1.2.2_p1`
+    # release.
+    #
+    # We point both of the Spack versions at the same tarball so they
+    # build the binaries that are on the release page as v1.2.2
+    version('1.2.2_p1', sha256='e1b02b2e77a0d44a3dd411209fa1f44f0c4ee304ef5cc83f098275085740d5a1')
     version('1.2.2', sha256='e1b02b2e77a0d44a3dd411209fa1f44f0c4ee304ef5cc83f098275085740d5a1', url="https://github.com/BenLangmead/bowtie/archive/v1.2.2_p1.tar.gz")
     version('1.2.1.1', sha256='1b38408b88f61d18d7ff28b2470a8cfeefccb3fc59fd46e4cc62e23874e52c20')
     version('1.2.1', sha256='b2a7c8c879cb08f00a82665bee43e1d4861de44a87912c54d168e44c90869728')
@@ -22,10 +29,11 @@ class Bowtie(MakefilePackage):
     # clearly identical to 1.2.0.
     version('1.2', md5='6d97f0ea1a65af11d17cc270cfac4af9', url='https://downloads.sourceforge.net/project/bowtie-bio/bowtie/1.2.0/bowtie-1.2-source.zip')
 
-    # Feel free to tighten this.  I know that v1.2.2 builds with
-    # %gcc@5.5.5 and fails to build with %gcc@8.2.0.  I'm not sure
-    # whether or not it works with other versions in the interval.
-    conflicts('%gcc@8:', when='@1.2.2')
+    # Feel free to tighten this.  I know that v1.2.2 (aka v1.2.2_p1)
+    # builds with %gcc@5.5.5 and fails to build with %gcc@8.2.0.  I'm
+    # not sure whether or not it works with other versions in the
+    # interval.
+    conflicts('%gcc@8:', when='@1.2.2:')
 
     variant('tbb', default=False, description='Use Intel thread building block')
 

--- a/var/spack/repos/builtin/packages/bowtie/package.py
+++ b/var/spack/repos/builtin/packages/bowtie/package.py
@@ -11,13 +11,30 @@ class Bowtie(MakefilePackage):
     for short DNA sequences (reads) from next-gen sequencers."""
 
     homepage = "https://sourceforge.net/projects/bowtie-bio/"
-    url      = "https://downloads.sourceforge.net/project/bowtie-bio/bowtie/1.2.0/bowtie-1.2-source.zip"
+    url      = "https://github.com/BenLangmead/bowtie/archive/v1.2.0.tar.gz"
 
-    version('1.2', '6d97f0ea1a65af11d17cc270cfac4af9')
+    # Release 1.2.2 fails to build with gcc@8.2.0
+    # Note that release 1.2.2 is tagged as v1.2.2_p1, so the URL is "odd".
+    version('1.2.2', sha256='e1b02b2e77a0d44a3dd411209fa1f44f0c4ee304ef5cc83f098275085740d5a1', url="https://github.com/BenLangmead/bowtie/archive/v1.2.2_p1.tar.gz")
+    version('1.2.1.1', sha256='1b38408b88f61d18d7ff28b2470a8cfeefccb3fc59fd46e4cc62e23874e52c20')
+    version('1.2.1', sha256='b2a7c8c879cb08f00a82665bee43e1d4861de44a87912c54d168e44c90869728')
+    version('1.2.0', sha256='dc4e7951b8eca56ce7714c47fd4e84f72badd5312ee9546c912af1963570f894')
+    version('1.2', md5='6d97f0ea1a65af11d17cc270cfac4af9', url='https://downloads.sourceforge.net/project/bowtie-bio/bowtie/1.2.0/bowtie-1.2-source.zip')
+
+    # Feel free to tighten this.  I know that
+    # - 1.2 -> 1.2.2 work with %gcc@5.5.0;
+    # - 1.2 -> 1.2.1.1 work with %gcc@8.2.0; and
+    # - 1.2.2 fails with %gcc@8.2.0
+    conflicts('%gcc@6.0.0:', when='@1.2.2')
 
     variant('tbb', default=False, description='Use Intel thread building block')
 
     depends_on('tbb', when='+tbb')
+
+    # See: https://github.com/BenLangmead/bowtie/issues/87, a
+    # different fix is in the FreeBSD ports/package tree
+    # https://svnweb.freebsd.org/ports?view=revision&revision=483954
+    patch('issue-87.patch', when='%gcc@8.0.0:')
 
     def edit(self, spec, prefix):
         makefile = FileFilter('Makefile')


### PR DESCRIPTION
Bowtie development shifted from Sourceforge to GitHub.  This updates the Spack package to follow.

This commit adds several versions from GitHub, using the archive tarballs.  Note that the tag and URL for 1.2.2 tarball is actually 'v1.2.2_p1'...  Sigh.

Versions 1.2.0 and newer come from GitHub (I'm unsure if the sourceforge 1.2 and github 1.2.0 are identical).

It leaves the old 1.2 release download info in place.

The PR includes a fix from https://github.com/BenLangmead/bowtie/issues/87 that enables %gcc@8.0.0: 

Sadly, v1.2.2 has trouble with "newer" gcc's, so the PR it only adds v1.2.2 for %gcc@6.0.0:.  I'm not sure what gcc's work and/or don't.  Others should feel free to tighten this.  I know that:

- 1.2 -> 1.2.2 work with %gcc@5.5.0;
- 1.2 -> 1.2.1.1 work with %gcc@8.2.0; and
- 1.2.2 fails with %gcc@8.2.0