### PR TITLE
docs: update build_stage examples

### DIFF
--- a/lib/spack/docs/config_yaml.rst
+++ b/lib/spack/docs/config_yaml.rst
@@ -90,8 +90,9 @@ space available in the temporary location than in the home directory.  If the
 username is not already in the path, Spack will also append the value of
 `$user` to the path.
 
-.. warning:: We highly recommend appending `spack-stage` to `$tempdir` in order
-   to ensure `spack clean` does not delete everything in `$tempdir`.
+.. warning:: We highly recommend appending ``spack-stage`` to ``$tempdir`` in
+   order to ensure ``spack clean`` does not delete unrelated files from
+   ``$tempdir``.
 
 By default, Spack's ``build_stage`` is configured like this:
 
@@ -103,8 +104,8 @@ By default, Spack's ``build_stage`` is configured like this:
 This can be an ordered list of paths that Spack should search when trying to
 find a temporary directory for the build stage.  The list is searched in
 order, and Spack will use the first directory to which it has write access.
-Specifying `~/.spack/stage` first will ensure each user builds in their home
-directory.  The historic Spack stage path `$spack/var/spack/stage` will build
+Specifying ``~/.spack/stage`` first will ensure each user builds in their home
+directory.  The historic Spack stage path ``$spack/var/spack/stage`` will build
 directly inside the Spack instance.  See :ref:`config-file-variables` for more
 on ``$tempdir`` and ``$spack``.
 

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -36,8 +36,8 @@ Here is an example ``config.yaml`` file:
      module_roots:
        lmod: $spack/share/spack/lmod
      build_stage:
-       - $tempdir
-       - /nfs/tmp2/$user
+       - $tempdir/spack-stage
+       - /nfs/tmp2/$user/spack
 
 Each Spack configuration file is nested under a top-level section
 corresponding to its name. So, ``config.yaml`` starts with ``config:``,
@@ -244,8 +244,8 @@ your configurations look like this:
      module_roots:
        lmod: $spack/share/spack/lmod
      build_stage:
-       - $tempdir
-       - /nfs/tmp2/$user
+       - $tempdir/spack-stage
+       - /nfs/tmp2/$user/spack
 
 
 .. code-block:: yaml
@@ -269,8 +269,8 @@ command:
      module_roots:
        lmod: $spack/share/spack/lmod
      build_stage:
-       - $tempdir
-       - /nfs/tmp2/$user
+       - $tempdir/spack-stage
+       - /nfs/tmp2/$user/spack
 
 
 .. _config-overrides:
@@ -312,8 +312,8 @@ Let's revisit the ``config.yaml`` example one more time. The
    :caption: $(prefix)/etc/spack/defaults/config.yaml
 
    build_stage:
-     - $tempdir
-     - /nfs/tmp2/$user
+     - $tempdir/spack-stage
+     - /nfs/tmp2/$user/spack
 
 
 Suppose the user configuration adds its *own* list of ``build_stage``
@@ -323,7 +323,7 @@ paths:
    :caption: ~/.spack/config.yaml
 
    build_stage:
-     - /lustre-scratch/$user
+     - /lustre-scratch/$user/spack-stage
      - ~/mystage
 
 
@@ -341,10 +341,10 @@ get config`` shows the result:
      module_roots:
        lmod: $spack/share/spack/lmod
      build_stage:
-       - /lustre-scratch/$user
+       - /lustre-scratch/$user/spack
        - ~/mystage
-       - $tempdir
-       - /nfs/tmp2/$user
+       - $tempdir/spack-stage
+       - /nfs/tmp2/$user/spack
 
 
 As in :ref:`config-overrides`, the higher-precedence scope can
@@ -356,7 +356,7 @@ user config looked like this:
    :caption: ~/.spack/config.yaml
 
    build_stage::
-     - /lustre-scratch/$user
+     - /lustre-scratch/$user/spack
      - ~/mystage
 
 
@@ -371,7 +371,7 @@ The merged configuration would look like this:
      module_roots:
        lmod: $spack/share/spack/lmod
      build_stage:
-       - /lustre-scratch/$user
+       - /lustre-scratch/$user/spack
        - ~/mystage
 
 
@@ -465,8 +465,8 @@ account all scopes. For example, to see the fully merged
        lmod: $spack/share/spack/lmod
        dotkit: $spack/share/spack/dotkit
      build_stage:
-     - $tempdir
-     - /nfs/tmp2/$user
+     - $tempdir/spack-stage
+     - /nfs/tmp2/$user/spack
      - $spack/var/spack/stage
      source_cache: $spack/var/spack/cache
      misc_cache: ~/.spack/cache
@@ -516,8 +516,8 @@ down the problem:
    /home/myuser/spack/etc/spack/defaults/config.yaml:34      lmod: $spack/share/spack/lmod
    /home/myuser/spack/etc/spack/defaults/config.yaml:35      dotkit: $spack/share/spack/dotkit
    /home/myuser/spack/etc/spack/defaults/config.yaml:49    build_stage:
-   /home/myuser/spack/etc/spack/defaults/config.yaml:50    - $tempdir
-   /home/myuser/spack/etc/spack/defaults/config.yaml:51    - /nfs/tmp2/$user
+   /home/myuser/spack/etc/spack/defaults/config.yaml:50    - $tempdir/spack-stage
+   /home/myuser/spack/etc/spack/defaults/config.yaml:51    - /nfs/tmp2/$user/spack
    /home/myuser/spack/etc/spack/defaults/config.yaml:52    - $spack/var/spack/stage
    /home/myuser/spack/etc/spack/defaults/config.yaml:57    source_cache: $spack/var/spack/cache
    /home/myuser/spack/etc/spack/defaults/config.yaml:62    misc_cache: ~/.spack/cache

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -3901,7 +3901,8 @@ The first step of ``spack install``.  Takes a spec and determines the
 correct download URL to use for the requested package version, then
 downloads the archive, checks it against an MD5 checksum, and stores
 it in a staging directory if the check was successful.  The staging
-directory will be located under ``$SPACK_HOME/var/spack``.
+directory will be located under the first writable directory in the
+``build_stage`` configuration setting.
 
 When run after the archive has already been downloaded, ``spack
 fetch`` is idempotent and will not download the archive again.

--- a/lib/spack/docs/tutorial_configuration.rst
+++ b/lib/spack/docs/tutorial_configuration.rst
@@ -856,7 +856,7 @@ from this file system with the following ``config.yaml``:
 
    It is important to distinguish the build stage directory from other
    directories in your scratch space to ensure ``spack clean`` does not
-   remove unrelated files.  See :ref:`_config-yaml` for details.
+   remove unrelated files.  See :ref:`config-yaml` for details.
 
 On systems with compilers that absolutely *require* environment variables
 like ``LD_LIBRARY_PATH``, it is possible to prevent Spack from cleaning

--- a/lib/spack/docs/tutorial_configuration.rst
+++ b/lib/spack/docs/tutorial_configuration.rst
@@ -849,8 +849,14 @@ from this file system with the following ``config.yaml``:
 
    config:
      build_stage:
-       - /scratch/$user
+       - /scratch/$user/spack
 
+
+.. note::
+
+   It is important to distinguish the build stage directory from other
+   directories in your scratch space to ensure ``spack clean`` does not
+   remove unrelated files.  See :ref:`_config-yaml` for details.
 
 On systems with compilers that absolutely *require* environment variables
 like ``LD_LIBRARY_PATH``, it is possible to prevent Spack from cleaning


### PR DESCRIPTION
See #12072 

Update more `build_stage` examples due to the potential impact of `spack clean` should the old example paths be used.