### PR TITLE
tests: require Python 2.6 tests to pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -130,8 +130,6 @@ jobs:
       env: TEST_SUITE=docker
   allow_failures:
     - env: TEST_SUITE=docker
-    # temporary Python 2.6 exception while we figure out why Travis is hanging
-    - python: '2.6'
 
 stages:
   - 'style checks'


### PR DESCRIPTION
We were allowing these to fail, but now that they pass, we'll require them again.