### PR TITLE
meson: add 0.49.1 and disable rpath stripping

### DIFF
--- a/var/spack/repos/builtin/packages/meson/package.py
+++ b/var/spack/repos/builtin/packages/meson/package.py
@@ -14,6 +14,7 @@ class Meson(PythonPackage):
     homepage = "http://mesonbuild.com/"
     url      = "https://github.com/mesonbuild/meson/archive/0.49.0.tar.gz"
 
+    version('0.49.1', sha256='a944e7f25a2bc8e4ba3502ab5835d8a8b8f2530415c9d6fcffb53e0abaea2ced')
     version('0.49.0', sha256='11bc959e7173e714e4a4e85dd2bd9d0149b0a51c8ba82d5f44cc63735f603c74')
     version('0.42.0', '9e26bf154ca439b78b1b9366c8a89437')
     version('0.41.2', 'aa9c69ced965e47f5c75a9257ee91ce3')
@@ -24,3 +25,8 @@ class Meson(PythonPackage):
     depends_on('python@3:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
     depends_on('ninja', when='+ninjabuild', type=('build', 'run'))
+
+    # By default, Meson strips the rpath on installation. This patch disables
+    # rpath modification completely to make sure that Spack's rpath changes
+    # are not reverted.
+    patch('rpath.patch', when='@0.49:')

--- a/var/spack/repos/builtin/packages/meson/rpath.patch
+++ b/var/spack/repos/builtin/packages/meson/rpath.patch
@@ -1,0 +1,11 @@
+diff -ru meson-0.49.1.orig/mesonbuild/scripts/depfixer.py meson-0.49.1/mesonbuild/scripts/depfixer.py
+--- meson-0.49.1.orig/mesonbuild/scripts/depfixer.py	2019-01-23 17:46:50.000000000 +0100
++++ meson-0.49.1/mesonbuild/scripts/depfixer.py	2019-01-29 14:38:45.590583458 +0100
+@@ -429,6 +429,7 @@
+     subprocess.check_call(['jar', 'ufm', fname, 'META-INF/MANIFEST.MF'])
+ 
+ def fix_rpath(fname, new_rpath, final_path, install_name_mappings, verbose=True):
++    return
+     # Static libraries never have rpaths
+     if fname.endswith('.a'):
+         return


### PR DESCRIPTION
rpath stripping breaks (at least) the gtkplus build because at-spi2-atk's dependencies can not be found.