### PR TITLE
don't record 'view: True' in environment config

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1029,7 +1029,14 @@ class Environment(object):
             view = self._view_path
         else:
             view = False
-        config_dict(self.yaml)['view'] = view
+
+        if view is not True:
+            # The default case is to keep an active view inside of the
+            # Spack environment directory. To avoid cluttering the config,
+            # we omit the setting in this case.
+            yaml_dict['view'] = view
+        elif 'view' in yaml_dict:
+            del yaml_dict['view']
 
         # if all that worked, write out the manifest file at the top level
         with fs.write_tmp_and_move(self.manifest_path) as f:


### PR DESCRIPTION
The default (implied) behavior for all environments, as of https://github.com/spack/spack/pull/10017, is that an environment will maintain a view in a location of its choosing. #10017 explicitly recorded all three possible states of maintaining a view:

1. Maintain a view, and let the environment decide where to put it (default)
2. Maintain a view, and let the user decide
3. Don't maintain a view

This PR updates the config writer so that for case [1], nothing will be written to the `config.yaml`. This will not change any existing behavior, it just serves to keep the config more compact (which ideally makes it more readable).