### PR TITLE
mesquite: fix build of the no mpi variant.

### DIFF
--- a/var/spack/repos/builtin/packages/mesquite/package.py
+++ b/var/spack/repos/builtin/packages/mesquite/package.py
@@ -36,5 +36,7 @@ class Mesquite(AutotoolsPackage):
             args.append('CC=%s' % self.spec['mpi'].mpicc)
             args.append('CXX=%s' % self.spec['mpi'].mpicxx)
             args.append('--with-mpi=%s' % self.spec['mpi'].prefix)
+        else:
+            args.append('--without-mpi')
 
         return args

--- a/var/spack/repos/builtin/packages/mesquite/package.py
+++ b/var/spack/repos/builtin/packages/mesquite/package.py
@@ -28,10 +28,13 @@ class Mesquite(AutotoolsPackage):
 
     def configure_args(self):
         args = [
-            'CC=%s' % self.spec['mpi'].mpicc,
-            'CXX=%s' % self.spec['mpi'].mpicxx,
-            '--with-mpi=%s' % self.spec['mpi'].prefix,
             '--enable-release',
             '--enable-shared',
         ]
+
+        if '+mpi' in self.spec:
+            args.append('CC=%s' % self.spec['mpi'].mpicc)
+            args.append('CXX=%s' % self.spec['mpi'].mpicxx)
+            args.append('--with-mpi=%s' % self.spec['mpi'].prefix)
+
         return args


### PR DESCRIPTION
Allows for the mesquite package to be built without mpi.

The --with-mpi option was always passed to the configure, it is now dependent on whether the mpi variant was chosen or not.