### PR TITLE
intel-tbb: Fix version check for clang builds

### DIFF
--- a/var/spack/repos/builtin/packages/intel-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-tbb/package.py
@@ -63,7 +63,7 @@ class IntelTbb(Package):
     #
     #    See https://github.com/intel/tbb/pull/147 for details.
     #
-    conflicts('%clang', when='@:2019.7',
+    conflicts('%clang', when='@:2019.6',
               msg='2019.7 or later required for clang')
 
     conflicts('%gcc@6.1:', when='@:4.4.3',


### PR DESCRIPTION
Update to #13893. Use correct range check for the version. This has been tested with gcc for 2019.5-2019.8 and with clang for 2019.7-2019.8. Once #13913 is merged, this will build cleanly.

Ping @mwkrentel