### PR TITLE
Add version 4 of interproscan

### DIFF
--- a/var/spack/repos/builtin/packages/interproscan/large-gid.patch
+++ b/var/spack/repos/builtin/packages/interproscan/large-gid.patch
@@ -1,0 +1,22 @@
+diff -ruN a/core/jms-implementation/pom.xml b/core/jms-implementation/pom.xml
+--- a/core/jms-implementation/pom.xml	2019-07-03 04:17:42.000000000 -0500
++++ b/core/jms-implementation/pom.xml	2019-09-21 10:20:42.710868269 -0500
+@@ -275,6 +275,7 @@
+                     <descriptors>
+                         <descriptor>assembly.xml</descriptor>
+                     </descriptors>
++		    <tarLongFileMode>posix</tarLongFileMode>
+                     <finalName>interproscan-5</finalName>
+                 </configuration>
+                 <executions>
+diff -ruN a/core/precalcmatches/berkeley/pom.xml b/core/precalcmatches/berkeley/pom.xml
+--- a/core/precalcmatches/berkeley/pom.xml	2019-07-03 04:17:42.000000000 -0500
++++ b/core/precalcmatches/berkeley/pom.xml	2019-09-21 10:21:16.874804845 -0500
+@@ -41,6 +41,7 @@
+                     <descriptors>
+                         <descriptor>assembly.xml</descriptor>
+                     </descriptors>
++		    <tarLongFileMode>posix</tarLongFileMode>
+                     <finalName>berkeley-db-builder</finalName>
+                 </configuration>
+                 <executions>

