### PR TITLE
Fix module_parsing test

### DIFF
--- a/lib/spack/spack/test/module_parsing.py
+++ b/lib/spack/spack/test/module_parsing.py
@@ -15,7 +15,10 @@ from spack.util.module_cmd import (
     ModuleError)
 
 
+env = os.environ.copy()
+env['LC_ALL'] = 'C'
 typeset_func = subprocess.Popen('module avail',
+                                env=env,
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE,
                                 shell=True)


### PR DESCRIPTION
The module_parsing test checks whether the module function is available by looking for the string 'not found'. If the user has set a different locale, the test can assume that the module function is available when it actually is not.