### PR TITLE
fix error when adding package to env in container

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -125,7 +125,7 @@ def activate(
             cmds += 'setenv SPACK_OLD_PROMPT "${prompt}";\n'
             cmds += 'set prompt="%s ${prompt}";\n' % prompt
     else:
-        if 'color' in os.environ['TERM'] and prompt:
+        if os.getenv('TERM') and 'color' in os.getenv('TERM') and prompt:
             prompt = colorize('@G{%s} ' % prompt, color=True)
 
         cmds += 'export SPACK_ENV=%s;\n' % env.path


### PR DESCRIPTION
When trying to use a spack environment in a singularity container, I came across the following:

```
+ spack -e canu add canu@1.8
Traceback (most recent call last):
  File "/opt/spack/bin/spack", line 48, in <module>
    sys.exit(spack.main.main())
  File "/opt/spack/lib/spack/spack/main.py", line 633, in main
    ev.activate(env, args.use_env_repo)
  File "/opt/spack/lib/spack/spack/environment.py", line 128, in activate
    if 'color' in os.environ['TERM'] and prompt:
  File "/usr/lib64/python2.7/UserDict.py", line 23, in __getitem__
    raise KeyError(key)
KeyError: 'TERM'
ABORT: Aborting with RETVAL=255
```

This patch corrects the issue