### PR TITLE
watch: new package

### DIFF
--- a/var/spack/repos/builtin/packages/package.py
+++ b/var/spack/repos/builtin/packages/package.py
@@ -1,0 +1,38 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Watch(Package):
+    """Executes a program periodically, showing output fullscreen."""
+
+    homepage = "https://gitlab.com/procps-ng/procps"
+    url      = "https://gitlab.com/procps-ng/procps/-/archive/v3.3.15/procps-v3.3.15.tar.bz2"
+    git      = "https://gitlab.com/procps-ng/procps.git"
+
+    version('3.3.15', sha256='191391fde24a1d3b9b0030d26f8dfdcbf641d36297aab7ecf2f941c5ca927e21')
+
+    depends_on('autoconf',     type='build')
+    depends_on('automake',     type='build')
+    depends_on('libtool',      type='build')
+    depends_on('pkgconfig',    type='build')
+    depends_on('xz',           type='build')
+
+    depends_on('gettext')
+
+    phases = ['autogen', 'install']
+
+    def autogen(self, spec, prefix):
+        autogen = Executable('./autogen.sh')
+        autogen('-fiv')
+
+    def install(self, spec, prefix):
+        configure('--disable-dependency-tracking',
+                  '--disable-nls',
+                  '--prefix=%s' % self.spec.prefix)
+        make('watch')
+        mkdir(prefix.bin)
+        install('watch', prefix.bin)

--- a/var/spack/repos/builtin/packages/watch/package.py
+++ b/var/spack/repos/builtin/packages/watch/package.py
@@ -32,6 +32,5 @@ class Watch(AutotoolsPackage):
         ]
 
     def install(self, spec, prefix):
-        make('watch')
         mkdir(prefix.bin)
-        install('watch', prefix)
+        install('watch', prefix.bin)

--- a/var/spack/repos/builtin/packages/watch/package.py
+++ b/var/spack/repos/builtin/packages/watch/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class Watch(Package):
+class Watch(AutotoolsPackage):
     """Executes a program periodically, showing output fullscreen."""
 
     homepage = "https://gitlab.com/procps-ng/procps"
@@ -23,16 +23,15 @@ class Watch(Package):
 
     depends_on('gettext')
 
-    phases = ['autogen', 'install']
+    build_targets = ['watch']
 
-    def autogen(self, spec, prefix):
-        autogen = Executable('./autogen.sh')
-        autogen('-fiv')
+    def configure_args(self):
+        return [
+            '--disable-dependency-tracking',
+            '--disable-nls'
+        ]
 
     def install(self, spec, prefix):
-        configure('--disable-dependency-tracking',
-                  '--disable-nls',
-                  '--prefix=%s' % self.spec.prefix)
         make('watch')
         mkdir(prefix.bin)
-        install('watch', prefix.bin)
+        install('watch', prefix)


### PR DESCRIPTION
This PR adds the `watch` package, which is popular on Unix systems for repeating commands on interval.