### PR TITLE
Qt@4.8.7: fix build issue due to +phonon variant, disable phonon backend

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -426,6 +426,10 @@ class Qt(Package):
             '-arch', str(spec.architecture.target),
         ])
 
+        if '+phonon' in self.spec:
+            config_args.append('-no-phonon-backend')
+
+
         if '~examples' in self.spec:
             config_args.extend(['-nomake', 'demos'])
 

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -426,9 +426,9 @@ class Qt(Package):
             '-arch', str(spec.architecture.target),
         ])
 
+        # Disable phonon backend until gstreamer is setup as dependency
         if '+phonon' in self.spec:
             config_args.append('-no-phonon-backend')
-
 
         if '~examples' in self.spec:
             config_args.extend(['-nomake', 'demos'])


### PR DESCRIPTION
disable phonon backend gstreamer until it is setup.