### PR TITLE
Py-scitools-iris: python library for analysing and visualising Earth science data

### DIFF
--- a/var/spack/repos/builtin/packages/py-scitools-iris/package.py
+++ b/var/spack/repos/builtin/packages/py-scitools-iris/package.py
@@ -15,6 +15,8 @@ class PyScitoolsIris(PythonPackage):
 
     version('2.2.0', sha256='1bf8853f5d7a210f711636d32a52ff62b84a56330fe159720ef56f36f3804ade')
 
+    patch('remove_site_cfg.patch', when='@2.2.0')
+
     depends_on('py-six', type=('build', 'run'))
     depends_on('py-pyke', type=('build', 'run'))
     depends_on('py-cartopy', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-scitools-iris/package.py
+++ b/var/spack/repos/builtin/packages/py-scitools-iris/package.py
@@ -15,8 +15,8 @@ class PyScitoolsIris(PythonPackage):
 
     version('2.2.0', sha256='1bf8853f5d7a210f711636d32a52ff62b84a56330fe159720ef56f36f3804ade')
 
-    depends_on('py-six', type='build')
-    depends_on('py-pyke', type='build')
+    depends_on('py-six', type=('build', 'run'))
+    depends_on('py-pyke', type=('build', 'run'))
     depends_on('py-cartopy', type=('build', 'run'))
     depends_on('proj@4:4.99')
     depends_on('py-cf-units', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-scitools-iris/package.py
+++ b/var/spack/repos/builtin/packages/py-scitools-iris/package.py
@@ -1,0 +1,49 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install py-scitools-iris
+#
+# You can edit this file again by typing:
+#
+#     spack edit py-scitools-iris
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+from spack import *
+
+
+class PyScitoolsIris(PythonPackage):
+    """A powerful, format-agnostic, community-driven Python library for
+    analysing and visualising Earth science data"""
+
+    homepage = "http://scitools.org.uk"
+    url      = "https://pypi.io/packages/source/s/scitools-iris/scitools-iris-2.2.0.tar.gz"
+
+    version('2.2.0', sha256='1bf8853f5d7a210f711636d32a52ff62b84a56330fe159720ef56f36f3804ade')
+
+    #depends_on('py-setuptools', type='build')
+    depends_on('py-cartopy', type=('build', 'run'))
+    depends_on('py-cf-units', type=('build', 'run'))
+    depends_on('py-cftime', type=('build', 'run'))
+    depends_on('py-dask', type=('build', 'run'))
+    depends_on('py-matplotlib@2:2.99', type=('build', 'run'))
+    depends_on('py-netcdf4', type=('build', 'run'))
+    depends_on('py-numpy', type=('build', 'run'))
+    depends_on('py-scipy', type=('build', 'run'))
+
+    def build_args(self, spec, prefix):
+        # FIXME: Add arguments other than --prefix
+        # FIXME: If not needed delete this function
+        args = []
+        return args

--- a/var/spack/repos/builtin/packages/py-scitools-iris/package.py
+++ b/var/spack/repos/builtin/packages/py-scitools-iris/package.py
@@ -16,6 +16,7 @@ class PyScitoolsIris(PythonPackage):
     version('2.2.0', sha256='1bf8853f5d7a210f711636d32a52ff62b84a56330fe159720ef56f36f3804ade')
 
     #depends_on('py-setuptools', type='build')
+    depends_on('py-six', type='build')
     depends_on('py-pyke', type='build')
     depends_on('py-cartopy', type=('build', 'run'))
     depends_on('proj@4:4.99')

--- a/var/spack/repos/builtin/packages/py-scitools-iris/package.py
+++ b/var/spack/repos/builtin/packages/py-scitools-iris/package.py
@@ -17,6 +17,7 @@ class PyScitoolsIris(PythonPackage):
 
     #depends_on('py-setuptools', type='build')
     depends_on('py-cartopy', type=('build', 'run'))
+    depends_on('proj@4:4.99')
     depends_on('py-cf-units', type=('build', 'run'))
     depends_on('py-cftime', type=('build', 'run'))
     depends_on('py-dask', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-scitools-iris/package.py
+++ b/var/spack/repos/builtin/packages/py-scitools-iris/package.py
@@ -27,3 +27,9 @@ class PyScitoolsIris(PythonPackage):
     depends_on('py-numpy', type=('build', 'run'))
     depends_on('py-scipy', type=('build', 'run'))
 
+    depends_on('py-mo-pack', type=('build', 'run'))
+    depends_on('py-nc-time-axis', type=('build', 'run'))
+    depends_on('py-pandas', type=('build', 'run'))
+    depends_on('py-stratify', type=('build', 'run'))
+    depends_on('py-pyugrid', type=('build', 'run'))
+    depends_on('graphviz')

--- a/var/spack/repos/builtin/packages/py-scitools-iris/package.py
+++ b/var/spack/repos/builtin/packages/py-scitools-iris/package.py
@@ -16,6 +16,7 @@ class PyScitoolsIris(PythonPackage):
     version('2.2.0', sha256='1bf8853f5d7a210f711636d32a52ff62b84a56330fe159720ef56f36f3804ade')
 
     #depends_on('py-setuptools', type='build')
+    depends_on('py-pyke', type='build')
     depends_on('py-cartopy', type=('build', 'run'))
     depends_on('proj@4:4.99')
     depends_on('py-cf-units', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-scitools-iris/package.py
+++ b/var/spack/repos/builtin/packages/py-scitools-iris/package.py
@@ -3,23 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-# ----------------------------------------------------------------------------
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install py-scitools-iris
-#
-# You can edit this file again by typing:
-#
-#     spack edit py-scitools-iris
-#
-# See the Spack documentation for more information on packaging.
-# ----------------------------------------------------------------------------
-
 from spack import *
 
 

--- a/var/spack/repos/builtin/packages/py-scitools-iris/package.py
+++ b/var/spack/repos/builtin/packages/py-scitools-iris/package.py
@@ -17,6 +17,7 @@ class PyScitoolsIris(PythonPackage):
 
     patch('remove_site_cfg.patch', when='@2.2.0')
 
+    depends_on('py-setuptools', type='build')
     depends_on('py-six', type=('build', 'run'))
     depends_on('py-pyke', type=('build', 'run'))
     depends_on('py-cartopy', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-scitools-iris/package.py
+++ b/var/spack/repos/builtin/packages/py-scitools-iris/package.py
@@ -15,7 +15,6 @@ class PyScitoolsIris(PythonPackage):
 
     version('2.2.0', sha256='1bf8853f5d7a210f711636d32a52ff62b84a56330fe159720ef56f36f3804ade')
 
-    #depends_on('py-setuptools', type='build')
     depends_on('py-six', type='build')
     depends_on('py-pyke', type='build')
     depends_on('py-cartopy', type=('build', 'run'))
@@ -28,8 +27,3 @@ class PyScitoolsIris(PythonPackage):
     depends_on('py-numpy', type=('build', 'run'))
     depends_on('py-scipy', type=('build', 'run'))
 
-    def build_args(self, spec, prefix):
-        # FIXME: Add arguments other than --prefix
-        # FIXME: If not needed delete this function
-        args = []
-        return args

--- a/var/spack/repos/builtin/packages/py-scitools-iris/remove_site_cfg.patch
+++ b/var/spack/repos/builtin/packages/py-scitools-iris/remove_site_cfg.patch
@@ -1,0 +1,8 @@
+--- a/lib/iris/etc/site.cfg	2017-06-01 19:54:28.000000000 +1000
++++ b/lib/iris/etc/site.cfg	1970-01-01 10:00:00.000000000 +1000
+@@ -1,5 +0,0 @@
+-[System]
+-udunits2_path = /home/h04/dkillick/usr/local/miniconda/envs/travis_env/lib/libudunits2.so
+-
+-[Resources]
+-test_data_dir = /home/h04/dkillick/git/iris-test-data/test_data


### PR DESCRIPTION
According to the documentation at https://scitools.org.uk/iris/docs/latest/:

> Iris implements a data model based on the CF conventions giving you a powerful, format-agnostic interface for working with your data. It excels when working with multi-dimensional Earth Science data, where tabular representations become unwieldy and inefficient.

Iris can read, write and visualise gridded data in netcdf, grib and UM formats. It is especially useful when working with the Unified Model, which is developed by the UK Met Office and numerous collaborators for weather and climate forecasts.