### PR TITLE
Build caching: support package hash for swig

### DIFF
--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -16,6 +16,11 @@ from spack.version import VersionChecksumError
 import spack.directives
 
 
+def _generate_content_strip_name(spec):
+    content = package_content(spec)
+    return content.replace(spec.package.__class__.__name__, '')
+
+
 @pytest.mark.usefixtures('config', 'mock_packages')
 class TestPackage(object):
     def test_load_package(self):
@@ -75,6 +80,23 @@ class TestPackage(object):
         content2 = content2.replace(spec2.package.__class__.__name__, '')
         assert spec1.package.content_hash(content=content1) == \
             spec2.package.content_hash(content=content2)
+
+    def test_content_hash_cannot_get_details_from_ast(self):
+        """Packages hash-test1 and hash-test3 would be considered the same
+           except that hash-test3 conditionally executes a phase based on
+           a "when" directive that Spack cannot evaluate by examining the
+           AST. This test ensures that Spack can compute a content hash
+           for hash-test3. If Spack cannot determine when a phase applies,
+           it adds it by default, so the test also ensures that the hashes
+           differ where Spack includes a phase on account of AST-examination
+           failure.
+        """
+        spec3 = Spec("hash-test1@1.7").concretized()
+        spec4 = Spec("hash-test3@1.7").concretized()
+        content3 = _generate_content_strip_name(spec3)
+        content4 = _generate_content_strip_name(spec4)
+        assert(spec3.package.content_hash(content=content3) !=
+               spec4.package.content_hash(content=content4))
 
     def test_all_same_but_archive_hash(self):
         spec1 = Spec("hash-test1@1.3")

--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -58,26 +58,18 @@ class TestPackage(object):
         assert '_3db' == mod_to_class('3db')
 
     def test_content_hash_all_same_but_patch_contents(self):
-        spec1 = Spec("hash-test1@1.1")
-        spec2 = Spec("hash-test2@1.1")
-        spec1.concretize()
-        spec2.concretize()
-        content1 = package_content(spec1)
-        content1 = content1.replace(spec1.package.__class__.__name__, '')
-        content2 = package_content(spec2)
-        content2 = content2.replace(spec2.package.__class__.__name__, '')
+        spec1 = Spec("hash-test1@1.1").concretized()
+        spec2 = Spec("hash-test2@1.1").concretized()
+        content1 = _generate_content_strip_name(spec1)
+        content2 = _generate_content_strip_name(spec2)
         assert spec1.package.content_hash(content=content1) != \
             spec2.package.content_hash(content=content2)
 
     def test_content_hash_different_variants(self):
-        spec1 = Spec("hash-test1@1.2 +variantx")
-        spec2 = Spec("hash-test2@1.2 ~variantx")
-        spec1.concretize()
-        spec2.concretize()
-        content1 = package_content(spec1)
-        content1 = content1.replace(spec1.package.__class__.__name__, '')
-        content2 = package_content(spec2)
-        content2 = content2.replace(spec2.package.__class__.__name__, '')
+        spec1 = Spec("hash-test1@1.2 +variantx").concretized()
+        spec2 = Spec("hash-test2@1.2 ~variantx").concretized()
+        content1 = _generate_content_strip_name(spec1)
+        content2 = _generate_content_strip_name(spec2)
         assert spec1.package.content_hash(content=content1) == \
             spec2.package.content_hash(content=content2)
 
@@ -99,14 +91,10 @@ class TestPackage(object):
                spec4.package.content_hash(content=content4))
 
     def test_all_same_but_archive_hash(self):
-        spec1 = Spec("hash-test1@1.3")
-        spec2 = Spec("hash-test2@1.3")
-        spec1.concretize()
-        spec2.concretize()
-        content1 = package_content(spec1)
-        content1 = content1.replace(spec1.package.__class__.__name__, '')
-        content2 = package_content(spec2)
-        content2 = content2.replace(spec2.package.__class__.__name__, '')
+        spec1 = Spec("hash-test1@1.3").concretized()
+        spec2 = Spec("hash-test2@1.3").concretized()
+        content1 = _generate_content_strip_name(spec1)
+        content2 = _generate_content_strip_name(spec2)
         assert spec1.package.content_hash(content=content1) != \
             spec2.package.content_hash(content=content2)
 

--- a/lib/spack/spack/util/package_hash.py
+++ b/lib/spack/spack/util/package_hash.py
@@ -69,8 +69,17 @@ class TagMultiMethods(ast.NodeVisitor):
         if node.decorator_list:
             dec = node.decorator_list[0]
             if isinstance(dec, ast.Call) and dec.func.id == 'when':
-                cond = dec.args[0].s
-                nodes.append((node, self.spec.satisfies(cond, strict=True)))
+                try:
+                    cond = dec.args[0].s
+                    nodes.append(
+                        (node, self.spec.satisfies(cond, strict=True)))
+                except AttributeError:
+                    # In this case the condition for the 'when' decorator is
+                    # not a string literal (for example it may be a Python
+                    # variable name). Therefore the function is added
+                    # unconditionally since we don't know whether the
+                    # constraint applies or not.
+                    nodes.append((node, None))
         else:
             nodes.append((node, None))
 

--- a/var/spack/repos/builtin.mock/packages/hash-test3/package.py
+++ b/var/spack/repos/builtin.mock/packages/hash-test3/package.py
@@ -8,23 +8,18 @@ from spack import *
 import os
 
 
-class HashTest1(Package):
+class HashTest3(Package):
     """Used to test package hashing
     """
 
-    homepage = "http://www.hashtest1.org"
-    url = "http://www.hashtest1.org/downloads/hashtest1-1.1.tar.bz2"
+    homepage = "http://www.hashtest3.org"
+    url = "http://www.hashtest1.org/downloads/hashtest3-1.1.tar.bz2"
 
-    version('1.1', 'a' * 32)
     version('1.2', 'b' * 32)
     version('1.3', 'c' * 32)
-    version('1.4', 'd' * 32)
     version('1.5', 'd' * 32)
     version('1.6', 'e' * 32)
     version('1.7', 'f' * 32)
-
-    patch('patch1.patch', when="@1.1")
-    patch('patch2.patch', when="@1.4")
 
     variant('variantx', default=False, description='Test variant X')
     variant('varianty', default=False, description='Test variant Y')
@@ -41,6 +36,7 @@ class HashTest1(Package):
     def install(self, spec, prefix):
         os.listdir(os.getcwd())
 
-    @when('@1.5,1.6')
-    def extra_phase(self, spec, prefix):
-        pass
+    for _version_constraint in ['@1.5', '@1.6']:
+        @when(_version_constraint)
+        def extra_phase(self, spec, prefix):
+            pass


### PR DESCRIPTION
Closes #13620
Closes #13265
Fixes #13237

Spack computes a "full hash" of packages as part of identifying them when retrieving binary packages for installation. The full hash includes a content hash that attempts to traverse the AST of a `package.py` file and include only the components that are used for the spec (e.g. if a patch is not applied for a particular spec version, then it is excluded from the content hash).

This AST examination fails in some cases where the "when" condition for a patch/phase is not a string literal. At this time `swig` is such an example. This PR updates the package hash calculation logic to fall back to including content when it cannot evaluate a `when` condition (even though it may not strictly be required by the spec).