### PR TITLE
mbedtls: add pic variant

### DIFF
--- a/var/spack/repos/builtin/packages/mbedtls/package.py
+++ b/var/spack/repos/builtin/packages/mbedtls/package.py
@@ -11,11 +11,13 @@ class Mbedtls(CMakePackage):
        developers to include cryptographic and SSL/TLS capabilities in
        their (embedded) products, facilitating this functionality with a
        minimal coding footprint.
-
     """
+
     homepage = "https://tls.mbed.org"
     url      = "https://github.com/ARMmbed/mbedtls/archive/mbedtls-2.2.1.tar.gz"
 
+    version('2.16.1', 'daf0d40f3016c34eb42d1e4b3b52be047e976d566aba8668977723c829af72f3')
+    version('2.7.10', '42b19b30b86a798bdb69c5da2f8bbd7d72ffede9a35b888ab986a29480f9dc3e')
     version('2.3.0', '98158e1160a0825a3e8db38881a177a0')
     version('2.2.1', '73a38f96898d6d03e32f55dd9f9a67be')
     version('2.2.0', 'eaf4586c1ef93ae872e606b6c1203942')
@@ -28,4 +30,16 @@ class Mbedtls(CMakePackage):
             values=('Debug', 'Release', 'Coverage', 'ASan', 'ASanDbg',
                     'MemSan', 'MemSanDbg', 'Check', 'CheckFull'))
 
+    variant('pic', default=False,
+            description='Compile with position independent code.')
+
     depends_on('cmake@2.6:', type='build')
+    depends_on('perl', type='build')
+
+    def flag_handler(self, name, flags):
+
+        # Compile with PIC, if requested.
+        if name == 'cflags' and '+pic' in self.spec:
+            flags.append(self.compiler.pic_flag)
+
+        return (flags, None, None)


### PR DESCRIPTION
Add variant 'pic' for including in shared libraries.

Add build dependency on perl.  Compiling mbedtls runs several perl
scripts.

Add versions 2.7.10 and 2.16.1, the heads of the two main stable
branches.