### PR TITLE
Add margo package and add rc1 tag for argobots package

### DIFF
--- a/var/spack/repos/builtin/packages/argobots/package.py
+++ b/var/spack/repos/builtin/packages/argobots/package.py
@@ -20,6 +20,7 @@ class Argobots(AutotoolsPackage):
     git      = "https://github.com/pmodels/argobots.git"
 
     version("develop", branch="master")
+    version("1.0rc1", "729c018f3353976cb79c07ecaa13319d")
     version("1.0b1", "5eeab7b2c639d08bbea22db3026cdf39")
     version("1.0a1", "9d29d57d14d718f93b505178f6ba3e08")
 

--- a/var/spack/repos/builtin/packages/margo/package.py
+++ b/var/spack/repos/builtin/packages/margo/package.py
@@ -1,0 +1,50 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Margo(AutotoolsPackage):
+    """Argobots bindings to the Mercury RPC API"""
+
+    homepage = "https://xgitlab.cels.anl.gov/sds/margo"
+    url      = "https://xgitlab.cels.anl.gov/sds/margo/-/archive/v0.4.3/margo-v0.4.3.tar.gz"
+    git      = "https://xgitlab.cels.anl.gov/sds/margo.git"
+
+    maintainers = ['fbudin69500', 'chuckatkins']
+
+    version('develop', branch='master')
+    version('0.4.3', sha256='61a634d6983bee2ffa06e1e2da4c541cb8f56ddd9dd9f8e04e8044fb38657475')
+
+    variant('shared', default=True,
+            description='Build shared libraries instead of static libraries')
+
+    depends_on('autoconf',  type='build')
+    depends_on('automake',  type='build')
+    depends_on('libtool',   type='build')
+    depends_on('m4',        type='build')
+    depends_on('pkgconfig', type='build')
+
+    depends_on('mercury')
+    depends_on('argobots@1.0rc1:')
+
+    build_directory = 'spack-build'
+
+    def configure_args(self):
+        spec = self.spec
+        args = []
+
+        if '+shared' in spec:
+            args.append('--enable-shared')
+            args.append('--disable-static')
+        else:
+            args.append('--enable-static')
+            args.append('--disable-shared')
+
+        return args
+
+    def autoreconf(self, spec, prefix):
+        sh = which('sh')
+        sh('./prepare.sh')


### PR DESCRIPTION
margo package is a required dependency for unifycr but the package
was not available in spack. margo requires a recent version of argobots
that has the ABT_SCHED_BASIC_WAIT scheduler (rc1 does while previously
available versions of this package in spack did not have it).