### PR TITLE
docs: fix compiler config

### DIFF
--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -591,11 +591,12 @@ flags to the ``icc`` command:
            operating_system: centos7
            paths:
              cc: /opt/intel-15.0.24/bin/icc-15.0.24-beta
-             cflags: -gcc-name ~/spack/opt/spack/linux-centos7-x86_64/gcc-4.9.3-iy4rw.../bin/gcc
              cxx: /opt/intel-15.0.24/bin/icpc-15.0.24-beta
-             cxxflags: -gxx-name ~/spack/opt/spack/linux-centos7-x86_64/gcc-4.9.3-iy4rw.../bin/g++
              f77: /opt/intel-15.0.24/bin/ifort-15.0.24-beta
              fc: /opt/intel-15.0.24/bin/ifort-15.0.24-beta
+           flags:
+             cflags: -gcc-name ~/spack/opt/spack/linux-centos7-x86_64/gcc-4.9.3-iy4rw.../bin/gcc
+             cxxflags: -gxx-name ~/spack/opt/spack/linux-centos7-x86_64/gcc-4.9.3-iy4rw.../bin/g++
              fflags: -gcc-name ~/spack/opt/spack/linux-centos7-x86_64/gcc-4.9.3-iy4rw.../bin/gcc
            spec: intel@15.0.24.4.9.3
 


### PR DESCRIPTION
It's no longer possible to parent compiler flags under paths:

```python-traceback
$ spack concretize -f
Traceback (most recent call last):
  File "/shared/admin/sw-src/rhel6/dynemol/18d7aa2/spack/bin/spack", line 48, in <module>
    sys.exit(spack.main.main())
  File "/shared/admin/sw-src/rhel6/dynemol/18d7aa2/spack/lib/spack/spack/main.py", line 633, in main
    env = ev.find_environment(args)
  File "/shared/admin/sw-src/rhel6/dynemol/18d7aa2/spack/lib/spack/spack/environment.py", line 263, in find_environment
    return Environment(env)
  File "/shared/admin/sw-src/rhel6/dynemol/18d7aa2/spack/lib/spack/spack/environment.py", line 534, in __init__
    self._read_manifest(f)
  File "/shared/admin/sw-src/rhel6/dynemol/18d7aa2/spack/lib/spack/spack/environment.py", line 561, in _read_manifest
    self.yaml = _read_yaml(f)
  File "/shared/admin/sw-src/rhel6/dynemol/18d7aa2/spack/lib/spack/spack/environment.py", line 402, in _read_yaml
    validate(data, filename)
  File "/shared/admin/sw-src/rhel6/dynemol/18d7aa2/spack/lib/spack/spack/environment.py", line 395, in validate
    e, data, filename, e.instance.lc.line + 1)
spack.config.ConfigFormatError: /shared/admin/sw-src/rhel6/dynemol/18d7aa2/spack.yaml:42: Additional properties are not allowed ('cflags' was unexpected)
```