### PR TITLE
Allow Spack to uninstall external extensions without permissions

### DIFF
--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -201,9 +201,12 @@ class YamlFilesystemView(FilesystemView):
                 # Write projections file to new view
                 # Not strictly necessary as the empty file is the empty
                 # projection but it makes sense for consistency
-                mkdirp(os.path.dirname(projections_path))
-                with open(projections_path, 'w') as f:
-                    f.write(s_yaml.dump({'projections': self.projections}))
+                try:
+                    mkdirp(os.path.dirname(projections_path))
+                    with open(projections_path, 'w') as f:
+                        f.write(s_yaml.dump({'projections': self.projections}))
+                except OSError:
+                    pass
         elif not os.path.exists(projections_path):
             # Write projections file to new view
             mkdirp(os.path.dirname(projections_path))

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -205,8 +205,9 @@ class YamlFilesystemView(FilesystemView):
                     mkdirp(os.path.dirname(projections_path))
                     with open(projections_path, 'w') as f:
                         f.write(s_yaml.dump({'projections': self.projections}))
-                except OSError:
-                    pass
+                except OSError as e:
+                    if self.projections:
+                        raise e
         elif not os.path.exists(projections_path):
             # Write projections file to new view
             mkdirp(os.path.dirname(projections_path))


### PR DESCRIPTION
Fixes #11980 

This is the simplest possible fix to the issue I raised in #11980. Currently, if you have an external package like `jdk` which happens to be extendable, and you install an extension for that package, it becomes impossible to install that package or its extensions if you don't have write access to that directory. For example, on macOS, JDK is installed to the system `/Library` directory. It looks like Spack is trying to create a file to keep track of which extensions are activated, but crashes because that is not possible.

Tested on Python 2 and 3.