### PR TITLE
WIP: Improve error reporting for concretization errors

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -211,7 +211,8 @@ def colorize_spec(spec):
     return colorize(re.sub(_separators, insert_color(), str(spec)) + '@.')
 
 def traced_concretization_step(function):
-    """Foo
+    """Wrap function such that trace info is printed when
+       it is invoked.
     """
 
     @functools.wraps(function)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -210,6 +210,7 @@ def colorize_spec(spec):
 
     return colorize(re.sub(_separators, insert_color(), str(spec)) + '@.')
 
+
 def traced_concretization_step(function):
     """Wrap function such that trace info is printed when
        it is invoked.
@@ -229,6 +230,7 @@ def traced_concretization_step(function):
         return return_value
     return wrapper
 
+
 def embiggen_unsat_spec_error_message(function):
     """A decorator which adds the spec being modified to the exception
     message for functions that might throw UnsatisfiableSpecError
@@ -246,7 +248,6 @@ def embiggen_unsat_spec_error_message(function):
             e.message += args[0].tree(indent=4)
             raise
     return wrapper
-
 
 
 @key_ordering


### PR DESCRIPTION
TODO:

- [ ] is tracing, as implemented, reasonable?  How should it be controlled (spack command flag or specific sub-command flags, or ...)?

- [ ] would/might this be applicable to other calls than `concretize`, and/or might it be useful to apply it to SpecError's in general?

---

This PR addresses the issues raised in #13742.

It addresses the issue point 1) by adding a decorator, which is used to wrap concretization steps, that prints out an indented message about the operation and argument.

It addresses the issue's points 2) and 3) by adding a decorator that adds the spec that was being processed (probably partially modified) to the exception.message and applying that decorator to the `concretize` function.

This makes it easier to see how the bits that caused the problem fit into the bigger picture, e.g.

```console
(alice)[14:58:52]spack>>./bin/spack spec py-multiqc
Input spec
--------------------------------
py-multiqc

Concretized
--------------------------------
==> Warning: clang@10.0.0-apple cannot build optimized binaries for "haswell". Using best target possible: "x86_64"
==> Error: An unsatisfiable version constraint has been detected for spec:

    python@3.7.4%clang@10.0.0-apple+bz2+ctypes+dbm+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline~shared+sqlite3+ssl~tix~tkinter~ucs4~uuid+zlib arch=darwin-highsierra-x86_64
        ^bzip2@1.0.8%clang@10.0.0-apple+shared arch=darwin-highsierra-x86_64
            ^diffutils@3.7%clang@10.0.0-apple arch=darwin-highsierra-x86_64
                ^libiconv@1.16%clang@10.0.0-apple arch=darwin-highsierra-x86_64
        ^expat
        ^gdbm
            ^readline
                ^ncurses
                    ^pkgconf@1.6.3%clang@10.0.0-apple arch=darwin-highsierra-x86_64
        ^gettext@0.20.1%clang@10.0.0-apple+bzip2+curses+git~libunistring+libxml2+tar+xz arch=darwin-highsierra-x86_64
            ^libxml2
                ^xz
                ^zlib@1.2.11%clang@10.0.0-apple+optimize+pic+shared arch=darwin-highsierra-x86_64
            ^tar
        ^libffi
        ^openssl@1.0.2:
            ^perl@5.14.0:
        ^sqlite@3.0.8:


while trying to concretize the partial spec:

    py-backports-functools-lru-cache


py-backports-functools-lru-cache requires python version 2.6.0:3.3.99, but spec asked for 3.7.4

The spec that was in the process of being modified is:

    py-multiqc@1.7%clang@10.0.0-apple arch=darwin-highsierra-x86_64
        ^py-click@7.0%clang@10.0.0-apple arch=darwin-highsierra-x86_64
            ^py-setuptools@41.4.0%clang@10.0.0-apple arch=darwin-highsierra-x86_64
                ^python@3.7.4%clang@10.0.0-apple+bz2+ctypes+dbm+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline~shared+sqlite3+ssl~tix~tkinter~ucs4~uuid+zlib arch=darwin-highsierra-x86_64
                    ^bzip2@1.0.8%clang@10.0.0-apple+shared arch=darwin-highsierra-x86_64
                        ^diffutils@3.7%clang@10.0.0-apple arch=darwin-highsierra-x86_64
                            ^libiconv@1.16%clang@10.0.0-apple arch=darwin-highsierra-x86_64
                    ^expat
                    ^gdbm
                        ^readline
                            ^ncurses
                                ^pkgconf@1.6.3%clang@10.0.0-apple arch=darwin-highsierra-x86_64
                    ^gettext@0.20.1%clang@10.0.0-apple+bzip2+curses+git~libunistring+libxml2+tar+xz arch=darwin-highsierra-x86_64
                        ^libxml2
                            ^xz
                            ^zlib@1.2.11%clang@10.0.0-apple+optimize+pic+shared arch=darwin-highsierra-x86_64
                        ^tar
                    ^libffi
                    ^openssl@1.0.2:
                        ^perl@5.14.0:
                    ^sqlite@3.0.8:
        ^py-future@0.17.1%clang@10.0.0-apple arch=darwin-highsierra-x86_64
        ^py-jinja2@2.10.3%clang@10.0.0-apple arch=darwin-highsierra-x86_64
            ^py-babel@2.7.0%clang@10.0.0-apple arch=darwin-highsierra-x86_64
                ^py-pytz@2019.3%clang@10.0.0-apple arch=darwin-highsierra-x86_64
            ^py-markupsafe@1.1.1%clang@10.0.0-apple arch=darwin-highsierra-x86_64
        ^py-lzstring@1.0.3%clang@10.0.0-apple arch=darwin-highsierra-x86_64
        ^py-matplotlib@2.2.3%clang@10.0.0-apple~animation backend=macosx +image~latex~movies arch=darwin-highsierra-x86_64
            ^freetype@2.10.1%clang@10.0.0-apple arch=darwin-highsierra-x86_64
                ^libpng@1.6.37%clang@10.0.0-apple arch=darwin-highsierra-x86_64
            ^py-backports-functools-lru-cache
            ^py-cycler@0.10.0%clang@10.0.0-apple arch=darwin-highsierra-x86_64
                ^py-six@1.12.0%clang@10.0.0-apple arch=darwin-highsierra-x86_64
            ^py-kiwisolver@1:
            ^py-numpy@1.17.4%clang@10.0.0-apple+blas+lapack arch=darwin-highsierra-x86_64
                ^blas
                ^lapack
            ^py-pyparsing@2.4.2%clang@10.0.0-apple arch=darwin-highsierra-x86_64
            ^py-python-dateutil@2.8.0%clang@10.0.0-apple arch=darwin-highsierra-x86_64
                ^py-setuptools-scm
        ^py-spectra@0.0.11%clang@10.0.0-apple arch=darwin-highsierra-x86_64
            ^py-colormath@3.0.0%clang@10.0.0-apple arch=darwin-highsierra-x86_64
                ^py-networkx@2.2%clang@10.0.0-apple arch=darwin-highsierra-x86_64
                    ^py-decorator@4.4.0%clang@10.0.0-apple arch=darwin-highsierra-x86_64
```

Fixes #13742