### PR TITLE
environment views: refactor build-only dependency removal

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -462,9 +462,7 @@ class ViewDescriptor(object):
             # recognize environment specs (which do store build deps), then
             # they need to be stripped
             if spec.concrete:  # Do not link unconcretized roots
-                specs_for_view.append(spack.spec.Spec.from_dict(
-                    spec.to_dict(all_deps=False)
-                ))
+                specs_for_view.append(spec.copy(deps=('link', 'run')))
 
         if self.select:
             specs_for_view = list(filter(self.select_fn, specs_for_view))


### PR DESCRIPTION
1. There exists ugly code that round trips specs to yaml to remove their build-only dependencies, because those are not stored in views.

2. There exists a nice function that copies a spec, optionally only copying link and run deptypes

This PR uses 2 to replace 1.