### PR TITLE
Restrict magics to proj@:5

### DIFF
--- a/var/spack/repos/builtin/packages/magics/package.py
+++ b/var/spack/repos/builtin/packages/magics/package.py
@@ -55,7 +55,7 @@ class Magics(CMakePackage):
     depends_on('perl-xml-parser', type='build')
 
     # Non-optional dependencies
-    depends_on('proj')
+    depends_on('proj@:5')
     depends_on('boost')
     depends_on('expat')
 


### PR DESCRIPTION
Version requirement comes from https://github.com/OSGeo/PROJ/wiki/proj.h-adoption-status