### PR TITLE
hpgmp: Don't add -mcpu=native on ARM and gcc 5.x or before.

### DIFF
--- a/var/spack/repos/builtin/packages/hpgmg/package.py
+++ b/var/spack/repos/builtin/packages/hpgmg/package.py
@@ -68,7 +68,7 @@ class Hpgmg(Package):
             cflags.append('-O3')
             if self.compiler.target in ['x86_64']:
                 cflags.append('-march=native')
-            else:
+            elif not self.spec.satisfies('target=aarch64 %gcc@:5.9'):
                 cflags.append('-mcpu=native')
                 cflags.append('-mtune=native')
         else:


### PR DESCRIPTION
hpgmp add -mcpu=native for gcc.
But gcc on aarch64 is supported -mcpu=native on gcc version 6:
https://www.gnu.org/software/gcc/gcc-6/changes.html#aarch64

This patch avoid -march=native on aarch64 and gcc 5 or before.