### PR TITLE
New Packages: ecp-io-sdk and ecp-viz-sdk

### DIFF
--- a/var/spack/repos/builtin/packages/ecp-io-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-io-sdk/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class EcpIoSdk(CMakePackage):
+    """ECP I/O Services SDK"""
+
+    homepage = "https://github.com/chuckatkins/ecp-data-viz-sdk"
+    git      = "https://github.com/chuckatkins/ecp-data-viz-sdk.git"
+
+    version('1.0', branch='master')
+
+    # FIXME: Add dependencies if required.
+    # depends_on('foo')
+
+    def cmake_args(self):
+        return [ '-DIO=ON' ]

--- a/var/spack/repos/builtin/packages/ecp-io-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-io-sdk/package.py
@@ -14,8 +14,24 @@ class EcpIoSdk(CMakePackage):
 
     version('1.0', branch='master')
 
-    # FIXME: Add dependencies if required.
-    # depends_on('foo')
+    variant('hdf5', default=False, description="Enable HDF5")
+    variant('adios2', default=False, description="Enable ADIOS2")
+    variant('pnetcdf', default=False, description="Enable PNetCDF")
+    variant('veloc', default=False, description="Enable VeloC")
+    variant('unifycr', default=False, description="Enable UnifyCR")
+    variant('darshan', default=False, description="Enable Darshan")
+    variant('mercury', default=False, description="Enable Mercury")
+    #variant('romio', default=False, description="Enable ROMIO")
+    #variant('faodel', default=False, description="Enable FAODEL")
+
+    depends_on('hdf5', when='+hdf5')
+    depends_on('adios2', when='+adios2')
+    depends_on('parallel-netcdf', when='+pnetcdf')
+    depends_on('veloc', when='+veloc')
+    depends_on('unifycr', when='+unifycr')
+    depends_on('darshan-runtime', when='+darshan')
+    depends_on('darshan-util', when='+darshan')
+    depends_on('mercury', when='+mercury')
 
     def cmake_args(self):
         return [ '-DIO=ON' ]

--- a/var/spack/repos/builtin/packages/ecp-io-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-io-sdk/package.py
@@ -23,14 +23,14 @@ class EcpIoSdk(CMakePackage):
     variant('mercury', default=True, description="Enable Mercury")
 
     # Broken dependency: boost
-    #variant('veloc', default=False, description="Enable VeloC")
+    # variant('veloc', default=False, description="Enable VeloC")
 
     # Missing dependency: margo
-    #variant('unifycr', default=False, description="Enable UnifyCR")
+    # variant('unifycr', default=False, description="Enable UnifyCR")
 
     # Currently no spack packages
-    #variant('romio', default=False, description="Enable ROMIO")
-    #variant('faodel', default=False, description="Enable FAODEL")
+    # variant('romio', default=False, description="Enable ROMIO")
+    # variant('faodel', default=False, description="Enable FAODEL")
 
     depends_on('hdf5', when='+hdf5')
     depends_on('adios2', when='+adios2')
@@ -42,4 +42,4 @@ class EcpIoSdk(CMakePackage):
     depends_on('mercury', when='+mercury')
 
     def cmake_args(self):
-        return [ '-DIO=ON' ]
+        return ['-DIO=ON']

--- a/var/spack/repos/builtin/packages/ecp-io-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-io-sdk/package.py
@@ -16,11 +16,11 @@ class EcpIoSdk(CMakePackage):
 
     version('1.0', branch='master')
 
-    variant('hdf5', default=False, description="Enable HDF5")
-    variant('adios2', default=False, description="Enable ADIOS2")
-    variant('pnetcdf', default=False, description="Enable PNetCDF")
-    variant('darshan', default=False, description="Enable Darshan")
-    variant('mercury', default=False, description="Enable Mercury")
+    variant('hdf5', default=True, description="Enable HDF5")
+    variant('adios2', default=True, description="Enable ADIOS2")
+    variant('pnetcdf', default=True, description="Enable PNetCDF")
+    variant('darshan', default=True, description="Enable Darshan")
+    variant('mercury', default=True, description="Enable Mercury")
 
     # Broken dependency: boost
     #variant('veloc', default=False, description="Enable VeloC")

