### PR TITLE
Add x86_64 as target to cray platform

### DIFF
--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -52,6 +52,7 @@ class Cray(Platform):
 
         self.add_target("x86_64", Target("x86_64"))
         self.add_target("front_end", Target("x86_64"))
+        self.front_end = "x86_64"
 
         # Get aliased targets from config or best guess from environment:
         for name in ('front_end', 'back_end'):
@@ -64,6 +65,7 @@ class Cray(Platform):
                 safe_name = _target.replace('-', '_')
                 setattr(self, name, safe_name)
                 self.add_target(name, self.targets[safe_name])
+
 
         if self.back_end is not None:
             self.default = self.back_end

--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -50,6 +50,9 @@ class Cray(Platform):
             name = target.replace('-', '_')
             self.add_target(name, Target(name, 'craype-%s' % target))
 
+        self.add_target("x86_64", Target("x86_64"))
+        self.add_target("front_end", Target("x86_64"))
+
         # Get aliased targets from config or best guess from environment:
         for name in ('front_end', 'back_end'):
             _target = getattr(self, name, None)

--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -66,7 +66,6 @@ class Cray(Platform):
                 setattr(self, name, safe_name)
                 self.add_target(name, self.targets[safe_name])
 
-
         if self.back_end is not None:
             self.default = self.back_end
             self.add_target('default', self.targets[self.back_end])


### PR DESCRIPTION
x86_64 as the frontend target does not get set in the cray platform.
This makes sure to add the target as named target x86_64 as well as the
aliased target front_end.  This fixes the issue where specifying
arch=cray-fe-x86_64 gives the error:

==> Error: ValueError: Can't recreate arch for spec cray-sles12-x86_64
on current arch cray-cnl6-mic_knl; spec architecture is too different

@scheibelp can you check whether this is a viable solution for @mwkrentel problem?