### PR TITLE
tests: rename checks in github actions

### DIFF
--- a/.github/workflows/linux_build_tests.yaml
+++ b/.github/workflows/linux_build_tests.yaml
@@ -1,4 +1,4 @@
-name: Build Tests Linux
+name: linux builds
 
 on:
   push:

--- a/.github/workflows/minimum_python_versions.yaml
+++ b/.github/workflows/minimum_python_versions.yaml
@@ -1,4 +1,4 @@
-name: Minimum Python Versions
+name: python version check
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
       - master
       - develop
 jobs:
-  build:
+  validate:
 
     runs-on: ubuntu-latest
 
@@ -19,7 +19,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v1
       with:
-        python-version: 2.7
+        python-version: 3.7
     - name: Install Python Packages
       run: |
         pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # <img src="https://cdn.rawgit.com/spack/spack/develop/share/spack/logo/spack-logo.svg" width="64" valign="middle" alt="Spack"/> Spack
 
 [![Build Status](https://travis-ci.org/spack/spack.svg?branch=develop)](https://travis-ci.org/spack/spack)
-[![](https://github.com/spack/spack/workflows/Build%20Tests%20Linux/badge.svg)](https://github.com/spack/spack/actions)
+[![Linux Builds](https://github.com/spack/spack/workflows/linux%20builds/badge.svg)](https://github.com/spack/spack/actions)
 [![codecov](https://codecov.io/gh/spack/spack/branch/develop/graph/badge.svg)](https://codecov.io/gh/spack/spack)
 [![Read the Docs](https://readthedocs.org/projects/spack/badge/?version=latest)](https://spack.readthedocs.io)
 [![Slack](https://spackpm.herokuapp.com/badge.svg)](https://spackpm.herokuapp.com)


### PR DESCRIPTION
I usually want to look at the Travis CI output, but I currently have to scroll down to see it. This renames checks to be a bit shorter and more consistent with Travis's naming, and also so that actions appear lower than travis and codecov in the list of checks.