### PR TITLE
Some fixes for Intel build system packages.

### DIFF
--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -965,7 +965,7 @@ class IntelPackage(PackageBase):
                 shared=True, recursive=True) + result
 
         if '^mpi' in self.spec.root and ('+mkl' in self.spec or
-                                    self.provides('scalapack')):
+                                         self.provides('scalapack')):
             result = self.scalapack_libs + result
 
         debug_print(result)

--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -964,7 +964,7 @@ class IntelPackage(PackageBase):
                 root=self.component_lib_dir('mpi'),
                 shared=True, recursive=True) + result
 
-        if '+mpi' in self.spec and ('+mkl' in self.spec or
+        if '^mpi' in self.spec and ('+mkl' in self.spec or
                                     self.provides('scalapack')):
             result = self.scalapack_libs + result
 

--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -964,7 +964,8 @@ class IntelPackage(PackageBase):
                 root=self.component_lib_dir('mpi'),
                 shared=True, recursive=True) + result
 
-        if '+mkl' in self.spec or self.provides('scalapack'):
+        if '+mpi' in self.spec and ('+mkl' in self.spec or
+                                    self.provides('scalapack')):
             result = self.scalapack_libs + result
 
         debug_print(result)
@@ -1198,6 +1199,9 @@ class IntelPackage(PackageBase):
 
         install_script = Executable('./install.sh')
         install_script.add_default_env('TMPDIR', tmpdir)
+
+        # Need to set HOME to avoid using ~/intel
+        install_script.add_default_env('HOME', prefix)
 
         # perform
         install_script('--silent', 'silent.cfg')

--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -964,7 +964,7 @@ class IntelPackage(PackageBase):
                 root=self.component_lib_dir('mpi'),
                 shared=True, recursive=True) + result
 
-        if '^mpi' in self.spec and ('+mkl' in self.spec or
+        if '^mpi' in self.spec.root and ('+mkl' in self.spec or
                                     self.provides('scalapack')):
             result = self.scalapack_libs + result
 


### PR DESCRIPTION
- Only return scalapack libraries if `+mpi` is in the spec.
  Fixes #11314
  Fixes #11289

- set HOME when the intel silent installer is run. This prevents the
  installer from using the ~/intel directory
  Fixes #9713