### PR TITLE
sz: Change optimization flags for Fujitsu compiler

### DIFF
--- a/var/spack/repos/builtin/packages/sz/fix_optimization.patch
+++ b/var/spack/repos/builtin/packages/sz/fix_optimization.patch
@@ -1,0 +1,11 @@
+--- spack-src/configure.org	2019-12-05 10:58:07.408584611 +0900
++++ spack-src/configure	2019-12-05 10:58:29.670909716 +0900
+@@ -3019,7 +3019,7 @@
+ 
+ 
+ # Checks for programs.
+-: ${CFLAGS=-O3 -std=c99 -Wall}
++: ${CFLAGS=-O2 -std=c99 -Wall}
+ ac_ext=c
+ ac_cpp='$CPP $CPPFLAGS'
+ ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'

--- a/var/spack/repos/builtin/packages/sz/package.py
+++ b/var/spack/repos/builtin/packages/sz/package.py
@@ -35,6 +35,10 @@ class Sz(AutotoolsPackage):
     variant('fortran', default=False,
             description='Enable fortran compilation')
 
+    # Part of latest sources don't support -O3 optimization
+    # with Fujitsu compiler.
+    patch('fix_optimization.patch', when='@2.0.2.0:%fj')
+
     def configure_args(self):
         args = []
         if '+fortran' in self.spec:


### PR DESCRIPTION
Part of latest sources couldn't execute to optimize `-O3` with Fujitsu compiler.
I'll lower optimize level to `-O2` only for Fujitsu compiler.

References for similar bugs:
https://github.com/HexHive/CFIXX/issues/6

Real error log:
```
libtool: compile:  /～/spack/lib/spack/env/fj/fcc -DHAVE_CONFIG_H -I. -I.. -I./ -I./compress -I./common -I./deprecated -I./dictBuilder -I./legacy -O3 -std=c99 -Wall -MT ./legacy/libzstd_la-zstd_v02.lo -MD -MP -MF ./legacy/.deps/libzstd_la-zstd_v02.Tpo -c ./legacy/zstd_v02.c  -fPIC -DPIC -o ./legacy/.libs/libzstd_la-zstd_v02.o

/～/lib64/libLLVMSupport.so.6(_ZN4ll
vm3sys15PrintStackTraceERNS_11raw_ostreamE+0x28)[0xffff9fd20888]
Stack dump:
0.      Program arguments: ～
1.      <eof> parser at end of file
2.      Per-module optimization passes
3.      Running pass 'CallGraph Pass Manager' on module './compress/zstd_opt.c'.
4.      Running pass 'Loop Pass Manager' on function '@ZSTD_compressBlock_opt_generic'
5.      Running pass 'Tree Height Reduction' on basic block '%7049'
libtool: compile:  /～/spack/lib/spack/env/fj/fcc -DHAVE_CONFIG_H -I. -I.. -I./ -I./compress -I./common -I./deprecated -I./dictBuilder -I./legacy -O3 -std=c99 -Wall -MT ./compress/libzstd_la-zstd_compress.lo -MD -MP -MF ./compress/.deps/libzstd_la-zstd_compress.Tpo -c ./compress/
zstd_compress.c -o ./compress/libzstd_la-zstd_compress.o >/dev/null 2>&1
...
```