### PR TITLE
ZFP: CMake Package

### DIFF
--- a/var/spack/repos/builtin/packages/adios/package.py
+++ b/var/spack/repos/builtin/packages/adios/package.py
@@ -79,7 +79,7 @@ class Adios(AutotoolsPackage):
     depends_on('sz@:1.4.10', when='@:1.12.0 +sz')
     depends_on('sz@1.4.11.0:1.4.11.99', when='@1.13.0 +sz')
     depends_on('sz@1.4.12.3:1.4.12.99', when='@1.13.1: +sz')
-    depends_on('zfp@:0.5.0', when='+zfp')
+    depends_on('zfp@0.5.1:0.5.99', when='+zfp')
     depends_on('lz4', when='+lz4')
     depends_on('c-blosc@1.12.0:', when='+blosc')
     # optional transports & file converters
@@ -100,6 +100,10 @@ class Adios(AutotoolsPackage):
     #   https://github.com/ornladios/ADIOS/commit/3b21a8a41509
     #   https://github.com/spack/spack/issues/1683
     patch('adios_1100.patch', when='@:1.10.0^hdf5@1.10:')
+
+    # ADIOS 1.13.1 is written for ZFP 0.5.0 interfaces
+    #   https://github.com/ornladios/ADIOS/pull/204
+    patch('zfp051.patch', when='@1.11.0:1.13.1')
 
     def validate(self, spec):
         """Checks if incompatible variants have been activated at the same time

--- a/var/spack/repos/builtin/packages/adios/zfp051.patch
+++ b/var/spack/repos/builtin/packages/adios/zfp051.patch
@@ -1,0 +1,22 @@
+diff --git a/src/transforms/adios_transform_zfp_common.h b/src/transforms/adios_transform_zfp_common.h
+index e453d078..681198ee 100644
+--- a/src/transforms/adios_transform_zfp_common.h
++++ b/src/transforms/adios_transform_zfp_common.h
+@@ -146,7 +146,7 @@ static void zfp_initialize(void* array, struct zfp_buffer* zbuff)
+ 			zbuff->error = true;
+ 			return;
+ 		}
+-	       	zfp_stream_set_accuracy(zbuff->zstream, tol, zbuff->type);
++	       	zfp_stream_set_accuracy(zbuff->zstream, tol);
+ 	}
+ 	else if (zbuff->mode == 1) 	// precision
+ 	{
+@@ -172,7 +172,7 @@ static void zfp_initialize(void* array, struct zfp_buffer* zbuff)
+ 		tol = (uint) ct;
+ 
+ 
+-		zfp_stream_set_precision(zbuff->zstream, tol, zbuff->type);
++		zfp_stream_set_precision(zbuff->zstream, tol);
+ 	}
+ 	else if (zbuff->mode == 2) 	// rate
+ 	{

--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -94,7 +94,7 @@ class Adios2(CMakePackage):
     depends_on('bzip2', when='+bzip2')
     depends_on('libpng@1.6:', when='@2.4.0: +png')
     # depends_on('mgard', when='@2.3.0: +mgard')
-    depends_on('zfp', when='+zfp')
+    depends_on('zfp@0.5.1:', when='+zfp')
     # depends_on('sz@:1.4.12', when='+sz')
 
     extends('python', when='+python')

--- a/var/spack/repos/builtin/packages/zfp/package.py
+++ b/var/spack/repos/builtin/packages/zfp/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class Zfp(MakefilePackage):
+class Zfp(CMakePackage):
     """zfp is an open source C/C++ library for high-fidelity, high-throughput
        lossy compression of floating-point and integer multi-dimensional
        arrays.
@@ -15,10 +15,10 @@ class Zfp(MakefilePackage):
     homepage = 'http://computing.llnl.gov/projects/floating-point-compression'
     url      = 'http://computing.llnl.gov/projects/floating-point-compression/download/zfp-0.5.2.tar.gz'
 
+    version('0.5.5', sha256='fdf7b948bab1f4e5dccfe2c2048fd98c24e417ad8fb8a51ed3463d04147393c5')
     version('0.5.4', sha256='768a05ed9bf10e54ac306f90b81dd17b0e7b13782f01823d7da4394fd2da8adb')
