### PR TITLE
bugfix: cdash tests shoudln't modify working directory

### DIFF
--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -678,11 +678,12 @@ def test_install_help_cdash(capsys):
 @pytest.mark.disable_clean_stage_check
 def test_cdash_auth_token(tmpdir, install_mockery, capfd):
     # capfd interferes with Spack's capturing
-    with capfd.disabled():
-        os.environ['SPACK_CDASH_AUTH_TOKEN'] = 'asdf'
-        out = install(
-            '-v',
-            '--log-file=cdash_reports',
-            '--log-format=cdash',
-            'a')
-        assert 'Using CDash auth token from environment' in out
+    with tmpdir.as_cwd():
+        with capfd.disabled():
+            os.environ['SPACK_CDASH_AUTH_TOKEN'] = 'asdf'
+            out = install(
+                '-v',
+                '--log-file=cdash_reports',
+                '--log-format=cdash',
+                'a')
+            assert 'Using CDash auth token from environment' in out


### PR DESCRIPTION
The latest cdash test creates a local cdash_reports directory, but it should do that in a tmpdir.

@zackgalbreath FYI