### PR TITLE
unzip: fix build for cray back-end

### DIFF
--- a/var/spack/repos/builtin/packages/unzip/package.py
+++ b/var/spack/repos/builtin/packages/unzip/package.py
@@ -14,9 +14,12 @@ class Unzip(MakefilePackage):
 
     version('6.0', '62b490407489521db863b523a7f86375')
 
-    conflicts('platform=cray', msg='Unzip does not currently build on Cray')
+    # The Cray cc wrapper doesn't handle the '-s' flag (strip) cleanly.
+    @when('platform=cray')
+    def patch(self):
+        filter_file(r'^LFLAGS2=.*', 'LFLAGS2=', join_path('unix', 'configure'))
 
-    make_args = ['-f', 'unix/Makefile']
+    make_args = ['-f', join_path('unix', 'Makefile')]
     build_targets = make_args + ['generic']
 
     def url_for_version(self, version):


### PR DESCRIPTION
Fixes #12007.

The Cray cc wrappers don't handle the -s flag (strip) cleanly, It's
not essential to strip the binary, so just remove the flag on Cray.

Note: the default build on Cray is for the back end and the unzip
binary won't run on the front end.  To build for FE, use something
like arch=cray-fe-x86_64.

----------

As I mentioned in #12199, the way I wrote this, this removes the `-s`
flag on Cray.  If you really wanted to strip the binary, there is
another one-line `filter_file` to put `-s` on `LFLAGS1` which works.

But I'd just as soon not strip the binary.  The zip package uses the
same Makefile except without -s, and I'd rather follow their example.
All five binaries combined are less than 1 meg.

ping @mamelara @jrood-nrel  @chuckatkins 