--- a/var/spack/repos/builtin/packages/ecp-io-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-io-sdk/package.py
@@ -12,6 +12,8 @@ class EcpIoSdk(CMakePackage):
     homepage = "https://github.com/chuckatkins/ecp-data-viz-sdk"
     git      = "https://github.com/chuckatkins/ecp-data-viz-sdk.git"
 
+    maintainers = ['chuckatkins']
+
     version('1.0', branch='master')
 
     variant('hdf5', default=False, description="Enable HDF5")

--- a/var/spack/repos/builtin/packages/ecp-io-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-io-sdk/package.py
@@ -17,10 +17,16 @@ class EcpIoSdk(CMakePackage):
     variant('hdf5', default=False, description="Enable HDF5")
     variant('adios2', default=False, description="Enable ADIOS2")
     variant('pnetcdf', default=False, description="Enable PNetCDF")
-    variant('veloc', default=False, description="Enable VeloC")
-    variant('unifycr', default=False, description="Enable UnifyCR")
     variant('darshan', default=False, description="Enable Darshan")
     variant('mercury', default=False, description="Enable Mercury")
+
+    # Broken dependency: boost
+    #variant('veloc', default=False, description="Enable VeloC")
+
+    # Missing dependency: margo
+    #variant('unifycr', default=False, description="Enable UnifyCR")
+
+    # Currently no spack packages
     #variant('romio', default=False, description="Enable ROMIO")
     #variant('faodel', default=False, description="Enable FAODEL")
 

--- a/var/spack/repos/builtin/packages/ecp-vis-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-vis-sdk/package.py
@@ -15,19 +15,26 @@ class EcpVisSdk(CMakePackage):
     version('1.0', branch='master')
 
     variant('paraview', default=False, description="Enable ParaView")
-    variant('catalyst', default=False, description="Enable Catalyst")
-    variant('cinema', default=False, description="Enable Cinema")
-    variant('vtk-m', default=False, description="Enable VTK-m")
-    variant('ascent', default=False, description="Enable Ascent")
-    variant('visit', default=False, description="Enable VisIt")
+    variant('vtkm', default=False, description="Enable VTK-m")
     variant('zfp', default=False, description="Enable ZFP")
     variant('sz', default=False, description="Enable SZ")
+
+    # TODO: fix +osmesa~rendering conflict
+    variant('catalyst', default=False, description="Enable Catalyst")
+
+    # Unsatisfiable dependencies: hdf5 and netcdf
+    # variant('visit', default=False, description="Enable VisIt")
+
+    # Broken dependency: vtk-h
+    # variant('ascent', default=False, description="Enable Ascent")
+
+    # Missing spack package
+    #variant('cinema', default=False, description="Enable Cinema")
     #variant('rover', default=False, description="Enable ROVER")
 
     depends_on('paraview', when='+paraview')
     depends_on('catalyst', when='+catalyst')
-    depends_on('cinema', when='+cinema')
-    depends_on('vtk-m', when='+vtk-m')
+    depends_on('vtkm', when='+vtkm')
     depends_on('ascent', when='+ascent')
     depends_on('visit', when='+visit')
     depends_on('zfp', when='+zfp')

--- a/var/spack/repos/builtin/packages/ecp-vis-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-vis-sdk/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class EcpVisSdk(CMakePackage):
+    """ECP Vis & Analysis SDK"""
+
+    homepage = "https://github.com/chuckatkins/ecp-data-viz-sdk"
+    git      = "https://github.com/chuckatkins/ecp-data-viz-sdk.git"
+
+    version('1.0', branch='master')
+
+    # FIXME: Add dependencies if required.
+    # depends_on('foo')
+
+    def cmake_args(self):
+        return [ '-DVIS=ON' ]

