### PR TITLE
subread: build on ARM.

### DIFF
--- a/var/spack/repos/builtin/packages/subread/package.py
+++ b/var/spack/repos/builtin/packages/subread/package.py
@@ -30,6 +30,20 @@ class Subread(MakefilePackage):
                     'CC_EXEC = {0}'.format(spack_cc),
                     'Makefile.Linux'
                 )
+                if spec.satisfies('target=aarch64'):
+                    filter_file('-mtune=core2', '', 'Makefile.Linux')
+                    if spec.satisfies('@1.6.2:1.6.4'):
+                        filter_file(
+                            '-mtune=core2',
+                            '',
+                            'longread-one/Makefile'
+                        )
+                    elif spec.satisfies('@1.6.0'):
+                        filter_file(
+                            '-mtune=core2',
+                            '',
+                            'longread-mapping/Makefile'
+                        )
                 make('-f', 'Makefile.Linux')
             elif plat.startswith('darwin'):
                 make('-f', 'Makefile.MacOS')


### PR DESCRIPTION
subread use -mtune=core2 to compile ooption.
But this option is not suppoeted on ARM.

This PR remove -mtune=core2 option when target is ARM.