### PR TITLE
New versions and bugfixes for the ACTS package

### DIFF
--- a/var/spack/repos/builtin/packages/acts-core/package.py
+++ b/var/spack/repos/builtin/packages/acts-core/package.py
@@ -78,7 +78,7 @@ class ActsCore(CMakePackage):
             cmake_variant("TGEO_PLUGIN", "tgeo")
         ]
 
-        if spec.satisfies('+tgeo'):
+        if 'root' in spec:
             cxxstd = spec['root'].variants['cxxstd'].value
             args.append("-DCMAKE_CXX_STANDARD={0}".format(cxxstd))
 

--- a/var/spack/repos/builtin/packages/acts-core/package.py
+++ b/var/spack/repos/builtin/packages/acts-core/package.py
@@ -60,14 +60,12 @@ class ActsCore(CMakePackage):
 
     def cmake_args(self):
         spec = self.spec
-        cxxstd = spec['root'].variants['cxxstd'].value
 
         def cmake_variant(cmake_label, spack_variant):
             enabled = spec.satisfies('+' + spack_variant)
             return "-DACTS_BUILD_{0}={1}".format(cmake_label, enabled)
 
         args = [
-            "-DCMAKE_CXX_STANDARD={0}".format(cxxstd),
             cmake_variant("LEGACY", "legacy"),
             cmake_variant("EXAMPLES", "examples"),
             cmake_variant("TESTS", "tests"),
@@ -79,4 +77,9 @@ class ActsCore(CMakePackage):
             cmake_variant("MATERIAL_PLUGIN", "material"),
             cmake_variant("TGEO_PLUGIN", "tgeo")
         ]
+
+        if spec.satisfies('+tgeo'):
+            cxxstd = spec['root'].variants['cxxstd'].value
+            args.append("-DCMAKE_CXX_STANDARD={0}".format(cxxstd))
+
         return args

--- a/var/spack/repos/builtin/packages/acts-core/package.py
+++ b/var/spack/repos/builtin/packages/acts-core/package.py
@@ -55,6 +55,8 @@ class ActsCore(CMakePackage):
     variant('tgeo', default=False, description='Build the TGeo plugin')
 
     depends_on('cmake @3.7:', type='build')
+    # Currently incompatible with boost 1.70.0, see also discussion at
+    #    https://gitlab.cern.ch/acts/acts-core/issues/592#note_2618474
     depends_on('boost @1.62:1.69.99 +program_options +test')
     depends_on('eigen @3.2.9:', type='build')
     depends_on('root @6.10: cxxstd=14', when='+tgeo @:0.8.0')

--- a/var/spack/repos/builtin/packages/acts-core/package.py
+++ b/var/spack/repos/builtin/packages/acts-core/package.py
@@ -33,6 +33,9 @@ class ActsCore(CMakePackage):
     git      = "https://gitlab.cern.ch/acts/acts-core.git"
 
     version('develop', branch='master')
+    version('0.9.2', commit='4e1f7fa73ffe07457080d787e206bf6466fe1680')
+    version('0.9.1', commit='69c451035516cb683b8f7bc0bab1a25893e9113d')
+    version('0.9.0', commit='004888b0a412f5bbaeef2ffaaeaf2aa182511494')
     version('0.8.2', commit='c5d7568714e69e7344582b93b8d24e45d6b81bf9')
     version('0.8.1', commit='289bdcc320f0b3ff1d792e29e462ec2d3ea15df6')
     version('0.8.0', commit='99eedb38f305e3a1cd99d9b4473241b7cd641fa9')  # Used by acts-framework

--- a/var/spack/repos/builtin/packages/acts-core/package.py
+++ b/var/spack/repos/builtin/packages/acts-core/package.py
@@ -55,7 +55,7 @@ class ActsCore(CMakePackage):
     variant('tgeo', default=False, description='Build the TGeo plugin')
 
     depends_on('cmake @3.7:', type='build')
-    depends_on('boost @1.62: +program_options +test')
+    depends_on('boost @1.62:1.69.99 +program_options +test')
     depends_on('eigen @3.2.9:', type='build')
     depends_on('root @6.10: cxxstd=14', when='+tgeo @:0.8.0')
     depends_on('root @6.10:', when='+tgeo @0.8.1:')


### PR DESCRIPTION
This PR enables building the new ACTS 0.9.x releases.

It also marks the package as incompatible with Boost 1.70.0 (as it breaks our CMake configuration) and fixes the C++ standard selection logic by incorporating #11054.