### PR TITLE
node-js: add Python 3 support

### DIFF
--- a/var/spack/repos/builtin/packages/node-js/package.py
+++ b/var/spack/repos/builtin/packages/node-js/package.py
@@ -13,8 +13,15 @@ class NodeJs(Package):
     engine."""
 
     homepage = "https://nodejs.org/"
-    url      = "https://nodejs.org/download/release/v6.3.0/node-v6.3.0.tar.gz"
+    url      = "https://nodejs.org/dist/v13.5.0/node-v13.5.0.tar.gz"
+    list_url = "https://nodejs.org/dist/"
+    list_depth = 1
 
+    # Current (latest features)
+    version('13.5.0',  sha256='4b8078d896a7550d7ed399c1b4ac9043e9f883be404d9b337185c8d8479f2db8')
+
+    # LTS (recommended for most users)
+    version('12.14.0', sha256='5c1939867228f3845c808ef84a89c8ee93cc35f857bf7587ecee1b5a6d9da67b', preferred=True)
     version('11.1.0',  sha256='3f53b5ac25b2d36ad538267083c0e603d9236867a936c22a9116d95fa10c60d5')
     version('10.13.0', sha256='aa06825fff375ece7c0d881ae0de5d402a857e8cabff9b4a50f2f0b7b44906be')
     version('8.9.1',   sha256='32491b7fcc4696b2cdead45c47e52ad16bbed8f78885d32e873952fee0f971e1')
@@ -29,14 +36,20 @@ class NodeJs(Package):
     variant('openssl', default=True,  description='Build with Spacks OpenSSL instead of the bundled version')
     variant('zlib', default=True,  description='Build with Spacks zlib instead of the bundled version')
 
+    # https://github.com/nodejs/node/blob/master/BUILDING.md#unix-and-macos
+    depends_on('gmake@3.81:', type='build')
     depends_on('libtool', type='build', when=sys.platform != 'darwin')
     depends_on('pkgconfig', type='build')
-    depends_on('python@2.7:2.8', type='build')
+    depends_on('python@2.7:2.8,3.5:', when='@13:', type='build')
+    depends_on('python@2.7:2.8', when='@:12', type='build')
     # depends_on('bash-completion', when="+bash-completion")
     depends_on('icu4c', when='+icu4c')
     depends_on('openssl@1.0.2d:1.0.99', when='@:9+openssl')
     depends_on('openssl@1.1:', when='@10:+openssl')
     depends_on('zlib', when='+zlib')
+
+    def setup_build_environment(self, env):
+        env.set('PYTHON', self.spec['python'].command.path)
 
     def install(self, spec, prefix):
         options = []


### PR DESCRIPTION
The latest version of node.js seems to support Python 3 now! It looks like there has been experimental support for quite some time, so I'm not sure what version was the first to add support. I tried both 12.14.0 and 13.5.0 and the former had some "ImportError: no module named 'site'" style errors, while 13.5.0 works fine. Now I just have to get `npm` working...

Successfully builds on macOS 10.15.2 with Clang 11.0.0 and Python 3.7.4.