### PR TITLE
vtkm: fix the directory cmake looks for the source code

### DIFF
--- a/var/spack/repos/builtin/packages/vtkm/package.py
+++ b/var/spack/repos/builtin/packages/vtkm/package.py
@@ -50,8 +50,7 @@ class Vtkm(CMakePackage, CudaPackage):
         spec = self.spec
         options = []
         with working_dir('spack-build', create=True):
-            options = ["../",
-                       "-DVTKm_ENABLE_TESTING:BOOL=OFF"]
+            options = ["-DVTKm_ENABLE_TESTING:BOOL=OFF"]
             # shared vs static libs
             if "+shared" in spec:
                 options.append('-DBUILD_SHARED_LIBS=ON')


### PR DESCRIPTION
Previously, the vtkm package was adding a "../" option to the
cmake command line. I suppose this was supposed to be pointing
to the source code, but did not. Rather, Spack correctly adds
the source directory as the first argument to cmake. However,
because ../ was added, it used that as the source directory
instead.

Simply remove this argument to make CMake work correctly.