### PR TITLE
Add py-astropy 2.0.14

### DIFF
--- a/var/spack/repos/builtin/packages/py-astropy/package.py
+++ b/var/spack/repos/builtin/packages/py-astropy/package.py
@@ -12,31 +12,59 @@ class PyAstropy(PythonPackage):
     Python astronomy packages."""
 
     homepage = 'http://www.astropy.org/'
-    url = 'https://pypi.io/packages/source/a/astropy/astropy-1.1.2.tar.gz'
+    url = 'https://pypi.io/packages/source/a/astropy/astropy-3.2.1.tar.gz'
 
-    version('3.2.1',     '706c0457789c78285e5464a5a336f5f0b058d646d60f4e5f5ba1f7d5bf424b28')
-    version('1.1.2',     'cbe32023b5b1177d1e2498a0d00cda51')
+    version('3.2.1', sha256='706c0457789c78285e5464a5a336f5f0b058d646d60f4e5f5ba1f7d5bf424b28')
+    version('2.0.14', sha256='618807068609a4d8aeb403a07624e9984f566adc0dc0f5d6b477c3658f31aeb6')
+    version('1.1.2', 'cbe32023b5b1177d1e2498a0d00cda51')
     version('1.1.post1', 'b52919f657a37d45cc45f5cb0f58c44d')
 
+    variant('extras', default=False, description='Enable extra functionality')
+
     # Required dependencies
+    depends_on('python@3.6:', when='@4.0:', type=('build', 'run'))
+    depends_on('python@3.5:', when='@3.0:', type=('build', 'run'))
+    depends_on('python@2.7:2.8,3.4:', when='@2.0:', type=('build', 'run'))
+    depends_on('python@2.7:2.8,3.3:', when='@1.2:', type=('build', 'run'))
+    depends_on('python@2.6:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
+    depends_on('py-numpy@1.13:', when='@3.1:', type=('build', 'run'))
+    depends_on('py-numpy@1.10:', when='@3.0:', type=('build', 'run'))
+    depends_on('py-numpy@1.9:', when='@2.0:', type=('build', 'run'))
+    depends_on('py-numpy@1.7:', when='@1.2:', type=('build', 'run'))
     depends_on('py-numpy', type=('build', 'run'))
 
     # Optional dependencies
-    depends_on('py-h5py', type=('build', 'run'))
-    depends_on('py-beautifulsoup4', type=('build', 'run'))
-    depends_on('py-pyyaml', type=('build', 'run'))
-    depends_on('py-scipy', type=('build', 'run'))
-    depends_on('libxml2')
-    depends_on('py-matplotlib', type=('build', 'run'))
-    depends_on('py-pytz', type=('build', 'run'))
-    depends_on('py-scikit-image', type=('build', 'run'))
-    depends_on('py-pandas', type=('build', 'run'))
-    depends_on('py-markupsafe', type=('build', 'run'))
+    depends_on('py-scipy', when='+extras', type=('build', 'run'))
+    depends_on('py-h5py', when='+extras', type=('build', 'run'))
+    depends_on('py-beautifulsoup4', when='+extras', type=('build', 'run'))
+    depends_on('py-html5lib', when='+extras', type=('build', 'run'))
+    depends_on('py-bleach', when='+extras', type=('build', 'run'))
+    depends_on('py-pyyaml', when='+extras', type=('build', 'run'))
+    depends_on('py-pandas', when='+extras', type=('build', 'run'))
+    depends_on('py-bintrees', when='+extras', type=('build', 'run'))
+    depends_on('py-sortedcontainers', when='+extras', type=('build', 'run'))
+    depends_on('py-pytz', when='+extras', type=('build', 'run'))
+    depends_on('py-jplephem', when='+extras', type=('build', 'run'))
+    depends_on('py-matplotlib@2.0:', when='+extras', type=('build', 'run'))
+    depends_on('py-scikit-image', when='+extras', type=('build', 'run'))
+    depends_on('py-mpmath', when='+extras', type=('build', 'run'))
+    depends_on('py-asdf@2.3:', when='+extras', type=('build', 'run'))
+    depends_on('py-bottleneck', when='+extras', type=('build', 'run'))
+    depends_on('py-pytest', when='+extras', type=('build', 'run'))
 
     # System dependencies
+    depends_on('erfa')
+    depends_on('wcslib')
     depends_on('cfitsio')
     depends_on('expat')
 
     def build_args(self, spec, prefix):
-        return ['--use-system-cfitsio', '--use-system-expat']
+        return [
+            '-j', str(make_jobs),
+            '--use-system-libraries',
+            '--use-system-erfa',
+            '--use-system-wcslib',
+            '--use-system-cfitsio',
+            '--use-system-expat'
+        ]


### PR DESCRIPTION
This PR includes the following changes:

- [x] Astropy 3 drops Python 3 support
- [x] Add latest version of Astropy that still supports Python 2
- [x] Add explicit version requirements for Python and NumPy
- [x] Make optional variants actually optional
- [x] Add additional external libraries that Astropy looks for
- [x] Build in parallel

Successfully builds on macOS 10.14.6 with Clang 10.0.1 and Python 3.7.4.