### PR TITLE
Adding Tpetra_INST_INT_LONG_LONG to Trilinos explicit_instantiation variant

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -701,6 +701,7 @@ class Trilinos(CMakePackage):
             options.extend([
                 '-DTpetra_INST_DOUBLE:BOOL=ON',
                 '-DTpetra_INST_INT_LONG:BOOL=ON',
+                '-DTpetra_INST_INT_LONG_LONG:BOOL=ON',
                 '-DTpetra_INST_COMPLEX_DOUBLE=%s' % complex_s,
                 '-DTpetra_INST_COMPLEX_FLOAT=%s' % complex_float_s,
                 '-DTpetra_INST_FLOAT=%s' % float_s,


### PR DESCRIPTION
This is a new instantiation option that appears to be required for STK to give 64 bit integers to Zoltan which goes through Tpetra.