### PR TITLE
Fix py-line-profiler incompatible decorators

### DIFF
--- a/var/spack/repos/builtin/packages/py-line-profiler/package.py
+++ b/var/spack/repos/builtin/packages/py-line-profiler/package.py
@@ -24,8 +24,11 @@ class PyLineProfiler(PythonPackage):
 
     # See https://github.com/rkern/line_profiler/issues/166
     @run_before('build')
-    @when('^python@3.7:')
     def fix_cython(self):
+        # TODO: Replace the check with a `@when('^python@3.7:')` decorator once
+        # https://github.com/spack/spack/issues/12736 is resolved
+        if not self.spec.satisfies("^python@3.7:"):
+            return
         cython = self.spec['py-cython'].command
         for root, _, files in os.walk('.'):
             for fn in files:


### PR DESCRIPTION
Because `@run_after` and `@when` are incompatible (issue #12736), we got
the following error when installing `py-line-profiler` with `python@2.7.16`.
```
/opt/spack/lib/spack/spack/package.py:1718, in build_process:
       1715                    echo = logger.echo
       1716                    self.log()
       1717
  >>   1718                # Run post install hooks before build stage is removed.
       1719                spack.hooks.post_install(self.spec)
       1720
       1721            # Stop timer.
NoSuchMethodError: Package PyLineProfiler does not support fix_cython called with py-line-profiler@2.1.2 [...] ^python@2.7.16 [...]
```
