### PR TITLE
tests: restore `spack spec mpileaks` for Python 2

### DIFF
--- a/share/spack/qa/run-unit-tests
+++ b/share/spack/qa/run-unit-tests
@@ -27,13 +27,11 @@ cd "$SPACK_ROOT"
 spack config get compilers
 
 # Run spack help to cover command import
-${coverage_run} bin/spack -h
-${coverage_run} bin/spack help -a
+bin/spack -h
+bin/spack help -a
 
 # Profile and print top 20 lines for a simple call to spack spec
-if [[ $TRAVIS_PYTHON_VERSION != 2* ]]; then
-    ${coverage_run} bin/spack -p --lines 20 spec mpileaks%gcc ^elfutils@0.170
-fi
+bin/spack -p --lines 20 spec mpileaks%gcc ^elfutils@0.170
 
 # Run unit tests with code coverage
 extra_args=""


### PR DESCRIPTION
Let's see if Travis hangs on `spack spec mpileaks` now that #10190 is in.