### PR TITLE
Mark conflicts between newer packages and Intel 14 compilers

### DIFF
--- a/var/spack/repos/builtin/packages/bison/package.py
+++ b/var/spack/repos/builtin/packages/bison/package.py
@@ -31,8 +31,8 @@ class Bison(AutotoolsPackage):
 
     patch('pgi.patch', when='@3.0.4')
 
-    # Intel 14 has immature C11 support
-    conflicts('%intel@:14', when='@3.4.2:')
+    conflicts('%intel@:14', when='@3.4.2:',
+              msg="Intel 14 has immature C11 support")
 
     if sys.platform == 'darwin' and macos_version() >= Version('10.13'):
         patch('secure_snprintf.patch', level=0, when='@3.0.4')

--- a/var/spack/repos/builtin/packages/bison/package.py
+++ b/var/spack/repos/builtin/packages/bison/package.py
@@ -31,6 +31,9 @@ class Bison(AutotoolsPackage):
 
     patch('pgi.patch', when='@3.0.4')
 
+    # Intel 14 has immature C11 support
+    conflicts('%intel@:14', when='@3.4.2:')
+
     if sys.platform == 'darwin' and macos_version() >= Version('10.13'):
         patch('secure_snprintf.patch', level=0, when='@3.0.4')
 

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -117,8 +117,8 @@ class Cmake(Package):
 
     # https://gitlab.kitware.com/cmake/cmake/issues/18166
     conflicts('%intel', when='@3.11.0:3.11.4')
-    # Intel 14 has immature C++11 support
-    conflicts('%intel@:14', when='@3.14:')
+    conflicts('%intel@:14', when='@3.14:',
+              msg="Intel 14 has immature C++11 support")
 
     phases = ['bootstrap', 'build', 'install']
 

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -117,6 +117,8 @@ class Cmake(Package):
 
     # https://gitlab.kitware.com/cmake/cmake/issues/18166
     conflicts('%intel', when='@3.11.0:3.11.4')
+    # Intel 14 has immature C++11 support
+    conflicts('%intel@:14', when='@3.14:')
 
     phases = ['bootstrap', 'build', 'install']
 

--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -28,8 +28,9 @@ class Icu4c(AutotoolsPackage):
             description='Use the specified C++ standard when building')
 
     depends_on('python', type='build', when='@64.1:')
-    # Intel compilers with immature C++11/multibyte support
-    conflicts('%intel@:16', when='@60.1:')
+
+    conflicts('%intel@:16', when='@60.1:',
+              msg="Intel compilers have immature C++11 and multibyte support")
 
     configure_directory = 'source'
 

--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -28,6 +28,8 @@ class Icu4c(AutotoolsPackage):
             description='Use the specified C++ standard when building')
 
     depends_on('python', type='build', when='@64.1:')
+    # Intel 14 has immature C++11 support
+    conflicts('%intel@:14', when='@60.1:')
 
     configure_directory = 'source'
 

--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -28,8 +28,8 @@ class Icu4c(AutotoolsPackage):
             description='Use the specified C++ standard when building')
 
     depends_on('python', type='build', when='@64.1:')
-    # Intel 14 has immature C++11 support
-    conflicts('%intel@:14', when='@60.1:')
+    # Intel compilers with immature C++11/multibyte support
+    conflicts('%intel@:16', when='@60.1:')
 
     configure_directory = 'source'
 

--- a/var/spack/repos/builtin/packages/nasm/package.py
+++ b/var/spack/repos/builtin/packages/nasm/package.py
@@ -23,5 +23,5 @@ class Nasm(AutotoolsPackage):
     # https://bugzilla.nasm.us/show_bug.cgi?id=3392461
     patch('https://src.fedoraproject.org/rpms/nasm/raw/0cc3eb244bd971df81a7f02bc12c5ec259e1a5d6/f/0001-Remove-invalid-pure_func-qualifiers.patch', level=1, sha256='ac9f315d204afa6b99ceefa1fe46d4eed2b8a23c7315d32d33c0f378d930e950', when='@2.13.03 %gcc@8:')
 
-    # Intel 14 has immature C11 support
-    conflicts('%intel@:14', when='@2.14:')
+    conflicts('%intel@:14', when='@2.14:',
+              msg="Intel 14 has immature C11 support")

--- a/var/spack/repos/builtin/packages/nasm/package.py
+++ b/var/spack/repos/builtin/packages/nasm/package.py
@@ -22,3 +22,6 @@ class Nasm(AutotoolsPackage):
     # Fix compilation with GCC 8
     # https://bugzilla.nasm.us/show_bug.cgi?id=3392461
     patch('https://src.fedoraproject.org/rpms/nasm/raw/0cc3eb244bd971df81a7f02bc12c5ec259e1a5d6/f/0001-Remove-invalid-pure_func-qualifiers.patch', level=1, sha256='ac9f315d204afa6b99ceefa1fe46d4eed2b8a23c7315d32d33c0f378d930e950', when='@2.13.03 %gcc@8:')
+
+    # Intel 14 has immature C11 support
+    conflicts('%intel@:14', when='@2.14:')


### PR DESCRIPTION
 I recently had to build out a compiler toolchain using Intel 14.0.4, which supports *most* but *not all* of C++11 and C11 features. I found the oldest Spack-defined versions of each package that failed Intel 14 and marked as conflicts the newer versions with Intel 14 and before.

