### PR TITLE
Use *virtual* jpeg package for package dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -85,7 +85,7 @@ class Lammps(CMakePackage):
     depends_on('mpi', when='+user-lb')
     depends_on('mpi', when='+user-h5md')
     depends_on('hdf5', when='+user-h5md')
-    depends_on('libjpeg', when='+jpeg')
+    depends_on('jpeg', when='+jpeg')
     depends_on('libpng', when='+png')
     depends_on('ffmpeg', when='+ffmpeg')
 

--- a/var/spack/repos/builtin/packages/ncbi-toolkit/package.py
+++ b/var/spack/repos/builtin/packages/ncbi-toolkit/package.py
@@ -16,7 +16,7 @@ class NcbiToolkit(AutotoolsPackage):
 
     depends_on('boost@1.35.0:')
     depends_on('bzip2')
-    depends_on('libjpeg')
+    depends_on('jpeg')
     depends_on('libpng')
     depends_on('libtiff')
     depends_on('libxml2')

--- a/var/spack/repos/builtin/packages/r-tiff/package.py
+++ b/var/spack/repos/builtin/packages/r-tiff/package.py
@@ -17,5 +17,5 @@ class RTiff(RPackage):
 
     version('0.1-5', '5052990b8647c77d3e27bc0ecf064e0b')
 
-    depends_on("libjpeg")
+    depends_on("jpeg")
     depends_on("libtiff")

--- a/var/spack/repos/builtin/packages/vigra/package.py
+++ b/var/spack/repos/builtin/packages/vigra/package.py
@@ -27,7 +27,7 @@ class Vigra(CMakePackage):
 
     depends_on('libtiff', when='+tiff')
     depends_on('libpng', when='+png')
-    depends_on('libjpeg', when='+jpeg')
+    depends_on('jpeg', when='+jpeg')
     depends_on('hdf5', when='+hdf5')
     depends_on('fftw', when='+fftw')
     depends_on('openexr', when='+exr')

--- a/var/spack/repos/builtin/packages/virtualgl/package.py
+++ b/var/spack/repos/builtin/packages/virtualgl/package.py
@@ -18,5 +18,5 @@ class Virtualgl(CMakePackage):
 
     version('2.5.2', '1a9f404f4a35afa9f56381cb33ed210c')
 
-    depends_on("libjpeg-turbo")
+    depends_on("jpeg")
     depends_on("glu")

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -87,7 +87,7 @@ class Vtk(CMakePackage):
     depends_on('freetype')
     depends_on('glew')
     depends_on('hdf5')
-    depends_on('libjpeg')
+    depends_on('jpeg')
     depends_on('jsoncpp')
     depends_on('libxml2')
     depends_on('lz4')


### PR DESCRIPTION
This prevents conflicts between descendents that depend on an unintentional
arbitrary jpeg implementation.