### PR TITLE
dealii: fix symengine constraints

### DIFF
--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -152,8 +152,8 @@ class Dealii(CMakePackage, CudaPackage):
     # This leads to conflicts between macros defined in the included
     # headers when they are not compiled in the same mode.
     # See https://github.com/symengine/symengine/issues/1516
-    depends_on("symengine@0.4:", when="@9.1:+symengine+trilinos^trilinos~debug")
-    depends_on("symengine@0.4:", when="@9.1:+symengine+trilinos^trilinos+debug")
+    depends_on("symengine@0.4: build_type=Release", when="@9.1:+symengine+trilinos^trilinos~debug")
+    depends_on("symengine@0.4: build_type=Debug", when="@9.1:+symengine+trilinos^trilinos+debug")
     depends_on('symengine@0.4:', when='@9.1:+symengine~trilinos')
     # do not require +rol to make concretization of xsdk possible
     depends_on('trilinos+amesos+aztec+epetra+ifpack+ml+muelu+sacado+teuchos',       when='+trilinos+mpi~int64~cuda')

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -152,9 +152,11 @@ class Dealii(CMakePackage, CudaPackage):
     # This leads to conflicts between macros defined in the included
     # headers when they are not compiled in the same mode.
     # See https://github.com/symengine/symengine/issues/1516
-    depends_on("symengine@0.4: build_type=Release", when="@9.1:+symengine+trilinos^trilinos~debug")
-    depends_on("symengine@0.4: build_type=Debug", when="@9.1:+symengine+trilinos^trilinos+debug")
-    depends_on('symengine@0.4:', when='@9.1:+symengine~trilinos')
+    # FIXME: uncomment when the following is fixed
+    # https://github.com/spack/spack/issues/11160
+    # depends_on("symengine@0.4: build_type=Release", when="@9.1:+symengine+trilinos^trilinos~debug")  # NOQA: ignore=E501
+    # depends_on("symengine@0.4: build_type=Debug", when="@9.1:+symengine+trilinos^trilinos+debug")  # NOQA: ignore=E501
+    depends_on('symengine@0.4:', when='@9.1:+symengine')
     # do not require +rol to make concretization of xsdk possible
     depends_on('trilinos+amesos+aztec+epetra+ifpack+ml+muelu+sacado+teuchos',       when='+trilinos+mpi~int64~cuda')
     depends_on('trilinos+amesos+aztec+epetra+ifpack+ml+muelu+sacado+teuchos~hypre', when='+trilinos+mpi+int64~cuda')

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -148,7 +148,13 @@ class Dealii(CMakePackage, CudaPackage):
     depends_on('slepc@:3.6.3',     when='@:8.4.1+slepc+petsc+mpi')
     depends_on('slepc~arpack',     when='+slepc+petsc+mpi+int64')
     depends_on('sundials@:3~pthread', when='@9.0:+sundials')
-    depends_on('symengine@0.4:', when='@9.1:+symengine')
+    # Both Trilinos and SymEngine bundle the Teuchos RCP library.
+    # This leads to conflicts between macros defined in the included
+    # headers when they are not compiled in the same mode.
+    # See https://github.com/symengine/symengine/issues/1516
+    depends_on("symengine@0.4:", when="@9.1:+symengine+trilinos^trilinos~debug")
+    depends_on("symengine@0.4:", when="@9.1:+symengine+trilinos^trilinos+debug")
+    depends_on('symengine@0.4:', when='@9.1:+symengine~trilinos')
     # do not require +rol to make concretization of xsdk possible
     depends_on('trilinos+amesos+aztec+epetra+ifpack+ml+muelu+sacado+teuchos',       when='+trilinos+mpi~int64~cuda')
     depends_on('trilinos+amesos+aztec+epetra+ifpack+ml+muelu+sacado+teuchos~hypre', when='+trilinos+mpi+int64~cuda')
@@ -156,13 +162,6 @@ class Dealii(CMakePackage, CudaPackage):
     # namespace "Kokkos::Impl" has no member "cuda_abort"
     depends_on('trilinos@master+amesos+aztec+epetra+ifpack+ml+muelu+rol+sacado+teuchos~amesos2~ifpack2~intrepid2~kokkos~tpetra~zoltan2',       when='+trilinos+mpi~int64+cuda')
     depends_on('trilinos@master+amesos+aztec+epetra+ifpack+ml+muelu+rol+sacado+teuchos~hypre~amesos2~ifpack2~intrepid2~kokkos~tpetra~zoltan2', when='+trilinos+mpi+int64+cuda')
-
-    # Both Trilinos and SymEngine bundle the Teuchos RCP library.
-    # This leads to conflicts between macros defined in the included
-    # headers when they are not compiled in the same mode.
-    # See https://github.com/symengine/symengine/issues/1516
-    depends_on("symengine build_type=Release", when="^symengine ^trilinos~debug")
-    depends_on("symengine build_type=Debug",   when="^symengine ^trilinos+debug")
 
     # Explicitly provide a destructor in BlockVector,
     # otherwise deal.II may fail to build with Intel compilers.


### PR DESCRIPTION
unfortunately https://github.com/spack/spack/pull/11499 is not working as expected (at least for me).

```
$ spack spec -I dealii@develop+symengine
Input spec
--------------------------------
 -   dealii@develop+symengine

Concretized
--------------------------------
==> Error: An unsatisfiable variant constraint has been detected for spec:
...
dealii requires symengine variant build_type=Debug,Release, but spec asked for build_type=Release
```

This looks like a bug in Spack (at least code in deal.II package does not require both variants).

In this PR I am trying to re-phrase the same constraints but make sure that `depends_on()` are self excluding. The first commit works both for `spack spec -I dealii@develop+symengine` and `spack spec -I dealii@develop+symengine^trilinos+debug`, but the second fails:

```
$ spack spec -I dealii@develop+symengine
Input spec
--------------------------------
 -   dealii@develop+symengine

Concretized
--------------------------------
==> Error: multiple values are not allowed for variant "build_type"
```

Again, pointing that something seems to be wrong with multi-valued variants and/or concretization with `^` constraints. @alalazo @tgamblin @scheibelp @adamjstewart any thoughts?

EDIT: concretization works as expected if I help concretizer with `trilinos` debug variant:
```
$ spack spec -I dealii@develop+symengine^trilinos+debug
```
