### PR TITLE
Fix latest HPL for MKL use

### DIFF
--- a/var/spack/repos/builtin/packages/hpl/package.py
+++ b/var/spack/repos/builtin/packages/hpl/package.py
@@ -105,6 +105,11 @@ class Hpl(AutotoolsPackage):
             'CFLAGS=-O3'
         ]
 
+        if (self.spec.satisfies('^intel-mkl') or
+            self.spec.satisfies('^intel-parallel-studio+mkl')):
+            config.append('LDFLAGS={0}'.format(
+                self.spec['blas'].libs.ld_flags))
+
         return config
 
     @when('@:2.2')


### PR DESCRIPTION
The 2.3 version of HPL needs LDFLAGS set for use of MKL libraries.