### PR TITLE
pythia6: fix input verification issue and example data checksum.

### DIFF
--- a/var/spack/repos/builtin/packages/pythia6/package.py
+++ b/var/spack/repos/builtin/packages/pythia6/package.py
@@ -99,7 +99,7 @@ class Pythia6(CMakePackage):
            'main81.f':
            'b02fecd1cd0f9ba16eaae53e9da0ba602569fdf0e46856cccdfb4c5b7ba33e8b',
            'ttbar.lhe':
-           'fb0d43175cc392b19c2b6633dcf673d0b56229b60bec92df4aa782c7196b149c'}
+           'db772b69ab4e0300d973b57414523ac8e7fa8535eac49ee52a6b69b1c131983d'}
 
     for example, checksum in iteritems(examples):
         resource(name=example,

--- a/var/spack/repos/builtin/packages/pythia6/package.py
+++ b/var/spack/repos/builtin/packages/pythia6/package.py
@@ -14,8 +14,7 @@ def _is_integral(x):
     """Accepts only integral values."""
     try:
         return isinstance(int(x), numbers.Integral) and \
-            (not isinstance(x, bool)) and \
-            int(x) == x
+            (not isinstance(x, bool))
     except ValueError:
         return False
 


### PR DESCRIPTION
Fix two issues with the pythia6 recipe:
1. The checksum of an ASCII data file downloaded as part of the examples has changed.
1. An upstream change (possibly) has exposed an issue verifying the value of the `NMXHEP` variant parameter.