### PR TITLE
clang: fix some error messages for C/C++ flags

### DIFF
--- a/lib/spack/spack/compilers/clang.py
+++ b/lib/spack/spack/compilers/clang.py
@@ -151,7 +151,7 @@ class Clang(Compiler):
                 raise UnsupportedCompilerFlag(self,
                                               "the C++17 standard",
                                               "cxx17_flag",
-                                              "< 5.0")
+                                              "< 3.5")
             elif self.version < ver('5.0'):
                 return "-std=c++1z"
             else:
@@ -167,7 +167,7 @@ class Clang(Compiler):
             raise UnsupportedCompilerFlag(self,
                                           "the C11 standard",
                                           "c11_flag",
-                                          "< 3.3")
+                                          "< 6.1.0")
         else:
             return "-std=c11"
 


### PR DESCRIPTION
A small follow up fix for #11618, cleaning up error messages caught [here](https://github.com/spack/spack/pull/11618#discussion_r290839260)