### PR TITLE
Fix typo in config

### DIFF
--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -419,7 +419,7 @@ a ``packages.yaml`` file) could contain:
      ...
      packages:
        all:
-         compilers: [intel]
+         compiler: [intel]
      ...
 
 This configuration sets the default compiler for all packages to


### PR DESCRIPTION
Using `compilers:` with the "s" is an invalid config section and throws an error.

```python-traceback
Traceback (most recent call last):
  File "spack/bin/spack", line 48, in <module>
    sys.exit(spack.main.main())
  File "/home/omsai/src/libkmap/spack/lib/spack/spack/main.py", line 633, in main
    env = ev.find_environment(args)
  File "/home/omsai/src/libkmap/spack/lib/spack/spack/environment.py", line 263, in find_environment
    return Environment(env)
  File "/home/omsai/src/libkmap/spack/lib/spack/spack/environment.py", line 534, in __init__
    self._read_manifest(f)
  File "/home/omsai/src/libkmap/spack/lib/spack/spack/environment.py", line 561, in _read_manifest
    self.yaml = _read_yaml(f)
  File "/home/omsai/src/libkmap/spack/lib/spack/spack/environment.py", line 402, in _read_yaml
    validate(data, filename)
  File "/home/omsai/src/libkmap/spack/lib/spack/spack/environment.py", line 395, in validate
    e, data, filename, e.instance.lc.line + 1)
spack.config.ConfigFormatError: /home/omsai/src/libkmap/spack.yaml:15: Additional properties are not allowed ('compilers' was unexpected)
```