### PR TITLE
Add enable-relax-coord-bound to parallel-netcdf if version 1.8 or greater

### DIFF
--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -70,6 +70,9 @@ class ParallelNetcdf(AutotoolsPackage):
         if '~fortran' in spec:
             args.append('--disable-fortran')
 
+        if spec.satisfies('@1.8.0:'):
+            args.append('--enable-relax-coord-bound')
+
         return args
 
     def install(self, spec, prefix):


### PR DESCRIPTION
Required for new versions of netcdf to succeed during configure.

Here is the error using NetCDF 4.6.3:
```
1 error found in build log:
     289    checking for ncmpi_create in -lpnetcdf... yes
     290    checking Is libpnetcdf version 1.6.0 or later?... yes
     291    checking for full path of header file pnetcdf.h... sed: couldn't flush stdout: Broken pipe
     292    /spack/opt/spack/linux-centos7-x86_64/gcc-7.4.0/parallel-netcdf-1.8.1-hlhhe3ef
            ocvp53itqj3ebqijkmp552u3/include/pnetcdf.h
     293    checking if erange-fill is enabled in PnetCDF... yes
     294    checking if relax-coord-bound is enabled in PnetCDF... no
  >> 295    configure: error: PNetCDF must be built with relax-coord-bound
```

Here is the website that shows this option was added in 1.8.0 https://lists.mcs.anl.gov/pipermail/parallel-netcdf/2016-December/001883.html

More info here: https://github.com/Unidata/netcdf-c/issues/1010 . It seems NetCDF 4.6.3 enabled relax coords by default and required it from PNetCDF. Then PNetCDF 1.10.0 enabled it by default. Therefore enabling it by default for PNetCDF >= 1.8.0 should be the solution. Note: https://github.com/Unidata/netcdf-c/issues/1010#issuecomment-393900652