### PR TITLE
Encode and decode fields from Unified Model

### DIFF
--- a/var/spack/repos/builtin/packages/libmo-unpack/package.py
+++ b/var/spack/repos/builtin/packages/libmo-unpack/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class LibmoUnpack(CMakePackage):
+    """A library for handling the WGDOS and RLE compression schemes
+    used in UM files."""
+
+    homepage = "https://github.com/SciTools/libmo_unpack"
+    url      = "https://github.com/SciTools/libmo_unpack/archive/v3.1.2.tar.gz"
+
+    version('3.1.2', sha256='e09ef3e6f1075144acc5d6466b4ef70b2fe32ed4ab1840dd4fb7e15a40f3d370')
+
+    depends_on('check')

--- a/var/spack/repos/builtin/packages/py-mo-pack/package.py
+++ b/var/spack/repos/builtin/packages/py-mo-pack/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyMoPack(PythonPackage):
+    """Packing methods used to encode and decode the data payloads of
+    Met Office Unified Model 'fields'"""
+
+    homepage = "https://github.com/SciTools/mo_pack"
+    url      = "https://github.com/SciTools/mo_pack/archive/v0.2.0.tar.gz"
+
+    version('0.2.0', sha256='4aa70e1f846b666670843bc2514435dedf7393203e88abaf74d48f8f2717a726')
+
+    depends_on('libmo-unpack')
+    depends_on('py-numpy', type=('build', 'run'))
+    depends_on('py-cython', type=('build', 'run'))


### PR DESCRIPTION
The Unified Model is an atmospheric model developed by the UK Met Office in partnership with researchers and weather services around the world. Outputs from the model are usually stored in a custom binary format (although netcdf can also be used in some applications). This package provides a library and a python interface to encode and decode fields from the binary files.

The package is required by py-scitools-iris, which is coming soon in a separate PR.