### PR TITLE
metabat: Add zlib and ncurses dependency.

### DIFF
--- a/var/spack/repos/builtin/packages/metabat/package.py
+++ b/var/spack/repos/builtin/packages/metabat/package.py
@@ -18,6 +18,8 @@ class Metabat(SConsPackage):
 
     depends_on('boost@1.55.0:', type=('build', 'run'))
     depends_on('perl', type='run')
+    depends_on('zlib', type='link')
+    depends_on('ncurses', type='link')
 
     def setup_environment(self, spack_env, run_env):
         spack_env.set('BOOST_ROOT', self.spec['boost'].prefix)


### PR DESCRIPTION
metabat use curses and zlib, but missing dependency.
This PR add ncurses and  zlib dependency on metabat.