### PR TITLE
Fix installation permissions on BLIS and libflame libs

### DIFF
--- a/var/spack/repos/builtin/packages/blis/Makefile_0.6.0.patch
+++ b/var/spack/repos/builtin/packages/blis/Makefile_0.6.0.patch
@@ -1,0 +1,31 @@
+From bc16ec7d1e2a30ce4a751255b70c9cbe87409e4f Mon Sep 17 00:00:00 2001
+From: "Field G. Van Zee" <field@cs.utexas.edu>
+Date: Mon, 23 Sep 2019 15:37:33 -0500
+Subject: [PATCH] Set execute bits of shared library at install-time.
+
+Details:
+- Modified the 0644 octal code used during installation of shared
+  libraries to 0755 (for Linux/OSX only). Thanks to Adam J. Stewart
+  for reporting this issue via #343.
+---
+ Makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 9cc81c9d..3c0e27f3 100644
+--- a/Makefile
++++ b/Makefile
+@@ -953,11 +953,11 @@ ifeq ($(IS_WIN),no)
+ $(INSTALL_LIBDIR)/%.$(LIBBLIS_SO_MMB_EXT): $(BASE_LIB_PATH)/%.$(SHLIB_EXT) $(CONFIG_MK_FILE)
+ ifeq ($(ENABLE_VERBOSE),yes)
+ 	$(MKDIR) $(@D)
+-	$(INSTALL) -m 0644 $< $@
++	$(INSTALL) -m 0755 $< $@
+ else
+ 	@echo "Installing $(@F) into $(INSTALL_LIBDIR)/"
+ 	@$(MKDIR) $(@D)
+-	@$(INSTALL) -m 0644 $< $@
++	@$(INSTALL) -m 0755 $< $@
+ endif
+ 
+ else # ifeq ($(IS_WIN),yes)

--- a/var/spack/repos/builtin/packages/blis/package.py
+++ b/var/spack/repos/builtin/packages/blis/package.py
@@ -73,6 +73,10 @@ class Blis(Package):
     provides('blas', when="+blas")
     provides('blas', when="+cblas")
 
+    # Problems with permissions on installed libraries:
+    # https://github.com/flame/blis/issues/343
+    patch('Makefile_0.6.0.patch', when='@0.4.0:0.6.0')
+
     phases = ['configure', 'build', 'install']
 
     def configure(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/libflame/Makefile_5.2.0.patch
+++ b/var/spack/repos/builtin/packages/libflame/Makefile_5.2.0.patch
@@ -1,0 +1,31 @@
+From 4356779fe843fb30b3728f5fdab049c7291d89c6 Mon Sep 17 00:00:00 2001
+From: "Field G. Van Zee" <field@cs.utexas.edu>
+Date: Mon, 23 Sep 2019 15:15:15 -0500
+Subject: [PATCH] Set execute bits of shared library at install-time.
+
+Details:
+- Modified the 0644 octal code used during installation of shared
+  libraries to 0755. Thanks to Adam J. Stewart for reporting this
+  issue in #24.
+---
+ Makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index d856af4c..6bd8bdce 100644
+--- a/Makefile
++++ b/Makefile
+@@ -643,11 +643,11 @@ endif
+ $(INSTALL_LIBDIR)/%.$(LIBFLAME_SO_MMB_EXT): $(BASE_LIB_PATH)/%.$(SHLIB_EXT) $(CONFIG_MK_FILE)
+ ifeq ($(ENABLE_VERBOSE),yes)
+ 	$(MKDIR) $(@D)
+-	$(INSTALL) -m 0644 $< $@
++	$(INSTALL) -m 0755 $< $@
+ else
+ 	@echo "Installing $(@F) into $(INSTALL_LIBDIR)/"
+ 	@$(MKDIR) $(@D)
+-	@$(INSTALL) -m 0644 $< $@
++	@$(INSTALL) -m 0755 $< $@
+ endif
+ 
+ 

--- a/var/spack/repos/builtin/packages/libflame/package.py
+++ b/var/spack/repos/builtin/packages/libflame/package.py
@@ -46,11 +46,15 @@ class Libflame(AutotoolsPackage):
 
     # TODO: Libflame prefers to defer to an external
     # LAPACK library for small problems. Is this to be
-    # implemented in spack ?
+    # implemented in spack?
 
-    # There is a known issue with the makefile :
+    # There is a known issue with the makefile:
     # https://groups.google.com/forum/#!topic/libflame-discuss/lQKEfjyudOY
     patch('Makefile_5.1.0.patch', when='@5.1.0')
+
+    # Problems with permissions on installed libraries:
+    # https://github.com/flame/libflame/issues/24
+    patch('Makefile_5.2.0.patch', when='@5.2.0')
 
     def flag_handler(self, name, flags):
         # -std=gnu99 at least required, old versions of GCC default to -std=c90

--- a/var/spack/repos/builtin/packages/libflame/package.py
+++ b/var/spack/repos/builtin/packages/libflame/package.py
@@ -48,6 +48,10 @@ class Libflame(AutotoolsPackage):
     # LAPACK library for small problems. Is this to be
     # implemented in spack?
 
+    # Libflame has a secondary dependency on BLAS:
+    # https://github.com/flame/libflame/issues/24
+    depends_on('blas')
+
     # There is a known issue with the makefile:
     # https://groups.google.com/forum/#!topic/libflame-discuss/lQKEfjyudOY
     patch('Makefile_5.1.0.patch', when='@5.1.0')
@@ -63,7 +67,10 @@ class Libflame(AutotoolsPackage):
         return (flags, None, None)
 
     def configure_args(self):
-        config_args = []
+        # Libflame has a secondary dependency on BLAS,
+        # but doesn't know which library name to expect:
+        # https://github.com/flame/libflame/issues/24
+        config_args = ['LIBS=' + self.spec['blas'].libs.link_flags]
 
         if '+lapack2flame' in self.spec:
             config_args.append("--enable-lapack2flame")


### PR DESCRIPTION
With this, I can finally build `py-numpy+blas+lapack ^blis ^libflame` on Linux. There are still build problems on macOS, and `libflame` still has undefined symbols, but it's a step in the right direction.

@s-sajid-ali 