### PR TITLE
root: new versions, variants and patches

### DIFF
--- a/var/spack/repos/builtin/packages/root/find-mysql.patch
+++ b/var/spack/repos/builtin/packages/root/find-mysql.patch
@@ -1,0 +1,60 @@
+diff --git a/cmake/modules/FindMySQL.cmake b/cmake/modules/FindMySQL.cmake
+index c818f5a..755da92 100644
+--- a/cmake/modules/FindMySQL.cmake
++++ b/cmake/modules/FindMySQL.cmake
+@@ -10,11 +10,18 @@ if(MYSQL_INCLUDE_DIR OR MYSQL_)
+ endif()
+ 
+ if(NOT WIN32)
+-  find_program(MYSQL_CONFIG_EXECUTABLE mysql_config
+-    /usr/bin/
+-    /usr/local/bin
+-    ${MYSQL_DIR}/bin $ENV{MYSQL_DIR}/bin
+-  )
++  # Split into two find_program invocations to avoid user-specified
++  # mariadb_config being overridden by system mysql_config.
++  find_program(MYSQL_CONFIG_EXECUTABLE NAMES mysql_config mariadb_config
++    PATH_SUFFIXES bin
++    NO_DEFAULT_PATH
++    HINTS ${MYSQL_DIR} $ENV{MYSQL_DIR}
++    )
++  # Will not overwrite if MYSQL_CONFIG_EXECUTABLE is already set.
++  find_program(MYSQL_CONFIG_EXECUTABLE NAMES mysql_config mariadb_config
++    PATH_SUFFIXES bin
++    PATHS /usr/local /usr
++    )
+ endif()
+ 
+ if(MYSQL_CONFIG_EXECUTABLE)
+@@ -26,17 +33,22 @@ if(MYSQL_CONFIG_EXECUTABLE)
+   execute_process(COMMAND ${MYSQL_CONFIG_EXECUTABLE} --libs OUTPUT_VARIABLE MYSQL_LIBRARIES OUTPUT_STRIP_TRAILING_WHITESPACE)
+ else()
+   find_path(MYSQL_INCLUDE_DIR mysql.h
+-    /usr/local/mysql/include
+-    /usr/local/include/mysql
+-    /usr/local/include
+-    /usr/include/mysql
+-    /usr/include
+-    /usr/mysql/include
+-    $ENV{MYSQL_DIR}/include
+-  )
++    PATH_SUFFIXES include include/mysql include/mariadb
++    HINTS ${MYSQL_DIR} $ENV{MYSQL_DIR}
++    NO_DEFAULT_PATH
++    )
++  if (NOT MYSQL_INCLUDE_DIR)
++    find_path(MYSQL_INCLUDE_DIR mysql.h
++      PATH_SUFFIXES include include/mysql include/mariadb
++      PATHS /usr/local/mysql /usr/local /usr
++      )
++  endif()
+   set(MYSQL_NAMES mysqlclient mysqlclient_r)
+   find_library(MYSQL_LIBRARY NAMES ${MYSQL_NAMES}
+-    PATHS /usr/local/mysql/lib /usr/local/lib /usr/lib $ENV{MYSQL_DIR}/lib $ENV{MYSQL_DIR}/lib/opt
++    PATH_SUFFIXES lib lib/mariadb lib/mysql
++    lib/opt lib/opt/mariadb lib/opt/mysql
++    HINTS ${MYSQL_DIR} $ENV{MYSQL_DIR}
++    PATHS /usr/local/mysql /usr/local /usr
+   )
+   set(MYSQL_LIBRARIES ${MYSQL_LIBRARY})
+ endif()

--- a/var/spack/repos/builtin/packages/root/find-mysql.patch
+++ b/var/spack/repos/builtin/packages/root/find-mysql.patch
@@ -38,13 +38,13 @@ index c818f5a..755da92 100644
 -    /usr/mysql/include
 -    $ENV{MYSQL_DIR}/include
 -  )
-+    PATH_SUFFIXES include include/mysql include/mariadb
++    PATH_SUFFIXES include/mysql include/mariadb
 +    HINTS ${MYSQL_DIR} $ENV{MYSQL_DIR}
 +    NO_DEFAULT_PATH
 +    )
 +  if (NOT MYSQL_INCLUDE_DIR)
 +    find_path(MYSQL_INCLUDE_DIR mysql.h
-+      PATH_SUFFIXES include include/mysql include/mariadb
++      PATH_SUFFIXES include/mysql include/mariadb
 +      PATHS /usr/local/mysql /usr/local /usr
 +      )
 +  endif()

