### PR TITLE
Remove warning from the "Custom Extensions" section of the docs

### DIFF
--- a/lib/spack/docs/extensions.rst
+++ b/lib/spack/docs/extensions.rst
@@ -9,12 +9,6 @@
 Custom Extensions
 =================
 
-.. warning::
-
-   The support for extending Spack with custom commands is still experimental.
-   Users should expect APIs or prescribed directory structures to
-   change at any time.
-
 *Spack extensions* permit you to extend Spack capabilities by deploying your
 own custom commands or logic in an arbitrary location on your filesystem.
 This might be extremely useful e.g. to develop and maintain a command whose purpose is


### PR DESCRIPTION
Extensions have been available for a while and the overall design seems solid enough to be extended without losing backward compatibility.