### PR TITLE
Refactor how global state is handled in test fixtures

### DIFF
--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -19,12 +19,6 @@ import sys
 ignore_modules = [r'^\.#', '~$']
 
 
-class classproperty(property):
-    """classproperty decorator: like property but for classmethods."""
-    def __get__(self, cls, owner):
-        return self.fget.__get__(None, owner)()
-
-
 def index_by(objects, *funcs):
     """Create a hierarchy of dictionaries by splitting the supplied
        set of objects on unique values of the supplied functions.

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -18,7 +18,20 @@ from spack.util.pattern import Args
 
 __all__ = ['add_common_arguments']
 
+#: dictionary of argument-generating functions, keyed by name
 _arguments = {}
+
+
+def arg(fn):
+    """Decorator for a function that generates a common argument.
+
+    This ensures that argument bunches are created lazily. Decorate
+    argument-generating functions below with @arg so that
+    ``add_common_arguments()`` can find them.
+
+    """
+    _arguments[fn.__name__] = fn
+    return fn
 
 
 def add_common_arguments(parser, list_of_arguments):
@@ -32,7 +45,8 @@ def add_common_arguments(parser, list_of_arguments):
         if argument not in _arguments:
             message = 'Trying to add non existing argument "{0}" to a command'
             raise KeyError(message.format(argument))
-        x = _arguments[argument]
+
+        x = _arguments[argument]()
         parser.add_argument(*x.flags, **x.kwargs)
 
 
@@ -118,64 +132,104 @@ class DeptypeAction(argparse.Action):
         setattr(namespace, self.dest, deptype)
 
 
-_arguments['constraint'] = Args(
-    'constraint', nargs=argparse.REMAINDER, action=ConstraintAction,
-    help='constraint to select a subset of installed packages')
+@arg
+def constraint():
+    return Args(
+        'constraint', nargs=argparse.REMAINDER, action=ConstraintAction,
+        help='constraint to select a subset of installed packages')
 
-_arguments['yes_to_all'] = Args(
-    '-y', '--yes-to-all', action='store_true', dest='yes_to_all',
-    help='assume "yes" is the answer to every confirmation request')
 
-_arguments['recurse_dependencies'] = Args(
-    '-r', '--dependencies', action='store_true', dest='recurse_dependencies',
-    help='recursively traverse spec dependencies')
+@arg
+def yes_to_all():
+    return Args(
+        '-y', '--yes-to-all', action='store_true', dest='yes_to_all',
+        help='assume "yes" is the answer to every confirmation request')
 
-_arguments['recurse_dependents'] = Args(
-    '-R', '--dependents', action='store_true', dest='dependents',
-    help='also uninstall any packages that depend on the ones given '
-    'via command line')
 
-_arguments['clean'] = Args(
-    '--clean',
-    action='store_false',
-    default=spack.config.get('config:dirty'),
-    dest='dirty',
-    help='unset harmful variables in the build environment (default)')
+@arg
+def recurse_dependencies():
+    return Args(
+        '-r', '--dependencies', action='store_true',
+        dest='recurse_dependencies',
+        help='recursively traverse spec dependencies')
 
-_arguments['deptype'] = Args(
-    '--deptype', action=DeptypeAction, default=dep.all_deptypes,
-    help="comma-separated list of deptypes to traverse\ndefault=%s"
-    % ','.join(dep.all_deptypes))
 
-_arguments['dirty'] = Args(
-    '--dirty',
-    action='store_true',
-    default=spack.config.get('config:dirty'),
-    dest='dirty',
-    help='preserve user environment in the spack build environment (danger!)')
+@arg
+def recurse_dependents():
+    return Args(
+        '-R', '--dependents', action='store_true', dest='dependents',
+        help='also uninstall any packages that depend on the ones given '
+        'via command line')
 
-_arguments['long'] = Args(
-    '-l', '--long', action='store_true',
-    help='show dependency hashes as well as versions')
 
-_arguments['very_long'] = Args(
-    '-L', '--very-long', action='store_true',
-    help='show full dependency hashes as well as versions')
+@arg
+def clean():
+    return Args(
+        '--clean',
+        action='store_false',
+        default=spack.config.get('config:dirty'),
+        dest='dirty',
+        help='unset harmful variables in the build environment (default)')
 
-_arguments['tags'] = Args(
-    '-t', '--tags', action='append',
-    help='filter a package query by tags')
 
-_arguments['jobs'] = Args(
-    '-j', '--jobs', action=SetParallelJobs, type=int, dest='jobs',
-    help='explicitly set number of parallel jobs')
+@arg
+def deptype():
+    return Args(
+        '--deptype', action=DeptypeAction, default=dep.all_deptypes,
+        help="comma-separated list of deptypes to traverse\ndefault=%s"
+        % ','.join(dep.all_deptypes))
 
-_arguments['install_status'] = Args(
-    '-I', '--install-status', action='store_true', default=False,
-    help='show install status of packages. packages can be: '
-         'installed [+], missing and needed by an installed package [-], '
-         'or not installed (no annotation)')
 
-_arguments['no_checksum'] = Args(
-    '-n', '--no-checksum', action='store_true', default=False,
-    help="do not use checksums to verify downloaded files (unsafe)")
+@arg
+def dirty():
+    return Args(
+        '--dirty',
+        action='store_true',
+        default=spack.config.get('config:dirty'),
+        dest='dirty',
+        help="preserve user environment in spack's build environment (danger!)"
+    )
+
+
+@arg
+def long():
+    return Args(
+        '-l', '--long', action='store_true',
+        help='show dependency hashes as well as versions')
+
+
+@arg
+def very_long():
+    return Args(
+        '-L', '--very-long', action='store_true',
+        help='show full dependency hashes as well as versions')
+
+
+@arg
+def tags():
+    return Args(
+        '-t', '--tags', action='append',
+        help='filter a package query by tags')
+
+
+@arg
+def jobs():
+    return Args(
+        '-j', '--jobs', action=SetParallelJobs, type=int, dest='jobs',
+        help='explicitly set number of parallel jobs')
+
+
+@arg
+def install_status():
+    return Args(
+        '-I', '--install-status', action='store_true', default=False,
+        help='show install status of packages. packages can be: '
+        'installed [+], missing and needed by an installed package [-], '
+        'or not installed (no annotation)')
+
+
+@arg
+def no_checksum():
+    return Args(
+        '-n', '--no-checksum', action='store_true', default=False,
+        help="do not use checksums to verify downloaded files (unsafe)")

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -8,8 +8,6 @@ import stat
 from six import string_types
 from six import iteritems
 
-from llnl.util.lang import classproperty
-
 import spack.repo
 import spack.error
 from spack.util.path import canonicalize_path
@@ -75,13 +73,12 @@ class PackagePrefs(object):
        provider_spec_list.sort(key=kf)
 
     """
