### PR TITLE
Add help2man 1.47.11

### DIFF
--- a/var/spack/repos/builtin/packages/help2man/package.py
+++ b/var/spack/repos/builtin/packages/help2man/package.py
@@ -11,8 +11,9 @@ class Help2man(AutotoolsPackage):
     output of other commands."""
 
     homepage = "https://www.gnu.org/software/help2man/"
-    url      = "https://ftpmirror.gnu.org/help2man/help2man-1.47.4.tar.xz"
+    url      = "https://ftpmirror.gnu.org/help2man/help2man-1.47.11.tar.xz"
 
+    version('1.47.11', sha256='5985b257f86304c8791842c0c807a37541d0d6807ee973000cf8a3fe6ad47b88')
     version('1.47.8', sha256='528f6a81ad34cbc76aa7dce5a82f8b3d2078ef065271ab81fda033842018a8dc')
     version('1.47.4', '544aca496a7d89de3e5d99e56a2f03d3')
 


### PR DESCRIPTION
Successfully installs on macOS 10.15 with Clang 11.0.0.