### PR TITLE
coverage: include Python 2.6 again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
       sudo: required
       os: linux
       language: python
-      env: TEST_SUITE=unit
+      env: [ TEST_SUITE=unit, COVERAGE=true ]
     - python: '2.7'
       sudo: required
       os: linux

--- a/share/spack/qa/run-unit-tests
+++ b/share/spack/qa/run-unit-tests
@@ -31,7 +31,9 @@ ${coverage_run} bin/spack -h
 ${coverage_run} bin/spack help -a
 
 # Profile and print top 20 lines for a simple call to spack spec
-${coverage_run} bin/spack -p --lines 20 spec mpileaks%gcc ^elfutils@0.170
+if [[ $TRAVIS_PYTHON_VERSION != 2.6 ]]; then
+    ${coverage_run} bin/spack -p --lines 20 spec mpileaks%gcc ^elfutils@0.170
+fi
 
 # Run unit tests with code coverage
 extra_args=""


### PR DESCRIPTION
See discussion at #11411.

Seeing just how much coverage 2.6 adds.

Also seeing whether we can get the 2.6 build working again -- it's been broken due to Travis's flaky containers for a while.