### PR TITLE
NETCDF-C: Add latest release 4.7.3

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -34,6 +34,7 @@ class NetcdfC(AutotoolsPackage):
         return url.format(version.dotted)
 
     version('master', branch='master')
+    version('4.7.3',   sha256='8e8c9f4ee15531debcf83788594744bd6553b8489c06a43485a15c93b4e0448b')
     version('4.7.2',   sha256='b751cc1f314ac8357df2e0a1bacf35a624df26fe90981d3ad3fa85a5bbd8989a')
     version('4.7.1',   sha256='5c537c585773e575a16b28c3973b9608a98fdc4cf7c42893aa5223024e0001fc')
     version('4.7.0',   sha256='a512d2b4828c6177dd4b96791c4163e4e06e6bfc7123bebfbfe01762d777d1cb')


### PR DESCRIPTION
Added checksum for recent 1.12.1 release.

This version has fixes required for building with OpenMPI-4.0.2 and later  related to the use of symbols deprecated in MPI-3.0