### PR TITLE
MKL: set appropriate CMake env vars

### DIFF
--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -1048,11 +1048,19 @@ class IntelPackage(PackageBase):
             env_mods = {
                 'MKLROOT': self.normalize_path('mkl'),
                 'SPACK_COMPILER_EXTRA_RPATHS': self.component_lib_dir('mkl'),
+                'CMAKE_PREFIX_PATH': self.normalize_path('mkl'),
+                'CMAKE_LIBRARY_PATH': self.component_lib_dir('mkl'),
+                'CMAKE_INCLUDE_PATH': self.component_include_dir('mkl'),
             }
 
             env.set('MKLROOT', env_mods['MKLROOT'])
             env.append_path('SPACK_COMPILER_EXTRA_RPATHS',
                             env_mods['SPACK_COMPILER_EXTRA_RPATHS'])
+            env.append_path('CMAKE_PREFIX_PATH', env_mods['CMAKE_PREFIX_PATH'])
+            env.append_path('CMAKE_LIBRARY_PATH',
+                            env_mods['CMAKE_LIBRARY_PATH'])
+            env.append_path('CMAKE_INCLUDE_PATH',
+                            env_mods['CMAKE_INCLUDE_PATH'])
 
             debug_print("adding/modifying build env:", env_mods)
 

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -180,11 +180,6 @@ class PyTorch(PythonPackage):
                 else:
                     env.set('NO_' + var, 'ON')
 
-        # Build system has problems locating MKL libraries
-        # See https://github.com/pytorch/pytorch/issues/24334
-        if 'mkl' in self.spec:
-            env.prepend_path('CMAKE_PREFIX_PATH', self.spec['mkl'].prefix.mkl)
-
         # Build in parallel to speed up build times
         env.set('MAX_JOBS', make_jobs)
 


### PR DESCRIPTION
PyTorch has trouble finding the MKL libraries when they are not in default system install locations. On macOS, simply setting `CMAKE_PREFIX_PATH` to the `<prefix>/mkl` directory is sufficient, but on Linux, the libraries are tucked away inside `<prefix>/mkl/intel64/lib`. This PR sets the appropriate CMake environment variables to allow PyTorch to find MKL. I put the changes in the `IntelPackage` base class so that other packages can benefit from this too.

Tested with PyTorch 1.3.1 and master on macOS 10.15.2 and Amazon Linux 2 with Intel MKL 2019.4.233 and 2019.5.281.

Fixes #14232 
Fixes https://github.com/pytorch/pytorch/issues/24334

@coreyjadams can you test this out?