### PR TITLE
breseq: fix dependency and limit compiler version.

### DIFF
--- a/var/spack/repos/builtin/packages/breseq/package.py
+++ b/var/spack/repos/builtin/packages/breseq/package.py
@@ -22,10 +22,13 @@ class Breseq(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('libtool', type='build')
     depends_on('m4', type='build')
-    depends_on('zlib', type='build')
+    depends_on('zlib', type='link')
 
     depends_on('bedtools2', type='run')
     depends_on('r', type='run')
+
+    conflicts('%gcc@:4.8')
+    conflicts('%clang@:3.3')
 
     def setup_environment(self, spack_env, run_env):
         spack_env.set('LDFLAGS',


### PR DESCRIPTION
* zlib dependency is fixed from build to link
* conflict unsupported gcc and clang version