### PR TITLE
externals: avoid importing jinja2 on startup

### DIFF
--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -804,10 +804,11 @@ class BaseModuleFileWriter(object):
 
         # Get the template for the module
         template_name = self._get_template()
+        import jinja2
         try:
             env = tengine.make_environment()
             template = env.get_template(template_name)
-        except tengine.TemplateNotFound:
+        except jinja2.TemplateNotFound:
             # If the template was not found raise an exception with a little
             # more information
             msg = 'template \'{0}\' was not found for \'{1}\''

--- a/lib/spack/spack/tengine.py
+++ b/lib/spack/spack/tengine.py
@@ -5,15 +5,11 @@
 import itertools
 import textwrap
 
-import jinja2
 import llnl.util.lang
 import six
 
 import spack.config
 from spack.util.path import canonicalize_path
-
-
-TemplateNotFound = jinja2.TemplateNotFound
 
 
 class ContextMeta(type):
@@ -76,6 +72,10 @@ def make_environment(dirs=None):
         extensions = spack.extensions.get_template_dirs()
         dirs = [canonicalize_path(d)
                 for d in itertools.chain(builtins, extensions)]
+
+    # avoid importing this at the top level as it's used infrequently and
+    # slows down startup a bit.
+    import jinja2
 
     # Loader for the templates
     loader = jinja2.FileSystemLoader(dirs)


### PR DESCRIPTION
Jinja2 costs a tenth to a few tenths of a second to import, so we should avoid importing it on startup.  This seems to speed up spack startup on clusters (especially with NFS).

- [x] only import jinja2 within functions