### PR TITLE
verilator: Fix FlexLexer.h not found

### DIFF
--- a/var/spack/repos/builtin/packages/verilator/package.py
+++ b/var/spack/repos/builtin/packages/verilator/package.py
@@ -39,7 +39,7 @@ class Verilator(AutotoolsPackage):
     version('3.904', '7d4dc8e61d5e0e564c3016a06f0b9d07')
 
     depends_on('bison', type='build')
-    depends_on('flex',  type='build')
+    depends_on('flex')
     depends_on('perl',  type=('build', 'run'))
 
     def setup_environment(self, spack_env, run_env):


### PR DESCRIPTION
Similar to #10956 flex needs to be a link-dependency for verilator in
order for `FlexLexer.h` to be found during install.