### PR TITLE
ACTS v0.11.0 + adding myself as maintainer

### DIFF
--- a/var/spack/repos/builtin/packages/acts-core/package.py
+++ b/var/spack/repos/builtin/packages/acts-core/package.py
@@ -34,6 +34,7 @@ class ActsCore(CMakePackage):
     maintainers = ['HadrienG2']
 
     version('develop', branch='master')
+    version('0.11.0', commit='22bcea1f19adb0021ca61b843b95cfd2462dd31d')
     version('0.10.5', commit='b6f7234ca8f18ee11e57709d019c14bf41cf9b19')
     version('0.10.4', commit='42cbc359c209f5cf386e620b5a497192c024655e')
     version('0.10.3', commit='a3bb86b79a65b3d2ceb962b60411fd0df4cf274c')

--- a/var/spack/repos/builtin/packages/acts-core/package.py
+++ b/var/spack/repos/builtin/packages/acts-core/package.py
@@ -31,6 +31,7 @@ class ActsCore(CMakePackage):
 
     homepage = "http://acts.web.cern.ch/ACTS/"
     git      = "https://gitlab.cern.ch/acts/acts-core.git"
+    maintainers = ['HadrienG2']
 
     version('develop', branch='master')
     version('0.10.5', commit='b6f7234ca8f18ee11e57709d019c14bf41cf9b19')


### PR DESCRIPTION
Yet another [largely uneventful ACTS release](https://gitlab.cern.ch/acts/acts-core/-/tags/v0.11.00), at least from a build system point of view.

I also figured out how to add myself as a maintainer, as was suggested during a previous last round of updates.