### PR TITLE
[WIP] Fix module's approach to testing for overriding keys

### DIFF
--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -169,7 +169,6 @@ def merge_config_rules(configuration, spec):
     # evaluated in order of appearance in the module file
     spec_configuration = module_specific_configuration.pop('all', {})
     for constraint, action in module_specific_configuration.items():
-        override = False
         if spec.satisfies(constraint, strict=True):
             if spack.config.override(constraint):
                 spec_configuration = {}

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -170,11 +170,8 @@ def merge_config_rules(configuration, spec):
     spec_configuration = module_specific_configuration.pop('all', {})
     for constraint, action in module_specific_configuration.items():
         override = False
-        if constraint.endswith(':'):
-            constraint = constraint.strip(':')
-            override = True
         if spec.satisfies(constraint, strict=True):
-            if override:
+            if spack.config.override(constraint):
                 spec_configuration = {}
             update_dictionary_extending_lists(spec_configuration, action)
 


### PR DESCRIPTION
Looking for feedback.

This probably needs tests before being merged. 

See issue: #10245

The code was testing for a trailing ':', but `_mark_overrides`, from https://github.com/spack/spack/commit/8f21332fec4c8adb5349ff90e30bb0e4f75e090e was stripping it off and setting a attribute (?) instead.