### PR TITLE
Add support for graphite2 to harfbuzz

### DIFF
--- a/var/spack/repos/builtin/packages/harfbuzz/package.py
+++ b/var/spack/repos/builtin/packages/harfbuzz/package.py
@@ -17,12 +17,15 @@ class Harfbuzz(AutotoolsPackage):
     version('1.4.6', sha256='21a78b81cd20cbffdb04b59ac7edfb410e42141869f637ae1d6778e74928d293')
     version('0.9.37', sha256='255f3b3842dead16863d1d0c216643d97b80bfa087aaa8fc5926da24ac120207')
 
+    variant('graphite2', default=False, description='enable support for graphite2 font engine')
+
     depends_on("pkgconfig", type="build")
     depends_on("glib")
     depends_on("icu4c")
     depends_on("freetype")
     depends_on("cairo")
     depends_on("zlib")
+    depends_on("graphite2", when='+graphite2')
 
     def configure_args(self):
         args = []
@@ -34,6 +37,8 @@ class Harfbuzz(AutotoolsPackage):
         args.append('GTKDOC_CHECK_PATH={0}'.format(true))
         args.append('GTKDOC_MKPDF={0}'.format(true))
         args.append('GTKDOC_REBASE={0}'.format(true))
+        args.extend(self.with_or_without('graphite2'))
+
         return args
 
     def patch(self):


### PR DESCRIPTION
This PR adds graphite2 support to harfbuzz. This PR depends on PR #14299, which added the graphite2 package to spack.