### PR TITLE
cdash: fix reporting issue with python 3

### DIFF
--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -302,7 +302,10 @@ class CDash(Reporter):
             request.get_method = lambda: 'PUT'
             response = opener.open(request)
             if self.current_package_name not in self.buildIds:
-                match = self.buildid_regexp.search(response.read())
+                resp_value = response.read()
+                if isinstance(resp_value, bytes):
+                    resp_value = resp_value.decode('utf-8')
+                match = self.buildid_regexp.search(resp_value)
                 if match:
                     buildid = match.group(1)
                     self.buildIds[self.current_package_name] = buildid


### PR DESCRIPTION
Hopefully fixes this issue I just ran into where installing with cdash reporting arguments resulted in:

```
Traceback (most recent call last):
  File "/data/scott/Documents/spack/single_repo_testing/spack/bin/spack", line 64, in <module>
    sys.exit(spack.main.main())
  File "/data/scott/Documents/spack/single_repo_testing/spack/lib/spack/spack/main.py", line 713, in main
    return _invoke_command(command, parser, args, unknown)
  File "/data/scott/Documents/spack/single_repo_testing/spack/lib/spack/spack/main.py", line 456, in _invoke_command
    return_val = command(parser, args)
  File "/data/scott/Documents/spack/single_repo_testing/spack/lib/spack/spack/cmd/install.py", line 335, in install
    install_spec(args, kwargs, abstract, concrete)
  File "/data/scott/Documents/spack/single_repo_testing/spack/lib/spack/spack/report.py", line 268, in __exit__
    self.report_writer.build_report(self.filename, report_data)
  File "/data/scott/Documents/spack/single_repo_testing/spack/lib/spack/spack/reporters/cdash.py", line 245, in build_report
    self.report_for_package(directory_name, package, duration)
  File "/data/scott/Documents/spack/single_repo_testing/spack/lib/spack/spack/reporters/cdash.py", line 216, in report_for_package
    self.upload(phase_report)
  File "/data/scott/Documents/spack/single_repo_testing/spack/lib/spack/spack/reporters/cdash.py", line 305, in upload
    match = self.buildid_regexp.search(response.read())
TypeError: cannot use a string pattern on a bytes-like object
```