### PR TITLE
Add machine-readable options to `spack find`

### DIFF
--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -334,6 +334,10 @@ Packages are divided into groups according to their architecture and
 compiler.  Within each group, Spack tries to keep the view simple, and
 only shows the version of installed packages.
 
+""""""""""""""""""""""""""""""""
+Viewing more metadata
+""""""""""""""""""""""""""""""""
+
 ``spack find`` can filter the package list based on the package name, spec, or
 a number of properties of their installation status.  For example, missing
 dependencies of a spec can be shown with ``--missing``, packages which were
@@ -391,8 +395,8 @@ use ``spack find --paths``:
        callpath@1.0.2        ~/spack/opt/linux-debian7-x86_64/gcc@4.4.7/callpath@1.0.2-5dce4318
    ...
 
-And, finally, you can restrict your search to a particular package
-by supplying its name:
+You can restrict your search to a particular package by supplying its
+name:
 
 .. code-block:: console
 
@@ -401,6 +405,10 @@ by supplying its name:
        libelf@0.8.11  ~/spack/opt/linux-debian7-x86_64/gcc@4.4.7/libelf@0.8.11
        libelf@0.8.12  ~/spack/opt/linux-debian7-x86_64/gcc@4.4.7/libelf@0.8.12
        libelf@0.8.13  ~/spack/opt/linux-debian7-x86_64/gcc@4.4.7/libelf@0.8.13
+
+""""""""""""""""""""""""""""""""
+Spec queries
+""""""""""""""""""""""""""""""""
 
 ``spack find`` actually does a lot more than this.  You can use
 *specs* to query for specific configurations and builds of each
@@ -428,6 +436,109 @@ We can also search for packages that have a certain attribute. For example,
 with the 'debug' compile-time option enabled.
 
 The full spec syntax is discussed in detail in :ref:`sec-specs`.
+
+
+""""""""""""""""""""""""""""""""
+Machine-readable output
+""""""""""""""""""""""""""""""""
+
+If you only want to see very specific things about installed packages,
+Spack has some options for you.  ``spack find --format`` can be used to
+output only specific fields:
+
+.. code-block:: console
+
+   $ spack find --format "{name}-{version}-{hash}"
+   autoconf-2.69-icynozk7ti6h4ezzgonqe6jgw5f3ulx4
+   automake-1.16.1-o5v3tc77kesgonxjbmeqlwfmb5qzj7zy
+   bzip2-1.0.6-syohzw57v2jfag5du2x4bowziw3m5p67
+   bzip2-1.0.8-zjny4jwfyvzbx6vii3uuekoxmtu6eyuj
+   cmake-3.15.1-7cf6onn52gywnddbmgp7qkil4hdoxpcb
+   ...
+
+or:
+
+.. code-block:: console
+
+   $ spack find --format "{hash:7}"
+   icynozk
+   o5v3tc7
+   syohzw5
+   zjny4jw
+   7cf6onn
+   ...
+
+This uses the same syntax as described in documentation for
+:meth:`~spack.spec.Spec.format` -- you can use any of the options there.
+This is useful for passing metadata about packages to other command-line
+tools.
+
+Alternately, if you want something even more machine readable, you can
+output each spec as JSON records using ``spack find --json``.  This will
+output metadata on specs and all dependencies as json:
+
+.. code-block:: console
+
+    $ spack find --json sqlite@3.28.0
+    [
+     {
+      "name": "sqlite",
+      "hash": "3ws7bsihwbn44ghf6ep4s6h4y2o6eznv",
+      "version": "3.28.0",
+      "arch": {
+       "platform": "darwin",
+       "platform_os": "mojave",
+       "target": "x86_64"
+      },
+      "compiler": {
+       "name": "clang",
+       "version": "10.0.0-apple"
+      },
+      "namespace": "builtin",
+      "parameters": {
+       "fts": true,
+       "functions": false,
+       "cflags": [],
+       "cppflags": [],
+       "cxxflags": [],
+       "fflags": [],
+       "ldflags": [],
+       "ldlibs": []
+      },
+      "dependencies": {
+       "readline": {
+        "hash": "722dzmgymxyxd6ovjvh4742kcetkqtfs",
+        "type": [
+         "build",
+         "link"
+        ]
+       }
+      }
+     },
+     ...
+    ]
+
+You can use this with tools like `jq <https://stedolan.github.io/jq/>`_ to quickly create JSON records
+structured the way you want:
+
+.. code-block:: console
+
+    $ spack find --json sqlite@3.28.0 | jq -C '.[] | { name, version, hash }'
+    {
+      "name": "sqlite",
+      "version": "3.28.0",
+      "hash": "3ws7bsihwbn44ghf6ep4s6h4y2o6eznv"
+    }
+    {
+      "name": "readline",
+      "version": "7.0",
+      "hash": "722dzmgymxyxd6ovjvh4742kcetkqtfs"
+    }
+    {
+      "name": "ncurses",
+      "version": "6.1",
+      "hash": "zvaa4lhlhilypw5quj3akyd3apbq5gap"
+    }
 
 .. _sec-specs:
 

--- a/lib/spack/docs/config_yaml.rst
+++ b/lib/spack/docs/config_yaml.rst
@@ -36,14 +36,13 @@ to help with that. Firstly, the ``install_hash_length`` parameter can
 set the length of the hash in the installation path from 1 to 32. The
 default path uses the full 32 characters.
 
-Secondly, it is
-also possible to modify the entire installation scheme. By default
-Spack uses
+Secondly, it is also possible to modify the entire installation
+scheme. By default Spack uses
 ``{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}``
 where the tokens that are available for use in this directive are the
-same as those understood by the ``Spec.format`` method. Using this parameter it
-is possible to use a different package layout or reduce the depth of
-the installation paths. For example
+same as those understood by the :meth:`~spack.spec.Spec.format`
+method. Using this parameter it is possible to use a different package
+layout or reduce the depth of the installation paths. For example
 
      .. code-block:: yaml
 

--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -545,7 +545,7 @@ most likely via the ``+blas`` variant specification.
      base directory of the same module, effectively preventing the possibility to
      load two or more versions of the same software at the same time. The tokens
      that are available for use in this directive are the same understood by
