### PR TITLE
Preferentially look for blas and lapack libs in prefix.lib, prefix.lib64

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1389,6 +1389,14 @@ def find_libraries(libraries, root, shared=True, recursive=False):
     # List of libraries we are searching with suffixes
     libraries = ['{0}.{1}'.format(lib, suffix) for lib in libraries]
 
+    if not recursive:
+        # If not recursive, look for the libraries directly in root
+        return LibraryList(find(root, libraries, False))
+
+    # To speedup the search for external packages configured e.g. in /usr,
+    # perform first non-recursive search in root/lib then in root/lib64 and
+    # finally search all of root recursively. The search stops when the first
+    # match is found.
     for subdir in ('lib', 'lib64'):
         dirname = join_path(root, subdir)
         if not os.path.isdir(dirname):
@@ -1397,7 +1405,7 @@ def find_libraries(libraries, root, shared=True, recursive=False):
         if found_libs:
             break
     else:
-        found_libs = find(root, libraries, recursive)
+        found_libs = find(root, libraries, True)
 
     return LibraryList(found_libs)
 

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1397,7 +1397,7 @@ def find_libraries(libraries, root, shared=True, recursive=False):
         if found_libs:
             break
     else:
-        found_libs = find(root, libraries, True)
+        found_libs = find(root, libraries, recursive)
 
     return LibraryList(found_libs)
 

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1390,12 +1390,14 @@ def find_libraries(libraries, root, shared=True, recursive=False):
     libraries = ['{0}.{1}'.format(lib, suffix) for lib in libraries]
 
     for subdir in ('lib', 'lib64'):
-        root = join_path(prefix, subdir)
-        found_libs = find(root, libraries, False)
+        dirname = join_path(root, subdir)
+        if not os.path.isdir(dirname):
+            continue
+        found_libs = find(dirname, libraries, False)
         if found_libs:
             break
     else:
