### PR TITLE
[WIP] Add macOS Terminal mark to tty prompts

### DIFF
--- a/lib/spack/llnl/util/tty/__init__.py
+++ b/lib/spack/llnl/util/tty/__init__.py
@@ -26,7 +26,7 @@ _msg_enabled = True
 _warn_enabled = True
 _error_enabled = True
 indent = "  "
-_osascript = os.path.exists('/usr/bin/osascript')
+_osascript = subprocess.call(['which', 'osascript']) == 0
 
 
 def is_verbose():

--- a/lib/spack/llnl/util/tty/__init__.py
+++ b/lib/spack/llnl/util/tty/__init__.py
@@ -26,6 +26,7 @@ _msg_enabled = True
 _warn_enabled = True
 _error_enabled = True
 indent = "  "
+_osascript = os.path.exists('/usr/bin/osascript')
 
 
 def is_verbose():
@@ -143,9 +144,10 @@ def msg(message, *args, **kwargs):
     if not msg_enabled():
         return
 
-    subprocess.call(['osascript', '-e', 'if app "Terminal" is frontmost then '
-                     'tell app "System Events" to keystroke "u" using command '
-                     'down'])
+    if _osascript:
+        subprocess.call(['osascript', '-e', 'if app "Terminal" is frontmost '
+                         'then tell app "System Events" to keystroke "u" '
+                         'using command down'])
 
     newline = kwargs.get('newline', True)
     st_text = ""
@@ -162,9 +164,10 @@ def msg(message, *args, **kwargs):
 
 
 def info(message, *args, **kwargs):
-    subprocess.call(['osascript', '-e', 'if app "Terminal" is frontmost then '
-                     'tell app "System Events" to keystroke "u" using command '
-                     'down'])
+    if _osascript:
+        subprocess.call(['osascript', '-e', 'if app "Terminal" is frontmost '
+                         'then tell app "System Events" to keystroke "u" '
+                         'using command down'])
 
     format = kwargs.get('format', '*b')
     stream = kwargs.get('stream', sys.stdout)

--- a/lib/spack/llnl/util/tty/__init__.py
+++ b/lib/spack/llnl/util/tty/__init__.py
@@ -7,10 +7,12 @@ from datetime import datetime
 import fcntl
 import os
 import struct
+import subprocess
 import sys
 import termios
 import textwrap
 import traceback
+
 from six import StringIO
 from six.moves import input
 
@@ -141,6 +143,10 @@ def msg(message, *args, **kwargs):
     if not msg_enabled():
         return
 
+    subprocess.call(['osascript', '-e', 'if app "Terminal" is frontmost then '
+                     'tell app "System Events" to keystroke "u" using command '
+                     'down'])
+
     newline = kwargs.get('newline', True)
     st_text = ""
     if _stacktrace:
@@ -156,6 +162,10 @@ def msg(message, *args, **kwargs):
 
 
 def info(message, *args, **kwargs):
+    subprocess.call(['osascript', '-e', 'if app "Terminal" is frontmost then '
+                     'tell app "System Events" to keystroke "u" using command '
+                     'down'])
+
     format = kwargs.get('format', '*b')
     stream = kwargs.get('stream', sys.stdout)
     wrap = kwargs.get('wrap', False)


### PR DESCRIPTION
Have you ever stared at the verbose output of a Spack build and lost track of where you were in the build process? Have you ever wished you could simply jump to the next stage in your terminal and see how the tests are progressing? With this PR, the future is now!

Simply use the macOS Terminal mark feature to jump between prompts using Cmd+Up/Down. See below .gif for a demonstration.

![mark](https://user-images.githubusercontent.com/12021217/57988005-7fb33700-7a4e-11e9-8516-49ce9575f657.gif)

This works by calling the `osascript` command on macOS to insert a mark. Credits to [Armin Briegel](https://scriptingosx.com/2017/03/terminal-the-marks-the-spot/) for figuring out how to do this.