### PR TITLE
module: Fix various errors during refresh

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -463,6 +463,10 @@ def log(pkg):
     # Archive the environment used for the build
     install(pkg.env_path, pkg.install_env_path)
 
+    if os.path.exists(pkg.configure_args_path):
+        # Archive the args used for the build
+        install(pkg.configure_args_path, pkg.install_configure_args_path)
+
     # Finally, archive files that are specific to each package
     with working_dir(pkg.stage.path):
         errors = six.StringIO()
@@ -1012,6 +1016,18 @@ class PackageInstaller(object):
                     with working_dir(pkg.stage.source_path):
                         # Save the build environment in a file before building.
                         dump_environment(pkg.env_path)
+
+                        for attr in ('configure_args', 'cmake_args'):
+                            try:
+                                configure_args = getattr(pkg, attr)()
+                                configure_args = ' '.join(configure_args)
+
+                                with open(pkg.configure_args_path, 'w') as args_file:
+                                    args_file.write(configure_args)
+
+                                break
+                            except Exception:
+                                pass
 
                         # cache debug settings
                         debug_enabled = tty.is_debug()

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -623,16 +623,9 @@ class BaseContext(tengine.Context):
             msg = 'unknown, software installed outside of Spack'
             return msg
 
-        # This is quite simple right now, but contains information on how
-        # to call different build system classes.
-        for attr in ('configure_args', 'cmake_args'):
-            try:
-                configure_args = getattr(pkg, attr)()
-                return ' '.join(configure_args)
-            except (AttributeError, IOError, KeyError):
-                # The method doesn't exist in the current spec,
-                # or it's not usable
-                pass
+        if os.path.exists(pkg.install_configure_args_path):
+            with open(pkg.install_configure_args_path, 'r') as args_file:
+                return args_file.read()
 
         # Returning a false-like value makes the default templates skip
         # the configure option section

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -68,6 +68,9 @@ _spack_build_logfile = 'spack-build-out.txt'
 # Filename for the Spack build/install environment file.
 _spack_build_envfile = 'spack-build-env.txt'
 
+# Filename for the Spack configure args file.
+_spack_configure_argsfile = 'spack-configure-args.txt'
+
 
 class InstallPhase(object):
     """Manages a single phase of the installation.
@@ -895,6 +898,18 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
 
         # Otherwise, return the current install log path name.
         return os.path.join(install_path, _spack_build_logfile)
+
+    @property
+    def configure_args_path(self):
+        """Return the configure args file path associated with staging."""
+        return os.path.join(self.stage.path, _spack_configure_argsfile)
+
+    @property
+    def install_configure_args_path(self):
+        """Return the configure args file path on successful installation."""
+        install_path = spack.store.layout.metadata_path(self.spec)
+
+        return os.path.join(install_path, _spack_configure_argsfile)
 
     def _make_fetcher(self):
         # Construct a composite fetcher that always contains at least

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -15,7 +15,8 @@ import spack.patch
 import spack.repo
 import spack.store
 from spack.spec import Spec
-from spack.package import _spack_build_envfile, _spack_build_logfile
+from spack.package import (_spack_build_envfile, _spack_build_logfile,
+                           _spack_configure_argsfile)
 
 
 def test_install_and_uninstall(install_mockery, mock_fetch, monkeypatch):
@@ -410,6 +411,9 @@ def test_pkg_install_paths(install_mockery):
     env_path = os.path.join(spec.prefix, '.spack', _spack_build_envfile)
     assert spec.package.install_env_path == env_path
 
+    args_path = os.path.join(spec.prefix, '.spack', _spack_configure_argsfile)
+    assert spec.package.install_configure_args_path == args_path
+
     # Backward compatibility checks
     log_dir = os.path.dirname(log_path)
     mkdirp(log_dir)
@@ -448,6 +452,7 @@ def test_pkg_install_log(install_mockery):
     with working_dir(log_dir):
         touch(log_path)
         touch(spec.package.env_path)
+        touch(spec.package.configure_args_path)
 
     install_path = os.path.dirname(spec.package.install_log_path)
     mkdirp(install_path)
@@ -456,6 +461,7 @@ def test_pkg_install_log(install_mockery):
 
     assert os.path.exists(spec.package.install_log_path)
     assert os.path.exists(spec.package.install_env_path)
+    assert os.path.exists(spec.package.install_configure_args_path)
 
     # Cleanup
     shutil.rmtree(log_dir)


### PR DESCRIPTION
This change fixes (at least) two problems:

1. proj uses its stage directory during configure_args. However, configure_options does not set up the stage, leading to OSErrors about the stage directory (see #10649). This change will lead to missing configure_args in such cases but allows regenerating the module file and avoids needlessy setting up fake stages during refresh.
2. libxml2 uses global variables exported by python. Again, configure_options does not set up the environment appropriately, leading to NameErrors (see #10716). In addition to ignoring NameErrors, this change will set up the package environment so global variables can be found during refresh.

Fixes #10649, #10716
closes #14361 