### PR TITLE
(py)arrow: new versions

### DIFF
--- a/var/spack/repos/builtin/packages/arrow/package.py
+++ b/var/spack/repos/builtin/packages/arrow/package.py
@@ -15,6 +15,9 @@ class Arrow(CMakePackage):
     homepage = "http://arrow.apache.org"
     url      = "https://github.com/apache/arrow/archive/apache-arrow-0.9.0.tar.gz"
 
+    version('0.15.1', sha256='ab1c0d371a10b615eccfcead71bb79832245d788f4834cc6b278c03c3872d593')
+    version('0.15.0', sha256='d1072d8c4bf9166949f4b722a89350a88b7c8912f51642a5d52283448acdfd58')
+    version('0.14.1', sha256='69d9de9ec60a3080543b28a5334dbaf892ca34235b8bd8f8c1c01a33253926c1')
     version('0.12.1', sha256='aae68622edc3dcadaa16b2d25ae3f00290d5233100321993427b03bcf5b1dd3b')
     version('0.11.0', sha256='0ac629a7775d86108e403eb66d9f1a3d3bdd6b3a497a86228aa4e8143364b7cc')
     version('0.9.0', sha256='65f89a3910b6df02ac71e4d4283db9b02c5b3f1e627346c7b6a5982ae994af91')

--- a/var/spack/repos/builtin/packages/py-pyarrow/package.py
+++ b/var/spack/repos/builtin/packages/py-pyarrow/package.py
@@ -25,7 +25,17 @@ class PyPyarrow(PythonPackage):
     depends_on('cmake@3.0.0:', type='build')
     depends_on('pkgconfig', type='build')
     depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools-scm', type='build', when='@0.15.0:')
     depends_on('py-cython', type='build')
+    depends_on('py-cython@0.29:', type='build', when='@0.15.0:')
+    depends_on('py-pytest', type='test', when='@0.15.0:')
+    depends_on('py-pandas', type='test', when='@0.15.0:')
+    depends_on('py-hypothesis', type='test', when='@0.15.0:')
+    depends_on('py-pathlib2', type='test', when='@0.15.0^python@:3.3.99')
+    depends_on('py-numpy@1.14:', type=('build', 'run'), when='@0.15.0:')
+    depends_on('py-six@1.0.0:', type=('build', 'run'), when='@0.15.0:')
+    depends_on('py-futures', type=('build', 'run'), when='@0.15.0:^python@:3.1.99')
+    depends_on('py-enum34@1.1.6:', type=('build', 'run'), when='@0.15.0:^python@:3.3.99')
 
     for v in ('@0.9.0', '@0.11.0', '@0.12.1', '@0.15.1'):
         depends_on('arrow+python' + v, when=v)

--- a/var/spack/repos/builtin/packages/py-pyarrow/package.py
+++ b/var/spack/repos/builtin/packages/py-pyarrow/package.py
@@ -13,8 +13,11 @@ class PyPyarrow(PythonPackage):
     """
 
     homepage = "http://arrow.apache.org"
-    url      = "https://pypi.org/packages/source/p/pyarrow/pyarrow-0.9.0.tar.gz"
+    url = 'https://www.apache.org/dyn/closer.cgi/arrow/arrow-0.15.0/apache-arrow-0.15.0.tar.gz'
 
+    version('0.15.1', sha256='ab1c0d371a10b615eccfcead71bb79832245d788f4834cc6b278c03c3872d593')
+    version('0.15.0', sha256='d1072d8c4bf9166949f4b722a89350a88b7c8912f51642a5d52283448acdfd58')
+    version('0.14.1', sha256='69d9de9ec60a3080543b28a5334dbaf892ca34235b8bd8f8c1c01a33253926c1')
     version('0.12.1', sha256='10db6e486c918c3af999d0114a22d92770687e3a6607ea3f14e6748854824c2a')
     version('0.11.0', sha256='07a6fd71c5d7440f2c42383dd2c5daa12d7f0a012f1e88288ed08a247032aead')
     version('0.9.0', sha256='7db8ce2f0eff5a00d6da918ce9f9cfec265e13f8a119b4adb1595e5b19fd6242')
@@ -26,11 +29,13 @@ class PyPyarrow(PythonPackage):
     depends_on('py-setuptools', type='build')
     depends_on('py-cython', type='build')
 
-    for v in ('@0.9.0', '@0.11.0', '@0.12.1'):
+    for v in ('@0.9.0', '@0.11.0', '@0.12.1', '@0.14.1', '@0.15.0'):
         depends_on('arrow+python' + v, when=v)
         depends_on('arrow+parquet+python' + v, when='+parquet' + v)
 
     phases = ['build_ext', 'install']
+
+    build_directory = 'python'
 
     def build_ext_args(self, spec, prefix):
         args = []

--- a/var/spack/repos/builtin/packages/py-pyarrow/package.py
+++ b/var/spack/repos/builtin/packages/py-pyarrow/package.py
@@ -13,7 +13,7 @@ class PyPyarrow(PythonPackage):
     """
 
     homepage = "http://arrow.apache.org"
