### PR TITLE
gcc: Fixes overly strict handling of pointers with(out) noncontiguous attribute

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/gfortran-noncontiguous_pointers.patch
+++ b/var/spack/repos/builtin/packages/gcc/gfortran-noncontiguous_pointers.patch
@@ -1,0 +1,89 @@
+[Fortran] Disable "Assignment to contiguous pointer from non-contiguous target" error
+
+2018-XX-YY  Cesar Philippidis  <cesar@codesourcery.com>
+
+	gcc/fortran/
+	* expr.c (gfc_check_pointer_assign): Demote "Assignment to
+	contiguous pointer from non-contiguous target" to a warning.
+
+	gcc/testsuite/
+	* gfortran.dg/contiguous_4.f90: Adjust.
+	* gfortran.dg/contiguous_4.f90: New test.
+---
+ gcc/fortran/expr.c                         |  6 +++---
+ gcc/testsuite/gfortran.dg/contiguous_4.f90 |  6 +++---
+ gcc/testsuite/gfortran.dg/contiguous_7.f90 | 24 ++++++++++++++++++++++++
+ 3 files changed, 30 insertions(+), 6 deletions(-)
+ create mode 100644 gcc/testsuite/gfortran.dg/contiguous_7.f90
+
+diff --git a/gcc/fortran/expr.c b/gcc/fortran/expr.c
+index 3315bb8..1cfda5f 100644
+--- a/gcc/fortran/expr.c    2019-02-11 10:25:28.142708056 -0500
++++ b/gcc/fortran/expr.c    2019-02-11 10:28:08.096736341 -0500
+@@ -3931,12 +3931,11 @@
+      }
+     }
+
+-  /* Error for assignments of contiguous pointers to targets which is not
+-     contiguous.  Be lenient in the definition of what counts as
+-     contiguous.  */
++  /* Warn for assignments of contiguous pointers to targets which is not contiguous.
++   * Be lenient in the definition of what counts as contiguous.  */
+
+   if (lhs_attr.contiguous && !gfc_is_simply_contiguous (rvalue, false, true))
+-    gfc_error ("Assignment to contiguous pointer from non-contiguous "
++    gfc_warning (OPT_Wextra, "Assignment to contiguous pointer from non-contiguous "
+           "target at %L", &rvalue->where);
+
+   /* Warn if it is the LHS pointer may lives longer than the RHS target.  */
+diff --git a/gcc/testsuite/gfortran.dg/contiguous_4.f90 b/gcc/testsuite/gfortran.dg/contiguous_4.f90
+index b05dcfb..874ef8b 100644
+--- a/gcc/testsuite/gfortran.dg/contiguous_4.f90
++++ b/gcc/testsuite/gfortran.dg/contiguous_4.f90
+@@ -10,10 +10,10 @@ program cont_01_neg
+ 
+   x = (/ (real(i),i=1,45) /)
+   x2 = reshape(x,shape(x2))
+-  r => x(::3)   ! { dg-error "Assignment to contiguous pointer" }
+-  r2 => x2(2:,:) ! { dg-error "Assignment to contiguous pointer" }
++  r => x(::3)
++  r2 => x2(2:,:)
+   r2 => x2(:,2:3)
+   r => x2(2:3,1)
+   r => x(::1)
+-  r => x(::n) ! { dg-error "Assignment to contiguous pointer" }
++  r => x(::n)
+ end program
+diff --git a/gcc/testsuite/gfortran.dg/contiguous_7.f90 b/gcc/testsuite/gfortran.dg/contiguous_7.f90
+new file mode 100644
+index 0000000..cccc89f
+--- /dev/null
++++ b/gcc/testsuite/gfortran.dg/contiguous_7.f90
+@@ -0,0 +1,24 @@
++! { dg-do compile }
++! { dg-additional-options "-Wextra" }
++!
++! Ensure that contiguous pointers pointing to noncontiguous pointers
++! to array results in a warning with -Wextra.
++
++program cont_01_neg
++  implicit none
++  real, pointer, contiguous :: r(:)
++  real, pointer, contiguous :: r2(:,:)
++  real, target :: x(45)
++  real, target :: x2(5,9)
++  integer :: i
++  integer :: n=1
++
++  x = (/ (real(i),i=1,45) /)
++  x2 = reshape(x,shape(x2))
++  r => x(::3) ! { dg-warning "ssignment to contiguous pointer from non-contiguous target" }
++  r2 => x2(2:,:) ! { dg-warning "ssignment to contiguous pointer from non-contiguous target" }
++  r2 => x2(:,2:3)
++  r => x2(2:3,1)
++  r => x(::1)
++  r => x(::n) ! { dg-warning "ssignment to contiguous pointer from non-contiguous target" }
++end program
+-- 
+2.7.4
+

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -177,6 +177,19 @@ class Gcc(AutotoolsPackage):
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85835
     patch('sys_ustat.h.patch', when='@5.0:6.4,7.0:7.3,8.1')
     patch('sys_ustat-4.9.patch', when='@4.9')
+    # This patch fixes a case of false-negative invalid code (valid code parsed as invalid)
+    # as described in the links below
+    # The patch itself is in the last-but-one message of the nabble link
+    # It had to be remade, moving 26 lines up to apply cleanly
+    # (Patching the patch anyone?)
+    # http://gcc.1065356.n8.nabble.com/patch-wip-warn-on-noncontiguous-pointers-td1516622.html
+    # https://gcc.gnu.org/ml/fortran/2018-09/msg00210.html
+    # From the dates on the thread and the tentative release date of GCC 8.3,
+    # https://gcc.gnu.org/ml/gcc/2019-02/msg00034.html
+    # I'm guessing that this patch will make it
+    # but could not find the exact bug number in GCC's bugzilla,
+    # so pin to version 8.2 for now
+    patch('gfortran-noncontiguous-pointers.patch', when='@8.2')
 
     build_directory = 'spack-build'
 


### PR DESCRIPTION
While compiling VASP 5.4.4 with gfortran 8.2 it stopped at the `wave.f90` file with the below message:

`Error: Assignment to contiguous pointer from non-contiguous target`

All the gory details are in the `package.py` file.