### PR TITLE
Specify self for lua internal setup method

### DIFF
--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -118,8 +118,8 @@ class Lua(Package):
         return lua_patterns, lua_cpatterns
 
     def setup_dependent_build_environment(self, env, dependent_spec):
-        lua_patterns, lua_cpatterns = _setup_dependent_env_helper(
-            self, env, dependent_spec)
+        lua_patterns, lua_cpatterns = self._setup_dependent_env_helper(
+            env, dependent_spec)
 
         env.set('LUA_PATH', ';'.join(lua_patterns), separator=';')
         env.set('LUA_CPATH', ';'.join(lua_cpatterns), separator=';')
@@ -127,8 +127,8 @@ class Lua(Package):
     def setup_dependent_run_environment(self, env, dependent_spec):
         # For run time environment set only the path for dependent_spec and
         # prepend it to LUAPATH
-        lua_patterns, lua_cpatterns = _setup_dependent_env_helper(
-            self, env, dependent_spec)
+        lua_patterns, lua_cpatterns = self._setup_dependent_env_helper(
+            env, dependent_spec)
 
         if dependent_spec.package.extends(self.spec):
             env.prepend_path('LUA_PATH', ';'.join(lua_patterns), separator=';')


### PR DESCRIPTION
I noticed this when deploying software with the 0.13.2 release:

```
==> Installing lua-luaposix
==> Searching for binary cache of lua-luaposix
==> Warning: No Spack mirrors are currently configured
==> No binary for lua-luaposix found: installing from source
==> Error: NameError: name '_setup_dependent_env_helper' is not defined

/opt/spack/var/spack/repos/builtin/packages/lua/package.py:121, in setup_dependent_build_environment:
        120    def setup_dependent_build_environment(self, env, dependent_spec):
  >>    121        lua_patterns, lua_cpatterns = _setup_dependent_env_helper(
        122            self, env, dependent_spec)
        123
        124        env.set('LUA_PATH', ';'.join(lua_patterns), separator=';')
```

I've included a fix that worked in my case but it could very well be something I simply overlooked.

I tested this on the recent  commit (a288449f0b23acbec128bab943e42b403f4f4df9) using the `spack/ubuntu-bionic` container.