### PR TITLE
lmod: add version 7.8.15

### DIFF
--- a/var/spack/repos/builtin/packages/lmod/package.py
+++ b/var/spack/repos/builtin/packages/lmod/package.py
@@ -19,6 +19,7 @@ class Lmod(AutotoolsPackage):
     homepage = 'https://www.tacc.utexas.edu/research-development/tacc-projects/lmod'
     url      = 'https://github.com/TACC/Lmod/archive/7.4.11.tar.gz'
 
+    version('7.8.15', sha256='00a257f5073d656adc73045997c28f323b7a4f6d901f1c57b7db2b0cd6bee6e6')
     version('7.8', sha256='40388380a36a00c3ce929a9f88c8fffc93deeabf87a7c3f8864a82acad38c3ba')
     version('7.7.29', 'bd3f171995e6863505e8a958d158ced1')
     version('7.7.13', 'e1d222fa04148707dceb08c82d7e9fa5')


### PR DESCRIPTION
Upstream project [fixed an unbound shell variable](https://github.com/TACC/Lmod/commit/dbc4472dbbda9804b5d996579c55d611d1171fd3), which looks like it made it into versions >= 7.8.6.   This PR adds the latest lmod release, which is 7.8.15.

Tested on Centos 7.6

FYI @hartzell 
