### PR TITLE
openPMD-api: pybind11>=2.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/openpmd-api/package.py
+++ b/var/spack/repos/builtin/packages/openpmd-api/package.py
@@ -45,8 +45,7 @@ class OpenpmdApi(CMakePackage):
     depends_on('adios2@2.3.0: ~mpi', when='~mpi +adios2')
     depends_on('adios2@2.3.0: +mpi', when='+mpi +adios2')
     depends_on('nlohmann-json@3.5.0:', when='+json')
-    # ideally we want 2.3.0+ for full C++11 CT function signature support
-    depends_on('py-pybind11@2.2.4:', when='+python', type='link')
+    depends_on('py-pybind11@2.3.0:', when='+python', type='link')
     depends_on('py-numpy@1.15.1:', when='+python', type=['test', 'run'])
     depends_on('py-mpi4py@2.1.0:', when='+python +mpi', type=['test', 'run'])
     depends_on('python@3.5:', when='+python', type=['link', 'test', 'run'])


### PR DESCRIPTION
Update the dependency on pybind11 to the latest version (`constexpr` signature support for all C++11 compilers + fixes).