### PR TITLE
patch opa-psm2 to correct installation prefixes

### DIFF
--- a/var/spack/repos/builtin/packages/opa-psm2/opa-psm2-install-prefix.patch
+++ b/var/spack/repos/builtin/packages/opa-psm2/opa-psm2-install-prefix.patch
@@ -1,0 +1,78 @@
+diff -Naupr opa-psm2-PSM2_11.2.68/Makefile opa-psm2-PSM2_11.2.68-pathfix/Makefile
+--- opa-psm2-PSM2_11.2.68/Makefile	2018-09-27 19:48:03.000000000 -0400
++++ opa-psm2-PSM2_11.2.68-pathfix/Makefile	2019-06-07 11:34:37.658270976 -0400
+@@ -135,9 +135,9 @@ endif
+ 
+ ifndef LIBDIR
+    ifeq (${arch},x86_64)
+-      INSTALL_LIB_TARG=/usr/lib64
++      INSTALL_LIB_TARG=/lib64
+    else
+-      INSTALL_LIB_TARG=/usr/lib
++      INSTALL_LIB_TARG=/lib
+    endif
+ else
+    INSTALL_LIB_TARG=${LIBDIR}
+@@ -177,7 +177,7 @@ UDEV_40_PSM_RULES := %{_udevrulesdir}/40
+ 
+ ifeq (fedora,$(DISTRO))
+ 	# On Fedora, we change these two variables to these values:
+-	LIBPSM2_COMPAT_CONF_DIR := /usr/lib
++	LIBPSM2_COMPAT_CONF_DIR := /lib
+ 	LIBPSM2_COMPAT_SYM_CONF_DIR := %{_prefix}/lib
+ 	SPEC_FILE_RELEASE_DIST := %{?dist}
+ 	UDEV_40_PSM_RULES :=#
+@@ -411,20 +411,20 @@ install: all
+ 		ln -sf ${TARGLIB}.so.${MAJOR} ${TARGLIB}.so)
+ 	install -D $(OUTDIR)/${TARGLIB}.a \
+ 		${DESTDIR}${INSTALL_LIB_TARG}/${TARGLIB}.a
+-	install -m 0644 -D psm2.h ${DESTDIR}/usr/include/psm2.h
+-	install -m 0644 -D psm2_mq.h ${DESTDIR}/usr/include/psm2_mq.h
+-	install -m 0644 -D psm2_am.h ${DESTDIR}/usr/include/psm2_am.h
++	install -m 0644 -D psm2.h ${DESTDIR}/include/psm2.h
++	install -m 0644 -D psm2_mq.h ${DESTDIR}/include/psm2_mq.h
++	install -m 0644 -D psm2_am.h ${DESTDIR}/include/psm2_am.h
+ ifneq (fedora,${DISTRO})
+ 	install -m 0644 -D 40-psm.rules ${DESTDIR}$(UDEVDIR)/rules.d/40-psm.rules
+ endif
+ 	# The following files and dirs were part of the noship rpm:
+-	mkdir -p ${DESTDIR}/usr/include/hfi1diag
+-	mkdir -p ${DESTDIR}/usr/include/hfi1diag/linux-x86_64
+-	install -m 0644 -D include/linux-x86_64/bit_ops.h ${DESTDIR}/usr/include/hfi1diag/linux-x86_64/bit_ops.h
+-	install -m 0644 -D include/linux-x86_64/sysdep.h ${DESTDIR}/usr/include/hfi1diag/linux-x86_64/sysdep.h
+-	install -m 0644 -D include/opa_udebug.h ${DESTDIR}/usr/include/hfi1diag/opa_udebug.h
+-	install -m 0644 -D include/opa_debug.h ${DESTDIR}/usr/include/hfi1diag/opa_debug.h
+-	install -m 0644 -D include/opa_intf.h ${DESTDIR}/usr/include/hfi1diag/opa_intf.h
++	mkdir -p ${DESTDIR}/include/hfi1diag
++	mkdir -p ${DESTDIR}/include/hfi1diag/linux-x86_64
++	install -m 0644 -D include/linux-x86_64/bit_ops.h ${DESTDIR}/include/hfi1diag/linux-x86_64/bit_ops.h
++	install -m 0644 -D include/linux-x86_64/sysdep.h ${DESTDIR}/include/hfi1diag/linux-x86_64/sysdep.h
++	install -m 0644 -D include/opa_udebug.h ${DESTDIR}/include/hfi1diag/opa_udebug.h
++	install -m 0644 -D include/opa_debug.h ${DESTDIR}/include/hfi1diag/opa_debug.h
++	install -m 0644 -D include/opa_intf.h ${DESTDIR}/include/hfi1diag/opa_intf.h
+ 	for h in opa_user_gen1.h opa_service_gen1.h opa_common_gen1.h ; do \
+ 		sed -e 's/#include "opa_user_gen1.h"/#include "opa_user.h"/' \
+ 			-e 's/#include "opa_common_gen1.h"/#include "opa_common.h"/' \
+@@ -434,14 +434,14 @@ endif
+ 	done
+ 	cat include/opa_user.h    $(TEMP_INST_DIR)/opa_user_gen1.h  > $(TEMP_INST_DIR)/opa_user.h
+ 	cat include/opa_service.h $(TEMP_INST_DIR)/opa_service_gen1.h > $(TEMP_INST_DIR)/opa_service.h
+-	install -m 0644 -D $(TEMP_INST_DIR)/opa_user.h    ${DESTDIR}/usr/include/hfi1diag/opa_user.h
+-	install -m 0644 -D $(TEMP_INST_DIR)/opa_service.h ${DESTDIR}/usr/include/hfi1diag/opa_service.h
+-	install -m 0644 -D $(TEMP_INST_DIR)/opa_common_gen1.h ${DESTDIR}/usr/include/hfi1diag/opa_common.h
+-	install -m 0644 -D include/opa_byteorder.h ${DESTDIR}/usr/include/hfi1diag/opa_byteorder.h
+-	install -m 0644 -D include/psm2_mock_testing.h ${DESTDIR}/usr/include/hfi1diag/psm2_mock_testing.h
+-	install -m 0644 -D include/opa_revision.h ${DESTDIR}/usr/include/hfi1diag/opa_revision.h
+-	install -m 0644 -D psmi_wrappers.h ${DESTDIR}/usr/include/hfi1diag/psmi_wrappers.h
+-	install -m 0644 -D psm_hal_gen1/hfi1_deprecated_gen1.h ${DESTDIR}/usr/include/hfi1diag/hfi1_deprecated.h
++	install -m 0644 -D $(TEMP_INST_DIR)/opa_user.h    ${DESTDIR}/include/hfi1diag/opa_user.h
++	install -m 0644 -D $(TEMP_INST_DIR)/opa_service.h ${DESTDIR}/include/hfi1diag/opa_service.h
++	install -m 0644 -D $(TEMP_INST_DIR)/opa_common_gen1.h ${DESTDIR}/include/hfi1diag/opa_common.h
++	install -m 0644 -D include/opa_byteorder.h ${DESTDIR}/include/hfi1diag/opa_byteorder.h
++	install -m 0644 -D include/psm2_mock_testing.h ${DESTDIR}/include/hfi1diag/psm2_mock_testing.h
++	install -m 0644 -D include/opa_revision.h ${DESTDIR}/include/hfi1diag/opa_revision.h
++	install -m 0644 -D psmi_wrappers.h ${DESTDIR}/include/hfi1diag/psmi_wrappers.h
++	install -m 0644 -D psm_hal_gen1/hfi1_deprecated_gen1.h ${DESTDIR}/include/hfi1diag/hfi1_deprecated.h
+ 	rm -fr $(TEMP_INST_DIR)
+ 
+ specfile: specfile_clean | $(OUTDIR)

