### PR TITLE
Apply URLFetchStrategy to ftp:// and ftps:// url schemes

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -1312,7 +1312,7 @@ def from_url_scheme(url, *args, **kwargs):
             'file': 'url',
             'http': 'url',
             'https': 'url',
-            'ftp': 'url', 
+            'ftp': 'url',
             'ftps': 'url',
         })
 

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -1311,7 +1311,9 @@ def from_url_scheme(url, *args, **kwargs):
         {
             'file': 'url',
             'http': 'url',
-            'https': 'url'
+            'https': 'url',
+            'ftp': 'url', 
+            'ftps': 'url',
         })
 
     scheme = parsed_url.scheme


### PR DESCRIPTION
Dear Spack developers,

this is just a small fix which enables sources with ftp:// urls to be downloaded. I hope that it helps.

Kind regards,

Andras