### PR TITLE
modules.yaml: Set LD_RUN_PATH

### DIFF
--- a/etc/spack/defaults/linux/modules.yaml
+++ b/etc/spack/defaults/linux/modules.yaml
@@ -17,5 +17,7 @@ modules:
   prefix_inspections:
     lib:
       - LD_LIBRARY_PATH
+      - LD_RUN_PATH
     lib64:
       - LD_LIBRARY_PATH
+      - LD_RUN_PATH


### PR DESCRIPTION
binutils's linker supports setting rpath via `LD_RUN_PATH`, which is useful when building software outside of Spack. For instance, an application linked against a library provided by a Spack package might use a system library or not find the library at all if users forget to load the module again before executing the application.