### PR TITLE
ocaml: Fix version conversion process

### DIFF
--- a/var/spack/repos/builtin/packages/ocaml/package.py
+++ b/var/spack/repos/builtin/packages/ocaml/package.py
@@ -20,7 +20,7 @@ class Ocaml(Package):
 
     def url_for_version(self, version):
         url = "http://caml.inria.fr/pub/distrib/ocaml-{0}/ocaml-{1}.tar.gz"
-        return url.format(version.up_to(2), version)
+        return url.format(str(version)[:-2], version)
 
     def install(self, spec, prefix):
         configure('-prefix', '{0}'.format(prefix))


### PR DESCRIPTION
The download url of the ocaml package was invalid because the following error occurred.
"The requested url returned error: 404 Not Found"

The purpose is to convert the version `4.06.0` to `4.06` 
But, when using up_to, `4.06` was converted to `4.6`.

http://caml.inria.fr/pub/distrib/ocaml-4.6/ocaml-4.06.0.tar.gz
http://caml.inria.fr/pub/distrib/ocaml-4.06/ocaml-4.06.0.tar.gz

So I converted the string of version in the recipe without using up_to.