### PR TITLE
patched a py3.7+-related-bug for llvm 6.0.0 & 6.0.1

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/llvm6.0.0+py3.7.patch
+++ b/var/spack/repos/builtin/packages/llvm/llvm6.0.0+py3.7.patch
@@ -1,0 +1,37 @@
+From ecdefed7f6ba11421fe1ecc6c13a135ab7bcda73 Mon Sep 17 00:00:00 2001
+From: Pavel Labath <labath@google.com>
+Date: Mon, 23 Jul 2018 11:37:36 +0100
+Subject: [PATCH] Fix PythonString::GetString for >=python-3.7
+
+
+The return value of PyUnicode_AsUTF8AndSize is now "const char *".
+---
+ .../Plugins/ScriptInterpreter/Python/PythonDataObjects.cpp  | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/tools/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.cpp b/tools/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.cpp
+index 6a9d57d5a..94f16b2c7 100644
+--- a/tools/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.cpp
++++ b/tools/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.cpp
+@@ -399,14 +399,16 @@ llvm::StringRef PythonString::GetString() const {
+     return llvm::StringRef();
+ 
+   Py_ssize_t size;
+-  char *c;
++  const char *data;
+ 
+ #if PY_MAJOR_VERSION >= 3
+   data = PyUnicode_AsUTF8AndSize(m_py_obj, &size);
+ #else
++  char *c;
+   PyString_AsStringAndSize(m_py_obj, &c, &size);
++  data = c;
+ #endif
+-  return llvm::StringRef(c, size);
++  return llvm::StringRef(data, size);
+ }
+ 
+ size_t PythonString::GetSize() const {
+-- 
+2.18.0.233.g985f88cf7e-goog
+

--- a/var/spack/repos/builtin/packages/llvm/llvm6.0.1+py3.7.patch
+++ b/var/spack/repos/builtin/packages/llvm/llvm6.0.1+py3.7.patch
@@ -1,0 +1,24 @@
+Fixed PythonString::GetString for llvm-6.0.1 (based on the 6.0.0 patch by Pavel Labath)
+
+--- a/tools/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.cpp
++++ b/tools/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.cpp
+@@ -404,14 +404,16 @@
+     return llvm::StringRef();
+ 
+   Py_ssize_t size;
+-  char *c;
++  const char *data;
+ 
+ #if PY_MAJOR_VERSION >= 3
+-  c = PyUnicode_AsUTF8AndSize(m_py_obj, &size);
++  data = PyUnicode_AsUTF8AndSize(m_py_obj, &size);
+ #else
++  char *c;
+   PyString_AsStringAndSize(m_py_obj, &c, &size);
++  data = c;
+ #endif
+-  return llvm::StringRef(c, size);
++  return llvm::StringRef(data, size);
+ }
+ 
+ size_t PythonString::GetSize() const {

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -577,6 +577,12 @@ class Llvm(CMakePackage):
 
     # Github issue #4986
     patch('llvm_gcc7.patch', when='@4.0.0:4.0.1+lldb %gcc@7.0:')
+    # https://bugs.llvm.org/show_bug.cgi?id=38233
+    # either python@v3.7.2:, gcc8 or libc-related (probably python)
+    # - compilation with 3.7.2 was fine on Debian 9, not on Fedora 30
+    # - both using a spack-built gcc@8.3.0
+    patch('llvm6.0.0+py3.7.patch', when='@6.0.0 %gcc@8.0:8.4 ^python@3.7:')
+    patch('llvm6.0.1+py3.7.patch', when='@6.0.1 %gcc@8.0:8.4 ^python@3.7:')
 
     @run_before('cmake')
     def check_darwin_lldb_codesign_requirement(self):


### PR DESCRIPTION
patched this [https://bugs.llvm.org/show_bug.cgi?id=38233] bug of llvm 6.0.x. I am not totally sure, whether it's only related to Python 3.7.3, gcc8 or something in system libcs, that's why I left a verbose comment