### PR TITLE
Ignore coverage drop due to lack of macOS tests

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,6 +5,7 @@ coverage:
   status:
     project:
       default: yes
+      threshold: 0.3
 
 ignore:
   - lib/spack/spack/test/.*

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,8 +4,8 @@ coverage:
   range: 60...90
   status:
     project:
-      default: yes
-      threshold: 0.3
+      default:
+        threshold: 0.3%
 
 ignore:
   - lib/spack/spack/test/.*


### PR DESCRIPTION
Ever since #13389 dropped macOS tests from PRs, GitHub has been a sea of ❌as every single PR fails its codecov tests. This prevents PRs from being merged on mobile devices, and [causes](https://github.com/spack/spack/pull/14322#issuecomment-569898843) [confusion](https://github.com/spack/spack/pull/14147#issuecomment-565453920) [among](https://github.com/spack/spack/pull/13931#issuecomment-560079501) [PR](https://github.com/spack/spack/pull/13707#issuecomment-553587158) [contributors](https://github.com/spack/spack/pull/13658#issuecomment-552118257). 

A more permanent solution would be to:

1. Skip coverage tests on package-only PRs, and
2. Run macOS tests for all core changes

This PR is a workaround until that happens.

@alalazo @tgamblin 