### PR TITLE
intel: Add mpicc wrapper bindir to dependent env

### DIFF
--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -935,6 +935,11 @@ class IntelPackage(PackageBase):
                 'MPIF90': compiler_wrapper_commands['MPIF90'],
             })
 
+        # Ensure that the directory containing the compiler wrappers is in the
+        # PATH. Spack packages add `prefix.bin` to their dependents' paths,
+        # but because of the intel directory hierarchy that is insufficient.
+        spack_env.prepend_path('PATH', os.path.dirname(wrapper_vars['MPICC']))
+
         for key, value in wrapper_vars.items():
             spack_env.set(key, value)
 


### PR DESCRIPTION
Packages that require the MPI compiler wrappers to be in the PATH previously failed with `intel-mpi` due to Intel's arcane directory structure.

The `intel` build system now fixes this by explicitly adding the `bin` path for the MPI compiler wrappers to its MPI-dependents environment.