### PR TITLE
raxml: simplified recipe by removing SIMD variants

### DIFF
--- a/var/spack/repos/builtin/packages/raxml/package.py
+++ b/var/spack/repos/builtin/packages/raxml/package.py
@@ -2,26 +2,22 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-from spack import *
-from spack.spec import ConflictsInSpecError
 import glob
 
 
 class Raxml(Package):
     """RAxML (Randomized Axelerated Maximum Likelihood) is a program for
-       sequential and parallel Maximum Likelihood based inference of large
-       phylogenetic trees."""
+    sequential and parallel Maximum Likelihood based inference of large
+    phylogenetic trees.
+    """
 
     homepage = "https://sco.h-its.org/exelixis/web/software/raxml"
-    url      = "https://github.com/stamatak/standard-RAxML/archive/v8.2.11.tar.gz"
+    url = "https://github.com/stamatak/standard-RAxML/archive/v8.2.11.tar.gz"
 
     version('8.2.11', '6bd5c4e1f93003ccf13c9b59a5d080ab')
 
     variant('mpi', default=True, description='Enable MPI parallel support')
     variant('pthreads', default=False, description='Enable pthreads version')
-    variant('sse', default=False, description='Enable SSE in order to substantially speed up execution')
-    variant('avx', default=False, description='Enable AVX in order to substantially speed up execution')
 
     depends_on('mpi', when='+mpi')
 
@@ -38,36 +34,6 @@ class Raxml(Package):
     # can't build multiple binaries in parallel without things breaking
     parallel = False
 
-    def flag_handler(self, name, flags):
-        arch = ''
-        spec = self.spec
-        if spec.satisfies("platform=cray"):
-            # FIXME; It is assumed that cray is x86_64.
-            # If you support arm on cray, you need to fix it.
-            arch = 'x86_64'
-        if arch != 'x86_64' and not spec.target.family == 'x86_64':
-            if spec.satisfies("+sse"):
-                raise ConflictsInSpecError(
-                    spec,
-                    [(
-                        spec,
-                        spec.architecture.target,
-                        spec.variants['sse'],
-                        '+sse is valid only on x86_64'
-                    )]
-                )
-            if spec.satisfies("+avx"):
-                raise ConflictsInSpecError(
-                    spec,
-                    [(
-                        spec,
-                        spec.architecture.target,
-                        spec.variants['avx'],
-                        '+avx is valid only on x86_64'
-                    )]
-                )
-        return (flags, None, None)
-
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
         files = glob.iglob("Makefile.*")
@@ -78,11 +44,11 @@ class Raxml(Package):
                 makefile.filter('mpicc', self.spec['mpi'].mpicc)
 
         if spec.target.family == 'x86_64':
-            if spec.satisfies('+mpi +avx +pthreads'):
+            if spec.satisfies('+mpi +pthreads') and 'avx' in spec.target:
                 make('-f', 'Makefile.AVX.HYBRID.gcc')
                 install('raxmlHPC-HYBRID-AVX', prefix.bin)
 
-            if spec.satisfies('+mpi +sse +pthreads'):
+            if spec.satisfies('+mpi +pthreads') and 'sse3' in spec.target:
                 make('-f', 'Makefile.SSE3.HYBRID.gcc')
                 install('raxmlHPC-HYBRID-SSE3', prefix.bin)
 
@@ -90,11 +56,11 @@ class Raxml(Package):
                 make('-f', 'Makefile.HYBRID.gcc')
                 install('raxmlHPC-HYBRID', prefix.bin)
 
-            if spec.satisfies('+mpi +avx'):
+            if spec.satisfies('+mpi') and 'avx' in spec.target:
                 make('-f', 'Makefile.AVX.MPI.gcc')
                 install('raxmlHPC-MPI-AVX', prefix.bin)
 
-            if spec.satisfies('+mpi +sse'):
+            if spec.satisfies('+mpi') and 'sse3' in spec.target:
                 make('-f', 'Makefile.SSE3.MPI.gcc')
                 install('raxmlHPC-MPI-SSE3', prefix.bin)
 
@@ -102,11 +68,11 @@ class Raxml(Package):
                 make('-f', 'Makefile.MPI.gcc')
                 install('raxmlHPC-MPI', prefix.bin)
 
-            if spec.satisfies('+pthreads +avx'):
+            if spec.satisfies('+pthreads') and 'avx' in spec.target:
                 make('-f', 'Makefile.AVX.PTHREADS.gcc')
                 install('raxmlHPC-PTHREADS-AVX', prefix.bin)
 
-            if spec.satisfies('+pthreads +sse'):
+            if spec.satisfies('+pthreads') and 'sse3' in spec.target:
                 make('-f', 'Makefile.SSE3.PTHREADS.gcc')
                 install('raxmlHPC-PTHREADS-SSE3', prefix.bin)
 
@@ -114,11 +80,11 @@ class Raxml(Package):
                 make('-f', 'Makefile.PTHREADS.gcc')
                 install('raxmlHPC-PTHREADS', prefix.bin)
 
-            if spec.satisfies('+sse'):
+            if 'sse3' in spec.target:
                 make('-f', 'Makefile.SSE3.gcc')
                 install('raxmlHPC-SSE3', prefix.bin)
 
-            if spec.satisfies('+avx'):
+            if 'avx' in spec.target:
                 make('-f', 'Makefile.AVX.gcc')
                 install('raxmlHPC-AVX', prefix.bin)
 


### PR DESCRIPTION
Now the support for SSE3 or AVX is tested on the selected target.

@tkameyama @akthoma