### PR TITLE
Add stub mpirun script for openmpi~legacylaunchers+slurm

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/nolegacylaunchers.sh
+++ b/var/spack/repos/builtin/packages/openmpi/nolegacylaunchers.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+echo "This version of Spack (openmpi ~legacylaunchers schedulers=slurm) "
+echo "is installed without the mpiexec/mpirun commands to prevent "
+echo "unintended performance issues. See https://github.com/spack/spack/pull/10340 "
+echo "for more details."
+echo "If you understand the potential consequences of a misconfigured `mpirun`, you can"
+echo "use spack to install `openmpi+legacylaunchers` to restore the executables."
+echo "Otherwise, use `srun` to launch your MPI executables."
+exit 2

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -484,8 +484,12 @@ class Openmpi(AutotoolsPackage):
                         self.prefix.bin.shmemrun,
                         self.prefix.bin.oshrun
                         ]
+            script_stub = join_path(os.path.dirname(__file__),
+                                    "nolegacylaunchers.sh")
             for exe in exe_list:
                 try:
                     os.remove(exe)
                 except OSError:
                     tty.debug("File not present: " + exe)
+                else:
+                    copy(script_stub, exe)


### PR DESCRIPTION
This adds a stub script for `mpirun` and other standard executables when installing OpenMPI with slurm. The purpose is to make the removal less of a surprise to administrators/users: it explains why they were removed and how to restore them.

See discussion on https://github.com/spack/spack/pull/10340 @alalazo 