### PR TITLE
Use command that shows --profile output in the profiling documentation

### DIFF
--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -488,7 +488,7 @@ supply ``--profile`` to Spack on the command line, before any subcommands.
 
 ``spack --profile`` output looks like this:
 
-.. command-output:: spack --profile graph dyninst
+.. command-output:: spack --profile list dyninst
    :ellipsis: 25
 
 The bottom of the output shows the top most time consuming functions,


### PR DESCRIPTION
Updates the Developer Guide documentation to provide an example of the profiling output, the current version just shows the top of the graph command. 

https://spack.readthedocs.io/en/latest/developer_guide.html#spack-profile
