### PR TITLE
libarchive: remove lzma dependency

### DIFF
--- a/var/spack/repos/builtin/packages/libarchive/package.py
+++ b/var/spack/repos/builtin/packages/libarchive/package.py
@@ -21,7 +21,6 @@ class Libarchive(AutotoolsPackage):
 
     depends_on('zlib')
     depends_on('bzip2')
-    depends_on('lzma')
     depends_on('lz4')
     depends_on('xz')
     depends_on('lzo')


### PR DESCRIPTION
lzma was last updated in 2008 and has compilation
issues on some platforms. The format has been superceded
by xz (see e.g. https://tukaani.org/xz/).