### PR TITLE
Fix valgrind concretization on macOS

### DIFF
--- a/var/spack/repos/builtin/packages/valgrind/package.py
+++ b/var/spack/repos/builtin/packages/valgrind/package.py
@@ -36,7 +36,7 @@ class Valgrind(AutotoolsPackage):
             description='Activates boost support for valgrind')
     variant('only64bit', default=True,
             description='Sets --enable-only64bit option for valgrind')
-    variant('ubsan', default=True,
+    variant('ubsan', default=sys.platform != 'darwin',
             description='Activates ubsan support for valgrind')
 
     conflicts('+ubsan', when='platform=darwin %clang',


### PR DESCRIPTION
The conflict immediately below the variant prevents building the package on macOS.