### PR TITLE
ngmlr: add zlib dependency.

### DIFF
--- a/var/spack/repos/builtin/packages/ngmlr/package.py
+++ b/var/spack/repos/builtin/packages/ngmlr/package.py
@@ -15,3 +15,5 @@ class Ngmlr(CMakePackage):
     url      = "https://github.com/philres/ngmlr/archive/v0.2.5.tar.gz"
 
     version('0.2.5', '1b2b1aaeb6a3accc8b9f3e5c29e77037')
+
+    depends_on('zlib', type='link')


### PR DESCRIPTION
ngmlr use zlib but missing dependency.
This PR add zlib dependency to ngmlr.