### PR TITLE
py-torchvision 0.4.X does not support py-pillow 7.X.Y

### DIFF
--- a/var/spack/repos/builtin/packages/py-torchvision/package.py
+++ b/var/spack/repos/builtin/packages/py-torchvision/package.py
@@ -31,7 +31,9 @@ class PyTorchvision(PythonPackage):
     depends_on('py-six', type=('build', 'run'))
     depends_on('py-torch@1.2.0:', when='@0.4.0:', type=('build', 'run'))
     depends_on('py-torch@1.1.0:', type=('build', 'run'))
-    depends_on('py-pillow@4.1.1:', type=('build', 'run'))  # or py-pillow-simd
+    # https://github.com/pytorch/vision/issues/1712
+    depends_on('py-pillow@4.1.1:6', when='@:0.4', type=('build', 'run'))  # or py-pillow-simd
+    depends_on('py-pillow@4.1.1:',  when='@0.5:', type=('build', 'run'))  # or py-pillow-simd
 
     # Many of the datasets require additional dependencies to use.
     # These can be installed after the fact.


### PR DESCRIPTION
The next release (0.5.0) will fix this, and is expected to be released sometime in the next week.