### PR TITLE
compiler: Fix unicode errors

### DIFF
--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -290,6 +290,7 @@ class Compiler(object):
                     'int main(int argc, char* argv[]) { '
                     '(void)argc; (void)argv; return 0; }\n')
             compiler_exe = spack.util.executable.Executable(first_compiler)
+            compiler_exe.add_default_env('LC_ALL', 'C')
             output = str(compiler_exe(cls.verbose_flag(), fin, '-o', fout,
                                       output=str, error=str))  # str for py2
 


### PR DESCRIPTION
When determining the implicit rpaths, the str() conversion can fail with errors such as this depending on the user's locale:
```
Error: 'ascii' codec can't encode character u'\xbb' in position 1644: ordinal not in range(128)
```

Moreover, `_parse_implicit_rpaths` looks for English strings, so force the C locale when looking for implicit rpaths.

cc: @alalazo Looks like you have dealt with similar encoding issues in #10190.