### PR TITLE
bugfix: colify_table should not revert to 1 column for non-tty

### DIFF
--- a/lib/spack/llnl/util/tty/colify.py
+++ b/lib/spack/llnl/util/tty/colify.py
@@ -199,10 +199,16 @@ def colify(elts, **options):
 def colify_table(table, **options):
     """Version of ``colify()`` for data expressed in rows, (list of lists).
 
-       Same as regular colify but takes a list of lists, where each
-       sub-list must be the same length, and each is interpreted as a
-       row in a table.  Regular colify displays a sequential list of
-       values in columns.
+       Same as regular colify but:
+
+       1. This takes a list of lists, where each sub-list must be the
+          same length, and each is interpreted as a row in a table.
+          Regular colify displays a sequential list of values in columns.
+
+       2. Regular colify will always print with 1 column when the output
+          is not a tty.  This will always print with same dimensions of
+          the table argument.
+
     """
     if table is None:
         raise TypeError("Can't call colify_table on NoneType")
@@ -219,6 +225,9 @@ def colify_table(table, **options):
     if 'cols' in options:
         raise ValueError("Cannot override columsn in colify_table.")
     options['cols'] = columns
+
+    # don't reduce to 1 column for non-tty
+    options['tty'] = True
 
     colify(transpose(), **options)
 


### PR DESCRIPTION
Commands like `spack blame` were printig poorly when redirected to files, as colify reverts to a single column when redirected.  This works for list data but not tables.

- [x] Force a table by always passing `tty=True` from `colify_table()`