### PR TITLE
Fetching from URLs falls back to mirrors if they exist

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -553,6 +553,33 @@ version. This is useful for packages that have an easy to extrapolate URL, but
 keep changing their URL format every few releases. With this method, you only
 need to specify the ``url`` when the URL changes.
 
+"""""""""""""""""""""""
+Mirrors of the main URL
+"""""""""""""""""""""""
+
+Spack supports listing mirrors of the main URL in a package by defining
+the ``mirrors`` attribute. This attribute must return a list of URLs:
+
+.. code-block:: python
+
+  class Foo(Package):
+
+    url = "http://example.com/foo-1.0.tar.gz"
+    mirrors = [
+        'http://mirror.com/foo-1.0.tar.gz'
+    ]
+
+When fetching a package Spack will always try first the main URL and
+proceed with mirrors in the order in which they are listed if that fails.
+
+A well-known case of packages that can be fetched from multiple mirrors is that
+of GNU. For that, Spack goes a step further and defines a mixin class that
+takes care of all of the plumbing and requires packagers to just define a proper
+``gnu_path`` attribute:
+
+.. literalinclude:: _spack_root/var/spack/repos/builtin/packages/autoconf/package.py
+   :lines: 9-18
+
 ^^^^^^^^^^^^^^^^^^^^^^^^
 Skipping the expand step
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -576,7 +576,7 @@ or ``urls`` can be present in a package, but not both at the same time.
 A well-known case of packages that can be fetched from multiple mirrors is that
 of GNU. For that, Spack goes a step further and defines a mixin class that
 takes care of all of the plumbing and requires packagers to just define a proper
-``gnu_path`` attribute:
+``gnu_mirror_path`` attribute:
 
 .. literalinclude:: _spack_root/var/spack/repos/builtin/packages/autoconf/package.py
    :lines: 9-18

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -558,19 +558,20 @@ Mirrors of the main URL
 """""""""""""""""""""""
 
 Spack supports listing mirrors of the main URL in a package by defining
-the ``mirrors`` attribute. This attribute must return a list of URLs:
+the ``urls`` attribute:
 
 .. code-block:: python
 
   class Foo(Package):
 
-    url = "http://example.com/foo-1.0.tar.gz"
-    mirrors = [
+    urls = [
+        'http://example.com/foo-1.0.tar.gz',
         'http://mirror.com/foo-1.0.tar.gz'
     ]
 
-When fetching a package Spack will always try first the main URL and
-proceed with mirrors in the order in which they are listed if that fails.
+instead of just a single ``url``. This attribute is a list of possible URLs that
+will be tried in order when fetching packages. Notice that either one of ``url``
+or ``urls`` can be present in a package, but not both at the same time.
 
 A well-known case of packages that can be fetched from multiple mirrors is that
 of GNU. For that, Spack goes a step further and defines a mixin class that

--- a/lib/spack/spack/build_systems/gnu.py
+++ b/lib/spack/spack/build_systems/gnu.py
@@ -11,7 +11,7 @@ import spack.package
 class GNUMirrorPackage(spack.package.PackageBase):
     """Mixin that takes care of setting url and mirrors for GNU packages."""
     #: Path of the package in a GNU mirror
-    gnu_path = None
+    gnu_mirror_path = None
 
     #: List of GNU mirrors used by Spack
     base_mirrors = [
@@ -24,13 +24,14 @@ class GNUMirrorPackage(spack.package.PackageBase):
 
     @property
     def urls(self):
-        self._ensure_gnu_path_is_set_or_raise()
+        self._ensure_gnu_mirror_path_is_set_or_raise()
         return [
-            os.path.join(m, self.gnu_path) for m in self.base_mirrors
+            os.path.join(m, self.gnu_mirror_path) for m in self.base_mirrors
         ]
 
-    def _ensure_gnu_path_is_set_or_raise(self):
-        if self.gnu_path is None:
+    def _ensure_gnu_mirror_path_is_set_or_raise(self):
+        if self.gnu_mirror_path is None:
             cls_name = type(self).__name__
-            msg = '{0} must define a `gnu_path` attribute [none defined]'
+            msg = ('{0} must define a `gnu_mirror_path` attribute'
+                   ' [none defined]')
             raise AttributeError(msg.format(cls_name))

--- a/lib/spack/spack/build_systems/gnu.py
+++ b/lib/spack/spack/build_systems/gnu.py
@@ -10,13 +10,12 @@ import spack.package
 
 class GNUMirrorPackage(spack.package.PackageBase):
     """Mixin that takes care of setting url and mirrors for GNU packages."""
+    #: Path of the package in a GNU mirror
     gnu_path = None
 
-    #: Primary URL to search for GNU packages
-    base_url = 'https://ftp.gnu.org/gnu'
-
-    #: List of GNU mirrors we'll use as a fall-back
+    #: List of GNU mirrors used by Spack
     base_mirrors = [
+        'https://ftp.gnu.org/gnu',
         'https://ftpmirror.gnu.org/',
         # Fall back to http if https didn't work (for instance because
         # Spack is bootstrapping curl)
@@ -24,12 +23,7 @@ class GNUMirrorPackage(spack.package.PackageBase):
     ]
 
     @property
-    def url(self):
-        self._ensure_gnu_path_is_set_or_raise()
-        return os.path.join(self.base_url, self.gnu_path)
-
-    @property
-    def mirrors(self):
+    def urls(self):
         self._ensure_gnu_path_is_set_or_raise()
         return [
             os.path.join(m, self.gnu_path) for m in self.base_mirrors

--- a/lib/spack/spack/build_systems/gnu.py
+++ b/lib/spack/spack/build_systems/gnu.py
@@ -8,7 +8,7 @@ import os.path
 import spack.package
 
 
-class GNUPackage(spack.package.PackageBase):
+class GNUMirrorPackage(spack.package.PackageBase):
     """Mixin that takes care of setting url and mirrors for GNU packages."""
     gnu_path = None
 
@@ -17,7 +17,10 @@ class GNUPackage(spack.package.PackageBase):
 
     #: List of GNU mirrors we'll use as a fall-back
     base_mirrors = [
-        'https://ftpmirror.gnu.org/'
+        'https://ftpmirror.gnu.org/',
+        # Fall back to http if https didn't work (for instance because
+        # Spack is bootstrapping curl)
+        'http://ftpmirror.gnu.org/'
     ]
 
     @property

--- a/lib/spack/spack/build_systems/gnu.py
+++ b/lib/spack/spack/build_systems/gnu.py
@@ -1,0 +1,39 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os.path
+
+import spack.package
+
+
+class GNUPackage(spack.package.PackageBase):
+    """Mixin that takes care of setting url and mirrors for GNU packages."""
+    gnu_path = None
+
+    #: Primary URL to search for GNU packages
+    base_url = 'https://ftp.gnu.org/gnu'
+
+    #: List of GNU mirrors we'll use as a fall-back
+    base_mirrors = [
+        'https://ftpmirror.gnu.org/'
+    ]
+
+    @property
+    def url(self):
+        self._ensure_gnu_path_is_set_or_raise()
+        return os.path.join(self.base_url, self.gnu_path)
+
+    @property
+    def mirrors(self):
+        self._ensure_gnu_path_is_set_or_raise()
+        return [
+            os.path.join(m, self.gnu_path) for m in self.base_mirrors
+        ]
+
+    def _ensure_gnu_path_is_set_or_raise(self):
+        if self.gnu_path is None:
+            cls_name = type(self).__name__
+            msg = '{0} must define a `gnu_path` attribute [none defined]'
+            raise AttributeError(msg.format(cls_name))

--- a/lib/spack/spack/cmd/url.py
+++ b/lib/spack/spack/cmd/url.py
@@ -135,7 +135,7 @@ def url_list(args):
 
     # Gather set of URLs from all packages
     for pkg in spack.repo.path.all_packages():
-        url = getattr(pkg.__class__, 'url', None)
+        url = getattr(pkg, 'url', None)
         urls = url_list_parsing(args, urls, url, pkg)
 
         for params in pkg.versions.values():
@@ -174,7 +174,7 @@ def url_summary(args):
     for pkg in spack.repo.path.all_packages():
         urls = set()
 
-        url = getattr(pkg.__class__, 'url', None)
+        url = getattr(pkg, 'url', None)
         if url:
             urls.add(url)
 

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -320,6 +320,7 @@ class URLFetchStrategy(FetchStrategy):
                          partial_file]  # use a .part file
         else:
             save_args = ['-O']
+
         curl_args = save_args + [
             '-f',  # fail on >400 errors
             '-D',
@@ -329,17 +330,22 @@ class URLFetchStrategy(FetchStrategy):
             '--connect-timeout', '10',
             url,
         ]
+
         if not spack.config.get('config:verify_ssl'):
             curl_args.append('-k')
+
         if sys.stdout.isatty() and tty.msg_enabled():
             curl_args.append('-#')  # status bar when using a tty
         else:
             curl_args.append('-sS')  # just errors when not.
+
         curl_args += self.extra_curl_options
+
         # Run curl but grab the mime type from the http headers
         curl = self.curl
         with working_dir(self.stage.path):
             headers = curl(*curl_args, output=str, fail_on_error=False)
+
         if curl.returncode != 0:
             # clean up archive on failure.
             if self.archive_file:
@@ -370,6 +376,7 @@ class URLFetchStrategy(FetchStrategy):
                 raise FailedDownloadError(
                     self.url,
                     "Curl failed with error %d" % curl.returncode)
+
         # Check if we somehow got an HTML file rather than the archive we
         # asked for.  We only look at the last content type, to handle
         # redirects properly.

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -22,33 +22,30 @@ in order to build it.  They need to define the following methods:
     * archive()
         Archive a source directory, e.g. for creating a mirror.
 """
+import copy
+import functools
 import os
 import os.path
-import sys
 import re
 import shutil
-import copy
+import sys
 import xml.etree.ElementTree
-from functools import wraps
-from six import string_types
-import six.moves.urllib.parse as urllib_parse
 
 import llnl.util.tty as tty
-from llnl.util.filesystem import (
-    working_dir, mkdirp, temp_rename, temp_cwd, get_single_file)
-
+import six
+import six.moves.urllib.parse as urllib_parse
 import spack.config
 import spack.error
 import spack.util.crypto as crypto
 import spack.util.pattern as pattern
-import spack.util.web as web_util
 import spack.util.url as url_util
-
+import spack.util.web as web_util
+from llnl.util.filesystem import (
+    working_dir, mkdirp, temp_rename, temp_cwd, get_single_file)
+from spack.util.compression import decompressor_for, extension
 from spack.util.executable import which
 from spack.util.string import comma_and, quote
 from spack.version import Version, ver
-from spack.util.compression import decompressor_for, extension
-
 
 #: List of all fetch strategies, created by FetchStrategy metaclass.
 all_strategies = []
@@ -69,7 +66,7 @@ def _needs_stage(fun):
     """Many methods on fetch strategies require a stage to be set
        using set_stage().  This decorator adds a check for self.stage."""
 
-    @wraps(fun)
+    @functools.wraps(fun)
     def wrapper(self, *args, **kwargs):
         if not self.stage:
             raise NoStageError(fun)
@@ -592,7 +589,7 @@ class VCSFetchStrategy(FetchStrategy):
 
         patterns = kwargs.get('exclude', None)
         if patterns is not None:
-            if isinstance(patterns, string_types):
+            if isinstance(patterns, six.string_types):
                 patterns = [patterns]
             for p in patterns:
                 tar.add_default_arg('--exclude=%s' % p)

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -106,16 +106,12 @@ class FetchStrategy(object):
         self.stage = None
         # Enable or disable caching for this strategy based on
         # 'no_cache' option from version directive.
-        self._cache_enabled = not kwargs.pop('no_cache', False)
+        self.cache_enabled = not kwargs.pop('no_cache', False)
 
     def set_stage(self, stage):
         """This is called by Stage before any of the fetching
            methods are called on the stage."""
         self.stage = stage
-
-    @property
-    def cache_enabled(self):
-        return self._cache_enabled
 
     # Subclasses need to implement these methods
     def fetch(self):
@@ -386,7 +382,7 @@ class URLFetchStrategy(FetchStrategy):
 
     @property
     def cachable(self):
-        return self._cache_enabled and bool(self.digest)
+        return self.cache_enabled and bool(self.digest)
 
     @_needs_stage
     def expand(self):
@@ -738,7 +734,7 @@ class GitFetchStrategy(VCSFetchStrategy):
 
     @property
     def cachable(self):
-        return self._cache_enabled and bool(self.commit or self.tag)
+        return self.cache_enabled and bool(self.commit or self.tag)
 
     def source_id(self):
         return self.commit or self.tag
@@ -921,7 +917,7 @@ class SvnFetchStrategy(VCSFetchStrategy):
 
     @property
     def cachable(self):
-        return self._cache_enabled and bool(self.revision)
+        return self.cache_enabled and bool(self.revision)
 
     def source_id(self):
         return self.revision
@@ -1035,7 +1031,7 @@ class HgFetchStrategy(VCSFetchStrategy):
 
     @property
     def cachable(self):
-        return self._cache_enabled and bool(self.revision)
+        return self.cache_enabled and bool(self.revision)
 
     def source_id(self):
         return self.revision

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -170,10 +170,14 @@ class FetchStrategy(object):
     def __str__(self):  # Should be human readable URL.
         return "FetchStrategy.__str___"
 
-    # This method is used to match fetch strategies to version()
-    # arguments in packages.
     @classmethod
     def matches(cls, args):
+        """Predicate that matches fetch strategies to arguments of
+        the version directive.
+
+        Args:
+            args: arguments of the version directive
+        """
         return cls.url_attr in args
 
 
@@ -227,10 +231,10 @@ class FetchStrategyComposite(object):
 
 @fetcher
 class URLFetchStrategy(FetchStrategy):
