### PR TITLE
GRASS GIS does not yet support PROJ.6

### DIFF
--- a/var/spack/repos/builtin/packages/grass/package.py
+++ b/var/spack/repos/builtin/packages/grass/package.py
@@ -48,6 +48,8 @@ class Grass(AutotoolsPackage):
     depends_on('flex', type='build')
     depends_on('bison', type='build')
     depends_on('proj')
+    depends_on('proj@:4', when='@:7.5')
+    depends_on('proj@:5', when='@:7.7')
     depends_on('gdal')
     depends_on('python@2.7:2.9', type=('build', 'run'))
     depends_on('libx11')


### PR DESCRIPTION
PROJ requirements taken from https://github.com/OSGeo/PROJ/wiki/proj.h-adoption-status