### PR TITLE
Add latest version of py-fiscalyear

### DIFF
--- a/var/spack/repos/builtin/packages/py-fiscalyear/package.py
+++ b/var/spack/repos/builtin/packages/py-fiscalyear/package.py
@@ -13,17 +13,19 @@ class PyFiscalyear(PythonPackage):
     the fiscal year and fiscal quarter of a date or datetime object."""
 
     homepage = "https://github.com/adamjstewart/fiscalyear"
-    url      = "https://pypi.io/packages/source/f/fiscalyear/fiscalyear-0.1.0.tar.gz"
+    url      = "https://pypi.io/packages/source/f/fiscalyear/fiscalyear-0.2.0.tar.gz"
     git      = "https://github.com/adamjstewart/fiscalyear.git"
 
     maintainers = ['adamjstewart']
     import_modules = ['fiscalyear']
 
     version('master', branch='master')
+    version('0.2.0', sha256='f513616aeb03046406c56d7c69cd9e26f6a12963c71c1410cc3d4532a5bfee71')
     version('0.1.0', sha256='3fde4a12eeb72da446beb487e078adf1223a92d130520e589b82d7d1509701a2')
 
-    depends_on('python@2.5:')
+    depends_on('python@2.5:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
 
     depends_on('py-pytest', type='test')
     depends_on('py-pytest-runner', type='test')
+    depends_on('py-pytest-mock', type='test')


### PR DESCRIPTION
Successfully installs on macOS 10.15 with Clang 11.0.0 and Python 3.7.4.

Shameless plug for some cool software I wrote!