### PR TITLE
r-sf may not support PROJ.6

### DIFF
--- a/var/spack/repos/builtin/packages/r-sf/package.py
+++ b/var/spack/repos/builtin/packages/r-sf/package.py
@@ -25,4 +25,6 @@ class RSf(RPackage):
     depends_on('r-magrittr', type=('build', 'run'))
     depends_on('gdal@2.0.0:')
     depends_on('geos@3.3.0:')
+    # Since PROJ.4 and PROJ.6 have incompatible APIs, I'm assuming
+    # that since r-sf supports PROJ.4, it doesn't support PROJ.6
     depends_on('proj@4.8.0:5')

--- a/var/spack/repos/builtin/packages/r-sf/package.py
+++ b/var/spack/repos/builtin/packages/r-sf/package.py
@@ -25,4 +25,4 @@ class RSf(RPackage):
     depends_on('r-magrittr', type=('build', 'run'))
     depends_on('gdal@2.0.0:')
     depends_on('geos@3.3.0:')
-    depends_on('proj@4.8.0:')
+    depends_on('proj@4.8.0:5')


### PR DESCRIPTION
Might be supported in the latest release according to https://github.com/OSGeo/PROJ/wiki/proj.h-adoption-status, but I can't access the CRAN site to confirm.