-    """
-    FetchStrategy that pulls source code from a URL for an archive, check the
-    archive against a checksum, and decompresses the archive.  The destination
-    for the resulting file(s) is the standard stage source path.
+    """URLFetchStrategy pulls source code from a URL for an archive, check the
+    archive against a checksum, and decompresses the archive.
+
+    The destination for the resulting file(s) is the standard stage path.
     """
     url_attr = 'url'
 
@@ -1233,14 +1237,13 @@ def _from_merged_attrs(fetcher, pkg, version):
     """Create a fetcher from merged package and version attributes."""
     if fetcher.url_attr == 'url':
         url = pkg.url_for_version(version)
+        mirrors = [spack.url.substitute_version(u, version)
+                   for u in getattr(pkg, 'urls', [])]
+        attrs = {fetcher.url_attr: url, 'mirrors': mirrors}
     else:
         url = getattr(pkg, fetcher.url_attr)
+        attrs = {fetcher.url_attr: url}
 
-    mirrors = getattr(pkg, 'mirrors', None)
-    if mirrors:
-        mirrors = [spack.url.substitute_version(u, version) for u in mirrors]
-
-    attrs = {fetcher.url_attr: url, 'mirrors': mirrors}
     attrs.update(pkg.versions[version])
     return fetcher(**attrs)
 

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -1244,6 +1244,8 @@ def _from_merged_attrs(fetcher, pkg, version):
     """Create a fetcher from merged package and version attributes."""
     if fetcher.url_attr == 'url':
         url = pkg.url_for_version(version)
+        # TODO: refactor this logic into its own method or function
+        # TODO: to avoid duplication
         mirrors = [spack.url.substitute_version(u, version)
                    for u in getattr(pkg, 'urls', [])]
         attrs = {fetcher.url_attr: url, 'mirrors': mirrors}

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -108,11 +108,6 @@ class FetchStrategy(object):
         # 'no_cache' option from version directive.
         self.cache_enabled = not kwargs.pop('no_cache', False)
 
-    def set_stage(self, stage):
-        """This is called by Stage before any of the fetching
-           methods are called on the stage."""
-        self.stage = stage
-
     # Subclasses need to implement these methods
     def fetch(self):
         """Fetch source code archive or repo.
@@ -223,7 +218,6 @@ class FetchStrategyComposite(object):
     Implements the GoF composite pattern.
     """
     matches = FetchStrategy.matches
-    set_stage = FetchStrategy.set_stage
 
     def source_id(self):
         component_ids = tuple(i.source_id() for i in self)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -510,8 +510,8 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
     maintainers = []
 
     #: List of attributes to be excluded from a package's hash.
-    metadata_attrs = ['homepage', 'url', 'list_url', 'extendable', 'parallel',
-                      'make_jobs']
+    metadata_attrs = ['homepage', 'url', 'urls', 'list_url', 'extendable',
+                      'parallel', 'make_jobs']
 
     def __init__(self, spec):
         # this determines how the package should be built.
@@ -523,6 +523,12 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         # Keep track of whether or not this package was installed from
         # a binary cache.
         self.installed_from_binary_cache = False
+
+        # Ensure that only one of these two attributes are present
+        if getattr(self, 'url', None) and getattr(self, 'urls', None):
+            msg = "a package can have either a 'url' or a 'urls' attribute"
+            msg += " [package '{0.name}' defines both]"
+            raise ValueError(msg.format(self))
 
         # Set a default list URL (place to find available versions)
         if not hasattr(self, 'list_url'):
@@ -727,7 +733,9 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             return version_urls[version]
 
         # If no specific URL, use the default, class-level URL
-        default_url = getattr(self, 'url', None)
+        url = getattr(self, 'url', None)
+        urls = getattr(self, 'urls', [None])
+        default_url = url or urls.pop(0)
 
         # if no exact match AND no class-level default, use the nearest URL
         if not default_url:

--- a/lib/spack/spack/pkgkit.py
+++ b/lib/spack/spack/pkgkit.py
@@ -30,6 +30,7 @@ from spack.build_systems.perl import PerlPackage
 from spack.build_systems.intel import IntelPackage
 from spack.build_systems.meson import MesonPackage
 from spack.build_systems.sip import SIPPackage
+from spack.build_systems.gnu import GNUPackage
 
 from spack.mixins import filter_compiler_wrappers
 

--- a/lib/spack/spack/pkgkit.py
+++ b/lib/spack/spack/pkgkit.py
@@ -30,7 +30,7 @@ from spack.build_systems.perl import PerlPackage
 from spack.build_systems.intel import IntelPackage
 from spack.build_systems.meson import MesonPackage
 from spack.build_systems.sip import SIPPackage
-from spack.build_systems.gnu import GNUPackage
+from spack.build_systems.gnu import GNUMirrorPackage
 
 from spack.mixins import filter_compiler_wrappers
 

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -271,7 +271,7 @@ class Stage(object):
         else:
             raise ValueError(
                 "Can't construct Stage without url or fetch strategy")
-        self.fetcher.set_stage(self)
+        self.fetcher.stage = self
         # self.fetcher can change with mirrors.
         self.default_fetcher = self.fetcher
         self.search_fn = search_fn
@@ -458,7 +458,7 @@ class Stage(object):
 
         for fetcher in generate_fetchers():
             try:
-                fetcher.set_stage(self)
+                fetcher.stage = self
                 self.fetcher = fetcher
                 self.fetcher.fetch()
                 break

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -240,9 +240,6 @@ def mock_fetch_cache(monkeypatch):
             return MockCacheFetcher()
 
     class MockCacheFetcher(object):
-        def set_stage(self, stage):
-            pass
-
         def fetch(self):
             raise FetchError('Mock cache always fails for tests')
 

--- a/lib/spack/spack/test/url_fetch.py
+++ b/lib/spack/spack/test/url_fetch.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import collections
 import os
 import pytest
 
@@ -10,8 +11,7 @@ from llnl.util.filesystem import working_dir, is_exe
 
 import spack.repo
 import spack.config
-from spack.fetch_strategy import FailedDownloadError
-from spack.fetch_strategy import from_list_url, URLFetchStrategy
+import spack.fetch_strategy as fs
 from spack.spec import Spec
 from spack.stage import Stage
 from spack.version import ver
@@ -23,10 +23,26 @@ def checksum_type(request):
     return request.param
 
 
+@pytest.fixture
+def pkg_factory():
+    Pkg = collections.namedtuple(
+        'Pkg', ['url_for_version', 'mirrors', 'url', 'versions']
+    )
+
+    def factory(url, mirrors):
+        fn = lambda v: spack.url.substitute_version(url, v)
+        return Pkg(
+            url_for_version=fn, url=url, mirrors=mirrors,
+            versions=collections.defaultdict(dict)
+        )
+
+    return factory
+
+
 def test_urlfetchstrategy_sans_url():
     """Ensure constructor with no URL fails."""
     with pytest.raises(ValueError):
-        with URLFetchStrategy(None):
+        with fs.URLFetchStrategy(None):
             pass
 
 
@@ -34,8 +50,8 @@ def test_urlfetchstrategy_bad_url(tmpdir):
     """Ensure fetch with bad URL fails as expected."""
     testpath = str(tmpdir)
 
-    with pytest.raises(FailedDownloadError):
-        fetcher = URLFetchStrategy(url='file:///does-not-exist')
+    with pytest.raises(fs.FailedDownloadError):
+        fetcher = fs.URLFetchStrategy(url='file:///does-not-exist')
         assert fetcher is not None
 
         with Stage(fetcher, path=testpath) as stage:
@@ -106,8 +122,8 @@ def test_from_list_url(mock_packages, config, spec, url, digest):
     """
     specification = Spec(spec).concretized()
     pkg = spack.repo.get(specification)
-    fetch_strategy = from_list_url(pkg)
-    assert isinstance(fetch_strategy, URLFetchStrategy)
+    fetch_strategy = fs.from_list_url(pkg)
+    assert isinstance(fetch_strategy, fs.URLFetchStrategy)
     assert os.path.basename(fetch_strategy.url) == url
     assert fetch_strategy.digest == digest
 
@@ -118,8 +134,8 @@ def test_from_list_url_unspecified(mock_packages, config):
 
     spec = Spec('url-list-test @2.0.0').concretized()
     pkg = spack.repo.get(spec)
-    fetch_strategy = from_list_url(pkg)
-    assert isinstance(fetch_strategy, URLFetchStrategy)
+    fetch_strategy = fs.from_list_url(pkg)
+    assert isinstance(fetch_strategy, fs.URLFetchStrategy)
     assert os.path.basename(fetch_strategy.url) == 'foo-2.0.0.tar.gz'
     assert fetch_strategy.digest is None
 
@@ -128,7 +144,7 @@ def test_nosource_from_list_url(mock_packages, config):
     """This test confirms BundlePackages do not have list url."""
     pkg = spack.repo.get('nosource')
 
-    fetch_strategy = from_list_url(pkg)
+    fetch_strategy = fs.from_list_url(pkg)
     assert fetch_strategy is None
 
 
@@ -148,9 +164,25 @@ def test_url_extra_fetch(tmpdir, mock_archive):
     """Ensure a fetch after downloading is effectively a no-op."""
     testpath = str(tmpdir)
 
-    fetcher = URLFetchStrategy(mock_archive.url)
+    fetcher = fs.URLFetchStrategy(mock_archive.url)
     with Stage(fetcher, path=testpath) as stage:
         assert fetcher.archive_file is None
         stage.fetch()
         assert fetcher.archive_file is not None
         fetcher.fetch()
+
+
+@pytest.mark.parametrize('url,mirrors,version,expected', [
+    ('https://ftpmirror.gnu.org/autoconf/autoconf-2.69.tar.gz',
+     ['https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz'],
+     '2.62',
+     ['https://ftpmirror.gnu.org/autoconf/autoconf-2.62.tar.gz',
+      'https://ftp.gnu.org/gnu/autoconf/autoconf-2.62.tar.gz'])
+])
+def test_candidate_urls(pkg_factory, url, mirrors, version, expected):
+    """Tests that candidate urls include mirrors and that they go through
+    pattern matching and substitution for versions.
+    """
+    pkg = pkg_factory(url, mirrors)
+    f = fs._from_merged_attrs(fs.URLFetchStrategy, pkg, version)
+    assert f.candidate_urls == expected

--- a/var/spack/repos/builtin.mock/packages/noversion-bundle/package.py
+++ b/var/spack/repos/builtin.mock/packages/noversion-bundle/package.py
@@ -14,5 +14,5 @@ class NoversionBundle(BundlePackage):
     """
 
     homepage = "http://www.example.com"
-
+    url = "http://www.example.com/a-1.0.tar.gz"
     depends_on('dependency-install')

--- a/var/spack/repos/builtin/packages/aspell/package.py
+++ b/var/spack/repos/builtin/packages/aspell/package.py
@@ -7,14 +7,14 @@ from spack import *
 
 
 # See also: AspellDictPackage
-class Aspell(AutotoolsPackage):
+class Aspell(AutotoolsPackage, GNUMirrorPackage):
     """GNU Aspell is a Free and Open Source spell checker designed to
     eventually replace Ispell."""
 
     homepage = "http://aspell.net/"
-    url      = "https://ftpmirror.gnu.org/aspell/aspell-0.60.6.1.tar.gz"
+    gnu_path = "aspell/aspell-0.60.6.1.tar.gz"
 
-    extendable = True           # support activating dictionaries
+    extendable = True  # support activating dictionaries
 
     version('0.60.6.1', sha256='f52583a83a63633701c5f71db3dc40aab87b7f76b29723aeb27941eff42df6e1')
 

--- a/var/spack/repos/builtin/packages/aspell/package.py
+++ b/var/spack/repos/builtin/packages/aspell/package.py
@@ -12,7 +12,7 @@ class Aspell(AutotoolsPackage, GNUMirrorPackage):
     eventually replace Ispell."""
 
     homepage = "http://aspell.net/"
-    gnu_path = "aspell/aspell-0.60.6.1.tar.gz"
+    gnu_mirror_path = "aspell/aspell-0.60.6.1.tar.gz"
 
     extendable = True  # support activating dictionaries
 

--- a/var/spack/repos/builtin/packages/aspell6-de/package.py
+++ b/var/spack/repos/builtin/packages/aspell6-de/package.py
@@ -6,10 +6,10 @@
 from spack import *
 
 
-class Aspell6De(AspellDictPackage):
+class Aspell6De(AspellDictPackage, GNUMirrorPackage):
     """German (de) dictionary for aspell."""
 
     homepage = "http://aspell.net/"
-    url      = "https://ftpmirror.gnu.org/aspell/dict/de/aspell6-de-20030222-1.tar.bz2"
+    gnu_path = "aspell/dict/de/aspell6-de-20030222-1.tar.bz2"
 
     version('6-de-20030222-1', sha256='ba6c94e11bc2e0e6e43ce0f7822c5bba5ca5ac77129ef90c190b33632416e906')

--- a/var/spack/repos/builtin/packages/aspell6-de/package.py
+++ b/var/spack/repos/builtin/packages/aspell6-de/package.py
@@ -10,6 +10,6 @@ class Aspell6De(AspellDictPackage, GNUMirrorPackage):
     """German (de) dictionary for aspell."""
 
     homepage = "http://aspell.net/"
-    gnu_path = "aspell/dict/de/aspell6-de-20030222-1.tar.bz2"
+    gnu_mirror_path = "aspell/dict/de/aspell6-de-20030222-1.tar.bz2"
 
     version('6-de-20030222-1', sha256='ba6c94e11bc2e0e6e43ce0f7822c5bba5ca5ac77129ef90c190b33632416e906')

--- a/var/spack/repos/builtin/packages/aspell6-en/package.py
+++ b/var/spack/repos/builtin/packages/aspell6-en/package.py
@@ -10,6 +10,6 @@ class Aspell6En(AspellDictPackage, GNUMirrorPackage):
     """English (en) dictionary for aspell."""
 
     homepage = "http://aspell.net/"
-    gnu_path = "aspell/dict/en/aspell6-en-2017.01.22-0.tar.bz2"
+    gnu_mirror_path = "aspell/dict/en/aspell6-en-2017.01.22-0.tar.bz2"
 
     version('2017.01.22-0', sha256='93c73fae3eab5ea3ca6db3cea8770715a820f1b7d6ea2b932dd66a17f8fd55e1')

--- a/var/spack/repos/builtin/packages/aspell6-en/package.py
+++ b/var/spack/repos/builtin/packages/aspell6-en/package.py
@@ -6,10 +6,10 @@
 from spack import *
 
 
-class Aspell6En(AspellDictPackage):
+class Aspell6En(AspellDictPackage, GNUMirrorPackage):
     """English (en) dictionary for aspell."""
 
     homepage = "http://aspell.net/"
-    url      = "https://ftpmirror.gnu.org/aspell/dict/en/aspell6-en-2017.01.22-0.tar.bz2"
+    gnu_path = "aspell/dict/en/aspell6-en-2017.01.22-0.tar.bz2"
 
     version('2017.01.22-0', sha256='93c73fae3eab5ea3ca6db3cea8770715a820f1b7d6ea2b932dd66a17f8fd55e1')

--- a/var/spack/repos/builtin/packages/aspell6-es/package.py
+++ b/var/spack/repos/builtin/packages/aspell6-es/package.py
@@ -10,6 +10,6 @@ class Aspell6Es(AspellDictPackage, GNUMirrorPackage):
     """Spanish (es) dictionary for aspell."""
 
     homepage = "http://aspell.net/"
-    gnu_path = "aspell/dict/es/aspell6-es-1.11-2.tar.bz2"
+    gnu_mirror_path = "aspell/dict/es/aspell6-es-1.11-2.tar.bz2"
 
     version('1.11-2', sha256='ad367fa1e7069c72eb7ae37e4d39c30a44d32a6aa73cedccbd0d06a69018afcc')

