### PR TITLE
llvm: fix PythonString::GetString for >=python-3.7

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/llvm_py37.patch
+++ b/var/spack/repos/builtin/packages/llvm/llvm_py37.patch
@@ -1,0 +1,37 @@
+From ecdefed7f6ba11421fe1ecc6c13a135ab7bcda73 Mon Sep 17 00:00:00 2001
+From: Pavel Labath <labath@google.com>
+Date: Mon, 23 Jul 2018 11:37:36 +0100
+Subject: [PATCH] Fix PythonString::GetString for >=python-3.7
+
+The return value of PyUnicode_AsUTF8AndSize is now "const char *".
+---
+ .../Plugins/ScriptInterpreter/Python/PythonDataObjects.cpp  | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/tools/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.cpp b/tools/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.cpp
+index 6a9d57d5a..94f16b2c7 100644
+--- a/tools/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.cpp
++++ b/tools/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.cpp
+@@ -404,14 +404,16 @@ llvm::StringRef PythonString::GetString() const {
+     return llvm::StringRef();
+ 
+   Py_ssize_t size;
+-  char *c;
++  const char *data;
+ 
+ #if PY_MAJOR_VERSION >= 3
+-  c = PyUnicode_AsUTF8AndSize(m_py_obj, &size);
++  data = PyUnicode_AsUTF8AndSize(m_py_obj, &size);
+ #else
++  char *c;
+   PyString_AsStringAndSize(m_py_obj, &c, &size);
++  data = c;
+ #endif
+-  return llvm::StringRef(c, size);
++  return llvm::StringRef(data, size);
+ }
+ 
+ size_t PythonString::GetSize() const {
+-- 
+2.18.0.233.g985f88cf7e-goog
+

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -607,7 +607,7 @@ class Llvm(CMakePackage):
     # Backport from llvm master; see
     # https://bugs.llvm.org/show_bug.cgi?id=38233
     # for a bug report about this problem in llvm master.
-    patch('llvm_py37.patch', when='@4:6.0.999 ^python@3.7:')
+    patch('llvm_py37.patch', when='@4:6 ^python@3.7:')
 
     @run_before('cmake')
     def check_darwin_lldb_codesign_requirement(self):

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -604,6 +604,11 @@ class Llvm(CMakePackage):
     # for a bug report about this problem in llvm master.
     patch('constexpr_longdouble.patch', when='@6:8+libcxx')
 
+    # Backport from llvm master; see
+    # https://bugs.llvm.org/show_bug.cgi?id=38233
+    # for a bug report about this problem in llvm master.
+    patch('llvm_py37.patch', when='@4:6.0.999 ^python@3.7:')
+
     @run_before('cmake')
     def check_darwin_lldb_codesign_requirement(self):
         if not self.spec.satisfies('+lldb platform=darwin'):


### PR DESCRIPTION
This PR applies a patch to llvm versions 4.x - 6.x that got applied in the master at version 7.  This fixes issues when the underlying python support is the same or newer than 3.7 to reflect the return value change in PyUnicode_AsUTF8AndSize.