### PR TITLE
cnpy: add zlib dependency.

### DIFF
--- a/var/spack/repos/builtin/packages/cnpy/package.py
+++ b/var/spack/repos/builtin/packages/cnpy/package.py
@@ -16,6 +16,8 @@ class Cnpy(CMakePackage):
 
     version('master', branch='master')
 
+    depends_on('zlib', type='link')
+
     def cmake_args(self):
         args = []
         if sys.platform == 'darwin':


### PR DESCRIPTION
cnpy use zlib, but dependency is missin.
This PR add zlib dependency on cnpy.