### PR TITLE
repeatmasker: various fixes

### DIFF
--- a/var/spack/repos/builtin/packages/repeatmasker/package.py
+++ b/var/spack/repos/builtin/packages/repeatmasker/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+import glob
 
 
 class Repeatmasker(Package):
@@ -87,5 +88,10 @@ class Repeatmasker(Package):
         with open(config_answers_filename, 'r') as f:
             perl = which('perl')
             perl('configure', input=f)
+
+        # fix perl paths
+        # every sbang points to perl, so a regex will suffice
+        for f in glob.glob('*.pm'):
+            filter_file('#!.*', '#!%s' % spec['perl'].command, f)
 
         install_tree('.', prefix.bin)

--- a/var/spack/repos/builtin/packages/repeatmasker/package.py
+++ b/var/spack/repos/builtin/packages/repeatmasker/package.py
@@ -71,6 +71,11 @@ class Repeatmasker(Package):
                                self.spec['ncbi-rmblastn'].prefix.bin,
                                'Y'])
 
+        # set non-default HMMER search
+        config_answers.extend(['3',
+                               self.spec['hmmer'].prefix,
+                               'N'])
+
         # end configuration
         config_answers.append('5')
 


### PR DESCRIPTION
`repeatmasker` depended on `hmmer` but was never actually configured to use it.
The package also had many shebangs pointing to random perl locations, now patched to use Spack's perl installation.