-    _packages_config_cache = None
-    _spec_cache = {}
-
     def __init__(self, pkgname, component, vpkg=None):
         self.pkgname = pkgname
         self.component = component
         self.vpkg = vpkg
+
+        self._spec_order = None
 
     def __call__(self, spec):
         """Return a key object (an index) that can be used to sort spec.
@@ -90,8 +87,10 @@ class PackagePrefs(object):
            this function as Python's sort functions already ensure that the
            key function is called at most once per sorted element.
         """
-        spec_order = self._specs_for_pkg(
-            self.pkgname, self.component, self.vpkg)
+        if self._spec_order is None:
+            self._spec_order = self._specs_for_pkg(
+                self.pkgname, self.component, self.vpkg)
+        spec_order = self._spec_order
 
         # integer is the index of the first spec in order that satisfies
         # spec, or it's a number larger than any position in the order.
@@ -107,13 +106,6 @@ class PackagePrefs(object):
             match_index -= 0.5
         return match_index
 
-    @classproperty
-    @classmethod
-    def _packages_config(cls):
-        if cls._packages_config_cache is None:
-            cls._packages_config_cache = get_packages_config()
-        return cls._packages_config_cache
-
     @classmethod
     def order_for_package(cls, pkgname, component, vpkg=None, all=True):
         """Given a package name, sort component (e.g, version, compiler, ...),
@@ -124,7 +116,7 @@ class PackagePrefs(object):
             pkglist.append('all')
 
         for pkg in pkglist:
-            pkg_entry = cls._packages_config.get(pkg)
+            pkg_entry = get_packages_config().get(pkg)
             if not pkg_entry:
                 continue
 
@@ -150,21 +142,9 @@ class PackagePrefs(object):
            return a list of CompilerSpecs, VersionLists, or Specs for
            that sorting list.
         """
-        key = (pkgname, component, vpkg)
-
-        specs = cls._spec_cache.get(key)
-        if specs is None:
-            pkglist = cls.order_for_package(pkgname, component, vpkg)
-            spec_type = _spec_type(component)
-            specs = [spec_type(s) for s in pkglist]
-            cls._spec_cache[key] = specs
-
-        return specs
-
-    @classmethod
-    def clear_caches(cls):
-        cls._packages_config_cache = None
-        cls._spec_cache = {}
+        pkglist = cls.order_for_package(pkgname, component, vpkg)
+        spec_type = _spec_type(component)
+        return [spec_type(s) for s in pkglist]
 
     @classmethod
     def has_preferred_providers(cls, pkgname, vpkg):
@@ -180,7 +160,7 @@ class PackagePrefs(object):
     def preferred_variants(cls, pkg_name):
         """Return a VariantMap of preferred variants/values for a spec."""
         for pkg in (pkg_name, 'all'):
-            variants = cls._packages_config.get(pkg, {}).get('variants', '')
+            variants = get_packages_config().get(pkg, {}).get('variants', '')
             if variants:
                 break
 

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -14,13 +14,13 @@ from spack.main import SpackCommand
 config = SpackCommand('config')
 
 
-def test_get_config_scope(mock_config):
+def test_get_config_scope(mock_low_high_config):
     assert config('get', 'compilers').strip() == 'compilers: {}'
 
 
-def test_get_config_scope_merged(mock_config):
-    low_path = mock_config.scopes['low'].path
-    high_path = mock_config.scopes['high'].path
+def test_get_config_scope_merged(mock_low_high_config):
+    low_path = mock_low_high_config.scopes['low'].path
+    high_path = mock_low_high_config.scopes['high'].path
 
     mkdirp(low_path)
     mkdirp(high_path)

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -403,8 +403,6 @@ env:
     mpileaks:
       version: [2.2]
 """
-    spack.package_prefs.PackagePrefs.clear_caches()
-
     _env_create('test', StringIO(test_config))
 
     e = ev.read('test')
@@ -423,8 +421,6 @@ env:
   specs:
   - mpileaks
 """
-    spack.package_prefs.PackagePrefs.clear_caches()
-
     _env_create('test', StringIO(test_config))
     e = ev.read('test')
 
@@ -452,7 +448,6 @@ env:
   - mpileaks
 """ % config_scope_path
 
-    spack.package_prefs.PackagePrefs.clear_caches()
     _env_create('test', StringIO(test_config))
 
     e = ev.read('test')
@@ -483,9 +478,6 @@ env:
   specs:
   - mpileaks
 """
-
-    spack.package_prefs.PackagePrefs.clear_caches()
-
     _env_create('test', StringIO(test_config))
     e = ev.read('test')
 
@@ -519,8 +511,6 @@ env:
   specs:
   - mpileaks
 """
-    spack.package_prefs.PackagePrefs.clear_caches()
-
     _env_create('test', StringIO(test_config))
     e = ev.read('test')
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -406,8 +406,8 @@ env:
     _env_create('test', StringIO(test_config))
 
     e = ev.read('test')
-    ev.prepare_config_scope(e)
-    e.concretize()
+    with e:
+        e.concretize()
 
     assert any(x.satisfies('mpileaks@2.2')
                for x in e._get_environment_specs())
@@ -431,8 +431,8 @@ packages:
     version: [2.2]
 """)
 
