### PR TITLE
Change how the libraries are installed for kaldi

### DIFF
--- a/var/spack/repos/builtin/packages/kaldi/package.py
+++ b/var/spack/repos/builtin/packages/kaldi/package.py
@@ -76,7 +76,7 @@ class Kaldi(Package):    # Does not use Autotools
             mkdirp(prefix.bin)
             for root, dirs, files in os.walk('.'):
                 for name in files:
-                    if name.endswith(".so") or name.endswith(".cc") \
+                    if name.endswith(".".format(dso_suffix)) or name.endswith(".cc") \
                             or name.endswith(".pptx"):
                         continue
                     if "configure" is name:
@@ -87,7 +87,7 @@ class Kaldi(Package):    # Does not use Autotools
             mkdir(prefix.lib)
             for root, dirs, files in os.walk('lib'):
                 for name in files:
-                    if name.endswith(".so"):
+                    if name.endswith(".".format(dso_suffix)):
                         fname, _ = os.path.splitext(name)
                         src = os.readlink(join(root, "{0}.{1}".format(fname, dso_suffix)))
                         install(src, prefix.lib)

--- a/var/spack/repos/builtin/packages/kaldi/package.py
+++ b/var/spack/repos/builtin/packages/kaldi/package.py
@@ -76,10 +76,11 @@ class Kaldi(Package):    # Does not use Autotools
             mkdirp(prefix.bin)
             for root, dirs, files in os.walk('.'):
                 for name in files:
-                    if name.endswith("." + dso_suffix) or name.endswith(".cc") \
+                    if name.endswith("." + dso_suffix) \
+                            or name.endswith(".cc") \
                             or name.endswith(".pptx"):
                         continue
-                    if "configure" is name:
+                    if "configure" == name:
                         continue
                     if os.access(join(root, name), os.X_OK):
                         install(join(root, name), prefix.bin)
@@ -89,7 +90,8 @@ class Kaldi(Package):    # Does not use Autotools
                 for name in files:
                     if name.endswith("." + dso_suffix):
                         fname, _ = os.path.splitext(name)
-                        src = os.readlink(join(root, "{0}.{1}".format(fname, dso_suffix)))
+                        fpath = join(root, "{0}.{1}".format(fname, dso_suffix))
+                        src = os.readlink(fpath)
                         install(src, prefix.lib)
 
             for root, dirs, files in os.walk('.'):

--- a/var/spack/repos/builtin/packages/kaldi/package.py
+++ b/var/spack/repos/builtin/packages/kaldi/package.py
@@ -89,8 +89,7 @@ class Kaldi(Package):    # Does not use Autotools
             for root, dirs, files in os.walk('lib'):
                 for name in files:
                     if name.endswith("." + dso_suffix):
-                        fname, _ = os.path.splitext(name)
-                        fpath = join(root, "{0}.{1}".format(fname, dso_suffix))
+                        fpath = join(root, name)
                         src = os.readlink(fpath)
                         install(src, prefix.lib)
 

--- a/var/spack/repos/builtin/packages/kaldi/package.py
+++ b/var/spack/repos/builtin/packages/kaldi/package.py
@@ -76,7 +76,7 @@ class Kaldi(Package):    # Does not use Autotools
             mkdirp(prefix.bin)
             for root, dirs, files in os.walk('.'):
                 for name in files:
-                    if name.endswith(".".format(dso_suffix)) or name.endswith(".cc") \
+                    if name.endswith("." + dso_suffix) or name.endswith(".cc") \
                             or name.endswith(".pptx"):
                         continue
                     if "configure" is name:
@@ -87,7 +87,7 @@ class Kaldi(Package):    # Does not use Autotools
             mkdir(prefix.lib)
             for root, dirs, files in os.walk('lib'):
                 for name in files:
-                    if name.endswith(".".format(dso_suffix)):
+                    if name.endswith("." + dso_suffix):
                         fname, _ = os.path.splitext(name)
                         src = os.readlink(join(root, "{0}.{1}".format(fname, dso_suffix)))
                         install(src, prefix.lib)

--- a/var/spack/repos/builtin/packages/kaldi/package.py
+++ b/var/spack/repos/builtin/packages/kaldi/package.py
@@ -85,7 +85,11 @@ class Kaldi(Package):    # Does not use Autotools
                         install(join(root, name), prefix.bin)
 
             mkdir(prefix.lib)
-            install_tree('lib', prefix.lib)
+            for root, dirs, files in os.walk('lib'):
+                for name in files:
+                    if name.endswith(".so"):
+                        src = os.readlink(join(root, name))
+                        install(src, prefix.lib)
 
             for root, dirs, files in os.walk('.'):
                 for name in files:

--- a/var/spack/repos/builtin/packages/kaldi/package.py
+++ b/var/spack/repos/builtin/packages/kaldi/package.py
@@ -88,7 +88,8 @@ class Kaldi(Package):    # Does not use Autotools
             for root, dirs, files in os.walk('lib'):
                 for name in files:
                     if name.endswith(".so"):
-                        src = os.readlink(join(root, name))
+                        fname, _ = os.path.splitext(name)
+                        src = os.readlink(join(root, "{0}.{1}".format(fname, dso_suffix)))
                         install(src, prefix.lib)
 
             for root, dirs, files in os.walk('.'):


### PR DESCRIPTION
@adamjstewart Currently the install_tree() call tries to copy the symlinks but not the
libraries themselves, they are instead pointed to somewhere in the build
stage directories. This breaks some of the binaries that are installed

This change looks at all the .so's in the lib directory, then installs
the real library files instead of just copying the symlink.