### PR TITLE
Consistently support pkg-config files in share subdirectory

### DIFF
--- a/etc/spack/defaults/modules.yaml
+++ b/etc/spack/defaults/modules.yaml
@@ -36,6 +36,8 @@ modules:
       - PKG_CONFIG_PATH
     lib64/pkgconfig:
       - PKG_CONFIG_PATH
+    share/pkgconfig:
+      - PKG_CONFIG_PATH
     '':
       - CMAKE_PREFIX_PATH
 

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -764,7 +764,7 @@ ACLOCAL_PATH        share/aclocal
 LD_LIBRARY_PATH     lib, lib64
 LIBRARY_PATH        lib, lib64
 CPATH               include
-PKG_CONFIG_PATH     lib/pkgconfig, lib64/pkgconfig
+PKG_CONFIG_PATH     lib/pkgconfig, lib64/pkgconfig, share/pkgconfig
 CMAKE_PREFIX_PATH   .
 =================== =========
 

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -949,7 +949,8 @@ class Environment(object):
             ('LD_LIBRARY_PATH', ['lib', 'lib64']),
             ('LIBRARY_PATH', ['lib', 'lib64']),
             ('CPATH', ['include']),
-            ('PKG_CONFIG_PATH', ['lib/pkgconfig', 'lib64/pkgconfig']),
+            ('PKG_CONFIG_PATH', ['lib/pkgconfig', 'lib64/pkgconfig',
+                                 'share/pkgconfig']),
             ('CMAKE_PREFIX_PATH', ['']),
         ]
 

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -506,6 +506,7 @@ def test_keys_are_ordered():
         'include',
         'lib/pkgconfig',
         'lib64/pkgconfig',
+        'share/pkgconfig',
         ''
     )
 

--- a/lib/spack/spack/test/data/config/modules.yaml
+++ b/lib/spack/spack/test/data/config/modules.yaml
@@ -38,5 +38,7 @@ modules:
       - PKG_CONFIG_PATH
     lib64/pkgconfig:
       - PKG_CONFIG_PATH
+    share/pkgconfig:
+      - PKG_CONFIG_PATH
     '':
       - CMAKE_PREFIX_PATH

--- a/lib/spack/spack/test/environment_modifications.py
+++ b/lib/spack/spack/test/environment_modifications.py
@@ -28,6 +28,7 @@ def test_inspect_path(tmpdir):
         'include': ['CPATH'],
         'lib/pkgconfig': ['PKG_CONFIG_PATH'],
         'lib64/pkgconfig': ['PKG_CONFIG_PATH'],
+        'share/pkgconfig': ['PKG_CONFIG_PATH'],
         '': ['CMAKE_PREFIX_PATH']
     }
 


### PR DESCRIPTION
While the build environment already takes share/pkgconfig into account, the generated module files etc. only consider lib/pkgconfig and lib64/pkgconfig.