### PR TITLE
Fix detection of Apple Clang 11.0.0

### DIFF
--- a/lib/spack/spack/compilers/clang.py
+++ b/lib/spack/spack/compilers/clang.py
@@ -205,7 +205,7 @@ class Clang(Compiler):
         ver = 'unknown'
         match = re.search(
             # Apple's LLVM compiler has its own versions, so suffix them.
-            r'^Apple LLVM version ([^ )]+)|'
+            r'^Apple (?:LLVM|clang) version ([^ )]+)|'
             # Normal clang compiler versions are left as-is
             r'clang version ([^ )]+)-svn[~.\w\d-]*|'
             r'clang version ([^ )]+)-[~.\w\d-]*|'

--- a/lib/spack/spack/test/compilers.py
+++ b/lib/spack/spack/test/compilers.py
@@ -329,6 +329,11 @@ def test_fj_flags():
 @pytest.mark.regression('10191')
 @pytest.mark.parametrize('version_str,expected_version', [
     # macOS clang
+    ('Apple clang version 11.0.0 (clang-1100.0.33.8)\n'
+     'Target: x86_64-apple-darwin18.7.0\n'
+     'Thread model: posix\n'
+     'InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin\n',  # noqa
+     '11.0.0-apple'),
     ('Apple LLVM version 7.0.2 (clang-700.1.81)\n'
      'Target: x86_64-apple-darwin15.2.0\n'
      'Thread model: posix\n', '7.0.2-apple'),


### PR DESCRIPTION
Also add unit tests to prevent a regression.

### Before

```console
$ spack compiler find
==> Added 1 new compiler to /Users/Adam/.spack/darwin/compilers.yaml
    clang@11.0.0
==> Compilers are defined in the following files:
    /Users/Adam/.spack/darwin/compilers.yaml
```

### After

```console
$ spack compiler find
==> Added 1 new compiler to /Users/Adam/.spack/darwin/compilers.yaml
    clang@11.0.0-apple
==> Compilers are defined in the following files:
    /Users/Adam/.spack/darwin/compilers.yaml
```

XCode 11 was released on September 20, 2019.