### PR TITLE
llnl/filesystem: ignore encoding issues when filtering files

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -158,15 +158,22 @@ def filter_file(regex, repl, *filenames, **kwargs):
         if not os.path.exists(backup_filename):
             shutil.copy(filename, backup_filename)
 
+        fileno, tmp_filename = tempfile.mkstemp(text=True)
         try:
-            for line in fileinput.input(filename, inplace=True):
-                print(re.sub(regex, repl, line.rstrip('\n')))
+            with os.fdopen(fileno, mode='w', errors='surrogateescape') as tmp:
+                with open(filename, errors='surrogateescape') as fd:
+                    for line in fd:
+                        tmp.write(re.sub(regex, repl, line))
+            permissions = os.stat(filename).st_mode
+            shutil.move(tmp_filename, filename)
+            os.chmod(filename, permissions)
         except BaseException:
             # clean up the original file on failure.
             shutil.move(backup_filename, filename)
             raise
-
         finally:
+            if os.path.exists(tmp_filename):
+                os.remove(tmp_filename)
             if not backup and os.path.exists(backup_filename):
                 os.remove(backup_filename)
 


### PR DESCRIPTION
We use the build cache a lot, and some headers don't have proper UTF-8
encoding, which trips up the filtering in place. E.g.,

boost/spirit/home/x3/support/subcontext.hpp

will fail relocation. Fileinput does not allow to specify an encoding
hook with `inplace=True`, so work around that.

Any thoughts?