### PR TITLE
Mass conversion of setup_(dependent_)?environment

### DIFF
--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -942,7 +942,7 @@ class IntelPackage(PackageBase):
         for key, value in wrapper_vars.items():
             env.set(key, value)
 
-        debug_print("adding to spack_env:", wrapper_vars)
+        debug_print("adding to build env:", wrapper_vars)
 
     # ---------------------------------------------------------------------
     # General support for child packages
@@ -1054,7 +1054,7 @@ class IntelPackage(PackageBase):
             env.append_path('SPACK_COMPILER_EXTRA_RPATHS',
                             env_mods['SPACK_COMPILER_EXTRA_RPATHS'])
 
-            debug_print("adding/modifying spack_env:", env_mods)
+            debug_print("adding/modifying build env:", env_mods)
 
         if '+mpi' in self.spec or self.provides('mpi'):
             if compilers_of_client:

--- a/lib/spack/spack/build_systems/octave.py
+++ b/lib/spack/spack/build_systems/octave.py
@@ -29,12 +29,11 @@ class OctavePackage(PackageBase):
     extends('octave')
     depends_on('octave', type=('build', 'run'))
 
-    def setup_environment(self, spack_env, run_env):
-        """Set up the compile and runtime environments for a package."""
+    def setup_build_environment(self, env):
         # octave does not like those environment variables to be set:
-        spack_env.unset('CC')
-        spack_env.unset('CXX')
-        spack_env.unset('FC')
+        env.unset('CC')
+        env.unset('CXX')
+        env.unset('FC')
 
     def install(self, spec, prefix):
         """Install the package from the archive file"""

--- a/lib/spack/spack/test/package_sanity.py
+++ b/lib/spack/spack/test/package_sanity.py
@@ -141,7 +141,6 @@ def test_all_packages_use_sha256_checksums():
     assert [] == errors
 
 
-@pytest.mark.xfail
 def test_api_for_build_and_run_environment():
     """Ensure that every package uses the correct API to set build and
     run environment, and not the old one.
@@ -154,7 +153,7 @@ def test_api_for_build_and_run_environment():
             failing.append(pkg)
 
     msg = ('there are {0} packages using the old API to set build '
-           'and run environment [{1}], for further information see'
+           'and run environment [{1}], for further information see '
            'https://github.com/spack/spack/pull/11115')
     assert not failing, msg.format(
         len(failing), ','.join(x.name for x in failing)
@@ -182,7 +181,9 @@ def test_prs_update_old_api():
             if failed:
                 failing.append(name)
 
-    msg = 'there are {0} packages still using old APIs in this PR [{1}]'
+    msg = ('there are {0} packages using the old API to set build '
+           'and run environment [{1}], for further information see '
+           'https://github.com/spack/spack/pull/11115')
     assert not failing, msg.format(
         len(failing), ','.join(failing)
     )

--- a/var/spack/repos/builtin/packages/amber/package.py
+++ b/var/spack/repos/builtin/packages/amber/package.py
@@ -40,11 +40,11 @@ class Amber(Package, CudaPackage):
     depends_on('py-matplotlib@:2.9', type=('build', 'run'))
     depends_on('zlib')
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_run_environment(self, env):
         sp_dir = join_path(self.prefix, 'python2.7/site-packages')
 
-        run_env.set('AMBERHOME', self.prefix)
-        run_env.prepend_path('PYTHONPATH', sp_dir)
+        env.set('AMBERHOME', self.prefix)
+        env.prepend_path('PYTHONPATH', sp_dir)
 
     def install(self, spec, prefix):
         # install AmberTools where it should be

--- a/var/spack/repos/builtin/packages/amrvis/package.py
+++ b/var/spack/repos/builtin/packages/amrvis/package.py
@@ -173,16 +173,16 @@ class Amrvis(MakefilePackage):
         with open('GNUmakefile', 'w') as file:
             file.writelines(contents)
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         # We don't want an AMREX_HOME the user may have set already
-        spack_env.unset('AMREX_HOME')
+        env.unset('AMREX_HOME')
         # Help force Amrvis to not pick up random system compilers
         if '+mpi' in self.spec:
-            spack_env.set('MPI_HOME', self.spec['mpi'].prefix)
-            spack_env.set('CC', self.spec['mpi'].mpicc)
-            spack_env.set('CXX', self.spec['mpi'].mpicxx)
-            spack_env.set('F77', self.spec['mpi'].mpif77)
-            spack_env.set('FC', self.spec['mpi'].mpifc)
+            env.set('MPI_HOME', self.spec['mpi'].prefix)
+            env.set('CC', self.spec['mpi'].mpicc)
+            env.set('CXX', self.spec['mpi'].mpicxx)
+            env.set('F77', self.spec['mpi'].mpif77)
+            env.set('FC', self.spec['mpi'].mpifc)
 
     def install(self, spec, prefix):
         # Install exe manually

--- a/var/spack/repos/builtin/packages/angsd/package.py
+++ b/var/spack/repos/builtin/packages/angsd/package.py
@@ -23,7 +23,7 @@ class Angsd(MakefilePackage):
     conflicts('^htslib@1.6:', when='@0.919')
 
     def setup_run_environment(self, env):
-        env.set('R_LIBS', prefix.R)
+        env.set('R_LIBS', self.prefix.R)
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin/packages/angsd/package.py
+++ b/var/spack/repos/builtin/packages/angsd/package.py
@@ -22,8 +22,8 @@ class Angsd(MakefilePackage):
     depends_on('htslib')
     conflicts('^htslib@1.6:', when='@0.919')
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.set('R_LIBS', prefix.R)
+    def setup_run_environment(self, env):
+        env.set('R_LIBS', prefix.R)
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin/packages/ants/package.py
+++ b/var/spack/repos/builtin/packages/ants/package.py
@@ -30,5 +30,5 @@ class Ants(CMakePackage):
             make("install")
         install_tree('Scripts', prefix.bin)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.set('ANTSPATH', self.prefix.bin)
+    def setup_run_environment(self, env):
+        env.set('ANTSPATH', self.prefix.bin)

--- a/var/spack/repos/builtin/packages/aspera-cli/package.py
+++ b/var/spack/repos/builtin/packages/aspera-cli/package.py
@@ -17,8 +17,8 @@ class AsperaCli(Package):
             url='https://download.asperasoft.com/download/sw/cli/3.7.7/aspera-cli-3.7.7.608.927cce8-linux-64-release.sh',
             expand=False)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PATH', self.prefix.cli.bin)
+    def setup_run_environment(self, env):
+        env.prepend_path('PATH', self.prefix.cli.bin)
 
     def install(self, spec, prefix):
         runfile = glob(join_path(self.stage.source_path, 'aspera-cli*.sh'))[0]

--- a/var/spack/repos/builtin/packages/astral/package.py
+++ b/var/spack/repos/builtin/packages/astral/package.py
@@ -44,5 +44,5 @@ class Astral(Package):
         filter_file('astral.jar', join_path(prefix.tools, jar_file),
                     script, **kwargs)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.set('ASTRAL_HOME', self.prefix.tools)
+    def setup_run_environment(self, env):
+        env.set('ASTRAL_HOME', self.prefix.tools)

--- a/var/spack/repos/builtin/packages/at-spi2-core/package.py
+++ b/var/spack/repos/builtin/packages/at-spi2-core/package.py
@@ -35,6 +35,6 @@ class AtSpi2Core(MesonPackage):
         url = 'http://ftp.gnome.org/pub/gnome/sources/at-spi2-core'
         return url + '/%s/at-spi2-core-%s.tar.xz' % (version.up_to(2), version)
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         # this avoids an "import site" error in the build
-        spack_env.unset('PYTHONHOME')
+        env.unset('PYTHONHOME')

--- a/var/spack/repos/builtin/packages/atk/package.py
+++ b/var/spack/repos/builtin/packages/atk/package.py
@@ -35,11 +35,11 @@ class Atk(Package):
         url = 'http://ftp.gnome.org/pub/gnome/sources/atk'
         return url + '/%s/atk-%s.tar.xz' % (version.up_to(2), version)
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        spack_env.prepend_path("XDG_DATA_DIRS",
-                               self.prefix.share)
-        run_env.prepend_path("XDG_DATA_DIRS",
-                             self.prefix.share)
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
 
     def install(self, spec, prefix):
         with working_dir('spack-build', create=True):

--- a/var/spack/repos/builtin/packages/bbmap/package.py
+++ b/var/spack/repos/builtin/packages/bbmap/package.py
@@ -20,6 +20,6 @@ class Bbmap(Package):
     def install(self, spec, prefix):
         install_tree('.', prefix.bin)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.set('BBMAP_CONFIG', self.prefix.bin.config)
-        run_env.set('BBMAP_RESOURCES', self.prefix.bin.resources)
+    def setup_run_environment(self, env):
+        env.set('BBMAP_CONFIG', self.prefix.bin.config)
+        env.set('BBMAP_RESOURCES', self.prefix.bin.resources)

--- a/var/spack/repos/builtin/packages/beast2/package.py
+++ b/var/spack/repos/builtin/packages/beast2/package.py
@@ -22,8 +22,8 @@ class Beast2(Package):
 
     depends_on('java')
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.set('BEAST', self.prefix)
+    def setup_run_environment(self, env):
+        env.set('BEAST', self.prefix)
 
     def install(self, spec, prefix):
         install_tree('bin', prefix.bin)

--- a/var/spack/repos/builtin/packages/blasr-libcpp/package.py
+++ b/var/spack/repos/builtin/packages/blasr-libcpp/package.py
@@ -45,10 +45,7 @@ class BlasrLibcpp(Package):
         install_tree('hdf', prefix.hdf)
         install_tree('pbdata', prefix.pbdata)
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        spack_env.prepend_path('LD_LIBRARY_PATH',
-                               self.spec.prefix.hdf)
-        spack_env.prepend_path('LD_LIBRARY_PATH',
-                               self.spec.prefix.alignment)
-        spack_env.prepend_path('LD_LIBRARY_PATH',
-                               self.spec.prefix.pbdata)
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.prepend_path('LD_LIBRARY_PATH', self.spec.prefix.hdf)
+        env.prepend_path('LD_LIBRARY_PATH', self.spec.prefix.alignment)
+        env.prepend_path('LD_LIBRARY_PATH', self.spec.prefix.pbdata)

--- a/var/spack/repos/builtin/packages/blasr/package.py
+++ b/var/spack/repos/builtin/packages/blasr/package.py
@@ -26,19 +26,19 @@ class Blasr(Package):
 
     phases = ['configure', 'build', 'install']
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PATH', self.spec.prefix.utils)
-        spack_env.prepend_path('CPATH', self.spec['blasr-libcpp'].prefix)
-        spack_env.prepend_path('CPATH', self.spec[
-                               'blasr-libcpp'].prefix.pbdata)
-        spack_env.prepend_path('CPATH', self.spec[
-                               'blasr-libcpp'].prefix.alignment)
-        spack_env.prepend_path('CPATH', self.spec['blasr-libcpp'].prefix.hdf)
+    def setup_build_environment(self, env):
+        env.prepend_path('CPATH', self.spec['blasr-libcpp'].prefix)
+        env.prepend_path('CPATH', self.spec['blasr-libcpp'].prefix.pbdata)
+        env.prepend_path('CPATH', self.spec['blasr-libcpp'].prefix.alignment)
+        env.prepend_path('CPATH', self.spec['blasr-libcpp'].prefix.hdf)
 
         # hdf has +mpi by default, so handle that possibility
         if ('+mpi' in self.spec['hdf5']):
-            spack_env.set('CC', self.spec['mpi'].mpicc)
-            spack_env.set('CXX', self.spec['mpi'].mpicxx)
+            env.set('CC', self.spec['mpi'].mpicc)
+            env.set('CXX', self.spec['mpi'].mpicxx)
+
+    def setup_run_environment(self, env):
+        env.prepend_path('PATH', self.spec.prefix.utils)
 
     def configure(self, spec, prefix):
         configure_args = [

--- a/var/spack/repos/builtin/packages/blat/package.py
+++ b/var/spack/repos/builtin/packages/blat/package.py
@@ -17,8 +17,8 @@ class Blat(Package):
 
     depends_on('libpng')
 
-    def setup_environment(self, spack_env, run_env):
-        spack_env.set('MACHTYPE', 'x86_64')
+    def setup_build_environment(self, env):
+        env.set('MACHTYPE', 'x86_64')
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin/packages/bohrium/package.py
+++ b/var/spack/repos/builtin/packages/bohrium/package.py
@@ -201,11 +201,11 @@ class Bohrium(CMakePackage, CudaPackage):
     #
     # Environment setup
     #
-    def setup_environment(self, spack_env, run_env):
+    def setup_run_environment(self, env):
         # Bohrium needs an extra include dir apart from
         # the self.prefix.include dir
-        run_env.prepend_path("CPATH", self.prefix.include.bohrium)
-        run_env.set("BH_CONFIG", self.config_file)
+        env.prepend_path("CPATH", self.prefix.include.bohrium)
+        env.set("BH_CONFIG", self.config_file)
 
     #
     # Quick tests

--- a/var/spack/repos/builtin/packages/braker/package.py
+++ b/var/spack/repos/builtin/packages/braker/package.py
@@ -62,5 +62,5 @@ class Braker(Package):
             for file in files:
                 filter_file(pattern, repl, *files, backup=False)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PERL5LIB', prefix.lib)
+    def setup_run_environment(self, env):
+        env.prepend_path('PERL5LIB', prefix.lib)

--- a/var/spack/repos/builtin/packages/braker/package.py
+++ b/var/spack/repos/builtin/packages/braker/package.py
@@ -63,4 +63,4 @@ class Braker(Package):
                 filter_file(pattern, repl, *files, backup=False)
 
     def setup_run_environment(self, env):
-        env.prepend_path('PERL5LIB', prefix.lib)
+        env.prepend_path('PERL5LIB', self.prefix.lib)

--- a/var/spack/repos/builtin/packages/breseq/package.py
+++ b/var/spack/repos/builtin/packages/breseq/package.py
@@ -30,8 +30,6 @@ class Breseq(AutotoolsPackage):
     conflicts('%gcc@:4.8')
     conflicts('%clang@:3.3')
 
-    def setup_environment(self, spack_env, run_env):
-        spack_env.set('LDFLAGS',
-                      "-L{0}".format(self.spec['zlib'].prefix.lib))
-        spack_env.set('CFLAGS',
-                      "-I{0}".format(self.spec['zlib'].prefix.include))
+    def setup_build_environment(self, env):
+        env.set('LDFLAGS', "-L{0}".format(self.spec['zlib'].prefix.lib))
+        env.set('CFLAGS', "-I{0}".format(self.spec['zlib'].prefix.include))

--- a/var/spack/repos/builtin/packages/casper/package.py
+++ b/var/spack/repos/builtin/packages/casper/package.py
@@ -25,5 +25,5 @@ class Casper(MakefilePackage):
     def install(self, spec, prefix):
         install_tree('.', prefix)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PATH', self.spec.prefix)
+    def setup_run_environment(self, env):
+        env.prepend_path('PATH', self.spec.prefix)

--- a/var/spack/repos/builtin/packages/catalyst/package.py
+++ b/var/spack/repos/builtin/packages/catalyst/package.py
@@ -148,7 +148,7 @@ class Catalyst(CMakePackage):
             tty.msg("Already generated %s in %s" % (self.name,
                                                     self.stage.source_path))
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_run_environment(self, env):
         # paraview 5.5 and later
         # - cmake under lib/cmake/paraview-5.5
         # - libs  under lib
@@ -160,18 +160,18 @@ class Catalyst(CMakePackage):
 
         if self.spec.version <= Version('5.4.1'):
             lib_dir = join_path(lib_dir, paraview_subdir)
-        run_env.set('ParaView_DIR', self.prefix)
-        run_env.prepend_path('LIBRARY_PATH', lib_dir)
-        run_env.prepend_path('LD_LIBRARY_PATH', lib_dir)
+        env.set('ParaView_DIR', self.prefix)
+        env.prepend_path('LIBRARY_PATH', lib_dir)
+        env.prepend_path('LD_LIBRARY_PATH', lib_dir)
 
         if '+python' in self.spec or '+python3' in self.spec:
             python_version = self.spec['python'].version.up_to(2)
-            run_env.prepend_path('PYTHONPATH', join_path(lib_dir,
-                                 'python{0}'.format(python_version),
-                                 'site-packages'))
+            env.prepend_path('PYTHONPATH', join_path(lib_dir,
+                             'python{0}'.format(python_version),
+                             'site-packages'))
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        spack_env.set('ParaView_DIR', self.prefix)
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.set('ParaView_DIR', self.prefix)
 
     @property
     def root_cmakelists_dir(self):

--- a/var/spack/repos/builtin/packages/cbench/package.py
+++ b/var/spack/repos/builtin/packages/cbench/package.py
@@ -31,27 +31,27 @@ class Cbench(MakefilePackage):
     conflicts('%xl')
     conflicts('%xl_r')
 
-    def setup_environment(self, build_env, run_env):
+    def setup_build_environment(self, env):
         # The location of the Cbench source tree
-        build_env.set('CBENCHOME', self.stage.source_path)
+        env.set('CBENCHOME', self.stage.source_path)
 
         # The location that will contain all of your tests and their results
-        build_env.set('CBENCHTEST', self.prefix)
+        env.set('CBENCHTEST', self.prefix)
 
         # The location of the system MPI tree
-        build_env.set('MPIHOME', self.spec['mpi'].prefix)
+        env.set('MPIHOME', self.spec['mpi'].prefix)
 
         # Pick the compiler collection/chain you want to compile with.
         # Examples include: intel, gcc, pgi.
-        build_env.set('COMPILERCOLLECTION', self.compiler.name)
+        env.set('COMPILERCOLLECTION', self.compiler.name)
 
         # Linking flags for BLAS/LAPACK and FFTW
-        build_env.set('BLASLIB', self.spec['blas'].libs.ld_flags)
-        build_env.set('LAPACKLIB', self.spec['lapack'].libs.ld_flags)
-        build_env.set('FFTWLIB', self.spec['fftw'].libs.ld_flags)
+        env.set('BLASLIB', self.spec['blas'].libs.ld_flags)
+        env.set('LAPACKLIB', self.spec['lapack'].libs.ld_flags)
+        env.set('FFTWLIB', self.spec['fftw'].libs.ld_flags)
 
         # The number of make jobs (commands) to run simultaneously
-        build_env.set('JOBS', str(make_jobs))
+        env.set('JOBS', str(make_jobs))
 
     @run_before('build')
     @on_package_attributes(run_tests=True)

--- a/var/spack/repos/builtin/packages/cdhit/package.py
+++ b/var/spack/repos/builtin/packages/cdhit/package.py
@@ -31,5 +31,5 @@ class Cdhit(MakefilePackage):
             make_args.append('zlib=no')
         make(*make_args)
 
-    def setup_environment(self, spack_env, run_env):
-        spack_env.set('PREFIX', prefix.bin)
+    def setup_build_environment(self, env):
+        env.set('PREFIX', prefix.bin)

--- a/var/spack/repos/builtin/packages/cdhit/package.py
+++ b/var/spack/repos/builtin/packages/cdhit/package.py
@@ -32,4 +32,4 @@ class Cdhit(MakefilePackage):
         make(*make_args)
 
     def setup_build_environment(self, env):
-        env.set('PREFIX', prefix.bin)
+        env.set('PREFIX', self.prefix.bin)

--- a/var/spack/repos/builtin/packages/charmpp/package.py
+++ b/var/spack/repos/builtin/packages/charmpp/package.py
@@ -82,17 +82,17 @@ class Charmpp(Package):
         provides('mpi@2', when='@6.7.1: build-target=AMPI backend={0}'.format(b))
         provides('mpi@2', when='@6.7.1: build-target=LIBS backend={0}'.format(b))
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        spack_env.set('MPICC',  join_path(self.prefix.bin, 'ampicc'))
-        spack_env.set('MPICXX', join_path(self.prefix.bin, 'ampicxx'))
-        spack_env.set('MPIF77', join_path(self.prefix.bin, 'ampif77'))
-        spack_env.set('MPIF90', join_path(self.prefix.bin, 'ampif90'))
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.set('MPICC',  self.prefix.bin.ampicc)
+        env.set('MPICXX', self.prefix.bin.ampicxx)
+        env.set('MPIF77', self.prefix.bin.ampif77)
+        env.set('MPIF90', self.prefix.bin.ampif90)
 
     def setup_dependent_package(self, module, dependent_spec):
-        self.spec.mpicc = join_path(self.prefix.bin, 'ampicc')
-        self.spec.mpicxx = join_path(self.prefix.bin, 'ampicxx')
-        self.spec.mpifc = join_path(self.prefix.bin, 'ampif90')
-        self.spec.mpif77 = join_path(self.prefix.bin, 'ampif77')
+        self.spec.mpicc  = self.prefix.bin.ampicc
+        self.spec.mpicxx = self.prefix.bin.ampicxx
+        self.spec.mpifc  = self.prefix.bin.ampif90
+        self.spec.mpif77 = self.prefix.bin.ampif77
 
     depends_on("mpi", when="backend=mpi")
     depends_on("papi", when="+papi")

--- a/var/spack/repos/builtin/packages/chill/package.py
+++ b/var/spack/repos/builtin/packages/chill/package.py
@@ -35,22 +35,27 @@ class Chill(AutotoolsPackage):
         bash = which('bash')
         bash('./bootstrap')
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         rose_home  = self.spec['rose'].prefix
         boost_home = self.spec['boost'].prefix
         iegen_home = self.spec['iegenlib'].prefix
 
-        spack_env.append_path('LD_LIBRARY_PATH', rose_home.lib)
-        spack_env.append_path('LD_LIBRARY_PATH', boost_home.lib)
-        spack_env.append_path('LD_LIBRARY_PATH', iegen_home.lib)
+        env.set('ROSEHOME', rose_home)
+        env.set('BOOSTHOME', boost_home)
+        env.set('IEGENHOME', iegen_home)
 
-        run_env.append_path('LD_LIBRARY_PATH', rose_home.lib)
-        run_env.append_path('LD_LIBRARY_PATH', boost_home.lib)
-        run_env.append_path('LD_LIBRARY_PATH', iegen_home.lib)
+        env.append_path('LD_LIBRARY_PATH', rose_home.lib)
+        env.append_path('LD_LIBRARY_PATH', boost_home.lib)
+        env.append_path('LD_LIBRARY_PATH', iegen_home.lib)
 
-        spack_env.set('ROSEHOME', rose_home)
-        spack_env.set('BOOSTHOME', boost_home)
-        spack_env.set('IEGENHOME', iegen_home)
+    def setup_run_environment(self, env):
+        rose_home  = self.spec['rose'].prefix
+        boost_home = self.spec['boost'].prefix
+        iegen_home = self.spec['iegenlib'].prefix
+
+        env.append_path('LD_LIBRARY_PATH', rose_home.lib)
+        env.append_path('LD_LIBRARY_PATH', boost_home.lib)
+        env.append_path('LD_LIBRARY_PATH', iegen_home.lib)
 
     def configure_args(self):
         args = ['--with-rose={0}'.format(self.spec['rose'].prefix),

--- a/var/spack/repos/builtin/packages/chlorop/package.py
+++ b/var/spack/repos/builtin/packages/chlorop/package.py
@@ -29,5 +29,5 @@ class Chlorop(Package):
         os.rename('chlorop', 'bin/chlorop')
         install_tree('.', prefix)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.set('CHLOROP', self.prefix)
+    def setup_run_environment(self, env):
+        env.set('CHLOROP', self.prefix)

--- a/var/spack/repos/builtin/packages/cinch/package.py
+++ b/var/spack/repos/builtin/packages/cinch/package.py
@@ -23,6 +23,6 @@ class Cinch(Package):
         # (CMake) Header Only library so just copy
         install_tree(self.stage.source_path, prefix)
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        spack_env.prepend_path('CMAKE_PREFIX_PATH', self.prefix)
-        spack_env.set('CINCH_SOURCE_DIR', self.prefix)
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.prepend_path('CMAKE_PREFIX_PATH', self.prefix)
+        env.set('CINCH_SOURCE_DIR', self.prefix)

--- a/var/spack/repos/builtin/packages/citcoms/package.py
+++ b/var/spack/repos/builtin/packages/citcoms/package.py
@@ -36,9 +36,9 @@ class Citcoms(AutotoolsPackage):
     conflicts('+pyre', when='@3.3:', msg='Pyre support was removed from 3.3+')
     conflicts('+exchanger', when='@3.3:', msg='Exchanger support was removed from 3.3+')
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         if '+ggrd' in self.spec:
-            spack_env.set('HC_HOME', self.spec['hc'].prefix)
+            env.set('HC_HOME', self.spec['hc'].prefix)
 
     def configure_args(self):
         args = ['CC={0}'.format(self.spec['mpi'].mpicc)]

--- a/var/spack/repos/builtin/packages/converge/package.py
+++ b/var/spack/repos/builtin/packages/converge/package.py
@@ -215,7 +215,7 @@ class Converge(Package):
             if not os.path.exists('make_surface'):
                 os.symlink(make_surface, 'make_surface')
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_run_environment(self, env):
         # CONVERGE searches for a valid license file in:
         #     $CONVERGE_ROOT/license/license.lic
-        run_env.set('CONVERGE_ROOT', self.prefix)
+        env.set('CONVERGE_ROOT', self.prefix)

--- a/var/spack/repos/builtin/packages/cppunit/package.py
+++ b/var/spack/repos/builtin/packages/cppunit/package.py
@@ -21,8 +21,8 @@ class Cppunit(AutotoolsPackage):
             multi=False,
             description='Use the specified C++ standard when building.')
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         cxxstd = self.spec.variants['cxxstd'].value
         cxxstdflag = '' if cxxstd == 'default' else \
                      getattr(self.compiler, 'cxx{0}_flag'.format(cxxstd))
-        spack_env.append_flags('CXXFLAGS', cxxstdflag)
+        env.append_flags('CXXFLAGS', cxxstdflag)

--- a/var/spack/repos/builtin/packages/cryptsetup/package.py
+++ b/var/spack/repos/builtin/packages/cryptsetup/package.py
@@ -47,7 +47,10 @@ class Cryptsetup(AutotoolsPackage):
         ]
         return args
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+    def setup_dependent_build_environment(self, env, dependent_spec):
         """Prepend the sbin directory to PATH."""
-        spack_env.prepend_path('PATH', self.prefix.sbin)
-        run_env.prepend_path('PATH', self.prefix.sbin)
+        env.prepend_path('PATH', self.prefix.sbin)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        """Prepend the sbin directory to PATH."""
+        env.prepend_path('PATH', self.prefix.sbin)

--- a/var/spack/repos/builtin/packages/darshan-runtime/package.py
+++ b/var/spack/repos/builtin/packages/darshan-runtime/package.py
@@ -54,7 +54,7 @@ class DarshanRuntime(Package):
             make()
             make('install')
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_run_environment(self, env):
         # default path for log file, could be user or site specific setting
-        darshan_log_dir = '%s' % os.environ['HOME']
-        run_env.set('DARSHAN_LOG_DIR_PATH', darshan_log_dir)
+        darshan_log_dir = os.environ['HOME']
+        env.set('DARSHAN_LOG_DIR_PATH', darshan_log_dir)

--- a/var/spack/repos/builtin/packages/dealii-parameter-gui/package.py
+++ b/var/spack/repos/builtin/packages/dealii-parameter-gui/package.py
@@ -17,5 +17,5 @@ class DealiiParameterGui(CMakePackage):
 
     depends_on('qt')
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.set('PARAMETER_GUI_DIR', self.prefix)
+    def setup_run_environment(self, env):
+        env.set('PARAMETER_GUI_DIR', self.prefix)

--- a/var/spack/repos/builtin/packages/deconseq-standalone/package.py
+++ b/var/spack/repos/builtin/packages/deconseq-standalone/package.py
@@ -37,5 +37,5 @@ class DeconseqStandalone(Package):
         chmod('+x', join_path(prefix.bin, 'deconseq.pl'))
         chmod('+x', join_path(prefix.bin, 'splitFasta.pl'))
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PERL5LIB', prefix)
+    def setup_run_environment(self, env):
+        env.prepend_path('PERL5LIB', self.prefix)

--- a/var/spack/repos/builtin/packages/dialign/package.py
+++ b/var/spack/repos/builtin/packages/dialign/package.py
@@ -24,5 +24,5 @@ class Dialign(MakefilePackage):
         mkdirp(prefix.share)
         install_tree('dialign2_dir', prefix.share)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.set('DIALIGN2_DIR', self.prefix.share)
+    def setup_run_environment(self, env):
+        env.set('DIALIGN2_DIR', self.prefix.share)

--- a/var/spack/repos/builtin/packages/dmd/package.py
+++ b/var/spack/repos/builtin/packages/dmd/package.py
@@ -32,10 +32,10 @@ class Dmd(MakefilePackage):
              sha256='71fa249dbfd278eec2b95ce577af32e623e44caf0d993905ddc189e3beec21d0',
              placement='tools')
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PATH', self.prefix.linux.bin64)
-        run_env.prepend_path('LIBRARY_PATH', self.prefix.linux.lib64)
-        run_env.prepend_path('LD_LIBRARY_PATH', self.prefix.linux.lib64)
+    def setup_run_environment(self, env):
+        env.prepend_path('PATH', self.prefix.linux.bin64)
+        env.prepend_path('LIBRARY_PATH', self.prefix.linux.lib64)
+        env.prepend_path('LD_LIBRARY_PATH', self.prefix.linux.lib64)
 
     def edit(self, spec, prefix):
         # Move contents to dmd/

--- a/var/spack/repos/builtin/packages/docbook-xsl/package.py
+++ b/var/spack/repos/builtin/packages/docbook-xsl/package.py
@@ -26,10 +26,10 @@ class DocbookXsl(Package):
     def catalog(self):
         return os.path.join(self.prefix, 'catalog.xml')
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_run_environment(self, env):
         catalog = self.catalog
-        run_env.set('XML_CATALOG_FILES', catalog, separator=' ')
+        env.set('XML_CATALOG_FILES', catalog, separator=' ')
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+    def setup_dependent_build_environment(self, env, dependent_spec):
         catalog = self.catalog
-        spack_env.prepend_path("XML_CATALOG_FILES", catalog)
+        env.prepend_path("XML_CATALOG_FILES", catalog)

--- a/var/spack/repos/builtin/packages/eclipse-gcj-parser/package.py
+++ b/var/spack/repos/builtin/packages/eclipse-gcj-parser/package.py
@@ -45,6 +45,3 @@ class EclipseGcjParser(Package):
     def install(self, spec, prefix):
         mkdirp(spec.prefix.bin)
         install('ecj1', spec.prefix.bin)
-
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PATH', self.prefix.bin)

--- a/var/spack/repos/builtin/packages/eigen/package.py
+++ b/var/spack/repos/builtin/packages/eigen/package.py
@@ -48,9 +48,8 @@ class Eigen(CMakePackage):
 
     patch('find-ptscotch.patch', when='@3.3.4')
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('CPATH',
-                             join_path(self.prefix, 'include', 'eigen3'))
+    def setup_run_environment(self, env):
+        env.prepend_path('CPATH', self.prefix.include.eigen3)
 
     @property
     def headers(self):

--- a/var/spack/repos/builtin/packages/everytrace-example/package.py
+++ b/var/spack/repos/builtin/packages/everytrace-example/package.py
@@ -18,6 +18,3 @@ class EverytraceExample(CMakePackage):
 
     # Currently the only MPI this everytrace works with.
     depends_on('openmpi')
-
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PATH', join_path(self.prefix, 'bin'))

--- a/var/spack/repos/builtin/packages/everytrace/package.py
+++ b/var/spack/repos/builtin/packages/everytrace/package.py
@@ -31,6 +31,3 @@ class Everytrace(CMakePackage):
             '-DUSE_MPI=%s' % ('YES' if '+mpi' in spec else 'NO'),
             '-DUSE_FORTRAN=%s' % ('YES' if '+fortran' in spec else 'NO'),
             '-DUSE_CXX=%s' % ('YES' if '+cxx' in spec else 'NO')]
-
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PATH', join_path(self.prefix, 'bin'))

--- a/var/spack/repos/builtin/packages/express/package.py
+++ b/var/spack/repos/builtin/packages/express/package.py
@@ -40,6 +40,6 @@ class Express(CMakePackage):
             edit.filter(r'\${CMAKE_CURRENT_SOURCE_DIR}/../bamtools/lib/'
                         'libbamtools.a', '%s' % self.spec['bamtools'].libs)
 
-    def setup_environment(self, spack_env, run_env):
-        spack_env.prepend_path('CPATH', self.spec[
-                               'bamtools'].prefix.include.bamtools)
+    def setup_build_environment(self, env):
+        env.prepend_path('CPATH',
+                         self.spec['bamtools'].prefix.include.bamtools)

--- a/var/spack/repos/builtin/packages/extrae/package.py
+++ b/var/spack/repos/builtin/packages/extrae/package.py
@@ -101,10 +101,10 @@ class Extrae(AutotoolsPackage):
             else:
                 make('install', parallel=False)
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_run_environment(self, env):
         # set EXTRAE_HOME in the module file
-        run_env.set('EXTRAE_HOME', self.prefix)
+        env.set('EXTRAE_HOME', self.prefix)
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+    def setup_dependent_build_environment(self, env, dependent_spec):
         # set EXTRAE_HOME for everyone using the Extrae package
-        spack_env.set('EXTRAE_HOME', self.prefix)
+        env.set('EXTRAE_HOME', self.prefix)

--- a/var/spack/repos/builtin/packages/fastqc/package.py
+++ b/var/spack/repos/builtin/packages/fastqc/package.py
@@ -34,8 +34,8 @@ class Fastqc(Package):
 
     # In theory the 'run' dependency on 'jdk' above should take
     # care of this for me. In practice, it does not.
-    def setup_environment(self, spack_env, run_env):
+    def setup_run_environment(self, env):
         """Add <prefix> to the path; the package has a script at the
            top level.
         """
-        run_env.prepend_path('PATH', self.spec['java'].prefix.bin)
+        env.prepend_path('PATH', self.spec['java'].prefix.bin)

--- a/var/spack/repos/builtin/packages/fgsl/package.py
+++ b/var/spack/repos/builtin/packages/fgsl/package.py
@@ -34,6 +34,6 @@ class Fgsl(AutotoolsPackage):
     def create_m4_dir(self):
         mkdir('m4')
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         if self.compiler.name == 'gcc':
-            spack_env.append_flags('FCFLAGS', "-ffree-line-length-none")
+            env.append_flags('FCFLAGS', "-ffree-line-length-none")

--- a/var/spack/repos/builtin/packages/flang/package.py
+++ b/var/spack/repos/builtin/packages/flang/package.py
@@ -71,9 +71,11 @@ class Flang(CMakePackage):
         chmod = which('chmod')
         chmod('+x', flang)
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         # to find llvm's libc++.so
-        spack_env.set('LD_LIBRARY_PATH', self.spec['llvm'].prefix.lib)
-        run_env.set('FC', join_path(self.spec.prefix.bin, 'flang'))
-        run_env.set('F77', join_path(self.spec.prefix.bin, 'flang'))
-        run_env.set('F90', join_path(self.spec.prefix.bin, 'flang'))
+        env.set('LD_LIBRARY_PATH', self.spec['llvm'].prefix.lib)
+
+    def setup_run_environment(self, env):
+        env.set('FC',  self.spec.prefix.bin.flang)
+        env.set('F77', self.spec.prefix.bin.flang)
+        env.set('F90', self.spec.prefix.bin.flang)

--- a/var/spack/repos/builtin/packages/foam-extend/package.py
+++ b/var/spack/repos/builtin/packages/foam-extend/package.py
@@ -118,7 +118,7 @@ class FoamExtend(Package):
     # - End of definitions / setup -
     #
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_run_environment(self, env):
         """Add environment variables to the generated module file.
         These environment variables come from running:
 
