### PR TITLE
Set ignore files for py-reportlab

### DIFF
--- a/var/spack/repos/builtin/packages/py-reportlab/package.py
+++ b/var/spack/repos/builtin/packages/py-reportlab/package.py
@@ -14,3 +14,9 @@ class PyReportlab(PythonPackage):
     url      = "https://pypi.io/packages/source/r/reportlab/reportlab-3.4.0.tar.gz"
 
     version('3.4.0', '3f2522cf3b69cd84426c216619bbff53')
+
+    # py-reportlab provides binaries that duplicate those of other packages,
+    # thus interfering with activation.
+    # - easy_install, provided by py-setuptools
+    # - pip, provided by py-pip
+    extends('python', ignore=r'bin/.*')


### PR DESCRIPTION
The py-reportlab package includes binaries for easy_install and pip.
That blocks activation if py-setuptools and/or py-pip are installed.
This PR block the binaries from py-reportlab as easy_install and pip
should be installed with their respective packages.