### PR TITLE
spack repo add: fix error message when `packages' directory is missing

### DIFF
--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -720,7 +720,7 @@ class Repo(object):
 
         self.packages_path = os.path.join(self.root, packages_dir_name)
         check(os.path.isdir(self.packages_path),
-              "No directory '%s' found in '%s'" % (repo_config_name, root))
+              "No directory '%s' found in '%s'" % (packages_dir_name, root))
 
         # Read configuration and validate namespace
         config = self._read_config()


### PR DESCRIPTION
To reproduce the issue:

```
$ cd $SPACK_ROOT/var/spack/repos
$ mkdir acme
$ <builtin/repo.yaml sed s/builting/acme/ > acme/repo.yaml
$ spack repo add acme
==> Error: No directory 'repo.yaml' found in '/tmp/spack/var/spack/repos/acme'
```

Should be _packages_ instead of _repo.yaml_