### PR TITLE
bugfix: Skip unneeded install check lock

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1511,23 +1511,22 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             return
 
         partial = self.check_for_unfinished_installation(keep_prefix, restage)
-
-        # Ensure package is not already installed
-        layout = spack.store.layout
-        with spack.store.db.prefix_read_lock(self.spec):
-            if partial:
-                tty.msg(
-                    "Continuing from partial install of %s" % self.name)
-            elif layout.check_installed(self.spec):
-                msg = '{0.name} is already installed in {0.prefix}'
-                tty.msg(msg.format(self))
-                rec = spack.store.db.get_record(self.spec)
-                # In case the stage directory has already been created,
-                # this ensures it's removed after we checked that the spec
-                # is installed
-                if keep_stage is False:
-                    self.stage.destroy()
-                return self._update_explicit_entry_in_db(rec, explicit)
+        if partial:
+            tty.msg("Continuing from partial install of %s" % self.name)
+        else:
+            # Ensure the package is not already installed
+            layout = spack.store.layout
+            with spack.store.db.prefix_read_lock(self.spec):
+                if layout.check_installed(self.spec):
+                    msg = '{0.name} is already installed in {0.prefix}'
+                    tty.msg(msg.format(self))
+                    rec = spack.store.db.get_record(self.spec)
+                    # In case the stage directory has already been created,
+                    # this ensures it's removed after we checked that the spec
+                    # is installed
+                    if keep_stage is False:
+                        self.stage.destroy()
+                    return self._update_explicit_entry_in_db(rec, explicit)
 
         self._do_install_pop_kwargs(kwargs)
 


### PR DESCRIPTION
May fix a deadlock issue discussed in #11981.

This change was extracted from a commit in #11981 .