### PR TITLE
fix ansi escape seq used to colorize PS1

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -17,7 +17,6 @@ from ordereddict_backport import OrderedDict
 
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
-from llnl.util.tty.color import colorize
 
 import spack.concretize
 import spack.error
@@ -146,18 +145,20 @@ def activate(
             cmds += 'set prompt="%s ${prompt}";\n' % prompt
     else:
         if os.getenv('TERM') and 'color' in os.getenv('TERM') and prompt:
-            prompt = colorize('@G{%s} ' % prompt, color=True)
+            prompt = r"\[\033[0;92m\]{0}\[\033[0m\]".format(prompt)
 
         cmds += 'export SPACK_ENV=%s;\n' % env.path
         cmds += "alias despacktivate='spack env deactivate';\n"
         if prompt:
             cmds += 'if [ -z ${SPACK_OLD_PS1+x} ]; then\n'
             cmds += '    if [ -z ${PS1+x} ]; then\n'
-            cmds += "        PS1='$$$$';\n"
+            cmds += "        PS1=' $> ';\n"
             cmds += '    fi;\n'
             cmds += '    export SPACK_OLD_PS1="${PS1}";\n'
+            cmds += 'else\n'
+            cmds += '    export PS1="${SPACK_OLD_PS1}";\n'
             cmds += 'fi;\n'
-            cmds += 'export PS1="%s ${PS1}";\n' % prompt
+            cmds += ' export PS1="{0} $PS1";\n'.format(prompt)
 
     if add_view and default_view_name in env.views:
         cmds += env.add_default_view_to_shell(shell)


### PR DESCRIPTION
(1) Properly encloses the ansi escape sequences used to colorize PS1 inside escaped square brackets -- a special requirement when using escape sequences inside PS1 that is necessary in order to properly determine the prompt length. Without this, formatting issues arise, as can easily be verified by (a) `spack env activate -p <env-name>` (b) type a long line of characters (c) try to delete the line, which will not be entirely possible.

(2) Fixes the following incorrect behavior:
```
$> spack env activate -p e1
[e1] $> spack env activate -p e2
[e2] [e1] $> ...
```
to be:
```
$> spack env activate -p e1
[e1] $> spack env activate -p e2
[e2] $> ...
```

(3) When PS1 was unset, the old code set PS1='$$$$' which evaluated to `PID` concatenated to `PID`. Here I set it to ' $> ' which seems like a reasonable prompt when one is not set already (?)