### PR TITLE
perl-perlio-gzip: add zlib dependency.

### DIFF
--- a/var/spack/repos/builtin/packages/perl-perlio-gzip/package.py
+++ b/var/spack/repos/builtin/packages/perl-perlio-gzip/package.py
@@ -14,3 +14,9 @@ class PerlPerlioGzip(PerlPackage):
 
     version('0.20', '0393eae5d0b23df6cf40ed44af7d711c')
     version('0.19', 'dbcfc1450f6b593b65048b8ced061c98')
+
+    depends_on('zlib', type='link')
+
+    def configure_args(self):
+        p = self.spec['zlib'].prefix.include
+        return ['INC=-I{0}'.format(p)]


### PR DESCRIPTION
perl-perlio-gzip use zlib, but dependency is missing.
This PR add zlib ependency on perl-perlio-gzip.