### PR TITLE
qt: Use more system dependencies and fix build with new gcc versions

### DIFF
--- a/var/spack/repos/builtin/packages/pcre/package.py
+++ b/var/spack/repos/builtin/packages/pcre/package.py
@@ -25,6 +25,9 @@ class Pcre(AutotoolsPackage):
     variant('jit', default=False,
             description='Enable JIT support.')
 
+    variant('multibyte', default=True,
+            description='Enable support for 16 and 32 bit characters.')
+
     variant('utf', default=True,
             description='Enable support for UTF-8/16/32, '
             'incompatible with EBCDIC.')
@@ -34,6 +37,10 @@ class Pcre(AutotoolsPackage):
 
         if '+jit' in self.spec:
             args.append('--enable-jit')
+
+        if '+multibyte' in self.spec:
+            args.append('--enable-pcre16')
+            args.append('--enable-pcre32')
 
         if '+utf' in self.spec:
             args.append('--enable-utf')

--- a/var/spack/repos/builtin/packages/pcre2/package.py
+++ b/var/spack/repos/builtin/packages/pcre2/package.py
@@ -16,3 +16,15 @@ class Pcre2(AutotoolsPackage):
 
     version('10.31', 'e0b91c891a3c49050f7fd15de33d0ba4')
     version('10.20', 'dcd027c57ecfdc8a6c3af9d0acf5e3f7')
+
+    variant('multibyte', default=True,
+            description='Enable support for 16 and 32 bit characters.')
+
+    def configure_args(self):
+        args = []
+
+        if '+multibyte' in self.spec:
+            args.append('--enable-pcre2-16')
+            args.append('--enable-pcre2-32')
+
+        return args


### PR DESCRIPTION
qt currently falls back to bundled versions of sqlite, harfbuzz, pcre, double-conversion and xcb. This adds the appropriate dependencies and configure arguments. A new variant adds multibyte support to pcre and pcre2, which is required by qt.

Additionally, newer versions of gcc (starting with @8.3.0) cause build failures. This adds a patch to fix the problem.

The changes have been tested with all versions of qt currently available in Spack. 5.2 and 5.3 do not build for reasons that seem to be unrelated to these changes, though.