### PR TITLE
[Draft] py-geant4 (g4py)

### DIFF
--- a/var/spack/repos/builtin/packages/py-geant4/package.py
+++ b/var/spack/repos/builtin/packages/py-geant4/package.py
@@ -1,0 +1,52 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyGeant4(CMakePackage):
+    """Python bindings for Geant4 (g4py)"""
+
+    homepage = "http://geant4.cern.ch/"
+    url = "http://geant4.cern.ch/support/source/geant4.10.01.p03.tar.gz"
+
+    version('10.04', sha256='f6d883132f110eb036c69da2b21df51f13c585dc7b99d4211ddd32f4ccee1670')
+
+    variant('cxxstd',
+            default='11',
+            values=('11', '14', '17'),
+            multi=False,
+            description='Use the specified C++ standard when building.')
+
+    depends_on('cmake@3.3:', type='build')
+
+    # take exact same Geant4 version
+    for v in ['10.04']:
+        depends_on('geant4@{0} +opengl+x11 cxxstd=11'.format(v),
+                   when='@{0} cxxstd=11'.format(v),
+                   type=['build', 'link', 'run'])
+        depends_on('geant4@{0} +opengl+x11 cxxstd=14'.format(v),
+                   when='@{0} cxxstd=14'.format(v),
+                   type=['build', 'link', 'run'])
+        depends_on('geant4@{0} +opengl+x11 cxxstd=17'.format(v),
+                   when='@{0} cxxstd=17'.format(v),
+                   type=['build', 'link', 'run'])
+
+    # C++11/14/17 support
+    depends_on('xerces-c cxxstd=11', when='cxxstd=11')
+    depends_on('xerces-c cxxstd=14', when='cxxstd=14')
+    depends_on('xerces-c cxxstd=17', when='cxxstd=17')
+
+    depends_on('boost +python')
+    depends_on('python')
+    depends_on('root')
+
+    root_cmakelists_dir = 'environments/g4py'
+
+    def setup_build_environment(self, env):
+        spec = self.spec
+        env.set('GEANT4_INSTALL', spec['geant4'].prefix)
+        # env.set('ROOTSYS', spec['root'].prefix)
+        env.set('XERCESC_ROOT_DIR', spec['xerces-c'].prefix)


### PR DESCRIPTION
Draft of a package shipping the [Geant4 python bindings](https://gitlab.cern.ch/geant4/geant4/tree/master/environments/g4py).
Same-version-pinning as already working in `adios` package for a very similar situation.

Note 1: `-lG4OpenGL` lib seam to be required to build `g4py`, otherwise related libs are not found during linking. Even with `^geant4+opengl` the lib is still missing in the install, but `^geant4+opengl+x11` helps.

The error that is then showing up in linking is
```
/usr/bin/ld: aTouchableHistoryAllocator: TLS reference in /home/axel/src/spack/opt/spack/linux-ubuntu18.04-skylake/gcc-8.3.0/geant4-10.04-bch5g6maf7srrfzageovu34dk3zyapmf/bin/../lib/libG4tracking.so mismatches non-TLS reference in CMakeFiles/pyG4geometry.dir/pyG4TouchableHistory.cc.o
/home/axel/src/spack/opt/spack/linux-ubuntu18.04-skylake/gcc-8.3.0/geant4-10.04-bch5g6maf7srrfzageovu34dk3zyapmf/bin/../lib/libG4tracking.so: error adding symbols: Bad value
collect2: error: ld returned 1 exit status
```

Note 2: `g4py` tries to link `-lboost_python` instead of `-lboost_python37`
Note 3: somehow `-lG4gl2ps` and `-lG4clhep` are also non-optional.

Note 3: due to some problems installing root #13637 I am testing this package via `spack install py-geant4 ^root~xml~x~opengl`.
Note 5: `root +x` (default) does not build (seen via `root ~xml`).
Note 6: `root ~x` does not build unless I also deactivate `~opengl` (default: `+opengl`).
