### PR TITLE
camellia: fix hdf5 dependency

### DIFF
--- a/var/spack/repos/builtin/packages/camellia/package.py
+++ b/var/spack/repos/builtin/packages/camellia/package.py
@@ -22,7 +22,12 @@ class Camellia(CMakePackage):
 
     depends_on('trilinos+amesos+amesos2+belos+epetra+epetraext+exodus+ifpack+ifpack2+intrepid+intrepid2+kokkos+ml+muelu+sacado+shards+teuchos+tpetra+zoltan+mumps+superlu-dist+hdf5+zlib+pnetcdf@master,12.12.1:')
     depends_on('moab@:4', when='+moab')
+
+    # Cameilla needs hdf5 but the description "hdf5@:1.8" is
+    # determined that "1.8.10" or "1.8.21" does not work.
+    # See https://github.com/spack/spack/pull/8337
     depends_on('hdf5@:1.8.21')
+
     depends_on('mpi')
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/camellia/package.py
+++ b/var/spack/repos/builtin/packages/camellia/package.py
@@ -22,7 +22,7 @@ class Camellia(CMakePackage):
 
     depends_on('trilinos+amesos+amesos2+belos+epetra+epetraext+exodus+ifpack+ifpack2+intrepid+intrepid2+kokkos+ml+muelu+sacado+shards+teuchos+tpetra+zoltan+mumps+superlu-dist+hdf5+zlib+pnetcdf@master,12.12.1:')
     depends_on('moab@:4', when='+moab')
-    depends_on('hdf5@:1.8')
+    depends_on('hdf5@:1.8.21')
     depends_on('mpi')
 
     def cmake_args(self):


### PR DESCRIPTION
As camellia needs hdf5 version:1.8.x, we changed the way to specify version of hdf5.

comments from https://github.com/spack/spack/pull/8337
"HDF5 1.10.x is incompatible with Camellia, at least right now, so adding dependency to versions up to 1.8.x."