### PR TITLE
shebangs: don't warn when patching long shebangs

### DIFF
--- a/lib/spack/spack/hooks/sbang.py
+++ b/lib/spack/spack/hooks/sbang.py
@@ -69,7 +69,7 @@ def filter_shebang(path):
     if saved_mode is not None:
         os.chmod(path, saved_mode)
 
-    tty.warn("Patched overlong shebang in %s" % path)
+    tty.debug("Patched overlong shebang in %s" % path)
 
 
 def filter_shebangs_in_directory(directory, filenames=None):


### PR DESCRIPTION
We've been doing this for quite a while now, and it does not seem to cause issues.

- [x] Switch the noisy warning to a debug to make Spack a bit quieter while building.