### PR TITLE
verify.py: os.path.exists exception handling

### DIFF
--- a/lib/spack/spack/verify.py
+++ b/lib/spack/spack/verify.py
@@ -28,24 +28,26 @@ def compute_hash(path):
 
 def create_manifest_entry(path):
     data = {}
-    stat = os.stat(path)
 
-    data['mode'] = stat.st_mode
-    data['owner'] = stat.st_uid
-    data['group'] = stat.st_gid
+    if os.path.exists(path):
+        stat = os.stat(path)
 
-    if os.path.islink(path):
-        data['type'] = 'link'
-        data['dest'] = os.readlink(path)
+        data['mode'] = stat.st_mode
+        data['owner'] = stat.st_uid
+        data['group'] = stat.st_gid
 
-    elif os.path.isdir(path):
-        data['type'] = 'dir'
+        if os.path.islink(path):
+            data['type'] = 'link'
+            data['dest'] = os.readlink(path)
 
-    else:
-        data['type'] = 'file'
-        data['hash'] = compute_hash(path)
-        data['time'] = stat.st_mtime
-        data['size'] = stat.st_size
+        elif os.path.isdir(path):
+            data['type'] = 'dir'
+
+        else:
+            data['type'] = 'file'
+            data['hash'] = compute_hash(path)
+            data['time'] = stat.st_mtime
+            data['size'] = stat.st_size
 
     return data
 


### PR DESCRIPTION
This PR adds exception handling around the `os.stat()` call during manifest creation so that installation of packages can run to completion should the package itself insert bogus files (e.g. a dangling symlink) into its install directory.  Without this patch, if any package so misbehaves, the `post_install()` section fails like this (even if the package itself successfully builds!):

```
==> Error: FileNotFoundError: [Errno 2] No such file or directory: '/usr/projects/packages/user_contrib/spack/opt/spack/linux-centos7-sandybridge/gcc-9.2.0/trilinos-12.12.1-wi5tyjl6gogocxjy4nvbv6nme7drcpzs/lib/cmake/tribits/doc/developers_guide/TribitsBuildReference.html'

/usr/projects/packages/user_contrib/spack/lib/spack/spack/package.py:1718, in build_process:
       1715                    echo = logger.echo
       1716                    self.log()
       1717
  >>   1718                # Run post install hooks before build stage is removed.
       1719                spack.hooks.post_install(self.spec)
       1720
       1721            # Stop timer.
```

Fixes #13648 
Fixes #13649