### PR TITLE
Moved build tests from Travis to Github Actions

### DIFF
--- a/.github/workflows/build_tests_linux.yaml
+++ b/.github/workflows/build_tests_linux.yaml
@@ -20,6 +20,13 @@ jobs:
         package: [lz4, mpich, tut, py-setuptools, openjpeg, r-rcpp]
     steps:
     - uses: actions/checkout@v1
+    - name: Cache ccache's store
+      uses: actions/cache@v1
+      with:
+        path: ~/.ccache
+        key: ccache-build-${{ matrix.package }}
+        restore-keys: |
+          ccache-build-${{ matrix.package }}
     - name: Setup Python
       uses: actions/setup-python@v1
       with:
@@ -31,7 +38,7 @@ jobs:
         perl --version
     - name: Copy Configuration
       run: |
-        ccache -M 2G && ccache -z
+        ccache -M 300M && ccache -z
         # Set up external deps for build tests, b/c they take too long to compile
         cp share/spack/qa/configuration/*.yaml etc/spack/
     - name: Run the build test

--- a/.github/workflows/build_tests_linux.yaml
+++ b/.github/workflows/build_tests_linux.yaml
@@ -9,6 +9,11 @@ on:
     branches:
     - master
     - develop
+    paths:
+      - 'lib/**'
+      - 'share/**'
+      - 'etc/**'
+      - 'bin/**'
 
 jobs:
   build:

--- a/.github/workflows/build_tests_linux.yaml
+++ b/.github/workflows/build_tests_linux.yaml
@@ -9,11 +9,15 @@ on:
     branches:
     - master
     - develop
-    paths:
-      - 'lib/**'
-      - 'share/**'
-      - 'etc/**'
-      - 'bin/**'
+    paths-ignore:
+      # Don't run if we only modified packages in the built-in repository
+      - 'var/spack/repos/builtin/**'
+      - '!var/spack/repos/builtin/packages/lz4/**'
+      - '!var/spack/repos/builtin/packages/mpich/**'
+      - '!var/spack/repos/builtin/packages/tut/**'
+      - '!var/spack/repos/builtin/packages/py-setuptools/**'
+      - '!var/spack/repos/builtin/packages/openjpeg/**'
+      - '!var/spack/repos/builtin/packages/r-rcpp/**'
 
 jobs:
   build:

--- a/.github/workflows/build_tests_linux.yaml
+++ b/.github/workflows/build_tests_linux.yaml
@@ -1,0 +1,41 @@
+name: Build Tests Linux
+
+on:
+  push:
+    branches:
+    - master
+    - develop
+  pull_request:
+    branches:
+    - master
+    - develop
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        package: [lz4, mpich, tut, py-setuptools, openjpeg, r-rcpp]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Setup Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Install System Packages
+      run: |
+        sudo apt-get -yqq install ccache gfortran perl perl-base r-base r-base-core r-base-dev findutils openssl libssl-dev libpciaccess-dev
+        R --version
+        perl --version
+    - name: Copy Configuration
+      run: |
+        ccache -M 2G && ccache -z
+        # Set up external deps for build tests, b/c they take too long to compile
+        cp share/spack/qa/configuration/*.yaml etc/spack/
+    - name: Run the build test
+      run: |
+        . share/spack/setup-env.sh
+        SPEC=${{ matrix.package }} share/spack/qa/run-build-tests
+        ccache -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,52 +61,10 @@ jobs:
       language: generic
       env: [ TEST_SUITE=unit, PYTHON_VERSION=2.7, COVERAGE=true ]
       if: type != pull_request
-# mpich (AutotoolsPackage)
-    - stage: 'build tests'
-      python: '2.7'
-      os: linux
-      language: python
-      env: [ TEST_SUITE=build, 'SPEC=mpich' ]
-# astyle (MakefilePackage)
-    - python: '3.8'
-      os: linux
-      language: python
-      env: [ TEST_SUITE=build, 'SPEC=astyle' ]
-# tut (WafPackage)
-    - python: '3.8'
-      os: linux
-      language: python
-      env: [ TEST_SUITE=build, 'SPEC=tut' ]
-# py-setuptools (PythonPackage)
-    - python: '3.8'
-      os: linux
-      language: python
-      env: [ TEST_SUITE=build, 'SPEC=py-setuptools' ]
-# perl-dbi (PerlPackage)
-#    - python: '3.8'
-#      os: linux
-#      language: python
-#      env: [ TEST_SUITE=build, 'SPEC=perl-dbi' ]
-# openjpeg (CMakePackage + external cmake)
-    - python: '3.8'
-      os: linux
-      language: python
-      env: [ TEST_SUITE=build, 'SPEC=openjpeg' ]
-# r-rcpp (RPackage + external R)
-    - python: '3.8'
-      os: linux
-      language: python
-      env: [ TEST_SUITE=build, 'SPEC=r-rcpp' ]
-# mpich (AutotoolsPackage)
-    - python: '3.8'
-      os: linux
-      language: python
-      env: [ TEST_SUITE=build, 'SPEC=mpich' ]
 
 stages:
   - 'style checks'
   - 'unit tests + documentation'
-  - 'build tests'
 
 
 #=============================================================================
@@ -181,11 +139,6 @@ before_script:
 
   # Need this to be able to compute the list of changed files
   - git fetch origin ${TRAVIS_BRANCH}:${TRAVIS_BRANCH}
-
-  # Set up external deps for build tests, b/c they take too long to compile
-  - if [[ "$TEST_SUITE" == "build" ]]; then
-        cp share/spack/qa/configuration/*.yaml etc/spack/;
-    fi
 
 #=============================================================================
 # Building

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # <img src="https://cdn.rawgit.com/spack/spack/develop/share/spack/logo/spack-logo.svg" width="64" valign="middle" alt="Spack"/> Spack
 
 [![Build Status](https://travis-ci.org/spack/spack.svg?branch=develop)](https://travis-ci.org/spack/spack)
+[![](https://github.com/spack/spack/workflows/Build%20Tests%20Linux/badge.svg)](https://github.com/spack/spack/actions)
 [![codecov](https://codecov.io/gh/spack/spack/branch/develop/graph/badge.svg)](https://codecov.io/gh/spack/spack)
 [![Read the Docs](https://readthedocs.org/projects/spack/badge/?version=latest)](https://spack.readthedocs.io)
 [![Slack](https://spackpm.herokuapp.com/badge.svg)](https://spackpm.herokuapp.com)

--- a/share/spack/qa/configuration/packages.yaml
+++ b/share/spack/qa/configuration/packages.yaml
@@ -2,12 +2,25 @@ packages:
   cmake:
     buildable: False
     paths:
-      cmake@2.8.12.2: /usr
+      cmake@3.12.4: /usr
   r:
     buildable: False
     paths:
-      r@3.0.2: /usr
+      r@3.4.4: /usr
   perl:
     buildable: False
     paths:
-      perl@5.18.2: /usr
+      perl@5.26.1: /usr
+  findutils:
+    buildable: False
+    paths:
+      findutils@4.6.0: /usr
+  openssl:
+    buildable: False
+    paths:
+      openssl@1.1.1: /usr
+  libpciaccess:
+    buildable: False
+    paths:
+      libpciaccess@0.13.5: /usr
+


### PR DESCRIPTION
refers #13485
closes #5842

This PR moves build smoke tests from TravisCI and migrates them to Github Actions. The result is that build tests are performed in parallel with unit tests and they don't hog additional resources on Travis. The workflow will not run if a PR only changes packages in the built-in repository, but will always run on pushes to develop or master.