### PR TITLE
dd4hep: Latest versions of CMake need a hand for Python detection

### DIFF
--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -43,5 +43,6 @@ class Dd4hep(CMakePackage):
             "-DBUILD_TESTING={0}".format(spec.satisfies('+testing')),
             "-DBOOST_ROOT={0}".format(spec['boost'].prefix),
             "-DBoost_NO_BOOST_CMAKE=ON",
+            "-DPYTHON_EXECUTABLE={0}".format(spec['python'].command.path),
         ]
         return args


### PR DESCRIPTION
This is basically the same issue which happened to ROOT back in the days of #11579, and the same fix happens to work here.