### PR TITLE
cgns: new version and updated hdf5 dependency

### DIFF
--- a/var/spack/repos/builtin/packages/cgns/package.py
+++ b/var/spack/repos/builtin/packages/cgns/package.py
@@ -16,17 +16,18 @@ class Cgns(CMakePackage):
     git      = "https://github.com/CGNS/CGNS"
 
     version('develop', branch='develop')
-    version('master', branch='master')
-    version('3.3.1', '65c55998270c3e125e28ec5c3742e15d')
-    version('3.3.0', '64e5e8d97144c1462bee9ea6b2a81d7f')
+    version('master',  branch='master')
+    version('3.4.0',   sha256='6372196caf25b27d38cf6f056258cb0bdd45757f49d9c59372b6dbbddb1e05da')
+    version('3.3.1',   sha256='81093693b2e21a99c5640b82b267a495625b663d7b8125d5f1e9e7aaa1f8d469')
+    version('3.3.0',   sha256='8422c67994f8dc6a2f201523a14f6c7d7e16313bdd404c460c16079dbeafc662')
 
-    variant('hdf5', default=True, description='Enable HDF5 interface')
+    variant('hdf5',    default=True,  description='Enable HDF5 interface')
     variant('fortran', default=False, description='Enable Fortran interface')
-    variant('scoping', default=True, description='Enable scoping')
-    variant('mpi', default=True, description='Enable parallel cgns')
-    variant('int64', default=False, description='Build with 64-bit integers')    
+    variant('scoping', default=True,  description='Enable scoping')
+    variant('mpi',     default=True,  description='Enable parallel cgns')
+    variant('int64',   default=False, description='Build with 64-bit integers')
 
-    depends_on('hdf5', when='+hdf5~mpi')
+    depends_on('hdf5~mpi', when='+hdf5~mpi')
     depends_on('hdf5+mpi', when='+hdf5+mpi')
     depends_on('mpi', when='+mpi')
 


### PR DESCRIPTION
Added the newly released cgns-3.4.0 version which adds some performance and bug fixes.

Updated the checksums to use `sha256` as that seems to be the current default chosen by spack.  Verfied that the previous checksums are still the same as shown in the pre-patched package.

Updated the `hdf5` dependency to explicitly ask for `hdf5~mpi` if the `~mpi` variant is selected and `hdf5+mpi` if `+mpi` variant is selected.  Without this change, the `~mpi` variant would select the `hdf5` dependency which would incorrectly add `+mpi` to hdf5 and we would get a dependency on mpi when it should not exist.  The `spack spec cgns~mpi` output is shown below for prior to the patch showing the dependency on mpi and following the patch showing the correct dependencies.

```
ews00321:spack(develop)> spack spec cgns~mpi
Input spec
--------------------------------
cgns~mpi

Concretized
--------------------------------
cgns@3.4.0%gcc@7.2.0 build_type=RelWithDebInfo ~fortran+hdf5~int64~mpi+scoping arch=linux-rhel7-x86_64 
    ^cmake@3.13.4%gcc@7.2.0~doc+ncurses+openssl~ownlibs~qt arch=linux-rhel7-x86_64 
    ^hdf5@1.10.5%gcc@7.2.0~cxx~debug~fortran~hl+mpi+pic+shared~szip~threadsafe arch=linux-rhel7-x86_64 
        ^openmpi@3.1.3%gcc@7.2.0~cuda+cxx_exceptions fabrics=auto ~java~legacylaunchers~memchecker~pmi schedulers=auto ~sqlite3~thread_multiple+vt arch=linux-rhel7-x86_64 
        ^zlib@1.2.11%gcc@7.2.0+optimize+pic+shared arch=linux-rhel7-x86_64 

ews00321:spack(develop)> spack spec cgns~mpi
Input spec
--------------------------------
cgns~mpi

Concretized
--------------------------------
cgns@3.4.0%gcc@7.2.0 build_type=RelWithDebInfo ~fortran+hdf5~int64~mpi+scoping arch=linux-rhel7-x86_64 
    ^cmake@3.13.4%gcc@7.2.0~doc+ncurses+openssl~ownlibs~qt arch=linux-rhel7-x86_64 
    ^hdf5@1.10.5%gcc@7.2.0~cxx~debug~fortran~hl~mpi+pic+shared~szip~threadsafe arch=linux-rhel7-x86_64 
        ^zlib@1.2.11%gcc@7.2.0+optimize+pic+shared arch=linux-rhel7-x86_64 
```