### PR TITLE
Forbid the assignment of Repo and RepoPath super-namespace

### DIFF
--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -638,11 +638,8 @@ class RepoPath(object):
         return self.first_repo()
 
     @autospec
-    def get(self, spec, new=False):
-        """Find a repo that contains the supplied spec's package.
-
-           Raises UnknownPackageError if not found.
-        """
+    def get(self, spec):
+        """Returns the package associated with the supplied spec."""
         return self.repo_for_pkg(spec).get(spec)
 
     def get_pkg_class(self, pkg_name):
@@ -873,6 +870,7 @@ class Repo(object):
 
     @autospec
     def get(self, spec):
+        """Returns the package associated with the supplied spec."""
         if not self.exists(spec.name):
             raise UnknownPackageError(spec.name)
 

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1138,15 +1138,15 @@ def create_repo(root, namespace=None):
             config.write("  namespace: '%s'\n" % namespace)
 
     except (IOError, OSError) as e:
-        raise BadRepoError('Failed to create new repository in %s.' % root,
-                           "Caused by %s: %s" % (type(e), e))
-
         # try to clean up.
         if existed:
             shutil.rmtree(config_path, ignore_errors=True)
             shutil.rmtree(packages_path, ignore_errors=True)
         else:
             shutil.rmtree(root, ignore_errors=True)
+
+        raise BadRepoError('Failed to create new repository in %s.' % root,
+                           "Caused by %s: %s" % (type(e), e))
 
     return full_path, namespace
 


### PR DESCRIPTION
fixes #11159 

This PR forbids the assignment of custom super-namespaces for `Repo` and `RepoPath`, as the only super-namespace supported by package directives is `spack.pkg`. 

It also adds a few minor maintenance changes:
- [x] Using `functools.wrap` for the `autospec decorator
- [x] Remove unused arguments from `RepoPath.get`
- [x] Move directory cleanup in `create_repo` before raising (the code was unreachable before)