### PR TITLE
Update SWIG versions and add Fortran fork

### DIFF
--- a/var/spack/repos/builtin/packages/swig/package.py
+++ b/var/spack/repos/builtin/packages/swig/package.py
@@ -38,7 +38,7 @@ class Swig(AutotoolsPackage):
 
     depends_on('pcre')
 
-    # Get repository does *not* include configure, so it calls autoreconf
+    # Git repository does *not* include configure script
     for _version in ['@fortran', '@master']:
         depends_on('autoconf', type='build', when=_version)
         depends_on('automake', type='build', when=_version)

--- a/var/spack/repos/builtin/packages/swig/package.py
+++ b/var/spack/repos/builtin/packages/swig/package.py
@@ -22,6 +22,7 @@ class Swig(AutotoolsPackage):
     homepage = "http://www.swig.org"
     url      = "http://prdownloads.sourceforge.net/swig/swig-3.0.12.tar.gz"
 
+    version('master', git='https://github.com/swig/swig.git')
     version('4.0.0', 'e8a39cd6437e342cdcbd5af27a9bf11b62dc9efec9248065debcb8276fcbb925')
     version('3.0.12', '82133dfa7bba75ff9ad98a7046be687c')
     version('3.0.11', '13732eb0f1ab2123d180db8425c1edea')
@@ -31,8 +32,6 @@ class Swig(AutotoolsPackage):
     version('2.0.12', 'c3fb0b2d710cc82ed0154b91e43085a4')
     version('2.0.2',  'eaf619a4169886923e5f828349504a29')
     version('1.3.40', '2df766c9e03e02811b1ab4bba1c7b9cc')
-    version('master',
-            git='https://github.com/swig/swig.git')
     version('fortran', branch='master',
             git='https://github.com/swig-fortran/swig.git')
 


### PR DESCRIPTION
- SWIG versions use commit hashes from tags at https://github.com/swig/swig/releases
- Since git repo doesn't include configure.sh, call autoreconf script
- For information on the Fortran fork: see https://arxiv.org/abs/1904.02546