### PR TITLE
Update py-theano dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/py-theano/package.py
+++ b/var/spack/repos/builtin/packages/py-theano/package.py
@@ -26,8 +26,8 @@ class PyTheano(PythonPackage):
     depends_on('python@2.6:2.8,3.3:')
 
     depends_on('py-setuptools', type=('build', 'run'))
-    depends_on('py-scipy@0.11:', type=('build', 'run'))
-    depends_on('py-numpy@1.7.1:', type=('build', 'run'))
+    depends_on('py-numpy@1.9.1:', type=('build', 'run'))
+    depends_on('py-scipy@0.14:', type=('build', 'run'))
     depends_on('py-six@1.9.0:', type=('build', 'run'))
 
     depends_on('blas')
@@ -38,4 +38,5 @@ class PyTheano(PythonPackage):
     depends_on('libgpuarray', when='+gpu')
 
     depends_on('py-nose@1.3.0:', type='test')
-    depends_on('py-nose-parameterized@0.5.0:', type='test')
+    depends_on('py-parameterized', type='test')
+    depends_on('py-flake8', type='test')


### PR DESCRIPTION
`py-nose-parameterized` was renamed to `py-parameterized`. Not sure which version of `py-theano` reflects this change, only looked at the latest version.