### PR TITLE
Add all the 'generic' architectures that are mentioned in recipes

### DIFF
--- a/lib/spack/llnl/util/cpu/microarchitectures.json
+++ b/lib/spack/llnl/util/cpu/microarchitectures.json
@@ -825,6 +825,41 @@
           "flags": "-march=armv8-a -mtune=generic"
         }
       }
+    },
+    "arm": {
+      "from": null,
+      "vendor": "generic",
+      "features": [],
+      "compilers": {
+      }
+    },
+    "ppc": {
+      "from": null,
+      "vendor": "generic",
+      "features": [],
+      "compilers": {
+      }
+    },
+    "ppcle": {
+      "from": null,
+      "vendor": "generic",
+      "features": [],
+      "compilers": {
+      }
+    },
+    "sparc": {
+      "from": null,
+      "vendor": "generic",
+      "features": [],
+      "compilers": {
+      }
+    },
+    "sparc64": {
+      "from": null,
+      "vendor": "generic",
+      "features": [],
+      "compilers": {
+      }
     }
   },
   "feature_aliases": {


### PR DESCRIPTION
LLVM, mesa and other packages check for these generic microarchitectures. One solution is to let Spack know they exist.

@odoublewen 