### PR TITLE
Added workaround for #12852 to perl-module-build-tiny

### DIFF
--- a/var/spack/repos/builtin/packages/perl-module-build-tiny/package.py
+++ b/var/spack/repos/builtin/packages/perl-module-build-tiny/package.py
@@ -18,3 +18,10 @@ class PerlModuleBuildTiny(PerlPackage):
     depends_on('perl-extutils-config', type=('build', 'run'))
     depends_on('perl-extutils-helpers', type=('build', 'run'))
     depends_on('perl-extutils-installpaths', type=('build', 'run'))
+
+    # The following is needed to work around #12852
+    @run_after('configure')
+    def fix_shebang(self):
+        pattern = '#!{0}'.format(self.spec['perl'].command.path)
+        repl = '#!/usr/bin/env perl'
+        filter_file(pattern, repl, 'Build', backup=False)


### PR DESCRIPTION
refers #12852 

The perl-module-build-tiny package builds from the Build script generated
by the configure step. The Build script has the shebang with the spack
built perl. This script needs to run before the shebang has been been
modified for overly long shebangs and will thus fail to run if it
happens to be too long. Work around this by switching the shebang of the
Build script to `#!/usr/bin/env perl`.