### PR TITLE
fastqvalidator: add zlib dependency and  Removes erroneous deletes in Chromosome

### DIFF
--- a/var/spack/repos/builtin/packages/fastqvalidator/chromosome.patch
+++ b/var/spack/repos/builtin/packages/fastqvalidator/chromosome.patch
@@ -1,0 +1,26 @@
+commit 3a10afe08c209dbacc3eca7794a5a8c0a42ee566
+Author: jonathonl <jonathonl@users.noreply.github.com>
+Date:   Thu Sep 20 11:57:06 2018 -0400
+
+    Removes erroneous deletes in Chromosome constructor.
+
+diff --git a/general/Chromosome.cpp b/general/Chromosome.cpp
+index ac2ff5c..2d773e8 100644
+--- a/general/Chromosome.cpp
++++ b/general/Chromosome.cpp
+@@ -27,7 +27,6 @@ Chromosome::Chromosome(GenomeSequence* gs, const char* chromosomeName)
+ Chromosome::Chromosome(const char* genomseSequenceFileName, unsigned int chromosomeIndex, bool isColorSpace) 
+ {
+     std::string s(genomseSequenceFileName);
+-    if (this->gs) delete gs;
+     gs = new GenomeSequence;
+     assert(gs);
+     gs->setReferenceName(s);
+@@ -39,7 +38,6 @@ Chromosome::Chromosome(const char* genomseSequenceFileName, unsigned int chromos
+ 
+ Chromosome::Chromosome(const std::string& genomseSequenceFileName, unsigned int chromosomeIndex, bool isColorSpace) 
+ {
+-    if (this->gs) delete gs;
+     gs = new GenomeSequence;
+     assert(gs);
+     gs->setReferenceName(genomseSequenceFileName);

--- a/var/spack/repos/builtin/packages/fastqvalidator/package.py
+++ b/var/spack/repos/builtin/packages/fastqvalidator/package.py
@@ -20,6 +20,9 @@ class Fastqvalidator(MakefilePackage):
         commit='9db9c23e176a6ce6f421a3c21ccadedca892ac0c'
     )
 
+    depends_on('zlib', type='link')
+    patch('chromosome.patch', when='@2017-01-10', working_dir='libStatGen')
+
     @property
     def build_targets(self):
         return ['LIB_PATH_GENERAL={0}'.format(


### PR DESCRIPTION
* fastqvalidator use zlib, but dependency is missing. This PR add zlib dependency.
* fastqvalidaor cannot build to erroneous deletes in Chromosome constructor.  This PR backport to upstream commit https://github.com/statgen/libStatGen/commit/3a10afe08c209dbacc3eca7794a5a8c0a42ee566