### PR TITLE
llvm: Extend version check for CppBackend to exclude flang versions of llvm

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -664,7 +664,7 @@ class Llvm(CMakePackage):
         if '+all_targets' not in spec:  # all is default on cmake
 
             targets = ['NVPTX', 'AMDGPU']
-            if (spec.version < Version('3.9.0') 
+            if (spec.version < Version('3.9.0')
                 and (str(spec.version)[:2] != 'fl')):
                 # Starting in 3.9.0 CppBackend is no longer a target (see
                 # LLVM_ALL_TARGETS in llvm's top-level CMakeLists.txt for

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -665,13 +665,13 @@ class Llvm(CMakePackage):
 
             targets = ['NVPTX', 'AMDGPU']
             if (spec.version < Version('3.9.0')
-                and (str(spec.version)[:2] != 'fl')):
+                and spec.version[0] != 'flang'):
                 # Starting in 3.9.0 CppBackend is no longer a target (see
                 # LLVM_ALL_TARGETS in llvm's top-level CMakeLists.txt for
                 # the complete list of targets)
 
                 # This also applies to the version of llvm used by flang
-                # hence the test to see if the version starts with "fl".
+                # hence the test to see if the version starts with "flang".
                 targets.append('CppBackend')
 
             if 'x86' in spec.architecture.target.lower():

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -664,12 +664,13 @@ class Llvm(CMakePackage):
         if '+all_targets' not in spec:  # all is default on cmake
 
             targets = ['NVPTX', 'AMDGPU']
-            if (spec.version < Version('3.9.0') and (str(spec.version)[:2] != 'fl')):
+            if (spec.version < Version('3.9.0') 
+                and (str(spec.version)[:2] != 'fl')):
                 # Starting in 3.9.0 CppBackend is no longer a target (see
                 # LLVM_ALL_TARGETS in llvm's top-level CMakeLists.txt for
                 # the complete list of targets)
 
-                # This also applies to the version of llvm used by flang 
+                # This also applies to the version of llvm used by flang
                 # hence the test to see if the version starts with "fl".
                 targets.append('CppBackend')
 

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -664,10 +664,13 @@ class Llvm(CMakePackage):
         if '+all_targets' not in spec:  # all is default on cmake
 
             targets = ['NVPTX', 'AMDGPU']
-            if spec.version < Version('3.9.0'):
+            if (spec.version < Version('3.9.0') and (str(spec.version)[:2] != 'fl')):
                 # Starting in 3.9.0 CppBackend is no longer a target (see
                 # LLVM_ALL_TARGETS in llvm's top-level CMakeLists.txt for
                 # the complete list of targets)
+
+                # This also applies to the version of llvm used by flang 
+                # hence the test to see if the version starts with "fl".
                 targets.append('CppBackend')
 
             if 'x86' in spec.architecture.target.lower():


### PR DESCRIPTION
When compiling llvm@flang-20180921 build fails because it tries to compile the `CppBackend` backend to LLVM which no longer exists in LLVM.  This is because for some reason the version check incorrectly decides that this is an older version of LLVM than 3.9.0.  This change extends this check to disable `CppBackend` for `spec.version`s that start with `fl`.