### PR TITLE
trilinos: temporarily pin to ^netcdf@:4.7.1 until build issues resolved with newer versions

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -297,7 +297,7 @@ class Trilinos(CMakePackage):
 
     # MPI related dependencies
     depends_on('mpi')
-    depends_on('netcdf+mpi', when="~pnetcdf")
+    depends_on('netcdf@:4.7.1+mpi', when="~pnetcdf")
     depends_on('netcdf+mpi+parallel-netcdf', when="+pnetcdf@master,12.12.1:")
     depends_on('parallel-netcdf', when="+pnetcdf@master,12.12.1:")
     depends_on('parmetis', when='+metis')


### PR DESCRIPTION
Trilinos install fails when trying to build against the latest version of netcdf (@4.7.2) -- it appears unable to find certain netcdf header files in the expected locations. This PR would temporarily constrain trilinos to use netcdf@:4.7.1 until the issue can be resolved. @becker33 