### PR TITLE
Simplified handling of parallel jobs during builds

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -410,7 +410,9 @@ def _set_variables_for_single_module(pkg, module):
         spack.config.set('config:build_jobs', 1, scope='package')
 
     # Number of jobs Spack will build with
-    jobs = spack.config.get('config:build_jobs') or multiprocessing.cpu_count()
+    jobs = spack.config.get(
+        'config:build_jobs', default=multiprocessing.cpu_count()
+    )
 
     m = module
     m.make_jobs = jobs

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -405,9 +405,8 @@ def set_build_environment_variables(pkg, env, dirty):
 def _set_variables_for_single_module(pkg, module):
     """Helper function to set module variables for single module."""
 
-    jobs = spack.config.get(
-        'config:build_jobs', default=multiprocessing.cpu_count()
-    ) if pkg.parallel else 1
+    jobs = spack.config.get('config:build_jobs') if pkg.parallel else 1
+    assert jobs is not None, "no default set for config:build_jobs"
 
     m = module
     m.make_jobs = jobs

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -404,11 +404,14 @@ def set_build_environment_variables(pkg, env, dirty):
 
 def _set_variables_for_single_module(pkg, module):
     """Helper function to set module variables for single module."""
+
+    # The package required a serial build by setting parallel=False
+    if not pkg.parallel:
+        spack.config.set('config:build_jobs', 1, scope='package')
+
     # number of jobs spack will build with.
     jobs = spack.config.get('config:build_jobs') or multiprocessing.cpu_count()
-    if not pkg.parallel:
-        jobs = 1
-    elif pkg.make_jobs:
+    if pkg.make_jobs:
         jobs = pkg.make_jobs
 
     m = module

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -407,7 +407,7 @@ def _set_variables_for_single_module(pkg, module):
 
     # The package required a serial build by setting parallel=False
     if not pkg.parallel:
-        spack.config.set('config:build_jobs', 1, scope='package')
+        spack.config.set('config:build_jobs', 1, scope='_builtin')
 
     # Number of jobs Spack will build with
     jobs = spack.config.get(

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -405,14 +405,9 @@ def set_build_environment_variables(pkg, env, dirty):
 def _set_variables_for_single_module(pkg, module):
     """Helper function to set module variables for single module."""
 
-    # The package required a serial build by setting parallel=False
-    if not pkg.parallel:
-        spack.config.set('config:build_jobs', 1, scope='_builtin')
-
-    # Number of jobs Spack will build with
     jobs = spack.config.get(
         'config:build_jobs', default=multiprocessing.cpu_count()
-    )
+    ) if pkg.parallel else 1
 
     m = module
     m.make_jobs = jobs

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -409,10 +409,8 @@ def _set_variables_for_single_module(pkg, module):
     if not pkg.parallel:
         spack.config.set('config:build_jobs', 1, scope='package')
 
-    # number of jobs spack will build with.
+    # Number of jobs Spack will build with
     jobs = spack.config.get('config:build_jobs') or multiprocessing.cpu_count()
-    if pkg.make_jobs:
-        jobs = pkg.make_jobs
 
     m = module
     m.make_jobs = jobs

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -15,9 +15,7 @@ level = "long"
 
 
 def setup_parser(subparser):
-    subparser.add_argument(
-        '-j', '--jobs', action='store', type=int,
-        help="explicitly set number of make jobs (default: #cpus)")
+    arguments.add_common_arguments(subparser, ['jobs'])
     subparser.add_argument(
         '--keep-prefix', action='store_true', dest='keep_prefix',
         help="don't remove the install prefix if installation fails")

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -38,7 +38,6 @@ def bootstrap(parser, args, **kwargs):
         'keep_prefix': args.keep_prefix,
         'keep_stage': args.keep_stage,
         'install_deps': 'dependencies',
-        'make_jobs': args.jobs,
         'verbose': args.verbose,
         'dirty': args.dirty
     })

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -86,10 +86,7 @@ class SetParallelJobs(argparse.Action):
                   '[expected a positive integer, got "{1}"]'
             raise ValueError(msg.format(option_string, jobs))
 
-        # Set the number of build jobs according to the argument passed
-        # via the command line
-        if jobs:
-            spack.config.set('config:build_jobs', jobs, scope='command_line')
+        spack.config.set('config:build_jobs', jobs, scope='command_line')
 
         setattr(namespace, 'jobs', jobs)
 

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -90,7 +90,7 @@ class SetParallelJobs(argparse.Action):
         # If no option was passed set the default to the number of CPUs,
         if values is None and not spack.config.get('config:build_jobs'):
             ncpus = multiprocessing.cpu_count()
