### PR TITLE
Features/deprecate

### DIFF
--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -292,12 +292,12 @@ minimal impact to their dependents.
 
 The ``spack deprecate`` command will remove one package and replace it
 with another by replacing the deprecated package's prefix with a link
-to the replacement package's prefix.
+to the deprecator package's prefix.
 
 .. warning::
 
   The ``spack deprecate`` command makes no promises about binary
-  compatibility. It is up to the user to ensure the replacement is
+  compatibility. It is up to the user to ensure the deprecator is
   suitable for the deprecated package.
 
 Spack tracks concrete deprecated specs and ensures that no future packages
@@ -305,18 +305,18 @@ concretize to a deprecated spec.
 
 The first spec given to the ``spack deprecate`` command is the package
 to deprecate. It is an abstract spec that must describe a single
-installed package. The second spec argument is the replacement
+installed package. The second spec argument is the deprecator
 spec. By default it must be an abstract spec that describes a single
-installed package, but with the ``-i/--install-replacement`` it can be
+installed package, but with the ``-i/--install-deprecator`` it can be
 any abstract spec that Spack will install and then use as the
-replacement. The ``-I/--no-install-replacement`` option will ensure
+deprecator. The ``-I/--no-install-deprecator`` option will ensure
 the default behavior.
 
 By default, ``spack deprecate`` will deprecate all dependencies of the
 deprecated spec, replacing each by the dependency of the same name in
-the replacement spec. The ``-d/--dependencies`` option will ensure the
+the deprecator spec. The ``-d/--dependencies`` option will ensure the
 default, while the ``-D/--no-dependencies`` option will deprecate only
-the root of the deprecate spec in favor of the root of the replacement
+the root of the deprecate spec in favor of the root of the deprecator
 spec.
 
 ``spack deprecate`` can use symbolic links or hard links. The default

--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -287,7 +287,7 @@ minimal impact to their dependents.
 .. warning::
 
   The ``spack deprecate`` command is designed for use only in
-  extroardinary circumstances. This is a VERY big hammer to be used
+  extraordinary circumstances. This is a VERY big hammer to be used
   with care.
 
 The ``spack deprecate`` command will remove one package and replace it

--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -277,6 +277,52 @@ the tarballs in question to it (see :ref:`mirrors`):
 
        $ spack install galahad
 
+-----------------------------
+Deprecating insecure packages
+-----------------------------
+
+``spack deprecate`` allows for the removal of insecure packages with
+minimal impact to their dependents.
+
+.. warning::
+
+  The ``spack deprecate`` command is designed for use only in
+  extroardinary circumstances. This is a VERY big hammer to be used
+  with care.
+
+The ``spack deprecate`` command will remove one package and replace it
+with another by replacing the deprecated package's prefix with a link
+to the replacement package's prefix.
+
+.. warning::
+
+  The ``spack deprecate`` command makes no promises about binary
+  compatibility. It is up to the user to ensure the replacement is
+  suitable for the deprecated package.
+
+Spack tracks concrete deprecated specs and ensures that no future packages
+concretize to a deprecated spec.
+
+The first spec given to the ``spack deprecate`` command is the package
+to deprecate. It is an abstract spec that must describe a single
+installed package. The second spec argument is the replacement
+spec. By default it must be an abstract spec that describes a single
+installed package, but with the ``-i/--install-replacement`` it can be
+any abstract spec that Spack will install and then use as the
+replacement. The ``-I/--no-install-replacement`` option will ensure
+the default behavior.
+
+By default, ``spack deprecate`` will deprecate all dependencies of the
+deprecated spec, replacing each by the dependency of the same name in
+the replacement spec. The ``-d/--dependencies`` option will ensure the
+default, while the ``-D/--no-dependencies`` option will deprecate only
+the root of the deprecate spec in favor of the root of the replacement
+spec.
+
+``spack deprecate`` can use symbolic links or hard links. The default
+behavior is symbolic links, but the ``-l/--link-type`` flag can take
+options ``hard`` or ``soft``.
+
 -----------------------
 Verifying installations
 -----------------------
@@ -372,11 +418,13 @@ only shows the version of installed packages.
 Viewing more metadata
 """"""""""""""""""""""""""""""""
 
-``spack find`` can filter the package list based on the package name, spec, or
-a number of properties of their installation status.  For example, missing
-dependencies of a spec can be shown with ``--missing``, packages which were
-explicitly installed with ``spack install <package>`` can be singled out with
-``--explicit`` and those which have been pulled in only as dependencies with
+``spack find`` can filter the package list based on the package name,
+spec, or a number of properties of their installation status.  For
+example, missing dependencies of a spec can be shown with
+``--missing``, deprecated packages can be included with
+``--deprecated``, packages which were explicitly installed with
+``spack install <package>`` can be singled out with ``--explicit`` and
+those which have been pulled in only as dependencies with
 ``--implicit``.
 
 In some cases, there may be different configurations of the *same*

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -182,9 +182,9 @@ def disambiguate_spec(spec, env, local=False, installed=True):
         env (spack.environment.Environment): a spack environment,
             if one is active, or None if no environment is active
         local (boolean, default False): do not search chained spack instances
-        installed (iterable or boolean, default True): iterable of install
-            status to match. If true, use ['installed']. If false, use
-            ['missing'].
+        installed (boolean or any, or spack.database.InstallStatus or iterable
+            of spack.database.InstallStatus): install status argument passed to
+            database query. See ``spack.database.Database._query`` for details.
     """
     hashes = env.all_hashes() if env else None
     if local:

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -174,7 +174,7 @@ def elide_list(line_list, max_num=10):
         return line_list
 
 
-def disambiguate_spec(spec, env, local=False):
+def disambiguate_spec(spec, env, local=False, installed=True):
     """Given a spec, figure out which installed package it refers to.
 
     Arguments:
@@ -182,12 +182,17 @@ def disambiguate_spec(spec, env, local=False):
         env (spack.environment.Environment): a spack environment,
             if one is active, or None if no environment is active
         local (boolean, default False): do not search chained spack instances
