### PR TITLE
"No Spack mirror configured": demoted the warning to a debug message

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -606,7 +606,7 @@ def get_specs(force=False):
 
     mirrors = spack.config.get('mirrors')
     if len(mirrors) == 0:
-        tty.warn("No Spack mirrors are currently configured")
+        tty.debug("No Spack mirrors are currently configured")
         return {}
 
     urls = set()


### PR DESCRIPTION
fixes #12010