### PR TITLE
allow bootstrap buildcache install of patchelf

### DIFF
--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -680,8 +680,8 @@ def file_is_relocatable(file):
 
     # if we're relocating patchelf itself, use it
 
-    if path_name[-13:] == "/bin/patchelf":
-        patchelf = Executable(path_name)
+    if file[-13:] == "/bin/patchelf":
+        patchelf = Executable(file)
     else:
         patchelf = Executable(get_patchelf())
 

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -341,7 +341,7 @@ def modify_elf_object(path_name, new_rpaths):
 
     if path_name[-13:] == "/bin/patchelf":
         bak_path = path_name + ".bak"
-        shutil.copy(path_name,bak_path)
+        shutil.copy(path_name, bak_path)
         patchelf = Executable(bak_path)
     else:
         patchelf = Executable(get_patchelf())

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -59,6 +59,7 @@ def test_file_is_relocatable(source_file, is_relocatable):
     assert spack.relocate.is_binary(executable)
     assert spack.relocate.file_is_relocatable(executable) is is_relocatable
 
+
 @pytest.mark.requires_executables(
     'patchelf', 'strings', 'file'
 )
@@ -66,6 +67,7 @@ def test_patchelf_is_relocatable():
     patchelf = spack.relocate.get_patchelf()
     assert spack.relocate.is_binary(patchelf)
     assert spack.relocate.file_is_relocatable(patchelf)
+
 
 @pytest.mark.skipif(
     platform.system().lower() != 'linux',

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -59,6 +59,13 @@ def test_file_is_relocatable(source_file, is_relocatable):
     assert spack.relocate.is_binary(executable)
     assert spack.relocate.file_is_relocatable(executable) is is_relocatable
 
+@pytest.mark.requires_executables(
+    'patchelf', 'strings', 'file'
+)
+def test_patchelf_is_relocatable():
+    patchelf = spack.relocate.get_patchelf()
+    assert spack.relocate.is_binary(patchelf)
+    assert spack.relocate.file_is_relocatable(patchelf)
 
 @pytest.mark.skipif(
     platform.system().lower() != 'linux',


### PR DESCRIPTION

Currently, even if you have patchelf in your binary cache, you cannot use it, because we try to install it to relocate the patchelf binary.

This patch notices if we're trying to use patchelf on patchelf itself, and lets us use it to relocate it 
(Note, you have to make a copy of the binary to actually  patch it to avoid a busy file error).

This lets you 
spack buildcache install patchelf
before buildcache installing anything else, and do all buildcache installs from the bottom up.
