### PR TITLE
llvm: depend on python only when +python

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -71,11 +71,12 @@ class Llvm(CMakePackage):
 
     # Build dependency
     depends_on('cmake@3.4.3:', type='build')
+    depends_on('python@2.7:2.8', when='@:4.999 ~python', type='build')
+    depends_on('python', when='@5: ~python', type='build')
 
     # Universal dependency
-    depends_on('python@2.7:2.8', when='@:4.999')
-    depends_on('python')
-    depends_on('py-lit', type=('build', 'run'))
+    depends_on('python@2.7:2.8', when='@:4.999+python')
+    depends_on('python', when='@5:+python')
 
     # openmp dependencies
     depends_on('perl-data-dumper', type=('build'))
@@ -590,7 +591,6 @@ class Llvm(CMakePackage):
 
     def cmake_args(self):
         spec = self.spec
-
         cmake_args = [
             '-DLLVM_REQUIRES_RTTI:BOOL=ON',
             '-DLLVM_ENABLE_RTTI:BOOL=ON',


### PR DESCRIPTION
Based on the LLVM documentation [1], Python is used to run the automated
test suite. Therefore is it always a dependency for LLVM. However, if
build without Python (~python), we limit it to a build time dependency.

Note that py-lit is not added as a spack dependency even though it is
available as a spack package. This is because it is already included
in llvm and llvm is difficult to configure using an external py-lit
(several CMake variables to set correctly). Additionally, having
py-lit as a spack dependency adds Python as a runtime dependency
for llvm even though it is not required at runtime.

[1] https://llvm.org/docs/GettingStarted.html#requirements

Replaces accidentally closed and deleted #10986