### PR TITLE
Fix libxml2 package download problem

### DIFF
--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -34,7 +34,7 @@ class Libxml2(AutotoolsPackage):
 
     # XML Conformance Test Suites
     # See http://www.w3.org/XML/Test/ for information
-    resource(name='xmlts', url='http://www.w3.org/XML/Test/xmlts20080827.tar.gz',
+    resource(name='xmlts', url='https://www.w3.org/XML/Test/xmlts20080827.tar.gz',
              sha256='96151685cec997e1f9f3387e3626d61e6284d4d6e66e0e440c209286c03e9cc7')
 
     @property


### PR DESCRIPTION
libxml2 installation was failing with `curl: (52) Empty reply from server`

It seems that the HTTP server does not redirect (so -L option for curl cannot do anything) and the resource is only available at HTTPS url.