### PR TITLE
r: set FPICFLAGS for compilers except 'gcc'

### DIFF
--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -131,6 +131,10 @@ class R(AutotoolsPackage):
         if '+memory_profiling' in spec:
             config_args.append('--enable-memory-profiling')
 
+        # Set FPICFLAGS for compilers except 'gcc'.
+        if self.compiler.name != 'gcc':
+            config_args.append('FPICFLAGS={0}'.format(self.compiler.pic_flag))
+
         return config_args
 
     @run_after('install')


### PR DESCRIPTION
The configure of the `r` package with the fujitsu compiler was failed because the following error occurred:
```
   300    configure: WARNING: I could not determine FPICFLAGS.
>> 301    configure: error: See the file doc/html/R-admin.html for more information.
```
According to the following URL, the build with compilers except `gcc` needs to set `FPICFLAGS`:
http://www.hep.by/gnu/r-patched/r-admin/R-admin_79.html

Therefore, I set `FPICFLAGS` for compilers except `gcc`.