### PR TITLE
new subcommand: config add/remove

### DIFF
--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -82,15 +82,20 @@ def _get_scope_and_section(args):
 
     # set scope defaults
     elif not scope:
-        # set section from value if the command takes a value
-        if hasattr(args, 'value'):
-            value = args.value
-            section = value[:value.find(':')] if ':' in value else value
-
         if section == 'compilers':
             scope = spack.config.default_modify_scope()
         else:
-            scope = 'user'
+            scope = spack.config.default_modify_scope(subscopes=False)
+
+    # special handling for commands that take value instead of section
+    if hasattr(args, 'value'):
+        value = args.value
+        section = value[:value.find(':')] if ':' in value else value
+        if not scope:
+            if section == 'compilers':
+                scope = spack.config.default_modify_scope
+            else:
+                scope = spack.config.default_modify_scope(False)
 
     return scope, section
 
@@ -173,7 +178,7 @@ def config_add(args):
     """Add the given configuration to the specified config scope
 
     This is a stateful operation that edits the config files under the hood"""
-    scope, _ = _get_scope_and_section(args)
+    scope, section = _get_scope_and_section(args)
 
     components = args.value.split(':')
     path = None
@@ -182,9 +187,22 @@ def config_add(args):
         test_existing = spack.config.get(test_path, scope=scope)
         if test_existing is None:
             path = test_path
-            # We've nested further than existing config, so we need empty
+            # We've nested further than existing config, so we need empty value
             # get type to ensure we treat lists properly when empty
-            existing = [] if isinstance(spack.config.get(path, scope=None), list) else None
+            for type in (list, dict, str, bool, int, float):
+                try:
+                    # Try validating with different types
+                    existing = type()
+                    test_data = existing
+                    for component in reversed(components[:idx + 1]):
+                        test_data = {component: test_data}
+                    spack.config.validate(
+                        test_data, spack.config.section_schemas[section])
+                    break
+                except spack.config.ConfigFormatError:
+                    # Wrong type, try the next one
+                    pass
+
             # construct value from this point down
             value = syaml.load(components[-1])
             for component in reversed(components[idx + 1:-1]):
@@ -198,7 +216,7 @@ def config_add(args):
 
     new = merge_value(existing, value)
 
-    if re.match(r'env.*', scope):
+    if re.match(r'env.*', scope or ''):
         e = ev.get_env(args, 'config add')
         e.set_config(path, new)
     else:
