### PR TITLE
Fix argparse rST parsing of help messages

### DIFF
--- a/lib/spack/llnl/util/argparsewriter.py
+++ b/lib/spack/llnl/util/argparsewriter.py
@@ -10,9 +10,10 @@ import errno
 import sys
 
 
-class ArgparseWriter(object):
+class ArgparseWriter(argparse.HelpFormatter):
     """Analyzes an argparse ArgumentParser for easy generation of help."""
     def __init__(self, out=sys.stdout):
+        super(ArgparseWriter, self).__init__(out)
         self.level = 0
         self.out = out
 
@@ -48,7 +49,7 @@ class ArgparseWriter(object):
         def action_group(function, actions):
             for action in actions:
                 arg = fmt._format_action_invocation(action)
-                help = action.help if action.help else ''
+                help = self._expand_help(action) if action.help else ''
                 function(arg, re.sub('\n', ' ', help))
 
         if root:


### PR DESCRIPTION
Argparse allows you to include parameters of `add_argument` in your help messages. See https://docs.python.org/3/library/argparse.html#help:

> The help strings can include various format specifiers to avoid repetition of things like the program name or the argument default. The available specifiers include the program name, %(prog)s and most keyword arguments to add_argument(), e.g. %(default)s, %(type)s, etc.:

This worked fine for `spack create -h`, but didn't work with our custom rST argparse formatter. This PR fixes that. @tldahlgren 

### Before
```console
$ spack commands --format=rst | grep -A 36 'spack create'
spack create
------------

create a new package file

.. code-block:: console

    spack create [-hf] [--keep-stage] [-n NAME] [-t TEMPLATE] [-r REPO]
             [-N NAMESPACE] [--skip-editor]
             [url]


**Positional arguments**

url
  url of package archive


**Optional arguments**

``-h, --help``
  show this help message and exit

``--keep-stage``
  don't clean up staging area when command completes

``-n NAME, --name NAME``
  name of the package to create

``-t TEMPLATE, --template TEMPLATE``
  build system template to use. options: %(choices)s

``-r REPO, --repo REPO``
  path to a repository where the package should be created

``-N NAMESPACE, --namespace NAMESPACE``
  specify a namespace for the package. must be the namespace of a repository registered with Spack

``-f, --force``
  overwrite any existing package file with the same name

``--skip-editor``
  skip the edit session for the package (e.g., automation)
```

### After
```console
$ spack commands --format=rst | grep -A 36 'spack create'
spack create
------------

create a new package file

.. code-block:: console

    spack create [-hf] [--keep-stage] [-n NAME] [-t TEMPLATE] [-r REPO]
             [-N NAMESPACE] [--skip-editor]
             [url]


**Positional arguments**

url
  url of package archive


**Optional arguments**

``-h, --help``
  show this help message and exit

``--keep-stage``
  don't clean up staging area when command completes

``-n NAME, --name NAME``
  name of the package to create

``-t TEMPLATE, --template TEMPLATE``
  build system template to use. options: autotools, autoreconf, cmake, bundle, qmake, scons, waf, bazel, python, r, perlmake, perlbuild, octave, makefile, intel, meson, sip, generic

``-r REPO, --repo REPO``
  path to a repository where the package should be created

``-N NAMESPACE, --namespace NAMESPACE``
  specify a namespace for the package. must be the namespace of a repository registered with Spack

``-f, --force``
  overwrite any existing package file with the same name

``--skip-editor``
  skip the edit session for the package (e.g., automation)
```

Closes #13993 