### PR TITLE
Add latest version of py-snowballstemmer

### DIFF
--- a/var/spack/repos/builtin/packages/py-snowballstemmer/package.py
+++ b/var/spack/repos/builtin/packages/py-snowballstemmer/package.py
@@ -11,8 +11,11 @@ class PySnowballstemmer(PythonPackage):
     English stemmer) generated from Snowball algorithms."""
 
     homepage = "https://github.com/shibukawa/snowball_py"
-    url      = "https://pypi.io/packages/source/s/snowballstemmer/snowballstemmer-1.2.1.tar.gz"
+    url      = "https://pypi.io/packages/source/s/snowballstemmer/snowballstemmer-2.0.0.tar.gz"
 
     import_modules = ['snowballstemmer']
 
+    version('2.0.0', sha256='df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52')
     version('1.2.1', sha256='919f26a68b2c17a7634da993d91339e288964f93c274f1343e3bbbe2096e1128')
+
+    depends_on('py-setuptools', type='build')


### PR DESCRIPTION
Successfully builds on macOS 10.15 with Clang 11.0.0 and Python 3.7.4.