### PR TITLE
py-dnaio: new package need by py-cutadapt

### DIFF
--- a/var/spack/repos/builtin/packages/py-dnaio/package.py
+++ b/var/spack/repos/builtin/packages/py-dnaio/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyDnaio(PythonPackage):
+    """Read and write FASTQ and FASTA"""
+
+    homepage = "https://github.com/marcelm/dnaio"
+    url      = "https://pypi.io/packages/source/d/dnaio/dnaio-0.3.tar.gz"
+    git      = "git@github.com:marcelm/dnaio.git"
+
+    version('0.3', sha256='47e4449affad0981978fe986684fc0d9c39736f05a157f6cf80e54dae0a92638')
+
+    depends_on('python@3.4:', type=('build', 'run'))    
+    depends_on('py-setuptools', type=('build', 'run'))
+    depends_on('py-xopen@0.8.2:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-dnaio/package.py
+++ b/var/spack/repos/builtin/packages/py-dnaio/package.py
@@ -11,7 +11,7 @@ class PyDnaio(PythonPackage):
 
     homepage = "https://github.com/marcelm/dnaio"
     url      = "https://pypi.io/packages/source/d/dnaio/dnaio-0.3.tar.gz"
-    git      = "git@github.com:marcelm/dnaio.git"
+    git      = "https://github.com/marcelm/dnaio.git"
 
     version('0.3', sha256='47e4449affad0981978fe986684fc0d9c39736f05a157f6cf80e54dae0a92638')
 


### PR DESCRIPTION
Tested on Centos6, gcc 8.2

This is needed by #12741