### PR TITLE
bugfix: include compiler.extra_rpaths when computing a package's rpaths (#12519)

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -613,6 +613,9 @@ def get_rpaths(pkg):
     # module show output.
     if pkg.compiler.modules and len(pkg.compiler.modules) > 1:
         rpaths.append(get_path_from_module(pkg.compiler.modules[1]))
+
+    rpaths.extend(pkg.compiler.extra_rpaths)
+
     return rpaths
 
 


### PR DESCRIPTION
Possibly naive attempt to fix #12519. 

Behaviour prior to 568e5fa is as in #12519; behaviour following 568e5fa is that `ldd` correctly resolves paths following a `spack setup` build workflow:

```(console)
	libc++.so.1 => /spack/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/llvm-8.0.0-vcde4opt4xfhe5qcrktcagi6r7uhskgf/lib/libc++.so.1 (0x00007fa2c7053000)
	libc++abi.so.1 => /spack/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/llvm-8.0.0-vcde4opt4xfhe5qcrktcagi6r7uhskgf/lib/libc++abi.so.1 (0x00007fa2c6687000)
```

where the resolved libraries point to paths specified as `extra_rpaths` in `compilers.yaml`:

```(yaml)
compilers:
- compiler:
    environment: {}
    extra_rpaths:
    - /spack/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/llvm-8.0.0-vcde4opt4xfhe5qcrktcagi6r7uhskgf/lib
    flags: {}
    modules:
    - llvm-8.0.0-gcc-5.4.0-vcde4op
    operating_system: ubuntu16.04
    paths:
      cc: /spack/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/llvm-8.0.0-vcde4opt4xfhe5qcrktcagi6r7uhskgf/bin/clang
      cxx: /spack/opt/spack/linux-ubuntu16.04-x86_64/gcc-5.4.0/llvm-8.0.0-vcde4opt4xfhe5qcrktcagi6r7uhskgf/bin/clang++
      f77: /usr/bin/gfortran
      fc: /usr/bin/gfortran
    spec: clang@8.0.0
    target: x86_64
```