### PR TITLE
xxhash: edit prefix in Makefile for macOS

### DIFF
--- a/var/spack/repos/builtin/packages/xxhash/package.py
+++ b/var/spack/repos/builtin/packages/xxhash/package.py
@@ -26,5 +26,6 @@ class Xxhash(MakefilePackage):
     version('0.5.1', '9417fd8a4d88204b680e21a60f0ccada')
     version('0.5.0', '42e9a31a2cfc2f626fde17e84a0b6bb7')
 
-    def install(self, spec, prefix):
-        make('prefix={0}'.format(prefix), 'install')
+    def edit(self, spec, prefix):
+        makefile = FileFilter("Makefile")
+        makefile.filter('/usr/local', prefix)


### PR DESCRIPTION
On macOS, the build of libxxhash is performed by a bare `make` launched by `MakePackage`s default `build` phase. As `prefix` is not set in `xxhash`'s `Makefile` at this point, the library gets compiled with a hard-coded install name of `/usr/local/libxxhash.dylib`. Downstream clients, in the tested case Root, will then fail to build as the install name is incorrect.

Move setting of `prefix` from `install` to `edit` so that it propagates to subsequent `build` and `install` phases.
