### PR TITLE
update to add ascent 0.5.0 release

### DIFF
--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -79,7 +79,7 @@ class Ascent(Package, CudaPackage):
 
     # use cmake 3.14, newest that provides proper cuda support
     # and we have seen errors with cuda in 3.15
-    depends_on("cmake@3.14.1:3.14.5")
+    depends_on("cmake@3.14.1:3.14.99")
     depends_on("conduit~python", when="~python")
     depends_on("conduit+python", when="+python+shared")
     depends_on("conduit~shared~python", when="~shared")

--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -28,7 +28,7 @@ def cmake_cache_entry(name, value, vtype=None):
     return 'set({0} "{1}" CACHE {2} "")\n\n'.format(name, value, vtype)
 
 
-class Ascent(Package):
+class Ascent(Package, CudaPackage):
     """Ascent is an open source many-core capable lightweight in situ
     visualization and analysis infrastructure for multi-physics HPC
     simulations."""
@@ -40,7 +40,8 @@ class Ascent(Package):
 
     version('develop',
             branch='develop',
-            submodules=True)
+            submodules=True,
+            preferred=True)
 
     ###########################################################################
     # package variants
@@ -50,6 +51,7 @@ class Ascent(Package):
     variant('test', default=True, description='Enable Ascent unit tests')
 
     variant("mpi", default=True, description="Build Ascent MPI Support")
+    variant("serial", default=True, description="build serial (non-mpi) libraries")
 
     # variants for language support
     variant("python", default=True, description="Build Ascent Python support")
@@ -72,10 +74,13 @@ class Ascent(Package):
     # package dependencies
     ###########################################################################
 
-    depends_on("cmake@3.14:", type='build')
+    depends_on("cmake@3.14.1:")
     depends_on("conduit~python", when="~python")
     depends_on("conduit+python", when="+python+shared")
     depends_on("conduit~shared~python", when="~shared")
+    depends_on("conduit~python~mpi", when="~python~mpi")
+    depends_on("conduit+python~mpi", when="+python+shared~mpi")
+    depends_on("conduit~shared~python~mpi", when="~shared~mpi")
 
     #######################
     # Python
@@ -85,6 +90,7 @@ class Ascent(Package):
     depends_on("python+shared", when="+python+shared")
     extends("python", when="+python+shared")
     depends_on("py-numpy", when="+python+shared", type=('build', 'run'))
+    depends_on("py-pip", when="+python+shared", type=('build', 'run'))
 
     #######################
     # MPI
@@ -96,24 +102,23 @@ class Ascent(Package):
     # TPLs for Runtime Features
     #############################
 
-    depends_on("vtk-m", when="+vtkh")
+    # ascent depends on pinned `ascent_ver` of vtk-h
+    depends_on("vtk-h@ascent_ver",             when="+vtkh")
+    depends_on("vtk-h@ascent_ver~openmp",      when="+vtkh~openmp")
+    depends_on("vtk-h@ascent_ver+cuda+openmp", when="+vtkh+cuda+openmp")
+    depends_on("vtk-h@ascent_ver+cuda~openmp", when="+vtkh+cuda~openmp")
 
-    depends_on("vtk-h@develop",             when="+vtkh")
-    depends_on("vtk-h@develop~openmp",      when="+vtkh~openmp")
-    depends_on("vtk-h@develop+cuda+openmp", when="+vtkh+cuda+openmp")
-    depends_on("vtk-h@develop+cuda~openmp", when="+vtkh+cuda~openmp")
-
-    depends_on("vtk-h@develop~shared",             when="~shared+vtkh")
-    depends_on("vtk-h@develop~shared~openmp",      when="~shared+vtkh~openmp")
-    depends_on("vtk-h@develop~shared+cuda",        when="~shared+vtkh+cuda")
-    depends_on("vtk-h@develop~shared+cuda~openmp", when="~shared+vtkh+cuda~openmp")
+    depends_on("vtk-h@ascent_ver~shared",             when="~shared+vtkh")
+    depends_on("vtk-h@ascent_ver~shared~openmp",      when="~shared+vtkh~openmp")
+    depends_on("vtk-h@ascent_ver~shared+cuda",        when="~shared+vtkh+cuda")
+    depends_on("vtk-h@ascent_ver~shared+cuda~openmp", when="~shared+vtkh+cuda~openmp")
 
     # mfem
