### PR TITLE
tmux: cppflags point to ncurses headers

### DIFF
--- a/var/spack/repos/builtin/packages/tmux/package.py
+++ b/var/spack/repos/builtin/packages/tmux/package.py
@@ -30,5 +30,10 @@ class Tmux(AutotoolsPackage):
     depends_on('libevent')
     depends_on('ncurses')
 
+    def flag_handler(self, name, flags):
+        if name == 'cppflags':
+            flags.append(self.spec['ncurses'].headers.include_flags)
+        return (None, flags, None)
+
     def configure_args(self):
         return ['LIBTINFO_LIBS=-lncurses']


### PR DESCRIPTION
While debugging this package on our Cray machine, tmux was throwing an
error involving the ncurses headers. Tmux would look for headers in
system locations rather than where spack installed ncurses. Tested only
on a Cray.