--- a/var/spack/repos/builtin/packages/ecp-vis-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-vis-sdk/package.py
@@ -14,8 +14,24 @@ class EcpVisSdk(CMakePackage):
 
     version('1.0', branch='master')
 
-    # FIXME: Add dependencies if required.
-    # depends_on('foo')
+    variant('paraview', default=False, description="Enable ParaView")
+    variant('catalyst', default=False, description="Enable Catalyst")
+    variant('cinema', default=False, description="Enable Cinema")
+    variant('vtk-m', default=False, description="Enable VTK-m")
+    variant('ascent', default=False, description="Enable Ascent")
+    variant('visit', default=False, description="Enable VisIt")
+    variant('zfp', default=False, description="Enable ZFP")
+    variant('sz', default=False, description="Enable SZ")
+    #variant('rover', default=False, description="Enable ROVER")
+
+    depends_on('paraview', when='+paraview')
+    depends_on('catalyst', when='+catalyst')
+    depends_on('cinema', when='+cinema')
+    depends_on('vtk-m', when='+vtk-m')
+    depends_on('ascent', when='+ascent')
+    depends_on('visit', when='+visit')
+    depends_on('zfp', when='+zfp')
+    depends_on('sz', when='+sz')
 
     def cmake_args(self):
         return [ '-DVIS=ON' ]

--- a/var/spack/repos/builtin/packages/ecp-viz-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-viz-sdk/package.py
@@ -31,8 +31,8 @@ class EcpVizSdk(CMakePackage):
     # variant('ascent', default=False, description="Enable Ascent")
 
     # Missing spack package
-    #variant('cinema', default=False, description="Enable Cinema")
-    #variant('rover', default=False, description="Enable ROVER")
+    # variant('cinema', default=False, description="Enable Cinema")
+    # variant('rover', default=False, description="Enable ROVER")
 
     depends_on('paraview', when='+paraview')
     depends_on('catalyst', when='+catalyst')
@@ -43,4 +43,4 @@ class EcpVizSdk(CMakePackage):
     depends_on('sz', when='+sz')
 
     def cmake_args(self):
-        return [ '-DVIZ=ON' ]
+        return ['-DVIZ=ON']

--- a/var/spack/repos/builtin/packages/ecp-viz-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-viz-sdk/package.py
@@ -6,8 +6,8 @@
 from spack import *
 
 
-class EcpVisSdk(CMakePackage):
-    """ECP Vis & Analysis SDK"""
+class EcpVizSdk(CMakePackage):
+    """ECP Viz & Analysis SDK"""
 
     homepage = "https://github.com/chuckatkins/ecp-data-viz-sdk"
     git      = "https://github.com/chuckatkins/ecp-data-viz-sdk.git"
@@ -41,4 +41,4 @@ class EcpVisSdk(CMakePackage):
     depends_on('sz', when='+sz')
 
     def cmake_args(self):
-        return [ '-DVIS=ON' ]
+        return [ '-DVIZ=ON' ]

--- a/var/spack/repos/builtin/packages/ecp-viz-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-viz-sdk/package.py
@@ -12,6 +12,8 @@ class EcpVizSdk(CMakePackage):
     homepage = "https://github.com/chuckatkins/ecp-data-viz-sdk"
     git      = "https://github.com/chuckatkins/ecp-data-viz-sdk.git"
 
+    maintainers = ['chuckatkins']
+
     version('1.0', branch='master')
 
     variant('paraview', default=False, description="Enable ParaView")


### PR DESCRIPTION
This is an initial set of meta-package for the Data & Viz SDK.  Each dependency is described as a variant and should work in isolation.  As interoperability issues are addressed then numerous variants will be enabled by default.  For now though, this puts the meta-package infrastructure in place.

TODO:
- Dependencies are currently only using default variants.  Adjust to use ecp-desired variants.
- Many interoperability issues between packages, some having to do with current limitations in the concretizer 