### PR TITLE
More carefully add slash to list_url

### DIFF
--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -299,7 +299,7 @@ def find_versions_of_archive(archive_urls, list_url=None, list_depth=0):
     # Add '/' to the end of the URL. Some web servers require this.
     additional_list_urls = set()
     for lurl in list_urls:
-        if not lurl.endswith('/'):
+        if not lurl.endswith('/') and not lurl.endswith('.html'):
             additional_list_urls.add(lurl + '/')
     list_urls.update(additional_list_urls)
 


### PR DESCRIPTION
Fixes #11680, a bug I introduced in #8429.

### Before
```console
$ spack checksum poppler
==> Found 76 versions of poppler:
  
  0.77.0  https://poppler.freedesktop.org/releases.html/poppler-0.77.0.tar.xz
  0.76.1  https://poppler.freedesktop.org/releases.html/poppler-0.76.1.tar.xz
  0.76.0  https://poppler.freedesktop.org/releases.html/poppler-0.76.0.tar.xz
  0.75.0  https://poppler.freedesktop.org/releases.html/poppler-0.75.0.tar.xz
  0.74.0  https://poppler.freedesktop.org/releases.html/poppler-0.74.0.tar.xz
  0.73.0  https://poppler.freedesktop.org/releases.html/poppler-0.73.0.tar.xz
  0.72.0  https://poppler.freedesktop.org/releases.html/poppler-0.72.0.tar.xz
  0.71.0  https://poppler.freedesktop.org/releases.html/poppler-0.71.0.tar.xz
  0.70.1  https://poppler.freedesktop.org/releases.html/poppler-0.70.1.tar.xz
  ...
  0.23.0  https://poppler.freedesktop.org/releases.html/poppler-0.23.0.tar.xz

==> How many would you like to checksum? (default is 1, q to abort)
```

### After
```console
$ spack checksum poppler
==> Found 76 versions of poppler:
  
  0.77.0  https://poppler.freedesktop.org/poppler-0.77.0.tar.xz
  0.76.1  https://poppler.freedesktop.org/poppler-0.76.1.tar.xz
  0.76.0  https://poppler.freedesktop.org/poppler-0.76.0.tar.xz
  0.75.0  https://poppler.freedesktop.org/poppler-0.75.0.tar.xz
  0.74.0  https://poppler.freedesktop.org/poppler-0.74.0.tar.xz
  0.73.0  https://poppler.freedesktop.org/poppler-0.73.0.tar.xz
  0.72.0  https://poppler.freedesktop.org/poppler-0.72.0.tar.xz
  0.71.0  https://poppler.freedesktop.org/poppler-0.71.0.tar.xz
  0.70.1  https://poppler.freedesktop.org/poppler-0.70.1.tar.xz
  ...
  0.23.0  https://poppler.freedesktop.org/poppler-0.23.0.tar.xz

==> How many would you like to checksum? (default is 1, q to abort)
```