### PR TITLE
Bugfix: spack find -p fails in environment

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -212,6 +212,9 @@ def disambiguate_spec(spec, env, local=False, installed=True):
 
 
 def gray_hash(spec, length):
+    if not length:
+        # default to maximum hash length
+        length = 32
     h = spec.dag_hash(length) if spec.concrete else '-' * length
     return colorize('@K{%s}' % h)
 

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -171,7 +171,6 @@ def display_env(env, args, decorator):
         # set for abstract specs. Same for hashes
         root_args = copy.copy(args)
         root_args.paths = False
-        root_args.long = False
         root_args.very_long = False
 
         # Roots are displayed with variants, etc. so that we can see

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -168,9 +168,11 @@ def display_env(env, args, decorator):
         tty.msg('Root specs')
 
         # Root specs cannot be displayed with prefixes, since those are not
-        # set for abstract specs
+        # set for abstract specs. Same for hashes
         root_args = copy.copy(args)
         root_args.paths = False
+        root_args.long = False
+        root_args.very_long = False
 
         # Roots are displayed with variants, etc. so that we can see
         # specifically what the user asked for.

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -171,7 +171,6 @@ def display_env(env, args, decorator):
         # set for abstract specs. Same for hashes
         root_args = copy.copy(args)
         root_args.paths = False
-        root_args.very_long = False
 
         # Roots are displayed with variants, etc. so that we can see
         # specifically what the user asked for.

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from __future__ import print_function
+import copy
 
 import llnl.util.tty as tty
 import llnl.util.tty.color as color
@@ -166,11 +167,16 @@ def display_env(env, args, decorator):
     else:
         tty.msg('Root specs')
 
+        # Root specs cannot be displayed with prefixes, since those are not
+        # set for abstract specs
+        root_args = copy.copy(args)
+        root_args.paths = False
+
         # Roots are displayed with variants, etc. so that we can see
         # specifically what the user asked for.
         cmd.display_specs(
             env.user_specs,
-            args,
+            root_args,
             decorator=lambda s, f: color.colorize('@*{%s}' % f),
             namespace=True,
             show_flags=True,

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -309,11 +309,12 @@ def test_find_command_basic_usage(database):
 
 @pytest.mark.regression('9875')
 def test_find_prefix_in_env(mutable_mock_env_path, install_mockery, mock_fetch,
-                            mock_packages, mock_archive):
+                            mock_packages, mock_archive, config):
     """Test `find` formats requiring concrete specs work in environments."""
     env('create', 'test')
     with ev.read('test'):
         install('mpileaks')
         find('-p')
+        find('-l')
         find('-L')
         # Would throw error on regression

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -12,9 +12,12 @@ import spack.cmd.find
 from spack.main import SpackCommand
 from spack.spec import Spec
 from spack.util.pattern import Bunch
+import spack.environment as ev
 
 
 find = SpackCommand('find')
+env = SpackCommand('env')
+install = SpackCommand('install')
 
 base32_alphabet = 'abcdefghijklmnopqrstuvwxyz234567'
 
@@ -302,3 +305,15 @@ def test_find_no_sections(database, config):
 def test_find_command_basic_usage(database):
     output = find()
     assert 'mpileaks' in output
+
+
+@pytest.mark.regression('9875')
+def test_find_prefix_in_env(mutable_mock_env_path, install_mockery, mock_fetch,
+                            mock_packages, mock_archive):
+    """Test `find` formats requiring concrete specs work in environments."""
+    env('create', 'test')
+    with ev.read('test'):
+        install('mpileaks')
+        find('-p')
+        find('-L')
+        # Would throw error on regression


### PR DESCRIPTION
Fixes #13971
Fixes #9875 (thanks @abernede and @nazavode for pointing that out).

Solution: force spack find -p to print abstract specs without prefixes

Spack was trying to print the prefix of an abstract spec, which causes an attribute error (or moral equivalent).