### PR TITLE
Add CDO 1.9.7.1

### DIFF
--- a/var/spack/repos/builtin/packages/cdo/package.py
+++ b/var/spack/repos/builtin/packages/cdo/package.py
@@ -17,7 +17,8 @@ class Cdo(AutotoolsPackage):
 
     maintainers = ['skosukhin']
 
-    version('1.9.7rc2', '62313bdf60860693e96494fd2fd8ff48e65266f600f6ae8c817e46a652e6b215', url='https://code.mpimet.mpg.de/attachments/download/19883/cdo-1.9.7rc2.tar.gz')
+    version('1.9.7.1', sha256='3771952e065bcf935d43e492707370ed2a0ecb59a06bea24f9ab69d77943962c',
+            url='https://code.mpimet.mpg.de/attachments/download/20124/cdo-1.9.7.1.tar.gz')
     version('1.9.6', '322f56c5e13f525c585ee5318d4435db', url='https://code.mpimet.mpg.de/attachments/download/19299/cdo-1.9.6.tar.gz')
     version('1.9.5', '0c60f2c94dc5c76421ecf363153a5043', url='https://code.mpimet.mpg.de/attachments/download/18264/cdo-1.9.5.tar.gz')
     version('1.9.4', '377c9e5aa7d8cbcb4a6c558abb2eb053', url='https://code.mpimet.mpg.de/attachments/download/17374/cdo-1.9.4.tar.gz')
@@ -69,7 +70,7 @@ class Cdo(AutotoolsPackage):
 
     depends_on('udunits2', when='+udunits2')
     depends_on('libxml2', when='+libxml2')
-    depends_on('proj', when='+proj')
+    depends_on('proj@:5', when='+proj')
     depends_on('curl', when='+curl')
     depends_on('fftw@3:', when='+fftw3')
     depends_on('magics', when='+magics')


### PR DESCRIPTION
Successfully built and passes all tests with Clang 10.0.1 on macOS 10.14.5.

I tried building with PROJ.6 and everything built just fine and all of the tests passed. However, according to https://code.mpimet.mpg.de/boards/1/topics/7600, PROJ.6 is still not supported in CDO. I'm going to err on the side of caution and restrict the dependency to `proj@:5`.

@skosukhin