### PR TITLE
py-chardet package: add py-pytest-runner as build dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-chardet/package.py
+++ b/var/spack/repos/builtin/packages/py-chardet/package.py
@@ -16,3 +16,4 @@ class PyChardet(PythonPackage):
     version('2.3.0', '25274d664ccb5130adae08047416e1a8')
 
     depends_on('py-setuptools', type='build')
+    depends_on('py-pytest-runner', type='build')


### PR DESCRIPTION
Fixes #12560 (where it was discovered `py-pytest-runner` is a necessary dependency)