### PR TITLE
coverage: only run coverage for subset of unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ jobs:
       sudo: required
       os: linux
       language: python
-      env: TEST_SUITE=unit
+      env: [ TEST_SUITE=unit, COVERAGE=true ]
     - python: '3.4'
       sudo: required
       os: linux
@@ -54,7 +54,7 @@ jobs:
       sudo: required
       os: linux
       language: python
-      env: TEST_SUITE=unit
+      env: [ TEST_SUITE=unit, COVERAGE=true ]
       addons:
         apt:
           packages:
@@ -80,7 +80,7 @@ jobs:
       env: TEST_SUITE=doc
     - os: osx
       language: generic
-      env: [ TEST_SUITE=unit, PYTHON_VERSION=2.7 ]
+      env: [ TEST_SUITE=unit, PYTHON_VERSION=2.7, COVERAGE=true ]
 # mpich (AutotoolsPackage)
     - stage: 'build tests'
       python: '2.7'

--- a/share/spack/qa/setup.sh
+++ b/share/spack/qa/setup.sh
@@ -16,8 +16,12 @@ export SPACK_ROOT=$(realpath "$QA_DIR/../../..")
 # Source the setup script
 . "$SPACK_ROOT/share/spack/setup-env.sh"
 
+# by default coverage is off.
+coverage=""
+coverage_run=""
+
 # Set up some variables for running coverage tests.
-if [[ "$TEST_SUITE" == "unit" || "$TEST_SUITE" == "build" ]]; then
+if [[ "$COVERAGE" == "true" ]]; then
     # these set up coverage for Python
     coverage=coverage
     coverage_run="coverage run"
@@ -33,9 +37,6 @@ if [[ "$TEST_SUITE" == "unit" || "$TEST_SUITE" == "build" ]]; then
         bashcov=$(realpath ${QA_DIR}/bashcov)
         sed -i~ "s@#\!/bin/bash@#\!${bashcov}@" "$cc_script"
     fi
-else
-    coverage=""
-    coverage_run=""
 fi
 
 #


### PR DESCRIPTION
- Codecov cannot handle as many coverage reports as we are generating
- As a result, our PR coverage pages have been broken for a while, and it's hard to tell people where to enhance their testing in PR reviews.
- Scale back to only running coverage for 3.7 and 2.7
- Make coverage depend on `COVERAGE=true` being in the environment, so we can control it from `.travis.yml`
- This is *probably* better.  We run the build tests for good measure, but we do not need to evaluate them for coverage.  The coverage reports are about unit tests.