### PR TITLE
motif: fix the download url

### DIFF
--- a/var/spack/repos/builtin/packages/motif/package.py
+++ b/var/spack/repos/builtin/packages/motif/package.py
@@ -12,7 +12,7 @@ class Motif(AutotoolsPackage):
     specification and the widget toolkit
     """
     homepage = "http://motif.ics.com/"
-    url = "http://cfhcable.dl.sourceforge.net/project/motif/Motif 2.3.8 Source Code/motif-2.3.8.tar.gz"
+    url = "http://cfhcable.dl.sourceforge.net/project/motif/Motif%202.3.8%20Source%20Code/motif-2.3.8.tar.gz"
 
     version('2.3.8', '7572140bb52ba21ec2f0c85b2605e2b1')
 


### PR DESCRIPTION
The download URL of the motif package was invalid because the following error occurred.
```
curl: (22) The requested URL returned error: 406 Not Acceptable
==> Fetching from http://cfhcable.dl.sourceforge.net/project/motif/Motif 2.3.8 Source Code/motif-2.3.8.tar.gz failed.
```
The above cause is `Motif 2.3.8 Source Code` of the URL can't be read with blanks.

Therefore, I changed blanks to `%20` and checked the checksum of tarball using the changed URL.
Please see below for the motif checksum:
```
$ curl -O http://cfhcable.dl.sourceforge.net/project/motif/Motif%202.3.8%20Source%20Code/motif-2.3.8.tar.gz

[ogura@langtx202 work]$ md5sum motif-2.3.8.tar.gz
7572140bb52ba21ec2f0c85b2605e2b1  motif-2.3.8.tar.gz
```
The above checksum is the same as the original checksum.
