### PR TITLE
Remove mirrors from Travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -159,7 +159,6 @@ cache:
   pip: true
   ccache: true
   directories:
-    - ~/.mirror
     - ~/.ccache
 
 # Work around Travis's lack of support for Python on OSX


### PR DESCRIPTION
It's a couple of days that a lot of jobs are failing on Travis due to corrupted caches for source mirrors. This PR removes the source mirror from caches to work around this issue.