### PR TITLE
Added missing dependencies for perl-list-moreutils

### DIFF
--- a/var/spack/repos/builtin/packages/perl-list-moreutils/package.py
+++ b/var/spack/repos/builtin/packages/perl-list-moreutils/package.py
@@ -13,3 +13,6 @@ class PerlListMoreutils(PerlPackage):
     url      = "http://search.cpan.org/CPAN/authors/id/R/RE/REHSACK/List-MoreUtils-0.428.tar.gz"
 
     version('0.428', '493032a211cdff1fcf45f59ebd680407')
+
+    depends_on('perl-exporter-tiny', type=('build', 'run'))
+    depends_on('perl-list-moreutils-xs', type=('build', 'run'))


### PR DESCRIPTION
The following dependencies were added:

+    depends_on('perl-exporter-tiny', type=('build', 'run'))
+    depends_on('perl-list-moreutils-xs', type=('build', 'run'))