### PR TITLE
New package: swipl

### DIFF
--- a/var/spack/repos/builtin/packages/py-cheroot/package.py
+++ b/var/spack/repos/builtin/packages/py-cheroot/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack import *
+
+
+class PyCheroot(PythonPackage):
+    """ Highly-optimized, pure-python HTTP server """
+
+    homepage = "https://cheroot.cherrypy.org/"
+    url      = "https://pypi.io/packages/source/c/cheroot/cheroot-6.5.5.tar.gz"
+
+    version(
+        '6.5.5', sha256='f6a85e005adb5bc5f3a92b998ff0e48795d4d98a0fbb7edde47a7513d4100601')
+
+    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools-scm@1.15.0:', type='build')
+    depends_on('py-setuptools-scm-git-archive@1.0:', type='build')
+    depends_on('py-more-itertools@2.6:', type=('build', 'run'))
+    depends_on('py-six@1.11.0:', type=('build', 'run'))
+    depends_on('py-backports-functools-lru-cache', type=('build', 'run'))
+    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/swipl/package.py
+++ b/var/spack/repos/builtin/packages/swipl/package.py
@@ -56,7 +56,9 @@ class Swipl(CMakePackage):
 
         def append_switch(variant, cmake_flag):
             val = 'ON' if variant in self.spec else 'OFF'
-            args.append('-D{}:BOOL={}'.format(cmake_flag, val))
+
+            flagdef = '-D' + cmake_flag + ':BOOL=' + val
+            args.append(flagdef)
 
         append_switch('+gmp', 'USE_GMP')
         append_switch('+xpce', 'SWIPL_PACKAGES_X')

--- a/var/spack/repos/builtin/packages/swipl/package.py
+++ b/var/spack/repos/builtin/packages/swipl/package.py
@@ -3,23 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-# ----------------------------------------------------------------------------
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install swipl
-#
-# You can edit this file again by typing:
-#
-#     spack edit swipl
-#
-# See the Spack documentation for more information on packaging.
-# ----------------------------------------------------------------------------
-
 from spack import *
 
 
@@ -39,9 +22,7 @@ class Swipl(CMakePackage):
     homepage = "https://www.swi-prolog.org"
     url      = "https://www.swi-prolog.org/download/stable/src/swipl-8.0.3.tar.gz"
 
-    # FIXME: Add a list of GitHub accounts to
-    # notify when the package is updated.
-    # maintainers = ['github_user1', 'github_user2']
+    maintainers = ['alexrobomind']
 
     version('8.0.3', sha256='cee59c0a477c8166d722703f6e52f962028f3ac43a5f41240ecb45dbdbe2d6ae')
 
@@ -81,6 +62,6 @@ class Swipl(CMakePackage):
         append_switch('+xpce', 'SWIPL_PACKAGES_X')
         append_switch('+odbc', 'SWIPL_PACKAGES_ODBC')
 
-        # The variants ssl and zlib are implicitly set up by the build system
+        # The variants ssl and zlib are implicitly set up by CMake
 
         return args

--- a/var/spack/repos/builtin/packages/swipl/package.py
+++ b/var/spack/repos/builtin/packages/swipl/package.py
@@ -51,6 +51,8 @@ class Swipl(CMakePackage):
     depends_on('fontconfig', when='+xpce')
     depends_on('pkg-config', when='+xpce')
 
+    conflicts('%intel', msg='Test builds with ICC failed when creating startup image')
+
     def cmake_args(self):
         args = []
 

--- a/var/spack/repos/builtin/packages/swipl/package.py
+++ b/var/spack/repos/builtin/packages/swipl/package.py
@@ -1,0 +1,86 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install swipl
+#
+# You can edit this file again by typing:
+#
+#     spack edit swipl
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+from spack import *
+
+
+class Swipl(CMakePackage):
+    """ SWI-Prolog is a versatile implementation of the Prolog language.
+    Although SWI-Prolog gained its popularity primarily in education,
+    its development is mostly driven by the needs for application development.
+    This is facilitated by a rich interface to other IT components by
+    supporting many document types and (network) protocols as well as a
+    comprehensive low-level interface to C that is the basis for high-level
+    interfaces to C++, Java (bundled), C#, Python, etc (externally available).
+
+    Data type extensions such as dicts and strings as well as full support
+    for Unicode and unbounded integers simplify smooth exchange of data
+    with other components."""
+
+    homepage = "https://www.swi-prolog.org"
+    url      = "https://www.swi-prolog.org/download/stable/src/swipl-8.0.3.tar.gz"
+
+    # FIXME: Add a list of GitHub accounts to
+    # notify when the package is updated.
+    # maintainers = ['github_user1', 'github_user2']
+
+    version('8.0.3', sha256='cee59c0a477c8166d722703f6e52f962028f3ac43a5f41240ecb45dbdbe2d6ae')
+
+    variant('gmp', default=True, description='bignum and rational number support')
+    variant('xpce', default=True, description='GUI support')
+    variant('ssl', default=True, description='SSL support')
+    variant('zlib', default=True, description='Compressed streams support')
+    variant('odbc', default=True, description='ODBC database access')
+    variant('unwind', default=True, description='Build with stack traces in crash reports')
+
+    depends_on('uuid')
+    depends_on('readline')
+
+    depends_on('gmp', when='+gmp')
+    depends_on('unwind', when='+unwind')
+    depends_on('unixodbc', when='+odbc')
+    depends_on('openssl', when='+ssl')
+    depends_on('zlib', when='+zlib')
+
+    depends_on('libxt', when='+xpce')
+    depends_on('libx11', when='+xpce')
+    depends_on('libjpeg', when='+xpce')
+    depends_on('libxpm', when='+xpce')
+
+    depends_on('libxft', when='+xpce')
+    depends_on('fontconfig', when='+xpce')
+    depends_on('pkg-config', when='+xpce')
+
+    def cmake_args(self):
+        args = []
+
+        def append_switch(variant, cmake_flag):
+            val = 'ON' if variant in self.spec else 'OFF'
+            args.append('-D{}:BOOL={}'.format(cmake_flag, val))
+
+        append_switch('+gmp', 'USE_GMP')
+        append_switch('+xpce', 'SWIPL_PACKAGES_X')
+        append_switch('+odbc', 'SWIPL_PACKAGES_ODBC')
+
+        # The variants ssl and zlib are implicitly set up by the build system
+
+        return args


### PR DESCRIPTION
This pull request contains a new package, that sets up the SWI-Prolog interpreter. Since some dependencies are optional, I added variants that control whether Spack should try installing them.

I am not a member of the SWIPL development team, just a user of the program. The configuration scripts are based on the following two documentation pages:

https://www.swi-prolog.org/build/unix.html
https://github.com/SWI-Prolog/swipl-devel/blob/master/CMAKE.md

I could build and install with GCC and all variants enabled, as well as all variants disabled. Compilation of the interpreter with ICC was also successful, but when building the core database, the interpreter failed with a segmentation fault (so it could not be installed with ICC). I am not sure whether that is a problem of the setup of our supercomputer. Should I include a conflicts_with("%icc") in the package?

Because some dependencies (e.g. pkg-config) have multiple providers, and the preferred version of libunwind is outdated, I could not install the package in "vanilla" setup, but had to specify dependency spec (^libunwind@2018.10.12 ^pkg-config). Should this be somehow addressed in the package, or are those issues of the dependency resolution?