### PR TITLE
py-python-htmlgen -> py-htmlgen

### DIFF
--- a/var/spack/repos/builtin/packages/py-h5glance/package.py
+++ b/var/spack/repos/builtin/packages/py-h5glance/package.py
@@ -19,4 +19,4 @@ class PyH5glance(PythonPackage):
 
     depends_on('python@3.5:', type=('build', 'run'))
     depends_on('py-h5py', type=('build', 'run'))
-    depends_on('py-python-htmlgen', type='run')
+    depends_on('py-htmlgen', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-htmlgen/package.py
+++ b/var/spack/repos/builtin/packages/py-htmlgen/package.py
@@ -7,7 +7,7 @@
 from spack import *
 
 
-class PyPythonHtmlgen(PythonPackage):
+class PyHtmlgen(PythonPackage):
     """Library to generate HTML from classes.
     """
 
@@ -16,9 +16,7 @@ class PyPythonHtmlgen(PythonPackage):
 
     version('1.2.2', sha256='9dc60e10511f0fd13014659514c6c333498c21779173deb585cd4964ea667770')
 
-    conflicts('python@3.0:3.3.99')
-
+    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
-    # dependencies for tests
+    depends_on('py-asserts@0.8.0:0.8.999', type='test')
     depends_on('py-typing', type='test')
-    depends_on('py-python-asserts', type='test')


### PR DESCRIPTION
Successfully installs on macOS 10.15.1 with Python 3.7.4 and Clang 11.0.0.