### PR TITLE
tcsh: change the download url, add version 6.21.00

### DIFF
--- a/var/spack/repos/builtin/packages/tcsh/package.py
+++ b/var/spack/repos/builtin/packages/tcsh/package.py
@@ -19,7 +19,7 @@ class Tcsh(AutotoolsPackage):
 
     version('6.21.00', sha256='c438325448371f59b12a4c93bfd3f6982e6f79f8c5aef4bc83aac8f62766e972',
             url='http://ftp.funet.fi/pub/mirrors/ftp.astron.com/pub/tcsh/tcsh-6.21.00.tar.gz')
-    version('6.20.00', sha256='59d40ef40a68e790d95e182069431834')
+    version('6.20.00', sha256='b89de7064ab54dac454a266cfe5d8bf66940cb5ed048d0c30674ea62e7ecef9d')
 
     def fedora_patch(commit, file, **kwargs):  # noqa
         prefix = 'https://src.fedoraproject.org/rpms/tcsh/raw/{0}/f/'.format(commit)

--- a/var/spack/repos/builtin/packages/tcsh/package.py
+++ b/var/spack/repos/builtin/packages/tcsh/package.py
@@ -15,11 +15,11 @@ class Tcsh(AutotoolsPackage):
     syntax."""
 
     homepage = "http://www.tcsh.org/"
-    url      = "http://ftp.funet.fi/pub/mirrors/ftp.astron.com/pub/tcsh/tcsh-6.21.00.tar.gz"
+    url      = "http://ftp.funet.fi/pub/mirrors/ftp.astron.com/pub/tcsh/old/tcsh-6.20.00.tar.gz"
 
-    version('6.21.00', sha256='c438325448371f59b12a4c93bfd3f6982e6f79f8c5aef4bc83aac8f62766e972')
-    version('6.20.00', '59d40ef40a68e790d95e182069431834',
-            url='http://ftp.funet.fi/pub/mirrors/ftp.astron.com/pub/tcsh/old/tcsh-6.20.00.tar.gz') 
+    version('6.21.00', sha256='c438325448371f59b12a4c93bfd3f6982e6f79f8c5aef4bc83aac8f62766e972',
+            url='http://ftp.funet.fi/pub/mirrors/ftp.astron.com/pub/tcsh/tcsh-6.21.00.tar.gz')
+    version('6.20.00', sha256='59d40ef40a68e790d95e182069431834')
 
     def fedora_patch(commit, file, **kwargs):  # noqa
         prefix = 'https://src.fedoraproject.org/rpms/tcsh/raw/{0}/f/'.format(commit)

--- a/var/spack/repos/builtin/packages/tcsh/package.py
+++ b/var/spack/repos/builtin/packages/tcsh/package.py
@@ -15,9 +15,11 @@ class Tcsh(AutotoolsPackage):
     syntax."""
 
     homepage = "http://www.tcsh.org/"
-    url      = "ftp://ftp.astron.com/pub/tcsh/tcsh-6.20.00.tar.gz"
+    url      = "http://ftp.funet.fi/pub/mirrors/ftp.astron.com/pub/tcsh/tcsh-6.21.00.tar.gz"
 
-    version('6.20.00', '59d40ef40a68e790d95e182069431834')
+    version('6.21.00', sha256='c438325448371f59b12a4c93bfd3f6982e6f79f8c5aef4bc83aac8f62766e972')
+    version('6.20.00', '59d40ef40a68e790d95e182069431834',
+            url='http://ftp.funet.fi/pub/mirrors/ftp.astron.com/pub/tcsh/old/tcsh-6.20.00.tar.gz') 
 
     def fedora_patch(commit, file, **kwargs):  # noqa
         prefix = 'https://src.fedoraproject.org/rpms/tcsh/raw/{0}/f/'.format(commit)


### PR DESCRIPTION
The download url of the tcsh package was invalid because the following error occurred.
"The requested url returned error: 404 Not Found"

So, I changed the download url and added the latest version (version 6.21.00).