### PR TITLE
Add new releases of Cube Tools, Opari2, OTF2, and Score-P

### DIFF
--- a/var/spack/repos/builtin/packages/cube/package.py
+++ b/var/spack/repos/builtin/packages/cube/package.py
@@ -17,6 +17,7 @@ class Cube(AutotoolsPackage):
     homepage = "http://www.scalasca.org/software/cube-4.x/download.html"
     url      = "http://apps.fz-juelich.de/scalasca/releases/cube/4.4/dist/cubegui-4.4.2.tar.gz"
 
+    version('4.4.4', '9b7b96d5a64b558a9017cc3599bba93a42095534e018e3de9b1f80ab6d04cc34')
     version('4.4.3', 'bf4b0f2ff68507ff82ba24eb4895aed961710dae16d783c222a12f152440cf36')
     version('4.4.2', '29b6479616a524f8325f5031a883963bf965fb92569de33271a020f08650ec7b')
     version('4.4',   '0620bae3ac357d0486ce7f5f97e448eeb2494c9a31865b679380ee08c6750e70')

--- a/var/spack/repos/builtin/packages/cubelib/package.py
+++ b/var/spack/repos/builtin/packages/cubelib/package.py
@@ -12,6 +12,7 @@ class Cubelib(AutotoolsPackage):
     homepage = "http://www.scalasca.org/software/cube-4.x/download.html"
     url = "http://apps.fz-juelich.de/scalasca/releases/cube/4.4/dist/cubelib-4.4.tar.gz"
 
+    version('4.4.4', 'adb8216ee3b7701383884417374e7ff946edb30e56640307c65465187dca7512')
     version('4.4.3', 'bcd4fa81a5ba37194e590a5d7c3e6c44b448f5e156a175837b77c21206847a8d')
     version('4.4.2', '843335c7d238493f1b4cb8e07555ccfe99a3fa521bf162e9d8eaa6733aa1f949')
     version('4.4',   'c903f3c44d3228ebefd00c831966988e')

--- a/var/spack/repos/builtin/packages/cubew/package.py
+++ b/var/spack/repos/builtin/packages/cubew/package.py
@@ -12,6 +12,7 @@ class Cubew(AutotoolsPackage):
     homepage = "http://www.scalasca.org/software/cube-4.x/download.html"
     url = "http://apps.fz-juelich.de/scalasca/releases/cube/4.4/dist/cubew-4.4.tar.gz"
 
+    version('4.4.3', '93fff6cc1e8b0780f0171ef5302a2e1a257f99b6383fbfc1b9b82f925ceff501')
     version('4.4.2', '31a71e9a05e6523de2b86b4026821bbb75fb411eb5b18ae38b27c1f44158014a')
     version('4.4.1', 'c09e3f5a3533ebedee2cc7dfaacd7bac4680c14c3fa540669466583a23f04b67')
     version('4.4',   'e9beb140719c2ad3d971e1efb99e0916')

--- a/var/spack/repos/builtin/packages/opari2/package.py
+++ b/var/spack/repos/builtin/packages/opari2/package.py
@@ -20,6 +20,7 @@ class Opari2(AutotoolsPackage):
     homepage = "http://www.vi-hps.org/projects/score-p"
     url      = "https://www.vi-hps.org/cms/upload/packages/opari2/opari2-2.0.4.tar.gz"
 
+    version('2.0.5', '9034dd7596ac2176401090fd5ced45d0ab9a9404444ff767f093ccce68114ef5')
     version('2.0.4', 'f69e324792f66780b473daf2b3c81f58ee8188adc72b6fe0dacf43d4c1a0a131')
     version('2.0.3', 'f34674718ffdb098a48732a1eb9c1aa2')
     version('2.0.1', '74af78f1f27b8caaa4271e0b97fb0fba')

--- a/var/spack/repos/builtin/packages/otf2/package.py
+++ b/var/spack/repos/builtin/packages/otf2/package.py
@@ -15,6 +15,7 @@ class Otf2(AutotoolsPackage):
     homepage = "http://www.vi-hps.org/projects/score-p"
     url      = "https://www.vi-hps.org/cms/upload/packages/otf2/otf2-2.1.1.tar.gz"
 
+    version('2.2',   'd0519af93839dc778eddca2ce1447b1ee23002c41e60beac41ea7fe43117172d')
     version('2.1.1', 'e51ad0d8ca374d25f47426746ca629e7')
     version('2.1',   'e2994e53d9b7c2cbd0c4f564d638751e')
     version('2.0',   '5b546188b25bc1c4e285e06dddf75dfc')

--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -15,6 +15,7 @@ class Scorep(AutotoolsPackage):
     homepage = "http://www.vi-hps.org/projects/score-p"
     url      = "https://www.vi-hps.org/cms/upload/packages/scorep/scorep-4.1.tar.gz"
 
+    version('6.0',   '5dc1023eb766ba5407f0b5e0845ec786e0021f1da757da737db1fb71fc4236b8')
     version('5.0',   '0651614eacfc92ffbe5264a3efebd0803527ae6e8b11f7df99a56a02c37633e1')
     version('4.1',   '7bb6c1eecdd699b4a3207caf202866778ee01f15ff39a9ec198fcd872578fe63')
     version('4.0',   'f04478e0407d67eeb8c49c3c51d91e12')
@@ -35,6 +36,8 @@ class Scorep(AutotoolsPackage):
     # information. Starting with scorep 4.0 / cube 4.4, Score-P only depends on
     # two components of cube -- cubew and cubelib.
 
+    # SCOREP 6
+    depends_on('otf2@2.2:', when='@6:')
     # SCOREP 4 and 5
     depends_on('otf2@2.1:', when='@4:')
     depends_on('opari2@2.0:', when='@4:')


### PR DESCRIPTION
Adding the new releases of Cube Tools, OPARI2, OTF2 and Score-P, which were released on August 1 and July 31 respectively.