### PR TITLE
bison: Fix build

### DIFF
--- a/var/spack/repos/builtin/packages/bison/package.py
+++ b/var/spack/repos/builtin/packages/bison/package.py
@@ -32,3 +32,7 @@ class Bison(AutotoolsPackage):
         patch('secure_snprintf.patch', level=0, when='@3.0.4')
 
     build_directory = 'spack-build'
+
+    @property
+    def parallel(self):
+        return not self.spec.satisfies('@3.4.2')


### PR DESCRIPTION
It seems that 3.4.2 includes a change that is supposed to fix parallel builds (https://lists.gnu.org/archive/html/bug-bison/2019-08/msg00000.html). Instead, it actually breaks it for me (with -j48) with errors such as:
```
mv: cannot stat 'examples/c/reccalc/scan.stamp.tmp': No such file or directory
Makefile:9323: recipe for target 'examples/c/reccalc/scan.stamp' failed
```