### PR TITLE
Dysco: a new package.

### DIFF
--- a/var/spack/repos/builtin/packages/dysco/package.py
+++ b/var/spack/repos/builtin/packages/dysco/package.py
@@ -16,4 +16,4 @@ class Dysco(CMakePackage):
 
     depends_on('casacore')
     depends_on('gsl')
-    depends_on('boost+date_time')
+    depends_on('boost+date_time+python')

--- a/var/spack/repos/builtin/packages/dysco/package.py
+++ b/var/spack/repos/builtin/packages/dysco/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Dysco(CMakePackage):
+    """Dysco is a compressing storage manager for Casacore mearement sets."""
+
+    homepage = "https://github.com/aroffringa/dysco"
+    url      = "https://github.com/aroffringa/dysco/archive/v1.2.tar.gz"
+
+    version('1.2', sha256='dd992c5a13df67173aa1d3f6dc5df9b51b0bea2fe77bc08f5be7a839be741269')
+
+    depends_on('casacore')
+    depends_on('gsl')
+    depends_on('boost+date_time')


### PR DESCRIPTION
This PR adds a new package: dysco. It has been built succesfully against gcc@5.4.0 on Cent OS 7.