### PR TITLE
WIP: Adding missing paths to PYTHONPATH for Paraview > 5.4

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -127,9 +127,12 @@ class Paraview(CMakePackage):
                 run_env.prepend_path('PYTHONPATH', join_path(pv_pydir, 'vtk'))
             else:
                 python_version = self.spec['python'].version.up_to(2)
-                run_env.prepend_path('PYTHONPATH', join_path(lib_dir,
+                pv_pydir = join_path(lib_dir,
                                      'python{0}'.format(python_version),
-                                     'site-packages'))
+                                     'site-packages')
+                run_env.prepend_path('PYTHONPATH', pv_pydir)
+                run_env.prepend_path('PYTHONPATH', join_path(pv_pydir, 'vtkmodules'))
+                run_env.prepend_path('PYTHONPATH', join_path(pv_pydir, 'paraview'))
 
     def cmake_args(self):
         """Populate cmake arguments for ParaView."""

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -133,8 +133,6 @@ class Paraview(CMakePackage):
                 run_env.prepend_path('PYTHONPATH', pv_pydir)
                 run_env.prepend_path('PYTHONPATH', join_path(pv_pydir,
                                                              'vtkmodules'))
-                run_env.prepend_path('PYTHONPATH', join_path(pv_pydir,
-                                                             'paraview'))
 
     def cmake_args(self):
         """Populate cmake arguments for ParaView."""

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -131,6 +131,8 @@ class Paraview(CMakePackage):
                                      'python{0}'.format(python_version),
                                      'site-packages')
                 run_env.prepend_path('PYTHONPATH', pv_pydir)
+                # The Trilinos Catalyst adapter requires
+                # the vtkmodules directory in PYTHONPATH
                 run_env.prepend_path('PYTHONPATH', join_path(pv_pydir,
                                                              'vtkmodules'))
 

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -131,8 +131,10 @@ class Paraview(CMakePackage):
                                      'python{0}'.format(python_version),
                                      'site-packages')
                 run_env.prepend_path('PYTHONPATH', pv_pydir)
-                run_env.prepend_path('PYTHONPATH', join_path(pv_pydir, 'vtkmodules'))
-                run_env.prepend_path('PYTHONPATH', join_path(pv_pydir, 'paraview'))
+                run_env.prepend_path('PYTHONPATH', join_path(pv_pydir,
+                                                             'vtkmodules'))
+                run_env.prepend_path('PYTHONPATH', join_path(pv_pydir,
+                                                             'paraview'))
 
     def cmake_args(self):
         """Populate cmake arguments for ParaView."""


### PR DESCRIPTION
I just realized the `vtkmodules` directory was missing from `PYTHONPATH` here. I need this to be able to use the Trilinos Catalyst adapter. @sbna @DarylGrunau 