### PR TITLE
Add new py-python-subunit package

### DIFF
--- a/var/spack/repos/builtin/packages/py-python-subunit/package.py
+++ b/var/spack/repos/builtin/packages/py-python-subunit/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyPythonSubunit(PythonPackage):
+    """Python implementation of subunit test streaming protocol."""
+
+    homepage = "https://launchpad.net/subunit"
+    url      = "https://pypi.io/packages/source/p/python-subunit/python-subunit-1.3.0.tar.gz"
+
+    version('1.3.0', sha256='9607edbee4c1e5a30ff88549ce8d9feb0b9bcbcb5e55033a9d76e86075465cbb')
+
+    depends_on('py-setuptools', type='build')
+    depends_on('py-extras', type=('build', 'run'))
+    depends_on('py-testtools@0.9.34:', type=('build', 'run'))


### PR DESCRIPTION
Successfully installs on macOS 10.15.1 with Python 3.7.4 and Clang 11.0.0.