### PR TITLE
Apply xl patch for cce@9: to fix cmake.

### DIFF
--- a/var/spack/repos/builtin/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-lapack/package.py
@@ -40,6 +40,7 @@ class NetlibLapack(CMakePackage):
 
     patch('ibm-xl.patch', when='@3.7: %xl')
     patch('ibm-xl.patch', when='@3.7: %xl_r')
+    patch('ibm-xl.patch', when='@3.7: %cce@9:')
 
     # https://github.com/Reference-LAPACK/lapack/issues/228
     # TODO: update 'when' once the version of lapack


### PR DESCRIPTION
New Cray CCE compilers (version 9+) trip over the same bug that XL has issues with (i.e.: a typo in `CBLAS/CMakeLists.txt`).  This PR simply applies the existing patch to the source to fix builds with `%cce@9.0.1.80`.  IMHO, this patch should probably be applied universally as it shouldn't negatively impact builds with other compilers.

I also opened an issue on the netlib-lapack github page to point out this deficiency: [CMake error CBLAS/CMakeLists.txt wrt FortranCInterface](https://github.com/Reference-LAPACK/lapack/issues/349).