### PR TITLE
Add --known-targets to bash completion for arch command

### DIFF
--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -126,7 +126,7 @@ function _spack_add {
 
 function _spack_arch {
     compgen -W "-h --help -p --platform -o --operating-system
-                -t --target" -- "$cur"
+                -t --target --known-targets" -- "$cur"
 }
 
 function _spack_blame {


### PR DESCRIPTION
This PR adds the new --known-targets flag to the `spack arch` command.