### PR TITLE
Remove Spack MKL hack for older version of QMCPACK.

### DIFF
--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -94,12 +94,12 @@ class Qmcpack(CMakePackage, CudaPackage):
 
     # Prior to QMCPACK 3.5.0 Intel MKL was not properly detected with
     # non-Intel compilers without a Spack-based hack. This hack
-    # had the potential to for negative side effects and let to more
+    # had the potential for negative side effects and led to more
     # complex Python code that would have been difficult to maintain
     # long term. Note that this has not been an issue since QMCPACK 3.5.0.
     # For older versions of QMCPACK, we issue a conflict below if you
-    # try to use Intel MKL with a non-Intel compilers.
-    mkl_warning = 'QMCPACK release prior to 3.5.0 require the ' \
+    # try to use Intel MKL with a non-Intel compiler.
+    mkl_warning = 'QMCPACK releases prior to 3.5.0 require the ' \
                   'Intel compiler when linking against Intel MKL'
     conflicts('%gcc', when='@:3.4.0 ^intel-mkl', msg=mkl_warning)
     conflicts('%pgi', when='@:3.4.0 ^intel-mkl', msg=mkl_warning)
@@ -285,7 +285,7 @@ class Qmcpack(CMakePackage, CudaPackage):
         ])
 
         # Next two environment variables were introduced in QMCPACK 3.5.0
-        # Prior to v3.5.0, these lines should be benign but you CMake
+        # Prior to v3.5.0, these lines should be benign but CMake
         # may issue a warning.
         if 'intel-mkl' in spec:
             args.append('-DENABLE_MKL=1')

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -92,6 +92,19 @@ class Qmcpack(CMakePackage, CudaPackage):
     conflicts('%pgi@:17', when='@3.6.0:', msg=compiler_warning)
     conflicts('%llvm@:3.4', when='@3.6.0:', msg=compiler_warning)
 
+    # Prior to QMCPACK 3.5.0 Intel MKL was not properly detected with
+    # non-Intel compilers without a Spack-based hack. This hack
+    # had the potential to for negative side effects and let to more
+    # complex Python code that would have been difficult to maintain
+    # long term. Note that this has not been an issue since QMCPACK 3.5.0.
+    # For older versions of QMCPACK, we issue a conflict below if you
+    # try to use Intel MKL with a non-Intel compilers.
+    mkl_warning = 'QMCPACK release prior to 3.5.0 require the ' \
+                  'Intel compiler when linking against Intel MKL'
+    conflicts('%gcc', when='@:3.4.0 ^intel-mkl', msg=mkl_warning)
+    conflicts('%pgi', when='@:3.4.0 ^intel-mkl', msg=mkl_warning)
+    conflicts('%llvm', when='@:3.4.0 ^intel-mkl', msg=mkl_warning)
+
     # Dependencies match those in the QMCPACK manual.
     # FIXME: once concretizer can unite unconditional and conditional
     # dependencies, some of the '~mpi' variants below will not be necessary.
@@ -258,35 +271,27 @@ class Qmcpack(CMakePackage, CudaPackage):
         # https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/dealii/package.py
         #
         # Basically, we override CMake's auto-detection mechanism
-        # and use the Spack's interface instead
+        # and use the Spack's interface instead.
+        #
+        # For version of QMCPACK prior to 3.5.0, the lines
+        # below are used for detection of all math libraries.
+        # For QMCPACK 3.5.0 and later, the lines below are only
+        # needed when MKL is *not* used. Thus, it is redundant
+        # but there are no negative side effects.
         lapack_blas = spec['lapack'].libs + spec['blas'].libs
         args.extend([
             '-DLAPACK_FOUND=true',
             '-DLAPACK_LIBRARIES=%s' % lapack_blas.joined(';')
         ])
 
-        # Additionally, we need to pass the BLAS+LAPACK include directory for
-        # header files. This is to insure vectorized math and FFT libraries
-        # get properly detected. Intel MKL requires special case due to
-        # differences in Darwin vs. Linux $MKLROOT naming schemes. This section
-        # of code is intentionally redundant for backwards compatibility.
+        # Next two environment variables were introduced in QMCPACK 3.5.0
+        # Prior to v3.5.0, these lines should be benign but you CMake
+        # may issue a warning.
         if 'intel-mkl' in spec:
-            lapack_dir = format(join_path(env['MKLROOT'], 'include'))
-            # Next two lines were introduced in QMCPACK 3.5.0 and later.
-            # Prior to v3.5.0, these lines should be benign.
             args.append('-DENABLE_MKL=1')
             args.append('-DMKL_ROOT=%s' % env['MKLROOT'])
         else:
             args.append('-DENABLE_MKL=0')
-            lapack_dir = ':'.join((
-                spec['lapack'].prefix.include,
-                spec['blas'].prefix.include
-            ))
-
-        args.extend([
-            '-DCMAKE_CXX_FLAGS=-I%s' % lapack_dir,
-            '-DCMAKE_C_FLAGS=-I%s' % lapack_dir
-        ])
 
         return args
 


### PR DESCRIPTION
A Spack hack for MKL usage was needed in QMCPACK prior to version 3.5 when non-Intel compilers were used. This Spack hack could have undesirable side-effects and led to ugly code that was extra work to maintain. For older version of QMCPACK, we through a conflict if you want to use Intel MKL with the other compilers commonly found on x86.

Note that there is no impact to version of QMCPACK since 3.5.