### PR TITLE
ESMF,NCL: Bug fixes for Intel Compilers

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/intel.patch
+++ b/var/spack/repos/builtin/packages/esmf/intel.patch
@@ -1,0 +1,17 @@
+--- old/build_config/Linux.intel.default/build_rules.mk	2019-06-27 15:55:30.857527494 -0400
++++ new/build_config/Linux.intel.default/build_rules.mk	2019-06-27 15:56:13.007089627 -0400
+@@ -187,10 +187,10 @@
+ ############################################################
+ # OpenMP compiler and linker flags
+ #
+-ESMF_OPENMP_F90COMPILEOPTS += -openmp
+-ESMF_OPENMP_CXXCOMPILEOPTS += -openmp
+-ESMF_OPENMP_F90LINKOPTS    += -openmp
+-ESMF_OPENMP_CXXLINKOPTS    += -openmp
++ESMF_OPENMP_F90COMPILEOPTS += -qopenmp
++ESMF_OPENMP_CXXCOMPILEOPTS += -qopenmp
++ESMF_OPENMP_F90LINKOPTS    += -qopenmp
++ESMF_OPENMP_CXXLINKOPTS    += -qopenmp
+ 
+ ############################################################
+ # Set rpath syntax

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -101,10 +101,10 @@ class Esmf(MakefilePackage):
         # ESMF will simply not build with Intel using backing GCC 8, in that
         # case you need to point to something older, below is commented but is
         # an example
-        os.environ['ESMF_CXXCOMPILEOPTS'] = \
-            '-O2 -std=c++11 -gcc-name=/usr/bin/gcc'
-        os.environ['ESMF_F90COMPILEOPTS'] = \
-            '-O2 -gcc-name=/usr/bin/gcc'
+        # os.environ['ESMF_CXXCOMPILEOPTS'] = \
+        #     '-O2 -std=c++11 -gcc-name=/usr/bin/gcc'
+        # os.environ['ESMF_F90COMPILEOPTS'] = \
+        #     '-O2 -gcc-name=/usr/bin/gcc'
 
         ############
         # Compiler #

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -42,6 +42,8 @@ class Esmf(MakefilePackage):
     # Testing dependencies
     depends_on('perl', type='test')
 
+    # Make esmf build with newer intel versions
+    patch('intel.patch', when='@:7.0.99 %intel@17:')
     # Make esmf build with newer gcc versions
     # https://sourceforge.net/p/esmf/esmf/ci/3706bf758012daebadef83d6575c477aeff9c89b/
     patch('gcc.patch', when='@:7.0.99 %gcc@6:')
@@ -90,6 +92,19 @@ class Esmf(MakefilePackage):
         os.environ['ESMF_INSTALL_BINDIR'] = 'bin'
         os.environ['ESMF_INSTALL_LIBDIR'] = 'lib'
         os.environ['ESMF_INSTALL_MODDIR'] = 'include'
+
+        # Allow compiler flags to carry through from compiler spec
+        os.environ['ESMF_CXXCOMPILEOPTS'] = \
+            ' '.join(spec.compiler_flags['cxxflags'])
+        os.environ['ESMF_F90COMPILEOPTS'] = \
+            ' '.join(spec.compiler_flags['fflags'])
+        # ESMF will simply not build with Intel using backing GCC 8, in that
+        # case you need to point to something older, below is commented but is
+        # an example
+        os.environ['ESMF_CXXCOMPILEOPTS'] = \
+            '-O2 -std=c++11 -gcc-name=/usr/bin/gcc'
+        os.environ['ESMF_F90COMPILEOPTS'] = \
+            '-O2 -gcc-name=/usr/bin/gcc'
 
         ############
         # Compiler #

--- a/var/spack/repos/builtin/packages/ncl/package.py
+++ b/var/spack/repos/builtin/packages/ncl/package.py
@@ -176,9 +176,9 @@ class Ncl(Package):
             # Build NCL?
             'y\n',
             # Parent installation directory :
-            '\'' + self.spec.prefix + '\'\n',
+            self.spec.prefix + '\n',
             # System temp space directory   :
-            '\'' + tempfile.gettempdir() + '\'\n',
+            tempfile.gettempdir() + '\n',
             # Build NetCDF4 feature support (optional)?
             'y\n'
         ]

--- a/var/spack/repos/builtin/packages/ncl/package.py
+++ b/var/spack/repos/builtin/packages/ncl/package.py
@@ -28,6 +28,8 @@ class Ncl(Package):
     patch('hdf5.patch', when="@6.4.0")
     # ymake-filter's buffer may overflow (upstream as of 6.5.0)
     patch('ymake-filter.patch', when="@6.4.0")
+    # ymake additional local library and includes will be filtered improperly
+    patch('ymake.patch', when="@6.4.0:")
 
     # This installation script is implemented according to this manual:
     # http://www.ncl.ucar.edu/Download/build_from_src.shtml
