### PR TITLE
WIP: Support parsing clispecs as yaml

### DIFF
--- a/lib/spack/spack/cmd/activate.py
+++ b/lib/spack/spack/cmd/activate.py
@@ -3,11 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import argparse
-
 import llnl.util.tty as tty
 
 import spack.cmd
+import spack.cmd.common.arguments as arguments
 import spack.environment as ev
 from spack.filesystem_view import YamlFilesystemView
 
@@ -23,13 +22,11 @@ def setup_parser(subparser):
     subparser.add_argument(
         '-v', '--view', metavar='VIEW', type=str,
         help="the view to operate on")
-    subparser.add_argument(
-        'spec', nargs=argparse.REMAINDER,
-        help="spec of package extension to activate")
+    arguments.add_common_arguments(subparser, ['specs'])
 
 
 def activate(parser, args):
-    specs = spack.cmd.parse_specs(args.spec)
+    specs = spack.cmd.parse_specs(args.specs)
     if len(specs) != 1:
         tty.die("activate requires one spec.  %d given." % len(specs))
 

--- a/lib/spack/spack/cmd/add.py
+++ b/lib/spack/spack/cmd/add.py
@@ -3,11 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import argparse
-
 import llnl.util.tty as tty
 
 import spack.cmd
+import spack.cmd.common.arguments as arguments
 import spack.environment as ev
 
 
@@ -17,8 +16,7 @@ level = "long"
 
 
 def setup_parser(subparser):
-    subparser.add_argument(
-        'specs', nargs=argparse.REMAINDER, help="specs of packages to add")
+    arguments.add_common_arguments(subparser, ['specs'])
 
 
 def add(parser, args):

--- a/lib/spack/spack/cmd/build_env.py
+++ b/lib/spack/spack/cmd/build_env.py
@@ -5,7 +5,6 @@
 
 from __future__ import print_function
 
-import argparse
 import os
 
 import llnl.util.tty as tty
@@ -21,7 +20,7 @@ level = "long"
 
 
 def setup_parser(subparser):
-    arguments.add_common_arguments(subparser, ['clean', 'dirty'])
+    arguments.add_common_arguments(subparser, ['clean', 'dirty', 'specs'])
     subparser.add_argument(
         '--dump', metavar="FILE",
         help="dump a source-able environment to FILE"
@@ -30,10 +29,6 @@ def setup_parser(subparser):
         '--pickle', metavar="FILE",
         help="dump a pickled source-able environment to FILE"
     )
-    subparser.add_argument(
-        'spec', nargs=argparse.REMAINDER,
-        metavar='spec [--] [cmd]...',
-        help="specs of package environment to emulate")
     subparser.epilog\
         = 'If a command is not specified, the environment will be printed ' \
         'to standard output (cf /usr/bin/env) unless --dump and/or --pickle ' \
@@ -42,7 +37,7 @@ def setup_parser(subparser):
 
 
 def build_env(parser, args):
-    if not args.spec:
+    if not args.specs:
         tty.die("spack build-env requires a spec.")
 
     # Specs may have spaces in them, so if they do, require that the
@@ -50,13 +45,13 @@ def build_env(parser, args):
     # executed.  If there is no '--', assume that the spec is the
     # first argument.
     sep = '--'
-    if sep in args.spec:
-        s = args.spec.index(sep)
-        spec = args.spec[:s]
-        cmd = args.spec[s + 1:]
+    if sep in args.specs:
+        s = args.specs.index(sep)
+        spec = args.specs[:s]
+        cmd = args.specs[s + 1:]
     else:
-        spec = args.spec[0]
-        cmd = args.spec[1:]
+        spec = args.specs[0]
+        cmd = args.specs[1:]
 
     specs = spack.cmd.parse_specs(spec, concretize=True)
     if len(specs) > 1:

--- a/lib/spack/spack/cmd/clean.py
+++ b/lib/spack/spack/cmd/clean.py
@@ -11,12 +11,14 @@ import llnl.util.tty as tty
 
 import spack.caches
 import spack.cmd
+import spack.cmd.common.arguments as arguments
 import spack.repo
 import spack.stage
 from spack.paths import lib_path, var_path
 
 
-description = "remove temporary build files and/or downloaded archives"
+description = """remove temporary build files and/or downloaded archives
+for specs"""
 section = "build"
 level = "long"
 
