### PR TITLE
r-cowplot: new versions, more specific dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/r-cowplot/package.py
+++ b/var/spack/repos/builtin/packages/r-cowplot/package.py
@@ -19,8 +19,13 @@ class RCowplot(RPackage):
     url      = "https://cran.rstudio.com/src/contrib/cowplot_0.8.0.tar.gz"
     list_url = "https://cran.rstudio.com/src/contrib/Archive/cowplot"
 
-    version('0.8.0', 'bcb19c72734d8eb5d73db393c1235c3d')
+    version('0.9.3', sha256='3e10475fd7506ea9297ed72eb1a3acf858c6fa99d26e46fc39654eba000c3dcb')
+    version('0.9.2', sha256='8b92ce7f92937fde06b0cfb86c7634a39b3b2101e362cc55c4bec6b3fde1d28f')
+    version('0.9.1', sha256='953fd9d6ff370472b9f5a9ee867a423bea3e26e406d08a2192ec1872a2e60047')
+    version('0.9.0', sha256='d5632f78294c3678c08d3eb090abe1eec5cc9cd15cb5d96f9c43794ead098cb5')
+    version('0.8.0', sha256='a617fde25030fe764f20967fb753a953d73b47745a2146c97c2565eb4d06700d')
 
-    depends_on('r-ggplot2', type=('build', 'run'))
-    depends_on('r-gtable', type=('build', 'run'))
-    depends_on('r-plyr', type=('build', 'run'))
+    depends_on('r@3.3.0:')
+    depends_on('r-ggplot2@2.1.0:', type=('build', 'run'))
+    depends_on('r-gtable@0.1.2:', type=('build', 'run'))
+    depends_on('r-plyr@1.8.2:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-cowplot/package.py
+++ b/var/spack/repos/builtin/packages/r-cowplot/package.py
@@ -25,7 +25,8 @@ class RCowplot(RPackage):
     version('0.9.0', sha256='d5632f78294c3678c08d3eb090abe1eec5cc9cd15cb5d96f9c43794ead098cb5')
     version('0.8.0', sha256='a617fde25030fe764f20967fb753a953d73b47745a2146c97c2565eb4d06700d')
 
-    depends_on('r@3.3.0:')
+    depends_on('r@3.3.0:', type=('build', 'run'))
     depends_on('r-ggplot2@2.1.0:', type=('build', 'run'))
     depends_on('r-gtable@0.1.2:', type=('build', 'run'))
     depends_on('r-plyr@1.8.2:', type=('build', 'run'))
+    depends_on('r-scales', type=('build', 'run'))


### PR DESCRIPTION
Filling in dependency versions from https://cran.r-project.org/web/packages/cowplot/index.html

I don't need all these versions of r-cowplot, only the latest, but I figured I should provide them while I'm at it (?)