### PR TITLE
compiler finding: preserve PATH precedence.

### DIFF
--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -512,9 +512,9 @@ def arguments_to_detect_version_fn(operating_system, paths):
                         )
                         command_arguments.append(detect_version_args)
 
-        # Reverse it here so that the dict creation (last insert wins)
-        # does not spoil the intended precedence.
-        return reversed(command_arguments)
+        # Don't reverse it here since we take the first result after
+        # grouping to not spoil the intended precedence.
+        return command_arguments
 
     fn = getattr(
         operating_system, 'arguments_to_detect_version_fn', _default


### PR DESCRIPTION
@alalazo we are having some problems with `spack compiler find` on a system with `/usr/lib64/ccache` in the path. The latter is preferred by Spack, even though the first entry in `$PATH` points to the correct location.

Reading through the code, [here](https://github.com/spack/spack/compare/develop...matz-e:compiler-finding?expand=1#diff-2704f79904cd8e67b76094c779924b79L599) we only take the first element, and don't override it later on. Dropping the `reversed` restores the priority as given in `$PATH`, which I think was the orginal intend?