### PR TITLE
Add latest version of py-execnet

### DIFF
--- a/var/spack/repos/builtin/packages/py-execnet/package.py
+++ b/var/spack/repos/builtin/packages/py-execnet/package.py
@@ -12,10 +12,12 @@ class PyExecnet(PythonPackage):
     across version, platform and network barriers."""
 
     homepage = "http://codespeak.net/execnet"
-    url      = "https://pypi.io/packages/source/e/execnet/execnet-1.4.1.tar.gz"
+    url      = "https://pypi.io/packages/source/e/execnet/execnet-1.7.1.tar.gz"
 
+    version('1.7.1', sha256='cacb9df31c9680ec5f95553976c4da484d407e85e41c83cb812aa014f0eddc50')
     version('1.4.1', sha256='f66dd4a7519725a1b7e14ad9ae7d3df8e09b2da88062386e08e941cafc0ef3e6')
 
+    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
     depends_on('py-setuptools',  type='build')
     depends_on('py-setuptools-scm',  type='build')
     depends_on('py-apipkg@1.4:', type=('build', 'run'))


### PR DESCRIPTION
Successfully builds on macOS 10.15 with Clang 11.0.0 and Python 3.7.4.