### PR TITLE
QMCPACK CMake fix

### DIFF
--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -190,6 +190,16 @@ class Qmcpack(CMakePackage, CudaPackage):
         args.append('-DCMAKE_C_FLAGS=%s' % ' '.join(cflags))
         args.append('-DCMAKE_CXX_FLAGS=%s' % ' '.join(cxxflags))
 
+        # This issue appears specifically with the the Intel compiler,
+        # but may be an issue with other compilers as well. The final fix
+        # probably needs to go into QMCPACK's CMake instead of in Spack.
+        # QMCPACK binaries are linked with the C++ compiler, but *may* contain
+        # Fortran libraries such as NETLIB-LAPACK and OpenBLAS on the link
+        # line. For the case of the Intel C++ compiler, we need to manually
+        # add a libray from the Intel Fortran compiler.
+        if self.compiler.name == 'intel':
+            args.append('-DQMC_EXTRA_LIBS=-lifcore')
+
         if '+mpi' in spec:
             mpi = spec['mpi']
             args.append('-DCMAKE_C_COMPILER={0}'.format(mpi.mpicc))

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -197,7 +197,7 @@ class Qmcpack(CMakePackage, CudaPackage):
         # Fortran libraries such as NETLIB-LAPACK and OpenBLAS on the link
         # line. For the case of the Intel C++ compiler, we need to manually
         # add a libray from the Intel Fortran compiler.
-        if self.compiler.name == 'intel':
+        if '%intel' in spec:
             args.append('-DQMC_EXTRA_LIBS=-lifcore')
 
         if '+mpi' in spec:

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -180,6 +180,16 @@ class Qmcpack(CMakePackage, CudaPackage):
         spec = self.spec
         args = []
 
+        # This bit of code is needed in order to pass compiler.yaml flags
+        # into the QMCPACK's CMake. Probably the CMake base class in
+        # the code of Spack should be doing this instead. Otherwise, it
+        # it would need to be done on a per package basis which is
+        # problematic.
+        cflags = spec.compiler_flags['cflags']
+        cxxflags = spec.compiler_flags['cxxflags']
+        args.append('-DCMAKE_C_FLAGS=%s' % ' '.join(cflags))
+        args.append('-DCMAKE_CXX_FLAGS=%s' % ' '.join(cxxflags))
+
         if '+mpi' in spec:
             mpi = spec['mpi']
             args.append('-DCMAKE_C_COMPILER={0}'.format(mpi.mpicc))


### PR DESCRIPTION
There are two separate CMake related fixes in the PR:

- cflags and cxxflags are not getting passed into CMake automatically. This causes problems when they are added either in packages.yaml or at the command line interface. A long term solution would be to add this kind of functionality into the CMake base package. However, it appears that many CMake Spack packages are already passing these flags explicitly into their own CMake.
- We need to add Intel's `ifcore` library into the link line. It is needed when linking a Fortran library, compiled by the Intel compiler, into the QMCPACK binary. This does not happen with GCC. Not sure if the responsibility should rest with the Intel compiler or QMCPACK's CMake. 