### PR TITLE
mysql: New versions, add conflicts, cope with use of dtrace.

### DIFF
--- a/var/spack/repos/builtin/packages/mysql/package.py
+++ b/var/spack/repos/builtin/packages/mysql/package.py
@@ -143,10 +143,12 @@ class Mysql(CMakePackage):
         flag = getattr(self.compiler, 'cxx{0}_flag'.format(cxxstd))
         if flag:
             spack_env.append_flags('CXXFLAGS', flag)
-        if cxxstd > 11:
-            spack_env.append_flags('CXXFLAGS', '-Wno-deprecated-declarations')
-        if cxxstd > 14:
-            spack_env.append_flags('CXXFLAGS', '-Wno-error=register')
+        if cxxstd != '98':
+            if int(cxxstd) > 11:
+                spack_env.append_flags('CXXFLAGS',
+                                       '-Wno-deprecated-declarations')
+            if int(cxxstd) > 14:
+                spack_env.append_flags('CXXFLAGS', '-Wno-error=register')
         if 'python' in self.spec.flat_dependencies() and \
            self.spec.satisfies('@:7.99.99'):
             self.fix_dtrace_usr_bin_path(spack_env)

--- a/var/spack/repos/builtin/packages/mysql/package.py
+++ b/var/spack/repos/builtin/packages/mysql/package.py
@@ -123,7 +123,8 @@ class Mysql(CMakePackage):
         # dtrace may cause build to fail because it uses
         # '/usr/bin/python' in the shebang. To work around that we copy
         # the original script into a temporary folder, and change the
-        # shebang to '/usr/bin/env python'.
+        # shebang to '/usr/bin/env python'. Treatment adapted from that
+        # used in glib recipe per M. Culpo @b2822b258.
         dtrace = which('dtrace').path
         dtrace_copy_path = os.path.join(tempfile.mkdtemp(), 'dtrace-copy')
         dtrace_copy = os.path.join(dtrace_copy_path, 'dtrace')

--- a/var/spack/repos/builtin/packages/mysql/package.py
+++ b/var/spack/repos/builtin/packages/mysql/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from spack import *
+import os
+import tempfile
 
 
 class Mysql(CMakePackage):
@@ -11,11 +13,13 @@ class Mysql(CMakePackage):
     homepage = "https://www.mysql.com/"
     url      = "https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-8.0.15.tar.gz"
 
+    version('8.0.16', sha256='8d9fe89920dc8bbbde2857b7b877ad2fa5ec2f231c68e941d484f3b72735eaea')
     version('8.0.15', sha256='bb1bca2dc2f23ee9dd395cc4db93b64561d4ac20b53be5d1dae563f7be64825e')
     version('8.0.14', sha256='bc53f4c914fb39650289700d144529121d71f38399d2d24a0f5c76e5a8abd204')
     version('8.0.13', sha256='d85eb7f98b6aa3e2c6fe38263bf40b22acb444a4ce1f4668473e9e59fb98d62e')
     version('8.0.12', sha256='69f16e20834dbc60cb28d6df7351deda323330b9de685d22415f135bcedd1b20')
     version('8.0.11', '38d5a5c1a1eeed1129fec3a999aa5efd')
+    version('5.7.26', sha256='5f01d579a20199e06fcbc28f0801c3cb545a54a2863ed8634f17fe526480b9f1')
     version('5.7.25', sha256='53751c6243806103114567c1a8b6a3ec27f23c0e132f377a13ce1eb56c63723f')
     version('5.7.24', sha256='05bf0c92c6a97cf85b67fff1ac83ca7b3467aea2bf306374d727fa4f18431f87')
     version('5.7.23', sha256='0730f2d5520bfac359e9272da6c989d0006682eacfdc086a139886c0741f6c65')
@@ -33,6 +37,7 @@ class Mysql(CMakePackage):
     version('5.7.11', sha256='54f8c7af87d3d8084419bde2b9f0d8970b3dada0757b015981b02f35a3681f0e')
     version('5.7.10', sha256='1ea1644884d086a23eafd8ccb04d517fbd43da3a6a06036f23c5c3a111e25c74')
     version('5.7.9',  sha256='315342f5bee1179548cecad2d776cd7758092fd2854024e60a3a5007feba34e0')
+    version('5.6.44', sha256='c031c92c3f226856b09bf929d8a26b0cd8600036cb9db4e0fdf6b6f032ced336')
     version('5.6.43', sha256='1c95800bf0e1b7a19a37d37fbc5023af85c6bc0b41532433b3a886263a1673ef')
     version('5.5.62', sha256='b1e7853bc1f04aabf6771e0ad947f35ac8d237f4b35d0706d1095c9526ff99d7')
 
@@ -44,7 +49,11 @@ class Mysql(CMakePackage):
             multi=False,
             description='Use the specified C++ standard when building.')
 
