### PR TITLE
Add New package feh and supporting packages

### DIFF
--- a/var/spack/repos/builtin/packages/feh/package.py
+++ b/var/spack/repos/builtin/packages/feh/package.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack import *
+
+
+class Feh(MakefilePackage):
+    """
+    feh is an X11 image viewer aimed mostly at console users. Unlike most
+    other viewers, it does not have a fancy GUI, but simply displays images. It
+    is controlled via commandline arguments and configurable key/mouse
+    actions.
+    """
+
+    homepage = "https://feh.finalrewind.org/"
+    url      = "https://feh.finalrewind.org/feh-3.3.tar.bz2"
+
+    maintainers = ['TheQueasle']
+
+    version('3.3',   sha256='f3959958258111d5f7c9fbe2e165c52b9d5987f07fd1f37540a4abf9f9638811')
+    version('3.1.1', sha256='61d0242e3644cf7c5db74e644f0e8a8d9be49b7bd01034265cc1ebb2b3f9c8eb')
+
+    depends_on('imlib2')
+    depends_on('curl')
+    depends_on('libxinerama')
+    depends_on('libexif')
+    depends_on('libxt')
+
+    def build(self, spec, prefix):
+        make('PREFIX={0}'.format(prefix), 'exif=1', 'help=1')
+
+    def install(self, spec, prefix):
+        make('install', 'PREFIX={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/imlib2/package.py
+++ b/var/spack/repos/builtin/packages/imlib2/package.py
@@ -1,0 +1,28 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack import *
+
+
+class Imlib2(AutotoolsPackage):
+    """
+    Library that does image file loading and saving as well as rendering,
+    manipulation, arbitrary polygon support
+    """
+
+    homepage = "http://sourceforge.net/projects/enlightenment/"
+    url      = "http://downloads.sourceforge.net/enlightenment/imlib2-1.5.1.tar.bz2"
+    
+    maintainers = ['TheQueasle']
+
+    version('1.5.1', '390aa207693e051bb692f2db650c694b')
+
+    depends_on('libtiff')
+    depends_on('giflib')
+    depends_on('bzip2')
+    depends_on('freetype')
+    depends_on('libxext')
+    depends_on('libpng')
+    depends_on('libid3tag')
+    depends_on('libjpeg-turbo')

--- a/var/spack/repos/builtin/packages/imlib2/package.py
+++ b/var/spack/repos/builtin/packages/imlib2/package.py
@@ -16,7 +16,7 @@ class Imlib2(AutotoolsPackage):
 
     maintainers = ['TheQueasle']
 
-    version('1.5.1', '390aa207693e051bb692f2db650c694b')
+    version('1.5.1', 'fa4e57452b8843f4a70f70fd435c746ae2ace813250f8c65f977db5d7914baae')
 
     depends_on('libtiff')
     depends_on('giflib')

--- a/var/spack/repos/builtin/packages/imlib2/package.py
+++ b/var/spack/repos/builtin/packages/imlib2/package.py
@@ -13,7 +13,7 @@ class Imlib2(AutotoolsPackage):
 
     homepage = "http://sourceforge.net/projects/enlightenment/"
     url      = "http://downloads.sourceforge.net/enlightenment/imlib2-1.5.1.tar.bz2"
-    
+
     maintainers = ['TheQueasle']
 
     version('1.5.1', '390aa207693e051bb692f2db650c694b')

--- a/var/spack/repos/builtin/packages/libexif/package.py
+++ b/var/spack/repos/builtin/packages/libexif/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack import *
+
+
+class Libexif(AutotoolsPackage):
+    """A library to parse an EXIF file and read the data from those tags"""
+
+    homepage = "https://sourceforge.net/projects/libexif"
+    url      = "https://downloads.sourceforge.net/sourceforge/libexif/libexif-0.6.21.tar.bz2"
+
+    maintainers = ['TheQueasle']
+
+    version('0.6.21', sha256='16cdaeb62eb3e6dfab2435f7d7bccd2f37438d21c5218ec4e58efa9157d4d41a')
+    depends_on('glib')

--- a/var/spack/repos/builtin/packages/libid3tag/10_utf16.diff
+++ b/var/spack/repos/builtin/packages/libid3tag/10_utf16.diff
@@ -1,0 +1,48 @@
+#! /bin/sh -e
+## 10_utf16.dpatch by  <kurt@roeckx.be>
+##
+## All lines beginning with `## DP:' are a description of the patch.
+## DP: Handle bogus UTF16 sequences that have a length that is not
+## DP: an even number of 8 bit characters.
+
+if [ $# -lt 1 ]; then
+    echo "`basename $0`: script expects -patch|-unpatch as argument" >&2
+    exit 1
+fi
+
+[ -f debian/patches/00patch-opts ] && . debian/patches/00patch-opts
+patch_opts="${patch_opts:--f --no-backup-if-mismatch} ${2:+-d $2}"
+
+case "$1" in
+    -patch) patch -p1 ${patch_opts} < $0;;
+    -unpatch) patch -R -p1 ${patch_opts} < $0;;
+    *)
+        echo "`basename $0`: script expects -patch|-unpatch as argument" >&2
+        exit 1;;
+esac
+
+exit 0
+
+@DPATCH@
+diff -urNad libid3tag-0.15.1b/utf16.c /tmp/dpep.tKvO7a/libid3tag-0.15.1b/utf16.c
+--- libid3tag-0.15.1b/utf16.c	2006-01-13 15:26:29.000000000 +0100
++++ /tmp/dpep.tKvO7a/libid3tag-0.15.1b/utf16.c	2006-01-13 15:27:19.000000000 +0100
+@@ -282,5 +282,18 @@
+ 
+   free(utf16);
+ 
++  if (end == *ptr && length % 2 != 0)
++  {
++     /* We were called with a bogus length.  It should always
++      * be an even number.  We can deal with this in a few ways:
++      * - Always give an error.
++      * - Try and parse as much as we can and
++      *   - return an error if we're called again when we
++      *     already tried to parse everything we can.
++      *   - tell that we parsed it, which is what we do here.
++      */
++     (*ptr)++;
++  }
++
+   return ucs4;
+ }

