### PR TITLE
Update optional-lite and span-lite to use CMakePackage

### DIFF
--- a/var/spack/repos/builtin/packages/optional-lite/package.py
+++ b/var/spack/repos/builtin/packages/optional-lite/package.py
@@ -7,7 +7,7 @@ from spack import *
 from shutil import copytree
 
 
-class OptionalLite(Package):
+class OptionalLite(CMakePackage):
     """
     A single-file header-only version of a C++17-like optional, a nullable
     object for C++98, C++11 and later.
@@ -16,6 +16,7 @@ class OptionalLite(Package):
     homepage = "https://github.com/martinmoene/optional-lite"
     url      = "https://github.com/martinmoene/optional-lite/archive/v3.0.0.tar.gz"
 
+    version('3.2.0', sha256='069c92f6404878588be761d609b917a111b0231633a91f7f908288fc77eb24c8')
     version('3.1.1', sha256='b61fe644b9f77d7cc1c555b3e40e973b135bf2c0350e5fa67bc6f379d9fc3158')
     version('3.1.0', sha256='66ca0d923e77c3f2a792ef3871e9ddbacf5fac2bfd6b8743df9c9c5814644718')
     version('3.0.0', sha256='36ae58512c478610647978811f0f4dbe105880372bd7ed39417314d50a27254e')
@@ -24,5 +25,39 @@ class OptionalLite(Package):
     version('2.0.0', sha256='e8d803cbc7be241df41a9ab267b525b7941df09747cd5a7deb55f863bd8a4e8d')
     version('1.0.3', sha256='7a2fb0fe20d61d091f6730237add9bab58bc0df1288cb96f3e8a61b859539067')
 
+    def cmake_args(self):
+        return [
+            "-DOPTIONAL_LITE_OPT_BUILD_TESTS=%s"
+            % ("ON" if self.run_tests else "OFF"),
+            "-DOPTIONAL_LITE_OPT_BUILD_EXAMPLES=OFF"
+        ]
+
+    # Pre-3.2.0 install was simply a copytree on the includes
+    def cmake(self, spec, prefix):
+        pass
+
+    def build(self, spec, prefix):
+        pass
+
     def install(self, spec, prefix):
         copytree('include', prefix.include)
+
+    def check(self):
+        pass
+
+    # Post-3.2.0 uses CMake
+    @when("@3.2.0:")
+    def cmake(self, spec, prefix):
+        super(OptionalLite, self).cmake(spec, prefix)
+
+    @when("@3.2.0:")
+    def build(self, spec, prefix):
+        super(OptionalLite, self).build(spec, prefix)
+
+    @when("@3.2.0:")
+    def install(self, spec, prefix):
+        super(OptionalLite, self).install(spec, prefix)
+
+    @when("@3.2.0:")
+    def check(self):
+        super(OptionalLite, self).check()

--- a/var/spack/repos/builtin/packages/optional-lite/package.py
+++ b/var/spack/repos/builtin/packages/optional-lite/package.py
@@ -33,31 +33,18 @@ class OptionalLite(CMakePackage):
         ]
 
     # Pre-3.2.0 install was simply a copytree on the includes
+    @when("@:3.1")
     def cmake(self, spec, prefix):
         pass
 
+    @when("@:3.1")
     def build(self, spec, prefix):
         pass
 
+    @when("@:3.1")
     def install(self, spec, prefix):
         copytree('include', prefix.include)
 
+    @when("@:3.1")
     def check(self):
         pass
-
-    # Post-3.2.0 uses CMake
-    @when("@3.2.0:")
-    def cmake(self, spec, prefix):
-        super(OptionalLite, self).cmake(spec, prefix)
-
-    @when("@3.2.0:")
-    def build(self, spec, prefix):
-        super(OptionalLite, self).build(spec, prefix)
-
-    @when("@3.2.0:")
-    def install(self, spec, prefix):
-        super(OptionalLite, self).install(spec, prefix)
-
-    @when("@3.2.0:")
-    def check(self):
-        super(OptionalLite, self).check()

--- a/var/spack/repos/builtin/packages/span-lite/package.py
+++ b/var/spack/repos/builtin/packages/span-lite/package.py
@@ -7,7 +7,7 @@ from spack import *
 from shutil import copytree
 
 
-class SpanLite(Package):
+class SpanLite(CMakePackage):
     """
     A single-file header-only version of a C++20-like span for C++98, C++11 and
     later
