### PR TITLE
Don't format local path when caching a local archive

### DIFF
--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -203,13 +203,8 @@ def warn_no_ssl_cert_checking():
              "your Python to enable certificate verification.")
 
 
-def push_to_url(local_path, remote_path, **kwargs):
+def push_to_url(local_file_path, remote_path, **kwargs):
     keep_original = kwargs.get('keep_original', True)
-
-    local_url = url_util.parse(local_path)
-    local_file_path = url_util.local_file_path(local_url)
-    if local_file_path is None:
-        raise ValueError('local path must be a file:// url')
 
     remote_url = url_util.parse(remote_path)
     verify_ssl = spack.config.get('config:verify_ssl')


### PR DESCRIPTION
Fixes #13404

fd58c98 formats the `Stage`'s `archive_path` in `Stage.archive` (as part of `web.push_to_url`). This is not needed and if the formatted differs from the original path (for example if the archive file name contains a URL query suffix), then the copy fails.

This removes the formatting that occurs in `web.push_to_url`. Admittedly the archive path chosen by the stage should strip off strings like `?r=http%3A%2F%2Fsourceforge.net%2Fprojects%2Flibuuid%2F&ts=1433881396&use_mirror=iweb` from `libuuid-1.0.3.tar.gz?r=http%3A%2F%2Fsourceforge.net%2Fprojects%2Flibuuid%2F&ts=1433881396&use_mirror=iweb`, but that should be handled when the archive names are chosen (i.e. in `Stage.expected_archive_files`).

See also: https://github.com/spack/spack/pull/11117#discussion_r338301058