### PR TITLE
CUDA: Keep 10.1.243 As Preferred

### DIFF
--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -60,7 +60,8 @@ class Cuda(Package):
         key = "{0}-{1}".format(platform.system(), platform.machine())
         pkg = packages.get(key)
         if pkg:
-            version(ver, sha256=pkg[0], url=pkg[1], expand=False)
+            version(ver, sha256=pkg[0], url=pkg[1], expand=False,
+                    preferred=(ver == "10.1.243"))  # see GH issue 13969
 
     # macOS Mojave drops NVIDIA graphics card support -- official NVIDIA
     # drivers do not exist for Mojave. See


### PR DESCRIPTION
Keep CUDA 10.1.243 as the preferred version until the issue of including implementation details of libcu++ is addressed: #13969 #13819

Related: #13991