### PR TITLE
libflame: fix macOS build

### DIFF
--- a/var/spack/repos/builtin/packages/libflame/Makefile_5.2.0_darwin.patch
+++ b/var/spack/repos/builtin/packages/libflame/Makefile_5.2.0_darwin.patch
@@ -1,0 +1,231 @@
+From 6dd3c19978a0b805b0e294271ce8f5ef2f421425 Mon Sep 17 00:00:00 2001
+From: "Field G. Van Zee" <field@cs.utexas.edu>
+Date: Wed, 25 Sep 2019 12:46:23 -0500
+Subject: [PATCH] Use OSX-specific SOFLAGS when building shared lib.
+
+Details:
+- Use linker flags and shared library suffix specific to OSX/Darwin when
+  the user appears to be building in OSX/Darwin. The OS is queried using
+  'uname -s'. Thanks to Adam J. Stewart for reporting this issue in #23.
+- Substitute os_name from configure into config.mk (and echo in
+  post-configure.sh).
+- Substitute CC_VENDOR from configure into config.mk (and echo in
+  post-configure.sh). This variable isn't needed yet, but may be in the
+  future.
+- Autoconf update to configure.
+- Whitespace changes.
+---
+ Makefile                               | 22 +++++++++++++++++++++-
+ build/ac-macros/fla_observe_os_name.m4 | 11 +++++++++++
+ build/ac-macros/fla_require_cc.m4      |  8 ++++++--
+ build/config.mk.in                     |  5 +++++
+ build/post-configure.sh.in             |  5 +++++
+ configure                              | 15 +++++++++++++++
+ configure.ac                           |  3 +++
+ 7 files changed, 66 insertions(+), 3 deletions(-)
+ create mode 100644 build/ac-macros/fla_observe_os_name.m4
+
+diff --git a/Makefile b/Makefile
+index 6bd8bdce..f9681439 100644
+--- a/Makefile
++++ b/Makefile
+@@ -92,7 +92,12 @@ endif
+ 
+ # --- Shared library extension ---
+ 
+-SHLIB_EXT            := so
++# The shared (dynamic) library file suffix is different for Linux and OS X.
++ifeq ($(OS_NAME),Darwin)
++SHLIB_EXT          := dylib
++else
++SHLIB_EXT          := so
++endif
+ 
+ # --- Library names ---
+ 
+@@ -107,8 +112,15 @@ LIBFLAME_SO          := $(LIBFLAME).$(SHLIB_EXT)
+ LIBFLAME_A_PATH      := $(BASE_LIB_PATH)/$(LIBFLAME_A)
+ LIBFLAME_SO_PATH     := $(BASE_LIB_PATH)/$(LIBFLAME_SO)
+ 
++ifeq ($(OS_NAME),Darwin)
++# OS X shared library extensions.
++LIBFLAME_SO_MAJ_EXT  := $(SO_MAJOR).$(SHLIB_EXT)
++LIBFLAME_SO_MMB_EXT  := $(SO_MMB).$(SHLIB_EXT)
++else
++# Linux shared library extensions.
+ LIBFLAME_SO_MAJ_EXT  := $(SHLIB_EXT).$(SO_MAJOR)
+ LIBFLAME_SO_MMB_EXT  := $(SHLIB_EXT).$(SO_MMB)
++endif
+ 
+ LIBFLAME_SONAME      := $(LIBFLAME).$(LIBFLAME_SO_MAJ_EXT)
+ LIBFLAME_SO_MAJ_PATH := $(BASE_LIB_PATH)/$(LIBFLAME_SONAME)
+@@ -124,8 +136,15 @@ LIBFLAME_SO_OUTPUT_NAME := $(LIBFLAME_SO_PATH)
+ 
+ # Specify the shared library's 'soname' field.
+ # NOTE: The flag for creating shared objects is different for Linux and OS X.
++ifeq ($(OS_NAME),Darwin)
++# OS X shared library link flags.
++SOFLAGS    := -dynamiclib
++SOFLAGS    += -Wl,-install_name,$(LIBFLAME_SONAME)
++else
+ SOFLAGS    := -shared
++# Linux shared library link flags.
+ SOFLAGS    += -Wl,-soname,$(LIBFLAME_SONAME)
++endif
+ 
+ 
+ 
+diff --git a/build/ac-macros/fla_observe_os_name.m4 b/build/ac-macros/fla_observe_os_name.m4
+new file mode 100644
+index 00000000..d3dbbf99
+--- /dev/null
++++ b/build/ac-macros/fla_observe_os_name.m4
+@@ -0,0 +1,11 @@
++AC_DEFUN([FLA_OBSERVE_OS_NAME],
++[
++	os_name=$(uname -s)
++	os_vers=$(uname -r)
++
++	dnl os_name_esc=$(echo "${os_name}" | sed 's/\//\\\//g')
++
++	dnl Substitute the OS name and version into autoconf output files
++	AC_SUBST(os_name)
++	AC_SUBST(os_vers)
++])
+diff --git a/build/ac-macros/fla_require_cc.m4 b/build/ac-macros/fla_require_cc.m4
+index 7f8131d8..5dd7cd38 100644
+--- a/build/ac-macros/fla_require_cc.m4
++++ b/build/ac-macros/fla_require_cc.m4
+@@ -6,19 +6,23 @@ AC_DEFUN([FLA_REQUIRE_CC],
+ 	dnl whether the user provided his own definition of CFLAGS.
+ 	fla_userdef_cflags=$CFLAGS
+ 	
+-	dnl Find a C compiler. 
++	dnl Find a C compiler.
+ 	dnl If the CC environment variable is not already set, search for the
+ 	dnl compiler defined by fla_requested_cc (which may be empty) and then
+ 	dnl continue searching for the compilers in $fla_c_compiler_list, if
+ 	dnl necessary. Also, if the C compiler found is not in ANSI mode, then
+ 	dnl try to add an option to make it so. If the GNU gcc was found, then
+-	dnl GCC shell variable is set to `yes'. 
++	dnl GCC shell variable is set to `yes'.
+ 	AC_PROG_CC([$fla_requested_cc $fla_c_compiler_list])
+ 
+ 	if test "$CC" = "" ; then
+ 		AC_MSG_ERROR([Could not locate any of the following C compilers: $CC $fla_requested_cc $fla_c_compiler_list. Cannot continue without a C compiler.],[1])
+ 	fi
++
++	dnl Ascertain the compiler "vendor".
++	CC_VENDOR=$(echo "$CC" | egrep -o 'icc|gcc|clang|emcc|pnacl|IBM' | { read first rest ; echo $first ; })
+ 	
+ 	dnl Substitute the user-defined CFLAGS into the autoconf output files.
+ 	AC_SUBST(fla_userdef_cflags)
++	AC_SUBST(CC_VENDOR)
+ ])
+diff --git a/build/config.mk.in b/build/config.mk.in
+index c4679b51..37cedb96 100644
+--- a/build/config.mk.in
++++ b/build/config.mk.in
+@@ -28,6 +28,10 @@ SO_MMB    := $(SO_MAJOR).$(SO_MINORB)
+ # library name.
+ ARCH                           := @fla_host_cpu@
+ 
++# This variable identifies the operating system / kernel. It is the result of
++# 'uname -s'.
++OS_NAME                        := @os_name@
++
+ # We have to set these particular variables because some of the @anchors@
+ # that are substituted in via configure may be defined *in terms of* these
+ # variables. For example, @libdir@ may be replaced with '${exec_prefix}/lib',
+@@ -101,6 +105,7 @@ EMPTY_FILE := /dev/null
+ 
+ # --- Determine the C compiler and related flags ---
+ CC           := @CC@
++CC_VENDOR    := @CC_VENDOR@
+ CPPROCFLAGS  := -D_POSIX_C_SOURCE=200809L @DEFS@ @fla_blis_flags@
+ CMISCFLAGS   := @fla_c_lang_flags@ @fla_c_openmp_flags@ @fla_c_prof_flags@
+ CDBGFLAGS    := @fla_c_debug_flags@
+diff --git a/build/post-configure.sh.in b/build/post-configure.sh.in
+index 26f9110d..61d59bca 100755
+--- a/build/post-configure.sh.in
++++ b/build/post-configure.sh.in
+@@ -17,6 +17,10 @@ echo ""
+ echo "build system type............................... : @build@"
+ echo "host system type................................ : @host@"
+ 
++echo ""
++echo "OS name......................................... : @os_name@"
++echo "OS version...................................... : @os_vers@"
++
+ echo ""
+ echo "Enable verbose make output...................... : @fla_enable_verbose_make_output@"
+ 
+@@ -25,6 +29,7 @@ echo "Enable maximum argument list hack............... : @fla_enable_max_arg_lis
+ 
+ echo ""
+ echo "C compiler...................................... : @CC@"
++echo "C compiler vendor............................... : @CC_VENDOR@"
+ echo "Library archiver................................ : @AR@"
+ echo "Library archive indexer......................... : @RANLIB@"
+ 
+diff --git a/configure b/configure
+index c3d19bbc..1e24f9a5 100755
+--- a/configure
++++ b/configure
+@@ -698,6 +698,7 @@ INSTALL_SCRIPT
+ INSTALL_PROGRAM
+ RANLIB
+ AR
++CC_VENDOR
+ fla_userdef_cflags
+ OBJEXT
+ EXEEXT
+@@ -707,6 +708,8 @@ LDFLAGS
+ CFLAGS
+ CC
+ fla_gnu_make_found
++os_vers
++os_name
+ fla_host_cpu
+ host_os
+ host_vendor
+@@ -2738,6 +2741,15 @@ case $host_os in *\ *) host_os=`echo "$host_os" | sed 's/ /-/g'`;; esac
+ 
+ 
+ 
++	os_name=$(uname -s)
++	os_vers=$(uname -r)
++
++
++
++
++
++
++
+ 
+ 
+ 
+@@ -3462,6 +3474,9 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
+ 		as_fn_error 1 "Could not locate any of the following C compilers: $CC $fla_requested_cc $fla_c_compiler_list. Cannot continue without a C compiler." "$LINENO" 5
+ 	fi
+ 
++		CC_VENDOR=$(echo "$CC" | egrep -o 'icc|gcc|clang|emcc|pnacl|IBM' | { read first rest ; echo $first ; })
++
++
+ 
+ 
+ 
+diff --git a/configure.ac b/configure.ac
+index 790ac90e..d8b0e6b0 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -227,6 +227,9 @@ dnl AC_PROG_CC and AC_PROG_F77 marcos in the variables fla_c_compiler_list and
+ dnl fla_f77_compiler_list, respectively.
+ FLA_OBSERVE_HOST_CPU_TYPE
+ 
++dnl Set the @os_name@ output variable to the output of 'uname -s'.
++FLA_OBSERVE_OS_NAME
++
+ dnl Set the default value of the $prefix value, normally set by the --prefix
+ dnl option to configure.
+ dnl AC_PREFIX_DEFAULT([$HOME/flame])

