### PR TITLE
Fix gcc~nvptx build

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -320,56 +320,57 @@ class Gcc(AutotoolsPackage):
         spec = self.spec
         prefix = self.prefix
 
-        if spec.satisfies('+nvptx'):
+        if not spec.satisfies('+nvptx'):
+            return
 
-            # config.guess returns the host triple, e.g. "x86_64-pc-linux-gnu"
-            guess = Executable('./config.guess')
-            targetguess = guess(output=str).rstrip('\n')
+        # config.guess returns the host triple, e.g. "x86_64-pc-linux-gnu"
+        guess = Executable('./config.guess')
+        targetguess = guess(output=str).rstrip('\n')
 
-            options = getattr(self, 'configure_flag_args', [])
-            options += ['--prefix={0}'.format(prefix)]
+        options = getattr(self, 'configure_flag_args', [])
+        options += ['--prefix={0}'.format(prefix)]
 
-            options += [
-                '--with-cuda-driver-include={0}'.format(
-                    spec['cuda'].prefix.include),
-                '--with-cuda-driver-lib={0}'.format(
-                    spec['cuda'].libs.directories[0]),
-            ]
+        options += [
+            '--with-cuda-driver-include={0}'.format(
+                spec['cuda'].prefix.include),
+            '--with-cuda-driver-lib={0}'.format(
+                spec['cuda'].libs.directories[0]),
+        ]
 
-            with working_dir('nvptx-tools'):
-                configure = Executable("./configure")
-                configure(*options)
-                make()
-                make('install')
+        with working_dir('nvptx-tools'):
+            configure = Executable("./configure")
+            configure(*options)
+            make()
+            make('install')
 
-            pattern = join_path(self.stage.source_path, 'newlibsource', '*')
-            files = glob.glob(pattern)
+        pattern = join_path(self.stage.source_path, 'newlibsource', '*')
+        files = glob.glob(pattern)
 
-            if files:
-                symlink(join_path(files[0], 'newlib'), 'newlib')
+        if files:
+            symlink(join_path(files[0], 'newlib'), 'newlib')
 
-            # self.build_directory = 'spack-build-nvptx'
-            with working_dir('spack-build-nvptx', create=True):
+        # self.build_directory = 'spack-build-nvptx'
+        with working_dir('spack-build-nvptx', create=True):
 
-                options = ['--prefix={0}'.format(prefix),
-                           '--enable-languages={0}'.format(
-                           ','.join(spec.variants['languages'].value)),
-                           '--with-mpfr={0}'.format(spec['mpfr'].prefix),
-                           '--with-gmp={0}'.format(spec['gmp'].prefix),
-                           '--target=nvptx-none',
-                           '--with-build-time-tools={0}'.format(
-                               join_path(prefix,
-                                         'nvptx-none', 'bin')),
-                           '--enable-as-accelerator-for={0}'.format(
-                               targetguess),
-                           '--disable-sjlj-exceptions',
-                           '--enable-newlib-io-long-long',
-                           ]
+            options = ['--prefix={0}'.format(prefix),
+                       '--enable-languages={0}'.format(
+                       ','.join(spec.variants['languages'].value)),
+                       '--with-mpfr={0}'.format(spec['mpfr'].prefix),
+                       '--with-gmp={0}'.format(spec['gmp'].prefix),
+                       '--target=nvptx-none',
+                       '--with-build-time-tools={0}'.format(
+                           join_path(prefix,
+                                     'nvptx-none', 'bin')),
+                       '--enable-as-accelerator-for={0}'.format(
+                           targetguess),
+                       '--disable-sjlj-exceptions',
+                       '--enable-newlib-io-long-long',
+                       ]
 
-                configure = Executable("../configure")
-                configure(*options)
-                make()
-                make('install')
+            configure = Executable("../configure")
+            configure(*options)
+            make()
+            make('install')
 
     @property
     def build_targets(self):

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -315,60 +315,61 @@ class Gcc(AutotoolsPackage):
 
     # run configure/make/make(install) for the nvptx-none target
     # before running the host compiler phases
