### PR TITLE
Spack environments can concretize specs together

### DIFF
--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -489,10 +489,9 @@ available from the yaml file.
 Spec concretization
 """""""""""""""""""
 
-Specs can be either concretized separately or together, as already
+Specs can be concretized separately or together, as already
 explained in :ref:`environments_concretization`. The behavior active
-under any environment is determined by the ``concretize_together``
-property:
+under any environment is determined by the ``concretization`` property:
 
 .. code-block:: yaml
 
@@ -502,9 +501,17 @@ property:
          - netcdf
          - nco
          - py-sphinx
-       concretize_together: true
+       concretization: together
 
-If this property is not set it will default to ``false``.
+which can currently take either one of the two allowed values ``together`` or ``separately``
+(the default).
+
+.. admonition:: Re-concretization of user specs
+
+   When concretizing specs together the entire set of specs will be
+   re-concretized after any addition of new user specs, to ensure that
+   the environment remains consistent. When instead the specs are concretized
+   separately only the new specs will be re-concretized after any addition.
 
 """""""""""""
 Spec Matrices

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -292,19 +292,37 @@ or
 
    $ spack -E myenv add python
 
+.. _environments_concretization:
+
 ^^^^^^^^^^^^
 Concretizing
 ^^^^^^^^^^^^
 
 Once some user specs have been added to an environment, they can be
-concretized.  The following command will concretize all user specs
-that have been added and not yet concretized:
+concretized. *By default specs are concretized separately*, one after
+the other. This mode of operation permits to deploy a full
+software stack where multiple configurations of the same package
+need to be installed alongside each other. Central installations done
+at HPC centers by system administrators or user support groups
+are a common case that fits in this behavior.
+Environments *can also be configured to concretize all
+the root specs in a self-consistent way* to ensure that
+each package in the environment comes with a single configuration. This
+mode of operation is usually what is required by software developers that
+want to deploy their development environment.
+
+Regardless of which mode of operation has been chosen, the following
+command will ensure all the root specs are concretized according to the
+constraints that are prescribed in the configuration:
 
 .. code-block:: console
 
    [myenv]$ spack concretize
 
-This command will re-concretize all specs:
+In the case of specs that are not concretized together, the command
+above will concretize only the specs that were added and not yet
+concretized. Forcing a re-concretization of all the specs can be done
+instead with this command:
 
 .. code-block:: console
 
@@ -466,6 +484,27 @@ the ``spack.yaml`` manifest under the heading ``specs``.
 Appending to this list in the yaml is identical to using the ``spack
 add`` command from the command line. However, there is more power
 available from the yaml file.
+
+"""""""""""""""""""
+Spec concretization
+"""""""""""""""""""
+
+Specs can be either concretized separately or together, as already
+explained in :ref:`environments_concretization`. The behavior active
+under any environment is determined by the ``concretize_together``
+property:
+
+.. code-block:: yaml
+
+   spack:
+       specs:
+         - ncview
+         - netcdf
+         - nco
+         - py-sphinx
+       concretize_together: true
+
+If this property is not set it will default to ``false``.
 
 """""""""""""
 Spec Matrices

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -905,6 +905,13 @@ class Environment(object):
         This will automatically concretize the single spec, but it won't
         affect other as-yet unconcretized specs.
         """
+        if self.concretize_together:
+            msg = 'cannot install a single spec in an environment that is ' \
+                  'configured to be concretized together. Run instead:\n\n' \
+                  '    $ spack add <spec>\n' \
+                  '    $ spack install\n'
+            raise SpackEnvironmentError(msg)
+
         spec = Spec(user_spec)
 
         if self.add(spec):

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import collections
 import os
 import re
 import sys
@@ -905,6 +906,23 @@ class Environment(object):
         if user_specs_did_not_change:
             return []
 
+        # Check that user specs don't have duplicate packages
+        counter = collections.defaultdict(int)
+        for user_spec in self.user_specs:
+            counter[user_spec.name] += 1
+
+        duplicates = []
+        for name, count in counter.items():
+            if count > 1:
+                duplicates.append(name)
+
+        if duplicates:
+            msg = ('environment that are configured to concretize specs'
+                   ' together cannot contain more than one spec for each'
+                   ' package [{0}]'.format(', '.join(duplicates)))
+            raise SpackEnvironmentError(msg)
+
+        # Proceed with concretization
         self.concretized_user_specs = []
         self.concretized_order = []
         self.specs_by_hash = {}

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -516,7 +516,9 @@ class Environment(object):
                 path to the view.
         """
         self.path = os.path.abspath(path)
