### PR TITLE
wcslib: fix darwin install name

### DIFF
--- a/var/spack/repos/builtin/packages/wcslib/package.py
+++ b/var/spack/repos/builtin/packages/wcslib/package.py
@@ -47,3 +47,9 @@ class Wcslib(AutotoolsPackage):
             args.append('--without-x')
 
         return args
+
+    @run_after('install')
+    def darwin_fix(self):
+        # The shared library is not installed correctly on Darwin; fix this
+        if self.spec.satisfies('platform=darwin'):
+            fix_darwin_install_name(self.prefix.lib)


### PR DESCRIPTION
### Before

```console
$ otool -L /Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/wcslib-6.4-rxqn53e3azxkvkxoe7qxy7nb2aga273g/lib/libwcs.dylib 
/Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/wcslib-6.4-rxqn53e3azxkvkxoe7qxy7nb2aga273g/lib/libwcs.dylib:
	libwcs.6.4.dylib (compatibility version 6.0.0, current version 6.4.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.250.1)
```

### After

```console
$ otool -L /Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/wcslib-6.4-rxqn53e3azxkvkxoe7qxy7nb2aga273g/lib/libwcs.dylib 
/Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/wcslib-6.4-rxqn53e3azxkvkxoe7qxy7nb2aga273g/lib/libwcs.dylib:
	/Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/wcslib-6.4-rxqn53e3azxkvkxoe7qxy7nb2aga273g/lib/libwcs.dylib (compatibility version 6.0.0, current version 6.4.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.250.1)
```