### PR TITLE
adding package to install squashfs for singularity

### DIFF
--- a/var/spack/repos/builtin/packages/squashfs/package.py
+++ b/var/spack/repos/builtin/packages/squashfs/package.py
@@ -5,6 +5,7 @@
 
 from spack import *
 
+
 class Squashfs(MakefilePackage):
     """Squashfs - read only compressed filesystem"""
 

--- a/var/spack/repos/builtin/packages/squashfs/package.py
+++ b/var/spack/repos/builtin/packages/squashfs/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+import os
+
+class Squashfs(MakefilePackage):
+    """Squashfs - read only compressed filesystem"""
+
+    homepage = 'http://squashfs.sourceforge.net'
+    url      = 'https://downloads.sourceforge.net/project/squashfs/squashfs/squashfs4.3/squashfs4.3.tar.gz'
+
+    # version      md5sum
+    version('4.3', 'd92ab59aabf5173f2a59089531e30dbf')
+    version('4.2', '1b7a781fb4cf8938842279bd3e8ee852')
+    version('4.1', '8e1b2b96f5d5f3fe48fef226ae8cd341')
+    version('4.0', 'a3c23391da4ebab0ac4a75021ddabf96')
+
+    depends_on('m4',       type='build')
+    depends_on('autoconf', type='build')
+    depends_on('automake', type='build')
+    depends_on('libtool',  type='build')
+
+    def build(self, spec, prefix):
+        with working_dir('squashfs-tools'):
+            make(parallel=False)
+
+    def install(self, spec, prefix):
+        with working_dir('squashfs-tools'):
+            make('install', 'INSTALL_DIR=%s' % prefix, parallel=False)

--- a/var/spack/repos/builtin/packages/squashfs/package.py
+++ b/var/spack/repos/builtin/packages/squashfs/package.py
@@ -11,11 +11,11 @@ class Squashfs(MakefilePackage):
     homepage = 'http://squashfs.sourceforge.net'
     url      = 'https://downloads.sourceforge.net/project/squashfs/squashfs/squashfs4.3/squashfs4.3.tar.gz'
 
-    # version      md5sum
-    version('4.3', 'd92ab59aabf5173f2a59089531e30dbf')
-    version('4.2', '1b7a781fb4cf8938842279bd3e8ee852')
-    version('4.1', '8e1b2b96f5d5f3fe48fef226ae8cd341')
-    version('4.0', 'a3c23391da4ebab0ac4a75021ddabf96')
+    # version      sha1
+    version('4.3', 'a615979db9cee82e4a934a1455577f597d290b41')
+    version('4.2', 'e0944471ff68e215d3fecd464f30ea6ceb635fd7')
+    version('4.1', '7f9b1f9839b3638882f636fd170fd817d650f856')
+    version('4.0', '3efe764ac27c507ee4a549fc6507bc86ea0660dd')
 
     depends_on('m4',       type='build')
     depends_on('autoconf', type='build')

--- a/var/spack/repos/builtin/packages/squashfs/package.py
+++ b/var/spack/repos/builtin/packages/squashfs/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-import os
 
 class Squashfs(MakefilePackage):
     """Squashfs - read only compressed filesystem"""


### PR DESCRIPTION
This is my first contribution (thanks in advance for helping me learn the codebase so I can contribute more!) to add installation of the squashfs tools package in order to prepare for the Singularity upgrade.

 - I chose 4.3 as the default, the latest version
 - I didn't go earlier than 4.0 because it was like, back in 2009! :O 
 - the library only requires a make and make install, so I chose `MakefilePackage` as the base class (I found the package.py file in the main source folder) and then set the prefix to the prefix variable, which I figured out was provided in the function, and the makefile expected INSTALL_DIR to be set to the prefix.
 - to change directory, I found other examples `with working_dir` and that seemed to do the trick!

Let me know what needs to be changed / improved, etc., and glad to do it! I'll have a few more of these after this one, and hopefully learn a little more each time.