### PR TITLE
cctools: fix python related error.

### DIFF
--- a/var/spack/repos/builtin/packages/cctools/cctools_6.1.1.python.patch
+++ b/var/spack/repos/builtin/packages/cctools/cctools_6.1.1.python.patch
@@ -1,0 +1,11 @@
+--- spack-src.org/umbrella/src/Makefile	2017-05-30 20:49:30.000000000 +0900
++++ spack-src/umbrella/src/Makefile	2019-11-20 17:23:42.101854924 +0900
+@@ -16,7 +16,7 @@
+ 
+ umbrella_helper.html: umbrella.py
+ 	# pydoc2/pydoc creates a html file, umbrella.html.
+-	if which pydoc2; then pydoc2 -w umbrella; elif which pydoc; then pydoc -w umbrella; fi
++	if which pydoc; then pydoc -w umbrella; elif which pydoc2; then pydoc2 -w umbrella; fi
+ 	if [ -f umbrella.html ]; then mv umbrella.html umbrella_helper.html; fi
+ 
+ clean:

--- a/var/spack/repos/builtin/packages/cctools/cctools_7.0.18.python.patch
+++ b/var/spack/repos/builtin/packages/cctools/cctools_7.0.18.python.patch
@@ -1,0 +1,69 @@
+--- spack-src.org/configure	2019-11-20 16:51:17.667672077 +0900
++++ spack-src/configure	2019-11-20 16:53:21.507295667 +0900
+@@ -973,6 +973,7 @@
+ 	fi
+ fi
+ 
++PYDOC=""
+ python=0    #to be set to the python path
+ if [ $config_python_path != no ]
+ then
+@@ -982,9 +983,23 @@
+ elif check_file ${python_path}/bin/python2
+ then
+ 	python=${python_path}/bin/python2
++	if check_file ${python_path}/bin/pydoc
++	then
++			PYDOC=${python_path}/bin/pydoc
++	elif check_file ${python_path}/bin/pydoc2
++	then
++			PYDOC=${python_path}/bin/pydoc2
++	fi
+ elif check_file ${python_path}/bin/python
+ then
+ 	python=${python_path}/bin/python
++	if check_file ${python_path}/bin/pydoc
++	then
++			PYDOC=${python_path}/bin/pydoc
++	elif check_file ${python_path}/bin/pydoc2
++	then
++			PYDOC=${python_path}/bin/pydoc2
++	fi
+ else
+ 	python=0
+ fi
+@@ -1056,7 +1071,7 @@
+ fi
+ fi
+ 
+-if [ $python_dev = no ]
++if [ "$python_dev" = no ]
+ then
+ 	if [ $config_python_path = yes ]
+ 	then
+@@ -1089,6 +1104,16 @@
+ 	else
+ 		python3=0
+ 	fi
++	if [ "$PYDOC" = "" ]
++	then
++		if check_file ${python3_path}/bin/pydoc
++	    then
++			PYDOC=${python3_path}/bin/pydoc
++	    elif check_file ${python3_path}/bin/pydoc3
++		then
++			PYDOC=${python3_path}/bin/pydoc3
++	    fi
++	fi
+ 	if [ $python3 != 0 ]
+ 	then
+ 		python3_version=`${python3} -V 2>&1 | cut -d " " -f 2`
+@@ -1630,7 +1655,7 @@
+ CCTOOLS_PYTHON3_2TO3=${python3_2to3}
+ CCTOOLS_PYTHON3_PATH=\$(CCTOOLS_INSTALL_DIR)/lib/python\$(CCTOOLS_PYTHON3_VERSION)/site-packages
+ 
+-CCTOOLS_PYDOC=$(which pydoc 2> /dev/null || which pydoc2 2> /dev/null || which pydoc3 > /dev/null)
++CCTOOLS_PYDOC=${PYDOC}
+ 
+ CCTOOLS_SGE_PARAMETERS=$(echo ${sge_parameters} | sed -e 's/\$/\\\$\$/g')
+ 

--- a/var/spack/repos/builtin/packages/cctools/cctools_7.0.18.python.patch
+++ b/var/spack/repos/builtin/packages/cctools/cctools_7.0.18.python.patch
@@ -1,6 +1,6 @@
---- spack-src.org/configure	2019-11-20 16:51:17.667672077 +0900
-+++ spack-src/configure	2019-11-20 16:53:21.507295667 +0900
-@@ -973,6 +973,7 @@
+--- spack-src.org/configure	2019-11-25 14:33:33.991883993 +0900
++++ spack-src/configure	2019-11-25 14:47:11.591066274 +0900
+@@ -973,18 +973,46 @@
  	fi
  fi
  
@@ -8,7 +8,22 @@
  python=0    #to be set to the python path
  if [ $config_python_path != no ]
  then
-@@ -982,9 +983,23 @@
+ 	if [ -n "$PYTHON" ] && check_file ${PYTHON}
+ then
+ 	python=${PYTHON}
++	python_dir=`dirname ${PYTHON}`
++	python_cmd=`basename ${PYTHON}`
++	pydoc_cmd=`echo $python_cmd | sed s/python/pydoc/`
++	pydoc2_cmd=`echo $python_cmd | sed s/python/pydoc2/`
++	pydoc=${python_dir}/${pydoc_cmd}
++	pydoc2=${python_dir}/${pydoc2_cmd}
++	if check_file $pydoc
++	then
++	    PYDOC=$pydoc
++    elif check_file $pydoc2
++	then
++	    PYDOC=$pydoc2
++    fi
  elif check_file ${python_path}/bin/python2
  then
  	python=${python_path}/bin/python2
