### PR TITLE
Skip invisible non-packages in package directory.

### DIFF
--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -150,11 +150,11 @@ class FastPackageChecker(Mapping):
             pkg_dir = os.path.join(self.packages_path, pkg_name)
 
             # Warn about invalid names that look like packages.
-            if (not valid_module_name(pkg_name)
-                    and not pkg_name.startswith('.')):
-                msg = 'Skipping package at {0}. '
-                msg += '"{1}" is not a valid Spack module name.'
-                tty.warn(msg.format(pkg_dir, pkg_name))
+            if not valid_module_name(pkg_name):
+                if not pkg_name.startswith('.'):
+                    tty.warn('Skipping package at {0}. "{1}" is not '
+                             'a valid Spack module name.'.format(
+                                 pkg_dir, pkg_name))
                 continue
 
             # Construct the file name from the directory

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -64,3 +64,9 @@ def test_repo_last_mtime():
     latest_mtime = max(os.path.getmtime(p.module.__file__)
                        for p in spack.repo.path.all_packages())
     assert spack.repo.path.last_mtime() == latest_mtime
+
+
+def test_repo_invisibles(repo_for_test, extra_repo):
+    with open(os.path.join(extra_repo.root, 'packages', '.invisible'), 'w'):
+        pass
+    extra_repo.all_package_names()


### PR DESCRIPTION
Having a non-directory invisible file in the `packages` dir causes `spack find` to die. This
fixes the logic to ignore invalid module names but only warn if they're
visible.
```
NotADirectoryError: [Errno 20] Not a directory: '/spack/var/spack/repos/builtin/packages/.DS_Store/package.py'
```