### PR TITLE
tau: replace absolute paths to compilers with compiler names

### DIFF
--- a/var/spack/repos/builtin/packages/tau/package.py
+++ b/var/spack/repos/builtin/packages/tau/package.py
@@ -97,8 +97,8 @@ class Tau(Package):
         compiler_path = os.path.dirname(self.compiler.cc)
         os.environ['PATH'] = ':'.join([compiler_path, os.environ['PATH']])
 
-        compiler_options = ['-c++=%s' % self.compiler.cxx,
-                            '-cc=%s' % self.compiler.cc]
+        compiler_options = ['-c++=%s' % self.compiler.cxx_names[0],
+                            '-cc=%s' % self.compiler.cc_names[0]]
 
         if self.compiler.fc:
             compiler_options.append('-fortran=%s' % self.compiler.fc_names[0])


### PR DESCRIPTION
The tau configure script does only accept compiler names
as mentioned in the comment in the tau spack package.

#8192 changed the spack package to use full paths for the C and C++ compiler.

For the Fortran compiler the configure script exits when this is not
the case, but for C and C++ only a warning will be printed and the configure
script will choose a default compiler, which is not necessarily the specified one.