@@ -126,13 +126,6 @@ class FoamExtend(Package):
 
            $ . $WM_PROJECT_DIR/etc/bashrc
         """
-
-        # NOTE: Spack runs setup_environment twice.
-        # 1) pre-build to set up the build environment
-        # 2) post-install to determine runtime environment variables
-        # The etc/bashrc is only available (with corrrect content)
-        # post-installation.
-
         bashrc = join_path(self.projectdir, 'etc', 'bashrc')
         minimal = True
         if os.path.isfile(bashrc):
@@ -173,7 +166,7 @@ class FoamExtend(Package):
                         'PYTHON_BIN_DIR',
                     ])
 
-                run_env.extend(mods)
+                env.extend(mods)
                 minimal = False
                 tty.info('foam-extend env: {0}'.format(bashrc))
             except Exception:
@@ -182,19 +175,19 @@ class FoamExtend(Package):
         if minimal:
             # pre-build or minimal environment
             tty.info('foam-extend minimal env {0}'.format(self.prefix))
-            run_env.set('FOAM_INST_DIR', os.path.dirname(self.projectdir)),
-            run_env.set('FOAM_PROJECT_DIR', self.projectdir)
-            run_env.set('WM_PROJECT_DIR', self.projectdir)
+            env.set('FOAM_INST_DIR', os.path.dirname(self.projectdir)),
+            env.set('FOAM_PROJECT_DIR', self.projectdir)
+            env.set('WM_PROJECT_DIR', self.projectdir)
             for d in ['wmake', self.archbin]:  # bin added automatically
-                run_env.prepend_path('PATH', join_path(self.projectdir, d))
+                env.prepend_path('PATH', join_path(self.projectdir, d))
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+    def setup_dependent_build_environment(self, env, dependent_spec):
         """Location of the OpenFOAM project.
         This is identical to the WM_PROJECT_DIR value, but we avoid that
         variable since it would mask the normal OpenFOAM cleanup of
         previous versions.
         """
-        spack_env.set('FOAM_PROJECT_DIR', self.projectdir)
+        env.set('FOAM_PROJECT_DIR', self.projectdir)
 
     @property
     def projectdir(self):

--- a/var/spack/repos/builtin/packages/font-util/package.py
+++ b/var/spack/repos/builtin/packages/font-util/package.py
@@ -77,10 +77,9 @@ class FontUtil(AutotoolsPackage):
             default=','.join(fonts),
             multi=True)
 
-    def setup_environment(self, spack_env, run_env):
-        spack_env.prepend_path('PATH', self.prefix.bin)
-        spack_env.prepend_path('PKG_CONFIG_PATH',
-                               join_path(self.prefix.lib, 'pkgconfig'))
+    def setup_build_environment(self, env):
+        env.prepend_path('PATH', self.prefix.bin)
+        env.prepend_path('PKG_CONFIG_PATH', self.prefix.lib.pkgconfig)
 
     @run_after('install')
     def font_install(self):

--- a/var/spack/repos/builtin/packages/fsl/package.py
+++ b/var/spack/repos/builtin/packages/fsl/package.py
@@ -51,33 +51,33 @@ class Fsl(Package):
 
         install_tree('.', prefix)
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         if not self.stage.source_path:
             self.stage.fetch()
             self.stage.expand_archive()
 
-        spack_env.set('FSLDIR', self.stage.source_path)
-
-        # Here, run-time environment variables are being set manually.
-        # Normally these would be added to the modulefile at build-time
-        # by sourcing fsl.sh, but incorrect paths were being set, pointing to
-        # the staging directory rather than the install directory.
-        run_env.set('FSLDIR', self.prefix)
-        run_env.set('FSLOUTPUTTYPE', 'NIFTI_GZ')
-        run_env.set('FSLMULTIFILEQUIT', 'TRUE')
-        run_env.set('FSLTCLSH', self.prefix.bin.fsltclsh)
-        run_env.set('FSLWISH', self.prefix.bin.fslwish)
-        run_env.set('FSLLOCKDIR', '')
-        run_env.set('FSLMACHINELIST', '')
-        run_env.set('FSLREMOTECALL', '')
-        run_env.set('FSLGECUDAQ', 'cuda.q')
-
-        run_env.prepend_path('PATH', self.prefix)
+        env.set('FSLDIR', self.stage.source_path)
 
         # Below is for sourcing purposes during building
         fslsetup = join_path(self.stage.source_path, 'etc', 'fslconf',
                              'fsl.sh')
 
         if os.path.isfile(fslsetup):
-            spack_env.extend(EnvironmentModifications.from_sourcing_file(
-                             fslsetup))
+            env.extend(EnvironmentModifications.from_sourcing_file(fslsetup))
+
+    def setup_run_environment(self, env):
+        # Here, run-time environment variables are being set manually.
+        # Normally these would be added to the modulefile at build-time
+        # by sourcing fsl.sh, but incorrect paths were being set, pointing to
+        # the staging directory rather than the install directory.
+        env.set('FSLDIR', self.prefix)
+        env.set('FSLOUTPUTTYPE', 'NIFTI_GZ')
+        env.set('FSLMULTIFILEQUIT', 'TRUE')
+        env.set('FSLTCLSH', self.prefix.bin.fsltclsh)
+        env.set('FSLWISH', self.prefix.bin.fslwish)
+        env.set('FSLLOCKDIR', '')
+        env.set('FSLMACHINELIST', '')
+        env.set('FSLREMOTECALL', '')
+        env.set('FSLGECUDAQ', 'cuda.q')
+
+        env.prepend_path('PATH', self.prefix)

--- a/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
@@ -33,8 +33,8 @@ class FujitsuMpi(Package):
         self.spec.mpif77 = self.prefix.bin.mpifrt
         self.spec.mpifc = self.prefix.bin.mpifrt
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        spack_env.set('MPICC', self.prefix.bin.mpifcc)
-        spack_env.set('MPICXX', self.prefix.bin.mpiFCC)
-        spack_env.set('MPIF77', self.prefix.bin.mpifrt)
-        spack_env.set('MPIF90', self.prefix.bin.mpifrt)
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.set('MPICC', self.prefix.bin.mpifcc)
+        env.set('MPICXX', self.prefix.bin.mpiFCC)
+        env.set('MPIF77', self.prefix.bin.mpifrt)
+        env.set('MPIF90', self.prefix.bin.mpifrt)

--- a/var/spack/repos/builtin/packages/g4ensdfstate/package.py
+++ b/var/spack/repos/builtin/packages/g4ensdfstate/package.py
@@ -21,8 +21,8 @@ class G4ensdfstate(Package):
                                  .format(self.version))
         install_tree(self.stage.source_path, install_path)
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        run_env.set('G4ENSDFSTATEDATA', join_path(prefix.share, 'data'))
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        env.set('G4ENSDFSTATEDATA', self.prefix.share.data)
 
     def url_for_version(self, version):
         """Handle version string."""

--- a/var/spack/repos/builtin/packages/gams/package.py
+++ b/var/spack/repos/builtin/packages/gams/package.py
@@ -20,10 +20,9 @@ class Gams(Package):
     def url_for_version(self, version):
         return "file://{0}/linux_x64_64_sfx.exe".format(os.getcwd())
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path("PATH", join_path(self.prefix,
-                                               'gams{0}_linux_x64_64_sfx'
-                                               .format(self.version)))
+    def setup_run_environment(self, env):
+        env.prepend_path("PATH", join_path(
+            self.prefix, 'gams{0}_linux_x64_64_sfx'.format(self.version)))
 
     def install(self, spec, prefix):
         os.chmod(join_path(self.stage.source_path,

--- a/var/spack/repos/builtin/packages/gatk/package.py
+++ b/var/spack/repos/builtin/packages/gatk/package.py
@@ -87,7 +87,7 @@ class Gatk(Package):
                 **kwargs
             )
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path(
-            "GATK", join_path(self.prefix, "bin", "GenomeAnalysisTK.jar")
+    def setup_run_environment(self, env):
+        env.prepend_path(
+            "GATK", join_path(self.prefix.bin, "GenomeAnalysisTK.jar")
         )

--- a/var/spack/repos/builtin/packages/gaussian/package.py
+++ b/var/spack/repos/builtin/packages/gaussian/package.py
@@ -47,5 +47,5 @@ class Gaussian(Package):
         env.set('GAUSS_ARCHDIR', self.prefix.bin.arch)
         env.set('GAUSS_BSDDIR', self.prefix.bin.bsd)
         env.prepend_path('LD_LIBRARY_PATH', join_path(self.prefix.bin,
-                         'linda8.2/opteron-linux/lib'))
+                         'linda8.2', 'opteron-linux', 'lib'))
         env.prepend_path('LD_LIBRARY_PATH', self.prefix.bin)

--- a/var/spack/repos/builtin/packages/gaussian/package.py
+++ b/var/spack/repos/builtin/packages/gaussian/package.py
@@ -38,15 +38,14 @@ class Gaussian(Package):
                 filter_file('/usr/bin/linda', prefix.bin, join_path(prefix.bin,
                             filename), string='True')
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.set('g09root', self.prefix)
-        run_env.set('GAUSSIANHOME', self.prefix)
-        run_env.set('GAUSS_EXEDIR', self.prefix.bin)
-        run_env.set('G09_BASIS', join_path(self.prefix.bin, 'basis'))
-        run_env.set('GAUSS_LEXEDIR', join_path(self.prefix.bin,
-                    'linda-exe'))
-        run_env.set('GAUSS_ARCHDIR', join_path(self.prefix.bin, 'arch'))
-        run_env.set('GAUSS_BSDDIR', join_path(self.prefix.bin, 'bsd'))
-        run_env.prepend_path('LD_LIBRARY_PATH', join_path(self.prefix.bin,
-                             'linda8.2/opteron-linux/lib'))
-        run_env.prepend_path('LD_LIBRARY_PATH', self.prefix.bin)
+    def setup_run_environment(self, env):
+        env.set('g09root', self.prefix)
+        env.set('GAUSSIANHOME', self.prefix)
+        env.set('GAUSS_EXEDIR', self.prefix.bin)
+        env.set('G09_BASIS', self.prefix.bin.basis)
+        env.set('GAUSS_LEXEDIR', join_path(self.prefix.bin, 'linda-exe'))
+        env.set('GAUSS_ARCHDIR', self.prefix.bin.arch)
+        env.set('GAUSS_BSDDIR', self.prefix.bin.bsd)
+        env.prepend_path('LD_LIBRARY_PATH', join_path(self.prefix.bin,
+                         'linda8.2/opteron-linux/lib'))
+        env.prepend_path('LD_LIBRARY_PATH', self.prefix.bin)

--- a/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
+++ b/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
@@ -46,11 +46,11 @@ class GdkPixbuf(Package):
         url = "https://ftp.acc.umu.se/pub/gnome/sources/gdk-pixbuf/{0}/gdk-pixbuf-{1}.tar.xz"
         return url.format(version.up_to(2), version)
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        spack_env.prepend_path("XDG_DATA_DIRS",
-                               self.prefix.share)
-        run_env.prepend_path("XDG_DATA_DIRS",
-                             self.prefix.share)
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
 
     def install(self, spec, prefix):
         with working_dir('spack-build', create=True):
@@ -81,7 +81,7 @@ class GdkPixbuf(Package):
         if self.run_tests:
             make('installcheck')
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         # The "post-install.sh" script uses gdk-pixbuf-query-loaders,
         # which was installed earlier.
-        spack_env.prepend_path('PATH', self.prefix.bin)
+        env.prepend_path('PATH', self.prefix.bin)

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -145,7 +145,7 @@ class Geant4(CMakePackage):
                 target = os.readlink(d)
                 os.symlink(target, os.path.basename(target))
 
-    def setup_dependent_environment(self, spack_env, run_env, dep_spec):
+    def setup_dependent_build_environment(self, env, dependent_spec):
         version = self.version
         major = version[0]
         minor = version[1]
@@ -154,6 +154,5 @@ class Geant4(CMakePackage):
         else:
             patch = 0
         datadir = 'Geant4-%s.%s.%s' % (major, minor, patch)
-        spack_env.append_path('CMAKE_MODULE_PATH',
-                              '{0}/{1}/Modules'.format(
-                                  self.prefix.lib64, datadir))
+        env.append_path('CMAKE_MODULE_PATH', join_path(
+            self.prefix.lib64, datadir, 'Modules'))

--- a/var/spack/repos/builtin/packages/genemark-et/package.py
+++ b/var/spack/repos/builtin/packages/genemark-et/package.py
@@ -55,5 +55,5 @@ class GenemarkEt(Package):
             for file in files:
                 filter_file(pattern, repl, *files, backup=False)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PERL5LIB', prefix.lib)
+    def setup_run_environment(self, env):
+        env.prepend_path('PERL5LIB', prefix.lib)

--- a/var/spack/repos/builtin/packages/genemark-et/package.py
+++ b/var/spack/repos/builtin/packages/genemark-et/package.py
@@ -56,4 +56,4 @@ class GenemarkEt(Package):
                 filter_file(pattern, repl, *files, backup=False)
 
     def setup_run_environment(self, env):
-        env.prepend_path('PERL5LIB', prefix.lib)
+        env.prepend_path('PERL5LIB', self.prefix.lib)

--- a/var/spack/repos/builtin/packages/genometools/package.py
+++ b/var/spack/repos/builtin/packages/genometools/package.py
@@ -25,5 +25,5 @@ class Genometools(MakefilePackage):
     def install(self, spec, prefix):
         make('install', 'prefix=%s' % prefix)
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        spack_env.set('CPATH', self.prefix.include.genometools)
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.set('CPATH', self.prefix.include.genometools)

--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -185,13 +185,13 @@ class Git(AutotoolsPackage):
     depends_on('m4',       type='build')
     depends_on('tk',       type=('build', 'link'), when='+tcltk')
 
-    # See the comment in setup_environment re EXTLIBS.
+    # See the comment in setup_build_environment re EXTLIBS.
     def patch(self):
         filter_file(r'^EXTLIBS =$',
                     '#EXTLIBS =',
                     'Makefile')
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         # We use EXTLIBS rather than LDFLAGS so that git's Makefile
         # inserts the information into the proper place in the link commands
         # (alongside the # other libraries/paths that configure discovers).
@@ -204,9 +204,9 @@ class Git(AutotoolsPackage):
         # In that case the node in the DAG gets truncated and git DOES NOT
         # have a gettext dependency.
         if 'gettext' in self.spec:
-            spack_env.append_flags('EXTLIBS', '-L{0} -lintl'.format(
+            env.append_flags('EXTLIBS', '-L{0} -lintl'.format(
                 self.spec['gettext'].prefix.lib))
-            spack_env.append_flags('CFLAGS', '-I{0}'.format(
+            env.append_flags('CFLAGS', '-I{0}'.format(
                 self.spec['gettext'].prefix.include))
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/gnutls/package.py
+++ b/var/spack/repos/builtin/packages/gnutls/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-import os
 
 
 class Gnutls(AutotoolsPackage):
@@ -49,11 +48,10 @@ class Gnutls(AutotoolsPackage):
         url = "https://www.gnupg.org/ftp/gcrypt/gnutls/v{0}/gnutls-{1}.tar.xz"
         return url.format(version.up_to(2), version)
 
-    def setup_environment(self, build_env, run_env):
+    def setup_build_environment(self, env):
         spec = self.spec
         if '+guile' in spec:
-            build_env.set('GUILE', os.path.join(spec["guile"].prefix.bin,
-                                                'guile'))
+            env.set('GUILE', spec["guile"].prefix.bin.guile)
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/go-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/go-bootstrap/package.py
@@ -55,8 +55,8 @@ class GoBootstrap(Package):
 
         install_tree('.', prefix)
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        spack_env.set('GOROOT_BOOTSTRAP', self.spec.prefix)
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.set('GOROOT_BOOTSTRAP', self.spec.prefix)
 
-    def setup_environment(self, spack_env, run_env):
-        spack_env.set('GOROOT_FINAL', self.spec.prefix)
+    def setup_build_environment(self, env):
+        env.set('GOROOT_FINAL', self.spec.prefix)

--- a/var/spack/repos/builtin/packages/gobject-introspection/package.py
+++ b/var/spack/repos/builtin/packages/gobject-introspection/package.py
@@ -57,9 +57,11 @@ class GobjectIntrospection(Package):
         url = 'http://ftp.gnome.org/pub/gnome/sources/gobject-introspection/{0}/gobject-introspection-{1}.tar.xz'
         return url.format(version.up_to(2), version)
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        spack_env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
-        run_env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
 
     def install(self, spec, prefix):
         configure("--prefix=%s" % prefix)
@@ -69,5 +71,5 @@ class GobjectIntrospection(Package):
         make()
         make("install")
 
-    def setup_environment(self, spack_env, run_env):
-        spack_env.set('SPACK_SBANG', "%s/bin/sbang" % spack_root)
+    def setup_build_environment(self, env):
+        env.set('SPACK_SBANG', "%s/bin/sbang" % spack_root)

--- a/var/spack/repos/builtin/packages/gpu-burn/package.py
+++ b/var/spack/repos/builtin/packages/gpu-burn/package.py
@@ -51,5 +51,5 @@ class GpuBurn(MakefilePackage, CudaPackage):
     # The gpu_burn program looks for the compare.ptx file in the current
     # working directory. Create an environment variable that can be pointed to
     # so that it can be copied or linked.
-    def setup_environment(self, spack_env, run_env):
-        run_env.set('COMPARE_PTX', join_path(self.prefix.share, 'compare.ptx'))
+    def setup_run_environment(self, env):
+        env.set('COMPARE_PTX', join_path(self.prefix.share, 'compare.ptx'))

--- a/var/spack/repos/builtin/packages/grnboost/package.py
+++ b/var/spack/repos/builtin/packages/grnboost/package.py
@@ -25,16 +25,16 @@ class Grnboost(Package):
     depends_on('xgboost+jvm-packages', type='run')
     depends_on('spark+hadoop', type='run')
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_run_environment(self, env):
         grnboost_jar = join_path(self.prefix, 'target',
                                  'scala-2.11', 'GRNBoost.jar')
         xgboost_version = self.spec['xgboost'].version.string
         xgboost_jar = join_path(self.spec['xgboost'].prefix,
                                 'xgboost4j-' + xgboost_version + '.jar')
-        run_env.set('GRNBOOST_JAR', grnboost_jar)
-        run_env.set('JAVA_HOME', self.spec['java'].prefix)
-        run_env.set('CLASSPATH', xgboost_jar)
-        run_env.set('XGBOOST_JAR', xgboost_jar)
+        env.set('GRNBOOST_JAR', grnboost_jar)
+        env.set('JAVA_HOME', self.spec['java'].prefix)
+        env.set('CLASSPATH', xgboost_jar)
+        env.set('XGBOOST_JAR', xgboost_jar)
 
     def install(self, spec, prefix):
         sbt = which('sbt')

--- a/var/spack/repos/builtin/packages/gtkplus/package.py
+++ b/var/spack/repos/builtin/packages/gtkplus/package.py
@@ -48,11 +48,11 @@ class Gtkplus(AutotoolsPackage):
         filter_file(r'CFLAGS="-DGDK_PIXBUF_DISABLE_DEPRECATED $CFLAGS"',
                     '', 'configure', string=True)
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        spack_env.prepend_path("XDG_DATA_DIRS",
-                               self.prefix.share)
-        run_env.prepend_path("XDG_DATA_DIRS",
-                             self.prefix.share)
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
 
     def configure_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/gtksourceview/package.py
+++ b/var/spack/repos/builtin/packages/gtksourceview/package.py
@@ -42,13 +42,17 @@ class Gtksourceview(AutotoolsPackage):
         url += '{0}/gtksourceview-{1}.tar.xz'
         return url.format(version.up_to(2), version)
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        spack_env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
-        run_env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
 
-    def setup_environment(self, spack_env, run_env):
-        spack_env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
-        run_env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
+
+    def setup_build_environment(self, env):
+        env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
+
+    def setup_run_environment(self, env):
+        env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
 
     # TODO: If https://github.com/spack/spack/pull/12344 is merged, this
     # method is unnecessary.

--- a/var/spack/repos/builtin/packages/gurobi/package.py
+++ b/var/spack/repos/builtin/packages/gurobi/package.py
@@ -35,8 +35,8 @@ class Gurobi(Package):
     def url_for_version(self, version):
         return "file://{0}/gurobi{1}_linux64.tar.gz".format(os.getcwd(), version)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.set('GUROBI_HOME', self.prefix)
+    def setup_run_environment(self, env):
+        env.set('GUROBI_HOME', self.prefix)
 
     def install(self, spec, prefix):
         install_tree('linux64', prefix)

--- a/var/spack/repos/builtin/packages/hdf5-blosc/package.py
+++ b/var/spack/repos/builtin/packages/hdf5-blosc/package.py
@@ -183,10 +183,14 @@ Done.
                 raise RuntimeError("HDF5 Blosc plugin check failed")
         shutil.rmtree(checkdir)
 
-    def setup_environment(self, spack_env, run_env):
-        spack_env.append_path("HDF5_PLUGIN_PATH", self.spec.prefix.lib)
-        run_env.append_path("HDF5_PLUGIN_PATH", self.spec.prefix.lib)
+    def setup_build_environment(self, env):
+        env.append_path("HDF5_PLUGIN_PATH", self.spec.prefix.lib)
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        spack_env.append_path("HDF5_PLUGIN_PATH", self.spec.prefix.lib)
-        run_env.append_path("HDF5_PLUGIN_PATH", self.spec.prefix.lib)
+    def setup_run_environment(self, env):
+        env.append_path("HDF5_PLUGIN_PATH", self.spec.prefix.lib)
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.append_path("HDF5_PLUGIN_PATH", self.spec.prefix.lib)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        env.append_path("HDF5_PLUGIN_PATH", self.spec.prefix.lib)

--- a/var/spack/repos/builtin/packages/hisat2/package.py
+++ b/var/spack/repos/builtin/packages/hisat2/package.py
@@ -40,5 +40,5 @@ class Hisat2(MakefilePackage):
             if os.path.isfile(file):
                 install(file, prefix.bin)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PATH', self.spec.prefix)
+    def setup_run_environment(self, env):
+        env.prepend_path('PATH', self.spec.prefix)

--- a/var/spack/repos/builtin/packages/hybpiper/package.py
+++ b/var/spack/repos/builtin/packages/hybpiper/package.py
@@ -31,8 +31,8 @@ class Hybpiper(Package):
     depends_on('bwa')
     depends_on('samtools')
 
-    def setup_envionment(self, spack_env, run_env):
-        run_env.set('HYBPIPER_HOME', prefix)
+    def setup_run_environment(self, env):
+        env.set('HYBPIPER_HOME', self.prefix)
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin/packages/ibm-java/package.py
+++ b/var/spack/repos/builtin/packages/ibm-java/package.py
@@ -48,11 +48,11 @@ class IbmJava(Package):
     def libs(self):
         return find_libraries(['libjvm'], root=self.home, recursive=True)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.set('JAVA_HOME', self.home)
+    def setup_run_environment(self, env):
+        env.set('JAVA_HOME', self.home)
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        spack_env.set('JAVA_HOME', self.home)
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.set('JAVA_HOME', self.home)
 
     def setup_dependent_package(self, module, dependent_spec):
         self.spec.home = self.home

--- a/var/spack/repos/builtin/packages/icedtea/package.py
+++ b/var/spack/repos/builtin/packages/icedtea/package.py
@@ -153,18 +153,18 @@ class Icedtea(AutotoolsPackage):
         ]
         return args
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_run_environment(self, env):
         """Set JAVA_HOME."""
 
-        run_env.set('JAVA_HOME', self.home)
+        env.set('JAVA_HOME', self.home)
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+    def setup_dependent_build_environment(self, env, dependent_spec):
         """Set JAVA_HOME and CLASSPATH.
 
         CLASSPATH contains the installation prefix for the extension and any
         other Java extensions it depends on."""
 
-        spack_env.set('JAVA_HOME', self.home)
+        env.set('JAVA_HOME', self.home)
 
         class_paths = []
         for d in dependent_spec.traverse(deptype=('build', 'run', 'test')):
@@ -172,14 +172,19 @@ class Icedtea(AutotoolsPackage):
                 class_paths.extend(find(d.prefix, '*.jar'))
 
         classpath = os.pathsep.join(class_paths)
-        spack_env.set('CLASSPATH', classpath)
+        env.set('CLASSPATH', classpath)
 
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        """Set CLASSPATH.
+
+        CLASSPATH contains the installation prefix for the extension and any
+        other Java extensions it depends on."""
         # For runtime environment set only the path for
         # dependent_spec and prepend it to CLASSPATH
         if dependent_spec.package.extends(self.spec):
             class_paths = find(dependent_spec.prefix, '*.jar')
             classpath = os.pathsep.join(class_paths)
-            run_env.prepend_path('CLASSPATH', classpath)
+            env.prepend_path('CLASSPATH', classpath)
 
     def setup_dependent_package(self, module, dependent_spec):
         """Allows spec['java'].home to work."""

--- a/var/spack/repos/builtin/packages/icet/package.py
+++ b/var/spack/repos/builtin/packages/icet/package.py
@@ -22,6 +22,6 @@ class Icet(CMakePackage):
     def cmake_args(self):
         return ['-DICET_USE_OPENGL:BOOL=OFF']
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+    def setup_dependent_build_environment(self, env, dependent_spec):
         """Work-around for ill-placed CMake modules"""
-        spack_env.prepend_path('CMAKE_PREFIX_PATH', self.prefix.lib)
+        env.prepend_path('CMAKE_PREFIX_PATH', self.prefix.lib)

--- a/var/spack/repos/builtin/packages/jmol/package.py
+++ b/var/spack/repos/builtin/packages/jmol/package.py
@@ -20,6 +20,6 @@ class Jmol(Package):
     def install(self, spec, prefix):
         install_tree('jmol-{0}'.format(self.version), prefix)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PATH', self.prefix)
-        run_env.set('JMOL_HOME', self.prefix)
+    def setup_run_environment(self, env):
+        env.prepend_path('PATH', self.prefix)
+        env.set('JMOL_HOME', self.prefix)

--- a/var/spack/repos/builtin/packages/jube/package.py
+++ b/var/spack/repos/builtin/packages/jube/package.py
@@ -33,10 +33,7 @@ class Jube(PythonPackage):
 
     depends_on('py-setuptools', type='build')
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_run_environment(self, env):
         if not self.spec.variants['resource_manager'].value == 'none':
-            run_env.prepend_path(
-                'JUBE_INCLUDE_PATH',
-                prefix + "/platform/" +
-                self.spec.variants['resource_manager'].value
-            )
+            env.prepend_path('JUBE_INCLUDE_PATH', join_path(
+                prefix.platform, self.spec.variants['resource_manager'].value))

--- a/var/spack/repos/builtin/packages/jube/package.py
+++ b/var/spack/repos/builtin/packages/jube/package.py
@@ -36,4 +36,5 @@ class Jube(PythonPackage):
     def setup_run_environment(self, env):
         if not self.spec.variants['resource_manager'].value == 'none':
             env.prepend_path('JUBE_INCLUDE_PATH', join_path(
-                prefix.platform, self.spec.variants['resource_manager'].value))
+                self.prefix.platform,
+                self.spec.variants['resource_manager'].value))

--- a/var/spack/repos/builtin/packages/karma/package.py
+++ b/var/spack/repos/builtin/packages/karma/package.py
@@ -24,15 +24,11 @@ class Karma(Package):
     phases = ['install']
 
     resource(
-                name='karma-linux',
-                url='ftp://ftp.atnf.csiro.au/pub/software/karma/karma-1.7.25-amd64_Linux_libc6.3.tar.bz2',
-                sha256='effc3ed61c28b966b357147d90357d03c22d743c6af6edb49a863c6eb625a441',
-                destination='./'
-               )
-
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('LIBRARY_PATH', self.prefix.lib)
-        run_env.prepend_path('LD_LIBRARY_PATH', self.prefix.lib)
+        name='karma-linux',
+        url='ftp://ftp.atnf.csiro.au/pub/software/karma/karma-1.7.25-amd64_Linux_libc6.3.tar.bz2',
+        sha256='effc3ed61c28b966b357147d90357d03c22d743c6af6edb49a863c6eb625a441',
+        destination='./'
+    )
 
     def install(self, spec, prefix):
         install_tree('./karma-1.7.25/amd64_Linux_libc6.3/bin', prefix.bin)

--- a/var/spack/repos/builtin/packages/launchmon/package.py
+++ b/var/spack/repos/builtin/packages/launchmon/package.py
@@ -28,9 +28,9 @@ class Launchmon(AutotoolsPackage):
 
     patch('launchmon-char-conv.patch', when='@1.0.2')
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         if self.spec.satisfies('@master'):
             # automake for launchmon requires the AM_PATH_LIBGCRYPT macro
             # which is defined in libgcrypt.m4
-            spack_env.prepend_path('ACLOCAL_PATH',
-                                   self.spec['libgcrypt'].prefix.share.aclocal)
+            env.prepend_path('ACLOCAL_PATH',
+                             self.spec['libgcrypt'].prefix.share.aclocal)

--- a/var/spack/repos/builtin/packages/ldc-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/ldc-bootstrap/package.py
@@ -31,14 +31,14 @@ class LdcBootstrap(CMakePackage):
     depends_on('libedit')
     depends_on('binutils')
 
-    def setup_dependent_environment(self, build_env, run_env, dep_spec):
+    def setup_dependent_build_environment(self, env, dep_spec):
 
         # The code below relies on this function being executed after the
         # environment has been sanitized (because LD_LIBRARY_PATH is among
         # the variables that get unset)
 
         # We need libphobos in LD_LIBRARY_PATH
-        build_env.prepend_path('LD_LIBRARY_PATH', self.prefix.lib)
+        env.prepend_path('LD_LIBRARY_PATH', self.prefix.lib)
 
     def cmake_args(self):
         return [

--- a/var/spack/repos/builtin/packages/libfabric/package.py
+++ b/var/spack/repos/builtin/packages/libfabric/package.py
@@ -90,9 +90,9 @@ class Libfabric(AutotoolsPackage):
              sha256='3b78d0ca1b223ff21b7f5b3627e67e358e3c18b700f86b017e2233fee7e88c2e',
              placement='fabtests', when='@1.5.0')
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         if self.run_tests:
-            spack_env.prepend_path('PATH', self.prefix.bin)
+            env.prepend_path('PATH', self.prefix.bin)
 
     @when('@develop')
     def autoreconf(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/libint/package.py
+++ b/var/spack/repos/builtin/packages/libint/package.py
@@ -81,15 +81,15 @@ class Libint(AutotoolsPackage):
 
         return flags
 
-    def setup_environment(self, build_env, run_env):
+    def setup_build_environment(self, env):
         # Set optimization flags
-        build_env.set('CFLAGS', self.optflags)
-        build_env.set('CXXFLAGS', self.optflags)
+        env.set('CFLAGS', self.optflags)
+        env.set('CXXFLAGS', self.optflags)
 
         # Change AR to xiar if we compile with Intel and we
         # find the executable
         if '%intel' in self.spec and which('xiar'):
-            build_env.set('AR', 'xiar')
+            env.set('AR', 'xiar')
 
     def configure_args(self):
 

--- a/var/spack/repos/builtin/packages/libmesh/package.py
+++ b/var/spack/repos/builtin/packages/libmesh/package.py
@@ -245,5 +245,5 @@ class Libmesh(AutotoolsPackage):
 
         return options
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        spack_env.append_flags('PERL', self.spec['perl'].command.path)
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.append_flags('PERL', self.spec['perl'].command.path)

--- a/var/spack/repos/builtin/packages/libpeas/package.py
+++ b/var/spack/repos/builtin/packages/libpeas/package.py
@@ -44,11 +44,13 @@ class Libpeas(AutotoolsPackage):
         url += '{0}/libpeas-{1}.tar.xz'
         return url.format(version.up_to(2), version)
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        spack_env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
-        run_env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.prepend_path('XDG_DATA_DIRS', self.prefix.share)
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        env.prepend_path('XDG_DATA_DIRS', self.prefix.share)
+
+    def setup_build_environment(self, env):
         # Let
         #
         # python = self.spec['python']
@@ -76,10 +78,11 @@ class Libpeas(AutotoolsPackage):
         python_pc_file = os.path.join(python_prefix, 'python3.pc')
         python_ldflags = pkg_config('--libs', python_pc_file, output=str)
 
-        spack_env.append_path('LDFLAGS',
-                              python_ldflags)
-        spack_env.prepend_path('XDG_DATA_DIRS', self.prefix.share)
-        run_env.prepend_path('XDG_DATA_DIRS', self.prefix.share)
+        env.append_path('LDFLAGS', python_ldflags)
+        env.prepend_path('XDG_DATA_DIRS', self.prefix.share)
+
+    def setup_run_environment(self, env):
+        env.prepend_path('XDG_DATA_DIRS', self.prefix.share)
 
     def autoreconf(self, spec, prefix):
         autoreconf_args = ['-ivf']

--- a/var/spack/repos/builtin/packages/librsvg/package.py
+++ b/var/spack/repos/builtin/packages/librsvg/package.py
@@ -30,10 +30,14 @@ class Librsvg(AutotoolsPackage):
         url += "{0}/librsvg-{1}.tar.xz"
         return url.format(version.up_to(2), version)
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        spack_env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
-        run_env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.prepend_path('XDG_DATA_DIRS', self.prefix.share)
 
-    def setup_environment(self, spack_env, run_env):
-        spack_env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
-        run_env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        env.prepend_path('XDG_DATA_DIRS', self.prefix.share)
+
+    def setup_build_environment(self, env):
+        env.prepend_path('XDG_DATA_DIRS', self.prefix.share)
+
+    def setup_run_environment(self, env):
+        env.prepend_path('XDG_DATA_DIRS', self.prefix.share)

--- a/var/spack/repos/builtin/packages/libtool/package.py
+++ b/var/spack/repos/builtin/packages/libtool/package.py
@@ -37,9 +37,8 @@ class Libtool(AutotoolsPackage):
     def _make_executable(self, name):
         return Executable(join_path(self.prefix.bin, name))
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        spack_env.append_path('ACLOCAL_PATH',
-                              join_path(self.prefix.share, 'aclocal'))
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.append_path('ACLOCAL_PATH', self.prefix.share.aclocal)
 
     def setup_dependent_package(self, module, dependent_spec):
         # Automake is very likely to be a build dependency, so we add

--- a/var/spack/repos/builtin/packages/libx11/package.py
+++ b/var/spack/repos/builtin/packages/libx11/package.py
@@ -27,9 +27,11 @@ class Libx11(AutotoolsPackage):
     depends_on('util-macros', type='build')
     depends_on('perl', type='build')
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        spack_env.prepend_path('XLOCALEDIR', self.prefix.share.X11.locale)
-        run_env.prepend_path('XLOCALEDIR', self.prefix.share.X11.locale)
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.prepend_path('XLOCALEDIR', self.prefix.share.X11.locale)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        env.prepend_path('XLOCALEDIR', self.prefix.share.X11.locale)
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/libxc/package.py
+++ b/var/spack/repos/builtin/packages/libxc/package.py
@@ -49,7 +49,7 @@ class Libxc(AutotoolsPackage):
             libraries, root=self.prefix, shared=shared, recursive=True
         )
 
-    def setup_build_environment(self, spack_env):
+    def setup_build_environment(self, env):
         optflags = '-O2'
         if self.compiler.name == 'intel':
             # Optimizations for the Intel compiler, suggested by CP2K
@@ -76,10 +76,10 @@ class Libxc(AutotoolsPackage):
             #
             optflags += ' -xSSE4.2 -axAVX,CORE-AVX2 -ipo'
             if which('xiar'):
-                spack_env.set('AR', 'xiar')
+                env.set('AR', 'xiar')
 
-        spack_env.append_flags('CFLAGS',  optflags)
-        spack_env.append_flags('FCFLAGS', optflags)
+        env.append_flags('CFLAGS',  optflags)
+        env.append_flags('FCFLAGS', optflags)
 
     def configure_args(self):
         args = ['--enable-shared']

--- a/var/spack/repos/builtin/packages/libxpm/package.py
+++ b/var/spack/repos/builtin/packages/libxpm/package.py
@@ -26,10 +26,10 @@ class Libxpm(AutotoolsPackage):
     depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         # If libxpm is installed as an external package, gettext won't
         # be available in the spec. See
         # https://github.com/spack/spack/issues/9149 for details.
         if 'gettext' in self.spec:
-            spack_env.append_flags('LDFLAGS', '-L{0} -lintl'.format(
+            env.append_flags('LDFLAGS', '-L{0} -lintl'.format(
                 self.spec['gettext'].prefix.lib))

--- a/var/spack/repos/builtin/packages/linux-headers/package.py
+++ b/var/spack/repos/builtin/packages/linux-headers/package.py
@@ -16,11 +16,11 @@ class LinuxHeaders(Package):
 
     version('4.9.10', sha256='bd6e05476fd8d9ea4945e11598d87bc97806bbc8d03556abbaaf809707661525')
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         # This variable is used in the Makefile. If it is defined on the
         # system, it can break the build if there is no build recipe for
         # that specific ARCH
-        spack_env.unset('ARCH')
+        env.unset('ARCH')
 
     def install(self, spec, prefix):
         make('headers_install', 'INSTALL_HDR_PATH={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/lmod/package.py
+++ b/var/spack/repos/builtin/packages/lmod/package.py
@@ -48,10 +48,10 @@ class Lmod(AutotoolsPackage):
 
     parallel = False
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         stage_lua_path = join_path(
             self.stage.source_path, 'src', '?.lua')
-        spack_env.append_path('LUA_PATH', stage_lua_path.format(
+        env.append_path('LUA_PATH', stage_lua_path.format(
             version=self.version), separator=';')
 
     def patch(self):

--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -94,7 +94,7 @@ class Lua(Package):
         paths.append(os.path.join(path, '?', 'init.lua'))
         cpaths.append(os.path.join(path, '?.so'))
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+    def _setup_dependent_env_helper(self, env, dependent_spec):
         lua_paths = []
         for d in dependent_spec.traverse(
                 deptypes=('build', 'run'), deptype_query='run'):
@@ -115,38 +115,44 @@ class Lua(Package):
                   os.path.join(self.spec.prefix, self.lua_share_dir)):
             self.append_paths(lua_patterns, lua_cpatterns, p)
 
-        spack_env.set('LUA_PATH', ';'.join(lua_patterns), separator=';')
-        spack_env.set('LUA_CPATH', ';'.join(lua_cpatterns), separator=';')
+        return lua_patterns, lua_cpatterns
 
-        # Add LUA to PATH for dependent packages
-        spack_env.prepend_path('PATH', self.prefix.bin)
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        lua_patterns, lua_cpatterns = _setup_dependent_env_helper(
+            self, env, dependent_spec)
 
+        env.set('LUA_PATH', ';'.join(lua_patterns), separator=';')
+        env.set('LUA_CPATH', ';'.join(lua_cpatterns), separator=';')
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
         # For run time environment set only the path for dependent_spec and
         # prepend it to LUAPATH
-        if dependent_spec.package.extends(self.spec):
-            run_env.prepend_path('LUA_PATH', ';'.join(lua_patterns),
-                                 separator=';')
-            run_env.prepend_path('LUA_CPATH', ';'.join(lua_cpatterns),
-                                 separator=';')
+        lua_patterns, lua_cpatterns = _setup_dependent_env_helper(
+            self, env, dependent_spec)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path(
+        if dependent_spec.package.extends(self.spec):
+            env.prepend_path('LUA_PATH', ';'.join(lua_patterns), separator=';')
+            env.prepend_path('LUA_CPATH', ';'.join(lua_cpatterns),
+                             separator=';')
+
+    def setup_run_environment(self, env):
+        env.prepend_path(
             'LUA_PATH',
             os.path.join(self.spec.prefix, self.lua_share_dir, '?.lua'),
             separator=';')
-        run_env.prepend_path(
+        env.prepend_path(
             'LUA_PATH', os.path.join(self.spec.prefix, self.lua_share_dir, '?',
                                      'init.lua'),
             separator=';')
-        run_env.prepend_path(
+        env.prepend_path(
             'LUA_PATH',
             os.path.join(self.spec.prefix, self.lua_lib_dir, '?.lua'),
             separator=';')
-        run_env.prepend_path(
+        env.prepend_path(
             'LUA_PATH',
             os.path.join(self.spec.prefix, self.lua_lib_dir, '?', 'init.lua'),
             separator=';')
-        run_env.prepend_path(
+        env.prepend_path(
             'LUA_CPATH',
             os.path.join(self.spec.prefix, self.lua_lib_dir, '?.so'),
             separator=';')

--- a/var/spack/repos/builtin/packages/mc/package.py
+++ b/var/spack/repos/builtin/packages/mc/package.py
@@ -21,11 +21,11 @@ class Mc(AutotoolsPackage):
     depends_on('glib@2.14:')
     depends_on('libssh2@1.2.5:')
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         # Fix compilation bug on macOS by pretending we don't have utimensat()
         # https://github.com/MidnightCommander/mc/pull/130
         if 'darwin' in self.spec.architecture:
-            env['ac_cv_func_utimensat'] = 'no'
+            env.set('ac_cv_func_utimensat', 'no')
 
     def configure_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/mefit/package.py
+++ b/var/spack/repos/builtin/packages/mefit/package.py
@@ -23,5 +23,5 @@ class Mefit(Package):
     def install(self, spec, prefix):
         install_tree('.', prefix)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PATH', self.prefix)
+    def setup_run_environment(self, env):
+        env.prepend_path('PATH', self.prefix)

--- a/var/spack/repos/builtin/packages/memsurfer/package.py
+++ b/var/spack/repos/builtin/packages/memsurfer/package.py
@@ -41,8 +41,8 @@ class Memsurfer(PythonPackage):
     depends_on('hdf5 +hl')
 
     # memsurfer's setup needs path to these deps to build extension modules
-    def setup_environment(self, spack_env, run_env):
-        spack_env.set('VTK_ROOT', self.spec['vtk'].prefix)
-        spack_env.set('CGAL_ROOT', self.spec['cgal'].prefix)
-        spack_env.set('BOOST_ROOT', self.spec['boost'].prefix)
-        spack_env.set('EIGEN_ROOT', self.spec['eigen'].prefix)
+    def setup_build_environment(self, env):
+        env.set('VTK_ROOT', self.spec['vtk'].prefix)
+        env.set('CGAL_ROOT', self.spec['cgal'].prefix)
+        env.set('BOOST_ROOT', self.spec['boost'].prefix)
+        env.set('EIGEN_ROOT', self.spec['eigen'].prefix)

--- a/var/spack/repos/builtin/packages/meraculous/package.py
+++ b/var/spack/repos/builtin/packages/meraculous/package.py
@@ -28,6 +28,6 @@ class Meraculous(CMakePackage):
         edit = FileFilter('CMakeLists.txt')
         edit.filter(r"-static-libstdc\+\+", "")
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.set('MERACULOUS_ROOT', self.prefix)
-        run_env.prepend_path('PERL5LIB', self.prefix.lib)
+    def setup_run_environment(self, env):
+        env.set('MERACULOUS_ROOT', self.prefix)
+        env.prepend_path('PERL5LIB', self.prefix.lib)

--- a/var/spack/repos/builtin/packages/mercurial/package.py
+++ b/var/spack/repos/builtin/packages/mercurial/package.py
@@ -39,12 +39,12 @@ class Mercurial(PythonPackage):
     depends_on('py-pygments', type=('build', 'run'))
     depends_on('py-certifi',  type=('build', 'run'))
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         # Python 3 support is still experimental, explicitly allow
-        spack_env.set('HGALLOWPYTHON3', True)
-        spack_env.set('HGPYTHON3', True)
+        env.set('HGALLOWPYTHON3', True)
+        env.set('HGPYTHON3', True)
         # Setuptools is still opt-in, explicitly enable
-        spack_env.set('FORCE_SETUPTOOLS', True)
+        env.set('FORCE_SETUPTOOLS', True)
 
     @run_after('install')
     def post_install(self):

--- a/var/spack/repos/builtin/packages/microbiomeutil/package.py
+++ b/var/spack/repos/builtin/packages/microbiomeutil/package.py
@@ -27,8 +27,8 @@ class Microbiomeutil(MakefilePackage):
         install_tree('RESOURCES', prefix.resources)
         install_tree('AmosCmp16Spipeline', prefix.AmosCmp16Spipeline)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PATH', self.prefix.ChimeraSlayer)
-        run_env.prepend_path('PATH', join_path(self.prefix, 'NAST-iEr'))
-        run_env.prepend_path('PATH', self.prefix.TreeChopper)
-        run_env.prepend_path('PATH', self.prefix.WigeoN)
+    def setup_run_environment(self, env):
+        env.prepend_path('PATH', self.prefix.ChimeraSlayer)
+        env.prepend_path('PATH', join_path(self.prefix, 'NAST-iEr'))
+        env.prepend_path('PATH', self.prefix.TreeChopper)
+        env.prepend_path('PATH', self.prefix.WigeoN)

--- a/var/spack/repos/builtin/packages/mii/package.py
+++ b/var/spack/repos/builtin/packages/mii/package.py
@@ -21,5 +21,5 @@ class Mii(MakefilePackage):
     version('1.0.3', sha256='9b5a0e4e0961cf848677ed61b4f6c03e6a443f8592ed668d1afea302314b47a8')
     version('1.0.2', sha256='1c2c86ec37779ecd3821c30ce5b6dd19be4ec1813da41832d49ff3dcf615e22d')
 
-    def setup_environment(self, spack_env, run_env):
-        spack_env.set('PREFIX', self.prefix)
+    def setup_build_environment(self, env):
+        env.set('PREFIX', self.prefix)

--- a/var/spack/repos/builtin/packages/mitofates/package.py
+++ b/var/spack/repos/builtin/packages/mitofates/package.py
@@ -44,6 +44,6 @@ class Mitofates(Package):
         chmod = which('chmod')
         chmod('+x', join_path(prefix, 'MitoFates.pl'))
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_run_environment(self, env):
         # We want the main MitoFates.pl script in the path
-        run_env.prepend_path('PATH', self.prefix)
+        env.prepend_path('PATH', self.prefix)

--- a/var/spack/repos/builtin/packages/mixcr/package.py
+++ b/var/spack/repos/builtin/packages/mixcr/package.py
@@ -25,5 +25,5 @@ class Mixcr(Package):
     def install(self, spec, prefix):
         install_tree('.', prefix)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PATH', self.prefix)
+    def setup_run_environment(self, env):
+        env.prepend_path('PATH', self.prefix)

--- a/var/spack/repos/builtin/packages/mpest/package.py
+++ b/var/spack/repos/builtin/packages/mpest/package.py
@@ -24,8 +24,8 @@ class Mpest(MakefilePackage):
             mkdirp(prefix.bin)
             install('mpest', prefix.bin)
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         if self.spec.satisfies('platform=darwin'):
-            spack_env.set('ARCHITECTURE', 'mac')
+            env.set('ARCHITECTURE', 'mac')
         else:
-            spack_env.set('ARCHITECTURE', 'unix')
+            env.set('ARCHITECTURE', 'unix')

--- a/var/spack/repos/builtin/packages/mrtrix3/package.py
+++ b/var/spack/repos/builtin/packages/mrtrix3/package.py
@@ -35,5 +35,5 @@ class Mrtrix3(Package):
         build()
         install_tree('.', prefix)
 
-    def setup_environment(self, spac_env, run_env):
-        run_env.prepend_path('PATH', self.prefix)
+    def setup_run_environment(self, env):
+        env.prepend_path('PATH', self.prefix)

--- a/var/spack/repos/builtin/packages/mumps/package.py
+++ b/var/spack/repos/builtin/packages/mumps/package.py
@@ -55,11 +55,6 @@ class Mumps(Package):
     patch('examples.patch', when='@5.1.1%clang^spectrum-mpi')
     patch('gfortran8.patch', when='@5.1.2')
 
-    # this function is not a patch function because in case scalapack
-    # is needed it uses self.spec['scalapack'].fc_link set by the
-    # setup_dependent_environment in scalapck. This happen after patch
-    # end before install
-    # def patch(self):
     def write_makefile_inc(self):
         if ('+parmetis' in self.spec or '+ptscotch' in self.spec) and (
                 '+mpi' not in self.spec):

--- a/var/spack/repos/builtin/packages/mutationpp/package.py
+++ b/var/spack/repos/builtin/packages/mutationpp/package.py
@@ -40,12 +40,12 @@ class Mutationpp(CMakePackage):
         if '+examples' in self.spec and os.path.isdir('examples'):
             install_tree('examples', self.prefix.examples)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.set('MPP_DIRECTORY', self.prefix)
+    def setup_run_environment(self, env):
+        env.set('MPP_DIRECTORY', self.prefix)
         if os.path.isdir(self.prefix.data):
-            run_env.set('MPP_DATA_DIRECTORY', self.prefix.data)
+            env.set('MPP_DATA_DIRECTORY', self.prefix.data)
 
-    def setup_dependent_environment(self, spack_env, run_env):
-        spack_env.set('MPP_DIRECTORY', self.prefix)
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.set('MPP_DIRECTORY', self.prefix)
         if os.path.isdir(self.prefix.data):
-            spack_env.set('MPP_DATA_DIRECTORY', self.prefix.data)
+            env.set('MPP_DATA_DIRECTORY', self.prefix.data)

--- a/var/spack/repos/builtin/packages/mysql/package.py
+++ b/var/spack/repos/builtin/packages/mysql/package.py
@@ -122,7 +122,7 @@ class Mysql(CMakePackage):
             options.append('-DWITHOUT_SERVER:BOOL=ON')
         return options
 
-    def _fix_dtrace_shebang(self, build_env):
+    def _fix_dtrace_shebang(self, env):
         # dtrace may cause build to fail because it uses
         # '/usr/bin/python' in the shebang. To work around that we copy
         # the original script into a temporary folder, and change the
@@ -141,13 +141,7 @@ class Mysql(CMakePackage):
         )
         # To have our own copy of dtrace in PATH, we need to
         # prepend to PATH the temporary folder where it resides.
-        build_env.prepend_path('PATH', dtrace_copy_path)
-
-    @run_before('cmake')
-    def _maybe_fix_dtrace_shebang(self):
-        if 'python' in self.spec.flat_dependencies() and \
-           self.spec.satisfies('@:7.99.99'):
-            self._fix_dtrace_shebang(build_env)
+        env.prepend_path('PATH', dtrace_copy_path)
 
     def setup_build_environment(self, env):
         cxxstd = self.spec.variants['cxxstd'].value
@@ -160,3 +154,7 @@ class Mysql(CMakePackage):
                                  '-Wno-deprecated-declarations')
             if int(cxxstd) > 14:
                 env.append_flags('CXXFLAGS', '-Wno-error=register')
+
+        if 'python' in self.spec.flat_dependencies() and \
+           self.spec.satisfies('@:7.99.99'):
+            self._fix_dtrace_shebang(env)

--- a/var/spack/repos/builtin/packages/nag/package.py
+++ b/var/spack/repos/builtin/packages/nag/package.py
@@ -37,6 +37,6 @@ class Nag(Package):
         # Run install script
         os.system('./INSTALLU.sh')
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.set('F77', join_path(self.prefix.bin, 'nagfor'))
-        run_env.set('FC',  join_path(self.prefix.bin, 'nagfor'))
+    def setup_run_environment(self, env):
+        env.set('F77', self.prefix.bin.nagfor)
+        env.set('FC',  self.prefix.bin.nagfor)

--- a/var/spack/repos/builtin/packages/nest/package.py
+++ b/var/spack/repos/builtin/packages/nest/package.py
@@ -147,5 +147,5 @@ class Nest(CMakePackage):
                                   self.stage.source_path, recursive=True):
                 install(f, path_headers)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.set("NEST_INSTALL_DIR", self.spec.prefix)
+    def setup_run_environment(self, env):
+        env.set("NEST_INSTALL_DIR", self.spec.prefix)

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -189,14 +189,12 @@ class Neuron(Package):
             make('VERBOSE=1')
             make('install')
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_run_environment(self, env):
         neuron_archdir = self.get_neuron_archdir()
-        run_env.prepend_path('PATH', join_path(neuron_archdir, 'bin'))
-        run_env.prepend_path(
-            'LD_LIBRARY_PATH', join_path(neuron_archdir, 'lib'))
+        env.prepend_path('PATH', join_path(neuron_archdir, 'bin'))
+        env.prepend_path('LD_LIBRARY_PATH', join_path(neuron_archdir, 'lib'))
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+    def setup_dependent_build_environment(self, env, dependent_spec):
         neuron_archdir = self.get_neuron_archdir()
-        spack_env.prepend_path('PATH', join_path(neuron_archdir, 'bin'))
-        spack_env.prepend_path(
-            'LD_LIBRARY_PATH', join_path(neuron_archdir, 'lib'))
+        env.prepend_path('PATH', join_path(neuron_archdir, 'bin'))
+        env.prepend_path('LD_LIBRARY_PATH', join_path(neuron_archdir, 'lib'))

--- a/var/spack/repos/builtin/packages/nghttp2/package.py
+++ b/var/spack/repos/builtin/packages/nghttp2/package.py
@@ -23,15 +23,15 @@ class Nghttp2(AutotoolsPackage):
 
     def setup_build_environment(self, env):
         site_packages_dir = os.path.join(
-            [self.spec.prefix.lib,
-             ('python' + str(self.spec['python'].version.up_to(2))),
-             'site-packages'])
+            self.spec.prefix.lib,
+            'python' + str(self.spec['python'].version.up_to(2)),
+            'site-packages')
         env.prepend_path('PYTHONPATH', site_packages_dir)
 
     @run_before('install')
     def ensure_install_dir_exists(self):
         site_packages_dir = os.path.join(
-            [self.spec.prefix.lib,
-             ('python' + str(self.spec['python'].version.up_to(2))),
-             'site-packages'])
+            self.spec.prefix.lib,
+            'python' + str(self.spec['python'].version.up_to(2)),
+            'site-packages')
         mkdirp(site_packages_dir)

--- a/var/spack/repos/builtin/packages/nghttp2/package.py
+++ b/var/spack/repos/builtin/packages/nghttp2/package.py
@@ -5,6 +5,8 @@
 
 from spack import *
 
+import os
+
 
 class Nghttp2(AutotoolsPackage):
     """nghttp2 is an implementation of HTTP/2 and its header compression
