### PR TITLE
bugfix: show dot after namespaces in `spack find -N`

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -264,7 +264,7 @@ def display_specs(specs, args=None, **kwargs):
         hashes = True
         hlen = None
 
-    nfmt = '{namespace}{name}' if namespace else '{name}'
+    nfmt = '{namespace}.{name}' if namespace else '{name}'
     ffmt = ''
     if full_compiler or flags:
         ffmt += '{%compiler.name}'

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -7,7 +7,11 @@ import argparse
 
 import pytest
 import spack.cmd.find
+from spack.main import SpackCommand
 from spack.util.pattern import Bunch
+
+
+find = SpackCommand('find')
 
 
 @pytest.fixture(scope='module')
@@ -98,3 +102,12 @@ def test_tag2_tag3(parser, specs):
     spack.cmd.find.find(parser, args)
 
     assert len(specs) == 0
+
+
+@pytest.mark.db
+def test_namespaces_shown_correctly(database):
+    out = find()
+    assert 'builtin.mock.zmpi' not in out
+
+    out = find('--namespace')
+    assert 'builtin.mock.zmpi' in out


### PR DESCRIPTION
- Namepsaces were shown without dots after the new format strings were added.

- [x] Add the dot back.
- [x] Add a test for `spack find` to ensure that find -N shows the right output.

@becker33: this one should be easy.