### PR TITLE
intel-xed and hpcviewer: adapt to new resource placement

### DIFF
--- a/var/spack/repos/builtin/packages/hpcviewer/package.py
+++ b/var/spack/repos/builtin/packages/hpcviewer/package.py
@@ -58,7 +58,7 @@ class Hpcviewer(Package):
             version(ver, url=viewer_url(*key), sha256=viewer_sha[key])
 
             resource(name='hpctraceviewer', url=trace_url(*key),
-                     sha256=trace_sha[key], destination='TRACE',
+                     sha256=trace_sha[key], placement='TRACE',
                      when='@{0}'.format(ver))
 
     depends_on('java@8', type=('build', 'run'))
@@ -73,7 +73,7 @@ class Hpcviewer(Package):
         inst = Executable(join_path('.', 'install'))
         inst(*args)
 
-        cd(join_path('TRACE', 'hpctraceviewer'))
+        cd('TRACE')
 
         inst = Executable(join_path('.', 'install'))
         inst(*args)

--- a/var/spack/repos/builtin/packages/intel-xed/package.py
+++ b/var/spack/repos/builtin/packages/intel-xed/package.py
@@ -34,14 +34,14 @@ class IntelXed(Package):
     version('develop', branch='master')
     resource(name='mbuild',
              git='https://github.com/intelxed/mbuild.git',
-             branch='master', destination='',
+             branch='master', placement='mbuild',
              when='@develop')
 
     for (vers, xed_hash, mbuild_hash) in version_list:
         version(vers, commit=xed_hash)
         resource(name='mbuild',
                  git='https://github.com/intelxed/mbuild.git',
-                 commit=mbuild_hash, destination='',
+                 commit=mbuild_hash, placement='mbuild',
                  when='@{0}'.format(vers))
 
     variant('debug', default=False, description='Enable debug symbols')
@@ -65,7 +65,7 @@ class IntelXed(Package):
         python_path = os.getenv('PYTHONPATH', '')
         os.environ['PYTHONPATH'] = mbuild_dir + ':' + python_path
 
-        mfile = Executable('./mfile.py')
+        mfile = Executable(join_path('.', 'mfile.py'))
 
         args = ['-j', str(make_jobs),
                 '--cc=%s' % spack_cc,


### PR DESCRIPTION
Change 'destination' to 'placement' in the use of resource() for
intel-xed and hpcviewer.  Recent commits (1842873f and eb584d89)
changed the directory path for a resource and thus broke the build
for these packages.