--- a/var/spack/repos/builtin/packages/aspell6-es/package.py
+++ b/var/spack/repos/builtin/packages/aspell6-es/package.py
@@ -6,10 +6,10 @@
 from spack import *
 
 
-class Aspell6Es(AspellDictPackage):
+class Aspell6Es(AspellDictPackage, GNUMirrorPackage):
     """Spanish (es) dictionary for aspell."""
 
     homepage = "http://aspell.net/"
-    url      = "https://ftpmirror.gnu.org/aspell/dict/es/aspell6-es-1.11-2.tar.bz2"
+    gnu_path = "aspell/dict/es/aspell6-es-1.11-2.tar.bz2"
 
     version('1.11-2', sha256='ad367fa1e7069c72eb7ae37e4d39c30a44d32a6aa73cedccbd0d06a69018afcc')

--- a/var/spack/repos/builtin/packages/autoconf/package.py
+++ b/var/spack/repos/builtin/packages/autoconf/package.py
@@ -6,15 +6,11 @@
 from spack import *
 
 
-class Autoconf(AutotoolsPackage):
+class Autoconf(AutotoolsPackage, GNUPackage):
     """Autoconf -- system configuration part of autotools"""
 
     homepage = 'https://www.gnu.org/software/autoconf/'
-    url = 'https://ftpmirror.gnu.org/autoconf/autoconf-2.69.tar.gz'
-
-    mirrors = [
-        'https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz'
-    ]
+    gnu_path = 'autoconf/autoconf-2.69.tar.gz'
 
     version('2.69', sha256='954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969')
     version('2.62', sha256='83aa747e6443def0ebd1882509c53f5a2133f502ddefa21b3de141c433914bdd')

--- a/var/spack/repos/builtin/packages/autoconf/package.py
+++ b/var/spack/repos/builtin/packages/autoconf/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class Autoconf(AutotoolsPackage, GNUPackage):
+class Autoconf(AutotoolsPackage, GNUMirrorPackage):
     """Autoconf -- system configuration part of autotools"""
 
     homepage = 'https://www.gnu.org/software/autoconf/'

--- a/var/spack/repos/builtin/packages/autoconf/package.py
+++ b/var/spack/repos/builtin/packages/autoconf/package.py
@@ -10,7 +10,11 @@ class Autoconf(AutotoolsPackage):
     """Autoconf -- system configuration part of autotools"""
 
     homepage = 'https://www.gnu.org/software/autoconf/'
-    url      = 'https://ftpmirror.gnu.org/autoconf/autoconf-2.69.tar.gz'
+    url = 'https://ftpmirror.gnu.org/autoconf/autoconf-2.69.tar.gz'
+
+    mirrors = [
+        'https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz'
+    ]
 
     version('2.69', sha256='954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969')
     version('2.62', sha256='83aa747e6443def0ebd1882509c53f5a2133f502ddefa21b3de141c433914bdd')

--- a/var/spack/repos/builtin/packages/autoconf/package.py
+++ b/var/spack/repos/builtin/packages/autoconf/package.py
@@ -10,7 +10,7 @@ class Autoconf(AutotoolsPackage, GNUMirrorPackage):
     """Autoconf -- system configuration part of autotools"""
 
     homepage = 'https://www.gnu.org/software/autoconf/'
-    gnu_path = 'autoconf/autoconf-2.69.tar.gz'
+    gnu_mirror_path = 'autoconf/autoconf-2.69.tar.gz'
 
     version('2.69', sha256='954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969')
     version('2.62', sha256='83aa747e6443def0ebd1882509c53f5a2133f502ddefa21b3de141c433914bdd')

--- a/var/spack/repos/builtin/packages/autogen/package.py
+++ b/var/spack/repos/builtin/packages/autogen/package.py
@@ -13,7 +13,7 @@ class Autogen(AutotoolsPackage, GNUMirrorPackage):
     synchronized."""
 
     homepage = "https://www.gnu.org/software/autogen/index.html"
-    gnu_path = "autogen/rel5.18.12/autogen-5.18.12.tar.gz"
+    gnu_mirror_path = "autogen/rel5.18.12/autogen-5.18.12.tar.gz"
     list_url = "https://ftp.gnu.org/gnu/autogen"
     list_depth = 1
 

--- a/var/spack/repos/builtin/packages/autogen/package.py
+++ b/var/spack/repos/builtin/packages/autogen/package.py
@@ -6,14 +6,14 @@
 from spack import *
 
 
-class Autogen(AutotoolsPackage):
+class Autogen(AutotoolsPackage, GNUMirrorPackage):
     """AutoGen is a tool designed to simplify the creation and maintenance of
     programs that contain large amounts of repetitious text. It is especially
     valuable in programs that have several blocks of text that must be kept
     synchronized."""
 
     homepage = "https://www.gnu.org/software/autogen/index.html"
-    url      = "https://ftpmirror.gnu.org/autogen/rel5.18.12/autogen-5.18.12.tar.gz"
+    gnu_path = "autogen/rel5.18.12/autogen-5.18.12.tar.gz"
     list_url = "https://ftp.gnu.org/gnu/autogen"
     list_depth = 1
 

--- a/var/spack/repos/builtin/packages/automake/package.py
+++ b/var/spack/repos/builtin/packages/automake/package.py
@@ -6,11 +6,11 @@
 from spack import *
 
 
-class Automake(AutotoolsPackage):
+class Automake(AutotoolsPackage, GNUMirrorPackage):
     """Automake -- make file builder part of autotools"""
 
     homepage = 'http://www.gnu.org/software/automake/'
-    url      = 'https://ftpmirror.gnu.org/automake/automake-1.15.tar.gz'
+    gnu_path = 'automake/automake-1.15.tar.gz'
 
     version('1.16.1', sha256='608a97523f97db32f1f5d5615c98ca69326ced2054c9f82e65bade7fc4c9dea8')
     version('1.15.1', sha256='988e32527abe052307d21c8ca000aa238b914df363a617e38f4fb89f5abf6260')

--- a/var/spack/repos/builtin/packages/automake/package.py
+++ b/var/spack/repos/builtin/packages/automake/package.py
@@ -10,7 +10,7 @@ class Automake(AutotoolsPackage, GNUMirrorPackage):
     """Automake -- make file builder part of autotools"""
 
     homepage = 'http://www.gnu.org/software/automake/'
-    gnu_path = 'automake/automake-1.15.tar.gz'
+    gnu_mirror_path = 'automake/automake-1.15.tar.gz'
 
     version('1.16.1', sha256='608a97523f97db32f1f5d5615c98ca69326ced2054c9f82e65bade7fc4c9dea8')
     version('1.15.1', sha256='988e32527abe052307d21c8ca000aa238b914df363a617e38f4fb89f5abf6260')

--- a/var/spack/repos/builtin/packages/bash/package.py
+++ b/var/spack/repos/builtin/packages/bash/package.py
@@ -6,11 +6,11 @@
 from spack import *
 
 
-class Bash(AutotoolsPackage):
+class Bash(AutotoolsPackage, GNUMirrorPackage):
     """The GNU Project's Bourne Again SHell."""
 
     homepage = "https://www.gnu.org/software/bash/"
-    url      = "https://ftpmirror.gnu.org/bash/bash-4.4.tar.gz"
+    gnu_path = "bash/bash-4.4.tar.gz"
 
     version('5.0',    sha256='b4a80f2ac66170b2913efbfb9f2594f1f76c7b1afd11f799e22035d63077fb4d')
     version('4.4.12', sha256='57d8432be54541531a496fd4904fdc08c12542f43605a9202594fa5d5f9f2331')
@@ -35,6 +35,7 @@ class Bash(AutotoolsPackage):
         ('5.0', '011', '2c4de332b91eaf797abbbd6c79709690b5cbd48b12e8dfe748096dbd7bf474ea'),
     ]
 