--- a/var/spack/repos/builtin/packages/root/format-stringbuf-size.patch
+++ b/var/spack/repos/builtin/packages/root/format-stringbuf-size.patch
@@ -1,0 +1,14 @@
+diff -Naur core/base/src/TString.cxx core/base/src/TString.cxx
+--- core/base/src/TString.cxx	2016-02-03 03:15:51.000000000 -0600
++++ core/base/src/TString.cxx	2016-02-22 16:51:35.283316959 -0600
+@@ -2397,8 +2397,8 @@
+ 
+ static char *Format(const char *format, va_list ap)
+ {
+-   static const int cb_size  = 4096;
+-   static const int fld_size = 2048;
++   static const int cb_size  = 3*4096;
++   static const int fld_size = 3*2048;
+ 
+    // a circular formating buffer
+    TTHREAD_TLS_ARRAY(char,cb_size,gFormbuf); // gFormbuf[cb_size]; // some slob for form overflow

--- a/var/spack/repos/builtin/packages/root/honor-unuran-switch.patch
+++ b/var/spack/repos/builtin/packages/root/honor-unuran-switch.patch
@@ -1,0 +1,26 @@
+From 20be628aeb0e2548693966b560fdde3e8d19c2d0 Mon Sep 17 00:00:00 2001
+From: Guilherme Amadio <amadio@cern.ch>
+Date: Tue, 8 May 2018 15:12:55 +0200
+Subject: [PATCH] Do not search for unuran or enable builtin_unuran if
+ unuran=OFF
+
+---
+ cmake/modules/SearchInstalledSoftware.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cmake/modules/SearchInstalledSoftware.cmake b/cmake/modules/SearchInstalledSoftware.cmake
+index f69158e..b47ba34 100644
+--- a/cmake/modules/SearchInstalledSoftware.cmake
++++ b/cmake/modules/SearchInstalledSoftware.cmake
+@@ -60,7 +60,7 @@ if(builtin_zlib)
+ endif()
+ 
+ #---Check for Unuran ------------------------------------------------------------------
+-if(NOT builtin_unuran)
++if(unuran AND NOT builtin_unuran)
+   message(STATUS "Looking for Unuran")
+   find_Package(Unuran)
+   if(NOT UNURAN_FOUND)
+-- 
+1.8.3.1
+

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -76,7 +76,8 @@ class Root(CMakePackage):
     variant('gdml', default=True,
         description='Enable GDML writer and reader')
     variant('gminimal', default=True,
-        description='Ignore most of Root\'s feature defaults except for basic graphic options')
+        description='Ignore most of Root\'s feature defaults except for '
+        'basic graphic options')
     variant('gsl', default=True,
         description='Enable linking against shared libraries for GSL')
     variant('http', default=False,
@@ -453,7 +454,8 @@ class Root(CMakePackage):
             '-Drfio:BOOL=OFF',      # not supported
             '-Droottest:BOOL=OFF',  # requires network
             '-Druby:BOOL=OFF',      # unmantained upstream
-            '-Druntime_cxxmodules:BOOL=OFF',  # use clang C++ modules, experimental
+            # Use clang C++ modules, experimental
+            '-Druntime_cxxmodules:BOOL=OFF',
             '-Dsapdb:BOOL=OFF',     # option not implemented
             '-Dsrp:BOOL=OFF',       # option not implemented
             '-Dtcmalloc:BOOL=OFF'

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -40,13 +40,28 @@ class Root(CMakePackage):
     version('6.06.02', sha256='18a4ce42ee19e1a810d5351f74ec9550e6e422b13b5c58e0c3db740cdbc569d1')
     version('5.34.38', sha256='2c3bda69601d94836bdd88283a6585b4774eafc813deb6aa348df0af2922c4d2')
 
+    # ###################### Patches ##########################
+
+    # Widely used patch (CMS, FNAL) to increase the size of static
+    # buffers used to improve the operation of TString.
     patch('format-stringbuf-size.patch', level=0)
+    # Support use of `mariadb-c-client` and `mariadb` to provide the
+    # MySQL API _cf_ https://github.com/root-project/root/pull/1993.
     patch('find-mysql.patch', level=1)
+    # Some ROOT versions did not honor the option to avoid building an
+    # internal version of unuran, _cf_
+    # https://github.com/root-project/ROOT/commit/3e60764f133218b6938e5aa4986de760e8f058d9.
     patch('honor-unuran-switch.patch', level=1, when='@:6.13.99')
+    # 6.16.00 fails to handle particular build option combinations, _cf_
+    # https://github.com/root-project/ROOT/commit/e0ae0483985d90a71a6cabd10d3622dfd1c15611.
     patch('root7-webgui.patch', level=1, when='@6.16.00')
 
     if sys.platform == 'darwin':
+        # Resolve non-standard use of uint, _cf_
+        # https://sft.its.cern.ch/jira/browse/ROOT-7886.
         patch('math_uint.patch', when='@6.06.02')
+        # Resolve circular dependency, _cf_
+        # https://sft.its.cern.ch/jira/browse/ROOT-8226.
         patch('root6-60606-mathmore.patch', when='@6.06.06')
 
     # ###################### Variants ##########################

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -190,6 +190,7 @@ class Root(CMakePackage):
     depends_on('libice')
     depends_on('libpng')
     depends_on('lz4', when='@6.13.02:')  # See cmake_args, below.
+    depends_on('ncurses')
     depends_on('pcre')
     depends_on('xxhash', when='@6.13.02:')  # See cmake_args, below.
     depends_on('xz')

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -46,8 +46,9 @@ class Root(CMakePackage):
     # buffers used to improve the operation of TString.
     patch('format-stringbuf-size.patch', level=0)
     # Support use of `mariadb-c-client` and `mariadb` to provide the
-    # MySQL API _cf_ https://github.com/root-project/root/pull/1993.
-    patch('find-mysql.patch', level=1)
+    # MySQL API _cf_
+    # https://github.com/root-project/root/commit/9c0fa8c554a569c971185249f9acfff4418c0c13.
+    patch('find-mysql.patch', level=1, when='@:6.16.00')
     # Some ROOT versions did not honor the option to avoid building an
     # internal version of unuran, _cf_
     # https://github.com/root-project/ROOT/commit/3e60764f133218b6938e5aa4986de760e8f058d9.

--- a/var/spack/repos/builtin/packages/root/root7-webgui.patch
+++ b/var/spack/repos/builtin/packages/root/root7-webgui.patch
@@ -1,0 +1,106 @@
+diff --git a/cmake/modules/CheckCompiler.cmake b/cmake/modules/CheckCompiler.cmake
+index 71f628f7f6..56d64fee43 100644
+--- a/cmake/modules/CheckCompiler.cmake
++++ b/cmake/modules/CheckCompiler.cmake
+@@ -130,10 +130,10 @@ if(cxx17)
+ endif()
+ if(root7)
+   if(cxx11)
+-    message(STATUS "ROOT7 interfaces require >= cxx14 which is disabled. Switching OFF root7 option")
+-    set(root7 OFF CACHE BOOL "" FORCE)
++    message(FATAL ERROR "ROOT 7 requires C++14 or higher")
++  elseif(NOT http)
++    set(http ON CACHE BOOL "(Enabled since it's needed by ROOT 7)" FORCE)
+   endif()
+-    set(http ON CACHE BOOL "" FORCE)
+ endif()
+ 
+ #---Check for libcxx option------------------------------------------------------------
+diff --git a/cmake/modules/RootBuildOptions.cmake b/cmake/modules/RootBuildOptions.cmake
+index f1e6237592..4406549367 100644
+--- a/cmake/modules/RootBuildOptions.cmake
++++ b/cmake/modules/RootBuildOptions.cmake
+@@ -156,6 +156,7 @@ ROOT_BUILD_OPTION(qt5web OFF "Enable support for Qt5 web-based display (requires
+ ROOT_BUILD_OPTION(r OFF "Enable support for R bindings (requires R, Rcpp, and RInside)")
+ ROOT_BUILD_OPTION(rfio OFF "Enable support for RFIO (Remote File IO) for CASTOR")
+ ROOT_BUILD_OPTION(roofit ON "Build RooFit advanced fitting package")
++ROOT_BUILD_OPTION(webui ON "Build Web-based UI components of ROOT (requires C++14 standard or higher)")
+ ROOT_BUILD_OPTION(root7 OFF "Build ROOT 7 components of ROOT (requires C++14 standard or higher)")
+ ROOT_BUILD_OPTION(rpath OFF "Link libraries with built-in RPATH (run-time search path)")
+ ROOT_BUILD_OPTION(runtime_cxxmodules OFF "Enable runtime support for C++ modules")
+@@ -317,6 +318,17 @@ endforeach()
+ #---Apply root7 versus language------------------------------------------------------------------
+ if(cxx14 OR cxx17 OR cxx14_defval OR cxx17_defval)
+   set(root7_defvalue ON)
++else()
++  set(root7_defvalue OFF)
++  set(webui_defvalue OFF)
++endif()
++
++if(webui)
++  if(cxx11)
++    message(FATAL_ERROR "WebUI requires C++14 or higher")
++  elseif(NOT http)
++    set(http ON CACHE BOOL "(Enabled since it's needed by webui)" FORCE)
++  endif()
+ endif()
+ 
+ #---roottest option implies testing
+diff --git a/cmake/modules/SearchInstalledSoftware.cmake b/cmake/modules/SearchInstalledSoftware.cmake
+index 8273d5e382..7598ccaaeb 100644
+--- a/cmake/modules/SearchInstalledSoftware.cmake
++++ b/cmake/modules/SearchInstalledSoftware.cmake
+@@ -1599,14 +1599,16 @@ endif()
+ 
+ 
+ #------------------------------------------------------------------------------------
+-ExternalProject_Add(
+-   OPENUI5
+-   URL ${CMAKE_SOURCE_DIR}/net/http/openui5/openui5.tar.gz
+-   URL_HASH SHA256=32e50e3e8808295c67ecb7561ea9cd9beb76dd934263170fbbd05ff59b6d501d
+-   CONFIGURE_COMMAND ""
+-   BUILD_COMMAND ""
+-   INSTALL_COMMAND ""
+-   SOURCE_DIR ${CMAKE_BINARY_DIR}/etc/http/openui5dist)
++if(webui)
++  ExternalProject_Add(
++    OPENUI5
++    URL ${CMAKE_SOURCE_DIR}/net/http/openui5/openui5.tar.gz
++    URL_HASH SHA256=32e50e3e8808295c67ecb7561ea9cd9beb76dd934263170fbbd05ff59b6d501d
++    CONFIGURE_COMMAND ""
++    BUILD_COMMAND ""
++    INSTALL_COMMAND ""
++    SOURCE_DIR ${CMAKE_BINARY_DIR}/etc/http/openui5dist)
++endif()
+ 
+ #---Report removed options---------------------------------------------------
+ foreach(opt afs glite sapdb srp chirp ios)
+diff --git a/gui/CMakeLists.txt b/gui/CMakeLists.txt
+index 499c427180..38b73b29cd 100644
+--- a/gui/CMakeLists.txt
++++ b/gui/CMakeLists.txt
+@@ -6,7 +6,7 @@ add_subdirectory(guihtml)
+ add_subdirectory(recorder)
+ add_subdirectory(sessionviewer)
+ 
+-if(cxx14 OR cxx17 OR root7)
++if(webui)
+    add_subdirectory(webdisplay)
+    if(cefweb)
+       add_subdirectory(cefdisplay)
+@@ -15,11 +15,10 @@ if(cxx14 OR cxx17 OR root7)
+       add_subdirectory(qt5webdisplay)
+    endif()
+    add_subdirectory(webgui6)
+-endif()
+-
+-if(root7)
+-  add_subdirectory(canvaspainter)
+-  add_subdirectory(fitpanelv7)
++   if(root7)
++     add_subdirectory(canvaspainter)
++     add_subdirectory(fitpanelv7)
++   endif()
+ endif()
+ if(qtgsi)
+   add_subdirectory(qtgsi)


### PR DESCRIPTION
This assorted improvement brings upstream `root` recipe into line with FNAL's use.

* Support MySQL.
* Patches:
    * Bigger stringbuf.
    * Find MySQL even when it's called `mariadb-c-client`.
    * Honor external provision of `unuran`.
    * Properly handle the ROOT7 web GUI for 6.16/00.
* `memstat` variant is now default-OFF due to version-related constraints.
* Add missing dependencies.
* Propagate `python` to `libxml2`.
* Handle external FTGL dependency with X / OpenGL: depends on #11214.
* Add `force=True` to `SPACK_INCLUDE_DIRS` to avoid Spack warning.
* New `gminimal` variant default ON per discussion with HSF Packaging Group.