### PR TITLE
Modifications to r package

### DIFF
--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import re
 
 from spack import *
 
@@ -70,9 +71,10 @@ class R(AutotoolsPackage):
     depends_on('pango~X', when='~X')
     depends_on('freetype')
     depends_on('tcl')
-    depends_on('tk')
+    depends_on('tk', when='+X')
     depends_on('libx11', when='+X')
     depends_on('libxt', when='+X')
+    depends_on('libxmu', when='+X')
     depends_on('curl')
     depends_on('pcre')
     depends_on('java')
@@ -92,7 +94,6 @@ class R(AutotoolsPackage):
         prefix = self.prefix
 
         tcl_config_path = join_path(spec['tcl'].prefix.lib, 'tclConfig.sh')
-        tk_config_path = join_path(spec['tk'].prefix.lib, 'tkConfig.sh')
 
         config_args = [
             '--libdir={0}'.format(join_path(prefix, 'rlib')),
@@ -100,14 +101,27 @@ class R(AutotoolsPackage):
             '--enable-BLAS-shlib',
             '--enable-R-framework=no',
             '--with-tcl-config={0}'.format(tcl_config_path),
-            '--with-tk-config={0}'.format(tk_config_path),
+            'LDFLAGS=-L{0} -Wl,-rpath,{0}'.format(join_path(prefix, 'rlib',
+                                                            'R', 'lib')),
         ]
+        if '^tk' in spec:
+            tk_config_path = join_path(spec['tk'].prefix.lib, 'tkConfig.sh')
+            config_args.append('--with-tk-config={0}'.format(tk_config_path))
 
         if '+external-lapack' in spec:
-            config_args.extend([
-                '--with-blas={0}'.format(spec['blas'].libs),
-                '--with-lapack'
-            ])
+            if '^mkl' in spec and 'gfortran' in self.compiler.fc:
+                mkl_re = re.compile(r'(mkl_)intel(_i?lp64\b)')
+                config_args.extend([
+                    mkl_re.sub(r'\g<1>gf\g<2>',
+                               '--with-blas={0}'.format(
+                                   spec['blas'].libs.ld_flags)),
+                    '--with-lapack'
+                ])
+            else:
+                config_args.extend([
+                    '--with-blas={0}'.format(spec['blas'].libs.ld_flags),
+                    '--with-lapack'
+                ])
 
         if '+X' in spec:
             config_args.append('--with-x')


### PR DESCRIPTION
This PR has several modifications for the r package.

- The tk package is always depended on but this pulls in X11, making the
  'X' variant non-functional. This PR sets a dependency of tk on '+X'.
- There is a missing dependency on libxmu when '+X' is set.
- The libraries for R wind up in a non-standard location and are thus
  left out of the RPATH settings. This PR adds that directory to RPATH.
- The MKL integer interface for gfortran is not in the BLAS libs. This
  PR replaces the intel interface with the gfortran interface if needed.
- Use the `LibraryList` `ld_flags` method for blas as that is more in
  line with th R Installation and Administration manual.

Note that this PR depends on PR #11956. This PR closes #8642.