### PR TITLE
Autotools modification for added a config.sub 

### DIFF
--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -141,6 +141,17 @@ class AutotoolsPackage(PackageBase):
                 mod = os.stat(my_config_guess).st_mode & 0o777 | stat.S_IWUSR
                 os.chmod(my_config_guess, mod)
                 shutil.copyfile(config_guess, my_config_guess)
+
+                # Look for a config.sub in the same location
+                root, ext = os.path.splitext(config_guess)
+                config_sub = root + ".sub"
+                root, ext = os.path.splitext(my_config_guess)
+                my_config_sub = root + ".sub"
+                if os.path.exists(config_sub) and os.path.exists(my_config_sub):
+                    mod = os.stat(my_config_sub).st_mode & 0o777 | stat.S_IWUSR
+                    os.chmod(my_config_sub, mod)
+                    shutil.copyfile(config_sub, my_config_sub)
+
                 return
             except Exception:
                 pass


### PR DESCRIPTION
Currently the autotools script copies the config.guess file to packages with an old autotools install.
Whilst this resolves the issues with many packages some still depend upon the config.sub file.

This patch introduces a naive way of copying a corresponding config.sub file when copying a config.guess file - whilst assuming the locations are the same.

This fixes some package build issues on arm, such as argtable, where the updated config.guess is insufficient.

I have not included any additional error checking - if necessary and/or if you would rather this in its own routine, then please feel free to edit / reject.