### PR TITLE
Improve spack checksum formatting

### DIFF
--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -61,3 +61,4 @@ def checksum(parser, args):
 
     print()
     print(version_lines)
+    print()

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -807,7 +807,7 @@ def get_checksums_for_versions(
     ])
 
     num_hash = len(version_hashes)
-    tty.msg("Checksummed {0} version{1} of {2}".format(
+    tty.msg("Checksummed {0} version{1} of {2}:".format(
         num_hash, '' if num_hash == 1 else 's', name))
 
     return version_lines

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -759,8 +759,8 @@ def get_checksums_for_versions(
             "",
             *spack.cmd.elide_list(
                 ["{0:{1}}  {2}".format(str(v), max_len, url_dict[v])
-                 for v in sorted_versions]))
-    tty.msg('')
+                 for v in sorted_versions]),
+            "")
 
     archives_to_fetch = tty.get_number(
         "How many would you like to checksum?", default=1, abort='q')

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from __future__ import print_function
+
 import os
 import stat
 import sys
@@ -759,8 +761,8 @@ def get_checksums_for_versions(
             "",
             *spack.cmd.elide_list(
                 ["{0:{1}}  {2}".format(str(v), max_len, url_dict[v])
-                 for v in sorted_versions]),
-            "")
+                 for v in sorted_versions]))
+    print()
 
     archives_to_fetch = tty.get_number(
         "How many would you like to checksum?", default=1, abort='q')


### PR DESCRIPTION
Very minor change.

### Before
```console
$ spack checksum mpich
==> Found 35 versions of mpich:
  
  3.3.1   http://www.mpich.org/static/downloads/3.3.1/mpich-3.3.1.tar.gz
  3.3rc1  http://www.mpich.org/static/downloads/3.3rc1/mpich-3.3rc1.tar.gz
  3.3b3   http://www.mpich.org/static/downloads/3.3b3/mpich-3.3b3.tar.gz
  3.3b2   http://www.mpich.org/static/downloads/3.3b2/mpich-3.3b2.tar.gz
  3.3b1   http://www.mpich.org/static/downloads/3.3b1/mpich-3.3b1.tar.gz
  3.3a3   http://www.mpich.org/static/downloads/3.3a3/mpich-3.3a3.tar.gz
  3.3a2   http://www.mpich.org/static/downloads/3.3a2/mpich-3.3a2.tar.gz
  3.3a1   http://www.mpich.org/static/downloads/3.3a1/mpich-3.3a1.tar.gz
  3.3     http://www.mpich.org/static/downloads/3.3/mpich-3.3.tar.gz
  ...
  3.0     http://www.mpich.org/static/downloads/3.0/mpich-3.0.tar.gz
==> 
==> How many would you like to checksum? (default is 1, q to abort) 3
==> Downloading...
==> Fetching http://www.mpich.org/static/downloads/3.3.1/mpich-3.3.1.tar.gz
########################################################################### 100.0%
==> Fetching http://www.mpich.org/static/downloads/3.3rc1/mpich-3.3rc1.tar.gz
########################################################################### 100.0%
==> Fetching http://www.mpich.org/static/downloads/3.3b3/mpich-3.3b3.tar.gz
########################################################################### 100.0%
==> Checksummed 3 versions of mpich

    version('3.3.1',  sha256='fe551ef29c8eea8978f679484441ed8bb1d943f6ad25b63c235d4b9243d551e5')
    version('3.3rc1', sha256='4a83f1f3b28d1bcd2f6dc9f91c87cf74583dc5f29cfef172015844b9ec75e9f2')
    version('3.3b3',  sha256='73a881c065f798a47a7db1e0ad34ad16c4cb73bf7ebf34c97618aac152c416bf')
$
```

### After

```console
$ spack checksum mpich
==> Found 35 versions of mpich:
  
  3.3.1   http://www.mpich.org/static/downloads/3.3.1/mpich-3.3.1.tar.gz
  3.3rc1  http://www.mpich.org/static/downloads/3.3rc1/mpich-3.3rc1.tar.gz
  3.3b3   http://www.mpich.org/static/downloads/3.3b3/mpich-3.3b3.tar.gz
  3.3b2   http://www.mpich.org/static/downloads/3.3b2/mpich-3.3b2.tar.gz
  3.3b1   http://www.mpich.org/static/downloads/3.3b1/mpich-3.3b1.tar.gz
  3.3a3   http://www.mpich.org/static/downloads/3.3a3/mpich-3.3a3.tar.gz
  3.3a2   http://www.mpich.org/static/downloads/3.3a2/mpich-3.3a2.tar.gz
  3.3a1   http://www.mpich.org/static/downloads/3.3a1/mpich-3.3a1.tar.gz
  3.3     http://www.mpich.org/static/downloads/3.3/mpich-3.3.tar.gz
  ...
  3.0     http://www.mpich.org/static/downloads/3.0/mpich-3.0.tar.gz

==> How many would you like to checksum? (default is 1, q to abort) 3
==> Downloading...
==> Fetching http://www.mpich.org/static/downloads/3.3.1/mpich-3.3.1.tar.gz
########################################################################### 100.0%
==> Fetching http://www.mpich.org/static/downloads/3.3rc1/mpich-3.3rc1.tar.gz
########################################################################### 100.0%
==> Fetching http://www.mpich.org/static/downloads/3.3b3/mpich-3.3b3.tar.gz
########################################################################### 100.0%
==> Checksummed 3 versions of mpich:

    version('3.3.1',  sha256='fe551ef29c8eea8978f679484441ed8bb1d943f6ad25b63c235d4b9243d551e5')
    version('3.3rc1', sha256='4a83f1f3b28d1bcd2f6dc9f91c87cf74583dc5f29cfef172015844b9ec75e9f2')
    version('3.3b3',  sha256='73a881c065f798a47a7db1e0ad34ad16c4cb73bf7ebf34c97618aac152c416bf')

$
```