### PR TITLE
Add GDL 0.9.9

### DIFF
--- a/var/spack/repos/builtin/packages/gdl/package.py
+++ b/var/spack/repos/builtin/packages/gdl/package.py
@@ -14,8 +14,9 @@ class Gdl(CMakePackage):
     """
 
     homepage = "https://github.com/gnudatalanguage/gdl"
-    url      = "https://github.com/gnudatalanguage/gdl/archive/v0.9.8.tar.gz"
+    url      = "https://github.com/gnudatalanguage/gdl/archive/v0.9.9.tar.gz"
 
+    version('0.9.9', sha256='ad5de3fec095a5c58b46338dcc7367d2565c093794ab1bbcf180bba1a712cf14')
     version('0.9.8', '447b0362e1df5ea8af814a969e89d3ec')
 
     variant(
@@ -34,6 +35,7 @@ class Gdl(CMakePackage):
 
     extends('python', when='+python')
 
+    depends_on('cmake@3:', type='build')
     depends_on('graphicsmagick', when='+graphicsmagick')
     depends_on('hdf', when='+hdf4')
     depends_on('hdf5', when='+hdf5')
@@ -41,7 +43,7 @@ class Gdl(CMakePackage):
     depends_on('plplot+wx', when='+wx@:5.11')
     depends_on('plplot+wx+wxold', when='+wx@5.12:')
     depends_on('plplot~wx', when='~wx')
-    depends_on('proj', when='+proj')
+    depends_on('proj@:5', when='+proj')
     depends_on('py-numpy', type=('build', 'run'), when='+embed_python')
     depends_on('python@2.7:2.8', type=('build', 'run'), when='+embed_python')
     depends_on('wx', when='+wx')

--- a/var/spack/repos/builtin/packages/gdl/package.py
+++ b/var/spack/repos/builtin/packages/gdl/package.py
@@ -43,6 +43,8 @@ class Gdl(CMakePackage):
     depends_on('plplot+wx', when='+wx@:5.11')
     depends_on('plplot+wx+wxold', when='+wx@5.12:')
     depends_on('plplot~wx', when='~wx')
+    # Too many dependencies to test if GDL supports PROJ.6,
+    # so restricting to old API
     depends_on('proj@:5', when='+proj')
     depends_on('py-numpy', type=('build', 'run'), when='+embed_python')
     depends_on('python@2.7:2.8', type=('build', 'run'), when='+embed_python')


### PR DESCRIPTION
This package has way too many dependencies for me to test PROJ.6 support, so I'm going to explicitly require `proj@:5` until someone has the time to make sure it works with PROJ.6.