### PR TITLE
fltk: fix about variable types

### DIFF
--- a/var/spack/repos/builtin/packages/fltk/fix_compare_val.patch
+++ b/var/spack/repos/builtin/packages/fltk/fix_compare_val.patch
@@ -1,0 +1,11 @@
+--- fltk-1.3.3/src/Fl_Tree_Item.cxx	2014-09-05 11:59:00.000000000 +0900
++++ fltk-1.3.3/src/Fl_Tree_Item_b.cxx	2019-08-05 19:10:28.620960943 +0900
+@@ -549,7 +549,7 @@
+   } else {					// different parent?
+     if ( to > to_parent->children() )		// try to prevent a reparent() error
+       return -4;
+-    if ( from_parent->deparent(from) < 0 )	// deparent self from current parent
++    if ( from_parent->deparent(from) == NULL )	// deparent self from current parent
+       return -5;
+     if ( to_parent->reparent(this, to) < 0 ) {	// reparent self to new parent at position 'to'
+       to_parent->reparent(this, 0);		// failed? shouldn't happen, reparent at 0

--- a/var/spack/repos/builtin/packages/fltk/package.py
+++ b/var/spack/repos/builtin/packages/fltk/package.py
@@ -29,11 +29,11 @@ class Fltk(Package):
 
     # https://github.com/fltk/fltk/commits/master/src/Fl_Tree_Item.cxx
     #  -Fix return value test, as pointed out by Albrecht.
-    patch('fix_compare_val.patch',when='@:1.3.3')
+    patch('fix_compare_val.patch', when='@:1.3.3')
     # https://github.com/fltk/fltk/commits/master/test/menubar.cxx
     # -Allow compilation with -std=c++11
-    # -Add missing cast (part of patch for STR #2813). 
-    patch('type_cast.patch',when='@:1.3.3')
+    # -Add missing cast (part of patch for STR #2813).
+    patch('type_cast.patch', when='@:1.3.3')
 
     variant('shared', default=True,
             description='Enables the build of shared libraries')

--- a/var/spack/repos/builtin/packages/fltk/package.py
+++ b/var/spack/repos/builtin/packages/fltk/package.py
@@ -27,6 +27,14 @@ class Fltk(Package):
 
     patch('font.patch', when='@1.3.3')
 
+    # https://github.com/fltk/fltk/commits/master/src/Fl_Tree_Item.cxx
+    #  -Fix return value test, as pointed out by Albrecht.
+    patch('fix_compare_val.patch',when='@:1.3.3')
+    # https://github.com/fltk/fltk/commits/master/test/menubar.cxx
+    # -Allow compilation with -std=c++11
+    # -Add missing cast (part of patch for STR #2813). 
+    patch('type_cast.patch',when='@:1.3.3')
+
     variant('shared', default=True,
             description='Enables the build of shared libraries')
 

--- a/var/spack/repos/builtin/packages/fltk/type_cast.patch
+++ b/var/spack/repos/builtin/packages/fltk/type_cast.patch
@@ -1,0 +1,17 @@
+--- fltk-1.3.3/test/menubar.cxx	2012-02-18 17:29:30.000000000 +0900
++++ fltk-1.3.3/test/menubar_b.cxx	2019-08-06 14:16:55.733089438 +0900
+@@ -127,10 +127,10 @@
+     {"Italic",	0, 0, 0, 0, 0, FL_ITALIC, 14},
+     {"BoldItalic",0,0,0, 0, 0, FL_BOLD+FL_ITALIC, 14},
+     {"Small",	0, 0, 0, 0, 0, FL_BOLD+FL_ITALIC, 10},
+-    {"Emboss",	0, 0, 0, 0, FL_EMBOSSED_LABEL},
+-    {"Engrave",	0, 0, 0, 0, FL_ENGRAVED_LABEL},
+-    {"Shadow",	0, 0, 0, 0, FL_SHADOW_LABEL},
+-    {"@->",	0, 0, 0, 0, FL_SYMBOL_LABEL},
++    {"Emboss",	0, 0, 0, 0, (uchar)FL_EMBOSSED_LABEL},
++    {"Engrave",	0, 0, 0, 0, (uchar)FL_ENGRAVED_LABEL},
++    {"Shadow",	0, 0, 0, 0, (uchar)FL_SHADOW_LABEL},
++    {"@->",	0, 0, 0, 0, (uchar)FL_SYMBOL_LABEL},
+     {0},
+   {"&International",0,0,0,FL_SUBMENU},
+     {"Sharp Ess",0x0000df},


### PR DESCRIPTION
Modifications to eliminate errors caused by variable type differences.

Referenced:
https://github.com/fltk/fltk/commits/master/src/Fl_Tree_Item.cxx
　-Fix return value test, as pointed out by Albrecht.
https://github.com/fltk/fltk/commits/master/test/menubar.cxx
　-Allow compilation with -std=c++11
　-Add missing cast (part of patch for STR #2813).