### PR TITLE
omega-h: requires empty CMAKE_BUILD_TYPE

### DIFF
--- a/var/spack/repos/builtin/packages/omega-h/package.py
+++ b/var/spack/repos/builtin/packages/omega-h/package.py
@@ -78,6 +78,8 @@ class OmegaH(CMakePackage):
             args.append('-DOmega_h_THROW:BOOL=ON')
         else:
             args.append('-DOmega_h_THROW:BOOL=OFF')
+        # omega-h requires empty CMAKE_BUILD_TYPE
+        args.append('-DCMAKE_BUILD_TYPE:STRING=')
         args += list(self._bob_options())
         return args
 


### PR DESCRIPTION
And breaks with current spak deafult  'RelWithDebInfo'

This is per https://github.com/ibaned/omega_h/issues/282#issuecomment-452824906

This fixes https://github.com/spack/spack/issues/10291

cc: @scottwittenburg  @ibaned 
 