### PR TITLE
Fix replacement of embedded 'gcc' in augustus

### DIFF
--- a/var/spack/repos/builtin/packages/augustus/package.py
+++ b/var/spack/repos/builtin/packages/augustus/package.py
@@ -34,6 +34,31 @@ class Augustus(MakefilePackage):
     depends_on('curl', when='@3.3.1:')
 
     def edit(self, spec, prefix):
+        # Set compile commands for each compiler and
+        # Fix for using 'boost' on Spack. (only after ver.3.3.1-tag1)
+        if self.version >= Version('3.3.1-tag1'):
+            with working_dir(join_path('auxprogs', 'utrrnaseq', 'Debug')):
+                filter_file('g++', spack_cxx, 'makefile', string=True)
+                filter_file('g++ -I/usr/include/boost', '{0} -I{1}'
+                            .format(spack_cxx,
+                                    self.spec['boost'].prefix.include),
+                            'src/subdir.mk', string=True)
+
+        # Set compile commands to all makefiles.
+        makefiles = [
+            'auxprogs/aln2wig/Makefile',
+            'auxprogs/bam2hints/Makefile',
+            'auxprogs/bam2wig/Makefile',
+            'auxprogs/checkTargetSortedness/Makefile',
+            'auxprogs/compileSpliceCands/Makefile',
+            'auxprogs/homGeneMapping/src/Makefile',
+            'auxprogs/joingenes/Makefile',
+            'src/Makefile'
+        ]
+        for makefile in makefiles:
+            filter_file('gcc', spack_cc, makefile, string=True)
+            filter_file('g++', spack_cxx, makefile, string=True)
+
         with working_dir(join_path('auxprogs', 'filterBam', 'src')):
             makefile = FileFilter('Makefile')
             makefile.filter('BAMTOOLS = .*', 'BAMTOOLS = %s' % self.spec[
@@ -83,31 +108,6 @@ class Augustus(MakefilePackage):
                             '$(SAMTOOLS)/../lib/libbam.a', string=True)
             makefile.filter('$(HTSLIB)/libhts.a',
                             '$(HTSLIB)/../lib/libhts.a', string=True)
-
-        # Set compile commands for each compiler and
-        # Fix for using 'boost' on Spack. (only after ver.3.3.1-tag1)
-        if self.version >= Version('3.3.1-tag1'):
-            with working_dir(join_path('auxprogs', 'utrrnaseq', 'Debug')):
-                filter_file('g++', spack_cxx, 'makefile', string=True)
-                filter_file('g++ -I/usr/include/boost', '{0} -I{1}'
-                            .format(spack_cxx,
-                                    self.spec['boost'].prefix.include),
-                            'src/subdir.mk', string=True)
-
-        # Set compile commands to all makefiles.
-        makefiles = [
-            'auxprogs/aln2wig/Makefile',
-            'auxprogs/bam2hints/Makefile',
-            'auxprogs/bam2wig/Makefile',
-            'auxprogs/checkTargetSortedness/Makefile',
-            'auxprogs/compileSpliceCands/Makefile',
-            'auxprogs/homGeneMapping/src/Makefile',
-            'auxprogs/joingenes/Makefile',
-            'src/Makefile'
-        ]
-        for makefile in makefiles:
-            filter_file('gcc', spack_cc, makefile, string=True)
-            filter_file('g++', spack_cxx, makefile, string=True)
 
     def install(self, spec, prefix):
         install_tree('bin', join_path(self.spec.prefix, 'bin'))


### PR DESCRIPTION
PR #13975 added makefile filtering to replace gcc/g++ with the spack
compiler. This conflicts with other filtering that is done in the package to
add paths for dependencies. The text of the dependency paths might
have 'gcc' in the path name, depending on the install_path_scheme, and
that was being replaced by the new compiler filters. That would mangle
the path to the dependecy resulting in a failed build.

This PR moves the compiler filters to be before the other filters to
make sure that the compiler is set before the dependency paths.