### PR TITLE
libsharp: Don't add -march=native on ARM

### DIFF
--- a/var/spack/repos/builtin/packages/libsharp/1.0.0-arm.patch
+++ b/var/spack/repos/builtin/packages/libsharp/1.0.0-arm.patch
@@ -1,0 +1,13 @@
+diff -ru spack-src/configure.ac spack-src.new/configure.ac
+--- spack-src/configure.ac	2019-07-19 13:59:16.000000000 +0900
++++ spack-src.new/configure.ac	2019-07-19 14:13:36.973408139 +0900
+@@ -49,7 +49,7 @@
+ 
+ case $CCTYPE in
+   gcc)
+-    CCFLAGS="-O3 -fno-tree-vectorize -ffast-math -fomit-frame-pointer -std=c99 -pedantic -Wextra -Wall -Wno-unknown-pragmas -Wshadow -Wmissing-prototypes -Wfatal-errors -march=native"
++    CCFLAGS="-O3 -fno-tree-vectorize -ffast-math -fomit-frame-pointer -std=c99 -pedantic -Wextra -Wall -Wno-unknown-pragmas -Wshadow -Wmissing-prototypes -Wfatal-errors"
+     GCCVERSION="`$CC -dumpversion 2>&1`"
+     echo "Using gcc version $GCCVERSION"
+     AC_SUBST(GCCVERSION)
+Only in spack-src.new: configure.ac.new

--- a/var/spack/repos/builtin/packages/libsharp/arm.patch
+++ b/var/spack/repos/builtin/packages/libsharp/arm.patch
@@ -1,0 +1,15 @@
+diff -ru spack-src/configure.ac spack-src.new/configure.ac
+--- spack-src/configure.ac	2019-07-19 11:40:41.000000000 +0900
++++ spack-src.new/configure.ac	2019-07-19 13:48:48.773238828 +0900
+@@ -56,8 +56,9 @@
+     changequote(,)
+     gcc43=`echo $GCCVERSION | grep -c '^4\.[3456789]'`
+     gcc44=`echo $GCCVERSION | grep -c '^4\.4'`
++    arch=`uname -m`
+     changequote([,])
+-    if test $gcc43 -gt 0; then
++    if test $gcc43 -gt 0 -a $arch != aarch64; then
+       CCFLAGS="$CCFLAGS -march=native"
+     fi
+     if test $gcc44 -gt 0; then
+Only in spack-src.new: configure.ac.new

--- a/var/spack/repos/builtin/packages/libsharp/package.py
+++ b/var/spack/repos/builtin/packages/libsharp/package.py
@@ -17,7 +17,7 @@ class Libsharp(AutotoolsPackage):
     homepage = "https://github.com/Libsharp/libsharp"
     git      = "https://github.com/Libsharp/libsharp.git"
 
-    version('1.0.0', commit='cc4753ff4b0ef393f0d4ada41a175c6d1dd85d71')
+    version('1.0.0', commit='cc4753ff4b0ef393f0d4ada41a175c6d1dd85d71', preferred=True)
     version('2018-01-17', commit='593d4eba67d61827191c32fb94bf235cb31205e1')
 
     depends_on('autoconf', type='build')

--- a/var/spack/repos/builtin/packages/libsharp/package.py
+++ b/var/spack/repos/builtin/packages/libsharp/package.py
@@ -23,6 +23,9 @@ class Libsharp(AutotoolsPackage):
     depends_on('autoconf', type='build')
     depends_on('mpi', when='+mpi')
 
+    patch('arm.patch', when='@2018-01-17 target=aarch64')
+    patch('1.0.0-arm.patch', when='@1.0.0 target=aarch64')
+
     def autoreconf(self, spec, prefix):
         """Generate autotools configuration"""
         bash = which('bash')


### PR DESCRIPTION
libsharp add -march=native for gcc 4.x.
But gcc on aarch64 is supported -mcpu=native on gcc version 6:
https://www.gnu.org/software/gcc/gcc-6/changes.html#aarch64

This patch avoid -march=native on aarch64.