### PR TITLE
Spack stacks: Allow combinatorial Environment specifications.

### DIFF
--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -667,7 +667,7 @@ excludes those built with the PGI compiler at version 18.5.
          select: [^mpi]
          exclude: ['%pgi@18.5']
          projections:
-           all: ${package}/${version}-${compilername}
+           all: {name}/{version}-{compiler.name}
 
 For more information on using view projections, see the section on
 :ref:`adding_projections_to_views`. The default for the ``select`` and

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -1,0 +1,635 @@
+.. Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+   Spack Project Developers. See the top-level COPYRIGHT file for details.
+
+   SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+.. _environments:
+
+============
+Environments
+============
+
+An environment is used to group together a set of specs for the
+purpose of building, rebuilding and deploying in a coherent fashion.
+Environments provide a number of advantages over the a la carte
+approach of building and loading individual Spack modules:
+
+#. Environments separate the steps of (a) choosing what to
+   install, (b) concretizing, and (c) installing.  This allows
+   Environments to remain stable and repeatable, even if Spack packages
+   are upgraded: specs are only re-concretized when the user
+   explicitly asks for it.  It is even be possible to reliably
+   transport environments between different computers running
+   different versions of Spack!
+#. Environments allow several specs to be built at once; a more robust
+   solution than ad-hoc scripts making multiple calls to ``spack
+   install``.
+#. An Environment that is built as a whole can be loaded as a whole
+   into the user environment. An Environment can be build to maintain
+   a filesystem view of its packages, and the environment can load
+   that view into the user environment at activation time. Spack can
+   also generate a script to load all modules related to an
+   environment.
+
+Other packaging systems also provide environments that are similar in
+some ways to Spack environments; for example, `Conda environments
+<https://conda.io/docs/user-guide/tasks/manage-environments.html>`_ or
+`Python Virtual Environments
+<https://docs.python.org/3/tutorial/venv.html>`_.  Spack environments
+provide some distinctive features:
+
+#. A spec installed "in" an environment is no different from the same
+   spec installed anywhere else in Spack.  Environments are assembled
+   simply by collecting together a set of specs.
+#. Spack Environments may contain more than one spec of the same
+   package.
+
+Spack uses a "manifest and lock" model similar to `Bundler gemfiles
+<https://bundler.io/man/gemfile.5.html>`_ and other package
+managers. The user input file is named ``spack.yaml`` and the lock
+file is named ``spack.lock``
+
+------------------
+Using Environments
+------------------
+
+Here we follow a typical use case of creating, concretizing,
+installing and loading an environment.
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Creating a named Environment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+An environment is created by:
+
+.. code-block:: console
+
+   $ spack env create myenv
+
+Spack then creates the directory ``var/spack/environments/myenv``.
+
+.. note::
+
+   All named environments are stored in the ``var/spack/environments`` folder.
+
+In the ``var/spack/environments/myenv`` directory, Spack creates the
+file ``spack.yaml`` and the hidden directory ``.spack-env``.
+
+Spack stores metadata in the ``.spack-env`` directory. User
+interaction will occur through the ``spack.yaml`` file and the Spack
+commands that affect it. When the environment is concretized, Spack
+will create a file ``spack.lock`` with the concrete information for
+the environment.
+
+In addition to being the default location for the view associated with
+an Environment, the ``.spack-env`` directory also contains:
+
+  * ``repo/``: A repo consisting of the Spack packages used in this
+    environment.  This allows the environment to build the same, in
+    theory, even on different verions of Spack with different
+    packages!
+  * ``logs/``: A directory containing the build logs for the packages
+    in this Environment.
+
+Spack Environments can also be created from either a ``spack.yaml``
+manifest or a ``spack.lock`` lockfile. To create an Environment from a
+``spack.yaml`` manifest:
+
+.. code-block:: console
+
+   $ spack env create myenv spack.yaml
+
+To create an Environment from a ``spack.lock`` lockfile:
+
+.. code-block:: console
+
+   $ spack env create myenv spack.lock
+
+Either of these commands can also take a full path to the
+initialization file.
+
+A Spack Environment created from a ``spack.yaml`` manifest is
+guaranteed to have the same root specs as the original Environment,
+but may concretize differently. A Spack Environment created from a
+``spack.lock`` lockfile is guaranteed to have the same concrete specs
+as the original Environment. Either may obviously then differ as the
+user modifies it.
+
+^^^^^^^^^^^^^^^^^^^^^^^^^
+Activating an Environment
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To activate an environment, use the following command:
+
+.. code-block:: console
+
+   $ spack env activate myenv
+
+By default, the ``spack env activate`` will load the view associated
+with the Environment into the user environment. The ``-v,
+--with-view`` argument ensures this behavior, and the ``-V,
+--without-vew`` argument activates the environment without changing
+the user environment variables.
+
+The ``-p`` option to the ``spack env activate`` command modifies the
+user's prompt to begin with the environment name in brackets.
+
+.. code-block:: console
+
+   $ spack env activate -p myenv
+   [myenv] $ ...
+
+To deactivate an environment, use the command:
+
+.. code-block:: console
+
+   $ spack env deactivate
+
+or the shortcut alias
+
+.. code-block:: console
+
+   $ despacktivate
+
+If the environment was activated with its view, deactivating the
+environment will remove the view from the user environment.
+
+^^^^^^^^^^^^^^^^^^^^^^
+Anonymous Environments
+^^^^^^^^^^^^^^^^^^^^^^
+
+Any directory can be treated as an environment if it contains a file
+``spack.yaml``. To load an anonymous environment, use:
+
+.. code-block:: console
+
+   $ spack env activate -d /path/to/directory
+
+Spack commands that are environment sensitive will also act on the
+environment any time the current working directory contains a
+``spack.yaml`` file. Changing working directory to a directory
+containing a ``spack.yaml`` file is equivalent to the command:
+
+.. code-block:: console
+
+   $ spack env activate -d /path/to/dir --without-view
+
+Anonymous specs can be created in place using the command:
+
+.. code-block:: console
+
+   $ spack env create -d .
+
+In this case Spack simply creates a spack.yaml file in the requested
+directory.
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Environment Sensitive Commands
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Spack commands are environment sensitive. For example, the ``find``
+command shows only the specs in the active Environment if an
+Environment has been activated. Similarly, the ``install`` and
+``uninstall`` commands act on the active environment.
+
+.. code-block:: console
+
+  $ spack find
+  ==> 0 installed packages
+
+  $ spack install zlib@1.2.11
+  ==> Installing zlib
+  ==> Searching for binary cache of zlib
+  ==> Warning: No Spack mirrors are currently configured
+  ==> No binary for zlib found: installing from source
+  ==> Fetching http://zlib.net/fossils/zlib-1.2.11.tar.gz
+  ######################################################################## 100.0%
+  ==> Staging archive: /spack/var/spack/stage/zlib-1.2.11-3r4cfkmx3wwfqeof4bc244yduu2mz4ur/zlib-1.2.11.tar.gz
+  ==> Created stage in /spack/var/spack/stage/zlib-1.2.11-3r4cfkmx3wwfqeof4bc244yduu2mz4ur
+ ==> No patches needed for zlib
+  ==> Building zlib [Package]
+  ==> Executing phase: 'install'
+  ==> Successfully installed zlib
+    Fetch: 0.36s.  Build: 11.58s.  Total: 11.93s.
+  [+] /spack/opt/spack/linux-rhel7-x86_64/gcc-4.9.3/zlib-1.2.11-3r4cfkmx3wwfqeof4bc244yduu2mz4ur
+
+  $ spack env activate myenv
+
+  $ spack find
+  ==> In environment myenv
+  ==> No root specs
+
+  ==> 0 installed packages
+
+  $ spack install zlib@1.2.8
+  ==> Installing zlib
+  ==> Searching for binary cache of zlib
+  ==> Warning: No Spack mirrors are currently configured
+  ==> No binary for zlib found: installing from source
+  ==> Fetching http://zlib.net/fossils/zlib-1.2.8.tar.gz
+  ######################################################################## 100.0%
+  ==> Staging archive: /spack/var/spack/stage/zlib-1.2.8-y2t6kq3s23l52yzhcyhbpovswajzi7f7/zlib-1.2.8.tar.gz
+  ==> Created stage in /spack/var/spack/stage/zlib-1.2.8-y2t6kq3s23l52yzhcyhbpovswajzi7f7
+  ==> No patches needed for zlib
+  ==> Building zlib [Package]
+  ==> Executing phase: 'install'
+  ==> Successfully installed zlib
+    Fetch: 0.26s.  Build: 2.08s.  Total: 2.35s.
+  [+] /spack/opt/spack/linux-rhel7-x86_64/gcc-4.9.3/zlib-1.2.8-y2t6kq3s23l52yzhcyhbpovswajzi7f7
+
+  $ spack find
+  ==> In environment myenv
+  ==> Root specs
+  zlib@1.2.8
+
+  ==> 1 installed package
+  -- linux-rhel7-x86_64 / gcc@4.9.3 -------------------------------
+  zlib@1.2.8
+
+  $ despacktivate
+  $ spack find
+  ==> 2 installed packages
+  -- linux-rhel7-x86_64 / gcc@4.9.3 -------------------------------
+  zlib@1.2.8  zlib@1.2.11
+
+Note that when we installed the abstract spec ``zlib@1.2.8``, it was
+presented as a root of the Environment. All explicitly installed
+packages will be listed as roots of the Environment.
+
+All of the Spack commands that act on the list of installed specs are
+Environment-sensitive in this way, including ``install``,
+``uninstall``, ``activate``, ``deactivate``, ``find``, ``extensions``,
+and more. In the :ref:`environment-configuration` section we will discuss
+Environment-sensitive commands further.
+
+^^^^^^^^^^^^^^^^^^^^^
+Adding Abstract Specs
+^^^^^^^^^^^^^^^^^^^^^
+
+An abstract spec is the user-specified spec before Spack has applied
+any defaults or dependency information.
+
+Users can add abstract specs to an Environment using the ``spack add``
+command. The most important component of an Environment is a list of
+abstract specs.
+
+Adding a spec adds to the manifest (the ``spack.yaml`` file) and to
+the roots of the Environment, but does not affect the concrete specs
+in the lockfile, nor does it install the spec.
+
+The ``spack add`` command is environment aware. It adds to the
+currently active environment. All environment aware commands can also
+be called using the ``spack -E`` flag to specify the environment.
+
+.. code-block:: console
+
+   $ spack activate myenv
+   $ spack add mpileaks
+
+or
+
+.. code-block:: console
+
+   $ spack -E myenv add python
+
+^^^^^^^^^^^^
+Concretizing
+^^^^^^^^^^^^
+
+Once some user specs have been added to an environment, they can be
+concretized.  The following command will concretize all user specs
+that have been added and not yet concretized:
+
+.. code-block:: console
+
+   [myenv]$ spack concretize
+
+This command will re-concretize all specs:
+
+.. code-block:: console
+
+   [myenv]$ spack concretize -f
+
+When the ``-f`` flag is not used to reconcretize all specs, Spack
+guarantees that already concretized specs are unchanged in the
+environment.
+
+The ``concretize`` command does not install any packages. For packages
+that have already been installed outside of the environment, the
+process of adding the spec and concretizing is identical to installing
+the spec assuming it concretizes to the exact spec that was installed
+ouside of the environment.
+
+The ``spack find`` command can show concretized specs separately from
+installed specs using the ``-c`` (``--concretized``) flag.
+
+.. code-block:: console
+
+  [myenv]$ spack add zlib
+  [myenv]$ spack concretize
+  [myenv]$ spack find -c
+  ==> In environment myenv
+  ==> Root specs
+  zlib
+
+  ==> Concretized roots
+  -- linux-rhel7-x86_64 / gcc@4.9.3 -------------------------------
+  zlib@1.2.11
+
+  ==> 0 installed packages
+
+^^^^^^^^^^^^^^^^^^^^^^^^^
+Installing an Environment
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In addition to installing individual specs into an Environment, one
+can install the entire Environment at once using the command
+
+.. code-block:: console
+
+   [myenv]$ spack install
+
+If the Environment has been concretized, Spack will install the
+concretized specs. Otherwise, ``spack install`` will first concretize
+the Environment and then install the concretized specs.
+
+As it installs, ``spack install`` creates symbolic links in the
+``logs/`` directory in the Environment, allowing for easy inspection
+of build logs related to that environment. The ``spack install``
+command also stores a Spack repo containing the ``package.py`` file
+used at install time for each package in the ``repos/`` directory in
+the Environment.
+
+^^^^^^^
+Loading
+^^^^^^^
+
+Once an environment has been installed, the following creates a load script for it:
+
+.. code-block:: console
+
+   $ spack env myenv loads -r
+
+This creates a file called ``loads`` in the environment directory.
+Sourcing that file in Bash will make the environment available to the
+user; and can be included in ``.bashrc`` files, etc.  The ``loads``
+file may also be copied out of the environment, renamed, etc.
+
+----------
+spack.yaml
+----------
+
+Spack environments can be customized at finer granularity by editing
+the ``spack.yaml`` manifest file directly.
+
+.. _environment-configuration:
+
+^^^^^^^^^^^^^^^^^^^^^^^^
+Configuring Environments
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+A variety of Spack behaviors are changed through Spack configuration
+files, covered in more detail in the :ref:`configuration`
+section.
+
+Spack Environments provide an additional level of configuration scope
+between the custom scope and the user scope discussed in the
+configuration documentation.
+
+There are two ways to include configuration information in a Spack Environment:
+
+#. Inline in the ``spack.yaml`` file
+
+#. Included in the ``spack.yaml`` file from another file.
+
+"""""""""""""""""""""
+Inline configurations
+"""""""""""""""""""""
+
+Inline Environment-scope configuration is done using the same yaml
+format as standard Spack configuration scopes, covered in the
+:ref:`configuration` section. Each section is contained under a
+top-level yaml object with it's name. For example, a ``spack.yaml``
+manifest file containing some package preference configuration (as in
+a ``packages.yaml`` file) could contain:
+
+.. code-block:: yaml
+
+   spack:
+     ...
+     packages:
+       all:
+         compilers: [intel]
+     ...
+
+This configuration sets the default compiler for all packages to
+``intel``.
+
+"""""""""""""""""""""""
+Included configurations
+"""""""""""""""""""""""
+
+Spack environments allow an ``include`` heading in their yaml
+schema. This heading pulls in external configuration files and applies
+them to the Environment.
+
+.. code-block:: yaml
+
+   spack:
+     include:
+     - relative/path/to/config.yaml
+     - /absolute/path/to/packages.yaml
+
+Environments can include files either with a relative or absolute
+paths. Inline configurations take precedence over included
+configurations, so you don't have to change shared configuration files
+to make small changes to an individual Environment. Included configs
+listed later will have higher precedence, as the included configs are
+applied in order.
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Manually Editing the Specs List
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The list of abstract/root specs in the Environment is maintained in
+the ``spack.yaml`` manifest under the heading ``specs``.
+
+.. code-block:: yaml
+
+   spack:
+       specs:
+         - ncview
+         - netcdf
+         - nco
+         - py-sphinx
+
+Appending to this list in the yaml is identical to using the ``spack
+add`` command from the command line. However, there is more power
+available from the yaml file.
+
+"""""""""""""
+Spec Matrices
+"""""""""""""
+
+Entries in the ``specs`` list can be individual abstract specs or a
+spec matrix.
+
+A spec matrix is a yaml object containing multiple lists of specs, and
+evaluates to the cross-product of those specs. Spec matrices also
+contain an ``excludes`` directive, which eliminates certain
+combinations from the evaluated result.
+
+The following two Environment manifests are identical:
+
+.. code-block:: yaml
+
+   spack:
+     specs:
+       - zlib %gcc@7.1.0
+       - zlib %gcc@4.9.3
+       - libelf %gcc@7.1.0
+       - libelf %gcc@4.9.3
+       - libdwarf %gcc@7.1.0
+       - cmake
+
+   spack:
+     specs:
+       - matrix:
+           - [zlib, libelf, libdwarf]
+           - ['%gcc@7.1.0', '%gcc@4.9.3']
+         exclude:
+           - libdwarf%gcc@4.9.3
+       - cmake
+
+Spec matrices can be used to install swaths of software across various
+toolchains.
+
+The concretization logic for spec matrices differs slightly from the
+rest of Spack. If a variant or dependency constraint from a matrix is
+invalid, Spack will reject the constraint and try again without
+it. For example, the following two Environment manifests will produce
+the same specs:
+
+.. code-block:: yaml
+
+   spack:
+     specs:
+       - matrix:
+           - [zlib, libelf, hdf5+mpi]
+           - [^mvapich2@2.2, ^openmpi@3.1.0]
+
+   spack:
+     specs:
+       - zlib
+       - libelf
+       - hdf5+mpi ^mvapich2@2.2
+       - hdf5+mpi ^openmpi@3.1.0
+
+This allows one to create toolchains out of combinations of
+constraints and apply them somewhat indiscriminantly to packages,
+without regard for the applicability of the constraint.
+
+""""""""""""""""""""
+Spec List References
+""""""""""""""""""""
+
+The last type of possible entry in the specs list is a reference.
+
+The Spack Environment manifest yaml schema contains an additional
+heading ``definitions``. Under definitions is an array of yaml
+objects. Each object has one or two fields. The one required field is
+a name, and the optional field is a ``when`` clause.
+
+The named field is a spec list. The spec list uses the same syntax as
+the ``specs`` entry. Each entry in the spec list can be a spec, a spec
+matrix, or a reference to an earlier named list. References are
+specified using the ``$`` sigil, and are "splatted" into place
+(i.e. the elements of the referent are at the same level as the
+elements listed separately). As an example, the following two manifest
+files are identical.
+
+.. code-block:: yaml
+
+   spack:
+     definitions:
+       - first: [libelf, libdwarf]
+       - compilers: ['%gcc', '^intel']
+       - second:
+           - $first
+           - matrix:
+               - [zlib]
+               - [$compilers]
+     specs:
+       - $second
+       - cmake
+
+   spack:
+     specs:
+       - libelf
+       - libdwarf
+       - zlib%gcc
+       - zlib%intel
+       - cmake
+
+.. note::
+
+   Named a spec list in the definitions section may only refer
+   to a named list defined above itself. Order matters.
+
+In short files like the example, it may be easier to simply list the
+included specs. However for more complicated examples involving many
+packages across many toolchains, separately factored lists make
+Environments substantially more manageable.
+
+Additionally, the ``-l`` option to the ``spack add`` command allows
+one to add to named lists in the definitions section of the manifest
+file directly from the command line.
+
+The ``when`` directive can be used to conditionally add specs to a
+named list. The ``when`` directive takes a string of python code
+referring to a restricted set of variables, and evaluates to a
+boolean. The specs listed are appended to the named list if the
+``when`` string evaluates to ``True``. In the following snippet, the
+named list ``compilers`` is ``['%gcc', '%clang', '%intel']`` on
+``x86_64`` systems and ``['%gcc', '%clang']`` on all other systems.
+
+.. code-block:: yaml
+
+   spack:
+     definitions:
+       - compilers: ['%gcc', '%clang']
+       - when: target == 'x86_64'
+         compilers: ['%intel']
+
+.. note::
+
+   Any definitions with the same named list with true ``when``
+   clauses (or absent ``when`` clauses) will be appended together
+
+The valid variables for a ``when`` clause are:
+
+#. ``platform``. The platform string of the default Spack
+   architecture on the system.
+
+#. ``os``. The os string of the default Spack architecture on
+   the system.
+
+#. ``target``. The target string of the default Spack
+   architecture on the system.
+
+#. ``architecture`` or ``arch``. The full string of the
+   default Spack architecture on the system.
+
+#. ``re``. The standard regex module in python.
+
+#. ``env``. The user environment (usually ``os.environ`` in python).
+
+#. ``hostname``. The hostname of the system (if ``hostname`` is an
+   executable in the user's PATH).
+
+^^^^^^^^^^^^^^^^^^^^^^^^^
+Environment-managed Views
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Code for Spack Environments is in code review at the
+moment. Documentation will be updated when the code is finalized.

