### PR TITLE
Fixed x86-64 optimization flags for clang

### DIFF
--- a/lib/spack/llnl/util/cpu/microarchitectures.json
+++ b/lib/spack/llnl/util/cpu/microarchitectures.json
@@ -64,13 +64,13 @@
         "clang": [
           {
             "versions": "0.0.0-apple:",
-            "family": "x86-64",
-            "flags": "-march={family}"
+            "name": "x86-64",
+            "flags": "-march={name}"
           },
           {
             "versions": ":",
-            "family": "x86-64",
-            "flags": "-march={family} -mcpu=generic"
+            "name": "x86-64",
+            "flags": "-march={name} -mtune=generic"
           }
         ],
         "intel": {
@@ -96,8 +96,7 @@
         },
         "clang": {
           "versions": "3.9:",
-          "family": "x86-64",
-          "flags": "-march={family} -mcpu={name}"
+          "flags": "-march={name} -mtune={name}"
         },
         "intel": {
           "versions": "16.0:",
@@ -122,8 +121,7 @@
         },
         "clang": {
           "versions": "3.9:",
-          "family": "x86-64",
-          "flags": "-march={family} -mcpu={name}"
+          "flags": "-march={name} -mtune={name}"
         },
         "intel": {
           "versions": "16.0:",
@@ -157,8 +155,7 @@
         ],
         "clang": {
           "versions": "3.9:",
-          "family": "x86-64",
-          "flags": "-march={family} -mcpu={name}"
+          "flags": "-march={name} -mtune={name}"
         },
         "intel": {
           "versions": "16.0:",
@@ -188,8 +185,7 @@
         },
         "clang": {
           "versions": "3.9:",
-          "family": "x86-64",
-          "flags": "-march={family} -mcpu={name}"
+          "flags": "-march={name} -mtune={name}"
         },
         "intel": {
           "versions": "16.0:",
@@ -227,8 +223,7 @@
         ],
         "clang": {
           "versions": "3.9:",
-          "family": "x86-64",
-          "flags": "-march={family} -mcpu={name}"
+          "flags": "-march={name} -mtune={name}"
         },
         "intel": [
           {
@@ -274,8 +269,7 @@
         ],
         "clang": {
           "versions": "3.9:",
-          "family": "x86-64",
-          "flags": "-march={family} -mcpu={name}"
+          "flags": "-march={name} -mtune={name}"
         },
         "intel": [
           {
@@ -326,8 +320,7 @@
         ],
         "clang": {
           "versions": "3.9:",
-          "family": "x86-64",
-          "flags": "-march={family} -mcpu={name}"
+          "flags": "-march={name} -mtune={name}"
         },
         "intel": [
           {
@@ -373,8 +366,7 @@
         },
         "clang": {
           "versions": "3.9:",
-          "family": "x86-64",
-          "flags": "-march={family} -mcpu={name}"
+          "flags": "-march={name} -mtune={name}"
         },
         "intel": {
           "versions": "18.0:",
@@ -416,8 +408,7 @@
         },
         "clang": {
           "versions": "3.9:",
-          "family": "x86-64",
-          "flags": "-march={family} -mcpu={name}"
+          "flags": "-march={name} -mtune={name}"
         },
         "intel": {
           "versions": "18.0:",
@@ -463,8 +454,7 @@
         "clang": {
           "versions": "3.9:",
           "name": "knl",
-          "family": "x86-64",
-          "flags": "-march={family} -mcpu={name}"
+          "flags": "-march={name} -mtune={name}"
         },
         "intel": {
           "versions": "18.0:",
@@ -515,8 +505,7 @@
         "clang": {
           "versions": "3.9:",
           "name": "skylake-avx512",
-          "family": "x86-64",
-          "flags": "-march={family} -mcpu={name}"
+          "flags": "-march={name} -mtune={name}"
         },
         "intel": {
           "versions": "18.0:",
@@ -568,8 +557,7 @@
         },
         "clang": {
           "versions": "3.9:",
-          "family": "x86-64",
-          "flags": "-march={family} -mcpu={name}"
+          "flags": "-march={name} -mtune={name}"
         },
         "intel": {
           "versions": "18.0:",
@@ -618,8 +606,7 @@
         },
         "clang": {
           "versions": "8.0:",
-          "family": "x86-64",
-          "flags": "-march={family} -mcpu={name}"
+          "flags": "-march={name} -mtune={name}"
         },
         "intel": {
           "versions": "19.0:",
@@ -685,13 +672,11 @@
           {
             "versions": "7.0:",
             "name": "icelake-client",
-            "family": "x86-64",
-            "flags": "-march={family} -mcpu={name}"
+            "flags": "-march={name} -mtune={name}"
           },
           {
             "versions": "6.0:6.9",
-            "family": "x86-64",
-            "flags": "-march={family} -mcpu={name}"
+            "flags": "-march={name} -mtune={name}"
           }
         ],
         "intel": {
@@ -723,8 +708,7 @@
         "clang": {
           "versions": "3.9:",
           "name": "amdfam10",
-          "family": "x86-64",
-          "flags": "-march={family} -mcpu={name}"
+          "flags": "-march={name} -mtune={name}"
         },
         "intel": {
           "versions": "16.0:",
@@ -761,8 +745,7 @@
         "clang": {
           "versions": "3.9:",
           "name": "bdver1",
-          "family": "x86-64",
-          "flags": "-march={family} -mcpu={name}"
+          "flags": "-march={name} -mtune={name}"
         },
         "intel": {
           "versions": "16.0:",
@@ -803,8 +786,7 @@
         "clang": {
           "versions": "3.9:",
           "name": "bdver2",
-          "family": "x86-64",
-          "flags": "-march={family} -mcpu={name}"
+          "flags": "-march={name} -mtune={name}"
         },
         "intel": {
           "versions": "16.0:",
@@ -846,8 +828,7 @@
         "clang": {
           "versions": "3.9:",
           "name": "bdver3",
-          "family": "x86-64",
-          "flags": "-march={family} -mcpu={name}"
+          "flags": "-march={name} -mtune={name}"
         },
         "intel": {
           "versions": "16.0:",
@@ -892,8 +873,7 @@
         "clang": {
           "versions": "3.9:",
           "name": "bdver4",
-          "family": "x86-64",
-          "flags": "-march={family} -mcpu={name}"
+          "flags": "-march={name} -mtune={name}"
         },
         "intel": {
           "versions": "16.0:",
@@ -942,8 +922,7 @@
         "clang": {
           "versions": "4.0:",
           "name": "znver1",
-          "family": "x86-64",
-          "flags": "-march={family} -mcpu={name}"
+          "flags": "-march={name} -mtune={name}"
         },
         "intel": {
           "versions": "16.0:",
@@ -993,8 +972,7 @@
         "clang": {
           "versions": "9.0:",
           "name": "znver2",
-          "family": "x86-64",
-          "flags": "-march={family} -mcpu={name}"
+          "flags": "-march={name} -mtune={name}"
         },
         "intel": {
           "versions": "16.0:",

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -176,7 +176,7 @@ def test_arch_spec_container_semantic(item, architecture_str):
     ('gcc@4.7.2', 'ivybridge', '-march=core-avx-i -mtune=core-avx-i'),
     # Check mixed toolchains
     ('clang@8.0.0', 'broadwell', ''),
-    ('clang@3.5', 'x86_64', '-march=x86-64 -mcpu=generic'),
+    ('clang@3.5', 'x86_64', '-march=x86-64 -mtune=generic'),
     # Check clang compilers with 'apple' suffix
     ('clang@9.1.0-apple', 'x86_64', '-march=x86-64')
 ])

--- a/lib/spack/spack/test/llnl/util/cpu.py
+++ b/lib/spack/spack/test/llnl/util/cpu.py
@@ -213,10 +213,11 @@ def test_target_json_schema():
     ('thunderx2', 'gcc', '4.8.5', '-march=armv8-a'),
     ('thunderx2', 'gcc', '4.9.3', '-march=armv8-a+crc+crypto'),
     # Test Clang / LLVM
-    ('sandybridge', 'clang', '3.9.0', '-march=x86-64 -mcpu=sandybridge'),
-    ('icelake', 'clang', '6.0.0', '-march=x86-64 -mcpu=icelake'),
-    ('icelake', 'clang', '8.0.0', '-march=x86-64 -mcpu=icelake-client'),
-    ('zen2', 'clang', '9.0.0', '-march=x86-64 -mcpu=znver2'),
+    ('sandybridge', 'clang', '3.9.0', '-march=sandybridge -mtune=sandybridge'),
+    ('icelake', 'clang', '6.0.0', '-march=icelake -mtune=icelake'),
+    ('icelake', 'clang', '8.0.0',
+     '-march=icelake-client -mtune=icelake-client'),
+    ('zen2', 'clang', '9.0.0', '-march=znver2 -mtune=znver2'),
     ('power9le', 'clang', '8.0.0', '-march=ppc64le -mcpu=pwr9'),
     ('thunderx2', 'clang', '6.0.0', '-march=armv8-a -mcpu=generic'),
     # Test Intel on Intel CPUs


### PR DESCRIPTION
Before the flags used where the one for llc, the underlying compiler from LLVM IR to machine assembly. It turns out that the semantic of `-march`, `-mtune` and `-mcpu` changes from clang front-end to llc.

I found no definitive reference for the flags submitted in this PR, but I checked the assembly on a vectorizable function using [Godbolt's web-site](https://godbolt.org/z/S9yFwU).

Refers to the discussion in https://github.com/spack/spack/pull/13825#discussion_r351107265 (thanks @t-karatsu !)