### PR TITLE
WIP, ENH: Support relative mirror paths

### DIFF
--- a/lib/spack/docs/mirrors.rst
+++ b/lib/spack/docs/mirrors.rst
@@ -187,6 +187,18 @@ You can tell your Spack installation to use that mirror like this:
 
 Each mirror has a name so that you can refer to it again later.
 
+Support is also available for adding mirrors at relative file paths.
+If this is done on the Spack command line, the relative path will
+be modified internally so that it is written to the ``mirrors.yaml``
+file as a path relative to that file. In this way, relative path
+addition via the command line or via direct editing of the ``mirrors.yaml``
+file can agree on a single convention. Additionally, with this approach,
+fetching from a relative path is not subject to the spack command
+working directory. Note that spack currently stores the path
+to the ``mirrors.yaml`` file inside the file itself as a mirror
+named ``yaml_path``, so this mirror name should be treated as reserved.
+
+
 .. _cmd-spack-mirror-list:
 
 ---------------------

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -84,7 +84,9 @@ def setup_parser(subparser):
 def mirror_add(args):
     """Add a mirror to Spack."""
     url = args.url
-    if url.startswith('/'):
+
+    # add appropriate prefix to absolute or relative paths
+    if url.startswith(('/', '..')):
         url = 'file://' + url
 
     mirrors = spack.config.get('mirrors', scope=args.scope)

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -401,12 +401,16 @@ class Stage(object):
             path_string = 'file://'
             # resolve relative paths to absolute for fetching
             # purposes
+            yaml_path = mirrors.pop('yaml_path', None)
             for key in mirrors.keys():
                 current_path = mirrors[key]
                 target_path = current_path.replace(path_string, '')
