### PR TITLE
damselfly: Add mpi dependency.

### DIFF
--- a/var/spack/repos/builtin/packages/damselfly/package.py
+++ b/var/spack/repos/builtin/packages/damselfly/package.py
@@ -14,3 +14,4 @@ class Damselfly(CMakePackage):
     version('1.0', sha256='560e1b800c9036766396a1033c00914bd8d181b911e87140c3ac8879baf6545a')
 
     depends_on('cmake@2.6:', type='build')
+    depends_on('mpi')


### PR DESCRIPTION
I got the following error when installing `damselfly`.
```
     35    mpicxx   -I/tmp/~/spack-stage-da
           mselfly-1.0-2ag34mthvthcixrhtvt3djsp6o64jj2p/spack-build  -O2 -g -DN
           DEBUG   -o CMakeFiles/damselfly.dir/src/ariesModeling.C.o -c /tmp/~
           ~/spack-stage-damselfly-1.0-2ag34mthvthcixrhtvt3djsp6o64jj2p/
           spack-src/src/ariesModeling.C
     36    make[2]: mpicxx: Command not found 
```
It means that `damselfly` needs mpi library, so I added `mpi` dependency.