### PR TITLE
Convert encoding of script in interproscan

### DIFF
--- a/var/spack/repos/builtin/packages/interproscan/package.py
+++ b/var/spack/repos/builtin/packages/interproscan/package.py
@@ -42,6 +42,7 @@ class Interproscan(Package):
 
     patch('large-gid.patch', when='@5:')
     patch('non-interactive.patch', when='@:4.8')
+    patch('ps_scan.patch', when='@:4.8')
 
     def install(self, spec, prefix):
         with working_dir('core'):

--- a/var/spack/repos/builtin/packages/interproscan/ps_scan.patch
+++ b/var/spack/repos/builtin/packages/interproscan/ps_scan.patch
@@ -1,0 +1,12 @@
+diff -ru a/bin/ps_scan.pl b/bin/ps_scan.pl
+--- a/bin/ps_scan.pl	2020-01-01 14:07:54.243869822 -0600
++++ b/bin/ps_scan.pl	2020-01-01 14:08:03.786850313 -0600
+@@ -8,7 +8,7 @@
+ # Authors: 
+ #   Alexandre Gattiker
+ #   Edouard de Castro; E-mail: ecastro@isb-sib.ch
+-#   Béatrice Cuche (evaluated_by post-processing)
++#   BÃ©atrice Cuche (evaluated_by post-processing)
+ #
+ # Contributions:
+ #   Lorenza Bordoli (repeat method)


### PR DESCRIPTION
One of the perl scripts was encoded with ISO-8859-1, which caused the
sbang replacement process to fail when spack uses python3. This PR
converts the ps_scan script to UTF-8 encoding.