### PR TITLE
Binary packaging: correct relative symlinks

### DIFF
--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -502,11 +502,11 @@ def make_link_relative(cur_path_names, orig_path_names):
     Change absolute links to be relative.
     """
     for cur_path, orig_path in zip(cur_path_names, orig_path_names):
-        old_src = os.readlink(orig_path)
-        new_src = os.path.relpath(old_src, orig_path)
+        target = os.readlink(orig_path)
+        relative_target = os.path.relpath(target, os.path.dirname(orig_path))
 
         os.unlink(cur_path)
-        os.symlink(new_src, cur_path)
+        os.symlink(relative_target, cur_path)
 
 
 def make_macho_binaries_relative(cur_path_names, orig_path_names, old_dir,


### PR DESCRIPTION
@becker33 

Something I missed when reviewing https://github.com/spack/spack/pull/10073

`relocate.make_link_relative` was resolving a path relative to a complete file path when in fact `os.path.relpath` expects a directory. The result was that the relative path was always "off" by one directory in the sense that it always added an extra initial `../` to the path.

This determines the link target relative path relative to the link directory rather than relative to the full link path (which includes the file name).