### PR TITLE
Add conflicts statement to freetype for icc

### DIFF
--- a/var/spack/repos/builtin/packages/freetype/package.py
+++ b/var/spack/repos/builtin/packages/freetype/package.py
@@ -24,6 +24,10 @@ class Freetype(AutotoolsPackage):
     depends_on('bzip2')
     depends_on('pkgconfig', type='build')
 
+    conflicts('%intel', when='@2.8:',
+              msg='freetype-2.8 and above cannot be built with icc (does not '
+              'support __builtin_shuffle)')
+
     patch('windows.patch', when='@2.9.1')
 
     def configure_args(self):


### PR DESCRIPTION
Freetype-2.8 and above use __builtin_shuffle which is not supported by
icc.