### PR TITLE
Fix plural typo in ROOT package

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -20,7 +20,7 @@ class Root(CMakePackage):
     version('master', git="https://github.com/root-project/root.git",
         branch='master')
 
-    # Development versions
+    # Development version
     version('6.15.02', sha256='2236fe4935139459239c935b2f93b3aa6bbfe92765ae9d9db9dd0b947bf19071')
 
     # Production version


### PR DESCRIPTION
During discussion around https://github.com/spack/spack/pull/10583 , there was general agreement on the fact that the plural "Development versions" wording in ROOT's package.py was confusing, but the PR was merged too quickly for me to fix it. So here's my smallest Spack PR diff ever. :wink: 