### PR TITLE
xcb-util-wm: add m4 build system dependency

### DIFF
--- a/var/spack/repos/builtin/packages/xcb-util-wm/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-wm/package.py
@@ -19,9 +19,6 @@ class XcbUtilWm(AutotoolsPackage):
 
     version('0.4.1', '0831399918359bf82930124fa9fd6a9b')
 
-    depends_on('autoconf', type='build')
-    depends_on('automake', type='build')
-    depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
 
     depends_on('libxcb@1.4:')

--- a/var/spack/repos/builtin/packages/xcb-util-wm/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-wm/package.py
@@ -19,6 +19,11 @@ class XcbUtilWm(AutotoolsPackage):
 
     version('0.4.1', '0831399918359bf82930124fa9fd6a9b')
 
+    depends_on('autoconf', type='build')
+    depends_on('automake', type='build')
+    depends_on('libtool',  type='build')
+    depends_on('m4',       type='build')
+
     depends_on('libxcb@1.4:')
 
     depends_on('pkgconfig', type='build')


### PR DESCRIPTION
This fixes the following error at configure phase on systems where m4 is not available:

`checking for m4 that supports -I option... configure: error: could not find m4 that supports -I option`

According to [build-system-dependencies](https://spack.readthedocs.io/en/latest/build_systems/autotoolspackage.html?highlight=autotools#build-system-dependencies), build systems dependecies were added to the package.
