### PR TITLE
Update VisIt to version 3.0.1 and fix on mac

### DIFF
--- a/var/spack/repos/builtin/packages/qwt/no-designer.patch
+++ b/var/spack/repos/builtin/packages/qwt/no-designer.patch
@@ -1,0 +1,33 @@
+--- qwt-6.1.3.orig/qwtconfig.pri	2016-06-13 03:14:23.000000000 -0400
++++ qwt-6.1.3/qwtconfig.pri	2019-03-29 19:06:22.000000000 -0400
+@@ -42,7 +42,7 @@
+ # runtime environment of designer/creator.
+ ######################################################################
+ 
+-QWT_INSTALL_PLUGINS   = $${QWT_INSTALL_PREFIX}/plugins/designer
++#QWT_INSTALL_PLUGINS   = $${QWT_INSTALL_PREFIX}/plugins/designer
+ 
+ # linux distributors often organize the Qt installation
+ # their way and QT_INSTALL_PREFIX doesn't offer a good
+@@ -118,7 +118,7 @@
+ # Otherwise you have to build it from the designer directory.
+ ######################################################################
+ 
+-QWT_CONFIG     += QwtDesigner
++#QWT_CONFIG     += QwtDesigner
+ 
+ ######################################################################
+ # Compile all Qwt classes into the designer plugin instead
+@@ -132,9 +132,9 @@
+ # environment of the designer/creator.
+ ######################################################################
+ 
+-win32 {
+-    QWT_CONFIG     += QwtDesignerSelfContained
+-}
++#win32 {
++#    QWT_CONFIG     += QwtDesignerSelfContained
++#}
+ 
+ ######################################################################
+ # If you want to auto build the examples, enable the line below

--- a/var/spack/repos/builtin/packages/qwt/package.py
+++ b/var/spack/repos/builtin/packages/qwt/package.py
@@ -19,7 +19,13 @@ class Qwt(QMakePackage):
     version('6.1.3', '19d1f5fa5e22054d22ee3accc37c54ba')
     version('5.2.2', '70d77e4008a6cc86763737f0f24726ca')
 
+    variant('designer', default=False,
+            description="Build extensions to QT designer")
+
+    patch('no-designer.patch', when='~designer')
+
     depends_on('qt+opengl')
+    depends_on('qt+tools', when='+designer')
     # Qwt 6.1.1 and older use a constant that was removed in Qt 5.4
     # https://bugs.launchpad.net/ubuntu/+source/qwt-qt5/+bug/1485213
     depends_on('qt@:5.3', when='@:6.1.1')

--- a/var/spack/repos/builtin/packages/visit/nonframework-qwt.patch
+++ b/var/spack/repos/builtin/packages/visit/nonframework-qwt.patch
@@ -1,0 +1,11 @@
+--- a/src/CMake/FindQwt.cmake	2019-02-15 18:31:27.000000000 -0500
++++ b/src/CMake/FindQwt.cmake	2019-08-11 09:18:38.000000000 -0400
+@@ -51,7 +51,7 @@
+ include(${VISIT_SOURCE_DIR}/CMake/SetUpThirdParty.cmake)
+ 
+ if(APPLE)
+-    if(VISIT_STATIC)
++    if ("TRUE")
+         SET_UP_THIRD_PARTY(QWT lib include qwt)
+     else()
+         SET_UP_THIRD_PARTY(QWT lib lib/qwt.framework/Versions/Current/Headers qwt)

--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -10,8 +10,10 @@ class Visit(CMakePackage):
     """VisIt is an Open Source, interactive, scalable, visualization,
        animation and analysis tool."""
     homepage = "https://wci.llnl.gov/simulation/computer-codes/visit/"
-    url = "http://portal.nersc.gov/project/visit/releases/2.10.1/visit2.10.1.tar.gz"
+    url = "https://portal.nersc.gov/project/visit/releases/3.0.1/visit3.0.1.tar.gz"
 
+    version('3.0.1', 'a506d4d83b8973829e68787d8d721199523ce7ec73e7594e93333c214c2c12bd')
+    version('2.13.3', 'cf0b3d2e39e1cd102dd886d3ef6da892733445e362fc28f24d9682012cccf2e5')
     version('2.13.0', '716644b8e78a00ff82691619d4d1e7a914965b6535884890b667b97ba08d6a0f')
     version('2.12.3', '2dd351a291ee3e79926bc00391ca89b202cfa4751331b0fdee1b960c7922161f')
     version('2.12.2', '355779b1dbf440cdd548526eecd77b60')
