### PR TITLE
patch boost version 1.54-1.55 with ANY gcc >= 5.0

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -169,7 +169,7 @@ class Boost(Package):
     patch('xl_1_62_0_le.patch', when='@1.62.0%xl')
 
     # Patch fix from https://svn.boost.org/trac/boost/ticket/10125
-    patch('call_once_variadic.patch', when='@1.54.0:1.55.9999%gcc@5.0:5.9')
+    patch('call_once_variadic.patch', when='@1.54.0:1.55.9999%gcc@5.0:')
 
     # Patch fix for PGI compiler
     patch('boost_1.67.0_pgi.patch', when='@1.67.0:1.68.9999%pgi')


### PR DESCRIPTION
I need to build boost 1.54 with gcc 8.20 and it currently fails with _exactly_ the same error as reported by #2821

I propose to extend the patch introduced in #2822 to apply to any gcc after 5.0, and not just 5.0-5.9.

I have tested this with gcc 8.2 on Centos 7 machine and it works nicely.  Perhaps I should conservatively bookend the patch to `%gcc@5.0:8.2`?

@hartzell 