### PR TITLE
Armor test script against shebang character limit if appropriate.

### DIFF
--- a/lib/spack/spack/test/util/executable.py
+++ b/lib/spack/spack/test/util/executable.py
@@ -8,6 +8,7 @@ import sys
 import llnl.util.filesystem as fs
 
 import spack.util.executable as ex
+from spack.hooks.sbang import filter_shebangs_in_directory
 
 
 def test_read_unicode(tmpdir):
@@ -28,6 +29,7 @@ print(u'\\xc3')
 
         # make it executable
         fs.set_executable(script_name)
+        filter_shebangs_in_directory('.', [script_name])
 
         # read the unicode back in and see whether things work
         script = ex.Executable('./%s' % script_name)


### PR DESCRIPTION
The unicode script written by `test_read_unicode()` can fail the shebang character limit with some development environments. Use `filter_shebangs_in_directory()` to guard against this.
