### PR TITLE
Add py-pyinstrument-cext package

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyinstrument-cext/package.py
+++ b/var/spack/repos/builtin/packages/py-pyinstrument-cext/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyPyinstrumentCext(PythonPackage):
+    """A CPython extension supporting pyinstrument."""
+
+    homepage = "https://github.com/joerick/pyinstrument_cext"
+    url      = "https://pypi.io/packages/source/p/pyinstrument_cext/pyinstrument_cext-0.2.2.tar.gz"
+
+    version('0.2.2', sha256='f29e25f71d74c0415ca9310e5567fff0f5d29f4240a09a885abf8b0eed71cc5b')
+
+    depends_on('py-setuptools', type='build')
+    depends_on('py-nose', type='test')


### PR DESCRIPTION
Successfully builds on macOS 10.15.2 with Clang 11.0.0 and Python 3.7.4.