### PR TITLE
Multi Build System Packages [Prototype; Please Review]

### DIFF
--- a/var/spack/repos/builtin/packages/superlu-dist/package.py
+++ b/var/spack/repos/builtin/packages/superlu-dist/package.py
@@ -4,9 +4,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+import os
+import glob
 
-
-class SuperluDist(CMakePackage):
+class SuperluDist(Package):
     """A general purpose library for the direct solution of large, sparse,
     nonsymmetric systems of linear equations on high performance machines."""
 
@@ -29,15 +30,64 @@ class SuperluDist(CMakePackage):
     version('5.1.2', 'e34865ad6696ee6a6d178b4a01c8e19103a7d241ba9de043603970d63b0ee1e2')
     version('5.1.0', '73f292ab748b590b6dd7469e6986aeb95d279b8b8b3da511c695a396bdbc996c')
     version('5.0.0', '78d1d6460ff16b3f71e4bcd7306397574d54d421249553ccc26567f00a10bfc6')
+    version('4.3', 'ee66c84e37b4f7cc557771ccc3dc43ae',
+        url='https://portal.nersc.gov/project/sparse/superlu/superlu_dist_4.3.tar.gz')
+    version('4.2', 'ae9fafae161f775fbac6eba11e530a65',
+        url='https://portal.nersc.gov/project/sparse/superlu/superlu_dist_4.2.tar.gz')
+    version('4.1', '4edee38cc29f687bd0c8eb361096a455',
+        url='https://portal.nersc.gov/project/sparse/superlu/superlu_dist_4.1.tar.gz')
+    version('4.0', 'c0b98b611df227ae050bc1635c6940e0',
+        url='https://portal.nersc.gov/project/sparse/superlu/superlu_dist_4.0.tar.gz')
+    version('3.3', 'f4805659157d93a962500902c219046b',
+        url='https://portal.nersc.gov/project/sparse/superlu/superlu_dist_3.3.tar.gz')
 
     variant('int64', default=False, description='Build with 64 bit integers')
-    variant('shared', default=True, description='Build shared libraries')
+    variant('shared', default=True, description='Build shared libraries')  # Should only be for version 5 and greater
 
     depends_on('mpi')
     depends_on('blas')
     depends_on('lapack')
     depends_on('parmetis')
     depends_on('metis@5:')
+
+    def install(self, spec, prefix):
+
+        if self.version >= Version('5.0.0'):
+            sub = SuperluDist_CMake(spec)
+        else:
+            sub = SuperluDist_Legacy(spec)
+
+        # See lib/spack/spack/directives.py
+        sub.versions = self.versions
+        sub.name = self.name
+        sub.dependencies = self.dependencies
+        sub.conflicts = self.conflicts
+        sub.extendees = self.extendees
+        sub.provided = self.provided
+        # sub.pkg = self.pkg    # ???
+        sub.variants = self.variants
+        sub.resources = self.resources
+
+#        sub.patches = self.patches
+#        sub.conditions = self.conditions
+#        sub.cur_patches = self.cur_patches
+
+        # See similar code in lib/spack/spack/package.py
+        for phase_name, phase_attr in zip(
+            sub.phases, sub._InstallPhase_phases):
+
+            #with logger.force_echo():
+            #    tty.msg(
+            #        "Executing phase: '%s'" % phase_name)
+
+            # Redirect stdout and stderr to daemon pipe
+            phase = getattr(sub, phase_attr)
+            phase(sub.spec, sub.prefix)
+
+
+
+
+class SuperluDist_CMake(CMakePackage):
 
     def cmake_args(self):
         spec = self.spec
@@ -71,3 +121,72 @@ class SuperluDist(CMakePackage):
         if name == 'cflags' and '%pgi' not in self.spec:
             flags.append('-std=c99')
         return (None, None, flags)
