### PR TITLE
bugfix: use string keys to set preferred targets

### DIFF
--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -865,9 +865,11 @@ or together by using the reserved keyword ``arch``:
 
    $ spack install libelf arch=cray-CNL10-haswell
 
-Normally users don't have to bother specifying the architecture
-if they are installing software for their current host as in that case the
-values will be detected automatically.
+Normally users don't have to bother specifying the architecture if they
+are installing software for their current host, as in that case the
+values will be detected automatically.  If you need fine-grained control
+over which packages use which targets (or over *all* packages' default
+target), see :ref:`concretization-preferences`.
 
 .. admonition:: Cray machines
 

--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -149,6 +149,7 @@ Here's an example ``packages.yaml`` file that sets preferred packages:
        version: [2.2, 2.4, 2.3]
      all:
        compiler: [gcc@4.4.7, 'gcc@4.6:', intel, clang, pgi]
+       target: [sandybridge]
        providers:
          mpi: [mvapich2, mpich, openmpi]
 
@@ -162,11 +163,11 @@ on the command line if explicitly requested.
 
 Each ``packages.yaml`` file begins with the string ``packages:`` and
 package names are specified on the next level. The special string ``all``
-applies settings to each package. Underneath each package name is
-one or more components: ``compiler``, ``variants``, ``version``,
-or ``providers``.  Each component has an ordered list of spec
-``constraints``, with earlier entries in the list being preferred over
-later entries.
+applies settings to *all* packages. Underneath each package name is one
+or more components: ``compiler``, ``variants``, ``version``,
+``providers``, and ``target``.  Each component has an ordered list of
+spec ``constraints``, with earlier entries in the list being preferred
+over later entries.
 
 Sometimes a package installation may have constraints that forbid
 the first concretization rule, in which case Spack will use the first

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -291,7 +291,7 @@ class Concretizer(object):
                         # we only consider x86_64 targets when on an
                         # x86_64 machine, etc. This may need to change to
                         # enable setting cross compiling as a default
-                        target = cpu.targets[s.architecture.target]
+                        target = cpu.targets[str(s.architecture.target)]
                         arch_family_name = target.family.name
                         return arch_family_name == platform.machine()
 

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -96,6 +96,26 @@ class TestConcretizePreferences(object):
         spec = concretize('mpileaks')
         assert spec.compiler == spack.spec.CompilerSpec('gcc@4.5.0')
 
+    def test_preferred_target(self, mutable_mock_packages):
+        """Test preferred compilers are applied correctly
+        """
+        spec = concretize('mpich')
+        default = str(spec.target)
+        preferred = str(spec.target.family)
+
+        update_packages('mpich', 'target', [preferred])
+        spec = concretize('mpich')
+        assert str(spec.target) == preferred
+
+        spec = concretize('mpileaks')
+        assert str(spec['mpileaks'].target) == default
+        assert str(spec['mpich'].target) == preferred
+
+        update_packages('mpileaks', 'target', [preferred])
+        spec = concretize('mpileaks')
+        assert str(spec['mpich'].target) == preferred
+        assert str(spec['mpich'].target) == preferred
+
     def test_preferred_versions(self):
         """Test preferred package versions are applied correctly
         """


### PR DESCRIPTION
Preferred targets (#3206) were failing because we were looking them up by `Microarchitecture` object, not by string.

You can now set up `packages.yaml` (or an environment) like this to prefer a particular target across your stack:

```yaml
packages:
  all:
    target: [sandybridge]
```



- [x] Add a call to `str()` to fix target lookup.
- [x] Add a test to exercise this part of concretization.
- [x] Add documentation for setting `target` in `packages.yaml`

@carns: this should allow you to set your default target.