### PR TITLE
Add latest version of py-markupsafe

### DIFF
--- a/var/spack/repos/builtin/packages/py-markupsafe/package.py
+++ b/var/spack/repos/builtin/packages/py-markupsafe/package.py
@@ -13,15 +13,17 @@ class PyMarkupsafe(PythonPackage):
     Mako templating engine, the Pylons web framework and many more."""
 
     homepage = "http://www.pocoo.org/projects/markupsafe/"
-    url      = "https://pypi.io/packages/source/M/MarkupSafe/MarkupSafe-1.0.tar.gz"
+    url      = "https://pypi.io/packages/source/M/MarkupSafe/MarkupSafe-1.1.1.tar.gz"
 
     import_modules = ['markupsafe']
 
-    version('1.0',  sha256='a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665')
-    version('0.23', sha256='a4ec1aff59b95a14b45eb2e23761a0179e98319da5a7eb76b56ea8cdc7b871c3')
-    version('0.22', sha256='7642852b6d1e55c9e12e00a552c0b8943880f2172e55141ccb41eb5f8675dfa5')
-    version('0.21', sha256='c6465cd6ed2b96509ef0100e7fff8718ed52c2affab1860ed5a9b67f604dd59a')
-    version('0.20', sha256='f6cf3bd233f9ea6147b21c7c02cac24e5363570ce4fd6be11dab9f499ed6a7d8')
-    version('0.19', sha256='62fcc5d641df8b5ad271ebbd6b77a19cd92eceba1e1a990de4e96c867789f037')
+    version('1.1.1', sha256='29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b')
+    version('1.0',   sha256='a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665')
+    version('0.23',  sha256='a4ec1aff59b95a14b45eb2e23761a0179e98319da5a7eb76b56ea8cdc7b871c3')
+    version('0.22',  sha256='7642852b6d1e55c9e12e00a552c0b8943880f2172e55141ccb41eb5f8675dfa5')
+    version('0.21',  sha256='c6465cd6ed2b96509ef0100e7fff8718ed52c2affab1860ed5a9b67f604dd59a')
+    version('0.20',  sha256='f6cf3bd233f9ea6147b21c7c02cac24e5363570ce4fd6be11dab9f499ed6a7d8')
+    version('0.19',  sha256='62fcc5d641df8b5ad271ebbd6b77a19cd92eceba1e1a990de4e96c867789f037')
 
+    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')


### PR DESCRIPTION
Successfully builds on macOS 10.15 with Clang 11.0.0 and Python 3.7.4.