### PR TITLE
Check for ARM compiler in addition to clang

### DIFF
--- a/var/spack/repos/builtin/packages/m4/package.py
+++ b/var/spack/repos/builtin/packages/m4/package.py
@@ -34,7 +34,8 @@ class M4(AutotoolsPackage):
         spec = self.spec
         args = ['--enable-c++']
 
-        if spec.satisfies('%clang') and not spec.satisfies('platform=darwin'):
+        if (spec.satisfies('%clang') or spec.satisfies('%arm')) and not \
+           spec.satisfies('platform=darwin'):
             args.append('CFLAGS=-rtlib=compiler-rt')
 
         if spec.satisfies('%intel'):


### PR DESCRIPTION
Add "-rtlib=compiler-rt" to CFLAGS when building with either Clang or
the ARM compiler.

Fixes #10279