### PR TITLE
libsodium: Updates source URL.

### DIFF
--- a/var/spack/repos/builtin/packages/libsodium/package.py
+++ b/var/spack/repos/builtin/packages/libsodium/package.py
@@ -28,6 +28,6 @@ class Libsodium(AutotoolsPackage):
         url = 'https://download.libsodium.org/libsodium/releases/'
         if version < Version('1.0.4'):
             url += 'old/unsupported/'
-        elif version < Version('1.0.12'):
+        elif version < Version('1.0.16'):
             url += 'old/'
         return url + 'libsodium-{0}.tar.gz'.format(version)


### PR DESCRIPTION
The source URL for versions 1.0.15 and older is updated to reflect where
those archives are now hosted by the upstream libsodium developers.

While two new releases of libsodium are available,

```
version('1.0.17', sha256='0cc3dae33e642cc187b5ceb467e0ad0e1b51dcba577de1190e9ffa17766ac2b1')
version('1.0.16', sha256='eeadc7e1e1bcef09680fb4837d448fbdf57224978f865ac1c16745868fbd0533')
```

This commit does not attempt to add them to the spack package since the
author has not tested them nor checked for other packages that might be
affected. This simply updates the location of the source archives during
the "fetch" stage of installation.