### PR TITLE
Fix #11240

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -423,14 +423,36 @@ def mkdirp(*paths, **kwargs):
     Keyword Aguments:
         mode (permission bits or None, optional): optional permissions to
             set on the created directory -- use OS default if not provided
+        mode_intermediate (permission bits or None, optional):
+            same as mode, but for newly-created intermediate directories
     """
     mode = kwargs.get('mode', None)
+    mode_intermediate = kwargs.get('mode_intermediate', None)
     for path in paths:
         if not os.path.exists(path):
             try:
+                intermediate_folders = []
+                if mode_intermediate is not None:
+                    # detect missing intermediate folders
+                    intermediate_path = os.path.dirname(path)
+
+                    while intermediate_path:
+                        if os.path.exists(intermediate_path):
+                            break
+
+                        intermediate_folders.append(intermediate_path)
+                        intermediate_path = os.path.dirname(intermediate_path)
+
+                # create folders
                 os.makedirs(path)
+
+                # leaf folder permissions
                 if mode is not None:
                     os.chmod(path, mode)
+
+                # newly-created intermediate folders permissions
+                for intermediate_path in reversed(intermediate_folders):
+                    os.chmod(intermediate_path, mode_intermediate)
             except OSError as e:
                 if e.errno != errno.EEXIST or not os.path.isdir(path):
                     raise e

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -450,7 +450,10 @@ def mkdirp(*paths, **kwargs):
                 if mode is not None:
                     os.chmod(path, mode)
 
-                # newly-created intermediate folders permissions
+                # for intermediate folders, change mode just for newly created
+                # ones and if mode_intermediate has been specified, otherwise
+                # intermediate folders list is not populated at all and default
+                # OS mode will be used
                 for intermediate_path in reversed(intermediate_folders):
                     os.chmod(intermediate_path, mode_intermediate)
             except OSError as e:

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -251,50 +251,6 @@ class YamlDirectoryLayout(DirectoryLayout):
     def build_packages_path(self, spec):
         return os.path.join(self.metadata_path(spec), self.packages_dir)
 
-    def _mkdirp(self, absolute_path, mode):
-        """
-        This mkdirp wrapper sets permissions to non-existing nested folders.
-
-        Nested folders are the ones which absolute_path prefix
-        is self.root (excluded)
-
-        e.g. absolute_path=self.root/a/b/c
-            If a path in set {a,b,c} does not exists, it will create it and
-            set permissions, otherwise it doesn't even touch it.
-            If self.root/a already exists, it will just create and
-            set permissions for b and c
-
-        Argument:
-            - absolute_path: (prefix must be self.root)
-                absolute path of the folder hierarchy to create
-            - mode:
-                permissions to set to all non existing nested folders
-        """
-        assert(os.path.commonprefix([self.root, absolute_path]) == self.root)
-
-        nested_path = os.path.relpath(absolute_path, self.root)
-
-        nested_folders = []
-        # by removing the lowest level each time, populate nested_folders list
-        while nested_path:
-            nested_path, nested_folder = os.path.split(nested_path)
-            nested_folders.append(os.path.join(nested_path, nested_folder))
-
-            # but if the upper nested_path already exists,
-            # there's nothing to do from now on
-            if os.path.exists(os.path.join(self.root, nested_path)):
-                break
-
-        # loop over nested folders from highest level to the lowest one,
-        # in order to add a single folder level at a time
-        for nested_relative_path in reversed(nested_folders):
-            absolute_nested_path = os.path.join(
-                self.root,
-                nested_relative_path)
-
-            # TODO it would be ok to replace mkdirp with mkdir
-            mkdirp(absolute_nested_path, mode=mode)
-
     def create_install_directory(self, spec):
         _check_concrete(spec)
 
@@ -308,14 +264,17 @@ class YamlDirectoryLayout(DirectoryLayout):
         from spack.package_prefs import get_package_group
         group = get_package_group(spec)
         perms = get_package_dir_permissions(spec)
+        perms_intermediate = 0o777
 
-        self._mkdirp(spec.prefix, perms)
+        mkdirp(spec.prefix, mode=perms, mode_intermediate=perms_intermediate)
         if group:
             chgrp(spec.prefix, group)
             # Need to reset the sticky group bit after chgrp
             os.chmod(spec.prefix, perms)
 
-        self._mkdirp(self.metadata_path(spec), perms)
+        mkdirp(self.metadata_path(spec),
+               mode=perms,
+               mode_intermediate=perms_intermediate)
 
         self.write_spec(spec, self.spec_file_path(spec))
 

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -272,9 +272,7 @@ class YamlDirectoryLayout(DirectoryLayout):
             # Need to reset the sticky group bit after chgrp
             os.chmod(spec.prefix, perms)
 
-        mkdirp(self.metadata_path(spec),
-               mode=perms,
-               mode_intermediate=perms_intermediate)
+        mkdirp(self.metadata_path(spec), mode=perms)
 
         self.write_spec(spec, self.spec_file_path(spec))
 

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -265,8 +265,8 @@ class YamlDirectoryLayout(DirectoryLayout):
             set permissions for b and c
 
         Argument:
-            - absolute_path: (prefix must be be self.root)
-                absolute path of the folder hierarcy to create
+            - absolute_path: (prefix must be self.root)
+                absolute path of the folder hierarchy to create
             - mode:
                 permissions to set to all non existing nested folders
         """

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -253,18 +253,20 @@ class YamlDirectoryLayout(DirectoryLayout):
 
     def _mkdirp(self, absolute_path, mode):
         """
-        A wrapper for mkdirp that sets permissions to all non-existing nested folders.
+        This mkdirp wrapper sets permissions to non-existing nested folders.
 
-        Nested folders are the ones which absolute_path prefix is self.root (excluded)
+        Nested folders are the ones which absolute_path prefix
+        is self.root (excluded)
 
         e.g. absolute_path=self.root/a/b/c
-            If a path in set {a,b,c} does not exists, it will create it and set permissions,
-            otherwise it doesn't even touch it.
-            If self.root/a already exists, it will just create and set permissions for b and c
+            If a path in set {a,b,c} does not exists, it will create it and
+            set permissions, otherwise it doesn't even touch it.
+            If self.root/a already exists, it will just create and
+            set permissions for b and c
 
         Argument:
-            - absolute_path:
-                absolute path of the folder hierarcy to create (its prefix must be be self.root)
+            - absolute_path: (prefix must be be self.root)
+                absolute path of the folder hierarcy to create
             - mode:
                 permissions to set to all non existing nested folders
         """
