### PR TITLE
boost: fix the bjam build for Cray

### DIFF
--- a/var/spack/repos/builtin/packages/boost/bootstrap-path.patch
+++ b/var/spack/repos/builtin/packages/boost/bootstrap-path.patch
@@ -1,0 +1,33 @@
+Remove the spack wrapper directories from PATH for the bootstrap step.
+This was breaking the build for Cray (and other cross-compile) because
+bjam was built for the BE and died on SIGILL on the FE.  See issue
+#9613.
+
+This only affects building bjam.  The boost libraries are still built
+the normal spack way with the spack wrappers.
+
+
+diff -Naurb boost_1_66_0.orig/bootstrap.sh boost_1_66_0/bootstrap.sh
+--- boost_1_66_0.orig/bootstrap.sh	2017-12-13 17:56:35.000000000 -0600
++++ boost_1_66_0/bootstrap.sh	2019-01-09 13:51:56.407553214 -0600
+@@ -7,6 +7,20 @@
+ 
+ # boostinspect:notab - Tabs are required for the Makefile.
+ 
++NEWPATH=
++OLDIFS="$IFS"
++IFS=:
++
++for dir in $PATH ; do
++   case "x$dir" in
++      *lib*spack*env* ) ;;
++      * ) NEWPATH="${NEWPATH}:${dir}" ;;
++   esac
++done
++
++IFS="$OLDIFS"
++PATH="$NEWPATH"
++
+ BJAM=""
+ TOOLSET=""
+ BJAM_CONFIG=""

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -156,6 +156,9 @@ class Boost(Package):
     patch('boost_1.63.0_pgi.patch', when='@1.63.0%pgi')
     patch('boost_1.63.0_pgi_17.4_workaround.patch', when='@1.63.0%pgi@17.4')
 
+    # Fix the bootstrap/bjam build for Cray
+    patch('bootstrap-path.patch', when='@1.39.0: platform=cray')
+
     def url_for_version(self, version):
         if version >= Version('1.63.0'):
             url = "https://dl.bintray.com/boostorg/release/{0}/source/boost_{1}.tar.bz2"


### PR DESCRIPTION
Fixes #9613, fixes #3209.

Remove the spack wrapper directories from PATH for the bootstrap step.
This was breaking the build for Cray (and other cross-compile) because
bjam was built for the BE and died on SIGILL on the FE.

This only affects building bjam.  The boost libraries are still built
the normal spack way with the spack wrappers.

----------

I wrote the patch to apply to Cray, without a variant.  Technically,
this patch (or something similar) would be needed on any cross-
compile, anywhere BE code would not run on the FE.

But Cray is the only example I could find that actually fell over.
(It seems to work on Blue Gene without this fix.)  So, I decided that
boost already has enough variants.  But if spack supports a true cross
compile, then this will be needed on all cross compiles.  (It would even
be harmless to just always apply the patch.)

I've checked that the patch applies cleanly to boost 1.39 to 1.69.
The bootstrap.sh script never changes.

But before 1.39, bootstrap.sh was named 'configure'.  (Same file, it
was renamed between 1.38 and 1.39.)  So, if you want to build a very
old boost on Cray, then you'll need the same patch for the file
'configure.'  (I decided not to bother.)

Btw, I think the boost recipe is broken for :1.38 because it doesn't
understand that the bootstrap.sh script used to be called 'configure'.
