### PR TITLE
module_cmd: use semicolons instead of newlines python command

### DIFF
--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -17,7 +17,7 @@ import llnl.util.tty as tty
 # This list is not exhaustive. Currently we only use load and unload
 # If we need another option that changes the environment, add it here.
 module_change_commands = ['load', 'swap', 'unload', 'purge', 'use', 'unuse']
-py_cmd = "'import os\nimport json\nprint(json.dumps(dict(os.environ)))'"
+py_cmd = "'import os;import json;print(json.dumps(dict(os.environ)))'"
 
 # This is just to enable testing. I hate it but we can't find a better way
 _test_mode = False


### PR DESCRIPTION
fixes a bug reported on slack.

`python -c` fails with lines delimited by newlines, but succeeds with lines delimited by semicolons.

This PR fixes Spack's `module` function to use semicolons instead of newlines.