### PR TITLE
Added NEON to the list of features required for the aarch64 family

### DIFF
--- a/lib/spack/llnl/util/cpu/microarchitectures.json
+++ b/lib/spack/llnl/util/cpu/microarchitectures.json
@@ -897,6 +897,12 @@
       "any_of": [
         "sse4_2"
       ]
+    },
+    "neon": {
+      "reason": "NEON is required in all standard ARMv8 implementations",
+      "families": [
+        "aarch64"
+      ]
     }
   }
 }

--- a/lib/spack/spack/test/llnl/util/cpu.py
+++ b/lib/spack/spack/test/llnl/util/cpu.py
@@ -156,6 +156,7 @@ def test_architecture_family(target_name, expected_family):
     ('skylake', 'sse3'),
     ('power8', 'altivec'),
     ('broadwell', 'sse4.1'),
+    ('aarch64', 'neon')
 ])
 def test_features_query(target_name, feature):
     target = llnl.util.cpu.targets[target_name]


### PR DESCRIPTION
Both floating-point and NEON are required in all standard ARMv8 implementations. Theoretically 
 though specialized markets can support no NEON or floating-point at all. Source for this info [here](https://developer.arm.com/docs/den0024/latest/aarch64-floating-point-and-neon).

On the other hand the base procedure call standard for Aarch64:

> assumes the availability of the vector registers for passing floating-point and SIMD arguments. 

Further:
> the Arm 64-bit architecture defines two mandatory register banks: a general-purpose register bank which can be used for scalar integer processing and pointer arithmetic; and a SIMD and Floating-Point register bank".

Source for this info [here](https://developer.arm.com/docs/ihi0055/latest/procedure-call-standard-for-the-arm-64-bit-architecture).

This makes customization of Aarch64 with no NEON instructions available so unlikely that we can probably consider them a feature of the generic family. 

@fspiga @t-karatsu 