-    @when('+nvptx')
     @run_before('configure')
     def nvptx_install(self):
         spec = self.spec
         prefix = self.prefix
 
-        # config.guess returns the host triple, e.g. "x86_64-pc-linux-gnu"
-        guess = Executable('./config.guess')
-        targetguess = guess(output=str).rstrip('\n')
+        if spec.satisfies('+nvptx'):
 
-        options = getattr(self, 'configure_flag_args', [])
-        options += ['--prefix={0}'.format(prefix)]
+            # config.guess returns the host triple, e.g. "x86_64-pc-linux-gnu"
+            guess = Executable('./config.guess')
+            targetguess = guess(output=str).rstrip('\n')
 
-        options += [
-            '--with-cuda-driver-include={0}'.format(
-                spec['cuda'].prefix.include),
-            '--with-cuda-driver-lib={0}'.format(
-                spec['cuda'].libs.directories[0]),
-        ]
+            options = getattr(self, 'configure_flag_args', [])
+            options += ['--prefix={0}'.format(prefix)]
 
-        with working_dir('nvptx-tools'):
-            configure = Executable("./configure")
-            configure(*options)
-            make()
-            make('install')
+            options += [
+                '--with-cuda-driver-include={0}'.format(
+                    spec['cuda'].prefix.include),
+                '--with-cuda-driver-lib={0}'.format(
+                    spec['cuda'].libs.directories[0]),
+            ]
 
-        pattern = join_path(self.stage.source_path, 'newlibsource', '*')
-        files = glob.glob(pattern)
+            with working_dir('nvptx-tools'):
+                configure = Executable("./configure")
+                configure(*options)
+                make()
+                make('install')
 
-        if files:
-            symlink(join_path(files[0], 'newlib'), 'newlib')
+            pattern = join_path(self.stage.source_path, 'newlibsource', '*')
+            files = glob.glob(pattern)
 
-        # self.build_directory = 'spack-build-nvptx'
-        with working_dir('spack-build-nvptx', create=True):
+            if files:
+                symlink(join_path(files[0], 'newlib'), 'newlib')
 
-            options = ['--prefix={0}'.format(prefix),
-                       '--enable-languages={0}'.format(
-                       ','.join(spec.variants['languages'].value)),
-                       '--with-mpfr={0}'.format(spec['mpfr'].prefix),
-                       '--with-gmp={0}'.format(spec['gmp'].prefix),
-                       '--target=nvptx-none',
-                       '--with-build-time-tools={0}'.format(
-                           join_path(prefix,
-                                     'nvptx-none', 'bin')),
-                       '--enable-as-accelerator-for={0}'.format(
-                           targetguess),
-                       '--disable-sjlj-exceptions',
-                       '--enable-newlib-io-long-long',
-                       ]
+            # self.build_directory = 'spack-build-nvptx'
+            with working_dir('spack-build-nvptx', create=True):
 
-            configure = Executable("../configure")
-            configure(*options)
-            make()
-            make('install')
+                options = ['--prefix={0}'.format(prefix),
+                           '--enable-languages={0}'.format(
+                           ','.join(spec.variants['languages'].value)),
+                           '--with-mpfr={0}'.format(spec['mpfr'].prefix),
+                           '--with-gmp={0}'.format(spec['gmp'].prefix),
+                           '--target=nvptx-none',
+                           '--with-build-time-tools={0}'.format(
+                               join_path(prefix,
+                                         'nvptx-none', 'bin')),
+                           '--enable-as-accelerator-for={0}'.format(
+                               targetguess),
+                           '--disable-sjlj-exceptions',
+                           '--enable-newlib-io-long-long',
+                           ]
+
+                configure = Executable("../configure")
+                configure(*options)
+                make()
+                make('install')
 
     @property
     def build_targets(self):


### PR DESCRIPTION
Looks like commit 040b65876bea73c761aaaf32cf7886fb790f496c broke the gcc~nvptx build (i.e. the default).  This PR inserts the proper logic into nvptx_install to select (or not) the nvptx offload capability