### PR TITLE
Add new py-hacking package

### DIFF
--- a/var/spack/repos/builtin/packages/py-hacking/package.py
+++ b/var/spack/repos/builtin/packages/py-hacking/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyHacking(PythonPackage):
+    """OpenStack Hacking Guideline Enforcement."""
+
+    homepage = "https://docs.openstack.org/hacking/latest/"
+    url      = "https://pypi.io/packages/source/h/hacking/hacking-1.1.0.tar.gz"
+
+    import_modules = ['hacking']
+
+    version('1.1.0', sha256='23a306f3a1070a4469a603886ba709780f02ae7e0f1fc7061e5c6fb203828fee')
+
+    depends_on('py-setuptools', type='build')


### PR DESCRIPTION
Successfully installs on macOS 10.15.1 with Python 3.7.4 and Clang 11.0.0.