### PR TITLE
Added packages for Flutter requirements

### DIFF
--- a/var/spack/repos/builtin/packages/ideviceinstaller/package.py
+++ b/var/spack/repos/builtin/packages/ideviceinstaller/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Ideviceinstaller(Package):
+    """Cross-platform library for communicating with iOS devices."""
+
+    homepage = "https://www.libimobiledevice.org/"
+    url      = "https://www.libimobiledevice.org/downloads/ideviceinstaller-1.1.0.tar.bz2"
+    git      = "https://git.libimobiledevice.org/ideviceinstaller.git"
+
+    version('master', branch='master')
+    version('1.1.0',  sha256='0821b8d3ca6153d9bf82ceba2706f7bd0e3f07b90a138d79c2448e42362e2f53')
+
+    depends_on('autoconf', when='@master')
+    depends_on('automake', when='@master')
+    depends_on('libtool',  when='@master')
+    depends_on('libimobiledevice')
+    depends_on('libzip')
+    depends_on('pkg-config')
+
+    def install(self, spec, prefix):
+        if self.spec.satisfies('@master'):
+            autogen = Executable('./autogen.sh')
+            autogen()
+        configure('--disable-dependency-tracking',
+                  '--prefix=%s' % self.spec.prefix)
+        make('install')

--- a/var/spack/repos/builtin/packages/ideviceinstaller/package.py
+++ b/var/spack/repos/builtin/packages/ideviceinstaller/package.py
@@ -15,6 +15,8 @@ class Ideviceinstaller(Package):
 
     version('master', branch='master')
     version('1.1.0',  sha256='0821b8d3ca6153d9bf82ceba2706f7bd0e3f07b90a138d79c2448e42362e2f53')
+    version('1.0.1',  sha256='e2e5dc41c08cce7cec9edaf4596322f424d5195c255d3c1b957b81b45529b4f5')
+    version('1.0.0',  sha256='6d781621e0823275b22cfbcfb13f2707d4630da040744acca77ed987d0928d86')
 
     depends_on('autoconf', when='@master')
     depends_on('automake', when='@master')

--- a/var/spack/repos/builtin/packages/libimobiledevice/package.py
+++ b/var/spack/repos/builtin/packages/libimobiledevice/package.py
@@ -1,0 +1,38 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Libimobiledevice(Package):
+    """Library to communicate with iOS devices natively."""
+
+    homepage = "https://www.libimobiledevice.org/"
+    url      = "https://www.libimobiledevice.org/downloads/libimobiledevice-1.2.0.tar.bz2"
+    git      = "https://git.libimobiledevice.org/libimobiledevice.git"
+
+    version('master', branch='master')
+    version('1.2.0',  sha256='786b0de0875053bf61b5531a86ae8119e320edab724fc62fe2150cc931f11037')
+
+    depends_on('autoconf', when='@master')
+    depends_on('automake', when='@master')
+    depends_on('libtool',  when='@master')
+    depends_on('libxml2',  when='@master')
+    depends_on('libplist')
+    depends_on('libtasn1')
+    depends_on('libusbmuxd')
+    depends_on('openssl')
+    depends_on('pkg-config')
+
+    def install(self, spec, prefix):
+        if self.spec.satisfies('@master'):
+            autogen = Executable('./autogen.sh')
+            autogen()
+        configure('--disable-dependency-tracking',
+                  '--disable-silent-rules',
+                  '--enable-debug-code',
+                  '--prefix=%s' % self.spec.prefix,
+                  '--without-cython')
+        make('install')

--- a/var/spack/repos/builtin/packages/libimobiledevice/package.py
+++ b/var/spack/repos/builtin/packages/libimobiledevice/package.py
@@ -19,7 +19,6 @@ class Libimobiledevice(Package):
     depends_on('autoconf', when='@master')
     depends_on('automake', when='@master')
     depends_on('libtool',  when='@master')
-    depends_on('libxml2',  when='@master')
     depends_on('libplist')
     depends_on('libtasn1')
     depends_on('libusbmuxd')

