### PR TITLE
py-cutadapt: Updated version checksum

### DIFF
--- a/var/spack/repos/builtin/packages/py-cutadapt/package.py
+++ b/var/spack/repos/builtin/packages/py-cutadapt/package.py
@@ -13,7 +13,7 @@ class PyCutadapt(PythonPackage):
 
     homepage = "https://cutadapt.readthedocs.io"
     url      = "https://pypi.io/packages/source/c/cutadapt/cutadapt-1.13.tar.gz"
-    git      = "git@github.com:marcelm/cutadapt.git"
+    git      = "https://github.com/marcelm/cutadapt.git"
 
     version('2.5', sha256='ced79e49b93e922e579d0bb9d21298dcb2d7b7b1ea721feed484277e08b1660b')
     version('1.13', '2d2d14e0c20ad53d7d84b57bc3e63b4c')

--- a/var/spack/repos/builtin/packages/py-cutadapt/package.py
+++ b/var/spack/repos/builtin/packages/py-cutadapt/package.py
@@ -13,9 +13,14 @@ class PyCutadapt(PythonPackage):
 
     homepage = "https://cutadapt.readthedocs.io"
     url      = "https://pypi.io/packages/source/c/cutadapt/cutadapt-1.13.tar.gz"
+    git      = "git@github.com:marcelm/cutadapt.git"
 
+    version('2.5', sha256='ced79e49b93e922e579d0bb9d21298dcb2d7b7b1ea721feed484277e08b1660b')
     version('1.13', '2d2d14e0c20ad53d7d84b57bc3e63b4c')
 
-    depends_on('python@2.6:', type=('build', 'run'))
+    depends_on('python@2.7:', type=('build', 'run'), when='@1.13')
+    depends_on('python@3.4:', type=('build', 'run'), when='@2.5:')
     depends_on('py-setuptools', type=('build', 'run'))
-    depends_on('py-xopen@0.1.1:', type=('build', 'run'))
+    depends_on('py-xopen@0.1.1:', type=('build', 'run'), when='@1.13')
+    depends_on('py-xopen@0.8.1:', type=('build', 'run'), when='@2.5:')
+    depends_on('py-dnaio', type=('build', 'run'), when='@2.5:')


### PR DESCRIPTION
Tested (build and execute with real data) on CentOS 6, gcc 8.2

This PR will be followed by two more in dependent packages, which are necessary for this updated version of py-cutadapt:
* py-xopen (update)
* py-dnaio (new package)