### PR TITLE
ncl: Fix build

### DIFF
--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -91,6 +91,7 @@ class Gdal(AutotoolsPackage):
     # Required dependencies
     depends_on('libtiff@3.6.0:')  # 3.9.0+ needed to pass testsuite
     depends_on('libgeotiff@1.2.1:')
+    depends_on('libgeotiff@:1.4', when='@:2.4')
     depends_on('libgeotiff@1.5:', when='@3:')
     depends_on('json-c', when='@2.3:')
     depends_on('json-c@0.12.1', when='@:2.2')

--- a/var/spack/repos/builtin/packages/ncl/package.py
+++ b/var/spack/repos/builtin/packages/ncl/package.py
@@ -76,7 +76,7 @@ class Ncl(Package):
 
     # Some of the optional dependencies according to the manual:
     depends_on('hdf', when='+hdf4')
-    depends_on('gdal', when='+gdal')
+    depends_on('gdal+proj@:2.4', when='+gdal')
     depends_on('udunits2', when='+udunits2')
 
     # We need src files of triangle to appear in ncl's src tree if we want


### PR DESCRIPTION
ncl does not build with newer versions of gdal (or rather proj). This also needs a small change to gdal, otherwise we end up with both proj@5 and proj@6 in the spec.