### PR TITLE
do not specify python include path for oss package

### DIFF
--- a/var/spack/repos/builtin/packages/openspeedshop/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop/package.py
@@ -92,7 +92,7 @@ class Openspeedshop(CMakePackage):
     depends_on("dyninst@10:", when='@2.3.1.3:9999')
 
     depends_on("python", when='@develop', type=('build', 'run'))
-    depends_on("python@2.7.14:2.7.15", when='@2.3.1.3:9999', type=('build', 'run'))
+    depends_on("python@2.7.14:2.7.99", when='@2.3.1.3:9999', type=('build', 'run'))
 
     depends_on("libxml2")
 


### PR DESCRIPTION
@jgalarowicz, my attempts to build openspeedshop in spack failed b/c it was specifying the PYTHON_INCLUDE_DIR only up to the python "include" path. The actual Python.h file is in the versioned sub directory pythonX.Y, i.e. "include/python2.7" for Python 2.7. CMake should be smart enough to figure this out, so in this PR, I remove the specification of the include directory. One could also specify it, but include the versioned sub directory if you feel that's a better solution.