### PR TITLE
Random123 - provide a patch to fix compiles with IBM XL

### DIFF
--- a/var/spack/repos/builtin/packages/random123/ibmxl.patch
+++ b/var/spack/repos/builtin/packages/random123/ibmxl.patch
@@ -1,0 +1,11 @@
+--- a/include/Random123/features/compilerfeatures.h
++++ b/include/Random123/features/compilerfeatures.h
+@@ -199,7 +199,7 @@ added to each of the *features.h files, AND to examples/ut_features.cpp.
+ #include "nvccfeatures.h"
+ #elif defined(__ICC)
+ #include "iccfeatures.h"
+-#elif defined(__xlC__)
++#elif defined(__xlC__) || defined(__ibmxl__)
+ #include "xlcfeatures.h"
+ #elif defined(__SUNPRO_C) || defined(__SUNPRO_CC)
+ #include "sunprofeatures.h"

--- a/var/spack/repos/builtin/packages/random123/package.py
+++ b/var/spack/repos/builtin/packages/random123/package.py
@@ -17,6 +17,8 @@ class Random123(Package):
 
     version('1.09', '67ae45ff94b12acea590a6aa04ed1123')
 
+    patch('ibmxl.patch', when='@1.09')
+
     def install(self, spec, prefix):
         # Random123 doesn't have a build system.
         # We have to do our own install here.


### PR DESCRIPTION
* Newer versions of IBM XL no longer define `__xlC__`, but define `__ibmxl__` instead.  This one-line patch fixes this problem in Random123.
* This patch was also provided to the Random123 maintiners (Random123@DEShawResearch.com). I don't expect a new release from them for a while, so I believe that this patch is the correct path forward (for now).
* I have chosen to always patch the source code, even when the spack compiler is not _xlc_.  This choice was made because Random123 is a header-only package that is frequently installed using a _Core_ or system default compiler (e.g. `/usr/bin/gcc`) even when the files will be consumed through include directives when other compilers are used (like _xlc_)