### PR TITLE
Fix recursive module find for upstream dependencies

### DIFF
--- a/lib/spack/spack/cmd/modules/__init__.py
+++ b/lib/spack/spack/cmd/modules/__init__.py
@@ -97,10 +97,6 @@ class NoSpecMatches(Exception):
     """
 
 
-class ModuleNotFoundError(Exception):
-    """Raised when a module cannot be found for a spec"""
-
-
 def one_spec_or_raise(specs):
     """Ensures exactly one spec has been selected, or raises the appropriate
     exception.
@@ -169,18 +165,19 @@ def loads(module_type, specs, args, out=sys.stdout):
 def find(module_type, specs, args):
     """Retrieve paths or use names of module files"""
 
-    spec = one_spec_or_raise(specs)
+    single_spec = one_spec_or_raise(specs)
 
     if args.recurse_dependencies:
-        specs_to_retrieve = list(spec.traverse(order='post', cover='nodes'))
+        specs_to_retrieve = list(
+            single_spec.traverse(order='post', cover='nodes'))
     else:
-        specs_to_retrieve = [spec]
+        specs_to_retrieve = [single_spec]
 
     try:
         modules = [spack.modules.common.get_module(module_type, spec,
                                                    args.full_path)
                    for spec in specs_to_retrieve]
-    except ModuleNotFoundError, e:
+    except spack.modules.common.ModuleNotFoundError, e:
         tty.die(e.message)
     print(' '.join(modules))
 

--- a/lib/spack/spack/cmd/modules/__init__.py
+++ b/lib/spack/spack/cmd/modules/__init__.py
@@ -15,6 +15,7 @@ from llnl.util import filesystem, tty
 import spack.cmd
 import spack.modules
 import spack.repo
+import spack.modules.common
 
 import spack.cmd.common.arguments as arguments
 
@@ -165,32 +166,6 @@ def loads(module_type, specs, args, out=sys.stdout):
         out.write('\n')
 
 
-def _get_module(module_type, spec, get_full_path, module_indices=None):
-    if spec.package.installed_upstream:
-        module = spack.modules.common.upstream_module(
-            spec, module_type, _module_indices=module_indices)
-        if not module:
-            err_msg = "No module available for upstream package {0}".format(
-                spec
-            )
-            raise ModuleNotFoundError(err_msg)
-        if get_full_path:
-            return module.path
-        else:
-            return module.use_name
-    else:
-        writer = spack.modules.module_types[module_type](spec)
-        if not os.path.isfile(writer.layout.filename):
-            err_msg = "No module available for package {0} at {1}".format(
-                spec, writer.layout.filename
-            )
-            raise ModuleNotFoundError(err_msg)
-        if get_full_path:
-            return writer.layout.filename
-        else:
-            return writer.layout.use_name
-
-
 def find(module_type, specs, args):
     """Retrieve paths or use names of module files"""
 
@@ -202,7 +177,8 @@ def find(module_type, specs, args):
         specs_to_retrieve = [spec]
 
     try:
-        modules = [_get_module(module_type, spec, args.full_path)
+        modules = [spack.modules.common.get_module(module_type, spec,
+                                                   args.full_path)
                    for spec in specs_to_retrieve]
     except ModuleNotFoundError, e:
         tty.die(e.message)

--- a/lib/spack/spack/cmd/modules/__init__.py
+++ b/lib/spack/spack/cmd/modules/__init__.py
@@ -169,7 +169,8 @@ def find(module_type, specs, args):
 
     if args.recurse_dependencies:
         specs_to_retrieve = list(
-            single_spec.traverse(order='post', cover='nodes'))
+            single_spec.traverse(order='post', cover='nodes',
+                                 deptype=('link', 'run')))
     else:
         specs_to_retrieve = [single_spec]
 

--- a/lib/spack/spack/cmd/modules/__init__.py
+++ b/lib/spack/spack/cmd/modules/__init__.py
@@ -165,15 +165,16 @@ def loads(module_type, specs, args, out=sys.stdout):
         out.write('\n')
 
 
-def _get_module(module_type, spec, full_path):
+def _get_module(module_type, spec, get_full_path, module_indices=None):
     if spec.package.installed_upstream:
