### PR TITLE
Updated Sphinx configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,9 @@
+version: 2
+
+sphinx:
+  configuration: lib/spack/docs/conf.py
+
+python:
+  version: 3.7
+  install:
+    - requirements: lib/spack/docs/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ jobs:
           - r-base-core
           - r-base-dev
 
-    - python: '3.6'
+    - python: '3.7'
       sudo: required
       os: linux
       language: python

--- a/lib/spack/docs/requirements.txt
+++ b/lib/spack/docs/requirements.txt
@@ -1,6 +1,6 @@
 # These dependencies should be installed using pip in order
 # to build the documentation.
 
-sphinx==1.7.0
-sphinxcontrib-programoutput
-sphinx-rtd-theme
+sphinx==2.0.1
+sphinxcontrib-programoutput==0.14
+sphinx-rtd-theme==0.4.3


### PR DESCRIPTION
@zzotta reported chain docs not present in our online documentation even though they were merged yesterday. I tried to have a look at our builds on readthedocs and the most recent one was from 2 months 
 and 3 weeks ago. Manually triggering a build is failing:
![Screenshot from 2019-04-11 12-46-37](https://user-images.githubusercontent.com/4199709/55951945-b41a2300-5c58-11e9-8604-ccd35dd6de5d.png)

Looking at the failed build, there's a message from the readthedocs guys that suggests to update our configuration by using a yaml file (like Travis):

![Screenshot from 2019-04-11 12-55-24](https://user-images.githubusercontent.com/4199709/55952153-2854c680-5c59-11e9-97de-092ec6844619.png)

This PR is an attempt to write a valid YAML file for readthedocs and update the dependencies and environment for Sphinx builds.