### PR TITLE
add generic module directories as well as microarchitecture specific

### DIFF
--- a/share/spack/csh/sp_get_generic_arch.csh
+++ b/share/spack/csh/sp_get_generic_arch.csh
@@ -1,0 +1,16 @@
+#!/bin/csh -f
+set target="`spack arch --target`"
+set os=`spack arch --operating-system`
+set plat=`spack arch --platform`
+set archs="`spack arch --known-targets | sed -e 's/^/_/' -e 's/  */:/g'`"
+foreach line ( $archs )
+    set c=( `echo $line | sed -e 's/:/ /g'` )
+    if ( $#c > 1 ) then
+        if ( "$c[1]" != "_" ) then
+            set generic="$c[3]"
+        endif
+        if ( "$c[2]" == "$target" ) then
+            echo "${plat}-${os}-${generic}"
+        endif
+    endif
+end

--- a/share/spack/setup-env.csh
+++ b/share/spack/setup-env.csh
@@ -26,8 +26,10 @@ if ($?SPACK_ROOT) then
 
     # Set up modules and dotkit search paths in the user environment
     set tcl_roots = `echo $_sp_tcl_roots:q | sed 's/:/ /g'`
+    set _sp_generic=`${_spack_share_dir}/csh/sp_get_generic_arch.csh`
     foreach tcl_root ($tcl_roots:q)
         _spack_pathadd MODULEPATH "$tcl_root/$_sp_sys_type"
+        _spack_pathadd MODULEPATH "$tcl_root/$_sp_generic"
     end
 
     set dotkit_roots = `echo $_sp_dotkit_roots:q | sed 's/:/ /g'`

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -340,17 +340,38 @@ else
     eval `spack --print-shell-vars sh`
 fi;
 
+_sp_get_generic_arch() {
+    local plat os target 
+    target=`spack arch --target`
+    os=`spack arch --operating-system`
+    plat=`spack arch --platform`
+    spack arch --known-targets | 
+       sed -e 's/^/_/' | 
+       while read c1 c2 c3
+       do
+          if [ "$c1" != "_" ]
+          then
+             generic="$c3"
+          fi
+          if [ "$c2" = "$target" ]
+          then
+              echo "${plat}-${os}-${generic}"
+          fi
+       done
+}
 
 #
 # set module system roots
 #
 _sp_multi_pathadd() {
+    export _sp_generic=`_sp_get_generic_arch`
     local IFS=':'
     if [ "$_sp_shell" = zsh ]; then
         setopt sh_word_split
     fi
     for pth in $2; do
         _spack_pathadd "$1" "${pth}/${_sp_sys_type}"
+        _spack_pathadd "$1" "${pth}/${_sp_generic}"
     done
 }
 _sp_multi_pathadd MODULEPATH "$_sp_tcl_roots"


### PR DESCRIPTION

Currently develop share/spack/setups.{csh,sh} puts just the micro-architecture specific (i.e. ivybridge) paths in `MODULEPATH,` anything built with the generic (i.e. x86_64) architecture thus cannot be accessed via module load, etc.   This patch adds them both to modulepath.  It finds the generic architecture by scanning the output of `spack arch --known-targets`