### PR TITLE
Archive all patches in a package after install

### DIFF
--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -9,6 +9,7 @@ import contextlib
 import errno
 import functools
 import inspect
+import itertools
 import os
 import re
 import shutil
@@ -921,7 +922,9 @@ class Repo(object):
 
         # Install patch files needed by the package.
         mkdirp(path)
-        for patch in spec.patches:
+        for patch in itertools.chain.from_iterable(
+            spec.package.patches.values()):
+
             if patch.path:
                 if os.path.exists(patch.path):
                     install(patch.path, path)

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -923,7 +923,7 @@ class Repo(object):
         # Install patch files needed by the package.
         mkdirp(path)
         for patch in itertools.chain.from_iterable(
-            spec.package.patches.values()):
+                spec.package.patches.values()):
 
             if patch.path:
                 if os.path.exists(patch.path):


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/12612

@glennpj can you confirm this fix?

When Spack installs a package it writes the `package.py` file and patches to a separate repository (which reflects the state of the package at the time it was installed). Previously, Spack only wrote patches that were used at installation time. This updates the archiving step to include all patch files that are relevant to the package (in case that repository is used in another context).

