### PR TITLE
libgeotiff: http -> https

### DIFF
--- a/var/spack/repos/builtin/packages/libgeotiff/package.py
+++ b/var/spack/repos/builtin/packages/libgeotiff/package.py
@@ -13,7 +13,7 @@ class Libgeotiff(AutotoolsPackage):
     """
 
     homepage = "https://trac.osgeo.org/geotiff/"
-    url      = "http://download.osgeo.org/geotiff/libgeotiff/libgeotiff-1.5.1.tar.gz"
+    url      = "https://download.osgeo.org/geotiff/libgeotiff/libgeotiff-1.5.1.tar.gz"
 
     maintainers = ['adamjstewart']
 


### PR DESCRIPTION
Successfully builds on macOS 10.15 with Clang 11.0.0.