### PR TITLE
tau: add conflicts for libelf/libdwarf variants

### DIFF
--- a/var/spack/repos/builtin/packages/tau/package.py
+++ b/var/spack/repos/builtin/packages/tau/package.py
@@ -83,7 +83,7 @@ class Tau(Package):
     # Elf only required from 2.28.1 on
     conflicts('+libelf', when='@:2.28.0')
     conflicts('+libdwarf', when='@:2.28.0')
-         
+
     filter_compiler_wrappers('tau_cc.sh', 'Makefile.tau', relative_root='bin')
 
     def set_compiler_options(self):

--- a/var/spack/repos/builtin/packages/tau/package.py
+++ b/var/spack/repos/builtin/packages/tau/package.py
@@ -80,6 +80,9 @@ class Tau(Package):
     depends_on('cuda', when='+cuda')
     depends_on('gasnet', when='+gasnet')
 
+    conflicts('+libelf', when='@:2.28.0')  # Elf only required from 2.28.1 on
+    conflicts('+libdwarf', when='@:2.28.0')  # Dwarf only required from 2.28.1 on
+         
     filter_compiler_wrappers('tau_cc.sh', 'Makefile.tau', relative_root='bin')
 
     def set_compiler_options(self):

--- a/var/spack/repos/builtin/packages/tau/package.py
+++ b/var/spack/repos/builtin/packages/tau/package.py
@@ -80,8 +80,9 @@ class Tau(Package):
     depends_on('cuda', when='+cuda')
     depends_on('gasnet', when='+gasnet')
 
-    conflicts('+libelf', when='@:2.28.0')  # Elf only required from 2.28.1 on
-    conflicts('+libdwarf', when='@:2.28.0')  # Dwarf only required from 2.28.1 on
+    # Elf only required from 2.28.1 on
+    conflicts('+libelf', when='@:2.28.0')
+    conflicts('+libdwarf', when='@:2.28.0')
          
     filter_compiler_wrappers('tau_cc.sh', 'Makefile.tau', relative_root='bin')
 


### PR DESCRIPTION
Resolves #11846.

Declare a conflict for TAU versions older than 2.28.1, that they
can't depend on libelf or libdwarf.  The user can still install it
by specifying `tau@2.24~libelf~libdwarf`.