### PR TITLE
[vim] Add sys_vimrc_file variant

### DIFF
--- a/var/spack/repos/builtin/packages/vim/package.py
+++ b/var/spack/repos/builtin/packages/vim/package.py
@@ -57,6 +57,9 @@ class Vim(AutotoolsPackage):
 
     depends_on('ncurses', when="@7.4:")
 
+    variant('sys_vimrc_file', default='none',
+            description='Name of the system-wide .vimrc file', multi=False)
+
     def configure_args(self):
         spec = self.spec
         feature_set = None
@@ -123,6 +126,17 @@ class Vim(AutotoolsPackage):
             configure_args.append("--enable-cscope")
 
         return configure_args
+
+    @run_before('configure')
+    def select_features(self):
+        """ Modify the build by editing a header file containing
+            defines for optional code and preferences. """
+        featurefile = FileFilter("src/feature.h")
+        sys_vimrc_file = self.spec.variants['sys_vimrc_file'].value
+        if sys_vimrc_file != 'none':
+            featurefile.filter('/\* #define SYS_VIMRC_FILE	"/etc/vimrc" \*/',
+                               '#define SYS_VIMRC_FILE	"{}"'
+                               .format(sys_vimrc_file))
 
     # Tests must be run in serial
     def check(self):


### PR DESCRIPTION
The vim source distribution has a file `src/feature.h` that users can edit to set defines for optional code and preferences. This PR adds a variant which triggers an edit of said file prior to running `make`.

This allowed me to run `spack install sys_vimrc_file=/etc/vimrc` which causes the system vimrc file in the vim installation to be set to `/etc/vimrc`, as confirmed by running `:version` inside of `vim` to observe

`
   system vimrc file: "/etc/vimrc"
`

which differs from a vanilla `vim` install in which

`
   system vimrc file: "$VIM/vimrc"
`

NOTE: I'm not sure this is the best way to connect package variants and header file edits, so if there is a better pattern to accomplish this, please let me know! @becker33 may know a better way.