### PR TITLE
Removed an argument to concretize that was there only for unit tests

### DIFF
--- a/lib/spack/spack/cmd/concretize.py
+++ b/lib/spack/spack/cmd/concretize.py
@@ -18,5 +18,6 @@ def setup_parser(subparser):
 
 def concretize(parser, args):
     env = ev.get_env(args, 'concretize', required=True)
-    env.concretize(force=args.force)
+    concretized_specs = env.concretize(force=args.force)
+    ev.display_specs(concretized_specs)
     env.write()

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -223,7 +223,8 @@ def install(parser, args, **kwargs):
         env = ev.get_env(args, 'install')
         if env:
             if not args.only_concrete:
-                env.concretize()
+                concretized_specs = env.concretize()
+                ev.display_specs(concretized_specs)
                 env.write()
             tty.msg("Installing environment %s" % env.name)
             env.install_all(args)

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -822,7 +822,7 @@ class Environment(object):
                 del self.concretized_order[i]
                 del self.specs_by_hash[dag_hash]
 
-    def concretize(self, force=False, _display=True):
+    def concretize(self, force=False):
         """Concretize user_specs in this environment.
 
         Only concretizes specs that haven't been concretized yet unless
@@ -863,13 +863,7 @@ class Environment(object):
                 concrete = _concretize_from_constraints(uspec_constraints)
                 self._add_concrete_spec(uspec, concrete)
 
-                if _display:
-                    # Display concretized spec to the user
-                    sys.stdout.write(concrete.tree(
-                        recurse_dependencies=True,
-                        status_fn=spack.spec.Spec.install_status,
-                        hashlen=7, hashes=True)
-                    )
+                sys.stdout.write(_tree_to_display(concrete))
 
     def install(self, user_spec, concrete_spec=None, **install_args):
         """Install a single spec into an environment.
@@ -1298,6 +1292,13 @@ class Environment(object):
         deactivate()
         if self._previous_active:
             activate(self._previous_active)
+
+
+def _tree_to_display(concrete_spec):
+    return concrete_spec.tree(
+        recurse_dependencies=True,
+        status_fn=spack.spec.Spec.install_status,
+        hashlen=7, hashes=True)
 
 
 def _concretize_from_constraints(spec_constraints):

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -834,6 +834,10 @@ class Environment(object):
         Arguments:
             force (bool): re-concretize ALL specs, even those that were
                already concretized
+
+        Returns:
+            List of specs that have been concretized. Each entry is a tuple of
+            the user spec and the corresponding concretized spec.
         """
         if force:
             # Clear previously concretized specs
@@ -855,15 +859,15 @@ class Environment(object):
                 concrete = old_specs_by_hash[h]
                 self._add_concrete_spec(s, concrete, new=False)
 
-        # concretize any new user specs that we haven't concretized yet
+        # Concretize any new user specs that we haven't concretized yet
+        concretized_specs = []
         for uspec, uspec_constraints in zip(
                 self.user_specs, self.user_specs.specs_as_constraints):
             if uspec not in old_concretized_user_specs:
-                tty.msg('Concretizing %s' % uspec)
                 concrete = _concretize_from_constraints(uspec_constraints)
                 self._add_concrete_spec(uspec, concrete)
-
-                sys.stdout.write(_tree_to_display(concrete))
+                concretized_specs.append((uspec, concrete))
+        return concretized_specs
 
     def install(self, user_spec, concrete_spec=None, **install_args):
         """Install a single spec into an environment.
@@ -1294,11 +1298,23 @@ class Environment(object):
             activate(self._previous_active)
 
 
