### PR TITLE
libcerf:add CFLAGS for fujitsu compiler

### DIFF
--- a/var/spack/repos/builtin/packages/libcerf/package.py
+++ b/var/spack/repos/builtin/packages/libcerf/package.py
@@ -25,5 +25,8 @@ class Libcerf(AutotoolsPackage):
         # http://clang.debian.net/status.php?version=3.8.1&key=UNUSED_FUNCTION
         if spec.satisfies('%clang'):
             options.append('CFLAGS=-Wno-unused-function')
+	# fujitsu compiler has a error about unused functions too.
+        if spec.satisfies('%fj'):
+            options.append('CFLAGS=-Wno-unused-function')
 
         return options

--- a/var/spack/repos/builtin/packages/libcerf/package.py
+++ b/var/spack/repos/builtin/packages/libcerf/package.py
@@ -25,7 +25,7 @@ class Libcerf(AutotoolsPackage):
         # http://clang.debian.net/status.php?version=3.8.1&key=UNUSED_FUNCTION
         if spec.satisfies('%clang'):
             options.append('CFLAGS=-Wno-unused-function')
-	# fujitsu compiler has a error about unused functions too.
+        # fujitsu compiler has a error about unused functions too.
         if spec.satisfies('%fj'):
             options.append('CFLAGS=-Wno-unused-function')
 


### PR DESCRIPTION
An error of unused functions occurs when building with Fujitsu compiler. Therefore, I added the same processing as Clang.