### PR TITLE
Fix CD: Packages Service First

### DIFF
--- a/share/spack/qa/run-docker-tests
+++ b/share/spack/qa/run-docker-tests
@@ -72,7 +72,17 @@ push_docker_image() {
     return $result
 }
 
-SPACK_VERSION="$( ../../../bin/spack --version )"
+# packages.spack.io service
+spack list --format version_json > packages.json
+./share/spack/packages/build-image.sh
+if [ "$TEST_SUITE" '=' "docker" -a \
+     "$TRAVIS_EVENT_TYPE" != "pull_request" ] && ensure_docker_login ; then
+    ./share/spack/packages/push-image.sh
+fi
+
+# spack images for users
+this_dir=$(cd $(dirname $0) && pwd)
+SPACK_VERSION="$( ${this_dir}/../../../bin/spack --version )"
 
 build_docker_image centos-6.dockerfile ../../.. spack/spack \
     "${SPACK_VERSION}-centos-6"                             \
@@ -96,9 +106,6 @@ build_docker_image ubuntu-1804.dockerfile ../../.. spack/spack \
     "ubuntu-18.04"                                             \
     "ubuntu-bionic"
 
-spack list --format version_json > packages.json
-./share/spack/packages/build-image.sh
-
 if [ "$TEST_SUITE" '=' "docker" -a \
      "$TRAVIS_EVENT_TYPE" != "pull_request" ] && ensure_docker_login ; then
     push_docker_image "spack/spack"      \
@@ -116,6 +123,4 @@ if [ "$TEST_SUITE" '=' "docker" -a \
         "ubuntu-xenial"                  \
         "ubuntu-bionic"                  \
         "latest"
-
-    ./share/spack/packages/push-image.sh
 fi

--- a/share/spack/qa/run-docker-tests
+++ b/share/spack/qa/run-docker-tests
@@ -32,46 +32,6 @@ ensure_docker_login() {
     return $__login_success
 }
 
-build_docker_image() {
-    local dockerfile="$1" ; shift
-    local build_ctx="$1" ; shift
-    local image_name="$1" ; shift
-    local first_tag="$1"
-    local tags=""
-    if [ -n "$*" ] ; then
-        tags="$( echo " $*" | sed "s|  *| -t ${image_name}:|g" )"
-        tags="${tags:1}"
-    fi
-
-    if [ -n "$first_tag" ] ; then
-        first_tag=":$first_tag"
-    fi
-
-    local cache=""
-    if docker pull "${image_name}${first_tag}" ; then
-        local cache="--cache-from ${image_name}${first_tag}"
-    fi
-
-    ( set +e
-      docker build -f "$dockerfile" $cache $tags "$build_ctx" )
-    return $?
-}
-
-push_docker_image() {
-    local image_name="$1" ; shift
-    local result=0
-    while [ -n "$*" ] ; do
-        local tag="$1" ; shift
-        (
-            set +e
-            docker push "${image_name}:${tag}"
-        )
-        result="$?"
-        [ "$result" '=' '0' ] || break
-    done
-    return $result
-}
-
 # packages.spack.io service
 spack list --format version_json > packages.json
 ./share/spack/packages/build-image.sh
@@ -80,47 +40,3 @@ if [ "$TEST_SUITE" '=' "docker" -a \
     ./share/spack/packages/push-image.sh
 fi
 
-# spack images for users
-this_dir=$(cd $(dirname $0) && pwd)
-SPACK_VERSION="$( ${this_dir}/../../../bin/spack --version )"
-
-build_docker_image centos-6.dockerfile ../../.. spack/spack \
-    "${SPACK_VERSION}-centos-6"                             \
-    "centos-6"
-
-build_docker_image centos-7.dockerfile ../../.. spack/spack \
-    "${SPACK_VERSION}-centos-7"                             \
-    "${SPACK_VERSION}"                                      \
-    "centos-7"                                              \
-    "latest"
-
-build_docker_image ubuntu-1604.dockerfile ../../.. spack/spack \
-    "${SPACK_VERSION}-ubuntu-16.04"                            \
-    "${SPACK_VERSION}-ubuntu-xenial"                           \
-    "ubuntu-16.04"                                             \
-    "ubuntu-xenial"
-
-build_docker_image ubuntu-1804.dockerfile ../../.. spack/spack \
-    "${SPACK_VERSION}-ubuntu-18.04"                            \
-    "${SPACK_VERSION}-ubuntu-bionic"                           \
-    "ubuntu-18.04"                                             \
-    "ubuntu-bionic"
-
-if [ "$TEST_SUITE" '=' "docker" -a \
-     "$TRAVIS_EVENT_TYPE" != "pull_request" ] && ensure_docker_login ; then
-    push_docker_image "spack/spack"      \
-        "${SPACK_VERSION}-centos-6"      \
-        "${SPACK_VERSION}-centos-7"      \
-        "${SPACK_VERSION}-ubuntu-16.04"  \
-        "${SPACK_VERSION}-ubuntu-18.04"  \
-        "${SPACK_VERSION}-ubuntu-xenial" \
-        "${SPACK_VERSION}-ubuntu-bionic" \
-        "${SPACK_VERSION}"               \
-        "centos-6"                       \
-        "centos-7"                       \
-        "ubuntu-16.04"                   \
-        "ubuntu-18.04"                   \
-        "ubuntu-xenial"                  \
-        "ubuntu-bionic"                  \
-        "latest"
-fi


### PR DESCRIPTION
Build the packages.spack.io service images first, so they are guaranteed to be pushed even if further images fail to build.

Fix the query to the `spack` script executed in later builds.

Update: remove Spack image builds which are now performed on Dockerhub.