### PR TITLE
Corrected `source_path` for built-in packages

### DIFF
--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -28,7 +28,7 @@ import spack.util.pattern as pattern
 from spack.util.path import canonicalize_path
 from spack.util.crypto import prefix_bits, bit_length
 
-_source_path_subdir = 'src'
+_source_path_subdir = 'spack-src'
 _stage_prefix = 'spack-stage-'
 
 

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -48,7 +48,7 @@ _include_extra = 3
 # to have the following structure:
 #
 # TMPDIR/                 temp stage dir
-#     src/                well-known stage source directory
+#     spack-src/          well-known stage source directory
 #         _readme_fn      Optional test_readme (contains _readme_contents)
 #     _hidden_fn          Optional hidden file (contains _hidden_contents)
 #     _archive_fn         archive_url = file:///path/to/_archive_fn
@@ -56,7 +56,7 @@ _include_extra = 3
 # while exploding tarball directories are expected to be structured as follows:
 #
 # TMPDIR/                 temp stage dir
-#     src/                well-known stage source directory
+#     spack-src/          well-known stage source directory
 #         archive_name/   archive dir
 #             _readme_fn  test_readme (contains _readme_contents)
 #         _extra_fn       test_extra file (contains _extra_contents)

--- a/var/spack/repos/builtin/packages/aspera-cli/package.py
+++ b/var/spack/repos/builtin/packages/aspera-cli/package.py
@@ -21,7 +21,7 @@ class AsperaCli(Package):
         run_env.prepend_path('PATH', self.prefix.cli.bin)
 
     def install(self, spec, prefix):
-        runfile = glob(join_path(self.stage.path, 'aspera-cli*.sh'))[0]
+        runfile = glob(join_path(self.stage.source_path, 'aspera-cli*.sh'))[0]
         # Update destination path
         filter_file('INSTALL_DIR=~/.aspera',
                     'INSTALL_DIR=%s' % prefix,

--- a/var/spack/repos/builtin/packages/bcl2fastq2/package.py
+++ b/var/spack/repos/builtin/packages/bcl2fastq2/package.py
@@ -69,19 +69,30 @@ class Bcl2fastq2(Package):
     def unpack_it(self, f):
         def wrap():
             f()                 # call the original expand_archive()
+
+            # The tarfile should now reside in the "well known" source
+            # directory (i.e., self.stage.source_path).
             with working_dir(self.stage.path):
                 files = glob.glob(os.path.join('src', 'bcl2fastq2*.tar.gz'))
                 if len(files) == 1:
+                    # Rename the tarball so it resides in self.stage.path
+                    # alongside the original zip file before unpacking it.
                     tarball = files[0]
                     basename = os.path.basename(tarball)
                     os.rename(tarball, basename)
                     tty.msg("Unpacking bcl2fastq2 tarball")
                     tar = which('tar')
                     tar('-xf', basename)
+
+                    # Rename the unpacked directory to 'src' so the files
+                    # reside in the "well known" source directory.
                     os.rename('bcl2fastq', 'src')
                     tty.msg("Finished unpacking bcl2fastq2 tarball")
+
                 elif self.stage.expanded:
-                    tty.msg("The tarball has already been unpacked")
+                    # The unpacked files already reside in the "well known"
+                    # source directory (i.e., self.stage.source_path).
+                    tty.msg("The tarball has already been unpacked.")
 
         return wrap
 

--- a/var/spack/repos/builtin/packages/bcl2fastq2/package.py
+++ b/var/spack/repos/builtin/packages/bcl2fastq2/package.py
@@ -5,7 +5,6 @@
 
 from spack import *
 import os
-import shutil
 import glob
 import llnl.util.tty as tty
 
@@ -71,18 +70,19 @@ class Bcl2fastq2(Package):
         def wrap():
             f()                 # call the original expand_archive()
             with working_dir(self.stage.path):
-                if os.path.isdir('bcl2fastq'):
-                    tty.msg("The tarball has already been unpacked")
-                else:
+                files = glob.glob(os.path.join('src', 'bcl2fastq2*.tar.gz'))
+                if len(files) == 1:
+                    tarball = files[0]
+                    basename = os.path.basename(tarball)
+                    os.rename(tarball, basename)
                     tty.msg("Unpacking bcl2fastq2 tarball")
-                    tarball = glob.glob(join_path('spack-expanded-archive',
-                                        'bcl2fastq2*.tar.gz'))[0]
-                    copy(tarball, '.')
-                    shutil.rmtree('spack-expanded-archive')
                     tar = which('tar')
-                    tarball = os.path.basename(tarball)
-                    tar('-xf', tarball)
+                    tar('-xf', basename)
+                    os.rename('bcl2fastq', 'src')
                     tty.msg("Finished unpacking bcl2fastq2 tarball")
+                elif self.stage.expanded:
+                    tty.msg("The tarball has already been unpacked")
+
         return wrap
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/bcl2fastq2/package.py
+++ b/var/spack/repos/builtin/packages/bcl2fastq2/package.py
@@ -70,10 +70,13 @@ class Bcl2fastq2(Package):
         def wrap():
             f()                 # call the original expand_archive()
 
-            # The tarfile should now reside in the "well known" source
+            # The tarfile should now reside in the well-known source
             # directory (i.e., self.stage.source_path).
             with working_dir(self.stage.path):
-                files = glob.glob(os.path.join('src', 'bcl2fastq2*.tar.gz'))
+                source_subdir = os.path.relpath(self.stage.source_path,
+                                                self.stage.path)
+                files = glob.glob(os.path.join(source_subdir,
+                                               'bcl2fastq2*.tar.gz'))
                 if len(files) == 1:
                     # Rename the tarball so it resides in self.stage.path
                     # alongside the original zip file before unpacking it.
@@ -84,9 +87,9 @@ class Bcl2fastq2(Package):
                     tar = which('tar')
                     tar('-xf', basename)
 
-                    # Rename the unpacked directory to 'src' so the files
-                    # reside in the "well known" source directory.
-                    os.rename('bcl2fastq', 'src')
+                    # Rename the unpacked directory to the well-known
+                    # source path self.stage.source_path.
+                    os.rename('bcl2fastq', source_subdir)
                     tty.msg("Finished unpacking bcl2fastq2 tarball")
 
                 elif self.stage.expanded:

--- a/var/spack/repos/builtin/packages/catalyst/package.py
+++ b/var/spack/repos/builtin/packages/catalyst/package.py
@@ -97,7 +97,7 @@ class Catalyst(CMakePackage):
         super(Catalyst, self).do_stage(mirror_only)
 
         # extract the catalyst part
-        paraview_dir = os.path.join(self.stage.path,
+        paraview_dir = os.path.join(self.stage.source_path,
                                     'ParaView-v' + str(self.version))
         catalyst_script = os.path.join(paraview_dir, 'Catalyst', 'catalyze.py')
         editions_dir = os.path.join(paraview_dir, 'Catalyst', 'Editions')
@@ -113,10 +113,10 @@ class Catalyst(CMakePackage):
         if not os.path.isdir(catalyst_source_dir):
             os.mkdir(catalyst_source_dir)
             subprocess.check_call(command)
-            tty.msg("Generated catalyst source in %s" % self.stage.path)
+            tty.msg("Generated catalyst source in %s" % self.stage.source_path)
         else:
             tty.msg("Already generated %s in %s" % (self.name,
-                                                    self.stage.path))
+                                                    self.stage.source_path))
 
     def setup_environment(self, spack_env, run_env):
         # paraview 5.5 and later