-     the ``Spec.format`` method.
+     the :meth:`~spack.spec.Spec.format` method.
 
 
 .. note::

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -201,115 +201,31 @@ def gray_hash(spec, length):
     return colorize('@K{%s}' % h)
 
 
-def display_formatted_specs(specs, format_string, deps=False):
-    """Print a list of specs formatted with the provided string.
-
-    Arguments:
-        specs (list): list of specs to display.
-        deps (bool): whether to also print dependencies of specs.
-    """
-    for spec in specs:
-        print(spec.format(format_string))
-        if deps:
-            for depth, dep in spec.traverse(depth=True, root=False):
-                print("   " * depth, dep.format(format_string))
-
-
 def display_specs_as_json(specs, deps=False):
     """Convert specs to a list of json records."""
     seen = set()
     records = []
     for spec in specs:
-        if spec.dag_hash() not in seen:
-            seen.add(spec.dag_hash())
-            records.append(spec.to_record_dict())
+        if spec.dag_hash() in seen:
+            continue
+        seen.add(spec.dag_hash())
+        records.append(spec.to_record_dict())
 
         if deps:
             for dep in spec.traverse():
-                if dep.dag_hash() not in seen:
-                    seen.add(spec.dag_hash())
-                    records.append(dep.to_record_dict())
+                if dep.dag_hash() in seen:
+                    continue
+                seen.add(dep.dag_hash())
+                records.append(dep.to_record_dict())
 
     sjson.dump(records, sys.stdout)
 
 
-def display_specs(specs, args=None, **kwargs):
-    """Display human readable specs with customizable formatting.
-
-    Prints the supplied specs to the screen, formatted according to the
-    arguments provided.
-
-    Specs are grouped by architecture and compiler, and columnized if
-    possible.  There are three possible "modes":
-
-      * ``short`` (default): short specs with name and version, columnized
-      * ``paths``: Two columns: one for specs, one for paths
-      * ``deps``: Dependency-tree style, like ``spack spec``; can get long
-
-    Options can add more information to the default display. Options can
-    be provided either as keyword arguments or as an argparse namespace.
-    Keyword arguments take precedence over settings in the argparse
-    namespace.
-
-    Args:
-        specs (list of spack.spec.Spec): the specs to display
-        args (optional argparse.Namespace): namespace containing
-            formatting arguments
-
-    Keyword Args:
-        mode (str): Either 'short', 'paths', or 'deps'
-        long (bool): Display short hashes with specs
-        very_long (bool): Display full hashes with specs (supersedes ``long``)
-        namespace (bool): Print namespaces along with names
-        show_flags (bool): Show compiler flags with specs
-        variants (bool): Show variants with specs
-        indent (int): indent each line this much
-        decorators (dict): dictionary mappng specs to decorators
-        header_callback (function): called at start of arch/compiler sections
-        all_headers (bool): show headers even when arch/compiler aren't defined
-    """
-    def get_arg(name, default=None):
-        """Prefer kwargs, then args, then default."""
-        if name in kwargs:
-            return kwargs.get(name)
-        elif args is not None:
-            return getattr(args, name, default)
-        else:
-            return default
-
-    mode          = get_arg('mode', 'short')
-    hashes        = get_arg('long', False)
-    namespace     = get_arg('namespace', False)
-    flags         = get_arg('show_flags', False)
-    full_compiler = get_arg('show_full_compiler', False)
-    variants      = get_arg('variants', False)
-    all_headers   = get_arg('all_headers', False)
-
-    decorator     = get_arg('decorator', None)
-    if decorator is None:
-        decorator = lambda s, f: f
-
-    indent = get_arg('indent', 0)
-    ispace = indent * ' '
-
-    hlen = 7
-    if get_arg('very_long', False):
-        hashes = True
-        hlen = None
-
-    nfmt = '{namespace}.{name}' if namespace else '{name}'
-    ffmt = ''
-    if full_compiler or flags:
-        ffmt += '{%compiler.name}'
-        if full_compiler:
-            ffmt += '{@compiler.version}'
-        ffmt += ' {compiler_flags}'
-    vfmt = '{variants}' if variants else ''
-    format_string = nfmt + '{@version}' + ffmt + vfmt
-
+def iter_sections(specs, indent, all_headers):
+    """Break a list of specs into sections indexed by arch/compiler."""
     # Make a dict with specs keyed by architecture and compiler.
     index = index_by(specs, ('architecture', 'compiler'))
-    transform = {'package': decorator, 'fullpackage': decorator}
+    ispace = indent * ' '
 
     # Traverse the index and print out each package
     for i, (architecture, compiler) in enumerate(sorted(index)):
@@ -331,57 +247,131 @@ def display_specs(specs, args=None, **kwargs):
 
         specs = index[(architecture, compiler)]
         specs.sort()
+        yield specs
 
-        if mode == 'paths':
-            # Print one spec per line along with prefix path
-            abbreviated = [s.cformat(format_string, transform=transform)
-                           for s in specs]
-            width = max(len(s) for s in abbreviated)
-            width += 2
 
