### PR TITLE
trimmomatic: restrict java dependency to version 8

### DIFF
--- a/var/spack/repos/builtin/packages/trimmomatic/package.py
+++ b/var/spack/repos/builtin/packages/trimmomatic/package.py
@@ -19,7 +19,7 @@ class Trimmomatic(Package):
     version('0.36', '8549130d86b6f0382b1a71a2eb45de39')
     version('0.33', '924fc8eb38fdff71740a0e05d32d6a2b')
 
-    depends_on('java@8:', type='run')
+    depends_on('java@8', type='run')
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)


### PR DESCRIPTION
Trimmomatic fails with newer versions of Java. 