### PR TITLE
Cap the maximum number of build jobs

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -99,10 +99,12 @@ config:
   locks: true
 
 
-  # The default number of jobs to use when running `make` in parallel.
-  # If set to 4, for example, `spack install` will run `make -j4`.
-  # If not set, all available cores are used by default.
-  # build_jobs: 4
+  # The tentative number of jobs to use when running `make` in parallel,
+  # always limited by the number of cores available. For instance:
+  # - If set to 16 on a 4 cores machine `spack install` will run `make -j4`
+  # - If set to 16 on a 18 cores machine `spack install` will run `make -j16`
+  # If not set, Spack will use all available cores up to 16.
+  # build_jobs: 16
 
 
   # If set to true, Spack will use ccache to cache C compiles.

--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -99,7 +99,7 @@ config:
   locks: true
 
 
-  # The tentative number of jobs to use when running `make` in parallel,
+  # The maximum number of jobs to use when running `make` in parallel,
   # always limited by the number of cores available. For instance:
   # - If set to 16 on a 4 cores machine `spack install` will run `make -j4`
   # - If set to 16 on a 18 cores machine `spack install` will run `make -j16`

--- a/lib/spack/docs/config_yaml.rst
+++ b/lib/spack/docs/config_yaml.rst
@@ -178,16 +178,23 @@ set ``dirty`` to ``true`` to skip the cleaning step and make all builds
 "dirty" by default.  Be aware that this will reduce the reproducibility
 of builds.
 
+.. _build-jobs:
+
 --------------
 ``build_jobs``
 --------------
 
 Unless overridden in a package or on the command line, Spack builds all
-packages in parallel. For a build system that uses Makefiles, this means
-running ``make -j<build_jobs>``, where ``build_jobs`` is the number of
-threads to use.
+packages in parallel. The default parallelism is equal to the number of
+cores on your machine, up to 16. Parallelism cannot exceed the number of
+cores available on the host. For a build system that uses Makefiles, this
+means running:
 
-The default parallelism is equal to the number of cores on your machine.
+- ``make -j<build_jobs>``, when ``build_jobs`` is less than the number of
+  cores on the machine
+- ``make -j<ncores>``, when ``build_jobs`` is greater or equal to the
+  number of cores on the machine
+
 If you work on a shared login node or have a strict ulimit, it may be
 necessary to set the default to a lower value. By setting ``build_jobs``
 to 4, for example, commands like ``spack install`` will run ``make -j4``

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -1713,12 +1713,11 @@ RPATHs in Spack are handled in one of three ways:
 Parallel builds
 ---------------
 
-By default, Spack will invoke ``make()`` with a ``-j <njobs>``
-argument, so that builds run in parallel.  It figures out how many
-jobs to run by determining how many cores are on the host machine.
-Specifically, it uses the number of CPUs reported by Python's
-`multiprocessing.cpu_count()
-<http://docs.python.org/library/multiprocessing.html#multiprocessing.cpu_count>`_.
+By default, Spack will invoke ``make()``, or any other similar tool,
+with a ``-j <njobs>`` argument, so that builds run in parallel.
+The parallelism is determined by the value of the ``build_jobs`` entry
+in ``config.yaml`` (see :ref:`here <build-jobs>` for more details on
+how this value is computed).
 
 If a package does not build properly in parallel, you can override
 this setting by adding ``parallel = False`` to your package.  For

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -5,6 +5,7 @@
 
 
 import argparse
+import multiprocessing
 
 import spack.cmd
 import spack.config
@@ -86,6 +87,7 @@ class SetParallelJobs(argparse.Action):
                   '[expected a positive integer, got "{1}"]'
             raise ValueError(msg.format(option_string, jobs))
 
+        jobs = min(jobs, multiprocessing.cpu_count())
         spack.config.set('config:build_jobs', jobs, scope='command_line')
 
         setattr(namespace, 'jobs', jobs)
@@ -94,7 +96,8 @@ class SetParallelJobs(argparse.Action):
     def default(self):
         # This default is coded as a property so that look-up
         # of this value is done only on demand
-        return spack.config.get('config:build_jobs')
+        return min(spack.config.get('config:build_jobs'),
+                   multiprocessing.cpu_count())
 
     @default.setter
     def default(self, value):

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -100,7 +100,7 @@ config_defaults = {
         'verify_ssl': True,
         'checksum': True,
         'dirty': False,
-        'build_jobs': multiprocessing.cpu_count(),
+        'build_jobs': min(16, multiprocessing.cpu_count()),
     }
 }
 


### PR DESCRIPTION
fixes #11072

`config:build_jobs` is capped by the number of cores available
    
`config:build_jobs` controls the number of parallel jobs to spawn during builds, but cannot ever exceed the number of cores on the machine. The default is set to 16 or the number of available cores, whatever is lowest.
