### PR TITLE
Add tooling to simplify the workflow for command extensions

### DIFF
--- a/lib/spack/docs/extensions.rst
+++ b/lib/spack/docs/extensions.rst
@@ -30,42 +30,104 @@ respects a prescribed naming and layout for files:
   │   └── test_filter.py
   └── templates # Templates that may be needed by the extension
 
-In the example above the extension named *scripting* adds an additional command (``filter``)
-and unit tests to verify its behavior. The code for this example can be
-obtained by cloning the corresponding git repository:
-
-.. TODO: write an ad-hoc "hello world" extension and make it part of the spack organization
+In the example above the extension named ``spack-scripting`` adds an additional ``filter``
+command and unit tests to verify its behavior. Spack provides a convenient command
+line interface to work with extensions. All its functionalities are grouped within
+a single command:
 
 .. code-block:: console
 
-   $ pwd
-   /home/user
-   $ mkdir tmp && cd tmp
-   $ git clone https://github.com/alalazo/spack-scripting.git
-   Cloning into 'spack-scripting'...
-   remote: Counting objects: 11, done.
-   remote: Compressing objects: 100% (7/7), done.
-   remote: Total 11 (delta 0), reused 11 (delta 0), pack-reused 0
-   Receiving objects: 100% (11/11), done.
+   $ spack command-extensions -h
+   usage: spack command-extensions [-h] SUBCOMMAND ...
 
-As you can see by inspecting the sources, Python modules that are part of the extension
-can import any core Spack module.
+   manage custom extensions to Spack
 
----------------------------------
-Configure Spack to Use Extensions
----------------------------------
+   positional arguments:
+     SUBCOMMAND
+       get       gets a custom extension from a URL
+       remove    removes a currently installed extension
+       update    ensure a custom extension is up to date
+       list      list all available custom extensions
+       inspect   returns information on a given extension
 
-To make your current Spack instance aware of extensions you should add their root
-paths to ``config.yaml``. In the case of our example this means ensuring that:
+   optional arguments:
+     -h, --help  show this help message and exit
+
+-------------------------------
+Install and remove an extension
+-------------------------------
+
+To install the ``spack-scripting`` extension shown in the previous section
+all you need to do is specify its Github path on the command line:
+
+.. code-block:: console
+
+   $ spack command-extensions get github.com/alalazo/spack-scripting
+   ==> Cloning custom extension from : https://github.com/alalazo/spack-scripting.git@master
+   ==> Extension "spack-scripting" has been installed and it is ready to be used
+
+Currently the command line manages only extensions hosted on Github, but the
+number of supported hosts will be extended in the future. You can then check
+the list of installed extensions:
+
+.. code-block:: console
+
+   $ spack command-extensions list
+   ---- "user/linux" scope ----
+       spack-scripting
+
+and make sure ``spack-scripting`` appears there. As you might have noticed the
+configuration scope where the extension was installed is reported. Like many
+other features in Spack, also command extensions are configuration driven and
+the command line interface is just a convenient way to manage the corresponding
+YAML file:
 
 .. code-block:: yaml
 
    config:
      extensions:
-     - /home/user/tmp/spack-scripting
+     - name: spack-scripting
+       version:
+         type: branch
+         value: master
+       root: /home/user/.spack/extensions
+       url: github.com/alalazo/spack-scripting
 
-is part of your configuration file. Once this is setup any command that the extension provides
-will be available from the command line:
+To remove an installed extension you just need to use the corresponding subcommand:
+
+.. code-block:: console
+
+   $ spack command-extensions remove spack-scripting
+   ==> Extension "spack-scripting" removed from "user/linux" scope
+
+   $ spack command-extensions list
+   ==> No extensions found
+
+By default removing an extension does not delete the repository that was checked out, so
+that it can be reused if you add it back later. If you want to prune the repository though
+there is an option:
+
+.. code-block:: console
+
+   $ spack command-extensions remove --delete spack-scripting
+
+-----------------------
+Inspecting an extension
+-----------------------
+
+Once an extension is installed, it is possible to inspect it:
+
+.. code-block:: console
+
+   $ spack command-extensions inspect spack-scripting
+   NAME:             spack-scripting
+   VERSION:          master
+   LOCAL REPOSITORY: /home/user/.spack/extensions/spack-scripting
+   COMMANDS:         filter
+
+and get more information on the commands it provides or the location of the local repository.
+In this case the extension provides the additional ``filter`` command.
+Let's verify it is available from the command line:
 
 .. code-block:: console
 
