### PR TITLE
Revert to manual flag enabling, due to RegCM bug in configure.

### DIFF
--- a/var/spack/repos/builtin/packages/regcm/package.py
+++ b/var/spack/repos/builtin/packages/regcm/package.py
@@ -97,10 +97,13 @@ class Regcm(AutotoolsPackage):
                 raise InstallError('The GCC compiler does not support '
                                    'multiple architecture optimizations.')
 
-        args += self.enable_or_disable('extension')
+            # RegCM configure script treats --disable-X as --enable-X, so we
+            # cannot use enable_or_disable; enable only the flags requested.
+            args += ('--enable-' + ext for ext in optimizations)
 
         for opt in ('debug', 'profile', 'singleprecision'):
-            args += self.enable_or_disable(opt)
+            if ('+' + opt) in self.spec:
+                args.append('--enable-' + opt)
 
         # RegCM SVN6916 introduced a specific flag to use some pnetcdf calls.
         if '+pnetcdf' in self.spec and '@4.7.0-SVN6916:' in self.spec:


### PR DESCRIPTION
The configure of RegCM treats --disable-FEATURE as --enable-FEATURE,
so we cannot use enable_or_disable.

I'd also like to fix issue #10163; I tried specifying: `depends_on('mpi', type=('build', 'link', 'run'))`
but the openmpi bin wasn't added to the PATH in the module created; the following is the line with PATH from the module:
`prepend-path PATH /.../intel/18.0.3/regcm/4.7.1-SVN6916-cosiybixa6r2korik6vaajsq4xfxhjmv/bin`.

Shouldn't `'run'` include the dependency in the PATH? Is it a bug?
https://spack.readthedocs.io/en/latest/packaging_guide.html?highlight=run#dependency-types