### PR TITLE
py-astor: specify py-setuptools versions as build fail with latest version

### DIFF
--- a/var/spack/repos/builtin/packages/py-astor/package.py
+++ b/var/spack/repos/builtin/packages/py-astor/package.py
@@ -17,6 +17,6 @@ class PyAstor(PythonPackage):
     version('0.6', sha256='175ec395cde36aa0178c5a3120d03954c65d1ef4bb19ec4aa30e9d7a7cc426c4')
 
     depends_on('python@2.7:2.8,3.4:')
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools@:41.0.1', type='build')
     depends_on('py-nose', type='test')
     depends_on('py-astunparse', type='test')

--- a/var/spack/repos/builtin/packages/py-astor/package.py
+++ b/var/spack/repos/builtin/packages/py-astor/package.py
@@ -17,6 +17,8 @@ class PyAstor(PythonPackage):
     version('0.6', sha256='175ec395cde36aa0178c5a3120d03954c65d1ef4bb19ec4aa30e9d7a7cc426c4')
 
     depends_on('python@2.7:2.8,3.4:')
+    # Build fails with py-setuptools@41.4.0
+    # https://github.com/berkerpeksag/astor/issues/162
     depends_on('py-setuptools@:41.0.1', type='build')
     depends_on('py-nose', type='test')
     depends_on('py-astunparse', type='test')

--- a/var/spack/repos/builtin/packages/py-astor/package.py
+++ b/var/spack/repos/builtin/packages/py-astor/package.py
@@ -19,6 +19,6 @@ class PyAstor(PythonPackage):
     depends_on('python@2.7:2.8,3.4:')
     # Build fails with py-setuptools@41.4.0
     # https://github.com/berkerpeksag/astor/issues/162
-    depends_on('py-setuptools@:41.0.1', type='build')
+    depends_on('py-setuptools@:41.3', type='build')
     depends_on('py-nose', type='test')
     depends_on('py-astunparse', type='test')


### PR DESCRIPTION
Fixes #13532 