### PR TITLE
Enhancement to module autoload documentation

### DIFF
--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -620,6 +620,20 @@ load their direct dependencies if the package installed depends on ``python``.
 The allowed values for the ``autoload`` statement are either ``none``,
 ``direct`` or ``all``.  The default is ``none``.
 
+.. tip::
+  Building external software
+     Setting ``autoload`` to ``direct`` for all packages can be useful
+     when building software outside of a Spack installation that depends on
+     artifacts in that installation.  E.g. (adjust ``lmod`` vs ``tcl``
+     as appropriate):
+
+  .. code-block:: yaml
+
+     modules:
+       lmod:
+         all:
+           autoload: 'direct'
+
 .. note::
   TCL prerequisites
      In the ``tcl`` section of the configuration file it is possible to use

--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -618,7 +618,7 @@ activated using ``spack activate``:
 The configuration file above will produce module files that will
 load their direct dependencies if the package installed depends on ``python``.
 The allowed values for the ``autoload`` statement are either ``none``,
-``direct`` or ``all``.
+``direct`` or ``all``.  The default is ``none``.
 
 .. note::
   TCL prerequisites


### PR DESCRIPTION
Add some helpful hints about autload:

- default is `none`
- setting to `direct` for all can be useful when building external software that uses artifacts from within the spack tree.

See #10307.