### PR TITLE
Only ever return a string from get_path_from_module_contents

### DIFF
--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -152,4 +152,4 @@ def get_path_from_module_contents(text, module_name):
             return path[:path.find('/bin')]
 
     # Unable to find module path
-    return None
+    return ''


### PR DESCRIPTION
This function returns a string, unless it can't find a suitable one, in which case it returns `None`. But other code using it expects a string, and does operations like `rpaths = ';'.join(spack.build_environment.get_rpaths(pkg))`. `join` requires a sequence of strings, so if a package has no relevant rpath, we get a runtime exception

Returning an empty string instead of `None` bypasses the problem. More generally, I think it is more robust for methods to either return a valid object of a given type, or raise an exception - returning `None` some-of-the-time requires every call to the method to be guarded with a check of the return value

This PR replaces the None return with an empty string, for this one routine