### PR TITLE
when removing a file from a view, don't fail if it doesn't exist

### DIFF
--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -358,6 +358,7 @@ class YamlFilesystemView(FilesystemView):
 
     def remove_file(self, src, dest):
         if not os.path.lexists(dest):
+            tty.warn("Tried to remove %s which does not exist" % dest)
             return
         if not os.path.islink(dest):
             raise ValueError("%s is not a link tree!" % dest)

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -357,6 +357,8 @@ class YamlFilesystemView(FilesystemView):
         tree.unmerge_directories(view_dst, ignore_file)
 
     def remove_file(self, src, dest):
+        if not os.path.lexists(dest):
+            return
         if not os.path.islink(dest):
             raise ValueError("%s is not a link tree!" % dest)
         # remove if dest is a hardlink/symlink to src; this will only


### PR DESCRIPTION
Sometimes when `remove_file` is called on a link, that link is missing (perhaps ctrl-C happened halfway through a previous action, a `make clean` went rogue, ...). As removing a non-existent file is no problem, this patch changes the behaviour so Spack continues rather than erroring. 

Currently you would see
```ValueError: /path/to/my/env/.spack-env/view/share/info/dir is not a link tree!```
and now it continues silently. 