### PR TITLE
[WIP] Bugfix: add package AST check to ensure full hash works

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -452,6 +452,7 @@ def _changed_files(base=None, untracked=True, all_files=False):
 
             changed.add(f)
 
+    changed = list(os.path.abspath(os.path.realpath(p)) for p in changed)
     return sorted(changed)
 
 

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -399,16 +399,17 @@ def spack_is_git_repo():
         return os.path.isdir('.git')
 
 
-def changed_files(**kwargs):
+def changed_files(base=None, untracked=True, all_files=False):
     with working_dir(spack.paths.prefix):
-        return _changed_files(**kwargs)
+        return _changed_files(
+            base=base, untracked=untracked, all_files=all_files)
 
 
 #: List of directories to exclude from checks.
 exclude_directories = [spack.paths.external_path]
 
 
-def _changed_files(base=None, untracked=True, all_files=False):
+def _changed_files(base, untracked, all_files):
     """Get list of changed files in the Spack repository."""
 
     git = which('git', required=True)

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -25,6 +25,7 @@ import spack.spec
 import spack.store
 import spack.util.spack_json as sjson
 import spack.util.string
+from spack.util.executable import which
 from spack.error import SpackError
 
 
@@ -401,6 +402,10 @@ def spack_is_git_repo():
 def changed_files(**kwargs):
     with working_dir(spack.paths.prefix):
         return _changed_files(**kwargs)
+
+
+#: List of directories to exclude from checks.
+exclude_directories = [spack.paths.external_path]
 
 
 def _changed_files(base=None, untracked=True, all_files=False):

--- a/lib/spack/spack/cmd/flake8.py
+++ b/lib/spack/spack/cmd/flake8.py
@@ -198,15 +198,12 @@ def flake8(parser, args):
     try:
         file_list = args.files
         if file_list:
-            def prefix_relative(path):
-                return os.path.relpath(
-                    os.path.abspath(os.path.realpath(path)),
-                    spack.paths.prefix)
-
-            file_list = [prefix_relative(p) for p in file_list]
+            file_list = [os.path.abspath(os.path.realpath(p))
+                         for p in file_list]
         else:
             file_list = spack.cmd.changed_files(
                 args.base, args.untracked, args.all)
+        file_list = [os.path.relpath(p, spack.paths.prefix) for p in file_list]
 
         print('=======================================================')
         print('flake8: running flake8 code checks on spack.')

--- a/lib/spack/spack/cmd/flake8.py
+++ b/lib/spack/spack/cmd/flake8.py
@@ -93,53 +93,6 @@ pattern_exemptions = dict(
     for file_pattern, error_dict in pattern_exemptions.items())
 
 
-def changed_files(base=None, untracked=True, all_files=False):
-    """Get list of changed files in the Spack repository."""
-
-    git = which('git', required=True)
-
-    if base is None:
-        base = os.environ.get('TRAVIS_BRANCH', 'develop')
-
-    range = "{0}...".format(base)
-
-    git_args = [
-        # Add changed files committed since branching off of develop
-        ['diff', '--name-only', '--diff-filter=ACMR', range],
-        # Add changed files that have been staged but not yet committed
-        ['diff', '--name-only', '--diff-filter=ACMR', '--cached'],
-        # Add changed files that are unstaged
-        ['diff', '--name-only', '--diff-filter=ACMR'],
-    ]
-
-    # Add new files that are untracked
-    if untracked:
-        git_args.append(['ls-files', '--exclude-standard', '--other'])
-
-    # add everything if the user asked for it
-    if all_files:
-        git_args.append(['ls-files', '--exclude-standard'])
-
-    excludes = [os.path.realpath(f) for f in exclude_directories]
-    changed = set()
-
-    for arg_list in git_args:
-        files = git(*arg_list, output=str).split('\n')
-
-        for f in files:
-            # Ignore non-Python files
-            if not (f.endswith('.py') or f == 'bin/spack'):
-                continue
-
-            # Ignore files in the exclude locations
-            if any(os.path.realpath(f).startswith(e) for e in excludes):
-                continue
-
-            changed.add(f)
-
-    return sorted(changed)
-
-
 def add_pattern_exemptions(line, codes):
     """Add a flake8 exemption to a line."""
     if line.startswith('#'):
@@ -254,10 +207,9 @@ def flake8(parser, args):
                     spack.paths.prefix)
 
             file_list = [prefix_relative(p) for p in file_list]
-
-        with working_dir(spack.paths.prefix):
-            if not file_list:
-                file_list = changed_files(args.base, args.untracked, args.all)
+        else:
+            file_list = spack.cmd.changed_files(
+                args.base, args.untracked, args.all)
 
         print('=======================================================')
         print('flake8: running flake8 code checks on spack.')

--- a/lib/spack/spack/cmd/flake8.py
+++ b/lib/spack/spack/cmd/flake8.py
@@ -33,9 +33,6 @@ def is_package(f):
     return f.startswith('var/spack/repos/') or 'docs/tutorial/examples' in f
 
 
-#: List of directories to exclude from checks.
-exclude_directories = [spack.paths.external_path]
-
 #: max line length we're enforcing (note: this duplicates what's in .flake8)
 max_line_length = 79
 

--- a/lib/spack/spack/cmd/package_ast_check.py
+++ b/lib/spack/spack/cmd/package_ast_check.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from __future__ import print_function
+import argparse
+import os
+import tempfile
+
+import spack.cmd
+from spack.util.package_hash import package_content
+
+from llnl.util.filesystem import working_dir
+
+
+def setup_parser(subparser):
+    subparser.add_argument(
+        'files', nargs=argparse.REMAINDER, help="specific files to check")
+
+
+def package_ast_check(parser, args):
+    temp = tempfile.mkdtemp()
+
+    file_list = args.files
+    if file_list:
+        file_list = [os.path.abspath(os.path.realpath(p)) for p in file_list]
+    else:
+        file_list = spack.cmd.changed_files()
+
+    all_pkg_names = spack.repo.all_package_names()
+
+    for pkg_name in all_pkg_names:
+        if spack.repo.path.filename_for_package_name(pkg_name) in file_list:
+            package_content(pkg_name)

--- a/share/spack/qa/run-flake8-tests
+++ b/share/spack/qa/run-flake8-tests
@@ -22,3 +22,6 @@ spack flake8
 
 # verify that the license headers are present
 spack license verify
+
+# check that Spack can construct content hash from all packages
+spack package-ast-check

--- a/var/spack/repos/builtin/packages/swig/package.py
+++ b/var/spack/repos/builtin/packages/swig/package.py
@@ -52,7 +52,6 @@ class Swig(AutotoolsPackage):
         with working_dir(self.prefix.bin):
             os.symlink('swig', 'swig{0}'.format(self.spec.version.up_to(2)))
 
-    for _version in ['@fortran', '@master']:
-        @when(_version)
-        def autoreconf(self, spec, prefix):
-            which('sh')('./autogen.sh')
+    @when('@fortran,master')
+    def autoreconf(self, spec, prefix):
+        which('sh')('./autogen.sh')


### PR DESCRIPTION
(UPDATE 12/12: I'm working on an alternative to this: see https://github.com/spack/spack/pull/13620#issuecomment-565266487)

Closes #13265
Fixes #13237

Some valid python syntax in package.py files does not work with full hashes (these hashes include the DAG details as well as a hash of the package contents, and are used for creating buildcache tarballs). This adjusts the one package which was using logic that did not work, and also adds a `spack package-ast-check` command that is called as part of the CI to make sure that future edits to packages work with `Spec.full_hash`