-        module = spack.modules.common.upstream_module(spec, module_type)
+        module = spack.modules.common.upstream_module(
+            spec, module_type, _module_indices=module_indices)
         if not module:
             err_msg = "No module available for upstream package {0}".format(
                 spec
             )
             raise ModuleNotFoundError(err_msg)
-        if full_path:
+        if get_full_path:
             return module.path
         else:
             return module.use_name
@@ -184,7 +185,7 @@ def _get_module(module_type, spec, full_path):
                 spec, writer.layout.filename
             )
             raise ModuleNotFoundError(err_msg)
-        if full_path:
+        if get_full_path:
             return writer.layout.filename
         else:
             return writer.layout.use_name
@@ -202,7 +203,7 @@ def find(module_type, specs, args):
 
     try:
         modules = [_get_module(module_type, spec, args.full_path)
-                   for spec in specs_to_retrieve)
+                   for spec in specs_to_retrieve]
     except ModuleNotFoundError, e:
         tty.die(e.message)
     print(' '.join(modules))

--- a/lib/spack/spack/cmd/modules/__init__.py
+++ b/lib/spack/spack/cmd/modules/__init__.py
@@ -177,7 +177,7 @@ def find(module_type, specs, args):
         modules = [spack.modules.common.get_module(module_type, spec,
                                                    args.full_path)
                    for spec in specs_to_retrieve]
-    except spack.modules.common.ModuleNotFoundError, e:
+    except spack.modules.common.ModuleNotFoundError as e:
         tty.die(e.message)
     print(' '.join(modules))
 

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -257,14 +257,17 @@ def read_module_index(root):
     if not os.path.exists(index_path):
         return {}
     with open(index_path, 'r') as index_file:
-        yaml_content = syaml.load(index_file)
-        index = {}
-        yaml_index = yaml_content['module_index']
-        for dag_hash, module_properties in yaml_index.items():
-            index[dag_hash] = ModuleIndexEntry(
-                module_properties['path'],
-                module_properties['use_name'])
-        return index
+        return _read_module_index(index_file)
+
+def _read_module_index(str_or_file):
+    yaml_content = syaml.load(str_or_file)
+    index = {}
+    yaml_index = yaml_content['module_index']
+    for dag_hash, module_properties in yaml_index.items():
+        index[dag_hash] = ModuleIndexEntry(
+            module_properties['path'],
+            module_properties['use_name'])
+    return index
 
 
 def read_module_indices():

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -281,6 +281,32 @@ def upstream_module(spec, module_type, _module_indices=None):
             return index[spec.dag_hash()]
 
 
+def get_module(module_type, spec, get_full_path, module_indices=None):
+    if spec.package.installed_upstream:
+        module = spack.modules.common.upstream_module(
+            spec, module_type, _module_indices=module_indices)
+        if not module:
+            err_msg = "No module available for upstream package {0}".format(
+                spec
+            )
+            raise ModuleNotFoundError(err_msg)
+        if get_full_path:
+            return module.path
+        else:
+            return module.use_name
+    else:
+        writer = spack.modules.module_types[module_type](spec)
+        if not os.path.isfile(writer.layout.filename):
+            err_msg = "No module available for package {0} at {1}".format(
+                spec, writer.layout.filename
+            )
+            raise ModuleNotFoundError(err_msg)
+        if get_full_path:
+            return writer.layout.filename
+        else:
+            return writer.layout.use_name
+
+
 class BaseConfiguration(object):
     """Manipulates the information needed to generate a module file to make
     querying easier. It needs to be sub-classed for specific module types.

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -274,8 +274,8 @@ def read_module_indices():
 module_type_to_indices = read_module_indices()
 
 
-def upstream_module(spec, module_type):
-    indices = module_type_to_indices[module_type]
+def upstream_module(spec, module_type, _module_indices=None):
+    indices = _module_indices or module_type_to_indices[module_type]
     for index in indices:
         if spec.dag_hash() in index:
             return index[spec.dag_hash()]

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -799,6 +799,10 @@ class ModulesError(spack.error.SpackError):
     """Base error for modules."""
 
 
+class ModuleNotFoundError(ModulesError):
+    """Raised when a module cannot be found for a spec"""
+
+
 class DefaultTemplateNotDefined(AttributeError, ModulesError):
     """Raised if the attribute 'default_template' has not been specified
     in the derived classes.

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -259,7 +259,11 @@ def read_module_index(root):
     with open(index_path, 'r') as index_file:
         return _read_module_index(index_file)
 
