### PR TITLE
ResourceStage: use expanded archive name by default

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -627,7 +627,7 @@ def temp_cwd():
 
 @contextmanager
 def temp_rename(orig_path, temp_path):
-    same_path = os.path.abspath(orig_path) == os.path.abspath(temp_path)
+    same_path = os.path.realpath(orig_path) == os.path.realpath(temp_path)
     if not same_path:
         shutil.move(orig_path, temp_path)
     try:

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -627,11 +627,14 @@ def temp_cwd():
 
 @contextmanager
 def temp_rename(orig_path, temp_path):
-    shutil.move(orig_path, temp_path)
+    same_path = os.path.abspath(orig_path) == os.path.abspath(temp_path)
+    if not same_path:
+        shutil.move(orig_path, temp_path)
     try:
         yield
     finally:
-        shutil.move(temp_path, orig_path)
+        if not same_path:
+            shutil.move(temp_path, orig_path)
 
 
 def can_access(file_name):

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -455,8 +455,10 @@ def working_dir(dirname, **kwargs):
 
     orig_dir = os.getcwd()
     os.chdir(dirname)
-    yield
-    os.chdir(orig_dir)
+    try:
+        yield
+    finally:
+        os.chdir(orig_dir)
 
 
 @contextmanager
@@ -616,16 +618,20 @@ def get_single_file(directory):
 @contextmanager
 def temp_cwd():
     tmp_dir = tempfile.mkdtemp()
-    with working_dir(tmp_dir):
-        yield tmp_dir
-    shutil.rmtree(tmp_dir)
+    try:
+        with working_dir(tmp_dir):
+            yield tmp_dir
+    finally:
+        shutil.rmtree(tmp_dir)
 
 
 @contextmanager
 def temp_rename(orig_path, temp_path):
     shutil.move(orig_path, temp_path)
-    yield
-    shutil.move(temp_path, orig_path)
+    try:
+        yield
+    finally:
+        shutil.move(temp_path, orig_path)
 
 
 def can_access(file_name):

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -605,6 +605,29 @@ def ancestor(dir, n=1):
     return parent
 
 
+def get_single_file(directory):
+    fnames = os.listdir(directory)
+    if len(fnames) != 1:
+        raise ValueError("Expected exactly 1 file, got {0}"
+                         .format(str(len(fnames))))
+    return fnames[0]
+
+
+@contextmanager
+def temp_cwd():
+    tmp_dir = tempfile.mkdtemp()
+    with working_dir(tmp_dir):
+        yield tmp_dir
+    shutil.rmtree(tmp_dir)
+
+
+@contextmanager
+def temp_rename(orig_path, temp_path):
+    shutil.move(orig_path, temp_path)
+    yield
+    shutil.move(temp_path, orig_path)
+
+
 def can_access(file_name):
     """True if we have read/write access to the file."""
     return os.access(file_name, os.R_OK | os.W_OK)

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -527,17 +527,15 @@ class VCSFetchStrategy(FetchStrategy):
             for p in patterns:
                 tar.add_default_arg('--exclude=%s' % p)
 
-        if self.stage.srcdir:
-            with temp_cwd() as cwd:
-                tmp_repo_path = os.path.join(cwd, self.stage.srcdir)
+        with working_dir(self.stage.path):
+            if self.stage.srcdir:
                 # Here we create an archive with the default repository name.
                 # The 'tar' command has options for changing the name of a
                 # directory that is included in the archive, but they differ
                 # based on OS, so we temporarily rename the repo
-                with temp_rename(self.stage.source_path, tmp_repo_path):
+                with temp_rename(self.stage.source_path, self.stage.srcdir):
                     tar('-czf', destination, self.stage.srcdir)
-        else:
-            with working_dir(self.stage.path):
+            else:
                 tar('-czf', destination,
                     os.path.basename(self.stage.source_path))
 

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -31,7 +31,7 @@ from functools import wraps
 from six import string_types, with_metaclass
 
 import llnl.util.tty as tty
