### PR TITLE
Bugfix/mirror all patch conflicts

### DIFF
--- a/lib/spack/spack/caches.py
+++ b/lib/spack/spack/caches.py
@@ -53,24 +53,26 @@ class MirrorCache(object):
     def __init__(self, root):
         self.root = os.path.abspath(root)
 
-    def store(self, fetcher, relative_dest, cosmetic_path=None):
+    def store(self, fetcher, relative_dest):
+        """Fetch and relocate the fetcher's target into our mirror cache."""
+
         # Note this will archive package sources even if they would not
         # normally be cached (e.g. the current tip of an hg/git branch)
         dst = os.path.join(self.root, relative_dest)
         mkdirp(os.path.dirname(dst))
         fetcher.archive(dst)
 
-        # Add a symlink path that a human can read to understand what resource
-        # the archive path refers to
-        if not cosmetic_path:
-            return
-        cosmetic_path = os.path.join(self.root, cosmetic_path)
+    def symlink(self, mirror_ref):
+        """Symlink a human readible path in our mirror to the actual
+        storage location."""
+
+        cosmetic_path = os.path.join(self.root, mirror_ref.cosmetic_path)
         relative_dst = os.path.relpath(
-            dst, start=os.path.dirname(cosmetic_path))
+            mirror_path.storage_path,
+            start=os.path.dirname(cosmetic_path))
         if not os.path.exists(cosmetic_path):
             mkdirp(os.path.dirname(cosmetic_path))
             os.symlink(relative_dst, cosmetic_path)
-
 
 #: Spack's local cache for downloaded source archives
 fetch_cache = llnl.util.lang.Singleton(_fetch_cache)

--- a/lib/spack/spack/caches.py
+++ b/lib/spack/spack/caches.py
@@ -68,11 +68,12 @@ class MirrorCache(object):
 
         cosmetic_path = os.path.join(self.root, mirror_ref.cosmetic_path)
         relative_dst = os.path.relpath(
-            mirror_path.storage_path,
+            mirror_ref.storage_path,
             start=os.path.dirname(cosmetic_path))
         if not os.path.exists(cosmetic_path):
             mkdirp(os.path.dirname(cosmetic_path))
             os.symlink(relative_dst, cosmetic_path)
+
 
 #: Spack's local cache for downloaded source archives
 fetch_cache = llnl.util.lang.Singleton(_fetch_cache)

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -522,7 +522,7 @@ def add_single_spec(spec, mirror_root, mirror_stats):
         else:
             tty.warn(
                 "Error while fetching %s" % spec.cformat('{name}{@version}'),
-                exception.message if hasattr(exception, 'message') else exception)
+                getattr(exception, 'message', exception))
         mirror_stats.error()
 
 

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -522,7 +522,7 @@ def add_single_spec(spec, mirror_root, mirror_stats):
         else:
             tty.warn(
                 "Error while fetching %s" % spec.cformat('{name}{@version}'),
-                exception.message)
+                exception.message if hasattr(exception, 'message') else exception)
         mirror_stats.error()
 
 

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -206,7 +206,7 @@ class UrlPatch(Patch):
         per_package_ref = os.path.join(self.owner.split('.')[-1], name)
         # Reference starting with "spack." is required to avoid cyclic imports
         mirror_ref = spack.mirror.mirror_archive_paths(
-            fetcher, 
+            fetcher,
             per_package_ref)
 
         self.stage = spack.stage.Stage(fetcher, mirror_paths=mirror_ref)
@@ -227,7 +227,7 @@ class UrlPatch(Patch):
             else:
                 raise NoSuchPatchError(
                     "Patch failed to download: %s" % self.url)
- 
+
         self.path = os.path.join(root, files.pop())
 
         if not os.path.isfile(self.path):

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -199,13 +199,15 @@ class UrlPatch(Patch):
         fetcher = fs.URLFetchStrategy(self.url, fetch_digest,
                                       expand=bool(self.archive_sha256))
 
-        # The same package can have multiple patches with the same name but with 
-        # different contents, therefore apply a subset of the hash.
+        # The same package can have multiple patches with the same name but
+        # with different contents, therefore apply a subset of the hash.
         name = '{0}-{1}'.format(os.path.basename(self.url), fetch_digest[:7])
 
         per_package_ref = os.path.join(self.owner.split('.')[-1], name)
         # Reference starting with "spack." is required to avoid cyclic imports
-        mirror_ref = spack.mirror.mirror_archive_paths(fetcher, per_package_ref)
+        mirror_ref = spack.mirror.mirror_archive_paths(
+            fetcher, 
+            per_package_ref)
 
         self.stage = spack.stage.Stage(fetcher, mirror_paths=mirror_ref)
         self.stage.create()
