### PR TITLE
mumps: add version 5.1.2

### DIFF
--- a/var/spack/repos/builtin/packages/mumps/gfortran8.patch
+++ b/var/spack/repos/builtin/packages/mumps/gfortran8.patch
@@ -1,0 +1,68 @@
+From 5fe5b9e56f78de2b7b1c199688f6c73ff3ff4c2d Mon Sep 17 00:00:00 2001
+From: Satish Balay <balay@mcs.anl.gov>
+Date: Fri, 16 Nov 2018 08:51:56 -0600
+Subject: gfortran-8: workarround
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Reported-by: Sébastien Gilles <sebastien.gilles@inria.fr>
+
+Fixed-by: https://listes.ens-lyon.fr/sympa/arc/mumps-users/2018-11/msg00003.html
+
+diff --git a/src/ctype3_root.F b/src/ctype3_root.F
+index 715141e..9a4048a 100644
+--- a/src/ctype3_root.F
++++ b/src/ctype3_root.F
+@@ -805,8 +805,8 @@ C
+       END SUBROUTINE CMUMPS_INIT_ROOT_ANA
+       SUBROUTINE CMUMPS_INIT_ROOT_FAC( N, root, FILS, IROOT,
+      &                                 KEEP, INFO )
++      USE CMUMPS_STRUC_DEF
+       IMPLICIT NONE
+-      INCLUDE 'cmumps_root.h'
+       TYPE ( CMUMPS_ROOT_STRUC ):: root
+       INTEGER N, IROOT, INFO(40), KEEP(500)
+       INTEGER FILS( N )
+diff --git a/src/dtype3_root.F b/src/dtype3_root.F
+index fc670bd..c5d7bdd 100644
+--- a/src/dtype3_root.F
++++ b/src/dtype3_root.F
+@@ -805,8 +805,8 @@ C
+       END SUBROUTINE DMUMPS_INIT_ROOT_ANA
+       SUBROUTINE DMUMPS_INIT_ROOT_FAC( N, root, FILS, IROOT,
+      &                                 KEEP, INFO )
++      USE DMUMPS_STRUC_DEF
+       IMPLICIT NONE
+-      INCLUDE 'dmumps_root.h'
+       TYPE ( DMUMPS_ROOT_STRUC ):: root
+       INTEGER N, IROOT, INFO(40), KEEP(500)
+       INTEGER FILS( N )
+diff --git a/src/stype3_root.F b/src/stype3_root.F
+index 628dc05..0016002 100644
+--- a/src/stype3_root.F
++++ b/src/stype3_root.F
+@@ -805,8 +805,8 @@ C
+       END SUBROUTINE SMUMPS_INIT_ROOT_ANA
+       SUBROUTINE SMUMPS_INIT_ROOT_FAC( N, root, FILS, IROOT,
+      &                                 KEEP, INFO )
++      USE SMUMPS_STRUC_DEF
+       IMPLICIT NONE
+-      INCLUDE 'smumps_root.h'
+       TYPE ( SMUMPS_ROOT_STRUC ):: root
+       INTEGER N, IROOT, INFO(40), KEEP(500)
+       INTEGER FILS( N )
+diff --git a/src/ztype3_root.F b/src/ztype3_root.F
+index 713f975..3b70e9e 100644
+--- a/src/ztype3_root.F
++++ b/src/ztype3_root.F
+@@ -805,8 +805,8 @@ C
+       END SUBROUTINE ZMUMPS_INIT_ROOT_ANA
+       SUBROUTINE ZMUMPS_INIT_ROOT_FAC( N, root, FILS, IROOT,
+      &                                 KEEP, INFO )
++      USE ZMUMPS_STRUC_DEF
+       IMPLICIT NONE
+-      INCLUDE 'zmumps_root.h'
+       TYPE ( ZMUMPS_ROOT_STRUC ):: root
+       INTEGER N, IROOT, INFO(40), KEEP(500)
+       INTEGER FILS( N )

--- a/var/spack/repos/builtin/packages/mumps/package.py
+++ b/var/spack/repos/builtin/packages/mumps/package.py
@@ -15,6 +15,7 @@ class Mumps(Package):
     homepage = "http://mumps.enseeiht.fr"
     url      = "http://mumps.enseeiht.fr/MUMPS_5.0.1.tar.gz"
 
+    version('5.1.2', 'eb345cda145da9aea01b851d17e54e7eef08e16bfa148100ac1f7f046cd42ae9')
     version('5.1.1', 'f15c6b5dd8c71b1241004cd19818259d')
     version('5.0.2', '591bcb2c205dcb0283872608cdf04927')
     # Alternate location if main server is down.
@@ -51,6 +52,7 @@ class Mumps(Package):
     depends_on('mpi', when='+mpi')
 
     patch('examples.patch', when='@5.1.1%clang^spectrum-mpi')
+    patch('gfortran8.patch', when='@5.1.2')
 
     # this function is not a patch function because in case scalapack
     # is needed it uses self.spec['scalapack'].fc_link set by the


### PR DESCRIPTION
Add patch for gfortran-8 runtime errors

Ref: https://listes.ens-lyon.fr/sympa/arc/mumps-users/2018-11/msg00003.html