### PR TITLE
py-apipkg: Fix mix up of checksums

### DIFF
--- a/var/spack/repos/builtin/packages/py-apipkg/package.py
+++ b/var/spack/repos/builtin/packages/py-apipkg/package.py
@@ -12,8 +12,8 @@ class PyApipkg(PythonPackage):
     homepage = "https://pypi.python.org/pypi/apipkg"
     url      = "https://pypi.io/packages/source/a/apipkg/apipkg-1.4.tar.gz"
 
-    version('1.5', sha256='2e38399dbe842891fe85392601aab8f40a8f4cc5a9053c326de35a1cc0297ac6')
-    version('1.4', sha256='37228cda29411948b422fae072f57e31d3396d2ee1c9783775980ee9c9990af6')
+    version('1.5', sha256='37228cda29411948b422fae072f57e31d3396d2ee1c9783775980ee9c9990af6')
+    version('1.4', sha256='2e38399dbe842891fe85392601aab8f40a8f4cc5a9053c326de35a1cc0297ac6')
 
     depends_on('py-setuptools@30.3.0:', type='build')
     depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))


### PR DESCRIPTION
The checksums for version `1.4` and `1.5` of `py-apipkg` are mixed up.

Compare:
https://pypi.org/project/apipkg/1.4/#copy-hash-modal-57804a89-dc76-417d-8c39-33b05b7f789a
https://pypi.org/project/apipkg/1.5/#copy-hash-modal-241f1f7c-fa7f-49f1-af44-338103d5ad4b