### PR TITLE
Add new py-testresources package

### DIFF
--- a/var/spack/repos/builtin/packages/py-testresources/package.py
+++ b/var/spack/repos/builtin/packages/py-testresources/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyTestresources(PythonPackage):
+    """Testresources, a pyunit extension for managing expensive test resources.
+    """
+
+    homepage = "https://launchpad.net/testresources"
+    url      = "https://pypi.io/packages/source/t/testresources/testresources-2.0.1.tar.gz"
+
+    version('2.0.1', sha256='ee9d1982154a1e212d4e4bac6b610800bfb558e4fb853572a827bc14a96e4417')
+
+    depends_on('py-setuptools', type='build')


### PR DESCRIPTION
Successfully installs on macOS 10.15.1 with Python 3.7.4 and Clang 11.0.0.