-                if current_path.startswith(path_string) and not (
+                if current_path.startswith((path_string, '..')) and not (
                         os.path.isabs(target_path)):
-                    absolute_target_path = os.path.abspath(target_path)
+                    # produce an absolute path based on path relative
+                    # to yaml file
+                    absolute_target_path = os.path.normpath(os.path.join(
+                        yaml_path, target_path))
                     # we concatenate the paths because the prefix
                     # path string "file://" is unnatural
                     mirrors[key] = path_string + absolute_target_path

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -398,6 +398,18 @@ class Stage(object):
         self.skip_checksum_for_mirror = True
         if self.mirror_path:
             mirrors = spack.config.get('mirrors')
+            path_string = 'file://'
+            # resolve relative paths to absolute for fetching
+            # purposes
+            for key in mirrors.keys():
+                current_path = mirrors[key]
+                target_path = current_path.replace(path_string, '')
+                if current_path.startswith(path_string) and not (
+                        os.path.isabs(target_path)):
+                    absolute_target_path = os.path.abspath(target_path)
+                    # we concatenate the paths because the prefix
+                    # path string "file://" is unnatural
+                    mirrors[key] = path_string + absolute_target_path
 
             # Join URLs of mirror roots with mirror paths. Because
             # urljoin() will strip everything past the final '/' in

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -5,6 +5,7 @@
 
 import pytest
 import os
+import subprocess
 
 from spack.main import SpackCommand
 from spack.stage import Stage
@@ -51,24 +52,103 @@ def test_mirror_from_env(tmpdir, mock_packages, mock_fetch, config,
 
 @pytest.mark.disable_clean_stage_check
 @pytest.mark.regression('12710')
-def test_mirror_paths(tmpdir, capfd, mock_packages, mock_archive):
+@pytest.mark.parametrize('new_working_path', [
+    # mirror paths should be relative to the yaml file they
+    # are added to, NOT the spack working directory, so
+    # the test should pass with a variety of working paths
+    '.',
+    '..',
+    '../..',
+    '../../..',
+])
+@pytest.mark.parametrize('mirror_prefix', [
+    # relative mirror paths should be handled whether
+    # the file:// prefix is used or not (to match absolute
+    # path handling)
+    'file://', ''])
+@pytest.mark.parametrize('add_method', [
+    # add spack mirrors using config.set or mirror cmd directly
+    # or writing the mirror path to a file (relative to the yaml file
+    # itself)
+    'set',
+    'direct',
+    'file',
+])
+def test_mirror_paths(tmpdir, capfd, mock_packages, mock_archive,
+                      new_working_path, mirror_prefix, add_method):
     # handle mirrors added via relative paths
 
     with tmpdir.as_cwd():
         with Stage('spack-mirror-test') as stage:
             mirror_root = os.path.join(stage.path, 'test-mirror')
+            # use relative path here:
+            mirror_path = mirror_prefix + os.path.relpath(mirror_root)
 
-            # register mirror with spack config
-            # use relative path here!
-            mirrors = {'spack-mirror-test': 'file://' +
-                                            os.path.relpath(mirror_root)}
-            spack.config.set('mirrors', mirrors)
+            if add_method == 'set':
+                # register mirror with spack config
+                mirrors = {'spack-mirror-test': mirror_path}
+                spack.config.set('mirrors', mirrors)
+                with spack.config.override('config:checksum', False):
+                    mirror('create', '-d', mirror_root, 'libdwarf')
+            elif add_method == 'direct':
+                try:
+                    subprocess.call("spack mirror remove spack-mirror-test",
+                                    shell=True)
+                except subprocess.CalledProcessError:
+                    pass
+                # can't use use SpackCommand mirror() because we need a custom
+                # temporary scope
+                # TODO: don't use subprocess, especially with shell=True
+                # no additional failures were observed with this approach--if
+                # it is the same code path, we could just remove this
+                tmp_scope = str(tmpdir)
+                subprocess.call("spack -C {tmp_scope} mirror add "
+                                "spack-mirror-test {mirror_path}".format(
+                                    tmp_scope=tmp_scope,
+                                    mirror_path=mirror_path),
+                                shell=True)
+                subprocess.call("spack -C {tmp_scope} mirror create "
+                                " -d {mirror_root} libdwarf".format(
+                                    tmp_scope=tmp_scope,
+                                    mirror_root=mirror_root),
+                                shell=True)
+            elif add_method == 'file':
+                try:
+                    subprocess.call("spack mirror remove spack-mirror-test",
+                                    shell=True)
+                except subprocess.CalledProcessError:
+                    pass
+                # write a path relative to the mirrors.yaml file created
+                # in tmp scope
+                tmp_scope = str(tmpdir)
+                tmp_mirror_file = os.path.join(tmp_scope, 'mirrors.yaml')
+                rel_path = os.path.relpath(mirror_root, tmp_mirror_file)
+                with open(tmp_mirror_file, 'w') as mirror_file:
+                    mirror_file.write("""\
+mirrors:
+   spack-mirror-test: {rel_path}\n""".format(
+                        rel_path=rel_path))
+                subprocess.call("spack -C {tmp_scope} mirror create "
+                                " -d {mirror_root} libdwarf".format(
+                                    tmp_scope=tmp_scope,
+                                    mirror_root=mirror_root),
+                                shell=True)
 
-            with spack.config.override('config:checksum', False):
-                mirror('create', '-d', mirror_root, 'libdwarf')
+            # ensure robustness relative to different
+            # spack working paths
+            os.chdir(new_working_path)
 
-            with capfd.disabled():
-                output = fetch('-n', 'libdwarf')
+            if add_method != 'set':
+                # prevent cache retrieval circumventing the detection
+                # of issues with fetch on relative path
+                subprocess.call('spack clean -a', shell=True)
+                output = subprocess.check_output("spack -C {tmp_scope} "
+                                                 "fetch -n libdwarf".format(
+                                                     tmp_scope=tmp_scope),
+                                                 shell=True).decode('utf-8')
+            else:
+                with capfd.disabled():
+                    output = fetch('-n', 'libdwarf')
 
             for fetch_line in output.split('==>'):
                 if mirror_root.split(os.sep)[-2] in fetch_line:
@@ -76,3 +156,10 @@ def test_mirror_paths(tmpdir, capfd, mock_packages, mock_archive):
                     # from relative mirror path
                     for bad_entry in ['curl', '503', 'error', 'failed']:
                         assert bad_entry not in fetch_line
+                else:
+                    # an http fetch line would mean local mirror fetches
+                    # ultimately failed
+                    assert 'http' not in fetch_line
+                    # using the cache is cheating for this test
+                    if 'failed' not in fetch_line:
+                        assert 'cache' not in fetch_line

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -60,7 +60,7 @@ def test_mirror_paths(tmpdir, capfd, mock_packages, mock_archive):
 
             # register mirror with spack config
             # use relative path here!
-            mirrors = {'spack-mirror-test': 'file://' + 
+            mirrors = {'spack-mirror-test': 'file://' +
                                             os.path.relpath(mirror_root)}
             spack.config.set('mirrors', mirrors)
 


### PR DESCRIPTION
Fixes #12710  cc @AndrewGaspar @junghans 

A number of things to discuss / review carefully here if core devs decide this is a good idea:

- I've added a regression test for the new feature that fails before/ succeeds after, but could use some suggestions for improved mocking / not using actual downloads / artifacts (the spack testing infrastructure seems to have a bunch of things for this, but not necessarily easy to use naturally given the pytest fixture magic, etc.)
- in the original issue, Andrew had suggested that the relative path support be relative to the *yaml file location,* but in practice this has worked out more naturally for me to be relative to the *spack invocation / working directory,* at least in part because one of the most natural ways to add a mirror to the yaml is from the spack command line invocation itself (and it is slightly confusing to think about path relative to i.e., `~/.spack/...` when not working there, unless you edit the yaml file manually); so some design decisions to be made there
- the requirement to prefix local filepaths with `file://` currently remains, even for the relative filepath support, presumably for the `curl` feed-through
- whatever is decided above, relative paths can be confusing so the behavior should be well-documented; even if relative file path support is not enabled in the end, detection & traceback on the attempt to add a relative path would still be useful vs. silent "failure" on the addition of something that can never be fetched