### PR TITLE
Add missing dependency to perl-xml-parser

### DIFF
--- a/var/spack/repos/builtin/packages/perl-xml-parser/package.py
+++ b/var/spack/repos/builtin/packages/perl-xml-parser/package.py
@@ -16,6 +16,7 @@ class PerlXmlParser(PerlPackage):
     version('2.44', 'af4813fe3952362451201ced6fbce379')
 
     depends_on('expat')
+    depends_on('perl-libwww-perl', type=('build', 'run'))
 
     def configure_args(self):
         args = []


### PR DESCRIPTION
This PR adds the following dependency:

+    depends_on('perl-libwww-perl', type=('build', 'run'))