### PR TITLE
Add readline 8.0

### DIFF
--- a/var/spack/repos/builtin/packages/readline/package.py
+++ b/var/spack/repos/builtin/packages/readline/package.py
@@ -15,8 +15,10 @@ class Readline(AutotoolsPackage):
     csh-like history expansion on previous commands."""
 
     homepage = "http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html"
-    url      = "https://ftpmirror.gnu.org/readline/readline-7.0.tar.gz"
+    # URL must remain http:// so Spack can bootstrap curl
+    url      = "http://ftpmirror.gnu.org/readline/readline-8.0.tar.gz"
 
+    version('8.0', sha256='e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461')
     version('7.0', '205b03a87fc83dab653b628c59b9fc91')
     version('6.3', '33c8fb279e981274f485fd91da77e94a')
 


### PR DESCRIPTION
Successfully builds on macOS 10.15 with Clang 11.0.0.

#3896 added a gdbm dependency to perl, meaning curl -> openssl -> perl -> gdbm -> readline -> ncurses -> pkgconf