### PR TITLE
py-numexpr3: Fixed version

### DIFF
--- a/var/spack/repos/builtin/packages/py-numexpr3/package.py
+++ b/var/spack/repos/builtin/packages/py-numexpr3/package.py
@@ -20,7 +20,7 @@ class PyNumexpr3(PythonPackage):
     homepage = "https://github.com/pydata/numexpr/tree/numexpr-3.0"
     url = "https://pypi.io/packages/source/n/numexpr3/numexpr3-3.0.1a1.tar.gz"
 
-    version('3.0.1.a1', sha256sum='de06f1b4206704b5bc19ea09b5c94350b97c211c26bc866f275252a8461b87e6')
+    version('3.0.1a1', sha256='de06f1b4206704b5bc19ea09b5c94350b97c211c26bc866f275252a8461b87e6')
     # TODO: Add CMake build system for better control of passing flags related
     # to CPU ISA.
 


### PR DESCRIPTION
I corrected the version referring to the following.
https://pypi.org/project/numexpr3/