### PR TITLE
kitty: Fix pkgconfig dependency

### DIFF
--- a/var/spack/repos/builtin/packages/kitty/package.py
+++ b/var/spack/repos/builtin/packages/kitty/package.py
@@ -33,7 +33,7 @@ class Kitty(PythonPackage):
     depends_on('zlib')
     depends_on('libpng')
     depends_on('gl', type=('build', 'link', 'run'))
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('py-setuptools', type='build')
     depends_on('py-sphinx', type='build')
     depends_on('freetype', when=sys.platform != 'darwin')


### PR DESCRIPTION
pkgconfig is the correct virtual dependency while pkg-config is a specific implementation.