### PR TITLE
add `spack spec --uarch-flags` option

### DIFF
--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -9,6 +9,7 @@ import argparse
 import sys
 
 import llnl.util.tty as tty
+import llnl.util.tty.color as color
 
 import spack
 import spack.cmd
@@ -37,6 +38,9 @@ def setup_parser(subparser):
     subparser.add_argument(
         '-N', '--namespaces', action='store_true', default=False,
         help='show fully qualified package names')
+    subparser.add_argument(
+        '-u', '--uarch-flags', action='store_true', default=False,
+        help='show microarchitecture optimization flags')
 
     subparser.add_argument(
         '-t', '--types', action='store_true', default=False,
@@ -49,6 +53,7 @@ def spec(parser, args):
     name_fmt = '{namespace}.{name}' if args.namespaces else '{name}'
     fmt = '{@version}{%compiler}{compiler_flags}{variants}{arch=architecture}'
     install_status_fn = spack.spec.Spec.install_status
+
     kwargs = {
         'cover': args.cover,
         'format': name_fmt + fmt,
@@ -79,6 +84,11 @@ def spec(parser, args):
         print(spec.tree(**kwargs))
 
         kwargs['hashes'] = args.long or args.very_long
+        if args.uarch_flags:
+            kwargs["format"] += color.colorize(
+                " @Kuarch_flags=\"{uarch_flags}\"@."
+            )
+
         print("Concretized")
         print("--------------------------------")
         spec.concretize()

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3769,6 +3769,17 @@ class Spec(object):
         result = out.getvalue()
         return result
 
+    @property
+    def uarch_flags(self):
+        """Specific target optimization flags."""
+        if not self.concrete:
+            return None
+
+        return self.target.optimization_flags(
+            self.compiler.name,
+            self.compiler.version,
+        )
+
     def cformat(self, *args, **kwargs):
         """Same as format, but color defaults to auto instead of False."""
         kwargs = kwargs.copy()

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1053,7 +1053,7 @@ function _spack_spec {
     then
         compgen -W "-h --help -l --long -L --very-long -I --install-status
                     -j --json -y --yaml -c --cover -N --namespaces
-                    -t --types" -- "$cur"
+                    -t --types -u --uarch-flags" -- "$cur"
     else
         compgen -W "$(_all_packages)" -- "$cur"
     fi


### PR DESCRIPTION
- [x] Add a convenience property that automatically gets the uarch flags for the particular compiler.  This makes it much simpler to get the target flags from a concrete spec.
- [x] `spack spec --uarch-flags` will now show microarch flags for each node in the DAG, so that you can see what flags will be used more easily.
- [ ] docs
- [ ] test

Example:

```console
$ spack spec --uarch-flags hdf5%gcc
Input spec
--------------------------------
hdf5%gcc

Concretized
--------------------------------
hdf5@1.10.5%gcc@8.2.0~cxx~debug~fortran~hl+mpi patches=b61e2f058964ad85be6ee5ecea10080bf79e73f83ff88d1fa4b602d00209da9c +pic+shared~szip~threadsafe arch=darwin-mojave-skylake uarch_flags="-march=skylake -mtune=skylake"
    ^openmpi@3.1.4%gcc@8.2.0~cuda+cxx_exceptions fabrics=none ~java~legacylaunchers~memchecker~pmi schedulers=none ~sqlite3~thread_multiple+vt arch=darwin-mojave-skylake uarch_flags="-march=skylake -mtune=skylake"
        ^hwloc@1.11.11%gcc@8.2.0~cairo~cuda~gl+libxml2~nvml~pci+shared arch=darwin-mojave-skylake uarch_flags="-march=skylake -mtune=skylake"
            ^libxml2@2.9.9%gcc@8.2.0~python arch=darwin-mojave-skylake uarch_flags="-march=skylake -mtune=skylake"
                ^libiconv@1.16%gcc@8.2.0 arch=darwin-mojave-skylake uarch_flags="-march=skylake -mtune=skylake"
                ^pkgconf@1.6.3%gcc@8.2.0 arch=darwin-mojave-skylake uarch_flags="-march=skylake -mtune=skylake"
                ^xz@5.2.4%gcc@8.2.0 arch=darwin-mojave-skylake uarch_flags="-march=skylake -mtune=skylake"
                ^zlib@1.2.11%gcc@8.2.0+optimize+pic+shared arch=darwin-mojave-skylake uarch_flags="-march=skylake -mtune=skylake"
```

