### PR TITLE
Dataspaces: Fix Fetch URL, Savanna Spec

### DIFF
--- a/var/spack/repos/builtin/packages/dataspaces/package.py
+++ b/var/spack/repos/builtin/packages/dataspaces/package.py
@@ -19,7 +19,7 @@ class Dataspaces(AutotoolsPackage):
     """an extreme scale data management framework."""
 
     homepage = "http://www.dataspaces.org"
-    url      = "http://personal.cac.rutgers.edu/TASSL/projects/data/downloads/dataspaces-1.6.2.tar.gz"
+    url      = "https://dataspaces.rdi2.rutgers.edu/downloads/dataspaces-1.6.2.tar.gz"
     git      = "https://github.com/melrom/dataspaces.git"
 
     version('develop', branch='master')

--- a/var/spack/repos/builtin/packages/savanna/package.py
+++ b/var/spack/repos/builtin/packages/savanna/package.py
@@ -21,7 +21,7 @@ class Savanna(MakefilePackage):
 
     depends_on('mpi')
     depends_on('stc')
-    depends_on('adios +fortran +zlib +sz +zfp +staging')
+    depends_on('adios +fortran +zlib +sz +zfp staging=dataspaces')  # flexpath
     depends_on('mpix-launch-swift')
     depends_on('tau', when='+tau')
 


### PR DESCRIPTION
Fix new URL for dataspaces.

Savanna has some other issues in dependencies besides its broken spec, which I am not addressing.