### PR TITLE
Use system libpng by default

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -199,6 +199,7 @@ class Paraview(CMakePackage):
             '-DVTK_USE_SYSTEM_EXPAT:BOOL=ON',
             '-DVTK_USE_SYSTEM_TIFF:BOOL=ON',
             '-DVTK_USE_SYSTEM_ZLIB:BOOL=ON',
+            '-DVTK_USE_SYSTEM_PNG:BOOL=ON',
             '-DOpenGL_GL_PREFERENCE:STRING=LEGACY'
         ]
 


### PR DESCRIPTION
It turns out that the embedded libpng in paraview doesn't build correctly
using more recent GNU compilers on aarch64 systems.  It ends up partially
configuring the embedded libpng for neon but the build fails with confusion
about whether to use neon instructions or not.

Specifying that the available system libpng be used instead resolves this problem.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>