### PR TITLE
Version bump: 1.13.1

### DIFF
--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -5,7 +5,7 @@
 
 
 #: major, minor, patch version for Spack, in a tuple
-spack_version_info = (0, 13, 0)
+spack_version_info = (0, 13, 1)
 
 #: String containing Spack version joined with .'s
 spack_version = '.'.join(str(v) for v in spack_version_info)


### PR DESCRIPTION
We forgot to bump the version when we released 1.13.1. We need a documented (or automated) process for releasing new versions that includes bumping the version number.