### PR TITLE
New package py-wradlib with new dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/py-deprecation/package.py
+++ b/var/spack/repos/builtin/packages/py-deprecation/package.py
@@ -12,18 +12,7 @@ class PyDeprecation(PythonPackage):
 
     homepage = "http://deprecation.readthedocs.io/"
     url      = "https://pypi.io/packages/source/d/deprecation/deprecation-2.0.7.tar.gz"
-    git      = "https://github.com/briancurtin/deprecation.git"
 
-    version('2.0.7', tag='2.0.7')
-    version('2.0.6', tag='2.0.6')
-    version('2.0.5', tag='2.0.5')
-    version('2.0.4', tag='2.0.4')
-    version('2.0.3', tag='2.0.3')
-    version('2.0.2', tag='2.0.2')
-    version('2.0.1', tag='2.0.1')
-    version('2.0.0', tag='2.0')
-    version('1.2.0', tag='1.2')
-    version('1.1.0', tag='1.1')
-    version('1.0.1', tag='1.0.1')
+    version('2.0.7', sha256='c0392f676a6146f0238db5744d73e786a43510d54033f80994ef2f4c9df192ed')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-deprecation/package.py
+++ b/var/spack/repos/builtin/packages/py-deprecation/package.py
@@ -16,3 +16,4 @@ class PyDeprecation(PythonPackage):
     version('2.0.7', sha256='c0392f676a6146f0238db5744d73e786a43510d54033f80994ef2f4c9df192ed')
 
     depends_on('py-setuptools', type='build')
+    depends_on('py-packaging', type='build')

--- a/var/spack/repos/builtin/packages/py-deprecation/package.py
+++ b/var/spack/repos/builtin/packages/py-deprecation/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyDeprecation(PythonPackage):
+    """The deprecation library provides a deprecated decorator and a
+    fail_if_not_removed decorator for your tests. """
+
+    homepage = "http://deprecation.readthedocs.io/"
+    url      = "https://pypi.io/packages/source/d/deprecation/deprecation-2.0.7.tar.gz"
+    git      = "https://github.com/briancurtin/deprecation.git"
+
+    version('2.0.7', tag='2.0.7')
+    version('2.0.6', tag='2.0.6')
+    version('2.0.5', tag='2.0.5')
+    version('2.0.4', tag='2.0.4')
+    version('2.0.3', tag='2.0.3')
+    version('2.0.2', tag='2.0.2')
+    version('2.0.1', tag='2.0.1')
+    version('2.0.0', tag='2.0')
+    version('1.2.0', tag='1.2')
+    version('1.1.0', tag='1.1')
+    version('1.0.1', tag='1.0.1')
+
+    depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-semver/package.py
+++ b/var/spack/repos/builtin/packages/py-semver/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PySemver(PythonPackage):
+    """A Python module for semantic versioning.
+    Simplifies comparing versions."""
+
+    homepage = "https://semver.org/"
+    git      = "https://github.com/k-bx/python-semver.git"
+
+    version('2.8.1', tag='2.8.1')
+    version('2.8.0', tag='2.8.0')
+    version('2.7.0', tag='2.7.0')
+    version('2.6.0', tag='2.6.0')
+    version('2.5.0', tag='2.5.0')
+    version('2.4.1', tag='2.4.1')
+
+    depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-semver/package.py
+++ b/var/spack/repos/builtin/packages/py-semver/package.py
@@ -11,13 +11,8 @@ class PySemver(PythonPackage):
     Simplifies comparing versions."""
 
     homepage = "https://semver.org/"
-    git      = "https://github.com/k-bx/python-semver.git"
+    url      = "https://pypi.io/packages/source/s/semver/semver-2.8.1.tar.gz"
 
-    version('2.8.1', tag='2.8.1')
-    version('2.8.0', tag='2.8.0')
-    version('2.7.0', tag='2.7.0')
-    version('2.6.0', tag='2.6.0')
-    version('2.5.0', tag='2.5.0')
-    version('2.4.1', tag='2.4.1')
+    version('2.8.1', sha256='5b09010a66d9a3837211bb7ae5a20d10ba88f8cb49e92cb139a69ef90d5060d8')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-wradlib/package.py
+++ b/var/spack/repos/builtin/packages/py-wradlib/package.py
@@ -14,14 +14,9 @@ class PyWradlib(PythonPackage):
     attenuation) and visualising the data."""
 
     homepage = "https://docs.wradlib.org"
-    git = "https://github.com/wradlib/wradlib.git"
+    url      = "https://pypi.io/packages/source/w/wradlib/wradlib-1.5.0.tar.gz"
 
