### PR TITLE
package/libspatialite: improve dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/libspatialite/package.py
+++ b/var/spack/repos/builtin/packages/libspatialite/package.py
@@ -11,11 +11,15 @@ class Libspatialite(AutotoolsPackage):
        SQLite core to support fully fledged Spatial SQL capabilities."""
 
     homepage = "http://www.gaia-gis.it"
-    url      = "http://www.gaia-gis.it/gaia-sins/libspatialite-4.3.0a.tar.gz"
+    url      = "http://www.gaia-gis.it/gaia-sins/libspatialite-sources/libspatialite-4.3.0a.tar.gz"
 
-    version('4.3.0a', '6b380b332c00da6f76f432b10a1a338c')
+    version('4.3.0a', sha256='88900030a4762904a7880273f292e5e8ca6b15b7c6c3fb88ffa9e67ee8a5a499')
+    version('3.0.1', sha256='4983d6584069fd5ff0cfcccccee1015088dab2db177c0dc7050ce8306b68f8e6')
 
-    depends_on('sqlite')
+    depends_on('pkg-config', type='build')
+    depends_on('sqlite+rtree')
     depends_on('proj@:5')
     depends_on('geos')
     depends_on('freexl')
+    depends_on('libiconv')
+    depends_on('libxml2')


### PR DESCRIPTION
- grep'ped the source code to confirm it has rtree dependency as mentioned in other places on the internet (also see https://docs.djangoproject.com/en/2.2/ref/contrib/gis/install/spatialite/)

- A careful look at config log reveals it has iconv and libxml2 dependency