### PR TITLE
Remove ginkgo's dependence on CudaPackage

### DIFF
--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -7,7 +7,7 @@ from spack import *
 import sys
 
 
-class Ginkgo(CMakePackage, CudaPackage):
+class Ginkgo(CMakePackage):
     """High-performance linear algebra library for manycore systems,
     with a focus on sparse solution of linear systems."""
 
@@ -21,6 +21,7 @@ class Ginkgo(CMakePackage, CudaPackage):
     version('master', branch='master')
     version('1.0.0', commit='4524464')  # v1.0.0
 
+    variant('cuda', default=False, description='Build with Ginkgo')
     variant('shared', default=True, description='Build shared libraries')
     variant('full_optimizations', default=False, description='Compile with all optimizations')
     variant('openmp', default=sys.platform != 'darwin',  description='Build with OpenMP')

--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -21,7 +21,7 @@ class Ginkgo(CMakePackage):
     version('master', branch='master')
     version('1.0.0', commit='4524464')  # v1.0.0
 
-    variant('cuda', default=False, description='Build with Ginkgo')
+    variant('cuda', default=False, description='Build with CUDA')
     variant('shared', default=True, description='Build shared libraries')
     variant('full_optimizations', default=False, description='Compile with all optimizations')
     variant('openmp', default=sys.platform != 'darwin',  description='Build with OpenMP')


### PR DESCRIPTION
This PR allows to break the CUDA compatibility rules. This comes from a problem noticed by @luszczek on Summit (ppc64le architecture) from xSDK tests.

### Description of the problem
In `./lib/spack/spack/build_systems/cuda.py`, it is stated that CUDA 9.X can only be used with GCC version < 6. In practice, building with GCC 6 CUDA 9.2 and other 9 versions work properly. This PR gives to the user the freedom to handpick both GCC and CUDA versions, at the risk of using incompatible versions.