### PR TITLE
Fix for overlong shebang in valgrind

### DIFF
--- a/var/spack/repos/builtin/packages/valgrind/package.py
+++ b/var/spack/repos/builtin/packages/valgrind/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+import glob
 import sys
 
 
@@ -67,3 +68,10 @@ clang: error: unknown argument: '-static-libubsan'
         if sys.platform == 'darwin':
             options.append('--build=amd64-darwin')
         return options
+
+    # Valgrind the potential for overlong perl shebangs
+    def patch(self):
+        for link_tool_in in glob.glob('coregrind/link_tool_exe_*.in'):
+            filter_file('^#! @PERL@',
+                        '#! /usr/bin/env perl',
+                        link_tool_in)


### PR DESCRIPTION
Fix for some overlong shebangs in valgrind. Borrowed from verrou/package.py