### PR TITLE
Make the concretizer respect compiler preferences

### DIFF
--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -601,8 +601,9 @@ A compiler version specifier looks exactly like a package version
 specifier.  Version specifiers will associate with the nearest package
 name or compiler specifier to their left in the spec.
 
-If the compiler spec is omitted, Spack will choose a default compiler
-based on site policies.
+A compiler specifier will apply to the package it has been specified
+for (the nearest one to the left) and all of its children. If the compiler
+spec is omitted, Spack will choose a default compiler based on site policies.
 
 
 .. _basic-variants:

--- a/lib/spack/docs/tutorial_basics.rst
+++ b/lib/spack/docs/tutorial_basics.rst
@@ -306,7 +306,7 @@ top-level package, we can also specify about a dependency using ``^``.
 
 .. code-block:: console
 
-  $ spack install tcl ^zlib @1.2.8 %clang
+  $ spack install tcl %clang ^zlib @1.2.8
   ==> Installing zlib
   ==> Searching for binary cache of zlib
   ==> Finding buildcaches in /mirror/build_cache

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -164,6 +164,11 @@ class PackagePrefs(object):
         cls._spec_cache = {}
 
     @classmethod
+    def has_preferred_compiler(cls, pkgname):
+        """Whether specific package has a preferred compiler."""
+        return bool(cls.order_for_package(pkgname, 'compiler', None, False))
+
+    @classmethod
     def has_preferred_providers(cls, pkgname, vpkg):
         """Whether specific package has a preferred vpkg providers."""
         return bool(cls.order_for_package(pkgname, 'providers', vpkg, False))

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -88,13 +88,73 @@ class TestConcretizePreferences(object):
     def test_preferred_compilers(self, mutable_mock_packages):
         """Test preferred compilers are applied correctly
         """
+        clang_spec = spack.spec.CompilerSpec('clang@3.3')
+        gcc_spec = spack.spec.CompilerSpec('gcc@4.5.0')
+
         update_packages('mpileaks', 'compiler', ['clang@3.3'])
         spec = concretize('mpileaks')
-        assert spec.compiler == spack.spec.CompilerSpec('clang@3.3')
+        assert spec.compiler == clang_spec
+        assert spec['callpath'].compiler == clang_spec
+        assert spec['mpi'].compiler == clang_spec
+
+        spec = concretize('mpileaks%gcc@4.5.0')
+        assert spec.compiler == gcc_spec
+        assert spec['callpath'].compiler == gcc_spec
+        assert spec['mpi'].compiler == gcc_spec
 
         update_packages('mpileaks', 'compiler', ['gcc@4.5.0'])
         spec = concretize('mpileaks')
