### PR TITLE
Release workflow

### DIFF
--- a/bin/rebuild-index.sh
+++ b/bin/rebuild-index.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+set -x
+
+SPACK_BIN_DIR="${CI_PROJECT_DIR}/bin"
+export PATH="${SPACK_BIN_DIR}:${PATH}"
+
+spack upload-s3 index

--- a/bin/rebuild-package.sh
+++ b/bin/rebuild-package.sh
@@ -1,0 +1,316 @@
+#!/bin/bash
+
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+###
+### This script represents a gitlab-ci job, corresponding to a single release
+### spec.  As such this script must first decide whether or not the spec it
+### has been assigned is up to date on the remote binary mirror.  If it is
+### not (i.e. the source code has changed in a way that caused a change in the
+### full_hash of the spec), this script will build the package, create a
+### binary cache for it, and then push all related files to the remote binary
+### mirror.  This script also communicates with a remote CDash instance to
+### share status on the package build process.
+###
+### The following environment variables are expected to be set in order for
+### the various elements in this script to function properly.  Listed first
+### are two defaults we rely on from gitlab, then three we set up in the
+### variables section of gitlab ourselves, and finally four variables
+### written into the .gitlab-ci.yml file.
+###
+### CI_PROJECT_DIR
+### CI_JOB_NAME
+###
+### AWS_ACCESS_KEY_ID
+### AWS_SECRET_ACCESS_KEY
+### SPACK_SIGNING_KEY
+###
+### CDASH_BASE_URL
+### ROOT_SPEC
+### DEPENDENCIES
+### MIRROR_URL
+###
+
+shopt -s expand_aliases
+
+export FORCE_UNSAFE_CONFIGURE=1
+
+TEMP_DIR="${CI_PROJECT_DIR}/jobs_scratch_dir"
+
+JOB_LOG_DIR="${TEMP_DIR}/logs"
+SPEC_DIR="${TEMP_DIR}/specs"
+LOCAL_MIRROR="${CI_PROJECT_DIR}/local_mirror"
+BUILD_CACHE_DIR="${LOCAL_MIRROR}/build_cache"
+SPACK_BIN_DIR="${CI_PROJECT_DIR}/bin"
+CDASH_UPLOAD_URL="${CDASH_BASE_URL}/submit.php?project=Spack"
+DEP_JOB_RELATEBUILDS_URL="${CDASH_BASE_URL}/api/v1/relateBuilds.php"
+declare -a JOB_DEPS_PKG_NAMES
+
+export SPACK_ROOT=${CI_PROJECT_DIR}
+export PATH="${SPACK_BIN_DIR}:${PATH}"
+export GNUPGHOME="${CI_PROJECT_DIR}/opt/spack/gpg"
+
+mkdir -p ${JOB_LOG_DIR}
+mkdir -p ${SPEC_DIR}
+
+cleanup() {
+    set +x
+
+    if [ -z "$exit_code" ] ; then
+
+        exit_code=$1
+        if [ -z "$exit_code" ] ; then
+            exit_code=0
+        fi
+
+        restore_io
+
+        if [ "$( type -t finalize )" '=' 'function' ] ; then
+            finalize "$JOB_LOG_DIR/cdash_log.txt"
+        fi
+
+        # We can clean these out later on, once we have a good sense for
+        # how the logging infrastructure is working
+        # rm -rf "$JOB_LOG_DIR"
+    fi
+
+    \exit $exit_code
+}
+
+alias exit='cleanup'
+
+begin_logging() {
+    trap "cleanup 1; \\exit \$exit_code" INT TERM QUIT
+    trap "cleanup 0; \\exit \$exit_code" EXIT
+
+    rm -rf "$JOB_LOG_DIR/cdash_log.txt"
+
+    # NOTE: Here, some redirects are set up
+    exec 3>&1 # fd 3 is now a dup of stdout
+    exec 4>&2 # fd 4 is now a dup of stderr
+
+    # stdout and stderr are joined and redirected to the log
+    exec &> "$JOB_LOG_DIR/cdash_log.txt"
+
+    set -x
+}
+
+restore_io() {
+    exec  >&-
+    exec 2>&-
+
+    exec  >&3
+    exec 2>&4
+
+    exec 3>&-
+    exec 4>&-
+}
+
+finalize() {
+    # If you define a finalize function:
+    #  - it will always be called at the very end of the script
+    #  - the log file will be passed in as the first argument, and
+    #  - the code in this function will not be logged.
+    echo "The full log file is located at $1"
+    # TODO: send this log data to cdash!
+}
+
+check_error()
+{
+    local last_exit_code=$1
+    local last_cmd=$2
+    if [[ ${last_exit_code} -ne 0 ]]; then
+        echo "${last_cmd} exited with code ${last_exit_code}"
+        echo "TERMINATING JOB"
+        exit 1
+    else
+        echo "${last_cmd} completed successfully"
+    fi
+}
+
+extract_build_id()
+{
+    LINES_TO_SEARCH=$1
+    regex="buildSummary\.php\?buildid=([[:digit:]]+)"
+    SINGLE_LINE_OUTPUT=$(echo ${LINES_TO_SEARCH} | tr -d '\n')
+
+    if [[ ${SINGLE_LINE_OUTPUT} =~ ${regex} ]]; then
+        echo "${BASH_REMATCH[1]}"
+    else
+        echo "NONE"
+    fi
+}
+
+get_relate_builds_post_data()
+{
+  cat <<EOF
+{
+  "project": "${1}",
+  "buildid": ${2},
+  "relatedid": ${3},
+  "relationship": "depends on"
+}
+EOF
+}
+
+gen_full_specs_for_job_and_deps() {
+
+    read -ra PARTSARRAY <<< "${CI_JOB_NAME}"
+    local pkgName="${PARTSARRAY[0]}"
+    local pkgVersion="${PARTSARRAY[1]}"
+    local compiler="${PARTSARRAY[2]}"
+    local osarch="${PARTSARRAY[3]}"
+
+    JOB_SPEC_NAME="${pkgName}@${pkgVersion}%${compiler} arch=${osarch}"
+    JOB_PKG_NAME="${pkgName}"
+    SPEC_YAML_PATH="${SPEC_DIR}/${pkgName}.yaml"
+    local root_spec_name="${ROOT_SPEC}"
+    local spec_names_to_save="${pkgName}"
+
+    IFS=';' read -ra DEPS <<< "${DEPENDENCIES}"
+    for i in "${DEPS[@]}"; do
+        read -ra PARTSARRAY <<< "${i}"
+        pkgName="${PARTSARRAY[0]}"
+        spec_names_to_save="${spec_names_to_save} ${pkgName}"
+        JOB_DEPS_PKG_NAMES+=("${pkgName}")
+    done
+
+    spack -d buildcache save-yaml --specs "${spec_names_to_save}" --root-spec "${root_spec_name}" --yaml-dir "${SPEC_DIR}"
+}
+
+begin_logging
+
+gen_full_specs_for_job_and_deps
+
+echo "Building package ${JOB_SPEC_NAME}, ${HASH}, ${MIRROR_URL}"
+
+# Finally, list the compilers spack knows about
+echo "Compiler Configurations:"
+spack config get compilers
+
+# Make the build_cache directory if it doesn't exist
+mkdir -p "${BUILD_CACHE_DIR}"
+
+# Get buildcache name so we can write a CDash build id file in the right place.
+# If we're unable to get the buildcache name, we may have encountered a problem
+# concretizing the spec, or some other issue that will eventually cause the job
+# to fail.
+JOB_BUILD_CACHE_ENTRY_NAME=`spack -d buildcache get-buildcache-name --spec-yaml "${SPEC_YAML_PATH}"`
+if [[ $? -ne 0 ]]; then
+    echo "ERROR, unable to get buildcache entry name for job ${CI_JOB_NAME} (spec: ${JOB_SPEC_NAME})"
+    exit 1
+fi
+
+# This should create the directory we referred to as GNUPGHOME earlier
+spack gpg list
+
+# Importing the secret key using gpg2 directly should allow to
+# sign and verify both
+set +x
+KEY_IMPORT_RESULT=`echo ${SPACK_SIGNING_KEY} | base64 --decode | gpg2 --import`
+check_error $? "gpg2 --import"
+set -x
+
+spack gpg list --trusted
+spack gpg list --signing
+
+# Whether we have to build the spec or download it pre-built, we expect to find
+# the cdash build id file sitting in this location afterwards.
+JOB_CDASH_ID_FILE="${BUILD_CACHE_DIR}/${JOB_BUILD_CACHE_ENTRY_NAME}.cdashid"
+
+# Finally, we can check the spec we have been tasked with build against
+# the built binary on the remote mirror to see if it needs to be rebuilt
+spack -d buildcache check --spec-yaml "${SPEC_YAML_PATH}" --mirror-url "${MIRROR_URL}" --rebuild-on-error
+
+if [[ $? -ne 0 ]]; then
+    # Configure mirror
+    spack mirror add local_artifact_mirror "file://${LOCAL_MIRROR}"
+
+    JOB_CDASH_ID="NONE"
+
+    # Install package, using the buildcache from the local mirror to
+    # satisfy dependencies.
+    BUILD_ID_LINE=`spack -d -k -v install --use-cache --cdash-upload-url "${CDASH_UPLOAD_URL}" --cdash-build "${JOB_SPEC_NAME}" --cdash-site "Spack AWS Gitlab Instance" --cdash-track "Experimental" -f "${SPEC_YAML_PATH}" | grep "buildSummary\\.php"`
+    check_error $? "spack install"
+
+    # By parsing the output of the "spack install" command, we can get the
+    # buildid generated for us by CDash
+    JOB_CDASH_ID=$(extract_build_id "${BUILD_ID_LINE}")
+
+    # Create buildcache entry for this package, reading the spec from the yaml
+    # file.
+    spack -d buildcache create --spec-yaml "${SPEC_YAML_PATH}" -a -f -d "${LOCAL_MIRROR}" --no-rebuild-index
+    check_error $? "spack buildcache create"
+
+    # Write the .cdashid file to the buildcache as well
+    echo "${JOB_CDASH_ID}" >> ${JOB_CDASH_ID_FILE}
+
+    # TODO: The upload-s3 command should eventually be replaced with something
+    # like: "spack buildcache put <mirror> <spec>", when that subcommand is
+    # properly implemented.
+    spack -d upload-s3 spec --base-dir "${LOCAL_MIRROR}" --spec-yaml "${SPEC_YAML_PATH}"
+    check_error $? "spack upload-s3 spec"
+else
+    echo "spec ${JOB_SPEC_NAME} is already up to date on remote mirror, downloading it"
+
+    # Configure remote mirror so we can download buildcache entry
+    spack mirror add remote_binary_mirror ${MIRROR_URL}
+
+    # Now download it
+    spack -d buildcache download --spec-yaml "${SPEC_YAML_PATH}" --path "${BUILD_CACHE_DIR}/" --require-cdashid
+    check_error $? "spack buildcache download"
+fi
+
+# The next step is to relate this job to the jobs it depends on
+if [ -f "${JOB_CDASH_ID_FILE}" ]; then
+    JOB_CDASH_BUILD_ID=$(<${JOB_CDASH_ID_FILE})
+
+    if [ "${JOB_CDASH_BUILD_ID}" == "NONE" ]; then
+        echo "ERROR: unable to read this jobs id from ${JOB_CDASH_ID_FILE}"
+        exit 1
+    fi
+
+    # Now get CDash ids for dependencies and "relate" each dependency build
+    # with this jobs build
+    for DEP_PKG_NAME in "${JOB_DEPS_PKG_NAMES[@]}"; do
+        echo "Getting cdash id for dependency --> ${DEP_PKG_NAME} <--"
+        DEP_SPEC_YAML_PATH="${SPEC_DIR}/${DEP_PKG_NAME}.yaml"
+        DEP_JOB_BUILDCACHE_NAME=`spack -d buildcache get-buildcache-name --spec-yaml "${DEP_SPEC_YAML_PATH}"`
+
+        if [[ $? -eq 0 ]]; then
+            DEP_JOB_ID_FILE="${BUILD_CACHE_DIR}/${DEP_JOB_BUILDCACHE_NAME}.cdashid"
+            echo "DEP_JOB_ID_FILE path = ${DEP_JOB_ID_FILE}"
+
+            if [ -f "${DEP_JOB_ID_FILE}" ]; then
+                DEP_JOB_CDASH_BUILD_ID=$(<${DEP_JOB_ID_FILE})
+                echo "File ${DEP_JOB_ID_FILE} contained value ${DEP_JOB_CDASH_BUILD_ID}"
+                echo "Relating builds -> ${JOB_SPEC_NAME} (buildid=${JOB_CDASH_BUILD_ID}) depends on ${DEP_PKG_NAME} (buildid=${DEP_JOB_CDASH_BUILD_ID})"
+                relateBuildsPostBody="$(get_relate_builds_post_data "Spack" ${JOB_CDASH_BUILD_ID} ${DEP_JOB_CDASH_BUILD_ID})"
+                relateBuildsResult=`curl "${DEP_JOB_RELATEBUILDS_URL}" -H "Content-Type: application/json" -H "Accept: application/json" -d "${relateBuildsPostBody}"`
+                echo "Result of curl request: ${relateBuildsResult}"
+            else
+                echo "ERROR: Did not find expected .cdashid file for dependency: ${DEP_JOB_ID_FILE}"
+                exit 1
+            fi
+        else
+            echo "ERROR: Unable to get buildcache entry name for ${DEP_SPEC_NAME}"
+            exit 1
+        fi
+    done
+else
+    echo "ERROR: Did not find expected .cdashid file ${JOB_CDASH_ID_FILE}"
+    exit 1
+fi
+
+# Show the size of the buildcache and a list of what's in it, directly
+# in the gitlab log output
+(
+    restore_io
+    du -sh ${BUILD_CACHE_DIR}
+    find ${BUILD_CACHE_DIR} -maxdepth 3 -type d -ls
+)
+
+echo "End of rebuild package script"

--- a/etc/spack/defaults/release.yaml
+++ b/etc/spack/defaults/release.yaml
@@ -1,0 +1,16 @@
+# -------------------------------------------------------------------------
+# This is the default spack release spec set.
+# -------------------------------------------------------------------------
+spec-set:
+    include: []
+    exclude: []
+    matrix:
+        - packages:
+            xsdk:
+                versions: [0.4.0]
+        - compilers:
+            gcc:
+                versions: [5.5.0]
+            clang:
+                versions: [6.0.0, '6.0.0-1ubuntu2']
+    cdash: ["https://spack.io/cdash/submit.php?project=spack"]

