### PR TITLE
Add latest version of libyaml

### DIFF
--- a/var/spack/repos/builtin/packages/libyaml/package.py
+++ b/var/spack/repos/builtin/packages/libyaml/package.py
@@ -6,34 +6,31 @@
 from spack import *
 
 
-class Libyaml(Package):
+class Libyaml(AutotoolsPackage):
     """A C library for parsing and emitting YAML."""
 
-    homepage = "https://github.com/yaml/libyaml"
-    url      = "https://github.com/yaml/libyaml/archive/0.2.1.tar.gz"
+    homepage = "https://pyyaml.org/wiki/LibYAML"
+    url      = "https://pyyaml.org/download/libyaml/yaml-0.2.2.tar.gz"
     git      = "https://github.com/yaml/libyaml.git"
 
-    version('master',     branch='master')
-    version('0.2.1',      sha256='1d2aeb87f7d317f1496e4c39410d913840714874a354970300f375eec9303dc4')
-    version('0.1.7',      sha256='e1884d0fa1eec8cf869ac6bebbf25391e81956aa2970267f974a9fa5e0b968e2')
-    version('0.1.6',      sha256='a0ad4b8cfa4b26c669c178af08147449ea7e6d50374cc26503edc56f3be894cf')
-    version('0.1.5',      sha256='79511ce3c1195e3c83157b7243bc98c48f945662ed75d8606aea9182eb8dccd5')
-    version('0.1.4',      sha256='6406d298a7889ad8e107239d3154c3540dbc0820ff4c5e889c60019fc2bf672b')
-    version('0.1.3',      sha256='87bd8237880ccf3f993cfa5718c1081673813d11572ca469b24cfc3df5a425f5')
-    version('0.1.2',      sha256='fa395384d1964ea2039744087fa825ed3ac321222df17ad66f198fecc48e39cd')
-    version('0.1.1',      sha256='1183790fc59795a77bf4c8193aa24439dc0f8712ac37e4639be2e821c9d4e463')
+    version('master', branch='master')
+    version('0.2.2', sha256='4a9100ab61047fd9bd395bcef3ce5403365cafd55c1e0d0299cde14958e47be9')
+    version('0.2.1', sha256='78281145641a080fb32d6e7a87b9c0664d611dcb4d542e90baf731f51cbb59cd')
+    version('0.1.7', sha256='8088e457264a98ba451a90b8661fcb4f9d6f478f7265d48322a196cec2480729')
+    version('0.1.6', sha256='7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749')
+    version('0.1.5', sha256='fa87ee8fb7b936ec04457bc044cd561155e1000a4d25029867752e543c2d3bef')
+    version('0.1.4', sha256='7bf81554ae5ab2d9b6977da398ea789722e0db75b86bffdaeb4e66d961de6a37')
+    version('0.1.3', sha256='a8bbad7e5250b3735126b7e3bd9f6fce9db19d6be7cc13abad17a24b59ec144a')
+    version('0.1.2', sha256='5beb94529cc7ac79b17e354f9b03aea311f5af17be5d48bc39e6f1db5059f70f')
+    version('0.1.1', sha256='76444692a94de4e6776a1bdf3b735e8f016bb374ae7c60496f8032fdc6085889')
 
-    depends_on('automake')
-    depends_on('autoconf')
-    depends_on('libtool')
+    depends_on('automake', when='@master')
+    depends_on('autoconf', when='@master')
+    depends_on('libtool',  when='@master')
+    depends_on('m4',       when='@master')
 
-    phases = ['bootstrap', 'install']
-
-    def bootstrap(self, spec, prefix):
-        bootstrap = Executable('./bootstrap')
-        bootstrap()
-
-    def install(self, spec, prefix):
-        configure('--disable-dependency-tracking',
-                  '--prefix=%s' % self.spec.prefix)
-        make('install')
+    @run_before('configure')
+    def bootstrap(self):
+        if self.spec.satisfies('@master'):
+            bootstrap = Executable('./bootstrap')
+            bootstrap()


### PR DESCRIPTION
Successfully builds on macOS 10.15 with Clang 11.0.0.

By switching to the official download tarballs, we no longer need Autotools except for the master branch.