### PR TITLE
Add macOS Catalina support

### DIFF
--- a/lib/spack/spack/operating_systems/mac_os.py
+++ b/lib/spack/spack/operating_systems/mac_os.py
@@ -32,19 +32,29 @@ class MacOs(OperatingSystem):
     """
 
     def __init__(self):
-        """ Autodetects the mac version from a dictionary. Goes back as
-            far as 10.6 snowleopard. If the user has an older mac then
-            the version will just be a generic mac_os.
+        """Autodetects the mac version from a dictionary.
+
+        If the mac version is too old or too new for Spack to recognize,
+        will use a generic "macos" version string until Spack is updated.
         """
-        mac_releases = {'10.6': "snowleopard",
-                        "10.7": "lion",
-                        "10.8": "mountainlion",
-                        "10.9": "mavericks",
-                        "10.10": "yosemite",
-                        "10.11": "elcapitan",
-                        "10.12": "sierra",
-                        "10.13": "highsierra",
-                        "10.14": "mojave"}
+        mac_releases = {
+            '10.0':  'cheetah',
+            '10.1':  'puma',
+            '10.2':  'jaguar',
+            '10.3':  'panther',
+            '10.4':  'tiger',
+            '10.5':  'leopard',
+            '10.6':  'snowleopard',
+            '10.7':  'lion',
+            '10.8':  'mountainlion',
+            '10.9':  'mavericks',
+            '10.10': 'yosemite',
+            '10.11': 'elcapitan',
+            '10.12': 'sierra',
+            '10.13': 'highsierra',
+            '10.14': 'mojave',
+            '10.15': 'catalina',
+        }
 
         mac_ver = str(macos_version().up_to(2))
         name = mac_releases.get(mac_ver, "macos")


### PR DESCRIPTION
### Before
```console
$ spack arch
darwin-macos-ivybridge
```
### After
```console
$ spack arch
darwin-catalina-ivybridge
```
Also added older macOS releases because why not?