### PR TITLE
Add latest releases for pFUnit

### DIFF
--- a/var/spack/repos/builtin/packages/pfunit/package.py
+++ b/var/spack/repos/builtin/packages/pfunit/package.py
@@ -17,6 +17,7 @@ class Pfunit(CMakePackage):
 
     maintainers = ['citibeth']
 
+    # Currently investigating build fails for v 4.0.0. See discussion in PR #11642.
     # version('4.0.0',  sha256='b8b6470f2b1e2b19c164c244c10e803bd69c8da9a6a5a65ba7c479fb8b92a1e1')
     version('3.3.3',  sha256='9f673b58d20ad23148040a100227b4f876458a9d9aee0f0d84a5f0eef209ced5')
     version('3.3.2',  sha256='b1cc2e109ba602ea71bccefaa3c4a06e7ab1330db9ce6c08db89cfde497b8ab8')

--- a/var/spack/repos/builtin/packages/pfunit/package.py
+++ b/var/spack/repos/builtin/packages/pfunit/package.py
@@ -17,8 +17,9 @@ class Pfunit(CMakePackage):
 
     maintainers = ['citibeth']
 
-    # Currently investigating build fails for v 4.0.0. See discussion in PR #11642.
-    # version('4.0.0',  sha256='b8b6470f2b1e2b19c164c244c10e803bd69c8da9a6a5a65ba7c479fb8b92a1e1')
+    # Currently investigating build fails for v 4.0.0. 
+    # See discussion in PR #11642.
+    # version('4.0.0',  sha256='b8b6470f2b1e2b19c164c244c10e803bd69c8da9a6a5a65ba7c479fb8b92a1e1') # noqa: E501
     version('3.3.3',  sha256='9f673b58d20ad23148040a100227b4f876458a9d9aee0f0d84a5f0eef209ced5')
     version('3.3.2',  sha256='b1cc2e109ba602ea71bccefaa3c4a06e7ab1330db9ce6c08db89cfde497b8ab8')
     version('3.3.1',  sha256='f8f4bea7de991a518a0371b4c70b19e492aa9a0d3e6715eff9437f420b0cdb45')

--- a/var/spack/repos/builtin/packages/pfunit/package.py
+++ b/var/spack/repos/builtin/packages/pfunit/package.py
@@ -17,7 +17,13 @@ class Pfunit(CMakePackage):
 
     maintainers = ['citibeth']
 
-    version('3.2.9', 'e13d8362284b13b7c863e2fe769a9d5c')
+    # version('4.0.0',  sha256='b8b6470f2b1e2b19c164c244c10e803bd69c8da9a6a5a65ba7c479fb8b92a1e1')
+    version('3.3.3',  sha256='9f673b58d20ad23148040a100227b4f876458a9d9aee0f0d84a5f0eef209ced5')
+    version('3.3.2',  sha256='b1cc2e109ba602ea71bccefaa3c4a06e7ab1330db9ce6c08db89cfde497b8ab8')
+    version('3.3.1',  sha256='f8f4bea7de991a518a0371b4c70b19e492aa9a0d3e6715eff9437f420b0cdb45')
+    version('3.3.0',  sha256='4036ab448b821b500fbe8be5e3d5ab3e419ebae8be82f7703bcf84ab1a0ff862')
+    version('3.2.10', sha256='b9debba6d0e31b682423ffa756531e9728c10acde08c4d8e1609b4554f552b1a')
+    version('3.2.9',  sha256='403f9a150865700c8b4240fd033162b8d3e8aeefa265c50c5a6fe14c455fbabc')
 
     variant('shared', default=True,
             description='Build shared library in addition to static')

--- a/var/spack/repos/builtin/packages/pfunit/package.py
+++ b/var/spack/repos/builtin/packages/pfunit/package.py
@@ -17,7 +17,7 @@ class Pfunit(CMakePackage):
 
     maintainers = ['citibeth']
 
-    # Currently investigating build fails for v 4.0.0. 
+    # Currently investigating build fails for v 4.0.0.
     # See discussion in PR #11642.
     # version('4.0.0',  sha256='b8b6470f2b1e2b19c164c244c10e803bd69c8da9a6a5a65ba7c479fb8b92a1e1') # noqa: E501
     version('3.3.3',  sha256='9f673b58d20ad23148040a100227b4f876458a9d9aee0f0d84a5f0eef209ced5')


### PR DESCRIPTION

[spack-fail-pfunit-4.0.0.txt](https://github.com/spack/spack/files/3259874/spack-fail-pfunit-4.0.0.txt)
  - 3.2.10, 3.3.0, 3.3.1, 3.3.2, 3.3.3
  - 3.2.9 now with sha256
  - 4.0.0 is added, but commented out (build fails, see errors)

Verification builds

Darwin x86_64:
dantopa@cn100:pr-pfunit-darwin-general.spack $ spack find pfunit
==> 5 installed packages
-- linux-centos7-x86_64 / gcc@4.8.5 -----------------------------
pfunit@3.2.9  pfunit@3.2.10  pfunit@3.3.0  pfunit@3.3.1  pfunit@3.3.2  pfunit@3.3.3

Darwin Power9:
-- linux-rhel7-ppc64le / gcc@4.8.5 ------------------------------
pfunit@3.2.9  pfunit@3.2.10  pfunit@3.3.0  pfunit@3.3.1  pfunit@3.3.2  pfunit@3.3.3

Darwin ARM:
dantopa@cn805:pr-pfunit-darwin-arm.spack $ spack find pfunit
==> 5 installed packages
-- linux-rhel7-aarch64 / gcc@4.8.5 ------------------------------
pfunit@3.2.9  pfunit@3.2.10  pfunit@3.3.0  pfunit@3.3.1  pfunit@3.3.2  pfunit@3.3.3

2019-05-05

Signed-off-by: Daniel Topa <dantopa@lanl.gov>