--- a/lib/spack/docs/index.rst
+++ b/lib/spack/docs/index.rst
@@ -65,6 +65,7 @@ or refer to the full manual below.
    configuration
    config_yaml
    build_settings
+   environments
    mirrors
    module_file_support
    repositories

--- a/lib/spack/spack/cmd/add.py
+++ b/lib/spack/spack/cmd/add.py
@@ -17,6 +17,9 @@ level = "long"
 
 
 def setup_parser(subparser):
+    subparser.add_argument('-l', '--list-name',
+                           dest='list_name', default='specs',
+                           help="name of the list to add specs to")
     subparser.add_argument(
         'specs', nargs=argparse.REMAINDER, help="specs of packages to add")
 
@@ -25,7 +28,7 @@ def add(parser, args):
     env = ev.get_env(args, 'add', required=True)
 
     for spec in spack.cmd.parse_specs(args.specs):
-        if not env.add(spec):
+        if not env.add(spec, args.list_name):
             tty.msg("Package {0} was already added to {1}"
                     .format(spec.name, env.name))
         else:

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -315,11 +315,11 @@ def env_view(args):
             if args.view_path:
                 view_path = args.view_path
             else:
-                view_path = env.default_view_path
-            env.update_view(view_path)
+                view_path = env.create_view_path
+            env.update_default_view(view_path)
             env.write()
         elif args.action == ViewAction.disable:
