### PR TITLE
antlr: Disble C# support

### DIFF
--- a/var/spack/repos/builtin/packages/antlr/package.py
+++ b/var/spack/repos/builtin/packages/antlr/package.py
@@ -32,9 +32,9 @@ class Antlr(AutotoolsPackage):
         spec = self.spec
 
         return [
-            '--disable-csharp',
-            '--{0}-cxx'.format('enable' if '+cxx' in spec else 'disable'),
-            '--{0}-java'.format('enable' if '+java' in spec else 'disable'),
-            '--{0}-python'.format('enable' if '+python' in spec else 'disable'),
-            '--disable-csharp'
+          '--disable-csharp',
+          '--{0}-cxx'.format('enable' if '+cxx' in spec else 'disable'),
+          '--{0}-java'.format('enable' if '+java' in spec else 'disable'),
+          '--{0}-python'.format('enable' if '+python' in spec else 'disable'),
+          '--disable-csharp'
         ]

--- a/var/spack/repos/builtin/packages/antlr/package.py
+++ b/var/spack/repos/builtin/packages/antlr/package.py
@@ -35,5 +35,6 @@ class Antlr(AutotoolsPackage):
             '--disable-csharp',
             '--{0}-cxx'.format('enable' if '+cxx' in spec else 'disable'),
             '--{0}-java'.format('enable' if '+java' in spec else 'disable'),
-            '--{0}-python'.format('enable' if '+python' in spec else 'disable')
+            '--{0}-python'.format('enable' if '+python' in spec else 'disable'),
+            '--disable-csharp'
         ]


### PR DESCRIPTION
Nobody in Spack-land is ever going to build this with C# support.  And if they are, they can update the package in the future and enable C# support then.  In the meantime, it builds more cleanly and reliably without.
