### PR TITLE
bugfix: Issue #14346, buildcache create s3 push fails when package w …

### DIFF
--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -263,7 +263,7 @@ def remove_url(url):
 
     if url.scheme == 's3':
         s3 = s3_util.create_s3_session(url)
-        s3.delete_object(Bucket=url.s3_bucket, Key=url.path)
+        s3.delete_object(Bucket=url.netloc, Key=url.path)
         return
 
     # Don't even try for other URL schemes.


### PR DESCRIPTION
Fix Issue #14346 with `spack buildcache create -d <s3-mirror> ...` which prevents pushing the exported package if it already exists on the S3 mirror. Is a problem when a package needs a re-build but the DAG hash stays the same, where in that case you want to be able to update the package at the mirror. Via @opadron suggestions