### PR TITLE
font-util: Add missing mkfontdir build dependency

### DIFF
--- a/var/spack/repos/builtin/packages/font-util/package.py
+++ b/var/spack/repos/builtin/packages/font-util/package.py
@@ -18,6 +18,7 @@ class FontUtil(AutotoolsPackage):
 
     depends_on('bdftopcf', type='build')
     depends_on('mkfontscale', type='build')
+    depends_on('mkfontdir', type='build')
 
     font_baseurl = 'https://www.x.org/archive/individual/font/'
     fonts = []


### PR DESCRIPTION
Some of the fonts now included in font-util need mkfontdir to build.