### PR TITLE
Add new r-condop package

### DIFF
--- a/var/spack/repos/builtin/packages/r-condop/package.py
+++ b/var/spack/repos/builtin/packages/r-condop/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class RCondop(RPackage):
+    """CONDOP: Condition-Dependent Operon Predictions.
+
+    An implementation of the computational strategy for the comprehensive
+    analysis of condition-dependent operon maps in prokaryotes proposed by
+    Fortino et al. (2014) <doi:10.1186/1471-2105-15-145>. It uses RNA-seq
+    transcriptome profiles to improve prokaryotic operon map inference."""
+
+    homepage = "https://cloud.r-project.org/package=CONDOP"
+    url      = "https://cloud.r-project.org/src/contrib/CONDOP_1.0.tar.gz"
+    list_url = "https://cloud.r-project.org/src/contrib/Archive/CONDOP"
+
+    version('1.0', sha256='3a855880f5c6b33f949c7e6de53c8e014b4d72b7024a93878b344d3e52b5296a')
+
+    depends_on('r-mclust', type=('build', 'run'))
+    depends_on('r-earth', type=('build', 'run'))
+    depends_on('r-plyr', type=('build', 'run'))
+    depends_on('r-seqinr', type=('build', 'run'))
+    depends_on('r-randomforest', type=('build', 'run'))
+    depends_on('r-rminer', type=('build', 'run'))
+    depends_on('r-genomicranges', type=('build', 'run'))
+    depends_on('r-genomeinfodb', type=('build', 'run'))
+    depends_on('r-s4vectors', type=('build', 'run'))
+    depends_on('r-iranges', type=('build', 'run'))


### PR DESCRIPTION
@tgamblin This is the package I was talking about that depends on `r-rminer`. To the best of my knowledge, this is now the slowest concretizing package in Spack. On my laptop:
```console
$ time spack spec r-condop
...
real	1m19.250s
user	1m8.797s
sys	0m4.655s
```
In comparison:
```console
$ time spack spec r-rminer
...
real	1m9.245s
user	0m59.829s
sys	0m4.205s
```
I imagine that the new concretizer will be much more efficient with these R packages. The main reason they take so long to concretize is that R itself has a whopping 58 dependencies! Since `r-condop` has another 107 R packages that it depends on, you end up with 6,000+ dependencies in the full DAG, mostly duplicates.