### PR TITLE
pytest: add __init__ files for all test subdirs

### DIFF
--- a/lib/spack/spack/test/cmd/__init__.py
+++ b/lib/spack/spack/test/cmd/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -765,13 +765,13 @@ def test_indirect_build_dep():
 @pytest.mark.usefixtures('config')
 def test_store_different_build_deps():
     r"""Ensure that an environment can store two instances of a build-only
-Dependency:
+    dependency::
 
-        x       y
-       /| (l)   | (b)
-  (b) | y       z2
-       \| (b)
-        z1
+              x       y
+             /| (l)   | (b)
+        (b) | y       z2
+             \| (b)
+              z1
 
     """
     default = ('build', 'link')

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -770,7 +770,7 @@ Dependency:
         x       y
        /| (l)   | (b)
   (b) | y       z2
-       \| (b)              # noqa: W605
+       \| (b)
         z1
 
     """

--- a/lib/spack/spack/test/llnl/util/__init.py
+++ b/lib/spack/spack/test/llnl/util/__init.py
@@ -1,0 +1,4 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/lib/spack/spack/test/modules/__init__.py
+++ b/lib/spack/spack/test/modules/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/lib/spack/spack/test/util/__init__.py
+++ b/lib/spack/spack/test/util/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)


### PR DESCRIPTION
Currently, `cmd/resource.py` in `lib/spack/spack/test` conflicts with a file in `celery`, so users who use spack in a python virtualenv with `celery` installed will not be able to run `spack test`.

This is also just best practices. We had already added a `__init__.py` file for the top level testing directory, this covers all the subdirectories.