@@ -32,7 +47,7 @@
  else
  	python=0
  fi
-@@ -1056,7 +1071,7 @@
+@@ -1056,7 +1084,7 @@
  fi
  fi
  
@@ -41,24 +56,56 @@
  then
  	if [ $config_python_path = yes ]
  	then
-@@ -1089,6 +1104,16 @@
+@@ -1073,12 +1101,48 @@
+ 	if [ -n "$PYTHON3" ] && check_file ${PYTHON3}
+ 	then
+ 		python3=${PYTHON3}
++		if [ "$PYDOC" = "" ]
++		then
++		    python_dir=`dirname ${PYTHON3}`
++			python_cmd=`basename ${PYTHON3}`
++			pydoc_cmd=`echo $python_cmd | sed s/python/pydoc/`
++			pydoc3_cmd=`echo $python_cmd | sed s/python/pydoc3/`
++			pydoc=${python_dir}/${pydoc_cmd}
++			pydoc3=${python_dir}/${pydoc3_cmd}
++			if check_file $pydoc
++			then
++			    PYDOC=$pydoc
++		    elif heck_file $pydoc3
++			then
++			    PYDOC=$pydoc3
++			fi
++        fi
+ 	elif check_file ${python3_path}/bin/python3
+ 	then
+ 		python3=${python3_path}/bin/python3
++		if [ "$PYDOC" = "" ]
++		then
++		    if check_file ${python3_path}/bin/pydoc
++			then
++			    PYDOC=${python3_path}/bin/pydoc
++		    elif check_file ${python3_path}/bin/pydoc3
++			then
++			    PYDOC=${python3_path}/bin/pydoc3
++			fi
++		fi
+ 	elif check_file ${python3_path}/bin/python
+ 	then
+ 		python3=${python3_path}/bin/python
++		if [ "$PYDOC" = "" ]
++		then
++		    if check_file ${python3_path}/bin/pydoc
++			then
++			    PYDOC=${python3_path}/bin/pydoc
++		    elif check_file ${python3_path}/bin/pydoc3
++			then
++			    PYDOC=${python3_path}/bin/pydoc3
++			fi
++		fi
  	else
  		python3=0
  	fi
-+	if [ "$PYDOC" = "" ]
-+	then
-+		if check_file ${python3_path}/bin/pydoc
-+	    then
-+			PYDOC=${python3_path}/bin/pydoc
-+	    elif check_file ${python3_path}/bin/pydoc3
-+		then
-+			PYDOC=${python3_path}/bin/pydoc3
-+	    fi
-+	fi
- 	if [ $python3 != 0 ]
- 	then
- 		python3_version=`${python3} -V 2>&1 | cut -d " " -f 2`
-@@ -1630,7 +1655,7 @@
+@@ -1630,7 +1694,7 @@
  CCTOOLS_PYTHON3_2TO3=${python3_2to3}
  CCTOOLS_PYTHON3_PATH=\$(CCTOOLS_INSTALL_DIR)/lib/python\$(CCTOOLS_PYTHON3_VERSION)/site-packages
  

--- a/var/spack/repos/builtin/packages/cctools/package.py
+++ b/var/spack/repos/builtin/packages/cctools/package.py
@@ -20,12 +20,15 @@ class Cctools(AutotoolsPackage):
 
     depends_on('openssl')
     depends_on('perl+shared', type=('build', 'run'))
-    depends_on('python@:3', type=('build', 'run'))
+    depends_on('python@:2.9', when='@6.1.1', type=('build', 'run'))
+    depends_on('python', type=('build', 'run'))
     depends_on('readline')
     depends_on('swig')
     # depends_on('xrootd')
     depends_on('zlib')
     patch('arm.patch', when='target=aarch64:')
+    patch('cctools_7.0.18.python.patch', when='@7.0.18')
+    patch('cctools_6.1.1.python.patch', when='@6.1.1')
 
     # Generally SYS_foo is defined to __NR_foo (sys/syscall.h) which
     # is then defined to a syscall number (asm/unistd_64.h).  Certain
@@ -41,10 +44,21 @@ class Cctools(AutotoolsPackage):
 
     def configure_args(self):
         args = []
+        # For python
+        if self.spec.satisfies('^python@3:'):
+            args.append('--with-python-path=no')
+            args.append(
+                '--with-python3-path={0}'.format(self.spec['python'].prefix)
+            )
+        else:
+            args.append('--with-python3-path=no')
+            args.append(
+                '--with-python-path={0}'.format(self.spec['python'].prefix)
+            )
         # disable these bits
-        for p in ['mysql', 'python3', 'xrootd']:
+        for p in ['mysql', 'xrootd']:
             args.append('--with-{0}-path=no'.format(p))
         # point these bits at the Spack installations
-        for p in ['openssl', 'perl', 'python', 'readline', 'swig', 'zlib']:
+        for p in ['openssl', 'perl', 'readline', 'swig', 'zlib']:
             args.append('--with-{0}-path={1}'.format(p, self.spec[p].prefix))
         return args


### PR DESCRIPTION
cctools configure option is separated python2 and python3.
But package.py allows python3 and specfies as python2.
Also cctools use pydoc but pydoc version is mismatch to specify spack.
(If pydoc2 is existed in PATH, cctools is used pydoc2, but spack installed python2 is installed pydoc.)

* python option of configure is corrrect.
* In version 7.0.18, pydoc is used as dependent python.
* In version 6.1.1, use pydoc insted of pydoc2.