### PR TITLE
BLD: enforce C++11 std for boost + xl_r

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -367,7 +367,7 @@ class Boost(Package):
                 cxxflags.append('-stdlib=libc++')
                 options.extend(['toolset=clang',
                                 'linkflags="-stdlib=libc++"'])
-        elif spec.satisfies('%xl_r'):
+        elif spec.satisfies('%xl') or spec.satisfies('%xl_r'):
             # see also: https://lists.boost.org/boost-users/2019/09/89953.php
             # the cxxstd setting via spack is not sufficient to drive the
             # change into boost compilation

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -367,6 +367,12 @@ class Boost(Package):
                 cxxflags.append('-stdlib=libc++')
                 options.extend(['toolset=clang',
                                 'linkflags="-stdlib=libc++"'])
+        elif spec.satisfies('%xl_r'):
+            # see also: https://lists.boost.org/boost-users/2019/09/89953.php
+            # the cxxstd setting via spack is not sufficient to drive the
+            # change into boost compilation
+            if spec.variants['cxxstd'].value == '11':
+                cxxflags.append('-std=c++11')
 
         if cxxflags:
             options.append('cxxflags="{0}"'.format(' '.join(cxxflags)))


### PR DESCRIPTION
* the spack `cxxstd` variant is not sufficient to enforce
`-std=c++11` usage in boost compile lines when `xl_r` compiler
spec is in use; while it would be nice if this were fixed
in a boost config file somewhere, for now this patch
allows boost to build on POWER9 with
an %xl_r compiler spec if the user specifies i.e.,:

`spack install boost@1.70.0+mpi cxxstd=11 %xl_r@16.1.1.5`

Related:
- #11849
- https://lists.boost.org/boost-users/2019/09/89953.php