### PR TITLE
ftpmirror.gnu.org -> ftp.gnu.org

### DIFF
--- a/var/spack/repos/builtin/packages/aspell/package.py
+++ b/var/spack/repos/builtin/packages/aspell/package.py
@@ -12,7 +12,7 @@ class Aspell(AutotoolsPackage):
     eventually replace Ispell."""
 
     homepage = "http://aspell.net/"
-    url      = "https://ftpmirror.gnu.org/aspell/aspell-0.60.6.1.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/aspell/aspell-0.60.6.1.tar.gz"
 
     extendable = True           # support activating dictionaries
 

--- a/var/spack/repos/builtin/packages/aspell6-de/package.py
+++ b/var/spack/repos/builtin/packages/aspell6-de/package.py
@@ -10,6 +10,6 @@ class Aspell6De(AspellDictPackage):
     """German (de) dictionary for aspell."""
 
     homepage = "http://aspell.net/"
-    url      = "https://ftpmirror.gnu.org/aspell/dict/de/aspell6-de-20030222-1.tar.bz2"
+    url      = "https://ftp.gnu.org/gnu/aspell/dict/de/aspell6-de-20030222-1.tar.bz2"
 
     version('6-de-20030222-1', sha256='ba6c94e11bc2e0e6e43ce0f7822c5bba5ca5ac77129ef90c190b33632416e906')

--- a/var/spack/repos/builtin/packages/aspell6-en/package.py
+++ b/var/spack/repos/builtin/packages/aspell6-en/package.py
@@ -10,6 +10,6 @@ class Aspell6En(AspellDictPackage):
     """English (en) dictionary for aspell."""
 
     homepage = "http://aspell.net/"
-    url      = "https://ftpmirror.gnu.org/aspell/dict/en/aspell6-en-2017.01.22-0.tar.bz2"
+    url      = "https://ftp.gnu.org/gnu/aspell/dict/en/aspell6-en-2017.01.22-0.tar.bz2"
 
     version('2017.01.22-0', sha256='93c73fae3eab5ea3ca6db3cea8770715a820f1b7d6ea2b932dd66a17f8fd55e1')

--- a/var/spack/repos/builtin/packages/aspell6-es/package.py
+++ b/var/spack/repos/builtin/packages/aspell6-es/package.py
@@ -10,6 +10,6 @@ class Aspell6Es(AspellDictPackage):
     """Spanish (es) dictionary for aspell."""
 
     homepage = "http://aspell.net/"
-    url      = "https://ftpmirror.gnu.org/aspell/dict/es/aspell6-es-1.11-2.tar.bz2"
+    url      = "https://ftp.gnu.org/gnu/aspell/dict/es/aspell6-es-1.11-2.tar.bz2"
 
     version('1.11-2', sha256='ad367fa1e7069c72eb7ae37e4d39c30a44d32a6aa73cedccbd0d06a69018afcc')

--- a/var/spack/repos/builtin/packages/autoconf/package.py
+++ b/var/spack/repos/builtin/packages/autoconf/package.py
@@ -10,7 +10,7 @@ class Autoconf(AutotoolsPackage):
     """Autoconf -- system configuration part of autotools"""
 
     homepage = 'https://www.gnu.org/software/autoconf/'
-    url      = 'https://ftpmirror.gnu.org/autoconf/autoconf-2.69.tar.gz'
+    url      = 'https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz'
 
     version('2.69', sha256='954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969')
     version('2.62', sha256='83aa747e6443def0ebd1882509c53f5a2133f502ddefa21b3de141c433914bdd')

--- a/var/spack/repos/builtin/packages/autogen/package.py
+++ b/var/spack/repos/builtin/packages/autogen/package.py
@@ -13,7 +13,7 @@ class Autogen(AutotoolsPackage):
     synchronized."""
 
     homepage = "https://www.gnu.org/software/autogen/index.html"
-    url      = "https://ftpmirror.gnu.org/autogen/rel5.18.12/autogen-5.18.12.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/autogen/rel5.18.12/autogen-5.18.12.tar.gz"
     list_url = "https://ftp.gnu.org/gnu/autogen"
     list_depth = 1
 

--- a/var/spack/repos/builtin/packages/automake/package.py
+++ b/var/spack/repos/builtin/packages/automake/package.py
@@ -10,7 +10,7 @@ class Automake(AutotoolsPackage):
     """Automake -- make file builder part of autotools"""
 
     homepage = 'http://www.gnu.org/software/automake/'
-    url      = 'https://ftpmirror.gnu.org/automake/automake-1.15.tar.gz'
+    url      = 'https://ftp.gnu.org/gnu/automake/automake-1.15.tar.gz'
 
     version('1.16.1', sha256='608a97523f97db32f1f5d5615c98ca69326ced2054c9f82e65bade7fc4c9dea8')
     version('1.15.1', sha256='988e32527abe052307d21c8ca000aa238b914df363a617e38f4fb89f5abf6260')

--- a/var/spack/repos/builtin/packages/bash/package.py
+++ b/var/spack/repos/builtin/packages/bash/package.py
@@ -10,7 +10,7 @@ class Bash(AutotoolsPackage):
     """The GNU Project's Bourne Again SHell."""
 
     homepage = "https://www.gnu.org/software/bash/"