@@ -20,32 +22,53 @@ class Visit(CMakePackage):
     version('2.10.1', '3cbca162fdb0249f17c4456605c4211e')
 
     variant('gui',    default=True, description='Enable VisIt\'s GUI')
+    variant('adios2', default=False, description='Enable ADIOS2 file format')
     variant('hdf5',   default=True, description='Enable HDF5 file format')
     variant('silo',   default=True, description='Enable Silo file format')
     variant('python', default=True, description='Enable Python support')
     variant('mpi',    default=True, description='Enable parallel engine')
 
+    patch('spack-changes.patch')
+    patch('nonframework-qwt.patch', when='^qt~framework platform=darwin')
+
     depends_on('cmake@3.0:', type='build')
-    depends_on('vtk@6.1.0~opengl2~mpi')
-    depends_on('qt@4.8.6', when='+gui')
+    depends_on('vtk@8.1.0:+opengl2', when='@3.0:3.0.1')
+    depends_on('vtk@6.1.0~opengl2', when='@:2.999')
+    depends_on('vtk+python', when='+python @3.0:')
+    depends_on('vtk~mpi')
+    depends_on('vtk+qt', when='+gui')
+    depends_on('qt@4.8.6:4.999', when='+gui @:2.999')
+    depends_on('qt@5.10:', when='+gui @3.0:')
     depends_on('qwt', when='+gui')
-    depends_on('python', when='+python')
+    depends_on('python@2.6:2.8', when='+python')
     depends_on('silo+shared', when='+silo')
     depends_on('hdf5', when='+hdf5')
     depends_on('mpi', when='+mpi')
+    depends_on('adios2', when='+adios2')
 
-    conflicts('+hdf5', when='~gui')
-    conflicts('+silo', when='~gui')
+    conflicts('+adios2', when='@:2.999')
+    conflicts('+hdf5', when='~gui @:2.999')
+    conflicts('+silo', when='~gui @:2.999')
 
     root_cmakelists_dir = 'src'
+
+    @when('@3.0.0:3.0.1')
+    def patch(self):
+        # Some of VTK's targets don't create explicit libraries, so there is no
+        # 'vtktiff'. Instead, replace with the library variable defined from
+        # VTK's module flies (e.g. lib/cmake/vtk-8.1/Modules/vtktiff.cmake)
+        for filename in find('src', 'CMakeLists.txt'):
+            filter_file(r'\bvtk(tiff|jpeg|png)', r'${vtk\1_LIBRARIES}',
+                        filename)
 
     def cmake_args(self):
         spec = self.spec
 
         args = [
-            '-DVTK_MAJOR_VERSION={0}'.format(spec['vtk'].version[0]),
-            '-DVTK_MINOR_VERSION={0}'.format(spec['vtk'].version[1]),
-            '-DVISIT_VTK_DIR:PATH={0}'.format(spec['vtk'].prefix),
+            '-DVTK_MAJOR_VERSION=' + str(spec['vtk'].version[0]),
+            '-DVTK_MINOR_VERSION=' + str(spec['vtk'].version[1]),
+            '-DVISIT_VTK_DIR:PATH=' + spec['vtk'].prefix,
+            '-DVISIT_ZLIB_DIR:PATH=' + spec['zlib'].prefix,
             '-DVISIT_USE_GLEW=OFF',
             '-DCMAKE_CXX_FLAGS=' + self.compiler.pic_flag,
             '-DCMAKE_C_FLAGS=' + self.compiler.pic_flag,
@@ -56,9 +79,11 @@ class Visit(CMakePackage):
 
         if '+gui' in spec:
             qt_bin = spec['qt'].prefix.bin
-            args.append(
-                '-DVISIT_LOC_QMAKE_EXE:FILEPATH={0}/qmake-qt4'.format(qt_bin))
-            args.append('-DVISIT_QWT_DIR:PATH={0}'.format(spec['qwt'].prefix))
+            args.extend([
+                '-DVISIT_LOC_QMAKE_EXE:FILEPATH={0}/qmake'.format(qt_bin),
+                '-DVISIT_QT_DIR:PATH=' + spec['qt'].prefix,
+                '-DVISIT_QWT_DIR:PATH=' + spec['qwt'].prefix
+            ])
         else:
             args.append('-DVISIT_SERVER_COMPONENTS_ONLY=ON')
             args.append('-DVISIT_ENGINE_ONLY=ON')

--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -47,14 +47,14 @@ class Visit(CMakePackage):
             '-DVTK_MINOR_VERSION={0}'.format(spec['vtk'].version[1]),
             '-DVISIT_VTK_DIR:PATH={0}'.format(spec['vtk'].prefix),
             '-DVISIT_USE_GLEW=OFF',
-            '-DCMAKE_CXX_FLAGS=-fPIC',
-            '-DCMAKE_C_FLAGS=-fPIC'
+            '-DCMAKE_CXX_FLAGS=' + self.compiler.pic_flag,
+            '-DCMAKE_C_FLAGS=' + self.compiler.pic_flag,
         ]
 
