### PR TITLE
"setup" support with environments

### DIFF
--- a/lib/spack/spack/cmd/add.py
+++ b/lib/spack/spack/cmd/add.py
@@ -19,13 +19,18 @@ level = "long"
 def setup_parser(subparser):
     subparser.add_argument(
         'specs', nargs=argparse.REMAINDER, help="specs of packages to add")
+    subparser.add_argument('--setup')
 
 
 def add(parser, args):
     env = ev.get_env(args, 'add', required=True)
 
+    setup = None
+    if args.setup:
+        setup = list(args.setup.split(','))
+
     for spec in spack.cmd.parse_specs(args.specs):
-        if not env.add(spec):
+        if not env.add(spec, setup):
             tty.msg("Package {0} was already added to {1}"
                     .format(spec.name, env.name))
         else:

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -41,13 +41,6 @@ def update_kwargs_from_args(args, kwargs):
         'dirty': args.dirty,
         'use_cache': args.use_cache
     })
-    if hasattr(args, 'setup'):
-        setups = set()
-        for arglist_s in args.setup:
-            for arg in [x.strip() for x in arglist_s.split(',')]:
-                setups.add(arg)
-        kwargs['setup'] = setups
-        tty.msg('Setup={0}'.format(kwargs['setup']))
 
 
 def setup_parser(subparser):
@@ -159,6 +152,10 @@ Defaults to current system hostname."""
         help="""Results will be reported to this group on CDash.
 Defaults to Experimental."""
     )
+    subparser.add_argument(
+        '--setup',
+        help="""Names of specs in this DAG for which the install should be
+managed by the user.""")
     arguments.add_common_arguments(subparser, ['yes_to_all'])
 
 
@@ -237,6 +234,9 @@ def install(parser, args, **kwargs):
         'install_dependencies': ('dependencies' in args.things_to_install),
         'install_package': ('package' in args.things_to_install)
     })
+
+    if args.setup:
+        kwargs['setup'] = list(args.setup.split(','))
 
     if args.run_tests:
         tty.warn("Deprecated option: --run-tests: use --test=all instead")

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -399,8 +399,8 @@ class Environment(object):
 
     def _set_user_specs_from_lockfile(self):
         """Copy user_specs from a read-in lockfile."""
-        self.user_specs = [UserSpecEntry(s) for s
-                           in self.concretized_user_specs]
+        self.user_spec_entriess = [
+            UserSpecEntry(s) for s in self.concretized_user_specs]
 
     def clear(self):
         self.user_spec_entries = []       # current user specs
@@ -413,7 +413,8 @@ class Environment(object):
 
     @property
     def user_specs(self):
-        return list(x.spec for x in self.user_spec_entries)
+        # Return a tuple rather than a list because this is read-only
+        return tuple(x.spec for x in self.user_spec_entries)
 
     @property
     def internal(self):
@@ -567,7 +568,8 @@ class Environment(object):
 
         for spec in matches:
             if spec in self.user_specs:
-                self.user_specs.remove(spec)
+                i = self.user_specs.index(spec)
+                del self.user_spec_entries[i]
 
             if force and spec in self.concretized_user_specs:
                 i = self.concretized_user_specs.index(spec)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1373,6 +1373,9 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         restage = kwargs.get('restage', False)
         partial = self.check_for_unfinished_installation(keep_prefix, restage)
 
+        if 'setup' in kwargs:
+            tty.debug('setup: ' + ', '.join(kwargs['setup']))
+
         # Ensure package is not already installed
         layout = spack.store.layout
         with spack.store.db.prefix_read_lock(self.spec):


### PR DESCRIPTION
See https://github.com/spack/spack/pull/7846

@citibeth this is intended to address:

> At this point, a change to the grammar is required so the YAML files can accommodate Spack Setup functionality. I don't know how to change the grammar appropriately.

But it is not complete: it only handles managing the configs and doesn't actually write the spconfig files etc. Depending on your time/preference, this can be folded into #7846 or I can add the rest of #7846 to this.

Allow user specs to store spec as well as a set of packages in the DAG to manage manually; update install/add commands with --setup option

This assumes that the `spack.yaml` stored for environments maintains user specs either as

```
spack:
  specs:
    - py-numpy
    - openblas
```

(as before) or as

```
spack
  specs:
    - spec: py-numpy
      setup: [python]
    - spec: openblas
      setup: []
```

This follows the existing environment schema definition (which allows for strings or dictionaries).