@@ -225,8 +227,7 @@ class UrlPatch(Patch):
             else:
                 raise NoSuchPatchError(
                     "Patch failed to download: %s" % self.url)
-
-        
+ 
         self.path = os.path.join(root, files.pop())
 
         if not os.path.isfile(self.path):

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -199,11 +199,9 @@ class UrlPatch(Patch):
         fetcher = fs.URLFetchStrategy(self.url, fetch_digest,
                                       expand=bool(self.archive_sha256))
 
-        # Patch url's can be ambiguous - The same patch name can have different
-        # versions that apply to different versions of the package. We append
-        # a bit of the hash to differentiate them. (Collision odds are exceedingly low
-        # given how few of these there should be, including b-day attack odds). 
-        name = '{0}-{1}'.format(os.path.basename(self.url), fetch_digest[:8])
+        # The same package can have multiple patches with the same name but with 
+        # different contents, therefore apply a subset of the hash.
+        name = '{0}-{1}'.format(os.path.basename(self.url), fetch_digest[:7])
 
         per_package_ref = os.path.join(self.owner.split('.')[-1], name)
         # Reference starting with "spack." is required to avoid cyclic imports

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -506,7 +506,7 @@ class Stage(object):
                 self.fetcher, self.mirror_paths.storage_path)
             stats.added(absolute_storage_path)
 
-        self.caches.mirror_cache.symlink(self.mirror_paths)
+        spack.caches.mirror_cache.symlink(self.mirror_paths)
 
     def expand_archive(self):
         """Changes to the stage directory and attempt to expand the downloaded

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -498,16 +498,15 @@ class Stage(object):
         absolute_storage_path = os.path.join(
             dst_root, self.mirror_paths.storage_path)
 
-        if (os.path.exists(absolute_storage_path) and
-                os.path.exists(self.mirror_paths.cosmetic_path)):
+        if os.path.exists(absolute_storage_path):
             stats.already_existed(absolute_storage_path)
-            return
+        else:
+            self.fetch()
+            spack.caches.mirror_cache.store(
+                self.fetcher, self.mirror_paths.storage_path)
+            stats.added(absolute_storage_path)
 
-        self.fetch()
-        spack.caches.mirror_cache.store(
-            self.fetcher, self.mirror_paths.storage_path,
-            self.mirror_paths.cosmetic_path)
-        stats.added(absolute_storage_path)
+        self.caches.mirror_cache.symlink(self.mirror_paths)
 
     def expand_archive(self):
         """Changes to the stage directory and attempt to expand the downloaded

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -498,7 +498,8 @@ class Stage(object):
         absolute_storage_path = os.path.join(
             dst_root, self.mirror_paths.storage_path)
 
-        if os.path.exists(absolute_storage_path):
+        if (os.path.exists(absolute_storage_path) and
+                os.path.exists(self.mirror_paths.cosmetic_path)):
             stats.already_existed(absolute_storage_path)
             return
 

--- a/var/spack/repos/builtin/packages/mpfr/package.py
+++ b/var/spack/repos/builtin/packages/mpfr/package.py
@@ -39,10 +39,8 @@ class Mpfr(AutotoolsPackage):
     }
 
     for ver, checksum in patches.items():
-        patch(
-            'https://www.mpfr.org/mpfr-{0}/allpatches'.format(ver),
-            when='@' + ver, 
-            sha256=checksum)
+        patch('https://www.mpfr.org/mpfr-{0}/allpatches'.format(ver),
+              when='@' + ver, sha256=checksum)
 
     def flag_handler(self, name, flags):
         # Work around macOS Catalina / Xcode 11 code generation bug

--- a/var/spack/repos/builtin/packages/mpfr/package.py
+++ b/var/spack/repos/builtin/packages/mpfr/package.py
@@ -39,8 +39,10 @@ class Mpfr(AutotoolsPackage):
     }
 
     for ver, checksum in patches.items():
-        patch('https://www.mpfr.org/mpfr-{0}/allpatches'.format(ver),
-              when='@' + ver, sha256=checksum)
+        patch(
+            'https://www.mpfr.org/mpfr-{0}/allpatches'.format(ver),
+            when='@' + ver, 
+            sha256=checksum)
 
     def flag_handler(self, name, flags):
         # Work around macOS Catalina / Xcode 11 code generation bug


### PR DESCRIPTION
Closes https://github.com/spack/spack/pull/13622

 - Appends part of the patch has to the patch name to differentiate
   patches with the same name (for the same package).
 - Patches are re-downloaded if the file isn't at the storage path
   or it's cosmetic name are missing.
 - Fixed an exception handling error in mirror.py (not all exceptions)
   have a 'message' attribute.

