### PR TITLE
Fix broken links to cosmetic path in mirrors

### DIFF
--- a/lib/spack/spack/caches.py
+++ b/lib/spack/spack/caches.py
@@ -63,16 +63,21 @@ class MirrorCache(object):
         fetcher.archive(dst)
 
     def symlink(self, mirror_ref):
-        """Symlink a human readible path in our mirror to the actual
-        storage location."""
+        """Symlink a human readable path in our mirror to the actual
+        storage location.
+
+        Returns:
+            The relative path used for the symbolic link.
+        """
 
         cosmetic_path = os.path.join(self.root, mirror_ref.cosmetic_path)
-        relative_dst = os.path.relpath(
-            mirror_ref.storage_path,
-            start=os.path.dirname(cosmetic_path))
+        cosmetic_dir = os.path.dirname(cosmetic_path)
+        storage_path = os.path.join(self.root, mirror_ref.storage_path)
+        relative_dst = os.path.relpath(storage_path, start=cosmetic_dir)
         if not os.path.exists(cosmetic_path):
-            mkdirp(os.path.dirname(cosmetic_path))
+            mkdirp(cosmetic_dir)
             os.symlink(relative_dst, cosmetic_path)
+        return relative_dst
 
 
 #: Spack's local cache for downloaded source archives

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -7,6 +7,7 @@ import filecmp
 import os
 import pytest
 
+import spack.caches
 import spack.repo
 import spack.mirror
 import spack.util.executable
@@ -192,3 +193,17 @@ def test_mirror_with_url_patches(mock_packages, config, monkeypatch):
             'abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234',
             'abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd.gz'  # NOQA: ignore=E501
         ]) - files_cached_in_mirror)
+
+
+@pytest.mark.regression('14067')
+def test_mirror_cache_symlinks(tmpdir):
+    """Tries to create a symlink structure in tmpdir and checks the
+    results are the expected one.
+    """
+    cosmetic_path = 'zlib/zlib-1.2.11.tar.gz'
+    global_path = '_source-cache/archive/c3/c3e5.tar.gz'
+    cache = spack.caches.MirrorCache(str(tmpdir))
+    reference = spack.mirror.MirrorReference(cosmetic_path, global_path)
+
+    link_path = cache.symlink(reference)
+    assert link_path == os.path.join('..', global_path)


### PR DESCRIPTION
fixes #14067

In #13789 an absolute path was erroneously substituted with a relative one, causing broken links in mirrors. This PR restores the absolute path and adds a unit test to avoid regressions.