### PR TITLE
Use specific version of googletest for uriparser

### DIFF
--- a/var/spack/repos/builtin/packages/uriparser/package.py
+++ b/var/spack/repos/builtin/packages/uriparser/package.py
@@ -18,7 +18,7 @@ class Uriparser(CMakePackage):
     variant('docs', default=False, description='Build API documentation')
 
     depends_on('cmake@3.3:', type='build')
-    depends_on('googletest@1.8.1:', type='link')
+    depends_on('googletest@1.8.1', type='link')
     depends_on('doxygen', when='+docs', type='build')
     depends_on('graphviz', when='+docs', type='build')
 


### PR DESCRIPTION
Successfully builds on macOS 10.15 with Clang 11.0.0.

Doesn't seem to build with googletest 1.10.0, and there are no newer releases than 1.8.1 to test against. Locking the version for now.