### PR TITLE
Add latest version of py-chardet

### DIFF
--- a/var/spack/repos/builtin/packages/py-chardet/package.py
+++ b/var/spack/repos/builtin/packages/py-chardet/package.py
@@ -10,10 +10,13 @@ class PyChardet(PythonPackage):
     """Universal encoding detector for Python 2 and 3"""
 
     homepage = "https://github.com/chardet/chardet"
-    url      = "https://pypi.io/packages/source/c/chardet/chardet-2.3.0.tar.gz"
+    url      = "https://pypi.io/packages/source/c/chardet/chardet-3.0.4.tar.gz"
 
+    version('3.0.4', sha256='84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae')
     version('3.0.2', sha256='4f7832e7c583348a9eddd927ee8514b3bf717c061f57b21dbe7697211454d9bb')
     version('2.3.0', sha256='e53e38b3a4afe6d1132de62b7400a4ac363452dc5dfcf8d88e8e0cce663c68aa')
 
     depends_on('py-setuptools', type='build')
     depends_on('py-pytest-runner', type='build')
+    depends_on('py-pytest', type='test')
+    depends_on('py-hypothesis', type='test')


### PR DESCRIPTION
Successfully builds on macOS 10.15 with Clang 11.0.0 and Python 3.7.4.