### PR TITLE
Typo fixes in .flake8 comments

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,24 +1,30 @@
 # -*- conf -*-
 # flake8 settings for Spack core files.
 #
-# These exceptions ar for Spack core files. We're slightly more lenient
+# These exceptions are for Spack core files. We're slightly more lenient
 # with packages.  See .flake8_packages for that.
 #
-# Let people line things up nicely:
+# E1: Indentation
 # - E129: visually indented line with same indent as next logical line
+#
+# E2: Whitespace
 # - E221: multiple spaces before operator
 # - E241: multiple spaces after ','
 # - E272: multiple spaces before keyword
 #
-# Let people use terse Python features:
-# - E731: lambda expressions
+# E7: Statement
+# - E731: do not assign a lambda expression, use a def
+#
+# W5: Line break warning
+# - W503: line break before binary operator
+# - W504: line break after binary operator
 #
 # These are required to get the package.py files to test clean:
 # - F999: syntax error in doctest
 #
-# Exempt to allow decorator classes to be lowercase, but follow otherwise:
-# - N801: CapWords for class names.
+# N8: PEP8-naming
+# - N801: class names should use CapWords convention
 #
 [flake8]
-ignore = E129,E221,E241,E272,E731,F999,N801,W503,W504
+ignore = E129,E221,E241,E272,E731,W503,W504,F999,N801
 max-line-length = 79

--- a/.flake8_packages
+++ b/.flake8_packages
@@ -7,16 +7,18 @@
 # wildcard import and dependencies can set globals for their
 # dependents. So we add exceptions for checks related to undefined names.
 #
-# Note that we also add *per-line* exemptions for certain patters in the
+# Note that we also add *per-line* exemptions for certain patterns in the
 # `spack flake8` command.  This is where F403 for `from spack import *`
 # is added (beause we *only* allow that wildcard).
 #
 # See .flake8 for regular exceptions.
 #
-# Redefinition exceptions:
+# F4: Import
 # - F405: `name` may be undefined, or undefined from star imports: `module`
-# - F821: undefined name `name` (needed for cmake, configure, etc.)
+#
+# F8: Name
+# - F821: undefined name `name`
 #
 [flake8]
-ignore = E129,E221,E241,E272,E731,F999,F405,F821,W503,W504
+ignore = E129,E221,E241,E272,E731,W503,W504,F405,F821,F999
 max-line-length = 79


### PR DESCRIPTION
This PR involves no functional changes, just a couple typo fixes and additional comments on ignored warning/error codes.

All warning/error code definitions come from one of:

- flake8: http://flake8.pycqa.org/en/latest/user/error-codes.html
- pycodestyle: https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
- pep8-naming: https://pypi.org/project/pep8-naming/