### PR TITLE
luarocks: Use `make` command instead of `install`

### DIFF
--- a/var/spack/repos/builtin/packages/lua-luafilesystem/package.py
+++ b/var/spack/repos/builtin/packages/lua-luafilesystem/package.py
@@ -45,4 +45,4 @@ class LuaLuafilesystem(Package):
         )
 
     def install(self, spec, prefix):
-        luarocks('--tree=' + prefix, 'install', self.rockspec)
+        luarocks('--tree=' + prefix, 'make', self.rockspec)

--- a/var/spack/repos/builtin/packages/lua-luaposix/package.py
+++ b/var/spack/repos/builtin/packages/lua-luaposix/package.py
@@ -18,4 +18,4 @@ class LuaLuaposix(Package):
 
     def install(self, spec, prefix):
         rockspec = glob.glob('luaposix-*.rockspec')
-        luarocks('--tree=' + prefix, 'install', rockspec[0])
+        luarocks('--tree=' + prefix, 'make', rockspec[0])


### PR DESCRIPTION
This way luarocks does not attempt to pull stuff from the internet.

Fix #3909
Fix #7848

Ref: https://stackoverflow.com/a/43321646/1334711