### PR TITLE
Fix detection of LLVM-enabled PGI compilers

### DIFF
--- a/lib/spack/spack/compilers/pgi.py
+++ b/lib/spack/spack/compilers/pgi.py
@@ -19,6 +19,10 @@ class Pgi(spack.compiler.Compiler):
     # Subclasses use possible names of Fortran 90 compiler
     fc_names = ['pgfortran', 'pgf95', 'pgf90']
 
+    # LLVM-enabled PGI compilers add a '-llvm' suffix:
+    #   pgcc-llvm, pgc++llvm, pgfortran-llvm
+    suffixes = ['-?llvm']
+
     # Named wrapper links within build_env_path
     link_paths = {'cc': 'pgi/pgcc',
                   'cxx': 'pgi/pgc++',
@@ -29,7 +33,7 @@ class Pgi(spack.compiler.Compiler):
     PrgEnv_compiler = 'pgi'
 
     version_argument = '-V'
-    version_regex = r'pg[^ ]* ([0-9.]+)-[0-9]+ [^ ]+ target on '
+    version_regex = r'pg[^ ]* ([0-9.]+)-[0-9]+ (LLVM )?[^ ]+ target on '
 
     @property
     def openmp_flag(self):

--- a/lib/spack/spack/test/compilers.py
+++ b/lib/spack/spack/test/compilers.py
@@ -316,7 +316,13 @@ def test_nag_version_detection(version_str, expected_version):
     # Output on PowerPC
     ('pgcc 17.4-0 linuxpower target on Linuxpower\n'
      'PGI Compilers and Tools\n'
-     'Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.\n', '17.4')
+     'Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.\n',
+     '17.4'),
+    # Output when LLVM-enabled
+    ('pgcc-llvm 18.4-0 LLVM 64-bit target on x86-64 Linux -tp haswell\n'
+     'PGI Compilers and Tools\n'
+     'Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.\n',
+     '18.4')
 ])
 def test_pgi_version_detection(version_str, expected_version):
     version = spack.compilers.pgi.Pgi.extract_version_from_output(version_str)


### PR DESCRIPTION
Fixes #10599 

@anderbubble Can you test this? I want to make sure:

1. It does detect the LLVM-enabled compilers
2. It doesn't add 2 copies of the compiler, one with and one without `-llvm`

Also, can you confirm that all of the flags are the same as for PGI, not LLVM?