### PR TITLE
Fix bug when system perl is used.

### DIFF
--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -189,16 +189,18 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
            In most cases, extensions will only need to have one line:
            perl('Makefile.PL','INSTALL_BASE=%s' % self.prefix)
         """
+        
+        # If system perl is used through packages.yaml there cannot be extensions.
+        if dependent_spec.package.is_extension:
 
         # perl extension builds can have a global perl executable function
-        module.perl = self.spec['perl'].command
+            module.perl = self.spec['perl'].command
 
         # Add variables for library directory
-        module.perl_lib_dir = dependent_spec.prefix.lib.perl5
+            module.perl_lib_dir = dependent_spec.prefix.lib.perl5
 
         # Make the site packages directory for extensions,
         # if it does not exist already.
-        if dependent_spec.package.is_extension:
             mkdirp(module.perl_lib_dir)
 
     @run_after('install')

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -189,8 +189,9 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
            In most cases, extensions will only need to have one line:
            perl('Makefile.PL','INSTALL_BASE=%s' % self.prefix)
         """
-        
-        # If system perl is used through packages.yaml there cannot be extensions.
+
+        # If system perl is used through packages.yaml
+        # there cannot be extensions.
         if dependent_spec.package.is_extension:
 
         # perl extension builds can have a global perl executable function

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -194,14 +194,15 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         # there cannot be extensions.
         if dependent_spec.package.is_extension:
 
-        # perl extension builds can have a global perl executable function
+            # perl extension builds can have a global perl
+            # executable function
             module.perl = self.spec['perl'].command
 
-        # Add variables for library directory
+            # Add variables for library directory
             module.perl_lib_dir = dependent_spec.prefix.lib.perl5
 
-        # Make the site packages directory for extensions,
-        # if it does not exist already.
+            # Make the site packages directory for extensions,
+            # if it does not exist already.
             mkdirp(module.perl_lib_dir)
 
     @run_after('install')


### PR DESCRIPTION
If system perl is being used through packages.yaml there cannot be dependent modules.
The  setup_dependent_packages function should not do anything in that case.

Addresses bug in https://github.com/spack/spack/issues/11033
