### PR TITLE
Fix py-matplotlib build (#12230)

### DIFF
--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -139,6 +139,8 @@ class PyMatplotlib(PythonPackage):
     def set_backend(self):
         """Set build options with regards to backend GUI libraries."""
 
+        backend = self.spec.variants['backend'].value
+
         with open('setup.cfg', 'w') as setup:
             # Default backend
             setup.write('[rc_options]\n')


### PR DESCRIPTION
Defines a missing variable needed to build py-matplotlib.