### PR TITLE
silence vtkm logging until it does not report false positives

### DIFF
--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -36,7 +36,7 @@ class VtkM(CMakePackage, CudaPackage):
     variant("cuda", default=False, description="build cuda support")
     variant("doubleprecision", default=True,
             description='enable double precision')
-    variant("logging", default=True, description="build logging support")
+    variant("logging", default=False, description="build logging support")
     variant("mpi", default=False, description="build mpi support")
     variant("openmp", default=(sys.platform != 'darwin'), description="build openmp support")
     variant("rendering", default=True, description="build rendering support")


### PR DESCRIPTION
During normal operation, vtkm is sending warnings to the terminal which are false positives and this is effecting the performance of dependent applications. This happens on every rank. Until this is resolved inside vtkm, suppress the logging output.