@@ -19,16 +21,16 @@ class Nghttp2(AutotoolsPackage):
     depends_on('py-cython@0.19:', type=('build', 'run'))
     depends_on('py-setuptools', type=('build'))
 
-    def setup_environment(self, spack_env, run_env):
-        site_packages_dir = '/'.join(
+    def setup_build_environment(self, env):
+        site_packages_dir = os.path.join(
             [self.spec.prefix.lib,
              ('python' + str(self.spec['python'].version.up_to(2))),
              'site-packages'])
-        spack_env.prepend_path('PYTHONPATH', site_packages_dir)
+        env.prepend_path('PYTHONPATH', site_packages_dir)
 
     @run_before('install')
     def ensure_install_dir_exists(self):
-        site_packages_dir = '/'.join(
+        site_packages_dir = os.path.join(
             [self.spec.prefix.lib,
              ('python' + str(self.spec['python'].version.up_to(2))),
              'site-packages'])

--- a/var/spack/repos/builtin/packages/nginx/package.py
+++ b/var/spack/repos/builtin/packages/nginx/package.py
@@ -28,6 +28,6 @@ class Nginx(AutotoolsPackage):
         args = ['--with-http_ssl_module']
         return args
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_run_environment(self, env):
         """Prepend the sbin directory to PATH."""
-        run_env.prepend_path('PATH', join_path(self.prefix, 'sbin'))
+        env.prepend_path('PATH', self.prefix.sbin)

--- a/var/spack/repos/builtin/packages/npm/package.py
+++ b/var/spack/repos/builtin/packages/npm/package.py
@@ -19,9 +19,14 @@ class Npm(AutotoolsPackage):
 
     depends_on('node-js', type=('build', 'run'))
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+    def setup_dependent_build_environment(self, env, dependent_spec):
         npm_config_cache_dir = "%s/npm-cache" % dependent_spec.prefix
         if not os.path.isdir(npm_config_cache_dir):
             mkdir(npm_config_cache_dir)
-        run_env.set('npm_config_cache', npm_config_cache_dir)
-        spack_env.set('npm_config_cache', npm_config_cache_dir)
+        env.set('npm_config_cache', npm_config_cache_dir)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        npm_config_cache_dir = "%s/npm-cache" % dependent_spec.prefix
+        if not os.path.isdir(npm_config_cache_dir):
+            mkdir(npm_config_cache_dir)
+        env.set('npm_config_cache', npm_config_cache_dir)

--- a/var/spack/repos/builtin/packages/occa/package.py
+++ b/var/spack/repos/builtin/packages/occa/package.py
@@ -41,7 +41,7 @@ class Occa(Package):
     conflicts('%gcc@7:', when='^cuda@:9')
 
     def install(self, spec, prefix):
-        # The build environment is set by the 'setup_environment' method.
+        # The build environment is set by the 'setup_build_environment' method.
         # Copy the source to the installation directory and build OCCA there.
         install_tree('.', prefix)
         make('-C', prefix)
@@ -65,7 +65,7 @@ class Occa(Package):
             s_env.set('OCCA_CUDA_COMPILER',
                       join_path(cuda_dir, 'bin', 'nvcc'))
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         spec = self.spec
         # The environment variable CXX is automatically set to the Spack
         # compiler wrapper.
@@ -79,7 +79,7 @@ class Occa(Package):
         # the verbose output, so we keep both.
         cxxflags = spec.compiler_flags['cxxflags']
         if cxxflags:
-            spack_env.set('CXXFLAGS', ' '.join(cxxflags))
+            env.set('CXXFLAGS', ' '.join(cxxflags))
 
         # For the cuda, openmp, and opencl variants, set the environment
         # variable OCCA_{CUDA,OPENMP,OPENCL}_ENABLED only if the variant is
@@ -92,21 +92,23 @@ class Occa(Package):
                                        cuda_dir,
                                        shared=True,
                                        recursive=True)
-            spack_env.set('OCCA_INCLUDE_PATH', cuda_dir.include)
-            spack_env.set('OCCA_LIBRARY_PATH', ':'.join(cuda_libs.directories))
+            env.set('OCCA_INCLUDE_PATH', cuda_dir.include)
+            env.set('OCCA_LIBRARY_PATH', ':'.join(cuda_libs.directories))
         else:
-            spack_env.set('OCCA_CUDA_ENABLED', '0')
+            env.set('OCCA_CUDA_ENABLED', '0')
 
         if '~opencl' in spec:
-            spack_env.set('OCCA_OPENCL_ENABLED', '0')
+            env.set('OCCA_OPENCL_ENABLED', '0')
 
         # Setup run-time environment for testing.
-        spack_env.set('OCCA_VERBOSE', '1')
-        self._setup_runtime_flags(spack_env)
-        # The 'run_env' is included in the Spack generated module files.
-        self._setup_runtime_flags(run_env)
+        env.set('OCCA_VERBOSE', '1')
+        self._setup_runtime_flags(env)
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+    def setup_run_environment(self, env):
+        # The 'env' is included in the Spack generated module files.
+        self._setup_runtime_flags(env)
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
         # Export OCCA_* variables for everyone using this package from within
         # Spack.
-        self._setup_runtime_flags(spack_env)
+        self._setup_runtime_flags(env)

--- a/var/spack/repos/builtin/packages/opa-psm2/package.py
+++ b/var/spack/repos/builtin/packages/opa-psm2/package.py
@@ -35,12 +35,12 @@ class OpaPsm2(MakefilePackage):
     patch('opa-psm2-compiler.patch', when='@11.2.68:',
           sha256='fe31fda9aaee13acb87d178af2282446196d2cc0b21163034573706110b2e2d6')
 
-    def setup_environment(self, spack_env, run_env):
-        spack_env.set('DESTDIR', self.prefix)
+    def setup_build_environment(self, env):
+        env.set('DESTDIR', self.prefix)
         if '%intel' in self.spec:
             # this variable must be set when we use the Intel compilers to
             # ensure that the proper flags are set
-            spack_env.set('CCARCH', 'icc')
+            env.set('CCARCH', 'icc')
 
     def edit(self, spec, prefix):
         # Change the makefile so libraries and includes are not

--- a/var/spack/repos/builtin/packages/opam/package.py
+++ b/var/spack/repos/builtin/packages/opam/package.py
@@ -23,10 +23,10 @@ class Opam(AutotoolsPackage):
 
     parallel = False
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         # Environment variable setting taken from
         # https://github.com/Homebrew/homebrew-core/blob/master/Formula/opam.rb
-        spack_env.set('OCAMLPARAM', 'safe-string=0,_')  # OCaml 4.06.0 compat
+        env.set('OCAMLPARAM', 'safe-string=0,_')  # OCaml 4.06.0 compat
 
     def build(self, spec, prefix):
         make('lib-ext')

--- a/var/spack/repos/builtin/packages/openfoam-org/package.py
+++ b/var/spack/repos/builtin/packages/openfoam-org/package.py
@@ -126,24 +126,24 @@ class OpenfoamOrg(Package):
             settings['label-size'] = False
         return settings
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_run_environment(self, env):
         # This should be similar to the openfoam package,
         # but sourcing the etc/bashrc here seems to exit with an error.
         # ... this needs to be examined in more detail.
         #
         # Minimal environment only.
-        run_env.set('FOAM_PROJECT_DIR', self.projectdir)
-        run_env.set('WM_PROJECT_DIR', self.projectdir)
+        env.set('FOAM_PROJECT_DIR', self.projectdir)
+        env.set('WM_PROJECT_DIR', self.projectdir)
         for d in ['wmake', self.archbin]:  # bin already added automatically
-            run_env.prepend_path('PATH', join_path(self.projectdir, d))
+            env.prepend_path('PATH', join_path(self.projectdir, d))
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+    def setup_dependent_build_environment(self, env, dependent_spec):
         """Location of the OpenFOAM project directory.
         This is identical to the WM_PROJECT_DIR value, but we avoid that
         variable since it would mask the normal OpenFOAM cleanup of
         previous versions.
         """
-        spack_env.set('FOAM_PROJECT_DIR', self.projectdir)
+        env.set('FOAM_PROJECT_DIR', self.projectdir)
 
     @property
     def projectdir(self):

--- a/var/spack/repos/builtin/packages/openjdk/package.py
+++ b/var/spack/repos/builtin/packages/openjdk/package.py
@@ -83,18 +83,18 @@ class Openjdk(Package):
     def install(self, spec, prefix):
         install_tree('.', prefix)
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_run_environment(self, env):
         """Set JAVA_HOME."""
 
-        run_env.set('JAVA_HOME', self.home)
+        env.set('JAVA_HOME', self.home)
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+    def setup_dependent_build_environment(self, env, dependent_spec):
         """Set JAVA_HOME and CLASSPATH.
 
         CLASSPATH contains the installation prefix for the extension and any
         other Java extensions it depends on."""
 
-        spack_env.set('JAVA_HOME', self.home)
+        env.set('JAVA_HOME', self.home)
 
         class_paths = []
         for d in dependent_spec.traverse(deptype=('build', 'run', 'test')):
@@ -102,14 +102,15 @@ class Openjdk(Package):
                 class_paths.extend(find(d.prefix, '*.jar'))
 
         classpath = os.pathsep.join(class_paths)
-        spack_env.set('CLASSPATH', classpath)
+        env.set('CLASSPATH', classpath)
 
+    def setup_dependent_run_environment(self, env, dependent_spec):
         # For runtime environment set only the path for
         # dependent_spec and prepend it to CLASSPATH
         if dependent_spec.package.extends(self.spec):
             class_paths = find(dependent_spec.prefix, '*.jar')
             classpath = os.pathsep.join(class_paths)
-            run_env.prepend_path('CLASSPATH', classpath)
+            env.prepend_path('CLASSPATH', classpath)
 
     def setup_dependent_package(self, module, dependent_spec):
         """Allows spec['java'].home to work."""

--- a/var/spack/repos/builtin/packages/openjdk/package.py
+++ b/var/spack/repos/builtin/packages/openjdk/package.py
@@ -105,6 +105,10 @@ class Openjdk(Package):
         env.set('CLASSPATH', classpath)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
+        """Set CLASSPATH.
+
+        CLASSPATH contains the installation prefix for the extension and any
+        other Java extensions it depends on."""
         # For runtime environment set only the path for
         # dependent_spec and prepend it to CLASSPATH
         if dependent_spec.package.extends(self.spec):

--- a/var/spack/repos/builtin/packages/orthomcl/package.py
+++ b/var/spack/repos/builtin/packages/orthomcl/package.py
@@ -26,5 +26,5 @@ class Orthomcl(Package):
         install_tree('doc', prefix.doc)
         install_tree('lib', prefix.lib)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PERL5LIB', self.prefix.lib)
+    def setup_run_environment(self, env):
+        env.prepend_path('PERL5LIB', self.prefix.lib)

--- a/var/spack/repos/builtin/packages/osu-micro-benchmarks/package.py
+++ b/var/spack/repos/builtin/packages/osu-micro-benchmarks/package.py
@@ -46,9 +46,9 @@ class OsuMicroBenchmarks(AutotoolsPackage):
 
         return config_args
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_run_environment(self, env):
         mpidir = join_path(self.prefix.libexec, 'osu-micro-benchmarks', 'mpi')
-        run_env.prepend_path('PATH', join_path(mpidir, 'startup'))
-        run_env.prepend_path('PATH', join_path(mpidir, 'pt2pt'))
-        run_env.prepend_path('PATH', join_path(mpidir, 'one-sided'))
-        run_env.prepend_path('PATH', join_path(mpidir, 'collective'))
+        env.prepend_path('PATH', join_path(mpidir, 'startup'))
+        env.prepend_path('PATH', join_path(mpidir, 'pt2pt'))
+        env.prepend_path('PATH', join_path(mpidir, 'one-sided'))
+        env.prepend_path('PATH', join_path(mpidir, 'collective'))

--- a/var/spack/repos/builtin/packages/pango/package.py
+++ b/var/spack/repos/builtin/packages/pango/package.py
@@ -56,8 +56,8 @@ class Pango(AutotoolsPackage):
     def install(self, spec, prefix):
         make("install", parallel=False)
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        spack_env.prepend_path("XDG_DATA_DIRS",
-                               self.prefix.share)
-        run_env.prepend_path("XDG_DATA_DIRS",
-                             self.prefix.share)
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.prepend_path('XDG_DATA_DIRS', self.prefix.share)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        env.prepend_path('XDG_DATA_DIRS', self.prefix.share)

--- a/var/spack/repos/builtin/packages/pasta/package.py
+++ b/var/spack/repos/builtin/packages/pasta/package.py
@@ -25,9 +25,9 @@ class Pasta(Package):
         destination='.'
     )
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         tools = join_path(self.prefix, 'sate-tools-linux')
-        spack_env.set('PASTA_TOOLS_DEVDIR', tools)
+        env.set('PASTA_TOOLS_DEVDIR', tools)
 
     def install(self, spec, prefix):
         # build process for pasta is very hacky -- uses hard links to source

