### PR TITLE
importing: make importlib_importer recognize .pyc cache files

### DIFF
--- a/lib/spack/spack/util/imp/importlib_importer.py
+++ b/lib/spack/spack/util/imp/importlib_importer.py
@@ -15,6 +15,12 @@ class PrependFileLoader(SourceFileLoader):
         super(PrependFileLoader, self).__init__(full_name, path)
         self.prepend = prepend
 
+    def path_stats(self, path):
+        stats = super(PrependFileLoader, self).path_stats(path)
+        if self.prepend:
+            stats["size"] += len(self.prepend) + 1
+        return stats
+
     def get_data(self, path):
         data = super(PrependFileLoader, self).get_data(path)
         if path != self.path or self.prepend is None:


### PR DESCRIPTION
Our importer was always parsing from source (which is considerably slower) because the source size recorded in the `.pyc` file differed from the size of the input file.

- [x] Override `path_stats` in the prepending importer to fool it into thinking that the source size is the size *with* the prepended code.

This speeds up importing all of Spack's packages by about 25% for me (13 seconds vs. 10 seconds).  In conjunction with #13238, this brings `import` time for all 3500 packages down to about 7 seconds (from 13).