### PR TITLE
Reference `spack help --spec` in `spack spec --help`

### DIFF
--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -24,6 +24,10 @@ level = "short"
 
 
 def setup_parser(subparser):
+    subparser.epilog = """\
+for further documentation regarding the spec syntax, see:
+    spack help --spec
+"""
     arguments.add_common_arguments(
         subparser, ['long', 'very_long', 'install_status'])
     subparser.add_argument(


### PR DESCRIPTION
@healther I finally figured out a clean way to do this!

```console
$ spack spec --help
usage: spack spec [-hlLIyjNt] [-c {nodes,edges,paths}] ...

show what would be installed, given a spec

positional arguments:
  specs                 specs of packages

optional arguments:
  -h, --help            show this help message and exit
  -l, --long            show dependency hashes as well as versions
  -L, --very-long       show full dependency hashes as well as versions
  -I, --install-status  show install status of packages. packages can be: installed [+], missing and needed by an installed package [-], or not installed (no annotation)
  -y, --yaml            print concrete spec as YAML
  -j, --json            print concrete spec as YAML
  -c {nodes,edges,paths}, --cover {nodes,edges,paths}
                        how extensively to traverse the DAG (default: nodes)
  -N, --namespaces      show fully qualified package names
  -t, --types           show dependency types

for further documentation regarding the spec syntax, see:
    spack help --spec
```

Supersedes #7909