### PR TITLE
Update package libgpg error

### DIFF
--- a/var/spack/repos/builtin/packages/gawk/package.py
+++ b/var/spack/repos/builtin/packages/gawk/package.py
@@ -23,6 +23,7 @@ class Gawk(AutotoolsPackage):
     homepage = "https://www.gnu.org/software/gawk/"
     url      = "https://ftpmirror.gnu.org/gawk/gawk-4.1.4.tar.xz"
 
+    version('5.0.1', sha256='8e4e86f04ed789648b66f757329743a0d6dfb5294c3b91b756a474f1ce05a794')
     version('4.1.4', sha256='53e184e2d0f90def9207860531802456322be091c7b48f23fdc79cda65adc266')
 
     depends_on('gettext')

--- a/var/spack/repos/builtin/packages/libgpg-error/awk-5.patch
+++ b/var/spack/repos/builtin/packages/libgpg-error/awk-5.patch
@@ -1,0 +1,196 @@
+--- a/src/Makefile.in	
++++ b/src/Makefile.in	
+@@ -1615,7 +1615,7 @@
+ 
+ errnos-sym.h: Makefile mkstrtable.awk errnos.in
+ 	$(AWK) -f $(srcdir)/mkstrtable.awk -v textidx=2 -v nogettext=1 \
+-		-v prefix=GPG_ERR_ -v namespace=errnos_ \
++		-v prefix=GPG_ERR_ -v pkg_namespace=errnos_ \
+ 		$(srcdir)/errnos.in >$@
+ 
+ mkheader$(EXEEXT_FOR_BUILD): mkheader.c Makefile
+
+diff --git a/NEWS b/NEWS
+index 75b8a99..ef29558 100644
+--- a/NEWS
++++ b/NEWS
+@@ -1,3 +1,7 @@
++Noteworthy changes in version 1.37 (unreleased) [C27/A27/R_]
++-----------------------------------------------
++
++
+ Noteworthy changes in version 1.36 (2019-03-19) [C27/A27/R0]
+ -----------------------------------------------
+ 
+diff --git a/configure.ac b/configure.ac
+index e46b240..a6526a9 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -29,7 +29,7 @@ min_automake_version="1.14"
+ # See below for the LT versions.
+ m4_define([mym4_package],[libgpg-error])
+ m4_define([mym4_major], [1])
+-m4_define([mym4_minor], [36])
++m4_define([mym4_minor], [37])
+ 
+ # Below is m4 magic to extract and compute the revision number, the
+ # decimalized short revision number, a beta version string, and a flag
+diff --git a/doc/yat2m.c b/doc/yat2m.c
+index 3c7b363..a6a74c9 100644
+--- a/doc/yat2m.c
++++ b/doc/yat2m.c
+@@ -49,7 +49,7 @@
+       .B whateever you want
+       @end ifset
+ 
+-    alternativly a special comment may be used:
++    alternatively a special comment may be used:
+ 
+       @c man:.B whatever you want
+ 
+@@ -705,7 +705,7 @@ write_th (FILE *fp)
+ 
+ 
+ /* Process the texinfo command COMMAND (without the leading @) and
+-   write output if needed to FP. REST is the remainer of the line
++   write output if needed to FP. REST is the remainder of the line
+    which should either point to an opening brace or to a white space.
+    The function returns the number of characters already processed
+    from REST.  LEN is the usable length of REST.  TABLE_LEVEL is used to
+@@ -725,7 +725,8 @@ proc_texi_cmd (FILE *fp, const char *command, const char *rest, size_t len,
+     { "url",     0, "\\fB", "\\fR" },
+     { "sc",      0, "\\fB", "\\fR" },
+     { "var",     0, "\\fI", "\\fR" },
+-    { "samp",    0, "\\(aq", "\\(aq"  },
++    { "samp",    0, "\\(oq", "\\(cq"  },
++    { "kbd",     0, "\\(oq", "\\(cq"  },
+     { "file",    0, "\\(oq\\fI","\\fR\\(cq" },
+     { "env",     0, "\\(oq\\fI","\\fR\\(cq" },
+     { "acronym", 0 },
+diff --git a/lang/cl/mkerrcodes.awk b/lang/cl/mkerrcodes.awk
+index ae29043..9a1fc18 100644
+--- a/lang/cl/mkerrcodes.awk
++++ b/lang/cl/mkerrcodes.awk
+@@ -122,7 +122,7 @@ header {
+ }
+ 
+ !header {
+-  sub (/\#.+/, "");
++  sub (/#.+/, "");
+   sub (/[ 	]+$/, ""); # Strip trailing space and tab characters.
+ 
+   if (/^$/)
+diff --git a/src/Makefile.am b/src/Makefile.am
+index ce1b882..f2590cb 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -293,7 +293,7 @@ code-from-errno.h: mkerrcodes$(EXEEXT_FOR_BUILD) Makefile
+ 
+ errnos-sym.h: Makefile mkstrtable.awk errnos.in
+ 	$(AWK) -f $(srcdir)/mkstrtable.awk -v textidx=2 -v nogettext=1 \
+-		-v prefix=GPG_ERR_ -v namespace=errnos_ \
++		-v prefix=GPG_ERR_ -v pkg_namespace=errnos_ \
+ 		$(srcdir)/errnos.in >$@
+ 
+ 
+diff --git a/src/mkerrcodes.awk b/src/mkerrcodes.awk
+index 46d436c..e9c857c 100644
+--- a/src/mkerrcodes.awk
++++ b/src/mkerrcodes.awk
+@@ -85,7 +85,7 @@ header {
+ }
+ 
+ !header {
+-  sub (/\#.+/, "");
++  sub (/#.+/, "");
+   sub (/[ 	]+$/, ""); # Strip trailing space and tab characters.
+ 
+   if (/^$/)
+diff --git a/src/mkerrcodes1.awk b/src/mkerrcodes1.awk
+index a771a73..4578e29 100644
+--- a/src/mkerrcodes1.awk
++++ b/src/mkerrcodes1.awk
+@@ -81,7 +81,7 @@ header {
+ }
+ 
+ !header {
+-  sub (/\#.+/, "");
++  sub (/#.+/, "");
+   sub (/[ 	]+$/, ""); # Strip trailing space and tab characters.
+ 
+   if (/^$/)
+diff --git a/src/mkerrcodes2.awk b/src/mkerrcodes2.awk
+index ea58503..188f7a4 100644
+--- a/src/mkerrcodes2.awk
++++ b/src/mkerrcodes2.awk
+@@ -91,7 +91,7 @@ header {
+ }
+ 
+ !header {
+-  sub (/\#.+/, "");
++  sub (/#.+/, "");
+   sub (/[ 	]+$/, ""); # Strip trailing space and tab characters.
+ 
+   if (/^$/)
+diff --git a/src/mkerrnos.awk b/src/mkerrnos.awk
+index f79df66..15b1aad 100644
+--- a/src/mkerrnos.awk
++++ b/src/mkerrnos.awk
+@@ -83,7 +83,7 @@ header {
+ }
+ 
+ !header {
+-  sub (/\#.+/, "");
++  sub (/#.+/, "");
+   sub (/[ 	]+$/, ""); # Strip trailing space and tab characters.
+ 
+   if (/^$/)
+diff --git a/src/mkstrtable.awk b/src/mkstrtable.awk
+index c9de9c1..285e45f 100644
+--- a/src/mkstrtable.awk
++++ b/src/mkstrtable.awk
+@@ -77,7 +77,7 @@
+ #
+ # The variable prefix can be used to prepend a string to each message.
+ #
+-# The variable namespace can be used to prepend a string to each
++# The variable pkg_namespace can be used to prepend a string to each
+ # variable and macro name.
+ 
+ BEGIN {
+@@ -102,7 +102,7 @@ header {
+       print "/* The purpose of this complex string table is to produce";
+       print "   optimal code with a minimum of relocations.  */";
+       print "";
+-      print "static const char " namespace "msgstr[] = ";
++      print "static const char " pkg_namespace "msgstr[] = ";
+       header = 0;
+     }
+   else
+@@ -110,7 +110,7 @@ header {
+ }
+ 
+ !header {
+-  sub (/\#.+/, "");
++  sub (/#.+/, "");
+   sub (/[ 	]+$/, ""); # Strip trailing space and tab characters.
+ 
+   if (/^$/)
+@@ -150,7 +150,7 @@ END {
+   else
+     print "  gettext_noop (\"" last_msgstr "\");";
+   print "";
+-  print "static const int " namespace "msgidx[] =";
++  print "static const int " pkg_namespace "msgidx[] =";
+   print "  {";
+   for (i = 0; i < coded_msgs; i++)
+     print "    " pos[i] ",";
+@@ -158,7 +158,7 @@ END {
+   print "  };";
+   print "";
+   print "static GPG_ERR_INLINE int";
+-  print namespace "msgidxof (int code)";
++  print pkg_namespace "msgidxof (int code)";
+   print "{";
+   print "  return (0 ? 0";
+ 

--- a/var/spack/repos/builtin/packages/libgpg-error/package.py
+++ b/var/spack/repos/builtin/packages/libgpg-error/package.py
@@ -21,4 +21,5 @@ class LibgpgError(AutotoolsPackage):
     version('1.18', sha256='9ff1d6e61d4cef7c1d0607ceef6d40dc33f3da7a3094170c3718c00153d80810')
 
     depends_on('awk', type=('build'))
+    # Patch for using gawk@5, c.f. https://dev.gnupg.org/T4459
     patch('awk-5.patch', when='@1.36^gawk@5:')

--- a/var/spack/repos/builtin/packages/libgpg-error/package.py
+++ b/var/spack/repos/builtin/packages/libgpg-error/package.py
@@ -20,4 +20,4 @@ class LibgpgError(AutotoolsPackage):
     version('1.21', sha256='b7dbdb3cad63a740e9f0c632a1da32d4afdb694ec86c8625c98ea0691713b84d')
     version('1.18', sha256='9ff1d6e61d4cef7c1d0607ceef6d40dc33f3da7a3094170c3718c00153d80810')
 
-    depends_on('gawk', type=('build'))
+    depends_on('awk', type=('build'))

--- a/var/spack/repos/builtin/packages/libgpg-error/package.py
+++ b/var/spack/repos/builtin/packages/libgpg-error/package.py
@@ -19,3 +19,5 @@ class LibgpgError(AutotoolsPackage):
     version('1.27', sha256='4f93aac6fecb7da2b92871bb9ee33032be6a87b174f54abf8ddf0911a22d29d2')
     version('1.21', sha256='b7dbdb3cad63a740e9f0c632a1da32d4afdb694ec86c8625c98ea0691713b84d')
     version('1.18', sha256='9ff1d6e61d4cef7c1d0607ceef6d40dc33f3da7a3094170c3718c00153d80810')
+
+    depends_on('gawk', type=('build'))

--- a/var/spack/repos/builtin/packages/libgpg-error/package.py
+++ b/var/spack/repos/builtin/packages/libgpg-error/package.py
@@ -21,3 +21,4 @@ class LibgpgError(AutotoolsPackage):
     version('1.18', sha256='9ff1d6e61d4cef7c1d0607ceef6d40dc33f3da7a3094170c3718c00153d80810')
 
     depends_on('awk', type=('build'))
+    patch('awk-5.patch', when='@1.36^gawk@5:')


### PR DESCRIPTION
- awk is a build depdency for this package

There is an [issue](https://dev.gnupg.org/rE7865041c77f4f7005282f10f9b6666b19072fbdf) with libgpg-error and gawk >= 5.0 which will be fixed in any release version of libgpg-error (it's the third commit on their master branch after the release tag 1.36). Therefore there should be a requirement in the sense of 

    depends_on('awk@:4, when='@:1.36', type='build')
    depends_on('awk@4:, when='@1.37:', type='build')

But since awk is a virtual dependency this would not work I assume? Shall I leave it as it is or specify this version constraint for each awk provider?