### PR TITLE
go-md2man: disable module-mode

### DIFF
--- a/var/spack/repos/builtin/packages/go-md2man/package.py
+++ b/var/spack/repos/builtin/packages/go-md2man/package.py
@@ -37,7 +37,7 @@ class GoMd2man(Package):
 
         with working_dir('src'):
             env['GOPATH'] = self.stage.source_path
-            env['GO111MODULE'] = r'off'
+            env['GO111MODULE'] = 'off'
             go = which('go')
             go('build', '-v', join_path(
                'github.com', 'cpuguy83', 'go-md2man'))

--- a/var/spack/repos/builtin/packages/go-md2man/package.py
+++ b/var/spack/repos/builtin/packages/go-md2man/package.py
@@ -37,6 +37,7 @@ class GoMd2man(Package):
 
         with working_dir('src'):
             env['GOPATH'] = self.stage.source_path
+            env['GO111MODULE'] = r'off'
             go = which('go')
             go('build', '-v', join_path(
                'github.com', 'cpuguy83', 'go-md2man'))


### PR DESCRIPTION
This PR explicitly disables module-mode that only came to being for go >= 1.11.  The intent of this spack recipe is to explicitly download go-md2man's dependency and put it into place for the final build.  This PR fixes #12787.