### PR TITLE
py-mpi4py: Added build argument for mpicc path

### DIFF
--- a/var/spack/repos/builtin/packages/py-mpi4py/package.py
+++ b/var/spack/repos/builtin/packages/py-mpi4py/package.py
@@ -26,3 +26,6 @@ class PyMpi4py(PythonPackage):
     depends_on('py-setuptools', type='build')
     depends_on('mpi')
     depends_on('py-cython', when='@develop', type='build')
+
+    def build_args(self, spec, prefix):
+      return ['--mpicc=%s -shared' % spec['mpi'].mpicc]

--- a/var/spack/repos/builtin/packages/py-mpi4py/package.py
+++ b/var/spack/repos/builtin/packages/py-mpi4py/package.py
@@ -28,4 +28,4 @@ class PyMpi4py(PythonPackage):
     depends_on('py-cython', when='@develop', type='build')
 
     def build_args(self, spec, prefix):
-      return ['--mpicc=%s -shared' % spec['mpi'].mpicc]
+        return ['--mpicc=%s -shared' % spec['mpi'].mpicc]


### PR DESCRIPTION
py-mpi4py fails to build on NERSC Cori when using Cray-MPICH with the error:

```
  >> 140    /global/gscratch1/sd/tconnors/spack-stage/spack-stage-zJSOhu/src/_configtest.c:6: undefined refere
            nce to `MPI_Init'
  >> 141    /usr/bin/ld: /global/gscratch1/sd/tconnors/spack-stage/spack-stage-zJSOhu/src/_configtest.c:7: und
            efined reference to `MPI_Finalize'
  >> 142    collect2: error: ld returned 1 exit status
     143    failure.
     144    removing: _configtest.c _configtest.o
  >> 145    error: Cannot link MPI programs. Check your configuration!!
```
However, it is able to build fine if using Spack built OpenMPI.

After checking the mpi4py documentation, it appears there is a build argument that needs to be added:

> If mpicc is not in your search path or the compiler wrapper has a different name, you can run the build command specifying its location:
> 
> `$ python setup.py build --mpicc=/where/you/have/mpicc`

After adding this build argument into the package.py, it was able to be successfully installed.