### PR TITLE
Allow developers to use Spack for partial builds

### DIFF
--- a/lib/spack/spack/cmd/diy.py
+++ b/lib/spack/spack/cmd/diy.py
@@ -39,6 +39,9 @@ def setup_parser(subparser):
         '-q', '--quiet', action='store_true', dest='quiet',
         help="do not display verbose build output while installing")
     subparser.add_argument(
+        '-u', '--until', type=str, dest='until', default=None,
+        help="phase to stop after when installing (default None)")
+    subparser.add_argument(
         'spec', nargs=argparse.REMAINDER,
         help="specs to use for install. must contain package AND version")
 
@@ -90,4 +93,5 @@ def diy(self, args):
         install_deps=not args.ignore_deps,
         verbose=not args.quiet,
         keep_stage=True,   # don't remove source dir for DIY.
-        dirty=args.dirty)
+        dirty=args.dirty,
+        stop_at=args.until)

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -403,7 +403,7 @@ function _spack_diy {
         compgen -W "-h --help -j --jobs -d --source-path
                     -i --ignore-dependencies -n --no-checksum
                     --keep-prefix --skip-patch -q --quiet --clean
-                    --dirty" -- "$cur"
+                    --dirty -u --until" -- "$cur"
     else
         compgen -W "$(_all_packages)" -- "$cur"
     fi


### PR DESCRIPTION
Developers use the `spack diy` command to build from local source (rather than fetching from the internet).

Previously, the `spack diy` command would run all the way through the install. This PR allows the `-u/--until` argument to the `spack diy` command, which gives the user the ability to specify the *last* install phase for Spack to run.

Use case:
```
spack diy -u configure my-package
make
<testing>
make
<testing>
etc
```