### PR TITLE
Update Mathematica recipe

### DIFF
--- a/var/spack/repos/builtin/packages/mathematica/package.py
+++ b/var/spack/repos/builtin/packages/mathematica/package.py
@@ -18,10 +18,18 @@ class Mathematica(Package):
        http://spack.readthedocs.io/en/latest/mirrors.html"""
 
     homepage = "https://www.wolfram.com/mathematica/"
-    url = 'file://{0}/Mathematica_12.0.0_LINUX.sh'.format(os.getcwd())
 
     version('12.0.0', sha256='b9fb71e1afcc1d72c200196ffa434512d208fa2920e207878433f504e58ae9d7',
             expand=False)
+
+    # Licensing
+    license_required = True
+    license_comment  = '#'
+    license_files    = ['Configuration/Licensing/mathpass']
+    license_url      = 'https://reference.wolfram.com/language/tutorial/RegistrationAndPasswords.html#857035062'
+
+    def url_for_version(self, version):
+        return "file://{0}/Mathematica_{1}_LINUX.sh".format(os.getcwd(), version)
 
     def install(self, spec, prefix):
         sh = which('sh')
@@ -29,3 +37,19 @@ class Mathematica(Package):
            '-targetdir={0}'.format(prefix),
            '-execdir={0}'.format(prefix.bin),
            '-selinux=y')
+        # .spack directory in the install directory may not exist and needs to be created
+        install_spack_dir = os.path.dirname(self.install_log_path)
+        os.makedirs(install_spack_dir, exist_ok=True)
+        # This is what most people would use on a cluster but the installer does not symlink it
+        ws_link_path = os.path.join(prefix.bin, 'wolframscript')
+        if not os.path.exists(ws_link_path):
+            ln = which('ln')
+            ws_path = os.path.join(prefix, 'Executables', 'wolframscript')
+            ln('-s', ws_path, ws_link_path)
+        # spec.yaml may not be generated automatically but required for successful registration of
+        # the package
+        spec_path = os.path.join(install_spack_dir, 'spec.yaml')
+        if not os.path.exists(spec_path):
+            with open(spec_path, 'w') as f:
+                spec.to_yaml(f)
+

--- a/var/spack/repos/builtin/packages/mathematica/package.py
+++ b/var/spack/repos/builtin/packages/mathematica/package.py
@@ -18,6 +18,7 @@ class Mathematica(Package):
        http://spack.readthedocs.io/en/latest/mirrors.html"""
 
     homepage = "https://www.wolfram.com/mathematica/"
+    url = 'file://{0}/Mathematica_12.0.0_LINUX.sh'.format(os.getcwd())
 
     version('12.0.0', sha256='b9fb71e1afcc1d72c200196ffa434512d208fa2920e207878433f504e58ae9d7',
             expand=False)
@@ -28,28 +29,16 @@ class Mathematica(Package):
     license_files    = ['Configuration/Licensing/mathpass']
     license_url      = 'https://reference.wolfram.com/language/tutorial/RegistrationAndPasswords.html#857035062'
 
-    def url_for_version(self, version):
-        return "file://{0}/Mathematica_{1}_LINUX.sh".format(os.getcwd(), version)
-
     def install(self, spec, prefix):
         sh = which('sh')
         sh(self.stage.archive_file, '--', '-auto', '-verbose',
            '-targetdir={0}'.format(prefix),
            '-execdir={0}'.format(prefix.bin),
            '-selinux=y')
-        # .spack directory in the install directory may not exist and needs to be created
-        install_spack_dir = os.path.dirname(self.install_log_path)
-        os.makedirs(install_spack_dir, exist_ok=True)
         # This is what most people would use on a cluster but the installer does not symlink it
         ws_link_path = os.path.join(prefix.bin, 'wolframscript')
         if not os.path.exists(ws_link_path):
             ln = which('ln')
             ws_path = os.path.join(prefix, 'Executables', 'wolframscript')
             ln('-s', ws_path, ws_link_path)
-        # spec.yaml may not be generated automatically but required for successful registration of
-        # the package
-        spec_path = os.path.join(install_spack_dir, 'spec.yaml')
-        if not os.path.exists(spec_path):
-            with open(spec_path, 'w') as f:
-                spec.to_yaml(f)
 

--- a/var/spack/repos/builtin/packages/mathematica/package.py
+++ b/var/spack/repos/builtin/packages/mathematica/package.py
@@ -20,7 +20,8 @@ class Mathematica(Package):
     homepage = "https://www.wolfram.com/mathematica/"
     url = 'file://{0}/Mathematica_12.0.0_LINUX.sh'.format(os.getcwd())
 
-    version('12.0.0', sha256='b9fb71e1afcc1d72c200196ffa434512d208fa2920e207878433f504e58ae9d7',
+    version('12.0.0',
+            sha256='b9fb71e1afcc1d72c200196ffa434512d208fa2920e207878433f504e58ae9d7',
             expand=False)
 
     # Licensing
@@ -35,10 +36,10 @@ class Mathematica(Package):
            '-targetdir={0}'.format(prefix),
            '-execdir={0}'.format(prefix.bin),
            '-selinux=y')
-        # This is what most people would use on a cluster but the installer does not symlink it
+        # This is what most people would use on a cluster but the installer
+        # does not symlink it
         ws_link_path = os.path.join(prefix.bin, 'wolframscript')
         if not os.path.exists(ws_link_path):
             ln = which('ln')
             ws_path = os.path.join(prefix, 'Executables', 'wolframscript')
             ln('-s', ws_path, ws_link_path)
-


### PR DESCRIPTION
This pull request addresses the following issues.

- Licensing is currently missing from the recipe. Assuming that majority of the installations will be on clusters, information about the licence manager server would be required
- Replace url with url_for_version in case subsequent versions are added
- Create .spack dir during installation. This directory may not be created automatically causing installation failure when spack is trying to copy the log file there.
- Symlink wolframscript. Most people running mathematica in the cluster environment would be using wolframscript binary. However, the installer does not symlink it, so full path is required to run it.
- Generate spec.yaml. This file may not be created automatically causing package registration failure.