### PR TITLE
portcullis: remove -m64 on aarch64.

### DIFF
--- a/var/spack/repos/builtin/packages/portcullis/package.py
+++ b/var/spack/repos/builtin/packages/portcullis/package.py
@@ -45,6 +45,11 @@ class Portcullis(AutotoolsPackage):
             'scripts/Makefile.am', string=True
         )
 
+        # remove -m64 on aarch64
+        if 'aarch64' in self.spec.architecture.target.lower():
+            for f in ['lib/Makefile.am', 'src/Makefile.am']:
+                filter_file('-m64', '', f)
+
     def build(self, spec, prefix):
         # build manpages
         make('man')

--- a/var/spack/repos/builtin/packages/portcullis/package.py
+++ b/var/spack/repos/builtin/packages/portcullis/package.py
@@ -46,7 +46,7 @@ class Portcullis(AutotoolsPackage):
         )
 
         # remove -m64 on aarch64
-        if 'aarch64' in self.spec.architecture.target.lower():
+        if self.spec.satisfies('target=aarch64'):
             for f in ['lib/Makefile.am', 'src/Makefile.am']:
                 filter_file('-m64', '', f)
 


### PR DESCRIPTION
portcullis package is useed -m64 flag to compile.
But gcc on aarch64 dose not support -m64.

This patch remove -m64 flag if target is aarch64.