### PR TITLE
flake8: exceptions for pedantic camelcase rules from pep8-naming

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -24,7 +24,9 @@
 #
 # N8: PEP8-naming
 # - N801: class names should use CapWords convention
+# - N813: camelcase imported as lowercase
+# - N814: camelcase imported as constant
 #
 [flake8]
-ignore = E129,E221,E241,E272,E731,W503,W504,F999,N801
+ignore = E129,E221,E241,E272,E731,W503,W504,F999,N801,N813,N814
 max-line-length = 79

--- a/.flake8_packages
+++ b/.flake8_packages
@@ -20,5 +20,5 @@
 # - F821: undefined name `name`
 #
 [flake8]
-ignore = E129,E221,E241,E272,E731,W503,W504,F405,F821,F999
+ignore = E129,E221,E241,E272,E731,W503,W504,F405,F821,F999,N801,N813,N814
 max-line-length = 79


### PR DESCRIPTION
…naming

Rules N813 and N814 prevented import statements like this:

  xml.etree.ElementTree as et
  xml.etree.ElementTree as ET

But both of those seem pretty reasonable.  We see no reason to require
any camelcase import to be imported "as" a camelcase word.