-    url = 'https://www.apache.org/dyn/closer.cgi/arrow/arrow-0.15.0/apache-arrow-0.15.0.tar.gz'
+    url = 'https://pypi.org/packages/source/p/pyarrow/pyarrow-0.15.1.tar.gz'
 
     version('0.15.1', sha256='ab1c0d371a10b615eccfcead71bb79832245d788f4834cc6b278c03c3872d593')
     version('0.15.0', sha256='d1072d8c4bf9166949f4b722a89350a88b7c8912f51642a5d52283448acdfd58')
@@ -29,7 +29,7 @@ class PyPyarrow(PythonPackage):
     depends_on('py-setuptools', type='build')
     depends_on('py-cython', type='build')
 
-    for v in ('@0.9.0', '@0.11.0', '@0.12.1', '@0.14.1', '@0.15.0'):
+    for v in ('@0.9.0', '@0.11.0', '@0.12.1', '@0.14.1', '@0.15.0', '@0.15.1'):
         depends_on('arrow+python' + v, when=v)
         depends_on('arrow+parquet+python' + v, when='+parquet' + v)
 

--- a/var/spack/repos/builtin/packages/py-pyarrow/package.py
+++ b/var/spack/repos/builtin/packages/py-pyarrow/package.py
@@ -15,9 +15,7 @@ class PyPyarrow(PythonPackage):
     homepage = "http://arrow.apache.org"
     url = 'https://pypi.org/packages/source/p/pyarrow/pyarrow-0.15.1.tar.gz'
 
-    version('0.15.1', sha256='ab1c0d371a10b615eccfcead71bb79832245d788f4834cc6b278c03c3872d593')
-    version('0.15.0', sha256='d1072d8c4bf9166949f4b722a89350a88b7c8912f51642a5d52283448acdfd58')
-    version('0.14.1', sha256='69d9de9ec60a3080543b28a5334dbaf892ca34235b8bd8f8c1c01a33253926c1')
+    version('0.15.1', sha256='7ad074690ba38313067bf3bbda1258966d38e2037c035d08b9ffe3cce07747a5')
     version('0.12.1', sha256='10db6e486c918c3af999d0114a22d92770687e3a6607ea3f14e6748854824c2a')
     version('0.11.0', sha256='07a6fd71c5d7440f2c42383dd2c5daa12d7f0a012f1e88288ed08a247032aead')
     version('0.9.0', sha256='7db8ce2f0eff5a00d6da918ce9f9cfec265e13f8a119b4adb1595e5b19fd6242')
@@ -29,13 +27,11 @@ class PyPyarrow(PythonPackage):
     depends_on('py-setuptools', type='build')
     depends_on('py-cython', type='build')
 
-    for v in ('@0.9.0', '@0.11.0', '@0.12.1', '@0.14.1', '@0.15.0', '@0.15.1'):
+    for v in ('@0.9.0', '@0.11.0', '@0.12.1', '@0.15.1'):
         depends_on('arrow+python' + v, when=v)
         depends_on('arrow+parquet+python' + v, when='+parquet' + v)
 
     phases = ['build_ext', 'install']
-
-    build_directory = 'python'
 
     def build_ext_args(self, spec, prefix):
         args = []

--- a/var/spack/repos/builtin/packages/py-pyarrow/package.py
+++ b/var/spack/repos/builtin/packages/py-pyarrow/package.py
@@ -31,7 +31,7 @@ class PyPyarrow(PythonPackage):
     depends_on('py-pytest', type='test', when='@0.15.0:')
     depends_on('py-pandas', type='test', when='@0.15.0:')
     depends_on('py-hypothesis', type='test', when='@0.15.0:')
-    depends_on('py-pathlib2', type='test', when='@0.15.0^python@:3.3.99')
+    depends_on('py-pathlib2', type='test', when='@0.15.0: ^python@:3.3.99')
     depends_on('py-numpy@1.14:', type=('build', 'run'), when='@0.15.0:')
     depends_on('py-six@1.0.0:', type=('build', 'run'), when='@0.15.0:')
     depends_on('py-futures', type=('build', 'run'), when='@0.15.0:^python@:3.1.99')


### PR DESCRIPTION
~~This doesn't currently work, as the `build_directory` setting is required for the apache downloads but doesn't work for the github ones~~

edit: ended up adding only 0.15.1 to py-pyarrow as pypi has sources for this only