### PR TITLE
Define a package's dependencies and versions in yaml file

### DIFF
--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -304,6 +304,7 @@ def versions_file(relative_path):
     their version lists in a file.
     """
     import jsonschema
+
     def _execute_versions_file(pkg):
         abs_path = _abs_path_from_relative_pkg_path(pkg, relative_path)
         data = yaml.load(open(abs_path))
@@ -429,6 +430,7 @@ def dependency_file(relative_path):
 
     """
     import jsonschema
+
     def _execute_dependency_file(pkg):
         abs_path = _abs_path_from_relative_pkg_path(pkg, relative_path)
         data = yaml.load(open(abs_path))

--- a/lib/spack/spack/schema/package_dependencies.py
+++ b/lib/spack/spack/schema/package_dependencies.py
@@ -1,0 +1,52 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""Schema for dependencies.yaml package dependency files.
+
+"""
+
+
+#: Properties for inclusion in other schemas
+properties = {
+    'dependencies': {
+        'type': 'object',
+        'default': {},
+        'additionalProperties': False,
+        'patternProperties': {
+            r'\w[\w-]*': {  # dependency spec
+                'type': 'object',
+                'default': {},
+                'additionalProperties': False,
+                'properties': {
+                    'when': {
+                        'type': 'string',
+                    },
+                    'patches': {
+                        'oneOf': [
+                            {'type': 'string'},
+                            {'type': 'array',
+                             'items': {'type': 'string'}}],
+                    },
+                    'type': {
+                        'oneOf': [
+                            {'type': 'string'},
+                            {'type': 'array',
+                             'items': {'type': 'string'}}],
+                    },
+                },
+            },
+        },
+    },
+}
+
+
+#: Full schema with metadata
+schema = {
+    '$schema': 'http://json-schema.org/schema#',
+    'title': 'Spack package dependency file schema',
+    'type': 'object',
+    'additionalProperties': False,
+    'properties': properties,
+}

--- a/lib/spack/spack/schema/package_versions.py
+++ b/lib/spack/spack/schema/package_versions.py
@@ -1,0 +1,40 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""Schema for versions.yaml package version files.
+
+"""
+
+
+#: Properties for inclusion in other schemas
+properties = {
+    'versions': {
+        'type': 'object',
+        'default': {},
+        'additionalProperties': False,
+        'patternProperties': {
+            r'\w[\w-]*': {  # version spec
+                'type': 'object',
+                'default': {},
+                'additionalProperties': True,
+                'properties': {
+                    'checksum': {
+                        'type': 'string',
+                    },
+                },
+            },
+        },
+    },
+}
+
+
+#: Full schema with metadata
+schema = {
+    '$schema': 'http://json-schema.org/schema#',
+    'title': 'Spack package versions file schema',
+    'type': 'object',
+    'additionalProperties': False,
+    'properties': properties,
+}


### PR DESCRIPTION
## What is it

- Adds the `dependency_file` directive so that a package's dependencies can be defined in an external yaml file of the form

  ```yaml
  dependencies:
    <spec>:
      when: ...
      type: ...
      patches: ...
  ```
   
- Adds the `versions_file` directive so that a package's versions can be defined in an external yaml file of the form
  ```yaml
  versions:
    <ver>:
      checksum: ...
      <additional properties>
  ```

In both cases, the external file must be defined relative to the package's `package.py` file.

## Why?

As a package's dependency list grows with new package versions, dependency versions, variants, etc., the `package.py` file can become cluttered with `versions` and `depends_on` directives.  Putting the directives in a file cleans up `package.py` and puts the dependencies in a nice, human readable, and version controllable form.

## What's next

I have not added tests, documentation, examples, etc.  If this feature will be useful and the PR has a chance of being merged, I will add any additional items necessary.