### PR TITLE
Add c-ares 1.15.0

### DIFF
--- a/var/spack/repos/builtin/packages/c-ares/package.py
+++ b/var/spack/repos/builtin/packages/c-ares/package.py
@@ -10,10 +10,11 @@ class CAres(CMakePackage):
     """c-ares: A C library for asynchronous DNS requests"""
 
     homepage = "https://c-ares.haxx.se"
-    url      = "https://github.com/c-ares/c-ares/archive/cares-1_13_0.tar.gz"
+    url      = "https://github.com/c-ares/c-ares/archive/cares-1_15_0.tar.gz"
     git      = "https://github.com/c-ares/c-ares.git"
 
-    version('develop', branch='master')
+    version('master', branch='master')
+    version('1.15.0', sha256='7deb7872cbd876c29036d5f37e30c4cbc3cc068d59d8b749ef85bb0736649f04')
     version('1.13.0', sha256='7c48c57706a38691041920e705d2a04426ad9c68d40edd600685323f214b2d57')
 
     def url_for_version(self, version):


### PR DESCRIPTION
This version fixes a bug on macOS where the library wasn't correctly RPATHed.

Successfully installs on macOS 10.15.1 with Clang 11.0.0.