### PR TITLE
bugfix: prevent ncurses from overriding the environment's CFLAGS (#11819)

### DIFF
--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -34,8 +34,8 @@ class Ncurses(AutotoolsPackage):
     patch('sed_pgi.patch',   when='@:6.0')
 
     def setup_environment(self, spack_env, run_env):
-            spack_env.append_flags('CFLAGS', self.compiler.pic_flag)
-            spack_env.append_flags('CXXFLAGS', self.compiler.pic_flag)
+        spack_env.append_flags('CFLAGS', self.compiler.pic_flag)
+        spack_env.append_flags('CXXFLAGS', self.compiler.pic_flag)
 
     def configure(self, spec, prefix):
         opts = [

--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -33,10 +33,12 @@ class Ncurses(AutotoolsPackage):
     patch('patch_gcc_5.txt', when='@6.0%gcc@5.0:')
     patch('sed_pgi.patch',   when='@:6.0')
 
+    def setup_environment(self, spack_env, run_env):
+            spack_env.append_flags('CFLAGS', self.compiler.pic_flag)
+            spack_env.append_flags('CXXFLAGS', self.compiler.pic_flag)
+
     def configure(self, spec, prefix):
         opts = [
-            'CFLAGS={0}'.format(self.compiler.pic_flag),
-            'CXXFLAGS={0}'.format(self.compiler.pic_flag),
             '--with-shared',
             '--with-cxx-shared',
             '--enable-overwrite',


### PR DESCRIPTION
This PR attempts to fix the issue of the ncurses build overriding the environment's `CFLAGS`/`CXXFLAGS` (#11819).