-            for abbrv, spec in zip(abbreviated, specs):
-                # optional hash prefix for paths
-                h = gray_hash(spec, hlen) if hashes else ''
+def display_specs(specs, args=None, **kwargs):
+    """Display human readable specs with customizable formatting.
 
-                # only show prefix for concrete specs
-                prefix = spec.prefix if spec.concrete else ''
+    Prints the supplied specs to the screen, formatted according to the
+    arguments provided.
 
-                # print it all out at once
-                fmt = "%%s%%s    %%-%ds%%s" % width
-                print(fmt % (ispace, h, abbrv, prefix))
+    Specs are grouped by architecture and compiler, and columnized if
+    possible.
 
-        elif mode == 'deps':
-            for spec in specs:
-                print(spec.tree(
-                    format=format_string,
-                    indent=4,
-                    prefix=(lambda s: gray_hash(s, hlen)) if hashes else None))
+    Options can add more information to the default display. Options can
+    be provided either as keyword arguments or as an argparse namespace.
+    Keyword arguments take precedence over settings in the argparse
+    namespace.
 
-        elif mode == 'short':
-            def fmt(s):
-                string = ""
-                if hashes:
-                    string += gray_hash(s, hlen) + ' '
-                string += s.cformat(
-                    nfmt + '{@version}' + vfmt, transform=transform)
-                return string
+    Args:
+        specs (list of spack.spec.Spec): the specs to display
+        args (optional argparse.Namespace): namespace containing
+            formatting arguments
 
-            if not flags and not full_compiler:
-                # Print columns of output if not printing flags
-                colify((fmt(s) for s in specs), indent=indent)
+    Keyword Args:
+        paths (bool): Show paths with each displayed spec
+        deps (bool): Display dependencies with specs
+        long (bool): Display short hashes with specs
+        very_long (bool): Display full hashes with specs (supersedes ``long``)
+        namespace (bool): Print namespaces along with names
+        show_flags (bool): Show compiler flags with specs
+        variants (bool): Show variants with specs
+        indent (int): indent each line this much
+        sections (bool): display specs grouped by arch/compiler (default True)
+        decorators (dict): dictionary mappng specs to decorators
+        header_callback (function): called at start of arch/compiler sections
+        all_headers (bool): show headers even when arch/compiler aren't defined
 
-            else:
-                # Print one entry per line if including flags
-                for spec in specs:
-                    # Print the hash if necessary
-                    hsh = gray_hash(spec, hlen) + ' ' if hashes else ''
-                    print(ispace + hsh + spec.cformat(
-                        format_string, transform=transform))
-
+    """
+    def get_arg(name, default=None):
+        """Prefer kwargs, then args, then default."""
+        if name in kwargs:
+            return kwargs.get(name)
+        elif args is not None:
+            return getattr(args, name, default)
         else:
-            raise ValueError(
-                "Invalid mode for display_specs: %s. Must be one of (paths,"
-                "deps, short)." % mode)
+            return default
+
+    paths         = get_arg('paths', False)
+    deps          = get_arg('deps', False)
+    hashes        = get_arg('long', False)
+    namespace     = get_arg('namespace', False)
+    flags         = get_arg('show_flags', False)
+    full_compiler = get_arg('show_full_compiler', False)
+    variants      = get_arg('variants', False)
+    sections      = get_arg('sections', True)
+    all_headers   = get_arg('all_headers', False)
+
+    decorator     = get_arg('decorator', None)
+    if decorator is None:
+        decorator = lambda s, f: f
+
+    indent = get_arg('indent', 0)
+
+    hlen = 7
+    if get_arg('very_long', False):
+        hashes = True
+        hlen = None
+
+    format_string = get_arg('format', None)
+    if format_string is None:
+        nfmt = '{namespace}.{name}' if namespace else '{name}'
+        ffmt = ''
+        if full_compiler or flags:
+            ffmt += '{%compiler.name}'
+            if full_compiler:
+                ffmt += '{@compiler.version}'
+            ffmt += ' {compiler_flags}'
+        vfmt = '{variants}' if variants else ''
+        format_string = nfmt + '{@version}' + ffmt + vfmt
+
+    transform = {'package': decorator, 'fullpackage': decorator}
+
+    def fmt(s, depth=0):
+        """Formatter function for all output specs"""
+        string = ""
+        if hashes:
+            string += gray_hash(s, hlen) + ' '
+        string += depth * "    "
+        string += s.cformat(format_string, transform=transform)
+        return string
+
+    def format_list(specs):
+        """Display a single list of specs, with no sections"""
+        # create the final, formatted versions of all specs
+        formatted = []
+        for spec in specs:
+            formatted.append((fmt(spec), spec))
+            if deps:
+                for depth, dep in spec.traverse(root=False, depth=True):
+                    formatted.append((fmt(dep, depth), dep))
+                formatted.append(('', None))  # mark newlines
+
+        # unless any of these are set, we can just colify and be done.
+        if not any((deps, paths)):
+            colify((f[0] for f in formatted), indent=indent)
+            return
+
+        # otherwise, we'll print specs one by one
+        max_width = max(len(f[0]) for f in formatted)
+        path_fmt = "%%-%ds%%s" % (max_width + 2)
+
+        for string, spec in formatted:
+            if not string:
+                print()  # print newline from above
+                continue
+
+            if paths:
+                print(path_fmt % (string, spec.prefix))
+            else:
+                print(string)
+
+    if sections:
+        for specs in iter_sections(specs, indent, all_headers):
+            format_list(specs)
+    else:
+        format_list(sorted(specs))
 
 
 def spack_is_git_repo():

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -221,8 +221,8 @@ def display_specs_as_json(specs, deps=False):
     sjson.dump(records, sys.stdout)
 
 
-def iter_sections(specs, indent, all_headers):
-    """Break a list of specs into sections indexed by arch/compiler."""
+def iter_groups(specs, indent, all_headers):
+    """Break a list of specs into groups indexed by arch/compiler."""
     # Make a dict with specs keyed by architecture and compiler.
     index = index_by(specs, ('architecture', 'compiler'))
     ispace = indent * ' '
@@ -278,9 +278,9 @@ def display_specs(specs, args=None, **kwargs):
         show_flags (bool): Show compiler flags with specs
         variants (bool): Show variants with specs
         indent (int): indent each line this much
-        sections (bool): display specs grouped by arch/compiler (default True)
+        groups (bool): display specs grouped by arch/compiler (default True)
         decorators (dict): dictionary mappng specs to decorators
