### PR TITLE
ADIOS2: Dataspaces, libffi, libfabric

### DIFF
--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -151,18 +151,17 @@ class Adios2(CMakePackage):
             args.append('-DADIOS2_USE_DataSpaces={0}'.format(
                 'ON' if '+dataspaces' in spec else 'OFF'))
 
-        # transitive dependencies in SST via DILL, FFS, EVPath, etc.
-        if spec.satisfies('~sst'):
-            args.append('-DCMAKE_DISABLE_FIND_PACKAGE_LibFFI=TRUE')
-        if spec.satisfies('~sst'):
-            args.append('-DCMAKE_DISABLE_FIND_PACKAGE_LIBFABRIC=TRUE')
-        # if spec.satisfies('~sst'):  # broken package
-        args.append('-DCMAKE_DISABLE_FIND_PACKAGE_BISON=TRUE')
-        # if spec.satisfies('~sst'):  # depends on BISON
-        args.append('-DCMAKE_DISABLE_FIND_PACKAGE_FLEX=TRUE')
-        # not yet packaged
-        args.append('-DCMAKE_DISABLE_FIND_PACKAGE_CrayDRC=TRUE')
-        args.append('-DCMAKE_DISABLE_FIND_PACKAGE_NVSTREAM=TRUE')
+        if '+sst' in spec:
+            args.extend([
+                # Broken dependency package
+                '-DCMAKE_DISABLE_FIND_PACKAGE_BISON=TRUE',
+                # Depends on ^
+                '-DCMAKE_DISABLE_FIND_PACKAGE_FLEX=TRUE',
+
+                # Not yet packaged
+                '-DCMAKE_DISABLE_FIND_PACKAGE_CrayDRC=TRUE',
+                '-DCMAKE_DISABLE_FIND_PACKAGE_NVSTREAM=TRUE'
+            ])
 
         if spec.satisfies('~shared'):
             args.append('-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL={0}'.format(

--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -58,12 +58,6 @@ class Adios2(CMakePackage):
     variant('hdf5', default=False,
             description='Enable the HDF5 engine')
 
-    # transitive dependencies with optional dependencies
-    variant('libffi', default=True,
-            description='Code generation for emulated platforms in DILL')
-    variant('libfabric', default=True,
-            description='RMDA communication in EVPath and SST')
-
     # optional language bindings, C++11 and C always provided
     variant('python', default=False,
             description='Enable the Python bindings')
@@ -84,8 +78,10 @@ class Adios2(CMakePackage):
     depends_on('cmake@3.6.0:', type='build')
     depends_on('pkgconfig', type='build')
 
-    depends_on('libffi', when='+libffi')               # optional in DILL
-    depends_on('libfabric@1.6.0:', when='+libfabric')  # optional in EVPath and SST
+    depends_on('libffi', when='+sst')            # optional in DILL
+    depends_on('libfabric@1.6.0:', when='+sst')  # optional in EVPath and SST
+    # depends_on('bison', when='+sst')     # optional in FFS, broken package
+    # depends_on('flex', when='+sst')      # optional in FFS, depends on BISON
 
     depends_on('mpi', when='+mpi')
     depends_on('zeromq', when='+dataman')
@@ -155,10 +151,18 @@ class Adios2(CMakePackage):
             args.append('-DADIOS2_USE_DataSpaces={0}'.format(
                 'ON' if '+dataspaces' in spec else 'OFF'))
 
-        if spec.satisfies('~libffi'):
+        # transitive dependencies in SST via DILL, FFS, EVPath, etc.
+        if spec.satisfies('~sst'):
             args.append('-DCMAKE_DISABLE_FIND_PACKAGE_LibFFI=TRUE')
-        if spec.satisfies('~libfabric'):
+        if spec.satisfies('~sst'):
             args.append('-DCMAKE_DISABLE_FIND_PACKAGE_LIBFABRIC=TRUE')
+        # if spec.satisfies('~sst'):  # broken package
+        args.append('-DCMAKE_DISABLE_FIND_PACKAGE_BISON=TRUE')
+        # if spec.satisfies('~sst'):  # depends on BISON
+        args.append('-DCMAKE_DISABLE_FIND_PACKAGE_FLEX=TRUE')
+        # not yet packaged
+        args.append('-DCMAKE_DISABLE_FIND_PACKAGE_CrayDRC=TRUE')
+        args.append('-DCMAKE_DISABLE_FIND_PACKAGE_NVSTREAM=TRUE')
 
         if spec.satisfies('~shared'):
             args.append('-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL={0}'.format(

--- a/var/spack/repos/builtin/packages/dataspaces/package.py
+++ b/var/spack/repos/builtin/packages/dataspaces/package.py
@@ -23,6 +23,7 @@ class Dataspaces(AutotoolsPackage):
     git      = "https://github.com/melrom/dataspaces.git"
 
     version('develop', branch='master')
+    version('1.8.0', sha256='7f204bb3c03c2990f5a2d76a29185466b584793c63ada03e5e694627e6060605')
     version('1.6.2', sha256='3c43d551c1e8198a4ab269c83928e1dc6f8054e6d41ceaee45155d91a48cf9bf')
 
     variant('dimes',
@@ -57,6 +58,7 @@ class Dataspaces(AutotoolsPackage):
         args = []
         cookie = self.spec.variants['gni-cookie'].value
         ptag = self.spec.variants['ptag'].value
+        args.append('CFLAGS={0}'.format(self.compiler.pic_flag))
         if self.spec.satisfies('+dimes'):
             args.append('--enable-dimes')
         if self.spec.satisfies('+cray-drc'):


### PR DESCRIPTION
Add missing dependencies to ADIOS2. Without explicit control, those dependencies might get picked up from the system environment and will cause unstable builds.

Add a newer release of DataSpaces (1.8.0) for ADIOS2. Also add missing `-fPIC` flags since this is a static library.

Mentioned in https://github.com/spack/spack/pull/13220#issuecomment-542380335

cc @williamfgc @chuckatkins @philip-davis