### PR TITLE
Update kaldi version

### DIFF
--- a/var/spack/repos/builtin/packages/kaldi/package.py
+++ b/var/spack/repos/builtin/packages/kaldi/package.py
@@ -18,6 +18,7 @@ class Kaldi(Package):    # Does not use Autotools
     git      = "https://github.com/kaldi-asr/kaldi.git"
 
     version('master')
+    version('2019-07-29', commit='7637de77e0a77bf280bef9bf484e4f37c4eb9475')
     version('2018-07-11', commit='6f2140b032b0108bc313eefdca65151289642773')
     version('2015-10-07', commit='c024e8aa0a727bf76c91a318f76a1f8b0b59249e')
 
@@ -35,6 +36,8 @@ class Kaldi(Package):    # Does not use Autotools
     depends_on('speex', type='run')
     depends_on('openfst@1.4.1-patch', when='@2015-10-07')
     depends_on('openfst@1.6.0:', when='@2018-07-11')
+    depends_on('openfst@1.6.0:', when='@2019-07-29')
+    depends_on('cub', when='@2019-07-29')
     depends_on('openfst')
 
     patch('openfst-1.4.1.patch', when='@2015-10-07')
@@ -68,6 +71,9 @@ class Kaldi(Package):    # Does not use Autotools
         if '+cuda' in spec:
             configure_args.append('--use-cuda=yes')
             configure_args.append('--cudatk-dir=' + spec['cuda'].prefix)
+
+        if spec.satisfies('@2019-07-29:'):
+            configure_args.append('--cub-root=' + spec['cub'].prefix.include)
 
         with working_dir("src"):
             configure(*configure_args)

--- a/var/spack/repos/builtin/packages/kaldi/package.py
+++ b/var/spack/repos/builtin/packages/kaldi/package.py
@@ -85,7 +85,11 @@ class Kaldi(Package):    # Does not use Autotools
                         install(join(root, name), prefix.bin)
 
             mkdir(prefix.lib)
-            install_tree('lib', prefix.lib)
+            for root, dirs, files in os.walk('lib'):
+                for name in files:
+                    if name.endswith(".so"):
+                        src = os.readlink(join(root, name))
+                        install(src, prefix.lib)
 
             for root, dirs, files in os.walk('.'):
                 for name in files:

--- a/var/spack/repos/builtin/packages/kaldi/package.py
+++ b/var/spack/repos/builtin/packages/kaldi/package.py
@@ -88,7 +88,8 @@ class Kaldi(Package):    # Does not use Autotools
             for root, dirs, files in os.walk('lib'):
                 for name in files:
                     if name.endswith(".so"):
-                        src = os.readlink(join(root, name))
+                        fname, _ = os.path.splitext(name)
+                        src = os.readlink(join(root, "{0}.{1}".format(fname, dso_suffix)))
                         install(src, prefix.lib)
 
             for root, dirs, files in os.walk('.'):


### PR DESCRIPTION
The kaldi build system is a bit messy as well as the fact that they don't do tags in their repo, this was the best I could come up with for fixing the package. 

I think this package probably needs a few more iterations of adding versions before a clean up can be done.