### PR TITLE
Libbeagle fixes

### DIFF
--- a/var/spack/repos/builtin/packages/beast1/package.py
+++ b/var/spack/repos/builtin/packages/beast1/package.py
@@ -26,6 +26,7 @@ class Beast1(Package):
 
     def setup_environment(self, spack_env, run_env):
         run_env.set('BEAST1', self.prefix)
+        run_env.set('BEAST_LIB', self.prefix.lib)
 
     def install(self, spec, prefix):
         install_tree('bin', prefix.bin)

--- a/var/spack/repos/builtin/packages/beast1/package.py
+++ b/var/spack/repos/builtin/packages/beast1/package.py
@@ -24,9 +24,9 @@ class Beast1(Package):
         base = 'https://github.com/beast-dev/beast-mcmc/releases/download'
         return '{0}/v{1}/BEASTv{1}.tgz'.format(base, ver.dotted)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.set('BEAST1', self.prefix)
-        run_env.set('BEAST_LIB', self.prefix.lib)
+    def setup_run_environment(self, env):
+        env.set('BEAST1', self.prefix)
+        env.set('BEAST_LIB', self.prefix.lib)
 
     def install(self, spec, prefix):
         install_tree('bin', prefix.bin)

--- a/var/spack/repos/builtin/packages/libbeagle/package.py
+++ b/var/spack/repos/builtin/packages/libbeagle/package.py
@@ -44,15 +44,15 @@ class Libbeagle(AutotoolsPackage, CudaPackage):
                         'configure.ac', string=True)
 
     def configure_args(self):
-        args = []
+        args = [
+            # Since spack will inject architecture flags turn off -march=native
+            # when building libbeagle.
+            '--disable-march-native',
+        ]
 
         if '+cuda' in self.spec:
-            args.append('--with-cuda=%s' % spec['cuda'].prefix)
+            args.append('--with-cuda=%s' % self.spec['cuda'].prefix)
         else:
             args.append('--without-cuda')
 
         return args
-
-    def setup_environment(self, spack_env, run_env):
-        prefix = self.prefix
-        run_env.prepend_path('BEAST_LIB', prefix.lib)


### PR DESCRIPTION
This PR fixes a couple of issues with the libbeagle package.

- Use args.append('--with-cuda=%s' % self.spec['cuda'].prefix)
- Disable the default of compiling with -march=native as Spack now
  inserts architecture specific flags
- Set BEAST_LIB in the beast1 package not in libbeagle.