### PR TITLE
Fix find_headers to also look for C++ headers and Fortran modules

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -957,7 +957,9 @@ class HeaderList(FileList):
     commonly used compiler flags or names.
     """
 
-    include_regex = re.compile(r'(.*)(include)(.*)')
+    # Make sure to only match complete words, otherwise path components such
+    # as "xinclude" will cause false matches.
+    include_regex = re.compile(r'(.*)(\binclude\b)(.*)')
 
     def __init__(self, files):
         super(HeaderList, self).__init__(files)
@@ -1122,10 +1124,11 @@ def find_headers(headers, root, recursive=False):
         raise TypeError(message)
 
     # Construct the right suffix for the headers
-    suffix = 'h'
+    suffixes = ['h', 'hpp', 'mod']
 
     # List of headers we are searching with suffixes
-    headers = ['{0}.{1}'.format(header, suffix) for header in headers]
+    headers = ['{0}.{1}'.format(header, suffix) for header in headers
+               for suffix in suffixes]
 
     return HeaderList(find(root, headers, recursive))
 


### PR DESCRIPTION
This is likely caused by #10623. Currently, only C headers are considered, causing build failures for packages depending on, e.g., netcdf-fortran and xerces-c. Additionally, the regex used to look for the include path component did not consider word boundaries, causing false matches.