### PR TITLE
petsc: fix suitesparse configure options.

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -301,7 +301,7 @@ class Petsc(Package):
                 'camd,amd,suitesparseconfig'
             options.extend([
                 '--with-suitesparse-include=%s' % spec[ss_spec].prefix.include,
-                '--with-suitesparse-lib=%s' % spec[ss_spec].libs.ld_flags,
+                '--with-suitesparse-lib=%s' % spec[ss_spec].libs.joined(),
                 '--with-suitesparse=1'
             ])
         else:


### PR DESCRIPTION
- spec[ss_spec].libs.ld_flags results in:

--with-suitesparse-lib="-L/raid/home/sajid/packages/spack/opt/spack/linux-rhel7-x86_64/gcc-8.3.0/suite-sparse-5.3.0-vteg2xpr3uz2ppisgdrjtacwpavzydm7/lib -L/lib64 -lumfpack
-lklu -lcholmod -lbtf -lccolamd -lcolamd -lcamd -lamd -lsuitesparseconfig -lrt"

-L/lib64 from above results in system libraries getting picked-up instead of spack installed packages [in this case hdf5]

Fixed-by: "Smith, Barry F." <bsmith@mcs.anl.gov>
Reported-by: "Syed, Sajid Ali" <sajidsyed2021@u.northwestern.edu>

cc: @BarrySmith @s-sajid-ali 