### PR TITLE
catalyst: Fix paths used for intermediate code generateion

### DIFF
--- a/var/spack/repos/builtin/packages/catalyst/package.py
+++ b/var/spack/repos/builtin/packages/catalyst/package.py
@@ -127,14 +127,14 @@ class Catalyst(CMakePackage):
         super(Catalyst, self).do_stage(mirror_only)
 
         # extract the catalyst part
-        paraview_dir = os.path.join(self.stage.source_path,
-                                    'ParaView-v' + str(self.version))
-        catalyst_script = os.path.join(paraview_dir, 'Catalyst', 'catalyze.py')
-        editions_dir = os.path.join(paraview_dir, 'Catalyst', 'Editions')
+        catalyst_script = os.path.join(self.stage.source_path, 'Catalyst',
+                                       'catalyze.py')
+        editions_dir = os.path.join(self.stage.source_path, 'Catalyst',
+                                    'Editions')
         catalyst_source_dir = os.path.abspath(self.root_cmakelists_dir)
 
         command = ['python', catalyst_script,
-                   '-r', paraview_dir,
+                   '-r', self.stage.source_path,
                    '-o', catalyst_source_dir]
 
         for edition in self.editions:


### PR DESCRIPTION
Bug introduced by  #11662
Fixes #12065