### PR TITLE
adios2: Fix backwards compatibility version logic for FindMPI

### DIFF
--- a/var/spack/repos/builtin/packages/adios2/cmake-update-findmpi.patch
+++ b/var/spack/repos/builtin/packages/adios2/cmake-update-findmpi.patch
@@ -596,7 +596,7 @@ index 6a874b3..8551821 100644
    endif()
  
 -  set_property(TARGET MPI::MPI_${LANG} PROPERTY INTERFACE_COMPILE_OPTIONS "${MPI_${LANG}_COMPILE_OPTIONS}")
-+  if(NOT CMAKE_VERSION VERSION_LESS 3.11)
++  if(NOT CMAKE_VERSION VERSION_LESS 3.12)
 +    # When this is consumed for compiling CUDA, use '-Xcompiler' to wrap '-pthread'.
 +    string(REPLACE "-pthread" "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler >-pthread"
 +      _MPI_${LANG}_COMPILE_OPTIONS "${MPI_${LANG}_COMPILE_OPTIONS}")


### PR DESCRIPTION
This addresses a specific issue with 3.11.x compatibility

https://github.com/ornladios/ADIOS2/pull/1654