### PR TITLE
fmt: Add version 5.3.0 with cxxstd variant support

### DIFF
--- a/var/spack/repos/builtin/packages/fmt/fmt-attributes-cpp11_4.1.0.patch
+++ b/var/spack/repos/builtin/packages/fmt/fmt-attributes-cpp11_4.1.0.patch
@@ -1,0 +1,13 @@
+diff --git a/fmt/format.h b/fmt/format.h
+index 561a9e0..9faf5ca 100644
+--- a/fmt/format.h
++++ b/fmt/format.h
+@@ -153,7 +153,7 @@ typedef __int64          intmax_t;
+ # define FMT_HAS_CPP_ATTRIBUTE(x) 0
+ #endif
+ 
+-#if FMT_HAS_CPP_ATTRIBUTE(maybe_unused)
++#if FMT_HAS_CPP_ATTRIBUTE(maybe_unused) && __cplusplus >= 201103L
+ # define FMT_HAS_CXX17_ATTRIBUTE_MAYBE_UNUSED
+ // VC++ 1910 support /std: option and that will set _MSVC_LANG macro
+ // Clang with Microsoft CodeGen doesn't define _MSVC_LANG macro

--- a/var/spack/repos/builtin/packages/fmt/fmt-no-export-cpp11flag_3.0.0.patch
+++ b/var/spack/repos/builtin/packages/fmt/fmt-no-export-cpp11flag_3.0.0.patch
@@ -1,0 +1,13 @@
+diff --git a/fmt/CMakeLists.txt b/fmt/CMakeLists.txt
+index c0ef02e..1634924 100644
+--- a/fmt/CMakeLists.txt
++++ b/fmt/CMakeLists.txt
+@@ -14,8 +14,6 @@ if (FMT_CPPFORMAT)
+   add_library(cppformat ${FMT_SOURCES} ${FMT_HEADERS})
+ endif ()
+ 
+-# Starting with cmake 3.1 the CXX_STANDARD property can be used instead.
+-target_compile_options(fmt PUBLIC ${CPP11_FLAG})
+ if (FMT_PEDANTIC)
+   target_compile_options(fmt PRIVATE ${PEDANTIC_COMPILE_FLAGS})
+ endif ()

--- a/var/spack/repos/builtin/packages/fmt/fmt-use-cmake-cxx-standard_3.0.0.patch
+++ b/var/spack/repos/builtin/packages/fmt/fmt-use-cmake-cxx-standard_3.0.0.patch
@@ -1,0 +1,15 @@
+diff --git a/support/cmake/cxx11.cmake b/support/cmake/cxx11.cmake
+index 31ea106..8581b9a 100644
+--- a/support/cmake/cxx11.cmake
++++ b/support/cmake/cxx11.cmake
+@@ -37,6 +37,10 @@ if (FMT_USE_CPP11)
+   endif ()
+ endif ()
+ 
++if (CMAKE_CXX_STANDARD)
++  set(CPP11_FLAG )
++endif ()
++
+ set(CMAKE_REQUIRED_FLAGS ${CPP11_FLAG})
+ 
+ # Check if variadic templates are working and not affected by GCC bug 39653:

--- a/var/spack/repos/builtin/packages/fmt/package.py
+++ b/var/spack/repos/builtin/packages/fmt/package.py
@@ -24,21 +24,54 @@ class Fmt(CMakePackage):
     version('3.0.1', sha256='4c9af0dc919a8ae7022b44e1a03c435e42d65c866f44667d8d920d342b098550')
     version('3.0.0', sha256='1b050b66fa31b74f1d75a14f15e99e728ab79572f176a53b2f8ad7c201c30ceb')
 
+    variant('cxxstd',
+            default='11',
+            values=('98', '11', '14', '17'),
+            multi=False,
+            description='Use the specified C++ standard when building')
+    variant('pic', default=True, description='Enable generation of position-independent code')
+
     depends_on('cmake@3.1.0:', type='build')
 
-    # Supported compilers are detailed here:
+    # Supported compilers/standards are detailed here:
     # http://fmtlib.net/latest/index.html#portability
     conflicts('%gcc@:4.3.999', when='@5:')
     conflicts('%llvm@:2.8.999', when='@5:')
