### PR TITLE
raxml: compile on non-x86 hosts.

### DIFF
--- a/var/spack/repos/builtin/packages/raxml/nox86.patch
+++ b/var/spack/repos/builtin/packages/raxml/nox86.patch
@@ -1,0 +1,244 @@
+diff -rNu spack-src/axml.c spack-src.new/axml.c
+--- spack-src/axml.c	2017-06-28 17:39:42.000000000 +0900
++++ spack-src.new/axml.c	2019-07-31 09:56:14.337741033 +0900
+@@ -66,7 +66,7 @@
+ 
+ #endif
+ 
+-#if ! (defined(__ppc) || defined(__powerpc__) || defined(PPC))
++#if defined(__x86_64)
+ #include <xmmintrin.h>
+ /*
+   special bug fix, enforces denormalized numbers to be flushed to zero,
+@@ -13702,7 +13702,7 @@
+     
+     
+     
+-#if ! (defined(__ppc) || defined(__powerpc__) || defined(PPC))
++#if defined(__x86_64)
+     
+     /* 
+        David Defour's command  
+diff -rNu spack-src/Makefile.HYBRID.nox86.gcc spack-src.new/Makefile.HYBRID.nox86.gcc
+--- spack-src/Makefile.HYBRID.nox86.gcc	1970-01-01 09:00:00.000000000 +0900
++++ spack-src.new/Makefile.HYBRID.nox86.gcc	2019-07-31 09:58:59.087746805 +0900
+@@ -0,0 +1,51 @@
++# Makefile November 2009 by Alexandros Stamatakis
++
++CC = mpicc
++
++
++CFLAGS = -D_WAYNE_MPI -D_GNU_SOURCE -fomit-frame-pointer -funroll-loops -O2  -D_USE_PTHREADS
++
++
++LIBRARIES = -lm -pthread
++
++RM = rm -f
++
++objs    = axml.o  optimizeModel.o multiple.o searchAlgo.o topologies.o parsePartitions.o treeIO.o models.o bipartitionList.o rapidBootstrap.o evaluatePartialGenericSpecial.o evaluateGenericSpecial.o newviewGenericSpecial.o makenewzGenericSpecial.o   classify.o fastDNAparsimony.o fastSearch.o leaveDropping.o rmqs.o rogueEPA.o ancestralStates.o  mem_alloc.o eigen.o 
++
++all : clean raxmlHPC-HYBRID
++
++GLOBAL_DEPS = axml.h globalVariables.h rmq.h rmqs.h #mem_alloc.h compiler.h  /fefs/home/r0001/work/spack/lib/spack/env/gcc/gcc.h  ll_asm.h  ll_list.h
++
++raxmlHPC-HYBRID : $(objs)
++	$(CC) -o raxmlHPC-HYBRID $(objs) $(LIBRARIES) $(LDFLAGS) 
++
++rmqs.o : rmqs.c $(GLOBAL_DEPS)
++classify.o : classify.c $(GLOBAL_DEPS)
++evaluatePartialSpecialGeneric.o : evaluatePartialSpecialGeneric.c $(GLOBAL_DEPS)
++bipartitionList.o : bipartitionList.c $(GLOBAL_DEPS)
++optimizeModel.o : optimizeModel.c $(GLOBAL_DEPS)
++multiple.o : multiple.c $(GLOBAL_DEPS)
++axml.o : axml.c $(GLOBAL_DEPS)
++searchAlgo.o : searchAlgo.c $(GLOBAL_DEPS)
++topologies.o : topologies.c $(GLOBAL_DEPS)
++parsePartitions.o : parsePartitions.c $(GLOBAL_DEPS)
++treeIO.o : treeIO.c $(GLOBAL_DEPS)
++models.o : models.c $(GLOBAL_DEPS)
++rapidBootstrap.o : rapidBootstrap.c $(GLOBAL_DEPS) 
++evaluatePartialGenericSpecial.o : evaluatePartialGenericSpecial.c $(GLOBAL_DEPS)
++evaluateGenericSpecial.o : evaluateGenericSpecial.c $(GLOBAL_DEPS)
++newviewGenericSpecial.o : newviewGenericSpecial.c $(GLOBAL_DEPS)
++makenewzGenericSpecial.o : makenewzGenericSpecial.c $(GLOBAL_DEPS)
++fastDNAparsimony.o : fastDNAparsimony.c  $(GLOBAL_DEPS)
++fastSearch.o : fastSearch.c $(GLOBAL_DEPS)
++leaveDropping.o : leaveDropping.c $(GLOBAL_DEPS)
++rogueEPA.o : rogueEPA.c $(GLOBAL_DEPS)
++ancestralStates.o : ancestralStates.c $(GLOBAL_DEPS)
++ mem_alloc.o eigen.o  : mem_alloc.c  $(GLOBAL_DEPS)
++
++eigen.o : eigen.c $(GLOBAL_DEPS)
++	$(CC) -c -o eigen.o eigen.c 
++clean : 
++	$(RM) *.o raxmlHPC-HYBRID
++
++dev : raxmlHPC-HYBRID
+diff -rNu spack-src/Makefile.MPI.nox86.gcc spack-src.new/Makefile.MPI.nox86.gcc
+--- spack-src/Makefile.MPI.nox86.gcc	1970-01-01 09:00:00.000000000 +0900
++++ spack-src.new/Makefile.MPI.nox86.gcc	2019-07-31 09:59:25.937748520 +0900
+@@ -0,0 +1,51 @@
++# Makefile November 2009 by Alexandros Stamatakis
++
++CC = mpicc
++
++
++CFLAGS = -D_WAYNE_MPI -D_GNU_SOURCE -fomit-frame-pointer -funroll-loops -O2
++
++
++LIBRARIES = -lm
++
++RM = rm -f
++
++objs    = axml.o  optimizeModel.o multiple.o searchAlgo.o topologies.o parsePartitions.o treeIO.o models.o bipartitionList.o rapidBootstrap.o evaluatePartialGenericSpecial.o evaluateGenericSpecial.o newviewGenericSpecial.o makenewzGenericSpecial.o   classify.o fastDNAparsimony.o fastSearch.o leaveDropping.o rmqs.o rogueEPA.o ancestralStates.o  mem_alloc.o eigen.o 
++
++all : clean raxmlHPC-MPI
++
++GLOBAL_DEPS = axml.h globalVariables.h rmq.h rmqs.h #mem_alloc.h
++
++raxmlHPC-MPI : $(objs)
++	$(CC) -o raxmlHPC-MPI $(objs) $(LIBRARIES) $(LDFLAGS) 
++
++rmqs.o : rmqs.c $(GLOBAL_DEPS)
++classify.o : classify.c $(GLOBAL_DEPS)
++evaluatePartialSpecialGeneric.o : evaluatePartialSpecialGeneric.c $(GLOBAL_DEPS)
++bipartitionList.o : bipartitionList.c $(GLOBAL_DEPS)
++optimizeModel.o : optimizeModel.c $(GLOBAL_DEPS)
++multiple.o : multiple.c $(GLOBAL_DEPS)
++axml.o : axml.c $(GLOBAL_DEPS)
++searchAlgo.o : searchAlgo.c $(GLOBAL_DEPS)
++topologies.o : topologies.c $(GLOBAL_DEPS)
++parsePartitions.o : parsePartitions.c $(GLOBAL_DEPS)
++treeIO.o : treeIO.c $(GLOBAL_DEPS)
++models.o : models.c $(GLOBAL_DEPS)
++rapidBootstrap.o : rapidBootstrap.c $(GLOBAL_DEPS) 
++evaluatePartialGenericSpecial.o : evaluatePartialGenericSpecial.c $(GLOBAL_DEPS)
++evaluateGenericSpecial.o : evaluateGenericSpecial.c $(GLOBAL_DEPS)
++newviewGenericSpecial.o : newviewGenericSpecial.c $(GLOBAL_DEPS)
++makenewzGenericSpecial.o : makenewzGenericSpecial.c $(GLOBAL_DEPS)
++fastDNAparsimony.o : fastDNAparsimony.c  $(GLOBAL_DEPS)
++fastSearch.o : fastSearch.c $(GLOBAL_DEPS)
++leaveDropping.o : leaveDropping.c $(GLOBAL_DEPS)
++rogueEPA.o : rogueEPA.c $(GLOBAL_DEPS)
++ancestralStates.o : ancestralStates.c $(GLOBAL_DEPS)
++ mem_alloc.o eigen.o  : mem_alloc.c  $(GLOBAL_DEPS)
++
++eigen.o : eigen.c $(GLOBAL_DEPS)
++	$(CC) -c -o eigen.o eigen.c 
++clean : 
++	$(RM) *.o raxmlHPC-MPI
++
++dev : raxmlHPC-MPI
+diff -rNu spack-src/Makefile.nox86.gcc spack-src.new/Makefile.nox86.gcc
+--- spack-src/Makefile.nox86.gcc	1970-01-01 09:00:00.000000000 +0900
++++ spack-src.new/Makefile.nox86.gcc	2019-07-31 09:59:47.987749919 +0900
+@@ -0,0 +1,53 @@
++# Makefile August 2006 by Alexandros Stamatakis
++# Makefile cleanup October 2006, Courtesy of Peter Cordes <peter@cordes.ca>
++
++CC = gcc
++
++
++CFLAGS = -D_GNU_SOURCE -fomit-frame-pointer -funroll-loops -O2 #-Wall -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
++
++LIBRARIES = -lm
++
++RM = rm -f
++
++objs    = axml.o  optimizeModel.o multiple.o searchAlgo.o topologies.o parsePartitions.o treeIO.o models.o bipartitionList.o rapidBootstrap.o evaluatePartialGenericSpecial.o evaluateGenericSpecial.o newviewGenericSpecial.o makenewzGenericSpecial.o   classify.o fastDNAparsimony.o fastSearch.o leaveDropping.o rmqs.o rogueEPA.o ancestralStates.o  mem_alloc.o  eigen.o
++
++all : clean raxmlHPC
++
++GLOBAL_DEPS = axml.h globalVariables.h rmq.h rmqs.h #mem_alloc.h
++
++raxmlHPC : $(objs)
++	$(CC) -o raxmlHPC $(objs) $(LIBRARIES) $(LDFLAGS) 
++
++rmqs.o : rmqs.c $(GLOBAL_DEPS)
++classify.o : classify.c $(GLOBAL_DEPS)
++evaluatePartialSpecialGeneric.o : evaluatePartialSpecialGeneric.c $(GLOBAL_DEPS)
++bipartitionList.o : bipartitionList.c $(GLOBAL_DEPS)
++optimizeModel.o : optimizeModel.c $(GLOBAL_DEPS)
++multiple.o : multiple.c $(GLOBAL_DEPS)
++axml.o : axml.c $(GLOBAL_DEPS)
++searchAlgo.o : searchAlgo.c $(GLOBAL_DEPS)
++topologies.o : topologies.c $(GLOBAL_DEPS)
++parsePartitions.o : parsePartitions.c $(GLOBAL_DEPS)
++treeIO.o : treeIO.c $(GLOBAL_DEPS)
++models.o : models.c $(GLOBAL_DEPS)
++rapidBootstrap.o : rapidBootstrap.c $(GLOBAL_DEPS) 
++evaluatePartialGenericSpecial.o : evaluatePartialGenericSpecial.c $(GLOBAL_DEPS)
++evaluateGenericSpecial.o : evaluateGenericSpecial.c $(GLOBAL_DEPS)
++newviewGenericSpecial.o : newviewGenericSpecial.c $(GLOBAL_DEPS)
++makenewzGenericSpecial.o : makenewzGenericSpecial.c $(GLOBAL_DEPS)
++fastDNAparsimony.o : fastDNAparsimony.c  $(GLOBAL_DEPS)
++fastSearch.o : fastSearch.c $(GLOBAL_DEPS)
++leaveDropping.o : leaveDropping.c $(GLOBAL_DEPS)
++rogueEPA.o : rogueEPA.c $(GLOBAL_DEPS)
++ancestralStates.o : ancestralStates.c $(GLOBAL_DEPS)
++mem_alloc.o eigen.o  : mem_alloc.c  $(GLOBAL_DEPS)
++
++
++
++eigen.o : eigen.c $(GLOBAL_DEPS)
++	$(CC) -c -o eigen.o eigen.c 
++clean : 
++	$(RM) *.o raxmlHPC
++
++dev : raxmlHPC
+diff -rNu spack-src/Makefile.PTHREADS.nox86.gcc spack-src.new/Makefile.PTHREADS.nox86.gcc
+--- spack-src/Makefile.PTHREADS.nox86.gcc	1970-01-01 09:00:00.000000000 +0900
++++ spack-src.new/Makefile.PTHREADS.nox86.gcc	2019-07-31 10:00:07.397751144 +0900
+@@ -0,0 +1,52 @@
++# Makefile August 2006 by Alexandros Stamatakis
++# Makefile cleanup October 2006, Courtesy of Peter Cordes <peter@cordes.ca>
++
++CC = gcc
++
++
++CFLAGS = -D_GNU_SOURCE -fomit-frame-pointer -funroll-loops -O2  -D_USE_PTHREADS #-Wall -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
++
++
++LIBRARIES = -lm -pthread
++
++RM = rm -f
++
++objs    = axml.o  optimizeModel.o multiple.o searchAlgo.o topologies.o parsePartitions.o treeIO.o models.o bipartitionList.o rapidBootstrap.o evaluatePartialGenericSpecial.o evaluateGenericSpecial.o newviewGenericSpecial.o makenewzGenericSpecial.o   classify.o  fastDNAparsimony.o fastSearch.o leaveDropping.o rmqs.o rogueEPA.o ancestralStates.o  mem_alloc.o eigen.o  
++
++all : clean raxmlHPC-PTHREADS
++
++GLOBAL_DEPS = axml.h globalVariables.h rmq.h rmqs.h #mem_alloc.h compiler.h  /fefs/home/r0001/work/spack/lib/spack/env/gcc/gcc.h  ll_asm.h  ll_list.h
++
++raxmlHPC-PTHREADS : $(objs)
++	$(CC) -o  raxmlHPC-PTHREADS $(objs) $(LIBRARIES) $(LDFLAGS) 
++
++rmqs.o : rmqs.c $(GLOBAL_DEPS)
++classify.o : classify.c $(GLOBAL_DEPS)
++evaluatePartialSpecialGeneric.o : evaluatePartialSpecialGeneric.c $(GLOBAL_DEPS)
++bipartitionList.o : bipartitionList.c $(GLOBAL_DEPS)
++optimizeModel.o : optimizeModel.c $(GLOBAL_DEPS)
++multiple.o : multiple.c $(GLOBAL_DEPS)
++axml.o : axml.c $(GLOBAL_DEPS)
++searchAlgo.o : searchAlgo.c $(GLOBAL_DEPS)
++topologies.o : topologies.c $(GLOBAL_DEPS)
++parsePartitions.o : parsePartitions.c $(GLOBAL_DEPS)
++treeIO.o : treeIO.c $(GLOBAL_DEPS)
++models.o : models.c $(GLOBAL_DEPS)
++rapidBootstrap.o : rapidBootstrap.c $(GLOBAL_DEPS) 
++evaluatePartialGenericSpecial.o : evaluatePartialGenericSpecial.c $(GLOBAL_DEPS)
++evaluateGenericSpecial.o : evaluateGenericSpecial.c $(GLOBAL_DEPS)
++newviewGenericSpecial.o : newviewGenericSpecial.c $(GLOBAL_DEPS)
++makenewzGenericSpecial.o : makenewzGenericSpecial.c $(GLOBAL_DEPS)
++fastDNAparsimony.o : fastDNAparsimony.c  $(GLOBAL_DEPS)
++fastSearch.o : fastSearch.c $(GLOBAL_DEPS)
++leaveDropping.o : leaveDropping.c $(GLOBAL_DEPS)
++rogueEPA.o : rogueEPA.c $(GLOBAL_DEPS)
++ancestralStates.o : ancestralStates.c $(GLOBAL_DEPS)
++mem_alloc.o eigen.o  : mem_alloc.c  $(GLOBAL_DEPS)
++
++eigen.o : eigen.c $(GLOBAL_DEPS)
++	$(CC) -c -o eigen.o eigen.c 
++clean : 
++	$(RM) *.o raxmlHPC-PTHREADS
++
++dev : raxmlHPC-PTHREADS

--- a/var/spack/repos/builtin/packages/raxml/package.py
+++ b/var/spack/repos/builtin/packages/raxml/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.spec import ConflictsInSpecError
 import glob
 
 
@@ -19,10 +20,12 @@ class Raxml(Package):
 
     variant('mpi', default=True, description='Enable MPI parallel support')
     variant('pthreads', default=False, description='Enable pthreads version')
-    variant('sse', default=True, description='Enable SSE in order to substantially speed up execution')
+    variant('sse', default=False, description='Enable SSE in order to substantially speed up execution')
     variant('avx', default=False, description='Enable AVX in order to substantially speed up execution')
 
     depends_on('mpi', when='+mpi')
+
+    patch('nox86.patch')
 
     # Compiles with either GCC or ICC.
     conflicts('%cce')
@@ -35,56 +38,104 @@ class Raxml(Package):
     # can't build multiple binaries in parallel without things breaking
     parallel = False
 
+    def flag_handler(self, name, flags):
+        arch = ''
+        spec = self.spec
+        if spec.satisfies("platform=cray"):
+            # FIXME; It is assumed that cray is x86_64.
+            # If you support arm on cray, you need to fix it.
+            arch = 'x86_64'
+        if (arch != 'x86_64' and not spec.satisfies("target=x86_64")):
+            if spec.satisfies("+sse"):
+                raise ConflictsInSpecError(
+                    spec,
+                    [(
+                        spec,
+                        spec.architecture.target,
+                        spec.variants['sse'],
+                        '+sse is valid only on x86_64'
+                    )]
+                )
+            if spec.satisfies("+avx"):
+                raise ConflictsInSpecError(
+                    spec,
+                    [(
+                        spec,
+                        spec.architecture.target,
+                        spec.variants['avx'],
+                        '+avx is valid only on x86_64'
+                    )]
+                )
+        return (flags, None, None)
+
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
         files = glob.iglob("Makefile.*")
         for file in files:
             makefile = FileFilter(file)
             makefile.filter('gcc', spack_cc)
+            if spec.satisfies('+mpi'):
+                makefile.filter('mpicc', self.spec['mpi'].mpicc)
 
-        if '+mpi' and '+avx' and '+pthreads' in spec:
-            make('-f', 'Makefile.AVX.HYBRID.gcc')
-            install('raxmlHPC-HYBRID-AVX', prefix.bin)
+        if spec.satisfies('target=x86_64'):
+            if spec.satisfies('+mpi +avx +pthreads'):
+                make('-f', 'Makefile.AVX.HYBRID.gcc')
+                install('raxmlHPC-HYBRID-AVX', prefix.bin)
 
-        if '+mpi' and '+sse' and '+pthreads' in spec:
-            make('-f', 'Makefile.SSE3.HYBRID.gcc')
-            install('raxmlHPC-HYBRID-SSE3', prefix.bin)
+            if spec.satisfies('+mpi +sse +pthreads'):
+                make('-f', 'Makefile.SSE3.HYBRID.gcc')
+                install('raxmlHPC-HYBRID-SSE3', prefix.bin)
 
-        if '+mpi' and '+pthreads' in spec:
-            make('-f', 'Makefile.HYBRID.gcc')
-            install('raxmlHPC-HYBRID', prefix.bin)
+            if spec.satisfies('+mpi +pthreads'):
+                make('-f', 'Makefile.HYBRID.gcc')
+                install('raxmlHPC-HYBRID', prefix.bin)
 
-        if '+mpi' and '+avx' in spec:
-            make('-f', 'Makefile.AVX.MPI.gcc')
-            install('raxmlHPC-MPI-AVX', prefix.bin)
+            if spec.satisfies('+mpi +avx'):
+                make('-f', 'Makefile.AVX.MPI.gcc')
+                install('raxmlHPC-MPI-AVX', prefix.bin)
 
-        if '+mpi' and '+sse' in spec:
-            make('-f', 'Makefile.SSE3.MPI.gcc')
-            install('raxmlHPC-MPI-SSE3', prefix.bin)
+            if spec.satisfies('+mpi +sse'):
+                make('-f', 'Makefile.SSE3.MPI.gcc')
+                install('raxmlHPC-MPI-SSE3', prefix.bin)
 
-        if '+mpi' in spec:
-            make('-f', 'Makefile.MPI.gcc')
-            install('raxmlHPC-MPI', prefix.bin)
+            if spec.satisfies('+mpi'):
+                make('-f', 'Makefile.MPI.gcc')
+                install('raxmlHPC-MPI', prefix.bin)
 
-        if '+pthreads' and '+avx' in spec:
-            make('-f', 'Makefile.AVX.PTHREADS.gcc')
-            install('raxmlHPC-PTHREADS-AVX', prefix.bin)
+            if spec.satisfies('+pthreads +avx'):
+                make('-f', 'Makefile.AVX.PTHREADS.gcc')
+                install('raxmlHPC-PTHREADS-AVX', prefix.bin)
 
-        if '+pthreads' and '+sse' in spec:
-            make('-f', 'Makefile.SSE3.PTHREADS.gcc')
-            install('raxmlHPC-PTHREADS-SSE3', prefix.bin)
+            if spec.satisfies('+pthreads +sse'):
+                make('-f', 'Makefile.SSE3.PTHREADS.gcc')
+                install('raxmlHPC-PTHREADS-SSE3', prefix.bin)
 
-        if '+pthreads' in spec:
-            make('-f', 'Makefile.PTHREADS.gcc')
-            install('raxmlHPC-PTHREADS', prefix.bin)
+            if spec.satisfies('+pthreads'):
+                make('-f', 'Makefile.PTHREADS.gcc')
+                install('raxmlHPC-PTHREADS', prefix.bin)
 
-        if '+sse' in spec:
-            make('-f', 'Makefile.SSE3.gcc')
-            install('raxmlHPC-SSE3', prefix.bin)
+            if spec.satisfies('+sse'):
+                make('-f', 'Makefile.SSE3.gcc')
+                install('raxmlHPC-SSE3', prefix.bin)
 
-        if '+avx' in spec:
-            make('-f', 'Makefile.AVX.gcc')
-            install('raxmlHPC-AVX', prefix.bin)
+            if spec.satisfies('+avx'):
+                make('-f', 'Makefile.AVX.gcc')
+                install('raxmlHPC-AVX', prefix.bin)
 
-        make('-f', 'Makefile.gcc')
-        install('raxmlHPC', prefix.bin)
+            make('-f', 'Makefile.gcc')
+            install('raxmlHPC', prefix.bin)
+        else:
+            if spec.satisfies('+mpi +pthreads'):
+                make('-f', 'Makefile.HYBRID.nox86.gcc')
+                install('raxmlHPC-HYBRID', prefix.bin)
+
+            if spec.satisfies('+mpi'):
+                make('-f', 'Makefile.MPI.nox86.gcc')
+                install('raxmlHPC-MPI', prefix.bin)
+
+            if spec.satisfies('+pthreads'):
+                make('-f', 'Makefile.PTHREADS.nox86.gcc')
+                install('raxmlHPC-PTHREADS', prefix.bin)
+
+            make('-f', 'Makefile.nox86.gcc')
+            install('raxmlHPC', prefix.bin)


### PR DESCRIPTION
* xmmintrrin.h is included x86 only.
* Add makefiles for non-x86 hosts.
* mpicc in Makefiles is replaced spacks mpi compile command.
* variant check is rewite with satisfies.