### PR TITLE
Testing bugfix: Spurious MacOS failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -166,6 +166,7 @@ addons:
       - gcc
       - gnupg2
       - ccache
+    update: true
 
 # ~/.ccache needs to be cached directly as Travis is not taking care of it
 # (possibly because we use 'language: python' and not 'language: c')


### PR DESCRIPTION
Currently, all macos tests are failing because brew cannot install ccache without updating brew.

This PR: ensure `brew update` is run before using brew in test environment