### PR TITLE
Fastx-toolkit: Specified the scope of pragma pack

### DIFF
--- a/var/spack/repos/builtin/packages/fastx-toolkit/fix_pragma_pack.patch
+++ b/var/spack/repos/builtin/packages/fastx-toolkit/fix_pragma_pack.patch
@@ -1,10 +1,19 @@
---- spack-src/src/libfastx/fastx.h.org	2019-12-18 14:45:33.191492491 +0900
-+++ spack-src/src/libfastx/fastx.h	2019-12-18 14:45:55.843830041 +0900
-@@ -58,7 +58,6 @@
+--- spack-src/src/libfastx/fastx.h.org	2019-12-19 12:05:37.497936486 +0900
++++ spack-src/src/libfastx/fastx.h	2019-12-19 13:44:55.481837853 +0900
+@@ -58,7 +58,7 @@
  	OUTPUT_SAME_AS_INPUT=3
  } OUTPUT_FILE_TYPE;
  
 -#pragma pack(1) 
++#pragma pack(push, 1) 
  typedef struct 
  {
  	/* Record data - common for FASTA/FASTQ */
+@@ -115,6 +115,7 @@
+ 	FILE*	input;
+ 	FILE*	output;
+ } FASTX ;
++#pragma pack(pop)
+ 
+ 
+ void fastx_init_reader(FASTX *pFASTX, const char* filename, 

--- a/var/spack/repos/builtin/packages/fastx-toolkit/fix_pragma_pack.patch
+++ b/var/spack/repos/builtin/packages/fastx-toolkit/fix_pragma_pack.patch
@@ -1,0 +1,10 @@
+--- spack-src/src/libfastx/fastx.h.org	2019-12-18 14:45:33.191492491 +0900
++++ spack-src/src/libfastx/fastx.h	2019-12-18 14:45:55.843830041 +0900
+@@ -58,7 +58,6 @@
+ 	OUTPUT_SAME_AS_INPUT=3
+ } OUTPUT_FILE_TYPE;
+ 
+-#pragma pack(1) 
+ typedef struct 
+ {
+ 	/* Record data - common for FASTA/FASTQ */

--- a/var/spack/repos/builtin/packages/fastx-toolkit/package.py
+++ b/var/spack/repos/builtin/packages/fastx-toolkit/package.py
@@ -19,5 +19,5 @@ class FastxToolkit(AutotoolsPackage):
 
     # patch implicit fallthrough
     patch("pr-22.patch")
-    # fix error [-Werror,-Wpragma-pack] 
-    patch('fix_pragma_pack.patch', when='%fj')
+    # fix error [-Werror,-Wpragma-pack]
+    patch('fix_pragma_pack.patch')

--- a/var/spack/repos/builtin/packages/fastx-toolkit/package.py
+++ b/var/spack/repos/builtin/packages/fastx-toolkit/package.py
@@ -19,3 +19,5 @@ class FastxToolkit(AutotoolsPackage):
 
     # patch implicit fallthrough
     patch("pr-22.patch")
+    # fix error [-Werror,-Wpragma-pack] 
+    patch('fix_pragma_pack.patch', when='%fj')

--- a/var/spack/repos/builtin/packages/fastx-toolkit/package.py
+++ b/var/spack/repos/builtin/packages/fastx-toolkit/package.py
@@ -20,4 +20,4 @@ class FastxToolkit(AutotoolsPackage):
     # patch implicit fallthrough
     patch("pr-22.patch")
     # fix error [-Werror,-Wpragma-pack]
-    patch('fix_pragma_pack.patch')
+    patch('fix_pragma_pack.patch', when='%fj')


### PR DESCRIPTION
I specified the scope of pragma pack because the following error occurred.
`error: the current #pragma pack aligment value is modified in the included file [-Werror,-Wpragma-pack]`