-    depends_on("mfem+shared+mpi+conduit", when="+shared+mfem+mpi")
-    depends_on("mfem~shared+mpi+conduit", when="~shared+mfem+mpi")
+    depends_on("mfem+threadsafe+shared+mpi+conduit", when="+shared+mfem+mpi")
+    depends_on("mfem+threadsafe~shared+mpi+conduit", when="~shared+mfem+mpi")
 
-    depends_on("mfem+shared~mpi+conduit", when="+shared+mfem~mpi")
-    depends_on("mfem~shared~mpi+conduit", when="~shared+mfem~mpi")
+    depends_on("mfem+threadsafe+shared~mpi+conduit", when="+shared+mfem~mpi")
+    depends_on("mfem+threadsafe~shared~mpi+conduit", when="~shared+mfem~mpi")
 
     depends_on("adios", when="+adios")
 
@@ -229,7 +234,7 @@ class Ascent(Package):
 
         if self.compiler.fc:
             # even if this is set, it may not exist so do one more sanity check
-            f_compiler = which(env["SPACK_FC"])
+            f_compiler = env["SPACK_FC"]
 
         #######################################################################
         # By directly fetching the names of the actual compilers we appear
@@ -285,7 +290,7 @@ class Ascent(Package):
         if "+fortran" in spec and f_compiler is not None:
             cfg.write(cmake_cache_entry("ENABLE_FORTRAN", "ON"))
             cfg.write(cmake_cache_entry("CMAKE_Fortran_COMPILER",
-                                        f_compiler.path))
+                                        f_compiler))
         else:
             cfg.write("# no fortran compiler found\n\n")
             cfg.write(cmake_cache_entry("ENABLE_FORTRAN", "OFF"))
@@ -347,6 +352,15 @@ class Ascent(Package):
             cfg.write(cmake_cache_entry("SPHINX_EXECUTABLE", sphinx_build_exe))
         else:
             cfg.write(cmake_cache_entry("ENABLE_DOCS", "OFF"))
+
+        #######################
+        # Serial
+        #######################
+
+        if "+serial" in spec:
+            cfg.write(cmake_cache_entry("ENABLE_SERIAL", "ON"))
+        else:
+            cfg.write(cmake_cache_entry("ENABLE_SERIAL", "OFF"))
 
         #######################
         # MPI
@@ -411,6 +425,13 @@ class Ascent(Package):
 
             cfg.write("# vtk-h from spack\n")
             cfg.write(cmake_cache_entry("VTKH_DIR", spec['vtk-h'].prefix))
+
+            if "+cuda" in spec:
+                cfg.write(cmake_cache_entry("VTKm_ENABLE_CUDA", "ON"))
+                cfg.write(cmake_cache_entry("CMAKE_CUDA_HOST_COMPILER",
+                          ''.format(env["SPACK_CXX"])))
+            else:
+                cfg.write(cmake_cache_entry("VTKm_ENABLE_CUDA", "OFF"))
 
         else:
             cfg.write("# vtk-h not built by spack \n")

--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -74,7 +74,9 @@ class Ascent(Package, CudaPackage):
     # package dependencies
     ###########################################################################
 
-    depends_on("cmake@3.14.1:")
+    # use cmake 3.14, newest that provides proper cuda support
+    # and we have seen errors with cuda in 3.15
+    depends_on("cmake@3.14.1:3.14.5")
     depends_on("conduit~python", when="~python")
     depends_on("conduit+python", when="+python+shared")
     depends_on("conduit~shared~python", when="~shared")

--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -104,17 +104,15 @@ class Ascent(Package, CudaPackage):
     # TPLs for Runtime Features
     #############################
 
