### PR TITLE
FIX Catalyst: corrected catalyst package for aarch64 targets

### DIFF
--- a/var/spack/repos/builtin/packages/catalyst/package.py
+++ b/var/spack/repos/builtin/packages/catalyst/package.py
@@ -225,7 +225,7 @@ class Catalyst(CMakePackage):
         else:
             cmake_args.append('-DPARAVIEW_ENABLE_PYTHON:BOOL=OFF')
 
-        if(arch.platform == 'linux' and arch.target == 'aarch64')
+        if(arch.platform == 'linux' and arch.target == 'aarch64'):
             cmake_args.append('-DCMAKE_CXX_FLAGS=-DPNG_ARM_NEON_OPT=0')
             cmake_args.append('-DCMAKE_C_FLAGS=-DPNG_ARM_NEON_OPT=0')
 

--- a/var/spack/repos/builtin/packages/catalyst/package.py
+++ b/var/spack/repos/builtin/packages/catalyst/package.py
@@ -225,6 +225,10 @@ class Catalyst(CMakePackage):
         else:
             cmake_args.append('-DPARAVIEW_ENABLE_PYTHON:BOOL=OFF')
 
+        if(arch.platform == 'linux' and arch.target == 'aarch64')
+            cmake_args.append('-DCMAKE_CXX_FLAGS=-DPNG_ARM_NEON_OPT=0')
+            cmake_args.append('-DCMAKE_C_FLAGS=-DPNG_ARM_NEON_OPT=0')
+
         return cmake_args
 
     def cmake(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/catalyst/package.py
+++ b/var/spack/repos/builtin/packages/catalyst/package.py
@@ -225,6 +225,7 @@ class Catalyst(CMakePackage):
         else:
             cmake_args.append('-DPARAVIEW_ENABLE_PYTHON:BOOL=OFF')
 
+        arch = spec.architecture
         if(arch.platform == 'linux' and arch.target == 'aarch64'):
             cmake_args.append('-DCMAKE_CXX_FLAGS=-DPNG_ARM_NEON_OPT=0')
             cmake_args.append('-DCMAKE_C_FLAGS=-DPNG_ARM_NEON_OPT=0')


### PR DESCRIPTION
This PR adds the `-DPNG_ARM_NEON_OPT=0` definition to CMAKE_CXX_FLAGS and CMAKE_C_FLAGS if the target is `aarch64`. Without these flags, Catalyst fails to compile on this architecture, with undefined references to `png_init_filter_functions_neon`.