### PR TITLE
QMCPACK Minor MKL buglet. 

### DIFF
--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -277,6 +277,7 @@ class Qmcpack(CMakePackage, CudaPackage):
             args.append('-DENABLE_MKL=1')
             args.append('-DMKL_ROOT=%s' % env['MKLROOT'])
         else:
+            args.append('-DENABLE_MKL=0')
             lapack_dir = ':'.join((
                 spec['lapack'].prefix.include,
                 spec['blas'].prefix.include


### PR DESCRIPTION
Now you are able to use the Intel compiler with other BLAS and LAPACK providers, no longer forced to use MKL.