### PR TITLE
Fix to option text for help command.

### DIFF
--- a/lib/spack/spack/cmd/help.py
+++ b/lib/spack/spack/cmd/help.py
@@ -86,12 +86,12 @@ def setup_parser(subparser):
     help_all_group = subparser.add_mutually_exclusive_group()
     help_all_group.add_argument(
         '-a', '--all', action='store_const', const='long', default='short',
-        help='print all available commands')
+        help='list all available commands and options')
 
     help_spec_group = subparser.add_mutually_exclusive_group()
     help_spec_group.add_argument(
         '--spec', action='store_const', dest='guide', const='spec',
-        default=None, help='print guide to specs')
+        default=None, help='help on the package specification syntax')
 
 
 def help(parser, args):

--- a/lib/spack/spack/cmd/help.py
+++ b/lib/spack/spack/cmd/help.py
@@ -91,7 +91,7 @@ def setup_parser(subparser):
     help_spec_group = subparser.add_mutually_exclusive_group()
     help_spec_group.add_argument(
         '--spec', action='store_const', dest='guide', const='spec',
-        default=None, help='print all available commands')
+        default=None, help='print guide to specs')
 
 
 def help(parser, args):

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -246,7 +246,7 @@ class SpackArgumentParser(argparse.ArgumentParser):
 {help}:
   spack help --all       list all commands and options
   spack help <command>   help on a specific command
-  spack help --spec      help on the spec syntax
+  spack help --spec      help on the package specification syntax
   spack docs             open http://spack.rtfd.io/ in a browser"""
 .format(help=section_descriptions['help']))
 


### PR DESCRIPTION
Fix to help option text, factored out of a drive-by fix in #11145.