### PR TITLE
Fix Sphinx deprecation warning when building docs

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -91,7 +91,7 @@ class PatchedPythonDomain(PythonDomain):
             env, fromdocname, builder, typ, target, node, contnode)
 
 def setup(sphinx):
-    sphinx.override_domain(PatchedPythonDomain)
+    sphinx.add_domain(PatchedPythonDomain, override=True)
 
 # -- General configuration -----------------------------------------------------
 

--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -68,7 +68,6 @@ subprocess.call([
 # Without this, the API Docs will never actually update
 #
 apidoc_args = [
-    '--force',         # Older versions of Sphinx ignore the first argument
     '--force',         # Overwrite existing files
     '--no-toc',        # Don't create a table of contents file
     '--output-dir=.',  # Directory to place all output
@@ -96,7 +95,7 @@ def setup(sphinx):
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+needs_sphinx = '1.8'
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.


### PR DESCRIPTION
When I try to build the docs with the latest version of Sphinx, I see the following deprecation warning:
```
/Users/Adam/spack/lib/spack/docs/conf.py:94: RemovedInSphinx30Warning: app.override_domain() is deprecated. Use app.add_domain() with override option instead.
  sphinx.override_domain(PatchedPythonDomain)
```
This PR fixes that. It also sets the minimum required version of Sphinx to 1.8, which is the version where the `override` option was added to `add_domain()`: https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.add_domain