### PR TITLE
Package/fujitsu mpi

### DIFF
--- a/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
@@ -13,15 +13,15 @@ class FujitsuMpi(Package):
 
     version('3.0')
 
-    conflict('%arm')
-    conflict('%cce')
-    conflict('%clang')
-    conflict('%gcc')
-    conflict('%intel')
-    conflict('%nag')
-    conflict('%pgi')
-    conflict('%xl')
-    conflict('%xl_r')
+    conflicts('%arm')
+    conflicts('%cce')
+    conflicts('%clang')
+    conflicts('%gcc')
+    conflicts('%intel')
+    conflicts('%nag')
+    conflicts('%pgi')
+    conflicts('%xl')
+    conflicts('%xl_r')
 
     provides('mpi@3.1:')
 

--- a/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
@@ -1,0 +1,39 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class FujitsuMpi(Package):
+    """Fujitsu MPI implementation only for Fujitsu compiler."""
+
+    version('3.0')
+
+    provides('mpi@3.1:')
+
+    def install(self, spec, prefix):
+        raise InstallError(
+            'Fujitsu MPI is not installable; it is vendor supplied')
+
+    def setup_dependent_package(self, module, dependent_spec):
+        if '%fj' in dependent_spec:
+            self.spec.mpicc = join_path(self.prefix.bin, 'mpifcc')
+            self.spec.mpicxx = join_path(self.prefix.bin, 'mpiFCC')
+            self.spec.mpif77 = join_path(self.prefix.bin, 'mpifrt')
+            self.spec.mpifc = join_path(self.prefix.bin, 'mpifrt')
+
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        if '%fj' in dependent_spec:
+            spack_env.set('MPICC', join_path(self.prefix.bin, 'mpifcc'))
+            spack_env.set('MPICXX', join_path(self.prefix.bin, 'mpiFCC'))
+            spack_env.set('MPIF77', join_path(self.prefix.bin, 'mpifrt'))
+            spack_env.set('MPIF90', join_path(self.prefix.bin, 'mpifrt'))
+
+        spack_env.set('OMPI_CC', spack_cc)
+        spack_env.set('OMPI_CXX', spack_cxx)
+        spack_env.set('OMPI_FC', spack_fc)
+        spack_env.set('OMPI_F77', spack_f77)
+
+        spack_env.prepend_path('LD_LIBRARY_PATH', self.prefix.lib)

--- a/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
@@ -28,15 +28,13 @@ class FujitsuMpi(Package):
             'Fujitsu MPI is not installable; it is vendor supplied')
 
     def setup_dependent_package(self, module, dependent_spec):
-        if '%fj' in dependent_spec:
-            self.spec.mpicc = self.prefix.bin.mpifcc
-            self.spec.mpicxx = self.prefix.bin.mpiFCC
-            self.spec.mpif77 = self.prefix.bin.mpifrt
-            self.spec.mpifc = self.prefix.bin.mpifrt
+        self.spec.mpicc = self.prefix.bin.mpifcc
+        self.spec.mpicxx = self.prefix.bin.mpiFCC
+        self.spec.mpif77 = self.prefix.bin.mpifrt
+        self.spec.mpifc = self.prefix.bin.mpifrt
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        if '%fj' in dependent_spec:
-            spack_env.set('MPICC', self.prefix.bin.mpifcc)
-            spack_env.set('MPICXX', self.prefix.bin.mpiFCC)
-            spack_env.set('MPIF77', self.prefix.bin.mpifrt)
-            spack_env.set('MPIF90', self.prefix.bin.mpifrt)
+        spack_env.set('MPICC', self.prefix.bin.mpifcc)
+        spack_env.set('MPICXX', self.prefix.bin.mpiFCC)
+        spack_env.set('MPIF77', self.prefix.bin.mpifrt)
+        spack_env.set('MPIF90', self.prefix.bin.mpifrt)

--- a/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
@@ -13,6 +13,16 @@ class FujitsuMpi(Package):
 
     version('3.0')
 
+    conflict('%arm')
+    conflict('%cce')
+    conflict('%clang')
+    conflict('%gcc')
+    conflict('%intel')
+    conflict('%nag')
+    conflict('%pgi')
+    conflict('%xl')
+    conflict('%xl_r')
+
     provides('mpi@3.1:')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
@@ -11,8 +11,6 @@ class FujitsuMpi(Package):
 
     homepage = "https://www.fujitsu.com/us/"
 
-    version('3.0')
-
     conflicts('%arm')
     conflicts('%cce')
     conflicts('%clang')

--- a/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
@@ -9,6 +9,8 @@ from spack import *
 class FujitsuMpi(Package):
     """Fujitsu MPI implementation only for Fujitsu compiler."""
 
+    homepage = "https://www.fujitsu.com/us/"
+
     version('3.0')
 
     provides('mpi@3.1:')

--- a/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
@@ -21,21 +21,14 @@ class FujitsuMpi(Package):
 
     def setup_dependent_package(self, module, dependent_spec):
         if '%fj' in dependent_spec:
-            self.spec.mpicc = join_path(self.prefix.bin, 'mpifcc')
-            self.spec.mpicxx = join_path(self.prefix.bin, 'mpiFCC')
-            self.spec.mpif77 = join_path(self.prefix.bin, 'mpifrt')
-            self.spec.mpifc = join_path(self.prefix.bin, 'mpifrt')
+            self.spec.mpicc = self.prefix.bin.mpifcc
+            self.spec.mpicxx = self.prefix.bin.mpiFCC
+            self.spec.mpif77 = self.prefix.bin.mpifrt
+            self.spec.mpifc = self.prefix.bin.mpifrt
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         if '%fj' in dependent_spec:
-            spack_env.set('MPICC', join_path(self.prefix.bin, 'mpifcc'))
-            spack_env.set('MPICXX', join_path(self.prefix.bin, 'mpiFCC'))
-            spack_env.set('MPIF77', join_path(self.prefix.bin, 'mpifrt'))
-            spack_env.set('MPIF90', join_path(self.prefix.bin, 'mpifrt'))
-
-        spack_env.set('OMPI_CC', spack_cc)
-        spack_env.set('OMPI_CXX', spack_cxx)
-        spack_env.set('OMPI_FC', spack_fc)
-        spack_env.set('OMPI_F77', spack_f77)
-
-        spack_env.prepend_path('LD_LIBRARY_PATH', self.prefix.lib)
+            spack_env.set('MPICC', self.prefix.bin.mpifcc)
+            spack_env.set('MPICXX', self.prefix.bin.mpiFCC)
+            spack_env.set('MPIF77', self.prefix.bin.mpifrt)
+            spack_env.set('MPIF90', self.prefix.bin.mpifrt)


### PR DESCRIPTION
This package is MPI library supplied from Fujitsu. It is assumed that Fujitsu MPI is installed externally.
- I assume that the path to Fujitsu MPI library is defined in the `packages.yaml`.
- Then add the name of the package as a package that provides `mpi`.
``` packages:
+  fujitsu-mpi:
+    paths:
+      fujitsu-mpi%fj arch=linux-rhel8-aarch64: /path/to/fujitsu-mpi
+    buildable: False
   all:
     compiler: [gcc, intel, pgi, clang, xl, nag, fj]
------------------
       mpe: [mpe2]
-      mpi: [openmpi, mpich]
+      mpi: [fujitsu-mpi, openmpi, mpich]
       mysql-client: [mysql, mariadb-c-client]
```
- This library can be used only for the `Fujitsu compiler`.