### PR TITLE
Update py-qtpy recipe

### DIFF
--- a/var/spack/repos/builtin/packages/py-qtpy/package.py
+++ b/var/spack/repos/builtin/packages/py-qtpy/package.py
@@ -7,12 +7,21 @@ from spack import *
 
 
 class PyQtpy(PythonPackage):
-    """QtPy: Abtraction layer for PyQt5/PyQt4/PySide"""
+    """QtPy: Abtraction layer for PyQt5/PyQt4/PySide/PySide2"""
 
     homepage = "https://github.com/spyder-ide/qtpy"
     url      = "https://pypi.io/packages/source/Q/QtPy/QtPy-1.2.1.tar.gz"
 
     version('1.2.1', sha256='5803ce31f50b24295e8e600b76cc91d7f2a3140a5a0d526d40226f9ec5e9097d')
+    version('1.7.1', sha256='e97275750934b3a1f4d8e263f5b889ae817ed36f26867ab0ce52be731ab1ed9e')
+
+    variant('qt4', default=False, description="Enable qt4 support")
+    variant('qt5', default=True, description="Enable qt5 support")
+    variant('pyside2', default=False, description="Enable pyside2 support")
+    variant('pyside', default=False, description="Enable pyside support")
 
     depends_on('py-setuptools', type='build')
-    depends_on('py-pyqt4',    type=('build', 'run'))
+    depends_on('py-pyqt4',    type=('build', 'run'), when="+qt4")
+    depends_on('py-pyqt5',    type=('build', 'run'), when="+qt5")
+    depends_on('py-pyside',   type=('build', 'run'), when="+pyside")
+    depends_on('py-pyside2',  type=('build', 'run'), when="+pyside2")

--- a/var/spack/repos/builtin/packages/py-qtpy/package.py
+++ b/var/spack/repos/builtin/packages/py-qtpy/package.py
@@ -17,12 +17,13 @@ class PyQtpy(PythonPackage):
 
     apis = ['pyqt5', 'pyqt4', 'pyside2', 'pyside']
 
-    variant('api', default='pyqt5', description='Default QT API', 
+    variant('api', default='pyqt5', description='Default QT API',
             values=apis, multi=False)
 
     depends_on('py-setuptools', type='build')
     for api in apis:
         depends_on('py-' + api, when='+' + api, type='run')
+
 
 def setup_run_environment(self, env):
     env.set('QT_API', self.spec.variants['api'].value)

--- a/var/spack/repos/builtin/packages/py-qtpy/package.py
+++ b/var/spack/repos/builtin/packages/py-qtpy/package.py
@@ -24,6 +24,5 @@ class PyQtpy(PythonPackage):
     for api in apis:
         depends_on('py-' + api, when='+' + api, type='run')
 
-
-def setup_run_environment(self, env):
-    env.set('QT_API', self.spec.variants['api'].value)
+    def setup_run_environment(self, env):
+        env.set('QT_API', self.spec.variants['api'].value)

--- a/var/spack/repos/builtin/packages/py-qtpy/package.py
+++ b/var/spack/repos/builtin/packages/py-qtpy/package.py
@@ -12,16 +12,17 @@ class PyQtpy(PythonPackage):
     homepage = "https://github.com/spyder-ide/qtpy"
     url      = "https://pypi.io/packages/source/Q/QtPy/QtPy-1.2.1.tar.gz"
 
-    version('1.2.1', sha256='5803ce31f50b24295e8e600b76cc91d7f2a3140a5a0d526d40226f9ec5e9097d')
     version('1.7.1', sha256='e97275750934b3a1f4d8e263f5b889ae817ed36f26867ab0ce52be731ab1ed9e')
+    version('1.2.1', sha256='5803ce31f50b24295e8e600b76cc91d7f2a3140a5a0d526d40226f9ec5e9097d')
 
-    variant('qt4', default=False, description="Enable qt4 support")
-    variant('qt5', default=True, description="Enable qt5 support")
-    variant('pyside2', default=False, description="Enable pyside2 support")
-    variant('pyside', default=False, description="Enable pyside support")
+    apis = ['pyqt5', 'pyqt4', 'pyside2', 'pyside']
+
+    variant('api', default='pyqt5', description='Default QT API', 
+            values=apis, multi=False)
 
     depends_on('py-setuptools', type='build')
-    depends_on('py-pyqt4',    type=('build', 'run'), when="+qt4")
-    depends_on('py-pyqt5',    type=('build', 'run'), when="+qt5")
-    depends_on('py-pyside',   type=('build', 'run'), when="+pyside")
-    depends_on('py-pyside2',  type=('build', 'run'), when="+pyside2")
+    for api in apis:
+        depends_on('py-' + api, when='+' + api, type='run')
+
+def setup_run_environment(self, env):
+    env.set('QT_API', self.spec.variants['api'].value)


### PR DESCRIPTION
This change allows one to use qtpy with pyqt5, pyside and pyside2 by enabling the appropriate variant.