### PR TITLE
Bugfix: preserve mirror order

### DIFF
--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -21,6 +21,8 @@ import six
 
 import ruamel.yaml.error as yaml_error
 
+from ordereddict_backport import OrderedDict
+
 try:
     from collections.abc import Mapping
 except ImportError:
@@ -166,7 +168,7 @@ class MirrorCollection(Mapping):
     """A mapping of mirror names to mirrors."""
 
     def __init__(self, mirrors=None, scope=None):
-        self._mirrors = dict(
+        self._mirrors = OrderedDict(
             (name, Mirror.from_dict(mirror, name))
             for name, mirror in (
                 mirrors.items() if mirrors is not None else
@@ -178,6 +180,7 @@ class MirrorCollection(Mapping):
     def to_yaml(self, stream=None):
         return syaml.dump(self.to_dict(True), stream)
 
+    # TODO: this isn't called anywhere
     @staticmethod
     def from_yaml(stream, name=None):
         try:


### PR DESCRIPTION
Fixes: https://github.com/spack/spack/issues/13541

Construct MirrorCollection with OrderedDict to preserve order from config

@opadron 

(EDIT: added explanation) it turns out this wasn't a configuration loading issue: after the config is loaded, the MirrorCollection object constructs a `dict` with the entries (and Python's `dict` doesn't guarantee ordering).