### PR TITLE
Add wcslib 6.4

### DIFF
--- a/var/spack/repos/builtin/packages/wcslib/package.py
+++ b/var/spack/repos/builtin/packages/wcslib/package.py
@@ -11,8 +11,9 @@ class Wcslib(AutotoolsPackage):
     defined in the FITS WCS papers."""
 
     homepage = "http://www.atnf.csiro.au/people/mcalabre/WCS/wcslib/"
-    url      = "ftp://ftp.atnf.csiro.au/pub/software/wcslib/wcslib-5.18.tar.bz2"
+    url      = "ftp://ftp.atnf.csiro.au/pub/software/wcslib/wcslib-6.4.tar.bz2"
 
+    version('6.4', sha256='13c11ff70a7725563ec5fa52707a9965fce186a1766db193d08c9766ea107000')
     version('5.18', '67a78354be74eca4f17d3e0853d5685f')
 
     variant('cfitsio', default=False, description='Include CFITSIO support')


### PR DESCRIPTION
Version 5.18 is no longer available for download.

Successfully builds on macOS 10.14.6 with Clang 10.0.1.