### PR TITLE
py-matplotlib only needs backports when ^python@:2

### DIFF
--- a/var/spack/repos/builtin/packages/py-enum34/package.py
+++ b/var/spack/repos/builtin/packages/py-enum34/package.py
@@ -15,6 +15,5 @@ class PyEnum34(PythonPackage):
     version('1.1.6', sha256='8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1')
 
     depends_on('python')
-    conflicts('python@3.4:')
     depends_on('py-ordereddict', when='^python@:2.6', type=('build', 'run'))
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -85,7 +85,7 @@ class PyMatplotlib(PythonPackage):
     depends_on('py-subprocess32', type=('build', 'run'), when='^python@:2.7')
     depends_on('py-functools32', type=('build', 'run'), when='@:2.0.999 ^python@2.7')
     depends_on('py-backports-functools-lru-cache', type=('build', 'run'),
-               when='@2.1.0:2.999.999')
+               when='@2.1.0:2.999.999 ^python@:2')
     depends_on('py-six@1.9.0:', type=('build', 'run'), when='@:2')
 
     # Optional backend dependencies

--- a/var/spack/repos/builtin/packages/py-multiqc/package.py
+++ b/var/spack/repos/builtin/packages/py-multiqc/package.py
@@ -31,5 +31,5 @@ class PyMultiqc(PythonPackage):
     depends_on('py-pyyaml', type=('build', 'run'))
     depends_on('py-simplejson', type=('build', 'run'))
     depends_on('py-requests', type=('build', 'run'), when='@1.5:')
-    depends_on('py-enum34', type=('build', 'run'), when='@1.5:')
+    depends_on('py-enum34', type=('build', 'run'), when='@1.5: ^python@:3.3')
     depends_on('py-markdown', type=('build', 'run'), when='@1.5:')

--- a/var/spack/repos/builtin/packages/py-multiqc/package.py
+++ b/var/spack/repos/builtin/packages/py-multiqc/package.py
@@ -31,5 +31,6 @@ class PyMultiqc(PythonPackage):
     depends_on('py-pyyaml', type=('build', 'run'))
     depends_on('py-simplejson', type=('build', 'run'))
     depends_on('py-requests', type=('build', 'run'), when='@1.5:')
-    depends_on('py-enum34', type=('build', 'run'), when='@1.5: ^python@:3.3')
+    depends_on('py-enum34', type=('build', 'run'), when='@1.4:1.5 ^python@:3.3')
+    depends_on('py-enum34', type=('build', 'run'), when='@1.3')
     depends_on('py-markdown', type=('build', 'run'), when='@1.5:')


### PR DESCRIPTION
This implements @scheibelp's suggestion in #13711.

py-matplotlib should only depends_on py-backports-functools-lru-cache
when it's using a python that actually *needs* it.

See #13711 for details.

Fixes #13711 