### PR TITLE
Add arch=spack.architecture.sys_type() when choosing which environmen…

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -584,7 +584,7 @@ def print_setup_info(*info):
     # print environment module system if available. This can be expensive
     # on clusters, so skip it if not needed.
     if 'modules' in info:
-        specs = spack.store.db.query('environment-modules')
+        specs = spack.store.db.query('environment-modules arch=%s' % spack.architecture.sys_type())
         if specs:
             shell_set('_sp_module_prefix', specs[-1].prefix)
         else:


### PR DESCRIPTION
This for #10883 to select a better environment-modules spec.