### PR TITLE
Disable unnecessary default dependencies of Eigen

### DIFF
--- a/var/spack/repos/builtin/packages/eigen/package.py
+++ b/var/spack/repos/builtin/packages/eigen/package.py
@@ -23,13 +23,16 @@ class Eigen(CMakePackage):
     version('3.2.8', '64f4aef8012a424c7e079eaf0be71793ab9bc6e0')
     version('3.2.7', 'cc1bacbad97558b97da6b77c9644f184')
 
-    variant('metis', default=False, description='Enables metis backend')
-    variant('scotch', default=False, description='Enables scotch backend')
-    variant('fftw', default=False, description='Enables FFTW backend')
+    variant('metis', default=False,
+            description='Enables metis permutations in sparse algebra')
+    variant('scotch', default=False,
+            description='Enables scotch/pastix factorizations in sparse algebra')
+    variant('fftw', default=False,
+            description='Enables FFTW backend for the FFT plugin')
     variant('suitesparse', default=False,
-            description='Enables SuiteSparse support')
+            description='Enables SuiteSparse factorizations in sparse algebra')
     variant('mpfr', default=False,
-            description='Enables support for multi-precisions FP via mpfr')
+            description='Enables the multi-precisions floating-point plugin')
     variant('build_type', default='RelWithDebInfo',
             description='The build type to build',
             values=('Debug', 'Release', 'RelWithDebInfo'))

--- a/var/spack/repos/builtin/packages/eigen/package.py
+++ b/var/spack/repos/builtin/packages/eigen/package.py
@@ -26,11 +26,11 @@ class Eigen(CMakePackage):
     variant('metis', default=False,
             description='Enables metis permutations in sparse algebra')
     variant('scotch', default=False,
-            description='Enables scotch/pastix factorizations in sparse algebra')
+            description='Enables scotch/pastix sparse factorization methods')
     variant('fftw', default=False,
             description='Enables FFTW backend for the FFT plugin')
     variant('suitesparse', default=False,
-            description='Enables SuiteSparse factorizations in sparse algebra')
+            description='Enables SuiteSparse sparse factorization methods')
     variant('mpfr', default=False,
             description='Enables the multi-precisions floating-point plugin')
     variant('build_type', default='RelWithDebInfo',

--- a/var/spack/repos/builtin/packages/eigen/package.py
+++ b/var/spack/repos/builtin/packages/eigen/package.py
@@ -23,12 +23,12 @@ class Eigen(CMakePackage):
     version('3.2.8', '64f4aef8012a424c7e079eaf0be71793ab9bc6e0')
     version('3.2.7', 'cc1bacbad97558b97da6b77c9644f184')
 
-    variant('metis', default=True, description='Enables metis backend')
-    variant('scotch', default=True, description='Enables scotch backend')
-    variant('fftw', default=True, description='Enables FFTW backend')
-    variant('suitesparse', default=True,
+    variant('metis', default=False, description='Enables metis backend')
+    variant('scotch', default=False, description='Enables scotch backend')
+    variant('fftw', default=False, description='Enables FFTW backend')
+    variant('suitesparse', default=False,
             description='Enables SuiteSparse support')
-    variant('mpfr', default=True,
+    variant('mpfr', default=False,
             description='Enables support for multi-precisions FP via mpfr')
     variant('build_type', default='RelWithDebInfo',
             description='The build type to build',


### PR DESCRIPTION
Considering how few mandatory dependencies Eigen has, it is a shame that Spack's Eigen package pulls in so many barely relevant dependencies by default, and requires users who care about their Docker image sizes and package build times to disable all of them one by one.

I would therefore propose to change the default to a more bare-bones Eigen install, and let those who are interested in Eigen's integration with various optional dependencies ask for them using the relevant variants.