### PR TITLE
abinit: Fix building with hdf5/netcdf.

### DIFF
--- a/var/spack/repos/builtin/packages/abinit/package.py
+++ b/var/spack/repos/builtin/packages/abinit/package.py
@@ -144,7 +144,7 @@ class Abinit(AutotoolsPackage):
             hdf5 = spec['hdf5:hl']
             netcdff = spec['netcdf-fortran:shared']
             options.extend([
-                '--with-netcdf-incs={0}'.format(netcdff.headers.cpp_flags),
+                '--with-netcdf-incs=-I{0}'.format(netcdff.prefix.include),
                 '--with-netcdf-libs={0}'.format(
                     netcdff.libs.ld_flags + ' ' + hdf5.libs.ld_flags
                 ),


### PR DESCRIPTION
When installing with `+hdf5` the error below happens.
This commit fixes the case.

```
==> Installing abinit
==> Fetching https://www.abinit.org/sites/default/files/packages/abinit-8.6.3.tar.gz
######################################################################## 100,0%
==> Staging archive: /opt/spack/var/spack/stage/abinit-8.6.3-tboqvkkotgm4povtnxbp2ljdkicql7pe/abinit-8.6.3.tar.gz
==> Created stage in /opt/spack/var/spack/stage/abinit-8.6.3-tboqvkkotgm4povtnxbp2ljdkicql7pe
==> No patches needed for abinit
==> Building abinit [AutotoolsPackage]
==> Executing phase: 'autoreconf'
==> Executing phase: 'configure'
==> Error: RuntimeError: Unable to locate netcdf-fortran headers in /opt/spack/opt/spack/linux-centos7-x86_64/gcc-7.3.0/netcdf-fortran-4.4.4-4wuiozygj7prfmh734zx52affutetwdx/include
RuntimeError: RuntimeError: Unable to locate netcdf-fortran headers in /opt/spack/opt/spack/linux-centos7-x86_64/gcc-7.3.0/netcdf-fortran-4.4.4-4wuiozygj7prfmh734zx52affutetwdx/include

/opt/spack/var/spack/repos/builtin/packages/abinit/package.py:165, in configure_args:
     55                hdf5 = spec['hdf5:hl']
     56                netcdff = spec['netcdf-fortran:shared']  
     57                options.extend([
  >> 58                    '--with-netcdf-incs={0'.format(netcdff.headers.cpp_flags),}
     59                    '--with-netcdf-libs={0}'.format(
     60                        netcdff.libs.ld_flags + ' ' + hdf5.libs.ld_flags
     61                    ),
```