### PR TITLE
Add compiler selection for ARM and POWER architecture

### DIFF
--- a/var/spack/repos/builtin/packages/likwid/package.py
+++ b/var/spack/repos/builtin/packages/likwid/package.py
@@ -6,6 +6,7 @@
 from spack import *
 import glob
 import os
+import platform
 
 
 class Likwid(Package):
@@ -41,6 +42,10 @@ class Likwid(Package):
     depends_on('perl', type=('build', 'run'))
 
     supported_compilers = {'clang': 'CLANG', 'gcc': 'GCC', 'intel': 'ICC'}
+    if platform.machine() == 'aarch64':
+        supported_compilers = {'gcc' : 'GCCARMv8'}
+    elif platform.machine().startswith('ppc64'):
+        supported_compilers = {'gcc' : 'GCCPOWER'}
 
     def patch(self):
         files = glob.glob('perl/*.*') + glob.glob('bench/perl/*.*')

--- a/var/spack/repos/builtin/packages/likwid/package.py
+++ b/var/spack/repos/builtin/packages/likwid/package.py
@@ -43,9 +43,9 @@ class Likwid(Package):
 
     supported_compilers = {'clang': 'CLANG', 'gcc': 'GCC', 'intel': 'ICC'}
     if platform.machine() == 'aarch64':
-        supported_compilers = {'gcc' : 'GCCARMv8'}
+        supported_compilers = {'gcc': 'GCCARMv8'}
     elif platform.machine().startswith('ppc64'):
-        supported_compilers = {'gcc' : 'GCCPOWER'}
+        supported_compilers = {'gcc': 'GCCPOWER'}
 
     def patch(self):
         files = glob.glob('perl/*.*') + glob.glob('bench/perl/*.*')

--- a/var/spack/repos/builtin/packages/likwid/package.py
+++ b/var/spack/repos/builtin/packages/likwid/package.py
@@ -7,6 +7,7 @@ from spack import *
 import glob
 import os
 
+
 class Likwid(Package):
     """Likwid is a simple to install and use toolsuite of command line
     applications for performance oriented programmers. It works for Intel and
@@ -59,7 +60,7 @@ class Likwid(Package):
         supported_compilers = {'clang': 'CLANG', 'gcc': 'GCC', 'intel': 'ICC'}
         if spec.target.family == 'aarch64':
             supported_compilers = {'gcc': 'GCCARMv8', 'clang': 'ARMCLANG'}
-        elif spec.target.family == 'ppc64' or  spec.target.family == 'ppc64le':
+        elif spec.target.family == 'ppc64' or spec.target.family == 'ppc64le':
             supported_compilers = {'gcc': 'GCCPOWER'}
         if self.compiler.name not in supported_compilers:
             raise RuntimeError('{0} is not a supported compiler \

--- a/var/spack/repos/builtin/packages/likwid/package.py
+++ b/var/spack/repos/builtin/packages/likwid/package.py
@@ -59,7 +59,7 @@ class Likwid(Package):
         supported_compilers = {'clang': 'CLANG', 'gcc': 'GCC', 'intel': 'ICC'}
         if spec.target.family == 'aarch64':
             supported_compilers = {'gcc': 'GCCARMv8', 'clang': 'ARMCLANG'}
-        elif spec.target().startswith('ppc64'):
+        elif spec.target.family == 'ppc64' or  spec.target.family == 'ppc64le':
             supported_compilers = {'gcc': 'GCCPOWER'}
         if self.compiler.name not in supported_compilers:
             raise RuntimeError('{0} is not a supported compiler \

--- a/var/spack/repos/builtin/packages/likwid/package.py
+++ b/var/spack/repos/builtin/packages/likwid/package.py
@@ -57,7 +57,7 @@ class Likwid(Package):
 
     def install(self, spec, prefix):
         supported_compilers = {'clang': 'CLANG', 'gcc': 'GCC', 'intel': 'ICC'}
-        if spec.target() == 'aarch64':
+        if spec.target.family == 'aarch64':
             supported_compilers = {'gcc': 'GCCARMv8', 'clang': 'ARMCLANG'}
         elif spec.target().startswith('ppc64'):
             supported_compilers = {'gcc': 'GCCPOWER'}


### PR DESCRIPTION
LIKWID 5.0.0 has support for ARM and POWER processors. Each architectures uses a different LIKWID-internal compiler name like GCCARMv8.

I wasn't sure how to check the version in the install function to raise an error if trying to build LIKWID < 5.0 with ARM and POWER compiler settings. If you could give me a hint, I'll add that of course.