### PR TITLE
Fix typo in yaml config docs

### DIFF
--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -148,7 +148,7 @@ Here's an example ``packages.yaml`` file that sets preferred packages:
      gperftools:
        version: [2.2, 2.4, 2.3]
      all:
-       compiler: [gcc@4.4.7, gcc@4.6:, intel, clang, pgi]
+       compiler: [gcc@4.4.7, 'gcc@4.6:', intel, clang, pgi]
        providers:
          mpi: [mvapich2, mpich, openmpi]
 


### PR DESCRIPTION
Whenever a compiler or package spec contains a version range, the `:` messes up our YAML parsing with an error message like:
```
==> Error: Error parsing yaml  in "/u/sciteam/stewart1/.spack/packages.yaml", line 4, column 20: found unexpected ':'
```
The solution is to wrap that spec in quotes.