### PR TITLE
Netcdf needs curl.

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf/package.py
+++ b/var/spack/repos/builtin/packages/netcdf/package.py
@@ -87,7 +87,7 @@ class Netcdf(AutotoolsPackage):
 
     # curl 7.18.0 or later is required:
     # http://www.unidata.ucar.edu/software/netcdf/docs/getting_and_building_netcdf.html
-    depends_on("curl@7.18.0:", when='+dap')
+    depends_on("curl@7.18.0:") # , when='+dap')
     # depends_on("curl@7.18.0:", when='+cdmremote')
 
     depends_on('parallel-netcdf', when='+parallel-netcdf')


### PR DESCRIPTION
+ The netcdf package already had a conditional dependency on curl, but version 4.7.0 on power9 seems to unconditionally require it.  Here is the error:

```
==> Error: ProcessError: Command exited with status 1:
    '.../spack/var/spack/stage/netcdf-4.7.0-dmymoqzyj7atgm7e7q4icastri4b2wg2/netcdf-c-4.7.0/configure'
  '--prefix=.../spack/opt/spack/linux-rhel7-ppc64le/gcc-7.3.0/netcdf-4.7.0-dmymoqzyj7atgm7e7q4icastri4b2wg2'
  '--enable-v2' '--enable-utilities' '--enable-static' '--enable-largefile'
  '--enable-netcdf-4' '--enable-fsync' '--enable-dynamic-loading'
  '--enable-shared' '--disable-dap' '--enable-parallel4' '--disable-pnetcdf'
  'CC=/projects/opt/ppc64le/openmpi/3.1.3-gcc_7.3.0/bin/mpicc' '--disable-hdf4'
  'CFLAGS=-fPIC'
  'CPPFLAGS=-I.../spack/opt/spack/linux-rhel7-ppc64le/gcc-7.3.0/hdf5-1.10.5-lul6gs4hesxaifyiu4ja5o73xobxwvoy/include'
  'LDFLAGS=-L.../spack/opt/spack/linux-rhel7-ppc64le/gcc-7.3.0/hdf5-1.10.5-lul6gs4hesxaifyiu4ja5o73xobxwvoy/lib'
  'LIBS='

1 error found in build log:
     224    checking whether mmap is enabled for in-memory files... no
     225    checking for mmap... yes
     226    checking for mremap... yes
     227    checking whether MAP_ANONYMOUS is defined... yes
     228    mmap functionality is not available: disabling mmap
     229    checking whether byte range support is enabled... no
  >> 230    configure: error: curl required for byte range support. Install curl
  or build without --enable-byterange.
```

The small change in this PR fixes the problem.