### PR TITLE
julia: new version and work on arm

### DIFF
--- a/var/spack/repos/builtin/packages/julia/armgcc.patch
+++ b/var/spack/repos/builtin/packages/julia/armgcc.patch
@@ -1,0 +1,42 @@
+diff -ru spack-src/src/ccalltest.c spack-src.new/src/ccalltest.c
+--- spack-src/src/ccalltest.c	2019-08-01 14:58:12.092094781 +0900
++++ spack-src.new/src/ccalltest.c	2019-08-01 14:57:53.242092475 +0900
+@@ -817,6 +817,7 @@
+     return x;
+ }
+ 
++#if defined(__GNUC__) && (__GNUC__ >= 6)
+ typedef struct {
+     __fp16 v1;
+     double v2;
+@@ -833,6 +834,7 @@
+     struct_aa64_2 x = {v4 / 2 + 1, v1 * 2 + v2 * 4 - v3};
+     return x;
+ }
++#endif
+ 
+ #include <arm_neon.h>
+
+diff -ru spack-src/src/test/ccall.jl spack-src.new/src/test/ccall.jl
+--- spack-src/test/ccall.jl	2019-05-16 13:13:14.000000000 +0900
++++ spack-src.new/test/ccall.jl	2019-08-02 15:24:47.632241893 +0900
+@@ -1130,19 +1130,6 @@
+         expected = Struct_AA64_1(v1 ÷ 2 + 1 - v3_1, v2 * 2 - 1 - v3_2)
+         @test res === expected
+     end
+-    for v1 in 1:4, v2 in -4:-1, v3 in 3:5, v4 in -(1:3)
+-        res = ccall((:test_aa64_fp16_1, libccalltest), Float16,
+-                    (Cint, Float32, Float64, Float16),
+-                    v1, v2, v3, v4)
+-        expected = Float16(v1 + v2 * 2 + v3 * 3 + v4 * 4)
+-        @test res === expected
+-
+-        res = ccall((:test_aa64_fp16_2, libccalltest), Struct_AA64_2,
+-                    (Cint, Float32, Float64, Float16),
+-                    v1, v2, v3, v4)
+-        expected = Struct_AA64_2(v4 / 2 + 1, v1 * 2 + v2 * 4 - v3)
+-        @test res === expected
+-    end
+     for v1_1 in 1:4, v1_2 in -2:2, v2 in -4:-1, v3_1 in 3:5, v3_2 in 6:8
+         res = ccall((:test_aa64_vec_1, libccalltest),
+                     VecReg{2,Int64},

--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -17,6 +17,8 @@ class Julia(Package):
     git      = "https://github.com/JuliaLang/julia.git"
 
     version('master', branch='master')
+    version('1.1.1',  sha256='3c5395dd3419ebb82d57bcc49dc729df3b225b9094e74376f8c649ee35ed79c2')
+    version('1.0.0', sha256='1a2497977b1d43bb821a5b7475b4054b29938baae8170881c6b8dd4099d133f1')
     version('0.6.2', '255d80bc8d56d5f059fe18f0798e32f6')
     version('release-0.5', branch='release-0.5')
     version('0.5.2', '8c3fff150a6f96cf0536fb3b4eaa5cbb')
@@ -40,6 +42,7 @@ class Julia(Package):
 
     patch('gc.patch', when='@0.4:0.4.5')
     patch('openblas.patch', when='@0.4:0.4.5')
+    patch('armgcc.patch', when='@1.0.0:1.1.1 %gcc@:5.9 target=aarch64')
 
     variant('binutils', default=sys.platform != 'darwin',
             description="Build via binutils")
@@ -97,6 +100,8 @@ class Julia(Package):
     depends_on("mpi", when="+mpi", type="run")
     depends_on("py-matplotlib", when="+plot", type="run")
 
+    conflicts("@:0.7.0", when="target=aarch64")
+
     def install(self, spec, prefix):
         # Julia needs git tags
         if os.path.isfile(".git/shallow"):
@@ -126,6 +131,10 @@ class Julia(Package):
                 "BUILD_LLVM_CLANG=1",
                 "LLVM_ASSERTIONS=1",
                 "USE_LLVM_SHLIB=1"]
+        if spec.satisfies('target=aarch64'):
+            options += [
+                'JULIA_CPU_TARGET=generic',
+                'MARCH=armv8-a+crc']
         with open('Make.user', 'w') as f:
             f.write('\n'.join(options) + '\n')
         make()
@@ -149,18 +158,29 @@ class Julia(Package):
         mkdirp(pkgdir)
 
         # Configure Julia
