### PR TITLE
BUG: recursively load modules with tcsh

### DIFF
--- a/share/spack/csh/spack.csh
+++ b/share/spack/csh/spack.csh
@@ -132,7 +132,12 @@ case unload:
             endif
             breaksw
         case "load":
-            set _sp_full_spec = ( "`\spack $_sp_flags module tcl find $_sp_spec`" )
+            # _sp_module_args may be "-r" for recursive spec retrieval
+            set _sp_full_spec = ( "`\spack $_sp_flags module tcl find $_sp_module_args $_sp_spec`" )
+            if ( "$_sp_module_args" == "-r" ) then
+                # module load can handle the list of modules to load and "-r" is not a valid option
+                set _sp_module_args = ""
+            endif
             if ( $? == 0 ) then
                 module load $_sp_module_args $_sp_full_spec
             endif


### PR DESCRIPTION
Fixes #12661 -- I'm not a C-shell expert & will need guidance on regression testing here though -- @tgamblin is there a core dev I should ping for that guidance?

* for `tcsh` and `csh`, `spack load -r package`
should now correctly load recursively instead
of only loading the target package without any
dependencies

So far, I've only tested this informally on one local machine--it does seem to work.