### PR TITLE
git: add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.py diff=python


### PR DESCRIPTION
Add a line to .gitattributes so that `git grep -p` shows function names properly for `*.py` files.  Without this, the class name is shown instead of the function for python files.

This also causes diff output to use proper functions as hunk headers in `diff` output.

Here's an example with `git grep -p`.

```console
$ git grep -p spack_cc var/spack/repos/builtin/packages/athena
var/spack/repos/builtin/packages/athena/package.py=class Athena(AutotoolsPackage):
var/spack/repos/builtin/packages/athena/package.py:            env.set('CC', spack_cc)
var/spack/repos/builtin/packages/athena/package.py:            env.set('LDR', spack_cc)
```
vs.
```console
$ git grep -p spack_cc var/spack/repos/builtin/packages/athena
var/spack/repos/builtin/packages/athena/package.py=    def setup_build_environment(self, env):
var/spack/repos/builtin/packages/athena/package.py:            env.set('CC', spack_cc)
var/spack/repos/builtin/packages/athena/package.py:            env.set('LDR', spack_cc)
```

Here's an example with `diff` output.

```console
$ git show c5da94eb585d503248234ce18f24ffff4bd1f47c
[...]
@@ -28,6 +29,7 @@ print(u'\\xc3')

         # make it executable
         fs.set_executable(script_name)
+        filter_shebangs_in_directory('.', [script_name])

         # read the unicode back in and see whether things work
         script = ex.Executable('./%s' % script_name)
```
vs.
```console
$ git show c5da94eb585d503248234ce18f24ffff4bd1f47c
[...]
@@ -28,6 +29,7 @@ def test_read_unicode(tmpdir):

       # make it executable
       fs.set_executable(script_name)
+      filter_shebangs_in_directory('.', [script_name])

       # read the unicode back in and see whether things work
       script = ex.Executable('./%s' % script_name)
```