### PR TITLE
Print environment name when removing active env

### DIFF
--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -249,7 +249,8 @@ def env_remove(args):
 
     for env in read_envs:
         if env.active:
-            tty.die("Environment %s can't be removed while activated.")
+            tty.die("Environment %s can't be removed while activated."
+                    % env.name)
 
         env.destroy()
         tty.msg("Successfully removed environment '%s'" % env.name)


### PR DESCRIPTION
Add the environment name to the error message shown when trying to remove an activated environment.