### PR TITLE
commands: completion for new --update and --header options

### DIFF
--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -243,7 +243,7 @@ function _spack_clone {
 function _spack_commands {
     if $list_options
     then
-        compgen -W "-h --help --format" -- "$cur"
+        compgen -W "-h --help --format --header --update" -- "$cur"
     fi
 }
 
@@ -664,7 +664,7 @@ function _spack_license_verify {
 function _spack_list {
     if $list_options
     then
-        compgen -W "-h --help -d --search-description --format
+        compgen -W "-h --help -d --search-description --format --update
                     -t --tags" -- "$cur"
     else
         compgen -W "$(_all_packages)" -- "$cur"


### PR DESCRIPTION
Accidentally left this out of #11521 -- I had worked it in with the other commits but the push failed and I didn't notice.

This adds completion for the new `--header` and `--update` options in `spack commands` and `spack list --format=rst`.