### PR TITLE
ftgl: update to 2.1.3-rc5.

### DIFF
--- a/var/spack/repos/builtin/packages/ftgl/ftgl-2.1.3-rc5-ldflags.patch
+++ b/var/spack/repos/builtin/packages/ftgl/ftgl-2.1.3-rc5-ldflags.patch
@@ -1,0 +1,118 @@
+diff -up ftgl-2.1.3~rc5/demo/Makefile.am.ldflags ftgl-2.1.3~rc5/demo/Makefile.am
+--- ftgl-2.1.3~rc5/demo/Makefile.am.ldflags	2008-06-02 03:10:10.000000000 +0200
++++ ftgl-2.1.3~rc5/demo/Makefile.am	2010-02-14 15:02:19.670081290 +0100
+@@ -9,14 +9,14 @@ simple_SOURCES = \
+     simple.cpp \
+     $(NULL)
+ simple_CXXFLAGS = $(FT2_CFLAGS) $(GL_CFLAGS)
+-simple_LDFLAGS = $(FT2_LIBS) $(GLUT_LIBS)
++simple_LDFLAGS = $(FT2_LIBS) $(GLUT_LIBS) $(GL_LIBS)
+ simple_LDADD = ../src/libftgl.la
+ 
+ c_demo_SOURCES = \
+     c-demo.c \
+     $(NULL)
+ c_demo_CFLAGS = $(FT2_CFLAGS) $(GL_CFLAGS)
+-c_demo_LDFLAGS = $(FT2_LIBS) $(GLUT_LIBS)
++c_demo_LDFLAGS = $(FT2_LIBS) $(GLUT_LIBS) $(GLUT_LIBS) -lm
+ c_demo_LDADD = ../src/libftgl.la
+ 
+ FTGLDemo_SOURCES = \
+@@ -27,7 +27,7 @@ FTGLDemo_SOURCES = \
+ 	trackball.h \
+ 	$(NULL)
+ FTGLDemo_CXXFLAGS = $(FT2_CFLAGS) $(GL_CFLAGS)
+-FTGLDemo_LDFLAGS = $(FT2_LIBS) $(GLUT_LIBS)
++FTGLDemo_LDFLAGS = $(FT2_LIBS) $(GLUT_LIBS) $(GL_LIBS)
+ FTGLDemo_LDADD = ../src/libftgl.la
+ 
+ FTGLMFontDemo_SOURCES = \
+@@ -38,7 +38,7 @@ FTGLMFontDemo_SOURCES = \
+ 	trackball.h \
+ 	$(NULL)
+ FTGLMFontDemo_CXXFLAGS = $(FT2_CFLAGS) $(GL_CFLAGS)
+-FTGLMFontDemo_LDFLAGS = $(FT2_LIBS) $(GLUT_LIBS)
++FTGLMFontDemo_LDFLAGS = $(FT2_LIBS) $(GLUT_LIBS) $(GL_LIBS)
+ FTGLMFontDemo_LDADD = ../src/libftgl.la
+ 
+ NULL =
+diff -up ftgl-2.1.3~rc5/demo/Makefile.in.ldflags ftgl-2.1.3~rc5/demo/Makefile.in
+--- ftgl-2.1.3~rc5/demo/Makefile.in.ldflags	2008-06-12 16:33:01.000000000 +0200
++++ ftgl-2.1.3~rc5/demo/Makefile.in	2010-02-14 15:02:01.866831398 +0100
+@@ -242,14 +242,14 @@ simple_SOURCES = \
+     $(NULL)
+ 
+ simple_CXXFLAGS = $(FT2_CFLAGS) $(GL_CFLAGS)
+-simple_LDFLAGS = $(FT2_LIBS) $(GLUT_LIBS)
++simple_LDFLAGS = $(FT2_LIBS) $(GLUT_LIBS) $(GL_LIBS)
+ simple_LDADD = ../src/libftgl.la
+ c_demo_SOURCES = \
+     c-demo.c \
+     $(NULL)
+ 
+ c_demo_CFLAGS = $(FT2_CFLAGS) $(GL_CFLAGS)
+-c_demo_LDFLAGS = $(FT2_LIBS) $(GLUT_LIBS)
++c_demo_LDFLAGS = $(FT2_LIBS) $(GLUT_LIBS) $(GL_LIBS) -lm
+ c_demo_LDADD = ../src/libftgl.la
+ FTGLDemo_SOURCES = \
+ 	FTGLDemo.cpp \
+@@ -260,7 +260,7 @@ FTGLDemo_SOURCES = \
+ 	$(NULL)
+ 
+ FTGLDemo_CXXFLAGS = $(FT2_CFLAGS) $(GL_CFLAGS)
+-FTGLDemo_LDFLAGS = $(FT2_LIBS) $(GLUT_LIBS)
++FTGLDemo_LDFLAGS = $(FT2_LIBS) $(GLUT_LIBS) $(GL_LIBS)
+ FTGLDemo_LDADD = ../src/libftgl.la
+ FTGLMFontDemo_SOURCES = \
+ 	FTGLMFontDemo.cpp \
+@@ -271,7 +271,7 @@ FTGLMFontDemo_SOURCES = \
+ 	$(NULL)
+ 
+ FTGLMFontDemo_CXXFLAGS = $(FT2_CFLAGS) $(GL_CFLAGS)
+-FTGLMFontDemo_LDFLAGS = $(FT2_LIBS) $(GLUT_LIBS)
++FTGLMFontDemo_LDFLAGS = $(FT2_LIBS) $(GLUT_LIBS) $(GL_LIBS)
+ FTGLMFontDemo_LDADD = ../src/libftgl.la
+ NULL = 
+ all: all-am
+diff -up ftgl-2.1.3~rc5/test/Makefile.am.ldflags ftgl-2.1.3~rc5/test/Makefile.am
+--- ftgl-2.1.3~rc5/test/Makefile.am.ldflags	2010-02-14 14:43:14.819077822 +0100
++++ ftgl-2.1.3~rc5/test/Makefile.am	2010-02-14 14:43:49.227081230 +0100
+@@ -51,7 +51,7 @@ AM_CPPFLAGS = \
+     $(NULL)
+ 
+ CXXTest_CXXFLAGS = $(FT2_CFLAGS) $(GL_CFLAGS)
+-CXXTest_LDFLAGS = $(FT2_LIBS) $(GLUT_LIBS) -lcppunit
++CXXTest_LDFLAGS = $(FT2_LIBS) $(GLUT_LIBS) $(GL_LIBS) -lcppunit
+ CXXTest_LDADD = ../src/libftgl.la
+ 
+ CTest_SOURCES = \
+@@ -64,7 +64,7 @@ CTest_CPPFLAGS = \
+     -I$(top_srcdir)/src/FTFont \
+     -I$(top_srcdir)/src/FTLayout
+ CTest_CFLAGS = $(FT2_CFLAGS) $(GL_CFLAGS)
+-CTest_LDFLAGS = $(FT2_LIBS) $(GLUT_LIBS)
++CTest_LDFLAGS = $(FT2_LIBS) $(GLUT_LIBS) $(GL_LIBS)
+ CTest_LDADD = ../src/libftgl.la
+ 
+ NULL =
+diff -up ftgl-2.1.3~rc5/test/Makefile.in.ldflags ftgl-2.1.3~rc5/test/Makefile.in
+--- ftgl-2.1.3~rc5/test/Makefile.in.ldflags	2010-02-14 14:43:20.365077958 +0100
++++ ftgl-2.1.3~rc5/test/Makefile.in	2010-02-14 14:44:13.653078013 +0100
+@@ -294,7 +294,7 @@ AM_CPPFLAGS = \
+     $(NULL)
+ 
+ CXXTest_CXXFLAGS = $(FT2_CFLAGS) $(GL_CFLAGS)
+-CXXTest_LDFLAGS = $(FT2_LIBS) $(GLUT_LIBS) -lcppunit
++CXXTest_LDFLAGS = $(FT2_LIBS) $(GLUT_LIBS) $(GL_LIBS) -lcppunit
+ CXXTest_LDADD = ../src/libftgl.la
+ CTest_SOURCES = \
+     CTest.c \
+@@ -308,7 +308,7 @@ CTest_CPPFLAGS = \
+     -I$(top_srcdir)/src/FTLayout
+ 
+ CTest_CFLAGS = $(FT2_CFLAGS) $(GL_CFLAGS)
+-CTest_LDFLAGS = $(FT2_LIBS) $(GLUT_LIBS)
++CTest_LDFLAGS = $(FT2_LIBS) $(GLUT_LIBS) $(GL_LIBS)
+ CTest_LDADD = ../src/libftgl.la
+ NULL = 
+ all: all-am

