### PR TITLE
Add mg, a gnu-emacs like fork of microemacs

### DIFF
--- a/var/spack/repos/builtin/packages/mg/package.py
+++ b/var/spack/repos/builtin/packages/mg/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class Mg(AutotoolsPackage):
+class Mg(Package):
     """Mg is intended to be a small, fast, and portable editor for people
     who can't (or don't want to) run emacs for one reason or another,
     or are not familiar with the vi editor. It is compatible with
@@ -20,8 +20,17 @@ class Mg(AutotoolsPackage):
 
     depends_on('ncurses')
 
-    def configure_args(self):
+    phases = ['configure', 'build', 'install']
+
+    def configure(self, spec, prefix):
+        configure = Executable('./configure')
         args = [
             '--mandir={0}'.format(self.prefix.man),
         ]
-        return args
+        configure(*args)
+
+    def build(self, spec, prefix):
+        make()
+
+    def install(self, spec, prefix):
+        make('install')

--- a/var/spack/repos/builtin/packages/mg/package.py
+++ b/var/spack/repos/builtin/packages/mg/package.py
@@ -1,0 +1,27 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Mg(AutotoolsPackage):
+    """Mg is intended to be a small, fast, and portable editor for people
+    who can't (or don't want to) run emacs for one reason or another,
+    or are not familiar with the vi editor. It is compatible with
+    emacs because there shouldn't be any reason to learn more editor
+    types than emacs or vi."""
+
+    homepage = "https://github.com/ibara/mg"
+    url      = "https://github.com/ibara/mg/archive/mg-6.6.tar.gz"
+
+    version('6.6', sha256='e8440353da1a52ec7d40fb88d4f145da49c320b5ba31daf895b0b0db5ccd0632')
+
+    depends_on('ncurses')
+
+    def configure_args(self):
+        args = [
+            '--mandir={0}'.format(self.prefix.man),
+        ]
+        return args

--- a/var/spack/repos/builtin/packages/mg/package.py
+++ b/var/spack/repos/builtin/packages/mg/package.py
@@ -26,6 +26,7 @@ class Mg(Package):
         configure = Executable('./configure')
         args = [
             '--mandir={0}'.format(self.prefix.man),
+            '--prefix={0}'.format(self.prefix),
         ]
         configure(*args)
 


### PR DESCRIPTION
TODO:

- [x] while it uses a `configure` script and builds as an `AutotoolsPackage` (`spack create` set it up this way), it is not truly an Autotools package.  Should I redo it as a `Package` instead?

  **Switched to using Package**.
---

Adds a package for the portable OpenBSD version of mg.  mg is a gnu-emacs-ified version of the micro-emacs editor.

Small, fast, quick-starting editor with gnu-emacs compat. key bindings.