### PR TITLE
igvtools: change package name to java from jdk.

### DIFF
--- a/var/spack/repos/builtin/packages/igvtools/package.py
+++ b/var/spack/repos/builtin/packages/igvtools/package.py
@@ -33,7 +33,7 @@ class Igvtools(Package):
 
         # Munge the helper script to explicitly point to java and the
         # jar file.
-        java = spec['jdk'].prefix.bin.java
+        java = spec['java'].prefix.bin.java
         kwargs = {'ignore_absent': False, 'backup': False, 'string': False}
         filter_file('^java', java, script, **kwargs)
         filter_file(jar_file, join_path(prefix.bin, jar_file),


### PR DESCRIPTION
Currently `openjdk` is Prioritized than `jdk` as `java` dependency. So I fixed to use a `java` virtual dependency name when specifying package  by `spec`.