### PR TITLE
clang: add another regex for version detection

### DIFF
--- a/lib/spack/spack/compilers/clang.py
+++ b/lib/spack/spack/compilers/clang.py
@@ -206,6 +206,7 @@ class Clang(Compiler):
             r'^Apple LLVM version ([^ )]+)|'
             # Normal clang compiler versions are left as-is
             r'clang version ([^ )]+)-svn[~.\w\d-]*|'
+            r'clang version ([^ )]+)-[~.\w\d-]*|'
             r'clang version ([^ )]+)',
             output
         )

--- a/lib/spack/spack/test/compilers.py
+++ b/lib/spack/spack/test/compilers.py
@@ -322,6 +322,10 @@ def test_fj_flags():
     ('clang version 3.1 (trunk 149096)\n'
      'Target: x86_64-unknown-linux-gnu\n'
      'Thread model: posix\n', '3.1'),
+    ('clang version 8.0.0-3~ubuntu18.04.1 (tags/RELEASE_800/final)\n'
+     'Target: x86_64-pc-linux-gnu\n'
+     'Thread model: posix\n'
+     'InstalledDir: /usr/bin\n', '8.0.0')
 ])
 def test_clang_version_detection(version_str, expected_version):
     version = compilers.clang.Clang.extract_version_from_output(version_str)


### PR DESCRIPTION
This is similar to #10191. The Ubuntu package for clang 8.0.0 displays a very unusual version string, and we need this new regex to detect it as just 8.0.0

Unit test have been complemented by the output that was failing detection.