### PR TITLE
Paraview:  Add motionfx variant

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -211,4 +211,11 @@ class Paraview(CMakePackage):
                 '-DGIT_EXECUTABLE=FALSE'
             ])
 
+        # A bug that has been found in vtk causes an error for 
+        # intel builds for version 5.6.  This should be revisited
+        # with later versions of Paraview to see if the issues still
+        # arises.
+        if '%intel' in spec and spec.version >= Version('5.6'):
+            cmake_args.append('-DPARAVIEW_ENABLE_MOTIONFX:BOOL=OFF')
+
         return cmake_args

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -211,7 +211,7 @@ class Paraview(CMakePackage):
                 '-DGIT_EXECUTABLE=FALSE'
             ])
 
-        # A bug that has been found in vtk causes an error for 
+        # A bug that has been found in vtk causes an error for
         # intel builds for version 5.6.  This should be revisited
         # with later versions of Paraview to see if the issues still
         # arises.

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -253,4 +253,7 @@ class Vtk(CMakePackage):
                 self.compiler.version >= Version('5.1.0')):
                 cmake_args.extend(['-DVTK_REQUIRED_OBJCXX_FLAGS=""'])
 
+            # A bug in tao pegtl causes build failures with intel compilers
+            if '%intel' in spec and spec.version >= Version('8.2'):
+                cmake_args.append('-DVTK_MODULE_ENABLE_VTK_IOMotionFX:BOOL=OFF')
         return cmake_args

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -255,5 +255,6 @@ class Vtk(CMakePackage):
 
             # A bug in tao pegtl causes build failures with intel compilers
             if '%intel' in spec and spec.version >= Version('8.2'):
-                cmake_args.append('-DVTK_MODULE_ENABLE_VTK_IOMotionFX:BOOL=OFF')
+                cmake_args.append(
+                    '-DVTK_MODULE_ENABLE_VTK_IOMotionFX:BOOL=OFF')
         return cmake_args


### PR DESCRIPTION
Paraview@5.6.0 fails to build with intel compilers on certain platforms.
Error messages have been traced to the optional MotionFX lib.
(see https://discourse.paraview.org/t/error-build-5-6-0-rc1/572)
Adding the motionfx variant allows for succesful builds on these platforms.