### PR TITLE
Added new package libidn2 as explicit dependency for gnutls...

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -79,6 +79,7 @@ class Cmake(Package):
     depends_on('openssl', when='+openssl')
     depends_on('openssl@:1.0.99', when='@:3.6.9+openssl')
     depends_on('ncurses',        when='+ncurses')
+    depends_on('gnutls')
 
     # Cannot build with Intel, should be fixed in 3.6.2
     # https://gitlab.kitware.com/cmake/cmake/issues/16226

--- a/var/spack/repos/builtin/packages/gnutls/package.py
+++ b/var/spack/repos/builtin/packages/gnutls/package.py
@@ -15,8 +15,9 @@ class Gnutls(AutotoolsPackage):
     and efficient with focus on security and interoperability."""
 
     homepage = "http://www.gnutls.org"
-    url      = "https://www.gnupg.org/ftp/gcrypt/gnutls/v3.5/gnutls-3.5.13.tar.xz"
+    url      = "https://www.gnupg.org/ftp/gcrypt/gnutls/v3.5/gnutls-3.5.19.tar.xz"
 
+    version('3.5.19', sha256='1936eb64f03aaefd6eb16cef0567457777618573826b94d03376bb6a4afadc44')
     version('3.5.13', '4fd41ad86572933c2379b4cc321a0959')
     version('3.5.10', '336c03a71ba90184ffd0388075dde504')
     version('3.5.9',  '0ab25eb6a1509345dd085bc21a387951')
@@ -27,6 +28,7 @@ class Gnutls(AutotoolsPackage):
     # Note that version 3.3.9 of gnutls doesn't support nettle 3.0.
     depends_on('nettle@:2.9', when='@3.3.9')
     depends_on('nettle', when='@3.5:')
+    depends_on('libidn2@:2.0.99', when='@:3.5.99')
     depends_on('zlib', when='+zlib')
     depends_on('gettext')
 

--- a/var/spack/repos/builtin/packages/libidn2/package.py
+++ b/var/spack/repos/builtin/packages/libidn2/package.py
@@ -19,7 +19,6 @@ class Libidn2(AutotoolsPackage):
     version('2.1.0',  sha256='032398dbaa9537af43f51a8d94e967e3718848547b1b2a4eb3138b20cad11d32')
     version('2.0.5',  sha256='53f69170886f1fa6fa5b332439c7a77a7d22626a82ef17e2c1224858bb4ca2b8')
 
-    # FIXME: Add dependencies if required.
     depends_on('libunistring')
 
     # in-source build fails

--- a/var/spack/repos/builtin/packages/libidn2/package.py
+++ b/var/spack/repos/builtin/packages/libidn2/package.py
@@ -25,7 +25,8 @@ from spack import *
 
 class Libidn2(AutotoolsPackage):
     """Libidn2 is a free software implementation of IDNA2008, Punycode and
-    TR46. Its purpose is to encode and decode internationalized domain names."""
+    TR46. Its purpose is to encode and decode internationalized domain
+    names."""
 
     homepage = "https://gitlab.com/libidn/libidn2"
     url      = "https://ftp.gnu.org/gnu/libidn/libidn2-2.0.5.tar.gz"

--- a/var/spack/repos/builtin/packages/libidn2/package.py
+++ b/var/spack/repos/builtin/packages/libidn2/package.py
@@ -1,0 +1,42 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install libidn2
+#
+# You can edit this file again by typing:
+#
+#     spack edit libidn2
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+from spack import *
+
+
+class Libidn2(AutotoolsPackage):
+    """Libidn2 is a free software implementation of IDNA2008, Punycode and
+    TR46. Its purpose is to encode and decode internationalized domain names."""
+
+    homepage = "https://gitlab.com/libidn/libidn2"
+    url      = "https://ftp.gnu.org/gnu/libidn/libidn2-2.0.5.tar.gz"
+
+    version('2.1.1a', sha256='57666bcf6ecf54230d7bac95c392379561954b57a673903aed4d3336b3048b72')
+    version('2.1.1',  sha256='95416080329298a13269e13175041b530cec3d98b54cafae9424b8dfd22078b1')
+    version('2.1.0',  sha256='032398dbaa9537af43f51a8d94e967e3718848547b1b2a4eb3138b20cad11d32')
+    version('2.0.5',  sha256='53f69170886f1fa6fa5b332439c7a77a7d22626a82ef17e2c1224858bb4ca2b8')
+
+    # FIXME: Add dependencies if required.
+    depends_on('libunistring')
+
+    # in-source build fails
+    build_directory = 'spack-build'

--- a/var/spack/repos/builtin/packages/libidn2/package.py
+++ b/var/spack/repos/builtin/packages/libidn2/package.py
@@ -3,23 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-# ----------------------------------------------------------------------------
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install libidn2
-#
-# You can edit this file again by typing:
-#
-#     spack edit libidn2
-#
-# See the Spack documentation for more information on packaging.
-# ----------------------------------------------------------------------------
-
 from spack import *
 
 


### PR DESCRIPTION
...also added gnutls as explicit dependency of cmake

I had trouble building cmake on my machine as it tried to use my global libgnutls which was apparently too new. After adding gnutls as an explicit dependency to cmake, I ran into trouble building gnutls as it tried to use my global libidn2 which also was too new. This fixed it.