### PR TITLE
prefer python3 to python2 for running Spack

### DIFF
--- a/bin/spack
+++ b/bin/spack
@@ -1,9 +1,25 @@
-#!/usr/bin/env python
+#!/bin/sh
+# -*- python -*-
 #
 # Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# This file is bilingual. The following shell code finds our preferred python.
+# Following line is a shell no-op, and starts a multi-line Python comment.
+# See https://stackoverflow.com/a/47886254
+""":"
+# prefer python3, then python, then python2
+for cmd in python3 python python2; do
+   command -v > /dev/null $cmd && exec $cmd $0 "$@"
+done
+
+echo "==> Error: spack could not find a python interpreter!" >&2
+exit 1
+":"""
+# Line above is a shell no-op, and ends a python multi-line comment.
+# The code above runs this file with our preferred python interpreter.
 
 from __future__ import print_function
 

--- a/lib/spack/spack/cmd/license.py
+++ b/lib/spack/spack/cmd/license.py
@@ -22,7 +22,7 @@ level = "long"
 git = which('git')
 
 #: SPDX license id must appear in the first <license_lines> lines of a file
-license_lines = 6
+license_lines = 7
 
 #: Spack's license identifier
 apache2_mit_spdx = "(Apache-2.0 OR MIT)"


### PR DESCRIPTION
Closes #11783.

@michaelkuhn: I think this accomplishes what #11783 set out to do, but in a much simpler way.

The Python landscape is going to be changing in 2020, and Python 2 will be end of life. Spack should *prefer* Python 3 to Python 2 by default, but we still need to run on systems that only have Python2 available.

This is trickier than it sounds, as on some systems, the `python` command is `python2`; on others it's `python3`, and [RHEL8 doesn't even have the `python` command](https://developers.redhat.com/blog/2018/11/14/python-in-rhel-8/).  Instead, it makes you choose `python3` or `python2`. You can thus no longer make a simple shebang to handle all the cases.

This commit makes the `spack` script bilingual.  It is still valid Python, but its shebang is `#!/bin/sh`, and it has a tiny bit of shell code at the beginning to pick the right python and execute itself with what it finds.

This has a lot of advantages.  I think this will help ensure that Spack works well in Python3 -- there are cases where we've missed things because Python2 is still the default `python` on most systems.  Also, with this change, you do not lose the ability to execute the `spack` script directly with a python interpreter.  This is useful for forcing your own version of python, running coverage tools, and running profiling tools.  i.e., these will not break with this change:

```console
$ python2 $(which spack) <args>
$ coverage run $(which spack) <args>
$ pyinstrument $(which spack) <args>
```

These would not work if we split `spack` into a python file and a shell script (see #11783).  So, this gives us the best of both worlds.  We get to control our interpreter *and* remain a mostly pure python executable.