### PR TITLE
Features/expand microarch for aarch64

### DIFF
--- a/lib/spack/llnl/util/cpu/detect.py
+++ b/lib/spack/llnl/util/cpu/detect.py
@@ -223,3 +223,12 @@ def compatibility_check_for_x86_64(info, target):
     return (target == arch_root or arch_root in target.ancestors) \
         and (target.vendor == vendor or target.vendor == 'generic') \
         and target.features.issubset(features)
+
+@compatibility_check(architecture_family='aarch64')
+def compatibility_check_for_aarch64(info, target):
+    basename = 'aarch64'
+    features = set(info.get('Features', '').split())
+
+    arch_root = targets[basename]
+    return (target == arch_root or arch_root in target.ancestors) \
+        and target.features.issubset(features)

--- a/lib/spack/llnl/util/cpu/detect.py
+++ b/lib/spack/llnl/util/cpu/detect.py
@@ -229,7 +229,9 @@ def compatibility_check_for_x86_64(info, target):
 def compatibility_check_for_aarch64(info, target):
     basename = 'aarch64'
     features = set(info.get('Features', '').split())
+    vendor = info.get('CPU implementer', 'generic')
 
     arch_root = targets[basename]
     return (target == arch_root or arch_root in target.ancestors) \
+        and (target.vendor == vendor or target.vendor == 'generic') \
         and target.features.issubset(features)

--- a/lib/spack/llnl/util/cpu/detect.py
+++ b/lib/spack/llnl/util/cpu/detect.py
@@ -224,6 +224,7 @@ def compatibility_check_for_x86_64(info, target):
         and (target.vendor == vendor or target.vendor == 'generic') \
         and target.features.issubset(features)
 
+
 @compatibility_check(architecture_family='aarch64')
 def compatibility_check_for_aarch64(info, target):
     basename = 'aarch64'

