### PR TITLE
Fix spack flake8 to use Travis's target as base when needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -211,7 +211,7 @@ before_script:
   - git config --global user.name "Test User"
 
   # Need this to be able to compute the list of changed files
-  - git fetch origin develop:develop
+  - git fetch origin ${TRAVIS_BRANCH}:${TRAVIS_BRANCH}
 
   # Set up external deps for build tests, b/c they take too long to compile
   - if [[ "$TEST_SUITE" == "build" ]]; then

--- a/lib/spack/spack/cmd/flake8.py
+++ b/lib/spack/spack/cmd/flake8.py
@@ -96,7 +96,11 @@ def changed_files(args):
 
     git = which('git', required=True)
 
-    range = "{0}...".format(args.base)
+    base = args.base
+    if base is None:
+        base = os.environ.get('TRAVIS_BRANCH', 'develop')
+
+    range = "{0}...".format(base)
 
     git_args = [
         # Add changed files committed since branching off of develop
@@ -193,7 +197,7 @@ def filter_file(source, dest, output=False):
 
 def setup_parser(subparser):
     subparser.add_argument(
-        '-b', '--base', action='store', default='develop',
+        '-b', '--base', action='store', default=None,
         help="select base branch for collecting list of modified files")
     subparser.add_argument(
         '-k', '--keep-temp', action='store_true',


### PR DESCRIPTION
- We were previously hardcoding the branch that `spack flake8` bases its changes on to `develop`
- Now it will use `$TRAVIS_BRANCH` as the base instead of `develop`
- This is needed for cases where `develop` is not the PR target.