### PR TITLE
Catch-all fallback for libs detection

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -38,6 +38,7 @@ __all__ = [
     'find_headers',
     'find_all_headers',
     'find_libraries',
+    'find_all_libraries',
     'find_system_libraries',
     'fix_darwin_install_name',
     'force_remove',
@@ -1487,6 +1488,19 @@ def find_libraries(libraries, root, shared=True, recursive=False):
         found_libs = find(root, libraries, True)
 
     return LibraryList(found_libs)
+
+
+def find_all_libraries(root, shared=True):
+    """Convenience function that returns the list of all libraries found
+    in the directory passed as argument.
+
+    Args:
+        root (path): directory where to look recursively for libraries
+
+    Returns:
+        List of all libraries found in ``root`` and subdirectories.
+    """
+    return find_libraries('lib*', root=root, shared=shared, recursive=True)
 
 
 @memoized

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -90,7 +90,8 @@ from six import StringIO
 from six import string_types
 from six import iteritems
 
-from llnl.util.filesystem import find_headers, find_libraries, is_exe
+from llnl.util.filesystem import find_headers, find_libraries
+from llnl.util.filesystem import find_all_libraries, is_exe
 from llnl.util.lang import key_ordering, HashableMap, ObjectWrapper, dedupe
 from llnl.util.lang import check_kwargs, memoized
 import llnl.util.tty as tty

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -93,6 +93,7 @@ from six import iteritems
 from llnl.util.filesystem import find_headers, find_libraries, is_exe
 from llnl.util.lang import key_ordering, HashableMap, ObjectWrapper, dedupe
 from llnl.util.lang import check_kwargs, memoized
+import llnl.util.tty as tty
 from llnl.util.tty.color import cwrite, colorize, cescape, get_color_when
 import llnl.util.tty as tty
 
@@ -745,7 +746,14 @@ def _libs_default_handler(descriptor, spec, cls):
         for shared in search_shared:
             libs = find_libraries(name, spec.prefix, shared=shared, recursive=True)
             if libs:
-                return libs
+                    if len(libs) > 1:
+                        # Some packages want to generate linker commands. The
+                        # default libs query is not usable for this purpose, and
+                        # must be overrided. See hdf5 package for an example.
+                        tty.debug("Multiple libraries were found. Please do not"
+                                  " use this library list to build a linker"
+                                  " command, as it is not dependency-ordered.")
+                    return libs
 
     msg = 'Unable to recursively locate {0} libraries in {1}'
     raise NoLibrariesError(msg.format(spec.name, spec.prefix))

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -96,7 +96,6 @@ from llnl.util.lang import key_ordering, HashableMap, ObjectWrapper, dedupe
 from llnl.util.lang import check_kwargs, memoized
 import llnl.util.tty as tty
 from llnl.util.tty.color import cwrite, colorize, cescape, get_color_when
-import llnl.util.tty as tty
 
 import spack.paths
 import spack.architecture

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -748,9 +748,9 @@ def _libs_default_handler(descriptor, spec, cls):
             if libs:
                     if len(libs) > 1:
                         # Some packages want to generate linker commands. The
-                        # default libs query is not usable for this purpose, and
-                        # must be overrided. See hdf5 package for an example.
-                        tty.debug("Multiple libraries were found. Please do not"
+                        # default libs query is not usable for this purpose,
+                        # and must be overrided. See e.g. the hdf5 package.
+                        tty.debug("Multiple libraries were found. Please don't"
                                   " use this library list to build a linker"
                                   " command, as it is not dependency-ordered.")
                     return libs

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -729,8 +729,12 @@ def _libs_default_handler(descriptor, spec, cls):
         spec_name = 'lib' + spec_name
 
     # Use a catch-all fallback in case the library name does not match the
-    # package name (as in Intel packages, X11 packages, gettext...).
-    search_names = [spec_name, 'lib*']
+    # package name (as in Intel packages, X11 packages, gettext...). This is
+    # only safe for "internal" spack packages which each get their own prefix:
+    # with external packages, we could end up pulling all of /usr/lib(64)...
+    search_names = [spec_name]
+    if not spec.external:
+        search_names.append('lib*')
 
     # If '+shared' search only for shared library; if '~shared' search only for
     # static library; otherwise, first search for shared and then for static.

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -9,6 +9,7 @@ import inspect
 import os
 import os.path
 import shutil
+import sys
 import xml.etree.ElementTree
 
 import ordereddict_backport

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -872,8 +872,9 @@ def installation_dir_with_libs(tmpdir_factory):
     # |   |-- libbaz.a
     # |   |-- libsomething.a
     #
-    root.ensure('lib', 'libfoo.so')
-    root.ensure('lib', 'libbar.so')
+    shared_fmt = 'lib{0}.dylib' if sys.platform == 'darwin' else 'lib{0}.so'
+    root.ensure('lib', shared_fmt.format('foo'))
+    root.ensure('lib', shared_fmt.format('bar'))
     root.ensure('lib64', 'libbaz.a')
     root.ensure('lib64', 'libsomething.a')
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -855,6 +855,31 @@ def installation_dir_with_headers(tmpdir_factory):
     return root
 
 
+@pytest.fixture()
+def installation_dir_with_libs(tmpdir_factory):
+    """Mock installation tree with a few libraries. Shouldn't be modified by
+    tests as it is session scoped.
+    """
+    root = tmpdir_factory.mktemp('prefix')
+
+    # Create a few pseudo-libraries:
+    #
+    # <prefix>
+    # |-- lib
+    # |   |-- libfoo.so
+    # |   |-- libbar.so
+    # |-- lib64
+    # |   |-- libbaz.a
+    # |   |-- libsomething.a
+    #
+    root.ensure('lib', 'libfoo.so')
+    root.ensure('lib', 'libbar.so')
+    root.ensure('lib64', 'libbaz.a')
+    root.ensure('lib64', 'libsomething.a')
+
+    return root
+
+
 ##########
 # Mock packages
 ##########

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -9,6 +9,7 @@ import llnl.util.filesystem as fs
 import os
 import stat
 import pytest
+import sys
 
 
 @pytest.fixture()

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -256,6 +256,37 @@ def test_recursive_search_of_headers_from_prefix(
     assert os.path.join(prefix, 'path', 'to', 'subdir') in include_dirs
 
 
+@pytest.mark.regression('10617')
+def test_recursive_search_of_libraries_from_prefix(
+        installation_dir_with_libs
+):
+    # Try to find shared libraries in <prefix>
+    prefix = str(installation_dir_with_libs)
+    libs_list = fs.find_all_libraries(prefix, shared=True)
+
+    # Check that shared libraries are listed, and static libraries aren't
+    assert os.path.join(prefix, 'lib', 'libfoo.so') in libs_list
+    assert os.path.join(prefix, 'lib', 'libbar.so') in libs_list
+    assert os.path.join(prefix, 'lib64', 'libbaz.a') not in libs_list
+    assert os.path.join(prefix, 'lib64', 'libsomething.a') not in libs_list
+
+    # Check that directories which contain shared libraries are listed, and
+    # directories which contain static libraries aren't
+    libs_dirs = libs_list.directories
+    assert os.path.join(prefix, 'lib') in libs_dirs
+    assert os.path.join(prefix, 'lib64') not in libs_dirs
+
+    # Do the same test for static libraries
+    libs_list = fs.find_all_libraries(prefix, shared=False)
+    assert os.path.join(prefix, 'lib', 'libfoo.so') not in libs_list
+    assert os.path.join(prefix, 'lib', 'libbar.so') not in libs_list
+    assert os.path.join(prefix, 'lib64', 'libbaz.a') in libs_list
+    assert os.path.join(prefix, 'lib64', 'libsomething.a') in libs_list
+    libs_dirs = libs_list.directories
+    assert os.path.join(prefix, 'lib') not in libs_dirs
+    assert os.path.join(prefix, 'lib64') in libs_dirs
+
+
 @pytest.mark.parametrize('list_of_headers,expected_directories', [
     (['/pfx/include/foo.h', '/pfx/include/subdir/foo.h'], ['/pfx/include']),
     (['/pfx/include/foo.h', '/pfx/subdir/foo.h'],

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -263,10 +263,11 @@ def test_recursive_search_of_libraries_from_prefix(
     # Try to find shared libraries in <prefix>
     prefix = str(installation_dir_with_libs)
     libs_list = fs.find_all_libraries(prefix, shared=True)
+    sh_fmt = 'lib{0}.dylib' if sys.platform == 'darwin' else 'lib{0}.so'
 
     # Check that shared libraries are listed, and static libraries aren't
-    assert os.path.join(prefix, 'lib', 'libfoo.so') in libs_list
-    assert os.path.join(prefix, 'lib', 'libbar.so') in libs_list
+    assert os.path.join(prefix, 'lib', sh_fmt.format('foo')) in libs_list
+    assert os.path.join(prefix, 'lib', sh_fmt.format('bar')) in libs_list
     assert os.path.join(prefix, 'lib64', 'libbaz.a') not in libs_list
     assert os.path.join(prefix, 'lib64', 'libsomething.a') not in libs_list
 
@@ -278,8 +279,8 @@ def test_recursive_search_of_libraries_from_prefix(
 
     # Do the same test for static libraries
     libs_list = fs.find_all_libraries(prefix, shared=False)
-    assert os.path.join(prefix, 'lib', 'libfoo.so') not in libs_list
-    assert os.path.join(prefix, 'lib', 'libbar.so') not in libs_list
+    assert os.path.join(prefix, 'lib', sh_fmt.format('foo')) not in libs_list
+    assert os.path.join(prefix, 'lib', sh_fmt.format('bar')) not in libs_list
     assert os.path.join(prefix, 'lib64', 'libbaz.a') in libs_list
     assert os.path.join(prefix, 'lib64', 'libsomething.a') in libs_list
     libs_dirs = libs_list.directories


### PR DESCRIPTION
The `_libs_default_handler` implicitly assumes that a library package called `(lib)?Something` will always produce a library called `libSomething`. This is not always the case, here are some counter examples:

- `gettext` (produces several `libgettextSomething`s and a `libintl`, but not `libgettext`)
- `intel-Something` (produces `libSomething`, without the intel prefix)
- X11 packages (though that one could be fixed with a case-insensitive search)

Currently, the result is that these libraries will not be correctly added to the RPATH, leading to problems like #10617 . One possibility is to override libs() for every such package, but that gets tedious quickly. As an alternative, this PR proposes to have the default libs handler try harder and enumerate every library in the package's Spack prefix instead.

I am quite convinced that this is a decent heuristic for library packages that are build using Spack, as the prefix will be specific to that package. But am not sure if this heuristic works or can be made to work for external packages where many libraries can end up sharing a common prefix. Extra review on this specific point would be most welcome.

See also #10617 for prior discussion.