### PR TITLE
boost: Fix build with XL/nvcc

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -248,8 +248,8 @@ class Boost(Package):
                 # error: version = <unspecified>
                 # error: previous initialization at ./user-config.jam:1
 
-                # Specifies -std=c++11 flag when using XL, which is needed
-                # for boost.thread
+                # -std=c++11 flag is needed for compiling boost.thread.
+                # Some compilers do not turn this on by default
                 f.write("using {0} : : {1} : {2} ;\n".format(boost_toolset_id,
                                                              spack_cxx,
                                                              spack_cxxflags))

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -234,9 +234,11 @@ class Boost(Package):
         if '+python' in spec:
             options.append('--with-python=%s' % spec['python'].command.path)
 
+        # -std=c++11 flag is needed for compiling boost.thread.
         spack_cxxflags = ''
         if spec.satisfies('%xl'):
-            spack_cxxflags = '<cxxflags>-std=c++11'
+            # XL does not turn on 11 by default.
+            spack_cxxflags = '<cxxflags>{0}'.format(self.compiler.cxx11_flag)
 
         with open('user-config.jam', 'w') as f:
             # Boost may end up using gcc even though clang+gfortran is set in
@@ -247,9 +249,6 @@ class Boost(Package):
                 # error: duplicate initialization of intel-linux with the following parameters:  # noqa
                 # error: version = <unspecified>
                 # error: previous initialization at ./user-config.jam:1
-
-                # -std=c++11 flag is needed for compiling boost.thread.
-                # Some compilers do not turn this on by default
                 f.write("using {0} : : {1} : {2} ;\n".format(boost_toolset_id,
                                                              spack_cxx,
                                                              spack_cxxflags))

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -243,8 +243,10 @@ class Boost(Package):
                 # error: duplicate initialization of intel-linux with the following parameters:  # noqa
                 # error: version = <unspecified>
                 # error: previous initialization at ./user-config.jam:1
-                f.write("using {0} : : {1} ;\n".format(boost_toolset_id,
-                                                       spack_cxx))
+                # Also, specifies -std=c++11 flag when using XL, which is needed for boost.thread
+                f.write("using {0} : : {1} : {2} ;\n".format(boost_toolset_id,
+                                                             spack_cxx,
+                                                             '<cxxflags>-std=c++11' if spec.satisfies('%xl') else ''))
 
             if '+mpi' in spec:
                 # Use the correct mpi compiler.  If the compiler options are

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -234,6 +234,10 @@ class Boost(Package):
         if '+python' in spec:
             options.append('--with-python=%s' % spec['python'].command.path)
 
+        spack_cxxflags = ''
+        if spec.satisfies('%xl'):
+            spack_cxxflags = '<cxxflags>-std=c++11'
+
         with open('user-config.jam', 'w') as f:
             # Boost may end up using gcc even though clang+gfortran is set in
             # compilers.yaml. Make sure this does not happen:
@@ -243,10 +247,12 @@ class Boost(Package):
                 # error: duplicate initialization of intel-linux with the following parameters:  # noqa
                 # error: version = <unspecified>
                 # error: previous initialization at ./user-config.jam:1
-                # Also, specifies -std=c++11 flag when using XL, which is needed for boost.thread
+
+                # Specifies -std=c++11 flag when using XL, which is needed
+                # for boost.thread
                 f.write("using {0} : : {1} : {2} ;\n".format(boost_toolset_id,
                                                              spack_cxx,
-                                                             '<cxxflags>-std=c++11' if spec.satisfies('%xl') else ''))
+                                                             spack_cxxflags))
 
             if '+mpi' in spec:
                 # Use the correct mpi compiler.  If the compiler options are

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -234,11 +234,8 @@ class Boost(Package):
         if '+python' in spec:
             options.append('--with-python=%s' % spec['python'].command.path)
 
