### PR TITLE
mysql: Support client-only, cxxstd and more versions.

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -34,7 +34,7 @@ packages:
       mkl: [intel-mkl]
       mpe: [mpe2]
       mpi: [openmpi, mpich]
-      mysql-client: [mariadb-c-client]
+      mysql-client: [mysql, mariadb-c-client]
       opencl: [pocl]
       openfoam: [openfoam-com, openfoam-org, foam-extend]
       pil: [py-pillow]

--- a/var/spack/repos/builtin/packages/mysql/fix-no-server-5.5.patch
+++ b/var/spack/repos/builtin/packages/mysql/fix-no-server-5.5.patch
@@ -1,0 +1,33 @@
+diff -Naur mysql-5.5.62/CMakeLists.txt mysql-5.5.62-new/CMakeLists.txt
+--- mysql-5.5.62/CMakeLists.txt	2017-06-05 01:38:02.000000000 -0500
++++ mysql-5.5.62-new/CMakeLists.txt	2017-09-22 09:17:29.000000000 -0500
+@@ -450,6 +450,13 @@
+   ADD_SUBDIRECTORY(packaging/rpm-oel)
+   ADD_SUBDIRECTORY(packaging/rpm-sles)
+   ADD_SUBDIRECTORY(packaging/rpm-docker)
++ELSE()
++  ADD_SUBDIRECTORY(client)
++  ADD_SUBDIRECTORY(sql/share)
++  ADD_SUBDIRECTORY(scripts)
++  IF(UNIX)
++    ADD_SUBDIRECTORY(man)
++  ENDIF()
+ ENDIF()
+ 
+ INCLUDE(cmake/abi_check.cmake)
+diff -Naur mysql-5.5.62/client/mysql.cc mysql-5.5.62-new/client/mysql.cc
+--- mysql-5.5.62/unittest/mysys/CMakeLists.txt	2017-06-05 01:38:02.000000000 -0500
++++ mysql-5.5.62-new/unittest/mysys/CMakeLists.txt	2017-09-22 09:17:29.000000000 -0500
+@@ -31,6 +31,7 @@
+   MY_ADD_TEST(${testname})
+ ENDFOREACH()
+ 
++IF(NOT WITHOUT_SERVER)
+ IF(WIN32)
+   ADD_EXECUTABLE(explain_filename-t explain_filename-t.cc
+                                     ../../sql/nt_servc.cc)
+@@ -39,3 +40,4 @@
+ ENDIF()
+ TARGET_LINK_LIBRARIES(explain_filename-t sql mytap)
+ ADD_TEST(explain_filename explain_filename-t)
++ENDIF(NOT WITHOUT_SERVER)

--- a/var/spack/repos/builtin/packages/mysql/package.py
+++ b/var/spack/repos/builtin/packages/mysql/package.py
@@ -12,27 +12,106 @@ class Mysql(CMakePackage):
     url      = "https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-8.0.15.tar.gz"
 
     version('8.0.15', sha256='bb1bca2dc2f23ee9dd395cc4db93b64561d4ac20b53be5d1dae563f7be64825e')
+    version('8.0.14', sha256='bc53f4c914fb39650289700d144529121d71f38399d2d24a0f5c76e5a8abd204')
+    version('8.0.13', sha256='d85eb7f98b6aa3e2c6fe38263bf40b22acb444a4ce1f4668473e9e59fb98d62e')
+    version('8.0.12', sha256='69f16e20834dbc60cb28d6df7351deda323330b9de685d22415f135bcedd1b20')
     version('8.0.11', '38d5a5c1a1eeed1129fec3a999aa5efd')
+    version('5.7.25', sha256='53751c6243806103114567c1a8b6a3ec27f23c0e132f377a13ce1eb56c63723f')
+    version('5.7.24', sha256='05bf0c92c6a97cf85b67fff1ac83ca7b3467aea2bf306374d727fa4f18431f87')
+    version('5.7.23', sha256='0730f2d5520bfac359e9272da6c989d0006682eacfdc086a139886c0741f6c65')
     version('5.7.22', '269935a8b72dcba2c774d8d63a8bd1dd')
