### PR TITLE
Geant4 data packages: Set the install path name explicitly.

### DIFF
--- a/var/spack/repos/builtin/packages/g4abla/package.py
+++ b/var/spack/repos/builtin/packages/g4abla/package.py
@@ -5,7 +5,6 @@
 
 
 from spack import *
-import os
 
 
 class G4abla(Package):
@@ -13,13 +12,15 @@ class G4abla(Package):
     homepage = "http://geant4.web.cern.ch"
     url = "http://geant4-data.web.cern.ch/geant4-data/datasets/G4ABLA.3.0.tar.gz"
 
-    version('3.0', sha256='99fd4dcc9b4949778f14ed8364088e45fa4ff3148b3ea36f9f3103241d277014')
-    version('3.1', sha256='7698b052b58bf1b9886beacdbd6af607adc1e099fc730ab6b21cf7f090c027ed')
+    version(
+        '3.0', sha256='99fd4dcc9b4949778f14ed8364088e45fa4ff3148b3ea36f9f3103241d277014')
+    version(
+        '3.1', sha256='7698b052b58bf1b9886beacdbd6af607adc1e099fc730ab6b21cf7f090c027ed')
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
-        install_path = join_path(prefix.share, 'data',
-                                 os.path.basename(self.stage.source_path))
+        install_path = join_path(prefix.share, 'data', 'G4ABLA{0}'
+                                 .format(self.version))
         install_tree(self.stage.source_path, install_path)
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/g4emlow/package.py
+++ b/var/spack/repos/builtin/packages/g4emlow/package.py
@@ -5,7 +5,6 @@
 
 
 from spack import *
-import os
 
 
 class G4emlow(Package):
@@ -13,13 +12,15 @@ class G4emlow(Package):
     homepage = "http://geant4.web.cern.ch"
     url = "http://geant4-data.web.cern.ch/geant4-data/datasets/G4EMLOW.6.50.tar.gz"
 
-    version('6.50', sha256='c97be73fece5fb4f73c43e11c146b43f651c6991edd0edf8619c9452f8ab1236')
-    version('7.3', sha256='583aa7f34f67b09db7d566f904c54b21e95a9ac05b60e2bfb794efb569dba14e')
+    version(
+        '6.50', sha256='c97be73fece5fb4f73c43e11c146b43f651c6991edd0edf8619c9452f8ab1236')
+    version(
+        '7.3', sha256='583aa7f34f67b09db7d566f904c54b21e95a9ac05b60e2bfb794efb569dba14e')
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
-        install_path = join_path(prefix.share, 'data',
-                                 os.path.basename(self.stage.source_path))
+        install_path = join_path(prefix.share, 'data', 'G4EMLOW{0}'
+                                 .format(self.version))
         install_tree(self.stage.source_path, install_path)
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/g4ensdfstate/package.py
+++ b/var/spack/repos/builtin/packages/g4ensdfstate/package.py
@@ -5,7 +5,6 @@
 
 
 from spack import *
-import os
 
 
 class G4ensdfstate(Package):
@@ -18,8 +17,8 @@ class G4ensdfstate(Package):
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
-        install_path = join_path(prefix.share, 'data',
-                                 os.path.basename(self.stage.source_path))
+        install_path = join_path(prefix.share, 'data', 'G4ENSDFSTATE{0}'
+                                 .format(self.version))
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):

--- a/var/spack/repos/builtin/packages/g4ndl/package.py
+++ b/var/spack/repos/builtin/packages/g4ndl/package.py
@@ -5,7 +5,6 @@
 
 
 from spack import *
-import os
 
 
 class G4ndl(Package):
@@ -17,8 +16,8 @@ class G4ndl(Package):
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
-        install_path = join_path(prefix.share, 'data',
-                                 os.path.basename(self.stage.source_path))
+        install_path = join_path(prefix.share, 'data', 'G4NDL{0}'
+                                 .format(self.version))
         install_tree(self.stage.source_path, install_path)
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/g4neutronxs/package.py
+++ b/var/spack/repos/builtin/packages/g4neutronxs/package.py
@@ -5,7 +5,6 @@
 
 
 from spack import *
-import os
 
 
 class G4neutronxs(Package):
@@ -18,8 +17,8 @@ class G4neutronxs(Package):
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
-        install_path = join_path(prefix.share, 'data',
-                                 os.path.basename(self.stage.source_path))
+        install_path = join_path(prefix.share, 'data', 'G4NEUTRONXS{0}'
+                                 .format(self.version))
         install_tree(self.stage.source_path, install_path)
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/g4photonevaporation/package.py
+++ b/var/spack/repos/builtin/packages/g4photonevaporation/package.py
@@ -5,7 +5,6 @@
 
 
 from spack import *
-import os
 
 
 class G4photonevaporation(Package):
