### PR TITLE
Fixed broken module file configuration

### DIFF
--- a/lib/spack/spack/schema/modules.py
+++ b/lib/spack/spack/schema/modules.py
@@ -78,7 +78,7 @@ module_file_configuration = {
             }
         }
     }
-},
+}
 
 module_type_configuration = {
     'type': 'object',


### PR DESCRIPTION
refers #9878 

Removed an extra comma after a dict literal.

The extra comma was turning a dict into a tuple, and caused errors during validation of the schema.