### PR TITLE
 Speed-up tests that rely on the database fixture

### DIFF
--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -17,5 +17,6 @@ buildcache = spack.main.SpackCommand('buildcache')
     platform.system().lower() != 'linux',
     reason='implementation for MacOS still missing'
 )
+@pytest.mark.db
 def test_buildcache_preview_just_runs(database):
     buildcache('preview', 'mpileaks')

--- a/lib/spack/spack/test/cmd/debug.py
+++ b/lib/spack/spack/test/cmd/debug.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import pytest
+
 import os
 import os.path
 
@@ -12,6 +14,7 @@ from spack.util.executable import which
 debug = SpackCommand('debug')
 
 
+@pytest.mark.db
 def test_create_db_tarball(tmpdir, database):
     with tmpdir.as_cwd():
         debug('create-db-tarball')

--- a/lib/spack/spack/test/cmd/module.py
+++ b/lib/spack/spack/test/cmd/module.py
@@ -19,6 +19,12 @@ def _module_files(module_type, *specs):
     return [writer_cls(spec).layout.filename for spec in specs]
 
 
+@pytest.fixture(scope='module', autouse=True)
+def ensure_module_files_are_there(database):
+    module('dotkit', 'refresh', '-y')
+    module('tcl', 'refresh', '-y')
+
+
 @pytest.fixture(
     params=[
         ['rm', 'doesnotexist'],  # Try to remove a non existing module

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -412,7 +412,7 @@ def test_010_all_install_sanity(database):
     ) == 1
 
 
-def test_015_write_and_read(database):
+def test_015_write_and_read(mutable_database):
     # write and read DB
     with spack.store.db.write_transaction():
         specs = spack.store.db.query()
@@ -431,10 +431,10 @@ def test_020_db_sanity(database):
     _check_db_sanity(database)
 
 
-def test_025_reindex(database):
+def test_025_reindex(mutable_database):
     """Make sure reindex works and ref counts are valid."""
     spack.store.store.reindex()
-    _check_db_sanity(database)
+    _check_db_sanity(mutable_database)
 
 
 def test_030_db_sanity_from_another_process(mutable_database):
@@ -493,64 +493,64 @@ def test_050_basic_query(database):
     assert len(database.query(end_date=datetime.datetime.max)) == 16
 
 
-def test_060_remove_and_add_root_package(database):
-    _check_remove_and_add_package(database, 'mpileaks ^mpich')
+def test_060_remove_and_add_root_package(mutable_database):
+    _check_remove_and_add_package(mutable_database, 'mpileaks ^mpich')
 
 
-def test_070_remove_and_add_dependency_package(database):
-    _check_remove_and_add_package(database, 'dyninst')
+def test_070_remove_and_add_dependency_package(mutable_database):
+    _check_remove_and_add_package(mutable_database, 'dyninst')
 
 
-def test_080_root_ref_counts(database):
-    rec = database.get_record('mpileaks ^mpich')
+def test_080_root_ref_counts(mutable_database):
+    rec = mutable_database.get_record('mpileaks ^mpich')
 
     # Remove a top-level spec from the DB
-    database.remove('mpileaks ^mpich')
+    mutable_database.remove('mpileaks ^mpich')
 
     # record no longer in DB
-    assert database.query('mpileaks ^mpich', installed=any) == []
+    assert mutable_database.query('mpileaks ^mpich', installed=any) == []
 
     # record's deps have updated ref_counts
-    assert database.get_record('callpath ^mpich').ref_count == 0
-    assert database.get_record('mpich').ref_count == 1
+    assert mutable_database.get_record('callpath ^mpich').ref_count == 0
+    assert mutable_database.get_record('mpich').ref_count == 1
 
     # Put the spec back
-    database.add(rec.spec, spack.store.layout)
+    mutable_database.add(rec.spec, spack.store.layout)
 
     # record is present again
-    assert len(database.query('mpileaks ^mpich', installed=any)) == 1
+    assert len(mutable_database.query('mpileaks ^mpich', installed=any)) == 1
 
     # dependencies have ref counts updated
-    assert database.get_record('callpath ^mpich').ref_count == 1
-    assert database.get_record('mpich').ref_count == 2
+    assert mutable_database.get_record('callpath ^mpich').ref_count == 1
+    assert mutable_database.get_record('mpich').ref_count == 2
 
 
-def test_090_non_root_ref_counts(database):
-    database.get_record('mpileaks ^mpich')
-    database.get_record('callpath ^mpich')
+def test_090_non_root_ref_counts(mutable_database):
+    mutable_database.get_record('mpileaks ^mpich')
+    mutable_database.get_record('callpath ^mpich')
 
     # "force remove" a non-root spec from the DB
-    database.remove('callpath ^mpich')
+    mutable_database.remove('callpath ^mpich')
 
     # record still in DB but marked uninstalled
-    assert database.query('callpath ^mpich', installed=True) == []
-    assert len(database.query('callpath ^mpich', installed=any)) == 1
+    assert mutable_database.query('callpath ^mpich', installed=True) == []
+    assert len(mutable_database.query('callpath ^mpich', installed=any)) == 1
 
     # record and its deps have same ref_counts
-    assert database.get_record(
+    assert mutable_database.get_record(
         'callpath ^mpich', installed=any
     ).ref_count == 1
-    assert database.get_record('mpich').ref_count == 2
+    assert mutable_database.get_record('mpich').ref_count == 2
 
     # remove only dependent of uninstalled callpath record
-    database.remove('mpileaks ^mpich')
+    mutable_database.remove('mpileaks ^mpich')
 
     # record and parent are completely gone.
-    assert database.query('mpileaks ^mpich', installed=any) == []
-    assert database.query('callpath ^mpich', installed=any) == []
+    assert mutable_database.query('mpileaks ^mpich', installed=any) == []
+    assert mutable_database.query('callpath ^mpich', installed=any) == []
 
     # mpich ref count updated properly.
-    mpich_rec = database.get_record('mpich')
+    mpich_rec = mutable_database.get_record('mpich')
     assert mpich_rec.ref_count == 0
 
 
@@ -597,18 +597,18 @@ def test_115_reindex_with_packages_not_in_repo(mutable_database):
         _check_db_sanity(mutable_database)
 
 
-def test_external_entries_in_db(database):
-    rec = database.get_record('mpileaks ^zmpi')
+def test_external_entries_in_db(mutable_database):
+    rec = mutable_database.get_record('mpileaks ^zmpi')
     assert rec.spec.external_path is None
     assert rec.spec.external_module is None
 
-    rec = database.get_record('externaltool')
+    rec = mutable_database.get_record('externaltool')
     assert rec.spec.external_path == '/path/to/external_tool'
     assert rec.spec.external_module is None
     assert rec.explicit is False
 
     rec.spec.package.do_install(fake=True, explicit=True)
-    rec = database.get_record('externaltool')
+    rec = mutable_database.get_record('externaltool')
     assert rec.spec.external_path == '/path/to/external_tool'
     assert rec.spec.external_module is None
     assert rec.explicit is True

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -19,6 +19,7 @@ from llnl.util.tty.colify import colify
 import spack.repo
 import spack.store
 import spack.database
+import spack.package
 import spack.spec
 from spack.test.conftest import MockPackage, MockPackageMultiRepo
 from spack.util.executable import Executable
@@ -646,3 +647,13 @@ def test_old_external_entries_prefix(mutable_database):
     assert record.path is None
     assert record.spec._prefix is None
     assert record.spec.prefix == record.spec.external_path
+
+
+def test_uninstall_by_spec(mutable_database):
+    with mutable_database.write_transaction():
+        for spec in mutable_database.query():
+            if spec.package.installed:
+                spack.package.PackageBase.uninstall_by_spec(spec, force=True)
+            else:
+                mutable_database.remove(spec)
+    assert len(mutable_database.query()) == 0

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -310,15 +310,15 @@ class TestSpecSyntax(object):
         assert len(specs) == 2
 
     @pytest.mark.db
-    def test_ambiguous_hash(self, database):
+    def test_ambiguous_hash(self, mutable_database):
         x1 = Spec('a')
         x1._hash = 'xy'
         x1._concrete = True
         x2 = Spec('a')
         x2._hash = 'xx'
         x2._concrete = True
-        database.add(x1, spack.store.layout)
-        database.add(x2, spack.store.layout)
+        mutable_database.add(x1, spack.store.layout)
+        mutable_database.add(x2, spack.store.layout)
 
         # ambiguity in first hash character
         self._check_raises(AmbiguousHashError, ['/x'])


### PR DESCRIPTION
The `database` and `mutable_database` fixtures were installing and uninstalling the same specs multiple times to maintain the test database in a consistent state. This PR optimizes the procedure by:
- Installing specs only the first time the fixtures are requested
- Caching the installation path into a persistent folder
- Erasing the installation path and copying the cache back into it when needed

The results on my laptop:
```console
$ uname -a
Linux nuvolari 4.15.0-54-generic #58-Ubuntu SMP Mon Jun 24 10:55:24 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux
```
 are the following. On `develop` (with 2 tests not marked):
```console
$ python3.7 bin/spack test -m db
============================================================== test session starts ===============================================================
platform linux -- Python 3.7.4, pytest-3.2.5, py-1.4.34, pluggy-0.4.0
rootdir: /home/mculpo/PycharmProjects/spack/lib/spack/spack/test, inifile: pytest.ini
collected 1553 items                                                                                                                              

database.py .......................
spec_syntax.py .......
cmd/dependencies.py ..
cmd/dependents.py ..
cmd/find.py ....
cmd/graph.py .....
cmd/location.py .......
cmd/module.py ............................
cmd/uninstall.py ...
modules/tcl.py ..

=========================================================== slowest 20 test durations ============================================================
4.01s setup    cmd/location.py::test_location_install_dir
4.00s setup    cmd/module.py::test_exit_with_failure[dotkit-failure_args0]
3.88s setup    cmd/graph.py::test_graph_ascii
3.85s setup    cmd/dependencies.py::test_immediate_installed_dependencies
3.82s setup    cmd/dependents.py::test_immediate_installed_dependents
3.82s setup    cmd/find.py::test_tag1
3.81s teardown database.py::test_old_external_entries_prefix
3.81s setup    spec_syntax.py::TestSpecSyntax::test_spec_by_hash
3.80s teardown database.py::test_regression_issue_8036
3.76s teardown database.py::test_030_db_sanity_from_another_process
3.75s teardown database.py::test_115_reindex_with_packages_not_in_repo
3.33s setup    modules/tcl.py::TestTcl::test_blacklist_implicits
3.22s teardown cmd/module.py::test_setdefault_command
3.21s setup    cmd/uninstall.py::test_multiple_matches
2.59s setup    database.py::test_default_queries
0.79s call     cmd/module.py::test_setdefault_command
0.63s call     database.py::test_025_reindex
0.55s call     cmd/module.py::test_remove_and_add[dotkit]
0.51s call     database.py::test_115_reindex_with_packages_not_in_repo
0.50s call     spec_syntax.py::TestSpecSyntax::test_spec_by_hash
============================================================= 1470 tests deselected ==============================================================
================================================== 83 passed, 1470 deselected in 64.46 seconds ===================================================
```
while with this PR:
```console
$ python3.7 bin/spack test -m db
============================================================== test session starts ===============================================================
platform linux -- Python 3.7.4, pytest-3.2.5, py-1.4.34, pluggy-0.4.0
rootdir: /home/mculpo/PycharmProjects/spack/lib/spack/spack/test, inifile: pytest.ini
collected 1553 items                                                                                                                              

database.py .......................
spec_syntax.py .......
cmd/buildcache.py .
cmd/debug.py .
cmd/dependencies.py ..
cmd/dependents.py ..
cmd/find.py ....
cmd/graph.py .....
cmd/location.py .......
cmd/module.py ............................
cmd/uninstall.py ...
modules/tcl.py ..

=========================================================== slowest 20 test durations ============================================================
2.45s setup    database.py::test_default_queries
0.74s call     cmd/module.py::test_setdefault_command
0.65s call     database.py::test_025_reindex
0.56s call     cmd/buildcache.py::test_buildcache_preview_just_runs
0.55s call     cmd/module.py::test_remove_and_add[dotkit]
0.54s call     cmd/module.py::test_remove_and_add[tcl]
0.54s call     spec_syntax.py::TestSpecSyntax::test_spec_by_hash
0.52s call     database.py::test_115_reindex_with_packages_not_in_repo
0.45s call     modules/tcl.py::TestTcl::test_autoload_with_constraints
0.28s call     cmd/uninstall.py::test_recursive_uninstall
0.25s call     database.py::test_060_remove_and_add_root_package
0.23s call     database.py::test_030_db_sanity_from_another_process
0.22s call     database.py::test_070_remove_and_add_dependency_package
0.21s call     database.py::test_010_all_install_sanity
0.20s call     database.py::test_090_non_root_ref_counts
0.19s call     database.py::test_020_db_sanity
0.15s call     database.py::test_015_write_and_read
0.15s call     database.py::test_080_root_ref_counts
0.14s call     cmd/module.py::test_find_recursive
0.13s call     cmd/dependents.py::test_transitive_installed_dependents
============================================================= 1468 tests deselected ==============================================================
================================================== 85 passed, 1468 deselected in 15.72 seconds ===================================================
```
 