### PR TITLE
starce: new version and build on ARM.

### DIFF
--- a/var/spack/repos/builtin/packages/strace/package.py
+++ b/var/spack/repos/builtin/packages/strace/package.py
@@ -13,9 +13,19 @@ class Strace(AutotoolsPackage):
     signal deliveries, and changes of process state."""
 
     homepage = "https://strace.io"
-    url      = "https://strace.io/files/4.21/strace-4.21.tar.xz"
+    url      = "https://github.com/strace/strace/releases/download/v5.2/strace-5.2.tar.xz"
 
     conflicts('platform=darwin', msg='strace runs only on Linux.')
 
+    version('5.2', sha256='d513bc085609a9afd64faf2ce71deb95b96faf46cd7bc86048bc655e4e4c24d2')
+    version('5.1', sha256='f5a341b97d7da88ee3760626872a4899bf23cf8dee56901f114be5b1837a9a8b')
     version('5.0', sha256='3b7ad77eb2b81dc6078046a9cc56eed5242b67b63748e7fc28f7c2daf4e647da')
     version('4.21', '785b679a75e9758ebeb66816f315b9fe')
+
+    def configure_args(self):
+        args = []
+        if self.spec.satisfies('target=aarch64'):
+            args.append('--enable-mpers=no')
+        else:
+            args.append('--enable-mpers=yes')
+        return args


### PR DESCRIPTION
* souce URL change to github.
* Add version 5.1 and 5.2
* enable build on ARM.
    * strace try to use -m32, but gcc on aarch64 dose not support -m32, so -m32 is off on aarch64.