### PR TITLE
Fix build for moab 4.9.2 on gcc8

### DIFF
--- a/var/spack/repos/builtin/packages/moab/package.py
+++ b/var/spack/repos/builtin/packages/moab/package.py
@@ -85,6 +85,8 @@ class Moab(AutotoolsPackage):
     # FIXME it seems that zoltan needs to be built without fortran
     depends_on('zoltan~fortran', when='+zoltan')
 
+    patch('tools-492.patch', when='@4.9.2')
+
     def configure_args(self):
         spec = self.spec
 

--- a/var/spack/repos/builtin/packages/moab/tools-492.patch
+++ b/var/spack/repos/builtin/packages/moab/tools-492.patch
@@ -1,0 +1,11 @@
+--- a/tools/mbpart.cpp	2019-03-22 10:10:23.242049300 -0400
++++ b/tools/mbpart.cpp	2019-03-22 10:10:26.354738990 -0400
+@@ -491,7 +491,7 @@
+       rval = mb.write_file(tmp_output_file.str().c_str());
+       if (MB_SUCCESS != rval)
+       {
+-        std::cerr << tmp_output_file << " : failed to write file." << std::endl;
++        std::cerr << tmp_output_file.str() << " : failed to write file." << std::endl;
+         std::cerr << "  Error code: " << mb.get_error_string(rval) << " ("
+                   << rval << ")" << std::endl;
+         std::string errstr;


### PR DESCRIPTION
Our code currently relies on an older version of Moab which has errors that cause it to fail compilation on GCC 8. This patches MOAB to allow it to compile.

```
5 errors found in build log:
     609      CXX      mbpart.o
     610      CXX      quality.o
     611      CXX      umr.o
     612      CXX      merge.o
     613      CXX      parread.o
     614    mbpart.cpp: In function 'int main(int, char**)':
  >> 615    mbpart.cpp:494:19: error: no match for 'operator<<' (operand types
            are 'std::ostream' {aka 'std::basic_ostream<char>'} and 'std::ostri
            ngstream' {aka 'std::__cxx11::basic_ostringstream<char>'})
     616             std::cerr << tmp_output_file << " : failed to write file."
             << std::endl;
     617             ~~~~~~~~~~^~~~~~~~~~~~~~~~~~
     618    mbpart.cpp:494:19: note: candidate: 'operator<<(int, int)' <built-i
            n>
     619    mbpart.cpp:494:19: note:   no known conversion for argument 2 from
            'std::ostringstream' {aka 'std::__cxx11::basic_ostringstream<char>'
            } to 'int'
     620    In file included from /software/user_tools/centos-7.2.1511/cades-ns
            ed-spack/opt/spack/linux-centos7-x86_64/gcc-4.8.5/gcc-8.2.0-uc6sbum
            ioobdbkw4rwfyn2givi4nyvwq/include/c++/8.2.0/iterator:64,
     621                     from /software/user_tools/centos-7.2.1511/cades-ns
            ed-spack/var/spack/stage/moab-4.9.2-77uuzmj4ofb7z7vz6m25sftyks7p5do
            7/spack-src/src/moab/Range.hpp:167,

     ...

     886    /software/user_tools/centos-7.2.1511/cades-nsed-spack/opt/spack/lin
            ux-centos7-x86_64/gcc-4.8.5/gcc-8.2.0-uc6sbumioobdbkw4rwfyn2givi4ny
            vwq/include/c++/8.2.0/ostream:682:5: note: candidate: 'template<cla
            ss _Ostream, class _Tp> typename std::enable_if<std::__and_<std::__
            not_<std::is_lvalue_reference<_Tp> >, std::__is_convertible_to_basi
            c_ostream<_Ostream>, std::__is_insertable<typename std::__is_conver
            tible_to_basic_ostream<_Tp>::__ostream_type, const _Tp&, void> >::v
            alue, typename std::__is_convertible_to_basic_ostream<_Tp>::__ostre
            am_type>::type std::operator<<(_Ostream&&, const _Tp&)'
     887         operator<<(_Ostream&& __os, const _Tp& __x)
     888         ^~~~~~~~
     889    /software/user_tools/centos-7.2.1511/cades-nsed-spack/opt/spack/lin
            ux-centos7-x86_64/gcc-4.8.5/gcc-8.2.0-uc6sbumioobdbkw4rwfyn2givi4ny
            vwq/include/c++/8.2.0/ostream:682:5: note:   template argument dedu
            ction/substitution failed:
     890    /software/user_tools/centos-7.2.1511/cades-nsed-spack/opt/spack/lin
            ux-centos7-x86_64/gcc-4.8.5/gcc-8.2.0-uc6sbumioobdbkw4rwfyn2givi4ny
            vwq/include/c++/8.2.0/ostream: In substitution of 'template<class _
            Ostream, class _Tp> typename std::enable_if<std::__and_<std::__not_
            <std::is_lvalue_reference<_Tp> >, std::__is_convertible_to_basic_os
            tream<_Ostream>, std::__is_insertable<typename std::__is_convertibl
            e_to_basic_ostream<_Tp>::__ostream_type, const _Tp&, void> >::value
            , typename std::__is_convertible_to_basic_ostream<_Tp>::__ostream_t
            ype>::type std::operator<<(_Ostream&&, const _Tp&) [with _Ostream =
             std::basic_ostream<char>&; _Tp = std::__cxx11::basic_ostringstream
            <char>]':
     891    mbpart.cpp:494:22:   required from here
  >> 892    /software/user_tools/centos-7.2.1511/cades-nsed-spack/opt/spack/lin
            ux-centos7-x86_64/gcc-4.8.5/gcc-8.2.0-uc6sbumioobdbkw4rwfyn2givi4ny
            vwq/include/c++/8.2.0/ostream:682:5: error: no type named 'type' in
             'struct std::enable_if<false, std::basic_ostream<char>&>'
     893      CXXLD    mbdepth
     894      CXXLD    hexmodops
  >> 895    make[2]: *** [mbpart.o] Error 1
     896    make[2]: *** Waiting for unfinished jobs....
     897    make[2]: Leaving directory `/localscratch/tmp/s3j-spack/spack-stage
            /spack-stage-NT13kT/spack-src/tools'
  >> 898    make[1]: *** [all-recursive] Error 1
     899    make[1]: Leaving directory `/localscratch/tmp/s3j-spack/spack-stage
            /spack-stage-NT13kT/spack-src/tools'
  >> 900    make: *** [all-recursive] Error 1
```