### PR TITLE
package/geopm: Added versions 1.0.0 and 1.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/geopm/package.py
+++ b/var/spack/repos/builtin/packages/geopm/package.py
@@ -18,12 +18,14 @@ class Geopm(AutotoolsPackage):
     msr-safe kernel module by your administrator."""
 
     homepage = "https://geopm.github.io"
-    url      = "https://github.com/geopm/geopm/releases/download/v0.4.0/geopm-0.4.0.tar.gz"
+    url      = "https://github.com/geopm/geopm/releases/download/v1.0.0/geopm-1.0.0.tar.gz"
     git      = "https://github.com/geopm/geopm.git"
 
     # Add additional proper versions and checksums here. "spack checksum geopm"
     version('develop', branch='dev')
     version('master', branch='master')
+    version('1.1.0', sha256='5f9a4df37ef0d64c53d64829d46736803c9fe614afd8d2c70fe7a5ebea09f88e')
+    version('1.0.0',     sha256='24fe72265a7e44d62bdfe49467c49f0b7a649131ddda402d763c00a49765e1cb')
     version('1.0.0-rc2', sha256='c6637df54728ded31fd682f39a07dffee45883f350e6dbd13e1496dd50243ffd',
             url='https://github.com/geopm/geopm/releases/download/v1.0.0%2Brc2/geopm-1.0.0+rc2.tar.gz')
     version('1.0.0-rc1', sha256='f8a2e5c384a15e9663f409de478b6372cd63e63a28d4701a33ac043fc27905e0', 
@@ -45,26 +47,43 @@ class Geopm(AutotoolsPackage):
     variant('doc', default=True, description='Create man pages with ruby-ronn.')
     variant('openmp', default=True, description='Build with OpenMP.')
     variant('ompt', default=False, description='Use OpenMP Tools Interface.')
-    variant('hwloc', default=False, description='Build with hwloc, deprecated and ignored after v0.5.1.')
     variant('gnu-ld', default=False, description='Assume C compiler uses gnu-ld.')
 
     # Added dependencies.
+    depends_on('ruby-ronn', type='build', when='+doc')
+    depends_on('doxygen', type='build', when='+doc')
+    depends_on('mpi@2.2:', when='+mpi')
+
     depends_on('m4', type='build')
-    depends_on('automake', type='build')
     depends_on('autoconf', type='build')
+    depends_on('automake', type='build')
     depends_on('libtool', type='build')
     depends_on('ruby-ronn', type='build', when='+doc')
     depends_on('doxygen', type='build', when='+doc')
-    depends_on('numactl')
+    depends_on('numactl', when="@:1.0.0-rc2")
     depends_on('mpi', when='+mpi')
     depends_on('hwloc@1.11.9', when='@:0.5.1+hwloc')
-    depends_on('json-c')
-    depends_on('py-pandas', type='run')
-    depends_on('py-numpy', type='run')
-    depends_on('py-natsort', type='run')
-    depends_on('py-matplotlib@2.2.3', type='run')
+    depends_on('json-c', when='@:0.9.9')
+    depends_on('py-cycler@0.10.0:', when="@1.0.0:", type=('build', 'run'))
+    depends_on('py-pandas@0.22.0:', type=('build', 'run'))
+    depends_on('py-tables@3.4.3:3.5.2', when="@1.0.0:", type=('build', 'run'))
+    depends_on('py-cffi@1.6.0:', when="@1.1.0:", type=('build', 'run'))
+    depends_on('py-pyyaml@5.1.0:', when="@1.1.0:", type=('build', 'run'))
+    depends_on('py-mock@3.0.0:', when="@1.1.0:", type=('build', 'run'))
+    depends_on('py-future@0.17.1:', when="@1.1.0:", type=('build', 'run'))
+    depends_on('py-numpy@1.14.3:', type=('build', 'run'))
+    depends_on('py-setuptools@39.2.0:', when="@1.0.0:", type='build')
+    depends_on('py-natsort@5.3.2:', type=('build', 'run'))
+    depends_on('py-psutil@5.4.8:', when="@1.0.0:", type=('build', 'run'))
+    depends_on('py-pylint@1.9.5:', when="@1.1.0:", type=('build', 'run'))
+    depends_on('py-matplotlib@2.2.3', when="@:1.0.0-rc2", type=('build', 'run'))
+    depends_on('py-matplotlib@2.2.3:', when="@1.1.0:", type=('build', 'run'))
 
     parallel = False
+
+    def autoreconf(self, spec, prefix):
+        bash = which("bash")
+        bash('./autogen.sh')
 
     def configure_args(self):
         args = []
@@ -77,10 +96,6 @@ class Geopm(AutotoolsPackage):
         args.extend(self.enable_or_disable('doc'))
         args.extend(self.enable_or_disable('openmp'))
         args.extend(self.enable_or_disable('ompt'))
-        if self.version <= Version('0.5.1'):
-            args.extend(self.with_or_without(
-                'hwloc',
-                activation_value='prefix'))
         args.extend(self.with_or_without('gnu-ld'))
 
         return args

--- a/var/spack/repos/builtin/packages/geopm/package.py
+++ b/var/spack/repos/builtin/packages/geopm/package.py
@@ -25,11 +25,7 @@ class Geopm(AutotoolsPackage):
     version('develop', branch='dev')
     version('master', branch='master')
     version('1.1.0', sha256='5f9a4df37ef0d64c53d64829d46736803c9fe614afd8d2c70fe7a5ebea09f88e')
-    version('1.0.0',     sha256='24fe72265a7e44d62bdfe49467c49f0b7a649131ddda402d763c00a49765e1cb')
-    version('1.0.0-rc2', sha256='c6637df54728ded31fd682f39a07dffee45883f350e6dbd13e1496dd50243ffd',
-            url='https://github.com/geopm/geopm/releases/download/v1.0.0%2Brc2/geopm-1.0.0+rc2.tar.gz')
-    version('1.0.0-rc1', sha256='f8a2e5c384a15e9663f409de478b6372cd63e63a28d4701a33ac043fc27905e0', 
-            url='https://github.com/geopm/geopm/releases/download/v1.0.0-rc1/geopm-1.0.0+rc1.tar.gz')
+    version('1.0.0', sha256='24fe72265a7e44d62bdfe49467c49f0b7a649131ddda402d763c00a49765e1cb')
     version('0.6.1', sha256='0ca42853f90885bf213df190c3462b8675c143cc843aee0d8b8a0e30802b55a9')
     version('0.6.0', sha256='95ccf256c2b7cb35838978152479569d154347c3065af1639ed17be1399182d3')
     version('0.5.1', sha256='db247af55f7000b6e4628af099956349b68a637500b9d4fe8d8fb13687124d53')


### PR DESCRIPTION
Added changes for 1.1.0 and 1.0.0 in this patch.
Patch for 1.0.0 was previously not merged.
Variant for hwloc removed since that is not a dependency since 0.5.1 and
variant('hwloc', when="@:0.5.1"... is not supported afaik.
Made depends_on versions more explicit.

New pull request as recommended in #11230 