-    version('1.5', branch='release/1.5')
-    version('1.4', branch='release/1.4')
-    version('1.3', branch='release/1.3')
-    version('1.2', branch='release/1.2')
-    version('1.1', branch='release/1.1')
-    version('1.0', branch='release/1.0')
+    version('1.5.0', sha256='9bf0742d7235ea830e83c2269f6b5d1afd83d92696efce0a7bcdb0c4f6604784')
 
     depends_on('py-setuptools', type='build')
 

--- a/var/spack/repos/builtin/packages/py-wradlib/package.py
+++ b/var/spack/repos/builtin/packages/py-wradlib/package.py
@@ -1,0 +1,42 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyWradlib(PythonPackage):
+    """wradlib is designed to assist you in the most important steps of
+    processing weather radar data. These may include: reading common data
+    formats, georeferencing, converting reflectivity to rainfall intensity,
+    identifying and correcting typical error sources (such as clutter or
+    attenuation) and visualising the data."""
+
+    homepage = "https://docs.wradlib.org"
+    git = "https://github.com/wradlib/wradlib.git"
+
+    version('1.5', branch='release/1.5')
+    version('1.4', branch='release/1.4')
+    version('1.3', branch='release/1.3')
+    version('1.2', branch='release/1.2')
+    version('1.1', branch='release/1.1')
+    version('1.0', branch='release/1.0')
+
+    depends_on('py-setuptools', type='build')
+
+    # https://docs.wradlib.org/en/stable/index.html
+    conflicts('^python@:2.999', when='@1.3:')
+
+    # recommended versions from https://docs.wradlib.org/en/stable/installation.html#dependencies
+    depends_on('py-numpy@1.16:', type=('build', 'run'))
+    depends_on('py-matplotlib@3.0.2:', type=('build', 'run'))
+    depends_on('py-scipy@1.2.0:', type=('build', 'run'))
+    depends_on('py-h5py@2.9:', type=('build', 'run'))
+    depends_on('py-netcdf4@1.4.2:', type=('build', 'run'))
+    depends_on('py-xarray@0.11.3:', type=('build', 'run'))
+    depends_on('py-xmltodict@0.11:', type=('build', 'run'))
+    depends_on('py-pygdal@2.4.0:', type=('build', 'run'))
+    depends_on('py-semver', type=('build', 'run'))
+    depends_on('py-deprecation', type=('build', 'run'))
+    depends_on('py-requests', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-wradlib/package.py
+++ b/var/spack/repos/builtin/packages/py-wradlib/package.py
@@ -31,7 +31,8 @@ class PyWradlib(PythonPackage):
     depends_on('py-netcdf4@1.4.2:', type=('build', 'run'))
     depends_on('py-xarray@0.11.3:', type=('build', 'run'))
     depends_on('py-xmltodict@0.11:', type=('build', 'run'))
-    depends_on('py-pygdal@2.4.0:', type=('build', 'run'))
     depends_on('py-semver', type=('build', 'run'))
     depends_on('py-deprecation', type=('build', 'run'))
     depends_on('py-requests', type=('build', 'run'))
+
+    depends_on('gdal@2.4.0:+python', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-wradlib/package.py
+++ b/var/spack/repos/builtin/packages/py-wradlib/package.py
@@ -20,9 +20,6 @@ class PyWradlib(PythonPackage):
 
     depends_on('py-setuptools', type='build')
 
-    # https://docs.wradlib.org/en/stable/index.html
-    conflicts('^python@:2.999', when='@1.3:')
-
     # recommended versions from https://docs.wradlib.org/en/stable/installation.html#dependencies
     depends_on('py-numpy@1.16:', type=('build', 'run'))
     depends_on('py-matplotlib@3.0.2:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-xarray/package.py
+++ b/var/spack/repos/builtin/packages/py-xarray/package.py
@@ -25,10 +25,10 @@ class PyXarray(PythonPackage):
 
     depends_on('py-setuptools', type='build')
 
-    depends_on('py-pandas@0.15.0:0.19.1',   when='@0.9.1',      type=('build', 'run'))
-    depends_on('py-pandas@0.19.2:0.23',     when='@0.11:0.13',  type=('build', 'run'))
-    depends_on('py-pandas@0.24:',           when='@0.14:',      type=('build', 'run'))
+    depends_on('py-pandas@0.15.0:', when='@0.9.1',      type=('build', 'run'))
+    depends_on('py-pandas@0.19.2:', when='@0.11:0.13',  type=('build', 'run'))
+    depends_on('py-pandas@0.24:',   when='@0.14:',      type=('build', 'run'))
 
-    depends_on('py-numpy@1.7:1.11',     when='@0.9.1',      type=('build', 'run'))
-    depends_on('py-numpy@1.12:1.13',    when='@0.11:0.13',  type=('build', 'run'))
-    depends_on('py-numpy@1.14:',        when='@0.14:',      type=('build', 'run'))
+    depends_on('py-numpy@1.7:',     when='@0.9.1',      type=('build', 'run'))
+    depends_on('py-numpy@1.12:',    when='@0.11:0.13',  type=('build', 'run'))
+    depends_on('py-numpy@1.14:',    when='@0.14:',      type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-xarray/package.py
+++ b/var/spack/repos/builtin/packages/py-xarray/package.py
@@ -18,6 +18,17 @@ class PyXarray(PythonPackage):
     version('0.11.0', sha256='636964baccfca0e5d69220ac4ecb948d561addc76f47704064dcbe399e03a818')
     version('0.9.1', sha256='89772ed0e23f0e71c3fb8323746374999ecbe79c113e3fadc7ae6374e6dc0525')
 
-    depends_on('py-setuptools',      type='build')
-    depends_on('py-pandas@0.15.0:',  type=('build', 'run'))
-    depends_on('py-numpy@1.7:',      type=('build', 'run'))
+    depends_on('python@2.7:2.8,3.5:',   when='@0.11:',  type=('build', 'run'))
+    depends_on('python@3.5:',           when='@0.12',   type=('build', 'run'))
+    depends_on('python@3.5.3:',         when='@0.13',   type=('build', 'run'))
+    depends_on('python@3.6:',           when='@0.14:',  type=('build', 'run'))
+
+    depends_on('py-setuptools', type='build')
+
+    depends_on('py-pandas@0.15.0:0.19.1',   when='@0.9.1',      type=('build', 'run'))
+    depends_on('py-pandas@0.19.2:0.23',     when='@0.11:0.13',  type=('build', 'run'))
+    depends_on('py-pandas@0.24:',           when='@0.14:',      type=('build', 'run'))
+
+    depends_on('py-numpy@1.7:1.11',     when='@0.9.1',      type=('build', 'run'))
+    depends_on('py-numpy@1.12:1.13',    when='@0.11:0.13',  type=('build', 'run'))
+    depends_on('py-numpy@1.14:',        when='@0.14:',      type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-xarray/package.py
+++ b/var/spack/repos/builtin/packages/py-xarray/package.py
@@ -11,12 +11,11 @@ class PyXarray(PythonPackage):
 
     homepage = "https://github.com/pydata/xarray"
     url      = "https://pypi.io/packages/source/x/xarray/xarray-0.9.1.tar.gz"
-    git      = "https://github.com/pydata/xarray.git"
 
-    version('0.14.0', tag='v0.14.0')
-    version('0.13.0', tag='v0.13.0')
-    version('0.12.0', tag='v0.12.0')
-    version('0.11.0', tag='v0.11.0')
+    version('0.14.0', sha256='a8b93e1b0af27fa7de199a2d36933f1f5acc9854783646b0f1b37fed9b4da091')
+    version('0.13.0', sha256='80e5746ffdebb96b997dba0430ff02d98028ef3828e6db6106cbbd6d62e32825')
+    version('0.12.0', sha256='856fd062c55208a248ac3784cac8d3524b355585387043efc92a4188eede57f3')
+    version('0.11.0', sha256='636964baccfca0e5d69220ac4ecb948d561addc76f47704064dcbe399e03a818')
     version('0.9.1', sha256='89772ed0e23f0e71c3fb8323746374999ecbe79c113e3fadc7ae6374e6dc0525')
 
     depends_on('py-setuptools',      type='build')

--- a/var/spack/repos/builtin/packages/py-xarray/package.py
+++ b/var/spack/repos/builtin/packages/py-xarray/package.py
@@ -11,7 +11,12 @@ class PyXarray(PythonPackage):
 
     homepage = "https://github.com/pydata/xarray"
     url      = "https://pypi.io/packages/source/x/xarray/xarray-0.9.1.tar.gz"
+    git      = "https://github.com/pydata/xarray.git"
 
+    version('0.14.0', tag='v0.14.0')
+    version('0.13.0', tag='v0.13.0')
+    version('0.12.0', tag='v0.12.0')
+    version('0.11.0', tag='v0.11.0')
     version('0.9.1', sha256='89772ed0e23f0e71c3fb8323746374999ecbe79c113e3fadc7ae6374e6dc0525')
 
     depends_on('py-setuptools',      type='build')

--- a/var/spack/repos/builtin/packages/py-xmltodict/package.py
+++ b/var/spack/repos/builtin/packages/py-xmltodict/package.py
@@ -16,3 +16,4 @@ class PyXmltodict(PythonPackage):
     version('0.12.0', sha256='50d8c638ed7ecb88d90561beedbf720c9b4e851a9fa6c47ebd64e99d166d8a21')
 
     depends_on('py-setuptools', type='build')
+    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-xmltodict/package.py
+++ b/var/spack/repos/builtin/packages/py-xmltodict/package.py
@@ -1,0 +1,46 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyXmltodict(PythonPackage):
+    """xmltodict is a Python module that makes working with XML feel like
+    you are working with JSON."""
+
+    homepage = "https://github.com/martinblech/xmltodict"
+    git      = "https://github.com/martinblech/xmltodict.git"
+
+    version('0.12.0', tag='v0.12.0')
+    version('0.11.0', tag='v0.11.0')
+    version('0.10.2', tag='v0.10.2')
+    version('0.10.1', tag='v0.10.1')
+    version('0.10.0', tag='v0.10.0')
+    version('0.9.2', tag='v0.9.2')
+    version('0.9.1', tag='v0.9.1')
+    version('0.9.0', tag='v0.9.0')
+    version('0.8.7', tag='v0.8.7')
+    version('0.8.6', tag='v0.8.6')
+    version('0.8.5', tag='v0.8.5')
+    version('0.8.4', tag='v0.8.4')
+    version('0.8.3', tag='v0.8.3')
+    version('0.8.2', tag='v0.8.2')
+    version('0.8.1', tag='v0.8.1')
+    version('0.8.0', tag='v0.8.0')
+    version('0.7.0', tag='v0.7.0')
+    version('0.6.0', tag='v0.6.0')
+    version('0.5.1', tag='v0.5.1')
+    version('0.5.0', tag='v0.5.0')
+    version('0.4.6', tag='v0.4.6')
+    version('0.4.5', tag='v0.4.5')
+    version('0.4.4', tag='v0.4.4')
+    version('0.4.3', tag='v0.4.3')
+    version('0.4.2', tag='v0.4.2')
+    version('0.4.1', tag='v0.4.1')
+    version('0.4.0', tag='v0.4')
+    version('0.3.0', tag='v0.3')
+    version('0.2.0', tag='v0.2')
+
+    depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-xmltodict/package.py
+++ b/var/spack/repos/builtin/packages/py-xmltodict/package.py
@@ -11,36 +11,8 @@ class PyXmltodict(PythonPackage):
     you are working with JSON."""
 
     homepage = "https://github.com/martinblech/xmltodict"
-    git      = "https://github.com/martinblech/xmltodict.git"
+    url      = "https://pypi.io/packages/source/x/xmltodict/xmltodict-0.12.0.tar.gz"
 
-    version('0.12.0', tag='v0.12.0')
-    version('0.11.0', tag='v0.11.0')
-    version('0.10.2', tag='v0.10.2')
-    version('0.10.1', tag='v0.10.1')
-    version('0.10.0', tag='v0.10.0')
-    version('0.9.2', tag='v0.9.2')
-    version('0.9.1', tag='v0.9.1')
-    version('0.9.0', tag='v0.9.0')
-    version('0.8.7', tag='v0.8.7')
-    version('0.8.6', tag='v0.8.6')
-    version('0.8.5', tag='v0.8.5')
-    version('0.8.4', tag='v0.8.4')
-    version('0.8.3', tag='v0.8.3')
-    version('0.8.2', tag='v0.8.2')
-    version('0.8.1', tag='v0.8.1')
-    version('0.8.0', tag='v0.8.0')
-    version('0.7.0', tag='v0.7.0')
-    version('0.6.0', tag='v0.6.0')
-    version('0.5.1', tag='v0.5.1')
-    version('0.5.0', tag='v0.5.0')
-    version('0.4.6', tag='v0.4.6')
-    version('0.4.5', tag='v0.4.5')
-    version('0.4.4', tag='v0.4.4')
-    version('0.4.3', tag='v0.4.3')
-    version('0.4.2', tag='v0.4.2')
-    version('0.4.1', tag='v0.4.1')
-    version('0.4.0', tag='v0.4')
-    version('0.3.0', tag='v0.3')
-    version('0.2.0', tag='v0.2')
+    version('0.12.0', sha256='50d8c638ed7ecb88d90561beedbf720c9b4e851a9fa6c47ebd64e99d166d8a21')
 
     depends_on('py-setuptools', type='build')


### PR DESCRIPTION
wradlib is an open source library for weather radar data processing (e.g. RADOLAN). Changes include new versions for xarray as well as new packages, on which py-wradlib depends:
- py-deprecation (provides a deprecated decorator and a fail_if_not_removed decorator)
- py-semver (semantic versioning, simplifies comparing versions)
- py-xmltodict (working with XML feel like you are working with JSON)