### PR TITLE
Add auto-dispatch specification to Intel packages

### DIFF
--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -25,6 +25,11 @@ from spack.util.executable import Executable
 from spack.util.prefix import Prefix
 from spack.build_environment import dso_suffix
 
+# Set the tuple for the auto dispatch variant. This is needed here so that the
+# iterator can access it in `configure_auto_dispatch`.
+auto_dispatch_options = ('COMMON-AVX512', 'MIC-AVX512', 'CORE-AVX512',
+                         'CORE-AVX2', 'CORE-AVX-I', 'AVX', 'SSE4.2', 'SSE4.1',
+                         'SSSE3', 'SSE3', 'SSE2')
 
 # A couple of utility functions that might be useful in general. If so, they
 # should really be defined elsewhere, unless deemed heretical.
@@ -1241,6 +1246,9 @@ class IntelPackage(PackageBase):
             with open(compiler_cfg, 'w') as fh:
                 fh.write('-Xlinker -rpath={0}\n'.format(compilers_lib_dir))
 
+    # Need a copy of the auto_dispatch_options to be used in the subclasses
+    auto_dispatch_options = auto_dispatch_options
+
     @run_after('install')
     def configure_auto_dispatch(self):
         if self._has_compilers:
@@ -1257,9 +1265,7 @@ class IntelPackage(PackageBase):
                         'auto_dispatch:\n\t' + f)
 
                 ad = []
-                for x in ('COMMON-AVX512', 'MIC-AVX512', 'CORE-AVX512',
-                          'CORE-AVX2', 'CORE-AVX-I', 'AVX', 'SSE4.2', 'SSE4.1',
-                          'SSSE3', 'SSE3', 'SSE2'):
+                for x in auto_dispatch_options:
                     if 'auto_dispatch={0}'.format(x) in self.spec:
                         ad.append(x)
 

--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -1243,30 +1243,29 @@ class IntelPackage(PackageBase):
 
     @run_after('install')
     def configure_auto_dispatch(self):
-        if ('auto_dispatch' not in self.spec or
-            'auto_dispatch=none' in self.spec):
-            return
+        if self._has_compilers:
+            if ('auto_dispatch=none' in self.spec):
+                return
 
-        # https://software.intel.com/en-us/cpp-compiler-18.0-developer-guide-and-reference-using-configuration-files
-        compilers_bin_dir = self.component_bin_dir('compiler')
+            compilers_bin_dir = self.component_bin_dir('compiler')
 
-        for compiler_name in 'icc icpc ifort'.split():
-            f = os.path.join(compilers_bin_dir, compiler_name)
-            if not os.path.isfile(f):
-                raise InstallError(
-                    'Cannot find compiler command to configure '
-                    'auto_dispatch:\n\t' + f)
+            for compiler_name in 'icc icpc ifort'.split():
+                f = os.path.join(compilers_bin_dir, compiler_name)
+                if not os.path.isfile(f):
+                    raise InstallError(
+                        'Cannot find compiler command to configure '
+                        'auto_dispatch:\n\t' + f)
 
-            ad = []
-            for x in ('COMMON-AVX512', 'MIC-AVX512', 'CORE-AVX512',
-                      'CORE-AVX2', 'CORE-AVX-I', 'AVX', 'SSE4.2', 'SSE4.1',
-                      'SSSE3', 'SSE3', 'SSE2'):
-                if 'auto_dispatch={0}'.format(x) in self.spec:
-                    ad.append(x)
+                ad = []
+                for x in ('COMMON-AVX512', 'MIC-AVX512', 'CORE-AVX512',
+                          'CORE-AVX2', 'CORE-AVX-I', 'AVX', 'SSE4.2', 'SSE4.1',
+                          'SSSE3', 'SSE3', 'SSE2'):
+                    if 'auto_dispatch={0}'.format(x) in self.spec:
+                        ad.append(x)
 
