### PR TITLE
root: Record a new ROOT/GCC incompatibility

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -237,6 +237,10 @@ class Root(CMakePackage):
     # ROOT <6.08 was incompatible with the GCC 5+ ABI
     conflicts('%gcc@5.0.0:', when='@:6.07.99')
 
+    # The version of Clang featured in ROOT <6.12 fails to build with
+    # GCC 9.2.1, which we can safely extrapolate to the GCC 9 series.
+    conflicts('%gcc@9.0.0:', when='@:6.11.99')
+
     # See README.md
     conflicts('+http',
               msg='HTTP server currently unsupported due to dependency issues')


### PR DESCRIPTION
Found while narrowing down ROOT / python 3 incompatibility as part of https://github.com/spack/spack/pull/14225 .