### PR TITLE
Fix conflict with respect to openssl and qt3 built for openspeedshop.

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -139,7 +139,10 @@ class Qt(Package):
     depends_on("libpng@1.2.57", when='@3')
     depends_on("pcre+multibyte", when='@5.0:5.8')
     depends_on("inputproto", when='@:5.8')
-    depends_on("openssl@:1.0.999", when='@:5.9+ssl')
+    if '+krellpatch':
+        depends_on("openssl@:1.0.999", when='@4.0:5.9+ssl')
+    else:
+        depends_on("openssl@:1.0.999", when='@:5.9+ssl')
 
     depends_on("glib", when='@4:')
     depends_on("libpng", when='@4:')

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -139,10 +139,7 @@ class Qt(Package):
     depends_on("libpng@1.2.57", when='@3')
     depends_on("pcre+multibyte", when='@5.0:5.8')
     depends_on("inputproto", when='@:5.8')
-    if '+krellpatch':
-        depends_on("openssl@:1.0.999", when='@4.0:5.9+ssl')
-    else:
-        depends_on("openssl@:1.0.999", when='@:5.9+ssl')
+    depends_on("openssl@:1.0.999", when='@:5.9+ssl~krellpatch')
 
     depends_on("glib", when='@4:')
     depends_on("libpng", when='@4:')


### PR DESCRIPTION
Fix an issue where the latest openssl is desired for multiple packages for the openspeedshop qt3 build, but the qt build wants to use an older version of openssl.  There does not appear to be any side effects for the openspeedshop gui when using the latest openssl, so making the change to resolve the conflict.