### PR TITLE
liblbxutil: Add zlib dependency.

### DIFF
--- a/var/spack/repos/builtin/packages/liblbxutil/package.py
+++ b/var/spack/repos/builtin/packages/liblbxutil/package.py
@@ -18,6 +18,7 @@ class Liblbxutil(AutotoolsPackage):
     depends_on('xproto', type='build')
     depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
+    depends_on('zlib', type='link')
 
     # There is a bug in the library that causes the following messages:
     # undefined symbol: Xfree


### PR DESCRIPTION
liblbxutil use zlib but dependency is missing.
This PR add zlib dependency on liblbxutil.