### PR TITLE
Add support for authenticated CDash uploads

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -7,6 +7,7 @@ import argparse
 import os
 import shutil
 import sys
+import textwrap
 
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
@@ -246,7 +247,13 @@ def install_spec(cli_args, kwargs, abstract_spec, spec):
 
 def install(parser, args, **kwargs):
     if args.help_cdash:
-        parser = argparse.ArgumentParser()
+        parser = argparse.ArgumentParser(
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            epilog=textwrap.dedent('''\
+environment variables:
+  SPACK_CDASH_AUTH_TOKEN
+                        authentication token to present to CDash
+                        '''))
         add_cdash_args(parser, True)
         parser.print_help()
         return

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -146,8 +146,9 @@ class InfoCollector(object):
                     # An InstallError is considered a failure (the recipe
                     # didn't work correctly)
                     package['result'] = 'failure'
-                    package['stdout'] = fetch_package_log(pkg)
                     package['message'] = e.message or 'Installation failure'
+                    package['stdout'] = fetch_package_log(pkg)
+                    package['stdout'] += package['message']
                     package['exception'] = e.traceback
 
                 except (Exception, BaseException) as e:

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -232,7 +232,8 @@ class CDash(Reporter):
             # from the binary cache.
             spec['packages'] = [
                 x for x in spec['packages']
-                if not x['installed_from_binary_cache']
+                if 'installed_from_binary_cache' not in x or
+                   not x['installed_from_binary_cache']
             ]
             for package in spec['packages']:
                 if 'stdout' in package:

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -17,6 +17,7 @@ from six.moves.urllib.request import build_opener, HTTPHandler, Request
 from six.moves.urllib.parse import urlencode
 
 from llnl.util.filesystem import working_dir
+import llnl.util.tty as tty
 from ordereddict_backport import OrderedDict
 import spack.build_environment
 import spack.fetch_strategy
@@ -58,12 +59,18 @@ class CDash(Reporter):
 
     def __init__(self, args):
         Reporter.__init__(self, args)
+        tty.set_verbose(args.verbose)
         self.template_dir = os.path.join('reports', 'cdash')
         self.cdash_upload_url = args.cdash_upload_url
 
         if self.cdash_upload_url:
             self.buildid_regexp = re.compile("<buildId>([0-9]+)</buildId>")
         self.phase_regexp = re.compile(r"Executing phase: '(.*)'")
+
+        self.authtoken = None
+        if 'SPACK_CDASH_AUTH_TOKEN' in os.environ:
+            tty.verbose("Using CDash auth token from environment")
+            self.authtoken = os.environ.get('SPACK_CDASH_AUTH_TOKEN')
 
         if args.package:
             packages = args.package
@@ -297,6 +304,9 @@ class CDash(Reporter):
             request = Request(url, data=f)
             request.add_header('Content-Type', 'text/xml')
             request.add_header('Content-Length', os.path.getsize(filename))
+            if self.authtoken:
+                request.add_header('Authorization',
+                                   'Bearer {0}'.format(self.authtoken))
             # By default, urllib2 only support GET and POST.
             # CDash needs expects this file to be uploaded via PUT.
             request.get_method = lambda: 'PUT'

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -679,3 +679,16 @@ def test_install_help_cdash(capsys):
     install_cmd = SpackCommand('install')
     out = install_cmd('--help-cdash')
     assert 'CDash URL' in out
+
+
+@pytest.mark.disable_clean_stage_check
+def test_cdash_auth_token(tmpdir, capfd):
+    # capfd interferes with Spack's capturing
+    with capfd.disabled():
+        os.environ['SPACK_CDASH_AUTH_TOKEN'] = 'asdf'
+        out = install(
+            '-v',
+            '--log-file=cdash_reports',
+            '--log-format=cdash',
+            'a')
+        assert 'Using CDash auth token from environment' in out


### PR DESCRIPTION
Also:
* Avoid 'installed_from_binary_cache' KeyError in CDash reporter
* Make it so InstallErrors get described in reports