### PR TITLE
TERM no longer required for environment activation

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -125,12 +125,12 @@ def activate(
             cmds += 'setenv SPACK_OLD_PROMPT "${prompt}";\n'
             cmds += 'set prompt="%s ${prompt}";\n' % prompt
     else:
-        if prompt and 'color' in os.environ.get('TERM', ''):
-            prompt = colorize('@G{%s} ' % prompt, color=True)
-
         cmds += 'export SPACK_ENV=%s;\n' % env.path
         cmds += "alias despacktivate='spack env deactivate';\n"
         if prompt:
+            if 'color' in os.environ.get('TERM', ''):
+                prompt = colorize('@G{%s} ' % prompt, color=True)
+
             cmds += 'if [ -z "${SPACK_OLD_PS1}" ]; then\n'
             cmds += 'export SPACK_OLD_PS1="${PS1}"; fi;\n'
             cmds += 'export PS1="%s ${PS1}";\n' % prompt

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -125,7 +125,7 @@ def activate(
             cmds += 'setenv SPACK_OLD_PROMPT "${prompt}";\n'
             cmds += 'set prompt="%s ${prompt}";\n' % prompt
     else:
-        if 'color' in os.environ['TERM'] and prompt:
+        if prompt and 'color' in os.environ.get('TERM', ''):
             prompt = colorize('@G{%s} ' % prompt, color=True)
 
         cmds += 'export SPACK_ENV=%s;\n' % env.path


### PR DESCRIPTION
When using Spack Environments from a non-interactive shell (without the `TERM` variable) you will experience the follow:

```
$ spack env activate .
==> Error: 'TERM'
$ spack env status
==> Using spack.yaml in current directory: /ecp/gitlab-runner/pbryant/example-gitlab-ci/builds/users/pbryant/6da32c28/1/pbryant/example-gitlab-ci/test
```

Upon another review I realized this was still an exit status is 0 so as seen in the example the environment is activated; however, it is still something that makes sense to correct as the error message seems unnecessary.

@becker33 - apologies for having to recreate the PR, I did not properly account for the changes in 10017.