-        self.concretization = False
+        # This attribute will be set properly from configuration
+        # during concretization
+        self.concretization = None
         self.clear()
 
         if init_file:

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -119,6 +119,10 @@ schema = {
                                 }
                             }
                         ]
+                    },
+                    'concretize_together': {
+                        'type': 'boolean',
+                        'default': False
                     }
                 }
             )

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -122,9 +122,7 @@ schema = {
                     },
                     'concretization': {
                         'type': 'string',
-                        # Strategies are added dynamically by the
-                        # Environment class
-                        'enum': [],
+                        'enum': ['together', 'separately'],
                         'default': 'separately'
                     }
                 }

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -120,9 +120,12 @@ schema = {
                             }
                         ]
                     },
-                    'concretize_together': {
-                        'type': 'boolean',
-                        'default': False
+                    'concretization': {
+                        'type': 'string',
+                        # Strategies are added dynamically by the
+                        # Environment class
+                        'enum': [],
+                        'default': 'separately'
                     }
                 }
             )

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1694,3 +1694,31 @@ def test_env_activate_csh_prints_shell_output(
     assert "setenv SPACK_ENV" in out
     assert "set prompt=" in out
     assert "alias despacktivate" in out
+
+
+def test_concretize_user_specs_together():
+    e = ev.create('coconcretization')
+    e.concretize_together = True
+
+    # Concretize a first time using 'mpich' as the MPI provider
+    e.add('mpileaks')
+    e.add('mpich')
+    e.concretize()
+
+    assert all('mpich' in spec for _, spec in e.concretized_specs())
+    assert all('mpich2' not in spec for _, spec in e.concretized_specs())
+
+    # Concretize a second time using 'mpich2' as the MPI provider
+    e.remove('mpich')
+    e.add('mpich2')
+    e.concretize()
+
+    assert all('mpich2' in spec for _, spec in e.concretized_specs())
+    assert all('mpich' not in spec for _, spec in e.concretized_specs())
+
+    # Concretize again without changing anything, check everything
+    # stays the same
+    e.concretize()
+
+    assert all('mpich2' in spec for _, spec in e.concretized_specs())
+    assert all('mpich' not in spec for _, spec in e.concretized_specs())

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1722,3 +1722,11 @@ def test_concretize_user_specs_together():
 
     assert all('mpich2' in spec for _, spec in e.concretized_specs())
     assert all('mpich' not in spec for _, spec in e.concretized_specs())
+
+
+def test_cant_install_single_spec_when_concretizing_together():
+    e = ev.create('coconcretization')
+    e.concretize_together = True
+
+    with pytest.raises(ev.SpackEnvironmentError, match=r'cannot install'):
+        e.install('zlib')

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1730,3 +1730,15 @@ def test_cant_install_single_spec_when_concretizing_together():
 
     with pytest.raises(ev.SpackEnvironmentError, match=r'cannot install'):
         e.install('zlib')
+
+
+def test_duplicate_packages_raise_when_concretizing_together():
+    e = ev.create('coconcretization')
+    e.concretization = 'together'
+
+    e.add('mpileaks+opt')
+    e.add('mpileaks~opt')
+    e.add('mpich')
+
+    with pytest.raises(ev.SpackEnvironmentError, match=r'cannot contain more'):
+        e.concretize()

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1698,7 +1698,7 @@ def test_env_activate_csh_prints_shell_output(
 
 def test_concretize_user_specs_together():
     e = ev.create('coconcretization')
-    e.concretize_together = True
+    e.concretization = 'together'
 
     # Concretize a first time using 'mpich' as the MPI provider
     e.add('mpileaks')
@@ -1726,7 +1726,7 @@ def test_concretize_user_specs_together():
 
 def test_cant_install_single_spec_when_concretizing_together():
     e = ev.create('coconcretization')
-    e.concretize_together = True
+    e.concretization = 'together'
 
     with pytest.raises(ev.SpackEnvironmentError, match=r'cannot install'):
         e.install('zlib')


### PR DESCRIPTION
depends on #12213 

fixes #9902
fixes #11095

This PR adds a boolean entry in `spack.yaml`:
```yaml
spack:
    concretize_together: true
```
If set to `true` all the specs in the environment are concretized to be self-consistent, meaning there will be a single configuration for each package and a single provider for each virtual dependency. The default value is `false` to maintain backward compatibility with the behavior before this PR.