### PR TITLE
commands: Add `--json` argument to `spack spec`

### DIFF
--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -25,8 +25,11 @@ def setup_parser(subparser):
     arguments.add_common_arguments(
         subparser, ['long', 'very_long', 'install_status'])
     subparser.add_argument(
-        '-y', '--yaml', action='store_true', default=False,
-        help='print concrete spec as YAML')
+        '-y', '--yaml', action='store_const', dest='format', default=None,
+        const='yaml', help='print concrete spec as YAML')
+    subparser.add_argument(
+        '-j', '--json', action='store_const', dest='format', default=None,
+        const='json', help='print concrete spec as YAML')
     subparser.add_argument(
         '-c', '--cover', action='store',
         default='nodes', choices=['nodes', 'edges', 'paths'],
@@ -59,12 +62,15 @@ def spec(parser, args):
 
     for spec in spack.cmd.parse_specs(args.specs):
         # With -y, just print YAML to output.
-        if args.yaml:
+        if args.format:
             if spec.name in spack.repo.path or spec.virtual:
                 spec.concretize()
 
-            # use write because to_yaml already has a newline.
-            sys.stdout.write(spec.to_yaml(hash=ht.build_hash))
+            if args.format == 'yaml':
+                # use write because to_yaml already has a newline.
+                sys.stdout.write(spec.to_yaml(hash=ht.build_hash))
+            else:
+                print(spec.to_json(hash=ht.build_hash))
             continue
 
         kwargs['hashes'] = False  # Always False for input spec

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -37,6 +37,18 @@ def test_spec_yaml():
     assert 'mpich' in mpileaks
 
 
+def test_spec_json():
+    output = spec('--json', 'mpileaks')
+
+    mpileaks = spack.spec.Spec.from_json(output)
+    assert 'mpileaks' in mpileaks
+    assert 'callpath' in mpileaks
+    assert 'dyninst' in mpileaks
+    assert 'libdwarf' in mpileaks
+    assert 'libelf' in mpileaks
+    assert 'mpich' in mpileaks
+
+
 def _parse_types(string):
     """Parse deptypes for specs from `spack spec -t` output."""
     lines = string.strip().split('\n')


### PR DESCRIPTION
We've had `spack spec --yaml` for a while, and we've had methods for JSON for a while as well.  We just haven't has a `--json` argument for `spack spec`.

- [x] Add a `--json` argument to `spack spec`, just like `--yaml`