### PR TITLE
bump extrae to 3.7.1, optionalise dyninst, papi

### DIFF
--- a/var/spack/repos/builtin/packages/extrae/package.py
+++ b/var/spack/repos/builtin/packages/extrae/package.py
@@ -38,6 +38,10 @@ class Extrae(AutotoolsPackage):
     version('3.7.1', sha256='95810b057f95e91bfc89813eb8bd320dfe40614fc8e98c63d95c5101c56dd213')
     version('3.4.1', '69001f5cfac46e445d61eeb567bc8844')
 
+    depends_on("autoconf", type='build')
+    depends_on("automake", type='build')
+    depends_on("libtool", type='build')
+
     depends_on("mpi")
     depends_on("libunwind")
     depends_on("boost")
@@ -78,8 +82,8 @@ class Extrae(AutotoolsPackage):
                  ["--without-dyninst"])
 
         if spec.satisfies("^dyninst@9.3.0:"):
-            make.add_default_arg('CXXFLAGS=-std=c++11')
-            args.append('CXXFLAGS=-std=c++11')
+            make.add_default_arg(self.compiler.cxx11_flag)
+            args.append(self.compiler.cxx11_flag)
 
         # This was added due to configure failure
         # https://www.gnu.org/software/gettext/FAQ.html#integrating_undefined

--- a/var/spack/repos/builtin/packages/extrae/package.py
+++ b/var/spack/repos/builtin/packages/extrae/package.py
@@ -24,7 +24,7 @@ from spack import *
 # LDFLAGS=-pthread
 
 
-class Extrae(Package):
+class Extrae(AutotoolsPackage):
     """Extrae is the package devoted to generate tracefiles which can
        be analyzed later by Paraver. Extrae is a tool that uses
        different interposition mechanisms to inject probes into the
@@ -35,9 +35,10 @@ class Extrae(Package):
        OpenMP, CUDA, OpenCL, pthread, OmpSs"""
     homepage = "https://tools.bsc.es/extrae"
     url      = "https://ftp.tools.bsc.es/extrae/extrae-3.4.1-src.tar.bz2"
-    version('3.7.1', sha256='95810b057f95e91bfc89813eb8bd320dfe40614fc8e98c63d95c5101c56dd213', preferred=True)
+    version('3.7.1', sha256='95810b057f95e91bfc89813eb8bd320dfe40614fc8e98c63d95c5101c56dd213')
     version('3.4.1', '69001f5cfac46e445d61eeb567bc8844')
 
+    depends_on("autoconf")
     depends_on("mpi")
     depends_on("libunwind")
     depends_on("boost")
@@ -45,55 +46,47 @@ class Extrae(Package):
     depends_on("papi")
     depends_on("elf", type="link")
     depends_on("libxml2")
-
-    variant('dyninst', default=False, description="Use dyninst for dynamic code installation")
-    depends_on('dyninst@:9.9.99', type=('build', 'link'), when='+dyninst')
-
-    variant('papi', default=True, description="Use PAPI to collect performance counters")
-    depends_on('papi', type=('build', 'link'), when='+papi')
-
+    depends_on("numactl")
+    depends_on("binutils+libiberty")
+    depends_on("gettext")
     # gettext dependency added to find -lintl
     # https://www.gnu.org/software/gettext/FAQ.html#integrating_undefined
-    depends_on("gettext")
-    depends_on("binutils+libiberty")
 
-    def install(self, spec, prefix):
-        if 'openmpi' in spec:
-            mpi = spec['openmpi']
-        elif 'mpich' in spec:
-            mpi = spec['mpich']
-        elif 'mvapich2' in spec:
-            mpi = spec['mvapich2']
+    build_directory = 'spack-build'
 
