### PR TITLE
fix: add jpeg dependency

### DIFF
--- a/var/spack/repos/builtin/packages/motif/package.py
+++ b/var/spack/repos/builtin/packages/motif/package.py
@@ -24,3 +24,4 @@ class Motif(AutotoolsPackage):
     depends_on("libxcomposite")
     depends_on("libxfixes")
     depends_on("xbitmaps")
+    depends_on("jpeg")


### PR DESCRIPTION
although on most systems configure will find something e.g. in /usr/lib64 - this PR would force explicit installation