### PR TITLE
Add knem and explicit ucx path to configure options

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -217,7 +217,8 @@ class Openmpi(AutotoolsPackage):
     variant(
         'fabrics',
         values=disjoint_sets(
-            ('auto',), ('psm', 'psm2', 'verbs', 'mxm', 'ucx', 'libfabric', 'knem')
+            ('auto',),
+            ('psm', 'psm2', 'verbs', 'mxm', 'ucx', 'libfabric', 'knem')
         ).with_non_feature_values('auto', 'none'),
         description="List of fabrics that are enabled; "
         "'auto' lets openmpi determine",


### PR DESCRIPTION
Spack UCX prefix is now used in configure stage to avoid linking against an
older version that may be installed on the system. Added KNEM option as well
into fabric variants.