### PR TITLE
py-pybigwig: fix build with python3 and numpy variant

### DIFF
--- a/var/spack/repos/builtin/packages/py-pybigwig/package.py
+++ b/var/spack/repos/builtin/packages/py-pybigwig/package.py
@@ -18,7 +18,7 @@ class PyPybigwig(PythonPackage):
     variant('numpy', default=True,
             description='Enable support for numpy integers and vectors')
 
-    patch('python3_curl.patch', when='@:0.3.12')
+    patch('python3_curl.patch', when='@:0.3.12 ^python@3:')
 
     depends_on('curl', type=('build', 'run'))
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-pybigwig/package.py
+++ b/var/spack/repos/builtin/packages/py-pybigwig/package.py
@@ -12,7 +12,15 @@ class PyPybigwig(PythonPackage):
     homepage = "https://pypi.python.org/pypi/pyBigWig"
     url      = "https://pypi.io/packages/source/p/pyBigWig/pyBigWig-0.3.4.tar.gz"
 
-    version('0.3.4', '8e0a91e26e87eeaa071408a3a749bfa9')
+    version('0.3.12', sha256='e01991790ece496bf6d3f00778dcfb136dd9ca0fd28acc1b3fb43051ad9b8403')
+    version('0.3.4',  sha256='8c97a19218023190041c0e426f1544f7a4944a7bb4568faca1d85f1975af9ee2')
 
-    depends_on('py-setuptools', type='build')
+    variant('numpy', default=True,
+            description='Enable support for numpy integers and vectors')
+
+    patch('python3_curl.patch', when='@:0.3.12')
+
     depends_on('curl', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')
+
+    depends_on('py-numpy', type=('build', 'run'), when='+numpy')

--- a/var/spack/repos/builtin/packages/py-pybigwig/python3_curl.patch
+++ b/var/spack/repos/builtin/packages/py-pybigwig/python3_curl.patch
@@ -1,0 +1,16 @@
+diff --git a/setup.py b/setup.py
+index ec31f9b..554a928 100755
+--- a/setup.py
++++ b/setup.py
+@@ -40,9 +40,9 @@ except:
+     defines.append(('NOCURL', None))
+     sys.stderr.write("Either libcurl isn't installed, it didn't come with curl-config, or curl-config isn't in your $PATH. pyBigWig will be installed without support for remote files.\n")
+ 
+-foo = foo.strip().split()
++foo = foo.decode().strip().split()
+ for v in foo:
+-    if(v[0:2] == "-L") :
++    if(v[0:2] == '-L') :
+         additional_libs.append(v[2:])
+ 
+ include_dirs = ['libBigWig', sysconfig.get_config_var("INCLUDEPY")]

--- a/var/spack/repos/builtin/packages/py-pybigwig/python3_curl.patch
+++ b/var/spack/repos/builtin/packages/py-pybigwig/python3_curl.patch
@@ -1,16 +1,13 @@
 diff --git a/setup.py b/setup.py
-index ec31f9b..554a928 100755
+index ec31f9b..02c0320 100755
 --- a/setup.py
 +++ b/setup.py
-@@ -40,9 +40,9 @@ except:
+@@ -40,7 +40,7 @@ except:
      defines.append(('NOCURL', None))
      sys.stderr.write("Either libcurl isn't installed, it didn't come with curl-config, or curl-config isn't in your $PATH. pyBigWig will be installed without support for remote files.\n")
  
 -foo = foo.strip().split()
 +foo = foo.decode().strip().split()
  for v in foo:
--    if(v[0:2] == "-L") :
-+    if(v[0:2] == '-L') :
+     if(v[0:2] == "-L") :
          additional_libs.append(v[2:])
- 
- include_dirs = ['libBigWig', sysconfig.get_config_var("INCLUDEPY")]


### PR DESCRIPTION
* added patch to correctly pick up non-system curl when building with python 3
* added numpy variant
* updated version and checksums