### PR TITLE
build environment: fallback to default prefix.lib only if libs() did …

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -283,10 +283,15 @@ def set_build_environment_variables(pkg, env, dirty):
         except spack.spec.NoLibrariesError:
             tty.debug("No libraries found for {0}".format(dep.name))
 
-        for default_lib_dir in ['lib', 'lib64']:
-            default_lib_prefix = os.path.join(dep.prefix, default_lib_dir)
-            if os.path.isdir(default_lib_prefix):
-                dep_link_dirs.append(default_lib_prefix)
+            # Fallback to default lib/lib64 ONLY if the package failed to
+            # provide working libs(). Otherwise with complicated Intel packages
+            # we may end up including un-versioned lib folder
+            # /apps/intel/ComposerXE2017/lib instead of
+            # /apps/intel/ComposerXE2017/compilers_and_libraries_2018.3.222/...
+            for default_lib_dir in ['lib', 'lib64']:
+                default_lib_prefix = os.path.join(dep.prefix, default_lib_dir)
+                if os.path.isdir(default_lib_prefix):
+                    dep_link_dirs.append(default_lib_prefix)
 
         link_dirs.extend(dep_link_dirs)
         if dep in rpath_deps:


### PR DESCRIPTION
…not work

for
```
  intel-mpi:
    version: [2018.3.222]
    paths:
      intel-mpi@2018.3.222%intel@18.0.3: /apps/intel/ComposerXE2018/
    buildable: False
```

to work with

```
$ ls /apps/intel/ComposerXE2018/
bin                      compilers_and_libraries_2018        compilers_and_libraries_2018.2.199  daal           documentation_2018  imb   include  itac  man  parallel_studio_xe_2018        pstl          tbb
compilers_and_libraries  compilers_and_libraries_2018.1.163  compilers_and_libraries_2018.3.222  debugger_2018  ide_support_2018    impi  ipp      lib   mkl  parallel_studio_xe_2018.3.051  samples_2018  uninstall
```

we shall NOT unconditionally add neither `include` nor `lib` in this case. `IntelPackage` is [clever enough](https://github.com/spack/spack/blob/develop/lib/spack/spack/build_systems/intel.py#L918-L951) to dig into `compilers_and_libraries_2018.3.222` and setup `libs()` and `headers()` correctly.


follow up to https://github.com/spack/spack/pull/10622