### PR TITLE
musl: prefix -> self.prefix

### DIFF
--- a/var/spack/repos/builtin/packages/musl/package.py
+++ b/var/spack/repos/builtin/packages/musl/package.py
@@ -43,7 +43,7 @@ class Musl(Package):
                           format(self.compiler.cc))
 
     def configure_args(self):
-        args = ['--prefix={0}'.format(prefix)]
+        args = ['--prefix={0}'.format(self.prefix)]
         if self.compiler.name == 'gcc':
             args.append('--enable-wrapper=gcc')
         elif self.compiler.name == 'clang':


### PR DESCRIPTION
This PR fixes a bug in the musl spec which arises when the modulefile is built:

`==> Warning:   --> global name 'prefix' is not defined <--
`
