### PR TITLE
shell: Fix module command in scripts

### DIFF
--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -317,17 +317,17 @@ if [ "${need_module}" = "yes" ]; then
     if [ "${_sp_module_prefix}" != "not_installed" ]; then
         # activate it!
         # environment-modules@4: has a bin directory inside its prefix
-        _sp_module_bin="${_sp_module_prefix}/bin"
-        if [ ! -d "${_sp_module_bin}" ]; then
+        _sp_module_init="${_sp_module_prefix}/init"
+        if [ ! -d "${_sp_module_init}" ]; then
             # environment-modules@3 has a nested bin directory
-            _sp_module_bin="${_sp_module_prefix}/Modules/bin"
+            _sp_module_init="${_sp_module_prefix}/Modules/init"
         fi
 
-        # _sp_module_bin and _sp_shell are evaluated here; the quoted
-        # eval statement and $* are deferred.
-        _sp_cmd="module() { eval \`${_sp_module_bin}/modulecmd ${_sp_shell} \$*\`; }"
-        eval "$_sp_cmd"
-        _spack_pathadd PATH "${_sp_module_bin}"
+        if [ -f "${_sp_module_init}/${_sp_shell}" ]; then
+            . "${_sp_module_init}/${_sp_shell}"
+        else
+            . "${_sp_module_init}/sh"
+        fi;
     fi;
 else
     eval `spack --print-shell-vars sh`


### PR DESCRIPTION
While Spack's shell integration does work interactively in the shell, there are problems if it is used embedded into another script. The following shell script shows that modifications to `LD_LIBRARY_PATH` will be overwritten by environment-modules:

```
export LD_LIBRARY_PATH=foobar
echo $LD_LIBRARY_PATH
. ./share/spack/setup-env.sh
spack load zlib target=x86_64
echo $LD_LIBRARY_PATH
```

This will print the following, that is, the initial value is lost:
```
foobar
[...]/opt/spack/linux-fedora31-x86_64/gcc-9.2.1/zlib-1.2.11-4zcnhczvb3xvv2vr5ezoh2un5equbddk/lib
```

Spack's shell integration still uses a module function copied from environment-modules@3, which exhibits this problem if used with environment-modules@4. Luckily, all versions ship appropriate init scripts that can be used instead.

After this change, the initial value will be preserved correctly:
```
foobar
[...]/opt/spack/linux-fedora31-x86_64/gcc-9.2.1/zlib-1.2.11-4zcnhczvb3xvv2vr5ezoh2un5equbddk/lib:foobar
```