### PR TITLE
gromacs: add options and variant

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -59,6 +59,11 @@ class Gromacs(CMakePackage):
                     'IBM_QPX', 'Sparc64_HPC_ACE', 'IBM_VMX', 'IBM_VSX',
                     'ARM_NEON', 'ARM_NEON_ASIMD'))
     variant('rdtscp', default=True, description='Enable RDTSCP instruction usage')
+    variant('mdrun_only', default=False,
+            description='Enables the build of a cut-down version' +
+                         'of libgromacs and/or the mdrun program')
+    variant('openmp', default=True, description='Enables OpenMP at configure time')
+    variant('double_precision', default=False, description='Enables a double-precision configuration')
 
     depends_on('mpi', when='+mpi')
     depends_on('plumed+mpi', when='+plumed+mpi')
@@ -78,6 +83,8 @@ class Gromacs(CMakePackage):
 
         if '+mpi' in self.spec:
             options.append('-DGMX_MPI:BOOL=ON')
+            options.append('-DCMAKE_C_COMPILER=%s' % self.spec['mpi'].mpicc)
+            options.append('-DCMAKE_CXX_COMPILER=%s' % self.spec['mpi'].mpicxx)
 
         if '+double' in self.spec:
             options.append('-DGMX_DOUBLE:BOOL=ON')
@@ -104,5 +111,14 @@ class Gromacs(CMakePackage):
             options.append('-DGMX_USE_RDTSCP:BOOL=OFF')
         else:
             options.append('-DGMX_USE_RDTSCP:BOOL=ON')
+
+        if '+mdrun_only' in self.spec:
+            options.append('-DGMX_BUILD_MDRUN_ONLY:BOOL=ON')
+
+        if '~openmp' in self.spec:
+            options.append('-DGMX_OPENMP:BOOL=OFF')
+
+        if '+double_precision' in self.spec:
+            options.append('-DGMX_RELAXED_DOUBLE_PRECISION:BOOL=ON')
 
         return options


### PR DESCRIPTION
The configure of the `gromacs` package was failed because the following error occurred:
```
 CMake Error at cmake/gmxManageMPI.cmake:169 (message):
   MPI support requested, but no MPI compiler found.  Either set the
   C-compiler (CMAKE_C_COMPILER) to the MPI compiler (often called m
 picc), or
   set the variables reported missing for MPI_C above.
```
The above cause is spack package of `gromacs` activate MPI support by default.
```
variant('mpi', default=True, description='Activate MPI support')
```
But, according to the following URL, MPI compiler is not active by default in `gromacs`:
http://manual.gromacs.org/documentation/current/install-guide/index.html#typical-installation

Therefore, I append MPI compiler to options in case MPI support is active.
```
if '+mpi' in self.spec:
    options.append('-DGMX_MPI:BOOL=ON')
    options.append('-DCMAKE_C_COMPILER=%s' % self.spec['mpi'].mpicc)
    options.append('-DCMAKE_CXX_COMPILER=%s' % self.spec['mpi'].mpicxx)
```

In addition, I add `variant` recommended by Fujitsu PRIMEHPC,
see: http://manual.gromacs.org/documentation/5.1.4/install-guide/index.html#fujitsu-primehpc
- `mdrun_only` enables the build of a cut-down version of libgromacs and/or the mdrun program.
- `openmp`  is default on, but Fujitsu PRIMEHPC need it off.
- `double_precison` enables a double-precision configuration to compute some quantities to single-precision accuracy.