### PR TITLE
Allow user to specify location of spack user config path

### DIFF
--- a/lib/spack/spack/paths.py
+++ b/lib/spack/spack/paths.py
@@ -47,7 +47,8 @@ packages_path      = os.path.join(repos_path, "builtin")
 mock_packages_path = os.path.join(repos_path, "builtin.mock")
 
 #: User configuration location
-user_config_path = os.path.expanduser('~/.spack')
+user_config_path = os.path.expanduser(
+    os.getenv("SPACK_USER_CONFIG_PATH", '~/.spack'))
 
 
 opt_path        = os.path.join(prefix, "opt")


### PR DESCRIPTION
Environment variable `SPACK_USER_CONFIG_PATH` can optionally specify the location of the user's spack config.

Closes: #506, #11919