### PR TITLE
Strict dependency constraint checking

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2899,7 +2899,7 @@ class Spec(object):
 
             selfdeps = self.traverse(root=False)
             otherdeps = other.traverse(root=False)
-            if not all(any(d.satisfies(dep) for d in selfdeps)
+            if not all(any(d.satisfies(dep, strict=True) for d in selfdeps)
                        for dep in otherdeps):
                 return False
 


### PR DESCRIPTION
Satisfaction checks on dependencies should be strict when the parent check is strict

This is intended for constraints like 

```
depends_on('py-backports-functools-lru-cache', when='^python@:2')
```

currently, Spack will add the `py-backports-functools-lru-cache` dependency at a point in the concretization when the dependency is just `^python` (without a version) because strict constraint checking does not propagate to dependency constraint checking.

Note that because the concretizer is greedy, the constraints applied by the `py-backports-functools-lru-cache` dependency will be applied later and may generate concretizer conflicts (which requires the user to specify certain constraints on the command line), but this avoids the concretizer incorrectly adding the `py-backports-functools-lru-cache` dependency incorrectly. 

An example package this fixes is `py-soupsieve`.