-        header_callback (function): called at start of arch/compiler sections
+        header_callback (function): called at start of arch/compiler groups
         all_headers (bool): show headers even when arch/compiler aren't defined
 
     """
@@ -300,7 +300,7 @@ def display_specs(specs, args=None, **kwargs):
     flags         = get_arg('show_flags', False)
     full_compiler = get_arg('show_full_compiler', False)
     variants      = get_arg('variants', False)
-    sections      = get_arg('sections', True)
+    groups        = get_arg('groups', True)
     all_headers   = get_arg('all_headers', False)
 
     decorator     = get_arg('decorator', None)
@@ -338,7 +338,7 @@ def display_specs(specs, args=None, **kwargs):
         return string
 
     def format_list(specs):
-        """Display a single list of specs, with no sections"""
+        """Display a single list of specs, with no groups"""
         # create the final, formatted versions of all specs
         formatted = []
         for spec in specs:
@@ -367,8 +367,8 @@ def display_specs(specs, args=None, **kwargs):
             else:
                 print(string)
 
-    if sections:
-        for specs in iter_sections(specs, indent, all_headers):
+    if groups:
+        for specs in iter_groups(specs, indent, all_headers):
             format_list(specs)
     else:
         format_list(sorted(specs))

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -21,6 +21,7 @@ import spack.extensions
 import spack.paths
 import spack.spec
 import spack.store
+import spack.util.spack_json as sjson
 from spack.error import SpackError
 
 
@@ -212,6 +213,24 @@ def display_formatted_specs(specs, format_string, deps=False):
         if deps:
             for depth, dep in spec.traverse(depth=True, root=False):
                 print("   " * depth, dep.format(format_string))
+
+
+def display_specs_as_json(specs, deps=False):
+    """Convert specs to a list of json records."""
+    seen = set()
+    records = []
+    for spec in specs:
+        if spec.dag_hash() not in seen:
+            seen.add(spec.dag_hash())
+            records.append(spec.to_record_dict())
+
+        if deps:
+            for dep in spec.traverse():
+                if dep.dag_hash() not in seen:
+                    seen.add(spec.dag_hash())
+                    records.append(dep.to_record_dict())
+
+    sjson.dump(records, sys.stdout)
 
 
 def display_specs(specs, args=None, **kwargs):

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -200,6 +200,20 @@ def gray_hash(spec, length):
     return colorize('@K{%s}' % h)
 
 
+def display_formatted_specs(specs, format_string, deps=False):
+    """Print a list of specs formatted with the provided string.
+
+    Arguments:
+        specs (list): list of specs to display.
+        deps (bool): whether to also print dependencies of specs.
+    """
+    for spec in specs:
+        print(spec.format(format_string))
+        if deps:
+            for depth, dep in spec.traverse(depth=True, root=False):
+                print("   " * depth, dep.format(format_string))
+
+
 def display_specs(specs, args=None, **kwargs):
     """Display human readable specs with customizable formatting.
 

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -2,6 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 from __future__ import print_function
 
 import llnl.util.tty as tty
@@ -12,7 +13,6 @@ import spack.environment as ev
 import spack.repo
 import spack.cmd as cmd
 import spack.cmd.common.arguments as arguments
-from spack.cmd import display_specs
 from spack.util.string import plural
 
 description = "list and search installed packages"
@@ -36,6 +36,9 @@ def setup_parser(subparser):
     format_group.add_argument(
         "--format", action="store", default=None,
         help="output specs with the specified format string")
+    format_group.add_argument(
+        "--json", action="store_true", default=False,
+        help="output specs as machine-readable json records")
 
     # TODO: separate this entirely from the "mode" option -- it's
     # TODO: orthogonal, but changing it for all commands that use it with
@@ -159,14 +162,14 @@ def display_env(env, args, decorator):
     else:
         tty.msg('Root specs')
         # TODO: Change this to not print extraneous deps and variants