+
 def _read_module_index(str_or_file):
+    """Read in the mapping of spec hash to module location/name. For a given
+       Spack installation there is assumed to be (at most) one such mapping
+       per module type."""
     yaml_content = syaml.load(str_or_file)
     index = {}
     yaml_index = yaml_content['module_index']
@@ -287,6 +291,9 @@ def read_module_indices():
 
 
 class UpstreamModuleIndex(object):
+    """This is responsible for taking the individual module indices of all
+       upstream Spack installations and locating the module for a given spec
+       based on which upstream install it is located in."""
     def __init__(self, local_db, module_indices):
         self.local_db = local_db
         self.upstream_dbs = local_db.upstream_dbs

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -238,9 +238,83 @@ def generate_module_index(root, modules):
         syaml.dump(index, index_file, default_flow_style=False)
 
 
+def _generate_upstream_module_index():
+    module_indices = read_module_indices()
+
+    return UpstreamModuleIndex(spack.store.db, module_indices)
+
+
+upstream_module_index = llnl.util.lang.Singleton(
+    _generate_upstream_module_index)
+
+
+ModuleIndexEntry = collections.namedtuple(
+    'ModuleIndexEntry', ['path', 'use_name'])
+
+
+def read_module_index(root):
+    index_path = os.path.join(root, 'module-index.yaml')
+    if not os.path.exists(index_path):
+        return {}
+    with open(index_path, 'r') as index_file:
+        yaml_content = syaml.load(index_file)
+        index = {}
+        yaml_index = yaml_content['module_index']
+        for dag_hash, module_properties in yaml_index.items():
+            index[dag_hash] = ModuleIndexEntry(
+                module_properties['path'],
+                module_properties['use_name'])
+        return index
+
+
+def read_module_indices():
+    other_spack_instances = spack.config.get(
+        'upstreams') or {}
+
+    module_indices = []
+
+    for install_properties in other_spack_instances.values():
+        module_type_to_index = {}
+        module_type_to_root = install_properties.get('modules', {})
+        for module_type, root in module_type_to_root.items():
+            module_type_to_index[module_type] = read_module_index(root)
+        module_indices.append(module_type_to_index)
+
+    return module_indices
+
+
+class UpstreamModuleIndex(object):
+    def __init__(self, local_db, module_indices):
+        self.local_db = local_db
+        self.upstream_dbs = local_db.upstream_dbs
+        self.module_indices = module_indices
+
+    def upstream_module(self, spec, module_type):
+        db_for_spec = self.local_db.db_for_spec_hash(spec.dag_hash())
+        if db_for_spec in self.upstream_dbs:
+            db_index = self.upstream_dbs.index(db_for_spec)
+        elif db_for_spec:
+            raise spack.error.SpackError(
+                "Unexpected: {0} is installed locally".format(spec))
+        else:
+            raise spack.error.SpackError(
+                "Unexpected: no install DB found for {0}".format(spec))
+        module_index = self.module_indices[db_index]
+        module_type_index = module_index.get(module_type, {})
+        if not module_type_index:
+            raise ModuleNotFoundError(
+                "No {0} modules associated with the Spack instance where"
+                " {1} is installed".format(module_type, spec))
+        if spec.dag_hash() in module_type_index:
+            return module_type_index[spec.dag_hash()]
+        else:
+            raise ModuleNotFoundError(
+                "No module is available for upstream package {0}".format(spec))
+
+
 def get_module(module_type, spec, get_full_path):
     if spec.package.installed_upstream:
