### PR TITLE
WIP: add cryptsetup

### DIFF
--- a/var/spack/repos/builtin/packages/cryptsetup/package.py
+++ b/var/spack/repos/builtin/packages/cryptsetup/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Cryptsetup(AutotoolsPackage):
+    """Cryptsetup and LUKS - open-source disk encryption."""
+
+    homepage = "https://gitlab.com/cryptsetup/cryptsetup"
+    url      = "https://www.kernel.org/pub/linux/utils/cryptsetup/v2.2/cryptsetup-2.2.1.tar.xz"
+
+    version('2.2.1', sha256='94e79a31ed38bdb0acd9af7ccca1605a2ac62ca850ed640202876b1ee11c1c61')
+
+    depends_on('libuuid', type=('build','link'))
+    depends_on('lvm2', type=('build','link'))
+
+    def install(self, spec, prefix):
+        make()
+        make('install')


### PR DESCRIPTION
This will be needed by singularity 3.4 in #12754

Couldn't find any explicit discussion of deps in upstream project, so I had to find the first two the hard way.  I got lucky -- they were already in spack.

Now I'm hitting this:
```
     172    checking for poptConfigFileToString in -lpopt... no
  >> 173    configure: error: You need popt 1.7 or newer to compile.
```

`popt` appears to be a command-line parser.  Is this its real home page? 
 https://openwrt.org/packages/pkgdata/libpopt ?  If there is a download link somewhere, it's escaping my eye right at this moment.... giving up for tonight...