### PR TITLE
Mark root+python as extending Python

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -215,6 +215,7 @@ class Root(CMakePackage):
     depends_on('postgresql', when='+postgres')
     depends_on('pythia6+root', when='+pythia6')
     depends_on('python@2.7:', when='+python', type=('build', 'run'))
+    extends("python", when="+python")
     depends_on('r',         when='+r', type=('build', 'run'))
     depends_on('r-rcpp',    when='+r', type=('build', 'run'))
     depends_on('r-rinside', when='+r', type=('build', 'run'))


### PR DESCRIPTION
I'm pretty sure that PyROOT matches Spack's vision of a Python extension.

This _might_ render the manual `PYTHONPATH` fiddling that the root package currently performs in its `setup_xyz_environment` hooks obsolete, but I have not tested that yet.