### PR TITLE
tk: avoid search for X headers and libraries

### DIFF
--- a/var/spack/repos/builtin/packages/tk/package.py
+++ b/var/spack/repos/builtin/packages/tk/package.py
@@ -65,7 +65,9 @@ class Tk(AutotoolsPackage):
 
     def configure_args(self):
         spec = self.spec
-        return ['--with-tcl={0}'.format(spec['tcl'].prefix.lib)]
+        return ['--with-tcl={0}'.format(spec['tcl'].prefix.lib),
+                '--x-includes={0}'.format(spec['libx11'].prefix.include),
+                '--x-libraries={0}'.format(spec['libx11'].prefix.lib)]
 
     @run_after('install')
     def symlink_wish(self):


### PR DESCRIPTION
The `configure` script in the tk package searches for X11 libraries and header files in standard directories. This PR ensures that X11 packages provided by spack are used instead.