### PR TITLE
libunistring: added newer versions and fixed older ones

### DIFF
--- a/var/spack/repos/builtin/packages/libunistring/package.py
+++ b/var/spack/repos/builtin/packages/libunistring/package.py
@@ -11,7 +11,12 @@ class Libunistring(AutotoolsPackage):
     and for manipulating C strings according to the Unicode standard."""
 
     homepage = "https://www.gnu.org/software/libunistring/"
-    url      = "https://ftpmirror.gnu.org/libunistring/libunistring-0.9.7.tar.xz"
-
+    url      = "https://ftpmirror.gnu.org/libunistring/libunistring-0.9.10.tar.xz"
+    version('0.9.10', sha256='eb8fb2c3e4b6e2d336608377050892b54c3c983b646c561836550863003c05d7')
+    version('0.9.9',  sha256='a4d993ecfce16cf503ff7579f5da64619cee66226fb3b998dafb706190d9a833')
+    version('0.9.8',  sha256='7b9338cf52706facb2e18587dceda2fbc4a2a3519efa1e15a3f2a68193942f80')
     version('0.9.7', '82e0545363d111bfdfec2ddbfe62ffd3')
     version('0.9.6', 'cb09c398020c27edac10ca590e9e9ef3')
+
+    # glibc 2.28+ removed libio.h and thus _IO_ftrylockfile
+    patch('removed_libio.patch', when='@:0.9.9')

--- a/var/spack/repos/builtin/packages/libunistring/removed_libio.patch
+++ b/var/spack/repos/builtin/packages/libunistring/removed_libio.patch
@@ -1,0 +1,21 @@
+--- a/lib/fseterr.c
++++ b/lib/fseterr.c
+@@ -32,13 +32,17 @@
+ 
+ #include "stdio-impl.h"
+ 
++/* This file is not used on systems that have the __fseterr function,
++   namely musl libc.  */
++
+ void
+ fseterr (FILE *fp)
+ {
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1
++  /* GNU libc, BeOS, Haiku, Linux libc5 */
+   fp->_flags |= _IO_ERR_SEEN;
+ #elif defined __sferror || defined __DragonFly__ || defined __ANDROID__
+   /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin, Minix 3, Android */


### PR DESCRIPTION
glibc 2.28+ removed libio.h where `_IO_ftrylockfile` was defined, thus causing the build to fail in `./lib/fseterr.c`. I added a patch to check for `IO_EOF_SEEN` as well like libunistring does since version 0.9.10.