### PR TITLE
add latest version of pixman

### DIFF
--- a/var/spack/repos/builtin/packages/pixman/package.py
+++ b/var/spack/repos/builtin/packages/pixman/package.py
@@ -15,6 +15,7 @@ class Pixman(AutotoolsPackage):
     homepage = "http://www.pixman.org"
     url      = "http://cairographics.org/releases/pixman-0.32.6.tar.gz"
 
+    version('0.38.0', '8f34a92041de2daaa4c34c5f7c860f21')
     version('0.34.0', 'e80ebae4da01e77f68744319f01d52a3')
     version('0.32.6', '3a30859719a41bd0f5cccffbfefdd4c2')
 

--- a/var/spack/repos/builtin/packages/pixman/package.py
+++ b/var/spack/repos/builtin/packages/pixman/package.py
@@ -15,9 +15,9 @@ class Pixman(AutotoolsPackage):
     homepage = "http://www.pixman.org"
     url      = "http://cairographics.org/releases/pixman-0.32.6.tar.gz"
 
-    version('0.38.0', '8f34a92041de2daaa4c34c5f7c860f21')
-    version('0.34.0', 'e80ebae4da01e77f68744319f01d52a3')
-    version('0.32.6', '3a30859719a41bd0f5cccffbfefdd4c2')
+    version('0.38.0', sha256='a7592bef0156d7c27545487a52245669b00cf7e70054505381cff2136d890ca8')
+    version('0.34.0', sha256='21b6b249b51c6800dc9553b65106e1e37d0e25df942c90531d4c3997aa20a88e')
+    version('0.32.6', sha256='3dfed13b8060eadabf0a4945c7045b7793cc7e3e910e748a8bb0f0dc3e794904')
 
     depends_on('pkgconfig', type='build')
     depends_on('libpng')


### PR DESCRIPTION
0.34.0 fails to build with clang@7.0.1 with
```shell
     630    1 warning generated.
  >> 631    utils-prng.c:207:27: error: use of unknown builtin '__builtin_shuffle' [-Wimplicit-function-declarati
            on]
     632                randdata.vb = __builtin_shuffle (randdata.vb, bswap_shufflemask);
     633                              ^
  >> 634    utils-prng.c:207:25: error: assigning to 'uint8x16' (vector of 16 'uint8_t' values) from incompatible
             type 'int'
     635                randdata.vb = __builtin_shuffle (randdata.vb, bswap_shufflemask);
     636                            ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
0.38.0 is fine.