### PR TITLE
bugfix: mirror path works for nonexisting versions

### DIFF
--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -306,8 +306,8 @@ def mirror_archive_paths(fetcher, per_package_ref, spec=None):
     storage path of the resource associated with the specified ``fetcher``."""
     ext = None
     if spec:
-        ext = spec.package.versions[spec.package.version].get(
-            'extension', None)
+        versions = spec.package.versions.get(spec.package.version, {})
+        ext = versions.get('extension', None)
     # If the spec does not explicitly specify an extension (the default case),
     # then try to determine it automatically. An extension can only be
     # specified for the primary source of the package (e.g. the source code

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -146,6 +146,12 @@ def test_all_mirror(
     repos.clear()
 
 
+def test_mirror_archive_paths_no_version(mock_packages, config, mock_archive):
+    spec = Spec('trivial-install-test-package@nonexistingversion')
+    fetcher = spack.fetch_strategy.URLFetchStrategy(mock_archive.url)
+    spack.mirror.mirror_archive_paths(fetcher, 'per-package-ref', spec)
+
+
 def test_mirror_with_url_patches(mock_packages, config, monkeypatch):
     spec = Spec('patch-several-dependencies')
     spec.concretize()


### PR DESCRIPTION
Fixes a second error mentioned by @zzotta in https://github.com/spack/spack/issues/13474#issuecomment-550281560.

`mirror_archive_path` was failing to acccount for the case where the fetched versions isn't known to Spack.

- [x] don't require the fetched version to be in `Package.versions`
- [x] add a regression test