### PR TITLE
Add missing libiconv dependency to wget

### DIFF
--- a/var/spack/repos/builtin/packages/wget/package.py
+++ b/var/spack/repos/builtin/packages/wget/package.py
@@ -43,6 +43,7 @@ class Wget(AutotoolsPackage):
 
     depends_on('perl@5.12.0:', type='build')
     depends_on('pkgconfig', type='build')
+    depends_on('libiconv')
 
     depends_on('valgrind', type='test')
 


### PR DESCRIPTION
Successfully installs on macOS 10.15 with Clang 11.0.0.