### PR TITLE
Lua: Fix unresolved symbols in shared library by linking with libdl.so

### DIFF
--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -58,7 +58,8 @@ class Lua(Package):
              'install')
 
         static_to_shared_library(join_path(prefix.lib, 'liblua.a'),
-                                 arguments=['-lm', '-ldl'], version=self.version,
+                                 arguments=['-lm', '-ldl'],
+                                 version=self.version,
                                  compat_version=self.version.up_to(2))
 
         # compatibility with ax_lua.m4 from autoconf-archive

--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -58,7 +58,7 @@ class Lua(Package):
              'install')
 
         static_to_shared_library(join_path(prefix.lib, 'liblua.a'),
-                                 arguments=['-lm'], version=self.version,
+                                 arguments=['-lm', '-ldl'], version=self.version,
                                  compat_version=self.version.up_to(2))
 
         # compatibility with ax_lua.m4 from autoconf-archive


### PR DESCRIPTION
The current lua package.py does not link with libdl.so, so you get unresolved symbols while linking with lua. This PR fixes this issue