### PR TITLE
Use 'shlex' to split Executable arguments

### DIFF
--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -5,6 +5,7 @@
 
 import os
 import re
+import shlex
 import subprocess
 from six import string_types, text_type
 
@@ -19,7 +20,7 @@ class Executable(object):
     """Class representing a program that can be run on the command line."""
 
     def __init__(self, name):
-        self.exe = name.split(' ')
+        self.exe = shlex.split(name)
         self.default_env = {}
         self.returncode = None
 


### PR DESCRIPTION
This allows shell commands for `spack edit` to be executed correctly if
they have quoted arguments. Example:
```sh
mvim -f -c "au VimLeave \* !open -a iTerm"
```
would fail because the quoted argument is being incorrectly split:
```
VIM - Vi IMproved 8.1 (2018 May 17, compiled Jun 13 2018 14:30:39)
Unknown option argument: "-a"
More info with: "vim -h"
==> Error: Command exited with status 1:
'mvim' '-f' '-c' '"au' 'VimLeave' '\*' '!open' '-a' 'iTerm"' '/rnsdhpc/code/spack/var/spack/repos/builtin/packages/qt/package.py'
```