### PR TITLE
cmake: fix cxx98flag's name

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -115,7 +115,7 @@ class Cmake(Package):
         if name == 'cxxflags' and self.compiler.name == 'fj':
             cxx11plus_flags = (self.compiler.cxx11_flag,
                                self.compiler.cxx14_flag)
-            cxxpre11_flags = (self.cxx98_flags)
+            cxxpre11_flags = (self.compiler.cxx98_flag)
             if any(f in flags for f in cxxpre11_flags):
                 raise ValueError('cannot build cmake pre-c++11 standard')
             elif not any(f in flags for f in cxx11plus_flags):


### PR DESCRIPTION
 I noticed that there is mistake of flag's name on following pullreq. So, I fixed cxx98flag's name, and succeeded installing cmake.

Referenced: cmake: Move cxx11 flags for fujitsu into the flag_handler method #12056