### PR TITLE
Add new py-testscenarios package

### DIFF
--- a/var/spack/repos/builtin/packages/py-testscenarios/package.py
+++ b/var/spack/repos/builtin/packages/py-testscenarios/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyTestscenarios(PythonPackage):
+    """Testscenarios, a pyunit extension for dependency injection"""
+
+    homepage = "https://launchpad.net/testscenarios"
+    url      = "https://pypi.io/packages/source/t/testscenarios/testscenarios-0.5.0.tar.gz"
+
+    version('0.5.0', sha256='c257cb6b90ea7e6f8fef3158121d430543412c9a87df30b5dde6ec8b9b57a2b6')
+
+    depends_on('py-setuptools', type='build')


### PR DESCRIPTION
Successfully installs on macOS 10.15.1 with Python 3.7.4 and Clang 11.0.0.