### PR TITLE
add BMI package

### DIFF
--- a/var/spack/repos/builtin/packages/bmi/package.py
+++ b/var/spack/repos/builtin/packages/bmi/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Bmi(AutotoolsPackage):
+    """a communications framework and network abstraction layer"""
+
+    homepage = 'http://git.mcs.anl.gov/bmi.git/'
+    git = 'git://git.mcs.anl.gov/bmi'
+
+    version('develop', branch='master')
+
+    depends_on('autoconf', type='build')
+
+    # need to override 'autoreconf' so we can run BMI's 'prepare' script
+    def autoreconf(self, spec, prefix):
+        Executable('./prepare')()
+
+    def configure_args(self):
+        args = ["--enable-shared", "--enable-bmi-only"]
+        return args

--- a/var/spack/repos/builtin/packages/mercury/package.py
+++ b/var/spack/repos/builtin/packages/mercury/package.py
@@ -34,8 +34,8 @@ class Mercury(CMakePackage):
             description='Enable udreg on supported Cray platforms')
 
     depends_on('cmake@2.8.12.2:', type='build')
-    # depends_on('bmi', when='+bmi')  # TODO: add BMI package
     # depends_on('cci', when='+cci')  # TODO: add CCI package
+    depends_on('bmi', when='+bmi')
     depends_on('mpi', when='+mpi')
     depends_on('libfabric@1.5:', when='+ofi')
     depends_on('openpa@1.0.3:', when='+opa')


### PR DESCRIPTION
- also enable optional dependency in Mercury

BMI is helpful as an alternative to libfabric for debugging and TCP oriented deployments.