### PR TITLE
cdo: Fix build with gcc@9

### DIFF
--- a/var/spack/repos/builtin/packages/cdo/gcc9-openmp-1.9.7rc2.patch
+++ b/var/spack/repos/builtin/packages/cdo/gcc9-openmp-1.9.7rc2.patch
@@ -1,0 +1,202 @@
+Only in cdo-1.9.7rc2: .spack_patched
+diff -ru cdo-1.9.7rc2.orig/src/after_sptrans.cc cdo-1.9.7rc2/src/after_sptrans.cc
+--- cdo-1.9.7rc2.orig/src/after_sptrans.cc	2019-04-23 08:10:06.000000000 +0200
++++ cdo-1.9.7rc2/src/after_sptrans.cc	2019-05-15 08:24:25.815215686 +0200
+@@ -300,7 +300,7 @@
+ #endif
+ 
+ #ifdef _OPENMP
+-#pragma omp parallel for default(none) shared(nlat, poli, pold, pdev, pol2, pol3, coslat, gmu, gwt, PlanetRadius)
++#pragma omp parallel for default(none) shared(nlat, poli, pold, pdev, pol2, pol3, coslat, gmu, gwt, PlanetRadius) firstprivate(dimsp, waves)
+ #endif
+   for (long jgl = 0; jgl < nlat; ++jgl)
+     {
+@@ -357,7 +357,7 @@
+   for (long jgl = 0; jgl < nlat; ++jgl) coslat[jgl] = sqrt(1.0 - gmu[jgl] * gmu[jgl]);
+ 
+ #ifdef _OPENMP
+-#pragma omp parallel for default(none) shared(nlat, ntr, pnm2, work2, gwt, gmu, poli, pold)
++#pragma omp parallel for default(none) shared(nlat, ntr, pnm2, work2, gwt, gmu, poli, pold) firstprivate(waves)
+ #endif
+   for (long jgl = 0; jgl < nlat / 2; jgl++)
+     {
+diff -ru cdo-1.9.7rc2.orig/src/Detrend.cc cdo-1.9.7rc2/src/Detrend.cc
+--- cdo-1.9.7rc2.orig/src/Detrend.cc	2019-04-25 08:15:01.000000000 +0200
++++ cdo-1.9.7rc2/src/Detrend.cc	2019-05-15 08:23:37.141221282 +0200
+@@ -116,7 +116,7 @@
+       for (levelID = 0; levelID < nlevels; levelID++)
+         {
+ #ifdef _OPENMP
+-#pragma omp parallel for default(none) shared(array1, array2, vars, varID, levelID)
++#pragma omp parallel for default(none) shared(array1, array2, vars, varID, levelID) firstprivate(gridsize, nsteps, missval)
+ #endif
+           for (size_t i = 0; i < gridsize; i++)
+             {
+diff -ru cdo-1.9.7rc2.orig/src/Ensstat3.cc cdo-1.9.7rc2/src/Ensstat3.cc
+--- cdo-1.9.7rc2.orig/src/Ensstat3.cc	2019-04-29 08:29:05.000000000 +0200
++++ cdo-1.9.7rc2/src/Ensstat3.cc	2019-05-15 08:23:37.141221282 +0200
+@@ -289,7 +289,7 @@
+       for (int recID = 0; recID < nrecs0; recID++)
+         {
+ #ifdef _OPENMP
+-#pragma omp parallel for default(none) shared(ef) private(streamID, nmiss) lastprivate(varID, levelID)
++#pragma omp parallel for default(none) shared(ef) private(streamID, nmiss) lastprivate(varID, levelID) firstprivate(nfiles)
+ #endif
+           for (int fileID = 0; fileID < nfiles; fileID++)
+             {
+diff -ru cdo-1.9.7rc2.orig/src/field2.cc cdo-1.9.7rc2/src/field2.cc
+--- cdo-1.9.7rc2.orig/src/field2.cc	2019-04-23 08:52:14.000000000 +0200
++++ cdo-1.9.7rc2/src/field2.cc	2019-05-15 08:23:37.141221282 +0200
+@@ -178,7 +178,7 @@
+   else
+     {
+ #ifdef _OPENMP
+-#pragma omp parallel for default(none) shared(array1, array2, w)
++#pragma omp parallel for default(none) shared(array1, array2, w) firstprivate(len)
+ #endif
+       for (size_t i = 0; i < len; i++) array1[i] += w * array2[i];
+     }
+@@ -188,7 +188,7 @@
+  * Compute the occurrence of values in field, if they do not equal refval.
+  * This can be used to compute the lengths of multiple periods in a timeseries.
+  * Missing field values are handled like refval, i.e. they stop a running period.
+- * If there is missing data in the occurence field, missing fields values do not 
++ * If there is missing data in the occurence field, missing fields values do not
+  * change anything (they do not start a non-period by setting occurrence to zero).
+  */
+ void
+diff -ru cdo-1.9.7rc2.orig/src/Fillmiss.cc cdo-1.9.7rc2/src/Fillmiss.cc
+--- cdo-1.9.7rc2.orig/src/Fillmiss.cc	2019-04-23 09:36:07.000000000 +0200
++++ cdo-1.9.7rc2/src/Fillmiss.cc	2019-05-15 08:23:37.141221282 +0200
+@@ -469,7 +469,7 @@
+ 
+ #ifdef _OPENMP
+ #pragma omp parallel for default(none) \
+-    shared(knnWeights, findex, mindex, vindex, array1, array2, xvals, yvals, gps, numNeighbors)
++    shared(knnWeights, findex, mindex, vindex, array1, array2, xvals, yvals, gps, numNeighbors) firstprivate(nmiss)
+ #endif
+   for (size_t i = 0; i < nmiss; ++i)
+     {
+diff -ru cdo-1.9.7rc2.orig/src/grid_area.cc cdo-1.9.7rc2/src/grid_area.cc
+--- cdo-1.9.7rc2.orig/src/grid_area.cc	2019-05-09 14:03:25.000000000 +0200
++++ cdo-1.9.7rc2/src/grid_area.cc	2019-05-15 08:23:37.141221282 +0200
+@@ -365,7 +365,7 @@
+   Progress::init();
+ 
+ #ifdef _OPENMP
+-#pragma omp parallel for default(none) shared(nlon, findex, area, nv, grid_corner_lon, grid_corner_lat)
++#pragma omp parallel for default(none) shared(nlon, findex, area, nv, grid_corner_lon, grid_corner_lat) firstprivate(gridsize)
+ #endif
+   for (size_t i = 0; i < gridsize; ++i)
+     {
+@@ -501,7 +501,7 @@
+ 
+ #ifdef _OPENMP
+ #pragma omp parallel for default(none) \
+-    shared(findex, area, grid_corner_lon, grid_corner_lat, grid_center_lon, grid_center_lat)
++    shared(findex, area, grid_corner_lon, grid_corner_lat, grid_center_lon, grid_center_lat) firstprivate(gridsize, nv)
+ #endif
+   for (size_t i = 0; i < gridsize; ++i)
+     {
+diff -ru cdo-1.9.7rc2.orig/src/Intlevel.cc cdo-1.9.7rc2/src/Intlevel.cc
+--- cdo-1.9.7rc2.orig/src/Intlevel.cc	2019-03-07 08:32:03.000000000 +0100
++++ cdo-1.9.7rc2/src/Intlevel.cc	2019-05-15 08:23:37.141221282 +0200
+@@ -74,7 +74,7 @@
+       const double *var1L2 = vardata1 + gridsize * idx2;
+ 
+ #ifdef _OPENMP
+-#pragma omp parallel for default(none) shared(gridsize, var2, var1L1, var1L2, missval)
++#pragma omp parallel for default(none) shared(gridsize, var2, var1L1, var1L2, missval) firstprivate(wgt1, wgt2)
+ #endif
+       for (size_t i = 0; i < gridsize; ++i)
+         {
+@@ -96,7 +96,7 @@
+       double *var2 = vardata2 + offset;
+ 
+ #ifdef _OPENMP
+-#pragma omp parallel for default(none) shared(gridsize, vardata1, var2, lev_idx1, lev_idx2, lev_wgt1, lev_wgt2, missval)
++#pragma omp parallel for default(none) shared(gridsize, vardata1, var2, lev_idx1, lev_idx2, lev_wgt1, lev_wgt2, missval) firstprivate(offset)
+ #endif
+       for (size_t i = 0; i < gridsize; i++)
+         {
+diff -ru cdo-1.9.7rc2.orig/src/Runstat.cc cdo-1.9.7rc2/src/Runstat.cc
+--- cdo-1.9.7rc2.orig/src/Runstat.cc	2019-04-04 08:17:54.000000000 +0200
++++ cdo-1.9.7rc2/src/Runstat.cc	2019-05-15 08:23:37.141221282 +0200
+@@ -164,7 +164,7 @@
+               for (size_t i = 0; i < fieldsize; i++) samp1[tsID][varID][levelID].vec[i] = (double) imask[i];
+ 
+ #ifdef _OPENMP
+-#pragma omp parallel for default(none) shared(tsID, imask, samp1, varID, levelID)
++#pragma omp parallel for default(none) shared(tsID, imask, samp1, varID, levelID) firstprivate(fieldsize)
+ #endif
+               for (int inp = 0; inp < tsID; inp++)
+                 {
+@@ -200,7 +200,7 @@
+           else
+             {
+ #ifdef _OPENMP
+-#pragma omp parallel for default(none) shared(tsID, vars1, varID, levelID, rvars1)
++#pragma omp parallel for default(none) shared(tsID, vars1, varID, levelID, rvars1) firstprivate(operfunc)
+ #endif
+               for (int inp = 0; inp < tsID; inp++)
+                 {
+@@ -314,7 +314,7 @@
+               for (size_t i = 0; i < fieldsize; i++) samp1[ndates - 1][varID][levelID].vec[i] = (double) imask[i];
+ 
+ #ifdef _OPENMP
+-#pragma omp parallel for default(none) shared(imask, samp1, varID, levelID)
++#pragma omp parallel for default(none) shared(imask, samp1, varID, levelID) firstprivate(ndates, fieldsize)
+ #endif
+               for (int inp = 0; inp < ndates - 1; inp++)
+                 {
+@@ -328,7 +328,7 @@
+             {
+               vfarmoq(vars2[ndates - 1][varID][levelID], vars1[ndates - 1][varID][levelID]);
+ #ifdef _OPENMP
+-#pragma omp parallel for default(none) shared(vars1, vars2, varID, levelID, rvars1)
++#pragma omp parallel for default(none) shared(vars1, vars2, varID, levelID, rvars1) firstprivate(ndates)
+ #endif
+               for (int inp = 0; inp < ndates - 1; inp++)
+                 {
+@@ -339,7 +339,7 @@
+           else if (lrange)
+             {
+ #ifdef _OPENMP
+-#pragma omp parallel for default(none) shared(vars1, vars2, varID, levelID, rvars1)
++#pragma omp parallel for default(none) shared(vars1, vars2, varID, levelID, rvars1) firstprivate(ndates)
+ #endif
+               for (int inp = 0; inp < ndates - 1; inp++)
+                 {
+@@ -350,7 +350,7 @@
+           else
+             {
+ #ifdef _OPENMP
+-#pragma omp parallel for default(none) shared(vars1, varID, levelID, rvars1)
++#pragma omp parallel for default(none) shared(vars1, varID, levelID, rvars1) firstprivate(ndates, operfunc)
+ #endif
+               for (int inp = 0; inp < ndates - 1; inp++)
+                 {
+diff -ru cdo-1.9.7rc2.orig/src/Timsort.cc cdo-1.9.7rc2/src/Timsort.cc
+--- cdo-1.9.7rc2.orig/src/Timsort.cc	2019-03-18 08:17:00.000000000 +0100
++++ cdo-1.9.7rc2/src/Timsort.cc	2019-05-15 08:23:37.141221282 +0200
+@@ -109,7 +109,7 @@
+       for (levelID = 0; levelID < nlevels; levelID++)
+         {
+ #ifdef _OPENMP
+-#pragma omp parallel for default(none) shared(sarray, vars, varID, levelID)
++#pragma omp parallel for default(none) shared(sarray, vars, varID, levelID) firstprivate(gridsize, nts)
+ #endif
+           for (size_t i = 0; i < gridsize; i++)
+             {
+diff -ru cdo-1.9.7rc2.orig/src/Tstepcount.cc cdo-1.9.7rc2/src/Tstepcount.cc
+--- cdo-1.9.7rc2.orig/src/Tstepcount.cc	2019-04-23 09:44:13.000000000 +0200
++++ cdo-1.9.7rc2/src/Tstepcount.cc	2019-05-15 08:23:37.141221282 +0200
+@@ -120,7 +120,7 @@
+       for (levelID = 0; levelID < nlevels; levelID++)
+         {
+ #ifdef _OPENMP
+-#pragma omp parallel for default(none) shared(mem, vars, varID, levelID) schedule(dynamic, 1)
++#pragma omp parallel for default(none) shared(mem, vars, varID, levelID) schedule(dynamic, 1) firstprivate(gridsize, nts, refval, missval)
+ #endif
+           for (size_t i = 0; i < gridsize; i++)
+             {

--- a/var/spack/repos/builtin/packages/cdo/package.py
+++ b/var/spack/repos/builtin/packages/cdo/package.py
@@ -17,6 +17,7 @@ class Cdo(AutotoolsPackage):
 
     maintainers = ['skosukhin']
 
+    version('1.9.7rc2', '62313bdf60860693e96494fd2fd8ff48e65266f600f6ae8c817e46a652e6b215', url='https://code.mpimet.mpg.de/attachments/download/19883/cdo-1.9.7rc2.tar.gz')
     version('1.9.6', '322f56c5e13f525c585ee5318d4435db', url='https://code.mpimet.mpg.de/attachments/download/19299/cdo-1.9.6.tar.gz')
     version('1.9.5', '0c60f2c94dc5c76421ecf363153a5043', url='https://code.mpimet.mpg.de/attachments/download/18264/cdo-1.9.5.tar.gz')
     version('1.9.4', '377c9e5aa7d8cbcb4a6c558abb2eb053', url='https://code.mpimet.mpg.de/attachments/download/17374/cdo-1.9.4.tar.gz')
@@ -26,6 +27,11 @@ class Cdo(AutotoolsPackage):
     version('1.9.0', '2d88561b3b4a880df0422a62e5027e40', url='https://code.mpimet.mpg.de/attachments/download/15187/cdo-1.9.0.tar.gz')
     version('1.8.2', '6a2e2f99b7c67ee9a512c40a8d4a7121', url='https://code.mpimet.mpg.de/attachments/download/14686/cdo-1.8.2.tar.gz')
     version('1.7.2', 'f08e4ce8739a4f2b63fc81a24db3ee31', url='https://code.mpimet.mpg.de/attachments/download/12760/cdo-1.7.2.tar.gz')
+
+    # The build fails due to changes to OpenMP data sharing in GCC 9.
+    # See: https://gcc.gnu.org/gcc-9/porting_to.html#ompdatasharing
+    # See: https://code.mpimet.mpg.de/issues/9038 (not public)
+    patch('gcc9-openmp-1.9.7rc2.patch', when='@1.9.7rc2%gcc@9:')
 
     variant('netcdf', default=True, description='Enable NetCDF support')
     variant('grib2', default='eccodes', values=('eccodes', 'grib-api', 'none'),
@@ -46,6 +52,8 @@ class Cdo(AutotoolsPackage):
     variant('magics', default=False,
             description='Enable Magics library support')
     variant('openmp', default=True, description='Enable OpenMP support')
+
+    depends_on('pkgconfig', type='build')
 
     depends_on('netcdf', when='+netcdf')
     # In this case CDO does not depend on hdf5 directly but we need the backend
@@ -71,6 +79,8 @@ class Cdo(AutotoolsPackage):
               msg='Eccodes is supported starting version 1.9.0')
     conflicts('+szip', when='+external-grib1 grib2=none',
               msg='The configuration does not support GRIB1')
+    conflicts('%gcc@9:', when='@:1.9.6',
+              msg='GCC 9 changed OpenMP data sharing behavior')
 
     def configure_args(self):
         config_args = self.with_or_without('netcdf', activation_value='prefix')


### PR DESCRIPTION
This makes several changes to make cdo work with cdo@9:
- Add version 1.9.7rc2
- Add a patch to make version 1.9.7rc2 build with gcc@9:
- Add a conflict for earlier versions

It also adds a pkgconfig build dependency as configure checks for it.