### PR TITLE
Improve package dependencies and conflicts for various toolchains

### DIFF
--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -42,6 +42,10 @@ class Binutils(AutotoolsPackage):
     depends_on('m4', type='build', when='@:2.29.99 +gold')
     depends_on('bison', type='build', when='@:2.29.99 +gold')
 
+    def setup_environment(self, spack_env, run_env):
+        if self.spec.satisfies('%clang@7:'):
+            spack_env.append_flags('CXXFLAGS', '-std=gnu++98')
+
     def configure_args(self):
         spec = self.spec
 

--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -57,7 +57,12 @@ class Curl(AutotoolsPackage):
     def configure_args(self):
         spec = self.spec
 
-        args = ['--with-zlib={0}'.format(spec['zlib'].prefix)]
+        args = ['--without-libidn2',
+                '--without-libpsl',
+                '--without-libmetalink',
+                '--without-librtmp',
+                '--without-brotli',
+                '--with-zlib={0}'.format(spec['zlib'].prefix)]
         if spec.satisfies('+darwinssl'):
             args.append('--with-darwinssl')
         else:

--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -16,6 +16,7 @@ class Icu4c(AutotoolsPackage):
     list_url = "http://download.icu-project.org/files/icu4c"
     list_depth = 2
 
+    version('64.1', 'f150be2231c13bb45206d79e0242372b')
     version('60.1', '3d164a2d1bcebd1464c6160ebb8315ef')
     version('58.2', 'fac212b32b7ec7ab007a12dff1f3aea1')
     version('57.1', '976734806026a4ef8bdd17937c8898b9')

--- a/var/spack/repos/builtin/packages/moab/package.py
+++ b/var/spack/repos/builtin/packages/moab/package.py
@@ -85,6 +85,8 @@ class Moab(AutotoolsPackage):
     # FIXME it seems that zoltan needs to be built without fortran
     depends_on('zoltan~fortran', when='+zoltan')
 
+    patch('tools-492.patch', when='@4.9.2')
+
     def configure_args(self):
         spec = self.spec
 

--- a/var/spack/repos/builtin/packages/moab/tools-492.patch
+++ b/var/spack/repos/builtin/packages/moab/tools-492.patch
@@ -1,0 +1,11 @@
+--- a/tools/mbpart.cpp	2019-03-22 10:10:23.242049300 -0400
++++ b/tools/mbpart.cpp	2019-03-22 10:10:26.354738990 -0400
+@@ -491,7 +491,7 @@
+       rval = mb.write_file(tmp_output_file.str().c_str());
+       if (MB_SUCCESS != rval)
+       {
+-        std::cerr << tmp_output_file << " : failed to write file." << std::endl;
++        std::cerr << tmp_output_file.str() << " : failed to write file." << std::endl;
+         std::cerr << "  Error code: " << mb.get_error_string(rval) << " ("
+                   << rval << ")" << std::endl;
+         std::string errstr;

--- a/var/spack/repos/builtin/packages/ncbi-toolkit/package.py
+++ b/var/spack/repos/builtin/packages/ncbi-toolkit/package.py
@@ -16,7 +16,7 @@ class NcbiToolkit(AutotoolsPackage):
 
     depends_on('boost@1.35.0:')
     depends_on('bzip2')
-    depends_on('libjpeg')
+    depends_on('jpeg')
     depends_on('libpng')
     depends_on('libtiff')
     depends_on('libxml2')

--- a/var/spack/repos/builtin/packages/py-ipython/package.py
+++ b/var/spack/repos/builtin/packages/py-ipython/package.py
@@ -19,7 +19,9 @@ class PyIpython(PythonPackage):
     version('3.1.0', 'a749d90c16068687b0ec45a27e72ef8f')
     version('2.3.1', '2b7085525dac11190bfb45bb8ec8dcbf')
 
-    depends_on('python@2.7:2.8,3.3:')
+    depends_on('python@3.5:', when='@7.0.0:')
+    depends_on('python@3.3:', when='@6.0.0:6.9.9')
+    depends_on('python@2.7:2.8,3.3:', when='@:5.9.9')
 
     depends_on('py-backports-shutil-get-terminal-size', type=('build', 'run'), when="^python@:3.2")
     depends_on('py-pathlib2', type=('build', 'run'), when="^python@:3.3")

--- a/var/spack/repos/builtin/packages/py-pycurl/package.py
+++ b/var/spack/repos/builtin/packages/py-pycurl/package.py
@@ -15,5 +15,11 @@ class PyPycurl(PythonPackage):
 
     version('7.43.0', 'c94bdba01da6004fa38325e9bd6b9760')
 
-    depends_on('python@2.6:')
+    depends_on('python@2.6:', type=('build', 'run'))
     depends_on('curl@7.19.0:')
+
+    def build_args(self, spec, prefix):
+        args = ['--curl-config={0}/{1}'.format(spec['curl'].prefix.bin,
+                                               'curl-config')]
+
+        return args

--- a/var/spack/repos/builtin/packages/r-tiff/package.py
+++ b/var/spack/repos/builtin/packages/r-tiff/package.py
@@ -17,5 +17,5 @@ class RTiff(RPackage):
 
     version('0.1-5', '5052990b8647c77d3e27bc0ecf064e0b')
 
-    depends_on("libjpeg")
+    depends_on("jpeg")
     depends_on("libtiff")

--- a/var/spack/repos/builtin/packages/virtualgl/package.py
+++ b/var/spack/repos/builtin/packages/virtualgl/package.py
@@ -18,7 +18,7 @@ class Virtualgl(CMakePackage):
 
     version('2.5.2', '1a9f404f4a35afa9f56381cb33ed210c')
 
-    depends_on("libjpeg-turbo")
+    depends_on("jpeg")
     # virtualgl require OpenGL but also wants to link libglu
     # on systems without development packages, provide with spack and depends
     # on mesa-glu, but we do not want Mesa OpenGL sw emulation, so added

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -80,7 +80,7 @@ class Vtk(CMakePackage):
     depends_on('freetype')
     depends_on('glew')
     depends_on('hdf5')
-    depends_on('libjpeg')
+    depends_on('jpeg')
     depends_on('jsoncpp')
     depends_on('libxml2')
     depends_on('lz4')


### PR DESCRIPTION
These changes come from building specific versions of code using `%gcc@8.2.0` and `%clang@7.0.1`.