### PR TITLE
tests/bugfix: Use config fixture for stage tests

### DIFF
--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -73,7 +73,7 @@ def get_tmp_root():
 
         path = _first_accessible_path(candidates)
         if not path:
-            raise StageError("No accessible stage paths in %s", candidates)
+            raise StageError("No accessible stage paths in:", candidates)
 
         # Return None to indicate we're using a local staging area.
         if path == canonicalize_path(spack.paths.stage_path):

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -178,6 +178,16 @@ def get_stage_path(stage, stage_name):
 
 
 @pytest.fixture
+def no_path_for_stage(monkeypatch):
+    """Ensure there is no accessible path for staging."""
+    def _no_stage_path(paths):
+        return None
+
+    monkeypatch.setattr(spack.stage, '_first_accessible_path', _no_stage_path)
+    yield
+
+
+@pytest.fixture
 def no_tmp_root_stage(monkeypatch):
     """
     Disable use of a temporary root for staging.
@@ -670,6 +680,13 @@ class TestStage(object):
     def test_get_tmp_root_no_use(self, no_tmp_root_stage):
         """Ensure not using tmp root results in no path."""
         assert spack.stage.get_tmp_root() is None
+
+    def test_get_tmp_root_no_stage_path(self, tmp_root_stage,
+                                        no_path_for_stage):
+        """Ensure using tmp root with no stage path raises StageError."""
+        with pytest.raises(spack.stage.StageError,
+                           match="No accessible stage paths in"):
+            spack.stage.get_tmp_root()
 
     def test_get_tmp_root_non_user_path(self, tmp_root_stage,
                                         non_user_path_for_stage):

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -191,7 +191,7 @@ def no_tmp_root_stage(monkeypatch):
 
 
 @pytest.fixture
-def non_user_path_for_stage():
+def non_user_path_for_stage(config):
     """
     Use a non-user path for staging.
 
@@ -206,7 +206,7 @@ def non_user_path_for_stage():
 
 
 @pytest.fixture
-def stage_path_for_stage():
+def stage_path_for_stage(config):
     """
     Use the basic stage_path for staging.
 
@@ -221,7 +221,7 @@ def stage_path_for_stage():
 
 
 @pytest.fixture
-def tmp_path_for_stage(tmpdir):
+def tmp_path_for_stage(tmpdir, config):
     """
     Use a built-in, temporary, test directory for staging.
 
@@ -248,7 +248,7 @@ def tmp_root_stage(monkeypatch):
 
 
 @pytest.fixture
-def tmpdir_for_stage(mock_stage_archive):
+def tmpdir_for_stage(config, mock_stage_archive):
     """
     Use the mock_stage_archive's temporary directory for staging.
 
@@ -266,7 +266,7 @@ def tmpdir_for_stage(mock_stage_archive):
 
 
 @pytest.fixture
-def tmp_build_stage_dir(tmpdir):
+def tmp_build_stage_dir(tmpdir, config):
     """Establish the temporary build_stage for the mock archive."""
     test_tmp_path = tmpdir.join('tmp')
 


### PR DESCRIPTION
Some tests introduced in #11528 temporarily set the user's `config:build_stage`, which affected (or created) a config.yaml file in the user's `$HOME/.spack` directory that could leave entries behind if the tests fail.

This change ensures only temporary configuration files are used/affected by these tests.