+
+class SuperluDist_Legacy(Package):
+
+    def install(self, spec, prefix):
+        lapack_blas = spec['lapack'].libs + spec['blas'].libs
+        makefile_inc = []
+        makefile_inc.extend([
+            'PLAT         = _mac_x',
+            'DSuperLUroot = %s' % self.stage.source_path,
+            'DSUPERLULIB  = $(DSuperLUroot)/lib/libsuperlu_dist.a',
+            'BLASDEF      = -DUSE_VENDOR_BLAS',
+            'BLASLIB      = %s' % lapack_blas.ld_flags,
+            'METISLIB     = %s' % spec['metis'].libs.ld_flags,
+            'PARMETISLIB  = %s' % spec['parmetis'].libs.ld_flags,
+            'HAVE_PARMETIS= TRUE',
+            'FLIBS        =',
+            'LIBS         = $(DSUPERLULIB) $(BLASLIB) $(PARMETISLIB) $(METISLIB)',  # noqa
+            'ARCH         = ar',
+            'ARCHFLAGS    = cr',
+            'RANLIB       = true',
+            'CXX          = {0}'.format(self.spec['mpi'].mpicxx),
+            'CXXFLAGS     = {0} {1} {2}'.format(
+                ' '.join(self.spec.compiler_flags['cxxflags']),
+                self.compiler.pic_flag,
+                self.compiler.cxx11_flag),
+            'CC           = {0}'.format(self.spec['mpi'].mpicc),
+            'CFLAGS       = %s %s -O2 %s %s %s' % (
+                self.compiler.pic_flag,
+                '' if '%pgi' in spec else '-std=c99',
+                spec['parmetis'].headers.cpp_flags,
+                spec['metis'].headers.cpp_flags,
+                '-D_LONGINT' if '+int64' in spec and not
+                self.spec.satisfies('@5.2.0:') else ''),
+            'XSDK_INDEX_SIZE = %s' % ('64' if '+int64' in spec else '32'),
+            'NOOPTS       = %s -std=c99' % (
+                self.compiler.pic_flag),
+            'FORTRAN      = {0}'.format(self.spec['mpi'].mpif77),
+            'F90FLAGS     = -O2',
+            'LOADER       = {0}'.format(self.spec['mpi'].mpif77),
+            'INCLUDEDIR   = $(SuperLUroot)/include',
+            'LOADOPTS     =',
+            'CDEFS        = %s' % ("-DNoChange"
+                                       if spack_f77.endswith('xlf') or
+                                          spack_f77.endswith('xlf_r')
+                                       else "-DAdd_")
+        ])
+
+        with open('make.inc', 'w') as fh:
+            fh.write('\n'.join(makefile_inc))
+
+        mkdirp(os.path.join(self.stage.source_path, 'lib'))
+        make("lib", parallel=False)
+
+        # FIXME:
+        # cd "EXAMPLE" do
+        # system "make"
+
+        # need to install by hand
+        headers_location = self.prefix.include
+        mkdirp(headers_location)
+        mkdirp(prefix.lib)
+
+        headers = glob.glob(join_path(self.stage.source_path, 'SRC', '*.h'))
+        for h in headers:
+            install(h, headers_location)
+
+        superludist_lib = join_path(self.stage.source_path,
+                                    'lib/libsuperlu_dist.a')
+        install(superludist_lib, self.prefix.lib)


### PR DESCRIPTION
related #10411

@alalazo @scheibelp @adamjstewart 
With a mass migration to `CMake` and Spack having lasted more than a couple of years, it is now becoming common for Spack packages to change build system due to upstream changes in build system.  For example, `superlu-dist` changed from ad-hoc manually-edited makefiles to CMake (see #12938).  This introduces a problem because now there need to be two fundamentally different Spack recipes for the same package --- one to build older versions, and one to build newer versions.  So far, there is no way to do this.  Instead, people have simply been dropping old versions of packages, which can create its own problems.

This PR provides a prototype of how a multiple build systems can be handled for a package in Spack, using `superlu-dist` as a real-world example.  I have used it successfully to install `superlu-dist@4.3`.  The downside of this is that now, the phases of the CMake-build package are hidden.  I'm sure that could cause headaches somewhere; but remember that early versions of Spack only had a single `install()` phase and life went on.  Maybe there is some what to finess the phase issue; for example, make the top-level package inherit phaes from the most-recent sub-package (in this case, the `CMakePackage` version of `superlu-dist`).

Comments / improvements welcome.  Ultimately, it would be great if this could be turned into a top-level, reusable `MultiBuildPackage` or something of the sort.
