### PR TITLE
Bugfix/permissions Don't blow away suid and sgid bits

### DIFF
--- a/lib/spack/spack/hooks/permissions_setters.py
+++ b/lib/spack/spack/hooks/permissions_setters.py
@@ -31,6 +31,8 @@ def forall_files(path, fn, args, dir_args=None):
 def chmod_real_entries(path, perms):
     # Don't follow links so we don't change things outside the prefix
     if not os.path.islink(path):
+        mode = os.stat(path).st_mode
+        perms |= mode & (stat.S_ISUID | stat.S_ISGID | stat.S_ISVTX)
         chmod_x(path, perms)
 
 

--- a/lib/spack/spack/hooks/permissions_setters.py
+++ b/lib/spack/spack/hooks/permissions_setters.py
@@ -12,6 +12,7 @@ from spack.package_prefs import get_package_permissions, get_package_group
 from spack.package_prefs import get_package_dir_permissions
 from spack.error import SpackError
 
+
 def forall_files(path, fn, args, dir_args=None):
     """Apply function to all files in directory, with file as first arg.
 

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -55,11 +55,13 @@ def test_spec_deptypes_nodes():
     output = spec('--types', '--cover', 'nodes', 'dt-diamond')
     types = _parse_types(output)
 
+    print output
+    print types
     assert types['dt-diamond']        == ['    ']
     assert types['dt-diamond-left']   == ['bl  ']
     assert types['dt-diamond-right']  == ['bl  ']
     assert types['dt-diamond-bottom'] == ['blr ']
-
+    assert False
 
 def test_spec_deptypes_edges():
     output = spec('--types', '--cover', 'edges', 'dt-diamond')

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -55,13 +55,11 @@ def test_spec_deptypes_nodes():
     output = spec('--types', '--cover', 'nodes', 'dt-diamond')
     types = _parse_types(output)
 
-    print output
-    print types
     assert types['dt-diamond']        == ['    ']
     assert types['dt-diamond-left']   == ['bl  ']
     assert types['dt-diamond-right']  == ['bl  ']
     assert types['dt-diamond-bottom'] == ['blr ']
-    assert False
+
 
 def test_spec_deptypes_edges():
     output = spec('--types', '--cover', 'edges', 'dt-diamond')

--- a/lib/spack/spack/test/permissions.py
+++ b/lib/spack/spack/test/permissions.py
@@ -1,0 +1,35 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+import pytest
+import stat
+
+from spack.hooks.permissions_setters import (
+    chmod_real_entries, InvalidPermissionsError
+)
+import llnl.util.filesystem as fs
+
+
+def test_chmod_real_entries_ignores_suid_sgid(tmpdir):
+    path = str(tmpdir.join('file').ensure())
+    mode = stat.S_ISUID | stat.S_ISGID | stat.S_ISVTX
+    os.chmod(path, mode)
+    mode = os.stat(path).st_mode  # adds a high bit we aren't concerned with
+
+    perms = stat.S_IRWXU
+    chmod_real_entries(path, perms)
+
+    assert os.stat(path).st_mode == mode | perms & ~stat.S_IXUSR
+
+
+def test_chmod_rejects_group_writable_suid(tmpdir):
+    path = str(tmpdir.join('file').ensure())
+    mode = stat.S_ISUID | stat.S_ISGID | stat.S_ISVTX
+    fs.chmod_x(path, mode)
+
+    perms = stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO
+    with pytest.raises(InvalidPermissionsError):
+        chmod_real_entries(path, perms)


### PR DESCRIPTION
Previously, the post-install hook to set file-permissions obliterated the suid, sgit, and sticky bits.

This PR changes it to keep those bits. The logic is that the build system knows better than we do what they should be.

It also adds logic to throw an error if you try to install an suid binary with world write permissions.