-from llnl.util.filesystem import working_dir, mkdirp, join_path
+from llnl.util.filesystem import working_dir, mkdirp
 
 import spack.config
 import spack.error
@@ -390,7 +390,7 @@ class URLFetchStrategy(FetchStrategy):
             # but I think there was an issue with handling exploding tarballs
             os.makedirs(self.stage.source_path)
             for fname in non_hidden:
-                fpath = join_path(tarball_container, fname)
+                fpath = os.path.join(tarball_container, fname)
                 shutil.move(fpath, self.stage.source_path)
             os.rmdir(tarball_container)
 

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -387,11 +387,7 @@ class URLFetchStrategy(FetchStrategy):
                 shutil.move(tarball_container, self.stage.source_path)
 
         else:
-            os.makedirs(self.stage.source_path)
-            for fname in non_hidden:
-                fpath = os.path.join(tarball_container, fname)
-                shutil.move(fpath, self.stage.source_path)
-            os.rmdir(tarball_container)
+            shutil.move(tarball_container, self.stage.source_path)
 
     def archive(self, destination):
         """Just moves this archive to the destination."""

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -387,8 +387,6 @@ class URLFetchStrategy(FetchStrategy):
                 shutil.move(tarball_container, self.stage.source_path)
 
         else:
-            # TODO: note this is note specifically an issue with resources,
-            # but I think there was an issue with handling exploding tarballs
             os.makedirs(self.stage.source_path)
             for fname in non_hidden:
                 fpath = os.path.join(tarball_container, fname)

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -857,8 +857,13 @@ class SvnFetchStrategy(VCSFetchStrategy):
         args = ['checkout', '--force', '--quiet']
         if self.revision:
             args += ['-r', self.revision]
-        args.extend([self.url, self.stage.source_path])
-        self.svn(*args)
+        args.extend([self.url])
+
+        with temp_cwd():
+            self.svn(*args)
+            repo_name = get_single_file('.')
+            self.stage.srcdir = repo_name
+            shutil.move(repo_name, self.stage.source_path)
 
     def _remove_untracked_files(self):
         """Removes untracked files in an svn repository."""
@@ -966,8 +971,13 @@ class HgFetchStrategy(VCSFetchStrategy):
         if self.revision:
             args.extend(['-r', self.revision])
 
-        args.extend([self.url, self.stage.source_path])
-        self.hg(*args)
+        args.extend([self.url])
+
+        with temp_cwd():
+            self.hg(*args)
+            repo_name = get_single_file('.')
+            self.stage.srcdir = repo_name
+            shutil.move(repo_name, self.stage.source_path)
 
     def archive(self, destination):
         super(HgFetchStrategy, self).archive(destination, exclude='.hg')

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -296,18 +296,13 @@ class Stage(object):
     def expected_archive_files(self):
         """Possible archive file paths."""
         paths = []
-        roots = [self.path]
-        if self.expanded:
-            roots.insert(0, self.source_path)
+        if isinstance(self.default_fetcher, fs.URLFetchStrategy):
+            paths.append(os.path.join(
+                self.path, os.path.basename(self.default_fetcher.url)))
 
-        for path in roots:
-            if isinstance(self.default_fetcher, fs.URLFetchStrategy):
-                paths.append(os.path.join(
-                    path, os.path.basename(self.default_fetcher.url)))
-
-            if self.mirror_path:
-                paths.append(os.path.join(
-                    path, os.path.basename(self.mirror_path)))
+        if self.mirror_path:
+            paths.append(os.path.join(
+                self.path, os.path.basename(self.mirror_path)))
 
         return paths
 

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -182,6 +182,8 @@ class Stage(object):
         # used for mirrored archives of repositories.
         self.skip_checksum_for_mirror = True
 
+        self.srcdir = None
+
         # TODO : this uses a protected member of tempfile, but seemed the only
         # TODO : way to get a temporary name besides, the temporary link name
         # TODO : won't be the same as the temporary stage area in tmp_root