+    # TODO: patches below are not managed by the GNUMirrorPackage base class
     for ver, num, checksum in patches:
         ver = Version(ver)
         patch('https://ftpmirror.gnu.org/bash/bash-{0}-patches/bash{1}-{2}'.format(ver, ver.joined, num),

--- a/var/spack/repos/builtin/packages/bash/package.py
+++ b/var/spack/repos/builtin/packages/bash/package.py
@@ -10,7 +10,7 @@ class Bash(AutotoolsPackage, GNUMirrorPackage):
     """The GNU Project's Bourne Again SHell."""
 
     homepage = "https://www.gnu.org/software/bash/"
-    gnu_path = "bash/bash-4.4.tar.gz"
+    gnu_mirror_path = "bash/bash-4.4.tar.gz"
 
     version('5.0',    sha256='b4a80f2ac66170b2913efbfb9f2594f1f76c7b1afd11f799e22035d63077fb4d')
     version('4.4.12', sha256='57d8432be54541531a496fd4904fdc08c12542f43605a9202594fa5d5f9f2331')

--- a/var/spack/repos/builtin/packages/bc/package.py
+++ b/var/spack/repos/builtin/packages/bc/package.py
@@ -12,7 +12,7 @@ class Bc(AutotoolsPackage, GNUMirrorPackage):
     interactive execution of statements."""
 
     homepage = "https://www.gnu.org/software/bc"
-    gnu_path = "bc/bc-1.07.tar.gz"
+    gnu_mirror_path = "bc/bc-1.07.tar.gz"
 
     version('1.07', sha256='55cf1fc33a728d7c3d386cc7b0cb556eb5bacf8e0cb5a3fcca7f109fc61205ad')
 

--- a/var/spack/repos/builtin/packages/bc/package.py
+++ b/var/spack/repos/builtin/packages/bc/package.py
@@ -6,13 +6,13 @@
 from spack import *
 
 
-class Bc(AutotoolsPackage):
+class Bc(AutotoolsPackage, GNUMirrorPackage):
     """bc is an arbitrary precision numeric processing language. Syntax is
     similar to C, but differs in many substantial areas. It supports
     interactive execution of statements."""
 
     homepage = "https://www.gnu.org/software/bc"
-    url      = "https://ftpmirror.gnu.org/bc/bc-1.07.tar.gz"
+    gnu_path = "bc/bc-1.07.tar.gz"
 
     version('1.07', sha256='55cf1fc33a728d7c3d386cc7b0cb556eb5bacf8e0cb5a3fcca7f109fc61205ad')
 

--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -7,11 +7,11 @@ from spack import *
 import glob
 
 
-class Binutils(AutotoolsPackage):
+class Binutils(AutotoolsPackage, GNUMirrorPackage):
     """GNU binutils, which contain the linker, assembler, objdump and others"""
 
     homepage = "http://www.gnu.org/software/binutils/"
-    url      = "https://ftpmirror.gnu.org/binutils/binutils-2.28.tar.bz2"
+    gnu_path = "binutils/binutils-2.28.tar.bz2"
 
     version('2.32', sha256='de38b15c902eb2725eac6af21183a5f34ea4634cb0bcef19612b50e5ed31072d')
     version('2.31.1', sha256='ffcc382695bf947da6135e7436b8ed52d991cf270db897190f19d6f9838564d0')

--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -11,7 +11,7 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
     """GNU binutils, which contain the linker, assembler, objdump and others"""
 
     homepage = "http://www.gnu.org/software/binutils/"
-    gnu_path = "binutils/binutils-2.28.tar.bz2"
+    gnu_mirror_path = "binutils/binutils-2.28.tar.bz2"
 
     version('2.32', sha256='de38b15c902eb2725eac6af21183a5f34ea4634cb0bcef19612b50e5ed31072d')
     version('2.31.1', sha256='ffcc382695bf947da6135e7436b8ed52d991cf270db897190f19d6f9838564d0')

--- a/var/spack/repos/builtin/packages/bison/package.py
+++ b/var/spack/repos/builtin/packages/bison/package.py
@@ -8,13 +8,13 @@ from spack.operating_systems.mac_os import macos_version
 import sys
 
 
-class Bison(AutotoolsPackage):
+class Bison(AutotoolsPackage, GNUMirrorPackage):
     """Bison is a general-purpose parser generator that converts
     an annotated context-free grammar into a deterministic LR or
     generalized LR (GLR) parser employing LALR(1) parser tables."""
 
     homepage = "https://www.gnu.org/software/bison/"
-    url      = "https://ftpmirror.gnu.org/bison/bison-3.4.2.tar.gz"
+    gnu_path = "bison/bison-3.4.2.tar.gz"
 
     version('3.4.2', sha256='ff3922af377d514eca302a6662d470e857bd1a591e96a2050500df5a9d59facf')
     version('3.0.5', sha256='cd399d2bee33afa712bac4b1f4434e20379e9b4099bce47189e09a7675a2d566')

--- a/var/spack/repos/builtin/packages/bison/package.py
+++ b/var/spack/repos/builtin/packages/bison/package.py
@@ -14,7 +14,7 @@ class Bison(AutotoolsPackage, GNUMirrorPackage):
     generalized LR (GLR) parser employing LALR(1) parser tables."""
 
     homepage = "https://www.gnu.org/software/bison/"
-    gnu_path = "bison/bison-3.4.2.tar.gz"
+    gnu_mirror_path = "bison/bison-3.4.2.tar.gz"
 
     version('3.4.2', sha256='ff3922af377d514eca302a6662d470e857bd1a591e96a2050500df5a9d59facf')
     version('3.0.5', sha256='cd399d2bee33afa712bac4b1f4434e20379e9b4099bce47189e09a7675a2d566')

--- a/var/spack/repos/builtin/packages/coreutils/package.py
+++ b/var/spack/repos/builtin/packages/coreutils/package.py
@@ -13,7 +13,7 @@ class Coreutils(AutotoolsPackage, GNUMirrorPackage):
        operating system.
     """
     homepage = "http://www.gnu.org/software/coreutils/"
-    gnu_path = "coreutils/coreutils-8.26.tar.xz"
+    gnu_mirror_path = "coreutils/coreutils-8.26.tar.xz"
 
     version('8.29', sha256='92d0fa1c311cacefa89853bdb53c62f4110cdfda3820346b59cbd098f40f955e')
     version('8.26', sha256='155e94d748f8e2bc327c66e0cbebdb8d6ab265d2f37c3c928f7bf6c3beba9a8e')

--- a/var/spack/repos/builtin/packages/coreutils/package.py
+++ b/var/spack/repos/builtin/packages/coreutils/package.py
@@ -6,14 +6,14 @@
 from spack import *
 
 
-class Coreutils(AutotoolsPackage):
+class Coreutils(AutotoolsPackage, GNUMirrorPackage):
     """The GNU Core Utilities are the basic file, shell and text
        manipulation utilities of the GNU operating system.  These are
        the core utilities which are expected to exist on every
        operating system.
     """
     homepage = "http://www.gnu.org/software/coreutils/"
-    url      = "https://ftpmirror.gnu.org/coreutils/coreutils-8.26.tar.xz"
+    gnu_path = "coreutils/coreutils-8.26.tar.xz"
 
     version('8.29', sha256='92d0fa1c311cacefa89853bdb53c62f4110cdfda3820346b59cbd098f40f955e')
     version('8.26', sha256='155e94d748f8e2bc327c66e0cbebdb8d6ab265d2f37c3c928f7bf6c3beba9a8e')

--- a/var/spack/repos/builtin/packages/cvs/package.py
+++ b/var/spack/repos/builtin/packages/cvs/package.py
@@ -7,10 +7,10 @@
 from spack import *
 
 
-class Cvs(AutotoolsPackage):
+class Cvs(AutotoolsPackage, GNUMirrorPackage):
     """CVS a very traditional source control system"""
     homepage = "http://www.nongnu.org/cvs/"
-    url      = "https://ftpmirror.gnu.org/non-gnu/cvs/source/feature/1.12.13/cvs-1.12.13.tar.bz2"
+    gnu_path = "non-gnu/cvs/source/feature/1.12.13/cvs-1.12.13.tar.bz2"
 
     version('1.12.13', sha256='78853613b9a6873a30e1cc2417f738c330e75f887afdaf7b3d0800cb19ca515e')
 

--- a/var/spack/repos/builtin/packages/cvs/package.py
+++ b/var/spack/repos/builtin/packages/cvs/package.py
@@ -10,7 +10,7 @@ from spack import *
 class Cvs(AutotoolsPackage, GNUMirrorPackage):
     """CVS a very traditional source control system"""
     homepage = "http://www.nongnu.org/cvs/"
-    gnu_path = "non-gnu/cvs/source/feature/1.12.13/cvs-1.12.13.tar.bz2"
+    gnu_mirror_path = "non-gnu/cvs/source/feature/1.12.13/cvs-1.12.13.tar.bz2"
 
     version('1.12.13', sha256='78853613b9a6873a30e1cc2417f738c330e75f887afdaf7b3d0800cb19ca515e')
 

--- a/var/spack/repos/builtin/packages/datamash/package.py
+++ b/var/spack/repos/builtin/packages/datamash/package.py
@@ -6,13 +6,13 @@
 from spack import *
 
 
-class Datamash(AutotoolsPackage):
+class Datamash(AutotoolsPackage, GNUMirrorPackage):
     """GNU datamash is a command-line program which performs basic numeric,
     textual and statistical operations on input textual data files.
     """
 
     homepage = "https://www.gnu.org/software/datamash/"
-    url      = "https://ftpmirror.gnu.org/datamash/datamash-1.0.5.tar.gz"
+    gnu_path = "datamash/datamash-1.0.5.tar.gz"
 
     version('1.3',   sha256='eebb52171a4353aaad01921384098cf54eb96ebfaf99660e017f6d9fc96657a6')
     version('1.1.0', sha256='a9e5acc86af4dd64c7ac7f6554718b40271aa67f7ff6e9819bdd919a25904bb0')

--- a/var/spack/repos/builtin/packages/datamash/package.py
+++ b/var/spack/repos/builtin/packages/datamash/package.py
@@ -12,7 +12,7 @@ class Datamash(AutotoolsPackage, GNUMirrorPackage):
     """
 
     homepage = "https://www.gnu.org/software/datamash/"
-    gnu_path = "datamash/datamash-1.0.5.tar.gz"
+    gnu_mirror_path = "datamash/datamash-1.0.5.tar.gz"
 
     version('1.3',   sha256='eebb52171a4353aaad01921384098cf54eb96ebfaf99660e017f6d9fc96657a6')
     version('1.1.0', sha256='a9e5acc86af4dd64c7ac7f6554718b40271aa67f7ff6e9819bdd919a25904bb0')

--- a/var/spack/repos/builtin/packages/dejagnu/package.py
+++ b/var/spack/repos/builtin/packages/dejagnu/package.py
@@ -6,12 +6,12 @@
 from spack import *
 
 
-class Dejagnu(AutotoolsPackage):
+class Dejagnu(AutotoolsPackage, GNUMirrorPackage):
     """DejaGnu is a framework for testing other programs. Its purpose
     is to provide a single front end for all tests."""
 
     homepage = "https://www.gnu.org/software/dejagnu/"
-    url      = "https://ftpmirror.gnu.org/dejagnu/dejagnu-1.6.tar.gz"
+    gnu_path = "dejagnu/dejagnu-1.6.tar.gz"
 
     version('1.6',   sha256='00b64a618e2b6b581b16eb9131ee80f721baa2669fa0cdee93c500d1a652d763')
     version('1.4.4', sha256='d0fbedef20fb0843318d60551023631176b27ceb1e11de7468a971770d0e048d')

--- a/var/spack/repos/builtin/packages/dejagnu/package.py
+++ b/var/spack/repos/builtin/packages/dejagnu/package.py
@@ -11,7 +11,7 @@ class Dejagnu(AutotoolsPackage, GNUMirrorPackage):
     is to provide a single front end for all tests."""
 
     homepage = "https://www.gnu.org/software/dejagnu/"
-    gnu_path = "dejagnu/dejagnu-1.6.tar.gz"
+    gnu_mirror_path = "dejagnu/dejagnu-1.6.tar.gz"
 
     version('1.6',   sha256='00b64a618e2b6b581b16eb9131ee80f721baa2669fa0cdee93c500d1a652d763')
     version('1.4.4', sha256='d0fbedef20fb0843318d60551023631176b27ceb1e11de7468a971770d0e048d')

--- a/var/spack/repos/builtin/packages/diffutils/package.py
+++ b/var/spack/repos/builtin/packages/diffutils/package.py
@@ -6,12 +6,12 @@
 from spack import *
 
 
-class Diffutils(AutotoolsPackage):
+class Diffutils(AutotoolsPackage, GNUMirrorPackage):
     """GNU Diffutils is a package of several programs related to finding
     differences between files."""
 
     homepage = "https://www.gnu.org/software/diffutils/"
-    url      = "https://ftpmirror.gnu.org/diffutils/diffutils-3.7.tar.xz"
+    gnu_path = "diffutils/diffutils-3.7.tar.xz"
 
     version('3.7', sha256='b3a7a6221c3dc916085f0d205abf6b8e1ba443d4dd965118da364a1dc1cb3a26')
     version('3.6', sha256='d621e8bdd4b573918c8145f7ae61817d1be9deb4c8d2328a65cea8e11d783bd6')

--- a/var/spack/repos/builtin/packages/diffutils/package.py
+++ b/var/spack/repos/builtin/packages/diffutils/package.py
@@ -11,7 +11,7 @@ class Diffutils(AutotoolsPackage, GNUMirrorPackage):
     differences between files."""
 
     homepage = "https://www.gnu.org/software/diffutils/"
-    gnu_path = "diffutils/diffutils-3.7.tar.xz"
+    gnu_mirror_path = "diffutils/diffutils-3.7.tar.xz"
 
     version('3.7', sha256='b3a7a6221c3dc916085f0d205abf6b8e1ba443d4dd965118da364a1dc1cb3a26')
     version('3.6', sha256='d621e8bdd4b573918c8145f7ae61817d1be9deb4c8d2328a65cea8e11d783bd6')

--- a/var/spack/repos/builtin/packages/ed/package.py
+++ b/var/spack/repos/builtin/packages/ed/package.py
@@ -12,7 +12,7 @@ class Ed(AutotoolsPackage, GNUMirrorPackage):
        interactively and via shell scripts."""
 
     homepage = "https://www.gnu.org/software/ed"
-    gnu_path = "ed/ed-1.4.tar.gz"
+    gnu_mirror_path = "ed/ed-1.4.tar.gz"
 
     version('1.4', sha256='db36da85ee1a9d8bafb4b041bd4c8c11becba0c43ec446353b67045de1634fda')
 

--- a/var/spack/repos/builtin/packages/ed/package.py
+++ b/var/spack/repos/builtin/packages/ed/package.py
@@ -6,13 +6,13 @@
 from spack import *
 
 
-class Ed(AutotoolsPackage):
+class Ed(AutotoolsPackage, GNUMirrorPackage):
     """GNU ed is a line-oriented text editor. It is used to create,
        display, modify and otherwise manipulate text files, both
        interactively and via shell scripts."""
 
     homepage = "https://www.gnu.org/software/ed"
-    url      = "https://ftpmirror.gnu.org/ed/ed-1.4.tar.gz"
+    gnu_path = "ed/ed-1.4.tar.gz"
 
     version('1.4', sha256='db36da85ee1a9d8bafb4b041bd4c8c11becba0c43ec446353b67045de1634fda')
 

--- a/var/spack/repos/builtin/packages/emacs/package.py
+++ b/var/spack/repos/builtin/packages/emacs/package.py
@@ -12,7 +12,7 @@ class Emacs(AutotoolsPackage, GNUMirrorPackage):
     """The Emacs programmable text editor."""
 
     homepage = "https://www.gnu.org/software/emacs"
-    gnu_path = "emacs/emacs-24.5.tar.gz"
+    gnu_mirror_path = "emacs/emacs-24.5.tar.gz"
 
     version('26.3', sha256='09c747e048137c99ed35747b012910b704e0974dde4db6696fde7054ce387591')
     version('26.2', sha256='4f99e52a38a737556932cc57479e85c305a37a8038aaceb5156625caf102b4eb')

--- a/var/spack/repos/builtin/packages/emacs/package.py
+++ b/var/spack/repos/builtin/packages/emacs/package.py
@@ -8,11 +8,11 @@ from spack import *
 import sys
 
 
-class Emacs(AutotoolsPackage):
+class Emacs(AutotoolsPackage, GNUMirrorPackage):
     """The Emacs programmable text editor."""
 
     homepage = "https://www.gnu.org/software/emacs"
-    url      = "https://ftpmirror.gnu.org/emacs/emacs-24.5.tar.gz"
+    gnu_path = "emacs/emacs-24.5.tar.gz"
 
     version('26.3', sha256='09c747e048137c99ed35747b012910b704e0974dde4db6696fde7054ce387591')
     version('26.2', sha256='4f99e52a38a737556932cc57479e85c305a37a8038aaceb5156625caf102b4eb')

--- a/var/spack/repos/builtin/packages/findutils/package.py
+++ b/var/spack/repos/builtin/packages/findutils/package.py
@@ -11,7 +11,7 @@ class Findutils(AutotoolsPackage, GNUMirrorPackage):
        utilities of the GNU operating system."""
 
     homepage = "https://www.gnu.org/software/findutils/"
-    gnu_path = "findutils/findutils-4.6.0.tar.gz"
+    gnu_mirror_path = "findutils/findutils-4.6.0.tar.gz"
 
     version('4.6.0',  sha256='ded4c9f73731cd48fec3b6bdaccce896473b6d8e337e9612e16cf1431bb1169d')
     version('4.4.2',  sha256='434f32d171cbc0a5e72cfc5372c6fc4cb0e681f8dce566a0de5b6fccd702b62a')

--- a/var/spack/repos/builtin/packages/findutils/package.py
+++ b/var/spack/repos/builtin/packages/findutils/package.py
@@ -6,12 +6,12 @@
 from spack import *
 
 
-class Findutils(AutotoolsPackage):
+class Findutils(AutotoolsPackage, GNUMirrorPackage):
     """The GNU Find Utilities are the basic directory searching
        utilities of the GNU operating system."""
 
     homepage = "https://www.gnu.org/software/findutils/"
-    url      = "https://ftpmirror.gnu.org/findutils/findutils-4.6.0.tar.gz"
+    gnu_path = "findutils/findutils-4.6.0.tar.gz"
 
     version('4.6.0',  sha256='ded4c9f73731cd48fec3b6bdaccce896473b6d8e337e9612e16cf1431bb1169d')
     version('4.4.2',  sha256='434f32d171cbc0a5e72cfc5372c6fc4cb0e681f8dce566a0de5b6fccd702b62a')

--- a/var/spack/repos/builtin/packages/gawk/package.py
+++ b/var/spack/repos/builtin/packages/gawk/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class Gawk(AutotoolsPackage):
+class Gawk(AutotoolsPackage, GNUMirrorPackage):
     """If you are like many computer users, you would frequently like to make
        changes in various text files wherever certain patterns appear, or
        extract data from parts of certain lines while discarding the
@@ -21,7 +21,7 @@ class Gawk(AutotoolsPackage):
     """
 
     homepage = "https://www.gnu.org/software/gawk/"
-    url      = "https://ftpmirror.gnu.org/gawk/gawk-4.1.4.tar.xz"
+    gnu_path = "gawk/gawk-4.1.4.tar.xz"
 
     version('5.0.1', sha256='8e4e86f04ed789648b66f757329743a0d6dfb5294c3b91b756a474f1ce05a794')
     version('4.1.4', sha256='53e184e2d0f90def9207860531802456322be091c7b48f23fdc79cda65adc266')

--- a/var/spack/repos/builtin/packages/gawk/package.py
+++ b/var/spack/repos/builtin/packages/gawk/package.py
@@ -21,7 +21,7 @@ class Gawk(AutotoolsPackage, GNUMirrorPackage):
     """
 
     homepage = "https://www.gnu.org/software/gawk/"
-    gnu_path = "gawk/gawk-4.1.4.tar.xz"
+    gnu_mirror_path = "gawk/gawk-4.1.4.tar.xz"
 
     version('5.0.1', sha256='8e4e86f04ed789648b66f757329743a0d6dfb5294c3b91b756a474f1ce05a794')
     version('4.1.4', sha256='53e184e2d0f90def9207860531802456322be091c7b48f23fdc79cda65adc266')

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -18,7 +18,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
     Fortran, Ada, and Go, as well as libraries for these languages."""
 
     homepage = 'https://gcc.gnu.org'
-    gnu_path = 'gcc/gcc-9.2.0/gcc-9.2.0.tar.xz'
+    gnu_mirror_path = 'gcc/gcc-9.2.0/gcc-9.2.0.tar.xz'
     svn      = 'svn://gcc.gnu.org/svn/gcc/'
     list_url = 'http://ftp.gnu.org/gnu/gcc/'
     list_depth = 1
@@ -229,11 +229,12 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
 
     def url_for_version(self, version):
         # This function will be called when trying to fetch from url, before
-        # mirrors are tried. It takes care of modifying the suffix of gnu_path
-        # so that Spack will also look for the correct file in the mirrors
+        # mirrors are tried. It takes care of modifying the suffix of gnu
+        # mirror path so that Spack will also look for the correct file in
+        # the mirrors
         if (version < Version('6.4.0')and version != Version('5.5.0')) \
                 or version == Version('7.1.0'):
-            self.gnu_path = self.gnu_path.replace('xz', 'bz2')
+            self.gnu_mirror_path = self.gnu_mirror_path.replace('xz', 'bz2')
         return super(Gcc, self).url_for_version(version)
 
     def patch(self):

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -13,12 +13,12 @@ import os
 import sys
 
 
-class Gcc(AutotoolsPackage):
+class Gcc(AutotoolsPackage, GNUMirrorPackage):
     """The GNU Compiler Collection includes front ends for C, C++, Objective-C,
     Fortran, Ada, and Go, as well as libraries for these languages."""
 
     homepage = 'https://gcc.gnu.org'
-    url      = 'https://ftpmirror.gnu.org/gcc/gcc-7.1.0/gcc-7.1.0.tar.bz2'
+    gnu_path = 'gcc/gcc-9.2.0/gcc-9.2.0.tar.xz'
     svn      = 'svn://gcc.gnu.org/svn/gcc/'
     list_url = 'http://ftp.gnu.org/gnu/gcc/'
     list_depth = 1
@@ -228,16 +228,13 @@ class Gcc(AutotoolsPackage):
     build_directory = 'spack-build'
 
     def url_for_version(self, version):
-        url = 'https://ftpmirror.gnu.org/gcc/gcc-{0}/gcc-{0}.tar.{1}'
-        suffix = 'xz'
-
-        if version < Version('6.4.0') or version == Version('7.1.0'):
-            suffix = 'bz2'
-
-        if version == Version('5.5.0'):
-            suffix = 'xz'
-
-        return url.format(version, suffix)
+        # This function will be called when trying to fetch from url, before
+        # mirrors are tried. It takes care of modifying the suffix of gnu_path
+        # so that Spack will also look for the correct file in the mirrors
+        if (version < Version('6.4.0')and version != Version('5.5.0')) \
+                or version == Version('7.1.0'):
+            self.gnu_path = self.gnu_path.replace('xz', 'bz2')
+        return super(Gcc, self).url_for_version(version)
 
     def patch(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/gdb/package.py
+++ b/var/spack/repos/builtin/packages/gdb/package.py
@@ -13,7 +13,7 @@ class Gdb(AutotoolsPackage, GNUMirrorPackage):
     """
 
     homepage = "https://www.gnu.org/software/gdb"
-    gnu_path = "gdb/gdb-7.10.tar.gz"
+    gnu_mirror_path = "gdb/gdb-7.10.tar.gz"
 
     version('8.3', sha256='b2266ec592440d0eec18ee1790f8558b3b8a2845b76cc83a872e39b501ce8a28')
     version('8.2.1', sha256='0107985f1edb8dddef6cdd68a4f4e419f5fec0f488cc204f0b7d482c0c6c9282')

--- a/var/spack/repos/builtin/packages/gdb/package.py
+++ b/var/spack/repos/builtin/packages/gdb/package.py
@@ -6,14 +6,14 @@
 from spack import *
 
 
-class Gdb(AutotoolsPackage):
+class Gdb(AutotoolsPackage, GNUMirrorPackage):
     """GDB, the GNU Project debugger, allows you to see what is going on
     'inside' another program while it executes -- or what another
     program was doing at the moment it crashed.
     """
 
     homepage = "https://www.gnu.org/software/gdb"
-    url      = "https://ftpmirror.gnu.org/gdb/gdb-7.10.tar.gz"
+    gnu_path = "gdb/gdb-7.10.tar.gz"
 
     version('8.3', sha256='b2266ec592440d0eec18ee1790f8558b3b8a2845b76cc83a872e39b501ce8a28')
     version('8.2.1', sha256='0107985f1edb8dddef6cdd68a4f4e419f5fec0f488cc204f0b7d482c0c6c9282')

--- a/var/spack/repos/builtin/packages/gdbm/package.py
+++ b/var/spack/repos/builtin/packages/gdbm/package.py
@@ -7,15 +7,14 @@
 from spack import *
 
 
-class Gdbm(AutotoolsPackage):
+class Gdbm(AutotoolsPackage, GNUMirrorPackage):
     """GNU dbm (or GDBM, for short) is a library of database functions
     that use extensible hashing and work similar to the standard UNIX dbm.
     These routines are provided to a programmer needing to create and
     manipulate a hashed database."""
 
     homepage = "http://www.gnu.org.ua/software/gdbm/gdbm.html"
-    # URL must remain http:// so Spack can bootstrap curl
-    url      = "http://ftpmirror.gnu.org/gdbm/gdbm-1.13.tar.gz"
+    gnu_path = "gdbm/gdbm-1.13.tar.gz"
 
     version('1.18.1', sha256='86e613527e5dba544e73208f42b78b7c022d4fa5a6d5498bf18c8d6f745b91dc')
     version('1.14.1', sha256='cdceff00ffe014495bed3aed71c7910aa88bf29379f795abc0f46d4ee5f8bc5f')

--- a/var/spack/repos/builtin/packages/gdbm/package.py
+++ b/var/spack/repos/builtin/packages/gdbm/package.py
@@ -14,7 +14,7 @@ class Gdbm(AutotoolsPackage, GNUMirrorPackage):
     manipulate a hashed database."""
 
     homepage = "http://www.gnu.org.ua/software/gdbm/gdbm.html"
-    gnu_path = "gdbm/gdbm-1.13.tar.gz"
+    gnu_mirror_path = "gdbm/gdbm-1.13.tar.gz"
 
     version('1.18.1', sha256='86e613527e5dba544e73208f42b78b7c022d4fa5a6d5498bf18c8d6f745b91dc')
     version('1.14.1', sha256='cdceff00ffe014495bed3aed71c7910aa88bf29379f795abc0f46d4ee5f8bc5f')

--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -10,7 +10,7 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
     """GNU internationalization (i18n) and localization (l10n) library."""
 
     homepage = "https://www.gnu.org/software/gettext/"
-    gnu_path = "gettext/gettext-0.20.1.tar.xz"
+    gnu_mirror_path = "gettext/gettext-0.20.1.tar.xz"
 
     version('0.20.1', sha256='53f02fbbec9e798b0faaf7c73272f83608e835c6288dd58be6c9bb54624a3800')
     version('0.19.8.1', sha256='105556dbc5c3fbbc2aa0edb46d22d055748b6f5c7cd7a8d99f8e7eb84e938be4')

--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -6,11 +6,11 @@
 from spack import *
 
 
-class Gettext(AutotoolsPackage):
+class Gettext(AutotoolsPackage, GNUMirrorPackage):
     """GNU internationalization (i18n) and localization (l10n) library."""
 
     homepage = "https://www.gnu.org/software/gettext/"
-    url      = "https://ftpmirror.gnu.org/gettext/gettext-0.20.1.tar.xz"
+    gnu_path = "gettext/gettext-0.20.1.tar.xz"
 
     version('0.20.1', sha256='53f02fbbec9e798b0faaf7c73272f83608e835c6288dd58be6c9bb54624a3800')
     version('0.19.8.1', sha256='105556dbc5c3fbbc2aa0edb46d22d055748b6f5c7cd7a8d99f8e7eb84e938be4')

--- a/var/spack/repos/builtin/packages/glpk/package.py
+++ b/var/spack/repos/builtin/packages/glpk/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class Glpk(AutotoolsPackage):
+class Glpk(AutotoolsPackage, GNUMirrorPackage):
     """The GLPK (GNU Linear Programming Kit) package is intended for solving
     large-scale linear programming (LP), mixed integer programming
     (MIP), and other related problems. It is a set of routines written
@@ -14,7 +14,7 @@ class Glpk(AutotoolsPackage):
     """
 
     homepage = "https://www.gnu.org/software/glpk"
-    url      = "https://ftpmirror.gnu.org/glpk/glpk-4.65.tar.gz"
+    gnu_path = "glpk/glpk-4.65.tar.gz"
 
     version('4.65', sha256='4281e29b628864dfe48d393a7bedd781e5b475387c20d8b0158f329994721a10')
     version('4.61', sha256='9866de41777782d4ce21da11b88573b66bb7858574f89c28be6967ac22dfaba9')

--- a/var/spack/repos/builtin/packages/glpk/package.py
+++ b/var/spack/repos/builtin/packages/glpk/package.py
@@ -14,7 +14,7 @@ class Glpk(AutotoolsPackage, GNUMirrorPackage):
     """
 
     homepage = "https://www.gnu.org/software/glpk"
-    gnu_path = "glpk/glpk-4.65.tar.gz"
+    gnu_mirror_path = "glpk/glpk-4.65.tar.gz"
 
     version('4.65', sha256='4281e29b628864dfe48d393a7bedd781e5b475387c20d8b0158f329994721a10')
     version('4.61', sha256='9866de41777782d4ce21da11b88573b66bb7858574f89c28be6967ac22dfaba9')

--- a/var/spack/repos/builtin/packages/gmake/package.py
+++ b/var/spack/repos/builtin/packages/gmake/package.py
@@ -11,7 +11,7 @@ class Gmake(AutotoolsPackage, GNUMirrorPackage):
     other non-source files of a program from the program's source files."""
 
     homepage = "https://www.gnu.org/software/make/"
-    gnu_path = "make/make-4.2.1.tar.gz"
+    gnu_mirror_path = "make/make-4.2.1.tar.gz"
 
     version('4.2.1', sha256='e40b8f018c1da64edd1cc9a6fce5fa63b2e707e404e20cad91fbae337c98a5b7')
     version('4.0',   sha256='fc42139fb0d4b4291929788ebaf77e2a4de7eaca95e31f3634ef7d4932051f69')

--- a/var/spack/repos/builtin/packages/gmake/package.py
+++ b/var/spack/repos/builtin/packages/gmake/package.py
@@ -6,12 +6,12 @@
 from spack import *
 
 
-class Gmake(AutotoolsPackage):
+class Gmake(AutotoolsPackage, GNUMirrorPackage):
     """GNU Make is a tool which controls the generation of executables and
     other non-source files of a program from the program's source files."""
 
     homepage = "https://www.gnu.org/software/make/"
-    url      = "https://ftpmirror.gnu.org/make/make-4.2.1.tar.gz"
+    gnu_path = "make/make-4.2.1.tar.gz"
 
     version('4.2.1', sha256='e40b8f018c1da64edd1cc9a6fce5fa63b2e707e404e20cad91fbae337c98a5b7')
     version('4.0',   sha256='fc42139fb0d4b4291929788ebaf77e2a4de7eaca95e31f3634ef7d4932051f69')

--- a/var/spack/repos/builtin/packages/gmp/package.py
+++ b/var/spack/repos/builtin/packages/gmp/package.py
@@ -11,7 +11,7 @@ class Gmp(AutotoolsPackage, GNUMirrorPackage):
     on signed integers, rational numbers, and floating-point numbers."""
 
     homepage = "https://gmplib.org"
-    gnu_path = "gmp/gmp-6.1.2.tar.bz2"
+    gnu_mirror_path = "gmp/gmp-6.1.2.tar.bz2"
 
     version('6.1.2',  sha256='5275bb04f4863a13516b2f39392ac5e272f5e1bb8057b18aec1c9b79d73d8fb2')
     version('6.1.1',  sha256='a8109865f2893f1373b0a8ed5ff7429de8db696fc451b1036bd7bdf95bbeffd6')

--- a/var/spack/repos/builtin/packages/gmp/package.py
+++ b/var/spack/repos/builtin/packages/gmp/package.py
@@ -6,12 +6,12 @@
 from spack import *
 
 
-class Gmp(AutotoolsPackage):
+class Gmp(AutotoolsPackage, GNUMirrorPackage):
     """GMP is a free library for arbitrary precision arithmetic, operating
     on signed integers, rational numbers, and floating-point numbers."""
 
     homepage = "https://gmplib.org"
-    url      = "https://ftpmirror.gnu.org/gmp/gmp-6.1.2.tar.bz2"
+    gnu_path = "gmp/gmp-6.1.2.tar.bz2"
 
     version('6.1.2',  sha256='5275bb04f4863a13516b2f39392ac5e272f5e1bb8057b18aec1c9b79d73d8fb2')
     version('6.1.1',  sha256='a8109865f2893f1373b0a8ed5ff7429de8db696fc451b1036bd7bdf95bbeffd6')

--- a/var/spack/repos/builtin/packages/gperf/package.py
+++ b/var/spack/repos/builtin/packages/gperf/package.py
@@ -15,7 +15,7 @@ class Gperf(AutotoolsPackage, GNUMirrorPackage):
     single string comparison only."""
 
     homepage = "https://www.gnu.org/software/gperf/"
-    gnu_path = "gperf/gperf-3.0.4.tar.gz"
+    gnu_mirror_path = "gperf/gperf-3.0.4.tar.gz"
 
     version('3.0.4', sha256='767112a204407e62dbc3106647cf839ed544f3cf5d0f0523aaa2508623aad63e')
 

--- a/var/spack/repos/builtin/packages/gperf/package.py
+++ b/var/spack/repos/builtin/packages/gperf/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class Gperf(AutotoolsPackage):
+class Gperf(AutotoolsPackage, GNUMirrorPackage):
     """GNU gperf is a perfect hash function generator. For a given
     list of strings, it produces a hash function and hash table, in
     form of C or C++ code, for looking up a value depending on the
@@ -15,7 +15,7 @@ class Gperf(AutotoolsPackage):
     single string comparison only."""
 
     homepage = "https://www.gnu.org/software/gperf/"
-    url      = "https://ftpmirror.gnu.org/gperf/gperf-3.0.4.tar.gz"
+    gnu_path = "gperf/gperf-3.0.4.tar.gz"
 
     version('3.0.4', sha256='767112a204407e62dbc3106647cf839ed544f3cf5d0f0523aaa2508623aad63e')
 

--- a/var/spack/repos/builtin/packages/groff/package.py
+++ b/var/spack/repos/builtin/packages/groff/package.py
@@ -6,14 +6,14 @@
 from spack import *
 
 
-class Groff(AutotoolsPackage):
+class Groff(AutotoolsPackage, GNUMirrorPackage):
     """Groff (GNU troff) is a typesetting system that reads
     plain text mixed with formatting commands and produces
     formatted output. Output may be PostScript or PDF, html, or
     ASCII/UTF8 for display at the terminal."""
 
     homepage = "https://www.gnu.org/software/groff/"
-    url      = "https://ftpmirror.gnu.org/groff/groff-1.22.3.tar.gz"
+    gnu_path = "groff/groff-1.22.3.tar.gz"
 
     # TODO: add html variant, spack doesn't have netpbm and its too
     # complicated for me to find out at this point in time.

--- a/var/spack/repos/builtin/packages/groff/package.py
+++ b/var/spack/repos/builtin/packages/groff/package.py
@@ -13,7 +13,7 @@ class Groff(AutotoolsPackage, GNUMirrorPackage):
     ASCII/UTF8 for display at the terminal."""
 
     homepage = "https://www.gnu.org/software/groff/"
-    gnu_path = "groff/groff-1.22.3.tar.gz"
+    gnu_mirror_path = "groff/groff-1.22.3.tar.gz"
 
     # TODO: add html variant, spack doesn't have netpbm and its too
     # complicated for me to find out at this point in time.

--- a/var/spack/repos/builtin/packages/gsl/package.py
+++ b/var/spack/repos/builtin/packages/gsl/package.py
@@ -15,7 +15,7 @@ class Gsl(AutotoolsPackage, GNUMirrorPackage):
     over 1000 functions in total with an extensive test suite."""
 
     homepage = "http://www.gnu.org/software/gsl"
-    gnu_path = "gsl/gsl-2.3.tar.gz"
+    gnu_mirror_path = "gsl/gsl-2.3.tar.gz"
 
     version('2.5', sha256='0460ad7c2542caaddc6729762952d345374784100223995eb14d614861f2258d')
     version('2.4',   sha256='4d46d07b946e7b31c19bbf33dda6204d7bedc2f5462a1bae1d4013426cd1ce9b')

--- a/var/spack/repos/builtin/packages/gsl/package.py
+++ b/var/spack/repos/builtin/packages/gsl/package.py
@@ -7,7 +7,7 @@
 from spack import *
 
 
-class Gsl(AutotoolsPackage):
+class Gsl(AutotoolsPackage, GNUMirrorPackage):
     """The GNU Scientific Library (GSL) is a numerical library for C and C++
     programmers. It is free software under the GNU General Public License. The
     library provides a wide range of mathematical routines such as random
@@ -15,7 +15,7 @@ class Gsl(AutotoolsPackage):
     over 1000 functions in total with an extensive test suite."""
 
     homepage = "http://www.gnu.org/software/gsl"
-    url      = "https://ftpmirror.gnu.org/gsl/gsl-2.3.tar.gz"
+    gnu_path = "gsl/gsl-2.3.tar.gz"
 
     version('2.5', sha256='0460ad7c2542caaddc6729762952d345374784100223995eb14d614861f2258d')
     version('2.4',   sha256='4d46d07b946e7b31c19bbf33dda6204d7bedc2f5462a1bae1d4013426cd1ce9b')

--- a/var/spack/repos/builtin/packages/guile/package.py
+++ b/var/spack/repos/builtin/packages/guile/package.py
@@ -6,12 +6,12 @@
 from spack import *
 
 
-class Guile(AutotoolsPackage):
+class Guile(AutotoolsPackage, GNUMirrorPackage):
     """Guile is the GNU Ubiquitous Intelligent Language for Extensions,
     the official extension language for the GNU operating system."""
 
     homepage = "https://www.gnu.org/software/guile/"
-    url      = "https://ftpmirror.gnu.org/guile/guile-2.2.0.tar.gz"
+    gnu_path = "guile/guile-2.2.0.tar.gz"
 
     version('2.2.6', sha256='08c0e7487777740b61cdd97949b69e8a5e2997d8c2fe6c7e175819eb18444506')
     version('2.2.5', sha256='c3c7a2f6ae0d8321a240c7ebc532a1d47af8c63214157a73789e2b2305b4c927')

--- a/var/spack/repos/builtin/packages/guile/package.py
+++ b/var/spack/repos/builtin/packages/guile/package.py
@@ -11,7 +11,7 @@ class Guile(AutotoolsPackage, GNUMirrorPackage):
     the official extension language for the GNU operating system."""
 
     homepage = "https://www.gnu.org/software/guile/"
-    gnu_path = "guile/guile-2.2.0.tar.gz"
+    gnu_mirror_path = "guile/guile-2.2.0.tar.gz"
 
     version('2.2.6', sha256='08c0e7487777740b61cdd97949b69e8a5e2997d8c2fe6c7e175819eb18444506')
     version('2.2.5', sha256='c3c7a2f6ae0d8321a240c7ebc532a1d47af8c63214157a73789e2b2305b4c927')

--- a/var/spack/repos/builtin/packages/help2man/package.py
+++ b/var/spack/repos/builtin/packages/help2man/package.py
@@ -6,12 +6,12 @@
 from spack import *
 
 
-class Help2man(AutotoolsPackage):
+class Help2man(AutotoolsPackage, GNUMirrorPackage):
     """help2man produces simple manual pages from the '--help' and '--version'
     output of other commands."""
 
     homepage = "https://www.gnu.org/software/help2man/"
-    url      = "https://ftpmirror.gnu.org/help2man/help2man-1.47.11.tar.xz"
+    gnu_path = "help2man/help2man-1.47.11.tar.xz"
 
     version('1.47.11', sha256='5985b257f86304c8791842c0c807a37541d0d6807ee973000cf8a3fe6ad47b88')
     version('1.47.8', sha256='528f6a81ad34cbc76aa7dce5a82f8b3d2078ef065271ab81fda033842018a8dc')

--- a/var/spack/repos/builtin/packages/help2man/package.py
+++ b/var/spack/repos/builtin/packages/help2man/package.py
@@ -11,7 +11,7 @@ class Help2man(AutotoolsPackage, GNUMirrorPackage):
     output of other commands."""
 
     homepage = "https://www.gnu.org/software/help2man/"
-    gnu_path = "help2man/help2man-1.47.11.tar.xz"
+    gnu_mirror_path = "help2man/help2man-1.47.11.tar.xz"
 
     version('1.47.11', sha256='5985b257f86304c8791842c0c807a37541d0d6807ee973000cf8a3fe6ad47b88')
     version('1.47.8', sha256='528f6a81ad34cbc76aa7dce5a82f8b3d2078ef065271ab81fda033842018a8dc')

--- a/var/spack/repos/builtin/packages/libiberty/package.py
+++ b/var/spack/repos/builtin/packages/libiberty/package.py
@@ -11,12 +11,12 @@ from spack import *
 # is useful for other packages that want the demangling functions
 # without the rest of binutils.
 
-class Libiberty(AutotoolsPackage):
+class Libiberty(AutotoolsPackage, GNUMirrorPackage):
     """The libiberty.a library from GNU binutils.  Libiberty provides
     demangling and support functions for the GNU toolchain."""
 
     homepage = "https://www.gnu.org/software/binutils/"
-    url      = "https://ftpmirror.gnu.org/binutils/binutils-2.31.1.tar.xz"
+    gnu_path = "binutils/binutils-2.31.1.tar.xz"
 
     version('2.31.1', sha256='5d20086ecf5752cc7d9134246e9588fa201740d540f7eb84d795b1f7a93bca86')
     version('2.30',   sha256='6e46b8aeae2f727a36f0bd9505e405768a72218f1796f0d09757d45209871ae6')

--- a/var/spack/repos/builtin/packages/libiberty/package.py
+++ b/var/spack/repos/builtin/packages/libiberty/package.py
@@ -16,7 +16,7 @@ class Libiberty(AutotoolsPackage, GNUMirrorPackage):
     demangling and support functions for the GNU toolchain."""
 
     homepage = "https://www.gnu.org/software/binutils/"
-    gnu_path = "binutils/binutils-2.31.1.tar.xz"
+    gnu_mirror_path = "binutils/binutils-2.31.1.tar.xz"
 
     version('2.31.1', sha256='5d20086ecf5752cc7d9134246e9588fa201740d540f7eb84d795b1f7a93bca86')
     version('2.30',   sha256='6e46b8aeae2f727a36f0bd9505e405768a72218f1796f0d09757d45209871ae6')

--- a/var/spack/repos/builtin/packages/libiconv/package.py
+++ b/var/spack/repos/builtin/packages/libiconv/package.py
@@ -11,7 +11,7 @@ class Libiconv(AutotoolsPackage, GNUMirrorPackage):
     and the iconv program for character set conversion."""
 
     homepage = "https://www.gnu.org/software/libiconv/"
-    gnu_path = "libiconv/libiconv-1.16.tar.gz"
+    gnu_mirror_path = "libiconv/libiconv-1.16.tar.gz"
 
     version('1.16', sha256='e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04')
     version('1.15', sha256='ccf536620a45458d26ba83887a983b96827001e92a13847b45e4925cc8913178')

--- a/var/spack/repos/builtin/packages/libiconv/package.py
+++ b/var/spack/repos/builtin/packages/libiconv/package.py
@@ -6,12 +6,12 @@
 from spack import *
 
 
-class Libiconv(AutotoolsPackage):
+class Libiconv(AutotoolsPackage, GNUMirrorPackage):
     """GNU libiconv provides an implementation of the iconv() function
     and the iconv program for character set conversion."""
 
     homepage = "https://www.gnu.org/software/libiconv/"
-    url      = "https://ftpmirror.gnu.org/libiconv/libiconv-1.16.tar.gz"
+    gnu_path = "libiconv/libiconv-1.16.tar.gz"
 
     version('1.16', sha256='e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04')
     version('1.15', sha256='ccf536620a45458d26ba83887a983b96827001e92a13847b45e4925cc8913178')

--- a/var/spack/repos/builtin/packages/libmatheval/package.py
+++ b/var/spack/repos/builtin/packages/libmatheval/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class Libmatheval(AutotoolsPackage):
+class Libmatheval(AutotoolsPackage, GNUMirrorPackage):
     """GNU libmatheval is a library (callable from C and Fortran) to parse
     and evaluate symbolic expressions input as text. It supports expressions
     in any number of variables of arbitrary names, decimal and symbolic
@@ -15,7 +15,7 @@ class Libmatheval(AutotoolsPackage):
     compute symbolic derivatives and output expressions to strings."""
 
     homepage = "https://www.gnu.org/software/libmatheval/"
-    url      = "https://ftpmirror.gnu.org/libmatheval/libmatheval-1.1.11.tar.gz"
+    gnu_path = "libmatheval/libmatheval-1.1.11.tar.gz"
 
     version('1.1.11', sha256='474852d6715ddc3b6969e28de5e1a5fbaff9e8ece6aebb9dc1cc63e9e88e89ab')
 

--- a/var/spack/repos/builtin/packages/libmatheval/package.py
+++ b/var/spack/repos/builtin/packages/libmatheval/package.py
@@ -15,7 +15,7 @@ class Libmatheval(AutotoolsPackage, GNUMirrorPackage):
     compute symbolic derivatives and output expressions to strings."""
 
     homepage = "https://www.gnu.org/software/libmatheval/"
-    gnu_path = "libmatheval/libmatheval-1.1.11.tar.gz"
+    gnu_mirror_path = "libmatheval/libmatheval-1.1.11.tar.gz"
 
     version('1.1.11', sha256='474852d6715ddc3b6969e28de5e1a5fbaff9e8ece6aebb9dc1cc63e9e88e89ab')
 

--- a/var/spack/repos/builtin/packages/libsigsegv/package.py
+++ b/var/spack/repos/builtin/packages/libsigsegv/package.py
@@ -6,11 +6,11 @@
 from spack import *
 
 
-class Libsigsegv(AutotoolsPackage):
+class Libsigsegv(AutotoolsPackage, GNUMirrorPackage):
     """GNU libsigsegv is a library for handling page faults in user mode."""
 
     homepage = "https://www.gnu.org/software/libsigsegv/"
-    url      = "https://ftpmirror.gnu.org/libsigsegv/libsigsegv-2.12.tar.gz"
+    gnu_path = "libsigsegv/libsigsegv-2.12.tar.gz"
 
     version('2.12', sha256='3ae1af359eebaa4ffc5896a1aee3568c052c99879316a1ab57f8fe1789c390b6')
     version('2.11', sha256='dd7c2eb2ef6c47189406d562c1dc0f96f2fc808036834d596075d58377e37a18')

--- a/var/spack/repos/builtin/packages/libsigsegv/package.py
+++ b/var/spack/repos/builtin/packages/libsigsegv/package.py
@@ -10,7 +10,7 @@ class Libsigsegv(AutotoolsPackage, GNUMirrorPackage):
     """GNU libsigsegv is a library for handling page faults in user mode."""
 
     homepage = "https://www.gnu.org/software/libsigsegv/"
-    gnu_path = "libsigsegv/libsigsegv-2.12.tar.gz"
+    gnu_mirror_path = "libsigsegv/libsigsegv-2.12.tar.gz"
 
     version('2.12', sha256='3ae1af359eebaa4ffc5896a1aee3568c052c99879316a1ab57f8fe1789c390b6')
     version('2.11', sha256='dd7c2eb2ef6c47189406d562c1dc0f96f2fc808036834d596075d58377e37a18')

--- a/var/spack/repos/builtin/packages/libtool/package.py
+++ b/var/spack/repos/builtin/packages/libtool/package.py
@@ -6,11 +6,11 @@
 from spack import *
 
 
-class Libtool(AutotoolsPackage):
+class Libtool(AutotoolsPackage, GNUMirrorPackage):
     """libtool -- library building part of autotools."""
 
     homepage = 'https://www.gnu.org/software/libtool/'
-    url      = 'https://ftpmirror.gnu.org/libtool/libtool-2.4.2.tar.gz'
+    gnu_path = "libtool/libtool-2.4.2.tar.gz"
 
     version('develop', git='https://git.savannah.gnu.org/git/libtool.git',
             branch='master', submodules=True)

--- a/var/spack/repos/builtin/packages/libtool/package.py
+++ b/var/spack/repos/builtin/packages/libtool/package.py
@@ -10,7 +10,7 @@ class Libtool(AutotoolsPackage, GNUMirrorPackage):
     """libtool -- library building part of autotools."""
 
     homepage = 'https://www.gnu.org/software/libtool/'
-    gnu_path = "libtool/libtool-2.4.2.tar.gz"
+    gnu_mirror_path = "libtool/libtool-2.4.2.tar.gz"
 
     version('develop', git='https://git.savannah.gnu.org/git/libtool.git',
             branch='master', submodules=True)

--- a/var/spack/repos/builtin/packages/libunistring/package.py
+++ b/var/spack/repos/builtin/packages/libunistring/package.py
@@ -6,12 +6,12 @@
 from spack import *
 
 
-class Libunistring(AutotoolsPackage):
+class Libunistring(AutotoolsPackage, GNUMirrorPackage):
     """This library provides functions for manipulating Unicode strings
     and for manipulating C strings according to the Unicode standard."""
 
     homepage = "https://www.gnu.org/software/libunistring/"
-    url      = "https://ftpmirror.gnu.org/libunistring/libunistring-0.9.10.tar.xz"
+    gnu_path = "libunistring/libunistring-0.9.10.tar.xz"
 
     version('0.9.10', sha256='eb8fb2c3e4b6e2d336608377050892b54c3c983b646c561836550863003c05d7')
     version('0.9.9',  sha256='a4d993ecfce16cf503ff7579f5da64619cee66226fb3b998dafb706190d9a833')

--- a/var/spack/repos/builtin/packages/libunistring/package.py
+++ b/var/spack/repos/builtin/packages/libunistring/package.py
@@ -11,7 +11,7 @@ class Libunistring(AutotoolsPackage, GNUMirrorPackage):
     and for manipulating C strings according to the Unicode standard."""
 
     homepage = "https://www.gnu.org/software/libunistring/"
-    gnu_path = "libunistring/libunistring-0.9.10.tar.xz"
+    gnu_mirror_path = "libunistring/libunistring-0.9.10.tar.xz"
 
     version('0.9.10', sha256='eb8fb2c3e4b6e2d336608377050892b54c3c983b646c561836550863003c05d7')
     version('0.9.9',  sha256='a4d993ecfce16cf503ff7579f5da64619cee66226fb3b998dafb706190d9a833')

--- a/var/spack/repos/builtin/packages/m4/package.py
+++ b/var/spack/repos/builtin/packages/m4/package.py
@@ -6,11 +6,11 @@
 from spack import *
 
 
-class M4(AutotoolsPackage):
+class M4(AutotoolsPackage, GNUMirrorPackage):
     """GNU M4 is an implementation of the traditional Unix macro processor."""
 
     homepage = "https://www.gnu.org/software/m4/m4.html"
-    url      = "https://ftpmirror.gnu.org/m4/m4-1.4.18.tar.gz"
+    gnu_path = "m4/m4-1.4.18.tar.gz"
 
     version('1.4.18', sha256='ab2633921a5cd38e48797bf5521ad259bdc4b979078034a3b790d7fec5493fab')
     version('1.4.17', sha256='3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e')

--- a/var/spack/repos/builtin/packages/m4/package.py
+++ b/var/spack/repos/builtin/packages/m4/package.py
@@ -10,7 +10,7 @@ class M4(AutotoolsPackage, GNUMirrorPackage):
     """GNU M4 is an implementation of the traditional Unix macro processor."""
 
     homepage = "https://www.gnu.org/software/m4/m4.html"
-    gnu_path = "m4/m4-1.4.18.tar.gz"
+    gnu_mirror_path = "m4/m4-1.4.18.tar.gz"
 
     version('1.4.18', sha256='ab2633921a5cd38e48797bf5521ad259bdc4b979078034a3b790d7fec5493fab')
     version('1.4.17', sha256='3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e')

--- a/var/spack/repos/builtin/packages/mpc/package.py
+++ b/var/spack/repos/builtin/packages/mpc/package.py
@@ -12,7 +12,7 @@ class Mpc(AutotoolsPackage, GNUMirrorPackage):
        result."""
 
     homepage = "http://www.multiprecision.org"
-    gnu_path = "mpc/mpc-1.1.0.tar.gz"
+    gnu_mirror_path = "mpc/mpc-1.1.0.tar.gz"
     list_url = "http://www.multiprecision.org/mpc/download.html"
 
     version('1.1.0', sha256='6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e')

--- a/var/spack/repos/builtin/packages/mpc/package.py
+++ b/var/spack/repos/builtin/packages/mpc/package.py
@@ -6,13 +6,13 @@
 from spack import *
 
 
-class Mpc(AutotoolsPackage):
+class Mpc(AutotoolsPackage, GNUMirrorPackage):
     """Gnu Mpc is a C library for the arithmetic of complex numbers
        with arbitrarily high precision and correct rounding of the
        result."""
 
     homepage = "http://www.multiprecision.org"
-    url      = "https://ftpmirror.gnu.org/mpc/mpc-1.1.0.tar.gz"
+    gnu_path = "mpc/mpc-1.1.0.tar.gz"
     list_url = "http://www.multiprecision.org/mpc/download.html"
 
     version('1.1.0', sha256='6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e')
@@ -24,14 +24,6 @@ class Mpc(AutotoolsPackage):
     depends_on('gmp@5.0.0:', when='@1.1.0:')
     depends_on('mpfr@2.4.2:')
     depends_on('mpfr@3.0.0:', when='@1.1.0:')
-
-    def url_for_version(self, version):
-        if version < Version("1.0.1"):
-            url = "http://www.multiprecision.org/mpc/download/mpc-{0}.tar.gz"
-        else:
-            url = "https://ftpmirror.gnu.org/mpc/mpc-{0}.tar.gz"
-
-        return url.format(version)
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/mpfr/package.py
+++ b/var/spack/repos/builtin/packages/mpfr/package.py
@@ -6,12 +6,12 @@
 from spack import *
 
 
-class Mpfr(AutotoolsPackage):
+class Mpfr(AutotoolsPackage, GNUMirrorPackage):
     """The MPFR library is a C library for multiple-precision
        floating-point computations with correct rounding."""
 
     homepage = "https://www.mpfr.org/"
-    url      = "https://ftpmirror.gnu.org/mpfr/mpfr-4.0.2.tar.bz2"
+    gnu_path = "mpfr/mpfr-4.0.2.tar.bz2"
 
     version('4.0.2', sha256='c05e3f02d09e0e9019384cdd58e0f19c64e6db1fd6f5ecf77b4b1c61ca253acc')
     version('4.0.1', sha256='a4d97610ba8579d380b384b225187c250ef88cfe1d5e7226b89519374209b86b')

--- a/var/spack/repos/builtin/packages/mpfr/package.py
+++ b/var/spack/repos/builtin/packages/mpfr/package.py
@@ -11,7 +11,7 @@ class Mpfr(AutotoolsPackage, GNUMirrorPackage):
        floating-point computations with correct rounding."""
 
     homepage = "https://www.mpfr.org/"
-    gnu_path = "mpfr/mpfr-4.0.2.tar.bz2"
+    gnu_mirror_path = "mpfr/mpfr-4.0.2.tar.bz2"
 
     version('4.0.2', sha256='c05e3f02d09e0e9019384cdd58e0f19c64e6db1fd6f5ecf77b4b1c61ca253acc')
     version('4.0.1', sha256='a4d97610ba8579d380b384b225187c250ef88cfe1d5e7226b89519374209b86b')

--- a/var/spack/repos/builtin/packages/nauty/package.py
+++ b/var/spack/repos/builtin/packages/nauty/package.py
@@ -47,8 +47,8 @@ class Nauty(AutotoolsPackage):
         ]
     }
     # Iterate over patches
