### PR TITLE
add support for tcp provider in libfabric

### DIFF
--- a/var/spack/repos/builtin/packages/libfabric/package.py
+++ b/var/spack/repos/builtin/packages/libfabric/package.py
@@ -36,7 +36,8 @@ class Libfabric(AutotoolsPackage):
                'udp',
                'rxm',
                'rxd',
-               'mlx')
+               'mlx',
+               'tcp')
 
     variant(
        'fabrics',


### PR DESCRIPTION
Adds optional ability to specify "tcp" provider for libfabric package.  The tcp provider (in conjunction with rxm) is an alternative to the sockets provider for emulating libfabrics communication over TCP/IP.  It will likely  perform better than the sockets provider in some scenarios, though.