### PR TITLE
Dependencies: various improvements to handling of static dependencies

### DIFF
--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -9,6 +9,7 @@ import multiprocessing
 
 import spack.cmd
 import spack.config
+import spack.dependency as dep
 import spack.environment as ev
 import spack.modules
 import spack.spec
@@ -104,6 +105,19 @@ class SetParallelJobs(argparse.Action):
         pass
 
 
+class DeptypeAction(argparse.Action):
+    """Creates a tuple of valid dependency tpyes from a deptype argument."""
+    def __call__(self, parser, namespace, values, option_string=None):
+        deptype = dep.all_deptypes
+        if values:
+            deptype = tuple(x.strip() for x in values.split(','))
+            if deptype == ('all',):
+                deptype = 'all'
+            deptype = dep.canonical_deptype(deptype)
+
+        setattr(namespace, self.dest, deptype)
+
+
 _arguments['constraint'] = Args(
     'constraint', nargs=argparse.REMAINDER, action=ConstraintAction,
     help='constraint to select a subset of installed packages')
@@ -127,6 +141,11 @@ _arguments['clean'] = Args(
     default=spack.config.get('config:dirty'),
     dest='dirty',
     help='unset harmful variables in the build environment (default)')
+
+_arguments['deptype'] = Args(
+    '--deptype', action=DeptypeAction, default=dep.all_deptypes,
+    help="comma-separated list of deptypes to traverse\ndefault=%s"
+    % ','.join(dep.all_deptypes))
 
 _arguments['dirty'] = Args(
     '--dirty',

--- a/lib/spack/spack/cmd/graph.py
+++ b/lib/spack/spack/cmd/graph.py
@@ -9,9 +9,9 @@ import argparse
 import llnl.util.tty as tty
 
 import spack.cmd
+import spack.cmd.common.arguments as arguments
 import spack.config
 import spack.store
-from spack.dependency import all_deptypes, canonical_deptype
 from spack.graph import graph_dot, graph_ascii
 
 description = "generate graphs of package dependency relationships"
@@ -31,21 +31,14 @@ def setup_parser(subparser):
         help="generate graph in dot format and print to stdout")
 
     subparser.add_argument(
-        '-n', '--normalize', action='store_true',
-        help="skip concretization; only print normalized spec")
-
-    subparser.add_argument(
         '-s', '--static', action='store_true',
-        help="use static information from packages, not dynamic spec info")
+        help="graph static (possible) deps, don't concretize (implies --dot)")
 
     subparser.add_argument(
         '-i', '--installed', action='store_true',
         help="graph all installed specs in dot format (implies --dot)")
 
