### PR TITLE
Travis exits at the first failing test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -167,7 +167,7 @@ install:
   - pip install --upgrade pip
   - pip install --upgrade six
   - pip install --upgrade setuptools
-  - pip install --upgrade codecov
+  - pip install --upgrade codecov coverage==4.5.4
   - pip install --upgrade flake8
   - pip install --upgrade pep8-naming
   - if [[ "$TEST_SUITE" == "doc" ]]; then

--- a/share/spack/qa/run-unit-tests
+++ b/share/spack/qa/run-unit-tests
@@ -46,7 +46,7 @@ extra_args=""
 if [[ -n "$@" ]]; then
     extra_args="-k $@"
 fi
-${coverage_run} bin/spack test --verbose "$extra_args"
+${coverage_run} bin/spack test -x --verbose "$extra_args"
 
 #-----------------------------------------------------------
 # Run tests for setup-env.sh


### PR DESCRIPTION
Before this commit we used to run the entire unit test suite in the presence of a failure. Since we currently rely a lot on the state of the filesystem etc. the end report was most of the time showing spurious failures that were a consequence of the first failing test.

This PR makes unit tests exit at the first failing test