### PR TITLE
AMD: fix architecture hierarchy (zen)

### DIFF
--- a/lib/spack/llnl/util/cpu/microarchitectures.json
+++ b/lib/spack/llnl/util/cpu/microarchitectures.json
@@ -514,19 +514,8 @@
         }
       }
     },
-    "barcelona": {
-      "from": "x86_64",
-      "vendor": "AuthenticAMD",
-      "features": [
-        "mmx",
-        "sse",
-        "sse2",
-        "sse4a",
-        "abm"
-      ]
-    },
     "bulldozer": {
-      "from": "barcelona",
+      "from": "x86_64",
       "vendor": "AuthenticAMD",
       "features": [
         "mmx",
@@ -562,6 +551,8 @@
         "sse4a",
         "abm",
         "avx",
+        "xop",
+        "lwp",
         "aes",
         "pclmulqdq",
         "cx16",
@@ -570,7 +561,8 @@
         "sse4_2",
         "bmi1",
         "f16c",
-        "fma"
+        "fma",
+        "tbm"
       ],
       "compilers": {
         "gcc": {
@@ -590,6 +582,8 @@
         "sse4a",
         "abm",
         "avx",
+        "xop",
+        "lwp",
         "aes",
         "pclmulqdq",
         "cx16",
@@ -599,7 +593,8 @@
         "bmi1",
         "f16c",
         "fma",
-        "fsgsbase"
+        "fsgsbase",
+        "tbm"
       ],
       "compilers": {
         "gcc": {
@@ -619,6 +614,8 @@
         "sse4a",
         "abm",
         "avx",
+        "xop",
+        "lwp",
         "aes",
         "pclmulqdq",
         "cx16",
@@ -631,7 +628,8 @@
         "fsgsbase",
         "bmi2",
         "avx2",
-        "movbe"
+        "movbe",
+        "tbm"
       ],
       "compilers": {
         "gcc": {

--- a/lib/spack/llnl/util/cpu/microarchitectures.json
+++ b/lib/spack/llnl/util/cpu/microarchitectures.json
@@ -642,7 +642,7 @@
       }
     },
     "zen": {
-      "from": "excavator",
+      "from": "x86_64",
       "vendor": "AuthenticAMD",
       "features": [
         "bmi1",

--- a/lib/spack/spack/test/data/targets/linux-rhel6-piledriver
+++ b/lib/spack/spack/test/data/targets/linux-rhel6-piledriver
@@ -1,0 +1,29 @@
+processor       : 0
+vendor_id       : AuthenticAMD
+cpu family      : 21
+model           : 2
+model name      : AMD FX(tm)-8350 Eight-Core Processor
+stepping        : 0
+microcode       : 0x6000832
+cpu MHz         : 4013.832
+cache size      : 2048 KB
+physical id     : 0
+siblings        : 8
+core id         : 0
+cpu cores       : 4
+apicid          : 16
+initial apicid  : 0
+fpu             : yes
+fpu_exception   : yes
+cpuid level     : 13
+wp              : yes
+flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl nonstop_tsc extd_apicid aperfmperf pni pclmulqdq monitor ssse3 fma cx16 sse4_1 sse4_2 popcnt aes xsave avx f16c lahf_lm cmp_legacy svm extapic cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw ibs xop skinit wdt lwp fma4 tce nodeid_msr tbm topoext perfctr_core perfctr_nb arat cpb hw_pstate npt lbrv svm_lock nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold vmmcall bmi1
+bugs            : fxsave_leak sysret_ss_attrs
+bogomips        : 8030.15
+TLB size        : 1536 4K pages
+clflush size    : 64
+cache_alignment : 64
+address sizes   : 48 bits physical, 48 bits virtual
+power management: ts ttp tm 100mhzsteps hwpstate cpb eff_freq_ro
+
+# /proc/cpuinfo taken from https://www.redhat.com/archives/vfio-users/2015-August/msg00111.html

--- a/lib/spack/spack/test/llnl/util/cpu.py
+++ b/lib/spack/spack/test/llnl/util/cpu.py
@@ -113,7 +113,7 @@ def test_equality(supported_target):
     # Test microarchitectures that are ordered with respect to each other
     ('x86_64 < skylake', True),
     ('icelake > skylake', True),
-    ('piledriver <= zen', True),
+    ('piledriver <= steamroller', True),
     ('zen2 >= zen', True),
     ('zen >= zen', True),
     # Test unrelated microarchitectures

--- a/lib/spack/spack/test/llnl/util/cpu.py
+++ b/lib/spack/spack/test/llnl/util/cpu.py
@@ -26,6 +26,7 @@ from llnl.util.cpu import Microarchitecture  # noqa
     'linux-rhel7-ivybridge',
     'linux-rhel7-haswell',
     'linux-rhel7-zen',
+    'linux-rhel6-piledriver',
     'linux-centos7-power8le',
     'darwin-mojave-ivybridge',
     'darwin-mojave-broadwell',


### PR DESCRIPTION
fixes #12896 

Changes in the AMD models:
- `zen` (17h family) derives directly from `x86_64` and is not compatible with any of the 15h family
- Added more features that are peculiar of the 15h family

Added a unit test for `piledriver` using a `/proc/cpuinfo` from [here](https://www.redhat.com/archives/vfio-users/2015-August/msg00111.html)