-    url      = "https://ftpmirror.gnu.org/bash/bash-4.4.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/bash/bash-4.4.tar.gz"
 
     version('5.0',    sha256='b4a80f2ac66170b2913efbfb9f2594f1f76c7b1afd11f799e22035d63077fb4d')
     version('4.4.12', sha256='57d8432be54541531a496fd4904fdc08c12542f43605a9202594fa5d5f9f2331')
@@ -37,7 +37,7 @@ class Bash(AutotoolsPackage):
 
     for ver, num, checksum in patches:
         ver = Version(ver)
-        patch('https://ftpmirror.gnu.org/bash/bash-{0}-patches/bash{1}-{2}'.format(ver, ver.joined, num),
+        patch('https://ftp.gnu.org/gnu/bash/bash-{0}-patches/bash{1}-{2}'.format(ver, ver.joined, num),
               level=0, when='@{0}'.format(ver), sha256=checksum)
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/bc/package.py
+++ b/var/spack/repos/builtin/packages/bc/package.py
@@ -12,7 +12,7 @@ class Bc(AutotoolsPackage):
     interactive execution of statements."""
 
     homepage = "https://www.gnu.org/software/bc"
-    url      = "https://ftpmirror.gnu.org/bc/bc-1.07.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/bc/bc-1.07.tar.gz"
 
     version('1.07', sha256='55cf1fc33a728d7c3d386cc7b0cb556eb5bacf8e0cb5a3fcca7f109fc61205ad')
 

--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -11,7 +11,7 @@ class Binutils(AutotoolsPackage):
     """GNU binutils, which contain the linker, assembler, objdump and others"""
 
     homepage = "http://www.gnu.org/software/binutils/"
-    url      = "https://ftpmirror.gnu.org/binutils/binutils-2.28.tar.bz2"
+    url      = "https://ftp.gnu.org/gnu/binutils/binutils-2.28.tar.bz2"
 
     version('2.32', sha256='de38b15c902eb2725eac6af21183a5f34ea4634cb0bcef19612b50e5ed31072d')
     version('2.31.1', sha256='ffcc382695bf947da6135e7436b8ed52d991cf270db897190f19d6f9838564d0')

--- a/var/spack/repos/builtin/packages/bison/package.py
+++ b/var/spack/repos/builtin/packages/bison/package.py
@@ -14,7 +14,7 @@ class Bison(AutotoolsPackage):
     generalized LR (GLR) parser employing LALR(1) parser tables."""
 
     homepage = "https://www.gnu.org/software/bison/"
-    url      = "https://ftpmirror.gnu.org/bison/bison-3.4.2.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/bison/bison-3.4.2.tar.gz"
 
     version('3.4.2', sha256='ff3922af377d514eca302a6662d470e857bd1a591e96a2050500df5a9d59facf')
     version('3.0.5', sha256='cd399d2bee33afa712bac4b1f4434e20379e9b4099bce47189e09a7675a2d566')

--- a/var/spack/repos/builtin/packages/coreutils/package.py
+++ b/var/spack/repos/builtin/packages/coreutils/package.py
@@ -13,7 +13,7 @@ class Coreutils(AutotoolsPackage):
        operating system.
     """
     homepage = "http://www.gnu.org/software/coreutils/"
-    url      = "https://ftpmirror.gnu.org/coreutils/coreutils-8.26.tar.xz"
+    url      = "https://ftp.gnu.org/gnu/coreutils/coreutils-8.26.tar.xz"
 
     version('8.29', sha256='92d0fa1c311cacefa89853bdb53c62f4110cdfda3820346b59cbd098f40f955e')
     version('8.26', sha256='155e94d748f8e2bc327c66e0cbebdb8d6ab265d2f37c3c928f7bf6c3beba9a8e')

--- a/var/spack/repos/builtin/packages/cvs/package.py
+++ b/var/spack/repos/builtin/packages/cvs/package.py
@@ -10,7 +10,7 @@ from spack import *
 class Cvs(AutotoolsPackage):
     """CVS a very traditional source control system"""
     homepage = "http://www.nongnu.org/cvs/"
-    url      = "https://ftpmirror.gnu.org/non-gnu/cvs/source/feature/1.12.13/cvs-1.12.13.tar.bz2"
+    url      = "https://ftp.gnu.org/gnu/non-gnu/cvs/source/feature/1.12.13/cvs-1.12.13.tar.bz2"
 
     version('1.12.13', sha256='78853613b9a6873a30e1cc2417f738c330e75f887afdaf7b3d0800cb19ca515e')
 

--- a/var/spack/repos/builtin/packages/datamash/package.py
+++ b/var/spack/repos/builtin/packages/datamash/package.py
@@ -12,7 +12,7 @@ class Datamash(AutotoolsPackage):
     """
 
     homepage = "https://www.gnu.org/software/datamash/"
-    url      = "https://ftpmirror.gnu.org/datamash/datamash-1.0.5.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/datamash/datamash-1.0.5.tar.gz"
 
     version('1.3',   sha256='eebb52171a4353aaad01921384098cf54eb96ebfaf99660e017f6d9fc96657a6')
     version('1.1.0', sha256='a9e5acc86af4dd64c7ac7f6554718b40271aa67f7ff6e9819bdd919a25904bb0')

--- a/var/spack/repos/builtin/packages/dejagnu/package.py
+++ b/var/spack/repos/builtin/packages/dejagnu/package.py
@@ -11,7 +11,7 @@ class Dejagnu(AutotoolsPackage):
     is to provide a single front end for all tests."""
 
     homepage = "https://www.gnu.org/software/dejagnu/"
-    url      = "https://ftpmirror.gnu.org/dejagnu/dejagnu-1.6.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/dejagnu/dejagnu-1.6.tar.gz"
 
     version('1.6',   sha256='00b64a618e2b6b581b16eb9131ee80f721baa2669fa0cdee93c500d1a652d763')
     version('1.4.4', sha256='d0fbedef20fb0843318d60551023631176b27ceb1e11de7468a971770d0e048d')

--- a/var/spack/repos/builtin/packages/diffutils/package.py
+++ b/var/spack/repos/builtin/packages/diffutils/package.py
@@ -11,7 +11,7 @@ class Diffutils(AutotoolsPackage):
     differences between files."""
 
     homepage = "https://www.gnu.org/software/diffutils/"
-    url      = "https://ftpmirror.gnu.org/diffutils/diffutils-3.7.tar.xz"
+    url      = "https://ftp.gnu.org/gnu/diffutils/diffutils-3.7.tar.xz"
 
     version('3.7', sha256='b3a7a6221c3dc916085f0d205abf6b8e1ba443d4dd965118da364a1dc1cb3a26')
     version('3.6', sha256='d621e8bdd4b573918c8145f7ae61817d1be9deb4c8d2328a65cea8e11d783bd6')

--- a/var/spack/repos/builtin/packages/ed/package.py
+++ b/var/spack/repos/builtin/packages/ed/package.py
@@ -12,7 +12,7 @@ class Ed(AutotoolsPackage):
        interactively and via shell scripts."""
 
     homepage = "https://www.gnu.org/software/ed"
-    url      = "https://ftpmirror.gnu.org/ed/ed-1.4.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/ed/ed-1.4.tar.gz"
 
     version('1.4', sha256='db36da85ee1a9d8bafb4b041bd4c8c11becba0c43ec446353b67045de1634fda')
 

--- a/var/spack/repos/builtin/packages/emacs/package.py
+++ b/var/spack/repos/builtin/packages/emacs/package.py
@@ -12,7 +12,7 @@ class Emacs(AutotoolsPackage):
     """The Emacs programmable text editor."""
 
     homepage = "https://www.gnu.org/software/emacs"
-    url      = "https://ftpmirror.gnu.org/emacs/emacs-24.5.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/emacs/emacs-24.5.tar.gz"
 
     version('26.3', sha256='09c747e048137c99ed35747b012910b704e0974dde4db6696fde7054ce387591')
     version('26.2', sha256='4f99e52a38a737556932cc57479e85c305a37a8038aaceb5156625caf102b4eb')

--- a/var/spack/repos/builtin/packages/findutils/package.py
+++ b/var/spack/repos/builtin/packages/findutils/package.py
@@ -11,7 +11,7 @@ class Findutils(AutotoolsPackage):
        utilities of the GNU operating system."""
 
     homepage = "https://www.gnu.org/software/findutils/"
-    url      = "https://ftpmirror.gnu.org/findutils/findutils-4.6.0.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/findutils/findutils-4.6.0.tar.gz"
 
     version('4.6.0',  sha256='ded4c9f73731cd48fec3b6bdaccce896473b6d8e337e9612e16cf1431bb1169d')
     version('4.4.2',  sha256='434f32d171cbc0a5e72cfc5372c6fc4cb0e681f8dce566a0de5b6fccd702b62a')

--- a/var/spack/repos/builtin/packages/gawk/package.py
+++ b/var/spack/repos/builtin/packages/gawk/package.py
@@ -21,7 +21,7 @@ class Gawk(AutotoolsPackage):
     """
 
     homepage = "https://www.gnu.org/software/gawk/"
-    url      = "https://ftpmirror.gnu.org/gawk/gawk-4.1.4.tar.xz"
+    url      = "https://ftp.gnu.org/gnu/gawk/gawk-4.1.4.tar.xz"
 
     version('4.1.4', sha256='53e184e2d0f90def9207860531802456322be091c7b48f23fdc79cda65adc266')
 

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -18,7 +18,7 @@ class Gcc(AutotoolsPackage):
     Fortran, Ada, and Go, as well as libraries for these languages."""
 
     homepage = 'https://gcc.gnu.org'
-    url      = 'https://ftpmirror.gnu.org/gcc/gcc-7.1.0/gcc-7.1.0.tar.bz2'
+    url      = 'https://ftp.gnu.org/gnu/gcc/gcc-7.1.0/gcc-7.1.0.tar.bz2'
     svn      = 'svn://gcc.gnu.org/svn/gcc/'
     list_url = 'http://ftp.gnu.org/gnu/gcc/'
     list_depth = 1
@@ -228,7 +228,7 @@ class Gcc(AutotoolsPackage):
     build_directory = 'spack-build'
 
     def url_for_version(self, version):
-        url = 'https://ftpmirror.gnu.org/gcc/gcc-{0}/gcc-{0}.tar.{1}'
+        url = 'https://ftp.gnu.org/gnu/gcc/gcc-{0}/gcc-{0}.tar.{1}'
         suffix = 'xz'
 
         if version < Version('6.4.0') or version == Version('7.1.0'):

--- a/var/spack/repos/builtin/packages/gdb/package.py
+++ b/var/spack/repos/builtin/packages/gdb/package.py
@@ -13,7 +13,7 @@ class Gdb(AutotoolsPackage):
     """
 
     homepage = "https://www.gnu.org/software/gdb"
-    url      = "https://ftpmirror.gnu.org/gdb/gdb-7.10.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/gdb/gdb-7.10.tar.gz"
 
     version('8.3', sha256='b2266ec592440d0eec18ee1790f8558b3b8a2845b76cc83a872e39b501ce8a28')
     version('8.2.1', sha256='0107985f1edb8dddef6cdd68a4f4e419f5fec0f488cc204f0b7d482c0c6c9282')

--- a/var/spack/repos/builtin/packages/gdbm/package.py
+++ b/var/spack/repos/builtin/packages/gdbm/package.py
@@ -15,7 +15,7 @@ class Gdbm(AutotoolsPackage):
 
     homepage = "http://www.gnu.org.ua/software/gdbm/gdbm.html"
     # URL must remain http:// so Spack can bootstrap curl
-    url      = "http://ftpmirror.gnu.org/gdbm/gdbm-1.13.tar.gz"
+    url      = "http://ftp.gnu.org/gnu/gdbm/gdbm-1.13.tar.gz"
 
     version('1.18.1', sha256='86e613527e5dba544e73208f42b78b7c022d4fa5a6d5498bf18c8d6f745b91dc')
     version('1.14.1', sha256='cdceff00ffe014495bed3aed71c7910aa88bf29379f795abc0f46d4ee5f8bc5f')

--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -10,7 +10,7 @@ class Gettext(AutotoolsPackage):
     """GNU internationalization (i18n) and localization (l10n) library."""
 
     homepage = "https://www.gnu.org/software/gettext/"
-    url      = "https://ftpmirror.gnu.org/gettext/gettext-0.20.1.tar.xz"
+    url      = "https://ftp.gnu.org/gnu/gettext/gettext-0.20.1.tar.xz"
 
     version('0.20.1', sha256='53f02fbbec9e798b0faaf7c73272f83608e835c6288dd58be6c9bb54624a3800')
     version('0.19.8.1', sha256='105556dbc5c3fbbc2aa0edb46d22d055748b6f5c7cd7a8d99f8e7eb84e938be4')

--- a/var/spack/repos/builtin/packages/glpk/package.py
+++ b/var/spack/repos/builtin/packages/glpk/package.py
@@ -14,7 +14,7 @@ class Glpk(AutotoolsPackage):
     """
 
     homepage = "https://www.gnu.org/software/glpk"
-    url      = "https://ftpmirror.gnu.org/glpk/glpk-4.65.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/glpk/glpk-4.65.tar.gz"
 
     version('4.65', sha256='4281e29b628864dfe48d393a7bedd781e5b475387c20d8b0158f329994721a10')
     version('4.61', sha256='9866de41777782d4ce21da11b88573b66bb7858574f89c28be6967ac22dfaba9')

--- a/var/spack/repos/builtin/packages/gmake/package.py
+++ b/var/spack/repos/builtin/packages/gmake/package.py
@@ -11,7 +11,7 @@ class Gmake(AutotoolsPackage):
     other non-source files of a program from the program's source files."""
 
     homepage = "https://www.gnu.org/software/make/"
-    url      = "https://ftpmirror.gnu.org/make/make-4.2.1.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/make/make-4.2.1.tar.gz"
 
     version('4.2.1', sha256='e40b8f018c1da64edd1cc9a6fce5fa63b2e707e404e20cad91fbae337c98a5b7')
     version('4.0',   sha256='fc42139fb0d4b4291929788ebaf77e2a4de7eaca95e31f3634ef7d4932051f69')

--- a/var/spack/repos/builtin/packages/gmp/package.py
+++ b/var/spack/repos/builtin/packages/gmp/package.py
@@ -11,7 +11,7 @@ class Gmp(AutotoolsPackage):
     on signed integers, rational numbers, and floating-point numbers."""
 
     homepage = "https://gmplib.org"
-    url      = "https://ftpmirror.gnu.org/gmp/gmp-6.1.2.tar.bz2"
+    url      = "https://ftp.gnu.org/gnu/gmp/gmp-6.1.2.tar.bz2"
 
     version('6.1.2',  sha256='5275bb04f4863a13516b2f39392ac5e272f5e1bb8057b18aec1c9b79d73d8fb2')
     version('6.1.1',  sha256='a8109865f2893f1373b0a8ed5ff7429de8db696fc451b1036bd7bdf95bbeffd6')

--- a/var/spack/repos/builtin/packages/gperf/package.py
+++ b/var/spack/repos/builtin/packages/gperf/package.py
@@ -15,7 +15,7 @@ class Gperf(AutotoolsPackage):
     single string comparison only."""
 
     homepage = "https://www.gnu.org/software/gperf/"
-    url      = "https://ftpmirror.gnu.org/gperf/gperf-3.0.4.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/gperf/gperf-3.0.4.tar.gz"
 
     version('3.0.4', sha256='767112a204407e62dbc3106647cf839ed544f3cf5d0f0523aaa2508623aad63e')
 

--- a/var/spack/repos/builtin/packages/groff/package.py
+++ b/var/spack/repos/builtin/packages/groff/package.py
@@ -13,7 +13,7 @@ class Groff(AutotoolsPackage):
     ASCII/UTF8 for display at the terminal."""
 
     homepage = "https://www.gnu.org/software/groff/"
-    url      = "https://ftpmirror.gnu.org/groff/groff-1.22.3.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/groff/groff-1.22.3.tar.gz"
 
     # TODO: add html variant, spack doesn't have netpbm and its too
     # complicated for me to find out at this point in time.

--- a/var/spack/repos/builtin/packages/gsl/package.py
+++ b/var/spack/repos/builtin/packages/gsl/package.py
@@ -15,7 +15,7 @@ class Gsl(AutotoolsPackage):
     over 1000 functions in total with an extensive test suite."""
 
     homepage = "http://www.gnu.org/software/gsl"
-    url      = "https://ftpmirror.gnu.org/gsl/gsl-2.3.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/gsl/gsl-2.3.tar.gz"
 
     version('2.5', sha256='0460ad7c2542caaddc6729762952d345374784100223995eb14d614861f2258d')
     version('2.4',   sha256='4d46d07b946e7b31c19bbf33dda6204d7bedc2f5462a1bae1d4013426cd1ce9b')

--- a/var/spack/repos/builtin/packages/guile/package.py
+++ b/var/spack/repos/builtin/packages/guile/package.py
@@ -11,7 +11,7 @@ class Guile(AutotoolsPackage):
     the official extension language for the GNU operating system."""
 
     homepage = "https://www.gnu.org/software/guile/"
-    url      = "https://ftpmirror.gnu.org/guile/guile-2.2.0.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/guile/guile-2.2.0.tar.gz"
 
     version('2.2.6', sha256='08c0e7487777740b61cdd97949b69e8a5e2997d8c2fe6c7e175819eb18444506')
     version('2.2.5', sha256='c3c7a2f6ae0d8321a240c7ebc532a1d47af8c63214157a73789e2b2305b4c927')

--- a/var/spack/repos/builtin/packages/help2man/package.py
+++ b/var/spack/repos/builtin/packages/help2man/package.py
@@ -11,7 +11,7 @@ class Help2man(AutotoolsPackage):
     output of other commands."""
 
     homepage = "https://www.gnu.org/software/help2man/"
-    url      = "https://ftpmirror.gnu.org/help2man/help2man-1.47.11.tar.xz"
+    url      = "https://ftp.gnu.org/gnu/help2man/help2man-1.47.11.tar.xz"
 
     version('1.47.11', sha256='5985b257f86304c8791842c0c807a37541d0d6807ee973000cf8a3fe6ad47b88')
     version('1.47.8', sha256='528f6a81ad34cbc76aa7dce5a82f8b3d2078ef065271ab81fda033842018a8dc')

--- a/var/spack/repos/builtin/packages/libiberty/package.py
+++ b/var/spack/repos/builtin/packages/libiberty/package.py
@@ -16,7 +16,7 @@ class Libiberty(AutotoolsPackage):
     demangling and support functions for the GNU toolchain."""
 
     homepage = "https://www.gnu.org/software/binutils/"
-    url      = "https://ftpmirror.gnu.org/binutils/binutils-2.31.1.tar.xz"
+    url      = "https://ftp.gnu.org/gnu/binutils/binutils-2.31.1.tar.xz"
 
     version('2.31.1', sha256='5d20086ecf5752cc7d9134246e9588fa201740d540f7eb84d795b1f7a93bca86')
     version('2.30',   sha256='6e46b8aeae2f727a36f0bd9505e405768a72218f1796f0d09757d45209871ae6')

--- a/var/spack/repos/builtin/packages/libiconv/package.py
+++ b/var/spack/repos/builtin/packages/libiconv/package.py
@@ -11,7 +11,7 @@ class Libiconv(AutotoolsPackage):
     and the iconv program for character set conversion."""
 
     homepage = "https://www.gnu.org/software/libiconv/"
-    url      = "https://ftpmirror.gnu.org/libiconv/libiconv-1.16.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/libiconv/libiconv-1.16.tar.gz"
 
     version('1.16', sha256='e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04')
     version('1.15', sha256='ccf536620a45458d26ba83887a983b96827001e92a13847b45e4925cc8913178')

--- a/var/spack/repos/builtin/packages/libmatheval/package.py
+++ b/var/spack/repos/builtin/packages/libmatheval/package.py
@@ -15,7 +15,7 @@ class Libmatheval(AutotoolsPackage):
     compute symbolic derivatives and output expressions to strings."""
 
     homepage = "https://www.gnu.org/software/libmatheval/"
-    url      = "https://ftpmirror.gnu.org/libmatheval/libmatheval-1.1.11.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/libmatheval/libmatheval-1.1.11.tar.gz"
 
     version('1.1.11', sha256='474852d6715ddc3b6969e28de5e1a5fbaff9e8ece6aebb9dc1cc63e9e88e89ab')
 

--- a/var/spack/repos/builtin/packages/libsigsegv/package.py
+++ b/var/spack/repos/builtin/packages/libsigsegv/package.py
@@ -10,7 +10,7 @@ class Libsigsegv(AutotoolsPackage):
     """GNU libsigsegv is a library for handling page faults in user mode."""
 
     homepage = "https://www.gnu.org/software/libsigsegv/"
-    url      = "https://ftpmirror.gnu.org/libsigsegv/libsigsegv-2.12.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/libsigsegv/libsigsegv-2.12.tar.gz"
 
     version('2.12', sha256='3ae1af359eebaa4ffc5896a1aee3568c052c99879316a1ab57f8fe1789c390b6')
     version('2.11', sha256='dd7c2eb2ef6c47189406d562c1dc0f96f2fc808036834d596075d58377e37a18')

--- a/var/spack/repos/builtin/packages/libtool/package.py
+++ b/var/spack/repos/builtin/packages/libtool/package.py
@@ -37,9 +37,8 @@ class Libtool(AutotoolsPackage):
     def _make_executable(self, name):
         return Executable(join_path(self.prefix.bin, name))
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        spack_env.append_path('ACLOCAL_PATH',
-                              join_path(self.prefix.share, 'aclocal'))
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.append_path('ACLOCAL_PATH', self.prefix.share.aclocal)
 
     def setup_dependent_package(self, module, dependent_spec):
         # Automake is very likely to be a build dependency, so we add

--- a/var/spack/repos/builtin/packages/libtool/package.py
+++ b/var/spack/repos/builtin/packages/libtool/package.py
@@ -10,7 +10,7 @@ class Libtool(AutotoolsPackage):
     """libtool -- library building part of autotools."""
 
     homepage = 'https://www.gnu.org/software/libtool/'
-    url      = 'https://ftpmirror.gnu.org/libtool/libtool-2.4.2.tar.gz'
+    url      = 'https://ftp.gnu.org/gnu/libtool/libtool-2.4.2.tar.gz'
 
     version('develop', git='https://git.savannah.gnu.org/git/libtool.git',
             branch='master', submodules=True)

--- a/var/spack/repos/builtin/packages/libunistring/package.py
+++ b/var/spack/repos/builtin/packages/libunistring/package.py
@@ -11,7 +11,7 @@ class Libunistring(AutotoolsPackage):
     and for manipulating C strings according to the Unicode standard."""
 
     homepage = "https://www.gnu.org/software/libunistring/"
-    url      = "https://ftpmirror.gnu.org/libunistring/libunistring-0.9.10.tar.xz"
+    url      = "https://ftp.gnu.org/gnu/libunistring/libunistring-0.9.10.tar.xz"
 
     version('0.9.10', sha256='eb8fb2c3e4b6e2d336608377050892b54c3c983b646c561836550863003c05d7')
     version('0.9.9',  sha256='a4d993ecfce16cf503ff7579f5da64619cee66226fb3b998dafb706190d9a833')

--- a/var/spack/repos/builtin/packages/m4/package.py
+++ b/var/spack/repos/builtin/packages/m4/package.py
@@ -10,7 +10,7 @@ class M4(AutotoolsPackage):
     """GNU M4 is an implementation of the traditional Unix macro processor."""
 
     homepage = "https://www.gnu.org/software/m4/m4.html"
-    url      = "https://ftpmirror.gnu.org/m4/m4-1.4.18.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/m4/m4-1.4.18.tar.gz"
 
     version('1.4.18', sha256='ab2633921a5cd38e48797bf5521ad259bdc4b979078034a3b790d7fec5493fab')
     version('1.4.17', sha256='3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e')

--- a/var/spack/repos/builtin/packages/mpc/package.py
+++ b/var/spack/repos/builtin/packages/mpc/package.py
@@ -12,7 +12,7 @@ class Mpc(AutotoolsPackage):
        result."""
 
     homepage = "http://www.multiprecision.org"
-    url      = "https://ftpmirror.gnu.org/mpc/mpc-1.1.0.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz"
     list_url = "http://www.multiprecision.org/mpc/download.html"
 
     version('1.1.0', sha256='6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e')
@@ -29,7 +29,7 @@ class Mpc(AutotoolsPackage):
         if version < Version("1.0.1"):
             url = "http://www.multiprecision.org/mpc/download/mpc-{0}.tar.gz"
         else:
-            url = "https://ftpmirror.gnu.org/mpc/mpc-{0}.tar.gz"
+            url = "https://ftp.gnu.org/gnu/mpc/mpc-{0}.tar.gz"
 
         return url.format(version)
 

--- a/var/spack/repos/builtin/packages/mpfr/package.py
+++ b/var/spack/repos/builtin/packages/mpfr/package.py
@@ -11,7 +11,7 @@ class Mpfr(AutotoolsPackage):
        floating-point computations with correct rounding."""
 
     homepage = "https://www.mpfr.org/"
-    url      = "https://ftpmirror.gnu.org/mpfr/mpfr-4.0.2.tar.bz2"
+    url      = "https://ftp.gnu.org/gnu/mpfr/mpfr-4.0.2.tar.bz2"
 
     version('4.0.2', sha256='c05e3f02d09e0e9019384cdd58e0f19c64e6db1fd6f5ecf77b4b1c61ca253acc')
     version('4.0.1', sha256='a4d97610ba8579d380b384b225187c250ef88cfe1d5e7226b89519374209b86b')

--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -18,7 +18,7 @@ class Ncurses(AutotoolsPackage):
 
     homepage = "http://invisible-island.net/ncurses/ncurses.html"
     # URL must remain http:// so Spack can bootstrap curl
-    url      = "http://ftpmirror.gnu.org/ncurses/ncurses-6.1.tar.gz"
+    url      = "http://ftp.gnu.org/gnu/ncurses/ncurses-6.1.tar.gz"
 
     version('6.1', sha256='aa057eeeb4a14d470101eff4597d5833dcef5965331be3528c08d99cebaa0d17')
     version('6.0', sha256='f551c24b30ce8bfb6e96d9f59b42fbea30fa3a6123384172f9e7284bcf647260')

--- a/var/spack/repos/builtin/packages/nettle/package.py
+++ b/var/spack/repos/builtin/packages/nettle/package.py
@@ -11,7 +11,7 @@ class Nettle(AutotoolsPackage):
     that is designed to fit easily in many contexts."""
 
     homepage = "https://www.lysator.liu.se/~nisse/nettle/"
-    url      = "https://ftpmirror.gnu.org/nettle/nettle-3.3.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/nettle/nettle-3.3.tar.gz"
 
     version('3.4.1', sha256='f941cf1535cd5d1819be5ccae5babef01f6db611f9b5a777bae9c7604b8a92ad')
     version('3.4',   sha256='ae7a42df026550b85daca8389b6a60ba6313b0567f374392e54918588a411e94')

--- a/var/spack/repos/builtin/packages/octave/package.py
+++ b/var/spack/repos/builtin/packages/octave/package.py
@@ -15,7 +15,7 @@ class Octave(AutotoolsPackage):
     Matlab. It may also be used as a batch-oriented language."""
 
     homepage = "https://www.gnu.org/software/octave/"
-    url      = "https://ftpmirror.gnu.org/octave/octave-4.0.0.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/octave/octave-4.0.0.tar.gz"
 
     extendable = True
 

--- a/var/spack/repos/builtin/packages/parallel/package.py
+++ b/var/spack/repos/builtin/packages/parallel/package.py
@@ -13,7 +13,7 @@ class Parallel(AutotoolsPackage):
     """
 
     homepage = "http://www.gnu.org/software/parallel/"
-    url      = "https://ftpmirror.gnu.org/parallel/parallel-20170122.tar.bz2"
+    url      = "https://ftp.gnu.org/gnu/parallel/parallel-20170122.tar.bz2"
 
     version('20190222', sha256='86b1badc56ee2de1483107c2adf634604fd72789c91f65e40138d21425906b1c')
     version('20170322', sha256='f8f810040088bf3c52897a2ee0c0c71bd8d097e755312364b946f107ae3553f6')

--- a/var/spack/repos/builtin/packages/patch/package.py
+++ b/var/spack/repos/builtin/packages/patch/package.py
@@ -13,7 +13,7 @@ class Patch(AutotoolsPackage):
     """
 
     homepage = "http://savannah.gnu.org/projects/patch/"
-    url      = "https://ftpmirror.gnu.org/patch/patch-2.7.6.tar.xz"
+    url      = "https://ftp.gnu.org/gnu/patch/patch-2.7.6.tar.xz"
 
     version('2.7.6', sha256='ac610bda97abe0d9f6b7c963255a11dcb196c25e337c61f94e4778d632f1d8fd')
     version('2.7.5', sha256='fd95153655d6b95567e623843a0e77b81612d502ecf78a489a4aed7867caa299')

--- a/var/spack/repos/builtin/packages/readline/package.py
+++ b/var/spack/repos/builtin/packages/readline/package.py
@@ -16,7 +16,7 @@ class Readline(AutotoolsPackage):
 
     homepage = "http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html"
     # URL must remain http:// so Spack can bootstrap curl
-    url      = "http://ftpmirror.gnu.org/readline/readline-8.0.tar.gz"
+    url      = "http://ftp.gnu.org/gnu/readline/readline-8.0.tar.gz"
 
     version('8.0', sha256='e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461')
     version('7.0', sha256='750d437185286f40a369e1e4f4764eda932b9459b5ec9a731628393dd3d32334')

--- a/var/spack/repos/builtin/packages/screen/package.py
+++ b/var/spack/repos/builtin/packages/screen/package.py
@@ -12,7 +12,7 @@ class Screen(AutotoolsPackage):
     """
 
     homepage = "https://www.gnu.org/software/screen/"
-    url      = "https://ftpmirror.gnu.org/screen/screen-4.3.1.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/screen/screen-4.3.1.tar.gz"
 
     version('4.6.2', sha256='1b6922520e6a0ce5e28768d620b0f640a6631397f95ccb043b70b91bb503fa3a')
     version('4.3.1', sha256='fa4049f8aee283de62e283d427f2cfd35d6c369b40f7f45f947dbfd915699d63')

--- a/var/spack/repos/builtin/packages/sed/package.py
+++ b/var/spack/repos/builtin/packages/sed/package.py
@@ -9,6 +9,6 @@ from spack import *
 class Sed(AutotoolsPackage):
     """GNU implementation of the famous stream editor."""
     homepage = "http://www.gnu.org/software/sed/"
-    url      = "https://ftpmirror.gnu.org/sed/sed-4.2.2.tar.bz2"
+    url      = "https://ftp.gnu.org/gnu/sed/sed-4.2.2.tar.bz2"
 
     version('4.2.2', sha256='f048d1838da284c8bc9753e4506b85a1e0cc1ea8999d36f6995bcb9460cddbd7')

--- a/var/spack/repos/builtin/packages/stow/package.py
+++ b/var/spack/repos/builtin/packages/stow/package.py
@@ -15,7 +15,7 @@ class Stow(AutotoolsPackage):
        installed in the same place."""
 
     homepage = "https://www.gnu.org/software/stow/"
-    url      = "https://ftpmirror.gnu.org/stow/stow-2.2.2.tar.bz2"
+    url      = "https://ftp.gnu.org/gnu/stow/stow-2.2.2.tar.bz2"
 
     version('2.2.2', sha256='a0022034960e47a8d23dffb822689f061f7a2d9101c9835cf11bf251597aa6fd')
     version('2.2.0', sha256='86bc30fe1d322a5c80ff3bd7580c2758149aad7c3bbfa18b48a9d95c25d66b05')

--- a/var/spack/repos/builtin/packages/tar/package.py
+++ b/var/spack/repos/builtin/packages/tar/package.py
@@ -11,7 +11,7 @@ class Tar(AutotoolsPackage):
     other kinds of manipulation."""
 
     homepage = "https://www.gnu.org/software/tar/"
-    url      = "https://ftpmirror.gnu.org/tar/tar-1.32.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/tar/tar-1.32.tar.gz"
 
     version('1.32', sha256='b59549594d91d84ee00c99cf2541a3330fed3a42c440503326dab767f2fbb96c')
     version('1.31', sha256='b471be6cb68fd13c4878297d856aebd50551646f4e3074906b1a74549c40d5a2')

--- a/var/spack/repos/builtin/packages/texinfo/package.py
+++ b/var/spack/repos/builtin/packages/texinfo/package.py
@@ -15,7 +15,7 @@ class Texinfo(AutotoolsPackage):
     of the time. It is used by many non-GNU projects as well."""
 
     homepage = "https://www.gnu.org/software/texinfo/"
-    url      = "https://ftpmirror.gnu.org/texinfo/texinfo-6.0.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/texinfo/texinfo-6.0.tar.gz"
 
     version('6.5', sha256='d34272e4042c46186ddcd66bd5d980c0ca14ff734444686ccf8131f6ec8b1427')
     version('6.3', sha256='300a6ba4958c2dd4a6d5ce60f0a335daf7e379f5374f276f6ba31a221f02f606')

--- a/var/spack/repos/builtin/packages/time/package.py
+++ b/var/spack/repos/builtin/packages/time/package.py
@@ -12,7 +12,7 @@ class Time(AutotoolsPackage):
        information about the resources used by that program."""
 
     homepage = "https://www.gnu.org/software/time/"
-    url      = "https://ftpmirror.gnu.org/time/time-1.9.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/time/time-1.9.tar.gz"
 
     version('1.9', sha256='fbacf0c81e62429df3e33bda4cee38756604f18e01d977338e23306a3e3b521e')
 

--- a/var/spack/repos/builtin/packages/units/package.py
+++ b/var/spack/repos/builtin/packages/units/package.py
@@ -10,7 +10,7 @@ class Units(AutotoolsPackage):
     """GNU units converts between different systems of units"""
 
     homepage = "https://www.gnu.org/software/units/"
-    url      = "https://ftpmirror.gnu.org/units/units-2.13.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/units/units-2.13.tar.gz"
 
     version('2.13', sha256='0ba5403111f8e5ea22be7d51ab74c8ccb576dc30ddfbf18a46cb51f9139790ab')
 

--- a/var/spack/repos/builtin/packages/wget/package.py
+++ b/var/spack/repos/builtin/packages/wget/package.py
@@ -13,7 +13,7 @@ class Wget(AutotoolsPackage):
     cron jobs, terminals without X-Windows support, etc."""
 
     homepage = "http://www.gnu.org/software/wget/"
-    url      = "https://ftpmirror.gnu.org/wget/wget-1.19.1.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/wget/wget-1.19.1.tar.gz"
 
     version('1.20.3', sha256='31cccfc6630528db1c8e3a06f6decf2a370060b982841cfab2b8677400a5092e')
     version('1.19.1', sha256='9e4f12da38cc6167d0752d934abe27c7b1599a9af294e73829be7ac7b5b4da40')


### PR DESCRIPTION
ftpmirror.gnu.org is currently down, causing all build tests in Travis to fail since we no longer use a downloads cache. This PR switches the downloads to the canonical ftp.gnu.org website.

See https://www.gnu.org/prep/ftp.html for more info on the mirrors GNU offers. GNU explicitly asks that everyone uses ftpmirror.gnu.org, which is why we were using it, but it's been very flakey for awhile now. I'm not sure if we can trust it. Once Spack has its own source mirror in AWS, we can switch things back.

@alalazo @tgamblin 