### PR TITLE
Rename py-pytables -> py-tables

### DIFF
--- a/var/spack/repos/builtin/packages/partitionfinder/package.py
+++ b/var/spack/repos/builtin/packages/partitionfinder/package.py
@@ -19,7 +19,7 @@ class Partitionfinder(Package):
     depends_on('python@2.7.10:2.999', type=('build', 'run'))
     depends_on('py-numpy', type=('build', 'run'))
     depends_on('py-pandas', type=('build', 'run'))
-    depends_on('py-pytables', type=('build', 'run'))
+    depends_on('py-tables', type=('build', 'run'))
     depends_on('py-pyparsing', type=('build', 'run'))
     depends_on('py-scipy', type=('build', 'run'))
     depends_on('py-scikit-learn', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-sfepy/package.py
+++ b/var/spack/repos/builtin/packages/py-sfepy/package.py
@@ -27,5 +27,5 @@ class PySfepy(PythonPackage):
     depends_on('py-matplotlib', type='run')
     depends_on('py-sympy', type='run')
     depends_on('hdf5+hl', type='run')
-    depends_on('py-pytables', type='run')
+    depends_on('py-tables', type='run')
     depends_on('py-petsc4py', type='run', when='+petsc')

--- a/var/spack/repos/builtin/packages/py-tables/package.py
+++ b/var/spack/repos/builtin/packages/py-tables/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class PyPytables(PythonPackage):
+class PyTables(PythonPackage):
     """PyTables is a package for managing hierarchical datasets and designed to
     efficiently and easily cope with extremely large amounts of data."""
     homepage = "http://www.pytables.org/"


### PR DESCRIPTION
The developers refer to their software as `PyTables`, but the package name on PyPI is just `tables`. The package name in Conda is `Pytables`, but the module that you import is called `tables`. I usually like to default to the PyPI package name, as that is what you will see in the `setup.py` whenever a package lists its dependencies.