### PR TITLE
ncurses: remove TERMINFO from build env

### DIFF
--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -33,6 +33,9 @@ class Ncurses(AutotoolsPackage):
     patch('patch_gcc_5.txt', when='@6.0%gcc@5.0:')
     patch('sed_pgi.patch',   when='@:6.0')
 
+    def setup_environment(self, spack_env, run_env):
+        spack_env.unset('TERMINFO')
+
     def configure(self, spec, prefix):
         opts = [
             'CFLAGS={0}'.format(self.compiler.pic_flag),


### PR DESCRIPTION
Fixes #11369

ncurses build system respects the $TERMINFO environment variable for the location of terminfo database. We need to unset this variable to keep the database inside the Spack install tree.