### PR TITLE
Add PROJ.6

### DIFF
--- a/var/spack/repos/builtin/packages/proj/package.py
+++ b/var/spack/repos/builtin/packages/proj/package.py
@@ -12,14 +12,13 @@ class Proj(AutotoolsPackage):
     another. This includes cartographic projections as well as geodetic
     transformations."""
 
-    homepage = "https://proj4.org/"
-    url      = "http://download.osgeo.org/proj/proj-5.0.1.tar.gz"
+    homepage = "https://proj.org/"
+    url      = "http://download.osgeo.org/proj/proj-6.1.0.tar.gz"
 
-    # Version 6.0.0 deprecates the older API, and things which do
-    # not know this will fail to build. So, I recommend that we
-    # do not put in 6.x until you are ready to put in selective
-    # dependencies in all packages which depend on proj. I have
-    # done libgeotiff, but there are lots of others.
+    maintainers = ['adamjstewart']
+
+    version('6.1.0', sha256='676165c54319d2f03da4349cbd7344eb430b225fe867a90191d848dc64788008')
+    version('6.0.0', sha256='4510a2c1c8f9056374708a867c51b1192e8d6f9a5198dd320bf6a168e44a3657')
     version('5.2.0', 'ad285c7d03cbb138d9246e10e1f3191c')
     version('5.1.0', '68c46f6da7e4cd5708f83fe47af80db6')
     version('5.0.1', '15c8d7d6a8cb945c7878d0ff322a232c')
@@ -39,6 +38,7 @@ class Proj(AutotoolsPackage):
     )
 
     # @6 appears to be the first version which makes use of sqlite at all.
+    depends_on('pkgconfig@0.9.0:', type='build', when='@6:')
     depends_on('sqlite@3.7:', when='@6:')
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/proj/package.py
+++ b/var/spack/repos/builtin/packages/proj/package.py
@@ -17,6 +17,9 @@ class Proj(AutotoolsPackage):
 
     maintainers = ['adamjstewart']
 
+    # Version 6 removes projects.h, while version 7 removes proj_api.h.
+    # Many packages that depend on proj do not yet support the newer API.
+    # See https://github.com/OSGeo/PROJ/wiki/proj.h-adoption-status
     version('6.1.0', sha256='676165c54319d2f03da4349cbd7344eb430b225fe867a90191d848dc64788008')
     version('6.0.0', sha256='4510a2c1c8f9056374708a867c51b1192e8d6f9a5198dd320bf6a168e44a3657')
     version('5.2.0', 'ad285c7d03cbb138d9246e10e1f3191c')
@@ -37,7 +40,7 @@ class Proj(AutotoolsPackage):
         placement='nad'
     )
 
-    # @6 appears to be the first version which makes use of sqlite at all.
+    # @6 appears to be the first version with dependencies
     depends_on('pkgconfig@0.9.0:', type='build', when='@6:')
     depends_on('sqlite@3.7:', when='@6:')
 


### PR DESCRIPTION
@citibeth @neilflood I decided to add PROJ.6 to Spack. As you probably know, the PROJ.6 API is not backwards compatible with PROJ.5 and PROJ.4. I updated several packages that depend on `proj` to account for this (in followup PRs), but if you could test other packages for me that would be great.

Packages that depend on `proj` that may need to be updated due to PROJ.6:

- [x] cdo (#11758)
- [x] gdal (#11733)
- [x] gdl (#11760)
- [x] gplates (#11761)
- [x] grass (#11762)
- [x] ibmisc (#11753)
- [x] libgeotiff (#11731)
- [x] libspatialite (#11752)
- [x] magics (#11763)
- [x] mapserver (#11764)
- [x] pism (#11754)
- [x] py-cartopy (#11765)
- [x] py-pyproj (#11735)
- [x] r-rgdal (#11766)
- [x] r-sf (#11767)
- [x] saga-gis (#11768)