### PR TITLE
docs: Minimal BundlePackage build system doc

### DIFF
--- a/lib/spack/docs/build_systems.rst
+++ b/lib/spack/docs/build_systems.rst
@@ -56,6 +56,7 @@ on these ideas for each distinct build system that Spack supports:
    :maxdepth: 1
    :caption: Other
 
+   build_systems/bundlepackage
    build_systems/cudapackage
    build_systems/intelpackage
    build_systems/custompackage

--- a/lib/spack/docs/build_systems/bundlepackage.rst
+++ b/lib/spack/docs/build_systems/bundlepackage.rst
@@ -1,0 +1,46 @@
+.. Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+   Spack Project Developers. See the top-level COPYRIGHT file for details.
+
+   SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+.. _bundlepackage
+
+-------------
+BundlePackage
+-------------
+
+``BundlePackage`` represents a set of packages that are expected to work well
+together, such as a collection of commonly used software libraries.  The
+associated software is specified as bundle dependencies.
+
+
+^^^^^^^^
+Creation
+^^^^^^^^
+
+Be sure to specify the ``bundle`` template if you are using ``spack create``
+to generate a package from the template.
+
+
+^^^^^^
+Phases
+^^^^^^
+
+The ``BundlePackage`` base class does not provide any phases by default
+since the bundle does not represent a build system.
+
+
+^^^
+URL
+^^^
+
+The ``url`` property does not have meaning since there is no package-specific
+code to fetch.
+
+
+^^^^^^^
+Version
+^^^^^^^
+
+At least one ``version`` must be specified in order for the package to
+build.

--- a/lib/spack/docs/build_systems/bundlepackage.rst
+++ b/lib/spack/docs/build_systems/bundlepackage.rst
@@ -3,7 +3,7 @@
 
    SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-.. _bundlepackage
+.. _bundlepackage:
 
 -------------
 BundlePackage
@@ -19,7 +19,13 @@ Creation
 ^^^^^^^^
 
 Be sure to specify the ``bundle`` template if you are using ``spack create``
-to generate a package from the template.
+to generate a package from the template.  For example, use the following
+command to create a bundle package whose class name will be ``Mybundle``:
+
+.. code-block:: console
+
+    $ spack create --template bundle --name mybundle
+
 
 
 ^^^^^^


### PR DESCRIPTION
Added a basic ``build_systems`` page for the ``BundlePackage``.