### PR TITLE
environment-modules: add version 4.4.1

### DIFF
--- a/var/spack/repos/builtin/packages/environment-modules/package.py
+++ b/var/spack/repos/builtin/packages/environment-modules/package.py
@@ -12,10 +12,11 @@ class EnvironmentModules(Package):
     """
 
     homepage = 'https://cea-hpc.github.io/modules/'
-    url = 'https://github.com/cea-hpc/modules/releases/download/v4.4.0/modules-4.4.0.tar.gz'
+    url = 'https://github.com/cea-hpc/modules/releases/download/v4.4.1/modules-4.4.1.tar.gz'
 
     maintainers = ['xdelaruelle']
 
+    version('4.4.1', sha256='3c20cfb2ff8a4d74ac6d566e7b5fa9dd220d96d17e6d8a4ae29b1ec0107ee407')
     version('4.4.0', sha256='4dd55ad6cc684905e891ad1ba9e3c542e79eea0a9cd9a0e99cd77abe6ed63fab')
     version('4.3.1', sha256='979efb5b3d3c8df2c3c364aaba61f97a459456fc5bbc092dfc02677da63e5654')
     version('4.3.0', sha256='231f059c4109a2d3028c771f483f6c92f1f3689eb0033648ce00060dad00e103')


### PR DESCRIPTION
Happy new year Spack folks!

New environment-modules bugfix release in the v4.4 serie.

Release announcement: https://timeline.noticeable.io/cbzeG7wTvAIqj21zbUmx/posts/modules-4-4-1-released