### PR TITLE
Gcc package: setup environment bug when installing

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -426,6 +426,10 @@ class Gcc(AutotoolsPackage):
 
         # Get the contents of the installed binary directory
         bin_path = self.spec.prefix.bin
+
+        if not os.path.isdir(bin_path):
+            return
+
         bin_contents = os.listdir(bin_path)
 
         # Find the first non-symlink compiler binary present for each language


### PR DESCRIPTION
https://github.com/spack/spack/pull/12454 (7bcb306) updated `setup_environment` in the GCC package to examine the bin/ directory to find alternatively-named instances of CC but this failed to account for when GCC was being installed and failed when it attempted to list the not-yet-existing installation prefix.

This problem would also be addressed by https://github.com/spack/spack/pull/11115