### PR TITLE
Added a function that concretizes specs together

### DIFF
--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -529,9 +529,9 @@ class NoCompilersForArchError(spack.error.SpackError):
                    (arch.os, arch.target))
 
         available_os_target_strs = list()
-        for operative_system, t in available_os_targets:
-            os_target_str = "%s-%s" % (operative_system, t) if t \
-                else operative_system
+        for operating_system, t in available_os_targets:
+            os_target_str = "%s-%s" % (operating_system, t) if t \
+                else operating_system
             available_os_target_strs.append(os_target_str)
         err_msg += (
             "\nCompilers are defined for the following"

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -15,6 +15,12 @@ TODO: make this customizable and allow users to configure
       concretization  policies.
 """
 from __future__ import print_function
+
+import os.path
+import tempfile
+import llnl.util.filesystem as fs
+import llnl.util.tty as tty
+
 from itertools import chain
 from functools_backport import reverse_order
 from contextlib import contextmanager
@@ -28,6 +34,7 @@ import spack.spec
 import spack.compilers
 import spack.architecture
 import spack.error
+import spack.tengine
 from spack.config import config
 from spack.version import ver, Version, VersionList, VersionRange
 from spack.package_prefs import PackagePrefs, spec_externals, is_spec_buildable
@@ -465,6 +472,54 @@ def _compiler_concretization_failure(compiler_spec, arch):
         raise UnavailableCompilerVersionError(compiler_spec, arch)
 
 
+def concretize_specs_together(*abstract_specs):
+    """Given a number of specs as input, tries to concretize them together.
+
+    Args:
+        *abstract_specs: abstract specs to be concretized
+
+    Returns:
+        List of concretized specs
+    """
+    # Create a temporary repository with an umbrella package
+    # that depends on each spec
+    tmpdir = tempfile.mkdtemp()
+    repo_path, namespace = spack.repo.create_repo(tmpdir)
+
+    debug_msg = '[CONCRETIZATION]: Creating helper repository in {0}'
+    tty.debug(debug_msg.format(repo_path))
+    pkg_dir = os.path.join(repo_path, 'packages', 'concretizationroot')
+    fs.mkdirp(pkg_dir)
+
+    environment = spack.tengine.make_environment()
+    template = environment.get_template('misc/coconcretization.pyt')
+
+    # Split recursive specs, as it seems the concretizer has issue
+    # respecting conditions on dependents expressed like
+    # depends_on('foo ^bar@1.0')
+    split_specs = []
+    for spec in abstract_specs:
+        split_specs.extend([s.strip() for s in spec.split('^')])
+
+    abstract_specs = [spack.spec.Spec(s) for s in abstract_specs]
+
+    with open(os.path.join(pkg_dir, 'package.py'), 'w') as f:
+        f.write(template.render(specs=[str(s) for s in split_specs]))
+
+    # Temporary use this repository on top of the existing ones
+    repo = spack.repo.Repo(repo_path)
+    with spack.repo.additional_repository(repo):
+        # Create a spec from that umbrella package and concretize it
+        concretization_root = spack.spec.Spec('concretizationroot')
+        concretization_root.concretize()
+        # Retrieve the direct dependencies
+        concrete_specs = [
+            concretization_root[spec.name] for spec in abstract_specs
+        ]
+
+    return concrete_specs
+
+
 class NoCompilersForArchError(spack.error.SpackError):
     def __init__(self, arch, available_os_targets):
         err_msg = ("No compilers found"
@@ -474,8 +529,9 @@ class NoCompilersForArchError(spack.error.SpackError):
                    (arch.os, arch.target))
 
         available_os_target_strs = list()
-        for os, t in available_os_targets:
-            os_target_str = "%s-%s" % (os, t) if t else os
+        for operative_system, t in available_os_targets:
+            os_target_str = "%s-%s" % (operative_system, t) if t \
+                else operative_system
             available_os_target_strs.append(os_target_str)
         err_msg += (
             "\nCompilers are defined for the following"

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -514,7 +514,7 @@ def concretize_specs_together(*abstract_specs):
         concretization_root.concretize()
         # Retrieve the direct dependencies
         concrete_specs = [
-            concretization_root[spec.name] for spec in abstract_specs
+            concretization_root[spec.name].copy() for spec in abstract_specs
         ]
 
     return concrete_specs

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -500,9 +500,8 @@ def concretize_specs_together(*abstract_specs):
         # Split recursive specs, as it seems the concretizer has issue
         # respecting conditions on dependents expressed like
         # depends_on('foo ^bar@1.0'), see issue #11160
-        split_specs = []
-        for spec in abstract_specs:
-            split_specs.extend([s.strip() for s in str(spec).split('^')])
+        split_specs = [str(dep) for spec in abstract_specs
+                       for dep in spec.traverse(root=True)]
 
         with open(os.path.join(pkg_dir, 'package.py'), 'w') as f:
             f.write(template.render(specs=[str(s) for s in split_specs]))

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -500,7 +500,7 @@ def concretize_specs_together(*abstract_specs):
         # Split recursive specs, as it seems the concretizer has issue
         # respecting conditions on dependents expressed like
         # depends_on('foo ^bar@1.0'), see issue #11160
-        split_specs = [str(dep) for spec in abstract_specs
+        split_specs = [dep for spec in abstract_specs
                        for dep in spec.traverse(root=True)]
 
         with open(os.path.join(pkg_dir, 'package.py'), 'w') as f:
@@ -512,7 +512,7 @@ def concretize_specs_together(*abstract_specs):
     concretization_repository = make_concretization_repository(abstract_specs)
 
     with spack.repo.additional_repository(concretization_repository):
-        # Create a spec from that umbrella package and concretize it
+        # Spec from a helper package that depends on all the abstract_specs
         concretization_root = spack.spec.Spec('concretizationroot')
         concretization_root.concretize()
         # Retrieve the direct dependencies

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1223,6 +1223,18 @@ def swap(repo_path):
     path = saved
 
 
+@contextlib.contextmanager
+def additional_repository(repository):
+    """Adds temporarily a repository to the default one.
+
+    Args:
+        repository: repository to be added
+    """
+    path.put_first(repository)
+    yield
+    path.remove(repository)
+
+
 class RepoError(spack.error.SpackError):
     """Superclass for repository-related errors."""
 

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -528,6 +528,11 @@ class TestConcretize(object):
         assert s.dag_hash() == t.dag_hash()
 
     @pytest.mark.parametrize('abstract_specs, checklist', [
+        # Establish a baseline - mpileaks alone concretizes with
+        # the newest version of callpath and dyninst
+        (['mpileaks'], [['callpath@1.0', 'dyninst@8.2']]),
+        # When concretized together with older version of callpath
+        # and dyninst it uses those older versions
         (['mpileaks', 'callpath@0.9', 'dyninst@8.1.1'],
          [['callpath@0.9', 'dyninst@8.1.1'],  # mpileaks
           ['callpath@0.9', 'dyninst@8.1.1'],  # callpath

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -546,3 +546,6 @@ class TestConcretize(object):
         specs = spack.concretize.concretize_specs_together(*abstract_specs)
         for spec, checks in zip(specs, checklist):
             assert all(check in spec for check in checks)
+            # Make sure the spec we test are top-level specs
+            # with no dependents
+            assert not spec.dependents()

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -535,6 +535,9 @@ class TestConcretize(object):
         ('mpileaks', 'callpath@0.9', 'dyninst@8.1.1'),
         # Handle recursive syntax within specs
         ('mpileaks', 'callpath@0.9 ^dyninst@8.1.1', 'dyninst'),
+        # Test specs that have overlapping dependencies but are not
+        # one a dependency of the other
+        ('mpileaks', 'direct-mpich')
     ])
     def test_simultaneous_concretization_of_specs(self, abstract_specs):
 

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -528,7 +528,6 @@ class TestConcretize(object):
         assert s.dag_hash() == t.dag_hash()
 
     @pytest.mark.parametrize('abstract_specs, checklist', [
-        # Handle
         (['mpileaks', 'callpath@0.9', 'dyninst@8.1.1'],
          [['callpath@0.9', 'dyninst@8.1.1'],  # mpileaks
           ['callpath@0.9', 'dyninst@8.1.1'],  # callpath

--- a/share/spack/templates/misc/coconcretization.pyt
+++ b/share/spack/templates/misc/coconcretization.pyt
@@ -1,0 +1,15 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class Concretizationroot(Package):
+    url = 'fake_url'
+
+    version('1.0')
+
+{% for dep in specs %}
+    depends_on('{{ dep }}')
+{% endfor %}
+


### PR DESCRIPTION
Refers to #9902
Refers to #11095

This PR adds a function that concretizes specs together or fails trying to do so.

### Rationale
In many contexts (e.g. when using Spack environments to develop software or sometimes when deploying applications in a container) there could be the need to concretize specs together - meaning there will be a single configuration for each package in the DAG. This PR adds a function that permits to do just that:
```python
import spack.concretize

# Hdf5 below will depend on `mpich` and `zlib@1.2.8`
concrete_specs = spack.concretize.concretize_specs_together('hdf5+mpi', 'zlib@1.2.8', 'mpich')
```
The function comes with unit tests and can be used later to solve issues like #9902

### Description
The implementation of this functionality relies on the current state of the concretizer and repository modules in Spack. This involves:
1. Creating a temporary repository on the fly that contains a fake package, whose only purpose is to depend on all the specs passed as input.
2. Concretize this fake package and extract its direct dependencies

Being factored within a single function, it shouldn't be difficult to adapt this once the new concretizer will be in place. If need be error handling (in particular user messages) can be improved either in this PR or in a follow up.

