### PR TITLE
libnrm,nrm,py-jsonpatch,py-jsonpointer,py-warlock: New packages.

### DIFF
--- a/var/spack/repos/builtin/packages/libnrm/package.py
+++ b/var/spack/repos/builtin/packages/libnrm/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Libnrm(AutotoolsPackage):
+    """Libnrm, the application instrumentation library for the Node
+    Resource Manager(NRM)."""
+
+    homepage = "https://xgitlab.cels.anl.gov/argo/libnrm"
+    url = "https://www.mcs.anl.gov/research/projects/argo/downloads/libnrm-0.1.0.tar.gz"
+    version('0.1.0', '2edae952edce3df9f1562ea64d4ae201')
+
+    depends_on('m4', type='build')
+    depends_on('autoconf', type='build')
+    depends_on('automake', type='build')
+    depends_on('libtool', type='build')
+
+    depends_on('zeromq')
+    depends_on('mpich')

--- a/var/spack/repos/builtin/packages/libnrm/package.py
+++ b/var/spack/repos/builtin/packages/libnrm/package.py
@@ -12,7 +12,7 @@ class Libnrm(AutotoolsPackage):
 
     homepage = "https://xgitlab.cels.anl.gov/argo/libnrm"
     url = "https://www.mcs.anl.gov/research/projects/argo/downloads/libnrm-0.1.0.tar.gz"
-    version('0.1.0', '2edae952edce3df9f1562ea64d4ae201')
+    version('0.1.0', '9261a55e58fd6350d9382dd09001cfd4')
 
     depends_on('m4', type='build')
     depends_on('autoconf', type='build')

--- a/var/spack/repos/builtin/packages/nrm/package.py
+++ b/var/spack/repos/builtin/packages/nrm/package.py
@@ -1,0 +1,26 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Nrm(PythonPackage):
+    """Node Resource Manager"""
+
+    homepage = "https://xgitlab.cels.anl.gov/argo/nrm"
+    url = "https://www.mcs.anl.gov/research/projects/argo/downloads/nrm-0.1.0.tar.gz"
+    version('0.1.0', '99a8c8d312fcf3880608cdc8274c285f')
+
+    depends_on('py-setuptools', type=('build'))
+
+    depends_on('py-six', type=('build', 'run'))
+    depends_on('py-zmq', type=('build', 'run'))
+    depends_on('py-pyyaml', type=('build', 'run'))
+    depends_on('py-tornado', type=('build', 'run'))
+    depends_on('py-numpy', type=('build', 'run'))
+    depends_on('py-argparse@1.2.1:', type=('build', 'run'))
+    depends_on('py-jsonschema@2.6.0', type=('build', 'run'))
+    depends_on('py-warlock', type=('build', 'run'))
+    depends_on('py-scipy', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/nrm/package.py
+++ b/var/spack/repos/builtin/packages/nrm/package.py
@@ -11,14 +11,14 @@ class Nrm(PythonPackage):
 
     homepage = "https://xgitlab.cels.anl.gov/argo/nrm"
     url = "https://www.mcs.anl.gov/research/projects/argo/downloads/nrm-0.1.0.tar.gz"
-    version('0.1.0', '99a8c8d312fcf3880608cdc8274c285f')
+    version('0.1.0', '2135baf658355480b515c0989d019758')
 
     depends_on('py-setuptools', type=('build'))
 
     depends_on('py-six', type=('build', 'run'))
-    depends_on('py-zmq', type=('build', 'run'))
+    depends_on('py-zmq@17.1.2', type=('build', 'run'))
     depends_on('py-pyyaml', type=('build', 'run'))
-    depends_on('py-tornado', type=('build', 'run'))
+    depends_on('py-tornado@5.1.1', type=('build', 'run'))
     depends_on('py-numpy', type=('build', 'run'))
     depends_on('py-argparse@1.2.1:', type=('build', 'run'))
     depends_on('py-jsonschema@2.6.0', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-jsonpatch/package.py
+++ b/var/spack/repos/builtin/packages/py-jsonpatch/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyJsonpatch(PythonPackage):
+    """Library to apply JSON Patches according to RFC 6902"""
+
+    homepage = "https://github.com/stefankoegl/python-json-patch"
+    url      = "https://github.com/stefankoegl/python-json-patch/archive/v1.23.tar.gz"
+
+    version('1.23', sha256='0af03651204ea3049bc4aedaa42b591e134a4ee16e421f9c5f3ac4e9092885ad')
+
+    depends_on('py-setuptools', type='build')
+    depends_on('py-jsonpointer@1.9', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-jsonpointer/package.py
+++ b/var/spack/repos/builtin/packages/py-jsonpointer/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyJsonpointer(PythonPackage):
+    """Library to resolve JSON Pointers according to RFC 6901"""
+
+    homepage = "https://github.com/stefankoegl/python-json-pointer"
+    url      = "https://github.com/stefankoegl/python-json-pointer/archive/v2.0.tar.gz"
+
+    version('2.0', sha256='9594b7574a3216c9994181e9db7566a5cafb4ab24956e554f2dba1bb39edecb2')
+
+    depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-warlock/package.py
+++ b/var/spack/repos/builtin/packages/py-warlock/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyWarlock(PythonPackage):
+    """Self-validating Python objects using JSON schema"""
+
+    homepage = "https://github.com/bcwaldon/warlock"
+    url      = "https://github.com/bcwaldon/warlock/archive/1.3.3.tar.gz"
+
+    version('1.3.3', sha256='b77e4977d5dc54d47f88cbcc9ab2d716f5f10171d123138785dad96aeb2858d0')
+
+    depends_on('py-setuptools', type='build')
+    depends_on('py-jsonschema@0.7:3', type=('build', 'run'))
+    depends_on('py-jsonpatch@0.10:1', type=('build', 'run'))
+    depends_on('py-six@1:', type=('build', 'run'))


### PR DESCRIPTION
Adds packages for two software pieces from Argonne National Laboratory.

NRM, a node-local resource manager: https://xgitlab.cels.anl.gov/argo/nrm
libnrm, its application interfacing library: https://xgitlab.cels.anl.gov/argo/libnrm

Also adds three json schema related python dependencies for NRM.