### PR TITLE
Random123: Provide a patch to allow preliminary support for ARM platforms

### DIFF
--- a/var/spack/repos/builtin/packages/random123/arm-gcc.patch
+++ b/var/spack/repos/builtin/packages/random123/arm-gcc.patch
@@ -1,0 +1,13 @@
+--- a/include/Random123/features/gccfeatures.h
++++ b/include/Random123/features/gccfeatures.h
+@@ -34,8 +34,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ #define R123_GNUC_VERSION (__GNUC__*10000 + __GNUC_MINOR__*100 + __GNUC_PATCHLEVEL__)
+
+-#if !defined(__x86_64__) && !defined(__i386__) && !defined(__powerpc__)
+-#  error "This code has only been tested on x86 and powerpc platforms."
++#if !defined(__x86_64__) && !defined(__i386__) && !defined(__powerpc__) && !defined(__aarch64__)
++#  error "This code has only been tested on x86, arm, and powerpc platforms."
+ #include <including_a_nonexistent_file_will_stop_some_compilers_from_continuing_with_a_hopeless_task>
+ { /* maybe an unbalanced brace will terminate the compilation */
+  /* Feel free to try the Random123 library on other architectures by changing

--- a/var/spack/repos/builtin/packages/random123/package.py
+++ b/var/spack/repos/builtin/packages/random123/package.py
@@ -18,6 +18,7 @@ class Random123(Package):
     version('1.09', '67ae45ff94b12acea590a6aa04ed1123')
 
     patch('ibmxl.patch', when='@1.09')
+    patch('arm-gcc.patch', when='@1.09')
 
     def install(self, spec, prefix):
         # Random123 doesn't have a build system.


### PR DESCRIPTION
+ The additional patch enables a non-optimized random123 code path that will work on ARM architectures. This solution is provided only for version 1.09 to allow the most current version of Random123 to function.
+ A more complete, long term solution will be the addition of a native ARM intrinsics-based implementation of random123.  This solution is being worked on but it is several weeks or months away.  Once the full implementation is available it will be provided to the author/maintainer of Random123.