### PR TITLE
default python preference for packages.yaml

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -49,3 +49,5 @@ packages:
     permissions:
       read: world
       write: user
+  python:
+    version: [3, 2]


### PR DESCRIPTION
This PR adds a python preference order to default packages.yaml to help with issues relating to python2/3 concretization errors.

This doesn't solve all issues related to the 2/3 difficulty, but I think would make the 'out of the box' experience work more as expected without user customization required, especially for setups like environments and building in containers.

Related to: #11531, #11468, #11396
