### PR TITLE
fix defunct editor exit in #11691

### DIFF
--- a/lib/spack/spack/hooks/licensing.py
+++ b/lib/spack/spack/hooks/licensing.py
@@ -54,6 +54,7 @@ def set_up_license(pkg):
                 raise EnvironmentError(
                     'No text editor found! Please set the VISUAL and/or EDITOR'
                     ' environment variable(s) to your preferred text editor.')
+
             def editor_wrapper(exe, args):
                 editor_exe(license_path)
             editor(license_path, _exec_func=editor_wrapper)

--- a/lib/spack/spack/hooks/licensing.py
+++ b/lib/spack/spack/hooks/licensing.py
@@ -9,6 +9,7 @@ import llnl.util.tty as tty
 from llnl.util.filesystem import mkdirp
 
 from spack.util.editor import editor
+from spack.util.executable import Executable, which
 
 
 def pre_install(spec):
@@ -37,8 +38,25 @@ def set_up_license(pkg):
             # Create a new license file
             write_license_file(pkg, license_path)
             # Open up file in user's favorite $EDITOR for editing
-            editor(license_path)
-            tty.msg("Added global license file %s" % license_path)
+            editor_exe = None
+            if 'VISUAL' in os.environ:
+                editor_exe = Executable(os.environ['VISUAL'])
+                # gvim runs in the background by default so we force it to run
+                # in the foreground to make sure the license file is updated
+                # before we try to install
+                if 'gvim' in os.environ['VISUAL']:
+                    editor_exe.add_default_arg('-f')
+            elif 'EDITOR' in os.environ:
+                editor_exe = Executable(os.environ['EDITOR'])
+            else:
+                editor_exe = which('vim', 'vi', 'emacs', 'nano')
+            if editor_exe is None:
+                raise EnvironmentError(
+                    'No text editor found! Please set the VISUAL and/or EDITOR '
+                    'environment variable(s) to your preferred text editor.')
+            def editor_wrapper(exe, args):
+                editor_exe(license_path)
+            editor(license_path, _exec_func=editor_wrapper)
         else:
             # Use already existing license file
             tty.msg("Found already existing license %s" % license_path)

--- a/lib/spack/spack/hooks/licensing.py
+++ b/lib/spack/spack/hooks/licensing.py
@@ -52,8 +52,8 @@ def set_up_license(pkg):
                 editor_exe = which('vim', 'vi', 'emacs', 'nano')
             if editor_exe is None:
                 raise EnvironmentError(
-                    'No text editor found! Please set the VISUAL and/or EDITOR '
-                    'environment variable(s) to your preferred text editor.')
+                    'No text editor found! Please set the VISUAL and/or EDITOR'
+                    ' environment variable(s) to your preferred text editor.')
             def editor_wrapper(exe, args):
                 editor_exe(license_path)
             editor(license_path, _exec_func=editor_wrapper)


### PR DESCRIPTION
It looks like https://github.com/spack/spack/commit/0aed3bcea676a9df4a5c1c26a9a5ca7151d85215 causes the editor process to become defunct on exit when updating the license file. This was reported in #11691. This reverts to using Spack's Executable instead of execv when updating a license file. 