### PR TITLE
Added conflict with %pgi in libpciaccess package.py...

### DIFF
--- a/var/spack/repos/builtin/packages/libpciaccess/package.py
+++ b/var/spack/repos/builtin/packages/libpciaccess/package.py
@@ -18,3 +18,12 @@ class Libpciaccess(AutotoolsPackage):
     depends_on('libtool', type='build')
     depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
+
+    # A known issue exists when building with PGI as documented here:
+    # https://bugs.freedesktop.org/show_bug.cgi?id=94398
+    # https://www.pgroup.com/userforum/viewtopic.php?f=4&t=5126
+    # https://gitlab.freedesktop.org/xorg/lib/libpciaccess/issues/7
+    #
+    # When the ability to use dependencies built by another compiler, using a
+    # libpciaccess built by gcc should be usable by PGI builds.
+    conflicts('%pgi')


### PR DESCRIPTION
 with relevant links in comments.

Temporarily addresses #3525 .  Real fix will be when a build using PGI can include dependencies (like libpciaccess) that were built with a different compiler (e.g. - GCC), which should come with the upcoming concretizer update.