### PR TITLE
mpa: fix package build error with a patch

### DIFF
--- a/var/spack/repos/builtin/packages/mount-point-attributes/mpa_type_conversion.patch
+++ b/var/spack/repos/builtin/packages/mount-point-attributes/mpa_type_conversion.patch
@@ -1,0 +1,21 @@
+*** MountPointAttributes/src/MountPointAttr.h.orig	Wed Jul 31 10:08:33 2019
+--- MountPointAttributes/src/MountPointAttr.h	Wed Jul 31 10:09:55 2019
+***************
+*** 248,255 ****
+       */
+      struct FileSystemTypeInfo {
+          FileSystemType t;
+!         unsigned short speed;
+!         unsigned short scalability;
+          const char *fs_name;
+      };
+  
+--- 248,255 ----
+       */
+      struct FileSystemTypeInfo {
+          FileSystemType t;
+!         short speed;
+!         short scalability;
+          const char *fs_name;
+      };
+  

--- a/var/spack/repos/builtin/packages/mount-point-attributes/package.py
+++ b/var/spack/repos/builtin/packages/mount-point-attributes/package.py
@@ -18,3 +18,5 @@ class MountPointAttributes(AutotoolsPackage):
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
     depends_on('libtool', type='build')
+
+    patch('mpa_type_conversion.patch', when='@1.1')


### PR DESCRIPTION
This patch resolves this build error:

libtool: compile: g++ -DHAVE_CONFIG_H -I. -I.. -I.. -g -O2 -MT libmpattr_la-MountPointAttr.lo -MD -MP -MF .deps/libmpattr_la-MountPointAttr.Tpo -c MountPointAttr.C -fPIC -DPIC -o .libs/libmpattr_la-MountPointAttr.o
MountPointAttr.C:133:1: error: narrowing conversion of '-1' from 'int' to 'short unsigned int' inside { } [-Wnarrowing]
};
^
MountPointAttr.C:133:1: error: narrowing conversion of '-1' from 'int' to 'short unsigned int' inside { } [-Wnarrowing]

The upstream MPA source will be updated with this PR https://github.com/LLNL/MountPointAttributes/pull/4.