+        installed (iterable or boolean, default True): iterable of install
+            status to match. If true, use ['installed']. If false, use
+            ['missing'].
     """
     hashes = env.all_hashes() if env else None
     if local:
-        matching_specs = spack.store.db.query_local(spec, hashes=hashes)
+        matching_specs = spack.store.db.query_local(spec, hashes=hashes,
+                                                    installed=installed)
     else:
-        matching_specs = spack.store.db.query(spec, hashes=hashes)
+        matching_specs = spack.store.db.query(spec, hashes=hashes,
+                                              installed=installed)
     if not matching_specs:
         tty.die("Spec '%s' matches no installed packages." % spec)
 

--- a/lib/spack/spack/cmd/deprecate.py
+++ b/lib/spack/spack/cmd/deprecate.py
@@ -83,7 +83,6 @@ def deprecate(parser, args):
 
     if args.install:
         replacement = specs[1].concretized()
-        replacement.package.do_install()
     else:
         replacement = spack.cmd.disambiguate_spec(specs[1], env, local=True)
 

--- a/lib/spack/spack/cmd/deprecate.py
+++ b/lib/spack/spack/cmd/deprecate.py
@@ -67,24 +67,6 @@ def setup_parser(sp):
                     help="spec to replace and spec to replace with")
 
 
-def find_single_matching_spec(spec, env, installed=True):
-    hashes = env.all_hashes() if env else None
-
-    specs = spack.store.db.query_local(spec, hashes=hashes,
-                                       installed=installed)
-    if len(specs) > 1:
-        tty.error('%s matches multiple packages:' % spec)
-        print()
-        print(spack.cmd.display_specs(specs, **display_args))
-        print()
-        tty.die("Use a more specific spec to refer to %s" % spec)
-    elif not specs:
-        t = 'package in envrionment %s' % env if env else 'installed package'
-        tty.die('%s does not match any %s.' % (spec, t))
-
-    return specs[0]
-
-
 def deprecate(parser, args):
     """Deprecate one spec in favor of another"""
     env = ev.get_env(args, 'deprecate')

--- a/lib/spack/spack/cmd/deprecate.py
+++ b/lib/spack/spack/cmd/deprecate.py
@@ -1,0 +1,81 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+'''Deprecate one Spack install in favor of another
+
+Spack packages of different configurations cannot be installed to the same
+location. However, in some circumstances (e.g. security patches) old
+installations should never be used again. In these cases, we will mark the old
+installation as deprecated, remove it, and link another installation into its
+place.
+
+It is up to the user to ensure binary compatibility between the deprecated
+installation and its replacement.
+'''
+import argparse
+import os
+
+import spack.cmd
+import spack.store
+
+description = "Replace one package with another via symlinks"
+section = "admin"
+level = "long"
+
+
+def setup_parser(sp):
+    setup_parser.parser = sp
+
+    deps = sp.add_mutually_exclusive_group()
+    deps.add_argument('-d', '--dependencies', action='store_true',
+                      default=True, dest='dependencies',
+                      help='Deprecate dependencies')
+    deps.add_argument('-D', '--no-dependencies', action='store_false',
+                      default=True, dest='dependencies',
+                      help='Do not deprecate dependencies')
+
+    install = sp.add_mutually_exclusive_group()
+    install.add_argument('-i', '--install-replacement', action='store_true',
+                         default=False, dest='install',
+                         help='Concretize and install replacement spec')
+    install.add_argument('-I', '--no-install-replacement',
+                         action='store_false', default=False, dest='install',
+                         help='Replacement spec must already be installed')
+
+    sp.add_argument('-l', '--link-type', type=str,
+                    default='soft', choices=['soft', 'hard'],
+                    help="Type of filesystem link to use for deprecation")
+
+    sp.add_argument('specs', nargs=argparse.REMAINDER,
+                    help="spec to replace and spec to replace with")
+
+
+def deprecate(parser, args):
+    """Deprecate one spec in favor of another"""
+    specs = spack.cmd.parse_specs(args.specs)
+
+    if len(specs) != 2:
+        raise SpackError('spack deprecate requires exactly two specs')
+
+    deprecated = spack.store.db.query_one(specs[0])
+
+    if args.install:
+        replacement = specs[1].concretized()
+        replacement.package.do_install()
+    else:
+        replacement = spack.store.db.query_one(specs[1])
+
+    link_fn = os.link if args.link_type == 'hard' else os.symlink
+
+    if args.dependencies:
+        for dep in deprecated.traverse(type='link'):
+            try:
+                repl = replacement[dep.name]
+                dep.package.do_deprecate(repl, link_fn)
+            except KeyError as e:
+                if "No spec with name" not in e.message:
+                    raise e
+
+    deprecated.package.do_deprecate(replacement, link_fn)
+

--- a/lib/spack/spack/cmd/deprecate.py
+++ b/lib/spack/spack/cmd/deprecate.py
@@ -23,7 +23,9 @@ import spack.cmd
 import spack.store
 import spack.cmd.common.arguments as arguments
 import spack.environment as ev
+
 from spack.error import SpackError
+from spack.database import InstallStatuses
 
 description = "Replace one package with another via symlinks"
 section = "admin"
@@ -75,9 +77,9 @@ def deprecate(parser, args):
     if len(specs) != 2:
         raise SpackError('spack deprecate requires exactly two specs')
 
+    install_query = [InstallStatuses.INSTALLED, InstallStatuses.DEPRECATED]
     deprecated = spack.cmd.disambiguate_spec(specs[0], env, local=True,
-                                             installed=['installed',
-                                                        'deprecated'])
+                                             installed=install_query)
 
     if args.install:
         replacement = specs[1].concretized()

--- a/lib/spack/spack/cmd/deprecate.py
+++ b/lib/spack/spack/cmd/deprecate.py
@@ -93,15 +93,15 @@ def deprecate(parser, args):
     if len(specs) != 2:
         raise SpackError('spack deprecate requires exactly two specs')
 
-    deprecated = find_single_matching_spec(specs[0], env,
-                                           installed=['installed',
-                                                      'deprecated'])
+    deprecated = spack.cmd.disambiguate_spec(specs[0], env, local=True,
+                                             installed=['installed',
+                                                        'deprecated'])
 
     if args.install:
         replacement = specs[1].concretized()
         replacement.package.do_install()
     else:
-        replacement = find_single_matching_spec(specs[1], env)
+        replacement = spack.cmd.disambiguate_spec(specs[1], env, local=True)
 
     # Check whether package to deprecate has active extensions
     if deprecated.package.extendable:

--- a/lib/spack/spack/cmd/deprecate.py
+++ b/lib/spack/spack/cmd/deprecate.py
@@ -13,6 +13,7 @@ place.
 It is up to the user to ensure binary compatibility between the deprecated
 installation and its replacement.
 '''
+from __future__ import print_function
 import argparse
 import os
 
@@ -73,7 +74,7 @@ def find_single_matching_spec(spec, env):
     if len(specs) > 1:
         tty.error('%s matches multiple packages:' % spec)
         print()
-        print spack.cmd.display_specs(spec, **display_args)
+        print(spack.cmd.display_specs(spec, **display_args))
         print()
         tty.die("Use a more specific spec to refer to %s" % spec)
     elif not specs:

--- a/lib/spack/spack/cmd/deprecate.py
+++ b/lib/spack/spack/cmd/deprecate.py
@@ -103,32 +103,6 @@ def deprecate(parser, args):
     else:
         replacement = spack.cmd.disambiguate_spec(specs[1], env, local=True)
 
-    # Check whether package to deprecate has active extensions
-    if deprecated.package.extendable:
-        view = spack.filesystem_view.YamlFilesystemView(deprecated.prefix,
-                                                        spack.store.layout)
-        active_exts = view.extensions_layout.extension_map(deprecated).values()
-        if active_exts:
-            short = deprecated.format('{name}/{hash:7}')
-            msg = "Spec %s has active extensions\n" % short
-            for active in active_exts:
-                msg += '        %s\n' % active.format('{name}/{hash:7}')
-                msg += "Deactivate extensions before deprecating %s" % short
-            tty.die(msg)
-
-    # Check whether package to deprecate is an active extension
-    if deprecated.package.is_extension:
-        extendee = deprecated.package.extendee_spec
-        view = spack.filesystem_view.YamlFilesystemView(extendee.prefix,
-                                                        spack.store.layout)
-        if deprecated.package.is_activated(view):
-            short = deprecated.format('{name}/{hash:7}')
-            short_extendee = extendee.format('{name}/{hash:7}')
-            msg = "Spec %s is an active extension of %s\n" % (short,
-                                                              short_extendee)
-            msg += "Deactivate %s to be able to deprecate it" % short
-            tty.die(msg)
-
     if not args.yes_to_all:
         tty.msg('The following package will be deprecated:\n')
         spack.cmd.display_specs([deprecated], **display_args)

--- a/lib/spack/spack/cmd/deprecate.py
+++ b/lib/spack/spack/cmd/deprecate.py
@@ -11,7 +11,7 @@ installation as deprecated, remove it, and link another installation into its
 place.
 
 It is up to the user to ensure binary compatibility between the deprecated
-installation and its replacement.
+installation and its deprecator.
 '''
 from __future__ import print_function
 import argparse
@@ -54,19 +54,19 @@ def setup_parser(sp):
                       help='Do not deprecate dependencies')
 
     install = sp.add_mutually_exclusive_group()
-    install.add_argument('-i', '--install-replacement', action='store_true',
+    install.add_argument('-i', '--install-deprecator', action='store_true',
                          default=False, dest='install',
-                         help='Concretize and install replacement spec')
-    install.add_argument('-I', '--no-install-replacement',
+                         help='Concretize and install deprecator spec')
+    install.add_argument('-I', '--no-install-deprecator',
                          action='store_false', default=False, dest='install',
-                         help='Replacement spec must already be installed (default)')  # noqa 501
+                         help='Deprecator spec must already be installed (default)')  # noqa 501
 
     sp.add_argument('-l', '--link-type', type=str,
                     default='soft', choices=['soft', 'hard'],
                     help="Type of filesystem link to use for deprecation (default soft)")  # noqa 501
 
     sp.add_argument('specs', nargs=argparse.REMAINDER,
-                    help="spec to replace and spec to replace with")
+                    help="spec to deprecate and spec to use as deprecator")
 
 
 def deprecate(parser, args):
@@ -82,28 +82,28 @@ def deprecate(parser, args):
                                             installed=install_query)
 
     if args.install:
-        replacement = specs[1].concretized()
+        deprecator = specs[1].concretized()
     else:
-        replacement = spack.cmd.disambiguate_spec(specs[1], env, local=True)
+        deprecator = spack.cmd.disambiguate_spec(specs[1], env, local=True)
 
     # calculate all deprecation pairs for errors and warning message
     all_deprecate = []
-    all_replacements = []
+    all_deprecators = []
 
     generator = deprecate.traverse(
         order='post', type='link', root=True
     ) if args.dependencies else [deprecate]
     for spec in generator:
         all_deprecate.append(spec)
-        all_replacements.append(replacement[spec.name])
-        # This will throw a key error if replament does not have a dep
+        all_deprecators.append(deprecator[spec.name])
+        # This will throw a key error if deprecator does not have a dep
         # that matches the name of a dep of the spec
 
     if not args.yes_to_all:
         tty.msg('The following packages will be deprecated:\n')
         spack.cmd.display_specs(all_deprecate, **display_args)
         tty.msg("In favor of (respectively):\n")
-        spack.cmd.display_specs(all_replacements, **display_args)
+        spack.cmd.display_specs(all_deprecators, **display_args)
         print()
 
         already_deprecated = []
@@ -125,5 +125,5 @@ def deprecate(parser, args):
 
     link_fn = os.link if args.link_type == 'hard' else os.symlink
 
-    for depr, repl in zip(all_deprecate, all_replacements):
-        depr.package.do_deprecate(repl, link_fn)
+    for dcate, dcator in zip(all_deprecate, all_deprecators):
+        dcate.package.do_deprecate(dcator, link_fn)

--- a/lib/spack/spack/cmd/deprecate.py
+++ b/lib/spack/spack/cmd/deprecate.py
@@ -67,14 +67,15 @@ def setup_parser(sp):
                     help="spec to replace and spec to replace with")
 
 
-def find_single_matching_spec(spec, env):
+def find_single_matching_spec(spec, env, installed=True):
     hashes = env.all_hashes() if env else None
 
-    specs = spack.store.db.query_local(spec, hashes=hashes)
+    specs = spack.store.db.query_local(spec, hashes=hashes,
+                                       installed=installed)
     if len(specs) > 1:
         tty.error('%s matches multiple packages:' % spec)
         print()
-        print(spack.cmd.display_specs(spec, **display_args))
+        print(spack.cmd.display_specs(specs, **display_args))
         print()
         tty.die("Use a more specific spec to refer to %s" % spec)
     elif not specs:
@@ -92,7 +93,9 @@ def deprecate(parser, args):
     if len(specs) != 2:
         raise SpackError('spack deprecate requires exactly two specs')
 
-    deprecated = find_single_matching_spec(specs[0], env)
+    deprecated = find_single_matching_spec(specs[0], env,
+                                           installed=['installed',
+                                                      'deprecated'])
 
     if args.install:
         replacement = specs[1].concretized()

--- a/lib/spack/spack/cmd/deprecate.py
+++ b/lib/spack/spack/cmd/deprecate.py
@@ -22,6 +22,7 @@ import spack.cmd
 import spack.store
 import spack.cmd.common.arguments as arguments
 import spack.environment as ev
+from spack.error import SpackError
 
 description = "Replace one package with another via symlinks"
 section = "admin"
@@ -98,8 +99,6 @@ def deprecate(parser, args):
     else:
         replacement = find_single_matching_spec(specs[1], env)
 
-    tty.msg('asslhfjajkslhgjasklghasl')
-
     # Check whether package to deprecate has active extensions
     if deprecated.package.extendable:
         view = spack.filesystem_view.YamlFilesystemView(deprecated.prefix,
@@ -121,7 +120,8 @@ def deprecate(parser, args):
         if deprecated.package.is_activated(view):
             short = deprecated.format('{name}/{hash:7}')
             short_extendee = extendee.format('{name}/{hash:7}')
-            msg = "Spec %s is an active extension of %s\n" % (short, extendee)
+            msg = "Spec %s is an active extension of %s\n" % (short,
+                                                              short_extendee)
             msg += "Deactivate %s to be able to deprecate it" % short
             tty.die(msg)
 
@@ -146,4 +146,3 @@ def deprecate(parser, args):
                     raise e
 
     deprecated.package.do_deprecate(replacement, link_fn)
-

--- a/lib/spack/spack/cmd/deprecate.py
+++ b/lib/spack/spack/cmd/deprecate.py
@@ -98,6 +98,33 @@ def deprecate(parser, args):
     else:
         replacement = find_single_matching_spec(specs[1], env)
 
+    tty.msg('asslhfjajkslhgjasklghasl')
+
+    # Check whether package to deprecate has active extensions
+    if deprecated.package.extendable:
+        view = spack.filesystem_view.YamlFilesystemView(deprecated.prefix,
+                                                        spack.store.layout)
+        active_exts = view.extensions_layout.extension_map(deprecated).values()
+        if active_exts:
+            short = deprecated.format('{name}/{hash:7}')
+            msg = "Spec %s has active extensions\n" % short
+            for active in active_exts:
+                msg += '        %s\n' % active.format('{name}/{hash:7}')
+                msg += "Deactivate extensions before deprecating %s" % short
+            tty.die(msg)
+
+    # Check whether package to deprecate is an active extension
+    if deprecated.package.is_extension:
+        extendee = deprecated.package.extendee_spec
+        view = spack.filesystem_view.YamlFilesystemView(extendee.prefix,
+                                                        spack.store.layout)
+        if deprecated.package.is_activated(view):
+            short = deprecated.format('{name}/{hash:7}')
+            short_extendee = extendee.format('{name}/{hash:7}')
+            msg = "Spec %s is an active extension of %s\n" % (short, extendee)
+            msg += "Deactivate %s to be able to deprecate it" % short
+            tty.die(msg)
+
     if not args.yes_to_all:
         tty.msg('The following package will be deprecated:\n')
         spack.cmd.display_specs([deprecated], **display_args)

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -14,6 +14,7 @@ import spack.repo
 import spack.cmd as cmd
 import spack.cmd.common.arguments as arguments
 from spack.util.string import plural
+from spack.database import InstallStatuses
 
 description = "list and search installed packages"
 section = "basic"
@@ -108,11 +109,11 @@ def query_arguments(args):
     # Set up query arguments.
     installed = []
     if not (args.only_missing or args.only_deprecated):
-        installed.append('installed')
+        installed.append(InstallStatuses.INSTALLED)
     if (args.deprecated or args.only_deprecated) and not args.only_missing:
-        installed.append('deprecated')
+        installed.append(InstallStatuses.DEPRECATED)
     if (args.missing or args.only_missing) and not args.only_deprecated:
-        installed.append('missing')
+        installed.append(InstallStatuses.MISSING)
 
     known = any
     if args.unknown:

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -83,6 +83,12 @@ def setup_parser(subparser):
                            action='store_true',
                            dest='only_missing',
                            help='show only missing dependencies')
+    subparser.add_argument(
+        '--deprecated', action='store_true',
+        help='show deprecated packages as well as installed specs')
+    subparser.add_argument(
+        '--only-deprecated', action='store_true',
+        help='show only deprecated packages')
     subparser.add_argument('-N', '--namespace',
                            action='store_true',
                            help='show fully qualified package names')
@@ -100,18 +106,24 @@ def setup_parser(subparser):
 
 def query_arguments(args):
     # Set up query arguments.
-    installed, known = True, any
-    if args.only_missing:
-        installed = False
-    elif args.missing:
-        installed = any
+    installed = []
+    if not (args.only_missing or args.only_deprecated):
+        installed.append('installed')
+    if (args.deprecated or args.only_deprecated) and not args.only_missing:
+        installed.append('deprecated')
+    if (args.missing or args.only_missing) and not args.only_deprecated:
+        installed.append('missing')
+
+    known = any
     if args.unknown:
         known = False
+
     explicit = any
     if args.explicit:
         explicit = True
     if args.implicit:
         explicit = False
+
     q_args = {'installed': installed, 'known': known, "explicit": explicit}
 
     # Time window of installation

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -81,7 +81,9 @@ def find_matching_specs(env, specs, allow_multiple_matches=False, force=False):
     specs_from_cli = []
     has_errors = False
     for spec in specs:
-        matching = spack.store.db.query_local(spec, hashes=hashes)
+        matching = spack.store.db.query_local(spec, hashes=hashes,
+                                              installed=('installed',
+                                                         'deprecated'))
         # For each spec provided, make sure it refers to only one package.
         # Fail and ask user to be unambiguous if it doesn't
         if not allow_multiple_matches and len(matching) > 1:

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -14,6 +14,7 @@ import spack.package
 import spack.cmd.common.arguments as arguments
 import spack.repo
 import spack.store
+from spack.database import InstallStatuses
 
 from llnl.util import tty
 from llnl.util.tty.colify import colify
@@ -81,9 +82,9 @@ def find_matching_specs(env, specs, allow_multiple_matches=False, force=False):
     specs_from_cli = []
     has_errors = False
     for spec in specs:
+        install_query = [InstallStatuses.INSTALLED, InstallStatuses.DEPRECATED]
         matching = spack.store.db.query_local(spec, hashes=hashes,
-                                              installed=('installed',
-                                                         'deprecated'))
+                                              installed=install_query)
         # For each spec provided, make sure it refers to only one package.
         # Fail and ask user to be unambiguous if it doesn't
         if not allow_multiple_matches and len(matching) > 1:

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1157,7 +1157,7 @@ class Database(object):
                 ``any``, all specs in database. If an InstallStatus or iterable
                 of InstallStatus, returns specs whose install status
                 (installed, deprecated, or missing) matches (one of) the
-                InstallStatus. (default: any)
+                InstallStatus. (default: True)
 
             explicit (bool or any, optional): A spec that was installed
                 following a specific user request is marked as explicit. If

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -136,7 +136,7 @@ class InstallRecord(object):
             try:
                 if any(x not in _valid_install_states for x in installed):
                     state_str = comma_and(list(map(lambda x: "'%d'" % x,
-                                                       _valid_install_states)))
+                                                   _valid_install_states)))
                     raise ValueError('Valid install states are %s' % state_str)
                 if self.installed:
                     return 'installed' in installed
@@ -567,8 +567,9 @@ class Database(object):
                 self._data = old_data
                 raise
 
-    def _construct_entry_from_directory_layout(self, directory_layout, old_data,
-                                               spec, replacement=None):
+    def _construct_entry_from_directory_layout(self, directory_layout,
+                                               old_data, spec,
+                                               replacement=None):
         # Try to recover explicit value from old DB, but
         # default it to True if DB was corrupt. This is
         # just to be conservative in case a command like

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -90,12 +90,26 @@ class DirectoryLayout(object):
         assert(not path.startswith(self.root))
         return os.path.join(self.root, path)
 
-    def remove_install_directory(self, spec):
+    def remove_install_directory(self, spec, deprecated=False):
         """Removes a prefix and any empty parent directories from the root.
            Raised RemoveFailedError if something goes wrong.
         """
         path = self.path_for_spec(spec)
         assert(path.startswith(self.root))
+
+        if deprecated:
+            if os.path.exists(path):
+                try:
+                    dep_file_name = spec.dag_hash() + '_' + self.spec_file_name
+                    metapath = os.path.join(os.readlink(path),
+                                            self.metadata_dir,
+                                            self.deprecated_dir,
+                                            dep_file_name)
+                    os.unlink(path)
+
+                    os.remove(metapath)
+                except OSError as e:
+                    raise RemoveFailedError(spec, path, e)
 
         if os.path.exists(path):
             try:

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -191,6 +191,7 @@ class YamlDirectoryLayout(DirectoryLayout):
         # If any of these paths change, downstream databases may not be able to
         # locate files in older upstream databases
         self.metadata_dir        = '.spack'
+        self.deprecated_dir      = 'deprecated'
         self.spec_file_name      = 'spec.yaml'
         self.extension_file_name = 'extensions.yaml'
         self.packages_dir        = 'repos'  # archive of package.py files
@@ -306,6 +307,20 @@ class YamlDirectoryLayout(DirectoryLayout):
         pattern = os.path.join(self.root, *path_elems)
         spec_files = glob.glob(pattern)
         return [self.read_spec(s) for s in spec_files]
+
+    def all_deprecated_specs(self):
+        if not os.path.isdir(self.root):
+            return []
+
+        path_elems = ["*"] * len(self.path_scheme.split(os.sep))
+        path_elems += [self.metadata_dir, self.deprecated_dir,
+                       '*_' + self.spec_file_name]
+        pattern = os.path.join(self.root, *path_elems)
+        spec_files = glob.glob(pattern)
+        dep_spec_to_spec_file = lambda x: os.path.join(
+            os.path.dirname(os.path.dirname(x)), self.spec_file_name)
+        return set((self.read_spec(s), self.read_spec(dep_spec_to_spec_file(s)))
+                for s in spec_files)
 
     def specs_by_hash(self):
         by_hash = {}

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -111,7 +111,7 @@ class DirectoryLayout(object):
                 except OSError as e:
                     raise RemoveFailedError(spec, path, e)
 
-        if os.path.exists(path):
+        elif os.path.exists(path):
             try:
                 shutil.rmtree(path)
             except OSError as e:

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -247,7 +247,7 @@ class YamlDirectoryLayout(DirectoryLayout):
         _check_concrete(spec)
         return os.path.join(self.metadata_path(spec), self.spec_file_name)
 
-    def deprecated_dir_path(self, spec):
+    def _deprecated_dir_path(self, spec):
         """Gets full path to spec deprecated dir
 
         directory of spec files for specs deprecated in favor of this spec"""
@@ -263,7 +263,7 @@ class YamlDirectoryLayout(DirectoryLayout):
         """Gets full path to spec file for deprecated spec"""
         _check_concrete(deprecated_spec)
         _check_concrete(replacement_spec)
-        return os.path.join(self.deprecated_dir_path(replacement_spec),
+        return os.path.join(self._deprecated_dir_path(replacement_spec),
                             self.deprecated_file_name(deprecated_spec))
 
     @contextmanager

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -252,7 +252,7 @@ class YamlDirectoryLayout(DirectoryLayout):
 
         directory of spec files for specs deprecated in favor of this spec"""
         _check_concrete(spec)
