### PR TITLE
Add watch package

### DIFF
--- a/var/spack/repos/builtin/packages/watch/package.py
+++ b/var/spack/repos/builtin/packages/watch/package.py
@@ -1,0 +1,44 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Watch(AutotoolsPackage):
+    """Executes a program periodically, showing output fullscreen."""
+
+    homepage = "https://gitlab.com/procps-ng/procps"
+    git      = "https://gitlab.com/procps-ng/procps.git"
+
+    version('master', branch='master')
+    version('3.3.15', tag='v3.3.15')
+
+    depends_on('autoconf', type='build')
+    depends_on('automake', type='build')
+    depends_on('libtool',  type='build')
+    depends_on('m4',       type='build')
+    depends_on('pkgconfig@0.9.0:', type='build')
+    depends_on('ncurses')
+
+    def autoreconf(self, spec, prefix):
+        sh = which('sh')
+        sh('autogen.sh')
+
+    def configure_args(self):
+        return [
+            '--with-ncurses',
+            # Required to avoid libintl linking errors
+            '--disable-nls',
+        ]
+
+    def build(self, spec, prefix):
+        make('watch')
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        mkdirp(prefix.man.man1)
+
+        install('watch', prefix.bin)
+        install('watch.1', prefix.man.man1)

--- a/var/spack/repos/builtin/packages/watch/package.py
+++ b/var/spack/repos/builtin/packages/watch/package.py
@@ -9,6 +9,10 @@ from spack import *
 class Watch(AutotoolsPackage):
     """Executes a program periodically, showing output fullscreen."""
 
+    # Note: there is a separate procps package, but it doesn't build on macOS.
+    # This package only contains the `watch` program, a subset of procps which
+    # does build on macOS.
+    # https://github.com/NixOS/nixpkgs/issues/18929#issuecomment-249388571
     homepage = "https://gitlab.com/procps-ng/procps"
     git      = "https://gitlab.com/procps-ng/procps.git"
 
@@ -22,6 +26,7 @@ class Watch(AutotoolsPackage):
     depends_on('pkgconfig@0.9.0:', type='build')
     depends_on('ncurses')
 
+    # https://github.com/Homebrew/homebrew-core/blob/master/Formula/watch.rb
     def autoreconf(self, spec, prefix):
         sh = which('sh')
         sh('autogen.sh')


### PR DESCRIPTION
Adds a new package for the Linux `watch` command. Unfortunately the full procps package is Linux-only, so I had to make a separate package for this single command to build on macOS. This package is based off of https://github.com/Homebrew/homebrew-core/blob/master/Formula/watch.rb

Successfully installs on macOS 10.14.6 with Clang 11.0.0.
```console
$ otool -L /Users/Adam/spack/opt/spack/darwin-mojave-ivybridge/clang-11.0.0-apple/watch-3.3.15-kiz3awhf7mwvjm2fj2dzyfymwiv6rwz3/bin/watch 
/Users/Adam/spack/opt/spack/darwin-mojave-ivybridge/clang-11.0.0-apple/watch-3.3.15-kiz3awhf7mwvjm2fj2dzyfymwiv6rwz3/bin/watch:
	/Users/Adam/spack/opt/spack/darwin-mojave-ivybridge/clang-11.0.0-apple/ncurses-6.1-ugyc74k76z7yu52ik3epobty2dscu53z/lib/libncurses.6.dylib (compatibility version 6.0.0, current version 6.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.250.1)
```