-        assert spec.compiler == spack.spec.CompilerSpec('gcc@4.5.0')
+        assert spec.compiler == gcc_spec
+        assert spec['callpath'].compiler == gcc_spec
+        assert spec['mpi'].compiler == gcc_spec
+
+        spec = concretize('mpileaks%clang@3.3')
+        assert spec.compiler == clang_spec
+        assert spec['callpath'].compiler == clang_spec
+        assert spec['mpi'].compiler == clang_spec
+
+        update_packages('all', 'compiler', ['clang@3.3'])
+        spec = concretize('mpileaks')
+        assert spec.compiler == clang_spec
+        assert spec['callpath'].compiler == clang_spec
+        assert spec['mpi'].compiler == clang_spec
+
+        spec = concretize('mpileaks%gcc@4.5.0')
+        assert spec.compiler == gcc_spec
+        assert spec['callpath'].compiler == gcc_spec
+        assert spec['mpi'].compiler == gcc_spec
+
+        update_packages('all', 'compiler', ['gcc@4.5.0'])
+        spec = concretize('mpileaks')
+        assert spec.compiler == gcc_spec
+        assert spec['callpath'].compiler == gcc_spec
+        assert spec['mpi'].compiler == gcc_spec
+
+        spec = concretize('mpileaks%clang@3.3')
+        assert spec.compiler == clang_spec
+        assert spec['callpath'].compiler == clang_spec
+        assert spec['mpi'].compiler == clang_spec
+
+        update_packages('callpath', 'compiler', ['clang@3.3'])
+        spec = concretize('mpileaks')
+        assert spec.compiler == gcc_spec
+        assert spec['callpath'].compiler == clang_spec
+        assert spec['mpi'].compiler == gcc_spec
+
+        spec = concretize('mpileaks%gcc@4.5.0')
+        assert spec.compiler == gcc_spec
+        assert spec['callpath'].compiler == gcc_spec
+        assert spec['mpi'].compiler == gcc_spec
+
+        spec = concretize('mpileaks ^callpath%gcc@4.5.0')
+        assert spec.compiler == gcc_spec
+        assert spec['callpath'].compiler == gcc_spec
+        assert spec['mpi'].compiler == gcc_spec
+
+        spec = concretize('mpileaks ^mpich%gcc@4.5.0')
+        assert spec.compiler == gcc_spec
+        assert spec['callpath'].compiler == clang_spec
+        assert spec['mpi'].compiler == gcc_spec
 
     def test_preferred_versions(self):
         """Test preferred package versions are applied correctly


### PR DESCRIPTION
While it is possible to specify compiler preferences for all packages, those for single packages are currently ignored.

For instance, a `packages.yaml` such as this:
```yaml
packages:
    all:
        compiler: [clang]
    ncurses:
        compiler: [gcc]
```
results in the following output for `spack spec readline`:
```
readline@7.0%clang@9.1.1 arch=linux-fedora30-x86_64
    ^ncurses@6.1%clang@9.1.1~symlinks~termlib arch=linux-fedora30-x86_64
        ^pkgconf@1.6.1%clang@9.1.1 arch=linux-fedora30-x86_64
```

Simply querying the package's compiler preferences is not enough due to the concretizer's current behavior. If a compiler preference is specified explicitly anywhere in the DAG, it is applied everywhere, as can be seen for `spack spec readline ^pkgconf%gcc`:
```
readline@7.0%gcc@9.1.1 arch=linux-fedora30-x86_64
    ^ncurses@6.1%gcc@9.1.1~symlinks~termlib arch=linux-fedora30-x86_64
        ^pkgconf@1.6.1%gcc@9.1.1 arch=linux-fedora30-x86_64
```

This is in contrast to the concretizer's behavior in other cases such as when dealing with compiler flags, which are only applied to children. For instance, `spack spec readline ^pkgconf cflags='-g'` produces:
```
readline@7.0%clang@9.1.1 arch=linux-fedora30-x86_64
    ^ncurses@6.1%clang@9.1.1~symlinks~termlib arch=linux-fedora30-x86_64
        ^pkgconf@1.6.1%clang@9.1.1 cflags="-g"  arch=linux-fedora30-x86_64
```

Therefore, this PR contains two changes to the concretizer:
1. Make compiler preferences only apply to children. On the one hand, this makes the concretizer's behavior more consistent. On the other hand, it makes sure that compiler preferences specified in `packages.yaml` are only applied to the specified package. Otherwise, it would get propagated up to its parents due to the concretizer's bottom-up approach.
2. Apply compiler preferences specified in `packages.yaml` to individual packages.

As can be seen with `spack spec readline`, the compiler preference from `packages.yaml` is applied correctly:
```
readline@7.0%clang@9.1.1 arch=linux-fedora30-x86_64
    ^ncurses@6.1%gcc@9.1.1~symlinks~termlib arch=linux-fedora30-x86_64
        ^pkgconf@1.6.1%clang@9.1.1 arch=linux-fedora30-x86_64
```

Moreover, `spack spec readline ^pkgconf%gcc` shows that compiler preferences only apply to children:
```
readline@7.0%clang@9.1.1 arch=linux-fedora30-x86_64
    ^ncurses@6.1%gcc@9.1.1~symlinks~termlib arch=linux-fedora30-x86_64
        ^pkgconf@1.6.1%gcc@9.1.1 arch=linux-fedora30-x86_64
```

It is also still possible to override compiler preferences in `packages.yaml` explicitly. For instance, `spack spec readline%clang`:
```
readline@7.0%clang@9.1.1 arch=linux-fedora30-x86_64
    ^ncurses@6.1%clang@9.1.1~symlinks~termlib arch=linux-fedora30-x86_64
        ^pkgconf@1.6.1%clang@9.1.1 arch=linux-fedora30-x86_64
```

Fixes: #1371