-        display_specs(
+        cmd.display_specs(
             env.user_specs, args,
             decorator=lambda s, f: color.colorize('@*{%s}' % f))
         print()
 
     if args.show_concretized:
         tty.msg('Concretized roots')
-        display_specs(
+        cmd.display_specs(
             env.specs_by_hash.values(), args, decorator=decorator)
         print()
 
@@ -205,4 +208,4 @@ def find(parser, args):
         if env:
             display_env(env, args, decorator)
         tty.msg("%s" % plural(len(results), 'installed package'))
-        display_specs(results, args, decorator=decorator, all_headers=True)
+        cmd.display_specs(results, args, decorator=decorator, all_headers=True)

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -35,10 +35,10 @@ def setup_parser(subparser):
     subparser.add_argument('-p', '--paths', action='store_true',
                            help='show paths to package install directories')
     subparser.add_argument(
-        '--sections', action='store_true', default=None, dest='sections',
-        help='group specs in arch/compiler sections (default on)')
+        '--groups', action='store_true', default=None, dest='groups',
+        help='display specs in arch/compiler groups (default on)')
     subparser.add_argument(
-        '--no-sections', action='store_false', default=None, dest='sections',
+        '--no-groups', action='store_false', default=None, dest='groups',
         help='do not group specs by arch/compiler')
 
     arguments.add_common_arguments(
@@ -177,16 +177,16 @@ def find(parser, args):
     if env:
         decorator, added, roots, removed = setup_env(env)
 
-    # use sections by default except with format.
-    if args.sections is None:
-        args.sections = not args.format
+    # use groups by default except with format.
+    if args.groups is None:
+        args.groups = not args.format
 
-    # Exit early if no package matches the constraint
+    # Exit early with an error code if no package matches the constraint
     if not results and args.constraint:
         msg = "No package matches the query: {0}"
         msg = msg.format(' '.join(args.constraint))
         tty.msg(msg)
-        return
+        return 1
 
     # If tags have been specified on the command line, filter by tags
     if args.tags:
@@ -199,7 +199,7 @@ def find(parser, args):
     else:
         if env:
             display_env(env, args, decorator)
-        if args.sections:
+        if args.groups:
             tty.msg("%s" % plural(len(results), 'installed package'))
         cmd.display_specs(
             results, args, decorator=decorator, all_headers=True)

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -952,6 +952,7 @@ class Environment(object):
             ('PKG_CONFIG_PATH', ['lib/pkgconfig', 'lib64/pkgconfig']),
             ('CMAKE_PREFIX_PATH', ['']),
         ]
+
         path_updates = list()
         if default_view_name in self.views:
             for var, subdirs in updates:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1540,6 +1540,31 @@ class Spec(object):
 
         return syaml_dict([('spec', node_list)])
 
+    def to_record_dict(self):
+        """Return a "flat" dictionary with name and hash as top-level keys.
+
+        This is similar to ``to_node_dict()``, but the name and the hash
+        are "flattened" into the dictionary for easiler parsing by tools
+        like ``jq``.  Instead of being keyed by name or hash, the
+        dictionary "name" and "hash" fields, e.g.::
+
+            {
+              "name": "openssl"
+              "hash": "3ws7bsihwbn44ghf6ep4s6h4y2o6eznv"
+              "version": "3.28.0",
+              "arch": {
+              ...
+            }
+
+        But is otherwise the same as ``to_node_dict()``.
+
+        """
+        dictionary = syaml_dict()
+        dictionary["name"] = self.name
+        dictionary["hash"] = self.dag_hash()
+        dictionary.update(self.to_node_dict()[self.name])
+        return dictionary
+
     def to_yaml(self, stream=None, hash=ht.dag_hash):
         return syaml.dump(
             self.to_dict(hash), stream=stream, default_flow_style=False)

--- a/lib/spack/spack/test/cmd/extensions.py
+++ b/lib/spack/spack/test/cmd/extensions.py
@@ -1,0 +1,79 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import pytest
+
+from spack.main import SpackCommand, SpackCommandError
+from spack.spec import Spec
+
+
+extensions = SpackCommand('extensions')
+
+
+@pytest.fixture
+def python_database(mock_packages, mutable_database):
+    specs = [Spec(s).concretized() for s in [
+        'python',
+        'py-extension1',
+        'py-extension2',
+    ]]
+
+    for spec in specs:
+        spec.package.do_install(fake=True, explicit=True)
+
+    yield
+
+
+@pytest.mark.db
+def test_extensions(mock_packages, python_database, capsys):
+    ext2   = Spec("py-extension2").concretized()
+
+    def check_output(ni, na):
+        with capsys.disabled():
+            output = extensions("python")
+            packages = extensions("-s", "packages", "python")
+            installed = extensions("-s", "installed", "python")
+            activated = extensions("-s", "activated", "python")
+        assert "==> python@2.7.11" in output
+        assert "==> 3 extensions" in output
+        assert "flake8" in output
+        assert "py-extension1" in output
+        assert "py-extension2" in output
+
+        assert "==> 3 extensions" in packages
+        assert "flake8" in packages
+        assert "py-extension1" in packages
+        assert "py-extension2" in packages
+        assert "installed" not in packages
+        assert "activated" not in packages
+
+        assert ("%s installed" % (ni if ni else "None")) in output
+        assert ("%s activated" % (na if na else "None")) in output
+        assert ("%s installed" % (ni if ni else "None")) in installed
+        assert ("%s activated" % (na if na else "None")) in activated
+
+    check_output(2, 0)
+
+    ext2.package.do_activate()
+    check_output(2, 2)
+
+    ext2.package.do_deactivate(force=True)
+    check_output(2, 1)
+
+    ext2.package.do_activate()
+    check_output(2, 2)
+
+    ext2.package.do_uninstall(force=True)
+    check_output(1, 1)
+
+
+def test_extensions_raises_if_not_extendable(mock_packages):
+    with pytest.raises(SpackCommandError):
+        extensions("flake8")
+
+
+def test_extensions_raises_if_multiple_specs(mock_packages):
+    with pytest.raises(SpackCommandError):
+        extensions("python", "flake8")

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -35,7 +35,7 @@ def mock_display(monkeypatch, specs):
     def display(x, *args, **kwargs):
         specs.extend(x)
 
-    monkeypatch.setattr(spack.cmd.find, 'display_specs', display)
+    monkeypatch.setattr(spack.cmd, 'display_specs', display)
 
 
 def test_query_arguments():

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -4,14 +4,19 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import argparse
+import json
 
 import pytest
+import spack.cmd as cmd
 import spack.cmd.find
 from spack.main import SpackCommand
+from spack.spec import Spec
 from spack.util.pattern import Bunch
 
 
 find = SpackCommand('find')
+
+base32_alphabet = 'abcdefghijklmnopqrstuvwxyz234567'
 
 
 @pytest.fixture(scope='module')
@@ -111,3 +116,181 @@ def test_namespaces_shown_correctly(database):
 
     out = find('--namespace')
     assert 'builtin.mock.zmpi' in out
+
+
+def _check_json_output(spec_list):
+    assert len(spec_list) == 3
+    assert all(spec["name"] == "mpileaks" for spec in spec_list)
+
+    deps = [spec["dependencies"] for spec in spec_list]
+    assert sum(["zmpi" in d for d in deps]) == 1
+    assert sum(["mpich" in d for d in deps]) == 1
+    assert sum(["mpich2" in d for d in deps]) == 1
+
+
+def _check_json_output_deps(spec_list):
+    assert len(spec_list) == 13
+
+    names = [spec["name"] for spec in spec_list]
+    assert names.count("mpileaks") == 3
+    assert names.count("callpath") == 3
+    assert names.count("zmpi") == 1
+    assert names.count("mpich") == 1
+    assert names.count("mpich2") == 1
+    assert names.count("fake") == 1
+    assert names.count("dyninst") == 1
+    assert names.count("libdwarf") == 1
+    assert names.count("libelf") == 1
+
+
+@pytest.mark.db
+def test_find_json(database):
+    output = find('--json', 'mpileaks')
+    spec_list = json.loads(output)
+    _check_json_output(spec_list)
+
+
+@pytest.mark.db
+def test_find_json_deps(database):
+    output = find('-d', '--json', 'mpileaks')
+    spec_list = json.loads(output)
+    _check_json_output_deps(spec_list)
+
+
+@pytest.mark.db
+def test_display_json(database, capsys):
+    specs = [Spec(s).concretized() for s in [
+        "mpileaks ^zmpi",
+        "mpileaks ^mpich",
+        "mpileaks ^mpich2",
+    ]]
+
+    cmd.display_specs_as_json(specs)
+    spec_list = json.loads(capsys.readouterr()[0])
+    _check_json_output(spec_list)
+
+    cmd.display_specs_as_json(specs + specs + specs)
+    spec_list = json.loads(capsys.readouterr()[0])
+    _check_json_output(spec_list)
+
+
+@pytest.mark.db
+def test_display_json_deps(database, capsys):
+    specs = [Spec(s).concretized() for s in [
+        "mpileaks ^zmpi",
+        "mpileaks ^mpich",
+        "mpileaks ^mpich2",
+    ]]
+
+    cmd.display_specs_as_json(specs, deps=True)
+    spec_list = json.loads(capsys.readouterr()[0])
+    _check_json_output_deps(spec_list)
+
+    cmd.display_specs_as_json(specs + specs + specs, deps=True)
+    spec_list = json.loads(capsys.readouterr()[0])
+    _check_json_output_deps(spec_list)
+
+
+@pytest.mark.db
+def test_find_format(database, config):
+    output = find('--format', '{name}-{^mpi.name}', 'mpileaks')
+    assert set(output.strip().split('\n')) == set([
+        "mpileaks-zmpi",
+        "mpileaks-mpich",
+        "mpileaks-mpich2",
+    ])
+
+    output = find('--format', '{name}-{version}-{compiler.name}-{^mpi.name}',
+                  'mpileaks')
+    assert set(output.strip().split('\n')) == set([
+        "mpileaks-2.3-gcc-zmpi",
+        "mpileaks-2.3-gcc-mpich",
+        "mpileaks-2.3-gcc-mpich2",
+    ])
+
+    output = find('--format', '{name}-{^mpi.name}-{hash:7}',
+                  'mpileaks')
+    elements = output.strip().split('\n')
+    assert set(e[:-7] for e in elements) == set([
+        "mpileaks-zmpi-",
+        "mpileaks-mpich-",
+        "mpileaks-mpich2-",
+    ])
+
+    # hashes are in base32
+    for e in elements:
+        for c in e[-7:]:
+            assert c in base32_alphabet
+
+
+@pytest.mark.db
+def test_find_format_deps(database, config):
+    output = find('-d', '--format', '{name}-{version}', 'mpileaks', '^zmpi')
+    assert output == """\
+mpileaks-2.3
+    callpath-1.0
+        dyninst-8.2
+            libdwarf-20130729
+                libelf-0.8.13
+        zmpi-1.0
+            fake-1.0
+
+"""
+
+
+@pytest.mark.db
+def test_find_format_deps_paths(database, config):
+    output = find('-dp', '--format', '{name}-{version}', 'mpileaks', '^zmpi')
+
+    spec = Spec("mpileaks ^zmpi").concretized()
+    prefixes = [s.prefix for s in spec.traverse()]
+
+    assert output == """\
+mpileaks-2.3                   {0}
+    callpath-1.0               {1}
+        dyninst-8.2            {2}
+            libdwarf-20130729  {3}
+                libelf-0.8.13  {4}
+        zmpi-1.0               {5}
+            fake-1.0           {6}
+
+""".format(*prefixes)
+
+
+@pytest.mark.db
+def test_find_very_long(database, config):
+    output = find('-L', '--no-groups', "mpileaks")
+
+    specs = [Spec(s).concretized() for s in [
+        "mpileaks ^zmpi",
+        "mpileaks ^mpich",
+        "mpileaks ^mpich2",
+    ]]
+
+    assert set(output.strip().split("\n")) == set([
+        ("%s mpileaks@2.3" % s.dag_hash()) for s in specs
+    ])
+
+
+@pytest.mark.db
+def test_find_show_compiler(database, config):
+    output = find('--no-groups', '--show-full-compiler', "mpileaks")
+    assert "mpileaks@2.3%gcc@4.5.0" in output
+
+
+@pytest.mark.db
+def test_find_not_found(database, config, capsys):
+    with capsys.disabled():
+        output = find("foobarbaz", fail_on_error=False)
+    assert "No package matches the query: foobarbaz" in output
+    assert find.returncode == 1
+
+
+@pytest.mark.db
+def test_find_no_sections(database, config):
+    output = find()
+    assert "-----------" in output
+
+    output = find("--no-groups")
+    assert "-----------" not in output
+    assert "==>" not in output

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -104,6 +104,20 @@ def test_using_ordered_dict(mock_packages):
         assert level >= 5
 
 
+def test_to_record_dict(mock_packages, config):
+    specs = ['mpileaks', 'zmpi', 'dttop']
+    for name in specs:
+        spec = Spec(name).concretized()
+        record = spec.to_record_dict()
+        assert record["name"] == name
+        assert "hash" in record
+
+        node = spec.to_node_dict()
+        for key, value in node[name].items():
+            assert key in record
+            assert record[key] == value
+
+
 def test_ordered_read_not_required_for_consistent_dag_hash(
         config, mock_packages
 ):

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -98,10 +98,6 @@ def test_using_ordered_dict(mock_packages):
     for spec in specs:
         dag = Spec(spec)
         dag.normalize()
-        from pprint import pprint
-        pprint(dag.to_node_dict())
-        break
-
         level = descend_and_check(dag.to_node_dict())
 
         # level just makes sure we are doing something here

--- a/lib/spack/spack/test/test_activations.py
+++ b/lib/spack/spack/test/test_activations.py
@@ -3,6 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+"""This includes tests for customized activation logic for specific packages
+   (e.g. python and perl).
+"""
+
 import os
 import pytest
 
@@ -13,23 +17,23 @@ from spack.directory_layout import YamlDirectoryLayout
 from spack.filesystem_view import YamlFilesystemView
 from spack.repo import RepoPath
 
-"""This includes tests for customized activation logic for specific packages
-   (e.g. python and perl).
-"""
 
-
-def create_ext_pkg(name, prefix, extendee_spec):
+def create_ext_pkg(name, prefix, extendee_spec, monkeypatch):
     ext_spec = spack.spec.Spec(name)
     ext_spec._concrete = True
 
     ext_spec.package.spec.prefix = prefix
     ext_pkg = ext_spec.package
-    ext_pkg.extends_spec = extendee_spec
+
+    # temporarily override extendee_spec property on the package
+    monkeypatch.setattr(ext_pkg.__class__, "extendee_spec", extendee_spec)
+
     return ext_pkg
 
 
-def create_python_ext_pkg(name, prefix, python_spec, namespace=None):
-    ext_pkg = create_ext_pkg(name, prefix, python_spec)
+def create_python_ext_pkg(name, prefix, python_spec, monkeypatch,
+                          namespace=None):
+    ext_pkg = create_ext_pkg(name, prefix, python_spec, monkeypatch)
     ext_pkg.py_namespace = namespace
     return ext_pkg
 
@@ -148,14 +152,15 @@ def namespace_extensions(tmpdir, builtin_and_mock_packages):
 
 
 def test_python_activation_with_files(tmpdir, python_and_extension_dirs,
-                                      builtin_and_mock_packages):
+                                      monkeypatch, builtin_and_mock_packages):
     python_prefix, ext_prefix = python_and_extension_dirs
 
     python_spec = spack.spec.Spec('python@2.7.12')
     python_spec._concrete = True
     python_spec.package.spec.prefix = python_prefix
 
