### PR TITLE
ROOT: Set PYTHON_EXECUTABLE with +python variant

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -501,7 +501,7 @@ class Root(CMakePackage):
                 self.spec['ftgl'].prefix))
             options.append('-DFTGL_INCLUDE_DIR={0}'.format(
                 self.spec['ftgl'].prefix.include))
-        
+
         if '+python' in self.spec:
             options.append('-DPYTHON_EXECUTABLE=%s/python' %
                            self.spec['python'].prefix.bin)

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -501,6 +501,10 @@ class Root(CMakePackage):
                 self.spec['ftgl'].prefix))
             options.append('-DFTGL_INCLUDE_DIR={0}'.format(
                 self.spec['ftgl'].prefix.include))
+        
+        if '+python' in self.spec:
+            options.append('-DPYTHON_EXECUTABLE=%s/python' %
+                           self.spec['python'].prefix.bin)
 
         return options
 

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -502,6 +502,7 @@ class Root(CMakePackage):
             options.append('-DFTGL_INCLUDE_DIR={0}'.format(
                 self.spec['ftgl'].prefix.include))
 
+        # see https://github.com/spack/spack/pull/11579
         if '+python' in self.spec:
             options.append('-DPYTHON_EXECUTABLE=%s/python' %
                            self.spec['python'].prefix.bin)


### PR DESCRIPTION
After cmake v3.12 FindPythonInterp used by llvm subsystem is deprecated. 
When building with python3 the cmake error below happens. 

FindPythonInterp sets PYTHON_EXECUTABLE=/usr/bin/python2.7 and calls

    execute_process(COMMAND "${PYTHON_EXECUTABLE}" -c
                            "import sys; sys.stdout.write(';'.join([str(x) for x in sys.version_info[:3]]))"
                    OUTPUT_VARIABLE _VERSION
                    RESULT_VARIABLE _PYTHON_VERSION_RESULT
                    ERROR_QUIET)

Since PYTHONPATH is set to the python3 install this results in an error importing site and the _VERSION variable is not set.

Setting -DPYTHON_EXECUTABLE=path_to_python fixes this error:


1 error found in build log:
     118    -- Doxygen disabled.
     119    -- Go bindings disabled.
     120    -- LLVM host triple: x86_64-unknown-linux-gnu
     121    -- LLVM default target triple: x86_64-unknown-linux-gnu
     122    -- Building with -fPIC
     123    -- Found PythonInterp: /usr/bin/python2.7
  >> 124    CMake Error at interpreter/llvm/src/CMakeLists.txt:613 (if):
     125      if given arguments:
     126    
     127        "VERSION_LESS" "2.7"
     128    
     129      Unknown arguments specified
     130    
