### PR TITLE
bugfix: hunspell: add missing gettext dependency

### DIFF
--- a/var/spack/repos/builtin/packages/hunspell/package.py
+++ b/var/spack/repos/builtin/packages/hunspell/package.py
@@ -12,6 +12,7 @@ class Hunspell(AutotoolsPackage):
     homepage = "http://hunspell.github.io/"
     url      = "https://github.com/hunspell/hunspell/archive/v1.6.0.tar.gz"
 
+    version('1.7.0', sha256='57be4e03ae9dd62c3471f667a0d81a14513e314d4d92081292b90435944ff951')
     version('1.6.0', '047c3feb121261b76dc16cdb62f54483')
 
     depends_on('autoconf', type='build')

--- a/var/spack/repos/builtin/packages/hunspell/package.py
+++ b/var/spack/repos/builtin/packages/hunspell/package.py
@@ -18,6 +18,7 @@ class Hunspell(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
+    depends_on('gettext')
 
     # TODO: If https://github.com/spack/spack/pull/12344 is merged, this
     # method is unnecessary.

--- a/var/spack/repos/builtin/packages/hunspell/package.py
+++ b/var/spack/repos/builtin/packages/hunspell/package.py
@@ -18,3 +18,9 @@ class Hunspell(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
+
+    # TODO: If https://github.com/spack/spack/pull/12344 is merged, this
+    # method is unnecessary.
+    def autoreconf(self, spec, prefix):
+        autoreconf = which('autoreconf')
+        autoreconf('-fiv')


### PR DESCRIPTION
Hunspell depends on `gettext` (specifically, it requires the `autopoint` binary, which is in `gettext`), but this dependency is missing from the Spack `hunspell` package. This pull request adds this missing dependency, and also includes a triage fix for #12343 while waiting for PR #12344 to be merged.