### PR TITLE
Add timeouts to fetchers

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -340,7 +340,8 @@ class URLFetchStrategy(FetchStrategy):
         # Run curl but grab the mime type from the http headers
         curl = self.curl
         with working_dir(self.stage.path):
-            headers = curl(*curl_args, output=str, fail_on_error=False)
+            headers = curl(*curl_args, output=str, fail_on_error=False,
+                           timeout=600)
 
         if curl.returncode != 0:
             # clean up archive on failure.
@@ -795,7 +796,7 @@ class GitFetchStrategy(VCSFetchStrategy):
             if not debug:
                 clone_args.insert(1, '--quiet')
             with temp_cwd():
-                git(*clone_args)
+                git(*clone_args, timeout=600)
                 repo_name = get_single_file('.')
                 self.stage.srcdir = repo_name
                 shutil.move(repo_name, self.stage.source_path)


### PR DESCRIPTION
This adds a timeout to fetching of resources in Spack. This assumes that any resource can be retrieved in a fixed amount of time (currently 10 minutes). The timeout is currently added only for git/URL resources (but could easily be added for any).

This is intended to address #13604, and to work as a catch-all for all issues which for one reason or another permanently stall fetching a resource. This could include:

* A download which never terminates
* A git clone which requires interaction (which will never occur when mirroring all packages)

Overall, this will only work well if timeouts are rare (since a large timeout is required to accommodate large downloads).