### PR TITLE
Update nlopt package to add Python bindings to PYTHONPATH

### DIFF
--- a/var/spack/repos/builtin/packages/nlopt/package.py
+++ b/var/spack/repos/builtin/packages/nlopt/package.py
@@ -16,7 +16,7 @@ class Nlopt(CMakePackage):
     url      = "https://github.com/stevengj/nlopt/archive/v2.5.0.tar.gz"
     git      = "https://github.com/stevengj/nlopt.git"
 
-    version('develop', branch='master')
+    version('master', branch='master')
     version('2.5.0', sha256='c6dd7a5701fff8ad5ebb45a3dc8e757e61d52658de3918e38bab233e7fd3b4ae')
 
     variant('shared', default=True, description='Enables the build of shared libraries')
@@ -28,8 +28,8 @@ class Nlopt(CMakePackage):
     # Note: matlab is licenced - spack does not download automatically
     variant("matlab", default=False, description="Build the Matlab bindings.")
 
-    depends_on('cmake@3.0:', type='build', when='@develop')
-    depends_on('python', when='+python')
+    depends_on('cmake@3.0:', type='build', when='@master')
+    depends_on('python', when='+python', type=('build', 'run'))
     depends_on('py-numpy', when='+python', type=('build', 'run'))
     depends_on('swig', when='+python')
     depends_on('guile', when='+guile')
@@ -44,7 +44,7 @@ class Nlopt(CMakePackage):
         args = []
 
         # Specify on command line to alter defaults:
-        # eg: spack install nlopt@develop +guile -octave +cxx
+        # eg: spack install nlopt@master +guile -octave +cxx
 
         # Spack should locate python by default - but to point to a build
         if '+python' in spec:

--- a/var/spack/repos/builtin/packages/nlopt/package.py
+++ b/var/spack/repos/builtin/packages/nlopt/package.py
@@ -35,17 +35,7 @@ class Nlopt(CMakePackage):
     depends_on('guile', when='+guile')
     depends_on('octave', when='+octave')
     depends_on('matlab', when='+matlab')
-
-    def setup_run_environment(self, env):
-        # Prepend PYTHON_PATH with NLopt Python bindings directory
-        spec = self.spec
-        if spec.satisfies("+python"):
-            lib_dir = self.prefix.lib
-            python_version = spec['python'].version.up_to(2)
-            nlopt_pydir = join_path(lib_dir,
-                                    'python{0}'.format(python_version),
-                                    "site-packages")
-            env.prepend_path('PYTHONPATH', nlopt_pydir)
+    extends('python', when='+python')
 
     def cmake_args(self):
         # Add arguments other than

--- a/var/spack/repos/builtin/packages/nlopt/package.py
+++ b/var/spack/repos/builtin/packages/nlopt/package.py
@@ -36,6 +36,17 @@ class Nlopt(CMakePackage):
     depends_on('octave', when='+octave')
     depends_on('matlab', when='+matlab')
 
+    def setup_run_environment(self, env):
+        # Prepend PYTHON_PATH with NLopt Python bindings directory
+        spec = self.spec
+        if spec.satisfies("+python"):
+            lib_dir = self.prefix.lib
+            python_version = spec['python'].version.up_to(2)
+            nlopt_pydir = join_path(lib_dir,
+                                    'python{0}'.format(python_version),
+                                    "site-packages")
+            env.prepend_path('PYTHONPATH', nlopt_pydir)
+
     def cmake_args(self):
         # Add arguments other than
         # CMAKE_INSTALL_PREFIX and CMAKE_BUILD_TYPE


### PR DESCRIPTION
Prepend PYTHONPATH with NLopt's Python directory when built with +python option. This allows nlopt to be imported in Python.