### PR TITLE
Fix CNL version detection

### DIFF
--- a/lib/spack/spack/operating_systems/cnl.py
+++ b/lib/spack/spack/operating_systems/cnl.py
@@ -50,6 +50,7 @@ def read_cle_release_file():
             result[key] = value.strip()
         return result
 
+
 def read_clerelease_file():
     """Read the CLE release file and return the Cray OS version.
 

--- a/lib/spack/spack/operating_systems/cnl.py
+++ b/lib/spack/spack/operating_systems/cnl.py
@@ -3,21 +3,26 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
 import re
 
 import llnl.util.tty as tty
 
+import spack.error
 import spack.version
 from spack.architecture import OperatingSystem
 from spack.util.module_cmd import module
 
-#: Location of the Cray CLE release file, which we look at to get the CNL
-#: OS version.
+#: Possible locations of the Cray CLE release file,
+#: which we look at to get the CNL OS version.
 _cle_release_file = '/etc/opt/cray/release/cle-release'
+_clerelease_file  = '/etc/opt/cray/release/clerelease'
 
 
 def read_cle_release_file():
     """Read the CLE release file and return a dict with its attributes.
+
+    This file is present on newer versions of Cray.
 
     The release file looks something like this::
 
@@ -33,6 +38,8 @@ def read_cle_release_file():
           ...
         }
 
+    Returns:
+        dict: dictionary of release attributes
     """
     with open(_cle_release_file) as release_file:
         result = {}
@@ -43,9 +50,25 @@ def read_cle_release_file():
             result[key] = value.strip()
         return result
 
+def read_clerelease_file():
+    """Read the CLE release file and return the Cray OS version.
+
+    This file is present on older versions of Cray.
+
+    The release file looks something like this::
+
+        5.2.UP04
+
+    Returns:
+        str: the Cray OS version
+    """
+    with open(_clerelease_file) as release_file:
+        for line in release_file:
+            return line.strip()
+
 
 class Cnl(OperatingSystem):
-    """ Compute Node Linux (CNL) is the operating system used for the Cray XC
+    """Compute Node Linux (CNL) is the operating system used for the Cray XC
     series super computers. It is a very stripped down version of GNU/Linux.
     Any compilers found through this operating system will be used with
     modules. If updated, user must make sure that version and name are
@@ -63,9 +86,16 @@ class Cnl(OperatingSystem):
 
     @classmethod
     def _detect_crayos_version(cls):
-        release_attrs = read_cle_release_file()
-        v = spack.version.Version(release_attrs['RELEASE'])
-        return v[0]
+        if os.path.isfile(_cle_release_file):
+            release_attrs = read_cle_release_file()
+            v = spack.version.Version(release_attrs['RELEASE'])
+            return v[0]
+        elif os.path.isfile(_clerelease_file):
+            v = read_clerelease_file()
+            return spack.version.Version(v)[0]
+        else:
+            raise spack.error.UnsupportedPlatformError(
+                'Unable to detect Cray OS version')
 
     def arguments_to_detect_version_fn(self, paths):
         import spack.compilers

--- a/lib/spack/spack/test/operating_system.py
+++ b/lib/spack/spack/test/operating_system.py
@@ -32,3 +32,42 @@ DUMMY=foo=bar
     assert attrs['DUMMY'] == 'foo=bar'
 
     assert cnl.Cnl._detect_crayos_version() == 6
+
+
+def test_read_clerelease_file(tmpdir, monkeypatch):
+    """test reading the Cray clerelease file"""
+    clerelease_path = tmpdir.join('clerelease')
+    with clerelease_path.open('w') as f:
+        f.write('5.2.UP04\n')
+
+    monkeypatch.setattr(cnl, '_clerelease_file', str(clerelease_path))
+    v = cnl.read_clerelease_file()
+
+    assert v == '5.2.UP04'
+
+    assert cnl.Cnl._detect_crayos_version() == 5
+
+
+def test_cle_release_precedence(tmpdir, monkeypatch):
+    """test that cle-release file takes precedence over clerelease file."""
+    cle_release_path = tmpdir.join('cle-release')
+    clerelease_path = tmpdir.join('clerelease')
+
+    with cle_release_path.open('w') as f:
+        f.write("""\
+RELEASE=6.0.UP07
+BUILD=6.0.7424
+DATE=20190611
+ARCH=noarch
+NETWORK=ari
+PATCHSET=35-201906112304
+DUMMY=foo=bar
+""")
+
+    with clerelease_path.open('w') as f:
+        f.write('5.2.UP04\n')
+
+    monkeypatch.setattr(cnl, '_clerelease_file', str(clerelease_path))
+    monkeypatch.setattr(cnl, '_cle_release_file', str(cle_release_path))
+
+    assert cnl.Cnl._detect_crayos_version() == 6


### PR DESCRIPTION
Fixes #12187 

With this PR, Spack successfully detects the Cray OS version on Blue Waters:
```console
$ spack arch
cray-cnl5-interlagos
```