### PR TITLE
coverage: add code climate integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -172,7 +172,11 @@ before_install:
         pip2 install virtualenv;
         virtualenv venv;
         source venv/bin/activate;
+        curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-darwin-amd64 > ./cc-test-reporter;
+    else
+        curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter;
     fi
+  - chmod +x ./cc-test-reporter
   - ccache -M 2G && ccache -z
 
 # Install various dependencies
@@ -212,6 +216,12 @@ script:
 after_success:
   - ccache -s
   - if [[ "$TEST_SUITE" == "unit" || "$TEST_SUITE" == "build" ]]; then
+        coverage combine;
+        coverage xml;
+        ./cc-test-reporter format-coverage -t coverage.py -o coverage/codeclimate.python.json;
+        ./cc-test-reporter format-coverage -t cobertura -o coverage/codeclimate.sh.json coverage/*/cobertura.xml;
+        ./cc-test-reporter sum-coverage coverage/codeclimate.*.json -p 2;
+        ./cc-test-reporter upload-coverage;
         codecov --env PYTHON_VERSION
                 --required
                 --flags "${TEST_SUITE}${TRAVIS_OS_NAME}";


### PR DESCRIPTION
We've been having some recent issues with Codecov:
1. Codecov's nice [browser extension](https://github.com/codecov/browser-extension) is deprecated in favor of a [new one using sourcegraph](https://github.com/codecov/sourcegraph-codecov), but the new one doesn't display diffs for PRs (!).  AFAIK this is our most common use case, so it's pretty disappointing.
2. The codecov website has taken to hanging frequently when fetching coverage results for pull requests.

Given this stuff, I'm not sure how we can effectively review PRs for test coverage using Codecov.  (1) is supposed to be forthcoming (see codecov/sourcegraph-codecov#10), and maybe (2) will get fixed, but in the meantime, I'm trying out Code Climate to see if it's a good replacement.