### PR TITLE
trilinos: update dtk@develop resourcedtk to require 'submodules=True' flag

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -194,6 +194,7 @@ class Trilinos(CMakePackage):
              git='https://github.com/ornl-cees/DataTransferKit.git',
              branch='master',
              placement='DataTransferKit',
+             submodules=True,
              when='+dtk @develop')
     resource(name='fortrilinos',
              git='https://github.com/trilinos/ForTrilinos.git',


### PR DESCRIPTION
DataTransferKit now requires ArborX submodule for its work. The 12.14 Trilinos's version has frozen dtk version, so we don't update that.