@@ -91,32 +153,56 @@ The corresponding unit tests can be run giving the appropriate options to ``spac
 
 .. code-block:: console
 
-   $ spack test --extension=scripting
-
-   ============================================================== test session starts ===============================================================
-   platform linux2 -- Python 2.7.15rc1, pytest-3.2.5, py-1.4.34, pluggy-0.4.0
-   rootdir: /home/mculpo/tmp/spack-scripting, inifile: pytest.ini
+   $ spack test --extension=spack-scripting
+   =================================================================== test session starts ====================================================================
+   platform linux -- Python 3.7.4, pytest-3.2.5, py-1.4.34, pluggy-0.4.0
+   rootdir: /home/user/.spack/extensions/spack-scripting, inifile: pytest.ini
    collected 5 items
 
    tests/test_filter.py ...XX
-   ============================================================ short test summary info =============================================================
+   ================================================================= short test summary info ==================================================================
    XPASS tests/test_filter.py::test_filtering_specs[flags3-specs3-expected3]
    XPASS tests/test_filter.py::test_filtering_specs[flags4-specs4-expected4]
 
-   =========================================================== slowest 20 test durations ============================================================
-   3.74s setup    tests/test_filter.py::test_filtering_specs[flags0-specs0-expected0]
-   0.17s call     tests/test_filter.py::test_filtering_specs[flags3-specs3-expected3]
-   0.16s call     tests/test_filter.py::test_filtering_specs[flags2-specs2-expected2]
-   0.15s call     tests/test_filter.py::test_filtering_specs[flags1-specs1-expected1]
-   0.13s call     tests/test_filter.py::test_filtering_specs[flags4-specs4-expected4]
-   0.08s call     tests/test_filter.py::test_filtering_specs[flags0-specs0-expected0]
-   0.04s teardown tests/test_filter.py::test_filtering_specs[flags4-specs4-expected4]
-   0.00s setup    tests/test_filter.py::test_filtering_specs[flags4-specs4-expected4]
-   0.00s setup    tests/test_filter.py::test_filtering_specs[flags3-specs3-expected3]
-   0.00s setup    tests/test_filter.py::test_filtering_specs[flags1-specs1-expected1]
+   ================================================================ slowest 20 test durations =================================================================
+   2.29s setup    tests/test_filter.py::test_filtering_specs[flags0-specs0-expected0]
+   0.25s call     tests/test_filter.py::test_filtering_specs[flags3-specs3-expected3]
+   0.21s call     tests/test_filter.py::test_filtering_specs[flags2-specs2-expected2]
+   0.20s call     tests/test_filter.py::test_filtering_specs[flags1-specs1-expected1]
+   0.19s call     tests/test_filter.py::test_filtering_specs[flags4-specs4-expected4]
+   0.15s call     tests/test_filter.py::test_filtering_specs[flags0-specs0-expected0]
    0.00s setup    tests/test_filter.py::test_filtering_specs[flags2-specs2-expected2]
-   0.00s teardown tests/test_filter.py::test_filtering_specs[flags2-specs2-expected2]
-   0.00s teardown tests/test_filter.py::test_filtering_specs[flags1-specs1-expected1]
+   0.00s teardown tests/test_filter.py::test_filtering_specs[flags4-specs4-expected4]
+   0.00s setup    tests/test_filter.py::test_filtering_specs[flags3-specs3-expected3]
+   0.00s setup    tests/test_filter.py::test_filtering_specs[flags4-specs4-expected4]
+   0.00s setup    tests/test_filter.py::test_filtering_specs[flags1-specs1-expected1]
    0.00s teardown tests/test_filter.py::test_filtering_specs[flags0-specs0-expected0]
