### PR TITLE
Add Open MPI v3.0.4

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -75,6 +75,7 @@ class Openmpi(AutotoolsPackage):
     version('3.1.2', sha256='c654ed847f34a278c52a15c98add40402b4a90f0c540779f1ae6c489af8a76c5')  # libmpi.so.40.10.2
     version('3.1.1', sha256='3f11b648dd18a8b878d057e9777f2c43bf78297751ad77ae2cef6db0fe80c77c')  # libmpi.so.40.10.1
     version('3.1.0', sha256='b25c044124cc859c0b4e6e825574f9439a51683af1950f6acda1951f5ccdf06c')  # libmpi.so.40.10.0
+    version('3.0.4', sha256='2ff4db1d3e1860785295ab95b03a2c0f23420cda7c1ae845c419401508a3c7b5')  # libmpi.so.40.00.5
     version('3.0.3', sha256='fb228e42893fe6a912841a94cd8a0c06c517701ae505b73072409218a12cf066')  # libmpi.so.40.00.4
     version('3.0.2', sha256='d2eea2af48c1076c53cabac0a1f12272d7470729c4e1cb8b9c2ccd1985b2fb06')  # libmpi.so.40.00.2
     version('3.0.1', sha256='663450d1ee7838b03644507e8a76edfb1fba23e601e9e0b5b2a738e54acd785d')  # libmpi.so.40.00.1


### PR DESCRIPTION
tarball posted 2019-04-15
https://www.open-mpi.org/software/ompi/v3.0/

```
dantopa@cn209:openmpi-3.0.4-5ienfvwpcxky3nz5jt3rygxzxzltkwm4 $ cd lib/

dantopa@cn209:lib $ ls -alh
total 27M
...
lrwxrwxrwx 1 dantopa dantopa   16 Apr 17 10:01 libmpi.so -> libmpi.so.40.0.5
```

## confirmation builds Darwin (LANL): ##

### x86_64 ###
```
-- linux-centos7-x86_64 / gcc@4.8.5 -----------------------------
5ienfvw    openmpi@3.0.4%gcc
bkkhvej        ^hwloc@1.11.11%gcc
5chyfxo            ^libpciaccess@0.13.5%gcc
bcnjbc3            ^libxml2@2.9.8%gcc
tt2hkol            ^numactl@2.0.12%gcc
64vg6e4        ^zlib@1.2.11%gcc
```

## ARM ##
-- linux-rhel7-aarch64 / gcc@4.8.5 ------------------------------
```
cq2y6b3    openmpi@3.0.4%gcc
7gqvelc        ^hwloc@1.11.11%gcc
6a4he35            ^libpciaccess@0.13.5%gcc
6a5uzd6            ^libxml2@2.9.8%gcc
m5neuus            ^numactl@2.0.12%gcc
67s2oqn        ^zlib@1.2.11%gcc
```

## Power9 ##
-- linux-rhel7-ppc64le / gcc@4.8.5 ------------------------------
```
otirvfn    openmpi@3.0.4%gcc
r6cylpu        ^hwloc@1.11.11%gcc
uzm3xdv            ^libpciaccess@0.13.5%gcc
trik6hj            ^libxml2@2.9.8%gcc
pmgndwh            ^numactl@2.0.12%gcc
4v3ticy        ^zlib@1.2.11%gcc
```

2019-04-18

Signed-off-by: Daniel Topa <dantopa@lanl.gov>