### PR TITLE
llvm: prevent building llvm@8: with an incompatilble gcc

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -572,7 +572,8 @@ class Llvm(CMakePackage):
     conflicts('+lldb',        when='~clang')
 
     # LLVM 4 and 5 does not build with GCC 8
-    conflicts('%gcc@8:',      when='@:5')
+    conflicts('%gcc@8:',       when='@:5')
+    conflicts('%gcc@:5.0.999', when='@8:')
 
     # Github issue #4986
     patch('llvm_gcc7.patch', when='@4.0.0:4.0.1+lldb %gcc@7.0:')


### PR DESCRIPTION
While trying to build the latest `llvm@8.0.0`, `cmake` dies with the following error msg:

```
>> 19    CMake Error at cmake/modules/CheckCompilerVersion.cmake:40 (message):
   20      Host GCC version should be at least 5.1 because LLVM will soon use new C++                                                                              
   21      features which your toolchain version doesn't support.
```

This PR adds a proper `conflict` according to the message above.