### PR TITLE
mafft: update to latest version

### DIFF
--- a/var/spack/repos/builtin/packages/mafft/package.py
+++ b/var/spack/repos/builtin/packages/mafft/package.py
@@ -15,6 +15,7 @@ class Mafft(Package):
     homepage = "http://mafft.cbrc.jp/alignment/software/index.html"
     url      = "http://mafft.cbrc.jp/alignment/software/mafft-7.221-with-extensions-src.tgz"
 
+    version('7.407', sha256='1840b51a0b93f40b4d6076af996ee46396428d8dbaf7ba1d847abff9cb1463e5')
     version('7.221', 'b1aad911e51024d631722a2e061ba215')
 
     def install(self, spec, prefix):


### PR DESCRIPTION
* updated mafft to v7.407 (release date 2018-07-23).
* previous version v7.221 was very old (2015-04-16)

Build was tested with gcc-8.2.0 on Centos 7, kernel 3.10.0-957.1.3.el7.x86_64
