### PR TITLE
rapidjson: Don't add -march=native on ARM and gcc 5.x or before.

### DIFF
--- a/var/spack/repos/builtin/packages/rapidjson/arm.patch
+++ b/var/spack/repos/builtin/packages/rapidjson/arm.patch
@@ -1,0 +1,15 @@
+diff -ru spack-src/CMakeLists.txt spack-src.new/CMakeLists.txt
+--- spack-src/CMakeLists.txt	2019-07-24 15:44:41.200676445 +0900
++++ spack-src.new/CMakeLists.txt	2019-07-24 15:43:52.140673234 +0900
+@@ -50,7 +50,10 @@
+ endif(CCACHE_FOUND)
+ 
+ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -Wall -Wextra")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
++    if(NOT (CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64") AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "6.0")
++        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
++    endif()
+     if (RAPIDJSON_BUILD_CXX11)
+         if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.7.0")
+             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")

--- a/var/spack/repos/builtin/packages/rapidjson/package.py
+++ b/var/spack/repos/builtin/packages/rapidjson/package.py
@@ -20,3 +20,5 @@ class Rapidjson(CMakePackage):
     # released versions compile with -Werror and fail with gcc-7
     # branch-fall-through warnings
     patch('0001-turn-off-Werror.patch')
+
+    patch('arm.patch', when='@1.1.0 target=aarch64 %gcc@:5.9')


### PR DESCRIPTION
rapidjson add -march=native for gcc.
But gcc on aarch64 is supported -march=native on gcc version 6:
https://www.gnu.org/software/gcc/gcc-6/changes.html#aarch64

This patch avoid -march=native on aarch64 and gcc 5 or before.