-    for condition, urls in urls_for_patches.items():
-        for path, sha256 in urls:
+    for condition, url_and_sha256 in urls_for_patches.items():
+        for path, sha256 in url_and_sha256:
             patch(path, when=condition, level=1, sha256=sha256)
 
     depends_on('m4',  type='build', when='@2.6r7')

--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -9,7 +9,7 @@ from os.path import exists, join
 from os import makedirs
 
 
-class Ncurses(AutotoolsPackage):
+class Ncurses(AutotoolsPackage, GNUMirrorPackage):
     """The ncurses (new curses) library is a free software emulation of
     curses in System V Release 4.0, and more. It uses terminfo format,
     supports pads and color and multiple highlights and forms
@@ -18,7 +18,7 @@ class Ncurses(AutotoolsPackage):
 
     homepage = "http://invisible-island.net/ncurses/ncurses.html"
     # URL must remain http:// so Spack can bootstrap curl
-    url      = "http://ftpmirror.gnu.org/ncurses/ncurses-6.1.tar.gz"
+    gnu_path = "ncurses/ncurses-6.1.tar.gz"
 
     version('6.1', sha256='aa057eeeb4a14d470101eff4597d5833dcef5965331be3528c08d99cebaa0d17')
     version('6.0', sha256='f551c24b30ce8bfb6e96d9f59b42fbea30fa3a6123384172f9e7284bcf647260')

--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -18,7 +18,7 @@ class Ncurses(AutotoolsPackage, GNUMirrorPackage):
 
     homepage = "http://invisible-island.net/ncurses/ncurses.html"
     # URL must remain http:// so Spack can bootstrap curl
-    gnu_path = "ncurses/ncurses-6.1.tar.gz"
+    gnu_mirror_path = "ncurses/ncurses-6.1.tar.gz"
 
     version('6.1', sha256='aa057eeeb4a14d470101eff4597d5833dcef5965331be3528c08d99cebaa0d17')
     version('6.0', sha256='f551c24b30ce8bfb6e96d9f59b42fbea30fa3a6123384172f9e7284bcf647260')

--- a/var/spack/repos/builtin/packages/nettle/package.py
+++ b/var/spack/repos/builtin/packages/nettle/package.py
@@ -6,12 +6,12 @@
 from spack import *
 
 
-class Nettle(AutotoolsPackage):
+class Nettle(AutotoolsPackage, GNUMirrorPackage):
     """The Nettle package contains the low-level cryptographic library
     that is designed to fit easily in many contexts."""
 
     homepage = "https://www.lysator.liu.se/~nisse/nettle/"
-    url      = "https://ftpmirror.gnu.org/nettle/nettle-3.3.tar.gz"
+    gnu_path = "nettle/nettle-3.3.tar.gz"
 
     version('3.4.1', sha256='f941cf1535cd5d1819be5ccae5babef01f6db611f9b5a777bae9c7604b8a92ad')
     version('3.4',   sha256='ae7a42df026550b85daca8389b6a60ba6313b0567f374392e54918588a411e94')

--- a/var/spack/repos/builtin/packages/nettle/package.py
+++ b/var/spack/repos/builtin/packages/nettle/package.py
@@ -11,7 +11,7 @@ class Nettle(AutotoolsPackage, GNUMirrorPackage):
     that is designed to fit easily in many contexts."""
 
     homepage = "https://www.lysator.liu.se/~nisse/nettle/"
