### PR TITLE
Add latest version of py-requests-toolbelt

### DIFF
--- a/var/spack/repos/builtin/packages/py-requests-toolbelt/package.py
+++ b/var/spack/repos/builtin/packages/py-requests-toolbelt/package.py
@@ -11,9 +11,10 @@ class PyRequestsToolbelt(PythonPackage):
     python-requests"""
 
     homepage = "https://toolbelt.readthedocs.org/"
-    url      = "https://github.com/requests/toolbelt/archive/0.8.0.tar.gz"
+    url      = "https://github.com/requests/toolbelt/archive/0.9.1.tar.gz"
 
+    version('0.9.1', sha256='c8e68e537e87ae088e3a0eb6d80ed5b7cf5d6df503d0e843e0a5e47283db487b')
     version('0.8.0', sha256='f151c07e88148dc05b6f31cc75dfb7a6770968e4a5c8e6690325eed4e79160a1')
 
     depends_on('py-setuptools', type='build')
-    depends_on('py-requests@2.0.1:3.0.0', type=('build', 'run'))
+    depends_on('py-requests@2.0.1:2.999', type=('build', 'run'))


### PR DESCRIPTION
Successfully builds on macOS 10.15 with Clang 11.0.0 and Python 3.7.4.