--- a/var/spack/repos/builtin/packages/ftgl/ftgl-2.1.3-rc5-ldflags.patch
+++ b/var/spack/repos/builtin/packages/ftgl/ftgl-2.1.3-rc5-ldflags.patch
@@ -14,7 +14,7 @@ diff -up ftgl-2.1.3~rc5/demo/Makefile.am.ldflags ftgl-2.1.3~rc5/demo/Makefile.am
      $(NULL)
  c_demo_CFLAGS = $(FT2_CFLAGS) $(GL_CFLAGS)
 -c_demo_LDFLAGS = $(FT2_LIBS) $(GLUT_LIBS)
-+c_demo_LDFLAGS = $(FT2_LIBS) $(GLUT_LIBS) $(GLUT_LIBS) -lm
++c_demo_LDFLAGS = $(FT2_LIBS) $(GLUT_LIBS) $(GL_LIBS) -lm
  c_demo_LDADD = ../src/libftgl.la
  
  FTGLDemo_SOURCES = \

--- a/var/spack/repos/builtin/packages/ftgl/package.py
+++ b/var/spack/repos/builtin/packages/ftgl/package.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-import sys
-import os
 
 
 class Ftgl(AutotoolsPackage):
@@ -16,10 +14,15 @@ class Ftgl(AutotoolsPackage):
     list_url = "https://sourceforge.net/projects/ftgl/files/FTGL%20Source/"
     list_depth = 1
 
