### PR TITLE
the gcc run_env sets F90, this breaks mpich and is not documented

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -415,4 +415,4 @@ class Gcc(AutotoolsPackage):
         run_env.set('CXX', join_path(self.spec.prefix.bin, 'g++'))
         run_env.set('FC', join_path(self.spec.prefix.bin, 'gfortran'))
         run_env.set('F77', join_path(self.spec.prefix.bin, 'gfortran'))
-        run_env.set('F90', join_path(self.spec.prefix.bin, 'gfortran'))
+

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -415,4 +415,3 @@ class Gcc(AutotoolsPackage):
         run_env.set('CXX', join_path(self.spec.prefix.bin, 'g++'))
         run_env.set('FC', join_path(self.spec.prefix.bin, 'gfortran'))
         run_env.set('F77', join_path(self.spec.prefix.bin, 'gfortran'))
-


### PR DESCRIPTION
The mpich package.py configure fails if F90 is set, it only permits FC. It should not need to work around compiler packages violating the documented behavior.
See:
https://spack.readthedocs.io/en/latest/packaging_guide.html#environment-variables