-    ext_pkg = create_python_ext_pkg('py-extension1', ext_prefix, python_spec)
+    ext_pkg = create_python_ext_pkg(
+        'py-extension1', ext_prefix, python_spec, monkeypatch)
 
     python_pkg = python_spec.package
     python_pkg.activate(ext_pkg, python_pkg.view())
@@ -171,14 +176,15 @@ def test_python_activation_with_files(tmpdir, python_and_extension_dirs,
 
 
 def test_python_activation_view(tmpdir, python_and_extension_dirs,
-                                builtin_and_mock_packages):
+                                builtin_and_mock_packages, monkeypatch):
     python_prefix, ext_prefix = python_and_extension_dirs
 
     python_spec = spack.spec.Spec('python@2.7.12')
     python_spec._concrete = True
     python_spec.package.spec.prefix = python_prefix
 
-    ext_pkg = create_python_ext_pkg('py-extension1', ext_prefix, python_spec)
+    ext_pkg = create_python_ext_pkg('py-extension1', ext_prefix, python_spec,
+                                    monkeypatch)
 
     view_dir = str(tmpdir.join('view'))
     layout = YamlDirectoryLayout(view_dir)
@@ -192,8 +198,8 @@ def test_python_activation_view(tmpdir, python_and_extension_dirs,
     assert os.path.exists(os.path.join(view_dir, 'bin/py-ext-tool'))
 
 
-def test_python_ignore_namespace_init_conflict(tmpdir, namespace_extensions,
-                                               builtin_and_mock_packages):
+def test_python_ignore_namespace_init_conflict(
+        tmpdir, namespace_extensions, builtin_and_mock_packages, monkeypatch):
     """Test the view update logic in PythonPackage ignores conflicting
        instances of __init__ for packages which are in the same namespace.
     """
@@ -203,9 +209,9 @@ def test_python_ignore_namespace_init_conflict(tmpdir, namespace_extensions,
     python_spec._concrete = True
 
     ext1_pkg = create_python_ext_pkg('py-extension1', ext1_prefix, python_spec,
-                                     py_namespace)
+                                     monkeypatch, py_namespace)
     ext2_pkg = create_python_ext_pkg('py-extension2', ext2_prefix, python_spec,
-                                     py_namespace)
+                                     monkeypatch, py_namespace)
 
     view_dir = str(tmpdir.join('view'))
     layout = YamlDirectoryLayout(view_dir)
