### PR TITLE
New Package: py-pyside2

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyside2/package.py
+++ b/var/spack/repos/builtin/packages/py-pyside2/package.py
@@ -1,0 +1,46 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+import os
+
+
+class PyPyside2(PythonPackage):
+    """Python bindings for Qt."""
+    homepage = "https://pypi.org/project/PySide2/"
+    url      = "https://code.qt.io/pyside/pyside-setup.git"
+    git      = "https://code.qt.io/pyside/pyside-setup.git"
+
+    # More recent versions of PySide2 (for Qt5) have been taken under
+    # the offical Qt umbrella.  For more information, see:
+    # http://wiki.qt.io/Qt_for_Python_Development_Getting_Started
+
+    version('dev', tag='dev')
+    version('5.13.2', tag='v5.13.2', submodules=True, preferred=True)
+    version('5.13.1', tag='v5.13.1', submodules=True)
+    version('5.13.0', tag='v5.13.0', submodules=True)
+    version('5.12.5', tag='v5.12.5', submodules=True)
+
+    depends_on('python@3.5:', type=('build','run'))
+
+    depends_on('cmake@3.1:', type='build')
+    depends_on('libxml2@2.6.32:', type='build')
+    depends_on('libxslt@1.1.19:', type='build')
+    depends_on('llvm@6:', type='build')
+    depends_on('py-setuptools', type='build')
+    depends_on('py-wheel', type='build')
+    depends_on('py-sphinx', type=('build', 'run'))
+    depends_on('qt@5.12:+opengl', type=('build','run'))
+    depends_on('graphviz', type='build')
+
+    def build_args(self, spec, prefix):
+        args = [
+            'install',
+            '--parallel={0}'.format(make_jobs),
+            '--ignore-git',
+#            '--build-tests',
+            '--qmake={0}'.format(os.path.join(spec['qt'].prefix.bin, 'qmake'))
+        ]
+        return args

--- a/var/spack/repos/builtin/packages/py-pyside2/package.py
+++ b/var/spack/repos/builtin/packages/py-pyside2/package.py
@@ -16,7 +16,7 @@ class PyPyside2(PythonPackage):
     # the offical Qt umbrella.  For more information, see:
     # http://wiki.qt.io/Qt_for_Python_Development_Getting_Started
 
-    version('dev', tag='dev')
+    version('develop', tag='dev')
     version('5.13.2', tag='v5.13.2', submodules=True)
     version('5.13.1', tag='v5.13.1', submodules=True)
     version('5.13.0', tag='v5.13.0', submodules=True)
@@ -35,7 +35,7 @@ class PyPyside2(PythonPackage):
     depends_on('graphviz', when='+doc', type='build')
     depends_on('libxml2@2.6.32:', when='+doc', type='build')
     depends_on('libxslt@1.1.19:', when='+doc', type='build')
-    depends_on('py-sphinx', when='+doc', type=('build', 'run'))
+    depends_on('py-sphinx', when='+doc', type='build')
 
     def build_args(self, spec, prefix):
         args = [

--- a/var/spack/repos/builtin/packages/py-pyside2/package.py
+++ b/var/spack/repos/builtin/packages/py-pyside2/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-import os
 
 
 class PyPyside2(PythonPackage):

--- a/var/spack/repos/builtin/packages/py-pyside2/package.py
+++ b/var/spack/repos/builtin/packages/py-pyside2/package.py
@@ -18,29 +18,38 @@ class PyPyside2(PythonPackage):
     # http://wiki.qt.io/Qt_for_Python_Development_Getting_Started
 
     version('dev', tag='dev')
-    version('5.13.2', tag='v5.13.2', submodules=True, preferred=True)
+    version('5.13.2', tag='v5.13.2', submodules=True)
     version('5.13.1', tag='v5.13.1', submodules=True)
     version('5.13.0', tag='v5.13.0', submodules=True)
     version('5.12.5', tag='v5.12.5', submodules=True)
 
-    depends_on('python@3.5:', type=('build','run'))
+    variant('doc', default=False, description='Enables the generation of html and man page documentation')
+
+    depends_on('python@2.7:2.7.99,3.5.0:3.5.99,3.6.1:')
 
     depends_on('cmake@3.1:', type='build')
-    depends_on('libxml2@2.6.32:', type='build')
-    depends_on('libxslt@1.1.19:', type='build')
     depends_on('llvm@6:', type='build')
     depends_on('py-setuptools', type='build')
     depends_on('py-wheel', type='build')
-    depends_on('py-sphinx', type=('build', 'run'))
-    depends_on('qt@5.12:+opengl', type=('build','run'))
-    depends_on('graphviz', type='build')
+    depends_on('qt@5.11:+opengl', type=('build', 'run'))
+
+    depends_on('graphviz', when='+doc', type='build')
+    depends_on('libxml2@2.6.32:', when='+doc', type='build')
+    depends_on('libxslt@1.1.19:', when='+doc', type='build')
+    depends_on('py-sphinx', when='+doc', type=('build', 'run'))
 
     def build_args(self, spec, prefix):
         args = [
-            'install',
+#            'install',
             '--parallel={0}'.format(make_jobs),
             '--ignore-git',
-#            '--build-tests',
-            '--qmake={0}'.format(os.path.join(spec['qt'].prefix.bin, 'qmake'))
+            '--qmake={0}'.format(spec['qt'].prefix.bin.qmake)
         ]
+        if self.run_tests:
+            args.append('--build-tests')
         return args
+
+    @run_after('build')
+    def build_docs(self):
+        if '+doc' in self.spec:
+            make('apidoc')

--- a/var/spack/repos/builtin/packages/py-pyside2/package.py
+++ b/var/spack/repos/builtin/packages/py-pyside2/package.py
@@ -25,7 +25,7 @@ class PyPyside2(PythonPackage):
 
     variant('doc', default=False, description='Enables the generation of html and man page documentation')
 
-    depends_on('python@2.7:2.7.99,3.5.0:3.5.99,3.6.1:')
+    depends_on('python@2.7:2.7.99,3.5.0:3.5.99,3.6.1:', type=('build', 'run'))
 
     depends_on('cmake@3.1:', type='build')
     depends_on('llvm@6:', type='build')
@@ -40,7 +40,6 @@ class PyPyside2(PythonPackage):
 
     def build_args(self, spec, prefix):
         args = [
-#            'install',
             '--parallel={0}'.format(make_jobs),
             '--ignore-git',
             '--qmake={0}'.format(spec['qt'].prefix.bin.qmake)


### PR DESCRIPTION
https://wiki.qt.io/Qt_for_Python

The Qt for Python project aims to provide a complete port of the PySide module to Qt 5. The development started on GitHub in May 2015. The project managed to port Pyside to Qt 5.3, 5.4 & 5.5. During April 2016 The Qt Company decided to properly support the port.