@@ -211,6 +229,11 @@ def config_remove(args):
     This is a stateful operation that edits the config files under the hood"""
     scope, _ = _get_scope_and_section(args)
 
+    e = ev.get_env(args, 'config remove')
+    if e:
+        import ruamel.yaml as yaml
+        tty.msg(str(getattr(e.yaml, yaml.comments.Comment.attrib, None)))
+
     path, _, value = args.value.rpartition(':')
     existing = spack.config.get(path, scope=scope)
 
@@ -218,20 +241,23 @@ def config_remove(args):
         path, _, value = path.rpartition(':')
         existing = spack.config.get(path, scope=scope)
 
+    value = syaml.load(value)
+
     if isinstance(existing, list):
-        new = [x for x in existing if x != value] if value else []
+        values = value if isinstance(value, list) else [value]
+        for v in values:
+            existing.remove(v)
     elif isinstance(existing, dict):
-        new = dict((k, v) for k, v in existing.items()
-                   if k != value) if value else {}
+        existing.pop(value, None)
     else:
         # This should be impossible to reach
         raise spack.config.ConfigError('Config has nested non-dict values')
 
-    if re.match(r'env.*', scope):
+    if re.match(r'env.*', scope or ''):
         e = ev.get_env(args, 'config remove')
-        e.set_config(path, new)
+        e.set_config(path, existing)
     else:
-        spack.config.set(path, new, scope=scope)
+        spack.config.set(path, existing, scope=scope)
 
 def config(parser, args):
     action = {'get': config_get,

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -6,6 +6,7 @@
 from __future__ import print_function
 import os
 import six
+import re
 
 import llnl.util.tty as tty
 
@@ -71,12 +72,7 @@ def setup_parser(subparser):
 def _get_scope_and_section(args):
     """Extract config scope and section from arguments."""
     scope = args.scope
-    if hasattr(args, 'value'):
-        # take first element of value for commands that accept nested values
-        value = args.value
-        section = value[:value.find(':')] if ':' in value else value
-    else:
-        section = args.section
+    section = getattr(args, 'section', '')
 
     # w/no args and an active environment, point to env manifest
     if not section:
@@ -86,6 +82,11 @@ def _get_scope_and_section(args):
 
     # set scope defaults
     elif not scope:
+        # set section from value if the command takes a value
+        if hasattr(args, 'value'):
+            value = args.value
+            section = value[:value.find(':')] if ':' in value else value
+
         if section == 'compilers':
             scope = spack.config.default_modify_scope()
         else:
@@ -181,14 +182,14 @@ def config_add(args):
         test_existing = spack.config.get(test_path, scope=scope)
         if test_existing is None:
             path = test_path
-
             # We've nested further than existing config, so we need empty
             # get type to ensure we treat lists properly when empty
-            existing = type(spack.config.get(path, scope=None))()
+            existing = [] if isinstance(spack.config.get(path, scope=None), list) else None
             # construct value from this point down
             value = syaml.load(components[-1])
             for component in reversed(components[idx + 1:-1]):
                 value = {component: value}
+            break
 
     if path is None:
         path, _, value = args.value.rpartition(':')
@@ -196,7 +197,12 @@ def config_add(args):
         existing = spack.config.get(path, scope=scope)
 
     new = merge_value(existing, value)
-    spack.config.set(path, new, scope=scope)
+
+    if re.match(r'env.*', scope):
+        e = ev.get_env(args, 'config add')
+        e.set_config(path, new)
+    else:
+        spack.config.set(path, new, scope=scope)
 
 
 def config_remove(args):
@@ -221,7 +227,11 @@ def config_remove(args):
         # This should be impossible to reach
         raise spack.config.ConfigError('Config has nested non-dict values')
 
-    spack.config.set(path, new, scope=scope)
+    if re.match(r'env.*', scope):
+        e = ev.get_env(args, 'config remove')
+        e.set_config(path, new)
+    else:
+        spack.config.set(path, new, scope=scope)
 
 def config(parser, args):
     action = {'get': config_get,

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -62,7 +62,8 @@ def setup_parser(subparser):
                             help='configuration value to set. Nested values '
                             'separated by colons (:)')
 
-    remove_parser = sp.add_parser('remove', help='remove configuration parameters')
+    remove_parser = sp.add_parser('remove', aliases=['rm'],
+                                  help='remove configuration parameters')
     remove_parser.add_argument('value',
                             help='configuration value to remove. Nested values '
                             'separated by colons (:).')
@@ -227,5 +228,6 @@ def config(parser, args):
               'blame': config_blame,
               'edit': config_edit,
               'add': config_add,
+              'rm': config_remove,
               'remove': config_remove}
     action[args.config_command](args)

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -5,6 +5,8 @@
 
 from __future__ import print_function
 import os
+import six
+import json
 
 import llnl.util.tty as tty
 
@@ -56,20 +58,37 @@ def setup_parser(subparser):
         '--print-file', action='store_true',
         help="print the file name that would be edited")
 
+    add_parser = sp.add_parser('add', help='add configuration parameters')
+    add_parser.add_argument('value',
+                            help='configuration value to set. Nested values '
+                            'separated by colons (:) or pipes (|). The '
+                            'rightmost value delimited by pipes or colons '
+                            'can be any valid JSON. Use pipes as delimiters '
+                            'when inputting JSON dicts.')
+
+    remove_parser = sp.add_parser('remove', help='remove configuration parameters')
+    remove_parser.add_argument('value',
+                            help='configuration value to remove. Nested values '
+                            'separated by colons (:).')
 
 def _get_scope_and_section(args):
     """Extract config scope and section from arguments."""
     scope = args.scope
-    section = args.section
+    if hasattr(args, 'value'):
+        # take first element of value for commands that accept nested values
+        value = args.value
+        section = value[:value.find(':')] if ':' in value else value
+    else:
+        section = args.section
 
     # w/no args and an active environment, point to env manifest
-    if not args.section:
+    if not section:
         env = ev.get_env(args, 'config edit')
         if env:
             scope = env.env_file_config_scope_name()
 
     # set scope defaults
-    elif not args.scope:
+    elif not scope:
         if section == 'compilers':
             scope = spack.config.default_modify_scope()
         else:
@@ -127,8 +146,81 @@ def config_edit(args):
         editor(config_file)
 
 
+def config_add(args):
+    """Add the given configuration to the specified config scope
+
+    This is a stateful operation that edits the config files under the hood"""
+    scope, _ = _get_scope_and_section(args)
+
+    # allow '|' delimiter so that json dicts can be included
+    if '|' in args.value:
+        path, _, value = args.value.rpartition('|')
+        path = path.replace('|', ':')
+    else:
+        path, _, value = args.value.rpartition(':')
+
+    existing = spack.config.get(path, scope=scope)
+
+    # turn value into yaml
+    # TODO: Fix this to iterate over path
+    try:
+        value = json.loads(value)
+    except ValueError:
+        # strings without quotes become strings
+        pass
+
+    # dictionaries have special handling
+    if isinstance(value, dict) or isinstance(existing, dict):
+        if isinstance(value, dict) and isinstance(existing, dict):
+            if existing:
+                new = existing
+                new.update(value)
+            new = value
+        elif existing is None:
+            new = value
+        else:
+            raise spack.config.ConfigError(
+                'Cannot overwrite config dict with non-dict entry')
+
+    elif isinstance(existing, list):
+        if isinstance(value, list):
+            new = existing + value
+        else:
+            new = existing + [value]
+    else:
+        new = value
+
+    spack.config.set(path, new, scope=scope)
+
+
+def config_remove(args):
+    """Remove the given configuration from the specified config scope
+
+    This is a stateful operation that edits the config files under the hood"""
+    scope, _ = _get_scope_and_section(args)
+
+    path, _, value = args.value.rpartition(':')
+    existing = spack.config.get(path, scope=scope)
+
+    if not isinstance(existing, (list, dict)):
+        path, _, value = path.rpartition(':')
+        existing = spack.config.get(path, scope=scope)
+
+    if isinstance(existing, list):
+        new = [x for x in existing if x != value] if value else []
+    elif isinstance(existing, dict):
+        new = dict((k, v) for k, v in existing.items()
+                   if k != value) if value else {}
+    else:
+        # This should be impossible to reach
+        raise spack.config.ConfigError('Config has nested non-dict values')
+
+    spack.config.set(path, new, scope=scope)
+
 def config(parser, args):
     action = {'get': config_get,
               'blame': config_blame,
-              'edit': config_edit}
+              'edit': config_edit,
+              'add': config_add,
+              'remove': config_remove}
     action[args.config_command](args)

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -6,13 +6,12 @@
 from __future__ import print_function
 import os
 import six
-import json
 
 import llnl.util.tty as tty
 
 import spack.config
 import spack.environment as ev
-
+import spack.util.spack_yaml as syaml
 from spack.util.editor import editor
 
 description = "get and set configuration options"
@@ -61,10 +60,7 @@ def setup_parser(subparser):
     add_parser = sp.add_parser('add', help='add configuration parameters')
     add_parser.add_argument('value',
                             help='configuration value to set. Nested values '
-                            'separated by colons (:) or pipes (|). The '
-                            'rightmost value delimited by pipes or colons '
-                            'can be any valid JSON. Use pipes as delimiters '
-                            'when inputting JSON dicts.')
+                            'separated by colons (:)')
 
     remove_parser = sp.add_parser('remove', help='remove configuration parameters')
     remove_parser.add_argument('value',
@@ -146,29 +142,7 @@ def config_edit(args):
         editor(config_file)
 
 
-def config_add(args):
-    """Add the given configuration to the specified config scope
-
-    This is a stateful operation that edits the config files under the hood"""
-    scope, _ = _get_scope_and_section(args)
-
-    # allow '|' delimiter so that json dicts can be included
-    if '|' in args.value:
-        path, _, value = args.value.rpartition('|')
-        path = path.replace('|', ':')
-    else:
-        path, _, value = args.value.rpartition(':')
-
-    existing = spack.config.get(path, scope=scope)
-
-    # turn value into yaml
-    # TODO: Fix this to iterate over path
-    try:
-        value = json.loads(value)
-    except ValueError:
-        # strings without quotes become strings
-        pass
-
+def merge_value(existing, value):
     # dictionaries have special handling
     if isinstance(value, dict) or isinstance(existing, dict):
         if isinstance(value, dict) and isinstance(existing, dict):
@@ -190,6 +164,37 @@ def config_add(args):
     else:
         new = value
 
+    return new
+
+
+def config_add(args):
+    """Add the given configuration to the specified config scope
+
+    This is a stateful operation that edits the config files under the hood"""
+    scope, _ = _get_scope_and_section(args)
+
+    components = args.value.split(':')
+    path = None
+    for idx, name in enumerate(components[:-1]):
+        test_path = ':'.join(components[:idx + 1])
+        test_existing = spack.config.get(test_path, scope=scope)
+        if test_existing is None:
+            path = test_path
+
+            # We've nested further than existing config, so we need empty
+            # get type to ensure we treat lists properly when empty
+            existing = type(spack.config.get(path, scope=None))()
+            # construct value from this point down
+            value = syaml.load(components[-1])
+            for component in reversed(components[idx + 1:-1]):
+                value = {component: value}
+
+    if path is None:
+        path, _, value = args.value.rpartition(':')
+        value = syaml.load(value)
+        existing = spack.config.get(path, scope=scope)
+
+    new = merge_value(existing, value)
     spack.config.set(path, new, scope=scope)
 
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -148,12 +148,14 @@ class ConfigScope(object):
     def write_section(self, section):
         filename = self.get_section_filename(section)
         data = self.get_section(section)
-        validate(data, section_schemas[section])
+
+        # We copy data here to avoid adding defaults at write time
+        validate_data = copy.deepcopy(data)
+        validate(validate_data, section_schemas[section])
 
         try:
             mkdirp(self.path)
             with open(filename, 'w') as f:
-                validate(data, section_schemas[section])
                 syaml.dump_config(data, stream=f, default_flow_style=False)
         except (yaml.YAMLError, IOError) as e:
             raise ConfigFileError(

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -357,6 +357,14 @@ class Configuration(object):
         """Non-internal scope with highest precedence."""
         return next(reversed(self.file_scopes), None)
 
+    def highest_precedence_non_subscope(self):
+        """Non-internal scope with highest precedence that is not a subscope"""
+        generator = reversed(self.file_scopes)
+        highest = next(generator, None)
+        while highest and '/' in highest.name:
+            highest = next(generator, None)
+        return highest
+
     def matching_scopes(self, reg_expr):
         """
         List of all scopes whose names match the provided regular expression.
