### PR TITLE
Adding a new package, scikit-build, which is useful for building Python Extensions

### DIFF
--- a/var/spack/repos/builtin/packages/py-scikit-build/package.py
+++ b/var/spack/repos/builtin/packages/py-scikit-build/package.py
@@ -3,41 +3,23 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-# ----------------------------------------------------------------------------
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install py-scikit-build
-#
-# You can edit this file again by typing:
-#
-#     spack edit py-scikit-build
-#
-# See the Spack documentation for more information on packaging.
-# ----------------------------------------------------------------------------
-
 from spack import *
 
 
 class PyScikitBuild(PythonPackage):
-    """FIXME: Put a proper description of your package here."""
+    """scikit-build is an improved build system generator for CPython C/C++/Fortran/Cython extensions. It provides better support for additional compilers, build systems, cross compilation, and locating dependencies and their associated build requirements.
 
-    # FIXME: Add a proper url for your package's homepage here.
+The scikit-build package is fundamentally just glue between the setuptools Python module and CMake."""
+
     homepage = "https://scikit-build.readthedocs.io/en/latest/"
     url      = "https://github.com/scikit-build/scikit-build/archive/0.10.0.tar.gz"
 
-    # FIXME: Add a list of GitHub accounts to
-    # notify when the package is updated.
-    # maintainers = ['github_user1', 'github_user2']
+    
+    maintainers = ['coreyjadams']
 
     version('0.10.0', sha256='2beec252813b20327072c15e9d997f15972aedcc6a130d0154979ff0fdb1b010')
 
-    # FIXME: Add dependencies if required.
-    # depends_on('python@2.X:2.Y,3.Z:', type=('build', 'run'))
+
     depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-packaging',  type=('build', 'run'))
     depends_on('py-wheel',      type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-scikit-build/package.py
+++ b/var/spack/repos/builtin/packages/py-scikit-build/package.py
@@ -1,0 +1,45 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install py-scikit-build
+#
+# You can edit this file again by typing:
+#
+#     spack edit py-scikit-build
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+from spack import *
+
+
+class PyScikitBuild(PythonPackage):
+    """FIXME: Put a proper description of your package here."""
+
+    # FIXME: Add a proper url for your package's homepage here.
+    homepage = "https://scikit-build.readthedocs.io/en/latest/"
+    url      = "https://github.com/scikit-build/scikit-build/archive/0.10.0.tar.gz"
+
+    # FIXME: Add a list of GitHub accounts to
+    # notify when the package is updated.
+    # maintainers = ['github_user1', 'github_user2']
+
+    version('0.10.0', sha256='2beec252813b20327072c15e9d997f15972aedcc6a130d0154979ff0fdb1b010')
+
+    # FIXME: Add dependencies if required.
+    # depends_on('python@2.X:2.Y,3.Z:', type=('build', 'run'))
+    depends_on('py-setuptools', type=('build', 'run'))
+    depends_on('py-packaging',  type=('build', 'run'))
+    depends_on('py-wheel',      type=('build', 'run'))
+
+

--- a/var/spack/repos/builtin/packages/py-scikit-build/package.py
+++ b/var/spack/repos/builtin/packages/py-scikit-build/package.py
@@ -7,21 +7,21 @@ from spack import *
 
 
 class PyScikitBuild(PythonPackage):
-    """scikit-build is an improved build system generator for CPython C/C++/Fortran/Cython extensions. It provides better support for additional compilers, build systems, cross compilation, and locating dependencies and their associated build requirements.
+    """scikit-build is an improved build system generator for CPython 
+       C/C++/Fortran/Cython extensions. It provides better support for 
+       additional compilers, build systems, cross compilation, and 
+       locating dependencies and their associated build requirements.
 
-The scikit-build package is fundamentally just glue between the setuptools Python module and CMake."""
+       The scikit-build package is fundamentally just glue between
+       the setuptools Python module and CMake."""
 
     homepage = "https://scikit-build.readthedocs.io/en/latest/"
     url      = "https://github.com/scikit-build/scikit-build/archive/0.10.0.tar.gz"
 
-    
     maintainers = ['coreyjadams']
 
     version('0.10.0', sha256='2beec252813b20327072c15e9d997f15972aedcc6a130d0154979ff0fdb1b010')
 
-
     depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-packaging',  type=('build', 'run'))
     depends_on('py-wheel',      type=('build', 'run'))
-
-

--- a/var/spack/repos/builtin/packages/py-scikit-build/package.py
+++ b/var/spack/repos/builtin/packages/py-scikit-build/package.py
@@ -24,4 +24,4 @@ class PyScikitBuild(PythonPackage):
 
     depends_on('py-setuptools@28.0.0:', type=('build', 'run'))
     depends_on('py-packaging',  type=('build', 'run'))
-    depends_on('py-wheel',      type=('build', 'run'))
+    depends_on('py-wheel@0.29.0:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-scikit-build/package.py
+++ b/var/spack/repos/builtin/packages/py-scikit-build/package.py
@@ -7,9 +7,9 @@ from spack import *
 
 
 class PyScikitBuild(PythonPackage):
-    """scikit-build is an improved build system generator for CPython 
-       C/C++/Fortran/Cython extensions. It provides better support for 
-       additional compilers, build systems, cross compilation, and 
+    """scikit-build is an improved build system generator for CPython
+       C/C++/Fortran/Cython extensions. It provides better support for
+       additional compilers, build systems, cross compilation, and
        locating dependencies and their associated build requirements.
 
        The scikit-build package is fundamentally just glue between

--- a/var/spack/repos/builtin/packages/py-scikit-build/package.py
+++ b/var/spack/repos/builtin/packages/py-scikit-build/package.py
@@ -22,6 +22,6 @@ class PyScikitBuild(PythonPackage):
 
     version('0.10.0', sha256='2beec252813b20327072c15e9d997f15972aedcc6a130d0154979ff0fdb1b010')
 
-    depends_on('py-setuptools', type=('build', 'run'))
+    depends_on('py-setuptools@28.0.0:', type=('build', 'run'))
     depends_on('py-packaging',  type=('build', 'run'))
     depends_on('py-wheel',      type=('build', 'run'))


### PR DESCRIPTION
Scikit-build is a useful python repository for building python extensions that use CMake.  It is pure python and independent of cmake itself.

Source code: https://github.com/scikit-build/scikit-build
Documentation: https://scikit-build.readthedocs.io/en/latest/index.html

This PR is exclusively the addition of a package for scikit-build.