### PR TITLE
autoconf: Respect $TMPDIR, and make it work, if sysadmins set it

### DIFF
--- a/var/spack/repos/builtin/packages/autoconf/package.py
+++ b/var/spack/repos/builtin/packages/autoconf/package.py
@@ -7,6 +7,7 @@ from spack import *
 import os
 import shutil
 
+
 class Autoconf(AutotoolsPackage):
     """Autoconf -- system configuration part of autotools"""
 
@@ -41,10 +42,11 @@ class Autoconf(AutotoolsPackage):
         # TMPDIR.  Autoconf build will crash if TMPDIR has not already
         # been created.
 
-        if ('TMPDIR' in os.environ) and (not os.path.exists(os.environ['TMPDIR'])):
+        if ('TMPDIR' in os.environ) and \
+           (not os.path.exists(os.environ['TMPDIR'])):
             os.makedirs(os.environ['TMPDIR'])
             # Store the fact that we created TMPDIR, so we can remove it later
-            with open('__CREATED_TMPDIR__', 'w') as fout:
+            with open('__CREATED_TMPDIR__', 'w'):
                 pass
             self.created_tmpdir = True
 
@@ -68,8 +70,6 @@ class Autoconf(AutotoolsPackage):
                     backup=False)
 
         # Remove TMPDIR
-
-
 
     def _make_executable(self, name):
         return Executable(join_path(self.prefix.bin, name))

--- a/var/spack/repos/builtin/packages/autoconf/package.py
+++ b/var/spack/repos/builtin/packages/autoconf/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-
+import os
 
 class Autoconf(AutotoolsPackage):
     """Autoconf -- system configuration part of autotools"""
@@ -30,6 +30,21 @@ class Autoconf(AutotoolsPackage):
         filter_file('^#! @PERL@ -w',
                     '#! /usr/bin/env perl',
                     'bin/autom4te.in')
+
+    def configure(self, spec, prefix):
+        # Intel compiler modules set TMPDIR; and must be loaded for
+        # Intel compiler to run.  If TMPDIR is set, then the autoconf
+        # build will use it; but autoconf does not actually create
+        # TMPDIR.  Autoconf build will crash if TMPDIR has not already
+        # been created.
+
+        if 'TMPDIR' in os.environ:
+            try:
+                os.makedirs(os.environ['TMPDIR'])
+            except OSError:
+                pass   # Already exists
+
+        super(Autoconf, self).configure(spec, prefix)
 
     @run_after('install')
     def filter_sbang(self):

--- a/var/spack/repos/builtin/packages/autoconf/package.py
+++ b/var/spack/repos/builtin/packages/autoconf/package.py
@@ -46,16 +46,16 @@ class Autoconf(AutotoolsPackage):
            (not os.path.exists(os.environ['TMPDIR'])):
             os.makedirs(os.environ['TMPDIR'])
             # Store the fact that we created TMPDIR, so we can remove it later
-            with open('__CREATED_TMPDIR__', 'w'):
+            with open('__SPACK_CREATED_TMPDIR__', 'w'):
                 pass
             self.created_tmpdir = True
 
     @run_after('install')
     def remove_tmpdir(self):
         # Clean up, remove the TMPDIR that we created
-        if os.path.exists('__CREATED_TMPDIR__'):
+        if os.path.exists('__SPACK_CREATED_TMPDIR__'):
             shutil.rmtree(os.environ['TMPDIR'], ignore_errors=True)
-            os.remove('__CREATED_TMPDIR__')
+            os.remove('__SPACK_CREATED_TMPDIR__')
 
     @run_after('install')
     def filter_sbang(self):

--- a/var/spack/repos/builtin/packages/autoconf/package.py
+++ b/var/spack/repos/builtin/packages/autoconf/package.py
@@ -22,7 +22,7 @@ class Autoconf(AutotoolsPackage):
     # needed when autoconf runs, not only when autoconf is built.
     depends_on('m4@1.4.6:', type=('build', 'run'))
     depends_on('perl', type=('build', 'run'))
-#    depends_on('help2man', type=('build'))
+    # depends_on('help2man', type=('build'))   # Optional dependency
 
     build_directory = 'spack-build'
 
@@ -32,26 +32,6 @@ class Autoconf(AutotoolsPackage):
         filter_file('^#! @PERL@ -w',
                     '#! /usr/bin/env perl',
                     'bin/autom4te.in')
-
-#    def configure(self, spec, prefix):
-#        # Intel compiler modules set TMPDIR; and must be loaded for
-#        # Intel compiler to run.  If TMPDIR is set, then the autoconf
-#        # build will use it; but autoconf does not actually create
-#        # TMPDIR.  Autoconf build will crash if TMPDIR has not already
-#        # been created.
-#
-#        print('fffffffffffffffffffff', os.environ['TMPDIR'])
-#        if 'TMPDIR' in os.environ:
-#            try:
-#                print('Creating TMPDIR')
-#                os.makedirs(os.environ['TMPDIR'])
-#                with open('__CREATED_TMPDIR__', 'w') as fout:
-#                    pass
-#                self.created_tmpdir = True
-#            except OSError:
-#                pass   # Already exists
-#
-#        super(Autoconf, self).configure(spec, prefix)
 
     @run_before('configure')
     def create_tmpdir(self):
@@ -63,12 +43,14 @@ class Autoconf(AutotoolsPackage):
 
         if ('TMPDIR' in os.environ) and (not os.path.exists(os.environ['TMPDIR'])):
             os.makedirs(os.environ['TMPDIR'])
+            # Store the fact that we created TMPDIR, so we can remove it later
             with open('__CREATED_TMPDIR__', 'w') as fout:
                 pass
             self.created_tmpdir = True
 
     @run_after('install')
     def remove_tmpdir(self):
+        # Clean up, remove the TMPDIR that we created
         if os.path.exists('__CREATED_TMPDIR__'):
             shutil.rmtree(os.environ['TMPDIR'], ignore_errors=True)
             os.remove('__CREATED_TMPDIR__')


### PR DESCRIPTION
I was getting the error message with `spack install autoconf`:
```
autom4te: cannot create /gpfsm/dnb53/tdirs/login/discover32.13546.rpfische/am4t8860.25474: 2
```
Inspection showed that `discover32.13546.rpfische` did not exist.  I am on a shared supercomputer where, in their infinite wisdom, the sysadmins decided to set my `$TMPDIR` in a particular way when I logged in.  I feel that should be respected, i.e. temporary files should be created there.  I use `spack install --dirty` because --- among other things --- the Intel compilers and MPI and git, etc. don't work unless you have just the right modules loaded.

`TMPDIR` gets picked up and used by some packages (such as `autoconf`). But `TMPDIR` is not actually created on my system, it's just set as an env var.  Thus, the package's build cannot create what it needs to create inside of `TMPDIR`.

This problem could be approached by patching the package's build, or by updating the Spack recipe.  I chose the latter.
