### PR TITLE
diffsplice: remove -m64 on ARM.

### DIFF
--- a/var/spack/repos/builtin/packages/diffsplice/package.py
+++ b/var/spack/repos/builtin/packages/diffsplice/package.py
@@ -17,6 +17,11 @@ class Diffsplice(MakefilePackage):
     version('0.1.2beta', 'a1df6e0b50968f2c229d5d7f97327336')
     version('0.1.1',     'be90e6c072402d5aae0b4e2cbb8c10ac')
 
+    def edit(self, spec, prefix):
+        if 'aarch64' in spec.architecture.target.lower():
+            makefile = FileFilter(join_path(self.build_directory, 'Makefile'))
+            makefile.filter('-m64', '')
+
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
         install('diffsplice', prefix.bin)

--- a/var/spack/repos/builtin/packages/diffsplice/package.py
+++ b/var/spack/repos/builtin/packages/diffsplice/package.py
@@ -18,7 +18,7 @@ class Diffsplice(MakefilePackage):
     version('0.1.1',     'be90e6c072402d5aae0b4e2cbb8c10ac')
 
     def edit(self, spec, prefix):
-        if 'aarch64' in spec.architecture.target.lower():
+        if spec.satisfies('target=aarch64'):
             makefile = FileFilter(join_path(self.build_directory, 'Makefile'))
             makefile.filter('-m64', '')
 


### PR DESCRIPTION
diffsplice package is useed -m64 flag to compile.
But gcc on aarch64 dose not support -m64.

This patch remove -m64 flag if target is aarch64.