### PR TITLE
Improve info variant header

### DIFF
--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -106,7 +106,9 @@ class VariantFormatter(object):
             yield '    None'
         else:
             yield '    ' + self.fmt % self.headers
-            yield '\n'
+            underline = tuple([l * "=" for l in self.column_widths])
+            yield '    ' + self.fmt % underline
+            yield ''
             for k, v in sorted(self.variants.items()):
                 name = textwrap.wrap(
                     '{0} [{1}]'.format(k, self.default(v)),


### PR DESCRIPTION
In "spack info" the Variants header currently has two blank lines under it. That's too much. It looks like the actual content belongs to something else.

Instead underline the headers to make things more obvious.