### PR TITLE
root: Do not apply the unuran patch to ROOT 6.06/xy, it is not compatible

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -57,7 +57,7 @@ class Root(CMakePackage):
     # Some ROOT versions did not honor the option to avoid building an
     # internal version of unuran, _cf_
     # https://github.com/root-project/ROOT/commit/3e60764f133218b6938e5aa4986de760e8f058d9.
-    patch('honor-unuran-switch.patch', level=1, when='@:6.13.99')
+    patch('honor-unuran-switch.patch', level=1, when='@6.08.06:6.13.99')
     # 6.16.00 fails to handle particular build option combinations, _cf_
     # https://github.com/root-project/ROOT/commit/e0ae0483985d90a71a6cabd10d3622dfd1c15611.
     patch('root7-webgui.patch', level=1, when='@6.16.00')


### PR DESCRIPTION
The patch which prevents ROOT from building its own version of unuran is not compatible with the ROOT 6.06 series. The first release on which it was tested to apply cleanly is ROOT 6.08/06.