### PR TITLE
Add OpenMP flag for Apple Clang

### DIFF
--- a/lib/spack/spack/compilers/clang.py
+++ b/lib/spack/spack/compilers/clang.py
@@ -83,10 +83,7 @@ class Clang(Compiler):
     @property
     def openmp_flag(self):
         if self.is_apple:
-            raise UnsupportedCompilerFlag(self,
-                                          "OpenMP",
-                                          "openmp_flag",
-                                          "Xcode {0}".format(self.version))
+            return "-Xpreprocessor -fopenmp"
         else:
             return "-fopenmp"
 

--- a/lib/spack/spack/test/compilers.py
+++ b/lib/spack/spack/test/compilers.py
@@ -193,7 +193,8 @@ def test_clang_flags():
     supported_flag_test("pic_flag", "-fPIC", "gcc@4.0")
 
     # Apple Clang.
-    unsupported_flag_test("openmp_flag", "clang@2.0.0-apple")
+    supported_flag_test(
+        "openmp_flag", "-Xpreprocessor -fopenmp", "clang@2.0.0-apple")
     unsupported_flag_test("cxx11_flag", "clang@2.0.0-apple")
     supported_flag_test("cxx11_flag", "-std=c++11", "clang@4.0.0-apple")
     unsupported_flag_test("cxx14_flag", "clang@5.0.0-apple")


### PR DESCRIPTION
According to https://iscinumpy.gitlab.io/post/omp-on-high-sierra/, Apple Clang can actually build with OpenMP, you just need to install separate OpenMP libraries. This was used in #11496, but split into a separate PR to allow more time for review.