### PR TITLE
FFTW now recognizes Cray arm_thunderx2 as an ARM processor

### DIFF
--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -85,7 +85,7 @@ class Fftw(AutotoolsPackage):
             ('x86_64',): ('sse', 'sse2', 'avx', 'avx2', 'avx512',
                           'avx-128-fma', 'kcvi'),
             ('ppc', 'ppc64le', 'power7'): ('altivec', 'vsx'),
-            ('arm',): ('neon',)
+            ('arm','arm_thunderx2'): ('neon',)
         }
 
         if spec.satisfies("platform=cray"):


### PR DESCRIPTION
**Change**
file: `var/spack/repos/builtin/packages/fftw/package.py`
method: `flag_handler`
change: `('arm',)  ==>  ('arm','arm_thunderx2')`

**Before: "arm_thunderx2" conflicts with "simd=neon"**
```
$ spack install fftw % gcc @ 8.3.0 arch=cray-cnl7-arm_thunderx2
...
==> Error: ConflictsInSpecError: Conflicts in concretized spec "fftw@3.3.8%arm@19.2+double+float~fma+long_double+mpi~openmp~pfft_patches~quad simd=neon arch=cray-cnl7-arm_thunderx2/mwdjb7s"

    List of matching conflicts for spec:

    fftw@3.3.8%arm@19.2+double+float~fma+long_double+mpi~openmp~pfft_patches~quad simd=neon arch=cray-cnl7-arm_thunderx2
        ^mpich@3.3.1%arm@19.2 device=ch3 +hydra netmod=tcp +pci pmi=pmi +romio~slurm~verbs+wrapperrpath arch=cray-cnl7-arm_thunderx2

1. "arm_thunderx2" conflicts with "simd=neon" [simd=neon are valid only on arm]
```
**After: FFTW builds successfully**
```
$ spack install fftw % cce @ 9.0.1 arch=cray-cnl7-arm_thunderx2
...
==> Successfully installed fftw
  Fetch: 0.15s.  Build: 5m 1.13s.  Total: 5m 1.28s.
[+] /pfs/scratch4/yellow/.mdt2/dantopa/flag/fftw-pr.spack/opt/spack/cray-cnl7-arm_thunderx2/cce-9.0.1/fftw-3.3.8-4zscwzopcr4i3nhrec3ygev7zzdkeoom

$ spack install fftw % cce @ 9.0.2 arch=cray-cnl7-arm_thunderx2
...
==> Successfully installed fftw
  Fetch: 0.02s.  Build: 5m 2.62s.  Total: 5m 2.64s.
[+] /pfs/scratch4/yellow/.mdt2/dantopa/flag/fftw-pr.spack/opt/spack/cray-cnl7-arm_thunderx2/cce-9.0.2/fftw-3.3.8-qdaonrk6rw67qgcqgki5uvtsdnfx7ode

$ spack install fftw % gcc @ 8.3.0 arch=cray-cnl7-arm_thunderx2
...
==> Successfully installed fftw
  Fetch: 0.02s.  Build: 4m 23.94s.  Total: 4m 23.96s.
[+] /pfs/scratch4/yellow/.mdt2/dantopa/flag/fftw-pr.spack/opt/spack/cray-cnl7-arm_thunderx2/gcc-8.3.0/fftw-3.3.8-u6b3bdetpxjwakq4mp5quqjimthdvpjj
```

**Confirmation**
```
$ spack find -ldf fftw
==> 3 installed packages
-- cray-cnl7-arm_thunderx2 / cce@9.0.1 --------------------------
4zscwzo fftw@3.3.8%cce
3xm7hnr     mpich@3.3.1%cce

-- cray-cnl7-arm_thunderx2 / cce@9.0.2 --------------------------
qdaonrk fftw@3.3.8%cce
iffmiyw     mpich@3.3.1%cce

-- cray-cnl7-arm_thunderx2 / gcc@8.3.0 --------------------------
u6b3bde fftw@3.3.8%gcc
xbbpd7i     mpich@3.3.1%gcc
```

**Test Platform: LANL HPC Capulin (Cray ARM)**
```
$ uname -a
Linux nid00001 4.12.14-25.22_5.0.70-cray_ari_c #1 SMP Tue Mar 5 00:08:48 UTC 2019 (bc16c54) aarch64 aarch64 aarch64 GNU/Linux
$ lsb_release -d
Description:	SUSE Linux Enterprise Server 15
```

Thanks to @scheibelp

Signed-off-by: Daniel Topa <dantopa@lanl.gov>
Thu Sep 19 17:33:48 MDT 2019