### PR TITLE
new package: py-zc-buildout

### DIFF
--- a/var/spack/repos/builtin/packages/acts-core/package.py
+++ b/var/spack/repos/builtin/packages/acts-core/package.py
@@ -33,6 +33,7 @@ class ActsCore(CMakePackage):
     git      = "https://gitlab.cern.ch/acts/acts-core.git"
 
     version('develop', branch='master')
+    version('0.10.5', commit='b6f7234ca8f18ee11e57709d019c14bf41cf9b19')
     version('0.10.4', commit='42cbc359c209f5cf386e620b5a497192c024655e')
     version('0.10.3', commit='a3bb86b79a65b3d2ceb962b60411fd0df4cf274c')
     version('0.10.2', commit='64cbf28c862d8b0f95232b00c0e8c38949d5015d')

--- a/var/spack/repos/builtin/packages/py-zc-buildout/package.py
+++ b/var/spack/repos/builtin/packages/py-zc-buildout/package.py
@@ -1,0 +1,12 @@
+from spack import *
+
+
+class PyZcBuildout(PythonPackage):
+    """System for managing development buildouts"""
+
+    homepage = "http://buildout.org/"
+    url      = "https://files.pythonhosted.org/packages/3f/92/bf6ddecce944e3dcebfd8af4efef414a7131276b1433afb4f842012ed5ca/zc.buildout-2.13.1.tar.gz"
+
+    version('2.13.1', sha256='3d14d07226963a517295dfad5879d2799e2e3b65b2c61c71b53cb80f5ab11484')
+
+    depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-zc-buildout/package.py
+++ b/var/spack/repos/builtin/packages/py-zc-buildout/package.py
@@ -5,7 +5,7 @@ class PyZcBuildout(PythonPackage):
     """System for managing development buildouts"""
 
     homepage = "http://buildout.org/"
-    url      = "https://files.pythonhosted.org/packages/3f/92/bf6ddecce944e3dcebfd8af4efef414a7131276b1433afb4f842012ed5ca/zc.buildout-2.13.1.tar.gz"
+    url      = "https://pypi.io/packages/source/z/zc.buildout/zc.buildout-2.13.1.tar.gz"
 
     version('2.13.1', sha256='3d14d07226963a517295dfad5879d2799e2e3b65b2c61c71b53cb80f5ab11484')
 

--- a/var/spack/repos/builtin/packages/py-zc-buildout/package.py
+++ b/var/spack/repos/builtin/packages/py-zc-buildout/package.py
@@ -9,4 +9,4 @@ class PyZcBuildout(PythonPackage):
 
     version('2.13.1', sha256='3d14d07226963a517295dfad5879d2799e2e3b65b2c61c71b53cb80f5ab11484')
 
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools@8.0:', type=('build', 'install'))

--- a/var/spack/repos/builtin/packages/py-zc-buildout/package.py
+++ b/var/spack/repos/builtin/packages/py-zc-buildout/package.py
@@ -14,4 +14,4 @@ class PyZcBuildout(PythonPackage):
 
     version('2.13.1', sha256='3d14d07226963a517295dfad5879d2799e2e3b65b2c61c71b53cb80f5ab11484')
 
-    depends_on('py-setuptools@8.0:', type=('build', 'install'))
+    depends_on('py-setuptools@8.0:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-zc-buildout/package.py
+++ b/var/spack/repos/builtin/packages/py-zc-buildout/package.py
@@ -1,3 +1,8 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 from spack import *
 
 


### PR DESCRIPTION
System for managing development buildouts -- dependency of cherrypy framework