### PR TITLE
Restrict stage and local cache permissions

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -785,6 +785,18 @@ def temp_rename(orig_path, temp_path):
             shutil.move(temp_path, orig_path)
 
 
+@contextmanager
+def temp_umask(mask):
+    """Within this context, restrict permissions on newly created files, pipes,
+    and processes.
+    """
+    orig_mask = os.umask(mask)
+    try:
+        yield
+    finally:
+        os.umask(orig_mask)
+
+
 def can_access(file_name):
     """True if we have read/write access to the file."""
     return os.access(file_name, os.R_OK | os.W_OK)

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -1377,6 +1377,7 @@ class FsCache(object):
         dst = os.path.join(self.root, relative_dest)
         mkdirp(os.path.dirname(dst))
         fetcher.archive(dst)
+        return dst
 
     def fetcher(self, target_path, digest, **kwargs):
         path = os.path.join(self.root, target_path)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1090,7 +1090,10 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         if checksum and self.version in self.versions:
             self.stage.check()
 
-        self.stage.cache_local()
+        with temp_umask(PRIVATE_MASK):
+            cached_path = self.stage.cache_local()
+        if cached_path is not None:
+            fp.set_permissions_by_spec(cached_path, self.spec)
 
         for patch in self.spec.patches:
             patch.fetch(self.stage)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1078,8 +1078,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
                                  self.spec.format('{name}{@version}'), ck_msg)
 
         # Restrict permissions to owner-only when staging
-        PRIVATE_MASK = 0o077
-        with temp_umask(PRIVATE_MASK):
+        with temp_umask(0o077):
             self.stage.create()
             self.stage.fetch(mirror_only)
         self._fetch_time = time.time() - start_time
@@ -1090,7 +1089,8 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         if checksum and self.version in self.versions:
             self.stage.check()
 
-        with temp_umask(PRIVATE_MASK):
+        # Restrict permissions to owner-only when caching locally
+        with temp_umask(0o077):
             cached_path = self.stage.cache_local()
         if cached_path is not None:
             fp.set_permissions_by_spec(cached_path, self.spec)

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -489,7 +489,7 @@ class Stage(object):
             self.fetcher.check()
 
     def cache_local(self):
-        spack.caches.fetch_cache.store(
+        return spack.caches.fetch_cache.store(
             self.fetcher, self.mirror_paths.storage_path)
 
     def cache_mirror(self, stats):

--- a/lib/spack/spack/util/pattern.py
+++ b/lib/spack/spack/util/pattern.py
@@ -64,8 +64,12 @@ def composite(interface=None, method_list=None, container=list):
 
             def __get__(self, instance, owner):
                 def getter(*args, **kwargs):
+                    final_result = None
                     for item in instance:
-                        getattr(item, self.name)(*args, **kwargs)
+                        result = getattr(item, self.name)(*args, **kwargs)
+                        if final_result is None:
+                            final_result = result
+                    return final_result
                 # If we are using this descriptor to wrap a method from an
                 # interface, then we must conditionally use the
                 # `functools.wraps` decorator to set the appropriate fields


### PR DESCRIPTION
When Spack is used on shared systems, the cache directories are by default world- and group- readable, even when the `packages.py` restricts the permissions of the installed modulefile and prefix.

This is something of a "straw man" PR since I'm not sure it's the best (least intrusive) way to make the changes, so I'd be happy for any suggestions of how to change it.

Resolves #13784.