--- a/var/spack/repos/builtin/packages/libplist/package.py
+++ b/var/spack/repos/builtin/packages/libplist/package.py
@@ -1,0 +1,40 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Libplist(Package):
+    """Library for Apple Binary- and XML-Property Lists."""
+
+    homepage = "https://www.libimobiledevice.org/"
+    url      = "https://www.libimobiledevice.org/downloads/libplist-2.0.0.tar.bz2"
+    git      = "https://git.sukimashita.com/libplist.git"
+
+    version('master',   branch='master')
+    version('2.0.0',    sha256='3a7e9694c2d9a85174ba1fa92417cfabaea7f6d19631e544948dc7e17e82f602')
+    version('1.10',     sha256='f44c52a0f8065d41d44772a7484f93bc5e7da21a8f4a9ad3f38a36b827eeff0b')
+    version('1.9',      sha256='53c4d49db3b3ac9e5a17a2abc3000c529cf2b7d0229c4a25d7c2d465bc3ce3fc')
+    version('1.8',      sha256='a418da3880308199b74766deef2a760a9b169b81a868a6a9032f7614e20500ec')
+    version('1.7',      sha256='92ad4d7e71ee13bd8ad17c99c193d26b22a18c226f0068c3ee63085a9f8c4451')
+    version('1.6',      sha256='2e548ef3239e7bbbbf4771b19a6eedbf78f91e5e6c96d5df83c52838e16cffd6')
+    version('1.5',      sha256='2380a93e8ae0c591f921798ab333a66fda35f85001bd31941aaa58f7aef1e0d9')
+    version('1.4',      sha256='2ad226abe1131a72e7ecbb2b921ad92f54b8e787c2281c89b00145b519479a71')
+    version('1.3',      sha256='982c8aac59cdc3fafc925a407a29b6cf367c5ec9bad6ad509fe5ea25d3e5b6b0')
+
+    depends_on('pkg-config')
+    depends_on('autoconf', when='@master')
+    depends_on('automake', when='@master')
+    depends_on('libtool',  when='@master')
+
+    def install(self, spec, prefix):
+        if self.spec.satisfies('@master:'):
+            autogen = Executable('./autogen.sh')
+            autogen()
+        configure('--disable-dependency-tracking',
+                  '--disable-silent-rules',
+                  '--prefix=%s' % self.spec.prefix,
+                  '--without-cython')
+        make('install', 'PYTHON_LDFLAGS=-undefined dynamic_lookup')

--- a/var/spack/repos/builtin/packages/libplist/package.py
+++ b/var/spack/repos/builtin/packages/libplist/package.py
@@ -11,7 +11,7 @@ class Libplist(Package):
 
     homepage = "https://www.libimobiledevice.org/"
     url      = "https://www.libimobiledevice.org/downloads/libplist-2.0.0.tar.bz2"
-    git      = "https://git.sukimashita.com/libplist.git"
+    git      = "https://git.libimobiledevice.org/libplist.git"
 
     version('master',   branch='master')
     version('2.0.0',    sha256='3a7e9694c2d9a85174ba1fa92417cfabaea7f6d19631e544948dc7e17e82f602')

--- a/var/spack/repos/builtin/packages/libplist/package.py
+++ b/var/spack/repos/builtin/packages/libplist/package.py
@@ -30,7 +30,7 @@ class Libplist(Package):
     depends_on('libtool',  when='@master')
 
     def install(self, spec, prefix):