-            spack.config.set('config:build_jobs', ncpus, scope='builtin')
+            spack.config.set('config:build_jobs', ncpus, scope='_builtin')
 
         # Set the number of build jobs according to the argument passed
         # via the command line

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -78,20 +78,20 @@ class SetParallelJobs(argparse.Action):
     The value is is set in the command line configuration scope so that
     it can be retrieved using the spack.config API.
     """
-    def __call__(self, parser, namespace, values, option_string):
+    def __call__(self, parser, namespace, jobs, option_string):
         # Values is a single integer, type conversion is already applied
         # see https://docs.python.org/3/library/argparse.html#action-classes
-        if values < 1:
+        if jobs < 1:
             msg = 'invalid value for argument "{0}" '\
                   '[expected a positive integer, got "{1}"]'
-            raise ValueError(msg.format(option_string, values))
+            raise ValueError(msg.format(option_string, jobs))
 
         # Set the number of build jobs according to the argument passed
         # via the command line
-        if values:
-            spack.config.set('config:build_jobs', values, scope='command_line')
+        if jobs:
+            spack.config.set('config:build_jobs', jobs, scope='command_line')
 
-        setattr(namespace, 'jobs', values)
+        setattr(namespace, 'jobs', jobs)
 
     @property
     def default(self):

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -141,10 +141,6 @@ _arguments['very_long'] = Args(
     '-L', '--very-long', action='store_true',
     help='show full dependency hashes as well as versions')
 
-_arguments['jobs'] = Args(
-    '-j', '--jobs', action='store', type=int, dest='jobs',
-    help="explicitely set number of make jobs. default is #cpus")
-
 _arguments['tags'] = Args(
     '-t', '--tags', action='append',
     help='filter a package query by tags')

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -151,7 +151,7 @@ _arguments['jobs'] = Args(
     type=int,
     dest='jobs',
     default=None,
-    help='explicitly set number of make jobs'
+    help='explicitly set number of parallel jobs'
 )
 
 _arguments['install_status'] = Args(

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -79,7 +79,7 @@ class SetParallelJobs(argparse.Action):
     it can be retrieved using the spack.config API.
     """
     def __call__(self, parser, namespace, jobs, option_string):
-        # Values is a single integer, type conversion is already applied
+        # Jobs is a single integer, type conversion is already applied
         # see https://docs.python.org/3/library/argparse.html#action-classes
         if jobs < 1:
             msg = 'invalid value for argument "{0}" '\

--- a/lib/spack/spack/cmd/diy.py
+++ b/lib/spack/spack/cmd/diy.py
@@ -50,10 +50,6 @@ def diy(self, args):
     if not args.spec:
         tty.die("spack diy requires a package spec argument.")
 
-    if args.jobs is not None:
-        if args.jobs <= 0:
-            tty.die("the -j option must be a positive integer")
-
     specs = spack.cmd.parse_specs(args.spec)
     if len(specs) > 1:
         tty.die("spack diy only takes one spec.")

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -35,7 +35,6 @@ def update_kwargs_from_args(args, kwargs):
         'keep_stage': args.keep_stage,
         'restage': not args.dont_restage,
         'install_source': args.install_source,
-        'make_jobs': args.jobs,
         'verbose': args.verbose,
         'fake': args.fake,
         'dirty': args.dirty,

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -231,10 +231,6 @@ def install(parser, args, **kwargs):
         else:
             tty.die("install requires a package argument or a spack.yaml file")
 
-    if args.jobs is not None:
-        if args.jobs <= 0:
-            tty.die("The -j option must be a positive integer!")
-
     if args.no_checksum:
         spack.config.set('config:checksum', False, scope='command_line')
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -396,9 +396,6 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
     #: By default we build in parallel.  Subclasses can override this.
     parallel = True
 
-    #: # jobs to use for parallel make. If set, overrides default of ncpus.
-    make_jobs = None
-
     #: By default do not run tests within package's install()
     run_tests = False
 
@@ -1369,8 +1366,6 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             skip_patch (bool): Skip patch stage of build if True.
             verbose (bool): Display verbose build output (by default,
                 suppresses it)
-            make_jobs (int): Number of make jobs to use for install. Default
-                is ncpus
             fake (bool): Don't really build; install fake stub files instead.
             explicit (bool): True if package was explicitly installed, False
                 if package was implicitly installed (as a dependency).
