### PR TITLE
Fix so that a package extrapolation error won't quietly prevent binary packages from being written

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1262,7 +1262,11 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             raise spack.error.SpackError(err_msg)
 
         hash_content = list()
-        source_id = fs.for_package_version(self, self.version).source_id()
+        source_id = False
+        try:
+            source_id = fs.for_package_version(self, self.version).source_id()
+        except spack.fetch_strategy.ExtrapolationError:
+            pass
         if not source_id:
             # TODO? in cases where a digest or source_id isn't available,
             # should this attempt to download the source and set one? This


### PR DESCRIPTION
In the case of a package built with a dependency satisfied by a local install (ie. opengl):
in etc/spack/packages.yaml:
```
packages:
  all:
  opengl:
    paths:
       opengl@4.5.0: /usr
       buildable: False
```

attempting to create a binary package will fail quietly, with a package extrapolation error thrown:

```
coltrane (SPACKIT/spack):spack buildcache create -d ./mirrors -u testit2
==> creating binary cache file for package testit2@master%gcc@4.8.5 arch=linux-centos7-ivybridge 
==> Warning: Missing a source id for testit2@master
==> Warning: Can't extrapolate a URL for version 4.5.0 because package opengl defines no URLs
coltrane (SPACKIT/spack):ls -alg mirrors/
total 4
drwxrwxr-x.  2 aweits    6 Jan  2 13:07 .
drwxrwxr-x. 11 aweits 4096 Jan  2 13:07 ..
```
after this patch:

```
coltrane (SPACKIT/spack):spack buildcache create -d ./mirrors -u testit2
==> creating binary cache file for package testit2@master%gcc@4.8.5 arch=linux-centos7-ivybridge 
==> Warning: Missing a source id for testit2@master
==> Warning: Missing a source id for opengl@4.5.0
coltrane (SPACKIT/spack):ls -lag mirrors/
total 8
drwxrwxr-x.  3 aweits   24 Jan  2 13:09 .
drwxrwxr-x. 11 aweits 4096 Jan  2 13:07 ..
drwxrwxr-x.  3 aweits 4096 Jan  2 13:09 build_cache
```