### PR TITLE
nanoflann: Don't add -mtune=native on ARM and gcc 5.x

### DIFF
--- a/var/spack/repos/builtin/packages/nanoflann/package.py
+++ b/var/spack/repos/builtin/packages/nanoflann/package.py
@@ -15,6 +15,10 @@ class Nanoflann(CMakePackage):
 
     version('1.2.3', '92a0f44a631c41aa06f9716c51dcdb11')
 
+    def patch(self):
+        if self.spec.satisfies('target=aarch64 %gcc@:5.9'):
+            filter_file('-mtune=native', '', 'CMakeLists.txt')
+
     def cmake_args(self):
         args = ['-DBUILD_SHARED_LIBS=ON']
         return args


### PR DESCRIPTION
nanoflann add -mtune=native for gcc.
But gcc on aarch64 is supported -mcpu=native on gcc version 6:
https://www.gnu.org/software/gcc/gcc-6/changes.html#aarch64

This patch avoid -march=native and -mmtune=native on aarch64 and gcc 5 or before.