### PR TITLE
tests: uninstall_by_spec error and rpath_args tests

### DIFF
--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -284,12 +284,8 @@ def test_uninstall_by_spec_errors(mutable_database):
     with pytest.raises(InstallError, matches="not installed"):
         PackageBase.uninstall_by_spec(rec.spec)
 
-    # Try uninstall -- without forcing -- a spec with dependencies
+    # Try an unforced uninstall of a spec with dependencies
     rec = mutable_database.get_record('mpich')
-
-    rpath_args = rec.spec.package.rpath_args
-    assert rpath_args.find('-rpath') > 0
-    assert rpath_args.rfind('mpich') > 0
 
     with pytest.raises(PackageStillNeededError, matches="cannot uninstall"):
         PackageBase.uninstall_by_spec(rec.spec)

--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -353,3 +353,13 @@ def test_git_url_top_level_conflicts(mock_packages, config):
 
     with pytest.raises(spack.fetch_strategy.FetcherConflict):
         spack.fetch_strategy.for_package_version(pkg, '1.3')
+
+
+def test_rpath_args(mutable_database):
+    """Test a package's rpath_args property."""
+
+    rec = mutable_database.get_record('mpich')
+
+    rpath_args = rec.spec.package.rpath_args
+    assert '-rpath' in rpath_args
+    assert 'mpich' in rpath_args


### PR DESCRIPTION
These tests were originally included in PR #11797.

These test cases are intended to increase Spack code coverage.