@@ -43,11 +45,7 @@ def setup_parser(subparser):
     subparser.add_argument(
         '-a', '--all', action=AllClean, help="equivalent to -sdmp", nargs=0
     )
-    subparser.add_argument(
-        'specs',
-        nargs=argparse.REMAINDER,
-        help="removes the build stages and tarballs for specs"
-    )
+    arguments.add_common_arguments(subparser, ['specs'])
 
 
 def clean(parser, args):

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -179,3 +179,8 @@ _arguments['install_status'] = Args(
 _arguments['no_checksum'] = Args(
     '-n', '--no-checksum', action='store_true', default=False,
     help="do not use checksums to verify downloaded files (unsafe)")
+
+_arguments['specs'] = Args(
+    'specs',
+    nargs=argparse.REMAINDER,
+    help='specs of the target packages')

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -183,4 +183,7 @@ _arguments['no_checksum'] = Args(
 _arguments['specs'] = Args(
     'specs',
     nargs=argparse.REMAINDER,
-    help='specs of the target packages')
+    help='specs of the target packages, which can be either abstract '
+    'clispecs or else paths to spec.yaml files, but cannot be mixed. '
+    'prefix relative paths with "./" to avoid ambiguity with '
+    'namespaced packages)')

--- a/lib/spack/spack/cmd/deactivate.py
+++ b/lib/spack/spack/cmd/deactivate.py
@@ -3,10 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import argparse
 import llnl.util.tty as tty
 
 import spack.cmd
+import spack.cmd.common.arguments as arguments
 import spack.environment as ev
 import spack.store
 from spack.filesystem_view import YamlFilesystemView
@@ -28,13 +28,11 @@ def setup_parser(subparser):
         '-a', '--all', action='store_true',
         help="deactivate all extensions of an extendable package, or "
         "deactivate an extension AND its dependencies")
-    subparser.add_argument(
-        'spec', nargs=argparse.REMAINDER,
-        help="spec of package extension to deactivate")
+    arguments.add_common_arguments(subparser, ['specs'])
 
 
 def deactivate(parser, args):
-    specs = spack.cmd.parse_specs(args.spec)
+    specs = spack.cmd.parse_specs(args.specs)
     if len(specs) != 1:
         tty.die("deactivate requires one spec.  %d given." % len(specs))
 

--- a/lib/spack/spack/cmd/dependencies.py
+++ b/lib/spack/spack/cmd/dependencies.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import argparse
-
 import llnl.util.tty as tty
 from llnl.util.tty.colify import colify
 
@@ -31,12 +29,11 @@ def setup_parser(subparser):
     subparser.add_argument(
         '-V', '--no-expand-virtuals', action='store_false', default=True,
         dest="expand_virtuals", help="do not expand virtual dependencies")
-    subparser.add_argument(
-        'spec', nargs=argparse.REMAINDER, help="spec or package name")
+    arguments.add_common_arguments(subparser, ['specs'])
 
 
 def dependencies(parser, args):
-    specs = spack.cmd.parse_specs(args.spec)
+    specs = spack.cmd.parse_specs(args.specs)
     if len(specs) != 1:
         tty.die("spack dependencies takes only one spec.")
 

--- a/lib/spack/spack/cmd/dependents.py
+++ b/lib/spack/spack/cmd/dependents.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import argparse
-
 import llnl.util.tty as tty
 from llnl.util.tty.colify import colify
 
@@ -12,6 +10,7 @@ import spack.environment as ev
 import spack.repo
 import spack.store
 import spack.cmd
+import spack.cmd.common.arguments as arguments
 
 description = "show packages that depend on another"
 section = "basic"
@@ -26,8 +25,7 @@ def setup_parser(subparser):
     subparser.add_argument(
         '-t', '--transitive', action='store_true', default=False,
         help="Show all transitive dependents.")
-    subparser.add_argument(
-        'spec', nargs=argparse.REMAINDER, help="spec or package name")
+    arguments.add_common_arguments(subparser, ['specs'])
 
 
 def inverted_dependencies():
@@ -77,7 +75,7 @@ def get_dependents(pkg_name, ideps, transitive=False, dependents=None):
 
 
 def dependents(parser, args):
