### PR TITLE
Updated prefix in cmake_args for Plasma

### DIFF
--- a/var/spack/repos/builtin/packages/plasma/package.py
+++ b/var/spack/repos/builtin/packages/plasma/package.py
@@ -70,8 +70,8 @@ class Plasma(CMakePackage):
         options = list()
 
         options.extend([
-            "-DCMAKE_INSTALL_PREFIX=%s" % prefix,
-            "-DCMAKE_INSTALL_NAME_DIR:PATH=%s/lib" % prefix,
+            "-DCMAKE_INSTALL_PREFIX=%s" % self.prefix,
+            "-DCMAKE_INSTALL_NAME_DIR:PATH=%s/lib" % self.prefix,
             "-DBLAS_LIBRARIES=%s" % self.spec["blas"].libs.joined(";"),
             "-DLAPACK_LIBRARIES=%s" % self.spec["lapack"].libs.joined(";")
         ])


### PR DESCRIPTION
Plasma installs correctly (in this instance as part of the xSDK but I've also installed individually) but I'm experiencing the following error when attempting to generate module files.

```bash
$ spack module lmod refresh
...
﻿==> Regenerating lmod module files
==> Warning: Could not write module file [/ecp/sw/dev/ecp-p9-4v100/modulefiles/xsdk/lmod/linux-centos7-ppc64le/netlib-lapack/3.8.0-er4hgnv/gcc/8.3.0/plasma/18.11.1.lua]
==> Warning:    --> global name 'prefix' is not defined <--
```

The fix appears to be using `self.prefix` instead of just `prefix` in the `cmake_args(self)` method. But if this is the wrong approach please let me know. Other posts relating to the "is not defined" error message did not help correct it.

@luszczek hope you don't mind I tag you on this PR since your marked as the maintainer.