### PR TITLE
Fix "specific target" detection in Python 3

### DIFF
--- a/lib/spack/llnl/util/cpu/detect.py
+++ b/lib/spack/llnl/util/cpu/detect.py
@@ -124,7 +124,7 @@ def raw_info_dictionary():
         try:
             info = factory()
         except Exception as e:
-            warnings.warn(e)
+            warnings.warn(str(e))
 
         if info:
             break

--- a/lib/spack/llnl/util/cpu/detect.py
+++ b/lib/spack/llnl/util/cpu/detect.py
@@ -7,7 +7,6 @@ import functools
 import platform
 import re
 import subprocess
-import sys
 import warnings
 
 import six

--- a/lib/spack/llnl/util/cpu/detect.py
+++ b/lib/spack/llnl/util/cpu/detect.py
@@ -77,11 +77,8 @@ def proc_cpuinfo():
 
 
 def check_output(args):
-    if sys.version_info[:2] == (2, 6):
-        return subprocess.run(
-            args, check=True, stdout=subprocess.PIPE).stdout  # nopyqver
-    else:
-        return subprocess.check_output(args)  # nopyqver
+    output = subprocess.Popen(args, stdout=subprocess.PIPE).communicate()[0]
+    return six.text_type(output.decode('utf-8'))
 
 
 @info_dict(operating_system='Darwin')

--- a/lib/spack/llnl/util/cpu/detect.py
+++ b/lib/spack/llnl/util/cpu/detect.py
@@ -8,6 +8,7 @@ import platform
 import re
 import subprocess
 import sys
+import warnings
 
 import six
 
@@ -80,7 +81,7 @@ def check_output(args):
         return subprocess.run(
             args, check=True, stdout=subprocess.PIPE).stdout  # nopyqver
     else:
-        return subprocess.check_output(args).decode('utf-8')  # nopyqver
+        return subprocess.check_output(args)  # nopyqver
 
 
 @info_dict(operating_system='Darwin')
@@ -124,7 +125,10 @@ def raw_info_dictionary():
     """
     info = {}
     for factory in info_factory[platform.system()]:
-        info = factory()
+        try:
+            info = factory()
+        except Exception as e:
+            warnings.warn(e)
 
         if info:
             break

--- a/lib/spack/llnl/util/cpu/detect.py
+++ b/lib/spack/llnl/util/cpu/detect.py
@@ -80,7 +80,7 @@ def check_output(args):
         return subprocess.run(
             args, check=True, stdout=subprocess.PIPE).stdout  # nopyqver
     else:
-        return subprocess.check_output(args)  # nopyqver
+        return subprocess.check_output(args).decode('utf-8')  # nopyqver
 
 
 @info_dict(operating_system='Darwin')
@@ -124,10 +124,7 @@ def raw_info_dictionary():
     """
     info = {}
     for factory in info_factory[platform.system()]:
-        try:
-            info = factory()
-        except Exception:
-            pass
+        info = factory()
 
         if info:
             break


### PR DESCRIPTION
Fixes #12905 

The output of `subprocess.check_output` is a byte string in Python 3. This causes dictionary lookup to fail later on.

A try-except around this function prevented this error from being noticed. Removed this so that more errors can propagate out.

@alalazo @tgamblin @becker33 