### PR TITLE
Add latest version of py-macs2

### DIFF
--- a/var/spack/repos/builtin/packages/py-macs2/package.py
+++ b/var/spack/repos/builtin/packages/py-macs2/package.py
@@ -11,13 +11,17 @@ class PyMacs2(PythonPackage):
     """MACS2 Model-based Analysis of ChIP-Seq"""
 
     homepage = "https://github.com/taoliu/MACS"
-    url      = "https://pypi.io/packages/source/M/MACS2/MACS2-2.1.1.20160309.tar.gz"
+    url      = "https://pypi.io/packages/source/M/MACS2/MACS2-2.2.4.tar.gz"
 
+    version('2.2.4',          sha256='b131aadc8f5fd94bec35308b821e1f7585def788d2e7c756fc8cac402ffee25b')
+    version('2.1.4',          sha256='e4966d001914320829ab859c7bc8e92c6410aa7bdbddfd00b7625e9a0fb15c97')
     version('2.1.1.20160309', sha256='2008ba838f83f34f8e0fddefe2a3a0159f4a740707c68058f815b31ddad53d26')
 
-    depends_on('python@2.7:2.8')
+    depends_on('python@3.5:',    when='@2.2:', type=('build', 'run'))
+    depends_on('python@2.7:2.8', when='@:2.1', type=('build', 'run'))
 
     # Most Python packages only require py-setuptools as a build dependency.
     # However, py-macs2 requires py-setuptools during runtime as well.
     depends_on('py-setuptools', type=('build', 'run'))
-    depends_on('py-numpy@1.6:', type=('build', 'run'))
+    depends_on('py-numpy@1.17:', when='@2.2:', type=('build', 'run'))
+    depends_on('py-numpy@1.16:', type=('build', 'run'))


### PR DESCRIPTION
py-macs2 now supports Python 3!

Successfully builds on macOS 10.15 with Clang 11.0.0 and Python 3.7.4.