-        return os.path.join(self.metadata_path(spec), self.metadata_dir)
+        return os.path.join(self.metadata_path(spec), self.deprecated_dir)
 
     def deprecated_file_name(self, spec):
         """Gets name of deprecated spec file in deprecated dir"""

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2218,7 +2218,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         # copy spec metadata to "deprecated" dir of deprecator
         depr_yaml = spack.store.layout.deprecated_file_path(spec,
                                                             deprecator)
-        fs.mkdirp(os.path.join(depr_yaml))
+        fs.mkdirp(os.path.dirname(depr_yaml))
         shutil.copy2(self_yaml, depr_yaml)
 
         # Any specs deprecated in favor of this spec are re-deprecated in

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2120,7 +2120,8 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             if specs:
                 if deprecator:
                     spack.store.db.deprecate(specs[0], deprecator)
-                    tty.msg("Deprecating stale DB entry for %s")
+                    tty.msg("Deprecating stale DB entry for "
+                            "%s" % spec.short_spec)
                 else:
                     spack.store.db.remove(specs[0])
                     tty.msg("Removed stale DB entry for %s" % spec.short_spec)
@@ -2134,7 +2135,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             if dependents:
                 raise PackageStillNeededError(spec, dependents)
 
-        # Try to get the pcakage for the spec
+        # Try to get the package for the spec
         try:
             pkg = spec.package
         except spack.repo.UnknownEntityError:

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2187,7 +2187,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             depr_yaml = spack.store.layout.deprecated_file_path(spec,
                                                                 replacement)
             fs.mkdirp(spack.store.layout.deprecated_dir_path(replacement))
