### PR TITLE
Make modules always autoload their direct run dependencies

### DIFF
--- a/etc/spack/defaults/modules.yaml
+++ b/etc/spack/defaults/modules.yaml
@@ -16,6 +16,7 @@
 modules:
   enable:
     - tcl
+    - lmod
   prefix_inspections:
     bin:
       - PATH
@@ -43,3 +44,5 @@ modules:
   lmod:
     hierarchy:
       - mpi
+    all:
+      autoload:  'direct'

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -136,7 +136,7 @@ def dependencies(spec, request='all'):
         return []
 
     if request == 'direct':
-        return spec.dependencies(deptype=('link', 'run'))
+        return spec.dependencies(deptype=('run'))
 
     # FIXME : during module file creation nodes seem to be visited multiple
     # FIXME : times even if cover='nodes' is given. This work around permits
@@ -147,7 +147,7 @@ def dependencies(spec, request='all'):
     deps = sorted(
         spec.traverse(order='post',
                       cover='nodes',
-                      deptype=('link', 'run'),
+                      deptype=('run'),
                       root=False),
         reverse=True)
     return [d for d in deps if not (d in seen or seen_add(d))]

--- a/share/spack/templates/modules/modulefile.lua
+++ b/share/spack/templates/modules/modulefile.lua
@@ -62,12 +62,7 @@ setenv("LMOD_{{ name|upper() }}_VERSION", "{{ version_part }}")
 
 {% block autoloads %}
 {% for module in autoload %}
-if not isloaded("{{ module }}") then
-{% if verbose %}
-    LmodMessage("Autoloading {{ module }}")
-{% endif %}
-    load("{{ module }}")
-end
+depends_on("{{ module }}")
 {% endfor %}
 {% endblock %}
 


### PR DESCRIPTION
[edit: fixed link to @adamjstewart's issue]

TODO:

- [ ] Does this have any negative interactions with `spack load`
      (specifically with `spack load -r`)?

  I don't load modules this way, so I'd appreciate feedback.

- [ ] Are there tests that I'm breaking (I'm sure the CI tests will
  let me know, publicly...) or that I should add?

- [ ] Should I add docs somewhere on how to disable this?  If so,
      where?

See #8639 for background and historical discussion.

This change:

1. adds lmod to the list of default module systems;
2. specifies that lmod should generate the autoload bits all direct
   dependencies;
3.  uses the lmod `depends_on` functionality instead of
    `isloaded`/`load`; and
4. changes the module system to only consider *run* dependencies.

Why (by the numbers)?

1. Because lmod is at least as useful as environment_modules, building
   the lua modulefiles doesn't require Lmod so there are no additional
   build-time requirements, and there's no harm to having the
   resulting lua files in the tree

2. So that I can simply `module load py-flake8` and avoid yet another
   embarrassing PR test failure.

3. So that I can then `module unload py-flake8` and get all of that
   stuff out of my environment, unless it's being used by another
   package.

4. Because otherwise I end up with every link time dependency crammed
   into my environment.

   **NOTE:** The length of various search paths and *etc.* are
   limited, so we should do what we can to avoid adding things that
   aren't needed.

   This begs the question, exactly *when* is *link* time?  At the
   moment it seems to be the union of *build* and *run*; some linking
   happens when packages are *built* and some happens as the program
   is *run*.

   Spack works hard to set RPATH values when things are built so that
   dynamic linking that happens at *run* time doesn't require
   additional configuration.

   Packages that can't take advantage of RPATH and/or need to do
   link-ish-smelling things at run time should list those dependencies
   as *run* and arrange to set e.g. LD_LIBRARY_PATH there.

   Perhaps *link* dependencies don't even really exist, but it'd take
   a very big glass of beer (nod to Arlo Guthrie/Steve Goodman) before
   I'd sit through that argument....

But what about:

- *aspell* -- we're still pretty much stuck using activation to make
  aspell dictionaries available.  It's possible to specify a *single*
  directory via ASPELL_CONF, but that's limiting and "someone" would
  have to code up a bit of conflict detection for the modulefiles so
  that they did the right thing.

- TCL modulefiles -- I'm not a user, but they should work too.  If
  they don't let me know (give me a test case, and a suggested fix)
  and I'll happily include it here.

- All the things that I haven't thought of?  Don't be shy....

Fixes #8639.