### PR TITLE
url summary: show right and wrong parse counts for each regex

### DIFF
--- a/lib/spack/spack/cmd/url.py
+++ b/lib/spack/spack/cmd/url.py
@@ -160,10 +160,13 @@ def url_summary(args):
     correct_versions = 0
 
     # Collect statistics on which regexes were matched and how often
-    name_regex_dict    = dict()
-    name_count_dict    = defaultdict(int)
-    version_regex_dict = dict()
-    version_count_dict = defaultdict(int)
+    name_regex_dict     = dict()
+    right_name_count    = defaultdict(int)
+    wrong_name_count    = defaultdict(int)
+
+    version_regex_dict  = dict()
+    right_version_count = defaultdict(int)
+    wrong_version_count = defaultdict(int)
 
     tty.msg('Generating a summary of URL parsing in Spack...')
 
@@ -189,9 +192,11 @@ def url_summary(args):
             try:
                 version, vs, vl, vi, vregex = parse_version_offset(url)
                 version_regex_dict[vi] = vregex
-                version_count_dict[vi] += 1
                 if version_parsed_correctly(pkg, version):
                     correct_versions += 1
+                    right_version_count[vi] += 1
+                else:
+                    wrong_version_count[vi] += 1
             except UndetectableVersionError:
                 pass
 
@@ -199,9 +204,11 @@ def url_summary(args):
             try:
                 name, ns, nl, ni, nregex = parse_name_offset(url, version)
                 name_regex_dict[ni] = nregex
-                name_count_dict[ni] += 1
                 if name_parsed_correctly(pkg, name):
                     correct_names += 1
+                    right_name_count[ni] += 1
+                else:
+                    wrong_name_count[ni] += 1
             except UndetectableNameError:
                 pass
 
@@ -216,24 +223,34 @@ def url_summary(args):
     tty.msg('Statistics on name regular expressions:')
 
     print()
-    print('    Index  Count  Regular Expression')
+    print('    Index   Right   Wrong   Total   Regular Expression')
     for ni in sorted(name_regex_dict.keys()):
-        print('    {0:>3}: {1:>6}   r{2!r}'.format(
-            ni, name_count_dict[ni], name_regex_dict[ni]))
+        print('    {0:>5}   {1:>5}   {2:>5}   {3:>5}   r{4!r}'.format(
+            ni,
+            right_name_count[ni],
+            wrong_name_count[ni],
+            right_name_count[ni] + wrong_name_count[ni],
+            name_regex_dict[ni])
+        )
     print()
 
     tty.msg('Statistics on version regular expressions:')
 
     print()
-    print('    Index  Count  Regular Expression')
+    print('    Index   Right   Wrong   Total   Regular Expression')
     for vi in sorted(version_regex_dict.keys()):
-        print('    {0:>3}: {1:>6}   r{2!r}'.format(
-            vi, version_count_dict[vi], version_regex_dict[vi]))
+        print('    {0:>5}   {1:>5}   {2:>5}   {3:>5}   r{4!r}'.format(
+            vi,
+            right_version_count[vi],
+            wrong_version_count[vi],
+            right_version_count[vi] + wrong_version_count[vi],
+            version_regex_dict[vi])
+        )
     print()
 
     # Return statistics, only for testing purposes
     return (total_urls, correct_names, correct_versions,
-            name_count_dict, version_count_dict)
+            right_name_count, right_version_count)
 
 
 def url_stats(args):


### PR DESCRIPTION
Previously this command only showed total counts for each regular expression.  This doesn't give you a sense of which regexes are working well and which ones are not.  We now display the number of right, wrong, and total URL parses per regex.

It's easier to see where we might improve the URL parsing with this change.

Let's see how triggered @adamjstewart is by these results -- there are some pretty unproductive regexes in here.

