### PR TITLE
py-ase: New version 3.18

### DIFF
--- a/var/spack/repos/builtin/packages/py-ase/package.py
+++ b/var/spack/repos/builtin/packages/py-ase/package.py
@@ -14,8 +14,11 @@ class PyAse(PythonPackage):
     homepage = "https://wiki.fysik.dtu.dk/ase/"
     url      = "https://pypi.io/packages/source/a/ase/ase-3.13.0.tar.gz"
 
+    version('3.18.0',
+            sha256='39d45f12def2669605bffc82926acfb13a0d0610e6d82740fa316aafa70f97f9')
     version('3.15.0', '65a0143753517c2df157e53bd29a18e3')
     version('3.13.0', 'e946a0addc5b61e5e2e75857e0f99b89')
 
-    depends_on('python@2.6:')
+    depends_on('python@2.6:', when='@:3.15.0')
+    depends_on('python@3.5:', when='@3.18.0:')
     depends_on('py-numpy', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-ase/package.py
+++ b/var/spack/repos/builtin/packages/py-ase/package.py
@@ -19,6 +19,9 @@ class PyAse(PythonPackage):
     version('3.15.0', '65a0143753517c2df157e53bd29a18e3')
     version('3.13.0', 'e946a0addc5b61e5e2e75857e0f99b89')
 
-    depends_on('python@2.6:', when='@:3.15.0')
-    depends_on('python@3.5:', when='@3.18.0:')
+    depends_on('python@2.6:', type=('build', 'run'), when='@:3.15.0')
+    depends_on('python@3.5:', type=('build', 'run'), when='@3.18.0:')
     depends_on('py-numpy', type=('build', 'run'))
+    depends_on('py-matplotlib', type=('build', 'run'))
+    depends_on('py-scipy', type=('build', 'run'))
+    depends_on('py-flask', type=('build', 'run'))


### PR DESCRIPTION
Add ASE version 3.18. ASE 3.18 has dropped support for python 2.x,
hence add a dependency on python@3.5: for it.