### PR TITLE
Update GMSH to 4.2.2 with OpenMP variant

### DIFF
--- a/var/spack/repos/builtin/packages/gmsh/package.py
+++ b/var/spack/repos/builtin/packages/gmsh/package.py
@@ -19,7 +19,8 @@ class Gmsh(CMakePackage):
     homepage = 'http://gmsh.info'
     url = 'http://gmsh.info/src/gmsh-2.11.0-source.tgz'
 
-    version('4.0.0', sha256='fb0c8afa37425c6f4315ab3b3124e9e102fcf270a35198423a4002796f04155f')
+    version('4.2.2', sha256='e9ee9f5c606bbec5f2adbb8c3d6023c4e2577f487fa4e4ecfcfc94a241cc8dcc')
+    version('4.0.0',  'fb0c8afa37425c6f4315ab3b3124e9e102fcf270a35198423a4002796f04155f')
     version('3.0.6',  '9700bcc440d7a6b16a49cbfcdcdc31db33efe60e1f5113774316b6fa4186987b')
     version('3.0.1',  '830b5400d9f1aeca79c3745c5c9fdaa2900cdb2fa319b664a5d26f7e615c749f')
     version('2.16.0', 'e829eaf32ea02350a385202cc749341f2a3217c464719384b18f653edd028eea')
@@ -29,6 +30,7 @@ class Gmsh(CMakePackage):
 
     variant('shared',      default=True,  description='Enables the build of shared libraries')
     variant('mpi',         default=True,  description='Builds MPI support for parser and solver')
+    variant('openmp',      default=True,  description='Enable OpenMP support')
     variant('fltk',        default=False, description='Enables the build of the FLTK GUI')
     variant('hdf5',        default=False, description='Enables HDF5 support')
     variant('compression', default=True,  description='Enables IO compression through zlib')
@@ -37,6 +39,7 @@ class Gmsh(CMakePackage):
     variant('petsc',       default=False, description='Build with PETSc')
     variant('slepc',       default=False, description='Build with SLEPc (only when PETSc is enabled)')
     variant('tetgen',      default=False, description='Build with Tetgen')
+    variant('metis',       default=True,  description='Build with Metis')
 
     depends_on('blas')
     depends_on('lapack')
@@ -53,6 +56,7 @@ class Gmsh(CMakePackage):
     depends_on('slepc', when='+slepc+petsc')
     depends_on('tetgen', when='+tetgen')
     depends_on('zlib',  when='+compression')
+    depends_on('metis', when='+metis')
 
     conflicts('+slepc', when='~petsc')
 
@@ -76,8 +80,12 @@ class Gmsh(CMakePackage):
             '-DBLAS_LAPACK_LIBRARIES={0}'.format(blas_lapack.ld_flags))
 
         # Gmsh does not have an option to compile against external metis.
-        # Its own Metis, however, fails to build
-        options.append('-DENABLE_METIS=OFF')
+        # Its own Metis, however, fails to build.
+        # However, Metis is needed for the Hxt library.
+        if '+metis' in spec:
+            options.append('-DENABLE_METIS=ON')
+        else:
+            options.append('-DENABLE_METIS=OFF')
 
         if '+fltk' in spec:
             options.append('-DENABLE_FLTK=ON')
@@ -121,6 +129,11 @@ class Gmsh(CMakePackage):
         else:
             # Builds and installs static library
             options.append('-DENABLE_BUILD_LIB:BOOL=ON')
+
+        if '+openmp' in spec:
+            options.append('-DENABLE_OPENMP=ON')
+        else:
+            options.append('-DENABLE_OPENMP=OFF')
 
         if '+mpi' in spec:
             options.append('-DENABLE_MPI:BOOL=ON')

--- a/var/spack/repos/builtin/packages/gmsh/package.py
+++ b/var/spack/repos/builtin/packages/gmsh/package.py
@@ -39,7 +39,7 @@ class Gmsh(CMakePackage):
     variant('petsc',       default=False, description='Build with PETSc')
     variant('slepc',       default=False, description='Build with SLEPc (only when PETSc is enabled)')
     variant('tetgen',      default=False, description='Build with Tetgen')
-    variant('metis',       default=True,  description='Build with Metis')
+    variant('metis',       default=False,  description='Build with Metis')
 
     depends_on('blas')
     depends_on('lapack')

--- a/var/spack/repos/builtin/packages/gmsh/package.py
+++ b/var/spack/repos/builtin/packages/gmsh/package.py
@@ -30,7 +30,7 @@ class Gmsh(CMakePackage):
 
     variant('shared',      default=True,  description='Enables the build of shared libraries')
     variant('mpi',         default=True,  description='Builds MPI support for parser and solver')
-    variant('openmp',      default=True,  description='Enable OpenMP support')
+    variant('openmp',      default=False,  description='Enable OpenMP support')
     variant('fltk',        default=False, description='Enables the build of the FLTK GUI')
     variant('hdf5',        default=False, description='Enables HDF5 support')
     variant('compression', default=True,  description='Enables IO compression through zlib')


### PR DESCRIPTION
This updates gmsh to its latest version.
I also added a variant to enable OpenMP support.
Metis seems to build fine and is required for compiling the Hxt internal lib, so the choice is left to the user.