### PR TITLE
lsof: fix url and checksum

### DIFF
--- a/var/spack/repos/builtin/packages/lsof/package.py
+++ b/var/spack/repos/builtin/packages/lsof/package.py
@@ -10,8 +10,11 @@ class Lsof(Package):
     """Lsof displays information about files open to Unix processes."""
 
     homepage = "https://people.freebsd.org/~abe/"
-    url      = "https://www.mirrorservice.org/sites/lsof.itap.purdue.edu/pub/tools/unix/lsof/OLD/lsof_4.89.tar.gz"
+    url      = "https://www.mirrorservice.org/sites/lsof.itap.purdue.edu/pub/tools/unix/lsof/lsof_4.91.tar.gz"
+    list_url = "https://www.mirrorservice.org/sites/lsof.itap.purdue.edu/pub/tools/unix/lsof/OLD/"
 
+    version('4.91', sha256='3ca57887470fdf223a8e8aae4559cd3a26787bea93b94336c90ee8062e29e352')
+    version('4.90', sha256='27794d3d6499fd5f0f08710b4518b33aed8a4580951d1adf27f6c25898685c9e')
     version('4.89', sha256='5d08da7ebe049c9d9a6472d6afb81aa5af54c4733a3f8822cbc22b57867633c9')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/lsof/package.py
+++ b/var/spack/repos/builtin/packages/lsof/package.py
@@ -10,9 +10,9 @@ class Lsof(Package):
     """Lsof displays information about files open to Unix processes."""
 
     homepage = "https://people.freebsd.org/~abe/"
-    url      = "https://www.mirrorservice.org/sites/lsof.itap.purdue.edu/pub/tools/unix/lsof/lsof_4.89.tar.gz"
+    url      = "https://www.mirrorservice.org/sites/lsof.itap.purdue.edu/pub/tools/unix/lsof/OLD/lsof_4.89.tar.gz"
 
-    version('4.89', sha256='ff4ac555966b587f06338475c8fcc0f41402b4c8e970e730f6f83b62be8b5c0d')
+    version('4.89', sha256='5d08da7ebe049c9d9a6472d6afb81aa5af54c4733a3f8822cbc22b57867633c9')
 
     def install(self, spec, prefix):
         tar = which('tar')


### PR DESCRIPTION
I got following error when installing `lsof`.
"The requested url returned error: 404 Not Found"

I changed the download url and I fixed the checksum because the checksum of version 4.89 has changed.