### PR TITLE
mrnet: remove nonexisting cti dependency

### DIFF
--- a/var/spack/repos/builtin/packages/mrnet/package.py
+++ b/var/spack/repos/builtin/packages/mrnet/package.py
@@ -20,14 +20,11 @@ class Mrnet(AutotoolsPackage):
     version('4.1.0', sha256='94758191ac46a9dbfea931a8e61167fe7e8a5f880caa418305c44f1d12af5e45')
     version('4.0.0', sha256='7207c6d493b3f17c386667cfefa81364c96b9c8b831c67442d218d77813c5d38')
 
-    variant('cti', default=False,
-            description="Build the MRNet with the CTI startup option")
     variant('lwthreads', default=False,
             description="Also build the MRNet LW threadsafe libraries")
     parallel = False
 
     depends_on("boost")
-    depends_on("cti", when='+cti')
 
     def configure_args(self):
         spec = self.spec
@@ -37,11 +34,5 @@ class Mrnet(AutotoolsPackage):
         # lwthreads variant is present
         if '+lwthreads' in spec:
             config_args.append('--enable-ltwt-threadsafe')
-        # Build the MRNet with CTI based start-up when
-        # the cti variant is present
-        if '+cti' in spec:
-            config_args.append('--with-startup=cray-cti')
-            cti = self.spec['cti'].prefix
-            config_args.append('--with-craycti-inc=-I%s/include' % cti)
-            config_args.append('--with-craycti-lib=-I%s/lib' % cti)
+
         return config_args


### PR DESCRIPTION
This is part of the cleanup of nonexisting dependencies in #13949.

MRNet had an optional dependency on `cti`, which doesn't exist.  Remove it from the repo, at least until someone adds `cti` back.

FYI @jgalarowicz.