### PR TITLE
py-brian2: py-nosetests -> py-nose

### DIFF
--- a/var/spack/repos/builtin/packages/py-brian2/package.py
+++ b/var/spack/repos/builtin/packages/py-brian2/package.py
@@ -10,20 +10,23 @@ class PyBrian2(PythonPackage):
     """A clock-driven simulator for spiking neural networks"""
 
     homepage = "http://www.briansimulator.org"
-    url      = "https://pypi.io/packages/source/B/Brian2/Brian2-2.0.1.tar.gz"
+    url      = "https://pypi.io/packages/source/B/Brian2/Brian2-2.2.2.1.tar.gz"
 
-    version('2.0.1', sha256='195d8ced0d20e9069917776948f92aa70b7457bbc6b5222b8199654402ee1153')
-    version('2.0rc3', sha256='05f347f5fa6b25d1ce5ec152a2407bbce033599eb6664f32f5331946eb3c7d66')
+    version('2.2.2.1', sha256='02075f66d42fd243fc5e28e1add8862709ae9fdabaffb69858e6d7f684a91525')
+    version('2.0.1',   sha256='195d8ced0d20e9069917776948f92aa70b7457bbc6b5222b8199654402ee1153')
+    version('2.0rc3',  sha256='05f347f5fa6b25d1ce5ec152a2407bbce033599eb6664f32f5331946eb3c7d66')
 
-    variant('doc', default=False, description='Build the documentation')
+    variant('docs', default=False, description='Build the documentation')
 
-    # depends on py-setuptools@6: for windows, if spack targets windows,
-    # this will need to be added here
-    depends_on('py-setuptools',     type='build')
-    depends_on('py-numpy@1.8.2:',   type=('build', 'run'))
-    depends_on('py-sympy@0.7.6:',   type=('build', 'run'))
-    depends_on('py-pyparsing',      type=('build', 'run'))
-    depends_on('py-jinja2@2.7:',    type=('build', 'run'))
-    depends_on('py-py-cpuinfo@0.1.6:', type=('build', 'run'))
-    depends_on('py-sphinx@1.4.2:',  type=('build', 'run'), when='+docs')
-    depends_on('py-nosetests@1.0:', type='test')
+    depends_on('python@2.7:', type=('build', 'run'))
+    depends_on('py-numpy@1.10:', type=('build', 'run'))
+    depends_on('py-cython@0.29:', type=('build', 'run'))
+    depends_on('py-sympy@0.7.6:1.0,1.1.1:', type=('build', 'run'))
+    depends_on('py-pyparsing', type=('build', 'run'))
+    depends_on('py-jinja2@2.7:', type=('build', 'run'))
+    depends_on('py-setuptools@21:', type=('build', 'run'))
+    depends_on('py-sphinx@1.5:', type=('build', 'run'), when='+docs')
+    depends_on('py-nose@1.0:', type='test')
+
+    def build_args(self, spec, prefix):
+        return ['--with-cython']


### PR DESCRIPTION
Successfully installs on macOS 10.15.1 with Python 3.7.4 and Clang 11.0.0.