### PR TITLE
Make module naming schemes backwards compatible

### DIFF
--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -65,6 +65,10 @@ _valid_tokens = (
     'compiler.name',
     'compiler.version',
     'architecture'
+    # tokens from old-style format strings
+    'package',
+    'compilername',
+    'compilerver',
 )
 
 


### PR DESCRIPTION
#10556 changed the format strings but maintained backwards compatibility in all cases except one.

The list of valid tokens for the module naming schemes was not updated properly to contain both the new and old styles for compilers and package names.

This PR re-adds the old tokens into the list of valid tokens.