### PR TITLE
add ninja v1.9.0

### DIFF
--- a/var/spack/repos/builtin/packages/ninja/package.py
+++ b/var/spack/repos/builtin/packages/ninja/package.py
@@ -17,7 +17,8 @@ class Ninja(Package):
     git      = "https://github.com/Kitware/ninja.git"
 
     version('kitware', branch='features-for-fortran')
-    version('1.8.2', '5fdb04461cc7f5d02536b3bfc0300166', preferred=True)
+    version('1.9.0', sha256='5d7ec75828f8d3fd1a0c2f31b5b0cea780cdfe1031359228c428c1a48bfcd5b9')
+    version('1.8.2', '5fdb04461cc7f5d02536b3bfc0300166')
     version('1.7.2', '7b482218757acbaeac4d4d54a3cd94e1')
     version('1.6.0', '254133059f2da79d8727f654d7198f43')
 


### PR DESCRIPTION
Locally when I remove `preferred=True` (instead of moving it to 1.9.0) it will default to 1.9.0.  Is this behavior we can rely on or should I add `preferred=True` to the 1.9.0 version?