### PR TITLE
Feature/conf package env

### DIFF
--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -645,6 +645,13 @@ class BaseContext(tengine.Context):
         build_environment.set_module_variables_for_package(self.spec.package)
         self.spec.package.setup_run_environment(env)
 
+        # User-configured modifications
+        env.extend(
+            build_environment.modifications_from_config(
+                self.spec, context='run'
+            )
+        )
+
         # Modifications required from modules.yaml
         env.extend(self.conf.env)
 

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -10,6 +10,64 @@
 """
 
 
+# env modification - e.g.: ["append_path", "PATH", "/some/path"]
+env_modification = {'type': 'array', 'items': {'type': 'string'}}
+
+
+# env modification entry - either an env modification, or a dict.
+#     If a dict, its keys can only be "build" or "run", and the value is a
+#     list of env modifications.
+#
+# e.g.:
+#
+# build:
+#   - ["append_path", "CMAKE_MODULE_PATH", "/some/path"]
+#   - ["unset", "VAR0", "VAR1"]
+#
+# This type allows for a list of env modification entries to look like this:
+#
+# env:
+#   - ["append_path", "PATH", "/some/path"]
+#   - ["append_path", "PATH", "/some/path"]
+#   - [... etc ... ]
+#
+#   - build:
+#       - ["append_path", "CMAKE_MODULE_PATH", "/some/path"]
+#       - ["unset", "VAR0", "VAR1"]
+#       - [ ... other build-only settings ]
+#       - [ ... other build-only settings ]
+#
+#   - run:
+#       - ["append_path", "CMAKE_MODULE_PATH", "/some/path"]
+#       - ["unset", "VAR0", "VAR1"]
+#       - [ ... other run-only settings ]
+#       - [ ... other run-only settings ]
+#
+#   - [ ... other common env settings ... ]
+#   - [ ... other common env settings ... ]
+env_mod_entry = {
+    'anyOf': [
+        env_modification,
+        {
+            'type': 'object',
+            'additionalProperties': False,
+            'properties': {
+                'build': {
+                    'type': 'array',
+                    'default': [],
+                    'items': env_modification,
+                },
+                'run': {
+                    'type': 'array',
+                    'default': [],
+                    'items': env_modification,
+                },
+            }
+        },
+    ]
+}
+
+
 #: Properties for inclusion in other schemas
 properties = {
     'packages': {
@@ -75,6 +133,18 @@ properties = {
                     'paths': {
                         'type': 'object',
                         'default': {},
+                    },
+                    'env': {
+                        'type': 'object',
+                        'default': {},
+                        'additionalProperties': False,
+                        'patternProperties': {
+                            r'\w[\w-]*': {
+                                'type': 'array',
+                                'default': [],
+                                'items': env_mod_entry,
+                            },
+                        },
                     },
                     'variants': {
                         'oneOf': [


### PR DESCRIPTION
This PR proposes to add a new optional section to the packages configuration.  Through this section, users can amend the set of environment modifications that are applied to a spec's `build` and `run` environments.

The motivating use case for this proposal is for external hardware-accelerated opengl implementations where the API calls are dispatched dynamically using [libglvnd](https://github.com/NVIDIA/libglvnd).  These are examples of external packages that would need to set environment variables at build and/or run time for correct operation.

This PR proposes to extend the packages configuration so users may customize build and/or run environments for these and other packages without having to write a modulefile.

The following is an example of a packages configuration that is supported by the current implementation.  This PR seeks feedback on the syntax of the configuration as well as the implementation:

```Yaml
---
packages:
  all:
    env:
      target=x86_64:
        - ["set", "ABC", "123"]
        - ["unset", "XYZ"]
        - build:
          - ["append_path", "BUILD_ABC", "BUILD_123"] # build environment only
          - ... other build-only settings ...
        - run:
          - ["prepend_path", "RUN_ABC", "RUN_123"] # run environment only
          - ... other run-only settings ...
        - ... other settings (both build and run environments) ...

  opengl:
    buildable: False
    path:
      "opengl +glvnd": /usr/local/nvidia/...
    env:
      "opengl +glvnd":
        - run:
          - ["set", "'__GLX_VENDOR_LIBRARY_NAME", "nvidia"]
          - ["set", "'__EGL_VENDOR_LIBRARY_FILENAMES", "30_nvidia.json"]
          - - prepend_path
            - __EGL_VENDOR_LIBRARY_DIRS
            - /usr/.../share/glvnd/egl_vendor.d
```
