### PR TITLE
add glx variant to libepoxy

### DIFF
--- a/var/spack/repos/builtin/packages/libepoxy/package.py
+++ b/var/spack/repos/builtin/packages/libepoxy/package.py
@@ -19,9 +19,22 @@ class Libepoxy(AutotoolsPackage):
     depends_on('pkgconfig', type='build')
     depends_on('meson')
     depends_on('gl')
+    depends_on('libx11', when='+glx')
+
+    variant('glx', default=True, description='enable GLX support')
 
     def configure_args(self):
         # Disable egl, otherwise configure fails with:
         # error: Package requirements (egl) were not met
         # Package 'egl', required by 'virtual:world', not found
-        return ['--enable-egl=no']
+        args = ['--enable-egl=no']
+
+        # --enable-glx defaults to auto and was failing on PPC64LE systems
+        # because libx11 was missing from the dependences. This explicitly
+        # enables/disables glx support.
+        if '+glx' in self.spec:
+            args.append('--enable-glx=yes')
+        else:
+            args.append('--enable-glx=no')
+
+        return args


### PR DESCRIPTION
On PPC64LE systems, libepoxy failed at configure with this error:

configure: error: libX11 headers (libx11-dev) required to build with GLX support

This is because --enable-glx is set to auto by default and was being implicitly turned on. This PR makes sure that glx support is explicitly enabled/disabled, and when enabled, that libx11 is brought in as a dependence.