### PR TITLE
Openmpi default for fabrics/schedulers=auto behavior

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -189,8 +189,6 @@ class Openmpi(AutotoolsPackage):
         'fabrics',
         values=disjoint_sets(
             ('auto',), ('psm', 'psm2', 'verbs', 'mxm', 'ucx', 'libfabric')
-        ).with_default(
-            'none' if _verbs_dir() is None else 'verbs'
         ).with_non_feature_values('auto', 'none'),
         description="List of fabrics that are enabled; "
         "'auto' lets openmpi determine",

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -185,18 +185,24 @@ class Openmpi(AutotoolsPackage):
     patch('btl_vader.patch', when='@3.0.1:3.0.2')
     patch('btl_vader.patch', when='@3.1.0:3.1.2')
 
-    fabrics = ('psm', 'psm2', 'verbs', 'mxm', 'ucx', 'libfabric')
     variant(
-        'fabrics', values=auto_or_any_combination_of(*fabrics).with_default(
-            'auto' if _verbs_dir() is None else 'verbs'
-        ),
-        description="List of fabrics that are enabled",
+        'fabrics',
+        values=disjoint_sets(
+            ('auto',), ('psm', 'psm2', 'verbs', 'mxm', 'ucx', 'libfabric')
+        ).with_default(
+            'none' if _verbs_dir() is None else 'verbs'
+        ).with_non_feature_values('auto', 'none'),
+        description="List of fabrics that are enabled; "
+        "'auto' lets openmpi determine",
     )
 
-    schedulers = ('alps', 'lsf', 'tm', 'slurm', 'sge', 'loadleveler')
     variant(
-        'schedulers', values=auto_or_any_combination_of(*schedulers),
-        description='List of schedulers for which support is enabled'
+        'schedulers',
+        values=disjoint_sets(
+            ('auto',), ('alps', 'lsf', 'tm', 'slurm', 'sge', 'loadleveler')
+        ).with_non_feature_values('auto', 'none'),
+        description="List of schedulers for which support is enabled; "
+        "'auto' lets openmpi determine",
     )
 
     # Additional support options

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -264,7 +264,8 @@ class Openmpi(AutotoolsPackage):
     conflicts('schedulers=slurm ~pmi', when='@1.5.4:',
               msg='+pmi is required for openmpi(>=1.5.5) to work with SLURM.')
     conflicts('schedulers=loadleveler', when='@3.0.0:',
-              msg='The loadleveler scheduler is not supported with openmpi(>=3.0.0).')
+              msg='The loadleveler scheduler is not supported with '
+              'openmpi(>=3.0.0).')
 
     filter_compiler_wrappers('openmpi/*-wrapper-data*', relative_root='share')
     conflicts('fabrics=libfabric', when='@:1.8')  # libfabric support was added in 1.10.0

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -263,6 +263,8 @@ class Openmpi(AutotoolsPackage):
     conflicts('+pmi', when='@:1.5.4')  # PMI support was added in 1.5.5
     conflicts('schedulers=slurm ~pmi', when='@1.5.4:',
               msg='+pmi is required for openmpi(>=1.5.5) to work with SLURM.')
+    conflicts('schedulers=loadleveler', when='@3.0.0:',
+              msg='The loadleveler scheduler is not supported with openmpi(>=3.0.0).')
 
     filter_compiler_wrappers('openmpi/*-wrapper-data*', relative_root='share')
     conflicts('fabrics=libfabric', when='@:1.8')  # libfabric support was added in 1.10.0
@@ -397,9 +399,11 @@ class Openmpi(AutotoolsPackage):
             config_args.append('--enable-mpi1-compatibility')
 
         # Fabrics
-        config_args.extend(self.with_or_without('fabrics'))
+        if 'fabrics=auto' not in spec:
+            config_args.extend(self.with_or_without('fabrics'))
         # Schedulers
-        config_args.extend(self.with_or_without('schedulers'))
+        if 'schedulers=auto' not in spec:
+            config_args.extend(self.with_or_without('schedulers'))
 
         config_args.extend(self.enable_or_disable('memchecker'))
         if spec.satisfies('+memchecker', strict=True):


### PR DESCRIPTION
This PR makes 2 changes to the openmpi package.

1. Adds a conflict for scheduler=loadleveler for openmpi >=3 as that is no longer a valid configure option.

1. Makes the behavior of the value of 'auto' for fabrics and schedulers defer to the openmpi configure script.

    The default for the fabrics variant is 'auto' if verbs is not detected.
    The default for the schedulers variant is 'auto'. In both cases, if/when
    the default is 'auto' the effect is to actually set the variants to
    'none'. This is because all of the possible values in the respective
    lists pass the `--without-...` option to configure.
    
    I believe the intent was to have those variants defer to the openmpi
    configure and let it determine and use what it finds available on the
    system. This is useful given that the required installations of fabrics
    and schedulers are likely to be installed outside of spack.
