### PR TITLE
`spack find` now displays variants and other spec constraints

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -331,7 +331,7 @@ def display_specs(specs, args=None, **kwargs):
 
     format_string = get_arg('format', None)
     if format_string is None:
-        nfmt = '{namespace}.{name}' if namespace else '{name}'
+        nfmt = '{fullname}' if namespace else '{name}'
         ffmt = ''
         if full_compiler or flags:
             ffmt += '{%compiler.name}'

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -165,10 +165,18 @@ def display_env(env, args, decorator):
         tty.msg('No root specs')
     else:
         tty.msg('Root specs')
-        # TODO: Change this to not print extraneous deps and variants
+
+        # Roots are displayed with variants, etc. so that we can see
+        # specifically what the user asked for.
         cmd.display_specs(
-            env.user_specs, args,
-            decorator=lambda s, f: color.colorize('@*{%s}' % f))
+            env.user_specs,
+            args,
+            decorator=lambda s, f: color.colorize('@*{%s}' % f),
+            namespace=True,
+            show_flags=True,
+            show_full_compiler=True,
+            variants=True
+        )
         print()
 
     if args.show_concretized:

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -615,6 +615,17 @@ def test_env_blocks_uninstall(mock_stage, mock_fetch, install_mockery):
     assert 'used by the following environments' in out
 
 
+def test_roots_display_with_variants():
+    env('create', 'test')
+    with ev.read('test'):
+        add('boost+shared')
+
+    with ev.read('test'):
+        out = find(output=str)
+
+    assert "boost +shared" in out
+
+
 def test_uninstall_removes_from_env(mock_stage, mock_fetch, install_mockery):
     env('create', 'test')
     with ev.read('test'):


### PR DESCRIPTION
If you do this in a spack environment:

    spack add hdf5+hl

hdf5+hl will be the root added to the `spack.yaml` file, and you should really expect `hdf5+hl` to display as a root in the environment.

Before:
```console
$ spack add hdf5+hl
$ spack find
==> In environment myproject2
==> Root specs
hdf5

==> 0 installed packages
```

After:
```console
$ spack add hdf5+hl
$ spack find
==> In environment myproject2
==> Root specs
hdf5 +hl

==> 0 installed packages
```

- [x] Add decoration to roots so that you can see the details about what is required to build.
- [x] Add a test.
