### PR TITLE
rocksdb: Don't add -march=native on ARM and gcc 5.x or before.

### DIFF
--- a/var/spack/repos/builtin/packages/rocksdb/package.py
+++ b/var/spack/repos/builtin/packages/rocksdb/package.py
@@ -34,6 +34,13 @@ class Rocksdb(MakefilePackage):
 
     phases = ['install']
 
+    def patch(self):
+        if (self.spec.satisfies('target=aarch64 %gcc@:5.9')):
+            filter_file(
+                '-march=native', '',
+                join_path('build_tools', 'build_detect_platform')
+            )
+
     def install(self, spec, prefix):
         cflags = []
         ldflags = []


### PR DESCRIPTION
rocksdb add -march=native for gcc.
But gcc on aarch64 is supported -mcpu=native on gcc version 6:
https://www.gnu.org/software/gcc/gcc-6/changes.html#aarch64

This patch avoid -march=native on aarch64 and gcc 5 or before.