### PR TITLE
Add container sub-command to generate container spec files

### DIFF
--- a/lib/spack/spack/cmd/container.py
+++ b/lib/spack/spack/cmd/container.py
@@ -9,9 +9,12 @@ import argparse
 
 import llnl.util.tty as tty
 
-import hpccm
-from hpccm.building_blocks.base import bb_base
-from hpccm.primitives import baseimage, comment, copy, environment, shell
+try:
+    import hpccm
+    from hpccm.building_blocks.base import bb_base
+    from hpccm.primitives import baseimage, comment, copy, environment, shell
+except ImportError:
+    tty.die("spack container requires HPCCM")
 
 import spack
 import spack.cmd

--- a/lib/spack/spack/cmd/container.py
+++ b/lib/spack/spack/cmd/container.py
@@ -19,8 +19,6 @@ except ImportError:
     # inside the container() function and error there.
     pass
 
-import spack
-
 description = "generate a container specification file"
 section = "build"
 level = "short"

--- a/lib/spack/spack/cmd/container.py
+++ b/lib/spack/spack/cmd/container.py
@@ -21,7 +21,6 @@ except ImportError:
 
 import spack
 import spack.cmd
-import spack.spec
 
 description = "generate a container specification file"
 section = "build"

--- a/lib/spack/spack/cmd/container.py
+++ b/lib/spack/spack/cmd/container.py
@@ -20,7 +20,6 @@ except ImportError:
     pass
 
 import spack
-import spack.cmd
 
 description = "generate a container specification file"
 section = "build"