-        config_args = ["--prefix=%s" % prefix,
-                       "--with-mpi=%s" % mpi.prefix,
-                       "--with-unwind=%s" % spec['libunwind'].prefix,
-                       "--with-boost=%s" % spec['boost'].prefix,
-                       "--with-dwarf=%s" % spec['libdwarf'].prefix,
-                       "--with-elf=%s" % spec['elf'].prefix,
-                       "--with-xml-prefix=%s" % spec['libxml2'].prefix,
-                       "--with-binutils=%s" % spec['binutils'].prefix]
 
-        config_args += (["--with-papi=%s" % spec['papi'].prefix]
-                        if '+papi' in self.spec else
-                        ["--without-papi"])
+    variant('dyninst', default=False, description="Use dyninst for dynamic code installation")
+    depends_on('dyninst@:9', when='+dyninst')
 
-        config_args += (["--with-dyninst=%s" % spec['dyninst'].prefix,
-                         "--with-dyninst-headers=%s" %
-                         spec['dyninst'].prefix.include,
-                         "--with-dyninst-libs=%s" % spec['dyninst'].prefix.lib]
-                        if '+dyninst' in self.spec else
-                        ["--without-dyninst"])
+    variant('papi', default=True, description="Use PAPI to collect performance counters")
+    depends_on('papi', when='+papi')
+
+    def configure_args(self):
+        spec=self.spec
+        prefix=self.prefix
+
+        args = ["--with-mpi=%s" % spec['mpi'].prefix,
+                "--with-unwind=%s" % spec['libunwind'].prefix,
+                "--with-boost=%s" % spec['boost'].prefix,
+                "--with-dwarf=%s" % spec['libdwarf'].prefix,
+                "--with-elf=%s" % spec['elf'].prefix,
+                "--with-xml-prefix=%s" % spec['libxml2'].prefix,
+                "--with-binutils=%s" % spec['binutils'].prefix]
+
+        args += (["--with-papi=%s" % spec['papi'].prefix]
+                  if '+papi' in self.spec else
+                  ["--without-papi"])
+
+        args += (["--with-dyninst=%s" % spec['dyninst'].prefix]
+                 if '+dyninst' in self.spec else
+                  ["--without-dyninst"])
 
         if spec.satisfies("^dyninst@9.3.0:"):
             make.add_default_arg('CXXFLAGS=-std=c++11')
-            config_args.append('CXXFLAGS=-std=c++11')
+            args.append('CXXFLAGS=-std=c++11')
 
         # This was added due to configure failure
         # https://www.gnu.org/software/gettext/FAQ.html#integrating_undefined
-        config_args.append('LDFLAGS=-lintl')
+        args.append('LDFLAGS=-lintl')
 
-        configure(*config_args)
-
-        make()
-        make("install", parallel=False)
+        return(args)

--- a/var/spack/repos/builtin/packages/extrae/package.py
+++ b/var/spack/repos/builtin/packages/extrae/package.py
@@ -89,6 +89,8 @@ class Extrae(AutotoolsPackage):
 
     def install(self, spec, prefix):
         with working_dir(self.build_directory):
+            # parallel installs are buggy prior to 3.7
+            # see https://github.com/bsc-performance-tools/extrae/issues/18
             if(spec.satisfies('@3.7:')):
                 make('install', parallel=True)
             else:

--- a/var/spack/repos/builtin/packages/extrae/package.py
+++ b/var/spack/repos/builtin/packages/extrae/package.py
@@ -82,8 +82,8 @@ class Extrae(AutotoolsPackage):
                  ["--without-dyninst"])
 
         if spec.satisfies("^dyninst@9.3.0:"):
-            make.add_default_arg(self.compiler.cxx11_flag)
-            args.append(self.compiler.cxx11_flag)
+            make.add_default_arg("CXXFLAGS=%s" % self.compiler.cxx11_flag)
+            args.append("CXXFLAGS=%s" % self.compiler.cxx11_flag)
 
         # This was added due to configure failure
         # https://www.gnu.org/software/gettext/FAQ.html#integrating_undefined

--- a/var/spack/repos/builtin/packages/extrae/package.py
+++ b/var/spack/repos/builtin/packages/extrae/package.py
@@ -54,7 +54,6 @@ class Extrae(AutotoolsPackage):
 
     build_directory = 'spack-build'
 