@@ -152,7 +152,8 @@ class Catalyst(CMakePackage):
 
         :return: directory containing CMakeLists.txt
         """
-        return os.path.join(self.stage.path, 'Catalyst-v' + str(self.version))
+        return os.path.join(self.stage.source_path,
+                            'Catalyst-v' + str(self.version))
 
     @property
     def build_directory(self):

--- a/var/spack/repos/builtin/packages/charmpp/package.py
+++ b/var/spack/repos/builtin/packages/charmpp/package.py
@@ -241,5 +241,5 @@ class Charmpp(Package):
     @run_after('install')
     @on_package_attributes(run_tests=True)
     def check_build(self):
-        make('-C', join_path(self.stage.path, 'charm/tests'),
+        make('-C', join_path(self.stage.source_path, 'charm/tests'),
              'test', parallel=False)

--- a/var/spack/repos/builtin/packages/clhep/package.py
+++ b/var/spack/repos/builtin/packages/clhep/package.py
@@ -51,8 +51,7 @@ class Clhep(CMakePackage):
     def patch(self):
         filter_file('SET CMP0042 OLD',
                     'SET CMP0042 NEW',
-                    '%s/%s/CLHEP/CMakeLists.txt'
-                    % (self.stage.path, self.spec.version))
+                    '%s/CLHEP/CMakeLists.txt' % self.stage.source_path)
 
     def cmake_args(self):
         cmake_args = ['-DCLHEP_BUILD_CXXSTD=-std=c++{0}'.format(

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -41,7 +41,7 @@ class Cuda(Package):
         run_env.set('CUDA_HOME', self.prefix)
 
     def install(self, spec, prefix):
-        runfile = glob(join_path(self.stage.path, 'cuda*_linux*'))[0]
+        runfile = glob(join_path(self.stage.source_path, 'cuda*_linux*'))[0]
         chmod = which('chmod')
         chmod('+x', runfile)
         runfile = which(runfile)

--- a/var/spack/repos/builtin/packages/lmod/package.py
+++ b/var/spack/repos/builtin/packages/lmod/package.py
@@ -51,7 +51,7 @@ class Lmod(AutotoolsPackage):
 
     def setup_environment(self, spack_env, run_env):
         stage_lua_path = join_path(
-            self.stage.source_path, 'Lmod-{version}', 'src', '?.lua')
+            self.stage.source_path, 'src', '?.lua')
         spack_env.append_path('LUA_PATH', stage_lua_path.format(
             version=self.version), separator=';')
 

--- a/var/spack/repos/builtin/packages/lmod/package.py
+++ b/var/spack/repos/builtin/packages/lmod/package.py
@@ -51,7 +51,7 @@ class Lmod(AutotoolsPackage):
 
     def setup_environment(self, spack_env, run_env):
         stage_lua_path = join_path(
-            self.stage.path, 'Lmod-{version}', 'src', '?.lua')
+            self.stage.source_path, 'Lmod-{version}', 'src', '?.lua')
         spack_env.append_path('LUA_PATH', stage_lua_path.format(
             version=self.version), separator=';')
 

--- a/var/spack/repos/builtin/packages/nseg/package.py
+++ b/var/spack/repos/builtin/packages/nseg/package.py
@@ -71,7 +71,7 @@ class Nseg(MakefilePackage):
         for key in self.resources:
             for res in self.resources[key]:
                 res_name = res.name
-                res_path = join_path(res.fetcher.stage.path, res.name)
+                res_path = join_path(res.fetcher.stage.source_path, res.name)
                 copy(res_path, join_path(self.build_directory, res_name))
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/singularity/package.py
+++ b/var/spack/repos/builtin/packages/singularity/package.py
@@ -53,10 +53,18 @@ class Singularity(MakefilePackage):
     def do_stage(self, mirror_only=False):
         super(Singularity, self).do_stage(mirror_only)
         if not os.path.exists(self.singularity_gopath_dir):
+            # Now that the files have been `staged` to `self.stage.source_path`
+            # (i.e., the well-known stage source directory called `src`), they
+            # must be moved to the expected go subdirectory.  Since a directory
+            # cannot be moved to a decendant subdirectory, temporarily move/
+            # rename it.
             go_source_path = join_path(self.stage.path, 'go')
             tty.debug("Temporarily moving {0} to {1}".format(
                 self.stage.source_path, go_source_path))
             shutil.move(self.stage.source_path, go_source_path)
+
+            # Now move/rename the temporary directory to the expected
+            # gopath `src`-based subdirectory.
             tty.debug("Moving {0} to {1}".format(
                 go_source_path, self.singularity_gopath_dir))
             shutil.move(go_source_path, self.singularity_gopath_dir)

--- a/var/spack/repos/builtin/packages/singularity/package.py
+++ b/var/spack/repos/builtin/packages/singularity/package.py
@@ -42,23 +42,24 @@ class Singularity(MakefilePackage):
 
     @property
     def sylabs_gopath_dir(self):
-        return join_path(self.gopath, 'src/github.com/sylabs/')
+        return join_path(self.stage.source_path, 'github.com/sylabs/')
 
     @property
     def singularity_gopath_dir(self):
         return join_path(self.sylabs_gopath_dir, 'singularity')
 
-    # Unpack the tarball as usual, then move the src dir into
-    # its home within GOPATH.
+    # Unpack the tarball as usual but ensure it lands in its home within
+    # GOPATH.
     def do_stage(self, mirror_only=False):
         super(Singularity, self).do_stage(mirror_only)
-        source_path = self.stage.source_path
         if not os.path.exists(self.singularity_gopath_dir):
+            go_source_path = join_path(self.stage.path, 'go')
+            tty.debug("Temporarily moving {0} to {1}".format(
+                self.stage.source_path, go_source_path))
+            shutil.move(self.stage.source_path, go_source_path)
             tty.debug("Moving {0} to {1}".format(
-                source_path, self.singularity_gopath_dir))
-            mkdirp(self.sylabs_gopath_dir)
-            shutil.move(source_path,
-                        self.singularity_gopath_dir)
+                go_source_path, self.singularity_gopath_dir))
+            shutil.move(go_source_path, self.singularity_gopath_dir)
 
     # MakefilePackage's stages use this via working_dir()
     @property


### PR DESCRIPTION
Fixes #11528 
See also #11648 for why this is necessary

Note that installing `catalyst` fails in the same place it does for the commit prior to merging changes for #11528.