### PR TITLE
fixes to get ipython to run properly

### DIFF
--- a/var/spack/repos/builtin/packages/py-ipython/package.py
+++ b/var/spack/repos/builtin/packages/py-ipython/package.py
@@ -20,16 +20,21 @@ class PyIpython(PythonPackage):
     version('2.3.1', '2b7085525dac11190bfb45bb8ec8dcbf')
 
     depends_on('python@2.7:2.8,3.3:')
+    depends_on('python@3.3:', when='@6.0:')
 
     depends_on('py-backports-shutil-get-terminal-size', type=('build', 'run'), when="^python@:3.2")
     depends_on('py-pathlib2', type=('build', 'run'), when="^python@:3.3")
-    depends_on('py-pygments',                   type=('build', 'run'))
-    depends_on('py-pickleshare',                type=('build', 'run'))
-    depends_on('py-simplegeneric@0.8:',         type=('build', 'run'))
-    depends_on('py-prompt-toolkit@1.0.4:1.999', type=('build', 'run'))
-    depends_on('py-traitlets@4.2:',             type=('build', 'run'))
-    depends_on('py-decorator',                  type=('build', 'run'))
-    depends_on('py-pexpect',                    type=('build', 'run'))
+    depends_on('py-pygments',                     type=('build', 'run'))
+    depends_on('py-pickleshare',                  type=('build', 'run'))
+    depends_on('py-simplegeneric@0.8:',           type=('build', 'run'))
+    depends_on('py-prompt-toolkit@1.0.4:1.999',   type=('build', 'run'),
+               when='@:5.1.0')
+    depends_on('py-prompt-toolkit@2.0.0:2.0.999', type=('build', 'run'),
+               when='@7.3.0:')
+    depends_on('py-traitlets@4.2:',               type=('build', 'run'))
+    depends_on('py-decorator',                    type=('build', 'run'))
+    depends_on('py-pexpect',                      type=('build', 'run'))
+    depends_on('py-backcall',                     type=('build', 'run'))
 
     depends_on('py-appnope', type=('build', 'run'),
                     when=sys.platform == 'darwin' and

--- a/var/spack/repos/builtin/packages/py-prompt-toolkit/package.py
+++ b/var/spack/repos/builtin/packages/py-prompt-toolkit/package.py
@@ -12,6 +12,7 @@ class PyPromptToolkit(PythonPackage):
     homepage = "https://pypi.python.org/pypi/prompt_toolkit"
     url      = "https://pypi.io/packages/source/p/prompt_toolkit/prompt_toolkit-1.0.9.tar.gz"
 
+    version('2.0.9', '091daddeec62015e0be36e8682d36562')
     version('1.0.9', 'a39f91a54308fb7446b1a421c11f227c')
 
     depends_on('py-setuptools', type='build')


### PR DESCRIPTION
ipython version 6 and newer require python 3. I also found that py-backcall is required to run ipython and that ipython version 7 requires a different version range of py-prompt-toolkit than this package previously required (see https://github.com/jupyter/notebook/issues/4050).