-        if(spec.variants['python'].value):
+        if '+python' in spec:
             args.append('-DPYTHON_DIR:PATH={0}'.format(spec['python'].home))
 
-        if(spec.variants['gui'].value):
+        if '+gui' in spec:
             qt_bin = spec['qt'].prefix.bin
             args.append(
                 '-DVISIT_LOC_QMAKE_EXE:FILEPATH={0}/qmake-qt4'.format(qt_bin))
@@ -63,18 +63,18 @@ class Visit(CMakePackage):
             args.append('-DVISIT_SERVER_COMPONENTS_ONLY=ON')
             args.append('-DVISIT_ENGINE_ONLY=ON')
 
-        if(spec.variants['hdf5'].value):
+        if '+hdf5' in spec:
             args.append(
                 '-DVISIT_HDF5_DIR:PATH={0}'.format(spec['hdf5'].prefix))
             if spec.satisfies('^hdf5+mpi', strict=True):
                 args.append('-DVISIT_HDF5_MPI_DIR:PATH={0}'.format(
                     spec['hdf5'].prefix))
 
-        if(spec.variants['silo'].value):
+        if '+silo' in spec:
             args.append(
                 '-DVISIT_SILO_DIR:PATH={0}'.format(spec['silo'].prefix))
 
-        if(spec.variants['mpi'].value):
+        if '+mpi' in spec:
             args.append('-DVISIT_PARALLEL=ON')
             args.append('-DVISIT_C_COMPILER={0}'.format(spec['mpi'].mpicc))
             args.append('-DVISIT_CXX_COMPILER={0}'.format(spec['mpi'].mpicxx))

--- a/var/spack/repos/builtin/packages/visit/spack-changes.patch
+++ b/var/spack/repos/builtin/packages/visit/spack-changes.patch
@@ -1,0 +1,22 @@
+--- a/src/CMakeLists.txt	2019-08-11 17:06:04.000000000 -0400
++++ b/src/CMakeLists.txt	2019-08-11 17:06:20.000000000 -0400
+@@ -459,6 +459,7 @@
+     cmake_policy(SET CMP0033 OLD)
+     cmake_policy(SET CMP0057 NEW)
+     cmake_policy(SET CMP0062 NEW)
++    cmake_policy(SET CMP0068 NEW)
+     IF(WIN32)
+         # don't automatically link with qtmain
+         cmake_policy(SET CMP0020 OLD)
+@@ -2271,11 +2272,6 @@
+ #     COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/osxfixup/osxfixup.py \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${VISIT_INSTALLED_VERSION} @executable_path/.. 3)
+ #ADD_DEPENDENCIES(osxfixup install)
+
+-# todo: replace below with lines above
+-IF(APPLE)
+-    ADD_SUBDIRECTORY(osxfixup)
+-ENDIF(APPLE)
+-
+ IF (NOT WIN32)
+     MESSAGE(STATUS "\n\nUse recmake_visit.sh or search for `CMAKE_INVOKE' in CMakeCache.txt to re-run CMake with the same arguments\n\n")
+ ELSE (NOT WIN32)

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -22,6 +22,7 @@ class Vtk(CMakePackage):
 
     version('8.1.2', sha256='0995fb36857dd76ccfb8bb07350c214d9f9099e80b1e66b4a8909311f24ff0db')
     version('8.1.1', sha256='71a09b4340f0a9c58559fe946dc745ab68a866cf20636a41d97b6046cb736324')