@@ -417,7 +425,12 @@ class Configuration(object):
         scope = self._validate_scope(scope)  # get ConfigScope object
 
         # read only the requested section's data.
-        scope.sections[section] = {section: update_data}
+        if section in scope.sections and scope.sections[section] is not None:
+            # don't overwrite yaml comment markings
+            scope.sections[section][section] = update_data
+        else:
+            scope.sections[section] = {section: update_data}
+
         scope.write_section(section)
 
     def get_config(self, section, scope=None):
@@ -779,6 +792,7 @@ def _merge_yaml(dest, source):
 
     # Source list is prepended (for precedence)
     if they_are(list):
+        # Make sure to copy ruamel comments
         dest[:] = source + [x for x in dest if x not in source]
         return dest
 
@@ -791,6 +805,7 @@ def _merge_yaml(dest, source):
             if _override(sk) or sk not in dest:
                 # if sk ended with ::, or if it's new, completely override
                 dest[sk] = copy.copy(sv)
+                # copy ruamel comments manually
             else:
                 # otherwise, merge the YAML
                 dest[sk] = _merge_yaml(dest[sk], source[sk])
@@ -821,14 +836,19 @@ def _merge_yaml(dest, source):
 #
 # Settings for commands that modify configuration
 #
-def default_modify_scope():
+def default_modify_scope(subscopes=True):
     """Return the config scope that commands should modify by default.
 
     Commands that modify configuration by default modify the *highest*
     priority scope.
-    """
-    return spack.config.config.highest_precedence_scope().name
 
