### PR TITLE
change Mercury's libfabric dependency on Cray platforms

### DIFF
--- a/var/spack/repos/builtin/packages/mercury/package.py
+++ b/var/spack/repos/builtin/packages/mercury/package.py
@@ -25,7 +25,6 @@ class Mercury(CMakePackage):
 
     depends_on('cci@master', when='+cci', type=('build', 'link', 'run'))
     depends_on('libfabric', when='+fabric', type=('build', 'link', 'run'))
-    depends_on('libfabric@develop', when='+fabric platform=cray', type=('build', 'link', 'run'))
     depends_on('bmi', when='+bmi', type=('build', 'link', 'run'))
     depends_on('openpa', type=('build', 'link', 'run'))
 


### PR DESCRIPTION
The Mercury package previously depended on libfabric@develop on Cray platforms in order to pick up a fix for the GNI provider that was only available in git.  This is no longer needed now that the libfabric package is at 1.7.0.  

This PR removes the special case dependency on Cray platforms.