### PR TITLE
bug report template: suggest --stacktrace instead of -s

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,10 +24,10 @@ If Spack reported an error, provide the error message. If it did not report an e
 but the output appears incorrect, provide the incorrect output. If there was no error
 message and no output but the result is incorrect, describe how it does not match
 what you expect. To provide more information you might re-run the commands with 
-the additional -sd flags:
+the additional -d/--stacktrace flags:
 ```console
-$ spack -sd <command1> <spec>
-$ spack -sd <command2> <spec>
+$ spack -d --stacktrace <command1> <spec>
+$ spack -d --stacktrace <command2> <spec>
 ...
 ```
 that activate the full debug output. 


### PR DESCRIPTION
See: https://github.com/spack/spack/issues/10544

https://github.com/spack/spack/commit/1137b183e32aae467b08be36d7223172d5d01337 removed the `-s` option from `spack` such that to see a stack trace you must pass the `--stacktrace` option. The bug report templates were not updated accordingly.
