### PR TITLE
ADIOS2: 2.5.0

### DIFF
--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -16,6 +16,7 @@ class Adios2(CMakePackage):
     maintainers = ['ax3l', 'chuckatkins']
 
     version('develop', branch='master')
+    version('2.5.0', sha256='7c8ff3bf5441dd662806df9650c56a669359cb0185ea232ecb3578de7b065329')
     version('2.4.0', sha256='50ecea04b1e41c88835b4b3fd4e7bf0a0a2a3129855c9cc4ba6cf6a1575106e2')
     version('2.3.1', sha256='3bf81ccc20a7f2715935349336a76ba4c8402355e1dc3848fcd6f4c3c5931893')
     version('2.2.0', sha256='77058ea2ff7224dc02ea519733de42d89112cf21ffe7474fb2fa3c5696152948')


### PR DESCRIPTION
Add the latest ADIOS2 release, [v2.5.0](https://github.com/ornladios/ADIOS2/releases/tag/v2.5.0) .

@chuckatkins any changes in dependencies? `zfp` seams not to be found yet during configuration stage.