### PR TITLE
libelf: move url to fossies.org

### DIFF
--- a/var/spack/repos/builtin/packages/libelf/package.py
+++ b/var/spack/repos/builtin/packages/libelf/package.py
@@ -14,7 +14,11 @@ class Libelf(AutotoolsPackage):
        maintained and packages that depend on libelf should migrate to
        elfutils."""
 
-    homepage = "http://www.mr511.de/software/english.html"
+    # The original homepage no longer exists, but the tar file is
+    # archived at fossies.org.
+    # homepage = "http://www.mr511.de/software/english.html"
+
+    homepage = "https://directory.fsf.org/wiki/Libelf"
     url      = "https://fossies.org/linux/misc/old/libelf-0.8.13.tar.gz"
 
     version('0.8.13', '4136d7b4c04df68b686570afa26988ac')

--- a/var/spack/repos/builtin/packages/libelf/package.py
+++ b/var/spack/repos/builtin/packages/libelf/package.py
@@ -10,13 +10,15 @@ class Libelf(AutotoolsPackage):
     """libelf lets you read, modify or create ELF object files in an
        architecture-independent way. The library takes care of size
        and endian issues, e.g. you can process a file for SPARC
-       processors on an Intel-based system."""
+       processors on an Intel-based system. Note: libelf is no longer
+       maintained and packages that depend on libelf should migrate to
+       elfutils."""
 
     homepage = "http://www.mr511.de/software/english.html"
-    url      = "http://www.mr511.de/software/libelf-0.8.13.tar.gz"
+    url      = "https://fossies.org/linux/misc/old/libelf-0.8.13.tar.gz"
 
     version('0.8.13', '4136d7b4c04df68b686570afa26988ac')
-    version('0.8.12', 'e21f8273d9f5f6d43a59878dc274fec7')
+    # version('0.8.12', 'e21f8273d9f5f6d43a59878dc274fec7')
 
     provides('elf@0')
 


### PR DESCRIPTION
Libelf is no longer maintained and the original mr511.de web site no
longer exists.  The final release, 0.8.13 from Nov 2009 is still
archived at fossies.org.

Fixes #10757.

----------

The libelf homepage (www.mr511.de) no longer exists, but I was unable
to find a satisfactory replacement.
