### PR TITLE
ibm-java: add conflicts for aarch64

### DIFF
--- a/var/spack/repos/builtin/packages/ibm-java/package.py
+++ b/var/spack/repos/builtin/packages/ibm-java/package.py
@@ -28,6 +28,7 @@ class IbmJava(Package):
     provides('java@8')
 
     conflicts('target=x86_64:', msg='ibm-java is only available for ppc64 and ppc64le')
+    conflicts('target=aarch64', msg='ibm-java is only available for ppc64 and ppc64le')
 
     # This assumes version numbers are 4-tuples: 8.0.5.30
     def url_for_version(self, version):


### PR DESCRIPTION
add conflicts for aarch64 because ibm-java is only available for ppc64 and ppc64le.