### PR TITLE
llvm: update link to the document explaining codesign

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -603,8 +603,8 @@ class Llvm(CMakePackage):
 
         except ProcessError:
             explanation = ('The "lldb_codesign" identity must be available'
-                           ' to build LLVM with LLDB. See https://llvm.org/'
-                           'svn/llvm-project/lldb/trunk/docs/code-signing'
+                           ' to build LLVM with LLDB. See https://github.com/'
+                           'jevinskie/llvm-lldb/blob/master/docs/code-signing'
                            '.txt for details on how to create this identity.')
             raise RuntimeError(explanation)
 


### PR DESCRIPTION
The old link is dead. This one works, but I'm not sure if this is an official repo of llvm or someone's private fork. Either way, this works the old one doesn't, so I think it's an improvement