### PR TITLE
boost: Use gcc toolset for bootstrap with Fujitsu compiler.

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -239,7 +239,7 @@ class Boost(Package):
         boost_toolset_id = self.determine_toolset(spec)
 
         # Arm compiler bootstraps with 'gcc' (but builds as 'clang')
-        if spec.satisfies('%arm'):
+        if spec.satisfies('%arm') or spec.satisfies('%fj'):
             options.append('--with-toolset=gcc')
         else:
             options.append('--with-toolset=%s' % boost_toolset_id)


### PR DESCRIPTION
Bootstraps with gcc, but compiles with clang.