-        if self.spec.satisfies('@master:'):
+        if self.spec.satisfies('@master'):
             autogen = Executable('./autogen.sh')
             autogen()
         configure('--disable-dependency-tracking',

--- a/var/spack/repos/builtin/packages/libtasn1/package.py
+++ b/var/spack/repos/builtin/packages/libtasn1/package.py
@@ -1,0 +1,33 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Libtasn1(Package):
+    """ASN.1 structure parser library."""
+
+    homepage = "https://www.gnu.org/software/libtasn1/"
+    url      = "https://ftp.gnu.org/gnu/libtasn1/libtasn1-4.13.tar.gz"
+
+    version('4.13',     sha256='7e528e8c317ddd156230c4e31d082cd13e7ddeb7a54824be82632209550c8cca')
+    version('4.12',     sha256='6753da2e621257f33f5b051cc114d417e5206a0818fe0b1ecfd6153f70934753')
+    version('4.10',     sha256='681a4d9a0d259f2125713f2e5766c5809f151b3a1392fd91390f780b4b8f5a02')
+    version('4.9',      sha256='4f6f7a8fd691ac2b8307c8ca365bad711db607d4ad5966f6938a9d2ecd65c920')
+    version('4.8',      sha256='fa802fc94d79baa00e7397cedf29eb6827d4bd8b4dd77b577373577c93a8c513')
+    version('4.7',      sha256='a40780dc93fc6d819170240e8ece25352058a85fd1d2347ce0f143667d8f11c9')
+    version('4.6',      sha256='3462fc25e2d2536878c39a8825f5e36ba2e2611b27ef535e064f4c56258e508b')
+    version('4.5',      sha256='89b3b5dce119273431544ecb305081f3530911001bb12e5d76588907edb71bda')
+    version('4.4',      sha256='f8349db1b4fe634105c77e11d26b2173e587827e86e1a489b5e38ffa822e0c5d')
+    version('4.3',      sha256='733513e3ffb03bd4910f97ef2683e602b40501428e4eb7649e325c2f4b1756cc')
+    version('4.2',      sha256='693b41cb36c2ac02d5990180b0712a79a591168e93d85f7fcbb75a0a0be4cdbb')
+    version('4.1',      sha256='60ee6571dcfa00cf55406404912274d6dc759cbaa80d666b89d819feeff5f301')
+    version('4.0',      sha256='41d044f7644bdd1c4f8a5c15ac1885ca1fcbf32f5f6dd4760a19278b979857fe')
+
+    def install(self, spec, prefix):
+        configure('--disable-dependency-tracking',
+                  '--disable-silent-rules',
+                  '--prefix=%s' % self.spec.prefix)
+        make('install')

--- a/var/spack/repos/builtin/packages/libusb/package.py
+++ b/var/spack/repos/builtin/packages/libusb/package.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Libusb(Package):
+    """Library for USB device access."""
+
+    homepage = "https://libusb.info/"
+    url      = "https://github.com/libusb/libusb/releases/download/v1.0.22/libusb-1.0.22.tar.bz2"
+    git      = "https://github.com/libusb/libusb"
+
+    version('master', branch='master')
+    version('1.0.22', sha256='75aeb9d59a4fdb800d329a545c2e6799f732362193b465ea198f2aa275518157')
+    version('1.0.21', sha256='7dce9cce9a81194b7065ee912bcd55eeffebab694ea403ffb91b67db66b1824b')
+    version('1.0.20', sha256='cb057190ba0a961768224e4dc6883104c6f945b2bf2ef90d7da39e7c1834f7ff')
+
+    depends_on('autoconf', when='@master')
+    depends_on('automake', when='@master')
+    depends_on('libtool',  when='@master')
+
+    def install(self, spec, prefix):
+        if self.spec.satisfies('@master'):
+            autogen = Executable('./autogen.sh')
+            autogen()
+        configure('--disable-dependency-tracking',
+                  '--prefix=%s' % self.spec.prefix)
+        make('install')

--- a/var/spack/repos/builtin/packages/libusbmuxd/package.py
+++ b/var/spack/repos/builtin/packages/libusbmuxd/package.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Libusbmuxd(Package):
+    """A client library to multiplex connections from and to iOS devices."""
+
+    homepage = "https://www.libimobiledevice.org/"
+    url      = "https://www.libimobiledevice.org/downloads/libusbmuxd-1.0.10.tar.bz2"
+    git      = "https://git.sukimashita.com/libusbmuxd.git"
+
+    version('master', branch='master')
+    version('1.0.10', sha256='1aa21391265d2284ac3ccb7cf278126d10d354878589905b35e8102104fec9f2')
+    version('1.0.9',  sha256='2e3f708a3df30ad7832d2d2389eeb29f68f4e4488a42a20149cc99f4f9223dfc')
+
+    depends_on('autoconf', when='@master')
+    depends_on('automake', when='@master')
+    depends_on('libtool',  when='@master')
+    depends_on('libplist')
+    depends_on('libusb')
+    depends_on('pkg-config')
+
+    def install(self, spec, prefix):
+        if self.spec.satisfies('@master'):
+            autogen = Executable('./autogen.sh')
+            autogen()
+        configure('--disable-dependency-tracking',
+                  '--disable-silent-rules',
+                  '--prefix=%s' % self.spec.prefix)
+        make('install')

--- a/var/spack/repos/builtin/packages/libusbmuxd/package.py
+++ b/var/spack/repos/builtin/packages/libusbmuxd/package.py
@@ -11,7 +11,7 @@ class Libusbmuxd(Package):
 
     homepage = "https://www.libimobiledevice.org/"
     url      = "https://www.libimobiledevice.org/downloads/libusbmuxd-1.0.10.tar.bz2"
-    git      = "https://git.sukimashita.com/libusbmuxd.git"
+    git      = "https://git.libimobiledevice.org/libusbmuxd.git"
 
     version('master', branch='master')
     version('1.0.10', sha256='1aa21391265d2284ac3ccb7cf278126d10d354878589905b35e8102104fec9f2')

--- a/var/spack/repos/builtin/packages/libusbmuxd/package.py
+++ b/var/spack/repos/builtin/packages/libusbmuxd/package.py
@@ -21,7 +21,6 @@ class Libusbmuxd(Package):
     depends_on('automake', when='@master')
     depends_on('libtool',  when='@master')
     depends_on('libplist')
-    depends_on('libusb')
     depends_on('pkg-config')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/usbmuxd/package.py
+++ b/var/spack/repos/builtin/packages/usbmuxd/package.py
@@ -32,4 +32,3 @@ class Usbmuxd(Package):
                   '--disable-silent-rules',
                   '--prefix=%s' % self.spec.prefix)
         make('install')
