### PR TITLE
Flux v0.11.1 - v0.11.3

### DIFF
--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -14,7 +14,10 @@ class FluxCore(AutotoolsPackage):
     url      = "https://github.com/flux-framework/flux-core/releases/download/v0.8.0/flux-core-0.8.0.tar.gz"
     git      = "https://github.com/flux-framework/flux-core.git"
 
-    version('master',  branch='master')
+    version('master', branch='master')
+    version('0.11.3', sha256='91b5d7dca8fc28a77777c4e4cb8717fc3dc2c174e70611740689a71901c6de7e')
+    version('0.11.2', sha256='ab8637428cd9b74b2dff4842d10e0fc4acc8213c4e51f31d32a4cbfbdf730412')
+    version('0.11.1', sha256='3c8495db0f3b701f6dfe3e2a75aed794fc561e9f28284e8c02ac67693bfe890e')
     version('0.11.0', sha256='a4d8ff92e79b4ca19d556395bb8c5f8dc02fd9d5a8cc38c4a2c66867a96de5ea')
     version('0.10.0', sha256='a70cdd228077af60c9443a5c69d3da932e447dd11697f5fef9028c48dabb3041')
     version('0.9.0',  sha256='7b5b4aa72704b3c4432136b9e515e0d663568e6dbfc3ecd2f91c83b65841104e')
@@ -46,10 +49,10 @@ class FluxCore(AutotoolsPackage):
     depends_on("py-cffi", type=('build', 'run'))
     depends_on("py-six", type=('build', 'run'), when="@0.11.0:,master")
     depends_on("py-pyyaml", type=('build', 'run'), when="@0.11.0:,master")
-    depends_on("py-jsonschema", type=('build', 'run'), when="@master")
+    depends_on("py-jsonschema", type=('build', 'run'), when="@0.12.0:,master")
     depends_on("jansson")
     depends_on("pkgconfig")
-    depends_on("yaml-cpp", when="@:0.11.0")
+    depends_on("yaml-cpp", when="@:0.11.99")
     depends_on("lz4", when="@0.11.0:,master")
 
     # versions up to 0.8.0 uses pylint to check Flux's python binding

--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -139,6 +139,26 @@ class FluxCore(AutotoolsPackage):
         env.prepend_path('FLUX_MODULE_PATH', self.prefix.lib.flux.modules)
         env.prepend_path('FLUX_EXEC_PATH', self.prefix.libexec.flux.cmd)
         env.prepend_path('FLUX_RC_PATH', self.prefix.etc.flux)
+        env.prepend_path('FLUX_RC1_PATH', self.prefix.etc.flux.rc1)
+        env.prepend_path('FLUX_RC3_PATH', self.prefix.etc.flux.rc3)
+        env.prepend_path(
+            'FLUX_CONNECTOR_PATH',
+            self.prefix.lib.flux.connectors
+        )
+        env.prepend_path(
+            'FLUX_PMI_LIBRARY_PATH',
+            os.path.join(self.prefix.lib.flux, "libpmi.so")
+        )
+        # Wreck was removed in 0.12
+        if self.version < Version("0.12.0"):
+            env.prepend_path(
+                'FLUX_WREXECD_PATH',
+                self.prefix.libexec.flux.wrexecd
+            )
+            env.prepend_path(
+                'FLUX_WRECK_LUA_PATTERN',
+                os.path.join(self.prefix.etc.wreck, "lua.d", "*.lua")
+            )
 
     def configure_args(self):
         args = ['--enable-pylint=no']

--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -118,7 +118,7 @@ class FluxCore(AutotoolsPackage):
 
     def setup_build_environment(self, env):
         #  Ensure ./fluxometer.lua can be found during flux's make check
