### PR TITLE
root: Fix root+x breakage from #11129

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -428,6 +428,9 @@ class Root(CMakePackage):
             env.append_path('CMAKE_PREFIX_PATH',
                             self.spec['lz4'].prefix)
         env.set('SPACK_INCLUDE_DIRS', '', force=True)
+        if self.spec.satisfies('@:6.12.99'):
+            env.append_path('SPACK_INCLUDE_DIRS',
+                            self.spec['zlib'].prefix.include)
         if '+x' in self.spec:
             env.append_path('SPACK_INCLUDE_DIRS',
                             self.spec['fontconfig'].prefix.include)

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -432,13 +432,14 @@ class Root(CMakePackage):
             env.append_path('SPACK_INCLUDE_DIRS',
                             self.spec['fontconfig'].prefix.include)
             env.append_path('SPACK_INCLUDE_DIRS',
-                            self.spec['glew'].prefix.include)
-            env.append_path('SPACK_INCLUDE_DIRS',
                             self.spec['libx11'].prefix.include)
             env.append_path('SPACK_INCLUDE_DIRS',
-                            self.spec['mesa-glu'].prefix.include)
-            env.append_path('SPACK_INCLUDE_DIRS',
                             self.spec['xproto'].prefix.include)
+        if '+opengl' in self.spec:
+            env.append_path('SPACK_INCLUDE_DIRS',
+                            self.spec['glew'].prefix.include)
+            env.append_path('SPACK_INCLUDE_DIRS',
+                            self.spec['mesa-glu'].prefix.include)
 
     def setup_run_environment(self, env):
         env.set('ROOTSYS', self.prefix)

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -428,6 +428,17 @@ class Root(CMakePackage):
             env.append_path('CMAKE_PREFIX_PATH',
                             self.spec['lz4'].prefix)
         env.set('SPACK_INCLUDE_DIRS', '', force=True)
+        if '+x' in self.spec:
+            env.append_path('SPACK_INCLUDE_DIRS',
+                            self.spec['fontconfig'].prefix.include)
+            env.append_path('SPACK_INCLUDE_DIRS',
+                            self.spec['glew'].prefix.include)
+            env.append_path('SPACK_INCLUDE_DIRS',
+                            self.spec['libx11'].prefix.include)
+            env.append_path('SPACK_INCLUDE_DIRS',
+                            self.spec['mesa-glu'].prefix.include)
+            env.append_path('SPACK_INCLUDE_DIRS',
+                            self.spec['xproto'].prefix.include)
 
     def setup_run_environment(self, env):
         env.set('ROOTSYS', self.prefix)

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -446,7 +446,7 @@ class Root(CMakePackage):
                 env.append_path('SPACK_INCLUDE_DIRS', include_path)
 
         # With that done, let's go fixing those deps
-        if self.spec.satisfies('@:6.08.99'):
+        if self.spec.satisfies('+x @:6.08.99'):
             add_include_path('xextproto')
         if self.spec.satisfies('@:6.12.99'):
             add_include_path('zlib')

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -428,6 +428,9 @@ class Root(CMakePackage):
             env.append_path('CMAKE_PREFIX_PATH',
                             self.spec['lz4'].prefix)
         env.set('SPACK_INCLUDE_DIRS', '', force=True)
+        if self.spec.satisfies('@:6.08.99'):
+            env.append_path('SPACK_INCLUDE_DIRS',
+                            self.spec['xextproto'].prefix.include)
         if self.spec.satisfies('@:6.12.99'):
             env.append_path('SPACK_INCLUDE_DIRS',
                             self.spec['zlib'].prefix.include)


### PR DESCRIPTION
For those unfamiliar with this longstanding issue, here's a quick summary:

- The design of Unices strongly favors putting all headers/libraries/binaries in one place, whereas the design of Spack strongly favors putting each package in its own prefix. As a result, if no further action is taken, file lookup sadness ensues.
- Spack's standard answer to this problem is the moral equivalent of crafting a CPATH which contains the include prefix of all dependencies during a build (using headers as an example, but it's the same idea for libraries & friends). That's `SPACK_INCLUDE_DIRS`.
- Sadly, this technique breaks when a package defines a header whose name clashes with that of a header of a dependency. Which is arguably a failure of C/++'s non-namespaced header file model, but well, we can't fix legacy programming languages...
- As it happens, ROOT builds encounter this edge case because both `asimage` (internally built by ROOT) and `python` (used by ROOT) define an `import.h` header. That's issue https://github.com/spack/spack/issues/10850 .
- In an attempt to fix that bug, PR https://github.com/spack/spack/pull/11129 disabled the `SPACK_INCLUDE_DIRS` mechanism for ROOT builds under the assumption that CMake would manage to find all the dependencies and to set include paths more precisely than Spack can.
- This was forgetting, however, that not everyone uses CMake, and as a result that PR broke all X11 and OpenGL-related functionality in ROOT. That was issue https://github.com/spack/spack/issues/12481 .
- So now, what I'm proposing to do is to bring back just enough of `SPACK_INCLUDE_DIRS` to get `root+x` and `root+x+opengl` builds to work again.

Fixes https://github.com/spack/spack/issues/12481 .