### PR TITLE
Do not use `string` module to be compatible with python 3 (#248)

### DIFF
--- a/lib/spack/spack/cmd/setup.py
+++ b/lib/spack/spack/cmd/setup.py
@@ -6,7 +6,6 @@
 import argparse
 import copy
 import os
-import string
 import sys
 
 import llnl.util.tty as tty
@@ -85,7 +84,7 @@ env = dict(os.environ)
         env_vars = sorted(list(env.keys()))
         for name in env_vars:
             val = env[name]
-            if string.find(name, 'PATH') < 0:
+            if name.find('PATH') < 0:
                 fout.write('env[%s] = %s\n' % (repr(name), repr(val)))
             else:
                 if name == 'SPACK_TRANSITIVE_INCLUDE_PATH':
@@ -95,7 +94,7 @@ env = dict(os.environ)
 
                 fout.write(
                     'env[%s] = "%s".join(cmdlist("""\n' % (repr(name), sep))
-                for part in string.split(val, sep):
+                for part in val.split(sep):
                     fout.write('    %s\n' % part)
                 fout.write('"""))\n')
 


### PR DESCRIPTION
`string.find` is not part of Python 3 anymore.

This pull-request allows one to use `spack setup ...` also with Python 3.