### PR TITLE
Mesa should depend_on('glproto')

### DIFF
--- a/var/spack/repos/builtin/packages/mesa/glproto-mr806.patch
+++ b/var/spack/repos/builtin/packages/mesa/glproto-mr806.patch
@@ -1,0 +1,32 @@
+diff --git a/meson.build b/meson.build
+index d975b0d..cbd4a2c 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1387,12 +1387,14 @@ if with_platform_x11
+       dep_xshmfence = dependency('xshmfence', version : '>= 1.1')
+     endif
+   endif
+-  if with_glx == 'dri'
++  if with_glx == 'dri' or with_glx == 'gallium-xlib'
++    dep_glproto = dependency('glproto', version : '>= 1.4.14')
++  endif
++  if with_glx == 'dri' 
+     if with_dri_platform == 'drm'
+       dep_dri2proto = dependency('dri2proto', version : '>= 2.8')
+       dep_xxf86vm = dependency('xxf86vm')
+     endif
+-    dep_glproto = dependency('glproto', version : '>= 1.4.14')
+   endif
+   if (with_egl or (
+       with_gallium_vdpau or with_gallium_xvmc or with_gallium_xa or
+diff --git a/src/gallium/state_trackers/glx/xlib/meson.build b/src/gallium/state_trackers/glx/xlib/meson.build
+index f4ee754..34b93c9 100644
+--- a/src/gallium/state_trackers/glx/xlib/meson.build
++++ b/src/gallium/state_trackers/glx/xlib/meson.build
+@@ -23,5 +23,5 @@ libxlib = static_library(
+   files('glx_api.c', 'glx_getproc.c', 'glx_usefont.c', 'xm_api.c', 'xm_st.c'),
+   c_args : c_vis_args,
+   include_directories : [inc_common, inc_mapi, inc_mesa],
+-  dependencies : [dep_x11, dep_xext, dep_xcb],
++  dependencies : [dep_x11, dep_xext, dep_xcb, dep_glproto],
+ )

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -33,7 +33,6 @@ class Mesa(MesonPackage):
     depends_on('libxml2')
     depends_on('zlib')
     depends_on('expat')
-    depends_on('glproto', when='+glx')
 
     # Internal options
     variant('llvm', default=True, description="Enable LLVM.")
@@ -69,6 +68,11 @@ class Mesa(MesonPackage):
     depends_on('libx11',  when='+glx')
     depends_on('libxcb',  when='+glx')
     depends_on('libxext', when='+glx')
+    depends_on('glproto@1.4.14:', when='+glx', type='build')
+
+    # Fix glproto dependency for glx=gallium-xlib
+    # https://gitlab.freedesktop.org/mesa/mesa/merge_requests/806
+    patch('glproto-mr806.patch', when='@19.0.0')
 
     def meson_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -33,7 +33,7 @@ class Mesa(MesonPackage):
     depends_on('libxml2')
     depends_on('zlib')
     depends_on('expat')
-    depends_on('glproto')
+    depends_on('glproto', when='+glx')
 
     # Internal options
     variant('llvm', default=True, description="Enable LLVM.")

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -33,6 +33,7 @@ class Mesa(MesonPackage):
     depends_on('libxml2')
     depends_on('zlib')
     depends_on('expat')
+    depends_on('glproto')
 
     # Internal options
     variant('llvm', default=True, description="Enable LLVM.")


### PR DESCRIPTION
This should be ready to go, see conversation for details.

---

ToDo:

- [x] I suspect that this should be conditional on the `opengl` variant, but would appreciate guidance from someone more familiar with that world.

---

The mesa package refers to `GL/glproto.h`.  On systems that don't have the OS packages installed, this leads to failures during the build [e.g. this comment in 01482](https://github.com/spack/spack/pull/10482#issuecomment-488786745).

This fixes it.  Tested on a minimally provisioned CentOS 7.

@opadron, can you check it on your systems (I'm using the same base system that @odoublewen is, but I'm sure he'll test it too...).


