### PR TITLE
hpx: overhaul of the package recipe

### DIFF
--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -38,10 +38,9 @@ class Hpx(CMakePackage, CudaPackage):
             description='Support for networking and multi=node runs')
     variant('tools', default=False, description='Build HPX tools')
 
-    depends_on('boost')
     depends_on('boost@1.55.0:')
     depends_on('hwloc@1.6:')
-    depends_on('python')
+    depends_on('python', type=('build', 'test', 'run'))
     depends_on('pkgconfig', type='build')
     depends_on('git', type='build')
 

--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -38,11 +38,20 @@ class Hpx(CMakePackage, CudaPackage):
             description='Support for networking and multi=node runs')
     variant('tools', default=False, description='Build HPX tools')
 
-    depends_on('boost@1.55.0:')
-    depends_on('hwloc@1.6:')
+    depends_on('boost')
+    depends_on('hwloc')
     depends_on('python', type=('build', 'test', 'run'))
     depends_on('pkgconfig', type='build')
     depends_on('git', type='build')
+
+    # Recommended dependency versions for 1.2.X
+    depends_on('cmake@3.9.0:', when='@:1.2.1', type='build')
+    depends_on('boost@1.62.0:', when='@:1.2.1')
+    depends_on('hwloc@1.11:', when='@:1.2.1')
+
+    # Recommended dependency versions before 1.2
+    depends_on('boost@1.55.0:', when='@:1.1.0')
+    depends_on('hwloc@1.6:', when='@:1.1.0')
 
     # CXX Standard
     depends_on('boost cxxstd=98', when='cxxstd=98')

--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -29,6 +29,9 @@ class Hpx(CMakePackage):
         'apex', 'google_perftools', 'papi', 'valgrind'
     ), description='Add support for various kind of instrumentation')
 
+    variant('networking', default=True,
+            description='Support for networking and multi=node runs')
+
     depends_on('boost@1.55.0:')
     depends_on('hwloc@1.6:')
     depends_on('python')
@@ -70,5 +73,10 @@ class Hpx(CMakePackage):
 
         # Instrumentation
         args.extend(self.instrumentation_args())
+
+        # Networking
+        args.append('-DHPX_WITH_NETWORKING={0}'.format(
+            'ON' if '+networking' in spec else 'OFF'
+        ))
 
         return args

--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -7,7 +7,7 @@
 from spack import *
 
 
-class Hpx(CMakePackage):
+class Hpx(CMakePackage, CudaPackage):
     """C++ runtime system for parallel and distributed applications."""
 
     homepage = "http://stellar.cct.lsu.edu/tag/hpx/"
@@ -31,6 +31,7 @@ class Hpx(CMakePackage):
 
     variant('networking', default=True,
             description='Support for networking and multi=node runs')
+    variant('tools', default=True, description='Build HPX tools')
 
     depends_on('boost@1.55.0:')
     depends_on('hwloc@1.6:')
@@ -77,6 +78,16 @@ class Hpx(CMakePackage):
         # Networking
         args.append('-DHPX_WITH_NETWORKING={0}'.format(
             'ON' if '+networking' in spec else 'OFF'
+        ))
+
+        # Cuda support
+        args.append('-DHPX_WITH_CUDA={0}'.format(
+            'ON' if '+cuda' in spec else 'OFF'
+        ))
+
+        # Tools
+        args.append('-DHPX_WITH_TOOLS={0}'.format(
+            'ON' if '+tools' in spec else 'OFF'
         ))
 
         return args

--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -11,13 +11,40 @@ class Hpx(CMakePackage):
     """C++ runtime system for parallel and distributed applications."""
 
     homepage = "http://stellar.cct.lsu.edu/tag/hpx/"
-    url      = "http://stellar.cct.lsu.edu/files/hpx_1.0.0.tar.gz"
+    url = "https://github.com/STEllAR-GROUP/hpx/archive/1.2.1.tar.gz"
 
-    version('1.0.0', '4983e7c6402417ec794d40343e36e417')
+    version('1.2.1', sha256='8cba9b48e919035176d3b7bbfc2c110df6f07803256626f1dad8d9dde16ab77a')
+    version('1.2.0', sha256='20942314bd90064d9775f63b0e58a8ea146af5260a4c84d0854f9f968077c170')
+    version('1.1.0', sha256='1f28bbe58d8f0da600d60c3a74a644d75ac777b20a018a5c1c6030a470e8a1c9')
+
+    version('1.0.0', '4983e7c6402417ec794d40343e36e417', url='http://stellar.cct.lsu.edu/files/hpx_1.0.0')
+
+    variant(
+        'malloc', default='tcmalloc',
+        description='define which allocator will be linked in',
+        values=('system', 'tcmalloc', 'jemalloc', 'tbbmalloc')
+    )
 
     depends_on('boost@1.55.0:')
     depends_on('hwloc@1.6:')
+    depends_on('python')
+    depends_on('pkgconfig', type='build')
+    depends_on('git', type='build')
+
+    # Malloc
+    depends_on('gperftools', when='malloc=tcmalloc')
+    depends_on('jemalloc', when='malloc=jemalloc')
+    depends_on('tbb', when='malloc=tbbmalloc')
+
+    # TODO: hpx can build perfectly fine in parallel, except that each
+    # TODO: process might need more than 2GB to compile. This is just the
+    # TODO: most conservative approach to ensure a sane build.
+    parallel = False
 
     def cmake_args(self):
-        args = ['-DHPX_BUILD_EXAMPLES=OFF', '-DHPX_MALLOC=system']
+        spec, args = self.spec, []
+
+        selected_malloc = spec.variants['malloc'].value
+        args.append('-DHPX_WITH_MALLOC={0}'.format(selected_malloc))
+
         return args


### PR DESCRIPTION
Modifications:

- [x] Added latest versions
- [x] Added support for different kind of malloc
- [x] Added support for instrumentation
- [x] Added support to activate or not `cuda`, networking and tools
- [x] Enforced the C++ standard through a variant, make it consistent with `boost`

