### PR TITLE
gobject-introspection: add GIR file search path

### DIFF
--- a/var/spack/repos/builtin/packages/gobject-introspection/package.py
+++ b/var/spack/repos/builtin/packages/gobject-introspection/package.py
@@ -57,6 +57,10 @@ class GobjectIntrospection(Package):
         url = 'http://ftp.gnome.org/pub/gnome/sources/gobject-introspection/{0}/gobject-introspection-{1}.tar.xz'
         return url.format(version.up_to(2), version)
 
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        spack_env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
+        run_env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
+
     def install(self, spec, prefix):
         configure("--prefix=%s" % prefix)
         # we need to filter this file to avoid an overly long hashbang line


### PR DESCRIPTION
When building other GNOME packages, configure scripts for those packages will search for the GIR files installed by gobject-introspection. In order for these scripts to detect those files successfully, the prefix path for those files must be prepended to `XDG_DATA_DIRS`. This commit adds this operation to the `setup_dependent_environment` method in the `gobject-introspection` Spack package.