### PR TITLE
diffutils: add missing libiconv dependency

### DIFF
--- a/var/spack/repos/builtin/packages/diffutils/package.py
+++ b/var/spack/repos/builtin/packages/diffutils/package.py
@@ -17,3 +17,5 @@ class Diffutils(AutotoolsPackage):
     version('3.6', sha256='d621e8bdd4b573918c8145f7ae61817d1be9deb4c8d2328a65cea8e11d783bd6')
 
     build_directory = 'spack-build'
+
+    depends_on('libiconv')


### PR DESCRIPTION
### Before

```console
$ otool -L /Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/diffutils-3.7-jvgimm7dfdzbuwjxhmrmrzfangw3r3ry/bin/diff
/Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/diffutils-3.7-jvgimm7dfdzbuwjxhmrmrzfangw3r3ry/bin/diff:
	/usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.250.1)
```

### After

```console
$ otool -L /Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/diffutils-3.7-yxlkgmwyhdbocjsbrswrdiiz65s6duje/bin/diff
/Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/diffutils-3.7-yxlkgmwyhdbocjsbrswrdiiz65s6duje/bin/diff:
	/Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/libiconv-1.15-6y7tjlqeuu7qmpv3zokgbdowqs7emk7y/lib/libiconv.2.dylib (compatibility version 9.0.0, current version 9.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.250.1)
```