### PR TITLE
netcdf: Eliminate spurious dependence on hdf5+mpi

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf/package.py
+++ b/var/spack/repos/builtin/packages/netcdf/package.py
@@ -95,7 +95,8 @@ class Netcdf(AutotoolsPackage):
 
     # High-level API of HDF5 1.8.9 or later is required for netCDF-4 support:
     # http://www.unidata.ucar.edu/software/netcdf/docs/getting_and_building_netcdf.html
-    depends_on('hdf5@1.8.9:+hl')
+    depends_on('hdf5@1.8.9:+hl~mpi', when='~mpi')
+    depends_on('hdf5@1.8.9:+hl+mpi', when='+mpi')
 
     # Starting version 4.4.0, it became possible to disable parallel I/O even
     # if HDF5 supports it. For previous versions of the library we need


### PR DESCRIPTION
Without the change in this PR, NetCDF will always depend on a `+mpi` variant of hdf5.  The best I can determine is that the simple specification of `depends_on('hdf5@1.8.9:+hl')` will always select the `+mpi` hdf5 variant whether `+mpi` or `~mpi` were specified for NetCDF:
```
ews00321:spack(develop)> spack spec netcdf+mpi
Input spec
--------------------------------
netcdf+mpi

Concretized
--------------------------------
netcdf@4.6.3%gcc@7.2.0~dap~hdf4 maxdims=1024 maxvars=8192 +mpi~parallel-netcdf+pic+shared arch=linux-rhel7-x86_64 
    ^hdf5@1.10.5%gcc@7.2.0~cxx~debug~fortran+hl+mpi+pic+shared~szip~threadsafe arch=linux-rhel7-x86_64 
        ^openmpi@3.1.3%gcc@7.2.0~cuda+cxx_exceptions fabrics=auto ~java~legacylaunchers~memchecker~pmi schedulers=auto ~sqlite3~thread_multiple+vt arch=linux-rhel7-x86_64 
        ^zlib@1.2.11%gcc@7.2.0+optimize+pic+shared arch=linux-rhel7-x86_64 
    ^m4@1.4.18%gcc@7.2.0 patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,c0a408fbffb7255fcc75e26bd8edab116fc81d216bfd18b473668b7739a4158e,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8 +sigsegv arch=linux-rhel7-x86_64 

ews00321:spack(develop)> spack spec netcdf~mpi
Input spec
--------------------------------
netcdf~mpi

Concretized
--------------------------------
netcdf@4.6.3%gcc@7.2.0~dap~hdf4 maxdims=1024 maxvars=8192 ~mpi~parallel-netcdf+pic+shared arch=linux-rhel7-x86_64 
    ^hdf5@1.10.5%gcc@7.2.0~cxx~debug~fortran+hl+mpi+pic+shared~szip~threadsafe arch=linux-rhel7-x86_64 
        ^openmpi@3.1.3%gcc@7.2.0~cuda+cxx_exceptions fabrics=auto ~java~legacylaunchers~memchecker~pmi schedulers=auto ~sqlite3~thread_multiple+vt arch=linux-rhel7-x86_64 
        ^zlib@1.2.11%gcc@7.2.0+optimize+pic+shared arch=linux-rhel7-x86_64 
    ^m4@1.4.18%gcc@7.2.0 patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,c0a408fbffb7255fcc75e26bd8edab116fc81d216bfd18b473668b7739a4158e,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8 +sigsegv arch=linux-rhel7-x86_64 
```

With the change in this PR, the `~mpi` variant now shows:
```
ews00321:spack(develop)> spack spec netcdf~mpi
Input spec
--------------------------------
netcdf~mpi

Concretized
--------------------------------
netcdf@4.6.3%gcc@7.2.0~dap~hdf4 maxdims=1024 maxvars=8192 ~mpi~parallel-netcdf+pic+shared arch=linux-rhel7-x86_64 
    ^hdf5@1.10.5%gcc@7.2.0~cxx~debug~fortran+hl~mpi+pic+shared~szip~threadsafe arch=linux-rhel7-x86_64 
        ^zlib@1.2.11%gcc@7.2.0+optimize+pic+shared arch=linux-rhel7-x86_64 
    ^m4@1.4.18%gcc@7.2.0 patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,c0a408fbffb7255fcc75e26bd8edab116fc81d216bfd18b473668b7739a4158e,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8 +sigsegv arch=linux-rhel7-x86_64 
``` 
which does not have the `openmpi` dependency and is correct.