### PR TITLE
Added depencies to perl-libwww-perl

### DIFF
--- a/var/spack/repos/builtin/packages/perl-libwww-perl/package.py
+++ b/var/spack/repos/builtin/packages/perl-libwww-perl/package.py
@@ -16,3 +16,17 @@ class PerlLibwwwPerl(PerlPackage):
     url      = "http://search.cpan.org/CPAN/authors/id/O/OA/OALDERS/libwww-perl-6.33.tar.gz"
 
     version('6.33', '2e15c1c789ac9036c99d094e47e3da23')
+
+    depends_on('perl-encode-locale', type=('build', 'run'))
+    depends_on('perl-file-listing', type=('build', 'run'))
+    depends_on('perl-html-parser', type=('build', 'run'))
+    depends_on('perl-http-cookies', type=('build', 'run'))
+    depends_on('perl-http-daemon', type=('build', 'run'))
+    depends_on('perl-http-date', type=('build', 'run'))
+    depends_on('perl-http-message', type=('build', 'run'))
+    depends_on('perl-http-negotiate', type=('build', 'run'))
+    depends_on('perl-lwp-mediatypes', type=('build', 'run'))
+    depends_on('perl-net-http', type=('build', 'run'))
+    depends_on('perl-try-tiny', type=('build', 'run'))
+    depends_on('perl-uri', type=('build', 'run'))
+    depends_on('perl-www-robotrules', type=('build', 'run'))


### PR DESCRIPTION
The following dependencies are needed for perl-libwww-perl according to
https://metacpan.org:

+    depends_on('perl-encode-locale', type=('build', 'run'))
+    depends_on('perl-file-listing', type=('build', 'run'))
+    depends_on('perl-html-parser', type=('build', 'run'))
+    depends_on('perl-http-cookies', type=('build', 'run'))
+    depends_on('perl-http-daemon', type=('build', 'run'))
+    depends_on('perl-http-date', type=('build', 'run'))
+    depends_on('perl-http-message', type=('build', 'run'))
+    depends_on('perl-http-negotiate', type=('build', 'run'))
+    depends_on('perl-lwp-mediatypes', type=('build', 'run'))
+    depends_on('perl-net-http', type=('build', 'run'))
+    depends_on('perl-try-tiny', type=('build', 'run'))
+    depends_on('perl-uri', type=('build', 'run'))
+    depends_on('perl-www-robotrules', type=('build', 'run'))