### PR TITLE
gtkplus' cairo dependency must be +gobject

### DIFF
--- a/var/spack/repos/builtin/packages/gtkplus/package.py
+++ b/var/spack/repos/builtin/packages/gtkplus/package.py
@@ -25,7 +25,7 @@ class Gtkplus(AutotoolsPackage):
     # Hardcode X11 support (former +X variant),
     # see #6940 for rationale:
     depends_on('pango+X')
-    depends_on('cairo+X+pdf')
+    depends_on('cairo+X+pdf+gobject')
     depends_on('gobject-introspection')
     depends_on('libepoxy', when='@3:')
     depends_on('libxi', when='@3:')


### PR DESCRIPTION
[wow, lost a big hunk of my commit message, recreated here...]
[edit: change -> changed]

#12568 ~~change~~ changed the cairo package so that its --enable-gobject flag 
is either explicitly true or false.  Previously, the feature defaulted to `auto`
and configure would *auto*magically run a test to figure whether to
include gobject support.   I'm betting that (on our systems, at
least), it decided to include it.

Now that we're defaulting it to off, that functionality is not being
included.

The gtk configure script blithely assumes that cairo *has* gobject
support, by searching for the `cairo-gobject.pc` pkg-config file and
crash/burning when it's not there.

Making the cairo dependency include gobject support fixes it (as in,
Works For Me(tm) and Works For Owen(patent-pending)).

I've tested it in a clean environment on CentOS 7.  Owen has also tested it in his CI environment.

Fixes #12654