### PR TITLE
use Package.libs in RPATH with a fallback to prefix.lib/lib64

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -259,7 +259,7 @@ def set_build_environment_variables(pkg, env, dirty):
     build_deps      = set(pkg.spec.dependencies(deptype=('build', 'test')))
     link_deps       = set(pkg.spec.traverse(root=False, deptype=('link')))
     build_link_deps = build_deps | link_deps
-    rpath_deps      = get_rpath_deps(pkg)
+    rpath_deps      = pkg.rpath_deps
 
     link_dirs = []
     include_dirs = []
@@ -577,22 +577,10 @@ def _static_to_shared_library(arch, compiler, static_lib, shared_lib=None,
     return compiler(*compiler_args, output=compiler_output)
 
 
-def get_rpath_deps(pkg):
-    """Return immediate or transitive RPATHs depending on the package."""
-    if pkg.transitive_rpaths:
-        return [d for d in pkg.spec.traverse(root=False, deptype=('link'))]
-    else:
-        return pkg.spec.dependencies(deptype='link')
-
-
 def get_rpaths(pkg):
     """Get a list of all the rpaths for a package."""
-    rpaths = [pkg.prefix.lib, pkg.prefix.lib64]
-    deps = get_rpath_deps(pkg)
-    rpaths.extend(d.prefix.lib for d in deps
-                  if os.path.isdir(d.prefix.lib))
-    rpaths.extend(d.prefix.lib64 for d in deps
-                  if os.path.isdir(d.prefix.lib64))
+    rpaths = pkg.rpath
+
     # Second module is our compiler mod name. We use that to get rpaths from
     # module show output.
     if pkg.compiler.modules and len(pkg.compiler.modules) > 1:

--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -18,6 +18,7 @@ from llnl.util.filesystem import \
     HeaderList, find_headers, \
     LibraryList, find_libraries, find_system_libraries
 
+from spack.error import NoLibrariesError
 from spack.version import Version, ver
 from spack.package import PackageBase, run_after, InstallError
 from spack.util.environment import EnvironmentModifications
@@ -45,7 +46,7 @@ def raise_lib_error(*args):
     '''Bails out with an error message. Shows args after the first as one per
     line, tab-indented, useful for long paths to line up and stand out.
     '''
-    raise InstallError("\n\t".join(str(i) for i in args))
+    raise NoLibrariesError("\n\t".join(str(i) for i in args))
 
 
 def _expand_fields(s):

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2185,10 +2185,19 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
                     e.message)
 
     @property
+    def rpath_deps(self):
+        """Return immediate or transitive RPATHs depending on the package."""
+        if self.transitive_rpaths:
+            return [d for d in self.spec.traverse(root=False,
+                                                  deptype=('link'))]
+        else:
+            return self.spec.dependencies(deptype='link')
+
+    @property
     def rpath(self):
         """Get the rpath this package links with, as a list of paths."""
         rpaths = [self.prefix.lib, self.prefix.lib64]
-        deps = self.spec.dependencies(deptype='link')
+        deps = self.rpath_deps
         rpaths.extend(d.prefix.lib for d in deps
                       if os.path.isdir(d.prefix.lib))
         rpaths.extend(d.prefix.lib64 for d in deps

--- a/var/spack/repos/builtin/packages/apple-libunwind/package.py
+++ b/var/spack/repos/builtin/packages/apple-libunwind/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.error import NoLibrariesError
 
 
 class AppleLibunwind(Package):
@@ -66,9 +67,9 @@ class AppleLibunwind(Package):
         libs = find_libraries('libSystem',
                               self.prefix.lib,
                               shared=True, recursive=False)
-        if libs:
-            return libs
-        return None
+        if not libs:
+            raise NoLibrariesError(self.name, self.prefix)
+        return libs
 
     @property
     def headers(self):

--- a/var/spack/repos/builtin/packages/essl/package.py
+++ b/var/spack/repos/builtin/packages/essl/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.error import NoLibrariesError
 
 
 class Essl(Package):
@@ -58,6 +59,8 @@ class Essl(Package):
             shared=True
         )
 
+        if not essl_libs:
+            raise NoLibrariesError(self.name, self.prefix)
         return essl_libs
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.error import NoLibrariesError
 import os
 import sys
 
@@ -137,8 +138,8 @@ class Hypre(Package):
 
     @property
     def headers(self):
