### PR TITLE
bugfix: install --only dependencies works in env

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1519,9 +1519,13 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         dirty = kwargs.get('dirty', False)
         restage = kwargs.get('restage', False)
 
-        # Pop install_self so that it doesn't affect recursion
-        # Pop explicit so that it doesn't affect recursion
+        # install_self defaults True and is popped so that dependencies are
+        # always installed regardless of whether the root was installed
         install_self = kwargs.pop('install_package', True)
+        # explicit defaults False so that dependents are implicit regardless
+        # of whether their dependents are implicitly or explicitly installed.
+        # Spack ensures root packages of install commands are always marked to
+        # install explicit
         explicit = kwargs.pop('explicit', False)
 
         # For external packages the workflow is simplified, and basically

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1519,6 +1519,11 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         dirty = kwargs.get('dirty', False)
         restage = kwargs.get('restage', False)
 
+        # Pop install_self so that it doesn't affect recursion
+        # Pop explicit so that it doesn't affect recursion
+        install_self = kwargs.pop('install_package', True)
+        explicit = kwargs.pop('explicit', False)
+
         # For external packages the workflow is simplified, and basically
         # consists in module file generation and registration in the DB
         if self.spec.external:
@@ -1567,6 +1572,9 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         # Then install the compiler if it is not already installed.
         if install_deps:
             Package._install_bootstrap_compiler(self, **kwargs)
+
+        if not install_self:
+            return
 
         # Then, install the package proper
         tty.msg(colorize('@*{Installing} @*g{%s}' % self.name))

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -634,14 +634,17 @@ def test_install_only_dependencies_in_env(tmpdir, mock_fetch, install_mockery,
 def test_install_only_dependencies_of_all_in_env(
     tmpdir, mock_fetch, install_mockery, mutable_mock_env_path
 ):
-    env('create', 'test')
+    env('create', '--without-view', 'test')
 
     with ev.read('test'):
-        dep = Spec('dependency-install').concretized()
-        root = Spec('dependent-install').concretized()
+        roots = [Spec('dependent-install@1.0').concretized(),
+                 Spec('dependent-install@2.0').concretized()]
 
-        add('dependent-install')
+        add('dependent-install@1.0')
+        add('dependent-install@2.0')
         install('--only', 'dependencies')
 
-        assert os.path.exists(dep.prefix)
-        assert not os.path.exists(root.prefix)
+        for root in roots:
+            assert not os.path.exists(root.prefix)
+            for dep in root.traverse(root=False):
+                assert os.path.exists(dep.prefix)

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -21,10 +21,13 @@ import spack.cmd.install
 from spack.error import SpackError
 from spack.spec import Spec
 from spack.main import SpackCommand
+import spack.environment as ev
 
 from six.moves.urllib.error import HTTPError, URLError
 
 install = SpackCommand('install')
+env = SpackCommand('env')
+add = SpackCommand('add')
 
 
 @pytest.fixture(scope='module')
@@ -600,3 +603,45 @@ def test_cache_only_fails(tmpdir, mock_fetch, install_mockery, capfd):
             assert False
         except spack.main.SpackCommandError:
             pass
+
+
+def test_install_only_dependencies(tmpdir, mock_fetch, install_mockery):
+    dep = Spec('dependency-install').concretized()
+    root = Spec('dependent-install').concretized()
+
+    install('--only', 'dependencies', 'dependent-install')
+
+    assert os.path.exists(dep.prefix)
+    assert not os.path.exists(root.prefix)
+
+
+@pytest.mark.regression('12002')
+def test_install_only_dependencies_in_env(tmpdir, mock_fetch, install_mockery,
+                                          mutable_mock_env_path):
+    env('create', 'test')
+
+    with ev.read('test'):
+        dep = Spec('dependency-install').concretized()
+        root = Spec('dependent-install').concretized()
+
+        install('-v', '--only', 'dependencies', 'dependent-install')
+
+        assert os.path.exists(dep.prefix)
+        assert not os.path.exists(root.prefix)
+
+
+@pytest.mark.regression('12002')
+def test_install_only_dependencies_of_all_in_env(
+    tmpdir, mock_fetch, install_mockery, mutable_mock_env_path
+):
+    env('create', 'test')
+
+    with ev.read('test'):
+        dep = Spec('dependency-install').concretized()
+        root = Spec('dependent-install').concretized()
+
+        add('dependent-install')
+        install('--only', 'dependencies')
+
+        assert os.path.exists(dep.prefix)
+        assert not os.path.exists(root.prefix)

--- a/var/spack/repos/builtin.mock/packages/dependent-install/package.py
+++ b/var/spack/repos/builtin.mock/packages/dependent-install/package.py
@@ -13,8 +13,10 @@ class DependentInstall(Package):
     url      = "http://www.example.com/a-1.0.tar.gz"
 
     version('1.0', '0123456789abcdef0123456789abcdef')
+    version('2.0', '0123456789abcdef0123456789abcdef')
 
-    depends_on('dependency-install')
+    depends_on('dependency-install@2.0', when='@2.0')
+    depends_on('dependency-install@1.0', when='@1.0')
 
     def install(self, spec, prefix):
         touch(join_path(prefix, 'an_installation_file'))


### PR DESCRIPTION
Fixes #12002 

Allows `spack install --only dependencies foo` or `spack install --only dependencies` in an environment to work. The former will install all dependencies of foo in the environment, and the latter will install all dependencies of all root specs in the environment.