### PR TITLE
WIP: allow using $spack when defining extensions in config/config.yaml

### DIFF
--- a/lib/spack/spack/extensions.py
+++ b/lib/spack/spack/extensions.py
@@ -101,8 +101,8 @@ def load_command_extension(command, path):
 def get_command_paths():
     """Return the list of paths where to search for command files."""
     command_paths = []
-    extension_paths = spack.config.get('config:extensions') or []
-
+    extension_paths = [canonicalize_path(e) for e in
+                       spack.config.get('config:extensions')] or []
     for path in extension_paths:
         extension = extension_name(path)
         if extension:
@@ -139,8 +139,9 @@ def get_module(cmd_name):
     """
     # If built-in failed the import search the extension
     # directories in order
-    extensions = spack.config.get('config:extensions') or []
-    for folder in [canonicalize_path(e) for e in extensions]:
+    extensions = [canonicalize_path(e) for e in
+                  spack.config.get('config:extensions')] or []
+    for folder in extensions:
         module = load_command_extension(cmd_name, folder)
         if module:
             return module
@@ -152,6 +153,7 @@ def get_template_dirs():
     """Returns the list of directories where to search for templates
     in extensions.
     """
-    extension_dirs = spack.config.get('config:extensions') or []
+    extension_dirs = [canonicalize_path(e) for e in
+                      spack.config.get('config:extensions')] or []
     extensions = [os.path.join(x, 'templates') for x in extension_dirs]
     return extensions

--- a/lib/spack/spack/extensions.py
+++ b/lib/spack/spack/extensions.py
@@ -13,6 +13,7 @@ import types
 import llnl.util.lang
 import llnl.util.tty as tty
 import spack.config
+from spack.util.path import canonicalize_path
 
 extension_regexp = re.compile(r'spack-([\w]*)')
 
@@ -139,7 +140,7 @@ def get_module(cmd_name):
     # If built-in failed the import search the extension
     # directories in order
     extensions = spack.config.get('config:extensions') or []
-    for folder in extensions:
+    for folder in [canonicalize_path(e) for e in extensions]:
         module = load_command_extension(cmd_name, folder)
         if module:
             return module


### PR DESCRIPTION
I would like to define extensions-paths relative to the spack-instance and therefore would like to have $spack working for values in the extensions-list in config.yaml

It appeared to me a simple change using canonicalize_path does the trick