### PR TITLE
py-antlr4-python3-runtime: new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-antlr4-python3-runtime/package.py
+++ b/var/spack/repos/builtin/packages/py-antlr4-python3-runtime/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyAntlr4Python3Runtime(PythonPackage):
+    """ANTLR (ANother Tool for Language Recognition) is a powerful parser generator
+for reading, processing, executing, or translating structured text or binary files.
+This package provides an ANTLR interface for python3."""
+
+    homepage = "https://www.antlr.org"
+    url      = "https://pypi.io/packages/source/a/antlr4-python3-runtime/antlr4-python3-runtime-4.7.2.tar.gz"
+
+    version('4.7.2', sha256='168cdcec8fb9152e84a87ca6fd261b3d54c8f6358f42ab3b813b14a7193bb50b')
+
+    depends_on('python@3:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-antlr4-python3-runtime/package.py
+++ b/var/spack/repos/builtin/packages/py-antlr4-python3-runtime/package.py
@@ -7,10 +7,9 @@ from spack import *
 
 
 class PyAntlr4Python3Runtime(PythonPackage):
-    """ANTLR (ANother Tool for Language Recognition) is a powerful
-    parser generator for reading, processing, executing, or translating
-    structured text or binary files.
-    This package provides an ANTLR interface for python3.
+    """This package provides runtime libraries required to use
+    parsers generated for the Python3 language by version 4 of 
+    ANTLR (ANother Tool for Language Recognition).
     """
 
     homepage = "https://www.antlr.org"

--- a/var/spack/repos/builtin/packages/py-antlr4-python3-runtime/package.py
+++ b/var/spack/repos/builtin/packages/py-antlr4-python3-runtime/package.py
@@ -7,8 +7,9 @@ from spack import *
 
 
 class PyAntlr4Python3Runtime(PythonPackage):
-    """ANTLR (ANother Tool for Language Recognition) is a powerful parser generator
-for reading, processing, executing, or translating structured text or binary files.
+    """ANTLR (ANother Tool for Language Recognition) is a powerful
+parser generator for reading, processing, executing, or translating
+structured text or binary files.
 This package provides an ANTLR interface for python3."""
 
     homepage = "https://www.antlr.org"

--- a/var/spack/repos/builtin/packages/py-antlr4-python3-runtime/package.py
+++ b/var/spack/repos/builtin/packages/py-antlr4-python3-runtime/package.py
@@ -8,7 +8,7 @@ from spack import *
 
 class PyAntlr4Python3Runtime(PythonPackage):
     """This package provides runtime libraries required to use
-    parsers generated for the Python3 language by version 4 of 
+    parsers generated for the Python3 language by version 4 of
     ANTLR (ANother Tool for Language Recognition).
     """
 

--- a/var/spack/repos/builtin/packages/py-antlr4-python3-runtime/package.py
+++ b/var/spack/repos/builtin/packages/py-antlr4-python3-runtime/package.py
@@ -8,9 +8,10 @@ from spack import *
 
 class PyAntlr4Python3Runtime(PythonPackage):
     """ANTLR (ANother Tool for Language Recognition) is a powerful
-parser generator for reading, processing, executing, or translating
-structured text or binary files.
-This package provides an ANTLR interface for python3."""
+    parser generator for reading, processing, executing, or translating
+    structured text or binary files.
+    This package provides an ANTLR interface for python3.
+    """
 
     homepage = "https://www.antlr.org"
     url      = "https://pypi.io/packages/source/a/antlr4-python3-runtime/antlr4-python3-runtime-4.7.2.tar.gz"


### PR DESCRIPTION
This package provides runtime libraries required to use parsers generated by ANTLR4 for the Python3 language.

The package is needed by the py-cf-units package (#11891).