### PR TITLE
Add triage label to non-feature GitHub issues (#12583)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report 
 about: Report a bug in the core of Spack (command not working as expected, etc.) 
-labels: bug
+labels: bug, triage
 ---
 
 

--- a/.github/ISSUE_TEMPLATE/build_error.md
+++ b/.github/ISSUE_TEMPLATE/build_error.md
@@ -1,7 +1,7 @@
 ---
 name: Build error 
 about: Some package in Spack didn't build correctly  
-labels: "build-error"
+labels: "build-error", triage
 ---
 
 *Thanks for taking the time to report this build failure. To proceed with the


### PR DESCRIPTION
Per Gregory Becker in https://spackpm.slack.com/archives/C5VL7V81G/p1566836354194100

> I think we should create the PR to add it (it should be a 2-liner) and open discussion there on what policies would be necessary once it’s merged
