### PR TITLE
googletest: fix darwin install name

### DIFF
--- a/var/spack/repos/builtin/packages/googletest/package.py
+++ b/var/spack/repos/builtin/packages/googletest/package.py
@@ -59,3 +59,9 @@ class Googletest(CMakePackage):
             else:
                 install('libgtest.a', prefix.lib)
                 install('libgtest_main.a', prefix.lib)
+
+    @run_after('install')
+    def darwin_fix(self):
+        # The shared library is not installed correctly on Darwin; fix this
+        if self.spec.satisfies('platform=darwin'):
+            fix_darwin_install_name(self.prefix.lib)


### PR DESCRIPTION
### Before

```console
$ otool -L /Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/googletest-1.8.1-sdcowbfxteo6x2mnlzbuh3yobr6znwzf/lib/libgtest_main.dylib 
/Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/googletest-1.8.1-sdcowbfxteo6x2mnlzbuh3yobr6znwzf/lib/libgtest_main.dylib:
	libgtest_main.dylib (compatibility version 0.0.0, current version 0.0.0)
	libgtest.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 400.9.4)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.250.1)
```

### After

```console
$ otool -L /Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/googletest-1.8.1-sdcowbfxteo6x2mnlzbuh3yobr6znwzf/lib/libgtest_main.dylib 
/Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/googletest-1.8.1-sdcowbfxteo6x2mnlzbuh3yobr6znwzf/lib/libgtest_main.dylib:
	/Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/googletest-1.8.1-sdcowbfxteo6x2mnlzbuh3yobr6znwzf/lib/libgtest_main.dylib (compatibility version 0.0.0, current version 0.0.0)
	/Users/Adam/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/googletest-1.8.1-sdcowbfxteo6x2mnlzbuh3yobr6znwzf/lib/libgtest.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 400.9.4)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.250.1)
```