### PR TITLE
repeatmasker: add 4.0.9

### DIFF
--- a/var/spack/repos/builtin/packages/repeatmasker/package.py
+++ b/var/spack/repos/builtin/packages/repeatmasker/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-import inspect
 
 
 class Repeatmasker(Package):
@@ -14,6 +13,7 @@ class Repeatmasker(Package):
     homepage = "http://www.repeatmasker.org"
     url      = "http://www.repeatmasker.org/RepeatMasker-open-4-0-7.tar.gz"
 
+    version('4.0.9', sha256='8d67415d89ed301670b7632ea411f794c6e30d8ed0f007a726c4b0a39c8638e5')
     version('4.0.7', '4dcbd7c88c5343e02d819f4b3e6527c6')
 
     variant('crossmatch', description='Enable CrossMatch search engine',
@@ -50,24 +50,37 @@ class Repeatmasker(Package):
         #    Repeatmasker? (Y/N)
         # Add a Search Engine: Done
 
-        config_answers = ['\n', '%s\n' % self.spec['perl'].command.path,
-                          '%s\n' % self.stage.source_path,
-                          '%s\n' % self.spec['trf'].prefix.bin.trf, '2\n',
-                          '%s\n' % self.spec['ncbi-rmblastn'].prefix.bin,
-                          'Y\n']
+        config_answers = []
 
+        if spec.satisfies('@4.0.9:'):
+            # 4.0.9 removes a bunch of the interactive options
+            config_answers.append('')
+        else:
+            config_answers.extend(['',
+                                   self.spec['perl'].command.path,
+                                   self.stage.source_path,
+                                   self.spec['trf'].prefix.bin.trf])
+
+        # add crossmatch search
         if '+crossmatch' in spec:
             crossmatch = self.spec['phrap-crossmatch-swat'].prefix.bin
-            config_answers.extend(['1\n', '%s\n' % crossmatch, 'N\n'])
+            config_answers.extend(['1', crossmatch, 'N'])
 
-        config_answers.append('5\n')
+        # set default BLAST search
+        config_answers.extend(['2',
+                               self.spec['ncbi-rmblastn'].prefix.bin,
+                               'Y'])
+
+        # end configuration
+        config_answers.append('5')
 
         config_answers_filename = 'spack-config.in'
 
         with open(config_answers_filename, 'w') as f:
-            f.writelines(config_answers)
+            f.write('\n'.join(config_answers))
 
         with open(config_answers_filename, 'r') as f:
-            inspect.getmodule(self).perl('configure', input=f)
+            perl = which('perl')
+            perl('configure', input=f)
 
         install_tree('.', prefix.bin)


### PR DESCRIPTION
repeatmasker 4.0.9 made some changes to the interactive configure script,
which required some refactoring in the package recipe.

The generation of spack-config.in was modified to be clearer about how lines were written,
and perl is now pulled from `which` instead of `inspect.getmodule(self)` which seemed to stop working for some reason.

Changes were tested to be backwards compatible with the existing 4.0.7 version.