### PR TITLE
py-flake8: Add missing dependencies for @3.7.7

### DIFF
--- a/var/spack/repos/builtin/packages/py-entrypoints/package.py
+++ b/var/spack/repos/builtin/packages/py-entrypoints/package.py
@@ -14,6 +14,7 @@ class PyEntrypoints(PythonPackage):
 
     import_modules = ['entrypoints']
 
+    version('0.3', 'c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451')
     version('0.2.3', '0d3ad1b0130d91e3596ef3a59f25a56c')
 
     depends_on('python@2.7:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-flake8/package.py
+++ b/var/spack/repos/builtin/packages/py-flake8/package.py
@@ -25,6 +25,12 @@ class PyFlake8(PythonPackage):
     # However, py-flake8 requires py-setuptools during runtime as well.
     depends_on('py-setuptools@30:', type=('build', 'run'))
 
+    # entrypoints >= 0.3.0, < 0.4.0
+    # FIXME @0.3.0:0.3.999 causes concretization to hang
+    depends_on('py-entrypoints@0.3', when='@3.7.7', type=('build', 'run'))
+
+    # pyflakes >= 2.1.0, < 2.2.0
+    depends_on('py-pyflakes@2.1.0:2.1.999', when='@3.7.7', type=('build', 'run'))
     # pyflakes >= 1.5.0, < 1.7.0
     depends_on('py-pyflakes@1.5.0:1.6.999', when='@3.5.0', type=('build', 'run'))
     # pyflakes >= 0.8.1, != 1.2.0, != 1.2.1, != 1.2.2, < 1.3.0
@@ -32,6 +38,8 @@ class PyFlake8(PythonPackage):
     # pyflakes >= 0.8.1, < 1.1
     depends_on('py-pyflakes@0.8.1:1.0.0', when='@2.5.4', type=('build', 'run'))
 
+    # pycodestyle >= 2.5.0, < 2.6.0
+    depends_on('py-pycodestyle@2.5.0:2.5.999', when='@3.7.7', type=('build', 'run'))
     # pycodestyle >= 2.3.0, < 2.4.0
     depends_on('py-pycodestyle@2.3.0:2.3.999', when='@3.5.0', type=('build', 'run'))
     # pycodestyle >= 2.0.0, < 2.1.0
@@ -40,7 +48,7 @@ class PyFlake8(PythonPackage):
     depends_on('py-pycodestyle@1.5.7,1.7.0:', when='@2.5.4', type=('build', 'run'))
 
     # mccabe >= 0.6.0, < 0.7.0
-    depends_on('py-mccabe@0.6.0:0.6.999', when='@3.5.0', type=('build', 'run'))
+    depends_on('py-mccabe@0.6.0:0.6.999', when='@3.5.0,3.7.7', type=('build', 'run'))
     # mccabe >= 0.5.0, < 0.6.0
     depends_on('py-mccabe@0.5.0:0.5.999', when='@3.0.4', type=('build', 'run'))
     # mccabe >= 0.2.1, < 0.5
@@ -54,6 +62,9 @@ class PyFlake8(PythonPackage):
     # module for Python versions 3.4 and later
     depends_on('py-enum34', when='^python@2.4:2.7.999,3.1:3.3.999',
                type=('build', 'run'))
+
+    depends_on('py-functools32', when='@3.7.7: ^python@:3.1.999', type=('build', 'run'))
+    depends_on('py-typing', when='@3.7.7: ^python@:3.4.999', type=('build', 'run'))
 
     depends_on('py-nose', type='test')
 

--- a/var/spack/repos/builtin/packages/py-pycodestyle/package.py
+++ b/var/spack/repos/builtin/packages/py-pycodestyle/package.py
@@ -13,6 +13,7 @@ class PyPycodestyle(PythonPackage):
     homepage = "https://github.com/PyCQA/pycodestyle"
     url      = "https://github.com/PyCQA/pycodestyle/archive/2.0.0.tar.gz"
 
+    version('2.5.0', 'a603453c07e8d8e15a43cf062aa7174741b74b4a27b110f9ad03d74d519173b5')
     version('2.3.1', '4185319f6137833eec9057dbf3293629')
     version('2.3.0', '1b2019b3c39c20becadbb7fdec6dcb5a')
     version('2.2.0', '6e21aab2e038c3dd38dca585011a6f38')


### PR DESCRIPTION
Without these dependencies, py-flake8 does not work at all for me.