### PR TITLE
disable CUDA in llvm

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -30,6 +30,8 @@ class Llvm(CMakePackage):
 
     variant('clang', default=True,
             description="Build the LLVM C/C++/Objective-C compiler frontend")
+    variant('cuda', default=False,
+            description="Build the LLVM with CUDA features enabled")
     variant('lldb', default=True, description="Build the LLVM debugger")
     variant('lld', default=True, description="Build the LLVM linker")
     variant('internal_unwind', default=True,
@@ -587,6 +589,12 @@ class Llvm(CMakePackage):
             '-DCLANG_DEFAULT_OPENMP_RUNTIME:STRING=libomp',
             '-DPYTHON_EXECUTABLE:PATH={0}'.format(spec['python'].command.path),
         ]
+
+        if '+cuda' not in spec:
+            cmake_args.extend([
+                '-DCUDA_TOOLKIT_ROOT_DIR:PATH=IGNORE',
+                '-DCUDA_SDK_ROOT_DIR:PATH=IGNORE',
+                '-DCUDA_NVCC_EXECUTABLE:FILEPATH=IGNORE'])
 
         if '+gold' in spec:
             cmake_args.append('-DLLVM_BINUTILS_INCDIR=' +

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -30,8 +30,17 @@ class Llvm(CMakePackage):
 
     variant('clang', default=True,
             description="Build the LLVM C/C++/Objective-C compiler frontend")
-    variant('cuda', default=False,
-            description="Build the LLVM with CUDA features enabled")
+
+    # TODO: The current version of this package unconditionally disables CUDA.
+    #       Better would be to add a "cuda" variant that:
+    #        - Adds dependency on the "cuda" package when enabled
+    #        - Sets the necessary CMake flags when enabled
+    #        - Disables CUDA (as this current version does) only when the
+    #          variant is also disabled.
+
+    # variant('cuda', default=False,
+    #         description="Build the LLVM with CUDA features enabled")
+
     variant('lldb', default=True, description="Build the LLVM debugger")
     variant('lld', default=True, description="Build the LLVM linker")
     variant('internal_unwind', default=True,
@@ -590,12 +599,13 @@ class Llvm(CMakePackage):
             '-DPYTHON_EXECUTABLE:PATH={0}'.format(spec['python'].command.path),
         ]
 
-        if '+cuda' not in spec:
-            cmake_args.extend([
-                '-DCUDA_TOOLKIT_ROOT_DIR:PATH=IGNORE',
-                '-DCUDA_SDK_ROOT_DIR:PATH=IGNORE',
-                '-DCUDA_NVCC_EXECUTABLE:FILEPATH=IGNORE',
-                '-DLIBOMPTARGET_DEP_CUDA_DRIVER_LIBRARIES:STRING=IGNORE'])
+        # TODO: Instead of unconditionally disabling CUDA, add a "cuda" variant
+        #       (see TODO above), and set the paths if enabled.
+        cmake_args.extend([
+            '-DCUDA_TOOLKIT_ROOT_DIR:PATH=IGNORE',
+            '-DCUDA_SDK_ROOT_DIR:PATH=IGNORE',
+            '-DCUDA_NVCC_EXECUTABLE:FILEPATH=IGNORE',
+            '-DLIBOMPTARGET_DEP_CUDA_DRIVER_LIBRARIES:STRING=IGNORE'])
 
         if '+gold' in spec:
             cmake_args.append('-DLLVM_BINUTILS_INCDIR=' +

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -594,7 +594,8 @@ class Llvm(CMakePackage):
             cmake_args.extend([
                 '-DCUDA_TOOLKIT_ROOT_DIR:PATH=IGNORE',
                 '-DCUDA_SDK_ROOT_DIR:PATH=IGNORE',
-                '-DCUDA_NVCC_EXECUTABLE:FILEPATH=IGNORE'])
+                '-DCUDA_NVCC_EXECUTABLE:FILEPATH=IGNORE',
+                '-DLIBOMPTARGET_DEP_CUDA_DRIVER_LIBRARIES:STRING=IGNORE'])
 
         if '+gold' in spec:
             cmake_args.append('-DLLVM_BINUTILS_INCDIR=' +


### PR DESCRIPTION
Adds a new variant to llvm: `cuda`, which if disabled (default), will set additional CMake variables so as to explicitly disable CUDA features from the llvm build.

These changes address an issue where a local cuda install outside of spack can leak into and break the build.  The variant doesn't add any dependencies on the `cuda` package, but perhaps it should?  Open to suggestions.