### PR TITLE
raja~openmp: explicitly disable OpenMP in CMake

### DIFF
--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -36,10 +36,8 @@ class Raja(CMakePackage):
         spec = self.spec
 
         options = []
-
-        if '+openmp' in spec:
-            options.extend([
-                '-DENABLE_OPENMP=On'])
+        options.append('-DENABLE_OPENMP={0}'.format(
+            'On' if '+openmp' in spec else 'Off'))
 
         if '+cuda' in spec:
             options.extend([


### PR DESCRIPTION
Before this commit, CMake would still attempt to detect OpenMP, even
if RAJA were being installed with `spack install raja~openmp`, because
the option `ENABLE_OPENMP` is set to "On" by default. This commit
explicitly disables OpenMP when the Spack install spec contains
'~openmp`, ensuring that CMake does not attempt to detect and link
with OpenMP.

Fixes https://github.com/spack/spack/issues/12571.