### PR TITLE
Fix plasma package on conflict condition with gcc compiler

### DIFF
--- a/var/spack/repos/builtin/packages/plasma/package.py
+++ b/var/spack/repos/builtin/packages/plasma/package.py
@@ -55,7 +55,7 @@ class Plasma(CMakePackage):
     # only GCC 4.9+ and higher have sufficient support for OpenMP 4+ tasks+deps
     conflicts("%gcc@:4.8.99", when='@:17.1')
     # only GCC 6.0+ and higher have for OpenMP 4+ Clause "priority"
-    conflicts("%gcc@:5.99", when='@17.2:')
+    conflicts("%gcc@:5.99", when='@:17.2')
 
     conflicts("%cce")
     conflicts("%clang")


### PR DESCRIPTION
I was getting this error:
```
==> Error: Conflicts in concretized spec "plasma@19.8.1%gcc@5.4.0 build_type=RelWithDebInfo ~lua patches=6ce78aaea37672a3cd63cbf3cc5f9f12da974a099b8312c6b0678b4b55020287,97606686359b620b7eae22a769793f269dafd52d838bb519ef57d7cb60bea3de +shared arch=linux-ubuntu16.04-x86_64/qlzgq7k"
List of matching conflicts for spec:

    plasma@19.8.1%gcc@5.4.0 build_type=RelWithDebInfo ~lua patches=6ce78aaea37672a3cd63cbf3cc5f9f12da974a099b8312c6b0678b4b55020287,97606686359b620b7eae22a769793f269dafd52d838bb519ef57d7cb60bea3de +shared arch=linux-ubuntu16.04-x86_64
        ^cmake@3.15.5%gcc@5.4.0~doc+ncurses+openssl+ownlibs~qt arch=linux-ubuntu16.04-x86_64
            ^ncurses@6.1%gcc@5.4.0~symlinks~termlib arch=linux-ubuntu16.04-x86_64
                ^pkgconf@1.6.3%gcc@5.4.0 arch=linux-ubuntu16.04-x86_64
            ^openssl@1.1.1d%gcc@5.4.0+systemcerts arch=linux-ubuntu16.04-x86_64
                ^perl@5.30.0%gcc@5.4.0+cpanm+shared+threads arch=linux-ubuntu16.04-x86_64
                    ^gdbm@1.18.1%gcc@5.4.0 arch=linux-ubuntu16.04-x86_64
                        ^readline@8.0%gcc@5.4.0 arch=linux-ubuntu16.04-x86_64
                ^zlib@1.2.11%gcc@5.4.0+optimize+pic+shared arch=linux-ubuntu16.04-x86_64
        ^openblas@0.3.7%gcc@5.4.0+avx2~avx512 cpu_target=auto ~ilp64+pic+shared threads=none ~virtual_machine arch=linux-ubuntu16.04-x86_64

1. "%gcc@:5.99" conflicts with "plasma@17.2:"
```