### PR TITLE
Docs: unlock requirement versions

### DIFF
--- a/lib/spack/docs/requirements.txt
+++ b/lib/spack/docs/requirements.txt
@@ -1,7 +1,7 @@
 # These dependencies should be installed using pip in order
 # to build the documentation.
 
-sphinx==2.0.1
-sphinxcontrib-programoutput==0.14
-sphinx-rtd-theme==0.4.3
+sphinx
+sphinxcontrib-programoutput
+sphinx-rtd-theme
 python-levenshtein


### PR DESCRIPTION
@alalazo @tgamblin thoughts on this PR? I just successfully built the docs with the latest version of all of these dependencies. I don't recall why we locked the versions in the first place (maybe because they started dropping Python 2.6 support), but now that we build with Python 3, we should make sure the latest version of these packages still works.

Alternatively, I can update the versions to the current releases I've tested if we want things to be more stable.