### PR TITLE
bowtie2: new release checksum

### DIFF
--- a/var/spack/repos/builtin/packages/bowtie2/package.py
+++ b/var/spack/repos/builtin/packages/bowtie2/package.py
@@ -14,6 +14,7 @@ class Bowtie2(Package):
     homepage = "bowtie-bio.sourceforge.net/bowtie2/index.shtml"
     url      = "http://downloads.sourceforge.net/project/bowtie-bio/bowtie2/2.3.1/bowtie2-2.3.1-source.zip"
 
+    version('2.3.5', sha256='2b6b2c46fbb5565ba6206b47d07ece8754b295714522149d92acebefef08347b')
     version('2.3.4.1', '8371bbb6eb02ae99c5cf633054265cb9')
     version('2.3.1', 'b4efa22612e98e0c23de3d2c9f2f2478')
     version('2.3.0', '3ab33f30f00f3c30fec1355b4e569ea2')


### PR DESCRIPTION
`spack install` tested on CentOS 7 with gcc 8.2.0