### PR TITLE
boost: add -c option to C/C++ compile commands for clang.

### DIFF
--- a/var/spack/repos/builtin/packages/boost/clang-linux_add_option.patch
+++ b/var/spack/repos/builtin/packages/boost/clang-linux_add_option.patch
@@ -1,0 +1,20 @@
+--- boost_1_63_0/tools/build/src/tools/clang-linux.jam.back	2019-09-04 15:51:25.052324575 +0900
++++ boost_1_63_0/tools/build/src/tools/clang-linux.jam	2019-09-04 15:52:22.278328007 +0900
+@@ -153,7 +153,7 @@
+ }
+ 
+ actions compile.c++.pch {
+-  rm -f "$(<)" && "$(CONFIG_COMMAND)" -x c++-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -Xclang -emit-pth -o "$(<)" "$(>)"
++  rm -f "$(<)" && "$(CONFIG_COMMAND)" -c -x c++-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -Xclang -emit-pth -o "$(<)" "$(>)"
+ }
+ 
+ rule compile.c.pch ( targets * : sources * : properties * ) {
+@@ -164,7 +164,7 @@
+ 
+ actions compile.c.pch
+ {
+-  rm -f "$(<)" && "$(CONFIG_COMMAND)" -x c-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -Xclang -emit-pth -o "$(<)" "$(>)"
++  rm -f "$(<)" && "$(CONFIG_COMMAND)" -c -x c-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -Xclang -emit-pth -o "$(<)" "$(>)"
+ }
+ 
+ ###############################################################################

--- a/var/spack/repos/builtin/packages/boost/clang-linux_add_option2.patch
+++ b/var/spack/repos/builtin/packages/boost/clang-linux_add_option2.patch
@@ -1,0 +1,20 @@
+--- boost_1_55_0/tools/build/v2/tools/clang-linux.jam.back	2019-09-04 16:43:57.542806983 +0900
++++ boost_1_55_0/tools/build/v2/tools/clang-linux.jam	2019-09-04 16:45:23.451800016 +0900
+@@ -152,7 +152,7 @@
+ }
+ 
+ actions compile.c++.pch {
+-  rm -f "$(<)" && "$(CONFIG_COMMAND)" -x c++-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -Xclang -emit-pth -o "$(<)" "$(>)"
++  rm -f "$(<)" && "$(CONFIG_COMMAND)" -c -x c++-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -Xclang -emit-pth -o "$(<)" "$(>)"
+ }
+ 
+ rule compile.c.pch ( targets * : sources * : properties * ) {
+@@ -163,7 +163,7 @@
+ 
+ actions compile.c.pch
+ {
+-  rm -f "$(<)" && "$(CONFIG_COMMAND)" -x c-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -Xclang -emit-pth -o "$(<)" "$(>)"
++  rm -f "$(<)" && "$(CONFIG_COMMAND)" -c -x c-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -Xclang -emit-pth -o "$(<)" "$(>)"
+ }
+ 
+ ###############################################################################

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -189,6 +189,10 @@ class Boost(Package):
     # Change the method for version analysis when using Fujitsu compiler.
     patch('fujitsu_version_analysis.patch', when='@1.67.0:%fj')
 
+    # Add option to C/C++ compile commands in clang-linux.jam
+    patch('clang-linux_add_option.patch', when='@1.56.0:1.63.0')
+    patch('clang-linux_add_option2.patch', when='@:1.55.0')
+
     def url_for_version(self, version):
         if version >= Version('1.63.0'):
             url = "https://dl.bintray.com/boostorg/release/{0}/source/boost_{1}.tar.bz2"


### PR DESCRIPTION
Versions up to 1.63.0 lack the `-c` option for C/C++ compiler commands in clang-linux.jam.
I fixed it.
※ The directory structure is different between the versions before 1.55.0 and the versions after 1.56.0.

Referenced:
http://boost.2283326.n4.nabble.com/Boost-Math-Weird-compiler-error-with-Clang-3-8-td4691122.html