### PR TITLE
Improve robustness of target detection

### DIFF
--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -131,12 +131,11 @@ class Cray(Platform):
         '''Return a list of available CrayPE CPU targets.'''
 
         def modules_in_output(output):
-            """Return list of valid modules parsed from modulecmd output string."""
+            """Returns a list of valid modules parsed from modulecmd output"""
             return [i for i in re.split(r'  |\n', output)
                     if len(i.split()) == 1]
 
-        def target_names_from_modules(modules):    
-            """Extend CrayPE CPU targets list with those found in list of modules."""
+        def target_names_from_modules(modules):
             # Craype- module prefixes that are not valid CPU targets.
             targets = []
             non_targets = (
@@ -153,7 +152,7 @@ class Cray(Platform):
             if os.path.isdir(craype_default_path):
                 return os.listdir(craype_default_path)
             return None
-        
+
         if getattr(self, '_craype_targets', None) is None:
             strategies = [
                 lambda: modules_in_output(module('avail', '-t', 'craype-')),
@@ -168,6 +167,6 @@ class Cray(Platform):
             else:
                 # If nothing is found add platform.machine()
                 # to avoid Spack erroring out
-                self._craype_targets = [platform.machine()]            
-                
+                self._craype_targets = [platform.machine()]
+
         return self._craype_targets

--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -16,23 +16,6 @@ from spack.operating_systems.cnl import Cnl
 from spack.util.module_cmd import module
 
 
-def _get_modules_in_modulecmd_output(output):
-    '''Return list of valid modules parsed from modulecmd output string.'''
-    return [i for i in re.split(r'  |\n', output)
-            if len(i.split()) == 1]
-
-
-def _fill_craype_target_names_from_modules(targets, modules):
-    '''Extend CrayPE CPU targets list with those found in list of modules.'''
-    # Craype- module prefixes that are not valid CPU targets.
-    non_targets = (
-        'hugepages', 'network', 'target', 'accel', 'xtpe', 'dl-plugin')
-    pattern = r'craype-(?!{0})(\S*)'.format('|'.join(non_targets))
-    for mod in modules:
-        if 'craype-' in mod:
-            targets.extend(re.findall(pattern, mod))
-
-
 _craype_name_to_target_name = {
     'x86_cascadelake': 'cascadelake',
     'x86_naples': 'zen',
@@ -145,9 +128,29 @@ class Cray(Platform):
 
     def _avail_targets(self):
         '''Return a list of available CrayPE CPU targets.'''
+
+        def modules_in_output(output):
+            """Return list of valid modules parsed from modulecmd output string."""
+            return [i for i in re.split(r'  |\n', output)
+                    if len(i.split()) == 1]
+
+        def target_names_from_modules(modules):    
+            """Extend CrayPE CPU targets list with those found in list of modules."""
+            # Craype- module prefixes that are not valid CPU targets.
+            targets = []
+            non_targets = (
+                'hugepages', 'network', 'target', 'accel', 'xtpe', 'dl-plugin')
+            pattern = r'craype-(?!{0})(\S*)'.format('|'.join(non_targets))
+            for mod in modules:
+                if 'craype-' in mod:
+                    targets.extend(re.findall(pattern, mod))
+
+            return targets
+
+        
         if getattr(self, '_craype_targets', None) is None:
             output = module('avail', '-t', 'craype-')
-            craype_modules = _get_modules_in_modulecmd_output(output)
-            self._craype_targets = targets = []
-            _fill_craype_target_names_from_modules(targets, craype_modules)
+            craype_modules = modules_in_output(output)
+            self._craype_targets = target_names_from_modules(craype_modules)
+
         return self._craype_targets

--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import os.path
 import re
 import platform
 import llnl.util.cpu as cpu
@@ -147,10 +148,26 @@ class Cray(Platform):
 
             return targets
 
+        def modules_from_listdir():
+            craype_default_path = '/opt/cray/pe/craype/default/modulefiles'
+            if os.path.isdir(craype_default_path):
+                return os.listdir(craype_default_path)
+            return None
         
         if getattr(self, '_craype_targets', None) is None:
-            output = module('avail', '-t', 'craype-')
-            craype_modules = modules_in_output(output)
-            self._craype_targets = target_names_from_modules(craype_modules)
-
+            strategies = [
+                lambda: modules_in_output(module('avail', '-t', 'craype-')),
+                modules_from_listdir
+            ]
+            for available_craype_modules in strategies:
+                craype_modules = available_craype_modules()
+                craype_targets = target_names_from_modules(craype_modules)
+                if craype_targets:
+                    self._craype_targets = craype_targets
+                    break
+            else:
+                # If nothing is found add platform.machine()
+                # to avoid Spack erroring out
+                self._craype_targets = [platform.machine()]            
+                
         return self._craype_targets


### PR DESCRIPTION
The code doing detection employs two different strategies:
- Check the currently modules available
- Check the directory where module files are stored

The list of strategies can be extended easily in the future, if need be. If nothing is found the default is set to `platform.machine()`.