### PR TITLE
Add chai package, link with raja and umpire

### DIFF
--- a/var/spack/repos/builtin/packages/chai/package.py
+++ b/var/spack/repos/builtin/packages/chai/package.py
@@ -41,6 +41,8 @@ class Chai(CMakePackage):
 
         options.append('-Dumpire_DIR:PATH='
                        + spec['umpire'].prefix + "/share/umpire/cmake")
+
+        # disable tests for now, fails on gcc@9.1.0
         options.append('-DENABLE_TESTS=Off')
         options.append('-DENABLE_BENCHMARKS=Off')
 

--- a/var/spack/repos/builtin/packages/chai/package.py
+++ b/var/spack/repos/builtin/packages/chai/package.py
@@ -1,0 +1,46 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Chai(CMakePackage):
+    """Copy-hiding array interface - array-interface that handles automatic data migration between memory spaces"""
+
+    homepage = "https://github.com/LLNL/CHAI"
+    url      = "https://github.com/LLNL/CHAI.git"
+
+    version('develop', branch='develop', submodules='True')
+    version('master', branch='master', submodules='True')
+    version('1.0', tag='v1.0', submodules='True')
+    version('1.1.0', tag='v1.1.0', submodules='True')
+    version('1.2.0', tag='v1.2.0', submodules='True')
+
+    variant('cuda', default=False, description='Build with CUDA support')
+    
+    depends_on('umpire')
+    depends_on('cmake@3.8:', type='build')
+    
+    depends_on('umpire+cuda', when="+cuda")
+    depends_on('cuda', when='+cuda')
+    depends_on('cmake@3.9:', type='build', when="+cuda")
+    
+    def cmake_args(self):
+        spec = self.spec
+
+        options = []
+
+        if '+cuda' in spec:
+            options.extend([
+                '-DENABLE_CUDA=On',
+                '-DCUDA_TOOLKIT_ROOT_DIR=%s' % (spec['cuda'].prefix)])
+        else:
+            options.append('-DENABLE_CUDA=Off')
+
+        options.append('-Dumpire_DIR:PATH='+spec['umpire'].prefix+"/share/umpire/cmake")
+        options.append('-DENABLE_TESTS=Off')
+        options.append('-DENABLE_BENCHMARKS=Off')
+
+        return options

--- a/var/spack/repos/builtin/packages/chai/package.py
+++ b/var/spack/repos/builtin/packages/chai/package.py
@@ -7,7 +7,7 @@ from spack import *
 
 
 class Chai(CMakePackage):
-    """Copy-hiding array interface - array-interface that handles automatic data migration between memory spaces"""
+    """Copy-hiding array interface for data migration between memory spaces"""
 
     homepage = "https://github.com/LLNL/CHAI"
     url      = "https://github.com/LLNL/CHAI.git"
@@ -19,14 +19,14 @@ class Chai(CMakePackage):
     version('1.2.0', tag='v1.2.0', submodules='True')
 
     variant('cuda', default=False, description='Build with CUDA support')
-    
+
     depends_on('umpire')
     depends_on('cmake@3.8:', type='build')
-    
+
     depends_on('umpire+cuda', when="+cuda")
     depends_on('cuda', when='+cuda')
     depends_on('cmake@3.9:', type='build', when="+cuda")
-    
+
     def cmake_args(self):
         spec = self.spec
 
@@ -39,7 +39,8 @@ class Chai(CMakePackage):
         else:
             options.append('-DENABLE_CUDA=Off')
 
-        options.append('-Dumpire_DIR:PATH='+spec['umpire'].prefix+"/share/umpire/cmake")
+        options.append('-Dumpire_DIR:PATH='
+                       + spec['umpire'].prefix + "/share/umpire/cmake")
         options.append('-DENABLE_TESTS=Off')
         options.append('-DENABLE_BENCHMARKS=Off')
 

