### PR TITLE
Add setup.py to cythonize parts of spack for speed up.

### DIFF
--- a/lib/spack/setup.py
+++ b/lib/spack/setup.py
@@ -1,0 +1,16 @@
+from distutils.core import setup
+from distutils.extension import Extension
+from Cython.Build import cythonize
+import glob
+
+extensions=[]
+
+excludes = ['spack/main.py','spack/paths.py']
+
+for f in glob.glob('spack/*.py'):
+    if f in excludes:
+        continue
+    extensions.append(Extension(f.replace('spack/','spack.').replace('.py',''),[f]))
+
+extensions.append(Extension('llnl.util.lang', ['llnl/util/lang.py']))
+setup(name="spack", ext_modules = cythonize(extensions))

--- a/lib/spack/setup.py
+++ b/lib/spack/setup.py
@@ -3,14 +3,16 @@ from distutils.extension import Extension
 from Cython.Build import cythonize
 import glob
 
-extensions=[]
+extensions = []
 
-excludes = ['spack/main.py','spack/paths.py']
+excludes = ['spack/main.py', 'spack/paths.py']
 
 for f in glob.glob('spack/*.py'):
     if f in excludes:
         continue
-    extensions.append(Extension(f.replace('spack/','spack.').replace('.py',''),[f]))
+    extensions.append(Extension(f.replace('spack/', 'spack.').replace('.py',
+                                                                      ''),
+                                [f]))
 
 extensions.append(Extension('llnl.util.lang', ['llnl/util/lang.py']))
-setup(name="spack", ext_modules = cythonize(extensions))
+setup(name="spack", ext_modules=cythonize(extensions))


### PR DESCRIPTION
Testing show that concretizing a spec with a deep dependency tree was taking over a minute to concretize. Using cython to generate C files for the modules and linking those into .so files speed up the concretization process to ~25 seconds. For the spack-dev initial setup each co-developed package has to be concretized. This can quickly add up to over 10 minutes. Every speed improvement is needed.


To use
cd spack/lib/spack
python setup.py build_ext --inplace
to build the corresponding *.so files.
Requires system or virtual env with cython installed.