### PR TITLE
add depends_on(python) to PythonPackage stub

### DIFF
--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -242,6 +242,7 @@ class PythonPackageTemplate(PackageTemplate):
 
     dependencies = """\
     # FIXME: Add dependencies if required.
+    # depends_on('python@2.X:2.Y,3.Z:', type=('build', 'run'))
     # depends_on('py-setuptools', type='build')
     # depends_on('py-foo',        type=('build', 'run'))"""
 


### PR DESCRIPTION
During the last round of package adding, @adamjstewart repeatedly reminded me to also track the python version compatibilities, so I ended up making spack show me that in the stub rather than adding it manually each time