### PR TITLE
Update c-blosc and fix building tests with icc

### DIFF
--- a/var/spack/repos/builtin/packages/c-blosc/package.py
+++ b/var/spack/repos/builtin/packages/c-blosc/package.py
@@ -14,6 +14,7 @@ class CBlosc(CMakePackage):
     homepage = "http://www.blosc.org"
     url      = "https://github.com/Blosc/c-blosc/archive/v1.11.1.tar.gz"
 
+    version('1.17.0', sha256='75d98c752b8cf0d4a6380a3089d56523f175b0afa2d0cf724a1bd0a1a8f975a4')
     version('1.16.3', sha256='bec56cb0956725beb93d50478e918aca09f489f1bfe543dbd3087827a7344396')
     version('1.15.0', sha256='dbbb01f9fedcdf2c2ff73296353a9253f44ce9de89c081cbd8146170dce2ba8f')
     version('1.12.1', sha256='e04535e816bb942bedc9a0ba209944d1eb34e26e2d9cca37f114e8ee292cb3c8')
@@ -32,12 +33,10 @@ class CBlosc(CMakePackage):
     depends_on('zstd')
     depends_on('lz4')
 
+    patch('test_forksafe.patch', when='@1.15.0:1.17.0%intel')
+
     def cmake_args(self):
         args = []
-
-        # Some of the tests do not build with icc.
-        if '%intel' in self.spec:
-            args.append('-DBUILD_TESTS=OFF')
 
         if '+avx2' in self.spec:
             args.append('-DDEACTIVATE_AVX2=OFF')

--- a/var/spack/repos/builtin/packages/c-blosc/test_forksafe.patch
+++ b/var/spack/repos/builtin/packages/c-blosc/test_forksafe.patch
@@ -1,0 +1,10 @@
+--- a/tests/test_forksafe.c	2019-07-30 15:01:36.208670230 -0500
++++ b/tests/test_forksafe.c	2019-07-30 15:02:27.475543401 -0500
+@@ -43,5 +43,6 @@
+   int success = 0;
+   int status = 0;
+-  for(float sec = 0; sec < 1; ) {
++  float sec = 0;
++  while (sec < 1) {
+     if(waitpid(newpid, &status, WNOHANG) != 0) {
+       success = 1;


### PR DESCRIPTION
- Update c-blosc to 1.17.0
- Add patch to build test_forksafe for versions 1.15.0 through 1.17.0
  when compiled with the Intel compiler.
- Remove code that turned off building the test with the Intel compiler