### PR TITLE
Use Version object for version comparison

### DIFF
--- a/var/spack/repos/builtin/packages/py-ipython/package.py
+++ b/var/spack/repos/builtin/packages/py-ipython/package.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-import sys
-import platform
 
 
 class PyIpython(PythonPackage):
@@ -32,9 +30,6 @@ class PyIpython(PythonPackage):
     depends_on('py-decorator',                  type=('build', 'run'))
     depends_on('py-pexpect',                    type=('build', 'run'))
     depends_on('py-backcall',                   type=('build', 'run'), when="^python@3.3:")
-
-    depends_on('py-appnope', type=('build', 'run'),
-                    when=sys.platform == 'darwin' and
-                            int(platform.mac_ver()[0].split('.')[1]) >= 9)
+    depends_on('py-appnope', type=('build', 'run'), when='platform=darwin')
 
     conflicts('^python@2.7:2.8', when='@7.0.0:')

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -84,7 +84,8 @@ class PyNumpy(PythonPackage):
         def write_library_dirs(f, dirs):
             f.write('library_dirs=%s\n' % dirs)
             if not ((platform.system() == "Darwin") and
-                    (platform.mac_ver()[0] == '10.12')):
+                    (Version(platform.mac_ver()[0]).up_to(2) == Version(
+                        '10.12'))):
                 f.write('rpath=%s\n' % dirs)
 
         # for build notes see http://www.scipy.org/scipylib/building/linux.html

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -320,8 +320,8 @@ class Qt(Package):
         if '@4' in self.spec and sys.platform == 'darwin':
             config_args.append('-cocoa')
 
-            mac_ver = tuple(platform.mac_ver()[0].split('.')[:2])
-            sdkname = 'macosx%s' % '.'.join(mac_ver)
+            mac_ver = Version(platform.mac_ver()[0])
+            sdkname = 'macosx{0}'.format(mac_ver.up_to(2))
             sdkpath = which('xcrun')('--show-sdk-path',
                                      '--sdk', sdkname,
                                      output=str)
@@ -338,7 +338,7 @@ class Qt(Package):
                 use_clang_platform = True
             if use_clang_platform:
                 config_args.append('-platform')
-                if mac_ver >= (10, 9):
+                if mac_ver >= Version('10.9'):
                     config_args.append('unsupported/macx-clang-libc++')
                 else:
                     config_args.append('unsupported/macx-clang')


### PR DESCRIPTION
Previously, we were doing string to int comparison like `(1, 3) > ('1', '2')`. This is incredibly buggy:
```python
$ python2
>>> '10' > 9
True
>>> 10 > '9'
False
>>> '9' < 10
False
>>> 9 < '10'
True
```
Also, this does not work at all in Python 3. You get the following error message when trying to install `qt@4 platform=darwin`:
```
==> Error: TypeError: '>=' not supported between instances of 'str' and 'int'
```
This PR makes use of the `Version` class for version comparison.