### PR TITLE
singularity: updated to 3.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/singularity/package.py
+++ b/var/spack/repos/builtin/packages/singularity/package.py
@@ -25,9 +25,8 @@ class Singularity(MakefilePackage):
     git      = "https://github.com/sylabs/singularity.git"
 
     version('develop', branch='master')
-    # TODO: 3.4.0 requires cryptsetup (both build and run) which still needs
-    # packaging
-    # version('3.4.0', sha256='eafb27f1ffbed427922ebe2b5b95d1c9c09bfeb897518867444fe230e3e35e41')
+
+    version('3.4.0', sha256='eafb27f1ffbed427922ebe2b5b95d1c9c09bfeb897518867444fe230e3e35e41')
     version('3.3.0', sha256='070530a472e7e78492f1f142c8d4b77c64de4626c4973b0589f0d18e1fcf5b4f')
     version('3.2.1', sha256='d4388fb5f7e0083f0c344354c9ad3b5b823e2f3f27980e56efa7785140c9b616')
     version('3.1.1', '158f58a79db5337e1d655ee0159b641e42ea7435')
@@ -38,6 +37,9 @@ class Singularity(MakefilePackage):
     depends_on('squashfs', type='run')
     depends_on('git', when='@develop')  # mconfig uses it for version info
     depends_on('shadow', type='run', when='@3.3:')
+    depends_on('cryptsetup', type=('build', 'run'), when='@3.4:')
+
+    patch('singularity_v3.4.0_remove_root_check.patch', level=0, when='@3.4.0')
 
     # Go has novel ideas about how projects should be organized.
     # We'll point GOPATH at the stage dir, and move the unpacked src

--- a/var/spack/repos/builtin/packages/singularity/singularity_v3.4.0_remove_root_check.patch
+++ b/var/spack/repos/builtin/packages/singularity/singularity_v3.4.0_remove_root_check.patch
@@ -1,0 +1,17 @@
+--- mlocal/frags/build_runtime_suid.mk	2019-08-30 20:43:13.000000000 -0700
++++ mlocal/frags/build_runtime_suid.mk	2019-09-10 12:21:09.120567773 -0700
+@@ -11,10 +11,10 @@
+ 		-o $@ $(SOURCEDIR)/cmd/starter/main_linux.go
+ 
+ $(starter_suid_INSTALL): $(starter_suid)
+-	@if [ `id -u` -ne 0 -a -z "${RPM_BUILD_ROOT}" ] ; then \
+-		echo "SUID binary requires to execute make install as root, use sudo make install to finish installation"; \
+-		exit 1 ; \
+-	fi
++#	@if [ `id -u` -ne 0 -a -z "${RPM_BUILD_ROOT}" ] ; then \
++#		echo "SUID binary requires to execute make install as root, use sudo make install to finish installation"; \
++#		exit 1 ; \
++#	fi
+ 	@echo " INSTALL SUID" $@
+ 	$(V)install -d $(@D)
+ 	$(V)install -m 4755 $(starter_suid) $(starter_suid_INSTALL)


### PR DESCRIPTION
updated singularity 3.4.0, with patch to allow non-root make install.

Tested with updates in pending PRs #12783 #12762 

The major new feature in v3.4.0 is container encryption, which appears to work:

```console
$ singularity build --encrypt lolcow.sif library://sylabsed/examples/lolcow
FATAL:   You must be root to build an encrypted container

$ sudo -i

# export SINGULARITY_ENCRYPTION_PASSPHRASE=lolcow

# singularity build --encrypt lolcow.sif library://sylabsed/examples/lolcow
INFO:    Starting build...
INFO:    Downloading library image
INFO:    Creating SIF file...
INFO:    Build complete: lolcow.sif

# singularity run lolcow.sif 
 ______________________________________
/ You will soon meet a person who will \
\ play an important role in your life. /
 --------------------------------------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||

# unset SINGULARITY_ENCRYPTION_PASSPHRASE

# singularity run lolcow.sif 
FATAL:   Unable to use container encryption. Must supply encryption material through enironment variables or flags.
```

And switching back to normal user, the sif file can be run with the passphrase.
```console
$ export SINGULARITY_ENCRYPTION_PASSPHRASE=lolcow
$ singularity run lolcow.sif 
 ________________________________________
/ You possess a mind not merely twisted, \
\ but actually sprained.                 /
 ----------------------------------------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||
```