### PR TITLE
Check "if version is not None", not "if version"

### DIFF
--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -268,6 +268,7 @@ def test_version_ranges():
     with pytest.raises(ValueError):
         VersionRange(2, 0)
 
+
 def test_contains():
     assert_in('1.3', '1.2:1.4')
     assert_in('1.2.5', '1.2:1.4')

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -9,7 +9,7 @@ where it makes sense.
 """
 import pytest
 
-from spack.version import Version, ver
+from spack.version import Version, VersionRange, ver
 
 
 def assert_ver_lt(a, b):
@@ -258,6 +258,15 @@ def test_version_ranges():
     assert_ver_lt('1.2:1.4', '1.5:1.6')
     assert_ver_gt('1.5:1.6', '1.2:1.4')
 
+    assert str(VersionRange(None, None)) == ':'
+    assert str(VersionRange(0, None)) == '0:'
+    assert str(VersionRange(None, 0)) == ':0'
+    assert str(VersionRange(0, 0)) == '0:0'
+
+    with pytest.raises(ValueError):
+        VersionRange(2, 1)
+    with pytest.raises(ValueError):
+        VersionRange(2, 0)
 
 def test_contains():
     assert_in('1.3', '1.2:1.4')

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -218,7 +218,6 @@ class Version(object):
         gcc@4.7 so that when a user asks to build with gcc@4.7, we can find
         a suitable compiler.
         """
-
         nself = len(self.version)
         nother = len(other.version)
         return nother <= nself and self.version[:nother] == other.version
@@ -384,7 +383,7 @@ class VersionRange(object):
 
         self.start = start
         self.end = end
-        if start and end and end < start:
+        if start is not None and end is not None and end < start:
             raise ValueError("Invalid Version range: %s" % self)
 
     def lowest(self):
@@ -486,7 +485,8 @@ class VersionRange(object):
         return (self.overlaps(other) or
                 # if either self.start or other.end are None, then this can't
                 # satisfy, or overlaps() would've taken care of it.
-                self.start and other.end and self.start.satisfies(other.end))
+                self.start is not None and other.end is not None and
+                self.start.satisfies(other.end))
 
     @coerced
     def overlaps(self, other):
@@ -568,10 +568,10 @@ class VersionRange(object):
 
     def __str__(self):
         out = ""
-        if self.start:
+        if self.start is not None:
             out += str(self.start)
         out += ":"
-        if self.end:
+        if self.end is not None:
             out += str(self.end)
         return out
 


### PR DESCRIPTION
I discovered several places in `version.py` where we were checking to see if a version evaluated as True when we really meant to check if a version is not None.

For example, `VersionRange(2, 1)` raised an "Invalid version range" ValueError, but `VersionRange(2, 0)` did not. Also, during string conversion, `VersionRange(0, 0)` and `VersionRange(None, None)` were equivalent.

From PEP-8:

> Comparisons to singletons like None should always be done with is or is not, never the equality operators.
> 
> Also, beware of writing if x when you really mean if x is not None -- e.g. when testing whether a variable or argument that defaults to None was set to some other value. The other value might have a type (such as a container) that could be false in a boolean context!