### PR TITLE
fixing target conversion to string

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -691,7 +691,8 @@ class Llvm(CMakePackage):
                 targets.append('AArch64')
             elif spec.target.family == 'sparc' or spec.target.family == 'sparc64':
                 targets.append('Sparc')
-            elif ('ppc' in spec.target.family or
+            elif (spec.target.family == 'ppc64' or spec.target.family == 'ppc64le' or
+                  spec.target.family == 'ppc' or spec.target.family == 'ppcle'):
                   'power' in spec.target.family):
                 targets.append('PowerPC')
 

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -685,7 +685,7 @@ class Llvm(CMakePackage):
 
             if spec.target.family == 'x86' or spec.target.family == 'x86_64'
                 targets.append('X86')
-            elif 'arm' in spec.target.family:
+            elif spec.target.family == 'arm':
                 targets.append('ARM')
             elif 'aarch64' in spec.target.family:
                 targets.append('AArch64')

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -689,7 +689,7 @@ class Llvm(CMakePackage):
                 targets.append('ARM')
             elif 'aarch64' in spec.target.family:
                 targets.append('AArch64')
-            elif 'sparc' in spec.target.family:
+            elif spec.target.family == 'sparc' or spec.target.family == 'sparc64':
                 targets.append('Sparc')
             elif ('ppc' in spec.target.family or
                   'power' in spec.target.family):

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -683,16 +683,17 @@ class Llvm(CMakePackage):
                 # hence the test to see if the version starts with "flang".
                 targets.append('CppBackend')
 
-            if 'x86' in spec.architecture.target.lower():
+            target_str = str(spec.architecture.target).lower()
+            if 'x86' in target_str:
                 targets.append('X86')
-            elif 'arm' in spec.architecture.target.lower():
+            elif 'arm' in target_str:
                 targets.append('ARM')
-            elif 'aarch64' in spec.architecture.target.lower():
+            elif 'aarch64' in target_str:
                 targets.append('AArch64')
-            elif 'sparc' in spec.architecture.target.lower():
+            elif 'sparc' in target_str:
                 targets.append('Sparc')
