### PR TITLE
tealeaf: Don't add -march=native on ARM and gcc 5.x or before.

### DIFF
--- a/var/spack/repos/builtin/packages/tealeaf/package.py
+++ b/var/spack/repos/builtin/packages/tealeaf/package.py
@@ -24,6 +24,12 @@ class Tealeaf(MakefilePackage):
 
     depends_on('mpi')
 
+    def edit(self, spec, prefix):
+        if (spec.satisfies('target=aarch64 %gcc@:5.9')):
+            filter_file(
+                '-march=native', '', join_path('TeaLeaf_ref', 'Makefile')
+            )
+
     @property
     def build_targets(self):
         targets = [


### PR DESCRIPTION
tealeaf add -march=native for gcc.
But gcc on aarch64 is supported -mcpu=native on gcc version 6:
https://www.gnu.org/software/gcc/gcc-6/changes.html#aarch64

This patch avoid -march=native and -mmtune=native on aarch64 and gcc 5 or before.