### PR TITLE
binutils: fix undefined symbol libintl_dgettext

### DIFF
--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -68,6 +68,7 @@ class Binutils(AutotoolsPackage):
 
         if '+nls' in spec:
             configure_args.append('--enable-nls')
+            configure_args.append('LDFLAGS=-lintl')
         else:
             configure_args.append('--disable-nls')
 


### PR DESCRIPTION
This fixes undefined symbol `libintl_dgettext` on `libbfd.so` when building `bintuils+nls`, which depends on `gettext`.

```
ldd -r `./spack/bin/spack location -i binutils+nls`/lib/libbfd.so
	linux-vdso.so.1 (0x00007ffcf4551000)
	libz.so.1 => /tmp/spack/opt/spack/linux-ubuntu19.04-x86_64/gcc-8.3.0/zlib-1.2.11-svvxgn7pln5jyvtfaexp4s6kkfwefraf/lib/libz.so.1 (0x00007f07ed9a6000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f07ed97b000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f07ed790000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f07ee082000)
undefined symbol: libintl_dngettext	(/tmp/spack/opt/spack/linux-ubuntu19.04-x86_64/gcc-8.3.0/binutils-2.32-wedlillsmksloz46hpuf6uywypwb3fvw/lib/libbfd.so)
undefined symbol: libintl_dgettext	(/tmp/spack/opt/spack/linux-ubuntu19.04-x86_64/gcc-8.3.0/binutils-2.32-wedlillsmksloz46hpuf6uywypwb3fvw/lib/libbfd.so)
```