### PR TITLE
isaac-server: Don't add -march=native on ARM and gcc 5.x or before.

### DIFF
--- a/var/spack/repos/builtin/packages/isaac-server/arm.patch
+++ b/var/spack/repos/builtin/packages/isaac-server/arm.patch
@@ -1,0 +1,18 @@
+diff -ru spack-src/server/CMakeLists.txt spack-src.new/server/CMakeLists.txt
+--- spack-src/server/CMakeLists.txt	2018-06-12 23:00:55.000000000 +0900
++++ spack-src.new/server/CMakeLists.txt	2019-07-16 19:05:23.842478919 +0900
+@@ -84,7 +84,13 @@
+ 	add_definitions(-DISAAC_JPEG)
+ endif (ISAAC_JPEG)
+ 
+-add_definitions(-std=c++11 -march=native -mtune=native)
++if (CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64 AND
++    CMAKE_C_COMPILER_ID STREQUAL GNU AND
++    CMAKE_C_COMPILER_VERSION VERSION_LESS 6.0)
++    add_definitions(-std=c++11)
++else ()
++    add_definitions(-std=c++11 -march=native -mtune=native)
++endif ()
+ 
+ add_executable(isaac ${HDRS} ${SRCS})
+ 

--- a/var/spack/repos/builtin/packages/isaac-server/package.py
+++ b/var/spack/repos/builtin/packages/isaac-server/package.py
@@ -35,5 +35,6 @@ class IsaacServer(CMakePackage):
 
     # https://github.com/ComputationalRadiationPhysics/isaac/pull/70
     patch('jpeg.patch', when='@:1.3.1')
+    patch('arm.patch', when='@:1.4.0 target=aarch64')
 
     root_cmakelists_dir = 'server'


### PR DESCRIPTION
isaac-server add -march=native for gcc.
But gcc on aarch64 is supported -mcpu=native on gcc version 6:
https://www.gnu.org/software/gcc/gcc-6/changes.html#aarch64

This patch avoid -march=native and -mmtune=native on aarch64 and gcc 5 or before.