--- a/lib/spack/llnl/util/cpu/microarchitectures.json
+++ b/lib/spack/llnl/util/cpu/microarchitectures.json
@@ -1162,7 +1162,7 @@
       }
     },
     "thunderx2": {
-      "from": aarch64,
+      "from": "aarch64",
       "vendor": "generic",
       "features": [
         "fp",
@@ -1176,10 +1176,21 @@
         "atomics",
         "cpuid",
         "asimdrdm"
-      ]
+      ],
+      "compilers": {
+        "gcc": {
+          "versions": "4.8.0:",
+          "flags": "-march=armv8-a -mtune=generic"
+        },
+        "clang": {
+          "versions": ":",
+          "family": "aarch64",
+          "flags": "-march={family} -mcpu=generic"
+        }
+      }
     },
     "a64fx": {
-      "from": aarch64,
+      "from": "aarch64",
       "vendor": "fujitsu",
       "features": [
         "fp",
@@ -1198,7 +1209,18 @@
         "fcma",
         "dcpop",
         "sve"
-      ]
+      ],
+      "compilers": {
+        "gcc": {
+          "versions": "4.8.0:",
+          "flags": "-march=armv8-a -mtune=generic"
+        },
+        "clang": {
+          "versions": ":",
+          "family": "aarch64",
+          "flags": "-march={family} -mcpu=generic"
+        }
+      }
     },
     "arm": {
       "from": null,

--- a/lib/spack/llnl/util/cpu/microarchitectures.json
+++ b/lib/spack/llnl/util/cpu/microarchitectures.json
@@ -1163,7 +1163,7 @@
     },
     "thunderx2": {
       "from": "aarch64",
-      "vendor": "generic",
+      "vendor": "0x43",
       "features": [
         "fp",
         "asimd",
@@ -1178,10 +1178,24 @@
         "asimdrdm"
       ],
       "compilers": {
-        "gcc": {
-          "versions": "4.8.0:",
-          "flags": "-march=armv8-a -mtune=generic"
-        },
+        "gcc": [
+          {
+            "versions": "4.8",
+            "flags": "-march=armv8-a"
+          },
+          {
+            "versions": "4.9:5",
+            "flags": "-march=armv8-a+crc+crypto"
+          },
+          {
+            "versions": "6",
+            "flags": "-march=armv8.1-a+crc+crypto"
+          },
+          {
+            "versions": "7:",
+            "flags": "-mcpu=thunderx2t99"
+          }
+        ],
         "clang": {
           "versions": ":",
           "family": "aarch64",
@@ -1191,7 +1205,7 @@
     },
     "a64fx": {
       "from": "aarch64",
-      "vendor": "fujitsu",
+      "vendor": "0x46",
       "features": [
         "fp",
         "asimd",
@@ -1211,10 +1225,28 @@
         "sve"
       ],
       "compilers": {
-        "gcc": {
-          "versions": "4.8.0:",
-          "flags": "-march=armv8-a -mtune=generic"
-        },
+        "gcc": [
+          {
+            "versions": "4.8",
+            "flags": "-march=armv8-a"
+          },
+          {
+            "versions": "4.9:5",
+            "flags": "-march=armv8-a+crc+crypto"
+          },
+          {
+            "versions": "6",
+            "flags": "-march=armv8.1-a+crc+crypto"
+          },
+          {
+            "versions": "7",
+            "flags": "-arch=armv8.2a+crc+crypt+fp16"
+          },
+          {
+            "versions": "8:",
+            "flags": "-arch=armv8.2a+crc+aes+sh2+fp16+sve -msve-vector-bits=512"
+          }
+        ],
         "clang": {
           "versions": ":",
           "family": "aarch64",

--- a/lib/spack/llnl/util/cpu/microarchitectures.json
+++ b/lib/spack/llnl/util/cpu/microarchitectures.json
@@ -1161,6 +1161,45 @@
         }
       }
     },
+    "thunderx2": {
+      "from": aarch64,
+      "vendor": "generic",
+      "features": [
+        "fp",
+        "asimd",
+        "evtstrm",
+        "aes",
+        "pmull",
+        "sha1",
+        "sha2",
+        "crc32",
+        "atomics",
+        "cpuid",
+        "asimdrdm"
+      ]
+    },
+    "a64fx": {
+      "from": aarch64,
+      "vendor": "fujitsu",
+      "features": [
+        "fp",
+        "asimd",
+        "evtstrm",
+        "aes",
+        "pmull",
+        "sha1",
+        "sha2",
+        "crc32",
+        "atomics",
+        "cpuid",
+        "asimdrdm",
+        "fphp",
+        "asimdhp",
+        "fcma",
+        "dcpop",
+        "sve"
+      ]
+    },
     "arm": {
       "from": null,
       "vendor": "generic",

--- a/lib/spack/llnl/util/cpu/microarchitectures.json
+++ b/lib/spack/llnl/util/cpu/microarchitectures.json
@@ -1180,15 +1180,15 @@
       "compilers": {
         "gcc": [
           {
-            "versions": "4.8",
+            "versions": "4.8:4.8.9",
             "flags": "-march=armv8-a"
           },
           {
-            "versions": "4.9:5",
+            "versions": "4.9:5.9",
             "flags": "-march=armv8-a+crc+crypto"
           },
           {
-            "versions": "6",
+            "versions": "6:6.9",
             "flags": "-march=armv8.1-a+crc+crypto"
           },
           {
@@ -1198,8 +1198,7 @@
         ],
         "clang": {
           "versions": ":",
-          "family": "aarch64",
-          "flags": "-march={family} -mcpu=generic"
+          "flags": "-march=armv8-a -mcpu=generic"
         }
       }
     },
@@ -1227,19 +1226,19 @@
       "compilers": {
         "gcc": [
           {
-            "versions": "4.8",
+            "versions": "4.8:4.8.9",
             "flags": "-march=armv8-a"
           },
           {
-            "versions": "4.9:5",
+            "versions": "4.9:5.9",
             "flags": "-march=armv8-a+crc+crypto"
           },
           {
-            "versions": "6",
+            "versions": "6:6.9",
             "flags": "-march=armv8.1-a+crc+crypto"
           },
           {
-            "versions": "7",
+            "versions": "7:7.9",
             "flags": "-arch=armv8.2a+crc+crypt+fp16"
           },
           {
@@ -1249,8 +1248,7 @@
         ],
         "clang": {
           "versions": ":",
-          "family": "aarch64",
-          "flags": "-march={family} -mcpu=generic"
+          "flags": "-march=armv8-a -mcpu=generic"
         }
       }
     },

--- a/lib/spack/spack/test/data/targets/linux-centos7-thunderx2
+++ b/lib/spack/spack/test/data/targets/linux-centos7-thunderx2
@@ -1,0 +1,8 @@
+processor       : 0
+BogoMIPS        : 400.00
+Features        : fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics cpuid asimdrdm
+CPU implementer : 0x43
+CPU architecture: 8
+CPU variant     : 0x1
+CPU part        : 0x0af
+CPU revision    : 1

--- a/lib/spack/spack/test/llnl/util/cpu.py
+++ b/lib/spack/spack/test/llnl/util/cpu.py
@@ -32,6 +32,7 @@ from llnl.util.cpu import Microarchitecture  # noqa
     'linux-scientific7-piledriver',
     'linux-rhel6-piledriver',
     'linux-centos7-power8le',
+    'linux-centos7-thunderx2',
     'darwin-mojave-ivybridge',
     'darwin-mojave-haswell',
     'darwin-mojave-skylake',
@@ -121,6 +122,8 @@ def test_equality(supported_target):
     ('piledriver <= steamroller', True),
     ('zen2 >= zen', True),
     ('zen >= zen', True),
+    ('aarch64 <= thunderx2', True),
+    ('aarch64 <= a64fx', True),
     # Test unrelated microarchitectures
     ('power8 < skylake', False),
     ('power8 <= skylake', False),
@@ -205,12 +208,15 @@ def test_target_json_schema():
     ('nehalem', 'gcc', '4.9.3', '-march=nehalem -mtune=nehalem'),
     ('nehalem', 'gcc', '4.8.5', '-march=corei7 -mtune=corei7'),
     ('sandybridge', 'gcc', '4.8.5', '-march=corei7-avx -mtune=corei7-avx'),
+    ('thunderx2', 'gcc', '4.8.5', '-march=armv8-a'),
+    ('thunderx2', 'gcc', '4.9.3', '-march=armv8-a+crc+crypto'),
     # Test Clang / LLVM
     ('sandybridge', 'clang', '3.9.0', '-march=x86-64 -mcpu=sandybridge'),
     ('icelake', 'clang', '6.0.0', '-march=x86-64 -mcpu=icelake'),
     ('icelake', 'clang', '8.0.0', '-march=x86-64 -mcpu=icelake-client'),
     ('zen2', 'clang', '9.0.0', '-march=x86-64 -mcpu=znver2'),
     ('power9le', 'clang', '8.0.0', '-march=ppc64le -mcpu=pwr9'),
+    ('thunderx2', 'clang', '6.0.0', '-march=armv8-a -mcpu=generic'),
     # Test Intel on Intel CPUs
     ('sandybridge', 'intel', '17.0.2', '-march=corei7-avx -mtune=corei7-avx'),
     ('sandybridge', 'intel', '18.0.5',


### PR DESCRIPTION
* Add microarchitecture branching from `aarch64`
　Add `thunderx2` microarchitecture and `a64fx` microarchitecture.
* Add process to determine `aarch64`microarchitecture
　Information field got from `/proc/cpuinfo` of `aarch64` and `x86_64` are different.
　features information is got from `Features` in `/proc/cpuinfo` of `aarch64`.
　vendor information is got from `CPU implementer` in `/proc/cpuinfo` of `aarch64`.