--- a/lib/spack/docs/example_files/spec_set.yaml
+++ b/lib/spack/docs/example_files/spec_set.yaml
@@ -1,0 +1,21 @@
+spec-set:
+    include: [ ape, atompaw, transset]
+    exclude: [binutils,tk]
+    packages:
+        ape:
+            versions: [2.2.1]
+        atompaw:
+            versions: [3.1.0.3, 4.0.0.13]
+        binutils:
+            versions: [2.20.1, 2.25, 2.23.2, 2.24, 2.27, 2.26]
+        tk:
+            versions: [8.6.5, 8.6.3]
+        transset:
+            versions: [1.0.1]
+    compilers:
+        gcc:
+            versions: [4.9, 4.8, 4.7]
+        clang:
+            versions: [3.5, 3.6]
+
+    dashboard: ["https://spack.io/cdash/submit.php?project=spack"]

--- a/lib/spack/docs/index.rst
+++ b/lib/spack/docs/index.rst
@@ -81,6 +81,11 @@ or refer to the full manual below.
    build_systems
    developer_guide
    docker_for_developers
+
+.. toctree::
+   :maxdepth: 2
+   :caption: API Docs
+
    Spack API Docs <spack>
    LLNL API Docs <llnl>
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -12,7 +12,9 @@ import tempfile
 import hashlib
 from contextlib import closing
 
-import ruamel.yaml as yaml
+import json
+
+from six.moves.urllib.error import URLError
 
 import llnl.util.tty as tty
 from llnl.util.filesystem import mkdirp, install_tree, get_filetype
@@ -21,10 +23,15 @@ import spack.cmd
 import spack.fetch_strategy as fs
 import spack.util.gpg as gpg_util
 import spack.relocate as relocate
+import spack.util.spack_yaml as syaml
+from spack.spec import Spec
 from spack.stage import Stage
 from spack.util.gpg import Gpg
-from spack.util.web import spider
+from spack.util.web import spider, read_from_url
 from spack.util.executable import ProcessError
+
+
+_build_cache_relative_path = 'build_cache'
 
 
 class NoOverwriteException(Exception):
@@ -90,11 +97,19 @@ def has_gnupg2():
         return False
 
 
+def build_cache_relative_path():
+    return _build_cache_relative_path
+
+
+def build_cache_directory(prefix):
+    return os.path.join(prefix, build_cache_relative_path())
+
+
 def buildinfo_file_name(prefix):
     """
     Filename of the binary package meta-data file
     """
-    name = prefix + "/.spack/binary_distribution"
+    name = os.path.join(prefix, ".spack/binary_distribution")
     return name
 
 
@@ -105,7 +120,7 @@ def read_buildinfo_file(prefix):
     filename = buildinfo_file_name(prefix)
     with open(filename, 'r') as inputfile:
         content = inputfile.read()
-        buildinfo = yaml.load(content)
+        buildinfo = syaml.load(content)
     return buildinfo
 
 
@@ -162,7 +177,7 @@ def write_buildinfo_file(prefix, workdir, rel=False):
     buildinfo['relocate_links'] = link_to_relocate
     filename = buildinfo_file_name(workdir)
     with open(filename, 'w') as outfile:
-        outfile.write(yaml.dump(buildinfo, default_flow_style=True))
+        outfile.write(syaml.dump(buildinfo, default_flow_style=True))
 
 
 def tarball_directory_name(spec):
@@ -235,35 +250,50 @@ def sign_tarball(key, force, specfile_path):
     Gpg.sign(key, specfile_path, '%s.asc' % specfile_path)
 
 
-def generate_index(outdir, indexfile_path):
-    f = open(indexfile_path, 'w')
+def _generate_html_index(path_list, output_path):
+    f = open(output_path, 'w')
     header = """<html>\n
 <head>\n</head>\n
 <list>\n"""
     footer = "</list>\n</html>\n"
-    paths = os.listdir(outdir + '/build_cache')
     f.write(header)
-    for path in paths:
+    for path in path_list:
         rel = os.path.basename(path)
         f.write('<li><a href="%s"> %s</a>\n' % (rel, rel))
     f.write(footer)
     f.close()
 
 
+def generate_package_index(build_cache_dir):
+    yaml_list = os.listdir(build_cache_dir)
+    path_list = [os.path.join(build_cache_dir, l) for l in yaml_list]
+
+    index_html_path_tmp = os.path.join(build_cache_dir, 'index.html.tmp')
+    index_html_path = os.path.join(build_cache_dir, 'index.html')
+
+    _generate_html_index(path_list, index_html_path_tmp)
+    shutil.move(index_html_path_tmp, index_html_path)
+
+
 def build_tarball(spec, outdir, force=False, rel=False, unsigned=False,
-                  allow_root=False, key=None):
+                  allow_root=False, key=None, regenerate_index=False):
     """
     Build a tarball from given spec and put it into the directory structure
     used at the mirror (following <tarball_directory_name>).
     """
+    if not spec.concrete:
+        raise ValueError('spec must be concrete to build tarball')
+
     # set up some paths
+    build_cache_dir = build_cache_directory(outdir)
+
     tarfile_name = tarball_name(spec, '.tar.gz')
-    tarfile_dir = os.path.join(outdir, "build_cache",
+    tarfile_dir = os.path.join(build_cache_dir,
                                tarball_directory_name(spec))
     tarfile_path = os.path.join(tarfile_dir, tarfile_name)
     mkdirp(tarfile_dir)
     spackfile_path = os.path.join(
-        outdir, "build_cache", tarball_path_name(spec, '.spack'))
+        build_cache_dir, tarball_path_name(spec, '.spack'))
     if os.path.exists(spackfile_path):
         if force:
             os.remove(spackfile_path)
@@ -275,8 +305,8 @@ def build_tarball(spec, outdir, force=False, rel=False, unsigned=False,
     spec_file = os.path.join(spec.prefix, ".spack", "spec.yaml")
     specfile_name = tarball_name(spec, '.spec.yaml')
     specfile_path = os.path.realpath(
-        os.path.join(outdir, "build_cache", specfile_name))
-    indexfile_path = os.path.join(outdir, "build_cache", "index.html")
+        os.path.join(build_cache_dir, specfile_name))
+
     if os.path.exists(specfile_path):
         if force:
             os.remove(specfile_path)
