### PR TITLE
Add latest version of py-idna

### DIFF
--- a/var/spack/repos/builtin/packages/py-idna/package.py
+++ b/var/spack/repos/builtin/packages/py-idna/package.py
@@ -11,9 +11,10 @@ class PyIdna(PythonPackage):
     """Internationalized Domain Names for Python (IDNA 2008 and UTS #46) """
 
     homepage = "https://github.com/kjd/idna"
-    url      = "https://pypi.io/packages/source/i/idna/idna-2.5.tar.gz"
+    url      = "https://pypi.io/packages/source/i/idna/idna-2.8.tar.gz"
 
+    version('2.8', sha256='c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407')
     version('2.5', sha256='3cb5ce08046c4e3a560fc02f138d0ac63e00f8ce5901a56b32ec8b7994082aab')
 
+    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
     depends_on('py-setuptools', type=('build', 'link'))
-    depends_on('python@2.6:',   type=('build', 'run'))


### PR DESCRIPTION
Successfully builds on macOS 10.15 with Clang 11.0.0 and Python 3.7.4.