-

--- a/var/spack/repos/builtin/packages/usbmuxd/package.py
+++ b/var/spack/repos/builtin/packages/usbmuxd/package.py
@@ -1,0 +1,35 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Usbmuxd(Package):
+    """A socket daemon to multiplex connections from and to iOS devices."""
+
+    homepage = "https://www.libimobiledevice.org/"
+    url      = "https://www.libimobiledevice.org/downloads/usbmuxd-1.1.0.tar.bz2"
+    git      = "https://cgit.libimobiledevice.org/usbmuxd.git"
+
+    version('master', branch='master')
+    version('1.1.0',  sha256='3e8948b4fe4250ee5c4bd41ccd1b83c09b8a6f5518a7d131a66fd38bd461b42d')
+
+    depends_on('autoconf', when='@master')
+    depends_on('automake', when='@master')
+    depends_on('libtool',  when='@master')
+    depends_on('libimobiledevice')
+    depends_on('libplist')
+    depends_on('libusb')
+    depends_on('pkg-config')
+
+    def install(self, spec, prefix):
+        if self.spec.satisfies('@master'):
+            autogen = Executable('./autogen.sh')
+            autogen()
+        configure('--disable-dependency-tracking',
+                  '--disable-silent-rules',
+                  '--prefix=%s' % self.spec.prefix)
+        make('install')
+

--- a/var/spack/repos/builtin/packages/usbmuxd/package.py
+++ b/var/spack/repos/builtin/packages/usbmuxd/package.py
@@ -11,7 +11,7 @@ class Usbmuxd(Package):
 
     homepage = "https://www.libimobiledevice.org/"
     url      = "https://www.libimobiledevice.org/downloads/usbmuxd-1.1.0.tar.bz2"
-    git      = "https://cgit.libimobiledevice.org/usbmuxd.git"
+    git      = "https://git.libimobiledevice.org/usbmuxd.git"
 
     version('master', branch='master')
     version('1.1.0',  sha256='3e8948b4fe4250ee5c4bd41ccd1b83c09b8a6f5518a7d131a66fd38bd461b42d')


### PR DESCRIPTION
This PR introduces all of the dependencies required to work with Google's [Flutter](http://flutter.io/) tooling. Most of this is porting/updating of the existing recipes on Homebrew, but pointing to the correct Git repositories and so on (fun fact: Homebrew uses the name "usbmuxd" when it actually means "libusbmuxd").

I installed all of these packages via `spack` and was able to use Flutter correctly, so I assume all is well. There's an oddity in `ideviceinstaller` though, in that `1.1.0` does not build on my machine. I think this is actually a bug in the code rather than the spec though because `@master` is fine.

If someone could guide me on the correct time to use `type='build'`, I think there might be a few candidates in here. I think the `pkg-config` dependencies can be `build`, as well as all of those utilities using `when='@master'`. If this makes sense to whoever reviews this, I can change that up - I'm just not sure currently. 

There are a lot of packages here, so I can re-target them as individual PRs if needed. I wasn't sure how to structure this PR because there's dependency between the packages so I wanted to avoid being blocked on PRs being merged to add future packages. 