### PR TITLE
thrust: add versions 1.9.0-1.9.4

### DIFF
--- a/var/spack/repos/builtin/packages/thrust/package.py
+++ b/var/spack/repos/builtin/packages/thrust/package.py
@@ -11,8 +11,13 @@ class Thrust(Package):
     which resembles the C++ Standard Template Library (STL)."""
 
     homepage = "https://thrust.github.io"
-    url      = "https://github.com/thrust/thrust/archive/1.8.2.tar.gz"
+    url      = "https://github.com/thrust/thrust/archive/1.9.4.tar.gz"
 
+    version('1.9.4', sha256='41931a7d73331fc39c6bea56d1eb8d4d8bbf7c73688979bbdab0e55772f538d1')
+    version('1.9.3', sha256='92482ad0219cd2d727766f42a4fc952d7c5fd0183c5e201d9a117568387b4fd1')
+    version('1.9.2', sha256='1fb1272be9e8c28973f5c39eb230d1914375ef38bcaacf09a3fa51c6b710b756')
+    version('1.9.1', sha256='7cf59bf42a7b05bc6799c88269bf41eb637ca2897726a5ade334a1b8b4579ef1')
+    version('1.9.0', sha256='a98cf59fc145dd161471291d4816f399b809eb0db2f7085acc7e3ebc06558b37')
     version('1.8.2', 'fc7fc807cba98640c816463b511fb53f')
 
     def install(self, spec, prefix):


### PR DESCRIPTION
Hi,

These added versions should be the ones that have been released with CUDA these past few years, and have recently been added to the official thrust [repository](https://github.com/thrust/thrust/releases).