### PR TITLE
pybind11: correct get_include path

### DIFF
--- a/var/spack/repos/builtin/packages/py-pybind11/package.py
+++ b/var/spack/repos/builtin/packages/py-pybind11/package.py
@@ -56,6 +56,13 @@ class PyPybind11(CMakePackage):
     def setup_build_environment(self, env):
         env.set('PYBIND11_USE_CMAKE', 1)
 
+    def patch(self):
+        """ see https://github.com/spack/spack/issues/13559 """
+        filter_file('import sys',
+                    'import sys; return "{0}"'.format(self.prefix.include),
+                    'pybind11/__init__.py',
+                    string=True)
+
     def install(self, spec, prefix):
         super(PyPybind11, self).install(spec, prefix)
         setup_py('install', '--single-version-externally-managed', '--root=/',

--- a/var/spack/repos/builtin/packages/py-pybind11/package.py
+++ b/var/spack/repos/builtin/packages/py-pybind11/package.py
@@ -73,8 +73,10 @@ class PyPybind11(CMakePackage):
     def test(self):
         with working_dir('spack-test', create=True):
             # test include helper points to right location
-            python = Executable(self.spec['python'].command.path)
-            inc = python('-c',
-                         'import pybind11 as py; print(py.get_include())',
-                         output=str)
+            python = self.spec['python'].command
+            inc = python(
+                '-c',
+                'import pybind11 as py; ' +
+                self.spec['python'].package.print_string('py.get_include()'),
+                output=str)
             assert inc.strip() == str(self.prefix.include)

--- a/var/spack/repos/builtin/packages/py-pybind11/package.py
+++ b/var/spack/repos/builtin/packages/py-pybind11/package.py
@@ -60,3 +60,14 @@ class PyPybind11(CMakePackage):
         super(PyPybind11, self).install(spec, prefix)
         setup_py('install', '--single-version-externally-managed', '--root=/',
                  '--prefix={0}'.format(prefix))
+
+    @run_after('install')
+    @on_package_attributes(run_tests=True)
+    def test(self):
+        with working_dir('spack-test', create=True):
+            # test include helper points to right location
+            python = Executable(self.spec['python'].command.path)
+            inc = python('-c',
+                         'import pybind11 as py; print(py.get_include())',
+                         output=str)
+            assert inc.strip() == str(self.prefix.include)


### PR DESCRIPTION
Helper for non-CMake downstream projects to find the pybind11 header location.

Patch the right location of our install prefix in.

Fix #13559