### PR TITLE
Do not remove mpirun when OpenMPI is built with Slurm

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -466,18 +466,3 @@ class Openmpi(AutotoolsPackage):
         else:
             config_args.append('--disable-cxx-exceptions')
         return config_args
-
-    @run_after('install')
-    def delete_mpirun_mpiexec(self):
-        # The preferred way to run an application when Slurm is the
-        # scheduler is to let Slurm manage process spawning via PMI.
-        #
-        # Deleting the links to orterun avoids users running their
-        # applications via mpirun or mpiexec, and leaves srun as the
-        # only sensible choice (orterun is still present, but normal
-        # users don't know about that).
-        if '@1.6: ~legacylaunchers schedulers=slurm' in self.spec:
-            os.remove(self.prefix.bin.mpirun)
-            os.remove(self.prefix.bin.mpiexec)
-            os.remove(self.prefix.bin.shmemrun)
-            os.remove(self.prefix.bin.oshrun)


### PR DESCRIPTION
#7574 removed the `mpirun`/`mpiexec` executable when OpenMPI is built with slurm support. I suggest restoring them for a few reasons:

1.  Calling `mpirun` after `salloc`/`sbatch` is a documented practice on OpenMPI website. See https://www.open-mpi.org/faq/?category=slurm. People might follow the instruction and get surprised -- either not find `mpirun` , or an incorrect version like `/usr/bin/mpirun` is called. Indeed this is how I find this issue.
2. Directly using `mpirun` is useful for fine-tuning the MCA parameter, e.g. force TCP and turn off IB & Vader by `mpirun --mca btl tcp,self`. Useful for debugging sometimes :) . With`srun` it can still be done by setting `OMPI_MCA_<param_name>`, but a bit inconvenient (https://www.open-mpi.org/faq/?category=tuning#setting-mca-params). Using `orterun` feels exotic for most users.
3. In certain cases `mpirun` can have better performance than `srun` (though probably rare with `srun --mpi=pmix`). See https://www.mail-archive.com/users@lists.open-mpi.org/msg31874.html

Just a small suggestion :)  In any case, I really appreciate #7574 (and #8427) -- OpenMPI + slurm works quite well so far!