### PR TITLE
r-gamlss: new package (and data) at 5.1-2

### DIFF
--- a/var/spack/repos/builtin/packages/r-gamlss-data/package.py
+++ b/var/spack/repos/builtin/packages/r-gamlss-data/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class RGamlssData(RPackage):
+    """gamlss.data: GAMLSS Data"""
+
+    homepage = "https://cran.r-project.org/package=gamlss.data"
+    url      = "https://cran.r-project.org/src/contrib/gamlss.data_5.1-0.tar.gz"
+    list_url = "https://cran.r-project.org/src/contrib/Archive/gamlss.data/"
+
+    version('5.1-0', sha256='0aad438ea1aa6395677e52cd2cb496f9f4c9ba2d39edc92c8cb42e7fc91fe6c1')
+
+    depends_on('r@2.10:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-gamlss-dist/package.py
+++ b/var/spack/repos/builtin/packages/r-gamlss-dist/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class RGamlssDist(RPackage):
+    """gamlss.dist: Distributions for Generalized Additive Models for
+       Location Scale and Shape"""
+
+    homepage = "https://cran.r-project.org/package=gamlss.dist"
+    url      = "https://cran.r-project.org/src/contrib/gamlss.dist_5.1-1.tar.gz"
+    list_url = "https://cran.r-project.org/src/contrib/Archive/gamlss.dist/"
+
+    version('5.1-1', sha256='44f999ff74ee516757eb39c8308c48aa850523aad2f38e622268313a13dda0b1')
+
+    depends_on('r@2.15:', type=('build', 'run'))
+    depends_on('r-mass', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-gamlss/package.py
+++ b/var/spack/repos/builtin/packages/r-gamlss/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class RGamlss(RPackage):
+    """gamlss: Generalised Additive Models for Location Scale and Shape"""
+
+    homepage = "https://cran.r-project.org/package=gamlss"
+    url      = "https://cran.r-project.org/src/contrib/gamlss_5.1-2.tar.gz"
+    list_url = "https://cran.r-project.org/src/contrib/Archive/gamlss/"
+
+    version('5.1-2', sha256='0d404e74768a8f98c6a5e9a48bd2cf4280125831a5dcd8c7f7b57922f57e016b')
+
+    depends_on('r@3.3.0:', type=('build', 'run'))
+    depends_on('r-gamlss-data@5.0-0:', type=('build', 'run'))
+    depends_on('r-gamlss-dist@4.3.1:', type=('build', 'run'))


### PR DESCRIPTION
gamlss consists of three packages (`gamlss`, `gamlss.data`, and `gamlss.dist`) so they are all bundled in this PR.