### PR TITLE
environments: activate/deactivate tests, support `set -u`

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -145,8 +145,12 @@ def activate(
         cmds += 'export SPACK_ENV=%s;\n' % env.path
         cmds += "alias despacktivate='spack env deactivate';\n"
         if prompt:
-            cmds += 'if [ -z "${SPACK_OLD_PS1}" ]; then\n'
-            cmds += 'export SPACK_OLD_PS1="${PS1}"; fi;\n'
+            cmds += 'if [ -z ${SPACK_OLD_PS1+x} ]; then\n'
+            cmds += '    if [ -z ${PS1+x} ]; then\n'
+            cmds += "        PS1='$$$$';\n"
+            cmds += '    fi;\n'
+            cmds += '    export SPACK_OLD_PS1="${PS1}";\n'
+            cmds += 'fi;\n'
             cmds += 'export PS1="%s ${PS1}";\n' % prompt
 
     if add_view and default_view_name in env.views:
@@ -184,11 +188,17 @@ def deactivate(shell='sh'):
         cmds += 'unsetenv SPACK_OLD_PROMPT;\n'
         cmds += 'unalias despacktivate;\n'
     else:
+        cmds += 'if [ ! -z ${SPACK_ENV+x} ]; then\n'
         cmds += 'unset SPACK_ENV; export SPACK_ENV;\n'
+        cmds += 'fi;\n'
         cmds += 'unalias despacktivate;\n'
-        cmds += 'if [ -n "$SPACK_OLD_PS1" ]; then\n'
-        cmds += 'export PS1="$SPACK_OLD_PS1";\n'
-        cmds += 'unset SPACK_OLD_PS1; export SPACK_OLD_PS1;\n'
+        cmds += 'if [ ! -z ${SPACK_OLD_PS1+x} ]; then\n'
+        cmds += '    if [ "$SPACK_OLD_PS1" = \'$$$$\' ]; then\n'
+        cmds += '        unset PS1; export PS1;\n'
+        cmds += '    else\n'
+        cmds += '        export PS1="$SPACK_OLD_PS1";\n'
+        cmds += '    fi;\n'
+        cmds += '    unset SPACK_OLD_PS1; export SPACK_OLD_PS1;\n'
         cmds += 'fi;\n'
 
     if default_view_name in _active_environment.views:

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -766,7 +766,7 @@ def test_env_updates_view_force_remove(
 
 
 def test_env_activate_view_fails(
-        tmpdir, mock_stage, mock_fetch, install_mockery):
+        tmpdir, mock_stage, mock_fetch, install_mockery, env_deactivate):
     """Sanity check on env activate to make sure it requires shell support"""
     out = env('activate', 'test')
     assert "To initialize spack's shell commands:" in out
@@ -1431,3 +1431,41 @@ env:
                 assert not os.path.exists(
                     os.path.join(combin_viewdir, spec.name, '%s-%s' %
                                  (spec.version, spec.compiler.name)))
+
+
+def test_env_activate_sh_prints_shell_output(
+        tmpdir, mock_stage, mock_fetch, install_mockery, env_deactivate
+):
+    """Check the shell commands output by ``spack env activate --sh``.
+
+    This is a cursory check; ``share/spack/qa/setup-env-test.sh`` checks
+    for correctness.
+    """
+    env('create', 'test', add_view=True)
+
+    out = env('activate', '--sh', 'test')
+    assert "export SPACK_ENV=" in out
+    assert "export PS1=" not in out
+    assert "alias despacktivate=" in out
+
+    out = env('activate', '--sh', '--prompt', 'test')
+    assert "export SPACK_ENV=" in out
+    assert "export PS1=" in out
+    assert "alias despacktivate=" in out
+
+
+def test_env_activate_csh_prints_shell_output(
+        tmpdir, mock_stage, mock_fetch, install_mockery, env_deactivate
+):
+    """Check the shell commands output by ``spack env activate --csh``."""
+    env('create', 'test', add_view=True)
+
+    out = env('activate', '--csh', 'test')
+    assert "setenv SPACK_ENV" in out
+    assert "setenv set prompt" not in out
+    assert "alias despacktivate" in out
+
+    out = env('activate', '--csh', '--prompt', 'test')
+    assert "setenv SPACK_ENV" in out
+    assert "set prompt=" in out
+    assert "alias despacktivate" in out


### PR DESCRIPTION
After #4048 I tried running `spack env activate` and `despacktivate` and noticed some problems.  Turned out they were with my environment, but I added shell tests for this stuff anyway.  This actually ended up catching a bug in the code output by `spack env deactivate --sh` -- it now works properly with `set -u`.

- [x] Add shell tests to ensure that `spack env activate`, `spack env deactivate`, and `despacktivate` continue to work.

- [x] Also ensure that activate and deactivate both work with `set -u`