### PR TITLE
docker: add `file`, adjust locale, and use python3 for ubuntu

### DIFF
--- a/share/spack/docker/ubuntu-1604.dockerfile
+++ b/share/spack/docker/ubuntu-1604.dockerfile
@@ -22,6 +22,7 @@ RUN apt-get -yqq update                           \
         build-essential                           \
         ca-certificates                           \
         curl                                      \
+        file                                      \
         g++                                       \
         gcc                                       \
         gfortran                                  \

--- a/share/spack/docker/ubuntu-1604.dockerfile
+++ b/share/spack/docker/ubuntu-1604.dockerfile
@@ -17,16 +17,28 @@ COPY share $SPACK_ROOT/share
 COPY var   $SPACK_ROOT/var
 RUN mkdir -p $SPACK_ROOT/opt/spack
 
-RUN apt-get -yqq update                                        \
- && apt-get -yqq install                                       \
-        build-essential ca-certificates curl       g++         \
-        gcc             gfortran        git        gnupg2      \
-        iproute2        lmod            locales    lua-posix   \
-        make            openssh-server  python     python-pip  \
-        python3-pip     tcl             unzip                  \
- && locale-gen en_US.UTF-8                                     \
- && pip install boto3                                          \
- && pip3 install boto3                                         \
+RUN apt-get -yqq update                           \
+ && apt-get -yqq install --no-install-recommends  \
+        build-essential                           \
+        ca-certificates                           \
+        curl                                      \
+        g++                                       \
+        gcc                                       \
+        gfortran                                  \
+        git                                       \
+        gnupg2                                    \
+        iproute2                                  \
+        lmod                                      \
+        locales                                   \
+        lua-posix                                 \
+        make                                      \
+        openssh-server                            \
+        python3                                   \
+        python3-pip                               \
+        tcl                                       \
+        unzip                                     \
+ && locale-gen en_US.UTF-8                        \
+ && pip3 install boto3                            \
  && rm -rf /var/lib/apt/lists/*
 
 # Add LANG default to en_US.UTF-8

--- a/share/spack/docker/ubuntu-1604.dockerfile
+++ b/share/spack/docker/ubuntu-1604.dockerfile
@@ -21,12 +21,18 @@ RUN apt-get -yqq update                                        \
  && apt-get -yqq install                                       \
         build-essential ca-certificates curl       g++         \
         gcc             gfortran        git        gnupg2      \
-        iproute2        lmod            lua-posix  make        \
-        openssh-server  python          python-pip python3-pip \
-        tcl             unzip                                  \
+        iproute2        lmod            locales    lua-posix   \
+        make            openssh-server  python     python-pip  \
+        python3-pip     tcl             unzip                  \
+ && locale-gen en_US.UTF-8                                     \
  && pip install boto3                                          \
  && pip3 install boto3                                         \
  && rm -rf /var/lib/apt/lists/*
+
+# Add LANG default to en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
 
 RUN ( echo ". /usr/share/lmod/lmod/init/bash"                       \
  &&   echo ". \$SPACK_ROOT/share/spack/setup-env.sh"                \

--- a/share/spack/docker/ubuntu-1604.dockerfile
+++ b/share/spack/docker/ubuntu-1604.dockerfile
@@ -17,14 +17,15 @@ COPY share $SPACK_ROOT/share
 COPY var   $SPACK_ROOT/var
 RUN mkdir -p $SPACK_ROOT/opt/spack
 
-RUN apt-get -yqq update                                   \
- && apt-get -yqq install                                  \
-        build-essential ca-certificates curl       g++    \
-        gcc             gfortran        git        gnupg2 \
-        iproute2        lmod            lua-posix  make   \
-        openssh-server  python          python-pip tcl    \
-        unzip                                             \
- && pip install boto3                                     \
+RUN apt-get -yqq update                                        \
+ && apt-get -yqq install                                       \
+        build-essential ca-certificates curl       g++         \
+        gcc             gfortran        git        gnupg2      \
+        iproute2        lmod            lua-posix  make        \
+        openssh-server  python          python-pip python3-pip \
+        tcl             unzip                                  \
+ && pip install boto3                                          \
+ && pip3 install boto3                                         \
  && rm -rf /var/lib/apt/lists/*
 
 RUN ( echo ". /usr/share/lmod/lmod/init/bash"                       \

--- a/share/spack/docker/ubuntu-1804.dockerfile
+++ b/share/spack/docker/ubuntu-1804.dockerfile
@@ -22,6 +22,7 @@ RUN apt-get -yqq update                           \
         build-essential                           \
         ca-certificates                           \
         curl                                      \
+        file                                      \
         g++                                       \
         gcc                                       \
         gfortran                                  \

--- a/share/spack/docker/ubuntu-1804.dockerfile
+++ b/share/spack/docker/ubuntu-1804.dockerfile
@@ -17,16 +17,28 @@ COPY share $SPACK_ROOT/share
 COPY var   $SPACK_ROOT/var
 RUN mkdir -p $SPACK_ROOT/opt/spack
 
-RUN apt-get -yqq update                                        \
- && apt-get -yqq install                                       \
-        build-essential ca-certificates curl       g++         \
-        gcc             gfortran        git        gnupg2      \
-        iproute2        lmod            locales    lua-posix   \
-        make            openssh-server  python     python-pip  \
-        python3-pip     tcl             unzip                  \
- && locale-gen en_US.UTF-8                                     \
- && pip install boto3                                          \
- && pip3 install boto3                                         \
+RUN apt-get -yqq update                           \
+ && apt-get -yqq install --no-install-recommends  \
+        build-essential                           \
+        ca-certificates                           \
+        curl                                      \
+        g++                                       \
+        gcc                                       \
+        gfortran                                  \
+        git                                       \
+        gnupg2                                    \
+        iproute2                                  \
+        lmod                                      \
+        locales                                   \
+        lua-posix                                 \
+        make                                      \
+        openssh-server                            \
+        python3                                   \
+        python3-pip                               \
+        tcl                                       \
+        unzip                                     \
+ && locale-gen en_US.UTF-8                        \
+ && pip3 install boto3                            \
  && rm -rf /var/lib/apt/lists/*
 
 # Add LANG default to en_US.UTF-8

--- a/share/spack/docker/ubuntu-1804.dockerfile
+++ b/share/spack/docker/ubuntu-1804.dockerfile
@@ -21,12 +21,18 @@ RUN apt-get -yqq update                                        \
  && apt-get -yqq install                                       \
         build-essential ca-certificates curl       g++         \
         gcc             gfortran        git        gnupg2      \
-        iproute2        lmod            lua-posix  make        \
-        openssh-server  python          python-pip python3-pip \
-        tcl             unzip                                  \
+        iproute2        lmod            locales    lua-posix   \
+        make            openssh-server  python     python-pip  \
+        python3-pip     tcl             unzip                  \
+ && locale-gen en_US.UTF-8                                     \
  && pip install boto3                                          \
  && pip3 install boto3                                         \
  && rm -rf /var/lib/apt/lists/*
+
+# Add LANG default to en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
 
 RUN ( echo ". /usr/share/lmod/lmod/init/bash"                       \
  &&   echo ". \$SPACK_ROOT/share/spack/setup-env.sh"                \

--- a/share/spack/docker/ubuntu-1804.dockerfile
+++ b/share/spack/docker/ubuntu-1804.dockerfile
@@ -17,14 +17,15 @@ COPY share $SPACK_ROOT/share
 COPY var   $SPACK_ROOT/var
 RUN mkdir -p $SPACK_ROOT/opt/spack
 
-RUN apt-get -yqq update                                   \
- && apt-get -yqq install                                  \
-        build-essential ca-certificates curl       g++    \
-        gcc             gfortran        git        gnupg2 \
-        iproute2        lmod            lua-posix  make   \
-        openssh-server  python          python-pip tcl    \
-        unzip                                             \
- && pip install boto3                                     \
+RUN apt-get -yqq update                                        \
+ && apt-get -yqq install                                       \
+        build-essential ca-certificates curl       g++         \
+        gcc             gfortran        git        gnupg2      \
+        iproute2        lmod            lua-posix  make        \
+        openssh-server  python          python-pip python3-pip \
+        tcl             unzip                                  \
+ && pip install boto3                                          \
+ && pip3 install boto3                                         \
  && rm -rf /var/lib/apt/lists/*
 
 RUN ( echo ". /usr/share/lmod/lmod/init/bash"                       \


### PR DESCRIPTION
I've noticed that:

1. now spack chooses python3 by default, and 
2. one of the packages installed brings python3, but 
3. the boto3 module is not installed under python3, so that 
4. spack/ubuntu images no longer work for accessing S3 buckets

This change should make sure boto3 is installed under python3 as well as python, so that boto3 is available in either case.