### PR TITLE
CUDA package: exclude compat libs

### DIFF
--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -5,6 +5,8 @@
 
 from spack import *
 from glob import glob
+from llnl.util.filesystem import LibraryList
+import os
 
 
 class Cuda(Package):
@@ -58,3 +60,16 @@ class Cuda(Package):
             '--toolkit',        # install CUDA Toolkit
             '--toolkitpath=%s' % prefix
         )
+
+    @property
+    def libs(self):
+        libs = find_libraries(
+            'libcuda', root=self.prefix, shared=True, recursive=True
+        )
+        filtered_libs = []
+        # CUDA 10.0 provides Compatability libraries for running newer versions
+        # of CUDA with older drivers. These do not work with newer drivers.
+        for lib in libs:
+            if 'compat' not in lib.split(os.sep):
+                filtered_libs.append(lib)
+        return LibraryList(filtered_libs)

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -63,6 +63,7 @@ class Cuda(Package):
 
     @property
     def libs(self):
+        prefix = self.prefix
         search_paths = [(prefix.lib, False), (prefix.lib64, False),
                         (prefix, True)]
         for search_root, recursive in search_paths:

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -63,9 +63,14 @@ class Cuda(Package):
 
     @property
     def libs(self):
-        libs = find_libraries(
-            'libcuda', root=self.prefix, shared=True, recursive=True
-        )
+        search_paths = [(prefix.lib, False), (prefix.lib64, False),
+                        (prefix, True)]
+        for search_root, recursive in search_paths:
+            libs = find_libraries(
+                'libcuda', root=search_root, shared=True, recursive=recursive)
+            if libs:
+                break
+
         filtered_libs = []
         # CUDA 10.0 provides Compatability libraries for running newer versions
         # of CUDA with older drivers. These do not work with newer drivers.


### PR DESCRIPTION
CUDA 10.0 provides Compatability libraries for running newer versions of CUDA with older drivers. These do not work with newer drivers.