### PR TITLE
bowtie: fix for aarch64, and bugfix about c++11-narrowing.

### DIFF
--- a/var/spack/repos/builtin/packages/bowtie/fix_narrowing_err.patch
+++ b/var/spack/repos/builtin/packages/bowtie/fix_narrowing_err.patch
@@ -1,0 +1,11 @@
+--- bowtie-1.2.3.org/alphabet.cpp	2019-09-26 12:14:35.508558749 +0900
++++ bowtie-1.2.3/alphabet.cpp	2019-09-26 14:15:56.960009461 +0900
+@@ -274,7 +274,7 @@
+ const char *iupacs = "!ACMGRSVTWYHKDBN!acmgrsvtwyhkdbn";
+ 
+ char mask2iupac[16] = {
+-	-1,
++	static_cast<char>(-1),
+ 	'A', // 0001
+ 	'C', // 0010
+ 	'M', // 0011

--- a/var/spack/repos/builtin/packages/bowtie/for_aarch64.patch
+++ b/var/spack/repos/builtin/packages/bowtie/for_aarch64.patch
@@ -1,0 +1,68 @@
+diff -ur bowtie-1.2.3.org/Makefile bowtie-1.2.3/Makefile
+--- bowtie-1.2.3.org/Makefile	2019-09-26 12:14:35.498557693 +0900
++++ bowtie-1.2.3/Makefile	2019-09-26 12:15:17.262960932 +0900
+@@ -174,14 +174,22 @@
+     ifeq (x86_64, $(shell uname -p))
+         BITS=64
+     endif
++    ifeq (aarch64, $(shell uname -p))
++        BITS=64
++    endif
+ endif
+ 
+ ifeq (32,$(BITS))
+     $(error bowtie2 compilation requires a 64-bit platform )
+ endif
+ 
+-DEBUG_FLAGS = -O0 -g3 -m64
+-RELEASE_FLAGS = -O3 -m64
++ifeq (aarch64, $(shell uname -p))
++    DEBUG_FLAGS = -O0 -g3
++    RELEASE_FLAGS = -O3
++else
++    DEBUG_FLAGS = -O0 -g3 -m64
++    RELEASE_FLAGS = -O3 -m64
++endif
+ NOASSERT_FLAGS = -DNDEBUG
+ FILE_FLAGS = -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE
+ 
+diff -ur bowtie-1.2.3.org/ebwt.h bowtie-1.2.3/ebwt.h
+--- bowtie-1.2.3.org/ebwt.h	2019-09-26 12:14:35.518559804 +0900
++++ bowtie-1.2.3/ebwt.h	2019-09-26 14:13:12.142637470 +0900
+@@ -1957,7 +1957,11 @@
+     struct USE_POPCNT_INSTRUCTION {
+         inline static int pop64(uint64_t x) {
+             int64_t count;
++#ifdef __aarch64__
++            count = __builtin_popcount(x);
++#else
+             asm ("popcntq %[x],%[count]\n": [count] "=&r" (count): [x] "r" (x));
++#endif
+             return count;
+         }
+     };
+diff -ur bowtie-1.2.3.org/third_party/cpuid.h bowtie-1.2.3/third_party/cpuid.h
+--- bowtie-1.2.3.org/third_party/cpuid.h	2019-09-26 12:14:35.548562971 +0900
++++ bowtie-1.2.3/third_party/cpuid.h	2019-09-26 12:17:41.677842567 +0900
+@@ -65,6 +65,7 @@
+ #define bit_FSGSBASE	(1 << 0)
+ #define bit_BMI		(1 << 3)
+ 
++#ifndef __aarch64__
+ #if defined(__i386__) && defined(__PIC__)
+ /* %ebx may be the PIC register.  */
+ #if __GNUC__ >= 3
+@@ -185,3 +186,13 @@
+   __cpuid (__level, *__eax, *__ebx, *__ecx, *__edx);
+   return 1;
+ }
++#endif
++#ifdef __aarch64__ 
++static __inline int
++__get_cpuid (unsigned int __level,
++             unsigned int *__eax, unsigned int *__ebx,
++             unsigned int *__ecx, unsigned int *__edx)
++{
++  return 1;
++}
++#endif

--- a/var/spack/repos/builtin/packages/bowtie/package.py
+++ b/var/spack/repos/builtin/packages/bowtie/package.py
@@ -45,6 +45,13 @@ class Bowtie(MakefilePackage):
     # https://svnweb.freebsd.org/ports?view=revision&revision=483954
     patch('issue-87.patch', when='@:1.2.2 %gcc@8.0.0:')
 
+    # correspond to 'aarch64' architecture
+    # reference: https://github.com/BenLangmead/bowtie/pull/13
+    patch('for_aarch64.patch', when='target=aarch64:')
+
+    # measures for narrowing error
+    patch('fix_narrowing_err.patch')
+
     def edit(self, spec, prefix):
         makefile = FileFilter('Makefile')
         makefile.filter('CC = .*', 'CC = ' + env['CC'])


### PR DESCRIPTION
* Correspond to `aarch64` architecture based on the following URL information.
   URL: https://github.com/BenLangmead/bowtie/pull/13
* Fix bug about 'narrowing error'.
```error: constant expression evaluates to -1 which cannot be narrowed to type 'char' [-Wc++11-narrowing]```