### PR TITLE
r-rmysql: add 0.10.17, mariadb-connector-c dependency

### DIFF
--- a/var/spack/repos/builtin/packages/r-rmysql/package.py
+++ b/var/spack/repos/builtin/packages/r-rmysql/package.py
@@ -13,7 +13,9 @@ class RRmysql(RPackage):
     url      = "https://cran.r-project.org/src/contrib/RMySQL_0.10.9.tar.gz"
     list_url = "https://cran.r-project.org/src/contrib/Archive/RMySQL"
 
+    version('0.10.17', sha256='754df4fce159078c1682ef34fc96aa5ae30981dc91f4f2bada8d1018537255f5')
     version('0.10.9', '3628200a1864ac3005cfd55cc7cde17a')
 
     depends_on('r-dbi', type=('build', 'run'))
     depends_on('mariadb')
+    depends_on('mariadb-connector-c')

--- a/var/spack/repos/builtin/packages/r-rmysql/package.py
+++ b/var/spack/repos/builtin/packages/r-rmysql/package.py
@@ -16,6 +16,5 @@ class RRmysql(RPackage):
     version('0.10.17', sha256='754df4fce159078c1682ef34fc96aa5ae30981dc91f4f2bada8d1018537255f5')
     version('0.10.9', '3628200a1864ac3005cfd55cc7cde17a')
 
-    depends_on('r-dbi', type=('build', 'run'))
-    depends_on('mariadb')
-    depends_on('mariadb-connector-c')
+    depends_on('r-dbi@0.4:', type=('build', 'run'))
+    depends_on('mariadb@:5.5.56')


### PR DESCRIPTION
depends on `mariadb-connector-c` in #11043