### PR TITLE
add mpi variant to p4est package to allow turning off MPI

### DIFF
--- a/var/spack/repos/builtin/packages/p4est/package.py
+++ b/var/spack/repos/builtin/packages/p4est/package.py
@@ -18,6 +18,7 @@ class P4est(AutotoolsPackage):
     version('2.0', 'c522c5b69896aab39aa5a81399372a19a6b03fc6200d2d5d677d9a22fe31029a')
     version('1.1', '37ba7f4410958cfb38a2140339dbf64f')
 
+    variant('mpi', default=True, description='Enable MPI')
     variant('openmp', default=False, description='Enable OpenMP')
 
     # build dependencies
@@ -26,7 +27,7 @@ class P4est(AutotoolsPackage):
     depends_on('libtool@2.4.2:', type='build')
 
     # other dependencies
-    depends_on('mpi')
+    depends_on('mpi', when='+mpi')
     depends_on('zlib')
 
     # from sc upstream, correct the default libraries
@@ -45,7 +46,6 @@ class P4est(AutotoolsPackage):
 
     def configure_args(self):
         args = [
-            '--enable-mpi',
             '--enable-shared',
             '--disable-vtk-binary',
             '--without-blas',
@@ -56,6 +56,11 @@ class P4est(AutotoolsPackage):
             'FC=%s'  % self.spec['mpi'].mpifc,
             'F77=%s' % self.spec['mpi'].mpif77
         ]
+
+        if '~mpi' in self.spec:
+            args.append('--disable-mpi')
+        else:
+            args.append('--enable-mpi')
 
         if '+openmp' in self.spec:
             try:


### PR DESCRIPTION
The default is to have MPI enabled, as before. But now the user has the option to turn off MPI if desired.