### PR TITLE
util-linux variant for libuuid, cryptsetup use it

### DIFF
--- a/var/spack/repos/builtin/packages/cryptsetup/package.py
+++ b/var/spack/repos/builtin/packages/cryptsetup/package.py
@@ -20,7 +20,7 @@ class Cryptsetup(AutotoolsPackage):
     depends_on('lvm2', type=('build', 'link'))
     depends_on('popt', type=('build', 'link'))
     depends_on('json-c', type=('build', 'link'))
-    depends_on('util-linux', type=('build', 'link'))
+    depends_on('util-linux~libuuid', type=('build', 'link'))
     depends_on('gettext', type=('build', 'link'))
 
     depends_on('autoconf', type='build')

--- a/var/spack/repos/builtin/packages/util-linux/package.py
+++ b/var/spack/repos/builtin/packages/util-linux/package.py
@@ -21,7 +21,8 @@ class UtilLinux(AutotoolsPackage):
     depends_on('python@2.7:')
     depends_on('pkgconfig')
 
-    # make it possible to use the libuuid package instead...
+    # Make it possible to disable util-linux's libuuid so that you may
+    # reliably depend_on(`libuuid`).
     variant('libuuid', default=True, description='Build libuuid')
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/util-linux/package.py
+++ b/var/spack/repos/builtin/packages/util-linux/package.py
@@ -31,8 +31,7 @@ class UtilLinux(AutotoolsPackage):
 
     def configure_args(self):
         config_args = [
-            '--disable-use-tty-group'
+            '--disable-use-tty-group',
         ]
-        if '~libuuid' in self.spec:
-            config_args.append('--disable-libuuid')
+        config_args.extend(self.enable_or_disable('libuuid'))
         return config_args

--- a/var/spack/repos/builtin/packages/util-linux/package.py
+++ b/var/spack/repos/builtin/packages/util-linux/package.py
@@ -21,9 +21,17 @@ class UtilLinux(AutotoolsPackage):
     depends_on('python@2.7:')
     depends_on('pkgconfig')
 
+    # make it possible to use the libuuid package instead...
+    variant('libuuid', default=True, description='Build libuuid')
+
     def url_for_version(self, version):
         url = "https://www.kernel.org/pub/linux/utils/util-linux/v{0}/util-linux-{1}.tar.gz"
         return url.format(version.up_to(2), version)
 
     def configure_args(self):
-        return ['--disable-use-tty-group']
+        config_args = [
+            '--disable-use-tty-group'
+        ]
+        if '~libuuid' in self.spec:
+            config_args.append('--disable-libuuid')
+        return config_args


### PR DESCRIPTION
This adds a variant to the util-linux package that controls whether it
builds its own libuuid.  Variant defaults to True.  It enables other
packages to choose to get libuuid from the libuuid package instead.

This also changes the cryptsetup package to use the ~libuuid variant.

Fixes #12829