### PR TITLE
denovogear: Add missing zlib depenbdency and fix open handling error.

### DIFF
--- a/var/spack/repos/builtin/packages/denovogear/package.py
+++ b/var/spack/repos/builtin/packages/denovogear/package.py
@@ -22,3 +22,6 @@ class Denovogear(CMakePackage):
     depends_on('boost@1.47:1.60', type=('build'))
     depends_on('htslib@1.2:', type=('build'))
     depends_on('eigen', type=('build'))
+    depends_on('zlib', type=('link'))
+
+    patch('stream-open.patch', when='@:1.1.1')

--- a/var/spack/repos/builtin/packages/denovogear/stream-open.patch
+++ b/var/spack/repos/builtin/packages/denovogear/stream-open.patch
@@ -1,0 +1,12 @@
+diff -ru spack-src.org/src/dng-dnm.cc spack-src/src/dng-dnm.cc
+--- spack-src.org/src/dng-dnm.cc	2015-04-21 09:16:59.000000000 +0900
++++ spack-src/src/dng-dnm.cc	2019-10-02 15:08:28.892042247 +0900
+@@ -161,7 +161,7 @@
+ int writeVCFHeader(std::ofstream& fo_vcf, string op_vcf_f, string bcf_file, string ped_file, string sample)
+ {
+   fo_vcf.open(op_vcf_f.c_str());
+-  if(fo_vcf == NULL) {
++  if(fo_vcf.fail()) {
+     cerr<<"Unable to open vcf file for writing output. Exiting !"<<endl;
+   }
+   fo_vcf<<"##fileformat=VCFv4.1\n";


### PR DESCRIPTION
* denovogear use zlib, but zlib dependency is missing
* Fix code to file open is failed.