### PR TITLE
ants: missing zlib dependency and fix working directory in install.

### DIFF
--- a/var/spack/repos/builtin/packages/ants/package.py
+++ b/var/spack/repos/builtin/packages/ants/package.py
@@ -20,8 +20,13 @@ class Ants(CMakePackage):
 
     version('2.2.0', '5661b949268100ac0f7baf6d2702b4dd')
 
+    depends_on('zlib', type='link')
+
     def install(self, spec, prefix):
-        with working_dir(join_path('spack-build', 'ANTS-build'), create=False):
+        with working_dir(
+                join_path(self.build_directory, 'ANTS-build'),
+                create=False
+        ):
             make("install")
         install_tree('Scripts', prefix.bin)
 


### PR DESCRIPTION
* ants use zlib but ependency is missing.
* install() asummes package stage directory is current directory, but the current directory is source directory in current spack version, so I specify working directory to use self.build_directory.