### PR TITLE
warpx: only allow master branch, and fix build on darwin

### DIFF
--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -18,7 +18,6 @@ class Warpx(MakefilePackage):
     url      = "https://github.com/ECP-WarpX/WarpX"
 
     version('master', git='https://github.com/ECP-WarpX/WarpX.git', tag='master')
-    version('dev', git='https://github.com/ECP-WarpX/WarpX.git', tag='dev')
 
     depends_on('mpi')
 
@@ -38,7 +37,7 @@ class Warpx(MakefilePackage):
 
     resource(name='amrex',
              git='https://github.com/AMReX-Codes/amrex.git',
-             tag='development',
+             tag='master',
              destination='.')
 
     resource(name='picsar',
@@ -68,8 +67,12 @@ class Warpx(MakefilePackage):
                         'USE_PSATD = {0}'.format(torf('+psatd')))
         makefile.filter('DO_ELECTROSTATIC .*',
                         'DO_ELECTROSTATIC = %s' % torf('+do_electrostatic'))
+        if spec.architecture.platform == 'darwin':
+            use_omp = 'FALSE'
+        else:
+            use_omp = torf('+openmp')
         makefile.filter('USE_OMP .*',
-                        'USE_OMP = {0}'.format(torf('+openmp')))
+                        'USE_OMP = {0}'.format(use_omp))
         makefile.filter('DEBUG .*',
                         'DEBUG = {0}'.format(torf('+debug')))
         makefile.filter('TINY_PROFILE .*',

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -45,6 +45,13 @@ class Warpx(MakefilePackage):
              tag='master',
              destination='.')
 
+    @property
+    def build_targets(self):
+        if self.spec.satisfies('%clang'):
+            return ['CXXFLAGS=-std=c++11']
+        else:
+            return []
+
     def edit(self, spec, prefix):
 
         comp = 'gcc'

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -41,18 +41,18 @@ class Warpx(MakefilePackage):
              git='https://github.com/AMReX-Codes/amrex.git',
              when='@master',
              tag='master',
-             destination='.')
+             placement='amrex')
 
     resource(name='amrex',
              git='https://github.com/AMReX-Codes/amrex.git',
              when='@dev',
              tag='development',
-             destination='.')
+             placement='amrex')
 
     resource(name='picsar',
              git='https://bitbucket.org/berkeleylab/picsar.git',
              tag='master',
-             destination='.')
+             placement='picsar')
 
     @property
     def build_targets(self):


### PR DESCRIPTION
These changes are needed so that WarpX will build without needing any extra specifications.