### PR TITLE
externals: add note to jsonschema about modifications

### DIFF
--- a/lib/spack/external/__init__.py
+++ b/lib/spack/external/__init__.py
@@ -55,7 +55,9 @@ jsonschema
 * Usage: An implementation of JSON Schema for Python.
 * Version: 2.4.0 (last version before functools32 dependency was added)
 * Note: functools32 doesn't support Python 2.6 or 3.0, so jsonschema
-  cannot be upgraded any further
+  cannot be upgraded any further until we drop 2.6.
+  Also, jsonschema/validators.py has been modified NOT to try to import
+  requests (see 7a1dd517b8).
 
 markupsafe
 ----------


### PR DESCRIPTION
Adding a note to the vendored `jsonschema` package to indicated how it has been modified not to import `requests`.

See  #12894.