### PR TITLE
hashing: fix caching of dependency hashes in to_node_dict

### DIFF
--- a/lib/spack/spack/hash_types.py
+++ b/lib/spack/spack/hash_types.py
@@ -18,19 +18,22 @@ class SpecHashDescriptor(object):
 
     We currently use different hashes for different use cases.
     """
-    def __init__(self, deptype=('link', 'run'), package_hash=False):
+    def __init__(self, deptype=('link', 'run'), package_hash=False, attr=None):
         self.deptype = dp.canonical_deptype(deptype)
         self.package_hash = package_hash
+        self.attr = attr
 
 
 #: Default Hash descriptor, used by Spec.dag_hash() and stored in the DB.
-dag_hash = SpecHashDescriptor(deptype=('link', 'run'), package_hash=False)
+dag_hash = SpecHashDescriptor(deptype=('link', 'run'), package_hash=False,
+                              attr='_hash')
 
 
 #: Hash descriptor that includes build dependencies.
 build_hash = SpecHashDescriptor(
-    deptype=('build', 'link', 'run'), package_hash=False)
+    deptype=('build', 'link', 'run'), package_hash=False, attr='_build_hash')
 
 
 #: Full hash used in build pipelines to determine when to rebuild packages.
-full_hash = SpecHashDescriptor(deptype=('link', 'run'), package_hash=True)
+full_hash = SpecHashDescriptor(deptype=('link', 'run'), package_hash=True,
+                               attr='_full_hash')


### PR DESCRIPTION
Fixes #12091 

We were failing to cache hashes internally in the `Spec.to_node_dict` method, causing performance issues.

On develop, before this PR:

```
$ time spack stage r-rminer
…
real    3m35.715s
user    3m29.394s
sys    0m1.393s
```

With this PR:
```
$ time spack stage r-rminer
...
real    0m8.735s
user    0m8.166s
sys    0m0.473s
```

Both timings are with the code already staged.