### PR TITLE
New Package: NTPoly

### DIFF
--- a/var/spack/repos/builtin/packages/ntpoly/package.py
+++ b/var/spack/repos/builtin/packages/ntpoly/package.py
@@ -18,7 +18,7 @@ class Ntpoly(CMakePackage):
     homepage = "https://william-dawson.github.io/NTPoly/"
     url      = "https://github.com/william-dawson/NTPoly/archive/ntpoly-v2.3.1-alpha.tar.gz"
 
-    version('2.3.1-alpha', sha256='c3a6f008acde27638375a17ab2aaa9d2a15eb84c1d059685795596ce4352075e')
+    version('2.3.1', sha256='af8c7690321607fbdee9671b9cb3acbed945148014e0541435858cf82bfd887e')
 
     depends_on('cmake', type='build')
     depends_on('blas', type='build')

--- a/var/spack/repos/builtin/packages/ntpoly/package.py
+++ b/var/spack/repos/builtin/packages/ntpoly/package.py
@@ -21,8 +21,8 @@ class Ntpoly(CMakePackage):
     version('2.3.1', sha256='af8c7690321607fbdee9671b9cb3acbed945148014e0541435858cf82bfd887e')
 
     depends_on('cmake', type='build')
-    depends_on('blas', type='build')
-    depends_on('mpi@3', type='build')
+    depends_on('blas', type='link')
+    depends_on('mpi@3')
 
     def cmake_args(self):
         args = ["-DNOSWIG=Yes"]

--- a/var/spack/repos/builtin/packages/ntpoly/package.py
+++ b/var/spack/repos/builtin/packages/ntpoly/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Ntpoly(CMakePackage):
+    """NTPoly - parallel library for computing matrix functions.
+
+    NTPoly is a library for computing the functions of
+    sparse, hermitian matrices based on polynomial expansions. For
+    sufficiently sparse matrices, most of the matrix functions in
+    NTPoly can be computed in linear time.
+    """
+
+    homepage = "https://william-dawson.github.io/NTPoly/"
+    url      = "https://github.com/william-dawson/NTPoly/archive/ntpoly-v2.3.1-alpha.tar.gz"
+
+    version('2.3.1-alpha', sha256='c3a6f008acde27638375a17ab2aaa9d2a15eb84c1d059685795596ce4352075e')
+
+    depends_on('cmake', type='build')
+    depends_on('blas', type='build')
+    depends_on('mpi@3', type='build')
+
+    def cmake_args(self):
+        args = ["-DNOSWIG=Yes"]
+        return args


### PR DESCRIPTION
I would like to contribute a new package for SPACK called NTPoly.

NTPoly is a massively parallel library for computing the functions of sparse, hermitian matrices based on polynomial expansions. For sufficiently sparse matrices, most of the matrix functions in NTPoly can be computed in linear time.

I would like to thank the SPACK developers for giving a tutorial a few weeks ago at RIKEN, and I hope that this PR lines up with what they taught us!