### PR TITLE
Add SCons 3.1.1

### DIFF
--- a/var/spack/repos/builtin/packages/scons/package.py
+++ b/var/spack/repos/builtin/packages/scons/package.py
@@ -10,8 +10,9 @@ class Scons(PythonPackage):
     """SCons is a software construction tool"""
 
     homepage = "http://scons.org"
-    url      = "https://pypi.io/packages/source/s/scons/scons-3.0.1.tar.gz"
+    url      = "https://pypi.io/packages/source/s/scons/scons-3.1.1.tar.gz"
 
+    version('3.1.1', sha256='fd44f8f2a4562e7e5bc8c63c82b01e469e8115805a3e9c2923ee54cdcd6678b3')
     version('3.1.0', sha256='94e0d0684772d3e6d9368785296716e0ed6ce757270b3ed814e5aa72d3163890')
     version('3.0.5', sha256='e95eaae17d9e490cf12cd37f091a6cbee8a628b5c8dbd3cab1f348f602f46462')
     version('3.0.4', sha256='72c0b56db84f40d3558f351918a0ab98cb4345e8696e879d3e271f4df4a5913c')


### PR DESCRIPTION
Successfully installs on macOS 10.15 with Clang 11.0.0.