### PR TITLE
Fix Spack Environments bug with space in PATH

### DIFF
--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -492,8 +492,8 @@ class EnvironmentModifications(object):
                 if new is None:
                     cmds += _shell_unset_strings[shell].format(name)
                 else:
-                    cmds += _shell_set_strings[shell].format(name,
-                                                             new_env[name])
+                    cmds += _shell_set_strings[shell].format(
+                        name, cmd_quote(new_env[name]))
         return cmds
 
     @staticmethod


### PR DESCRIPTION
Fixes #12730 

Not sure what other bugs this may have influenced, or if there are other places in Spack where we should be escaping spaces in paths and we're not currently.

@tgamblin @alalazo 