### PR TITLE
LLVM code-signing on OSX: link to the offical documentation

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -619,9 +619,9 @@ class Llvm(CMakePackage):
 
         except ProcessError:
             explanation = ('The "lldb_codesign" identity must be available'
-                           ' to build LLVM with LLDB. See https://github.com/'
-                           'jevinskie/llvm-lldb/blob/master/docs/code-signing'
-                           '.txt for details on how to create this identity.')
+                           ' to build LLVM with LLDB. See https://lldb.llvm'
+                           '.org/resources/build.html#code-signing-on-macos'
+                           'for details on how to create this identity.')
             raise RuntimeError(explanation)
 
     def setup_environment(self, spack_env, run_env):

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -624,12 +624,13 @@ class Llvm(CMakePackage):
                            'for details on how to create this identity.')
             raise RuntimeError(explanation)
 
-    def setup_environment(self, spack_env, run_env):
-        spack_env.append_flags('CXXFLAGS', self.compiler.cxx11_flag)
+    def setup_build_environment(self, env):
+        env.append_flags('CXXFLAGS', self.compiler.cxx11_flag)
 
+    def setup_run_environment(self, env):
         if '+clang' in self.spec:
-            run_env.set('CC', join_path(self.spec.prefix.bin, 'clang'))
-            run_env.set('CXX', join_path(self.spec.prefix.bin, 'clang++'))
+            env.set('CC', join_path(self.spec.prefix.bin, 'clang'))
+            env.set('CXX', join_path(self.spec.prefix.bin, 'clang++'))
 
     def cmake_args(self):
         spec = self.spec


### PR DESCRIPTION
Follow-up to #13047 @kljohann pointed out that my previous improvement was due to an old version being the head of someone's private fork and provided a link to the official documentation. Using that link here rather than the old one.