### PR TITLE
New package: TexStudio

### DIFF
--- a/var/spack/repos/builtin/packages/poppler/package.py
+++ b/var/spack/repos/builtin/packages/poppler/package.py
@@ -74,6 +74,9 @@ class Poppler(CMakePackage):
             '-DENABLE_SPLASH=OFF',
             '-DWITH_NSS3=OFF',
         ]
+	    
+	# Install header files
+	args.append('-DENABLE_UNSTABLE_API_ABI_HEADERS=ON')
 
         if '+cms' in spec:
             args.append('-DENABLE_CMS=lcms2')

--- a/var/spack/repos/builtin/packages/poppler/package.py
+++ b/var/spack/repos/builtin/packages/poppler/package.py
@@ -12,7 +12,10 @@ class Poppler(CMakePackage):
     homepage = "https://poppler.freedesktop.org"
     url      = "https://poppler.freedesktop.org/poppler-0.77.0.tar.xz"
     list_url = "https://poppler.freedesktop.org/releases.html"
+    git      = "https://gitlab.freedesktop.org/poppler/poppler.git"
 
+    version('master', branch='master')
+    version('0.79.0', sha256='f985a4608fe592d2546d9d37d4182e502ff6b4c42f8db4be0a021a1c369528c8')
     version('0.77.0', sha256='7267eb4cbccd64a58244b8211603c1c1b6bf32c7f6a4ced2642865346102f36b')
     version('0.72.0', sha256='c1747eb8f26e9e753c4001ed951db2896edc1021b6d0f547a0bd2a27c30ada51')
     version('0.65.0', 'b9a0af02e43deb26265f130343e90d78')

--- a/var/spack/repos/builtin/packages/poppler/package.py
+++ b/var/spack/repos/builtin/packages/poppler/package.py
@@ -57,6 +57,11 @@ class Poppler(CMakePackage):
     depends_on('qt@5.0:',      when='@0.62.0:+qt')
     depends_on('qt@4.0:4.8.6', when='@:0.61.999+qt')
 
+    # Splash is unconditionally disabled. Unfortunately there's
+    # a small section of code in the QT5 wrappers that expects it
+    # to be present.
+    patch('poppler_page_splash.patch', when='@0.64.0: ^qt@5.0:')
+
     # Only needed to run `make test`
     resource(
         name='test',
@@ -74,9 +79,9 @@ class Poppler(CMakePackage):
             '-DENABLE_SPLASH=OFF',
             '-DWITH_NSS3=OFF',
         ]
-	    
-	# Install header files
-	args.append('-DENABLE_UNSTABLE_API_ABI_HEADERS=ON')
+
+        # Install header files
+        args.append('-DENABLE_UNSTABLE_API_ABI_HEADERS=ON')
 
         if '+cms' in spec:
             args.append('-DENABLE_CMS=lcms2')

--- a/var/spack/repos/builtin/packages/poppler/package.py
+++ b/var/spack/repos/builtin/packages/poppler/package.py
@@ -20,6 +20,7 @@ class Poppler(CMakePackage):
     version('0.72.0', sha256='c1747eb8f26e9e753c4001ed951db2896edc1021b6d0f547a0bd2a27c30ada51')
     version('0.65.0', 'b9a0af02e43deb26265f130343e90d78')
     version('0.64.0', 'f7f687ebb60004f8ad61994575018044')
+    version('0.61.1', sha256='1266096343f5163c1a585124e9a6d44474e1345de5cdfe55dc7b47357bcfcda9')
 
     variant('cms',      default=False, description='Use color management system')
     variant('cpp',      default=False, description='Compile poppler cpp wrapper')
@@ -27,7 +28,7 @@ class Poppler(CMakePackage):
     variant('gobject',  default=False, description='Generate GObject introspection')
     variant('libcurl',  default=False, description='Build libcurl based HTTP support')
     variant('openjpeg', default=False, description='Use libopenjpeg for JPX streams')
-    variant('qt5',      default=False, description='Compile poppler qt5 wrapper')
+    variant('qt',       default=False, description='Compile poppler qt wrapper')
     variant('zlib',     default=False, description='Build with zlib')
     variant('iconv',    default=False, description='Search for Iconv package')
     variant('jpeg',     default=False, description='Search for JPEG package')
@@ -45,13 +46,16 @@ class Poppler(CMakePackage):
     depends_on('gobject-introspection', when='+gobject')
     depends_on('curl', when='+libcurl')
     depends_on('openjpeg', when='+openjpeg')
