### PR TITLE
Add latest version of patchelf

### DIFF
--- a/var/spack/repos/builtin/packages/patchelf/package.py
+++ b/var/spack/repos/builtin/packages/patchelf/package.py
@@ -11,10 +11,10 @@ class Patchelf(AutotoolsPackage):
        ELF executables."""
 
     homepage = "https://nixos.org/patchelf.html"
-    url = "http://nixos.org/releases/patchelf/patchelf-0.8/patchelf-0.8.tar.gz"
-
-    list_url = "http://nixos.org/releases/patchelf/"
+    url      = "https://nixos.org/releases/patchelf/patchelf-0.10/patchelf-0.10.tar.gz"
+    list_url = "https://nixos.org/releases/patchelf/"
     list_depth = 1
 
-    version('0.9', sha256='f2aa40a6148cb3b0ca807a1bf836b081793e55ec9e5540a5356d800132be7e0a')
-    version('0.8', sha256='14af06a2da688d577d64ff8dac065bb8903bbffbe01d30c62df7af9bf4ce72fe')
+    version('0.10', sha256='b2deabce05c34ce98558c0efb965f209de592197b2c88e930298d740ead09019')
+    version('0.9',  sha256='f2aa40a6148cb3b0ca807a1bf836b081793e55ec9e5540a5356d800132be7e0a')
+    version('0.8',  sha256='14af06a2da688d577d64ff8dac065bb8903bbffbe01d30c62df7af9bf4ce72fe')


### PR DESCRIPTION
Successfully installs on macOS 10.15 with Clang 11.0.0.