### PR TITLE
Infer abstract spec for file-based installs

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -272,6 +272,7 @@ def install(parser, args, **kwargs):
             tty.warn(msg.format(file))
             continue
 
+        abstract_specs.append(s)
         specs.append(s.concretized())
 
     if len(specs) == 0:


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/10141

As noted in https://github.com/spack/spack/issues/10141, when installing a spec that was stored in a yaml file using the `spack install -f` option, the install was no longer taking place. This has been broken since https://github.com/spack/spack/commit/87aec4134daba7dee43c958151b45ca72c02e617, which overlooked that specs read from files didn't have abstract specs.

This treats the spec initially read from the file as the abstract spec. Note if a user concretizes and writes a spec using logic like:

```
>>> s = Spec('openmpi')
>>> s.concretize()
>>> open('openmpi.yaml', 'w').write(s.to_yaml(all_deps=True))
```

(i.e. in the `spack-python` shell)

That the spec initially read from this file will be the concrete spec (e.g. it will not simply be `openmpi`).