### PR TITLE
blast-plus: remove --with-64 on ARM.

### DIFF
--- a/var/spack/repos/builtin/packages/blast-plus/package.py
+++ b/var/spack/repos/builtin/packages/blast-plus/package.py
@@ -102,10 +102,11 @@ class BlastPlus(AutotoolsPackage):
             '--with-bin-release',
             '--without-debug',
             '--with-mt',
-            '--with-64',
             '--without-boost',
         ]
 
+        if not 'aarch64' in spec.architecture.target.lower():
+            config_args.append('--with-64')
         if '+static' in spec:
             config_args.append('--with-static')
             # FIXME

--- a/var/spack/repos/builtin/packages/blast-plus/package.py
+++ b/var/spack/repos/builtin/packages/blast-plus/package.py
@@ -105,7 +105,7 @@ class BlastPlus(AutotoolsPackage):
             '--without-boost',
         ]
 
-        if not 'aarch64' in spec.architecture.target.lower():
+        if 'aarch64' not in spec.architecture.target.lower():
             config_args.append('--with-64')
         if '+static' in spec:
             config_args.append('--with-static')


### PR DESCRIPTION
blast-plus package pass --with-64 flag to configure, 
and configure is checked compiler to -m64 flag is correct.
But gcc on aarch64 dose not support -m64.

This patch remove --with-64 flag if target is aarch64.
