### PR TITLE
brotli: fix darwin install name

### DIFF
--- a/var/spack/repos/builtin/packages/brotli/package.py
+++ b/var/spack/repos/builtin/packages/brotli/package.py
@@ -13,3 +13,9 @@ class Brotli(CMakePackage):
     url      = "https://github.com/google/brotli/archive/v1.0.7.tar.gz"
 
     version('1.0.7', sha256='4c61bfb0faca87219ea587326c467b95acb25555b53d1a421ffa3c8a9296ee2c')
+
+    @run_after('install')
+    def darwin_fix(self):
+        # The shared library is not installed correctly on Darwin; fix this
+        if self.spec.satisfies('platform=darwin'):
+            fix_darwin_install_name(self.prefix.lib)


### PR DESCRIPTION
Successfully builds on macOS 10.15 with Clang 11.0.0.

### Before
```console
$ otool -L /Users/Adam/spack/opt/spack/darwin-catalina-ivybridge/clang-11.0.0-apple/brotli-1.0.7-vqhkxyd6fyuiettn3c5mel7e5givipwg/lib/libbrotli*.dylib | sort | uniq
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)
	libbrotlicommon.1.dylib (compatibility version 1.0.0, current version 1.0.7)
	libbrotlidec.1.dylib (compatibility version 1.0.0, current version 1.0.7)
	libbrotlienc.1.dylib (compatibility version 1.0.0, current version 1.0.7)
```

### After
```console
$ otool -L /Users/Adam/spack/opt/spack/darwin-catalina-ivybridge/clang-11.0.0-apple/brotli-1.0.7-vqhkxyd6fyuiettn3c5mel7e5givipwg/lib/libbrotli*.dylib | sort | uniq
	/Users/Adam/spack/opt/spack/darwin-catalina-ivybridge/clang-11.0.0-apple/brotli-1.0.7-vqhkxyd6fyuiettn3c5mel7e5givipwg/lib/libbrotlicommon.1.dylib (compatibility version 1.0.0, current version 1.0.7)
	/Users/Adam/spack/opt/spack/darwin-catalina-ivybridge/clang-11.0.0-apple/brotli-1.0.7-vqhkxyd6fyuiettn3c5mel7e5givipwg/lib/libbrotlicommon.dylib (compatibility version 1.0.0, current version 1.0.7)
	/Users/Adam/spack/opt/spack/darwin-catalina-ivybridge/clang-11.0.0-apple/brotli-1.0.7-vqhkxyd6fyuiettn3c5mel7e5givipwg/lib/libbrotlidec.dylib (compatibility version 1.0.0, current version 1.0.7)
	/Users/Adam/spack/opt/spack/darwin-catalina-ivybridge/clang-11.0.0-apple/brotli-1.0.7-vqhkxyd6fyuiettn3c5mel7e5givipwg/lib/libbrotlienc.1.0.7.dylib (compatibility version 1.0.0, current version 1.0.7)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)
```