### PR TITLE
Release a new version v2.1.8.0 for SZ

### DIFF
--- a/var/spack/repos/builtin/packages/sz/package.py
+++ b/var/spack/repos/builtin/packages/sz/package.py
@@ -11,11 +11,12 @@ class Sz(AutotoolsPackage):
     """Error-bounded Lossy Compressor for HPC Data."""
 
     homepage = "https://collab.cels.anl.gov/display/ESR/SZ"
-    url      = "https://github.com/disheng222/SZ/archive/v2.0.2.0.tar.gz"
+    url      = "https://github.com/disheng222/SZ/archive/v2.1.8.0.tar.gz"
 
     git      = "https://github.com/disheng222/SZ.git"
 
     version('develop', branch='master')
+    version('2.1.8.0', sha256='8d6bceb59a03d52e601e29d9b35c21b146c248abae352f9a4828e91d8d26aa24')
     version('2.0.2.0',  sha256='176c65b421bdec8e91010ffbc9c7bf7852c799972101d6b66d2a30d9702e59b0')
     version('1.4.13.5', sha256='b5e37bf3c377833eed0a7ca0471333c96cd2a82863abfc73893561aaba5f18b9')
     version('1.4.13.4', sha256='c99b95793c48469cac60e6cf82f921babf732ca8c50545a719e794886289432b')

--- a/var/spack/repos/builtin/packages/sz/package.py
+++ b/var/spack/repos/builtin/packages/sz/package.py
@@ -12,6 +12,7 @@ class Sz(AutotoolsPackage):
 
     homepage = "https://collab.cels.anl.gov/display/ESR/SZ"
     url      = "https://github.com/disheng222/SZ/archive/v2.1.8.0.tar.gz"
+    maintainers = ['disheng222']
 
     git      = "https://github.com/disheng222/SZ.git"
 

--- a/var/spack/repos/builtin/packages/sz/package.py
+++ b/var/spack/repos/builtin/packages/sz/package.py
@@ -13,6 +13,7 @@ class Sz(AutotoolsPackage):
     homepage = "https://collab.cels.anl.gov/display/ESR/SZ"
     url      = "https://github.com/disheng222/SZ/archive/v2.1.8.0.tar.gz"
     maintainers = ['disheng222']
+    parallel = False
 
     git      = "https://github.com/disheng222/SZ.git"
 


### PR DESCRIPTION
I am releasing v2.1.8.0 for SZ, also modifying package.py by adding maintainer and parallel=False.
I ran 'spack test' but failed. However, it seems that failure has nothing to do with my modification. I just modified sz/package.py. The failures are 'test_url_parse', 'test_url_local_file_path', 'test_url_join_local_paths'. 