### PR TITLE
Add PyTorch 1.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -6,13 +6,50 @@
 from spack import *
 
 
-class PyPytorch(PythonPackage):
+class PyTorch(PythonPackage):
     """Tensors and Dynamic neural networks in Python
     with strong GPU acceleration."""
 
     homepage = "http://pytorch.org/"
     git      = "https://github.com/pytorch/pytorch.git"
 
+    maintainers = ['adamjstewart']
+    import_modules = [
+        'tools', 'caffe2', 'torch', 'tools.cwrap', 'tools.autograd',
+        'tools.setup_helpers', 'tools.shared', 'tools.jit', 'tools.pyi',
+        'tools.nnwrap', 'tools.cwrap.plugins', 'caffe2.core', 'caffe2.proto',
+        'caffe2.python', 'caffe2.distributed', 'caffe2.perfkernels',
+        'caffe2.experiments', 'caffe2.contrib', 'caffe2.quantization',
+        'caffe2.core.nomnigraph', 'caffe2.python.ideep', 'caffe2.python.mint',
+        'caffe2.python.layers', 'caffe2.python.onnx', 'caffe2.python.trt',
+        'caffe2.python.models', 'caffe2.python.docs', 'caffe2.python.modeling',
+        'caffe2.python.mkl', 'caffe2.python.examples',
+        'caffe2.python.predictor', 'caffe2.python.helpers',
+        'caffe2.python.rnn', 'caffe2.python.onnx.bin',
+        'caffe2.python.models.seq2seq', 'caffe2.experiments.python',
+        'caffe2.contrib.nnpack', 'caffe2.contrib.warpctc',
+        'caffe2.contrib.nccl', 'caffe2.contrib.playground',
+        'caffe2.contrib.gloo', 'caffe2.contrib.script', 'caffe2.contrib.prof',
+        'caffe2.contrib.tensorboard', 'caffe2.contrib.aten',
+        'caffe2.contrib.playground.resnetdemo',
+        'caffe2.contrib.script.examples', 'caffe2.contrib.aten.docs',
+        'caffe2.quantization.server', 'torch.nn', 'torch.onnx',
+        'torch.distributed', 'torch.autograd', 'torch.multiprocessing',
+        'torch.cuda', 'torch.backends', 'torch.optim', 'torch.utils',
+        'torch.contrib', 'torch.jit', 'torch.sparse',
+        'torch.for_onnx', 'torch._thnn', 'torch.distributions',
+        'torch.nn.parallel', 'torch.nn._functions', 'torch.nn.backends',
+        'torch.nn.utils', 'torch.nn.modules', 'torch.nn.parallel.deprecated',
+        'torch.nn._functions.thnn', 'torch.distributed.deprecated',
+        'torch.autograd._functions', 'torch.backends.cuda',
+        'torch.backends.mkl', 'torch.backends.mkldnn', 'torch.backends.openmp',
+        'torch.backends.cudnn', 'torch.utils.backcompat',
+        'torch.utils.bottleneck', 'torch.utils.ffi', 'torch.utils.tensorboard',
+        'torch.utils.data', 'torch.utils.data._utils'
+    ]
+
+    version('1.1.0', tag='v1.1.0', submodules=True)
+    version('1.0.1', tag='v1.0.1', submodules=True)
     version('1.0.0', tag='v1.0.0', submodules=True)
     version('0.4.1', tag='v0.4.1', submodules=True)
     version('0.4.0', tag='v0.4.0', submodules=True)
@@ -35,10 +72,12 @@ class PyPytorch(PythonPackage):
     depends_on('blas')
     depends_on('lapack')
     depends_on('py-pyyaml', type=('run', 'build'))
-    depends_on('py-typing', when='@0.3.2:', type=('run', 'build'))
+    depends_on('py-typing', when='@0.3.2: ^python@:3.4', type=('run', 'build'))
     depends_on('intel-mkl', when='+mkl')
     depends_on('cuda@7.5:', when='+cuda', type=('build', 'link', 'run'))
+    depends_on('cuda@9:', when='@1.1:+cuda', type=('build', 'link', 'run'))
     depends_on('cudnn@6:', when='+cuda+cudnn')
+    depends_on('cudnn@7:', when='@1.1:+cuda+cudnn')
     depends_on('nccl', when='+cuda+nccl')
     depends_on('magma+shared', when='+cuda+magma')
 


### PR DESCRIPTION
Successfully builds for me on macOS 10.14.5 with Clang 10.0.1.

I renamed the package to `py-torch` to be consistent with the PyPI name.