--- a/var/spack/repos/builtin/packages/opa-psm2/package.py
+++ b/var/spack/repos/builtin/packages/opa-psm2/package.py
@@ -12,6 +12,7 @@ class OpaPsm2(MakefilePackage):
     homepage = "http://github.com/intel/opa-psm2"
     url      = "https://github.com/intel/opa-psm2/archive/PSM2_10.3-8.tar.gz"
 
+    version('11.2.77', sha256='5cc33d1e19d871a5861efe0bb897526f404b4bf2b88ac58bb277db96ac5ecb54')
     version('11.2.68', sha256='42e16a14fc8c90b50855dcea46af3315bee32fb1ae89d83060f9b2ebdce1ec26')
     version('10.3-37',  '9bfca04f29b937b3856f893e1f8b1b60')
     version('10.3-17',  'e7263eb449939cb87612e2c7623ca21c')

--- a/var/spack/repos/builtin/packages/opa-psm2/package.py
+++ b/var/spack/repos/builtin/packages/opa-psm2/package.py
@@ -25,6 +25,11 @@ class OpaPsm2(MakefilePackage):
 
     depends_on('numactl')
 
+    # patch to prevent opa-psm2 from adding an additional "usr/"
+    #   subdirectory within the installation prefix, which breaks paths for
+    #   dependent packages like libfabric
+    patch('opa-psm2-install-prefix.patch', when='@11.2.68:') 
+
     def setup_environment(self, spack_env, run_env):
         spack_env.set('DESTDIR', self.prefix)
 


### PR DESCRIPTION
This PR corrects a problem with the opa-psm2 package.  It was installing headers into `<prefix>/usr/include` and libraries into `<prefix>/usr/lib` instead of `<prefix>/include` and `<prefix>/lib`.  The extra level of `usr/` subdirectories causes dependent packages like libfabric to fail to build. 

To reproduce, run the following on any x86 system (it does not need to have Omni-Path hardware present):

`spack install libfabric fabrics=psm2`

The above command will fail due to lack of psm2 headers (or else mistakenly pick up system psm2 headers if present) unless the PR is applied.