### PR TITLE
tests: add more template creation tests

### DIFF
--- a/lib/spack/spack/test/cmd/create.py
+++ b/lib/spack/spack/test/cmd/create.py
@@ -24,23 +24,65 @@ def parser():
     return prs
 
 
-@pytest.mark.parametrize('args,name_index,expected', [
-    (['test-package'], 0, [r'TestPackage(Package)', r'def install(self']),
-    (['-n', 'test-named-package', 'file://example.tar.gz'], 1,
+@pytest.mark.parametrize('args,name,expected', [
+    # Basic package cases
+    (['test-package'], 'test-package',
+     [r'TestPackage(Package)', r'def install(self']),
+    (['-n', 'test-named-package', 'file://example.tar.gz'],
+     'test-named-package',
      [r'TestNamedPackage(Package)', r'def install(self']),
-    (['file://example.tar.gz'], -1,
+    (['file://example.tar.gz'], 'example',
      [r'Example(Package)', r'def install(self']),
-    (['-t', 'bundle', 'test-bundle'], 2, [r'TestBundle(BundlePackage)'])
+
+    # Template-specific cases
+    (['-t', 'autoreconf', 'test-autoreconf'], 'test-autoreconf',
+     [r'TestAutoreconf(AutotoolsPackage)', r"depends_on('autoconf",
+      r'def autoreconf(self', r'def configure_args(self']),
+    (['-t', 'autotools', 'test-autotools'], 'test-autotools',
+     [r'TestAutotools(AutotoolsPackage)', r'def configure_args(self']),
+    (['-t', 'bazel', 'test-bazel'], 'test-bazel',
+     [r'TestBazel(Package)', r"depends_on('bazel", r'bazel()']),
+    (['-t', 'bundle', 'test-bundle'], 'test-bundle',
+     [r'TestBundle(BundlePackage)']),
+    (['-t', 'cmake', 'test-cmake'], 'test-cmake',
+     [r'TestCmake(CMakePackage)', r'def cmake_args(self']),
+    (['-t', 'intel', 'test-intel'], 'test-intel',
+     [r'TestIntel(IntelPackage)', r'setup_environment']),
+    (['-t', 'makefile', 'test-makefile'], 'test-makefile',
+     [r'TestMakefile(MakefilePackage)', r'def edit(self', r'makefile']),
+    (['-t', 'meson', 'test-meson'], 'test-meson',
+     [r'TestMeson(MesonPackage)', r'def meson_args(self']),
+    (['-t', 'octave', 'test-octave'], 'octave-test-octave',
+     [r'OctaveTestOctave(OctavePackage)', r"extends('octave",
+      r"depends_on('octave"]),
+    (['-t', 'perlbuild', 'test-perlbuild'], 'perl-test-perlbuild',
+     [r'PerlTestPerlbuild(PerlPackage)', r"depends_on('perl-module-build",
+      r'def configure_args(self']),
+    (['-t', 'perlmake', 'test-perlmake'], 'perl-test-perlmake',
+     [r'PerlTestPerlmake(PerlPackage)', r"depends_on('perl-",
+      r'def configure_args(self']),
+    (['-t', 'python', 'test-python'], 'py-test-python',
+     [r'PyTestPython(PythonPackage)', r"depends_on('py-",
+      r'def build_args(self']),
+    (['-t', 'qmake', 'test-qmake'], 'test-qmake',
+     [r'TestQmake(QMakePackage)', r'def qmake_args(self']),
+    (['-t', 'r', 'test-r'], 'r-test-r',
+     [r'RTestR(RPackage)', r"depends_on('r-", r'def configure_args(self']),
+    (['-t', 'scons', 'test-scons'], 'test-scons',
+     [r'TestScons(SConsPackage)', r'def build_args(self']),
+    (['-t', 'sip', 'test-sip'], 'py-test-sip',
+     [r'PyTestSip(SIPPackage)', r'def configure_args(self']),
+    (['-t', 'waf', 'test-waf'], 'test-waf',
+     [r'TestWaf(WafPackage)', r'configure_args()'])
 ])
-def test_create_template(parser, mock_test_repo, args, name_index, expected):
+def test_create_template(parser, mock_test_repo, args, name, expected):
     """Test template creation."""
     repo, repodir = mock_test_repo
 
     constr_args = parser.parse_args(['--skip-editor'] + args)
     spack.cmd.create.create(parser, constr_args)
 
-    pkg_name = args[name_index] if name_index > -1 else 'example'
-    filename = repo.filename_for_package_name(pkg_name)
+    filename = repo.filename_for_package_name(name)
     assert os.path.exists(filename)
 
     with open(filename, 'r') as package_file:


### PR DESCRIPTION
This PR adds the creation of the remaining (16) templates to ensure we can create them with expected content.  The goal is to facilitate catching problems such as #12804 during testing.