### PR TITLE
Add CMake package equivalent of "with_or_without"

### DIFF
--- a/lib/spack/docs/build_systems/cmakepackage.rst
+++ b/lib/spack/docs/build_systems/cmakepackage.rst
@@ -128,17 +128,20 @@ Adding flags to cmake
 ^^^^^^^^^^^^^^^^^^^^^
 
 To add additional flags to the ``cmake`` call, simply override the
-``cmake_args`` function:
+``cmake_args`` function. The following example defines values for the flags
+``WHATEVER``, ``ENABLE_BROKEN_FEATURE``, ``DETECT_HDF5``, and ``THREADS`` with
+and without the :py:meth:`~.CMakePackage.define` and
+:py:meth:`~.CMakePackage.define_from_variant` helper functions:
 
 .. code-block:: python
 
    def cmake_args(self):
-       args = []
-
-       if '+hdf5' in self.spec:
-           args.append('-DDETECT_HDF5=ON')
-       else:
-           args.append('-DDETECT_HDF5=OFF')
+       args = [
+           '-DWHATEVER:STRING=somevalue',
+           self.define('ENABLE_BROKEN_FEATURE', False),
+           self.define_from_variant('DETECT_HDF5', 'hdf5'),
+           self.define_from_variant('THREADS'), # True if +threads
+       ]
 
        return args
 

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -181,8 +181,15 @@ class CMakePackage(PackageBase):
     def define(cmake_var, value, kind=None):
         """Return a CMake command line argument that defines a variable.
 
-        The resulting argument will correctly convert boolean values to OFF/ON
-        and multi-valued variants to CMake semicolon-separated lists.
+        The "kind" argument corresponds to the CMake variable type annotation,
+        one of BOOL/STRING/PATH/FILEPATH/LIST . If not specified, it will be
+        detected from the ``value``'s type. String types with a leading slash
+        will assume ``kind="PATH"``.
+
+        If ``kind == "BOOL"``, then the value is cast to a ``bool`` and
+        converted to the cmake OFF/ON value. For ``kind == LIST``, where the
+        value is a container, its items will be converted to strings and joined
+        with semicolons.
 
         Examples:
 
@@ -211,6 +218,8 @@ class CMakePackage(PackageBase):
                 kind = "PATH"
             else:
                 kind = "STRING"
+        else:
+            kind = kind.upper()
 
         if kind == "BOOL":
             value = "ON" if value else "OFF"

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -262,7 +262,12 @@ class CMakePackage(PackageBase):
         if variant not in self.variants:
             raise KeyError(
                 '"{0}" is not a variant of "{1}"'.format(variant, self.name))
+
         value = self.spec.variants[variant].value
+        if isinstance(value, (tuple, list)):
+            # Sort multi-valued variants for reproducibility
+            value = sorted(value)
+
         return self.define(cmake_var, value)
 
     def flags_to_build_system_args(self, flags):

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -181,3 +181,21 @@ class TestAutotoolsPackage(object):
         assert '--without-bar' in options
         assert '--without-baz' in options
         assert '--no-fee' in options
+
+
+@pytest.mark.usefixtures('config', 'mock_packages')
+class TestCMakePackage(object):
+
+    def test_define_from_variant(self):
+        s = Spec('cmake-client multi=up,right ~truthy single=red')
+        s.concretize()
+        pkg = spack.repo.get(s)
+
+        arg = pkg.define_from_variant('multi')
+        assert arg == '-DMULTI:STRING=right;up'
+
+        arg = pkg.define_from_variant('truthy', 'ENABLE_TRUTH')
+        assert arg == '-DENABLE_TRUTH:BOOL=OFF'
+
+        arg = pkg.define_from_variant('single')
+        assert arg == '-DSINGLE:STRING=red'

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -186,16 +186,36 @@ class TestAutotoolsPackage(object):
 @pytest.mark.usefixtures('config', 'mock_packages')
 class TestCMakePackage(object):
 
+    def test_define(self):
+        s = Spec('cmake-client multi=up,right ~truthy single=red')
+        s.concretize()
+        pkg = spack.repo.get(s)
+
+        for cls in (list, tuple):
+            arg = pkg.define('MULTI', cls(['right', 'up']))
+            assert arg == '-DMULTI:STRING=right;up'
+
+        arg = pkg.define('ENABLE_TRUTH', False)
+        assert arg == '-DENABLE_TRUTH:BOOL=OFF'
+        arg = pkg.define('ENABLE_TRUTH', True)
+        assert arg == '-DENABLE_TRUTH:BOOL=ON'
+
+        arg = pkg.define('SINGLE', 'red')
+        assert arg == '-DSINGLE:STRING=red'
+
     def test_define_from_variant(self):
         s = Spec('cmake-client multi=up,right ~truthy single=red')
         s.concretize()
         pkg = spack.repo.get(s)
 
-        arg = pkg.define_from_variant('multi')
+        arg = pkg.define_from_variant('MULTI')
         assert arg == '-DMULTI:STRING=right;up'
 
-        arg = pkg.define_from_variant('truthy', 'ENABLE_TRUTH')
+        arg = pkg.define_from_variant('ENABLE_TRUTH', 'truthy')
         assert arg == '-DENABLE_TRUTH:BOOL=OFF'
 
-        arg = pkg.define_from_variant('single')
+        arg = pkg.define_from_variant('SINGLE')
         assert arg == '-DSINGLE:STRING=red'
+
+        with pytest.raises(KeyError, match="not a variant"):
+            pkg.define_from_variant('NONEXISTENT')

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -203,18 +203,6 @@ class TestCMakePackage(object):
         arg = pkg.define('SINGLE', 'red')
         assert arg == '-DSINGLE:STRING=red'
 
-        arg = pkg.define('PREFIX', '/foo')
-        assert arg == '-DPREFIX:PATH=/foo'
-
-        # Given values are converted to Python bools and thence to CMake
-        arg = pkg.define('MYVAL', 'not an empty string', kind='BOOL')
-        assert arg == '-DMYVAL:BOOL=ON'
-        arg = pkg.define('MYVAL', [], kind='BOOL')
-        assert arg == '-DMYVAL:BOOL=OFF'
-
-        with pytest.raises(ValueError, match="Invalid CMake variable kind"):
-            pkg.define('FOOD', 'CARROT', kind='VEGETABLE')
-
     def test_define_from_variant(self):
         s = Spec('cmake-client multi=up,right ~truthy single=red')
         s.concretize()

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -187,7 +187,7 @@ class TestAutotoolsPackage(object):
 class TestCMakePackage(object):
 
     def test_define(self):
-        s = Spec('cmake-client multi=up,right ~truthy single=red')
+        s = Spec('cmake-client')
         s.concretize()
         pkg = spack.repo.get(s)
 
@@ -202,6 +202,18 @@ class TestCMakePackage(object):
 
         arg = pkg.define('SINGLE', 'red')
         assert arg == '-DSINGLE:STRING=red'
+
+        arg = pkg.define('PREFIX', '/foo')
+        assert arg == '-DPREFIX:PATH=/foo'
+
+        # Given values are converted to Python bools and thence to CMake
+        arg = pkg.define('MYVAL', 'not an empty string', kind='BOOL')
+        assert arg == '-DMYVAL:BOOL=ON'
+        arg = pkg.define('MYVAL', [], kind='BOOL')
+        assert arg == '-DMYVAL:BOOL=OFF'
+
+        with pytest.raises(ValueError, match="Invalid CMake variable kind"):
+            pkg.define('FOOD', 'CARROT', kind='VEGETABLE')
 
     def test_define_from_variant(self):
         s = Spec('cmake-client multi=up,right ~truthy single=red')

--- a/var/spack/repos/builtin.mock/packages/cmake-client/package.py
+++ b/var/spack/repos/builtin.mock/packages/cmake-client/package.py
@@ -21,6 +21,14 @@ class CmakeClient(CMakePackage):
 
     version('1.0', '4cb3ff35b2472aae70f542116d616e63')
 
+    variant(
+        'multi', description='',
+        values=any_combination_of('up', 'right', 'back').with_default('up')
+    )
+    variant('single', description='', default='blue',
+            values=('blue', 'red', 'green'), multi=False)
+    variant('truthy', description='', default=True)
+
     callback_counter = 0
 
     flipped = False


### PR DESCRIPTION
This is a first crack at a convenience function for creating a helper function to simplify CMake package definitions, namely to simplify the common but ugly and potentially error-prone idiom of
```python
args.append('-DFOO=%s' % ('ON' if '+foo' in self.spec else 'OFF'))
```
to
```python
args.append(self.define_from_variant('foo'))
```