### PR TITLE
fix_cantera_installation

### DIFF
--- a/var/spack/repos/builtin/packages/cantera/package.py
+++ b/var/spack/repos/builtin/packages/cantera/package.py
@@ -27,10 +27,10 @@ class Cantera(SConsPackage):
 
     # Required dependencies
     depends_on('fmt@3.0.0:3.0.2', when='@2.3.0:')
-    depends_on('googletest',      when='@2.3.0:')
+    depends_on('googletest+gmock', when='@2.3.0:')
     depends_on('eigen',           when='@2.3.0:')
     depends_on('boost')
-    depends_on('sundials', when='+sundials')  # must be compiled with -fPIC
+    depends_on('sundials@:3.1.2', when='+sundials')  # must be compiled with -fPIC
     depends_on('blas')
     depends_on('lapack')
 


### PR DESCRIPTION
For a successful cantera installation, googletest has to be installed with gmock on, and sundials has to be of version less than 3.2