### PR TITLE
added tix package and python variant for tix

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -101,7 +101,7 @@ class Python(AutotoolsPackage):
     variant('ctypes',   default=True,  description='Build ctypes module')
     variant('tkinter',  default=False, description='Build tkinter module')
     variant('uuid',     default=False, description='Build uuid module')
-    variant('tix',      default=False, description='Build with Tix support')
+    variant('tix',      default=False, description='Build Tix module')
 
     depends_on('pkgconfig@0.9.0:', type='build')
 

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -141,6 +141,8 @@ class Python(AutotoolsPackage):
         when='+optimizations',
         msg='+optimizations is incompatible with +shared in python@2.X'
     )
+    conflicts('+tix', when='~tkinter',
+              msg='python+tix requires python+tix+tkinter')
 
     _DISTUTIL_VARS_TO_SAVE = ['LDSHARED']
     _DISTUTIL_CACHE_FILENAME = 'sysconfig.json'

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -101,6 +101,7 @@ class Python(AutotoolsPackage):
     variant('ctypes',   default=True,  description='Build ctypes module')
     variant('tkinter',  default=False, description='Build tkinter module')
     variant('uuid',     default=False, description='Build uuid module')
+    variant('tix',      default=False, description='Build with Tix support')
 
     depends_on('pkgconfig@0.9.0:', type='build')
 
@@ -120,6 +121,7 @@ class Python(AutotoolsPackage):
     depends_on('libffi', when='+ctypes')
     depends_on('tk', when='+tkinter')
     depends_on('tcl', when='+tkinter')
+    depends_on('tix', when='+tix')
     depends_on('libuuid', when='+uuid')
 
     patch('tkinter.patch', when='@:2.8,3.3: platform=darwin')

--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -25,7 +25,7 @@ class Tcl(AutotoolsPackage):
     version('8.6.5', '0e6426a4ca9401825fbc6ecf3d89a326')
     version('8.6.4', 'd7cbb91f1ded1919370a30edd1534304')
     version('8.6.3', 'db382feca91754b7f93da16dc4cdad1f')
-    version('8.5.19', '0e6426a4ca9401825fbc6ecf3d89a326')
+    version('8.5.19', '4f4e1c919f6a6dbb37e9a12d429769a6')
 
     extendable = True
 

--- a/var/spack/repos/builtin/packages/tix/package.py
+++ b/var/spack/repos/builtin/packages/tix/package.py
@@ -28,5 +28,5 @@ class Tix(AutotoolsPackage):
     def install(self, spec, prefix):
         make('install')
         with working_dir(self.prefix.lib):
-            symlink('Tix{0}/libTix{0}.so'.format(self.version),
-                    'libtix.so')
+            symlink('Tix{0}/libTix{0}.{1}'.format(self.version, dso_suffix),
+                    'libtix.{0}'.format(dso_suffix))

--- a/var/spack/repos/builtin/packages/tix/package.py
+++ b/var/spack/repos/builtin/packages/tix/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Tix(AutotoolsPackage):
+    """Tix is a powerful high-level widget set that expands the capabilities
+       of your Tk/Tcl and Python applications."""
+
+    homepage = "https://sourceforge.net/projects/tix/"
+    url      = "https://sourceforge.net/projects/tix/files/tix/8.4.3/Tix8.4.3-src.tar.gz/download"
+    version('8.4.3', '2b8bf4b10a852264678182652f477e59')
+
+    extends('tcl')
+    depends_on('tk@:8.5.99')
+    depends_on('tcl@:8.5.99')
+
+    def configure_args(self):
+        spec = self.spec
+        config_args = ['--with-tcl={0}'.format(spec['tcl'].prefix.lib),
+                       '--with-tk={0}'.format(spec['tk'].prefix.lib),
+                       '--exec-prefix={0}'.format(spec.prefix)]
+        return config_args
+
+    def install(self, spec, prefix):
+        make('install')
+        with working_dir(self.prefix.lib):
+            symlink('Tix{0}/libTix{0}.so'.format(self.version),
+                    'libtix.so')

--- a/var/spack/repos/builtin/packages/tk/package.py
+++ b/var/spack/repos/builtin/packages/tk/package.py
@@ -34,7 +34,7 @@ class Tk(AutotoolsPackage):
         with working_dir(self.build_directory):
             make('install')
 
-            # Some applications like Expect require private Tcl headers.
+            # Some applications like Expect require private Tk headers.
             make('install-private-headers')
 
             # Copy source to install tree

--- a/var/spack/repos/builtin/packages/tk/package.py
+++ b/var/spack/repos/builtin/packages/tk/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+import os
 
 
 class Tk(AutotoolsPackage):
@@ -20,13 +21,32 @@ class Tk(AutotoolsPackage):
     version('8.6.6', 'dd7dbb3a6523c42d05f6ab6e86096e99')
     version('8.6.5', '11dbbd425c3e0201f20d6a51482ce6c4')
     version('8.6.3', '85ca4dbf4dcc19777fd456f6ee5d0221')
+    version('8.5.19', 'e89df710447cce0fc0bde65667c12f85')
 
     extends('tcl')
 
-    depends_on('tcl@8.6:')
+    depends_on('tcl@8.6:', when='@8.6:')
     depends_on('libx11')
 
     configure_directory = 'unix'
+
+    def install(self, spec, prefix):
+        with working_dir(self.build_directory):
+            make('install')
+
+            # Some applications like Expect require private Tcl headers.
+            make('install-private-headers')
+
+            # Copy source to install tree
+            installed_src = join_path(
+                self.spec.prefix, 'share', self.name, 'src')
+            stage_src = os.path.realpath(self.stage.source_path)
+            install_tree(stage_src, installed_src)
+
+            # Replace stage dir -> installed src dir in tkConfig
+            filter_file(
+                stage_src, installed_src,
+                join_path(self.spec.prefix, 'lib', 'tkConfig.sh'))
 
     @property
     def libs(self):


### PR DESCRIPTION
Tix appears to be old, but a user at LLNL has requested it be supported in Python. It looks like Tix uses structures in tcl that were removed from tcl 8.6, hence the dependence on older versions. Because of this, I thought it would be best to make tix a variant in python that is not enabled by default, rather than forcing all python builds to use the older tcl/tk versions.