### PR TITLE
Add latest version of py-tabulate

### DIFF
--- a/var/spack/repos/builtin/packages/py-tabulate/package.py
+++ b/var/spack/repos/builtin/packages/py-tabulate/package.py
@@ -10,8 +10,10 @@ class PyTabulate(PythonPackage):
     """Pretty-print tabular data"""
 
     homepage = "https://bitbucket.org/astanin/python-tabulate"
-    url      = "https://pypi.io/packages/source/t/tabulate/tabulate-0.7.7.tar.gz"
+    url      = "https://pypi.io/packages/source/t/tabulate/tabulate-0.8.6.tar.gz"
 
+    version('0.8.6', sha256='5470cc6687a091c7042cee89b2946d9235fe9f6d49c193a4ae2ac7bf386737c8')
+    version('0.8.3', sha256='8af07a39377cee1103a5c8b3330a421c2d99b9141e9cc5ddd2e3263fea416943')
     version('0.7.7', sha256='83a0b8e17c09f012090a50e1e97ae897300a72b35e0c86c0b53d3bd2ae86d8c6')
 
     depends_on('py-setuptools', type='build')


### PR DESCRIPTION
Successfully installs on macOS 10.15.1 with Clang 11.0.0 and Python 3.7.4.