### PR TITLE
specs: better lookup by hash; allow references to missing dependency hashes

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3951,17 +3951,15 @@ class SpecParser(spack.parse.Parser):
     def spec_by_hash(self):
         self.expect(ID)
 
-        specs = spack.store.db.query()
-        matches = [spec for spec in specs if
-                   spec.dag_hash()[:len(self.token.value)] == self.token.value]
-
+        dag_hash = self.token.value
+        matches = spack.store.db.get_by_hash(dag_hash)
         if not matches:
-            raise NoSuchHashError(self.token.value)
+            raise NoSuchHashError(dag_hash)
 
         if len(matches) != 1:
             raise AmbiguousHashError(
                 "Multiple packages specify hash beginning '%s'."
-                % self.token.value, *matches)
+                % dag_hash, *matches)
 
         return matches[0]
 

--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -8,6 +8,7 @@ import spack.store
 from spack.main import SpackCommand, SpackCommandError
 
 uninstall = SpackCommand('uninstall')
+install = SpackCommand('install')
 
 
 class MockArgs(object):
@@ -21,24 +22,21 @@ class MockArgs(object):
 
 
 @pytest.mark.db
-@pytest.mark.usefixtures('database')
-def test_multiple_matches():
+def test_multiple_matches(mutable_database):
     """Test unable to uninstall when multiple matches."""
     with pytest.raises(SpackCommandError):
         uninstall('-y', 'mpileaks')
 
 
 @pytest.mark.db
-@pytest.mark.usefixtures('database')
-def test_installed_dependents():
+def test_installed_dependents(mutable_database):
     """Test can't uninstall when ther are installed dependents."""
     with pytest.raises(SpackCommandError):
         uninstall('-y', 'libelf')
 
 
 @pytest.mark.db
-@pytest.mark.usefixtures('mutable_database')
-def test_recursive_uninstall():
+def test_recursive_uninstall(mutable_database):
     """Test recursive uninstall."""
     uninstall('-y', '-a', '--dependents', 'callpath')
 
@@ -56,12 +54,11 @@ def test_recursive_uninstall():
 
 @pytest.mark.db
 @pytest.mark.regression('3690')
-@pytest.mark.usefixtures('mutable_database')
 @pytest.mark.parametrize('constraint,expected_number_of_specs', [
     ('dyninst', 7), ('libelf', 5)
 ])
 def test_uninstall_spec_with_multiple_roots(
-        constraint, expected_number_of_specs
+        constraint, expected_number_of_specs, mutable_database
 ):
     uninstall('-y', '-a', '--dependents', constraint)
 
