### PR TITLE
ntpoly: Define module directry when compiling with Fujitsu compiler.

### DIFF
--- a/var/spack/repos/builtin/packages/ntpoly/package.py
+++ b/var/spack/repos/builtin/packages/ntpoly/package.py
@@ -26,4 +26,7 @@ class Ntpoly(CMakePackage):
 
     def cmake_args(self):
         args = ["-DNOSWIG=Yes"]
+        if self.spec.satisfies('%fj'):
+            args.append('-DCMAKE_Fortran_MODDIR_FLAG="-M"')
+
         return args

--- a/var/spack/repos/builtin/packages/ntpoly/package.py
+++ b/var/spack/repos/builtin/packages/ntpoly/package.py
@@ -27,6 +27,6 @@ class Ntpoly(CMakePackage):
     def cmake_args(self):
         args = ["-DNOSWIG=Yes"]
         if self.spec.satisfies('%fj'):
-            args.append('-DCMAKE_Fortran_MODDIR_FLAG="-M"')
+            args.append('-DCMAKE_Fortran_MODDIR_FLAG=-M')
 
         return args


### PR DESCRIPTION
I added definition of `CMAKE_Fortran_MODDIR_FLAG` to detect fortran modules when using Fujitsu compiler.