### PR TITLE
Install the newest version of ncbi-rmblastn

### DIFF
--- a/var/spack/repos/builtin/packages/ncbi-rmblastn/isb-2.9.0+-rmblast-p1.patch
+++ b/var/spack/repos/builtin/packages/ncbi-rmblastn/isb-2.9.0+-rmblast-p1.patch
@@ -1,0 +1,238 @@
+diff -rupN ncbi-blast-2.9.0+-src.orig/c++/src/app/rmblastn/Makefile.in ncbi-blast-2.9.0+-src/c++/src/app/rmblastn/Makefile.in
+--- ncbi-blast-2.9.0+-src.orig/c++/src/app/rmblastn/Makefile.in	1969-12-31 16:00:00.000000000 -0800
++++ ncbi-blast-2.9.0+-src/c++/src/app/rmblastn/Makefile.in	2019-04-01 13:25:24.854320235 -0700
+@@ -0,0 +1,16 @@
++# $Id: Makefile.in 371962 2012-08-14 09:45:56Z coulouri $
++
++# Meta-makefile("APP" project)
++#################################
++
++REQUIRES = objects algo
++
++APP_PROJ = rmblastn
++
++srcdir = @srcdir@
++include @builddir@/Makefile.meta
++
++.PHONY: all $(APP_PROJ)
++
++rmblastn:
++	${MAKE} ${MFLAGS} -f Makefile.rmblastn_app
+diff -rupN ncbi-blast-2.9.0+-src.orig/c++/src/app/rmblastn/Makefile.rmblastn.app ncbi-blast-2.9.0+-src/c++/src/app/rmblastn/Makefile.rmblastn.app
+--- ncbi-blast-2.9.0+-src.orig/c++/src/app/rmblastn/Makefile.rmblastn.app	1969-12-31 16:00:00.000000000 -0800
++++ ncbi-blast-2.9.0+-src/c++/src/app/rmblastn/Makefile.rmblastn.app	2019-04-01 13:25:24.856320218 -0700
+@@ -0,0 +1,16 @@
++WATCHERS = camacho madden maning
++
++APP = rmblastn
++SRC = rmblastn_app
++LIB_ = $(BLAST_INPUT_LIBS) $(BLAST_LIBS) $(OBJMGR_LIBS)
++LIB = blast_app_util $(LIB_:%=%$(STATIC))
++
++# De-universalize Mac builds to work around a PPC toolchain limitation
++CFLAGS   = $(FAST_CFLAGS:ppc=i386)
++CXXFLAGS = $(FAST_CXXFLAGS:ppc=i386)
++LDFLAGS  = $(FAST_LDFLAGS:ppc=i386)
++
++CPPFLAGS = $(ORIG_CPPFLAGS)
++LIBS = $(CMPRS_LIBS) $(DL_LIBS) $(PCRE_LIBS) $(NETWORK_LIBS) $(ORIG_LIBS)
++
++REQUIRES = objects -Cygwin
+diff -rupN ncbi-blast-2.9.0+-src.orig/c++/src/app/rmblastn/rmblastn_app.cpp ncbi-blast-2.9.0+-src/c++/src/app/rmblastn/rmblastn_app.cpp
+--- ncbi-blast-2.9.0+-src.orig/c++/src/app/rmblastn/rmblastn_app.cpp	1969-12-31 16:00:00.000000000 -0800
++++ ncbi-blast-2.9.0+-src/c++/src/app/rmblastn/rmblastn_app.cpp	2019-04-01 13:25:24.858320200 -0700
+@@ -0,0 +1,183 @@
++/*  $Id: rmblastn_app.cpp 371962 2012-08-14 09:45:56Z coulouri $
++ * ===========================================================================
++ *
++ *                            PUBLIC DOMAIN NOTICE
++ *
++ * ===========================================================================
++ *
++ * Authors:  Robert M. Hubley
++ *           Christiam Camacho ( original blastn_app.cpp )
++ *
++ */
++
++/** @file rmblastn_app.cpp
++ * RMBLASTN command line application
++ */
++
++#ifndef SKIP_DOXYGEN_PROCESSING
++static char const rcsid[] = 
++	"$Id: rmblastn_app.cpp 371962 2012-08-14 09:45:56Z coulouri $";
++#endif /* SKIP_DOXYGEN_PROCESSING */
++
++#include <ncbi_pch.hpp>
++#include <corelib/ncbiapp.hpp>
++#include <algo/blast/api/local_blast.hpp>
++#include <algo/blast/api/remote_blast.hpp>
++#include <algo/blast/blastinput/blast_fasta_input.hpp>
++#include <algo/blast/blastinput/rmblastn_args.hpp>
++#include <algo/blast/api/objmgr_query_data.hpp>
++#include <algo/blast/format/blast_format.hpp>
++#include "../blast/blast_app_util.hpp"
++
++#ifndef SKIP_DOXYGEN_PROCESSING
++USING_NCBI_SCOPE;
++USING_SCOPE(blast);
++USING_SCOPE(objects);
++#endif
++
++class CRMBlastnApp : public CNcbiApplication
++{
++public:
++    /** @inheritDoc */
++    CRMBlastnApp() {
++        CRef<CVersion> version(new CVersion());
++        version->SetVersionInfo(new CBlastVersion());
++        SetFullVersion(version);
++    }
++private:
++    /** @inheritDoc */
++    virtual void Init();
++    /** @inheritDoc */
++    virtual int Run();
++
++    /// This application's command line args
++    CRef<CRMBlastnAppArgs> m_CmdLineArgs; 
++};
++
++
++
++void CRMBlastnApp::Init()
++{
++    // formulate command line arguments
++    m_CmdLineArgs.Reset(new CRMBlastnAppArgs());
++
++    // read the command line
++
++    HideStdArgs(fHideLogfile | fHideConffile | fHideFullVersion | fHideXmlHelp | fHideDryRun);
++    SetupArgDescriptions(m_CmdLineArgs->SetCommandLine());
++}
++
++int CRMBlastnApp::Run(void)
++{
++    int status = BLAST_EXIT_SUCCESS;
++
++    try {
++
++        // Allow the fasta reader to complain on invalid sequence input
++        SetDiagPostLevel(eDiag_Warning);
++
++        /*** Get the BLAST options ***/
++        const CArgs& args = GetArgs();
++        CRef<CBlastOptionsHandle> opts_hndl;
++        if(RecoverSearchStrategy(args, m_CmdLineArgs)) {
++           	opts_hndl.Reset(&*m_CmdLineArgs->SetOptionsForSavedStrategy(args));
++        }
++        else {
++           	opts_hndl.Reset(&*m_CmdLineArgs->SetOptions(args));
++        }
++        const CBlastOptions& opt = opts_hndl->GetOptions();
++
++        /*** Get the query sequence(s) ***/
++        CRef<CQueryOptionsArgs> query_opts = 
++            m_CmdLineArgs->GetQueryOptionsArgs();
++        SDataLoaderConfig dlconfig(query_opts->QueryIsProtein());
++        dlconfig.OptimizeForWholeLargeSequenceRetrieval();
++        CBlastInputSourceConfig iconfig(dlconfig, query_opts->GetStrand(),
++                                     query_opts->UseLowercaseMasks(),
++                                     query_opts->GetParseDeflines(),
++                                     query_opts->GetRange());
++        iconfig.SetSkipSeqCheck(true);
++        CBlastFastaInputSource fasta(m_CmdLineArgs->GetInputStream(), iconfig);
++        CBlastInput input(&fasta, m_CmdLineArgs->GetQueryBatchSize());
++
++        /*** Initialize the database/subject ***/
++        CRef<CBlastDatabaseArgs> db_args(m_CmdLineArgs->GetBlastDatabaseArgs());
++        CRef<CLocalDbAdapter> db_adapter;
++        CRef<CScope> scope;
++        InitializeSubject(db_args, opts_hndl, m_CmdLineArgs->ExecuteRemotely(),
++                         db_adapter, scope);
++        _ASSERT(db_adapter && scope);
++
++        // Initialize the megablast database index now so we can know whether an indexed search will be run.
++        // This is only important for the reference in the report, but would be done anyway.
++        if (opt.GetUseIndex() && !m_CmdLineArgs->ExecuteRemotely()) {
++            CRef<CBlastOptions> my_options(&(opts_hndl->SetOptions()));
++            CSetupFactory::InitializeMegablastDbIndex(my_options);
++        }
++
++        /*** Get the formatting options ***/
++        CRef<CFormattingArgs> fmt_args(m_CmdLineArgs->GetFormattingArgs());
++        CBlastFormat formatter(opt, *db_adapter,
++                               fmt_args->GetFormattedOutputChoice(),
++                               query_opts->GetParseDeflines(),
++                               m_CmdLineArgs->GetOutputStream(),
++                               fmt_args->GetNumDescriptions(),
++                               fmt_args->GetNumAlignments(),
++                               *scope,
++                               opt.GetMatrixName(),
++                               fmt_args->ShowGis(),
++                               fmt_args->DisplayHtmlOutput(),
++                               opt.GetQueryGeneticCode(),
++                               opt.GetDbGeneticCode(),
++                               opt.GetSumStatisticsMode(),
++                               m_CmdLineArgs->ExecuteRemotely(),
++                               db_adapter->GetFilteringAlgorithm(),
++                               fmt_args->GetCustomOutputFormatSpec(),
++                               m_CmdLineArgs->GetTask() == "megablast",
++                               opt.GetMBIndexLoaded());
++                               
++        
++        formatter.PrintProlog();
++        
++        /*** Process the input ***/
++        for (; !input.End(); formatter.ResetScopeHistory()) {
++
++            CRef<CBlastQueryVector> query_batch(input.GetNextSeqBatch(*scope));
++            CRef<IQueryFactory> queries(new CObjMgr_QueryFactory(*query_batch));
++
++            SaveSearchStrategy(args, m_CmdLineArgs, queries, opts_hndl);
++
++            CRef<CSearchResultSet> results;
++
++            if (m_CmdLineArgs->ExecuteRemotely()) {
++                CRef<CRemoteBlast> rmt_blast = 
++                    InitializeRemoteBlast(queries, db_args, opts_hndl,
++                          m_CmdLineArgs->ProduceDebugRemoteOutput());
++                results = rmt_blast->GetResultSet();
++            } else {
++                CLocalBlast lcl_blast(queries, opts_hndl, db_adapter);
++                lcl_blast.SetNumberOfThreads(m_CmdLineArgs->GetNumThreads());
++                results = lcl_blast.Run();
++            }
++
++            ITERATE(CSearchResultSet, result, *results) {
++                formatter.PrintOneResultSet(**result, query_batch);
++            }
++        }
++
++        formatter.PrintEpilog(opt);
++
++        if (m_CmdLineArgs->ProduceDebugOutput()) {
++            opts_hndl->GetOptions().DebugDumpText(NcbiCerr, "BLAST options", 1);
++        }
++
++    } CATCH_ALL(status)
++    return status;
++}
++
++#ifndef SKIP_DOXYGEN_PROCESSING
++int main(int argc, const char* argv[] /*, const char* envp[]*/)
++{
++    return CRMBlastnApp().AppMain(argc, argv, 0, eDS_Default, 0);
++}
++#endif /* SKIP_DOXYGEN_PROCESSING */
+
+--- ncbi-blast-2.9.0+-src.orig/c++/src/objtools/blast/seqdb_reader/seqdbimpl.cpp 2019-08-02 15:07:03.643749527 -0700
++++ ncbi-blast-2.9.0+-src/c++/src/objtools/blast/seqdb_reader/seqdbimpl.cpp 2019-08-02 15:07:05.839730395 -0700
+@@ -808,7 +808,6 @@
+     if (! m_OidListSetup) {
+         x_GetOidList(locked);
+     }
+-    m_Atlas.Unlock(locked);
+ 
+     if (const CSeqDBVol * vol = m_VolSet.FindVol(oid, vol_oid)) {
+         return vol->GetSeqIDs(vol_oid);

--- a/var/spack/repos/builtin/packages/ncbi-rmblastn/package.py
+++ b/var/spack/repos/builtin/packages/ncbi-rmblastn/package.py
@@ -9,9 +9,19 @@ from spack import *
 class NcbiRmblastn(AutotoolsPackage):
     """RMBlast search engine for NCBI"""
 
-    homepage = "https://www.ncbi.nlm.nih.gov/"
-    url      = "ftp://ftp.ncbi.nlm.nih.gov/blast/executables/rmblast/LATEST/ncbi-rmblastn-2.2.28-src.tar.gz"
+    homepage = "http://www.repeatmasker.org/RMBlast.html"
+    url      = "ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.9.0/ncbi-blast-2.9.0+-src.tar.gz"
 
-    version('2.2.28', 'fb5f4e2e02ffcb1b17af2e9f206c5c22')
+    version('2.9.0', 'e6a44564e6278c445826ec2720f104b4')
+    patch('isb-2.9.0+-rmblast-p1.patch', when="@2.9.0")
 
     configure_directory = 'c++'
+
+    def configure_args(self):
+        args = [
+            "--with-mt",
+            "--without-debug",
+            "--without-krb5",
+            "--without-openssl",
+            "--with-projects=scripts/projects/rmblastn/project.lst"]
+        return args


### PR DESCRIPTION
Ncbi-rmblastn 2.2.28 configuration fails for Gcc compiler on Ubuntu 16.04 due to some compatibility issues that requires manual intervention to keep the installation going. However you still stumble upon other issues while compiling it.
Using Intel compiler passes the configuration step but fails for the compilation process as well.

Here I'm using the latest version and patch, and the recommended configuration option as mention in http://www.repeatmasker.org/RMBlast.html