### PR TITLE
Add PLASMA patches to work around CMake versions

### DIFF
--- a/var/spack/repos/builtin/packages/plasma/fix_cmake_include.patch
+++ b/var/spack/repos/builtin/packages/plasma/fix_cmake_include.patch
@@ -1,0 +1,11 @@
+diff --git a/Modules/FindMKL.cmake b/Modules/FindMKL.cmake
+--- a/Modules/FindMKL.cmake
++++ b/Modules/FindMKL.cmake
+@@ -33,6 +33,7 @@
+       set(MATH_LIB "-lm")
+    endif ()
+   set(CMAKE_REQUIRED_LIBRARIES ${BLAS_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${MATH_LIB})
++  include(CheckSymbolExists)
+   check_symbol_exists(cblas_cgemm mkl.h MKL_WORKS)
+   unset(CMAKE_REQUIRED_INCLUDES)
+   unset(CMAKE_REQUIRED_LIBRARIES)

--- a/var/spack/repos/builtin/packages/plasma/package.py
+++ b/var/spack/repos/builtin/packages/plasma/package.py
@@ -66,6 +66,8 @@ class Plasma(CMakePackage):
     conflicts("%xl_r")
 
     patch("remove_absolute_mkl_include.patch", when="@17.1")
+    patch("protect_cmake_version.patch", when="@19.8.0:19.8.9")
+    patch("fix_cmake_include.patch", when="@19.8.0:19.8.9")
 
     @when("@18.9.0:")
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/plasma/protect_cmake_version.patch
+++ b/var/spack/repos/builtin/packages/plasma/protect_cmake_version.patch
@@ -1,0 +1,25 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -66,8 +66,10 @@
+ 
+ set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_SOURCE_DIR}/Modules")
+ 
+-cmake_policy(PUSH)
+-cmake_policy(SET CMP0074 NEW) # allows to use CBLAS_ROOT and LAPACKE_ROOT
++if(${CMAKE_VERSION} VERSION_GREATER 11.99.9)
++  cmake_policy(PUSH)
++  cmake_policy(SET CMP0074 NEW) # allows to use CBLAS_ROOT and LAPACKE_ROOT
++endif()
+ 
+ find_package( CBLAS REQUIRED )
+ include_directories(${CBLAS_INCLUDE_DIRS})
+@@ -82,7 +84,9 @@
+ find_package( LAPACKE REQUIRED )
+ include_directories(${LAPACKE_INCLUDE_DIRS})
+ 
++if(${CMAKE_VERSION} VERSION_GREATER 11.99.9)
+ cmake_policy(POP)
++endif()
+ 
+ set(PLASMA_LINALG_LIBRARIES ${LAPACKE_LIBRARIES} ${LAPACK_LIBRARIES} ${CBLAS_LIBRARIES} ${BLAS_LIBRARIES})


### PR DESCRIPTION
- Use of symbol testing macro requires explicit include()
- CMake policies are not version-portable and the support has to queried
  based on CMake version