@@ -512,9 +514,14 @@ class ResourceStage(Stage):
         """
         root_stage = self.root_stage
         resource = self.resource
-        placement = os.path.basename(self.source_path) \
-            if resource.placement is None \
-            else resource.placement
+
+        if resource.placement:
+            placement = resource.placement
+        elif self.srcdir:
+            placement = self.srcdir
+        else:
+            placement = self.source_path
+
         if not isinstance(placement, dict):
             placement = {'': placement}
 

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -501,6 +501,31 @@ class TestStage(object):
                 root_stage.source_path, 'resource-dir', fname)
             assert os.path.exists(file_path)
 
+    @pytest.mark.disable_clean_stage_check
+    @pytest.mark.usefixtures('tmpdir_for_stage')
+    def test_composite_stage_with_expand_resource_default_placement(
+            self, mock_stage_archive, mock_expand_resource,
+            composite_stage_with_expanding_resource):
+        """For a resource which refers to a compressed archive which expands
+        to a directory, check that by default the resource is placed in
+        the source_path of the root stage with the name of the decompressed
+        directory.
+        """
+
+        composite_stage, root_stage, resource_stage = (
+            composite_stage_with_expanding_resource)
+
+        resource_stage.resource.placement = None
+
+        composite_stage.create()
+        composite_stage.fetch()
+        composite_stage.expand_archive()
+
+        for fname in mock_expand_resource.files:
+            file_path = os.path.join(
+                root_stage.source_path, 'resource-expand', fname)
+            assert os.path.exists(file_path)
+
     def test_setup_and_destroy_no_name_without_tmp(self, mock_stage_archive):
         archive = mock_stage_archive()
         with Stage(archive.url) as stage:

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -348,24 +348,6 @@ def mock_stage_archive(tmp_build_stage_dir, tmp_root_stage, request):
 
 
 @pytest.fixture
-def mock_exploding_archive(tmpdir):
-    files = ['f1', 'f2', 'f3']
-    for f in files:
-        tmpdir.ensure(f)
-
-    archive_name = 'resource.tar.gz'
-    archive = tmpdir.join(archive_name)
-    archive_url = 'file://' + str(archive)
-
-    with tmpdir.as_cwd():
-        tar = spack.util.executable.which('tar', required=True)
-        tar('czf', str(archive_name), *files)
-
-    Archive = collections.namedtuple('Archive', ['url', 'files'])
-    return Archive(url=archive_url, files=files)
-
-
-@pytest.fixture
 def mock_noexpand_resource(tmpdir):
     """Set up a non-expandable resource in the tmpdir prior to staging."""
     test_resource = tmpdir.join('resource-no-expand.sh')
@@ -472,19 +454,6 @@ class TestStage(object):
         with Stage(archive.url) as stage:
             check_setup(stage, None, archive)
         check_destroy(stage, None)
-
-    @pytest.mark.usefixtures('tmpdir_for_stage')
-    def test_stage_with_exploding_archive(self, mock_exploding_archive):
-        """For stage which refers to an archive that expands to a list of
-        files (i.e. an exploding tarball), check that the individual files
-        are placed in the source_path of the stage.
-        """
-        with Stage(mock_exploding_archive.url) as stage:
-            stage.fetch()
-            stage.expand_archive()
-            for f in mock_exploding_archive.files:
-                expected_path = os.path.join(stage.source_path, f)
-                assert os.path.exists(expected_path)
 
     @pytest.mark.disable_clean_stage_check
     @pytest.mark.usefixtures('tmpdir_for_stage')

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -348,6 +348,24 @@ def mock_stage_archive(tmp_build_stage_dir, tmp_root_stage, request):
 
 
 @pytest.fixture
+def mock_exploding_archive(tmpdir):
+    files = ['f1', 'f2', 'f3']
+    for f in files:
+        tmpdir.ensure(f)
+
+    archive_name = 'resource.tar.gz'
+    archive = tmpdir.join(archive_name)
+    archive_url = 'file://' + str(archive)
+
+    with tmpdir.as_cwd():
+        tar = spack.util.executable.which('tar', required=True)
+        tar('czf', str(archive_name), *files)
+
+    Archive = collections.namedtuple('Archive', ['url', 'files'])
+    return Archive(url=archive_url, files=files)
+
+
+@pytest.fixture
 def mock_noexpand_resource(tmpdir):
     """Set up a non-expandable resource in the tmpdir prior to staging."""
     test_resource = tmpdir.join('resource-no-expand.sh')
@@ -454,6 +472,19 @@ class TestStage(object):
         with Stage(archive.url) as stage:
             check_setup(stage, None, archive)
         check_destroy(stage, None)
+
+    @pytest.mark.usefixtures('tmpdir_for_stage')
+    def test_stage_with_exploding_archive(self, mock_exploding_archive):
+        """For stage which refers to an archive that expands to a list of
+        files (i.e. an exploding tarball), check that the individual files
+        are placed in the source_path of the stage.
+        """
+        with Stage(mock_exploding_archive.url) as stage:
+            stage.fetch()
+            stage.expand_archive()
+            for f in mock_exploding_archive.files:
+                expected_path = os.path.join(stage.source_path, f)
+                assert os.path.exists(expected_path)
 
     @pytest.mark.disable_clean_stage_check
     @pytest.mark.usefixtures('tmpdir_for_stage')

--- a/var/spack/repos/builtin/packages/intel-xed/package.py
+++ b/var/spack/repos/builtin/packages/intel-xed/package.py
@@ -41,7 +41,7 @@ class IntelXed(Package):
         version(vers, commit=xed_hash)
         resource(name='mbuild',
                  git='https://github.com/intelxed/mbuild.git',
-                 commit=mbuild_hash, placement='mbuild',
+                 commit=mbuild_hash,
                  when='@{0}'.format(vers))
 
     variant('debug', default=False, description='Enable debug symbols')

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -40,19 +40,16 @@ class Warpx(MakefilePackage):
     resource(name='amrex',
              git='https://github.com/AMReX-Codes/amrex.git',
              when='@master',
-             tag='master',
-             placement='amrex')
+             tag='master')
 
     resource(name='amrex',
              git='https://github.com/AMReX-Codes/amrex.git',
              when='@dev',
-             tag='development',
-             placement='amrex')
+             tag='development')
 
     resource(name='picsar',
              git='https://bitbucket.org/berkeleylab/picsar.git',
-             tag='master',
-             placement='picsar')
+             tag='master')
 
     @property
     def build_targets(self):


### PR DESCRIPTION
For resources, it is desirable to use the expanded archive name of the resource as the name of the directory when adding it to the root staging area.

#11528 established 'spack-src' as the universal directory where source files are placed, which also affected the behavior of resources managed with Stages.

This adds a new property to Stage to remember the name of the expanded source directory, and uses this as the default name when placing a resource directory in the root staging area.

This also:

* Ensures that downloaded sources are archived using the expanded archive name
* Updates working_dir context manager to guarantee restoration of original working directory when an exception occurs
* Adds a "temp_cwd" context manager which creates a temporary directory and sets it as the working directory
* ~Tests handling of exploding tarballs~ (Edit 6/19: this was already handled)

TODOS:

- [x] Tests should be added to avoid regressions.
- [x] (New: 6/14) Fix python 2.6 errors

Note: this does not support resources using the `go` fetch strategy, but `go` fetching logic is currently in flux anyhow and no packages currently use `go`-based resources.

Note: this undoes some changes from https://github.com/spack/spack/pull/11676 and https://github.com/spack/spack/pull/11667 that accommodated the behavior changes from #11528. Those changes are compatible with this PR but I removed them because they are not strictly required (and in general the purpose of this PR was to reduce the amount of work required to use resources). In terms of staging, this PR would work with the logic for `hpcviewer` before or after #11676, but the `hpcviewer` changes are not undone because that PR updated the directory structure for that package build.