### PR TITLE
gmodel: Fix various errors during build

### DIFF
--- a/var/spack/repos/builtin/packages/gmodel/fix_gmodel.cpp.patch
+++ b/var/spack/repos/builtin/packages/gmodel/fix_gmodel.cpp.patch
@@ -1,0 +1,54 @@
+--- spack-src/gmodel.cpp.org	2019-12-13 10:43:51.578849661 +0900
++++ spack-src/gmodel.cpp	2019-12-13 10:54:55.467737618 +0900
+@@ -30,9 +30,9 @@
+     /* PLANE   = */ "Physical Surface",
+     /* RULED   = */ "Physical Surface",
+     /* VOLUME  = */ "Physical Volume",
+-    /* LOOP    = */ 0,
+-    /* SHELL   = */ 0,
+-    /* GROUP   = */ 0};
++    /* LOOP    = */ nullptr,
++    /* SHELL   = */ nullptr,
++    /* GROUP   = */ nullptr};
+ 
+ int const type_dims[NTYPES] = {
+     /* POINT   = */ 0,
+@@ -63,11 +63,6 @@
+   return v.at(std::size_t(i));
+ }
+ 
+-template <typename T>
+-static int size(std::vector<T> const& v) {
+-  return int(v.size());
+-}
+-
+ int is_entity(int t) { return t <= VOLUME; }
+ 
+ int is_face(int t) { return t == PLANE || t == RULED; }
+@@ -452,7 +447,7 @@
+   auto loop = new_loop();
+   add_use(loop, FORWARD, start);
+   add_use(loop, FORWARD, right.middle);
+-  ObjPtr end = 0;
++  ObjPtr end = nullptr;
+   switch (start->type) {
+     case LINE: {
+       end = new_line2(std::dynamic_pointer_cast<Point>(left.end),
+@@ -492,7 +487,7 @@
+       break;
+     }
+     default:
+-      end = 0;
++      end = nullptr;
+       break;
+   }
+   add_use(loop, REVERSE, end);
+@@ -508,7 +503,7 @@
+       middle = new_ruled2(loop);
+       break;
+     default:
+-      middle = 0;
++      middle = nullptr;
+       break;
+   }
+   return Extruded{middle, end};

--- a/var/spack/repos/builtin/packages/gmodel/package.py
+++ b/var/spack/repos/builtin/packages/gmodel/package.py
@@ -18,3 +18,8 @@ class Gmodel(CMakePackage):
     url      = "https://github.com/ibaned/gmodel/archive/v2.1.0.tar.gz"
 
     version('2.1.0', sha256='80df0c6dc413a9ffa0f0e7b65118b05b643ba3e1bfcac28fb91d2d3ad017fda0')
+
+    # fix error [-Werror,-Wzero-as-null-pointer-constant]
+    # fix error [-Werror,-Wunused-template]
+    # Ref: https://github.com/ibaned/gmodel/commit/6b81ec190cf2ce9a6554a99cb6d759b023393cdd
+    patch('fix_gmodel.cpp.patch')


### PR DESCRIPTION
・I changed 0 to nullptr because I got following error when installing gmodel.
`error: zero as null pointer constant [-Werror,-Wzero-as-null-pointer-constant]`

・I deleted function template because  I got following error when installing gmodel.
`error: unused function template 'size' [-Werror,-Wunused-template]`

・Ref: https://github.com/ibaned/gmodel/commit/6b81ec190cf2ce9a6554a99cb6d759b023393cdd