### PR TITLE
squashfs should depend_on('zlib')

### DIFF
--- a/var/spack/repos/builtin/packages/squashfs/package.py
+++ b/var/spack/repos/builtin/packages/squashfs/package.py
@@ -22,6 +22,7 @@ class Squashfs(MakefilePackage):
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
+    depends_on('zlib')
 
     def build(self, spec, prefix):
         with working_dir('squashfs-tools'):


### PR DESCRIPTION
On my CentOS system it was getting linked in (from Spack, no less)
fortuitously.

On a minimal Ubuntu system it failed until it was added as an explicit
dependency.