### PR TITLE
Add libs property to lcms package

### DIFF
--- a/var/spack/repos/builtin/packages/lcms/package.py
+++ b/var/spack/repos/builtin/packages/lcms/package.py
@@ -21,3 +21,7 @@ class Lcms(AutotoolsPackage):
     depends_on('jpeg')
     depends_on('libtiff')
     depends_on('zlib')
+
+    @property
+    def libs(self):
+        return find_libraries('liblcms2', root=self.prefix, recursive=True)


### PR DESCRIPTION
Library is `liblcms2`, not `liblcms`