@@ -16,10 +16,46 @@ class SpanLite(Package):
     homepage = "https://github.com/martinmoene/span-lite"
     url      = "https://github.com/martinmoene/span-lite/archive/v0.3.0.tar.gz"
 
+    version('0.5.0', sha256='405ae095bca3c63da28c72a3528369b9ba3996f1992f3ae90fcb01a9d8bdef38')
     version('0.4.0', sha256='973858839cc881f9457a874b9c39e16c3d4a798b1204258bb0ca997cd13d1a87')
     version('0.3.0', sha256='e083f368167fe632f866956edaa2c7a7d57a33ffb0d8def9b9f1a9daa47834bb')
     version('0.2.0', sha256='6e3305fe868442410a00962a39fc59ed494cecc4f99fe2aff187e33932f06e46')
     version('0.1.0', sha256='0a84b9369f86beba326e2160b683fd0922f416ce136437751a9ed70afcc67a1c')
 
+    def cmake_args(self):
+        return [
+            "-DSPAN_LITE_EXPORT_PACKAGE=ON",
+            "-DSPAN_LITE_OPT_BUILD_TESTS=%s"
+            % ("ON" if self.run_tests else "OFF"),
+            "-DSPAN_LITE_OPT_BUILD_EXAMPLES=OFF"
+        ]
+
+    # Pre-0.5.0 install was simply a copytree on the includes
+    def cmake(self, spec, prefix):
+        pass
+
+    def build(self, spec, prefix):
+        pass
+
     def install(self, spec, prefix):
         copytree('include', prefix.include)
+
+    def check(self):
+        pass
+
+    # Post-0.5.0 uses CMake
+    @when("@0.5.0:")
+    def cmake(self, spec, prefix):
+        super(SpanLite, self).cmake(spec, prefix)
+
+    @when("@0.5.0:")
+    def build(self, spec, prefix):
+        super(SpanLite, self).build(spec, prefix)
+
+    @when("@0.5.0:")
+    def install(self, spec, prefix):
+        super(SpanLite, self).install(spec, prefix)
+
+    @when("@0.5.0:")
+    def check(self):
+        super(SpanLite, self).check()

--- a/var/spack/repos/builtin/packages/span-lite/package.py
+++ b/var/spack/repos/builtin/packages/span-lite/package.py
@@ -31,31 +31,18 @@ class SpanLite(CMakePackage):
         ]
 
     # Pre-0.5.0 install was simply a copytree on the includes
+    @when("@:0.4")
     def cmake(self, spec, prefix):
         pass
 
+    @when("@:0.4")
     def build(self, spec, prefix):
         pass
 
+    @when("@:0.4")
     def install(self, spec, prefix):
         copytree('include', prefix.include)
 
+    @when("@:0.4")
     def check(self):
         pass
-
-    # Post-0.5.0 uses CMake
-    @when("@0.5.0:")
-    def cmake(self, spec, prefix):
-        super(SpanLite, self).cmake(spec, prefix)
-
-    @when("@0.5.0:")
-    def build(self, spec, prefix):
-        super(SpanLite, self).build(spec, prefix)
-
-    @when("@0.5.0:")
-    def install(self, spec, prefix):
-        super(SpanLite, self).install(spec, prefix)
-
-    @when("@0.5.0:")
-    def check(self):
-        super(SpanLite, self).check()

