### PR TITLE
qt: fix patch checksum

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -82,7 +82,7 @@ class Qt(Package):
 
     # Fix build failure with newer versions of GCC
     patch('https://github.com/qt/qtbase/commit/a52d7861edfb5956de38ba80015c4dd0b596259b.patch',
-          sha256='e10c871033568a9aed982628ed627356761f72f63c5fdaf11882dc147528e9ed',
+          sha256='c49b228c27e3ad46ec3af4bac0e9985af5b5b28760f238422d32e14f98e49b1e',
           working_dir='qtbase',
           when='@5.10:5.12.0 %gcc@9:')
 


### PR DESCRIPTION
It seems that GitHub's output changed slightly for this patch (one more letter for both short hashes on the index line), probably due to the number of objects in the repository.