-    subparser.add_argument(
-        '-t', '--deptype', action='store',
-        help="comma-separated list of deptypes to traverse. default=%s"
-        % ','.join(all_deptypes))
+    arguments.add_common_arguments(subparser, ['deptype'])
 
     subparser.add_argument(
         'specs', nargs=argparse.REMAINDER,
@@ -53,7 +46,6 @@ def setup_parser(subparser):
 
 
 def graph(parser, args):
-    concretize = not args.normalize
     if args.installed:
         if args.specs:
             tty.die("Can't specify specs with --installed")
@@ -61,26 +53,21 @@ def graph(parser, args):
         specs = spack.store.db.query()
 
     else:
-        specs = spack.cmd.parse_specs(
-            args.specs, normalize=True, concretize=concretize)
+        specs = spack.cmd.parse_specs(args.specs, concretize=not args.static)
 
     if not specs:
         setup_parser.parser.print_help()
         return 1
 
-    deptype = all_deptypes
-    if args.deptype:
-        deptype = tuple(args.deptype.split(','))
-        if deptype == ('all',):
-            deptype = 'all'
-        deptype = canonical_deptype(deptype)
+    if args.static:
+        args.dot = True
 
-    if args.dot:  # Dot graph only if asked for.
-        graph_dot(specs, static=args.static, deptype=deptype)
+    if args.dot:
+        graph_dot(specs, static=args.static, deptype=args.deptype)
 
     elif specs:  # ascii is default: user doesn't need to provide it explicitly
         debug = spack.config.get('config:debug')
-        graph_ascii(specs[0], debug=debug, deptype=deptype)
+        graph_ascii(specs[0], debug=debug, deptype=args.deptype)
         for spec in specs[1:]:
             print()  # extra line bt/w independent graphs
             graph_ascii(spec, debug=debug)

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -875,7 +875,8 @@ class Database(object):
             return self._remove(spec)
 
     @_autospec
-    def installed_relatives(self, spec, direction='children', transitive=True):
+    def installed_relatives(self, spec, direction='children', transitive=True,
+                            deptype='all'):
         """Return installed specs related to this one."""
         if direction not in ('parents', 'children'):
             raise ValueError("Invalid direction: %s" % direction)
@@ -883,11 +884,12 @@ class Database(object):
         relatives = set()
         for spec in self.query(spec):
             if transitive:
-                to_add = spec.traverse(direction=direction, root=False)
+                to_add = spec.traverse(
+                    direction=direction, root=False, deptype=deptype)
             elif direction == 'parents':
-                to_add = spec.dependents()
+                to_add = spec.dependents(deptype=deptype)
             else:  # direction == 'children'
-                to_add = spec.dependencies()
+                to_add = spec.dependencies(deptype=deptype)
 
             for relative in to_add:
                 hash_key = relative.dag_hash()

--- a/lib/spack/spack/dependency.py
+++ b/lib/spack/spack/dependency.py
@@ -34,17 +34,14 @@ def canonical_deptype(deptype):
             raise ValueError('Invalid dependency type: %s' % deptype)
         return (deptype,)
 
-    elif isinstance(deptype, (tuple, list)):
+    elif isinstance(deptype, (tuple, list, set)):
         bad = [d for d in deptype if d not in all_deptypes]
         if bad:
             raise ValueError(
                 'Invalid dependency types: %s' % ','.join(str(t) for t in bad))
         return tuple(sorted(deptype))
 
-    elif deptype is None:
-        raise ValueError('Invalid dependency type: None')
-
-    return deptype
+    raise ValueError('Invalid dependency type: %s' % repr(deptype))
 
 
 class Dependency(object):

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -100,11 +100,6 @@ class DirectiveMeta(type):
         # that the directives are called on the class to set it up
 
         if 'spack.pkg' in cls.__module__:
-            # Package name as taken
-            # from llnl.util.lang.get_calling_module_name
-            pkg_name = cls.__module__.split('.')[-1]
-            setattr(cls, 'name', pkg_name)
-
             # Ensure the presence of the dictionaries associated
             # with the directives
             for d in DirectiveMeta._directive_names:

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -62,10 +62,6 @@ from spack.version import Version
 from spack.package_prefs import get_package_dir_permissions, get_package_group
 
 
-"""Allowed URL schemes for spack packages."""
-_ALLOWED_URL_SCHEMES = ["http", "https", "ftp", "file", "git"]
-
-
 class InstallPhase(object):
     """Manages a single phase of the installation.
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -525,9 +525,10 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
 
         return self._installed_upstream
 
+    @classmethod
     def possible_dependencies(
-            self, transitive=True, expand_virtuals=True, visited=None):
-        """Return set of possible dependencies of this package.
+            cls, transitive=True, expand_virtuals=True, visited=None):
+        """Return set of possible transitive dependencies of this package.
 
         Note: the set returned *includes* the package itself.
 
@@ -539,9 +540,9 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             visited (set): set of names of dependencies visited so far.
         """
         if visited is None:
-            visited = set([self.name])
+            visited = set([cls.name])
 
