### PR TITLE
Views: fix python in views when python prefix is under a symlink

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -857,6 +857,9 @@ class Python(AutotoolsPackage):
                 # the spack install tree is located at a symlink or a
                 # descendent of a symlink. What we need here is the real
                 # relative path from the python prefix to src
+                # TODO: generalize this logic in the link_tree object
+                #    add a method to resolve a link relative to the link_tree
+                #    object root.
                 realpath_src = os.path.realpath(src)
                 realpath_prefix = os.path.realpath(self.spec.prefix)
                 realpath_rel = os.path.relpath(realpath_src, realpath_prefix)

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -853,7 +853,15 @@ class Python(AutotoolsPackage):
                         backup=False
                     )
             else:
-                orig_link_target = os.path.realpath(src)
+                # orig_link_target = os.path.realpath(src) is insufficient when
+                # the spack install tree is located at a symlink or a
+                # descendent of a symlink. What we need here is the real
+                # relative path from the python prefix to src
+                realpath_src = os.path.realpath(src)
+                realpath_prefix = os.path.realpath(self.spec.prefix)
+                realpath_rel = os.path.relpath(realpath_src, realpath_prefix)
+                orig_link_target = os.path.join(self.spec.prefix, realpath_rel)
+
                 new_link_target = os.path.abspath(merge_map[orig_link_target])
                 view.link(new_link_target, dst)
 


### PR DESCRIPTION
Currently, the python `add_files_to_view` method attempts to get the real path from the prefix to a file using `os.path.realpath`. However, that only works if the prefix itself is not under a symlink. If the prefix itself is under a symlink, the entire `merge_map` is created relative to that link.

By computing `os.path.realpath` of both the file and the python prefix, we can use `os.path.relpath` to compute the real relative path from the python prefix to the file, and prepend that with the python prefix to get the value we should expect in our `merge_map`.

Tested with `python@3.7` in a stack with a managed view. Spack could not link Python into the view without this change, and now can.