### PR TITLE
velvet: remove -m64 on aarch64.

### DIFF
--- a/var/spack/repos/builtin/packages/velvet/package.py
+++ b/var/spack/repos/builtin/packages/velvet/package.py
@@ -17,6 +17,11 @@ class Velvet(MakefilePackage):
 
     depends_on('zlib')
 
+    def edit(self, spec, prefix):
+        if spec.satisfies('target=aarch64'):
+            makefile = FileFilter('Makefile')
+            makefile.filter('-m64', '')
+
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
         install('velvetg', prefix.bin)


### PR DESCRIPTION
velvet package is useed -m64 flag to compile.
But gcc on aarch64 dose not support -m64.

This patch remove -m64 flag if target is aarch64.