### PR TITLE
gapfiller: traverse subdirectories in patch

### DIFF
--- a/var/spack/repos/builtin/packages/gapfiller/package.py
+++ b/var/spack/repos/builtin/packages/gapfiller/package.py
@@ -33,7 +33,7 @@ class Gapfiller(Package):
 
     def patch(self):
         with working_dir('.'):
-            files = glob.glob("**.pl")
+            files = glob.iglob("**.pl")
             for file in files:
                 change = FileFilter(file)
                 change.filter('usr/bin/perl', 'usr/bin/env perl')

--- a/var/spack/repos/builtin/packages/gapfiller/package.py
+++ b/var/spack/repos/builtin/packages/gapfiller/package.py
@@ -33,7 +33,7 @@ class Gapfiller(Package):
 
     def patch(self):
         with working_dir('.'):
-            files = glob.iglob("*.pl")
+            files = glob.glob("**.pl")
             for file in files:
                 change = FileFilter(file)
                 change.filter('usr/bin/perl', 'usr/bin/env perl')

--- a/var/spack/repos/builtin/packages/gapfiller/package.py
+++ b/var/spack/repos/builtin/packages/gapfiller/package.py
@@ -33,7 +33,7 @@ class Gapfiller(Package):
 
     def patch(self):
         with working_dir('.'):
-            files = glob.iglob("**.pl")
+            files = glob.glob("*.pl") + glob.glob('bwa/*.pl')
             for file in files:
                 change = FileFilter(file)
                 change.filter('usr/bin/perl', 'usr/bin/env perl')


### PR DESCRIPTION
The current gapfiller package patches some but not all (bwa) of the necessary perl sources.