### PR TITLE
preCICE: Enable PETSc by default

### DIFF
--- a/var/spack/repos/builtin/packages/precice/package.py
+++ b/var/spack/repos/builtin/packages/precice/package.py
@@ -31,7 +31,7 @@ class Precice(CMakePackage):
     # Skip version 1.1.1 entirely, the cmake was lacking install.
 
     variant('mpi', default=True, description='Enable MPI support')
-    variant('petsc', default=False, description='Enable PETSc support')
+    variant('petsc', default=True, description='Enable PETSc support')
     variant('python', default=False, description='Enable Python support')
     variant('shared', default=True, description='Build shared libraries')
 


### PR DESCRIPTION
This PR changes preCICE to enable PETSc by default.
This has been extensively tested by @balay.