### PR TITLE
Patch: explicitly use xbitmaps include dir in the automake package

### DIFF
--- a/var/spack/repos/builtin/packages/motif/add_xbitmaps_dependency.patch
+++ b/var/spack/repos/builtin/packages/motif/add_xbitmaps_dependency.patch
@@ -1,0 +1,36 @@
+diff -Naur motif-2.3.8/ac_find_xbitmaps.m4 motif-2.3.8_patched/ac_find_xbitmaps.m4
+--- motif-2.3.8/ac_find_xbitmaps.m4	1970-01-01 01:00:00.000000000 +0100
++++ motif-2.3.8_patched/ac_find_xbitmaps.m4	2019-12-11 16:01:58.463883900 +0100
+@@ -0,0 +1,10 @@
++AC_DEFUN([AC_FIND_XBITMAPS],
++[
++
++AC_CHECK_HEADERS(X11/bitmaps/gray)
++
++CFLAGS="$CFLAGS `pkg-config xbitmaps --cflags`"
++AC_SUBST(CFLAGS)
++LIBS="$LIBS `pkg-config xbitmaps --libs`"
++AC_SUBST(LIBS)
++])
+diff -Naur motif-2.3.8/AUTHORS motif-2.3.8_patched/AUTHORS
+--- motif-2.3.8/AUTHORS	1970-01-01 01:00:00.000000000 +0100
++++ motif-2.3.8_patched/AUTHORS	2019-12-12 08:40:39.947561253 +0100
+@@ -0,0 +1 @@
++Dummy AUTHORS file: upstream Motif did not supply this and autoreconf needs it.
+\ No newline at end of file
+diff -Naur motif-2.3.8/configure.ac motif-2.3.8_patched/configure.ac
+--- motif-2.3.8/configure.ac	2017-12-05 13:43:54.000000000 +0100
++++ motif-2.3.8_patched/configure.ac	2019-12-11 16:01:58.467217264 +0100
+@@ -274,6 +274,7 @@
+ AC_SUBST(LIB_XP)
+ 
+ AC_FIND_XFT
++AC_FIND_XBITMAPS
+ AC_IMAGE_SUPPORT
+ 
+ 
+diff -Naur motif-2.3.8/NEWS motif-2.3.8_patched/NEWS
+--- motif-2.3.8/NEWS	1970-01-01 01:00:00.000000000 +0100
++++ motif-2.3.8_patched/NEWS	2019-12-12 08:40:59.010963846 +0100
+@@ -0,0 +1 @@
++Dummy NEWS file: upstream motif did not supply this but autoreconf needs it.

--- a/var/spack/repos/builtin/packages/motif/package.py
+++ b/var/spack/repos/builtin/packages/motif/package.py
@@ -11,6 +11,8 @@ class Motif(AutotoolsPackage):
     Motif - Graphical user interface (GUI)
     specification and the widget toolkit
     """
+    force_autoreconf = True
+
     homepage = "http://motif.ics.com/"
     url = "http://cfhcable.dl.sourceforge.net/project/motif/Motif%202.3.8%20Source%20Code/motif-2.3.8.tar.gz"
 
@@ -25,3 +27,10 @@ class Motif(AutotoolsPackage):
     depends_on("libxfixes")
     depends_on("xbitmaps")
     depends_on("jpeg")
+
+    patch('add_xbitmaps_dependency.patch')
+
+    def autoreconf(self, spec, prefix):
+        autoreconf = which('autoreconf')
+        with working_dir(self.configure_directory):
+            autoreconf('-ivf', '--warnings=none')

--- a/var/spack/repos/builtin/packages/motif/package.py
+++ b/var/spack/repos/builtin/packages/motif/package.py
@@ -28,9 +28,15 @@ class Motif(AutotoolsPackage):
     depends_on("xbitmaps")
     depends_on("jpeg")
 
+    # we need the following for autoreconf
+    depends_on("automake", type="build")
+    depends_on("autoconf", type="build")
+    depends_on("m4", type="build")
+    depends_on("libtool", type="build")
+
     patch('add_xbitmaps_dependency.patch')
 
     def autoreconf(self, spec, prefix):
         autoreconf = which('autoreconf')
         with working_dir(self.configure_directory):
-            autoreconf('-ivf', '--warnings=none')
+            autoreconf('-ivf')


### PR DESCRIPTION
Installing motif does not work, see the corresponding issue #14127 . The problem is that the upstream package does not expect header files from the `xbitmaps` package to appear in a different prefix than the other X11 libraries. I made a patch to correct for this, and force an autoreconf in the package.py script.

Additionally, I have found that autoreconf complains about missing AUTHORS and NEWS files in the source distribution. The same patch also adds dummy files to satisfy autoreconf.