### PR TITLE
Patch libtool when using the Arm compiler

### DIFF
--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -58,8 +58,8 @@ class AutotoolsPackage(PackageBase):
     build_system_class = 'AutotoolsPackage'
     #: Whether or not to update ``config.guess`` on old architectures
     patch_config_guess = True
-    #: Whether or not to update ``libtool`` (currently only for Arm/Clang
-    #: compilers)
+    #: Whether or not to update ``libtool``
+    #: (currently only for Arm/Clang/Fujitsu compilers)
     patch_libtool = True
 
     #: Targets for ``make`` during the :py:meth:`~.AutotoolsPackage.build`
@@ -156,17 +156,19 @@ class AutotoolsPackage(PackageBase):
     def _do_patch_libtool(self):
         """If configure generates a "libtool" script that does not correctly
         detect the compiler (and patch_libtool is set), patch in the correct
-        flags for the Arm and Clang/Flang compilers."""
+        flags for the Arm, Clang/Flang, and Fujitsu compilers."""
 
         libtool = os.path.join(self.build_directory, "libtool")
         if self.patch_libtool and os.path.exists(libtool):
-            if self.spec.satisfies('%arm') or self.spec.satisfies('%clang'):
+            if self.spec.satisfies('%arm') or self.spec.satisfies('%clang') \
+                    or self.spec.satisfies('%fj'):
                 for line in fileinput.input(libtool, inplace=True):
                     # Replace missing flags with those for Arm/Clang
                     if line == 'wl=""\n':
                         line = 'wl="-Wl,"\n'
                     if line == 'pic_flag=""\n':
-                        line = 'pic_flag="-fPIC -DPIC"\n'
+                        line = 'pic_flag="{0}"\n'\
+                               .format(self.compiler.pic_flag)
                     sys.stdout.write(line)
 
     @property


### PR DESCRIPTION
If libtool does not have values for linker/pic flags, patch them in.

Caused by older versions of config.guess.

Akin to `sed` commands seen here: https://developer.arm.com/tools-and-software/server-and-hpc/arm-architecture-tools/resources/porting-and-tuning/building-hdf5-with-arm-compiler