### PR TITLE
Fix py-matplotlib build with Intel compiler

### DIFF
--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -131,11 +131,6 @@ class PyMatplotlib(PythonPackage):
     patch('freetype-include-path.patch', when='@2.2.2:2.9.9')
 
     @run_before('build')
-    def set_cc(self):
-        if self.spec.satisfies('%intel'):
-            env['CC'] = spack_cxx
-
-    @run_before('build')
     def set_backend(self):
         """Set build options with regards to backend GUI libraries."""
 


### PR DESCRIPTION
Not sure what happened between #5321 and now but the CC=CXX fix now
prevents py-matplotlib from building with the Intel compiler. I verified
with versions of py-matplotlib from 2.0.2 to 3.0.2 and intel-17.0.4 and
19.0.4 that py-matplotlib successfully builds with the Intel compiler
without that code.