### PR TITLE
mumps: Add '-DMAIN_COMP' when using Fujitsu compiler.

### DIFF
--- a/var/spack/repos/builtin/packages/mumps/package.py
+++ b/var/spack/repos/builtin/packages/mumps/package.py
@@ -119,6 +119,7 @@ class Mumps(Package):
         using_pgi = self.compiler.name == "pgi"
         using_intel = self.compiler.name == "intel"
         using_xl = self.compiler.name in ['xl', 'xl_r']
+        using_fj = self.compiler.name == "fj"
 
         # The llvm compiler suite does not contain a Fortran compiler by
         # default.  Its possible that a Spack user may have configured
@@ -183,10 +184,11 @@ class Mumps(Package):
 
         # TODO: change the value to the correct one according to the
         # compiler possible values are -DAdd_, -DAdd__ and/or -DUPPER
-        if using_intel or using_pgi:
-            # Intel & PGI Fortran compiler provides the main() function so
-            # C examples linked with the Fortran compiler require a
-            # hack defined by _DMAIN_COMP (see examples/c_example.c)
+        if using_intel or using_pgi or using_fj:
+            # Intel, PGI, and Fujitsu Fortran compiler provides
+            # the main() function so C examples linked with the Fortran
+            # compiler require a hack defined by _DMAIN_COMP
+            # (see examples/c_example.c)
             makefile_conf.append("CDEFS   = -DAdd_ -DMAIN_COMP")
         else:
             if not using_xlf:


### PR DESCRIPTION
Fujitsu Fortran compiler requires using `MAIN__()`  instead of `main()` in C program. C programs in `MUMPS` use `MAIN__` when `MAIN_COMP` is defined, so I added Fujitsu compiler to the judgment conditions.