### PR TITLE
Environment views: add all paths on activation

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -955,10 +955,8 @@ class Environment(object):
 
         path_updates = list()
         if default_view_name in self.views:
-            for var, subdirs in updates:
-                paths = filter(lambda x: os.path.exists(x),
-                               list(os.path.join(self.default_view.root, x)
-                                    for x in subdirs))
+            for var, dirs in updates:
+                paths = [os.path.join(self.default_view.root, x) for x in dirs]
                 path_updates.append((var, paths))
         return path_updates
 


### PR DESCRIPTION
Currently, environments only load existing paths on activation. This means that new packages in the environment do not load properly. For example

```
$ unset LD_LIBRARY_PATH
$ spack env create myenv
$ spack env activate myenv
$ spack install zlib
$ echo $LD_LIBRARY_PATH

```

results in nothing in `LD_LIBRARY_PATH`. Under this PR, it now results in `$spack/var/spack/environments/myenv/.spack-env/view/lib:$spack/var/spack/environments/myenv/.spack-env/view/lib64`.