### PR TITLE
bugfix: `pgcc -V` returns 2 on power machines

### DIFF
--- a/lib/spack/spack/architecture.py
+++ b/lib/spack/spack/architecture.py
@@ -69,6 +69,7 @@ from llnl.util.lang import memoized, list_modules, key_ordering
 import spack.compiler
 import spack.paths
 import spack.error as serr
+import spack.util.executable
 import spack.version
 from spack.util.naming import mod_to_class
 from spack.util.spack_yaml import syaml_dict
@@ -214,7 +215,11 @@ class Target(object):
             import spack.spec
             if isinstance(compiler, spack.spec.CompilerSpec):
                 compiler = spack.compilers.compilers_for_spec(compiler).pop()
-            compiler_version = compiler.cc_version(compiler.cc)
+            try:
+                compiler_version = compiler.cc_version(compiler.cc)
+            except spack.util.executable.ProcessError as e:
+                # log this and just return compiler.version instead
+                tty.debug(str(e))
 
         return self.microarchitecture.optimization_flags(
             compiler.name, str(compiler_version)

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -32,7 +32,7 @@ def _verify_executables(*paths):
 
 
 @llnl.util.lang.memoized
-def get_compiler_version_output(compiler_path, version_arg):
+def get_compiler_version_output(compiler_path, version_arg, ignore_errors=()):
     """Invokes the compiler at a given path passing a single
     version argument and returns the output.
 
@@ -41,7 +41,8 @@ def get_compiler_version_output(compiler_path, version_arg):
         version_arg (str): the argument used to extract version information
     """
     compiler = spack.util.executable.Executable(compiler_path)
-    output = compiler(version_arg, output=str, error=str)
+    output = compiler(
+        version_arg, output=str, error=str, ignore_errors=ignore_errors)
     return output
 
 
@@ -198,6 +199,9 @@ class Compiler(object):
 
     #: Compiler argument that produces version information
     version_argument = '-dumpversion'
+
+    #: Return values to ignore when invoking the compiler to get its version
+    ignore_version_errors = ()
 
     #: Regex used to extract version from compiler's output
     version_regex = '(.*)'
@@ -412,7 +416,8 @@ class Compiler(object):
     @classmethod
     def default_version(cls, cc):
         """Override just this to override all compiler version functions."""
-        output = get_compiler_version_output(cc, cls.version_argument)
+        output = get_compiler_version_output(
+            cc, cls.version_argument, tuple(cls.ignore_version_errors))
         return cls.extract_version_from_output(output)
 
     @classmethod

--- a/lib/spack/spack/compilers/pgi.py
+++ b/lib/spack/spack/compilers/pgi.py
@@ -30,6 +30,7 @@ class Pgi(Compiler):
     PrgEnv_compiler = 'pgi'
 
     version_argument = '-V'
+    ignore_version_errors = [2]  # `pgcc -V` on PowerPC annoyingly returns 2
     version_regex = r'pg[^ ]* ([0-9.]+)-[0-9]+ (LLVM )?[^ ]+ target on '
 
     @classmethod


### PR DESCRIPTION
`pgcc -V` was failing on `ppc64` machines because it returns 2 (despite correctly printing version information).  On `x86_64` machines the same command returns 0 and doesn't cause an error.

- [x] Ignore return value of 2 for `pgcc` when doing a version check, so that the version check works on `power9`
- [x] relax the version check for custom compilers introduced in #13222 so that we fall back on the verbatim compiler version if the version check fails.

@becker33 @alalazo FYI