### PR TITLE
added build dependences required after cairo package change

### DIFF
--- a/var/spack/repos/builtin/packages/pango/package.py
+++ b/var/spack/repos/builtin/packages/pango/package.py
@@ -25,8 +25,6 @@ class Pango(AutotoolsPackage):
 
     depends_on("pkgconfig", type="build")
     depends_on("harfbuzz")
-    depends_on("freetype")
-    depends_on("fontconfig")
     depends_on("cairo+ft+fc")
     depends_on("cairo~X", when='~X')
     depends_on("cairo+X", when='+X')

--- a/var/spack/repos/builtin/packages/pango/package.py
+++ b/var/spack/repos/builtin/packages/pango/package.py
@@ -25,7 +25,9 @@ class Pango(AutotoolsPackage):
 
     depends_on("pkgconfig", type="build")
     depends_on("harfbuzz")
-    depends_on("cairo")
+    depends_on("freetype")
+    depends_on("fontconfig")
+    depends_on("cairo+ft+fc")
     depends_on("cairo~X", when='~X')
     depends_on("cairo+X", when='+X')
     depends_on("libxft", when='+X')


### PR DESCRIPTION
Due to the changes in #14092, pango needs to specify additional requirements.