### PR TITLE
bugfix: fix m4 on osx high sierra

### DIFF
--- a/var/spack/repos/builtin/packages/m4/package.py
+++ b/var/spack/repos/builtin/packages/m4/package.py
@@ -51,7 +51,7 @@ class M4(AutotoolsPackage):
 
         # http://lists.gnu.org/archive/html/bug-m4/2016-09/msg00002.html
         arch = spec.architecture
-        if (arch.platform == 'darwin' and arch.platform_os == 'sierra' and
+        if (arch.platform == 'darwin' and arch.os == 'sierra' and
             '%gcc' in spec):
             args.append('ac_cv_type_struct_sched_param=yes')
 


### PR DESCRIPTION
Fixed logic that was checking for `arch.platform_os`, which,
does not appear to be a member of the ArchSpec class
anymore.