### PR TITLE
Add --frontend and --backend option to spack arch.

### DIFF
--- a/lib/spack/spack/cmd/arch.py
+++ b/lib/spack/spack/cmd/arch.py
@@ -23,6 +23,12 @@ def setup_parser(subparser):
     parts.add_argument(
         '-t', '--target', action='store_true', default=False,
         help='print only the target')
+    parts.add_argument(
+        '-f', '--frontend', action='store_true', default=False,
+        help='print frontend')
+    parts.add_argument(
+        '-b', '--backend', action='store_true', default=False,
+        help='print backend')
 
 
 def arch(parser, args):
@@ -35,5 +41,11 @@ def arch(parser, args):
         print(arch.os)
     elif args.target:
         print(arch.target)
+    elif args.frontend:
+        print(str(arch.platform) + "-" + arch.platform.front_os + "-"
+              + arch.platform.front_end)
+    elif args.backend:
+        print(str(arch.platform) + "-" + arch.platform.back_os + "-"
+              + arch.platform.back_end)
     else:
         print(arch)

--- a/lib/spack/spack/cmd/arch.py
+++ b/lib/spack/spack/cmd/arch.py
@@ -14,6 +14,7 @@ level = "short"
 
 def setup_parser(subparser):
     parts = subparser.add_mutually_exclusive_group()
+    parts2 = subparser.add_mutually_exclusive_group()
     parts.add_argument(
         '-p', '--platform', action='store_true', default=False,
         help='print only the platform')
@@ -23,17 +24,24 @@ def setup_parser(subparser):
     parts.add_argument(
         '-t', '--target', action='store_true', default=False,
         help='print only the target')
-    parts.add_argument(
+    parts2.add_argument(
         '-f', '--frontend', action='store_true', default=False,
         help='print frontend')
-    parts.add_argument(
+    parts2.add_argument(
         '-b', '--backend', action='store_true', default=False,
         help='print backend')
 
 
 def arch(parser, args):
-    arch = architecture.Arch(
-        architecture.platform(), 'default_os', 'default_target')
+    if args.frontend:
+        arch = architecture.Arch(architecture.platform(),
+                                 'frontend', 'frontend')
+    elif args.backend:
+        arch = architecture.Arch(architecture.platform(),
+                                 'backend', 'backend')
+    else:
+        arch = architecture.Arch(architecture.platform(),
+                                 'default_os', 'default_target')
 
     if args.platform:
         print(arch.platform)
@@ -41,11 +49,5 @@ def arch(parser, args):
         print(arch.os)
     elif args.target:
         print(arch.target)
-    elif args.frontend:
-        print(str(arch.platform) + "-" + arch.platform.front_os + "-"
-              + arch.platform.front_end)
-    elif args.backend:
-        print(str(arch.platform) + "-" + arch.platform.back_os + "-"
-              + arch.platform.back_end)
     else:
         print(arch)

--- a/lib/spack/spack/test/cmd/arch.py
+++ b/lib/spack/spack/test/cmd/arch.py
@@ -34,3 +34,17 @@ def test_arch_target():
 
     arch('-t')
     arch('--target')
+
+
+def test_arch_frontend():
+    """Sanity check ``spack arch --frontend`` to make sure it works."""
+
+    arch('-f')
+    arch('--frontend')
+
+
+def test_arch_backend():
+    """Sanity check ``spack arch --backend`` to make sure it works."""
+
+    arch('-b')
+    arch('--backend')

--- a/lib/spack/spack/test/cmd/arch.py
+++ b/lib/spack/spack/test/cmd/arch.py
@@ -13,6 +13,10 @@ def test_arch():
     """Sanity check ``spack arch`` to make sure it works."""
 
     arch()
+    arch('-f')
+    arch('--frontend')
+    arch('-b')
+    arch('--backend')
 
 
 def test_arch_platform():
@@ -20,6 +24,8 @@ def test_arch_platform():
 
     arch('-p')
     arch('--platform')
+    arch('-f', '-p')
+    arch('-b', '-p')
 
 
 def test_arch_operating_system():
@@ -27,6 +33,8 @@ def test_arch_operating_system():
 
     arch('-o')
     arch('--operating-system')
+    arch('-f', '-o')
+    arch('-b', '-o')
 
 
 def test_arch_target():
@@ -34,17 +42,5 @@ def test_arch_target():
 
     arch('-t')
     arch('--target')
-
-
-def test_arch_frontend():
-    """Sanity check ``spack arch --frontend`` to make sure it works."""
-
-    arch('-f')
-    arch('--frontend')
-
-
-def test_arch_backend():
-    """Sanity check ``spack arch --backend`` to make sure it works."""
-
-    arch('-b')
-    arch('--backend')
+    arch('-f', '-t')
+    arch('-b', '-t')


### PR DESCRIPTION
spack has frontend and backend in platform.
For example, we install zlib to frontend, we can use as follows:
 `spack install zlib arch=frontend`
But `spack arch` output only default (currently same as backend) architecture, and we can't known frontend archtecture.

This patch add --frontend and --backend options on `spack arch` to print frontned and backend architecture.