-    # todo:
-    # ascent depends on pinned `ascent_ver` of vtk-h
-    depends_on("vtk-h@develop",             when="+vtkh")
-    depends_on("vtk-h@develop~openmp",      when="+vtkh~openmp")
-    depends_on("vtk-h@develop+cuda+openmp", when="+vtkh+cuda+openmp")
-    depends_on("vtk-h@develop+cuda~openmp", when="+vtkh+cuda~openmp")
+    depends_on("vtk-h@0.5.0",             when="+vtkh")
+    depends_on("vtk-h@0.5.0~openmp",      when="+vtkh~openmp")
+    depends_on("vtk-h@0.5.0+cuda+openmp", when="+vtkh+cuda+openmp")
+    depends_on("vtk-h@0.5.0+cuda~openmp", when="+vtkh+cuda~openmp")
 
-    depends_on("vtk-h@develop~shared",             when="~shared+vtkh")
-    depends_on("vtk-h@develop~shared~openmp",      when="~shared+vtkh~openmp")
-    depends_on("vtk-h@develop~shared+cuda",        when="~shared+vtkh+cuda")
-    depends_on("vtk-h@develop~shared+cuda~openmp", when="~shared+vtkh+cuda~openmp")
+    depends_on("vtk-h@0.5.0~shared",             when="~shared+vtkh")
+    depends_on("vtk-h@0.5.0~shared~openmp",      when="~shared+vtkh~openmp")
+    depends_on("vtk-h@0.5.0~shared+cuda",        when="~shared+vtkh+cuda")
+    depends_on("vtk-h@0.5.0~shared+cuda~openmp", when="~shared+vtkh+cuda~openmp")
 
     # mfem
     depends_on("mfem+threadsafe+shared+mpi+conduit", when="+shared+mfem+mpi")

--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -41,7 +41,8 @@ class Ascent(Package, CudaPackage):
 
     version('develop',
             branch='develop',
-            submodules=True)
+            submodules=True,
+            prefered=True)
 
     version('0.5.0', sha256='2837b7371db3ac1bcc31a479d7cf0eb62a503cacadfa4187061502b3c4a89fa0')
 

--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -129,6 +129,7 @@ class Ascent(Package, CudaPackage):
     # Documentation related
     #######################
     depends_on("py-sphinx", when="+python+doc", type='build')
+    depends_on("py-sphinx-rtd-theme", when="+python+doc", type='build')
 
     def setup_build_environment(self, env):
         env.set('CTEST_OUTPUT_ON_FAILURE', '1')

--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -35,6 +35,7 @@ class Ascent(Package, CudaPackage):
 
     homepage = "https://github.com/Alpine-DAV/ascent"
     git      = "https://github.com/Alpine-DAV/ascent.git"
+    url      = "https://github.com/Alpine-DAV/ascent/releases/download/v0.5.0/ascent-v0.5.0-src-with-blt.tar.gz"
 
     maintainers = ['cyrush']
 
@@ -42,6 +43,8 @@ class Ascent(Package, CudaPackage):
             branch='develop',
             submodules=True,
             preferred=True)
+
+    version('0.5.0', sha256='e26df83d9e0b3b2ac3c56319707134f1cf7c7c5245627b944d26e1b6b636b7dc')
 
     ###########################################################################
     # package variants

--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -41,8 +41,7 @@ class Ascent(Package, CudaPackage):
 
     version('develop',
             branch='develop',
-            submodules=True,
-            prefered=True)
+            submodules=True)
 
     version('0.5.0', sha256='2837b7371db3ac1bcc31a479d7cf0eb62a503cacadfa4187061502b3c4a89fa0')
 

--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -41,10 +41,9 @@ class Ascent(Package, CudaPackage):
 
     version('develop',
             branch='develop',
-            submodules=True,
-            preferred=True)
+            submodules=True)
 
-    version('0.5.0', sha256='e26df83d9e0b3b2ac3c56319707134f1cf7c7c5245627b944d26e1b6b636b7dc')
+    version('0.5.0', sha256='2837b7371db3ac1bcc31a479d7cf0eb62a503cacadfa4187061502b3c4a89fa0')
 
     ###########################################################################
     # package variants
@@ -79,7 +78,7 @@ class Ascent(Package, CudaPackage):
 
     # use cmake 3.14, newest that provides proper cuda support
     # and we have seen errors with cuda in 3.15
-    depends_on("cmake@3.14.1:3.14.99")
+    depends_on("cmake@3.14.1:3.14.99", type='build')
     depends_on("conduit~python", when="~python")
     depends_on("conduit+python", when="+python+shared")
     depends_on("conduit~shared~python", when="~shared")
