### PR TITLE
Add py-bintrees package

### DIFF
--- a/var/spack/repos/builtin/packages/py-bintrees/package.py
+++ b/var/spack/repos/builtin/packages/py-bintrees/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyBintrees(PythonPackage):
+    """Package provides Binary-, RedBlack- and AVL-Trees in Python and Cython.
+    """
+
+    homepage = "https://github.com/mozman/bintrees"
+    url      = "https://pypi.io/packages/source/b/bintrees/bintrees-2.0.7.zip"
+
+    version('2.0.7', sha256='60675e6602cef094abcd38bf4aecc067d78ae2d5e1645615c789724542d11270')
+
+    depends_on('py-setuptools', type='build')


### PR DESCRIPTION
Successfully builds on macOS 10.14.6 with Clang 10.0.1 and Python 3.7.4.