-            env.update_view(None)
+            env.update_default_view(None)
             env.write()
     else:
         tty.msg("No active environment")

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -315,7 +315,7 @@ def env_view(args):
             if args.view_path:
                 view_path = args.view_path
             else:
-                view_path = env.create_view_path
+                view_path = env.view_path_default
             env.update_default_view(view_path)
             env.write()
         elif args.action == ViewAction.disable:

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -310,7 +310,7 @@ def env_view(args):
 
     if env:
         if args.action == ViewAction.regenerate:
-            env.regenerate_view()
+            env.regenerate_views()
         elif args.action == ViewAction.enable:
             if args.view_path:
                 view_path = args.view_path

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -175,6 +175,7 @@ def find(parser, args):
             tty.msg('No root specs')
         else:
             tty.msg('Root specs')
+            # TODO: Change this to not print extraneous deps and variants
             display_specs(
                 env.user_specs, args,
                 decorator=lambda s, f: color.colorize('@*{%s}' % f))

--- a/lib/spack/spack/cmd/release_jobs.py
+++ b/lib/spack/spack/cmd/release_jobs.py
@@ -87,12 +87,12 @@ def get_job_name(spec, osarch):
 
 def get_spec_string(spec):
     format_elements = [
-        '${package}@${version}',
-        '%${compilername}@${compilerversion}',
+        '{name}{@version}',
+        '{%compiler}',
     ]
 
     if spec.architecture:
-        format_elements.append(' arch=${architecture}')
+        format_elements.append(' {arch=architecture}')
 
     return spec.format(''.join(format_elements))
 

--- a/lib/spack/spack/cmd/remove.py
+++ b/lib/spack/spack/cmd/remove.py
@@ -20,6 +20,9 @@ def setup_parser(subparser):
     subparser.add_argument(
         '-a', '--all', action='store_true',
         help="remove all specs from (clear) the environment")
+    subparser.add_argument('-l', '--list-name',
+                           dest='list_name', default='specs',
+                           help="name of the list to remove specs from")
     subparser.add_argument(
         '-f', '--force', action='store_true',
         help="remove concretized spec (if any) immediately")
@@ -35,5 +38,5 @@ def remove(parser, args):
     else:
         for spec in spack.cmd.parse_specs(args.specs):
             tty.msg('Removing %s from environment %s' % (spec, env.name))
-            env.remove(spec, force=args.force)
+            env.remove(spec, args.list_name, force=args.force)
     env.write()

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -500,7 +500,8 @@ def concretize_specs_together(*abstract_specs):
         # Split recursive specs, as it seems the concretizer has issue
         # respecting conditions on dependents expressed like
         # depends_on('foo ^bar@1.0'), see issue #11160
-        split_specs = [dep for spec in abstract_specs
+        split_specs = [dep.copy(deps=False)
+                       for spec in abstract_specs
                        for dep in spec.traverse(root=True)]
 
         with open(os.path.join(pkg_dir, 'package.py'), 'w') as f:

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -7,9 +7,12 @@ import os
 import re
 import sys
 import shutil
+import copy
 
 import ruamel.yaml
 import six
+
+from ordereddict_backport import OrderedDict
 
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
@@ -21,10 +24,13 @@ import spack.schema.env
 import spack.spec
 import spack.util.spack_json as sjson
 import spack.config
-from spack.spec import Spec
 from spack.filesystem_view import YamlFilesystemView
-
 from spack.util.environment import EnvironmentModifications
+import spack.architecture as architecture
+from spack.spec import Spec
+from spack.spec_list import SpecList, InvalidSpecConstraintError
+from spack.variant import UnknownVariantError
+from spack.util.executable import which
 
 #: environment variable used to indicate the active environment
 spack_env_var = 'SPACK_ENV'
@@ -385,6 +391,29 @@ def _write_yaml(data, str_or_file):
                      default_flow_style=False)
 
 
