### PR TITLE
Buildcache relocate.py error fix

### DIFF
--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -594,4 +594,6 @@ def mime_type(file):
     file_cmd = Executable('file')
     output = file_cmd('-b', '-h', '--mime-type', file, output=str, error=str)
     tty.debug('[MIME_TYPE] {0} -> {1}'.format(file, output.strip()))
+    if not '/' in output:
+        output +='/' 
     return tuple(output.strip().split('/'))

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -594,6 +594,6 @@ def mime_type(file):
     file_cmd = Executable('file')
     output = file_cmd('-b', '-h', '--mime-type', file, output=str, error=str)
     tty.debug('[MIME_TYPE] {0} -> {1}'.format(file, output.strip()))
-    if not '/' in output:
-        output +='/' 
+    if '/' not in output:
+        output += '/'
     return tuple(output.strip().split('/'))

--- a/var/spack/repos/builtin/packages/libxpm/package.py
+++ b/var/spack/repos/builtin/packages/libxpm/package.py
@@ -26,6 +26,6 @@ class Libxpm(AutotoolsPackage):
     depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
-    def setup_environment(self, spack_env, run_env):
-        spack_env.append_flags('LDFLAGS', '-L{0} -lintl'.format(
-            self.spec['gettext'].prefix.lib))
+#    def setup_environment(self, spack_env, run_env):
+#        spack_env.append_flags('LDFLAGS', '-L{0} -lintl'.format(
+#            self.spec['gettext'].prefix.lib))

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -501,12 +501,10 @@ class Root(CMakePackage):
                 self.spec['ftgl'].prefix))
             options.append('-DFTGL_INCLUDE_DIR={0}'.format(
                 self.spec['ftgl'].prefix.include))
-
         # see https://github.com/spack/spack/pull/11579
         if '+python' in self.spec:
             options.append('-DPYTHON_EXECUTABLE=%s' %
                            spec['python'].command.path)
-
         return options
 
     def setup_environment(self, spack_env, run_env):


### PR DESCRIPTION
Addresses  this error

> spack buildcache create -raf flecsi
---Lots of operations complete---
==> creating binary cache file for package cmake@3.14.2%gcc@7.4.0~doc+ncurses+openssl+ownlibs~qt arch=linux-centos7-x86_64 
==> Error: need more than 1 value to unpack