### PR TITLE
Catch StopIteration Exception in Case of No Specs to Install

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -994,7 +994,10 @@ class Environment(object):
         else:
             # spec might be in the user_specs, but not installed.
             # TODO: Redo name-based comparison for old style envs
-            spec = next(s for s in self.user_specs if s.satisfies(user_spec))
+            try:
+              spec = next(s for s in self.user_specs if s.satisfies(user_spec))
+            except StopIteration as it:
+              pass
             concrete = self.specs_by_hash.get(spec.build_hash())
             if not concrete:
                 concrete = spec.concretized()


### PR DESCRIPTION
This prevents failure of commands like `spack install --only dependencies <spec>` where `<spec>` has no dependencies. This seems to be OK when not in the presence of an Spack environment, but for some reason when you run such a command in a directory with a `spack.yaml` you would get a StopIteration exception due to the modified lines of environment.py.
@becker33 @adrienbernede 