### PR TITLE
Add r 3.6.1.

### DIFF
--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -21,6 +21,7 @@ class R(AutotoolsPackage):
 
     extendable = True
 
+    version('3.6.1', sha256='5baa9ebd3e71acecdcc3da31d9042fb174d55a42829f8315f2457080978b1389')
     version('3.6.0', sha256='36fcac3e452666158e62459c6fc810adc247c7109ed71c5b6c3ad5fc2bf57509')
     version('3.5.3', sha256='2bfa37b7bd709f003d6b8a172ddfb6d03ddd2d672d6096439523039f7a8e678c')
     version('3.5.2', sha256='e53d8c3cf20f2b8d7a9c1631b6f6a22874506fb392034758b3bb341c586c5b62')


### PR DESCRIPTION
Add r 3.6.1 which has been built successfully via `spack install r %gcc@8.3.0 r+external-lapack+X ^openblas threads=openmp ^cairo+X+pdf`.