### PR TITLE
spack.compilers.clang: Add new version check

### DIFF
--- a/lib/spack/spack/compilers/clang.py
+++ b/lib/spack/spack/compilers/clang.py
@@ -208,7 +208,9 @@ class Clang(Compiler):
             r'^Apple (?:LLVM|clang) version ([^ )]+)|'
             # Normal clang compiler versions are left as-is
             r'clang version ([^ )]+)-svn[~.\w\d-]*|'
-            r'clang version ([^ )]+)-[~.\w\d-]*|'
+            # Don't include hyphenated patch numbers in the version
+            # (see https://github.com/spack/spack/pull/14365 for details)
+            r'clang version ([^ )]+?)-[~.\w\d-]*|'
             r'clang version ([^ )]+)',
             output
         )

--- a/lib/spack/spack/test/compilers.py
+++ b/lib/spack/spack/test/compilers.py
@@ -348,6 +348,14 @@ def test_fj_flags():
     ('clang version 8.0.0-3~ubuntu18.04.1 (tags/RELEASE_800/final)\n'
      'Target: x86_64-pc-linux-gnu\n'
      'Thread model: posix\n'
+     'InstalledDir: /usr/bin\n', '8.0.0'),
+    ('clang version 9.0.1-+201911131414230800840845a1eea-1~exp1~20191113231141.78\n' # noqa
+     'Target: x86_64-pc-linux-gnu\n'
+     'Thread model: posix\n'
+     'InstalledDir: /usr/bin\n', '9.0.1'),
+    ('clang version 8.0.0-3 (tags/RELEASE_800/final)\n'
+     'Target: aarch64-unknown-linux-gnu\n'
+     'Thread model: posix\n'
      'InstalledDir: /usr/bin\n', '8.0.0')
 ])
 def test_clang_version_detection(version_str, expected_version):


### PR DESCRIPTION
Starting with clang-9, Ubuntu no longer uses the 'svn' prefix in its version information. This was causing the version string

    clang version 9.0.1-+201911131414230800840845a1eea-1~exp1~20191113231141.78

to report a version of 

    9.0.1-+201911131414230800840845a1eea

which was interpreted as a version of `9.0.1-` and a variant. With this patch, the version is correctly reported as just `9.0.1`, and the compiler subcommands work correctly.

**Before**

    $ cat ~/.spack/linux/compilers.yaml
      compilers: []

    $ spack compiler find
      ==> Added 10 new compilers to /home/tim/.spack/linux/compilers.yaml
          gcc@8.3.0  gcc@6.5.0  gcc@4.9.4  gcc@4.7                                     clang@8.0.1
          gcc@7.4.0  gcc@5.5.0  gcc@4.8    clang@9.0.1-+201911131414230800840845a1eea  clang@6.0.1
      ==> Compilers are defined in the following files:
          /home/tim/.spack/linux/compilers.yaml

    $ spack compiler list
      ==> Available compilers
      -- clang linuxmint18-x86_64 -------------------------------------
      clang@9.0.1-  clang@8.0.1  clang@6.0.1

      -- gcc linuxmint18-x86_64 ---------------------------------------
      gcc@8.3.0  gcc@7.4.0  gcc@6.5.0  gcc@5.5.0  gcc@4.9.4  gcc@4.8  gcc@4.7

    $ spack compiler remove -a clang && spack compiler rm -a gcc
      ==> Removed compiler clang@6.0.1
      ==> Removed compiler clang@8.0.1
      ==> Removed compiler gcc@4.9.4
      ==> Removed compiler gcc@7.4.0
      ==> Removed compiler gcc@6.5.0
      ==> Removed compiler gcc@4.7
      ==> Removed compiler gcc@5.5.0
      ==> Removed compiler gcc@8.3.0
      ==> Removed compiler gcc@4.8

    $ spack compiler list
      ==> Available compilers
      -- clang linuxmint18-x86_64 -------------------------------------
      clang@9.0.1-


**After**

    $ cat ~/.spack/linux/compilers.yaml
      compilers: []

    $ spack compiler find
      ==> Added 10 new compilers to /home/tim/.spack/linux/compilers.yaml
          gcc@8.3.0  gcc@7.4.0  gcc@6.5.0  gcc@5.5.0  gcc@4.9.4  gcc@4.8  gcc@4.7  clang@9.0.1  clang@8.0.1  clang@6.0.1
      ==> Compilers are defined in the following files:
          /home/tim/.spack/linux/compilers.yaml

    $ spack compiler list
      ==> Available compilers
      -- clang linuxmint18-x86_64 -------------------------------------
      clang@9.0.1  clang@8.0.1  clang@6.0.1

      -- gcc linuxmint18-x86_64 ---------------------------------------
      gcc@8.3.0  gcc@7.4.0  gcc@6.5.0  gcc@5.5.0  gcc@4.9.4  gcc@4.8  gcc@4.7

    $ spack compiler remove -a clang && spack compiler rm -a gcc
      ==> Removed compiler clang@9.0.1
      ==> Removed compiler clang@8.0.1
      ==> Removed compiler clang@6.0.1
      ==> Removed compiler gcc@5.5.0
      ==> Removed compiler gcc@7.4.0
      ==> Removed compiler gcc@4.9.4
      ==> Removed compiler gcc@6.5.0
      ==> Removed compiler gcc@4.8
      ==> Removed compiler gcc@8.3.0
      ==> Removed compiler gcc@4.7

    $ cat ~/.spack/linux/compilers.yaml
      compilers: []
---

This PR works with all of the version strings I could find

    clang version 8.0.1-svn369350-1~exp1~20190820122438.78 (branches/release_80)
    clang version 9.0.1-+201911131414230800840845a1eea-1~exp1~20191113231141.78
    clang version 8.0.0-3 (tags/RELEASE_800/final)
    clang version 8.0.1 (tags/RELEASE_801/final)
    clang version 9.0.0