+   0.00s teardown tests/test_filter.py::test_filtering_specs[flags1-specs1-expected1]
+   0.00s teardown tests/test_filter.py::test_filtering_specs[flags2-specs2-expected2]
    0.00s teardown tests/test_filter.py::test_filtering_specs[flags3-specs3-expected3]
-   ====================================================== 3 passed, 2 xpassed in 4.51 seconds =======================================================
+   =========================================================== 3 passed, 2 xpassed in 3.31 seconds ============================================================
+
+-------------------
+Updating extensions
+-------------------
+
+Finally it's possible to update extensions, e.g. to check out the latest version of
+the code or switch to another branch or tag in the repository:
+
+.. code-block:: console
+
+   $ spack command-extensions update spack-scripting
+   ==> Updating extension "spack-scripting" in the "user/linux" scope
+   ==> Finished updating the "user/linux" scope
+
+With any number of extension names specified, the ``update`` command updates
+their code base by pulling the remote information. If no name is specified,
+then the update is run on all the installed extensions. When updating or
+getting an extension it's also possible to employ the ``@`` symbol to
+specify the branch or tag to check out:
+
+.. code-block:: console
+
+   $ spack  command-extensions update spack-scripting@master
+   ==> Updating extension "spack-scripting" in the "user/linux" scope [@master]
+   ==> Finished updating the "user/linux" scope

