### PR TITLE
LAMMPS: Fix USER-REAXC package variant

### DIFF
--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -48,10 +48,10 @@ class Lammps(CMakePackage, CudaPackage):
     supported_packages = ['asphere', 'body', 'class2', 'colloid', 'compress',
                           'coreshell', 'dipole', 'granular', 'kspace', 'latte',
                           'manybody', 'mc', 'meam', 'misc', 'molecule',
-                          'mpiio', 'peri', 'poems', 'python', 'qeq', 'reax',
+                          'mpiio', 'peri', 'poems', 'python', 'qeq',
                           'replica', 'rigid', 'shock', 'snap', 'spin', 'srd',
                           'user-atc', 'user-h5md', 'user-lb', 'user-misc',
-                          'user-netcdf', 'user-omp', 'voronoi']
+                          'user-netcdf', 'user-omp', 'user-reaxc', 'voronoi']
 
     for pkg in supported_packages:
         variant(pkg, default=False,


### PR DESCRIPTION
The incorrect `reax` package keyword is replaced with the correct `user-reaxc` keyword, according to LAMMPS' [package details](https://lammps.sandia.gov/doc/Packages_details.html#pkg-user-reaxc).

The correction has been validated by running a LAMMPS task that requires the `USER-REAXC` package.

Thank you.