### PR TITLE
Update setup-env.sh

### DIFF
--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -214,10 +214,10 @@ fi
 # Figure out where this file is.  Below code needs to be portable to
 # bash and zsh.
 #
-_sp_source_file="${BASH_SOURCE[0]}"  # Bash's location of last sourced file.
+_sp_source_file="${BASH_SOURCE[0]:-}"  # Bash's location of last sourced file.
 if [ -z "$_sp_source_file" ]; then
-    _sp_source_file="$0:A"           # zsh way to do it
-    if [[ "$_sp_source_file" == *":A" ]]; then
+    _sp_source_file="${(%):-%N}"       # zsh way to do it
+    if [ -z "$_sp_source_file" ]; then
         # Not zsh either... bail out with plain old $0,
         # which WILL NOT work if this is sourced indirectly.
         _sp_source_file="$0"


### PR DESCRIPTION
Per [this](https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/) post on safer bash scripts, I've been adding `set -Eeuxo pipefail` to many of my bash/zsh scripts. This caused `setup-env.sh` to fail during sourcing with an unset parameter error, namely `_sp_source_file`, because I use `zsh`. In addition, per [this](https://stackoverflow.com/questions/9901210/bash-source0-equivalent-in-zsh) SO question, the syntax for `BASH_SOURCE[0]` in `zsh` is slightly different than the existing code.

The proposed changes still look for `BASH_SOURCE[0]` first, but if it's not set, `_sp_source_file` is initialized to an empty value addressing the unset parameter error (line 217). The change on line 219 moves to the zsh syntax mentioned in the SO question referenced above.

Cheers,
David