### PR TITLE
hpcviewer: update sha sums for version 2019.07

### DIFF
--- a/var/spack/repos/builtin/packages/hpcviewer/package.py
+++ b/var/spack/repos/builtin/packages/hpcviewer/package.py
@@ -33,9 +33,9 @@ class Hpcviewer(Package):
     homepage = "http://hpctoolkit.org"
 
     viewer_sha = {
-        ('2019.07', 'x86_64'):  '3bc10354e02c4d4b9dfd2075395b380dda8e9436f5cb4c40e4d50fe4795d7270',
-        ('2019.07', 'ppc64'):   '28628890c3297754aed06b6ddcefb4f30a563854f28667288660444cfadde2a4',
-        ('2019.07', 'ppc64le'): 'bdc1ee69f938996cc795dcd012f1d0d46e7bd594175aad920d39a0a32590a0f9',
+        ('2019.07', 'x86_64'):  'e999781d6a7d178cb1db5b549650024fa9b19891e933bac8b0441d24e7bf015c',
+        ('2019.07', 'ppc64'):   '057ce0e2d6be5639639f762fb43b116fe31fb855745abaf4ea26bd281cffaab1',
+        ('2019.07', 'ppc64le'): '40d6928e0761568168f3ce34f3ed320916ea60bda830dd74513897ef77386b28',
         ('2019.04', 'x86_64'):  'c524498ef235171e298c8142b7e73b0a1f7c433f9c471fb692d31f0685e53aa4',
         ('2019.04', 'ppc64'):   'dc9daee886ba72c0615db909860ee1aed0979f12c0d113efbe721ddabdf55199',
         ('2019.04', 'ppc64le'): 'dddabccef156996d390653639096ad3e27b7384a5754f42084f50c4a50a9009b',
@@ -45,9 +45,9 @@ class Hpcviewer(Package):
     }
 
     trace_sha = {
-        ('2019.07', 'x86_64'):  'c69db0dd10bc861eb7c594cb1e5f32bf9e104d0858c4a3c075b58a446485f2bf',
-        ('2019.07', 'ppc64'):   '927c8a2443d4cec3725dab28879f7f1efbc337cdc3c0bb7536ec891daacb50ab',
-        ('2019.07', 'ppc64le'): '3b04244e254d9d11802321199c11c8799040f86389b520842af64fa73dfc58a8',
+        ('2019.07', 'x86_64'):  '267052cf742d12bbe900bc03bc7c47c8e1704fbaad0e1a3fc77b73dc506d5a68',
+        ('2019.07', 'ppc64'):   '5ae63d8e2f2edf5c3b982d3663311e4d55f9b378f512926b3ebadab27ba72e22',
+        ('2019.07', 'ppc64le'): 'c2883714cbafa5252432c52d1d32ab5f34554b33a9bad20dcd2c0632388fbee5',
         ('2019.04', 'x86_64'):  'f5f908c0e52c97a72af1af8519f4b191298fe52bd811dd06a051b68cd7bcce27',
         ('2019.04', 'ppc64'):   '221683c992e4fe2cd9079ad2ebb531d99d04a3cbb3a8860f795b276b1eaeab19',
         ('2019.04', 'ppc64le'): 'fe539c6a165a72bba6ea7bdb34a90d862d427c4d55095c97794d54e6dd9d3075',


### PR DESCRIPTION
We (Rice HPCToolkit) issued a re-release of hpcviewer 2019.07 due to
some serious bugs.

----------

I'd like to say, "Sorry, this won't happen again," but what are the
odds.  :-)