### PR TITLE
match bootstrapped compiler to architecture

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1509,6 +1509,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         )
         if not compilers:
             dep = spack.compilers.pkg_spec_for_compiler(self.spec.compiler)
+            dep.architecture = self.spec.architecture
             # concrete CompilerSpec has less info than concrete Spec
             # concretize as Spec to add that information
             dep.concretize()


### PR DESCRIPTION
@scottwittenburg noticed that when bootstrapping compilers, we just concretize the compiler spec without trying to match its arch/os to the spec it came from.

This PR ensures that the bootstrapped compiler is built for the same architecture as the spec for which it is being bootstrapped.