-        for i, name in enumerate(self.dependencies):
+        for i, name in enumerate(cls.dependencies):
             if spack.repo.path.is_virtual(name):
                 if expand_virtuals:
                     providers = spack.repo.path.providers_for(name)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -229,6 +229,19 @@ class PackageMeta(
         """Name of this package, including the namespace"""
         return '%s.%s' % (self.namespace, self.name)
 
+    @property
+    def name(self):
+        """The name of this package.
+
+        The name of a package is the name of its Python module, without
+        the containing module names.
+        """
+        if not hasattr(self, '_name'):
+            self._name = self.module.__name__
+            if '.' in self._name:
+                self._name = self._name[self._name.rindex('.') + 1:]
+        return self._name
+
 
 def run_before(*phases):
     """Registers a method of a package to be run before a given phase"""
@@ -472,12 +485,6 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         # this determines how the package should be built.
         self.spec = spec
 
-        # Name of package is the name of its module, without the
-        # containing module names.
-        self.name = self.module.__name__
-        if '.' in self.name:
-            self.name = self.name[self.name.rindex('.') + 1:]
-
         # Allow custom staging paths for packages
         self.path = None
 
@@ -584,6 +591,11 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
     def fullname(self):
         """Name of this package, including namespace: namespace.name."""
         return type(self).fullname
+
+    @property
+    def name(self):
+        """Name of this package (the module without parent modules)."""
+        return type(self).name
 
     @property
     def global_license_dir(self):

--- a/lib/spack/spack/test/cmd/dependencies.py
+++ b/lib/spack/spack/test/cmd/dependencies.py
@@ -32,6 +32,20 @@ def test_transitive_dependencies(mock_packages):
     assert expected == actual
 
 
+def test_transitive_dependencies_with_deptypes(mock_packages):
+    out = dependencies('--transitive', '--deptype=link,run', 'dtbuild1')
+    deps = set(re.split(r'\s+', out.strip()))
+    assert set(['dtlink2', 'dtrun2']) == deps
+
+    out = dependencies('--transitive', '--deptype=build', 'dtbuild1')
+    deps = set(re.split(r'\s+', out.strip()))
+    assert set(['dtbuild2', 'dtlink2']) == deps
+
+    out = dependencies('--transitive', '--deptype=link', 'dtbuild1')
+    deps = set(re.split(r'\s+', out.strip()))
+    assert set(['dtlink2']) == deps
+
+
 @pytest.mark.db
 def test_immediate_installed_dependencies(mock_packages, database):
     with color_when(False):

--- a/lib/spack/spack/test/cmd/graph.py
+++ b/lib/spack/spack/test/cmd/graph.py
@@ -27,13 +27,6 @@ def test_graph_dot():
 
 @pytest.mark.db
 @pytest.mark.usefixtures('mock_packages', 'database')
-def test_graph_normalize():
-    """Tests spack graph --normalize"""
-    graph('--normalize', 'dt-diamond')
-
-
-@pytest.mark.db
-@pytest.mark.usefixtures('mock_packages', 'database')
 def test_graph_static():
     """Tests spack graph --static"""
     graph('--static', 'dt-diamond')

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -1,0 +1,52 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""Test class methods on Package objects.
+
+This doesn't include methods on package *instances* (like do_install(),
+etc.).  Only methods like ``possible_dependencies()`` that deal with the
+static DSL metadata for packages.
+"""
+
+import spack.repo
+
+
+def test_possible_dependencies(mock_packages):
+    mpileaks = spack.repo.get('mpileaks')
+    mpi_names = [spec.name for spec in spack.repo.path.providers_for('mpi')]
+
+    assert mpileaks.possible_dependencies() == {
+        'callpath': set(['dyninst'] + mpi_names),
+        'dyninst': set(['libdwarf', 'libelf']),
+        'fake': set(),
+        'libdwarf': set(['libelf']),
+        'libelf': set(),
+        'mpich': set(),
+        'mpich2': set(),
+        'mpileaks': set(['callpath'] + mpi_names),
+        'multi-provider-mpi': set(),
+        'zmpi': set(['fake']),
+    }
+
+
+def test_possible_dependencies_with_deptypes(mock_packages):
+    dtbuild1 = spack.repo.get('dtbuild1')
+
+    assert dtbuild1.possible_dependencies(deptype=('link', 'run')) == {
+        'dtbuild1': set(['dtrun2', 'dtlink2']),
+        'dtlink2': set(),
+        'dtrun2': set(),
+    }
+
+    assert dtbuild1.possible_dependencies(deptype=('build')) == {
+        'dtbuild1': set(['dtbuild2', 'dtlink2']),
+        'dtbuild2': set(),
+        'dtlink2': set(),
+    }
+
+    assert dtbuild1.possible_dependencies(deptype=('link')) == {
+        'dtbuild1': set(['dtlink2']),
+        'dtlink2': set(),
+    }


### PR DESCRIPTION
There's a fair amount of cruft in the Spack core, and this the first of what will be ongoing attempts to clean a bunch of it up in advance of adding a new concretizer.  

The main user-facing changes here are:
- [x] `spack graph --static`, which is supposed to graph the *possible* dependencies of a spec, does what you would expect now (it was concretizing before and only graphing possible deps of what was in the concretized spec).  Now it doesn't concretize; it only traverses the potential dependencies of and generates a graph. Useful if you want to see just how deep dependency hierarchies can go, or if you want to understand all the possible ways packages can depend on each other.
- [x] `spack dependencies` and `spack graph` both support a `--deptype` argument that lets you pick which types of dependencies you want to traverse.  e.g., you can limit things to *just* `run` and `test` deps if you want.

There are also a number of changes to `PackageBase` to make all this cleaner.  In particular:

- [x] `ALLOWED_URL_SCHEMES` was excised; it's vestigial and no longer used -- all of that stuff moved to the fetchers long ago.
- [x] This may be somewhat baffling, but it was no longer entirely clear how packages were getting their `name` set.  It turns out this had moved into `directives.py` and was being done in the `DirectiveMeta` class over in . `directives.py`.  `name` is now class property on PackageBase and a property on `PackageMeta`, consistent with other attributes like it.  Also removed some name-related cruft from the `PackageBase` constructor that was no longer doing anything.
- [x] `PackageBase.possible_dependencies()` is now a class method, so you do not need a package *instance* to run it.

More details are in the commits; probably best to read those while reviewing this.