### PR TITLE
range-v3: Resolve installation issues with 0.5.0

### DIFF
--- a/var/spack/repos/builtin/packages/range-v3/fix-is_trivial.patch
+++ b/var/spack/repos/builtin/packages/range-v3/fix-is_trivial.patch
@@ -1,0 +1,96 @@
+diff --git a/include/meta/meta_fwd.hpp b/include/meta/meta_fwd.hpp
+index edfb9068..ac041999 100644
+--- a/include/meta/meta_fwd.hpp
++++ b/include/meta/meta_fwd.hpp
+@@ -152,6 +152,13 @@
+ #define META_TYPE_CONSTRAINT(...) typename
+ #endif
+ 
++#if (defined(__cpp_lib_type_trait_variable_templates) && \
++     __cpp_lib_type_trait_variable_templates > 0)
++#define META_CXX_TRAIT_VARIABLE_TEMPLATES 1
++#else
++#define META_CXX_TRAIT_VARIABLE_TEMPLATES 0
++#endif
++
+ namespace meta
+ {
+ #if META_CXX_INTEGER_SEQUENCE
+@@ -208,8 +215,10 @@ namespace meta
+         META_CONCEPT_BARRIER(__is_same(T, U));
+ #elif defined(__GNUC__) && __GNUC__ >= 6
+         META_CONCEPT_BARRIER(__is_same_as(T, U));
+-#else
++#elif defined(META_CXX_TRAIT_VARIABLE_TEMPLATES)
+         META_CONCEPT_BARRIER(std::is_same_v<T, U>);
++#else
++        META_CONCEPT_BARRIER(std::is_same<T, U>::value);
+ #endif
+ 
+     template <template <typename...> class C, typename... Ts>
+@@ -248,7 +257,11 @@ namespace meta
+         typename T::type::value_type;
+     }
+     && Same<typename T::value_type, typename T::type::value_type>
++#if META_CXX_TRAIT_VARIABLE_TEMPLATES
+     && std::is_integral_v<typename T::value_type>
++#else
++    && std::is_integral<typename T::value_type>::value
++#endif
+     && requires
+     {
+         // { T::value } -> Same<const typename T::value_type&>;
+diff --git a/include/range/v3/range_fwd.hpp b/include/range/v3/range_fwd.hpp
+index 0378a0bd..2fabf26c 100644
+--- a/include/range/v3/range_fwd.hpp
++++ b/include/range/v3/range_fwd.hpp
+@@ -247,6 +247,16 @@ namespace ranges
+             struct priority_tag<0>
+             {};
+ 
++        template<typename T>
++        using is_trivial = meta::bool_<
++#if META_CXX_TRAIT_VARIABLE_TEMPLATES
++            std::is_trivially_copyable_v<T> &&
++            std::is_trivially_default_constructible_v<T>>;
++#else
++            std::is_trivially_copyable<T>::value &&
++            std::is_trivially_default_constructible<T>::value>;
++#endif
++
+         #if defined(__clang__) && !defined(_LIBCPP_VERSION)
+             template<typename T, typename... Args>
+             using is_trivially_constructible =
+@@ -272,19 +282,6 @@ namespace ranges
+             template<typename T>
+             using is_trivially_copyable =
+                 meta::bool_<__is_trivially_copyable(T)>;
+-        #elif defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 5
+-            template<typename T>
+-            using is_trivially_default_constructible = std::is_trivial<T>;
+-            template<typename T>
+-            using is_trivially_copy_constructible = std::is_trivial<T>;
+-            template<typename T>
+-            using is_trivially_move_constructible = std::is_trivial<T>;
+-            template<typename T>
+-            using is_trivially_copy_assignable = std::is_trivial<T>;
+-            template<typename T>
+-            using is_trivially_move_assignable = std::is_trivial<T>;
+-            template<typename T>
+-            using is_trivially_copyable = std::is_trivial<T>;
+         #else
+             template<typename T>
+             using is_trivially_default_constructible =
+diff --git a/include/range/v3/utility/box.hpp b/include/range/v3/utility/box.hpp
+index 5e8b90dd..33d674df 100644
+--- a/include/range/v3/utility/box.hpp
++++ b/include/range/v3/utility/box.hpp
+@@ -128,7 +128,7 @@ namespace ranges
+             // MSVC pukes passing non-constant-expression objects to constexpr
+             // functions, so do not coalesce.
+             template<typename T, typename = meta::if_<
+-                meta::strict_and<std::is_empty<T>, std::is_trivial<T>>>>
++                meta::strict_and<std::is_empty<T>, detail::is_trivial<T>>>>
+             constexpr box_compress box_compression_(int)
+             {
+                 return box_compress::coalesce;

--- a/var/spack/repos/builtin/packages/range-v3/gcc-compile-opt-check.patch
+++ b/var/spack/repos/builtin/packages/range-v3/gcc-compile-opt-check.patch
@@ -1,0 +1,43 @@
+From 0c20dbf05973368339aeae0c4e106560e2dcf76b Mon Sep 17 00:00:00 2001
+From: Nicholas Guriev <guriev-ns@ya.ru>
+Date: Sat, 27 Apr 2019 09:10:38 +0300
+Subject: [PATCH] Improve check of -Wno-* compiler flags
+
+The GCC documentation says that unrecognized warning options in
+the -Wno-* form do not cause errors unless other diagnostics are issued.
+And thus unsupported flags may be appended. This results in a failed
+build when there are some false positive warnings. So to check warning
+options, we strip "no-" prefix.
+
+The ranges_append_flag macro is no longer variadic and it takes only the
+first two arguments. Use quotes if you need flags separated by spaces.
+Example: ranges_append_flag(TEST "-X val").
+---
+ cmake/ranges_flags.cmake | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/cmake/ranges_flags.cmake b/cmake/ranges_flags.cmake
+index 00e23179..714968e9 100644
+--- a/cmake/ranges_flags.cmake
++++ b/cmake/ranges_flags.cmake
+@@ -8,10 +8,14 @@
+ 
+ # Compilation flags
+ include(CheckCXXCompilerFlag)
+-macro(ranges_append_flag testname flag ${ARGN})
+-    check_cxx_compiler_flag("${flag} ${ARGN}" ${testname})
++macro(ranges_append_flag testname flag)
++    # As -Wno-* flags do not lead to build failure when there are no other
++    # diagnostics, we check positive option to determine their applicability.
++    # Of course, we set the original flag that is requested in the parameters.
++    string(REGEX REPLACE "^-Wno-" "-W" alt ${flag})
++    check_cxx_compiler_flag(${alt} ${testname})
+     if (${testname})
+-        add_compile_options(${flag} ${ARGN})
++        add_compile_options(${flag})
+     endif()
+ endmacro()
+ 
+-- 
+2.20.1
+

--- a/var/spack/repos/builtin/packages/range-v3/package.py
+++ b/var/spack/repos/builtin/packages/range-v3/package.py
@@ -5,6 +5,9 @@
 
 from spack import *
 
+import os
+import shutil
+
 
 class RangeV3(CMakePackage):
     """Range v3 forms the basis of a proposal to add range support to the
@@ -16,6 +19,7 @@ class RangeV3(CMakePackage):
     homepage = "https://github.com/ericniebler/range-v3"
     url      = "https://github.com/ericniebler/range-v3/archive/0.3.6.tar.gz"
     git      = "https://github.com/ericniebler/range-v3.git"
+    maintainers = ['chissg']
 
     version('develop', branch='master')
     version('0.5.0', sha256='32e30b3be042246030f31d40394115b751431d9d2b4e0f6d58834b2fd5594280')
@@ -41,6 +45,18 @@ class RangeV3(CMakePackage):
             multi=False,
             description='Use the specified C++ standard when building.')
 
+    variant('doc',
+            default=True,
+            description='Build and install documentation.')
+
+    variant('examples',
+            default=False,
+            description='Build and install examples.')
+
+    variant('perf',
+            default=False,
+            description='Build performance benchmarks')
+
     # Known compiler conflicts. Your favorite compiler may also conflict
     # depending on its C++ standard support.
     conflicts('%clang@:3.6.1')
@@ -49,10 +65,113 @@ class RangeV3(CMakePackage):
     conflicts('%gcc@:5.99.99', when='cxxstd=17')
 
     depends_on('cmake@3.6:', type='build')
-    depends_on('doxygen+graphviz', type='build')
+    depends_on('doxygen+graphviz', type='build', when='+doc')
+    depends_on('boost@1.59.0: cxxstd=14', type='build',
+               when='+examples cxxstd=14')
+    depends_on('boost@1.59.0: cxxstd=17', type='build',
+               when='+examples cxxstd=17')
+
+    # Fix reported upstream issue
+    # https://github.com/ericniebler/range-v3/issues/1196 per PR
+    # https://github.com/ericniebler/range-v3/pull/1202.
+    patch('fix-is_trivial.patch', level=1, when='@0.5.0')
+
+    # Some -Wno-... options unknown to GCC were being checked as OK to
+    # use but causing problems during the build. Patch from
+    # https://github.com/ericniebler/range-v3/commit/0c20dbf05973368339aeae0c4e106560e2dcf76b#diff-acb9169b4ccbac494ced5140d285a015
+    patch('gcc-compile-opt-check.patch', level=1, when='@0.5.0%gcc')
+
+    def _remove_cmake_subdir(self, subdir):
+        filter_file(r'^(\s*add_subdirectory\s*\(\s*{0}\s*\))'.format(subdir),
+                    r'#\1',
+                    'CMakeLists.txt')
+
+    # Deal with variant choices for versions that don't have applicable
+    # CMake switches.
+    def patch(self):
+        spec = self.spec
+        if spec.satisfies('@:0.3.0'):
+            if not self.run_tests:
+                self._remove_cmake_subdir('test')
+            if '+examples' not in spec:
+                self._remove_cmake_subdir('example')
+            if '+perf' not in spec:
+                self._remove_cmake_subdir('perf')
+        if spec.satisfies('@:0.3.6~doc'):
+            self._remove_cmake_subdir('doc')
 
     def cmake_args(self):
+        spec = self.spec
+        cxxstd = self.spec.variants['cxxstd'].value
+
+        on_or_off = lambda opt: 'ON' if '+' + opt in spec else 'OFF'
+
         args = [
-            '-DRANGES_CXX_STD={0}'.format(self.spec.variants['cxxstd'].value)
+            '-DRANGES_CXX_STD={0}'.format(cxxstd)
         ]
+
+        if spec.satisfies('@0.3.7:'):
+            args.append('-DRANGE_V3_DOCS=' + on_or_off('doc'))
+
+        if spec.satisfies('@0.3.6:'):
+            args.append('-DRANGE_V3_TESTS=' +
+                        ('ON' if self.run_tests else 'OFF'))
+            args.append('-DRANGE_V3_EXAMPLES=' + on_or_off('examples'))
+            args.append('-DRANGE_V3_PERF=' + on_or_off('perf'))
+        elif spec.satisfies('@0.3.1:'):
+            args.append('-DRANGE_V3_NO_TESTING=' +
+                        ('OFF' if self.run_tests else 'ON'))
+            args.append('-DRANGE_V3_NO_EXAMPLE=' +
+                        ('OFF' if '+examples' in spec else 'ON'))
+            args.append('-DRANGE_V3_NO_PERF=' +
+                        ('OFF' if '+perf' in spec else 'ON'))
+        else:
+            # Older versions don't have the right switches. See patch() above.
+            pass
+
+        if not self.run_tests:
+            args.append('-DRANGE_V3_NO_HEADER_CHECK=ON')
+
+        if '+examples' in spec:
+            args.append('-DRANGES_BUILD_CALENDAR_EXAMPLE=' +
+                        ('ON' if cxxstd in ['14', '17']
+                         else 'OFF'))
+
         return args
+
+    @property
+    def build_targets(self):
+        spec = self.spec
+        targets = []
+        if '+doc' in spec:
+            targets.extend(['all', 'doc'])
+        return targets
+
+    def _copy_and_clean_dirs(self, subdir):
+        install_tree(subdir, os.path.join(self.prefix, subdir))
+        with working_dir(self.build_directory):
+            install_tree(subdir, os.path.join(self.prefix, subdir))
+        with working_dir(os.path.join(self.prefix, subdir)):
+            shutil.rmtree('CMakeFiles')
+            for f in ('cmake_install.cmake', 'CTestTestfile.cmake',
+                      'Makefile', 'CMakeLists.txt'):
+                if os.path.exists(f):
+                    os.remove(f)
+
+    @run_after('install')
+    def install_extra(self):
+        spec = self.spec
+
+        # Install docs.
+        if '+doc' in spec:
+            with working_dir(self.build_directory):
+                install_tree(os.path.join('doc', 'html'),
+                             os.path.join(self.prefix, 'doc', 'html'))
+
+        # Install examples.
+        if '+examples' in spec:
+            self._copy_and_clean_dirs('example')
+
+        # Install performance benchmarks.
+        if '+perf' in spec:
+            self._copy_and_clean_dirs('perf')


### PR DESCRIPTION
Resolves #11481.

* Incorporate as a patch upstream commit https://github.com/ericniebler/range-v3/commit/0c20dbf05973368339aeae0c4e106560e2dcf76b#diff-acb9169b4ccbac494ced5140d285a015 resolving problems with `-Wno-...` options not being understood by GCC.
* Incorporate as a patch upstream PR https://github.com/ericniebler/range-v3/pull/1202 fixing upstream issue https://github.com/ericniebler/range-v3/issues/1196.
* Compile tests only if we actually want to run them.
* Optionally compile documentation with a `+doc` variant.
* Add `+examples` and `+perf` variants to avoid unnecessary compilation of components usually not required for install.
* Add conditional build-only dependency on Boost when appropriate.
* Install docs, examples and performance tests if built (not part of upstream build instructions).
* Add @chissg as a maintainer.
