### PR TITLE
sublime-text: New version, adapt install process

### DIFF
--- a/var/spack/repos/builtin/packages/sublime-text/package.py
+++ b/var/spack/repos/builtin/packages/sublime-text/package.py
@@ -46,6 +46,3 @@ class SublimeText(Package):
         mkdirp(dst)
         force_symlink(src, join_path(dst, 'sublime_text'))
         force_symlink(src, join_path(dst, 'subl'))
-
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PATH', join_path(self.prefix, "bin"))

--- a/var/spack/repos/builtin/packages/sublime-text/package.py
+++ b/var/spack/repos/builtin/packages/sublime-text/package.py
@@ -11,9 +11,10 @@ class SublimeText(Package):
     prose."""
 
     homepage = "http://www.sublimetext.com/"
-    url      = "https://download.sublimetext.com/sublime_text_3_build_3176_x64.tar.bz2"
+    url      = "https://download.sublimetext.com/sublime_text_3_build_3211_x64.tar.bz2"
 
-    version('3.2.1.3207', 'acb64f1de024a0f004888096afa101051e48d96c7a3e7fe96e11312d524938c4')
+    version('3.2.2.3211', sha256='0b3c8ca5e6df376c3c24a4b9ac2e3b391333f73b229bc6e87d0b4a5f636d74ee')
+    version('3.2.1.3207', sha256='acb64f1de024a0f004888096afa101051e48d96c7a3e7fe96e11312d524938c4')
     version('3.1.1.3176', '7d4c8c5167224888d901e8cbafb6ec7f')
     version('3.0.3126',   'acc34252b0ea7dff1f581c5db1564dcb')
     version('2.0.2',      '699cd26d7fe0bada29eb1b2cd7b50e4b')
@@ -39,8 +40,12 @@ class SublimeText(Package):
             return "https://download.sublimetext.com/sublime_text_{0}_build_{1}_x64.tar.bz2".format(version[0], version[-1])
 
     def install(self, spec, prefix):
-        # Sublime text comes as a pre-compiled binary.
         install_tree('.', prefix)
+        src = join_path(prefix, 'sublime_text')
+        dst = join_path(prefix, 'bin')
+        mkdirp(dst)
+        force_symlink(src, join_path(dst, 'sublime_text'))
+        force_symlink(src, join_path(dst, 'subl'))
 
     def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PATH', self.prefix)
+        run_env.prepend_path('PATH', join_path(self.prefix, "bin"))


### PR DESCRIPTION
* added new version 3.2.2.3211
* symlink to the binary into a new subdirectory `bin` to keep $PATH clean
* sublime_text may also be called from the terminal with optional flags, on the web often referred to as `subl`