### PR TITLE
Specs with quoted flags containing spaces are parsed correctly

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -24,6 +24,7 @@ import spack.paths
 import spack.spec
 import spack.store
 import spack.util.spack_json as sjson
+import spack.util.string
 from spack.error import SpackError
 
 
@@ -134,7 +135,9 @@ def parse_specs(args, **kwargs):
     tests = kwargs.get('tests', False)
 
     try:
-        sargs = args if isinstance(args, six.string_types) else ' '.join(args)
+        sargs = args
+        if not isinstance(args, six.string_types):
+            sargs = ' '.join(spack.util.string.quote(args))
         specs = spack.spec.parse(sargs)
         for spec in specs:
             if concretize:

--- a/lib/spack/spack/test/cmd/common/arguments.py
+++ b/lib/spack/spack/test/cmd/common/arguments.py
@@ -9,6 +9,7 @@ import multiprocessing
 import pytest
 
 
+import spack.cmd
 import spack.cmd.common.arguments as arguments
 import spack.config
 
@@ -62,3 +63,20 @@ def test_negative_integers_not_allowed_for_parallel_jobs(parser):
         parser.parse_args(['-j', '-2'])
 
     assert 'expected a positive integer' in str(exc_info.value)
+
+
+@pytest.mark.parametrize('specs,expected_variants,unexpected_variants', [
+    (['coreutils', 'cflags=-O3 -g'], [], ['g']),
+    (['coreutils', 'cflags=-O3', '-g'], ['g'], []),
+])
+@pytest.mark.regression('12951')
+def test_parse_spec_flags_with_spaces(
+        specs, expected_variants, unexpected_variants
+):
+    spec_list = spack.cmd.parse_specs(specs)
+    assert len(spec_list) == 1
+
+    s = spec_list.pop()
+
+    assert all(x not in s.variants for x in unexpected_variants)
+    assert all(x in s.variants for x in expected_variants)


### PR DESCRIPTION
fixes #12951
