### PR TITLE
Bug Fix in permission setter

### DIFF
--- a/lib/spack/spack/hooks/permissions_setters.py
+++ b/lib/spack/spack/hooks/permissions_setters.py
@@ -23,7 +23,7 @@ def forall_files(path, fn, args, dir_args=None):
                 else:
                     fn(os.path.join(root, d), *args)
         for f in files:
-            if not os.path.islink(os.path.join(root, d)):
+            if not os.path.islink(os.path.join(root, f)):
                 fn(os.path.join(root, f), *args)
 
 

--- a/lib/spack/spack/hooks/permissions_setters.py
+++ b/lib/spack/spack/hooks/permissions_setters.py
@@ -15,7 +15,8 @@ def forall_files(path, fn, args, dir_args=None):
     """Apply function to all files in directory, with file as first arg.
 
     Does not apply to the root dir. Does not apply to links"""
-    for root, dirs, files in os.walk(path):
+    # os.walk explicitly set not to follow links
+    for root, dirs, files in os.walk(path, followlinks=False):
         for d in dirs:
             if not os.path.islink(os.path.join(root, d)):
                 if dir_args:


### PR DESCRIPTION
When installing openssl with write permission for group, the installation failed in post-install hook due to an attempt to change permission on a system file. It turns out that it is simply due to a small typo in the permission-setter.