### PR TITLE
fixes spack module loads for upstream packages

### DIFF
--- a/lib/spack/spack/cmd/modules/__init__.py
+++ b/lib/spack/spack/cmd/modules/__init__.py
@@ -137,7 +137,12 @@ def loads(module_type, specs, args, out=sys.stdout):
             modules.append((spec, module_cls(spec).layout.use_name))
         elif spec.package.installed_upstream:
             tty.debug("Using upstream module for {0}".format(spec))
-            module = spack.modules.common.upstream_module(spec, module_type)
+
+            import spack.modules.common as common
+            module = common.upstream_module_index.upstream_modules(
+                spec,
+                module_type
+            )
             modules.append((spec, module.use_name))
 
     module_commands = {


### PR DESCRIPTION
Fixes #12062

It seems that a non-existing function was used. I replaced it with the one used also by the `find` sub-command.

@scheibelp, it seems that last change to this section was from you, I tried tracking if this function was existing before, but with no luck. I mentioned you just because you may be able to check quickly if this is the right fix.