### PR TITLE
OpenMPI: add support for pbs/tm at configure.

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -44,6 +44,18 @@ def _mxm_dir():
         return None
 
 
+def _tm_dir():
+    """Look for default directory where the PBS/TM package is
+    installed. Return None if not found.
+    """
+    # /opt/pbs from PBS 18+; make this more flexible in the future
+    paths_list = ("/opt/pbs", )
+    for path in paths_list:
+        if os.path.isdir(path) and os.path.isfile(path + "/include/tm.h"):
+            return path
+    return None
+
+
 class Openmpi(AutotoolsPackage):
     """An open source Message Passing Interface implementation.
 
@@ -332,7 +344,18 @@ class Openmpi(AutotoolsPackage):
             return '--without-{0}'.format(opt)
         line = '--with-{0}'.format(opt)
         path = _mxm_dir()
-        if (path is not None):
+        if path is not None:
+            line += '={0}'.format(path)
+        return line
+
+    def with_or_without_tm(self, activated):
+        opt = 'tm'
+        # If the option has not been activated return --without-mxm
+        if not activated:
+            return '--without-{0}'.format(opt)
+        line = '--with-{0}'.format(opt)
+        path = _tm_dir()
+        if path is not None:
             line += '={0}'.format(path)
         return line
 

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -350,7 +350,7 @@ class Openmpi(AutotoolsPackage):
 
     def with_or_without_tm(self, activated):
         opt = 'tm'
-        # If the option has not been activated return --without-mxm
+        # If the option has not been activated return --without-tm
         if not activated:
             return '--without-{0}'.format(opt)
         line = '--with-{0}'.format(opt)


### PR DESCRIPTION
Hi!
I'd like to add support to PBS/TM to OpenMPI, as it's already done with the mellanox mxm drivers.