### PR TITLE
MPI Defaults: MPICH

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -34,7 +34,7 @@ packages:
       mariadb-client: [mariadb-c-client, mariadb]
       mkl: [intel-mkl]
       mpe: [mpe2]
-      mpi: [openmpi, mpich]
+      mpi: [mpich, openmpi]
       mysql-client: [mysql, mariadb-c-client]
       opencl: [pocl]
       pil: [py-pillow]


### PR DESCRIPTION
Change the default MPI implementation to MPICH. MPICH is reportedly more robust in its defaults, has a battle-proven I/O implementation, is very low in memory leaks and very portable. Leftover from #13216

This should just overall reduce the amount of central bug reports we receive from new users, installing default-on MPI software via Spack and not having the experience (yet) to switch default spec concretizations when needed.

cc @jrood-nrel @ggouaillardet @rblake-llnl @hppritcha 