### PR TITLE
add generic "darwin-x86_64" profile to microarchitectures.json

### DIFF
--- a/lib/spack/llnl/util/cpu/microarchitectures.json
+++ b/lib/spack/llnl/util/cpu/microarchitectures.json
@@ -860,6 +860,13 @@
       "features": [],
       "compilers": {
       }
+    },
+    "darwin-x86_64": {
+      "from": null,
+      "vendor": "generic",
+      "features": [],
+      "compilers": {
+      }
     }
   },
   "feature_aliases": {


### PR DESCRIPTION
Found another "missing" architecture that is currently causing package libaio to fail to install, e.g.:

```
==> Installing libaio
==> Searching for binary cache of libaio
==> Finding buildcaches in /bifx/apps/spack/mirror/build_cache
==> No binary for libaio found: installing from source
==> Fetching file:///bifx/apps/spack/mirror/libaio/libaio-0.3.110.tar.gz
==> Staging archive: /tmp/srv_bioinfo/spack-stage/libaio-0.3.110-pz3gbgpkgnzvxriadtzihnsbd5nqxzhy/libaio_0.3.110.orig.tar.gz
==> Created stage in /tmp/srv_bioinfo/spack-stage/libaio-0.3.110-pz3gbgpkgnzvxriadtzihnsbd5nqxzhy
==> No patches needed for libaio
==> Building libaio [Package]
==> Executing phase: 'install'
==> Error: ValueError: "darwin-x86_64" is not a valid target name
```

This PR is following the fix that @alalazo implemented in #12958

I would like to do a rip-grep through all spack packages to see if there are other cases that need to be added to this json file.... but won't have time to do this for a couple days.