### PR TITLE
Ceed: Added required version

### DIFF
--- a/var/spack/repos/builtin/packages/ceed/package.py
+++ b/var/spack/repos/builtin/packages/ceed/package.py
@@ -16,6 +16,8 @@ class Ceed(BundlePackage):
 
     homepage = "https://ceed.exascaleproject.org"
 
+    version('2.0')
+
     variant('cuda', default=False,
             description='Build MAGMA; enable CUDA support in libCEED and OCCA')
     variant('mfem', default=True, description='Build MFEM and Laghos')


### PR DESCRIPTION
I'm working on "build system" documentation for BundlePackage and noticed I could not build this package because it does not have a version.

This commit adds an initial version entry (the latest per the web site) to allow it to be built.