### PR TITLE
WIP: Release workflow improvements

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,10 @@
+generate ci jobs:
+  script:
+    - "./bin/generate-gitlab-ci-yml.sh"
+  tags:
+    - "spack-k8s"
+  image: "scottwittenburg/spack_ci_generator_alpine"
+  artifacts:
+    paths:
+      - ci-generation
+    when: always

--- a/bin/create-buildgroups.py
+++ b/bin/create-buildgroups.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import re
+import requests
+import sys
+
+from ruamel.yaml import YAML
+
+
+yaml = YAML(typ='safe')
+job_name_regex = re.compile('([^\\s]+)\\s+([^\\s]+)\\s+([^\\s]+)\\s+([^\\s]+)\\s+([^\\s]+)')
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="CDash BuildGroup Creator")
+    requiredNamed = parser.add_argument_group("required named arguments")
+    requiredNamed.add_argument("-c", "--credentials",
+        help="path to file containing a CDash authentication token",
+        default=None, required=True)
+    requiredNamed.add_argument("-f", "--buildfile",
+        help="Text file containing a list of expected build names (one per line)",
+        required=True)
+    requiredNamed.add_argument("-p", "--projectid",
+        help="The Id of the project in CDash that you'd like to modify",
+        required=True)
+    requiredNamed.add_argument("-s", "--siteid",
+        help="The Id of the site in CDash that will be submitting the builds",
+        required=True)
+    requiredNamed.add_argument("-u", "--cdash-url",
+        help="CDash base URL (index.php removed)",
+        required=True)
+    args = parser.parse_args()
+
+    print('Creating buildgroups:')
+    print('  credentials {0}'.format('provided' if args.credentials else 'NOT provided'))
+    print('  buildfile: {0}'.format(args.buildfile))
+    print('  projectid: {0}'.format(args.projectid))
+    print('  siteid: {0}'.format(args.siteid))
+    print('  cdash-url: {0}'.format(args.cdash_url))
+
+
+    with open(args.buildfile, "r") as build_file:
+        # Create the BuildGroup and a corresponding "Latest" BuildGroup.
+        auth_token = args.credentials
+        headers = {"Authorization": "Bearer {0}".format(auth_token)}
+        url = "{0}/api/v1/buildgroup.php".format(args.cdash_url)
+
+        group_id_map = {}
+
+        def create_buildgroup(args, headers, url, group_name, group_type):
+            payload = {
+                "newbuildgroup": group_name,
+                "projectid": args.projectid,
+                "type": group_type
+            }
+            r = requests.post(url, json=payload, headers=headers)
+            if not r.ok:
+                print("Problem creating '{0}' group: {1} / {2}\n".format(group_name, r.status_code, r.text))
+                sys.exit(1)
+            return r.json()['id']
+
+        def get_buildgroup(group_name):
+            if group_name not in group_id_map:
+                group_id_map[group_name] = {
+                    'daily': create_buildgroup(args, headers, url, group_name, "Daily"),
+                    'latest': create_buildgroup(args, headers, url, "Latest {0}".format(group_name), "Latest"),
+                }
+            groupids = group_id_map[group_name]
+            return groupids['daily'], groupids['latest']
+
+        # Populate the 'Latest' BuildGroup with our list of expected builds.
+        ci_jobs = yaml.load(build_file.read())
+
+        for job_name, job_entry in ci_jobs.items():
+            print('    job_name: {0}'.format(job_name))
+            m = job_name_regex.search(job_name)
+            if m:
+                pkg_name = m.group(1)
+                pkg_version = m.group(2)
+                compiler = m.group(3)
+                os_arch = m.group(4)
+                release_tag = m.group(5)
+
+                daily_groupid, latest_groupid = get_buildgroup(release_tag)
+                build_name = '{0}@{1}%{2} arch={3} ({4})'.format(
+                pkg_name, pkg_version, compiler, os_arch, release_tag)
+
+                payload = {
+                    "match": build_name,
+                    "projectid": args.projectid,
+                    "buildgroup": {"id": daily_groupid},
+                    "dynamic": {"id": latest_groupid},
+                    "site": {"id": args.siteid},
+                }
+                print('      Sending payload: {0}'.format(payload))
+                r = requests.post(url, json=payload, headers=headers)
+                if not r.ok:
+                    print("Problem creating dynamic row for '{0}': {1} / {2}\n".format(build_name, r.status_code, r.text))
+                    sys.exit(1)
+        print("Success")

