### PR TITLE
fftw: simplify the recipe and make use of specific targets

### DIFF
--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -108,13 +108,7 @@ class Fftw(AutotoolsPackage):
     @property
     def selected_precisions(self):
         """Precisions that have been selected in this build"""
-        spec = self.spec
-        return list(filter(None, [
-            'float' if spec.satisfies('precision=float') else None,
-            'double' if spec.satisfies('precision=double') else None,
-            'long_double' if spec.satisfies('precision=long_double') else None,
-            'quad' if spec.satisfies('precision=quad') else None
-        ]))
+        return self.spec.variants['precision'].value
 
     def configure(self, spec, prefix):
         # Base options


### PR DESCRIPTION
This PR simplifies the FFTW recipe making use of the features introduced in #3206 and #9481:

- The variants to specify floating point precision have been collapsed in a single multi-valued variant
- The variants to specify SIMD support and FMA have been removed. Now the flags are activated when a feature is detected in the spec target