--- a/var/spack/repos/builtin/packages/pbbam/package.py
+++ b/var/spack/repos/builtin/packages/pbbam/package.py
@@ -38,6 +38,6 @@ class Pbbam(CMakePackage):
         install_tree('spack-build/lib', prefix.lib)
         install_tree('include/pbbam', prefix.include.pbbam)
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        spack_env.set('PacBioBAM_LIBRARIES', self.prefix.lib)
-        spack_env.set('PacBioBAM_INCLUDE_DIRS', self.prefix.include)
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.set('PacBioBAM_LIBRARIES', self.prefix.lib)
+        env.set('PacBioBAM_INCLUDE_DIRS', self.prefix.include)

--- a/var/spack/repos/builtin/packages/pbsuite/package.py
+++ b/var/spack/repos/builtin/packages/pbsuite/package.py
@@ -24,5 +24,5 @@ class Pbsuite(Package):
         install_tree('pbsuite', prefix.pbsuite)
         install_tree('bin', prefix.bin)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PYTHONPATH', self.prefix)
+    def setup_run_environment(self, env):
+        env.prepend_path('PYTHONPATH', self.prefix)

--- a/var/spack/repos/builtin/packages/pfunit/package.py
+++ b/var/spack/repos/builtin/packages/pfunit/package.py
@@ -82,12 +82,14 @@ class Pfunit(CMakePackage):
                 return value
         raise InstallError('Unsupported compiler.')
 