+    version('5.7.21', sha256='fa205079c27a39c24f3485e7498dd0906a6e0b379b4f99ebc0ec38a9ec5b09b7')
+    version('5.7.20', sha256='5397549bb7c238f396c123db2df4cad2191b11adf8986de7fe63bff8e2786487')
+    version('5.7.19', sha256='3e51e76f93179ca7b165a7008a6cc14d56195b3aef35d26d3ac194333d291eb1')
+    version('5.7.18', sha256='0b5d71ed608656cd8181d3bb0434d3e36bac192899038dbdddf5a7594aaea1a2')
+    version('5.7.17', sha256='cebf23e858aee11e354c57d30de7a079754bdc2ef85eb684782458332a4b9651')
+    version('5.7.16', sha256='4935b59974edb275629f6724a0fcf72265a5845faf1e30eeb50ed4b6528318a5')
+    version('5.7.15', sha256='9085353143bfda59c90aa959e79a35622a22aa592e710993416e193b37eb9956')
+    version('5.7.14', sha256='f7415bdac2ca8bbccd77d4f22d8a0bdd7280b065bd646a71a506b77c7a8bd169')
+    version('5.7.13', sha256='50bf1a1635a61235fc43fd4876df2f77163de109372679e29c1ff8dbc38a0b87')
+    version('5.7.12', sha256='32843cb6d22ab22cd2340262b53c0d6009b5bd41b1fa4102beda19635a5c1c87')
+    version('5.7.11', sha256='54f8c7af87d3d8084419bde2b9f0d8970b3dada0757b015981b02f35a3681f0e')
+    version('5.7.10', sha256='1ea1644884d086a23eafd8ccb04d517fbd43da3a6a06036f23c5c3a111e25c74')
+    version('5.7.9',  sha256='315342f5bee1179548cecad2d776cd7758092fd2854024e60a3a5007feba34e0')
+    version('5.6.43', sha256='1c95800bf0e1b7a19a37d37fbc5023af85c6bc0b41532433b3a886263a1673ef')
+    version('5.5.62', sha256='b1e7853bc1f04aabf6771e0ad947f35ac8d237f4b35d0706d1095c9526ff99d7')
+
+    variant('client_only', default=False,
+            description='Build and install client only.')
+    variant('cxxstd',
+            default='default',
+            values=('default', '98', '11', '14', '17'),
+            multi=False,
+            description='Use the specified C++ standard when building.')
+
+    conflicts('+client_only', when='@5.7.0:5.7.999')
+
+    provides('mysql-client')
 
     # https://dev.mysql.com/doc/refman/8.0/en/source-installation.html
 
     # See CMAKE_MINIMUM_REQUIRED in CMakeLists.txt
-    depends_on('cmake@3.8.0:', type='build', when='platform=win32')
-    depends_on('cmake@3.9.2:', type='build', when='platform=darwin')
-    depends_on('cmake@3.4.0:', type='build', when='platform=solaris')
-    depends_on('cmake@2.8.12:', type='build')
+    depends_on('cmake@3.1.0:', type='build', when='@5.7.0:5.7.999 platform=win32')
+    depends_on('cmake@3.8.0:', type='build', when='@8.0.0: platform=win32')
+    depends_on('cmake@3.9.2:', type='build', when='@8.0.0: platform=darwin')
+    depends_on('cmake@3.4.0:', type='build', when='@8.0.0: platform=solaris')
+    depends_on('cmake@2.6:', type='build', when='@:5.6.999')
+    depends_on('cmake@2.8.9:', type='build', when='@5.7.0:5.7.999')
+    depends_on('cmake@2.8.12:', type='build', when='@8.0.0:')
 
     depends_on('gmake@3.75:', type='build')
 
     # Each version of MySQL requires a specific version of boost
     # See BOOST_PACKAGE_NAME in cmake/boost.cmake
