### PR TITLE
fetching: computation.llnl.gov is now computing.llnl.gov

### DIFF
--- a/var/spack/repos/builtin/packages/amg/package.py
+++ b/var/spack/repos/builtin/packages/amg/package.py
@@ -13,7 +13,7 @@ class Amg(MakefilePackage):
     """
     tags = ['proxy-app', 'ecp-proxy-app']
 
-    homepage = "https://computation.llnl.gov/projects/co-design/amg2013"
+    homepage = "https://computing.llnl.gov/projects/co-design/amg2013"
     git      = "https://github.com/LLNL/AMG.git"
 
     version('develop', branch='master')

--- a/var/spack/repos/builtin/packages/amg2013/package.py
+++ b/var/spack/repos/builtin/packages/amg2013/package.py
@@ -14,11 +14,11 @@ class Amg2013(MakefilePackage):
     in the Center for Applied Scientific Computing (CASC) at LLNL.
     """
     tags = ['proxy-app']
-    homepage = "https://computation.llnl.gov/projects/co-design/amg2013"
-    url      = "https://computation.llnl.gov/projects/co-design/download/amg2013.tgz"
+    homepage = "https://computing.llnl.gov/projects/co-design/amg2013"
+    url      = "https://computing.llnl.gov/projects/co-design/download/amg2013.tgz"
 
     version('master', '9d918d2a69528b83e6e0aba6ba601fef',
-            url='https://computation.llnl.gov/projects/co-design/download/amg2013.tgz')
+            url='https://computing.llnl.gov/projects/co-design/download/amg2013.tgz')
 
     variant('openmp', default=True, description='Build with OpenMP support')
     variant('assumedpartition', default=False, description='Use assumed partition (for thousands of processors)')

--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -13,7 +13,7 @@ class Hypre(Package):
        features parallel multigrid methods for both structured and
        unstructured grid problems."""
 
-    homepage = "http://computation.llnl.gov/project/linear_solvers/software.php"
+    homepage = "http://computing.llnl.gov/project/linear_solvers/software.php"
     url      = "https://github.com/hypre-space/hypre/archive/v2.14.0.tar.gz"
     git      = "https://github.com/hypre-space/hypre.git"
 
@@ -71,7 +71,7 @@ class Hypre(Package):
         if version >= Version('2.12.0'):
             url = 'https://github.com/hypre-space/hypre/archive/v{0}.tar.gz'
         else:
-            url = 'http://computation.llnl.gov/project/linear_solvers/download/hypre-{0}.tar.gz'
+            url = 'http://computing.llnl.gov/project/linear_solvers/download/hypre-{0}.tar.gz'
 
         return url.format(version)
 

--- a/var/spack/repos/builtin/packages/kripke/package.py
+++ b/var/spack/repos/builtin/packages/kripke/package.py
@@ -10,8 +10,8 @@ class Kripke(CMakePackage):
     """Kripke is a simple, scalable, 3D Sn deterministic particle
        transport proxy/mini app.
     """
-    homepage = "https://computation.llnl.gov/projects/co-design/kripke"
-    url      = "https://computation.llnl.gov/projects/co-design/download/kripke-openmp-1.1.tar.gz"
+    homepage = "https://computing.llnl.gov/projects/co-design/kripke"
+    url      = "https://computing.llnl.gov/projects/co-design/download/kripke-openmp-1.1.tar.gz"
 
     tags = ['proxy-app']
     version('1.1', '7fe6f2b26ed983a6ce5495ab701f85bf')

--- a/var/spack/repos/builtin/packages/laghos/package.py
+++ b/var/spack/repos/builtin/packages/laghos/package.py
@@ -14,7 +14,7 @@ class Laghos(MakefilePackage):
     """
     tags = ['proxy-app', 'ecp-proxy-app']
 
-    homepage = "https://computation.llnl.gov/projects/co-design/laghos"
+    homepage = "https://computing.llnl.gov/projects/co-design/laghos"
     url      = "https://github.com/CEED/Laghos/archive/v1.0.tar.gz"
     git      = "https://github.com/CEED/Laghos.git"
 

--- a/var/spack/repos/builtin/packages/lcals/package.py
+++ b/var/spack/repos/builtin/packages/lcals/package.py
@@ -16,8 +16,8 @@ class Lcals(MakefilePackage):
         by Frank H. McMahon, UCRL-53745.). The suite contains facilities to
         generate timing statistics and reports."""
 
-    homepage = "https://computation.llnl.gov/projects/co-design/lcals"
-    url      = "https://computation.llnl.gov/projects/co-design/download/lcals-v1.0.2.tgz"
+    homepage = "https://computing.llnl.gov/projects/co-design/lcals"
+    url      = "https://computing.llnl.gov/projects/co-design/download/lcals-v1.0.2.tgz"
 
     tags = ['proxy-app']
 

--- a/var/spack/repos/builtin/packages/lulesh/package.py
+++ b/var/spack/repos/builtin/packages/lulesh/package.py
@@ -12,7 +12,7 @@ class Lulesh(MakefilePackage):
     code to only solve a Sedov blast problem with analytic answer
     """
     tags = ['proxy-app']
-    homepage = "https://computation.llnl.gov/projects/co-design/lulesh"
+    homepage = "https://computing.llnl.gov/projects/co-design/lulesh"
     git      = "https://github.com/LLNL/LULESH.git"
 
     version('2.0.3', tag='2.0.3')

