### PR TITLE
slurm: Add PMI support

### DIFF
--- a/var/spack/repos/builtin/packages/slurm/package.py
+++ b/var/spack/repos/builtin/packages/slurm/package.py
@@ -34,6 +34,7 @@ class Slurm(AutotoolsPackage):
     variant('hwloc', default=False, description='Enable hwloc support')
     variant('hdf5', default=False, description='Enable hdf5 support')
     variant('readline', default=True, description='Enable readline support')
+    variant('pmix', default=False, description='Enable PMIx support')
 
     # TODO: add variant for BG/Q and Cray support
 
@@ -55,6 +56,7 @@ class Slurm(AutotoolsPackage):
     depends_on('hdf5', when='+hdf5')
     depends_on('hwloc', when='+hwloc')
     depends_on('mariadb', when='+mariadb')
+    depends_on('pmix', when='+pmix')
 
     def configure_args(self):
 
@@ -87,4 +89,13 @@ class Slurm(AutotoolsPackage):
         else:
             args.append('--without-hwloc')
 
+        if '+pmix' in spec:
+            args.append('--with-pmix={0}'.format(spec['pmix'].prefix))
+        else:
+            args.append('--without-pmix')
+
         return args
+
+    def install(self, spec, prefix):
+        make('install')
+        make('-C', 'contribs/pmi2', 'install')


### PR DESCRIPTION
- Add support for pmix
- Add support for installing pmi2 header and library

pmi2 support is currently a variant; maybe we should just do it by default?