### PR TITLE
Bug fix in lib/spack/spack/spec.py

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3237,7 +3237,7 @@ class Spec(object):
                         hashlen = None
                     out.write(fmt % (self.dag_hash(hashlen)))
                 elif named_str == 'NAMESPACE':
-                    out.write(fmt % transform(self.namespace))
+                    out.write(fmt % transform(self, self.namespace))
                 elif named_str.startswith('DEP:'):
                     _, dep_name, dep_option = named_str.lower().split(':', 2)
                     dep_spec = self[dep_name]

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -70,6 +70,13 @@ def test_yaml_directory_layout_parameters(
     arch_path_package = layout_arch_package.relative_path_for_spec(spec)
     assert(arch_path_package == spec.format(arch_scheme_package))
 
+    # Test separation of namespace
+    ns_scheme_package = "${ARCHITECTURE}/${NAMESPACE}/${PACKAGE}-${VERSION}-${HASH:7}"   # NOQA: ignore=E501
+    layout_ns_package = YamlDirectoryLayout(str(tmpdir),
+                                              path_scheme=ns_scheme_package)
+    ns_path_package = layout_ns_package.relative_path_for_spec(spec)
+    assert(ns_path_package == spec.format(ns_scheme_package))
+
     # Ensure conflicting parameters caught
     with pytest.raises(InvalidDirectoryLayoutParametersError):
         YamlDirectoryLayout(str(tmpdir),

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -73,7 +73,7 @@ def test_yaml_directory_layout_parameters(
     # Test separation of namespace
     ns_scheme_package = "${ARCHITECTURE}/${NAMESPACE}/${PACKAGE}-${VERSION}-${HASH:7}"   # NOQA: ignore=E501
     layout_ns_package = YamlDirectoryLayout(str(tmpdir),
-                                              path_scheme=ns_scheme_package)
+                                            path_scheme=ns_scheme_package)
     ns_path_package = layout_ns_package.relative_path_for_spec(spec)
     assert(ns_path_package == spec.format(ns_scheme_package))
 


### PR DESCRIPTION
Fixed bug in `lib/spack/spack/spec.py` when `${NAMESPACE}` is included in directory layout.  Added test to prevent regression.