### PR TITLE
Add dependency and patch for perl-dbfile

### DIFF
--- a/var/spack/repos/builtin/packages/perl-dbfile/package.py
+++ b/var/spack/repos/builtin/packages/perl-dbfile/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-
+import os
 
 class PerlDbfile(PerlPackage):
     """DB_File is a module which allows Perl programs to make use of the
@@ -20,3 +20,18 @@ class PerlDbfile(PerlPackage):
     version('1.840', sha256='b7864707fad0f2d1488c748c4fa08f1fb8bcfd3da247c36909fd42f20bfab2c4')
 
     depends_on('perl-extutils-makemaker', type='build')
+    depends_on('berkeley-db', type='build')
+
+    def patch(self):
+        if os.path.isfile('config.in'):
+            with open('config.in', 'r') as f:
+              filedata = f.read()
+
+            # Replace the target string
+            filedata = filedata.replace('/usr/local/BerkeleyDB/', self.spec['berkeley-db'].prefix + '/')
+
+            # Write the file out again
+            with open('file.txt', 'w') as file:
+                file.write(filedata)
+        else:
+            raise InstallError("cannot find file config.in")

--- a/var/spack/repos/builtin/packages/perl-dbfile/package.py
+++ b/var/spack/repos/builtin/packages/perl-dbfile/package.py
@@ -23,5 +23,5 @@ class PerlDbfile(PerlPackage):
     depends_on('berkeley-db', type='build')
 
     def patch(self):
-        filter_file('/usr/local/BerkeleyDB', \
+        filter_file('/usr/local/BerkeleyDB',
                     self.spec['berkeley-db'].prefix, 'config.in')

--- a/var/spack/repos/builtin/packages/perl-dbfile/package.py
+++ b/var/spack/repos/builtin/packages/perl-dbfile/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-import os
 
 
 class PerlDbfile(PerlPackage):
@@ -24,17 +23,4 @@ class PerlDbfile(PerlPackage):
     depends_on('berkeley-db', type='build')
 
     def patch(self):
-        if os.path.isfile('config.in'):
-            # Load the config file
-            with open('config.in', 'r') as f:
-                filedata = f.read()
-
-            # Replace the BerkeleyDB using the correct path
-            filedata = filedata.replace('/usr/local/BerkeleyDB/',
-                                        self.spec['berkeley-db'].prefix + '/')
-
-            # Update the config file
-            with open('file.txt', 'w') as f:
-                f.write(filedata)
-        else:
-            raise InstallError("cannot find file config.in")
+        filter_file('/usr/local/BerkeleyDB', self.spec['berkeley-db'].prefix, 'config.in')

--- a/var/spack/repos/builtin/packages/perl-dbfile/package.py
+++ b/var/spack/repos/builtin/packages/perl-dbfile/package.py
@@ -23,4 +23,5 @@ class PerlDbfile(PerlPackage):
     depends_on('berkeley-db', type='build')
 
     def patch(self):
-        filter_file('/usr/local/BerkeleyDB', self.spec['berkeley-db'].prefix, 'config.in')
+        filter_file('/usr/local/BerkeleyDB', \
+                    self.spec['berkeley-db'].prefix, 'config.in')

--- a/var/spack/repos/builtin/packages/perl-dbfile/package.py
+++ b/var/spack/repos/builtin/packages/perl-dbfile/package.py
@@ -6,6 +6,7 @@
 from spack import *
 import os
 
+
 class PerlDbfile(PerlPackage):
     """DB_File is a module which allows Perl programs to make use of the
     facilities provided by Berkeley DB version 1.x (if you have a newer version
@@ -24,14 +25,16 @@ class PerlDbfile(PerlPackage):
 
     def patch(self):
         if os.path.isfile('config.in'):
+            # Load the config file
             with open('config.in', 'r') as f:
-              filedata = f.read()
+                filedata = f.read()
 
-            # Replace the target string
-            filedata = filedata.replace('/usr/local/BerkeleyDB/', self.spec['berkeley-db'].prefix + '/')
+            # Replace the BerkeleyDB using the correct path
+            filedata = filedata.replace('/usr/local/BerkeleyDB/',
+                                        self.spec['berkeley-db'].prefix + '/')
 
-            # Write the file out again
-            with open('file.txt', 'w') as file:
-                file.write(filedata)
+            # Update the config file
+            with open('file.txt', 'w') as f:
+                f.write(filedata)
         else:
             raise InstallError("cannot find file config.in")


### PR DESCRIPTION
Resolve two issues for the building of `perl-dbfile`:

1) add package dependence on `berkeley-db`
2) fix the building using a patch, which locates the position of `berkeley-db` and modify the configuration file for the building