### PR TITLE
Perl take in flags

### DIFF
--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -239,6 +239,10 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
             substitute = "ld='{ld}'".format(ld=self.compiler.cc)
             filter_file(match, substitute, config_heavy, **kwargs)
 
+            match = "^ccflags='"
+            substitute = "ccflags='%s " % ' '.join(self.spec.compiler_flags['cflags'])
+            filter_file(match, substitute, config_heavy, **kwargs)
+
     @contextmanager
     def make_briefly_writable(self, path):
         """Temporarily make a file writable, then reset"""

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -240,7 +240,8 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
             filter_file(match, substitute, config_heavy, **kwargs)
 
             match = "^ccflags='"
-            substitute = "ccflags='%s " % ' '.join(self.spec.compiler_flags['cflags'])
+            substitute = "ccflags='%s " % ' '\
+                         .join(self.spec.compiler_flags['cflags'])
             filter_file(match, substitute, config_heavy, **kwargs)
 
     @contextmanager


### PR DESCRIPTION
・`PerlPackage` uses setting information in `config_heavy.pl` for generating `Makefile` from `Makefile.PL`.
・`spack_cflags` specified when installing`PerlPackage` doesn't take in `Makefile`.
So, I fixed the `perl` package file so that `spack_cflags` are taken in `config_heavy.pl` when installing `perl`.