### PR TITLE
Use Ninja as makefile generator for Trilinos

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -317,6 +317,11 @@ class Trilinos(CMakePackage):
     depends_on('py-numpy', when='+python', type=('build', 'run'))
     depends_on('swig', when='+python')
 
+    # Use Ninja for faster build times
+    generator = 'Ninja'
+    # Need to use a Ninja with Fortran support
+    depends_on('ninja@1.9.0.1:', type='build')
+
     patch('umfpack_from_suitesparse.patch', when='@11.14.1:12.8.1')
     patch('xlf_seacas.patch', when='@12.10.1:12.12.1 %xl')
     patch('xlf_seacas.patch', when='@12.10.1:12.12.1 %xl_r')


### PR DESCRIPTION
Depends on #11347 for a Ninja with Fortran support, although I don't really know how to make the version dependency robust enough to guarantee it has Fortran support. A `ninja-fortran` package exists, but it probably makes sense to consolidate it into `ninja` as in #11347 . I've been wanting to get Ninja as a generator into Trilinos for a while and now it appears I don't need to do it with this anymore which was stopping me previously (along with the lack of official Fortran support):
```
@property
    def generator(self):
        if '+ninja' in self.spec:
            return 'Ninja'
        else:
            return 'Unix Makefiles'
```

Edit: I think https://github.com/ninja-build/ninja/pull/1521 means the Kitware Fortran features are finally merged into Ninja itself?