### PR TITLE
Add py-emcee 2.2.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-emcee/package.py
+++ b/var/spack/repos/builtin/packages/py-emcee/package.py
@@ -11,8 +11,9 @@ class PyEmcee(PythonPackage):
     Affine Invariant Markov chain Monte Carlo (MCMC) Ensemble sampler."""
 
     homepage = "http://dan.iel.fm/emcee/current/"
-    url = "https://pypi.io/packages/source/e/emcee/emcee-2.1.0.tar.gz"
+    url = "https://pypi.io/packages/source/e/emcee/emcee-2.2.1.tar.gz"
 
+    version('2.2.1', sha256='b83551e342b37311897906b3b8acf32979f4c5542e0a25786ada862d26241172')
     version('2.1.0', 'c6b6fad05c824d40671d4a4fc58dfff7')
 
     depends_on('py-setuptools', type='build')


### PR DESCRIPTION
Successfully builds on macOS 10.14.6 with Clang 10.0.1 and Python 3.7.4.