### PR TITLE
Fix issue where fetch failed to prefer local mirrors over public remote resources

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -32,7 +32,6 @@ import xml.etree.ElementTree
 from functools import wraps
 from six import string_types, with_metaclass
 import six.moves.urllib.parse as urllib_parse
-import six.moves.urllib.error as urllib_error
 
 import llnl.util.tty as tty
 from llnl.util.filesystem import (
@@ -1138,10 +1137,7 @@ class S3FetchStrategy(URLFetchStrategy):
         basename = os.path.basename(parsed_url.path)
 
         with working_dir(self.stage.path):
-            try:
-                _, headers, stream = web_util.read_from_url(self.url)
-            except urllib_error.URLError as err:
-                raise FailedDownloadError(self.url, err)
+            _, headers, stream = web_util.read_from_url(self.url)
 
             with open(basename, 'wb') as f:
                 shutil.copyfileobj(stream, f)

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -433,11 +433,9 @@ class Stage(object):
 
             # Add URL strategies for all the mirrors with the digest
             for url in urls:
-                fetchers.append(fs.from_url_scheme(
-                    url, digest, expand=expand, extension=extension))
-                # fetchers.insert(
-                #     0, fs.URLFetchStrategy(
-                #         url, digest, expand=expand, extension=extension))
+                fetchers.insert(
+                    0, fs.from_url_scheme(
+                        url, digest, expand=expand, extension=extension))
 
             if self.default_fetcher.cachable:
                 for rel_path in reversed(list(self.mirror_paths)):

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -181,7 +181,8 @@ def read_from_url(url, accept_content_type=None):
     try:
         response = _urlopen(req, timeout=_timeout, context=context)
     except URLError as err:
-        raise SpackWebError(err)
+        raise SpackWebError('Download failed: {ERROR}'.format(
+            ERROR=str(err)))
 
     if accept_content_type and not is_web_url:
         content_type = response.headers.get('Content-type')

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -177,7 +177,11 @@ def read_from_url(url, accept_content_type=None):
 
     # Do the real GET request when we know it's just HTML.
     req.get_method = lambda: "GET"
-    response = _urlopen(req, timeout=_timeout, context=context)
+
+    try:
+        response = _urlopen(req, timeout=_timeout, context=context)
+    except urllib_error.URLError as err:
+        raise SpackWebError(err)
 
     if accept_content_type and not is_web_url:
         content_type = response.headers.get('Content-type')

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -180,7 +180,7 @@ def read_from_url(url, accept_content_type=None):
 
     try:
         response = _urlopen(req, timeout=_timeout, context=context)
-    except urllib_error.URLError as err:
+    except URLError as err:
         raise SpackWebError(err)
 
     if accept_content_type and not is_web_url:


### PR DESCRIPTION
Also updates the S3FetchStrategy so that it throws a SpackError if the fetch fails.  Before, it was throwing URLError, which was not being caught in stage.py. (This uncaught exception is what had originally confused me and led to my erroneous changes in `stage.py`.)

Fixes #13537 