### PR TITLE
Support yaml paths anywhere specs are handled on CLI

### DIFF
--- a/lib/spack/spack/parse.py
+++ b/lib/spack/spack/parse.py
@@ -12,7 +12,7 @@ from six import string_types
 import spack.error
 
 
-class Token:
+class Token(object):
     """Represents tokens; generated from input by lexer and fed to parse()."""
 
     def __init__(self, type, value='', start=0, end=0):
@@ -25,7 +25,7 @@ class Token:
         return str(self)
 
     def __str__(self):
-        return "'%s'" % self.value
+        return "<%d: '%s'>" % (self.type, self.value)
 
     def is_a(self, type):
         return self.type == type
@@ -128,7 +128,7 @@ class Parser(object):
         raise ParseError(message, self.text, self.token.start)
 
     def unexpected_token(self):
-        self.next_token_error("Unexpected token")
+        self.next_token_error("Unexpected token: '%s'" % self.next.value)
 
     def expect(self, id):
         """Like accept(), but fails if we don't like the next token."""

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -564,7 +564,7 @@ class RepoPath(object):
     def providers_for(self, vpkg_spec):
         providers = self.provider_index.providers_for(vpkg_spec)
         if not providers:
-            raise UnknownPackageError(vpkg_spec.name)
+            raise UnknownPackageError(vpkg_spec.fullname)
         return providers
 
     @autospec
@@ -967,7 +967,7 @@ class Repo(object):
     def providers_for(self, vpkg_spec):
         providers = self.provider_index.providers_for(vpkg_spec)
         if not providers:
-            raise UnknownPackageError(vpkg_spec.name)
+            raise UnknownPackageError(vpkg_spec.fullname)
         return providers
 
     @autospec
@@ -1283,10 +1283,17 @@ class UnknownPackageError(UnknownEntityError):
     def __init__(self, name, repo=None):
         msg = None
         if repo:
-            msg = "Package %s not found in repository %s" % (name, repo)
+            msg = "Package '%s' not found in repository '%s'" % (name, repo)
         else:
-            msg = "Package %s not found." % name
-        super(UnknownPackageError, self).__init__(msg)
+            msg = "Package '%s' not found." % name
+
+        # special handling for specs that may have been intended as filenames
+        # prompt the user to ask whether they intended to write './<name>'
+        long_msg = None
+        if name.endswith(".yaml"):
+            long_msg = "Did you mean to specify a filename with './%s'?" % name
+
+        super(UnknownPackageError, self).__init__(msg, long_msg)
         self.name = name
 
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3828,7 +3828,7 @@ class SpecLexer(spack.parse.Lexer):
             (r'\=', lambda scanner, val: self.token(EQ,    val)),
 
             # Filenames match before identifiers, so no initial filename
-            # ccomponent is parsed as a spec (e.g., in subdir/spec.yaml)
+            # component is parsed as a spec (e.g., in subdir/spec.yaml)
             (r'[/\w.-]+\.yaml[^\b]*', lambda scanner, v: self.token(FILE, v)),
 
             # Hash match after filename. No valid filename can be a hash


### PR DESCRIPTION
This is maybe a cleaner approach to do the same thing as described in #11103.  It gets around some of the ambiguities there and allows any combination of clispecs and yaml paths, including depending on other specs by yaml path.

## Notes on the approach:

Paths to spec yaml files (files containing concreted specs) can come in three flavors:

1. file in current directory (no relative path specifiers included e.g. `pkgconf.yaml`)
2. relative path (e.g. `./pkgconf.yaml`, `../../Documents/pkgconf.yaml`, etc.)
3. absolute path (`/home/me/pkgconf.yaml`, `/home/me/../me/pkgconf.yaml`, etc.)

### Case 1 (relative path, current directory):
  
This case collides with existing handling of namespaced specs.  Current examples like `builtin.yaml-cpp`, which need to keep working, provided some of the constraints we needed to handle.  To handle this case, we let the normal tokenization catch, e.g., `pkgconf.yaml` as an ID, which would normally be treated as a namespaced package, but now we first check if there is a file in the current directory with that name, and if that is the case, then we assume the user meant that rather than namespace `pkgconf` and package name `yaml`.

### Case 2 (relative path starting with or containing "." and ".."):

We added the `DOTS` token to the lexer to notice any instances of `.` or `..` in the input.  These don't get confused with ID tokens because ID must start with a word character.  If we ever see this new token, we look ahead in the input to see if any token ends with '.yaml' and from there try to handle spec yaml path.  We allow `DOTS` to appear anywhere in the path, e.g. `../../some_directory/./pkgconf.yaml`

### Case 3 (absolute paths starting with '/'):

This case collides with the existing parsing that sees `/` as the beginning of a package hash.  So the general approach we took here was to first try to treat anything after a `/` as a hash.  And only if that results in a `NoSuchHashError`, do we attempt to treat what comes next as possibly a path to a yaml file. 

Currently, there were three cases where "/<pkg-hash>" could be expected to appear in cli input taking "specs":

- Just referring to a root spec by hash
- Some other spec depending on a spec by hash
- Hash used to qualify previous spec in input (like a variant)

In all those cases, we allow spec parsing to first try to treat what comes after the '/' as a spec hash.  If the result is a `NoSuchHashError`, then we were about to bail anyway, telling the user about the bad hash.  So it seems safe to just peek ahead in the input at this point and see if what comes next could be interpreted as a path to a spec yaml file (it must end in .yaml).  If we don't find that, then we just go ahead and report the `NoSuchHashError`.  Otherwise we assume the user meant to provide a path to a yaml file, and proceed on that assumption.

The result of this is that we can now accept path to spec yaml files (but the file must be named with the .yaml extension) anywhere we could accept other types of cli specs on the command line.