### PR TITLE
Update MrBayes to 3.2.7a and correct MPI variants

### DIFF
--- a/var/spack/repos/builtin/packages/mrbayes/package.py
+++ b/var/spack/repos/builtin/packages/mrbayes/package.py
@@ -13,9 +13,10 @@ class Mrbayes(AutotoolsPackage):
        of model parameters."""
 
     homepage = "http://mrbayes.sourceforge.net"
-    git      = "https://github.com/NBISweden/MrBayes.git"
+    url      = "https://github.com/NBISweden/MrBayes/releases/download/v3.2.7a/mrbayes-3.2.7a.tar.gz"
 
-    version('3.2.7a', commit='0176ac2d0bfed53a5bc0aaf3f5a3def71f23575f')
+    version('3.2.7a', sha256='1a4670be84e6b968d59382328294db4c8ceb73e0c19c702265deec6f2177815c')
+    version('3.2.7',  sha256='39d9eb269969b501268d5c27f77687c6eaa2c71ccf15c724e6f330fc405f24b9')
 
     variant('mpi', default=True, description='Enable MPI parallel support')
     variant('beagle', default=True, description='Enable BEAGLE library for speed benefits')
@@ -24,13 +25,9 @@ class Mrbayes(AutotoolsPackage):
     variant('avx', default=True, description='Enable AVX in order to substantially speed up execution')
     variant('fma', default=True, description='Enable FMA in order to substantially speed up execution')
 
-    depends_on('autoconf', type='build')
-    depends_on('automake', type='build')
-    depends_on('libtool',  type='build')
-    depends_on('m4',       type='build')
-
     depends_on('libbeagle', when='+beagle')
     depends_on('mpi', when='+mpi')
+    depends_on('readline', when='+readline')
 
     def configure_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/mrbayes/package.py
+++ b/var/spack/repos/builtin/packages/mrbayes/package.py
@@ -20,10 +20,7 @@ class Mrbayes(AutotoolsPackage):
 
     variant('mpi', default=True, description='Enable MPI parallel support')
     variant('beagle', default=True, description='Enable BEAGLE library for speed benefits')
-    variant('readline', default=True, description='Enable readline library')
-    variant('sse', default=True, description='Enable SSE in order to substantially speed up execution')
-    variant('avx', default=True, description='Enable AVX in order to substantially speed up execution')
-    variant('fma', default=True, description='Enable FMA in order to substantially speed up execution')
+    variant('readline', default=False, description='Enable readline library, not recommended with MPI')
 
     depends_on('libbeagle', when='+beagle')
     depends_on('mpi', when='+mpi')
@@ -35,22 +32,10 @@ class Mrbayes(AutotoolsPackage):
             args.append('--with-beagle=no')
         else:
             args.append('--with-beagle=%s' % self.spec['libbeagle'].prefix)
-        if '~readline' in self.spec:
-            args.append('--with-readline=no')
-        else:
+        if '+readline' in self.spec:
             args.append('--with-readline=yes')
-        if '~sse' in self.spec:
-            args.append('--enable-sse=no')
         else:
-            args.append('--enable-sse=yes')
-        if '~avx' in self.spec:
-            args.append('--enable-avx=no')
-        else:
-            args.append('--enable-avx=yes')
-        if '~fma' in self.spec:
-            args.append('--enable-fma=no')
-        else:
-            args.append('--enable-fma=yes')
+            args.append('--with-readline=no')
         if '~mpi' in self.spec:
             args.append('--with-mpi=no')
         else:

--- a/var/spack/repos/builtin/packages/mrbayes/package.py
+++ b/var/spack/repos/builtin/packages/mrbayes/package.py
@@ -15,11 +15,14 @@ class Mrbayes(AutotoolsPackage):
     homepage = "http://mrbayes.sourceforge.net"
     git      = "https://github.com/NBISweden/MrBayes.git"
 
-    version('2017-11-22', commit='8a9adb11bcc538cb95d91d57568dff383f924503')
+    version('3.2.7a', commit='0176ac2d0bfed53a5bc0aaf3f5a3def71f23575f')
 
     variant('mpi', default=True, description='Enable MPI parallel support')
     variant('beagle', default=True, description='Enable BEAGLE library for speed benefits')
+    variant('readline', default=True, description='Enable readline library')
     variant('sse', default=True, description='Enable SSE in order to substantially speed up execution')
+    variant('avx', default=True, description='Enable AVX in order to substantially speed up execution')
+    variant('fma', default=True, description='Enable FMA in order to substantially speed up execution')
 
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
@@ -35,14 +38,26 @@ class Mrbayes(AutotoolsPackage):
             args.append('--with-beagle=no')
         else:
             args.append('--with-beagle=%s' % self.spec['libbeagle'].prefix)
+        if '~readline' in self.spec:
+            args.append('--with-readline=no')
+        else:
+            args.append('--with-readline=yes')
         if '~sse' in self.spec:
             args.append('--enable-sse=no')
         else:
             args.append('--enable-sse=yes')
-        if '~mpi' in self.spec:
-            args.append('--enable-mpi=no')
+        if '~avx' in self.spec:
+            args.append('--enable-avx=no')
         else:
-            args.append('--enable-mpi=yes')
+            args.append('--enable-avx=yes')
+        if '~fma' in self.spec:
+            args.append('--enable-fma=no')
+        else:
+            args.append('--enable-fma=yes')
+        if '~mpi' in self.spec:
+            args.append('--with-mpi=no')
+        else:
+            args.append('--with-mpi=yes')
         return args
 
     def install(self, spec, prefix):


### PR DESCRIPTION
* Updated MrBayes to release version 3.2.7a (latest).
* Fixed incorrect MPI configure argument.
* Added several new configure arguments as variants.

Thanks.