### PR TITLE
py-gpaw: Fixed broken fftw linking in newer versions of py-gpaw

### DIFF
--- a/var/spack/repos/builtin/packages/py-gpaw/package.py
+++ b/var/spack/repos/builtin/packages/py-gpaw/package.py
@@ -99,3 +99,5 @@ class PyGpaw(PythonPackage):
             if '+scalapack' in spec:
                 f.write("scalapack = True\n")
                 f.write("define_macros += {0}\n".format(scalapack_macros))
+            if '+fftw' in spec:
+                f.write("fftw = True\n")


### PR DESCRIPTION
The newer version of py-gpaw requires the value

```py
fftw = True
```

to be set in ``customize.py``. Otherwise fftw is not linked properly.

This pull request fixes that.