--- a/lib/spack/spack/cmd/command_extensions.py
+++ b/lib/spack/spack/cmd/command_extensions.py
@@ -1,0 +1,355 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import os.path
+import re
+import shutil
+
+import llnl.util.filesystem as fs
+import llnl.util.lang as lang
+import llnl.util.tty as tty
+import llnl.util.tty.colify as colify
+import spack.extensions
+import spack.config
+import spack.util.executable as executable
+
+description = "manage custom extensions to Spack"
+section = "commands"
+level = "short"
+
+# FIXME: generalize this mechanism
+extensions_root = os.path.expanduser('~/.spack/extensions')
+
+#: This is the git executable, wrapped into a lazy loader
+git = lang.Singleton(lambda: executable.which('git', required=True))
+
+
+def checkout_tag_or_branch(repository_dir, tag_or_branch):
+    """Moves to a repository and checks out a given branch or tag
+
+    Args:
+        repository_dir (str): directory of the repository
+        checkout_name (str): name of the branch or tag to checkout
+        checkout_type (str): type of the checkout
+    """
+    with fs.working_dir(repository_dir):
+        git('fetch', '--all', '--tags', output=os.devnull, error=os.devnull)
+        git('checkout', tag_or_branch, output=os.devnull, error=os.devnull)
+        git('pull', output=os.devnull, error=os.devnull)
+
+
+def clone_repository(folder, url, branch_or_tag):
+    """Clones a repository at a branch or tag in a given folder.
+
+    Args:
+        folder (str): root folder where the clone is performed
+        url (str): url of the repository
+        branch_or_tag (str): branch or tag to checkout
+    """
+    msg = 'Cloning custom extension from : {0}@{1}'
+    tty.msg(msg.format(url, branch_or_tag))
+    with fs.working_dir(folder, create=True):
+        git('clone', '-q', '--branch', branch_or_tag, url)
+
+
+def remote_url(repository_dir):
+    """Returns the first remote url of a repository.
+
+    Args:
+        repository_dir (str): directory where the repository resides
+    """
+    with fs.working_dir(repository_dir):
+        remote = git('remote', output=str).split().pop(0)
+        url = git('remote', 'get-url', remote, output=str).strip()
+    return url
+
+
+def verify_user_url(url):
+    """Verifies that the user url has the form we expect.
+
+    Currently only urls from github.com are supported.
+
+    Args:
+        url: url as prompted on the cli by the user
+
+    Returns:
+        Return the user or organization, name of the extension and version
+
+    Raises:
+        ValueError: if the url is not valid
+    """
+    # TODO: Allow for different provenance than github.com
+    github_regexp = r'github\.com/([\w]+)/(spack-[\w-]+)@?(.*)'
+    m = re.match(github_regexp, url)
+    if not m:
+        msg = 'the url "{0}" does not match the required format r"{1}"'
+        raise ValueError(msg.format(url, github_regexp))
+
+    return m.group(1, 2, 3)
+
+
+def analyze_repository(url):
+    """Returns the branches and tags in a remote repository.
+
+    Args:
+        url (str): url of the repository to be analyzed
+
+    Returns:
+        The list of branches and tags
+    """
+    output = git('ls-remote', url, output=str)
+    output = output.split()
+    refs = output[1::2]
+    tags = [x.replace('refs/tags/', '') for x in refs if 'refs/tags/' in x]
+    branches = [
+        x.replace('refs/heads/', '') for x in refs if 'refs/heads/' in x
+    ]
+    return branches, tags
+
+
+def ensure_url_and_version(ext):
+    """Ensures an extension has url and version set.
+
+    Args:
+        ext: extension to be checked
+
+    Returns:
+        True if the extension has been modified, False otherwise
+    """
+    updated = False
+    folder = os.path.join(ext['root'], ext['name'])
+    if not ext['url']:
+        updated = True
+        ext['url'] = remote_url(folder)
+    if not ext['version']['value']:
+        msg = 'Adding a version to the "{0}" extension'
+        tty.msg(msg.format(ext['name']))
+        updated = True
+        ext['version'] = {
+            'type': 'branch',
+            'value': 'master'
+        }
+        checkout_tag_or_branch(folder, ext['version']['value'])
+    return updated
+
+
+def setup_parser(subparser):
+    sp = subparser.add_subparsers(metavar='SUBCOMMAND', dest='subcommand')
+
+    # spack command-extensions get github.com/alalazo/spack-container@develop
+    get_parser = sp.add_parser(
+        'get', help='gets a custom extension from a URL'
+    )
+    get_parser.add_argument('url', help='the url of the custom extension')
+
+    # spack command-extensions remove spack-container
+    remove_parser = sp.add_parser(
+        'remove', help='removes a currently installed extension'
+    )
+    remove_parser.add_argument(
+        '--delete', action='store_true',
+        help='deletes the extension source code'
+    )
+    remove_parser.add_argument('name', help='the name of the custom extension')
+
+    # spack command extensions update spack-container
+    # spack command extensions update spack-container@develop
+    # spack command extensions update spack-container@v0.1.0
+    # spack command extensions update spack-container@<hash>
+    # spack command extensions update --all
+    update_parser = sp.add_parser(
+        'update', help='ensure a custom extension is up to date'
+    )
+    update_parser.add_argument(
+        'url', help='the name of the custom extension', nargs='*'
+    )
+
+    # spack command extensions list
+    sp.add_parser(
+        'list', help='list all available custom extensions'
+    )
+
+    # spack command-extensions inspect
+    inspect_parser = sp.add_parser(
+        'inspect', help='returns information on a given extension'
+    )
+    inspect_parser.add_argument(
+        'name', help='the name of the custom extension'
+    )
+
+
+def command_extensions_get(args):
+    user_or_org, name, version = verify_user_url(args.url)
+    extensions = spack.extensions.from_config()
+    if any(e['name'] == name for e in extensions):
+        msg = 'The extension "{0}" is already installed. If you want to ' \
+              'modify it use the "spack command-extensions update" command '
+        tty.msg(msg.format(name))
+        return
+
+    # Extract version information
+    protocol = 'https://'
+    full_url = protocol + '/'.join(['github.com', user_or_org, name]) + '.git'
+    version = version or 'master'
+    branches, tags = analyze_repository(full_url)
+    version_type = None
+    if version in branches:
+        version_type = 'branch'
+    elif version in tags:
+        version_type = 'tag'
+    if version_type is None:
+        msg = 'cannot find branch or tag "{0}" in the repository at {1}'
+        raise ValueError(msg.format(version, full_url))
+
+    # Check if the repository is already on disk
+    extension_dir = os.path.join(extensions_root, name)
+    if not os.path.exists(extension_dir):
+        clone_repository(extensions_root, full_url, version)
+    else:
+        # If it's not the same url and the extension was not
+        # registered before wipe out what's there and clone again
+        url = remote_url(extension_dir)
+        if full_url != url:
+            shutil.rmtree(extension_dir)
+            clone_repository(extensions_root, full_url, version)
+        else:
+            # Else checkout the branch and pull
+            msg = 'Repository {0} already present at {1}, checking-out "{2}"'
+            tty.msg(msg.format(full_url, extension_dir, version))
+            checkout_tag_or_branch(extension_dir, version)
+
+    config_scope = spack.config.default_modify_scope()
+    current_extensions = spack.extensions.from_config(scope=config_scope)
+    current_extensions.append({
+        'name': name,
+        'version': {
+            'type': version_type,
+            'value': version
+        },
+        'root': extensions_root,
+        'url': args.url
+    })
+    spack.config.set(
+        'config:extensions', current_extensions, scope=config_scope
+    )
+
+    msg = 'Extension "{0}" has been installed and it is ready to be used'
+    tty.msg(msg.format(name))
+
+
+def command_extensions_remove(args):
+    found = False
+    for scope in spack.config.scopes():
+        extensions = spack.extensions.from_config(scope=scope)
+        if any(e['name'] == args.name for e in extensions):
+            found = True
+            updated = [x for x in extensions if x['name'] != args.name]
+            spack.config.set('config:extensions', updated, scope=scope)
+            msg = 'Extension "{0}" removed from "{1}" scope'
+            tty.msg(msg.format(args.name, scope))
+            if args.delete:
+                to_delete = [x for x in extensions if x['name'] == args.name]
+                for x in to_delete:
+                    folder = os.path.join(x['root'], x['name'])
+                    shutil.rmtree(folder)
+                    msg = 'Removing folder {0}'
+                    tty.debug(msg.format(folder))
+
+    if not found:
+        msg = 'Extension "{0}" is not installed'
+        tty.msg(msg.format(args.name))
+
+
+def command_extensions_update(args):
+    for scope in spack.config.scopes():
+        # Skip default scopes when updating as those are meant to be red-only
+        if 'defaults' in scope:
+            continue
+
+        # If there are no extensions in this scope, skip it
+        extensions = spack.extensions.from_config(scope=scope)
+        if not extensions:
+            continue
+
+        # Construct a map name->version based on user input
+        ext2ver = {}
+        for x in args.url:
+            name, _, version = x.partition('@')
+            ext2ver[name] = version
+
+        # Make sure the extensions fields are all assigned
+        # (they could not be there if the extension comes
+        # from the old format)
+        updated = False
+        for ext in extensions:
+            # If the user specified a list of extensions, look
+            # only for what matches
+            name = ext['name']
+            repository_dir = os.path.join(ext['root'], name)
+            if ext2ver and name not in ext2ver:
+                continue
+
+            updated = True
+            # The call below is needed to deal with the old string format
+            ensure_url_and_version(ext)
+
+            # Check if we have a specific version to check out
+            version = ext2ver.get(ext['name'], None)
+            if version:
+                msg = 'Updating extension "{0}" in the "{1}" scope [@{2}]'
+                tty.msg(msg.format(name, scope, version))
+                checkout_tag_or_branch(repository_dir, version)
+            else:
+                msg = 'Updating extension "{0}" in the "{1}" scope'
+                tty.msg(msg.format(name, scope, version))
+                with fs.working_dir(repository_dir):
+                    git('pull', output=os.devnull, error=os.devnull)
+
+        if updated:
+            spack.config.set('config:extensions', extensions, scope=scope)
+            msg = 'Finished updating the "{0}" scope'
+            tty.msg(msg.format(scope))
+
+
+def command_extensions_list(args):
+    found = False
+    for scope in spack.config.scopes():
+        extensions = spack.extensions.from_config(scope=scope)
+        if extensions:
+            found = True
+            print('---- "{0}" scope ----'.format(scope))
+            colify.colify([x['name'] for x in extensions], indent=4)
+            print('')
+
+    if not found:
+        tty.msg('No extensions found')
+
+
+def command_extensions_inspect(args):
+    extensions = spack.extensions.from_config()
+    try:
+        selected = next(filter(lambda x: x['name'] == args.name, extensions))
+    except StopIteration:
+        tty.msg('Extension "{0}" not found'.format(args.name))
+        return
+
+    print('NAME:             {0}'.format(selected['name']))
+    print('VERSION:          {0}'.format(selected['version']['value']))
+    repository_dir = os.path.join(selected['root'], selected['name'])
+    print('LOCAL REPOSITORY: {0}'.format(repository_dir))
+    name = spack.extensions.extension_name(repository_dir)
+    cmd_dir = os.path.join(repository_dir, name, 'cmd')
+    commands = [f[:-3] for f in os.listdir(cmd_dir) if f.endswith('.py')]
+    print('COMMANDS:         {0}'.format(', '.join(commands)))
+
+
+def command_extensions(parser, args):
+    subcommands = {
+        'get': command_extensions_get,
+        'remove': command_extensions_remove,
+        'update': command_extensions_update,
+        'list': command_extensions_list,
+        'inspect': command_extensions_inspect
+    }
+    subcommands[args.subcommand](args)

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -86,7 +86,7 @@ def test(parser, args, unknown_args):
     pytest_root = spack.paths.test_path
     if args.extension:
         target = args.extension
