### PR TITLE
Build R without recommended packages

### DIFF
--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -100,6 +100,7 @@ class R(AutotoolsPackage):
             '--enable-R-shlib',
             '--enable-BLAS-shlib',
             '--enable-R-framework=no',
+            '--without-recommended-packages',
             '--with-tcl-config={0}'.format(tcl_config_path),
             'LDFLAGS=-L{0} -Wl,-rpath,{0}'.format(join_path(prefix, 'rlib',
                                                             'R', 'lib')),


### PR DESCRIPTION
The documentation states that Spack builds R without the recommmened
packages, with Spack handling the build of those packages to satisfy
dependencies. From the docs:

> Spack explicitly adds the --without-recommended-packages flag to
> prevent the installation of these packages. Due to the way Spack
> handles package activation (symlinking packages to the R installation
> directory), pre-existing recommended packages will cause conflicts for
> already-existing files. We could either not include these recommended
> packages in Spack and require them to be installed through
> --with-recommended-packages, or we could not install them with R and
> let users choose the version of the package they want to install. We
> chose the latter.

However, this is not what Spack is actually doing. The
`--without-recommended` configure option is not passed to R and
therefore those packages are built. This prevents R extension activation
from working as files in the recommended packages installed with R will
block linking of file from the respective `r-` packages.

This PR adds the `--without-recommended` flag to the configure options
of the R package. This will then have the Spack R build match what is
documented.