### PR TITLE
spdlog: v1.4.1

### DIFF
--- a/var/spack/repos/builtin/packages/spdlog/package.py
+++ b/var/spack/repos/builtin/packages/spdlog/package.py
@@ -12,6 +12,7 @@ class Spdlog(CMakePackage):
     homepage = "https://github.com/gabime/spdlog"
     url = "https://github.com/gabime/spdlog/archive/v0.9.0.tar.gz"
 
+    version('1.4.1', sha256='3291958eb54ed942d1bd3aef1b4f8ccf70566cbc04d34296ec61eb96ceb73cff')
     version('1.2.1', sha256='867a4b7cedf9805e6f76d3ca41889679054f7e5a3b67722fe6d0eae41852a767')
     version('1.2.0', sha256='0ba31b9e7f8e43a7be328ab0236d57810e5d4fc8a1a7842df665ae22d5cbd128')
     version('1.1.0',  sha256='3dbcbfd8c07e25f5e0d662b194d3a7772ef214358c49ada23c044c4747ce8b19')
@@ -28,4 +29,25 @@ class Spdlog(CMakePackage):
     version('0.10.0', '57b471ef97a23cc29c38b62e00e89a411a87ea7f')
     version('0.9.0', 'dda741ef8e12d57d91f778d85e95a27d84a82ac4')
 
-    depends_on('cmake@3.1:', type='build')
+    variant('shared', default=True,
+            description='Build shared libraries (v1.4.0+)')
+
+    depends_on('cmake@3.2:', type='build')
+
+    def cmake_args(self):
+        spec = self.spec
+
+        args = []
+
+        if self.spec.version >= Version('1.4.0'):
+            args.extend([
+                '-DSPDLOG_BUILD_SHARED:BOOL={0}'.format(
+                    'ON' if '+shared' in spec else 'OFF'),
+                # tests and examples
+                '-DSPDLOG_BUILD_TESTS:BOOL={0}'.format(
+                    'ON' if self.run_tests else 'OFF'),
+                '-DSPDLOG_BUILD_EXAMPLE:BOOL={0}'.format(
+                    'ON' if self.run_tests else 'OFF')
+            ])
+
+        return args


### PR DESCRIPTION
Add newest release with ability to pre-build as shared or static library.

Intentionally skip 1.4.0 to avoid some regressions.