### PR TITLE
Buildcache: pass string.encode('utf-8') for old_dir and new_dir to replace_prefix_bin

### DIFF
--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -429,7 +429,8 @@ def relocate_macho_binaries(path_names, old_dir, new_dir, allow_root):
             modify_object_macholib(path_name, placeholder, new_dir)
             modify_object_macholib(path_name, old_dir, new_dir)
         if len(new_dir) <= len(old_dir):
-            replace_prefix_bin(path_name, old_dir, new_dir)
+            replace_prefix_bin(path_name, old_dir.encode('utf-8'),
+                               new_dir.encode('utf-8'))
         else:
             tty.warn('Cannot do a binary string replacement'
                      ' with padding for %s'


### PR DESCRIPTION
This should fix a Python3 error from concatenating strings and bytes.