### PR TITLE
add C standard flags to compiler classes

### DIFF
--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -195,6 +195,24 @@ class Compiler(object):
                                       "the C++17 standard",
                                       "cxx17_flag")
 
+    # This property should be overridden in the compiler subclass if
+    # C99 is supported by that compiler
+    @property
+    def c99_flag(self):
+        # If it is not overridden, assume it is not supported and warn the user
+        raise UnsupportedCompilerFlag(self,
+                                      "the C99 standard",
+                                      "c99_flag")
+
+    # This property should be overridden in the compiler subclass if
+    # C11 is supported by that compiler
+    @property
+    def c11_flag(self):
+        # If it is not overridden, assume it is not supported and warn the user
+        raise UnsupportedCompilerFlag(self,
+                                      "the C11 standard",
+                                      "c11_flag")
+
     #
     # Compiler classes have methods for querying the version of
     # specific compiler executables.  This is used when discovering compilers.

--- a/lib/spack/spack/compilers/arm.py
+++ b/lib/spack/spack/compilers/arm.py
@@ -54,6 +54,14 @@ class Arm(spack.compiler.Compiler):
         return "-std=c++1z"
 
     @property
+    def c99_flag(self):
+        return "-std=c99"
+
+    @property
+    def c11_flag(self):
+        return "-std=c11"
+
+    @property
     def pic_flag(self):
         return "-fPIC"
 

--- a/lib/spack/spack/compilers/cce.py
+++ b/lib/spack/spack/compilers/cce.py
@@ -43,5 +43,9 @@ class Cce(spack.compiler.Compiler):
         return "-h std=c++11"
 
     @property
+    def c99_flag(self):
+        return "-h c99"
+
+    @property
     def pic_flag(self):
         return "-h PIC"

--- a/lib/spack/spack/compilers/clang.py
+++ b/lib/spack/spack/compilers/clang.py
@@ -158,6 +158,20 @@ class Clang(Compiler):
                 return "-std=c++17"
 
     @property
+    def c99_flag(self):
+        return '-std=c99'
+
+    @property
+    def c11_flag(self):
+        if self.version < ver('6.1.0'):
+            raise UnsupportedCompilerFlag(self,
+                                          "the C11 standard",
+                                          "c11_flag",
+                                          "< 3.3")
+        else:
+            return "-std=c11"
+
+    @property
     def pic_flag(self):
         return "-fPIC"
 

--- a/lib/spack/spack/compilers/gcc.py
+++ b/lib/spack/spack/compilers/gcc.py
@@ -88,6 +88,24 @@ class Gcc(Compiler):
             return "-std=c++17"
 
     @property
+    def c99_flag(self):
+        if self.version < ver('4.5'):
+            raise UnsupportedCompilerFlag(self,
+                                          "the C99 standard",
+                                          "c99_flag",
+                                          "< 4.5")
+        return "-std=c99"
+
+    @property
+    def c11_flag(self):
+        if self.version < ver('4.7'):
+            raise UnsupportedCompilerFlag(self,
+                                          "the C11 standard",
+                                          "c11_flag",
+                                          "< 4.7")
+        return "-std=c11"
+
+    @property
     def pic_flag(self):
         return "-fPIC"
 

--- a/lib/spack/spack/compilers/intel.py
+++ b/lib/spack/spack/compilers/intel.py
@@ -66,6 +66,26 @@ class Intel(Compiler):
             return "-std=c++14"
 
     @property
+    def c99_flag(self):
+        if self.version < ver('12'):
+            raise UnsupportedCompilerFlag(self,
+                                          "the C99 standard",
+                                          "c99_flag",
+                                          "< 12")
+        else:
+            return "-std=c99"
+
+    @property
+    def c11_flag(self):
+        if self.version < ver('16'):
+            raise UnsupportedCompilerFlag(self,
+                                          "the C11 standard",
+                                          "c11_flag",
+                                          "< 16")
+        else:
+            return "-std=c1x"
+
+    @property
     def pic_flag(self):
         return "-fPIC"
 

--- a/lib/spack/spack/compilers/xl.py
+++ b/lib/spack/spack/compilers/xl.py
@@ -44,6 +44,14 @@ class Xl(Compiler):
             return "-qlanglvl=extended0x"
 
     @property
+    def c99_flag(self):
+        return '-std=c99'
+
+    @property
+    def c11_flag(self):
+        return '-std=c11'
+
+    @property
     def pic_flag(self):
         return "-qpic"
 


### PR DESCRIPTION
This adds the `c99_flag` and `c11_flag` virtual methods to the compiler class, and implements it for most of the existing compilers.

This is a cleaner solution to the problem seen in #11611