### PR TITLE
Add missing dependencies to py-apipkg

### DIFF
--- a/var/spack/repos/builtin/packages/py-apipkg/package.py
+++ b/var/spack/repos/builtin/packages/py-apipkg/package.py
@@ -16,4 +16,7 @@ class PyApipkg(PythonPackage):
     version('1.4', sha256='2e38399dbe842891fe85392601aab8f40a8f4cc5a9053c326de35a1cc0297ac6')
 
     depends_on('py-setuptools@30.3.0:', type='build')
+    depends_on('py-setuptools-scm', type='build')
     depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
+    depends_on('py-py', type='test')
+    depends_on('py-pytest', type='test')


### PR DESCRIPTION
Successfully builds on macOS 10.15 with Clang 11.0.0 and Python 3.7.4.