### PR TITLE
Add support to fetch from specfiles

### DIFF
--- a/lib/spack/spack/cmd/fetch.py
+++ b/lib/spack/spack/cmd/fetch.py
@@ -23,17 +23,36 @@ def setup_parser(subparser):
     subparser.add_argument(
         '-D', '--dependencies', action='store_true',
         help="also fetch all dependencies")
+    subparser.add_argument(
+        '-f', '--file', action='append', default=[],
+        dest='specfiles', metavar='SPEC_YAML_FILE',
+        help="fetch from file. Read specs to fetch from .yaml files")
     arguments.add_common_arguments(subparser, ['specs'])
 
 
 def fetch(parser, args):
-    if not args.specs:
-        tty.die("fetch requires at least one package argument")
+    if not args.specs and not args.specfiles:
+        tty.die("fetch requires at least one package argument or specfile")
 
     if args.no_checksum:
         spack.config.set('config:checksum', False, scope='command_line')
 
+    # specs from cli
     specs = spack.cmd.parse_specs(args.specs, concretize=True)
+
+    # specs via specfiles
+    for file in args.specfiles:
+        with open(file, 'r') as f:
+            s = spack.spec.Spec.from_yaml(f)
+
+        if s.concretized().dag_hash() != s.dag_hash():
+            msg = 'skipped invalid file "{0}". '
+            msg += 'The file does not contain a concrete spec.'
+            tty.warn(msg.format(file))
+            continue
+
+        specs.append(s.concretized())
+
     for spec in specs:
         if args.missing or args.dependencies:
             for s in spec.traverse():

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -820,7 +820,7 @@ _spack_extensions() {
 _spack_fetch() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -n --no-checksum -m --missing -D --dependencies"
+        SPACK_COMPREPLY="-h --help -n --no-checksum -m --missing -D --dependencies -f --file"
     else
         _all_packages
     fi


### PR DESCRIPTION
This change mirrors the `install` command's ability to take spec-input via specfiles.

Same as for `install` they can be supplied via `--file`.

This is useful when concretizing a bunch of packages in parallel and then fetching them in sequence so every dependency is only downloaded once.