### PR TITLE
Install squashfs exe's into prefix.bin, not prefix

### DIFF
--- a/var/spack/repos/builtin/packages/squashfs/package.py
+++ b/var/spack/repos/builtin/packages/squashfs/package.py
@@ -29,4 +29,4 @@ class Squashfs(MakefilePackage):
 
     def install(self, spec, prefix):
         with working_dir('squashfs-tools'):
-            make('install', 'INSTALL_DIR=%s' % prefix, parallel=False)
+            make('install', 'INSTALL_DIR=%s' % prefix.bin, parallel=False)


### PR DESCRIPTION
The squashfs Makefile's `INSTALL_DIR` args is the path to the `bin` directory, not the top of the install tree.

Adjust accordingly.

FYI: @vsoch 