--- a/bin/generate-gitlab-ci-yml.sh
+++ b/bin/generate-gitlab-ci-yml.sh
@@ -1,0 +1,48 @@
+#! /usr/bin/env bash
+
+if [ -z "$DOWNSTREAM_CI_REPO" ] ; then
+    echo "Warning: missing variable: DOWNSTREAM_CI_REPO" >&2
+fi
+
+current_branch="$CI_COMMIT_REF_NAME"
+
+original_directory=$(pwd)
+workdir="${original_directory}/ci-generation"
+mkdir -p ${workdir}
+cd $workdir
+
+micro_service_url="https://internal.spack.io/glciy/${CI_COMMIT_SHA}.yaml"
+wget ${micro_service_url}
+yaml_file="${workdir}/${CI_COMMIT_SHA}.yaml"
+cp "$yaml_file" "${original_directory}/.gitlab-ci.yml"
+
+py_script="${original_directory}/bin/create-buildgroups.py"
+$py_script --credentials ${CDASH_AUTH_TOKEN} \
+           --buildfile ${yaml_file} \
+           --projectid "2" \
+           --siteid "3" \
+           --cdash-url "https://cdash.spack.io"
+
+git config --global user.email "robot@spack.io"
+git config --global user.name "Build Robot"
+
+commit_msg="Auto-generated commit testing ${current_branch} (${CI_COMMIT_SHA})"
+
+cd ${original_directory}
+echo "git status"
+git status
+echo "git branch"
+git branch -D ___multi_ci___ 2> /dev/null || true
+echo "git checkout"
+git checkout -b ___multi_ci___
+echo "git add"
+git add .gitlab-ci.yml
+echo "git commit"
+git commit -m "$commit_msg"
+echo "git commit-tree/reset"
+git reset "$( git commit-tree HEAD^{tree} -m ${commit_msg} )"
+echo "git status"
+git status
+echo "git push"
+git push --force "$DOWNSTREAM_CI_REPO" \
+    "___multi_ci___:$current_branch"

--- a/etc/spack/defaults/release.yaml
+++ b/etc/spack/defaults/release.yaml
@@ -2,15 +2,28 @@
 # This is the default spack release spec set.
 # -------------------------------------------------------------------------
 spec-set:
+    release-tag: 'test-release-v1.4'
+    ci-only:
+        - 'enhance-release-spec-set'
     include: []
     exclude: []
     matrix:
         - packages:
-            xsdk:
-                versions: [0.4.0]
+            libpng:
+                versions: [1.6.34]
+            ncurses:
+                versions: [6.1]
+            pkgconf:
+                versions: [1.4.2]
+            readline:
+                versions: [7.0]
+            zlib:
+                versions: [1.2.11]
         - compilers:
             gcc:
                 versions: [5.5.0]
             clang:
                 versions: [6.0.0, '6.0.0-1ubuntu2']
-    cdash: ["https://spack.io/cdash/submit.php?project=spack"]
+    cdash:
+        baseurl: "http://cdash"
+        project: "Spack Testing"

--- a/lib/spack/spack/cmd/location.py
+++ b/lib/spack/spack/cmd/location.py
@@ -14,6 +14,7 @@ import spack.cmd
 import spack.environment
 import spack.paths
 import spack.repo
+from spack.spec import Spec
 
 description = "print out locations of packages and spack directories"
 section = "basic"
@@ -55,6 +56,9 @@ def setup_parser(subparser):
         help="location of an environment managed by spack")
 
     subparser.add_argument(
+        '-f', '--spec-file', default=None,
+        help="Read spec from yaml file rather that command line")
+    subparser.add_argument(
         'spec', nargs=argparse.REMAINDER,
         help="spec of package to fetch directory for")
 
@@ -79,7 +83,11 @@ def location(parser, args):
         print(spack.paths.stage_path)
 
     else:
-        specs = spack.cmd.parse_specs(args.spec)
+        if args.spec_file:
+            with open(args.spec_file, 'r') as fd:
+                specs = [Spec.from_yaml(fd)]
+        else:
+            specs = spack.cmd.parse_specs(args.spec)
         if not specs:
             tty.die("You must supply a spec.")
         if len(specs) != 1:

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -10,6 +10,7 @@ import os.path
 import platform
 import re
 import socket
+import sys
 import time
 import xml.sax.saxutils
 from six import text_type
@@ -244,7 +245,14 @@ class CDash(Reporter):
             # By default, urllib2 only support GET and POST.
             # CDash needs expects this file to be uploaded via PUT.
             request.get_method = lambda: 'PUT'
+            sys.stderr.write('CDash reporter making request:\n')
+            sys.stderr.write('  url: {0}\n'.format(request.get_full_url()))
+            sys.stderr.write('  headers: {0}\n'.format(request.headers))
+            sys.stderr.write('  data: {0}\n'.format(request.get_data()))
+            sys.stderr.flush()
             response = opener.open(request)
+            sys.stderr.write('CDash reporter finished making request\n')
+            sys.stderr.flush()
             if not self.buildId:
                 match = buildid_regexp.search(response.read())
                 if match:

