### PR TITLE
Add external package for IBM Platform LSF and have OpenMPI depend on it when LSF is specified in the schedulers variant.

### DIFF
--- a/var/spack/repos/builtin/packages/lsf/package.py
+++ b/var/spack/repos/builtin/packages/lsf/package.py
@@ -23,5 +23,4 @@ class Lsf(Package):
 
     def install(self, spec, prefix):
         raise InstallError('LSF is not installable; it is vendor supplied')
-~
-~
+

--- a/var/spack/repos/builtin/packages/lsf/package.py
+++ b/var/spack/repos/builtin/packages/lsf/package.py
@@ -23,4 +23,3 @@ class Lsf(Package):
 
     def install(self, spec, prefix):
         raise InstallError('LSF is not installable; it is vendor supplied')
-

--- a/var/spack/repos/builtin/packages/lsf/package.py
+++ b/var/spack/repos/builtin/packages/lsf/package.py
@@ -10,8 +10,8 @@ from spack import *
 class Lsf(Package):
     """IBM Platform LSF is a batch scheduler for HPC environments"""
 
-    homepage = "https://www.ibm.com/ch-en/marketplace/hpc-workload-management"
-    url = "https://www.ibm.com/ch-en/marketplace/hpc-workload-management"
+    homepage = "https://www.ibm.com/marketplace/hpc-workload-management"
+    url = "https://www.ibm.com/marketplace/hpc-workload-management"
 
     # LSF needs to be added as an external package to SPACK. For this, the
     # config file packages.yaml needs to be adjusted:

--- a/var/spack/repos/builtin/packages/lsf/package.py
+++ b/var/spack/repos/builtin/packages/lsf/package.py
@@ -1,0 +1,27 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack import *
+
+
+class Lsf(Package):
+    """IBM Platform LSF is a batch scheduler for HPC environments"""
+
+    homepage = "https://www.ibm.com/ch-en/marketplace/hpc-workload-management"
+    url = "https://www.ibm.com/ch-en/marketplace/hpc-workload-management"
+
+    # LSF needs to be added as an external package to SPACK. For this, the
+    # config file packages.yaml needs to be adjusted:
+    #   lsf:
+    #     version: [10.1]
+    #     paths:
+    #       lsf@10.1: /usr/local/lsf/10.1 (path to your LSF installation)
+    #     buildable: False
+
+    def install(self, spec, prefix):
+        raise InstallError('LSF is not installable; it is vendor supplied')
+~
+~

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -259,6 +259,7 @@ class Openmpi(AutotoolsPackage):
     depends_on('ucx', when='fabrics=ucx')
     depends_on('libfabric', when='fabrics=libfabric')
     depends_on('slurm', when='schedulers=slurm')
+    depends_on('lsf', when='schedulers=lsf')
     depends_on('binutils+libiberty', when='fabrics=mxm')
 
     conflicts('+cuda', when='@:1.6')  # CUDA support was added in 1.7


### PR DESCRIPTION
Related: #8503

Hello!

:tipping_hand_woman: This PR adds a new external package for [IBM Platform LSF](https://www.ibm.com/marketplace/hpc-workload-management) (`lsf`) and adds it as a dependency for `openmpi` when `schedulers=lsf`.

LSF (Load Sharing Facility) is a batch scheduler for HPC environments; similar to Slurm, Torque, etc. The current Open MPI package supports `lsf` as a scheduler variant and will add the `--with-lsf` configure flag when compiling `openmpi`. However, the path for LSF is not necessarily standardized. It is also closed-source software that you retrieve from the IBM website and unpack onto a cluster as part of the initial setup, so it cannot be naturally-managed by Spack. Because the path is not standardized, passing `--with-lsf` instead of `--with-lsf=/path/to/lsf/install` will likely fail during configure.

Additionally, the dependency on LSF (when using `schedulers=lsf`) is loose and not represented as a true dependency during concretization. Therefore, we add a new external package (similar to how `spectrum-mpi`, an IBM implementation of MPI is implemented).

Similar work was done in #8503 but also couples the addition of this external package with changes to Open MPI defaults. This PR has a narrower focus and simply sets up the dependency.

Lastly, users of Spack that need to compile support for LSF into Open MPI will need to maintain a `packages.yaml` (documented in comments of the `lsf` package) that specifies the version of LSF they are using as well as the path to that installation.

I appreciate your time in review and look forward to diving deeper into Spack. I'm at NC State in the College of Engineering; working with our central HPC unit to evaluate moving a lot of our maintained cluster software into Spack. This was the first issue I've hit so far. 