### PR TITLE
py-astropy: added latest version 3.2.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-astropy/package.py
+++ b/var/spack/repos/builtin/packages/py-astropy/package.py
@@ -14,6 +14,7 @@ class PyAstropy(PythonPackage):
     homepage = 'http://www.astropy.org/'
     url = 'https://pypi.io/packages/source/a/astropy/astropy-1.1.2.tar.gz'
 
+    version('3.2.1',     '706c0457789c78285e5464a5a336f5f0b058d646d60f4e5f5ba1f7d5bf424b28')
     version('1.1.2',     'cbe32023b5b1177d1e2498a0d00cda51')
     version('1.1.post1', 'b52919f657a37d45cc45f5cb0f58c44d')
 


### PR DESCRIPTION
- correctly installs under python@3.5:3.7.3
- (partially) fixes https://github.com/spack/spack/issues/11966