### PR TITLE
Fix 'make test' detection when LANG is not in English

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1139,7 +1139,10 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         Returns:
             bool: True if 'target' is found, else False
         """
-        make = inspect.getmodule(self).make
+        make = copy.deepcopy(inspect.getmodule(self).make)
+
+        # Use English locale for missing target message comparison
+        make.add_default_env('LC_ALL', 'C')
 
         # Check if we have a Makefile
         for makefile in ['GNUmakefile', 'Makefile', 'makefile']:

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1139,6 +1139,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         Returns:
             bool: True if 'target' is found, else False
         """
+        # Prevent altering LC_ALL for 'make' outside this function
         make = copy.deepcopy(inspect.getmodule(self).make)
 
         # Use English locale for missing target message comparison


### PR DESCRIPTION
Fixes #10487.

@weidendo can you test this?

We need to be careful here, as `config.yaml` provides a `build_language` setting that we don't want to overwrite.