### PR TITLE
py-flye: change to build ARM.

### DIFF
--- a/var/spack/repos/builtin/packages/py-flye/package.py
+++ b/var/spack/repos/builtin/packages/py-flye/package.py
@@ -16,3 +16,8 @@ class PyFlye(PythonPackage):
     version('2.4.2', sha256='5b74d4463b860c9e1614ef655ab6f6f3a5e84a7a4d33faf3b29c7696b542c51a')
 
     depends_on('python@2.7:2.8', type=('build', 'run'))
+
+    def setup_environment(self, spack_env, run_env):
+        if self.spec.satisfies('target=aarch64'):
+            spack_env.set('arm_neon', '1')
+            spack_env.set('aarch64', '1')


### PR DESCRIPTION
py-flye is included minimap2.
We need to set makefile variable to build minimap2 on ARM.

This PR set makefile variable to environment variable when build for ARM.