### PR TITLE
seqprep: add zlib dependency.

### DIFF
--- a/var/spack/repos/builtin/packages/seqprep/package.py
+++ b/var/spack/repos/builtin/packages/seqprep/package.py
@@ -15,6 +15,8 @@ class Seqprep(MakefilePackage):
 
     version('1.3.2', 'b6a4f5491dfdb0ce38bf791454151468')
 
+    depends_on('zlib', type='link')
+
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
         install('SeqPrep', prefix.bin)


### PR DESCRIPTION
seqprep use zlib. but dependency is missing.
This PR add zlib dependency on seqprep.