-    version('0.5.2', '2f0a77aa34087219a6e10b8b7d031e77')
-    version('0.5.1', '0ed7059a9b480635e0dd33745e213d17')
-    version('0.5.0', '2ab29a852e65ad85aae38925c5003654')
+    version('0.5.2', sha256='89e718edb966422b5898b5c37b1b0a781d4effacb511520558469e3ff7f65d7c')
+    version('0.5.1', sha256='867c04cf965f1c70d9725b396c6e1b5d29db55b0d69b8e87a995aaebd221b830')
 
     variant('bsws',
             default='64',
@@ -30,37 +30,18 @@ class Zfp(MakefilePackage):
     variant('shared', default=True,
             description='Build shared versions of the library')
 
-    def edit(self, spec, prefix):
-        config_file = FileFilter('Config')
-        config_file.filter(
-            r'^\s*#\s*DEFS\s*\+=\s*-DBIT_STREAM_WORD_TYPE\s*=\s*uint8',
-            'DEFS += -DBIT_STREAM_WORD_TYPE=uint%s' %
-            spec.variants['bsws'].value)
+    depends_on('cmake@3.4.0:', type='build')
 
-    def build(self, spec, prefix):
-        with working_dir('src'):
-            if '~shared' in spec:
-                make('static')
-            else:
-                make('shared')
+    def cmake_args(self):
+        spec = self.spec
 
-    def install(self, spec, prefix):
-        incdir = 'include' if spec.satisfies('@0.5.1:') else 'inc'
+        args = [
+            '-DBUILD_SHARED_LIBS:BOOL={0}'.format(
+                'ON' if '+shared' in spec else 'OFF'),
+            '-DZFP_BIT_STREAM_WORD_SIZE:STRING={0}'.format(
+                spec.variants['bsws'].value),
+            '-DBUILD_TESTING:BOOL={0}'.format(
+                'ON' if self.run_tests else 'OFF')
+        ]
 
-        # Note: ZFP package does not provide an install target
-        mkdirp(prefix.lib)
-        mkdirp(prefix.include)
-        # Note: ZFP package builds .so files even on OSX
-        if '~shared' in spec:
-            install('lib/libzfp.a', prefix.lib)
-        else:
-            install('lib/libzfp.so', prefix.lib)
-        install('%s/zfp.h' % incdir, prefix.include)
-        install('%s/bitstream.h' % incdir, prefix.include)
-        if spec.satisfies('@0.5.1:'):
-            mkdirp('%s/zfp' % prefix.include)
-            install('%s/zfp/system.h' % incdir, '%s/zfp' % prefix.include)
-            install('%s/zfp/types.h' % incdir, '%s/zfp' % prefix.include)
-        else:
-            install('%s/types.h' % incdir, prefix.include)
-            install('%s/system.h' % incdir, prefix.include)
+        return args

--- a/var/spack/repos/builtin/packages/zfp/package.py
+++ b/var/spack/repos/builtin/packages/zfp/package.py
@@ -26,7 +26,16 @@ class Zfp(CMakePackage):
             multi=False,
             description='Bit stream word size: use smaller for finer '
             'rate granularity. Use 8 for H5Z-ZFP filter.')
-
+    variant('strided', default=False,
+            description='Enable strided access for progressive zfp streams')
+    variant('aligned', default=False,
+            description='Enable aligned memory allocation')
+    variant('twoway', default=False,
+            description='Use two-way skew-associative cache')
+    variant('fasthash', default=False,
+            description='Use a faster but more collision prone hash function')
+    variant('profile', default=False,
+            description='Count cache misses')
     variant('shared', default=True,
             description='Build shared versions of the library')
 
@@ -36,12 +45,23 @@ class Zfp(CMakePackage):
         spec = self.spec
 
         args = [
-            '-DBUILD_SHARED_LIBS:BOOL={0}'.format(
-                'ON' if '+shared' in spec else 'OFF'),
             '-DZFP_BIT_STREAM_WORD_SIZE:STRING={0}'.format(
                 spec.variants['bsws'].value),
+            '-DZFP_WITH_BIT_STREAM_STRIDED:BOOL={0}'.format(
+                'ON' if '+strided' in spec else 'OFF'),
+            '-DZFP_WITH_ALIGNED_ALLOC:BOOL={0}'.format(
+                'ON' if '+aligned' in spec else 'OFF'),
+            '-DZFP_WITH_CACHE_TWOWAY:BOOL={0}'.format(
+                'ON' if '+twoway' in spec else 'OFF'),
+            '-DBUILD_SHARED_LIBS:BOOL={0}'.format(
+                'ON' if '+shared' in spec else 'OFF'),
             '-DBUILD_TESTING:BOOL={0}'.format(
                 'ON' if self.run_tests else 'OFF')
         ]
+        if spec.version >= Version('0.5.2'):
+            args.append('-DZFP_WITH_CACHE_FAST_HASH:BOOL={0}'.format(
+                'ON' if '+fasthash' in spec else 'OFF'))
+            args.append('-DZFP_WITH_CACHE_PROFILE:BOOL={0}'.format(
+                'ON' if '+profile' in spec else 'OFF'))
 
         return args


### PR DESCRIPTION
ZFP is primarily build via CMake, which will have all install logic and configuration files generated.
The 0.5.0 release did not support this yet, so we toss it.

Fix #12998

cc @markcmiller86 @michaelkuhn 

## Install Tests

- [x] ZFP 0.5.1-0.5.5
- [x] ADIOS 1.13.1 https://github.com/ornladios/ADIOS/issues/203
- [x] ADIOS2 2.4.0 & 2.5.0
- [x] h5z-zfp 0.8.0 (^hdf5@1.10.5)
- [x] ecp-viz-sdk 1.0 (+zfp)
- [x] savanna https://github.com/ornladios/ADIOS/issues/203 #13001
- [x] macsio 1.1 (+zfp)