### PR TITLE
libbeagle: add cuda flags, patches

### DIFF
--- a/var/spack/repos/builtin/packages/libbeagle/package.py
+++ b/var/spack/repos/builtin/packages/libbeagle/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class Libbeagle(AutotoolsPackage):
+class Libbeagle(AutotoolsPackage, CudaPackage):
     """Beagle performs genotype calling, genotype phasing, imputation of
        ungenotyped markers, and identity-by-descent segment detection."""
 
@@ -23,6 +23,34 @@ class Libbeagle(AutotoolsPackage):
     depends_on('subversion', type='build')
     depends_on('pkgconfig', type='build')
     depends_on('java', type='build')
+
+    def patch(self):
+        # update cuda architecture if necessary
+        if '+cuda' in self.spec:
+            arch = self.spec.variants['cuda_arch'].value
+            archflag = ''
+
+            if arch[0] != 'none':
+                archflag = '-arch=%s' % arch[0]
+
+            filter_file('-arch compute_13', archflag,
+                        'libhmsbeagle/GPU/kernels/Makefile.am',
+                        string=True)
+
+            # point CUDA_LIBS to libcuda.so
+            filter_file('-L$with_cuda/lib', '-L$with_cuda/lib64/stubs',
+                        'configure.ac', string=True)
+
+    def configure_args(self):
+        spec = self.spec
+        args = []
+
+        if '+cuda' in spec:
+            args.append('--with-cuda=%s' % spec['cuda'].prefix)
+        else:
+            args.append('--without-cuda')
+
+        return args
 
     def url_for_version(self, version):
         url = "https://github.com/beagle-dev/beagle-lib/archive/beagle_release_{0}.tar.gz"

--- a/var/spack/repos/builtin/packages/libbeagle/package.py
+++ b/var/spack/repos/builtin/packages/libbeagle/package.py
@@ -42,10 +42,9 @@ class Libbeagle(AutotoolsPackage, CudaPackage):
                         'configure.ac', string=True)
 
     def configure_args(self):
-        spec = self.spec
         args = []
 
-        if '+cuda' in spec:
+        if '+cuda' in self.spec:
             args.append('--with-cuda=%s' % spec['cuda'].prefix)
         else:
             args.append('--without-cuda')


### PR DESCRIPTION
libbeagle compiles against CUDA by default but no there is no mention of it in the package recipe.
This PR adds explicit cuda paths and variants, and fixes the target architecture as well (for those who don't have compute_13)