### PR TITLE
parsimonator: Enable build on non x86_64 hosts.

### DIFF
--- a/var/spack/repos/builtin/packages/parsimonator/nox86.patch
+++ b/var/spack/repos/builtin/packages/parsimonator/nox86.patch
@@ -1,0 +1,49 @@
+diff -ruN spack-src/axml.c spack-src.new/axml.c
+--- spack-src/axml.c	2019-07-30 11:00:46.000000000 +0900
++++ spack-src.new/axml.c	2019-07-30 13:13:39.345602753 +0900
+@@ -48,7 +48,7 @@
+ 
+ 
+ 
+-#if ! (defined(__ppc) || defined(__powerpc__) || defined(PPC))
++#if defined(x86_64)
+ #include <xmmintrin.h>
+ 
+ #endif
+diff -ruN spack-src/Makefile.nosse spack-src.new/Makefile.nosse
+--- spack-src/Makefile.nosse	1970-01-01 09:00:00.000000000 +0900
++++ spack-src.new/Makefile.nosse	2019-07-30 14:07:03.385661664 +0900
+@@ -0,0 +1,33 @@
++# Makefile June 2011 by Alexandros Stamatakis
++
++# to compile OPENMP version use INTEL icc !
++
++CC = gcc 
++#icc
++
++
++CFLAGS = -D_GNU_SOURCE -fomit-frame-pointer -funroll-loops -O2 #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
++
++LIBRARIES = -lm
++
++#Intel OPENMP flag for linking and compiling: -openmp 
++
++RM = rm -f
++
++objs    = axml.o  fastDNAparsimony.o
++
++
++all : raxmlHPC
++
++GLOBAL_DEPS = axml.h
++
++raxmlHPC : $(objs)
++	$(CC) -o parsimonator $(objs) $(LIBRARIES) 
++
++
++axml.o : axml.c $(GLOBAL_DEPS)
++fastDNAparsimony.o : fastDNAparsimony.c  $(GLOBAL_DEPS)
++
++
++clean : 
++	$(RM) *.o parsimonator

--- a/var/spack/repos/builtin/packages/parsimonator/package.py
+++ b/var/spack/repos/builtin/packages/parsimonator/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.spec import ConflictsInSpecError
 
 
 class Parsimonator(MakefilePackage):
@@ -15,14 +16,48 @@ class Parsimonator(MakefilePackage):
 
     version('1.0.2', commit='78368c6ab1e9adc7e9c6ec9256dd7ff2a5bb1b0a')
 
-    variant('sse', default=True, description='Enable SSE in order to substantially speed up execution')
+    variant('sse', default=False, description='Enable SSE in order to substantially speed up execution')
     variant('avx', default=False, description='Enable AVX in order to substantially speed up execution')
 
     conflicts('+avx', when='+sse')
 
+    patch('nox86.patch')
+
+    def flag_handler(self, name, flags):
+        arch = ''
+        spec = self.spec
+        if spec.satisfies("platform=cray"):
+            # FIXME; It is assumed that cray is x86_64.
+            # If you support arm on cray, you need to fix it.
+            arch = 'x86_64'
+        if (arch != 'x86_64' and not spec.satisfies("target=x86_64")):
+            if spec.satisfies("+sse"):
+                raise ConflictsInSpecError(
+                    spec,
+                    [(
+                        spec,
+                        spec.architecture.target,
+                        spec.variants['sse'],
+                        '+sse is valid only on x86_64'
+                    )]
+                )
+            if spec.satisfies("+avx"):
+                raise ConflictsInSpecError(
+                    spec,
+                    [(
+                        spec,
+                        spec.architecture.target,
+                        spec.variants['avx'],
+                        '+avx is valid only on x86_64'
+                    )]
+                )
+        return (flags, None, None)
+
     @property
     def makefile_file(self):
-        if '+sse' in self.spec:
+        if not self.spec.satisfies('target=x86_64'):
+            return 'Makefile.nosse'
+        elif '+sse' in self.spec:
             return 'Makefile.SSE3.gcc'
         elif '+avx' in self.spec:
             return 'Makefile.AVX.gcc'
@@ -38,7 +73,9 @@ class Parsimonator(MakefilePackage):
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
-        if '+sse' in spec:
+        if not self.spec.satisfies('target=x86_64'):
+            install('parsimonator', prefix.bin)
+        elif '+sse' in spec:
             install('parsimonator-SSE3', prefix.bin)
         elif '+avx' in spec:
             install('parsimonator-AVX', prefix.bin)


### PR DESCRIPTION
To build parsomonnator on non x86_64 host, I changed as follows:
* axml.c was include xmmintrin.h when host is not powerPC. I changed include only host is x86_64.
* Add Makefile.nosse for non-x86 hosts.
* sse variant change to False.
* Add check sse and avx variant dose not set non-x86 hosts.
