### PR TITLE
Add latest version of npth

### DIFF
--- a/var/spack/repos/builtin/packages/npth/package.py
+++ b/var/spack/repos/builtin/packages/npth/package.py
@@ -11,7 +11,8 @@ class Npth(AutotoolsPackage):
        non-preemptive threads implementation."""
 
     homepage = "https://gnupg.org/software/npth/index.html"
-    url = "https://gnupg.org/ftp/gcrypt/npth/npth-1.5.tar.bz2"
+    url      = "https://gnupg.org/ftp/gcrypt/npth/npth-1.6.tar.bz2"
 
+    version('1.6', sha256='1393abd9adcf0762d34798dc34fdcf4d0d22a8410721e76f1e3afcd1daa4e2d1')
     version('1.5', sha256='294a690c1f537b92ed829d867bee537e46be93fbd60b16c04630fbbfcd9db3c2')
     version('1.4', sha256='8915141836a3169a502d65c1ebd785fcc6d406cae5ee84474272ebf2fa96f1f2')


### PR DESCRIPTION
Successfully installs on macOS 10.15 with Clang 11.0.0.