### PR TITLE
mirdeep2: make sure bins are executable

### DIFF
--- a/var/spack/repos/builtin/packages/mirdeep2/package.py
+++ b/var/spack/repos/builtin/packages/mirdeep2/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from os import chmod
 import glob
 
 
@@ -31,6 +32,7 @@ class Mirdeep2(Package):
         with working_dir('src'):
             files = glob.iglob("*.pl")
             for file in files:
+                chmod(file, 0755)
                 change = FileFilter(file)
                 change.filter('usr/bin/perl', 'usr/bin/env perl')
                 change.filter('perl -W', 'perl')

--- a/var/spack/repos/builtin/packages/mirdeep2/package.py
+++ b/var/spack/repos/builtin/packages/mirdeep2/package.py
@@ -32,7 +32,7 @@ class Mirdeep2(Package):
         with working_dir('src'):
             files = glob.iglob("*.pl")
             for file in files:
-                chmod(file, 0755)
+                chmod(file, 0o755)
                 change = FileFilter(file)
                 change.filter('usr/bin/perl', 'usr/bin/env perl')
                 change.filter('perl -W', 'perl')


### PR DESCRIPTION
many of the perl scripts installed to bin had incorrect permissions; explicitly performs chmod before installing