### PR TITLE
tabix: add zlib dependency.

### DIFF
--- a/var/spack/repos/builtin/packages/tabix/package.py
+++ b/var/spack/repos/builtin/packages/tabix/package.py
@@ -16,6 +16,7 @@ class Tabix(MakefilePackage):
 
     depends_on('perl', type=('build', 'run'))
     depends_on('python', type=('build', 'run'))
+    depends_on('zlib', type='link')
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)


### PR DESCRIPTION
tabix use zlib.  but zlib dependency is missing.
This pr add zlib dependency to tabix.