-        spack_env.append_path('LUA_PATH', './?.lua', separator=';')
+        env.append_path('LUA_PATH', './?.lua', separator=';')
 
     def setup_run_environment(self, env):
         env.prepend_path(

--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -32,7 +32,7 @@ class FluxCore(AutotoolsPackage):
 
     depends_on("libzmq@4.0.4:")
     depends_on("czmq")
-    depends_on("czmq@2.2:3.99", when="@0.1:0.6.99")
+    depends_on("czmq@2.2:3.99", when="@0.1:0.6")
     depends_on("czmq@3.0.1:", when="@0.7:")
     depends_on("hwloc@1.11.1:1.99")
     depends_on("hwloc +cuda", when='+cuda')
@@ -52,7 +52,7 @@ class FluxCore(AutotoolsPackage):
     depends_on("py-jsonschema", type=('build', 'run'), when="@0.12.0:")
     depends_on("jansson")
     depends_on("pkgconfig")
-    depends_on("yaml-cpp", when="@:0.11.99")
+    depends_on("yaml-cpp", when="@:0.11")
     depends_on("lz4", when="@0.11.0:")
 
     # versions up to 0.8.0 uses pylint to check Flux's python binding

--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -63,6 +63,24 @@ class FluxCore(AutotoolsPackage):
     depends_on("automake", type='build', when='@master')
     depends_on("libtool", type='build', when='@master')
 
+    def url_for_version(self, version):
+        '''
+        Flux uses a fork of ZeroMQ's Collective Code Construction Contract
+        (https://github.com/flux-framework/rfc/blob/master/spec_1.adoc).
+        This model requires a repository fork for every stable release that has
+        patch releases.  For example, 0.8.0 and 0.9.0 are both tags within the
+        main repository, but 0.8.1 and 0.9.5 would be releases on the v0.8 and
+        v0.9 forks, respectively.
+
+        Rather than provide an explicit URL for each patch release, make Spack
+        aware of this repo structure.
+        '''
+        if version[-1] == 0:
+            url = "https://github.com/flux-framework/flux-core/releases/download/v{0}/flux-core-{0}.tar.gz"
+        else:
+            url = "https://github.com/flux-framework/flux-core-v{1}/releases/download/v{0}/flux-core-{0}.tar.gz"
+        return url.format(version.up_to(3), version.up_to(2))
+
     def setup(self):
         pass
 

--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -33,7 +33,7 @@ class FluxCore(AutotoolsPackage):
     depends_on("libzmq@4.0.4:")
     depends_on("czmq")
     depends_on("czmq@2.2:3.99", when="@0.1:0.6.99")
-    depends_on("czmq@3.0.1:", when="@0.7:,master")
+    depends_on("czmq@3.0.1:", when="@0.7:")
     depends_on("hwloc@1.11.1:1.99")
     depends_on("hwloc +cuda", when='+cuda')
     # Provide version hints for lua so that the concretizer succeeds when no
@@ -45,15 +45,15 @@ class FluxCore(AutotoolsPackage):
     depends_on("munge", when="@0.1.0:0.10.0")
     depends_on("python", type=('build', 'run'))
     depends_on("python@2.7:2.99", when="@0.1.0:0.11.0")
-    depends_on("python@2.7:", when="@0.11.1:,master")
+    depends_on("python@2.7:", when="@0.11.1:")
     depends_on("py-cffi", type=('build', 'run'))
-    depends_on("py-six", type=('build', 'run'), when="@0.11.0:,master")
-    depends_on("py-pyyaml", type=('build', 'run'), when="@0.11.0:,master")
-    depends_on("py-jsonschema", type=('build', 'run'), when="@0.12.0:,master")
+    depends_on("py-six", type=('build', 'run'), when="@0.11.0:")
+    depends_on("py-pyyaml", type=('build', 'run'), when="@0.11.0:")
+    depends_on("py-jsonschema", type=('build', 'run'), when="@0.12.0:")
     depends_on("jansson")
     depends_on("pkgconfig")
     depends_on("yaml-cpp", when="@:0.11.99")
-    depends_on("lz4", when="@0.11.0:,master")
+    depends_on("lz4", when="@0.11.0:")
 
     # versions up to 0.8.0 uses pylint to check Flux's python binding
     # later versions provide a configure flag and disable the check by default

--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -66,6 +66,11 @@ class FluxCore(AutotoolsPackage):
     depends_on("automake", type='build', when='@master')
     depends_on("libtool", type='build', when='@master')
 
+    # Testing Dependencies
+    depends_on("mpich pmi=pmi", type="test")
+    depends_on("valgrind", type="test")
+    depends_on("jq", type="test", when='@0.12.0:')
+
     def url_for_version(self, version):
         '''
         Flux uses a fork of ZeroMQ's Collective Code Construction Contract

--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -27,9 +27,9 @@ class FluxSched(AutotoolsPackage):
 
     variant('cuda', default=False, description='Build dependencies with support for CUDA')
 
-    depends_on("boost+graph@1.53.0,1.59.0:", when='@0.5.0:,master')
-    depends_on("py-pyyaml", when="@0.7.0:,master")
-    depends_on("libxml2@2.9.1:", when="@0.6.0,master")
+    depends_on("boost+graph@1.53.0,1.59.0:", when='@0.5.0:')
+    depends_on("py-pyyaml", when="@0.7.0:")
+    depends_on("libxml2@2.9.1:", when="@0.6.0")
     depends_on("yaml-cpp", when="@0.7.0:")
     depends_on("libuuid")
     depends_on("pkgconfig")

--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -106,18 +106,18 @@ class FluxSched(AutotoolsPackage):
     def lua_lib_dir(self):
         return os.path.join('lib', 'lua', str(self.lua_version))
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path(
+    def setup_run_environment(self, env):
+        env.prepend_path(
             'LUA_PATH',
             os.path.join(self.spec.prefix, self.lua_share_dir, '?.lua'),
             separator=';')
-        run_env.prepend_path(
+        env.prepend_path(
             'LUA_CPATH',
             os.path.join(self.spec.prefix, self.lua_lib_dir, '?.so'),
             separator=';')
 
-        run_env.prepend_path('FLUX_MODULE_PATH', self.prefix.lib.flux.modules)
-        run_env.prepend_path('FLUX_MODULE_PATH',
-                             self.prefix.lib.flux.modules.sched)
-        run_env.prepend_path('FLUX_EXEC_PATH', self.prefix.libexec.flux.cmd)
-        run_env.prepend_path('FLUX_RC_EXTRA', self.prefix.etc.flux)
+        env.prepend_path('FLUX_MODULE_PATH', self.prefix.lib.flux.modules)
+        env.prepend_path('FLUX_MODULE_PATH',
+                         self.prefix.lib.flux.modules.sched)
+        env.prepend_path('FLUX_EXEC_PATH', self.prefix.libexec.flux.cmd)
+        env.prepend_path('FLUX_RC_EXTRA', self.prefix.etc.flux)

--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -46,6 +46,24 @@ class FluxSched(AutotoolsPackage):
     depends_on("automake", type='build', when='@master')
     depends_on("libtool", type='build', when='@master')
 
+    def url_for_version(self, version):
+        '''
+        Flux uses a fork of ZeroMQ's Collective Code Construction Contract
+        (https://github.com/flux-framework/rfc/blob/master/spec_1.adoc).
+        This model requires a repository fork for every stable release that has
+        patch releases.  For example, 0.8.0 and 0.9.0 are both tags within the
+        main repository, but 0.8.1 and 0.9.5 would be releases on the v0.8 and
+        v0.9 forks, respectively.
+
+        Rather than provide an explicit URL for each patch release, make Spack
+        aware of this repo structure.
+        '''
+        if version[-1] == 0:
+            url = "https://github.com/flux-framework/flux-sched/releases/download/v{0}/flux-sched-{0}.tar.gz"
+        else:
+            url = "https://github.com/flux-framework/flux-sched-v{1}/releases/download/v{0}/flux-sched-{0}.tar.gz"
+        return url.format(version.up_to(3), version.up_to(2))
+
     def setup(self):
         pass
 

--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -15,6 +15,7 @@ class FluxSched(AutotoolsPackage):
     git      = "https://github.com/flux-framework/flux-sched.git"
 
     version('master', branch='master')
+    version('0.7.1', sha256='a35e555a353feed6b7b814ae83d05362356f9ee33ffa75d7dfb7e2fe86c21294')
     version('0.7.0', sha256='69267a3aaacaedd9896fd90cfe17aef266cba4fb28c77f8123d95a31ce739a7b')
     version('0.6.0', sha256='3301d4c10810414228e5969b84b75fe1285abb97453070eb5a77f386d8184f8d')
     version('0.5.0', sha256='d6347f5c85c12c76364dccb39d63c007094ca9cbbbae4e8f4e98d8b1c0b07e89')
@@ -39,6 +40,7 @@ class FluxSched(AutotoolsPackage):
     depends_on("flux-core@0.9.0", when='@0.5.0')
     depends_on("flux-core@0.10.0", when='@0.6.0')
     depends_on("flux-core@0.11.0", when='@0.7.0')
+    depends_on("flux-core@0.11.2:0.11.99", when='@0.7.1')
     depends_on("flux-core@master", when='@master')
 
     # Need autotools when building on master:


### PR DESCRIPTION
Support flux-core versions v0.11.1 to v0.11.3 (and associated flux-sched versions).  

Encode the C4 repo model in the `url_for_version` function to support future patch release (and minor versions once it passes v1.0).