### PR TITLE
Git: patch to make git relocatable with buildcache.

### DIFF
--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -219,6 +219,11 @@ class Git(AutotoolsPackage):
             spack_env.append_flags('CFLAGS', '-I{0}'.format(
                 self.spec['gettext'].prefix.include))
 
+        run_env.set('GIT_EXEC_PATH', '%s/git-core' % self.spec.prefix.libexec)
+        run_env.set('GIT_TEMPLATE_DIR', '%s/git-core/templates' % self.spec.prefix.share)
+        run_env.set('GIT_HOME', '%s' % self.spec.prefix)
+        run_env.set('GITPERLLIB', '%s/perl5' % self.spec.prefix.share)
+
     def configure_args(self):
         spec = self.spec
 

--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -220,7 +220,8 @@ class Git(AutotoolsPackage):
                 self.spec['gettext'].prefix.include))
 
         run_env.set('GIT_EXEC_PATH', '%s/git-core' % self.spec.prefix.libexec)
-        run_env.set('GIT_TEMPLATE_DIR', '%s/git-core/templates' % self.spec.prefix.share)
+        run_env.set('GIT_TEMPLATE_DIR', '%s/git-core/templates' %
+                     self.spec.prefix.share)
         run_env.set('GIT_HOME', '%s' % self.spec.prefix)
         run_env.set('GITPERLLIB', '%s/perl5' % self.spec.prefix.share)
 

--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -221,7 +221,7 @@ class Git(AutotoolsPackage):
 
         run_env.set('GIT_EXEC_PATH', '%s/git-core' % self.spec.prefix.libexec)
         run_env.set('GIT_TEMPLATE_DIR', '%s/git-core/templates' %
-                     self.spec.prefix.share)
+                    self.spec.prefix.share)
         run_env.set('GIT_HOME', '%s' % self.spec.prefix)
         run_env.set('GITPERLLIB', '%s/perl5' % self.spec.prefix.share)
 

--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -240,10 +240,10 @@ class Git(AutotoolsPackage):
 
     @run_after('configure')
     def make_opts(self):
-        self.build_targets=['NO_INSTALL_HARDLINKS=1',
+        self.build_targets = ['NO_INSTALL_HARDLINKS=1',
                             'ETC_GITATTRIBUTES=config',
                             'ETC_GITCONFIG=config']
-        self.install_targets=['NO_INSTALL_HARDLINKS=1',
+        self.install_targets = ['NO_INSTALL_HARDLINKS=1',
                               'ETC_GITATTRIBUTES=config',
                               'ETC_GITCONFIG=config',
                               'install']

--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -238,6 +238,16 @@ class Git(AutotoolsPackage):
             # Don't link with -lrt; the system has no (and needs no) librt
             filter_file(r' -lrt$', '', 'Makefile')
 
+    @run_after('configure')
+    def make_opts(self):
+        self.build_targets=['NO_INSTALL_HARDLINKS=1',
+                            'ETC_GITATTRIBUTES=config',
+                            'ETC_GITCONFIG=config']
+        self.install_targets=['NO_INSTALL_HARDLINKS=1',
+                              'ETC_GITATTRIBUTES=config',
+                              'ETC_GITCONFIG=config',
+                              'install']
+
     def check(self):
         make('test')
 

--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -185,6 +185,8 @@ class Git(AutotoolsPackage):
     depends_on('m4',       type='build')
     depends_on('tk',       type=('build', 'link'), when='+tcltk')
 
+    patch('patch/relocatable.patch',0)
+
     # See the comment in setup_environment re EXTLIBS.
     def patch(self):
         filter_file(r'^EXTLIBS =$',

--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -187,6 +187,14 @@ class Git(AutotoolsPackage):
 
     patch('patch/relocatable.patch', 0)
 
+    build_targets = ['NO_INSTALL_HARDLINKS=1',
+                     'ETC_GITATTRIBUTES=config',
+                     'ETC_GITCONFIG=config']
+    install_targets = ['NO_INSTALL_HARDLINKS=1',
+                       'ETC_GITATTRIBUTES=config',
+                       'ETC_GITCONFIG=config',
+                       'install']
+
     # See the comment in setup_environment re EXTLIBS.
     def patch(self):
         filter_file(r'^EXTLIBS =$',
@@ -237,16 +245,6 @@ class Git(AutotoolsPackage):
         if sys.platform == 'darwin':
             # Don't link with -lrt; the system has no (and needs no) librt
             filter_file(r' -lrt$', '', 'Makefile')
-
-    @run_after('configure')
-    def make_opts(self):
-        self.build_targets = ['NO_INSTALL_HARDLINKS=1',
-                            'ETC_GITATTRIBUTES=config',
-                            'ETC_GITCONFIG=config']
-        self.install_targets = ['NO_INSTALL_HARDLINKS=1',
-                              'ETC_GITATTRIBUTES=config',
-                              'ETC_GITCONFIG=config',
-                              'install']
 
     def check(self):
         make('test')

--- a/var/spack/repos/builtin/packages/git/patch/relocatable.patch
+++ b/var/spack/repos/builtin/packages/git/patch/relocatable.patch
@@ -1,0 +1,40 @@
+diff -Naur config.c config.c
+--- config.c	2015-07-15 14:31:07.000000000 -0500
++++ config.c	2015-07-17 10:33:34.966072446 -0500
+@@ -1153,7 +1153,15 @@
+ {
+ 	static const char *system_wide;
+ 	if (!system_wide)
+-		system_wide = system_path(ETC_GITCONFIG);
++		/* system_wide = system_path(ETC_GITCONFIG); */
++		system_wide = ETC_GITCONFIG;
++		if (!is_absolute_path(system_wide)) {
++			/* interpret path relative to exec-dir */
++			const char *exec_path = git_exec_path();
++			system_wide = prefix_path(exec_path, strlen(exec_path),
++						system_wide);
++		}
++
+ 	return system_wide;
+ }
+
+diff -Naur attr.c attr.c
+--- attr.c	2015-07-15 14:31:07.000000000 -0500
++++ attr.c	2015-07-17 10:33:34.966072446 -0500
+@@ -479,7 +479,15 @@
+ {
+ 	static const char *system_wide;
+ 	if (!system_wide)
+-		system_wide = system_path(ETC_GITATTRIBUTES);
++		/* system_wide = system_path(ETC_GITATTRIBUTES); */
++		system_wide = ETC_GITATTRIBUTES;
++		if (!is_absolute_path(system_wide)) {
++			/* interpret path relative to exec-dir */
++			const char *exec_path = git_exec_path();
++			system_wide = prefix_path(exec_path, strlen(exec_path),
++						system_wide);
++		}
++
+ 	return system_wide;
+ }
+ 

--- a/var/spack/repos/builtin/packages/git/patch/relocatable.patch
+++ b/var/spack/repos/builtin/packages/git/patch/relocatable.patch
@@ -1,3 +1,5 @@
+# Copied from  https://cdcvs.fnal.gov/redmine/projects/build-framework/repository/git-ssi-build/revisions/master/entry/patch/git.patch
+# curl -o relocatable.patch https://cdcvs.fnal.gov/redmine/projects/build-framework/repository/git-ssi-build/revisions/master/raw/patch/git.patch
 diff -Naur config.c config.c
 --- config.c	2015-07-15 14:31:07.000000000 -0500
 +++ config.c	2015-07-17 10:33:34.966072446 -0500


### PR DESCRIPTION
Apply patch to git to make it search for config files from its current install directory instead of the hard coded at install directory.