### PR TITLE
py-linecache2: pbr is only a build dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-linecache2/package.py
+++ b/var/spack/repos/builtin/packages/py-linecache2/package.py
@@ -15,4 +15,6 @@ class PyLinecache2(PythonPackage):
     version('1.0.0', sha256='4b26ff4e7110db76eeb6f5a7b64a82623839d595c2038eeda662f2a2db78e97c')
 
     depends_on('py-setuptools', type='build')
-    depends_on('py-pbr', type=('build', 'run'))
+    depends_on('py-pbr', type='build')
+    depends_on('py-fixtures', type='test')
+    depends_on('py-unittest2', type='test')


### PR DESCRIPTION
Successfully builds on macOS 10.15 with Clang 11.0.0 and Python 3.7.4.