+def _eval_conditional(string):
+    """Evaluate conditional definitions using restricted variable scope."""
+    arch = architecture.Arch(
+        architecture.platform(), 'default_os', 'default_target')
+    valid_variables = {
+        'target': str(arch.target),
+        'os': str(arch.platform_os),
+        'platform': str(arch.platform),
+        'arch': str(arch),
+        'architecture': str(arch),
+        're': re,
+        'env': os.environ,
+    }
+    hostname_bin = which('hostname')
+    if hostname_bin:
+        hostname = str(hostname_bin(output=str, error=str)).strip()
+        valid_variables['hostname'] = hostname
+    else:
+        tty.warn("Spack was unable to find the executable `hostname`"
+                 " hostname will be unavailable in conditionals")
+    return eval(string, valid_variables)
+
+
 class Environment(object):
     def __init__(self, path, init_file=None, with_view=None):
         """Create a new environment.
@@ -425,6 +454,18 @@ class Environment(object):
                 if default_manifest:
                     self._set_user_specs_from_lockfile()
 
+            if os.path.exists(self.manifest_path):
+                # read the spack.yaml file, if exists
+                with open(self.manifest_path) as f:
+                    self._read_manifest(f)
+            elif self.concretized_user_specs:
+                # if not, take user specs from the lockfile
+                self._set_user_specs_from_lockfile()
+                self.yaml = _read_yaml(default_manifest_yaml)
+            else:
+                # if there's no manifest or lockfile, use the default
+                self._read_manifest(default_manifest_yaml)
+
         if with_view is False:
             self._view_path = None
         elif isinstance(with_view, six.string_types):
@@ -435,9 +476,38 @@ class Environment(object):
     def _read_manifest(self, f):
         """Read manifest file and set up user specs."""
         self.yaml = _read_yaml(f)
+
+        self.read_specs = OrderedDict()
+
+        for item in list(self.yaml.values())[0].get('definitions', []):
+            entry = copy.deepcopy(item)
+            when = _eval_conditional(entry.pop('when', 'True'))
+            assert len(entry) == 1
+            if when:
+                name, spec_list = list(entry.items())[0]
+                user_specs = SpecList(name, spec_list, self.read_specs.copy())
+                if name in self.read_specs:
+                    self.read_specs[name].extend(user_specs)
+                else:
+                    self.read_specs[name] = user_specs
+
         spec_list = config_dict(self.yaml).get('specs')
-        if spec_list:
-            self.user_specs = [Spec(s) for s in spec_list if s]
+        user_specs = SpecList('specs', [s for s in spec_list if s],
+                              self.read_specs.copy())
+        self.read_specs['specs'] = user_specs
+
+        enable_view = config_dict(self.yaml).get('view')
+        # enable_view can be boolean, string, or None
+        if enable_view is True or enable_view is None:
+            self._view_path = self.default_view_path
+        elif isinstance(enable_view, six.string_types):
+            self._view_path = enable_view
+        else:
+            self._view_path = None
+
+    @property
+    def user_specs(self):
+        return self.read_specs['specs']
 
         enable_view = config_dict(self.yaml).get('view')
         # enable_view can be true/false, a string, or None (if the manifest did
@@ -452,10 +522,14 @@ class Environment(object):
 
     def _set_user_specs_from_lockfile(self):
         """Copy user_specs from a read-in lockfile."""
-        self.user_specs = [Spec(s) for s in self.concretized_user_specs]
+        self.read_specs = {
+            'specs': SpecList(
+                'specs', [Spec(s) for s in self.concretized_user_specs]
+            )
+        }
 
     def clear(self):
-        self.user_specs = []              # current user specs
+        self.read_specs = {'specs': SpecList()}      # specs read from yaml
         self.concretized_user_specs = []  # user specs from last concretize
         self.concretized_order = []       # roots of last concretize, in order
         self.specs_by_hash = {}           # concretized specs by hash
@@ -578,7 +652,7 @@ class Environment(object):
         """Remove this environment from Spack entirely."""
         shutil.rmtree(self.path)
 
-    def add(self, user_spec):
+    def add(self, user_spec, list_name='specs'):
         """Add a single user_spec (non-concretized) to the Environment
 
         Returns:
@@ -587,47 +661,86 @@ class Environment(object):
 
         """
         spec = Spec(user_spec)
-        if not spec.name:
-            raise SpackEnvironmentError(
-                'cannot add anonymous specs to an environment!')
-        elif not spack.repo.path.exists(spec.name):
-            raise SpackEnvironmentError('no such package: %s' % spec.name)
 
-        existing = set(s for s in self.user_specs if s.name == spec.name)
-        if not existing:
-            self.user_specs.append(spec)
+        if list_name not in self.read_specs:
+            raise SpackEnvironmentError(
+                'No list %s exists in environment %s' % (list_name, self.name)
+            )
+
+        if list_name == 'specs':
+            if not spec.name:
+                raise SpackEnvironmentError(
+                    'cannot add anonymous specs to an environment!')
+            elif not spack.repo.path.exists(spec.name):
+                raise SpackEnvironmentError('no such package: %s' % spec.name)
+
+        added = False
+        existing = False
+        for i, (name, speclist) in enumerate(self.read_specs.items()):
+            # Iterate over all named lists from an OrderedDict()
+            if name == list_name:
+                # We need to modify this list
+                # TODO: Add conditional which reimplements name-level checking
+                existing = str(spec) in speclist.yaml_list
+                if not existing:
+                    speclist.add(str(spec))
+                    added = True
+            elif added:
+                # We've already modified a list, so all later lists need to
+                # have their references updated.
+                new_reference = dict((n, self.read_specs[n])
+                                     for n in list(self.read_specs.keys())[:i])
+                speclist.update_reference(new_reference)
         return bool(not existing)
 
-    def remove(self, query_spec, force=False):
+    def remove(self, query_spec, list_name='specs', force=False):
         """Remove specs from an environment that match a query_spec"""
         query_spec = Spec(query_spec)
 
-        # try abstract specs first
-        matches = []
-        if not query_spec.concrete:
-            matches = [s for s in self.user_specs if s.satisfies(query_spec)]
+        removed = False
+        for i, (name, speclist) in enumerate(self.read_specs.items()):
+            # Iterate over all named lists from an OrderedDict()
+            if name == list_name:
+                # We need to modify this list
+                # try abstract specs first
+                matches = []
 
-        if not matches:
-            # concrete specs match against concrete specs in the env
-            specs_hashes = zip(
-                self.concretized_user_specs, self.concretized_order)
-            matches = [
-                s for s, h in specs_hashes if query_spec.dag_hash() == h]
+                if not query_spec.concrete:
+                    matches = [s for s in speclist if s.satisfies(query_spec)]
 
-        if not matches:
-            raise SpackEnvironmentError("Not found: {0}".format(query_spec))
+                if not matches:
+                    # concrete specs match against concrete specs in the env
+                    specs_hashes = zip(
+                        self.concretized_user_specs, self.concretized_order)
+                    matches = [
+                        s for s, h in specs_hashes
+                        if query_spec.dag_hash() == h
+                    ]
 
-        for spec in matches:
-            if spec in self.user_specs:
-                self.user_specs.remove(spec)
+                if not matches:
+                    raise SpackEnvironmentError(
+                        "Not found: {0}".format(query_spec))
 
-            if force and spec in self.concretized_user_specs:
-                i = self.concretized_user_specs.index(spec)
-                del self.concretized_user_specs[i]
+                for spec in matches:
+                    if spec in speclist:
+                        speclist.remove(spec)
+                        removed = True
 
-                dag_hash = self.concretized_order[i]
-                del self.concretized_order[i]
-                del self.specs_by_hash[dag_hash]
+                    if force and spec in self.concretized_user_specs:
+                        i = self.concretized_user_specs.index(spec)
+                        del self.concretized_user_specs[i]
+
+                        dag_hash = self.concretized_order[i]
+                        del self.concretized_order[i]
+                        del self.specs_by_hash[dag_hash]
+                        removed = True
+
+            elif removed:
+                # We've already modified one list, so all later lists need
+                # their references updated.
+                new_reference = dict((n, self.read_specs[n])
+                                     for n in list(self.read_specs.keys())[:i])
+                speclist.update_reference(new_reference)
 
     def concretize(self, force=False):
         """Concretize user_specs in this environment.
