### PR TITLE
Add libs property to openjpeg package

### DIFF
--- a/var/spack/repos/builtin/packages/openjpeg/package.py
+++ b/var/spack/repos/builtin/packages/openjpeg/package.py
@@ -50,3 +50,8 @@ class Openjpeg(CMakePackage):
             'https://github.com/uclouvain/openjpeg/archive/version.{0}.tar.gz'
 
         return url_fmt.format(version)
+
+    @property
+    def libs(self):
+        return find_libraries('libopenjp{0}'.format(self.version.up_to(1)),
+                              root=self.prefix, recursive=True)


### PR DESCRIPTION
Library is `libopenjp2`, not `libopenjpeg`