### PR TITLE
Fixing bug in openblas package

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -201,7 +201,7 @@ class Openblas(MakefilePackage):
         if '+ilp64' in self.spec:
             make_defs += ['INTERFACE64=1']
 
-        if 'x86' in self.spec.target.family:
+        if self.spec.target.family == 'x86_64':
             if '~avx2' in self.spec:
                 make_defs += ['NO_AVX2=1']
             if '~avx512' in self.spec:

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -201,7 +201,7 @@ class Openblas(MakefilePackage):
         if '+ilp64' in self.spec:
             make_defs += ['INTERFACE64=1']
 
-        if 'x86' in str(self.spec.architecture.target).lower():
+        if 'x86' in self.spec.target.family:
             if '~avx2' in self.spec:
                 make_defs += ['NO_AVX2=1']
             if '~avx512' in self.spec:

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -201,7 +201,7 @@ class Openblas(MakefilePackage):
         if '+ilp64' in self.spec:
             make_defs += ['INTERFACE64=1']
 
-        if 'x86' in self.spec.architecture.target.lower():
+        if 'x86' in str(self.spec.architecture.target).lower():
             if '~avx2' in self.spec:
                 make_defs += ['NO_AVX2=1']
             if '~avx512' in self.spec:


### PR DESCRIPTION
Currently the Openblas package shows the following error:

```
==> Error: AttributeError: 'Target' object has no attribute 'lower'

/projects/spack/var/spack/repos/builtin/packages/openblas/package.py:204, in make_defs:
        201        if '+ilp64' in self.spec:
        202            make_defs += ['INTERFACE64=1']
        203
  >>    204        if 'x86' in self.spec.architecture.target.lower():
        205            if '~avx2' in self.spec:
        206                make_defs += ['NO_AVX2=1']
        207            if '~avx512' in self.spec:
```

This PR fixes this by converting the Target object into a string so that `lower()` can be called on it.