### PR TITLE
Add version constraint to graphviz patches

### DIFF
--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -24,6 +24,11 @@ class Graphviz(AutotoolsPackage):
     # This commit hash is tag='stable_release_2.40.1'
     version('2.40.1', commit='67cd2e5121379a38e0801cc05cce5033f8a2a609')
 
+    conflicts('%gcc@:5.9',
+              when='@2.40.1+qt ^qt@5:',
+              msg='graphviz-2.40.1 needs gcc-6 or greater to compile with QT5 '
+              'suppport')
+
     # Language bindings
     language_bindings = ['java']
 
@@ -59,7 +64,7 @@ class Graphviz(AutotoolsPackage):
 
     patch('http://www.linuxfromscratch.org/patches/blfs/9.0/graphviz-2.40.1-qt5-1.patch',
           sha256='bd532df325df811713e311d17aaeac3f5d6075ea4fd0eae8d989391e6afba930',
-          when='+qt^qt@5:')
+          when='@:2.40+qt^qt@5:')
     patch('https://raw.githubusercontent.com/easybuilders/easybuild-easyconfigs/master/easybuild/easyconfigs/g/Graphviz/Graphviz-2.38.0_icc_sfio.patch',
           sha256='393a0a772315a89dcc970b5efd4765d22dba83493d7956303673eb89c45b949f',
           level=0,
@@ -95,7 +100,7 @@ class Graphviz(AutotoolsPackage):
     depends_on('libpng', when='+pangocairo')
     depends_on('pango', when='+pangocairo')
     depends_on('zlib')
-    depends_on('qt@4', when='+qt')
+    depends_on('qt', when='+qt')
     depends_on('libx11', when="+x")
 
     # Build dependencies

--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -63,10 +63,10 @@ class Graphviz(AutotoolsPackage):
     patch('https://raw.githubusercontent.com/easybuilders/easybuild-easyconfigs/master/easybuild/easyconfigs/g/Graphviz/Graphviz-2.38.0_icc_sfio.patch',
           sha256='393a0a772315a89dcc970b5efd4765d22dba83493d7956303673eb89c45b949f',
           level=0,
-          when='%intel')
+          when='@:2.40%intel')
     patch('https://raw.githubusercontent.com/easybuilders/easybuild-easyconfigs/master/easybuild/easyconfigs/g/Graphviz/Graphviz-2.40.1_icc_vmalloc.patch',
           sha256='813e6529e79161a18b0f24a969b7de22f8417b2e942239e658b5402884541bc2',
-          when='%intel')
+          when='@:2.40%intel')
 
     if not MACOS_VERSION:
         conflicts('+quartz',


### PR DESCRIPTION
This PR restricts the graphviz version that the patches for building
with the Intel compiler apply to. The two patches that were needed for
building graphviz-2.40.1 with the Intel compiler are not needed for
graphviz-2.42.2.