### PR TITLE
Buildcache: Catch warning from visit(root) in full_hash() call tree to allow completion of .spack file when using relative rpath option.

### DIFF
--- a/lib/spack/spack/util/package_hash.py
+++ b/lib/spack/spack/util/package_hash.py
@@ -123,7 +123,13 @@ def package_ast(spec):
     RemoveDirectives(spec).visit(root)
 
     fmm = TagMultiMethods(spec)
-    fmm.visit(root)
+    try:
+        fmm.visit(root)
+    except Exception as e:
+        import llnl.util.tty as tty
+        tty.debug('[PACKAGE_HASH] ' +
+                  'TagMultiMethods(spec).visit(ast.parse(text)) ' +
+                  'produced Exception %s' % e)
 
     root = ResolveMultiMethods(fmm.methods).visit(root)
     return root


### PR DESCRIPTION
A warning prevents the completion of building a .spack file when the relative rpaths option is used.
See https://github.com/spack/spack/issues/13237 for details

The warning comes during this call
https://github.com/spack/spack/blob/b4383825be628e3493da316937995df4fef9ab00/lib/spack/spack/util/package_hash.py#L126

My solution is to put a try except statement around it the catch the warning so it does not propagate higher and prevent the yaml file needed for the .spack file from being created.