### PR TITLE
Added dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -58,6 +58,7 @@ class Vtk(CMakePackage):
     # version 3.2 or higher.
     depends_on('gl@3.2:', when='+opengl2')
     depends_on('gl@1.2:', when='~opengl2')
+    depends_on('libxt', when='+opengl2')
 
     if sys.platform != 'darwin':
         depends_on('glx', when='~osmesa')
@@ -81,7 +82,8 @@ class Vtk(CMakePackage):
     depends_on('expat')
     depends_on('freetype')
     depends_on('glew')
-    depends_on('hdf5')
+    # set hl variant explicitly, similar to issue #7145
+    depends_on('hdf5+hl')
     depends_on('jpeg')
     depends_on('jsoncpp')
     depends_on('libxml2')

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -58,10 +58,10 @@ class Vtk(CMakePackage):
     # version 3.2 or higher.
     depends_on('gl@3.2:', when='+opengl2')
     depends_on('gl@1.2:', when='~opengl2')
-    depends_on('libxt', when='+opengl2')
 
     if sys.platform != 'darwin':
         depends_on('glx', when='~osmesa')
+        depends_on('libxt', when='~osmesa')
 
     # Note: it is recommended to use mesa+llvm, if possible.
     # mesa default is software rendering, llvm makes it faster


### PR DESCRIPTION
Fixes two issues:
1. OpenGL2 dependency needs libxt, since CMake searches for X11_Xt_LIB
2. Same issue like #7145, same solution like #7404