### PR TITLE
root: Record that old versions of ROOT don't support modern GCC

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -234,7 +234,7 @@ class Root(CMakePackage):
     # See https://sft.its.cern.ch/jira/browse/ROOT-7517
     conflicts('%intel')
 
-    # ROOT was incompatible with the GCC 5+ ABI until v6.08
+    # ROOT v6.06 was incompatible with the GCC 5+ ABI
     conflicts('%gcc@5.0.0:', when=':6.06.99')
 
     # See README.md

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -234,8 +234,8 @@ class Root(CMakePackage):
     # See https://sft.its.cern.ch/jira/browse/ROOT-7517
     conflicts('%intel')
 
-    # ROOT v6.06 was incompatible with the GCC 5+ ABI
-    conflicts('%gcc@5.0.0:', when=':6.06.99')
+    # ROOT <6.08 was incompatible with the GCC 5+ ABI
+    conflicts('%gcc@5.0.0:', when='@:6.07.99')
 
     # See README.md
     conflicts('+http',

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -234,6 +234,9 @@ class Root(CMakePackage):
     # See https://sft.its.cern.ch/jira/browse/ROOT-7517
     conflicts('%intel')
 
+    # ROOT was incompatible with the GCC 5+ ABI until v6.08
+    conflicts('%gcc@5.0.0:', when=':6.06.99')
+
     # See README.md
     conflicts('+http',
               msg='HTTP server currently unsupported due to dependency issues')


### PR DESCRIPTION
@chissg After further investigation, the latest 6.06/xy releases clearly state that they're not compatible with the GCC 5 ABI, so getting ROOT 6.06 to work on GCC 5+ is probably a lost cause.