### PR TITLE
libjpeg-turbo: Use spack flags for cmake building with Fujitsu compiler.

### DIFF
--- a/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
+++ b/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
@@ -38,6 +38,22 @@ class LibjpegTurbo(Package):
     def libs(self):
         return find_libraries("libjpeg*", root=self.prefix, recursive=True)
 
+    def flag_handler(self, name, flags):
+        if self.spec.satisfies('@1.5.90:'):
+            return (None, None, flags)
+        else:
+            # compiler flags for earlier version are injected into the
+            # spack compiler wrapper
+            return (flags, None, None)
+
+    def flags_to_build_system_args(self, flags):
+        # This only handles cflags, other flags are discarded
+        cmake_flag_args = []
+        if 'cflags' in flags and flags['cflags']:
+            cmake_flag_args.append('-DCMAKE_C_FLAGS={0}'.format(
+                                   ' '.join(flags['cflags'])))
+        self.cmake_flag_args = cmake_flag_args
+
     @when('@1.3.1:1.5.3')
     def install(self, spec, prefix):
         autoreconf('-ifv')
@@ -48,13 +64,8 @@ class LibjpegTurbo(Package):
     @when('@1.5.90:')
     def install(self, spec, prefix):
         cmake_args = ['-GUnix Makefiles']
-
-        # For Fujitsu compiler(fj)
-        # Use spack compiler flags for cmake.
-        if self.compiler.name == 'fj':
-            cmake_args.extend(['-DCMAKE_C_FLAGS=%s'
-                              % ''.join(spec.compiler_flags['cflags'])])
-
+        if hasattr(self, 'cmake_flag_args'):
+            cmake_args.extend(self.cmake_flag_args)
         cmake_args.extend(std_cmake_args)
         with working_dir('spack-build', create=True):
             cmake('..', *cmake_args)

--- a/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
+++ b/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
@@ -52,8 +52,8 @@ class LibjpegTurbo(Package):
         # For Fujitsu compiler(fj)
         # Use spack compiler flags for cmake.
         if self.compiler.name == 'fj':
-            cmake_args.extend(['-DCMAKE_C_FLAGS={0}'
-                              .format(env["SPACK_CFLAGS"])])
+            cmake_args.extend(['-DCMAKE_C_FLAGS=%s'
+                              % ''.join(spec.compiler_flags['cflags'])])
 
         cmake_args.extend(std_cmake_args)
         with working_dir('spack-build', create=True):

--- a/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
+++ b/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
@@ -48,6 +48,13 @@ class LibjpegTurbo(Package):
     @when('@1.5.90:')
     def install(self, spec, prefix):
         cmake_args = ['-GUnix Makefiles']
+
+        # For Fujitsu compiler(fj)
+        # Use spack compiler flags for cmake.
+        if self.compiler.name == 'fj':
+            cmake_args.extend(['-DCMAKE_C_FLAGS={0}'
+                              .format(env["SPACK_CFLAGS"])])
+
         cmake_args.extend(std_cmake_args)
         with working_dir('spack-build', create=True):
             cmake('..', *cmake_args)


### PR DESCRIPTION
Cmake executed try_compile when installing libjpeg-turbo, but it was failed with Fujitsu compiler.
Because cmake didn't use compiler flags and Fujitsu compiler needs flags for each environment.

So, we will add spack cflags to cmake options only when using Fujitsu compiler.
※ Libjpeg-turbo doesn't need CXXFLAGS or FFLAGS.