@@ -278,16 +280,20 @@ class YamlDirectoryLayout(DirectoryLayout):
             nested_path, nested_folder = os.path.split(nested_path)
             nested_folders.append(os.path.join(nested_path, nested_folder))
 
-            # but if the upper nested_path already exists, there's nothing to do from now on
+            # but if the upper nested_path already exists,
+            # there's nothing to do from now on
             if os.path.exists(os.path.join(self.root, nested_path)):
                 break
 
         # loop over nested folders from highest level to the lowest one,
         # in order to add a single folder level at a time
         for nested_relative_path in reversed(nested_folders):
-            absolute_nested_path = os.path.join(self.root, nested_relative_path)
+            absolute_nested_path = os.path.join(
+                self.root,
+                nested_relative_path)
 
-            mkdirp(absolute_nested_path, mode=mode) # TODO it would be ok to replace mkdirp with mkdir
+            # TODO it would be ok to replace mkdirp with mkdir
+            mkdirp(absolute_nested_path, mode=mode)
 
     def create_install_directory(self, spec):
         _check_concrete(spec)

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -262,6 +262,14 @@ class YamlDirectoryLayout(DirectoryLayout):
         # Cannot import at top of file
         from spack.package_prefs import get_package_dir_permissions
         from spack.package_prefs import get_package_group
+
+        # Each package folder can have its own specific permissions, while
+        # intermediate folders (arch/compiler) are set with full access to
+        # everyone (0o777) and install_tree root folder is the chokepoint
+        # for restricting global access.
+        # So, whoever has access to the install_tree is allowed to install
+        # packages for same arch/compiler and since no data is stored in
+        # intermediate folders, it does not represent a security threat.
         group = get_package_group(spec)
         perms = get_package_dir_permissions(spec)
         perms_intermediate = 0o777


### PR DESCRIPTION
Specialised wrapper for `mkdirp`

It sets permissions to all folders that it creates and not just the deepest one.
It is used to create install_dir hierarchy for packages with right permissions.

Proposed fix for #11240