### PR TITLE
ioapi: add version 3.2

### DIFF
--- a/var/spack/repos/builtin/packages/ioapi/package.py
+++ b/var/spack/repos/builtin/packages/ioapi/package.py
@@ -30,9 +30,6 @@ class Ioapi(MakefilePackage):
         makefile.filter('^BININST.*', 'BININST = ' + prefix.bin)
         makefile.filter('^LIBINST.*', 'LIBINST = ' + prefix.lib)
 
-    def build(self, spec, prefix):
-        make()
-
     def install(self, spec, prefix):
         make('install')
         # Install the header files.

--- a/var/spack/repos/builtin/packages/ioapi/package.py
+++ b/var/spack/repos/builtin/packages/ioapi/package.py
@@ -1,0 +1,48 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import glob
+import os
+
+from spack import *
+
+
+class Ioapi(MakefilePackage):
+    """Models-3/EDSS Input/Output Applications Programming Interface."""
+
+    homepage = "https://www.cmascenter.org/ioapi/"
+    url      = "https://www.cmascenter.org/ioapi/download/ioapi-3.2.tar.gz"
+    version('3.2', sha256=('56771ff0053d47f2445e00ff369bca7b'
+                           'fc484325a2816b2c648744e523134fe9'))
+    depends_on('netcdf@4:')
+    depends_on('netcdf-fortran@4:')
+    depends_on('sed', type='build')
+
+    def edit(self, spec, prefix):
+        # No default Makefile bundled; edit the template.
+        os.symlink('Makefile.template', 'Makefile')
+        # The makefile uses stubborn assignments of = instead of ?= so
+        # edit the makefile instead of using environmental variables.
+        makefile = FileFilter('Makefile')
+        makefile.filter('^BASEDIR.*', 'BASEDIR = ' + self.build_directory)
+        makefile.filter('^INSTALL.*', 'INSTALL = ' + prefix)
+        makefile.filter('^BININST.*', 'BININST = ' + prefix.bin)
+        makefile.filter('^LIBINST.*', 'LIBINST = ' + prefix.lib)
+
+    def build(self, spec, prefix):
+        make()
+
+    def install(self, spec, prefix):
+        make('install')
+        # Install the header files.
+        mkdirp(prefix.include.fixed132)
+        headers = glob.glob('ioapi/*.EXT')
+        for header in headers:
+            install(header, prefix.include)
+        # Install the header files for CMAQ and SMOKE in the
+        # non-standard -ffixed-line-length-132 format.
+        headers_fixed132 = glob.glob('ioapi/fixed_src/*.EXT')
+        for header in headers_fixed132:
+            install(header, prefix.include.fixed132)

--- a/var/spack/repos/builtin/packages/ioapi/package.py
+++ b/var/spack/repos/builtin/packages/ioapi/package.py
@@ -14,8 +14,7 @@ class Ioapi(MakefilePackage):
 
     homepage = "https://www.cmascenter.org/ioapi/"
     url      = "https://www.cmascenter.org/ioapi/download/ioapi-3.2.tar.gz"
-    version('3.2', sha256=('56771ff0053d47f2445e00ff369bca7b'
-                           'fc484325a2816b2c648744e523134fe9'))
+    version('3.2', sha256='56771ff0053d47f2445e00ff369bca7bfc484325a2816b2c648744e523134fe9')
     depends_on('netcdf@4:')
     depends_on('netcdf-fortran@4:')
     depends_on('sed', type='build')


### PR DESCRIPTION
New package for IOAPI.

So far only works on GNU/Linux.  

I've posted on the [mailing list](https://groups.google.com/forum/#!topic/spack/R6orWxLCtfg) about adding logic for other architectures supported by upstream, but I don't have exotic hardware to test anyway besides `linux x86_64`, so I figured I would send the working version with my architecture.