### PR TITLE
Make flake8 check python files without .py extension

### DIFF
--- a/lib/spack/spack/cmd/flake8.py
+++ b/lib/spack/spack/cmd/flake8.py
@@ -127,7 +127,7 @@ def changed_files(args):
 
         for f in files:
             # Ignore non-Python files
-            if not (f.endswith('.py') or f.endswith('spack')):
+            if not (f.endswith('.py') or f == 'bin/spack'):
                 continue
 
             # Ignore files in the exclude locations

--- a/lib/spack/spack/cmd/flake8.py
+++ b/lib/spack/spack/cmd/flake8.py
@@ -127,7 +127,7 @@ def changed_files(args):
 
         for f in files:
             # Ignore non-Python files
-            if not f.endswith('.py'):
+            if not (f.endswith('.py') or f.endswith('spack')):
                 continue
 
             # Ignore files in the exclude locations


### PR DESCRIPTION
I recently made a change to the `spack` executable, but `spack flake8` did not detect the change. This PR fixes that.

Are there any other Python files in Spack that don't end in `.py`? We could check for `python` in the shebang, but that's probably more costly than it needs to be. For what it's worth, `flake8` also only looks at `*.py` files [by default](https://github.com/PyCQA/flake8/blob/master/src/flake8/main/options.py#L88,L96). We could also use the `file` command on UNIX:
```console
$ file spack
spack: Python script text executable, ASCII text
$ file spack-python 
spack-python: POSIX shell script text executable, ASCII text
```