### PR TITLE
Add latest version of py-typing

### DIFF
--- a/var/spack/repos/builtin/packages/py-typing/package.py
+++ b/var/spack/repos/builtin/packages/py-typing/package.py
@@ -11,13 +11,13 @@ class PyTyping(PythonPackage):
     versions older than 3.6."""
 
     homepage = "https://docs.python.org/3/library/typing.html"
-    url      = "https://pypi.io/packages/source/t/typing/typing-3.6.1.tar.gz"
+    url      = "https://pypi.io/packages/source/t/typing/typing-3.7.4.1.tar.gz"
 
     import_modules = ['typing']
 
+    version('3.7.4.1', sha256='91dfe6f3f706ee8cc32d38edbbf304e9b7583fb37108fef38229617f8b3eba23')
     version('3.6.4', sha256='d400a9344254803a2368533e4533a4200d21eb7b6b729c173bc38201a74db3f2')
     version('3.6.1', sha256='c36dec260238e7464213dcd50d4b5ef63a507972f5780652e835d0228d0edace')
 
-    # You need Python 2.7 or 3.3+ to install the typing package
-    depends_on('python@2.7:2.8,3.3:', type=('build', 'run'))
+    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')


### PR DESCRIPTION
Successfully builds on macOS 10.15 with Clang 11.0.0 and Python 3.7.4.