+    Arguments:
+        subscopes (boolean): allow scopes that are subscopes. (Defaultv True)
+    """
+    if subscopes:
+        return spack.config.config.highest_precedence_scope().name
+    else:
+        return spack.config.config.highest_precedence_non_subscope().name
 
 def default_list_scope():
     """Return the config scope that is listed by default.

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -772,6 +772,15 @@ class Environment(object):
         """A list of all configuration scopes for this environment."""
         return self.included_config_scopes() + [self.env_file_config_scope()]
 
+    def set_config(self, path, value):
+        """Set configuration for this environment"""
+        yaml = config_dict(self.yaml)
+        keys = path.split(':')
+        for key in keys[:-1]:
+            yaml = yaml[key]
+        yaml[keys[-1]] = value
+        self.write()
+
     def destroy(self):
         """Remove this environment from Spack entirely."""
         shutil.rmtree(self.path)

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -12,7 +12,7 @@ import spack.environment as ev
 from spack.main import SpackCommand
 
 config = SpackCommand('config')
-
+env = SpackCommand('env')
 
 def test_get_config_scope(mock_config):
     assert config('get', 'compilers').strip() == 'compilers: {}'
@@ -91,3 +91,126 @@ def test_config_edit_fails_correctly_with_no_env(mutable_mock_env_path):
 def test_config_get_fails_correctly_with_no_env(mutable_mock_env_path):
     output = config('get', fail_on_error=False)
     assert "requires a section argument or an active environment" in output
