### PR TITLE
mesa: disable use of libunwind for arm arch

### DIFF
--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -101,6 +101,9 @@ class Mesa(AutotoolsPackage):
         args_gallium_drivers = ['swrast']
         args_dri_drivers = []
 
+        if 'arm' in spec.architecture.target.lower():
+            args.append('--disable-libunwind')
+
         num_frontends = 0
         if '+osmesa' in spec:
             num_frontends += 1


### PR DESCRIPTION
There are problems with libunwind for arm and trying to use it with mesa.
See for example:

https://github.com/grate-driver/mesa/issues/6

disabling use of libunwind for arm, allows the package to be built

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>