### PR TITLE
curl: Add more complete dependencies, to avoid pollution from system stuff.

### DIFF
--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -67,7 +67,7 @@ class Curl(AutotoolsPackage):
     conflicts('platform=darwin', when='+libssh')
     conflicts('platform=linux', when='+darwinssl')
 
-    # ================= 
+    # =================
     depends_on('zlib')
     depends_on('cares', when='+cares')
     depends_on('gnutls', when='+gnutls')


### PR DESCRIPTION
Previously, the `curl` build was picking up a system dependency that dependend on the system `openssl`.  Thus, both the system and Spack `openssl` were included in the build, which caused it to fail in weird ways.  This problem was not caught on most systems because the Spack and system `openssl` are similar (enough) versions.  But I'm building on an old system with a really old system `openssl`, making the bug apparent.

The solution was to go through the dependency list, add more variants where appropriate, and explicitly turn off dependencies we don't use.