### PR TITLE
Fix download path, the existing one has been removed from nvidia's site

### DIFF
--- a/var/spack/repos/builtin/packages/cudnn/package.py
+++ b/var/spack/repos/builtin/packages/cudnn/package.py
@@ -13,7 +13,7 @@ class Cudnn(Package):
     homepage = "https://developer.nvidia.com/cudnn"
 
     version('7.3', '72666d3532850752612706601258a0b2',
-            url='https://developer.nvidia.com/compute/machine-learning/cudnn/secure/v7.3.0/prod/9.0_2018920/cudnn-9.0-linux-x64-v7.3.0.29.tgz')
+            url='http://developer.download.nvidia.com/compute/redist/cudnn/v7.3.0/cudnn-9.0-linux-x64-v7.3.0.29.tgz')
     version('6.0', 'a08ca487f88774e39eb6b0ef6507451d',
             url='http://developer.download.nvidia.com/compute/redist/cudnn/v6.0/cudnn-8.0-linux-x64-v6.0.tgz')
     version('5.1', '406f4ac7f7ee8aa9e41304c143461a69',


### PR DESCRIPTION
this is a fix to the download path which has disappeared