-        with open(join_path(prefix, "etc", "julia", "juliarc.jl"),
+        if spec.satisfies('@master') or spec.satisfies("@0.7:"):
+            julia_config = 'startup.jl'
+            cache_path = 'DEPOT_PATH'
+            unshift = 'pushfirst!'
+        else:
+            julia_config = 'juliarc.jl'
+            cache_path = 'LOAD_CACHE_PATH'
+            unshift = 'unshift!'
+        with open(join_path(prefix, "etc", "julia", julia_config),
                   "a") as juliarc:
-            if "@master" in spec or "@release-0.5" in spec or "@0.5:" in spec:
+            if "@master" in spec or "@release-0.5" in spec or "@0.5" in spec:
                 # This is required for versions @0.5:
                 juliarc.write(
                     '# Point package manager to working certificates\n')
+                if spec.satisfies('@master') or spec.satisfies('@0,7'):
+                    juliarc.write('import LibGit2;')
                 juliarc.write('LibGit2.set_ssl_cert_locations("%s")\n' %
                               cacert_file)
                 juliarc.write('\n')
             juliarc.write('# Put compiler cache into a private directory\n')
-            juliarc.write('empty!(Base.LOAD_CACHE_PATH)\n')
-            juliarc.write('unshift!(Base.LOAD_CACHE_PATH, "%s")\n' % cachedir)
+            juliarc.write('empty!(Base.%s)\n' % cache_path)
+            juliarc.write('%s(Base.%s, "%s")\n' %
+                          (unshift, cache_path, cachedir))
             juliarc.write('\n')
             juliarc.write('# Put Julia packages into a private directory\n')
             juliarc.write('ENV["JULIA_PKGDIR"] = "%s"\n' % pkgdir)
@@ -168,22 +188,26 @@ class Julia(Package):
 
         # Install some commonly used packages
         julia = spec['julia'].command
-        julia("-e", 'Pkg.init(); Pkg.update()')
+        if spec.satisfies("@:0.7"):
+            julia("-e", 'Pkg.init(); Pkg.update()')
+            pkgstart = ''
+        else:
+            pkgstart = 'import Pkg;'
 
         # Install HDF5
         if "+hdf5" in spec:
-            with open(join_path(prefix, "etc", "julia", "juliarc.jl"),
+            with open(join_path(prefix, "etc", "julia", julia_config),
                       "a") as juliarc:
                 juliarc.write('# HDF5\n')
                 juliarc.write('push!(Libdl.DL_LOAD_PATH, "%s")\n' %
                               spec["hdf5"].prefix.lib)
                 juliarc.write('\n')
-            julia("-e", 'Pkg.add("HDF5"); using HDF5')
-            julia("-e", 'Pkg.add("JLD"); using JLD')
+            julia("-e", pkgstart + 'Pkg.add("HDF5"); using HDF5')
+            julia("-e", pkgstart + 'Pkg.add("JLD"); using JLD')
 
         # Install MPI
         if "+mpi" in spec:
-            with open(join_path(prefix, "etc", "julia", "juliarc.jl"),
+            with open(join_path(prefix, "etc", "julia", julia_config),
                       "a") as juliarc:
                 juliarc.write('# MPI\n')
                 juliarc.write('ENV["JULIA_MPI_C_COMPILER"] = "%s"\n' %
@@ -191,11 +215,11 @@ class Julia(Package):
                 juliarc.write('ENV["JULIA_MPI_Fortran_COMPILER"] = "%s"\n' %
                               join_path(spec["mpi"].prefix.bin, "mpifort"))
                 juliarc.write('\n')
-            julia("-e", 'Pkg.add("MPI"); using MPI')
+            julia("-e", pkgstart + 'Pkg.add("MPI"); using MPI')
 
         # Install Python
         if "+python" in spec or "+plot" in spec:
-            with open(join_path(prefix, "etc", "julia", "juliarc.jl"),
+            with open(join_path(prefix, "etc", "julia", julia_config),
                       "a") as juliarc:
                 juliarc.write('# Python\n')
                 juliarc.write('ENV["PYTHON"] = "%s"\n' % spec["python"].home)
@@ -203,15 +227,18 @@ class Julia(Package):
             # Python's OpenSSL package installer complains:
             # Error: PREFIX too long: 166 characters, but only 128 allowed
             # Error: post-link failed for: openssl-1.0.2g-0
-            julia("-e", 'Pkg.add("PyCall"); using PyCall')
+            julia("-e", pkgstart + 'Pkg.add("PyCall"); using PyCall')
 
         if "+plot" in spec:
-            julia("-e", 'Pkg.add("PyPlot"); using PyPlot')
-            julia("-e", 'Pkg.add("Colors"); using Colors')
+            julia("-e", pkgstart + 'Pkg.add("PyPlot"); using PyPlot')
+            julia("-e", pkgstart + 'Pkg.add("Colors"); using Colors')
             # These require maybe gtk and image-magick
-            julia("-e", 'Pkg.add("Plots"); using Plots')
-            julia("-e", 'Pkg.add("PlotRecipes"); using PlotRecipes')
-            julia("-e", 'Pkg.add("UnicodePlots"); using UnicodePlots')
+            julia("-e", pkgstart + 'Pkg.add("Plots"); using Plots')
+            julia("-e", pkgstart + 'Pkg.add("PlotRecipes"); using PlotRecipes')
+            julia(
+                "-e",
+                pkgstart + 'Pkg.add("UnicodePlots"); using UnicodePlots'
+            )
             julia("-e", """\
 using Plots
 using UnicodePlots
@@ -221,6 +248,6 @@ plot(x->sin(x)*cos(x), linspace(0, 2pi))
 
         # Install SIMD
         if "+simd" in spec:
-            julia("-e", 'Pkg.add("SIMD"); using SIMD')
+            julia("-e", pkgstart + 'Pkg.add("SIMD"); using SIMD')
 
-        julia("-e", 'Pkg.status()')
+        julia("-e", pkgstart + 'Pkg.status()')


### PR DESCRIPTION
* add version 1.0 and 1.1
     *  startup file and codes is changed. (#9278)
* change to work on arm
     *  remove fp16 code when gcc is old. (https://www.gnu.org/software/gcc/gcc-6/changes.html#aarch64)
     * to assemble crc32, add -marc=armv8-a+crc