### PR TITLE
set GUILE env var when building gnutls

### DIFF
--- a/var/spack/repos/builtin/packages/gnutls/package.py
+++ b/var/spack/repos/builtin/packages/gnutls/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+import os
 
 
 class Gnutls(AutotoolsPackage):
@@ -44,6 +45,12 @@ class Gnutls(AutotoolsPackage):
     def url_for_version(self, version):
         url = "https://www.gnupg.org/ftp/gcrypt/gnutls/v{0}/gnutls-{1}.tar.xz"
         return url.format(version.up_to(2), version)
+
+    def setup_environment(self, build_env, run_env):
+        spec = self.spec
+        if '+guile' in spec:
+            build_env.set('GUILE', os.path.join(spec["guile"].prefix.bin,
+                                                'guile'))
 
     def configure_args(self):
         spec = self.spec


### PR DESCRIPTION
The gnutls configure script was picking up /usr/bin/guile2 instead of the spack-built guile executable. Setting GUILE in the environment forces the gnutls configure script to use the spack-built build executable.

fixes #11601 