-
     variant('dyninst', default=False, description="Use dyninst for dynamic code installation")
     depends_on('dyninst@:9', when='+dyninst')
 
@@ -62,9 +61,7 @@ class Extrae(AutotoolsPackage):
     depends_on('papi', when='+papi')
 
     def configure_args(self):
-        spec=self.spec
-        prefix=self.prefix
-
+        spec = self.spec
         args = ["--with-mpi=%s" % spec['mpi'].prefix,
                 "--with-unwind=%s" % spec['libunwind'].prefix,
                 "--with-boost=%s" % spec['boost'].prefix,
@@ -74,12 +71,12 @@ class Extrae(AutotoolsPackage):
                 "--with-binutils=%s" % spec['binutils'].prefix]
 
         args += (["--with-papi=%s" % spec['papi'].prefix]
-                  if '+papi' in self.spec else
-                  ["--without-papi"])
+                 if '+papi' in self.spec else
+                 ["--without-papi"])
 
         args += (["--with-dyninst=%s" % spec['dyninst'].prefix]
                  if '+dyninst' in self.spec else
-                  ["--without-dyninst"])
+                 ["--without-dyninst"])
 
         if spec.satisfies("^dyninst@9.3.0:"):
             make.add_default_arg('CXXFLAGS=-std=c++11')

--- a/var/spack/repos/builtin/packages/extrae/package.py
+++ b/var/spack/repos/builtin/packages/extrae/package.py
@@ -38,7 +38,6 @@ class Extrae(AutotoolsPackage):
     version('3.7.1', sha256='95810b057f95e91bfc89813eb8bd320dfe40614fc8e98c63d95c5101c56dd213')
     version('3.4.1', '69001f5cfac46e445d61eeb567bc8844')
 
-    depends_on("autoconf")
     depends_on("mpi")
     depends_on("libunwind")
     depends_on("boost")
@@ -87,3 +86,10 @@ class Extrae(AutotoolsPackage):
         args.append('LDFLAGS=-lintl')
 
         return(args)
+
+    def install(self, spec, prefix):
+        with working_dir(self.build_directory):
+            if(spec.satisfies('@3.7:')):
+                make('install', parallel=True)
+            else:
+                make('install', parallel=False)

--- a/var/spack/repos/builtin/packages/extrae/package.py
+++ b/var/spack/repos/builtin/packages/extrae/package.py
@@ -108,4 +108,3 @@ class Extrae(AutotoolsPackage):
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         # set EXTRAE_HOME for everyone using the Extrae package
         spack_env.set('EXTRAE_HOME', self.prefix)
-

--- a/var/spack/repos/builtin/packages/extrae/package.py
+++ b/var/spack/repos/builtin/packages/extrae/package.py
@@ -41,6 +41,7 @@ class Extrae(AutotoolsPackage):
     depends_on("autoconf", type='build')
     depends_on("automake", type='build')
     depends_on("libtool", type='build')
+    depends_on("m4", type='build')
 
     depends_on("mpi")
     depends_on("libunwind")
@@ -99,3 +100,12 @@ class Extrae(AutotoolsPackage):
                 make('install', parallel=True)
             else:
                 make('install', parallel=False)
+
+    def setup_environment(self, spack_env, run_env):
+        # set EXTRAE_HOME in the module file
+        run_env.set('EXTRAE_HOME', self.prefix)
+
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        # set EXTRAE_HOME for everyone using the Extrae package
+        spack_env.set('EXTRAE_HOME', self.prefix)
+


### PR DESCRIPTION
Version bump to latest extrae version.

Dyninst and PAPI are both optional deps hence addition of variants.  Dyninst in particular is problematic for our uses on various machines, hence disabled as a default.

Dyninst also limited in version to <10 as recommended by extrae devs. (https://github.com/bsc-performance-tools/extrae/issues/30)