### PR TITLE
bugfix/gdk-pixbuf

### DIFF
--- a/var/spack/repos/builtin/packages/docbook-xsl/package.py
+++ b/var/spack/repos/builtin/packages/docbook-xsl/package.py
@@ -22,6 +22,13 @@ class DocbookXsl(Package):
     def install(self, spec, prefix):
         install_tree('.', prefix)
 
+    def catalog(self):
+        return os.path.join(self.prefix, 'catalog.xml')
+
     def setup_environment(self, spack_env, run_env):
-        catalog = os.path.join(self.prefix, 'catalog.xml')
+        catalog = self.catalog()
         run_env.set('XML_CATALOG_FILES', catalog, separator=' ')
+
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        catalog = self.catalog()
+        spack_env.prepend_path("XML_CATALOG_FILES", catalog)

--- a/var/spack/repos/builtin/packages/docbook-xsl/package.py
+++ b/var/spack/repos/builtin/packages/docbook-xsl/package.py
@@ -22,13 +22,14 @@ class DocbookXsl(Package):
     def install(self, spec, prefix):
         install_tree('.', prefix)
 
+    @property
     def catalog(self):
         return os.path.join(self.prefix, 'catalog.xml')
 
     def setup_environment(self, spack_env, run_env):
-        catalog = self.catalog()
+        catalog = self.catalog
         run_env.set('XML_CATALOG_FILES', catalog, separator=' ')
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        catalog = self.catalog()
+        catalog = self.catalog
         spack_env.prepend_path("XML_CATALOG_FILES", catalog)

--- a/var/spack/repos/builtin/packages/gdk-pixbuf/docbook-cdn.patch
+++ b/var/spack/repos/builtin/packages/gdk-pixbuf/docbook-cdn.patch
@@ -1,0 +1,11 @@
+--- a/docs/meson.build	2019-01-10 17:55:09.573701375 -0800
++++ b/docs/meson.build	2019-01-10 17:56:03.672667410 -0800
+@@ -89,7 +89,7 @@
+                     xsltproc,
+                     xlstproc_flags,
+                     '-o', '@OUTPUT@',
+-                    'http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl',
++                    'http://cdn.docbook.org/release/xsl/current/manpages/docbook.xsl',
+                     '@INPUT@',
+                   ],
+                   install: true,

--- a/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
+++ b/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
@@ -31,9 +31,10 @@ class GdkPixbuf(Package):
     depends_on('libxslt', type='build')
     depends_on('docbook-xsl', type='build')
     depends_on('gettext')
-    depends_on('glib')
+    depends_on('glib@2.38.0:')
     depends_on('jpeg')
     depends_on('libpng')
+    depends_on('zlib')
     depends_on('libtiff')
     depends_on('gobject-introspection')
 

--- a/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
+++ b/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
@@ -37,6 +37,8 @@ class GdkPixbuf(Package):
     depends_on('libtiff')
     depends_on('gobject-introspection')
 
+    # Replace the docbook stylesheet URL with the one that our
+    # docbook-xsl package uses/recognizes.
     patch('docbook-cdn.patch')
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
+++ b/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
@@ -27,7 +27,7 @@ class GdkPixbuf(Package):
     depends_on('shared-mime-info', type='build', when='@2.36.8: platform=linux')
     depends_on('shared-mime-info', type='build', when='@2.36.8: platform=cray')
     depends_on('pkgconfig', type='build')
-    # Building the man pages requires libxslt.
+    # Building the man pages requires libxslt and the Docbook stylesheets
     depends_on('libxslt', type='build')
     depends_on('docbook-xsl', type='build')
     depends_on('gettext')

--- a/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
+++ b/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
@@ -37,6 +37,8 @@ class GdkPixbuf(Package):
     depends_on('libtiff')
     depends_on('gobject-introspection')
 
+    patch('docbook-cdn.patch')
+
     def url_for_version(self, version):
         url = "https://ftp.acc.umu.se/pub/gnome/sources/gdk-pixbuf/{0}/gdk-pixbuf-{1}.tar.xz"
         return url.format(version.up_to(2), version)

--- a/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
+++ b/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
@@ -73,3 +73,8 @@ class GdkPixbuf(Package):
         make('install')
         if self.run_tests:
             make('installcheck')
+
+    def setup_environment(self, spack_env, run_env):
+        # The "post-install.sh" script uses gdk-pixbuf-query-loaders,
+        # which was installed earlier.
+        spack_env.prepend_path('PATH', self.prefix.bin)

--- a/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
+++ b/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
@@ -55,6 +55,8 @@ class GdkPixbuf(Package):
         with working_dir('spack-build', create=True):
             meson('..', *std_meson_args)
             ninja('-v')
+            if self.run_tests:
+                ninja('test')
             ninja('install')
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
+++ b/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
@@ -27,6 +27,9 @@ class GdkPixbuf(Package):
     depends_on('shared-mime-info', type='build', when='@2.36.8: platform=linux')
     depends_on('shared-mime-info', type='build', when='@2.36.8: platform=cray')
     depends_on('pkgconfig', type='build')
+    # Building the man pages requires libxslt.
+    depends_on('libxslt', type='build')
+    depends_on('docbook-xsl', type='build')
     depends_on('gettext')
     depends_on('glib')
     depends_on('jpeg')


### PR DESCRIPTION
[edit: wordsmith point 4]

Docbook processing now works correctly for gdk-pixbuf

1. The various bits of documentation in gdk-pixbuf include hardcoded references to dtd's and stuff at their canonical, Internet, locations.  BUT, gdk-pixbuf runs xslt-proc with the `--nonet` option, which forbids it from using the network.

    Sadness ensues.

   Traditionally folks use XML Catalogs to map these to local copies.  Our docbook-xsl package wasn't setting the appropriate env var in its dependents environments to use our catalog.

   Now it does.  Less sadness ensues.

2. If we're going to use these things, we should depend on them.

3. The "post-install.sh" script uses gdk-pixbuf-query-loaders, which was installed earlier.

   If py-psyclone can set its own bin on its PATH in its environment, so can we...

4. Our docbook-xsl package assumes that the canonical location is  `http://cdn.docbook.org/release/xsl/current/manpages/docbook.xsl`,  but the gdk-pixbuf's meson build script uses
`http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl`.

   This means that our XML Catalog doesn't fix the reference and sadness happens.

   Just patch the build so that it sees what it wants to see, then it can make it right.

There are at least two things that I could use some feedback on:

1. I made a little helper `catalog` method in the docbook-xsl package.  Perhaps is should not be a method and should instead have some sort of a decorator on it.  Python feedback welcome....

2. The docbook-xml package almost certainly should also be setting XML_CATALOG_FILES for it's dependents, it's basically a clone of docbook-xsl.  But *If It Ain't Broke, Don't Fix It* and *It's Not My Problem* and *What Docbook-xml Package?*.  More seriously, I don't have anything useful to test any changes I might make.  Perhaps just throw a note over there?

Fixes #10222