### PR TITLE
Ignore pgcc-llvm and friends, default to pgcc

### DIFF
--- a/lib/spack/spack/compilers/pgi.py
+++ b/lib/spack/spack/compilers/pgi.py
@@ -20,10 +20,6 @@ class Pgi(Compiler):
     # Subclasses use possible names of Fortran 90 compiler
     fc_names = ['pgfortran', 'pgf95', 'pgf90']
 
-    # LLVM-enabled PGI compilers add a '-llvm' suffix:
-    #   pgcc-llvm, pgc++llvm, pgfortran-llvm
-    suffixes = ['-?llvm']
-
     # Named wrapper links within build_env_path
     link_paths = {'cc': 'pgi/pgcc',
                   'cxx': 'pgi/pgc++',


### PR DESCRIPTION
Follow-up to #10704, see #10599.

From @anderbubble:

> On current develop, it's picking up the `-llvm` variants by default in all circumstances now.

> My understanding is that the llvm variant doesn't support all the same features as the traditional variant of the pgi code generator; so defaulting to the llvm variant is probably the wrong thing.

> In my opinion, `spack compiler find` shouldn't be looking for the `-llvm` binaries by name; it should just be willing to accept when the standard binary names return LLVM in their version string. That way, you can specify which compiler you want by pointing it at `linux86-64` or `linux86-64-llvm`.

This change reverts to the previous behavior of only looking for `pgcc` and friends, not `pgcc-llvm` and friends. 