### PR TITLE
bugfix: conflicts should print out the spec that has the conflict

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2017,13 +2017,18 @@ class Spec(object):
 
         # Now that the spec is concrete we should check if
         # there are declared conflicts
+        #
+        # TODO: this needs rethinking, as currently we can only express
+        # TODO: internal configuration conflicts within one package.
         matches = []
         for x in self.traverse():
             for conflict_spec, when_list in x.package_class.conflicts.items():
                 if x.satisfies(conflict_spec, strict=True):
                     for when_spec, msg in when_list:
                         if x.satisfies(when_spec, strict=True):
-                            matches.append((x, conflict_spec, when_spec, msg))
+                            when = when_spec.copy()
+                            when.name = x.name
+                            matches.append((x, conflict_spec, when, msg))
         if matches:
             raise ConflictsInSpecError(self, matches)
 


### PR DESCRIPTION
This fix a bug introdcued by removing parse_anonymous_spec() in #10206.  See [this comment](https://github.com/spack/spack/pull/10206#issuecomment-508979049) by @balay.

Conflicts' when specs are now *actually* anonymous, and the name of the package is implicit, so we need to remember to add it back to error messages.

@balay: does this work for you?