### PR TITLE
libxsmm: fix missing install of bin

### DIFF
--- a/var/spack/repos/builtin/packages/libxsmm/package.py
+++ b/var/spack/repos/builtin/packages/libxsmm/package.py
@@ -97,6 +97,7 @@ class Libxsmm(MakefilePackage):
             os.rename(pcfile, os.path.join('lib/pkgconfig',
                                            os.path.basename(pcfile)))
 
+        install_tree('bin', prefix.bin)
         if '+header-only' in spec:
             install_tree('src', prefix.src)
         else:


### PR DESCRIPTION
This PR fixes `libxsmm` not installing the `bin` directory.