### PR TITLE
boost: patch for problem with warnings for 1.69.0.

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -160,6 +160,13 @@ class Boost(Package):
     # Fix the bootstrap/bjam build for Cray
     patch('bootstrap-path.patch', when='@1.39.0: platform=cray')
 
+    # Patch fix for warnings from commits 2d37749, af1dc84, c705bab, and
+    # 0134441 on http://github.com/boostorg/system.
+    patch('system-non-virtual-dtor-include.patch', when='@1.69.0',
+          level=2)
+    patch('system-non-virtual-dtor-test.patch', when='@1.69.0',
+          working_dir='libs/system', level=1)
+
     def url_for_version(self, version):
         if version >= Version('1.63.0'):
             url = "https://dl.bintray.com/boostorg/release/{0}/source/boost_{1}.tar.bz2"

--- a/var/spack/repos/builtin/packages/boost/system-non-virtual-dtor-include.patch
+++ b/var/spack/repos/builtin/packages/boost/system-non-virtual-dtor-include.patch
@@ -1,0 +1,74 @@
+From af1dc841609c980cd76f8e3c5db486d69073214b Mon Sep 17 00:00:00 2001
+From: Peter Dimov <pdimov@gmail.com>
+Date: Mon, 4 Mar 2019 16:35:35 +0200
+Subject: [PATCH] Disable -Wnon-virtual-dtor
+
+---
+ include/boost/system/error_code.hpp | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/include/boost/system/error_code.hpp b/include/boost/system/error_code.hpp
+index 93899df..b9c590d 100644
+--- a/include/boost/system/error_code.hpp
++++ b/include/boost/system/error_code.hpp
+@@ -155,6 +155,10 @@ template<> struct is_error_condition_enum<errc::errc_t>
+ };
+ 
+ // class error_category
++#if defined( BOOST_GCC ) || defined( BOOST_CLANG )
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
++#endif
+ 
+ #ifdef BOOST_MSVC
+ #pragma warning( push )
+@@ -314,6 +318,10 @@ public:
+ 
+ } // namespace detail
+ 
++#if defined( BOOST_GCC ) || defined( BOOST_CLANG )
++#pragma GCC diagnostic pop
++#endif
++
+ // generic_category(), system_category()
+ 
+ #if defined(BOOST_SYSTEM_HAS_CONSTEXPR)
+-- 
+2.20.1
+
+
+From c705bab504dafdc8925b30709e1ef8f83c62b9af Mon Sep 17 00:00:00 2001
+From: Peter Dimov <pdimov@gmail.com>
+Date: Mon, 4 Mar 2019 17:38:52 +0200
+Subject: [PATCH] #pragma GCC diagnostic push/pop requires gcc 4.6
+
+---
+ include/boost/system/error_code.hpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/include/boost/system/error_code.hpp b/include/boost/system/error_code.hpp
+index b9c590d..f1d7ddb 100644
+--- a/include/boost/system/error_code.hpp
++++ b/include/boost/system/error_code.hpp
+@@ -155,7 +155,7 @@ template<> struct is_error_condition_enum<errc::errc_t>
+ };
+ 
+ // class error_category
+-#if defined( BOOST_GCC ) || defined( BOOST_CLANG )
++#if ( defined( BOOST_GCC ) && BOOST_GCC >= 40600 ) || defined( BOOST_CLANG )
+ #pragma GCC diagnostic push
+ #pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
+ #endif
+@@ -318,7 +318,7 @@ public:
+ 
+ } // namespace detail
+ 
+-#if defined( BOOST_GCC ) || defined( BOOST_CLANG )
++#if ( defined( BOOST_GCC ) && BOOST_GCC >= 40600 ) || defined( BOOST_CLANG )
+ #pragma GCC diagnostic pop
+ #endif
+ 
+-- 
+2.20.1
+
+

