### PR TITLE
use NONRPM mode as default INSTALL_MODE for intel

### DIFF
--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -1170,6 +1170,7 @@ class IntelPackage(PackageBase):
             'CONTINUE_WITH_OPTIONAL_ERROR':         'yes',
             'CONTINUE_WITH_INSTALLDIR_OVERWRITE':   'yes',
             'SIGNING_ENABLED':                      'no',
+            'INSTALL_MODE':                         'NONRPM',
 
             # Highly variable package specifics:
             'PSET_INSTALL_DIR':                     prefix,


### PR DESCRIPTION
rpm system will install intel packages as rpm packages. but spack will not manage the rpm packages.