### PR TITLE
expect: fix darwin install name

### DIFF
--- a/var/spack/repos/builtin/packages/expect/package.py
+++ b/var/spack/repos/builtin/packages/expect/package.py
@@ -58,3 +58,10 @@ class Expect(AutotoolsPackage):
         link_name = join_path(self.prefix.lib, link_name)
 
         symlink(target, link_name)
+
+    @run_after('install')
+    def darwin_fix(self):
+        # The shared library is not installed correctly on Darwin; fix this
+        if self.spec.satisfies('platform=darwin'):
+            fix_darwin_install_name(
+                join_path(self.prefix.lib, 'expect{0}'.format(self.version)))

--- a/var/spack/repos/builtin/packages/expect/package.py
+++ b/var/spack/repos/builtin/packages/expect/package.py
@@ -65,3 +65,8 @@ class Expect(AutotoolsPackage):
         if self.spec.satisfies('platform=darwin'):
             fix_darwin_install_name(
                 join_path(self.prefix.lib, 'expect{0}'.format(self.version)))
+
+        old = 'libexpect{0}.dylib'.format(self.version)
+        new = glob.glob(join_path(self.prefix.lib, 'expect*', 'libexpect*'))[0]
+        install_name_tool = Executable('install_name_tool')
+        install_name_tool('-change', old, new, self.prefix.bin.expect)


### PR DESCRIPTION
### Before

```console
$ otool -L /Users/Adam/spack/opt/spack/darwin-mojave-ivybridge/clang-11.0.0-apple/expect-5.45-w4kvty4l6eemafjlslp7t53am5o3ob4c/lib/libexpect5.45.dylib 
/Users/Adam/spack/opt/spack/darwin-mojave-ivybridge/clang-11.0.0-apple/expect-5.45-w4kvty4l6eemafjlslp7t53am5o3ob4c/lib/libexpect5.45.dylib:
	libexpect5.45.dylib (compatibility version 5.45.0, current version 5.45.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.250.1)
$ otool -L /Users/Adam/spack/opt/spack/darwin-mojave-ivybridge/clang-11.0.0-apple/expect-5.45-w4kvty4l6eemafjlslp7t53am5o3ob4c/bin/expect 
/Users/Adam/spack/opt/spack/darwin-mojave-ivybridge/clang-11.0.0-apple/expect-5.45-w4kvty4l6eemafjlslp7t53am5o3ob4c/bin/expect:
	libexpect5.45.dylib (compatibility version 5.45.0, current version 5.45.0)
	/Users/Adam/spack/opt/spack/darwin-mojave-ivybridge/clang-11.0.0-apple/tcl-8.6.8-zspmkfnhk7tfd2gqruab2qj5rvjqaii7/lib/libtcl8.6.dylib (compatibility version 8.6.0, current version 8.6.8)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.250.1)
```

### After

```console
$ otool -L /Users/Adam/spack/opt/spack/darwin-mojave-ivybridge/clang-11.0.0-apple/expect-5.45-w4kvty4l6eemafjlslp7t53am5o3ob4c/lib/libexpect5.45.dylib 
/Users/Adam/spack/opt/spack/darwin-mojave-ivybridge/clang-11.0.0-apple/expect-5.45-w4kvty4l6eemafjlslp7t53am5o3ob4c/lib/libexpect5.45.dylib:
	/Users/Adam/spack/opt/spack/darwin-mojave-ivybridge/clang-11.0.0-apple/expect-5.45-w4kvty4l6eemafjlslp7t53am5o3ob4c/lib/expect5.45/libexpect5.45.dylib (compatibility version 5.45.0, current version 5.45.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.250.1)
$ otool -L /Users/Adam/spack/opt/spack/darwin-mojave-ivybridge/clang-11.0.0-apple/expect-5.45-w4kvty4l6eemafjlslp7t53am5o3ob4c/bin/expect 
/Users/Adam/spack/opt/spack/darwin-mojave-ivybridge/clang-11.0.0-apple/expect-5.45-w4kvty4l6eemafjlslp7t53am5o3ob4c/bin/expect:
	/Users/Adam/spack/opt/spack/darwin-mojave-ivybridge/clang-11.0.0-apple/expect-5.45-w4kvty4l6eemafjlslp7t53am5o3ob4c/lib/expect5.45/libexpect5.45.dylib (compatibility version 5.45.0, current version 5.45.0)
	/Users/Adam/spack/opt/spack/darwin-mojave-ivybridge/clang-11.0.0-apple/tcl-8.6.8-zspmkfnhk7tfd2gqruab2qj5rvjqaii7/lib/libtcl8.6.dylib (compatibility version 8.6.0, current version 8.6.8)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.250.1)
```