### PR TITLE
spack diy: add option to run tests.

### DIFF
--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -119,6 +119,13 @@ _arguments['tags'] = Args(
     '-t', '--tags', action='append',
     help='filter a package query by tags')
 
+_arguments['test'] = Args(
+    '--test', default=None, choices=['root', 'all'],
+    help="If 'root' is chosen, run package tests during installation for "
+         "top-level packages (but skip tests for dependencies).  if 'all' "
+         "is chosen, run package tests during installation for all packages. "
+         "If neither are chosen, don't run tests for any packages.")
+
 _arguments['jobs'] = Args(
     '-j', '--jobs', action='store', type=int, dest="jobs",
     help="explicitly set number of make jobs, default is #cpus.")
@@ -132,3 +139,7 @@ _arguments['install_status'] = Args(
 _arguments['no_checksum'] = Args(
     '-n', '--no-checksum', action='store_true', default=False,
     help="do not use checksums to verify downloadeded files (unsafe)")
+
+_arguments['overwrite'] = Args(
+    '--overwrite', action='store_true',
+    help="reinstall an existing spec, even if it has dependents")

--- a/lib/spack/spack/cmd/diy.py
+++ b/lib/spack/spack/cmd/diy.py
@@ -7,6 +7,7 @@ import sys
 import os
 import argparse
 
+import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 
 import spack.config
@@ -21,7 +22,7 @@ level = "long"
 
 
 def setup_parser(subparser):
-    arguments.add_common_arguments(subparser, ['jobs'])
+    arguments.add_common_arguments(subparser, ['jobs', 'test', 'overwrite', 'yes_to_all'])
     subparser.add_argument(
         '-d', '--source-path', dest='source_path', default=None,
         help="path to source directory. defaults to the current directory")
@@ -32,10 +33,6 @@ def setup_parser(subparser):
     subparser.add_argument(
         '--keep-prefix', action='store_true',
         help="do not remove the install prefix if installation fails")
-    subparser.add_argument(
-        '--run-tests', action='store_true',
-        help='run package tests during installation'
-    )
     subparser.add_argument(
         '--skip-patch', action='store_true',
         help="skip patching for the DIY build")
@@ -63,6 +60,11 @@ def diy(self, args):
         tty.die("spack diy only takes one spec.")
 
     spec = specs[0]
+    tests = False
+    if args.test == 'all':
+        tests = True
+    elif args.test == 'root':
+        tests = [spec.name]
     if not spack.repo.path.exists(spec.name):
         tty.die("No package for '{0}' was found.".format(spec.name),
                 "  Use `spack create` to create a new package")
@@ -75,11 +77,6 @@ def diy(self, args):
     spec.concretize()
     package = spack.repo.get(spec)
 
-    if package.installed:
-        tty.error("Already installed in %s" % package.prefix)
-        tty.msg("Uninstall or try adding a version suffix for this DIY build.")
-        sys.exit(1)
-
     source_path = args.source_path
     if source_path is None:
         source_path = os.getcwd()
@@ -89,14 +86,45 @@ def diy(self, args):
     package.stage = DIYStage(source_path)
 
     # disable checksumming if requested
-    if args.no_checksum:
+    if args.no_checksum or args.yes_to_all:
         spack.config.set('config:checksum', False, scope='command_line')
 
-    package.do_install(
+    kwargs = dict(
         make_jobs=args.jobs,
         keep_prefix=args.keep_prefix,
         install_deps=not args.ignore_deps,
         verbose=not args.quiet,
         keep_stage=True,   # don't remove source dir for DIY.
-        tests=args.run_tests,
+        tests=tests,
         dirty=args.dirty)
+
+    if args.overwrite:
+        assert package.installed, "to overwrite a spec you must install it first"
+
+        # Give the user a last chance to think about overwriting an already
+        # existing installation
+        if not args.yes_to_all:
+            tty.msg('The following package will be reinstalled:\n')
+
+            display_args = {
+                'long': True,
+                'show_flags': True,
+                'variants': True
+            }
+
+            t = spack.store.db.query(spec)
+            spack.cmd.display_specs(t, **display_args)
+            answer = tty.get_yes_or_no(
+                'Do you want to proceed?', default=False
+            )
+            if not answer:
+                tty.die('Reinstallation aborted.')
+
+        with fs.replace_directory_transaction(spec.prefix):
+            package.do_install(**kwargs)
+    elif package.installed:
+        tty.error("Already installed in %s" % package.prefix)
+        tty.msg("Uninstall or try adding a version suffix for this DIY build.")
+        sys.exit(1)
+    else:
+        package.do_install(**kwargs)

--- a/lib/spack/spack/cmd/diy.py
+++ b/lib/spack/spack/cmd/diy.py
@@ -33,6 +33,10 @@ def setup_parser(subparser):
         '--keep-prefix', action='store_true',
         help="do not remove the install prefix if installation fails")
     subparser.add_argument(
+        '--run-tests', action='store_true',
+        help='run package tests during installation'
+    )
+    subparser.add_argument(
         '--skip-patch', action='store_true',
         help="skip patching for the DIY build")
     subparser.add_argument(
@@ -94,4 +98,5 @@ def diy(self, args):
         install_deps=not args.ignore_deps,
         verbose=not args.quiet,
         keep_stage=True,   # don't remove source dir for DIY.
+        tests=args.run_tests,
         dirty=args.dirty)

--- a/lib/spack/spack/cmd/diy.py
+++ b/lib/spack/spack/cmd/diy.py
@@ -22,7 +22,10 @@ level = "long"
 
 
 def setup_parser(subparser):
-    arguments.add_common_arguments(subparser, ['jobs', 'test', 'overwrite', 'yes_to_all'])
+    arguments.add_common_arguments(subparser, ['jobs',
+                                               'test',
+                                               'overwrite',
+                                               'yes_to_all'])
     subparser.add_argument(
         '-d', '--source-path', dest='source_path', default=None,
         help="path to source directory. defaults to the current directory")
@@ -120,7 +123,8 @@ def diy(self, args):
                 package.do_install(**kwargs)
         else:
             tty.error("Already installed in %s" % package.prefix)
-            tty.msg("Uninstall or try adding a version suffix for this DIY build.")
+            tty.msg("Uninstall or try adding a version suffix for "
+                    "this DIY build.")
             sys.exit(1)
             # Give the user a last chance to think about overwriting an already
             # existing installation

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -61,10 +61,8 @@ the default is to install the package along with all its dependencies.
 alternatively one can decide to install only the package or only
 the dependencies"""
     )
-    arguments.add_common_arguments(subparser, ['jobs', 'install_status'])
-    subparser.add_argument(
-        '--overwrite', action='store_true',
-        help="reinstall an existing spec, even if it has dependents")
+    arguments.add_common_arguments(subparser,
+                                   ['jobs', 'install_status', 'overwrite'])
     subparser.add_argument(
         '--keep-prefix', action='store_true',
         help="don't remove the install prefix if installation fails")
@@ -113,14 +111,7 @@ the dependencies"""
         help="spec of the package to install"
     )
     testing = subparser.add_mutually_exclusive_group()
-    testing.add_argument(
-        '--test', default=None,
-        choices=['root', 'all'],
-        help="""If 'root' is chosen, run package tests during
-installation for top-level packages (but skip tests for dependencies).
-if 'all' is chosen, run package tests during installation for all
-packages. If neither are chosen, don't run tests for any packages."""
-    )
+    arguments.add_common_arguments(testing, ['test'])
     testing.add_argument(
         '--run-tests', action='store_true',
         help='run package tests during installation (same as --test=all)'


### PR DESCRIPTION
Attempt more feature parity with `install`. We use this in CI, installing from the appropriate source directory.