### PR TITLE
r-hoardr: new package at 0.5.2

### DIFF
--- a/var/spack/repos/builtin/packages/r-hoardr/package.py
+++ b/var/spack/repos/builtin/packages/r-hoardr/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class RHoardr(RPackage):
+    """hoardr: Manage Cached Files"""
+
+    homepage = "https://cran.r-project.org/package=hoardr"
+    url      = "https://cran.r-project.org/src/contrib/hoardr_0.5.2.tar.gz"
+    list_url = "https://cran.r-project.org/src/contrib/Archive/hoardr/"
+
+    version('0.5.2', sha256='819113f0e25da105f120a676b5173872a4144f2f6f354cad14b35f898e76dc54')
+
+    depends_on('r-r6@2.2.0:', type=('build', 'run'))
+    depends_on('r-rappdirs@0.3.1:', type=('build', 'run'))
+    depends_on('r-digest', type=('build', 'run'))
+    depends_on('r-roxygen2@6.0.1:', type=('build', 'run'))
+    depends_on('r-testthat', type=('build', 'run'))
+    depends_on('r-knitr', type=('build', 'run'))
+    depends_on('r-rmarkdown', type=('build', 'run'))


### PR DESCRIPTION
depends on newer version of `r-roxygen2` in #11045 