### PR TITLE
Bootstrap environment modules optimizing for generic architectures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,11 @@ jobs:
       os: linux
       language: python
       env: TEST_SUITE=flake8
+# Shell integration with module files
+    - python: '3.7'
+      os: linux
+      language: python
+      env: [ TEST_SUITE=bootstrap ]
     - stage: 'unit tests + documentation'
       python: '2.6'
       dist: trusty

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import llnl.util.cpu
 import llnl.util.tty as tty
 
 import spack.repo
@@ -52,7 +53,12 @@ def bootstrap(parser, args, **kwargs):
     # Define requirement dictionary defining general specs which need
     # to be satisfied, and the specs to install when the general spec
     # isn't satisfied.
-    requirement_dict = {'environment-modules': 'environment-modules~X'}
+    requirement_dict = {
+        # Install environment-modules with generic optimizations
+        'environment-modules': 'environment-modules~X target={0}'.format(
+            llnl.util.cpu.host().family
+        )
+    }
 
     for requirement in requirement_dict:
         installed_specs = spack.store.db.query(requirement)

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -20,6 +20,7 @@ import traceback
 import warnings
 from six import StringIO
 
+import llnl.util.cpu
 import llnl.util.tty as tty
 import llnl.util.tty.color as color
 from llnl.util.tty.log import log_output
@@ -621,8 +622,9 @@ def print_setup_info(*info):
     # print environment module system if available. This can be expensive
     # on clusters, so skip it if not needed.
     if 'modules' in info:
-        specs = spack.store.db.query(
-            'environment-modules arch=%s' % spack.architecture.sys_type())
+        generic_arch = llnl.util.cpu.host().family
+        module_spec = 'environment-modules target={0}'.format(generic_arch)
+        specs = spack.store.db.query(module_spec)
         if specs:
             shell_set('_sp_module_prefix', specs[-1].prefix)
         else:

--- a/share/spack/qa/run-bootstrap-tests
+++ b/share/spack/qa/run-bootstrap-tests
@@ -1,0 +1,37 @@
+#!/bin/bash -e
+#
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+#
+# Description:
+#     Checks that Spack shell integration with modules works correctly.
+#
+# Usage:
+#     run-bootstrap-tests
+#
+. "$(dirname $0)/setup.sh"
+check_dependencies ${coverage} git hg svn
+
+# Fetch the sources in a mirror, and add it to Spack
+mkdir -p ~/.mirror
+bin/spack mirror add travis ~/.mirror
+bin/spack mirror create -D -d ~/.mirror environment-modules~X
+
+
+# Move to root directory of Spack
+# Allows script to be run from anywhere
+cd "$SPACK_ROOT"
+
+# Print compiler information
+spack config get compilers
+
+# Run some build smoke tests, potentially with code coverage
+${coverage_run} bin/spack bootstrap
+
+# Check module integration
+. "share/spack/setup-env.sh"
+module av || exit 1
+spack load tcl || exit 1


### PR DESCRIPTION
fixes #13073

Since #3206 was merged bootstrapping environment-modules was using the architecture of the current host or the best match supported by the default compiler. The former case is an issue since shell integration was looking for a spec targeted at the host microarchitecture.

This commit fixes the problem by:

1. Bootstrapping an en modules targeted at generic architectures
2. Looking for generic targets in shell integration scripts