### PR TITLE
stacks: fix conditional dependencies

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1344,7 +1344,7 @@ def _concretize_from_constraints(spec_constraints):
                                    for d in invalid_msg.split()
                                    if d != 'or']
             invalid_deps = [c for c in spec_constraints
-                            if any(c.satisfies(invd)
+                            if any(c.satisfies(invd, strict=True)
                                    for invd in invalid_deps_string)]
             if len(invalid_deps) != len(invalid_deps_string):
                 raise e


### PR DESCRIPTION
Spack stacks drop invalid dependencies applied to packages by a spec_list matrix operation

Without this fix, Spack would raise an error if orthogonal dependency constraints and non-dependency constraints were applied to the same package by a matrix and the dependency constraint was invalid for that package. This is an error, fixed by this PR.

```
spack:
  definitions:
  - packages: [libelf, hdf5+mpi]
  - compilers: ['%gcc']
  - mpis: [^openmpi]

  specs:
  - matrix:
    - $packages
    - $compilers
    - $mpis
```