+    version('8.1.0', sha256='6e269f07b64fb13774f5925161fb4e1f379f4e6a0131c8408c555f6b58ef3cb7')
     version('8.0.1', '692d09ae8fadc97b59d35cab429b261a')
     version('7.1.0', 'a7e814c1db503d896af72458c2d0228f')
     version('7.0.0', '5fe35312db5fb2341139b8e4955c367d')
@@ -32,7 +33,6 @@ class Vtk(CMakePackage):
     variant('opengl2', default=True, description='Enable OpenGL2 backend')
     variant('osmesa', default=False, description='Enable OSMesa support')
     variant('python', default=False, description='Enable Python support')
-    variant('python3', default=False, description='Enable Python3 support')
     variant('qt', default=False, description='Build with support for Qt')
     variant('xdmf', default=False, description='Build XDMF file support')
     variant('ffmpeg', default=False, description='Build with FFMPEG support')
@@ -43,21 +43,16 @@ class Vtk(CMakePackage):
     # At the moment, we cannot build with both osmesa and qt, but as of
     # VTK 8.1, that should change
     conflicts('+osmesa', when='+qt')
-    conflicts('+python', when='+python3')
-    conflicts('+python3', when='@:8.0')
+    conflicts('^python@3:', when='@:8.0')
 
     extends('python', when='+python')
-    extends('python', when='+python3')
 
-    depends_on('python@2.7:2.8', when='+python', type=('build', 'run'))
-    depends_on('python@3:', when='+python3', type=('build', 'run'))
-
+    depends_on('python@2.7:', when='+python', type=('build', 'run'))
     depends_on('py-mpi4py', when='+python+mpi', type='run')
-    depends_on('py-mpi4py', when='+python3+mpi', type='run')
 
     # python3.7 compatibility patch backported from upstream
     # https://gitlab.kitware.com/vtk/vtk/commit/706f1b397df09a27ab8981ab9464547028d0c322
-    patch('python3.7-const-char.patch', when='@:8.1.1 ^python@3.7:')
+    patch('python3.7-const-char.patch', when='@7.0.0:8.1.1 ^python@3.7:')
 
     # The use of the OpenGL2 backend requires at least OpenGL Core Profile
     # version 3.2 or higher.
@@ -129,6 +124,9 @@ class Vtk(CMakePackage):
             '-DNETCDF_C_ROOT={0}'.format(spec['netcdf'].prefix),
             '-DNETCDF_CXX_ROOT={0}'.format(spec['netcdf-cxx'].prefix),
 
+            # Allow downstream codes (e.g. VisIt) to override VTK's classes
+            '-DVTK_ALL_NEW_OBJECT_FACTORY:BOOL=ON',
+
             # Disable wrappers for other languages.
             '-DVTK_WRAP_JAVA=OFF',
             '-DVTK_WRAP_TCL=OFF',
@@ -144,12 +142,13 @@ class Vtk(CMakePackage):
             cmake_args.extend(['-DModule_vtkIOFFMPEG:BOOL=ON'])
 
         # Enable/Disable wrappers for Python.
-        if '+python' in spec or '+python3' in spec:
+        if '+python' in spec:
             cmake_args.extend([
                 '-DVTK_WRAP_PYTHON=ON',
                 '-DPYTHON_EXECUTABLE={0}'.format(spec['python'].command.path),
-                '-DVTK_USE_SYSTEM_MPI4PY:BOOL=ON'
             ])
+            if '+mpi' in spec:
+                cmake_args.append('-DVTK_USE_SYSTEM_MPI4PY:BOOL=ON')
         else:
             cmake_args.append('-DVTK_WRAP_PYTHON=OFF')
 
@@ -206,12 +205,10 @@ class Vtk(CMakePackage):
             if '+mpi' in spec:
                 cmake_args.extend(["-DModule_vtkIOParallelXdmf3:BOOL=ON"])
 
-        cmake_args.extend([
-            '-DVTK_USE_SYSTEM_GLEW:BOOL=ON',
+        cmake_args.append('-DVTK_RENDERING_BACKEND:STRING=' + opengl_ver)
 
-            '-DVTK_RENDERING_BACKEND:STRING=OpenGL{0}'.format(
-                '2' if '+opengl2' in spec else ''),
-        ])
+        if spec.satisfies('@:8.1.0'):
+            cmake_args.append('-DVTK_USE_SYSTEM_GLEW:BOOL=ON')
 
         if '+osmesa' in spec:
             cmake_args.extend([
@@ -220,9 +217,10 @@ class Vtk(CMakePackage):
                 '-DVTK_OPENGL_HAS_OSMESA:BOOL=ON'])
 
         else:
