### PR TITLE
Build go-md2man using Go modules

### DIFF
--- a/var/spack/repos/builtin/packages/go-md2man/package.py
+++ b/var/spack/repos/builtin/packages/go-md2man/package.py
@@ -14,7 +14,7 @@ class GoMd2man(Package):
 
     version('1.0.10', sha256='76aa56849123b99b95fcea2b15502fd886dead9a5c35be7f78bdc2bad6be8d99')
 
-    depends_on('go@1.12:')  # modules support
+    depends_on('go@1.11:')  # modules support
 
     def install(self, spec, prefix):
         env['GO111MODULE'] = 'on'  # not the default for go@1.11.x

--- a/var/spack/repos/builtin/packages/go-md2man/package.py
+++ b/var/spack/repos/builtin/packages/go-md2man/package.py
@@ -14,33 +14,11 @@ class GoMd2man(Package):
 
     version('1.0.10', sha256='76aa56849123b99b95fcea2b15502fd886dead9a5c35be7f78bdc2bad6be8d99')
 
-    depends_on('go')
-
-    resource(name='blackfriday',
-             url='https://github.com/russross/blackfriday/archive/v1.5.2.tar.gz',
-             sha256='626138a08abb8579474a555e9d45cb5260629a2c07e8834428620a650dc9f195',
-             placement='blackfriday',
-             destination=join_path('src', 'github.com', 'russross'))
-
-    def patch(self):
-        mkdirp(join_path(self.stage.source_path,
-               'src', 'github.com', 'russross'))
-
-        mkdirp(join_path(self.stage.source_path,
-               'src', 'github.com', 'cpuguy83'))
-
-        ln = which('ln')
-        ln('-s', self.stage.source_path, join_path(
-           'src', 'github.com', 'cpuguy83', 'go-md2man'))
+    depends_on('go@1.12:')  # modules support
 
     def install(self, spec, prefix):
-
-        with working_dir('src'):
-            env['GOPATH'] = self.stage.source_path
-            env['GO111MODULE'] = 'off'
-            go = which('go')
-            go('build', '-v', join_path(
-               'github.com', 'cpuguy83', 'go-md2man'))
-
-            mkdir(prefix.bin)
-            install('go-md2man', prefix.bin)
+        env['GO111MODULE'] = 'on'  # not the default for go@1.11.x
+        go = Executable("go")
+        go("build")
+        mkdir(prefix.bin)
+        install('go-md2man', prefix.bin)


### PR DESCRIPTION
Release of go-md2man@v1.0.9: use the Go modules system ([release notes here](https://github.com/cpuguy83/go-md2man/releases)).  The current Go release at that point was v1.12, which supported modules.

The initial commit for this package set the build directory up to use the old-style GOPATH build system and defined a resource for the blackfriday markdown parser.

The package should use the build system intended by the go-md2man project, Go modules.

The package should *not* have overridden the copy of blackfriday that the go-md2man authors vendored into their repository, indeed it's not clear to me *which* copy the build actually uses.

The sole downside is that the build will not work for go@:1.10.8, which did *not* support modules.  Since the official Go support policy is

> Each major Go release is supported until there are two newer major releases.

this is probably *not* an issue now, although it may have been a consideration when the package was originally submitted.