### PR TITLE
binutils: added '-Wno-narrowing' to CXXFLAGS when using fj compiler via flag_handler

### DIFF
--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -76,10 +76,6 @@ class Binutils(AutotoolsPackage):
         if spec.satisfies('platform=darwin'):
             configure_args.append('--program-prefix=g')
 
-        # To ignore the errors of narrowing conversions
-        if self.compiler.name == 'fj':
-            configure_args.append('CXXFLAGS=-Wno-narrowing')
-
         return configure_args
 
     @run_after('install')
@@ -95,3 +91,9 @@ class Binutils(AutotoolsPackage):
             for current_file in glob.glob(join_path(self.build_directory,
                                                     'bfd', '*.h')):
                 install(current_file, extradir)
+
+    def flag_handler(self, name, flags):
+        # To ignore the errors of narrowing conversions for the Fujitsu compiler
+        if name == 'cxxflags' and self.compiler.name == 'fj':
+            flags.append('-Wno-narrowing')
+        return (flags, None, None)

--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -11,7 +11,7 @@ class Binutils(AutotoolsPackage):
     """GNU binutils, which contain the linker, assembler, objdump and others"""
 
     homepage = "http://www.gnu.org/software/binutils/"
-    url      = "https://ftpmirror.gnu.org/binutils/binutils-2.28.tar.bz2"
+    url      = "http://ftp.jaist.ac.jp/pub/GNU/binutils/binutils-2.31.1.tar.bz2"
 
     version('2.31.1', 'ffcc382695bf947da6135e7436b8ed52d991cf270db897190f19d6f9838564d0')
     version('2.29.1', '9af59a2ca3488823e453bb356fe0f113')
@@ -75,6 +75,10 @@ class Binutils(AutotoolsPackage):
         # https://github.com/Homebrew/homebrew-core/blob/master/Formula/binutils.rb
         if spec.satisfies('platform=darwin'):
             configure_args.append('--program-prefix=g')
+
+        # To ignore the errors of narrowing conversions
+        if self.compiler.name == 'fj':
+            configure_args.append('CXXFLAGS=-Wno-narrowing')
 
         return configure_args
 

--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -93,7 +93,9 @@ class Binutils(AutotoolsPackage):
                 install(current_file, extradir)
 
     def flag_handler(self, name, flags):
-        # To ignore the errors of narrowing conversions for the Fujitsu compiler
-        if name == 'cxxflags' and self.compiler.name == 'fj':
+        # To ignore the errors of narrowing conversions for
+        # the Fujitsu compiler
+        if name == 'cxxflags' and self.compiler.name == 'fj'\
+           and self.version <= ver('2.31.1'):
             flags.append('-Wno-narrowing')
         return (flags, None, None)

--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -11,7 +11,7 @@ class Binutils(AutotoolsPackage):
     """GNU binutils, which contain the linker, assembler, objdump and others"""
 
     homepage = "http://www.gnu.org/software/binutils/"
-    url      = "http://ftp.jaist.ac.jp/pub/GNU/binutils/binutils-2.31.1.tar.bz2"
+    url      = "https://ftpmirror.gnu.org/binutils/binutils-2.28.tar.bz2"
 
     version('2.31.1', 'ffcc382695bf947da6135e7436b8ed52d991cf270db897190f19d6f9838564d0')
     version('2.29.1', '9af59a2ca3488823e453bb356fe0f113')


### PR DESCRIPTION
I fixed the download URL because the previous URL are no longer available.

In addition, installing binutils with Fujitsu compiler will cause the following errors:
`x86_64.cc:1592:10: error: case value evaluates to 3221225474, which cannot be narrowed to type 'int' [-Wc++11-narrowing]`

The above cause is narrowing conversions are not allowed by {} initialization, since C++11. 

http://www.stroustrup.com/C++11FAQ.html#narrowing

Therefore, I used `-Wno-narrowing` to ignore the above errors and continue with the previous semantics of silently converting values.

https://gcc.gnu.org/wiki/FAQ#Wnarrowing