### PR TITLE
fix glib dependency build fixes #9992

### DIFF
--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -156,6 +156,7 @@ class Glib(AutotoolsPackage):
         spec = self.spec
         if spec.satisfies('@2:2.99'):
             pattern = 'Libs:'
-            repl = 'Libs: -L{0} '.format(spec['gettext'].prefix.lib)
+            repl = 'Libs: -L{0} -Wl,-rpath={0} '.format(
+                   spec['gettext'].prefix.lib)
             myfile = join_path(self.prefix.lib.pkgconfig, 'glib-2.0.pc')
             filter_file(pattern, repl, myfile, backup=False)

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -145,3 +145,17 @@ class Glib(AutotoolsPackage):
 
         files = [join_path(self.prefix.bin, file) for file in files]
         filter_file(pattern, repl, *files, backup=False)
+
+    @run_after('install')
+    def gettext_libdir(self):
+        # Packages that link to glib were also picking up -lintl from glib's
+        # glib-2.0.pc file. However, packages such as py-pygobject were
+        # bypassing spack's compiler wrapper for linking and thus not finding
+        # the gettext library directory. The patch below explitly adds the
+        # appropriate -L path.
+        spec = self.spec
+        if spec.satisfies('@2:2.99'):
+            pattern = 'Libs:'
+            repl = 'Libs: -L{0} '.format(spec['gettext'].prefix.lib)
+            myfile = join_path(self.prefix.lib.pkgconfig, 'glib-2.0.pc')
+            filter_file(pattern, repl, myfile, backup=False)

--- a/var/spack/repos/builtin/packages/py-pygobject/package.py
+++ b/var/spack/repos/builtin/packages/py-pygobject/package.py
@@ -35,6 +35,12 @@ class PyPygobject(PythonPackage):
     # for https://bugzilla.gnome.org/show_bug.cgi?id=668522
     patch('pygobject-2.28.6-gio-types-2.32.patch', when='@2.28.6')
 
+    # pygobject links directly using the compiler, not spack's wrapper.
+    # This causes it to fail to add the appropriate rpaths. This patch modifies
+    # pygobject's setup.py file to add -Wl,-rpath arguments for dependent
+    # libraries found with pkg-config.
+    patch('pygobject-3.28.3-setup-py.patch', when='@3.28.3')
+
     def url_for_version(self, version):
         url = 'http://ftp.gnome.org/pub/GNOME/sources/pygobject'
         return url + '/%s/pygobject-%s.tar.xz' % (version.up_to(2), version)

--- a/var/spack/repos/builtin/packages/py-pygobject/pygobject-3.28.3-setup-py.patch
+++ b/var/spack/repos/builtin/packages/py-pygobject/pygobject-3.28.3-setup-py.patch
@@ -1,0 +1,23 @@
+*** spack-src/setup.py	Tue Jul 30 07:25:06 2019
+--- spack-src/setup.py.new	Tue Jul 30 07:44:00 2019
+***************
+*** 620,627 ****
+          min_version = get_version_requirement(script_dir, name)
+          pkg_config_version_check(name, min_version)
+          ext.include_dirs += pkg_config_parse("--cflags-only-I", name)
+          ext.library_dirs += pkg_config_parse("--libs-only-L", name)
+          ext.libraries += pkg_config_parse("--libs-only-l", name)
+  
+  
+  du_build_ext = get_command_class("build_ext")
+--- 620,629 ----
+          min_version = get_version_requirement(script_dir, name)
+          pkg_config_version_check(name, min_version)
+          ext.include_dirs += pkg_config_parse("--cflags-only-I", name)
+          ext.library_dirs += pkg_config_parse("--libs-only-L", name)
+          ext.libraries += pkg_config_parse("--libs-only-l", name)
++         for libdir in ext.library_dirs:
++             ext.extra_link_args.append('-Wl,-rpath=%s' %libdir)
+  
+  
+  du_build_ext = get_command_class("build_ext")


### PR DESCRIPTION
Packages that link to glib were also picking up -lintl from glib's glib-2.0.pc file. However, packages such as py-pygobject were  bypassing spack's compiler wrapper for linking and thus not finding the gettext library directory. The patch below explitly adds the appropriate -L path.

This fixes #9992. 