### PR TITLE
r-popvar: new package at 1.2.1

### DIFF
--- a/var/spack/repos/builtin/packages/r-popvar/package.py
+++ b/var/spack/repos/builtin/packages/r-popvar/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class RPopvar(RPackage):
+    """PopVar: Genomic Breeding Tools: Genetic Variance Prediction andCross-
+       Validation"""
+
+    homepage = "https://cran.r-project.org/package=PopVar"
+    url      = "https://cran.r-project.org/src/contrib/PopVar_1.2.1.tar.gz"
+    list_url = "https://cran.r-project.org/src/contrib/Archive/PopVar"
+
+    version('1.2.1', sha256='5e3df79634ab63708a431e4b8e6794675972ac6c58d2bc615726aa0f142f5f25')
+
+    depends_on('r@3.1.1:', type=('build', 'run'))
+    depends_on('r-bglr', type=('build', 'run'))
+    depends_on('r-qtl', type=('build', 'run'))
+    depends_on('r-rrblup', type=('build', 'run'))


### PR DESCRIPTION
depends on `r-bglr` in #11489, `r-rrblup` in #11488, `r-qtl` in #11487