--- a/lib/spack/spack/cmd/container.py
+++ b/lib/spack/spack/cmd/container.py
@@ -1,0 +1,145 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from __future__ import print_function
+
+import argparse
+import sys
+
+import llnl.util.tty as tty
+
+import hpccm
+from hpccm.building_blocks.base import bb_base
+from hpccm.primitives import baseimage, comment, copy, environment, shell
+
+import spack
+import spack.cmd
+import spack.cmd.common.arguments as arguments
+import spack.spec
+
+description = "generate a container specification file"
+section = "build"
+level = "short"
+
+def setup_parser(subparser):
+    subparser.add_argument(
+        'specs', nargs=argparse.REMAINDER, help="specs of packages")
+
+    subparser.add_argument(
+        '--baseimage', action='store', type=str, default='centos:7',
+        help='container base image (default: centos:7)')
+    subparser.add_argument(
+        '--depth', action='store', type=int, default=2,
+        help='spack DAG depth to use (default: 2)')
+    subparser.add_argument(
+        '--distro', action='store', type=str, default='',
+        choices=['centos', 'rhel', 'ubuntu', 'ubuntu16', 'ubuntu18'],
+        help='Linux distribution type of the base image (default: try to determine automatically from the base image name)')
+    subparser.add_argument(
+        '--format', action='store', type=str, default='docker',
+        choices=['docker', 'singularity'],
+        help='container specification format (default: docker)')
+    subparser.add_argument(
+        '--multi-stage', action='store_true', default=False,
+        help='generate a multi-stage Dockerfile (Docker specific)')
+    subparser.add_argument(
+        '--no-checksum', action='store_true', default=False,
+        help='do not use checksums to verify downloaded files (unsafe)')
+    subparser.add_argument(
+        '--show-log-on-error', action='store_true', default=False,
+        help='print full build log if build fails')
+    subparser.add_argument(
+        '--spack-branch', '--branch', action='store', type=str,
+        default='master',
+        help='branch of Spack to deploy (default: master)')
+
+def container(parser, args):
+    if not args.specs:
+        tty.die("spack spec requires at least one spec")
+
+    recipe = hpccm.Stage()
+
+    recipe += baseimage(image=args.baseimage, _distro=args.distro)
+
+    # OS dependencies
+    recipe += hpccm.building_blocks.packages(
+        apt=['autoconf', 'build-essential', 'bzip2', 'ca-certificates',
+             'coreutils', 'cpio', 'curl', 'environment-modules', 'git',
+             'gzip', 'libssl-dev', 'make', 'openssh-client', 'patch',
+             'pkg-config', 'svn', 'tar', 'tcl', 'unzip', 'zlib1g'],
+        yum=['autoconf', 'bzip2', 'ca-certificates', 'coreutils', 'cpio',
+             'curl', 'environment-modules', 'git', 'gzip', 'make',
+             'openssh-clients', 'openssl-devel', 'patch', 'pkg-config',
+             'svn', 'tar', 'tcl', 'unzip', 'zlib-devel'])
+
+    # GNU compilers
+    recipe += hpccm.building_blocks.gnu()
+
+    # Spack itself
+    spack_bb = bb_base()
+    spack_bb += comment('Spack')
+    spack_bb += shell(commands=[
+        'mkdir -p /opt && cd /opt',
+        'git clone --depth=1 --branch {} https://github.com/spack/spack'.format(args.spack_branch),
+        '/opt/spack/bin/spack bootstrap',
+        'ln -s /opt/spack/share/spack/setup-env.sh /etc/profile.d/spack.sh',
+        'ln -s /opt/spack/share/spack/spack-completion.bash /etc/profile.d'])
+    spack_bb += environment(variables={'PATH': '/opt/spack/bin:$PATH',
+                                       'FORCE_UNSAFE_CONFIGURE': '1'})
+    recipe += spack_bb
+
+    # spack install command line arguments
+    install_args = ['-y']
+    if args.no_checksum:
+        install_args.append('--no-checksum')
+    if args.show_log_on_error:
+        install_args.append('--show-log-on-error')
+    install_args_str = ' '.join(install_args)
+
+    # Process each spec
+    for spec in spack.cmd.parse_specs(args.specs):
+        spec.concretize()
+
+        bb = bb_base()
+        bb += comment('{0} {1}'.format(spec.name, spec.version))
+
+        # Process each dependency.  Use a selectable depth to balance
+        # the build cache vs. container spec file complexity
+        for depth, dspec in spec.traverse_edges(order='post', depth=True):
+            if depth <= args.depth:
+                node = dspec.spec
+                cmd = 'spack install {0} {1}@{2}'.format(install_args_str,
+                                                         node.name,
+                                                         node.version)
+                bb += shell(chdir=False, commands=[cmd, 'spack clean --all'])
+
+        recipe += bb
+
+    hpccm.config.set_container_format(args.format)
+    print(recipe)
+
+    # Really basic implementation of a multi-stage container
+    # specification.  Assume the same base image should be used and
+    # just copy /opt/spack.  If more advanced runtime capabilities
+    # become available, this should become more selective in what
+    # files are copied for a much bigger reduction in container size
+    # (e.g., build vs. link dependencies).  Multi-stage containers are
+    # Docker specific.
+    if args.multi_stage and args.format == 'docker':
+        runtime = hpccm.Stage()
+        runtime += baseimage(image=args.baseimage, _distro=args.distro)
+        runtime += recipe.runtime()
+
+        spack_rt = bb_base()
+        spack_rt += comment('Spack')
+        spack_rt += copy(_from='0', src='/opt/spack', dest='/opt/spack')
+        spack_rt += shell(commands=[
+        'ln -s /opt/spack/share/spack/setup-env.sh /etc/profile.d/spack.sh',
+        'ln -s /opt/spack/share/spack/spack-completion.bash /etc/profile.d'])
+        spack_rt += environment(variables={'PATH': '/opt/spack/bin:$PATH'})
+        runtime += spack_rt
+
+        # Prepend newline to clearly separate stages
+        print('\n' + str(runtime))

--- a/lib/spack/spack/cmd/container.py
+++ b/lib/spack/spack/cmd/container.py
@@ -6,7 +6,6 @@
 from __future__ import print_function
 
 import argparse
-import sys
 
 import llnl.util.tty as tty
 
@@ -16,12 +15,12 @@ from hpccm.primitives import baseimage, comment, copy, environment, shell
 
 import spack
 import spack.cmd
-import spack.cmd.common.arguments as arguments
 import spack.spec
 
 description = "generate a container specification file"
 section = "build"
 level = "short"
