### PR TITLE
hisea: build on ARM.

### DIFF
--- a/var/spack/repos/builtin/packages/hisea/package.py
+++ b/var/spack/repos/builtin/packages/hisea/package.py
@@ -19,6 +19,10 @@ class Hisea(MakefilePackage):
 
     depends_on('boost')
 
+    def patch(self):
+        if self.spec.satisfies("target=aarch64"):
+            filter_file('-mpopcnt', '', 'Makefile')
+
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
         install('hisea', prefix.bin)


### PR DESCRIPTION
hisea use -mpopcnt  compile options.
But these options is not support ARM.

This PR remove these options when target is ARM.