### PR TITLE
erfa: a new package.

### DIFF
--- a/var/spack/repos/builtin/packages/erfa/package.py
+++ b/var/spack/repos/builtin/packages/erfa/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Erfa(AutotoolsPackage):
+    """ERFA(Essential Routines for Fundamental Astronomy)
+    is a C library containing key algorithms for astronomy."""
+
+    homepage = "https://github.com/liberfa/erfa"
+    url      = "https://github.com/liberfa/erfa/archive/v1.4.0.tar.gz"
+
+    version('1.4.0', sha256='90113f18a1a05a3d26970a95b70a71ec52d71156b967ffd6c26dd1626d92e946')
+
+    depends_on('m4', type='build')
+    depends_on('autoconf', type='build')
+    depends_on('automake', type='build')
+    depends_on('libtool', type='build')


### PR DESCRIPTION
This commit adds a new package: erfa (Essential Routines for Fundamental Astronomy) which has been built succesffully against gcc@5.4.0 on CentOS 7.