### PR TITLE
jdk: Fix fetching with curl 7.64.0+

### DIFF
--- a/var/spack/repos/builtin/packages/jdk/package.py
+++ b/var/spack/repos/builtin/packages/jdk/package.py
@@ -26,8 +26,8 @@ class Jdk(Package):
     # http://stackoverflow.com/questions/10268583/how-to-automate-download-and-installation-of-java-jdk-on-linux
     curl_options = [
         '-j',  # junk cookies
-        '-H',  # specify required License Agreement cookie
-        'Cookie: oraclelicense=accept-securebackup-cookie'
+        '-b',  # specify required License Agreement cookie
+        'oraclelicense=accept-securebackup-cookie'
     ]
 
     # To add the latest version, go to the homepage listed above,


### PR DESCRIPTION
With current `HEAD`:
```
$ spack fetch jdk
==> Fetching http://download.oracle.com/otn-pub/java/jdk/11.0.2+9/f51449fcd52f4d52b93a989c5c56ed3c/jdk-11.0.2_linux-x64_bin.tar.gz
==> Warning: The contents of the archive look like HTML. Either the URL you are trying to use does not exist or you have an internet gateway issue. You can remove the bad archive using 'spack clean <package>', then try again using the correct URL.
==> Error: sha256 checksum failed for ${SPACKFOLDER}/spack/var/spack/stage/jdk-11.0.2_9-eew5mfdv2z343v2z5nvb5hmcmwyi2o4j/jdk-11.0.2_linux-x64_bin.tar.gz
Expected 7b4fd8ffcf53e9ff699d964a80e4abf9706b5bdb5644a765c2b96f99e3a2cdc8 but got 80212f7748c2671b89b6085000717c747851db004409dce3bb97f3a2aeb91cdd
```

With this PR, fetching `jdk` works as expected again.

~~This fixes #11006.~~