### PR TITLE
UnifyCR: update dependencies and build options

### DIFF
--- a/var/spack/repos/builtin/packages/unifycr/package.py
+++ b/var/spack/repos/builtin/packages/unifycr/package.py
@@ -60,7 +60,18 @@ class Unifycr(AutotoolsPackage):
     # Parallel disabled to prevent tests from being run out-of-order when
     # installed with the --test={root, all} option.
     parallel = False
+    debug_build = False
     build_directory = 'spack-build'
+
+    # Only builds properly with debug symbols when flag_handler =
+    # build_system_flags.
+    # Override the default behavior in order to set debug_build which is used
+    # to set the --disable-silent-rules option when configuring.
+    def flag_handler(self, name, flags):
+        if name in ('cflags', 'cppflags'):
+            if '-g' in flags:
+                self.debug_build = True
+        return (None, None, flags)
 
     def configure_args(self):
         spec = self.spec
@@ -89,7 +100,7 @@ class Unifycr(AutotoolsPackage):
         if '+pmix' in spec:
             args.append('--enable-pmix')
 
-        if spack.config.get('config:debug'):
+        if self.debug_build:
             args.append('--disable-silent-rules')
         else:
             args.append('--enable-silent-rules')

--- a/var/spack/repos/builtin/packages/unifycr/package.py
+++ b/var/spack/repos/builtin/packages/unifycr/package.py
@@ -17,13 +17,17 @@ class Unifycr(AutotoolsPackage):
     homepage = "https://github.com/LLNL/UnifyCR"
     git      = "https://github.com/LLNL/UnifyCR.git"
     url      = "https://github.com/LLNL/UnifyCR/releases/download/v0.2.0/unifycr-0.2.0.tar.gz"
+    maintainers = ['CamStan']
 
     version('develop', branch='dev', preferred=True)
     version('0.2.0', sha256='7439b0e885234bc64e8cbb449d8abfadd386692766b6f00647a7b6435efb2066')
 
-    variant('debug', default='False', description='Enable debug build options')
     variant('hdf5', default='False', description='Build with parallel HDF5 (install with `^hdf5~mpi` for serial)')
+    variant('fortran', default='False', description='Build with gfortran support')
     variant('numa', default='False', description='Build with NUMA')
+    variant('pmpi', default='False', description='Enable transparent mount/unmount at MPI_Init/Finalize')
+    variant('pmi', default='False', description='Enable PMI2 build options')
+    variant('pmix', default='False', description='Enable PMIx build options')
 
     depends_on('autoconf',  type='build')
     depends_on('automake',  type='build')
@@ -32,20 +36,26 @@ class Unifycr(AutotoolsPackage):
     depends_on('pkgconfig', type='build')
 
     # Required dependencies
+    depends_on('flatcc')
     # Latest version of GOTCHA has API changes that break UnifyCR.
     # Updates to UnifyCR are coming in order to fix this.
-    depends_on('flatcc')
     depends_on('gotcha@0.0.2')
     depends_on('leveldb')
     depends_on('margo')
+    depends_on('mercury+bmi+sm')
     depends_on('mpi')
 
     # Optional dependencies
     depends_on('hdf5', when='+hdf5')
     depends_on('numactl',  when='+numa')
 
-    # we depend on numactl, which doesn't currently build on darwin
+    conflicts('^mercury~bmi')
+    conflicts('^mercury~sm')
+    # UnifyCR depends on numactl, which doesn't currently build on darwin.
     conflicts('platform=darwin', when='+numa')
+    # Known compatibility issues with ifort and xlf. Fixes coming.
+    conflicts('%intel', when='+fortran')
+    conflicts('%xl', when='+fortran')
 
     # Parallel disabled to prevent tests from being run out-of-order when
     # installed with the --test={root, all} option.
@@ -67,8 +77,17 @@ class Unifycr(AutotoolsPackage):
                                          lambda x: spec['numactl'].prefix))
         args.extend(self.with_or_without('hdf5', hdf5_compiler_path))
 
-        if '+debug' in spec:
-            args.append('--enable-debug')
+        if '+fortran' in spec:
+            args.append('--enable-fortran')
+
+        if '+pmpi' in spec:
+            args.append('--enable-mpi-mount')
+
+        if '+pmi' in spec:
+            args.append('--enable-pmi')
+
+        if '+pmix' in spec:
+            args.append('--enable-pmix')
 
         if spack.config.get('config:debug'):
             args.append('--disable-silent-rules')


### PR DESCRIPTION
This adds some specifics about dependencies and conflicts and adds additional build options and variants.

UnifyCR now also has limited fortran support.

ECP project.