### PR TITLE
correct with-xxx-lib= options

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -316,7 +316,7 @@ class Petsc(Package):
         if 'zlib' in spec:
             options.extend([
                 '--with-zlib-include=%s' % spec['zlib'].prefix.include,
-                '--with-zlib-lib=%s'     % spec['zlib'].libs.ld_flags,
+                '--with-zlib-lib=%s'     % spec['zlib'].libs.joined(),
                 '--with-zlib=1'
             ])
         else:


### PR DESCRIPTION
use list of library files for --with-zlib-lib=  to get rpath included correctly

Fixes #10585