### PR TITLE
zstd: fix build linking error

### DIFF
--- a/var/spack/repos/builtin/packages/zstd/package.py
+++ b/var/spack/repos/builtin/packages/zstd/package.py
@@ -12,10 +12,11 @@ class Zstd(MakefilePackage):
     better compression ratios."""
 
     homepage = "http://facebook.github.io/zstd/"
-    url      = "https://github.com/facebook/zstd/archive/v1.1.2.tar.gz"
+    url      = "https://github.com/facebook/zstd/archive/v1.4.2.tar.gz"
 
-    version('1.4.0', '63be339137d2b683c6d19a9e34f4fb684790e864fee13c7dd40e197a64c705c1')
-    version('1.3.8', '90d902a1282cc4e197a8023b6d6e8d331c1fd1dfe60f7f8e4ee9da40da886dc3')
+    version('1.4.2', sha256='7a6e1dad34054b35e2e847eb3289be8820a5d378228802239852f913c6dcf6a7')
+    version('1.4.0', sha256='63be339137d2b683c6d19a9e34f4fb684790e864fee13c7dd40e197a64c705c1')
+    version('1.3.8', sha256='90d902a1282cc4e197a8023b6d6e8d331c1fd1dfe60f7f8e4ee9da40da886dc3')
     version('1.3.0', '888660a850e33c2dcc7c4f9d0b04d347')
     version('1.1.2', '4c57a080d194bdaac83f2d3251fc7ffc')
 
@@ -24,6 +25,9 @@ class Zstd(MakefilePackage):
     def setup_environment(self, spack_env, run_env):
         if '+pic' in self.spec:
             spack_env.append_flags('CFLAGS', self.compiler.pic_flag)
+
+    def build(self, spec, prefix):
+        make('PREFIX={0}'.format(prefix))
 
     def install(self, spec, prefix):
         make('install', 'PREFIX={0}'.format(prefix))


### PR DESCRIPTION
Also adds latest version of zstd.

### Before
```console
$ otool -L libzstd.dylib 
libzstd.dylib:
	/usr/local/lib/libzstd.1.dylib (compatibility version 1.0.0, current version 1.4.2)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.250.1)
```
There is no zstd library in `/usr/local/lib`.
### After
```console
$ otool -L libzstd.dylib 
libzstd.dylib:
	/Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/zstd-1.4.2-mhzqhmg5hhpc7j6rhcs2yndwyvb5ow7p/lib/libzstd.1.dylib (compatibility version 1.0.0, current version 1.4.2)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.250.1)
```
Correctly links to the Spack library.