### PR TITLE
Added autoreconf stage for czmq

### DIFF
--- a/var/spack/repos/builtin/packages/czmq/package.py
+++ b/var/spack/repos/builtin/packages/czmq/package.py
@@ -22,6 +22,10 @@ class Czmq(AutotoolsPackage):
     depends_on("libuuid")
     depends_on('zeromq')
 
+    def autoreconf(self, spec, prefix):
+        autogen = Executable('./autogen.sh')
+        autogen()
+
     def configure_args(self):
         config_args = []
         if 'clang' in self.compiler.name:


### PR DESCRIPTION
I’m may have been missing something obvious but I’m running into the following when installing `czmq` with the latest version of Spack.
```
$ spack install czmq
...
==> Executing phase: 'autoreconf'
==> Error: ProcessError: Command exited with status 1:
    '/ecp/sw/opt/xeon-x86_64/linux-centos7-x86_64/gcc-4.8.5/autoconf-2.69-dzuvqtysoqchxxlnfcfdvflwlvnwl542/bin/autoreconf' '-ivf' '-I' '/ecp/sw/opt/xeon-x86_64/linux-centos7-x86_64/gcc-4.8.5/pkgconf-1.6.1-zyia6fm5vvznsxxla43wto6vezv3jciz/share/aclocal'

1 error found in build log:
     5     ==> [2019-09-17-08:03:53.989870] Warning: *        a custom AUTORECO
           NF phase in the package       *
     6     ==> [2019-09-17-08:03:53.989947] Warning: **************************
           *******************************
     7     ==> [2019-09-17-08:03:53.999625] '/ecp/sw/opt/xeon-x86_64/linux-cent
           os7-x86_64/gcc-4.8.5/autoconf-2.69-dzuvqtysoqchxxlnfcfdvflwlvnwl542/
           bin/autoreconf' '-ivf' '-I' '/ecp/sw/opt/xeon-x86_64/linux-centos7-x
           86_64/gcc-4.8.5/pkgconf-1.6.1-zyia6fm5vvznsxxla43wto6vezv3jciz/share
           /aclocal'
     8     autoreconf: Entering directory `.'
     9     autoreconf: configure.ac: not using Gettext
     10    autoreconf: running: aclocal -I /ecp/sw/opt/xeon-x86_64/linux-centos
           7-x86_64/gcc-4.8.5/pkgconf-1.6.1-zyia6fm5vvznsxxla43wto6vezv3jciz/sh
           are/aclocal --force -I config
  >> 11    aclocal: error: couldn't open directory 'config': No such file or di
           rectory
     12    autoreconf: aclocal failed with exit status: 1

```
I’ve tried on a different machine with the same results. Should note I’ve been able to successfully install this in the past and trying with a Spack revision from a few months ago worked as expected. Looking at the dependencies the only change was a newer version of `zeromq` and I wasn't able to find a specific change to autotools that would seem like I could attribute to this new error?

https://github.com/spack/spack/blob/develop/lib/spack/spack/build_systems/autotools.py#L188

So adding the `def autoreconf` to execute the `autogen.sh` seemed like the solution in this case but I'm not an expert on this package so there may exist a better solution.