### PR TITLE
Module load should not print environment

### DIFF
--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -40,7 +40,6 @@ def module(*args):
         # Cray modules spit out warnings that we cannot supress.
         # This hack skips to the last output (the environment)
         env_output = str(module_p.communicate()[0].decode())
-        print(env_output)
         env = env_output.strip().split('\n')[-1]
 
         # Update os.environ with new dict


### PR DESCRIPTION
Removes a vestigial print statement introduced in #8570 
