### PR TITLE
IDBA: package does not need conflicts with other compilers

### DIFF
--- a/var/spack/repos/builtin/packages/idba/package.py
+++ b/var/spack/repos/builtin/packages/idba/package.py
@@ -19,11 +19,3 @@ class Idba(AutotoolsPackage):
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
     depends_on('libtool', type='build')    
-
-    conflicts('%cce')
-    conflicts('%clang')
-    conflicts('%intel')
-    conflicts('%nag')
-    conflicts('%pgi')
-    conflicts('%xl')
-    conflicts('%xl_r')


### PR DESCRIPTION
The IDBA package can be built with Intel 19 compilers.  There is no need to block building against other compilers, though it appears it's been sometime since the package has been updated by the primary developer.  No evidence that only GCC compiler can be supported: https://github.com/loneknightpy/idba