### PR TITLE
WIP, ENH: remove ~/.spack requirement

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -18,6 +18,14 @@ config:
   # You can use $spack here to refer to the root of the spack instance.
   install_tree: $spack/opt/spack
 
+  # the repository default of ~/.spack will get expanded
+  # internally for backward compatibilty, but it is now
+  # also possible to specify a custom "user" directory
+  # for spack config; see gh-12892 and gh-13057
+  # paths not containing "~" will simply remain
+  # unchanged internally
+  user_path: "~/.spack"
+
 
   # Locations where templates should be found
   template_dirs:

--- a/lib/spack/docs/config_yaml.rst
+++ b/lib/spack/docs/config_yaml.rst
@@ -26,6 +26,30 @@ These settings can be overridden in ``etc/spack/config.yaml`` or
 The location where Spack will install packages and their dependencies.
 Default is ``$spack/opt/spack``.
 
+--------------------
+``user_path``
+--------------------
+
+The location of the user level configuration scope files. This may
+include a number of configuration and cache files and folders
+written by Spack. For example, if you add a mirror, this configuration
+update should be written using the path root provided by ``user_path``.
+
+It should be specified at the system or, perhaps
+most likely, site configuration scope, and might be used for
+example to prevent complications from multiple Spack instances
+writing to and depending on configuration data stored in the
+default ``~/.spack`` path when separated configurations and
+caches are more desirable.
+
+While setting ``user_path`` will automatically set the root of
+``misc_cache`` to include the new base path, it may still be useful
+to manually adjust ``build_stage`` to use a secondary/backup path
+that does not point to ``~/.spack/stage``.
+
+Setting ``user_path`` at configuration scopes with higher precedence
+than ``site`` is not currently supported.
+
 ---------------------------------------------------
 ``install_hash_length`` and ``install_path_scheme``
 ---------------------------------------------------

--- a/lib/spack/spack/caches.py
+++ b/lib/spack/spack/caches.py
@@ -24,7 +24,8 @@ def _misc_cache():
     """
     path = spack.config.get('config:misc_cache')
     if not path:
-        path = os.path.join(spack.paths.user_config_path, 'cache')
+        path = os.path.join(os.path.join(os.path.expanduser(
+                            spack.config.get('config:user_path')), 'cache'))
     path = canonicalize_path(path)
 
     return spack.util.file_cache.FileCache(path)

--- a/lib/spack/spack/caches.py
+++ b/lib/spack/spack/caches.py
@@ -24,8 +24,8 @@ def _misc_cache():
     """
     path = spack.config.get('config:misc_cache')
     if not path:
-        path = os.path.join(os.path.join(os.path.expanduser(
-                            spack.config.get('config:user_path')), 'cache'))
+        path = os.path.join(os.path.expanduser(
+                            spack.config.get('config:user_path')), 'cache')
     path = canonicalize_path(path)
 
     return spack.util.file_cache.FileCache(path)

--- a/lib/spack/spack/paths.py
+++ b/lib/spack/spack/paths.py
@@ -47,7 +47,8 @@ mock_packages_path = os.path.join(repos_path, "builtin.mock")
 
 #: User configuration location
 # This is now obsolete as it can be customized
-# in etc/spack/defaults/config.yaml;
+# by setting user_path in a config.yaml file at
+# system or site scope;
 # the default has been retained for backward
 # compatibility
 # user_config_path = os.path.expanduser('~/.spack')

--- a/lib/spack/spack/paths.py
+++ b/lib/spack/spack/paths.py
@@ -46,7 +46,11 @@ packages_path      = os.path.join(repos_path, "builtin")
 mock_packages_path = os.path.join(repos_path, "builtin.mock")
 
 #: User configuration location
