### PR TITLE
Fix svn tests, skip if svnadmin not found

### DIFF
--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -109,7 +109,8 @@ def test_git_mirror(mock_git_repository):
 
 
 @pytest.mark.skipif(
-    not which('svn'), reason='requires subversion to be installed')
+    not which('svn') or not which('svnadmin'),
+    reason='requires subversion to be installed')
 def test_svn_mirror(mock_svn_repository):
     set_up_package('svn-test', mock_svn_repository, 'svn')
     check_mirror()

--- a/lib/spack/spack/test/svn_fetch.py
+++ b/lib/spack/spack/test/svn_fetch.py
@@ -19,7 +19,8 @@ from spack.util.executable import which
 
 
 pytestmark = pytest.mark.skipif(
-    not which('svn'), reason='requires subversion to be installed')
+    not which('svn') or not which('svnadmin'),
+    reason='requires subversion to be installed')
 
 
 @pytest.mark.parametrize("type_of_test", ['default', 'rev0'])


### PR DESCRIPTION
The SVN mock fixture requires both `svn` and `svnadmin`, but we only check for `svn`. macOS Catalina comes with `svn` but not `svnadmin`. This change causes the SVN tests to correctly be skipped.