### PR TITLE
py-deeptools: add version 3.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-deeptools/package.py
+++ b/var/spack/repos/builtin/packages/py-deeptools/package.py
@@ -11,10 +11,12 @@ class PyDeeptools(PythonPackage):
        that are now routinely generated from DNA sequencing centers."""
 
     homepage = "https://pypi.io/packages/source/d/deepTools"
-    url      = "https://pypi.io/packages/source/d/deepTools/deepTools-2.5.2.tar.gz"
+    # The test suite and associated test data is missing in the pypi tarball.
+    url      = "https://github.com/deeptools/deepTools/archive/3.3.0.tar.gz"
 
-    version('3.2.1', sha256='ccbabb46d6c17c927e96fadc43d8d4770efeaf40b9bcba3b94915a211007378e')
-    version('2.5.2', 'ba8a44c128c6bb1ed4ebdb20bf9ae9c2')
+    version('3.3.0', sha256='a7aaf79fe939ca307fe6ec5e156750389fdfa4324bf0dd6bf5f53d5fda109358')
+    version('3.2.1', sha256='dbee7676951a9fdb1b88956fe4a3294c99950ef193ea1e9edfba1ca500bd6a75')
+    version('2.5.2', sha256='16d0cfed29af37eb3c4cedd9da89b4952591dc1a7cd8ec71fcba87c89c62bf79')
 
     depends_on('python@2.7:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
@@ -22,6 +24,18 @@ class PyDeeptools(PythonPackage):
     depends_on('py-scipy@0.17.0:', type=('build', 'run'))
     depends_on('py-py2bit@0.2.0:', type=('build', 'run'))
     depends_on('py-pybigwig@0.2.1:', type=('build', 'run'))
-    depends_on('py-pysam@0.8.2:', type=('build', 'run'))
-    depends_on('py-matplotlib@1.4.0:', type=('build', 'run'))
+    depends_on('py-pysam@0.14.0:', type=('build', 'run'))
+    depends_on('py-matplotlib@2.1.2:', type=('build', 'run'))
     depends_on('py-numpydoc@0.5:', type=('build', 'run'))
+    depends_on('py-plotly@2.0.0:', type=('build', 'run'))
+    depends_on('py-deeptoolsintervals@0.1.8:', type=('build', 'run'))
+
+    depends_on('py-nose', type='test')
+
+    def patch(self):
+        # Add nosetest hook for "python setup.py test" argument.
+        filter_file(r'^setup\(',
+                    r'''setup(
+    tests_require='nose',
+    test_suite='nose.collector',''',
+                    'setup.py')

--- a/var/spack/repos/builtin/packages/py-deeptoolsintervals/package.py
+++ b/var/spack/repos/builtin/packages/py-deeptoolsintervals/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyDeeptoolsintervals(PythonPackage):
+    """A python module creating/accessing GTF-based interval trees with
+    associated meta-data."""
+
+    homepage = 'https://pypi.org/project/deeptoolsintervals/'
+    url = 'https://pypi.io/packages/source/d/deeptoolsintervals/deeptoolsintervals-0.1.9.tar.gz'
+
+    version('0.1.9', sha256='7d94c36fd2b6f10d8b99e536d2672e8228971f1fc810497d33527bba2c40d4f6')
+
+    depends_on('python@2.7:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')


### PR DESCRIPTION
Getting several import and other runtime errors from `py-deeptools@3.2.1` executables due to missing dependencies lagging behind upstream:
https://github.com/deeptools/deepTools/blob/master/requirements.txt

To run unit tests via spack, I patch in upstream's nose test suite so that we can now run:

```bash
spack install --test root --verbose py-deeptools ^python@3:
```

1.  The trade off for running unit tests is switching the URL from the small pypi tarball [188K] to the larger GitHub release tarball [60M] which includes the test data files.  But I expect it will save us maintainers multiple hours of packaging and troubleshooting.
2. Of the 108 tests, only 5 fail, all of which are related to the heatmapper plotting functions.  Those failures look harmless to me; they are image size differences and RMS tolerance differences.  Reported upstream in deeptools/deepTools#863