### PR TITLE
hpcviewer: add version 2019.07

### DIFF
--- a/var/spack/repos/builtin/packages/hpcviewer/package.py
+++ b/var/spack/repos/builtin/packages/hpcviewer/package.py
@@ -33,6 +33,9 @@ class Hpcviewer(Package):
     homepage = "http://hpctoolkit.org"
 
     viewer_sha = {
+        ('2019.07', 'x86_64'):  '3bc10354e02c4d4b9dfd2075395b380dda8e9436f5cb4c40e4d50fe4795d7270',
+        ('2019.07', 'ppc64'):   '28628890c3297754aed06b6ddcefb4f30a563854f28667288660444cfadde2a4',
+        ('2019.07', 'ppc64le'): 'bdc1ee69f938996cc795dcd012f1d0d46e7bd594175aad920d39a0a32590a0f9',
         ('2019.04', 'x86_64'):  'c524498ef235171e298c8142b7e73b0a1f7c433f9c471fb692d31f0685e53aa4',
         ('2019.04', 'ppc64'):   'dc9daee886ba72c0615db909860ee1aed0979f12c0d113efbe721ddabdf55199',
         ('2019.04', 'ppc64le'): 'dddabccef156996d390653639096ad3e27b7384a5754f42084f50c4a50a9009b',
@@ -42,6 +45,9 @@ class Hpcviewer(Package):
     }
 
     trace_sha = {
+        ('2019.07', 'x86_64'):  'c69db0dd10bc861eb7c594cb1e5f32bf9e104d0858c4a3c075b58a446485f2bf',
+        ('2019.07', 'ppc64'):   '927c8a2443d4cec3725dab28879f7f1efbc337cdc3c0bb7536ec891daacb50ab',
+        ('2019.07', 'ppc64le'): '3b04244e254d9d11802321199c11c8799040f86389b520842af64fa73dfc58a8',
         ('2019.04', 'x86_64'):  'f5f908c0e52c97a72af1af8519f4b191298fe52bd811dd06a051b68cd7bcce27',
         ('2019.04', 'ppc64'):   '221683c992e4fe2cd9079ad2ebb531d99d04a3cbb3a8860f795b276b1eaeab19',
         ('2019.04', 'ppc64le'): 'fe539c6a165a72bba6ea7bdb34a90d862d427c4d55095c97794d54e6dd9d3075',
@@ -50,7 +56,7 @@ class Hpcviewer(Package):
         ('2019.02', 'ppc64le'): '01a159306e7810efe07157ec823ac6ca7570ec2014c95db599a3f90eee33355c',
     }
 
-    version_list = ['2019.04', '2019.02']
+    version_list = ['2019.07', '2019.04', '2019.02']
 
     for ver in version_list:
         key = (ver, platform.machine())

--- a/var/spack/repos/builtin/packages/ibm-java/package.py
+++ b/var/spack/repos/builtin/packages/ibm-java/package.py
@@ -17,7 +17,7 @@ class IbmJava(Package):
     # There are separate tar files for big and little-endian machine
     # types.  When we add more versions, then turn this into a mapping
     # from version and machine type to sha256sum.
-    mach = platform.machine()
+    mach = platform.machine() if platform.machine() == 'ppc64' else 'ppc64le'
     if mach == 'ppc64le':
         sha = 'dec6434d926861366c135aac6234fc28b3e7685917015aa3a3089c06c3b3d8f0'
     else:


### PR DESCRIPTION
ibm-java: fix the URL to only use a machine type that ibm-java
supports so that 'spack info' doesn't report a non-existent URL on
platforms that it doesn't support.