### PR TITLE
New package: py-zc-lockfile

### DIFF
--- a/var/spack/repos/builtin/packages/acts-core/package.py
+++ b/var/spack/repos/builtin/packages/acts-core/package.py
@@ -33,6 +33,7 @@ class ActsCore(CMakePackage):
     git      = "https://gitlab.cern.ch/acts/acts-core.git"
 
     version('develop', branch='master')
+    version('0.10.5', commit='b6f7234ca8f18ee11e57709d019c14bf41cf9b19')
     version('0.10.4', commit='42cbc359c209f5cf386e620b5a497192c024655e')
     version('0.10.3', commit='a3bb86b79a65b3d2ceb962b60411fd0df4cf274c')
     version('0.10.2', commit='64cbf28c862d8b0f95232b00c0e8c38949d5015d')

--- a/var/spack/repos/builtin/packages/py-zc-lockfile/package.py
+++ b/var/spack/repos/builtin/packages/py-zc-lockfile/package.py
@@ -1,0 +1,12 @@
+from spack import *
+
+
+class PyZcLockfile(PythonPackage):
+    """Basic inter-process locks """
+
+    homepage = "http://www.python.org/pypi/zc.lockfile"
+    url      = "https://files.pythonhosted.org/packages/58/c2/d7c89bdad237b4b7837609172be3e8bf5630796c0020494a15b97ece8eb1/zc.lockfile-1.4.tar.gz"
+
+    version('1.4', sha256='95a8e3846937ab2991b61703d6e0251d5abb9604e18412e2714e1b90db173253')
+
+    depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-zc-lockfile/package.py
+++ b/var/spack/repos/builtin/packages/py-zc-lockfile/package.py
@@ -7,6 +7,7 @@ class PyZcLockfile(PythonPackage):
     homepage = "http://www.python.org/pypi/zc.lockfile"
     url      = "https://files.pythonhosted.org/packages/58/c2/d7c89bdad237b4b7837609172be3e8bf5630796c0020494a15b97ece8eb1/zc.lockfile-1.4.tar.gz"
 
-    version('1.4', sha256='95a8e3846937ab2991b61703d6e0251d5abb9604e18412e2714e1b90db173253')
+    version(
+        '1.4', sha256='95a8e3846937ab2991b61703d6e0251d5abb9604e18412e2714e1b90db173253')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-zc-lockfile/package.py
+++ b/var/spack/repos/builtin/packages/py-zc-lockfile/package.py
@@ -7,13 +7,11 @@ from spack import *
 
 
 class PyZcLockfile(PythonPackage):
-    """Basic inter-process locks """
+    """Basic inter-process locks"""
 
-    homepage = "http://www.python.org/pypi/zc.lockfile"
+    homepage = "https://www.python.org/pypi/zc.lockfile"
     url      = "https://pypi.io/packages/source/z/zc.lockfile/zc.lockfile-1.4.tar.gz"
 
-    version(
-        '1.4', sha256='95a8e3846937ab2991b61703d6e0251d5abb9604e18412e2714e1b90db173253')
+    version('1.4', sha256='95a8e3846937ab2991b61703d6e0251d5abb9604e18412e2714e1b90db173253')
 
     depends_on('py-setuptools', type=('build', 'run'))
-    depends_on('py-zc-buildout', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-zc-lockfile/package.py
+++ b/var/spack/repos/builtin/packages/py-zc-lockfile/package.py
@@ -10,4 +10,4 @@ class PyZcLockfile(PythonPackage):
     version(
         '1.4', sha256='95a8e3846937ab2991b61703d6e0251d5abb9604e18412e2714e1b90db173253')
 
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-zc-lockfile/package.py
+++ b/var/spack/repos/builtin/packages/py-zc-lockfile/package.py
@@ -5,7 +5,7 @@ class PyZcLockfile(PythonPackage):
     """Basic inter-process locks """
 
     homepage = "http://www.python.org/pypi/zc.lockfile"
-    url      = "https://files.pythonhosted.org/packages/58/c2/d7c89bdad237b4b7837609172be3e8bf5630796c0020494a15b97ece8eb1/zc.lockfile-1.4.tar.gz"
+    url      = "https://pypi.io/packages/source/z/zc.lockfile/zc.lockfile-1.4.tar.gz"
 
     version(
         '1.4', sha256='95a8e3846937ab2991b61703d6e0251d5abb9604e18412e2714e1b90db173253')

--- a/var/spack/repos/builtin/packages/py-zc-lockfile/package.py
+++ b/var/spack/repos/builtin/packages/py-zc-lockfile/package.py
@@ -11,3 +11,4 @@ class PyZcLockfile(PythonPackage):
         '1.4', sha256='95a8e3846937ab2991b61703d6e0251d5abb9604e18412e2714e1b90db173253')
 
     depends_on('py-setuptools', type=('build', 'run'))
+    depends_on('py-zc-buildout', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-zc-lockfile/package.py
+++ b/var/spack/repos/builtin/packages/py-zc-lockfile/package.py
@@ -1,3 +1,8 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 from spack import *
 
 


### PR DESCRIPTION
interprocess locking in pythyon, dependency of cherrypy framework