### PR TITLE
pkgconfig: Disable pkgconf and pkg-config's path stripping

### DIFF
--- a/var/spack/repos/builtin/packages/pkg-config/package.py
+++ b/var/spack/repos/builtin/packages/pkg-config/package.py
@@ -27,10 +27,20 @@ class PkgConfig(AutotoolsPackage):
 
     parallel = False
 
+    def setup_environment(self, spack_env, run_env):
+        # Allow pkgconf to return paths that are considered system paths
+        spack_env.set('PKG_CONFIG_ALLOW_SYSTEM_CFLAGS', '1')
+        spack_env.set('PKG_CONFIG_ALLOW_SYSTEM_LIBS', '1')
+        run_env.set('PKG_CONFIG_ALLOW_SYSTEM_CFLAGS', '1')
+        run_env.set('PKG_CONFIG_ALLOW_SYSTEM_LIBS', '1')
+
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        """Adds the ACLOCAL path for autotools."""
+        # Adds the ACLOCAL path for autotools.
         spack_env.append_path('ACLOCAL_PATH',
                               join_path(self.prefix.share, 'aclocal'))
+        # Allow pkgconf to return paths that are considered system paths
+        spack_env.set('PKG_CONFIG_ALLOW_SYSTEM_CFLAGS', '1')
+        spack_env.set('PKG_CONFIG_ALLOW_SYSTEM_LIBS', '1')
 
     def configure_args(self):
         config_args = ['--enable-shared']

--- a/var/spack/repos/builtin/packages/pkgconf/package.py
+++ b/var/spack/repos/builtin/packages/pkgconf/package.py
@@ -26,10 +26,20 @@ class Pkgconf(AutotoolsPackage):
     # TODO: Add a package for the kyua testing framework
     # depends_on('kyua', type='test')
 
+    def setup_environment(self, spack_env, run_env):
+        # Allow pkgconf to return paths that are considered system paths
+        spack_env.set('PKG_CONFIG_ALLOW_SYSTEM_CFLAGS', '1')
+        spack_env.set('PKG_CONFIG_ALLOW_SYSTEM_LIBS', '1')
+        run_env.set('PKG_CONFIG_ALLOW_SYSTEM_CFLAGS', '1')
+        run_env.set('PKG_CONFIG_ALLOW_SYSTEM_LIBS', '1')
+
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        """Adds the ACLOCAL path for autotools."""
+        # Adds the ACLOCAL path for autotools.
         spack_env.append_path('ACLOCAL_PATH',
                               join_path(self.prefix.share, 'aclocal'))
+        # Allow pkgconf to return paths that are considered system paths
+        spack_env.set('PKG_CONFIG_ALLOW_SYSTEM_CFLAGS', '1')
+        spack_env.set('PKG_CONFIG_ALLOW_SYSTEM_LIBS', '1')
 
     @run_after('install')
     def link_pkg_config(self):


### PR DESCRIPTION
By default, pkgconf and pkg-config strip out system paths. This can cause problems because Spack sets `CPATH`, which is taken into account when determining the system paths.

The difference of this change can be tested with: `spack build-env gettext -- pkg-config --cflags libxml-2.0`

Before this change, the output should be empty because the libxml2 package explicitly sets `CPATH`, which causes pkgconf and pkg-config to strip out its include directory. After this change, the output should contain the include directory.