### PR TITLE
openspeedshop: fixed build on arm.

### DIFF
--- a/var/spack/repos/builtin/packages/openspeedshop-utils/arm.patch
+++ b/var/spack/repos/builtin/packages/openspeedshop-utils/arm.patch
@@ -1,0 +1,25 @@
+diff --git a/plugins/views/iot/iot_view.cxx b/plugins/views/iot/iot_view.cxx
+index f4cdf48..ef1b81f 100644
+--- a/plugins/views/iot/iot_view.cxx
++++ b/plugins/views/iot/iot_view.cxx
+@@ -45,6 +45,20 @@ int64_t application_elapsed_time = 0.0;
+ # endif
+ #endif
+ /* End part 2 of 2 for Hack to get around inconsistent syscall definitions */
++/* Start Added Hack to get around inconsistent syscall definitions */
++#ifndef SYS_open
++#define SYS_open SYS_openat
++#endif
++#ifndef SYS_creat
++#define SYS_creat SYS_openat
++#endif
++#ifndef SYS_dup2
++#define SYS_dup2 SYS_dup3
++#endif
++#ifndef SYS_pipe
++#define SYS_pipe SYS_pipe2
++#endif
++/* end Added Hack to get around inconsistent syscall definitions */
+ 
+ 
+ 

--- a/var/spack/repos/builtin/packages/openspeedshop-utils/arm.patch
+++ b/var/spack/repos/builtin/packages/openspeedshop-utils/arm.patch
@@ -2,7 +2,7 @@ diff --git a/plugins/views/iot/iot_view.cxx b/plugins/views/iot/iot_view.cxx
 index f4cdf48..ef1b81f 100644
 --- a/plugins/views/iot/iot_view.cxx
 +++ b/plugins/views/iot/iot_view.cxx
-@@ -45,6 +45,20 @@ int64_t application_elapsed_time = 0.0;
+@@ -45,6 +45,20 @@
  # endif
  #endif
  /* End part 2 of 2 for Hack to get around inconsistent syscall definitions */

--- a/var/spack/repos/builtin/packages/openspeedshop-utils/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop-utils/package.py
@@ -142,6 +142,7 @@ class OpenspeedshopUtils(CMakePackage):
     depends_on("mrnet@5.0.1-3:+cti", when='@2.3.1.3:9999+cti', type=('build', 'link', 'run'))
     depends_on("mrnet@5.0.1-3:+lwthreads", when='@2.3.1.3:9999', type=('build', 'link', 'run'))
 
+    patch('arm.patch', when='target=aarch64')
     parallel = False
 
     build_directory = 'build_openspeedshop'

--- a/var/spack/repos/builtin/packages/openspeedshop/arm.patch
+++ b/var/spack/repos/builtin/packages/openspeedshop/arm.patch
@@ -1,0 +1,25 @@
+diff --git a/plugins/views/iot/iot_view.cxx b/plugins/views/iot/iot_view.cxx
+index f4cdf48..ef1b81f 100644
+--- a/plugins/views/iot/iot_view.cxx
++++ b/plugins/views/iot/iot_view.cxx
+@@ -45,6 +45,20 @@ int64_t application_elapsed_time = 0.0;
+ # endif
+ #endif
+ /* End part 2 of 2 for Hack to get around inconsistent syscall definitions */
++/* Start Added Hack to get around inconsistent syscall definitions */
++#ifndef SYS_open
++#define SYS_open SYS_openat
++#endif
++#ifndef SYS_creat
++#define SYS_creat SYS_openat
++#endif
++#ifndef SYS_dup2
++#define SYS_dup2 SYS_dup3
++#endif
++#ifndef SYS_pipe
++#define SYS_pipe SYS_pipe2
++#endif
++/* end Added Hack to get around inconsistent syscall definitions */
+ 
+ 
+ 

--- a/var/spack/repos/builtin/packages/openspeedshop/arm.patch
+++ b/var/spack/repos/builtin/packages/openspeedshop/arm.patch
@@ -2,7 +2,7 @@ diff --git a/plugins/views/iot/iot_view.cxx b/plugins/views/iot/iot_view.cxx
 index f4cdf48..ef1b81f 100644
 --- a/plugins/views/iot/iot_view.cxx
 +++ b/plugins/views/iot/iot_view.cxx
-@@ -45,6 +45,20 @@ int64_t application_elapsed_time = 0.0;
+@@ -45,6 +45,20 @@
  # endif
  #endif
  /* End part 2 of 2 for Hack to get around inconsistent syscall definitions */

--- a/var/spack/repos/builtin/packages/openspeedshop/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop/package.py
@@ -141,6 +141,7 @@ class Openspeedshop(CMakePackage):
     depends_on("mrnet@5.0.1-3:+cti", when='@2.3.1.3:9999+cti', type=('build', 'link', 'run'))
     depends_on("mrnet@5.0.1-3:+lwthreads", when='@2.3.1.3:9999', type=('build', 'link', 'run'))
 
+    patch('arm.patch', when='target=aarch64')
     parallel = False
 
     build_directory = 'build_openspeedshop'


### PR DESCRIPTION
openspeedshop and openspeedshop-utils  use some linux system call number.
But aarch64 linux kernel is deprecated some system call (For example, open).
This patch replace deprecated system call to existed system call.