### PR TITLE
Ignore Modules v4 environment variables in `from_sourcing_file`

### DIFF
--- a/lib/spack/spack/test/data/sourceme_unset.sh
+++ b/lib/spack/spack/test/data/sourceme_unset.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+unset UNSET_ME

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -879,15 +879,17 @@ def environment_after_sourcing_files(*files, **kwargs):
 
         return environment
 
-    kwargs.setdefault('env', dict(os.environ))
+    current_environment = kwargs.get('env', dict(os.environ))
     for f in files:
         # Normalize the input to the helper function
         if isinstance(f, six.string_types):
             f = [f]
 
-        kwargs['env'] = _source_single_file(f, environment=kwargs['env'])
+        current_environment = _source_single_file(
+            f, environment=current_environment
+        )
 
-    return kwargs['env']
+    return current_environment
 
 
 def sanitize(environment, blacklist, whitelist):

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -565,7 +565,12 @@ class EnvironmentModifications(object):
                              for k, v in env_after.items())
 
         # Other variables unrelated to sourcing a file
-        blacklist.extend(['SHLVL', '_', 'PWD', 'OLDPWD', 'PS2'])
+        blacklist.extend([
+            # Bash internals
+            'SHLVL', '_', 'PWD', 'OLDPWD', 'PS2', 'ENV',
+            # Environment modules v4
+            'LOADEDMODULES', '_LMFILES_', 'BASH_FUNC_module()'
+        ])
 
         def set_intersection(fullset, *args):
             # A set intersection using string literals and regexs

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -527,25 +527,27 @@ class EnvironmentModifications(object):
             raise RuntimeError(msg)
 
         # Prepare a whitelist and a blacklist of environment variable names
-        bl = kwargs.get('blacklist', [])
-        wl = kwargs.get('whitelist', [])
+        blacklist = kwargs.get('blacklist', [])
+        whitelist = kwargs.get('whitelist', [])
         clean = kwargs.get('clean', False)
 
         # Other variables unrelated to sourcing a file
-        bl.extend([
+        blacklist.extend([
             # Bash internals
-            'SHLVL', '_', 'PWD', 'OLDPWD', 'PS2', 'ENV',
+            'SHLVL', '_', 'PWD', 'OLDPWD', 'PS1', 'PS2', 'ENV',
             # Environment modules v4
             'LOADEDMODULES', '_LMFILES_', 'BASH_FUNC_module()', 'MODULEPATH',
             'MODULES_(.*)', r'(\w*)_mod(quar|share)'
         ])
 
         # Compute the environments before and after sourcing
-        before = sanitize(dict(os.environ), blacklist=bl, whitelist=wl)
+        before = sanitize(
+            dict(os.environ), blacklist=blacklist, whitelist=whitelist
+        )
         file_and_args = (filename,) + arguments
         after = sanitize(
             environment_after_sourcing_files(file_and_args, **kwargs),
-            blacklist=bl, whitelist=wl
+            blacklist=blacklist, whitelist=whitelist
         )
 
         # Delegate to the other factory

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -173,6 +173,11 @@ class NameModifier(object):
 
         self.args.update(kwargs)
 
+    def __eq__(self, other):
+        if not isinstance(other, NameModifier):
+            return False
+        return self.name == other.name
+
     def update_args(self, **kwargs):
         self.__dict__.update(kwargs)
         self.args.update(kwargs)
@@ -186,6 +191,13 @@ class NameValueModifier(object):
         self.separator = kwargs.get('separator', ':')
         self.args = {'name': name, 'value': value, 'separator': self.separator}
         self.args.update(kwargs)
+
+    def __eq__(self, other):
+        if not isinstance(other, NameValueModifier):
+            return False
+        return self.name == other.name and \
+            self.value == other.value and \
+            self.separator == other.separator
 
     def update_args(self, **kwargs):
         self.__dict__.update(kwargs)


### PR DESCRIPTION
fixes #11522 
closes #7536

Credits for this change goes also to @mgsternberg (original author of #7536)

Modifications done in this PR:

- [x] ~Fixed a bug stemming from a missing `continue` in a for loop~ merged in #10950 
- [x] Added the environment variables that are specific to Modules v4 to the list of the ones that are blacklisted in `EnvironmentModifications.from_sourcing_file`
- [x] Refactored `EnvironmentModifications.from_sourcing_file` into different functions / methods
- [x] Added unit tests to stress common use cases
