### PR TITLE
prevent UnboundLocalError when sourcing files

### DIFF
--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -542,6 +542,7 @@ class EnvironmentModifications(object):
                     search = sep.join(after_list[start:end + 1])
                 except IndexError:
                     env.prepend_path(x, after)
+                    continue
 
                 if search not in before:
                     # We just need to set the variable to the new value


### PR DESCRIPTION
Patch extracted from #7536 courtesy of @mgsternberg

CC: @alalazo 

This was preventing an Intel 2019 battle (lmod), but the `continue` statement fixed my issues :slightly_smiling_face:

I can't tell what the status of the other PR is, but I think it would be a good idea to get this in since it seems to affect all module systems (?)