-            compiler_cfg = os.path.abspath(f + '.cfg')
-            with open(compiler_cfg, 'a') as fh:
-                fh.write('-ax{0}\n'.format(','.join(ad)))
+                compiler_cfg = os.path.abspath(f + '.cfg')
+                with open(compiler_cfg, 'a') as fh:
+                    fh.write('-ax{0}\n'.format(','.join(ad)))
 
     @run_after('install')
     def filter_compiler_wrappers(self):

--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -25,12 +25,6 @@ from spack.util.executable import Executable
 from spack.util.prefix import Prefix
 from spack.build_environment import dso_suffix
 
-# Set the tuple for the auto dispatch variant. This is needed here so that the
-# iterator can access it in `configure_auto_dispatch`.
-auto_dispatch_options = ('COMMON-AVX512', 'MIC-AVX512', 'CORE-AVX512',
-                         'CORE-AVX2', 'CORE-AVX-I', 'AVX', 'SSE4.2', 'SSE4.1',
-                         'SSSE3', 'SSE3', 'SSE2')
-
 # A couple of utility functions that might be useful in general. If so, they
 # should really be defined elsewhere, unless deemed heretical.
 # (Or na"ive on my part).
@@ -120,6 +114,14 @@ class IntelPackage(PackageBase):
         'intel-mkl@11.3.0:11.3.999':  2016,
         'intel-mpi@5.1:5.99':         2016,
     }
+
+    # Below is the list of possible values for setting auto dispatch functions
+    # for the Intel compilers. Using these allows for the building of fat
+    # binaries that will detect the CPU SIMD capabilities at run time and
+    # activate the appropriate extensions.
+    auto_dispatch_options = ('COMMON-AVX512', 'MIC-AVX512', 'CORE-AVX512',
+                             'CORE-AVX2', 'CORE-AVX-I', 'AVX', 'SSE4.2',
+                             'SSE4.1', 'SSSE3', 'SSE3', 'SSE2')
 
     @property
     def license_required(self):
@@ -1247,9 +1249,6 @@ class IntelPackage(PackageBase):
             with open(compiler_cfg, 'w') as fh:
                 fh.write('-Xlinker -rpath={0}\n'.format(compilers_lib_dir))
 
-    # Need a copy of the auto_dispatch_options to be used in the subclasses
-    auto_dispatch_options = auto_dispatch_options
-
     @run_after('install')
     def configure_auto_dispatch(self):
         if self._has_compilers:
@@ -1266,7 +1265,7 @@ class IntelPackage(PackageBase):
                         'auto_dispatch:\n\t' + f)
 
                 ad = []
-                for x in auto_dispatch_options:
+                for x in IntelPackage.auto_dispatch_options:
                     if 'auto_dispatch={0}'.format(x) in self.spec:
                         ad.append(x)
 

