### PR TITLE
Xrootd: set PYTHON_EXECUTABLE with +python variant

### DIFF
--- a/var/spack/repos/builtin/packages/xrootd/package.py
+++ b/var/spack/repos/builtin/packages/xrootd/package.py
@@ -79,7 +79,7 @@ class Xrootd(CMakePackage):
         # see https://github.com/spack/spack/pull/11581
         if '+python' in self.spec:
             options.append('-DPYTHON_EXECUTABLE=%s' %
-                           spec['python'].command.path
+                           spec['python'].command.path)
 
         return options
 

--- a/var/spack/repos/builtin/packages/xrootd/package.py
+++ b/var/spack/repos/builtin/packages/xrootd/package.py
@@ -78,8 +78,8 @@ class Xrootd(CMakePackage):
         ]
         # see https://github.com/spack/spack/pull/11581
         if '+python' in self.spec:
-            options.append('-DPYTHON_EXECUTABLE=%s/python' %
-                           self.spec['python'].prefix.bin)
+            options.append('-DPYTHON_EXECUTABLE=%s' %
+                           spec['python'].command.path
 
         return options
 

--- a/var/spack/repos/builtin/packages/xrootd/package.py
+++ b/var/spack/repos/builtin/packages/xrootd/package.py
@@ -76,6 +76,10 @@ class Xrootd(CMakePackage):
             format('ON' if '+readline' in spec else 'OFF'),
             '-DENABLE_CEPH:BOOL=OFF'
         ]
+        if '+python' in self.spec:
+	            options.append('-DPYTHON_EXECUTABLE=%s/python' %
+	                           self.spec['python'].prefix.bin)
+	        
         return options
 
     def setup_environment(self, spack_env, run_env):

--- a/var/spack/repos/builtin/packages/xrootd/package.py
+++ b/var/spack/repos/builtin/packages/xrootd/package.py
@@ -76,7 +76,7 @@ class Xrootd(CMakePackage):
             format('ON' if '+readline' in spec else 'OFF'),
             '-DENABLE_CEPH:BOOL=OFF'
         ]
-	# see https://github.com/spack/spack/pull/11581
+        # see https://github.com/spack/spack/pull/11581
         if '+python' in self.spec:
             options.append('-DPYTHON_EXECUTABLE=%s/python' %
                            self.spec['python'].prefix.bin)

--- a/var/spack/repos/builtin/packages/xrootd/package.py
+++ b/var/spack/repos/builtin/packages/xrootd/package.py
@@ -76,6 +76,7 @@ class Xrootd(CMakePackage):
             format('ON' if '+readline' in spec else 'OFF'),
             '-DENABLE_CEPH:BOOL=OFF'
         ]
+	# see https://github.com/spack/spack/pull/11581
         if '+python' in self.spec:
 	            options.append('-DPYTHON_EXECUTABLE=%s/python' %
 	                           self.spec['python'].prefix.bin)

--- a/var/spack/repos/builtin/packages/xrootd/package.py
+++ b/var/spack/repos/builtin/packages/xrootd/package.py
@@ -78,9 +78,9 @@ class Xrootd(CMakePackage):
         ]
 	# see https://github.com/spack/spack/pull/11581
         if '+python' in self.spec:
-	            options.append('-DPYTHON_EXECUTABLE=%s/python' %
-	                           self.spec['python'].prefix.bin)
-	        
+            options.append('-DPYTHON_EXECUTABLE=%s/python' %
+                           self.spec['python'].prefix.bin)
+
         return options
 
     def setup_environment(self, spack_env, run_env):


### PR DESCRIPTION
When building with python3 PYTHON_EXECUTABLE needs to be set for deprecated FindPythonInterp to work as expected.