### PR TITLE
add numpy@1.16.1, patch numpy%intel

### DIFF
--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -26,6 +26,7 @@ class PyNumpy(PythonPackage):
         'numpy.distutils.command', 'numpy.distutils.fcompiler'
     ]
 
+    version('1.16.1', 'dafda51934f645d888866f98424521ae')
     version('1.15.2', sha256='27a0d018f608a3fe34ac5e2b876f4c23c47e38295c47dd0775cc294cd2614bc1')
     version('1.15.1', '898004d5be091fde59ae353e3008fe9b')
     version('1.14.3', '97416212c0a172db4bc6b905e9c4634b')


### PR DESCRIPTION
- Adds new numpy version 1.16.1
- Patches 1.15.* - 1.16.* releases.  See [`numpy/12991`](https://github.com/numpy/numpy/pull/12991).

I didn't see a good way to do this multiline patch with existing utilities.  Please let me know if there's a cleaner way to do this (see comments, patch file can't be used because the line numbers change).