### PR TITLE
Update tutorial page with RIKEN tutorial slides.

### DIFF
--- a/lib/spack/docs/tutorial.rst
+++ b/lib/spack/docs/tutorial.rst
@@ -10,33 +10,48 @@ Tutorial: Spack 101
 =============================
 
 This is a full-day introduction to Spack with lectures and live demos.
-It was presented as a tutorial at the `Exascale Computing Project Annual
-Meeting <https://ecpannualmeeting.com/agenda.php>`_ in 2019.  You can use
-these materials to teach a course on Spack at your own site, or you can
-just skip ahead and read the live demo scripts to see how Spack is used
-in practice.
+It was presented as a tutorial for staff at the `RIKEN Center for
+Computational Science (R-CCS)
+<http://www.riken.jp/en/research/labs/r-ccs/>`_.  You can use these
+materials to teach a course on Spack at your own site, or you can just
+skip ahead and read the live demo scripts to see how Spack is used in
+practice.
 
 .. _sc16-slides:
 
 .. rubric:: Slides
 
 .. figure:: tutorial/sc16-tutorial-slide-preview.png
-   :target: http://spack.io/slides/Spack-ECP19-Tutorial.pdf
+   :target: https://spack.io/slides/Spack-RIKEN19-Tutorial.pdf
    :height: 72px
    :align: left
    :alt: Slide Preview
 
-`Download Slides <http://spack.io/slides/Spack-ECP19-Tutorial.pdf>`_.
+`Download Slides <https://spack.io/slides/Spack-RIKEN19-Tutorial.pdf>`_.
 
-**Full citation:** Todd Gamblin, Gregory Becker, Matt Legendre, Mario
-Melara, and Peter Scheibel.  `Spack Tutorial
-<https://whova.com/embedded/subsession/aecm_201901/503158/503161/>`_.
-Presented at ECP Annual Meeting 2019. January 14, 2019. Houston, TX, USA.
+**Full citation:** Todd Gamblin, Gregory Becker, and Peter Scheibel.
+Managing HPC Software Complexity with Spack.  Tutorial presented at RIKEN
+Center for Computational Science. April 23, 2019.  Kobe, Japan.
+
+.. _sc16-live-demos:
 
 .. rubric:: Live Demos
 
-These scripts will take you step-by-step through basic Spack tasks.  They
-correspond to sections in the slides above.
+We provide scripts that take you step-by-step through basic Spack tasks.
+They correspond to sections in the slides above. You can use one of the
+following methods to run through the scripts:
+
+  1. We provide the `spack/tutorial
+     <https://hub.docker.com/r/spack/tutorial>`_ container image on
+     Docker Hub that you can use to do the tutorial on your local
+     machine.  You can invoke ``docker run -it spack/tutorial`` to start
+     using the container.
+
+  2. When we host the tutorial, we also provision VM instances in `AWS
+     <https://aws.amazon.com/>`_, so that users who are unfamiliar with
+     Docker can simply log into a VPM to do the demo exercises.
+
+You should now be ready to run through our demo scripts:
 
   1. :ref:`basics-tutorial`
   2. :ref:`configs-tutorial`


### PR DESCRIPTION
- Add link to container image, as well as a description of VMs
- Update slide link to point to latest RIKEN tutorial