### PR TITLE
fftw: change default value of simd variant for other than x86_64

### DIFF
--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -54,8 +54,9 @@ class Fftw(AutotoolsPackage):
 
     variant(
         'simd',
-        default='sse2,avx,avx2',
+        default='dfault',
         values=(
+            'default',
             'sse', 'sse2', 'avx', 'avx2', 'avx512',  # Intel
             'avx-128-fma', 'kcvi',  # Intel
             'altivec', 'vsx',  # IBM
@@ -149,6 +150,12 @@ class Fftw(AutotoolsPackage):
             options.append('--enable-mpi')
 
         # SIMD support
+        if 'default' in self.spec.variants['simd'].value:
+            if 'x86_64' in spec.architecture.target.lower():
+                self.spec.variants['simd'].value = 'sse2,avx,avx2'
+            else:
+                self.spec.variants['simd'].value = \
+                    'generic-simd128,generic-simd256'
         float_options, double_options = [], []
         if spec.satisfies('@3:', strict=True):
             for opts in (float_options, double_options):

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -54,9 +54,8 @@ class Fftw(AutotoolsPackage):
 
     variant(
         'simd',
-        default='dfault',
+        default='generic-simd128,generic-simd256',
         values=(
-            'default',
             'sse', 'sse2', 'avx', 'avx2', 'avx512',  # Intel
             'avx-128-fma', 'kcvi',  # Intel
             'altivec', 'vsx',  # IBM
@@ -150,12 +149,6 @@ class Fftw(AutotoolsPackage):
             options.append('--enable-mpi')
 
         # SIMD support
-        if 'default' in self.spec.variants['simd'].value:
-            if 'x86_64' in spec.architecture.target.lower():
-                self.spec.variants['simd'].value = 'sse2,avx,avx2'
-            else:
-                self.spec.variants['simd'].value = \
-                    'generic-simd128,generic-simd256'
         float_options, double_options = [], []
         if spec.satisfies('@3:', strict=True):
             for opts in (float_options, double_options):

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.spec import ConflictsInSpecError
 
 import llnl.util.lang
 # os is used for rename, etc in patch()
@@ -76,6 +77,60 @@ class Fftw(AutotoolsPackage):
 
     provides('fftw-api@2', when='@2.1.5')
     provides('fftw-api@3', when='@3:')
+
+    def flag_handler(self, name, flags):
+        spec = self.spec
+        arch = ""
+        simd_x86 = [
+            'sse', 'sse2', 'avx', 'avx2', 'avx512', 'avx-128-fma',
+            'kcvi'
+        ]
+        simd_ppc = ['altivec', 'vsx']
+        simd_arm = ['neon']
+
+        if (spec.satisfies("platform=cray")):
+            # FIXME; It is assumed that cray is x86_64.
+            # If you support arm on cray, you need to fix it.
+            arch  = "x86_64"
+        if (arch != "x86_64" and not spec.satisfies("target=x86_64")):
+            for s in simd_x86:
+                if (spec.satisfies("simd={0}".format(s))):
+                    raise ConflictsInSpecError(
+                        spec,
+                        [(
+                            spec,
+                            spec.architecture.target,
+                            spec.variants['simd'],
+                            'simd=sse,sse2,avx,avx2,avx-128-fma and kcvi'
+                            ' are valid only on x86_64'
+                        )]
+                    )
+        if (arch != "ppc64" and not spec.satisfies("target=ppc64") and
+                not spec.satisfies("target=power7")):
+            for s in simd_ppc:
+                if (spec.satisfies("simd={0}".format(s))):
+                    raise ConflictsInSpecError(
+                        spec,
+                        [(
+                            spec,
+                            spec.architecture.target,
+                            spec.variants['simd'],
+                            'simd=altvec and vsx are valid only on ppc64'
+                        )]
+                    )
+        if (arch != "aarch64" and not spec.satisfies("target=aarch64")):
+            for s in simd_arm:
+                if (spec.satisfies("simd={0}".format(s))):
+                    raise ConflictsInSpecError(
+                        spec,
+                        [(
+                            spec,
+                            spec.architecture.target,
+                            spec.variants['simd'],
+                            'simd=neon is valid only on aarch64'
+                        )]
+                    )
+        return (flags, None, None)
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -79,57 +79,39 @@ class Fftw(AutotoolsPackage):
     provides('fftw-api@3', when='@3:')
 
     def flag_handler(self, name, flags):
-        spec = self.spec
         arch = ""
-        simd_x86 = [
-            'sse', 'sse2', 'avx', 'avx2', 'avx512', 'avx-128-fma',
-            'kcvi'
-        ]
-        simd_ppc = ['altivec', 'vsx']
-        simd_arm = ['neon']
+        spec = self.spec
+        target_simds = {
+            ('x86_64',): ('sse', 'sse2', 'avx', 'avx2', 'avx512',
+                          'avx-128-fma', 'kcvi'),
+            ('ppc', 'ppc64le', 'power7'): ('altivec', 'vsx'),
+            ('aarch64',): ('neon',)
+        }
 
-        if (spec.satisfies("platform=cray")):
+        if spec.satisfies("platform=cray"):
             # FIXME; It is assumed that cray is x86_64.
             # If you support arm on cray, you need to fix it.
             arch  = "x86_64"
-        if (arch != "x86_64" and not spec.satisfies("target=x86_64")):
-            for s in simd_x86:
-                if (spec.satisfies("simd={0}".format(s))):
-                    raise ConflictsInSpecError(
-                        spec,
-                        [(
+
+        for targets, simds in target_simds.items():
+            if (
+                (not arch in targets)
+                and not any(
+                    spec.satisfies('target={0}'.format(t)) for t in targets)
+            ):
+                if any(spec.satisfies('simd={0}'.format(x)) for x in simds):
+                        raise ConflictsInSpecError(
                             spec,
-                            spec.architecture.target,
-                            spec.variants['simd'],
-                            'simd=sse,sse2,avx,avx2,avx-128-fma and kcvi'
-                            ' are valid only on x86_64'
-                        )]
-                    )
-        if (arch != "ppc64" and not spec.satisfies("target=ppc64") and
-                not spec.satisfies("target=power7")):
-            for s in simd_ppc:
-                if (spec.satisfies("simd={0}".format(s))):
-                    raise ConflictsInSpecError(
-                        spec,
-                        [(
-                            spec,
-                            spec.architecture.target,
-                            spec.variants['simd'],
-                            'simd=altvec and vsx are valid only on ppc64'
-                        )]
-                    )
-        if (arch != "aarch64" and not spec.satisfies("target=aarch64")):
-            for s in simd_arm:
-                if (spec.satisfies("simd={0}".format(s))):
-                    raise ConflictsInSpecError(
-                        spec,
-                        [(
-                            spec,
-                            spec.architecture.target,
-                            spec.variants['simd'],
-                            'simd=neon is valid only on aarch64'
-                        )]
-                    )
+                            [(
+                                spec,
+                                spec.architecture.target,
+                                spec.variants['simd'],
+                                'simd={0} are valid only on {1}'.format(
+                                    ','.join(target_simds[targets]),
+                                    ','.join(targets)
+                                )
+                            )]
+                        )
         return (flags, None, None)
 
     @property

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -85,7 +85,7 @@ class Fftw(AutotoolsPackage):
             ('x86_64',): ('sse', 'sse2', 'avx', 'avx2', 'avx512',
                           'avx-128-fma', 'kcvi'),
             ('ppc', 'ppc64le', 'power7'): ('altivec', 'vsx'),
-            ('aarch64',): ('neon',)
+            ('arm',): ('neon',)
         }
 
         if spec.satisfies("platform=cray"):
@@ -95,23 +95,23 @@ class Fftw(AutotoolsPackage):
 
         for targets, simds in target_simds.items():
             if (
-                (not arch in targets)
+                (arch not in targets)
                 and not any(
                     spec.satisfies('target={0}'.format(t)) for t in targets)
             ):
                 if any(spec.satisfies('simd={0}'.format(x)) for x in simds):
-                        raise ConflictsInSpecError(
+                    raise ConflictsInSpecError(
+                        spec,
+                        [(
                             spec,
-                            [(
-                                spec,
-                                spec.architecture.target,
-                                spec.variants['simd'],
-                                'simd={0} are valid only on {1}'.format(
-                                    ','.join(target_simds[targets]),
-                                    ','.join(targets)
-                                )
-                            )]
-                        )
+                            spec.architecture.target,
+                            spec.variants['simd'],
+                            'simd={0} are valid only on {1}'.format(
+                                ','.join(target_simds[targets]),
+                                ','.join(targets)
+                            )
+                        )]
+                    )
         return (flags, None, None)
 
     @property


### PR DESCRIPTION
Currently, default value of simd variant is dependent to x86_64 architecture.
And if we execute `spack install fftw` on other than x86_64, the command is failed.

This patch change defaul value to 'default', and the value is determined to configure().