### PR TITLE
constexpr_longdouble.patch should be applied to v6 too

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -602,7 +602,7 @@ class Llvm(CMakePackage):
     # Backport from llvm master + additional fix
     # see  https://bugs.llvm.org/show_bug.cgi?id=39696
     # for a bug report about this problem in llvm master.
-    patch('constexpr_longdouble.patch', when='@7:8+libcxx')
+    patch('constexpr_longdouble.patch', when='@6:8+libcxx')
 
     @run_before('cmake')
     def check_darwin_lldb_codesign_requirement(self):


### PR DESCRIPTION
This PR applies constexpr_longdouble.patch to LLVM versions 6.x as well.  I've demonstrated successful patching and building with 6.0.0 and 6.0.1.