### PR TITLE
Do not report on packages installed from the cache

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -493,6 +493,10 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         # Allow custom staging paths for packages
         self.path = None
 
+        # Keep track of whether or not this package was installed from
+        # a binary cache.
+        self.installed_from_binary_cache = False
+
         # Check versions in the versions dict.
         for v in self.versions:
             assert (isinstance(v, Version))
@@ -1420,6 +1424,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         binary_distribution.extract_tarball(
             binary_spec, tarball, allow_root=False,
             unsigned=False, force=False)
+        self.installed_from_binary_cache = True
         spack.store.db.add(
             self.spec, spack.store.layout, explicit=explicit)
         return True

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -126,7 +126,8 @@ class InfoCollector(object):
                     'id': pkg.spec.dag_hash(),
                     'elapsed_time': None,
                     'result': None,
-                    'message': None
+                    'message': None,
+                    'installed_from_binary_cache': False
                 }
 
                 start_time = time.time()
@@ -136,6 +137,8 @@ class InfoCollector(object):
                     value = do_install(pkg, *args, **kwargs)
                     package['result'] = 'success'
                     package['stdout'] = fetch_package_log(pkg)
+                    package['installed_from_binary_cache'] = \
+                        pkg.installed_from_binary_cache
                     if installed_on_entry:
                         return
 

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -221,6 +221,12 @@ class CDash(Reporter):
         # do not explicitly include the package's name in the CDash build name.
         num_packages = 0
         for spec in input_data['specs']:
+            # Do not generate reports for packages that were installed
+            # from the binary cache.
+            spec['packages'] = [
+                x for x in spec['packages']
+                if not x['installed_from_binary_cache']
+            ]
             for package in spec['packages']:
                 if 'stdout' in package:
                     num_packages += 1


### PR DESCRIPTION
Skip generating reports for any packages that were found in the binary cache.