@@ -663,10 +776,11 @@ class Environment(object):
                 self._add_concrete_spec(s, concrete, new=False)
 
         # concretize any new user specs that we haven't concretized yet
-        for uspec in self.user_specs:
+        for uspec, uspec_constraints in zip(
+                self.user_specs, self.user_specs.specs_as_constraints):
             if uspec not in old_concretized_user_specs:
                 tty.msg('Concretizing %s' % uspec)
-                concrete = uspec.concretized()
+                concrete = _concretize_from_constraints(uspec_constraints)
                 self._add_concrete_spec(uspec, concrete)
 
                 # Display concretized spec to the user
@@ -689,7 +803,8 @@ class Environment(object):
             self._add_concrete_spec(spec, concrete)
         else:
             # spec might be in the user_specs, but not installed.
-            spec = next(s for s in self.user_specs if s.name == spec.name)
+            # TODO: Redo name-based comparison for old style envs
+            spec = next(s for s in self.user_specs if s.satisfies(user_spec))
             concrete = self.specs_by_hash.get(spec.dag_hash())
             if not concrete:
                 concrete = spec.concretized()
@@ -1018,10 +1133,16 @@ class Environment(object):
         # invalidate _repo cache
         self._repo = None
 
+        # put any changes in the definitions in the YAML
+        named_speclists = list(self.read_specs.items())
+        for i, (name, speclist) in enumerate(named_speclists[:-1]):
+            conf = config_dict(self.yaml)
+            yaml_list = conf.get('definitions', [])[i].setdefault(name, [])
+            yaml_list[:] = speclist.yaml_list
+
         # put the new user specs in the YAML
-        yaml_dict = config_dict(self.yaml)
-        yaml_spec_list = yaml_dict.setdefault('specs', [])
-        yaml_spec_list[:] = [str(s) for s in self.user_specs]
+        yaml_spec_list = config_dict(self.yaml).setdefault('specs', [])
+        yaml_spec_list[:] = self.user_specs.yaml_list
 
         if self._view_path == self.default_view_path:
             view = True
@@ -1055,6 +1176,48 @@ class Environment(object):
         deactivate()
         if self._previous_active:
             activate(self._previous_active)
+
+
+def _concretize_from_constraints(spec_constraints):
+    # Accept only valid constraints from list and concretize spec
+    # Get the named spec even if out of order
+    root_spec = [s for s in spec_constraints if s.name]
+    if len(root_spec) != 1:
+        m = 'The constraints %s are not a valid spec ' % spec_constraints
+        m += 'concretization target. all specs must have a single name '
+        m += 'constraint for concretization.'
+        raise InvalidSpecConstraintError(m)
+    spec_constraints.remove(root_spec[0])
+
+    invalid_constraints = []
+    while True:
+        # Attach all anonymous constraints to one named spec
+        s = root_spec[0].copy()
+        for c in spec_constraints:
+            if c not in invalid_constraints:
+                s.constrain(c)
+        try:
+            return s.concretized()
+        except spack.spec.InvalidDependencyError as e:
+            dep_index = e.message.index('depend on ') + len('depend on ')
+            invalid_msg = e.message[dep_index:]
+            invalid_deps_string = ['^' + d.strip(',')
+                                   for d in invalid_msg.split()
+                                   if d != 'or']
+            invalid_deps = [c for c in spec_constraints
+                            if any(c.satisfies(invd)
+                                   for invd in invalid_deps_string)]
+            if len(invalid_deps) != len(invalid_deps_string):
+                raise e
+            invalid_constraints.extend(invalid_deps)
+        except UnknownVariantError as e:
+            invalid_variants = re.findall(r"'(\w+)'", e.message)
+            invalid_deps = [c for c in spec_constraints
+                            if any(name in c.variants
+                                   for name in invalid_variants)]
+            if len(invalid_deps) != len(invalid_variants):
+                raise e
+            invalid_constraints.extend(invalid_deps)
 
 
 def make_repo_path(root):

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -397,7 +397,7 @@ def _eval_conditional(string):
         architecture.platform(), 'default_os', 'default_target')
     valid_variables = {
         'target': str(arch.target),
-        'os': str(arch.platform_os),
+        'os': str(arch.os),
         'platform': str(arch.platform),
         'arch': str(arch),
         'architecture': str(arch),
@@ -1204,6 +1204,7 @@ class Environment(object):
         else:
             view = False
 
+        yaml_dict = config_dict(self.yaml)
         if view is not True:
             # The default case is to keep an active view inside of the
             # Spack environment directory. To avoid cluttering the config,

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -210,9 +210,16 @@ class YamlFilesystemView(FilesystemView):
             with open(projections_path, 'w') as f:
                 f.write(s_yaml.dump({'projections': self.projections}))
         else:
-            msg = 'View at %s has projections file' % self._root
-            msg += ' and was passed projections manually.'
-            raise ConflictingProjectionsError(msg)
+            # Ensure projections are the same from each source
+            # Read projections file from view
+            with open(projections_path, 'r') as f:
+                projections_data = s_yaml.load(f)
+                spack.config.validate(projections_data,
+                                      spack.schema.projections.schema)
+                if self.projections != projections_data['projections']:
+                    msg = 'View at %s has projections file' % self._root
+                    msg += ' which does not match projections passed manually.'
+                    raise ConflictingProjectionsError(msg)
 
         self.extensions_layout = YamlViewExtensionsLayout(self, layout)
 

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -96,6 +96,10 @@ schema = {
                                           'root': {
                                               'type': 'string'
                                           },
+                                          'link': {
+                                              'type': 'string',
+                                              'pattern': '(roots|all)',
+                                          },
                                           'select': {
                                               'type': 'array',
                                               'items': {

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -11,7 +11,40 @@
 from llnl.util.lang import union_dicts
 
 import spack.schema.merged
+import spack.schema.projections
 
+
+spec_list_schema = {
+    'type': 'array',
+    'default': [],
+    'items': {
+        'anyOf': [
+            {'type': 'object',
+             'additionalProperties': False,
+             'properties': {
+                 'matrix': {
+                     'type': 'array',
+                     'items': {
+                         'type': 'array',
+                         'items': {
+                             'type': 'string',
+                         }
+                     }
+                 },
+                 'exclude': {
+                     'type': 'array',
+                     'items': {
+                         'type': 'string'
+                     }
+                 }
+             }},
+            {'type': 'string'},
+            {'type': 'null'}
+        ]
+    }
+}
+
+projections_scheme = spack.schema.projections.properties['projections']
 
 schema = {
     '$schema': 'http://json-schema.org/schema#',
@@ -34,22 +67,52 @@ schema = {
                             'type': 'string'
                         },
                     },
-                    'specs': {
-                        # Specs is a list of specs, which can have
-                        # optional additional properties in a sub-dict
-                        'type': 'array',
-                        'default': [],
-                        'additionalProperties': False,
-                        'items': {
-                            'anyOf': [
-                                {'type': 'string'},
-                                {'type': 'null'},
-                                {'type': 'object'},
-                            ]
-                        }
-                    },
                     'view': {
                         'type': ['boolean', 'string']
+                    },
+                    'definitions': {
+                        'type': 'array',
+                        'default': [],
+                        'items': {
+                            'type': 'object',
+                            'properties': {
+                                'when': {
+                                    'type': 'string'
+                                }
+                            },
+                            'patternProperties': {
+                                '^(?!when$)\w*': spec_list_schema
+                            }
+                        }
+                    },
+                    'specs': spec_list_schema,
+                    'view': {
+                        'anyOf': [
+                            {'type': 'boolean'},
+                            {'type': 'string'},
+                            {'type': 'object',
+                             'required': ['root'],
+                             'additionalProperties': False,
+                             'properties': {
+                                 'root': {
+                                     'type': 'string'
+                                 },
+                                 'select': {
+                                     'type': 'array',
+                                     'items': {
+                                         'type': 'string'
+                                     }
+                                 },
+                                 'exclude': {
+                                     'type': 'array',
+                                     'items': {
+                                         'type': 'string'
+                                     }
+                                 },
+                                 'projections': projections_scheme
+                             }
+                            }
+                        ]
                     }
                 }
             )

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -67,9 +67,6 @@ schema = {
                             'type': 'string'
                         },
                     },
-                    'view': {
-                        'type': ['boolean', 'string']
-                    },
                     'definitions': {
                         'type': 'array',
                         'default': [],
@@ -81,7 +78,7 @@ schema = {
                                 }
                             },
                             'patternProperties': {
-                                '^(?!when$)\w*': spec_list_schema
+                               r'^(?!when$)\w*': spec_list_schema
                             }
                         }
                     },
