### PR TITLE
Update PyTorch variable name

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -207,7 +207,7 @@ class PyTorch(PythonPackage):
 
         enable_or_disable('caffe2', keyword='BUILD', var='CAFFE2_OPS')
         enable_or_disable('gloo', newer=True)
-        enable_or_disable('gloo', var='GLOO_IBVERBS', newer=True)
+        enable_or_disable('gloo', var='IBVERBS', newer=True)
         enable_or_disable('opencv', newer=True)
         enable_or_disable('openmp', newer=True)
         enable_or_disable('ffmpeg', newer=True)


### PR DESCRIPTION
When building PyTorch 1.3.0, it emits the following warning message:
```
WARNING: USE_GLOO_IBVERBS is deprecated. Use USE_IBVERBS instead.
```