-def _tree_to_display(concrete_spec):
-    return concrete_spec.tree(
-        recurse_dependencies=True,
-        status_fn=spack.spec.Spec.install_status,
-        hashlen=7, hashes=True)
+def display_specs(concretized_specs):
+    """Displays the list of specs returned by `Environment.concretize()`.
+
+    Args:
+        concretized_specs (list): list of specs returned by
+            `Environment.concretize()`
+    """
+    def _tree_to_display(spec):
+        return spec.tree(
+            recurse_dependencies=True,
+            status_fn=spack.spec.Spec.install_status,
+            hashlen=7, hashes=True)
+
+    for user_spec, concrete_spec in concretized_specs:
+        tty.msg('Concretized {0}'.format(user_spec))
+        sys.stdout.write(_tree_to_display(concrete_spec))
+        print('')
 
 
 def _concretize_from_constraints(spec_constraints):

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -56,12 +56,6 @@ def env_deactivate():
     os.environ.pop('SPACK_ENV', None)
 
 
-@pytest.fixture()
-def no_display(monkeypatch):
-    """Instead of returning a tree to display, returns and empty string."""
-    monkeypatch.setattr(ev, '_tree_to_display', lambda x: '')
-
-
 def test_add():
     e = ev.create('test')
     e.add('mpileaks')
@@ -716,7 +710,7 @@ def test_read_old_lock_creates_backup(tmpdir):
         assert y.dag_hash() in lockfile_dict_v1['concrete_specs']
 
 
-@pytest.mark.usefixtures('config', 'no_display')
+@pytest.mark.usefixtures('config')
 def test_indirect_build_dep():
     """Simple case of X->Y->Z where Y is a build/link dep and Z is a
     build-only dep. Make sure this concrete DAG is preserved when writing the
@@ -752,7 +746,7 @@ def test_indirect_build_dep():
         assert x_env_spec == x_concretized
 
 
-@pytest.mark.usefixtures('config', 'no_display')
+@pytest.mark.usefixtures('config')
 def test_store_different_build_deps():
     r"""Ensure that an environment can store two instances of a build-only
 Dependency:

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -56,6 +56,12 @@ def env_deactivate():
     os.environ.pop('SPACK_ENV', None)
 
 
+@pytest.fixture()
+def no_display(monkeypatch):
+    """Instead of returning a tree to display, returns and empty string."""
+    monkeypatch.setattr(ev, '_tree_to_display', lambda x: '')
+
+
 def test_add():
     e = ev.create('test')
     e.add('mpileaks')
@@ -710,7 +716,7 @@ def test_read_old_lock_creates_backup(tmpdir):
         assert y.dag_hash() in lockfile_dict_v1['concrete_specs']
 
 
-@pytest.mark.usefixtures('config')
+@pytest.mark.usefixtures('config', 'no_display')
 def test_indirect_build_dep():
     """Simple case of X->Y->Z where Y is a build/link dep and Z is a
     build-only dep. Make sure this concrete DAG is preserved when writing the
@@ -736,7 +742,7 @@ def test_indirect_build_dep():
         _env_create('test', with_view=False)
         e = ev.read('test')
         e.add(x_spec)
-        e.concretize(_display=False)
+        e.concretize()
         e.write()
 
         e_read = ev.read('test')
@@ -746,7 +752,7 @@ def test_indirect_build_dep():
         assert x_env_spec == x_concretized
 
 
-@pytest.mark.usefixtures('config')
+@pytest.mark.usefixtures('config', 'no_display')
 def test_store_different_build_deps():
     r"""Ensure that an environment can store two instances of a build-only
 Dependency:
@@ -788,7 +794,7 @@ Dependency:
         e = ev.read('test')
         e.add(y_spec)
         e.add(x_spec)
-        e.concretize(_display=False)
+        e.concretize()
         e.write()
 
         e_read = ev.read('test')


### PR DESCRIPTION
While rebasing #11372 I noticed that the `Environment.concretize` method changed signature in 0715b512a19d5d966f596559274ca7b8a3406701:

https://github.com/spack/spack/blob/0715b512a19d5d966f596559274ca7b8a3406701/lib/spack/spack/environment.py#L823

as a new argument `_display` got added. This argument seems to be used only in unit tests to switch off part of the code. To avoid: 
1. Using an argument to a function that starts with a leading underscore
2. Having code that is needed only for tests mixed with business logic

this PR extracts the logic to display specs into its own function. Client code is then responsible to make an additional call if it needs to display the result of concretization - and unit tests can simply skip that call.