### PR TITLE
fixes py-basemap package

### DIFF
--- a/var/spack/repos/builtin/packages/py-basemap/package.py
+++ b/var/spack/repos/builtin/packages/py-basemap/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+import os
 
 
 class PyBasemap(PythonPackage):
@@ -11,8 +12,8 @@ class PyBasemap(PythonPackage):
     2D data on maps in Python."""
 
     homepage = "http://matplotlib.org/basemap/"
-    url      = "https://downloads.sourceforge.net/project/matplotlib/matplotlib-toolkits/basemap-1.0.7/basemap-1.0.7.tar.gz"
-    version('1.2.0', 'f8e64bd150590223701a48d60408e939', url='https://github.com/matplotlib/basemap/archive/v1.2.0rel.tar.gz')
+
+    version('1.2.0', 'f8e64bd150590223701a48d60408e939')
     version('1.0.7', '48c0557ced9e2c6e440b28b3caff2de8')
 
     # Per Github issue #3813, setuptools is required at runtime in order
@@ -21,8 +22,32 @@ class PyBasemap(PythonPackage):
     depends_on('py-setuptools', type=('run'))
     depends_on('py-numpy', type=('build', 'run'))
     depends_on('py-matplotlib', type=('build', 'run'))
+    depends_on('py-pyproj', type=('build', 'run'))
+    depends_on('py-pyshp', type=('build', 'run'))
     depends_on('pil', type=('build', 'run'))
     depends_on('geos')
 
+    def url_for_version(self, version):
+        if version >= Version('1.2.0'):
+            return 'https://github.com/matplotlib/basemap/archive/v{0}rel.tar.gz'.format(version)
+        else:
+            return 'https://downloads.sourceforge.net/project/matplotlib/matplotlib-toolkits/basemap-{0}/basemap-{0}.tar.gz'.format(version)
+
     def setup_environment(self, spack_env, run_env):
         spack_env.set('GEOS_DIR', self.spec['geos'].prefix)
+
+    def install(self, spec, prefix):
+        """Install everything from build directory."""
+        args = self.install_args(spec, prefix)
+
+        self.setup_py('install', *args)
+
+        # namespace packages should not create an __init__.py file. This has
+        # been reported to the basemap project in
+        # https://github.com/matplotlib/basemap/issues/456
+        for root, dirs, files in os.walk(spec.prefix.lib):
+            for filename in files:
+                if (filename == '__init__.py' and
+                    os.path.basename(root) == 'mpl_toolkits'):
+                    os.rename(os.path.join(root, filename),
+                              os.path.join(root, filename + '.bak'))

--- a/var/spack/repos/builtin/packages/py-basemap/package.py
+++ b/var/spack/repos/builtin/packages/py-basemap/package.py
@@ -49,5 +49,4 @@ class PyBasemap(PythonPackage):
             for filename in files:
                 if (filename == '__init__.py' and
                     os.path.basename(root) == 'mpl_toolkits'):
-                    os.rename(os.path.join(root, filename),
-                              os.path.join(root, filename + '.bak'))
+                    os.remove(os.path.join(root, filename))


### PR DESCRIPTION
The basemap package was failing to import. This is because basemap installed an __init__.py in its mpl_toolkits namespace directory. Per https://packaging.python.org/guides/packaging-namespace-packages/:

> It is extremely important that every distribution that uses the namespace package omits the __init__.py or uses a pkgutil-style __init__.py. If any distribution does not, it will cause the namespace logic to fail and the other sub-packages will not be importable.

This has been reported to the basemap project as https://github.com/matplotlib/basemap/issues/456.

This PR should supercede #10590.