### PR TITLE
r-graph: update R constraint to reflect DESCRIPTION

### DIFF
--- a/var/spack/repos/builtin/packages/r-graph/package.py
+++ b/var/spack/repos/builtin/packages/r-graph/package.py
@@ -14,5 +14,5 @@ class RGraph(RPackage):
 
     version('1.54.0', commit='2a8b08520096241620421078fc1098f4569c7301')
 
-    depends_on('r@3.4.0:3.4.9', when='@1.54.0')
+    depends_on('r@2.10:', type=('build', 'run'), when='@1.54.0')
     depends_on('r-biocgenerics', type=('build', 'run'))


### PR DESCRIPTION
The current version constraint matches the appropriate Bioconductor release (R@3.4:3.9) but the DESCRIPTION in this package allows it to build with R >= 2.10.