### PR TITLE
bedops: avoid static linking with glibc

### DIFF
--- a/var/spack/repos/builtin/packages/bedops/package.py
+++ b/var/spack/repos/builtin/packages/bedops/package.py
@@ -19,6 +19,11 @@ class Bedops(MakefilePackage):
     version('2.4.34', 'fc467d96134a0efe8b134e638af87a1a')
     version('2.4.30', '4e5d9f7b7e5432b28aef8d17a22cffab')
 
+    @property
+    def build_targets(self):
+        # avoid static linking with glibc for all invocations
+        return ['SFLAGS=']
+
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
         make('install', "BINDIR=%s" % prefix.bin)


### PR DESCRIPTION
by default bedops will try and statically link with stdc++; this patches the package to dynamically link instead