### PR TITLE
Remove python2-ism in root package

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -6,7 +6,6 @@
 
 from spack import *
 import sys
-import types
 
 
 class Root(CMakePackage):
@@ -450,7 +449,7 @@ class Root(CMakePackage):
 
         def _process_opt(opt_name, cond_or_variant=None):
             val = cond_or_variant if \
-                isinstance(cond_or_variant, types.BooleanType) else \
+                isinstance(cond_or_variant, bool) else \
                 ('+{variant}'.format(variant=cond_or_variant or opt_name)
                  in self.spec)
             return '-D{opt}:BOOL={val}'.format(opt=opt_name, val='ON' if


### PR DESCRIPTION
As it turns out, the check for value bool-ness of https://github.com/spack/spack/pull/14203 was not compatible with python 3. This PR fixes that without breaking python 2 compatibility.