-            shutil.copy2(self_yaml, new_file)
+            shutil.copy2(self_yaml, depr_yaml)
 
             Package.uninstall_by_spec(self.spec, force=True,
                                       replace=replacement)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2143,14 +2143,15 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         # Pre-uninstall hook runs first.
         with spack.store.db.prefix_write_lock(spec):
 
-            if pkg is not None and not replace:
+            if pkg is not None:
                 spack.hooks.pre_uninstall(spec)
 
             # Uninstalling in Spack only requires removing the prefix.
             if not spec.external:
                 msg = 'Deleting package prefix [{0}]'
                 tty.debug(msg.format(spec.short_spec))
-                spack.store.layout.remove_install_directory(spec)
+                deprecated = spack.store.db.get_record(spec).deprecated_for
+                spack.store.layout.remove_install_directory(spec, deprecated)
             # Delete DB entry
             if replace:
                 msg = 'deprecating DB entry [{0}] in favor of [{1}]'

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2183,18 +2183,14 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
                 r = replacement.format('{name}/{hash:7}')
                 tty.error("spec %s already deprecated in favor of %s" % (s, r))
         else:
-            self_meta_path = spack.store.layout.metadata_path(spec)
-            self_yaml = os.path.join(self_meta_path,
-                                     spack.store.layout.spec_file_name)
-            repl_meta_path = spack.store.layout.metadata_path(replacement)
-            repl_deprecated_dir = os.path.join(repl_meta_path,
-                                               spack.store.layout.deprecated_dir)
-            new_name = spec.dag_hash() + '_' + spack.store.layout.spec_file_name
-            new_file = os.path.join(repl_deprecated_dir, new_name)
-            fs.mkdirp(repl_deprecated_dir)
+            self_yaml = spack.store.layout.spec_file_path(spec)
+            depr_yaml = spack.store.layout.deprecated_file_path(spec,
+                                                                replacement)
+            fs.mkdirp(spack.store.layout.deprecated_dir_path(replacement))
             shutil.copy2(self_yaml, new_file)
 