--- a/var/spack/repos/builtin/packages/string-view-lite/package.py
+++ b/var/spack/repos/builtin/packages/string-view-lite/package.py
@@ -30,31 +30,18 @@ class StringViewLite(CMakePackage):
         ]
 
     # Pre-1.2.0 install was simply a copytree on the includes
+    @when("@:1.1")
     def cmake(self, spec, prefix):
         pass
 
+    @when("@:1.1")
     def build(self, spec, prefix):
         pass
 
+    @when("@:1.1")
     def install(self, spec, prefix):
         copytree('include', prefix.include)
 
+    @when("@:1.1")
     def check(self):
         pass
-
-    # Post-1.2.0 uses CMake
-    @when("@1.2.0:")
-    def cmake(self, spec, prefix):
-        super(StringViewLite, self).cmake(spec, prefix)
-
-    @when("@1.2.0:")
-    def build(self, spec, prefix):
-        super(StringViewLite, self).build(spec, prefix)
-
-    @when("@1.2.0:")
-    def install(self, spec, prefix):
-        super(StringViewLite, self).install(spec, prefix)
-
-    @when("@1.2.0:")
-    def check(self):
-        super(StringViewLite, self).check()

--- a/var/spack/repos/builtin/packages/string-view-lite/package.py
+++ b/var/spack/repos/builtin/packages/string-view-lite/package.py
@@ -7,7 +7,7 @@ from spack import *
 from shutil import copytree
 
 
-class StringViewLite(Package):
+class StringViewLite(CMakePackage):
     """
     A single-file header-only version of a C++17-like string_view for C++98,
     C++11 and later
@@ -16,10 +16,45 @@ class StringViewLite(Package):
     homepage = "https://github.com/martinmoene/string-view-lite"
     url      = "https://github.com/martinmoene/string-view-lite/archive/v1.0.0.tar.gz"
 
+    version('1.2.0', sha256='de5c8be782831bac7e7f9656b7fa185b015ae39fac8123195aeba7cbde019da4')
     version('1.1.0', sha256='88fb33ad7a345a25aca4ddf3244afd81b8d54787e5fb316a7ed60f702bc646cd')
     version('1.0.0', sha256='44e30dedd6f4777e646da26528f9d2d5cc96fd0fa79e2e5c0adc14817d048d63')
     version('0.2.0', sha256='c8ae699dfd2ccd15c5835e9b1d246834135bbb91b82f7fc4211b8ac366bffd34')
     version('0.1.0', sha256='7de87d6595230a6085655dab6145340bc423f2cf206263ef73c9b78f7b153340')
 
+    def cmake_args(self):
+        return [
+            "-DSTRINGVIEW_LITE_OPT_BUILD_TESTS=%s"
+            % ("ON" if self.run_tests else "OFF"),
+            "-DSTRINGVIEW_LITE_OPT_BUILD_EXAMPLES=OFF"
+        ]
+
+    # Pre-1.2.0 install was simply a copytree on the includes
+    def cmake(self, spec, prefix):
+        pass
+
+    def build(self, spec, prefix):
+        pass
+
     def install(self, spec, prefix):
         copytree('include', prefix.include)
+
+    def check(self):
+        pass
+
+    # Post-1.2.0 uses CMake
+    @when("@1.2.0:")
+    def cmake(self, spec, prefix):
+        super(StringViewLite, self).cmake(spec, prefix)
+
+    @when("@1.2.0:")
+    def build(self, spec, prefix):
+        super(StringViewLite, self).build(spec, prefix)
+
+    @when("@1.2.0:")
+    def install(self, spec, prefix):
+        super(StringViewLite, self).install(spec, prefix)
+
+    @when("@1.2.0:")
+    def check(self):
+        super(StringViewLite, self).check()


### PR DESCRIPTION
These packages only have CMake installs on their most recent versions.
Therefore, we overload all of the CMake stages to fallback to the old
versions (no-op for most, copytree for install), and use CMakePackage on
the new versions.