### PR TITLE
spack install --with-cache: Add --no-check-signature

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -42,7 +42,8 @@ def update_kwargs_from_args(args, kwargs):
         'use_cache': args.use_cache,
         'cache_only': args.cache_only,
         'explicit': True,  # Always true for install command
-        'stop_at': args.until
+        'stop_at': args.until,
+        'unsigned': args.unsigned,
     })
 
     kwargs.update({
@@ -98,6 +99,10 @@ the dependencies"""
         '--cache-only', action='store_true', dest='cache_only', default=False,
         help="only install package from binary mirrors")
 
+    subparser.add_argument(
+        '--no-check-signature', action='store_true',
+        dest='unsigned', default=False,
+        help="do not check signatures of binary packages")
     subparser.add_argument(
         '--show-log-on-error', action='store_true',
         help="print full build log to stderr if build fails")

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1508,7 +1508,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
                 message = '{s.name}@{s.version} : marking the package explicit'
                 tty.msg(message.format(s=self))
 
-    def try_install_from_binary_cache(self, explicit):
+    def try_install_from_binary_cache(self, explicit, unsigned=False):
         tty.msg('Searching for binary cache of %s' % self.name)
         specs = binary_distribution.get_spec(spec=self.spec,
                                              force=False)
@@ -1525,7 +1525,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         tty.msg('Installing %s from binary cache' % self.name)
         binary_distribution.extract_tarball(
             binary_spec, tarball, allow_root=False,
-            unsigned=False, force=False)
+            unsigned=unsigned, force=False)
         self.installed_from_binary_cache = True
         spack.store.db.add(
             self.spec, spack.store.layout, explicit=explicit)
@@ -1666,7 +1666,8 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         tty.msg(colorize('@*{Installing} @*g{%s}' % self.name))
 
         if kwargs.get('use_cache', True):
-            if self.try_install_from_binary_cache(explicit):
+            if self.try_install_from_binary_cache(
+                    explicit, unsigned=kwargs.get('unsigned', False)):
                 tty.msg('Successfully installed %s from binary cache'
                         % self.name)
                 print_pkg(self.prefix)

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -945,7 +945,7 @@ _spack_info() {
 _spack_install() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --only -u --until -j --jobs --overwrite --keep-prefix --keep-stage --dont-restage --use-cache --no-cache --cache-only --show-log-on-error --source -n --no-checksum -v --verbose --fake --only-concrete -f --file --clean --dirty --test --run-tests --log-format --log-file --help-cdash --cdash-upload-url --cdash-build --cdash-site --cdash-track --cdash-buildstamp -y --yes-to-all"
+        SPACK_COMPREPLY="-h --help --only -u --until -j --jobs --overwrite --keep-prefix --keep-stage --dont-restage --use-cache --no-cache --cache-only --no-check-signature --show-log-on-error --source -n --no-checksum -v --verbose --fake --only-concrete -f --file --clean --dirty --test --run-tests --log-format --log-file --help-cdash --cdash-upload-url --cdash-build --cdash-site --cdash-track --cdash-buildstamp -y --yes-to-all"
     else
         _all_packages
     fi


### PR DESCRIPTION
When running `spack install` with `--with-cache` (which is the default)
and spack will try to verify all packages found in the buildcache.

If the buildcache contains unsigned packages it will fail at
`lib/spack/spack/binary_distribution.py:522`.
```python
NoVerifyException(
    "Package spec file failed signature verification.\n"
    "Use spack buildcache keys to download "
    "and install a key for verification from the mirror.")
```

This commit introduces `--unsigned` for `spack install` so that unsigned
packages can be installed.