### PR TITLE
rapidjson: "Werror" too strict for recent compilers

### DIFF
--- a/var/spack/repos/builtin/packages/rapidjson/0001-turn-off-Werror.patch
+++ b/var/spack/repos/builtin/packages/rapidjson/0001-turn-off-Werror.patch
@@ -1,0 +1,68 @@
+From dda5029e62d107c424b062f4792439ee32fd7380 Mon Sep 17 00:00:00 2001
+From: Rob Latham <robl@mcs.anl.gov>
+Date: Mon, 4 Mar 2019 20:32:30 -0600
+Subject: [PATCH] turn off Werror
+
+---
+ CMakeLists.txt               | 4 ++--
+ example/CMakeLists.txt       | 4 ++--
+ test/unittest/CMakeLists.txt | 4 ++--
+ 3 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ceda71b1..fbf8c692 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -50,7 +50,7 @@ if(CCACHE_FOUND)
+ endif(CCACHE_FOUND)
+ 
+ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -Wall -Wextra -Werror")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -Wall -Wextra")
+     if (RAPIDJSON_BUILD_CXX11)
+         if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.7.0")
+             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+@@ -73,7 +73,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+         endif()
+     endif()
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -Wall -Wextra -Werror -Wno-missing-field-initializers")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -Wall -Wextra -Wno-missing-field-initializers")
+     if (RAPIDJSON_BUILD_CXX11)
+         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+     endif()
+diff --git a/example/CMakeLists.txt b/example/CMakeLists.txt
+index 4d448ccc..47d19edc 100644
+--- a/example/CMakeLists.txt
++++ b/example/CMakeLists.txt
+@@ -26,9 +26,9 @@ include_directories("../include/")
+ add_definitions(-D__STDC_FORMAT_MACROS)
+ 
+ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -Werror -Wall -Wextra -Weffc++ -Wswitch-default")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -Wall -Wextra -Weffc++ -Wswitch-default")
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall -Wextra -Weffc++ -Wswitch-default -Wfloat-equal -Wimplicit-fallthrough -Weverything")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Weffc++ -Wswitch-default -Wfloat-equal -Wimplicit-fallthrough -Weverything")
+ endif()
+ 
+ foreach (example ${EXAMPLES})
+diff --git a/test/unittest/CMakeLists.txt b/test/unittest/CMakeLists.txt
+index b3204d6c..d1c0add2 100644
+--- a/test/unittest/CMakeLists.txt
++++ b/test/unittest/CMakeLists.txt
+@@ -37,9 +37,9 @@ if(CCACHE_FOUND)
+ endif(CCACHE_FOUND)
+ 
+ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall -Wextra -Weffc++ -Wswitch-default -Wfloat-equal")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Weffc++ -Wswitch-default -Wfloat-equal")
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall -Wextra -Weffc++ -Wswitch-default -Wfloat-equal -Wimplicit-fallthrough -Weverything")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Weffc++ -Wswitch-default -Wfloat-equal -Wimplicit-fallthrough -Weverything")
+     # If the user is running a newer version of Clang that includes the
+     # -Wdouble-promotion, we will ignore that warning.
+     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 3.7)
+-- 
+2.17.1
+

--- a/var/spack/repos/builtin/packages/rapidjson/package.py
+++ b/var/spack/repos/builtin/packages/rapidjson/package.py
@@ -16,3 +16,7 @@ class Rapidjson(CMakePackage):
     version('1.0.2', '97cc60d01282a968474c97f60714828c')
     version('1.0.1', '48cc188df49617b859d13d31344a50b8')
     version('1.0.0', '08247fbfa464d7f15304285f04b4b228')
+
+    # released versions compile with -Werror and fail with gcc-7
+    # branch-fall-through warnings
+    patch('0001-turn-off-Werror.patch')


### PR DESCRIPTION
rapidjson gives warnings with gcc-7.3 and branch fall through

I admire the developers commitment to warning-free code, but spack cannot build this package in its present state with gcc7.

rapidjson addressed this in its git repository through gcc-specific pragmas.  For the sake of spack, however, I thought it was sufficient to just not use Werror.