-    depends_on('boost@1.68.0', type='build', when='@8.0.15')
-    depends_on('boost@1.66.0', type='build', when='@8.0.11')
-    depends_on('boost@1.59.0', type='build', when='@5.7.22')
+    # 8.0.14+
+    depends_on('boost@1.68.0 cxxstd=default', type='build', when='@8.0.14: cxxstd=default')
+    depends_on('boost@1.68.0 cxxstd=98', type='build', when='@8.0.14: cxxstd=98')
+    depends_on('boost@1.68.0 cxxstd=11', type='build', when='@8.0.14: cxxstd=11')
+    depends_on('boost@1.68.0 cxxstd=14', type='build', when='@8.0.14: cxxstd=14')
+    depends_on('boost@1.68.0 cxxstd=17', type='build', when='@8.0.14: cxxstd=17')
+    # 8.0.12--8.0.13
+    depends_on('boost@1.67.0 cxxstd=default', type='build', when='@8.0.12:8.0.13 cxxstd=default')
+    depends_on('boost@1.67.0 cxxstd=98', type='build', when='@8.0.12:8.0.13 cxxstd=98')
+    depends_on('boost@1.67.0 cxxstd=11', type='build', when='@8.0.12:8.0.13 cxxstd=11')
+    depends_on('boost@1.67.0 cxxstd=14', type='build', when='@8.0.12:8.0.13 cxxstd=14')
+    depends_on('boost@1.67.0 cxxstd=17', type='build', when='@8.0.12:8.0.13 cxxstd=17')
+    # 8.0.11
+    depends_on('boost@1.66.0 cxxstd=default', type='build', when='@8.0.11 cxxstd=default')
+    depends_on('boost@1.66.0 cxxstd=98', type='build', when='@8.0.11 cxxstd=98')
+    depends_on('boost@1.66.0 cxxstd=11', type='build', when='@8.0.11 cxxstd=11')
+    depends_on('boost@1.66.0 cxxstd=14', type='build', when='@8.0.11 cxxstd=14')
+    depends_on('boost@1.66.0 cxxstd=17', type='build', when='@8.0.11 cxxstd=17')
+    # 5.7.X
+    depends_on('boost@1.59.0 cxxstd=default', type='build', when='@5.7.0:5.7.999 cxxstd=default')
+    depends_on('boost@1.59.0 cxxstd=98', type='build', when='@5.7.0:5.7.999 cxxstd=98')
+    depends_on('boost@1.59.0 cxxstd=11', type='build', when='@5.7.0:5.7.999 cxxstd=11')
+    depends_on('boost@1.59.0 cxxstd=14', type='build', when='@5.7.0:5.7.999 cxxstd=14')
+    depends_on('boost@1.59.0 cxxstd=17', type='build', when='@5.7.0:5.7.999 cxxstd=17')
 
     depends_on('ncurses')
     depends_on('openssl')
     depends_on('perl', type='test')
     depends_on('bison@2.1:', type='build', when='@develop')
     depends_on('m4', type='build', when='@develop platform=solaris')
+
+    patch('fix-no-server-5.5.patch', level=1, when='@5.5.0:5.5.999')
+
+    def url_for_version(self, version):
+        url = "https://dev.mysql.com/get/Downloads/MySQL-{0}/mysql-{1}.tar.gz"
+        return url.format(version.up_to(2), version)
+
+    def cmake_args(self):
+        spec = self.spec
+        options = []
+        if 'boost' in spec:
+            options.append('-DBOOST_ROOT={0}'.format(spec['boost'].prefix))
+        if '+client_only' in self.spec:
+            options.append('-DWITHOUT_SERVER:BOOL=ON')
+        return options
+
+    def setup_environment(self, spack_env, run_env):
+        cxxstd = self.spec.variants['cxxstd'].value
+        flag = '' if cxxstd == 'default' else \
+               getattr(self.compiler, 'cxx{0}_flag'.format(cxxstd))
+        if flag:
+            spack_env.append_flags('CXXFLAGS', flag)

