### PR TITLE
sdl2: fix dependency for libxext and build on ARM

### DIFF
--- a/var/spack/repos/builtin/packages/sdl2/package.py
+++ b/var/spack/repos/builtin/packages/sdl2/package.py
@@ -7,9 +7,9 @@ from spack import *
 
 
 class Sdl2(CMakePackage):
-    """Simple DirectMedia Layer is a cross-platform development library designed
-    to provide low level access to audio, keyboard, mouse, joystick, and
-    graphics hardware via OpenGL and Direct3D."""
+    """Simple DirectMedia Layer is a cross-platform development library
+    designed to provide low level access to audio, keyboard, mouse, joystick,
+    and graphics hardware via OpenGL and Direct3D."""
 
     homepage = "https://wiki.libsdl.org/FrontPage"
     url      = "https://libsdl.org/release/SDL2-2.0.5.tar.gz"
@@ -17,3 +17,11 @@ class Sdl2(CMakePackage):
     version('2.0.5', 'd4055424d556b4a908aa76fad63abd3c')
 
     depends_on('cmake@2.8.5:', type='build')
+    depends_on('libxext', type='link')
+
+    def cmake_args(self):
+        return [
+            '-DSSEMATH={0}'.format(
+                'OFF' if self.spec.satisfies('target=aarch64') else 'ON'
+            )
+        ]


### PR DESCRIPTION
* add dependency for libxext2.
* SSEMATH is off when target is aarch64.
* reformat comment for flake8.