### PR TITLE
docs: Alphabetize create cmd template options

### DIFF
--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -417,7 +417,7 @@ templates = {
 
 
 def setup_parser(subparser):
-    options = templates.keys()
+    options = sorted(templates.keys())
     subparser.add_argument(
         'url', nargs='?',
         help="url of package archive")

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -417,7 +417,6 @@ templates = {
 
 
 def setup_parser(subparser):
-    options = sorted(templates.keys())
     subparser.add_argument(
         'url', nargs='?',
         help="url of package archive")
@@ -428,9 +427,8 @@ def setup_parser(subparser):
         '-n', '--name',
         help="name of the package to create")
     subparser.add_argument(
-        '-t', '--template', metavar='TEMPLATE', choices=options,
-        help="build system template to use. options: {0}"
-        .format(', '.join(options)))
+        '-t', '--template', metavar='TEMPLATE', choices=sorted(templates.keys()),
+        help="build system template to use. options: %(choices)s")
     subparser.add_argument(
         '-r', '--repo',
         help="path to a repository where the package should be created")

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -417,6 +417,7 @@ templates = {
 
 
 def setup_parser(subparser):
+    options = templates.keys()
     subparser.add_argument(
         'url', nargs='?',
         help="url of package archive")
@@ -427,8 +428,9 @@ def setup_parser(subparser):
         '-n', '--name',
         help="name of the package to create")
     subparser.add_argument(
-        '-t', '--template', metavar='TEMPLATE', choices=templates.keys(),
-        help="build system template to use. options: %(choices)s")
+        '-t', '--template', metavar='TEMPLATE', choices=options,
+        help="build system template to use. options: {0}"
+        .format(', '.join(options)))
     subparser.add_argument(
         '-r', '--repo',
         help="path to a repository where the package should be created")

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -427,7 +427,8 @@ def setup_parser(subparser):
         '-n', '--name',
         help="name of the package to create")
     subparser.add_argument(
-        '-t', '--template', metavar='TEMPLATE', choices=sorted(templates.keys()),
+        '-t', '--template', metavar='TEMPLATE',
+        choices=sorted(templates.keys()),
         help="build system template to use. options: %(choices)s")
     subparser.add_argument(
         '-r', '--repo',


### PR DESCRIPTION
Noticed the docs --and ``spack create -h``-- were showing a format option instead of the template choices so this change fixes (or should) this problem.

UPDATE:  Changed to only alphabetize the options given #14014 fix.