### PR TITLE
Restrict parallel build of py-astropy to Python 3

### DIFF
--- a/var/spack/repos/builtin/packages/py-astropy/package.py
+++ b/var/spack/repos/builtin/packages/py-astropy/package.py
@@ -60,11 +60,15 @@ class PyAstropy(PythonPackage):
     depends_on('expat')
 
     def build_args(self, spec, prefix):
-        return [
-            '-j', str(make_jobs),
+        args = [
             '--use-system-libraries',
             '--use-system-erfa',
             '--use-system-wcslib',
             '--use-system-cfitsio',
             '--use-system-expat'
         ]
+
+        if spec.satisfies('^python@3:'):
+            args.extend(['-j', str(make_jobs)])
+
+        return args


### PR DESCRIPTION
Fixes #13119 

@Sinan81 can you test this? Some of the other build flags may also be specific to the latest release.

I'm not sure exactly which version of Python/setuptools is required for parallel builds, but this seems like a good default for now.