### PR TITLE
Add py-clipboard package

### DIFF
--- a/var/spack/repos/builtin/packages/py-clipboard/package.py
+++ b/var/spack/repos/builtin/packages/py-clipboard/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyClipboard(PythonPackage):
+    """A cross platform clipboard operation library of Python."""
+
+    homepage = "https://github.com/terryyin/clipboard"
+    url      = "https://pypi.io/packages/source/c/clipboard/clipboard-0.0.4.tar.gz"
+
+    version('0.0.4', sha256='a72a78e9c9bf68da1c3f29ee022417d13ec9e3824b511559fd2b702b1dd5b817')
+
+    depends_on('py-setuptools', type='build')
+    depends_on('py-pyperclip@1.3:', type=('build', 'run'))


### PR DESCRIPTION
Successfully installed on Cray CNL5 with GCC 6.3.0 and Python 3.7.4.