### PR TITLE
fix x86_64 arch check in pmdk package

### DIFF
--- a/var/spack/repos/builtin/packages/pmdk/package.py
+++ b/var/spack/repos/builtin/packages/pmdk/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-import spack.architecture
 
 
 class Pmdk(Package):
@@ -36,7 +35,7 @@ class Pmdk(Package):
 
         # pmdk is particular about the ARCH specification, must be
         # exactly "x86_64" for build to work
-        if 'x86_64' in spack.architecture.sys_type():
+        if spec.target.family == 'x86_64':
             make_args += ['ARCH=x86_64']
 
         make("install", *make_args)


### PR DESCRIPTION
Update logic that checks for x86_64 architectures in the pmdk package.