### PR TITLE
add autoconf/automake build deps to font-util

### DIFF
--- a/var/spack/repos/builtin/packages/font-util/package.py
+++ b/var/spack/repos/builtin/packages/font-util/package.py
@@ -20,6 +20,9 @@ class FontUtil(AutotoolsPackage):
     depends_on('mkfontscale', type='build')
     depends_on('mkfontdir', type='build')
 
+    depends_on('autoconf', type='build')
+    depends_on('automake', type='build')
+
     font_baseurl = 'https://www.x.org/archive/individual/font/'
     fonts = []
     # name, version, md5


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/12026

Required on some systems