### PR TITLE
Update icu4c to version 64.1

### DIFF
--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -16,6 +16,7 @@ class Icu4c(AutotoolsPackage):
     list_url = "http://download.icu-project.org/files/icu4c"
     list_depth = 2
 
+    version('64.1', 'f150be2231c13bb45206d79e0242372b')
     version('60.1', '3d164a2d1bcebd1464c6160ebb8315ef')
     version('58.2', 'fac212b32b7ec7ab007a12dff1f3aea1')
     version('57.1', '976734806026a4ef8bdd17937c8898b9')


### PR DESCRIPTION
icu4c is a dependency of `qt@4.8.7`. Version 60.1 fails to build on linux with clang@7.0.1 and clang@8.0.0:

```
digitlst.cpp:508:9: error: use of undeclared identifier 'freelocale'
        freelocale(gCLocale);
        ^
   clang++     ...  coll.cpp
digitlst.cpp:520:26: error: use of undeclared identifier 'LC_ALL_MASK'
    gCLocale = newlocale(LC_ALL_MASK, "C", (locale_t)0);
                         ^
   clang++     ...  sortkey.cpp
   clang++     ...  bocsu.cpp
   clang++     ...  ucoleitr.cpp
   clang++     ...  ucol.cpp
   clang++     ...  ucol_res.cpp
2 errors generated.
   clang++     ...  ucol_sit.cpp
   clang++     ...  collation.cpp
*** Failed compilation command follows:
----------------------------------------------------------
/projects/spack/lib/spack/env/clang/clang++ -D_REENTRANT
-DU_HAVE_ELF_H=1 -DU_HAVE_ATOMIC=1 -DU_HAVE_STRTOD_L=1
-DU_HAVE_XLOCALE_H=1 -I. -I../common -DU_ATTRIBUTE_DEPRECATED=
-DU_I18N_IMPLEMENTATION -std=c++11 -W -Wall -pedantic -Wpointer-arith
-Wwrite-strings -Wno-long-long -c -DPIC -fPIC -o digitlst.o digitlst.cpp
--- ( rebuild with "make VERBOSE=1 all" to show all parameters )
--------
make[1]: *** [digitlst.o] Error 1
make[1]: *** Waiting for unfinished jobs....
   clang++     ...  collationsettings.cpp
make[1]: Leaving directory
`/build/s3j-spack/spack-stage/spack-stage-k9ba3gqo/spack-src/source/i18n'
make: *** [all-recursive] Error 2
```