### PR TITLE
py-netcdf4: depend on hdf5+hl

### DIFF
--- a/var/spack/repos/builtin/packages/py-netcdf4/package.py
+++ b/var/spack/repos/builtin/packages/py-netcdf4/package.py
@@ -23,7 +23,7 @@ class PyNetcdf4(PythonPackage):
     depends_on('py-cftime', type=('build', 'run'))
 
     depends_on('netcdf')
-    depends_on('hdf5@1.8.0:')
+    depends_on('hdf5@1.8.0:+hl')
 
     def setup_environment(self, spack_env, run_env):
         """Ensure installed netcdf and hdf5 libraries are used"""


### PR DESCRIPTION
`spack spec py-netcdf4` produces the following error message:

```
netcdf requires hdf5 variant +hl, but spec asked for ~hl
```

py-netcdf4 depends on netcdf, which depends on `hdf5+hl`. py-netcdf4 also depends on `hdf5`, which uses variant `hdf5~hl` by default, causing a conflict. We can resolve the conflict by depending on `hdf5+hl` in py-netcdf4.