### PR TITLE
Restore computation of include directories

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -410,10 +410,10 @@ case "$mode" in
     ld|ccld)
         # Set extra RPATHs
         IFS=':' read -ra extra_rpaths <<< "$SPACK_COMPILER_EXTRA_RPATHS"
-        for extra_rpath in "${extra_rpaths[@]}"; do
-            $add_rpaths && rpaths+=("$extra_rpath")
-            libdirs+=("$extra_rpath")
-        done
+        libdirs+=("${extra_rpaths[@]}")
+        if [[ "$add_rpaths" != "false" ]] ; then
+            rpaths+=("${extra_rpaths[@]}")
+        fi
 
         # Add SPACK_LDLIBS to args
         for lib in "${SPACK_LDLIBS[@]}"; do

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -975,15 +975,14 @@ class HeaderList(FileList):
 
     @directories.setter
     def directories(self, value):
+        value = value or []
         # Accept a single directory as input
         if isinstance(value, six.string_types):
             value = [value]
 
         # Setting the property to None makes the initial default
         # kick-in again
-        self._directories = None if value is None else [
-            os.path.normpath(x) for x in value
-        ]
+        self._directories = [os.path.normpath(x) for x in value]
 
     def _default_directories(self):
         """Default computation of directories based on the list of

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -36,6 +36,7 @@ __all__ = [
     'filter_file',
     'find',
     'find_headers',
+    'find_all_headers',
     'find_libraries',
     'find_system_libraries',
     'fix_darwin_install_name',
@@ -1130,6 +1131,19 @@ def find_headers(headers, root, recursive=False):
     headers = ['{0}.{1}'.format(header, suffix) for header in headers]
 
     return HeaderList(find(root, headers, recursive))
+
+
+def find_all_headers(root):
+    """Convenience function that returns the list of all headers found
+    in the directory passed as argument.
+
+    Args:
+        root (path): directory where to look recursively for header files
+
+    Returns:
+        List of all headers found in ``root`` and subdirectories.
+    """
+    return find_headers('*', root=root, recursive=True)
 
 
 class LibraryList(FileList):

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -956,10 +956,25 @@ class HeaderList(FileList):
     commonly used compiler flags or names.
     """
 
+    include_regex = re.compile(r'(.*)(include)(.*)')
+
     def __init__(self, files):
         super(HeaderList, self).__init__(files)
 
         self._macro_definitions = []
+
+    @property
+    def directories(self):
+        dir_list = super(HeaderList, self).directories
+        values = []
+        for d in dir_list:
+            # If the path contains a subdirectory named 'include' then stop
+            # there and don't add anything else to the path.
+            m = self.include_regex.match(d)
+            value = os.path.join(*m.group(1, 2)) if m else d
+            values.append(value)
+
+        return list(dedupe(values))
 
     @property
     def headers(self):

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -980,8 +980,6 @@ class HeaderList(FileList):
         if isinstance(value, six.string_types):
             value = [value]
 
-        # Setting the property to None makes the initial default
-        # kick-in again
         self._directories = [os.path.normpath(x) for x in value]
 
     def _default_directories(self):

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -962,9 +962,30 @@ class HeaderList(FileList):
         super(HeaderList, self).__init__(files)
 
         self._macro_definitions = []
+        self._directories = None
 
     @property
     def directories(self):
+        """Directories to be searched for header files."""
+        values = self._directories or self._default_directories()
+        return list(dedupe(values))
+
+    @directories.setter
+    def directories(self, value):
+        # Accept a single directory as input
+        if isinstance(value, six.string_types):
+            value = [value]
+
+        # Setting the property to None makes the initial default
+        # kick-in again
+        self._directories = None if value is None else [
+            os.path.normpath(x) for x in value
+        ]
+
+    def _default_directories(self):
+        """Default computation of directories based on the list of
+        header files.
+        """
         dir_list = super(HeaderList, self).directories
         values = []
         for d in dir_list:
@@ -973,8 +994,7 @@ class HeaderList(FileList):
             m = self.include_regex.match(d)
             value = os.path.join(*m.group(1, 2)) if m else d
             values.append(value)
-
-        return list(dedupe(values))
+        return values
 
     @property
     def headers(self):

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -967,7 +967,9 @@ class HeaderList(FileList):
     @property
     def directories(self):
         """Directories to be searched for header files."""
-        values = self._directories or self._default_directories()
+        values = self._directories
+        if values is None:
+            values = self._default_directories()
         return list(dedupe(values))
 
     @directories.setter

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -292,10 +292,10 @@ def set_build_environment_variables(pkg, env, dirty):
         if dep in rpath_deps:
             rpath_dirs.extend(dep_link_dirs)
 
