### PR TITLE
Bugfix: Install missing compilers doesn't work for packages with dependencies

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1444,13 +1444,14 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
                 dep.package.do_install(**dep_kwargs)
 
         # Then, install the compiler if it is not already installed.
-        if install_deps:
-            tty.debug('Boostrapping {0} compiler for {1}'.format(
-                self.spec.compiler, self.name
-            ))
-            comp_kwargs = kwargs.copy()
-            comp_kwargs['explicit'] = False
-            self.bootstrap_compiler(**comp_kwargs)
+        if install_deps or not explicit:
+            if spack.config.get('config:install_missing_compilers', False):
+                tty.debug('Boostrapping {0} compiler for {1}'.format(
+                        self.spec.compiler, self.name
+                        ))
+                comp_kwargs = kwargs.copy()
+                comp_kwargs['explicit'] = False
+                self.bootstrap_compiler(**comp_kwargs)
 
         # Then, install the package proper
         tty.msg(colorize('@*{Installing} @*g{%s}' % self.name))

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1447,8 +1447,8 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         if install_deps or not explicit:
             if spack.config.get('config:install_missing_compilers', False):
                 tty.debug('Boostrapping {0} compiler for {1}'.format(
-                        self.spec.compiler, self.name
-                        ))
+                    self.spec.compiler, self.name
+                ))
                 comp_kwargs = kwargs.copy()
                 comp_kwargs['explicit'] = False
                 self.bootstrap_compiler(**comp_kwargs)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1441,18 +1441,15 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             dep_kwargs['explicit'] = False
             dep_kwargs['install_deps'] = False
             for dep in self.spec.traverse(order='post', root=False):
+                if spack.config.get('config:install_missing_compilers', False):
+                    tty.debug('Boostrapping {0} compiler for {1}'.format(
+                        self.spec.compiler, self.name
+                    ))
+                    comp_kwargs = kwargs.copy()
+                    comp_kwargs['explicit'] = False
+                    comp_kwargs['install_deps'] = True
+                    dep.package.bootstrap_compiler(**comp_kwargs)
                 dep.package.do_install(**dep_kwargs)
-
-        # Then, install the compiler if it is not already installed.
-        if install_deps or not explicit:
-            if spack.config.get('config:install_missing_compilers', False):
-                tty.debug('Boostrapping {0} compiler for {1}'.format(
-                    self.spec.compiler, self.name
-                ))
-                comp_kwargs = kwargs.copy()
-                comp_kwargs['explicit'] = False
-                comp_kwargs['install_deps'] = True
-                self.bootstrap_compiler(**comp_kwargs)
 
         # Then, install the package proper
         tty.msg(colorize('@*{Installing} @*g{%s}' % self.name))

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1451,6 +1451,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
                 ))
                 comp_kwargs = kwargs.copy()
                 comp_kwargs['explicit'] = False
+                comp_kwargs['install_deps'] = True
                 self.bootstrap_compiler(**comp_kwargs)
 
         # Then, install the package proper

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1442,7 +1442,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             dep_kwargs['install_deps'] = False
             for dep in self.spec.traverse(order='post', root=False):
                 if spack.config.get('config:install_missing_compilers', False):
-                    tty.debug('Boostrapping {0} compiler for {1}'.format(
+                    tty.debug('Bootstrapping {0} compiler for {1}'.format(
                         self.spec.compiler, self.name
                     ))
                     comp_kwargs = kwargs.copy()


### PR DESCRIPTION
This fixes the recursion so dependencies and packages with dependencies install properly using `install_missing_compilers`.