### PR TITLE
Don't try to build TARGET=PILEDRIVER on aarch64

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -158,7 +158,6 @@ class Openblas(MakefilePackage):
         # invoke make with the correct TARGET for aarch64
         elif 'aarch64' in spack.architecture.sys_type():
             make_defs += [
-                'TARGET=PILEDRIVER',
                 'TARGET=ARMV8'
             ]
         if self.spec.satisfies('%gcc@:4.8.4'):


### PR DESCRIPTION
Piledriver is a codename for an AMD x86-64 processor, it can't
possibly make sense to compile for that if the architecture is
aarch64.