@@ -91,25 +88,29 @@ schema = {
                             {'type': 'boolean'},
                             {'type': 'string'},
                             {'type': 'object',
-                             'required': ['root'],
-                             'additionalProperties': False,
-                             'properties': {
-                                 'root': {
-                                     'type': 'string'
-                                 },
-                                 'select': {
-                                     'type': 'array',
-                                     'items': {
-                                         'type': 'string'
-                                     }
-                                 },
-                                 'exclude': {
-                                     'type': 'array',
-                                     'items': {
-                                         'type': 'string'
-                                     }
-                                 },
-                                 'projections': projections_scheme
+                             'patternProperties': {
+                                  r'\w+': {
+                                      'required': ['root'],
+                                      'additionalProperties': False,
+                                      'properties': {
+                                          'root': {
+                                              'type': 'string'
+                                          },
+                                          'select': {
+                                              'type': 'array',
+                                              'items': {
+                                                  'type': 'string'
+                                              }
+                                          },
+                                          'exclude': {
+                                              'type': 'array',
+                                              'items': {
+                                                  'type': 'string'
+                                              }
+                                        },
+                                          'projections': projections_scheme
+                                      }
+                                  }
                              }
                             }
                         ]

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2494,7 +2494,7 @@ class Spec(object):
         """Apply constraints of other spec's dependencies to this spec."""
         other = self._autospec(other)
 
-        if not self._dependencies or not other._dependencies:
+        if not other._dependencies:
             return False
 
         # TODO: might want more detail than this, e.g. specific deps

--- a/lib/spack/spack/spec_list.py
+++ b/lib/spack/spack/spec_list.py
@@ -136,7 +136,7 @@ class SpecList(object):
                         return ret
                     else:
                         msg = 'SpecList %s refers to ' % self.name
-                        msg = 'named list %s ' % name
+                        msg += 'named list %s ' % name
                         msg += 'which does not appear in its reference dict'
                         raise UndefinedReferenceError(msg)
             # No references in this

--- a/lib/spack/spack/spec_list.py
+++ b/lib/spack/spack/spec_list.py
@@ -1,0 +1,168 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import itertools
+from six import string_types
+
+from spack.spec import Spec
+from spack.error import SpackError
+
+
+def spec_ordering_key(s):
+    if s.startswith('^'):
+        return 5
+    elif s.startswith('/'):
+        return 4
+    elif s.startswith('%'):
+        return 3
+    elif any(s.startswith(c) for c in '~-+@') or '=' in s:
+        return 2
+    else:
+        return 1
+
+
+class SpecList(object):
+
+    def __init__(self, name='specs', yaml_list=[], reference={}):
+        self.name = name
+        self._reference = reference  # TODO: Do we need defensive copy here?
+
+        self.yaml_list = yaml_list[:]
+
+        # Expansions can be expensive to compute and difficult to keep updated
+        # We cache results and invalidate when self.yaml_list changes
+        self._expanded_list = None
+        self._constraints = None
+        self._specs = None
+
+    @property
+    def specs_as_yaml_list(self):
+        if self._expanded_list is None:
+            self._expanded_list = self._expand_references(self.yaml_list)
+        return self._expanded_list
+
+    @property
+    def specs_as_constraints(self):
+        if self._constraints is None:
+            constraints = []
+            for item in self.specs_as_yaml_list:
+                if isinstance(item, dict):  # matrix of specs
+                    excludes = item.get('exclude', [])
+                    for combo in itertools.product(*(item['matrix'])):
+                        # Test against the excludes using a single spec
+                        ordered_combo = sorted(combo, key=spec_ordering_key)
+                        test_spec = Spec(' '.join(ordered_combo))
+                        if any(test_spec.satisfies(x) for x in excludes):
+                            continue
+
+                        # Add as list of constraints
+                        constraints.append([Spec(x) for x in ordered_combo])
+                else:  # individual spec
+                    constraints.append([Spec(item)])
+            self._constraints = constraints
+
+        return self._constraints
+
+    @property
+    def specs(self):
+        if self._specs is None:
+            specs = []
+            # This could be slightly faster done directly from yaml_list,
+            # but this way is easier to maintain.
+            for constraint_list in self.specs_as_constraints:
+                spec = constraint_list[0].copy()
+                for const in constraint_list[1:]:
+                    spec.constrain(const)
+                specs.append(spec)
+            self._specs = specs
+
+        return self._specs
+
+    def add(self, spec):
+        self.yaml_list.append(str(spec))
+
+        # expanded list can be updated without invalidation
+        if self._expanded_list is not None:
+            self._expanded_list.append(str(spec))
+
+        # Invalidate cache variables when we change the list
+        self._constraints = None
+        self._specs = None
+
+    def remove(self, spec):
+        # Get spec to remove from list
+        remove = [s for s in self.yaml_list
+                  if (isinstance(s, string_types) and not s.startswith('$'))
+                  and Spec(s) == Spec(spec)]
+        if not remove:
+            msg = 'Cannot remove %s from SpecList %s\n' % (spec, self.name)
+            msg += 'Either %s is not in %s or %s is ' % (spec, self.name, spec)
+            msg += 'expanded from a matrix and cannot be removed directly.'
+            raise SpecListError(msg)
+        assert len(remove) == 1
+        self.yaml_list.remove(remove[0])
+
+        # invalidate cache variables when we change the list
+        self._expanded_list = None
+        self._constraints = None
+        self._specs = None
+
+    def extend(self, other, copy_reference=True):
+        self.yaml_list.extend(other.yaml_list)
+        self._expanded_list = None
+        self._constraints = None
+        self._specs = None
+
+        if copy_reference:
+            self._reference = other._reference
+
+    def update_reference(self, reference):
+        self._reference = reference
+        self._expanded_list = None
+        self._constraints = None
+        self._specs = None
+
+    def _expand_references(self, yaml):
+        if isinstance(yaml, list):
+            for idx, item in enumerate(yaml):
+                if isinstance(item, string_types) and item.startswith('$'):
+                    name = item[1:]
+                    if name in self._reference:
+                        ret = [self._expand_references(i) for i in yaml[:idx]]
+                        ret += self._reference[name].specs_as_yaml_list
+                        ret += [self._expand_references(i)
+                                for i in yaml[idx + 1:]]
+                        return ret
+                    else:
+                        msg = 'SpecList %s refers to ' % self.name
+                        msg = 'named list %s ' % name
+                        msg += 'which does not appear in its reference dict'
+                        raise UndefinedReferenceError(msg)
+            # No references in this
+            return [self._expand_references(item) for item in yaml]
+        elif isinstance(yaml, dict):
+            # There can't be expansions in dicts
+            return dict((name, self._expand_references(val))
+                        for (name, val) in yaml.items())
+        else:
+            # Strings are just returned
+            return yaml
+
+    def __len__(self):
+        return len(self.specs)
+
+    def __getitem__(self, key):
+        return self.specs[key]
+
+
+class SpecListError(SpackError):
+    """Error class for all errors related to SpecList objects."""
+
+
+class UndefinedReferenceError(SpecListError):
+    """Error class for undefined references in Spack stacks."""
+
+
+class InvalidSpecConstraintError(SpecListError):
+    """Error class for invalid spec constraints at concretize time."""

--- a/lib/spack/spack/spec_list.py
+++ b/lib/spack/spack/spec_list.py
@@ -131,8 +131,7 @@ class SpecList(object):
                     if name in self._reference:
                         ret = [self._expand_references(i) for i in yaml[:idx]]
                         ret += self._reference[name].specs_as_yaml_list
-                        ret += [self._expand_references(i)
-                                for i in yaml[idx + 1:]]
+                        ret += self._expand_references(yaml[idx + 1:])
                         return ret
                     else:
                         msg = 'SpecList %s refers to ' % self.name

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -827,6 +827,33 @@ env:
         assert Spec('callpath') in test.user_specs
 
 
+def test_stack_yaml_remove_from_list_force(tmpdir):
+    filename = str(tmpdir.join('spack.yaml'))
+    with open(filename, 'w') as f:
+        f.write("""\
+env:
+  definitions:
+    - packages: [mpileaks, callpath]
+  specs:
+    - matrix:
+        - [$packages]
+        - [^mpich, ^zmpi]
+""")
+    with tmpdir.as_cwd():
+        env('create', 'test', './spack.yaml')
+        with ev.read('test'):
+            concretize()
+            remove('-f', '-l', 'packages', 'mpileaks')
+            find_output = find('-c')
+
+        print find_output
+        assert False
+        test = ev.read('test')
+
+        assert Spec('mpileaks') not in test.user_specs
+        assert Spec('callpath') in test.user_specs
+
+
 def test_stack_yaml_attempt_remove_from_matrix(tmpdir):
     filename = str(tmpdir.join('spack.yaml'))
     with open(filename, 'w') as f:

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1116,7 +1116,7 @@ env:
     combinatorial:
       root: %s
       projections:
-        'all': '${package}/${version}-${compilername}'""" % viewdir)
+        'all': '{name}/{version}-{compiler.name}'""" % viewdir)
     with tmpdir.as_cwd():
         env('create', 'test', './spack.yaml')
         with ev.read('test'):
