### PR TITLE
Add missing test dependency to py-bottleneck

### DIFF
--- a/var/spack/repos/builtin/packages/py-bottleneck/package.py
+++ b/var/spack/repos/builtin/packages/py-bottleneck/package.py
@@ -16,3 +16,4 @@ class PyBottleneck(PythonPackage):
 
     depends_on('py-setuptools', type='build')
     depends_on('py-numpy', type=('build', 'run'))
+    depends_on('py-nose', type='test')


### PR DESCRIPTION
Successfully installs on macOS 10.15 with Clang 11.0.0.