### PR TITLE
Update GnuPG and associated packages

### DIFF
--- a/var/spack/repos/builtin/packages/gnupg/package.py
+++ b/var/spack/repos/builtin/packages/gnupg/package.py
@@ -13,11 +13,13 @@ class Gnupg(AutotoolsPackage):
     homepage = "https://gnupg.org/index.html"
     url = "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.3.tar.bz2"
 
+    version('2.2.15', sha256='cb8ce298d7b36558ffc48aec961b14c830ff1783eef7a623411188b5e0f5d454')
     version('2.2.3', '6911c0127e4231ce52d60f26029dba68')
     version('2.1.21', '685ebf4c3a7134ba0209c96b18b2f064')
 
     depends_on('libgcrypt')
-    depends_on('libassuan')
+    depends_on('libassuan@2.4:', when='@:2.2.3')
+    depends_on('libassuan@2.5:', when='@2.2.15:')
     depends_on('libksba')
     depends_on('libgpg-error')
     depends_on('npth')

--- a/var/spack/repos/builtin/packages/libassuan/package.py
+++ b/var/spack/repos/builtin/packages/libassuan/package.py
@@ -13,6 +13,7 @@ class Libassuan(AutotoolsPackage):
     homepage = "https://gnupg.org/software/libassuan/index.html"
     url = "https://gnupg.org/ftp/gcrypt/libassuan/libassuan-2.4.5.tar.bz2"
 
+    version('2.5.3', sha256='91bcb0403866b4e7c4bc1cc52ed4c364a9b5414b3994f718c70303f7f765e702')
     version('2.4.5', '4f22bdb70d424cfb41b64fd73b7e1e45')
     version('2.4.3', '8e01a7c72d3e5d154481230668e6eb5a')
 

--- a/var/spack/repos/builtin/packages/libgcrypt/package.py
+++ b/var/spack/repos/builtin/packages/libgcrypt/package.py
@@ -15,6 +15,7 @@ class Libgcrypt(AutotoolsPackage):
     homepage = "http://www.gnu.org/software/libgcrypt/"
     url = "https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.8.1.tar.bz2"
 
+    version('1.8.4', sha256='f638143a0672628fde0cad745e9b14deb85dffb175709cacc1f4fe24b93f2227')
     version('1.8.1', 'b21817f9d850064d2177285f1073ec55')
     version('1.7.6', '54e180679a7ae4d090f8689ca32b654c')
     version('1.6.2', 'b54395a93cb1e57619943c082da09d5f')

--- a/var/spack/repos/builtin/packages/libgpg-error/package.py
+++ b/var/spack/repos/builtin/packages/libgpg-error/package.py
@@ -15,6 +15,7 @@ class LibgpgError(AutotoolsPackage):
     homepage = "https://www.gnupg.org/related_software/libgpg-error"
     url = "https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.27.tar.bz2"
 
+    version('1.36', sha256='babd98437208c163175c29453f8681094bcaf92968a15cafb1a276076b33c97c')
     version('1.27', '5217ef3e76a7275a2a3b569a12ddc989')
     version('1.21', 'ab0b5aba6d0a185b41d07bda804fd8b2')
     version('1.18', '12312802d2065774b787cbfc22cc04e9')


### PR DESCRIPTION
Update GnuPG to the latest version. Note that while some of the updates are only housekeeping, libassuan must be updated to at least version 2.5.0 for GnuPG version 2.2.15.