### PR TITLE
ipopt: Add condition for 'aarch64' to Ipopt/config.guess

### DIFF
--- a/var/spack/repos/builtin/packages/ipopt/ipopt_aarch64_build.patch
+++ b/var/spack/repos/builtin/packages/ipopt/ipopt_aarch64_build.patch
@@ -1,0 +1,12 @@
+--- spack-src/Ipopt/config.guess.org	2019-10-30 13:52:51.920159919 +0900
++++ spack-src/Ipopt/config.guess	2019-10-30 13:55:27.956506585 +0900
+@@ -835,6 +835,9 @@
+     arm*:Linux:*:*)
+ 	echo ${UNAME_MACHINE}-unknown-linux-gnu
+ 	exit ;;
++    aarch64:Linux:*:*)
++        echo ${UNAME_MACHINE}-unknown-linux-gnu
++        exit ;;
+     avr32*:Linux:*:*)
+ 	echo ${UNAME_MACHINE}-unknown-linux-gnu
+ 	exit ;;

--- a/var/spack/repos/builtin/packages/ipopt/package.py
+++ b/var/spack/repos/builtin/packages/ipopt/package.py
@@ -39,6 +39,7 @@ class Ipopt(AutotoolsPackage):
     depends_on('metis@4.0:', when='+metis')
 
     patch('ipopt_ppc_build.patch', when='arch=ppc64le')
+    patch('ipopt_aarch64_build.patch', when='arch=aarch64')
 
     flag_handler = build_system_flags
     build_directory = 'spack-build'


### PR DESCRIPTION
`Ipopt/config.guess` does not recognize `aarch64` architecture, so I added condition to recognize  'aarch64' to `Ipopt/config.guess`.