### PR TITLE
Spec Header Dirs: Only first include/

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1156,7 +1156,9 @@ class HeaderList(FileList):
 
     # Make sure to only match complete words, otherwise path components such
     # as "xinclude" will cause false matches.
-    include_regex = re.compile(r'(.*)(\binclude\b)(.*)')
+    # Avoid matching paths such as <prefix>/include/something/detail/include,
+    # e.g. in the CUDA Toolkit which ships internal libc++ headers.
+    include_regex = re.compile(r'(.*?)(\binclude\b)(.*)')
 
     def __init__(self, files):
         super(HeaderList, self).__init__(files)

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -17,7 +17,7 @@ from spack.util.executable import Executable
 from spack.util.spack_yaml import syaml_dict, syaml_str
 from spack.util.environment import EnvironmentModifications
 
-from llnl.util.filesystem import LibraryList
+from llnl.util.filesystem import LibraryList, HeaderList
 
 
 @pytest.fixture
@@ -242,6 +242,18 @@ def test_set_build_environment_variables(
     directories via the SPACK_LINK_DIRS and SPACK_INCLUDE_DIRS environment
     variables.
     """
+
+    # https://github.com/spack/spack/issues/13969
+    cuda_headers = HeaderList([
+        'prefix/include/cuda_runtime.h',
+        'prefix/include/cuda/atomic',
+        'prefix/include/cuda/std/detail/libcxx/include/ctype.h'])
+    cuda_include_dirs = cuda_headers.directories
+    assert(os.path.join('prefix', 'include')
+           in cuda_include_dirs)
+    assert(os.path.join('prefix', 'include', 'cuda', 'std', 'detail',
+                        'libcxx', 'include')
+           not in cuda_include_dirs)
 
     root = spack.spec.Spec('dt-diamond')
     root.concretize()

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -60,8 +60,7 @@ class Cuda(Package):
         key = "{0}-{1}".format(platform.system(), platform.machine())
         pkg = packages.get(key)
         if pkg:
-            version(ver, sha256=pkg[0], url=pkg[1], expand=False,
-                    preferred=(ver == "10.1.243"))  # see GH issue 13969
+            version(ver, sha256=pkg[0], url=pkg[1], expand=False)
 
     # macOS Mojave drops NVIDIA graphics card support -- official NVIDIA
     # drivers do not exist for Mojave. See


### PR DESCRIPTION
Avoid matching recurringly nested include paths that most certainly refer to internally shipped libraries in packages.
Example in CUDA Toolkit #13819 #13983, shipping a libc++ fork internally with libcu++ since 10.2.89: `<prefix>/include/cuda/std/detail/libcxx/include`.

Quick fix #13969 

A more thorough solution is not to recursively search for headers anymore since this is against the idea of C/C++ facade headers: https://github.com/spack/spack/issues/13969#issuecomment-561929481 Unfortunately, it's not that easy for us to find which headers are facade and which ones are detail, but I am not sure we have to know anything besides the include dir locations.

Generally, just searching for *any* `include/` in the overall path (instead of just taking the `<prefix>/include`) is dangerous as well. For example, spack could be installed in `/my/large/software/include/here/is/axels/home/src/spack/` ;-)

General policy suggestion: just add `<prefix>/include` to the build environment by default. Packages that break this unix-wide default should provide the
```py
@property
def headers(self):
```

@adamjstewart mentioned on Slack that some Python packages might need special treatment, let's see if we can find examples again to double check.