+
 
 def setup_parser(subparser):
     subparser.add_argument(
@@ -36,7 +35,8 @@ def setup_parser(subparser):
     subparser.add_argument(
         '--distro', action='store', type=str, default='',
         choices=['centos', 'rhel', 'ubuntu', 'ubuntu16', 'ubuntu18'],
-        help='Linux distribution type of the base image (default: try to determine automatically from the base image name)')
+        help='Linux distribution type of the base image '
+        '(default: try to determine automatically from the base image name)')
     subparser.add_argument(
         '--format', action='store', type=str, default='docker',
         choices=['docker', 'singularity'],
@@ -54,6 +54,7 @@ def setup_parser(subparser):
         '--spack-branch', '--branch', action='store', type=str,
         default='master',
         help='branch of Spack to deploy (default: master)')
+
 
 def container(parser, args):
     if not args.specs:
@@ -136,8 +137,8 @@ def container(parser, args):
         spack_rt += comment('Spack')
         spack_rt += copy(_from='0', src='/opt/spack', dest='/opt/spack')
         spack_rt += shell(commands=[
-        'ln -s /opt/spack/share/spack/setup-env.sh /etc/profile.d/spack.sh',
-        'ln -s /opt/spack/share/spack/spack-completion.bash /etc/profile.d'])
+            'ln -s /opt/spack/share/spack/setup-env.sh /etc/profile.d/spack.sh',
+            'ln -s /opt/spack/share/spack/spack-completion.bash /etc/profile.d'])
         spack_rt += environment(variables={'PATH': '/opt/spack/bin:$PATH'})
         runtime += spack_rt
 

--- a/lib/spack/spack/cmd/container.py
+++ b/lib/spack/spack/cmd/container.py
@@ -73,7 +73,8 @@ def container(parser, args):
     try:
         recipe = hpccm.Stage()
     except NameError:
-        tty.die('The HPCCM Python module must be installed to use spack container')
+        tty.die('The HPCCM Python module must be installed to use '
+                'spack container')
 
     recipe += baseimage(image=args.baseimage, _distro=args.distro)
 

--- a/lib/spack/spack/cmd/container.py
+++ b/lib/spack/spack/cmd/container.py
@@ -137,8 +137,10 @@ def container(parser, args):
         spack_rt += comment('Spack')
         spack_rt += copy(_from='0', src='/opt/spack', dest='/opt/spack')
         spack_rt += shell(commands=[
-            'ln -s /opt/spack/share/spack/setup-env.sh /etc/profile.d/spack.sh',
-            'ln -s /opt/spack/share/spack/spack-completion.bash /etc/profile.d'])
+            'ln -s /opt/spack/share/spack/setup-env.sh'
+            ' /etc/profile.d/spack.sh',
+            'ln -s /opt/spack/share/spack/spack-completion.bash'
+            ' /etc/profile.d'])
         spack_rt += environment(variables={'PATH': '/opt/spack/bin:$PATH'})
         runtime += spack_rt
 


### PR DESCRIPTION
This PR adds a new subcommand, `container`, to generate container specification files.

I am sure this PR is incomplete.  The objective is primarily to start a discussion about the usefulness of adding a container spec generation feature and the proposed implementation.

It uses HPC Container Maker (https://github.com/NVIDIA/hpc-container-maker) to generate either Dockerfiles or Singularity definition files based on the user selection.  HPCCM must be installed to use this capability (`pip install hpccm`).  

Examples:
```
$ spack container --help
$ spack container gromacs
$ spack container --baseimage ubuntu:16.04 gromacs
$ spack container --format singularity gromacs
```

The container unwinds the DAG to build the dependencies in separate steps.  The reason for this is twofold.  

1. The individual layers can be cached and re-used.  Consider building containers for both `gromacs@2019` and `gromacs@2018.2`.  Thanks to the container build cache, the second build will go much faster since only the final gromacs build step differs.

2. If a layer fails (e.g., a download times out), then the build can be restarted from the last cached layer rather than having to restart from scratch, again saving considerable time.

This can be modified by the `--depth` option.  Set `--depth=0` to disable this capability.

When generating Dockerfiles, multi-stage builds can be enabled by setting `--multi-stage`.  Currently this does not do much, but in the future if the runtime dependencies can be separated from the build dependencies, then this could be enhanced to produce significantly smaller container images.