### PR TITLE
Boost: fixed problem when requesting ~signals for boost >= 1.69

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -389,17 +389,17 @@ class Boost(Package):
         # Remove libraries that the release version does not support
         if spec.satisfies('@1.69.0:') and 'signals' in with_libs:
             with_libs.remove('signals')
-        if not spec.satisfies('@1.54.0:'):
+        if not spec.satisfies('@1.54.0:') and 'log' in with_libs:
             with_libs.remove('log')
-        if not spec.satisfies('@1.53.0:'):
+        if not spec.satisfies('@1.53.0:') and 'atomic' in with_libs:
             with_libs.remove('atomic')
-        if not spec.satisfies('@1.48.0:'):
+        if not spec.satisfies('@1.48.0:') and 'locale' in with_libs:
             with_libs.remove('locale')
-        if not spec.satisfies('@1.47.0:'):
+        if not spec.satisfies('@1.47.0:') and 'chrono' in with_libs:
             with_libs.remove('chrono')
-        if not spec.satisfies('@1.43.0:'):
+        if not spec.satisfies('@1.43.0:') and 'random' in with_libs:
             with_libs.remove('random')
-        if not spec.satisfies('@1.39.0:'):
+        if not spec.satisfies('@1.39.0:') and 'exception' in with_libs:
             with_libs.remove('exception')
         if '+graph' in spec and '+mpi' in spec:
             with_libs.append('graph_parallel')

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -387,7 +387,7 @@ class Boost(Package):
             return
 
         # Remove libraries that the release version does not support
-        if spec.satisfies('@1.69.0:'):
+        if spec.satisfies('@1.69.0:') and 'signals' in with_libs:
             with_libs.remove('signals')
         if not spec.satisfies('@1.54.0:'):
             with_libs.remove('log')


### PR DESCRIPTION
Without this fix, when requesting `boost~signals` for a boost version greater than or equal to 1.69, spack throws an exception on line 391 saying that 'signals' is not in `with_libs`.

With this fix, spack will simply ignore the ~signals since the signals variant does not exist after 1.69.