@@ -319,7 +349,7 @@ def build_tarball(spec, outdir, force=False, rel=False, unsigned=False,
     spec_dict = {}
     with open(spec_file, 'r') as inputfile:
         content = inputfile.read()
-        spec_dict = yaml.load(content)
+        spec_dict = syaml.load(content)
     bchecksum = {}
     bchecksum['hash_algorithm'] = 'sha256'
     bchecksum['hash'] = checksum
@@ -330,8 +360,15 @@ def build_tarball(spec, outdir, force=False, rel=False, unsigned=False,
     buildinfo['relative_prefix'] = os.path.relpath(
         spec.prefix, spack.store.layout.root)
     spec_dict['buildinfo'] = buildinfo
+    spec_dict['full_hash'] = spec.full_hash()
+
+    tty.debug('The full_hash ({0}) of {1} will be written into {2}'.format(
+        spec_dict['full_hash'], spec.name, specfile_path))
+    tty.debug(spec.tree())
+
     with open(specfile_path, 'w') as outfile:
-        outfile.write(yaml.dump(spec_dict))
+        outfile.write(syaml.dump(spec_dict))
+
     # sign the tarball and spec file with gpg
     if not unsigned:
         sign_tarball(key, force, specfile_path)
@@ -349,9 +386,9 @@ def build_tarball(spec, outdir, force=False, rel=False, unsigned=False,
         os.remove('%s.asc' % specfile_path)
 
     # create an index.html for the build_cache directory so specs can be found
-    if os.path.exists(indexfile_path):
-        os.remove(indexfile_path)
-    generate_index(outdir, indexfile_path)
+    if regenerate_index:
+        generate_package_index(build_cache_dir)
+
     return None
 
 
@@ -365,8 +402,8 @@ def download_tarball(spec):
         tty.die("Please add a spack mirror to allow " +
                 "download of pre-compiled packages.")
     tarball = tarball_path_name(spec, '.spack')
-    for key in mirrors:
-        url = mirrors[key] + "/build_cache/" + tarball
+    for mirror_name, mirror_url in mirrors.items():
+        url = mirror_url + '/' + _build_cache_relative_path + '/' + tarball
         # stage the tarball into standard place
         stage = Stage(url, name="build_cache", keep=True)
         try:
@@ -493,7 +530,7 @@ def extract_tarball(spec, filename, allow_root=False, unsigned=False,
     spec_dict = {}
     with open(specfile_path, 'r') as inputfile:
         content = inputfile.read()
-        spec_dict = yaml.load(content)
+        spec_dict = syaml.load(content)
     bchecksum = spec_dict['binary_cache_checksum']
 
     # if the checksums don't match don't install
@@ -563,10 +600,9 @@ def get_specs(force=False):
 
     path = str(spack.architecture.sys_type())
     urls = set()
-    for key in mirrors:
-        url = mirrors[key]
-        if url.startswith('file'):
-            mirror = url.replace('file://', '') + '/build_cache'
+    for mirror_name, mirror_url in mirrors.items():
+        if mirror_url.startswith('file'):
+            mirror = mirror_url.replace('file://', '') + "/" + _build_cache_relative_path
             tty.msg("Finding buildcaches in %s" % mirror)
             if os.path.exists(mirror):
                 files = os.listdir(mirror)
@@ -575,8 +611,8 @@ def get_specs(force=False):
                         link = 'file://' + mirror + '/' + file
                         urls.add(link)
         else:
-            tty.msg("Finding buildcaches on %s" % url)
-            p, links = spider(url + "/build_cache")
+            tty.msg("Finding buildcaches on %s" % mirror_url)
+            p, links = spider(mirror_url + "/" + _build_cache_relative_path)
             for link in links:
                 if re.search("spec.yaml", link) and re.search(path, link):
                     urls.add(link)
@@ -595,7 +631,7 @@ def get_specs(force=False):
                 # read the spec from the build cache file. All specs
                 # in build caches are concrete (as they are built) so
                 # we need to mark this spec concrete on read-in.
-                spec = spack.spec.Spec.from_yaml(f)
+                spec = Spec.from_yaml(f)
                 spec._mark_concrete()
                 _cached_specs.add(spec)
 
@@ -612,10 +648,10 @@ def get_keys(install=False, trust=False, force=False):
                 "download of build caches.")
 
     keys = set()
-    for key in mirrors:
-        url = mirrors[key]
-        if url.startswith('file'):
-            mirror = url.replace('file://', '') + '/build_cache'
+    for mirror_name, mirror_url in mirrors.items():
+        if mirror_url.startswith('file'):
+            mirror = os.path.join(
+                mirror_url.replace('file://', ''), _build_cache_relative_path)
             tty.msg("Finding public keys in %s" % mirror)
             files = os.listdir(mirror)
             for file in files:
@@ -623,8 +659,8 @@ def get_keys(install=False, trust=False, force=False):
                     link = 'file://' + mirror + '/' + file
                     keys.add(link)
         else:
-            tty.msg("Finding public keys on %s" % url)
-            p, links = spider(url + "/build_cache", depth=1)
+            tty.msg("Finding public keys on %s" % mirror_url)
+            p, links = spider(mirror_url + "/build_cache", depth=1)
             for link in links:
                 if re.search(r'\.key', link):
                     keys.add(link)
@@ -645,3 +681,148 @@ def get_keys(install=False, trust=False, force=False):
                 else:
                     tty.msg('Will not add this key to trusted keys.'
                             'Use -t to install all downloaded keys')
+
+
+def needs_rebuild(spec, mirror_url, rebuild_on_errors=False):
+    if not spec.concrete:
+        raise ValueError('spec must be concrete to check against mirror')
+
+    pkg_name = spec.name
+    pkg_version = spec.version
+
+    pkg_hash = spec.dag_hash()
+    pkg_full_hash = spec.full_hash()
+
+    tty.debug('Checking {0}-{1}, dag_hash = {2}, full_hash = {3}'.format(
+        pkg_name, pkg_version, pkg_hash, pkg_full_hash))
+    tty.debug(spec.tree())
+
+    # Try to retrieve the .spec.yaml directly, based on the known
+    # format of the name, in order to determine if the package
+    # needs to be rebuilt.
+    build_cache_dir = build_cache_directory(mirror_url)
+    spec_yaml_file_name = tarball_name(spec, '.spec.yaml')
+    file_path = os.path.join(build_cache_dir, spec_yaml_file_name)
+
+    result_of_error = 'Package ({0}) will {1}be rebuilt'.format(
+        spec.short_spec, '' if rebuild_on_errors else 'not ')
+
+    try:
+        yaml_contents = read_from_url(file_path)
+    except URLError as url_err:
+        err_msg = [
+            'Unable to determine whether {0} needs rebuilding,',
+            ' caught URLError attempting to read from {1}.',
+        ]
+        tty.error(''.join(err_msg).format(spec.short_spec, file_path))
+        tty.debug(url_err)
+        tty.warn(result_of_error)
+        return rebuild_on_errors
+
+    if not yaml_contents:
+        tty.error('Reading {0} returned nothing'.format(file_path))
+        tty.warn(result_of_error)
+        return rebuild_on_errors
+
+    spec_yaml = syaml.load(yaml_contents)
+
+    # If either the full_hash didn't exist in the .spec.yaml file, or it
+    # did, but didn't match the one we computed locally, then we should
+    # just rebuild.  This can be simplified once the dag_hash and the
+    # full_hash become the same thing.
+    if ('full_hash' not in spec_yaml or
+        spec_yaml['full_hash'] != pkg_full_hash):
+        if 'full_hash' in spec_yaml:
+            reason = 'hash mismatch, remote = {0}, local = {1}'.format(
+                spec_yaml['full_hash'], pkg_full_hash)
+        else:
+            reason = 'full_hash was missing from remote spec.yaml'
+        tty.msg('Rebuilding {0}, reason: {1}'.format(
+            spec.short_spec, reason))
+        tty.msg(spec.tree())
+        return True
+
+    return False
+
+
+def check_specs_against_mirrors(mirrors, specs, output_file=None,
+                                rebuild_on_errors=False):
+    """Check all the given specs against buildcaches on the given mirrors and
+    determine if any of the specs need to be rebuilt.  Reasons for needing to
+    rebuild include binary cache for spec isn't present on a mirror, or it is
+    present but the full_hash has changed since last time spec was built.
+
+    Arguments:
+        mirrors (dict): Mirrors to check against
+        specs (iterable): Specs to check against mirrors
+        output_file (string): Path to output file to be written.  If provided,
+            mirrors with missing or out-of-date specs will be formatted as a
+            JSON object and written to this file.
+        rebuild_on_errors (boolean): Treat any errors encountered while
+            checking specs as a signal to rebuild package.
+
+    Returns: 1 if any spec was out-of-date on any mirror, 0 otherwise.
+
+    """
+    rebuilds = {}
+    for mirror_name, mirror_url in mirrors.items():
+        tty.msg('Checking for built specs at %s' % mirror_url)
+
+        rebuild_list = []
+
+        for spec in specs:
+            if needs_rebuild(spec, mirror_url, rebuild_on_errors):
+                rebuild_list.append({
+                    'short_spec': spec.short_spec,
+                    'hash': spec.dag_hash()
+                })
+
+        if rebuild_list:
+            rebuilds[mirror_url] = {
+                'mirrorName': mirror_name,
+                'mirrorUrl': mirror_url,
+                'rebuildSpecs': rebuild_list
+            }
+
+    if output_file:
+        with open(output_file, 'w') as outf:
+            outf.write(json.dumps(rebuilds))
+
+    return 1 if rebuilds else 0
+
+
+def _download_buildcache_entry(mirror_root, descriptions):
+    for description in descriptions:
+        url = os.path.join(mirror_root, description['url'])
+        path = description['path']
+        fail_if_missing = not description['required']
+
+        mkdirp(path)
+
+        stage = Stage(url, name="build_cache", path=path, keep=True)
+
+        try:
+            stage.fetch()
+        except fs.FetchError:
+            if fail_if_missing:
+                tty.error('Failed to download required url {0}'.format(url))
+                return False
+
+    return True
+
+
+def download_buildcache_entry(file_descriptions):
+    mirrors = spack.config.get('mirrors')
+    if len(mirrors) == 0:
+        tty.die("Please add a spack mirror to allow " +
+                "download of buildcache entries.")
+
+    for mirror_name, mirror_url in mirrors.items():
+        mirror_root = os.path.join(mirror_url, _build_cache_relative_path)
+
+        if _download_buildcache_entry(mirror_root, file_descriptions):
+            return True
+        else:
+            continue
+
+    return False

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -4,14 +4,21 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import argparse
+import os
+import sys
 
 import llnl.util.tty as tty
 
 import spack.cmd
 import spack.environment as ev
+from spack.error import SpecError
+import spack.config
 import spack.repo
 import spack.store
-import spack.spec
+from spack.paths import etc_path
+from spack.spec import Spec, save_dependency_spec_yamls
+from spack.spec_set import CombinatorialSpecSet
+
 import spack.binary_distribution as bindist
 import spack.cmd.common.arguments as arguments
 from spack.cmd import display_specs
@@ -43,6 +50,11 @@ def setup_parser(subparser):
     create.add_argument('-d', '--directory', metavar='directory',
                         type=str, default='.',
                         help="directory in which to save the tarballs.")
+    create.add_argument('--no-rebuild-index', action='store_true',
+                        default=False, help="skip rebuilding index after " +
+                                            "building package(s)")
+    create.add_argument('-y', '--spec-yaml', default=None,
+                        help='Create buildcache entry for spec from yaml file')
     create.add_argument(
         'packages', nargs=argparse.REMAINDER,
         help="specs of packages to create buildcache for")
@@ -88,6 +100,81 @@ def setup_parser(subparser):
                         help="force new download of keys")
     dlkeys.set_defaults(func=getkeys)
 
+    # Check if binaries need to be rebuilt on remote mirror
+    check = subparsers.add_parser('check', help=check_binaries.__doc__)
+    check.add_argument(
+        '-m', '--mirror-url', default=None,
+        help='Override any configured mirrors with this mirror url')
+
+    check.add_argument(
+        '-o', '--output-file', default=None,
+        help='File where rebuild info should be written')
+
+    # used to construct scope arguments below
+    scopes = spack.config.scopes()
+    scopes_metavar = spack.config.scopes_metavar
+
+    check.add_argument(
+        '--scope', choices=scopes, metavar=scopes_metavar,
+        default=spack.config.default_modify_scope(),
+        help="configuration scope containing mirrors to check")
+
+    check.add_argument(
+        '-s', '--spec', default=None,
+        help='Check single spec instead of release specs file')
+
+    check.add_argument(
+        '-y', '--spec-yaml', default=None,
+        help='Check single spec from yaml file instead of release specs file')
+
+    check.add_argument(
+        '--rebuild-on-error', default=False, action='store_true',
+        help="Default to rebuilding packages if errors are encountered " +
+             "during the process of checking whether rebuilding is needed")
+
+    check.set_defaults(func=check_binaries)
+
+    # Download tarball and spec.yaml
+    dltarball = subparsers.add_parser('download', help=get_tarball.__doc__)
+    dltarball.add_argument(
+        '-s', '--spec', default=None,
+        help="Download built tarball for spec from mirror")
+    dltarball.add_argument(
+        '-y', '--spec-yaml', default=None,
+        help="Download built tarball for spec (from yaml file) from mirror")
+    dltarball.add_argument(
+        '-p', '--path', default=None,
+        help="Path to directory where tarball should be downloaded")
+    dltarball.add_argument(
+        '-c', '--require-cdashid', action='store_true', default=False,
+        help="Require .cdashid file to be downloaded with buildcache entry")
+    dltarball.set_defaults(func=get_tarball)
+
+    # Get buildcache name
+    getbuildcachename = subparsers.add_parser('get-buildcache-name',
+                                              help=get_buildcache_name.__doc__)
+    getbuildcachename.add_argument(
+        '-s', '--spec', default=None,
+        help='Spec string for which buildcache name is desired')
+    getbuildcachename.add_argument(
+        '-y', '--spec-yaml', default=None,
+        help='Path to spec yaml file for which buildcache name is desired')
+    getbuildcachename.set_defaults(func=get_buildcache_name)
+
+    # Given the root spec, save the yaml of the dependent spec to a file
+    saveyaml = subparsers.add_parser('save-yaml',
+                                     help=save_spec_yamls.__doc__)
+    saveyaml.add_argument(
+        '-r', '--root-spec', default=None,
+        help='Root spec of dependent spec')
+    saveyaml.add_argument(
+        '-s', '--specs', default=None,
+        help='List of dependent specs for which saved yaml is desired')
+    saveyaml.add_argument(
+        '-y', '--yaml-dir', default=None,
+        help='Path to directory where spec yamls should be saved')
+    saveyaml.set_defaults(func=save_spec_yamls)
+
 
 def find_matching_specs(
         pkgs, allow_multiple_matches=False, force=False, env=None):
@@ -106,6 +193,7 @@ def find_matching_specs(
     # List of specs that match expressions given via command line
     specs_from_cli = []
     has_errors = False
+    tty.debug('find_matching_specs: about to parse specs for {0}'.format(pkgs))
     specs = spack.cmd.parse_specs(pkgs)
     for spec in specs:
         matching = spack.store.db.query(spec, hashes=hashes)
@@ -178,10 +266,22 @@ def match_downloaded_specs(pkgs, allow_multiple_matches=False, force=False):
 
 def createtarball(args):
     """create a binary package from an existing install"""
-    if not args.packages:
+    if args.spec_yaml:
+        packages = set()
+        tty.msg('createtarball, reading spec from {0}'.format(args.spec_yaml))
+        with open(args.spec_yaml, 'r') as fd:
+            yaml_text = fd.read()
+            tty.debug('createtarball read spec yaml:')
+            tty.debug(yaml_text)
+            s = Spec.from_yaml(yaml_text)
+            packages.add('/{0}'.format(s.dag_hash()))
+    elif args.packages:
+        packages = args.packages
+    else:
         tty.die("build cache file creation requires at least one" +
-                " installed package argument")
-    pkgs = set(args.packages)
+                " installed package argument or else path to a" +
+                " yaml file containing a spec to install")
+    pkgs = set(packages)
     specs = set()
     outdir = '.'
     if args.directory:
@@ -194,7 +294,12 @@ def createtarball(args):
     env = ev.get_env(args, 'buildcache create')
 
     matches = find_matching_specs(pkgs, False, False, env=env)
+
+    if matches:
+        tty.msg('Found at least one matching spec')
+
     for match in matches:
+        tty.msg('examining match {0}'.format(match.format()))
         if match.external or match.virtual:
             tty.msg('skipping external or virtual spec %s' %
                     match.format())
@@ -217,7 +322,8 @@ def createtarball(args):
     for spec in specs:
         tty.msg('creating binary cache file for package %s ' % spec.format())
         bindist.build_tarball(spec, outdir, args.force, args.rel,
-                              args.unsigned, args.allow_root, signkey)
+                              args.unsigned, args.allow_root, signkey,
+                              not args.no_rebuild_index)
 
 
 def installtarball(args):
@@ -233,7 +339,7 @@ def installtarball(args):
 
 
 def install_tarball(spec, args):
-    s = spack.spec.Spec(spec)
+    s = Spec(spec)
     if s.external or s.virtual:
         tty.warn("Skipping external or virtual package %s" % spec.format())
         return
@@ -270,6 +376,151 @@ def listspecs(args):
 def getkeys(args):
     """get public keys available on mirrors"""
     bindist.get_keys(args.install, args.trust, args.force)
+
+
+def check_binaries(args):
+    """Check specs (either a single spec from --spec, or else the full set
+    of release specs) against remote binary mirror(s) to see if any need
+    to be rebuilt.  This command uses the process exit code to indicate
+    its result, specifically, if the exit code is non-zero, then at least
+    one of the indicated specs needs to be rebuilt.
+    """
+    if args.spec or args.spec_yaml:
+        specs = [get_concrete_spec(args)]
+    else:
+        release_specs_path = os.path.join(
+            etc_path, 'spack', 'defaults', 'release.yaml')
+        spec_set = CombinatorialSpecSet.from_file(release_specs_path)
+        specs = [spec for spec in spec_set]
+
+    if not specs:
+        tty.msg('No specs provided, exiting.')
+        sys.exit(0)
+
+    for spec in specs:
+        spec.concretize()
+
+    # Next see if there are any configured binary mirrors
+    configured_mirrors = spack.config.get('mirrors', scope=args.scope)
+
+    if args.mirror_url:
+        configured_mirrors = {'additionalMirrorUrl': args.mirror_url}
+
+    if not configured_mirrors:
+        tty.msg('No mirrors provided, exiting.')
+        sys.exit(0)
+
+    sys.exit(bindist.check_specs_against_mirrors(
+        configured_mirrors, specs, args.output_file, args.rebuild_on_error))
+
+
+def get_tarball(args):
+    """Download buildcache entry from a remote mirror to local folder.  This
+    command uses the process exit code to indicate its result, specifically,
+    a non-zero exit code indicates that the command failed to download at
+    least one of the required buildcache components.  Normally, just the
+    tarball and .spec.yaml files are required, but if the --require-cdashid
+    argument was provided, then a .cdashid file is also required."""
+    if not args.spec and not args.spec_yaml:
+        tty.msg('No specs provided, exiting.')
+        sys.exit(0)
+
+    if not args.path:
+        tty.msg('No download path provided, exiting')
+        sys.exit(0)
+
+    spec = get_concrete_spec(args)
+
+    tarfile_name = bindist.tarball_name(spec, '.spack')
+    tarball_dir_name = bindist.tarball_directory_name(spec)
+    tarball_path_name = os.path.join(tarball_dir_name, tarfile_name)
+    local_tarball_path = os.path.join(args.path, tarball_dir_name)
+
+    files_to_fetch = [
+        {
+            'url': tarball_path_name,
+            'path': local_tarball_path,
+            'required': True,
+        }, {
+            'url': bindist.tarball_name(spec, '.spec.yaml'),
+            'path': args.path,
+            'required': True,
+        }, {
+            'url': bindist.tarball_name(spec, '.cdashid'),
+            'path': args.path,
+            'required': args.require_cdashid,
+        },
+    ]
+
+    result = bindist.download_buildcache_entry(files_to_fetch)
+
+    if result:
+        sys.exit(0)
+
+    sys.exit(1)
+
+
+def get_concrete_spec(args):
+    spec_str = args.spec
+    spec_yaml_path = args.spec_yaml
+
+    if not spec_str and not spec_yaml_path:
+        tty.msg('Must provide either spec string or path to ' +
+                'yaml to concretize spec')
+        sys.exit(1)
+
+    if spec_str:
+        try:
+            spec = Spec(spec_str)
+            spec.concretize()
+        except SpecError as spec_error:
+            tty.error('Unable to concrectize spec {0}'.format(args.spec))
+            tty.debug(spec_error)
+            sys.exit(1)
+
+        return spec
+
+    with open(spec_yaml_path, 'r') as fd:
+        return Spec.from_yaml(fd.read())
+
+
+def get_buildcache_name(args):
+    """Get name (prefix) of buildcache entries for this spec"""
+    spec = get_concrete_spec(args)
+    buildcache_name = bindist.tarball_name(spec, '')
+
+    print('{0}'.format(buildcache_name))
+
+    sys.exit(0)
+
+
+def save_spec_yamls(args):
+    """Get full spec for dependencies, relative to root spec, and write them
+    to files in the specified output directory.  Uses exit code to signal
+    success or failure.  An exit code of zero means the command was likely
+    successful.  If any errors or exceptions are encountered, or if expected
+    command-line arguments are not provided, then the exit code will be
+    non-zero."""
+    if not args.root_spec:
+        tty.msg('No root spec provided, exiting.')
+        sys.exit(1)
+
+    if not args.specs:
+        tty.msg('No dependent specs provided, exiting.')
+        sys.exit(1)
+
+    if not args.yaml_dir:
+        tty.msg('No yaml directory provided, exiting.')
+        sys.exit(1)
+
+    root_spec = Spec(args.root_spec)
+    root_spec.concretize()
+    root_spec_as_yaml = root_spec.to_yaml(all_deps=True)
+
+    save_dependency_spec_yamls(
+        root_spec_as_yaml, args.yaml_dir, args.specs.split())
+
+    sys.exit(0)
 
 
 def buildcache(parser, args):

--- a/lib/spack/spack/cmd/release_jobs.py
+++ b/lib/spack/spack/cmd/release_jobs.py
@@ -1,0 +1,607 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import argparse
+import json
+import os
+import shutil
+import tempfile
+
+import subprocess
+from jsonschema import validate, ValidationError
+from six import iteritems
+
+import llnl.util.tty as tty
+
+from spack.architecture import sys_type
+from spack.dependency import all_deptypes
+from spack.spec import Spec, CompilerSpec
+from spack.paths import spack_root
+from spack.error import SpackError
+from spack.schema.os_container_mapping import schema as mapping_schema
+from spack.schema.specs_deps import schema as specs_deps_schema
+from spack.spec_set import CombinatorialSpecSet
+import spack.util.spack_yaml as syaml
+
+description = "generate release build set as .gitlab-ci.yml"
+section = "build"
+level = "long"
+
+
+def setup_parser(subparser):
+    subparser.add_argument(
+        '-s', '--spec-set', default=None,
+        help="path to release spec-set yaml file")
+
+    subparser.add_argument(
+        '-m', '--mirror-url', default=None,
+        help="url of binary mirror where builds should be pushed")
+
+    subparser.add_argument(
+        '-o', '--output-file', default=".gitlab-ci.yml",
+        help="path to output file to write")
+
+    subparser.add_argument(
+        '-t', '--shared-runner-tag', default=None,
+        help="tag to add to jobs for shared runner selection")
+
+    subparser.add_argument(
+        '-k', '--signing-key', default=None,
+        help="hash of gpg key to use for package signing")
+
+    subparser.add_argument(
+        '-c', '--cdash-url', default='https://cdash.spack.io',
+        help="Base url of CDash instance jobs should communicate with")
+
+    subparser.add_argument(
+        '-p', '--print-summary', action='store_true', default=False,
+        help="Print summary of staged jobs to standard output")
+
+    subparser.add_argument(
+        '--resolve-deps-locally', action='store_true', default=False,
+        help="Use only the current machine to concretize specs, " +
+        "instead of iterating over items in os-container-mapping.yaml " +
+        "and using docker run.  Assumes the current machine architecure " +
+        "is listed in the os-container-mapping.yaml config file.")
+
+    subparser.add_argument(
+        '--specs-deps-output', default='/dev/stdout',
+        help="A file path to which spec deps should be written.  This " +
+             "argument is generally for internal use, and should not be " +
+             "provided by end-users under normal conditions.")
+
+    subparser.add_argument(
+        'specs', nargs=argparse.REMAINDER,
+        help="These positional arguments are generally for internal use.  " +
+             "The --spec-set argument should be used to identify a yaml " +
+             "file describing the set of release specs to include in the " +
+             ".gitlab-ci.yml file.")
+
+
+def get_job_name(spec, osarch):
+    return '{0} {1} {2} {3}'.format(spec.name, spec.version,
+                                    spec.compiler, osarch)
+
+
+def get_spec_string(spec):
+    format_elements = [
+        '${package}@${version}',
+        '%${compilername}@${compilerversion}',
+    ]
+
+    if spec.architecture:
+        format_elements.append(' arch=${architecture}')
+
+    return spec.format(''.join(format_elements))
+
+
+def spec_deps_key_label(s):
+    return s.dag_hash(), "%s/%s" % (s.name, s.dag_hash(7))
+
+
+def _add_dependency(spec_label, dep_label, deps):
+    if spec_label == dep_label:
+        return
+    if spec_label not in deps:
+        deps[spec_label] = set()
+    deps[spec_label].add(dep_label)
+
+
+def get_deps_using_container(specs, image):
+    image_home_dir = '/home/spackuser'
+    repo_mount_location = '{0}/spack'.format(image_home_dir)
+    temp_dir = tempfile.mkdtemp(dir='/tmp')
+
+    # The paths this module will see (from outside the container)
+    temp_file = os.path.join(temp_dir, 'spec_deps.json')
+    temp_err = os.path.join(temp_dir, 'std_err.log')
+
+    # The paths the bash_command will see inside the container
+    json_output = '/work/spec_deps.json'
+    std_error = '/work/std_err.log'
+
+    specs_arg = ' '.join([str(spec) for spec in specs])
+
+    bash_command = " ".join(["source {0}/share/spack/setup-env.sh ;",
+                             "spack release-jobs",
+                             "--specs-deps-output {1}",
+                             "{2}",
+                             "2> {3}"]).format(
+        repo_mount_location, json_output, specs_arg, std_error)
+
+    docker_cmd_to_run = [
+        'docker', 'run', '--rm',
+        '-v', '{0}:{1}'.format(spack_root, repo_mount_location),
+        '-v', '{0}:{1}'.format(temp_dir, '/work'),
+        '--entrypoint', 'bash',
+        '-t', str(image),
+        '-c',
+        bash_command,
+    ]
+
+    tty.debug('Running subprocess command:')
+    tty.debug(' '.join(docker_cmd_to_run))
+
+    # Docker is going to merge the stdout/stderr from the script and write it
+    # all to the stdout of the running container.  For this reason, we won't
+    # pipe any stdout/stderr from the docker command, but rather write the
+    # output we care about to a file in a mounted directory.  Similarly, any
+    # errors from running the spack command inside the container are redirected
+    # to another file in the mounted directory.
+    proc = subprocess.Popen(docker_cmd_to_run)
+    proc.wait()
+
+    # Check for errors from spack command
+    if os.path.exists(temp_err) and os.path.getsize(temp_err) > 0:
+        # Spack wrote something to stderr inside the container.  We will
+        # print out whatever it is, but attempt to carry on with the process.
+        tty.error('Encountered spack error running command in container:')
+        with open(temp_err, 'r') as err:
+            tty.error(err.read())
+
+    spec_deps_obj = {}
+
+    try:
+        # Finally, try to read/parse the output we really care about: the
+        # specs and dependency edges for the provided spec, as it was
+        # concretized in the appropriate container.
+        with open(temp_file, 'r') as fd:
+            spec_deps_obj = json.loads(fd.read())
+
+    except ValueError as val_err:
+        tty.error('Failed to read json object from spec-deps output file:')
+        tty.error(str(val_err))
+    except IOError as io_err:
+        tty.error('Problem reading from spec-deps json output file:')
+        tty.error(str(io_err))
+    finally:
+        shutil.rmtree(temp_dir)
+
+    return spec_deps_obj
+
+
+def get_spec_dependencies(specs, deps, spec_labels, image=None):
+    if image:
+        spec_deps_obj = get_deps_using_container(specs, image)
+    else:
+        spec_deps_obj = compute_spec_deps(specs)
+
+    try:
+        validate(spec_deps_obj, specs_deps_schema)
+    except ValidationError as val_err:
+        tty.error('Ill-formed specs dependencies JSON object')
+        tty.error(spec_deps_obj)
+        tty.debug(val_err)
+        return
+
+    if spec_deps_obj:
+        dependencies = spec_deps_obj['dependencies']
+        specs = spec_deps_obj['specs']
+
+        for entry in specs:
+            spec_labels[entry['label']] = {
+                'spec': Spec(entry['spec']),
+                'rootSpec': entry['root_spec'],
+            }
+
+        for entry in dependencies:
+            _add_dependency(entry['spec'], entry['depends'], deps)
+
+
+def stage_spec_jobs(spec_set, containers, current_system=None):
+    """Take a set of release specs along with a dictionary describing the
+        available docker containers and what compilers they have, and generate
+        a list of "stages", where the jobs in any stage are dependent only on
+        jobs in previous stages.  This allows us to maximize build parallelism
+        within the gitlab-ci framework.
+
+    Arguments:
+        spec_set (CombinatorialSpecSet): Iterable containing all the specs
+            to build.
+        containers (dict): Describes the docker containers available to use
+            for concretizing specs (and also for the gitlab runners to use
+            for building packages).  The schema can be found at
+            "lib/spack/spack/schema/os_container_mapping.py"
+        current_system (string): If provided, this indicates not to use the
+            containers for concretizing the release specs, but rather just
+            assume the current system is in the "containers" dictionary.  A
+            SpackError will be raised if the current system is not in that
+            dictionary.
+
+    Returns: A tuple of information objects describing the specs, dependencies
+        and stages:
+
+        spec_labels: A dictionary mapping the spec labels which are made of
+            (pkg-name/hash-prefix), to objects containing "rootSpec" and "spec"
+            keys.  The root spec is the spec of which this spec is a dependency
+            and the spec is the formatted spec string for this spec.
+
+        deps: A dictionary where the keys should also have appeared as keys in
+            the spec_labels dictionary, and the values are the set of
+            dependencies for that spec.
+
+        stages: An ordered list of sets, each of which contains all the jobs to
+            built in that stage.  The jobs are expressed in the same format as
+            the keys in the spec_labels and deps objects.
+
+    """
+
+    # The convenience method below, "remove_satisfied_deps()", does not modify
+    # the "deps" parameter.  Instead, it returns a new dictionary where only
+    # dependencies which have not yet been satisfied are included in the
+    # return value.
+    def remove_satisfied_deps(deps, satisfied_list):
+        new_deps = {}
+
+        for key, value in iteritems(deps):
+            new_value = set([v for v in value if v not in satisfied_list])
+            if new_value:
+                new_deps[key] = new_value
+
+        return new_deps
+
+    deps = {}
+    spec_labels = {}
+
+    if current_system:
+        if current_system not in containers:
+            error_msg = ' '.join(['Current system ({0}) does not appear in',
+                                  'os_container_mapping.yaml, ignoring',
+                                  'request']).format(
+                current_system)
+            raise SpackError(error_msg)
+        os_names = [current_system]
+    else:
+        os_names = [name for name in containers]
+
+    container_specs = {}
+    for name in os_names:
+        container_specs[name] = {'image': None, 'specs': []}
+
+    # Collect together all the specs that should be concretized in each
+    # container so they can all be done at once, avoiding the need to
+    # run the docker container for each spec separately.
+    for spec in spec_set:
+        for osname in os_names:
+            container_info = containers[osname]
+            image = None if current_system else container_info['image']
+            if image:
+                container_specs[osname]['image'] = image
+            if 'compilers' in container_info:
+                found_at_least_one = False
+                for item in container_info['compilers']:
+                    container_compiler_spec = CompilerSpec(item['name'])
+                    if spec.compiler == container_compiler_spec:
+                        container_specs[osname]['specs'].append(spec)
+                        found_at_least_one = True
+                if not found_at_least_one:
+                    tty.warn('No compiler in {0} satisfied {1}'.format(
+                        osname, spec.compiler))
+
+    for osname in container_specs:
+        if container_specs[osname]['specs']:
+            image = container_specs[osname]['image']
+            specs = container_specs[osname]['specs']
+            get_spec_dependencies(specs, deps, spec_labels, image)
+
+    # Save the original deps, as we need to return them at the end of the
+    # function.  In the while loop below, the "dependencies" variable is
+    # overwritten rather than being modified each time through the loop,
+    # thus preserving the original value of "deps" saved here.
+    dependencies = deps
+    unstaged = set(spec_labels.keys())
+    stages = []
+
+    while dependencies:
+        dependents = set(dependencies.keys())
+        next_stage = unstaged.difference(dependents)
+        stages.append(next_stage)
+        unstaged.difference_update(next_stage)
+        # Note that "dependencies" is a dictionary mapping each dependent
+        # package to the set of not-yet-handled dependencies.  The final step
+        # below removes all the dependencies that are handled by this stage.
+        dependencies = remove_satisfied_deps(dependencies, next_stage)
+
+    if unstaged:
+        stages.append(unstaged.copy())
+
+    return spec_labels, deps, stages
+
+
+def print_staging_summary(spec_labels, dependencies, stages):
+    if not stages:
+        return
+
+    tty.msg('Staging summary:')
+    stage_index = 0
+    for stage in stages:
+        tty.msg('  stage {0} ({1} jobs):'.format(stage_index, len(stage)))
+
+        for job in sorted(stage):
+            s = spec_labels[job]['spec']
+            tty.msg('    {0} -> {1}'.format(job, get_spec_string(s)))
+
+        stage_index += 1
+
+
+def compute_spec_deps(spec_list, stream_like=None):
+    """
+    Computes all the dependencies for the spec(s) and generates a JSON
+    object which provides both a list of unique spec names as well as a
+    comprehensive list of all the edges in the dependency graph.  For
+    example, given a single spec like 'readline@7.0', this function
+    generates the following JSON object:
+
+    .. code-block:: JSON
+
+       {
+           "dependencies": [
+               {
+                   "depends": "readline/ip6aiun",
+                   "spec": "readline/ip6aiun"
+               },
+               {
+                   "depends": "ncurses/y43rifz",
+                   "spec": "readline/ip6aiun"
+               },
+               {
+                   "depends": "ncurses/y43rifz",
+                   "spec": "readline/ip6aiun"
+               },
+               {
+                   "depends": "pkgconf/eg355zb",
+                   "spec": "ncurses/y43rifz"
+               },
+               {
+                   "depends": "pkgconf/eg355zb",
+                   "spec": "readline/ip6aiun"
+               }
+           ],
+           "specs": [
+               {
+                 "root_spec": "readline@7.0%clang@9.1.0-apple arch=darwin-...",
+                 "spec": "readline@7.0%clang@9.1.0-apple arch=darwin-highs...",
+                 "label": "readline/ip6aiun"
+               },
+               {
+                 "root_spec": "readline@7.0%clang@9.1.0-apple arch=darwin-...",
+                 "spec": "ncurses@6.1%clang@9.1.0-apple arch=darwin-highsi...",
+                 "label": "ncurses/y43rifz"
+               },
+               {
+                 "root_spec": "readline@7.0%clang@9.1.0-apple arch=darwin-...",
+                 "spec": "pkgconf@1.5.4%clang@9.1.0-apple arch=darwin-high...",
+                 "label": "pkgconf/eg355zb"
+               }
+           ]
+       }
+
+    The object can be optionally written out to some stream.  This is
+    useful, for example, when we need to concretize and generate the
+    dependencies of a spec in a specific docker container.
+
+    """
+    deptype = all_deptypes
+    spec_labels = {}
+
+    specs = []
+    dependencies = []
+
+    def append_dep(s, d):
+        dependencies.append({
+            'spec': s,
+            'depends': d,
+        })
+
+    for spec in spec_list:
+        spec.concretize()
+
+        root_spec = get_spec_string(spec)
+
+        rkey, rlabel = spec_deps_key_label(spec)
+
+        for s in spec.traverse(deptype=deptype):
+            skey, slabel = spec_deps_key_label(s)
+            spec_labels[slabel] = {
+                'spec': get_spec_string(s),
+                'root': root_spec,
+            }
+            append_dep(rlabel, slabel)
+
+            for d in s.dependencies(deptype=deptype):
+                dkey, dlabel = spec_deps_key_label(d)
+                append_dep(slabel, dlabel)
+
+    for l, d in spec_labels.items():
+        specs.append({
+            'label': l,
+            'spec': d['spec'],
+            'root_spec': d['root'],
+        })
+
+    deps_json_obj = {
+        'specs': specs,
+        'dependencies': dependencies,
+    }
+
+    if stream_like:
+        stream_like.write(json.dumps(deps_json_obj))
+
+    return deps_json_obj
+
+
+def release_jobs(parser, args):
+    share_path = os.path.join(spack_root, 'share', 'spack', 'docker')
+    os_container_mapping_path = os.path.join(
+        share_path, 'os-container-mapping.yaml')
+
+    with open(os_container_mapping_path, 'r') as fin:
+        os_container_mapping = syaml.load(fin)
+
+    try:
+        validate(os_container_mapping, mapping_schema)
+    except ValidationError as val_err:
+        tty.error('Ill-formed os-container-mapping configuration object')
+        tty.error(os_container_mapping)
+        tty.debug(val_err)
+        return
+
+    containers = os_container_mapping['containers']
+
+    if args.specs:
+        # Just print out the spec labels and all dependency edges in
+        # a json format.
+        spec_list = [Spec(s) for s in args.specs]
+        with open(args.specs_deps_output, 'w') as out:
+            compute_spec_deps(spec_list, out)
+        return
+
+    current_system = sys_type() if args.resolve_deps_locally else None
+
+    release_specs_path = args.spec_set
+    if not release_specs_path:
+        raise SpackError('Must provide path to release spec-set')
+
+    release_spec_set = CombinatorialSpecSet.from_file(release_specs_path)
+
+    mirror_url = args.mirror_url
+
+    if not mirror_url:
+        raise SpackError('Must provide url of target binary mirror')
+
+    cdash_url = args.cdash_url
+
+    spec_labels, dependencies, stages = stage_spec_jobs(
+        release_spec_set, containers, current_system)
+
+    if not stages:
+        tty.msg('No jobs staged, exiting.')
+        return
+
+    if args.print_summary:
+        print_staging_summary(spec_labels, dependencies, stages)
+
+    output_object = {}
+    job_count = 0
+
+    stage_names = ['stage-{0}'.format(i) for i in range(len(stages))]
+    stage = 0
+
+    for stage_jobs in stages:
+        stage_name = stage_names[stage]
+
+        for spec_label in stage_jobs:
+            release_spec = spec_labels[spec_label]['spec']
+            root_spec = spec_labels[spec_label]['rootSpec']
+
+            pkg_compiler = release_spec.compiler
+            pkg_hash = release_spec.dag_hash()
+
+            osname = str(release_spec.architecture)
+            job_name = get_job_name(release_spec, osname)
+            container_info = containers[osname]
+            build_image = container_info['image']
+
+            job_scripts = ['./bin/rebuild-package.sh']
+
+            if 'setup_script' in container_info:
+                job_scripts.insert(
+                    0, container_info['setup_script'] % pkg_compiler)
+
+            job_dependencies = []
+            if spec_label in dependencies:
+                job_dependencies = (
+                    [get_job_name(spec_labels[dep_label]['spec'], osname)
+                        for dep_label in dependencies[spec_label]])
+
+            job_object = {
+                'stage': stage_name,
+                'variables': {
+                    'MIRROR_URL': mirror_url,
+                    'CDASH_BASE_URL': cdash_url,
+                    'HASH': pkg_hash,
+                    'DEPENDENCIES': ';'.join(job_dependencies),
+                    'ROOT_SPEC': str(root_spec),
+                },
+                'script': job_scripts,
+                'image': build_image,
+                'artifacts': {
+                    'paths': [
+                        'local_mirror/build_cache',
+                        'jobs_scratch_dir',
+                        'cdash_report',
+                    ],
+                    'when': 'always',
+                },
+                'dependencies': job_dependencies,
+            }
+
+            # If we see 'compilers' in the container iformation, it's a
+            # filter for the compilers this container can handle, else we
+            # assume it can handle any compiler
+            if 'compilers' in container_info:
+                do_job = False
+                for item in container_info['compilers']:
+                    container_compiler_spec = CompilerSpec(item['name'])
+                    if pkg_compiler == container_compiler_spec:
+                        do_job = True
+            else:
+                do_job = True
+
+            if args.shared_runner_tag:
+                job_object['tags'] = [args.shared_runner_tag]
+
+            if args.signing_key:
+                job_object['variables']['SIGN_KEY_HASH'] = args.signing_key
+
+            if do_job:
+                output_object[job_name] = job_object
+                job_count += 1
+
+        stage += 1
+
+    tty.msg('{0} build jobs generated in {1} stages'.format(
+        job_count, len(stages)))
+
+    final_stage = 'stage-rebuild-index'
+
+    final_job = {
+        'stage': final_stage,
+        'variables': {
+            'MIRROR_URL': mirror_url,
+        },
+        'image': build_image,
+        'script': './bin/rebuild-index.sh',
+    }
+
+    if args.shared_runner_tag:
+        final_job['tags'] = [args.shared_runner_tag]
+
+    output_object['rebuild-index'] = final_job
+    stage_names.append(final_stage)
+    output_object['stages'] = stage_names
+
+    with open(args.output_file, 'w') as outf:
+        outf.write(syaml.dump(output_object))

--- a/lib/spack/spack/cmd/upload_s3.py
+++ b/lib/spack/spack/cmd/upload_s3.py
@@ -1,0 +1,212 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# TODO: This will be merged into the buildcache command once
+# everything is working.
+
+import os
+import re
+import sys
+
+try:
+    import boto3
+    import botocore
+    have_boto3_support = True
+except ImportError:
+    have_boto3_support = False
+
+import llnl.util.tty as tty
+
+from spack.error import SpackError
+import spack.tengine as template_engine
+from spack.spec import Spec
+
+
+import spack.binary_distribution as bindist
+
+
+description = "temporary command to upload buildcaches to 's3.spack.io'"
+section = "packaging"
+level = "long"
+
+
+def setup_parser(subparser):
+    setup_parser.parser = subparser
+    subparsers = subparser.add_subparsers(help='upload-s3 sub-commands')
+
+    # sub-command to upload a built spec to s3
+    spec = subparsers.add_parser('spec', help=upload_spec.__doc__)
+
+    spec.add_argument('-s', '--spec', default=None,
+                      help='Spec to upload')
+
+    spec.add_argument('-y', '--spec-yaml', default=None,
+                      help='Path to spec yaml file containing spec to upload')
+
+    spec.add_argument('-b', '--base-dir', default=None,
+                      help='Path to root of buildcaches')
+
+    spec.add_argument('-e', '--endpoint-url',
+                      default='https://s3.spack.io', help='URL of mirror')
+
+    spec.set_defaults(func=upload_spec)
+
+    # sub-command to update the index of a buildcache on s3
+    index = subparsers.add_parser('index', help=update_index.__doc__)
+
+    index.add_argument('-e', '--endpoint-url',
+        default='https://s3.spack.io', help='URL of mirror')
+
+    index.set_defaults(func=update_index)
+
+
+def get_s3_session(endpoint_url):
+    if not have_boto3_support:
+        raise SpackError('boto3 module not available')
+
+    session = boto3.Session()
+    s3 = session.resource('s3')
+
+    bucket_names = []
+    for bucket in s3.buckets.all():
+        bucket_names.append(bucket.name)
+
+    if len(bucket_names) > 1:
+        raise SpackError('More than one bucket associated with credentials')
+
+    bucket_name = bucket_names[0]
+
+    return s3, bucket_name
+
+
+def update_index(args):
+    """Update the index of an s3 buildcache"""
+    s3, bucket_name = get_s3_session(args.endpoint_url)
+
+    bucket = s3.Bucket(bucket_name)
+    exists = True
+
+    try:
+        s3.meta.client.head_bucket(Bucket=bucket_name)
+    except botocore.exceptions.ClientError as e:
+        # If a client error is thrown, then check that it was a 404 error.
+        # If it was a 404 error, then the bucket does not exist.
+        error_code = e.response['Error']['Code']
+        if error_code == '404':
+            exists = False
+
+    if not exists:
+        tty.error('S3 bucket "{0}" does not exist'.format(bucket_name))
+        sys.exit(1)
+
+    build_cache_dir = os.path.join(
+        'mirror', bindist.build_cache_relative_path())
+
+    spec_yaml_regex = re.compile('{0}/(.+\\.spec\\.yaml)$'.format(
+        build_cache_dir))
+    spack_regex = re.compile('{0}/([^/]+)/.+\\.spack$'.format(
+        build_cache_dir))
+
+    top_level_keys = set()
+
+    for key in bucket.objects.all():
+        m = spec_yaml_regex.search(key.key)
+        if m:
+            top_level_keys.add(m.group(1))
+            print(m.group(1))
+            continue
+
+        m = spack_regex.search(key.key)
+        if m:
+            top_level_keys.add(m.group(1))
+            print(m.group(1))
+            continue
+
+    index_data = {
+        'top_level_keys': top_level_keys,
+    }
+
+    env = template_engine.make_environment()
+    template_dir = 'misc'
+    index_template = os.path.join(template_dir, 'buildcache_index.html')
+    t = env.get_template(index_template)
+    contents = t.render(index_data)
+
+    index_key = os.path.join(build_cache_dir, 'index.html')
+
+    tty.debug('Generated index:')
+    tty.debug(contents)
+    tty.debug('Pushing it to {0} -> {1}'.format(bucket_name, index_key))
+
+    s3_obj = s3.Object(bucket_name, index_key)
+    s3_obj.put(Body=contents, ACL='public-read')
+
+
+def upload_spec(args):
+    """Upload a spec to s3 bucket"""
+    if not args.spec and not args.spec_yaml:
+        tty.error('Cannot upload spec without spec arg or path to spec yaml')
+        sys.exit(1)
+
+    if not args.base_dir:
+        tty.error('No base directory for buildcache specified')
+        sys.exit(1)
+
+    if args.spec:
+        try:
+            spec = Spec(args.spec)
+            spec.concretize()
+        except Exception:
+            tty.error('Unable to concrectize spec from string {0}'.format(
+                args.spec))
+            sys.exit(1)
+    else:
+        try:
+            with open(args.spec_yaml, 'r') as fd:
+                spec = Spec.from_yaml(fd.read())
+        except Exception:
+            tty.error('Unable to concrectize spec from yaml {0}'.format(
+                args.spec_yaml))
+            sys.exit(1)
+
+    s3, bucket_name = get_s3_session(args.endpoint_url)
+
+    build_cache_dir = bindist.build_cache_relative_path()
+
+    tarball_key = os.path.join(
+        build_cache_dir, bindist.tarball_path_name(spec, '.spack'))
+    tarball_path = os.path.join(args.base_dir, tarball_key)
+
+    specfile_key = os.path.join(
+        build_cache_dir, bindist.tarball_name(spec, '.spec.yaml'))
+    specfile_path = os.path.join(args.base_dir, specfile_key)
+
+    cdashidfile_key = os.path.join(
+        build_cache_dir, bindist.tarball_name(spec, '.cdashid'))
+    cdashidfile_path = os.path.join(args.base_dir, cdashidfile_key)
+
+    tty.msg('Uploading {0}'.format(tarball_key))
+    s3.meta.client.upload_file(
+        tarball_path, bucket_name,
+        os.path.join('mirror', tarball_key),
+        ExtraArgs={'ACL': 'public-read'})
+
+    tty.msg('Uploading {0}'.format(specfile_key))
+    s3.meta.client.upload_file(
+        specfile_path, bucket_name,
+        os.path.join('mirror', specfile_key),
+        ExtraArgs={'ACL': 'public-read'})
+
+    if os.path.exists(cdashidfile_path):
+        tty.msg('Uploading {0}'.format(cdashidfile_key))
+        s3.meta.client.upload_file(
+            cdashidfile_path, bucket_name,
+            os.path.join('mirror', cdashidfile_key),
+            ExtraArgs={'ACL': 'public-read'})
+
+
+def upload_s3(parser, args):
+    if args.func:
+        args.func(args)

--- a/lib/spack/spack/schema/os_container_mapping.py
+++ b/lib/spack/spack/schema/os_container_mapping.py
@@ -1,0 +1,50 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""Schema for os-container-mapping.yaml configuration file.
+
+.. literalinclude:: ../spack/schema/os_container_mapping.py
+   :lines: 32-
+"""
+
+
+schema = {
+    '$schema': 'http://json-schema.org/schema#',
+    'title': 'Spack release builds os/container mapping config file schema',
+    'type': 'object',
+    'additionalProperties': False,
+    'patternProperties': {
+        r'containers': {
+            'type': 'object',
+            'default': {},
+            'patternProperties': {
+                r'[\w\d\-_\.]+': {
+                    'type': 'object',
+                    'default': {},
+                    'additionalProperties': False,
+                    'required': ['image'],
+                    'properties': {
+                        'image': {'type': 'string'},
+                        'setup_script': {'type': 'string'},
+                        'compilers': {
+                            'type': 'array',
+                            'default': [],
+                            'items': {
+                                'type': 'object',
+                                'default': {},
+                                'additionalProperties': False,
+                                'required': ['name'],
+                                'properties': {
+                                    'name': {'type': 'string'},
+                                    'path': {'type': 'string'},
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
+}

--- a/lib/spack/spack/schema/spec_set.py
+++ b/lib/spack/spack/schema/spec_set.py
@@ -1,0 +1,110 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""Schema for Spack spec-set configuration file.
+
+.. literalinclude:: ../spack/schema/spec_set.py
+   :lines: 32-
+"""
+
+
+schema = {
+    '$schema': 'http://json-schema.org/schema#',
+    'title': 'Spack test configuration file schema',
+    'definitions': {
+        # used for include/exclude
+        'list_of_specs': {
+            'type': 'array',
+            'items': {'type': 'string'}
+        },
+        # used for compilers and for packages
+        'objects_with_version_list': {
+            'type': 'object',
+            'additionalProperties': False,
+            'patternProperties': {
+                r'\w[\w-]*': {
+                    'type': 'object',
+                    'additionalProperties': False,
+                    'required': ['versions'],
+                    'properties': {
+                        'versions': {
+                            'type': 'array',
+                            'items': {
+                                'oneOf': [
+                                    {'type': 'string'},
+                                    {'type': 'number'},
+                                ],
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        'packages': {
+            'type': 'object',
+            'additionalProperties': False,
+            'properties': {
+                'packages': {
+                    '$ref': '#/definitions/objects_with_version_list'
+                },
+            }
+        },
+        'compilers': {
+            'type': 'object',
+            'additionalProperties': False,
+            'properties': {
+                'compilers': {
+                    '$ref': '#/definitions/objects_with_version_list'
+                },
+            }
+        },
+        'specs': {
+            'type': 'object',
+            'additionalProperties': False,
+            'properties': {
+                'specs': {'$ref': '#/definitions/list_of_specs'},
+            }
+        },
+    },
+    # this is the actual top level object
+    'type': 'object',
+    'additionalProperties': False,
+    'properties': {
+        'spec-set': {
+            'type': 'object',
+            'additionalProperties': False,
+            'required': ['matrix'],
+            'properties': {
+                # top-level settings are keys and need to be unique
+                'include': {'$ref': '#/definitions/list_of_specs'},
+                'exclude': {'$ref': '#/definitions/list_of_specs'},
+                'cdash': {
+                    'oneOf': [
+                        {'type': 'string'},
+                        {'type': 'array',
+                         'items': {'type': 'string'}
+                        },
+                    ],
+                },
+                'project': {
+                    'type': 'string',
+                },
+                # things under matrix (packages, compilers, etc.)  are a
+                # list so that we can potentiall have multiple of them.
+                'matrix': {
+                    'type': 'array',
+                    'items': {
+                        'type': 'object',
+                        'oneOf': [
+                            {'$ref': '#/definitions/specs'},
+                            {'$ref': '#/definitions/packages'},
+                            {'$ref': '#/definitions/compilers'},
+                        ],
+                    },
+                },
+            },
+        },
+    },
+}

--- a/lib/spack/spack/schema/specs_deps.py
+++ b/lib/spack/spack/schema/specs_deps.py
@@ -1,0 +1,48 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""Schema for expressing dependencies of a set of specs in a JSON file
+
+.. literalinclude:: ../spack/schema/specs_deps.py
+   :lines: 32-
+"""
+
+
+schema = {
+    '$schema': 'http://json-schema.org/schema#',
+    'title': 'Spack schema for the dependencies of a set of specs',
+    'type': 'object',
+    'additionalProperties': False,
+    'required': ['specs'],
+    'properties': {
+        r'dependencies': {
+            'type': 'array',
+            'default': [],
+            'items': {
+                'type': 'object',
+                'additionalProperties': False,
+                'required': ['depends', 'spec'],
+                'properties': {
+                    r'depends': {'type': 'string'},
+                    r'spec': {'type': 'string'},
+                },
+            },
+        },
+        r'specs': {
+            'type': 'array',
+            'default': [],
+            'items': {
+                'type': 'object',
+                'additionalProperties': False,
+                'required': ['root_spec', 'spec', 'label'],
+                'properties': {
+                    r'root_spec': {'type': 'string'},
+                    r'spec': {'type': 'string'},
+                    r'label': {'type': 'string'},
+                }
+            },
+        },
+    },
+}

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3695,6 +3695,33 @@ def parse_anonymous_spec(spec_like, pkg_name):
     return anon_spec
 
 
+def save_dependency_spec_yamls(
+        root_spec_as_yaml, output_directory, dependencies=None):
+    """Given a root spec (represented as a yaml object), index it with a subset
+       of its dependencies, and write each dependency to a separate yaml file
+       in the output directory.  By default, all dependencies will be written
+       out.  To choose a smaller subset of dependencies to be written, pass a
+       list of package names in the dependencies parameter.  In case of any
+       kind of error, SaveSpecDependenciesError is raised with a specific
+       message about what went wrong."""
+    root_spec = Spec.from_yaml(root_spec_as_yaml)
+
+    dep_list = dependencies
+    if not dep_list:
+        dep_list = [dep.name for dep in root_spec.traverse()]
+
+    for dep_name in dep_list:
+        if dep_name not in root_spec:
+            msg = 'Dependency {0} does not exist in root spec {1}'.format(
+                dep_name, root_spec.name)
+            raise SpecDependencyNotFoundError(msg)
+        dep_spec = root_spec[dep_name]
+        yaml_path = os.path.join(output_directory, '{0}.yaml'.format(dep_name))
+
+        with open(yaml_path, 'w') as fd:
+            fd.write(dep_spec.to_yaml(all_deps=True))
+
+
 def base32_prefix_bits(hash_string, bits):
     """Return the first <bits> bits of a base32 string as an integer."""
     if bits > len(hash_string) * 5:
@@ -3880,3 +3907,8 @@ class ConflictsInSpecError(SpecError, RuntimeError):
                 long_message += match_fmt_custom.format(idx + 1, c, w, msg)
 
         super(ConflictsInSpecError, self).__init__(message, long_message)
+
+
+class SpecDependencyNotFoundError(SpecError):
+    """Raised when a failure is encountered writing the dependencies of
+    a spec."""

--- a/lib/spack/spack/spec_set.py
+++ b/lib/spack/spack/spec_set.py
@@ -1,0 +1,188 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import itertools
+from jsonschema import validate
+
+import llnl.util.tty as tty
+from llnl.util.tty.colify import colify
+
+import spack
+import spack.compilers
+import spack.architecture as sarch
+import spack.schema.spec_set as spec_set_schema
+import spack.util.spack_yaml as syaml
+
+from spack.error import SpackError
+from spack.spec import Spec, ArchSpec
+
+
+class CombinatorialSpecSet:
+    """Set of combinatorial Specs constructed from YAML file."""
+
+    def __init__(self, yaml_like, ignore_invalid=True):
+        """Construct a combinatorial Spec set.
+
+        Args:
+            yaml_like: either raw YAML data as a dict, a file-like object
+                to read the YAML from, or a string containing YAML.  In the
+                first case, we assume already-parsed YAML data.  In the second
+                two cases, we just run yaml.load() on the data.
+            ignore_invalid (bool): whether to ignore invalid specs when
+                expanding the values of this spec set.
+        """
+        self.ignore_invalid = ignore_invalid
+
+        if isinstance(yaml_like, dict):
+            # if it's raw data, just assign it to self.data
+            self.data = yaml_like
+        else:
+            # otherwise try to load it.
+            self.data = syaml.load(yaml_like)
+
+        # validate against the spec set schema
+        validate(self.data, spec_set_schema.schema)
+
+        # chop off the initial spec-set label after valiation.
+        self.data = self.data['spec-set']
+
+        # initialize these from data.
+        self.cdash = self.data.get('cdash', None)
+        if isinstance(self.cdash, str):
+            self.cdash = [self.cdash]
+        self.project = self.data.get('project', None)
+
+        # _spec_lists is a list of lists of specs, to be combined as a
+        # cartesian product when we iterate over all specs in the set.
+        # it's initialized lazily.
+        self._spec_lists = None
+        self._include = []
+        self._exclude = []
+
+    @staticmethod
+    def from_file(path):
+        try:
+            with open(path, 'r') as fin:
+                specs_yaml = syaml.load(fin.read())
+
+                # For now, turn off ignoring invalid specs, as it prevents
+                # iteration if the specified compilers can't be found.
+                return CombinatorialSpecSet(specs_yaml, ignore_invalid=False)
+        except Exception as e:
+            emsg = e.message
+            if not emsg:
+                emsg = e.problem
+            msg = ('Unable to create CombinatorialSpecSet from file ({0})'
+                   ' due to {1}'.format(path, emsg))
+            raise SpackError(msg)
+
+    def all_package_versions(self):
+        """Get package/version combinations for all spack packages."""
+        for name in spack.repo.all_package_names():
+            pkg = spack.repo.get(name)
+            for v in pkg.versions:
+                yield Spec('{0}@{1}'.format(name, v))
+
+    def _specs(self, data):
+        """Read a list of specs from YAML data"""
+        return [Spec(s) for s in data]
+
+    def _compiler_specs(self, data):
+        """Read compiler specs from YAML data.
+        Example YAML:
+            gcc:
+                versions: [4.4.8, 4.9.3]
+            clang:
+                versions: [3.6.1, 3.7.2, 3.8]
+
+        Optionally, data can be 'all', in which case all compilers for
+        the current platform are returned.
+        """
+        # get usable compilers for current platform.
+        arch = ArchSpec(str(sarch.platform()), 'default_os', 'default_target')
+        available_compilers = [
+            c.spec for c in spack.compilers.compilers_for_arch(arch)]
+
+        # return compilers for this platform if asked for everything.
+        if data == 'all':
+            return [cspec.copy() for cspec in available_compilers]
+
+        # otherwise create specs from the YAML file.
+        cspecs = set([
+            Spec('%{0}@{1}'.format(compiler, version))
+            for compiler in data for version in data[compiler]['versions']])
+
+        # filter out invalid specs if caller said to ignore them.
+        if self.ignore_invalid:
+            missing = [c for c in cspecs if not any(
+                c.compiler.satisfies(comp) for comp in available_compilers)]
+            tty.warn("The following compilers were unavailable:")
+            colify(sorted(m.compiler for m in missing))
+            cspecs -= set(missing)
+
+        return cspecs
+
+    def _package_specs(self, data):
+        """Read package/version specs from YAML data.
+        Example YAML:
+            gmake:
+                versions: [4.0, 4.1, 4.2]
+            qt:
+                versions: [4.8.6, 5.2.1, 5.7.1]
+
+        Optionally, data can be 'all', in which case all packages and
+        versions from the package repository are returned.
+        """
+        if data == 'all':
+            return set(self.all_package_versions())
+
+        return set([
+            Spec('{0}@{1}'.format(name, version))
+            for name in data for version in data[name]['versions']])
+
+    def _get_specs(self, matrix_dict):
+        """Parse specs out of an element in the build matrix."""
+        readers = {
+            'packages': self._package_specs,
+            'compilers': self._compiler_specs,
+            'specs': self._specs
+        }
+
+        key = next(iter(matrix_dict), None)
+        assert key in readers
+        return readers[key](matrix_dict[key])
+
+    def __iter__(self):
+        # read in data from YAML file lazily.
+        if self._spec_lists is None:
+            self._spec_lists = [self._get_specs(spec_list)
+                                for spec_list in self.data['matrix']]
+
+            if 'include' in self.data:
+                self._include = [Spec(s) for s in self.data['include']]
+            if 'exclude' in self.data:
+                self._exclude = [Spec(s) for s in self.data['exclude']]
+
+        for spec_list in itertools.product(*self._spec_lists):
+            # if there is an empty array in spec_lists, we'll get this.
+            if not spec_list:
+                yield spec_list
+                continue
+
+            # merge all the constraints in spec_list with each other
+            spec = spec_list[0].copy()
+            for s in spec_list[1:]:
+                spec.constrain(s)
+
+            # test each spec for include/exclude
+            if (self._include and
+                not any(spec.satisfies(s) for s in self._include)):
+                continue
+
+            if any(spec.satisfies(s) for s in self._exclude):
+                continue
+
+            # we now know we can include this spec in the set
+            yield spec

--- a/lib/spack/spack/test/cmd/release_jobs.py
+++ b/lib/spack/spack/test/cmd/release_jobs.py
@@ -1,0 +1,118 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import json
+
+from jsonschema import validate
+
+from spack import repo
+from spack.architecture import sys_type
+from spack.cmd.release_jobs import stage_spec_jobs, spec_deps_key_label
+from spack.main import SpackCommand
+from spack.schema.specs_deps import schema as specs_deps_schema
+from spack.spec import Spec
+from spack.test.conftest import MockPackage, MockPackageMultiRepo
+
+
+release_jobs = SpackCommand('release-jobs')
+
+
+def test_specs_deps(tmpdir, config):
+    """If we ask for the specs dependencies to be written to disk, then make
+    sure we get a file of the correct format."""
+
+    output_path = str(tmpdir.mkdir('json').join('spec_deps.json'))
+    release_jobs('--specs-deps-output', output_path, 'readline')
+
+    deps_object = None
+
+    with open(output_path, 'r') as fd:
+        deps_object = json.loads(fd.read())
+
+    assert (deps_object is not None)
+
+    validate(deps_object, specs_deps_schema)
+
+
+def test_specs_staging(config):
+    """Make sure we achieve the best possible staging for the following
+spec DAG::
+
+        a
+       /|
+      c b
+        |\
+        e d
+          |\
+          f g
+
+In this case, we would expect 'c', 'e', 'f', and 'g' to be in the first stage,
+and then 'd', 'b', and 'a' to be put in the next three stages, respectively.
+
+"""
+    current_system = sys_type()
+
+    config_compilers = config.get_config('compilers')
+    first_compiler = config_compilers[0]
+    compiler_spec = first_compiler['compiler']['spec']
+
+    # Whatever that first compiler in the configuration was, let's make sure
+    # we mock up an entry like we'd find in os-container-mapping.yaml which
+    # has that compiler.
+    mock_containers = {}
+    mock_containers[current_system] = {
+        "image": "dontcare",
+        "compilers": [
+            {
+                "name": compiler_spec,
+            }
+        ],
+    }
+
+    default = ('build', 'link')
+
+    g = MockPackage('g', [], [])
+    f = MockPackage('f', [], [])
+    e = MockPackage('e', [], [])
+    d = MockPackage('d', [f, g], [default, default])
+    c = MockPackage('c', [], [])
+    b = MockPackage('b', [d, e], [default, default])
+    a = MockPackage('a', [b, c], [default, default])
+
+    mock_repo = MockPackageMultiRepo([a, b, c, d, e, f, g])
+
+    with repo.swap(mock_repo):
+        # Now we'll ask for the root package to be compiled with whatever that
+        # first compiler in the configuration was.
+        spec_a = Spec('a%{0}'.format(compiler_spec))
+        spec_a.concretize()
+
+        spec_a_label = spec_deps_key_label(spec_a)[1]
+        spec_b_label = spec_deps_key_label(spec_a['b'])[1]
+        spec_c_label = spec_deps_key_label(spec_a['c'])[1]
+        spec_d_label = spec_deps_key_label(spec_a['d'])[1]
+        spec_e_label = spec_deps_key_label(spec_a['e'])[1]
+        spec_f_label = spec_deps_key_label(spec_a['f'])[1]
+        spec_g_label = spec_deps_key_label(spec_a['g'])[1]
+
+        spec_labels, dependencies, stages = stage_spec_jobs(
+            [spec_a], mock_containers, current_system)
+
+        assert (len(stages) == 4)
+
+        assert (len(stages[0]) == 4)
+        assert (spec_c_label in stages[0])
+        assert (spec_e_label in stages[0])
+        assert (spec_f_label in stages[0])
+        assert (spec_g_label in stages[0])
+
+        assert (len(stages[1]) == 1)
+        assert (spec_d_label in stages[1])
+
+        assert (len(stages[2]) == 1)
+        assert (spec_b_label in stages[2])
+
+        assert (len(stages[3]) == 1)
+        assert (spec_a_label in stages[3])

--- a/lib/spack/spack/test/spec_set.py
+++ b/lib/spack/spack/test/spec_set.py
@@ -1,0 +1,299 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import pytest
+
+from spack.spec import Spec
+from jsonschema import ValidationError
+from spack.spec_set import CombinatorialSpecSet
+
+
+pytestmark = pytest.mark.usefixtures('config')
+
+
+basic_yaml_file = {
+    'spec-set': {
+        'cdash': 'http://example.com/cdash',
+        'project': 'testproj',
+        'include': ['gmake'],
+        'matrix': [
+            {'packages': {
+                'gmake': {
+                    'versions': ['4.0']
+                }
+            }},
+            {'compilers': {
+                'gcc': {
+                    'versions': ['4.2.1', '6.3.0']
+                }, 'clang': {
+                    'versions': ['8.0', '3.8']
+                }
+            }},
+        ]
+    }
+}
+
+
+def test_spec_set_basic():
+    """The "include" isn't required, but if it is present, we should only
+    see specs mentioned there.  Also, if we include cdash and project
+    properties, those should be captured and stored on the resulting
+    CombinatorialSpecSet as attributes."""
+    spec_set = CombinatorialSpecSet(basic_yaml_file, False)
+    specs = list(spec for spec in spec_set)
+    assert len(specs) == 4
+    assert spec_set.cdash == ['http://example.com/cdash']
+    assert spec_set.project == 'testproj'
+
+
+def test_spec_set_no_include():
+    """Make sure that without any exclude or include, we get the full cross-
+    product of specs/versions."""
+    yaml_file = {
+        'spec-set': {
+            'matrix': [
+                {'packages': {
+                    'gmake': {
+                        'versions': ['4.0']
+                    }
+                }},
+                {'compilers': {
+                    'gcc': {
+                        'versions': ['4.2.1', '6.3.0']
+                    }, 'clang': {
+                        'versions': ['8.0', '3.8']
+                    }
+                }},
+            ]
+        }
+    }
+    spec_set = CombinatorialSpecSet(yaml_file, False)
+    specs = list(spec for spec in spec_set)
+    assert len(specs) == 4
+
+
+def test_spec_set_include_exclude_conflict():
+    """Exclude should override include"""
+    yaml_file = {
+        'spec-set': {
+            'include': ['gmake'],
+            'exclude': ['gmake'],
+            'matrix': [
+                {'packages': {
+                    'gmake': {
+                        'versions': ['4.0']
+                    }
+                }},
+                {'compilers': {
+                    'gcc': {
+                        'versions': ['4.2.1', '6.3.0']
+                    }, 'clang': {
+                        'versions': ['8.0', '3.8']
+                    }
+                }},
+            ]
+        }
+    }
+    spec_set = CombinatorialSpecSet(yaml_file, False)
+    specs = list(spec for spec in spec_set)
+    assert len(specs) == 0
+
+
+def test_spec_set_exclude():
+    """The exclude property isn't required, but if it appears, any specs
+    mentioned there should not appear in the output specs"""
+    yaml_file = {
+        'spec-set': {
+            'exclude': ['gmake'],
+            'matrix': [
+                {'packages': {
+                    'gmake': {
+                        'versions': ['4.0']
+                    },
+                    'appres': {
+                        'versions': ['1.0.4']
+                    },
+                    'allinea-reports': {
+                        'versions': ['6.0.4']
+                    }
+                }},
+                {'compilers': {
+                    'gcc': {
+                        'versions': ['4.2.1', '6.3.0']
+                    }, 'clang': {
+                        'versions': ['8.0', '3.8']
+                    }
+                }},
+            ]
+        }
+    }
+    spec_set = CombinatorialSpecSet(yaml_file, False)
+    specs = list(spec for spec in spec_set)
+    assert len(specs) == 8
+
+
+def test_spec_set_include_limited_packages():
+    """If we see the include key, it is a filter and only the specs mentioned
+    there should actually be included."""
+    yaml_file = {
+        'spec-set': {
+            'include': ['gmake'],
+            'matrix': [
+                {'packages': {
+                    'gmake': {
+                        'versions': ['4.0']
+                    },
+                    'appres': {
+                        'versions': ['1.0.4']
+                    },
+                    'allinea-reports': {
+                        'versions': ['6.0.4']
+                    }
+                }},
+                {'compilers': {
+                    'gcc': {
+                        'versions': ['4.2.1', '6.3.0']
+                    }, 'clang': {
+                        'versions': ['8.0', '3.8']
+                    }
+                }},
+            ]
+        }
+    }
+    spec_set = CombinatorialSpecSet(yaml_file, False)
+    specs = list(spec for spec in spec_set)
+    assert len(specs) == 4
+
+
+def test_spec_set_simple_spec_list():
+    """Make sure we can handle the slightly more concise syntax where we
+    include the package name/version together and skip the extra keys in
+    the dictionary."""
+    yaml_file = {
+        'spec-set': {
+            'matrix': [
+                {'specs': [
+                    'gmake@4.0',
+                    'appres@1.0.4',
+                    'allinea-reports@6.0.4'
+                ]},
+            ]
+        }
+    }
+    spec_set = CombinatorialSpecSet(yaml_file, False)
+    specs = list(spec for spec in spec_set)
+    assert len(specs) == 3
+
+
+def test_spec_set_with_specs():
+    """Make sure we only see the specs mentioned in the include"""
+    yaml_file = {
+        'spec-set': {
+            'include': ['gmake', 'appres'],
+            'matrix': [
+                {'specs': [
+                    'gmake@4.0',
+                    'appres@1.0.4',
+                    'allinea-reports@6.0.4'
+                ]},
+                {'compilers': {
+                    'gcc': {
+                        'versions': ['4.2.1', '6.3.0']
+                    }, 'clang': {
+                        'versions': ['8.0', '3.8']
+                    }
+                }},
+            ]
+        }
+    }
+    spec_set = CombinatorialSpecSet(yaml_file, False)
+    specs = list(spec for spec in spec_set)
+    assert len(specs) == 8
+
+
+def test_spec_set_packages_no_matrix():
+    """The matrix property is required, make sure we error out if it is
+    missing"""
+    yaml_file = {
+        'spec-set': {
+            'include': ['gmake'],
+            'packages': {
+                'gmake': {
+                    'versions': ['4.0']
+                },
+                'appres': {
+                    'versions': ['1.0.4']
+                },
+                'allinea-reports': {
+                    'versions': ['6.0.4']
+                }
+            },
+        }
+    }
+    with pytest.raises(ValidationError):
+        CombinatorialSpecSet(yaml_file)
+
+
+def test_spec_set_get_cdash_array():
+    """Make sure we can handle multiple cdash sites in a list"""
+    yaml_file = {
+        'spec-set': {
+            'cdash': ['http://example.com/cdash', 'http://example.com/cdash2'],
+            'project': 'testproj',
+            'matrix': [
+                {'packages': {
+                    'gmake': {'versions': ['4.0']},
+                }},
+                {'compilers': {
+                    'gcc': {'versions': ['4.2.1', '6.3.0']},
+                    'clang': {'versions': ['8.0', '3.8']},
+                }},
+            ]
+        }
+    }
+
+    spec_set = CombinatorialSpecSet(yaml_file)
+    assert spec_set.cdash == [
+        'http://example.com/cdash', 'http://example.com/cdash2']
+    assert spec_set.project == 'testproj'
+
+
+def test_compiler_specs():
+    spec_set = CombinatorialSpecSet(basic_yaml_file, False)
+    compilers = spec_set._compiler_specs({
+        'gcc': {
+            'versions': ['4.2.1', '6.3.0']
+        }, 'clang': {
+            'versions': ['8.0', '3.8']
+        }})
+
+    assert len(list(compilers)) == 4
+    assert Spec('%gcc@4.2.1') in compilers
+    assert Spec('%gcc@6.3.0') in compilers
+    assert Spec('%clang@8.0') in compilers
+    assert Spec('%clang@3.8') in compilers
+
+
+def test_package_specs():
+    spec_set = CombinatorialSpecSet(basic_yaml_file, False)
+
+    packages = spec_set._package_specs({
+        'gmake': {
+            'versions': ['4.0', '5.0']
+        },
+        'appres': {
+            'versions': ['1.0.4']
+        },
+        'allinea-reports': {
+            'versions': ['6.0.1', '6.0.3', '6.0.4']
+        }
+    })
+
+    assert Spec('gmake@4.0') in packages
+    assert Spec('gmake@5.0') in packages
+    assert Spec('appres@1.0.4') in packages
+    assert Spec('allinea-reports@6.0.1') in packages
+    assert Spec('allinea-reports@6.0.3') in packages
+    assert Spec('allinea-reports@6.0.4') in packages

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -8,12 +8,16 @@
 YAML format preserves DAG information in the spec.
 
 """
+import os
+
 from collections import Iterable, Mapping
 
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
-from spack.spec import Spec
+from spack import repo
+from spack.spec import Spec, save_dependency_spec_yamls
 from spack.util.spack_yaml import syaml_dict
+from spack.test.conftest import MockPackage, MockPackageMultiRepo
 
 
 def check_yaml_round_trip(spec):
@@ -198,3 +202,38 @@ def reverse_all_dicts(data):
         return type(data)(reverse_all_dicts(elt) for elt in data)
     else:
         return data
+
+
+def check_specs_equal(original_spec, spec_yaml_path):
+    with open(spec_yaml_path, 'r') as fd:
+        spec_yaml = fd.read()
+        spec_from_yaml = Spec.from_yaml(spec_yaml)
+        return original_spec.eq_dag(spec_from_yaml)
+
+
+def test_save_dependency_spec_yamls_subset(tmpdir, config):
+    output_path = str(tmpdir.mkdir('spec_yamls'))
+
+    default = ('build', 'link')
+
+    g = MockPackage('g', [], [])
+    f = MockPackage('f', [], [])
+    e = MockPackage('e', [], [])
+    d = MockPackage('d', [f, g], [default, default])
+    c = MockPackage('c', [], [])
+    b = MockPackage('b', [d, e], [default, default])
+    a = MockPackage('a', [b, c], [default, default])
+
+    mock_repo = MockPackageMultiRepo([a, b, c, d, e, f, g])
+
+    with repo.swap(mock_repo):
+        spec_a = Spec('a')
+        spec_a.concretize()
+        b_spec = spec_a['b']
+        c_spec = spec_a['c']
+        spec_a_yaml = spec_a.to_yaml(all_deps=True)
+
+        save_dependency_spec_yamls(spec_a_yaml, output_path, ['b', 'c'])
+
+        assert check_specs_equal(b_spec, os.path.join(output_path, 'b.yaml'))
+        assert check_specs_equal(c_spec, os.path.join(output_path, 'c.yaml'))

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -86,6 +86,58 @@ else:
             super(NonDaemonPool, self).__init__(*args, **kwargs)
 
 
+def _read_from_url(url, accept_content_type=None):
+    context = None
+    verify_ssl = spack.config.get('config:verify_ssl')
+    pyver = sys.version_info
+    if (pyver < (2, 7, 9) or (3,) < pyver < (3, 4, 3)):
+        if verify_ssl:
+            tty.warn("Spack will not check SSL certificates. You need to "
+                     "update your Python to enable certificate "
+                     "verification.")
+    elif verify_ssl:
+        # without a defined context, urlopen will not verify the ssl cert for
+        # python 3.x
+        context = ssl.create_default_context()
+    else:
+        context = ssl._create_unverified_context()
+
+    req = Request(url)
+
+    if accept_content_type:
+        # Make a HEAD request first to check the content type.  This lets
+        # us ignore tarballs and gigantic files.
+        # It would be nice to do this with the HTTP Accept header to avoid
+        # one round-trip.  However, most servers seem to ignore the header
+        # if you ask for a tarball with Accept: text/html.
+        req.get_method = lambda: "HEAD"
+        resp = _urlopen(req, timeout=_timeout, context=context)
+
+        if "Content-type" not in resp.headers:
+            tty.debug("ignoring page " + url)
+            return None, None
+
+        if not resp.headers["Content-type"].startswith(accept_content_type):
+            tty.debug("ignoring page " + url + " with content type " +
+                      resp.headers["Content-type"])
+            return None, None
+
+    # Do the real GET request when we know it's just HTML.
+    req.get_method = lambda: "GET"
+    response = _urlopen(req, timeout=_timeout, context=context)
+    response_url = response.geturl()
+
+    # Read the page and and stick it in the map we'll return
+    page = response.read().decode('utf-8')
+
+    return response_url, page
+
+
+def read_from_url(url, accept_content_type=None):
+    resp_url, contents = _read_from_url(url, accept_content_type)
+    return contents
+
+
 def _spider(url, visited, root, depth, max_depth, raise_on_error):
     """Fetches URL and any pages it links to up to max_depth.
 
@@ -107,46 +159,11 @@ def _spider(url, visited, root, depth, max_depth, raise_on_error):
         root = re.sub('/index.html$', '', root)
 
     try:
-        context = None
-        verify_ssl = spack.config.get('config:verify_ssl')
-        pyver = sys.version_info
-        if (pyver < (2, 7, 9) or (3,) < pyver < (3, 4, 3)):
-            if verify_ssl:
-                tty.warn("Spack will not check SSL certificates. You need to "
-                         "update your Python to enable certificate "
-                         "verification.")
-        elif verify_ssl:
-            # We explicitly create default context to avoid error described in
-            # https://blog.sucuri.net/2016/03/beware-unverified-tls-certificates-php-python.html
-            context = ssl.create_default_context()
-        else:
-            context = ssl._create_unverified_context()
+        response_url, page = _read_from_url(url, 'text/html')
 
-        # Make a HEAD request first to check the content type.  This lets
-        # us ignore tarballs and gigantic files.
-        # It would be nice to do this with the HTTP Accept header to avoid
-        # one round-trip.  However, most servers seem to ignore the header
-        # if you ask for a tarball with Accept: text/html.
-        req = Request(url)
-        req.get_method = lambda: "HEAD"
-        resp = _urlopen(req, timeout=_timeout, context=context)
-
-        if "Content-type" not in resp.headers:
-            tty.debug("ignoring page " + url)
+        if not response_url or not page:
             return pages, links
 
-        if not resp.headers["Content-type"].startswith('text/html'):
-            tty.debug("ignoring page " + url + " with content type " +
-                      resp.headers["Content-type"])
-            return pages, links
-
-        # Do the real GET request when we know it's just HTML.
-        req.get_method = lambda: "GET"
-        response = _urlopen(req, timeout=_timeout, context=context)
-        response_url = response.geturl()
-
-        # Read the page and and stick it in the map we'll return
-        page = response.read().decode('utf-8')
         pages[response_url] = page
 
         # Parse out the links in the page

--- a/share/spack/docker/os-container-mapping.yaml
+++ b/share/spack/docker/os-container-mapping.yaml
@@ -1,0 +1,11 @@
+containers:
+  linux-ubuntu18.04-x86_64:
+    image: scottwittenburg/spack_builder_ubuntu_18.04
+    compilers:
+      - name: gcc@5.5.0
+      - name: clang@6.0.0-1ubuntu2
+  linux-centos7-x86_64:
+    image: scottwittenburg/spack_builder_centos_7
+    compilers:
+      - name: gcc@5.5.0
+      - name: clang@6.0.0

--- a/share/spack/docker/spack_builder/Dockerfile-spack_builder_centos_7
+++ b/share/spack/docker/spack_builder/Dockerfile-spack_builder_centos_7
@@ -1,0 +1,61 @@
+
+#
+# To build this image:
+#
+# cd <path-to-spack-repo>/share/spack/docker/spack_builder
+# docker build -f Dockerfile-spack_builder_centos_7 -t spack_builder_centos_7 .
+#
+
+from spack/centos:7
+
+RUN yum update -y          && \
+    yum install -y            \
+        gmp-devel             \
+        libmpc-devel          \
+        mpfr-devel            \
+        vim                   \
+        which              && \
+    rm -rf /var/cache/yum && yum clean all
+
+# Download, build and install gcc 5.5.0
+RUN mkdir -p /home/spackuser/Download/gcc550/build-gcc550            && \
+    mkdir -p /opt/gcc/gcc-5.5.0                                      && \
+    cd /home/spackuser/Download/gcc550                               && \
+    curl -OL https://ftp.gnu.org/gnu/gcc/gcc-5.5.0/gcc-5.5.0.tar.xz  && \
+    tar -xvf gcc-5.5.0.tar.xz                                        && \
+    cd build-gcc550                                                  && \
+    ../gcc-5.5.0/configure                                              \
+        --enable-languages=c,c++,fortran                                \
+        --disable-multilib                                              \
+        --prefix=/opt/gcc/gcc-5.5.0                                  && \
+    make -j$(nproc)                                                  && \
+    make install                                                     && \
+    cd /home/spackuser                                               && \
+    rm -rf /home/spackuser/Download
+
+RUN export PATH=/spack/bin:$PATH              && \
+    spack compiler find /opt/gcc/gcc-5.5.0
+
+RUN sed -i 's/f77: null/f77: \/opt\/gcc\/gcc-5.5.0\/bin\/gfortran/g;s/fc: null/fc: \/opt\/gcc\/gcc-5.5.0\/bin\/gfortran/g' ~/.spack/linux/compilers.yaml
+
+RUN mkdir -p /home/spackuser/spackcommand
+
+COPY update_rpaths.py /home/spackuser/spackcommand/update_rpaths.py
+
+RUN spack python /home/spackuser/spackcommand/update_rpaths.py  \
+        --prefix /opt/gcc/gcc-5.5.0                             \
+        --rpaths /opt/gcc/gcc-5.5.0/lib64
+
+RUN export PATH=/spack/bin:$PATH              && \
+    spack install -y llvm@6.0.0%gcc@5.5.0     && \
+    spack clean -a
+
+RUN export PATH=/spack/bin:$PATH                                     && \
+    spack compiler find $(spack location -i llvm@6.0.0%gcc@5.5.0)
+
+RUN sed -i 's/f77: null/f77: \/opt\/gcc\/gcc-5.5.0\/bin\/gfortran/g;s/fc: null/fc: \/opt\/gcc\/gcc-5.5.0\/bin\/gfortran/g' ~/.spack/linux/compilers.yaml
+
+RUN spack python /home/spackuser/spackcommand/update_rpaths.py  \
+        --prefix /spack/opt/spack/linux-centos7-x86_64/gcc-5.5.0/llvm-6.0.0-awfpo7kn3k24weu655rrt2erihzd4gii                             \
+        --rpaths /spack/opt/spack/linux-centos7-x86_64/gcc-5.5.0/llvm-6.0.0-awfpo7kn3k24weu655rrt2erihzd4gii/lib
+

--- a/share/spack/docker/spack_builder/Dockerfile-spack_builder_ubuntu_18.04
+++ b/share/spack/docker/spack_builder/Dockerfile-spack_builder_ubuntu_18.04
@@ -1,0 +1,23 @@
+
+#
+# To build this image:
+#
+# cd <path-to-spack-repo>/share/spack/docker/spack_builder
+# docker build -f Dockerfile-spack_builder_ubuntu_18.04 -t spack_builder_ubuntu_18.04 .
+#
+
+from spack/ubuntu:bionic
+
+RUN apt-get -yqq update && apt-get -yqq install \
+        clang                                   \
+        g++-5                                   \
+        gcc-5                                   \
+        gfortran-5                              \
+        unzip                                   \
+        vim                                  && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN export PATH=/spack/bin:$PATH             && \
+    spack compiler find gcc clang
+
+RUN sed -i 's/f77: null/f77: \/usr\/bin\/gfortran/g;s/fc: null/fc: \/usr\/bin\/gfortran/g' ~/.spack/linux/compilers.yaml

--- a/share/spack/docker/spack_builder/update_rpaths.py
+++ b/share/spack/docker/spack_builder/update_rpaths.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import argparse
+from spack.config import config as spack_config
+
+
+def update_compiler(prefix, rpaths):
+    compilers_config = spack_config.get('compilers')
+
+    for compiler_entry in compilers_config:
+        if compiler_entry['compiler']['paths']['cc'].startswith(prefix):
+            print('found target compiler: {0}'.format(
+                compiler_entry['compiler']['spec']))
+            compiler_entry['compiler']['extra_rpaths'].append(rpaths)
+
+    spack_config.update_config('compilers', compilers_config)
+
+
+if __name__ == "__main__":
+    # Create argument parser
+    parser = argparse.ArgumentParser(
+        description="Add extra_rpaths to default system compilers.yaml")
+
+    parser.add_argument('-p', '--prefix', default=None,
+                        help="Install prefix of compiler to update")
+    parser.add_argument('-r', '--rpaths', default=None,
+                        help="Extra rpaths to add to target compiler")
+
+    args = parser.parse_args()
+
+    update_compiler(args.prefix, args.rpaths)

--- a/share/spack/templates/misc/buildcache_index.html
+++ b/share/spack/templates/misc/buildcache_index.html
@@ -1,0 +1,11 @@
+<html>
+  <head>
+  </head>
+  <body>
+    <ul>
+{% for bucket_key in top_level_keys %}
+      <li><a href="{{ bucket_key }}">{{ bucket_key }}</a></li>
+{% endfor %}
+    </ul>
+  </body>
+</html>


### PR DESCRIPTION
This topic implements several pieces needed to support a release workflow for Spack.  Some of the pieces included:

1. A new Spack command to create a description of packages for Gitlab-CI to build. It defines a gitlab-ci.yml file that would be placed in a repository, such that when Gitlab-CI detects a commit to the branch, it will build the packages mentioned in the description.  More details on this new command are provided further down in this PR description ("Details of `release-jobs` command).

2. A build job shell script to be run by Gitlab-CI.  The responsibility of this script is to be assigned a spec, determine if the package corresponding to that spec exists and is up-to-date on a configured binary mirror, and if it is not, build the package, create a buildcache for it, and push that buildcache to the binary mirror, communicating with a CDash instance along the way.

3. Other infrastructure and changes in support of the items above.

The command to generate this `.gitlab-ci.yml` file looks like this:

```
spack release-jobs --spec-set <path-to-release.yaml> --mirror-url "https://mirror.spack.io" --shared-runner-tag spack-k8s
```

A summary of the jobs/stages can be printed by the above command if you add the `--print-summary` command-line argument.

### One approach to managing the release workflow

To avoid churn in the Spack repository, we plan not to keep the full list of release jobs under source control in a full `.gitlab-ci.yml` file.  Rather, a separate microservice will be capable of generating the bulk of the contents of the `.gitlab-ci.yml` on demand, for a given commit or sha.  

Here is an example of the `.gitlab-ci.yml` that might be maintained within the Spack repository:

```yaml
include:
  - remote: 'https://internal.spack.io/glciy/${CI_COMMIT_SHA}.yaml'
```

Whenever the pipeline is configured to run, the file above would trigger the microservice to checkout the given sha, run the `spack release-jobs ...` command on the release spec set, and return the full list of staged jobs to be run.

### Details of `release-jobs` command

The `release-jobs` command makes use of two new configuration files defined in the repository, `etc/spack/defaults/release.yaml` (or an arbitrary yaml file following the same schema) and 'share/spack/docker/os-container-mapping.yaml'.  First the `release.yaml` file is used to construct a `CombinatorialSpecSet`, which expands the contents into a list of the entire cross-product of packages/versions/compilers expressed in that file.  Next, the `os-container-mapping.yaml` file is used to find docker containers with compilers that "satisfy" the specs in the expanded cross-product.  The `os-container-mapping.yaml` file is essentially a list of operating systems which each provide an `image` (the image should exist on DockerHub so it can be pulled by both the `release-jobs` command and the AWS gitlab runners), and a list of available compilers on that image.  For any compiler found in one of the containers that satisfies the compiler requirement of a release spec, that spec (with the OS from `os-container-mapping.yaml` added to it) is added to a list that will be concretized in the appropriate docker container in order to gather all the specific dependencies of the spec.  Then all the resulting specs are combined and staged.

For example, given the following `release.yaml`:

```
spec-set:
    include: []
    exclude: []
    matrix:
        - packages:
            libpng:
                versions: [1.6.34]
            ncurses:
                versions: [6.1]
            pkgconf:
                versions: [1.4.2]
            readline:
                versions: [7.0]
            zlib:
                versions: [1.2.11]
        - compilers:
            gcc:
                versions: [5.5.0]
    cdash: ["https://spack.io/cdash/submit.php?project=spack"]
```

and given this `os-container-mapping.yaml`:

```
containers:
  linux-ubuntu18.04-x86_64:
    image: scottwittenburg/spack_builder_ubuntu_18.04
    compilers:
      - name: gcc@5.5.0
      - name: clang@6.0.0-1ubuntu2
  linux-centos7-x86_64:
    image: scottwittenburg/spack_builder_centos_7
    compilers:
      - name: gcc@5.5.0
```

then the `release-jobs` command will generate the following specs to be built:

```
$ spack release-jobs --spec-set .../spack/etc/spack/defaults/release.yaml --mirror-url https://mirror.spack.io --shared-runner-tag spack-k8s --print-summary
==> Staging summary:
==>   stage 0 (6 jobs):
==>     pkgconf/atbmtyn -> pkgconf@1.5.4%gcc@5.5.0 arch=linux-centos7-x86_64
==>     pkgconf/bp4fmns -> pkgconf@1.4.2%gcc@5.5.0 arch=linux-ubuntu18.04-x86_64
==>     pkgconf/qdgufjf -> pkgconf@1.4.2%gcc@5.5.0 arch=linux-centos7-x86_64
==>     pkgconf/unoed43 -> pkgconf@1.5.4%gcc@5.5.0 arch=linux-ubuntu18.04-x86_64
==>     zlib/ijtgxbh -> zlib@1.2.11%gcc@5.5.0 arch=linux-centos7-x86_64
==>     zlib/ymics2i -> zlib@1.2.11%gcc@5.5.0 arch=linux-ubuntu18.04-x86_64
==>   stage 1 (4 jobs):
==>     libpng/2vicq3d -> libpng@1.6.34%gcc@5.5.0 arch=linux-ubuntu18.04-x86_64
==>     libpng/drgxai6 -> libpng@1.6.34%gcc@5.5.0 arch=linux-centos7-x86_64
==>     ncurses/aqchhtc -> ncurses@6.1%gcc@5.5.0 arch=linux-centos7-x86_64
==>     ncurses/qkjccof -> ncurses@6.1%gcc@5.5.0 arch=linux-ubuntu18.04-x86_64
==>   stage 2 (2 jobs):
==>     readline/vuigree -> readline@7.0%gcc@5.5.0 arch=linux-ubuntu18.04-x86_64
==>     readline/xlb6j2a -> readline@7.0%gcc@5.5.0 arch=linux-centos7-x86_64
==> 12 build jobs generated in 3 stages
```

Note that although the `clang@6.0.0-1ubuntu2` compiler is available in the `linux-ubuntu18.04-x86_64` container, no jobs with that compiler were staged because it wasn't listed as a desired compiler in the `release.yaml`.  Conversely, also note the additional version of `pkgconf` which will be built, even though it wasn't specifically mentioned in the `release.yaml`.  This is because that particular version was a dependency of another spec in the spec set.

To avoid running the concretization of release specs (and generation of dependencies) in docker containers, the `--this-machine-only` argument may be passed to the `release-jobs` command.  In this case, the current machine will be used for concretization and dependency generation, but for this to work, the `os-container-mapping.yaml` file must contain an entry corresponding to `spack.architecture.sys_type().

### Additional Notes

Currently the Spack Gitlab instance is set up to test branches it finds on my fork (`scottwittenburg/spack`), so that will need to be changed before merging this topic will seem to have any effect.

This PR replaces both #8451 and #8718.

Before we can merge this, we need to address at least #10141, but there may be other prerequisites as well, hence the `WIP` on this PR for the time being.

Things currently holding this up:

- [x] Fix issue installing from spec.yaml using `-f` #10141 
- [x] Fix issue concretizing xsdk-0.4.0 (just needs merge) #10288 
- [x] Fix omega_h regression (proposed fix here: #10297)