### PR TITLE
Add conflicts statement to mariadb

### DIFF
--- a/var/spack/repos/builtin/packages/mariadb/package.py
+++ b/var/spack/repos/builtin/packages/mariadb/package.py
@@ -35,3 +35,5 @@ class Mariadb(CMakePackage):
     depends_on('libevent', when='+nonblocking')
     depends_on('ncurses')
     depends_on('zlib')
+
+    conflicts('%gcc@9.1.0:', when='@:5.5')


### PR DESCRIPTION
The mariadb-5.5 series can not be compiled with gcc-9.1.0 and above. Add
a conflicts statement to refect that.

The errors are due to -Werror=address-of-packed-member, a warning that is new in gcc-9.