### PR TITLE
try to workaround an issue with docker/dockerhub

### DIFF
--- a/share/spack/qa/run-docker-tests
+++ b/share/spack/qa/run-docker-tests
@@ -21,15 +21,20 @@ ensure_docker_login() {
         return $__login_success
     fi
 
-    # NOTE: work around an issue with docker/docker hub
-    # https://github.com/docker/hub-feedback/issues/1222
-    # https://github.com/docker/cli/issues/1180
-    rm -f $HOME/.docker/config.json
+    if [ "$CI" '=' 'true' -a "$TRAVIS" '=' 'true' ] ; then
+        # NOTE: work around an issue with docker/docker hub
+        # https://github.com/docker/hub-feedback/issues/1222
+        # https://github.com/docker/cli/issues/1180
+        rm -f $HOME/.docker/config.json
+    fi
 
     echo "$DOCKER_PASSWORD" | \
         docker login -u "$DOCKER_USERNAME" --password-stdin
 
-    if [ '!' -f $HOME/.docker/config.json ] ; then
+    if [ "$CI" '=' 'true' -a \
+         "$TRAVIS" '=' 'true' -a \
+         '!' -f "$HOME/.docker/config.json" ]
+    then
         echo "Warning: config file $HOME/.docker/config.json not created" >&2
     fi
 

--- a/share/spack/qa/run-docker-tests
+++ b/share/spack/qa/run-docker-tests
@@ -21,8 +21,17 @@ ensure_docker_login() {
         return $__login_success
     fi
 
+    # NOTE: work around an issue with docker/docker hub
+    # https://github.com/docker/hub-feedback/issues/1222
+    # https://github.com/docker/cli/issues/1180
+    rm -f $HOME/.docker/config.json
+
     echo "$DOCKER_PASSWORD" | \
         docker login -u "$DOCKER_USERNAME" --password-stdin
+
+    if [ '!' -f $HOME/.docker/config.json ] ; then
+        echo "Warning: config file $HOME/.docker/config.json not created" >&2
+    fi
 
     if [ $? '=' '0' ] ; then
           __login_success=0


### PR DESCRIPTION
Checking the latest build log, it looks like everything docker-related is working, except for what seems to be an issue with docker/dockerhub

See the end of this build log -- docker reports successful log in, but then fails to authenticate at push time:
https://api.travis-ci.org/v3/job/490096345/log.txt

Here are two (among many) github issues describing the problem:
https://github.com/docker/cli/issues/1180
https://github.com/docker/hub-feedback/issues/1222

This PR implements a fix suggested in a comment:
https://github.com/docker/hub-feedback/issues/1222#issuecomment-459390746