### PR TITLE
Add CORS for spack.packages.io

### DIFF
--- a/share/spack/packages/Dockerfile
+++ b/share/spack/packages/Dockerfile
@@ -7,5 +7,6 @@ RUN /build/split.sh
 
 FROM nginx:mainline-alpine
 COPY --from=build-env --chown=nginx:nginx /build/packages /build/packages.json /usr/share/nginx/html/api/
+COPY cors-header.conf /etc/nginx/conf.d/
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/share/spack/packages/cors-header.conf
+++ b/share/spack/packages/cors-header.conf
@@ -1,0 +1,3 @@
+# potentially add even more for preflight support
+# https://enable-cors.org/server_nginx.html
+add_header 'Access-Control-Allow-Origin' '*';


### PR DESCRIPTION
Add the HTTP header `Access-Control-Allow-Origin: *` for our NGINX service that is serving static JSON content on https://spack.packages.io .

Fix #12760 .