### PR TITLE
install command: add cache-only option

### DIFF
--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -34,6 +34,9 @@ def setup_parser(subparser):
     cache_group.add_argument(
         '--no-cache', action='store_false', dest='use_cache', default=True,
         help="do not check for pre-built Spack packages in mirrors")
+    cache_group.add_argument(
+        '--cache-only', action='store_true', dest='cache_only', default=False,
+        help="only install package from binary mirrors")
 
     cd_group = subparser.add_mutually_exclusive_group()
     arguments.add_common_arguments(cd_group, ['clean', 'dirty'])
@@ -46,7 +49,8 @@ def bootstrap(parser, args, **kwargs):
         'install_deps': 'dependencies',
         'verbose': args.verbose,
         'dirty': args.dirty,
-        'use_cache': args.use_cache
+        'use_cache': args.use_cache,
+        'cache_only': args.cache_only
     })
 
     # Define requirement dictionary defining general specs which need

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -38,7 +38,8 @@ def update_kwargs_from_args(args, kwargs):
         'verbose': args.verbose,
         'fake': args.fake,
         'dirty': args.dirty,
-        'use_cache': args.use_cache
+        'use_cache': args.use_cache,
+        'cache_only': args.cache_only
     })
     if hasattr(args, 'setup'):
         setups = set()
@@ -81,6 +82,9 @@ the dependencies"""
     cache_group.add_argument(
         '--no-cache', action='store_false', dest='use_cache', default=True,
         help="do not check for pre-built Spack packages in mirrors")
+    cache_group.add_argument(
+        '--cache-only', action='store_true', dest='cache_only', default=False,
+        help="only install package from binary mirrors")
 
     subparser.add_argument(
         '--show-log-on-error', action='store_true',

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1789,7 +1789,6 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
 
         if restage and self.stage.managed_by_spack:
             self.stage.destroy()
-            self.stage.create()
 
         return partial
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1493,6 +1493,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             restage (bool): Force spack to restage the package source.
             force (bool): Install again, even if already installed.
             use_cache (bool): Install from binary package, if available.
+            cache_only (bool): Fail if binary package unavailable.
             stop_at (InstallPhase): last installation phase to be executed
                 (or None)
         """
@@ -1571,6 +1572,8 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
                 print_pkg(self.prefix)
                 spack.hooks.post_install(self.spec)
                 return
+            elif kwargs.get('cache_only', False):
+                tty.die('No binary for %s found and cache-only specified')
 
             tty.msg('No binary for %s found: installing from source'
                     % self.name)

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -591,3 +591,12 @@ def test_build_warning_output(tmpdir, mock_fetch, install_mockery, capfd):
 
         assert 'WARNING: ALL CAPITAL WARNING!' in msg
         assert 'foo.c:89: warning: some weird warning!' in msg
+
+
+def test_cache_only_fails(tmpdir, mock_fetch, install_mockery, capfd):
+    with capfd.disabled():
+        try:
+            install('--cache-only', 'libdwarf')
+            assert False
+        except spack.main.SpackCommandError as e:
+            assert "--cache-only" in e.message

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -598,5 +598,5 @@ def test_cache_only_fails(tmpdir, mock_fetch, install_mockery, capfd):
         try:
             install('--cache-only', 'libdwarf')
             assert False
-        except spack.main.SpackCommandError as e:
-            assert "--cache-only" in e.message
+        except spack.main.SpackCommandError:
+            pass


### PR DESCRIPTION
Creates the option to install only from binary cache, ignoring Spack's ability to build from source.