### PR TITLE
patch opa-psm2 to build with spack wrappers

### DIFF
--- a/var/spack/repos/builtin/packages/opa-psm2/opa-psm2-compiler.patch
+++ b/var/spack/repos/builtin/packages/opa-psm2/opa-psm2-compiler.patch
@@ -1,0 +1,45 @@
+--- opa-psm2-PSM2_11.2.77/buildflags.mak	2019-01-16 09:21:55.000000000 -0800
++++ opa-psm2-PSM2_11.2.77.compiler_fix/buildflags.mak	2019-08-12 10:17:01.044565000 -0700
+@@ -61,13 +61,13 @@ export os ?= $(shell uname -s | tr '[A-Z
+ export arch := $(shell uname -m | sed -e 's,\(i[456]86\|athlon$$\),i386,')
+ 
+ ifeq (${CCARCH},gcc)
+-	export CC := gcc
++	export CC := cc
+ else
+ 	ifeq (${CCARCH},gcc4)
+ 		export CC := gcc4
+ 	else
+ 		ifeq (${CCARCH},icc)
+-		     export CC := icc
++		     export CC := cc
+ 		else
+ 		     anerr := $(error Unknown C compiler arch: ${CCARCH})
+ 		endif # ICC
+@@ -107,7 +107,7 @@ BASECFLAGS +=-Wall $(WERROR)
+ #
+ # test if compiler supports 32B(AVX2)/64B(AVX512F) move instruction.
+ #
+-ifeq (${CC},icc)
++ifeq (${CCARCH},icc)
+   ifeq ($(PSM_DISABLE_AVX2),)
+     MAVX2=-xATOM_SSE4.2 -DPSM_AVX512
+   else
+@@ -121,7 +121,7 @@ else
+   endif
+ endif
+ 
+-ifneq (icc,${CC})
++ifneq (icc,${CCARCH})
+   ifeq ($(PSM_DISABLE_AVX2),)
+     RET := $(shell echo "int main() {}" | ${CC} ${MAVX2} -E -dM -xc - 2>&1 | grep -q AVX2 ; echo $$?)
+   else
+@@ -141,7 +141,7 @@ endif
+ # This support is dynamic at runtime, so is OK to enable as long as compiler can generate
+ # the code.
+ ifneq (,${PSM_AVX512})
+-  ifneq (icc,${CC})
++  ifneq (icc,${CCARCH})
+     RET := $(shell echo "int main() {}" | ${CC} -mavx512f -E -dM -xc - 2>&1 | grep -q AVX512 ; echo $$?)
+     ifeq (0,${RET})
+       BASECFLAGS += -mavx512f

--- a/var/spack/repos/builtin/packages/opa-psm2/package.py
+++ b/var/spack/repos/builtin/packages/opa-psm2/package.py
@@ -29,10 +29,18 @@ class OpaPsm2(MakefilePackage):
     # patch to prevent opa-psm2 from adding an additional "usr/"
     #   subdirectory within the installation prefix, which breaks paths for
     #   dependent packages like libfabric
-    patch('opa-psm2-install-prefix.patch', when='@11.2.68:') 
+    patch('opa-psm2-install-prefix.patch', when='@11.2.68:')
+
+    # patch to get the Makefile to use the spack compiler wrappers
+    patch('opa-psm2-compiler.patch', when='@11.2.68:',
+          sha256='fe31fda9aaee13acb87d178af2282446196d2cc0b21163034573706110b2e2d6')
 
     def setup_environment(self, spack_env, run_env):
         spack_env.set('DESTDIR', self.prefix)
+        if '%intel' in self.spec:
+            # this variable must be set when we use the Intel compilers to
+            # ensure that the proper flags are set
+            spack_env.set('CCARCH', 'icc')
 
     def edit(self, spec, prefix):
         # Change the makefile so libraries and includes are not


### PR DESCRIPTION
patch to get the Makefile to use the spack compiler wrappers. Also sets a CCARCH=icc variable when using the Intel compilers to ensure the appropriate compiler flags are specified.