### PR TITLE
Removed references to '(-march|-mtune|-mcpu)=native' in packages

### DIFF
--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -160,7 +160,6 @@ class Cp2k(MakefilePackage, CudaPackage):
         optimization_flags = {
             'gcc': [
                 '-O2',
-                '-mtune=native',
                 '-funroll-loops',
                 '-ftree-vectorize',
             ],

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -277,13 +277,10 @@ class Dealii(CMakePackage, CudaPackage):
         # https://groups.google.com/forum/?fromgroups#!topic/dealii/3Yjy8CBIrgU
         if spec.satisfies('%gcc'):
             cxx_flags_release.extend(['-O3'])
-            cxx_flags.extend(['-march=native'])
         elif spec.satisfies('%intel'):
             cxx_flags_release.extend(['-O3'])
-            cxx_flags.extend(['-march=native'])
         elif spec.satisfies('%clang'):
             cxx_flags_release.extend(['-O3', '-ffp-contract=fast'])
-            cxx_flags.extend(['-march=native'])
 
         # Python bindings
         if spec.satisfies('@8.5.0:'):

--- a/var/spack/repos/builtin/packages/elpa/package.py
+++ b/var/spack/repos/builtin/packages/elpa/package.py
@@ -84,8 +84,8 @@ class Elpa(AutotoolsPackage):
         # adjust the C compiler or CFLAGS
         if '+optflags' in self.spec:
             options.extend([
-                'FCFLAGS=-O2 -march=native -ffree-line-length-none',
-                'CFLAGS=-O2 -march=native'
+                'FCFLAGS=-O2 -ffree-line-length-none',
+                'CFLAGS=-O2'
             ])
         if '+openmp' in self.spec:
             options.append('--enable-openmp')

--- a/var/spack/repos/builtin/packages/hpgmg/package.py
+++ b/var/spack/repos/builtin/packages/hpgmg/package.py
@@ -66,11 +66,6 @@ class Hpgmg(Package):
             cflags.append('-g')
         elif any(map(self.spec.satisfies, ['%gcc', '%clang', '%intel'])):
             cflags.append('-O3')
-            if self.compiler.target in ['x86_64']:
-                cflags.append('-march=native')
-            elif not self.spec.satisfies('target=aarch64: %gcc@:5.9'):
-                cflags.append('-mcpu=native')
-                cflags.append('-mtune=native')
         else:
             cflags.append('-O3')
 

--- a/var/spack/repos/builtin/packages/krims/package.py
+++ b/var/spack/repos/builtin/packages/krims/package.py
@@ -58,8 +58,6 @@ class Krims(CMakePackage):
             "-DAUTOCHECKOUT_MISSING_REPOS=OFF",
             #
             "-DBUILD_SHARED_LIBS=" + str("+shared" in spec),
-            "-DDRB_MACHINE_SPECIFIC_OPTIM_Release=ON",  # Adds -march=native
-            #
             # TODO Hard-disable tests for now, since rapidcheck not in Spack
             "-DKRIMS_ENABLE_TESTS=OFF",
             "-DKRIMS_ENABLE_EXAMPLES=" + str("+examples" in spec),

--- a/var/spack/repos/builtin/packages/lazyten/package.py
+++ b/var/spack/repos/builtin/packages/lazyten/package.py
@@ -71,8 +71,6 @@ class Lazyten(CMakePackage):
             "-DAUTOCHECKOUT_MISSING_REPOS=OFF",
             #
             "-DBUILD_SHARED_LIBS=" + str("+shared" in spec),
-            "-DDRB_MACHINE_SPECIFIC_OPTIM_Release=ON",  # Adds -march=native
-            #
             # TODO Hard-disable tests for now, since rapidcheck not in Spack
             "-DLAZYTEN_ENABLE_TESTS=OFF",
             "-DLAZYTEN_ENABLE_EXAMPLES=" + str("+examples" in spec),

--- a/var/spack/repos/builtin/packages/libceed/package.py
+++ b/var/spack/repos/builtin/packages/libceed/package.py
@@ -62,10 +62,6 @@ class Libceed(Package):
                 opt = '-g'
             elif compiler.name == 'gcc':
                 opt = '-O3 -g -ffp-contract=fast'
-                if compiler.target in ['x86_64']:
-                    opt += ' -march=native'
-                elif compiler.target in ['ppc64le']:
-                    opt += ' -mcpu=native -mtune=native'
                 if compiler.version >= ver(4.9):
                     opt += ' -fopenmp-simd'
             elif compiler.name == 'clang':

--- a/var/spack/repos/builtin/packages/nanoflann/package.py
+++ b/var/spack/repos/builtin/packages/nanoflann/package.py
@@ -16,9 +16,7 @@ class Nanoflann(CMakePackage):
     version('1.2.3', '92a0f44a631c41aa06f9716c51dcdb11')
 
     def patch(self):
-        if self.spec.target.family == 'aarch64' and \
-                self.spec.satisfies('%gcc@:5.9'):
-            filter_file('-mtune=native', '', 'CMakeLists.txt')
+        filter_file('-mtune=native', '', 'CMakeLists.txt')
 
     def cmake_args(self):
         args = ['-DBUILD_SHARED_LIBS=ON']

--- a/var/spack/repos/builtin/packages/rocksdb/package.py
+++ b/var/spack/repos/builtin/packages/rocksdb/package.py
@@ -35,12 +35,10 @@ class Rocksdb(MakefilePackage):
     phases = ['install']
 
     def patch(self):
-        if (self.spec.target.family == 'aarch64' and
-            self.spec.satisfies('%gcc@:5.9')):
-            filter_file(
-                '-march=native', '',
-                join_path('build_tools', 'build_detect_platform')
-            )
+        filter_file(
+            '-march=native', '',
+            join_path('build_tools', 'build_detect_platform')
+        )
 
     def install(self, spec, prefix):
         cflags = []

--- a/var/spack/repos/builtin/packages/tealeaf/package.py
+++ b/var/spack/repos/builtin/packages/tealeaf/package.py
@@ -25,10 +25,7 @@ class Tealeaf(MakefilePackage):
     depends_on('mpi')
 
     def edit(self, spec, prefix):
-        if spec.target.family == 'aarch64' and spec.satisfies('%gcc@:5.9'):
-            filter_file(
-                '-march=native', '', join_path('TeaLeaf_ref', 'Makefile')
-            )
+        filter_file('-march=native', '', join_path('TeaLeaf_ref', 'Makefile'))
 
     @property
     def build_targets(self):

--- a/var/spack/repos/tutorial/packages/elpa/package.py
+++ b/var/spack/repos/tutorial/packages/elpa/package.py
@@ -65,13 +65,10 @@ class Elpa(AutotoolsPackage):
         # https://src.fedoraproject.org/cgit/rpms/elpa.git/
         # https://packages.qa.debian.org/e/elpa.html
         options = []
-        # without -march=native there is configure error for 2017.05.02
-        # Could not compile test program, try with --disable-sse, or
-        # adjust the C compiler or CFLAGS
         if '+optflags' in self.spec:
             options.extend([
-                'FCFLAGS=-O2 -march=native -ffree-line-length-none',
-                'CFLAGS=-O2 -march=native'
+                'FCFLAGS=-O2 -ffree-line-length-none',
+                'CFLAGS=-O2'
             ])
         if '+openmp' in self.spec:
             options.append('--enable-openmp')


### PR DESCRIPTION
Now that Spack injects microarchitecture specific optimizations for the selected target, packages should avoid adding flags that could step over those flags.