### PR TITLE
bugfix: StageComposite must include the `expanded` property`

### DIFF
--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -577,6 +577,10 @@ class StageComposite:
         return self[0].source_path
 
     @property
+    def expanded(self):
+        return self[0].expanded
+
+    @property
     def path(self):
         return self[0].path
 


### PR DESCRIPTION
After #11528, `spack cd` would fail like this in `spack location` because the `StageComposite` object didn't have all the necessary properties:

```console
(spackbook):~$ spack cd lua-luafilesystem
==> Error: 'StageComposite' object has no attribute 'expanded'
```

Added the new `expanded` property to it.