### PR TITLE
PyTorch: avoid use of third party vendored deps

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -185,7 +185,8 @@ class PyTorch(PythonPackage):
         env.set('USE_PYTORCH_QNNPACK', 'OFF')
         env.set('USE_SYSTEM_EIGEN_INSTALL', 'ON')
         env.set('pybind11_DIR', self.spec['py-pybind11'].prefix)
-        env.set('pybind11_INCLUDE_DIR', self.spec['py-pybind11'].prefix.include)
+        env.set('pybind11_INCLUDE_DIR',
+                self.spec['py-pybind11'].prefix.include)
 
         enable_or_disable('cuda')
         if '+cuda' in self.spec:

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -6,6 +6,7 @@
 from spack import *
 
 
+# TODO: try switching to CMakePackage for more control over build
 class PyTorch(PythonPackage):
     """Tensors and Dynamic neural networks in Python
     with strong GPU acceleration."""
@@ -102,12 +103,16 @@ class PyTorch(PythonPackage):
     depends_on('cmake@3.5:', type='build')
     depends_on('python@2.7:2.8,3.5:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
-    depends_on('py-numpy', type=('run', 'build'))
+    depends_on('py-numpy', type=('build', 'run'))
     depends_on('py-future', when='@1.1: ^python@:2', type='build')
-    depends_on('py-pyyaml', type=('run', 'build'))
-    depends_on('py-typing', when='@0.4: ^python@:3.4', type=('run', 'build'))
+    depends_on('py-pyyaml', type=('build', 'run'))
+    depends_on('py-typing', when='@0.4: ^python@:3.4', type=('build', 'run'))
+    depends_on('py-pybind11', when='@0.4:', type=('build', 'run'))
     depends_on('blas')
     depends_on('lapack')
+    depends_on('protobuf', when='@0.4:')
+    depends_on('eigen', when='@0.4:')
+    # TODO: replace all third_party packages with Spack packages
 
     # Optional dependencies
     depends_on('cuda@7.5:', when='+cuda', type=('build', 'link', 'run'))
@@ -175,6 +180,13 @@ class PyTorch(PythonPackage):
 
         env.set('MAX_JOBS', make_jobs)
 
+        # Don't use vendored third-party libraries
+        env.set('BUILD_CUSTOM_PROTOBUF', 'OFF')
+        env.set('USE_PYTORCH_QNNPACK', 'OFF')
+        env.set('USE_SYSTEM_EIGEN_INSTALL', 'ON')
+        env.set('pybind11_DIR', self.spec['py-pybind11'].prefix)
+        env.set('pybind11_INCLUDE_DIR', self.spec['py-pybind11'].prefix.include)
+
         enable_or_disable('cuda')
         if '+cuda' in self.spec:
             env.set('CUDA_HOME', self.spec['cuda'].prefix)
@@ -200,8 +212,6 @@ class PyTorch(PythonPackage):
 
         enable_or_disable('nnpack')
         enable_or_disable('qnnpack')
-        # Never use vendored copy of QNNPACK
-        env.set('USE_PYTORCH_QNNPACK=OFF')
         enable_or_disable('distributed')
 
         enable_or_disable('nccl')


### PR DESCRIPTION
Successfully builds on Cray CNL5 with GCC 5.3.0 and CUDA 9.

Without these changes, PyTorch tried to use vendored third party dependencies for all of these packages. There are still several other vendored deps I would like to remove in the future, but this is a step in the right direction.

I also needed the following patch to build on Blue Waters:
```diff
diff --git a/c10/util/Half.h b/c10/util/Half.h
index 338f271627..1e4a2e7be1 100644
--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -31,6 +31,7 @@
 #include <limits>
 #include <sstream>
 #include <stdexcept>
+#include <stdint-gcc.h>
 #include <string>
 #include <utility>
 
diff --git a/c10/util/llvmMathExtras.h b/c10/util/llvmMathExtras.h
index 76ae3b26a2..a1422faf5d 100644
--- a/c10/util/llvmMathExtras.h
+++ b/c10/util/llvmMathExtras.h
@@ -19,6 +19,7 @@
  #include <climits>
  #include <cstring>
  #include <limits>
+ #include <stdint-gcc.h>
  #include <type_traits>
 
  #ifdef __ANDROID_NDK__
diff --git a/caffe2/utils/fixed_divisor.h b/caffe2/utils/fixed_divisor.h
index 7cf7ebf248..4bdd81d870 100644
--- a/caffe2/utils/fixed_divisor.h
+++ b/caffe2/utils/fixed_divisor.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <stdint-gcc.h>
 
 // See Note [hip-clang differences to hcc]
 
diff --git a/c10/util/thread_name.cpp b/c10/util/thread_name.cpp
index dfc7528dc2..fdc3c15e50 100644
--- a/c10/util/thread_name.cpp
+++ b/c10/util/thread_name.cpp
@@ -13,12 +13,6 @@
 namespace c10 {
 
 void setThreadName(std::string name) {
-#ifdef C10_HAS_PTHREAD_SETNAME_NP
-  constexpr size_t kMaxThreadName = 15;
-  name.resize(std::min(name.size(), kMaxThreadName));
-
-  pthread_setname_np(pthread_self(), name.c_str());
-#endif
 }
 
 } // namespace c10
```
However, this is clearly to hacky to merge. If the PyTorch devs ever figure out a safer way to incorporate this, I'll add their patch. See https://github.com/pytorch/pytorch/issues/23482 for future updates.