### PR TITLE
added relion 3.0.8 [latest stable version in 3.0 branch] as well as 3.1_beta

### DIFF
--- a/var/spack/repos/builtin/packages/relion/package.py
+++ b/var/spack/repos/builtin/packages/relion/package.py
@@ -15,9 +15,17 @@ class Relion(CMakePackage, CudaPackage):
     homepage = "http://http://www2.mrc-lmb.cam.ac.uk/relion"
     git      = "https://github.com/3dem/relion.git"
 
-    version('3.0.7', tag='3.0.7')
+    # 3.1 is beta but referenced in published papers
+    # won't yet compile!
+    version('3.1_beta', branch='ver3.1')
+
+    # 3.0.8 latest [stable] release in 3.0 branch
+    # we prefer this for now
+    version('3.0.8', tag='3.0.8', preferred=True)
+
     # relion has no develop branch though pulling from master
     # should be considered the same as develop
+    # as of now develop contains 3.0 code
     version('develop', branch='master')
 
     variant('gui', default=True, description="build the gui")
@@ -34,9 +42,6 @@ class Relion(CMakePackage, CudaPackage):
                     'Profiling', 'Benchmarking'))
 
     depends_on('mpi')
-    # relion will not build with newer versions of cmake
-    # per https://github.com/3dem/relion/issues/380
-    depends_on('cmake@3:3.9.4', type='build')
     depends_on('fftw precision=float,double')
     depends_on('fltk', when='+gui')
     depends_on('libtiff')

--- a/var/spack/repos/builtin/packages/relion/package.py
+++ b/var/spack/repos/builtin/packages/relion/package.py
@@ -16,17 +16,17 @@ class Relion(CMakePackage, CudaPackage):
     git      = "https://github.com/3dem/relion.git"
 
     # 3.1 is beta but referenced in published papers
-    # won't yet compile!
+    # prefer stable 3.0 until no longer beta
     version('3.1_beta', branch='ver3.1')
 
-    # 3.0.8 latest [stable] release in 3.0 branch
-    # we prefer this for now
+    # 3.0.8 latest release in 3.0 branch
+    # prefer for now
     version('3.0.8', tag='3.0.8', preferred=True)
+    version('3.0.7', tag='3.0.7')
 
-    # relion has no develop branch though pulling from master
-    # should be considered the same as develop
-    # as of now develop contains 3.0 code
-    version('develop', branch='master')
+    # relion master contains development code
+    # contains 3.0 branch code
+    version('master')
 
     variant('gui', default=True, description="build the gui")
     variant('cuda', default=True, description="enable compute on gpu")
@@ -42,6 +42,7 @@ class Relion(CMakePackage, CudaPackage):
                     'Profiling', 'Benchmarking'))
 
     depends_on('mpi')
+    depends_on('cmake@2.8:', type='build')
     depends_on('fftw precision=float,double')
     depends_on('fltk', when='+gui')
     depends_on('libtiff')

--- a/var/spack/repos/builtin/packages/relion/package.py
+++ b/var/spack/repos/builtin/packages/relion/package.py
@@ -42,7 +42,7 @@ class Relion(CMakePackage, CudaPackage):
                     'Profiling', 'Benchmarking'))
 
     depends_on('mpi')
-    depends_on('cmake@2.8:', type='build')
+    depends_on('cmake@3:', type='build')
     depends_on('fftw precision=float,double')
     depends_on('fltk', when='+gui')
     depends_on('libtiff')


### PR DESCRIPTION
Note, 3.0.7 removed as it contains bugs.  3.0.8 latest stable version in 3.0 branch.  I added 3.1_beta which isn't yet stable so we are still preferring 3.0.

3.0.8 will compile with latest cmake / gcc so remove that constraint.