### PR TITLE
Add variant to turn of wrapper ldflags in openmpi

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -223,6 +223,7 @@ class Openmpi(AutotoolsPackage):
         default=False,
         description='Do not remove mpirun/mpiexec when building with slurm'
     )
+    variant('wrapper_ldflags', default=True, description='Enable wrapper ldflags')
 
     provides('mpi')
     provides('mpi@:2.2', when='@1.6.5')
@@ -360,11 +361,12 @@ class Openmpi(AutotoolsPackage):
         ]
 
         # Add extra_rpaths dirs from compilers.yaml into link wrapper
-        rpaths = [self.compiler.cc_rpath_arg + path
-                  for path in self.compiler.extra_rpaths]
-        config_args.extend([
-            '--with-wrapper-ldflags={0}'.format(' '.join(rpaths))
-        ])
+        if spec.satisfies('+wrapper_ldflags', strict=True):
+            rpaths = [self.compiler.cc_rpath_arg + path
+                      for path in self.compiler.extra_rpaths]
+            config_args.extend([
+                '--with-wrapper-ldflags={0}'.format(' '.join(rpaths))
+            ])
 
         # According to this comment on github:
         #


### PR DESCRIPTION
This was added from 15d96f01660057463863a05049b287df3341175e, but it was causing strange linker problems for me, when I do not have this feature enabled my applications link and run correctly due /usr/lib64 being inserted, it caused protobuf 3.5.x to be linked incorrectly for me.

I've added this variant in as a default to have this enabled, setting it to false will disable this for those who need it.