-            cmake_args.extend([
-                '-DVTK_OPENGL_HAS_OSMESA:BOOL=OFF',
-                '-DOpenGL_GL_PREFERENCE:STRING=LEGACY'])
+            cmake_args.append('-DVTK_OPENGL_HAS_OSMESA:BOOL=OFF')
+            if spec.satisfies('@:7.9.9'):
+                # This option is gone in VTK 8.1.2
+                cmake_args.append('-DOpenGL_GL_PREFERENCE:STRING=LEGACY')
 
             if 'darwin' in spec.architecture:
                 cmake_args.extend([
@@ -262,10 +260,11 @@ class Vtk(CMakePackage):
             if (self.spec.satisfies('%clang') and
                 self.compiler.is_apple and
                 self.compiler.version >= Version('5.1.0')):
-                cmake_args.extend(['-DVTK_REQUIRED_OBJCXX_FLAGS=""'])
+                cmake_args.extend(['-DVTK_REQUIRED_OBJCXX_FLAGS='])
 
             # A bug in tao pegtl causes build failures with intel compilers
             if '%intel' in spec and spec.version >= Version('8.2'):
                 cmake_args.append(
                     '-DVTK_MODULE_ENABLE_VTK_IOMotionFX:BOOL=OFF')
+
         return cmake_args


### PR DESCRIPTION
With these changes I was successfully able to install the latest VisIt on my mac using the spack toolchain. I needed to make changes to the VisIt package and to two upstream packages (QWT and VTK) for my configuration, so please let me know if those should be separate pull requests.

Changes to QWT are to allow building with `qt~tools`.

Changes to VTK:
- Fix compile error due to `""` in mac-specific configure flags
- Enable `VTK_ALL_NEW_OBJECT_FACTORY` (needed for visit, I don't think it would be harmful in any other case) option
- Merge `+python` and `+python3` variants

Changes to VisIt:
- Add new version and checksums
- Add support for building with a QWT that was compiled as a library rather than framework on mac
- Add more explicit version dependencies based on VisIt build_script distribution (this includes restricting python to 2.x)
- Patch VisIt's cmake to work with a VTK installation that creates library *targets* rather than explicit libraries

---

Dependencies for the successful install, for the sake of posterity:
```
$ spack find -lvd visit
==> 1 installed package
-- darwin-mojave-x86_64 / clang@10.0.1-apple --------------------
wspwvzx    visit@3.0.1~adios2 build_type=RelWithDebInfo +gui+hdf5+mpi patches=81fd707305a9ba245bc5d8108d738f5229513eedddf7d683d0c4f3fdcc55e887,b1c10e8f99fd869cc488e7c17e135849c7f0d4ca4414d18a6760247188114031 +python+silo
pkx22jw        ^hdf5@1.10.5~cxx~debug~fortran+hl~mpi+pic+shared+szip~threadsafe
2vgfs6n            ^libszip@2.1.1
nqnlnxd            ^zlib@1.2.11+optimize+pic+shared
qz6zsrm        ^openmpi@3.1.4~cuda+cxx_exceptions fabrics=none ~java~legacylaunchers~memchecker~pmi schedulers=none ~sqlite3~thread_multiple+vt
jbig2eu            ^hwloc@1.11.11~cairo~cuda~gl+libxml2~nvml~pci+shared
owmrtw3                ^libxml2@2.9.9~python
6y7tjlq                    ^libiconv@1.15
snwzcou                    ^xz@5.2.4
vhkc3zr        ^python@2.7.16+bz2+ctypes+dbm+lzma~nis~optimizations patches=210df3f28cde02a8135b58cc4168e70ab91dbf9097359d05938f1e2843875e57 +pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib
llnc6sq            ^bzip2@1.0.8+shared
ivx3l77            ^expat@2.2.5~libbsd
pvjwide            ^gdbm@1.18.1
kn3u3qh                ^readline@7.0
nhodl3c                    ^ncurses@6.1~symlinks~termlib
n3673fl            ^gettext@0.19.8.1+bzip2+curses+git~libunistring+libxml2 patches=9acdb4e73f67c241b5ef32505c9ddf7cf6884ca8ea661692f21dca28483b04b8 +tar+xz
vyjf7fd                ^tar@1.31
rmioaof            ^libffi@3.2.1
z6erpib            ^openssl@1.1.1b+systemcerts
mijtevf            ^sqlite@3.28.0+fts~functions
sk7ms2t        ^qt@5.11.3~dbus~examples~framework freetype=none ~gtk~krellpatch+opengl patches=0aaad63f10d68ba936fcef85c38429b3b3ce260098dfdc19e37ea1e03ac042e9,48ff18be2f4050de7288bddbae7f47e949512ac4bcd126c2f504be2ac701158b,7f34d48d2faaa108dc3fcc47187af1ccd1d37ee0f931b42597b820f03a99864c,c52f72dac7fdff5a296467536cc9ea024d78f94b49903286395f53fd0eb66e5e ~phonon+shared~sql~ssl~tools~webkit
mf7korx            ^double-conversion@2.0.1 build_type=RelWithDebInfo
hhpucpw            ^glib@2.56.3~libmount patches=c325997b72a205ad1638bb3e3ba0e5b73e3d32ce63b2d0d3282f3e3a2ff4663c tracing=none
mgfx4te                ^pcre@8.42~jit+multibyte+utf
ycsefbj                ^perl@5.28.1+cpanm+shared+threads
jcyt46x            ^harfbuzz@2.3.1
r6siffb                ^cairo@1.16.0~X~pdf
ktmcn2j                    ^fontconfig@2.12.3
jkc3lwy                        ^font-util@1.3.1 fonts=encodings,font-adobe-100dpi,font-adobe-75dpi,font-adobe-utopia-100dpi,font-adobe-utopia-75dpi,font-adobe-utopia-type1,font-alias,font-arabic-misc,font-bh-100dpi,font-bh-75dpi,font-bh-lucidatypewriter-100dpi,font-bh-lucidatypewriter-75dpi,font-bh-ttf,font-bh-type1,font-bitstream-100dpi,font-bitstream-75dpi,font-bitstream-speedo,font-bitstream-type1,font-cronyx-cyrillic,font-cursor-misc,font-daewoo-misc,font-dec-misc,font-ibm-type1,font-isas-misc,font-jis-misc,font-micro-misc,font-misc-cyrillic,font-misc-ethiopic,font-misc-meltho,font-misc-misc,font-mutt-misc,font-schumacher-misc,font-screen-cyrillic,font-sun-misc,font-winitzki-cyrillic,font-xfree86-type1
l4ys7nh                        ^freetype@2.9.1 patches=08466355e8649235ff01f13b3e56bbd551c7cfb2ca97903cc11575c163ea32a3
h24accp                            ^libpng@1.6.34
uyvgo63                    ^pixman@0.38.0
iuyrtmm                ^icu4c@60.1 cxxstd=11
hzhdmt6            ^libjpeg-turbo@2.0.2
lz2tuha            ^libmng@2.0.3
faanb5f                ^lcms@2.9
7skodcs                    ^libtiff@4.0.10
2u2rd6c            ^opengl@2.1
sbr6r5l            ^pcre2@10.31+multibyte
bmfxirw        ^qwt@6.1.3~designer patches=73df7272a11effc11546ab63aec4fc5ee25983d631c3fe5df024db3be8e83a1e
i4qtmvs        ^silo@4.10.2+fortran~mpi patches=7b5a1dc2a0e358e667088d77e7caa780967fa8ea60be89c44986605df9990abe +pic+shared~silex
472rma2        ^vtk@8.1.2 build_type=RelWithDebInfo ~ffmpeg~mpi+opengl2~osmesa+python+qt~xdmf
olku6ay            ^glew@2.0.0
iqcta2x            ^jsoncpp@1.7.3 build_type=RelWithDebInfo
sxghj4k            ^lz4@1.9.0
uwt2xa6            ^netcdf@4.7.0~dap~hdf4 maxdims=1024 maxvars=8192 ~mpi~parallel-netcdf patches=10a1c3f7fa05e2c82457482e272bbe04d66d0047b237ad0a73e87d63d848b16c +pic+shared
thc7k4t            ^netcdf-cxx@4.2+netcdf4
```