+    # 5 and above require C++11
+    conflicts('cxxstd=98', when='@5:')
+    # 5.0.0 enables C++14 auto return types in C++11 mode
+    conflicts('cxxstd=11', when='@5.0.0')
+    # 4.1 fails with C++17 (https://github.com/fmtlib/fmt/issues/722)
+    conflicts('cxxstd=17', when='@4.1.0')
 
-    variant('pic', default=True, description='Enable generation of position-independent code')
+    # Use CMAKE_CXX_STANDARD to define C++ flag, as in later versions
+    patch('fmt-use-cmake-cxx-standard_3.0.0.patch', when='@3.0.0')
+
+    # Remove hardcoding of "-std=c++11/0x" in INTERFACE_COMPILE_OPTIONS
+    patch('fmt-no-export-cpp11flag_3.0.0.patch', when='@3.0.0:3.0.1')
+
+    # Only allow [[attributes]] on C++11 and higher
+    patch('fmt-attributes-cpp11_4.1.0.patch', when='@4.1.0')
 
     def cmake_args(self):
         spec = self.spec
         args = []
+
         if '+pic' in spec:
             args.extend([
                 '-DCMAKE_C_FLAGS={0}'.format(self.compiler.pic_flag),
                 '-DCMAKE_CXX_FLAGS={0}'.format(self.compiler.pic_flag)
             ])
+
+        args.append('-DCMAKE_CXX_STANDARD={0}'.format(
+                    spec.variants['cxxstd'].value))
+
+        # When cxxstd is 98, must disable FMT_USE_CPP11
+        if 'cxxstd=98' in spec:
+            args.append('-DFMT_USE_CPP11=OFF')
+
+        # Can't build docs without doxygen+python+virtualenv
+        # and call to build "doc" target
+        args.append("-DFMT_DOC=OFF")
+
         return args

--- a/var/spack/repos/builtin/packages/fmt/package.py
+++ b/var/spack/repos/builtin/packages/fmt/package.py
@@ -65,6 +65,9 @@ class Fmt(CMakePackage):
 
         args.append('-DCMAKE_CXX_STANDARD={0}'.format(
                     spec.variants['cxxstd'].value))
+        # Require standard at configure time to guarantee the
+        # compiler supports the selected standard.
+        args.append('-DCMAKE_CXX_STANDARD_REQUIRED=ON')
 
         # When cxxstd is 98, must disable FMT_USE_CPP11
         if 'cxxstd=98' in spec:

--- a/var/spack/repos/builtin/packages/fmt/package.py
+++ b/var/spack/repos/builtin/packages/fmt/package.py
@@ -14,6 +14,7 @@ class Fmt(CMakePackage):
     homepage = "http://fmtlib.net/latest/index.html"
     url      = "https://github.com/fmtlib/fmt/releases/download/5.2.1/fmt-5.2.1.zip"
 
+    version('5.3.0', sha256='2ba1469c1f7677e70cb32bcd7dd0907e6952e16a161f07e05c7ffa388643b607')
     version('5.2.1', sha256='43894ab8fe561fc9e523a8024efc23018431fa86b95d45b06dbe6ddb29ffb6cd')
     version('5.2.0', sha256='c016db7f825bce487a7929e1edb747b9902a2935057af6512cad3df3a080a027')
     version('5.1.0', sha256='77ef9fea638dc846e484409fbc1ea710bb9bcea042e7b35b8805041bf7655ad5')


### PR DESCRIPTION
This revives and rebases #10569 

Spack supported versions of fmt default to C++11 for versions less than 5, C++14 greater than 5, with fmt implementing fallbacks to whatever compiler supports.

To give better ABI compatibility and use of newer standards, provide a cxxstd variant defaulting to 11 with 98-17 options. Use cmake_args to set CMAKE_CXX_STANDARD as appropriate, plus use of FMT_USE_CPP11 option for C++98 builds. Use conflicts to disable use of certain standards in versions that don't support, or fail the build, with those standards. Use CMAKE_CXX_STANDARD_REQUIRED to fail, at configure step only, use of compiler/cmake combination that do not support/know the requested standard.

Add patches to unify use of CMAKE_CXX_STANDARD in 3.0 versions, remove hard-coding of compiler flags in fmt-config.cmake, and prevent use of C++11 features in 4.1.0 when in supported C++98 mode.

Default to not building documents as no dependency on Doxygen is yet present, and they are not part of the "all" build.

The latest 5.3.0 version is added and checksummed.