### PR TITLE
root: unset SPACK_INCLUDE_DIRS so the compiler wrapper does not prepend any -I flags. 

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -463,6 +463,7 @@ class Root(CMakePackage):
 
     def setup_environment(self, spack_env, run_env):
         run_env.prepend_path('PYTHONPATH', self.prefix.lib)
+        spack_env.set('SPACK_INCLUDE_DIRS', '')
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         spack_env.set('ROOTSYS', self.prefix)


### PR DESCRIPTION
The assumption is that cmake will set the correct include flags.