### PR TITLE
Elfutils requires m4 to build.

### DIFF
--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -17,10 +17,11 @@ class Elfutils(AutotoolsPackage):
     version of elfutils."""
 
     homepage = "https://fedorahosted.org/elfutils/"
-    url      = "https://sourceware.org/elfutils/ftp/0.168/elfutils-0.168.tar.bz2"
+    url      = "https://sourceware.org/elfutils/ftp/0.176/elfutils-0.176.tar.bz2"
     list_url = "https://sourceware.org/elfutils/ftp"
     list_depth = 1
 
+    version('0.176', '077e4f49320cad82bf17a997068b1db9')
     version('0.175', '9a02b0382b78cc2d515fb950275d4c02')
     version('0.174', '48bec24c0c8b2c16820326956dff9378')
     version('0.173', '35decb1ebfb90d565e4c411bee4185cc')

--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -42,6 +42,7 @@ class Elfutils(AutotoolsPackage):
     depends_on('xz',    type='link', when='+xz')
     depends_on('zlib',  type='link')
     depends_on('gettext', when='+nls')
+    depends_on('m4',    type='build')
 
     conflicts('%gcc@7.2.0:', when='@0.163')
 


### PR DESCRIPTION
Presumably this was missed because a system m4 is usually findable.