### PR TITLE
Updated download location for libxc.

### DIFF
--- a/var/spack/repos/builtin/packages/libxc/package.py
+++ b/var/spack/repos/builtin/packages/libxc/package.py
@@ -10,9 +10,10 @@ class Libxc(AutotoolsPackage):
     """Libxc is a library of exchange-correlation functionals for
     density-functional theory."""
 
-    homepage = "http://www.tddft.org/programs/octopus/wiki/index.php/Libxc"
-    url      = "http://www.tddft.org/programs/octopus/down.php?file=libxc/libxc-2.2.2.tar.gz"
+    homepage = "http://tddft.org/programs/libxc/"
+    url      = "http://www.tddft.org/programs/libxc/down.php?file=4.3.2/libxc-4.3.2.tar.gz"
 
+    version('4.3.4', sha256='a8ee37ddc5079339854bd313272856c9d41a27802472ee9ae44b58ee9a298337')
     version('4.3.2', sha256='bc159aea2537521998c7fb1199789e1be71e04c4b7758d58282622e347603a6f')
     version('4.2.3', sha256='02e49e9ba7d21d18df17e9e57eae861e6ce05e65e966e1e832475aa09e344256')
     version('3.0.0', sha256='5542b99042c09b2925f2e3700d769cda4fb411b476d446c833ea28c6bfa8792a')
@@ -22,13 +23,8 @@ class Libxc(AutotoolsPackage):
     patch('configure_add_fj.patch')
 
     def url_for_version(self, version):
-        if version < Version('3.0.0'):
-            return ("http://www.tddft.org/programs/octopus/"
-                    "down.php?file=libxc/libxc-{0}.tar.gz"
-                    .format(version))
-
-        return ("http://www.tddft.org/programs/octopus/"
-                "down.php?file=libxc/{0}/libxc-{0}.tar.gz"
+        return ("http://www.tddft.org/programs/libxc/"
+                "down.php?file={0}/libxc-{0}.tar.gz"
                 .format(version))
 
     @property


### PR DESCRIPTION
The previous download location fails:

```
==> Installing libxc
==> Searching for binary cache of libxc
==> No binary for libxc found: installing from source
==> Fetching http://www.tddft.org/programs/octopus/down.php?file=libxc/4.3.2/libxc-4.3.2.tar.gz
######################################################################### 100.0% #=#=-#   #                                                                    
curl: (22) The requested URL returned error: 404 Not Found
==> Fetching from http://www.tddft.org/programs/octopus/down.php?file=libxc/4.3.2/libxc-4.3.2.tar.gz failed.
==> Error: FetchError: All fetchers failed for libxc-4.3.2-34h75cxc5o2zxznufh66rjapjwc7c5ly

/opt/spack/lib/spack/spack/package.py:1064, in do_fetch:
       1061                raise FetchError("Will not fetch %s" %
       1062                                 self.spec.format('{name}{@version}'), ck_msg)
       1063
  >>   1064        self.stage.create()
       1065        self.stage.fetch(mirror_only)
       1066        self._fetch_time = time.time() - start_time
       1067
```

And the updated one works:
```
==> Installing libxc
==> Searching for binary cache of libxc
==> Warning: No Spack mirrors are currently configured
==> No binary for libxc found: installing from source
==> Fetching http://www.tddft.org/programs/libxc/down.php?file=4.3.4/libxc-4.3.4.tar.gz
######################################################################### 100.0%######################################################################### 100.0%
==> Staging archive: /tmp/dave/spack-stage/spack-stage-libxc-4.3.4-o4uvjr4xggcd7bnpdzm4lqkhvr7ecs4f/libxc-4.3.4.tar.gz
==> Created stage in /tmp/dave/spack-stage/spack-stage-libxc-4.3.4-o4uvjr4xggcd7bnpdzm4lqkhvr7ecs4f
==> Applied patch /opt/spack/var/spack/repos/builtin/packages/libxc/configure_add_fj.patch
==> Building libxc [AutotoolsPackage]
```