### PR TITLE
cmake: Move cxx11 flags for fujitsu into the flag_handler method

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -112,7 +112,13 @@ class Cmake(Package):
 
     def flag_handler(self, name, flags):
         if name == 'cxxflags' and self.compiler.name == 'fc':
-            flags.append(self.compiler.cxx11_flag)
+            cxx11plus_flags = (self.compiler.cxx11_flag,
+                               self.compiler.cxx14_flag)
+            cxxpre11_flags = (self.cxx98_flags)
+            if any(f in flags for f in cxxpre11_flags):
+                raise ValueError('cannot build cmake pre-c++11 standard')
+            elif not any(f in flags for f in cxx11plus_flags):
+                flags.append(self.compiler.cxx11_flag)
         return (flags, None, None)
 
     def bootstrap_args(self):

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -111,7 +111,7 @@ class Cmake(Package):
     phases = ['bootstrap', 'build', 'install']
 
     def flag_handler(self, name, flags):
-        if name == 'cxxflags' and self.compiler.name == 'fc':
+        if name == 'cxxflags' and self.compiler.name == 'fj':
             cxx11plus_flags = (self.compiler.cxx11_flag,
                                self.compiler.cxx14_flag)
             cxxpre11_flags = (self.cxx98_flags)

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -110,11 +110,10 @@ class Cmake(Package):
 
     phases = ['bootstrap', 'build', 'install']
 
-    def setup_environment(self, spack_env, run_env):
-        if self.compiler.name == 'fj' \
-                and self.compiler.cxx11_flag \
-                not in self.spec.compiler_flags['cxxflags']:
-            spack_env.append_flags('CXXFLAGS', self.compiler.cxx11_flag)
+    def flag_handler(self, name, flags):
+        if name == 'cxxflags' and self.compiler.name == 'fc':
+            flags.append(self.compiler.cxx11_flag)
+        return (flags, None, None)
 
     def bootstrap_args(self):
         spec = self.spec


### PR DESCRIPTION
This is a follow-up to #11839, which I merged prematurely.

See https://github.com/spack/spack/pull/11839#issuecomment-512863141