### PR TITLE
fix typo in docker test script

### DIFF
--- a/share/spack/qa/run-docker-tests
+++ b/share/spack/qa/run-docker-tests
@@ -37,7 +37,7 @@ for config in share/spack/docker/config/* ; do
     ./share/spack/docker/build-image.sh;
 done
 
-if [ "$TEST_SUITE" '=' "docker build" -a \
+if [ "$TEST_SUITE" '=' "docker" -a \
      "$TRAVIS_EVENT_TYPE" != "pull_request" -a \
      ensure_docker_login ] ; then
 


### PR DESCRIPTION
Huzzah! The docker images are finally building in Travis! :tada: :tada: :tada:
But, they're not actually getting pushed, because of a silly oversight on my part. :(

This PR fixes a typo from when the test suite was initially called `docker build`, instead of simply `docker`.

CC'ing a few of the usual suspects.  It would be great if we could merge this one-liner in quickly, as it very well may be the only thing standing between us and images on docker hub!