### PR TITLE
migrate: add zlib dependency.

### DIFF
--- a/var/spack/repos/builtin/packages/migrate/package.py
+++ b/var/spack/repos/builtin/packages/migrate/package.py
@@ -28,8 +28,9 @@ class Migrate(AutotoolsPackage):
     depends_on('openmpi', type=('build', 'link', 'run'), when='+mpi')
 
     configure_directory = 'src'
+
     def configure_args(self):
-        return  ['--with-zlib=system']
+        return ['--with-zlib=system']
 
     def build(self, spec, prefix):
         with working_dir('src'):

--- a/var/spack/repos/builtin/packages/migrate/package.py
+++ b/var/spack/repos/builtin/packages/migrate/package.py
@@ -23,10 +23,13 @@ class Migrate(AutotoolsPackage):
     depends_on('automake')
     depends_on('libtool')
     depends_on('m4')
+    depends_on('zlib', type='link')
 
     depends_on('openmpi', type=('build', 'link', 'run'), when='+mpi')
 
     configure_directory = 'src'
+    def configure_args(self):
+        return  ['--with-zlib=system']
 
     def build(self, spec, prefix):
         with working_dir('src'):

--- a/var/spack/repos/builtin/packages/migrate/package.py
+++ b/var/spack/repos/builtin/packages/migrate/package.py
@@ -19,10 +19,10 @@ class Migrate(AutotoolsPackage):
     variant('mpi', default=False,
             description='Build MPI binaries')
 
-    depends_on('autoconf')
-    depends_on('automake')
-    depends_on('libtool')
-    depends_on('m4')
+    depends_on('autoconf', type='build')
+    depends_on('automake', type='build')
+    depends_on('libtool', type='build')
+    depends_on('m4', type='build')
     depends_on('zlib', type='link')
 
     depends_on('openmpi', type=('build', 'link', 'run'), when='+mpi')


### PR DESCRIPTION
migrate use zlib.
If zlib is not found, migrate is compiled zlib.
Currentry zlib dependency is missing.
TRhis PR add zlib dependency, and use the library.