-        # -std=c++11 flag is needed for compiling boost.thread.
-        spack_cxxflags = ''
-        if spec.satisfies('%xl'):
-            # XL does not turn on 11 by default.
-            spack_cxxflags = '<cxxflags>{0}'.format(self.compiler.cxx11_flag)
+        # C++11 is required for boost libraries with some compilers.
+        spack_cxxflags = '<cxxflags>{0}'.format(self.compiler.cxx11_flag)
 
         with open('user-config.jam', 'w') as f:
             # Boost may end up using gcc even though clang+gfortran is set in

--- a/var/spack/repos/builtin/packages/bzip2/package.py
+++ b/var/spack/repos/builtin/packages/bzip2/package.py
@@ -46,6 +46,13 @@ class Bzip2(Package):
             filter_file('-Wall -Winline', '-Minform=inform', 'Makefile')
             filter_file('-Wall -Winline', '-Minform=inform', 'Makefile-libbz2_so')  # noqa
 
+
+        # The Makefiles use GCC flags that are incompatible with XL and nvcc
+        if self.compiler.name == 'xl':
+            filter_file('-fpic', '', 'Makefile')
+            filter_file('-fpic', '', 'Makefile-libbz2_so')
+            filter_file('bzip2.c libbz2.so.1.0.6', 'bzip2.c -L. -l:libbz2.so.1.0.6', 'Makefile-libbz2_so')
+
         # Patch the link line to use RPATHs on macOS
         if 'darwin' in self.spec.architecture:
             v = self.spec.version

--- a/var/spack/repos/builtin/packages/bzip2/package.py
+++ b/var/spack/repos/builtin/packages/bzip2/package.py
@@ -46,12 +46,13 @@ class Bzip2(Package):
             filter_file('-Wall -Winline', '-Minform=inform', 'Makefile')
             filter_file('-Wall -Winline', '-Minform=inform', 'Makefile-libbz2_so')  # noqa
 
-
         # The Makefiles use GCC flags that are incompatible with XL and nvcc
         if self.compiler.name == 'xl':
             filter_file('-fpic', '', 'Makefile')
             filter_file('-fpic', '', 'Makefile-libbz2_so')
-            filter_file('bzip2.c libbz2.so.1.0.6', 'bzip2.c -L. -l:libbz2.so.1.0.6', 'Makefile-libbz2_so')
+            filter_file('bzip2.c libbz2.so.1.0.6',
+                        'bzip2.c -L. -l:libbz2.so.1.0.6',
+                        'Makefile-libbz2_so')
 
         # Patch the link line to use RPATHs on macOS
         if 'darwin' in self.spec.architecture:

--- a/var/spack/repos/builtin/packages/bzip2/package.py
+++ b/var/spack/repos/builtin/packages/bzip2/package.py
@@ -50,8 +50,8 @@ class Bzip2(Package):
         if self.compiler.name == 'xl':
             filter_file('-fpic', '', 'Makefile')
             filter_file('-fpic', '', 'Makefile-libbz2_so')
-            filter_file('bzip2.c libbz2.so.1.0.6',
-                        'bzip2.c -L. -l:libbz2.so.1.0.6',
+            filter_file('bzip2.c libbz2.so.{0}'.format(self.spec.version),
+                        'bzip2.c -L. -l:libbz2.so.{0}'.format(self.spec.version),
                         'Makefile-libbz2_so')
 
         # Patch the link line to use RPATHs on macOS


### PR DESCRIPTION
This addresses two issue found when trying to build boost with XL as:
```
$ spack install boost@1.69 %xl
```
bzip2 issues:
- xl does not support `-fpic`. `-fPIC` is supported.
- nvcc does not support absolute paths to shared objects. Requires `-L. -l:<lib>` syntax.

boost issues:
- boost.thread uses decltype and therefore requires the c++11 standard. Modern xlC versions seem not to default to C++11.

This is my first contribution to spack, so I would appreciate any suggestions to improve it. Thanks!