### PR TITLE
Compiler wrappers don't add "pkg.headers.directories" to the include list

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -385,26 +385,24 @@ esac
 # Prepend include directories
 IFS=':' read -ra include_dirs <<< "$SPACK_INCLUDE_DIRS"
 if [[ $mode == cpp || $mode == cc || $mode == as || $mode == ccld ]]; then
-    for include_dir in "${include_dirs[@]}"; do
-        includes=("${includes[@]}" "$include_dir")
-    done
+    includes=("${includes[@]}" "${include_dirs[@]}")
 fi
 
 IFS=':' read -ra rpath_dirs <<< "$SPACK_RPATH_DIRS"
 if [[ $mode == ccld || $mode == ld ]]; then
-    for rpath_dir in "${rpath_dirs[@]}"; do
+
+    if [[ "$add_rpaths" != "false" ]] ; then
         # Append RPATH directories. Note that in the case of the
         # top-level package these directories may not exist yet. For dependencies
         # it is assumed that paths have already been confirmed.
-        $add_rpaths && rpaths=("${rpaths[@]}" "$rpath_dir")
-    done
+        rpaths=("${rpaths[@]}" "${rpath_dirs[@]}")
+    fi
+
 fi
 
 IFS=':' read -ra link_dirs <<< "$SPACK_LINK_DIRS"
 if [[ $mode == ccld || $mode == ld ]]; then
-    for link_dir in "${link_dirs[@]}"; do
-        libdirs=("${libdirs[@]}" "$link_dir")
-    done
+    libdirs=("${libdirs[@]}" "${link_dirs[@]}")
 fi
 
 # add RPATHs if we're in in any linking mode

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -287,10 +287,11 @@ def set_build_environment_variables(pkg, env, dirty):
         except spack.spec.NoLibrariesError:
             tty.debug("No libraries found for {0}".format(dep.name))
 
-        try:
-            include_dirs.extend(query.headers.directories)
-        except spack.spec.NoHeadersError:
-            tty.debug("No headers found for {0}".format(dep.name))
+        # TODO: fix the line below, currently the logic is broken for
+        # TODO: packages that uses directories as namespaces e.g.
+        # TODO: #include <boost/xxx.hpp>
+        # include_dirs.extend(query.headers.directories)
+
         if os.path.isdir(dep.prefix.include):
             include_dirs.append(dep.prefix.include)
 

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -243,7 +243,6 @@ def test_set_build_environment_variables(
     dep2_pkg = root['dt-diamond-right'].package
     dep2_pkg.spec.prefix = str(dep2_prefix)
     dep2_inc_paths = ['/test2/path/to/ex1.h', '/test2/path/to/subdir/ex2.h']
-    dep2_inc_dirs = ['/test2/path/to', '/test2/path/to/subdir']
     dep2_includes = HeaderList(dep2_inc_paths)
 
     setattr(dep_pkg, 'libs', dep_libs)
@@ -276,7 +275,7 @@ def test_set_build_environment_variables(
         # (regardless of whether it contains any header files)
         assert (
             normpaths(header_dir_var.split(':')) ==
-            normpaths(dep2_inc_dirs + [str(dep2_include)]))
+            normpaths([str(dep2_include)]))
     finally:
         delattr(dep_pkg, 'libs')
         delattr(dep2_pkg, 'headers')


### PR DESCRIPTION
fixes #10601
fixes #10603 

Due to a bug this attribute is wrong for packages that use directories as namespaces. For instance it will add `<boost-prefix>/include/boost` instead of `<boost-prefix>/include` to the include path.

As a minor addition a few loops in the compiler wrappers have been simplified.