### PR TITLE
Add bison 3.4.2

### DIFF
--- a/var/spack/repos/builtin/packages/bison/package.py
+++ b/var/spack/repos/builtin/packages/bison/package.py
@@ -13,9 +13,10 @@ class Bison(AutotoolsPackage):
     an annotated context-free grammar into a deterministic LR or
     generalized LR (GLR) parser employing LALR(1) parser tables."""
 
-    homepage = "http://www.gnu.org/software/bison/"
-    url      = "https://ftpmirror.gnu.org/bison/bison-3.0.4.tar.gz"
+    homepage = "https://www.gnu.org/software/bison/"
+    url      = "https://ftpmirror.gnu.org/bison/bison-3.4.2.tar.gz"
 
+    version('3.4.2', sha256='ff3922af377d514eca302a6662d470e857bd1a591e96a2050500df5a9d59facf')
     version('3.0.5', sha256='cd399d2bee33afa712bac4b1f4434e20379e9b4099bce47189e09a7675a2d566')
     version('3.0.4', sha256='b67fd2daae7a64b5ba862c66c07c1addb9e6b1b05c5f2049392cfd8a2172952e')
     version('2.7',   sha256='19bbe7374fd602f7a6654c131c21a15aebdc06cc89493e8ff250cb7f9ed0a831')


### PR DESCRIPTION
Successfully installs on macOS 10.15 with Clang 11.0.0.