### PR TITLE
muse: add zlib dependency.

### DIFF
--- a/var/spack/repos/builtin/packages/muse/package.py
+++ b/var/spack/repos/builtin/packages/muse/package.py
@@ -14,6 +14,8 @@ class Muse(MakefilePackage):
 
     version('1.0-rc', 'c63fdb48c041f6f9545879f1a7e4da58')
 
+    depends_on('zlib', type='link')
+
     def install(self, spec, prefix):
         mkdir(prefix.bin)
         install('MuSE', prefix.bin.MuSE)


### PR DESCRIPTION
muse use zlib, bad zlib dependency is missiong.
This PR add zlib dependency on muse.