### PR TITLE
texinfo: fix unescaped braces, and update locale handling

### DIFF
--- a/var/spack/repos/builtin/packages/texinfo/fix_unescaped_braces.patch
+++ b/var/spack/repos/builtin/packages/texinfo/fix_unescaped_braces.patch
@@ -1,0 +1,16 @@
+--- spack-src/tp/Texinfo/Parser.pm.org	2019-11-18 15:02:20.184202910 +0900
++++ spack-src/tp/Texinfo/Parser.pm	2019-11-18 15:02:46.927022528 +0900
+@@ -5478,11 +5478,11 @@
+     }
+   } elsif ($command eq 'clickstyle') {
+     # REMACRO
+-    if ($line =~ /^\s+@([[:alnum:]][[:alnum:]\-]*)({})?\s*/) {
++    if ($line =~ /^\s+@([[:alnum:]][[:alnum:]\-]*)(\{\})?\s*/) {
+       $args = ['@'.$1];
+       $self->{'clickstyle'} = $1;
+       $remaining = $line;
+-      $remaining =~ s/^\s+@([[:alnum:]][[:alnum:]\-]*)({})?\s*(\@(c|comment)((\@|\s+).*)?)?//;
++      $remaining =~ s/^\s+@([[:alnum:]][[:alnum:]\-]*)(\{\})?\s*(\@(c|comment)((\@|\s+).*)?)?//;
+       $has_comment = 1 if (defined($4));
+     } else {
+       $self->line_error (sprintf($self->__(

--- a/var/spack/repos/builtin/packages/texinfo/fix_unescaped_braces_2.patch
+++ b/var/spack/repos/builtin/packages/texinfo/fix_unescaped_braces_2.patch
@@ -1,0 +1,17 @@
+--- texinfo-6.0/tp/Texinfo/Parser.pm.org	2019-11-20 15:51:15.193575181 +0900
++++ texinfo-6.0/tp/Texinfo/Parser.pm	2019-11-20 15:51:59.648252047 +0900
+@@ -5650,12 +5650,12 @@
+     }
+   } elsif ($command eq 'clickstyle') {
+     # REMACRO
+-    if ($line =~ /^\s+@([[:alnum:]][[:alnum:]\-]*)({})?\s*/) {
++    if ($line =~ /^\s+@([[:alnum:]][[:alnum:]\-]*)(\{\})?\s*/) {
+       $args = ['@'.$1];
+       $self->{'clickstyle'} = $1
+         unless(_ignore_global_commands($self));
+       $remaining = $line;
+-      $remaining =~ s/^\s+@([[:alnum:]][[:alnum:]\-]*)({})?\s*(\@(c|comment)((\@|\s+).*)?)?//;
++      $remaining =~ s/^\s+@([[:alnum:]][[:alnum:]\-]*)(\{\})?\s*(\@(c|comment)((\@|\s+).*)?)?//;
+       $has_comment = 1 if (defined($4));
+     } else {
+       $self->line_error (sprintf($self->__(

--- a/var/spack/repos/builtin/packages/texinfo/fix_unescaped_braces_3.patch
+++ b/var/spack/repos/builtin/packages/texinfo/fix_unescaped_braces_3.patch
@@ -1,0 +1,17 @@
+--- texinfo-5.0/tp/Texinfo/Parser.pm.org	2019-11-20 15:53:10.625719249 +0900
++++ texinfo-5.0/tp/Texinfo/Parser.pm	2019-11-20 15:53:42.949119841 +0900
+@@ -5299,12 +5299,12 @@
+     }
+   } elsif ($command eq 'clickstyle') {
+     # REMACRO
+-    if ($line =~ /^\s+@([[:alnum:]][[:alnum:]\-]*)({})?\s*/) {
++    if ($line =~ /^\s+@([[:alnum:]][[:alnum:]\-]*)(\{\})?\s*/) {
+       $args = ['@'.$1];
+       $self->{'clickstyle'} = $1
+         unless(_ignore_global_commands($self));
+       my $remaining = $line;
+-      $remaining =~ s/^\s+@([[:alnum:]][[:alnum:]\-]*)({})?\s*//;
++      $remaining =~ s/^\s+@([[:alnum:]][[:alnum:]\-]*)(\{\})?\s*//;
+       $self->line_warn(sprintf($self->__(
+                            "remaining argument on \@%s line: %s"), 
+                              $command, $remaining), $line_nr) if ($remaining);

--- a/var/spack/repos/builtin/packages/texinfo/package.py
+++ b/var/spack/repos/builtin/packages/texinfo/package.py
@@ -31,3 +31,8 @@ class Texinfo(AutotoolsPackage):
     patch('fix_unescaped_braces.patch', when='@6.3:')
     patch('fix_unescaped_braces_2.patch', when='@5.1:6.0')
     patch('fix_unescaped_braces_3.patch', when='@5.0')
+
+    # Apply this fix to perform thread-safe processing in code
+    # that uses the global locale.
+    # Ref: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=902771
+    patch('update_locale_handling.patch', when='@6.3:')

--- a/var/spack/repos/builtin/packages/texinfo/package.py
+++ b/var/spack/repos/builtin/packages/texinfo/package.py
@@ -25,3 +25,9 @@ class Texinfo(AutotoolsPackage):
     version('5.0', sha256='2c579345a39a2a0bb4b8c28533f0b61356504a202da6a25d17d4d866af7f5803')
 
     depends_on('perl')
+
+    # Fix unescaped braces in regexps.
+    # Ref: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=898994
+    patch('fix_unescaped_braces.patch', when='@6.3:')
+    patch('fix_unescaped_braces_2.patch', when='@5.1:6.0')
+    patch('fix_unescaped_braces_3.patch', when='@5.0')

--- a/var/spack/repos/builtin/packages/texinfo/update_locale_handling.patch
+++ b/var/spack/repos/builtin/packages/texinfo/update_locale_handling.patch
@@ -1,0 +1,25 @@
+--- spack-src/tp/Texinfo/Convert/XSParagraph/xspara.c.org	2019-11-18 17:33:07.717005871 +0900
++++ spack-src/tp/Texinfo/Convert/XSParagraph/xspara.c	2019-11-18 17:34:56.318436594 +0900
+@@ -248,6 +248,11 @@
+ 
+   dTHX;
+ 
++#if PERL_VERSION > 27 || (PERL_VERSION == 27 && PERL_SUBVERSION > 8)
++  /* needed due to thread-safe locale handling in newer perls */
++  switch_to_global_locale();
++#endif
++
+   if (setlocale (LC_CTYPE, "en_US.UTF-8")
+       || setlocale (LC_CTYPE, "en_US.utf8"))
+     goto success;
+@@ -319,6 +324,10 @@
+   else
+     {
+ success: ;
++#if PERL_VERSION > 27 || (PERL_VERSION == 27 && PERL_SUBVERSION > 8)
++      /* needed due to thread-safe locale handling in newer perls */
++      sync_locale();
++#endif
+       free (utf8_locale);
+       /*
+       fprintf (stderr, "tried to set LC_CTYPE to UTF-8.\n");


### PR DESCRIPTION
* Fix unescaped braces in regexps.
Ref: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=898994

* Apply this fix to perform thread-safe processing in code that uses the global locale.
Ref: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=902771