### PR TITLE
bug fix: copy permissions when staging

### DIFF
--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -548,9 +548,9 @@ class ResourceStage(Stage):
                 src = os.path.realpath(source_path)
 
                 if os.path.isdir(src):
-                    copy_tree(src, destination_path, _permissions=True)
+                    install_tree(src, destination_path)
                 else:
-                    copy(src, destination_path, _permissions=True)
+                    install(src, destination_path)
 
 
 @pattern.composite(method_list=[

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -548,9 +548,9 @@ class ResourceStage(Stage):
                 src = os.path.realpath(source_path)
 
                 if os.path.isdir(src):
-                    copy_tree(src, destination_path)
+                    copy_tree(src, destination_path, _permissions=True)
                 else:
-                    copy(src, destination_path)
+                    copy(src, destination_path, _permissions=True)
 
 
 @pattern.composite(method_list=[

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -15,7 +15,7 @@ from six import iteritems
 from six.moves.urllib.parse import urljoin
 
 import llnl.util.tty as tty
-from llnl.util.filesystem import mkdirp, can_access, copy, copy_tree
+from llnl.util.filesystem import mkdirp, can_access, install, install_tree
 from llnl.util.filesystem import remove_if_dead_link, remove_linked_tree
 
 import spack.paths


### PR DESCRIPTION
This is proposed as a fix for #10284 which I recently reported.

PR #10152  replaced `shutil.move` with llnl's `copy` and `copy_tree`
https://github.com/spack/spack/pull/10152/files#diff-b96a1a55f58dffde150cbe13f13ae2acL548

I think this is causing the build error with lua that I'm seeing today.  See below for details.  I don't know if this is an acceptable way to fix the issue, but I offer this PR as both a bug report and suggestion of possible fix.

```
$ spack install lua                                                                                                           

[snip]
                                  
==> Building lua [Package]                                                                                                                                                      
==> Executing phase: 'install'                                                                                                                                                  
==> Error: ProcessError: ./configure: Permission denied                                                                                                                         
    Command: './configure' '--prefix=/bifx/apps/spack/spack-20190108/opt/spack/linux-centos7-x86_64/gcc-8.2.0/lua-5.3.4-diuptpgekoebrs4bg6eprp6c4sizzaxu' '--with-lua=/bifx/apps
/spack/spack-20190108/opt/spack/linux-centos7-x86_64/gcc-8.2.0/lua-5.3.4-diuptpgekoebrs4bg6eprp6c4sizzaxu'                                                                      
```

The `configure` in `luarocks` is executable when the tarball is unpacked, but when the tree is copied into lua, it is no longer executable:

```
$ ls -l /bifx/apps/spack/spack-20190108/var/spack/stage/resource-luarocks-diuptpgekoebrs4bg6eprp6c4sizzaxu/luarocks-2.3.0/configure
-rwxr-xr-x 1 osolberg domain users 13021 Dec 29  2015 configure

$ ls -l /bifx/apps/spack/spack-20190108/var/spack/stage/lua-5.3.4-diuptpgekoebrs4bg6eprp6c4sizzaxu/lua-5.3.4/luarocks/luarocks/configure
-rw-r--r-- 1 osolberg domain users 13021 Jan  8 13:50 configure
```

@hartzell FYI