### PR TITLE
Bugfix/stack write reference

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1237,9 +1237,11 @@ class Environment(object):
             # Remove any specs in yaml that are not in internal representation
             for ayl in active_yaml_lists:
                 # If it's not a string, it's a matrix. Those can't have changed
+                # If it is a string that starts with '$', it's a reference.
+                # Those also can't have changed.
                 ayl[name][:] = [s for s in ayl.setdefault(name, [])
-                                if not isinstance(s, six.string_types) or
-                                Spec(s) in speclist.specs]
+                                if (not isinstance(s, six.string_types)) or
+                                s.startswith('$') or Spec(s) in speclist.specs]
 
             # Put the new specs into the first active list from the yaml
             new_specs = [entry for entry in speclist.yaml_list

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -965,6 +965,29 @@ env:
         assert Spec('callpath') in test.user_specs
 
 
+@pytest.mark.regression('12095')
+def test_stack_yaml_definitions_write_reference(tmpdir):
+    filename = str(tmpdir.join('spack.yaml'))
+    with open(filename, 'w') as f:
+        f.write("""\
+env:
+  definitions:
+    - packages: [mpileaks, callpath]
+    - indirect: [$packages]
+  specs:
+    - $packages
+""")
+    with tmpdir.as_cwd():
+        env('create', 'test', './spack.yaml')
+
+        with ev.read('test'):
+            concretize()
+        test = ev.read('test')
+
+        assert Spec('mpileaks') in test.user_specs
+        assert Spec('callpath') in test.user_specs
+
+
 def test_stack_yaml_add_to_list(tmpdir):
     filename = str(tmpdir.join('spack.yaml'))
     with open(filename, 'w') as f:


### PR DESCRIPTION
Fixes #12095 

Spack environment definitions were improperly considering definition references to be specs at `Env.write()` time, and were generating invalid character errors when attempting to create specs.

Now they don't.