@@ -1393,7 +1388,6 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         install_deps = kwargs.get('install_deps', True)
         skip_patch = kwargs.get('skip_patch', False)
         verbose = kwargs.get('verbose', False)
-        make_jobs = kwargs.get('make_jobs', None)
         fake = kwargs.get('fake', False)
         explicit = kwargs.get('explicit', False)
         tests = kwargs.get('tests', False)
@@ -1468,9 +1462,6 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         # Set run_tests flag before starting build
         self.run_tests = (tests is True or
                           tests and self.name in tests)
-
-        # Set parallelism before starting build.
-        self.make_jobs = make_jobs
 
         # Then install the package itself.
         def build_process():

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -279,3 +279,20 @@ def test_set_build_environment_variables(
 
     finally:
         delattr(dep_pkg, 'libs')
+
+
+def test_parallel_false_is_not_propagating(config, mock_packages):
+    class AttributeHolder(object):
+        pass
+
+    # Package A has parallel = False and depends on B which instead
+    # can be built in parallel
+    s = spack.spec.Spec('a foobar=bar')
+    s.concretize()
+
+    for spec in s.traverse():
+        expected_jobs = spack.config.get('config:build_jobs') \
+            if s.package.parallel else 1
+        m = AttributeHolder()
+        spack.build_environment._set_variables_for_single_module(s.package, m)
+        assert m.make_jobs == expected_jobs

--- a/lib/spack/spack/test/cmd/common/arguments.py
+++ b/lib/spack/spack/test/cmd/common/arguments.py
@@ -1,0 +1,36 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import argparse
+import multiprocessing
+
+import pytest
+
+
+import spack.cmd.common.arguments as arguments
+
+
+@pytest.fixture()
+def parser():
+    return argparse.ArgumentParser()
+
+
+def test_setting_parallel_jobs(parser):
+    arguments.add_common_arguments(parser, ['jobs'])
+
+    # A negative integer has no meaning and raises an exception
+    with pytest.raises(ValueError) as exc_info:
+        parser.parse_args(['-j', '-2'])
+
+    assert 'expected a positive integer' in str(exc_info.value)
+
+    # Check that the default value is computed correctly
+    ncpus = multiprocessing.cpu_count()
+    namespace = parser.parse_args([])
+    assert namespace.jobs == ncpus
+
+    # Check that a positive integer works as expected
+    namespace = parser.parse_args(['-j', '24'])
+    assert namespace.jobs == 24

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -288,7 +288,11 @@ def config(configuration_dir):
 
     real_configuration = spack.config.config
 
-    test_scopes = [
+    defaults = spack.config.InternalConfigScope(
+        '_builtin', spack.config.config_defaults
+    )
+    test_scopes = [defaults]
+    test_scopes += [
         spack.config.ConfigScope(name, str(configuration_dir.join(name)))
         for name in ['site', 'system', 'user']]
     test_scopes.append(spack.config.InternalConfigScope('command_line'))

--- a/var/spack/repos/builtin.mock/packages/a/package.py
+++ b/var/spack/repos/builtin.mock/packages/a/package.py
@@ -32,6 +32,8 @@ class A(AutotoolsPackage):
 
     depends_on('b', when='foobar=bar')
 
+    parallel = False
+
     def with_or_without_fee(self, activated):
         if not activated:
             return '--no-fee'

--- a/var/spack/repos/builtin/packages/bazel/package.py
+++ b/var/spack/repos/builtin/packages/bazel/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import inspect
+
 from spack import *
 from multiprocessing import cpu_count
 from spack.util.environment import env_flag
@@ -90,8 +92,9 @@ class Bazel(Package):
                 return super(BazelExecutable, self).__call__(*args, **kwargs)
 
         jobs = cpu_count()
+        dependent_module = inspect.getmodule(dependent_spec.package)
         if not dependent_spec.package.parallel:
             jobs = 1
-        elif dependent_spec.package.make_jobs:
-            jobs = dependent_spec.package.make_jobs
+        elif dependent_module.make_jobs:
+            jobs = dependent_module.make_jobs
         module.bazel = BazelExecutable('bazel', 'build', jobs)


### PR DESCRIPTION
This PR implements the refactoring requests in https://github.com/spack/spack/pull/11373#discussion_r281064828, in particular:

- [x] Config scopes are used to handle builtin defaults, command line overrides and package overrides (`parallel=False`)
- [x] `Package.make_jobs` attribute has been removed
- [x] The use of the argument `-j` has been rationalized across commands
- [x] Add unit tests to check that setting parallel jobs works as expected
- [x] Fix packages that used `Package.make_jobs` (i.e. `bazel`)