### PR TITLE
boost: use clang toolset when building with Fujitsu compiler.

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -197,7 +197,8 @@ class Boost(Package):
                     'clang++': 'clang',
                     'xlc++': 'xlcpp',
                     'xlc++_r': 'xlcpp',
-                    'pgc++': 'pgi'}
+                    'pgc++': 'pgi',
+                    'FCC': 'clang'}
 
         if spec.satisfies('@1.47:'):
             toolsets['icpc'] += '-linux'


### PR DESCRIPTION
We will use clang toolset when building with Fujitsu compiler.