### PR TITLE
Overhaul py-pillow package

### DIFF
--- a/var/spack/repos/builtin/packages/py-pillow/package.py
+++ b/var/spack/repos/builtin/packages/py-pillow/package.py
@@ -80,9 +80,6 @@ class PyPillow(PythonPackage):
             library_dirs.extend(query.libs.directories)
             include_dirs.extend(query.headers.directories)
 
-        print('library_dirs:', library_dirs)
-        print('include_dirs:', include_dirs)
-
         setup = FileFilter('setup.py')
         setup.filter('library_dirs = []',
                      'library_dirs = {0}'.format(library_dirs), string=True)
@@ -94,13 +91,14 @@ class PyPillow(PythonPackage):
             able = 'enable' if '+' + variant in spec else 'disable'
             return '--{0}-{1}'.format(able, variant)
 
-        variants = [
-            'zlib', 'jpeg', 'tiff', 'freetype', 'lcms',
-            'webp', 'webpmux', 'jpeg2000'
-        ]
-        args = list(map(variant_to_flag, variants))
+        args = ['--enable-zlib', '--enable-jpeg']
+
+        variants = ['tiff', 'freetype', 'lcms', 'webp', 'webpmux', 'jpeg2000']
+        args.extend(list(map(variant_to_flag, variants)))
+
         # Spack does not (yet) support these modes of building
         args.append('--disable-imagequant')
+
         args.append('--rpath={0}'.format(':'.join(self.rpath)))
         return args
 

--- a/var/spack/repos/builtin/packages/py-pillow/package.py
+++ b/var/spack/repos/builtin/packages/py-pillow/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-import sys
 
 
 class PyPillow(PythonPackage):
@@ -14,8 +13,14 @@ class PyPillow(PythonPackage):
     capabilities."""
 
     homepage = "https://python-pillow.org/"
-    url = "https://pypi.io/packages/source/P/Pillow/Pillow-6.2.0.tar.gz"
+    url      = "https://pypi.io/packages/source/P/Pillow/Pillow-7.0.0.tar.gz"
 
+    maintainers = ['adamjstewart']
+    import_modules = ['PIL']
+
+    version('7.0.0', sha256='4d9ed9a64095e031435af120d3c910148067087541131e82b3e8db302f4c8946')
+    version('6.2.2', sha256='db9ff0c251ed066d367f53b64827cc9e18ccea001b986d08c265e53625dab950')
+    version('6.2.1', sha256='bf4e972a88f8841d8fdc6db1a75e0f8d763e66e3754b03006cbc3854d89f1cb1')
     version('6.2.0', sha256='4548236844327a718ce3bb182ab32a16fa2050c61e334e959f554cac052fb0df')
     version('5.4.1', sha256='5233664eadfa342c639b9b9977190d64ad7aca4edc51a966394d7e08e7f38a9f')
     version('5.1.0', sha256='cee9bc75bff455d317b6947081df0824a8f118de2786dc3d74a3503fd631f4ef')
@@ -25,81 +30,81 @@ class PyPillow(PythonPackage):
     provides('pil')
 
     # These defaults correspond to Pillow defaults
-    variant('tiff',     default=False, description='Access to TIFF files')
-    variant('freetype', default=False, description='Font related services')
+    # https://pillow.readthedocs.io/en/stable/installation.html#external-libraries
+    variant('tiff',     default=False, description='Compressed TIFF functionality')
+    variant('freetype', default=False, description='Type related services')
     variant('lcms',     default=False, description='Color management')
-    variant('jpeg2000', default=False, description='Provide JPEG 2000 functionality')
+    variant('webp',     default=False, description='WebP format')
+    variant('webpmux',  default=False, description='WebP metadata')
+    variant('jpeg2000', default=False, description='JPEG 2000 functionality')
 
     # Spack does not (yet) support these modes of building
-    # variant('webp', default=False, description='Provide the WebP format')
-    # variant('webpmux', default=False,
-    #         description='WebP metadata, relies on WebP support')
     # variant('imagequant', default=False,
-    #         description='Provide improved color quantization')
+    #         description='Improved color quantization')
 
     # Required dependencies
-    depends_on('binutils', type='build', when=sys.platform != 'darwin')
-    depends_on('python@2.7:2.8,3.4:', when='@:5.4.1', type=('build', 'run'))
+    depends_on('python@2.6:2.8,3.2:', when='@3:', type=('build', 'run'))
+    depends_on('python@2.7:2.8,3.3:', when='@4:', type=('build', 'run'))
+    depends_on('python@2.7:2.8,3.4:', when='@5:', type=('build', 'run'))
     depends_on('python@2.7:2.8,3.5:', when='@6:', type=('build', 'run'))
+    depends_on('python@3.5:',         when='@7:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
-    depends_on('jpeg')
     depends_on('zlib')
+    depends_on('jpeg')
+    depends_on('py-pytest', type='test')
+    depends_on('py-pytest-runner', type='test')
 
     # Optional dependencies
     depends_on('libtiff', when='+tiff')
     depends_on('freetype', when='+freetype')
-    depends_on('lcms', when='+lcms')
+    depends_on('lcms@2:', when='+lcms')
+    depends_on('libwebp', when='+webp')
+    depends_on('libwebp+libwebpmux+libwebpdemux', when='+webpmux')
     depends_on('openjpeg', when='+jpeg2000')
 
     # Spack does not (yet) support these modes of building
-    # depends_on('webp', when='+webp')
-    # depends_on('webpmux', when='+webpmux')
-    # depends_on('imagequant', when='+imagequant')
+    # depends_on('libimagequant', when='+imagequant')
+
+    conflicts('+webpmux', when='~webp', msg='Webpmux relies on WebP support')
 
     phases = ['build_ext', 'install']
 
     def patch(self):
-        """Patch setup.py to provide lib and include directories
+        """Patch setup.py to provide library and include directories
         for dependencies."""
 
