### PR TITLE
Update BOLT package

### DIFF
--- a/var/spack/repos/builtin/packages/bolt/package.py
+++ b/var/spack/repos/builtin/packages/bolt/package.py
@@ -25,14 +25,17 @@ class Bolt(CMakePackage):
     version("1.0rc1", "77733ba2ad9440c29b36d1c1411a9793")
     version("1.0b1", "df76beb3a7f13ae2dcaf9ab099eea87b")
 
+    depends_on('argobots')
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
     depends_on('libtool', type='build')
 
     def cmake_args(self):
+        spec = self.spec
         options = [
             '-DLIBOMP_USE_ITT_NOTIFY=off',
-            '-DLIBOMP_USE_ARGOBOTS=on'
+            '-DLIBOMP_USE_ARGOBOTS=on',
+            '-DLIBOMP_ARGOBOTS_INSTALL_DIR=' + spec['argobots'].prefix
         ]
 
         return options

--- a/var/spack/repos/builtin/packages/bolt/package.py
+++ b/var/spack/repos/builtin/packages/bolt/package.py
@@ -19,7 +19,10 @@ class Bolt(CMakePackage):
 
     homepage = "http://www.bolt-omp.org/"
     url      = "https://github.com/pmodels/bolt/releases/download/v1.0b1/bolt-1.0b1.tar.gz"
+    git      = "https://github.com/pmodels/bolt.git"
 
+    version("master", branch="master")
+    version("1.0rc1", "77733ba2ad9440c29b36d1c1411a9793")
     version("1.0b1", "df76beb3a7f13ae2dcaf9ab099eea87b")
 
     depends_on('autoconf', type='build')


### PR DESCRIPTION
This PR adds two new versions (`1.0rc1` and `develop`) and missing dependencies (CMake and Argobots) to the BOLT package.
Note that this BOLT package previously uses a built-in Argobots, but it complicates the version control. The Argobots/BOLT team would like to separate it from the BOLT package.