@@ -70,14 +67,91 @@ def test_uninstall_spec_with_multiple_roots(
 
 
 @pytest.mark.db
-@pytest.mark.usefixtures('mutable_database')
 @pytest.mark.parametrize('constraint,expected_number_of_specs', [
     ('dyninst', 13), ('libelf', 13)
 ])
 def test_force_uninstall_spec_with_ref_count_not_zero(
-        constraint, expected_number_of_specs
+        constraint, expected_number_of_specs, mutable_database
 ):
     uninstall('-f', '-y', constraint)
 
     all_specs = spack.store.layout.all_specs()
     assert len(all_specs) == expected_number_of_specs
+
+
+@pytest.mark.db
+def test_force_uninstall_and_reinstall_by_hash(mutable_database):
+    """Test forced uninstall and reinstall of old specs."""
+    # this is the spec to be removed
+    callpath_spec = spack.store.db.query_one('callpath ^mpich')
+    dag_hash = callpath_spec.dag_hash()
+
+    # ensure can look up by hash and that it's a dependent of mpileaks
+    def validate_callpath_spec(installed):
+        assert installed is True or installed is False
+
+        specs = spack.store.db.get_by_hash(dag_hash, installed=installed)
+        assert len(specs) == 1 and specs[0] == callpath_spec
+
+        specs = spack.store.db.get_by_hash(dag_hash[:7], installed=installed)
+        assert len(specs) == 1 and specs[0] == callpath_spec
+
+        specs = spack.store.db.get_by_hash(dag_hash, installed=any)
+        assert len(specs) == 1 and specs[0] == callpath_spec
+
+        specs = spack.store.db.get_by_hash(dag_hash[:7], installed=any)
+        assert len(specs) == 1 and specs[0] == callpath_spec
+
+        specs = spack.store.db.get_by_hash(dag_hash, installed=not installed)
+        assert specs is None
+
+        specs = spack.store.db.get_by_hash(dag_hash[:7],
+                                           installed=not installed)
+        assert specs is None
+
+        mpileaks_spec = spack.store.db.query_one('mpileaks ^mpich')
+        assert callpath_spec in mpileaks_spec
+
+        spec = spack.store.db.query_one('callpath ^mpich', installed=installed)
+        assert spec == callpath_spec
+
+        spec = spack.store.db.query_one('callpath ^mpich', installed=any)
+        assert spec == callpath_spec
+
+        spec = spack.store.db.query_one('callpath ^mpich',
+                                        installed=not installed)
+        assert spec is None
+
+    validate_callpath_spec(True)
+
+    uninstall('-y', '-f', 'callpath ^mpich')
+
+    # ensure that you can still look up by hash and see deps, EVEN though
+    # the callpath spec is missing.
+    validate_callpath_spec(False)
+
+    # BUT, make sure that the removed callpath spec is not in queries
+    def db_specs():
+        all_specs = spack.store.layout.all_specs()
+        return (
+            all_specs,
+            [s for s in all_specs if s.satisfies('mpileaks')],
+            [s for s in all_specs if s.satisfies('callpath')],
+            [s for s in all_specs if s.satisfies('mpi')]
+        )
+    all_specs, mpileaks_specs, callpath_specs, mpi_specs = db_specs()
+    assert len(all_specs) == 13
+    assert len(mpileaks_specs) == 3
+    assert len(callpath_specs) == 2
+    assert len(mpi_specs) == 3
+
+    # Now, REINSTALL the spec and make sure everything still holds
+    install('--fake', '/%s' % dag_hash[:7])
+
+    validate_callpath_spec(True)
+
+    all_specs, mpileaks_specs, callpath_specs, mpi_specs = db_specs()
+    assert len(all_specs) == 14      # back to 14
+    assert len(mpileaks_specs) == 3
+    assert len(callpath_specs) == 3  # back to 3
+    assert len(mpi_specs) == 3


### PR DESCRIPTION
Previously spec parsing didn't allow you to look up missing (but still known) specs by hash.

For example:

```console
$ spack uninstall -f /7lpqufu  # force uninstall a still-needed package
```

Notice that xz is uninstalled (`[-]`) below:
```console
$ spack spec -Il /tddqgvd
Concretized
--------------------------------
[+]  tddqgvd  hdf5@1.10.2%clang@8.1.0-apple~cxx~debug~fortran~hl+mpi+pic+shared~szip~threadsafe arch=darwin-highsierra-x86_64 
[+]  j55gl56      ^openmpi@3.1.1%clang@8.1.0-apple~cuda+cxx_exceptions fabrics= ~java~memchecker~pmi schedulers= ~sqlite3~thread_multiple+vt arch=darwin-highsierra-x86_64 
[+]  4qjjdvh          ^hwloc@1.11.9%clang@8.1.0-apple~cairo~cuda+libxml2~pci+shared arch=darwin-highsierra-x86_64 
[+]  cmhpqwp              ^libxml2@2.9.8%clang@8.1.0-apple~python arch=darwin-highsierra-x86_64 
[-]  7lpqufu                  ^xz@5.2.4%clang@8.1.0-apple arch=darwin-highsierra-x86_64 
[+]  n3eiwqp                  ^zlib@1.2.11%clang@8.1.0-apple+optimize+pic+shared arch=darwin-highsierra-x86_64 
```

This would previously fail to understand the xz hash, but now works:
```console
$ spack spec -Il /7lpqufu
Concretized
--------------------------------
xz@5.2.4%clang@8.1.0-apple arch=darwin-highsierra-x86_64
```
You could now do this to reinstall:
```console
$ spack install /7lpqufu
```

- Allow referencing and potentially reinstalling force-uninstalled dependencies
- Add testing for force uninstall and for reference by spec