### PR TITLE
blis: fix darwin install name

### DIFF
--- a/var/spack/repos/builtin/packages/blis/package.py
+++ b/var/spack/repos/builtin/packages/blis/package.py
@@ -50,7 +50,7 @@ class Blis(Package):
     )
 
     variant(
-        'cblas', default=False,
+        'cblas', default=True,
         description='CBLAS compatibility',
     )
 
@@ -117,3 +117,9 @@ class Blis(Package):
 
     def install(self, spec, prefix):
         make('install')
+
+    @run_after('install')
+    def darwin_fix(self):
+        # The shared library is not installed correctly on Darwin; fix this
+        if self.spec.satisfies('platform=darwin'):
+            fix_darwin_install_name(self.prefix.lib)


### PR DESCRIPTION
Fixes https://github.com/numpy/numpy/issues/14180

### Before

```console
$ otool -L /Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/blis-0.6.0-rufmzbffyfzqafiolixs4ztwdwz73adj/lib/libblis.dylib 
/Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/blis-0.6.0-rufmzbffyfzqafiolixs4ztwdwz73adj/lib/libblis.dylib:
	libblis.2.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.250.1)
```

### After

```console
$ otool -L /Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/blis-0.6.0-v7dirtoptoe5d3vaxjb223mr6to6y3sb/lib/libblis.dylib 
/Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/blis-0.6.0-v7dirtoptoe5d3vaxjb223mr6to6y3sb/lib/libblis.dylib:
	/Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/blis-0.6.0-v7dirtoptoe5d3vaxjb223mr6to6y3sb/lib/libblis.2.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.250.1)
```

With this PR, I'm finally able to build `py-numpy +blas~lapack ^blis+cblas`! All numpy unit tests pass, and library is linked correctly:
```console
$ otool -L /Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/py-numpy-1.17.2-pi2y57jtkngucg44dn2w5m3rgtkd2r66/lib/python3.7/site-packages/numpy/core/_multiarray_umath.cpython-37m-darwin.so 
/Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/py-numpy-1.17.2-pi2y57jtkngucg44dn2w5m3rgtkd2r66/lib/python3.7/site-packages/numpy/core/_multiarray_umath.cpython-37m-darwin.so:
	/Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/blis-0.6.0-v7dirtoptoe5d3vaxjb223mr6to6y3sb/lib/libblis.2.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.250.1)
```
Since `--enable-cblas` is required to build `py-numpy`, I opted to switch it to `default=True` in the `blis` package.

@s-sajid-ali 