### PR TITLE
Singularity 3.4.1 still needs the makefile patch

### DIFF
--- a/var/spack/repos/builtin/packages/singularity/package.py
+++ b/var/spack/repos/builtin/packages/singularity/package.py
@@ -41,7 +41,7 @@ class Singularity(MakefilePackage):
     depends_on('shadow', type='run', when='@3.3:')
     depends_on('cryptsetup', type=('build', 'run'), when='@3.4:')
 
-    patch('singularity_v3.4.0_remove_root_check.patch', level=0, when='@3.4.0:')
+    patch('singularity_v3.4.0_remove_root_check.patch', level=0, when='@3.4.0:3.4.1')
 
     # Go has novel ideas about how projects should be organized.
     # We'll point GOPATH at the stage dir, and move the unpacked src

--- a/var/spack/repos/builtin/packages/singularity/package.py
+++ b/var/spack/repos/builtin/packages/singularity/package.py
@@ -41,7 +41,7 @@ class Singularity(MakefilePackage):
     depends_on('shadow', type='run', when='@3.3:')
     depends_on('cryptsetup', type=('build', 'run'), when='@3.4:')
 
-    patch('singularity_v3.4.0_remove_root_check.patch', level=0, when='@3.4.0')
+    patch('singularity_v3.4.0_remove_root_check.patch', level=0, when='@3.4.0:')
 
     # Go has novel ideas about how projects should be organized.
     # We'll point GOPATH at the stage dir, and move the unpacked src


### PR DESCRIPTION
#12995 broke the singularity build, at least for non-root users:

```
[+] /home/ghartzell/tmp/spack-direnv-update/spack/opt/spack/linux-centos7-skylake_avx512/gcc-8.2.0/squashfs-4.3-3bq655rauqfz4uvlcqdm7axs3szla7ir
==> Installing singularity
==> Searching for binary cache of singularity
==> Warning: No Spack mirrors are currently configured
==> No binary for singularity found: installing from source
==> Fetching https://github.com/sylabs/singularity/releases/download/v3.4.1/singularity-3.4.1.tar.gz
###################################################################################################################################################################################### 100.0%
==> Staging archive: /tmp/ghartzell/spack-stage/singularity-3.4.1-pzr4a77jsakpga6yl3oiwj2ndjplmbcz/singularity-3.4.1.tar.gz
==> Created stage in /tmp/ghartzell/spack-stage/singularity-3.4.1-pzr4a77jsakpga6yl3oiwj2ndjplmbcz
==> No patches needed for singularity
==> Building singularity [MakefilePackage]
==> Executing phase: 'edit'
==> Executing phase: 'build'
==> Executing phase: 'install'
==> Error: ProcessError: Command exited with status 2:
    'make' '-j16' 'install' '-C' 'builddir' 'parallel=False'

1 error found in build log:
     137     INSTALL /home/ghartzell/tmp/spack-direnv-update/spack/opt/spack/linux-centos7-skylake_avx512/gcc-8.2.0/singularity-3.4.1-pzr4a77jsakpga6yl3oiwj2ndjplmbcz/etc/singularity/ecl.t
            oml
     138     INSTALL /home/ghartzell/tmp/spack-direnv-update/spack/opt/spack/linux-centos7-skylake_avx512/gcc-8.2.0/singularity-3.4.1-pzr4a77jsakpga6yl3oiwj2ndjplmbcz/etc/singularity/actio
            ns
     139     INSTALL /home/ghartzell/tmp/spack-direnv-update/spack/opt/spack/linux-centos7-skylake_avx512/gcc-8.2.0/singularity-3.4.1-pzr4a77jsakpga6yl3oiwj2ndjplmbcz/etc/singularity/secco
            mp-profiles/default.json
     140     INSTALL /home/ghartzell/tmp/spack-direnv-update/spack/opt/spack/linux-centos7-skylake_avx512/gcc-8.2.0/singularity-3.4.1-pzr4a77jsakpga6yl3oiwj2ndjplmbcz/etc/singularity/nvlib
            list.conf
     141     INSTALL /home/ghartzell/tmp/spack-direnv-update/spack/opt/spack/linux-centos7-skylake_avx512/gcc-8.2.0/singularity-3.4.1-pzr4a77jsakpga6yl3oiwj2ndjplmbcz/etc/singularity/cgrou
            ps/cgroups.toml
     142    SUID binary requires to execute make install as root, use sudo make install to finish installation
  >> 143    make: *** [/home/ghartzell/tmp/spack-direnv-update/spack/opt/spack/linux-centos7-skylake_avx512/gcc-8.2.0/singularity-3.4.1-pzr4a77jsakpga6yl3oiwj2ndjplmbcz/libexec/singularity
            /bin/starter-suid] Error 1
     144    make: *** Waiting for unfinished jobs....
     145    make: Leaving directory `/tmp/ghartzell/spack-stage/singularity-3.4.1-pzr4a77jsakpga6yl3oiwj2ndjplmbcz/src/github.com/sylabs/singularity/builddir'

See build log for details:
  /tmp/ghartzell/spack-stage/singularity-3.4.1-pzr4a77jsakpga6yl3oiwj2ndjplmbcz/spack-build-out.txt

```

It seems that we need to apply the patch for 3.4.0 to this version also.