### PR TITLE
add newer versions of ninja-fortran

### DIFF
--- a/var/spack/repos/builtin/packages/ninja-fortran/package.py
+++ b/var/spack/repos/builtin/packages/ninja-fortran/package.py
@@ -29,7 +29,7 @@ class NinjaFortran(Package):
     phases = ['configure', 'install']
 
     def url_for_version(self, version):
-        old_url_versions = ['1.7.1.g7ca7f', '1.7.2.gcc0ea', \
+        old_url_versions = ['1.7.1.g7ca7f', '1.7.2.gcc0ea',
                             '1.7.2.gaad58', '1.8.2.g972a7']
         if version.string in old_url_versions:
             url = 'https://github.com/Kitware/ninja/archive/v{0}.kitware.dyndep-1.tar.gz'

--- a/var/spack/repos/builtin/packages/ninja-fortran/package.py
+++ b/var/spack/repos/builtin/packages/ninja-fortran/package.py
@@ -20,13 +20,20 @@ class NinjaFortran(Package):
     version('1.8.2.g81279', '0e29d0c441dcbd9b9ee9291c3a8dfbdd')
     version('1.8.2.g3bbbe', 'de6257118f2e3ac7fa1abca1e7c70afa')
     version('1.8.2.g972a7', '8ace90ad0c5657022d10ba063783a652')
+    version('1.7.2.gaad58', 'eb51b042b9dbaf8ecd79a6fb24de1320')
+    version('1.7.2.gcc0ea', '3982f508c415c0abaca34cb5e92e711a')
+    version('1.7.1.g7ca7f', '187a8d15c1e20e5e9b00c5c3f227ca8a')
 
     depends_on('python', type=('build', 'run'))
 
     phases = ['configure', 'install']
 
     def url_for_version(self, version):
-        url = 'https://github.com/Kitware/ninja/archive/v{0}.kitware.dyndep-1.jobserver-1.tar.gz'
+        old_url_versions = ['1.7.1.g7ca7f', '1.7.2.gcc0ea', '1.7.2.gaad58', '1.8.2.g972a7']
+        if version.string in old_url_versions:
+            url = 'https://github.com/Kitware/ninja/archive/v{0}.kitware.dyndep-1.tar.gz'
+        else:
+            url = 'https://github.com/Kitware/ninja/archive/v{0}.kitware.dyndep-1.jobserver-1.tar.gz'
         return url.format(version)
 
     def configure(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/ninja-fortran/package.py
+++ b/var/spack/repos/builtin/packages/ninja-fortran/package.py
@@ -14,28 +14,38 @@ class NinjaFortran(Package):
 
     # Each version is a fork off of a specific commit of ninja
     # Hashes don't sort properly, so manually set newest version
-    version('1.9.0.g99df1', 'f0892b1c8fd2984e8f47e9e1fcb9ce32', preferred=True)
-    version('1.9.0.g5b44b', 'f7c2e718801c1fd097a728530559e0d4')
-    version('1.9.0.gad558', 'cb93ffb5871225e2b813eb9c34b3096d')
-    version('1.8.2.g81279', '0e29d0c441dcbd9b9ee9291c3a8dfbdd')
-    version('1.8.2.g3bbbe', 'de6257118f2e3ac7fa1abca1e7c70afa')
-    version('1.8.2.g972a7', '8ace90ad0c5657022d10ba063783a652')
-    version('1.7.2.gaad58', 'eb51b042b9dbaf8ecd79a6fb24de1320')
-    version('1.7.2.gcc0ea', '3982f508c415c0abaca34cb5e92e711a')
-    version('1.7.1.g7ca7f', '187a8d15c1e20e5e9b00c5c3f227ca8a')
+    # Also added "artificial" tweak-level version number prior to
+    # the hashes for sorting puposes
+    version('1.9.0.2.g99df1', 'f0892b1c8fd2984e8f47e9e1fcb9ce32', preferred=True)
+    version('1.9.0.1.g5b44b', 'f7c2e718801c1fd097a728530559e0d4')
+    version('1.9.0.0.gad558', 'cb93ffb5871225e2b813eb9c34b3096d')
+    version('1.8.2.2.g81279', '0e29d0c441dcbd9b9ee9291c3a8dfbdd')
+    version('1.8.2.1.g3bbbe', 'de6257118f2e3ac7fa1abca1e7c70afa')
+    version('1.8.2.0.g972a7', '8ace90ad0c5657022d10ba063783a652')
+    version('1.7.2.0.gaad58', 'eb51b042b9dbaf8ecd79a6fb24de1320')
+    version('1.7.2.0.gcc0ea', '3982f508c415c0abaca34cb5e92e711a')
+    version('1.7.1.0.g7ca7f', '187a8d15c1e20e5e9b00c5c3f227ca8a')
 
     depends_on('python', type=('build', 'run'))
 
     phases = ['configure', 'install']
 
     def url_for_version(self, version):
-        old_url_versions = ['1.7.1.g7ca7f', '1.7.2.gcc0ea',
-                            '1.7.2.gaad58', '1.8.2.g972a7']
-        if version.string in old_url_versions:
+        # for some reason the hashes are being stripped from incomming
+        # version, so find the incomming version in all package versions
+        for ver in self.versions:
+            if str(version) in str(ver):
+                break
+
+        # remove the "artificial" tweak-level
+        split_ver = str(ver).split('.')
+        url_version = ".".join(split_ver[:3]) + "." + split_ver[4]
+
+        if version < spack.version.Version('1.8.2.1'):
             url = 'https://github.com/Kitware/ninja/archive/v{0}.kitware.dyndep-1.tar.gz'
         else:
             url = 'https://github.com/Kitware/ninja/archive/v{0}.kitware.dyndep-1.jobserver-1.tar.gz'
-        return url.format(version)
+        return url.format(url_version)
 
     def configure(self, spec, prefix):
         python('configure.py', '--bootstrap')

--- a/var/spack/repos/builtin/packages/ninja-fortran/package.py
+++ b/var/spack/repos/builtin/packages/ninja-fortran/package.py
@@ -13,16 +13,15 @@ class NinjaFortran(Package):
     url      = "https://github.com/Kitware/ninja/archive/v1.9.0.g99df1.kitware.dyndep-1.jobserver-1.tar.gz"
 
     # Each version is a fork off of a specific commit of ninja
-    # Hashes don't sort properly, so manually set newest version
-    # Also added "artificial" tweak-level version number prior to
-    # the hashes for sorting puposes
-    version('1.9.0.2.g99df1', 'f0892b1c8fd2984e8f47e9e1fcb9ce32', preferred=True)
+    # Hashes don't sort properly, so added "artificial" tweak-level version
+    # number prior to the hashes for sorting puposes
+    version('1.9.0.2.g99df1', 'f0892b1c8fd2984e8f47e9e1fcb9ce32')
     version('1.9.0.1.g5b44b', 'f7c2e718801c1fd097a728530559e0d4')
     version('1.9.0.0.gad558', 'cb93ffb5871225e2b813eb9c34b3096d')
     version('1.8.2.2.g81279', '0e29d0c441dcbd9b9ee9291c3a8dfbdd')
     version('1.8.2.1.g3bbbe', 'de6257118f2e3ac7fa1abca1e7c70afa')
     version('1.8.2.0.g972a7', '8ace90ad0c5657022d10ba063783a652')
-    version('1.7.2.0.gaad58', 'eb51b042b9dbaf8ecd79a6fb24de1320')
+    version('1.7.2.1.gaad58', 'eb51b042b9dbaf8ecd79a6fb24de1320')
     version('1.7.2.0.gcc0ea', '3982f508c415c0abaca34cb5e92e711a')
     version('1.7.1.0.g7ca7f', '187a8d15c1e20e5e9b00c5c3f227ca8a')
 

--- a/var/spack/repos/builtin/packages/ninja-fortran/package.py
+++ b/var/spack/repos/builtin/packages/ninja-fortran/package.py
@@ -29,7 +29,8 @@ class NinjaFortran(Package):
     phases = ['configure', 'install']
 
     def url_for_version(self, version):
-        old_url_versions = ['1.7.1.g7ca7f', '1.7.2.gcc0ea', '1.7.2.gaad58', '1.8.2.g972a7']
+        old_url_versions = ['1.7.1.g7ca7f', '1.7.2.gcc0ea', \
+                            '1.7.2.gaad58', '1.8.2.g972a7']
         if version.string in old_url_versions:
             url = 'https://github.com/Kitware/ninja/archive/v{0}.kitware.dyndep-1.tar.gz'
         else:

--- a/var/spack/repos/builtin/packages/ninja-fortran/package.py
+++ b/var/spack/repos/builtin/packages/ninja-fortran/package.py
@@ -10,20 +10,23 @@ class NinjaFortran(Package):
     """A Fortran capable fork of ninja."""
 
     homepage = "https://github.com/Kitware/ninja"
-    url      = "https://github.com/Kitware/ninja/archive/v1.7.2.gaad58.kitware.dyndep-1.tar.gz"
+    url      = "https://github.com/Kitware/ninja/archive/v1.9.0.g99df1.kitware.dyndep-1.jobserver-1.tar.gz"
 
     # Each version is a fork off of a specific commit of ninja
     # Hashes don't sort properly, so manually set newest version
-    version('1.7.2.gaad58', 'eb51b042b9dbaf8ecd79a6fb24de1320', preferred=True)
-    version('1.7.2.gcc0ea', '3982f508c415c0abaca34cb5e92e711a')
-    version('1.7.1.g7ca7f', '187a8d15c1e20e5e9b00c5c3f227ca8a')
+    version('1.9.0.g99df1', 'f0892b1c8fd2984e8f47e9e1fcb9ce32', preferred=True)
+    version('1.9.0.g5b44b', 'f7c2e718801c1fd097a728530559e0d4')
+    version('1.9.0.gad558', 'cb93ffb5871225e2b813eb9c34b3096d')
+    version('1.8.2.g81279', '0e29d0c441dcbd9b9ee9291c3a8dfbdd')
+    version('1.8.2.g3bbbe', 'de6257118f2e3ac7fa1abca1e7c70afa')
+    version('1.8.2.g972a7', '8ace90ad0c5657022d10ba063783a652')
 
     depends_on('python', type=('build', 'run'))
 
     phases = ['configure', 'install']
 
     def url_for_version(self, version):
-        url = 'https://github.com/Kitware/ninja/archive/v{0}.kitware.dyndep-1.tar.gz'
+        url = 'https://github.com/Kitware/ninja/archive/v{0}.kitware.dyndep-1.jobserver-1.tar.gz'
         return url.format(version)
 
     def configure(self, spec, prefix):


### PR DESCRIPTION
Adding newer versions updates the base url and invalidates the previous
versions' urls