### PR TITLE
Added "file" package and added missing depenency to VIM

### DIFF
--- a/var/spack/repos/builtin/packages/file/package.py
+++ b/var/spack/repos/builtin/packages/file/package.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack import *
+
+
+class File(AutotoolsPackage):
+    """The file command is "a file type guesser", that is, a command-line
+    tool that tells you in words what kind of data a file contains"""
+
+    homepage = "http://www.darwinsys.com/file/"
+    url      = "https://astron.com/pub/file/file-5.37.tar.gz"
+
+    version('5.37', sha256='e9c13967f7dd339a3c241b7710ba093560b9a33013491318e88e6b8b57bae07f')

--- a/var/spack/repos/builtin/packages/gmake/package.py
+++ b/var/spack/repos/builtin/packages/gmake/package.py
@@ -22,6 +22,8 @@ class Gmake(AutotoolsPackage):
     depends_on('gettext', when='+nls')
     depends_on('guile', when='+guile')
 
+    depends_on('texinfo', type='build')
+
     build_directory = 'spack-build'
 
     patch('https://src.fedoraproject.org/rpms/make/raw/519a7c5bcbead22e6ea2d2c2341d981ef9e25c0d/f/make-4.2.1-glob-fix-2.patch', level=1, sha256='fe5b60d091c33f169740df8cb718bf4259f84528b42435194ffe0dd5b79cd125', when='@4.2.1')

--- a/var/spack/repos/builtin/packages/grep/package.py
+++ b/var/spack/repos/builtin/packages/grep/package.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack import *
+
+
+class Grep(AutotoolsPackage):
+    """Grep searches one or more input files for lines containing a match to
+    a specified pattern"""
+
+    homepage = "https://www.gnu.org/software/grep/"
+    url      = "https://ftp.gnu.org/gnu/grep/grep-3.3.tar.xz"
+
+    version('3.3', sha256='b960541c499619efd6afe1fa795402e4733c8e11ebf9fafccc0bb4bccdc5b514')

--- a/var/spack/repos/builtin/packages/gzip/package.py
+++ b/var/spack/repos/builtin/packages/gzip/package.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack import *
+
+
+class Gzip(AutotoolsPackage):
+    """GNU Gzip is a popular data compression program originally written by
+    Jean-loup Gailly for the GNU project."""
+
+    homepage = "https://www.gnu.org/software/gzip/"
+    url      = "https://ftp.gnu.org/gnu/gzip/gzip-1.10.tar.gz"
+
+    version('1.10', sha256='c91f74430bf7bc20402e1f657d0b252cb80aa66ba333a25704512af346633c68')

--- a/var/spack/repos/builtin/packages/vim/package.py
+++ b/var/spack/repos/builtin/packages/vim/package.py
@@ -57,6 +57,7 @@ class Vim(AutotoolsPackage):
     depends_on('libxtst', when="+x")
 
     depends_on('ncurses', when="@7.4:")
+    depends_on('findutils', type='build')
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/which/package.py
+++ b/var/spack/repos/builtin/packages/which/package.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack import *
+
+
+class Which(AutotoolsPackage):
+    """GNU which - is a utility that is used to find which executable (or
+    alias or shell function) is executed when entered on the shell prompt."""
+
+    homepage = "https://savannah.gnu.org/projects/which/"
+    url      = "https://ftp.gnu.org/gnu/which/which-2.21.tar.gz"
+
+    version('2.21', sha256='f4a245b94124b377d8b49646bf421f9155d36aa7614b6ebf83705d3ffc76eaad')


### PR DESCRIPTION
Installing `vim` in `registry.access.redhat.com/ubi8/ubi-minimal` container had configure error because the image did not have `file`.

**Edit: Added GNU `which` and `grep`