-        module = spack.store.upstream_module_index.upstream_module(
+        module = spack.modules.common.upstream_module_index.upstream_module(
             spec, module_type)
         if get_full_path:
             return module.path
@@ -749,6 +823,10 @@ class BaseModuleFileWriter(object):
 
 class ModulesError(spack.error.SpackError):
     """Base error for modules."""
+
+
+class ModuleNotFoundError(ModulesError):
+    """Raised when a module cannot be found for a spec"""
 
 
 class DefaultTemplateNotDefined(AttributeError, ModulesError):

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -24,6 +24,7 @@ configuration.
 
 """
 import os
+import collections
 
 import llnl.util.lang
 
@@ -32,6 +33,7 @@ import spack.config
 import spack.util.path
 import spack.database
 import spack.directory_layout
+import spack.util.spack_yaml as syaml
 
 #: default installation root, relative to the Spack install path
 default_root = os.path.join(spack.paths.opt_path, 'spack')
@@ -60,11 +62,11 @@ class Store(object):
         self.root = root
 
         upstream_dbs = retrieve_upstream_dbs()
-        module_indices = spack.modules.common.read_module_indices()
+        module_indices = read_module_indices()
 
         self.db = spack.database.Database(
             root, upstream_dbs=upstream_dbs)
-        self.upstream_module_index = spack.modules.common.UpstreamModuleIndex(
+        self.upstream_module_index = UpstreamModuleIndex(
             self.db, module_indices)
         self.layout = spack.directory_layout.YamlDirectoryLayout(
             root, hash_len=hash_length, path_scheme=path_scheme)
@@ -78,6 +80,8 @@ def _store():
     """Get the singleton store instance."""
     root = spack.config.get('config:install_tree', default_root)
     root = spack.util.path.canonicalize_path(root)
+
+    #import pdb; pdb.set_trace()
 
     return Store(root,
                  spack.config.get('config:install_path_scheme'),
@@ -117,3 +121,71 @@ def _construct_upstream_dbs_from_install_roots(
         accumulated_upstream_dbs.insert(0, next_db)
 
     return accumulated_upstream_dbs
+
+
+ModuleIndexEntry = collections.namedtuple(
+    'ModuleIndexEntry', ['path', 'use_name'])
+
+
+def read_module_index(root):
+    index_path = os.path.join(root, 'module-index.yaml')
+    if not os.path.exists(index_path):
+        return {}
+    with open(index_path, 'r') as index_file:
+        yaml_content = syaml.load(index_file)
+        index = {}
+        yaml_index = yaml_content['module_index']
+        for dag_hash, module_properties in yaml_index.items():
+            index[dag_hash] = ModuleIndexEntry(
+                module_properties['path'],
+                module_properties['use_name'])
+        return index
+
+
+def read_module_indices():
+    other_spack_instances = spack.config.get(
+        'upstreams') or {}
+
+    module_indices = []
+
+    for install_properties in other_spack_instances.values():
+        module_type_to_index = {}
+        module_type_to_root = install_properties.get('modules', {})
+        for module_type, root in module_type_to_root.items():
+            module_type_to_index[module_type] = read_module_index(root)
+        module_indices.append(module_type_to_index)
+
+    return module_indices
+
+
+class UpstreamModuleIndex(object):
+    def __init__(self, local_db, module_indices):
+        self.local_db = local_db
+        self.upstream_dbs = local_db.upstream_dbs
+        self.module_indices = module_indices
+
+    def upstream_module(self, spec, module_type):
+        db_for_spec = self.local_db.db_for_spec_hash(spec.dag_hash())
+        if db_for_spec in self.upstream_dbs:
+            db_index = self.upstream_dbs.index(db_for_spec)
+        elif db_for_spec:
+            raise spack.error.SpackError(
+                "Unexpected: {0} is installed locally".format(spec))
+        else:
+            raise spack.error.SpackError(
+                "Unexpected: no install DB found for {0}".format(spec))
+        module_index = self.module_indices[db_index]
+        module_type_index = module_index.get(module_type, {})
+        if not module_type_index:
+            raise ModuleNotFoundError(
+                "No {0} modules associated with the Spack instance where"
+                " {1} is installed".format(module_type, spec))
+        if spec.dag_hash() in module_type_index:
+            return module_type_index[spec.dag_hash()]
+        else:
+            raise ModuleNotFoundError(
+                "No module is available for upstream package {0}".format(spec))
+
+
+class ModuleNotFoundError(spack.error.SpackError):
+    """Raised when a module cannot be found for a spec"""

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -58,9 +58,8 @@ class Store(object):
     """
     def __init__(self, root, path_scheme=None, hash_length=None):
         self.root = root
-        upstream_dbs = retrieve_upstream_dbs()
         self.db = spack.database.Database(
-            root, upstream_dbs=upstream_dbs)
+            root, upstream_dbs=retrieve_upstream_dbs())
         self.layout = spack.directory_layout.YamlDirectoryLayout(
             root, hash_len=hash_length, path_scheme=path_scheme)
 

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -58,8 +58,14 @@ class Store(object):
     """
     def __init__(self, root, path_scheme=None, hash_length=None):
         self.root = root
+
+        upstream_dbs = retrieve_upstream_dbs()
+        module_indices = spack.modules.common.read_module_indices()
+
         self.db = spack.database.Database(
-            root, upstream_dbs=retrieve_upstream_dbs())
+            root, upstream_dbs=upstream_dbs)
+        self.upstream_module_index = spack.modules.common.UpstreamModuleIndex(
+            self.db, module_indices)
         self.layout = spack.directory_layout.YamlDirectoryLayout(
             root, hash_len=hash_length, path_scheme=path_scheme)
 
@@ -85,6 +91,8 @@ store = llnl.util.lang.Singleton(_store)
 root = llnl.util.lang.LazyReference(lambda: store.root)
 db = llnl.util.lang.LazyReference(lambda: store.db)
 layout = llnl.util.lang.LazyReference(lambda: store.layout)
+upstream_module_index = llnl.util.lang.LazyReference(
+    lambda: store.upstream_module_index)
 
 
 def retrieve_upstream_dbs():

--- a/lib/spack/spack/test/modules/common.py
+++ b/lib/spack/spack/test/modules/common.py
@@ -3,13 +3,11 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import pytest
 import os
 import stat
 import spack.spec
-import spack.modules.common
 import spack.modules.tcl
-from spack.store import (
+from spack.modules.common import (
     ModuleIndexEntry, UpstreamModuleIndex, ModuleNotFoundError)
 import spack.error
 

--- a/lib/spack/spack/test/modules/common.py
+++ b/lib/spack/spack/test/modules/common.py
@@ -5,14 +5,15 @@
 
 import os
 import stat
+import pytest
+import collections
+
 import spack.spec
 import spack.modules.tcl
 from spack.modules.common import (
-    ModuleIndexEntry, UpstreamModuleIndex, ModuleNotFoundError)
-import spack.error
+    UpstreamModuleIndex, ModuleNotFoundError)
 
-import pytest
-import collections
+import spack.error
 
 
 def test_update_dictionary_extending_list():

--- a/lib/spack/spack/test/modules/common.py
+++ b/lib/spack/spack/test/modules/common.py
@@ -9,8 +9,7 @@ import stat
 import spack.spec
 import spack.modules.common
 import spack.modules.tcl
-
-from spack.modules.common import (
+from spack.store import (
     ModuleIndexEntry, UpstreamModuleIndex, ModuleNotFoundError)
 import spack.error
 

--- a/lib/spack/spack/test/modules/common.py
+++ b/lib/spack/spack/test/modules/common.py
@@ -98,9 +98,16 @@ def test_upstream_module_index():
     s3 = MockSpec('spec-3')
     s4 = MockSpec('spec-4')
 
+    tcl_module_index = """\
+module_index:
+  {0}:
+    path: /path/to/a
+    use_name: a
+""".format(s1.dag_hash())
+
     module_indices = [
         {
-            'tcl': {s1.dag_hash(): ModuleIndexEntry('/path/to/a', 'a')}
+            'tcl': spack.modules.common._read_module_index(tcl_module_index)
         },
         {}
     ]

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -211,7 +211,6 @@ class TestTcl(object):
         assert index[s1.dag_hash()].use_name == w1.layout.use_name
         assert index[s2.dag_hash()].path == w2.layout.filename
 
-
     def test_find_local_with_upstream_dep(
             self, factory, tmpdir_factory, config, install_mockery):
 
@@ -230,7 +229,6 @@ class TestTcl(object):
             setattr(x_spec.package, 'installed_upstream', False)
 
             wx = spack.modules.tcl.TclModulefileWriter(x_spec)
-            wy = spack.modules.tcl.TclModulefileWriter(y_spec)
 
             # For the purposes of the test, the module file doesn't have to
             # contain anything, we just want to make sure we can locate it

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -8,6 +8,7 @@ import pytest
 import spack.modules.common
 import spack.modules.tcl
 import spack.spec
+import spack.store
 from spack.test.conftest import MockPackage, MockPackageMultiRepo
 import os
 
@@ -206,7 +207,7 @@ class TestTcl(object):
 
         spack.modules.common.generate_module_index(test_root, [w1, w2])
 
-        index = spack.modules.common.read_module_index(test_root)
+        index = spack.store.read_module_index(test_root)
 
         assert index[s1.dag_hash()].use_name == w1.layout.use_name
         assert index[s2.dag_hash()].path == w2.layout.filename

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -3,14 +3,13 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
 import pytest
+
 import spack.modules.common
 import spack.modules.tcl
 import spack.spec
 import spack.store
-from spack.test.conftest import MockPackage, MockPackageMultiRepo
-import os
+
 
 mpich_spec_string = 'mpich@3.0.4'
 mpileaks_spec_string = 'mpileaks'
@@ -207,7 +206,7 @@ class TestTcl(object):
 
         spack.modules.common.generate_module_index(test_root, [w1, w2])
 
-        index = spack.store.read_module_index(test_root)
+        index = spack.modules.common.read_module_index(test_root)
 
         assert index[s1.dag_hash()].use_name == w1.layout.use_name
         assert index[s2.dag_hash()].path == w2.layout.filename

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -211,43 +211,6 @@ class TestTcl(object):
         assert index[s1.dag_hash()].use_name == w1.layout.use_name
         assert index[s2.dag_hash()].path == w2.layout.filename
 
-    def test_find_local_with_upstream_dep(
-            self, factory, tmpdir_factory, config, install_mockery):
-
-        default = ('build', 'link')
-
-        y = MockPackage('y', [], [])
-        x = MockPackage('x', [y], [default])
-
-        mock_repo = MockPackageMultiRepo([x, y])
-        with spack.repo.swap(mock_repo):
-            x_spec = spack.spec.Spec('x')
-            x_spec.concretize()
-
-            y_spec = x_spec['y']
-            setattr(y_spec.package, 'installed_upstream', True)
-            setattr(x_spec.package, 'installed_upstream', False)
-
-            wx = spack.modules.tcl.TclModulefileWriter(x_spec)
-
-            # For the purposes of the test, the module file doesn't have to
-            # contain anything, we just want to make sure we can locate it
-            # properly
-            open(wx.layout.filename, 'w')
-
-            y_module_index_entry = spack.modules.common.ModuleIndexEntry(
-                '/test/path/to/y-module', 'y-module')
-            test_index = {y_spec.dag_hash(): y_module_index_entry}
-
-            x_mod = spack.modules.common.get_module(
-                'tcl', x_spec, False, [test_index])
-            assert x_mod == wx.layout.use_name
-            y_mod = spack.modules.common.get_module(
-                'tcl', y_spec, False, [test_index]
-            )
-            assert y_mod == 'y-module'
-            os.remove(wx.layout.filename)
-
     def test_suffixes(self, module_configuration, factory):
         """Tests adding suffixes to module file name."""
         module_configuration('suffix')

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -8,8 +8,6 @@ import pytest
 import spack.modules.common
 import spack.modules.tcl
 import spack.spec
-import spack.store
-
 
 mpich_spec_string = 'mpich@3.0.4'
 mpileaks_spec_string = 'mpileaks'

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -241,10 +241,10 @@ class TestTcl(object):
                 '/test/path/to/y-module', 'y-module')
             test_index = {y_spec.dag_hash(): y_module_index_entry}
 
-            x_mod = spack.cmd.modules._get_module(
+            x_mod = spack.modules.common.get_module(
                 'tcl', x_spec, False, [test_index])
             assert x_mod == wx.layout.use_name
-            y_mod = spack.cmd.modules._get_module(
+            y_mod = spack.modules.common.get_module(
                 'tcl', y_spec, False, [test_index]
             )
             assert y_mod == 'y-module'


### PR DESCRIPTION
`spack module tcl find -r <spec>` (and equivalents for other module systems) was failing when a dependency was installed in an upstream Spack instance. This updates the logic to appropriately handle that case and adds a test for it.