### PR TITLE
libunistring: add missing dependency on libiconv

### DIFF
--- a/var/spack/repos/builtin/packages/libunistring/package.py
+++ b/var/spack/repos/builtin/packages/libunistring/package.py
@@ -12,11 +12,14 @@ class Libunistring(AutotoolsPackage):
 
     homepage = "https://www.gnu.org/software/libunistring/"
     url      = "https://ftpmirror.gnu.org/libunistring/libunistring-0.9.10.tar.xz"
+
     version('0.9.10', sha256='eb8fb2c3e4b6e2d336608377050892b54c3c983b646c561836550863003c05d7')
     version('0.9.9',  sha256='a4d993ecfce16cf503ff7579f5da64619cee66226fb3b998dafb706190d9a833')
     version('0.9.8',  sha256='7b9338cf52706facb2e18587dceda2fbc4a2a3519efa1e15a3f2a68193942f80')
     version('0.9.7', '82e0545363d111bfdfec2ddbfe62ffd3')
     version('0.9.6', 'cb09c398020c27edac10ca590e9e9ef3')
+
+    depends_on('libiconv')
 
     # glibc 2.28+ removed libio.h and thus _IO_ftrylockfile
     patch('removed_libio.patch', when='@:0.9.9')


### PR DESCRIPTION
Successfully installs and passes all unit tests on macOS 10.14.6 with Clang 10.0.1.

### Before

```console
$ otool -L /Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/libunistring-0.9.10-ivxnfbyjb3jd5tebppqoj6cdqsi3dpvm/lib/libunistring.dylib 
/Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/libunistring-0.9.10-ivxnfbyjb3jd5tebppqoj6cdqsi3dpvm/lib/libunistring.dylib:
	/Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/libunistring-0.9.10-ivxnfbyjb3jd5tebppqoj6cdqsi3dpvm/lib/libunistring.2.dylib (compatibility version 4.0.0, current version 4.0.0)
	/usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1570.15.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.250.1)
```

### After

```console
$ otool -L /Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/libunistring-0.9.10-7ldnpywhgu6ycyzavxxpsgdjb65yhdhs/lib/libunistring.dylib 
/Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/libunistring-0.9.10-7ldnpywhgu6ycyzavxxpsgdjb65yhdhs/lib/libunistring.dylib:
	/Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/libunistring-0.9.10-7ldnpywhgu6ycyzavxxpsgdjb65yhdhs/lib/libunistring.2.dylib (compatibility version 4.0.0, current version 4.0.0)
	/Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/libiconv-1.15-6y7tjlqeuu7qmpv3zokgbdowqs7emk7y/lib/libiconv.2.dylib (compatibility version 9.0.0, current version 9.0.0)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1575.19.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.250.1)
```