-        """Export the main hypre header, HYPRE.h; all other headers can be found
-        in the same directory.
+        """Export the main hypre header, HYPRE.h; all other headers can be
+        found in the same directory.
         Sample usage: spec['hypre'].headers.cpp_flags
         """
         hdrs = find_headers('HYPRE', self.prefix.include, recursive=False)
@@ -157,4 +158,5 @@ class Hypre(Package):
                                   shared=is_shared, recursive=recursive)
             if libs:
                 return libs
-        return None
+
+        raise NoLibrariesError(self.name, self.prefix)

--- a/var/spack/repos/builtin/packages/libx11/package.py
+++ b/var/spack/repos/builtin/packages/libx11/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.error import NoLibrariesError
 
 
 class Libx11(AutotoolsPackage):
@@ -38,4 +39,4 @@ class Libx11(AutotoolsPackage):
                                   shared=True, recursive=False)
             if libs:
                 return libs
-        return None
+        raise NoLibrariesError(self.name, self.prefix)

--- a/var/spack/repos/builtin/packages/libxsmm/package.py
+++ b/var/spack/repos/builtin/packages/libxsmm/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.error import NoLibrariesError
 import os
 from glob import glob
 
@@ -59,6 +60,9 @@ class Libxsmm(MakefilePackage):
         if len(result) == 0:
             result = find_libraries(['libxsmm', 'libxsmmf'], root=self.prefix,
                                     shared=False, recursive=True)
+        if not result:
+            raise NoLibrariesError(self.name, self.prefix)
+
         return result
 
     def build(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/mesa-glu/package.py
+++ b/var/spack/repos/builtin/packages/mesa-glu/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.error import NoLibrariesError
 
 
 class MesaGlu(AutotoolsPackage):
@@ -25,3 +26,4 @@ class MesaGlu(AutotoolsPackage):
                                   shared=True, recursive=False)
             if libs:
                 return libs
+        raise NoLibrariesError(self.name, self.prefix)

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.error import NoLibrariesError
 import os
 import shutil
 
@@ -471,7 +472,9 @@ class Mfem(Package):
         """
         libs = find_libraries('libmfem', root=self.prefix.lib,
                               shared=('+shared' in self.spec), recursive=False)
-        return libs or None
+        if not libs:
+            raise NoLibrariesError(self.name, self.prefix)
+        return libs
 
     @property
     def config_mk(self):

--- a/var/spack/repos/builtin/packages/mumps/package.py
+++ b/var/spack/repos/builtin/packages/mumps/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.error import NoLibrariesError
 import os
 import sys
 import glob
@@ -304,7 +305,10 @@ class Mumps(Package):
     @property
     def libs(self):
         component_libs = ['*mumps*', 'pord']
-        return find_libraries(['lib' + comp for comp in component_libs],
+        libs = find_libraries(['lib' + comp for comp in component_libs],
                               root=self.prefix.lib,
                               shared=('+shared' in self.spec),
-                              recursive=False) or None
+                              recursive=False)
+        if not libs:
+            raise NoLibrariesError(self.name, self.prefix)
+        return libs

--- a/var/spack/repos/builtin/packages/opengl/package.py
+++ b/var/spack/repos/builtin/packages/opengl/package.py
@@ -6,6 +6,7 @@
 import sys
 
 from spack import *
+from spack.error import NoLibrariesError
 
 
 class Opengl(Package):
@@ -73,3 +74,4 @@ class Opengl(Package):
                                   shared=True, recursive=False)
             if libs:
                 return libs
+        raise NoLibrariesError(self.name, self.prefix)

--- a/var/spack/repos/builtin/packages/openglu/package.py
+++ b/var/spack/repos/builtin/packages/openglu/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.error import NoLibrariesError
 
 
 class Openglu(Package):
@@ -64,3 +65,4 @@ class Openglu(Package):
                                   shared=True, recursive=False)
             if libs:
                 return libs
+        raise NoLibrariesError(self.name, self.prefix)

--- a/var/spack/repos/builtin/packages/suite-sparse/package.py
+++ b/var/spack/repos/builtin/packages/suite-sparse/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.error import NoLibrariesError
 
 
 class SuiteSparse(Package):
@@ -139,6 +140,6 @@ class SuiteSparse(Package):
         libs = find_libraries(['lib' + c for c in comps], root=self.prefix.lib,
                               shared=True, recursive=False)
         if not libs:
-            return None
+            raise NoLibrariesError(self.name, self.prefix)
         libs += find_system_libraries('librt')
         return libs

--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.error import NoLibrariesError
 import os
 import sys
 
@@ -508,4 +509,4 @@ class Sundials(CMakePackage):
                                   recursive=recursive)
             if libs:
                 return libs
-        return None  # Raise an error
+        raise NoLibrariesError(self.name, self.prefix)


### PR DESCRIPTION
blocked by https://github.com/spack/spack/pull/10992 (first commit)