### PR TITLE
Fix build_jobs exceeding number of cores

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -406,6 +406,7 @@ def _set_variables_for_single_module(pkg, module):
     """Helper function to set module variables for single module."""
 
     jobs = spack.config.get('config:build_jobs') if pkg.parallel else 1
+    jobs = min(jobs, multiprocessing.cpu_count())
     assert jobs is not None, "no default set for config:build_jobs"
 
     m = module


### PR DESCRIPTION
All documentation mentions that `build_jobs` is limited by the number of cores available in the system. This is also enforced when setting it via `--jobs`. However, when setting it via `config.yaml`, it can exceed the number of cores available, making builds run out of memory.