### PR TITLE
[WIP] Bugfix syaml_int repr for Python 3.8.0

### DIFF
--- a/lib/spack/spack/util/spack_yaml.py
+++ b/lib/spack/spack/util/spack_yaml.py
@@ -47,7 +47,7 @@ class syaml_str(str):
 
 
 class syaml_int(int):
-    __repr__ = str.__repr__
+    __repr__ = int.__repr__
 
 
 #: mapping from syaml type -> primitive type


### PR DESCRIPTION
https://github.com/spack/spack/issues/13247#issuecomment-543205666 notes that python 3.8.0 removes `__str__` from `int`, so for python 3.8.0 invocations of `str` fall back on `repr`. Spack's `syaml_int` type assigns `__repr__ = str.__repr__` which appears to be causing failures.

This updates syaml_int type to use `int.__repr__` rather than `str.__repr__`, which allows running Spack with Python 3.8.0 and assigning integer configuration settings.