### PR TITLE
spack list: format version_json

### DIFF
--- a/lib/spack/spack/test/cmd/list.py
+++ b/lib/spack/spack/test/cmd/list.py
@@ -45,6 +45,15 @@ def test_list_format_name_only():
 
 
 @pytest.mark.maybeslow
+def test_list_format_version_json():
+    output = list('--format', 'version_json')
+    assert '  {"name": "cloverleaf3d",' in output
+    assert '  {"name": "hdf5",' in output
+    import json
+    json.loads(output)
+
+
+@pytest.mark.maybeslow
 def test_list_format_html():
     output = list('--format', 'html')
     assert '<div class="section" id="cloverleaf3d">' in output

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -9,7 +9,7 @@ where it makes sense.
 """
 import pytest
 
-from spack.version import Version, ver
+from spack.version import Version, VersionList, ver
 
 
 def assert_ver_lt(a, b):
@@ -548,3 +548,15 @@ def test_get_item():
     # Raise TypeError on tuples
     with pytest.raises(TypeError):
         b.__getitem__(1, 2)
+
+
+def test_list_highest():
+    vl = VersionList(['master', '1.2.3', 'develop', '3.4.5', 'foobar'])
+    assert vl.highest() == Version('develop')
+    assert vl.lowest() == Version('foobar')
+    assert vl.highest_numeric() == Version('3.4.5')
+
+    vl2 = VersionList(['master', 'develop'])
+    assert vl2.highest_numeric() is None
+    assert vl2.preferred() == Version('develop')
+    assert vl2.lowest() == Version('master')

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -643,6 +643,23 @@ class VersionList(object):
         else:
             return self[-1].highest()
 
+    def highest_numeric(self):
+        """Get the highest numeric version in the list."""
+        numeric_versions = list(filter(
+            lambda v: str(v) not in infinity_versions,
+            self.versions))
+        if not any(numeric_versions):
+            return None
+        else:
+            return numeric_versions[-1].highest()
+
+    def preferred(self):
+        """Get the preferred (latest) version in the list."""
+        latest = self.highest_numeric()
+        if latest is None:
+            latest = self.highest()
+        return latest
+
     @coerced
     def overlaps(self, other):
         if not other or not self:


### PR DESCRIPTION
List the latest version of each package in JSON encoding.
Preparation for consumption for a "spack badge" service.

```command
spack list --format version_json
```
```json
[
  {"...": "..."},
  {"name": "adios2",
   "latest_version": "2.3.1",
   "versions": ["develop", "2.3.1", "2.2.0", "2.1.0", "2.0.0"],
   "homepage": "https://www.olcf.ornl.gov/center-projects/adios/",
   "file": "https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/adios2/package.py",
   "maintainers": ["ax3l", "chuckatkins"],
   "dependencies": {"build": ["cmake", "pkgconfig", "mpi", "zeromq", "hdf5", "adios", "bzip2", "zfp", "python", "py-numpy", "py-mpi4py"], "link": ["mpi", "zeromq", "hdf5", "adios", "bzip2", "zfp", "python"], "run": ["python", "py-numpy", "py-mpi4py"], "test": []}},
  {"...": "..."},
  {"name": "zsh",
   "latest_version": "5.4.2",
   "versions": ["5.4.2", "5.3.1", "5.1.1"],
   "homepage": "http://www.zsh.org",
   "file": "https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/zsh/package.py",
   "maintainers": [],
   "dependencies": {"build": ["pcre", "ncurses"], "link": ["pcre", "ncurses"], "run": [], "test": []}},
  {"name": "zstd",
   "latest_version": "1.4.0",
   "versions": ["1.4.0", "1.3.8", "1.3.0", "1.1.2"],
   "homepage": "http://facebook.github.io/zstd/",
   "file": "https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/zstd/package.py",
   "maintainers": [],
   "dependencies": {"build": [], "link": [], "run": [], "test": []}}
]
```

Generating a package index suitable for RESTful consumption in a static HTML service:
```bash
base_dir=$(pwd)/packages/
for pkg in $(spack list --format version_json | jq -c '.[]')
do
    name="$(echo ${pkg} | jq -r '.name')";
    first_letter=${name::1}
    mkdir -p ${base_dir}${first_letter}/
    echo ${pkg} > ${base_dir}${first_letter}/${name}.json
done
````

```
$ tree packages
packages/
├── a
│   ├── abinit.json
│   ├── abyss.json
│   ├── accfft.json
│   ├── ack.json
│   ├── activeharmony.json
│   ├── acts-core.json
│   ├── adept-utils.json
│   ├── adios2.json
│   ├── adios.json
...
├── y
│   ├── yajl.json
│   ├── yambo.json
│   ├── yaml-cpp.json
│   ├── yara.json
│   ├── yasm.json
│   └── yorick.json
└── z
    ├── z3.json
    ├── zeromq.json
    ├── zfp.json
    ├── zip.json
    ├── zlib.json
    ├── zoltan.json
    ├── zsh.json
    └── zstd.json

$ du -hs packages/                                                                                                       (topic-
13M	packages/
$ tree packages/ | wc -l                                                                                                     (topic-
3260
```