### PR TITLE
Add py-pyasn1 0.4.6

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyasn1/package.py
+++ b/var/spack/repos/builtin/packages/py-pyasn1/package.py
@@ -8,11 +8,14 @@ from spack import *
 
 
 class PyPyasn1(PythonPackage):
-    """ Generic ASN.1 library for Python http://pyasn1.sf.net"""
+    """Pure-Python implementation of ASN.1 types and DER/BER/CER codecs
+    (X.208)."""
 
     homepage = "https://github.com/etingof/pyasn1"
-    url      = "https://pypi.io/packages/source/p/pyasn1/pyasn1-0.2.3.tar.gz"
+    url      = "https://pypi.io/packages/source/p/pyasn1/pyasn1-0.4.6.tar.gz"
 
+    version('0.4.6', sha256='b773d5c9196ffbc3a1e13bdf909d446cad80a039aa3340bcad72f395b76ebc86')
     version('0.2.3', '79f98135071c8dd5c37b6c923c51be45')
-    depends_on('py-setuptools',    type='build')
+
     depends_on('python@2.4:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')


### PR DESCRIPTION
Successfully installed on macOS 10.14.5 with Clang 10.0.1.