### PR TITLE
Cmake/add option for fujitsu compiler

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -109,6 +109,10 @@ class Cmake(Package):
 
     phases = ['bootstrap', 'build', 'install']
 
+    def setup_environment(self, spack_env, run_env):
+        if self.compiler.name == 'fj':
+            spack_env.append_flags('CXXFLAGS', '-std=c++11')
+
     def bootstrap_args(self):
         spec = self.spec
         args = [

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -110,7 +110,9 @@ class Cmake(Package):
     phases = ['bootstrap', 'build', 'install']
 
     def setup_environment(self, spack_env, run_env):
-        if self.compiler.name == 'fj':
+        if self.compiler.name == 'fj' \
+                and self.compiler.cxx11_flag \
+                not in self.spec.compiler_flags['cxxflags']:
             spack_env.append_flags('CXXFLAGS', self.compiler.cxx11_flag)
 
     def bootstrap_args(self):

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -111,7 +111,7 @@ class Cmake(Package):
 
     def setup_environment(self, spack_env, run_env):
         if self.compiler.name == 'fj':
-            spack_env.append_flags('CXXFLAGS', '-std=c++11')
+            spack_env.append_flags('CXXFLAGS', self.compiler.cxx11_flag)
 
     def bootstrap_args(self):
         spec = self.spec


### PR DESCRIPTION
When installing cmake with Fujitsu compiler, add the process of setting the environment variable to build based on the C++11 specification.