### PR TITLE
openmpi: fixes a case of build failure with pmi=True

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -251,6 +251,7 @@ class Openmpi(AutotoolsPackage):
     depends_on('ucx', when='fabrics=ucx')
     depends_on('libfabric', when='fabrics=libfabric')
     depends_on('slurm', when='schedulers=slurm')
+    depends_on('pmix', when='schedulers=slurm')
     depends_on('binutils+libiberty', when='fabrics=mxm')
 
     conflicts('+cuda', when='@:1.6')  # CUDA support was added in 1.7
@@ -372,7 +373,7 @@ class Openmpi(AutotoolsPackage):
         # for versions older than 3.0.3,3.1.3,4.0.0
         # Presumably future versions after 11/2018 should support slurm+static
         if spec.satisfies('schedulers=slurm'):
-            config_args.append('--with-pmi={0}'.format(spec['slurm'].prefix))
+            config_args.append('--with-pmi={0}'.format(spec['pmix'].prefix))
             if spec.satisfies('@3.1.3:') or spec.satisfies('@3.0.3'):
                 config_args.append('--enable-static')
         else:


### PR DESCRIPTION
When in the `configure` phase, openmpi will search in slurm's 18-08-0-1 `/lib` directory
for a shared library named pmi or pmi2 due to the option `--with-pmi=$slurm_prefix` and finds nothing.
This commit adds **pmix** as a dependency and changes the value of the `--with-pmi` option to `$pmix_prefix`.

PS: I'm aware that pmi/pmi2 are not exactly the same thing as pmix,
but they are compatible enough to give the user a working openmpi install.