### PR TITLE
Build xed CLI for the intel-xed package

### DIFF
--- a/var/spack/repos/builtin/packages/intel-xed/package.py
+++ b/var/spack/repos/builtin/packages/intel-xed/package.py
@@ -84,18 +84,22 @@ class IntelXed(Package):
 
         mkdirp(prefix.include)
         mkdirp(prefix.lib)
+        mkdirp(prefix.bin)
 
         libs = glob.glob(join_path('obj', 'lib*.a'))
         for lib in libs:
             install(lib, prefix.lib)
 
-        # Build and install shared libxed.so.
+        # Build and install shared libxed.so and examples (to get the CLI).
         mfile('--clean')
-        mfile('--shared', *args)
+        mfile('examples', '--shared', *args)
 
         libs = glob.glob(join_path('obj', 'lib*.so'))
         for lib in libs:
             install(lib, prefix.lib)
+
+        # Install the xed program
+        install(join_path('obj', 'examples', 'xed'), prefix.bin)
 
         # Install header files.
         hdrs = glob.glob(join_path('include', 'public', 'xed', '*.h'))  \


### PR DESCRIPTION
The xed CLI is handy, and can be gotten by building the examples in the
intel-xed package. This PR builds the examples and installs the xed CLI.
It would also be possible to install more of the example binaries if
someone thinks they are useful.