### PR TITLE
Add Open MPI v. 4.0.2

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -78,9 +78,10 @@ class Openmpi(AutotoolsPackage):
     version('develop', branch='master')
 
     # Current
-    version('4.0.1', sha256='cce7b6d20522849301727f81282201d609553103ac0b09162cf28d102efb9709')  # libmpi.so.40.20.1
+    version('4.0.2', sha256='900bf751be72eccf06de9d186f7b1c4b5c2fa9fa66458e53b77778dffdfe4057')  # libmpi.so.40.20.2
 
     # Still supported
+    version('4.0.1', sha256='cce7b6d20522849301727f81282201d609553103ac0b09162cf28d102efb9709')  # libmpi.so.40.20.1
     version('4.0.0', sha256='2f0b8a36cfeb7354b45dda3c5425ef8393c9b04115570b615213faaa3f97366b')  # libmpi.so.40.20.0
     version('3.1.4', preferred=True, sha256='17a69e0054db530c7dc119f75bd07d079efa147cf94bf27e590905864fe379d6')  # libmpi.so.40.10.4
     version('3.1.3', sha256='8be04307c00f51401d3fb9d837321781ea7c79f2a5a4a2e5d4eaedc874087ab6')  # libmpi.so.40.10.3


### PR DESCRIPTION
## Verification builds on LANL Darwin x86_64, ARM, and, Power9:

### x86_64: OPTANE
```
dantopa@cn733:pr-openmpi-4.0.2.spack $ spack arch
linux-centos7-skylake_avx512

$ spack install openmpi @ 4.0.2 % gcc @ 4.8.5
...
==> Installing openmpi
...
==> Successfully installed openmpi
  Fetch: 2m 15.65s.  Build: 6m 13.17s.  Total: 8m 28.82s.
[+] /scratch/users/dantopa/new-spack/pr-openmpi-4.0.2.spack/opt/spack/linux-centos7-haswell/gcc-4.8.5/openmpi-4.0.2-jrypg7vfnk6nl5if2rnzt65wdrjelxsq
```

### x86_64: NEHALEM
```
$ spack arch
linux-centos7-nehalem

$ spack install openmpi @ 4.0.2 % gcc @ 4.8.5
...
==> Installing openmpi
...
==> Successfully installed openmpi
  Fetch: 50.48s.  Build: 9m 11.45s.  Total: 10m 1.93s.
[+] /scratch/users/dantopa/new-spack/pr-openmpi-4.0.2.spack/opt/spack/linux-centos7-nehalem/gcc-4.8.5/openmpi-4.0.2-4jz3bcwjci44taizt4jqzxqh4y75uswc
```

### ARM
```
$ spack arch
linux-rhel7-aarch64

$ spack install openmpi @ 4.0.2 % gcc @ 4.8.5
...
==> Installing openmpi
...
==> Successfully installed openmpi
  Fetch: 1m 10.47s.  Build: 11m 41.45s.  Total: 12m 51.92s.
[+] /scratch/users/dantopa/new-spack/pr-openmpi-4.0.2.spack/opt/spack/linux-rhel7-aarch64/gcc-4.8.5/openmpi-4.0.2-ygr77roadqzdnsdgqz3uactjqnb5nayn
```

### POWER9
```
$ spack arch
linux-rhel7-power9le

$ spack install openmpi @ 4.0.2 % gcc @ 4.8.5
==> Warning: Using GCC 4.8 to optimize for Power 8 might not work if you are not on Red Hat Enterprise Linux 7, where a custom backport of the feature has been done. Upstream support from GCC starts in version 4.9
...
==> Installing openmpi
...
==> Successfully installed openmpi
  Fetch: 23.95s.  Build: 9m 7.67s.  Total: 9m 31.62s.
[+] /scratch/users/dantopa/new-spack/pr-openmpi-4.0.2.spack/opt/spack/linux-rhel7-power8le/gcc-4.8.5/openmpi-4.0.2-cid4wfzr2iwgz6ybhkexludwu7koi266
```
### Build chains
```
$ spack find -ldf openmpi
==> 4 installed packages
-- linux-centos7-haswell / gcc@4.8.5 ----------------------------
jrypg7v openmpi@4.0.2%gcc
lliismp     hwloc@1.11.11%gcc
7dqpxas         libpciaccess@0.13.5%gcc
viidrh5         libxml2@2.9.9%gcc
yhvj3br         numactl@2.0.12%gcc
pkmj6e7     zlib@1.2.11%gcc

-- linux-centos7-nehalem / gcc@4.8.5 ----------------------------
4jz3bcw openmpi@4.0.2%gcc
pcauu6w     hwloc@1.11.11%gcc
yiqf6bj         libpciaccess@0.13.5%gcc
wpfgqf2         libxml2@2.9.9%gcc
fd2xpnm         numactl@2.0.12%gcc
xguzaxf     zlib@1.2.11%gcc

-- linux-rhel7-aarch64 / gcc@4.8.5 ------------------------------
ygr77ro openmpi@4.0.2%gcc
omy3xi2     hwloc@1.11.11%gcc
6a4he35         libpciaccess@0.13.5%gcc
txqo4cc         libxml2@2.9.9%gcc
m5neuus         numactl@2.0.12%gcc
67s2oqn     zlib@1.2.11%gcc

-- linux-rhel7-power8le / gcc@4.8.5 -----------------------------
cid4wfz openmpi@4.0.2%gcc
zcdnwb3     hwloc@1.11.11%gcc
lencfon         libpciaccess@0.13.5%gcc
bve4jop         libxml2@2.9.9%gcc
kajzqwg         numactl@2.0.12%gcc
tjbynt2     zlib@1.2.11%gcc
```

Thu Oct 17 19:02:50 MDT 2019

Signed-off-by: Daniel Topa <dantopa@lanl.gov>