-    gnu_path = "nettle/nettle-3.3.tar.gz"
+    gnu_mirror_path = "nettle/nettle-3.3.tar.gz"
 
     version('3.4.1', sha256='f941cf1535cd5d1819be5ccae5babef01f6db611f9b5a777bae9c7604b8a92ad')
     version('3.4',   sha256='ae7a42df026550b85daca8389b6a60ba6313b0567f374392e54918588a411e94')

--- a/var/spack/repos/builtin/packages/octave/package.py
+++ b/var/spack/repos/builtin/packages/octave/package.py
@@ -7,7 +7,7 @@ from spack import *
 import sys
 
 
-class Octave(AutotoolsPackage):
+class Octave(AutotoolsPackage, GNUMirrorPackage):
     """GNU Octave is a high-level language, primarily intended for numerical
     computations. It provides a convenient command line interface for solving
     linear and nonlinear problems numerically, and for performing other
@@ -15,7 +15,7 @@ class Octave(AutotoolsPackage):
     Matlab. It may also be used as a batch-oriented language."""
 
     homepage = "https://www.gnu.org/software/octave/"
-    url      = "https://ftpmirror.gnu.org/octave/octave-4.0.0.tar.gz"
+    gnu_path = "octave/octave-4.0.0.tar.gz"
 
     extendable = True
 

