### PR TITLE
root: Configure ROOT correctly for python3

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -354,8 +354,7 @@ class Root(CMakePackage):
                 ['pgsql', 'postgres'],
                 ['pythia6'],
                 ['pythia8', False],
-                ['python', self.spec.satisfies('+python ^python@2.7:2.99.99')],
-                ['python3', self.spec.satisfies('+python ^python@3.0:')],
+                ['python', self.spec.satisfies('+python')],
                 ['qt', 'qt4'],  # See conflicts
                 ['qtgsi', 'qt4'],  # See conflicts
                 ['r', 'R'],

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -237,6 +237,9 @@ class Root(CMakePackage):
     # ROOT <6.08 was incompatible with the GCC 5+ ABI
     conflicts('%gcc@5.0.0:', when='@:6.07.99')
 
+    # ROOT <6.14 was incompatible with Python 3.7+
+    conflicts('python@3.7:', when='@:6.13.99 +python')
+
     # See README.md
     conflicts('+http',
               msg='HTTP server currently unsupported due to dependency issues')

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -236,7 +236,7 @@ class Root(CMakePackage):
 
     # ROOT <6.08 was incompatible with the GCC 5+ ABI
     conflicts('%gcc@5.0.0:', when='@:6.07.99')
-    
+
     # The version of Clang featured in ROOT <6.12 fails to build with
     # GCC 9.2.1, which we can safely extrapolate to the GCC 9 series.
     conflicts('%gcc@9.0.0:', when='@:6.11.99')


### PR DESCRIPTION
To quote Guilherme Amadio in [ROOT-9033](https://sft.its.cern.ch/jira/browse/ROOT-9033), back in February 2018:

> The `python3` option should be avoided. It has been removed in the master branch, and on the other branches, the recommended way to configure ROOT with Python 3.x is to pass `-Dpython=ON -DPYTHON_EXECUTABLE=<full path to python3 interpreter>` to CMake when configuring ROOT.

(Further, other comments on that issue suggest that the `python3` CMake option was already gone at least as far as in 2017 / the ROOT 6.10 era.)

We're already doing the `-DPYTHON_EXECUTABLE` part, but we don't set `-Dpython` when building for Python 3, which means in practice that we're not building PyROOT...