### PR TITLE
fix incorrect gpu arch map for vtk-m package

### DIFF
--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -58,7 +58,7 @@ class VtkM(CMakePackage, CudaPackage):
                           '30': 'kepler',  '32': 'kepler',  '35': 'kepler',
                           '50': 'maxwell', '52': 'maxwell', '53': 'maxwell',
                           '60': 'pascal',  '61': 'pascal',  '62': 'pascal',
-                          '70': 'turing',  '72': 'turing',  '75': 'turing'}
+                          '70': 'volta',   '72': 'turing',  '75': 'turing'}
         with working_dir('spack-build', create=True):
             options = ["-DVTKm_ENABLE_TESTING:BOOL=OFF"]
             # shared vs static libs logic


### PR DESCRIPTION
This fixes an incorrect entry in the gpu architecture map that caused code to fail on summit.