### PR TITLE
New package py-astor (and test dependency py-astunparse)

### DIFF
--- a/var/spack/repos/builtin/packages/py-astor/package.py
+++ b/var/spack/repos/builtin/packages/py-astor/package.py
@@ -13,8 +13,8 @@ class PyAstor(PythonPackage):
     homepage = "https://pypi.python.org/pypi/astor"
     url      = "https://pypi.io/packages/source/a/astor/astor-0.8.0.tar.gz"
 
-    version('0.8.0', '37a6eed8b371f1228db08234ed7f6cfdc7817a3ed3824797e20cbb11dc2a7862')
-    version('0.6', '175ec395cde36aa0178c5a3120d03954c65d1ef4bb19ec4aa30e9d7a7cc426c4')
+    version('0.8.0', sha256='37a6eed8b371f1228db08234ed7f6cfdc7817a3ed3824797e20cbb11dc2a7862')
+    version('0.6', sha256='175ec395cde36aa0178c5a3120d03954c65d1ef4bb19ec4aa30e9d7a7cc426c4')
 
     depends_on('python@2.7:2.8,3.4:')
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-astor/package.py
+++ b/var/spack/repos/builtin/packages/py-astor/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack import *
+
+class PyAstor(PythonPackage):
+    """
+    astor is designed to allow easy manipulation of Python source via the AST.
+    """
+
+    homepage = "https://pypi.python.org/pypi/astor"
+    url      = "https://pypi.io/packages/source/a/astor/astor-0.8.0.tar.gz"
+
+    version('0.8.0', '37a6eed8b371f1228db08234ed7f6cfdc7817a3ed3824797e20cbb11dc2a7862')
+    version('0.6', '175ec395cde36aa0178c5a3120d03954c65d1ef4bb19ec4aa30e9d7a7cc426c4')
+
+    depends_on('python@2.7:2.8,3.4:')
+    depends_on('py-setuptools', type='build')
+    depends_on('py-nose', type='test')
+    depends_on('py-astunparse', type='test')

--- a/var/spack/repos/builtin/packages/py-astor/package.py
+++ b/var/spack/repos/builtin/packages/py-astor/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from spack import *
 
+
 class PyAstor(PythonPackage):
     """
     astor is designed to allow easy manipulation of Python source via the AST.

--- a/var/spack/repos/builtin/packages/py-astunparse/package.py
+++ b/var/spack/repos/builtin/packages/py-astunparse/package.py
@@ -1,3 +1,7 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from spack import *
 
 

--- a/var/spack/repos/builtin/packages/py-astunparse/package.py
+++ b/var/spack/repos/builtin/packages/py-astunparse/package.py
@@ -1,0 +1,18 @@
+from spack import *
+
+
+class PyAstunparse(PythonPackage):
+    """An AST unparser for Python.
+
+    This is a factored out version of unparse found in the Python source
+    distribution; under Demo/parser in Python 2 and under Tools/parser in
+    Python 3."""
+
+    homepage = "https://pypi.org/project/astunparse/"
+    url      = "https://pypi.io/packages/source/a/astunparse/astunparse-1.6.2.tar.gz"
+
+    version('1.6.2', sha256='dab3e426715373fd76cd08bb1abe64b550f5aa494cf1e32384f26fd60961eb67')
+
+    depends_on('py-setuptools', type='build')
+    depends_on('py-wheel@0.23.0:0.99.99',        type=('build', 'run'))
+    depends_on('py-six@1.6.1:1.99.99',        type=('build', 'run'))


### PR DESCRIPTION
Are the license headers no longer a requirement? `spack create https://pypi.io/packages/source/a/astunparse/astunparse-1.6.2.tar.gz` did not automatically create it