### PR TITLE
svn: use `svn info --xml` instead of `svn info` to get revisions

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -26,6 +26,7 @@ import sys
 import re
 import shutil
 import copy
+import xml.etree.ElementTree
 from functools import wraps
 from six import string_types, with_metaclass
 
@@ -771,13 +772,9 @@ class SvnFetchStrategy(VCSFetchStrategy):
         return self.revision
 
     def get_source_id(self):
-        output = self.svn('info', self.url, output=str)
-        if not output:
-            return None
-        lines = output.split('\n')
-        for line in lines:
-            if line.startswith('Revision:'):
-                return line.split()[-1]
+        output = self.svn('info', '--xml', self.url, output=str)
+        info = xml.etree.ElementTree.fromstring(output)
+        return info.find('entry/commit').get('revision')
 
     @_needs_stage
     def fetch(self):

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -9,7 +9,7 @@ import inspect
 import os
 import os.path
 import shutil
-import re
+import xml.etree.ElementTree
 
 import ordereddict_backport
 import py
@@ -725,12 +725,9 @@ def mock_svn_repository(tmpdir_factory):
     }
 
     def get_rev():
-        output = svn('info', output=str)
-        assert "Revision" in output
-        for line in output.split('\n'):
-            match = re.match(r'Revision: (\d+)', line)
-            if match:
-                return match.group(1)
+        output = svn('info', '--xml', output=str)
+        info = xml.etree.ElementTree.fromstring(output)
+        return info.find('entry/commit').get('revision')
 
     t = Bunch(checks=checks, url=url, hash=get_rev, path=str(repodir))
     yield t


### PR DESCRIPTION
- `svn info` prints different results depending on the system locale
- In particular, Japanese output doesn't contain "Revision:" -- it contains「レビジョン：」
- Change Spack code to use XML output instead of using the human-readable output