-user_config_path = os.path.expanduser('~/.spack')
+# This is now obsolete as it can be customized
+# in etc/spack/defaults/config.yaml;
+# the default has been retained for backward
+# compatibility
+# user_config_path = os.path.expanduser('~/.spack')
 
 
 opt_path        = os.path.join(prefix, "opt")

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -17,6 +17,7 @@ properties = {
         'default': {},
         'properties': {
             'install_tree': {'type': 'string'},
+            'user_path': {'type': 'string'},
             'install_hash_length': {'type': 'integer', 'minimum': 1},
             'install_path_scheme': {'type': 'string'},
             'build_stage': {

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -8,6 +8,7 @@ import os
 from llnl.util.filesystem import mkdirp
 
 import spack.config
+from spack.config import ConfigScope
 import spack.environment as ev
 from spack.main import SpackCommand
 
@@ -91,3 +92,142 @@ def test_config_edit_fails_correctly_with_no_env(mutable_mock_env_path):
 def test_config_get_fails_correctly_with_no_env(mutable_mock_env_path):
     output = config('get', fail_on_error=False)
     assert "requires a section argument or an active environment" in output
+
+
+def test_get_config_user_path_priority(mock_config, tmpdir):
+    # the user_path config.yaml variable should
+    # obey the usual scope priority hierarchy
+    # when overriding the ~/.spack default
+
+    # set up mock scope paths as usual
+    low_path = mock_config.scopes['low'].path
+    high_path = mock_config.scopes['high'].path
+    mkdirp(low_path)
+    mkdirp(high_path)
+
+    # create two separate subdirectories where the user_path
+    # will be assigned depending on scope priority
+    user_low_path = os.path.join(str(tmpdir), 'low')
+    user_high_path = os.path.join(str(tmpdir), 'high')
+
+    for path in [user_low_path, user_high_path]:
+        mkdirp(path)
+
+    # we're going to remove and then restore the 'low' and
+    # 'high' priority mock_config scopes, so that they
+    # can gain priority when pushed back in---ideally we'd
+    # test the built-in hierarchy directly, but we don't want
+    # to i.e., modify local spack settings
+
+    high_scope = mock_config.pop_scope()
+    low_scope = mock_config.pop_scope()
+
+    # make sure no scopes are currently available
+    assert not mock_config.file_scopes
+
+    # the default user_path remains ~/.spack
+    # so loading in the default as the first scope
+    # should return that value
+    mock_config.push_scope(ConfigScope('defaults',
+                           os.path.join(spack.paths.etc_path,
+                                        'spack', 'defaults')))
+
+    expected_path = "~/.spack"
+    assert spack.config.get('config:user_path') == expected_path
+
+    # the next added scope, "low", should override user_path with
+    # its unique value for that setting
+
+    with open(os.path.join(low_path, 'config.yaml'), 'w') as f:
+        f.write('''\
+config:
+  user_path: {user_low_path}
+'''.format(user_low_path=user_low_path))
+
+    mock_config.push_scope(low_scope)
+    assert spack.config.get('config:user_path') == user_low_path
+
+    # check that if we set something with spack, it
+    # starts populating user_low_path with files, consistent
+    # with default ~/.spack behavior for the user_path
+
+    # initially there should be only 1 file in the new user_path:
+    files_present = os.listdir(user_low_path)
+    assert len(files_present) == 1
+    assert 'config.yaml' in files_present
+
+    # if we add a repo, even one that doesn't really exist,
+    # this should generate a file in the user path
+    spack.config.set('repos',
+                     [str(tmpdir)],
+                     scope='low')
+
+    files_present = os.listdir(user_low_path)
+    assert len(files_present) == 2
+    assert 'repos.yaml' in files_present
+
+    # a high priority scope config.yaml addition to user_path
+    # should override the lower priority value set above:
+
+    with open(os.path.join(high_path, 'config.yaml'), 'w') as f:
+        f.write('''\
+config:
+  user_path: {user_high_path}
+'''.format(user_high_path=user_high_path))
+
+    mock_config.push_scope(high_scope)
+    assert spack.config.get('config:user_path') == user_high_path
+
+    # confirm population of new user path once again,
+    # this time looking for a mirrors.yaml file
+
+    spack.config.set('mirrors',
+                     {'dummy': str(tmpdir)})
+
+    files_present = os.listdir(user_high_path)
+    assert len(files_present) == 2
+    assert 'mirrors.yaml' in files_present
+    assert 'repos.yaml' not in files_present
+
+    # make sure previous user_path is no longer being
+    # "polluted"
+    assert 'mirrors.yaml' not in os.listdir(user_low_path)
+
+
+def test_misc_cache_user_path(tmpdir):
+    # the misc_cache path should become rooted
+    # in the user_path when user_path is set
+    # by user to a non-default value, otherwise
+    # we'd continue writing to ~/.spack/cache
+    # when user_path is not ~/.spack
+
+    # to avoid disrupting local spack instance,
+    # create a duplicate configuration here with
+    # a high priority scope pointing to a tmpdir path
+    # added in
+
+    from spack.config import configuration_paths, _config
+    import llnl.util.lang
+
+    test_config_path = os.path.join(str(tmpdir), 'test')
+    mkdirp(test_config_path)
+    new_config_path = ('test', test_config_path)
+
+    with open(os.path.join(test_config_path, 'config.yaml'), 'w') as f:
+        f.write('''\
+config:
+  user_path: {test_path}
+'''.format(test_path=test_config_path))
+
+    configuration_paths = list(configuration_paths)
+    configuration_paths.append(new_config_path)
+
+    spack.config.configuration_paths = tuple(configuration_paths)
+
+    # flush through code path in the library by creating
+    # the new singleton instance:
+    test_config = llnl.util.lang.Singleton(_config)
+
+    config = test_config.get('config')
+    expected_misc_cache_path = os.path.join(test_config_path, 'cache')
+    assert config['misc_cache'] == expected_misc_cache_path


### PR DESCRIPTION
* it is no longer absolutely required that
`~/.spack` be used as the user-level config
scope path---it can now be customized
to any arbitrary system path

* `~/.spack` remains the default for backward
compatibility, but a custom value may
be provided in `etc/spack/defaults/config.yaml`

* to accomplish this, it was necessary to
generate a second `Configuration` instance containing
only the default scope, so that this scope
could be parsed for the `user_path` setting
when populating the true `Configuration`
scope

Fixes #12892
Fixes #13057
Closes #7433

cc @junghans @AndrewGaspar @alalazo

### Notes

- the diff makes it look more complicated than it really is because of the shifting around of functions in the config scope code
- if the core team thinks this might work, I could use some guidance on unit tests---for now, I've been able to change the new `user_path` variable value and my repos and mirror lists get cleared, and if I add new ones then the new `user_path` starts getting populated with config files, which is a good sign, I think