### PR TITLE
singularity: update version to 3.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/singularity/package.py
+++ b/var/spack/repos/builtin/packages/singularity/package.py
@@ -137,7 +137,8 @@ class Singularity(MakefilePackage):
         tty.warn("""
         For full functionality, you'll need to chown and chmod some files
         after installing the package.  This has security implications.
-        See: https://singularity.lbl.gov/docs-security for details.
+        See: https://sylabs.io/guides/3.2/admin-guide/admin_quickstart.html#singularity-security
+        for details.
 
         We've installed a script that will make the necessary changes;
         read through it and then execute it as root (e.g. via sudo).

--- a/var/spack/repos/builtin/packages/singularity/package.py
+++ b/var/spack/repos/builtin/packages/singularity/package.py
@@ -137,8 +137,9 @@ class Singularity(MakefilePackage):
         tty.warn("""
         For full functionality, you'll need to chown and chmod some files
         after installing the package.  This has security implications.
-        See: https://sylabs.io/guides/3.2/admin-guide/admin_quickstart.html#singularity-security
-        for details.
+        For details, see: 
+        https://sylabs.io/guides/2.6/admin-guide/security.html
+        https://sylabs.io/guides/3.2/admin-guide/admin_quickstart.html#singularity-security
 
         We've installed a script that will make the necessary changes;
         read through it and then execute it as root (e.g. via sudo).

--- a/var/spack/repos/builtin/packages/singularity/package.py
+++ b/var/spack/repos/builtin/packages/singularity/package.py
@@ -137,7 +137,7 @@ class Singularity(MakefilePackage):
         tty.warn("""
         For full functionality, you'll need to chown and chmod some files
         after installing the package.  This has security implications.
-        For details, see: 
+        For details, see:
         https://sylabs.io/guides/2.6/admin-guide/security.html
         https://sylabs.io/guides/3.2/admin-guide/admin_quickstart.html#singularity-security
 

--- a/var/spack/repos/builtin/packages/singularity/package.py
+++ b/var/spack/repos/builtin/packages/singularity/package.py
@@ -17,7 +17,7 @@ class Singularity(MakefilePackage):
        which has a different install base (Autotools).
 
        Needs post-install chmod/chown steps to enable full functionality.
-       See package definition for details.
+       See package definition or `spack-build-out.txt` build log for details.
     '''
 
     homepage = "https://www.sylabs.io/singularity/"

--- a/var/spack/repos/builtin/packages/singularity/package.py
+++ b/var/spack/repos/builtin/packages/singularity/package.py
@@ -35,6 +35,9 @@ class Singularity(MakefilePackage):
     depends_on('squashfs', type='run')
     depends_on('git', when='@develop')  # mconfig uses it for version info
 
+    # TODO: add dependency to support fakeroot option, for example:
+    # depends_on('shadow-uidmap', type='run', when='@3.3:')
+
     # Go has novel ideas about how projects should be organized.
     # We'll point GOPATH at the stage dir, and move the unpacked src
     # tree into the proper subdir in our overridden do_stage below.

--- a/var/spack/repos/builtin/packages/singularity/package.py
+++ b/var/spack/repos/builtin/packages/singularity/package.py
@@ -25,6 +25,7 @@ class Singularity(MakefilePackage):
     git      = "https://github.com/sylabs/singularity.git"
 
     version('develop', branch='master')
+    version('3.3.0', sha256='070530a472e7e78492f1f142c8d4b77c64de4626c4973b0589f0d18e1fcf5b4f')
     version('3.2.1', sha256='d4388fb5f7e0083f0c344354c9ad3b5b823e2f3f27980e56efa7785140c9b616')
     version('3.1.1', '158f58a79db5337e1d655ee0159b641e42ea7435')
 


### PR DESCRIPTION
Tested successfully on linux-centos7-x86_64 / gcc@4.8.5

I added what I hope is a slightly more helpful note, referring folks to the build log (where the fully instantiated post-install instructions wind up) rather than just the package definition.

URL for security implications updated per admonition banner at https://singularity.lbl.gov/docs-security
