### PR TITLE
Relax Python version constraints on py-html5lib

### DIFF
--- a/var/spack/repos/builtin/packages/py-html5lib/package.py
+++ b/var/spack/repos/builtin/packages/py-html5lib/package.py
@@ -15,8 +15,8 @@ class PyHtml5lib(PythonPackage):
     version('1.0.1', '66cb0dcfdbbc4f9c3ba1a63fdb511ffdbd4f513b2b6d81b80cd26ce6b3fb3736')
     version('0.9999999', 'ef43cb05e9e799f25d65d1135838a96f')
 
-    depends_on('python@2.6:2.8,3.2:3.5', when='@0.9999999')
-    depends_on('python@2.6:2.8,3.3.0:3.6.99', when='@1.0.1:')
+    depends_on('python@2.6:2.8,3.2:', when='@0.9999999', type=('build', 'run'))
+    depends_on('python@2.6:2.8,3.3:', when='@1.0.1:', type=('build', 'run'))
     depends_on('py-six', type=('build', 'run'))
     depends_on('py-six@1.9:', type=('build', 'run'), when='@1.0.1:')
     depends_on('py-setuptools', type='build', when='@1.0.1:')


### PR DESCRIPTION
The Python version constraints for this package were too strict. There are actually several more packages in Spack that exhibit this, but I haven't gotten around to updating them yet.

Successfully builds on macOS 10.14.6 with Clang 10.0.1 and Python 3.7.4.