### PR TITLE
bugfix/tests: ensure `test_changed_files` uses only flake8 defaults

### DIFF
--- a/lib/spack/spack/cmd/flake8.py
+++ b/lib/spack/spack/cmd/flake8.py
@@ -227,6 +227,9 @@ def setup_parser(subparser):
         '-U', '--no-untracked', dest='untracked', action='store_false',
         default=True, help="exclude untracked files from checks")
     subparser.add_argument(
+        '-d', '--debug', action='store_true',
+        help="support spack option to write out debug logs during testing")
+    subparser.add_argument(
         'files', nargs=argparse.REMAINDER, help="specific files to check")
 
 

--- a/lib/spack/spack/cmd/flake8.py
+++ b/lib/spack/spack/cmd/flake8.py
@@ -227,9 +227,6 @@ def setup_parser(subparser):
         '-U', '--no-untracked', dest='untracked', action='store_false',
         default=True, help="exclude untracked files from checks")
     subparser.add_argument(
-        '-d', '--debug', action='store_true',
-        help="support spack option to write out debug logs during testing")
-    subparser.add_argument(
         'files', nargs=argparse.REMAINDER, help="specific files to check")
 
 

--- a/lib/spack/spack/test/cmd/flake8.py
+++ b/lib/spack/spack/test/cmd/flake8.py
@@ -45,7 +45,7 @@ def flake8_package():
 
 
 def test_changed_files(parser, flake8_package):
-    args = parser.parse_args()
+    args = parser.parse_args([])
 
     # changed_files returns file paths relative to the root
     # directory of Spack. Convert to absolute file paths.


### PR DESCRIPTION
A developer should be able to use the `-d` option when running spack tests but the `test_changed_files` test has been failing with `spack: error: unrecognized arguments: -d` (for me) if it is used.  

You can quickly reproduce the issue by entering `spack -d test -k test_changed_files`.

This PR changes the offending test case so it uses only the flake8 defaults (rather than picking up arguments from the spack command line).