### PR TITLE
libint: 2-stage build with 'tune' and 'fortran' variants

### DIFF
--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -99,7 +99,8 @@ class Cp2k(MakefilePackage, CudaPackage):
                    when='@7.0: lmax={0}'.format(lmax))
 
     depends_on('libxc@2.2.2:', when='+libxc@:5.5999', type='build')
-    depends_on('libxc@4.0.3:', when='+libxc@6.0:', type='build')
+    depends_on('libxc@4.0.3:', when='+libxc@6.0:6.9', type='build')
+    depends_on('libxc@4.0.3:', when='+libxc@7.0:')
 
     depends_on('mpi@2:', when='+mpi')
     depends_on('scalapack', when='+mpi')
@@ -309,14 +310,16 @@ class Cp2k(MakefilePackage, CudaPackage):
                 libs.append(wannier)
 
         if '+libxc' in spec:
-            libxc = spec['libxc:fortran,static']
-            cppflags += [
-                '-D__LIBXC',
-                libxc.headers.cpp_flags
-            ]
+            cppflags += ['-D__LIBXC']
 
-            ldflags.append(libxc.libs.search_flags)
-            libs.append(str(libxc.libs))
+            if '@:6.9' in spec:
+                libxc = spec['libxc:fortran,static']
+                cppflags += [libxc.headers.cpp_flags]
+                ldflags.append(libxc.libs.search_flags)
+                libs.append(str(libxc.libs))
+            else:
+                fcflags += ['$(shell pkg-config --cflags libxcf03)']
+                libs += ['$(shell pkg-config --libs libxcf03)']
 
         if '+pexsi' in self.spec:
             cppflags.append('-D__LIBPEXSI')

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -61,6 +61,14 @@ class Cp2k(MakefilePackage, CudaPackage):
     variant('cuda_blas', default=False,
             description=('Use CUBLAS for general matrix operations in DBCSR'))
 
+    HFX_LMAX_RANGE = range(4, 8)
+
+    variant('lmax',
+            description='Maximum supported angular momentum (HFX and others)',
+            default='5',
+            values=list(HFX_LMAX_RANGE),
+            multi=False)
+
     depends_on('python', type='build')
 
     depends_on('fftw@3:', when='~openmp')
@@ -80,9 +88,16 @@ class Cp2k(MakefilePackage, CudaPackage):
     depends_on('libxsmm@1.11:~header-only', when='smm=libxsmm')
     # use pkg-config (support added in libxsmm-1.10) to link to libxsmm
     depends_on('pkgconfig', type='build', when='smm=libxsmm')
+    # ... and in CP2K 7.0+ for linking to libint2
+    depends_on('pkgconfig', type='build', when='@7.0:')
 
     # libint & libxc are always statically linked
-    depends_on('libint@1.1.4:1.2', when='@3.0:', type='build')
+    depends_on('libint@1.1.4:1.2', when='@3.0:6.9', type='build')
+    for lmax in HFX_LMAX_RANGE:
+        # libint2 can be linked dynamically again
+        depends_on('libint@2.6.0:+fortran tune=cp2k-lmax-{0}'.format(lmax),
+                   when='@7.0: lmax={0}'.format(lmax))
+
     depends_on('libxc@2.2.2:', when='+libxc@:5.5999', type='build')
     depends_on('libxc@4.0.3:', when='+libxc@6.0:', type='build')
 
@@ -169,12 +184,16 @@ class Cp2k(MakefilePackage, CudaPackage):
 
         dflags = ['-DNDEBUG']
         cppflags = [
-            '-D__FFTW3',
             '-D__LIBINT',
-            '-D__LIBINT_MAX_AM=6',
-            '-D__LIBDERIV_MAX_AM1=5',
+            '-D__FFTW3',
             fftw.headers.cpp_flags,
         ]
+
+        if '@:6.9' in spec:
+            cppflags += [
+                '-D__LIBINT_MAX_AM=6',
+                '-D__LIBDERIV_MAX_AM1=5',
+            ]
 
         if '^mpi@3:' in spec:
             cppflags.append('-D__MPI_VERSION=3')
@@ -220,14 +239,18 @@ class Cp2k(MakefilePackage, CudaPackage):
         if 'superlu-dist@4.3' in spec:
             ldflags.insert(0, '-Wl,--allow-multiple-definition')
 
-        # libint-1.x.y has to be linked statically to work around
-        # inconsistencies in its Fortran interface definition
-        # (short-int vs int) which otherwise causes segfaults at runtime
-        # due to wrong offsets into the shared library symbols.
-        libs.extend([
-            os.path.join(spec['libint'].libs.directories[0], 'libderiv.a'),
-            os.path.join(spec['libint'].libs.directories[0], 'libint.a'),
-        ])
+        if '@:6.9' in spec:
+            # libint-1.x.y has to be linked statically to work around
+            # inconsistencies in its Fortran interface definition
+            # (short-int vs int) which otherwise causes segfaults at runtime
+            # due to wrong offsets into the shared library symbols.
+            libs.extend([
+                os.path.join(spec['libint'].libs.directories[0], 'libderiv.a'),
+                os.path.join(spec['libint'].libs.directories[0], 'libint.a'),
+            ])
+        else:
+            fcflags += ['$(shell pkg-config --cflags libint2)']
+            libs += ['$(shell pkg-config --libs libint2)']
 
         if '+plumed' in self.spec:
             dflags.extend(['-D__PLUMED2'])


### PR DESCRIPTION
This is basically the alternative to #12403: instead of using the libint package prepared by the CP2K project we can configure it directly. To make it easy I'd suggest an enumerated `tune` variant to switch sets of `./configure` parameters.