-        # TODO: fix the line below, currently the logic is broken for
-        # TODO: packages that uses directories as namespaces e.g.
-        # TODO: #include <boost/xxx.hpp>
-        # include_dirs.extend(query.headers.directories)
+        try:
+            include_dirs.extend(query.headers.directories)
+        except spack.spec.NoHeadersError:
+            tty.debug("No headers found for {0}".format(dep.name))
 
         if os.path.isdir(dep.prefix.include):
             include_dirs.append(dep.prefix.include)

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -297,9 +297,6 @@ def set_build_environment_variables(pkg, env, dirty):
         except spack.spec.NoHeadersError:
             tty.debug("No headers found for {0}".format(dep.name))
 
-        if os.path.isdir(dep.prefix.include):
-            include_dirs.append(dep.prefix.include)
-
     link_dirs = list(dedupe(filter_system_paths(link_dirs)))
     include_dirs = list(dedupe(filter_system_paths(include_dirs)))
     rpath_dirs = list(dedupe(filter_system_paths(rpath_dirs)))

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -14,7 +14,7 @@ from spack.util.executable import Executable
 from spack.util.spack_yaml import syaml_dict, syaml_str
 from spack.util.environment import EnvironmentModifications
 
-from llnl.util.filesystem import LibraryList, HeaderList
+from llnl.util.filesystem import LibraryList
 
 
 @pytest.fixture
@@ -221,7 +221,7 @@ def test_package_inheritance_module_setup(config, mock_packages):
 
 
 def test_set_build_environment_variables(
-        config, mock_packages, working_env, monkeypatch, tmpdir_factory):
+        config, mock_packages, working_env, monkeypatch, tmp_installation_dir):
     """Check that build_environment supplies the needed library/include
     directories via the SPACK_LINK_DIRS and SPACK_INCLUDE_DIRS environment
     variables.
@@ -238,16 +238,10 @@ def test_set_build_environment_variables(
     dep_lib_dirs = ['/test/path/to', '/test/path/to/subdir']
     dep_libs = LibraryList(dep_lib_paths)
 
-    dep2_prefix = tmpdir_factory.mktemp('prefix')
-    dep2_include = dep2_prefix.ensure('include', dir=True)
     dep2_pkg = root['dt-diamond-right'].package
-    dep2_pkg.spec.prefix = str(dep2_prefix)
-    dep2_inc_paths = ['/test2/path/to/ex1.h', '/test2/path/to/subdir/ex2.h']
-    dep2_inc_dirs = ['/test2/path/to', '/test2/path/to/subdir']
-    dep2_includes = HeaderList(dep2_inc_paths)
+    dep2_pkg.spec.prefix = str(tmp_installation_dir)
 
     setattr(dep_pkg, 'libs', dep_libs)
-    setattr(dep2_pkg, 'headers', dep2_includes)
     try:
         pkg = root.package
         env_mods = EnvironmentModifications()
@@ -272,11 +266,16 @@ def test_set_build_environment_variables(
             normpaths(root_libdirs + dep_lib_dirs))
 
         header_dir_var = os.environ['SPACK_INCLUDE_DIRS']
-        # As long as a dependency package has an 'include' prefix, it is added
-        # (regardless of whether it contains any header files)
-        assert (
-            normpaths(header_dir_var.split(':')) ==
-            normpaths(dep2_inc_dirs + [str(dep2_include)]))
+
+        # The default implementation looks for header files only
+        # in <prefix>/include and subdirectories
+        prefix = str(tmp_installation_dir)
+        include_dirs = normpaths(header_dir_var.split(':'))
+
+        assert os.path.join(prefix, 'include') in include_dirs
+        assert os.path.join(prefix, 'include', 'boost') not in include_dirs
+        assert os.path.join(prefix, 'path', 'to') not in include_dirs
+        assert os.path.join(prefix, 'path', 'to', 'subdir') not in include_dirs
+
     finally:
         delattr(dep_pkg, 'libs')
-        delattr(dep2_pkg, 'headers')

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -221,7 +221,9 @@ def test_package_inheritance_module_setup(config, mock_packages):
 
 
 def test_set_build_environment_variables(
-        config, mock_packages, working_env, monkeypatch, tmp_installation_dir):
+        config, mock_packages, working_env, monkeypatch,
+        installation_dir_with_headers
+):
     """Check that build_environment supplies the needed library/include
     directories via the SPACK_LINK_DIRS and SPACK_INCLUDE_DIRS environment
     variables.