--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -35,6 +35,7 @@ auto_dispatch_options = ('COMMON-AVX512', 'MIC-AVX512', 'CORE-AVX512',
 # should really be defined elsewhere, unless deemed heretical.
 # (Or na"ive on my part).
 
+
 def debug_print(msg, *args):
     '''Prints a message (usu. a variable) and the callers' names for a couple
     of stack frames.

--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -1243,7 +1243,8 @@ class IntelPackage(PackageBase):
 
     @run_after('install')
     def configure_auto_dispatch(self):
-        if 'auto_dispatch=none' in self.spec:
+        if ('auto_dispatch' not in self.spec or
+            'auto_dispatch=none' in self.spec):
             return
 
         # https://software.intel.com/en-us/cpp-compiler-18.0-developer-guide-and-reference-using-configuration-files

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -128,11 +128,11 @@ class IntelParallelStudio(IntelPackage):
         values=('openmp', 'none'),
         multi=False
     )
+
+    auto_dispatch_options = IntelPackage.auto_dispatch_options
     variant(
         'auto_dispatch',
-        values=any_combination_of('COMMON-AVX512', 'MIC-AVX512', 'CORE-AVX512',
-                                  'CORE-AVX2', 'CORE-AVX-I', 'AVX', 'SSE4.2',
-                                  'SSE4.1', 'SSSE3', 'SSE3', 'SSE2'),
+        values=any_combination_of(*auto_dispatch_options),
         description='Enable generation of multiple auto-dispatch code paths'
     )
 

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -128,6 +128,13 @@ class IntelParallelStudio(IntelPackage):
         values=('openmp', 'none'),
         multi=False
     )
+    variant(
+        'auto_dispatch',
+        values=any_combination_of('COMMON-AVX512', 'MIC-AVX512', 'CORE-AVX512',
+                                  'CORE-AVX2', 'CORE-AVX-I', 'AVX', 'SSE4.2',
+                                  'SSE4.1', 'SSSE3', 'SSE3', 'SSE2'),
+        description='Enable generation of multiple auto-dispatch code paths'
+    )
 
     # Components available in all editions
     variant('daal', default=True,
@@ -185,6 +192,12 @@ class IntelParallelStudio(IntelPackage):
     conflicts('+daal',      when='@professional.0:professional.2015.7')
     conflicts('+daal',      when='@cluster.0:cluster.2015.7')
     conflicts('+daal',      when='@composer.0:composer.2015.7')
+
+    # MacOS does not support some of the auto dispatch settings
+    conflicts('auto_dispatch=SSE2', 'platform=darwin',
+              msg='SSE2 is not supported on MacOS')
+    conflicts('auto_dispatch=SSE3', 'platform=darwin target=x86_64',
+              msg='SSE3 is not supported on MacOS x86_64')
 
     def setup_dependent_environment(self, *args):
         # Handle in callback, conveying client's compilers in additional arg.

--- a/var/spack/repos/builtin/packages/intel/package.py
+++ b/var/spack/repos/builtin/packages/intel/package.py
@@ -43,5 +43,19 @@ class Intel(IntelPackage):
 
     variant('rpath', default=True, description='Add rpath to .cfg files')
 
+    variant(
+        'auto_dispatch',
+        values=any_combination_of('COMMON-AVX512', 'MIC-AVX512', 'CORE-AVX512',
+                                  'CORE-AVX2', 'CORE-AVX-I', 'AVX', 'SSE4.2',
+                                  'SSE4.1', 'SSSE3', 'SSE3', 'SSE2'),
+        description='Enable generation of multiple auto-dispatch code paths'
+    )
+
+    # MacOS does not support some of the auto dispatch settings
+    conflicts('auto_dispatch=SSE2', 'platform=darwin',
+              msg='SSE2 is not supported on MacOS')
+    conflicts('auto_dispatch=SSE3', 'platform=darwin target=x86_64',
+              msg='SSE3 is not supported on MacOS x86_64')
+
     # Since the current package is a subset of 'intel-parallel-studio',
     # all remaining Spack actions are handled in the package class.

--- a/var/spack/repos/builtin/packages/intel/package.py
+++ b/var/spack/repos/builtin/packages/intel/package.py
@@ -43,11 +43,10 @@ class Intel(IntelPackage):
 
     variant('rpath', default=True, description='Add rpath to .cfg files')
 
+    auto_dispatch_options = IntelPackage.auto_dispatch_options
     variant(
         'auto_dispatch',
-        values=any_combination_of('COMMON-AVX512', 'MIC-AVX512', 'CORE-AVX512',
-                                  'CORE-AVX2', 'CORE-AVX-I', 'AVX', 'SSE4.2',
-                                  'SSE4.1', 'SSSE3', 'SSE3', 'SSE2'),
+        values=any_combination_of(*auto_dispatch_options),
         description='Enable generation of multiple auto-dispatch code paths'
     )
 


### PR DESCRIPTION
This PR adds the ability to specify the auto-dispatch targets that can
be used by the Intel compilers. The `-ax` flag will be written to the
respective compiler configuration files. This ability is very handy when
wanting to build optimized builds for various architectures. This PR
does not set any optimization flags, however.