-        extensions = spack.config.get('config:extensions')
+        extensions = spack.extensions.from_config()
         pytest_root = spack.extensions.path_for_extension(target, *extensions)
 
     # pytest.ini lives in the root of the spack repository.

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -31,7 +31,28 @@ properties = {
             },
             'extensions': {
                 'type': 'array',
-                'items': {'type': 'string'}
+                'items': {
+                    'anyOf': [
+                        {'type': 'string'},
+                        {
+                            'type': 'object',
+                            'properties': {
+                                'name': {'type': 'string'},
+                                'version': {
+                                    'type': 'object',
+                                    'properties': {
+                                        'type': {'type': 'string'},
+                                        'value': {'type': 'string'}
+                                    },
+                                    'additionalProperties': False
+                                },
+                                'url': {'type': 'string'},
+                                'root': {'type': 'string'}
+                            },
+                            'additionalProperties': False
+                        }
+                    ]
+                }
             },
             'template_dirs': {
                 'type': 'array',

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -444,7 +444,7 @@ def _populate(mock_db):
 
 
 @pytest.fixture(scope='session')
-def _store_dir_and_cache(tmpdir_factory):
+def store_dir_and_cache(tmpdir_factory):
     """Returns the directory where to build the mock database and
     where to cache it.
     """
@@ -454,13 +454,13 @@ def _store_dir_and_cache(tmpdir_factory):
 
 
 @pytest.fixture(scope='module')
-def database(tmpdir_factory, mock_packages, config, _store_dir_and_cache):
+def database(tmpdir_factory, mock_packages, config, store_dir_and_cache):
     """Creates a read-only mock database with some packages installed note
     that the ref count for dyninst here will be 3, as it's recycled
     across each install.
     """
     real_store = spack.store.store
-    store_path, store_cache = _store_dir_and_cache
+    store_path, store_cache = store_dir_and_cache
 
     mock_store = spack.store.Store(str(store_path))
     spack.store.store = mock_store
@@ -480,12 +480,12 @@ def database(tmpdir_factory, mock_packages, config, _store_dir_and_cache):
 
 
 @pytest.fixture(scope='function')
-def mutable_database(database, _store_dir_and_cache):
+def mutable_database(database, store_dir_and_cache):
     """Writeable version of the fixture, restored to its initial state
     after each test.
     """
     # Make the database writeable, as we are going to modify it
-    store_path, store_cache = _store_dir_and_cache
+    store_path, store_cache = store_dir_and_cache
     store_path.join('.spack-db').chmod(mode=0o755, rec=1)
 
     yield database


### PR DESCRIPTION
fixes #12600

This PR adds a new command to simplify working with Spack extensions. Documentation is added to highlight its use and show common scenarios.

Current roadmap for this PR:

- [x] Add commands to manage command extensions from the command line
- [x] Extend the documentation section on "Custom extensions"
- [ ] Add tests for the new feature, consolidate the code