### PR TITLE
exonerate: use autotools  for new architecture host

### DIFF
--- a/var/spack/repos/builtin/packages/exonerate/package.py
+++ b/var/spack/repos/builtin/packages/exonerate/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class Exonerate(Package):
+class Exonerate(AutotoolsPackage):
     """Pairwise sequence alignment of DNA and proteins"""
 
     homepage = "http://www.ebi.ac.uk/about/vertebrate-genomics/software/exonerate"
@@ -19,8 +19,10 @@ class Exonerate(Package):
 
     parallel = False
 
-    def install(self, spec, prefix):
-        configure('--prefix={0}'.format(prefix), '--disable-debug',
-                  '--disable-dependency-tracking')
-        make()
-        make('install')
+    def configure_args(self):
+        args = []
+
+        args.append('--disable-debug')
+        args.append('--disable-dependency-tracking')
+
+        return args


### PR DESCRIPTION
The packages of exonerate use original configure.
Because these scripts is very old, new architecture host is faild to configure.

This patch use autotools for exonerate to update config.guess.