### PR TITLE
Add missing dependencies to perl-http-daemon

### DIFF
--- a/var/spack/repos/builtin/packages/perl-http-daemon/package.py
+++ b/var/spack/repos/builtin/packages/perl-http-daemon/package.py
@@ -16,3 +16,5 @@ class PerlHttpDaemon(PerlPackage):
 
     depends_on('perl-lwp-mediatypes', type=('build', 'run'))
     depends_on('perl-http-message', type=('build', 'run'))
+    depends_on('perl-http-date', type=('build', 'run'))
+    depends_on('perl-module-build-tiny', type='build')


### PR DESCRIPTION
Added the following dependencies:

+    depends_on('perl-http-date', type=('build', 'run'))
+    depends_on('perl-module-build-tiny', type='build')