### PR TITLE
revbayes: add new versions

### DIFF
--- a/var/spack/repos/builtin/packages/revbayes/package.py
+++ b/var/spack/repos/builtin/packages/revbayes/package.py
@@ -12,7 +12,11 @@ class Revbayes(CMakePackage):
 
     homepage = "https://revbayes.github.io"
     url      = "https://github.com/revbayes/revbayes/archive/v1.0.11.tar.gz"
+    git      = "https://github.com/revbayes/revbayes.git"
 
+    version('develop', branch='development')
+    version('1.0.13', sha256='472b4ccc44d813c1ff1b8d27e8ccf3d96388de79aa1688b3714f683ba65038fa')
+    version('1.0.12', sha256='d79f3a9bc72305cab35009d11e1f027fcaacde7329a4c49b5b8285588a8d3588')
     version('1.0.11', sha256='7e81b1952e3a63cb84617fa632f4ccdf246b4d79e7d537a423540de047dadf50')
     version('1.0.10', sha256='95e9affe8ca8d62880cf46778b6ec9dd8726e62a185670ebcbadf2eb2bb79f93')
 
@@ -21,9 +25,14 @@ class Revbayes(CMakePackage):
     depends_on('boost')
     depends_on('mpi', when='+mpi')
 
-    conflicts('%gcc@7.1.0:')
+    conflicts('%gcc@7.1.0:', when='@:1.0.12')
 
-    root_cmakelists_dir = 'projects/cmake/build'
+    @property
+    def root_cmakelists_dir(self):
+        if self.spec.version > Version('1.0.13') and '+mpi' in self.spec:
+            return 'projects/cmake/build-mpi'
+        else:
+            return 'projects/cmake/build'
 
     @run_before('cmake')
     def regenerate(self):
@@ -44,3 +53,9 @@ class Revbayes(CMakePackage):
         else:
             install_path = join_path(self.build_directory, '..', 'rb')
             install(install_path, prefix.bin)
+
+    @when('@1.0.12:1.0.13')
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        install_path = join_path(self.build_directory, '..', 'rb')
+        install(install_path, prefix.bin)


### PR DESCRIPTION
The GCC version conflict has been resolved in newer versions as the build process specifies the C++ it needs rather than relying on the compiler default.

The MPI build is done in a different folder on development, and the executable name produced was different in 1.0.12 and 1.0.13 than before and in the current development branch.