-        spec = self.spec
-        setup = FileFilter('setup.py')
+        library_dirs = []
+        include_dirs = []
+        for dep in self.spec.dependencies(deptype='link'):
+            query = self.spec[dep.name]
+            library_dirs.extend(query.libs.directories)
+            include_dirs.extend(query.headers.directories)
 
-        setup.filter('JPEG_ROOT = None',
-                     'JPEG_ROOT=("{0}","{1}")'.format(
-                         spec['jpeg'].libs.directories[0],
-                         spec['jpeg'].prefix.include))
-        setup.filter('ZLIB_ROOT = None',
-                     'ZLIB_ROOT = ("{0}", "{1}")'.format(
-                         spec['zlib'].prefix.lib,
-                         spec['zlib'].prefix.include))
-        if '+tiff' in spec:
-            setup.filter('TIFF_ROOT = None',
-                         'TIFF_ROOT = ("{0}", "{1}")'.format(
-                             spec['libtiff'].prefix.lib,
-                             spec['libtiff'].prefix.include))
-        if '+freetype' in spec:
-            setup.filter('FREETYPE_ROOT = None',
-                         'FREETYPE_ROOT = ("{0}", "{1}")'.format(
-                             spec['freetype'].prefix.lib,
-                             spec['freetype'].prefix.include))
-        if '+lcms' in spec:
-            setup.filter('LCMS_ROOT = None',
-                         'LCMS_ROOT = ("{0}", "{1}")'.format(
-                             spec['lcms'].prefix.lib,
-                             spec['lcms'].prefix.include))
-        if '+jpeg2000' in spec:
-            setup.filter('JPEG2K_ROOT = None',
-                         'JPEG2K_ROOT = ("{0}", "{1}")'.format(
-                             spec['openjpeg'].prefix.lib,
-                             spec['openjpeg'].prefix.include))
+        print('library_dirs:', library_dirs)
+        print('include_dirs:', include_dirs)
+
+        setup = FileFilter('setup.py')
+        setup.filter('library_dirs = []',
+                     'library_dirs = {0}'.format(library_dirs), string=True)
+        setup.filter('include_dirs = []',
+                     'include_dirs = {0}'.format(include_dirs), string=True)
 
     def build_ext_args(self, spec, prefix):
         def variant_to_flag(variant):
-            able = 'enable' if '+{0}'.format(variant) in spec else 'disable'
+            able = 'enable' if '+' + variant in spec else 'disable'
             return '--{0}-{1}'.format(able, variant)
 
