### PR TITLE
Add latest version of py-mock

### DIFF
--- a/var/spack/repos/builtin/packages/py-mock/package.py
+++ b/var/spack/repos/builtin/packages/py-mock/package.py
@@ -12,14 +12,16 @@ class PyMock(PythonPackage):
     they have been used."""
 
     homepage = "https://github.com/testing-cabal/mock"
-    url      = "https://pypi.io/packages/source/m/mock/mock-1.3.0.tar.gz"
+    url      = "https://pypi.io/packages/source/m/mock/mock-3.0.5.tar.gz"
 
+    version('3.0.5', sha256='83657d894c90d5681d62155c82bda9c1187827525880eda8ff5df4ec813437c3')
     version('2.0.0', sha256='b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba')
     version('1.3.0', sha256='1e247dbecc6ce057299eb7ee019ad68314bb93152e81d9a6110d35f4d5eca0f6')
 
-    depends_on('py-pbr@0.11:', type=('build', 'run'))
-    depends_on('py-six@1.7:',  type=('build', 'run'))
-    depends_on('py-six@1.9:',  type=('build', 'run'), when='@2.0.0:')
-    # requirements.txt references @1:, but 0.4 is newest available..
-    depends_on('py-funcsigs',  type=('build', 'run'), when='^python@:3.2.99')
-    depends_on('py-setuptools@17.1:', type='build')
+    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')
+    depends_on('py-six@1.7:', type=('build', 'run'))
+    depends_on('py-six@1.9:', type=('build', 'run'), when='@2.0.0:')
+    depends_on('py-funcsigs@1:', type=('build', 'run'), when='^python@:3.2')
+    depends_on('py-pytest', type='test')
+    depends_on('py-pytest-cov', type='test')


### PR DESCRIPTION
Successfully builds on macOS 10.15 with Clang 11.0.0 and Python 3.7.4.