### PR TITLE
update web site and git url for BMI package

### DIFF
--- a/var/spack/repos/builtin/packages/bmi/package.py
+++ b/var/spack/repos/builtin/packages/bmi/package.py
@@ -9,8 +9,8 @@ from spack import *
 class Bmi(AutotoolsPackage):
     """a communications framework and network abstraction layer"""
 
-    homepage = 'http://git.mcs.anl.gov/bmi.git/'
-    git = 'git://git.mcs.anl.gov/bmi'
+    homepage = 'https://xgitlab.cels.anl.gov/sds/bmi'
+    git = 'https://xgitlab.cels.anl.gov/sds/bmi.git'
 
     version('develop', branch='master')
 


### PR DESCRIPTION
The git server that previously hosted the BMI repository is being retired and will no longer be publicly accessible after July 22, 2019.  We migrated the repo to a new (long term) server.