### PR TITLE
externals: avoid importing requests in jsonschema

### DIFF
--- a/lib/spack/external/jsonschema/validators.py
+++ b/lib/spack/external/jsonschema/validators.py
@@ -4,10 +4,7 @@ import contextlib
 import json
 import numbers
 
-try:
-    import requests
-except ImportError:
-    requests = None
+requests = None
 
 from jsonschema import _utils, _validators
 from jsonschema.compat import (


### PR DESCRIPTION
Spack doesn't need `requests`, and neither does `jsonschema`, but `jsonschema` tries to import it, and it'll succeed if `requests` is on your machine (which is likely, given how popular it is).  This commit removes the import in our vendored `jsonschema` to improve Spack's startup time a bit.  (see https://github.com/psf/requests/issues/3213).

On my mac, the import of requests is ~28% of Spack's startup time when run as `spack --print-shell-vars sh,modules` (.069 / .25 seconds), which is what `setup-env.sh` runs.

On a Linux cluster where Python is mounted from NFS, this reduces `setup-env.sh` source time from ~1s to .75s.

Note: This issue will be eliminated if we upgrade to a newer `jsonschema` (we'd need to drop Python 2.6 for that).  See https://github.com/Julian/jsonschema/pull/388.