### PR TITLE
libaio: check if platform=darwin, not arch

### DIFF
--- a/var/spack/repos/builtin/packages/libaio/package.py
+++ b/var/spack/repos/builtin/packages/libaio/package.py
@@ -16,7 +16,7 @@ class Libaio(Package):
 
     def install(self, spec, prefix):
         # libaio is not supported on OS X
-        if spec.satisfies('arch=darwin-x86_64'):
+        if spec.satisfies('platform=darwin'):
             # create a dummy directory
             mkdir(prefix.lib)
             return


### PR DESCRIPTION
Newer develop versions of spack fail with this syntax as follows:

`Error: ValueError: "darwin-x86_64" is not a valid target name`

This PR tests the `platform` instead of the `arch` to fix the issue, and be backwards compatible.