### PR TITLE
binutils: Adding Clang to narrowing conversion error workaround

### DIFF
--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -95,7 +95,8 @@ class Binutils(AutotoolsPackage):
     def flag_handler(self, name, flags):
         # To ignore the errors of narrowing conversions for
         # the Fujitsu compiler
-        if name == 'cxxflags' and self.compiler.name == 'fj'\
+        if name == 'cxxflags'\
+           and (self.compiler.name == 'fj' or self.compiler.name == 'clang')\
            and self.version <= ver('2.31.1'):
             flags.append('-Wno-narrowing')
         return (flags, None, None)


### PR DESCRIPTION
Clang also shows an error for the narrowing conversion in binutils