### PR TITLE
Reference non-expanding resources by "Stage.archive_file"

### DIFF
--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -296,13 +296,21 @@ class Stage(object):
     def expected_archive_files(self):
         """Possible archive file paths."""
         paths = []
+
+        fnames = []
+        expanded = True
         if isinstance(self.default_fetcher, fs.URLFetchStrategy):
-            paths.append(os.path.join(
-                self.path, os.path.basename(self.default_fetcher.url)))
+            expanded = self.default_fetcher.expand_archive
+            fnames.append(os.path.basename(self.default_fetcher.url))
 
         if self.mirror_path:
-            paths.append(os.path.join(
-                self.path, os.path.basename(self.mirror_path)))
+            fnames.append(os.path.basename(self.mirror_path))
+
+        paths.extend(os.path.join(self.path, f) for f in fnames)
+        if not expanded:
+            # If the download file is not compressed, the "archive" is a
+            # single file placed in Stage.source_path
+            paths.extend(os.path.join(self.source_path, f) for f in fnames)
 
         return paths
 

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -465,6 +465,19 @@ class TestStage(object):
             check_setup(stage, None, archive)
         check_destroy(stage, None)
 
+    @pytest.mark.usefixtures('tmpdir_for_stage')
+    def test_noexpand_stage_file(
+            self, mock_stage_archive, mock_noexpand_resource):
+        """When creating a stage with a nonexpanding URL, the 'archive_file'
+        property of the stage should refer to the path of that file.
+        """
+        test_noexpand_fetcher = spack.fetch_strategy.from_kwargs(
+            url='file://' + mock_noexpand_resource, expand=False)
+        with Stage(test_noexpand_fetcher) as stage:
+            stage.fetch()
+            stage.expand_archive()
+            assert os.path.exists(stage.archive_file)
+
     @pytest.mark.disable_clean_stage_check
     @pytest.mark.usefixtures('tmpdir_for_stage')
     def test_composite_stage_with_noexpand_resource(


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/11816

@paulbry

Allow packages to refer to non-expanded downloads (e.g. a single script) using Stage.archive_file. This addresses a regression from https://github.com/spack/spack/pull/11688 and adds a unit test for it.