### PR TITLE
bracken: Use correct python command

### DIFF
--- a/var/spack/repos/builtin/packages/bracken/package.py
+++ b/var/spack/repos/builtin/packages/bracken/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+import os
 
 
 class Bracken(Package):
@@ -16,8 +17,8 @@ class Bracken(Package):
 
     version('1.0.0', sha256='8ee736535ad994588339d94d0db4c0b1ba554a619f5f96332ee09f2aabdfe176')
 
-    depends_on('perl')
-    depends_on('python@2.7:')
+    depends_on('perl', type=('build', 'link', 'run'))
+    depends_on('python@2.7:', type=('build', 'link', 'run'))
     depends_on('perl-exporter-tiny')
     depends_on('perl-list-moreutils')
     depends_on('perl-parallel-forkmanager')
@@ -34,13 +35,15 @@ class Bracken(Package):
 
         filter_file(
             r'#!/usr/bin/python',
-            '#!/usr/bin/env python',
+            '#!/usr/bin/env {0}'.format(
+                os.path.basename(self.spec['python'].command.path)),
             'est_abundance.py'
         )
 
         filter_file(
             r'#!/usr/bin/python',
-            '#!/usr/bin/env python',
+            '#!/usr/bin/env {0}'.format(
+                os.path.basename(self.spec['python'].command.path)),
             'generate_kmer_distribution.py'
         )
 


### PR DESCRIPTION
python~pythoncmd does not provide a python symlink for python3, so make sure we pick the right command.