### PR TITLE
dyninst: add patch to work with new boost

### DIFF
--- a/var/spack/repos/builtin/packages/dyninst/package.py
+++ b/var/spack/repos/builtin/packages/dyninst/package.py
@@ -54,6 +54,7 @@ class Dyninst(CMakePackage):
     patch('stat_dysect.patch', when='+stat_dysect')
     patch('stackanalysis_h.patch', when='@9.2.0')
     patch('v9.3.2-auto.patch', when='@9.3.2 %gcc@:4.7.99')
+    patch('tribool.patch', when='@9.3.0:10.0.0 ^boost@1.69:')
 
     # Versions 9.3.x used cotire, but have no knob to turn it off.
     # Cotire has no real use for one-time builds and can break

--- a/var/spack/repos/builtin/packages/dyninst/tribool.patch
+++ b/var/spack/repos/builtin/packages/dyninst/tribool.patch
@@ -1,5 +1,8 @@
-Add explicit casts from boost::tribool to bool.
-This was breaking the build when using boost >= 1.69.
+Add explicit casts from boost::tribool to bool.  Starting with 1.69,
+tribool added 'explicit' to the conversion operator to bool, and this
+was breaking the build when using boost >= 1.69.
+
+Patch is from:  https://github.com/dyninst/dyninst/commit/54a2debd9
 
 
 diff --git a/dataflowAPI/rose/util/Message.C b/dataflowAPI/rose/util/Message.C

--- a/var/spack/repos/builtin/packages/dyninst/tribool.patch
+++ b/var/spack/repos/builtin/packages/dyninst/tribool.patch
@@ -1,0 +1,31 @@
+Add explicit casts from boost::tribool to bool.
+This was breaking the build when using boost >= 1.69.
+
+
+diff --git a/dataflowAPI/rose/util/Message.C b/dataflowAPI/rose/util/Message.C
+index a8a66ad4c..5e276f97d 100644
+--- a/dataflowAPI/rose/util/Message.C
++++ b/dataflowAPI/rose/util/Message.C
+@@ -1123,7 +1123,7 @@ StreamBuf::bake() {
+         destination_->bakeDestinations(message_.properties(), baked_/*out*/);
+         anyUnbuffered_ = false;
+         for (BakedDestinations::const_iterator bi=baked_.begin(); bi!=baked_.end() && !anyUnbuffered_; ++bi)
+-            anyUnbuffered_ = !bi->second.isBuffered;
++            anyUnbuffered_ = static_cast<bool>(!bi->second.isBuffered);
+         isBaked_ = true;
+     }
+ }
+diff --git a/dataflowAPI/rose/util/Message.h b/dataflowAPI/rose/util/Message.h
+index 816f68d2e..03592cb97 100644
+--- a/dataflowAPI/rose/util/Message.h
++++ b/dataflowAPI/rose/util/Message.h
+@@ -386,7 +386,8 @@ struct SAWYER_EXPORT ColorSpec {
+     ColorSpec(AnsiColor fg, AnsiColor bg, bool bold): foreground(fg), background(bg), bold(bold) {}
+ 
+     /** Returns true if this object is in its default-constructed state. */
+-    bool isDefault() const { return COLOR_DEFAULT==foreground && COLOR_DEFAULT==background && !bold; }
++    bool isDefault() const { return COLOR_DEFAULT==foreground && COLOR_DEFAULT==background
++                                    && static_cast<bool>(!bold); }
+ };
+ 
+ /** Colors to use for each message importance.


### PR DESCRIPTION
Add tribool.patch to add explicit casts from tribool to bool in two
places.  Boost, starting with version 1.69, turned on explicit
conversions for tribool, which breaks the build for dyninst.

----------

The purpose of this PR is to allow dyninst 9.3.x and 10.0.0 to work
with the latest boost >= 1.69.

Also, probably within a week, I expect dyninst 10.1.0 to be released.
10.1 will include the patch.

My plan is to wait for 10.1 to be tagged and released and fold that
into this PR.  It's a 1-line change to add version 10.1.0 and I could
add that line now.  (I know what the tag will be.)  We just have wait
until the tag exists before merging the PR.

I'm leaning in favor of waiting, but we could do two commits if the
release is delayed.  Either way.

ping @hainest from dyninst