### PR TITLE
ADIOS2: Document endian_reverse variant

### DIFF
--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -32,7 +32,8 @@ class Adios2(CMakePackage):
             description='Enable position independent code '
                         '(for usage of static in shared downstream deps)')
     variant('endian_reverse', default=False,
-            description='Enable Endian Interoperability')
+            description='Enable endian conversion if a different '
+                        'endianness is detected between write and read.')
 
     # compression libraries
     variant('blosc', default=True,


### PR DESCRIPTION
Update the documentation of the `endian_reverse` variant in ADIOS2. The short description caused [some confusion](https://github.com/ornladios/ADIOS2/issues/1822) (for me) :-)

cc @williamfgc @chuckatkins 