### PR TITLE
gotcha: fixed to build on ARM.

### DIFF
--- a/var/spack/repos/builtin/packages/gotcha/arm.patch
+++ b/var/spack/repos/builtin/packages/gotcha/arm.patch
@@ -1,0 +1,19 @@
+commit 6f494384b0f00513d950b94a60c14ad1c20eb353
+Author: David Poliakoff <david.poliakoff@gmail.com>
+Date:   Thu Sep 20 10:59:54 2018 -0700
+
+    Pushed fix to help build on ARM systems
+
+diff --git a/src/libc_wrappers.c b/src/libc_wrappers.c
+index 504e31a..5937e5a 100644
+--- a/src/libc_wrappers.c
++++ b/src/libc_wrappers.c
+@@ -358,7 +358,7 @@ int gotcha_open(const char *pathname, int flags, ...)
+    }
+    va_end(args);
+ 
+-   result = syscall(SYS_open, pathname, flags, mode);
++   result = syscall(SYS_openat, AT_FDCWD, pathname, flags, mode);
+    if (result >= 0)
+       return (int) result;
+    

--- a/var/spack/repos/builtin/packages/gotcha/package.py
+++ b/var/spack/repos/builtin/packages/gotcha/package.py
@@ -19,6 +19,7 @@ class Gotcha(CMakePackage):
     version('0.0.2', tag='0.0.2')
 
     variant('test', default=False, description='Build tests for Gotcha')
+    patch('arm.patch', when='@1.0.2')
 
     def configure_args(self):
         spec = self.spec


### PR DESCRIPTION
gotcha install fail the following message:

    >> 56    /usr/local/spack/var/spack/stage/gotcha-1.0.2-chlsywpzmeffiqynie65b4
                  fxd3x5wkca/src/src/libc_wrappers.c:361:21: error: 'SYS_open' undecla
                   red (first use in this function)
       57        result = syscall(SYS_open, pathname, flags, mode)

This error is fixed by pull request of gotcha (https://github.com/LLNL/GOTCHA/pull/79), but this is not merged:

This patch is aplly this patch in current version.