### PR TITLE
Fix PyTorch build with Intel MKL

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -169,6 +169,11 @@ class PyTorch(PythonPackage):
                 else:
                     env.set('NO_' + var, 'ON')
 
+        # Build system has problems locating MKL libraries
+        # See https://github.com/pytorch/pytorch/issues/24334
+        if 'mkl' in self.spec:
+            env.prepend_path('CMAKE_PREFIX_PATH', self.spec['mkl'].prefix.mkl)
+
         env.set('MAX_JOBS', make_jobs)
 
         enable_or_disable('cuda')


### PR DESCRIPTION
With this patch, PyTorch 1.3.0 successfully locates the Intel MKL libraries.