### PR TITLE
Feature: installed file verification from manifest

### DIFF
--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -277,6 +277,40 @@ the tarballs in question to it (see :ref:`mirrors`):
 
        $ spack install galahad
 
+-----------------------
+Verifying installations
+-----------------------
+
+The ``spack verify`` command can be used to verify the validity of
+Spack-installed packages any time after installation.
+
+At installation time, Spack creates a manifest of every file in the
+installation prefix. For links, Spack tracks the mode, ownership, and
+destination. For directories, Spack tracks the mode, and
+ownership. For files, Spack tracks the mode, ownership, modification
+time, hash, and size. The Spack verify command will check, for every
+file in each package, whether any of those attributes have changed. It
+will also check for newly added files or deleted files from the
+installation prefix. Spack can either check all installed packages
+using the `-a,--all` or accept specs listed on the command line to
+verify.
+
+The ``spack verify`` command can also verify for individual files that
+they haven't been altered since installation time. If the given file
+is not in a Spack installation prefix, Spack will report that it is
+not owned by any package. To check individual files instead of specs,
+use the ``-f,--files`` option.
+
+Spack installation manifests are part of the tarball signed by Spack
+for binary package distribution. When installed from a binary package,
+Spack uses the packaged installation manifest instead of creating one
+at install time.
+
+The ``spack verify`` command also accepts the ``-l,--local`` option to
+check only local packages (as opposed to those used transparently from
+``upstream`` spack instances) and the ``-j,--json`` option to output
+machine-readable json data for any errors.
+
 -------------------------
 Seeing installed packages
 -------------------------

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -594,7 +594,7 @@ def replace_directory_transaction(directory_name, tmp_root=None):
         tty.debug('TEMPORARY DIRECTORY DELETED [{0}]'.format(tmp_dir))
 
 
-def hash_directory(directory):
+def hash_directory(directory, ignore=[]):
     """Hashes recursively the content of a directory.
 
     Args:
@@ -611,11 +611,12 @@ def hash_directory(directory):
     for root, dirs, files in os.walk(directory):
         for name in sorted(files):
             filename = os.path.join(root, name)
-            # TODO: if caching big files becomes an issue, convert this to
-            # TODO: read in chunks. Currently it's used only for testing
-            # TODO: purposes.
-            with open(filename, 'rb') as f:
-                md5_hash.update(f.read())
+            if filename not in ignore:
+                # TODO: if caching big files becomes an issue, convert this to
+                # TODO: read in chunks. Currently it's used only for testing
+                # TODO: purposes.
+                with open(filename, 'rb') as f:
+                    md5_hash.update(f.read())
 
     return md5_hash.hexdigest()
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -580,6 +580,12 @@ def extract_tarball(spec, filename, allow_root=False, unsigned=False,
     # and any relocation has been done.
     else:
         install_tree(workdir, spec.prefix, symlinks=True)
+        manifest_file = os.path.join(spec.prefix,
+                                     spack.store.layout.metadata_dir,
+                                     spack.store.layout.manifest_file_name)
+        if not os.path.exists(manifest_file):
+            spec_id = spec.format('{name}/{hash:7}')
+            tty.warn('No manifest file in tarball for spec %s' % spec_id)
     finally:
         shutil.rmtree(tmpdir)
 

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -171,7 +171,7 @@ def elide_list(line_list, max_num=10):
         return line_list
 
 
-def disambiguate_spec(spec, env):
+def disambiguate_spec(spec, env, local=False):
     """Given a spec, figure out which installed package it refers to.
 
     Arguments:
