### PR TITLE
libxpm: cope with system gettext if configured.

### DIFF
--- a/var/spack/repos/builtin/packages/libxpm/package.py
+++ b/var/spack/repos/builtin/packages/libxpm/package.py
@@ -27,7 +27,9 @@ class Libxpm(AutotoolsPackage):
     depends_on('util-macros', type='build')
 
     def setup_environment(self, spack_env, run_env):
-        # In case we're using gettext from the system.
+        # If libxpm is installed as an external package, gettext won't
+        # be available in the spec. See
+        # https://github.com/spack/spack/issues/9149 for details.
         if 'gettext' in self.spec:
             spack_env.append_flags('LDFLAGS', '-L{0} -lintl'.format(
                 self.spec['gettext'].prefix.lib))

--- a/var/spack/repos/builtin/packages/libxpm/package.py
+++ b/var/spack/repos/builtin/packages/libxpm/package.py
@@ -27,5 +27,7 @@ class Libxpm(AutotoolsPackage):
     depends_on('util-macros', type='build')
 
     def setup_environment(self, spack_env, run_env):
-        spack_env.append_flags('LDFLAGS', '-L{0} -lintl'.format(
-            self.spec['gettext'].prefix.lib))
+        # In case we're using gettext from the system.
+        if 'gettext' in self.spec:
+            spack_env.append_flags('LDFLAGS', '-L{0} -lintl'.format(
+                self.spec['gettext'].prefix.lib))


### PR DESCRIPTION
If gettext is installed in the system it won't be in the spec tree.