@@ -19,7 +18,8 @@ class G4photonevaporation(Package):
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
         install_path = join_path(prefix.share, 'data',
-                                 os.path.basename(self.stage.source_path))
+                                 'G4PhotonEvaporation{0}'
+                                 .format(self.version))
         install_tree(self.stage.source_path, install_path)
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/g4photonevaporation/package.py
+++ b/var/spack/repos/builtin/packages/g4photonevaporation/package.py
@@ -18,7 +18,7 @@ class G4photonevaporation(Package):
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
         install_path = join_path(prefix.share, 'data',
-                                 'G4PhotonEvaporation{0}'
+                                 'PhotonEvaporation{0}'
                                  .format(self.version))
         install_tree(self.stage.source_path, install_path)
 

--- a/var/spack/repos/builtin/packages/g4pii/package.py
+++ b/var/spack/repos/builtin/packages/g4pii/package.py
@@ -5,7 +5,6 @@
 
 
 from spack import *
-import os
 
 
 class G4pii(Package):
@@ -17,8 +16,8 @@ class G4pii(Package):
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
-        install_path = join_path(prefix.share, 'data',
-                                 os.path.basename(self.stage.source_path))
+        install_path = join_path(prefix.share, 'data', 'G4PII{0}'
+                                 .format(self.version))
         install_tree(self.stage.source_path, install_path)
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/g4radioactivedecay/package.py
+++ b/var/spack/repos/builtin/packages/g4radioactivedecay/package.py
@@ -17,8 +17,8 @@ class G4radioactivedecay(Package):
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
-        install_path = join_path(prefix.share, 'data', 'G4RadioactiveDecay{0}'
-                                 .format(self.prefix))
+        install_path = join_path(prefix.share, 'data', 'RadioactiveDecay{0}'
+                                 .format(self.version))
         install_tree(self.stage.source_path, install_path)
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/g4radioactivedecay/package.py
+++ b/var/spack/repos/builtin/packages/g4radioactivedecay/package.py
@@ -5,7 +5,6 @@
 
 
 from spack import *
-import os
 
 
 class G4radioactivedecay(Package):
@@ -18,8 +17,8 @@ class G4radioactivedecay(Package):
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
-        install_path = join_path(prefix.share, 'data',
-                                 os.path.basename(self.stage.source_path))
+        install_path = join_path(prefix.share, 'data', 'G4RadioactiveDecay{0}'
+                                 .format(self.prefix))
         install_tree(self.stage.source_path, install_path)
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/g4realsurface/package.py
+++ b/var/spack/repos/builtin/packages/g4realsurface/package.py
@@ -18,9 +18,8 @@ class G4realsurface(Package):
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
-        install_path = join_path(prefix.share, 'data', '{0}RealSurface{1}'
-                                 .format("G4" if self.version > Version('1.0')
-                                         else "", self.version))
+        install_path = join_path(prefix.share, 'data', 'RealSurface{0}'
+                                 .format(self.version))
         install_tree(self.stage.source_path, install_path)
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/g4realsurface/package.py
+++ b/var/spack/repos/builtin/packages/g4realsurface/package.py
@@ -5,7 +5,6 @@
 
 
 from spack import *
-import os
 
 
 class G4realsurface(Package):
@@ -19,10 +18,12 @@ class G4realsurface(Package):
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
-        install_path = join_path(prefix.share, 'data',
-                                 os.path.basename(self.stage.source_path))
+        install_path = join_path(prefix.share, 'data', '{0}RealSurface{1}'
+                                 .format("G4" if self.version > Version('1.0')
+                                         else "", self.version))
         install_tree(self.stage.source_path, install_path)
 
     def url_for_version(self, version):
         """Handle version string."""
-        return ("http://geant4-data.web.cern.ch/geant4-data/datasets/RealSurface.1.0.tar.gz" % version)
+        return "http://geant4-data.web.cern.ch/geant4-data/datasets/{0}RealSurface.{1}.tar.gz".format(
+            "G4" if version > Version('1.0') else "", version)

--- a/var/spack/repos/builtin/packages/g4saiddata/package.py
+++ b/var/spack/repos/builtin/packages/g4saiddata/package.py
@@ -5,7 +5,6 @@
 
 
 from spack import *
-import os
 
 
 class G4saiddata(Package):
@@ -17,8 +16,8 @@ class G4saiddata(Package):
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
-        install_path = join_path(prefix.share, 'data',
-                                 os.path.basename(self.stage.source_path))
+        install_path = join_path(prefix.share, 'data', 'G4SAIDDATA{0}'
+                                 .format(self.version))
         install_tree(self.stage.source_path, install_path)
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/g4tendl/package.py
+++ b/var/spack/repos/builtin/packages/g4tendl/package.py
@@ -5,7 +5,6 @@
 
 
 from spack import *
-import os
 
 
 class G4tendl(Package):
@@ -18,8 +17,8 @@ class G4tendl(Package):
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
-        install_path = join_path(prefix.share, 'data',
-                                 os.path.basename(self.stage.source_path))
+        install_path = join_path(prefix.share, 'data', "G4TENDL{0}"
+                                 .format(self.version))
         install_tree(self.stage.source_path, install_path)
 
     def url_for_version(self, version):


### PR DESCRIPTION
Previously I had relied on the using the extracted directory name. This was changed with https://github.com/spack/spack/commit/16530f84be04b8466769b9b74fe920d67006b988
Now the install directory paths are explicitly names.