### PR TITLE
Update package.py

### DIFF
--- a/var/spack/repos/builtin/packages/doxygen/package.py
+++ b/var/spack/repos/builtin/packages/doxygen/package.py
@@ -13,13 +13,24 @@ class Doxygen(CMakePackage):
     Microsoft, and UNO/OpenOffice flavors), Fortran, VHDL, Tcl, and to some
     extent D.."""
 
-    homepage = "http://www.doxygen.nl/"
-    url      = "https://sourceforge.net/projects/doxygen/files/rel-1.8.14/doxygen-1.8.14.src.tar.gz/download"
+    homepage  = "https://github.com/doxygen/doxygen/"
+    git       = "https://github.com/doxygen/doxygen.git"
 
-    version('1.8.14', '41d8821133e8d8104280030553e2b42b')
-    version('1.8.12', '08e0f7850c4d22cb5188da226b209a96')
-    version('1.8.11', 'f4697a444feaed739cfa2f0644abc19b')
-    version('1.8.10', '79767ccd986f12a0f949015efb5f058f')
+    # Doxygen versions on GitHub
+    version('1.8.15', commit='dc89ac01407c24142698c1374610f2cee1fbf200')
+            #url='https://github.com/doxygen/doxygen/archive/Release_1_8_15.tar.gz'
+
+    version('1.8.14', commit='2f4139de014bf03898320a45fe52c92872c1e0f4')
+            #url='https://github.com/doxygen/doxygen/archive/Release_1_8_14.tar.gz'
+
+    version('1.8.12', commit='4951df8d0d0acf843b4147136f945504b96536e7')
+            #url='https://github.com/doxygen/doxygen/archive/Release_1_8_12.tar.gz'
+
+    version('1.8.11', commit='a6d4f4df45febe588c38de37641513fd576b998f')
+            #url='https://github.com/doxygen/doxygen/archive/Release_1_8_11.tar.gz'
+
+    version('1.8.10', commit='fdae7519a2e29f94e65c0e718513343f07302ddb')
+            #url='https://github.com/doxygen/doxygen/archive/Release_1_8_10.tar.gz'
 
     # graphviz appears to be a run-time optional dependency
     variant('graphviz', default=False,


### PR DESCRIPTION
Doxygen has migrated from a private SVN to GitHub. This PR updates the URLs and adds versioned commit hashes from GitHub. It also includes version 1.8.15 as the latest option.