### PR TITLE
Make OpenJDK the default

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -28,7 +28,7 @@ packages:
       glu: [mesa-glu, openglu]
       golang: [gcc]
       ipp: [intel-ipp]
-      java: [jdk, openjdk, ibm-java]
+      java: [openjdk, jdk, ibm-java]
       jpeg: [libjpeg-turbo, libjpeg]
       lapack: [openblas]
       mariadb-client: [mariadb-c-client, mariadb]


### PR DESCRIPTION
Makes OpenJDK the default over JDK because JDK is now a licensed product that is not freely available.  Having JDK as default broke builds of people who didn't even care about Java (eg: R).