### PR TITLE
Package sanity tests need to be able to find packages in repos other

### DIFF
--- a/lib/spack/spack/test/package_sanity.py
+++ b/lib/spack/spack/test/package_sanity.py
@@ -75,8 +75,7 @@ def test_no_fixme():
         r'example.com',
     ]
     for name in spack.repo.all_package_names():
-        repo = spack.repo.Repo(spack.paths.packages_path)
-        filename = repo.filename_for_package_name(name)
+        filename = spack.repo.path.filename_for_package_name(name)
         with open(filename, 'r') as package_file:
             for i, line in enumerate(package_file):
                 pattern = next((r for r in fixme_regexes


### PR DESCRIPTION
than the builtin repo.