### PR TITLE
Bugfix/prank

### DIFF
--- a/var/spack/repos/builtin/packages/prank/package.py
+++ b/var/spack/repos/builtin/packages/prank/package.py
@@ -21,6 +21,11 @@ class Prank(Package):
 
     def install(self, spec, prefix):
         with working_dir('src'):
+            filter_file('gcc', '{0}'.format(spack_cc), 'Makefile', string=True)
+            filter_file('g++', '{0}'.format(spack_cxx), 'Makefile', string=True)
+            if not spec.target.family == 'x86_64':
+              filter_file('-m64', '', 'Makefile', string=True)
+              filter_file('-pipe', '', 'Makefile', string=True)
             make()
             mkdirp(prefix.bin)
             install('prank', prefix.bin)

--- a/var/spack/repos/builtin/packages/prank/package.py
+++ b/var/spack/repos/builtin/packages/prank/package.py
@@ -21,11 +21,15 @@ class Prank(Package):
 
     def install(self, spec, prefix):
         with working_dir('src'):
-            filter_file('gcc', '{0}'.format(spack_cc), 'Makefile', string=True)
-            filter_file('g++', '{0}'.format(spack_cxx), 'Makefile', string=True)
+
+            filter_file('gcc', '{0}'.format(spack_cc),
+                        'Makefile', string=True)
+            filter_file('g++', '{0}'.format(spack_cxx),
+                        'Makefile', string=True)
             if not spec.target.family == 'x86_64':
-              filter_file('-m64', '', 'Makefile', string=True)
-              filter_file('-pipe', '', 'Makefile', string=True)
+                filter_file('-m64', '', 'Makefile', string=True)
+                filter_file('-pipe', '', 'Makefile', string=True)
+
             make()
             mkdirp(prefix.bin)
             install('prank', prefix.bin)


### PR DESCRIPTION
* Rewrite `gcc/g++` to spack compiler commands to use compiler except `gcc`.
* Remove options that may not be compatible with non-x86_64 environments.