### PR TITLE
Fix sha256 sum for IOR

### DIFF
--- a/var/spack/repos/builtin/packages/ior/package.py
+++ b/var/spack/repos/builtin/packages/ior/package.py
@@ -13,7 +13,7 @@ class Ior(AutotoolsPackage):
     homepage = "https://github.com/hpc/ior"
     url      = "https://github.com/hpc/ior/archive/3.2.0.tar.gz"
 
-    version('3.2.0',    sha256='0cda0e00b7f070c6754ef8acb3873eb3a625bd8dee3f2e220291656be1322bbb')
+    version('3.2.0',    sha256='91a766fb9c34b5780705d0997b71b236a1120da46652763ba11d9a8c44251852')
     version('3.0.1', '71150025e0bb6ea1761150f48b553065')
 
     variant('hdf5',  default=False, description='support IO with HDF5 backend')


### PR DESCRIPTION
The current sha256 sum seems wrong. Can check it by:

```
$ wget https://github.com/hpc/ior/archive/3.2.0.tar.gz
$ sha256sum 3.2.0.tar.gz
91a766fb9c34b5780705d0997b71b236a1120da46652763ba11d9a8c44251852
```