### PR TITLE
Add try-except for Python installation

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -623,11 +623,15 @@ class Python(AutotoolsPackage):
         and symlinks it to ``/usr/local``. Users may not know the actual
         installation directory and add ``/usr/local`` to their
         ``packages.yaml`` unknowingly. Query the python executable to
-        determine exactly where it is installed."""
+        determine exactly where it is installed. Fall back on
+        ``spec['python'].prefix`` if that doesn't work."""
 
         dag_hash = self.spec.dag_hash()
         if dag_hash not in self._homes:
-            prefix = self.get_config_var('prefix')
+            try:
+                prefix = self.get_config_var('prefix')
+            except ProcessError:
+                prefix = self.prefix
             self._homes[dag_hash] = Prefix(prefix)
         return self._homes[dag_hash]
 


### PR DESCRIPTION
Fixes an issue reported by @gartung on Slack:

> On a side note the python package defines several methods that call python. This breaks installing python packages built for macOS on a linux host because the python executable is a mach-o binary. This line is evaluated on python package install
https://github.com/spack/spack/blob/a288449f0b23acbec128bab943e42b403f4f4df9/var/spack/repos/builtin/packages/python/package.py#L562 