### PR TITLE
Add EasyBuild 4.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/easybuild/package.py
+++ b/var/spack/repos/builtin/packages/easybuild/package.py
@@ -12,10 +12,16 @@ class Easybuild(PythonPackage):
     """
 
     homepage = 'http://hpcugent.github.io/easybuild/'
-    url      = 'https://pypi.io/packages/source/e/easybuild/easybuild-3.1.2.tar.gz'
+    url      = 'https://pypi.io/packages/source/e/easybuild/easybuild-4.0.0.tar.gz'
+    maintainers = ['boegel']
 
+    version('4.0.0', sha256='21bcc1048525ad6219667cc97a7421b5388068c670cabba356712e474896de40')
     version('3.1.2', 'c2d901c2a71f51b24890fa69c3a46383')
 
-    depends_on('py-easybuild-framework@3.1.2', when='@3.1.2', type='run')
-    depends_on('py-easybuild-easyblocks@3.1.2', when='@3.1.2', type='run')
-    depends_on('py-easybuild-easyconfigs@3.1.2', when='@3.1.2', type='run')
+    depends_on('python@2.6:2.8', when='@:3', type=('build', 'run'))
+    depends_on('python@2.6:2.8,3.5:', when='@4:', type=('build', 'run'))
+
+    for v in ['@4.0.0', '@3.1.2']:
+        depends_on('py-easybuild-framework'   + v, when=v, type='run')
+        depends_on('py-easybuild-easyblocks'  + v, when=v, type='run')
+        depends_on('py-easybuild-easyconfigs' + v, when=v, type='run')

--- a/var/spack/repos/builtin/packages/easybuild/package.py
+++ b/var/spack/repos/builtin/packages/easybuild/package.py
@@ -11,7 +11,7 @@ class Easybuild(PythonPackage):
     for (scientific) software on HPC systems.
     """
 
-    homepage = 'http://hpcugent.github.io/easybuild/'
+    homepage = 'https://easybuilders.github.io/easybuild/'
     url      = 'https://pypi.io/packages/source/e/easybuild/easybuild-4.0.0.tar.gz'
     maintainers = ['boegel']
 

--- a/var/spack/repos/builtin/packages/py-easybuild-easyblocks/package.py
+++ b/var/spack/repos/builtin/packages/py-easybuild-easyblocks/package.py
@@ -12,8 +12,14 @@ class PyEasybuildEasyblocks(PythonPackage):
     """
 
     homepage = 'http://hpcugent.github.io/easybuild/'
-    url      = 'https://pypi.io/packages/source/e/easybuild-easyblocks/easybuild-easyblocks-3.1.2.tar.gz'
+    url      = 'https://pypi.io/packages/source/e/easybuild-easyblocks/easybuild-easyblocks-4.0.0.tar.gz'
+    maintainers = ['boegel']
 
+    version('4.0.0', sha256='a0fdef6c33c786e323bde1b28bab942fd8e535c26842877d705e692e85b31b07')
     version('3.1.2', 'be08da30c07e67ed3e136e8d38905fbc')
 
-    depends_on('py-easybuild-framework@3.1:', when='@3.1:', type='run')
+    depends_on('python@2.6:2.8', when='@:3', type=('build', 'run'))
+    depends_on('python@2.6:2.8,3.5:', when='@4:', type=('build', 'run'))
+
+    for v in ['@3.1:', '@4.0:']:
+        depends_on('py-easybuild-framework' + v, when=v, type='run')

--- a/var/spack/repos/builtin/packages/py-easybuild-easyblocks/package.py
+++ b/var/spack/repos/builtin/packages/py-easybuild-easyblocks/package.py
@@ -11,7 +11,7 @@ class PyEasybuildEasyblocks(PythonPackage):
     installation framework for (scientific) software on HPC systems.
     """
 
-    homepage = 'http://hpcugent.github.io/easybuild/'
+    homepage = 'https://easybuilders.github.io/easybuild'
     url      = 'https://pypi.io/packages/source/e/easybuild-easyblocks/easybuild-easyblocks-4.0.0.tar.gz'
     maintainers = ['boegel']
 
@@ -21,5 +21,5 @@ class PyEasybuildEasyblocks(PythonPackage):
     depends_on('python@2.6:2.8', when='@:3', type=('build', 'run'))
     depends_on('python@2.6:2.8,3.5:', when='@4:', type=('build', 'run'))
 
-    for v in ['@3.1:', '@4.0:']:
+    for v in ['@3.1.2:', '@4.0.0:']:
         depends_on('py-easybuild-framework' + v, when=v, type='run')

--- a/var/spack/repos/builtin/packages/py-easybuild-easyblocks/package.py
+++ b/var/spack/repos/builtin/packages/py-easybuild-easyblocks/package.py
@@ -21,5 +21,5 @@ class PyEasybuildEasyblocks(PythonPackage):
     depends_on('python@2.6:2.8', when='@:3', type=('build', 'run'))
     depends_on('python@2.6:2.8,3.5:', when='@4:', type=('build', 'run'))
 
-    for v in ['@3.1.2:', '@4.0.0:']:
+    for v in ['@3.1.2', '@4.0.0']:
         depends_on('py-easybuild-framework' + v, when=v, type='run')