@@ -226,8 +232,8 @@ def test_python_ignore_namespace_init_conflict(tmpdir, namespace_extensions,
     assert os.path.exists(os.path.join(view_dir, init_file))
 
 
-def test_python_keep_namespace_init(tmpdir, namespace_extensions,
-                                    builtin_and_mock_packages):
+def test_python_keep_namespace_init(
+        tmpdir, namespace_extensions, builtin_and_mock_packages, monkeypatch):
     """Test the view update logic in PythonPackage keeps the namespace
        __init__ file as long as one package in the namespace still
        exists.
@@ -238,9 +244,9 @@ def test_python_keep_namespace_init(tmpdir, namespace_extensions,
     python_spec._concrete = True
 
     ext1_pkg = create_python_ext_pkg('py-extension1', ext1_prefix, python_spec,
-                                     py_namespace)
+                                     monkeypatch, py_namespace)
     ext2_pkg = create_python_ext_pkg('py-extension2', ext2_prefix, python_spec,
-                                     py_namespace)
+                                     monkeypatch, py_namespace)
 
     view_dir = str(tmpdir.join('view'))
     layout = YamlDirectoryLayout(view_dir)
@@ -269,7 +275,7 @@ def test_python_keep_namespace_init(tmpdir, namespace_extensions,
 
 
 def test_python_namespace_conflict(tmpdir, namespace_extensions,
-                                   builtin_and_mock_packages):
+                                   monkeypatch, builtin_and_mock_packages):
     """Test the view update logic in PythonPackage reports an error when two
        python extensions with different namespaces have a conflicting __init__
        file.
@@ -281,9 +287,9 @@ def test_python_namespace_conflict(tmpdir, namespace_extensions,
     python_spec._concrete = True
 
     ext1_pkg = create_python_ext_pkg('py-extension1', ext1_prefix, python_spec,
-                                     py_namespace)
+                                     monkeypatch, py_namespace)
     ext2_pkg = create_python_ext_pkg('py-extension2', ext2_prefix, python_spec,
-                                     other_namespace)
+                                     monkeypatch, other_namespace)
 
     view_dir = str(tmpdir.join('view'))
     layout = YamlDirectoryLayout(view_dir)
@@ -342,7 +348,7 @@ def perl_and_extension_dirs(tmpdir, builtin_and_mock_packages):
     return str(perl_prefix), str(ext_prefix)
 
 
-def test_perl_activation(tmpdir, builtin_and_mock_packages):
+def test_perl_activation(tmpdir, builtin_and_mock_packages, monkeypatch):
     # Note the lib directory is based partly on the perl version
     perl_spec = spack.spec.Spec('perl@5.24.1')
     perl_spec._concrete = True
@@ -357,21 +363,23 @@ def test_perl_activation(tmpdir, builtin_and_mock_packages):
 
     ext_name = 'perl-extension'
     tmpdir.ensure(ext_name, dir=True)
-    ext_pkg = create_ext_pkg(ext_name, str(tmpdir.join(ext_name)), perl_spec)
+    ext_pkg = create_ext_pkg(
+        ext_name, str(tmpdir.join(ext_name)), perl_spec, monkeypatch)
 
     perl_pkg = perl_spec.package
     perl_pkg.activate(ext_pkg, perl_pkg.view())
 
 
 def test_perl_activation_with_files(tmpdir, perl_and_extension_dirs,
-                                    builtin_and_mock_packages):
+                                    monkeypatch, builtin_and_mock_packages):
     perl_prefix, ext_prefix = perl_and_extension_dirs
 
     perl_spec = spack.spec.Spec('perl@5.24.1')
     perl_spec._concrete = True
     perl_spec.package.spec.prefix = perl_prefix
 
