### PR TITLE
bugfix for -p,--prompt switch to `spack env activate`

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -17,7 +17,6 @@ from ordereddict_backport import OrderedDict
 
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
-from llnl.util.tty.color import colorize
 
 import spack.error
 import spack.hash_types as ht
@@ -142,18 +141,17 @@ def activate(
             cmds += 'set prompt="%s ${prompt}";\n' % prompt
     else:
         if os.getenv('TERM') and 'color' in os.getenv('TERM') and prompt:
-            prompt = colorize('@G{%s} ' % prompt, color=True)
+            prompt = r"\[\033[0;92m\]{}\[\033[0m\]".format(prompt)
 
         cmds += 'export SPACK_ENV=%s;\n' % env.path
         cmds += "alias despacktivate='spack env deactivate';\n"
         if prompt:
-            cmds += 'if [ -z ${SPACK_OLD_PS1+x} ]; then\n'
-            cmds += '    if [ -z ${PS1+x} ]; then\n'
-            cmds += "        PS1='$$$$';\n"
-            cmds += '    fi;\n'
+            cmds += 'if [ -z "${SPACK_OLD_PS1}" ]; then\n'
             cmds += '    export SPACK_OLD_PS1="${PS1}";\n'
+            cmds += 'else\n'
+            cmds += '    export PS1="${SPACK_OLD_PS1}";\n'
             cmds += 'fi;\n'
-            cmds += 'export PS1="%s ${PS1}";\n' % prompt
+            cmds += 'export PS1="{0} $PS1";\n'.format(prompt)
 
     if add_view and default_view_name in env.views:
         cmds += env.add_default_view_to_shell(shell)


### PR DESCRIPTION
This fixes a couple issues with the `-p,--prompt` option passed to `spack env activate`. 

* The escape sequences used to color+tag the Bash prompt with the name of the active Spack environment need to be enclosed in escaped square brackets. This is a special requirement when ANSI escape sequences are used to modify PS1, ensuring that the character count of the prompt  is accurate. 

* Invocation of `spack env activate -p <env>` when inside an already active Spack environment also activated with the `-p` switch led to problems like below:
   - `$> spack env activate -p env1`
   - `[env1] $> spack env activate -p env2`
   - `[env2] [env1] $>`