### PR TITLE
Add Lizard (LZ5)

### DIFF
--- a/var/spack/repos/builtin/packages/c-blosc2/package.py
+++ b/var/spack/repos/builtin/packages/c-blosc2/package.py
@@ -32,12 +32,11 @@ class CBlosc2(CMakePackage):
             description='support for ZSTD')
 
     depends_on('cmake@2.8.10:', type='build')
-    # TODO https://github.com/inikep/lizard/issues/21
-    # depends_on('lizard')
-    depends_on('lz4')
-    depends_on('snappy')
-    depends_on('zlib')
-    depends_on('zstd')
+    depends_on('lizard', when='+lizard')
+    depends_on('lz4', when='+lz4')
+    depends_on('snappy', when='+snappy')
+    depends_on('zlib', when='+zlib')
+    depends_on('zstd', when='+zstd')
 
     def cmake_args(self):
         spec = self.spec
@@ -53,8 +52,7 @@ class CBlosc2(CMakePackage):
                 'ON' if '~zlib' in spec else 'OFF'),
             '-DDEACTIVATE_ZSTD={0}'.format(
                 'ON' if '~zstd' in spec else 'OFF'),
-            # TODO https://github.com/inikep/lizard/issues/21
-            '-DPREFER_EXTERNAL_LIZARD=OFF',
+            '-DPREFER_EXTERNAL_LIZARD=ON',
             '-DPREFER_EXTERNAL_LZ4=ON',
             # snappy is supported via external install only
             '-DPREFER_EXTERNAL_ZLIB=ON',

--- a/var/spack/repos/builtin/packages/lizard/fix-install-decompress.patch
+++ b/var/spack/repos/builtin/packages/lizard/fix-install-decompress.patch
@@ -1,0 +1,76 @@
+From 02c35c25e565a090ec6b49fbc6210f6593519b44 Mon Sep 17 00:00:00 2001
+From: Przemyslaw Skibinski <przemyslaw.skibinski@percona.com>
+Date: Fri, 25 Oct 2019 10:03:39 +0200
+Subject: [PATCH] Fix missing `lizard_decompress.h` after `make install`.
+
+---
+ lib/Makefile            | 2 ++
+ lib/lizard_common.h     | 7 +++++++
+ lib/lizard_decompress.h | 9 +--------
+ 3 files changed, 10 insertions(+), 8 deletions(-)
+
+diff --git a/lib/Makefile b/lib/Makefile
+index 64c07dd..9484056 100644
+--- a/lib/Makefile
++++ b/lib/Makefile
+@@ -143,6 +143,7 @@ endif
+ 	@ln -sf liblizard.$(SHARED_EXT_VER) $(DESTDIR)$(LIBDIR)/liblizard.$(SHARED_EXT)
+ 	@echo Installing includes
+ 	@$(INSTALL_DATA) lizard_compress.h $(DESTDIR)$(INCLUDEDIR)/lizard_compress.h
++	@$(INSTALL_DATA) lizard_decompress.h $(DESTDIR)$(INCLUDEDIR)/lizard_decompress.h
+ 	@$(INSTALL_DATA) lizard_common.h $(DESTDIR)$(INCLUDEDIR)/lizard_common.h
+ 	@$(INSTALL_DATA) lizard_frame.h $(DESTDIR)$(INCLUDEDIR)/lizard_frame.h
+ 	@echo lizard static and shared libraries installed
+@@ -154,6 +155,7 @@ uninstall:
+ 	@$(RM) $(DESTDIR)$(LIBDIR)/liblizard.$(SHARED_EXT_VER)
+ 	@$(RM) $(DESTDIR)$(LIBDIR)/liblizard.a
+ 	@$(RM) $(DESTDIR)$(INCLUDEDIR)/lizard_compress.h
++	@$(RM) $(DESTDIR)$(INCLUDEDIR)/lizard_decompress.h
+ 	@$(RM) $(DESTDIR)$(INCLUDEDIR)/lizard_common.h
+ 	@$(RM) $(DESTDIR)$(INCLUDEDIR)/lizard_frame.h
+ 	@echo lizard libraries successfully uninstalled
+diff --git a/lib/lizard_common.h b/lib/lizard_common.h
+index 1677abb..45730cf 100644
+--- a/lib/lizard_common.h
++++ b/lib/lizard_common.h
+@@ -192,6 +192,13 @@ struct Lizard_stream_s
+     const BYTE* destBase;
+ };
+ 
++struct Lizard_streamDecode_s {
++    const BYTE* externalDict;
++    size_t extDictSize;
++    const BYTE* prefixEnd;
++    size_t prefixSize;
++};
++
+ struct Lizard_dstream_s
+ {
+     const BYTE*  offset16Ptr;
+diff --git a/lib/lizard_decompress.h b/lib/lizard_decompress.h
+index 5453b4d..ad9fc8e 100644
+--- a/lib/lizard_decompress.h
++++ b/lib/lizard_decompress.h
+@@ -39,8 +39,6 @@
+ extern "C" {
+ #endif
+ 
+-#include "entropy/mem.h"     /* U32 */
+-
+ 
+ /*^***************************************************************
+ *  Export parameters
+@@ -95,12 +93,7 @@ LIZARDDLIB_API int Lizard_decompress_safe_partial (const char* source, char* des
+ /*-**********************************************
+ *  Streaming Decompression Functions
+ ************************************************/
+-typedef struct {
+-    const BYTE* externalDict;
+-    size_t extDictSize;
+-    const BYTE* prefixEnd;
+-    size_t prefixSize;
+-} Lizard_streamDecode_t;
++typedef struct Lizard_streamDecode_s Lizard_streamDecode_t;
+ 
+ /*
+  * Lizard_streamDecode_t

--- a/var/spack/repos/builtin/packages/lizard/package.py
+++ b/var/spack/repos/builtin/packages/lizard/package.py
@@ -1,0 +1,27 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Lizard(MakefilePackage):
+    """Lizard (formerly LZ5) is an efficient compressor with very
+       fast decompression. It achieves compression ratio that is
+       comparable to zip/zlib and zstd/brotli (at low and medium
+       compression levels) at decompression speed of 1000 MB/s and
+       faster."""
+
+    homepage = "https://github.com/inikep/lizard"
+    url      = "https://github.com/inikep/lizard/archive/v1.0.tar.gz"
+    git      = "https://github.com/inikep/lizard.git"
+
+    version('develop', branch='lizard')
+    version('1.0',
+            sha256='6f666ed699fc15dc7fdaabfaa55787b40ac251681b50c0d8df017c671a9457e6')
+
+    patch('fix-install-decompress.patch', when='@1.0')
+
+    def install(self, spec, prefix):
+        make("PREFIX=%s" % prefix, "install")


### PR DESCRIPTION
Add a new package for Lizard, formerly LZ5, a very fast compressor and decompressor library.
https://github.com/inikep/lizard

With the new package, use an external Lizard (LZ5) dependency and add missing "when="s for other compressor dependants.