### PR TITLE
nettle: fix broken build

### DIFF
--- a/var/spack/repos/builtin/packages/nettle/package.py
+++ b/var/spack/repos/builtin/packages/nettle/package.py
@@ -22,3 +22,6 @@ class Nettle(AutotoolsPackage):
 
     depends_on('gmp')
     depends_on('m4', type='build')
+
+    def configure_args(self):
+        return ['CFLAGS=-std=c99']

--- a/var/spack/repos/builtin/packages/nettle/package.py
+++ b/var/spack/repos/builtin/packages/nettle/package.py
@@ -24,4 +24,4 @@ class Nettle(AutotoolsPackage):
     depends_on('m4', type='build')
 
     def configure_args(self):
-        return ['CFLAGS=-std=c99']
+        return ['CFLAGS={0}'.format(self.compiler.c99_flag)]


### PR DESCRIPTION
nettle's source uses some C99-specific language features which can break building on some systems.
This forces the compiler to build against the C99 standard.