### PR TITLE
patch cairo build files for build without fontconfig fixes #14112

### DIFF
--- a/var/spack/repos/builtin/packages/cairo/fontconfig.patch
+++ b/var/spack/repos/builtin/packages/cairo/fontconfig.patch
@@ -1,0 +1,36 @@
+diff --git a/test/Makefile.am b/test/Makefile.am
+index e3c42ea88..7b5568d85 100644
+--- a/test/Makefile.am
++++ b/test/Makefile.am
+@@ -158,8 +158,10 @@ ps-features			\
+ svg-clip			\
+ svg-surface			\
+ toy-font-face			\
+-font-variations			\
+ user-data
++#if CAIRO_HAS_FT_FONT
++NOLOG_TESTS += font-variations
++#endif
+
+ # A target to summarise the failures
+ check-summary:
+diff --git a/test/Makefile.sources b/test/Makefile.sources
+index c47131faf..8568f7cf8 100644
+--- a/test/Makefile.sources
++++ b/test/Makefile.sources
+@@ -144,7 +144,6 @@ test_sources = \
+ 	font-face-get-type.c				\
+ 	font-matrix-translation.c			\
+ 	font-options.c					\
+-	font-variations.c				\
+ 	glyph-cache-pressure.c				\
+ 	get-and-set.c					\
+ 	get-clip.c					\
+@@ -399,6 +398,7 @@ pthread_test_sources =					\
+
+ ft_font_test_sources = \
+ 	bitmap-font.c \
++	font-variations.c				\
+ 	ft-font-create-for-ft-face.c \
+ 	ft-show-glyphs-positioning.c \
+ 	ft-show-glyphs-table.c \

--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -35,12 +35,22 @@ class Cairo(AutotoolsPackage):
     depends_on('librsvg', when='+svg')
     depends_on('glib')
     depends_on('pixman')
+    depends_on('automake', type='build')
     depends_on('freetype', when='+ft')
     depends_on('pkgconfig', type='build')
     depends_on('fontconfig@2.10.91:', when='+fc')  # Require newer version of fontconfig.
 
     conflicts('+png', when='platform=darwin')
     conflicts('+svg', when='platform=darwin')
+
+    # patch from https://gitlab.freedesktop.org/cairo/cairo/issues/346
+    patch('fontconfig.patch', when='@1.16.0')
+
+    def setup_build_environment(self, env):
+        env.set('NOCONFIGURE', "1")
+
+    def autoreconf(self, spec, prefix):
+        which('sh')('./autogen.sh')
 
     def configure_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -36,6 +36,9 @@ class Cairo(AutotoolsPackage):
     depends_on('glib')
     depends_on('pixman')
     depends_on('automake', type='build')
+    depends_on('autoconf', type='build')
+    depends_on('libtool', type='build')
+    depends_on('m4', type='build')
     depends_on('freetype', when='+ft')
     depends_on('pkgconfig', type='build')
     depends_on('fontconfig@2.10.91:', when='+fc')  # Require newer version of fontconfig.


### PR DESCRIPTION
With #14092, cairo is building with fontconfig disabled by default. However, cairo's build system is still looking for fontconfig in one of its files. I found a bug report to cairo with a patch on https://gitlab.freedesktop.org/cairo/cairo/issues/346. This was also report in Spack issue #14112.