-    version('2.1.2', 'f81c0a7128192ba11e036186f9a968f2')
+    version('2.1.3-rc5', sha256='5458d62122454869572d39f8aa85745fc05d5518001bcefa63bd6cbb8d26565b')
 
-    # There is an unnecessary qualifier around, which makes modern GCC sad
-    patch('remove-extra-qualifier.diff')
+    patch('ftgl-2.1.3-rc5-ldflags.patch')
+
+    def patch(self):
+        filter_file('SUBDIRS = src test demo docs',
+                    'SUBDIRS = src test demo', 'Makefile.am')
+        filter_file('SUBDIRS = src test demo docs',
+                    'SUBDIRS = src test demo', 'Makefile.in')
 
     # Ftgl does not come with a configure script
     depends_on('autoconf', type='build')
@@ -32,17 +35,17 @@ class Ftgl(AutotoolsPackage):
     depends_on('glu')
     depends_on('freetype@2.0.9:')
 
-    # Currently, "make install" will fail if the docs weren't built
-    #
-    # FIXME: Can someone with autotools experience fix the build system
-    #        so that it doesn't fail when that happens?
-    #
-    depends_on('doxygen', type='build')
-
-    @property
-    @when('@2.1.2')
-    def configure_directory(self):
-        subdir = 'unix'
-        if sys.platform == 'darwin':
-            subdir = 'mac'
-        return os.path.join(self.stage.source_path, subdir)
+    def configure_args(self):
+        args = ['--enable-shared', '--disable-static',
+                '--with-gl-inc={0}'.format(
+                    self.spec['gl'].prefix.include),
+                '--with-gl-lib={0}'.format(
+                    self.spec['gl'].prefix.lib),
+                '--with-freetype={0}'.format(
+                    self.spec['freetype'].prefix),
+                '--with-glut-inc={0}'.format(
+                    self.spec['glu'].prefix.include),
+                '--with-glut-lib={0}'.format(
+                    self.spec['glu'].prefix.lib),
+                '--with-x']
+        return args


### PR DESCRIPTION
This updates to the last release (from 2008) with patches required to work with Spack and Root.

These changes were implemented by @gartung on https://github.com/FNALssi/spack and abstracted for upstream by @chissg.