### PR TITLE
gromacs: depend on hwloc v1

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -80,7 +80,9 @@ class Gromacs(CMakePackage):
     depends_on('cmake@2.8.8:3.99.99', type='build')
     depends_on('cmake@3.4.3:3.99.99', type='build', when='@2018:')
     depends_on('cuda', when='+cuda')
-    depends_on('hwloc', when='+hwloc')
+
+    # TODO: openmpi constraint; remove when concretizer is fixed
+    depends_on('hwloc@:1.999', when='+hwloc')
 
     patch('gmxDetectCpu-cmake-3.14.patch', when='@2018:2019.3^cmake@3.14.0:')
     patch('gmxDetectSimd-cmake-3.14.patch', when='@:2017.99^cmake@3.14.0:')


### PR DESCRIPTION
Because of a bug in the current concretizer,
spack install gromacs
fails because gromacs depends on hwloc (default is v2), and Open MPI
(the default MPI library) depends on hwloc v1.
As discussed in https://github.com/spack/spack/issues/14339, this
workaround should be removed once the concretizer is fixed

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>