### PR TITLE
Backport Environment managed views onto v0.12

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -664,6 +664,7 @@ class Environment(object):
             with fs.working_dir(self.path):
                 spec.package.do_install(**kwargs)
 
+            if not spec.external:
                 # Link the resulting log file into logs dir
                 build_log_link = os.path.join(
                     log_path, '%s-%s.log' % (spec.name, spec.dag_hash(7)))


### PR DESCRIPTION
We want to do a point release of `v0.12` that includes views in environments, so that we can add an example of this feature to the environments tutorial.