### PR TITLE
guile package: Handling the threads option.

### DIFF
--- a/var/spack/repos/builtin/packages/guile/package.py
+++ b/var/spack/repos/builtin/packages/guile/package.py
@@ -26,10 +26,10 @@ class Guile(AutotoolsPackage):
     variant('readline', default=True, description='Use the readline library')
     variant(
         'threads',
-         default='none',
-         values=('none', 'posix', 'dgux386'),
-         multi=False,
-         description='Use the thread interface'
+        default='none',
+        values=('none', 'posix', 'dgux386'),
+        multi=False,
+        description='Use the thread interface'
     )
 
     depends_on('bdw-gc@7.0: threads=none', when='threads=none')
@@ -60,9 +60,9 @@ class Guile(AutotoolsPackage):
         ]
 
         if 'threads=none' in spec:
-           config_args.append('--without-threads')
+            config_args.append('--without-threads')
         else:
-           config_args.append('--with-threads')
+            config_args.append('--with-threads')
 
         if '+readline' in spec:
             config_args.append('--with-libreadline-prefix={0}'.format(


### PR DESCRIPTION
Currently, guile by default tries to compile its thread variant.
However, the threaded version can only be compiled if bdw-gc is
compiled with some threads support. Currently, the default
compilation of the bdw garbage collector is compiled without any
thread support resulting in a compilation error.

I have changed the default guile compilation to the non-threaded
version. I have also added the appropriated options for the bdw-gc
compilation in case the user prefers the threaded variant.

Without the changes this is the error message you get when installing guile:
```
==> Error: ProcessError: Command exited with status 2:
    'make' '-j36'

9 errors found in build log:
     1602      SNARF  socket.doc
     1603      SNARF  regex-posix.doc
     1604      CCLD     libguile-2.2.la
     1605    .libs/libguile_2.2_la-posix.o: In function `scm_tmpnam':
     1606    /tmp/swadm/spack-stage/spack-stage-guile-2.2.6-odygubqttlo7n4oqigw
             4twn6m5hjheds/spack-src/libguile/posix.c:1601: warning: the use of
              `tmpnam' is dangerous, better use `mkstemp'
     1607      CCLD     guile
  >> 1608    ./.libs/libguile-2.2.so: undefined reference to `GC_unregister_my_
             thread'                                                                                                                                                               
  >> 1609    ./.libs/libguile-2.2.so: undefined reference to `GC_get_suspend_si
             gnal'                                                                                                                                                                 
  >> 1610    ./.libs/libguile-2.2.so: undefined reference to `GC_allow_register
             _threads'                                                                                                                                                             
  >> 1611    ./.libs/libguile-2.2.so: undefined reference to `GC_register_my_th
             read'                                                                                                                                                                 
  >> 1612    collect2: error: ld returned 1 exit status
  >> 1613    make[3]: *** [guile] Error 1
     1614    make[3]: Leaving directory `/tmp/swadm/spack-stage/spack-stage-gui
             le-2.2.6-odygubqttlo7n4oqigw4twn6m5hjheds/spack-src/spack-build/li
             bguile'
  >> 1615    make[2]: *** [all] Error 2
     1616    make[2]: Leaving directory `/tmp/swadm/spack-stage/spack-stage-gui
             le-2.2.6-odygubqttlo7n4oqigw4twn6m5hjheds/spack-src/spack-build/li
             bguile'
  >> 1617    make[1]: *** [all-recursive] Error 1
     1618    make[1]: Leaving directory `/tmp/swadm/spack-stage/spack-stage-gui
             le-2.2.6-odygubqttlo7n4oqigw4twn6m5hjheds/spack-src/spack-build'
  >> 1619    make: *** [all] Error 2

See build log for details:
  /tmp/swadm/spack-stage/spack-stage-guile-2.2.6-odygubqttlo7n4oqigw4twn6m5hjheds/spack-build-out.txt
```