### PR TITLE
py-gpaw: Fixing missing numpy include path, adding newer version of p…

### DIFF
--- a/var/spack/repos/builtin/packages/py-gpaw/libxc.patch
+++ b/var/spack/repos/builtin/packages/py-gpaw/libxc.patch
@@ -1,0 +1,12 @@
+diff -Naur gpaw-1.3.0.orig/c/xc/libxc.c gpaw-1.3.0/c/xc/libxc.c
+--- gpaw-1.3.0.orig/c/xc/libxc.c	2019-09-06 14:59:35.151442058 +0300
++++ gpaw-1.3.0/c/xc/libxc.c	2019-09-06 15:00:46.211440365 +0300
+@@ -801,7 +801,7 @@
+     if (!PyArg_ParseTuple(args, "dOOOOOO",
+                           &c, &n_g, &sigma_g, &lapl_g, &tau_g, &v_g, &vx_g))
+         return NULL;
+-    xc_mgga_x_tb09_set_params(self->functional[0], c);
++    xc_func_set_ext_params(self->functional[0], &c);
+     xc_mgga_vxc(self->functional[0], PyArray_DIM(n_g, 0),
+                 PyArray_DATA(n_g),
+                 PyArray_DATA(sigma_g),

--- a/var/spack/repos/builtin/packages/py-gpaw/package.py
+++ b/var/spack/repos/builtin/packages/py-gpaw/package.py
@@ -14,6 +14,7 @@ class PyGpaw(PythonPackage):
     homepage = "https://wiki.fysik.dtu.dk/gpaw/index.html"
     url      = "https://pypi.io/packages/source/g/gpaw/gpaw-1.3.0.tar.gz"
 
+    version('19.8.1', sha256='79dee367d695d68409c4d69edcbad5c8679137d6715da403f6c2500cb2178c2a')
     version('1.3.0', '82e8c80e637696248db00b5713cdffd1')
 
     variant('mpi', default=True, description='Build with MPI support')
@@ -33,6 +34,8 @@ class PyGpaw(PythonPackage):
     depends_on('fftw~mpi', when='+fftw ~mpi')
     depends_on('scalapack', when='+scalapack')
 
+    patch('libxc.patch', when='@1.3.0')
+
     def patch(self):
         spec = self.spec
         # For build notes see https://wiki.fysik.dtu.dk/gpaw/install.html
@@ -41,8 +44,16 @@ class PyGpaw(PythonPackage):
         blas = spec['blas']
         lapack = spec['lapack']
 
+        python_include = spec['python'].headers.directories[0]
+        numpy_include = join_path(
+            spec['py-numpy'].prefix,
+            spec['python'].package.site_packages_dir,
+            'numpy', 'core', 'include')
+
         libs = blas.libs + lapack.libs + libxc.libs
         include_dirs = [
+            python_include,
+            numpy_include,
             blas.prefix.include,
             lapack.prefix.include,
             libxc.prefix.include

--- a/var/spack/repos/builtin/packages/py-gpaw/package.py
+++ b/var/spack/repos/builtin/packages/py-gpaw/package.py
@@ -23,8 +23,10 @@ class PyGpaw(PythonPackage):
     variant('fftw', default=True, description='Build with FFTW support')
 
     depends_on('mpi', when='+mpi', type=('build', 'link', 'run'))
-    depends_on('python@2.6:')
-    depends_on('py-ase@3.13.0:', type=('build', 'run'))
+    depends_on('python@2.6:', type=('build', 'run'), when='@:1.3.0')
+    depends_on('python@3.5:', type=('build', 'run'), when='@19.8.1:')
+    depends_on('py-ase@3.13.0:', type=('build', 'run'), when='@1.3.0')
+    depends_on('py-ase@3.18.0:', type=('build', 'run'), when='@19.8.1')
     depends_on('py-numpy +blas +lapack', type=('build', 'run'))
     depends_on('py-scipy', type=('build', 'run'))
     depends_on('libxc')

--- a/var/spack/repos/builtin/packages/py-gpaw/package.py
+++ b/var/spack/repos/builtin/packages/py-gpaw/package.py
@@ -18,7 +18,7 @@ class PyGpaw(PythonPackage):
     version('1.3.0', '82e8c80e637696248db00b5713cdffd1')
 
     variant('mpi', default=True, description='Build with MPI support')
-    variant('scalapack', default=False,
+    variant('scalapack', default=True,
             description='Build with ScaLAPACK support')
     variant('fftw', default=True, description='Build with FFTW support')
 


### PR DESCRIPTION
The following commit fixes the following issues with py-gpaw package:
1. py-numpy's include directory was not set correctly in the original package.
2. Older version of gpaw had a call to a function in libxc that is no longer present. The patch fixes this. See [this issue](https://gitlab.com/gpaw/gpaw/merge_requests/267) for more information. 

In addition the newest version of py-gpaw is added. 