### PR TITLE
Change openfoam-com kahip variant to default False

### DIFF
--- a/var/spack/repos/builtin/packages/openfoam-com/package.py
+++ b/var/spack/repos/builtin/packages/openfoam-com/package.py
@@ -276,7 +276,7 @@ class OpenfoamCom(Package):
             description='With 64-bit labels')
     variant('knl', default=False,
             description='Use KNL compiler settings')
-    variant('kahip', default=True,
+    variant('kahip', default=False,
             description='With kahip decomposition')
     variant('metis', default=False,
             description='With metis decomposition')


### PR DESCRIPTION
Kahip does not build with clang (`conflicts('%clang')` in kahip package.

Because of this, openfoam-com %clang fails concretization.

In light of this, consider changing default openfoam-com variant for kahip to False.