### PR TITLE
Disable macOS builds on PRs while we wait for Travis to catch up.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ jobs:
     - os: osx
       language: generic
       env: [ TEST_SUITE=unit, PYTHON_VERSION=2.7, COVERAGE=true ]
+      if: type != pull_request
 # mpich (AutotoolsPackage)
     - stage: 'build tests'
       python: '2.7'


### PR DESCRIPTION
Travis macOS builds are taking too long to run, so we'll only run them on `develop` until they get faster.