### PR TITLE
Bugfix/mirror symlinks

### DIFF
--- a/lib/spack/spack/caches.py
+++ b/lib/spack/spack/caches.py
@@ -70,7 +70,13 @@ class MirrorCache(object):
         relative_dst = os.path.relpath(
             mirror_ref.storage_path,
             start=os.path.dirname(cosmetic_path))
+
         if not os.path.exists(cosmetic_path):
+            if os.path.lexists(cosmetic_path):
+                # In this case the link itself exists but it is broken: remove
+                # it and recreate it (in order to fix any symlinks broken prior
+                # to https://github.com/spack/spack/pull/13908)
+                os.unlink(cosmetic_path)
             mkdirp(os.path.dirname(cosmetic_path))
             os.symlink(relative_dst, cosmetic_path)
 

--- a/lib/spack/spack/caches.py
+++ b/lib/spack/spack/caches.py
@@ -67,8 +67,9 @@ class MirrorCache(object):
         storage location."""
 
         cosmetic_path = os.path.join(self.root, mirror_ref.cosmetic_path)
+        storage_path = os.path.join(self.root, mirror_ref.storage_path)
         relative_dst = os.path.relpath(
-            mirror_ref.storage_path,
+            storage_path,
             start=os.path.dirname(cosmetic_path))
 
         if not os.path.exists(cosmetic_path):

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -505,7 +505,6 @@ def add_single_spec(spec, mirror_root, mirror_stats):
             with spec.package.stage as pkg_stage:
                 pkg_stage.cache_mirror(mirror_stats)
                 for patch in spec.package.all_patches():
-                    patch.fetch(pkg_stage)
                     if patch.cache():
                         patch.cache().cache_mirror(mirror_stats)
                     patch.clean()

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1086,7 +1086,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         self.stage.cache_local()
 
         for patch in self.spec.patches:
-            patch.fetch(self.stage)
+            patch.fetch()
             if patch.cache():
                 patch.cache().cache_local()
 

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -64,11 +64,8 @@ class Patch(object):
         self.level = level
         self.working_dir = working_dir
 
-    def fetch(self, stage):
+    def fetch(self):
         """Fetch the patch in case of a UrlPatch
-
-        Args:
-            stage: stage for the package that needs to be patched
         """
 
     def clean(self):
@@ -185,8 +182,7 @@ class UrlPatch(Patch):
         if not self.sha256:
             raise PatchDirectiveError("URL patches require a sha256 checksum")
 
-    # TODO: this function doesn't use the stage arg
-    def fetch(self, stage):
+    def fetch(self):
         """Retrieve the patch in a temporary stage and compute self.path
 
         Args:

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -502,6 +502,7 @@ class Stage(object):
             stats.already_existed(absolute_storage_path)
         else:
             self.fetch()
+            self.check()
             spack.caches.mirror_cache.store(
                 self.fetcher, self.mirror_paths.storage_path)
             stats.added(absolute_storage_path)

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -494,6 +494,16 @@ class Stage(object):
 
     def cache_mirror(self, stats):
         """Perform a fetch if the resource is not already cached"""
+        if isinstance(self.default_fetcher, fs.BundleFetchStrategy):
+            # BundleFetchStrategy has no source to fetch. The associated
+            # fetcher does nothing but the associated stage may still exist.
+            # There is currently no method available on the fetcher to
+            # distinguish this ('cachable' refers to whether the fetcher
+            # refers to a resource with a fixed ID, which is not the same
+            # concept as whether there is anything to fetch at all) so we
+            # must examine the type of the fetcher.
+            return
+
         dst_root = spack.caches.mirror_cache.root
         absolute_storage_path = os.path.join(
             dst_root, self.mirror_paths.storage_path)

--- a/lib/spack/spack/test/patch.py
+++ b/lib/spack/spack/test/patch.py
@@ -79,7 +79,7 @@ first line
 third line
 """)
         # apply the patch and compare files
-        patch.fetch(stage)
+        patch.fetch()
         patch.apply(stage)
         patch.clean()
 


### PR DESCRIPTION
(update 12/4: this PR should be rebased the commits apply fixes for thematically-related but functionally-separate problems, and I intend that the commits are properly-formatted and organized for that)

Fixes #13722 (or rather addresses the parts of it that were not addressed by #13789)
Fixes #14067
Closes #14093

* Don't try to fetch `BundlePackage`s
* Don't fetch patches if they were already added to the mirror
* #13789 started calculating a relative path, relative to another relative path. This can fail based on the working directory, so the intended reference point for the relative path is created explicitly as the absolute path
* Allow repeated invocations of `spack mirror create` on the same mirror directory (in develop this currently reports errors)