### PR TITLE
perf: spack find -p now does only one DB transaction

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -357,15 +357,18 @@ def display_specs(specs, args=None, **kwargs):
         max_width = max(len(f[0]) for f in formatted)
         path_fmt = "%%-%ds%%s" % (max_width + 2)
 
-        for string, spec in formatted:
-            if not string:
-                print()  # print newline from above
-                continue
+        # getting lots of prefixes requires DB lookups. Ensure
+        # all spec.prefix calls are in one transaction.
+        with spack.store.db.read_transaction():
+            for string, spec in formatted:
+                if not string:
+                    print()  # print newline from above
+                    continue
 
-            if paths:
-                print(path_fmt % (string, spec.prefix))
-            else:
-                print(string)
+                if paths:
+                    print(path_fmt % (string, spec.prefix))
+                else:
+                    print(string)
 
     if groups:
         for specs in iter_groups(specs, indent, all_headers):


### PR DESCRIPTION
`spec.prefix` reads from Spack's database, and if you do this with
multiple consecutive read transactions, it can take a long time.  Or, at
least, you can see the paths get written out one by one.

This uses an outer read transaction to ensure that actual disk locks are
acquired only once for the whole `spack find` operation, and that each
transaction inside `spec.prefix` is an in-memory operation. This speeds
up `spack find -p` a lot.