### PR TITLE
lmod: module files are written in a root folder named by target family

### DIFF
--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -198,7 +198,11 @@ class LmodFileLayout(BaseFileLayout):
     @property
     def arch_dirname(self):
         """Returns the root folder for THIS architecture"""
-        arch_folder = str(self.spec.architecture)
+        arch_folder = '-'.join([
+            str(self.spec.platform),
+            str(self.spec.os),
+            str(self.spec.target.family)
+        ])
         return os.path.join(
             self.dirname(),  # root for lmod module files
             arch_folder,  # architecture relative path

--- a/lib/spack/spack/test/modules/lmod.py
+++ b/lib/spack/spack/test/modules/lmod.py
@@ -262,3 +262,19 @@ class TestLmod(object):
         # Assert we have core compilers now
         writer, _ = factory(mpileaks_spec_string)
         assert writer.conf.core_compilers
+
+    @pytest.mark.parametrize('spec_str', [
+        'mpileaks target=haswell',
+        'mpileaks target=core2',
+        'mpileaks target=x86_64',
+    ])
+    @pytest.mark.regression('13005')
+    def test_only_generic_microarchitectures_in_root(
+            self, spec_str, factory, module_configuration
+    ):
+        module_configuration('complex_hierarchy')
+        writer, spec = factory(spec_str)
+
+        assert str(spec.target.family) in writer.layout.arch_dirname
+        if spec.target.family != spec.target:
+            assert str(spec.target) not in writer.layout.arch_dirname

--- a/share/spack/templates/modules/modulefile.lua
+++ b/share/spack/templates/modules/modulefile.lua
@@ -8,6 +8,7 @@
 {% if short_description %}
 whatis([[Name : {{ spec.name }}]])
 whatis([[Version : {{ spec.version }}]])
+whatis([[Target : {{ spec.target }}]])
 whatis([[Short description : {{ short_description }}]])
 {% endif %}
 {% if configure_options %}


### PR DESCRIPTION
fixes #13005

This commit fixes an issue with the name of the root directory for module file hierarchies. 

Since #3206 the root folder was named after the microarchitecture used for the spec, which is too specific and not backward compatible for lmod hierarchies. Here we compute the root folder name using the target family instead of the target name itself and we add target information in the "whatis" portion of the module file.