### PR TITLE
Add missing metis include to superlu-dist

### DIFF
--- a/var/spack/repos/builtin/packages/superlu-dist/package.py
+++ b/var/spack/repos/builtin/packages/superlu-dist/package.py
@@ -55,8 +55,8 @@ class SuperluDist(CMakePackage):
             '-DTPL_PARMETIS_LIBRARIES=%s' % spec['parmetis'].libs.ld_flags +
             ';' + spec['metis'].libs.ld_flags,
             '-DTPL_PARMETIS_INCLUDE_DIRS=%s' %
-                spec['parmetis'].prefix.include +
-                ';' + spec['metis'].prefix.include
+            spec['parmetis'].prefix.include +
+            ';' + spec['metis'].prefix.include
         ]
 
         if (spec.satisfies('%xl') or spec.satisfies('%xl_r')) and \

--- a/var/spack/repos/builtin/packages/superlu-dist/package.py
+++ b/var/spack/repos/builtin/packages/superlu-dist/package.py
@@ -54,7 +54,8 @@ class SuperluDist(CMakePackage):
             '-DUSE_XSDK_DEFAULTS=YES',
             '-DTPL_PARMETIS_LIBRARIES=%s' % spec['parmetis'].libs.ld_flags +
             ';' + spec['metis'].libs.ld_flags,
-            '-DTPL_PARMETIS_INCLUDE_DIRS=%s' % spec['parmetis'].prefix.include
+            '-DTPL_PARMETIS_INCLUDE_DIRS=%s' % spec['parmetis'].prefix.include +
+            ';' + spec['metis'].prefix.include
         ]
 
         if (spec.satisfies('%xl') or spec.satisfies('%xl_r')) and \

--- a/var/spack/repos/builtin/packages/superlu-dist/package.py
+++ b/var/spack/repos/builtin/packages/superlu-dist/package.py
@@ -54,8 +54,9 @@ class SuperluDist(CMakePackage):
             '-DUSE_XSDK_DEFAULTS=YES',
             '-DTPL_PARMETIS_LIBRARIES=%s' % spec['parmetis'].libs.ld_flags +
             ';' + spec['metis'].libs.ld_flags,
-            '-DTPL_PARMETIS_INCLUDE_DIRS=%s' % spec['parmetis'].prefix.include +
-            ';' + spec['metis'].prefix.include
+            '-DTPL_PARMETIS_INCLUDE_DIRS=%s' %
+                spec['parmetis'].prefix.include +
+                ';' + spec['metis'].prefix.include
         ]
 
         if (spec.satisfies('%xl') or spec.satisfies('%xl_r')) and \


### PR DESCRIPTION
Ran into a problem compiling Superlu-dist because metis and parmetis was built in a different directories.  Adding metis's include directory solved this problem.