### PR TITLE
Use correct GCC installation when installing clang with GCC

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -697,6 +697,10 @@ class Llvm(CMakePackage):
         if '+omp_tsan' in spec:
             cmake_args.append('-DLIBOMP_TSAN_SUPPORT=ON')
 
+        if self.compiler.name == 'gcc':
+            gcc_prefix = ancestor(self.compiler.cc, 2)
+            cmake_args.append('-DGCC_INSTALL_PREFIX=' + gcc_prefix)
+
         if spec.satisfies('@4.0.0:') and spec.satisfies('platform=linux'):
             cmake_args.append('-DCMAKE_BUILD_WITH_INSTALL_RPATH=1')
         return cmake_args


### PR DESCRIPTION
This fixes #12380 by configuring Clang to include the correct GCC version in its search paths if building with GCC.

See [this thread](http://clang-developers.42468.n3.nabble.com/Control-selected-GCC-installation-selected-libstdc-version-td4050363.html) for the relevant configure option.

---

Before this change, the search directories for Clang seem to be using the system GCC instead of the 8.2 that it was compiled with:
```console
$ clang -print-search-dirs
programs: =/projects/spack/opt/spack/linux-rhel7-x86_64/gcc-8.2.0/llvm-7.0.1-avafczo6dbasez3obndejep4rwbmwnrl/bin:/usr/lib/gcc/x86_64-redhat-linux/4.8.5/../../../../x86_64-redhat-linux/bin
libraries: =/projects/spack/opt/spack/linux-rhel7-x86_64/gcc-8.2.0/llvm-7.0.1-avafczo6dbasez3obndejep4rwbmwnrl/lib/clang/7.0.1:/usr/lib/gcc/x86_64-redhat-linux/4.8.5:/usr/lib/gcc/x86_64-redhat-linux/4.8.5/../../../../lib64:/lib/../lib64:/usr/lib/../lib64:/usr/lib/gcc/x86_64-redhat-linux/4.8.5/../../..:/projects/spack/opt/spack/linux-rhel7-x86_64/gcc-8.2.0/llvm-7.0.1-avafczo6dbasez3obndejep4rwbmwnrl/bin/../lib:/lib:/usr/lib
```

---

After the change, 

```console
$ $(spack location -i llvm)/bin/clang -print-search-dirs
programs: =/projects/spack2/opt/spack/linux-rhel7-x86_64/gcc-8.2.0/llvm-7.0.1-rnw3lziolux2ylebsuof3laiqiqjhops/bin:/projects/spack2/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-8.2.0-3gf5hj6qpbqqh44sdsnueyyvbnjtbgnh/lib/gcc/x86_64-pc-linux-gnu/8.2.0/../../../../x86_64-pc-linux-gnu/bin
libraries: =/projects/spack2/opt/spack/linux-rhel7-x86_64/gcc-8.2.0/llvm-7.0.1-rnw3lziolux2ylebsuof3laiqiqjhops/lib/clang/7.0.1:/projects/spack2/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-8.2.0-3gf5hj6qpbqqh44sdsnueyyvbnjtbgnh/lib/gcc/x86_64-pc-linux-gnu/8.2.0:/projects/spack2/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-8.2.0-3gf5hj6qpbqqh44sdsnueyyvbnjtbgnh/lib/gcc/x86_64-pc-linux-gnu/8.2.0/../../../../lib64:/lib/../lib64:/usr/lib/../lib64:/projects/spack2/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-8.2.0-3gf5hj6qpbqqh44sdsnueyyvbnjtbgnh/lib/gcc/x86_64-pc-linux-gnu/8.2.0/../../..:/projects/spack2/opt/spack/linux-rhel7-x86_64/gcc-8.2.0/llvm-7.0.1-rnw3lziolux2ylebsuof3laiqiqjhops/bin/../lib:/lib:/usr/lib
```