### PR TITLE
Fix problem detecting a symlink pointing to a non-existent file.

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -668,7 +668,7 @@ class Environment(object):
                 build_log_link = os.path.join(
                     log_path, '%s-%s.log' % (spec.name, spec.dag_hash(7)))
                 if os.path.exists(build_log_link) or \
-                os.path.islink(build_log_link):
+                   os.path.islink(build_log_link):
                     os.remove(build_log_link)
                 os.symlink(spec.package.build_log_path, build_log_link)
 

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -668,7 +668,7 @@ class Environment(object):
                 build_log_link = os.path.join(
                     log_path, '%s-%s.log' % (spec.name, spec.dag_hash(7)))
                 if os.path.exists(build_log_link) or \
-                    os.path.islink(build_log_link):
+                os.path.islink(build_log_link):
                     os.remove(build_log_link)
                 os.symlink(spec.package.build_log_path, build_log_link)
 

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -667,7 +667,8 @@ class Environment(object):
                 # Link the resulting log file into logs dir
                 build_log_link = os.path.join(
                     log_path, '%s-%s.log' % (spec.name, spec.dag_hash(7)))
-                if os.path.exists(build_log_link) or os.path.islink(build_log_link):
+                if os.path.exists(build_log_link) or \
+                    os.path.islink(build_log_link):
                     os.remove(build_log_link)
                 os.symlink(spec.package.build_log_path, build_log_link)
 

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -667,7 +667,7 @@ class Environment(object):
                 # Link the resulting log file into logs dir
                 build_log_link = os.path.join(
                     log_path, '%s-%s.log' % (spec.name, spec.dag_hash(7)))
-                if os.path.exists(build_log_link):
+                if os.path.exists(build_log_link) or os.path.islink(build_log_link):
                     os.remove(build_log_link)
                 os.symlink(spec.package.build_log_path, build_log_link)
 


### PR DESCRIPTION
The problem happens when `x->y` but `y` does not exist.  This can happen (but is harmless) when using Spack Setup.  See below for how these cases are handled in Python:
```
$ ln -s x y
$ ls -l x
ls: cannot access x: No such file or directory
$ ls -l y
lrwxrwxrwx 1 rpfische s1001 1 Feb 20 10:09 y -> x


$ python
Python 2.6.9 (unknown, Nov 19 2014, 15:44:49) 
[GCC 4.3.4 [gcc-4_3-branch revision 152973]] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> os.path.exists('x')
False
>>> os.path.exists('y')
False

$ echo hello >x
$ python
>>> os.path.exists('x')
True
>>> os.path.exists('y')
True

$ rm x
$ python
>>> os.path.islink('y')
True
>>> os.path.islink('ggg')
False
```