-    ext_pkg = create_ext_pkg('perl-extension', ext_prefix, perl_spec)
+    ext_pkg = create_ext_pkg(
+        'perl-extension', ext_prefix, perl_spec, monkeypatch)
 
     perl_pkg = perl_spec.package
     perl_pkg.activate(ext_pkg, perl_pkg.view())
@@ -380,14 +388,15 @@ def test_perl_activation_with_files(tmpdir, perl_and_extension_dirs,
 
 
 def test_perl_activation_view(tmpdir, perl_and_extension_dirs,
-                              builtin_and_mock_packages):
+                              monkeypatch, builtin_and_mock_packages):
     perl_prefix, ext_prefix = perl_and_extension_dirs
 
     perl_spec = spack.spec.Spec('perl@5.24.1')
     perl_spec._concrete = True
     perl_spec.package.spec.prefix = perl_prefix
 
-    ext_pkg = create_ext_pkg('perl-extension', ext_prefix, perl_spec)
+    ext_pkg = create_ext_pkg(
+        'perl-extension', ext_prefix, perl_spec, monkeypatch)
 
     view_dir = str(tmpdir.join('view'))
     layout = YamlDirectoryLayout(view_dir)

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -521,7 +521,8 @@ function _spack_fetch {
 function _spack_find {
     if $list_options
     then
-        compgen -W "-h --help -s --short -p --paths -d --deps -l --long
+        compgen -W "-h --help -s --short -d --deps -p --paths
+                    --format --json --groups --no-groups -l --long
                     -L --very-long -t --tags -c --show-concretized
                     -f --show-flags --show-full-compiler -x --explicit
                     -X --implicit -u --unknown -m --missing -v --variants
@@ -1282,7 +1283,7 @@ function _all_resource_hashes {
 }
 
 function _installed_packages {
-    spack --color=never find | grep -v "^--"
+    spack --color=never find --no-groups
 }
 
 function _installed_compilers {

--- a/var/spack/repos/builtin.mock/packages/perl-extension/package.py
+++ b/var/spack/repos/builtin.mock/packages/perl-extension/package.py
@@ -15,14 +15,9 @@ class PerlExtension(PerlPackage):
     version('1.0', 'hash-extension-1.0')
     version('2.0', 'hash-extension-2.0')
 
+    extends("perl")
+
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
         with open(os.path.join(prefix.bin, 'perl-extension'), 'w+') as fout:
             fout.write(str(spec.version))
-
-    # Give the package a hook to set the extendee spec
-    extends_spec = 'perl'
-
-    @property
-    def extendee_spec(self):
-        return self.extends_spec

--- a/var/spack/repos/builtin.mock/packages/py-extension1/package.py
+++ b/var/spack/repos/builtin.mock/packages/py-extension1/package.py
@@ -20,9 +20,4 @@ class PyExtension1(PythonPackage):
         with open(os.path.join(prefix.bin, 'py-extension1'), 'w+') as fout:
             fout.write(str(spec.version))
 
-    # Give the package a hook to set the extendee spec
-    extends_spec = 'python'
-
-    @property
-    def extendee_spec(self):
-        return self.extends_spec
+    extends('python')

--- a/var/spack/repos/builtin.mock/packages/py-extension2/package.py
+++ b/var/spack/repos/builtin.mock/packages/py-extension2/package.py
@@ -13,6 +13,7 @@ class PyExtension2(PythonPackage):
     homepage = "http://www.example.com"
     url      = "http://www.example.com/extension2-1.0.tar.gz"
 
+    extends("python")
     depends_on('py-extension1', type=('build', 'run'))
 
     version('1.0', 'hash-extension2-1.0')
@@ -21,10 +22,3 @@ class PyExtension2(PythonPackage):
         mkdirp(prefix.bin)
         with open(os.path.join(prefix.bin, 'py-extension2'), 'w+') as fout:
             fout.write(str(spec.version))
-
-    # Give the package a hook to set the extendee spec
-    extends_spec = 'python'
-
-    @property
-    def extendee_spec(self):
-        return self.extends_spec


### PR DESCRIPTION
Fixes #2638.

We've had some nice spec format string syntax since #10556 ([documented here](https://spack.readthedocs.io/en/latest/spack.html#spack.spec.Spec.format)), and people have asked for easier ways to parse `spack find` output.

I've added two options to `spack find` to address this:

- [x] `spack find --format`
    You can provide a format string to `spack find`, as in #10556, and you can print out exactly those parts of the spec you want, one per line, with no frills:

    ```console
    $ spack find --format "{name}-{version}-{hash}"
    autoconf-2.69-icynozk7ti6h4ezzgonqe6jgw5f3ulx4
    automake-1.16.1-o5v3tc77kesgonxjbmeqlwfmb5qzj7zy
    bzip2-1.0.6-syohzw57v2jfag5du2x4bowziw3m5p67
    bzip2-1.0.8-zjny4jwfyvzbx6vii3uuekoxmtu6eyuj
    cmake-3.15.1-7cf6onn52gywnddbmgp7qkil4hdoxpcb
    ```

    See the docs for more details.

- [x] `spack find --json`
    You can get JSON records for each result of `spack find`, in a format that is easily parsed with tools like [jq](https://stedolan.github.io/jq/).  `spack find --json` also works with `-d` if you want the dependencies included in the output.

    ```console
    $ spack find --json sqlite@3.28.0
    [
     {
      "name": "sqlite",
      "hash": "3ws7bsihwbn44ghf6ep4s6h4y2o6eznv",
      "version": "3.28.0",
      "arch": {
       "platform": "darwin",
       "platform_os": "mojave",
       "target": "x86_64"
      },
      "compiler": {
       "name": "clang",
       "version": "10.0.0-apple"
    ...
    ```
- [x] Refactor `spack.cmd.display_specs` and `spack find` so that any options can be used together with `-d`.  This cleans up the display logic considerably, as there are no longer multiple "modes".
- [x] docs
- [x] tests
- [x] tab completion