### PR TITLE
r-dt: new versions

### DIFF
--- a/var/spack/repos/builtin/packages/r-dt/package.py
+++ b/var/spack/repos/builtin/packages/r-dt/package.py
@@ -16,8 +16,14 @@ class RDt(RPackage):
     url      = "https://cran.r-project.org/src/contrib/DT_0.1.tar.gz"
     list_url = "https://cran.r-project.org/src/contrib/Archive/DT"
 
-    version('0.1', '5c8df984921fa484784ec4b8a4fb6f3c')
+    version('0.5', sha256='0e5bbb91b88a769e52ba079ebac266a25ea0f0a23bdf3deff31f51d2a81eade8')
+    version('0.4', sha256='3daa96b819ca54e5fbc2c7d78cb3637982a2d44be58cea0683663b71cfc7fa19')
+    version('0.3', sha256='ef42b24c9ea6cfa1ce089687bf858d773ac495dc80756d4475234e979bd437eb')
+    version('0.2', sha256='a1b7f9e5c31a241fdf78ac582499f346e915ff948554980bbc2262c924b806bd')
+    version('0.1', sha256='129bdafededbdcc3279d63b16f00c885b215f23cab2edfe33c9cbe177c8c4756')
 
-    depends_on('r-htmltools', type=('build', 'run'))
-    depends_on('r-htmlwidgets', type=('build', 'run'))
+    depends_on('r-htmltools@0.3.6:', type=('build', 'run'))
+    depends_on('r-htmlwidgets@1.3:', type=('build', 'run'))
     depends_on('r-magrittr', type=('build', 'run'))
+    depends_on('r-crosstalk', type=('build', 'run'))
+

--- a/var/spack/repos/builtin/packages/r-dt/package.py
+++ b/var/spack/repos/builtin/packages/r-dt/package.py
@@ -26,4 +26,3 @@ class RDt(RPackage):
     depends_on('r-htmlwidgets@1.3:', type=('build', 'run'))
     depends_on('r-magrittr', type=('build', 'run'))
     depends_on('r-crosstalk', type=('build', 'run'))
-

--- a/var/spack/repos/builtin/packages/r-dt/package.py
+++ b/var/spack/repos/builtin/packages/r-dt/package.py
@@ -16,7 +16,6 @@ class RDt(RPackage):
     url      = "https://cran.r-project.org/src/contrib/DT_0.1.tar.gz"
     list_url = "https://cran.r-project.org/src/contrib/Archive/DT"
 
-    version('0.5', sha256='0e5bbb91b88a769e52ba079ebac266a25ea0f0a23bdf3deff31f51d2a81eade8')
     version('0.4', sha256='3daa96b819ca54e5fbc2c7d78cb3637982a2d44be58cea0683663b71cfc7fa19')
     version('0.3', sha256='ef42b24c9ea6cfa1ce089687bf858d773ac495dc80756d4475234e979bd437eb')
     version('0.2', sha256='a1b7f9e5c31a241fdf78ac582499f346e915ff948554980bbc2262c924b806bd')


### PR DESCRIPTION
* updated release and checksums
  - I need version 0.4, seems like I ought to include the latest (0.5), and why not include the others while I'm at it (?)
* also tightened `depends_on()` per https://cran.r-project.org/web/packages/DT/index.html

Question: the CRAN page above says that `promises` is a dependency.  But it was not previously in this package.py, and `r-promises` doesn't exist in spack.  How is it possible that this worked before then?  

FYI @hartzell 