--- a/var/spack/repos/builtin/packages/libid3tag/11_unknown_encoding.dif
+++ b/var/spack/repos/builtin/packages/libid3tag/11_unknown_encoding.dif
@@ -1,0 +1,37 @@
+#! /bin/sh /usr/share/dpatch/dpatch-run
+## 11_unknown_encoding.dpatch by Andreas Henriksson <andreas@fatal.se>
+##
+## All lines beginning with `## DP:' are a description of the patch.
+## DP: In case of an unknown/invalid encoding, id3_parse_string() will
+## DP: return NULL, but the return value wasn't checked resulting
+## DP: in segfault in id3_ucs4_length().  This is the only place
+## DP: the return value wasn't checked.
+
+@DPATCH@
+diff -urNad libid3tag-0.15.1b~/compat.gperf libid3tag-0.15.1b/compat.gperf
+--- libid3tag-0.15.1b~/compat.gperf	2004-01-23 09:41:32.000000000 +0000
++++ libid3tag-0.15.1b/compat.gperf	2007-01-14 14:36:53.000000000 +0000
+@@ -236,6 +236,10 @@
+ 
+     encoding = id3_parse_uint(&data, 1);
+     string   = id3_parse_string(&data, end - data, encoding, 0);
++    if (!string)
++    {
++	continue;
++    }
+ 
+     if (id3_ucs4_length(string) < 4) {
+       free(string);
+diff -urNad libid3tag-0.15.1b~/parse.c libid3tag-0.15.1b/parse.c
+--- libid3tag-0.15.1b~/parse.c	2004-01-23 09:41:32.000000000 +0000
++++ libid3tag-0.15.1b/parse.c	2007-01-14 14:37:34.000000000 +0000
+@@ -165,6 +165,9 @@
+   case ID3_FIELD_TEXTENCODING_UTF_8:
+     ucs4 = id3_utf8_deserialize(ptr, length);
+     break;
++  default:
++  	/* FIXME: Unknown encoding! Print warning? */
++	return NULL;
+   }
+ 
+   if (ucs4 && !full) {

--- a/var/spack/repos/builtin/packages/libid3tag/CVE-2008-2109.patch
+++ b/var/spack/repos/builtin/packages/libid3tag/CVE-2008-2109.patch
@@ -1,0 +1,11 @@
+--- field.c.orig	2008-05-05 09:49:15.000000000 -0400
++++ field.c	2008-05-05 09:49:25.000000000 -0400
+@@ -291,7 +291,7 @@
+ 
+       end = *ptr + length;
+ 
+-      while (end - *ptr > 0) {
++      while (end - *ptr > 0 && **ptr != '\0') {
+ 	ucs4 = id3_parse_string(ptr, end - *ptr, *encoding, 0);
+ 	if (ucs4 == 0)
+ 	  goto fail;

--- a/var/spack/repos/builtin/packages/libid3tag/libid3tag-gperf.patch
+++ b/var/spack/repos/builtin/packages/libid3tag/libid3tag-gperf.patch
@@ -1,0 +1,26 @@
+Index: libid3tag-0.15.1b/frametype.h
+===================================================================
+--- libid3tag-0.15.1b.orig/frametype.h
++++ libid3tag-0.15.1b/frametype.h
+@@ -37,6 +37,6 @@ extern struct id3_frametype const id3_fr
+ extern struct id3_frametype const id3_frametype_obsolete;
+ 
+ struct id3_frametype const *id3_frametype_lookup(register char const *,
+-						 register unsigned int);
++						 register size_t);
+ 
+ # endif
+Index: libid3tag-0.15.1b/compat.h
+===================================================================
+--- libid3tag-0.15.1b.orig/compat.h
++++ libid3tag-0.15.1b/compat.h
+@@ -34,7 +34,7 @@ struct id3_compat {
+ };
+ 
+ struct id3_compat const *id3_compat_lookup(register char const *,
+-					   register unsigned int);
++					   register size_t);
+ 
+ int id3_compat_fixup(struct id3_tag *);
+ 
+

--- a/var/spack/repos/builtin/packages/libid3tag/package.py
+++ b/var/spack/repos/builtin/packages/libid3tag/package.py
@@ -1,0 +1,33 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack import *
+
+
+class Libid3tag(AutotoolsPackage):
+    """library for id3 tagging"""
+
+    homepage = "https://www.underbit.com/products/mad/"
+    url      = "ftp://ftp.mars.org/pub/mpeg/libid3tag-0.15.1b.tar.gz"
+
+    maintainers = ['TheQueasle']
+
+    version('0.15.1b', 'e5808ad997ba32c498803822078748c3')
+
+    depends_on('zlib')
+    depends_on('gperf')
+
+    patch('10_utf16.diff')
+    patch('11_unknown_encoding.dif')
+    patch('CVE-2008-2109.patch', level=0)
+    patch('libid3tag-gperf.patch', when="^gperf@3.1:")
+
+    @run_before('configure')
+    def preclean(self):
+        """
+        Regenerate compat.c and frametype.c from gperf sources
+        """
+        rm = which('rm')
+        rm('-v', 'compat.c')
+        rm('-v', 'frametype.c')

--- a/var/spack/repos/builtin/packages/libid3tag/package.py
+++ b/var/spack/repos/builtin/packages/libid3tag/package.py
@@ -15,7 +15,7 @@ class Libid3tag(AutotoolsPackage):
 
     maintainers = ['TheQueasle']
 
-    version('0.15.1b', 'e5808ad997ba32c498803822078748c3')
+    version('0.15.1b', '63da4f6e7997278f8a3fef4c6a372d342f705051d1eeb6a46a86b03610e26151')
 
     depends_on('zlib')
     depends_on('gperf')

--- a/var/spack/repos/builtin/packages/libid3tag/package.py
+++ b/var/spack/repos/builtin/packages/libid3tag/package.py
@@ -6,6 +6,7 @@ from spack import *
 
 import os
 
+
 class Libid3tag(AutotoolsPackage):
     """library for id3 tagging"""
 
@@ -19,13 +20,13 @@ class Libid3tag(AutotoolsPackage):
     depends_on('zlib')
     depends_on('gperf')
 
-    ## source: https://git.archlinux.org/svntogit/packages.git/tree/trunk/10_utf16.diff?h=packages/libid3tag
+    # source: https://git.archlinux.org/svntogit/packages.git/tree/trunk/10_utf16.diff?h=packages/libid3tag
     patch('10_utf16.diff')
-    ## source: https://git.archlinux.org/svntogit/packages.git/tree/trunk/11_unknown_encoding.diff?h=packages/libid3tag
+    # source: https://git.archlinux.org/svntogit/packages.git/tree/trunk/11_unknown_encoding.diff?h=packages/libid3tag
     patch('11_unknown_encoding.dif')
-    ## source: https://git.archlinux.org/svntogit/packages.git/tree/trunk/CVE-2008-2109.patch?h=packages/libid3tag
+    # source: https://git.archlinux.org/svntogit/packages.git/tree/trunk/CVE-2008-2109.patch?h=packages/libid3tag
     patch('CVE-2008-2109.patch', level=0)
-    ## source: https://git.archlinux.org/svntogit/packages.git/tree/trunk/libid3tag-gperf.patch?h=packages/libid3tag
+    # source: https://git.archlinux.org/svntogit/packages.git/tree/trunk/libid3tag-gperf.patch?h=packages/libid3tag
     patch('libid3tag-gperf.patch', when="^gperf@3.1:")
 
     @run_before('configure')

--- a/var/spack/repos/builtin/packages/libid3tag/package.py
+++ b/var/spack/repos/builtin/packages/libid3tag/package.py
@@ -26,7 +26,7 @@ class Libid3tag(AutotoolsPackage):
     @run_before('configure')
     def preclean(self):
         """
-        Regenerate compat.c and frametype.c from gperf sources
+        Remove compat.c and frametype.c in order to regenerate from gperf sources
         """
         rm = which('rm')
         rm('-v', 'compat.c')

--- a/var/spack/repos/builtin/packages/libid3tag/package.py
+++ b/var/spack/repos/builtin/packages/libid3tag/package.py
@@ -26,7 +26,8 @@ class Libid3tag(AutotoolsPackage):
     @run_before('configure')
     def preclean(self):
         """
-        Remove compat.c and frametype.c in order to regenerate from gperf sources
+        Remove compat.c and frametype.c in order to regenerate from gperf
+        sources
         """
         rm = which('rm')
         rm('-v', 'compat.c')

--- a/var/spack/repos/builtin/packages/libid3tag/package.py
+++ b/var/spack/repos/builtin/packages/libid3tag/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from spack import *
 
+import os
 
 class Libid3tag(AutotoolsPackage):
     """library for id3 tagging"""
@@ -18,9 +19,13 @@ class Libid3tag(AutotoolsPackage):
     depends_on('zlib')
     depends_on('gperf')
 
+    ## source: https://git.archlinux.org/svntogit/packages.git/tree/trunk/10_utf16.diff?h=packages/libid3tag
     patch('10_utf16.diff')
+    ## source: https://git.archlinux.org/svntogit/packages.git/tree/trunk/11_unknown_encoding.diff?h=packages/libid3tag
     patch('11_unknown_encoding.dif')
+    ## source: https://git.archlinux.org/svntogit/packages.git/tree/trunk/CVE-2008-2109.patch?h=packages/libid3tag
     patch('CVE-2008-2109.patch', level=0)
+    ## source: https://git.archlinux.org/svntogit/packages.git/tree/trunk/libid3tag-gperf.patch?h=packages/libid3tag
     patch('libid3tag-gperf.patch', when="^gperf@3.1:")
 
     @run_before('configure')
@@ -29,6 +34,5 @@ class Libid3tag(AutotoolsPackage):
         Remove compat.c and frametype.c in order to regenerate from gperf
         sources
         """
-        rm = which('rm')
-        rm('-v', 'compat.c')
-        rm('-v', 'frametype.c')
+        os.remove('compat.c')
+        os.remove('frametype.c')


### PR DESCRIPTION
### Package

* **Name**: feh
* **Description**: feh is an X11 image viewer aimed mostly at console users. Unlike most other viewers, it does not have a fancy GUI, but simply displays images. It is controlled via commandline arguments and configurable key/mouse actions.

### Supporting Packages
* **imlib2**: Library that does image file loading and saving as well as rendering, manipulation, arbitrary polygon support
* **libexif**: A library to parse an EXIF file and read the data from those tags
* **libid3tag**: library for id3 tagging

---
If need be I can resubmit this as 4 separate Pull Requests but as the 3 extra packages are just to support the topic of this PR (feh), I decided to submit one request that includes all 4 packages.