### PR TITLE
Harden shell detection when procfs is available

### DIFF
--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -215,11 +215,14 @@ _spack_pathadd() {
 }
 
 
-#
 # Determine which shell is being used
-#
 _spack_determine_shell() {
-    if [ -n "${BASH:-}" ]; then
+    if [ -f "/proc/$$/exe" ]; then
+        # If procfs is present this seems a more reliable
+        # way to detect the current shell
+        _sp_exe=$(readlink /proc/$$/exe)
+        basename ${_sp_exe}
+    elif [ -n "${BASH:-}" ]; then
         echo bash
     elif [ -n "${ZSH_NAME:-}" ]; then
         echo zsh


### PR DESCRIPTION
This change should harden shell detection when `procfs` is available, so that Spack detects the correct shell even when the setup script is sourced indirectly (as part of another script).