@@ -59,6 +61,9 @@ class Ncl(Package):
     depends_on('libx11')
     depends_on('libxaw')
     depends_on('libxmu')
+    depends_on('pixman')
+    depends_on('bzip2')
+    depends_on('freetype')
 
     # In Spack, we do not have an option to compile netcdf without netcdf-4
     # support, so we will tell the ncl configuration script that we want
@@ -219,12 +224,12 @@ class Ncl(Package):
             # Build GRIB2 support (optional) into NCL?
             'n\n',
             # Enter local library search path(s) :
-            # The paths will be passed by the Spack wrapper.
-            ' \n',
+            self.spec['pixman'].prefix.lib64 + ' ' +
+            self.spec['bzip2'].prefix.lib64 + '\n',
             # Enter local include search path(s) :
             # All other paths will be passed by the Spack wrapper.
-            '\'' + join_path(self.spec['freetype'].prefix.include,
-                             'freetype2') + '\'\n',
+            join_path(self.spec['freetype'].prefix.include, 'freetype2') +
+            '\n',
             # Go back and make more changes or review?
             'n\n',
             # Save current configuration?

--- a/var/spack/repos/builtin/packages/ncl/package.py
+++ b/var/spack/repos/builtin/packages/ncl/package.py
@@ -224,8 +224,8 @@ class Ncl(Package):
             # Build GRIB2 support (optional) into NCL?
             'n\n',
             # Enter local library search path(s) :
-            self.spec['pixman'].prefix.lib64 + ' ' +
-            self.spec['bzip2'].prefix.lib64 + '\n',
+            self.spec['pixman'].prefix.lib + ' ' +
+            self.spec['bzip2'].prefix.lib + '\n',
             # Enter local include search path(s) :
             # All other paths will be passed by the Spack wrapper.
             join_path(self.spec['freetype'].prefix.include, 'freetype2') +

--- a/var/spack/repos/builtin/packages/ncl/ymake.patch
+++ b/var/spack/repos/builtin/packages/ncl/ymake.patch
@@ -1,0 +1,16 @@
+diff --git a/config/ymake b/config/ymake
+index 7b785bc..ca24dba 100755
+--- a/config/ymake
++++ b/config/ymake
+@@ -649,6 +649,11 @@ case    UNICOS:
+         set cppopt = -N
+         breaksw
+ case    Linux:
++        set cppopt = -traditional-cpp
++        # because local libraries and includes will otherwise have this prefix 
++        # '1-rhel7-1' instead of 'linux-rhel7-x86_64'
++        set defines = "$defines -Dlinux=linux -Dx86_64=x86_64"
++        breaksw
+ case	FreeBSD:
+ case    CYGWIN:
+         set cppopt = -traditional-cpp


### PR DESCRIPTION
This PR targets NCL, but ESMF needs to be fixed as NCL has it as a dependent.
Bug fixes are targeting my testing with Intel 19.0.3 compilers.  However, some other fixes are not Intel compiler based.

## ESMF bug fixes

1. Support Intel 17+ `-qopenmp` where appropriate, this has to be done in a patch because `build_rules.mk` sets the options in the source files.
2. Allow compiler flags to be injected from the compiler spec.

## NCL bug fixes

1. Remove single quote specification in configure script, this keeps some subprograms from linking to libraries properly. 
2. Add in the deps:
```
    depends_on('pixman')
    depends_on('bzip2')
    depends_on('freetype') # should have been there initially
```

Comment: `pixman` and `bzip2` need to be in there because the final `ncl` would not link without the presence of `-lbz2` and `-lpixman-1`.  I was probably more easily able to catch this because of the use of Intel compilers and not having those packages in the matching compiler spec.

3. Apply a new `ymake` patch.  This patch leverages an existing case statement for Linux and should be sufficient to shield against other architectures.

With Linux specifically, there's a funny behavior with `linux` and `x86_64` being a part of the package path.  Preprocessor output looks something like this:

```
grep somefile  -e linux -e x86_64
#define LibSearch -L/usr/local/pacerepov2/spack/packages/0.12/linux-rhel7-x86_64/gcc-8.3.0/freetype-2.9.1-psjwxp5sxil4p6a5najqi7qrlkrtjifr/include/freetype2
#define __x86_64 1
#define __linux 1
#define __linux__ 1
#define __gnu_linux__ 1
#define _ArchDef -Dx86_64
#define x86_64 1
#define __x86_64__ 1
#define linux 1
```

This has the unfortunate effect of defining package paths with substrings `1-rhel7-1`.

At this time, the easiest way to installation happiness is to override the existing preprocessor macro with additional re-definitions of `-Dlinux=linux` and `-Dx86_64=x86_64`

I'm aware there are complaint messages:
```
error: detected recursion whilst expanding macro "linux"
```
But the installation proceeds... There may be a more robust override strategy, but I would like this to be considered as a first-fix measure.
