### PR TITLE
NumPy 1.18.1 requires Cython 0.29.14

### DIFF
--- a/var/spack/repos/builtin/packages/py-cython/package.py
+++ b/var/spack/repos/builtin/packages/py-cython/package.py
@@ -10,7 +10,7 @@ class PyCython(PythonPackage):
     """The Cython compiler for writing C extensions for the Python language."""
 
     homepage = "https://pypi.python.org/pypi/cython"
-    url      = "https://pypi.io/packages/source/c/cython/Cython-0.29.13.tar.gz"
+    url      = "https://pypi.io/packages/source/c/cython/Cython-0.29.14.tar.gz"
 
     import_modules = [
         'cython', 'Cython', 'Cython.Build', 'Cython.Compiler',
@@ -20,6 +20,7 @@ class PyCython(PythonPackage):
         'Cython.Tempita', 'pyximport',
     ]
 
+    version('0.29.14', sha256='e4d6bb8703d0319eb04b7319b12ea41580df44fd84d83ccda13ea463c6801414')
     version('0.29.13', sha256='c29d069a4a30f472482343c866f7486731ad638ef9af92bfe5fca9c7323d638e')
     version('0.29.7',  sha256='55d081162191b7c11c7bfcb7c68e913827dfd5de6ecdbab1b99dab190586c1e8')
     version('0.29.5',  sha256='9d5290d749099a8e446422adfb0aa2142c711284800fb1eb70f595101e32cbf1')

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -79,7 +79,9 @@ class PyNumpy(PythonPackage):
     depends_on('python@2.7:2.8,3.5:', type=('build', 'run'), when='@1.16:')
     depends_on('python@3.5:', type=('build', 'run'), when='@1.17:')
     depends_on('py-setuptools', type='build')
-    depends_on('py-cython@0.29.13:', when='@1.18:', type='build')
+    # Check pyproject.toml for updates to the required cython version
+    depends_on('py-cython@0.29.13:', when='@1.18.0:', type='build')
+    depends_on('py-cython@0.29.14:', when='@1.18.1:', type='build')
     depends_on('blas',   when='+blas')
     depends_on('lapack', when='+lapack')
 


### PR DESCRIPTION
I accidentally merged NumPy 1.18.1 without checking to see if its dependencies changed. Apparently it depends on the bleeding edge of Cython. Successfully installs on macOS 10.15.2 with Clang 11.0.0 and Python 3.7.4.