### PR TITLE
Packages/zoltan

### DIFF
--- a/var/spack/repos/builtin/packages/zoltan/notparallel.patch
+++ b/var/spack/repos/builtin/packages/zoltan/notparallel.patch
@@ -1,0 +1,23 @@
+--- a/src/Makefile.in	2013-10-28 14:05:33.000000000 -0600
++++ b/src/Makefile.in	2019-01-23 17:18:00.419423207 -0700
+@@ -3858,6 +3858,9 @@
+ 
+ include $(top_builddir)/Makefile.export.zoltan
+ 
++
++@BUILD_ZOLTAN_F90_INTERFACE_TRUE@.NOTPARALLEL:
++
+ # Tell versions [3.59,3.63) of GNU make to not export all variables.
+ # Otherwise a system limit (for SysV at least) may be exceeded.
+ .NOEXPORT:
+--- a/src/fdriver/Makefile.in	2013-10-28 14:05:33.000000000 -0600
++++ b/src/fdriver/Makefile.in	2019-01-23 17:38:28.024843139 -0700
+@@ -683,6 +683,8 @@
+ 
+ include $(top_builddir)/Makefile.export.zoltan
+ 
++.NOTPARALLEL:
++
+ # Tell versions [3.59,3.63) of GNU make to not export all variables.
+ # Otherwise a system limit (for SysV at least) may be exceeded.
+ .NOEXPORT:

--- a/var/spack/repos/builtin/packages/zoltan/package.py
+++ b/var/spack/repos/builtin/packages/zoltan/package.py
@@ -29,6 +29,8 @@ class Zoltan(Package):
     version('3.6', '9cce794f7241ecd8dbea36c3d7a880f9')
     version('3.3', '5eb8f00bda634b25ceefa0122bd18d65')
 
+    patch('notparallel.patch', when='@3.8')
+
     variant('debug', default=False, description='Builds a debug version of the library.')
     variant('shared', default=True, description='Builds a shared version of the library.')
 


### PR DESCRIPTION
This PR inserts a patch when Zoltan version 3.8 is selected which serializes the F90 interface build.  The _tiny_ patch introduces syntax to 3.8 which was already added to the latest version (3.83) to prevent the same dependency nightmare, thereby enabling version 3.8 to build consistently.