### PR TITLE
fixing PMDK dependency: ncurses missing

### DIFF
--- a/var/spack/repos/builtin/packages/pmdk/package.py
+++ b/var/spack/repos/builtin/packages/pmdk/package.py
@@ -21,6 +21,7 @@ class Pmdk(Package):
     version('1.6',     sha256='3b99e6c30709326a94d2e73a9247a8dfb58d0a394c5b7714e5c3d8a3ad2e2e9f')
     version('1.5',     sha256='6b069d7207febeb62440e89245e8b18fcdf40b6170d2ec2ef33c252ed16db2d4')
 
+    depends_on('ncurses', when='@1.6:')
     # documentation requires doxygen and a bunch of other dependencies
     patch('0001-make-doc-building-explicit.patch')
 


### PR DESCRIPTION
Apparently PMDK 1.6 cannot be built without ncurses. This PR fixes the dependency.