### PR TITLE
ArchSpec: fix constraint satisfaction for targets

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -395,6 +395,10 @@ class ArchSpec(object):
             if not sep and self_target == t_min:
                 return True
 
+            if not sep and self_target != t_min:
+                return False
+
+            # Check against a range
             min_ok = self_target.microarchitecture >= t_min if t_min else True
             max_ok = self_target.microarchitecture <= t_max if t_max else True
 

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -972,7 +972,12 @@ class TestSpecSematics(object):
         ('libelf target=haswell', 'target=:haswell', True),
         ('libelf target=haswell', 'target=icelake,:nocona', False),
         ('libelf target=haswell', 'target=haswell,:nocona', True),
+        # Check that a single target is not treated as the start
+        # or the end of an open range
+        ('libelf target=haswell', 'target=x86_64', False),
+        ('libelf target=x86_64', 'target=haswell', False),
     ])
+    @pytest.mark.regression('13111')
     def test_target_constraints(self, spec, constraint, expected_result):
         s = Spec(spec)
         assert s.satisfies(constraint) is expected_result


### PR DESCRIPTION
fixes #13111

Due to a missing case we were treating a single target that was not equal to the one we were comparing to as a range open on the right.