### PR TITLE
Add missing gettext dependency to watch

### DIFF
--- a/var/spack/repos/builtin/packages/watch/package.py
+++ b/var/spack/repos/builtin/packages/watch/package.py
@@ -24,6 +24,7 @@ class Watch(AutotoolsPackage):
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
     depends_on('pkgconfig@0.9.0:', type='build')
+    depends_on('gettext', type='build')
     depends_on('ncurses')
 
     # https://github.com/Homebrew/homebrew-core/blob/master/Formula/watch.rb


### PR DESCRIPTION
Successfully installs on macOS 10.15 with Clang 11.0.0.