### PR TITLE
Preventing jsoncpp from building tests

### DIFF
--- a/var/spack/repos/builtin/packages/jsoncpp/package.py
+++ b/var/spack/repos/builtin/packages/jsoncpp/package.py
@@ -26,4 +26,9 @@ class Jsoncpp(CMakePackage):
     depends_on('python', type='test')
 
     def cmake_args(self):
-        return ['-DBUILD_SHARED_LIBS=ON', '-DJSONCPP_WITH_TESTS=OFF']
+        args = ['-DBUILD_SHARED_LIBS=ON']
+        if self.run_tests:
+            args.append('-DJSONCPP_WITH_TESTS=ON')
+        else:
+            args.append('-DJSONCPP_WITH_TESTS=OFF')
+        return args

--- a/var/spack/repos/builtin/packages/jsoncpp/package.py
+++ b/var/spack/repos/builtin/packages/jsoncpp/package.py
@@ -26,4 +26,4 @@ class Jsoncpp(CMakePackage):
     depends_on('python', type='test')
 
     def cmake_args(self):
-        return ['-DBUILD_SHARED_LIBS=ON']
+        return ['-DBUILD_SHARED_LIBS=ON', '-DJSONCPP_WITH_TESTS=OFF']


### PR DESCRIPTION
By default, jsoncpp will build and execute tests during its build process. This fails on some platforms that use cross-compiling (i.e. compilers used by spack are actually wrappers for cross-compiling to the target hardware). This PR adds `-DJSONCPP_WITH_TESTS=OFF` so that jsoncpp doesn't build its tests.