-    specs = spack.cmd.parse_specs(args.spec)
+    specs = spack.cmd.parse_specs(args.specs)
     if len(specs) != 1:
         tty.die("spack dependents takes only one spec.")
 

--- a/lib/spack/spack/cmd/diy.py
+++ b/lib/spack/spack/cmd/diy.py
@@ -5,7 +5,6 @@
 
 import sys
 import os
-import argparse
 
 import llnl.util.tty as tty
 
@@ -28,7 +27,7 @@ def setup_parser(subparser):
     subparser.add_argument(
         '-i', '--ignore-dependencies', action='store_true', dest='ignore_deps',
         help="don't try to install dependencies of requested packages")
-    arguments.add_common_arguments(subparser, ['no_checksum'])
+    arguments.add_common_arguments(subparser, ['no_checksum', 'specs'])
     subparser.add_argument(
         '--keep-prefix', action='store_true',
         help="do not remove the install prefix if installation fails")
@@ -38,19 +37,16 @@ def setup_parser(subparser):
     subparser.add_argument(
         '-q', '--quiet', action='store_true', dest='quiet',
         help="do not display verbose build output while installing")
-    subparser.add_argument(
-        'spec', nargs=argparse.REMAINDER,
-        help="specs to use for install. must contain package AND version")
 
     cd_group = subparser.add_mutually_exclusive_group()
     arguments.add_common_arguments(cd_group, ['clean', 'dirty'])
 
 
 def diy(self, args):
-    if not args.spec:
+    if not args.specs:
         tty.die("spack diy requires a package spec argument.")
 
-    specs = spack.cmd.parse_specs(args.spec)
+    specs = spack.cmd.parse_specs(args.specs)
     if len(specs) > 1:
         tty.die("spack diy only takes one spec.")
 

--- a/lib/spack/spack/cmd/extensions.py
+++ b/lib/spack/spack/cmd/extensions.py
@@ -3,13 +3,12 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import argparse
-
 import llnl.util.tty as tty
 from llnl.util.tty.colify import colify
 
 import spack.environment as ev
 import spack.cmd
+import spack.cmd.common.arguments as arguments
 import spack.cmd.find
 import spack.repo
 import spack.store
@@ -39,13 +38,11 @@ def setup_parser(subparser):
         '-v', '--view', metavar='VIEW', type=str,
         help="the view to operate on")
 
-    subparser.add_argument(
-        'spec', nargs=argparse.REMAINDER,
-        help='spec of package to list extensions for')
+    arguments.add_common_arguments(subparser, ['specs'])
 
 
 def extensions(parser, args):
-    if not args.spec:
+    if not args.specs:
         tty.die("extensions requires a package spec.")
 
     show_packages = False
@@ -69,7 +66,7 @@ def extensions(parser, args):
     #
     # Checks
     #
-    spec = spack.cmd.parse_specs(args.spec)
+    spec = spack.cmd.parse_specs(args.specs)
     if len(spec) > 1:
         tty.die("Can only list extensions for one package.")
 

--- a/lib/spack/spack/cmd/fetch.py
+++ b/lib/spack/spack/cmd/fetch.py
@@ -3,14 +3,12 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import argparse
-
 import llnl.util.tty as tty
 
 import spack.cmd
+import spack.cmd.common.arguments as arguments
 import spack.config
 import spack.repo
-import spack.cmd.common.arguments as arguments
 
 description = "fetch archives for packages"
 section = "build"
@@ -25,19 +23,17 @@ def setup_parser(subparser):
     subparser.add_argument(
         '-D', '--dependencies', action='store_true',
         help="also fetch all dependencies")
-    subparser.add_argument(
-        'packages', nargs=argparse.REMAINDER,
-        help="specs of packages to fetch")
+    arguments.add_common_arguments(subparser, ['specs'])
 
 
 def fetch(parser, args):
-    if not args.packages:
+    if not args.specs:
         tty.die("fetch requires at least one package argument")
 
     if args.no_checksum:
         spack.config.set('config:checksum', False, scope='command_line')
 
-    specs = spack.cmd.parse_specs(args.packages, concretize=True)
+    specs = spack.cmd.parse_specs(args.specs, concretize=True)
     for spec in specs:
         if args.missing or args.dependencies:
             for s in spec.traverse():

--- a/lib/spack/spack/cmd/graph.py
+++ b/lib/spack/spack/cmd/graph.py
@@ -5,7 +5,6 @@
 
 from __future__ import print_function
 
