### PR TITLE
bib2xhtml: change the download url

### DIFF
--- a/var/spack/repos/builtin/packages/bib2xhtml/package.py
+++ b/var/spack/repos/builtin/packages/bib2xhtml/package.py
@@ -10,9 +10,9 @@ from glob import glob
 class Bib2xhtml(Package):
     """bib2xhtml is a program that converts BibTeX files into HTML."""
     homepage = "http://www.spinellis.gr/sw/textproc/bib2xhtml/"
-    url = 'http://www.spinellis.gr/sw/textproc/bib2xhtml/bib2xhtml-v3.0-15-gf506.tar.gz'
+    url = 'https://www.spinellis.gr/sw/textproc/bib2xhtml/bib2xhtml-v3.0-79-ge935.tar.gz'
 
-    version('3.0-15-gf506', 'a26ba02fe0053bbbf2277bdf0acf8645')
+    version('3.0-79-ge935', sha256='4a2d2d89dd2f3fed1c735055b806809b5cc1cde32dee1aa5987097ec5bf2181f')
 
     def install(self, spec, prefix):
         # Add the bst include files to the install directory


### PR DESCRIPTION
The download url of the bib2xhtml package was invalid because the following error occurred.
"The requested url returned error: 404 Not Found"

So, I changed the download url.
The version of the bib2xhtml package provided by the vendor has changed from "v3.0-15-gf506" to "v3.0-79-ge935".
"https://www.spinellis.gr/sw/textproc/bib2xhtml/"