### PR TITLE
Mapnik: fix runtime error involving py-pycairo and PDF

### DIFF
--- a/var/spack/repos/builtin/packages/mapnik/package.py
+++ b/var/spack/repos/builtin/packages/mapnik/package.py
@@ -37,9 +37,9 @@ class Mapnik(AutotoolsPackage):
 
     conflicts('%gcc@9.0.0:')
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         spec = self.spec
-        spack_env.set('GDAL_DATA', spec['gdal'].prefix.share.gdal)
+        env.set('GDAL_DATA', spec['gdal'].prefix.share.gdal)
 
     def configure_args(self):
         return [

--- a/var/spack/repos/builtin/packages/mapnik/package.py
+++ b/var/spack/repos/builtin/packages/mapnik/package.py
@@ -29,7 +29,7 @@ class Mapnik(AutotoolsPackage):
     depends_on('libjpeg')
     depends_on('libtiff')
     depends_on('proj')
-    depends_on('cairo')
+    depends_on('cairo+pdf')  # +pdf needed for mapnik.printing
     depends_on('postgresql', type=('build', 'link', 'run'))
     depends_on('gdal', type=('build', 'link', 'run'))
     depends_on('sqlite+rtree', type=('build', 'link', 'run'))

--- a/var/spack/repos/builtin/packages/py-python-mapnik/package.py
+++ b/var/spack/repos/builtin/packages/py-python-mapnik/package.py
@@ -20,6 +20,8 @@ class PyPythonMapnik(PythonPackage):
     depends_on('py-setuptools', type='build')
     depends_on('mapnik', type=('build', 'link', 'run'))
     depends_on('boost +python+thread')
+    # py-pycairo is need by mapnik.printing
+    depends_on('py-pycairo', type=('build', 'run'))
 
     # Package can't find boost_python without the following
     def setup_environment(self, spack_env, run_env):

--- a/var/spack/repos/builtin/packages/py-python-mapnik/package.py
+++ b/var/spack/repos/builtin/packages/py-python-mapnik/package.py
@@ -28,4 +28,4 @@ class PyPythonMapnik(PythonPackage):
         # Inform the package that boost python library is of form
         # 'libboost_python27.so' as opposed to 'libboost_python.so'
         py_ver = str(self.spec['python'].version.up_to(2).joined)
-        spack_env.set('BOOST_PYTHON_LIB', 'boost_python' + py_ver)
+        env.set('BOOST_PYTHON_LIB', 'boost_python' + py_ver)

--- a/var/spack/repos/builtin/packages/py-python-mapnik/package.py
+++ b/var/spack/repos/builtin/packages/py-python-mapnik/package.py
@@ -24,7 +24,7 @@ class PyPythonMapnik(PythonPackage):
     depends_on('py-pycairo', type=('build', 'run'))
 
     # Package can't find boost_python without the following
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         # Inform the package that boost python library is of form
         # 'libboost_python27.so' as opposed to 'libboost_python.so'
         py_ver = str(self.spec['python'].version.up_to(2).joined)


### PR DESCRIPTION
without py-pycairo and cairo+pdf, `import mapnik.printing` yields runtime errors.