### PR TITLE
Bugfix: BundlePackages failing to download/install on account of missing API

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -225,6 +225,9 @@ class BundleFetchStrategy(FetchStrategy):
         """BundlePackages don't have a source id."""
         return ''
 
+    def mirror_id(self):
+        """BundlePackages don't have a mirror id."""
+
 
 @pattern.composite(interface=FetchStrategy)
 class FetchStrategyComposite(object):


### PR DESCRIPTION
4af4487 added a `mirror_id` function to most `FetchStrategy` implementations that is used to calculate resource locations in mirrors. It left out `BundleFetchStrategy` which broke all packages making use of `BundlePackage` (e.g. `xsdk`). This adds a noop implementation of `mirror_id` to `BundleFetchStrategy` so that the download/installation of `BundlePackage`s can proceed as normal.