--- a/var/spack/repos/builtin/packages/interproscan/non-interactive.patch
+++ b/var/spack/repos/builtin/packages/interproscan/non-interactive.patch
@@ -1,0 +1,165 @@
+--- a/Config.pl	2019-09-21 20:28:01.980128054 -0500
++++ b/Config.pl	2019-09-21 21:45:50.926522289 -0500
+@@ -75,11 +75,12 @@
+     close INS;
+ }
+ 
+-$insDone =  get_user_prompt('Reconfigure everything? (first time install)', $insDone, '(y|n)');
++$insDone = 'y';
+ 
+ $Tip = "!\n! InterProScan needs to know where it is installed and where perl is installed\n!";
+ 
+ undef($set_path);
++$set_path = 'y';
+ 
+ while(!defined($set_path)){
+     $set_path = get_user_prompt('Do you want to set paths to perl and the installation directory?', $insDone, 'y|n', $Tip);
+@@ -106,7 +107,7 @@
+ 	  $suggest_path = $HOME if($HOME ne "");
+ 	  chomp($suggest_path);
+ 	  
+-	  $install_path = get_user_prompt('Please enter the full path for the InterProScan installation', $suggest_path, '.+', $Tip);
++	  $install_path = $suggest_path;
+ 	  
+ 	  unless ( -d $install_path )
+ 	    {
+@@ -121,7 +122,7 @@
+     #Setting the iprscan home installation path
+     for(@homechange){
+ 	my $file = $install_path . $ARG;
+-	patch_file($file, "\\\$ENV{IPRSCAN_HOME}", "$install_path");
++	patch_file($file, "\\\$ENV\\\{IPRSCAN_HOME\\\}", "$install_path");
+ 	patch_file($file, "IPRSCAN_HOME", "$install_path", 1);
+     }
+     
+@@ -133,7 +134,7 @@
+     undef($res);
+     
+     while(!defined($res)){
+-	$res = get_user_prompt("Do you want to set another Perl command in place of [$PERL_CMD]?", 'n' , 'y|n');
++	$res = $PERL_CMD;
+ 	unless(defined($res)){
+ 	    print STDOUT "WARNING: The input is not valid must be \'y\' or \'n\', try again\n";
+ 	    undef($res);
+@@ -174,7 +175,7 @@
+ 	unless(open(MOD, ">$PWD/test.pl")){
+ 	    die "FATAL: Could not open $PWD/test.pl in writing mode to test for presence of modules :$!\n";
+ 	}
+-	print MOD "#!$PERL_CMD\n";
++	print MOD "#!/usr/bin/env perl\n";
+ 	print MOD "use $ARG;\n";
+ 	print MOD "1;\n";
+ 	close MOD;
+@@ -203,7 +204,7 @@
+ $Tip = "!\n! To cope with bulk jobs and to enable efficient parallelization, InterProScan splits input files\n"
+ 	."! with FASTA formatted sequences into smaller parts (chunks). Default size is \"100\" sequences per chunk\n!";
+ 
+-$setcnk = get_user_prompt('Do you want to setup chunk size', $insDone, '(y|n)', $Tip);
++$setcnk = 'y';
+ my $chunkz;
+ 
+ if ($setcnk eq "y")
+@@ -211,7 +212,7 @@
+       $Tip = "!\n! Here you should specify the maximum number of sequences allowed in each part (chunk).  Please note\n"
+            ."! it is not recommended to have more then 3000 chunks.\n!";
+ 
+-      $chunkz = get_user_prompt('Enter chunk size', '100', '[0-9]+', $Tip);
++      $chunkz = '100';
+   }
+ print STDOUT "\n";
+ 
+@@ -225,7 +226,7 @@
+ 
+ my($maxinaa, $maxinnt, $maxlennt, $minlenaa, $minorflen, $cdntable) = (undef, undef, undef, undef, undef, undef);
+ 
+-my $setseq = get_user_prompt('Do you want to configure this?', $insDone, '(y|n)', $Tip);
++my $setseq = 'y';
+ 
+ if($setseq eq 'y'){
+     $maxinaa   = '1000';
+@@ -234,13 +235,6 @@
+     $minlenaa  = '5';
+     $minorflen = '50';
+     $cdntable  = '0';
+-
+-    $maxinaa = get_user_prompt('Enter the maximum number of input protein sequences allowed', $maxinaa, '\d+');
+-    $maxinnt = get_user_prompt('Enter the maximum number of input nucleic sequences allowed', $maxinnt, '\d+');
+-    $maxlennt = get_user_prompt('Enter the maximum length (in nucleic acids) for a nucleotide sequence', $maxlennt, '\d+');
+-    $minlenaa = get_user_prompt('Enter the minimum length (in amino acids) for a protein sequence', $minlenaa, '\d+');
+-    $minorflen = get_user_prompt('Enter the minimum allowed length of a translated orf', $minorflen, '\d+');
+-    $cdntable = get_user_prompt('Enter the default codon table value to use to translate dna/rna in six frames', $cdntable, '\d+');
+ }
+ print STDOUT "\n";
+ 
+@@ -249,7 +243,7 @@
+ 	."! set up a particular search tool against a database and how exactly that application will be configured to run\n"
+ 	."! in this next section. You will configure the queue systems (if any) you will use, first\n!";
+ 
+-$applset = get_user_prompt('Do you want to setup applications (if you don\'t, no applications will be included in InterProScan by default)?', $insDone, '(y|n)', $Tip);
++$applset = 'y';
+ my @setAppl = ();
+ 
+ if($applset eq "y"){
+@@ -258,7 +252,7 @@
+ 	."! Currently, we mainly support LSF (which is used at EBI) however, we also provide configuration files for other systems\n"
+ 	."! which are listed in the documentation\n!";
+ 
+-    $UseQ = get_user_prompt('Do you wish to use a queue system?', 'n', '(y|n)', $Tip);
++    $UseQ = 'n';
+     $Qsys = undef;
+     
+     my $cluster = 'foo';
+@@ -395,7 +389,7 @@
+ 
+     #Defining local host name and arch
+     my $supported_arch = 'OSF1|IRIX64|Linux|SunOS|Darwin|AIX';
+-    ($local_server = `hostname`);
++    ($local_server = 'localhost');
+     ($local_arch = `uname`);
+     ($serv = $local_server);
+     $local_server =~ s/\n//g;
+@@ -416,7 +410,7 @@
+ 	
+ 	my $rep = ($ARG eq "tmhmm" || $ARG eq "signalp" ? 'n' : 'y');
+ 	$Tip = "! ".ucfirst($ARG) . " " . $appldesc->{$ARG};
+-	my $useappl = get_user_prompt("Do you want to use $ARG ?", $rep, '(y|n)', $Tip);
++	my $useappl = 'y';
+ 	my $linkdone = "$HOME/bin/binaries";
+ 	my $arch = `uname`;
+ 	$arch =~ s/\n//g;
+@@ -502,7 +496,7 @@
+ 		
+ 		SERVER : while(!defined($res_server)){
+ 		    
+-		    $res_server = get_user_prompt("\nPlease enter the execution host name of $ARG (or if you want to run locally, enter \'localhost\')", $serv, '\S+');
++		    $res_server = 'localhost';
+ 		    chomp($res_server);
+ 		    if($local_server ne $res_server){
+ 			# rsh command has different behavior depending on the shell type.
+@@ -658,7 +652,7 @@
+     $Tip = "!\n! You can specify an email address for the administrator. By default it will be you ($ENV{USER})\n"
+ 	."! Administrators receive an email when a problem occurs in InterProScan.\n!";
+ 
+-    $user = get_user_prompt("Do you want to set an administrator email address?", 'y', 'y|n', $Tip);
++    $user = 'n';
+     if($user eq 'y'){
+ 	$user = get_user_prompt("Please enter the email address of the administrator:", '', '[\w\.\-]+\@[\w\.\-]+');
+     }else{
+@@ -735,7 +729,7 @@
+ 
+ $Tip = "!\n! InterProScan can be launched through a web interface. It can also be launched through secure HTTP (https)\n!";
+ 
+-my $useWeb = get_user_prompt("Do you want to run InterProScan using a web interface?", 'n', 'y|n', $Tip);
++my $useWeb = 'n';
+ my $HTTPProto;
+ if($useWeb eq 'y'){
+     
+@@ -816,7 +810,7 @@
+ $Tip = "!\n!  We would appreciate it if you would register your installation of InterProScan.  This will allow us to notify you\n"
+ 	."! of bug fixes and new releases of the software. We will not use your email address for any other purpose.\n!";
+ 
+-my $register = get_user_prompt("Would you like to register InterProScan?", $insDone, '(y|n)', $Tip); 
++my $register = 'n';
+ if ($register eq "y")
+   {
+       my $org_name = get_user_prompt("What is the name of your organization?", '', '\S+'); 

--- a/var/spack/repos/builtin/packages/interproscan/package.py
+++ b/var/spack/repos/builtin/packages/interproscan/package.py
@@ -16,11 +16,30 @@ class Interproscan(Package):
     url      = "https://github.com/ebi-pf-team/interproscan/archive/5.36-75.0.tar.gz"
 
     version('5.36-75.0', sha256='383d7431e47c985056c856ceb6d4dcf7ed2559a4a3d5c210c01ce3975875addb')
+    version('4.8',
+            sha256='f1cb0ae1218eb05ed59ad7f94883f474eb9a6185a56ad3a93a364acb73506a3f',
+            url='ftp://ftp.ebi.ac.uk/pub/software/unix/iprscan/4/RELEASE/4.8/iprscan_v4.8.tar.gz')
 
-    depends_on('java@8.0:8.9', type=('build', 'run'))
-    depends_on('maven', type='build')
+    resource(
+        when='@:4.8',
+        name='binaries',
+        url="http://ftp.ebi.ac.uk/pub/databases/interpro/iprscan/BIN/4.x/iprscan_bin4.x_Linux64.tar.gz",
+        sha256='551610a4682b112522f3ded5268f76ba9a47399a72e726fafb17cc938a50e7ee',
+    )
+
+    depends_on('java@8.0:8.9', when='@5:', type=('build', 'run'))
+    depends_on('maven', when='@5:', type='build')
+    depends_on('python@3:', when='@5:', type=('build', 'run'))
     depends_on('perl@5:', type=('build', 'run'))
-    depends_on('python@3:', type=('build', 'run'))
+    depends_on('perl-cgi', when='@:4.8', type=('build', 'run'))
+    depends_on('perl-mailtools', when='@:4.8', type=('build', 'run'))
+    depends_on('perl-xml-quote', when='@:4.8', type=('build', 'run'))
+    depends_on('perl-xml-parser', when='@:4.8', type=('build', 'run'))
+    depends_on('perl-io-string', when='@:4.8', type=('build', 'run'))
+    depends_on('perl-io-stringy', when='@:4.8', type=('build', 'run'))
+
+    patch('large-gid.patch', when='@5:')
+    patch('non-interactive.patch', when='@:4.8')
 
     def install(self, spec, prefix):
         with working_dir('core'):
@@ -31,3 +50,16 @@ class Interproscan(Package):
         # link the main shell script into the PATH
         ips_bin_suffix = 'core/jms-implementation/target/interproscan-5-dist'
         symlink(join_path(prefix, ips_bin_suffix), prefix.bin)
+
+    @when('@:4.8')
+    def install(self, spec, prefix):
+        perl = which('perl')
+
+        src = join_path(self.stage.source_path, 'iprscan', 'bin', 'Linux')
+        dst = join_path(self.stage.source_path, 'bin', 'binaries')
+        force_symlink(src, dst)
+
+        install_tree('.', prefix)
+
+        with working_dir(prefix):
+            perl('Config.pl')


### PR DESCRIPTION
This PR adds interproscan-4.8, which has a completely different build
system than version 5. Note that this builds for running on a host as
opposed to a queue system. I am fairly certain that a queue system can
be configured later.

This PR also adds a patch for intrproscan-5 to build when the user
building the packages has a large GID by setting posix mode for tar.