### PR TITLE
Updated lmod (to version 8.1.5) and associated dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/lmod/package.py
+++ b/var/spack/repos/builtin/packages/lmod/package.py
@@ -19,6 +19,8 @@ class Lmod(AutotoolsPackage):
     homepage = 'https://www.tacc.utexas.edu/research-development/tacc-projects/lmod'
     url      = 'https://github.com/TACC/Lmod/archive/7.4.11.tar.gz'
 
+    version('8.1.5', sha256='3e5846d3d8e593cbcdfa0aed1474569bf5b5cfd19fd288de22051823d449d344')
+    version('8.0.9', sha256='9813c22ae4dd21eb3dc480f6ce307156512092b4bca954bf8aacc15944f23673')
     version('7.8.15', sha256='00a257f5073d656adc73045997c28f323b7a4f6d901f1c57b7db2b0cd6bee6e6')
     version('7.8', sha256='40388380a36a00c3ce929a9f88c8fffc93deeabf87a7c3f8864a82acad38c3ba')
     version('7.7.29', 'bd3f171995e6863505e8a958d158ced1')
@@ -40,7 +42,7 @@ class Lmod(AutotoolsPackage):
     depends_on('lua@5.1:')
     depends_on('lua-luaposix', type=('build', 'run'))
     depends_on('lua-luafilesystem', type=('build', 'run'))
-    depends_on('tcl', type=('build', 'run'))
+    depends_on('tcl', type=('build', 'link', 'run'))
 
     patch('fix_tclsh_paths.patch', when='@:6.4.3')
     patch('0001-fix-problem-with-MODULESHOME-and-issue-271.patch', when='@7.3.28:7.4.10')

--- a/var/spack/repos/builtin/packages/lua-luafilesystem/package.py
+++ b/var/spack/repos/builtin/packages/lua-luafilesystem/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+import os.path
 
 
 class LuaLuafilesystem(Package):
@@ -19,6 +19,7 @@ class LuaLuafilesystem(Package):
     homepage = 'http://keplerproject.github.io/luafilesystem'
     url = 'https://github.com/keplerproject/luafilesystem/archive/v1_6_3.tar.gz'
 
+    version('1_7_0_2', sha256='23b4883aeb4fb90b2d0f338659f33a631f9df7a7e67c54115775a77d4ac3cc59')
     version('1_6_3', 'bed11874cfded8b4beed7dd054127b24')
 
     # The version constraint here comes from this post:
@@ -29,10 +30,20 @@ class LuaLuafilesystem(Package):
     depends_on('git@1.9.0:', type='build')
     extends('lua')
 
+    @property
+    def rockspec(self):
+        version = self.spec.version
+        semver = version[0:3]
+        tweak_level = version[3] if len(version) > 3 else 1
+        fmt = os.path.join(
+            self.stage.path,
+            'luafilesystem-{version.underscored}',
+            'rockspecs',
+            'luafilesystem-{semver.dotted}-{tweak_level}.rockspec'
+        )
+        return fmt.format(
+            version=version, semver=semver, tweak_level=tweak_level
+        )
+
     def install(self, spec, prefix):
-        rockspec_fmt = join_path(self.stage.path,
-                                 'luafilesystem-{version.underscored}',
-                                 'rockspecs',
-                                 'luafilesystem-{version.dotted}-1.rockspec')
-        luarocks('--tree=' + prefix, 'install',
-                 rockspec_fmt.format(version=self.spec.version))
+        luarocks('--tree=' + prefix, 'install', self.rockspec)

--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -13,6 +13,7 @@ class Lua(Package):
     homepage = "http://www.lua.org"
     url = "http://www.lua.org/ftp/lua-5.3.4.tar.gz"
 
+    version('5.3.5', sha256='0c2eed3f960446e1a3e4b9a1ca2f3ff893b6ce41942cf54d5dd59ab4b3b058ac')
     version('5.3.4', '53a9c68bcc0eda58bdc2095ad5cdfc63')
     version('5.3.2', '33278c2ab5ee3c1a875be8d55c1ca2a1')
     version('5.3.1', '797adacada8d85761c079390ff1d9961')


### PR DESCRIPTION
New versions added:
- Lmod version 8.1.5
- Lua version 5.3.5
- Lua Filesystem 1.7.0.2

Turned tcl to a link dependency so that Lmod's configure can find it.