### PR TITLE
Rename build.out to build.txt

### DIFF
--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -190,7 +190,7 @@ class YamlDirectoryLayout(DirectoryLayout):
         self.metadata_dir        = '.spack'
         self.spec_file_name      = 'spec.yaml'
         self.extension_file_name = 'extensions.yaml'
-        self.build_log_name      = 'build.out'  # build log.
+        self.build_log_name      = 'build.txt'  # build log.
         self.build_env_name      = 'build.env'  # build environment
         self.packages_dir        = 'repos'      # archive of package.py files
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -433,7 +433,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
     #: List of glob expressions. Each expression must either be
     #: absolute or relative to the package source path.
     #: Matching artifacts found at the end of the build process will
-    #: be copied in the same directory tree as build.env and build.out.
+    #: be copied in the same directory tree as build.env and build.txt.
     archive_files = []
 
     #
@@ -786,7 +786,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
 
     @property
     def log_path(self):
-        return os.path.join(self.stage.path, 'spack-build.out')
+        return os.path.join(self.stage.path, 'spack-build.txt')
 
     def _make_fetcher(self):
         # Construct a composite fetcher that always contains at least
@@ -1814,7 +1814,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         if self.installed:
             return spack.store.layout.build_log_path(self.spec)
         else:
-            return os.path.join(self.stage.path, 'spack-build.out')
+            return os.path.join(self.stage.path, 'spack-build.txt')
 
     @classmethod
     def inject_flags(cls, name, flags):

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1814,7 +1814,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         if self.installed:
             return spack.store.layout.build_log_path(self.spec)
         else:
-            return os.path.join(self.stage.path, 'spack-build.txt')
+            return self.log_path
 
     @classmethod
     def inject_flags(cls, name, flags):

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -125,7 +125,7 @@ def test_package_output(tmpdir, capsys, install_mockery, mock_fetch):
     pkg = spec.package
     pkg.do_install(verbose=True)
 
-    log_file = os.path.join(spec.prefix, '.spack', 'build.out')
+    log_file = os.path.join(spec.prefix, '.spack', 'build.txt')
     with open(log_file) as f:
         out = f.read()
 


### PR DESCRIPTION
A common annoyance on the Spack mailing list has been this scenario:
 1. Alice reports a problem building
 2. Bob asks them to share their `spack-build.out` file.
 3. Alice does so, attaching it to an email message or GitHub Issue comment.
 4. Bob cannot just click on the resulting file in email to view it, because desktop applications (and GMail too) don't know what application to launch of `.out` files.

Now, Bob has to spend more time downloading the file and opening it in an editor, than how long it might take them to spot the problem.

This PR solves that problem by simply calling the file `spack-build.txt` instead.  That will make everybody's lives a little easier; and I can see no downside to it.