--- a/var/spack/repos/builtin/packages/libflame/package.py
+++ b/var/spack/repos/builtin/packages/libflame/package.py
@@ -60,6 +60,10 @@ class Libflame(AutotoolsPackage):
     # https://github.com/flame/libflame/issues/24
     patch('Makefile_5.2.0.patch', when='@5.2.0')
 
+    # Problems building on macOS:
+    # https://github.com/flame/libflame/issues/23
+    patch('Makefile_5.2.0_darwin.patch', when='@5.2.0')
+
     def flag_handler(self, name, flags):
         # -std=gnu99 at least required, old versions of GCC default to -std=c90
         if self.spec.satisfies('%gcc@:5.1') and name == 'cflags':
@@ -104,3 +108,9 @@ class Libflame(AutotoolsPackage):
         config_args.append("--enable-max-arg-list-hack")
 
         return config_args
+
+    @run_after('install')
+    def darwin_fix(self):
+        # The shared library is not installed correctly on Darwin; fix this
+        if self.spec.satisfies('platform=darwin'):
+            fix_darwin_install_name(self.prefix.lib)


### PR DESCRIPTION
With this PR, I'm finally able to build NumPy 1.17.2 with libflame 5.2.0, BLIS 0.6.0, Python 3.7.4, and Clang 11.0.0 on macOS 10.14.6. All unit tests pass.

@s-sajid-ali 