--- a/var/spack/repos/builtin/packages/octave/package.py
+++ b/var/spack/repos/builtin/packages/octave/package.py
@@ -15,7 +15,7 @@ class Octave(AutotoolsPackage, GNUMirrorPackage):
     Matlab. It may also be used as a batch-oriented language."""
 
     homepage = "https://www.gnu.org/software/octave/"
-    gnu_path = "octave/octave-4.0.0.tar.gz"
+    gnu_mirror_path = "octave/octave-4.0.0.tar.gz"
 
     extendable = True
 

--- a/var/spack/repos/builtin/packages/parallel/package.py
+++ b/var/spack/repos/builtin/packages/parallel/package.py
@@ -13,7 +13,7 @@ class Parallel(AutotoolsPackage, GNUMirrorPackage):
     """
 
     homepage = "http://www.gnu.org/software/parallel/"
-    gnu_path = "parallel/parallel-20170122.tar.bz2"
+    gnu_mirror_path = "parallel/parallel-20170122.tar.bz2"
 
     version('20190222', sha256='86b1badc56ee2de1483107c2adf634604fd72789c91f65e40138d21425906b1c')
     version('20170322', sha256='f8f810040088bf3c52897a2ee0c0c71bd8d097e755312364b946f107ae3553f6')

--- a/var/spack/repos/builtin/packages/parallel/package.py
+++ b/var/spack/repos/builtin/packages/parallel/package.py
@@ -6,14 +6,14 @@
 from spack import *
 
 
-class Parallel(AutotoolsPackage):
+class Parallel(AutotoolsPackage, GNUMirrorPackage):
     """GNU parallel is a shell tool for executing jobs in parallel using
     one or more computers. A job can be a single command or a small
     script that has to be run for each of the lines in the input.
     """
 
     homepage = "http://www.gnu.org/software/parallel/"
-    url      = "https://ftpmirror.gnu.org/parallel/parallel-20170122.tar.bz2"
+    gnu_path = "parallel/parallel-20170122.tar.bz2"
 
     version('20190222', sha256='86b1badc56ee2de1483107c2adf634604fd72789c91f65e40138d21425906b1c')
     version('20170322', sha256='f8f810040088bf3c52897a2ee0c0c71bd8d097e755312364b946f107ae3553f6')

--- a/var/spack/repos/builtin/packages/patch/package.py
+++ b/var/spack/repos/builtin/packages/patch/package.py
@@ -6,14 +6,14 @@
 from spack import *
 
 
-class Patch(AutotoolsPackage):
+class Patch(AutotoolsPackage, GNUMirrorPackage):
     """Patch takes a patch file containing a difference listing produced by
     the diff program and applies those differences to one or more
     original files, producing patched versions.
     """
 
     homepage = "http://savannah.gnu.org/projects/patch/"
-    url      = "https://ftpmirror.gnu.org/patch/patch-2.7.6.tar.xz"
+    gnu_path = "patch/patch-2.7.6.tar.xz"
 
     version('2.7.6', sha256='ac610bda97abe0d9f6b7c963255a11dcb196c25e337c61f94e4778d632f1d8fd')
     version('2.7.5', sha256='fd95153655d6b95567e623843a0e77b81612d502ecf78a489a4aed7867caa299')

