### PR TITLE
Enable compiler bootstrapping for single packages

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1534,14 +1534,12 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             dep_kwargs['install_deps'] = False
             for dep in self.spec.traverse(order='post', root=False):
                 if spack.config.get('config:install_missing_compilers', False):
-                    tty.debug('Bootstrapping {0} compiler for {1}'.format(
-                        self.spec.compiler, self.name
-                    ))
-                    comp_kwargs = kwargs.copy()
-                    comp_kwargs['explicit'] = False
-                    comp_kwargs['install_deps'] = True
-                    dep.package.bootstrap_compiler(**comp_kwargs)
+                    Package._install_bootstrap_compiler(dep.package, **kwargs)
                 dep.package.do_install(**dep_kwargs)
+
+        # Then, install the compiler if it is not already installed.
+        if install_deps:
+            Package._install_bootstrap_compiler(self, **kwargs)
 
         # Then, install the package proper
         tty.msg(colorize('@*{Installing} @*g{%s}' % self.name))
@@ -1704,6 +1702,16 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             # not created so that the next time self.stage is invoked, we
             # check the filesystem for it.
             self.stage.created = False
+
+    @staticmethod
+    def _install_bootstrap_compiler(pkg, **install_kwargs):
+        tty.debug('Bootstrapping {0} compiler for {1}'.format(
+            pkg.spec.compiler, pkg.name
+        ))
+        comp_kwargs = install_kwargs.copy()
+        comp_kwargs['explicit'] = False
+        comp_kwargs['install_deps'] = True
+        pkg.bootstrap_compiler(**comp_kwargs)
 
     def unit_test_check(self):
         """Hook for unit tests to assert things about package internals.


### PR DESCRIPTION
@becker33 

@scottwittenburg does this resolve the issue for you?

Fixes https://github.com/spack/spack/issues/12298

https://github.com/spack/spack/pull/11175 enabled installing compilers for dependencies but not for the root package (and in particular not for DAGs which consist of one package); this enables bootstrapping compilers for both types of DAGs