### PR TITLE
Grep the cray PrgEnv directly

### DIFF
--- a/lib/spack/spack/operating_systems/cnl.py
+++ b/lib/spack/spack/operating_systems/cnl.py
@@ -32,6 +32,7 @@ class Cnl(OperatingSystem):
         output = module("avail", "PrgEnv-")
         matches = re.findall(r'PrgEnv-\w+/(\d+).\d+.\d+', output)
         major_versions = set(matches)
+        print(major_versions)
         latest_version = max(major_versions)
         return latest_version
 

--- a/lib/spack/spack/operating_systems/cnl.py
+++ b/lib/spack/spack/operating_systems/cnl.py
@@ -32,7 +32,6 @@ class Cnl(OperatingSystem):
         output = module("avail", "PrgEnv-")
         matches = re.findall(r'PrgEnv-\w+/(\d+).\d+.\d+', output)
         major_versions = set(matches)
-        print(major_versions)
         latest_version = max(major_versions)
         return latest_version
 

--- a/lib/spack/spack/operating_systems/cnl.py
+++ b/lib/spack/spack/operating_systems/cnl.py
@@ -29,8 +29,8 @@ class Cnl(OperatingSystem):
         return self.name + str(self.version)
 
     def _detect_crayos_version(self):
-        output = module("avail", "PrgEnv-")
-        matches = re.findall(r'PrgEnv-\w+/(\d+).\d+.\d+', output)
+        output = module("avail", "PrgEnv-cray")
+        matches = re.findall(r'PrgEnv-cray/(\d+).\d+.\d+', output)
         major_versions = set(matches)
         latest_version = max(major_versions)
         return latest_version


### PR DESCRIPTION
At NERSC, we added our own custom module PrgEnv-llnl which was
incorrectly reporting the os version as cnl9 instead of cnl6. Rather
than just grep all PrgEnv modules just grep the Cray.