### PR TITLE
Fix Eigen include path

### DIFF
--- a/var/spack/repos/builtin/packages/eigen/package.py
+++ b/var/spack/repos/builtin/packages/eigen/package.py
@@ -46,3 +46,7 @@ class Eigen(CMakePackage):
     depends_on('gmp', when='+mpfr')
 
     patch('find-ptscotch.patch', when='@3.3.4')
+
+    def setup_environment(self, spack_env, run_env):
+        run_env.prepend_path('CPATH',
+                             join_path(self.prefix, 'include', 'eigen3'))


### PR DESCRIPTION
Eigen installs its headers in [`<install_prefix>/include/eigen3`](https://bitbucket.org/eigen/eigen/src/4f9e93b66572c3a52c23d5f463aa3aa28bca6d58/CMakeLists.txt?at=default&fileviewer=file-view-default#CMakeLists.txt-422), and the users are encouraged to include them as:
```cpp
#include <Eigen/Core>
#include <Eigen/Dense>
```

However, the current `package.py` doesn't reflect the custom path so the users have to include the headers as:
```cpp
#include <eigen3/Eigen/Core>
#include <eigen3/Eigen/Dense>
```
Otherwise, it fails to find the header.

This PR fixes it following [this guide](https://spack.readthedocs.io/en/latest/module_file_support.html#override-api-calls-in-package-py).