### PR TITLE
tests: Add template creation test

### DIFF
--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -393,6 +393,9 @@ def setup_parser(subparser):
     subparser.add_argument(
         '-f', '--force', action='store_true',
         help="overwrite any existing package file with the same name")
+    subparser.add_argument(
+        '--skip-editor', action='store_true',
+        help="skip the edit session for the package (e.g., automation)")
 
 
 class BuildSystemGuesser:
@@ -671,5 +674,6 @@ def create(parser, args):
     package.write(pkg_path)
     tty.msg("Created package file: {0}".format(pkg_path))
 
-    # Open up the new package file in your $EDITOR
-    editor(pkg_path)
+    # Optionally open up the new package file in your $EDITOR
+    if not args.skip_editor:
+        editor(pkg_path)

--- a/lib/spack/spack/test/cmd/create.py
+++ b/lib/spack/spack/test/cmd/create.py
@@ -1,0 +1,69 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import argparse
+import os
+import pytest
+
+import spack.cmd.create
+import spack.util.editor
+
+from spack.main import SpackCommand
+
+
+create = SpackCommand('create')
+
+
+@pytest.fixture("module")
+def cmd_create_repo(tmpdir_factory):
+    repo_namespace = 'cmd_create_repo'
+    repodir = tmpdir_factory.mktemp(repo_namespace)
+    repodir.ensure(spack.repo.packages_dir_name, dir=True)
+    yaml = repodir.join('repo.yaml')
+    yaml.write("""
+repo:
+    namespace: cmd_create_repo
+""")
+
+    db = spack.repo.RepoPath(str(repodir))
+    with spack.repo.swap(db):
+        yield repodir
+
+    # shutil.rmtree(str(repodir))
+
+
+@pytest.fixture(scope='module')
+def parser():
+    """Returns the parser for the module"""
+    prs = argparse.ArgumentParser()
+    spack.cmd.create.setup_parser(prs)
+    return prs
+
+
+@pytest.fixture
+def mock_editor(monkeypatch):
+    def _editor(*args, **kwargs):
+        return
+
+    monkeypatch.setattr(spack.util.editor, 'editor', _editor)
+    yield
+
+
+def test_create_template(parser, cmd_create_repo):
+    """Test template creation."""
+    repodir = cmd_create_repo
+
+    name = 'test-package'
+    args = parser.parse_args(['--skip-editor', name])
+    spack.cmd.create.create(parser, args)
+
+    filename = str(repodir.join(spack.repo.packages_dir_name, name,
+                                spack.repo.package_file_name))
+    assert os.path.exists(filename)
+
+    with open(filename, 'r') as package_file:
+        content = ' '.join(package_file.readlines())
+        for entry in [r'TestPackage(Package)', r'def install(self']:
+            assert content.find(entry) > -1

--- a/lib/spack/spack/test/cmd/create.py
+++ b/lib/spack/spack/test/cmd/create.py
@@ -27,9 +27,9 @@ repo:
     namespace: cmd_create_repo
 """)
 
-    db = spack.repo.RepoPath(str(repodir))
-    with spack.repo.swap(db):
-        yield repodir
+    repo = spack.repo.RepoPath(str(repodir))
+    with spack.repo.swap(repo):
+        yield repo, repodir
 
 
 @pytest.fixture(scope='module')
@@ -42,14 +42,13 @@ def parser():
 
 def test_create_template(parser, cmd_create_repo):
     """Test template creation."""
-    repodir = cmd_create_repo
+    repo, repodir = cmd_create_repo
 
     name = 'test-package'
     args = parser.parse_args(['--skip-editor', name])
     spack.cmd.create.create(parser, args)
 
-    filename = str(repodir.join(spack.repo.packages_dir_name, name,
-                                spack.repo.package_file_name))
+    filename = repo.filename_for_package_name(name)
     assert os.path.exists(filename)
 
     with open(filename, 'r') as package_file:

--- a/lib/spack/spack/test/cmd/create.py
+++ b/lib/spack/spack/test/cmd/create.py
@@ -31,8 +31,6 @@ repo:
     with spack.repo.swap(db):
         yield repodir
 
-    # shutil.rmtree(str(repodir))
-
 
 @pytest.fixture(scope='module')
 def parser():
@@ -40,15 +38,6 @@ def parser():
     prs = argparse.ArgumentParser()
     spack.cmd.create.setup_parser(prs)
     return prs
-
-
-@pytest.fixture
-def mock_editor(monkeypatch):
-    def _editor(*args, **kwargs):
-        return
-
-    monkeypatch.setattr(spack.util.editor, 'editor', _editor)
-    yield
 
 
 def test_create_template(parser, cmd_create_repo):

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -352,7 +352,7 @@ function _spack_create {
     if $list_options
     then
         compgen -W "-h --help --keep-stage -n --name -t --template -r --repo
-                    -N --namespace -f --force" -- "$cur"
+                    -N --namespace -f --force --skip-editor" -- "$cur"
     fi
 }
 


### PR DESCRIPTION
This is a variant of the tests originally added as part of PR #11797.

NOTES:
- Patch coverage cannot be increased with automated testing
- This PR "blocks" the addition of the `BundlePackage` template creation test mentioned in #11981 

TODO:
- [x] Add `--skip-editor` option for `spack create` to `spack-completion.bash` (per Adam (adamjstewart))
- [x] Cleanup unused `test_create_template` code
- [x] Use repo to get test package filename