### PR TITLE
Add all compatible system types directory to module paths

### DIFF
--- a/lib/spack/spack/architecture.py
+++ b/lib/spack/spack/architecture.py
@@ -493,3 +493,15 @@ def sys_type():
     """
     arch = Arch(platform(), 'default_os', 'default_target')
     return str(arch)
+
+
+@memoized
+def compatible_sys_types():
+    """Returns a list of all the systypes compatible with the current host."""
+    compatible_archs = []
+    current_host = cpu.host()
+    compatible_targets = [current_host] + current_host.ancestors
+    for target in compatible_targets:
+        arch = Arch(platform(), 'default_os', target)
+        compatible_archs.append(str(arch))
+    return compatible_archs

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -585,7 +585,8 @@ def print_setup_info(*info):
 
     # print sys type
     shell_set('_sp_sys_type', spack.architecture.sys_type())
-
+    shell_set('_sp_compatible_sys_types',
+              ':'.join(spack.architecture.compatible_sys_types()))
     # print roots for all module systems
     module_roots = spack.config.get('config:module_roots')
     module_to_roots = {

--- a/share/spack/setup-env.csh
+++ b/share/spack/setup-env.csh
@@ -26,8 +26,11 @@ if ($?SPACK_ROOT) then
 
     # Set up modules and dotkit search paths in the user environment
     set tcl_roots = `echo $_sp_tcl_roots:q | sed 's/:/ /g'`
+    set compatible_sys_types = `echo $_sp_compatible_sys_types:q | sed 's/:/ /g'`
     foreach tcl_root ($tcl_roots:q)
-        _spack_pathadd MODULEPATH "$tcl_root/$_sp_sys_type"
+        foreach systype ($compatible_sys_types:q)
+            _spack_pathadd MODULEPATH "$tcl_root/$systype"
+        end
     end
 
     set dotkit_roots = `echo $_sp_dotkit_roots:q | sed 's/:/ /g'`

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -350,7 +350,9 @@ _sp_multi_pathadd() {
         setopt sh_word_split
     fi
     for pth in $2; do
-        _spack_pathadd "$1" "${pth}/${_sp_sys_type}"
+        for systype in ${_sp_compatible_sys_types}; do
+            _spack_pathadd "$1" "${pth}/${systype}"
+        done
     done
 }
 _sp_multi_pathadd MODULEPATH "$_sp_tcl_roots"


### PR DESCRIPTION
fixes #12915
closes #12916

Since Spack has support for specific targets it might happen that software is built for targets that are not exactly the host because it was either an explicit user request or the compiler being used is too old to support the host.

Modules for different targets are written into different directories and by default Spack was adding to MODULEPATH only the directory corresponding to the current host. This PR modifies this behavior to add all the directories that are **compatible** with the current host.

@smjenness @pat-s @oehlrich9 @marcmengel