### PR TITLE
Add Open MPI 2.1.6

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -77,6 +77,7 @@ class Openmpi(AutotoolsPackage):
     version('3.0.1', sha256='663450d1ee7838b03644507e8a76edfb1fba23e601e9e0b5b2a738e54acd785d')  # libmpi.so.40.00.1
     version('3.0.0', sha256='f699bff21db0125d8cccfe79518b77641cd83628725a1e1ed3e45633496a82d7')  # libmpi.so.40.00.0
 
+    version('2.1.6', sha256='98b8e1b8597bbec586a0da79fcd54a405388190247aa04d48e8c40944d4ca86e')  # libmpi.20.20.10.3
     version('2.1.5', sha256='b807ccab801f27c3159a5edf29051cd3331d3792648919f9c4cee48e987e7794')  # libmpi.so.20.10.3
     version('2.1.4', sha256='3e03695ca8bd663bc2d89eda343c92bb3d4fc79126b178f5ddcb68a8796b24e2')  # libmpi.so.20.10.3
     version('2.1.3', sha256='285b3e2a69ed670415524474496043ecc61498f2c63feb48575f8469354d79e8')  # libmpi.so.20.10.2


### PR DESCRIPTION
Verification builds, LANL Darwin:

Intel Xeon
[+] /scratch/users/dantopa/new-spack/spack.pr.open-mpi-2.16/opt/spack/linux-centos7-x86_64/gcc-8.2.0/openmpi-2.1.6-dbgnmvjmaxz2f3qfhu7eveybihyw3iu6

ARM
[+] /scratch/users/dantopa/new-spack/spack.pr.open-mpi-2.16/opt/spack/linux-rhel7-aarch64/gcc-4.8.5/openmpi-2.1.6-pbveyqpfwzgunlip3xs6imuiv3hjnhel

Power9
[+] /scratch/users/dantopa/new-spack/spack.pr.open-mpi-2.16/opt/spack/linux-rhel7-ppc64le/gcc-4.8.5/openmpi-2.1.6-nva7q77c7b6ccjcyzczo7amg2da2u7ih

Signed-off-by: Daniel Topa <dantopa@lanl.gov>