### PR TITLE
for fakeroot support, add "shadow" dependency

### DIFF
--- a/var/spack/repos/builtin/packages/singularity/package.py
+++ b/var/spack/repos/builtin/packages/singularity/package.py
@@ -25,7 +25,9 @@ class Singularity(MakefilePackage):
     git      = "https://github.com/sylabs/singularity.git"
 
     version('develop', branch='master')
-    version('3.4.0', sha256='eafb27f1ffbed427922ebe2b5b95d1c9c09bfeb897518867444fe230e3e35e41')
+    # TODO: 3.4.0 requires cryptsetup (both build and run) which still needs
+    # packaging
+    # version('3.4.0', sha256='eafb27f1ffbed427922ebe2b5b95d1c9c09bfeb897518867444fe230e3e35e41')
     version('3.3.0', sha256='070530a472e7e78492f1f142c8d4b77c64de4626c4973b0589f0d18e1fcf5b4f')
     version('3.2.1', sha256='d4388fb5f7e0083f0c344354c9ad3b5b823e2f3f27980e56efa7785140c9b616')
     version('3.1.1', '158f58a79db5337e1d655ee0159b641e42ea7435')

--- a/var/spack/repos/builtin/packages/singularity/package.py
+++ b/var/spack/repos/builtin/packages/singularity/package.py
@@ -25,6 +25,7 @@ class Singularity(MakefilePackage):
     git      = "https://github.com/sylabs/singularity.git"
 
     version('develop', branch='master')
+    version('3.4.0', sha256='eafb27f1ffbed427922ebe2b5b95d1c9c09bfeb897518867444fe230e3e35e41')
     version('3.3.0', sha256='070530a472e7e78492f1f142c8d4b77c64de4626c4973b0589f0d18e1fcf5b4f')
     version('3.2.1', sha256='d4388fb5f7e0083f0c344354c9ad3b5b823e2f3f27980e56efa7785140c9b616')
     version('3.1.1', '158f58a79db5337e1d655ee0159b641e42ea7435')
@@ -34,9 +35,7 @@ class Singularity(MakefilePackage):
     depends_on('libgpg-error')
     depends_on('squashfs', type='run')
     depends_on('git', when='@develop')  # mconfig uses it for version info
-
-    # TODO: add dependency to support fakeroot option, for example:
-    # depends_on('shadow-uidmap', type='run', when='@3.3:')
+    depends_on('shadow', type='run', when='@3.3:')
 
     # Go has novel ideas about how projects should be organized.
     # We'll point GOPATH at the stage dir, and move the unpacked src


### PR DESCRIPTION
WIP.  @vsoch @hartzell 

* v3.3 now depends on the new package `shadow` (#12750) and appears to build successfully.  --fakeroot option still needs testing.
* v3.4 does not yet build.  The build error message is:

```
 checking: libseccomp+headers... no
 checking: cryptsetup... no

unable to find the cryptsetup program, is the package cryptsetup-bin installed?
```
