### PR TITLE
Add test dependencies to list of RPATHed dependencies

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -257,7 +257,8 @@ def set_build_environment_variables(pkg, env, dirty):
     """
     # Gather information about various types of dependencies
     build_deps      = set(pkg.spec.dependencies(deptype=('build', 'test')))
-    link_deps       = set(pkg.spec.traverse(root=False, deptype=('link')))
+    link_deps       = set(pkg.spec.traverse(root=False,
+                                            deptype=('link', 'test')))
     build_link_deps = build_deps | link_deps
     rpath_deps      = get_rpath_deps(pkg)
 


### PR DESCRIPTION
In #5132, we added a `test` deptype with the following properties:

- Dependency is only added when `spack install --test` is specified
- Doesn't affect the package hash
- Performs same env modifications as `build` deptype

This PR adds one additional property:

- Performs same modifications to `-I`, `-L`, and `-Wl,-rpath` in compiler wrapper as `link` deptype

When we discussed #5132, one of the assumptions was that "test" dependencies only needed to be added to the `PATH` or `PYTHONPATH` to use them. However, this is not the case for all "test" dependencies. Specifically, `googletest` is needed as a "test" dependency for many packages, however it has no `prefix.bin` directory. It only has `prefix.include` and `prefix.lib` directories that are used to compile the unit tests of a package. This PR allows `googletest` to be RPATHed to the unit tests.

One concern I have is what happens when a unit test has many dependencies that we don't want RPATHed into the resulting executable. Could this be a problem? I want to make sure that `build` and `test` dependencies can still be uninstalled after installation without causing any unforeseen problems. Also, this won't affect the spec hash, right?