### PR TITLE
Add py-pillow 6.2.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-pillow/package.py
+++ b/var/spack/repos/builtin/packages/py-pillow/package.py
@@ -71,7 +71,7 @@ class PyPillow(PythonPackage):
         setup.filter('ZLIB_ROOT = None',
                      'ZLIB_ROOT = ("{0}", "{1}")'.format(
                          spec['zlib'].prefix.lib,
-                             spec['zlib'].prefix.include))
+                         spec['zlib'].prefix.include))
         if '+tiff' in spec:
             setup.filter('TIFF_ROOT = None',
                          'TIFF_ROOT = ("{0}", "{1}")'.format(

--- a/var/spack/repos/builtin/packages/py-pillow/package.py
+++ b/var/spack/repos/builtin/packages/py-pillow/package.py
@@ -14,8 +14,9 @@ class PyPillow(PythonPackage):
     capabilities."""
 
     homepage = "https://python-pillow.org/"
-    url = "https://pypi.io/packages/source/P/Pillow/Pillow-5.1.0.tar.gz"
+    url = "https://pypi.io/packages/source/P/Pillow/Pillow-6.2.0.tar.gz"
 
+    version('6.2.0', sha256='4548236844327a718ce3bb182ab32a16fa2050c61e334e959f554cac052fb0df')
     version('5.4.1', sha256='5233664eadfa342c639b9b9977190d64ad7aca4edc51a966394d7e08e7f38a9f')
     version('5.1.0', sha256='cee9bc75bff455d317b6947081df0824a8f118de2786dc3d74a3503fd631f4ef')
     version('3.2.0', sha256='64b0a057210c480aea99406c9391180cd866fc0fd8f0b53367e3af21b195784a')
@@ -24,11 +25,9 @@ class PyPillow(PythonPackage):
     provides('pil')
 
     # These defaults correspond to Pillow defaults
-    variant('jpeg', default=True, description='Provide JPEG functionality')
-    variant('zlib', default=True, description='Access to compressed PNGs')
-    variant('tiff', default=False, description='Access to TIFF files')
+    variant('tiff',     default=False, description='Access to TIFF files')
     variant('freetype', default=False, description='Font related services')
-    variant('lcms', default=False, description='Color management')
+    variant('lcms',     default=False, description='Color management')
     variant('jpeg2000', default=False, description='Provide JPEG 2000 functionality')
 
     # Spack does not (yet) support these modes of building
@@ -40,11 +39,10 @@ class PyPillow(PythonPackage):
 
     # Required dependencies
     depends_on('binutils', type='build', when=sys.platform != 'darwin')
+    depends_on('python@2.7:2.8,3.5:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
-
-    # Recommended dependencies
-    depends_on('jpeg', when='+jpeg')
-    depends_on('zlib', when='+zlib')
+    depends_on('jpeg')
+    depends_on('zlib')
 
     # Optional dependencies
     depends_on('libtiff', when='+tiff')
@@ -66,15 +64,13 @@ class PyPillow(PythonPackage):
         spec = self.spec
         setup = FileFilter('setup.py')
 
-        if '+jpeg' in spec:
-            setup.filter('JPEG_ROOT = None',
-                         'JPEG_ROOT=("{0}","{1}")'.format(
-                             spec['jpeg'].libs.directories[0],
-                             spec['jpeg'].prefix.include))
-        if '+zlib' in spec:
-            setup.filter('ZLIB_ROOT = None',
-                         'ZLIB_ROOT = ("{0}", "{1}")'.format(
-                             spec['zlib'].prefix.lib,
+        setup.filter('JPEG_ROOT = None',
+                     'JPEG_ROOT=("{0}","{1}")'.format(
+                         spec['jpeg'].libs.directories[0],
+                         spec['jpeg'].prefix.include))
+        setup.filter('ZLIB_ROOT = None',
+                     'ZLIB_ROOT = ("{0}", "{1}")'.format(
+                         spec['zlib'].prefix.lib,
                              spec['zlib'].prefix.include))
         if '+tiff' in spec:
             setup.filter('TIFF_ROOT = None',


### PR DESCRIPTION
Successfully installs on macOS 10.15 with Clang 11.0.0.