@@ -1149,7 +1149,7 @@ env:
       root: %s
       select: ['%%gcc']
       projections:
-        'all': '${package}/${version}-${compilername}'""" % viewdir)
+        'all': '{name}/{version}-{compiler.name}'""" % viewdir)
     with tmpdir.as_cwd():
         env('create', 'test', './spack.yaml')
         with ev.read('test'):
@@ -1187,7 +1187,7 @@ env:
       root: %s
       exclude: [callpath]
       projections:
-        'all': '${package}/${version}-${compilername}'""" % viewdir)
+        'all': '{name}/{version}-{compiler.name}'""" % viewdir)
     with tmpdir.as_cwd():
         env('create', 'test', './spack.yaml')
         with ev.read('test'):
@@ -1226,7 +1226,7 @@ env:
       select: ['%%gcc']
       exclude: [callpath]
       projections:
-        'all': '${package}/${version}-${compilername}'""" % viewdir)
+        'all': '{name}/{version}-{compiler.name}'""" % viewdir)
     with tmpdir.as_cwd():
         env('create', 'test', './spack.yaml')
         with ev.read('test'):
@@ -1330,8 +1330,8 @@ env:
       root: %s
       exclude: [callpath %%gcc]
       projections:
-        'all': '${package}/${version}-${compilername}'""" % (default_viewdir,
-                                                             combin_viewdir))
+        'all': '{name}/{version}-{compiler.name}'""" % (default_viewdir,
+                                                        combin_viewdir))
     with tmpdir.as_cwd():
         env('create', 'test', './spack.yaml')
         with ev.read('test'):

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -675,7 +675,7 @@ env:
 
     e = ev.read('test')
     # Try retrieving the view object
-    view = e.default_view
+    view = e.default_view.view()
     assert view.get_spec('mpileaks')
 
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -846,12 +846,12 @@ env:
             remove('-f', '-l', 'packages', 'mpileaks')
             find_output = find('-c')
 
-        print find_output
-        assert False
-        test = ev.read('test')
+        assert 'mpileaks' not in find_output
 
-        assert Spec('mpileaks') not in test.user_specs
-        assert Spec('callpath') in test.user_specs
+        test = ev.read('test')
+        assert len(test.user_specs) == 2
+        assert Spec('callpath ^zmpi') in test.user_specs
+        assert Spec('callpath ^mpich') in test.user_specs
 
 
 def test_stack_yaml_attempt_remove_from_matrix(tmpdir):

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -15,6 +15,7 @@ from spack.spec import Spec, CompilerSpec
 from spack.spec import ConflictsInSpecError, SpecError
 from spack.version import ver
 from spack.test.conftest import MockPackage, MockPackageMultiRepo
+import spack.compilers
 
 
 def check_spec(abstract, concrete):

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -109,6 +109,18 @@ def no_chdir():
         assert os.getcwd() == original_wd
 
 
+@pytest.fixture(scope='function', autouse=True)
+def reset_compiler_cache():
+    """Ensure that the compiler cache is not shared across Spack tests
+
+    This cache can cause later tests to fail if left in a state incompatible
+    with the new configuration. Since tests can make almost unlimited changes
+    to their setup, default to not use the compiler cache across tests."""
+    spack.compilers._compiler_cache = {}
+    yield
+    spack.compilers._compiler_cache = {}
+
+
 @pytest.fixture(scope='session', autouse=True)
 def mock_stage(tmpdir_factory):
     """Mocks up a fake stage directory for use by tests."""

--- a/lib/spack/spack/test/spec_list.py
+++ b/lib/spack/spack/test/spec_list.py
@@ -1,0 +1,144 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.spec_list import SpecList
+from spack.spec import Spec
+
+
+class TestSpecList(object):
+    default_input = ['mpileaks', '$mpis',
+                     {'matrix': [['hypre'], ['$gccs', '%clang@3.3']]},
+                     'libelf']
+
+    default_reference = {'gccs': SpecList('gccs', ['%gcc@4.5.0']),
+                         'mpis': SpecList('mpis', ['zmpi@1.0', 'mpich@3.0'])}
+
+    default_expansion = ['mpileaks', 'zmpi@1.0', 'mpich@3.0',
+                         {'matrix': [
+                             ['hypre'],
+                             ['%gcc@4.5.0', '%clang@3.3'],
+                         ]},
+                         'libelf']
+
+    default_constraints = [[Spec('mpileaks')],
+                           [Spec('zmpi@1.0')],
+                           [Spec('mpich@3.0')],
+                           [Spec('hypre'), Spec('%gcc@4.5.0')],
+                           [Spec('hypre'), Spec('%clang@3.3')],
+                           [Spec('libelf')]]
+
+    default_specs = [Spec('mpileaks'), Spec('zmpi@1.0'),
+                     Spec('mpich@3.0'), Spec('hypre%gcc@4.5.0'),
+                     Spec('hypre%clang@3.3'), Spec('libelf')]
+
+    def test_spec_list_expansions(self):
+        speclist = SpecList('specs', self.default_input,
+                            self.default_reference)
+
+        assert speclist.specs_as_yaml_list == self.default_expansion
+        assert speclist.specs_as_constraints == self.default_constraints
+        assert speclist.specs == self.default_specs
+
+    def test_spec_list_constraint_ordering(self):
+        specs = [{'matrix': [
+            ['^zmpi'],
+            ['%gcc@4.5.0'],
+            ['hypre', 'libelf'],
+            ['~shared'],
+            ['cflags=-O3', 'cflags="-g -O0"'],
+            ['^foo']
+        ]}]
+
+        speclist = SpecList('specs', specs)
+
+        expected_specs = [
+            Spec('hypre cflags=-O3 ~shared %gcc@4.5.0 ^foo ^zmpi'),
+            Spec('hypre cflags="-g -O0" ~shared %gcc@4.5.0 ^foo ^zmpi'),
+            Spec('libelf cflags=-O3 ~shared %gcc@4.5.0 ^foo ^zmpi'),
+            Spec('libelf cflags="-g -O0" ~shared %gcc@4.5.0 ^foo ^zmpi'),
+        ]
+        assert speclist.specs == expected_specs
+
+    def test_spec_list_add(self):
+        speclist = SpecList('specs', self.default_input,
+                            self.default_reference)
+
+        assert speclist.specs_as_yaml_list == self.default_expansion
+        assert speclist.specs_as_constraints == self.default_constraints
+        assert speclist.specs == self.default_specs
+
+        speclist.add('libdwarf')
+
+        assert speclist.specs_as_yaml_list == self.default_expansion + [
+            'libdwarf']
+        assert speclist.specs_as_constraints == self.default_constraints + [
+            [Spec('libdwarf')]]
+        assert speclist.specs == self.default_specs + [Spec('libdwarf')]
+
+    def test_spec_list_remove(self):
+        speclist = SpecList('specs', self.default_input,
+                            self.default_reference)
+
+        assert speclist.specs_as_yaml_list == self.default_expansion
+        assert speclist.specs_as_constraints == self.default_constraints
+        assert speclist.specs == self.default_specs
+
+        speclist.remove('libelf')
+
+        assert speclist.specs_as_yaml_list + [
+            'libelf'
+        ] == self.default_expansion
+
+        assert speclist.specs_as_constraints + [
+            [Spec('libelf')]
+        ] == self.default_constraints
+
+        assert speclist.specs + [Spec('libelf')] == self.default_specs
+
+    def test_spec_list_update_reference(self):
+        speclist = SpecList('specs', self.default_input,
+                            self.default_reference)
+
+        assert speclist.specs_as_yaml_list == self.default_expansion
+        assert speclist.specs_as_constraints == self.default_constraints
+        assert speclist.specs == self.default_specs
+
+        new_mpis = SpecList('mpis', self.default_reference['mpis'].yaml_list)
+        new_mpis.add('mpich@3.3')
+        new_reference = self.default_reference.copy()
+        new_reference['mpis'] = new_mpis
+
+        speclist.update_reference(new_reference)
+
+        expansion = list(self.default_expansion)
+        expansion.insert(3, 'mpich@3.3')
+        constraints = list(self.default_constraints)
+        constraints.insert(3, [Spec('mpich@3.3')])
+        specs = list(self.default_specs)
+        specs.insert(3, Spec('mpich@3.3'))
+
+        assert speclist.specs_as_yaml_list == expansion
+        assert speclist.specs_as_constraints == constraints
+        assert speclist.specs == specs
+
+    def test_spec_list_extension(self):
+        speclist = SpecList('specs', self.default_input,
+                            self.default_reference)
+
+        assert speclist.specs_as_yaml_list == self.default_expansion
+        assert speclist.specs_as_constraints == self.default_constraints
+        assert speclist.specs == self.default_specs
+
+        new_ref = self.default_reference.copy()
+        otherlist = SpecList('specs',
+                             ['zlib', {'matrix': [['callpath'],
+                                                  ['%intel@18']]}],
+                             new_ref)
+
+        speclist.extend(otherlist)
+
+        assert speclist.specs_as_yaml_list == (self.default_expansion +
+                                               otherlist.specs_as_yaml_list)
+        assert speclist.specs == self.default_specs + otherlist.specs
+        assert speclist._reference is new_ref

