### PR TITLE
Update packages which need include subdirectories

### DIFF
--- a/var/spack/repos/builtin/packages/eigen/package.py
+++ b/var/spack/repos/builtin/packages/eigen/package.py
@@ -46,3 +46,9 @@ class Eigen(CMakePackage):
     depends_on('gmp', when='+mpfr')
 
     patch('find-ptscotch.patch', when='@3.3.4')
+
+    @property
+    def headers(self):
+        headers = find_all_headers(self.prefix.include)
+        headers.directories = [self.prefix.include.eigen3]
+        return headers

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -619,12 +619,14 @@ class Python(AutotoolsPackage):
     def headers(self):
         config_h = self.get_config_h_filename()
 
-        if os.path.exists(config_h):
-            return HeaderList(config_h)
-        else:
+        if not os.path.exists(config_h):
             includepy = self.get_config_var('INCLUDEPY')
             msg = 'Unable to locate {0} headers in {1}'
             raise RuntimeError(msg.format(self.name, includepy))
+
+        headers = HeaderList(config_h)
+        headers.directories = [os.path.dirname(config_h)]
+        return headers
 
     @property
     def python_lib_dir(self):


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/10769
~Closes https://github.com/spack/spack/pull/10751~ (EDIT: see https://github.com/spack/spack/pull/10773#issuecomment-469355115)

@HadrienG2 @davydden @jslee02 @alalazo 

https://github.com/spack/spack/pull/10623 updated the default behavior of `.headers.directories` to exclude subdirectories (since this can cause clashes with system headers). This broke some packages which depended on the old behavior of `.headers.directories`: for example if you had `<package-prefix>/include/subdir/ex1.h`, `.headers.directories` would include `<package-prefix>/include/subdir`.

This updates the `.headers` property to include subdirectories for Python and Eigen (as is recommended by these packages).

In hindsight, it was a mistake not to request documentation on https://github.com/spack/spack/pull/10623. So that should be added here or soon.