### PR TITLE
Handle external perl

### DIFF
--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -170,14 +170,9 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
            any other perl extensions it depends on,
            assuming they were installed with INSTALL_BASE defined."""
         perl_lib_dirs = []
-        perl_bin_dirs = []
         for d in dependent_spec.traverse(deptype=deptypes):
             if d.package.extends(self.spec):
                 perl_lib_dirs.append(d.prefix.lib.perl5)
-                perl_bin_dirs.append(d.prefix.bin)
-        if perl_bin_dirs:
-            perl_bin_path = ':'.join(perl_bin_dirs)
-            env.prepend_path('PATH', perl_bin_path)
         if perl_lib_dirs:
             perl_lib_path = ':'.join(perl_lib_dirs)
             env.prepend_path('PERL5LIB', perl_lib_path)

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -165,15 +165,13 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
                 make()
                 make('install')
 
-    def setup_dependent_build_environment(self, env, dependent_spec):
+    def _setup_dependent_env(self, env, dependent_spec, deptypes):
         """Set PATH and PERL5LIB to include the extension and
            any other perl extensions it depends on,
            assuming they were installed with INSTALL_BASE defined."""
-        perl_lib_dirs = [join_path(self.spec.prefix.lib,
-                                   str(self.spec.version))]
-        perl_bin_dirs = [self.spec.prefix.bin]
-        for d in dependent_spec.traverse(
-                deptype=('build', 'run'), deptype_query='run'):
+        perl_lib_dirs = []
+        perl_bin_dirs = []
+        for d in dependent_spec.traverse(deptype=deptypes):
             if d.package.extends(self.spec):
                 perl_lib_dirs.append(d.prefix.lib.perl5)
                 perl_bin_dirs.append(d.prefix.bin)
@@ -184,24 +182,12 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
             perl_lib_path = ':'.join(perl_lib_dirs)
             env.prepend_path('PERL5LIB', perl_lib_path)
 
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        self._setup_dependent_env(env, dependent_spec,
+                                  deptypes=('build', 'run'))
+
     def setup_dependent_run_environment(self, env, dependent_spec):
-        """Set PATH and PERL5LIB to include the extension and
-           any other perl extensions it depends on,
-           assuming they were installed with INSTALL_BASE defined."""
-        perl_lib_dirs = [join_path(self.spec.prefix.lib,
-                                   str(self.spec.version))]
-        perl_bin_dirs = [self.spec.prefix.bin]
-        for d in dependent_spec.traverse(
-                deptype=('run',), deptype_query='run'):
-            if d.package.extends(self.spec):
-                perl_lib_dirs.append(d.prefix.lib.perl5)
-                perl_bin_dirs.append(d.prefix.bin)
-        if perl_bin_dirs:
-            perl_bin_path = ':'.join(perl_bin_dirs)
-            env.prepend_path('PATH', perl_bin_path)
-        if perl_lib_dirs:
-            perl_lib_path = ':'.join(perl_lib_dirs)
-            env.prepend_path('PERL5LIB', perl_lib_path)
+        self._setup_dependent_env(env, dependent_spec, deptypes=('run',))
 
     def setup_dependent_package(self, module, dependent_spec):
         """Called before perl modules' install() methods.


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/13792
Fixes #13930 

https://github.com/spack/spack/commit/99dfff447509a68d672a82812e5abfbc463b6d26 updated `perl` to add `perl`'s `bin/` directory to `PATH` but does not filter it when it is a system path. This removes that logic from the `perl` package because adding `bin` for a given package is already handled in Spack core (and it includes filtering logic for system dirs)