### PR TITLE
docs: set gettext_uuid to False to reduce churn

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -150,7 +150,7 @@ release = spack.spack_version
 
 # Sphinx gettext settings
 gettext_compact = True
-gettext_uuid = True
+gettext_uuid = False
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/lib/spack/docs/requirements.txt
+++ b/lib/spack/docs/requirements.txt
@@ -4,3 +4,4 @@
 sphinx==2.0.1
 sphinxcontrib-programoutput==0.14
 sphinx-rtd-theme==0.4.3
+python-levenshtein


### PR DESCRIPTION
- `gettext_uuid=True` makes every commit update every .pot file in [spack/localized-docs](/spack/localized-docs) , and speeds up the internationalized doc build slightly.

- Optimize for less repository churn, and use `python-levenshtein` to accelerate the build instead.