### PR TITLE
Fix gcc recipe for RHEL7.

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -424,7 +424,7 @@ class Gcc(AutotoolsPackage):
                               self.prefix.lib, self.prefix.lib64))
         set_install_permissions(specs_file)
 
-    def setup_run_environment(self, run_env):
+    def setup_run_environment(self, env):
         # Search prefix directory for possibly modified compiler names
         from spack.compilers.gcc import Gcc as Compiler
 
@@ -450,6 +450,6 @@ class Gcc(AutotoolsPackage):
                     continue
 
                 # Set the proper environment variable
-                run_env.set(lang.upper(), abspath)
+                env.set(lang.upper(), abspath)
                 # Stop searching filename/regex combos for this language
                 break

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -424,7 +424,7 @@ class Gcc(AutotoolsPackage):
                               self.prefix.lib, self.prefix.lib64))
         set_install_permissions(specs_file)
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_run_environment(self, spack_env, run_env):
         # Search prefix directory for possibly modified compiler names
         from spack.compilers.gcc import Gcc as Compiler
 

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -424,7 +424,7 @@ class Gcc(AutotoolsPackage):
                               self.prefix.lib, self.prefix.lib64))
         set_install_permissions(specs_file)
 
-    def setup_run_environment(self, spack_env, run_env):
+    def setup_run_environment(self, run_env):
         # Search prefix directory for possibly modified compiler names
         from spack.compilers.gcc import Gcc as Compiler
 

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -100,7 +100,7 @@ class Gcc(AutotoolsPackage):
     depends_on('isl@0.15:0.18', when='@6:8.9')
     depends_on('isl@0.15:0.20', when='@9:')
     depends_on('zlib', when='@6:')
-    depends_on('libiconv')
+    depends_on('libiconv', when='platform=darwin')
     depends_on('gnat', when='languages=ada')
     depends_on('binutils~libiberty', when='+binutils')
     depends_on('zip', type='build', when='languages=java')
@@ -279,7 +279,6 @@ class Gcc(AutotoolsPackage):
                 ','.join(spec.variants['languages'].value)),
             # Drop gettext dependency
             '--disable-nls',
-            '--with-libiconv-prefix={0}'.format(spec['libiconv'].prefix),
             '--with-mpfr={0}'.format(spec['mpfr'].prefix),
             '--with-gmp={0}'.format(spec['gmp'].prefix),
         ]
@@ -328,7 +327,8 @@ class Gcc(AutotoolsPackage):
         if sys.platform == 'darwin':
             options.extend([
                 '--with-native-system-header-dir=/usr/include',
-                '--with-sysroot={0}'.format(macos_sdk_path())
+                '--with-sysroot={0}'.format(macos_sdk_path()),
+                '--with-libiconv-prefix={0}'.format(spec['libiconv'].prefix)
             ])
 
         return options


### PR DESCRIPTION
+ It appears that macOS related changes to the gcc recipe (PR #13202) broke gcc on RHEL7.  This bug manifests as `libstdc++.so: undefined reference to libiconv` when gcc is used.
+ Fixes #13452 by moving `--with-libiconv-prefix={0}'.format(spec['libiconv'].prefix)` into the darwin OS section of the configuration.
+ Also fixes #13391
+ Needs to be tested on macOS and other Linux flavors.