### PR TITLE
Allow bsseeker2 to build with Python 3

### DIFF
--- a/var/spack/repos/builtin/packages/bsseeker2/package.py
+++ b/var/spack/repos/builtin/packages/bsseeker2/package.py
@@ -18,7 +18,7 @@ class Bsseeker2(Package):
     version('2.1.2', '5f7f0ef4071711e56b59c5c16b7f34a7',
             url='https://github.com/BSSeeker/BSseeker2/archive/v2.1.2.tar.gz')
 
-    depends_on('python@2.6:2.999', type=('build', 'run'))
+    depends_on('python@2.6:', type=('build', 'run'))
     depends_on('py-pysam', type=('build', 'run'))
 
     def install(self, spec, prefix):


### PR DESCRIPTION
I see no evidence that bsseeker2 does not support Python 3. The [system requirements](https://github.com/BSSeeker/BSseeker2#3-system-requirements) say Python 2.6+, and the [bioconda package](https://github.com/bioconda/bioconda-recipes/blob/master/recipes/bs-seeker2/meta.yaml) does not restrict things to Python 2.