### PR TITLE
Prevent conflicts between libuuid and Apple Cocoa Framework on Mac

### DIFF
--- a/var/spack/repos/builtin/packages/libuuid/package.py
+++ b/var/spack/repos/builtin/packages/libuuid/package.py
@@ -13,7 +13,3 @@ class Libuuid(AutotoolsPackage):
     url      = "http://downloads.sourceforge.net/project/libuuid/libuuid-1.0.3.tar.gz?r=http%3A%2F%2Fsourceforge.net%2Fprojects%2Flibuuid%2F&ts=1433881396&use_mirror=iweb"
 
     version('1.0.3', 'd44d866d06286c08ba0846aba1086d68')
-
-    conflicts('platform=darwin',
-              msg="This version of libuuid will prevent any downstream code "
-              "from linking against the Carbon framework")

--- a/var/spack/repos/builtin/packages/libuuid/package.py
+++ b/var/spack/repos/builtin/packages/libuuid/package.py
@@ -13,3 +13,7 @@ class Libuuid(AutotoolsPackage):
     url      = "http://downloads.sourceforge.net/project/libuuid/libuuid-1.0.3.tar.gz?r=http%3A%2F%2Fsourceforge.net%2Fprojects%2Flibuuid%2F&ts=1433881396&use_mirror=iweb"
 
     version('1.0.3', 'd44d866d06286c08ba0846aba1086d68')
+
+    conflicts('platform=darwin',
+              msg="This version of libuuid will prevent any downstream code "
+              "from linking against the Carbon framework")

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -126,6 +126,11 @@ class Python(AutotoolsPackage):
     depends_on('tcl', when='+tkinter')
     depends_on('tix', when='+tix')
     if sys.platform != 'darwin':
+        # On macOS systems, Spack's libuuid conflicts with the system-installed
+        # version and breaks anything linked against Cocoa/Carbon. Since the
+        # system-provided version is sufficient to build Python's UUID support,
+        # the easy solution is to only depend on Spack's libuuid when *not* on
+        # a Mac.
         depends_on('libuuid', when='+uuid')
 
     patch('tkinter.patch', when='@:2.8,3.3: platform=darwin')

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -125,7 +125,8 @@ class Python(AutotoolsPackage):
     depends_on('tk', when='+tkinter')
     depends_on('tcl', when='+tkinter')
     depends_on('tix', when='+tix')
-    depends_on('libuuid', when='+uuid')
+    if sys.platform != 'darwin':
+        depends_on('libuuid', when='+uuid')
 
     patch('tkinter.patch', when='@:2.8,3.3: platform=darwin')
 


### PR DESCRIPTION
Building Python with `+uuid` currently requires the Spack-built `libuuid` package. However, the vanilla `libuuid` is incompatible with Apple's frameworks. This results in build failures in Python 2.7 (since that version of Python uses Carbon, which also includes libuuid), as well as in code that's downstream of Python (such as py-matplotlib, which includes an `osx` backend).

The commit message documents the error messages for system/compiler versions:
```
    MacOS version 10.14.5
    Xcode 10.2.1
    Apple LLVM version 10.0.1 (clang-1001.0.46.4)
```

but the final error message is always:
```
/usr/include/hfs/hfs_format.h:794:2: error: unknown type name 'uuid_string_t'; did you mean 'io_string_t'?
```
because `uuid_string_t` is defined *only* in Apple's `uuid.h` and not in Spack's.