### PR TITLE
amrex: Define module directry when compiling with Fujitsu compiler.

### DIFF
--- a/var/spack/repos/builtin/packages/amrex/package.py
+++ b/var/spack/repos/builtin/packages/amrex/package.py
@@ -79,4 +79,7 @@ class Amrex(CMakePackage):
             '-DENABLE_PARTICLES:BOOL=%s' % self.cmake_is_on('+particles'),
             '-DENABLE_SUNDIALS:BOOL=%s' % self.cmake_is_on('+sundials')
         ]
+        if self.spec.satisfies('%fj'):
+            args.append('-DCMAKE_Fortran_MODDIR_FLAG=-M')
+
         return args


### PR DESCRIPTION
I added definition of CMAKE_Fortran_MODDIR_FLAG, because specifying place to output fortran modules when using Fujitsu compiler.