### PR TITLE
Update diffutils to work around an issue with recent clang releases

### DIFF
--- a/var/spack/repos/builtin/packages/diffutils/package.py
+++ b/var/spack/repos/builtin/packages/diffutils/package.py
@@ -20,7 +20,7 @@ class Diffutils(AutotoolsPackage):
 
     depends_on('libiconv')
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, spack_env, run_env):
         if self.spec.satisfies('%clang@9:'):
             spack_env.append_flags('CFLAGS',
                                    '-Werror=implicit-function-declaration')

--- a/var/spack/repos/builtin/packages/diffutils/package.py
+++ b/var/spack/repos/builtin/packages/diffutils/package.py
@@ -20,7 +20,7 @@ class Diffutils(AutotoolsPackage):
 
     depends_on('libiconv')
 
-    def setup_build_environment(self, spack_env, run_env):
+    def setup_build_environment(self, spack_env):
         if self.spec.satisfies('%clang@9:'):
             spack_env.append_flags('CFLAGS',
                                    '-Werror=implicit-function-declaration')

--- a/var/spack/repos/builtin/packages/diffutils/package.py
+++ b/var/spack/repos/builtin/packages/diffutils/package.py
@@ -22,5 +22,5 @@ class Diffutils(AutotoolsPackage):
 
     def setup_environment(self, spack_env, run_env):
         if self.spec.satisfies('%clang@9:'):
-            spack_env.append_flags('CFLAGS',  
+            spack_env.append_flags('CFLAGS',
                                    '-Werror=implicit-function-declaration')

--- a/var/spack/repos/builtin/packages/diffutils/package.py
+++ b/var/spack/repos/builtin/packages/diffutils/package.py
@@ -19,3 +19,7 @@ class Diffutils(AutotoolsPackage):
     build_directory = 'spack-build'
 
     depends_on('libiconv')
+
+    def setup_environment(self, spack_env, run_env):
+        if self.spec.satisfies('%clang@9:'):
+            spack_env.append_flags('CFLAGS',  '-Werror=implicit-function-declaration')

--- a/var/spack/repos/builtin/packages/diffutils/package.py
+++ b/var/spack/repos/builtin/packages/diffutils/package.py
@@ -22,4 +22,5 @@ class Diffutils(AutotoolsPackage):
 
     def setup_environment(self, spack_env, run_env):
         if self.spec.satisfies('%clang@9:'):
-            spack_env.append_flags('CFLAGS',  '-Werror=implicit-function-declaration')
+            spack_env.append_flags('CFLAGS',  
+                                   '-Werror=implicit-function-declaration')


### PR DESCRIPTION
This is a hacky patch, but resolves #13484 

The problem was that automake attempts to use an implicit function declaration to lint the compiler. With recent clang versions, this generates a warning and not an error. So we override to make that warning back into an error.