### PR TITLE
argobots: consistently use 'master'

### DIFF
--- a/var/spack/repos/builtin/packages/argobots/package.py
+++ b/var/spack/repos/builtin/packages/argobots/package.py
@@ -28,10 +28,10 @@ class Argobots(AutotoolsPackage):
 
     variant("valgrind", default=False, description="Enable Valgrind")
 
-    depends_on("m4", type=("build"), when="@develop")
-    depends_on("autoconf", type=("build"), when="@develop")
-    depends_on("automake", type=("build"), when="@develop")
-    depends_on("libtool", type=("build"), when="@develop")
+    depends_on("m4", type=("build"), when="@master")
+    depends_on("autoconf", type=("build"), when="@master")
+    depends_on("automake", type=("build"), when="@master")
+    depends_on("libtool", type=("build"), when="@master")
     depends_on("valgrind", when="+valgrind")
 
     def configure_args(self):


### PR DESCRIPTION
Commit 71cd91e4 changed "latest from git" to 'master' from former
'develop'.  Build dependencies still pointed to @develop, though