### PR TITLE
Fix shebang line in Build script of perl-readonly

### DIFF
--- a/var/spack/repos/builtin/packages/perl-readonly/package.py
+++ b/var/spack/repos/builtin/packages/perl-readonly/package.py
@@ -15,3 +15,10 @@ class PerlReadonly(PerlPackage):
     version('2.05', sha256='4b23542491af010d44a5c7c861244738acc74ababae6b8838d354dfb19462b5e')
 
     depends_on('perl-module-build-tiny', type='build')
+
+    # The following is needed to work around #12852
+    @run_after('configure')
+    def fix_shebang(self):
+        pattern = '#!{0}'.format(self.spec['perl'].command.path)
+        repl = '#!/usr/bin/env perl'
+        filter_file(pattern, repl, 'Build', backup=False)


### PR DESCRIPTION
This works around #12852.

The perl-readonly package builds from the Build script generated
by the configure step. The Build script has the shebang with the spack
built perl. This script needs to run before the shebang has been been
modified for overly long shebangs and will thus fail to run if it
happens to be too long. Work around this by switching the shebang of the
Build script to `#!/usr/bin/env perl`.