### PR TITLE
flang: build on arm.

### DIFF
--- a/var/spack/repos/builtin/packages/flang/package.py
+++ b/var/spack/repos/builtin/packages/flang/package.py
@@ -24,6 +24,8 @@ class Flang(CMakePackage):
     depends_on('llvm@flang-20180921', when='@20180921 target=x86_64')
     depends_on('llvm@flang-20180612', when='@20180612 target=x86_64')
 
+    depends_on('llvm@flang-20180921', when='@20180921 target=aarch64')
+
     # LLVM version specific to OpenPOWER.
     depends_on('llvm@flang-ppc64le-20180921', when='@20180921 target=ppc64le')
     depends_on('llvm@flang-ppc64le-20180612', when='@20180612 target=ppc64le')


### PR DESCRIPTION
When I install  flang on arm,  the build is  failed because spec ['llvm'] is not set.
This PR fixed to build on arm.
I check only version 20180921. so the pr is only add 20180921.