### PR TITLE
bugfix: add required fixture for CDash authentication test

### DIFF
--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -676,7 +676,7 @@ def test_install_help_cdash(capsys):
 
 
 @pytest.mark.disable_clean_stage_check
-def test_cdash_auth_token(tmpdir, capfd):
+def test_cdash_auth_token(tmpdir, install_mockery, capfd):
     # capfd interferes with Spack's capturing
     with capfd.disabled():
         os.environ['SPACK_CDASH_AUTH_TOKEN'] = 'asdf'


### PR DESCRIPTION
This test passed in #14200, but the intervening merge of #14309 revealed a missing fixture.  I've added the `install_mockery` fixture here.

@zackgalbreath: FYI