### PR TITLE
gdbm: https -> http

### DIFF
--- a/var/spack/repos/builtin/packages/gdbm/package.py
+++ b/var/spack/repos/builtin/packages/gdbm/package.py
@@ -14,7 +14,8 @@ class Gdbm(AutotoolsPackage):
     manipulate a hashed database."""
 
     homepage = "http://www.gnu.org.ua/software/gdbm/gdbm.html"
-    url      = "https://ftpmirror.gnu.org/gdbm/gdbm-1.13.tar.gz"
+    # URL must remain http:// so Spack can bootstrap curl
+    url      = "http://ftpmirror.gnu.org/gdbm/gdbm-1.13.tar.gz"
 
     version('1.18.1', '86e613527e5dba544e73208f42b78b7c022d4fa5a6d5498bf18c8d6f745b91dc')
     version('1.14.1', 'c2ddcb3897efa0f57484af2bd4f4f848')


### PR DESCRIPTION
#3896 added a gdbm dependency to perl, meaning curl -> openssl -> perl -> gdbm -> readline -> ncurses -> pkgconf