### PR TITLE
WIP, ENH: Linux simultaneous install locking

### DIFF
--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -638,11 +638,11 @@ def test_simultaneous_installs():
     # TODO: use more secure shell=False
     output = subprocess.check_output("spack install bzip2 & "
                                      "spack install bzip2 && "
-                                     "wait", shell=True).decode(
-                                                         'utf-8')
+                                     "wait",
+                                     shell=True).decode('utf-8')
 
     query_string = 'Successfully installed bzip2'
-    query_lock_string =  'spack is currently locked'
+    query_lock_string = 'spack is currently locked'
 
     # a controlled simultaneous install scenario involves
     # one successful install & one locked access exit


### PR DESCRIPTION
Linux-only for now

- adds experimental support for "locking" attempts at doing `spack install package` multiple times simultaneously with the same spack instance (can be a problem leading to errors in certain CI testing situations, for example)
- the regression test, while reproducibly failing locally before the fix & passing after, is a little gruesome with `subprocess` shell usage---there may be better ways to use your mocking test infrastructure here?

Here's a simple example of this working for me locally on a Linux box, along with output:

```
tyler@machine:$ spack install bzip2 & spack install bzip2 && wait
[1] 32050
Acquired spack install Linux lock
spack is currently locked from additional install commands to protect against undesirable behavior with simultaneous installs
==> libiconv is already installed in /home/tyler/github_projects/spack/opt/spack/linux-ubuntu18.04-skylake_avx512/gcc-7.4.0/libiconv-1.16-ajkkpczfc3ijoubpfvksfghjg6hy2ovq
==> diffutils is already installed in /home/tyler/github_projects/spack/opt/spack/linux-ubuntu18.04-skylake_avx512/gcc-7.4.0/diffutils-3.7-woopak5zo6qrczxc37b4r6wvwm5o5snx
==> Installing bzip2
==> Searching for binary cache of bzip2
==> No binary for bzip2 found: installing from source
==> Using cached archive: /home/tyler/github_projects/spack/var/spack/cache/bzip2/bzip2-1.0.8.tar.gz
==> Staging archive: /tmp/tyler/spack-stage/bzip2-1.0.8-x4qtjiesmosoaosdibkhxsacpovckflu/bzip2-1.0.8.tar.gz
==> Created stage in /tmp/tyler/spack-stage/bzip2-1.0.8-x4qtjiesmosoaosdibkhxsacpovckflu
==> Ran patch() for bzip2
==> Building bzip2 [Package]
==> Executing phase: 'install'
==> Successfully installed bzip2
  Fetch: 0.00s.  Build: 1.92s.  Total: 1.93s.

```

cc @junghans 