### PR TITLE
Fix bug in string conversion of py-cython

### DIFF
--- a/var/spack/repos/builtin/packages/py-cython/package.py
+++ b/var/spack/repos/builtin/packages/py-cython/package.py
@@ -43,4 +43,4 @@ class PyCython(PythonPackage):
 
     def test(self):
         # Warning: full suite of unit tests takes a very long time
-        python('runtests.py', '-j', make_jobs)
+        python('runtests.py', '-j', str(make_jobs))


### PR DESCRIPTION
This seems to be a Python 3-specific bug. When run with Python 3,
```console
$ spack install --test=root py-cython
...
==> Error: TypeError: expected string or bytes-like object

/Users/Adam/spack/var/spack/repos/builtin/packages/py-cython/package.py:46, in test:
         44    def test(self):
         45        # Warning: full suite of unit tests takes a very long time
  >>     46        python('runtests.py', '-j', make_jobs)

```
This PR explicitly casts the object to a string.