--- a/var/spack/repos/builtin/packages/patch/package.py
+++ b/var/spack/repos/builtin/packages/patch/package.py
@@ -13,7 +13,7 @@ class Patch(AutotoolsPackage, GNUMirrorPackage):
     """
 
     homepage = "http://savannah.gnu.org/projects/patch/"
-    gnu_path = "patch/patch-2.7.6.tar.xz"
+    gnu_mirror_path = "patch/patch-2.7.6.tar.xz"
 
     version('2.7.6', sha256='ac610bda97abe0d9f6b7c963255a11dcb196c25e337c61f94e4778d632f1d8fd')
     version('2.7.5', sha256='fd95153655d6b95567e623843a0e77b81612d502ecf78a489a4aed7867caa299')

--- a/var/spack/repos/builtin/packages/readline/package.py
+++ b/var/spack/repos/builtin/packages/readline/package.py
@@ -16,7 +16,7 @@ class Readline(AutotoolsPackage, GNUMirrorPackage):
 
     homepage = "http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html"
     # URL must remain http:// so Spack can bootstrap curl
-    gnu_path = "readline/readline-8.0.tar.gz"
+    gnu_mirror_path = "readline/readline-8.0.tar.gz"
 
     version('8.0', sha256='e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461')
     version('7.0', sha256='750d437185286f40a369e1e4f4764eda932b9459b5ec9a731628393dd3d32334')

--- a/var/spack/repos/builtin/packages/readline/package.py
+++ b/var/spack/repos/builtin/packages/readline/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class Readline(AutotoolsPackage):
+class Readline(AutotoolsPackage, GNUMirrorPackage):
     """The GNU Readline library provides a set of functions for use by
     applications that allow users to edit command lines as they are typed in.
     Both Emacs and vi editing modes are available. The Readline library
@@ -16,7 +16,7 @@ class Readline(AutotoolsPackage):
 
     homepage = "http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html"
     # URL must remain http:// so Spack can bootstrap curl
-    url      = "http://ftpmirror.gnu.org/readline/readline-8.0.tar.gz"
+    gnu_path = "readline/readline-8.0.tar.gz"
 
     version('8.0', sha256='e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461')
     version('7.0', sha256='750d437185286f40a369e1e4f4764eda932b9459b5ec9a731628393dd3d32334')

--- a/var/spack/repos/builtin/packages/screen/package.py
+++ b/var/spack/repos/builtin/packages/screen/package.py
@@ -12,7 +12,7 @@ class Screen(AutotoolsPackage, GNUMirrorPackage):
     """
 
     homepage = "https://www.gnu.org/software/screen/"
-    gnu_path = "screen/screen-4.3.1.tar.gz"
+    gnu_mirror_path = "screen/screen-4.3.1.tar.gz"
 
     version('4.6.2', sha256='1b6922520e6a0ce5e28768d620b0f640a6631397f95ccb043b70b91bb503fa3a')
     version('4.3.1', sha256='fa4049f8aee283de62e283d427f2cfd35d6c369b40f7f45f947dbfd915699d63')

--- a/var/spack/repos/builtin/packages/screen/package.py
+++ b/var/spack/repos/builtin/packages/screen/package.py
@@ -6,13 +6,13 @@
 from spack import *
 
 
-class Screen(AutotoolsPackage):
+class Screen(AutotoolsPackage, GNUMirrorPackage):
     """Screen is a full-screen window manager that multiplexes a physical
     terminal between several processes, typically interactive shells.
     """
 
     homepage = "https://www.gnu.org/software/screen/"
-    url      = "https://ftpmirror.gnu.org/screen/screen-4.3.1.tar.gz"
+    gnu_path = "screen/screen-4.3.1.tar.gz"
 
     version('4.6.2', sha256='1b6922520e6a0ce5e28768d620b0f640a6631397f95ccb043b70b91bb503fa3a')
     version('4.3.1', sha256='fa4049f8aee283de62e283d427f2cfd35d6c369b40f7f45f947dbfd915699d63')

--- a/var/spack/repos/builtin/packages/sed/package.py
+++ b/var/spack/repos/builtin/packages/sed/package.py
@@ -9,6 +9,6 @@ from spack import *
 class Sed(AutotoolsPackage, GNUMirrorPackage):
     """GNU implementation of the famous stream editor."""
     homepage = "http://www.gnu.org/software/sed/"
-    gnu_path = "sed/sed-4.2.2.tar.bz2"
+    gnu_mirror_path = "sed/sed-4.2.2.tar.bz2"
 
     version('4.2.2', sha256='f048d1838da284c8bc9753e4506b85a1e0cc1ea8999d36f6995bcb9460cddbd7')

--- a/var/spack/repos/builtin/packages/sed/package.py
+++ b/var/spack/repos/builtin/packages/sed/package.py
@@ -6,9 +6,9 @@
 from spack import *
 
 
-class Sed(AutotoolsPackage):
+class Sed(AutotoolsPackage, GNUMirrorPackage):
     """GNU implementation of the famous stream editor."""
     homepage = "http://www.gnu.org/software/sed/"
-    url      = "https://ftpmirror.gnu.org/sed/sed-4.2.2.tar.bz2"
+    gnu_path = "sed/sed-4.2.2.tar.bz2"
 
     version('4.2.2', sha256='f048d1838da284c8bc9753e4506b85a1e0cc1ea8999d36f6995bcb9460cddbd7')

--- a/var/spack/repos/builtin/packages/stow/package.py
+++ b/var/spack/repos/builtin/packages/stow/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class Stow(AutotoolsPackage):
+class Stow(AutotoolsPackage, GNUMirrorPackage):
     """GNU Stow: a symlink farm manager
 
        GNU Stow is a symlink farm manager which takes distinct
@@ -15,7 +15,7 @@ class Stow(AutotoolsPackage):
        installed in the same place."""
 
     homepage = "https://www.gnu.org/software/stow/"
-    url      = "https://ftpmirror.gnu.org/stow/stow-2.2.2.tar.bz2"
+    gnu_path = "stow/stow-2.2.2.tar.bz2"
 
     version('2.2.2', sha256='a0022034960e47a8d23dffb822689f061f7a2d9101c9835cf11bf251597aa6fd')
     version('2.2.0', sha256='86bc30fe1d322a5c80ff3bd7580c2758149aad7c3bbfa18b48a9d95c25d66b05')

--- a/var/spack/repos/builtin/packages/stow/package.py
+++ b/var/spack/repos/builtin/packages/stow/package.py
@@ -15,7 +15,7 @@ class Stow(AutotoolsPackage, GNUMirrorPackage):
        installed in the same place."""
 
     homepage = "https://www.gnu.org/software/stow/"
-    gnu_path = "stow/stow-2.2.2.tar.bz2"
+    gnu_mirror_path = "stow/stow-2.2.2.tar.bz2"
 
     version('2.2.2', sha256='a0022034960e47a8d23dffb822689f061f7a2d9101c9835cf11bf251597aa6fd')
     version('2.2.0', sha256='86bc30fe1d322a5c80ff3bd7580c2758149aad7c3bbfa18b48a9d95c25d66b05')

--- a/var/spack/repos/builtin/packages/tar/package.py
+++ b/var/spack/repos/builtin/packages/tar/package.py
@@ -6,12 +6,12 @@
 from spack import *
 
 
-class Tar(AutotoolsPackage):
+class Tar(AutotoolsPackage, GNUMirrorPackage):
     """GNU Tar provides the ability to create tar archives, as well as various
     other kinds of manipulation."""
 
     homepage = "https://www.gnu.org/software/tar/"
-    url      = "https://ftpmirror.gnu.org/tar/tar-1.32.tar.gz"
+    gnu_path = "tar/tar-1.32.tar.gz"
 
     version('1.32', sha256='b59549594d91d84ee00c99cf2541a3330fed3a42c440503326dab767f2fbb96c')
     version('1.31', sha256='b471be6cb68fd13c4878297d856aebd50551646f4e3074906b1a74549c40d5a2')

--- a/var/spack/repos/builtin/packages/tar/package.py
+++ b/var/spack/repos/builtin/packages/tar/package.py
@@ -11,7 +11,7 @@ class Tar(AutotoolsPackage, GNUMirrorPackage):
     other kinds of manipulation."""
 
     homepage = "https://www.gnu.org/software/tar/"
-    gnu_path = "tar/tar-1.32.tar.gz"
+    gnu_mirror_path = "tar/tar-1.32.tar.gz"
 
     version('1.32', sha256='b59549594d91d84ee00c99cf2541a3330fed3a42c440503326dab767f2fbb96c')
     version('1.31', sha256='b471be6cb68fd13c4878297d856aebd50551646f4e3074906b1a74549c40d5a2')

--- a/var/spack/repos/builtin/packages/texinfo/package.py
+++ b/var/spack/repos/builtin/packages/texinfo/package.py
@@ -15,7 +15,7 @@ class Texinfo(AutotoolsPackage, GNUMirrorPackage):
     of the time. It is used by many non-GNU projects as well."""
 
     homepage = "https://www.gnu.org/software/texinfo/"
-    gnu_path = "texinfo/texinfo-6.0.tar.gz"
+    gnu_mirror_path = "texinfo/texinfo-6.0.tar.gz"
 
     version('6.5', sha256='d34272e4042c46186ddcd66bd5d980c0ca14ff734444686ccf8131f6ec8b1427')
     version('6.3', sha256='300a6ba4958c2dd4a6d5ce60f0a335daf7e379f5374f276f6ba31a221f02f606')

--- a/var/spack/repos/builtin/packages/texinfo/package.py
+++ b/var/spack/repos/builtin/packages/texinfo/package.py
@@ -7,7 +7,7 @@
 from spack import *
 
 
-class Texinfo(AutotoolsPackage):
+class Texinfo(AutotoolsPackage, GNUMirrorPackage):
     """Texinfo is the official documentation format of the GNU project.
 
     It was invented by Richard Stallman and Bob Chassell many years ago,
@@ -15,7 +15,7 @@ class Texinfo(AutotoolsPackage):
     of the time. It is used by many non-GNU projects as well."""
 
     homepage = "https://www.gnu.org/software/texinfo/"
-    url      = "https://ftpmirror.gnu.org/texinfo/texinfo-6.0.tar.gz"
+    gnu_path = "texinfo/texinfo-6.0.tar.gz"
 
     version('6.5', sha256='d34272e4042c46186ddcd66bd5d980c0ca14ff734444686ccf8131f6ec8b1427')
     version('6.3', sha256='300a6ba4958c2dd4a6d5ce60f0a335daf7e379f5374f276f6ba31a221f02f606')

--- a/var/spack/repos/builtin/packages/time/package.py
+++ b/var/spack/repos/builtin/packages/time/package.py
@@ -7,12 +7,12 @@
 from spack import *
 
 
-class Time(AutotoolsPackage):
+class Time(AutotoolsPackage, GNUMirrorPackage):
     """The time command runs another program, then displays
        information about the resources used by that program."""
 
     homepage = "https://www.gnu.org/software/time/"
-    url      = "https://ftpmirror.gnu.org/time/time-1.9.tar.gz"
+    gnu_path = "time/time-1.9.tar.gz"
 
     version('1.9', sha256='fbacf0c81e62429df3e33bda4cee38756604f18e01d977338e23306a3e3b521e')
 

--- a/var/spack/repos/builtin/packages/time/package.py
+++ b/var/spack/repos/builtin/packages/time/package.py
@@ -12,7 +12,7 @@ class Time(AutotoolsPackage, GNUMirrorPackage):
        information about the resources used by that program."""
 
     homepage = "https://www.gnu.org/software/time/"
-    gnu_path = "time/time-1.9.tar.gz"
+    gnu_mirror_path = "time/time-1.9.tar.gz"
 
     version('1.9', sha256='fbacf0c81e62429df3e33bda4cee38756604f18e01d977338e23306a3e3b521e')
 

--- a/var/spack/repos/builtin/packages/units/package.py
+++ b/var/spack/repos/builtin/packages/units/package.py
@@ -10,7 +10,7 @@ class Units(AutotoolsPackage, GNUMirrorPackage):
     """GNU units converts between different systems of units"""
 
     homepage = "https://www.gnu.org/software/units/"
-    gnu_path = "units/units-2.13.tar.gz"
+    gnu_mirror_path = "units/units-2.13.tar.gz"
 
     version('2.13', sha256='0ba5403111f8e5ea22be7d51ab74c8ccb576dc30ddfbf18a46cb51f9139790ab')
 

--- a/var/spack/repos/builtin/packages/units/package.py
+++ b/var/spack/repos/builtin/packages/units/package.py
@@ -6,11 +6,11 @@
 from spack import *
 
 
-class Units(AutotoolsPackage):
+class Units(AutotoolsPackage, GNUMirrorPackage):
     """GNU units converts between different systems of units"""
 
     homepage = "https://www.gnu.org/software/units/"
-    url      = "https://ftpmirror.gnu.org/units/units-2.13.tar.gz"
+    gnu_path = "units/units-2.13.tar.gz"
 
     version('2.13', sha256='0ba5403111f8e5ea22be7d51ab74c8ccb576dc30ddfbf18a46cb51f9139790ab')
 

--- a/var/spack/repos/builtin/packages/wget/package.py
+++ b/var/spack/repos/builtin/packages/wget/package.py
@@ -6,14 +6,14 @@
 from spack import *
 
 
-class Wget(AutotoolsPackage):
+class Wget(AutotoolsPackage, GNUMirrorPackage):
     """GNU Wget is a free software package for retrieving files using
     HTTP, HTTPS and FTP, the most widely-used Internet protocols. It is a
     non-interactive commandline tool, so it may easily be called from scripts,
     cron jobs, terminals without X-Windows support, etc."""
 
     homepage = "http://www.gnu.org/software/wget/"
-    url      = "https://ftpmirror.gnu.org/wget/wget-1.19.1.tar.gz"
+    gnu_path = "wget/wget-1.19.1.tar.gz"
 
     version('1.20.3', sha256='31cccfc6630528db1c8e3a06f6decf2a370060b982841cfab2b8677400a5092e')
     version('1.19.1', sha256='9e4f12da38cc6167d0752d934abe27c7b1599a9af294e73829be7ac7b5b4da40')

--- a/var/spack/repos/builtin/packages/wget/package.py
+++ b/var/spack/repos/builtin/packages/wget/package.py
@@ -13,7 +13,7 @@ class Wget(AutotoolsPackage, GNUMirrorPackage):
     cron jobs, terminals without X-Windows support, etc."""
 
     homepage = "http://www.gnu.org/software/wget/"
-    gnu_path = "wget/wget-1.19.1.tar.gz"
+    gnu_mirror_path = "wget/wget-1.19.1.tar.gz"
 
     version('1.20.3', sha256='31cccfc6630528db1c8e3a06f6decf2a370060b982841cfab2b8677400a5092e')
     version('1.19.1', sha256='9e4f12da38cc6167d0752d934abe27c7b1599a9af294e73829be7ac7b5b4da40')


### PR DESCRIPTION
fixes #5613
fixes #4212
fixes #1090
refers to #13874 

This PR permits to list mirrors of the main `url` in packages. If the main `url` is not available the `url` in the mirrors will be tried in order. It also defines a `GNUMirrorPackage` mixin to deal with the special case of GNU packages and modifies all the GNU packages in the built-in repository.

Note that the feature is implemented starting from 5b377a0 while previous commits are just trivial refactors that should reduce a bit the complexity of fetchers. If they are considered noise for a review I can split this PR into two.