### PR TITLE
Ferret: add version 7.2 and adjust dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/ferret/package.py
+++ b/var/spack/repos/builtin/packages/ferret/package.py
@@ -59,29 +59,20 @@ class Ferret(Package):
         filter_file(r'-lm',
                     '-lgfortran -lm',
                     'FERRET/platform_specific.mk.x86_64-linux')
+        filter_file(r'\$\(NETCDF4_DIR\)/lib64/libnetcdff.a',
+                    "-L%s -lnetcdff" % self.spec['netcdf-fortran'].prefix.lib,
+                    'FERRET/platform_specific.mk.x86_64-linux')
+        filter_file(r'\$\(NETCDF4_DIR\)/lib64/libnetcdf.a',
+                    "-L%s -lnetcdf" % self.spec['netcdf'].prefix.lib,
+                    'FERRET/platform_specific.mk.x86_64-linux')
+        filter_file(r'\$\(HDF5_DIR\)/lib64/libhdf5_hl.a',
+                    "-L%s -lhdf5_hl" % self.spec['hdf5'].prefix.lib,
+                    'FERRET/platform_specific.mk.x86_64-linux')
+        filter_file(r'\$\(HDF5_DIR\)/lib64/libhdf5.a',
+                    "-L%s -lhdf5" % self.spec['hdf5'].prefix.lib,
+                    'FERRET/platform_specific.mk.x86_64-linux')
 
     def install(self, spec, prefix):
-        hdf5_prefix = spec['hdf5'].prefix
-        netcdff_prefix = spec['netcdf-fortran'].prefix
-        netcdf_prefix = spec['netcdf'].prefix
-        libz_prefix = spec['zlib'].prefix
-        ln = which('ln')
-        ln('-sf',
-           hdf5_prefix + '/lib',
-           hdf5_prefix + '/lib64')
-        ln('-sf',
-           netcdff_prefix + '/lib',
-           netcdff_prefix + '/lib64')
-        ln('-sf',
-           netcdf_prefix + '/lib/libnetcdf.a',
-           netcdff_prefix + '/lib/libnetcdf.a')
-        ln('-sf',
-           netcdf_prefix + '/lib/libnetcdf.la',
-           netcdff_prefix + '/lib/libnetcdf.la')
-        ln('-sf',
-           libz_prefix + '/lib',
-           libz_prefix + '/lib64')
-
         if 'LDFLAGS' in env and env['LDFLAGS']:
             env['LDFLAGS'] += ' ' + '-lquadmath'
         else:

--- a/var/spack/repos/builtin/packages/ferret/package.py
+++ b/var/spack/repos/builtin/packages/ferret/package.py
@@ -18,8 +18,8 @@ class Ferret(Package):
     version('7.2', '21c339b1bafa6939fc869428d906451f130f7e77e828c532ab9488d51cf43095')
     version('6.96', '51722027c864369f41bab5751dfff8cc')
 
-    depends_on("hdf5~mpi")
-    depends_on("netcdf~mpi")
+    depends_on("hdf5+hl")
+    depends_on("netcdf")
     depends_on("netcdf-fortran")
     depends_on("readline")
     depends_on("zlib")

--- a/var/spack/repos/builtin/packages/ferret/package.py
+++ b/var/spack/repos/builtin/packages/ferret/package.py
@@ -17,7 +17,7 @@ class Ferret(Package):
 
     version('6.96', '51722027c864369f41bab5751dfff8cc')
 
-    depends_on("hdf5~mpi~fortran")
+    depends_on("hdf5~mpi")
     depends_on("netcdf~mpi")
     depends_on("netcdf-fortran")
     depends_on("readline")

--- a/var/spack/repos/builtin/packages/ferret/package.py
+++ b/var/spack/repos/builtin/packages/ferret/package.py
@@ -15,6 +15,7 @@ class Ferret(Package):
     homepage = "http://ferret.pmel.noaa.gov/Ferret/home"
     url      = "ftp://ftp.pmel.noaa.gov/ferret/pub/source/fer_source.v696.tar.gz"
 
+    version('7.2', '21c339b1bafa6939fc869428d906451f130f7e77e828c532ab9488d51cf43095')
     version('6.96', '51722027c864369f41bab5751dfff8cc')
 
     depends_on("hdf5~mpi")

--- a/var/spack/repos/builtin/packages/ferret/package.py
+++ b/var/spack/repos/builtin/packages/ferret/package.py
@@ -22,6 +22,7 @@ class Ferret(Package):
     depends_on("netcdf-fortran")
     depends_on("readline")
     depends_on("zlib")
+    depends_on("libx11")
 
     def url_for_version(self, version):
         return "ftp://ftp.pmel.noaa.gov/ferret/pub/source/fer_source.v{0}.tar.gz".format(
@@ -86,7 +87,7 @@ class Ferret(Package):
             env['LDFLAGS'] = '-lquadmath'
 
         with working_dir('FERRET', create=False):
-            os.environ['LD_X11'] = '-L/usr/lib/X11 -lX11'
+            os.environ['LD_X11'] = '-L%s -lX11' % spec['libx11'].prefix.lib
             os.environ['HOSTTYPE'] = 'x86_64-linux'
             make(parallel=False)
             make("install")


### PR DESCRIPTION
The ferret package has not been changed since 2016, and newer versions of the ferret software are now available. This PR provides the current version (7.2).

Ferret can use hdf5 and netcdf with or without mpi, so the variant `~mpi` is unnecessary (and causes extra package installations when `+mpi` packages already exist). However, the `+hl` variant of hdf5 is required to avoid a spec conflict, because the default for hdf5 is `~hl` but netcdf requires `hdf5+hl`.

Ferret searches for X11, and it tries to use system libraries if they exist. We prefer to use libx11 provided by spack, to avoid problems with the ancient X libraries in some HPC operating systems (e.g. RHEL6).

The previous package created symlinks to netcdf, hdf5 and zlib libraries, assuming that static libraries existed. This failed when my spack user configuration requested external versions of netcdf and hdf5 (i.e. from a vendor), because some of the external packages only provided shared libraries. To avoid this problem, I filter the platform configuration used in the ferret Makefile, so that the symlinks are no longer required.