### PR TITLE
openPMD-api: 0.10.2

### DIFF
--- a/var/spack/repos/builtin/packages/openpmd-api/package.py
+++ b/var/spack/repos/builtin/packages/openpmd-api/package.py
@@ -15,6 +15,7 @@ class OpenpmdApi(CMakePackage):
     maintainers = ['ax3l']
 
     version('develop', branch='dev')
+    version('0.10.2',  tag='0.10.2-alpha')
     version('0.10.1',  tag='0.10.1-alpha')
     version('0.10.0',  tag='0.10.0-alpha')
 


### PR DESCRIPTION
Add the latest release of openPMD-api, `v0.10.2` .