### PR TITLE
fix archlinux docker build

### DIFF
--- a/share/spack/docker/Dockerfile
+++ b/share/spack/docker/Dockerfile
@@ -25,11 +25,12 @@ RUN mkdir -p $SPACK_ROOT/opt/spack
 
 MASK PUSH
 MASK [[ $DISTRO == arch ]]
-RUN pacman -Sy --noconfirm                                     \
-        base-devel   ca-certificates curl   gcc                \
-        gcc-fortran  git             gnupg2 iproute2           \
-        make         openssh         python python-pip         \
-        sudo         tcl                                       \
+RUN pacman -Syu --noconfirm                                    \
+ && pacman -Sy --noconfirm                                     \
+        base-devel   ca-certificates curl    gcc               \
+        gcc-fortran  git             gnupg2  inetutils         \
+        iproute2     make            openssh procps-ng         \
+        python       python-pip      sudo    tcl               \
  && echo 'nobody ALL=(ALL) NOPASSWD: ALL' >                    \
         /etc/sudoers.d/nobody-sudo                             \
  && sudo -u nobody git clone                                   \

--- a/share/spack/docker/config/arch.bash
+++ b/share/spack/docker/config/arch.bash
@@ -11,8 +11,6 @@ unset BASE_TAG
 unset TAG
 unset EXTRA_TAGS
 
-export BASE_IMAGE="base/archlinux"
+export BASE_IMAGE="archlinux/base"
 export BASE_NAME="archlinux"
-export BASE_TAG="2018.10.01"
 export DISTRO="arch"
-export EXTRA_TAGS="latest"


### PR DESCRIPTION
Fix Arch Linux docker build.

 - Switch from an unsupported base image to a community-supported image, based on the information found [here](https://wiki.archlinux.org/index.php/Docker#Images).

 - Perform the equivalent of `sudo apt-get update` prior to installing Arch packages.

 - Add a few missing packages.