### PR TITLE
CD: Package Index

### DIFF
--- a/share/spack/packages/Dockerfile
+++ b/share/spack/packages/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:18.04 AS build-env
+WORKDIR /build
+RUN apt-get update && apt-get install -y jq
+COPY packages.json ./
+COPY split.sh ./
+RUN /build/split.sh
+
+FROM nginx:mainline-alpine
+COPY --from=build-env --chown=nginx:nginx /build/packages /build/packages.json /usr/share/nginx/html/api/
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/share/spack/packages/build-image.sh
+++ b/share/spack/packages/build-image.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+script="$( basename "$0" )"
+cd "$( dirname "$0" )"
+
+export IMAGE="spack/packages.spack.io:latest"
+
+if [ "$script" '=' 'push-image.sh' ] ; then
+    docker push "${IMAGE}"
+else
+    docker build -f -t "${IMAGE}" .
+fi

--- a/share/spack/packages/push-image.sh
+++ b/share/spack/packages/push-image.sh
@@ -1,0 +1,1 @@
+build-image.sh

--- a/share/spack/packages/split.sh
+++ b/share/spack/packages/split.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# split the package index in a small file tree of
+#    /p/package.json
+# files with sub-directories grouped by the initial letter of the packages
+
+base_dir=$(pwd)/packages/
+
+for pkg in $(cat packages.json | jq -c '.[]')
+do
+    name="$(echo ${pkg} | jq -r '.name')";
+    first_letter=${name::1}
+    mkdir -p ${base_dir}${first_letter}/
+    echo ${pkg} > ${base_dir}${first_letter}/${name}.json
+done

--- a/share/spack/qa/run-docker-tests
+++ b/share/spack/qa/run-docker-tests
@@ -37,10 +37,14 @@ for config in share/spack/docker/config/* ; do
     ./share/spack/docker/build-image.sh;
 done
 
+spack list --format version_json > packages.json
+./share/spack/packages/build-image.sh
+
 if [ "$TEST_SUITE" '=' "docker" -a \
      "$TRAVIS_EVENT_TYPE" != "pull_request" ] && ensure_docker_login ; then
     for config in share/spack/docker/config/* ; do
         source "$config"
         ./share/spack/docker/push-image.sh
     done
+    ./share/spack/packages/push-image.sh
 fi


### PR DESCRIPTION
Build the docker image for the new package index REST API on each merge/push to develop and master.

Follow-up to: #11652