### PR TITLE
cmake: Add a patch to revert a findmpi regression

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/cmake-revert-findmpi-link-flag-list.patch
+++ b/var/spack/repos/builtin/packages/cmake/cmake-revert-findmpi-link-flag-list.patch
@@ -1,0 +1,29 @@
+From 89fc3b1fd22f97f9380990b521dd79f306ac18fd Mon Sep 17 00:00:00 2001
+From: Chuck Atkins <chuck.atkins@kitware.com>
+Date: Thu, 25 Jul 2019 09:37:20 -0400
+Subject: [PATCH] Revert "FindMPI: Store imported target link flags as a list
+ instead of a string"
+
+This reverts commit f7eaa342de316707d99e6ae29c693a480861560d.
+---
+ Modules/FindMPI.cmake | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/Modules/FindMPI.cmake b/Modules/FindMPI.cmake
+index a80f799..fe09764 100644
+--- a/Modules/FindMPI.cmake
++++ b/Modules/FindMPI.cmake
+@@ -1144,9 +1144,7 @@ macro(_MPI_create_imported_target LANG)
+ 
+   set_property(TARGET MPI::MPI_${LANG} PROPERTY INTERFACE_LINK_LIBRARIES "")
+   if(MPI_${LANG}_LINK_FLAGS)
+-    separate_arguments(_MPI_${LANG}_LINK_FLAGS NATIVE_COMMAND "${MPI_${LANG}_LINK_FLAGS}")
+-    set_property(TARGET MPI::MPI_${LANG} APPEND PROPERTY INTERFACE_LINK_LIBRARIES "${_MPI_${LANG}_LINK_FLAGS}")
+-    unset(_MPI_${LANG}_LINK_FLAGS)
++    set_property(TARGET MPI::MPI_${LANG} APPEND PROPERTY INTERFACE_LINK_LIBRARIES "${MPI_${LANG}_LINK_FLAGS}")
+   endif()
+   # If the compiler links MPI implicitly, no libraries will be found as they're contained within
+   # CMAKE_<LANG>_IMPLICIT_LINK_LIBRARIES already.
+-- 
+2.5.5
+

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -59,8 +59,8 @@ class Cmake(Package):
     version('3.0.2',    'db4c687a31444a929d2fdc36c4dfb95f')
     version('2.8.10.2', '097278785da7182ec0aea8769d06860c')
 
-    # Revert the change that introduced a regression when parsing mpi link flags
-    # See https://gitlab.kitware.com/cmake/cmake/issues/19516
+    # Revert the change that introduced a regression when parsing mpi link
+    # flags, see: https://gitlab.kitware.com/cmake/cmake/issues/19516
     patch('cmake-revert-findmpi-link-flag-list.patch', when='@3.15.0')
 
     # Fix linker error when using external libs on darwin.

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -59,6 +59,10 @@ class Cmake(Package):
     version('3.0.2',    'db4c687a31444a929d2fdc36c4dfb95f')
     version('2.8.10.2', '097278785da7182ec0aea8769d06860c')
 
+    # Revert the change that introduced a regression when parsing mpi link flags
+    # See https://gitlab.kitware.com/cmake/cmake/issues/19516
+    patch('cmake-revert-findmpi-link-flag-list.patch', when='@3.15.0')
+
     # Fix linker error when using external libs on darwin.
     # See https://gitlab.kitware.com/cmake/cmake/merge_requests/2873
     patch('cmake-macos-add-coreservices.patch', when='@3.11.0:3.13.3')


### PR DESCRIPTION
See https://gitlab.kitware.com/cmake/cmake/issues/19516
Replaces #12121 
Fixes #12120 