### PR TITLE
ack: Fix install modifying download cache

### DIFF
--- a/var/spack/repos/builtin/packages/ack/package.py
+++ b/var/spack/repos/builtin/packages/ack/package.py
@@ -25,11 +25,13 @@ class Ack(Package):
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
-        ack = 'ack-{0}-single-file'.format(self.version)
+        ack_source = 'ack-{0}-single-file'.format(self.version)
+        ack_installed = join_path(prefix.bin, "ack")
+
+        # install source
+        install(ack_source, ack_installed)
+        set_executable(ack_installed)
 
         # rewrite the script's #! line to call the perl dependency
         shbang = '#!' + spec['perl'].command.path
-        filter_file(r'^#!/usr/bin/env perl', shbang, ack)
-
-        install(ack, join_path(prefix.bin, "ack"))
-        set_executable(join_path(prefix.bin, "ack"))
+        filter_file(r'^#!/usr/bin/env perl', shbang, ack_installed)


### PR DESCRIPTION
This makes several installs from the same download cache impossible once
the hash of the used perl-install changes.

Fixes: #13824