### PR TITLE
Add latest version of py-pybind11

### DIFF
--- a/var/spack/repos/builtin/packages/py-pybind11/package.py
+++ b/var/spack/repos/builtin/packages/py-pybind11/package.py
@@ -8,6 +8,7 @@ from spack import *
 
 class PyPybind11(CMakePackage):
     """pybind11 -- Seamless operability between C++11 and Python.
+
     pybind11 is a lightweight header-only library that exposes C++ types in
     Python and vice versa, mainly to create Python bindings of existing C++
     code. Its goals and syntax are similar to the excellent Boost.Python
@@ -18,9 +19,11 @@ class PyPybind11(CMakePackage):
     homepage = "https://pybind11.readthedocs.io"
     url      = "https://github.com/pybind/pybind11/archive/v2.1.0.tar.gz"
     git      = "https://github.com/pybind/pybind11.git"
+
     maintainers = ['ax3l']
 
-    version('develop', branch='master')
+    version('master', branch='master')
+    version('2.4.3', sha256='1eed57bc6863190e35637290f97a20c81cfe4d9090ac0a24f3bbf08f265eb71d')
     version('2.3.0', sha256='0f34838f2c8024a6765168227ba587b3687729ebf03dc912f88ff75c7aa9cfe8')
     version('2.2.4', sha256='b69e83658513215b8d1443544d0549b7d231b9f201f6fc787a2b2218b408181e')
     version('2.2.3', sha256='3a3b7b651afab1c5ba557f4c37d785a522b8030dfc765da26adc2ecd1de940ea')

--- a/var/spack/repos/builtin/packages/py-pybind11/package.py
+++ b/var/spack/repos/builtin/packages/py-pybind11/package.py
@@ -53,8 +53,8 @@ class PyPybind11(CMakePackage):
         ]
         return args
 
-    def setup_environment(self, spack_env, run_env):
-        spack_env.set('PYBIND11_USE_CMAKE', 1)
+    def setup_build_environment(self, env):
+        env.set('PYBIND11_USE_CMAKE', 1)
 
     def install(self, spec, prefix):
         super(PyPybind11, self).install(spec, prefix)


### PR DESCRIPTION
Successfully builds on Cray CNL5 with GCC 5.3.0.

@ax3l 