### PR TITLE
Specify which versions of PROJ work with MapServer

### DIFF
--- a/var/spack/repos/builtin/packages/mapserver/package.py
+++ b/var/spack/repos/builtin/packages/mapserver/package.py
@@ -29,6 +29,8 @@ class Mapserver(CMakePackage):
     depends_on('jpeg')
     depends_on('zlib')
     depends_on('proj')
+    depends_on('proj@:5', when='@:7.3')
+    depends_on('proj@6:', when='@7.4:')
     depends_on('curl', when='+curl')
     depends_on('geos')
     depends_on('libxml2')


### PR DESCRIPTION
See https://github.com/OSGeo/PROJ/wiki/proj.h-adoption-status and https://github.com/mapserver/mapserver/issues/5766. It sounds like the latest release supports PROJ.6, though I didn't test it.