### PR TITLE
docs: add example for an external module in packages.yaml

### DIFF
--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -66,8 +66,18 @@ This example lists three installations of OpenMPI, one built with GCC,
 one built with GCC and debug information, and another built with Intel.
 If Spack is asked to build a package that uses one of these MPIs as a
 dependency, it will use the pre-installed OpenMPI in
-the given directory. ``packages.yaml`` can also be used to specify modules
-to load instead of the installation prefixes.
+the given directory. Note that the specified path is the top-level
+install prefix, not the ``bin`` subdirectory.
+
+``packages.yaml`` can also be used to specify modules to load instead
+of the installation prefixes.  The following example says that module
+``CMake/3.7.2`` provides cmake version 3.7.2.
+
+.. code-block:: yaml
+
+   cmake:
+     modules:
+       cmake@3.7.2: CMake/3.7.2
 
 Each ``packages.yaml`` begins with a ``packages:`` token, followed
 by a list of package names.  To specify externals, add a ``paths`` or ``modules``


### PR DESCRIPTION
Add an example of a 'modules:' entry for an external package in
packages.yaml.  The 'External Packages' section of 'Build
Customization' mentions 'paths:' and 'modules:' and gives an
example of paths, but not modules.

----------

I was showing someone how to set up a `packages.yaml` file for an
external (not spack built) module and I told him, "Look, it's right
here in the docs."  Except it wasn't, so ....

Also, when I first tried this, I was confused about the correct
directory for paths.  Cmake was in `/usr/bin/cmake`, so my first try
was `/usr/bin`, which is not correct.  So, I added one sentence for
that.