### PR TITLE
cctools: fixed to build on ARM.

### DIFF
--- a/var/spack/repos/builtin/packages/cctools/arm.patch
+++ b/var/spack/repos/builtin/packages/cctools/arm.patch
@@ -1,0 +1,28 @@
+diff --git a/resource_monitor/src/rmonitor_helper.c b/resource_monitor/src/rmonitor_helper.c
+index 3953da7..3a2a616 100644
+--- a/resource_monitor/src/rmonitor_helper.c
++++ b/resource_monitor/src/rmonitor_helper.c
+@@ -294,7 +294,11 @@ int open(const char *path, int flags, ...)
+ 	va_end(ap);
+ 
+ 	if(!original_open) {
++#ifdef SYS_open
+ 		return syscall(SYS_open, path, flags, mode);
++#else
++		return syscall(SYS_openat, AT_FDCWD, path, flags, mode);
++#endif
+ 	}
+ 
+ 	debug(D_RMON, "open %s from %d.\n", path, getpid());
+@@ -337,7 +341,11 @@ int open64(const char *path, int flags, ...)
+ 	va_end(ap);
+ 
+ 	if(!original_open64) {
++#ifdef SYS_open
+ 		return syscall(SYS_open, path, flags | O_LARGEFILE, mode);
++#else
++		return syscall(SYS_openat, AT_FDCWD, path, flags | O_LARGEFILE, mode);
++#endif
+ 	}
+ 
+ 	debug(D_RMON, "open64 %s from %d.\n", path, getpid());

--- a/var/spack/repos/builtin/packages/cctools/package.py
+++ b/var/spack/repos/builtin/packages/cctools/package.py
@@ -24,6 +24,7 @@ class Cctools(AutotoolsPackage):
     depends_on('swig')
     # depends_on('xrootd')
     depends_on('zlib')
+    patch('arm.patch', when='target=aarch64')
 
     # Generally SYS_foo is defined to __NR_foo (sys/syscall.h) which
     # is then defined to a syscall number (asm/unistd_64.h).  Certain


### PR DESCRIPTION
cctols use some linux system call directory.
But aarch64 linux kernel is deprecated some system call (For example, open).
This patch replace deprecated system call to existed system call.