--- a/var/spack/repos/builtin/packages/boost/system-non-virtual-dtor-test.patch
+++ b/var/spack/repos/builtin/packages/boost/system-non-virtual-dtor-test.patch
@@ -1,0 +1,95 @@
+From 2d37749d00cf9293fa3c7e0e1d2eec13f5546834 Mon Sep 17 00:00:00 2001
+From: Peter Dimov <pdimov@gmail.com>
+Date: Mon, 4 Mar 2019 15:40:03 +0200
+Subject: [PATCH] Enable -Wnon-virtual-dtor in warnings_test
+
+---
+ test/Jamfile.v2 | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/Jamfile.v2 b/test/Jamfile.v2
+index 6a24bd4..bf07950 100644
+--- a/test/Jamfile.v2
++++ b/test/Jamfile.v2
+@@ -61,4 +61,4 @@ system-run failed_constexpr_test.cpp ;
+ # Quick (CI) test
+ run quick.cpp ;
+ 
+-run quick.cpp : : : <warnings>all <warnings-as-errors>on : warnings_test ;
++run quick.cpp : : : <warnings>all <warnings-as-errors>on <toolset>gcc:<cxxflags>-Wnon-virtual-dtor <toolset>clang:<cxxflags>-Wnon-virtual-dtor : warnings_test ;
+-- 
+2.20.1
+
+From 0134441a6e628f407e77275b675e9a5757f65c0a Mon Sep 17 00:00:00 2001
+From: Peter Dimov <pdimov@gmail.com>
+Date: Mon, 4 Mar 2019 19:23:32 +0200
+Subject: [PATCH] Add warnings_test.cpp; disable -Wnon-virtual-dtor on g++ <
+ 4.6
+
+---
+ test/Jamfile.v2        |  2 +-
+ test/warnings_test.cpp | 42 ++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 43 insertions(+), 1 deletion(-)
+ create mode 100644 test/warnings_test.cpp
+
+diff --git a/test/Jamfile.v2 b/test/Jamfile.v2
+index bf07950..1648d46 100644
+--- a/test/Jamfile.v2
++++ b/test/Jamfile.v2
+@@ -61,4 +61,4 @@ system-run failed_constexpr_test.cpp ;
+ # Quick (CI) test
+ run quick.cpp ;
+ 
+-run quick.cpp : : : <warnings>all <warnings-as-errors>on <toolset>gcc:<cxxflags>-Wnon-virtual-dtor <toolset>clang:<cxxflags>-Wnon-virtual-dtor : warnings_test ;
++run warnings_test.cpp : : : <warnings>all <warnings-as-errors>on <toolset>gcc:<cxxflags>-Wnon-virtual-dtor <toolset>clang:<cxxflags>-Wnon-virtual-dtor ;
+diff --git a/test/warnings_test.cpp b/test/warnings_test.cpp
+new file mode 100644
+index 0000000..f7554e1
+--- /dev/null
++++ b/test/warnings_test.cpp
+@@ -0,0 +1,42 @@
++
++// Copyright 2017, 2019 Peter Dimov.
++//
++// Distributed under the Boost Software License, Version 1.0.
++//
++// See accompanying file LICENSE_1_0.txt or copy at
++// http://www.boost.org/LICENSE_1_0.txt
++
++// See library home page at http://www.boost.org/libs/system
++
++#include <boost/config.hpp>
++
++#if defined( BOOST_GCC ) && BOOST_GCC < 40600
++#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
++#endif
++
++#include <boost/system/error_code.hpp>
++#include <boost/core/lightweight_test.hpp>
++#include <cerrno>
++
++int main()
++{
++    boost::system::error_category const & bt = boost::system::generic_category();
++
++    int ev = ENOENT;
++
++    boost::system::error_code bc( ev, bt );
++
++    BOOST_TEST_EQ( bc.value(), ev );
++    BOOST_TEST_EQ( &bc.category(), &bt );
++
++    boost::system::error_condition bn = bt.default_error_condition( ev );
++
++    BOOST_TEST_EQ( bn.value(), ev );
++    BOOST_TEST_EQ( &bn.category(), &bt );
++
++    BOOST_TEST( bt.equivalent( ev, bn ) );
++
++    BOOST_TEST( bc == bn );
++
++    return boost::report_errors();
++}
+-- 
+2.20.1
+


### PR DESCRIPTION
Boost 1.69.0 has issues in a relatively low level header that cause compile warnings when a particular non-bundled warning (`-Wnon-virtual-dtor`) is activated. This can cause problems for downstream code that uses `-Werror`. This PR applies a pair of patches comprising the fixes for this issue that have already been applied to the `develop` branch of the relevant Boost package (`system`) and will be released with 1.70.0.