### PR TITLE
Add latest version of py-tqdm

### DIFF
--- a/var/spack/repos/builtin/packages/py-tqdm/package.py
+++ b/var/spack/repos/builtin/packages/py-tqdm/package.py
@@ -10,8 +10,13 @@ class PyTqdm(PythonPackage):
     """A Fast, Extensible Progress Meter"""
 
     homepage = "https://github.com/tqdm/tqdm"
-    url      = "https://pypi.io/packages/source/t/tqdm/tqdm-4.8.4.tar.gz"
+    url      = "https://pypi.io/packages/source/t/tqdm/tqdm-4.36.1.tar.gz"
 
-    version('4.8.4', sha256='bab05f8bb6efd2702ab6c532e5e6a758a66c0d2f443e09784b73e4066e6b3a37')
+    version('4.36.1', sha256='abc25d0ce2397d070ef07d8c7e706aede7920da163c64997585d42d3537ece3d')
+    version('4.8.4',  sha256='bab05f8bb6efd2702ab6c532e5e6a758a66c0d2f443e09784b73e4066e6b3a37')
 
+    depends_on('python@2.6:2.8,3.2:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
+    depends_on('py-nose', type='test')
+    depends_on('py-flake8', type='test')
+    depends_on('py-coverage', type='test')


### PR DESCRIPTION
Successfully builds on macOS 10.15 with Clang 11.0.0 and Python 3.7.4.