```
(spackbook):spack$ spack url summary
==> Generating a summary of URL parsing in Spack...

    Total URLs found:          3477
    Names correctly parsed:    3045/3477 (87.58%)
    Versions correctly parsed: 3159/3477 (90.85%)

==> Statistics on name regular expressions:

    Index   Right   Wrong   Total   Regular Expression
        0     664     112     776   r'github\\.com/[^/]+/([^/]+)'
        1       7       1       8   r'gitlab[^/]+/api/v4/projects/[^/]+%2F([^/]+)'
        2       5       2       7   r'gitlab[^/]+/(?!api/v4/projects)[^/]+/([^/]+)'
        3      13       4      17   r'bitbucket\\.org/[^/]+/([^/]+)'
        4     518       7     525   r'pypi\\.(?:python\\.org|io)/packages/source/[A-Za-z\\d]/([^/]+)'
        6       8       0       8   r'\\?package=([A-Za-z\\d+-]+)'
        7       0       2       2   r'([^/]+)/download.php$'
        8    1830     303    2133   r'^([A-Za-z\\d+\\._-]+)$'

==> Statistics on version regular expressions:

    Index   Right   Wrong   Total   Regular Expression
        0    2374      54    2428   r'^[a-zA-Z+._-]+[._-]v?(\\d[\\d._-]*)$'
        1     495      21     516   r'^v?(\\d[\\d._-]*)$'
        2      10      15      25   r'^[a-zA-Z+]*(\\d[\\da-zA-Z]*)$'
        3       7       4      11   r'^[a-zA-Z+-]*(\\d[\\da-zA-Z-]*)$'
        4       3      77      80   r'^[a-zA-Z+_]*(\\d[\\da-zA-Z_]*)$'
        5      34      19      53   r'^[a-zA-Z+.]*(\\d[\\da-zA-Z.]*)$'
        6     158       6     164   r'^[a-zA-Z\\d+-]+-v?(\\d[\\da-zA-Z.]*)$'
        7       1       0       1   r'^[a-zA-Z\\d+-]+-v?(\\d[\\da-zA-Z_]*)$'
        8      20       0      20   r'^[a-zA-Z\\d+_]+_v?(\\d[\\da-zA-Z.]*)$'
        9       0       1       1   r'^[a-zA-Z\\d+_]+\\.v?(\\d[\\da-zA-Z.]*)$'
       10      17      51      68   r'^(?:[a-zA-Z\\d+-]+-)?v?(\\d[\\da-zA-Z.-]*)$'
       11       3       0       3   r'^[a-zA-Z+]+v?(\\d[\\da-zA-Z.-]*)$'
       12       4       1       5   r'^[a-zA-Z\\d+_]+-v?(\\d[\\da-zA-Z.]*)$'
       13      11       2      13   r'^[a-zA-Z\\d+.]+_v?(\\d[\\da-zA-Z.-]*)$'
       14       0       1       1   r'^[a-zA-Z\\d+-]+-v?(\\d[\\da-zA-Z._]*)$'
       15       1       1       2   r'^[a-zA-Z\\d+._]+-v?(\\d[\\da-zA-Z.]*)$'
       16       4       0       4   r'^[a-zA-Z+-]+(\\d[\\da-zA-Z._]*)$'
       17       1       0       1   r'bzr(\\d[\\da-zA-Z._-]*)$'
       18       4       1       5   r'github\\.com/[^/]+/[^/]+/releases/download/[a-zA-Z+._-]*v?(\\d[\\da-zA-Z._-]*)/'
       19       8       0       8   r'\\?sha=[a-zA-Z+._-]*v?(\\d[\\da-zA-Z._-]*)$'
       20       1       0       1   r'\\?ref=[a-zA-Z+._-]*v?(\\d[\\da-zA-Z._-]*)$'
       21       1       0       1   r'\\?version=v?(\\d[\\da-zA-Z._-]*)$'
       23       2       0       2   r'\\?package=[a-zA-Z\\d+-]+&get=[a-zA-Z\\d+-]+-v?(\\d[\\da-zA-Z.]*)$'
```