### PR TITLE
make cfitsio explicitly depend on curl

### DIFF
--- a/var/spack/repos/builtin/packages/cfitsio/package.py
+++ b/var/spack/repos/builtin/packages/cfitsio/package.py
@@ -22,6 +22,7 @@ class Cfitsio(AutotoolsPackage):
     variant('bzip2', default=True, description='Enable bzip2 support')
     variant('shared', default=True, description='Build shared libraries')
 
+    depends_on('curl')
     depends_on('bzip2', when='+bzip2')
 
     def url_for_version(self, version):


### PR DESCRIPTION
- currently cfitsio uses system curl, potentially pulling in unwanted system dependencies and lib-paths