### PR TITLE
Add singularity@3.5.2

### DIFF
--- a/var/spack/repos/builtin/packages/singularity/package.py
+++ b/var/spack/repos/builtin/packages/singularity/package.py
@@ -27,6 +27,7 @@ class Singularity(MakefilePackage):
     maintainers = ['ArangoGutierrez', 'alalazo']
     version('master', branch='master')
 
+    version('3.5.2', sha256='f9c21e289377a4c40ed7a78a0c95e1ff416dec202ed49a6c616dd2c37700eab8')
     version('3.4.1', sha256='638fd7cc5ab2a20e779b8768f73baf21909148339d6c4edf6ff61349c53a70c2')
     version('3.4.0', sha256='eafb27f1ffbed427922ebe2b5b95d1c9c09bfeb897518867444fe230e3e35e41')
     version('3.3.0', sha256='070530a472e7e78492f1f142c8d4b77c64de4626c4973b0589f0d18e1fcf5b4f')


### PR DESCRIPTION
Builds for me on CentOS 7.

Tested (after running the setuid helper script) by running a docker container/

```
[hartzell@spacker spack]$ singularity exec docker://ubuntu:latest echo "Hello Dinosaur..."
INFO:    Converting OCI blobs to SIF format
INFO:    Starting build...
Getting image source signatures
Copying blob 2746a4a261c9 done
Copying blob 4c1d20cdee96 done
Copying blob 0d3160e1d0de done
Copying blob c8e37668deea done
Copying config d2d21cbe92 done
Writing manifest to image destination
Storing signatures
2020/01/06 19:03:01  info unpack layer: sha256:2746a4a261c9e18bfd7ff0429c18fd7522acc14fa4c7ec8ab37ba5ebaadbc584
2020/01/06 19:03:03  info unpack layer: sha256:4c1d20cdee96111c8acf1858b62655a37ce81ae48648993542b7ac363ac5c0e5
2020/01/06 19:03:03  info unpack layer: sha256:0d3160e1d0de4061b5b32ee09af687b898921d36ed9556df5910ddc3104449cd
2020/01/06 19:03:03  info unpack layer: sha256:c8e37668deea784f47c8726d934adc12b8d20a2b1c50b0b0c18cb62771cd3684
INFO:    Creating SIF file...
Hello Dinosaur...
```


fixes #14397