### PR TITLE
py-line-profiler: add 2.1.2, re-run cython if needed

### DIFF
--- a/var/spack/repos/builtin/packages/py-line-profiler/package.py
+++ b/var/spack/repos/builtin/packages/py-line-profiler/package.py
@@ -17,7 +17,7 @@ class PyLineProfiler(PythonPackage):
     version('2.1.2', sha256='efa66e9e3045aa7cb1dd4bf0106e07dec9f80bc781a993fbaf8162a36c20af5c')
     version('2.0', 'fc93c6bcfac3b7cb1912cb28836d7ee6')
 
-    depends_on('python@2.5:')
+    depends_on('python@2.5:', type=('build', 'run'))
     depends_on('py-setuptools',     type='build')
     depends_on('py-cython',         type='build')
     depends_on('py-ipython@0.13:',  type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-line-profiler/package.py
+++ b/var/spack/repos/builtin/packages/py-line-profiler/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack import *
 
 
@@ -12,9 +14,20 @@ class PyLineProfiler(PythonPackage):
     homepage = "https://github.com/rkern/line_profiler"
     url      = "https://pypi.io/packages/source/l/line_profiler/line_profiler-2.0.tar.gz"
 
+    version('2.1.2', sha256='efa66e9e3045aa7cb1dd4bf0106e07dec9f80bc781a993fbaf8162a36c20af5c')
     version('2.0', 'fc93c6bcfac3b7cb1912cb28836d7ee6')
 
     depends_on('python@2.5:')
     depends_on('py-setuptools',     type='build')
     depends_on('py-cython',         type='build')
     depends_on('py-ipython@0.13:',  type=('build', 'run'))
+
+    # See https://github.com/rkern/line_profiler/issues/166
+    @run_before('build')
+    @when('^python@3.7:')
+    def fix_cython(self):
+        cython = self.spec['py-cython'].command
+        for root, _, files in os.walk('.'):
+            for fn in files:
+                if fn.endswith('.pyx'):
+                    cython(os.path.join(root, fn))


### PR DESCRIPTION
See rkern/line_profiler#166. Closes #13059.