### PR TITLE
py-unittest2: fix dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/py-unittest2/package.py
+++ b/var/spack/repos/builtin/packages/py-unittest2/package.py
@@ -16,7 +16,6 @@ class PyUnittest2(PythonPackage):
     version('1.1.0', sha256='22882a0e418c284e1f718a822b3b022944d53d2d908e1690b319a9d3eb2c0579')
 
     depends_on('py-setuptools', type='build')
-    depends_on('py-enum34', when='^python@:3.3', type=('build', 'run'))
     depends_on('py-traceback2', type=('build', 'run'))
-    depends_on('py-six', type=('build', 'run'))
+    depends_on('py-six@1.4:', type=('build', 'run'))
     depends_on('py-argparse', type=('build', 'run'))


### PR DESCRIPTION
Successfully builds on macOS 10.15 with Clang 11.0.0 and Python 3.7.4.