### PR TITLE
intel-tbb: fix typo.

### DIFF
--- a/var/spack/repos/builtin/packages/intel-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-tbb/package.py
@@ -124,7 +124,7 @@ class IntelTbb(Package):
                     if l.strip().startswith("CPLUS ="):
                         of.write("# coerced to spack\n")
                         of.write("CPLUS = $(CXX)\n")
-                    elif l.strip().startswith("CPLUS ="):
+                    elif l.strip().startswith("CONLY ="):
                         of.write("# coerced to spack\n")
                         of.write("CONLY = $(CC)\n")
                     else:


### PR DESCRIPTION
This process needs to judge if start of sentence is `CONLY=`.