### PR TITLE
fluxbox: fix the comparison method with zero.

### DIFF
--- a/var/spack/repos/builtin/packages/fluxbox/fix_zero_comparison.patch
+++ b/var/spack/repos/builtin/packages/fluxbox/fix_zero_comparison.patch
@@ -1,0 +1,11 @@
+--- spack-src/util/fluxbox-remote.cc.org	2019-11-08 16:22:55.647747144 +0900
++++ spack-src/util/fluxbox-remote.cc	2019-11-08 16:23:15.709859444 +0900
+@@ -73,7 +73,7 @@
+     if (strcmp(cmd, "result") == 0) {
+         XTextProperty text_prop;
+         if (XGetTextProperty(disp, root, &text_prop, atom_result) != 0
+-            && text_prop.value > 0
++            && text_prop.value != 0
+             && text_prop.nitems > 0) {
+ 
+             printf("%s", text_prop.value);

--- a/var/spack/repos/builtin/packages/fluxbox/package.py
+++ b/var/spack/repos/builtin/packages/fluxbox/package.py
@@ -19,6 +19,9 @@ class Fluxbox(AutotoolsPackage):
 
     version('1.3.7', sha256='c99e2baa06fff1e96342b20415059d12ff1fa2917ade0173c75b2fa570295b9f')
 
+    # Referenced:https://sourceforge.net/p/fluxbox/bugs/1171/
+    patch('fix_zero_comparison.patch')
+
     depends_on('pkgconfig', type='build')
     depends_on('freetype')
     depends_on('libxrender')


### PR DESCRIPTION
Modifications to eliminate errors caused by zero comparision.
Reference: https://sourceforge.net/p/fluxbox/bugs/1171/