### PR TITLE
Add new py-fixtures package

### DIFF
--- a/var/spack/repos/builtin/packages/py-fixtures/package.py
+++ b/var/spack/repos/builtin/packages/py-fixtures/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyFixtures(PythonPackage):
+    """Fixtures, reusable state for writing clean tests and more."""
+
+    homepage = "https://launchpad.net/python-fixtures"
+    url      = "https://pypi.io/packages/source/f/fixtures/fixtures-3.0.0.tar.gz"
+
+    version('3.0.0', sha256='fcf0d60234f1544da717a9738325812de1f42c2fa085e2d9252d8fff5712b2ef')
+
+    depends_on('py-setuptools', type='build')


### PR DESCRIPTION
Successfully installs on macOS 10.15.1 with Python 3.7.4 and Clang 11.0.0.