### PR TITLE
modules: fully consider external modules.

### DIFF
--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -485,7 +485,7 @@ class BaseConfiguration(object):
     @property
     def specs_to_load(self):
         """List of specs that should be loaded in the module file."""
-        return self._create_list_for('autoload')
+        return self._create_list_for('autoload', external=True)
 
     @property
     def literals_to_load(self):
@@ -502,11 +502,13 @@ class BaseConfiguration(object):
         """List of variables that should be left unmodified."""
         return self.conf.get('filter', {}).get('environment_blacklist', {})
 
-    def _create_list_for(self, what):
+    def _create_list_for(self, what, external=False):
         whitelist = []
         for item in self.conf[what]:
             conf = type(self)(item)
             if not conf.blacklisted:
+                whitelist.append(item)
+            elif external and item.external and item.external_module:
                 whitelist.append(item)
         return whitelist
 

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -6,7 +6,6 @@
 import stat
 
 from six import string_types
-from six import iteritems
 
 import spack.repo
 import spack.error

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -190,22 +190,18 @@ def spec_externals(spec):
     if (not pkg_paths) and (not pkg_modules):
         return []
 
-    for external_spec, path in iteritems(pkg_paths):
-        if not path:
+    pkgs = set(pkg_paths) | set(pkg_modules)
+
+    for external_spec in pkgs:
+        path = pkg_paths.get(external_spec)
+        module = pkg_modules.get(external_spec)
+        if not path and not module:
             # skip entries without paths (avoid creating extra Specs)
             continue
 
         external_spec = spack.spec.Spec(external_spec,
-                                        external_path=canonicalize_path(path))
-        if external_spec.satisfies(spec):
-            external_specs.append(external_spec)
-
-    for external_spec, module in iteritems(pkg_modules):
-        if not module:
-            continue
-
-        external_spec = spack.spec.Spec(
-            external_spec, external_module=module)
+                                        external_path=canonicalize_path(path),
+                                        external_module=module)
         if external_spec.satisfies(spec):
             external_specs.append(external_spec)
 

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -197,9 +197,10 @@ def spec_externals(spec):
         if not path and not module:
             # skip entries without paths (avoid creating extra Specs)
             continue
-
+        if path:
+            path = canonicalize_path(path)
         external_spec = spack.spec.Spec(external_spec,
-                                        external_path=canonicalize_path(path),
+                                        external_path=path,
                                         external_module=module)
         if external_spec.satisfies(spec):
             external_specs.append(external_spec)


### PR DESCRIPTION
Issue: when external packages are defined with both paths and modules, Spack exhibits a preference for the path part and drops the module part when registering the package in the database. I.e, given this Python in `packages.yaml`:
```
  python:
    version: [3.6.5]
    paths:
      'python@3.6.5 +dbm~optimizations+pic+pythoncmd+shared~tk~ucs4': /our/path/to/deployment/linux-rhel7-x86_64/gcc-6.4.0/python-3.6.5-ukuow6gd2f
    modules:
      'python@3.6.5 +dbm~optimizations+pic+pythoncmd+shared~tk~ucs4': python/3.6
```
And installing, e.g., `py-six`, I see the following entry in the database for `python`:
```
      "external": {
       "path": "/our/path/to/deployment/linux-rhel7-x86_64/gcc-6.4.0/python-3.6.5-ukuow6gd2f",
       "module": null
      },

```
Now if I generate modules with autoload enabled, `py-six` will not load the Python module I specified as available.

This PR changes the way external paths and modules are registered by considering both together, rather than one after another (this leads to an implicit bias for paths over modules). In addition, when generating the autoload list of modules, modules for external packages will be loaded.

Any thoughts on this?