### PR TITLE
environments: allow 'add' command to add virtuals

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -811,9 +811,10 @@ class Environment(object):
                 raise SpackEnvironmentError(
                     'cannot add anonymous specs to an environment!')
             elif not spack.repo.path.exists(spec.name):
-                valid_virtuals = spack.repo.path.provider_index.providers.keys()
-                if spec.name not in valid_virtuals:
-                    raise SpackEnvironmentError('no such package: %s' % spec.name)
+                virtuals = spack.repo.path.provider_index.providers.keys()
+                if spec.name not in virtuals:
+                    msg = 'no such package: %s' % spec.name
+                    raise SpackEnvironmentError(msg)
 
         list_to_change = self.spec_lists[list_name]
         existing = str(spec) in list_to_change.yaml_list

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -811,7 +811,9 @@ class Environment(object):
                 raise SpackEnvironmentError(
                     'cannot add anonymous specs to an environment!')
             elif not spack.repo.path.exists(spec.name):
-                raise SpackEnvironmentError('no such package: %s' % spec.name)
+                valid_virtuals = spack.repo.path.provider_index.providers.keys()
+                if spec.name not in valid_virtuals:
+                    raise SpackEnvironmentError('no such package: %s' % spec.name)
 
         list_to_change = self.spec_lists[list_name]
         existing = str(spec) in list_to_change.yaml_list

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -63,6 +63,27 @@ def test_add():
     assert Spec('mpileaks') in e.user_specs
 
 
+def test_env_add_virtual():
+    env('create', 'test')
+
+    e = ev.read('test')
+    e.add('mpi')
+    e.concretize()
+
+    hashes = e.concretized_order
+    assert len(hashes) == 1
+    spec = e.specs_by_hash[hashes[0]]
+    assert spec.satisfies('mpi')
+
+
+def test_env_add_nonexistant_fails():
+    env('create', 'test')
+
+    e = ev.read('test')
+    with pytest.raises(ev.SpackEnvironmentError, match=r'no such package'):
+        e.add('thispackagedoesnotexist')
+
+
 def test_env_list(mutable_mock_env_path):
     env('create', 'foo')
     env('create', 'bar')
@@ -1777,7 +1798,7 @@ def test_duplicate_packages_raise_when_concretizing_together():
 
 
 def test_env_write_only_non_default():
-    print(env('create', 'test'))
+    env('create', 'test')
 
     e = ev.read('test')
     with open(e.manifest_path, 'r') as f:


### PR DESCRIPTION
@sethrj requested the ability to add virtual packages to environments using `spack add`.

This PR allows virtual packages to be added to the `specs` list using the `add` command.

Virtual packages are already allowed in named lists in spack environments/stacks.

Virtual packages are already allowed in the `specs` list when added using the yaml directly.