### PR TITLE
Add Python 3.7.2 updated

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -29,7 +29,12 @@ class Python(AutotoolsPackage):
     list_url = "https://www.python.org/downloads/"
     list_depth = 1
 
-    version('3.7.0', '41b6595deb4147a1ed517a7d9a580271')
+    version('3.7.2',  sha256='f09d83c773b9cc72421abba2c317e4e6e05d919f9bcf34468e192b6a6c8e328d')
+    version('3.7.1',  sha256='36c1b81ac29d0f8341f727ef40864d99d8206897be96be73dc34d4739c9c9f06')
+    version('3.7.0',  '41b6595deb4147a1ed517a7d9a580271')
+    version('3.6.8',  sha256='7f5b1f08b3b0a595387ef6c64c85b1b13b38abef0dd871835ee923262e4f32f0')
+    version('3.6.7',  sha256='b7c36f7ed8f7143b2c46153b7332db2227669f583ea0cce753facf549d1a4239')
+    version('3.6.6',  sha256='7d56dadf6c7d92a238702389e80cfe66fbfae73e584189ed6f89c75bbf3eda58')
     version('3.6.5', 'ab25d24b1f8cc4990ade979f6dc37883')
     version('3.6.4', '9de6494314ea199e3633211696735f65')
     version('3.6.3', 'e9180c69ed9a878a4a8a3ab221e32fa9')


### PR DESCRIPTION
Also add versions 3.7.1, 3.6.8, 3.6.7, 3.6.6. Does NOT alter preferred version (2.7.15).

Supplants PR "Add Python 3.7.2" (https://github.com/spack/spack/pull/10491).

Verification builds on LANL Darwin:

**Intel Xeon**
```
[+] /scratch/users/dantopa/new-spack/pr.new.python-3.7.2/general/opt/spack/linux-centos7-x86_64/gcc-4.8.5/python-3.7.2-d3p7vg6w2r563cpmwsmbgjbsiqc4j4fq
[+] /scratch/users/dantopa/new-spack/pr.new.python-3.7.2/general/opt/spack/linux-centos7-x86_64/gcc-4.8.5/python-3.7.1-ibom6qj2z64egyaqz5htkwp5tr362il6
[+] /scratch/users/dantopa/new-spack/pr.new.python-3.7.2/general/opt/spack/linux-centos7-x86_64/gcc-4.8.5/python-3.6.8-rkifc3c7mjgdglw27upiap767ut4wpkz
[+] /scratch/users/dantopa/new-spack/pr.new.python-3.7.2/general/opt/spack/linux-centos7-x86_64/gcc-4.8.5/python-3.6.7-meuesn43twttt756exyzqgdhohjgipjq
[+] /scratch/users/dantopa/new-spack/pr.new.python-3.7.2/general/opt/spack/linux-centos7-x86_64/gcc-4.8.5/python-3.6.6-qwnwme7otyuoqqudcglfmfy75t5npywl
```

**Arm**
```
[+] /scratch/users/dantopa/new-spack/pr.new.python-3.7.2/arm/opt/spack/linux-rhel7-aarch64/gcc-4.8.5/python-3.7.2-qj27kzs4ttdqudm3hsi3pt57kv7lshco
[+] /scratch/users/dantopa/new-spack/pr.new.python-3.7.2/arm/opt/spack/linux-rhel7-aarch64/gcc-4.8.5/python-3.7.1-io5eneirgvpegy3tosvp6wq5ndf7yjis
[+] /scratch/users/dantopa/new-spack/pr.new.python-3.7.2/arm/opt/spack/linux-rhel7-aarch64/gcc-4.8.5/python-3.6.8-ej3vnvta2hbtrh7p5hokfqkuewxeqgsa
[+] /scratch/users/dantopa/new-spack/pr.new.python-3.7.2/arm/opt/spack/linux-rhel7-aarch64/gcc-4.8.5/python-3.6.7-l3qnue72ewppn2wxza3w6l62l7ijlque
[+] /scratch/users/dantopa/new-spack/pr.new.python-3.7.2/arm/opt/spack/linux-rhel7-aarch64/gcc-4.8.5/python-3.6.6-b55pdoqsr5bie4k5djd4vokm3nywhm45
```

**Power9**
```
[+] /scratch/users/dantopa/new-spack/pr.new.python-3.7.2/power9/opt/spack/linux-rhel7-ppc64le/gcc-4.8.5/python-3.7.2-cicayvl7ki4tswoqlljsmcetwqcnoh3x
[+] /scratch/users/dantopa/new-spack/pr.new.python-3.7.2/power9/opt/spack/linux-rhel7-ppc64le/gcc-4.8.5/python-3.7.1-7vej3zvnvyj2jvz5lnxhnts3ok2fcxbp
[+] /scratch/users/dantopa/new-spack/pr.new.python-3.7.2/power9/opt/spack/linux-rhel7-ppc64le/gcc-4.8.5/python-3.6.8-xijljmdanyrybcx2rv65qshycmbrfv6c
[+] /scratch/users/dantopa/new-spack/pr.new.python-3.7.2/power9/opt/spack/linux-rhel7-ppc64le/gcc-4.8.5/python-3.6.7-vqdhzg7c3xxxregqmzxsqqfzxt2hajvq
[+] /scratch/users/dantopa/new-spack/pr.new.python-3.7.2/power9/opt/spack/linux-rhel7-ppc64le/gcc-4.8.5/python-3.6.6-jf4bnsdwk3qjhtmvjjhblnrcz5dztfdq
```

2019-02-06
Signed-off-by: Daniel Topa <dantopa@lanl.gov>
