### PR TITLE
MPark.Variant: Patch NVCC C++14 Build

### DIFF
--- a/var/spack/repos/builtin/packages/mpark-variant/nvcc.patch
+++ b/var/spack/repos/builtin/packages/mpark-variant/nvcc.patch
@@ -1,0 +1,27 @@
+From 443d9454e8a665cef01cbf63036648a6e0ad9ffd Mon Sep 17 00:00:00 2001
+From: Axel Huebl <axel.huebl@plasma.ninja>
+Date: Mon, 25 Nov 2019 17:56:38 -0800
+Subject: [PATCH] NVCC: Avoid Specific Constexpr Construct
+
+Out of the many C++14 `constexpr` constructs, one does not compile
+with NVCC - even when using `-std=c++14 --expt-relaxed-constexpr`.
+Seen with all versions of NVCC so far (latest tests with 10.1 and
+10.2).
+---
+ include/mpark/variant.hpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/mpark/variant.hpp b/include/mpark/variant.hpp
+index ef496619b..728e69395 100644
+--- a/include/mpark/variant.hpp
++++ b/include/mpark/variant.hpp
+@@ -1998,7 +1998,7 @@ namespace mpark {
+     return false;
+   }
+ 
+-#ifdef MPARK_CPP14_CONSTEXPR
++#if defined(MPARK_CPP14_CONSTEXPR) && !defined(__NVCC__)
+   namespace detail {
+ 
+     inline constexpr bool all(std::initializer_list<bool> bs) {
+

--- a/var/spack/repos/builtin/packages/mpark-variant/package.py
+++ b/var/spack/repos/builtin/packages/mpark-variant/package.py
@@ -16,5 +16,8 @@ class MparkVariant(CMakePackage):
     version('1.4.0', sha256='8f6b28ab3640b5d76d5b6664dda7257a4405ce59179220431b8fd196c79b2ecb')
     version('1.3.0', sha256='d0f7e41f818fcc839797a8017e76b8b66b323651c304cff641a83a56ae9943c6')
 
+    # Ref.: https://github.com/mpark/variant/pull/71
+    patch('nvcc.patch')
+
     conflicts('%gcc@:4.7')
     conflicts('%clang@:3.5')


### PR DESCRIPTION
Fix a (downstream) issue with NVCC when building with C++14.
Patch works with both tagged versions.

Ref.: https://github.com/mpark/variant/pull/71