### PR TITLE
Add additional options to GROMACS

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -58,10 +58,13 @@ class Gromacs(CMakePackage):
                     'AVX2_128', 'AVX2_256', 'AVX_512', 'AVX_512_KNL',
                     'IBM_QPX', 'Sparc64_HPC_ACE', 'IBM_VMX', 'IBM_VSX',
                     'ARM_NEON', 'ARM_NEON_ASIMD'))
-    variant('rdtscp', default=True, description='Enable RDTSCP instruction usage')
-    variant('subcounters', default=False, description='Enable wallcycle subcounters')
+    variant('rdtscp', default=True,
+            description='Enable RDTSCP instruction usage')
+    variant('subcounters', default=False,
+            description='Enable wallcycle subcounters')
     variant('own_fftw', default=True, description='Build own FFTW')
-    variant('omp_max_threads', default='auto', description='Max number of OpenMP threads',
+    variant('omp_max_threads', default='auto',
+            description='Max number of OpenMP threads',
             values=('auto', '32', '64', '128', '256'))
     variant('static', default=False, description='Prefer static libraries')
     variant('mdrun_only', default=False, description='Build only mdrun')
@@ -116,10 +119,10 @@ class Gromacs(CMakePackage):
 
         if '+subcounters' in self.spec:
             options.append('-DGMX_CYCLE_SUBCOUNTERS:BOOL=ON')
-            
+
         if '+own_fftw' in self.spec:
             options.append('-DGMX_BUILD_OWN_FFTW:BOOL=ON')
-            
+
         if '+mdrun_only' in self.spec:
             options.append('-DGMX_BUILD_MDRUN_ONLY:BOOL=ON')
 
@@ -127,6 +130,7 @@ class Gromacs(CMakePackage):
         if omp_max_threads_value == 'auto':
             pass
         else:
-            options.append('-DDGMX_OPENMP_MAX_THREADS:STRING=%s' % omp_max_threads_value)
+            options.append('-DDGMX_OPENMP_MAX_THREADS:STRING=%s'
+                           % omp_max_threads_value)
 
         return options


### PR DESCRIPTION
This PR adds additional options used to install GROMACS at CSCS. 
* The `subcounters` options add additional statistical information at the end of GROMACS output, which give hint to users on the directions of setting the correct number of MPI ranks, OpenMP threads and PME nodes. This does not add time to the simulations, since these statistics are only computed after the md loop has finished.
* The `own_fftw` options add the possibility of allowing GROMACS to install FFTW. At least on the systems that we have tested at CSCS, this option generates a executable that runs up-to 5% faster when using PME.
* The `omp_max_threads` options allows to change the number of OpenMP threads. By default GROMACS sets it to 64. We have systems with more than that number of cores. The number of OpenMP threads has to be a multiple of 32, in this case, I have given the possibility to choose between `auto` (let GROMACS set it), `64`, `128` and `256`.
* The `static` option adds the CMake option `-DGMX_PREFER_STATIC_LIB=ON` to GROMACS build. This generates static binaries and it is the advised way of compiling on a Cray (http://manual.gromacs.org/documentation/2019.3/install-guide/index.html#building-on-cray). However, some tests on other non-Cray systems have shown that for some input files this option  generates a executable that runs up-to 10% faster.
* The `mdrun_only` options adds the possibility to build/install only the `mdrun` executable.