For posterity, here is what I successfully installed:
```
-- linux-rhel6-x86_64 / intel@14.0.4 ----------------------------
autoconf@2.69
automake@1.16.1
bison@3.0.5
bzip2@1.0.8+shared
cmake@3.12.4~doc+ncurses+openssl+ownlibs patches=93488edf3f89cef6f3c77e821007c022e88e9f1f566ae9bf824a87ecbac97ebb,dd3a40d4d92f6b2158b87d6fb354c277947c776424aa03f6dc8096cf3135f5d0 ~qt
diffutils@3.7
expat@2.2.9+libbsd
freetype@2.7.1
gdbm@1.18.1
gettext@0.20.1+bzip2+curses+git~libunistring+libxml2+tar+xz
glib@2.56.3~libmount patches=c325997b72a205ad1638bb3e3ba0e5b73e3d32ce63b2d0d3282f3e3a2ff4663c tracing=none
hdf5@1.10.5+cxx~debug+fortran+hl~mpi+pic+shared+szip~threadsafe
help2man@1.47.11
hwloc@1.11.11~cairo~cuda~gl+libxml2~nvml+pci+shared
icu4c@58.2 cxxstd=11
inputproto@2.3.2
kbproto@1.0.7
lcms@2.9
libbsd@0.10.0 patches=71b49f52a01420ab632f23373135853a2565f88725fb77e625a7fbf7ea812eef
libffi@3.2.1
libgpg-error@1.36
libiconv@1.16
libjpeg@9c
libmng@2.0.3
libpciaccess@0.13.5
libpng@1.6.37
libpthread-stubs@0.4
libsigsegv@2.12
libszip@2.1.1
libtiff@4.0.10
libtool@2.4.6
libuuid@1.0.3
libx11@1.6.7
libxau@1.0.8
libxcb@1.13
libxdmcp@1.1.2
libxext@1.3.3
libxkbcommon@0.8.2
libxkbfile@1.0.9
libxml2@2.9.9~python
m4@1.4.18 patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8 +sigsegv
ncurses@6.1~symlinks~termlib
numactl@2.0.12
openblas@0.3.7+avx2~avx512 cpu_target=GENERIC ~ilp64+pic+shared threads=none +virtual_machine
openmpi@1.10.6~cuda+cxx_exceptions fabrics=none ~java~legacylaunchers~memchecker~pmi schedulers=none ~sqlite3~thread_multiple+vt
openssl@1.1.1d+systemcerts
pcre@8.42+jit+multibyte+utf
perl@5.30.0+cpanm+shared+threads
pkgconf@1.6.3
py-alabaster@0.7.12
py-babel@2.7.0
py-certifi@2019.9.11
py-chardet@3.0.4
py-cython@0.29.13
py-docutils@0.15.2
py-h5py@2.9.0~mpi
py-idna@2.8
py-imagesize@1.1.0
py-jinja2@2.10.3
py-markupsafe@1.1.1
py-nose@1.3.7
py-numpy@1.16.5+blas+lapack patches=196dc7cc8e1367de199726d4e005bba50c3d13fb2843c4753c5f07f7894f10c9
py-packaging@19.2
py-pip@19.3
py-pkgconfig@1.4.0
py-pygments@2.4.2
py-pyparsing@2.4.2
py-pytest-runner@5.1
py-pytz@2019.3
py-requests@2.22.0
py-setuptools@41.4.0
py-setuptools-scm@3.3.3
py-six@1.12.0
py-snowballstemmer@2.0.0
py-sphinx@1.8.4
py-sphinxcontrib-websupport@1.1.2
py-typing@3.7.4.1
py-urllib3@1.25.6
python@2.7.16+bz2+ctypes+dbm+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib
qt@4.8.7~dbus~examples~framework freetype=none ~gtk~krellpatch~opengl patches=4f40b7c6230471c19fd1aea45e264a1642c654023d2da1c8063a05ef095d6586,88ec914c9f2026599cce3258006db3fab48138cb9b37f0a7a182d6731fbe2d4d,a4f37427b34d88df6a6adc16e1e6c805087d4f3a7c658e1797450b0912fcbf5d ~phonon+shared~sql~ssl+tools~webkit
readline@8.0
scale-data@6.3.0-A3
silo@4.10.2+fortran~mpi patches=7b5a1dc2a0e358e667088d77e7caa780967fa8ea60be89c44986605df9990abe +pic+shared~silex
sqlite@3.30.1~column_metadata+fts~functions~rtree
tar@1.32
util-macros@1.19.1
xcb-proto@1.13
xcb-util@0.4.0
xcb-util-image@0.4.0
xcb-util-keysyms@0.4.0
xcb-util-renderutil@0.3.9
xcb-util-wm@0.4.1
xextproto@7.3.0
xkbcomp@1.3.1
xkbdata@1.0.1
xproto@7.0.31
xtrans@1.3.5
xz@5.2.4
zlib@1.2.11+optimize+pic+shared
```

This is with Intel pointing to a GCC 4.8.3 installation for libstdc++, with the compiler definition:
```yaml
- compiler:
    environment: {}
    extra_rpaths:
    - ${GCC_ROOT}/lib64
    modules: []
    flags:
      cxxflags: -cxxlib=${GCC_ROOT}
    operating_system: rhel6
    paths:
      cc: ${INTEL_ROOT}/bin/icc
      cxx: ${INTEL_ROOT}/bin/icpc
      f77: ${INTEL_ROOT}/bin/ifort
      fc: ${INTEL_ROOT}/bin/ifort
    spec: intel@14.0.4
    target: x86_64
```