### PR TITLE
font-util: add missing autoconf automake dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/font-util/package.py
+++ b/var/spack/repos/builtin/packages/font-util/package.py
@@ -13,6 +13,9 @@ class FontUtil(AutotoolsPackage):
     url      = "https://www.x.org/archive/individual/font/font-util-1.3.1.tar.gz"
     version('1.3.1', 'd153a9af216e4498fa171faea2c82514')
 
+    depends_on('autoconf', type='build')
+    depends_on('automake', type='build')
+
     depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 


### PR DESCRIPTION
This fixes the following post install error on systems where autoreconf and aclocal are not available:

> 0dpi-1.0.3.tar.gz
==> Created stage in /home/marlin/tmp/spack-font-util/spack/var/spack/stage/resource-font-bh-lucidatypewriter-100dpi-q3hfsdfvovwl5i6757tgiesw5z4tfrhn
==> Moving resource stage
        source : /home/marlin/tmp/spack-font-util/spack/var/spack/stage/resource-font-bh-lucidatypewriter-100dpi-q3hfsdfvovwl5i6757tgiesw5z4tfrhn/spack-src/
        destination : /home/marlin/tmp/spack-font-util/spack/var/spack/stage/font-util-1.3.1-q3hfsdfvovwl5i6757tgiesw5z4tfrhn/spack-src/font-bh-lucidatypewriter-100dpi/font-bh-lucidatypewriter-100dpi-1.0.3
==> No patches needed for font-util
==> Building font-util [AutotoolsPackage]
==> Executing phase: 'autoreconf'
==> Executing phase: 'configure'
==> Executing phase: 'build'
==> Executing phase: 'install'
==> Error: TypeError: 'NoneType' object is not callable
> /home/marlin/tmp/spack-font-util/spack/var/spack/repos/builtin/packages/font-util/package.py:105, in font_install:
        102                autoreconf(*autoconf_args)
        103                configure = Executable("./configure")
        104                configure('--prefix={0}'.format(self.prefix))
        105                make('install')