### PR TITLE
Fix URLs for Geant4 surface data, and fix data install location

### DIFF
--- a/var/spack/repos/builtin/packages/g4realsurface/package.py
+++ b/var/spack/repos/builtin/packages/g4realsurface/package.py
@@ -11,11 +11,11 @@ import os
 class G4realsurface(Package):
     """Geant4 data for measured optical surface reflectance"""
     homepage = "http://geant4.web.cern.ch"
-    url = "http://geant4-data.web.cern.ch/geant4-data/datasets/RealSurface.1.0.tar.gz"
+    url = "http://geant4-data.web.cern.ch/geant4-data/datasets/G4RealSurface.2.1.1.tar.gz"
 
-    version('1.0', '3e2d2506600d2780ed903f1f2681962e208039329347c58ba1916740679020b1')
-    version('2.1', '2a287adbda1c0292571edeae2082a65b7f7bd6cf2bf088432d1d6f889426dcf3')
     version('2.1.1', '90481ff97a7c3fa792b7a2a21c9ed80a40e6be386e581a39950c844b2dd06f50')
+    version('2.1', '2a287adbda1c0292571edeae2082a65b7f7bd6cf2bf088432d1d6f889426dcf3')
+    version('1.0', '3e2d2506600d2780ed903f1f2681962e208039329347c58ba1916740679020b1')
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
@@ -25,4 +25,5 @@ class G4realsurface(Package):
 
     def url_for_version(self, version):
         """Handle version string."""
-        return ("http://geant4-data.web.cern.ch/geant4-data/datasets/RealSurface.1.0.tar.gz" % version)
+        return "http://geant4-data.web.cern.ch/geant4-data/datasets/{0}RealSurface.{1}.tar.gz".format(
+                "G4" if version > Version('1.0') else "", version)


### PR DESCRIPTION
A typo in the `g4realsurface` package causes *all* versions of the data to try to pull the *1.0* data, leading to a checksum failure:
```
==> Installing g4realsurface
==> Searching for binary cache of g4realsurface
==> Warning: No Spack mirrors are currently configured
==> No binary for g4realsurface found: installing from source
==> Fetching http://geant4-data.web.cern.ch/geant4-data/datasets/RealSurface.1.0.tar.gz
######################################################################## 100.0%
==> Error: ChecksumError: sha256 checksum failed for /projects/spack2/var/spack/stage/g4realsurface-2.1-rq2f5h57qev3imhdwlmfg346jz7uwfnz/RealSurface.1.0.tar.gz
    Expected 2a287adbda1c0292571edeae2082a65b7f7bd6cf2bf088432d1d6f889426dcf3 but got 3e2d2506600d2780ed903f1f2681962e208039329347c58ba1916740679020b1
```

Furthermore, a recent change to Spack means that installing data files to `os.path.basename(self.stage.source_path))` means that they all get installed to `share/data/spack-src` rather than (e.g.) `share/data/G4ABLA.3.1`