### PR TITLE
downgrade warning message to debug message

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -691,9 +691,9 @@ def setup_package(pkg, dirty):
         dpkg.setup_dependent_environment(spack_env, run_env, spec)
 
     if (not dirty) and (not spack_env.is_unset('CPATH')):
-        tty.warn("A dependency has updated CPATH, this may lead pkg-config"
-                 " to assume that the package is part of the system"
-                 " includes and omit it when invoked with '--cflags'.")
+        tty.debug("A dependency has updated CPATH, this may lead pkg-config"
+                  " to assume that the package is part of the system"
+                  " includes and omit it when invoked with '--cflags'.")
 
     set_module_variables_for_package(pkg)
     pkg.setup_environment(spack_env, run_env)


### PR DESCRIPTION
Spack warns users when a dependency package updates CPATH. This warning message is generating bug reports and alarm in cases where there is no problem. For now this downgrades the warning message to the debug level, so it only shows up if something goes wrong for the user.

Also note that https://github.com/spack/spack/pull/10644 may be merged soon which would avoid this issue entirely.