### PR TITLE
libfabric: add EFA fabric

### DIFF
--- a/var/spack/repos/builtin/packages/libfabric/package.py
+++ b/var/spack/repos/builtin/packages/libfabric/package.py
@@ -37,7 +37,8 @@ class Libfabric(AutotoolsPackage):
                'rxm',
                'rxd',
                'mlx',
-               'tcp')
+               'tcp',
+               'efa')
 
     variant(
        'fabrics',


### PR DESCRIPTION
`libfabric` 1.8 (https://github.com/spack/spack/pull/11918) has integrated Amazon-developed Elastic Fabric Adapter (EFA) (https://aws.amazon.com/about-aws/whats-new/2019/07/elastic-fabric-adapter-officially-integrated-into-libfabric-library/). 

This pull request adds `efa` fabric to the spack package description allowing EFA-enabled `libfabric` to be installed via spack:
```
spack install libfabric fabrics=efa
```