### PR TITLE
[WIP]: allowing user config path to be set by cli

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -330,6 +330,9 @@ def make_argument_parser(**kwargs):
         '-C', '--config-scope', dest='config_scopes', action='append',
         metavar='DIR', help="add a custom configuration scope")
     parser.add_argument(
+        '-u', '--user-config', action='store', dest='user_config_path',
+        metavar='DIR', help="use this for the user configuration scope")
+    parser.add_argument(
         '-d', '--debug', action='store_true',
         help="write out debug logs during compile")
     parser.add_argument(
@@ -405,6 +408,11 @@ def setup_main_options(args):
     tty.set_verbose(args.verbose)
     tty.set_debug(args.debug)
     tty.set_stacktrace(args.stacktrace)
+
+    if args.user_config_path is not None:
+        # This must be set before any uses of spack.config so that the config
+        # singleton sees the correct user config path.
+        spack.paths.user_config_path = args.user_config_path
 
     # debug must be set first so that it can even affect behvaior of
     # errors raised by spack.config.

--- a/lib/spack/spack/paths.py
+++ b/lib/spack/spack/paths.py
@@ -13,48 +13,79 @@ import os
 from llnl.util.filesystem import ancestor
 
 
-#: This file lives in $prefix/lib/spack/spack/__file__
-prefix = ancestor(__file__, 4)
+class Paths:
+    #: This file lives in $prefix/lib/spack/spack/__file__
+    prefix = ancestor(__file__, 4)
 
-#: synonym for prefix
-spack_root = prefix
+    #: synonym for prefix
+    spack_root = prefix
 
-#: bin directory in the spack prefix
-bin_path = os.path.join(prefix, "bin")
+    #: bin directory in the spack prefix
+    bin_path = os.path.join(prefix, "bin")
 
-#: The spack script itself
-spack_script = os.path.join(bin_path, "spack")
+    #: The spack script itself
+    spack_script = os.path.join(bin_path, "spack")
 
-# spack directory hierarchy
-lib_path              = os.path.join(prefix, "lib", "spack")
-external_path         = os.path.join(lib_path, "external")
-build_env_path        = os.path.join(lib_path, "env")
-module_path           = os.path.join(lib_path, "spack")
-command_path          = os.path.join(module_path, "cmd")
-platform_path         = os.path.join(module_path, 'platforms')
-compilers_path        = os.path.join(module_path, "compilers")
-build_systems_path    = os.path.join(module_path, 'build_systems')
-operating_system_path = os.path.join(module_path, 'operating_systems')
-test_path             = os.path.join(module_path, "test")
-hooks_path            = os.path.join(module_path, "hooks")
-var_path              = os.path.join(prefix, "var", "spack")
-repos_path            = os.path.join(var_path, "repos")
-share_path            = os.path.join(prefix, "share", "spack")
+    # spack directory hierarchy
+    lib_path              = os.path.join(prefix, "lib", "spack")
+    external_path         = os.path.join(lib_path, "external")
+    build_env_path        = os.path.join(lib_path, "env")
+    module_path           = os.path.join(lib_path, "spack")
+    command_path          = os.path.join(module_path, "cmd")
+    platform_path         = os.path.join(module_path, 'platforms')
+    compilers_path        = os.path.join(module_path, "compilers")
+    build_systems_path    = os.path.join(module_path, 'build_systems')
+    operating_system_path = os.path.join(module_path, 'operating_systems')
+    test_path             = os.path.join(module_path, "test")
+    hooks_path            = os.path.join(module_path, "hooks")
+    var_path              = os.path.join(prefix, "var", "spack")
+    repos_path            = os.path.join(var_path, "repos")
+    share_path            = os.path.join(prefix, "share", "spack")
 
-# Paths to built-in Spack repositories.
-packages_path      = os.path.join(repos_path, "builtin")
-mock_packages_path = os.path.join(repos_path, "builtin.mock")
+    # Paths to built-in Spack repositories.
+    packages_path      = os.path.join(repos_path, "builtin")
+    mock_packages_path = os.path.join(repos_path, "builtin.mock")
 
-#: User configuration location
-user_config_path = os.path.expanduser('~/.spack')
+    #: User configuration location
+    user_config_path = os.path.expanduser('~/.spack')
+
+    opt_path        = os.path.join(prefix, "opt")
+    etc_path        = os.path.join(prefix, "etc")
+    system_etc_path = '/etc'
+
+    # GPG paths.
+    gpg_keys_path      = os.path.join(var_path, "gpg")
+    mock_gpg_data_path = os.path.join(var_path, "gpg.mock", "data")
+    mock_gpg_keys_path = os.path.join(var_path, "gpg.mock", "keys")
+    gpg_path           = os.path.join(opt_path, "spack", "gpg")
 
 
-opt_path        = os.path.join(prefix, "opt")
-etc_path        = os.path.join(prefix, "etc")
-system_etc_path = '/etc'
+# The following allows the Paths() class to replace this module in sys.modules:
+#
+# From Guido van Rossum:
+#   (https://mail.python.org/pipermail/python-ideas/2012-May/014969.html)
+# There is actually a hack that is occasionally used and recommended: a module
+# can define a class with the desired functionality, and then at the end,
+# replace itself in sys.modules with an instance of that class (or with the
+# class, if you insist, but that's generally less useful). E.g.:
+#
+#  # module foo.py
+#
+#    import sys
+#
+#    class Foo:
+#        def funct1(self, <args>): <code>
+#        def funct2(self, <args>): <code>
+#
+#    sys.modules[__name__] = Foo()
+#
+# This works because the import machinery is actively enabling this hack, and
+# as its final step pulls the actual module out of sys.modules, after loading
+# it. (This is no accident. The hack was proposed long ago and we decided we
+# liked enough to support it in the import machinery.)
 
-# GPG paths.
-gpg_keys_path      = os.path.join(var_path, "gpg")
-mock_gpg_data_path = os.path.join(var_path, "gpg.mock", "data")
-mock_gpg_keys_path = os.path.join(var_path, "gpg.mock", "keys")
-gpg_path           = os.path.join(opt_path, "spack", "gpg")
+# But why? We want user_config_path to be a property so that it can be set from
+# a command line option.
+import sys  # noqa: E402
+
+sys.modules[__name__] = Paths()

--- a/lib/spack/spack/paths.py
+++ b/lib/spack/spack/paths.py
@@ -47,7 +47,7 @@ class Paths:
     mock_packages_path = os.path.join(repos_path, "builtin.mock")
 
     #: User configuration location
-    user_config_path = os.path.expanduser('~/.spack')
+    _user_config_path = os.path.expanduser('~/.spack')
 
     opt_path        = os.path.join(prefix, "opt")
     etc_path        = os.path.join(prefix, "etc")
@@ -58,6 +58,16 @@ class Paths:
     mock_gpg_data_path = os.path.join(var_path, "gpg.mock", "data")
     mock_gpg_keys_path = os.path.join(var_path, "gpg.mock", "keys")
     gpg_path           = os.path.join(opt_path, "spack", "gpg")
+
+    @property
+    def user_config_path(self):
+        """Return the path to the user configuration directory"""
+        return self._user_config_path
+
+    @user_config_path.setter
+    def user_config_path(self, arg):
+        """Set the user_config_path"""
+        self._user_config_path = arg
 
 
 # The following allows the Paths() class to replace this module in sys.modules:
@@ -84,8 +94,8 @@ class Paths:
 # it. (This is no accident. The hack was proposed long ago and we decided we
 # liked enough to support it in the import machinery.)
 
-# But why? We want user_config_path to be a property so that it can be set from
-# a command line option.
+# But why? We want user_config_path to provide an API for modifying the
+# user_config_path
 import sys  # noqa: E402
 
 sys.modules[__name__] = Paths()


### PR DESCRIPTION
This is an alternative to PRs like #13139, #11951 - and other attempts to make the user configuration path not hard coded to `~.spack`

This is only meant to propose another alternative and continue discussion.  It uses a method described by  Guido van Rossum at https://mail.python.org/pipermail/python-ideas/2012-May/014969.html.