### PR TITLE
Typo in py-markdown

### DIFF
--- a/var/spack/repos/builtin/packages/py-markdown/package.py
+++ b/var/spack/repos/builtin/packages/py-markdown/package.py
@@ -33,6 +33,6 @@ class PyMarkdown(PythonPackage):
 
     depends_on('python@2.7:2.8,3.2:3.4', when='@:2.6.7')
     depends_on('python@2.7:2.8,3.2:3.6', when='@2.6.8:2.6.11')
-    depends_on('python@2.7,2.8,3.3.5:', when='@3.1.1:')
+    depends_on('python@2.7:2.8,3.3.5:', when='@3.1.1:')
 
     depends_on('py-setuptools', type='build', when='@2.6.11:')


### PR DESCRIPTION
The last depends_on has a comma rather than a semicolon separating
python2 versions.