### PR TITLE
blitz: add papi as a dependency

### DIFF
--- a/var/spack/repos/builtin/packages/blitz/package.py
+++ b/var/spack/repos/builtin/packages/blitz/package.py
@@ -14,6 +14,8 @@ class Blitz(AutotoolsPackage):
     version('1.0.1', 'fe43e2cf6c9258bc8b369264dd008971')
     version('1.0.0', '971c43e22318bbfe8da016e6ef596234')
 
+    depends_on('papi')
+
     build_targets = ['lib']
 
     def check(self):


### PR DESCRIPTION
When building blitz I get the following error:

    354    blitz-1.0.1/blitz/timer.h:124:10: fatal error: papi.h: No such file or directory
    355     #include <papi.h>
    356              ^~~~~~~~
    357    compilation terminated.

which is alleviated by adding PAPI as a dependency.