### PR TITLE
Add py-pysmartdl package

### DIFF
--- a/var/spack/repos/builtin/packages/py-pysmartdl/package.py
+++ b/var/spack/repos/builtin/packages/py-pysmartdl/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyPysmartdl(PythonPackage):
+    """A Smart Download Manager for Python."""
+
+    homepage = "https://pypi.python.org/pypi/pySmartDL/"
+    url      = "https://pypi.io/packages/source/p/pySmartDL/pySmartDL-1.3.2.tar.gz"
+
+    version('1.3.2', sha256='9a96deb3ee4f4ab2279b22eb908d506f57215e1fbad290d540adcebff187a52c')
+    version('1.2.5', sha256='d3968ce59412f99d8e17ca532a1d949d2aa770a914e3f5eb2c0385579dc2b6b8')
+
+    depends_on('py-setuptools', type='build')


### PR DESCRIPTION
Successfully installed on Cray CNL5 with GCC 6.3.0 and Python 3.7.4.