### PR TITLE
spack.cmd.compiler: Do not implicitly add compilers when using 'spack compiler list'

### DIFF
--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -157,6 +157,18 @@ def compiler_info(args):
 
 def compiler_list(args):
     tty.msg("Available compilers")
+
+    # If no compilers are known, do not look for them
+    #     The default behavior of `spack.compilers.all_compilers`
+    #     is to search for compilers if none are known
+    if not spack.config.get('compilers', scope=args.scope):
+        msg = "No compilers found"
+        if args.scope:
+            msg += " in scope '{0:s}'".format(args.scope)
+        tty.msg(msg)
+        tty.msg("Try using 'spack compiler find' to add some")
+        return
+
     index = index_by(spack.compilers.all_compilers(scope=args.scope),
                      lambda c: (c.spec.name, c.operating_system, c.target))
     ordered_sections = sorted(index.items(), key=lambda item: item[0])


### PR DESCRIPTION
If Spack does not have any known compilers, running 'spack compiler list' should not implicitly add any as this violates the principle of least surprise. This also applies to 'spack compilers'. This is in more direct accord with the meaning of the current [documentation](https://spack.readthedocs.io/en/latest/getting_started.html#spack-compilers) of this command. This may adversely affect user workflows which previously relied on the surprising behavior, but I would argue such workflows are using unintended/undefined behavior.