-    depends_on('qt@5.0:5.999', when='+qt5')
+    depends_on('qt@4.0:', when='+qt')
     depends_on('zlib', when='+zlib')
     depends_on('cairo@1.10.0:', when='+glib')
     depends_on('libiconv', when='+iconv')
     depends_on('jpeg', when='+jpeg')
     depends_on('libpng', when='+png')
     depends_on('libtiff', when='+tiff')
+
+    depends_on('qt@5.0:',      when='@0.62.0:+qt')
+    depends_on('qt@4.0:4.8.6', when='@:0.61.999+qt')
 
     # Only needed to run `make test`
     resource(
@@ -109,9 +113,14 @@ class Poppler(CMakePackage):
         else:
             args.append('-DENABLE_LIBOPENJPEG=none')
 
-        if '+qt5' in spec:
+        if '+qt' in spec and spec.satisfies('^qt@4.0:4.8.6'):
+            args.append('-DENABLE_QT4=ON')
+            args.append('-DENABLE_QT5=OFF')
+        elif '+qt' in spec and spec.satisfies('^qt@5.0:'):
             args.append('-DENABLE_QT5=ON')
+            args.append('-DENABLE_QT4=OFF')
         else:
+            args.append('-DENABLE_QT4=OFF')
             args.append('-DENABLE_QT5=OFF')
 
         if '+zlib' in spec:

--- a/var/spack/repos/builtin/packages/poppler/poppler_page_splash.patch
+++ b/var/spack/repos/builtin/packages/poppler/poppler_page_splash.patch
@@ -1,0 +1,21 @@
+diff --git a/qt5/src/poppler-page.cc b/qt5/src/poppler-page.cc
+index c4d00a6..e72c26b 100644
+--- a/qt5/src/poppler-page.cc
++++ b/qt5/src/poppler-page.cc
+@@ -103,6 +103,8 @@ public:
+   QVariant payload;
+ };
+ 
++#if defined(HAVE_SPLASH)
++
+ class Qt5SplashOutputDev : public SplashOutputDev, public OutputDevCallbackHelper
+ {
+ public:
+@@ -170,6 +172,7 @@ private:
+   bool ignorePaperColor;
+ };
+ 
++#endif
+ 
+ class QImageDumpingArthurOutputDev : public ArthurOutputDev, public OutputDevCallbackHelper
+ {

--- a/var/spack/repos/builtin/packages/texstudio/package.py
+++ b/var/spack/repos/builtin/packages/texstudio/package.py
@@ -1,0 +1,42 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Texstudio(QMakePackage):
+    """TeXstudio is a fully featured LaTeX editor, whose goal is to make writing
+    LaTeX documents as easy and comfortable as possible."""
+
+    homepage = "http://www.texstudio.org"
+    url      = "https://github.com/texstudio-org/texstudio/archive/2.12.16.tar.gz"
+    git      = "https://github.com/texstudio-org/texstudio.git"
+
+    version('master', branch='master')
+    version('2.12.16', sha256='a14b8912bfd15d982cfbe5f00deed37ca85fb6e38d3aa0c2dac23b4ecaab0984')
+    version('2.12.14', sha256='61df71f368bbf21f865645534f63840fd48dbd2996d6d0188aa26d3b647fede0')
+    version('2.12.12', sha256='5978daa806c616f9a1eea231bb613f0bc1037d7d2435ee5ca6b14fe88a2caa8c')
+    version('2.12.10', sha256='92cf9cbb536e58a5929611fa40438cd9d7ea6880022cd3c5de0483fd15d3df0b')
+
+    variant('poppler', default=True, description='Compile with Poppler library for internal pdf preview')
+
+    # Base dependencies
+    depends_on('poppler+qt', when="+poppler")
+    # There is a known issue with QT 5.10
+    # See https://github.com/texstudio-org/texstudio/wiki/Compiling
+    depends_on('qt@4.4.4:5.9.999,5.11.0:')
+
+    def qmake_args(self):
+        args = ['PREFIX={0}'.format(self.prefix)]
+
+        if (self.spec.satisfies('+poppler')):
+            args.append('INCLUDEPATH+={0}'.format(
+                self.spec['poppler'].prefix.include))
+            args.append('LIBS+={0}'.format(
+                self.spec['poppler'].libs.search_flags))
+        else:
+            args.append('NO_POPPLER_PREVIEW=true')
+
+        return args


### PR DESCRIPTION
I also refactored the `Poppler` package to build with QT4. `TexStudio` expects `libpoppler-qt<version>` to be available when building against `poppler` (required for internal viewing of PDFs), so `^poppler+qt` is necessary. However, I couldn't get it to build with QT5, so trying QT4 seemed appropriate. I'll open an issue for the QT5 problem later.