### PR TITLE
netcdf-cxx4: add m4 dep for call to autoreconf

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -25,6 +25,7 @@ class NetcdfCxx4(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('autoconf', type='build')
     depends_on('libtool', type='build')
+    depends_on('m4', type='build')
 
     force_autoreconf = True
 


### PR DESCRIPTION
Installing version 4.3.0 required calling `autoreconf` to create the `configure` script.  Without the `m4` dependency the following error is hit:
https://github.com/spack/spack/blob/b4862be875dee58187a670e08c4d79f2b49f8cb9/lib/spack/spack/build_systems/autotools.py#L184-L186

This PR adds the `m4` dependency.