### PR TITLE
xsdk@develop: enable hypre shared (even on OSX) and superlu-dist variant

### DIFF
--- a/var/spack/repos/builtin/packages/xsdk/package.py
+++ b/var/spack/repos/builtin/packages/xsdk/package.py
@@ -30,7 +30,7 @@ class Xsdk(Package):
     variant('omega-h', default=True, description='Enable omega-h package build')
     variant('dealii', default=True, description='Enable dealii package build')
 
-    depends_on('hypre@develop~internal-superlu', when='@develop')
+    depends_on('hypre@develop~internal-superlu+superlu-dist+shared', when='@develop')
     depends_on('hypre@2.15.1~internal-superlu', when='@0.4.0')
     depends_on('hypre@2.12.1~internal-superlu', when='@0.3.0')
     depends_on('hypre@xsdk-0.2.0~internal-superlu', when='@xsdk-0.2.0')


### PR DESCRIPTION
ref: https://github.com/spack/spack/pull/10985

cc: @ulrikeyang