### PR TITLE
Fix OpenMPI v4.0.0 + Slurm installation error

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -485,7 +485,7 @@ class Openmpi(AutotoolsPackage):
                         self.prefix.bin.oshrun
                         ]
             for exe in exe_list:
-                 try:
-                     os.remove(exe)
-                 except OSError:
-                     tty.debug("File not present: " + exe)
+                try:
+                    os.remove(exe)
+                except OSError:
+                    tty.debug("File not present: " + exe)

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -6,6 +6,7 @@
 
 import os
 import sys
+import llnl.util.tty as tty
 
 
 def _verbs_dir():
@@ -478,11 +479,13 @@ class Openmpi(AutotoolsPackage):
         # only sensible choice (orterun is still present, but normal
         # users don't know about that).
         if '@1.6: ~legacylaunchers schedulers=slurm' in self.spec:
-            try:
-                # OpenMPI 4.0 does not have shmemrun and oshrun
-                os.remove(self.prefix.bin.mpirun)
-                os.remove(self.prefix.bin.mpiexec)
-                os.remove(self.prefix.bin.shmemrun)
-                os.remove(self.prefix.bin.oshrun)
-            except OSError:
-                pass
+            exe_list = [self.prefix.bin.mpirun,
+                        self.prefix.bin.mpiexec,
+                        self.prefix.bin.shmemrun,
+                        self.prefix.bin.oshrun
+                        ]
+            for exe in exe_list:
+                 try:
+                     os.remove(exe)
+                 except OSError:
+                     tty.debug("File not present: " + exe)

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -478,7 +478,11 @@ class Openmpi(AutotoolsPackage):
         # only sensible choice (orterun is still present, but normal
         # users don't know about that).
         if '@1.6: ~legacylaunchers schedulers=slurm' in self.spec:
-            os.remove(self.prefix.bin.mpirun)
-            os.remove(self.prefix.bin.mpiexec)
-            os.remove(self.prefix.bin.shmemrun)
-            os.remove(self.prefix.bin.oshrun)
+            try:
+                # OpenMPI 4.0 does not have shmemrun and oshrun
+                os.remove(self.prefix.bin.mpirun)
+                os.remove(self.prefix.bin.mpiexec)
+                os.remove(self.prefix.bin.shmemrun)
+                os.remove(self.prefix.bin.oshrun)
+            except OSError:
+                pass


### PR DESCRIPTION
`shmemrun` and `oshrun` do not exist in OpenMPI v4.0.0
(ref: https://www.open-mpi.org/doc/v4.0/)

Simply calling `os.remove` on them will cause Spack install error:
```
$ spack install openmpi@4.0.0+pmi schedulers=slurm
...
==> Executing phase: 'autoreconf'
==> Executing phase: 'configure'
==> Executing phase: 'build'
==> Executing phase: 'install'
==> Error: OSError: [Errno 2] No such file or directory: '/shared/spack/opt/spack/linux-centos7-x86_64/intel-19.0.1.144/openmpi-4.0.0-mbndkoanvn5tknggr35g7omsrgkajnj5/bin/shmemrun'

/shared/spack/var/spack/repos/builtin/packages/openmpi/package.py:483, in delete_mpirun_mpiexec:
        480        if '@1.6: ~legacylaunchers schedulers=slurm' in self.spec:
        481            os.remove(self.prefix.bin.mpirun)
        482            os.remove(self.prefix.bin.mpiexec)
  >>    483            os.remove(self.prefix.bin.shmemrun)
        484            os.remove(self.prefix.bin.oshrun)

See build log for details:
  /shared/spack/var/spack/stage/openmpi-4.0.0-mbndkoanvn5tknggr35g7omsrgkajnj5/openmpi-4.0.0/spack-build.out
```
