### PR TITLE
Fix libbsd build on Intel compilers

### DIFF
--- a/var/spack/repos/builtin/packages/libbsd/local-elf.h.patch
+++ b/var/spack/repos/builtin/packages/libbsd/local-elf.h.patch
@@ -1,0 +1,11 @@
+--- a/src/local-elf.h	2018-04-21 17:30:22.000000000 -0400
++++ b/src/local-elf.h	2019-11-13 11:02:53.965684506 -0500
+@@ -43,7 +43,7 @@
+ #define ELF_TARG_CLASS	ELFCLASS64
+ #define ELF_TARG_DATA	ELFDATA2LSB
+ 
+-#elif defined(__amd64__)
++#elif defined(__amd64__) || defined(__x86_64__)
+ 
+ #define ELF_TARG_MACH	EM_X86_64
+ #if defined(__ILP32__)

--- a/var/spack/repos/builtin/packages/libbsd/package.py
+++ b/var/spack/repos/builtin/packages/libbsd/package.py
@@ -16,12 +16,14 @@ class Libbsd(AutotoolsPackage):
     homepage = "https://libbsd.freedesktop.org/wiki/"
     url      = "https://libbsd.freedesktop.org/releases/libbsd-0.9.1.tar.xz"
 
+    version('0.10.0', sha256='34b8adc726883d0e85b3118fa13605e179a62b31ba51f676136ecb2d0bc1a887')
     version('0.9.1', sha256='56d835742327d69faccd16955a60b6dcf30684a8da518c4eca0ac713b9e0a7a4')
     version('0.9.0', sha256='8a469afd1bab340992cf99e1e6b7ae4f4c54882d663d8a2c5ea52250617afb01')
     version('0.8.7', sha256='f548f10e5af5a08b1e22889ce84315b1ebe41505b015c9596bad03fd13a12b31')
     version('0.8.6', sha256='467fbf9df1f49af11f7f686691057c8c0a7613ae5a870577bef9155de39f9687')
 
     patch('cdefs.h.patch', when='@0.8.6 %gcc@:4')
+    patch('local-elf.h.patch', when='%intel')
 
     # https://gitlab.freedesktop.org/libbsd/libbsd/issues/1
     conflicts('platform=darwin')


### PR DESCRIPTION
Libbsd assumes GCC-defined compiler macros:
```
In file included from nlist.c(44):
local-elf.h(238): catastrophic error: #error directive: Unknown ELF machine type
  #error Unknown ELF machine type
   ^
```
The `__amd64__` and `__x86_64__` macros should be equivalent, but the latter is defined by intel.
