### PR TITLE
Allow uninstalling missing packages

### DIFF
--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -78,10 +78,13 @@ class DirectoryLayout(object):
 
         if spec.external:
             return spec.external_path
-        if self.check_upstream and spec.package.installed_upstream:
-            raise SpackError(
-                "Internal error: attempted to call path_for_spec on"
-                " upstream-installed package.")
+        if self.check_upstream:
+            upstream, record = spack.store.db.query_by_spec_hash(
+                spec.dag_hash())
+            if upstream:
+                raise SpackError(
+                    "Internal error: attempted to call path_for_spec on"
+                    " upstream-installed package.")
 
         path = self.relative_path_for_spec(spec)
         assert(not path.startswith(self.root))


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/11870

Remove package access from directory_layout; add regression test to ensure that specs can be uninstalled without a package being known