### PR TITLE
py-configparser: bump version (v3.5.1, which fixes backports namespaces issues)

### DIFF
--- a/var/spack/repos/builtin/packages/py-configparser/package.py
+++ b/var/spack/repos/builtin/packages/py-configparser/package.py
@@ -13,6 +13,7 @@ class PyConfigparser(PythonPackage):
     homepage = "https://docs.python.org/3/library/configparser.html"
     url      = "https://pypi.io/packages/source/c/configparser/configparser-3.5.0.tar.gz"
 
+    version('3.5.1', sha256='f41e19cb29bebfccb1a78627b3f328ec198cc8f39510c7c55e7dfc0ab58c8c62')
     version('3.5.0', 'cfdd915a5b7a6c09917a64a573140538')
 
     depends_on('py-setuptools', type='build')


### PR DESCRIPTION
This release includes a fix to clean up how configparser used namespaces.

I can now install `py-flake8`, load the resulting `py-flake8` module, and have a working `flake8` command (this was the failure case in #8343).

Chain of details starts here: https://github.com/jaraco/configparser/pull/22

Closes #8343, #7370

FYI: @healther 