-            elif ('ppc' in spec.architecture.target.lower() or
-                  'power' in spec.architecture.target.lower()):
+            elif ('ppc' in target_str or
+                  'power' in target_str):
                 targets.append('PowerPC')
 
             cmake_args.append(

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -687,7 +687,7 @@ class Llvm(CMakePackage):
                 targets.append('X86')
             elif spec.target.family == 'arm':
                 targets.append('ARM')
-            elif 'aarch64' in spec.target.family:
+            elif spec.target.family == 'aarch64':
                 targets.append('AArch64')
             elif spec.target.family == 'sparc' or spec.target.family == 'sparc64':
                 targets.append('Sparc')

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -683,7 +683,7 @@ class Llvm(CMakePackage):
                 # hence the test to see if the version starts with "flang".
                 targets.append('CppBackend')
 
-            if 'x86' in spec.target.family:
+            if spec.target.family == 'x86' or spec.target.family == 'x86_64'
                 targets.append('X86')
             elif 'arm' in spec.target.family:
                 targets.append('ARM')

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -683,17 +683,16 @@ class Llvm(CMakePackage):
                 # hence the test to see if the version starts with "flang".
                 targets.append('CppBackend')
 
-            target_str = str(spec.architecture.target).lower()
-            if 'x86' in target_str:
+            if 'x86' in spec.architecture.target.family:
                 targets.append('X86')
-            elif 'arm' in target_str:
+            elif 'arm' in spec.architecture.target.family:
                 targets.append('ARM')
-            elif 'aarch64' in target_str:
+            elif 'aarch64' in spec.architecture.target.family:
                 targets.append('AArch64')
-            elif 'sparc' in target_str:
+            elif 'sparc' in spec.architecture.target.family:
                 targets.append('Sparc')
-            elif ('ppc' in target_str or
-                  'power' in target_str):
+            elif ('ppc' in spec.architecture.target.family or
+                  'power' in spec.architecture.target.family):
                 targets.append('PowerPC')
 
             cmake_args.append(

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -683,17 +683,19 @@ class Llvm(CMakePackage):
                 # hence the test to see if the version starts with "flang".
                 targets.append('CppBackend')
 
-            if spec.target.family == 'x86' or spec.target.family == 'x86_64'
+            if spec.target.family == 'x86' or spec.target.family == 'x86_64':
                 targets.append('X86')
             elif spec.target.family == 'arm':
                 targets.append('ARM')
             elif spec.target.family == 'aarch64':
                 targets.append('AArch64')
-            elif spec.target.family == 'sparc' or spec.target.family == 'sparc64':
+            elif (spec.target.family == 'sparc' or
+                  spec.target.family == 'sparc64'):
                 targets.append('Sparc')
-            elif (spec.target.family == 'ppc64' or spec.target.family == 'ppc64le' or
-                  spec.target.family == 'ppc' or spec.target.family == 'ppcle'):
-                  'power' in spec.target.family):
+            elif (spec.target.family == 'ppc64' or
+                  spec.target.family == 'ppc64le' or
+                  spec.target.family == 'ppc' or
+                  spec.target.family == 'ppcle'):
                 targets.append('PowerPC')
 
             cmake_args.append(

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -683,16 +683,16 @@ class Llvm(CMakePackage):
                 # hence the test to see if the version starts with "flang".
                 targets.append('CppBackend')
 
-            if 'x86' in spec.architecture.target.family:
+            if 'x86' in spec.target.family:
                 targets.append('X86')
-            elif 'arm' in spec.architecture.target.family:
+            elif 'arm' in spec.target.family:
                 targets.append('ARM')
-            elif 'aarch64' in spec.architecture.target.family:
+            elif 'aarch64' in spec.target.family:
                 targets.append('AArch64')
-            elif 'sparc' in spec.architecture.target.family:
+            elif 'sparc' in spec.target.family:
                 targets.append('Sparc')
-            elif ('ppc' in spec.architecture.target.family or
-                  'power' in spec.architecture.target.family):
+            elif ('ppc' in spec.target.family or
+                  'power' in spec.target.family):
                 targets.append('PowerPC')
 
             cmake_args.append(

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -101,7 +101,7 @@ class Mesa(AutotoolsPackage):
         args_gallium_drivers = ['swrast']
         args_dri_drivers = []
 
-        if 'arm' in spec.architecture.target.lower():
+        if 'arm' in str(spec.architecture.target).lower():
             args.append('--disable-libunwind')
 
         num_frontends = 0

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -101,7 +101,7 @@ class Mesa(AutotoolsPackage):
         args_gallium_drivers = ['swrast']
         args_dri_drivers = []
 
-        if 'arm' in str(spec.architecture.target).lower():
+        if 'arm' in spec.architecture.target.family:
             args.append('--disable-libunwind')
 
         num_frontends = 0

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -101,7 +101,7 @@ class Mesa(AutotoolsPackage):
         args_gallium_drivers = ['swrast']
         args_dri_drivers = []
 
-        if 'arm' in spec.architecture.target.family:
+        if 'arm' in spec.target.family:
             args.append('--disable-libunwind')
 
         num_frontends = 0

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -101,7 +101,7 @@ class Mesa(AutotoolsPackage):
         args_gallium_drivers = ['swrast']
         args_dri_drivers = []
 
-        if 'arm' in spec.target.family:
+        if spec.target.family == 'arm':
             args.append('--disable-libunwind')
 
         num_frontends = 0


### PR DESCRIPTION
Fixes #12931.

I suppose the recent introduction of a Target object broke a number of packages that assumed `spec.architecture.target` to be a string. Here is a fix for the llvm and mesa packages.