+    # 5.7.X cannot be compiled client-only.
     conflicts('+client_only', when='@5.7.0:5.7.999')
+    # Server code has a macro 'byte', which conflicts with C++17's
+    # std::byte.
+    conflicts('cxxstd=17', when='@8.0.0:~client_only')
 
     provides('mysql-client')
 
@@ -63,11 +72,16 @@ class Mysql(CMakePackage):
 
     # Each version of MySQL requires a specific version of boost
     # See BOOST_PACKAGE_NAME in cmake/boost.cmake
-    # 8.0.14+
-    depends_on('boost@1.68.0 cxxstd=98', type='build', when='@8.0.14: cxxstd=98')
-    depends_on('boost@1.68.0 cxxstd=11', type='build', when='@8.0.14: cxxstd=11')
-    depends_on('boost@1.68.0 cxxstd=14', type='build', when='@8.0.14: cxxstd=14')
-    depends_on('boost@1.68.0 cxxstd=17', type='build', when='@8.0.14: cxxstd=17')
+    # 8.0.16+
+    depends_on('boost@1.69.0 cxxstd=98', type='build', when='@8.0.16: cxxstd=98')
+    depends_on('boost@1.69.0 cxxstd=11', type='build', when='@8.0.16: cxxstd=11')
+    depends_on('boost@1.69.0 cxxstd=14', type='build', when='@8.0.16: cxxstd=14')
+    depends_on('boost@1.69.0 cxxstd=17', type='build', when='@8.0.16: cxxstd=17')
+    # 8.0.14--8.0.15
+    depends_on('boost@1.68.0 cxxstd=98', type='build', when='@8.0.14:8.0.15 cxxstd=98')
+    depends_on('boost@1.68.0 cxxstd=11', type='build', when='@8.0.14:8.0.15 cxxstd=11')
+    depends_on('boost@1.68.0 cxxstd=14', type='build', when='@8.0.14:8.0.15 cxxstd=14')
+    depends_on('boost@1.68.0 cxxstd=17', type='build', when='@8.0.14:8.0.15 cxxstd=17')
     # 8.0.12--8.0.13
     depends_on('boost@1.67.0 cxxstd=98', type='build', when='@8.0.12:8.0.13 cxxstd=98')
     depends_on('boost@1.67.0 cxxstd=11', type='build', when='@8.0.12:8.0.13 cxxstd=11')
@@ -86,7 +100,7 @@ class Mysql(CMakePackage):
 
     depends_on('ncurses')
     depends_on('openssl')
-    depends_on('perl', type='test')
+    depends_on('perl', type=['build', 'test'], when='@:7.99.99')
     depends_on('bison@2.1:', type='build', when='@develop')
     depends_on('m4', type='build', when='@develop platform=solaris')
 
@@ -105,8 +119,34 @@ class Mysql(CMakePackage):
             options.append('-DWITHOUT_SERVER:BOOL=ON')
         return options
 
+    def fix_dtrace_usr_bin_path(self, spack_env):
+        # dtrace may cause build to fail because it uses
+        # '/usr/bin/python' in the shebang. To work around that we copy
+        # the original script into a temporary folder, and change the
+        # shebang to '/usr/bin/env python'.
+        dtrace = which('dtrace').path
+        dtrace_copy_path = os.path.join(tempfile.mkdtemp(), 'dtrace-copy')
+        dtrace_copy = os.path.join(dtrace_copy_path, 'dtrace')
+        mkdirp(dtrace_copy_path)
+        copy(dtrace, dtrace_copy)
+        filter_file(
+            '^#!/usr/bin/python',
+            '#!/usr/bin/env python',
+            dtrace_copy
+        )
+        # To have our own copy of dtrace in PATH, we need to
+        # prepend to PATH the temporary folder where it resides.
+        spack_env.prepend_path('PATH', dtrace_copy_path)
+
     def setup_environment(self, spack_env, run_env):
         cxxstd = self.spec.variants['cxxstd'].value
         flag = getattr(self.compiler, 'cxx{0}_flag'.format(cxxstd))
         if flag:
             spack_env.append_flags('CXXFLAGS', flag)
+        if cxxstd > 11:
+            spack_env.append_flags('CXXFLAGS', '-Wno-deprecated-declarations')
+        if cxxstd > 14:
+            spack_env.append_flags('CXXFLAGS', '-Wno-error=register')
+        if 'python' in self.spec.flat_dependencies() and \
+           self.spec.satisfies('@:7.99.99'):
+            self.fix_dtrace_usr_bin_path(spack_env)


### PR DESCRIPTION
* New versions:
  * 8.0.16
  * 5.7.26
  * 5.6.44
* Perl is also a build-time dependency for <8.0.
* Special measures to allow use of dtrace to be successful when Python is in the dependency tree.