### PR TITLE
F18 Oct2019 Minor Update

### DIFF
--- a/var/spack/repos/builtin/packages/f18/package.py
+++ b/var/spack/repos/builtin/packages/f18/package.py
@@ -10,9 +10,9 @@ class F18(CMakePackage):
     """F18 is a front-end for Fortran intended to replace the existing front-end
     in the Flang compiler"""
 
+    # Package information
     homepage = "https://github.com/flang-compiler/f18"
-
-    git      = "https://github.com/flang-compiler/f18"
+    git      = "https://github.com/flang-compiler/f18.git"
 
     version('master', branch='master')
 

--- a/var/spack/repos/builtin/packages/f18/package.py
+++ b/var/spack/repos/builtin/packages/f18/package.py
@@ -22,7 +22,7 @@ class F18(CMakePackage):
             values=('Debug', 'Release', 'RelWithDebInfo'))
 
     # Dependencies
-    depends_on('cmake@3.9.0:')
+    depends_on('cmake@3.9.0:', type='build')
     depends_on('llvm+clang@7:')
 
     # Conflicts

--- a/var/spack/repos/builtin/packages/f18/package.py
+++ b/var/spack/repos/builtin/packages/f18/package.py
@@ -16,4 +16,18 @@ class F18(CMakePackage):
 
     version('master', branch='master')
 
-    depends_on('llvm@6.0.0+clang', when='@master')
+    # Variants
+    variant('build_type', default='Release',
+            description='The build type to build',
+            values=('Debug', 'Release', 'RelWithDebInfo'))
+
+    # Dependencies
+    depends_on('cmake@3.9.0:')
+    depends_on('llvm+clang@7:')
+
+    # Conflicts
+    compiler_warning = 'F18 requires a compiler with support for C++17'
+    conflicts('%clang@:6', msg=compiler_warning)
+    conflicts('%gcc@:7.1', msg=compiler_warning)
+    conflicts('%intel', msg=compiler_warning)
+    conflicts('%pgi', msg=compiler_warning)


### PR DESCRIPTION
Minor updates and enhancements to the F18 package:

- Support CMake build types
- Update LLVM dependency
- Add conflict to only include compilers that support C++17

@certik @adamjstewart 