### PR TITLE
cmd/install: remove unused install_status option

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -72,7 +72,7 @@ the dependencies"""
     subparser.add_argument(
         '-u', '--until', type=str, dest='until', default=None,
         help="phase to stop after when installing (default None)")
-    arguments.add_common_arguments(subparser, ['jobs', 'install_status'])
+    arguments.add_common_arguments(subparser, ['jobs'])
     subparser.add_argument(
         '--overwrite', action='store_true',
         help="reinstall an existing spec, even if it has dependents")

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -635,12 +635,13 @@ function _spack_info {
 function _spack_install {
     if $list_options
     then
-        compgen -W "-h --help --only -j --jobs -I --install-status
-                    --overwrite --keep-prefix --keep-stage --dont-restage
-                    --use-cache --no-cache --show-log-on-error --source
-                    -n --no-checksum -v --verbose --fake --only-concrete
-                    -f --file --clean --dirty --test --log-format --log-file
-                    --cdash-upload-url -y --yes-to-all" -- "$cur"
+        compgen -W "-h --help --only -j --jobs --overwrite --keep-prefix
+                    --keep-stage --dont-restage --use-cache --no-cache
+                    --cache-only --show-log-on-error --source -n --no-checksum
+                    -v --verbose --fake --only-concrete -f --file --clean
+                    --dirty --test --run-tests --log-format --log-file
+                    --cdash-upload-url --cdash-build --cdash-site --cdash-track
+                    --cdash-buildstamp -y --yes-to-all" -- "$cur"
     else
         compgen -W "$(_all_packages)" -- "$cur"
     fi


### PR DESCRIPTION
Pretty straightforward. The option isn't actually hooked up to any functionality, and I'm not sure how it got into the `install` command.

Motivated by the error report on slack that confused it with the similarly named option for the `spack spec` command.