### PR TITLE
ninja{-fortran}: make pkgs nonvirtual (fix #11628)

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -36,8 +36,6 @@ packages:
       mpe: [mpe2]
       mpi: [openmpi, mpich]
       mysql-client: [mysql, mariadb-c-client]
-      ninja: [ninja, ninja-fortran]
-      ninja-fortran: [ninja-fortran, ninja@kitware]
       opencl: [pocl]
       openfoam: [openfoam-com, openfoam-org, foam-extend]
       pil: [py-pillow]

--- a/var/spack/repos/builtin/packages/ninja-fortran/package.py
+++ b/var/spack/repos/builtin/packages/ninja-fortran/package.py
@@ -27,8 +27,6 @@ class NinjaFortran(Package):
 
     depends_on('python', type='build')
 
-    provides('ninja')
-
     phases = ['configure', 'install']
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/ninja/package.py
+++ b/var/spack/repos/builtin/packages/ninja/package.py
@@ -24,8 +24,6 @@ class Ninja(Package):
 
     depends_on('python', type='build')
 
-    provides('ninja-fortran', when='@kitware')
-
     phases = ['configure', 'install']
 
     def configure(self, spec, prefix):


### PR DESCRIPTION
Temporary fix to #11628.

I think a more permanent fix would be something along the lines of:
- write at least one virtual package, call the 1st one `ninja-build`
- if it's possible, give `ninja-build` a `+fortran` variant, if not, have a 2nd virtual package called `ninja-build-fortran`
- have `ninja` and `ninja-fortran` provide the appropriate virtual packages