### PR TITLE
Gromacs/add option and variant

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -59,6 +59,11 @@ class Gromacs(CMakePackage):
                     'IBM_QPX', 'Sparc64_HPC_ACE', 'IBM_VMX', 'IBM_VSX',
                     'ARM_NEON', 'ARM_NEON_ASIMD'))
     variant('rdtscp', default=True, description='Enable RDTSCP instruction usage')
+    variant('mdrun_only', default=False,
+            description='Enables the build of a cut-down version' +
+                         'of libgromacs and/or the mdrun program')
+    variant('openmp', default=True, description='Enables OpenMP at configure time')
+    variant('double_precision', default=False, description='Enables a double-precision configuration')
 
     depends_on('mpi', when='+mpi')
     depends_on('plumed+mpi', when='+plumed+mpi')
@@ -78,6 +83,8 @@ class Gromacs(CMakePackage):
 
         if '+mpi' in self.spec:
             options.append('-DGMX_MPI:BOOL=ON')
+            options.append('-DCMAKE_C_COMPILER=%s' % self.spec['mpi'].mpicc)
+            options.append('-DCMAKE_CXX_COMPILER=%s' % self.spec['mpi'].mpicxx)
 
         if '+double' in self.spec:
             options.append('-DGMX_DOUBLE:BOOL=ON')
@@ -104,5 +111,14 @@ class Gromacs(CMakePackage):
             options.append('-DGMX_USE_RDTSCP:BOOL=OFF')
         else:
             options.append('-DGMX_USE_RDTSCP:BOOL=ON')
+
+        if '+mdrun_only' in self.spec:
+            options.append('-DGMX_BUILD_MDRUN_ONLY:BOOL=ON')
+
+        if '~openmp' in self.spec:
+            options.append('-DGMX_OPENMP:BOOL=OFF')
+
+        if '+double_precision' in self.spec:
+            options.append('-DGMX_RELAXED_DOUBLE_PRECISION:BOOL=ON')
 
         return options

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -61,7 +61,7 @@ class Gromacs(CMakePackage):
     variant('rdtscp', default=True, description='Enable RDTSCP instruction usage')
     variant('mdrun_only', default=False,
             description='Enables the build of a cut-down version' +
-                         'of libgromacs and/or the mdrun program')
+                         ' of libgromacs and/or the mdrun program')
     variant('openmp', default=True, description='Enables OpenMP at configure time')
     variant('double_precision', default=False, description='Enables a double-precision configuration')
 

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -83,8 +83,6 @@ class Gromacs(CMakePackage):
 
         if '+mpi' in self.spec:
             options.append('-DGMX_MPI:BOOL=ON')
-            options.append('-DCMAKE_C_COMPILER=%s' % self.spec['mpi'].mpicc)
-            options.append('-DCMAKE_CXX_COMPILER=%s' % self.spec['mpi'].mpicxx)
 
         if '+double' in self.spec:
             options.append('-DGMX_DOUBLE:BOOL=ON')

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -112,11 +112,17 @@ class Gromacs(CMakePackage):
 
         if '+mdrun_only' in self.spec:
             options.append('-DGMX_BUILD_MDRUN_ONLY:BOOL=ON')
+        else:
+            options.append('-DGMX_BUILD_MDRUN_ONLY:BOOL=OFF')
 
         if '~openmp' in self.spec:
             options.append('-DGMX_OPENMP:BOOL=OFF')
+        else:
+            options.append('-DGMX_OPENMP:BOOL=ON')
 
         if '+double_precision' in self.spec:
             options.append('-DGMX_RELAXED_DOUBLE_PRECISION:BOOL=ON')
+        else:
+            options.append('-DGMX_RELAXED_DOUBLE_PRECISION:BOOL=OFF')
 
         return options


### PR DESCRIPTION
I add `variants` recommended by Fujitsu PRIMEHPC,
see: http://manual.gromacs.org/documentation/5.1.4/install-guide/index.html#fujitsu-primehpc
- `mdrun_only` enables the build of a cut-down version of libgromacs and/or the mdrun program.
- `openmp` is default on, but Fujitsu PRIMEHPC need it off.
- `double_precison` enables a double-precision configuration to compute some quantities to single-precision accuracy.