@@ -180,7 +180,10 @@ def disambiguate_spec(spec, env):
             if one is active, or None if no environment is active
     """
     hashes = env.all_hashes() if env else None
-    matching_specs = spack.store.db.query(spec, hashes=hashes)
+    if local:
+        matching_specs = spack.store.db.query(spec, hashes=hashes)
+    else:
+        matching_specs = spack.store.db.query_local(spec, hashes=hashes)
     if not matching_specs:
         tty.die("Spec '%s' matches no installed packages." % spec)
 

--- a/lib/spack/spack/cmd/verify.py
+++ b/lib/spack/spack/cmd/verify.py
@@ -21,6 +21,8 @@ def setup_parser(subparser):
 
     subparser.add_argument('-l', '--local', action='store_true',
                            help="Verify only locally installed packages")
+    subparser.add_argument('-j', '--json', action='store_true',
+                           help="Ouptut json-formatted errors")
     subparser.add_argument('-a', '--all', action='store_true',
                            help="Verify all packages")
     subparser.add_argument('files_or_specs', nargs=argparse.REMAINDER,
@@ -45,7 +47,10 @@ def verify(parser, args):
         for file in args.files_or_specs:
             results = spack.verify.check_file_manifest(file)
             if results:
-                print(results)
+                if args.json:
+                    print(results.json_string())
+                else:
+                    print(results)
 
         return 0
     else:
@@ -78,7 +83,10 @@ def verify(parser, args):
         tty.debug("Verifying package %s")
         results = spack.verify.check_spec_manifest(spec)
         if results:
-            tty.msg("In package %s" % spec.format('{name}/{hash:7}'))
-            print(results)
+            if args.json:
+                print(results.json_string())
+            else:
+                tty.msg("In package %s" % spec.format('{name}/{hash:7}'))
+                print(results)
         else:
             tty.debug(results)

--- a/lib/spack/spack/cmd/verify.py
+++ b/lib/spack/spack/cmd/verify.py
@@ -37,6 +37,10 @@ def verify(parser, args):
             specs = spack.store.db.query(installed=True)
 
     for spec in specs:
-        tty.msg("Verifying package %s" % spec.format('{name}/{hash:7}'))
-        results = spack.verify.check_prefix(spec.prefix)
-        print(results)
+        tty.debug("Verifying package %s")
+        results = spack.verify.check(spec)
+        if results:
+            tty.msg("In package %s" % spec.format('{name}/{hash:7}'))
+            print(results)
+        else:
+            tty.debug(results)

--- a/lib/spack/spack/cmd/verify.py
+++ b/lib/spack/spack/cmd/verify.py
@@ -17,28 +17,66 @@ level = "long"
 
 
 def setup_parser(subparser):
+    setup_parser.parser = subparser
+
     subparser.add_argument('-l', '--local', action='store_true',
                            help="Verify only locally installed packages")
-    subparser.add_argument('-s', '--strict', action='store_true',
-                           help="Raise error for prefixes not owned by user")
-    subparser.add_argument('specs', nargs=argparse.REMAINDER,
-                           help="Specs to verify (default all)")
+    subparser.add_argument('-a', '--all', action='store_true',
+                           help="Verify all packages")
+    subparser.add_argument('files_or_specs', nargs=argparse.REMAINDER,
+                           help="Files or specs to verify")
 
+    type = subparser.add_mutually_exclusive_group()
+    type.add_argument('-s', '--specs', action='store_const', const='specs',
+                      dest='type', default='specs',
+                      help='Treat entries as specs (default)')
+    type.add_argument('-f', '--files', action='store_const', const='files',
+                      dest='type', default='specs',
+                      help="Treat entries as files. Cannot be used with '-a'")
 
 def verify(parser, args):
-    if args.specs:
-        specs = spack.cmd.parse_specs(args.specs)
-        env = ev.get_env(args, 'verify')
-        specs = list(map(lambda x: spack.cmd.disambiguate_spec(x, env), specs))
+    local = args.local
+
+    if args.type == 'files':
+        if args.all:
+            setup_parser.parser.print_help()
+            return 1
+
+        for file in args.files_or_specs:
+            results = spack.verify.check_file_manifest(file)
+            if results:
+                print(results)
+
+        return 0
     else:
-        if args.local:
-            specs = spack.store.db.query_local(installed=True)
+        spec_args = spack.cmd.parse_specs(args.files_or_specs)
+
+    if args.all:
+        # setup db query local vs global
+        query = spack.store.db.query_local if local else spack.store.db.query
+
+        # construct spec list
+        if spec_args:
+            spec_list = spack.cmd.parse_specs(args.files_or_specs)
+            specs = []
+            for spec in spec_list:
+                specs += query(spec, installed=True)
         else:
-            specs = spack.store.db.query(installed=True)
+            specs = query(installed=true)
+
+    elif args.files_or_specs:
+        # construct disambiguated spec list
+        env = ev.get_env(args, 'verify')
+        specs = list(map(lambda x: spack.cmd.disambiguate_spec(x, env,
+                                                               local=local),
+                         spec_args))
+    else:
+        setup_parser.parser.print_help()
+        return 1
 
     for spec in specs:
         tty.debug("Verifying package %s")
-        results = spack.verify.check(spec)
+        results = spack.verify.check_spec_manifest(spec)
         if results:
             tty.msg("In package %s" % spec.format('{name}/{hash:7}'))
             print(results)

--- a/lib/spack/spack/cmd/verify.py
+++ b/lib/spack/spack/cmd/verify.py
@@ -1,0 +1,42 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from __future__ import print_function
+import argparse
+
+import llnl.util.tty as tty
+
+import spack.store
+import spack.verify
+import spack.environment as ev
+
+description = "Check that all spack packages are on disk as installed"
+section = "admin"
+level = "long"
+
+
+def setup_parser(subparser):
+    subparser.add_argument('-l', '--local', action='store_true',
+                           help="Verify only locally installed packages")
+    subparser.add_argument('-s', '--strict', action='store_true',
+                           help="Raise error for prefixes not owned by user")
+    subparser.add_argument('specs', nargs=argparse.REMAINDER,
+                           help="Specs to verify (default all)")
+
+
+def verify(parser, args):
+    if args.specs:
+        specs = spack.cmd.parse_specs(args.specs)
+        env = ev.get_env(args, 'verify')
+        specs = list(map(lambda x: spack.cmd.disambiguate_spec(x, env), specs))
+    else:
+        if args.local:
+            specs = spack.store.db.query_local(installed=True)
+        else:
+            specs = spack.store.db.query(installed=True)
+
+    for spec in specs:
+        tty.msg("Verifying package %s" % spec.format('{name}/{hash:7}'))
+        results = spack.verify.check_prefix(spec.prefix)
+        print(results)

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -431,6 +431,11 @@ class YamlViewExtensionsLayout(ExtensionsLayout):
     def _write_extensions(self, spec, extensions):
         path = self.extension_file_path(spec)
 
+        if not extensions:
+            # Remove the empty extensions file
+            os.remove(path)
+            return
+
         # Create a temp file in the same directory as the actual file.
         dirname, basename = os.path.split(path)
         mkdirp(dirname)

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -194,6 +194,7 @@ class YamlDirectoryLayout(DirectoryLayout):
         self.spec_file_name      = 'spec.yaml'
         self.extension_file_name = 'extensions.yaml'
         self.packages_dir        = 'repos'  # archive of package.py files
+        self.manifest_file_name  = 'install_manifest.json'
 
     @property
     def hidden_file_paths(self):

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -188,46 +188,42 @@ class YamlFilesystemView(FilesystemView):
 
         # Super class gets projections from the kwargs
         # YAML specific to get projections from YAML file
-        projections_path = os.path.join(self._root, _projections_path)
+        self.projections_path = os.path.join(self._root, _projections_path)
         if not self.projections:
-            if os.path.exists(projections_path):
-                # Read projections file from view
-                with open(projections_path, 'r') as f:
-                    projections_data = s_yaml.load(f)
-                    spack.config.validate(projections_data,
-                                          spack.schema.projections.schema)
-                    self.projections = projections_data['projections']
-            else:
-                # Write projections file to new view
-                # Not strictly necessary as the empty file is the empty
-                # projection but it makes sense for consistency
-                try:
-                    mkdirp(os.path.dirname(projections_path))
-                    with open(projections_path, 'w') as f:
-                        f.write(s_yaml.dump({'projections': self.projections}))
-                except OSError as e:
-                    if self.projections:
-                        raise e
-        elif not os.path.exists(projections_path):
+            # Read projections file from view
+            self.projections = self.read_projections()
+        elif not os.path.exists(self.projections_path):
             # Write projections file to new view
-            mkdirp(os.path.dirname(projections_path))
-            with open(projections_path, 'w') as f:
-                f.write(s_yaml.dump({'projections': self.projections}))
+            self.write_projections()
         else:
             # Ensure projections are the same from each source
             # Read projections file from view
-            with open(projections_path, 'r') as f:
-                projections_data = s_yaml.load(f)
-                spack.config.validate(projections_data,
-                                      spack.schema.projections.schema)
-                if self.projections != projections_data['projections']:
-                    msg = 'View at %s has projections file' % self._root
-                    msg += ' which does not match projections passed manually.'
-                    raise ConflictingProjectionsError(msg)
+            if self.projections != self.read_projections():
+                msg = 'View at %s has projections file' % self._root
+                msg += ' which does not match projections passed manually.'
+                raise ConflictingProjectionsError(msg)
 
         self.extensions_layout = YamlViewExtensionsLayout(self, layout)
 
         self._croot = colorize_root(self._root) + " "
+
+    def write_projections(self):
+        if self.projections:
+            mkdirp(os.path.dirname(self.projections_path))
+            with open(self.projections_path, 'w') as f:
+                f.write(s_yaml.dump({'projections': self.projections}))
+
+    def read_projections(self):
+        try:
+            with open(self.projections_path, 'r') as f:
+                projections_data = s_yaml.load(f)
+                spack.config.validate(projections_data,
+                                      spack.schema.projections.schema)
+                return projections_data['projections']
+        except IOError:
+            return {}
+        except OSError:
+            return {}
 
     def add_specs(self, *specs, **kwargs):
         assert all((s.concrete for s in specs))

--- a/lib/spack/spack/hooks/__init__.py
+++ b/lib/spack/spack/hooks/__init__.py
@@ -37,6 +37,10 @@ def all_hook_modules():
         path = os.path.join(spack.paths.hooks_path, name) + ".py"
         mod = simp.load_source(mod_name, path)
         modules.append(mod)
+        if name == 'write_install_manifest':
+            last_mod = mod
+
+    modules.sort(key=lambda x: x is last_mod)
 
     return modules
 

--- a/lib/spack/spack/hooks/write_install_manifest.py
+++ b/lib/spack/spack/hooks/write_install_manifest.py
@@ -2,65 +2,9 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import os
-import json
-import hashlib
-import base64
-import sys
 
-import spack.store
-import spack.util.file_permissions as fp
 import spack.verify
-
-def create_manifest_entry(path):
-    data = {}
-    stat = os.stat(path)
-
-    data['mode'] = stat.st_mode
-    data['owner'] = stat.st_uid
-    data['group'] = stat.st_gid
-
-    if os.path.islink(path):
-        data['type'] = 'link'
-        data['dest'] = os.readlink(path)
-
-    elif os.path.isdir(path):
-        data['type'] = 'dir'
-
-    else:
-        data['type'] = 'file'
-        data['hash'] = spack.verify.compute_hash(path)
-        data['time'] = stat.st_mtime
-        data['size'] = stat.st_size
-
-    return data
-
-
-def generate_manifest(prefix):
-    manifest = {}
-    for root, dirs, files in os.walk(prefix):
-        for entry in list(dirs + files):
-            path = os.path.join(root, entry)
-            manifest[path] = create_manifest_entry(path)
-    manifest[prefix] = create_manifest_entry(prefix)
-
-    return manifest
 
 def post_install(spec):
     if not spec.external:
-        manifest_file = os.path.join(spec.prefix,
-                                     spack.store.layout.metadata_dir,
-                                     spack.store.layout.manifest_file_name)
-
-        if not manifest_file:
-            tty.debug("Writing manifest file: No manifest from binary")
-
-            manifest = generate_manifest(spec.prefix)
-
-            with open(manifest_file, 'wb') as f:
-                js = json.dumps(manifest, f)
-                if sys.version_info[0] >= 3:
-                    js = js.encode()
-                f.write(js)
-
-            fp.set_permissions_by_spec(manifest_file, spec)
+        spack.verify.write_manifest(spec)

--- a/lib/spack/spack/hooks/write_install_manifest.py
+++ b/lib/spack/spack/hooks/write_install_manifest.py
@@ -1,0 +1,66 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import os
+import json
+import hashlib
+import base64
+import sys
+
+import spack.store
+import spack.util.file_permissions as fp
+import spack.verify
+
+def create_manifest_entry(path):
+    data = {}
+    stat = os.stat(path)
+
+    data['mode'] = stat.st_mode
+    data['owner'] = stat.st_uid
+    data['group'] = stat.st_gid
+
+    if os.path.islink(path):
+        data['type'] = 'link'
+        data['dest'] = os.readlink(path)
+
+    elif os.path.isdir(path):
+        data['type'] = 'dir'
+
+    else:
+        data['type'] = 'file'
+        data['hash'] = spack.verify.compute_hash(path)
+        data['time'] = stat.st_mtime
+        data['size'] = stat.st_size
+
+    return data
+
+
+def generate_manifest(prefix):
+    manifest = {}
+    for root, dirs, files in os.walk(prefix):
+        for entry in list(dirs + files):
+            path = os.path.join(root, entry)
+            manifest[path] = create_manifest_entry(path)
+    manifest[prefix] = create_manifest_entry(prefix)
+
+    return manifest
+
+def post_install(spec):
+    if not spec.external:
+        manifest_file = os.path.join(spec.prefix,
+                                     spack.store.layout.metadata_dir,
+                                     spack.store.layout.manifest_file_name)
+
+        if not manifest_file:
+            tty.debug("Writing manifest file: No manifest from binary")
+
+            manifest = generate_manifest(spec.prefix)
+
+            with open(manifest_file, 'wb') as f:
+                js = json.dumps(manifest, f)
+                if sys.version_info[0] >= 3:
+                    js = js.encode()
+                f.write(js)
+
+            fp.set_permissions_by_spec(manifest_file, spec)

--- a/lib/spack/spack/test/verification.py
+++ b/lib/spack/spack/test/verification.py
@@ -1,0 +1,155 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""Tests for the `spack.verify` module"""
+import os
+import llnl.util.filesystem as fs
+import spack.verify
+import spack.spec
+
+def test_link_manifest(tmpdir):
+    file = str(tmpdir.join('file'))
+    open(file, 'a').close()
+    link = str(tmpdir.join('link'))
+    os.symlink(file, link)
+
+    data = spack.verify.create_manifest_entry(link)
+    assert data['type'] == 'link'
+    assert data['dest'] == file
+    assert all(x in data for x in ('mode', 'owner', 'group'))
+
+    results = spack.verify.check_entry(link, data)
+    assert not results
+
+    data['type'] = 'garbage'
+    results = spack.verify.check_entry(link, data)
+
+    results = spack.verify.check_entry(link, data)
+    assert results
+    assert link in results.errors
+    assert results.errors[link] == ['type']
+
+    data['type'] = 'link'
+
+    file2 = str(tmpdir.join('file2'))
+    open(file2, 'a').close()
+    os.remove(link)
+    os.symlink(file2, link)
+
+    results = spack.verify.check_entry(link, data)
+    assert results
+    assert link in results.errors
+    assert results.errors[link] == ['link']
+
+
+def test_dir_manifest(tmpdir):
+    dirent = str(tmpdir.join('dir'))
+    fs.mkdirp(dirent)
+
+    data = spack.verify.create_manifest_entry(dirent)
+    assert data['type'] == 'dir'
+    assert all(x in data for x in ('mode', 'owner', 'group'))
+
+    results = spack.verify.check_entry(dirent, data)
+    assert not results
+
+    data['type'] = 'garbage'
+
+    results = spack.verify.check_entry(dirent, data)
+    assert results
+    assert dirent in results.errors
+    assert results.errors[dirent] == ['type']
+
+
+def test_file_manifest(tmpdir):
+    file = str(tmpdir.join('dir'))
+    with open(file, 'w') as f:
+        f.write('This is a file')
+
+    data = spack.verify.create_manifest_entry(file)
+    assert data['type'] == 'file'
+    assert data['size'] == 14
+    assert all(x in data for x in ('mode', 'owner', 'group'))
+
+    results = spack.verify.check_entry(file, data)
+    assert not results
+
+    data['type'] = 'garbage'
+
+    results = spack.verify.check_entry(file, data)
+    assert results
+    assert file in results.errors
+    assert results.errors[file] == ['type']
+
+    data['type'] = 'file'
+
+    with open(file, 'w') as f:
+        f.write('The file has changed')
+
+    results = spack.verify.check_entry(file, data)
+    assert results
+    assert file in results.errors
+    assert all(x in results.errors[file] for x in ('size', 'hash', 'mtime'))
+    assert len(results.errors[file]) == 3
+
+
+def test_check_chmod_manifest(tmpdir):
+    file = str(tmpdir.join('dir'))
+    with open(file, 'w') as f:
+        f.write('This is a file')
+
+    data = spack.verify.create_manifest_entry(file)
+
+    os.chmod(file, data['mode'] - 1)
+
+    results = spack.verify.check_entry(file, data)
+    assert results
+    assert file in results.errors
+    assert results.errors[file] == ['mode']
+
+
+def test_check_prefix_manifest(tmpdir, monkeypatch):
+    prefix_path = tmpdir.join('prefix')
+    prefix = str(prefix_path)
+
+    spec = spack.spec.Spec('libelf')
+    spec._mark_concrete()
+    monkeypatch.setattr(spack.spec.Spec, 'prefix', prefix)
+
+    results = spack.verify.check_spec_manifest(spec)
+    assert results
+    assert prefix in results.errors
+    assert results.errors[prefix] == ['manifest missing']
+
+    metadata_dir = str(prefix_path.join('.spack'))
+    bin_dir = str(prefix_path.join('bin'))
+    other_dir = str(prefix_path.join('other'))
+
+    for d in (metadata_dir, bin_dir, other_dir):
+        fs.mkdirp(d)
+
+    file = os.path.join(other_dir, 'file')
+    with open(file, 'w') as f:
+        f.write("I'm a little file short and stout")
+
+    link = os.path.join(bin_dir, 'run')
+    os.symlink(file, link)
+
+    spack.verify.write_manifest(spec)
+    results = spack.verify.check_spec_manifest(spec)
+    assert not results
+
+    os.remove(link)
+    malware = os.path.join(metadata_dir, 'hiddenmalware')
+    with open(malware, 'w') as f:
+        f.write("Foul evil deeds")
+
+    results = spack.verify.check_spec_manifest(spec)
+    assert results
+    assert all(x in results.errors for x in (malware, link))
+    assert len(results.errors) == 2
+
+    assert results.errors[link] == ['deleted']
+    assert results.errors[malware] == ['added']

--- a/lib/spack/spack/verify.py
+++ b/lib/spack/spack/verify.py
@@ -234,6 +234,9 @@ class VerificationResults(object):
         # Backwards compatibility for python 2.x
         return self.__bool__()
 
+    def json_string(self):
+        return json.dumps(self.errors)
+
     def __str__(self):
         res = ''
         for path, fields in self.errors.items():


### PR DESCRIPTION
Binary package managers generally offer some form of verification for installed packages. This allows sysadmins to confirm that the files on their system or image are the files they wanted, and provides a smoke test (although not any sort of comprehensive protection) against certain sorts of malicious behavior.

This feature adds such tracking to Spack. It adds a post-install hook that generates a manifest of every file in the prefix. This manifest can then be used to ensure that no files have changed since installation time. The hook is skipped when installing from a binary cache that has an install manifest in the tarball, so for signed tarballs we can confirm that the files on disk are the files installed at build time.

The ``spack verify`` command has three modes.

With the `-a,--all` option it will check every installed package.
With the `-f,--files` option, it will check some specific files, determine which package they belong to, and confirm that they have not been changed.
With the `-s,--specs` option or by default, it will check some specific packages that no files havae changed.

It also accepts option to check local packages only and to output json data.