### PR TITLE
New package:  py-jaraco-functools

### DIFF
--- a/var/spack/repos/builtin/packages/acts-core/package.py
+++ b/var/spack/repos/builtin/packages/acts-core/package.py
@@ -33,6 +33,7 @@ class ActsCore(CMakePackage):
     git      = "https://gitlab.cern.ch/acts/acts-core.git"
 
     version('develop', branch='master')
+    version('0.10.5', commit='b6f7234ca8f18ee11e57709d019c14bf41cf9b19')
     version('0.10.4', commit='42cbc359c209f5cf386e620b5a497192c024655e')
     version('0.10.3', commit='a3bb86b79a65b3d2ceb962b60411fd0df4cf274c')
     version('0.10.2', commit='64cbf28c862d8b0f95232b00c0e8c38949d5015d')

--- a/var/spack/repos/builtin/packages/py-jaraco-functools/package.py
+++ b/var/spack/repos/builtin/packages/py-jaraco-functools/package.py
@@ -1,0 +1,12 @@
+from spack import *
+
+
+class PyJaracoFunctools(PythonPackage):
+    """Functools like those found in stdlib"""
+
+    homepage = "https://github.com/jaraco/jaraco.functools"
+    url      = "https://files.pythonhosted.org/packages/a9/1e/44f6a5cffef147a3ffd37a748b8f4c2ded9b07ca20a15f17cd9874158f24/jaraco.functools-2.0.tar.gz"
+
+    version('2.0', sha256='35ba944f52b1a7beee8843a5aa6752d1d5b79893eeb7770ea98be6b637bf9345')
+
+    depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-jaraco-functools/package.py
+++ b/var/spack/repos/builtin/packages/py-jaraco-functools/package.py
@@ -16,8 +16,8 @@ class PyJaracoFunctools(PythonPackage):
         '2.0', sha256='35ba944f52b1a7beee8843a5aa6752d1d5b79893eeb7770ea98be6b637bf9345')
 
     depends_on('py-setuptools', type='build')
-    depends_on('py-setuptools-scm@1.15.0', type='build')
-    depends_on('py-backports-functools-lru-cache@1.15.0',
+    depends_on('py-setuptools-scm@1.15.0:', type='build')
+    depends_on('py-backports-functools-lru-cache@1.15.0:',
                type=('build', 'run'))
     depends_on('py-more-itertools', type=('build', 'run'))
-    depends_on('python@2.7', type=('build', 'run'))
+    depends_on('python@2.7:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-jaraco-functools/package.py
+++ b/var/spack/repos/builtin/packages/py-jaraco-functools/package.py
@@ -5,7 +5,7 @@ class PyJaracoFunctools(PythonPackage):
     """Functools like those found in stdlib"""
 
     homepage = "https://github.com/jaraco/jaraco.functools"
-    url      = "https://files.pythonhosted.org/packages/a9/1e/44f6a5cffef147a3ffd37a748b8f4c2ded9b07ca20a15f17cd9874158f24/jaraco.functools-2.0.tar.gz"
+    url      = "https://pypi.io/packages/source/j/jaraco.functools/jaraco.functools-2.0.tar.gz"
 
     version(
         '2.0', sha256='35ba944f52b1a7beee8843a5aa6752d1d5b79893eeb7770ea98be6b637bf9345')

--- a/var/spack/repos/builtin/packages/py-jaraco-functools/package.py
+++ b/var/spack/repos/builtin/packages/py-jaraco-functools/package.py
@@ -11,3 +11,7 @@ class PyJaracoFunctools(PythonPackage):
         '2.0', sha256='35ba944f52b1a7beee8843a5aa6752d1d5b79893eeb7770ea98be6b637bf9345')
 
     depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools-scm@1.15.0', type='build')
+    depends_on('py-backports-functools-lru-cache@1.15.0', type=('build', 'run'))
+    depends_on('py-more-itertools', type=('build', 'run'))
+    depends_on('python@2.7', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-jaraco-functools/package.py
+++ b/var/spack/repos/builtin/packages/py-jaraco-functools/package.py
@@ -7,6 +7,7 @@ class PyJaracoFunctools(PythonPackage):
     homepage = "https://github.com/jaraco/jaraco.functools"
     url      = "https://files.pythonhosted.org/packages/a9/1e/44f6a5cffef147a3ffd37a748b8f4c2ded9b07ca20a15f17cd9874158f24/jaraco.functools-2.0.tar.gz"
 
-    version('2.0', sha256='35ba944f52b1a7beee8843a5aa6752d1d5b79893eeb7770ea98be6b637bf9345')
+    version(
+        '2.0', sha256='35ba944f52b1a7beee8843a5aa6752d1d5b79893eeb7770ea98be6b637bf9345')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-jaraco-functools/package.py
+++ b/var/spack/repos/builtin/packages/py-jaraco-functools/package.py
@@ -1,3 +1,8 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 from spack import *
 
 
@@ -12,6 +17,7 @@ class PyJaracoFunctools(PythonPackage):
 
     depends_on('py-setuptools', type='build')
     depends_on('py-setuptools-scm@1.15.0', type='build')
-    depends_on('py-backports-functools-lru-cache@1.15.0', type=('build', 'run'))
+    depends_on('py-backports-functools-lru-cache@1.15.0',
+               type=('build', 'run'))
     depends_on('py-more-itertools', type=('build', 'run'))
     depends_on('python@2.7', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-jaraco-functools/package.py
+++ b/var/spack/repos/builtin/packages/py-jaraco-functools/package.py
@@ -17,7 +17,7 @@ class PyJaracoFunctools(PythonPackage):
 
     depends_on('py-setuptools', type='build')
     depends_on('py-setuptools-scm@1.15.0:', type='build')
-    depends_on('py-backports-functools-lru-cache@1.15.0:',
-               type=('build', 'run'))
+    depends_on('py-backports-functools-lru-cache@1.0.3:',
+               when='^python@:2', type=('build', 'run'))
     depends_on('py-more-itertools', type=('build', 'run'))
     depends_on('python@2.7:', type=('build', 'run'))


### PR DESCRIPTION
second order dependency for cherrypy web framework/tempora 