### PR TITLE
Add new py-testtools package

### DIFF
--- a/var/spack/repos/builtin/packages/py-testtools/package.py
+++ b/var/spack/repos/builtin/packages/py-testtools/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyTesttools(PythonPackage):
+    """Extensions to the Python standard library unit testing framework."""
+
+    homepage = "https://github.com/testing-cabal/testtools"
+    url      = "https://pypi.io/packages/source/t/testtools/testtools-2.3.0.tar.gz"
+
+    version('2.3.0', sha256='5827ec6cf8233e0f29f51025addd713ca010061204fdea77484a2934690a0559')
+
+    depends_on('py-setuptools', type='build')


### PR DESCRIPTION
Successfully installs on macOS 10.15.1 with Python 3.7.4 and Clang 11.0.0.