-        found_libs = find(prefix, libraries, True)
+        found_libs = find(root, libraries, True)
 
     return LibraryList(found_libs)
 

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -39,7 +39,6 @@ __all__ = [
     'find_all_headers',
     'find_libraries',
     'find_system_libraries',
-    'find_libraries_in_prefix',
     'fix_darwin_install_name',
     'force_remove',
     'force_symlink',
@@ -1390,34 +1389,15 @@ def find_libraries(libraries, root, shared=True, recursive=False):
     # List of libraries we are searching with suffixes
     libraries = ['{0}.{1}'.format(lib, suffix) for lib in libraries]
 
-    return LibraryList(find(root, libraries, recursive))
-
-
-def find_libraries_in_prefix(libraries, prefix, shared=True):
-    """Returns an iterable of full paths to libraries found in prefix.
-
-    To speedup the search for external packages configured e.g. in /usr,
-    perform first non-recursive search in prefix/lib then in prefix/lib64 and
-    finally search all of prefix recursively. The search stops when the first
-    match is found.
-
-    Args:
-        libraries (str or list of str): Library name(s) to search for
-        prefix (str): The prefix to search.
-        shared (bool, optional): if True searches for shared libraries,
-            otherwise for static. Defaults to True.
-
-    Returns:
-        LibraryList: The libraries that have been found
-
-    """
     for subdir in ('lib', 'lib64'):
         root = join_path(prefix, subdir)
-        libs = find_libraries(libraries, root=root, shared=shared, recursive=False)
-        if libs:
-            return libs
+        found_libs = find(root, libraries, False)
+        if found_libs:
+            break
     else:
-        return find_libraries(libraries, root=prefix, shared=shared, recursive=True)
+        found_libs = find(prefix, libraries, True)
+
+    return LibraryList(found_libs)
 
 
 @memoized

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -39,6 +39,7 @@ __all__ = [
     'find_all_headers',
     'find_libraries',
     'find_system_libraries',
+    'find_libraries_in_prefix',
     'fix_darwin_install_name',
     'force_remove',
     'force_symlink',
@@ -1390,6 +1391,33 @@ def find_libraries(libraries, root, shared=True, recursive=False):
     libraries = ['{0}.{1}'.format(lib, suffix) for lib in libraries]
 
     return LibraryList(find(root, libraries, recursive))
+
+
+def find_libraries_in_prefix(libraries, prefix, shared=True):
+    """Returns an iterable of full paths to libraries found in prefix.
+
+    To speedup the search for external packages configured e.g. in /usr,
+    perform first non-recursive search in prefix/lib then in prefix/lib64 and
+    finally search all of prefix recursively. The search stops when the first
+    match is found.
+
+    Args:
+        libraries (str or list of str): Library name(s) to search for
+        prefix (str): The prefix to search.
+        shared (bool, optional): if True searches for shared libraries,
+            otherwise for static. Defaults to True.
+
+    Returns:
+        LibraryList: The libraries that have been found
+
+    """
+    for subdir in ('lib', 'lib64'):
+        root = join_path(prefix, subdir)
+        libs = find_libraries(libraries, root=root, shared=shared, recursive=False)
+        if libs:
+            return libs
+    else:
+        return find_libraries(libraries, root=prefix, shared=shared, recursive=True)
 
 
 @memoized

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -711,13 +711,14 @@ def _libs_default_handler(descriptor, spec, cls):
 
     # Variable 'name' is passed to function 'find_libraries', which supports
     # glob characters. For example, we have a package with a name 'abc-abc'.
-    # Now, we don't know if the original name of the package is 'abc_abc' (and
-    # it generates a library 'libabc_abc.so') or 'abc-abc' (and it generates a
-    # library 'libabc-abc.so'). So, we tell the function 'find_libraries' to
-    # give us anything that matches 'libabc?abc' and it gives us either
-    # 'libabc-abc.so' or 'libabc_abc.so' (or an error) depending on which one
-    # exists (there is a possibility, of course, to get something like
-    # 'libabcXabc.so, but for now we consider this unlikely).
+    # Now, we don't know if the original name of the package is 'abc_abc'
+    # (and it generates a library 'libabc_abc.so') or 'abc-abc' (and it
+    # generates a library 'libabc-abc.so'). So, we tell the function
+    # 'find_libraries' to give us anything that matches 'libabc?abc' and it
+    # gives us either 'libabc-abc.so' or 'libabc_abc.so' (or an error)
+    # depending on which one exists (there is a possibility, of course, to
+    # get something like 'libabcXabc.so, but for now we consider this
+    # unlikely).
     name = spec.name.replace('-', '?')
 
     # Avoid double 'lib' for packages whose names already start with lib

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -730,7 +730,7 @@ def _libs_default_handler(descriptor, spec, cls):
         ([False] if ('~shared' in spec) else [True, False])
 
     for shared in search_shared:
-        libs = find_libraries(name, spec.prefix, shared=shared)
+        libs = find_libraries(name, spec.prefix, shared=shared, recursive=True)
         if libs:
             return libs
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -90,7 +90,7 @@ from six import StringIO
 from six import string_types
 from six import iteritems
 
-from llnl.util.filesystem import find_headers, find_libraries_in_prefix, is_exe
+from llnl.util.filesystem import find_headers, find_libraries, is_exe
 from llnl.util.lang import key_ordering, HashableMap, ObjectWrapper, dedupe
 from llnl.util.lang import check_kwargs, memoized
 from llnl.util.tty.color import cwrite, colorize, cescape, get_color_when
@@ -709,15 +709,15 @@ def _libs_default_handler(descriptor, spec, cls):
         NoLibrariesError: If no libraries are found
     """
 
-    # Variable 'name' is passed to function 'find_libraries_in_prefix', which
-    # supports glob characters. For example, we have a package with a name
-    # 'abc-abc'. Now, we don't know if the original name of the package is
-    # 'abc_abc' (and it generates a library 'libabc_abc.so') or 'abc-abc' (and
-    # it generates a library 'libabc-abc.so'). So, we tell the function
-    # 'find_libraries_in_prefix' to give us anything that matches 'libabc?abc'
-    # and it gives us either 'libabc-abc.so' or 'libabc_abc.so' (or an error)
-    # depending on which one exists (there is a possibility, of course, to get
-    # something like 'libabcXabc.so, but for now we consider this unlikely).
+    # Variable 'name' is passed to function 'find_libraries', which supports
+    # glob characters. For example, we have a package with a name 'abc-abc'.
+    # Now, we don't know if the original name of the package is 'abc_abc' (and
+    # it generates a library 'libabc_abc.so') or 'abc-abc' (and it generates a
+    # library 'libabc-abc.so'). So, we tell the function 'find_libraries' to
+    # give us anything that matches 'libabc?abc' and it gives us either
+    # 'libabc-abc.so' or 'libabc_abc.so' (or an error) depending on which one
+    # exists (there is a possibility, of course, to get something like
+    # 'libabcXabc.so, but for now we consider this unlikely).
     name = spec.name.replace('-', '?')
 
     # Avoid double 'lib' for packages whose names already start with lib
@@ -730,7 +730,7 @@ def _libs_default_handler(descriptor, spec, cls):
         ([False] if ('~shared' in spec) else [True, False])
 
     for shared in search_shared:
-        libs = find_libraries_in_prefix(name, spec.prefix, shared=shared)
+        libs = find_libraries(name, spec.prefix, shared=shared)
         if libs:
             return libs
 

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -63,14 +63,8 @@ class Cuda(Package):
 
     @property
     def libs(self):
-        prefix = self.prefix
-        search_paths = [(prefix.lib, False), (prefix.lib64, False),
-                        (prefix, True)]
-        for search_root, recursive in search_paths:
-            libs = find_libraries(
-                'libcuda', root=search_root, shared=True, recursive=recursive)
-            if libs:
-                break
+        libs = find_libraries('libcuda', root=self.prefix, shared=True,
+                              recursive=True)
 
         filtered_libs = []
         # CUDA 10.0 provides Compatability libraries for running newer versions

--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -150,12 +150,7 @@ class Hypre(Package):
         """Export the hypre library.
         Sample usage: spec['hypre'].libs.ld_flags
         """
-        search_paths = [[self.prefix.lib, False], [self.prefix.lib64, False],
-                        [self.prefix, True]]
         is_shared = '+shared' in self.spec
-        for path, recursive in search_paths:
-            libs = find_libraries('libHYPRE', root=path,
-                                  shared=is_shared, recursive=recursive)
-            if libs:
-                return libs
-        return None
+        libs = find_libraries('libHYPRE', root=self.prefix, shared=is_shared,
+                              recursive=True)
+        return libs or None

--- a/var/spack/repos/builtin/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-lapack/package.py
@@ -98,7 +98,7 @@ class NetlibLapack(CMakePackage):
         }
         key = tuple(sorted(query_parameters))
         libraries = query2libraries[key]
-        return find_libraries_in_prefix(libraries, self.prefix, shared=shared)
+        return find_libraries(libraries, self.prefix, shared=shared)
 
     @property
     def lapack_libs(self):
@@ -119,7 +119,7 @@ class NetlibLapack(CMakePackage):
         }
         key = tuple(sorted(query_parameters))
         libraries = query2libraries[key]
-        return find_libraries_in_prefix(libraries, self.prefix, shared=shared)
+        return find_libraries(libraries, self.prefix, shared=shared)
 
     @property
     def headers(self):

--- a/var/spack/repos/builtin/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-lapack/package.py
@@ -98,14 +98,7 @@ class NetlibLapack(CMakePackage):
         }
         key = tuple(sorted(query_parameters))
         libraries = query2libraries[key]
-        prefix = self.prefix
-        search_paths = [(prefix.lib, False), (prefix.lib64, False), (prefix, True)]
-        for path, recursive in search_paths:
-            libs = find_libraries(
-                name, root=path, shared=shared, recursive=recursive
-            )
-            if libs:
-                return libs
+        return find_libraries_in_prefix(libraries, self.prefix, shared=shared)
 
     @property
     def lapack_libs(self):
@@ -126,14 +119,7 @@ class NetlibLapack(CMakePackage):
         }
         key = tuple(sorted(query_parameters))
         libraries = query2libraries[key]
-        prefix = self.prefix
-        search_paths = [(prefix.lib, False), (prefix.lib64, False), (prefix, True)]
-        for path, recursive in search_paths:
-            libs = find_libraries(
-                name, root=path, shared=shared, recursive=recursive
-            )
-            if libs:
-                return libs
+        return find_libraries_in_prefix(libraries, self.prefix, shared=shared)
 
     @property
     def headers(self):

--- a/var/spack/repos/builtin/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-lapack/package.py
@@ -98,10 +98,11 @@ class NetlibLapack(CMakePackage):
         }
         key = tuple(sorted(query_parameters))
         libraries = query2libraries[key]
-        search_paths = [self.prefix.lib, self.prefix.lib64, self.prefix]
-        for path in search_paths:
+        prefix = self.prefix
+        search_paths = [(prefix.lib, False), (prefix.lib64, False), (prefix, True)]
+        for path, recursive in search_paths:
             libs = find_libraries(
-                name, root=path, shared=shared, recursive=True
+                name, root=path, shared=shared, recursive=recursive
             )
             if libs:
                 return libs
@@ -125,10 +126,11 @@ class NetlibLapack(CMakePackage):
         }
         key = tuple(sorted(query_parameters))
         libraries = query2libraries[key]
-        search_paths = [self.prefix.lib, self.prefix.lib64, self.prefix]
-        for path in search_paths:
+        prefix = self.prefix
+        search_paths = [(prefix.lib, False), (prefix.lib64, False), (prefix, True)]
+        for path, recursive in search_paths:
             libs = find_libraries(
-                name, root=path, shared=shared, recursive=True
+                name, root=path, shared=shared, recursive=recursive
             )
             if libs:
                 return libs

--- a/var/spack/repos/builtin/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-lapack/package.py
@@ -98,7 +98,9 @@ class NetlibLapack(CMakePackage):
         }
         key = tuple(sorted(query_parameters))
         libraries = query2libraries[key]
-        return find_libraries(libraries, self.prefix, shared=shared)
+        return find_libraries(
+            libraries, root=self.prefix, shared=shared, recursive=True
+        )
 
     @property
     def lapack_libs(self):
@@ -119,7 +121,9 @@ class NetlibLapack(CMakePackage):
         }
         key = tuple(sorted(query_parameters))
         libraries = query2libraries[key]
-        return find_libraries(libraries, self.prefix, shared=shared)
+        return find_libraries(
+            libraries, root=self.prefix, shared=shared, recursive=True
+        )
 
     @property
     def headers(self):

--- a/var/spack/repos/builtin/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-lapack/package.py
@@ -98,9 +98,13 @@ class NetlibLapack(CMakePackage):
         }
         key = tuple(sorted(query_parameters))
         libraries = query2libraries[key]
-        return find_libraries(
-            libraries, root=self.prefix, shared=shared, recursive=True
-        )
+        search_paths = [self.prefix.lib, self.prefix.lib64, self.prefix]
+        for path in search_paths:
+            libs = find_libraries(
+                name, root=path, shared=shared, recursive=True
+            )
+            if libs:
+                return libs
 
     @property
     def lapack_libs(self):
@@ -121,9 +125,13 @@ class NetlibLapack(CMakePackage):
         }
         key = tuple(sorted(query_parameters))
         libraries = query2libraries[key]
-        return find_libraries(
-            libraries, root=self.prefix, shared=shared, recursive=True
-        )
+        search_paths = [self.prefix.lib, self.prefix.lib64, self.prefix]
+        for path in search_paths:
+            libs = find_libraries(
+                name, root=path, shared=shared, recursive=True
+            )
+            if libs:
+                return libs
 
     @property
     def headers(self):

--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -500,12 +500,9 @@ class Sundials(CMakePackage):
             # Q: should the result be ordered by dependency?
         else:
             sun_libs = ['libsundials_' + p for p in query_parameters]
-        search_paths = [[self.prefix.lib, False], [self.prefix.lib64, False],
-                        [self.prefix, True]]
         is_shared = '+shared' in self.spec
-        for path, recursive in search_paths:
-            libs = find_libraries(sun_libs, root=path, shared=is_shared,
-                                  recursive=recursive)
-            if libs:
-                return libs
-        return None  # Raise an error
+
+        libs = find_libraries(sun_libs, root=self.prefix, shared=is_shared,
+                              recursive=True)
+
+        return libs or None  # Raise an error if no libs are found


### PR DESCRIPTION
Avoids excessive search times when, eg, lapack-blas is an external package installed in large system directories.

Closes: #11929