### PR TITLE
libimobiledevice: new package

### DIFF
--- a/var/spack/repos/builtin/packages/libimobiledevice/package.py
+++ b/var/spack/repos/builtin/packages/libimobiledevice/package.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Libimobiledevice(AutotoolsPackage):
+    """Library to communicate with iOS devices natively."""
+
+    homepage = "https://www.libimobiledevice.org/"
+    url      = "https://www.libimobiledevice.org/downloads/libimobiledevice-1.2.0.tar.bz2"
+    git      = "https://git.libimobiledevice.org/libimobiledevice.git"
+
+    version('master', branch='master')
+    version('1.2.0',  sha256='786b0de0875053bf61b5531a86ae8119e320edab724fc62fe2150cc931f11037')
+
+    depends_on('autoconf',   type='build', when='@master')
+    depends_on('automake',   type='build', when='@master')
+    depends_on('libtool',    type='build', when='@master')
+    depends_on('pkg-config', type='build')
+    depends_on('libplist')
+    depends_on('libtasn1')
+    depends_on('libusbmuxd')
+    depends_on('openssl')
+
+    def configure_args(self):
+        return [
+            '--disable-dependency-tracking',
+            '--disable-silent-rules',
+            '--enable-debug-code',
+            '--without-cython'
+        ]

--- a/var/spack/repos/builtin/packages/libimobiledevice/package.py
+++ b/var/spack/repos/builtin/packages/libimobiledevice/package.py
@@ -1,9 +1,7 @@
-# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-from spack import *
 
 
 class Libimobiledevice(AutotoolsPackage):


### PR DESCRIPTION
This PR adds `libimobiledevice, needed for iOS interaction from various Unix systems.

There's a small catch with this PR that I'm not sure what to do with; the `1.2.0` version (latest) requires `SSLv3` which we don't have variants for in `openssl`. As this is deprecated by the IETF, I don't want to add that variant.

As such, should I simply remove the `1.2.0` version from this package for now, or leave it so that people can link OpenSSL manually? 