### PR TITLE
bugfix: lua-luafilesystem package should use stage.source_path

### DIFF
--- a/var/spack/repos/builtin/packages/lua-luafilesystem/package.py
+++ b/var/spack/repos/builtin/packages/lua-luafilesystem/package.py
@@ -36,8 +36,7 @@ class LuaLuafilesystem(Package):
         semver = version[0:3]
         tweak_level = version[3] if len(version) > 3 else 1
         fmt = os.path.join(
-            self.stage.path,
-            'luafilesystem-{version.underscored}',
+            self.stage.source_path,
             'rockspecs',
             'luafilesystem-{semver.dotted}-{tweak_level}.rockspec'
         )


### PR DESCRIPTION
Fixes #11645.
@odoublewen 

After #11528, we use `$stage_dir/src` as the path for all expanded tarballs, so that the expanded path is *known* in advance. This helps client code that needs to know the checked out source path before fetching and expanding the source.

Some builds seem to assume they know `stage.source_path` and construct it themselves.  e.g, `lua-luafilesystem` was doing this:

```python
fmt = os.path.join(
    self.stage.path,
    'luafilesystem-{version.underscored}',
    'rockspecs',
    'luafilesystem-{semver.dotted}-{tweak_level}.rockspec'
)
```

It assumes the name of the directory under stage is `'luafilesystem-{version.underscored}'`.  Code like this should use `stage.source_path` instead of joining `stage.path` with an assumed name.

Here is the fix:

```python
fmt = os.path.join(
    self.stage.source_path,
    'rockspecs',
    'luafilesystem-{semver.dotted}-{tweak_level}.rockspec'
)
```
