### PR TITLE
intel-tbb: add 2019.{3,4} and patches for pedantic warnings.

### DIFF
--- a/var/spack/repos/builtin/packages/intel-tbb/gcc_generic-pedantic-2019.patch
+++ b/var/spack/repos/builtin/packages/intel-tbb/gcc_generic-pedantic-2019.patch
@@ -1,0 +1,29 @@
+From e125b22536eadcaba3c1f765c83f7bb687f9f51a Mon Sep 17 00:00:00 2001
+From: Chris Green <artists@fnal.gov>
+Date: Thu, 7 Mar 2019 11:16:00 -0600
+Subject: [PATCH] Remove superfluous semicolons to satisfy -pedantic.
+
+---
+ include/tbb/machine/gcc_generic.h | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/include/tbb/machine/gcc_generic.h b/include/tbb/machine/gcc_generic.h
+index 740cfd3..6a8d4b7 100644
+--- a/include/tbb/machine/gcc_generic.h
++++ b/include/tbb/machine/gcc_generic.h
+@@ -216,9 +216,9 @@ struct machine_load_store_seq_cst {
+ 
+ // __builtin_clz counts the number of leading zeroes
+ namespace tbb{ namespace internal { namespace gcc_builtins {
+-    inline int clz(unsigned int x){ return __builtin_clz(x); };
+-    inline int clz(unsigned long int x){ return __builtin_clzl(x); };
+-    inline int clz(unsigned long long int x){ return __builtin_clzll(x); };
++    inline int clz(unsigned int x){ return __builtin_clz(x); }
++    inline int clz(unsigned long int x){ return __builtin_clzl(x); }
++    inline int clz(unsigned long long int x){ return __builtin_clzll(x); }
+ }}}
+ // logarithm is the index of the most significant non-zero bit
+ static inline intptr_t __TBB_machine_lg( uintptr_t x ) {
+-- 
+2.20.1
+

--- a/var/spack/repos/builtin/packages/intel-tbb/gcc_generic-pedantic-4.4.patch
+++ b/var/spack/repos/builtin/packages/intel-tbb/gcc_generic-pedantic-4.4.patch
@@ -1,0 +1,29 @@
+From cdea634c02e1549408cf137e2766e8e3ee0c2b14 Mon Sep 17 00:00:00 2001
+From: Chris Green <artists@fnal.gov>
+Date: Thu, 7 Mar 2019 11:34:58 -0600
+Subject: [PATCH] Remove superfluous semicolons to satisfy -pedantic.
+
+---
+ include/tbb/machine/gcc_generic.h | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/include/tbb/machine/gcc_generic.h b/include/tbb/machine/gcc_generic.h
+index bd698a4..d970653 100644
+--- a/include/tbb/machine/gcc_generic.h
++++ b/include/tbb/machine/gcc_generic.h
+@@ -107,9 +107,9 @@ __TBB_MACHINE_DEFINE_ATOMICS(8,int64_t)
+ #undef __TBB_MACHINE_DEFINE_ATOMICS
+ 
+ namespace tbb{ namespace internal { namespace gcc_builtins {
+-    inline int clz(unsigned int x){ return __builtin_clz(x);};
+-    inline int clz(unsigned long int x){ return __builtin_clzl(x);};
+-    inline int clz(unsigned long long int x){ return __builtin_clzll(x);};
++    inline int clz(unsigned int x){ return __builtin_clz(x);}
++    inline int clz(unsigned long int x){ return __builtin_clzl(x);}
++    inline int clz(unsigned long long int x){ return __builtin_clzll(x);}
+ }}}
+ //gcc __builtin_clz builtin count _number_ of leading zeroes
+ static inline intptr_t __TBB_machine_lg( uintptr_t x ) {
+-- 
+2.20.1
+

--- a/var/spack/repos/builtin/packages/intel-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-tbb/package.py
@@ -18,8 +18,10 @@ class IntelTbb(Package):
     homepage = "http://www.threadingbuildingblocks.org/"
 
     # See url_for_version() below.
-    version('2019.2', '1245aa394a92099e23ce2f60cdd50c90eb3ddcd61d86cae010ef2f1de61f32d9')
-    version('2019.1', 'a4875c6b6853213083e52ecd303546bdf424568ec67cfc7e51d132a7c037c66a')
+    version('2019.4', sha256='342a0a2cd583879850658284b86e9351ea019b4f3fcd731f4c18456f0ce9f900')
+    version('2019.3', sha256='b2244147bc8159cdd8f06a38afeb42f3237d3fc822555499d7ccfbd4b86f8ece')
+    version('2019.2', sha256='1245aa394a92099e23ce2f60cdd50c90eb3ddcd61d86cae010ef2f1de61f32d9')
+    version('2019.1', sha256='a4875c6b6853213083e52ecd303546bdf424568ec67cfc7e51d132a7c037c66a')
     version('2019',   '2119f1db2f905dc5b423482d7689b7d6')
     version('2018.6', '9a0f78db4f72356068b00f29f54ee6bc')
     version('2018.5', 'ff3ae09f8c23892fbc3008c39f78288f')
@@ -69,6 +71,8 @@ class IntelTbb(Package):
     patch("tbb_gcc_rtm_key.patch", level=0, when='%gcc@4.8.0: os=rhel6')
     patch("tbb_gcc_rtm_key.patch", level=0, when='%gcc@4.8.0: os=scientific6')
     patch("tbb_gcc_rtm_key.patch", level=0, when='%gcc@4.8.0: os=centos6')
+    patch("gcc_generic-pedantic-4.4.patch", level=1, when='@:2018.99')
+    patch("gcc_generic-pedantic-2019.patch", level=1, when='@2019:')
 
     # Patch cmakeConfig.cmake.in to find the libraries where we install them.
     patch("tbb_cmakeConfig.patch", level=0, when='@2017.0:')


### PR DESCRIPTION
In addition to adding checksums for recent versions of Intel Threading Building Blocks, we also add a pair of patches to resolve pedantic warnings in versions `2017:2019`. The patch against version `2019` has been submitted upstream as https://github.com/01org/tbb/pull/129.