### PR TITLE
m4: Define flags when using fujitsu compiler

### DIFF
--- a/var/spack/repos/builtin/packages/m4/package.py
+++ b/var/spack/repos/builtin/packages/m4/package.py
@@ -40,6 +40,9 @@ class M4(AutotoolsPackage):
         if spec.satisfies('%arm') and not spec.satisfies('platform=darwin'):
             args.append('LDFLAGS=-rtlib=compiler-rt')
 
+        if spec.satisfies('%fj') and not spec.satisfies('platform=darwin'):
+            args.append('LDFLAGS=-rtlib=compiler-rt')
+
         if spec.satisfies('%intel'):
             args.append('CFLAGS=-no-gcc')
 


### PR DESCRIPTION
I  will add LDFLAGS  to configure options when building with fujitsu compiler.
This is a necessary change to build m4 with Fujitsu compiler.