### PR TITLE
QMCPACK Update - Jan 2019

### DIFF
--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -85,13 +85,6 @@ class Qmcpack(CMakePackage):
         msg='QMCPACK does not support MKL 64-bit integer variant'
     )
 
-    # CUDA conflicts taken from here
-    # https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html
-    cuda_warning = 'CUDA is not supported by this version of your compiler'
-    conflicts('%gcc@8:', when='+cuda', msg=cuda_warning)
-    conflicts('%llvm@7:', when='+cuda', msg=cuda_warning)
-    conflicts('%intel@19:', when='+cuda', msg=cuda_warning)
-
     # QMCPACK 3.6.0 or later requires support for C++14
     compiler_warning = 'QMCPACK 3.6.0 or later requires a ' \
                        'compiler with support for C++14'

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -282,6 +282,11 @@ class Qmcpack(CMakePackage):
 
         return args
 
+    # QMCPACK 3.6.0 release and later has a functional 'make install',
+    # the Spack 'def install' is retained for backwards compatiblity.
+    # Note that the two install methods differ in their directory
+    # structure.
+    @when('@:3.5.0')
     def install(self, spec, prefix):
         """Make the install targets"""
 

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -60,6 +60,18 @@ class Qmcpack(CMakePackage):
 
     # conflicts
     conflicts(
+        '+phdf5',
+        when='~mpi',
+        msg='Parallel collective I/O requires MPI-enabled QMCPACK.\n \
+        Please add \'~phdf5\' to the Spack install line for serial QMCPACK.'
+    )
+    conflicts(
+        '+qe',
+        when='~mpi',
+        msg='QMCPACK QE variant requires MPI due to limitation in QE build system.\n \
+        Please add \'~qe\' to the Spack install line for serial QMCPACK.'
+    )
+    conflicts(
         '+soa',
         when='+cuda',
         msg='QMCPACK SOA variant does not exist for CUDA'

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -99,7 +99,7 @@ class Qmcpack(CMakePackage):
     # Essential libraries
     depends_on('cmake@3.4.3:', when='@:3.5.0', type='build')
     depends_on('cmake@3.6.0:', when='@3.6.0:', type='build')
-    depends_on('boost', when='@:3.5.0')
+    depends_on('boost')
     depends_on('boost@1.61.0:', when='@3.6.0:')
     depends_on('libxml2')
     depends_on('mpi', when='+mpi')

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -193,19 +193,19 @@ class Qmcpack(CMakePackage):
         # Default is MPI, serial version is convenient for cases, e.g. laptops
         if '+mpi' in spec:
             args.append('-DQMC_MPI=1')
-        elif '~mpi' in spec:
+        else:
             args.append('-DQMC_MPI=0')
 
         # Default is parallel collective I/O enabled
         if '+phdf5' in spec:
             args.append('-DENABLE_PHDF5=1')
-        elif '~phdf5' in spec:
+        else:
             args.append('-DENABLE_PHDF5=0')
 
         # Default is real-valued single particle orbitals
         if '+complex' in spec:
             args.append('-DQMC_COMPLEX=1')
-        elif '~complex' in spec:
+        else:
             args.append('-DQMC_COMPLEX=0')
 
         # When '-DQMC_CUDA=1', CMake automatically sets:
@@ -216,13 +216,13 @@ class Qmcpack(CMakePackage):
 
         if '+cuda' in spec:
             args.append('-DQMC_CUDA=1')
-        elif '~cuda' in spec:
+        else:
             args.append('-DQMC_CUDA=0')
 
         # Mixed-precision versues double-precision CPU and GPU code
         if '+mixed' in spec:
             args.append('-DQMC_MIXED_PRECISION=1')
-        elif '~mixed' in spec:
+        else:
             args.append('-DQMC_MIXED_PRECISION=0')
 
         # New Structure-of-Array (SOA) code, much faster than default
@@ -230,13 +230,13 @@ class Qmcpack(CMakePackage):
         # No support for local atomic orbital basis.
         if '+soa' in spec:
             args.append('-DENABLE_SOA=1')
-        elif '~soa' in spec:
+        else:
             args.append('-DENABLE_SOA=0')
 
         # Manual Timers
         if '+timers' in spec:
             args.append('-DENABLE_TIMERS=1')
-        elif '~timers' in spec:
+        else:
             args.append('-DENABLE_TIMERS=0')
 
         # Proper detection of optimized BLAS and LAPACK.

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -314,6 +314,23 @@ class Qmcpack(CMakePackage):
             # install binaries
             install_tree('bin', prefix.bin)
 
+    # QMCPACK 3.6.0 install directory structure changed, thus there
+    # thus are two version of the setup_environment method
+    @when('@:3.5.0')
+    def setup_environment(self, spack_env, run_env):
+        """Set-up runtime environment for QMCPACK.
+        Set PYTHONPATH for basic analysis scripts and for Nexus."""
+        run_env.prepend_path('PYTHONPATH', join_path(self.prefix, 'nexus'))
+
+    @when('@3.6.0:')
+    def setup_environment(self, spack_env, run_env):
+        """Set-up runtime environment for QMCPACK.
+        Set PYTHONPATH for basic analysis scripts and for Nexus. Binaries
+        are in the  'prefix' directory instead of 'prefix.bin' which is
+        not set by the default module environment"""
+        run_env.prepend_path('PATH', self.prefix)
+        run_env.prepend_path('PYTHONPATH', self.prefix)
+
     @run_after('build')
     @on_package_attributes(run_tests=True)
     def check(self):

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -313,7 +313,7 @@ class Qmcpack(CMakePackage):
     def setup_environment(self, spack_env, run_env):
         """Set-up runtime environment for QMCPACK.
         Set PYTHONPATH for basic analysis scripts and for Nexus."""
-        run_env.prepend_path('PYTHONPATH', join_path(self.prefix, 'nexus'))
+        run_env.prepend_path('PYTHONPATH', self.prefix.nexus)
 
     @when('@3.6.0:')
     def setup_environment(self, spack_env, run_env):

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -244,7 +244,7 @@ class Qmcpack(CMakePackage):
         # get properly detected. Intel MKL requires special case due to
         # differences in Darwin vs. Linux $MKLROOT naming schemes. This section
         # of code is intentionally redundant for backwards compatibility.
-        if 'intel-mkl' in self.spec:
+        if 'intel-mkl' in spec:
             lapack_dir = format(join_path(env['MKLROOT'], 'include'))
             # Next two lines were introduced in QMCPACK 3.5.0 and later.
             # Prior to v3.5.0, these lines should be benign.

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -63,13 +63,13 @@ class Qmcpack(CMakePackage):
         '+phdf5',
         when='~mpi',
         msg='Parallel collective I/O requires MPI-enabled QMCPACK.\n \
-        Please add \'~phdf5\' to the Spack install line for serial QMCPACK.'
+        Please add "~phdf5" to the Spack install line for serial QMCPACK.'
     )
     conflicts(
         '+qe',
         when='~mpi',
         msg='QMCPACK QE variant requires MPI due to limitation in QE build system.\n \
-        Please add \'~qe\' to the Spack install line for serial QMCPACK.'
+        Please add "~qe" to the Spack install line for serial QMCPACK.'
     )
     conflicts(
         '+soa',

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -62,14 +62,15 @@ class Qmcpack(CMakePackage):
     conflicts(
         '+phdf5',
         when='~mpi',
-        msg='Parallel collective I/O requires MPI-enabled QMCPACK.\n \
-        Please add "~phdf5" to the Spack install line for serial QMCPACK.'
+        msg='Parallel collective I/O requires MPI-enabled QMCPACK. ' \
+        'Please add "~phdf5" to the Spack install line for serial QMCPACK.'
     )
     conflicts(
         '+qe',
         when='~mpi',
-        msg='QMCPACK QE variant requires MPI due to limitation in QE build system.\n \
-        Please add "~qe" to the Spack install line for serial QMCPACK.'
+        msg='QMCPACK QE variant requires MPI due to limitation in QE build ' \
+        'system. Please add "~qe" to the Spack install line for serial ' \
+        'QMCPACK.'
     )
     conflicts(
         '+soa',

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -93,11 +93,11 @@ class Qmcpack(CMakePackage):
     conflicts('%intel@19:', when='+cuda', msg=cuda_warning)
 
     # QMCPACK 3.6.0 or later requires support for C++14
-    compiler_warning = 'QMCPACK 3.6.0 or later requires a \
-    compiler with support for C++14'
-    conflicts('%gcc@:5', when='@3.6.0:', msg=compiler_warning)
-    conflicts('%intel@:18', when='@3.6.0:', msg=compiler_warning)
-    conflicts('%pgi@:18', when='@3.6.0:', msg=compiler_warning)
+    compiler_warning = 'QMCPACK 3.6.0 or later requires a ' \
+                       'compiler with support for C++14'
+    conflicts('%gcc@:4', when='@3.6.0:', msg=compiler_warning)
+    conflicts('%intel@:17', when='@3.6.0:', msg=compiler_warning)
+    conflicts('%pgi@:17', when='@3.6.0:', msg=compiler_warning)
     conflicts('%llvm@:3.4', when='@3.6.0:', msg=compiler_warning)
 
     # Dependencies match those in the QMCPACK manual.

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -33,6 +33,7 @@ class Qmcpack(CMakePackage):
     # These defaults match those in the QMCPACK manual
     variant('debug', default=False, description='Build debug version')
     variant('mpi', default=True, description='Build with MPI support')
+    variant('phdf5', default=True, description='Build with parallel collective I/O')
     variant('cuda', default=False,
             description='Enable CUDA and GPU acceleration')
     variant('complex', default=False,
@@ -189,6 +190,12 @@ class Qmcpack(CMakePackage):
             args.append('-DQMC_MPI=1')
         elif '~mpi' in spec:
             args.append('-DQMC_MPI=0')
+
+        # Default is parallel collective I/O enabled
+        if '+phdf5' in spec:
+            args.append('-DENABLE_PHDF5=1')
+        elif '~phdf5' in spec:
+            args.append('-DENABLE_PHDF5=0')
 
         # Default is real-valued single particle orbitals
         if '+complex' in spec:

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -72,6 +72,13 @@ class Qmcpack(CMakePackage):
         msg='QMCPACK does not support MKL 64-bit integer variant'
     )
 
+    # CUDA conflicts taken from here
+    # https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html
+    cuda_warning = 'CUDA is not supported by this version of your compiler'
+    conflicts('%gcc@8:', when='+cuda', msg=cuda_warning)
+    conflicts('%llvm@7:', when='+cuda', msg=cuda_warning)
+    conflicts('%intel@19:', when='+cuda', msg=cuda_warning)
+
     # QMCPACK 3.6.0 or later requires support for C++14
     compiler_warning = 'QMCPACK 3.6.0 or later requires a \
     compiler with support for C++14'

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -81,8 +81,8 @@ class Qmcpack(CMakePackage):
 
     # Dependencies match those in the QMCPACK manual.
     # FIXME: once concretizer can unite unconditional and conditional
-    # dependencies the some of the '~mpi' will not be necessary.
-    depends_on('cmake@3.4.3:', type='build')
+    # dependencies, some of the '~mpi' variants below will not be necessary.
+    depends_on('cmake@3.6.0:', type='build')
     depends_on('mpi', when='+mpi')
     depends_on('libxml2')
     depends_on('hdf5')

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -22,6 +22,7 @@ class Qmcpack(CMakePackage):
     # can occasionally change.
     # NOTE: 12/19/2017 QMCPACK 3.0.0 does not build properly with Spack.
     version('develop')
+    version('3.6.0', tag='v3.6.0')
     version('3.5.0', tag='v3.5.0')
     version('3.4.0', tag='v3.4.0')
     version('3.3.0', tag='v3.3.0')

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -167,10 +167,11 @@ class Qmcpack(CMakePackage):
         args.append('-DLibxml2_INCLUDE_DIRS={0}'.format(xml2_prefix.include))
         args.append('-DLibxml2_LIBRARY_DIRS={0}'.format(xml2_prefix.lib))
 
-        fftw_prefix = spec['fftw'].prefix
-        args.append('-DFFTW_HOME={0}'.format(fftw_prefix))
-        args.append('-DFFTW_INCLUDE_DIRS={0}'.format(fftw_prefix.include))
-        args.append('-DFFTW_LIBRARY_DIRS={0}'.format(fftw_prefix.lib))
+        if '^fftw@3:' in spec:
+            fftw_prefix = spec['fftw'].prefix
+            args.append('-DFFTW_HOME={0}'.format(fftw_prefix))
+            args.append('-DFFTW_INCLUDE_DIRS={0}'.format(fftw_prefix.include))
+            args.append('-DFFTW_LIBRARY_DIRS={0}'.format(fftw_prefix.lib))
 
         args.append('-DBOOST_ROOT={0}'.format(self.spec['boost'].prefix))
         args.append('-DHDF5_ROOT={0}'.format(self.spec['hdf5'].prefix))

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -90,17 +90,25 @@ class Qmcpack(CMakePackage):
     # Dependencies match those in the QMCPACK manual.
     # FIXME: once concretizer can unite unconditional and conditional
     # dependencies, some of the '~mpi' variants below will not be necessary.
-    depends_on('cmake@3.6.0:', type='build')
-    depends_on('mpi', when='+mpi')
+    # Essential libraries
+    depends_on('cmake@3.4.3:', when='@:3.5.0', type='build')
+    depends_on('cmake@3.6.0:', when='@3.6.0:', type='build')
+    depends_on('boost', when='@:3.5.0')
+    depends_on('boost@1.61.0:', when='@3.6.0:')
     depends_on('libxml2')
-    depends_on('hdf5')
-    depends_on('hdf5+mpi', when='+mpi')
-    depends_on('hdf5~mpi', when='~mpi')
-    depends_on('boost')
+    depends_on('mpi', when='+mpi')
+    depends_on('cuda', when='+cuda')
+    # HDF5
+    depends_on('hdf5+hl+fortran', when='+qe')
+    depends_on('hdf5+hl+fortran+mpi', when='+qe+mpi')
+    depends_on('hdf5+hl+fortran~mpi', when='+qe~mpi')
+    depends_on('hdf5~hl~fortran', when='~qe')
+    depends_on('hdf5~hl~fortran+mpi', when='~qe+mpi')
+    depends_on('hdf5~hl~fortran~mpi', when='~qe~mpi')
+    # Math libraries
     depends_on('blas')
     depends_on('lapack')
     depends_on('fftw-api@3')
-    depends_on('cuda', when='+cuda')
 
     # qmcpack data analysis tools
     # basic command line tool based on Python and NumPy

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -96,8 +96,10 @@ class Qmcpack(CMakePackage):
 
     # qmcpack data analysis tools
     # basic command line tool based on Python and NumPy
-    # blas and lapack patching fails often and so are disabled at this time
-    depends_on('py-numpy~blas~lapack', when='+da', type='run')
+    # It may be necesseary to disable the blas and lapack
+    # when building the 'py-numpy' package, but it should not be a hard
+    # dependency on the 'py-numpy~blas~lapack' variant
+    depends_on('py-numpy', when='+da', type='run')
 
     # GUI is optional for data anlysis
     # py-matplotlib leads to a long complex DAG for dependencies

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -83,7 +83,7 @@ class Qmcpack(CMakePackage):
     compiler_warning = 'QMCPACK 3.6.0 or later requires a \
     compiler with support for C++14'
     conflicts('%gcc@:5', when='@3.6.0:', msg=compiler_warning)
-    conflicts('%intel@:18', when='@3.6.0', msg=compiler_warning)
+    conflicts('%intel@:18', when='@3.6.0:', msg=compiler_warning)
     conflicts('%pgi@:18', when='@3.6.0:', msg=compiler_warning)
     conflicts('%llvm@:3.4', when='@3.6.0:', msg=compiler_warning)
 

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -119,7 +119,7 @@ class Qmcpack(CMakePackage):
     # Spack package
     patch_url = 'https://raw.githubusercontent.com/QMCPACK/qmcpack/develop/external_codes/quantum_espresso/add_pw2qmcpack_to_qe-6.3.diff'
     patch_checksum = '2ee346e24926479f5e96f8dc47812173a8847a58354bbc32cf2114af7a521c13'
-    depends_on('quantum-espresso@6.3~elpa+hdf5',
+    depends_on('quantum-espresso@6.3~elpa+mpi+hdf5',
                patches=patch(patch_url, sha256=patch_checksum, when='+qe'),
                    when='+qe+mpi', type='run')
 

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -57,9 +57,27 @@ class Qmcpack(CMakePackage):
     # variant('+mixed', default=True, when='+cuda', description="...")
 
     # conflicts
-    conflicts('+soa', when='+cuda')
-    conflicts('^openblas+ilp64')
-    conflicts('^intel-mkl+ilp64')
+    conflicts(
+        '+soa',
+        when='+cuda',
+        msg='QMCPACK SOA variant does not exist for CUDA'
+    )
+    conflicts(
+        '^openblas+ilp64',
+        msg='QMCPACK does not support OpenBLAS 64-bit integer variant'
+    )
+    conflicts(
+        '^intel-mkl+ilp64',
+        msg='QMCPACK does not support MKL 64-bit integer variant'
+    )
+
+    # QMCPACK 3.6.0 or later requires support for C++14
+    compiler_warning = 'QMCPACK 3.6.0 or later requires a \
+    compiler with support for C++14'
+    conflicts('%gcc@:5', when='@3.6.0:', msg=compiler_warning)
+    conflicts('%intel@:18', when='@3.6.0', msg=compiler_warning)
+    conflicts('%pgi@:18', when='@3.6.0:', msg=compiler_warning)
+    conflicts('%llvm@:3.4', when='@3.6.0:', msg=compiler_warning)
 
     # Dependencies match those in the QMCPACK manual.
     # FIXME: once concretizer can unite unconditional and conditional

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -91,9 +91,7 @@ class Qmcpack(CMakePackage):
     depends_on('boost')
     depends_on('blas')
     depends_on('lapack')
-    depends_on('fftw')
-    depends_on('fftw+mpi', when='+mpi')
-    depends_on('fftw~mpi', when='~mpi')
+    depends_on('fftw-api@3')
     depends_on('cuda', when='+cuda')
 
     # qmcpack data analysis tools


### PR DESCRIPTION
This update to the QMCPACK Spack package has a number of updates and bug fixes:

- QMCPACK now uses the FFTW-API provider. You can only need intel-mkl or fftw, but not both.
- QMCPACK release 6.0 is now supported. This requires detection of a compiler that supports C++14, a newer version of boost, a newer version of CMake, etc.
- Relax dependencies on the +da variant
- Issue conflicts when an incompatible compiler-CUDA combination is chosen.
- Added QMCPACK collective I/O variant.
- Some clean-up of Spack code.
- Update conflicts, in particular qmcpack+qe~mpi variant does not work due to limitations in QE 3.6.0. May be able to fix this later by applying patch to QE.
- Correctly set-up Python environment for QMCPACK data analysis scripts