### PR TITLE
ncurses: improve build time

### DIFF
--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -56,7 +56,9 @@ class Ncurses(AutotoolsPackage):
                       '--without-manpages',
                       '--without-tests']
 
-        wide_opts = ['--enable-widec']
+        wide_opts = ['--enable-widec',
+                     '--without-manpages',
+                     '--without-tests']
 
         if '+symlinks' in self.spec:
             opts.append('--enable-symlinks')


### PR DESCRIPTION
Apply configure options to skip manpage generation and test builds for both wide and non-wide builds.