### PR TITLE
ADIOS2: Default no Python

### DIFF
--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -57,7 +57,7 @@ class Adios2(CMakePackage):
             description='Enable the HDF5 engine')
 
     # optional language bindings, C++11 and C always provided
-    variant('python', default=True,
+    variant('python', default=False,
             description='Enable the Python bindings')
     variant('fortran', default=True,
             description='Enable the Fortran bindings')


### PR DESCRIPTION
There are few conventions for variant defaults in Spack, but `shared` (true), `mpi` (true) and `python` (false) are defined.
https://spack.readthedocs.io/en/latest/packaging_guide.html#variant-names

This can still be requested explicitly by users (`spack install adios2 +python`) and reduces the complexity of the default install a bit. Fortran bindings should potentially also be requested explicitly, but Spack (due to MPI packages) defaults them in anyway.

cc @williamfgc @chuckatkins 