### PR TITLE
Add latest version of py-sphinxcontrib-programoutput

### DIFF
--- a/var/spack/repos/builtin/packages/py-sphinxcontrib-programoutput/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinxcontrib-programoutput/package.py
@@ -11,12 +11,14 @@ class PySphinxcontribProgramoutput(PythonPackage):
     into documents, helping you to keep your command examples up to date."""
 
     homepage = "https://sphinxcontrib-programoutput.readthedocs.org/"
-    url      = "https://pypi.io/packages/source/s/sphinxcontrib-programoutput/sphinxcontrib-programoutput-0.10.tar.gz"
+    url      = "https://pypi.io/packages/source/s/sphinxcontrib-programoutput/sphinxcontrib-programoutput-0.15.tar.gz"
 
     # FIXME: These import tests don't work for some reason
     # import_modules = ['sphinxcontrib', 'sphinxcontrib.programoutput']
 
+    version('0.15', sha256='80dd5b4eab780a13ff2c23500cac3dbf0e04ef9976b409ef25a47c263ef8ab94')
     version('0.10', sha256='fdee94fcebb0d8fddfccac5c4fa560f6177d5340c4349ee447c890bea8857094')
 
+    depends_on('python@2.7:2.8,3.5:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
-    depends_on('py-sphinx@1.3.5:', type=('build', 'run'))
+    depends_on('py-sphinx@1.7.0:', type=('build', 'run'))


### PR DESCRIPTION
Successfully builds on macOS 10.15 with Clang 11.0.0 and Python 3.7.4.