### PR TITLE
Add py-packaging 19.2

### DIFF
--- a/var/spack/repos/builtin/packages/py-packaging/package.py
+++ b/var/spack/repos/builtin/packages/py-packaging/package.py
@@ -10,16 +10,17 @@ class PyPackaging(PythonPackage):
     """Core utilities for Python packages."""
 
     homepage = "https://github.com/pypa/packaging"
-    url      = "https://pypi.io/packages/source/p/packaging/packaging-19.1.tar.gz"
+    url      = "https://pypi.io/packages/source/p/packaging/packaging-19.2.tar.gz"
 
     import_modules = ['packaging']
 
+    version('19.2', sha256='28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47')
     version('19.1', sha256='c491ca87294da7cc01902edbe30a5bc6c4c28172b5138ab4e4aa1b9d7bfaeafe')
     version('17.1', '8baf8241d1b6b0a5fae9b00f359976a8')
     version('16.8', '53895cdca04ecff80b54128e475b5d3b')
 
     depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
-    depends_on('py-attrs', type=('build', 'run'))
+    depends_on('py-attrs', when='@:19.1', type=('build', 'run'))
     depends_on('py-pyparsing@2.0.2:', type=('build', 'run'))
     depends_on('py-six', type=('build', 'run'))
 


### PR DESCRIPTION
Successfully installs on macOS 10.15 with Clang 11.0.0.