### PR TITLE
Add SQLite 3.29.0

### DIFF
--- a/var/spack/repos/builtin/packages/sqlite/package.py
+++ b/var/spack/repos/builtin/packages/sqlite/package.py
@@ -14,6 +14,7 @@ class Sqlite(AutotoolsPackage):
     """
     homepage = "https://www.sqlite.org"
 
+    version('3.29.0', sha256='8e7c1e2950b5b04c5944a981cb31fffbf9d2ddda939d536838ebc854481afd5b')
     version('3.28.0', sha256='d61b5286f062adfce5125eaf544d495300656908e61fca143517afcc0a89b7c3')
     version('3.27.2', sha256='50c39e85ea28b5ecfdb3f9e860afe9ba606381e21836b2849efca6a0bfe6ef6e')
     version('3.27.1', sha256='54a92b8ff73ff6181f89b9b0c08949119b99e8cccef93dbef90e852a8b10f4f8')
@@ -23,6 +24,7 @@ class Sqlite(AutotoolsPackage):
     # is enabled, see https://blade.tencent.com/magellan/index_en.html
 
     depends_on('readline')
+    depends_on('zlib')
 
     variant('functions', default=False,
             description='Provide mathematical and string extension functions '


### PR DESCRIPTION
Also adds missing dependency on zlib.

Successfully installs on macOS 10.14.6 with Clang 10.0.1.

### Before

```console
$ otool -L /Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/sqlite-3.28.0-bnexuocixdforrf4cz6unyimqighnvpa/lib/libsqlite3.dylib 
/Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/sqlite-3.28.0-bnexuocixdforrf4cz6unyimqighnvpa/lib/libsqlite3.dylib:
	/Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/sqlite-3.28.0-bnexuocixdforrf4cz6unyimqighnvpa/lib/libsqlite3.0.dylib (compatibility version 9.0.0, current version 9.6.0)
	/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.250.1)
```

### After

```console
$ otool -L /Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/sqlite-3.29.0-gu7sgnipt56mtrra2qh7uxnhbkgovfkc/lib/libsqlite3.dylib 
/Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/sqlite-3.29.0-gu7sgnipt56mtrra2qh7uxnhbkgovfkc/lib/libsqlite3.dylib:
	/Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/sqlite-3.29.0-gu7sgnipt56mtrra2qh7uxnhbkgovfkc/lib/libsqlite3.0.dylib (compatibility version 9.0.0, current version 9.6.0)
	/Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/zlib-1.2.11-nqnlnxddpa4qfz5cnf4grnct57ds25ks/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.250.1)
```