-            Package.uninstall_by_spec(self.spec, force=True, replace=replacement)
+            Package.uninstall_by_spec(self.spec, force=True,
+                                      replace=replacement)
             link_fn(replacement.prefix, self.spec.prefix)
 
     def _check_extendable(self):

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2192,17 +2192,23 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
 
         # Check whether package to deprecate is an active extension
         if self.is_extension:
+            tty.msg('AAAAAAAAAA')
             extendee = self.extendee_spec
             view = spack.filesystem_view.YamlFilesystemView(extendee.prefix,
                                                             spack.store.layout)
 
             if self.is_activated(view):
+                tty.msg('BBBBBBBB')
                 short = spec.format('{name}/{hash:7}')
                 short_ext = extendee.format('{name}/{hash:7}')
                 msg = "Spec %s is an active extension of %s\n" % (short,
                                                                   short_ext)
                 msg += "Deactivate %s to be able to deprecate it" % short
                 tty.die(msg)
+
+        # Install replacement if it isn't installed already
+        if not spack.store.db.query(replacement):
+            replacement.package.do_install()
 
         old_deprecator = spack.store.db.deprecator(spec)
         if old_deprecator:

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2178,10 +2178,9 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         spec = self.spec
         deprecated = spack.store.db.get_record(spec).deprecated_for
         if deprecated:
-            if deprecated == replacement.dag_hash():
-                s = spec.format('{name}/{hash:7}')
-                r = replacement.format('{name}/{hash:7}')
-                tty.error("spec %s already deprecated in favor of %s" % (s, r))
+            s = spec.format('{name}/{hash:7}')
+            r = replacement.format('{name}/{hash:7}')
+            tty.error("spec %s already deprecated in favor of %s" % (s, r))
         else:
             self_yaml = spack.store.layout.spec_file_path(spec)
             depr_yaml = spack.store.layout.deprecated_file_path(spec,

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2151,6 +2151,8 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             if not spec.external:
                 msg = 'Deleting package prefix [{0}]'
                 tty.debug(msg.format(spec.short_spec))
+                # test if spec is already deprecated, not whether we want to
+                # deprecate it now
                 deprecated = bool(spack.store.db.deprecator(spec))
                 spack.store.layout.remove_install_directory(spec, deprecated)
             # Delete DB entry

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2192,13 +2192,11 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
 
         # Check whether package to deprecate is an active extension
         if self.is_extension:
-            tty.msg('AAAAAAAAAA')
             extendee = self.extendee_spec
             view = spack.filesystem_view.YamlFilesystemView(extendee.prefix,
                                                             spack.store.layout)
 
             if self.is_activated(view):
-                tty.msg('BBBBBBBB')
                 short = spec.format('{name}/{hash:7}')
                 short_ext = extendee.format('{name}/{hash:7}')
                 msg = "Spec %s is an active extension of %s\n" % (short,

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4512,5 +4512,6 @@ class SpecDependencyNotFoundError(SpecError):
     """Raised when a failure is encountered writing the dependencies of
     a spec."""
 
+
 class SpecDeprecatedError(SpecError):
     """Raised when a spec concretizes to a deprecated spec or dependency."""

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2241,6 +2241,9 @@ class Spec(object):
 
                 s.external_path = get_path_from_module(s.external_module)
 
+        # Mark everything in the spec as concrete, as well.
+        self._mark_concrete()
+
         # If any spec in the DAG is deprecated, throw an error
         deprecated = []
         for x in self.traverse():
@@ -2255,9 +2258,6 @@ class Spec(object):
             msg += '\n'
             msg += "    For each package listed, choose another spec\n"
             raise SpecDeprecatedError(msg)
-
-        # Mark everything in the spec as concrete, as well.
-        self._mark_concrete()
 
         # Now that the spec is concrete we should check if
         # there are declared conflicts

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2241,6 +2241,21 @@ class Spec(object):
 
                 s.external_path = get_path_from_module(s.external_module)
 
+        # If any spec in the DAG is deprecated, throw an error
+        deprecated = []
+        for x in self.traverse():
+            _, rec = spack.store.db.query_by_spec_hash(x.dag_hash())
+            if rec and rec.deprecated_for:
+                deprecated.append(rec)
+        if deprecated:
+            msg = "\n    The following specs have been deprecated"
+            msg += " in favor of specs with the hashes shown:\n"
+            for rec in deprecated:
+                msg += '        %s  --> %s\n' % (rec.spec, rec.deprecated_for)
+            msg += '\n'
+            msg += "    For each package listed, choose another spec\n"
+            raise SpecDeprecatedError(msg)
+
         # Mark everything in the spec as concrete, as well.
         self._mark_concrete()
 
@@ -4496,3 +4511,6 @@ class ConflictsInSpecError(SpecError, RuntimeError):
 class SpecDependencyNotFoundError(SpecError):
     """Raised when a failure is encountered writing the dependencies of
     a spec."""
+
+class SpecDeprecatedError(SpecError):
+    """Raised when a spec concretizes to a deprecated spec or dependency."""

--- a/lib/spack/spack/test/cmd/deprecate.py
+++ b/lib/spack/spack/test/cmd/deprecate.py
@@ -1,0 +1,81 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import pytest
+
+from spack.main import SpackCommand
+import spack.store
+
+install = SpackCommand('install')
+deprecate = SpackCommand('deprecate')
+find = SpackCommand('find')
+
+
+def test_deprecate(mock_packages, mock_archive, mock_fetch, install_mockery):
+    install('libelf@0.8.13')
+    install('libelf@0.8.10')
+
+    all_installed = spack.store.db.query()
+    assert len(all_installed) == 2
+
+    deprecate('-y', 'libelf@0.8.10', 'libelf@0.8.13')
+
+    non_deprecated = spack.store.db.query()
+    all_available = spack.store.db.query(installed=any)
+    assert all_available == all_installed
+    assert non_deprecated == spack.store.db.query('libelf@0.8.13')
+
+
+def test_deprecate_no_such_package(mock_packages, mock_archive, mock_fetch,
+                                   install_mockery):
+    output = deprecate('-y', 'libelf@0.8.10', 'libelf@0.8.13',
+                       fail_on_error=False)
+    assert 'libelf@0.8.10 does not match any installed package' in output
+
+    install('libelf@0.8.10')
+
+    output = deprecate('-y', 'libelf@0.8.10', 'libelf@0.8.13',
+                       fail_on_error=False)
+    assert 'libelf@0.8.13 does not match any installed package' in output
+
+
+def test_deprecate_install(mock_packages, mock_archive, mock_fetch,
+                           install_mockery):
+    install('libelf@0.8.10')
+
+    to_deprecate = spack.store.db.query()
+    assert len(to_deprecate) == 1
+
+    deprecate('-y', '-i', 'libelf@0.8.10', 'libelf@0.8.13')
+
+    non_deprecated = spack.store.db.query()
+    deprecated = spack.store.db.query(installed=['deprecated'])
+    assert deprecated == to_deprecate
+    assert len(non_deprecated) == 1
+    assert non_deprecated[0].satisfies('libelf@0.8.13')
+
+
+def test_deprecate_deps(mock_packages, mock_archive, mock_fetch,
+                        install_mockery):
+    install('libdwarf@20130729 ^libelf@0.8.13')
+    install('libdwarf@20130207 ^libelf@0.8.10')
+
+    all_installed = spack.store.db.query()
+
+    deprecate('-y', '-d', 'libdwarf@20130207', 'libdwarf@20130729')
+
+    non_deprecated = spack.store.db.query()
+    all_available = spack.store.db.query(installed=any)
+    deprecated = spack.store.db.query(installed=['deprecated'])
+
+    assert all_available == all_installed
+    assert sorted(all_available) == sorted(deprecated + non_deprecated)
+
+    new_spec = spack.spec.Spec('libdwarf@20130729^libelf@0.8.13').concretized()
+    assert sorted(non_deprecated) == sorted(list(new_spec.traverse()))
+
+    old_spec = spack.spec.Spec('libdwarf@20130207^libelf@0.8.10').concretized()
+    assert sorted(deprecated) == sorted(list(old_spec.traverse()))
+
+

--- a/lib/spack/spack/test/cmd/deprecate.py
+++ b/lib/spack/spack/test/cmd/deprecate.py
@@ -2,8 +2,6 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import pytest
-
 from spack.main import SpackCommand
 import spack.store
 

--- a/lib/spack/spack/test/cmd/deprecate.py
+++ b/lib/spack/spack/test/cmd/deprecate.py
@@ -29,8 +29,12 @@ def test_deprecate(mock_packages, mock_archive, mock_fetch, install_mockery):
     assert non_deprecated == spack.store.db.query('libelf@0.8.13')
 
 
-def test_deprecate_no_such_package(mock_packages, mock_archive, mock_fetch,
-                                   install_mockery):
+def test_deprecate_fails_no_such_package(mock_packages, mock_archive,
+                                         mock_fetch, install_mockery):
+    """Tests that deprecating a spec that is not installed fails.
+
+    Tests that deprecating without the ``-i`` option in favor of a spec that
+    is not installed fails."""
     output = deprecate('-y', 'libelf@0.8.10', 'libelf@0.8.13',
                        fail_on_error=False)
     assert "Spec 'libelf@0.8.10' matches no installed packages" in output
@@ -44,6 +48,8 @@ def test_deprecate_no_such_package(mock_packages, mock_archive, mock_fetch,
 
 def test_deprecate_install(mock_packages, mock_archive, mock_fetch,
                            install_mockery):
+    """Tests that the ```-i`` option allows us to deprecate in favor of a spec
+    that is not yet installed."""
     install('libelf@0.8.10')
 
     to_deprecate = spack.store.db.query()
@@ -60,6 +66,7 @@ def test_deprecate_install(mock_packages, mock_archive, mock_fetch,
 
 def test_deprecate_deps(mock_packages, mock_archive, mock_fetch,
                         install_mockery):
+    """Test that the deprecate command deprecates all dependencies properly."""
     install('libdwarf@20130729 ^libelf@0.8.13')
     install('libdwarf@20130207 ^libelf@0.8.10')
 
@@ -81,8 +88,10 @@ def test_deprecate_deps(mock_packages, mock_archive, mock_fetch,
     assert sorted(deprecated) == sorted(list(old_spec.traverse()))
 
 
-def test_deprecate_fails_extensions(mock_packages, mock_archive, mock_fetch,
-                                    install_mockery):
+def test_deprecate_fails_active_extensions(mock_packages, mock_archive,
+                                           mock_fetch, install_mockery):
+    """Tests that active extensions and their extendees cannot be
+    deprecated."""
     install('extendee')
     install('extension1')
     activate('extension1')
@@ -100,6 +109,7 @@ def test_deprecate_fails_extensions(mock_packages, mock_archive, mock_fetch,
 
 def test_uninstall_deprecated(mock_packages, mock_archive, mock_fetch,
                               install_mockery):
+    """Tests that we can still uninstall deprecated packages."""
     install('libelf@0.8.13')
     install('libelf@0.8.10')
 
@@ -113,8 +123,9 @@ def test_uninstall_deprecated(mock_packages, mock_archive, mock_fetch,
     assert spack.store.db.query() == non_deprecated
 
 
-def test_deprecate_deprecated(mock_packages, mock_archive, mock_fetch,
-                              install_mockery):
+def test_deprecate_already_deprecated(mock_packages, mock_archive, mock_fetch,
+                                      install_mockery):
+    """Tests that we can re-deprecate a spec to change its deprecator."""
     install('libelf@0.8.13')
     install('libelf@0.8.12')
     install('libelf@0.8.10')
@@ -139,6 +150,8 @@ def test_deprecate_deprecated(mock_packages, mock_archive, mock_fetch,
 
 def test_deprecate_deprecator(mock_packages, mock_archive, mock_fetch,
                               install_mockery):
+    """Tests that when a deprecator spec is deprecated, its deprecatee specs
+    are updated to point to the new deprecator."""
     install('libelf@0.8.13')
     install('libelf@0.8.12')
     install('libelf@0.8.10')
@@ -167,6 +180,8 @@ def test_deprecate_deprecator(mock_packages, mock_archive, mock_fetch,
 
 def test_concretize_deprecated(mock_packages, mock_archive, mock_fetch,
                                install_mockery):
+    """Tests that the concretizer throws an error if we concretize to a
+    deprecated spec"""
     install('libelf@0.8.13')
     install('libelf@0.8.10')
 

--- a/lib/spack/spack/test/cmd/deprecate.py
+++ b/lib/spack/spack/test/cmd/deprecate.py
@@ -90,7 +90,7 @@ def test_deprecate_fails_extensions(mock_packages, mock_archive, mock_fetch,
     assert 'extension1' in output
     assert "Deactivate extensions before deprecating" in output
 
-    output = deprecate('-yi', 'extension1', 'libelf', fail_on_error=False)
+    output = deprecate('-yiD', 'extension1', 'libelf', fail_on_error=False)
     assert 'extendee' in output
     assert 'is an active extension of' in output
 

--- a/lib/spack/spack/test/cmd/deprecate.py
+++ b/lib/spack/spack/test/cmd/deprecate.py
@@ -10,6 +10,7 @@ import spack.store
 install = SpackCommand('install')
 deprecate = SpackCommand('deprecate')
 find = SpackCommand('find')
+activate = SpackCommand('activate')
 
 
 def test_deprecate(mock_packages, mock_archive, mock_fetch, install_mockery):
@@ -79,3 +80,16 @@ def test_deprecate_deps(mock_packages, mock_archive, mock_fetch,
     assert sorted(deprecated) == sorted(list(old_spec.traverse()))
 
 
+def test_deprecate_fails_extensions(mock_packages, mock_archive, mock_fetch,
+                                    install_mockery):
+    install('extendee')
+    install('extension1')
+    activate('extension1')
+
+    output = deprecate('-yi', 'extendee', 'libelf', fail_on_error=False)
+    assert 'extension1' in output
+    assert "Deactivate extensions before deprecating" in output
+
+    output = deprecate('-yi', 'extension1', 'libelf', fail_on_error=False)
+    assert 'extendee' in output
+    assert 'is an active extension of' in output

--- a/lib/spack/spack/test/cmd/deprecate.py
+++ b/lib/spack/spack/test/cmd/deprecate.py
@@ -5,6 +5,7 @@
 import pytest
 from spack.main import SpackCommand
 import spack.store
+from spack.database import InstallStatuses
 
 install = SpackCommand('install')
 uninstall = SpackCommand('uninstall')
@@ -51,7 +52,7 @@ def test_deprecate_install(mock_packages, mock_archive, mock_fetch,
     deprecate('-y', '-i', 'libelf@0.8.10', 'libelf@0.8.13')
 
     non_deprecated = spack.store.db.query()
-    deprecated = spack.store.db.query(installed=['deprecated'])
+    deprecated = spack.store.db.query(installed=InstallStatuses.DEPRECATED)
     assert deprecated == to_deprecate
     assert len(non_deprecated) == 1
     assert non_deprecated[0].satisfies('libelf@0.8.13')
@@ -71,7 +72,7 @@ def test_deprecate_deps(mock_packages, mock_archive, mock_fetch,
 
     non_deprecated = spack.store.db.query()
     all_available = spack.store.db.query(installed=any)
-    deprecated = spack.store.db.query(installed=['deprecated'])
+    deprecated = spack.store.db.query(installed=InstallStatuses.DEPRECATED)
 
     assert all_available == all_installed
     assert sorted(all_available) == sorted(deprecated + non_deprecated)

--- a/lib/spack/spack/test/cmd/deprecate.py
+++ b/lib/spack/spack/test/cmd/deprecate.py
@@ -32,13 +32,13 @@ def test_deprecate_no_such_package(mock_packages, mock_archive, mock_fetch,
                                    install_mockery):
     output = deprecate('-y', 'libelf@0.8.10', 'libelf@0.8.13',
                        fail_on_error=False)
-    assert 'libelf@0.8.10 does not match any installed package' in output
+    assert "Spec 'libelf@0.8.10' matches no installed packages" in output
 
     install('libelf@0.8.10')
 
     output = deprecate('-y', 'libelf@0.8.10', 'libelf@0.8.13',
                        fail_on_error=False)
-    assert 'libelf@0.8.13 does not match any installed package' in output
+    assert "Spec 'libelf@0.8.13' matches no installed packages" in output
 
 
 def test_deprecate_install(mock_packages, mock_archive, mock_fetch,

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -50,6 +50,8 @@ def test_query_arguments():
     args = Bunch(
         only_missing=False,
         missing=False,
+        only_deprecated=False,
+        deprecated=False,
         unknown=False,
         explicit=False,
         implicit=False,
@@ -61,7 +63,7 @@ def test_query_arguments():
     assert 'installed' in q_args
     assert 'known' in q_args
     assert 'explicit' in q_args
-    assert q_args['installed'] is True
+    assert q_args['installed'] == ['installed']
     assert q_args['known'] is any
     assert q_args['explicit'] is any
     assert 'start_date' in q_args

--- a/lib/spack/spack/test/cmd/reindex.py
+++ b/lib/spack/spack/test/cmd/reindex.py
@@ -1,0 +1,54 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import pytest
+import os
+from spack.main import SpackCommand
+import spack.store
+
+install = SpackCommand('install')
+deprecate = SpackCommand('deprecate')
+reindex = SpackCommand('reindex')
+
+
+def test_reindex_basic(mock_packages, mock_archive, mock_fetch,
+                       install_mockery):
+    install('libelf@0.8.13')
+    install('libelf@0.8.12')
+
+    all_installed = spack.store.db.query()
+
+    reindex()
+
+    assert spack.store.db.query() == all_installed
+
+
+def test_reindex_db_deleted(mock_packages, mock_archive, mock_fetch,
+                            install_mockery):
+    install('libelf@0.8.13')
+    install('libelf@0.8.12')
+
+    all_installed = spack.store.db.query()
+
+    os.remove(spack.store.db._index_path)
+    reindex()
+
+    assert spack.store.db.query() == all_installed
+
+
+def test_reindex_with_deprecated_packages(mock_packages, mock_archive,
+                                          mock_fetch, install_mockery):
+    install('libelf@0.8.13')
+    install('libelf@0.8.12')
+
+    deprecate('-y', 'libelf@0.8.12', 'libelf@0.8.13')
+
+    all_installed = spack.store.db.query(installed=any)
+    non_deprecated = spack.store.db.query(installed=True)
+
+    os.remove(spack.store.db._index_path)
+    reindex()
+
+    assert spack.store.db.query(installed=any) == all_installed
+    assert spack.store.db.query(installed=True) == non_deprecated

--- a/lib/spack/spack/test/cmd/reindex.py
+++ b/lib/spack/spack/test/cmd/reindex.py
@@ -2,7 +2,6 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import pytest
 import os
 from spack.main import SpackCommand
 import spack.store

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -437,6 +437,16 @@ def test_025_reindex(mutable_database):
     _check_db_sanity(mutable_database)
 
 
+def test_026_reindex_after_deprecate(mutable_database):
+    """Make sure reindex works and ref counts are valid after deprecation."""
+    mpich = mutable_database.query_one('mpich')
+    zmpi = mutable_database.query_one('zmpi')
+    mutable_database.deprecate(mpich, zmpi)
+
+    spack.store.store.reindex()
+    _check_db_sanity(mutable_database)
+
+
 def test_030_db_sanity_from_another_process(mutable_database):
     def read_and_modify():
         # check that other process can read DB
@@ -456,6 +466,15 @@ def test_030_db_sanity_from_another_process(mutable_database):
 def test_040_ref_counts(database):
     """Ensure that we got ref counts right when we read the DB."""
     database._check_ref_counts()
+
+
+def test_041_ref_counts_deprecate(mutable_database):
+    """Ensure that we have appropriate ref counts after deprecating"""
+    mpich = mutable_database.query_one('mpich')
+    zmpi = mutable_database.query_one('zmpi')
+
+    mutable_database.deprecate(mpich, zmpi)
+    mutable_database._check_ref_counts()
 
 
 def test_050_basic_query(database):


### PR DESCRIPTION
Closes #172.
Closes #7409.

``spack deprecate`` allows for the removal of insecure packages with minimal impact to their dependents. It is intended as a very big hammer for people who really know what they're doing, that will allow one package to be symlinked into the prefix of another to provide seamless transition for rpath'd and hard-coded applications using the old version.

Take openssl as an example. Old versions are often found to have security flaws, and diligent sysadmins want to purge them from the system. Spack currently provides no way to do this without breaking every package that depends on openssl. With `spack deprecate`, the sysadmin will run 

``spack deprecate /hash-of-old-openssl /hash-of-new-openssl``

and all hardcoded codes can use the new one transparently.

From the documentation in this PR:

``spack deprecate`` allows for the removal of insecure packages with minimal impact to their dependents.

.. warning::

  The ``spack deprecate`` command is designed for use only in extroardinary circumstances. This is a VERY big hammer to be used with care.

The ``spack deprecate`` command will remove one package and replace it with another by replacing the deprecated package's prefix with a link to the replacement package's prefix.

.. warning::

  The ``spack deprecate`` command makes no promises about binary compatibility. It is up to the user to ensure the replacement is suitable for the deprecated package.

Spack tracks concrete deprecated specs and ensures that no future packages concretize to a deprecated spec.

The first spec given to the ``spack deprecate`` command is the package to deprecate. It is an abstract spec that must describe a single installed package. The second spec argument is the replacement spec. By default it must be an abstract spec that describes a single installed package, but with the ``-i/--install-replacement`` it can be any abstract spec that Spack will install and then use as the replacement. The ``-I/--no-install-replacement`` option will ensure the default behavior.

By default, ``spack deprecate`` will deprecate all dependencies of the deprecated spec, replacing each by the dependency of the same name in the replacement spec. The ``-d/--dependencies`` option will ensure the default, while the ``-D/--no-dependencies`` option will deprecate only the root of the deprecate spec in favor of the root of the replacement spec.

``spack deprecate`` can use symbolic links or hard links. The default behavior is symbolic links, but the ``-l/--link-type`` flag can take options ``hard`` or ``soft``.