### PR TITLE
[WIP] Incomplete implementation of compiler wrapper insertion control

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -288,14 +288,16 @@ def set_build_environment_variables(pkg, env, dirty):
             if os.path.isdir(default_lib_prefix):
                 dep_link_dirs.append(default_lib_prefix)
 
-        link_dirs.extend(dep_link_dirs)
-        if dep in rpath_deps:
+        if 'libdir' in dep.wrapper_items:
+            link_dirs.extend(dep_link_dirs)
+        if 'rpath' in dep.wrapper_items and dep in rpath_deps:
             rpath_dirs.extend(dep_link_dirs)
 
-        try:
-            include_dirs.extend(query.headers.directories)
-        except spack.spec.NoHeadersError:
-            tty.debug("No headers found for {0}".format(dep.name))
+        if 'incdir' in dep.wrapper_items:
+            try:
+                include_dirs.extend(query.headers.directories)
+            except spack.spec.NoHeadersError:
+                tty.debug("No headers found for {0}".format(dep.name))
 
     link_dirs = list(dedupe(filter_system_paths(link_dirs)))
     include_dirs = list(dedupe(filter_system_paths(include_dirs)))


### PR DESCRIPTION
Issue #10850 is an instance of where legitimate actions taken in an external package's build system can be subverted or broken by Spack's feature of prepending flags (specifically `-I` here for include directories of dependencies) in the compiler wrapper.

This PR attempts to sketch out a non-disruptive scheme to allow recipes, on a global default or per-dependency basis, to control which if any of the three usually-prepended entities (referred to in the code as `incdir`, `libdir`, and `rpath` are actually prepended in the compiler wrapper used to build the recipe.

In brief:
* A recipe can use a new directive (`default_wrapper_item`) to define the default behavior of the wrapper with respect to the prepending of flag options.
* Any `dependes_on` statement can specify a `wrapper_items` flag to do the same thing for specific dependencies.
* The `wrapper_items` settings are stored in `Dependency` objects.
* The implementation of `build_environment.set_build_environment_variables()` herein is currently *wrong*, as my analysis of the code was unable to trace how the new attribute of `Dependency` might properly be transferred into the data structures available via the `Package` object or its `DependencySpec` tree.

Any insight into this would be greatly appreciated. I am not tied to anything particularly related to this (beginnings of) a solution, although it is pretty certain that some way needs to be found of controlling the compiler wrapper flag insertion in order to facilitate the resolution of #10850.
