### PR TITLE
coverage: restore status updates on PRs

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,8 +4,7 @@ coverage:
   range: 60...90
   status:
     project:
-      default:
-        threshold: 0.5
+      default: yes
 
 ignore:
   - lib/spack/spack/test/.*


### PR DESCRIPTION
Codecov is not updating PRs with status anymore.

- [x] Fix `.codecov.yaml` to restore updates.