--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -29,11 +29,11 @@ class Raja(CMakePackage):
     variant('targetopenmp', default=False, description='Build target OpenmP backend')
     variant('tbb', default=False, description='Build TBB backend')
     variant('chai', default=False, description='Build with CHAI support')
-    
+
     depends_on('cuda', when='+cuda')
     depends_on('chai', when='+chai')
     depends_on('chai+cuda', when='+chai+cuda')
-    
+
     depends_on('cmake@3.8:', type='build')
     depends_on('cmake@3.9:', when='+cuda', type='build')
 
@@ -60,5 +60,5 @@ class Raja(CMakePackage):
         if '+chai' in spec:
             options.extend([
                 '-DENABLE_CHAI=On'])
-        
+
         return options

--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -32,6 +32,7 @@ class Raja(CMakePackage):
     
     depends_on('cuda', when='+cuda')
     depends_on('chai', when='+chai')
+    depends_on('chai+cuda', when='+chai+cuda')
     
     depends_on('cmake@3.8:', type='build')
     depends_on('cmake@3.9:', when='+cuda', type='build')

--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -26,9 +26,13 @@ class Raja(CMakePackage):
 
     variant('cuda', default=False, description='Build with CUDA backend')
     variant('openmp', default=True, description='Build OpenMP backend')
-
+    variant('targetopenmp', default=False, description='Build target OpenmP backend')
+    variant('tbb', default=False, description='Build TBB backend')
+    variant('chai', default=False, description='Build with CHAI support')
+    
     depends_on('cuda', when='+cuda')
-
+    depends_on('chai', when='+chai')
+    
     depends_on('cmake@3.8:', type='build')
     depends_on('cmake@3.9:', when='+cuda', type='build')
 
@@ -44,4 +48,16 @@ class Raja(CMakePackage):
                 '-DENABLE_CUDA=On',
                 '-DCUDA_TOOLKIT_ROOT_DIR=%s' % (spec['cuda'].prefix)])
 
+        if '+targetopenmp' in spec:
+            options.extend([
+                '-DENABLE_TARGET_OPENMP=On'])
+
+        if '+tbb' in spec:
+            options.extend([
+                '-DENABLE_TBB=On'])
+
+        if '+chai' in spec:
+            options.extend([
+                '-DENABLE_CHAI=On'])
+        
         return options

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -61,5 +61,5 @@ class Umpire(CMakePackage):
 
         options.append('-DENABLE_TESTS=Off')
         options.append('-DENABLE_BENCHMARKS=Off')
-            
+
         return options

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -59,6 +59,7 @@ class Umpire(CMakePackage):
         if '+numa' in spec:
             options.append('-DENABLE_NUMA=On')
 
+        # disable tests for now, fails on gcc@9.1.0
         options.append('-DENABLE_TESTS=Off')
         options.append('-DENABLE_BENCHMARKS=Off')
 

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -16,6 +16,9 @@ class Umpire(CMakePackage):
 
     version('develop', branch='develop', submodules='True')
     version('master', branch='master', submodules='True')
+    version('1.0.0', tag='v1.0.0', submodules='True')
+    version('0.3.5', tag='v0.3.5', submodules='True')
+    version('0.3.4', tag='v0.3.4', submodules='True')
     version('0.3.3', tag='v0.3.3', submodules='True')
     version('0.3.2', tag='v0.3.2', submodules='True')
     version('0.3.1', tag='v0.3.1', submodules='True')
@@ -56,4 +59,7 @@ class Umpire(CMakePackage):
         if '+numa' in spec:
             options.append('-DENABLE_NUMA=On')
 
+        options.append('-DENABLE_TESTS=Off')
+        options.append('-DENABLE_BENCHMARKS=Off')
+            
         return options


### PR DESCRIPTION
- added a spack package for chai
- added appropriate build options to raja so raja can be built with chai.
- updated the umpire revisions, as chai requires newer versions of umpire in order to compile.
- disabled blt tests in chai + umpire, as the google test they use is incompatible with gcc@9.1.0
