### PR TITLE
git: ignore share/spack/templates/modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@
 /share/spack/dotkit
 /share/spack/modules
 /share/spack/lmod
+# Ignore everything in /share/spack/templates/modules except
+# modulefile.lua and modulefile.tcl
+/share/spack/templates/modules/*
+!/share/spack/templates/modules/modulefile.lua
+!/share/spack/templates/modules/modulefile.tcl
 /TAGS
 *.swp
 /htmlcov


### PR DESCRIPTION
This PR makes additions to `.gitignore` which ignores files within `$SPACK_ROOT/share/spack/templates/modules` except the default `modulefile.lua` and `modulefile.tcl`.  I have several custom lua/tcl templates that I'm maintaining which are always seen as untracked files.