### PR TITLE
hpcviewer: new package

### DIFF
--- a/var/spack/repos/builtin/packages/hpcviewer/package.py
+++ b/var/spack/repos/builtin/packages/hpcviewer/package.py
@@ -6,6 +6,7 @@
 from spack import *
 import platform
 
+
 # The viewer and trace viewer tar files and sha256sum depend on the
 # version and machine type.
 def viewer_url(ver, mach):
@@ -13,6 +14,7 @@ def viewer_url(ver, mach):
         'http://hpctoolkit.org/download/hpcviewer/{0}/'
         'hpcviewer-linux.gtk.{1}.tgz'
     ).format(ver, mach)
+
 
 def trace_url(ver, mach):
     return (

--- a/var/spack/repos/builtin/packages/hpcviewer/package.py
+++ b/var/spack/repos/builtin/packages/hpcviewer/package.py
@@ -6,6 +6,20 @@
 from spack import *
 import platform
 
+# The viewer and trace viewer tar files and sha256sum depend on the
+# version and machine type.
+def viewer_url(ver, mach):
+    return (
+        'http://hpctoolkit.org/download/hpcviewer/{0}/'
+        'hpcviewer-linux.gtk.{1}.tgz'
+    ).format(ver, mach)
+
+def trace_url(ver, mach):
+    return (
+        'http://hpctoolkit.org/download/hpcviewer/{0}/'
+        'hpctraceviewer-linux.gtk.{1}.tgz'
+    ).format(ver, mach)
+
 
 class Hpcviewer(Package):
     """Binary distribution of hpcviewer and hpctraceviewer for the
@@ -18,31 +32,16 @@ class Hpcviewer(Package):
 
     mach = platform.machine()
 
-    # The viewer and trace viewer tar files and sha256sum depend on
-    # the version and machine type.
-
-    def viewer_url(ver, mach):
-        return (
-            'http://hpctoolkit.org/download/hpcviewer/{0}/'
-            'hpcviewer-linux.gtk.{1}.tgz'
-        ).format(ver, mach)
-
-    def trace_url(ver, mach):
-        return (
-            'http://hpctoolkit.org/download/hpcviewer/{0}/'
-            'hpctraceviewer-linux.gtk.{1}.tgz'
-        ).format(ver, mach)
-
     viewer_sha = {
-        ('2019.02', 'x86_64')  : 'e24368a3ec27b82736a781971a8371abfe7744b2a4f68b7b41d76f84af306b83',
-        ('2019.02', 'ppc64')   : '72c1ef1a5682c3273e900bb248f126428a02dfe728af0c49c7ee8381938d1e18',
-        ('2019.02', 'ppc64le') : '02aaf27bb5b0f72d5b5738289bce60f6ef0ef7327ca96a890892509a09adc946',
+        ('2019.02', 'x86_64'):  'e24368a3ec27b82736a781971a8371abfe7744b2a4f68b7b41d76f84af306b83',
+        ('2019.02', 'ppc64'):   '72c1ef1a5682c3273e900bb248f126428a02dfe728af0c49c7ee8381938d1e18',
+        ('2019.02', 'ppc64le'): '02aaf27bb5b0f72d5b5738289bce60f6ef0ef7327ca96a890892509a09adc946',
     }
 
     trace_sha = {
-        ('2019.02', 'x86_64')  : '5ff11317a638318295821204ffcb1276e9da1684cd5f298410ae2bf78ce88b6b',
-        ('2019.02', 'ppc64')   : '95b2a7d848ecb924591c248f5e47c641646ef90a071db48237ddb96c4b71a8fb',
-        ('2019.02', 'ppc64le') : '01a159306e7810efe07157ec823ac6ca7570ec2014c95db599a3f90eee33355c',
+        ('2019.02', 'x86_64'):  '5ff11317a638318295821204ffcb1276e9da1684cd5f298410ae2bf78ce88b6b',
+        ('2019.02', 'ppc64'):   '95b2a7d848ecb924591c248f5e47c641646ef90a071db48237ddb96c4b71a8fb',
+        ('2019.02', 'ppc64le'): '01a159306e7810efe07157ec823ac6ca7570ec2014c95db599a3f90eee33355c',
     }
 
     for ver in ['2019.02']:

--- a/var/spack/repos/builtin/packages/hpcviewer/package.py
+++ b/var/spack/repos/builtin/packages/hpcviewer/package.py
@@ -56,7 +56,7 @@ class Hpcviewer(Package):
     # Both hpcviewer and trace viewer have an install script.
     def install(self, spec, prefix):
         args = [
-            '--java', spec['java'].prefix,
+            '--java', spec['java'].home,
             prefix
         ]
 

--- a/var/spack/repos/builtin/packages/hpcviewer/package.py
+++ b/var/spack/repos/builtin/packages/hpcviewer/package.py
@@ -24,15 +24,13 @@ def trace_url(ver, mach):
 
 
 class Hpcviewer(Package):
-    """Binary distribution of hpcviewer and hpctraceviewer for the
-    Rice HPCToolkit (Linux only).  Note: hpctoolkit databases are
-    platform independent, so you don't need to install hpctoolkit to
-    run the viewers and it's common to run hpcrun and hpcviewer on
-    different machines."""
+    """Binary distribution of hpcviewer and hpctraceviewer for the Rice
+    HPCToolkit (Linux x86_64, ppc64 and ppc64le).  Note: hpctoolkit
+    databases are platform independent, so you don't need to install
+    hpctoolkit to run the viewers and it's common to run hpcrun and
+    hpcviewer on different machines."""
 
     homepage = "http://hpctoolkit.org"
-
-    mach = platform.machine()
 
     viewer_sha = {
         ('2019.02', 'x86_64'):  'e24368a3ec27b82736a781971a8371abfe7744b2a4f68b7b41d76f84af306b83',
@@ -47,10 +45,12 @@ class Hpcviewer(Package):
     }
 
     for ver in ['2019.02']:
-        version(ver, url=viewer_url(ver, mach), sha256=viewer_sha[(ver, mach)])
+        key = (ver, platform.machine())
+        if key in viewer_sha and key in trace_sha:
+            version(ver, url=viewer_url(*key), sha256=viewer_sha[key])
 
-        resource(name='hpctraceviewer', url=trace_url(ver, mach),
-                 sha256=trace_sha[(ver, mach)], destination='TRACE')
+            resource(name='hpctraceviewer', url=trace_url(*key),
+                     sha256=trace_sha[key], destination='TRACE')
 
     depends_on('java@8', type=('build', 'run'))
 

--- a/var/spack/repos/builtin/packages/hpcviewer/package.py
+++ b/var/spack/repos/builtin/packages/hpcviewer/package.py
@@ -1,0 +1,69 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+import platform
+
+
+class Hpcviewer(Package):
+    """Binary distribution of hpcviewer and hpctraceviewer for the
+    Rice HPCToolkit (Linux only).  Note: hpctoolkit databases are
+    platform independent, so you don't need to install hpctoolkit to
+    run the viewers and it's common to run hpcrun and hpcviewer on
+    different machines."""
+
+    homepage = "http://hpctoolkit.org"
+
+    mach = platform.machine()
+
+    # The viewer and trace viewer tar files and sha256sum depend on
+    # the version and machine type.
+
+    def viewer_url(ver, mach):
+        return (
+            'http://hpctoolkit.org/download/hpcviewer/{0}/'
+            'hpcviewer-linux.gtk.{1}.tgz'
+        ).format(ver, mach)
+
+    def trace_url(ver, mach):
+        return (
+            'http://hpctoolkit.org/download/hpcviewer/{0}/'
+            'hpctraceviewer-linux.gtk.{1}.tgz'
+        ).format(ver, mach)
+
+    viewer_sha = {
+        ('2019.02', 'x86_64')  : 'e24368a3ec27b82736a781971a8371abfe7744b2a4f68b7b41d76f84af306b83',
+        ('2019.02', 'ppc64')   : '72c1ef1a5682c3273e900bb248f126428a02dfe728af0c49c7ee8381938d1e18',
+        ('2019.02', 'ppc64le') : '02aaf27bb5b0f72d5b5738289bce60f6ef0ef7327ca96a890892509a09adc946',
+    }
+
+    trace_sha = {
+        ('2019.02', 'x86_64')  : '5ff11317a638318295821204ffcb1276e9da1684cd5f298410ae2bf78ce88b6b',
+        ('2019.02', 'ppc64')   : '95b2a7d848ecb924591c248f5e47c641646ef90a071db48237ddb96c4b71a8fb',
+        ('2019.02', 'ppc64le') : '01a159306e7810efe07157ec823ac6ca7570ec2014c95db599a3f90eee33355c',
+    }
+
+    for ver in ['2019.02']:
+        version(ver, url=viewer_url(ver, mach), sha256=viewer_sha[(ver, mach)])
+
+        resource(name='hpctraceviewer', url=trace_url(ver, mach),
+                 sha256=trace_sha[(ver, mach)], destination='TRACE')
+
+    depends_on('java@8', type=('build', 'run'))
+
+    # Both hpcviewer and trace viewer have an install script.
+    def install(self, spec, prefix):
+        args = [
+            '--java', spec['java'].prefix,
+            prefix
+        ]
+
+        inst = Executable(join_path('.', 'install'))
+        inst(*args)
+
+        cd(join_path('TRACE', 'hpctraceviewer'))
+
+        inst = Executable(join_path('.', 'install'))
+        inst(*args)

--- a/var/spack/repos/builtin/packages/ibm-java/package.py
+++ b/var/spack/repos/builtin/packages/ibm-java/package.py
@@ -40,8 +40,22 @@ class IbmJava(Package):
 
         return url
 
+    @property
+    def home(self):
+        return self.prefix
+
+    @property
+    def libs(self):
+        return find_libraries(['libjvm'], root=self.home, recursive=True)
+
     def setup_environment(self, spack_env, run_env):
-        run_env.set('JAVA_HOME', self.prefix)
+        run_env.set('JAVA_HOME', self.home)
+
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        spack_env.set('JAVA_HOME', self.home)
+
+    def setup_dependent_package(self, module, dependent_spec):
+        self.spec.home = self.home
 
     def install(self, spec, prefix):
         archive = os.path.basename(self.stage.archive_file)


### PR DESCRIPTION
Add binary package for hpcviewer and hpctraceviewer for the Rice
hpctoolkit on Linux x86_64, ppc64 and ppc64le.

----------

I may be pushing the boundaries of flake with the long sha256 strings.
But folding them to the next line is ugly.  So, we'll see how the
judge rules.


Also, hpcviewer depends on java, but the tcl module that spack
created for hpcviewer doesn't depend on java.  I was expecting that
`module load hpcviewer` would also load jdk as a dependency, but it
didn't.

The module file sets `PATH` and `CMAKE_PREFIX_PATH` and prints a help
string.  Nothing else, no mention of java.

Did I miss something, or do tcl modules just not support dependencies?