-import argparse
 import llnl.util.tty as tty
 
 import spack.cmd
@@ -40,9 +39,7 @@ def setup_parser(subparser):
 
     arguments.add_common_arguments(subparser, ['deptype'])
 
-    subparser.add_argument(
-        'specs', nargs=argparse.REMAINDER,
-        help="specs of packages to graph")
+    arguments.add_common_arguments(subparser, ['specs'])
 
 
 def graph(parser, args):

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import argparse
 import os
 import shutil
 import sys
@@ -106,11 +105,8 @@ the dependencies"""
     cd_group = subparser.add_mutually_exclusive_group()
     arguments.add_common_arguments(cd_group, ['clean', 'dirty'])
 
-    subparser.add_argument(
-        'package',
-        nargs=argparse.REMAINDER,
-        help="spec of the package to install"
-    )
+    arguments.add_common_arguments(subparser, ['specs'])
+
     testing = subparser.add_mutually_exclusive_group()
     testing.add_argument(
         '--test', default=None,
@@ -217,7 +213,7 @@ def install_spec(cli_args, kwargs, abstract_spec, spec):
 
 
 def install(parser, args, **kwargs):
-    if not args.package and not args.specfiles:
+    if not args.specs and not args.specfiles:
         # if there are no args but an active environment or spack.yaml file
         # then install the packages from it.
         env = ev.get_env(args, 'install')
@@ -250,7 +246,7 @@ def install(parser, args, **kwargs):
     if args.log_file:
         reporter.filename = args.log_file
 
-    abstract_specs = spack.cmd.parse_specs(args.package)
+    abstract_specs = spack.cmd.parse_specs(args.specs)
     tests = False
     if args.test == 'all' or args.run_tests:
         tests = True
@@ -260,7 +256,7 @@ def install(parser, args, **kwargs):
 
     try:
         specs = spack.cmd.parse_specs(
-            args.package, concretize=True, tests=tests)
+            args.specs, concretize=True, tests=tests)
     except SpackError as e:
         tty.debug(e)
         reporter.concretization_report(e.message)

--- a/lib/spack/spack/cmd/load.py
+++ b/lib/spack/spack/cmd/load.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import argparse
 from spack.cmd.common import print_module_placeholder_help, arguments
 
 description = "add package to environment using `module load`"
@@ -14,11 +13,8 @@ level = "short"
 def setup_parser(subparser):
     """Parser is only constructed so that this prints a nice help
        message with -h. """
-    subparser.add_argument(
-        'spec', nargs=argparse.REMAINDER,
-        help="spec of package to load with modules "
-    )
-    arguments.add_common_arguments(subparser, ['recurse_dependencies'])
+    arguments.add_common_arguments(
+        subparser, ['recurse_dependencies', 'specs'])
 
 
 def load(parser, args):

--- a/lib/spack/spack/cmd/location.py
+++ b/lib/spack/spack/cmd/location.py
@@ -6,11 +6,11 @@
 from __future__ import print_function
 
 import os
-import argparse
 import llnl.util.tty as tty
 
 import spack.environment as ev
 import spack.cmd
+import spack.cmd.common.arguments as arguments
 import spack.environment
 import spack.paths
 import spack.repo
@@ -54,9 +54,7 @@ def setup_parser(subparser):
         '-e', '--env', action='store',
         help="location of an environment managed by spack")
 
-    subparser.add_argument(
-        'spec', nargs=argparse.REMAINDER,
-        help="spec of package to fetch directory for")
+    arguments.add_common_arguments(subparser, ['specs'])
 
 
 def location(parser, args):
@@ -79,7 +77,7 @@ def location(parser, args):
         print(spack.paths.stage_path)
 
     else:
-        specs = spack.cmd.parse_specs(args.spec)
+        specs = spack.cmd.parse_specs(args.specs)
         if not specs:
             tty.die("You must supply a spec.")
         if len(specs) != 1:
@@ -110,5 +108,5 @@ def location(parser, args):
                     if not pkg.stage.expanded:
                         tty.die("Build directory does not exist yet. "
                                 "Run this to create it:",
-                                "spack stage " + " ".join(args.spec))
+                                "spack stage " + " ".join(args.specs))
                     print(pkg.stage.source_path)

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -7,7 +7,6 @@ import sys
 import os
 from datetime import datetime
 
-import argparse
 import llnl.util.tty as tty
 from llnl.util.tty.colify import colify
 
@@ -36,9 +35,7 @@ def setup_parser(subparser):
     create_parser = sp.add_parser('create', help=mirror_create.__doc__)
     create_parser.add_argument('-d', '--directory', default=None,
                                help="directory in which to create mirror")
-    create_parser.add_argument(
-        'specs', nargs=argparse.REMAINDER,
-        help="specs of packages to put in mirror")
+    arguments.add_common_arguments(subparser, ['specs'])
     create_parser.add_argument(
         '-f', '--file', help="file with specs of packages to put in mirror")
     create_parser.add_argument(

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -35,7 +35,7 @@ def setup_parser(subparser):
     create_parser = sp.add_parser('create', help=mirror_create.__doc__)
     create_parser.add_argument('-d', '--directory', default=None,
                                help="directory in which to create mirror")
-    arguments.add_common_arguments(subparser, ['specs'])
+    arguments.add_common_arguments(create_parser, ['specs'])
     create_parser.add_argument(
         '-f', '--file', help="file with specs of packages to put in mirror")
     create_parser.add_argument(

--- a/lib/spack/spack/cmd/patch.py
+++ b/lib/spack/spack/cmd/patch.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import argparse
-
 import llnl.util.tty as tty
 
 import spack.repo
@@ -18,20 +16,17 @@ level = "long"
 
 
 def setup_parser(subparser):
-    arguments.add_common_arguments(subparser, ['no_checksum'])
-    subparser.add_argument(
-        'packages', nargs=argparse.REMAINDER,
-        help="specs of packages to stage")
+    arguments.add_common_arguments(subparser, ['no_checksum', 'specs'])
 
 
 def patch(parser, args):
-    if not args.packages:
+    if not args.specs:
         tty.die("patch requires at least one package argument")
 
     if args.no_checksum:
         spack.config.set('config:checksum', False, scope='command_line')
 
-    specs = spack.cmd.parse_specs(args.packages, concretize=True)
+    specs = spack.cmd.parse_specs(args.specs, concretize=True)
     for spec in specs:
         package = spack.repo.get(spec)
         package.do_patch()

--- a/lib/spack/spack/cmd/providers.py
+++ b/lib/spack/spack/cmd/providers.py
@@ -9,6 +9,7 @@ import sys
 import llnl.util.tty.colify as colify
 
 import spack.cmd
+import spack.cmd.common.arguments as arguments
 import spack.repo
 
 description = "list packages that provide a particular virtual package"
@@ -19,11 +20,7 @@ level = "long"
 def setup_parser(subparser):
     subparser.epilog = 'If called without argument returns ' \
                        'the list of all valid virtual packages'
-    subparser.add_argument(
-        'virtual_package',
-        nargs='*',
-        help='find packages that provide this virtual package'
-    )
+    arguments.add_common_arguments(subparser, ['specs'])
 
 
 def providers(parser, args):
@@ -37,12 +34,12 @@ def providers(parser, args):
     valid_virtuals_str = buffer.getvalue()
 
     # If called without arguments, list all the virtual packages
-    if not args.virtual_package:
+    if not args.specs:
         print(valid_virtuals_str)
         return
 
     # Otherwise, parse the specs from command line
-    specs = spack.cmd.parse_specs(args.virtual_package)
+    specs = spack.cmd.parse_specs(args.specs)
 
     # Check prerequisites
     non_virtual = [

--- a/lib/spack/spack/cmd/remove.py
+++ b/lib/spack/spack/cmd/remove.py
@@ -3,11 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import argparse
-
 import llnl.util.tty as tty
 
 import spack.cmd
+import spack.cmd.common.arguments as arguments
 import spack.environment as ev
 
 
@@ -23,8 +22,7 @@ def setup_parser(subparser):
     subparser.add_argument(
         '-f', '--force', action='store_true',
         help="remove concretized spec (if any) immediately")
-    subparser.add_argument(
-        'specs', nargs=argparse.REMAINDER, help="specs to be removed")
+    arguments.add_common_arguments(subparser, ['specs'])
 
 
 def remove(parser, args):

--- a/lib/spack/spack/cmd/restage.py
+++ b/lib/spack/spack/cmd/restage.py
@@ -3,11 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import argparse
-
 import llnl.util.tty as tty
 
 import spack.cmd
+import spack.cmd.common.arguments as arguments
 import spack.repo
 
 description = "revert checked out package source code"
@@ -16,15 +15,14 @@ level = "long"
 
 
 def setup_parser(subparser):
-    subparser.add_argument('packages', nargs=argparse.REMAINDER,
-                           help="specs of packages to restage")
+    arguments.add_common_arguments(subparser, ['specs'])
 
 
 def restage(parser, args):
-    if not args.packages:
+    if not args.specs:
         tty.die("spack restage requires at least one package spec.")
 
-    specs = spack.cmd.parse_specs(args.packages, concretize=True)
+    specs = spack.cmd.parse_specs(args.specs, concretize=True)
     for spec in specs:
         package = spack.repo.get(spec)
         package.do_restage()

--- a/lib/spack/spack/cmd/setup.py
+++ b/lib/spack/spack/cmd/setup.py
@@ -34,9 +34,7 @@ def setup_parser(subparser):
     subparser.add_argument(
         '-v', '--verbose', action='store_true', dest='verbose',
         help="display verbose build output while installing")
-    subparser.add_argument(
-        'spec', nargs=argparse.REMAINDER,
-        help="specs to use for install. must contain package AND version")
+    arguments.add_common_arguments(subparser, ['specs'])
 
     cd_group = subparser.add_mutually_exclusive_group()
     arguments.add_common_arguments(cd_group, ['clean', 'dirty'])
@@ -108,10 +106,10 @@ env = dict(os.environ)
 
 
 def setup(self, args):
-    if not args.spec:
+    if not args.specs:
         tty.die("spack setup requires a package spec argument.")
 
-    specs = spack.cmd.parse_specs(args.spec)
+    specs = spack.cmd.parse_specs(args.specs)
     if len(specs) > 1:
         tty.die("spack setup only takes one spec.")
 
@@ -148,7 +146,7 @@ def setup(self, args):
             install.setup_parser(parser)
             inst_args = copy.deepcopy(args)
             inst_args = parser.parse_args(
-                ['--only=dependencies'] + args.spec,
+                ['--only=dependencies'] + args.specs,
                 namespace=inst_args
             )
             install.install(parser, inst_args)
@@ -164,7 +162,7 @@ def setup(self, args):
         # module file regeneration
         inst_args = copy.deepcopy(args)
         inst_args = parser.parse_args(
-            ['--only=package', '--fake'] + args.spec,
+            ['--only=package', '--fake'] + args.specs,
             namespace=inst_args
         )
         install.install(parser, inst_args)

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -5,7 +5,6 @@
 
 from __future__ import print_function
 
-import argparse
 import sys
 
 import llnl.util.tty as tty
@@ -22,7 +21,7 @@ level = "short"
 
 def setup_parser(subparser):
     arguments.add_common_arguments(
-        subparser, ['long', 'very_long', 'install_status'])
+        subparser, ['long', 'very_long', 'install_status', 'specs'])
     subparser.add_argument(
         '-y', '--yaml', action='store_true', default=False,
         help='print concrete spec as YAML')
@@ -37,8 +36,6 @@ def setup_parser(subparser):
     subparser.add_argument(
         '-t', '--types', action='store_true', default=False,
         help='show dependency types')
-    subparser.add_argument(
-        'specs', nargs=argparse.REMAINDER, help="specs of packages")
 
 
 def spec(parser, args):

--- a/lib/spack/spack/cmd/stage.py
+++ b/lib/spack/spack/cmd/stage.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import argparse
-
 import llnl.util.tty as tty
 
 import spack.environment as ev
@@ -18,13 +16,10 @@ level = "long"
 
 
 def setup_parser(subparser):
-    arguments.add_common_arguments(subparser, ['no_checksum'])
+    arguments.add_common_arguments(subparser, ['no_checksum', 'specs'])
     subparser.add_argument(
         '-p', '--path', dest='path',
         help="path to stage package, does not add to spack tree")
-
-    subparser.add_argument(
-        'specs', nargs=argparse.REMAINDER, help="specs of packages to stage")
 
 
 def stage(parser, args):

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -5,8 +5,6 @@
 
 from __future__ import print_function
 
-import argparse
-
 import spack.cmd
 import spack.environment as ev
 import spack.package
@@ -41,7 +39,7 @@ def add_common_arguments(subparser):
         help="remove regardless of whether other packages or environments "
         "depend on this one")
     arguments.add_common_arguments(
-        subparser, ['recurse_dependents', 'yes_to_all'])
+        subparser, ['recurse_dependents', 'yes_to_all', 'specs'])
 
 
 def setup_parser(subparser):
@@ -54,11 +52,6 @@ def setup_parser(subparser):
         "supplied, all installed packages will be uninstalled. "
         "If used in an environment, all packages in the environment "
         "will be uninstalled.")
-
-    subparser.add_argument(
-        'packages',
-        nargs=argparse.REMAINDER,
-        help="specs of packages to uninstall")
 
 
 def find_matching_specs(env, specs, allow_multiple_matches=False, force=False):
@@ -327,10 +320,10 @@ def uninstall_specs(args, specs):
 
 
 def uninstall(parser, args):
-    if not args.packages and not args.all:
+    if not args.specs and not args.all:
         tty.die('uninstall requires at least one package argument.',
                 '  Use `spack uninstall --all` to uninstall ALL packages.')
 
     # [any] here handles the --all case by forcing all specs to be returned
     uninstall_specs(
-        args, spack.cmd.parse_specs(args.packages) if args.packages else [any])
+        args, spack.cmd.parse_specs(args.specs) if args.specs else [any])

--- a/lib/spack/spack/cmd/unload.py
+++ b/lib/spack/spack/cmd/unload.py
@@ -3,8 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import argparse
 from spack.cmd.common import print_module_placeholder_help
+import spack.cmd.common.arguments as arguments
 
 description = "remove package from environment using `module unload`"
 section = "modules"
@@ -14,9 +14,7 @@ level = "short"
 def setup_parser(subparser):
     """Parser is only constructed so that this prints a nice help
        message with -h. """
-    subparser.add_argument(
-        'spec', nargs=argparse.REMAINDER,
-        help='spec of package to unload with modules')
+    arguments.add_common_arguments(subparser, ['specs'])
 
 
 def unload(parser, args):

--- a/lib/spack/spack/cmd/unuse.py
+++ b/lib/spack/spack/cmd/unuse.py
@@ -3,8 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import argparse
 from spack.cmd.common import print_module_placeholder_help
+import spack.cmd.common.arguments as arguments
 
 description = "remove package from environment using dotkit"
 section = "modules"
@@ -14,9 +14,7 @@ level = "long"
 def setup_parser(subparser):
     """Parser is only constructed so that this prints a nice help
        message with -h. """
-    subparser.add_argument(
-        'spec', nargs=argparse.REMAINDER,
-        help='spec of package to unuse with dotkit')
+    arguments.add_common_arguments(subparser, ['specs'])
 
 
 def unuse(parser, args):

--- a/lib/spack/spack/cmd/use.py
+++ b/lib/spack/spack/cmd/use.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import argparse
 from spack.cmd.common import print_module_placeholder_help, arguments
 
 description = "add package to environment using dotkit"
@@ -14,10 +13,8 @@ level = "long"
 def setup_parser(subparser):
     """Parser is only constructed so that this prints a nice help
        message with -h. """
-    subparser.add_argument(
-        'spec', nargs=argparse.REMAINDER,
-        help='spec of package to use with dotkit')
-    arguments.add_common_arguments(subparser, ['recurse_dependencies'])
+    arguments.add_common_arguments(
+        subparser, ['recurse_dependencies', 'specs'])
 
 
 def use(parser, args):

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -65,8 +65,8 @@ class CDash(Reporter):
             self.buildid_regexp = re.compile("<buildId>([0-9]+)</buildId>")
         self.phase_regexp = re.compile(r"Executing phase: '(.*)'")
 
-        if args.package:
-            packages = args.package
+        if args.specs:
+            packages = args.specs
         else:
             packages = []
             for file in args.specfiles:

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -312,6 +312,26 @@ def test_install_from_file(spec, concretize, error_code, tmpdir):
     assert install.returncode == error_code
 
 
+@pytest.mark.usefixtures('noop_install', 'config')
+@pytest.mark.parametrize('spec', [
+    (Spec('mpi')),
+    (Spec('mpi')),
+    (Spec('boost')),
+    (Spec('boost'))
+])
+def test_install_clispec_as_yaml_path(spec, tmpdir):
+    spec.concretize()
+
+    specfile = tmpdir.join('spec.yaml')
+
+    with specfile.open('w') as f:
+        spec.to_yaml(f)
+
+    # Test that we can install passing absolute path to spec yaml
+    install(str(specfile), fail_on_error=False)
+    assert install.returncode == 0
+
+
 @pytest.mark.disable_clean_stage_check
 @pytest.mark.usefixtures(
     'mock_packages', 'mock_archive', 'mock_fetch', 'config', 'install_mockery'

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -332,6 +332,21 @@ def test_install_clispec_as_yaml_path(spec, tmpdir):
     assert install.returncode == 0
 
 
+@pytest.mark.usefixtures('noop_install', 'config')
+def test_install_combine_clispec_and_yaml_fails(mock_packages, tmpdir):
+    s = Spec('archive-files')
+    s.concretize()
+
+    specfile = tmpdir.join('spec.yaml')
+
+    with specfile.open('w') as f:
+        f.write(s.to_yaml(all_deps=True))
+
+    # Make sure combining yaml path and clispecs failes
+    with pytest.raises(SpackError):
+        install(str(specfile), 'libdwarf')
+
+
 @pytest.mark.disable_clean_stage_check
 @pytest.mark.usefixtures(
     'mock_packages', 'mock_archive', 'mock_fetch', 'config', 'install_mockery'


### PR DESCRIPTION
Currently commands that operate on specs, like `spack install` for example, might or might not additionally allow users to provide the `-f <path-to-spec.yaml>` argument as an alternate way to identify specs.  Using the `-f` option is nice because it removes all ambiguity as to what will be installed, or the spec for which a buildcache will be created, etc.

Instead of incrementally updating all the various commands where this `-f <path-to-spec.yaml>` functionality might be useful (see, for example, #10912), this PR represents an attempt to support it in one go for all commands simultaneously.

At a high level, this PR attempts to let the `spack.cmd.parse_specs(...)` method do what it has always done, i.e. assume the positional arguments are clispecs.  If that fails, however, then it additionally tries to see if the positional arguments are readable files representing concrete specs.  So for example, while you can still say:

```
spack install pkgconf bzip2
```

You could also now concretize the `pkgconf` and `bzip2` specs and write those out to the filesystem before saying:

```
spack install /tmp/pkgconf.yaml /tmp/bzip2.yaml
```

In order to unify the way commands handle specs on the command line, the first commit in this PR creates a new common command line argument, `specs`, as the `REMAINDER` of the positional args, and any commands that called `parse_specs()`, now use that common arg.  This also allows documenting the limitations discussed below in a single location, instead of in every command that operates on specs.

There are still some unanswered questions here though.

1. Previously the `spack install -f ...` form could handle relative paths:

```
cd /tmp
spack install -f bzip2.yaml
```

But with the change proposed in this PR, spack thinks that `bzip2` is some kind of namespace and expects `yaml` to refer to a package.  If we were to first treat the positional args as if they might be file paths, it would avoid this issue, but it's my understanding that doing things in that order would cause other problems.

**EDIT**

*This PR now simply documents that the above relative path must be prefixed with `./` in order to avoid the ambiguity.*

2. This PR doesn't support mixed mode specs, i.e. you can't pass as positional arguments some abstract spec strings along with some file paths, ala:

```
spack install pkgconf@1.4.2 /tmp/bzip2.yaml
```

There are currently some tests for mixed mode spec installation, see e.g. `test_install_mix_cli_and_files` in `lib/spack/spack/test/cmd/install.py`.  In that test, the mixed mode is achieved by passing positional arguments along with the `-f` option and supplying file paths.  Keeping the `-f` option where in the commands where it exists already could be a way to continue supporting mixed mode identification of specs, as well as provide backward compatibility for users expecting the `-f` option.

**EDIT**

*This PR now documents that the above mixed-mode approach to providing specs on the command line is not supported.*

3. What should happen if you have a `spec.yaml` from another system, and you accidentally try to install from it?  It may be seen as concrete due to being read from a yaml file, but the concretization may not be valid on the current system.  This may or may not already be an issue when using the `-f` option, however, so maybe isn't a big deal from the perspective of this PR.
