### PR TITLE
libint-cp2k: initial commit

### DIFF
--- a/var/spack/repos/builtin/packages/libint-cp2k/package.py
+++ b/var/spack/repos/builtin/packages/libint-cp2k/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class LibintCp2k(CMakePackage):
+    """libint configured for CP2K."""
+
+    homepage = "https://github.com/cp2k/libint-cp2k"
+
+    version('2.6.0', sha256='1cd72206afddb232bcf2179c6229fbf6e42e4ba8440e701e6aa57ff1e871e9db')
+
+    depends_on('python', type='build')
+    depends_on('boost')
+
+    def url_for_version(self, version):
+        url = 'https://github.com/cp2k/libint-cp2k/releases/download/v{0}/libint-v{0}-cp2k-lmax-{1}.tgz'
+
+        return url.format(version, 5)
+
+    def cmake_args(self):
+        return ['-DENABLE_FORTRAN=ON']


### PR DESCRIPTION
This is a new package for libint v2.6.0+ configured specifically for CP2K, based on the prepared libint tarballs on https://github.com/cp2k/libint-cp2k/releases

This could be integrated in `libint`, although there are several challenges:

* to build the required Fortran bindings, libint **must** be built in a 2-stage process (= 2 times configure+make for <=2.5.0, respectively configure+make+cmake+make for >= 2.6.0)
* CP2K needs a a specific configuration of libint which would have to be added either as single variants or collected under one code-specific variant (codes like orca or gamess need different configurations): https://github.com/cp2k/libint-cp2k/blob/064d4eee558d0cc1bc43c24655af835a89c57626/Jenkinsfile#L58-L67
* generating the code takes time (see sizes of the cp2k-prepared tarballs)