### PR TITLE
py-traceback2: fix dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/py-traceback2/package.py
+++ b/var/spack/repos/builtin/packages/py-traceback2/package.py
@@ -15,5 +15,10 @@ class PyTraceback2(PythonPackage):
     version('1.4.0', sha256='05acc67a09980c2ecfedd3423f7ae0104839eccb55fc645773e1caa0951c3030')
 
     depends_on('py-setuptools', type='build')
-    depends_on('py-linecache2', type=('build', 'run'))
-    depends_on('py-pbr', type=('build', 'run'))
+    depends_on('py-pbr', type='build')
+
+    # test-requirements.txt
+    depends_on('py-contextlib2', type='test')
+    depends_on('py-fixtures', type='test')
+    depends_on('py-testtools', type='test')
+    depends_on('py-unittest2', type='test')


### PR DESCRIPTION
Successfully builds on macOS 10.15 with Clang 11.0.0 and Python 3.7.4.