### PR TITLE
Sanity check missing dependencies

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2663,6 +2663,34 @@ def dump_packages(spec, path):
             spack.repo.path.dump_provenance(node, dest_pkg_dir)
 
 
+def possible_dependencies(*pkg_or_spec, **kwargs):
+    """Get the possible dependencies of a number of packages.
+
+    See ``PackageBase.possible_dependencies`` for details.
+    """
+    transitive = kwargs.get('transitive', True)
+    expand_virtuals = kwargs.get('expand_virtuals', True)
+    deptype = kwargs.get('deptype', 'all')
+
+    packages = []
+    for pos in pkg_or_spec:
+        if isinstance(pos, PackageMeta):
+            pkg = pos
+        elif isinstance(pos, spack.spec.Spec):
+            pkg = pos.package
+        else:
+            pkg = spack.spec.Spec(pos).package
+
+        packages.append(pkg)
+
+    visited = {}
+    for pkg in packages:
+        pkg.possible_dependencies(
+            transitive, expand_virtuals, deptype, visited)
+
+    return visited
+
+
 def print_pkg(message):
     """Outputs a message with a package icon."""
     from llnl.util.tty.color import cwrite

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -47,6 +47,15 @@ def test_possible_dependencies(mock_packages, mpileaks_possible_deps):
     }
 
 
+def test_possible_dependencies_missing(mock_packages):
+    md = spack.repo.get("missing-dependency")
+    missing = {}
+    md.possible_dependencies(transitive=True, missing=missing)
+    assert missing["missing-dependency"] == set([
+        "this-is-a-missing-dependency"
+    ])
+
+
 def test_possible_dependencies_with_deptypes(mock_packages):
     dtbuild1 = spack.repo.get('dtbuild1')
 

--- a/lib/spack/spack/test/package_sanity.py
+++ b/lib/spack/spack/test/package_sanity.py
@@ -10,6 +10,7 @@ import re
 import pytest
 
 import spack.fetch_strategy
+import spack.package
 import spack.paths
 import spack.repo
 import spack.util.executable as executable
@@ -186,4 +187,19 @@ def test_prs_update_old_api():
            'https://github.com/spack/spack/pull/11115')
     assert not failing, msg.format(
         len(failing), ','.join(failing)
+    )
+
+
+def test_all_dependencies_exist():
+    """Make sure no packages have nonexisting dependencies."""
+    missing = {}
+    pkgs = [pkg for pkg in spack.repo.path.all_package_names()]
+    spack.package.possible_dependencies(
+        *pkgs, transitive=True, missing=missing)
+
+    lines = [
+        "%s: [%s]" % (name, ", ".join(deps)) for name, deps in missing.items()
+    ]
+    assert not missing, "These packages have missing dependencies:\n" + (
+        "\n".join(lines)
     )

--- a/var/spack/repos/builtin.mock/packages/missing-dependency/package.py
+++ b/var/spack/repos/builtin.mock/packages/missing-dependency/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class MissingDependency(Package):
+    """Package with a dependency that does not exist."""
+
+    homepage = "http://www.example.com"
+    url      = "http://www.example.com/missing-dependency-1.0.tar.gz"
+
+    version('1.0', '0123456789abcdef0123456789abcdef')
+
+    # intentionally missing to test possible_dependencies()
+    depends_on("this-is-a-missing-dependency")
+
+    # this one is a "real" mock dependency
+    depends_on("a")


### PR DESCRIPTION
fixes #1735

Currently, there are some packages in the mainline that list dependencies that don't exist.  We should get rid of those or add the missing packages.  To address this, I've added a sanity check that reports non-existing dependencies in `builtin`.

I tracked this down because it was causing issues with dependency solves in the new concretizer -- we can keep this issue open and keep rebasing it until we sanitize `develop`, but it would be nice to get these resolved soon.

Here's the current list:

- [x] cbtf-krell: [mpich2, mvapich] (#14021)
- [x] flann: [latex, gtest] (#14022)
- [x] mrnet: [cti] (#14178)
- [x] polymake: [perl-term-readkey] (#14034)
- [x] pumi: [simmetrix-simmodsuite] (#8730)
- [x] py-abipy: [py-jupyter, py-wxmplot] (#14035, #14036)
- [x] py-brian2: [py-nosetests] (#14037)
- [x] py-cherrypy: [py-zc-lockfile] (#13586)
- [x] py-dateparser: [py-parameterized] (#14016)
- [x] py-graphviz: [py-tox] (#14023, #14024)
- [x] py-htmlgen: [py-asserts] (#14038, #14039)
- [x] py-luigi: [py-test] (#14042)
- [x] py-pbr: [py-testtools, py-hacking, py-testresources, py-fixtures, py-testscenarios, py-stestr, py-testrepository] (#14025, #14026, #14027, #14028, #14029, #14030, #14031, #14032, #14033)
- [x] py-requests-oauthlib: [py-requests-mock] (#14043)
- [x] py-scikit-optimize: [py-test] (#14210)
- [x] py-tatsu: [py-pytest-mypy] (#14041)
- [x] py-theano: [py-parameterized] (#14015, #14016)
- [x] py-torch: [fbgemm, miopen, nnpack] (#14044)
- [x] r-ggraph: [r-tidygraph, r-graphlayouts] (#14045, #14046)
- [x] root: [libcxx, avahi, kerberos, ldap, http, veccore, odbc] (#14203)
- [x] wireshark: [portaudio, adwaita-icon-theme, libsmi, gtkplus3] (#14209)

- @adamjstewart: some of these are python test dependencies -- I think they're yours and we just need to add them.
- @chissg, @gartung: not sure what to do with the ones on `root`.
- @jgalarowicz: A few of these are yours.  For `cbtf-krell` I'm guessing the dependencies should probably be `mpich` and `mvapich2`, and for `mrnet` I don't know what `cti` is.  Maybe we should remove that?
- @cwsmith: what do you want to do with `simmetrix-simmodsuite`?
- @healther: what do you want to do with `wireshark`?