### PR TITLE
environments: make shell modifications partially unconditional

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1038,7 +1038,7 @@ class Environment(object):
         """List of environment (shell) modifications to be processed for view.
 
         This list does not depend on the specs in this environment"""
-        env = spack.util.EnvironmentModifications()
+        env = spack.util.environment.EnvironmentModifications()
 
         for subdir, vars in self.prefix_inspections.items():
             full_subdir = os.path.join(view.root, subdir)

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1085,7 +1085,7 @@ class Environment(object):
             return env_mod.shell_modifications(shell)
 
         env_mod.extend(self.unconditional_environment_modifications(
-                self.default_view))
+            self.default_view))
 
         for _, spec in self.concretized_specs():
             if spec in self.default_view:
@@ -1106,7 +1106,7 @@ class Environment(object):
             return env_mod.shell_modifications(shell)
 
         env_mod.extend(self.unconditional_environment_modifications(
-                self.default_view).reversed())
+            self.default_view).reversed())
 
         for _, spec in self.concretized_specs():
             if spec in self.default_view:

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1034,8 +1034,24 @@ class Environment(object):
         '': ['CMAKE_PREFIX_PATH']
     }
 
+    def unconditional_environment_modifications(self, view):
+        """List of environment (shell) modifications to be processed for view.
+
+        This list does not depend on the specs in this environment"""
+        env = spack.util.EnvironmentModifications()
+
+        for subdir, vars in self.prefix_inspections.items():
+            full_subdir = os.path.join(view.root, subdir)
+            for var in vars:
+                env.prepend_path(var, full_subdir)
+
+        return env
+
     def environment_modifications_for_spec(self, spec, view=None):
-        """List of environment modifications to be processed."""
+        """List of environment (shell) modifications to be processed for spec.
+
+        This list is specific to the location of the spec or its projection in
+        the view."""
         spec = spec.copy()
         if view:
             spec.prefix = Prefix(view.view().get_projection_for_spec(spec))
@@ -1068,6 +1084,9 @@ class Environment(object):
             # No default view to add to shell
             return env_mod.shell_modifications(shell)
 
+        env_mod.extend(self.unconditional_environment_modifications(
+                self.default_view))
+
         for _, spec in self.concretized_specs():
             if spec in self.default_view:
                 env_mod.extend(self.environment_modifications_for_spec(
@@ -1085,6 +1104,9 @@ class Environment(object):
         if default_view_name not in self.views:
             # No default view to add to shell
             return env_mod.shell_modifications(shell)
+
+        env_mod.extend(self.unconditional_environment_modifications(
+                self.default_view).reversed())
 
         for _, spec in self.concretized_specs():
             if spec in self.default_view:

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1704,8 +1704,8 @@ def test_env_activate_csh_prints_shell_output(
 
 
 @pytest.mark.regression('12719')
-def test_env_activate_default_view_root_unconditional(
-    env_deactivate, mutable_mock_env_path):
+def test_env_activate_default_view_root_unconditional(env_deactivate,
+                                                      mutable_mock_env_path):
     """Check that the root of the default view in the environment is added
     to the shell unconditionally."""
     env('create', 'test', add_view=True)

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1703,6 +1703,20 @@ def test_env_activate_csh_prints_shell_output(
     assert "alias despacktivate" in out
 
 
+@pytest.mark.regression('12719')
+def test_env_activate_default_view_root_unconditional(
+    env_deactivate, mutable_mock_env_path):
+    """Check that the root of the default view in the environment is added
+    to the shell unconditionally."""
+    env('create', 'test', add_view=True)
+
+    with ev.read('test') as e:
+        viewdir = e.default_view.root
+
+    out = env('activate', '--sh', 'test')
+    assert 'PATH=%s' % os.path.join(viewdir, 'bin') in out
+
+
 def test_concretize_user_specs_together():
     e = ev.create('coconcretization')
     e.concretization = 'together'


### PR DESCRIPTION
I inadvertently reverted my changes from #12719 in #13249. This reinstates the functionality from #12719.