### PR TITLE
Add py-sphinxcontrib-applehelp package

### DIFF
--- a/var/spack/repos/builtin/packages/py-sphinxcontrib-applehelp/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinxcontrib-applehelp/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PySphinxcontribApplehelp(PythonPackage):
+    """sphinxcontrib-applehelp is a sphinx extension which outputs Apple
+    help books."""
+
+    homepage = "http://sphinx-doc.org/"
+    url      = "https://pypi.io/packages/source/s/sphinxcontrib-applehelp/sphinxcontrib-applehelp-1.0.1.tar.gz"
+
+    version('1.0.1', sha256='edaa0ab2b2bc74403149cb0209d6775c96de797dfd5b5e2a71981309efab3897')
+
+    depends_on('python@3.5:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')
+
+    def test(self):
+        # Requires sphinx, creating a circular dependency
+        pass


### PR DESCRIPTION
Successfully builds on macOS 10.15 with Clang 11.0.0 and Python 3.7.4.