### PR TITLE
Add py-setuptools-scm 3.3.3

### DIFF
--- a/var/spack/repos/builtin/packages/py-setuptools-scm/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools-scm/package.py
@@ -10,10 +10,11 @@ class PySetuptoolsScm(PythonPackage):
     """The blessed package to manage your versions by scm tags."""
 
     homepage = "https://github.com/pypa/setuptools_scm"
-    url      = "https://pypi.io/packages/source/s/setuptools_scm/setuptools_scm-3.1.0.tar.gz"
+    url      = "https://pypi.io/packages/source/s/setuptools_scm/setuptools_scm-3.3.3.tar.gz"
 
     import_modules = ['setuptools_scm']
 
+    version('3.3.3',  sha256='bd25e1fb5e4d603dcf490f1fde40fb4c595b357795674c3e5cb7f6217ab39ea5')
     version('3.1.0',  sha256='1191f2a136b5e86f7ca8ab00a97ef7aef997131f1f6d4971be69a1ef387d8b40')
     version('1.15.6', sha256='49ab4685589986a42da85706b3311a2f74f1af567d39fee6cb1e088d7a75fb5f')
 


### PR DESCRIPTION
Successfully installs on macOS 10.15 with Clang 11.0.0.