### PR TITLE
ncurses: fix pic and opt flags

### DIFF
--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -36,10 +36,14 @@ class Ncurses(AutotoolsPackage):
     def setup_environment(self, spack_env, run_env):
         spack_env.unset('TERMINFO')
 
+    def flag_handler(self, name, flags):
+        if name == 'cflags' or name == 'cxxflags':
+            flags.append(self.compiler.pic_flag)
+
+        return (flags, None, None)
+
     def configure(self, spec, prefix):
         opts = [
-            'CFLAGS={0}'.format(self.compiler.pic_flag),
-            'CXXFLAGS={0}'.format(self.compiler.pic_flag),
             '--with-shared',
             '--with-cxx-shared',
             '--enable-overwrite',


### PR DESCRIPTION
Resolves #11932.

Move the PIC flags from CFLAGS on the configure line to the spack
compiler wrapper for ncurses.  The problem with the configure line for
autotools is that specifying CFLAGS sets the entire flags, thus
deleting the flags that configure would add itself.

By default, if CFLAGS is unspecified, then configure picks a sensible
default of `-g -O2`.  But adding `-fPIC` erases these and it ends up
building unoptimized.

----------

This patch is a simple and safe way of fixing the problem of building
ncurses unoptimized.  But this brings up two larger issues that affect
autotools in general.

(1) Autotools was designed to pass compiler flags via CFLAGS and
CXXFLAGS on the configure line.  You can either set these yourself, or
else leave them unspecified and then configure selects sensible
defaults, normally `-g -O2`.

The problem is that if you specify **any** flag, then configure uses
those as the entire flags.  This erases the `-O2` flag and builds the
package unoptimized, unless you add it yourself.  You have to do
things like setting `CFLAGS='-fPIC -g -O2'` to keep `-O2`.

Cmake has an easier time of this because every cmake package has a
`build_type` variant which is orthogonal to the opt flags.

(2) The `--with-shared` and `--with-cxx-shared` options tell configure
to build shared libraries and libtool already adds the PIC flag.
(Run `spack -d install` and you see that `-fPIC` is added twice.)

So, adding `-fPIC` should not be necessary at all, and certainly
that's true for the latest ncurses and GNU.  But there are reports
#3135 that libtool has trouble with the PGI compiler, at least for
older libtool.

I suspect that whatever problems there were have long since been
fixed.  Either that or libtool is fundamentally broken for PGI, which
I find hard to believe.

This deserves further study, but we'll keep the `-fPIC` for now.  The
last thing I want to do is break someone else's use case.