-    def setup_environment(self, spack_env, run_env):
-        spack_env.set('PFUNIT', self.spec.prefix)
-        run_env.set('PFUNIT', self.spec.prefix)
-        spack_env.set('F90_VENDOR', self.compiler_vendor())
-        run_env.set('F90_VENDOR', self.compiler_vendor())
+    def setup_build_environment(self, env):
+        env.set('PFUNIT', self.spec.prefix)
+        env.set('F90_VENDOR', self.compiler_vendor())
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        spack_env.set('PFUNIT', self.spec.prefix)
-        spack_env.set('F90_VENDOR', self.compiler_vendor())
+    def setup_run_environment(self, env):
+        env.set('PFUNIT', self.spec.prefix)
+        env.set('F90_VENDOR', self.compiler_vendor())
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.set('PFUNIT', self.spec.prefix)
+        env.set('F90_VENDOR', self.compiler_vendor())

--- a/var/spack/repos/builtin/packages/pgi/package.py
+++ b/var/spack/repos/builtin/packages/pgi/package.py
@@ -87,16 +87,10 @@ class Pgi(Package):
         # Run install script
         os.system("./install")
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_run_environment(self, env):
         prefix = Prefix(join_path(self.prefix, 'linux86-64', self.version))
 
-        run_env.set('CC',  join_path(prefix.bin, 'pgcc'))
-        run_env.set('CXX', join_path(prefix.bin, 'pgc++'))
-        run_env.set('F77', join_path(prefix.bin, 'pgfortran'))
-        run_env.set('FC',  join_path(prefix.bin, 'pgfortran'))
-
-        run_env.prepend_path('PATH',            prefix.bin)
-        run_env.prepend_path('CPATH',           prefix.include)
-        run_env.prepend_path('LIBRARY_PATH',    prefix.lib)
-        run_env.prepend_path('LD_LIBRARY_PATH', prefix.lib)
-        run_env.prepend_path('MANPATH',         prefix.man)
+        env.set('CC',  join_path(prefix.bin, 'pgcc'))
+        env.set('CXX', join_path(prefix.bin, 'pgc++'))
+        env.set('F77', join_path(prefix.bin, 'pgfortran'))
+        env.set('FC',  join_path(prefix.bin, 'pgfortran'))