-    ev.prepare_config_scope(e)
-    e.concretize()
+    with e:
+        e.concretize()
 
     assert any(x.satisfies('mpileaks@2.2')
                for x in e._get_environment_specs())
@@ -460,8 +460,8 @@ packages:
     version: [2.2]
 """)
 
-    ev.prepare_config_scope(e)
-    e.concretize()
+    with e:
+        e.concretize()
 
     assert any(x.satisfies('mpileaks@2.2')
                for x in e._get_environment_specs())
@@ -490,8 +490,8 @@ packages:
     version: [0.8.11]
 """)
 
-    ev.prepare_config_scope(e)
-    e.concretize()
+    with e:
+        e.concretize()
 
     # ensure included scope took effect
     assert any(
@@ -530,8 +530,8 @@ packages:
     version: [0.8.12]
 """)
 
-    ev.prepare_config_scope(e)
-    e.concretize()
+    with e:
+        e.concretize()
 
     assert any(
         x.satisfies('mpileaks@2.2') for x in e._get_environment_specs())

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -26,7 +26,7 @@ import spack.util.spack_json as sjson
 
 # everything here uses the mock_env_path
 pytestmark = pytest.mark.usefixtures(
-    'mutable_mock_env_path', 'config', 'mutable_mock_packages')
+    'mutable_mock_env_path', 'config', 'mutable_mock_repo')
 
 env        = SpackCommand('env')
 install    = SpackCommand('install')

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -30,14 +30,6 @@ env = SpackCommand('env')
 add = SpackCommand('add')
 
 
-@pytest.fixture(scope='module')
-def parser():
-    """Returns the parser for the module command"""
-    parser = argparse.ArgumentParser()
-    spack.cmd.install.setup_parser(parser)
-    return parser
-
-
 @pytest.fixture()
 def noop_install(monkeypatch):
     def noop(*args, **kwargs):
@@ -115,7 +107,9 @@ def test_install_package_already_installed(
     (['--clean'], False),
     (['--dirty'], True),
 ])
-def test_install_dirty_flag(parser, arguments, expected):
+def test_install_dirty_flag(arguments, expected):
+    parser = argparse.ArgumentParser()
+    spack.cmd.install.setup_parser(parser)
     args = parser.parse_args(arguments)
     assert args.dirty == expected
 

--- a/lib/spack/spack/test/cmd/module.py
+++ b/lib/spack/spack/test/cmd/module.py
@@ -10,19 +10,26 @@ import pytest
 
 import spack.main
 import spack.modules
+from spack.test.conftest import use_store, use_configuration, use_repo
 
 module = spack.main.SpackCommand('module')
+
+#: make sure module files are generated for all the tests here
+@pytest.fixture(scope='module', autouse=True)
+def ensure_module_files_are_there(
+        mock_repo_path, mock_store, mock_configuration):
+    """Generate module files for module tests."""
+    module = spack.main.SpackCommand('module')
+    with use_store(mock_store):
+        with use_configuration(mock_configuration):
+            with use_repo(mock_repo_path):
+                module('tcl', 'refresh', '-y')
 
 
 def _module_files(module_type, *specs):
     specs = [spack.spec.Spec(x).concretized() for x in specs]
     writer_cls = spack.modules.module_types[module_type]
     return [writer_cls(spec).layout.filename for spec in specs]
-
-
-@pytest.fixture(scope='module', autouse=True)
-def ensure_module_files_are_there(database):
-    module('tcl', 'refresh', '-y')
 
 
 @pytest.fixture(

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -9,7 +9,7 @@ import pytest
 import spack.spec
 from spack.main import SpackCommand
 
-pytestmark = pytest.mark.usefixtures('config', 'mutable_mock_packages')
+pytestmark = pytest.mark.usefixtures('config', 'mutable_mock_repo')
 
 spec = SpackCommand('spec')
 

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -302,7 +302,7 @@ class TestConcretize(object):
         with pytest.raises(spack.spec.MultipleProviderError):
             s.concretize()
 
-    def test_no_matching_compiler_specs(self, mock_config):
+    def test_no_matching_compiler_specs(self, mock_low_high_config):
         # only relevant when not building compilers as needed
         with spack.concretize.enable_compiler_existence_check():
             s = Spec('a %gcc@0.0.0')

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -276,7 +276,7 @@ class TestConcretize(object):
         Spec('hypre').concretize()
 
     def test_concretize_two_virtuals_with_one_bound(
-            self, mutable_mock_packages
+            self, mutable_mock_repo
     ):
         """Test a package with multiple virtual dependencies and one preset."""
         Spec('hypre ^openblas').concretize()

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -23,7 +23,6 @@ def concretize_scope(config, tmpdir):
     yield
 
     config.pop_scope()
-    spack.package_prefs.PackagePrefs.clear_caches()
     spack.repo.path._provider_index = None
 
 
@@ -60,7 +59,6 @@ def update_packages(pkgname, section, value):
     """Update config and reread package list"""
     conf = {pkgname: {section: value}}
     spack.config.set('packages', conf, scope='concretize')
-    spack.package_prefs.PackagePrefs.clear_caches()
 
 
 def assert_variant_values(spec, **variants):
@@ -204,7 +202,6 @@ all:
         spack.config.set('packages', conf, scope='concretize')
 
         # should be no error for 'all':
-        spack.package_prefs.PackagePrefs.clear_caches()
         spack.package_prefs.get_packages_config()
 
     def test_external_mpi(self):

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -83,7 +83,7 @@ class TestConcretizePreferences(object):
             'mpileaks', debug=True, opt=True, shared=False, static=False
         )
 
-    def test_preferred_compilers(self, mutable_mock_packages):
+    def test_preferred_compilers(self, mutable_mock_repo):
         """Test preferred compilers are applied correctly
         """
         update_packages('mpileaks', 'compiler', ['clang@3.3'])
@@ -94,7 +94,7 @@ class TestConcretizePreferences(object):
         spec = concretize('mpileaks')
         assert spec.compiler == spack.spec.CompilerSpec('gcc@4.5.0')
 
-    def test_preferred_target(self, mutable_mock_packages):
+    def test_preferred_target(self, mutable_mock_repo):
         """Test preferred compilers are applied correctly
         """
         spec = concretize('mpich')

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -203,7 +203,7 @@ def compiler_specs():
     return CompilerSpecs(a=a, b=b)
 
 
-def test_write_key_in_memory(mock_config, compiler_specs):
+def test_write_key_in_memory(mock_low_high_config, compiler_specs):
     # Write b_comps "on top of" a_comps.
     spack.config.set('compilers', a_comps['compilers'], scope='low')
     spack.config.set('compilers', b_comps['compilers'], scope='high')
@@ -213,7 +213,7 @@ def test_write_key_in_memory(mock_config, compiler_specs):
     check_compiler_config(b_comps['compilers'], *compiler_specs.b)
 
 
-def test_write_key_to_disk(mock_config, compiler_specs):
+def test_write_key_to_disk(mock_low_high_config, compiler_specs):
     # Write b_comps "on top of" a_comps.
     spack.config.set('compilers', a_comps['compilers'], scope='low')
     spack.config.set('compilers', b_comps['compilers'], scope='high')
@@ -226,7 +226,7 @@ def test_write_key_to_disk(mock_config, compiler_specs):
     check_compiler_config(b_comps['compilers'], *compiler_specs.b)
 
 
-def test_write_to_same_priority_file(mock_config, compiler_specs):
+def test_write_to_same_priority_file(mock_low_high_config, compiler_specs):
     # Write b_comps in the same file as a_comps.
     spack.config.set('compilers', a_comps['compilers'], scope='low')
     spack.config.set('compilers', b_comps['compilers'], scope='low')
@@ -247,7 +247,7 @@ repos_high = {'repos': ["/some/other/path"]}
 
 
 # repos
-def test_write_list_in_memory(mock_config):
+def test_write_list_in_memory(mock_low_high_config):
     spack.config.set('repos', repos_low['repos'], scope='low')
     spack.config.set('repos', repos_high['repos'], scope='high')
 
@@ -255,7 +255,7 @@ def test_write_list_in_memory(mock_config):
     assert config == repos_high['repos'] + repos_low['repos']
 
 
-def test_substitute_config_variables(mock_config):
+def test_substitute_config_variables(mock_low_high_config):
     prefix = spack.paths.prefix.lstrip('/')
 
     assert os.path.join(
@@ -315,7 +315,7 @@ packages_merge_high = {
 
 
 @pytest.mark.regression('7924')
-def test_merge_with_defaults(mock_config, write_config_file):
+def test_merge_with_defaults(mock_low_high_config, write_config_file):
     """This ensures that specified preferences merge with defaults as
        expected. Originally all defaults were initialized with the
        exact same object, which led to aliasing problems. Therefore
@@ -331,14 +331,14 @@ def test_merge_with_defaults(mock_config, write_config_file):
     assert cfg['baz']['version'] == ['c']
 
 
-def test_substitute_user(mock_config):
+def test_substitute_user(mock_low_high_config):
     user = getpass.getuser()
     assert '/foo/bar/' + user + '/baz' == canonicalize_path(
         '/foo/bar/$user/baz'
     )
 
 
-def test_substitute_tempdir(mock_config):
+def test_substitute_tempdir(mock_low_high_config):
     tempdir = tempfile.gettempdir()
     assert tempdir == canonicalize_path('$tempdir')
     assert tempdir + '/foo/bar/baz' == canonicalize_path(
@@ -346,12 +346,12 @@ def test_substitute_tempdir(mock_config):
     )
 
 
-def test_read_config(mock_config, write_config_file):
+def test_read_config(mock_low_high_config, write_config_file):
     write_config_file('config', config_low, 'low')
     assert spack.config.get('config') == config_low['config']
 
 
-def test_read_config_override_all(mock_config, write_config_file):
+def test_read_config_override_all(mock_low_high_config, write_config_file):
     write_config_file('config', config_low, 'low')
     write_config_file('config', config_override_all, 'high')
     assert spack.config.get('config') == {
@@ -359,7 +359,7 @@ def test_read_config_override_all(mock_config, write_config_file):
     }
 
 
-def test_read_config_override_key(mock_config, write_config_file):
+def test_read_config_override_key(mock_low_high_config, write_config_file):
     write_config_file('config', config_low, 'low')
     write_config_file('config', config_override_key, 'high')
     assert spack.config.get('config') == {
@@ -368,7 +368,7 @@ def test_read_config_override_key(mock_config, write_config_file):
     }
 
 
-def test_read_config_merge_list(mock_config, write_config_file):
+def test_read_config_merge_list(mock_low_high_config, write_config_file):
     write_config_file('config', config_low, 'low')
     write_config_file('config', config_merge_list, 'high')
     assert spack.config.get('config') == {
@@ -377,7 +377,7 @@ def test_read_config_merge_list(mock_config, write_config_file):
     }
 
 
-def test_read_config_override_list(mock_config, write_config_file):
+def test_read_config_override_list(mock_low_high_config, write_config_file):
     write_config_file('config', config_low, 'low')
     write_config_file('config', config_override_list, 'high')
     assert spack.config.get('config') == {
@@ -386,33 +386,34 @@ def test_read_config_override_list(mock_config, write_config_file):
     }
 
 
-def test_internal_config_update(mock_config, write_config_file):
+def test_internal_config_update(mock_low_high_config, write_config_file):
     write_config_file('config', config_low, 'low')
 
-    before = mock_config.get('config')
+    before = mock_low_high_config.get('config')
     assert before['install_tree'] == 'install_tree_path'
 
     # add an internal configuration scope
     scope = spack.config.InternalConfigScope('command_line')
     assert 'InternalConfigScope' in repr(scope)
 
-    mock_config.push_scope(scope)
+    mock_low_high_config.push_scope(scope)
 
-    command_config = mock_config.get('config', scope='command_line')
+    command_config = mock_low_high_config.get('config', scope='command_line')
     command_config['install_tree'] = 'foo/bar'
 
-    mock_config.set('config', command_config, scope='command_line')
+    mock_low_high_config.set('config', command_config, scope='command_line')
 
-    after = mock_config.get('config')
+    after = mock_low_high_config.get('config')
     assert after['install_tree'] == 'foo/bar'
 
 
-def test_internal_config_filename(mock_config, write_config_file):
+def test_internal_config_filename(mock_low_high_config, write_config_file):
     write_config_file('config', config_low, 'low')
-    mock_config.push_scope(spack.config.InternalConfigScope('command_line'))
+    mock_low_high_config.push_scope(
+        spack.config.InternalConfigScope('command_line'))
 
     with pytest.raises(NotImplementedError):
-        mock_config.get_config_filename('command_line', 'config')
+        mock_low_high_config.get_config_filename('command_line', 'config')
 
 
 def test_mark_internal():
@@ -585,7 +586,7 @@ mirrors:
         assert "mirrors.yaml:5" in str(e)
 
 
-def test_bad_config_section(mock_config):
+def test_bad_config_section(mock_low_high_config):
     """Test that getting or setting a bad section gives an error."""
     with pytest.raises(spack.config.ConfigSectionError):
         spack.config.set('foobar', 'foobar')
@@ -595,7 +596,7 @@ def test_bad_config_section(mock_config):
 
 
 @pytest.mark.skipif(os.getuid() == 0, reason='user is root')
-def test_bad_command_line_scopes(tmpdir, mock_config):
+def test_bad_command_line_scopes(tmpdir, mock_low_high_config):
     cfg = spack.config.Configuration()
 
     with tmpdir.as_cwd():
@@ -844,7 +845,7 @@ compilers:
 
 @pytest.mark.regression('13045')
 def test_dotkit_in_config_does_not_raise(
-        mock_config, write_config_file, capsys
+        mock_low_high_config, write_config_file, capsys
 ):
     write_config_file('config',
                       {'config': {'module_roots': {'dotkit': '/some/path'}}},

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import collections
-import copy
+import contextlib
 import errno
 import inspect
 import itertools
@@ -270,31 +270,75 @@ def _skip_if_missing_executables(request):
 spack.architecture.real_platform = spack.architecture.platform
 spack.architecture.platform = lambda: spack.platforms.test.Test()
 
-##########
-# Test-specific fixtures
-##########
+
+#
+# Context managers used by fixtures
+#
+# Because these context managers modify global state, they should really
+# ONLY be used persistently (i.e., around yield statements) in
+# function-scoped fixtures, OR in autouse session- or module-scoped
+# fixtures.
+#
+# If they're used in regular tests or in module-scoped fixtures that are
+# then injected as function arguments, weird things can happen, because
+# the original state won't be restored until *after* the fixture is
+# destroyed.  This makes sense for an autouse fixture, where you know
+# everything in the module/session is going to need the modified
+# behavior, but modifying global state for one function in a way that
+# won't be restored until after the module or session is done essentially
+# leaves garbage behind for other tests.
+#
+# In general, we should module- or session-scope the *STATE* required for
+# these global objects, but we shouldn't module- or session-scope their
+# *USE*, or things can get really confusing.
+#
+
+@contextlib.contextmanager
+def use_configuration(config):
+    """Context manager to swap out the global Spack configuration."""
+    saved = spack.config.config
+    spack.config.config = config
+    yield
+    spack.config.config = saved
 
 
-@pytest.fixture(scope='session')
-def repo_path():
-    """Session scoped RepoPath object pointing to the mock repository"""
-    return spack.repo.RepoPath(spack.paths.mock_packages_path)
+@contextlib.contextmanager
+def use_store(store):
+    """Context manager to swap out the global Spack store."""
+    saved = spack.store.store
+    spack.store.store = store
+    yield
+    spack.store.store = saved
 
 
-@pytest.fixture(scope='module')
-def mock_packages(repo_path):
-    """Use the 'builtin.mock' repository instead of 'builtin'"""
-    mock_repo = copy.deepcopy(repo_path)
-    with spack.repo.swap(mock_repo):
+@contextlib.contextmanager
+def use_repo(repo):
+    """Context manager to swap out the global Spack repo path."""
+    with spack.repo.swap(repo):
         yield
+
+
+#
+# Test-specific fixtures
+#
+@pytest.fixture(scope='session')
+def mock_repo_path():
+    yield spack.repo.RepoPath(spack.paths.mock_packages_path)
 
 
 @pytest.fixture(scope='function')
-def mutable_mock_packages(mock_packages, repo_path):
+def mock_packages(mock_repo_path):
+    """Use the 'builtin.mock' repository instead of 'builtin'"""
+    with use_repo(mock_repo_path):
+        yield mock_repo_path
+
+
+@pytest.fixture(scope='function')
+def mutable_mock_repo(mock_repo_path):
     """Function-scoped mock packages, for tests that need to modify them."""
-    mock_repo = copy.deepcopy(repo_path)
-    with spack.repo.swap(mock_repo):
-        yield
+    mock_repo_path = spack.repo.RepoPath(spack.paths.mock_packages_path)
+    with use_repo(mock_repo_path):
+        yield mock_repo_path
 
 
 @pytest.fixture(scope='session')
@@ -345,12 +389,9 @@ def configuration_dir(tmpdir_factory, linux_os):
     shutil.rmtree(str(tmpdir))
 
 
-@pytest.fixture(scope='module')
-def config(configuration_dir):
-    """Hooks the mock configuration files into spack.config"""
-    # Set up a mock config scope
-    real_configuration = spack.config.config
-
+@pytest.fixture(scope='session')
+def mock_configuration(configuration_dir):
+    """Create a persistent Configuration object from the configuration_dir."""
     defaults = spack.config.InternalConfigScope(
         '_builtin', spack.config.config_defaults
     )
@@ -360,11 +401,14 @@ def config(configuration_dir):
         for name in ['site', 'system', 'user']]
     test_scopes.append(spack.config.InternalConfigScope('command_line'))
 
-    spack.config.config = spack.config.Configuration(*test_scopes)
+    yield spack.config.Configuration(*test_scopes)
 
-    yield spack.config.config
 
-    spack.config.config = real_configuration
+@pytest.fixture(scope='function')
+def config(mock_configuration):
+    """This fixture activates/deactivates the mock configuration."""
+    with use_configuration(mock_configuration):
+        yield mock_configuration
 
 
 @pytest.fixture(scope='function')
@@ -376,27 +420,24 @@ def mutable_config(tmpdir_factory, configuration_dir, monkeypatch):
     cfg = spack.config.Configuration(
         *[spack.config.ConfigScope(name, str(mutable_dir))
           for name in ['site', 'system', 'user']])
-    monkeypatch.setattr(spack.config, 'config', cfg)
 
     # This is essential, otherwise the cache will create weird side effects
     # that will compromise subsequent tests if compilers.yaml is modified
     monkeypatch.setattr(spack.compilers, '_cache_config_file', [])
 
-    yield spack.config.config
+    with use_configuration(cfg):
+        yield cfg
 
 
 @pytest.fixture()
 def mock_config(tmpdir):
     """Mocks two configuration scopes: 'low' and 'high'."""
-    real_configuration = spack.config.config
-
-    spack.config.config = spack.config.Configuration(
+    config = spack.config.Configuration(
         *[spack.config.ConfigScope(name, str(tmpdir.join(name)))
           for name in ['low', 'high']])
 
-    yield spack.config.config
-
-    spack.config.config = real_configuration
+    with use_configuration(config):
+        yield config
 
 
 def _populate(mock_db):
@@ -443,30 +484,41 @@ def _store_dir_and_cache(tmpdir_factory):
     return store, cache
 
 
-@pytest.fixture(scope='module')
-def database(tmpdir_factory, mock_packages, config, _store_dir_and_cache):
+@pytest.fixture(scope='session')
+def mock_store(tmpdir_factory, mock_repo_path, mock_configuration,
+               _store_dir_and_cache):
     """Creates a read-only mock database with some packages installed note
     that the ref count for dyninst here will be 3, as it's recycled
     across each install.
-    """
-    real_store = spack.store.store
-    store_path, store_cache = _store_dir_and_cache
 
-    mock_store = spack.store.Store(str(store_path))
-    spack.store.store = mock_store
+    This does not actually activate the store for use by Spack -- see the
+    ``database`` fixture for that.
+
+    """
+    store_path, store_cache = _store_dir_and_cache
+    store = spack.store.Store(str(store_path))
 
     # If the cache does not exist populate the store and create it
     if not os.path.exists(str(store_cache.join('.spack-db'))):
-        _populate(mock_store.db)
+        with use_configuration(mock_configuration):
+            with use_store(store):
+                with use_repo(mock_repo_path):
+                    _populate(store.db)
         store_path.copy(store_cache, mode=True, stat=True)
 
-    # Make the database read-only to ensure we can't modify entries
+    # Make the DB filesystem read-only to ensure we can't modify entries
     store_path.join('.spack-db').chmod(mode=0o555, rec=1)
 
-    yield mock_store.db
+    yield store
 
     store_path.join('.spack-db').chmod(mode=0o755, rec=1)
-    spack.store.store = real_store
+
+
+@pytest.fixture(scope='function')
+def database(mock_store, mock_packages, config):
+    """This activates the mock store, packages, AND config."""
+    with use_store(mock_store):
+        yield mock_store.db
 
 
 @pytest.fixture(scope='function')

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -349,8 +349,6 @@ def configuration_dir(tmpdir_factory, linux_os):
 def config(configuration_dir):
     """Hooks the mock configuration files into spack.config"""
     # Set up a mock config scope
-    spack.package_prefs.PackagePrefs.clear_caches()
-
     real_configuration = spack.config.config
 
     defaults = spack.config.InternalConfigScope(
@@ -367,14 +365,11 @@ def config(configuration_dir):
     yield spack.config.config
 
     spack.config.config = real_configuration
-    spack.package_prefs.PackagePrefs.clear_caches()
 
 
 @pytest.fixture(scope='function')
 def mutable_config(tmpdir_factory, configuration_dir, monkeypatch):
     """Like config, but tests can modify the configuration."""
-    spack.package_prefs.PackagePrefs.clear_caches()
-
     mutable_dir = tmpdir_factory.mktemp('mutable_config').join('tmp')
     configuration_dir.copy(mutable_dir)
 
@@ -388,8 +383,6 @@ def mutable_config(tmpdir_factory, configuration_dir, monkeypatch):
     monkeypatch.setattr(spack.compilers, '_cache_config_file', [])
 
     yield spack.config.config
-
-    spack.package_prefs.PackagePrefs.clear_caches()
 
 
 @pytest.fixture()

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -430,7 +430,7 @@ def mutable_config(tmpdir_factory, configuration_dir, monkeypatch):
 
 
 @pytest.fixture()
-def mock_config(tmpdir):
+def mock_low_high_config(tmpdir):
     """Mocks two configuration scopes: 'low' and 'high'."""
     config = spack.config.Configuration(
         *[spack.config.ConfigScope(name, str(tmpdir.join(name)))

--- a/lib/spack/spack/test/data/config.yaml
+++ b/lib/spack/spack/test/data/config.yaml
@@ -11,4 +11,4 @@ config:
   misc_cache: ~/.spack/cache
   verify_ssl: true
   checksum: true
-  dirty: True
+  dirty: false

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -88,7 +88,7 @@ def test_fetch(type_of_test,
                secure,
                mock_git_repository,
                config,
-               mutable_mock_packages,
+               mutable_mock_repo,
                git_version):
     """Tries to:
 
@@ -137,7 +137,7 @@ def test_fetch(type_of_test,
 
 
 @pytest.mark.parametrize("type_of_test", ['branch', 'commit'])
-def test_debug_fetch(type_of_test, mock_git_repository, config):
+def test_debug_fetch(mock_packages, type_of_test, mock_git_repository, config):
     """Fetch the repo with debug enabled."""
     # Retrieve the right test parameters
     t = mock_git_repository.checks[type_of_test]
@@ -176,7 +176,7 @@ def test_needs_stage():
 
 @pytest.mark.parametrize("get_full_repo", [True, False])
 def test_get_full_repo(get_full_repo, git_version, mock_git_repository,
-                       config, mutable_mock_packages):
+                       config, mutable_mock_repo):
     """Ensure that we can clone a full repository."""
 
     if git_version < ver('1.7.1'):

--- a/lib/spack/spack/test/hg_fetch.py
+++ b/lib/spack/spack/test/hg_fetch.py
@@ -29,7 +29,7 @@ def test_fetch(
         secure,
         mock_hg_repository,
         config,
-        mutable_mock_packages
+        mutable_mock_repo
 ):
     """Tries to:
 

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -128,7 +128,7 @@ def test_dont_add_patches_to_installed_package(install_mockery, mock_fetch):
 
 
 def test_installed_dependency_request_conflicts(
-        install_mockery, mock_fetch, mutable_mock_packages):
+        install_mockery, mock_fetch, mutable_mock_repo):
     dependency = Spec('dependency-install')
     dependency.concretize()
     dependency.package.do_install()
@@ -141,7 +141,7 @@ def test_installed_dependency_request_conflicts(
 
 
 def test_install_dependency_symlinks_pkg(
-        install_mockery, mock_fetch, mutable_mock_packages):
+        install_mockery, mock_fetch, mutable_mock_repo):
     """Test dependency flattening/symlinks mock package."""
     spec = Spec('flatten-deps')
     spec.concretize()
@@ -154,7 +154,7 @@ def test_install_dependency_symlinks_pkg(
 
 
 def test_flatten_deps(
-        install_mockery, mock_fetch, mutable_mock_packages):
+        install_mockery, mock_fetch, mutable_mock_repo):
     """Explicitly test the flattening code for coverage purposes."""
     # Unfortunately, executing the 'flatten-deps' spec's installation does
     # not affect code coverage results, so be explicit here.

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -16,7 +16,7 @@ from spack.util.executable import which
 
 from llnl.util.filesystem import resolve_link_target_relative_to_the_link
 
-pytestmark = pytest.mark.usefixtures('config', 'mutable_mock_packages')
+pytestmark = pytest.mark.usefixtures('config', 'mutable_mock_repo')
 
 # paths in repos that shouldn't be in the mirror tarballs.
 exclude = ['.hg', '.git', '.svn']

--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -182,7 +182,7 @@ def test_urls_for_versions(mock_packages, config):
         assert url == 'http://www.doesnotexist.org/url_override-0.8.1.tar.gz'
 
 
-def test_url_for_version_with_no_urls():
+def test_url_for_version_with_no_urls(mock_packages, config):
     pkg = spack.repo.get('git-test')
     with pytest.raises(spack.package.NoURLError):
         pkg.url_for_version('1.0')

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -10,14 +10,6 @@ import spack.repo
 import spack.paths
 
 
-# Unlike the repo_path fixture defined in conftest, this has a test-level
-# scope rather than a session level scope, since we want to edit the
-# given RepoPath
-@pytest.fixture()
-def repo_for_test():
-    return spack.repo.RepoPath(spack.paths.mock_packages_path)
-
-
 @pytest.fixture()
 def extra_repo(tmpdir_factory):
     repo_namespace = 'extra_test_repo'
@@ -32,31 +24,31 @@ repo:
     return spack.repo.Repo(str(repo_dir))
 
 
-def test_repo_getpkg(repo_for_test):
-    repo_for_test.get('a')
-    repo_for_test.get('builtin.mock.a')
+def test_repo_getpkg(mutable_mock_repo):
+    mutable_mock_repo.get('a')
+    mutable_mock_repo.get('builtin.mock.a')
 
 
-def test_repo_multi_getpkg(repo_for_test, extra_repo):
-    repo_for_test.put_first(extra_repo)
-    repo_for_test.get('a')
-    repo_for_test.get('builtin.mock.a')
+def test_repo_multi_getpkg(mutable_mock_repo, extra_repo):
+    mutable_mock_repo.put_first(extra_repo)
+    mutable_mock_repo.get('a')
+    mutable_mock_repo.get('builtin.mock.a')
 
 
-def test_repo_multi_getpkgclass(repo_for_test, extra_repo):
-    repo_for_test.put_first(extra_repo)
-    repo_for_test.get_pkg_class('a')
-    repo_for_test.get_pkg_class('builtin.mock.a')
+def test_repo_multi_getpkgclass(mutable_mock_repo, extra_repo):
+    mutable_mock_repo.put_first(extra_repo)
+    mutable_mock_repo.get_pkg_class('a')
+    mutable_mock_repo.get_pkg_class('builtin.mock.a')
 
 
-def test_repo_pkg_with_unknown_namespace(repo_for_test):
+def test_repo_pkg_with_unknown_namespace(mutable_mock_repo):
     with pytest.raises(spack.repo.UnknownNamespaceError):
-        repo_for_test.get('unknown.a')
+        mutable_mock_repo.get('unknown.a')
 
 
-def test_repo_unknown_pkg(repo_for_test):
+def test_repo_unknown_pkg(mutable_mock_repo):
     with pytest.raises(spack.repo.UnknownPackageError):
-        repo_for_test.get('builtin.mock.nonexistentpackage')
+        mutable_mock_repo.get('builtin.mock.nonexistentpackage')
 
 
 @pytest.mark.maybeslow
@@ -66,7 +58,7 @@ def test_repo_last_mtime():
     assert spack.repo.path.last_mtime() == latest_mtime
 
 
-def test_repo_invisibles(repo_for_test, extra_repo):
+def test_repo_invisibles(mutable_mock_repo, extra_repo):
     with open(os.path.join(extra_repo.root, 'packages', '.invisible'), 'w'):
         pass
     extra_repo.all_package_names()

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -189,7 +189,7 @@ def test_conditional_dep_with_user_constraints():
         assert ('y@3' in spec)
 
 
-@pytest.mark.usefixtures('mutable_mock_packages')
+@pytest.mark.usefixtures('mutable_mock_repo')
 class TestSpecDag(object):
 
     def test_conflicting_package_constraints(self, set_dependency):

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -61,7 +61,7 @@ def test_concrete_spec(config, mock_packages):
     check_yaml_round_trip(spec)
 
 
-def test_yaml_multivalue():
+def test_yaml_multivalue(config, mock_packages):
     spec = Spec('multivalue_variant foo="bar,baz"')
     spec.concretize()
     check_yaml_round_trip(spec)

--- a/lib/spack/spack/test/svn_fetch.py
+++ b/lib/spack/spack/test/svn_fetch.py
@@ -30,7 +30,7 @@ def test_fetch(
         secure,
         mock_svn_repository,
         config,
-        mutable_mock_packages
+        mutable_mock_repo
 ):
     """Tries to:
 

--- a/lib/spack/spack/test/url_fetch.py
+++ b/lib/spack/spack/test/url_fetch.py
@@ -75,7 +75,7 @@ def test_fetch(
         secure,
         checksum_type,
         config,
-        mutable_mock_packages
+        mutable_mock_repo
 ):
     """Fetch an archive and make sure we can checksum it."""
     mock_archive.url


### PR DESCRIPTION
This was originally just about making `spack.cmd.common.arguments` more lazy to shave some time off Spack startup.  I attempted to refactor that module so that it would not construct so many `Args` objects at module scope.  That is now done lazily instead.

### The small problem
When doing that, a weird issue arose.  This test was failing:

```python
@pytest.mark.parametrize('arguments,expected', [
    ([], spack.config.get('config:dirty')),  # default from config file
    (['--clean'], False),
    (['--dirty'], True),
])
def test_install_dirty_flag(parser, arguments, expected):
    args = parser.parse_args(arguments)
    assert args.dirty == expected
```

It turns out it failed because `Args` are now fetched lazily:

```python
@arg
def dirty():
    return Args(
        '--dirty',
        action='store_true',
        default=spack.config.get('config:dirty'),
        dest='dirty',
        help="preserve user environment in spack's build environment (danger!)"
    )
```

And `spack.config.get('config:dirty')` is now called at module scope for the decorator on `test_install_dirty`, but `dirty()` is called at test setup time to create the `Args`.  This is because the `config` fixture sets up a mock config scope using `test/data/config.yaml`, which set `dirty` to `True` by default.  That was probably an accident, as it's different from Spack's global default of `False`, so I've changed it back to `False`.

### The bigger problem

Ok, so what's the big deal?  The real issue here is that `test_install_dirty_flag` **doesn't use the `config` fixture**.  That's a problem.  Why is the mock configuration live if the fixture is not used!?

It turns out we have a lot of confusing global state in the tests.  Fixtures like `config`, `database`, and `store` are module-scoped, but they'ree frequently used as arguments to test functions.  These fixtures swap out globals on setup and restore them on teardown.  As function arguments, they do the right set-up, but they leave the global changes in place for the whole module the function lives in.  This meant that if you use `config` once, other functions in the same module would inadvertently inherit the mock Spack configuration, as it would only be torn down once all tests in the module were complete.  Worse, this is order dependent, so the tests could fail depending on which ones you run.

The reason we added these fixtures was to avoid the cost of constructing things like mock databases.  That's good, and it makes the tests fast.  The problem is that we're tightly coupling the **construction** of expensive things with their **use**.  If we module-scoped the `database` fixture, the database *also* had to be **in use** for as long as it existed, as the same test would set `spack.store` to the mock store.

### Refactoring global state

I've done a lot of refactoring here to *decouple* these things.  There is now a session-scoped `mock_configuration` fixture that sets up the filesystem with mock configurations, and the `config` fixture that enables the mock configuration by setting the `spack.config.config` global is function-scoped.  In general, we should module- or session-scope the **state** required for these global objects, but we should always function-scope the actual activation.  That way, the mock database is only "live" for the tests that say they want to use it.  We don't get confusing behavior where teardown is delayed until the module is done.

I think this will generally make it easier to work with tests.  You can compare this to the way a lot of the builtin `pytest` fixtures work -- things like `tmpdir` are function-scoped (the directory is only live for one function) but `tmpdir_factory` is session-scoped and can be used by module- or session-scoped fixtures.  Things that should only be constructed once are still session- or module-scoped to avoid construction costs, but their *usage* is function-scoped.

### Other stuff

@scheibelp @becker33 @alalazo @tldahlgren: you should all take a look at this and see what you think.  Feedback would be much appreciated.

In addition to all that refactoring, I also did a few other things:
- [x] Do the refactoring described above
- [x] FIx a number of tests that did not properly inject the fixtures they needed (this was revealed by the refactoring)
- [x] Fix bugs in `cmd/env.py` tests (they did not tear down config scopes properly)
- [x] Move caching in `PackagePrefs` from the class level to the instance level.  Caching is now done per concretization instead of per Spack invocation, which means we no longer have to clear the `PackagePrefs` caches all over the place -- it just handles itself.   I think this will also reduce confusion when writing tests.
- [x] Refactor `spack.cmd.common.arguments` to construct `Args` lazily