### PR TITLE
Add latest version of py-psutil

### DIFF
--- a/var/spack/repos/builtin/packages/py-psutil/package.py
+++ b/var/spack/repos/builtin/packages/py-psutil/package.py
@@ -12,11 +12,15 @@ class PyPsutil(PythonPackage):
     in Python."""
 
     homepage = "https://pypi.python.org/pypi/psutil"
-    url      = "https://pypi.io/packages/source/p/psutil/psutil-5.4.5.tar.gz"
+    url      = "https://pypi.io/packages/source/p/psutil/psutil-5.6.3.tar.gz"
 
+    version('5.6.3', sha256='863a85c1c0a5103a12c05a35e59d336e1d665747e531256e061213e2e90f63f3')
     version('5.5.1', sha256='72cebfaa422b7978a1d3632b65ff734a34c6b34f4578b68a5c204d633756b810')
     version('5.4.5', sha256='ebe293be36bb24b95cdefc5131635496e88b17fabbcf1e4bc9b5c01f5e489cfe')
     version('5.0.1', sha256='9d8b7f8353a2b2eb6eb7271d42ec99d0d264a9338a37be46424d56b4e473b39e')
 
-    depends_on('python@2.6:')
+    depends_on('python@2.6:2.8,3.4:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
+    depends_on('py-unittest2', when='^python@:2.6', type='test')
+    depends_on('py-mock', when='^python@:2.7', type='test')
+    depends_on('py-ipaddress', when='^python@:3.2', type='test')


### PR DESCRIPTION
Successfully builds on macOS 10.15 with Clang 11.0.0 and Python 3.7.4.