--- a/var/spack/repos/builtin/packages/picard/package.py
+++ b/var/spack/repos/builtin/packages/picard/package.py
@@ -63,10 +63,9 @@ class Picard(Package):
         filter_file('picard.jar', join_path(prefix.bin, 'picard.jar'),
                     script, **kwargs)
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_run_environment(self, env):
         """The Picard docs suggest setting this as a convenience."""
-        run_env.prepend_path('PICARD',
-                             join_path(self.prefix, 'bin', 'picard.jar'))
+        env.prepend_path('PICARD', join_path(self.prefix.bin, 'picard.jar'))
 
     def url_for_version(self, version):
         if version < Version('2.6.0'):

--- a/var/spack/repos/builtin/packages/pkg-config/package.py
+++ b/var/spack/repos/builtin/packages/pkg-config/package.py
@@ -27,10 +27,9 @@ class PkgConfig(AutotoolsPackage):
 
     parallel = False
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+    def setup_dependent_build_environment(self, env, dependent_spec):
         """Adds the ACLOCAL path for autotools."""
-        spack_env.append_path('ACLOCAL_PATH',
-                              join_path(self.prefix.share, 'aclocal'))
+        env.append_path('ACLOCAL_PATH', self.prefix.share.aclocal)
 
     def configure_args(self):
         config_args = ['--enable-shared']

--- a/var/spack/repos/builtin/packages/pkgconf/package.py
+++ b/var/spack/repos/builtin/packages/pkgconf/package.py
@@ -30,10 +30,9 @@ class Pkgconf(AutotoolsPackage):
     # TODO: Add a package for the kyua testing framework
     # depends_on('kyua', type='test')
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+    def setup_dependent_build_environment(self, env, dependent_spec):
         """Adds the ACLOCAL path for autotools."""
-        spack_env.append_path('ACLOCAL_PATH',
-                              join_path(self.prefix.share, 'aclocal'))
+        env.append_path('ACLOCAL_PATH', self.prefix.share.aclocal)
 
     @run_after('install')
     def link_pkg_config(self):

--- a/var/spack/repos/builtin/packages/planck-likelihood/package.py
+++ b/var/spack/repos/builtin/packages/planck-likelihood/package.py
@@ -107,17 +107,15 @@ class PlanckLikelihood(Package):
         for dir in dirs:
             install_tree(dir, join_path(prefix, 'share', 'clik', dir))
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        prefix = self.prefix
-        spack_env.set('CLIK_PATH', prefix)
-        spack_env.set('CLIK_DATA', join_path(prefix, 'share', 'clik'))
-        spack_env.set('CLIK_PLUGIN', 'rel2015')
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.set('CLIK_PATH', self.prefix)
+        env.set('CLIK_DATA', self.prefix.share.clik)
+        env.set('CLIK_PLUGIN', 'rel2015')
 
-    def setup_environment(self, spack_env, run_env):
-        prefix = self.prefix
-        run_env.set('CLIK_PATH', prefix)
-        run_env.set('CLIK_DATA', join_path(prefix, 'share', 'clik'))
-        run_env.set('CLIK_PLUGIN', 'rel2015')
+    def setup_run_environment(self, env):
+        env.set('CLIK_PATH', self.prefix)
+        env.set('CLIK_DATA', self.prefix.share.clik)
+        env.set('CLIK_PLUGIN', 'rel2015')
 
     @run_after('install')
     @on_package_attributes(run_tests=True)

--- a/var/spack/repos/builtin/packages/postgresql/package.py
+++ b/var/spack/repos/builtin/packages/postgresql/package.py
@@ -87,25 +87,32 @@ class Postgresql(AutotoolsPackage):
         else:
             AutotoolsPackage.install(self, spec, prefix)
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_run_environment(self, env):
         spec = self.spec
 
         if '+perl' in spec:
-            run_env.prepend_path('PERL5LIB', self.prefix.lib)
+            env.prepend_path('PERL5LIB', self.prefix.lib)
         if '+tcl' in spec:
-            run_env.prepend_path('TCLLIBPATH', self.prefix.lib)
+            env.prepend_path('TCLLIBPATH', self.prefix.lib)
         if '+python' in spec:
-            run_env.prepend_path('PYTHONPATH', self.prefix.lib)
+            env.prepend_path('PYTHONPATH', self.prefix.lib)
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+    def setup_dependent_build_environment(self, env, dependent_spec):
         spec = self.spec
 
         if '+perl' in spec:
-            spack_env.prepend_path('PERL5LIB', self.prefix.lib)
-            run_env.prepend_path('PERL5LIB', self.prefix.lib)
+            env.prepend_path('PERL5LIB', self.prefix.lib)
         if '+tcl' in spec:
-            spack_env.prepend_path('TCLLIBPATH', self.prefix.lib)
-            run_env.prepend_path('TCLLIBPATH', self.prefix.lib)
+            env.prepend_path('TCLLIBPATH', self.prefix.lib)
         if '+python' in spec:
-            spack_env.prepend_path('PYTHONPATH', self.prefix.lib)
-            run_env.prepend_path('PYTHONPATH', self.prefix.lib)
+            env.prepend_path('PYTHONPATH', self.prefix.lib)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        spec = self.spec
+
+        if '+perl' in spec:
+            env.prepend_path('PERL5LIB', self.prefix.lib)
+        if '+tcl' in spec:
+            env.prepend_path('TCLLIBPATH', self.prefix.lib)
+        if '+python' in spec:
+            env.prepend_path('PYTHONPATH', self.prefix.lib)

--- a/var/spack/repos/builtin/packages/preseq/package.py
+++ b/var/spack/repos/builtin/packages/preseq/package.py
@@ -21,5 +21,5 @@ class Preseq(MakefilePackage):
     depends_on('samtools')
     depends_on('gsl')
 
-    def setup_environment(self, spack_env, run_env):
-        spack_env.set('PREFIX', self.prefix)
+    def setup_build_environment(self, env):
+        env.set('PREFIX', self.prefix)

--- a/var/spack/repos/builtin/packages/prodigal/package.py
+++ b/var/spack/repos/builtin/packages/prodigal/package.py
@@ -18,5 +18,5 @@ class Prodigal(MakefilePackage):
     def install(self, spec, prefix):
         make('INSTALLDIR={0}'.format(self.prefix), 'install')
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PATH', prefix)
+    def setup_run_environment(self, env):
+        env.prepend_path('PATH', self.prefix)

--- a/var/spack/repos/builtin/packages/psmc/package.py
+++ b/var/spack/repos/builtin/packages/psmc/package.py
@@ -17,8 +17,8 @@ class Psmc(MakefilePackage):
 
     depends_on('zlib', type='link')
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PATH', prefix.bin.utils)
+    def setup_run_environment(self, env):
+        env.prepend_path('PATH', self.prefix.bin.utils)
 
     def build(self, spec, prefix):
         make()

--- a/var/spack/repos/builtin/packages/pvm/package.py
+++ b/var/spack/repos/builtin/packages/pvm/package.py
@@ -38,7 +38,7 @@ class Pvm(MakefilePackage):
         install_tree(join_path('lib', pvm_arch), prefix.lib)
         install_tree('man', prefix.man)
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_run_environment(self, env):
         # Before running PVM, you must set the environment
         # variable "PVM_ROOT" to the path where PVM resides
-        run_env.set('PVM_ROOT', self.prefix)
+        env.set('PVM_ROOT', self.prefix)

--- a/var/spack/repos/builtin/packages/py-basemap/package.py
+++ b/var/spack/repos/builtin/packages/py-basemap/package.py
@@ -34,8 +34,8 @@ class PyBasemap(PythonPackage):
         else:
             return 'https://downloads.sourceforge.net/project/matplotlib/matplotlib-toolkits/basemap-{0}/basemap-{0}.tar.gz'.format(version)
 
-    def setup_environment(self, spack_env, run_env):
-        spack_env.set('GEOS_DIR', self.spec['geos'].prefix)
+    def setup_build_environment(self, env):
+        env.set('GEOS_DIR', self.spec['geos'].prefix)
 
     def install(self, spec, prefix):
         """Install everything from build directory."""

--- a/var/spack/repos/builtin/packages/py-cogent/package.py
+++ b/var/spack/repos/builtin/packages/py-cogent/package.py
@@ -13,7 +13,7 @@ class PyCogent(PythonPackage):
     url      = "https://pypi.io/packages/source/c/cogent/cogent-1.9.tar.gz"
 
     version('1.9', sha256='57d8c58e0273ffe4f2b907874f9b49dadfd0600f5507b7666369f4e44d56ce14')
-    version('1.5.3', url="https://pypi.io/packages/source/c/cogent/cogent-1.5.3.tgz", 
+    version('1.5.3', url="https://pypi.io/packages/source/c/cogent/cogent-1.5.3.tgz",
         sha256='1215ac219070b7b2207b0b47b4388510f3e30ccd88160aa9f02f25d24bcbcd95')
 
     variant('matplotlib', default=False, description="graphs related to codon usage")
@@ -30,5 +30,5 @@ class PyCogent(PythonPackage):
     depends_on('py-pymysql', when='+mysql', type=('build', 'run'))
     depends_on('py-cython@0.17.1:', type='build')
 
-    def setup_environment(self, spack_env, run_env):
-        spack_env.set('DONT_USE_PYREX', '1')
+    def setup_build_environment(self, env):
+        env.set('DONT_USE_PYREX', '1')

--- a/var/spack/repos/builtin/packages/py-cvxopt/package.py
+++ b/var/spack/repos/builtin/packages/py-cvxopt/package.py
@@ -37,85 +37,77 @@ class PyCvxopt(PythonPackage):
     # depends_on('mosek@8:',  when='+mosek')
     depends_on('dsdp@5.8:', when='+dsdp')
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         spec = self.spec
 
         # BLAS/LAPACK Libraries
 
         # Default names of BLAS and LAPACK libraries
-        spack_env.set('CVXOPT_BLAS_LIB', ';'.join(spec['blas'].libs.names))
-        spack_env.set('CVXOPT_LAPACK_LIB', ';'.join(spec['lapack'].libs.names))
+        env.set('CVXOPT_BLAS_LIB', ';'.join(spec['blas'].libs.names))
+        env.set('CVXOPT_LAPACK_LIB', ';'.join(spec['lapack'].libs.names))
 
         # Directory containing BLAS and LAPACK libraries
-        spack_env.set('CVXOPT_BLAS_LIB_DIR', spec['blas'].libs.directories[0])
+        env.set('CVXOPT_BLAS_LIB_DIR', spec['blas'].libs.directories[0])
 
         # SuiteSparse Libraries
 
         # Directory containing SuiteSparse libraries
-        spack_env.set('CVXOPT_SUITESPARSE_LIB_DIR',
-                      spec['suite-sparse'].libs.directories[0])
+        env.set('CVXOPT_SUITESPARSE_LIB_DIR',
+                spec['suite-sparse'].libs.directories[0])
 
         # Directory containing SuiteSparse header files
-        spack_env.set('CVXOPT_SUITESPARSE_INC_DIR',
-                      spec['suite-sparse'].headers.directories[0])
+        env.set('CVXOPT_SUITESPARSE_INC_DIR',
+                spec['suite-sparse'].headers.directories[0])
 
         # GSL Libraries
 
         if '+gsl' in spec:
-            spack_env.set('CVXOPT_BUILD_GSL', 1)
+            env.set('CVXOPT_BUILD_GSL', 1)
 
             # Directory containing libgsl
-            spack_env.set('CVXOPT_GSL_LIB_DIR',
-                          spec['gsl'].libs.directories[0])
+            env.set('CVXOPT_GSL_LIB_DIR', spec['gsl'].libs.directories[0])
 
             # Directory containing the GSL header files
-            spack_env.set('CVXOPT_GSL_INC_DIR',
-                          spec['gsl'].headers.directories[0])
+            env.set('CVXOPT_GSL_INC_DIR', spec['gsl'].headers.directories[0])
         else:
-            spack_env.set('CVXOPT_BUILD_GSL', 0)
+            env.set('CVXOPT_BUILD_GSL', 0)
 
         # FFTW Libraries
 
         if '+fftw' in spec:
-            spack_env.set('CVXOPT_BUILD_FFTW', 1)
+            env.set('CVXOPT_BUILD_FFTW', 1)
 
             # Directory containing libfftw3
-            spack_env.set('CVXOPT_FFTW_LIB_DIR',
-                          spec['fftw'].libs.directories[0])
+            env.set('CVXOPT_FFTW_LIB_DIR', spec['fftw'].libs.directories[0])
 
             # Directory containing fftw.h
-            spack_env.set('CVXOPT_FFTW_INC_DIR',
-                          spec['fftw'].headers.directories[0])
+            env.set('CVXOPT_FFTW_INC_DIR', spec['fftw'].headers.directories[0])
         else:
-            spack_env.set('CVXOPT_BUILD_FFTW', 0)
+            env.set('CVXOPT_BUILD_FFTW', 0)
 
         # GLPK Libraries
 
         if '+glpk' in spec:
-            spack_env.set('CVXOPT_BUILD_GLPK', 1)
+            env.set('CVXOPT_BUILD_GLPK', 1)
 
             # Directory containing libglpk
-            spack_env.set('CVXOPT_GLPK_LIB_DIR',
-                          spec['glpk'].libs.directories[0])
+            env.set('CVXOPT_GLPK_LIB_DIR', spec['glpk'].libs.directories[0])
 
             # Directory containing glpk.h
-            spack_env.set('CVXOPT_GLPK_INC_DIR',
-                          spec['glpk'].headers.directories[0])
+            env.set('CVXOPT_GLPK_INC_DIR', spec['glpk'].headers.directories[0])
         else:
-            spack_env.set('CVXOPT_BUILD_GLPK', 0)
+            env.set('CVXOPT_BUILD_GLPK', 0)
 
         # DSDP Libraries
 
         if '+dsdp' in spec:
-            spack_env.set('CVXOPT_BUILD_DSDP', 1)
+            env.set('CVXOPT_BUILD_DSDP', 1)
 
             # Directory containing libdsdp
-            spack_env.set('CVXOPT_DSDP_LIB_DIR',
-                          spec['dsdp'].libs.directories[0])
+            env.set('CVXOPT_DSDP_LIB_DIR', spec['dsdp'].libs.directories[0])
 
             # Directory containing dsdp5.h
-            spack_env.set('CVXOPT_DSDP_INC_DIR',
-                          spec['dsdp'].headers.directories[0])
+            env.set('CVXOPT_DSDP_INC_DIR', spec['dsdp'].headers.directories[0])
 
     @run_after('install')
     @on_package_attributes(run_tests=True)

--- a/var/spack/repos/builtin/packages/py-flye/package.py
+++ b/var/spack/repos/builtin/packages/py-flye/package.py
@@ -28,7 +28,7 @@ class PyFlye(PythonPackage):
     conflicts('%clang@:3.2', msg=msg)
     # Requires Apple Clang 5.0+ but no way to specify that right now
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         if self.spec.target.family == 'aarch64':
-            spack_env.set('arm_neon', '1')
-            spack_env.set('aarch64', '1')
+            env.set('arm_neon', '1')
+            env.set('aarch64', '1')

--- a/var/spack/repos/builtin/packages/py-git-review/package.py
+++ b/var/spack/repos/builtin/packages/py-git-review/package.py
@@ -23,5 +23,5 @@ class PyGitReview(PythonPackage):
     depends_on('git',              type=('run'))
     depends_on('tk',               type=('run'))
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.set('PBR_VERSION', str(self.spec.version))
+    def setup_run_environment(self, env):
+        env.set('PBR_VERSION', str(self.spec.version))

--- a/var/spack/repos/builtin/packages/py-pipits/package.py
+++ b/var/spack/repos/builtin/packages/py-pipits/package.py
@@ -57,15 +57,15 @@ class PyPipits(PythonPackage):
         install_tree(join_path(self.stage.source_path, 'refdb'),
                      self.prefix.refdb)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.set('PIPITS_UNITE_REFERENCE_DATA_CHIMERA', join_path(
-                    self.prefix, 'refdb',
-                    'uchime_reference_dataset_01.01.2016',
-                    'uchime_reference_dataset_01.01.2016.fasta'))
-        run_env.set('PIPITS_UNITE_RETRAINED_DIR',
-                    self.prefix.refdb.UNITE_retrained)
-        run_env.set('PIPITS_WARCUP_RETRAINED_DIR',
-                    self.prefix.refdb.warcup_retrained_V2)
-        run_env.set('PIPITS_RDP_CLASSIFIER_JAR', join_path(
-                    self.spec['rdp-classifier'].prefix.bin,
-                    'classifier.jar'))
+    def setup_run_environment(self, env):
+        env.set('PIPITS_UNITE_REFERENCE_DATA_CHIMERA', join_path(
+                self.prefix, 'refdb',
+                'uchime_reference_dataset_01.01.2016',
+                'uchime_reference_dataset_01.01.2016.fasta'))
+        env.set('PIPITS_UNITE_RETRAINED_DIR',
+                self.prefix.refdb.UNITE_retrained)
+        env.set('PIPITS_WARCUP_RETRAINED_DIR',
+                self.prefix.refdb.warcup_retrained_V2)
+        env.set('PIPITS_RDP_CLASSIFIER_JAR', join_path(
+                self.spec['rdp-classifier'].prefix.bin,
+                'classifier.jar'))

--- a/var/spack/repos/builtin/packages/py-psyclone/package.py
+++ b/var/spack/repos/builtin/packages/py-psyclone/package.py
@@ -38,6 +38,6 @@ class PyPsyclone(PythonPackage):
         with working_dir('src'):
             Executable('py.test')()
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         # Allow testing with installed executables:
-        spack_env.prepend_path('PATH', self.prefix.bin)
+        env.prepend_path('PATH', self.prefix.bin)

--- a/var/spack/repos/builtin/packages/py-pyproj/package.py
+++ b/var/spack/repos/builtin/packages/py-pyproj/package.py
@@ -30,5 +30,5 @@ class PyPyproj(PythonPackage):
     depends_on('proj@6.1:', when='@2.2:')
     depends_on('proj@6.0:', when='@2.0:')
 
-    def setup_environment(self, spack_env, run_env):
-        spack_env.set('PROJ_DIR', self.spec['proj'].prefix)
+    def setup_build_environment(self, env):
+        env.set('PROJ_DIR', self.spec['proj'].prefix)

--- a/var/spack/repos/builtin/packages/py-rtree/package.py
+++ b/var/spack/repos/builtin/packages/py-rtree/package.py
@@ -16,9 +16,9 @@ class PyRtree(PythonPackage):
     depends_on('py-setuptools', type='build')
     depends_on('libspatialindex')
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         lib = self.spec['libspatialindex'].prefix.lib
-        spack_env.set('SPATIALINDEX_LIBRARY',
-                      join_path(lib, 'libspatialindex.%s'   % dso_suffix))
-        spack_env.set('SPATIALINDEX_C_LIBRARY',
-                      join_path(lib, 'libspatialindex_c.%s' % dso_suffix))
+        env.set('SPATIALINDEX_LIBRARY',
+                join_path(lib, 'libspatialindex.%s'   % dso_suffix))
+        env.set('SPATIALINDEX_C_LIBRARY',
+                join_path(lib, 'libspatialindex_c.%s' % dso_suffix))

--- a/var/spack/repos/builtin/packages/py-shapely/package.py
+++ b/var/spack/repos/builtin/packages/py-shapely/package.py
@@ -30,6 +30,6 @@ class PyShapely(PythonPackage):
     depends_on('geos@3.3:', when='@1.3:')
     depends_on('py-pytest', type='test')
 
-    def setup_environment(self, spack_env, run_env):
-        spack_env.set('GEOS_CONFIG',
-                      join_path(self.spec['geos'].prefix.bin, 'geos-config'))
+    def setup_build_environment(self, env):
+        env.set('GEOS_CONFIG',
+                join_path(self.spec['geos'].prefix.bin, 'geos-config'))

--- a/var/spack/repos/builtin/packages/qbank/package.py
+++ b/var/spack/repos/builtin/packages/qbank/package.py
@@ -36,11 +36,9 @@ class Qbank(Package):
     phases = ['configure', 'build', 'install']
 
     def configure_args(self):
-        prefix = self.prefix
-
         config_args = [
-            '--prefix', prefix,
-            '--logdir', join_path(prefix, 'var', 'log', 'qbank')
+            '--prefix', self.prefix,
+            '--logdir', self.prefix.var.log.qbank
         ]
 
         return config_args
@@ -59,11 +57,8 @@ class Qbank(Package):
         make('install')
 
         if '+doc' in spec:
-            install_tree('doc', join_path(prefix, 'doc'))
+            install_tree('doc', prefix.doc)
 
-    def setup_environment(self, spack_env, run_env):
-        spec = self.spec
-        prefix = self.prefix
-
-        if '+doc' in spec:
-            run_env.prepend_path('MANPATH', join_path(prefix, 'doc'))
+    def setup_run_environment(self, env):
+        if '+doc' in self.spec:
+            env.prepend_path('MANPATH', self.prefix.doc)

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -353,7 +353,7 @@ class Qmcpack(CMakePackage, CudaPackage):
             install_tree('bin', prefix.bin)
 
     # QMCPACK 3.6.0 install directory structure changed, thus there
-    # thus are two version of the setup_environment method
+    # thus are two version of the setup_run_environment method
     @when('@:3.5.0')
     def setup_run_environment(self, env):
         """Set-up runtime environment for QMCPACK.

--- a/var/spack/repos/builtin/packages/qscintilla/package.py
+++ b/var/spack/repos/builtin/packages/qscintilla/package.py
@@ -38,7 +38,7 @@ class Qscintilla(QMakePackage):
     # When INSTALL_ROOT is unset, qscintilla is installed under qt_prefix
     # giving 'Nothing Installed Error'
     def setup_build_environment(self, env):
-        spack_env.set('INSTALL_ROOT', self.prefix)
+        env.set('INSTALL_ROOT', self.prefix)
 
     def setup_run_environment(self, env):
         env.prepend_path('QT_PLUGIN_PATH', self.prefix.plugins)

--- a/var/spack/repos/builtin/packages/qtgraph/package.py
+++ b/var/spack/repos/builtin/packages/qtgraph/package.py
@@ -25,11 +25,11 @@ class Qtgraph(QMakePackage):
     depends_on("graphviz@2.40.1:", when='@develop')
     depends_on("graphviz@2.40.1", when='@1.0.0.0:')
 
-    def setup_environment(self, spack_env, run_env):
-        """Set up the compile and runtime environments for a package."""
-        spack_env.set('GRAPHVIZ_ROOT', self.spec['graphviz'].prefix)
-        spack_env.set('INSTALL_ROOT', self.prefix)
+    def setup_build_environment(self, env):
+        env.set('GRAPHVIZ_ROOT', self.spec['graphviz'].prefix)
+        env.set('INSTALL_ROOT', self.prefix)
 
+    def setup_run_environment(self, env):
         # What library suffix should be used based on library existence
         if os.path.isdir(self.prefix.lib64):
             lib_dir = self.prefix.lib64
@@ -38,9 +38,7 @@ class Qtgraph(QMakePackage):
 
         # The implementor has set up the library and include paths in
         # a non-conventional way.  We reflect that here.
-        run_env.prepend_path(
-            'LD_LIBRARY_PATH', join_path(
-                lib_dir,
-                '{0}'.format(self.spec['qt'].version.up_to(3))))
+        env.prepend_path('LD_LIBRARY_PATH', join_path(
+            lib_dir, '{0}'.format(self.spec['qt'].version.up_to(3))))
 
-        run_env.prepend_path('CPATH', self.prefix.include.QtGraph)
+        env.prepend_path('CPATH', self.prefix.include.QtGraph)

--- a/var/spack/repos/builtin/packages/r-phantompeakqualtools/package.py
+++ b/var/spack/repos/builtin/packages/r-phantompeakqualtools/package.py
@@ -26,5 +26,5 @@ class RPhantompeakqualtools(RPackage):
 
     conflicts('%gcc@6:')
 
-    def setup_environment(self, spack_env, run_env):
-        spack_env.set('BOOST_ROOT', self.spec['boost'].prefix)
+    def setup_build_environment(self, env):
+        env.set('BOOST_ROOT', self.spec['boost'].prefix)

--- a/var/spack/repos/builtin/packages/rclone/package.py
+++ b/var/spack/repos/builtin/packages/rclone/package.py
@@ -17,9 +17,9 @@ class Rclone(Package):
 
     depends_on("go", type='build')
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         # Point GOPATH at the top of the staging dir for the build step.
-        spack_env.prepend_path('GOPATH', self.stage.path)
+        env.prepend_path('GOPATH', self.stage.path)
 
     def install(self, spec, prefix):
         go('build')

--- a/var/spack/repos/builtin/packages/ruby/package.py
+++ b/var/spack/repos/builtin/packages/ruby/package.py
@@ -63,7 +63,7 @@ class Ruby(AutotoolsPackage):
         args.append('--with-tk=%s' % self.spec['tk'].prefix)
         return args
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+    def setup_dependent_build_environment(self, env, dependent_spec):
         # TODO: do this only for actual extensions.
         # Set GEM_PATH to include dependent gem directories
         ruby_paths = []
@@ -71,10 +71,10 @@ class Ruby(AutotoolsPackage):
             if d.package.extends(self.spec):
                 ruby_paths.append(d.prefix)
 
-        spack_env.set_path('GEM_PATH', ruby_paths)
+        env.set_path('GEM_PATH', ruby_paths)
 
         # The actual installation path for this gem
-        spack_env.set('GEM_HOME', dependent_spec.prefix)
+        env.set('GEM_HOME', dependent_spec.prefix)
 
     def setup_dependent_package(self, module, dependent_spec):
         """Called before ruby modules' install() methods.  Sets GEM_HOME

--- a/var/spack/repos/builtin/packages/samrai/package.py
+++ b/var/spack/repos/builtin/packages/samrai/package.py
@@ -95,6 +95,6 @@ class Samrai(AutotoolsPackage):
 
         return options
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+    def setup_dependent_build_environment(self, env, dependent_spec):
         if self.spec.satisfies('@3.12:'):
-            spack_env.append_flags('CXXFLAGS', self.compiler.cxx11_flag)
+            env.append_flags('CXXFLAGS', self.compiler.cxx11_flag)

--- a/var/spack/repos/builtin/packages/shared-mime-info/package.py
+++ b/var/spack/repos/builtin/packages/shared-mime-info/package.py
@@ -24,8 +24,8 @@ class SharedMimeInfo(AutotoolsPackage):
     depends_on('gettext', type='build')
     depends_on('pkgconfig', type='build')
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        spack_env.prepend_path("XDG_DATA_DIRS",
-                               self.prefix.share)
-        run_env.prepend_path("XDG_DATA_DIRS",
-                             self.prefix.share)
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.prepend_path('XDG_DATA_DIRS', self.prefix.share)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        env.prepend_path('XDG_DATA_DIRS', self.prefix.share)

--- a/var/spack/repos/builtin/packages/shiny-server/package.py
+++ b/var/spack/repos/builtin/packages/shiny-server/package.py
@@ -47,10 +47,8 @@ class ShinyServer(CMakePackage):
         bash('-c', 'bin/npm --python="$PYTHON" install')
         bash('-c', 'bin/node ./ext/node/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js --python="$PYTHON" rebuild')  # noqa: E501
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PATH',
-                             join_path(self.prefix, 'shiny-server', 'bin'))
+    def setup_run_environment(self, env):
+        env.prepend_path('PATH', join_path(self.prefix, 'shiny-server', 'bin'))
         # shiny comes with its own pandoc; hook it up...
