### PR TITLE
Allow spack install to take either cdash stamp or track

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -153,11 +153,20 @@ Defaults to spec of the package to install."""
         help="""The site name that will be reported to CDash.
 Defaults to current system hostname."""
     )
-    subparser.add_argument(
+    cdash_subgroup = subparser.add_mutually_exclusive_group()
+    cdash_subgroup.add_argument(
         '--cdash-track',
         default='Experimental',
         help="""Results will be reported to this group on CDash.
 Defaults to Experimental."""
+    )
+    cdash_subgroup.add_argument(
+        '--cdash-buildstamp',
+        default=None,
+        help="""Instead of letting the CDash reporter prepare the
+buildstamp which, when combined with build name, site and project,
+uniquely identifies the build, provide this argument to identify
+the build yourself.  Format: %%Y%%m%%d-%%H%%M-[cdash-track]"""
     )
     arguments.add_common_arguments(subparser, ['yes_to_all'])
 

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -72,9 +72,12 @@ class CDash(Reporter):
         self.site = args.cdash_site or socket.gethostname()
         self.osname = platform.system()
         self.endtime = int(time.time())
-        buildstamp_format = "%Y%m%d-%H%M-{0}".format(args.cdash_track)
-        self.buildstamp = time.strftime(buildstamp_format,
-                                        time.localtime(self.endtime))
+        if args.cdash_buildstamp:
+            self.buildstamp = args.cdash_buildstamp
+        else:
+            buildstamp_format = "%Y%m%d-%H%M-{0}".format(args.cdash_track)
+            self.buildstamp = time.strftime(buildstamp_format,
+                                            time.localtime(self.endtime))
         self.buildId = None
         self.revision = ''
         git = which('git')

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -8,6 +8,7 @@ import os
 import filecmp
 import re
 from six.moves import builtins
+import time
 
 import pytest
 
@@ -503,6 +504,33 @@ def test_cdash_upload_extra_params(tmpdir, mock_fetch, install_mockery, capfd):
             assert 'Site BuildName="my_custom_build"' in content
             assert 'Name="my_custom_site"' in content
             assert '-my_custom_track' in content
+
+
+@pytest.mark.disable_clean_stage_check
+def test_cdash_buildstamp_param(tmpdir, mock_fetch, install_mockery, capfd):
+    # capfd interferes with Spack's capturing
+    with capfd.disabled():
+        with tmpdir.as_cwd():
+            cdash_track = 'some_mocked_track'
+            buildstamp_format = "%Y%m%d-%H%M-{0}".format(cdash_track)
+            buildstamp = time.strftime(buildstamp_format,
+                                       time.localtime(int(time.time())))
+            with pytest.raises((HTTPError, URLError)):
+                install(
+                    '--log-file=cdash_reports',
+                    '--cdash-build=my_custom_build',
+                    '--cdash-site=my_custom_site',
+                    '--cdash-buildstamp={0}'.format(buildstamp),
+                    '--cdash-upload-url=http://localhost/fakeurl/submit.php?project=Spack',
+                    'a')
+            report_dir = tmpdir.join('cdash_reports')
+            assert report_dir in tmpdir.listdir()
+            report_file = report_dir.join('Build.xml')
+            assert report_file in report_dir.listdir()
+            content = report_file.open().read()
+            assert 'Site BuildName="my_custom_build"' in content
+            assert 'Name="my_custom_site"' in content
+            assert buildstamp in content
 
 
 @pytest.mark.disable_clean_stage_check


### PR DESCRIPTION
When providing a track, the cdash reporter will format the stamp
itself, as it has always done, and register the build during the
package installation process.  When providing a stamp, it should
first be formatted as cdash expects, and then cdash will be sure
to report results to same build id which was registered manually
elsewhere.