### PR TITLE
Improve concretization performance

### DIFF
--- a/lib/spack/spack/architecture.py
+++ b/lib/spack/spack/architecture.py
@@ -436,6 +436,7 @@ class Arch(object):
         return arch_for_spec(spec)
 
 
+@memoized
 def get_platform(platform_name):
     """Returns a platform object that corresponds to the given name."""
     platform_list = all_platforms()

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -25,6 +25,7 @@ import spack.hash_types as ht
 import spack.repo
 import spack.schema.env
 import spack.spec
+import spack.store
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
 import spack.config
@@ -1235,13 +1236,16 @@ class Environment(object):
         Yields the user spec for non-concretized specs, and the concrete
         spec for already concretized but not yet installed specs.
         """
-        concretized = dict(self.concretized_specs())
-        for spec in self.user_specs:
-            concrete = concretized.get(spec)
-            if not concrete:
-                yield spec
-            elif not concrete.package.installed:
-                yield concrete
+        # use a transaction to avoid overhead of repeated calls
+        # to `package.installed`
+        with spack.store.db.read_transaction():
+            concretized = dict(self.concretized_specs())
+            for spec in self.user_specs:
+                concrete = concretized.get(spec)
+                if not concrete:
+                    yield spec
+                elif not concrete.package.installed:
+                    yield concrete
 
     def concretized_specs(self):
         """Tuples of (user spec, concrete spec) for all concrete specs."""

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2243,10 +2243,12 @@ class Spec(object):
 
         # If any spec in the DAG is deprecated, throw an error
         deprecated = []
-        for x in self.traverse():
-            _, rec = spack.store.db.query_by_spec_hash(x.dag_hash())
-            if rec and rec.deprecated_for:
-                deprecated.append(rec)
+        with spack.store.db.read_transaction():
+            for x in self.traverse():
+                _, rec = spack.store.db.query_by_spec_hash(x.dag_hash())
+                if rec and rec.deprecated_for:
+                    deprecated.append(rec)
+
         if deprecated:
             msg = "\n    The following specs have been deprecated"
             msg += " in favor of specs with the hashes shown:\n"

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -94,6 +94,10 @@ def current_host(request, monkeypatch):
     # preferred target via packages.yaml
     cpu, _, is_preference = request.param.partition('-')
     target = llnl.util.cpu.targets[cpu]
+
+    # this function is memoized, so clear its state for testing
+    spack.architecture.get_platform.cache.clear()
+
     if not is_preference:
         monkeypatch.setattr(llnl.util.cpu, 'host', lambda: target)
         monkeypatch.setattr(spack.platforms.test.Test, 'default', cpu)
@@ -103,6 +107,9 @@ def current_host(request, monkeypatch):
         PackagePrefs._packages_config_cache = None
         with spack.config.override('packages:all', {'target': [cpu]}):
             yield target
+
+    # clear any test values fetched
+    spack.architecture.get_platform.cache.clear()
 
 
 @pytest.mark.usefixtures('config', 'mock_packages')


### PR DESCRIPTION
Fixes #12779.

This addresses two problems:

1. Checks for deprecated specs (introduced in #12933) were repeatedly taking out read locks on the database, which can be very slow.
2. `get_platform()` is pretty expensive and can be called many times in a spack invocation.

- [x] put a read transaction around the deprecation check to avoid repeated locking/reading
- [x] memoize `get_platform()`

@ajw1980 @matz-e: does this improve things for you?