### PR TITLE
adding perl dependency to json-c

### DIFF
--- a/var/spack/repos/builtin/packages/json-c/package.py
+++ b/var/spack/repos/builtin/packages/json-c/package.py
@@ -16,7 +16,7 @@ class JsonC(AutotoolsPackage):
     version('0.11',   'aa02367d2f7a830bf1e3376f77881e98')
 
     depends_on('autoconf', type='build')
-    depends_on('perl@5.16.3')
+    depends_on('perl@5.16.3:')
 
     parallel = False
 

--- a/var/spack/repos/builtin/packages/json-c/package.py
+++ b/var/spack/repos/builtin/packages/json-c/package.py
@@ -16,6 +16,7 @@ class JsonC(AutotoolsPackage):
     version('0.11',   'aa02367d2f7a830bf1e3376f77881e98')
 
     depends_on('autoconf', type='build')
+    depends_on('perl@5.16.3')
 
     parallel = False
 


### PR DESCRIPTION
This will address a small error that the default perl is too old to support json-c. If the user hasn't installed anything with perl recently, it will trigger an error. The error was reported in #11613 which is closed, but the issue remains with the json-c package. The user fixed by installing 2.28, but I chose the earliest version of perl with a hash provided here. @ziya reported other issues with installing packages that depend on a newer version of perl, and (although he didn't share) these should also be looked into.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>