@@ -239,7 +241,7 @@ def test_set_build_environment_variables(
     dep_libs = LibraryList(dep_lib_paths)
 
     dep2_pkg = root['dt-diamond-right'].package
-    dep2_pkg.spec.prefix = str(tmp_installation_dir)
+    dep2_pkg.spec.prefix = str(installation_dir_with_headers)
 
     setattr(dep_pkg, 'libs', dep_libs)
     try:
@@ -269,7 +271,7 @@ def test_set_build_environment_variables(
 
         # The default implementation looks for header files only
         # in <prefix>/include and subdirectories
-        prefix = str(tmp_installation_dir)
+        prefix = str(installation_dir_with_headers)
         include_dirs = normpaths(header_dir_var.split(':'))
 
         assert os.path.join(prefix, 'include') in include_dirs

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -243,6 +243,7 @@ def test_set_build_environment_variables(
     dep2_pkg = root['dt-diamond-right'].package
     dep2_pkg.spec.prefix = str(dep2_prefix)
     dep2_inc_paths = ['/test2/path/to/ex1.h', '/test2/path/to/subdir/ex2.h']
+    dep2_inc_dirs = ['/test2/path/to', '/test2/path/to/subdir']
     dep2_includes = HeaderList(dep2_inc_paths)
 
     setattr(dep_pkg, 'libs', dep_libs)
@@ -275,7 +276,7 @@ def test_set_build_environment_variables(
         # (regardless of whether it contains any header files)
         assert (
             normpaths(header_dir_var.split(':')) ==
-            normpaths([str(dep2_include)]))
+            normpaths(dep2_inc_dirs + [str(dep2_include)]))
     finally:
         delattr(dep_pkg, 'libs')
         delattr(dep2_pkg, 'headers')

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -716,6 +716,31 @@ def mutable_mock_env_path(tmpdir_factory):
     spack.environment.env_path = saved_path
 
 
+@pytest.fixture(scope='session')
+def tmp_installation_dir(tmpdir_factory):
+    root = tmpdir_factory.mktemp('prefix')
+
+    # Create a few header files:
+    #
+    # <prefix>
+    # |-- include
+    # |   |--boost
+    # |   |   |-- ex3.h
+    # |   |-- ex3.h
+    # |-- path
+    #     |-- to
+    #         |-- ex1.h
+    #         |-- subdir
+    #             |-- ex2.h
+    #
+    root.ensure('include', 'boost', 'ex3.h')
+    root.ensure('include', 'ex3.h')
+    root.ensure('path', 'to', 'ex1.h')
+    root.ensure('path', 'to', 'subdir', 'ex2.h')
+
+    return root
+
+
 ##########
 # Mock packages
 ##########

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -717,7 +717,11 @@ def mutable_mock_env_path(tmpdir_factory):
 
 
 @pytest.fixture(scope='session')
-def tmp_installation_dir(tmpdir_factory):
+def installation_dir_with_headers(tmpdir_factory):
+    """Mock installation tree with a few headers placed in different
+    subdirectories. Shouldn't be modified by tests as it is session
+    scoped.
+    """
     root = tmpdir_factory.mktemp('prefix')
 
     # Create a few header files:

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -716,7 +716,7 @@ def mutable_mock_env_path(tmpdir_factory):
     spack.environment.env_path = saved_path
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture()
 def installation_dir_with_headers(tmpdir_factory):
     """Mock installation tree with a few headers placed in different
     subdirectories. Shouldn't be modified by tests as it is session

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -251,3 +251,28 @@ def test_computation_of_header_directories(
 ):
     hl = fs.HeaderList(list_of_headers)
     assert hl.directories == expected_directories
+
+
+def test_directories_can_be_set():
+    hl = fs.HeaderList(
+        ['/pfx/include/subdir/foo.h', '/pfx/include/subdir/bar.h']
+    )
+
+    # Set directories using a list
+    hl.directories = ['/pfx/include/subdir']
+    assert hl.directories == ['/pfx/include/subdir']
+
+    # If it's a single directory it's fine to not wrap it into a list
+    # when setting the property
+    hl.directories = '/pfx/include/subdir'
+    assert hl.directories == ['/pfx/include/subdir']
+
+    # Paths are normalized, so it doesn't matter how many backslashes etc.
+    # are present in the original directory being used
+    hl.directories = '/pfx/include//subdir/'
+    assert hl.directories == ['/pfx/include/subdir']
+
+    # Setting the property back to None makes the default computation
+    # kick-in again
+    hl.directories = None
+    assert hl.directories == ['/pfx/include']

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -237,3 +237,17 @@ def test_recursive_search_of_headers_from_prefix(tmp_installation_dir):
     assert os.path.join(prefix, 'include', 'boost') not in include_dirs
     assert os.path.join(prefix, 'path', 'to') in include_dirs
     assert os.path.join(prefix, 'path', 'to', 'subdir') in include_dirs
+
+
+@pytest.mark.parametrize('list_of_headers,expected_directories', [
+    (['/pfx/include/foo.h', '/pfx/include/subdir/foo.h'], ['/pfx/include']),
+    (['/pfx/include/foo.h', '/pfx/subdir/foo.h'],
+     ['/pfx/include', '/pfx/subdir']),
+    (['/pfx/include/subdir/foo.h', '/pfx/subdir/foo.h'],
+     ['/pfx/include', '/pfx/subdir'])
+])
+def test_computation_of_header_directories(
+        list_of_headers, expected_directories
+):
+    hl = fs.HeaderList(list_of_headers)
+    assert hl.directories == expected_directories

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -219,10 +219,12 @@ def test_move_transaction_rollback(tmpdir):
 
 @pytest.mark.regression('10601')
 @pytest.mark.regression('10603')
-def test_recursive_search_of_headers_from_prefix(tmp_installation_dir):
+def test_recursive_search_of_headers_from_prefix(
+        installation_dir_with_headers
+):
     # Try to inspect recursively from <prefix> and ensure we don't get
     # subdirectories of the '<prefix>/include' path
-    prefix = str(tmp_installation_dir)
+    prefix = str(installation_dir_with_headers)
     header_list = fs.find_headers('*', root=prefix, recursive=True)
 
     # Check that the header files we expect are all listed
@@ -253,7 +255,7 @@ def test_computation_of_header_directories(
     assert hl.directories == expected_directories
 
 
-def test_directories_can_be_set():
+def test_headers_directory_setter():
     hl = fs.HeaderList(
         ['/pfx/include/subdir/foo.h', '/pfx/include/subdir/bar.h']
     )
@@ -271,6 +273,10 @@ def test_directories_can_be_set():
     # are present in the original directory being used
     hl.directories = '/pfx/include//subdir/'
     assert hl.directories == ['/pfx/include/subdir']
+
+    # Setting an empty list is allowed and returns an empty list
+    hl.directories = []
+    assert hl.directories == []
 
     # Setting the property back to None makes the default computation
     # kick-in again

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -278,7 +278,6 @@ def test_headers_directory_setter():
     hl.directories = []
     assert hl.directories == []
 
-    # Setting the property back to None makes the default computation
-    # kick-in again
+    # Setting directories to None also returns an empty list
     hl.directories = None
-    assert hl.directories == ['/pfx/include']
+    assert hl.directories == []

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -225,7 +225,7 @@ def test_recursive_search_of_headers_from_prefix(
     # Try to inspect recursively from <prefix> and ensure we don't get
     # subdirectories of the '<prefix>/include' path
     prefix = str(installation_dir_with_headers)
-    header_list = fs.find_headers('*', root=prefix, recursive=True)
+    header_list = fs.find_all_headers(prefix)
 
     # Check that the header files we expect are all listed
     assert os.path.join(prefix, 'include', 'ex3.h') in header_list

--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -36,6 +36,13 @@ class Libxml2(AutotoolsPackage):
     resource(name='xmlts', url='http://www.w3.org/XML/Test/xmlts20080827.tar.gz',
              sha256='96151685cec997e1f9f3387e3626d61e6284d4d6e66e0e440c209286c03e9cc7')
 
+    @property
+    def headers(self):
+        include_dir = self.spec.prefix.include.libxml2
+        hl = find_headers('*', root=include_dir, recursive=True)
+        hl.directories = include_dir
+        return hl
+
     def configure_args(self):
         spec = self.spec
 
@@ -50,10 +57,6 @@ class Libxml2(AutotoolsPackage):
             args.append('--without-python')
 
         return args
-
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        spack_env.prepend_path('CPATH', self.prefix.include.libxml2)
-        run_env.prepend_path('CPATH', self.prefix.include.libxml2)
 
     @run_after('install')
     @on_package_attributes(run_tests=True)

--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -39,7 +39,7 @@ class Libxml2(AutotoolsPackage):
     @property
     def headers(self):
         include_dir = self.spec.prefix.include.libxml2
-        hl = find_headers('*', root=include_dir, recursive=True)
+        hl = find_all_headers(include_dir)
         hl.directories = include_dir
         return hl
 


### PR DESCRIPTION
This PR restores the computation of the include directories that was remove as part of the hotfix in #10604 It also adds the following modifications:

- [x] Remove the separate addition of `<prefix>/include` to the list of include dirs
- [x] Add unit tests to stress the behavior of `HeaderList.directories`

- [x] Implement a way for packages to customize the include dirs injected into compiler wrappers (refers to #8324 or `libxml2` - thanks to @scheibelp for the reference)