### PR TITLE
Fixed a Python 2.6 parsing error

### DIFF
--- a/lib/spack/spack/parse.py
+++ b/lib/spack/spack/parse.py
@@ -143,7 +143,7 @@ class Parser(object):
 
     def setup(self, text):
         if isinstance(text, string_types):
-            text = shlex.split(text)
+            text = shlex.split(str(text))
         self.text = text
         self.push_tokens(self.lexer.lex(text))
 

--- a/lib/spack/spack/test/cmd/release_jobs.py
+++ b/lib/spack/spack/test/cmd/release_jobs.py
@@ -3,10 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import pytest
-
 import json
-import sys
 
 from jsonschema import validate
 
@@ -39,11 +36,6 @@ def test_specs_deps(tmpdir, config):
     validate(deps_object, specs_deps_schema)
 
 
-@pytest.mark.skipif(
-    sys.version_info[:2] < (2, 7),
-    reason="For some reason in Python2.6 we get a utf-32 string "
-           "that can't be parsed"
-)
 def test_specs_staging(config):
     """Make sure we achieve the best possible staging for the following
 spec DAG::

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -97,7 +97,7 @@ class TestSpecSyntax(object):
 
     def check_lex(self, tokens, spec):
         """Check that the provided spec parses to the provided token list."""
-        spec = shlex.split(spec)
+        spec = shlex.split(str(spec))
         lex_output = sp.SpecLexer().lex(spec)
         for tok, spec_tok in zip(tokens, lex_output):
             if tok.type == sp.ID or tok.type == sp.VAL:

--- a/lib/spack/spack/util/editor.py
+++ b/lib/spack/spack/util/editor.py
@@ -41,7 +41,7 @@ def _find_exe_from_env_var(var):
         return None, []
 
     # split env var into executable and args if needed
-    args = shlex.split(exe)
+    args = shlex.split(str(exe))
     if not args:
         return None, []
 

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -20,7 +20,7 @@ class Executable(object):
     """Class representing a program that can be run on the command line."""
 
     def __init__(self, name):
-        self.exe = shlex.split(name)
+        self.exe = shlex.split(str(name))
         self.default_env = {}
         self.returncode = None
 


### PR DESCRIPTION
fixes #12268 

Apparently `shlex.split` can't deal with unicode encoded characters in Python 2.6. The solution is to convert to `str` before calling the function.