### PR TITLE
Fixed issue caused by a custom dotkit root present in config.yaml

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -588,10 +588,13 @@ def print_setup_info(*info):
     shell_set('_sp_compatible_sys_types',
               ':'.join(spack.architecture.compatible_sys_types()))
     # print roots for all module systems
-    module_roots = spack.config.get('config:module_roots')
     module_to_roots = {
         'tcl': list(),
         'lmod': list()
+    }
+    module_roots = spack.config.get('config:module_roots')
+    module_roots = {
+        k: v for k, v in module_roots.items() if k in module_to_roots
     }
     for name, path in module_roots.items():
         path = spack.util.path.canonicalize_path(path)
@@ -601,6 +604,10 @@ def print_setup_info(*info):
         'upstreams') or {}
     for install_properties in other_spack_instances.values():
         upstream_module_roots = install_properties.get('modules', {})
+        upstream_module_roots = {
+            k: v for k, v in upstream_module_roots.items()
+            if k in module_to_roots
+        }
         for module_type, root in upstream_module_roots.items():
             module_to_roots[module_type].append(root)
 

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -593,9 +593,9 @@ def print_setup_info(*info):
         'lmod': list()
     }
     module_roots = spack.config.get('config:module_roots')
-    module_roots = {
-        k: v for k, v in module_roots.items() if k in module_to_roots
-    }
+    module_roots = dict(
+        (k, v) for k, v in module_roots.items() if k in module_to_roots
+    )
     for name, path in module_roots.items():
         path = spack.util.path.canonicalize_path(path)
         module_to_roots[name].append(path)
@@ -604,10 +604,10 @@ def print_setup_info(*info):
         'upstreams') or {}
     for install_properties in other_spack_instances.values():
         upstream_module_roots = install_properties.get('modules', {})
-        upstream_module_roots = {
-            k: v for k, v in upstream_module_roots.items()
+        upstream_module_roots = dict(
+            (k, v) for k, v in upstream_module_roots.items()
             if k in module_to_roots
-        }
+        )
         for module_type, root in upstream_module_roots.items():
             module_to_roots[module_type].append(root)
 

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -16,6 +16,7 @@ import ruamel.yaml as yaml
 
 import spack.paths
 import spack.config
+import spack.main
 import spack.schema.compilers
 import spack.schema.config
 import spack.schema.env
@@ -759,3 +760,19 @@ compilers:
     - compiler:
          fenfironfent: /bad/value
 """)
+
+
+@pytest.mark.regression('13045')
+def test_dotkit_in_config_does_not_raise(
+        mock_config, write_config_file, capsys
+):
+    write_config_file('config',
+                      {'config': {'module_roots': {'dotkit': '/some/path'}}},
+                      'high')
+    spack.main.print_setup_info('sh')
+    captured = capsys.readouterr()
+
+    # Check that we set the variables we expect and that
+    # we throw a a deprecation warning without raising
+    assert '_sp_sys_type' in captured[0]  # stdout
+    assert 'Warning' in captured[1]  # stderr


### PR DESCRIPTION
fixes #13045

When removing support for dotkit in #11986 the code trying to set the paths of the various module files was not updated to skip it. This results in a failure because of a key error after the deprecation
warning is displayed to user.

This commit fixes the issue and adds a unit test for regression. Note that code for Spack chains has been updated accordingly but no unit test has been added for that case.