### PR TITLE
Don't apply build-dependency constraints for installed packages

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2275,7 +2275,7 @@ class Spec(object):
 
         # if we descend into a virtual spec, there's nothing more
         # to normalize.  Concretize will finish resolving it later.
-        if self.virtual or self.external:
+        if self.virtual or self.external or self.concrete:
             return False
 
         # Combine constraints from package deps with constraints from

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2073,8 +2073,9 @@ class Spec(object):
 
             if not copy:
                 for spec in flat_deps.values():
-                    spec._dependencies.clear()
-                    spec._dependents.clear()
+                    if not spec.concrete:
+                        spec._dependencies.clear()
+                        spec._dependents.clear()
                 self._dependencies.clear()
 
             return flat_deps

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2282,6 +2282,11 @@ class Spec(object):
         # these may include build dependencies which are not needed for this
         # install (since this package is already installed).
         if self.concrete and self.package.installed:
+            # Mark all dependencies as visited: we may not visit them if we
+            # stop the recursive call here, and we know they are necessary
+            # since they are dependencies of the installed package (and that's
+            # what the visited datastructure is tracking).
+            visited.update(spec.name for spec in self.traverse())
             return False
 
         # Combine constraints from package deps with constraints from

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2282,11 +2282,6 @@ class Spec(object):
         # these may include build dependencies which are not needed for this
         # install (since this package is already installed).
         if self.concrete and self.package.installed:
-            # Mark all dependencies as visited: we may not visit them if we
-            # stop the recursive call here, and we know they are necessary
-            # since they are dependencies of the installed package (and that's
-            # what the visited datastructure is tracking).
-            visited.update(spec.name for spec in self.traverse())
             return False
 
         # Combine constraints from package deps with constraints from

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2055,7 +2055,11 @@ class Spec(object):
            without modifying the spec it's called on.
 
            If copy is False, clears this spec's dependencies and
-           returns them.
+           returns them. This disconnects all dependency links including
+           transitive dependencies, except for concrete specs: if a spec
+           is concrete it will not be disconnected from its dependencies
+           (although a non-concrete spec with concrete dependencies will
+           be disconnected from those dependencies).
         """
         copy = kwargs.get('copy', True)
 

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -145,7 +145,7 @@ def test_read_and_write_spec(
             read_separately = Spec.from_yaml(spec_file.read())
 
         # TODO: revise this when build deps are in dag_hash
-        norm = read_separately.normalized().copy(deps=stored_deptypes)
+        norm = read_separately.copy(deps=stored_deptypes)
         assert norm == spec_from_file
         assert norm.eq_dag(spec_from_file)
 

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -85,6 +85,11 @@ w->y deptypes are (link, build), w->x and y->z deptypes are (test)
 
 @pytest.mark.usefixtures('config')
 def test_installed_deps():
+    """Preinstall a package P with a constrained build dependency D, then
+    concretize a dependent package which also depends on P and D, specifying
+    that the installed instance of P should be used. In this case, D should
+    not be constrained by P since P is already built.
+    """
     default = ('build', 'link')
     build_only = ('build',)
 


### PR DESCRIPTION
See: https://github.com/spack/spack/issues/11542

The intent of this PR is that for a spec DAG like:

```
X->Y->Z (all link dependencies)
X->W->Z (W has a build dependency on Z)
```

that you can do something like

```
$ spack install w
$ spack install X ^/hash-of-installed-w
```

In this case, if Y and W have differing constraints on Z, this allows Y to build Z without using constraints from W (since W only needed Z to build).