### PR TITLE
Add freetype 2.10.1

### DIFF
--- a/var/spack/repos/builtin/packages/freetype/package.py
+++ b/var/spack/repos/builtin/packages/freetype/package.py
@@ -13,12 +13,13 @@ class Freetype(AutotoolsPackage):
     of most vector and bitmap font formats."""
 
     homepage = "https://www.freetype.org/index.html"
-    url      = "https://download.savannah.gnu.org/releases/freetype/freetype-2.9.1.tar.gz"
+    url      = "https://download.savannah.gnu.org/releases/freetype/freetype-2.10.1.tar.gz"
 
-    version('2.9.1', sha256='ec391504e55498adceb30baceebd147a6e963f636eb617424bcfc47a169898ce')
-    version('2.7.1', sha256='162ef25aa64480b1189cdb261228e6c5c44f212aac4b4621e28cf2157efb59f5')
-    version('2.7',   sha256='7b657d5f872b0ab56461f3bd310bd1c5ec64619bd15f0d8e08282d494d9cfea4')
-    version('2.5.3', sha256='41217f800d3f40d78ef4eb99d6a35fd85235b64f81bc56e4812d7672fca7b806')
+    version('2.10.1', sha256='3a60d391fd579440561bf0e7f31af2222bc610ad6ce4d9d7bd2165bca8669110')
+    version('2.9.1',  sha256='ec391504e55498adceb30baceebd147a6e963f636eb617424bcfc47a169898ce')
+    version('2.7.1',  sha256='162ef25aa64480b1189cdb261228e6c5c44f212aac4b4621e28cf2157efb59f5')
+    version('2.7',    sha256='7b657d5f872b0ab56461f3bd310bd1c5ec64619bd15f0d8e08282d494d9cfea4')
+    version('2.5.3',  sha256='41217f800d3f40d78ef4eb99d6a35fd85235b64f81bc56e4812d7672fca7b806')
 
     depends_on('libpng')
     depends_on('bzip2')


### PR DESCRIPTION
Successfully installs on macOS 10.15 with Clang 11.0.0.