### PR TITLE
bugfix: atk build requires libffi to detect glib

### DIFF
--- a/var/spack/repos/builtin/packages/atk/package.py
+++ b/var/spack/repos/builtin/packages/atk/package.py
@@ -28,6 +28,7 @@ class Atk(Package):
     depends_on('gettext')
     depends_on('pkgconfig', type='build')
     depends_on('gobject-introspection')
+    depends_on('libffi')
 
     def url_for_version(self, version):
         """Handle gnome's version-based custom URLs."""


### PR DESCRIPTION
This pull request adds `libffi` as a dependency to the `atk` package, because its `configure` script checks for `libffi` as part of detecting `glib`. A similar fix for `pango` can be found in PR #12384 due to a similar issue in `pango` reported in issue #12383.