### PR TITLE
boost: add variant for symbol visibility

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -129,6 +129,12 @@ class Boost(Package):
             description='Generate position-independent code (PIC), useful '
                         'for building static libraries')
 
+    # https://boostorg.github.io/build/manual/develop/index.html#bbv2.builtin.features.visibility
+    variant('visibility', values=('global', 'protected', 'hidden'),
+            default='hidden', multi=False,
+            description='Default symbol visibility in compiled libraries '
+            '(1.69.0 or later)')
+
     depends_on('icu4c', when='+icu')
     depends_on('python', when='+python')
     depends_on('mpi', when='+mpi')
@@ -334,6 +340,10 @@ class Boost(Package):
 
         if cxxflags:
             options.append('cxxflags="{0}"'.format(' '.join(cxxflags)))
+
+        # Visibility was added in 1.69.0.
+        if spec.satisfies('@1.69.0:'):
+            options.append('visibility=%s' % spec.variants['visibility'].value)
 
         return threading_opts
 


### PR DESCRIPTION
Starting with 1.69.0, boost added a bjam option for the default symbol
visibility.  Up to 1.68.0, the value was always 'global'.  1.69.0
changed the default to 'hidden' but added an option.

Most packages will work with hidden and won't notice.  But some
packages may discover that an interface that they rely on is now
hidden and inaccessible.

https://boostorg.github.io/build/manual/develop/index.html#bbv2.builtin.features.visibility

----------

In my case (hpctoolkit), we needed `parse_graphviz_from_string()` from
graph which went dark in 1.69.

Btw, with `--keep-stage` or building boost outside of spack, you can
see that boost has added an extra directory level for visibililty in
the build stage.

In 1.68.0, compiling date_time has:

```
gcc.compile.c++ bin.v2/libs/date_time/build/gcc-7.3.1/release/cxxstd-98-iso/link-static/threading-multi/gregorian/date_generators.o
```

But 1.69.0 added an extra level:

```
gcc.compile.c++ bin.v2/libs/date_time/build/gcc-7.3.1/release/cxxstd-98-iso/link-static/threading-multi/visibility-hidden/gregorian/date_generators.o
```
