### PR TITLE
Loosen restriction on setuptools version of py-backports-shutil-get-terminal-size

### DIFF
--- a/var/spack/repos/builtin/packages/py-backports-shutil-get-terminal-size/package.py
+++ b/var/spack/repos/builtin/packages/py-backports-shutil-get-terminal-size/package.py
@@ -19,5 +19,5 @@ class PyBackportsShutilGetTerminalSize(PythonPackage):
 
     # newer setuptools version mess with "namespace" packages in an
     # incompatible way cf. https://github.com/pypa/setuptools/issues/900
-    depends_on('py-setuptools@:30.999.999', type='build')
+    depends_on('py-setuptools@:30.999.999,41:', type='build')
     depends_on('python@:3.2')


### PR DESCRIPTION
The bug seems to be fixed at least in setuptools 41.0.0