### PR TITLE
Add apr-util 1.6.1

### DIFF
--- a/var/spack/repos/builtin/packages/apr-util/package.py
+++ b/var/spack/repos/builtin/packages/apr-util/package.py
@@ -10,8 +10,9 @@ class AprUtil(AutotoolsPackage):
     """Apache Portable Runtime Utility"""
 
     homepage  = 'https://apr.apache.org/'
-    url       = 'http://archive.apache.org/dist/apr/apr-util-1.6.0.tar.gz'
+    url       = 'https://archive.apache.org/dist/apr/apr-util-1.6.1.tar.gz'
 
+    version('1.6.1', sha256='b65e40713da57d004123b6319828be7f1273fbc6490e145874ee1177e112c459')
     version('1.6.0', sha256='483ef4d59e6ac9a36c7d3fd87ad7b9db7ad8ae29c06b9dd8ff22dda1cc416389')
     version('1.5.4', sha256='976a12a59bc286d634a21d7be0841cc74289ea9077aa1af46be19d1a6e844c19')
 


### PR DESCRIPTION
Successfully installs on macOS 10.15 with Clang 11.0.0.