### PR TITLE
style: remove unnecessary NOQA exception

### DIFF
--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -825,15 +825,15 @@ class TestSpecSematics(object):
                 spec.format(fmt_str)
 
         bad_formats = [
-            '{}',
-            'name}',
-            '\{name}',  # NOQA: ignore=W605
-            '{name',
-            '{name\}',  # NOQA: ignore=W605
-            '{_concrete}',
-            '{dag_hash}',
-            '{foo}',
-            '{+variants.debug}'
+            r'{}',
+            r'name}',
+            r'\{name}',
+            r'{name',
+            r'{name\}',
+            r'{_concrete}',
+            r'{dag_hash}',
+            r'{foo}',
+            r'{+variants.debug}'
         ]
 
         for fmt_str in bad_formats:


### PR DESCRIPTION
This removes some unnecessary noqa's from the Spack code.  Specifically:

```python
    '\{name}',  # NOQA: ignore=W605
```

This one is actually borderline erroneous, as it relies on `'\{'` not being a valid escape sequence. If at some point it _became_ a valid escape, the code would be wrong.

Lines like the above one should either be written:
```python
    '\\{name}',
```

or (probably preferable):
```python
    r'\{name}',
```

I've found that `W605` is nearly always raised correctly -- we should pay attention to it.

cc: @becker33 @scheibelp 
