### PR TITLE
Boost: Fix iostream autodetect libraries outside Spack

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -284,7 +284,9 @@ class Boost(Package):
                 '-s', 'BZIP2_INCLUDE=%s' % spec['bzip2'].prefix.include,
                 '-s', 'BZIP2_LIBPATH=%s' % spec['bzip2'].prefix.lib,
                 '-s', 'ZLIB_INCLUDE=%s' % spec['zlib'].prefix.include,
-                '-s', 'ZLIB_LIBPATH=%s' % spec['zlib'].prefix.lib])
+                '-s', 'ZLIB_LIBPATH=%s' % spec['zlib'].prefix.lib,
+                '-s', 'NO_LZMA=1',
+                '-s', 'NO_ZSTD=1'])
 
         link_types = ['static']
         if '+shared' in spec:


### PR DESCRIPTION
Boost iostream autodetects the compression libraries libzstd and liblzma outside of the Spack environment.

This PR disables mentioned libraries. [Boost docs](https://www.boost.org/doc/libs/develop/libs/iostreams/doc/installation.html)