### PR TITLE
sqlite: New versions; restore old versions; variant to resolve security issues

### DIFF
--- a/var/spack/repos/builtin/packages/sqlite/package.py
+++ b/var/spack/repos/builtin/packages/sqlite/package.py
@@ -14,10 +14,13 @@ class Sqlite(AutotoolsPackage):
     """
     homepage = "https://www.sqlite.org"
 
-    version('3.26.0', '9af2df1a6da5db6e2ecf3f463625f16740e036e9',
-            url='https://sqlite.org/2018/sqlite-autoconf-3260000.tar.gz')
-    # All versions prior to 3.26.0 are vulnerable to Magellan, see
-    # https://blade.tencent.com/magellan/index_en.html
+    version('3.28.0', sha256='d61b5286f062adfce5125eaf544d495300656908e61fca143517afcc0a89b7c3')
+    version('3.27.2', sha256='50c39e85ea28b5ecfdb3f9e860afe9ba606381e21836b2849efca6a0bfe6ef6e')
+    version('3.27.1', sha256='54a92b8ff73ff6181f89b9b0c08949119b99e8cccef93dbef90e852a8b10f4f8')
+    version('3.27.0', sha256='dbfb0fb4fc32569fa427d3658e888f5e3b84a0952f706ccab1fd7c62a54f10f0')
+    version('3.26.0', '9af2df1a6da5db6e2ecf3f463625f16740e036e9')
+    # All versions prior to 3.26.0 are vulnerable to Magellan when FTS
+    # is enabled, see https://blade.tencent.com/magellan/index_en.html
 
     depends_on('readline')
 
@@ -26,6 +29,13 @@ class Sqlite(AutotoolsPackage):
                         'for SQL queries using the loadable extensions '
                         'mechanism.')
 
+    variant('fts', default=True,
+            description='Enable FTS support '
+            '(unsafe for <3.26.0.0 due to Magellan).')
+
+    # See https://blade.tencent.com/magellan/index_en.html
+    conflicts('+fts', when='@:3.25.99.99')
+
     resource(name='extension-functions',
              url='https://sqlite.org/contrib/download/extension-functions.c/download/extension-functions.c?get=25',
              md5='3a32bfeace0d718505af571861724a43',
@@ -33,6 +43,44 @@ class Sqlite(AutotoolsPackage):
              placement={'extension-functions.c?get=25':
                         'extension-functions.c'},
              when='+functions')
+
+    # On some platforms (e.g., PPC) the include chain includes termios.h which
+    # defines a macro B0. Sqlite has a shell.c source file that declares a
+    # variable named B0 and will fail to compile when the macro is found. The
+    # following patch undefines the macro in shell.c
+    patch('sqlite_b0.patch', when='@3.18.0:3.21.0')
+
+    # Starting version 3.17.0, SQLite uses compiler built-ins
+    # __builtin_sub_overflow(), __builtin_add_overflow(), and
+    # __builtin_mul_overflow(), which are not supported by Intel compiler.
+    # Starting version 3.21.0 SQLite doesn't use the built-ins if Intel
+    # compiler is used.
+    patch('remove_overflow_builtins.patch', when='@3.17.0:3.20%intel')
+
+    def url_for_version(self, version):
+        full_version = list(version.version) + [0 * (4 - len(version.version))]
+        version_string\
+            = str(full_version[0]) + \
+            ''.join(['%02d' % v for v in full_version[1:]])
+        # See https://sqlite.org/chronology.html for version -> year
+        # correspondence.
+        if version >= Version('3.27.0'):
+            year = '2019'
+        elif version >= Version('3.22.0'):
+            year = '2018'
+        elif version >= Version('3.16.0'):
+            year = '2017'
+        elif version >= Version('3.10.0'):
+            year = '2016'
+        elif version >= Version('3.8.8'):
+            year = '2015'
+        elif version >= Version('3.8.3'):
+            year = '2014'
+        elif version >= Version('3.7.16'):
+            year = '2013'
+        else:
+            raise ValueError('Unsupported version {0}'.format(version))
+        return 'https://sqlite.org/{0}/sqlite-autoconf-{1}.tar.gz'.format(year, version_string)
 
     @property
     def libs(self):
@@ -48,6 +96,9 @@ class Sqlite(AutotoolsPackage):
 
         if self.get_arch() == 'ppc64le':
             args.append('--build=powerpc64le-redhat-linux-gnu')
+
+        if '+fts' not in self.spec:
+            args.extend(['--disable-fts4', '--disable-fts5'])
 
         return args
 

--- a/var/spack/repos/builtin/packages/sqlite/remove_overflow_builtins.patch
+++ b/var/spack/repos/builtin/packages/sqlite/remove_overflow_builtins.patch
@@ -1,0 +1,48 @@
+diff --git a/sqlite3.c b/sqlite3.c
+index 4ec1271..8615169 100644
+--- a/sqlite3.c
++++ b/sqlite3.c
+@@ -29466,9 +29466,6 @@ SQLITE_PRIVATE int sqlite3SafetyCheckSickOrOk(sqlite3 *db){
+ ** overflow, leave *pA unchanged and return 1.
+ */
+ SQLITE_PRIVATE int sqlite3AddInt64(i64 *pA, i64 iB){
+-#if GCC_VERSION>=5004000
+-  return __builtin_add_overflow(*pA, iB, pA);
+-#else
+   i64 iA = *pA;
+   testcase( iA==0 ); testcase( iA==1 );
+   testcase( iB==-1 ); testcase( iB==0 );
+@@ -29483,12 +29480,8 @@ SQLITE_PRIVATE int sqlite3AddInt64(i64 *pA, i64 iB){
+   }
+   *pA += iB;
+   return 0; 
+-#endif
+ }
+ SQLITE_PRIVATE int sqlite3SubInt64(i64 *pA, i64 iB){
+-#if GCC_VERSION>=5004000
+-  return __builtin_sub_overflow(*pA, iB, pA);
+-#else
+   testcase( iB==SMALLEST_INT64+1 );
+   if( iB==SMALLEST_INT64 ){
+     testcase( (*pA)==(-1) ); testcase( (*pA)==0 );
+@@ -29498,12 +29491,8 @@ SQLITE_PRIVATE int sqlite3SubInt64(i64 *pA, i64 iB){
+   }else{
+     return sqlite3AddInt64(pA, -iB);
+   }
+-#endif
+ }
+ SQLITE_PRIVATE int sqlite3MulInt64(i64 *pA, i64 iB){
+-#if GCC_VERSION>=5004000
+-  return __builtin_mul_overflow(*pA, iB, pA);
+-#else
+   i64 iA = *pA;
+   if( iB>0 ){
+     if( iA>LARGEST_INT64/iB ) return 1;
+@@ -29519,7 +29508,6 @@ SQLITE_PRIVATE int sqlite3MulInt64(i64 *pA, i64 iB){
+   }
+   *pA = iA*iB;
+   return 0;
+-#endif
+ }
+ 
+ /*

--- a/var/spack/repos/builtin/packages/sqlite/sqlite_b0.patch
+++ b/var/spack/repos/builtin/packages/sqlite/sqlite_b0.patch
@@ -1,0 +1,13 @@
+--- a/shell.c  2017-05-03 10:49:13.266276246 -0700
++++ b/shell.c  2017-05-03 10:51:34.868963321 -0700
+@@ -198,6 +198,10 @@
+ #define getrusage(A,B) memset(B,0,sizeof(*B))
+ #endif
+ 
++#ifdef B0
++#undef B0
++#endif
++
+ /* Saved resource information for the beginning of an operation */
+ static struct rusage sBegin;  /* CPU time at start */
+ static sqlite3_int64 iBegin;  /* Wall-clock time at start */


### PR DESCRIPTION
* New versions 3.27.{0,1,2}, 3.28.0.
* Restore ability to download and compile older versions (no checksums, therefore not preferred) with the addition of a variant (`+fts`) which conflicts with versions <3.26.0, thereby resolving issues with Magellan vulnerability.
* Automatic URL calculations.