### PR TITLE
planck-likelihood: remove -m64 on ARM

### DIFF
--- a/var/spack/repos/builtin/packages/planck-likelihood/arm.patch
+++ b/var/spack/repos/builtin/packages/planck-likelihood/arm.patch
@@ -1,0 +1,16 @@
+diff -ur spack-src/Makefile new/Makefile
+--- spack-src/Makefile	2015-04-28 02:21:27.000000000 +0900
++++ new/Makefile	2019-07-01 15:12:04.985193793 +0900
+@@ -186,10 +186,10 @@
+ else
+ DEFINES = $(DEFINESLINUX) $(DEFINESCOMMON)
+ ifndef CM64
+-CM64 = -m64
++CM64 =
+ endif
+ ifndef FM64
+-FM64 = -m64
++FM64 =
+ endif
+ endif
+ 

--- a/var/spack/repos/builtin/packages/planck-likelihood/package.py
+++ b/var/spack/repos/builtin/packages/planck-likelihood/package.py
@@ -27,6 +27,7 @@ class PlanckLikelihood(Package):
 
     patch('fortran.patch')
     patch('make.patch')
+    patch('arm.patch', when='target=aarch64')
 
     resource(
         name='baseline',


### PR DESCRIPTION
planck-likelihood package is useed -m64 flag to compile.
But gcc on aarch64 dose not support -m64.

This patch remove -m64 flag if target is aarch64.