### PR TITLE
packages: Add autotools dependencies to bolt

### DIFF
--- a/var/spack/repos/builtin/packages/bolt/package.py
+++ b/var/spack/repos/builtin/packages/bolt/package.py
@@ -22,6 +22,10 @@ class Bolt(CMakePackage):
 
     version("1.0b1", "df76beb3a7f13ae2dcaf9ab099eea87b")
 
+    depends_on('autoconf', type='build')
+    depends_on('automake', type='build')
+    depends_on('libtool', type='build')
+
     def cmake_args(self):
         options = [
             '-DLIBOMP_USE_ITT_NOTIFY=off',


### PR DESCRIPTION
Fixes #12060 (per wspear).

This change is needed for minimal container environments.