### PR TITLE
ginkgo: fix branch -> commit for @1.0.0. Also add variant: develtools

### DIFF
--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -17,11 +17,12 @@ class Ginkgo(CMakePackage, CudaPackage):
 
     version('develop', branch='develop')
     version('master', branch='master')
-    version('1.0.0', branch='v1.0.0')
+    version('1.0.0', commit='4524464')  # v1.0.0
 
     variant('shared', default=True, description='Build shared libraries')
     variant('full_optimizations', default=False, description='Compile with all optimizations')
     variant('openmp', default=sys.platform != 'darwin',  description='Build with OpenMP')
+    variant('develtools', default=False, description='Compile with develtools enabled')
     variant('build_type', default='Release',
             description='The build type to build',
             values=('Debug', 'Release'))
@@ -37,6 +38,8 @@ class Ginkgo(CMakePackage, CudaPackage):
             '-DBUILD_SHARED_LIBS=%s' % ('ON' if '+shared' in spec else 'OFF'),
             '-DGINKGO_JACOBI_FULL_OPTIMIZATIONS=%s' % (
                 'ON' if '+full_optimizations' in spec else 'OFF'),
+            '-DGINKGO_DEVEL_TOOLS=%s' % (
+                'ON' if '+develtools' in spec else 'OFF'),
             # As we are not exposing benchmarks, examples, tests nor doc
             # as part of the installation, disable building them altogether.
             '-DGINKGO_BUILD_BENCHMARKS=OFF',


### PR DESCRIPTION
This fixes error with multiple builds - when they use the cached tarball.

cc: @tcojean
