### PR TITLE
create package popt

### DIFF
--- a/var/spack/repos/builtin/packages/popt/package.py
+++ b/var/spack/repos/builtin/packages/popt/package.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Popt(AutotoolsPackage):
+    """The popt library parses command line options."""
+
+    homepage = "https://launchpad.net/popt"
+    url      = "https://launchpad.net/popt/head/1.16/+download/popt-1.16.tar.gz"
+
+    version('1.16', sha256='e728ed296fe9f069a0e005003c3d6b2dde3d9cad453422a10d6558616d304cc8')


### PR DESCRIPTION
Tested on CentOS 7 with gcc 8.2 and 4.8.

Motivation is to support new package cryptsetup (#12762)