### PR TITLE
Add CMOR 3.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/cmor/package.py
+++ b/var/spack/repos/builtin/packages/cmor/package.py
@@ -13,8 +13,9 @@ class Cmor(AutotoolsPackage):
     standard model experiments."""
 
     homepage = "http://cmor.llnl.gov"
-    url = "https://github.com/PCMDI/cmor/archive/3.1.2.tar.gz"
+    url = "https://github.com/PCMDI/cmor/archive/3.4.0.tar.gz"
 
+    version('3.4.0', sha256='e700a6d50f435e6ffdedf23bf6832b7d37fe21dc78815e1372f218d1d52bd2cb')
     version('3.3.0', 'cfdeeddab1aedb823e26ec38723bd67e')
     version('3.2.0', 'b48105105d4261012c19cd65e89ff7a6')
     version('3.1.2', '72f7227159c901e4bcf80d2c73a8ce77')
@@ -28,7 +29,7 @@ class Cmor(AutotoolsPackage):
     depends_on('hdf5@:1.8.19')
 
     extends('python', when='+python')
-    depends_on('python@:2.8', when='+python')
+    depends_on('python@:2', when='@:3.3 +python')
     depends_on('py-numpy', type=('build', 'run'), when='+python')
 
     @run_before('configure')


### PR DESCRIPTION
It's unclear when CMOR added Python 3 support, but their [circleci config file](https://github.com/PCMDI/cmor/blob/master/.circleci/config.yml) tests Python 3, and [conda](https://anaconda.org/PCMDI/cmor/files) has binaries for Python 3.