### PR TITLE
py-matplotlib: Fix dependencies in [2.1.0:3.0.0)

### DIFF
--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -61,8 +61,10 @@ class PyMatplotlib(PythonPackage):
     depends_on('py-pytz', type=('build', 'run'))
     depends_on('py-cycler@0.9:', type=('build', 'run'))
     depends_on('py-subprocess32', type=('build', 'run'), when='^python@:2.7')
-    depends_on('py-functools32', type=('build', 'run'), when='^python@2.7')
+    depends_on('py-functools32', type=('build', 'run'), when='@:2.0.999 ^python@2.7')
     depends_on('py-kiwisolver', type=('build', 'run'), when='@2.2.0:')
+    depends_on('py-backports-functools-lru-cache', type=('build', 'run'),
+               when='@2.1.0:2.999.999')
 
     # ------ Optional GUI frameworks
     depends_on('tk@8.3:', when='+tk')  # not 8.6.0 or 8.6.1


### PR DESCRIPTION
Starting with 2.1.0, `backports.functools_lru_cache` replaces `functools32`
when using python 2.7.x until python2 support is dropped in 3.0.0.