### PR TITLE
cp2k is now a MakefilePackage

### DIFF
--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -18,10 +18,10 @@ class Cp2k(Package):
     url = 'https://github.com/cp2k/cp2k/releases/download/v3.0.0/cp2k-3.0.tar.bz2'
     list_url = 'https://github.com/cp2k/cp2k/releases'
 
-    version('6.1', '573a4de5a0ee2aaabb213e04543cb10f')
-    version('5.1', 'f25cf301aec471d7059179de4dac3ee7')
-    version('4.1', 'b0534b530592de15ac89828b1541185e')
-    version('3.0', 'c05bc47335f68597a310b1ed75601d35')
+    version('6.1', sha256='af803558e0a6b9e9d9ce8a3ab955ba32bacd179922455424e061c82c9fefa34b')
+    version('5.1', sha256='e23613b593354fa82e0b8410e17d94c607a0b8c6d9b5d843528403ab09904412')
+    version('4.1', sha256='4a3e4a101d8a35ebd80a9e9ecb02697fb8256364f1eccdbe4e5a85d31fe21343')
+    version('3.0', sha256='1acfacef643141045b7cbade7006f9b7538476d861eeecd9658c9e468dc61151')
 
     variant('mpi', default=True, description='Enable MPI support')
     variant('blas', default='openblas', values=('openblas', 'mkl', 'accelerate'),

--- a/var/spack/repos/builtin/packages/libint/package.py
+++ b/var/spack/repos/builtin/packages/libint/package.py
@@ -14,10 +14,13 @@ class Libint(AutotoolsPackage):
     homepage = "https://github.com/evaleev/libint"
     url = "https://github.com/evaleev/libint/archive/v2.1.0.tar.gz"
 
-    version('2.2.0', 'da37dab862fb0b97a7ed7d007695ef47')
-    version('2.1.0', 'd0dcb985fe32ddebc78fe571ce37e2d6')
-    version('1.1.6', '990f67b55f49ecc18f32c58da9240684')
-    version('1.1.5', '379b7d0718ff398715d6898807adf628')
+    version('2.4.2', sha256='86dff38065e69a3a51d15cfdc638f766044cb87e5c6682d960c14f9847e2eac3')
+    version('2.4.1', sha256='0513be124563fdbbc7cd3c7043e221df1bda236a037027ba9343429a27db8ce4')
+    version('2.4.0', sha256='52eb16f065406099dcfaceb12f9a7f7e329c9cfcf6ed9bfacb0cff7431dd6019')
+    version('2.2.0', sha256='f737d485f33ac819d7f28c6ce303b1f3a2296bfd2c14f7c1323f8c5d370bb0e3')
+    version('2.1.0', sha256='43c453a1663aa1c55294df89ff9ece3aefc8d1bbba5ea31dbfe71b2d812e24c8')
+    version('1.1.6', sha256='f201b0c621df678cfe8bdf3990796b8976ff194aba357ae398f2f29b0e2985a6')
+    version('1.1.5', sha256='ec8cd4a4ba1e1a98230165210c293632372f0e573acd878ed62e5ec6f8b6174b')
 
     # Build dependencies
     depends_on('autoconf@2.52:', type='build')

--- a/var/spack/repos/builtin/packages/libxc/package.py
+++ b/var/spack/repos/builtin/packages/libxc/package.py
@@ -13,10 +13,11 @@ class Libxc(AutotoolsPackage):
     homepage = "http://www.tddft.org/programs/octopus/wiki/index.php/Libxc"
     url      = "http://www.tddft.org/programs/octopus/down.php?file=libxc/libxc-2.2.2.tar.gz"
 
-    version('4.2.3', '6176ac7edf234425d973903f82199350')
-    version('3.0.0', '8227fa3053f8fc215bd9d7b0d36de03c')
-    version('2.2.2', 'd9f90a0d6e36df6c1312b6422280f2ec')
-    version('2.2.1', '38dc3a067524baf4f8521d5bb1cd0b8f')
+    version('4.3.2', sha256='bc159aea2537521998c7fb1199789e1be71e04c4b7758d58282622e347603a6f')
+    version('4.2.3', sha256='02e49e9ba7d21d18df17e9e57eae861e6ce05e65e966e1e832475aa09e344256')
+    version('3.0.0', sha256='5542b99042c09b2925f2e3700d769cda4fb411b476d446c833ea28c6bfa8792a')
+    version('2.2.2', sha256='6ca1d0bb5fdc341d59960707bc67f23ad54de8a6018e19e02eee2b16ea7cc642')
+    version('2.2.1', sha256='ade61c1fa4ed238edd56408fd8ee6c2e305a3d5753e160017e2a71817c98fd00')
 
     def url_for_version(self, version):
         if version < Version('3.0.0'):

--- a/var/spack/repos/builtin/packages/plumed/package.py
+++ b/var/spack/repos/builtin/packages/plumed/package.py
@@ -4,8 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import collections
-
-from spack import *
+import os.path
 
 
 class Plumed(AutotoolsPackage):
@@ -80,7 +79,7 @@ class Plumed(AutotoolsPackage):
 
         # Get available patches
         plumed_patch = Executable(
-            join_path(self.spec.prefix.bin, 'plumed-patch')
+            os.path.join(self.spec.prefix.bin, 'plumed-patch')
         )
 
         out = plumed_patch('-q', '-l', output=str)
@@ -102,6 +101,12 @@ class Plumed(AutotoolsPackage):
     def setup_dependent_package(self, module, dependent_spec):
         # Make plumed visible from dependent packages
         module.plumed = dependent_spec['plumed'].command
+
+    @property
+    def plumed_inc(self):
+        return os.path.join(
+            self.prefix.lib, 'plumed', 'src', 'lib', 'Plumed.inc'
+        )
 
     @run_before('autoreconf')
     def filter_gslcblas(self):


### PR DESCRIPTION
This PR contains a reworking of `cp2k` with a few improvements:

- [x] The base class now is `MakefilePackage`
- [x] The Makefile that gets generated is being archived upon installation
- [x] The checksums of `cp2k`, `libint` and `libxc` are all sha256
- [x] The custom Makefile is written at the end of the `edit` method (before the writing war intertwined with computation of flags and libraries)

@baip @dev-zero 