### PR TITLE
Update CUDA support in QMCPACK

### DIFF
--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -7,7 +7,7 @@ from spack import *
 import llnl.util.tty as tty
 
 
-class Qmcpack(CMakePackage):
+class Qmcpack(CMakePackage, CudaPackage):
     """QMCPACK, is a modern high-performance open-source Quantum Monte
        Carlo (QMC) simulation code."""
 
@@ -217,6 +217,9 @@ class Qmcpack(CMakePackage):
 
         if '+cuda' in spec:
             args.append('-DQMC_CUDA=1')
+            cuda_arch = spec.variants['cuda_arch'].value
+            if cuda_arch is not None:
+                args.append('-DCUDA_ARCH=sm_{0}'.format(cuda_arch[0]))
         else:
             args.append('-DQMC_CUDA=0')
 

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -218,6 +218,8 @@ class Qmcpack(CMakePackage, CudaPackage):
             cuda_arch = spec.variants['cuda_arch'].value
             if cuda_arch is not None:
                 args.append('-DCUDA_ARCH=sm_{0}'.format(cuda_arch[0]))
+            else:
+                args.append('-DCUDA_ARCH=sm_35')
         else:
             args.append('-DQMC_CUDA=0')
 

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -34,8 +34,6 @@ class Qmcpack(CMakePackage, CudaPackage):
     variant('debug', default=False, description='Build debug version')
     variant('mpi', default=True, description='Build with MPI support')
     variant('phdf5', default=True, description='Build with parallel collective I/O')
-    variant('cuda', default=False,
-            description='Enable CUDA and GPU acceleration')
     variant('complex', default=False,
             description='Build the complex (general twist/k-point) version')
     variant('mixed', default=False,


### PR DESCRIPTION
This PR updates the CUDA support in QMCPACK:

- Removes the explicit CUDA variant in QMCPACK, since its now built into every package.
- Add support for passing CUDA_ARCH value into the QMCPACK's  CMake