### PR TITLE
llvm: various updates

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -164,6 +164,22 @@ class Llvm(CMakePackage):
             }
         },
         {
+            'version': '7.0.1',
+            'md5': '79f1256f97d52a054da8660706deb5f6',
+            'resources': {
+                'compiler-rt': '697b70141ae7cc854e4fbde1a07b7287',
+                'openmp': 'd7d05ac0109df51a47099cba08cb43ec',
+                'polly': '287d7391438b5285265fede3b08e1e29',
+                'libcxx': 'aa9202ebb2aef2078fccfa24b3b1eed1',
+                'libcxxabi': 'c82a187e95744d15c040108bc2b8868f',
+                'cfe': '8583c9fb2af0ce61a7154fd9125363c1',
+                'clang-tools-extra': 'f0a94f63cc3d717f8f6662e0bf9c7330',
+                'lldb': '9ea3dc5cb9a1d9e390652d42ef1ccf41',
+                'lld': '9162cde32887cd33facead766645ef1f',
+                'libunwind': 'fe8c801dd79e087a6fa8d039390a47d0'
+            }
+        },
+        {
             'version': '7.0.0',
             'md5': 'e0140354db83cdeb8668531b431398f0',
             'resources': {

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -66,6 +66,9 @@ class Llvm(CMakePackage):
     depends_on('python')
     depends_on('py-lit', type=('build', 'run'))
 
+    # openmp dependencies
+    depends_on('perl-data-dumper', type=('build'))
+
     # lldb dependencies
     depends_on('ncurses', when='+lldb')
     depends_on('swig', when='+lldb')

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -582,6 +582,8 @@ class Llvm(CMakePackage):
 
         cmake_args = [
             '-DLLVM_REQUIRES_RTTI:BOOL=ON',
+            '-DLLVM_ENABLE_RTTI:BOOL=ON',
+            '-DLLVM_ENABLE_EH:BOOL=ON',
             '-DCLANG_DEFAULT_OPENMP_RUNTIME:STRING=libomp',
             '-DPYTHON_EXECUTABLE:PATH={0}'.format(spec['python'].command.path),
         ]


### PR DESCRIPTION
- Bump the version to 7.0.1
- Fix openmp build time dependency (Depends on #10425, will rebase once merged)
- Fix lldb stability issue with libstdc++ < from gcc < 4.9
  - See https://github.com/llvm/llvm-project/blob/f9ebacfd299c7711b5b3a3fae5f36b61e14a580e/lldb/cmake/modules/LLDBConfig.cmake#L424-L443 for details
  - Since compilers like PGI, Intel, and Cray tend to use the C++ library from some system-supplied GCC installation, there's not currently a reliable way to check in the package file whether or not exception handling is needed.  It's not particularly harmful and generally useful so always enabling it should be a reliable safe bet.