### PR TITLE
gromacs: make sure cuda support is disabled when cuda=False

### DIFF
--- a/var/spack/repos/builtin/packages/abinit/package.py
+++ b/var/spack/repos/builtin/packages/abinit/package.py
@@ -144,7 +144,7 @@ class Abinit(AutotoolsPackage):
             hdf5 = spec['hdf5:hl']
             netcdff = spec['netcdf-fortran:shared']
             options.extend([
-                '--with-netcdf-incs=-I{0}'.format(netcdff.prefix.include),
+                '--with-netcdf-incs={0}'.format(netcdff.headers.cpp_flags),
                 '--with-netcdf-libs={0}'.format(
                     netcdff.libs.ld_flags + ' ' + hdf5.libs.ld_flags
                 ),

--- a/var/spack/repos/builtin/packages/abinit/package.py
+++ b/var/spack/repos/builtin/packages/abinit/package.py
@@ -144,7 +144,7 @@ class Abinit(AutotoolsPackage):
             hdf5 = spec['hdf5:hl']
             netcdff = spec['netcdf-fortran:shared']
             options.extend([
-                '--with-netcdf-incs={0}'.format(netcdff.headers.cpp_flags),
+                '--with-netcdf-incs=-I{0}'.format(netcdff.prefix.include),
                 '--with-netcdf-libs={0}'.format(
                     netcdff.libs.ld_flags + ' ' + hdf5.libs.ld_flags
                 ),

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -87,6 +87,8 @@ class Gromacs(CMakePackage):
             options.append('-DGMX_GPU:BOOL=ON')
             options.append('-DCUDA_TOOLKIT_ROOT_DIR:STRING=' +
                            self.spec['cuda'].prefix)
+        else:
+            options.append('-DGMX_GPU:BOOL=OFF')
 
         simd_value = self.spec.variants['simd'].value
         if simd_value == 'auto':


### PR DESCRIPTION
If for some reason there's a cuda toolkit installed by other means,
(i.e. not by spack) cmake will still try to build with cuda support,
even though 'cuda=False' is the default of the spec.