### PR TITLE
Fix 'arch' string in QT4 due to microarchitecture change

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -427,7 +427,7 @@ class Qt(Package):
             '-{0}gtkstyle'.format('' if '+gtk' in spec else 'no-'),
             '-{0}webkit'.format('' if '+webkit' in spec else 'no-'),
             '-{0}phonon'.format('' if '+phonon' in spec else 'no-'),
-            '-arch', str(spec.architecture.target),
+            '-arch', str(spec.target.family),
         ])
 
         # Disable phonon backend until gstreamer is setup as dependency


### PR DESCRIPTION
Since #3206, 'spec.architecture.target' returned the microarchitecture
target rather than the architecture family. This causes QT 4 to fail to
build because it's expecting something like 'x86_64' rather than
'broadwell'.

See #12914

Erorr message:
```
==> [2019-09-26-09:37:33.834286] './configure' '-prefix' '/rnsdhpc/code/spack/opt/spack/clang/qt/aguusfi' '-v' '-opensource' '-no-opengl' '-release' '-confirm-license' '-optimized-qmake' '-no-pch' '-no-freetype' '-no-openssl' '-no-sql-db2' '-no-sql-ibase' '-no-sql-oci' '-no-sql-tds' '-no-sql-mysql' '-no-sql-odbc' '-no-sql-psql' '-no-sql-sqlite' '-no-sql-sqlite2' '-shared' '-no-openvg' '-no-nis' '-nomake' 'examples' '-nomake' 'tools' '-no-dbus' '-no-framework' '-fast' '-no-declarative-debug' '-no-gtkstyle' '-no-webkit' '-no-phonon' '-arch' 'broadwell' '-nomake' 'demos' '-cocoa' '-platform' 'unsupported/macx-clang-libc++' '-sdk' '/var/folders/gy/mrg1ffts2h945qj9k29s1l1dvvmbqb/T/s3j/spack-stage/xcode-select/clang/10.0.1-apple/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk'
Determining system architecture... (Darwin:18.7.0:x86_64)
    'macosx' is supported
System architecture: 'macosx'
Unknown architecture: "broadwell". Supported architectures: x86[i386] ppc x86_64 ppc64 arm armv6 armv7
```

@tmdelellis