### PR TITLE
Homebrew style caveats (in info and post-install)

### DIFF
--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -64,6 +64,8 @@ class {class_name}({base_class_name}):
 
 {dependencies}
 
+{caveats}
+
 {body}
 '''
 
@@ -83,6 +85,20 @@ class PackageTemplate(object):
         make()
         make('install')"""
 
+    caveats = """\
+    # FIXME: Package caveats; for example, steps users must
+    # take post-install.
+    # Delete this entirely if there are no caveats.
+    # It is called from a post_install hook with a concrete
+    # spec and from `spack info` with a simple spec.
+    # def caveats(self):
+    #     # if self.spec.concrete:
+    #     #     e.g. can use self.spec.prefix here
+    #     # else:
+    #     #     e.g. must use default/example values here
+    #     warnings = "Things the user should know..."
+    #     return warnings"""
+
     def __init__(self, name, url, versions):
         self.name       = name
         self.class_name = mod_to_class(name)
@@ -101,7 +117,8 @@ class PackageTemplate(object):
                 url=self.url,
                 versions=self.versions,
                 dependencies=self.dependencies,
-                body=self.body))
+                body=self.body,
+                caveats=self.caveats))
 
 
 class AutotoolsPackageTemplate(PackageTemplate):

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -86,12 +86,14 @@ class PackageTemplate(object):
         make('install')"""
 
     caveats = """\
-    # FIXME: Package caveats; for example, steps users must
-    # take post-install.
+    # FIXME: Description of package caveats; for example, steps
+    # users must take post-install.
     # Delete this entirely if there are no caveats.
     # It is called from a post_install hook with a concrete
-    # spec and from `spack info` with a simple spec.
+    # spec and from `spack info` with a simple spec, you should
+    # handle both cases.
     # def caveats(self):
+    #     '''Documents package caveats'''
     #     # if self.spec.concrete:
     #     #     e.g. can use self.spec.prefix here
     #     # else:

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -141,6 +141,13 @@ def print_text_info(pkg):
     else:
         color.cprint("    None")
 
+    color.cprint(section_title('Caveats:'))
+    if pkg.caveats():
+        color.cprint(color.cescape(pkg.format_caveats(indent=4)))
+    else:
+        color.cprint("    None")
+    print("")                   # consistent line spacing, caveat or not
+
     color.cprint(section_title('Homepage: ') + pkg.homepage)
 
     if len(pkg.maintainers) > 0:

--- a/lib/spack/spack/hooks/caveats.py
+++ b/lib/spack/spack/hooks/caveats.py
@@ -1,0 +1,13 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import llnl.util.tty as tty
+
+
+def post_install(spec):
+    """Print caveats after the install"""
+    c = spec.package.caveats()
+    if c:
+        tty.warn("Caveats:\n{0}".format(c))

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2148,6 +2148,23 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             results.write((" " * indent) + line + "\n")
         return results.getvalue()
 
+    def format_caveats(self, **kwargs):
+        """Trim trailing white space and indent"""
+        indent = kwargs.get('indent', 0)
+
+        if not self.caveats():
+            return ""
+
+        c = self.caveats()
+        c = c.rstrip()
+        lines = c.split('\n')
+        lines = [(indent * ' ') + line for line in lines]
+        c = "\n".join(lines)
+        return c
+
+    def caveats(self):
+        return ""
+
     @property
     def all_urls(self):
         """A list of all URLs in a package.

--- a/lib/spack/spack/test/cmd/info.py
+++ b/lib/spack/spack/test/cmd/info.py
@@ -57,6 +57,7 @@ def test_info_fields(pkg_query, parser, info_lines):
 
     expected_fields = (
         'Description:',
+        'Caveats:',
         'Homepage:',
         'Safe versions:',
         'Variants:',


### PR DESCRIPTION
ToDo (Feedback welcome):

- [ ] if more tests are necessary, how should they be set up?
- [ ] should this PR include additions to the Spack documentation?

---

There are times when special information needs to be called to the
user's attention.  For example, for full functionality the singularity
package requires that several files need to be owned by root and one
needs to be setuid.  Caveats can be used to remind the user and to
point to the Spack-built helper script.

This:

- Adds a post-install hook that uses `tty.warn()` to display caveats
  to the installer.
- Adds a 'Caveats:' section to the output of the `info` command.
- Adds a caveats method to the template for the `create` command,
  commented out and marked "FIXME".
- Teaches the info cmd test to check for the presence of the
  'Caveats:' section.

See Also:

- #11244 (There appears to be no way to print a message after installing a package)
- #2566 (Allow tty output during spack install)
    - #10412 (Allow tty output during spack install)
- #11094 (Update/package singularity)

Closes #11244 

FYI @vsoch