@@ -434,7 +433,7 @@ class Ascent(Package, CudaPackage):
             if "+cuda" in spec:
                 cfg.write(cmake_cache_entry("VTKm_ENABLE_CUDA", "ON"))
                 cfg.write(cmake_cache_entry("CMAKE_CUDA_HOST_COMPILER",
-                          ''.format(env["SPACK_CXX"])))
+                          env["SPACK_CXX"]))
             else:
                 cfg.write(cmake_cache_entry("VTKm_ENABLE_CUDA", "OFF"))
 

--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -102,16 +102,17 @@ class Ascent(Package, CudaPackage):
     # TPLs for Runtime Features
     #############################
 
+    # todo:
     # ascent depends on pinned `ascent_ver` of vtk-h
-    depends_on("vtk-h@ascent_ver",             when="+vtkh")
-    depends_on("vtk-h@ascent_ver~openmp",      when="+vtkh~openmp")
-    depends_on("vtk-h@ascent_ver+cuda+openmp", when="+vtkh+cuda+openmp")
-    depends_on("vtk-h@ascent_ver+cuda~openmp", when="+vtkh+cuda~openmp")
+    depends_on("vtk-h@develop",             when="+vtkh")
+    depends_on("vtk-h@develop~openmp",      when="+vtkh~openmp")
+    depends_on("vtk-h@develop+cuda+openmp", when="+vtkh+cuda+openmp")
+    depends_on("vtk-h@develop+cuda~openmp", when="+vtkh+cuda~openmp")
 
-    depends_on("vtk-h@ascent_ver~shared",             when="~shared+vtkh")
-    depends_on("vtk-h@ascent_ver~shared~openmp",      when="~shared+vtkh~openmp")
-    depends_on("vtk-h@ascent_ver~shared+cuda",        when="~shared+vtkh+cuda")
-    depends_on("vtk-h@ascent_ver~shared+cuda~openmp", when="~shared+vtkh+cuda~openmp")
+    depends_on("vtk-h@develop~shared",             when="~shared+vtkh")
+    depends_on("vtk-h@develop~shared~openmp",      when="~shared+vtkh~openmp")
+    depends_on("vtk-h@develop~shared+cuda",        when="~shared+vtkh+cuda")
+    depends_on("vtk-h@develop~shared+cuda~openmp", when="~shared+vtkh+cuda~openmp")
 
     # mfem
     depends_on("mfem+threadsafe+shared+mpi+conduit", when="+shared+mfem+mpi")

--- a/var/spack/repos/builtin/packages/conduit/package.py
+++ b/var/spack/repos/builtin/packages/conduit/package.py
@@ -68,7 +68,7 @@ class Conduit(Package):
     variant("adios", default=False, description="Build Conduit ADIOS support")
 
     # zfp compression
-    variant("zfp", default=True, description="Build Conduit ZFP support")
+    variant("zfp", default=False, description="Build Conduit ZFP support")
 
     # variants for dev-tools (docs, etc)
     variant("doc", default=False, description="Build Conduit's documentation")

--- a/var/spack/repos/builtin/packages/metis/package.py
+++ b/var/spack/repos/builtin/packages/metis/package.py
@@ -17,13 +17,15 @@ class Metis(Package):
        multilevel recursive-bisection, multilevel k-way, and multi-constraint
        partitioning schemes."""
 
-    homepage = "http://glaros.dtc.umn.edu/gkhome/metis/metis/overview"
+    #
+    # the previous metis website http://glaros.dtc.umn.edu/gkhome/metis/metis
+    # no longer exists. This is a github mirror that provides metis 5.1.0
+    #
+
+    homepage = "https://github.com/scivision/METIS/"
     url      = "https://github.com/scivision/METIS/raw/master/metis-5.1.0.tar.gz"
-    list_url = "http://glaros.dtc.umn.edu/gkhome/fsroot/sw/metis/OLD"
 
     version('5.1.0', sha256='76faebe03f6c963127dbb73c13eab58c9a3faeae48779f049066a21c087c5db2')
-    version('5.0.2', sha256='f79790676ca2ce3dfa9d5e2d74801e91d92415664ede2c2fc18fc49d4a161981')
-    version('4.0.3', sha256='5efa35de80703c1b2c4d0de080fafbcf4e0d363a21149a1ad2f96e0144841a55')
 
     variant('shared', default=True, description='Enables the build of shared libraries.')
     variant('gdb', default=False, description='Enables gdb support (version 5+).')
@@ -49,13 +51,6 @@ class Metis(Package):
 
     patch('install_gklib_defs_rename.patch', when='@5:')
     patch('gklib_nomisleadingindentation_warning.patch', when='@5: %gcc@6:')
-
-    def url_for_version(self, version):
-        url = "http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis"
-        if version < Version('4.0.3'):
-            url += "/OLD"
-        url += "/metis-{0}.tar.gz".format(version)
-        return url
 
     @when('@5:')
     def patch(self):

--- a/var/spack/repos/builtin/packages/metis/package.py
+++ b/var/spack/repos/builtin/packages/metis/package.py
@@ -18,7 +18,7 @@ class Metis(Package):
        partitioning schemes."""
 
     homepage = "http://glaros.dtc.umn.edu/gkhome/metis/metis/overview"
