### PR TITLE
Fix parsing of key=value pairs

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -137,7 +137,18 @@ def parse_specs(args, **kwargs):
     try:
         sargs = args
         if not isinstance(args, six.string_types):
-            sargs = ' '.join(spack.util.string.quote(args))
+            if len(sargs) == 1:
+                # a single argument contains a full spec and will confuse the
+                # Parser if escaped -> simply take it out of the list
+                if not isinstance(sargs, type([])):
+                    # Since the list keyword is taken we have to get the type
+                    # via the literal.
+                    # Sets do not support indexing -> convert to list as simply
+                    # popping the only element would modify the argument.
+                    sargs = type([])(sargs)
+                sargs = sargs[0]
+            else:
+                sargs = ' '.join(spack.util.string.quote(args))
         specs = spack.spec.parse(sargs)
         for spec in specs:
             if concretize:

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -87,3 +87,9 @@ def test_spec_returncode():
     with pytest.raises(spack.main.SpackCommandError):
         spec()
     assert spec.returncode == 1
+
+
+def test_spec_singlestring():
+    spec('multivalue_variant foo=baz target=x86_64 ^a@1.0')
+
+    assert spec.returncode == 0


### PR DESCRIPTION
Fix parsing key-value pairs being too greedy and only working if the
key=value pair is the last entry in the spec.

Example:
```
$ spack spec "py-matplotlib backend=agg target=x86_64 +image ^python@3.7.5"
==> Error: invalid values for variant "backend" in package "py-matplotlib": ['agg target=x86_64 +image ^python@3.7.5']
```

The error is that the parser just checks for the first entry being
non-whitespace (`[\S]`) and then simply matches the whole remaining
string (`.*`). However, we want the parser to match non-whitespace
characters only.

Fixes: #13752

Change-Id: I2314bbddff385fe5ccf6a39260332ec842d1b0cf