### PR TITLE
py-python-dateutil: Version 2.7.0 acquired dependency on setuptools-scm

### DIFF
--- a/var/spack/repos/builtin/packages/py-python-dateutil/package.py
+++ b/var/spack/repos/builtin/packages/py-python-dateutil/package.py
@@ -25,6 +25,7 @@ class PyPythonDateutil(PythonPackage):
 
     depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
     depends_on('py-setuptools@24.3:', type='build')
+    depends_on('py-setuptools-scm', type='build', when='@2.7.0:')
     depends_on('py-six@1.5:', type=('build', 'run'))
     # depends_on('py-pytest', type='test')
     # depends_on('py-hypothesis', type='test')


### PR DESCRIPTION
setup.py secretly downloads it anyway, but this fails on air-gapped machines. 