### PR TITLE
package/Python: compile python with sqlite loadable extensions

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -286,6 +286,10 @@ class Python(AutotoolsPackage):
                     spec['tcl'].libs.ld_flags, spec['tk'].libs.ld_flags)
             ])
 
+        # https://docs.python.org/3.8/library/sqlite3.html#f1
+        if spec.satisfies('@3.2: +sqlite3'):
+            config_args.append('--enable-loadable-sqlite-extensions')
+
         return config_args
 
     @run_after('install')


### PR DESCRIPTION
It seems loadable extensions are already enabled by default in SQlite. Also enable this feature in python so that one can do
```python
import sqlite3
con = sqlite3.connect(":memory:")
# enable extension loading
con.enable_load_extension(True)
```
If not compiled with this option, the last line throws errors.

Refs:

- https://docs.python.org/3.8/library/sqlite3.html#f1
- https://www.sqlite.org/loadext.html

Note that footnotes in 1st Ref above doesn't apply here since spack compiles SQLite from scratch