### PR TITLE
Download GNU packages from mirrors (Part 2)

### DIFF
--- a/var/spack/repos/builtin/packages/diffutils/package.py
+++ b/var/spack/repos/builtin/packages/diffutils/package.py
@@ -11,7 +11,7 @@ class Diffutils(AutotoolsPackage):
     differences between files."""
 
     homepage = "https://www.gnu.org/software/diffutils/"
-    url      = "https://ftp.gnu.org/gnu/diffutils/diffutils-3.6.tar.xz"
+    url      = "https://ftpmirror.gnu.org/diffutils/diffutils-3.7.tar.xz"
 
     version('3.7', sha256='b3a7a6221c3dc916085f0d205abf6b8e1ba443d4dd965118da364a1dc1cb3a26')
     version('3.6', sha256='d621e8bdd4b573918c8145f7ae61817d1be9deb4c8d2328a65cea8e11d783bd6')

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -181,7 +181,7 @@ class Gcc(AutotoolsPackage):
     build_directory = 'spack-build'
 
     def url_for_version(self, version):
-        url = 'http://ftp.gnu.org/gnu/gcc/gcc-{0}/gcc-{0}.tar.{1}'
+        url = 'https://ftpmirror.gnu.org/gcc/gcc-{0}/gcc-{0}.tar.{1}'
         suffix = 'xz'
 
         if version < Version('6.4.0') or version == Version('7.1.0'):

--- a/var/spack/repos/builtin/packages/mpc/package.py
+++ b/var/spack/repos/builtin/packages/mpc/package.py
@@ -29,7 +29,7 @@ class Mpc(AutotoolsPackage):
         if version < Version("1.0.1"):
             url = "http://www.multiprecision.org/mpc/download/mpc-{0}.tar.gz"
         else:
-            url = "https://ftp.gnu.org/gnu/mpc/mpc-{0}.tar.gz"
+            url = "https://ftpmirror.gnu.org/mpc/mpc-{0}.tar.gz"
 
         return url.format(version)
 

--- a/var/spack/repos/builtin/packages/time/package.py
+++ b/var/spack/repos/builtin/packages/time/package.py
@@ -12,7 +12,7 @@ class Time(AutotoolsPackage):
        information about the resources used by that program."""
 
     homepage = "https://www.gnu.org/software/time/"
-    url      = "https://ftp.gnu.org/gnu/time/time-1.9.tar.gz"
+    url      = "https://ftpmirror.gnu.org/time/time-1.9.tar.gz"
 
     version('1.9', sha256='fbacf0c81e62429df3e33bda4cee38756604f18e01d977338e23306a3e3b521e')
 


### PR DESCRIPTION
This is a continuation of #8992.

I wasn't able to download `diffutils` from the previous URL. Switching to a mirror resolved the problem.

Successfully downloaded all 4 packages, and the checksums still match.