### PR TITLE
OpenGL always provides gl

### DIFF
--- a/var/spack/repos/builtin/packages/opengl/package.py
+++ b/var/spack/repos/builtin/packages/opengl/package.py
@@ -13,6 +13,7 @@ class Opengl(Package):
 
     homepage = "https://www.opengl.org/"
 
+    provides('gl')
     provides('gl@:4.5', when='@4.5:')
     provides('gl@:4.4', when='@4.4:')
     provides('gl@:4.3', when='@4.3:')


### PR DESCRIPTION
macOS comes with OpenGL 2.1. With this PR, I can add OpenGL as an external package and Spack will use it as long as there are no version requirements.