### PR TITLE
Set preferred version of perl-bioperl

### DIFF
--- a/var/spack/repos/builtin/packages/perl-bioperl/package.py
+++ b/var/spack/repos/builtin/packages/perl-bioperl/package.py
@@ -35,7 +35,9 @@ class PerlBioperl(PerlPackage):
     homepage = "https://metacpan.org/pod/BioPerl"
     url      = "https://cpan.metacpan.org/authors/id/C/CD/CDRAUG/BioPerl-1.7.6.tar.gz"
 
-    version('1.7.6', sha256='df2a3efc991b9b5d7cc9d038a1452c6dac910c9ad2a0e47e408dd692c111688d')
+    version('1.7.6',
+            sha256='df2a3efc991b9b5d7cc9d038a1452c6dac910c9ad2a0e47e408dd692c111688d',
+            preferred=True)
     version('1.007002', sha256='17aa3aaab2f381bbcaffdc370002eaf28f2c341b538068d6586b2276a76464a1')
 
     # According to cpandeps.grinnz.com Module-Build is both a build and run


### PR DESCRIPTION
Due to formatting differences, the older version of perl-bioperl was
getting picked up as the preferred version. This PR explicitly sets the
newer version to be preferred.