### PR TITLE
intel: consolidate libs() in the base class

### DIFF
--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -935,18 +935,26 @@ class IntelPackage(PackageBase):
     @property
     def libs(self):
         result = LibraryList([])
+        if '+tbb' in self.spec or self.provides('tbb'):
+            result = self.tbb_libs + result
+        if '+mkl' in self.spec or self.provides('blas'):
+            result = self.blas_libs + result
+        if '+mkl' in self.spec or self.provides('lapack'):
+            result = self.lapack_libs + result
         if '+mpi' in self.spec or self.provides('mpi'):
             # If prefix is too general, recursive searches may get files from
             # supported but inappropriate sub-architectures like 'mic'.
             libnames = ['libmpifort', 'libmpi']
             if 'cxx' in self.spec.last_query.extra_parameters:
                 libnames = ['libmpicxx'] + libnames
-            result += find_libraries(
+            result = find_libraries(
                 libnames,
                 root=self.component_lib_dir('mpi'),
-                shared=True, recursive=True)
+                shared=True, recursive=True) + result
+        
+        if '+mkl' in self.spec or self.provides('scalapack'):
+            libs = self.scalapack_libs + libs
 
-        # NB: MKL uses domain-specifics: blas_libs/lapack_libs/scalapack_libs
 
         debug_print(result)
         return result

--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -951,9 +951,9 @@ class IntelPackage(PackageBase):
                 libnames,
                 root=self.component_lib_dir('mpi'),
                 shared=True, recursive=True) + result
-        
+
         if '+mkl' in self.spec or self.provides('scalapack'):
-            libs = self.scalapack_libs + libs
+            result = self.scalapack_libs + result
 
         debug_print(result)
         return result

--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -955,7 +955,6 @@ class IntelPackage(PackageBase):
         if '+mkl' in self.spec or self.provides('scalapack'):
             libs = self.scalapack_libs + libs
 
-
         debug_print(result)
         return result
 

--- a/var/spack/repos/builtin/packages/intel-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-mkl/package.py
@@ -65,16 +65,3 @@ class IntelMkl(IntelPackage):
     if sys.platform == 'darwin':
         # there is no libmkl_gnu_thread on macOS
         conflicts('threads=openmp', when='%gcc')
-
-    @property
-    def libs(self):
-        libs = LibraryList([])
-        if self.provides('blas'):
-            libs = self.blas_libs
-        if self.provides('lapack'):
-            libs = self.lapack_libs + libs
-        if self.provides('scalapack'):
-            libs = self.scalapack_libs + libs
-
-        debug_print(libs)
-        return libs

--- a/var/spack/repos/builtin/packages/intel-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-mkl/package.py
@@ -6,7 +6,6 @@
 import sys
 
 from spack import *
-from spack.build_systems.intel import debug_print
 
 
 class IntelMkl(IntelPackage):

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.build_systems.intel import debug_print
 
 
 class IntelParallelStudio(IntelPackage):

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -196,16 +196,3 @@ class IntelParallelStudio(IntelPackage):
             'F90':  spack_fc,
             'FC':   spack_fc,
         })
-
-    @property
-    def libs(self):
-        libs = LibraryList([])
-        if self.provides('blas'):
-            libs = self.blas_libs
-        if self.provides('lapack'):
-            libs = self.lapack_libs + libs
-        if self.provides('scalapack'):
-            libs = self.scalapack_libs + libs
-
-        debug_print(libs)
-        return libs


### PR DESCRIPTION
follow up to https://github.com/spack/spack/pull/10993 , in that PR I did not notice that the base class already has `libs()`, we should have put everything there from the beginning.