### PR TITLE
Add latest version of py-pytest-xdist

### DIFF
--- a/var/spack/repos/builtin/packages/py-pytest-xdist/package.py
+++ b/var/spack/repos/builtin/packages/py-pytest-xdist/package.py
@@ -10,11 +10,14 @@ class PyPytestXdist(PythonPackage):
     """py.test xdist plugin for distributed testing and loop-on-failing mode"""
 
     homepage = "https://github.com/pytest-dev/pytest-xdist"
-    url      = "https://pypi.io/packages/source/p/pytest-xdist/pytest-xdist-1.16.0.tar.gz"
+    url      = "https://pypi.io/packages/source/p/pytest-xdist/pytest-xdist-1.30.0.tar.gz"
 
+    version('1.30.0', sha256='5d1b1d4461518a6023d56dab62fb63670d6f7537f23e2708459a557329accf48')
     version('1.16.0', sha256='42e5a1e5da9d7cff3e74b07f8692598382f95624f234ff7e00a3b1237e0feba2')
 
+    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
     depends_on('py-setuptools',    type='build')
     depends_on('py-execnet@1.1:',  type=('build', 'run'))
-    depends_on('py-pytest@2.7.0:', type=('build', 'run'))
-    depends_on('py-py@1.4.22:',    type=('build', 'run'))
+    depends_on('py-pytest@4.4.0:', type=('build', 'run'))
+    depends_on('py-pytest-forked', type=('build', 'run'))
+    depends_on('py-six', type=('build', 'run'))


### PR DESCRIPTION
Successfully builds on macOS 10.15 with Clang 11.0.0 and Python 3.7.4.