### PR TITLE
 error messages: include whole spec for "no externals found" message

### DIFF
--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -587,6 +587,6 @@ class NoBuildError(spack.error.SpackError):
        no satisfactory external versions can be found"""
 
     def __init__(self, spec):
-        msg = ("The spec '%s' is configured as not buildable, "
+        msg = ("The spec\n'%s'\nis configured as not buildable, "
                "and no matching external installs were found")
-        super(NoBuildError, self).__init__(msg % spec.name)
+        super(NoBuildError, self).__init__(msg % spec)

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -587,6 +587,6 @@ class NoBuildError(spack.error.SpackError):
        no satisfactory external versions can be found"""
 
     def __init__(self, spec):
-        msg = ("The spec\n'%s'\nis configured as not buildable, "
+        msg = ("The spec\n    '%s'\n    is configured as not buildable, "
                "and no matching external installs were found")
         super(NoBuildError, self).__init__(msg % spec)


### PR DESCRIPTION
Provide better error message when matching externals are found for package marked not buildable

Now, the entire spec is in the message.