+
+
+def test_config_add(mock_config):
+    config('add', 'config:dirty:true')
+    output = config('get', 'config')
+
+    assert output == """config:
+  dirty: true
+"""
+
+
+def test_config_add_list(mock_config):
+    config('add', 'config:template_dirs:test1')
+    config('add', 'config:template_dirs:[test2]')
+    config('add', 'config:template_dirs:test3')
+    output = config('get', 'config')
+
+    assert output == """config:
+  template_dirs:
+  - test1
+  - test2
+  - test3
+"""
+
+
+def test_config_add_update_dict(mock_config):
+    config('add', 'packages:all:compiler:[gcc]')  # TODO
+    config('add', 'packages:all:version:1.0.0')
+    output = config('get', 'packages')
+
+    assert output == """packages:
+  all:
+    version:
+    - 1.0.0
+    compiler:
+    - gcc
+"""
+
+
+def test_config_remove_value(mock_config):
+    config('add', 'config:dirty:true')
+    config('remove', 'config:dirty:true')
+    output = config('get', 'config')
+
+    assert output == """config: {}
+"""
+
+
+def test_config_remove_alias_rm(mock_config):
+    config('add', 'config:dirty:true')
+    config('rm', 'config:dirty:true')
+    output = config('get', 'config')
+
+    assert output == """config: {}
+"""
+
+
+def test_config_remove_dict(mock_config):
+    config('add', 'config:dirty:true')
+    config('rm', 'config:dirty')
+    output = config('get', 'config')
+
+    assert output == """config: {}
+"""
+
+
+def test_remove_from_list(mock_config):
+    config('add', 'config:template_dirs:test1')
+    config('add', 'config:template_dirs:[test2]')
+    config('add', 'config:template_dirs:test3')
+    config('remove', 'config:template_dirs:test2')
+    output = config('get', 'config')
+
+    assert output == """config:
+  template_dirs:
+  - test1
+  - test3
+"""
+
+
+def test_remove_list(mock_config):
+    config('add', 'config:template_dirs:test1')
+    config('add', 'config:template_dirs:[test2]')
+    config('add', 'config:template_dirs:test3')
+    config('remove', 'config:template_dirs:[test2]')
+    output = config('get', 'config')
+
+    assert output == """config:
+  template_dirs:
+  - test1
+  - test3
+"""
+
+
+def test_config_add_to_env(mock_config, mutable_mock_env_path):
+    env = ev.create('test')
+    with env:
+        config('add', 'config:dirty:true')
+        output = config('get')
+
+    expected = ev.default_manifest_yaml
+    expected += """  config:
+    dirty: true
+
+"""
+    assert output == expected
+
+
+def test_config_remove_from_env(mock_config, mutable_mock_env_path):
+    env('create', 'test')
+
+    with ev.read('test'):
+        config('add', 'config:dirty:true')
+
+    with ev.read('test'):
+        config('rm', 'config:dirty')
+        output = config('get')
+
+    expected = ev.default_manifest_yaml
+    expected += """  config: {}
+
+"""
+    assert output == expected


### PR DESCRIPTION
In this PR:

`spack config add <value>`: adds nested value `value` to the configuration scope specified.

For example:

#. in an environment `spack config add config:dirty:true` sets the `dirty` config value to True in the environment.
#. outside all environments, `spack config add packages:all:variants:~shared` sets the configuration to build all packages with a `shared` variant as `~shared`.

`spack config remove/rm`: Removes specified configuration from the relevant scope:

For example:

#. `spack config remove config:dirty:true` will remove `dirty:true` from the config file
#. `spack config remove config:dirty` will also remove `dirty:true` from the config file

Both the `spack config add` and `spack config remove` commands know to append to/remove from lists appropriately. However, if the heading under which the list appears does not yet exist in the config file, lists must be specified directly for the `spack config add` command.

I.E. if the `packages:all:compiler` entry already exists in the configuration file, the following are equivalent. If it does not exist, only the latter is valid.

`spack config add packages:all:compiler:gcc`
`spack config add packages:all:compiler:[gcc]`