### PR TITLE
Do not build c-blosc test if intel in spec

### DIFF
--- a/var/spack/repos/builtin/packages/c-blosc/package.py
+++ b/var/spack/repos/builtin/packages/c-blosc/package.py
@@ -35,6 +35,10 @@ class CBlosc(CMakePackage):
     def cmake_args(self):
         args = []
 
+        # Some of the tests do not build with icc.
+        if '%intel' in self.spec:
+            args.append('-DBUILD_TESTS=OFF')
+
         if '+avx2' in self.spec:
             args.append('-DDEACTIVATE_AVX2=OFF')
         else:


### PR DESCRIPTION
While the c-blosc library compiles with icc some of the c-blosc tests do
not. Disable the tests so that the spack build can continue.