--- a/lib/spack/spack/test/spec_list.py
+++ b/lib/spack/spack/test/spec_list.py
@@ -8,10 +8,11 @@ from spack.spec import Spec
 
 class TestSpecList(object):
     default_input = ['mpileaks', '$mpis',
-                     {'matrix': [['hypre'], ['$gccs', '%clang@3.3']]},
+                     {'matrix': [['hypre'], ['$gccs', '$clangs']]},
                      'libelf']
 
     default_reference = {'gccs': SpecList('gccs', ['%gcc@4.5.0']),
+                         'clangs': SpecList('clangs', ['%clang@3.3']),
                          'mpis': SpecList('mpis', ['zmpi@1.0', 'mpich@3.0'])}
 
     default_expansion = ['mpileaks', 'zmpi@1.0', 'mpich@3.0',

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -695,6 +695,7 @@ class TestSpecSematics(object):
         check_constrain_changed('libelf^foo%gcc', 'libelf^foo%gcc@4.5')
         check_constrain_changed('libelf^foo', 'libelf^foo+debug')
         check_constrain_changed('libelf^foo', 'libelf^foo~debug')
+        check_constrain_changed('libelf', '^foo')
 
         platform = spack.architecture.platform()
         default_target = platform.target('default_target').name

--- a/var/spack/repos/builtin.mock/packages/mpich/package.py
+++ b/var/spack/repos/builtin.mock/packages/mpich/package.py
@@ -28,4 +28,4 @@ class Mpich(Package):
     provides('mpi@:1', when='@:1')
 
     def install(self, spec, prefix):
-        pass
+        touch(prefix.mpich)

--- a/var/spack/repos/builtin.mock/packages/mpileaks/package.py
+++ b/var/spack/repos/builtin.mock/packages/mpileaks/package.py
@@ -27,7 +27,7 @@ class Mpileaks(Package):
     libs = None
 
     def install(self, spec, prefix):
-        pass
+        touch(prefix.mpileaks)
 
     def setup_environment(self, senv, renv):
         renv.set('FOOBAR', self.name)


### PR DESCRIPTION
Resolves #8835

This PR requires an update after #10017 is merged. I've marked WIP for now.

Allow users to specify combinatorial sets of packages for Environments.

This feature is aimed at facilities deployment people, to enable Spack usage at the facility level.

From the documentation (with only slight formatting changes):

"
Entries in the ``specs`` list can be individual abstract specs or a
spec matrix.

A spec matrix is a yaml object containing multiple lists of specs, and
evaluates to the cross-product of those specs. Spec matrices also
contain an ``excludes`` directive, which eliminates certain
combinations from the evaluated result.

The following two Environment manifests are identical:

```yaml
spack:
  specs:
    - zlib %gcc@7.1.0
    - zlib %gcc@4.9.3
    - libelf %gcc@7.1.0
    - libelf %gcc@4.9.3
    - libdwarf %gcc@7.1.0
    - cmake
```
```yaml
spack:
  specs:
    - matrix:
        - [zlib, libelf, libdwarf]
        - ['%gcc@7.1.0', '%gcc@4.9.3']
      exclude:
        - libdwarf%gcc@4.9.3
    - cmake
```

Spec matrices can be used to install swaths of software across various
toolchains.

The concretization logic for spec matrices differs slightly from the
rest of Spack. If a variant or dependency constraint from a matrix is
invalid, Spack will reject the constraint and try again without
it. For example, the following two Environment manifests will produce
the same specs:

```yaml
spack:
  specs:
    - matrix:
        - [zlib, libelf, hdf5+mpi]
        - [^mvapich2@2.2, ^openmpi@3.1.0]
```
```yaml
spack:
  specs:
    - zlib
    - libelf
    - hdf5+mpi ^mvapich2@2.2
    - hdf5+mpi ^openmpi@3.1.0
```

This allows one to create toolchains out of combinations of
constraints and apply them somewhat indiscriminantly to packages,
without regard for the applicability of the constraint.

The last type of possible entry in the specs list is a reference.

The Spack Environment manifest yaml schema contains an additional
heading ``definitions``. Under definitions is an array of yaml
objects. Each object has one or two fields. The one required field is
a name, and the optional field is a ``when`` clause.

The named field is a spec list. The spec list uses the same syntax as
the ``specs`` entry. Each entry in the spec list can be a spec, a spec
matrix, or a reference to an earlier named list. References are
specified using the ``$`` sigil, and are "splatted" into place
(i.e. the elements of the referent are at the same level as the
elements listed separately). As an example, the following two manifest
files are identical.

```yaml
spack:
  definitions:
    - first: [libelf, libdwarf]
    - compilers: ['%gcc', '%intel']
    - second:
        - $first
        - matrix:
            - [zlib]
            - [$compilers]
  specs:
    - $second
    - cmake
```
```yaml
spack:
  specs:
    - libelf
    - libdwarf
    - zlib%gcc
    - zlib%intel
    - cmake
```

N.B. Named a spec list in the definitions section may only refer
   to a named list defined above itself. Order matters.

In short files like the example, it may be easier to simply list the
included specs. However for more complicated examples involving many
packages across many toolchains, separately factored lists make
Environments substantially more manageable.

Additionally, the ``-l`` option to the ``spack add`` command allows
one to add to named lists in the definitions section of the manifest
file directly from the command line.

The ``when`` directive can be used to conditionally add specs to a
named list. The ``when`` directive takes a string of python code
referring to a restricted set of variables, and evaluates to a
boolean. The specs listed are appended to the named list if the
``when`` string evaluates to ``True``. In the following snippet, the
named list ``compilers`` is ``['%gcc', '%clang', '%intel']`` on
``x86_64`` systems and ``['%gcc', '%clang']`` on all other systems.

```yaml
spack:
  definitions:
    - compilers: ['%gcc', '%clang']
    - when: spack_target == 'x64_64'
      compilers: ['%intel']
```
  N.B. Any definitions with the same named list with true ``when``
   clauses (or absent ``when`` clauses) will be appended together

The valid variables for a ``when`` clause are:

1. ``spack_platform``. The platform string of the default Spack architecture on the system. 

2. ``spack_os``. The os string of the default Spack architecture on the system.

3.  ``spack_target``. The target string of the default Spack architecture on the system.

4.  ``spack_architecture`` or ``spack_arch``. The full string of the default Spack architecture on the system.

5. ``re``. The standard regex module in python.

6. ``env``. The user environment (usually ``os.environ`` in python).
 
7.  ``hostname``. The hostname of the system (if ``hostname`` is an executable in the user's PATH).
"