### PR TITLE
openfoam-com: Fix flex dependency

### DIFF
--- a/var/spack/repos/builtin/packages/openfoam-com/package.py
+++ b/var/spack/repos/builtin/packages/openfoam-com/package.py
@@ -307,7 +307,7 @@ class OpenfoamCom(Package):
     depends_on('cgal')
     # The flex restriction is ONLY to deal with a spec resolution clash
     # introduced by the restriction within scotch!
-    depends_on('flex@:2.6.1,2.6.4:', type='build')
+    depends_on('flex@:2.6.1,2.6.4:')
     depends_on('cmake', type='build')
 
     # Require scotch with ptscotch - corresponds to standard OpenFOAM setup


### PR DESCRIPTION
openfoam-com needs flex's FlexLexer.h, which can only be found if flex is also a link dependency.

Should also fix #7439.