### PR TITLE
coverage: remove sub-reports; only show project/patch on PRs

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,28 +4,8 @@ coverage:
   range: 60...90
   status:
     project:
-      default: true
-      llnl:
+      default:
         threshold: 0.5
-        paths:
-          - lib/spack/llnl
-      commands:
-        threshold: 0.5
-        paths:
-          - lib/spack/spack/cmd
-      build_systems:
-        threshold: 0.5
-        paths:
-          - lib/spack/spack/build_systems
-      modules:
-        threshold: 0.5
-        paths:
-          - lib/spack/spack/modules
-      core:
-        threshold: 0.5
-        paths:
-          - "!lib/spack/llnl"
-          - "!lib/spack/spack/cmd"
 
 ignore:
   - lib/spack/spack/test/.*


### PR DESCRIPTION
There's too much information on our PRs, and the Travis test results (which are arguably more important than coverage) get buried in coverage information.

- [x] remove coverage sub-categories, as you can browse codecov's file view to see roughly the same thing
- [x] show only project/patch on GitHub PRs.

 cc: @alalazo 