### PR TITLE
Fastmath: Added required version

### DIFF
--- a/var/spack/repos/builtin/packages/fastmath/package.py
+++ b/var/spack/repos/builtin/packages/fastmath/package.py
@@ -15,7 +15,7 @@ class Fastmath(BundlePackage):
 
     homepage = "https://fastmath-scidac.org/"
 
-    version('0.0.1')  # TODO: What should this be?
+    version('latest')
 
     depends_on('amrex')  # default is 3 dimensions
     depends_on('chombo@3.2')

--- a/var/spack/repos/builtin/packages/fastmath/package.py
+++ b/var/spack/repos/builtin/packages/fastmath/package.py
@@ -13,7 +13,9 @@ class Fastmath(BundlePackage):
     libraries for ODE's, Time Integrators, Iterative, Non-Linear, and Direct
     Solvers."""
 
-    homepage = "www.fastmath-scidac.org/"
+    homepage = "https://fastmath-scidac.org/"
+
+    version('0.0.1')  # TODO: What should this be?
 
     depends_on('amrex')  # default is 3 dimensions
     depends_on('chombo@3.2')


### PR DESCRIPTION
I'm working on "build system" documentation for ``BundlePackage`` and noticed I could not build this package because it does not have a version.

This commit adds a version placeholder and tweaks the URL (since the redirect caused problems for me) .