### PR TITLE
binary cache: show all packages for compatible differing targets

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -610,7 +610,9 @@ def get_specs(force=False):
         tty.warn("No Spack mirrors are currently configured")
         return {}
 
-    path = str(spack.architecture.sys_type())
+    arch = spack.architecture.sys_type()
+    arch_spec = 'platform=%s os=%s target=:%s' % tuple(arch.split('-'))
+
     urls = set()
     for mirror_name, mirror_url in mirrors.items():
         if mirror_url.startswith('file'):
@@ -627,7 +629,7 @@ def get_specs(force=False):
             tty.msg("Finding buildcaches on %s" % mirror_url)
             p, links = spider(mirror_url + "/" + _build_cache_relative_path)
             for link in links:
-                if re.search("spec.yaml", link) and re.search(path, link):
+                if re.search("spec.yaml", link):
                     urls.add(link)
 
     _cached_specs = []
@@ -646,7 +648,8 @@ def get_specs(force=False):
                 # we need to mark this spec concrete on read-in.
                 spec = Spec.from_yaml(f)
                 spec._mark_concrete()
-                _cached_specs.append(spec)
+                if spec.satisfies(arch_spec):
+                    _cached_specs.append(spec)
 
     return _cached_specs
 


### PR DESCRIPTION
Since #3206 build caches are too specific in which packages they show as available. On a broadwell machine, build caches should consider all packages built for x86_64 architectures broadwell or earlier.

Fixes #12935 