### PR TITLE
database: update database format version

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -50,7 +50,9 @@ from spack.util.lock import Lock, WriteTransaction, ReadTransaction, LockError
 _db_dirname = '.spack-db'
 
 # DB version.  This is stuck in the DB file to track changes in format.
-_db_version = Version('0.9.3')
+# Increment by one when the database format changes.
+# versions before 5 were not integers
+_db_version = Version('5')
 
 # Timeout for spack database locks in seconds
 _db_lock_timeout = 120


### PR DESCRIPTION
I forgot to bump the database format version when I added the `spack deprecate` command, which included a change to the database format.

After discussion with @scheibelp and @tgamblin we also changed to an integer database format version (instead of tracking the Spack version).