### PR TITLE
Allow section overrides in environment config

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -676,11 +676,7 @@ def _read_config_file(filename, schema):
     try:
         tty.debug("Reading config file %s" % filename)
         with open(filename) as f:
-            data = _mark_overrides(syaml.load(f))
-
-        if data:
-            validate(data, schema)
-        return data
+            return _read_config(f, schema)
 
     except MarkedYAMLError as e:
         raise ConfigFileError(
@@ -689,6 +685,13 @@ def _read_config_file(filename, schema):
     except IOError as e:
         raise ConfigFileError(
             "Error reading configuration file %s: %s" % (filename, str(e)))
+
+
+def _read_config(stream, schema):
+    data = _mark_overrides(syaml.load(stream))
+    if data:
+        validate(data, schema)
+    return data
 
 
 def _override(string):

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -225,7 +225,7 @@ class SingleFileScope(ConfigScope):
                 self._raw_data = self._raw_data[key]
 
             for section_key, data in self._raw_data.items():
-                self.sections[section_key] = {section_key : data}
+                self.sections[section_key] = {section_key: data}
 
         return self.sections[section]
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -676,8 +676,7 @@ def _read_config_file(filename, schema):
     try:
         tty.debug("Reading config file %s" % filename)
         with open(filename) as f:
-            base_data = syaml.load(f)
-            data = _mark_overrides(base_data)
+            data = _mark_overrides(syaml.load(f))
 
         if data:
             validate(data, schema)

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -224,8 +224,8 @@ class SingleFileScope(ConfigScope):
 
                 self._raw_data = self._raw_data[key]
 
-            for section, data in self._raw_data.items():
-                self.sections[section] = {section : data}
+            for section_key, data in self._raw_data.items():
+                self.sections[section_key] = {section_key : data}
 
         return self.sections[section]
 
@@ -471,7 +471,6 @@ class Configuration(object):
     """
         # TODO: Currently only handles maps. Think about lists if neded.
         section, _, rest = path.partition(':')
-
         value = self.get_config(section, scope=scope)
         if not rest:
             return value

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -7,7 +7,6 @@ import os
 import re
 import sys
 import shutil
-import tempfile
 import StringIO
 
 import ruamel.yaml

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -302,15 +302,6 @@ def all_environments():
         yield read(name)
 
 
-def validate(data, filename=None):
-    import jsonschema
-    try:
-        spack.schema.Validator(spack.schema.env.schema).validate(data)
-    except jsonschema.ValidationError as e:
-        raise spack.config.ConfigFormatError(
-            e, data, filename, e.instance.lc.line + 1)
-
-
 def _validate_config(data, schema):
     t = tempfile.NamedTemporaryFile()
     with open(t.name, 'wb') as f:

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -327,7 +327,6 @@ def _read_yaml(str_or_file):
 
 def _write_yaml(data, str_or_file):
     """Write YAML to a file preserving comments and dict order."""
-    filename = getattr(str_or_file, 'name', None)
     _validate_config(data, spack.schema.env.schema)
     ruamel.yaml.dump(data, str_or_file, Dumper=ruamel.yaml.RoundTripDumper,
                      default_flow_style=False)

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -8,6 +8,7 @@ import re
 import sys
 import shutil
 import tempfile
+import StringIO
 
 import ruamel.yaml
 
@@ -303,12 +304,11 @@ def all_environments():
 
 
 def _validate_config(data, schema):
-    t = tempfile.NamedTemporaryFile()
-    with open(t.name, 'wb') as f:
-        ruamel.yaml.dump(data, f, Dumper=ruamel.yaml.RoundTripDumper,
-                         encoding='utf-8')
+    stream = StringIO.StringIO()
+    ruamel.yaml.dump(data, stream, Dumper=ruamel.yaml.RoundTripDumper,
+                     encoding='utf-8')
 
-    spack.config._read_config_file(t.name, schema)
+    spack.config._read_config(stream, schema)
 
 
 def _validate_file(path, schema):

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -7,6 +7,7 @@ import os
 import re
 import sys
 import shutil
+import tempfile
 
 import ruamel.yaml
 
@@ -308,9 +309,6 @@ def validate(data, filename=None):
     except jsonschema.ValidationError as e:
         raise spack.config.ConfigFormatError(
             e, data, filename, e.instance.lc.line + 1)
-
-
-import tempfile
 
 
 def _validate_config(data, schema):

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -305,7 +305,8 @@ def all_environments():
 def _validate_config(data, schema):
     t = tempfile.NamedTemporaryFile()
     with open(t.name, 'wb') as f:
-        ruamel.yaml.dump(data, f, Dumper=ruamel.yaml.RoundTripDumper)
+        ruamel.yaml.dump(data, f, Dumper=ruamel.yaml.RoundTripDumper,
+                         encoding='utf-8')
 
     spack.config._read_config_file(t.name, schema)
 

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -616,7 +616,7 @@ def test_bad_command_line_scopes(tmpdir, mock_config):
 def test_add_command_line_scopes(tmpdir, mutable_config):
     config_yaml = str(tmpdir.join('config.yaml'))
     with open(config_yaml, 'w') as f:
-            f.write("""\
+        f.write("""\
 config:
     verify_ssl: False
     dirty: False

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -667,7 +667,6 @@ env:
 
         # from the lower config scopes
         assert spack.config.get('config:checksum') is True
-        assert spack.config.get('config:checksum') is True
         assert spack.config.get('packages:externalmodule:buildable') is False
         assert spack.config.get('repos') == [
             '/x/y/z', '$spack/var/spack/repos/builtin']

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -672,6 +672,40 @@ env:
             '/x/y/z', '$spack/var/spack/repos/builtin']
 
 
+def test_single_file_scope_section_override(tmpdir, config):
+    """Check that individual config sections can be overridden in an
+    environment config. The config here primarily differs in that the
+    ``packages`` section is intended to override all other scopes (using the
+    "::" syntax).
+    """
+    env_yaml = str(tmpdir.join("env.yaml"))
+    with open(env_yaml, 'w') as f:
+        f.write("""\
+env:
+    config:
+        verify_ssl: False
+    packages::
+        libelf:
+            compiler: [ 'gcc@4.5.3' ]
+    repos:
+        - /x/y/z
+""")
+
+    scope = spack.config.SingleFileScope(
+        'env', env_yaml, spack.schema.env.schema, ['env'])
+
+    with spack.config.override(scope):
+        # from the single-file config
+        assert spack.config.get('config:verify_ssl') is False
+        assert spack.config.get('packages:libelf:compiler') == ['gcc@4.5.3']
+
+        # from the lower config scopes
+        assert spack.config.get('config:checksum') is True
+        assert not spack.config.get('packages:externalmodule')
+        assert spack.config.get('repos') == [
+            '/x/y/z', '$spack/var/spack/repos/builtin']
+
+
 def check_schema(name, file_contents):
     """Check a Spack YAML schema against some data"""
     f = StringIO(file_contents)


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/10550

The following allows for environment configs like

```yaml
spack:
  specs:
    - python@3.6.1
  packages::                 <--- note the double colon
    python:
      variants: +optimizations
```

Spack environments use the `ruaml.yaml` library to read/write `yaml` in a manner that preserves comments, but Spack's own yaml reader contains logic specifically for allowing a `::` for any dictionary key to override a section.

This validates environment configuration by reading it in as a `spack_yaml` object, but preserves it as a `ruaml.yaml` object when it is being manipulated.