### PR TITLE
py-basemap: install without egg

### DIFF
--- a/var/spack/repos/builtin/packages/py-basemap/package.py
+++ b/var/spack/repos/builtin/packages/py-basemap/package.py
@@ -19,7 +19,7 @@ class PyBasemap(PythonPackage):
     # Per Github issue #3813, setuptools is required at runtime in order
     # to make mpl_toolkits a namespace package that can span multiple
     # directories (i.e., matplotlib and basemap)
-    depends_on('py-setuptools', type=('run'))
+    depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-numpy', type=('build', 'run'))
     depends_on('py-matplotlib', type=('build', 'run'))
     depends_on('py-pyproj', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-basemap/package.py
+++ b/var/spack/repos/builtin/packages/py-basemap/package.py
@@ -22,6 +22,7 @@ class PyBasemap(PythonPackage):
     depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-numpy', type=('build', 'run'))
     depends_on('py-matplotlib', type=('build', 'run'))
+    depends_on('py-pyproj@:1.99', type=('build', 'run'), when='@:1.2.0')
     depends_on('py-pyproj', type=('build', 'run'))
     depends_on('py-pyshp', type=('build', 'run'))
     depends_on('pil', type=('build', 'run'))


### PR DESCRIPTION
According to the basemap tutorial (https://basemaptutorial.readthedocs.io/en/latest/first_map.html), the way to import Basemap is as follows:

```
from mpl_toolkits.basemap import Basemap
```

However, this failed when I tried it with py-basemap from spack. The py-basemap package was installing into an egg, but the above command assumes that basemap is installed into an existing mpl_toolkits package (part of py-matplotlib).

By adding py-setuptools as a dependency at build time, py-basemap installs into a normal directory tree. When py-basemap and py-matplotlib are both activated, the basemap directory is linked into mpl_toolkits, so that the above import statement works correctly.