### PR TITLE
Add new version of Intel MKL-DNN

### DIFF
--- a/var/spack/repos/builtin/packages/intel-mkl-dnn/package.py
+++ b/var/spack/repos/builtin/packages/intel-mkl-dnn/package.py
@@ -10,14 +10,18 @@ class IntelMklDnn(CMakePackage):
     """Intel(R) Math Kernel Library for Deep Neural Networks
     (Intel(R) MKL-DNN)."""
 
-    homepage = "https://01.org/mkl-dnn"
-    url      = "https://github.com/intel/mkl-dnn/archive/v0.19.tar.gz"
+    homepage = "http://intel.github.io/mkl-dnn/"
+    url      = "https://github.com/intel/mkl-dnn/archive/v1.1.1.tar.gz"
 
-    version('1.0-pc2', sha256='fcc2d951f7170eade0cfdd0d8d1d58e3e7785bd326bca6555f3722f8cba71811')
-    version('0.19',    sha256='ba39da6adb263df05c4ca2a120295641fc97be75b588922e4274cb628dbe1dcd', preferred=True)
-    version('0.18.1',  sha256='fc7506701dfece9b03c0dc83d0cda9a44a5de17cdb54bc7e09168003f02dbb70')
-    version('0.11', sha256='4cb4a85b05fe42aa527fd70a048caddcba9361f6d3d7bea9f33d74524e206d7d')
-    version('0.10', sha256='59828764ae43f1151f77b8997012c52e0e757bc50af1196b86fce8934178c570')
-    version('0.9',  sha256='8606a80851c45b0076f7d4047fbf774ce13d6b6d857cb2edf95c7e1fd4bca1c7')
+    version('1.1.1',  sha256='a31b08a89473bfe3bd6ed542503336d21b4177ebe4ccb9a97810808f634db6b6')
+    version('0.19',   sha256='ba39da6adb263df05c4ca2a120295641fc97be75b588922e4274cb628dbe1dcd')
+    version('0.18.1', sha256='fc7506701dfece9b03c0dc83d0cda9a44a5de17cdb54bc7e09168003f02dbb70')
+    version('0.11',   sha256='4cb4a85b05fe42aa527fd70a048caddcba9361f6d3d7bea9f33d74524e206d7d')
+    version('0.10',   sha256='59828764ae43f1151f77b8997012c52e0e757bc50af1196b86fce8934178c570')
+    version('0.9',    sha256='8606a80851c45b0076f7d4047fbf774ce13d6b6d857cb2edf95c7e1fd4bca1c7')
 
+    depends_on('cmake@2.8.11:', type='build')
     depends_on('intel-mkl')
+
+    # https://github.com/intel/mkl-dnn/issues/591
+    # depends_on('llvm-openmp', when='%clang platform=darwin')

--- a/var/spack/repos/builtin/packages/intel-mkl-dnn/package.py
+++ b/var/spack/repos/builtin/packages/intel-mkl-dnn/package.py
@@ -13,6 +13,8 @@ class IntelMklDnn(CMakePackage):
     homepage = "https://intel.github.io/mkl-dnn/"
     url      = "https://github.com/intel/mkl-dnn/archive/v1.1.1.tar.gz"
 
+    maintainers = ['adamjstewart']
+
     version('1.1.1',  sha256='a31b08a89473bfe3bd6ed542503336d21b4177ebe4ccb9a97810808f634db6b6')
     version('0.19',   sha256='ba39da6adb263df05c4ca2a120295641fc97be75b588922e4274cb628dbe1dcd')
     version('0.18.1', sha256='fc7506701dfece9b03c0dc83d0cda9a44a5de17cdb54bc7e09168003f02dbb70')

--- a/var/spack/repos/builtin/packages/intel-mkl-dnn/package.py
+++ b/var/spack/repos/builtin/packages/intel-mkl-dnn/package.py
@@ -37,6 +37,9 @@ class IntelMklDnn(CMakePackage):
                 '-DOpenMP_libomp_LIBRARY={0}'.format(
                     self.spec['llvm-openmp'].libs.libraries[0]
                 ),
+                '-DCMAKE_SHARED_LINKER_FLAGS={0}'.format(
+                    self.spec['llvm-openmp'].libs.ld_flags
+                ),
             ])
 
         return args

--- a/var/spack/repos/builtin/packages/intel-mkl-dnn/package.py
+++ b/var/spack/repos/builtin/packages/intel-mkl-dnn/package.py
@@ -22,6 +22,21 @@ class IntelMklDnn(CMakePackage):
 
     depends_on('cmake@2.8.11:', type='build')
     depends_on('intel-mkl')
+    depends_on('llvm-openmp', when='%clang platform=darwin')
 
-    # https://github.com/intel/mkl-dnn/issues/591
-    # depends_on('llvm-openmp', when='%clang platform=darwin')
+    def cmake_args(self):
+        args = []
+
+        # https://github.com/intel/mkl-dnn/issues/591
+        if self.spec.satisfies('%clang platform=darwin'):
+            args.extend([
+                '-DOpenMP_CXX_FLAGS={0}'.format(self.compiler.openmp_flag),
+                '-DOpenMP_C_FLAGS={0}'.format(self.compiler.openmp_flag),
+                '-DOpenMP_CXX_LIB_NAMES=libomp',
+                '-DOpenMP_C_LIB_NAMES=libomp',
+                '-DOpenMP_libomp_LIBRARY={0}'.format(
+                    self.spec['llvm-openmp'].libs.libraries[0]
+                ),
+            ])
+
+        return args

--- a/var/spack/repos/builtin/packages/intel-mkl-dnn/package.py
+++ b/var/spack/repos/builtin/packages/intel-mkl-dnn/package.py
@@ -10,7 +10,7 @@ class IntelMklDnn(CMakePackage):
     """Intel(R) Math Kernel Library for Deep Neural Networks
     (Intel(R) MKL-DNN)."""
 
-    homepage = "http://intel.github.io/mkl-dnn/"
+    homepage = "https://intel.github.io/mkl-dnn/"
     url      = "https://github.com/intel/mkl-dnn/archive/v1.1.1.tar.gz"
 
     version('1.1.1',  sha256='a31b08a89473bfe3bd6ed542503336d21b4177ebe4ccb9a97810808f634db6b6')

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -128,7 +128,7 @@ class PyTorch(PythonPackage):
     depends_on('fbgemm', when='+fbgemm')
     # TODO: add dependency: https://github.com/ROCmSoftwarePlatform/MIOpen
     depends_on('miopen', when='+miopen')
-    depends_on('mkl', when='+mkldnn')
+    depends_on('intel-mkl-dnn', when='+mkldnn')
     # TODO: add dependency: https://github.com/Maratyszcza/NNPACK
     depends_on('nnpack', when='+nnpack')
     depends_on('qnnpack', when='+qnnpack')
@@ -219,7 +219,7 @@ class PyTorch(PythonPackage):
 
         enable_or_disable('mkldnn')
         if '+mkldnn' in self.spec:
-            env.set('MKLDNN_HOME', self.spec['intel-mkl'].prefix)
+            env.set('MKLDNN_HOME', self.spec['intel-mkl-dnn'].prefix)
 
         enable_or_disable('nnpack')
         enable_or_disable('qnnpack')


### PR DESCRIPTION
Successfully installs and passes all unit tests on macOS 10.15.1 with Clang 11.0.0.

Ran into a few bugs I'm still trying to resolve:

* https://github.com/intel/mkl-dnn/issues/591
* https://github.com/spack/spack/pull/13656#issuecomment-552273278