### PR TITLE
blast-legacy: new package at 2.2.26

### DIFF
--- a/var/spack/repos/builtin/packages/blast-legacy/package.py
+++ b/var/spack/repos/builtin/packages/blast-legacy/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from os import symlink
 
 
 class BlastLegacy(Package):

--- a/var/spack/repos/builtin/packages/blast-legacy/package.py
+++ b/var/spack/repos/builtin/packages/blast-legacy/package.py
@@ -19,6 +19,9 @@ class BlastLegacy(Package):
     depends_on('tcsh', type='build')
 
     def install(self, spec, prefix):
+        filter_file('/bin/csh -f', '/bin/env tcsh', 'make/ln-if-absent',
+                    string=True)
+
         tcsh = which('tcsh')
         with working_dir('..'):
             tcsh('./ncbi/make/makedis.csh')

--- a/var/spack/repos/builtin/packages/blast-legacy/package.py
+++ b/var/spack/repos/builtin/packages/blast-legacy/package.py
@@ -11,9 +11,21 @@ class BlastLegacy(Package):
        Contains older programs including `blastall'"""
 
     homepage = "https://www.ncbi.nlm.nih.gov/"
-    url      = "ftp://ftp.ncbi.nlm.nih.gov/blast/executables/legacy.NOTSUPPORTED/2.2.26/blast-2.2.26-x64-linux.tar.gz"
+    url      = "ftp://ftp.ncbi.nlm.nih.gov/blast/executables/legacy.NOTSUPPORTED/2.2.26/ncbi.tar.gz"
 
-    version('2.2.26', sha256='8a2f986cf47f0f7cbdb3478c4fc7e25c7198941d2262264d0b6b86194b3d063d')
+    version('2.2.26', sha256='d8fffac25efc8ca894c707c840a4797a8a949ae6fd983d2f91c9972f788efb7d')
+
+    depends_on('tcsh', type='build')
 
     def install(self, spec, prefix):
-        install_tree('.', prefix)
+        tcsh = which('tcsh')
+        with working_dir('..'):
+            tcsh('./ncbi/make/makedis.csh')
+
+        # depends on local data in the source tree
+        install_path = join_path(prefix, 'usr/local/blast-legacy')
+        mkdirp(install_path)
+        install_tree('.', install_path)
+
+        # symlink build output with binaries
+        symlink(join_path(install_path, 'build'), prefix.bin)

--- a/var/spack/repos/builtin/packages/blast-legacy/package.py
+++ b/var/spack/repos/builtin/packages/blast-legacy/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class BlastLegacy(Package):
+    """Legacy NCBI BLAST distribution -- no longer supported.
+       Contains older programs including `blastall'"""
+
+    homepage = "https://www.ncbi.nlm.nih.gov/"
+    url      = "ftp://ftp.ncbi.nlm.nih.gov/blast/executables/legacy.NOTSUPPORTED/2.2.26/blast-2.2.26-x64-linux.tar.gz"
+
+    version('2.2.26', sha256='8a2f986cf47f0f7cbdb3478c4fc7e25c7198941d2262264d0b6b86194b3d063d')
+
+    def install(self, spec, prefix):
+        install_tree('.', prefix)


### PR DESCRIPTION
provides legacy `blastall` binary required by some older packages