### PR TITLE
automake@1.13.4: add new version

### DIFF
--- a/var/spack/repos/builtin/packages/automake/package.py
+++ b/var/spack/repos/builtin/packages/automake/package.py
@@ -12,12 +12,12 @@ class Automake(AutotoolsPackage):
     homepage = 'http://www.gnu.org/software/automake/'
     url      = 'https://ftpmirror.gnu.org/automake/automake-1.15.tar.gz'
 
-    version('1.16.1', '83cc2463a4080efd46a72ba2c9f6b8f5')
-    version('1.15.1', '95df3f2d6eb8f81e70b8cb63a93c8853')
-    version('1.15',   '716946a105ca228ab545fc37a70df3a3')
-    version('1.14.1', 'd052a3e884631b9c7892f2efce542d75')
+    version('1.16.1', '608a97523f97db32f1f5d5615c98ca69326ced2054c9f82e65bade7fc4c9dea8')
+    version('1.15.1', '988e32527abe052307d21c8ca000aa238b914df363a617e38f4fb89f5abf6260')
+    version('1.15',   '7946e945a96e28152ba5a6beb0625ca715c6e32ac55f2e353ef54def0c8ed924')
+    version('1.14.1', '814c2333f350ce00034a1fe718e0e4239998ceea7b0aff67e9fd273ed6dfc23b')
     version('1.13.4', '4c93abc0bff54b296f41f92dd3aa1e73e554265a6f719df465574983ef6f878c')
-    version('1.11.6', '0286dc30295b62985ca51919202ecfcc')
+    version('1.11.6', '53dbf1945401c43f4ce19c1971baecdbf8bc32e0f37fa3f49fe7b6992d0d2030')
 
     depends_on('autoconf', type='build')
     depends_on('perl', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/automake/package.py
+++ b/var/spack/repos/builtin/packages/automake/package.py
@@ -16,6 +16,7 @@ class Automake(AutotoolsPackage):
     version('1.15.1', '95df3f2d6eb8f81e70b8cb63a93c8853')
     version('1.15',   '716946a105ca228ab545fc37a70df3a3')
     version('1.14.1', 'd052a3e884631b9c7892f2efce542d75')
+    version('1.13.4', '4c93abc0bff54b296f41f92dd3aa1e73e554265a6f719df465574983ef6f878c')
     version('1.11.6', '0286dc30295b62985ca51919202ecfcc')
 
     depends_on('autoconf', type='build')


### PR DESCRIPTION
This pull request:

* Adds automake version 1.13.4
* Replaces MD5 hashes for all versions of automake with SHA256 hashes