-        run_env.prepend_path('PATH',
-                             join_path(self.prefix, 'shiny-server',
-                                       'ext', 'pandoc', 'static'))
+        env.prepend_path('PATH', join_path(
+            self.prefix, 'shiny-server', 'ext', 'pandoc', 'static'))

--- a/var/spack/repos/builtin/packages/shortbred/package.py
+++ b/var/spack/repos/builtin/packages/shortbred/package.py
@@ -28,5 +28,5 @@ class Shortbred(Package):
         install('shortbred_quantify.py', prefix.bin)
         install_tree('src', prefix.src)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PYTHONPATH', self.prefix)
+    def setup_run_environment(self, env):
+        env.prepend_path('PYTHONPATH', self.prefix)

--- a/var/spack/repos/builtin/packages/signalp/package.py
+++ b/var/spack/repos/builtin/packages/signalp/package.py
@@ -39,5 +39,5 @@ class Signalp(Package):
         install_tree('lib', prefix.lib)
         install_tree('syn', prefix.syn)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PATH', prefix)
+    def setup_run_environment(self, env):
+        env.prepend_path('PATH', self.prefix)

--- a/var/spack/repos/builtin/packages/signify/package.py
+++ b/var/spack/repos/builtin/packages/signify/package.py
@@ -16,5 +16,5 @@ class Signify(MakefilePackage):
 
     depends_on('libbsd@0.8:')
 
-    def setup_environment(self, spack_env, run_env):
-        spack_env.set('PREFIX', self.prefix)
+    def setup_build_environment(self, env):
+        env.set('PREFIX', self.prefix)

--- a/var/spack/repos/builtin/packages/singularity/package.py
+++ b/var/spack/repos/builtin/packages/singularity/package.py
@@ -87,10 +87,9 @@ class Singularity(MakefilePackage):
     build_targets = ['-C', 'builddir', 'parallel=False']
     install_targets = ['install', '-C', 'builddir', 'parallel=False']
 
-    def setup_environment(self, spack_env, run_env):
-        # Point GOPATH at the top of the staging dir for the build
-        # step.
-        spack_env.prepend_path('GOPATH', self.gopath)
+    def setup_build_environment(self, env):
+        # Point GOPATH at the top of the staging dir for the build step.
+        env.prepend_path('GOPATH', self.gopath)
 
     # `singularity` has a fixed path where it will look for
     # mksquashfs.  If it lives somewhere else you need to specify the

--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -31,11 +31,10 @@ class Slate(Package):
 
     conflicts('%gcc@:5')
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         if('+cuda' in self.spec):
-            spack_env.prepend_path('CPATH', self.spec['cuda'].prefix.include)
-        spack_env.prepend_path('CPATH', self.spec['intel-mkl'].prefix
-                               + '/mkl/include')
+            env.prepend_path('CPATH', self.spec['cuda'].prefix.include)
+        env.prepend_path('CPATH', self.spec['intel-mkl'].prefix.mkl.include)
 
     def install(self, spec, prefix):
         f_cuda = "1" if spec.variants['cuda'].value else "0"

--- a/var/spack/repos/builtin/packages/slepc/package.py
+++ b/var/spack/repos/builtin/packages/slepc/package.py
@@ -101,6 +101,6 @@ class Slepc(Package):
 
         make('install', parallel=False)
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+    def setup_dependent_build_environment(self, env, dependent_spec):
         # set up SLEPC_DIR for everyone using SLEPc package
-        spack_env.set('SLEPC_DIR', self.prefix)
+        env.set('SLEPC_DIR', self.prefix)

--- a/var/spack/repos/builtin/packages/snap-korf/package.py
+++ b/var/spack/repos/builtin/packages/snap-korf/package.py
@@ -38,6 +38,6 @@ class SnapKorf(MakefilePackage):
         install_tree('HMM', prefix.HMM)
         install_tree('DNA', prefix.DNA)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.set('ZOE', self.prefix)
-        run_env.prepend_path('PATH', self.prefix)
+    def setup_run_environment(self, env):
+        env.set('ZOE', self.prefix)
+        env.prepend_path('PATH', self.prefix)

--- a/var/spack/repos/builtin/packages/snphylo/package.py
+++ b/var/spack/repos/builtin/packages/snphylo/package.py
@@ -33,5 +33,5 @@ class Snphylo(Package):
             bash('./setup.sh', input=f)
             install_tree('.', prefix)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PATH', self.spec.prefix)
+    def setup_run_environment(self, env):
+        env.prepend_path('PATH', self.spec.prefix)

--- a/var/spack/repos/builtin/packages/sosflow/package.py
+++ b/var/spack/repos/builtin/packages/sosflow/package.py
@@ -21,14 +21,15 @@ class Sosflow(CMakePackage):
     depends_on('pkgconfig')
     depends_on('mpi')
 
-    def setup_environment(self, spack_env, run_env):
-        spack_env.set('SOS_HOST_KNOWN_AS', 'SPACK-SOS-BUILD')
-        spack_env.set('SOS_HOST_NODE_NAME', 'SPACK-SOS-NODE')
-        spack_env.set('SOS_HOST_DETAILED', 'SPACK-SOS-DETAILED')
+    def setup_build_environment(self, env):
+        env.set('SOS_HOST_KNOWN_AS', 'SPACK-SOS-BUILD')
+        env.set('SOS_HOST_NODE_NAME', 'SPACK-SOS-NODE')
+        env.set('SOS_HOST_DETAILED', 'SPACK-SOS-DETAILED')
 
-        run_env.set('SOS_ROOT', self.spec.prefix)
-        run_env.set('SOS_BUILD_DIR', self.spec.prefix)
-        run_env.set('SOS_CMD_PORT', '22500')
-        run_env.set('SOS_WORK', env['HOME'])
-        run_env.set('SOS_EVPATH_MEETUP', env['HOME'])
-        run_env.set('SOS_ENV_SET', 'true')
+    def setup_run_environment(self, env):
+        env.set('SOS_ROOT', self.spec.prefix)
+        env.set('SOS_BUILD_DIR', self.spec.prefix)
+        env.set('SOS_CMD_PORT', '22500')
+        env.set('SOS_WORK', env['HOME'])
+        env.set('SOS_EVPATH_MEETUP', env['HOME'])
+        env.set('SOS_ENV_SET', 'true')

--- a/var/spack/repos/builtin/packages/spark/package.py
+++ b/var/spack/repos/builtin/packages/spark/package.py
@@ -47,7 +47,7 @@ class Spark(Package):
         install('RELEASE', prefix)
 
     @when('+hadoop')
-    def setup_environment(self, spack_env, run_env):
+    def setup_run_environment(self, env):
         hadoop = self.spec['hadoop'].command
         hadoop.add_default_env('JAVA_HOME', self.spec['java'].home)
         hadoop_classpath = hadoop('classpath', output=str)
@@ -56,4 +56,4 @@ class Spark(Package):
         # module files
         hadoop_classpath = re.sub(r'[\s+]', '', hadoop_classpath)
 
-        run_env.set('SPARK_DIST_CLASSPATH', hadoop_classpath)
+        env.set('SPARK_DIST_CLASSPATH', hadoop_classpath)

--- a/var/spack/repos/builtin/packages/sspace-standard/package.py
+++ b/var/spack/repos/builtin/packages/sspace-standard/package.py
@@ -49,5 +49,5 @@ class SspaceStandard(Package):
         install(rootscript, prefix)
 
     def setup_run_environment(self, env):
-        env.set('SSPACE_HOME', prefix)
-        env.prepend_path('PATH', prefix)
+        env.set('SSPACE_HOME', self.prefix)
+        env.prepend_path('PATH', self.prefix)

--- a/var/spack/repos/builtin/packages/sspace-standard/package.py
+++ b/var/spack/repos/builtin/packages/sspace-standard/package.py
@@ -48,6 +48,6 @@ class SspaceStandard(Package):
         install_tree('tools', prefix.tools)
         install(rootscript, prefix)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.set('SSPACE_HOME', prefix)
-        run_env.prepend_path('PATH', prefix)
+    def setup_run_environment(self, env):
+        env.set('SSPACE_HOME', prefix)
+        env.prepend_path('PATH', prefix)

--- a/var/spack/repos/builtin/packages/stata/package.py
+++ b/var/spack/repos/builtin/packages/stata/package.py
@@ -38,7 +38,7 @@ class Stata(Package):
 
     # STATA is simple and needs really just the PATH set.
     def setup_run_environment(self, env):
-        env.prepend_path('PATH', prefix)
+        env.prepend_path('PATH', self.prefix)
         env.prepend_path('LD_LIBRARY_PATH', self.spec['libpng'].prefix.lib)
 
     # Extracting the file provides the following:

--- a/var/spack/repos/builtin/packages/stata/package.py
+++ b/var/spack/repos/builtin/packages/stata/package.py
@@ -37,9 +37,9 @@ class Stata(Package):
         return "file://{0}/Stata{1}Linux64.tar.gz".format(os.getcwd(), version)
 
     # STATA is simple and needs really just the PATH set.
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PATH', prefix)
-        run_env.prepend_path('LD_LIBRARY_PATH', self.spec['libpng'].prefix.lib)
+    def setup_run_environment(self, env):
+        env.prepend_path('PATH', prefix)
+        env.prepend_path('LD_LIBRARY_PATH', self.spec['libpng'].prefix.lib)
 
     # Extracting the file provides the following:
     # ./unix/

--- a/var/spack/repos/builtin/packages/steps/package.py
+++ b/var/spack/repos/builtin/packages/steps/package.py
@@ -55,7 +55,7 @@ class Steps(CMakePackage):
         args.append('-DBLAS_LIBRARIES=' + spec['blas'].libs.joined(";"))
         return args
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_run_environment(self, env):
         # This recipe exposes a Python package from a C++ CMake project.
         # This hook is required to reproduce what Spack PythonPackage does.
-        run_env.prepend_path('PYTHONPATH', self.prefix)
+        env.prepend_path('PYTHONPATH', self.prefix)

--- a/var/spack/repos/builtin/packages/supernova/package.py
+++ b/var/spack/repos/builtin/packages/supernova/package.py
@@ -36,8 +36,8 @@ class Supernova(Package):
     def url_for_version(self, version):
         return "file://{0}/supernova-{1}.tar.gz".format(os.getcwd(), version)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PATH', self.prefix)
+    def setup_run_environment(self, env):
+        env.prepend_path('PATH', self.prefix)
 
     def install(self, spec, prefix):
         rm = which('rm')

--- a/var/spack/repos/builtin/packages/swiftsim/package.py
+++ b/var/spack/repos/builtin/packages/swiftsim/package.py
@@ -33,14 +33,15 @@ class Swiftsim(AutotoolsPackage):
     depends_on('hdf5~mpi', when='~mpi')
     depends_on('hdf5+mpi', when='+mpi')
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         # Needed to be able to download from the Durham gitlab repository
         tty.warn('Setting "GIT_SSL_NO_VERIFY=1"')
         tty.warn('This is needed to clone SWIFT repository')
-        spack_env.set('GIT_SSL_NO_VERIFY', 1)
+        env.set('GIT_SSL_NO_VERIFY', 1)
 
     def configure_args(self):
-        return ['--prefix=%s' % self.prefix,
-                '--enable-mpi' if '+mpi' in self.spec else '--disable-mpi',
-                '--with-metis={0}'.format(self.spec['metis'].prefix),
-                '--enable-optimization']
+        return [
+            '--enable-mpi' if '+mpi' in self.spec else '--disable-mpi',
+            '--with-metis={0}'.format(self.spec['metis'].prefix),
+            '--enable-optimization'
+        ]

--- a/var/spack/repos/builtin/packages/targetp/package.py
+++ b/var/spack/repos/builtin/packages/targetp/package.py
@@ -44,6 +44,6 @@ class Targetp(Package):
         install_tree('tmp', prefix.tmp)
         install('targetp', prefix.targetp)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.set('TARGETP', self.prefix)
-        run_env.prepend_path('PATH', self.prefix)
+    def setup_run_environment(self, env):
+        env.set('TARGETP', self.prefix)
+        env.prepend_path('PATH', self.prefix)

--- a/var/spack/repos/builtin/packages/tassel/package.py
+++ b/var/spack/repos/builtin/packages/tassel/package.py
@@ -22,4 +22,4 @@ class Tassel(Package):
         install_tree('.', prefix.bin)
 
     def setup_run_environment(self, env):
-        env.prepend_path('CLASSPATH', prefix.bin.lib)
+        env.prepend_path('CLASSPATH', self.prefix.bin.lib)

--- a/var/spack/repos/builtin/packages/tassel/package.py
+++ b/var/spack/repos/builtin/packages/tassel/package.py
@@ -21,5 +21,5 @@ class Tassel(Package):
     def install(self, spec, prefix):
         install_tree('.', prefix.bin)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('CLASSPATH', prefix.bin.lib)
+    def setup_run_environment(self, env):
+        env.prepend_path('CLASSPATH', prefix.bin.lib)

