### PR TITLE
bison: Fix parallel build

### DIFF
--- a/var/spack/repos/builtin/packages/bison/package.py
+++ b/var/spack/repos/builtin/packages/bison/package.py
@@ -21,6 +21,9 @@ class Bison(AutotoolsPackage):
     version('3.0.4', sha256='b67fd2daae7a64b5ba862c66c07c1addb9e6b1b05c5f2049392cfd8a2172952e')
     version('2.7',   sha256='19bbe7374fd602f7a6654c131c21a15aebdc06cc89493e8ff250cb7f9ed0a831')
 
+    # https://lists.gnu.org/archive/html/bug-bison/2019-08/msg00008.html
+    patch('parallel.patch', when='@3.4.2')
+
     depends_on('diffutils', type='build')
     depends_on('m4', type=('build', 'run'))
     depends_on('perl', type='build')
@@ -32,7 +35,3 @@ class Bison(AutotoolsPackage):
         patch('secure_snprintf.patch', level=0, when='@3.0.4')
 
     build_directory = 'spack-build'
-
-    @property
-    def parallel(self):
-        return not self.spec.satisfies('@3.4.2')

--- a/var/spack/repos/builtin/packages/bison/parallel.patch
+++ b/var/spack/repos/builtin/packages/bison/parallel.patch
@@ -1,0 +1,85 @@
+--- a/examples/c/reccalc/local.mk	2019-09-12 09:05:52.000000000 +0200
++++ b/examples/c/reccalc/local.mk	2019-10-23 21:34:45.754643942 +0200
+@@ -36,16 +36,40 @@
+ # additional dependency.
+ DASH = -
+ %D%/reccalc$(DASH)parse.o: %D%/scan.h
++# Tell Make scan.o depends on parse.h, except that Make sees only
++# parse.c, not parse.h.  We can't use BUILT_SOURCES to this end, since
++# we use the built bison.
++%D%/reccalc$(DASH)scan.o: %D%/parse.c
+ 
++# Likewise, but for Automake before 1.16.
++%D%/examples_c_reccalc_reccalc$(DASH)parse.o: %D%/scan.h
++%D%/examples_c_reccalc_reccalc$(DASH)scan.o: %D%/parse.c
++
++## See "info automake 'Multiple Outputs'" for this rule.
+ %D%/scan.c %D%/scan.h: %D%/scan.stamp
+-	@test -f $@ || rm -f %D%/scan.stamp
+-	@test -f $@ || $(MAKE) $(AM_MAKEFLAGS) %D%/scan.stamp
++## Recover from the removal of $@
++	@if test -f $@; then :; else \
++	  trap 'rm -rf %D%/scan.lock %D%/scan.stamp' 1 2 13 15; \
++## mkdir is a portable test-and-set
++	  if mkdir %D%/scan.lock 2>/dev/null; then \
++## This code is being executed by the first process.
++	    rm -f %D%/scan.stamp; \
++	    $(MAKE) $(AM_MAKEFLAGS) %D%/scan.stamp; \
++	    result=$$?; rm -rf %D%/scan.lock; exit $$result; \
++	  else \
++## This code is being executed by the follower processes.
++## Wait until the first process is done.
++	    while test -d %D%/scan.lock; do sleep 1; done; \
++## Succeed if and only if the first process succeeded.
++	    test -f %D%/scan.stamp; \
++	  fi; \
++	fi
+ 
+ %D%/scan.stamp: %D%/scan.l
+ 	$(AM_V_LEX)rm -f $@ $@.tmp
+ 	$(AM_V_at)$(MKDIR_P) %D%
+ 	$(AM_V_at)touch $@.tmp
+-	$(AM_V_at)$(LEX) -o%D%/scan.c --header-file=%D%/scan.h $(srcdir)/%D%/scan.l
++	$(AM_V_at)$(LEX) $(AM_LFLAGS) $(LFLAGS) -o%D%/scan.c --header-file=%D%/scan.h $(srcdir)/%D%/scan.l
+ 	$(AM_V_at)mv $@.tmp $@
+ 
+ 
+--- a/Makefile.in	2019-09-12 17:41:48.000000000 +0200
++++ b/Makefile.in	2019-10-23 21:34:56.899729446 +0200
+@@ -9314,16 +9314,33 @@
+ 
+ examples/c/reccalc/parse.c: $(dependencies)
+ examples/c/reccalc/reccalc$(DASH)parse.o: examples/c/reccalc/scan.h
++# Tell Make scan.o depends on parse.h, except that Make sees only
++# parse.c, not parse.h.  We can't use BUILT_SOURCES to this end, since
++# we use the built bison.
++examples/c/reccalc/reccalc$(DASH)scan.o: examples/c/reccalc/parse.c
++
++# Likewise, but for Automake before 1.16.
++examples/c/reccalc/examples_c_reccalc_reccalc$(DASH)parse.o: examples/c/reccalc/scan.h
++examples/c/reccalc/examples_c_reccalc_reccalc$(DASH)scan.o: examples/c/reccalc/parse.c
+ 
+ examples/c/reccalc/scan.c examples/c/reccalc/scan.h: examples/c/reccalc/scan.stamp
+-	@test -f $@ || rm -f examples/c/reccalc/scan.stamp
+-	@test -f $@ || $(MAKE) $(AM_MAKEFLAGS) examples/c/reccalc/scan.stamp
++	@if test -f $@; then :; else \
++	  trap 'rm -rf examples/c/reccalc/scan.lock examples/c/reccalc/scan.stamp' 1 2 13 15; \
++	  if mkdir examples/c/reccalc/scan.lock 2>/dev/null; then \
++	    rm -f examples/c/reccalc/scan.stamp; \
++	    $(MAKE) $(AM_MAKEFLAGS) examples/c/reccalc/scan.stamp; \
++	    result=$$?; rm -rf examples/c/reccalc/scan.lock; exit $$result; \
++	  else \
++	    while test -d examples/c/reccalc/scan.lock; do sleep 1; done; \
++	    test -f examples/c/reccalc/scan.stamp; \
++	  fi; \
++	fi
+ 
+ examples/c/reccalc/scan.stamp: examples/c/reccalc/scan.l
+ 	$(AM_V_LEX)rm -f $@ $@.tmp
+ 	$(AM_V_at)$(MKDIR_P) examples/c/reccalc
+ 	$(AM_V_at)touch $@.tmp
+-	$(AM_V_at)$(LEX) -oexamples/c/reccalc/scan.c --header-file=examples/c/reccalc/scan.h $(srcdir)/examples/c/reccalc/scan.l
++	$(AM_V_at)$(LEX) $(AM_LFLAGS) $(LFLAGS) -oexamples/c/reccalc/scan.c --header-file=examples/c/reccalc/scan.h $(srcdir)/examples/c/reccalc/scan.l
+ 	$(AM_V_at)mv $@.tmp $@
+ examples/c/rpcalc/rpcalc.c: $(dependencies)
+ 


### PR DESCRIPTION
Turns out a patch for #13231 has been available in the bison mailing list archives. I did a few test builds and the patch seems to fix the problem for me. I am not sure whether the added dependencies make it worth it, though (most of them are already required by bison anyway). @adamjstewart

I will send feedback to the developers to make sure it gets included in the next release.