--- a/var/spack/repos/builtin/packages/py-easybuild-easyconfigs/package.py
+++ b/var/spack/repos/builtin/packages/py-easybuild-easyconfigs/package.py
@@ -11,7 +11,7 @@ class PyEasybuildEasyconfigs(PythonPackage):
     installation framework for (scientific) software on HPC systems.
     """
 
-    homepage = 'http://hpcugent.github.io/easybuild/'
+    homepage = 'https://easybuilders.github.io/easybuild'
     url      = 'https://pypi.io/packages/source/e/easybuild-easyconfigs/easybuild-easyconfigs-4.0.0.tar.gz'
     maintainers = ['boegel']
 
@@ -21,7 +21,6 @@ class PyEasybuildEasyconfigs(PythonPackage):
     depends_on('python@2.6:2.8', when='@:3', type=('build', 'run'))
     depends_on('python@2.6:2.8,3.5:', when='@4:', type=('build', 'run'))
 
-    for v in ['@3.1:', '@4.0:']:
-        depends_on('py-easybuild-framework' + v, when=v, type='run')
     for v in ['@3.1.2', '@4.0.0']:
+        depends_on('py-easybuild-framework{0}:'.format(v), when=v + ':', type='run')
         depends_on('py-easybuild-easyblocks{0}:'.format(v), when=v, type='run')

--- a/var/spack/repos/builtin/packages/py-easybuild-easyconfigs/package.py
+++ b/var/spack/repos/builtin/packages/py-easybuild-easyconfigs/package.py
@@ -12,9 +12,16 @@ class PyEasybuildEasyconfigs(PythonPackage):
     """
 
     homepage = 'http://hpcugent.github.io/easybuild/'
-    url      = 'https://pypi.io/packages/source/e/easybuild-easyconfigs/easybuild-easyconfigs-3.1.2.tar.gz'
+    url      = 'https://pypi.io/packages/source/e/easybuild-easyconfigs/easybuild-easyconfigs-4.0.0.tar.gz'
+    maintainers = ['boegel']
 
+    version('4.0.0', sha256='90d4e8f8abb11e7ae2265745bbd1241cd69d02570e9b4530175c4b2e2aba754e')
     version('3.1.2', '13a4a97fe8a5b9a94f885661cf497d13')
 
-    depends_on('py-easybuild-framework@3.1:', when='@3.1:', type='run')
-    depends_on('py-easybuild-easyblocks@3.1.2:', when='@3.1.2', type='run')
+    depends_on('python@2.6:2.8', when='@:3', type=('build', 'run'))
+    depends_on('python@2.6:2.8,3.5:', when='@4:', type=('build', 'run'))
+
+    for v in ['@3.1:', '@4.0:']:
+        depends_on('py-easybuild-framework' + v, when=v, type='run')
+    for v in ['@3.1.2', '@4.0.0']:
+        depends_on('py-easybuild-easyblocks{0}:'.format(v), when=v, type='run')

--- a/var/spack/repos/builtin/packages/py-easybuild-framework/package.py
+++ b/var/spack/repos/builtin/packages/py-easybuild-framework/package.py
@@ -11,7 +11,7 @@ class PyEasybuildFramework(PythonPackage):
     for (scientific) software on HPC systems.
     """
 
-    homepage = 'http://hpcugent.github.io/easybuild/'
+    homepage = 'https://easybuilders.github.io/easybuild'
     url      = 'https://pypi.io/packages/source/e/easybuild-framework/easybuild-framework-4.0.0.tar.gz'
     maintainers = ['boegel']
 
@@ -21,5 +21,7 @@ class PyEasybuildFramework(PythonPackage):
     depends_on('python@2.6:2.8', when='@:3', type=('build', 'run'))
     depends_on('python@2.6:2.8,3.5:', when='@4:', type=('build', 'run'))
     depends_on('py-setuptools', when='@:3', type=('build', 'run'))
-    depends_on('py-vsc-base@2.5.4:', when='@2.9:', type='run')
-    depends_on('py-vsc-install', type='test')  # only required for tests (python -O -m test.framework.suite)
+    depends_on('py-vsc-base@2.5.4:', when='@2.9:3', type='run')
+
+    # Only required for tests (python -O -m test.framework.suite)
+    depends_on('py-vsc-install', when='@:3', type='test')

--- a/var/spack/repos/builtin/packages/py-easybuild-framework/package.py
+++ b/var/spack/repos/builtin/packages/py-easybuild-framework/package.py
@@ -12,11 +12,14 @@ class PyEasybuildFramework(PythonPackage):
     """
 
     homepage = 'http://hpcugent.github.io/easybuild/'
-    url      = 'https://pypi.io/packages/source/e/easybuild-framework/easybuild-framework-3.1.2.tar.gz'
+    url      = 'https://pypi.io/packages/source/e/easybuild-framework/easybuild-framework-4.0.0.tar.gz'
+    maintainers = ['boegel']
 
+    version('4.0.0', sha256='f5c40345cc8b9b5750f53263ade6c9c3a8cd3dfab488d58f76ac61a8ca7c5a77')
     version('3.1.2', '283bc5f6bdcb90016b32986d52fd04a8')
 
-    depends_on('python@2.6:2.8', type='run')
-    depends_on('py-setuptools', type=('build', 'run'))
+    depends_on('python@2.6:2.8', when='@:3', type=('build', 'run'))
+    depends_on('python@2.6:2.8,3.5:', when='@4:', type=('build', 'run'))
+    depends_on('py-setuptools', when='@:3', type=('build', 'run'))
     depends_on('py-vsc-base@2.5.4:', when='@2.9:', type='run')
-    depends_on('py-vsc-install', type='run')  # only required for tests (python -O -m test.framework.suite)
+    depends_on('py-vsc-install', type='test')  # only required for tests (python -O -m test.framework.suite)


### PR DESCRIPTION
Congratulations to EasyBuild for their big 4.0 release!

Among other things, EasyBuild 4.0 adds Python 3 support. As EasyBuild was one of the few remaining Spack packages that required Python 2, I took the liberty of updating to the latest version.

@boegel can you review this?