### PR TITLE
hapcut2: add zlib dependency.

### DIFF
--- a/var/spack/repos/builtin/packages/hapcut2/package.py
+++ b/var/spack/repos/builtin/packages/hapcut2/package.py
@@ -17,6 +17,8 @@ class Hapcut2(MakefilePackage):
     version('2017-07-10', commit='2966b94c2c2f97813b757d4999b7a6471df1160e',
             submodules=True)
 
+    depends_on('zlib', type='link')
+
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
         with working_dir('build'):


### PR DESCRIPTION
hapcut2 use zlib but dependency is missing, This PR add zlib dependency to hapcut2.