### PR TITLE
patch launchmon to fix char * conversion error

### DIFF
--- a/var/spack/repos/builtin/packages/launchmon/launchmon-char-conv.patch
+++ b/var/spack/repos/builtin/packages/launchmon/launchmon-char-conv.patch
@@ -1,0 +1,19 @@
+*** launchmon-v1.0.2/launchmon/src/linux/lmon_api/lmon_coloc_spawner.cxx.orig	Wed Jul 31 10:44:44 2019
+--- launchmon-v1.0.2/launchmon/src/linux/lmon_api/lmon_coloc_spawner.cxx	Wed Jul 31 10:45:04 2019
+***************
+*** 122,128 ****
+        memcpy(lmonpl, (*iter).c_str(), (*iter).size() + 1);
+        lmonpl += (*iter).size() + 1;
+      }
+!   lmonpl = '\0'; /* ending null */
+  
+    if (write_lmonp_long_msg(m_be_master_sockfd, msg, msgsize) < 0)
+      {
+--- 122,128 ----
+        memcpy(lmonpl, (*iter).c_str(), (*iter).size() + 1);
+        lmonpl += (*iter).size() + 1;
+      }
+!   *lmonpl = '\0'; /* ending null */
+  
+    if (write_lmonp_long_msg(m_be_master_sockfd, msg, msgsize) < 0)
+      {

--- a/var/spack/repos/builtin/packages/launchmon/package.py
+++ b/var/spack/repos/builtin/packages/launchmon/package.py
@@ -26,6 +26,8 @@ class Launchmon(AutotoolsPackage):
     depends_on("boost")
     depends_on("spectrum-mpi", when='arch=ppc64le')
 
+    patch('launchmon-char-conv.patch', when='@1.0.2')
+
     def setup_environment(self, spack_env, run_env):
         if self.spec.satisfies('@master'):
             # automake for launchmon requires the AM_PATH_LIBGCRYPT macro


### PR DESCRIPTION
There are build errors in the launchmon package with newer gcc compilers:

>      272    lmon_coloc_spawner.cxx: In member function 'bool spawner_coloc_t::d
>             o_frontend()':
>   >> 273    lmon_coloc_spawner.cxx:125:12: error: invalid conversion from 'char
>             ' to 'char*' [-fpermissive]
>      274       lmonpl = '\0'; /* ending null */

The upstream launchmon has been fixed, but a new version has not been released. This patch applies the fix to allow launchmon 1.0.2 to build OK in Spack.