### PR TITLE
Add libhio v1.4.1.3, 1.4.1.1

### DIFF
--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -25,7 +25,7 @@ def get_module_cmd(bashopts=''):
             return get_module_cmd_from_which()
         except ModuleError:
             raise ModuleError('Spack requires modulecmd or a defined module'
-                              ' fucntion. Make sure modulecmd is in your path'
+                              ' function. Make sure modulecmd is in your path'
                               ' or the function "module" is defined in your'
                               ' bash environment.')
 

--- a/var/spack/repos/builtin/packages/libhio/package.py
+++ b/var/spack/repos/builtin/packages/libhio/package.py
@@ -21,8 +21,10 @@ class Libhio(AutotoolsPackage):
     # We don't include older versions since they are missing features
     # needed by current and future consumers of libhio
     #
-    version('1.4.1.2', '38c7d33210155e5796b16d536d1b5cfe')
-    version('1.4.1.0', '6ef566fd8cf31fdcd05fab01dd3fae44')
+    version('1.4.1.3', sha256='b6ad2354f1bc597e7e55fc989ff50944835d64149f4925c2f45df950919e4d08')
+    version('1.4.1.2', sha256='87a0f9b72b7aa69485c40d9bd36f02af653b70e8eed3eb0b50eaeb02ff0a9049')
+    version('1.4.1.1', sha256='5c65d18bf74357f9d9960bf6b9ad2432f8fc5a2b653e72befe4d1caabb9a2f7a')
+    version('1.4.1.0', sha256='963f4a8d365afd92a5593f80946e2c4c79f4185d897436a43fae61dae5567ac4')
 
     #
     # main users of libhio thru spack will want to use HFDF5 plugin,


### PR DESCRIPTION
- Switch all libhio tarball listings to sha256 checksums
- Correct typo in alert message in /lib/spack/spack/util/module_cmd.py: fucntion -> function

https://github.com/hpc/libhio/releases
Released 2019-02-01

Verification builds on LANL Darwin:

**Intel Xeon**
Architecture:          x86_64
CPU op-mode(s):        32-bit, 64-bit
Byte Order:            Little Endian
CPU(s):                40
On-line CPU(s) list:   0-39
Thread(s) per core:    2
Core(s) per socket:    10
Socket(s):             2
NUMA node(s):          2
Vendor ID:             GenuineIntel
CPU family:            6
Model:                 63
Model name:            Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz
Stepping:              2
CPU MHz:               1198.779
CPU max MHz:           3300.0000
CPU min MHz:           1200.0000
BogoMIPS:              5193.70
Virtualization:        VT-x
L1d cache:             32K
L1i cache:             32K
L2 cache:              256K
L3 cache:              25600K
NUMA node0 CPU(s):     0-9,20-29
NUMA node1 CPU(s):     10-19,30-39
Flags:                 fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb invpcid_single pti intel_ppin tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid cqm xsaveopt cqm_llc cqm_occup_llc dtherm ida arat pln pts
```
[+] /scratch/users/dantopa/new-spack/strawman.pr.libhio/opt/spack/linux-centos7-x86_64/gcc-4.8.5/libhio-1.4.1.3-s4fnmesfp65trhks5qi3it5p73ssfpsp
[+] /scratch/users/dantopa/new-spack/strawman.pr.libhio/opt/spack/linux-centos7-x86_64/gcc-4.8.5/libhio-1.4.1.2-fkgh5vqpijvwqywffmokgmsglqxwfrtl
```

**Arm**
Architecture:          aarch64
Byte Order:            Little Endian
CPU(s):                256
On-line CPU(s) list:   0-255
Thread(s) per core:    4
Core(s) per socket:    32
Socket(s):             2
NUMA node(s):          2
Model:                 0
BogoMIPS:              400.00
L1d cache:             32K
L1i cache:             32K
L2 cache:              256K
L3 cache:              32768K
NUMA node0 CPU(s):     0-127
NUMA node1 CPU(s):     128-255
Flags:                 fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics cpuid asimdrdm
```
[+] /scratch/users/dantopa/new-spack/strawman.pr.libhio/opt/spack/linux-rhel7-aarch64/gcc-4.8.5/libhio-1.4.1.3-q6nnwiy6bi7ktnghdsngwamom23zpmgy
[+] /scratch/users/dantopa/new-spack/strawman.pr.libhio/opt/spack/linux-rhel7-aarch64/gcc-4.8.5/libhio-1.4.1.2-y6nwovff3qbdy242zc4x2toloz6xpcvm
```

2019-02-25

Signed-off-by: Daniel Topa <dantopa@lanl.gov>