### PR TITLE
FAODEL: Add FAODEL package to spack

### DIFF
--- a/var/spack/repos/builtin/packages/faodel/array.patch
+++ b/var/spack/repos/builtin/packages/faodel/array.patch
@@ -1,0 +1,11 @@
+diff --git a/src/common/Configuration.cpp b/src/common/Configuration.cpp
+index f844488..70186cc 100644
+--- a/src/common/Configuration.cpp
++++ b/src/common/Configuration.cpp
+@@ -1,4 +1,5 @@
+
++#include <array>
+ #include <vector>
+ #include <map>
+ #include <algorithm>
+

--- a/var/spack/repos/builtin/packages/faodel/faodel_mpi.patch
+++ b/var/spack/repos/builtin/packages/faodel/faodel_mpi.patch
@@ -1,0 +1,68 @@
+diff --git a/src/kelpie/CMakeLists.txt b/src/kelpie/CMakeLists.txt
+index f2e8ef6..7f957a7 100644
+--- a/src/kelpie/CMakeLists.txt
++++ b/src/kelpie/CMakeLists.txt
+@@ -36,7 +36,7 @@ set( HEADERS
+      pools/DHTPool/DHTPool.hh
+      pools/PoolRegistry.hh
+      pools/UnconfiguredPool/UnconfiguredPool.hh
+-        services/PoolServerDriver.hh
++
+ )
+ 
+ set( SOURCES
+@@ -67,12 +67,17 @@ set( SOURCES
+      pools/PoolBase.cpp
+      pools/PoolRegistry.cpp
+      pools/UnconfiguredPool/UnconfiguredPool.cpp
+-        services/PoolServerDriver.cpp
+ )
+ 
+ if( Faodel_ENABLE_MPI_SUPPORT )
+-  LIST( APPEND HEADERS pools/RFTPool/RFTPool.hh)
+-  LIST( APPEND SOURCES pools/RFTPool/RFTPool.cpp)
++  LIST( APPEND HEADERS
++        pools/RFTPool/RFTPool.hh
++        services/PoolServerDriver.hh
++  )
++  LIST( APPEND SOURCES
++        pools/RFTPool/RFTPool.cpp
++        services/PoolServerDriver.cpp
++  )
+ endif( Faodel_ENABLE_MPI_SUPPORT )
+ 
+ 
+diff --git a/tools/kelpie-server/CMakeLists.txt b/tools/kelpie-server/CMakeLists.txt
+index 57f8a81..d05337b 100644
+--- a/tools/kelpie-server/CMakeLists.txt
++++ b/tools/kelpie-server/CMakeLists.txt
+@@ -1,15 +1,16 @@
++if( Faodel_ENABLE_MPI_SUPPORT )
++  set(
++    SOURCES
++          kelpie_server_main.cpp
++  )
+ 
+-set(
+-  SOURCES
+-        kelpie_server_main.cpp
+-)
++  add_executable( kelpie-server ${SOURCES} )
++  set_target_properties( kelpie-server PROPERTIES LINKER_LANGUAGE CXX )
+ 
+-add_executable( kelpie-server ${SOURCES} )
+-set_target_properties( kelpie-server PROPERTIES LINKER_LANGUAGE CXX )
++  target_link_libraries( kelpie-server kelpie) #Faodel::kelpie )
+ 
+-target_link_libraries( kelpie-server kelpie) #Faodel::kelpie )
+-
+-install(TARGETS kelpie-server
+-        EXPORT faodelTargets
+-        RUNTIME DESTINATION "${BINARY_INSTALL_DIR}" COMPONENT bin
+-  )
+\ No newline at end of file
++  install(TARGETS kelpie-server
++          EXPORT faodelTargets
++          RUNTIME DESTINATION "${BINARY_INSTALL_DIR}" COMPONENT bin
++    )
++endif()

--- a/var/spack/repos/builtin/packages/faodel/faodel_sbl.patch
+++ b/var/spack/repos/builtin/packages/faodel/faodel_sbl.patch
@@ -1,0 +1,35 @@
+diff --git a/src/faodel-common/LoggingInterface.cpp b/src/faodel-common/LoggingInterface.cpp
+index d15eb23..86bf0ef 100644
+--- a/src/faodel-common/LoggingInterface.cpp
++++ b/src/faodel-common/LoggingInterface.cpp
+@@ -11,7 +11,7 @@
+ 
+ 
+ #if Faodel_LOGGINGINTERFACE_DISABLED==0 && Faodel_LOGGINGINTERFACE_USE_SBL==1
+-#include <sbl/sbl_logger.hpp>
++#include <sbl/sbl_logger.hh>
+ #endif
+ 
+ 
+@@ -27,7 +27,7 @@
+ 
+ #if Faodel_LOGGINGINTERFACE_USE_SBL==1
+ 
+-#include <sbl/sbl_logger.hpp>
++#include <sbl/sbl_logger.hh>
+ 
+ sbl::logger *faodel::LoggingInterface::sbl_logger=nullptr;
+ 
+diff --git a/src/sbl/README_SBL.md b/src/sbl/README_SBL.md
+index d490f75..4eec0ee 100644
+--- a/src/sbl/README_SBL.md
++++ b/src/sbl/README_SBL.md
+@@ -205,7 +205,7 @@ Example:
+     #include <thread>
+     #include <map>
+ 
+-    #include "sbl/sbl_logger.hpp"
++    #include "sbl/sbl_logger.hh"
+     
+     int main(int argc, char *argv[])
+     {

--- a/var/spack/repos/builtin/packages/faodel/package.py
+++ b/var/spack/repos/builtin/packages/faodel/package.py
@@ -10,11 +10,12 @@ class Faodel(CMakePackage):
     """Flexible, Asynchronous, Object Data-Exchange Libraries"""
 
     homepage = "https://github.com/faodel/faodel"
-    url      = "https://github.com/faodel/faodel/archive/v1.1811.1.tar.gz"
+    url      = "https://github.com/faodel/faodel/archive/v1.1811.2.tar.gz"
     git      = "https://github.com/faodel/faodel.git"
 
     maintainers = ['tkordenbrock', 'craigulmer']
 
+    version('1.1811.2', sha256='22feb502dad0f56fb8af492f6e2cdc53a97fd6c31f6fa3c655be0a6266c46996')
     version('1.1811.1', sha256='8e95ee99b8c136ff687eb07a2481ee04560cb1526408eb22ab56cd9c60206916')
     version('1.1803.1', sha256='70ce7125c02601e14abe5985243d67adf677ed9e7a4dd6d3eaef8a97cf281a16')
 
@@ -51,7 +52,7 @@ class Faodel(CMakePackage):
     # variant('leveldb', default=False,
     #        description='Build the LevelDB-based IOM in Kelpie')
 
-    # Only clang requires this patch, but it should be applied for all compilers
+    # Only clang requires this patch, but it should be applied for all
     patch('array.patch', when="@1.1803.1")
 
     # FAODEL Github issue #4

--- a/var/spack/repos/builtin/packages/faodel/package.py
+++ b/var/spack/repos/builtin/packages/faodel/package.py
@@ -1,0 +1,78 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Faodel(CMakePackage):
+    """Flexible, Asynchronous, Object Data-Exchange Libraries"""
+
+    homepage = "https://github.com/faodel/faodel"
+    url      = "https://github.com/faodel/faodel/archive/v1.1811.1.tar.gz"
+    git      = "https://github.com/faodel/faodel.git"
+
+    maintainers = ['fbudin69500', 'chuckatkins']
+
+    version('develop', branch='master')
+    version('1.1811.1', sha256='8e95ee99b8c136ff687eb07a2481ee04560cb1526408eb22ab56cd9c60206916')
+    version('1.1803.1', sha256='70ce7125c02601e14abe5985243d67adf677ed9e7a4dd6d3eaef8a97cf281a16')
+
+    variant('shared', default=False,
+            description='Build Faodel as shared libs')
+    variant('mpi', default=True,
+            description='Enable MPI')
+    variant('hdf5', default=False, description="Build the HDF5-based IOM in Kelpie")
+
+    variant('tcmalloc', default=True,
+            description='Use tcmalloc from gperftools in Lunasa, \
+                         potentially other places')
+    variant('logging', default='stdout', values=('stdout', 'sbl', 'disabled'),
+            description='Select where logging interface output is routed')
+    variant('network', default='nnti', values=('nnti', 'libfabric'),
+            description='RDMA Network library to use for \
+                         low-level communication')
+
+    depends_on('mpi', when='+mpi')
+    depends_on('boost+mpi', when='+mpi', type='build')
+    depends_on('boost~mpi', when='~mpi', type='build')
+    depends_on('hdf5+mpi', when='+hdf5+mpi')
+    depends_on('hdf5~mpi', when='+hdf5~mpi')
+    depends_on('libfabric', when='network=libfabric')
+
+    # Github issue #11267
+    # Requires master branch of `leveldb` which is not available in spack
+    # (only versions 1.20 and 1.18 are available).
+    # depends_on('leveldb', when='+leveldb')
+    # variant('leveldb', default=False,
+    #        description='Build the LevelDB-based IOM in Kelpie')
+
+    # FAODEL Github issue #4
+    patch('faodel_mpi.patch', when='~mpi')
+    # FAODEL Github issue #5
+    patch('faodel_sbl.patch', when='logging=sbl')
+
+    def cmake_args(self):
+        spec = self.spec
+
+        args = [
+            '-DBUILD_SHARED_LIBS:BOOL={0}'.format(
+                'ON' if '+shared' in spec else 'OFF'),
+            '-DBUILD_TESTS:BOOL=OFF',
+            '-DBOOST_ROOT:PATH={0}'.format(spec['boost'].prefix),
+            '-DBUILD_DOCS:BOOL=OFF',
+            '-DFaodel_ENABLE_IOM_HDF5:BOOL={0}'.format(
+                'ON' if '+hdf5' in spec else 'OFF'),
+            '-DFaodel_ENABLE_IOM_LEVELDB:BOOL={0}'.format(
+                'ON' if '+leveldb' in spec else 'OFF'),
+            '-DFaodel_ENABLE_MPI_SUPPORT:BOOL={0}'.format(
+                'ON' if '+mpi' in spec else 'OFF'),
+            '-DFaodel_ENABLE_TCMALLOC:BOOL={0}'.format(
+                'ON' if '+tcmalloc' in spec else 'OFF'),
+            '-DFaodel_LOGGING_METHOD:STRING={0}'.format(
+                spec.variants['logging'].value),
+            '-DFaodel_NETWORK_LIBRARY:STRING={0}'.format(
+                spec.variants['network'].value)
+        ]
+        return args


### PR DESCRIPTION
FAODEL (Flexible, Asynchronous, Object Data-Exchange Libraries) is a collection
of software libraries that are used to implement different data management
services on high-performance computing (HPC) platforms. This project is part of
the Advanced Technology Development and Mitigation (ATDM) effort for NNSA's ASC
program at Sandia National Laboratories.

This PR replaces spack#11268.

@chuckatkins @fbudin69500 @craigulmer Please review.
