### PR TITLE
PNETCDF: Update to include latest release 1.12.1

### DIFF
--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -27,6 +27,7 @@ class ParallelNetcdf(AutotoolsPackage):
 
     version('develop', branch='develop')
     version('master', branch='master')
+    version('1.12.1', sha256='56f5afaa0ddc256791c405719b6436a83b92dcd5be37fe860dea103aee8250a2')
     version('1.11.2', sha256='d2c18601b364c35b5acb0a0b46cd6e14cae456e0eb854e5c789cf65f3cd6a2a7')
     version('1.11.1', sha256='0c587b707835255126a23c104c66c9614be174843b85b897b3772a590be45779')
     version('1.11.0', sha256='a18a1a43e6c4fd7ef5827dbe90e9dcf1363b758f513af1f1356ed6c651195a9f')


### PR DESCRIPTION
Added checksum for recent 1.12.1 release.

This version has fixes required for building with OpenMPI-4.0.2 and later  related to the use of symbols deprecated in MPI-3.0