### PR TITLE
add libaio variant to fio

### DIFF
--- a/var/spack/repos/builtin/packages/fio/package.py
+++ b/var/spack/repos/builtin/packages/fio/package.py
@@ -16,9 +16,11 @@ class Fio(AutotoolsPackage):
 
     variant('gui', default=False, description='Enable building of gtk gfio')
     variant('doc', default=False, description='Generate documentation')
+    variant('libaio', default=False, description='Enable libaio engine')
 
     depends_on('gtkplus@2.18:', when='+gui')
     depends_on('cairo',         when='+gui')
+    depends_on('libaio',        when='+libaio')
 
     depends_on('py-sphinx', type='build', when='+doc')
 


### PR DESCRIPTION
This variant will add libaio (which is already present in spack) as a dependency to fio so that fio is built with the libaio engine.