### PR TITLE
tutorial basics section: fix gcc install version

### DIFF
--- a/lib/spack/docs/tutorial_basics.rst
+++ b/lib/spack/docs/tutorial_basics.rst
@@ -1635,7 +1635,7 @@ added to the configuration.
 
 .. code-block:: console
 
-  $ spack install gcc
+  $ spack install gcc @7.2.0
   ==> libsigsegv is already installed in /home/spack1/spack/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/libsigsegv-2.11-fypapcprssrj3nstp6njprskeyynsgaz
   ==> m4 is already installed in /home/spack1/spack/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/m4-1.4.18-suf5jtcfehivwfesrc5hjy72r4nukyel
   ==> pkgconf is already installed in /home/spack1/spack/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/pkgconf-1.4.2-fovrh7alpft646n6mhis5mml6k6e5f4v


### PR DESCRIPTION
We used gcc@7.2.0 for our spack-installed compiler in the tutorial at version 0.12.0 because gcc@8.1.0 was relatively new and we were worried not all bugs had been shaken out yet. This updates the tutorial script to match.

This should be back-ported onto v0.12.0.