--- a/lib/spack/spack/schema/spec_set.py
+++ b/lib/spack/spack/schema/spec_set.py
@@ -67,6 +67,18 @@ schema = {
                 'specs': {'$ref': '#/definitions/list_of_specs'},
             }
         },
+        'cdashsite': {
+            'type': 'object',
+            'additionalProperties': False,
+            'properties': {
+                'baseurl': {
+                    'type': 'string',
+                },
+                'project': {
+                    'type': 'string',
+                },
+            },
+        },
     },
     # this is the actual top level object
     'type': 'object',
@@ -80,14 +92,7 @@ schema = {
                 # top-level settings are keys and need to be unique
                 'include': {'$ref': '#/definitions/list_of_specs'},
                 'exclude': {'$ref': '#/definitions/list_of_specs'},
-                'cdash': {
-                    'oneOf': [
-                        {'type': 'string'},
-                        {'type': 'array',
-                         'items': {'type': 'string'}
-                        },
-                    ],
-                },
+                'cdash': {'$ref': '#/definitions/cdashsite'},
                 'project': {
                     'type': 'string',
                 },
@@ -102,6 +107,21 @@ schema = {
                             {'$ref': '#/definitions/packages'},
                             {'$ref': '#/definitions/compilers'},
                         ],
+                    },
+                },
+                'release-tag': {
+                    'type': 'string',
+                },
+                'ci-only': {
+                    'type': 'array',
+                    'items': {
+                        'type': 'string',
+                    },
+                },
+                'ci-except': {
+                    'type': 'array',
+                    'items': {
+                        'type': 'string',
                     },
                 },
             },

--- a/lib/spack/spack/spec_set.py
+++ b/lib/spack/spack/spec_set.py
@@ -50,9 +50,10 @@ class CombinatorialSpecSet:
 
         # initialize these from data.
         self.cdash = self.data.get('cdash', None)
-        if isinstance(self.cdash, str):
-            self.cdash = [self.cdash]
         self.project = self.data.get('project', None)
+        self.release_tag = self.data.get('release-tag', None)
+        self.ci_only = self.data.get('ci-only', [])
+        self.ci_except = self.data.get('ci-except', [])
 
         # _spec_lists is a list of lists of specs, to be combined as a
         # cartesian product when we iterate over all specs in the set.
@@ -60,6 +61,26 @@ class CombinatorialSpecSet:
         self._spec_lists = None
         self._include = []
         self._exclude = []
+
+    @property
+    def cdash(self):
+        return self.cdash
+
+    @property
+    def project(self):
+        return self.project
+
+    @property
+    def release_tag(self):
+        return self.release_tag
+
+    @property
+    def ci_only(self):
+        return self.ci_only
+
+    @property
+    def ci_except(self):
+        return self.ci_except
 
     @staticmethod
     def from_file(path):

--- a/share/spack/docker/spack_builder/Dockerfile-spack_ci_generator
+++ b/share/spack/docker/spack_builder/Dockerfile-spack_ci_generator
@@ -1,0 +1,8 @@
+from python:3.7.2-alpine
+
+RUN apk add --no-cache git bash
+
+RUN pip install requests ruamel.yaml
+
+ENTRYPOINT ["/usr/bin/env"]
+CMD ["bash"]


### PR DESCRIPTION
This change adds new fields to the `release.yaml` file, fixes an issue where the `cdash` field from that file was ignored, and updates the release workflow to make use of two repositories.

New fields are added to the `release.yaml` file: `ci-except` and `ci-only` allows lists of strings which will be added to each job to control conditions under which the jobs will or will not run.  The values provided in these two new fields are expected to be compatible with the strings allowed in the [only/except](https://docs.gitlab.com/ee/ci/yaml/#onlyexcept-basic) fields of jobs as described in the gitlab-ci documentation.  Another new field added to `release.yaml` is `release-tag`, which will be used in two ways: added to the job name, and used as the build group within CDash.

This change also fixes the issue where the 'cdash' field of the `release.yaml` was ignored and instead expected to be provided as argument to the `release-jobs` command.  That argument has been removed in favor of the field from the yaml file.  Also, since we are not currently reporting to more than one cdash site for a release, the 'cdash' field has been changed from a list to a single entry, but where the baseurl and project can be configured separately.

Additionally, this change adds support for a 2-repo approach to the workflow release.  In this approach, a first repository (in the cloud system, the gitlab set up to mirror spack on github) is used to generate the `.gitlab-ci.yaml`, and push it as a commit to a secondary repository, where the build jobs will actually be run.  In the current incarnation, the first repo CI executes a single job which:

1. sends a `GET` requests to the microservice to generate the jobs (.gitlab-ci.yaml)
2. parses that file for the job names, and register all of them under the build group identified by the `release-tag` in the `release.yaml`
3. commits the `.gitlab-ci.yml` and pushes it to the next CI repo where the packages are actually built