### PR TITLE
py-stratify: vertical interpolation/stratification of atmos/ocean data

### DIFF
--- a/var/spack/repos/builtin/packages/py-stratify/package.py
+++ b/var/spack/repos/builtin/packages/py-stratify/package.py
@@ -13,9 +13,9 @@ class PyStratify(PythonPackage):
     """
 
     homepage = "https://github.com/SciTools-incubator/python-stratify"
-    url      = "https://github.com/SciTools-incubator/python-stratify/archive/v0.1.tar.gz"
+    url      = "https://pypi.io/packages/source/s/stratify/stratify-0.1.tar.gz"
 
-    version('0.1', sha256='e154383bd2336122d153daa85f5ec9f5ba7639df0bf6ee66a52a7fb7b30d3377')
+    version('0.1', sha256='5426f3b66e45e1010952d426e5a7be42cd45fe65f1cd73a98fee1eb7c110c6ee')
 
     depends_on('py-setuptools', type='build')
     depends_on('py-numpy',      type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-stratify/package.py
+++ b/var/spack/repos/builtin/packages/py-stratify/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyStratify(PythonPackage):
+    """Vectorized interpolators that are especially useful for
+    Nd vertical interpolation/stratification of atmospheric and
+    oceanographic datasets.
+    """
+
+    homepage = "https://github.com/SciTools-incubator/python-stratify"
+    url      = "https://github.com/SciTools-incubator/python-stratify/archive/v0.1.tar.gz"
+
+    version('0.1', sha256='e154383bd2336122d153daa85f5ec9f5ba7639df0bf6ee66a52a7fb7b30d3377')
+
+    depends_on('py-setuptools', type='build')
+    depends_on('py-numpy',      type=('build', 'run'))
+    depends_on('py-cython',     type=('build', 'run'))


### PR DESCRIPTION
The purpose of this package is explained in https://github.com/SciTools-incubator/python-stratify/blob/master/index.ipynb:

> Whilst this is not the only use for the stratify package, NWP vertical interpolation was the motivating usecase for the package's creation.

> In its simplest form, vertical interpolation amounts to a 1d interpolation at each grid-point. Whilst some more sophistication exists for a number of interpolators, stratify can be seen as an optimisation to vectorize these interpolations beyond naïve nested for-loops.

Requirement for py-scitools-iris (coming soon).