### PR TITLE
Improve mock_archive versatility; Remove unwanted ALLOWED_ARCHIVE_TYPES.

### DIFF
--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -585,8 +585,8 @@ def module_configuration(monkeypatch, request):
 ##########
 
 
-@pytest.fixture(scope='session')
-def mock_archive(tmpdir_factory):
+@pytest.fixture(scope='session', params=[('.tar.gz', 'z')])
+def mock_archive(request, tmpdir_factory):
     """Creates a very simple archive directory with a configure script and a
     makefile that installs to a prefix. Tars it up into an archive.
     """
@@ -615,8 +615,10 @@ def mock_archive(tmpdir_factory):
 
     # Archive it
     with tmpdir.as_cwd():
-        archive_name = '{0}.tar.gz'.format(spack.stage._source_path_subdir)
-        tar('-czf', archive_name, spack.stage._source_path_subdir)
+        archive_name = '{0}{1}'.format(spack.stage._source_path_subdir,
+                                       request.param[0])
+        tar('-c{0}f'.format(request.param[1]), archive_name,
+            spack.stage._source_path_subdir)
 
     Archive = collections.namedtuple('Archive',
                                      ['url', 'path', 'archive_file',

--- a/lib/spack/spack/test/url_fetch.py
+++ b/lib/spack/spack/test/url_fetch.py
@@ -45,6 +45,11 @@ def test_urlfetchstrategy_bad_url(tmpdir):
 
 
 @pytest.mark.parametrize('secure', [True, False])
+@pytest.mark.parametrize('mock_archive',
+                         [('.tar.gz', 'z'), ('.tgz', 'z'),
+                          ('.tar.bz2', 'j'), ('.tbz2', 'j'),
+                          ('.tar.xz', 'J'), ('.txz', 'J')],
+                         indirect=True)
 def test_fetch(
         mock_archive,
         secure,

--- a/lib/spack/spack/util/compression.py
+++ b/lib/spack/spack/util/compression.py
@@ -9,12 +9,13 @@ from itertools import product
 from spack.util.executable import which
 
 # Supported archive extensions.
-PRE_EXTS = ["tar", "TAR"]
-EXTS     = ["gz", "bz2", "xz", "Z", "zip", "tgz", "tbz2", "txz"]
+PRE_EXTS   = ["tar", "TAR"]
+EXTS       = ["gz", "bz2", "xz", "Z"]
+NOTAR_EXTS = ["zip", "tgz", "tbz2", "txz"]
 
 # Add PRE_EXTS and EXTS last so that .tar.gz is matched *before* .tar or .gz
 ALLOWED_ARCHIVE_TYPES = [".".join(l) for l in product(
-    PRE_EXTS, EXTS)] + PRE_EXTS + EXTS
+    PRE_EXTS, EXTS)] + PRE_EXTS + EXTS + NOTAR_EXTS
 
 
 def allowed_archive(path):


### PR DESCRIPTION
`mock_archive` can now take multiple extension / tar option pairs (default matches old behavior).

`url_fetch.test_fetch` tests more archive types.

`compression.EXTS` split into `EXTS` and `NOTAR_EXTS` to avoid unwanted, non-meaningful combinatoric extensions such as `.tar.tbz2`.