### PR TITLE
Add variant to Conduit package

### DIFF
--- a/var/spack/repos/builtin/packages/conduit/package.py
+++ b/var/spack/repos/builtin/packages/conduit/package.py
@@ -61,7 +61,7 @@ class Conduit(Package):
     variant("mpi", default=True, description="Build Conduit MPI Support")
     variant("hdf5", default=True, description="Build Conduit HDF5 support")
     variant("hdf5_compat", default=True,
-            description="Build Conduit with HDF5 1.8.x support (compatibility mode)")
+            description="Build Conduit with HDF5 1.8.x (compatibility mode)")
     variant("silo", default=False, description="Build Conduit Silo support")
     variant("adios", default=False, description="Build Conduit ADIOS support")
 

--- a/var/spack/repos/builtin/packages/conduit/package.py
+++ b/var/spack/repos/builtin/packages/conduit/package.py
@@ -60,6 +60,8 @@ class Conduit(Package):
     # variants for comm and i/o
     variant("mpi", default=True, description="Build Conduit MPI Support")
     variant("hdf5", default=True, description="Build Conduit HDF5 support")
+    variant("hdf5_compat", default=True,
+            description="Build Conduit with HDF5 1.8.x support (compatibility mode)")
     variant("silo", default=False, description="Build Conduit Silo support")
     variant("adios", default=False, description="Build Conduit ADIOS support")
 
@@ -97,8 +99,10 @@ class Conduit(Package):
     #
     # Use HDF5 1.8, for wider output compatibly
     # variants reflect we are not using hdf5's mpi or fortran features.
-    depends_on("hdf5@1.8.19:1.8.999~cxx~mpi~fortran", when="+hdf5+shared")
-    depends_on("hdf5@1.8.19:1.8.999~shared~cxx~mpi~fortran", when="+hdf5~shared")
+    depends_on("hdf5@1.8.19:1.8.999~cxx~mpi~fortran", when="+hdf5+hdf5_compat+shared")
+    depends_on("hdf5@1.8.19:1.8.999~shared~cxx~mpi~fortran", when="+hdf5+hdf5_compat~shared")
+    depends_on("hdf5~cxx~mpi~fortran", when="+hdf5~hdf5_compat+shared")
+    depends_on("hdf5~shared~cxx~mpi~fortran", when="+hdf5~hdf5_compat~shared")
 
     # we are not using silo's fortran features
     depends_on("silo~fortran", when="+silo+shared")


### PR DESCRIPTION
Added a variant to allow conduit to build with newer versions of
HDF5.  Set the default for the variant to prefer compatibility mode
with HDF5 v1.8 per Cyrus Harrison's request.