### PR TITLE
Expand link search in find_versions_of_archive

### DIFF
--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -287,8 +287,9 @@ def find_versions_of_archive(archive_urls, list_url=None, list_depth=0):
     list_urls.update(additional_list_urls)
 
     # Grab some web pages to scrape.
+    # Start with any links already given.
     pages = {}
-    links = set()
+    links = set(archive_urls)
     for lurl in list_urls:
         pg, lnk = spider(lurl, depth=list_depth)
         pages.update(pg)


### PR DESCRIPTION
When executing `spack create` with an archive URL spack will sometimes miss versions passed on the command line:

```
$ spack create -n r-abn 'https://cran.r-project.org/src/contrib/abn_1.3.tar.gz'
==> Using specified package name: 'r-abn'
==> Warning: Spack will not check SSL certificates. You need to update your Python to enable certificate verification.
==> Warning: Spack will not check SSL certificates. You need to update your Python to enable certificate verification.
==> Found 11 versions of r-abn:
  
  1.2    https://cran.r-project.org/src/contrib/Archive/abn/abn_1.2.tar.gz
  1.0.2  https://cran.r-project.org/src/contrib/Archive/abn/abn_1.0.2.tar.gz
  1.0    https://cran.r-project.org/src/contrib/Archive/abn/abn_1.0.tar.gz
  0.86   https://cran.r-project.org/src/contrib/Archive/abn/abn_0.86.tar.gz
  0.85   https://cran.r-project.org/src/contrib/Archive/abn/abn_0.85.tar.gz
  0.83   https://cran.r-project.org/src/contrib/Archive/abn/abn_0.83.tar.gz
  0.82   https://cran.r-project.org/src/contrib/Archive/abn/abn_0.82.tar.gz
  0.8    https://cran.r-project.org/src/contrib/Archive/abn/abn_0.8.tar.gz
  0.7    https://cran.r-project.org/src/contrib/Archive/abn/abn_0.7.tar.gz
  ...
  0.3-1  https://cran.r-project.org/src/contrib/Archive/abn/abn_0.3-1.tar.gz

==> How many would you like to checksum? (default is 1, q to abort) 
```

This patch modifies the link search in `find_versions_of_archive` to include the initial archive_url in the set of potential archive paths. Spack then finds all of the versions:

```
$ spack create -n r-abn 'https://cran.r-project.org/src/contrib/abn_1.3.tar.gz'                                                                                                                                                                                                                                                                                                                                     
==> Using specified package name: 'r-abn'
==> Warning: Spack will not check SSL certificates. You need to update your Python to enable certificate verification.
==> Warning: Spack will not check SSL certificates. You need to update your Python to enable certificate verification.
==> Found 12 versions of r-abn:
  
  1.3    https://cran.r-project.org/src/contrib/abn_1.3.tar.gz
  1.2    https://cran.r-project.org/src/contrib/Archive/abn/abn_1.2.tar.gz
  1.0.2  https://cran.r-project.org/src/contrib/Archive/abn/abn_1.0.2.tar.gz
  1.0    https://cran.r-project.org/src/contrib/Archive/abn/abn_1.0.tar.gz
  0.86   https://cran.r-project.org/src/contrib/Archive/abn/abn_0.86.tar.gz
  0.85   https://cran.r-project.org/src/contrib/Archive/abn/abn_0.85.tar.gz
  0.83   https://cran.r-project.org/src/contrib/Archive/abn/abn_0.83.tar.gz
  0.82   https://cran.r-project.org/src/contrib/Archive/abn/abn_0.82.tar.gz
  0.8    https://cran.r-project.org/src/contrib/Archive/abn/abn_0.8.tar.gz
  ...
  0.3-1  https://cran.r-project.org/src/contrib/Archive/abn/abn_0.3-1.tar.gz

==> How many would you like to checksum? (default is 1, q to abort)
```