### PR TITLE
 diamond: fix narrowing error.

### DIFF
--- a/var/spack/repos/builtin/packages/diamond/fix_narrowing_error.patch
+++ b/var/spack/repos/builtin/packages/diamond/fix_narrowing_error.patch
@@ -1,5 +1,5 @@
---- spack-src/src/basic/score_matrix.cpp.org	2019-12-10 14:49:46.698520161 +0900
-+++ spack-src/src/basic/score_matrix.cpp	2019-12-10 14:50:04.740418478 +0900
+--- diamond-0.9.25/src/basic/score_matrix.cpp.org	2019-12-10 15:16:46.549126025 +0900
++++ diamond-0.9.25/src/basic/score_matrix.cpp	2019-12-10 15:17:08.721466092 +0900
 @@ -36,7 +36,7 @@
  
  const double INT2_MAX = std::numeric_limits<double>::max();
@@ -14,5 +14,5 @@
  	constants[4] = K;
  	constants_ = constants;
 -}
-\ ファイル末尾に改行がありません
+\ No newline at end of file
 +}

--- a/var/spack/repos/builtin/packages/diamond/fix_narrowing_error.patch
+++ b/var/spack/repos/builtin/packages/diamond/fix_narrowing_error.patch
@@ -1,0 +1,18 @@
+--- spack-src/src/basic/score_matrix.cpp.org	2019-12-10 14:49:46.698520161 +0900
++++ spack-src/src/basic/score_matrix.cpp	2019-12-10 14:50:04.740418478 +0900
+@@ -36,7 +36,7 @@
+ 
+ const double INT2_MAX = std::numeric_limits<double>::max();
+ 
+-const char DNA_scores[5 * 5] = {
++const signed char DNA_scores[5 * 5] = {
+ 	2, -3, -3, -3, -3,
+ 	-3,2,-3,-3,-3,
+ 	-3,-3,2,-3,-3,
+@@ -317,4 +317,4 @@
+ 	constants[3] = lambda;
+ 	constants[4] = K;
+ 	constants_ = constants;
+-}
+\ ファイル末尾に改行がありません
++}

--- a/var/spack/repos/builtin/packages/diamond/package.py
+++ b/var/spack/repos/builtin/packages/diamond/package.py
@@ -26,4 +26,5 @@ class Diamond(CMakePackage):
     depends_on('zlib')
 
     # fix error [-Wc++11-narrowing]
+    # Ref: https://github.com/bbuchfink/diamond/commit/155e076d662b0e9268e2b00bef6d33d90aede7ff
     patch('fix_narrowing_error.patch')

--- a/var/spack/repos/builtin/packages/diamond/package.py
+++ b/var/spack/repos/builtin/packages/diamond/package.py
@@ -24,3 +24,6 @@ class Diamond(CMakePackage):
     version('0.8.26', sha256='00d2be32dad76511a767ab8e917962c0ecc572bc808080be60dec028df45439f')
 
     depends_on('zlib')
+
+    # fix error [-Wc++11-narrowing]
+    patch('fix_narrowing_error.patch')


### PR DESCRIPTION
・Fix about narrowing error
`error: constant expression evaluates to -3 which cannot be narrowed to type 'char' [-Wc++11-narrowing]`
　Ref:https://github.com/bbuchfink/diamond/commit/155e076d662b0e9268e2b00bef6d33d90aede7ff#diff-27acfe5422eb9cf2b8dd1a4cd11e17c3