### PR TITLE
aspa: Fix common errors.

### DIFF
--- a/var/spack/repos/builtin/packages/aspa/fix_common_errors.patch
+++ b/var/spack/repos/builtin/packages/aspa/fix_common_errors.patch
@@ -11,13 +11,13 @@ diff -ur spack-src.org/src/mtl_headers/mtl/linalg_vec.h spack-src/src/mtl_header
    public:
 diff -ur spack-src.org/src/utils/toolbox/database/HDFDatabase.cc spack-src/src/utils/toolbox/database/HDFDatabase.cc
 --- spack-src.org/src/utils/toolbox/database/HDFDatabase.cc	2019-12-25 13:38:14.201696799 +0900
-+++ spack-src/src/utils/toolbox/database/HDFDatabase.cc	2019-12-25 13:39:13.617945248 +0900
++++ spack-src/src/utils/toolbox/database/HDFDatabase.cc	2019-12-25 14:50:42.627965265 +0900
 @@ -686,7 +686,7 @@
     herr_t errf;
     if (nelements > 0) {
  
 -      hsize_t dim[] = {nelements};
-+      hsize_t dim[] = {(unsigned long)nelements};
++      hsize_t dim[] = {(unsigned long long)nelements};
        hid_t space = H5Screate_simple(1, dim, NULL);
  #ifdef ASSERT_HDF5_RETURN_VALUES
        assert( space >= 0 );
@@ -26,7 +26,7 @@ diff -ur spack-src.org/src/utils/toolbox/database/HDFDatabase.cc spack-src/src/u
     if (nelements > 0) {
  
 -      hsize_t dim[] = {nelements};
-+      hsize_t dim[] = {(unsigned long)nelements};
++      hsize_t dim[] = {(unsigned long long)nelements};
        hid_t space = H5Screate_simple(1, dim, NULL);
  #ifdef ASSERT_HDF5_RETURN_VALUES
        assert( space >= 0 );
@@ -35,7 +35,7 @@ diff -ur spack-src.org/src/utils/toolbox/database/HDFDatabase.cc spack-src/src/u
     if (nelements > 0) {
  
 -      hsize_t dim[] = {nelements};
-+      hsize_t dim[] = {(unsigned long)nelements};
++      hsize_t dim[] = {(unsigned long long)nelements};
        hid_t space = H5Screate_simple(1, dim, NULL);
  #ifdef ASSERT_HDF5_RETURN_VALUES
        assert( space >= 0 );
@@ -44,7 +44,7 @@ diff -ur spack-src.org/src/utils/toolbox/database/HDFDatabase.cc spack-src/src/u
     if (nelements > 0) {
  
 -      hsize_t dim[] = {nelements};
-+      hsize_t dim[] = {(unsigned long)nelements};
++      hsize_t dim[] = {(unsigned long long)nelements};
        hid_t space = H5Screate_simple(1, dim, NULL);
  #ifdef ASSERT_HDF5_RETURN_VALUES
        assert(space >= 0);
@@ -53,7 +53,7 @@ diff -ur spack-src.org/src/utils/toolbox/database/HDFDatabase.cc spack-src/src/u
  #endif
  
 -      hsize_t dim[] = {nelements};
-+      hsize_t dim[] = {(unsigned long)nelements};
++      hsize_t dim[] = {(unsigned long long)nelements};
        hid_t space = H5Screate_simple(1, dim, NULL);
  #ifdef ASSERT_HDF5_RETURN_VALUES
        assert( space >= 0 );

--- a/var/spack/repos/builtin/packages/aspa/fix_common_errors.patch
+++ b/var/spack/repos/builtin/packages/aspa/fix_common_errors.patch
@@ -1,0 +1,59 @@
+diff -ur spack-src.org/src/mtl_headers/mtl/linalg_vec.h spack-src/src/mtl_headers/mtl/linalg_vec.h
+--- spack-src.org/src/mtl_headers/mtl/linalg_vec.h	2019-12-25 13:38:14.191695748 +0900
++++ spack-src/src/mtl_headers/mtl/linalg_vec.h	2019-12-25 13:39:08.887447770 +0900
+@@ -116,6 +116,7 @@
+   typedef difference_type Vec_difference_type;
+   typedef iterator Vec_iterator;
+   typedef const_iterator Vec_const_iterator;
++  typedef value_type Vec_value_type;
+ 
+   class IndexArray {
+   public:
+diff -ur spack-src.org/src/utils/toolbox/database/HDFDatabase.cc spack-src/src/utils/toolbox/database/HDFDatabase.cc
+--- spack-src.org/src/utils/toolbox/database/HDFDatabase.cc	2019-12-25 13:38:14.201696799 +0900
++++ spack-src/src/utils/toolbox/database/HDFDatabase.cc	2019-12-25 13:39:13.617945248 +0900
+@@ -686,7 +686,7 @@
+    herr_t errf;
+    if (nelements > 0) {
+ 
+-      hsize_t dim[] = {nelements};
++      hsize_t dim[] = {(unsigned long)nelements};
+       hid_t space = H5Screate_simple(1, dim, NULL);
+ #ifdef ASSERT_HDF5_RETURN_VALUES
+       assert( space >= 0 );
+@@ -1233,7 +1233,7 @@
+    herr_t errf;
+    if (nelements > 0) {
+ 
+-      hsize_t dim[] = {nelements};
++      hsize_t dim[] = {(unsigned long)nelements};
+       hid_t space = H5Screate_simple(1, dim, NULL);
+ #ifdef ASSERT_HDF5_RETURN_VALUES
+       assert( space >= 0 );
+@@ -1478,7 +1478,7 @@
+    herr_t errf;
+    if (nelements > 0) {
+ 
+-      hsize_t dim[] = {nelements};
++      hsize_t dim[] = {(unsigned long)nelements};
+       hid_t space = H5Screate_simple(1, dim, NULL);
+ #ifdef ASSERT_HDF5_RETURN_VALUES
+       assert( space >= 0 );
+@@ -1722,7 +1722,7 @@
+    herr_t errf;
+    if (nelements > 0) {
+ 
+-      hsize_t dim[] = {nelements};
++      hsize_t dim[] = {(unsigned long)nelements};
+       hid_t space = H5Screate_simple(1, dim, NULL);
+ #ifdef ASSERT_HDF5_RETURN_VALUES
+       assert(space >= 0);
+@@ -1998,7 +1998,7 @@
+       assert( errf >= 0 );
+ #endif
+ 
+-      hsize_t dim[] = {nelements};
++      hsize_t dim[] = {(unsigned long)nelements};
+       hid_t space = H5Screate_simple(1, dim, NULL);
+ #ifdef ASSERT_HDF5_RETURN_VALUES
+       assert( space >= 0 );

--- a/var/spack/repos/builtin/packages/aspa/package.py
+++ b/var/spack/repos/builtin/packages/aspa/package.py
@@ -28,6 +28,8 @@ class Aspa(MakefilePackage):
     depends_on('mpi', when='+mpi')
     depends_on('hdf5')
 
+    patch('fix_common_errors.patch')
+
     @property
     def build_targets(self):
         targets = [


### PR DESCRIPTION
* defined new member 'Vec_value_type' in 'self' namespace.
```
     460    In file included from ../src/mtl_headers/mtl/matrix_implementation.h:27:
  >> 461    ../src/mtl_headers/mtl/linalg_vec.h:135:21: error: no member named 'Vec_value_type
            ' in 'linalg_vec<RepType, RepPtr, NN>'
     462            while (*i == self::Vec_value_type(0)) ++i;
     463                         ~~~~~~^
```
I defined `Vec_value_type` as a member of `linalg_vec` namespace with reference to other header file `src/mtl_headers/mtl/dense1D.h`.

* fix narrowing error.
```
  >> 915    ../src/utils/toolbox/database/HDFDatabase.cc:689:24: error: non-con
            stant-expression cannot be narrowed from type 'int' to 'hsize_t' (a
            ka 'unsigned long long') in initializer list [-Wc++11-narrowing]
     916          hsize_t dim[] = {nelements};
     917                           ^~~~~~~~~
```
I did a typecast for `nelements` to 'unsigned long long' from 'int'.