### PR TITLE
Add gettext 0.20.1

### DIFF
--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -10,8 +10,9 @@ class Gettext(AutotoolsPackage):
     """GNU internationalization (i18n) and localization (l10n) library."""
 
     homepage = "https://www.gnu.org/software/gettext/"
-    url      = "https://ftpmirror.gnu.org/gettext/gettext-0.19.7.tar.xz"
+    url      = "https://ftpmirror.gnu.org/gettext/gettext-0.20.1.tar.xz"
 
+    version('0.20.1', sha256='53f02fbbec9e798b0faaf7c73272f83608e835c6288dd58be6c9bb54624a3800')
     version('0.19.8.1', 'df3f5690eaa30fd228537b00cb7b7590')
     version('0.19.7',   'f81e50556da41b44c1d59ac93474dca5')
 


### PR DESCRIPTION
Successfully builds on macOS 10.15 with Clang 11.0.0.