### PR TITLE
f90cache: change the download url

### DIFF
--- a/var/spack/repos/builtin/packages/f90cache/package.py
+++ b/var/spack/repos/builtin/packages/f90cache/package.py
@@ -17,3 +17,5 @@ class F90cache(AutotoolsPackage):
     url      = "https://perso.univ-rennes1.fr/edouard.canot/f90cache/f90cache-0.99c.tar.gz"
 
     version('0.99c', sha256='13f8297ecba73671d43376b71ef0e453bd9d6677a901d1c95f01f16cc33776e1')
+    version('0.99', 'e4767ae876203ed4f3e118e22204cdec',
+            url='http://distfiles.exherbo.org/distfiles/f90cache-0.99.tar.bz2')

--- a/var/spack/repos/builtin/packages/f90cache/package.py
+++ b/var/spack/repos/builtin/packages/f90cache/package.py
@@ -14,6 +14,6 @@ class F90cache(AutotoolsPackage):
        great speedup in common compilations.
     """
     homepage = "https://perso.univ-rennes1.fr/edouard.canot/f90cache/"
-    url      = "https://perso.univ-rennes1.fr/edouard.canot/f90cache/f90cache-0.99.tar.bz2"
+    url      = "https://perso.univ-rennes1.fr/edouard.canot/f90cache/f90cache-0.99c.tar.gz"
 
-    version('0.99', 'e4767ae876203ed4f3e118e22204cdec')
+    version('0.99c', sha256='13f8297ecba73671d43376b71ef0e453bd9d6677a901d1c95f01f16cc33776e1')


### PR DESCRIPTION
The download url of the f90cache package was invalid because the following error occurred.
"The requested url returned error: 404 Not Found"

So, I changed the download url.
The version of the f90cache package provided by the vendor has changed from "0.99" to "0.99c".
"https://perso.univ-rennes1.fr/edouard.canot/f90cache/"