### PR TITLE
dialign-tx: build on ARM.

### DIFF
--- a/var/spack/repos/builtin/packages/dialign-tx/package.py
+++ b/var/spack/repos/builtin/packages/dialign-tx/package.py
@@ -24,6 +24,8 @@ class DialignTx(MakefilePackage):
             makefile = FileFilter('Makefile')
             makefile.filter(' -march=i686 ', ' ')
             makefile.filter('CC=gcc', 'CC=%s' % spack_cc)
+            if spec.satisfies('target=aarch64'):
+                makefile.filter('-mfpmath=sse -msse  -mmmx', ' ')
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)


### PR DESCRIPTION
dialign-x use SSE related compile options.
But these options is not support ARM.

This PR remove these options when target is ARM.