### PR TITLE
Add int64 variant to pumi and zoltan

### DIFF
--- a/var/spack/repos/builtin/packages/pumi/package.py
+++ b/var/spack/repos/builtin/packages/pumi/package.py
@@ -32,6 +32,7 @@ class Pumi(CMakePackage):
     version('2.2.0', commit='8c7e6f13943893b2bc1ece15003e4869a0e9634f')  # tag 2.2.0
     version('2.1.0', commit='840fbf6ec49a63aeaa3945f11ddb224f6055ac9f')
 
+    variant('int64', default=False, description='Enable 64bit mesh entity ids')
     variant('shared', default=False, description='Build shared libraries')
     variant('zoltan', default=False, description='Enable Zoltan Features')
     variant('fortran', default=False, description='Enable FORTRAN interface')
@@ -44,6 +45,7 @@ class Pumi(CMakePackage):
     depends_on('mpi')
     depends_on('cmake@3:', type='build')
     depends_on('zoltan', when='+zoltan')
+    depends_on('zoltan+int64', when='+zoltan+int64')
     simbase = "+base"
     simkernels = simbase + "+parasolid+acis+discrete"
     simfull = simkernels + "+abstract+adv+advmodel\
@@ -66,7 +68,8 @@ class Pumi(CMakePackage):
             '-DBUILD_SHARED_LIBS=%s' % ('ON' if '+shared' in spec else 'OFF'),
             '-DCMAKE_Fortran_COMPILER=%s' % spec['mpi'].mpifc,
             '-DPUMI_FORTRAN_INTERFACE=%s' %
-            ('ON' if '+fortran' in spec else 'OFF')
+            ('ON' if '+fortran' in spec else 'OFF'),
+            '-DMDS_ID_TYPE=%s' % ('long' if '+64bitIds' in spec else 'int')
         ]
         if self.spec.satisfies('simmodsuite=base'):
             args.append('-DENABLE_SIMMETRIX=ON')

--- a/var/spack/repos/builtin/packages/pumi/package.py
+++ b/var/spack/repos/builtin/packages/pumi/package.py
@@ -69,7 +69,7 @@ class Pumi(CMakePackage):
             '-DCMAKE_Fortran_COMPILER=%s' % spec['mpi'].mpifc,
             '-DPUMI_FORTRAN_INTERFACE=%s' %
             ('ON' if '+fortran' in spec else 'OFF'),
-            '-DMDS_ID_TYPE=%s' % ('long' if '+64bitIds' in spec else 'int')
+            '-DMDS_ID_TYPE=%s' % ('long' if '+int64' in spec else 'int')
         ]
         if self.spec.satisfies('simmodsuite=base'):
             args.append('-DENABLE_SIMMETRIX=ON')

--- a/var/spack/repos/builtin/packages/zoltan/package.py
+++ b/var/spack/repos/builtin/packages/zoltan/package.py
@@ -35,10 +35,12 @@ class Zoltan(AutotoolsPackage):
     variant('fortran', default=True, description='Enable Fortran support.')
     variant('mpi', default=True, description='Enable MPI support.')
     variant('parmetis', default=False, description='Enable ParMETIS support.')
+    variant('int64', default=False, description='Enable 64bit indices.')
 
     depends_on('mpi', when='+mpi')
 
     depends_on('parmetis@4:', when='+parmetis')
+    depends_on('metis+int64', when='+parmetis+int64')
     depends_on('metis', when='+parmetis')
 
     depends_on('perl@:5.21', type='build', when='@:3.6')
@@ -98,6 +100,9 @@ class Zoltan(AutotoolsPackage):
                 config_args.append('--with-libs=-lgfortran')
             if spec.satisfies('%intel'):
                 config_args.append('--with-libs=-lifcore')
+
+        if '+int64' in spec:
+            config_args.append('--with-id-type=ulong')
 
         if '+parmetis' in spec:
             parmetis_prefix = spec['parmetis'].prefix


### PR DESCRIPTION
Adds variant to pumi and zoltan that enables 64bit indices.