### PR TITLE
Add latest version of py-pyyaml

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyyaml/package.py
+++ b/var/spack/repos/builtin/packages/py-pyyaml/package.py
@@ -9,8 +9,12 @@ from spack import *
 class PyPyyaml(PythonPackage):
     """PyYAML is a YAML parser and emitter for Python."""
     homepage = "http://pyyaml.org/wiki/PyYAML"
-    url      = "http://pyyaml.org/download/pyyaml/PyYAML-3.11.tar.gz"
+    url      = "http://pyyaml.org/download/pyyaml/PyYAML-5.1.2.tar.gz"
 
-    version('3.13', sha256='3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf')
-    version('3.12', sha256='592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab')
-    version('3.11', sha256='c36c938a872e5ff494938b33b14aaa156cb439ec67548fcab3535bb78b0846e8')
+    version('5.1.2', sha256='01adf0b6c6f61bd11af6e10ca52b7d4057dd0be0343eb9283c878cf3af56aee4')
+    version('3.13',  sha256='3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf')
+    version('3.12',  sha256='592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab')
+    version('3.11',  sha256='c36c938a872e5ff494938b33b14aaa156cb439ec67548fcab3535bb78b0846e8')
+
+    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
+    depends_on('libyaml')


### PR DESCRIPTION
Successfully builds on macOS 10.15 with Clang 11.0.0 and Python 3.7.4.

The libyaml dependency is optional. Without it, it falls back on a pure-Python implementation, which is much slower.