-    url      = "http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/metis-5.1.0.tar.gz"
+    url      = "https://github.com/scivision/METIS/raw/master/metis-5.1.0.tar.gz"
     list_url = "http://glaros.dtc.umn.edu/gkhome/fsroot/sw/metis/OLD"
 
     version('5.1.0', sha256='76faebe03f6c963127dbb73c13eab58c9a3faeae48779f049066a21c087c5db2')

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -464,8 +464,8 @@ class Mfem(Package):
             conduit_include_path = join_path(conduit.prefix.include,
                                              "conduit")
             # add this path to the found flags
-            conduit_opt_flags = "-I{} {}".format(conduit_include_path,
-                                                 headers.cpp_flags)
+            conduit_opt_flags = "-I{0} {1}".format(conduit_include_path,
+                                                   headers.cpp_flags)
 
             options += [
                 'CONDUIT_OPT=%s' % conduit_opt_flags,

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -428,10 +428,39 @@ class Mfem(Package):
 
         if '+conduit' in spec:
             conduit = spec['conduit']
-            headers = HeaderList(find(join_path(conduit.prefix.include,
-                                                "conduit"),
-                                      'conduit.hpp',
+            ##################
+            # cyrush note:
+            ##################
+            # spack's HeaderList is applying too much magic, undermining us:
+            #
+            #  It applies a regex to strip back to the last "include" dir
+            #  in the path. In our case we want to pass:
+            #
+            #    <install_path>/include/conduit
+            #
+            # To be passed w/ -I as part cpp_flags, the regex always kills
+            # the trailing conduit dir, breaking the path.
+            #
+            # We need control to add the actual path.
+            #
+            # The only way I found to make this work is by initing and
+            # adding to headers._directories, which seems evil. But sometimes
+            # evil must be deployed to fight evil regexs.
+            #
+            # Note: I also tried adding to headers.files and
+            # headers.directories, but those don't work for various reasons.
+            # For example headers.directories is property.
+            ##################
+
+            # build headers object
+            headers = HeaderList(find(conduit.prefix.include, 'conduit.hpp',
                                       recursive=True))
+            # construct proper path
+            conduit_include_path = join_path(conduit.prefix.include,
+                                             "conduit")
+            # inject proper path
+            headers._directories = []
+            headers._directories.append(conduit_include_path)
             conduit_libs = ['libconduit', 'libconduit_relay',
                             'libconduit_blueprint']
             libs = find_libraries(conduit_libs, conduit.prefix.lib,

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -461,8 +461,7 @@ class Mfem(Package):
             ##################
 
             # construct proper include path
-            conduit_include_path = join_path(conduit.prefix.include,
-                                             "conduit")
+            conduit_include_path = conduit.prefix.include.conduit
             # add this path to the found flags
             conduit_opt_flags = "-I{0} {1}".format(conduit_include_path,
                                                    headers.cpp_flags)

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -428,7 +428,9 @@ class Mfem(Package):
 
         if '+conduit' in spec:
             conduit = spec['conduit']
-            headers = HeaderList(find(conduit.prefix.include, 'conduit.hpp',
+            headers = HeaderList(find(join_path(conduit.prefix.include,
+                                                "conduit"),
+                                      'conduit.hpp',
                                       recursive=True))
             conduit_libs = ['libconduit', 'libconduit_relay',
                             'libconduit_blueprint']

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -428,18 +428,7 @@ class Mfem(Package):
 
         if '+conduit' in spec:
             conduit = spec['conduit']
-            ##################
-            # cyrush note:
-            ##################
-            # spack's HeaderList is applying too much magic, undermining us:
-            #
-            #  It applies a regex to strip back to the last "include" dir
-            #  in the path. In our case we want to pass:
-            #
-            #    <install_path>/include/conduit
-            #
-            # To be passed w/ -I as part cpp_flags, the regex always kills
-            # the trailing conduit dir, breaking the path.
+
             #
             # We need control to add the actual path.
             #
@@ -455,9 +444,6 @@ class Mfem(Package):
             # build headers object
             headers = HeaderList(find(conduit.prefix.include, 'conduit.hpp',
                                       recursive=True))
-            # construct proper path
-            conduit_include_path = join_path(conduit.prefix.include,
-                                             "conduit")
             # inject proper path
             headers._directories = []
             headers._directories.append(conduit_include_path)
@@ -470,8 +456,36 @@ class Mfem(Package):
                 hdf5 = conduit['hdf5']
                 headers += find_headers('hdf5', hdf5.prefix.include)
                 libs += hdf5.libs
+
+            ##################
+            # cyrush note:
+            ##################
+            # spack's HeaderList is applying too much magic, undermining us:
+            #
+            #  It applies a regex to strip back to the last "include" dir
+            #  in the path. In our case we need to pass the following
+            #  as part of the CONDUIT_OPT flags:
+            #
+            #    -I<install_path>/include/conduit
+            #
+            #  I tried several ways to present this path to the HeaderList,
+            #  but the regex always kills the trailing conduit dir
+            #  breaking build.
+            #
+            #  To resolve the issue, we simply join our own string with
+            #  the headers results (which are important b/c they handle
+            #  hdf5 paths when enabled).
+            ##################
+
+            # construct proper include path
+            conduit_include_path = join_path(conduit.prefix.include,
+                                             "conduit")
+            # add this path to the found flags
+            conduit_opt_flags = "-I{} {}".format(conduit_include_path,
+                                                 headers.cpp_flags)
+
             options += [
-                'CONDUIT_OPT=%s' % headers.cpp_flags,
+                'CONDUIT_OPT=%s' % conduit_opt_flags,
                 'CONDUIT_LIB=%s' % ld_flags_from_library_list(libs)]
 
         make('config', *options, parallel=False)

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -428,25 +428,8 @@ class Mfem(Package):
 
         if '+conduit' in spec:
             conduit = spec['conduit']
-
-            #
-            # We need control to add the actual path.
-            #
-            # The only way I found to make this work is by initing and
-            # adding to headers._directories, which seems evil. But sometimes
-            # evil must be deployed to fight evil regexs.
-            #
-            # Note: I also tried adding to headers.files and
-            # headers.directories, but those don't work for various reasons.
-            # For example headers.directories is property.
-            ##################
-
-            # build headers object
             headers = HeaderList(find(conduit.prefix.include, 'conduit.hpp',
                                       recursive=True))
-            # inject proper path
-            headers._directories = []
-            headers._directories.append(conduit_include_path)
             conduit_libs = ['libconduit', 'libconduit_relay',
                             'libconduit_blueprint']
             libs = find_libraries(conduit_libs, conduit.prefix.lib,

--- a/var/spack/repos/builtin/packages/vtk-h/package.py
+++ b/var/spack/repos/builtin/packages/vtk-h/package.py
@@ -38,10 +38,6 @@ class VtkH(Package, CudaPackage):
 
     maintainers = ['cyrush']
 
-    #version('ascent_ver', commit='f67aef0b9aef7ed999cb3d3e687b837a7671be03',
-    #        submodules=True,
-    #        preferred=True)
-
     version('develop', branch='develop', submodules=True)
 
     variant("shared", default=True, description="Build vtk-h as shared libs")

--- a/var/spack/repos/builtin/packages/vtk-h/package.py
+++ b/var/spack/repos/builtin/packages/vtk-h/package.py
@@ -34,11 +34,13 @@ class VtkH(Package, CudaPackage):
     and DIY2 to provide a toolkit with hybrid parallel capabilities."""
 
     homepage = "https://github.com/Alpine-DAV/vtk-h"
+    url      = "https://github.com/Alpine-DAV/vtk-h/releases/download/v0.5.0/vtkh-v0.5.0.tar.gz"
     git      = "https://github.com/Alpine-DAV/vtk-h.git"
 
     maintainers = ['cyrush']
 
     version('develop', branch='develop', submodules=True)
+    version('0.5.0', sha256="9014a8a61a8d7ff636866c6e3b1ebb918ff23fa67cf8d4de801c4a2981de8c96")
 
     variant("shared", default=True, description="Build vtk-h as shared libs")
     variant("mpi", default=True, description="build mpi support")

--- a/var/spack/repos/builtin/packages/vtk-h/package.py
+++ b/var/spack/repos/builtin/packages/vtk-h/package.py
@@ -51,7 +51,7 @@ class VtkH(Package, CudaPackage):
 
     # use cmake 3.14, newest that provides proper cuda support
     # and we have seen errors with cuda in 3.15
-    depends_on("cmake@3.14.1:3.14.5")
+    depends_on("cmake@3.14.1:3.14.99")
 
     depends_on("mpi", when="+mpi")
     depends_on("cuda", when="+cuda")

--- a/var/spack/repos/builtin/packages/vtk-h/package.py
+++ b/var/spack/repos/builtin/packages/vtk-h/package.py
@@ -47,7 +47,9 @@ class VtkH(Package, CudaPackage):
     variant("openmp", default=(sys.platform != 'darwin'),
             description="build openmp support")
 
-    depends_on("cmake@3.14.1:")
+    # use cmake 3.14, newest that provides proper cuda support
+    # and we have seen errors with cuda in 3.15
+    depends_on("cmake@3.14.1:3.14.5")
 
     depends_on("mpi", when="+mpi")
     depends_on("cuda", when="+cuda")

--- a/var/spack/repos/builtin/packages/vtk-h/package.py
+++ b/var/spack/repos/builtin/packages/vtk-h/package.py
@@ -51,7 +51,7 @@ class VtkH(Package, CudaPackage):
 
     # use cmake 3.14, newest that provides proper cuda support
     # and we have seen errors with cuda in 3.15
-    depends_on("cmake@3.14.1:3.14.99")
+    depends_on("cmake@3.14.1:3.14.99", type='build')
 
     depends_on("mpi", when="+mpi")
     depends_on("cuda", when="+cuda")

--- a/var/spack/repos/builtin/packages/vtk-h/package.py
+++ b/var/spack/repos/builtin/packages/vtk-h/package.py
@@ -38,9 +38,9 @@ class VtkH(Package, CudaPackage):
 
     maintainers = ['cyrush']
 
-    version('ascent_ver', commit='f67aef0b9aef7ed999cb3d3e687b837a7671be03',
-            submodules=True,
-            preferred=True)
+    #version('ascent_ver', commit='f67aef0b9aef7ed999cb3d3e687b837a7671be03',
+    #        submodules=True,
+    #        preferred=True)
 
     version('develop', branch='develop', submodules=True)
 

--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -22,11 +22,11 @@ class VtkM(CMakePackage, CudaPackage):
     git      = "https://gitlab.kitware.com/vtk/vtk-m.git"
 
     version('master', branch='master')
-    version('1.5.0', sha256="cd38957bb552e28b5197e4f738d5bb0b2c6f4025c3e17a66c8b19ee501273fbe")
-    version('1.4.0', sha256="8d83cca7cd5e204d10da151ce4f1846c1f7414c7c1e579173d15c5ea0631555a")
-    version('1.3.0', sha256="f88c1b0a1980f695240eeed9bcccfa420cc089e631dc2917c9728a2eb906df2e")
-    version('1.2.0', sha256="607272992e05f8398d196f0acdcb4af025a4a96cd4f66614c6341f31d4561763")
-    version('1.1.0', sha256="78618c81ca741b1fbba0853cb5d7af12c51973b514c268fc96dfb36b853cdb18")
+    version('1.5.0', sha256="b1b13715c7fcc8d17f5c7166ff5b3e9025f6865dc33eb9b06a63471c21349aa8")
+    version('1.4.0', sha256="60e1ce73a8c6beda8aed5f2d3ae670b6b0c78c068c6eff4ece769e6d719d5065")
+    version('1.3.0', sha256="72c2c8525a77a456fe0b6a1af0328dad6b9a688f402a3d3ebfa8942e0b5dba1a")
+    version('1.2.0', sha256="9103d954284661f6f03e5b18be6d7bc94254603e6abc8fce67f617f4ad325a0e")
+    version('1.1.0', sha256="a1746b1547d6fb901ea7d7ed50834e8832d6d41ddd497c84d02e1481100d43bc")
 
     # use release, instead of release with debug symbols b/c vtkm libs
     # can overwhelm compilers with too many symbols

--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -23,10 +23,10 @@ class VtkM(CMakePackage, CudaPackage):
 
     version('master', branch='master')
     version('1.5.0', sha256="b1b13715c7fcc8d17f5c7166ff5b3e9025f6865dc33eb9b06a63471c21349aa8")
-    version('1.4.0', sha256="60e1ce73a8c6beda8aed5f2d3ae670b6b0c78c068c6eff4ece769e6d719d5065")
-    version('1.3.0', sha256="72c2c8525a77a456fe0b6a1af0328dad6b9a688f402a3d3ebfa8942e0b5dba1a")
-    version('1.2.0', sha256="9103d954284661f6f03e5b18be6d7bc94254603e6abc8fce67f617f4ad325a0e")
-    version('1.1.0', sha256="a1746b1547d6fb901ea7d7ed50834e8832d6d41ddd497c84d02e1481100d43bc")
+    version('1.4.0', sha256="8d83cca7cd5e204d10da151ce4f1846c1f7414c7c1e579173d15c5ea0631555a")
+    version('1.3.0', sha256="f88c1b0a1980f695240eeed9bcccfa420cc089e631dc2917c9728a2eb906df2e")
+    version('1.2.0', sha256="607272992e05f8398d196f0acdcb4af025a4a96cd4f66614c6341f31d4561763")
+    version('1.1.0', sha256="78618c81ca741b1fbba0853cb5d7af12c51973b514c268fc96dfb36b853cdb18")
 
     # use release, instead of release with debug symbols b/c vtkm libs
     # can overwhelm compilers with too many symbols
@@ -99,8 +99,7 @@ class VtkM(CMakePackage, CudaPackage):
 
             # logging support
             if "+logging" in spec:
-                if spec.satisfies('@:1.2.0') and \
-                        spec['vtk-m'].version.string != 'master':
+                if spec.satisfies('@:1.2.0'):
                     raise InstallError('logging is not supported for\
                             vtkm version lower than 1.3')
                 options.append("-DVTKm_ENABLE_LOGGING:BOOL=ON")
@@ -109,8 +108,7 @@ class VtkM(CMakePackage, CudaPackage):
 
             # mpi support
             if "+mpi" in spec:
-                if spec.satisfies('@:1.2.0') and \
-                        spec['vtk-m'].version.string != 'master':
+                if spec.satisfies('@:1.2.0'):
                     raise InstallError('mpi is not supported for\
                             vtkm version lower than 1.3')
                 options.append("-DVTKm_ENABLE_MPI:BOOL=ON")
@@ -120,8 +118,7 @@ class VtkM(CMakePackage, CudaPackage):
             # openmp support
             if "+openmp" in spec:
                 # openmp is added since version 1.3.0
-                if spec.satisfies('@:1.2.0') and \
-                        spec['vtk-m'].version.string != 'master':
+                if spec.satisfies('@:1.2.0'):
                     raise InstallError('OpenMP is not supported for\
                             vtkm version lower than 1.3')
                 options.append("-DVTKm_ENABLE_OPENMP:BOOL=ON")


### PR DESCRIPTION
update ascent, vtk-h, and vtkm to new releases. 
changes zfp variant default for conduit to false

Also includes fixes to metis download and flags passed to the mfem for conduit
