### PR TITLE
googletest: Fix reversed +pthreads option

### DIFF
--- a/var/spack/repos/builtin/packages/googletest/package.py
+++ b/var/spack/repos/builtin/packages/googletest/package.py
@@ -38,7 +38,7 @@ class Googletest(CMakePackage):
             options = []
 
         options.append('-Dgtest_disable_pthreads={0}'.format(
-            'ON' if '+pthreads' in spec else 'OFF'))
+            'OFF' if '+pthreads' in spec else 'ON'))
         options.append('-DBUILD_SHARED_LIBS={0}'.format(
             'ON' if '+shared' in spec else 'OFF'))
         return options


### PR DESCRIPTION
If +pthreads is specified, googletest actually gets build without
pthreads support and vice versa.

If pthreads is not available, googletest should detect it itself which
is why "enabling" pthreads in case of ~pthreads does not seem to cause
any error.