### PR TITLE
Add latest version of py-sphinxcontrib-websupport

### DIFF
--- a/var/spack/repos/builtin/packages/py-sphinxcontrib-websupport/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinxcontrib-websupport/package.py
@@ -11,7 +11,7 @@ class PySphinxcontribWebsupport(PythonPackage):
     Sphinx documentation into your Web application."""
 
     homepage = "http://sphinx-doc.org/"
-    url      = "https://pypi.io/packages/source/s/sphinxcontrib-websupport/sphinxcontrib-websupport-1.0.1.tar.gz"
+    url      = "https://pypi.io/packages/source/s/sphinxcontrib-websupport/sphinxcontrib-websupport-1.1.2.tar.gz"
 
     # FIXME: These import tests don't work for some reason
     # import_modules = [
@@ -19,10 +19,13 @@ class PySphinxcontribWebsupport(PythonPackage):
     #     'sphinxcontrib.websupport.storage', 'sphinxcontrib.websupport.search'
     # ]
 
+    version('1.1.2', sha256='1501befb0fdf1d1c29a800fdbf4ef5dc5369377300ddbdd16d2cd40e54c6eefc')
     version('1.1.0', sha256='9de47f375baf1ea07cdb3436ff39d7a9c76042c10a769c52353ec46e4e8fc3b9')
     version('1.0.1', sha256='7a85961326aa3a400cd4ad3c816d70ed6f7c740acd7ce5d78cd0a67825072eb9')
 
+    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
 
-    depends_on('py-pytest', type='test')
-    depends_on('py-mock',   type='test')
+    def test(self):
+        # Unit tests require sphinx, creating a circular dependency
+        pass


### PR DESCRIPTION
Successfully builds on macOS 10.15 with Clang 11.0.0 and Python 3.7.4.