### PR TITLE
Add UCX 1.6.0

### DIFF
--- a/var/spack/repos/builtin/packages/ucx/package.py
+++ b/var/spack/repos/builtin/packages/ucx/package.py
@@ -14,6 +14,7 @@ class Ucx(AutotoolsPackage):
     url      = "https://github.com/openucx/ucx/releases/download/v1.3.1/ucx-1.3.1.tar.gz"
 
     # Current
+    version('1.6.0', sha256='360e885dd7f706a19b673035a3477397d100a02eb618371697c7f3ee4e143e2c')
     version('1.5.2', sha256='1a333853069860e86ba69b8d071ccc9871209603790e2b673ec61f8086913fad')
     version('1.5.1', sha256='567119cd80ad2ae6968ecaa4bd1d2a80afadd037ccc988740f668de10d2fdb7e')
     version('1.5.0', sha256='84f6e4fa5740afebb9b1c8bb405c07206e58c56f83120dcfcd8dc89e4b7d7458')


### PR DESCRIPTION
https://github.com/openucx/ucx/releases/tag/v1.6.0
Released 2019-07-17

## Verification builds on LANL Darwin x86_64 and Power9:

```
dantopa@cn2037:pr-update-ucx.spack $ date
Mon Jul 22 17:04:14 MDT 2019
```
```
dantopa@cn2037:pr-update-ucx.spack $ pwd
/scratch/users/dantopa/repos/spack/pr-update-ucx.spack
```
```
dantopa@cn2037:pr-update-ucx.spack $ spack find -ldf ucx

==> 2 installed packages
```
```
-- linux-centos7-x86_64 / gcc@4.8.5 -----------------------------
w7fp4n6    ucx@1.6.0%gcc
tt2hkol        ^numactl@2.0.12%gcc
srhy7ry        ^rdma-core@20%gcc
kvgvhpv            ^libnl@3.3.0%gcc

```
```
-- linux-rhel7-ppc64le / gcc@4.8.5 ------------------------------
cji3ce7    ucx@1.6.0%gcc
pmgndwh        ^numactl@2.0.12%gcc
qymrwx6        ^rdma-core@20%gcc
2263pm5            ^libnl@3.3.0%gcc
```
Signed-off-by: Daniel Topa <dantopa@lanl.gov>