### PR TITLE
tests: stop testing Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,11 +35,6 @@ jobs:
       os: linux
       language: python
       env: [ TEST_SUITE=unit, COVERAGE=true ]
-    - python: '3.4'
-      sudo: required
-      os: linux
-      language: python
-      env: TEST_SUITE=unit
     - python: '3.5'
       sudo: required
       os: linux


### PR DESCRIPTION
Python 3.4 was released in 2014, and it's [end-of-life](https://www.python.org/downloads/release/python-340/).  AFAIK it is not used as the default Python on any operating systems, so I do not believe we need to support it anymore.