### PR TITLE
Use stage.path for cuda tmpdir

### DIFF
--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -58,6 +58,7 @@ class Cuda(Package):
             '--verbose',        # create verbose log file
             '--override',       # override compiler version checks
             '--toolkit',        # install CUDA Toolkit
+            '--tmpdir=%s' % self.stage.path,
             '--toolkitpath=%s' % prefix
         )
 


### PR DESCRIPTION
Our /tmp didn't have enough space to allow cuda to install.
This injects a spack-controlled path into the installation
process.

I would rather have it use the configured value for build_stage,
but (a) I don't know if that's appropriate, since this is
actually the install stage, and (b) I don't know how to
determine that path from within the install stage anyway.