### PR TITLE
Make sure we look into /sbin and /usr/sbin for sysctl

### DIFF
--- a/lib/spack/spack/test/cmd/compiler_command.py
+++ b/lib/spack/spack/test/cmd/compiler_command.py
@@ -24,7 +24,8 @@ def no_compilers_yaml(mutable_config, monkeypatch):
             os.remove(compilers_yaml)
 
 
-@pytest.mark.regression('11678')
+@pytest.mark.regression('11678,13138')
+@pytest.mark.filterwarnings('error')
 def test_compiler_find_without_paths(no_compilers_yaml, working_env, tmpdir):
     with tmpdir.as_cwd():
         with open('gcc', 'w') as f:

--- a/lib/spack/spack/test/cmd/compiler_command.py
+++ b/lib/spack/spack/test/cmd/compiler_command.py
@@ -25,7 +25,6 @@ def no_compilers_yaml(mutable_config, monkeypatch):
 
 
 @pytest.mark.regression('11678,13138')
-@pytest.mark.filterwarnings('error')
 def test_compiler_find_without_paths(no_compilers_yaml, working_env, tmpdir):
     with tmpdir.as_cwd():
         with open('gcc', 'w') as f:

--- a/lib/spack/spack/test/llnl/util/cpu.py
+++ b/lib/spack/spack/test/llnl/util/cpu.py
@@ -67,7 +67,7 @@ def expected_target(request, monkeypatch):
                 key, value = line.split(':')
                 info[key.strip()] = value.strip()
 
-        def _check_output(args):
+        def _check_output(args, env):
             current_key = args[-1]
             return info[current_key]
 


### PR DESCRIPTION
fixes #13138
closes #13354

This PR ensures that on Darwin we always append `/sbin` and `/usr/sbin` to `PATH`, if they are not already present, when looking for `sysctl`.