### PR TITLE
openblas: fix target detection for cross-compiling

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -197,7 +197,7 @@ class Openblas(MakefilePackage):
         if '+ilp64' in self.spec:
             make_defs += ['INTERFACE64=1']
 
-        if 'x86' in spack.architecture.sys_type():
+        if 'x86' in self.spec.architecture.target.lower():
             if '~avx2' in self.spec:
                 make_defs += ['NO_AVX2=1']
             if '~avx512' in self.spec:


### PR DESCRIPTION
In a review of a previous pull request (
https://github.com/spack/spack/pull/10713 ) it was mentioned that the
proper way to figure out the target architecture is via
spec.architecture.target.  This patch fixes this for the openblas
package.

Signed-off-by: Janne Blomqvist <janne.blomqvist@aalto.fi>