### PR TITLE
qt: Fix build for newer versions

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -294,8 +294,6 @@ class Qt(Package):
     @when('@5')
     def patch(self):
         # Fix qmake compilers in the default mkspec
-        filter_file('^QMAKE_COMPILER .*', 'QMAKE_COMPILER = cc',
-                    'qtbase/mkspecs/common/g++-base.conf')
         filter_file('^QMAKE_CC .*', 'QMAKE_CC = cc',
                     'qtbase/mkspecs/common/g++-base.conf')
         filter_file('^QMAKE_CXX .*', 'QMAKE_CXX = c++',


### PR DESCRIPTION
For some reason, newer versions of qt fail to build because they cannot find certain system libraries such as libatomic and libdl.

Leaving the qmake compiler set to gcc seems to fix the problem.

Fixes #13221