### PR TITLE
r-abadata: change the download url

### DIFF
--- a/var/spack/repos/builtin/packages/r-abadata/package.py
+++ b/var/spack/repos/builtin/packages/r-abadata/package.py
@@ -17,6 +17,7 @@ class RAbadata(RPackage):
     All datasets are restricted to protein coding genes."""
 
     homepage = "https://bioconductor.org/packages/ABAData/"
-    url      = "https://bioconductor.org/packages/release/data/experiment/src/contrib/ABAData_1.14.0.tar.gz"
+    url      = "http://bioconductor.org/packages/release/data/experiment/src/contrib/ABAData_1.16.0.tar.gz"
 
+    version('1.16.0', sha256='a41049ac83f6edb938ab63964ea387c84827b959f552f6b3cd0601b1eeee68d7')
     version('1.14.0', sha256='d203d968044c292cdfab57a4d6bf52dfb60470bd78b4c9bd88892577ac42b2b7')

--- a/var/spack/repos/builtin/packages/r-abadata/package.py
+++ b/var/spack/repos/builtin/packages/r-abadata/package.py
@@ -20,4 +20,5 @@ class RAbadata(RPackage):
     url      = "http://bioconductor.org/packages/release/data/experiment/src/contrib/ABAData_1.16.0.tar.gz"
 
     version('1.16.0', sha256='a41049ac83f6edb938ab63964ea387c84827b959f552f6b3cd0601b1eeee68d7')
-    version('1.14.0', sha256='d203d968044c292cdfab57a4d6bf52dfb60470bd78b4c9bd88892577ac42b2b7')
+    version('1.14.0', preferred=True, sha256='d203d968044c292cdfab57a4d6bf52dfb60470bd78b4c9bd88892577ac42b2b7',
+            url='http://bioconductor.jp/packages/release/data/experiment/src/contrib/ABAData_1.14.0.tar.gz')


### PR DESCRIPTION
The download url of the r-abadata package was invalid because the following error occurred.
"The requested url returned error: 404 Not Found"

So, I changed the download url.
The version of the r-abadata package provided by the vendor has changed from "1.14.0" to "1.16.0".
https://bioconductor.org/packages/ABAData/