-        variants = ['jpeg', 'zlib', 'tiff', 'freetype', 'lcms', 'jpeg2000']
+        variants = [
+            'zlib', 'jpeg', 'tiff', 'freetype', 'lcms',
+            'webp', 'webpmux', 'jpeg2000'
+        ]
         args = list(map(variant_to_flag, variants))
-        args.extend(['--rpath=%s' % ":".join(self.rpath)])
+        # Spack does not (yet) support these modes of building
+        args.append('--disable-imagequant')
+        args.append('--rpath={0}'.format(':'.join(self.rpath)))
         return args
+
+    # Tests need to be re-added since `phases` was overridden
+    run_after('build_ext')(PythonPackage.test)
+    run_after('install')(PythonPackage.import_module_test)
+    run_after('install')(PythonPackage.sanity_check_prefix)


### PR DESCRIPTION
Makes the following changes:

- [x] Add myself as a maintainer
- [x] Add Pillow 7.0.0 (drops Python 2 support)
- [x] Add support for webp and webpmux
- [x] Add tests
- [x] Add test dependencies
- [x] Remove binutils dependency (see [Getting Started docs](https://spack.readthedocs.io/en/latest/getting_started.html#binutils))
- [x] Simplify patching logic (previous logic didn't work for webp)
- [x] Fix bug where zlib and jpeg were always disabled

Successfully installs and passes all unit tests on macOS 10.15.2 with Python 3.7.4 and Clang 11.0.0 with all variants enabled and all variants disabled. 

```
--------------------------------------------------------------------
PIL SETUP SUMMARY
--------------------------------------------------------------------
version      Pillow 7.0.0
platform     darwin 3.7.4 (default, Nov  6 2019, 16:24:25)
             [Clang 11.0.0 (clang-1100.0.33.12)]
--------------------------------------------------------------------
--- JPEG support available
--- OPENJPEG (JPEG2000) support available (2.3)
--- ZLIB (PNG/ZIP) support available
*** LIBIMAGEQUANT support not available
--- LIBTIFF support available
--- FREETYPE2 support available
--- LITTLECMS2 support available
--- WEBP support available
--- WEBPMUX support available
--------------------------------------------------------------------
```
Libraries are correctly linked:
```console
$ otool -L $(find . -name '*.so') | sort | uniq
...
	/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/clang-11.0.0-apple/freetype-2.10.1-52goouhw7dni3yozivnw2py5d2x36yck/lib/libfreetype.6.dylib (compatibility version 24.0.0, current version 24.1.0)
	/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/clang-11.0.0-apple/lcms-2.9-5duz5uysiwmclvgga3euiyinxa3lyfpg/lib/liblcms2.2.dylib (compatibility version 3.0.0, current version 3.8.0)
	/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/clang-11.0.0-apple/libtiff-4.0.10-nlewmdvi5wqohlp3dp5waxe4djy3cl46/lib/libtiff.5.dylib (compatibility version 10.0.0, current version 10.0.0)
	/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/clang-11.0.0-apple/libwebp-1.0.3-uj3feqesh44l7lpkkocstg4xe4zmi2pb/lib/libwebp.7.dylib (compatibility version 8.0.0, current version 8.5.0)
	/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/clang-11.0.0-apple/libwebp-1.0.3-uj3feqesh44l7lpkkocstg4xe4zmi2pb/lib/libwebpdemux.2.dylib (compatibility version 3.0.0, current version 3.6.0)
	/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/clang-11.0.0-apple/libwebp-1.0.3-uj3feqesh44l7lpkkocstg4xe4zmi2pb/lib/libwebpmux.3.dylib (compatibility version 4.0.0, current version 4.4.0)
	/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/clang-11.0.0-apple/openjpeg-2.3.1-zp442otrfpxcdknldup7lq4p5nnc3oau/lib/libopenjp2.7.dylib (compatibility version 7.0.0, current version 2.3.1)
	/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/clang-11.0.0-apple/zlib-1.2.11-cvrek7vtvob6v2dfnvdowu2rkqtqtmmi/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)
	@rpath/libjpeg.62.dylib (compatibility version 62.0.0, current version 62.3.0)
```