### PR TITLE
Add py-botocore 1.13.44

### DIFF
--- a/var/spack/repos/builtin/packages/py-botocore/package.py
+++ b/var/spack/repos/builtin/packages/py-botocore/package.py
@@ -10,10 +10,11 @@ class PyBotocore(PythonPackage):
     """Low-level, data-driven core of boto 3."""
 
     homepage = "https://github.com/boto/botocore"
-    url      = "https://pypi.io/packages/source/b/botocore/botocore-1.13.38.tar.gz"
+    url      = "https://pypi.io/packages/source/b/botocore/botocore-1.13.44.tar.gz"
 
     import_modules = ['botocore']
 
+    version('1.13.44',  sha256='a4409008c32a3305b9c469c5cc92edb5b79d6fcbf6f56fe126886b545f0a4f3f')
     version('1.13.38',  sha256='15766a367f39dba9de3c6296aaa7da31030f08a0117fd12685e7df682d8acee2')
     version('1.12.169', sha256='25b44c3253b5ed1c9093efb57ffca440c5099a2d62fa793e8b6c52e72f54b01e')
 
@@ -22,7 +23,7 @@ class PyBotocore(PythonPackage):
     depends_on('py-docutils@0.10:0.15', type=('build', 'run'))
     depends_on('py-ordereddict@1.1', type=('build', 'run'), when='^python@2.6.0:2.6.999')
     depends_on('py-simplejson@3.3.0', type=('build', 'run'), when='^python@2.6.0:2.6.999')
-    depends_on('py-python-dateutil@2.1:2.8.0', type=('build', 'run'))
+    depends_on('py-python-dateutil@2.1:2.999', type=('build', 'run'))
     depends_on('py-python-dateutil@2.1:2.6', type=('build', 'run'), when='^python@2.6.0:2.6.999')
     depends_on('py-urllib3@1.20:1.25', type=('build', 'run'))
     depends_on('py-urllib3@1.20:1.23', type=('build', 'run'), when='^python@2.6.0:2.6.999')


### PR DESCRIPTION
Successfully installs on macOS 10.15.2 with Python 3.7.4 and Clang 11.0.0.