### PR TITLE
Update DMTCP package to v2.6.0

### DIFF
--- a/var/spack/repos/builtin/packages/dmtcp/package.py
+++ b/var/spack/repos/builtin/packages/dmtcp/package.py
@@ -12,6 +12,7 @@ class Dmtcp(AutotoolsPackage):
     with no modifications to user code or to the O/S."""
 
     homepage = "http://dmtcp.sourceforge.net/"
-    url      = "https://sourceforge.net/projects/dmtcp/files/2.5.2/dmtcp-2.5.2.tar.gz/download"
+    url      = "https://sourceforge.net/projects/dmtcp/files/2.6.0/dmtcp-2.6.0.tar.gz/download"
 
+    version('2.6.0', sha256='3ed62a86dd0cb9c828b93ee8c7c852d6f9c96a0efa48bcfe867521adf7bced68')
     version('2.5.2', sha256='0e3e5e15bd401b7b6937f2b678cd7d6a252eab0a143d5740b89cc3bebb4282be')


### PR DESCRIPTION
Updated DMTCP package to v2.6.0, released August 2019.