--- a/var/spack/repos/builtin/packages/tau/package.py
+++ b/var/spack/repos/builtin/packages/tau/package.py
@@ -262,7 +262,7 @@ class Tau(Package):
                 if os.path.isdir(src) and not os.path.exists(dest):
                     os.symlink(join_path(subdir, d), dest)
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_run_environment(self, env):
         pattern = join_path(self.prefix.lib, 'Makefile.*')
         files = glob.glob(pattern)
 
@@ -272,4 +272,4 @@ class Tau(Package):
         # directory to inspect. The conditional below will set `TAU_MAKEFILE`
         # in the latter case.
         if files:
-            run_env.set('TAU_MAKEFILE', files[0])
+            env.set('TAU_MAKEFILE', files[0])

--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -97,17 +97,17 @@ class Tcl(AutotoolsPackage):
         return join_path(self.tcl_lib_dir,
                          'tcl{0}'.format(self.version.up_to(2)))
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_run_environment(self, env):
         # When using Tkinter from within spack provided python+tkinter, python
         # will not be able to find Tcl/Tk unless TCL_LIBRARY is set.
-        run_env.set('TCL_LIBRARY', join_path(self.prefix, self.tcl_lib_dir))
+        env.set('TCL_LIBRARY', join_path(self.prefix, self.tcl_lib_dir))
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+    def setup_dependent_build_environment(self, env, dependent_spec):
         """Set TCLLIBPATH to include the tcl-shipped directory for
         extensions and any other tcl extension it depends on.
         For further info see: https://wiki.tcl.tk/1787"""
 
-        spack_env.set('TCL_LIBRARY', join_path(self.prefix, self.tcl_lib_dir))
+        env.set('TCL_LIBRARY', join_path(self.prefix, self.tcl_lib_dir))
 
         # If we set TCLLIBPATH, we must also ensure that the corresponding
         # tcl is found in the build environment. This to prevent cases
@@ -116,7 +116,7 @@ class Tcl(AutotoolsPackage):
         # it boils down to the same situation we have here.
         path = os.path.dirname(self.command.path)
         if not is_system_path(path):
-            spack_env.prepend_path('PATH', path)
+            env.prepend_path('PATH', path)
 
         tcl_paths = [join_path(self.prefix, self.tcl_builtin_lib_dir)]
 
@@ -130,12 +130,16 @@ class Tcl(AutotoolsPackage):
         # "TCLLIBPATH is a Tcl list, not some platform-specific
         # colon-separated or semi-colon separated format"
         tcllibpath = ' '.join(tcl_paths)
-        spack_env.set('TCLLIBPATH', tcllibpath)
+        env.set('TCLLIBPATH', tcllibpath)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        """Set TCLLIBPATH to include the tcl-shipped directory for
+        extensions and any other tcl extension it depends on.
+        For further info see: https://wiki.tcl.tk/1787"""
 
         # For run time environment set only the path for
         # dependent_spec and prepend it to TCLLIBPATH
         if dependent_spec.package.extends(self.spec):
             dependent_tcllibpath = join_path(dependent_spec.prefix,
                                              self.tcl_lib_dir)
-            run_env.prepend_path('TCLLIBPATH', dependent_tcllibpath,
-                                 separator=' ')
+            env.prepend_path('TCLLIBPATH', dependent_tcllibpath, separator=' ')

--- a/var/spack/repos/builtin/packages/templight/package.py
+++ b/var/spack/repos/builtin/packages/templight/package.py
@@ -101,10 +101,12 @@ class Templight(CMakePackage):
         with open("tools/clang/tools/CMakeLists.txt", "a") as cmake_lists:
             cmake_lists.write("add_clang_subdirectory(templight)")
 
-    def setup_environment(self, spack_env, run_env):
-        spack_env.append_flags('CXXFLAGS', self.compiler.cxx11_flag)
-        run_env.set('CC', join_path(self.spec.prefix.bin, 'templight'))
-        run_env.set('CXX', join_path(self.spec.prefix.bin, 'templight++'))
+    def setup_build_environment(self, env):
+        env.append_flags('CXXFLAGS', self.compiler.cxx11_flag)
+
+    def setup_run_environment(self, env):
+        env.set('CC', join_path(self.spec.prefix.bin, 'templight'))
+        env.set('CXX', join_path(self.spec.prefix.bin, 'templight++'))
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/texlive/package.py
+++ b/var/spack/repos/builtin/packages/texlive/package.py
@@ -47,9 +47,9 @@ class Texlive(Package):
 
     depends_on('perl', type='build')
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_run_environment(self, env):
         suffix = "%s-%s" % (platform.machine(), platform.system().lower())
-        run_env.prepend_path('PATH', join_path(self.prefix.bin, suffix))
+        env.prepend_path('PATH', join_path(self.prefix.bin, suffix))
 
     def install(self, spec, prefix):
         # Using texlive's mirror system leads to mysterious problems,

--- a/var/spack/repos/builtin/packages/tk/package.py
+++ b/var/spack/repos/builtin/packages/tk/package.py
@@ -60,14 +60,14 @@ class Tk(AutotoolsPackage):
         return find_libraries(['libtk{0}'.format(self.version.up_to(2))],
                               root=self.prefix, recursive=True)
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_run_environment(self, env):
         # When using Tkinter from within spack provided python+tkinter, python
         # will not be able to find Tcl/Tk unless TK_LIBRARY is set.
-        run_env.set('TK_LIBRARY', join_path(self.prefix.lib, 'tk{0}'.format(
+        env.set('TK_LIBRARY', join_path(self.prefix.lib, 'tk{0}'.format(
             self.spec.version.up_to(2))))
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        spack_env.set('TK_LIBRARY', join_path(self.prefix.lib, 'tk{0}'.format(
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.set('TK_LIBRARY', join_path(self.prefix.lib, 'tk{0}'.format(
             self.spec.version.up_to(2))))
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/tppred/package.py
+++ b/var/spack/repos/builtin/packages/tppred/package.py
@@ -32,4 +32,4 @@ class Tppred(Package):
         install_tree('tppred2modules', prefix.modules)
 
     def setup_run_environment(self, env):
-        env.set('TPPRED_ROOT', prefix)
+        env.set('TPPRED_ROOT', self.prefix)

--- a/var/spack/repos/builtin/packages/tppred/package.py
+++ b/var/spack/repos/builtin/packages/tppred/package.py
@@ -31,5 +31,5 @@ class Tppred(Package):
         install_tree('example', prefix.example)
         install_tree('tppred2modules', prefix.modules)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.set('TPPRED_ROOT', prefix)
+    def setup_run_environment(self, env):
+        env.set('TPPRED_ROOT', prefix)

--- a/var/spack/repos/builtin/packages/transdecoder/package.py
+++ b/var/spack/repos/builtin/packages/transdecoder/package.py
@@ -30,5 +30,5 @@ class Transdecoder(MakefilePackage):
         install_tree('util', prefix.util)
 
     def setup_run_environment(self, env):
-        env.prepend_path('PATH', prefix)
-        env.prepend_path('PATH', prefix.util)
+        env.prepend_path('PATH', self.prefix)
+        env.prepend_path('PATH', self.prefix.util)

--- a/var/spack/repos/builtin/packages/transdecoder/package.py
+++ b/var/spack/repos/builtin/packages/transdecoder/package.py
@@ -29,6 +29,6 @@ class Transdecoder(MakefilePackage):
         install_tree('PerlLib', prefix.PerlLib)
         install_tree('util', prefix.util)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PATH', prefix)
-        run_env.prepend_path('PATH', prefix.util)
+    def setup_run_environment(self, env):
+        env.prepend_path('PATH', prefix)
+        env.prepend_path('PATH', prefix.util)

--- a/var/spack/repos/builtin/packages/turbomole/package.py
+++ b/var/spack/repos/builtin/packages/turbomole/package.py
@@ -52,9 +52,8 @@ class Turbomole(Package):
             return
 
     def install(self, spec, prefix):
-        if spec.satisfies('@:7.0.2'):
-            calculate_version = 'calculate_2.4_linux64'
-            molecontrol_version = 'MoleControl_2.5'
+        calculate_version = 'calculate_2.4_linux64'
+        molecontrol_version = 'MoleControl_2.5'
 
         tm_arch = self.get_tm_arch()
 
@@ -114,33 +113,25 @@ class Turbomole(Package):
             install('mpirun_scripts/ricc2', join_path(dst, 'mpirun_scripts'))
             install('mpirun_scripts/ridft', join_path(dst, 'mpirun_scripts'))
 
-    def setup_environment(self, spack_env, run_env):
-        if self.spec.satisfies('@:7.0.2'):
-            molecontrol_version = 'MoleControl_2.5'
+    def setup_run_environment(self, env):
+        molecontrol_version = 'MoleControl_2.5'
 
         tm_arch = self.get_tm_arch()
 
-        run_env.set('TURBODIR', join_path(self.prefix, 'TURBOMOLE'))
-        run_env.set('MOLE_CONTROL',
-                    join_path(self.prefix, 'TURBOMOLE', molecontrol_version))
+        env.set('TURBODIR', self.prefix.TURBOMOLE)
+        env.set('MOLE_CONTROL',
+                join_path(self.prefix, 'TURBOMOLE', molecontrol_version))
 
-        run_env.prepend_path('PATH',
-                             join_path(self.prefix, 'TURBOMOLE', 'thermocalc'))
-        run_env.prepend_path('PATH',
-                             join_path(self.prefix, 'TURBOMOLE', 'scripts'))
+        env.prepend_path('PATH', self.prefix.TURBOMOLE.thermocalc)
+        env.prepend_path('PATH', self.prefix.TURBOMOLE.scripts)
         if '+mpi' in self.spec:
-            run_env.set('PARA_ARCH', 'MPI')
-            run_env.prepend_path('PATH',
-                                 join_path(self.prefix,
-                                           'TURBOMOLE', 'bin', '%s_mpi'
-                                           % tm_arch))
+            env.set('PARA_ARCH', 'MPI')
+            env.prepend_path('PATH', join_path(
+                self.prefix, 'TURBOMOLE', 'bin', '%s_mpi' % tm_arch))
         elif '+smp' in self.spec:
-            run_env.set('PARA_ARCH', 'SMP')
-            run_env.prepend_path('PATH',
-                                 join_path(self.prefix,
-                                           'TURBOMOLE', 'bin', '%s_smp'
-                                           % tm_arch))
+            env.set('PARA_ARCH', 'SMP')
+            env.prepend_path('PATH', join_path(
+                self.prefix, 'TURBOMOLE', 'bin', '%s_smp' % tm_arch))
         else:
-            run_env.prepend_path('PATH',
-                                 join_path(self.prefix,
-                                           'TURBOMOLE', 'bin', tm_arch))
+            env.prepend_path('PATH', join_path(
+                self.prefix, 'TURBOMOLE', 'bin', tm_arch))

--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -45,32 +45,33 @@ class Upcxx(Package):
             url = "https://bitbucket.org/berkeleylab/upcxx/downloads/upcxx-{0}-offline.tar.gz"
         return url.format(version)
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         if 'platform=cray' in self.spec:
-            spack_env.set('GASNET_CONFIGURE_ARGS', '--enable-mpi=probe')
+            env.set('GASNET_CONFIGURE_ARGS', '--enable-mpi=probe')
 
         if 'cross=none' not in self.spec:
-            spack_env.set('CROSS', self.spec.variants['cross'].value)
+            env.set('CROSS', self.spec.variants['cross'].value)
 
         if '+cuda' in self.spec:
-            spack_env.set('UPCXX_CUDA', '1')
-            spack_env.set('UPCXX_CUDA_NVCC', self.spec['cuda'].prefix.bin.nvcc)
+            env.set('UPCXX_CUDA', '1')
+            env.set('UPCXX_CUDA_NVCC', self.spec['cuda'].prefix.bin.nvcc)
 
-        run_env.set('UPCXX_INSTALL', self.prefix)
-        run_env.set('UPCXX', self.prefix.bin.upcxx)
+    def setup_run_environment(self, env):
+        env.set('UPCXX_INSTALL', self.prefix)
+        env.set('UPCXX', self.prefix.bin.upcxx)
         if 'platform=cray' in self.spec:
-            run_env.set('UPCXX_GASNET_CONDUIT', 'aries')
-            run_env.set('UPCXX_NETWORK', 'aries')
+            env.set('UPCXX_GASNET_CONDUIT', 'aries')
+            env.set('UPCXX_NETWORK', 'aries')
 
     def setup_dependent_package(self, module, dep_spec):
         dep_spec.upcxx = self.prefix.bin.upcxx
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        spack_env.set('UPCXX_INSTALL', self.prefix)
-        spack_env.set('UPCXX', self.prefix.bin.upcxx)
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.set('UPCXX_INSTALL', self.prefix)
+        env.set('UPCXX', self.prefix.bin.upcxx)
         if 'platform=cray' in self.spec:
-            spack_env.set('UPCXX_GASNET_CONDUIT', 'aries')
-            spack_env.set('UPCXX_NETWORK', 'aries')
+            env.set('UPCXX_GASNET_CONDUIT', 'aries')
+            env.set('UPCXX_NETWORK', 'aries')
 
     def install(self, spec, prefix):
         env['CC'] = self.compiler.cc

--- a/var/spack/repos/builtin/packages/util-macros/package.py
+++ b/var/spack/repos/builtin/packages/util-macros/package.py
@@ -17,7 +17,6 @@ class UtilMacros(AutotoolsPackage):
     version('1.19.1', sha256='18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6')
     version('1.19.0', sha256='2835b11829ee634e19fa56517b4cfc52ef39acea0cd82e15f68096e27cbed0ba')
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+    def setup_dependent_build_environment(self, env, dependent_spec):
         """Adds the ACLOCAL path for autotools."""
-        spack_env.append_path('ACLOCAL_PATH',
-                              join_path(self.prefix.share, 'aclocal'))
+        env.append_path('ACLOCAL_PATH', self.prefix.share.aclocal)

--- a/var/spack/repos/builtin/packages/varscan/package.py
+++ b/var/spack/repos/builtin/packages/varscan/package.py
@@ -35,6 +35,6 @@ class Varscan(Package):
         filter_file('varscan.jar', join_path(prefix.jar, jar_file),
                     script, **kwargs)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.set('VARSCAN_HOME', self.prefix.jar)
-        run_env.set('CLASSPATH', self.prefix.jar)
+    def setup_run_environment(self, env):
+        env.set('VARSCAN_HOME', self.prefix.jar)
+        env.set('CLASSPATH', self.prefix.jar)

--- a/var/spack/repos/builtin/packages/vcftools/package.py
+++ b/var/spack/repos/builtin/packages/vcftools/package.py
@@ -23,7 +23,7 @@ class Vcftools(AutotoolsPackage):
     depends_on('perl', type=('build', 'run'))
     depends_on('zlib')
 
-    # this needs to be in sync with what setup_environment adds to
+    # this needs to be in sync with what setup_run_environment adds to
     # PERL5LIB below
     def configure_args(self):
         return ['--with-pmdir={0}'.format(self.prefix.lib)]
@@ -51,5 +51,5 @@ class Vcftools(AutotoolsPackage):
             kwargs = {'ignore_absent': True, 'backup': False, 'string': False}
             filter_file(match, substitute, *files, **kwargs)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PERL5LIB', self.prefix.lib)
+    def setup_run_environment(self, env):
+        env.prepend_path('PERL5LIB', self.prefix.lib)

--- a/var/spack/repos/builtin/packages/verilator/package.py
+++ b/var/spack/repos/builtin/packages/verilator/package.py
@@ -42,8 +42,8 @@ class Verilator(AutotoolsPackage):
     depends_on('flex')
     depends_on('perl',  type=('build', 'run'))
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('VERILATOR_ROOT', self.prefix)
+    def setup_run_environment(self, env):
+        env.prepend_path('VERILATOR_ROOT', self.prefix)
 
     # verilator requires access to its shipped scripts (bin) and include
     # but the standard make doesn't put it in the correct places

--- a/var/spack/repos/builtin/packages/vesta/package.py
+++ b/var/spack/repos/builtin/packages/vesta/package.py
@@ -21,9 +21,9 @@ class Vesta(Package):
 
     conflicts('%gcc@:5.3')
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PATH', self.prefix)
-        run_env.prepend_path('LD_LIBRARY_PATH', self.prefix)
+    def setup_run_environment(self, env):
+        env.prepend_path('PATH', self.prefix)
+        env.prepend_path('LD_LIBRARY_PATH', self.prefix)
 
     def install(self, spec, prefix):
         install_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/wordnet/package.py
+++ b/var/spack/repos/builtin/packages/wordnet/package.py
@@ -28,6 +28,6 @@ class Wordnet(AutotoolsPackage):
 
         return args
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.set('WNHOME', self.prefix)
-        run_env.set('WNSEARCHDIR', self.prefix.dict)
+    def setup_run_environment(self, env):
+        env.set('WNHOME', self.prefix)
+        env.set('WNSEARCHDIR', self.prefix.dict)

--- a/var/spack/repos/builtin/packages/workrave/package.py
+++ b/var/spack/repos/builtin/packages/workrave/package.py
@@ -67,13 +67,13 @@ class Workrave(AutotoolsPackage):
              destination='',
              placement=m4files[1])
 
-    def setup_environment(self, build_env, run_env):
+    def setup_build_environment(self, env):
         # unset PYTHONHOME to let system python script with explict
         # system python sbangs like glib-mkenums work, see #6968
         # Without this, we will get
         # ImportError: No module named site
         # during build phase when make runs glib-mkenums
-        build_env.unset('PYTHONHOME')
+        env.unset('PYTHONHOME')
 
     @run_before('autoreconf')
     def extra_m4(self):

--- a/var/spack/repos/builtin/packages/xkeyboard-config/package.py
+++ b/var/spack/repos/builtin/packages/xkeyboard-config/package.py
@@ -31,6 +31,8 @@ class XkeyboardConfig(AutotoolsPackage):
     # perl@5.8.1:
     # perl XML::Parser
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        spack_env.prepend_path('XKB_CONFIG_ROOT', self.prefix.share.X11.xkb)
-        run_env.prepend_path('XKB_CONFIG_ROOT', self.prefix.share.X11.xkb)
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.prepend_path('XKB_CONFIG_ROOT', self.prefix.share.X11.xkb)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        env.prepend_path('XKB_CONFIG_ROOT', self.prefix.share.X11.xkb)

--- a/var/spack/repos/builtin/packages/xrootd/package.py
+++ b/var/spack/repos/builtin/packages/xrootd/package.py
@@ -13,10 +13,8 @@ class Xrootd(CMakePackage):
     homepage = "http://xrootd.org"
     url      = "http://xrootd.org/download/v4.6.0/xrootd-4.6.0.tar.gz"
 
-    version('4.8.5',
-            sha256='42e4d2cc6f8b442135f09bcc12c7be38b1a0c623a005cb5e69ff3d27997bdf73')
-    version('4.8.4',
-            sha256='f148d55b16525567c0f893edf9bb2975f7c09f87f0599463e19e1b456a9d95ba')
+    version('4.8.5', sha256='42e4d2cc6f8b442135f09bcc12c7be38b1a0c623a005cb5e69ff3d27997bdf73')
+    version('4.8.4', sha256='f148d55b16525567c0f893edf9bb2975f7c09f87f0599463e19e1b456a9d95ba')
     version('4.8.3', sha256='9cd30a343758b8f50aea4916fa7bd37de3c37c5b670fe059ae77a8b2bbabf299')
     version('4.8.2', sha256='8f28ec53e799d4aa55bd0cc4ab278d9762e0e57ac40a4b02af7fc53dcd1bef39')
     version('4.8.1', sha256='edee2673d941daf7a6e5c963d339d4a69b4db5c4b6f77b4548b3129b42198029')
@@ -83,7 +81,7 @@ class Xrootd(CMakePackage):
 
         return options
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         cxxstdflag = ''
         if self.spec.variants['cxxstd'].value == '98':
             cxxstdflag = self.compiler.cxx98_flag
@@ -101,4 +99,4 @@ class Xrootd(CMakePackage):
                 "cxxstd={0}".format(self.spec.variants['cxxstd'].value))
 
         if cxxstdflag:
-            spack_env.append_flags('CXXFLAGS', cxxstdflag)
+            env.append_flags('CXXFLAGS', cxxstdflag)

--- a/var/spack/repos/builtin/packages/xsd/package.py
+++ b/var/spack/repos/builtin/packages/xsd/package.py
@@ -24,9 +24,9 @@ class Xsd(MakefilePackage):
     def install(self, spec, prefix):
         make('install', 'install_prefix=' + prefix)
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         xercesc_lib_flags = self.spec['xerces-c'].libs.search_flags
-        spack_env.append_flags('LDFLAGS', xercesc_lib_flags)
+        env.append_flags('LDFLAGS', xercesc_lib_flags)
 
     def url_for_version(self, version):
         url = "https://www.codesynthesis.com/download/xsd/{0}/xsd-{1}+dep.tar.bz2"


### PR DESCRIPTION
Felt like procrastinating my research, and I got tired of asking contributors to update `setup_environment` themselves.

@alalazo can you take a look? My goal is to change the current functionality as little as possible, just replacing `setup_(dependent_)?_environment` and fixing bugs I see along the way.

Now that no packages use `setup_(dependent_)?_environment`, should we delete those methods and the respective tests, or keep them around as deprecated functions for a little while?