### PR TITLE
Small fixes for font-util package

### DIFF
--- a/var/spack/repos/builtin/packages/font-util/package.py
+++ b/var/spack/repos/builtin/packages/font-util/package.py
@@ -23,9 +23,6 @@ class FontUtil(AutotoolsPackage):
     depends_on('mkfontscale', type='build')
     depends_on('mkfontdir', type='build')
 
-    depends_on('autoconf', type='build')
-    depends_on('automake', type='build')
-
     font_baseurl = 'https://www.x.org/archive/individual/font/'
     fonts = []
     # name, version, md5

--- a/var/spack/repos/builtin/packages/font-util/package.py
+++ b/var/spack/repos/builtin/packages/font-util/package.py
@@ -101,7 +101,7 @@ class FontUtil(AutotoolsPackage):
 
         for font in fonts:
             fontroot = find(font, '*', recursive=False)
-            with working_dir(join_path(font, fontroot[0])):
+            with working_dir(fontroot[0]):
                 autoreconf(*autoconf_args)
                 configure = Executable("./configure")
                 configure('--prefix={0}'.format(self.prefix))


### PR DESCRIPTION
Hi,

Just some small fixes for the font-util package:
1. Remove duplicated dependencies: cosmetic change.
2. Fix path handling for font resources: avoid doing nonsensical `join_path` like `join_path('encodings', '/tmp/.../spack-stage/spack-stage-1g54sz/spack-src/encodings/encodings-1.0.4')`.

Rémi