--- a/var/spack/repos/builtin/packages/macsio/package.py
+++ b/var/spack/repos/builtin/packages/macsio/package.py
@@ -11,7 +11,7 @@ class Macsio(CMakePackage):
 
     tags = ['proxy-app', 'ecp-proxy-app']
 
-    homepage = "https://computation.llnl.gov/projects/co-design/macsio"
+    homepage = "https://computing.llnl.gov/projects/co-design/macsio"
     url      = "https://github.com/LLNL/MACSio/archive/v1.1.tar.gz"
     git      = "https://github.com/LLNL/MACSio.git"
 

--- a/var/spack/repos/builtin/packages/samrai/package.py
+++ b/var/spack/repos/builtin/packages/samrai/package.py
@@ -14,8 +14,8 @@ class Samrai(AutotoolsPackage):
        (SAMR) technology in large-scale parallel application development.
 
     """
-    homepage = "https://computation.llnl.gov/projects/samrai"
-    url      = "https://computation.llnl.gov/projects/samrai/download/SAMRAI-v3.11.2.tar.gz"
+    homepage = "https://computing.llnl.gov/projects/samrai"
+    url      = "https://computing.llnl.gov/projects/samrai/download/SAMRAI-v3.11.2.tar.gz"
     list_url = homepage
 
     version('3.12.0',     '07364f6e209284e45ac0e9caf1d610f6')

--- a/var/spack/repos/builtin/packages/scr/package.py
+++ b/var/spack/repos/builtin/packages/scr/package.py
@@ -13,7 +13,7 @@ class Scr(CMakePackage):
        Linux cluster to provide a fast, scalable checkpoint/restart
        capability for MPI codes"""
 
-    homepage = "http://computation.llnl.gov/projects/scalable-checkpoint-restart-for-mpi"
+    homepage = "http://computing.llnl.gov/projects/scalable-checkpoint-restart-for-mpi"
     url      = "https://github.com/LLNL/scr/archive/v1.2.0.tar.gz"
     git      = "https://github.com/llnl/scr.git"
 

--- a/var/spack/repos/builtin/packages/spindle/package.py
+++ b/var/spack/repos/builtin/packages/spindle/package.py
@@ -12,7 +12,7 @@ class Spindle(AutotoolsPackage):
        overload on a shared file system when loading dynamically
        linked libraries, causing site-wide performance problems.
     """
-    homepage = "https://computation.llnl.gov/project/spindle/"
+    homepage = "https://computing.llnl.gov/project/spindle/"
     url      = "https://github.com/hpc/Spindle/archive/v0.8.1.tar.gz"
 
     version('0.8.1', 'f11793a6b9d8df2cd231fccb2857d912')

--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -12,8 +12,8 @@ class Sundials(CMakePackage):
     """SUNDIALS (SUite of Nonlinear and DIfferential/ALgebraic equation
     Solvers)"""
 
-    homepage = "https://computation.llnl.gov/projects/sundials"
-    url = "https://computation.llnl.gov/projects/sundials/download/sundials-2.7.0.tar.gz"
+    homepage = "https://computing.llnl.gov/projects/sundials"
+    url = "https://computing.llnl.gov/projects/sundials/download/sundials-2.7.0.tar.gz"
     maintainers = ['cswoodward', 'gardner48', 'balos1']
 
     # ==========================================================================

--- a/var/spack/repos/builtin/packages/xbraid/package.py
+++ b/var/spack/repos/builtin/packages/xbraid/package.py
@@ -11,8 +11,8 @@ import os.path
 class Xbraid(MakefilePackage):
     """XBraid: Parallel time integration with Multigrid"""
 
-    homepage = "https://computation.llnl.gov/projects/parallel-time-integration-multigrid/software"
-    url      = "https://computation.llnl.gov/projects/parallel-time-integration-multigrid/download/braid_2.2.0.tar.gz"
+    homepage = "https://computing.llnl.gov/projects/parallel-time-integration-multigrid/software"
+    url      = "https://computing.llnl.gov/projects/parallel-time-integration-multigrid/download/braid_2.2.0.tar.gz"
 
     version('2.2.0', '0a9c2fc3eb8f605f73cce78ab0d8a7d9')
 

--- a/var/spack/repos/builtin/packages/zfp/package.py
+++ b/var/spack/repos/builtin/packages/zfp/package.py
@@ -12,8 +12,8 @@ class Zfp(MakefilePackage):
        arrays.
     """
 
-    homepage = 'http://computation.llnl.gov/projects/floating-point-compression'
-    url      = 'http://computation.llnl.gov/projects/floating-point-compression/download/zfp-0.5.2.tar.gz'
+    homepage = 'http://computing.llnl.gov/projects/floating-point-compression'
+    url      = 'http://computing.llnl.gov/projects/floating-point-compression/download/zfp-0.5.2.tar.gz'
 
     version('0.5.4', sha256='768a05ed9bf10e54ac306f90b81dd17b0e7b13782f01823d7da4394fd2da8adb')
     version('0.5.2', '2f0a77aa34087219a6e10b8b7d031e77')


### PR DESCRIPTION
LLNL's "Computation" directorate is now the "Computing" directorate, and they're rebranding the website.

Unfortunately, changing the URL still does not fix things, as all of the downloads seem to have permissions set incorrectly after the change.  But I expect these URLs to be right eventually, and the old ones do not work, either.