### PR TITLE
py-pytables: Add hdf5 1.10.x support for versions above 3.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-pytables/package.py
+++ b/var/spack/repos/builtin/packages/py-pytables/package.py
@@ -17,12 +17,13 @@ class PyPytables(PythonPackage):
     version('3.2.2', '7cbb0972e4d6580f629996a5bed92441',
             url='https://github.com/PyTables/PyTables/archive/v.3.2.2.tar.gz')
 
-    depends_on('hdf5@1.8.0:1.8.999')
+    depends_on('hdf5@1.8.0:1.8.999', when="@:3.3.99")
+    depends_on('hdf5@1.8.0:1.10.999', when="@3.4.0:")
     depends_on('py-numpy@1.8.0:', type=('build', 'run'))
     depends_on('py-numexpr@2.5.2:', type=('build', 'run'))
     depends_on('py-cython', type=('build', 'run'))
     depends_on('py-six', type=('build', 'run'))
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools', type=('build', 'run'))
 
     def setup_environment(self, spack_env, run_env):
         spack_env.set('HDF5_DIR', self.spec['hdf5'].prefix)


### PR DESCRIPTION
Also fixes setuptools import error at software runtime.