### PR TITLE
Avoid sending empty reports to codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -200,9 +200,11 @@ after_success:
   - ccache -s
   - case "$TEST_SUITE" in
         unit)
-            codecov --env PYTHON_VERSION
-                    --required
-                    --flags "${TEST_SUITE}${TRAVIS_OS_NAME}";
+            if [[ "$COVERAGE" == "true" ]]; then
+                codecov --env PYTHON_VERSION
+                        --required
+                        --flags "${TEST_SUITE}${TRAVIS_OS_NAME}";
+            fi
             ;;
     esac
 


### PR DESCRIPTION
Before this commit we were sending reports also for unit tests that were not collecting coverage data.