--- a/var/spack/repos/builtin/packages/mysql/package.py
+++ b/var/spack/repos/builtin/packages/mysql/package.py
@@ -39,8 +39,8 @@ class Mysql(CMakePackage):
     variant('client_only', default=False,
             description='Build and install client only.')
     variant('cxxstd',
-            default='default',
-            values=('default', '98', '11', '14', '17'),
+            default='98',
+            values=('98', '11', '14', '17'),
             multi=False,
             description='Use the specified C++ standard when building.')
 
@@ -64,25 +64,21 @@ class Mysql(CMakePackage):
     # Each version of MySQL requires a specific version of boost
     # See BOOST_PACKAGE_NAME in cmake/boost.cmake
     # 8.0.14+
-    depends_on('boost@1.68.0 cxxstd=default', type='build', when='@8.0.14: cxxstd=default')
     depends_on('boost@1.68.0 cxxstd=98', type='build', when='@8.0.14: cxxstd=98')
     depends_on('boost@1.68.0 cxxstd=11', type='build', when='@8.0.14: cxxstd=11')
     depends_on('boost@1.68.0 cxxstd=14', type='build', when='@8.0.14: cxxstd=14')
     depends_on('boost@1.68.0 cxxstd=17', type='build', when='@8.0.14: cxxstd=17')
     # 8.0.12--8.0.13
-    depends_on('boost@1.67.0 cxxstd=default', type='build', when='@8.0.12:8.0.13 cxxstd=default')
     depends_on('boost@1.67.0 cxxstd=98', type='build', when='@8.0.12:8.0.13 cxxstd=98')
     depends_on('boost@1.67.0 cxxstd=11', type='build', when='@8.0.12:8.0.13 cxxstd=11')
     depends_on('boost@1.67.0 cxxstd=14', type='build', when='@8.0.12:8.0.13 cxxstd=14')
     depends_on('boost@1.67.0 cxxstd=17', type='build', when='@8.0.12:8.0.13 cxxstd=17')
     # 8.0.11
-    depends_on('boost@1.66.0 cxxstd=default', type='build', when='@8.0.11 cxxstd=default')
     depends_on('boost@1.66.0 cxxstd=98', type='build', when='@8.0.11 cxxstd=98')
     depends_on('boost@1.66.0 cxxstd=11', type='build', when='@8.0.11 cxxstd=11')
     depends_on('boost@1.66.0 cxxstd=14', type='build', when='@8.0.11 cxxstd=14')
     depends_on('boost@1.66.0 cxxstd=17', type='build', when='@8.0.11 cxxstd=17')
     # 5.7.X
-    depends_on('boost@1.59.0 cxxstd=default', type='build', when='@5.7.0:5.7.999 cxxstd=default')
     depends_on('boost@1.59.0 cxxstd=98', type='build', when='@5.7.0:5.7.999 cxxstd=98')
     depends_on('boost@1.59.0 cxxstd=11', type='build', when='@5.7.0:5.7.999 cxxstd=11')
     depends_on('boost@1.59.0 cxxstd=14', type='build', when='@5.7.0:5.7.999 cxxstd=14')
@@ -111,7 +107,6 @@ class Mysql(CMakePackage):
 
     def setup_environment(self, spack_env, run_env):
         cxxstd = self.spec.variants['cxxstd'].value
-        flag = '' if cxxstd == 'default' else \
-               getattr(self.compiler, 'cxx{0}_flag'.format(cxxstd))
+        flag = getattr(self.compiler, 'cxx{0}_flag'.format(cxxstd))
         if flag:
             spack_env.append_flags('CXXFLAGS', flag)


### PR DESCRIPTION
Support client-only builds where feasible.

Support many more versions.

Add cxxstd variant and handle combinatorics in Boost dependency.

Integrate with virtual package mysql-client provided by PR #7729.