### PR TITLE
mesa: Patch missing gl symbols in OSMesa

### DIFF
--- a/var/spack/repos/builtin/packages/mesa/meson-expose-glapi-through-osmesa.patch
+++ b/var/spack/repos/builtin/packages/mesa/meson-expose-glapi-through-osmesa.patch
@@ -1,0 +1,45 @@
+commit ccb8ea7acfb710c6c5298f3ffcadbe3d79b9b913
+Author: Eric Engestrom <eric.engestrom@intel.com>
+Date:   Thu May 2 12:42:48 2019 +0100
+
+    meson: expose glapi through osmesa
+    
+    Suggested-by: Pierre Guillou <pierre.guillou@lip6.fr>
+    Bugzilla: https://bugs.freedesktop.org/show_bug.cgi?id=109659
+    Fixes: f121a669c7d94d2ff672 "meson: build gallium based osmesa"
+    Fixes: cbbd5bb889a2c271a504 "meson: build classic osmesa"
+    Cc: Brian Paul <brianp@vmware.com>
+    Cc: Dylan Baker <dylan@pnwbakers.com>
+    Signed-off-by: Eric Engestrom <eric.engestrom@intel.com>
+    Tested-by: Chuck Atkins <chuck.atkins@kitware.com>
+
+diff --git a/src/gallium/targets/osmesa/meson.build b/src/gallium/targets/osmesa/meson.build
+index b4ae8f4..e873e31 100644
+--- a/src/gallium/targets/osmesa/meson.build
++++ b/src/gallium/targets/osmesa/meson.build
+@@ -43,9 +43,9 @@ libosmesa = shared_library(
+     inc_gallium_drivers,
+   ],
+   link_depends : osmesa_link_deps,
+-  link_whole : [libosmesa_st],
++  link_whole : [libosmesa_st, libglapi_static],
+   link_with : [
+-    libmesa_gallium, libgallium, libglapi_static, libws_null, osmesa_link_with,
++    libmesa_gallium, libgallium, libws_null, osmesa_link_with,
+   ],
+   dependencies : [
+     dep_selinux, dep_thread, dep_clock, dep_unwind,
+diff --git a/src/mesa/drivers/osmesa/meson.build b/src/mesa/drivers/osmesa/meson.build
+index a406bb3..c479b74 100644
+--- a/src/mesa/drivers/osmesa/meson.build
++++ b/src/mesa/drivers/osmesa/meson.build
+@@ -33,7 +33,8 @@ libosmesa = shared_library(
+   include_directories : [
+     inc_include, inc_src, inc_mapi, inc_mesa, inc_gallium, inc_gallium_aux,
+   ],
+-  link_with : [libmesa_classic, libglapi_static, osmesa_link_with],
++  link_whole : libglapi_static,
++  link_with : [libmesa_classic, osmesa_link_with],
+   dependencies : [dep_thread, dep_selinux],
+   version : '8.0.0',
+   install : true,

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -82,6 +82,10 @@ class Mesa(MesonPackage):
     # Was included in the upstream patch release for 19.0.4
     patch('glproto-mr806.patch', when='@19.0.0:19.0.3')
 
+    # Fix missing gl symbols in OSMesa
+    # https://bugs.freedesktop.org/show_bug.cgi?id=109659
+    patch('meson-expose-glapi-through-osmesa.patch', when='@19.0.0:')
+
     def meson_args(self):
         spec = self.spec
         args = [


### PR DESCRIPTION
Add upstream patch to fix missing gl symbols in OSMesa

Combined with #11485, Fixes #11398