### PR TITLE
Add patches and missing dependency to bash

### DIFF
--- a/var/spack/repos/builtin/packages/bash/package.py
+++ b/var/spack/repos/builtin/packages/bash/package.py
@@ -19,6 +19,26 @@ class Bash(AutotoolsPackage):
 
     depends_on('ncurses')
     depends_on('readline@5.0:')
+    depends_on('libiconv')
+
+    patches = [
+        ('5.0', '001', 'f2fe9e1f0faddf14ab9bfa88d450a75e5d028fedafad23b88716bd657c737289'),
+        ('5.0', '002', '87e87d3542e598799adb3e7e01c8165bc743e136a400ed0de015845f7ff68707'),
+        ('5.0', '003', '4eebcdc37b13793a232c5f2f498a5fcbf7da0ecb3da2059391c096db620ec85b'),
+        ('5.0', '004', '14447ad832add8ecfafdce5384badd933697b559c4688d6b9e3d36ff36c62f08'),
+        ('5.0', '005', '5bf54dd9bd2c211d2bfb34a49e2c741f2ed5e338767e9ce9f4d41254bf9f8276'),
+        ('5.0', '006', 'd68529a6ff201b6ff5915318ab12fc16b8a0ebb77fda3308303fcc1e13398420'),
+        ('5.0', '007', '17b41e7ee3673d8887dd25992417a398677533ab8827938aa41fad70df19af9b'),
+        ('5.0', '008', 'eec64588622a82a5029b2776e218a75a3640bef4953f09d6ee1f4199670ad7e3'),
+        ('5.0', '009', 'ed3ca21767303fc3de93934aa524c2e920787c506b601cc40a4897d4b094d903'),
+        ('5.0', '010', 'd6fbc325f0b5dc54ddbe8ee43020bced8bd589ddffea59d128db14b2e52a8a11'),
+        ('5.0', '011', '2c4de332b91eaf797abbbd6c79709690b5cbd48b12e8dfe748096dbd7bf474ea'),
+    ]
+
+    for ver, num, checksum in patches:
+        ver = Version(ver)
+        patch('https://ftpmirror.gnu.org/bash/bash-{0}-patches/bash{1}-{2}'.format(ver, ver.joined, num),
+              level=0, when='@{0}'.format(ver), sha256=checksum)
 
     def configure_args(self):
         spec = self.spec
@@ -27,7 +47,8 @@ class Bash(AutotoolsPackage):
             'LIBS=-lncursesw',
             '--with-curses',
             '--enable-readline',
-            '--with-installed-readline={0}'.format(spec['readline'].prefix),
+            '--with-installed-readline',
+            '--with-libiconv-prefix={0}'.format(spec['libiconv'].prefix),
         ]
 
     def check(self):


### PR DESCRIPTION
Successfully builds on macOS 10.15 with Clang 11.0.0.