### PR TITLE
libxc: Make configure recognize Fujitsu compiler

### DIFF
--- a/var/spack/repos/builtin/packages/libxc/configure_add_fj.patch
+++ b/var/spack/repos/builtin/packages/libxc/configure_add_fj.patch
@@ -1,0 +1,21 @@
+--- libxc-4.3.2/configure	2019-02-08 17:40:50.000000000 +0900
++++ libxc-4.3.2/configure_b	2019-07-25 14:48:51.825394300 +0900
+@@ -14405,6 +14405,18 @@
+ 	lt_prog_compiler_pic_FC='-qpic'
+ 	lt_prog_compiler_static_FC='-qstaticlink'
+ 	;;
++      fcc* | FCC* )
++        # Fujitsu C/C++ compiler
++        lt_prog_compiler_wl_FC='-Wl,'
++        lt_prog_compiler_pic_FC='-KPIC'
++        lt_prog_compiler_static_FC='-Bstatic'
++        ;;
++      frt* )
++        # Fujitsu Fortran compiler
++        lt_prog_compiler_wl_FC='-Wl,'
++        lt_prog_compiler_pic_FC='-KPIC'
++        lt_prog_compiler_static_FC='-Kstatic_fjlib'
++        ;;
+       *)
+ 	case `$CC -V 2>&1 | sed 5q` in
+ 	*Sun\ Ceres\ Fortran* | *Sun*Fortran*\ [1-7].* | *Sun*Fortran*\ 8.[0-3]*)

--- a/var/spack/repos/builtin/packages/libxc/package.py
+++ b/var/spack/repos/builtin/packages/libxc/package.py
@@ -19,6 +19,8 @@ class Libxc(AutotoolsPackage):
     version('2.2.2', sha256='6ca1d0bb5fdc341d59960707bc67f23ad54de8a6018e19e02eee2b16ea7cc642')
     version('2.2.1', sha256='ade61c1fa4ed238edd56408fd8ee6c2e305a3d5753e160017e2a71817c98fd00')
 
+    patch('configure_add_fj.patch')
+
     def url_for_version(self, version):
         if version < Version('3.0.0'):
             return ("http://www.tddft.org/programs/octopus/"


### PR DESCRIPTION
- Fujitsu compiler doesn't recognized by configure, so linker flags were not set.
So, I added a branch for setting of the Fujitsu compiler to `configure`.