### PR TITLE
Add py-bleach 3.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-bleach/package.py
+++ b/var/spack/repos/builtin/packages/py-bleach/package.py
@@ -10,11 +10,12 @@ class PyBleach(PythonPackage):
     """An easy whitelist-based HTML-sanitizing tool."""
 
     homepage = "http://github.com/mozilla/bleach"
-    url      = "https://pypi.io/packages/source/b/bleach/bleach-1.5.0.tar.gz"
+    url      = "https://pypi.io/packages/source/b/bleach/bleach-3.1.0.tar.gz"
 
+    version('3.1.0', sha256='3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa')
     version('1.5.0', 'b663300efdf421b3b727b19d7be9c7e7')
 
-    depends_on('python@2.6:2.8,3.2:3.5')
+    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
-    depends_on('py-six', type=('build', 'run'))
-    depends_on('py-html5lib@0.999,0.999999:0.9999999', type=('build', 'run'))
+    depends_on('py-six@1.9.0:', type=('build', 'run'))
+    depends_on('py-webencodings', type=('build', 'run'))


### PR DESCRIPTION
Successfully builds on macOS 10.14.6 with Clang 10.0.1 and Python 3.7.4.