### PR TITLE
libcircle: add develop version from git master branch

### DIFF
--- a/var/spack/repos/builtin/packages/libcircle/package.py
+++ b/var/spack/repos/builtin/packages/libcircle/package.py
@@ -11,10 +11,9 @@ class Libcircle(AutotoolsPackage):
 
     homepage = "https://github.com/hpc/libcircle"
     git      = "https://github.com/hpc/libcircle.git"
-    url      = "https://github.com/hpc/libcircle/releases/download/0.2.1-rc.1/libcircle-0.2.1-rc.1.tar.gz'url='https://github.com/hpc/libcircle/releases/download/0.2.1-rc.1/libcircle-0.2.1-rc.1.tar.gz"
+    url      = "https://github.com/hpc/libcircle/releases/download/0.2.1-rc.1/libcircle-0.2.1-rc.1.tar.gz"
 
     version('master', branch='master')
-    version('develop', branch='master')
     version('0.2.1-rc.1', sha256='5747f91cf4417023304dcc92fd07e3617ac712ca1eeb698880979bbca3f54865')
 
     depends_on('mpi')

--- a/var/spack/repos/builtin/packages/libcircle/package.py
+++ b/var/spack/repos/builtin/packages/libcircle/package.py
@@ -11,8 +11,19 @@ class Libcircle(AutotoolsPackage):
        using self-stabilizing work stealing."""
 
     homepage = "https://github.com/hpc/libcircle"
+    git      = "https://github.com/hpc/libcircle.git"
 
+
+    version('develop', branch='master')
     version('0.2.1-rc.1', sha256='5747f91cf4417023304dcc92fd07e3617ac712ca1eeb698880979bbca3f54865',
             url='https://github.com/hpc/libcircle/releases/download/0.2.1-rc.1/libcircle-0.2.1-rc.1.tar.gz')
 
     depends_on('mpi')
+
+    @when('@develop')
+    def autoreconf(self, spec, prefix):
+        with working_dir(self.configure_directory):
+            # Bootstrap with autotools
+            bash = which('bash')
+            bash('./autogen.sh')
+

--- a/var/spack/repos/builtin/packages/libcircle/package.py
+++ b/var/spack/repos/builtin/packages/libcircle/package.py
@@ -5,6 +5,7 @@
 
 from spack import *
 
+
 class Libcircle(AutotoolsPackage):
     """libcircle provides an efficient distributed queue on a cluster,
        using self-stabilizing work stealing."""

--- a/var/spack/repos/builtin/packages/libcircle/package.py
+++ b/var/spack/repos/builtin/packages/libcircle/package.py
@@ -14,7 +14,7 @@ class Libcircle(AutotoolsPackage):
     git      = "https://github.com/hpc/libcircle.git"
 
 
-    version('develop', branch='master')
+    version('master', branch='master')
     version('0.2.1-rc.1', sha256='5747f91cf4417023304dcc92fd07e3617ac712ca1eeb698880979bbca3f54865',
             url='https://github.com/hpc/libcircle/releases/download/0.2.1-rc.1/libcircle-0.2.1-rc.1.tar.gz')
 
@@ -26,4 +26,3 @@ class Libcircle(AutotoolsPackage):
             # Bootstrap with autotools
             bash = which('bash')
             bash('./autogen.sh')
-

--- a/var/spack/repos/builtin/packages/libcircle/package.py
+++ b/var/spack/repos/builtin/packages/libcircle/package.py
@@ -5,22 +5,21 @@
 
 from spack import *
 
-
 class Libcircle(AutotoolsPackage):
     """libcircle provides an efficient distributed queue on a cluster,
        using self-stabilizing work stealing."""
 
     homepage = "https://github.com/hpc/libcircle"
     git      = "https://github.com/hpc/libcircle.git"
-
+    url      = "https://github.com/hpc/libcircle/releases/download/0.2.1-rc.1/libcircle-0.2.1-rc.1.tar.gz'url='https://github.com/hpc/libcircle/releases/download/0.2.1-rc.1/libcircle-0.2.1-rc.1.tar.gz"
 
     version('master', branch='master')
-    version('0.2.1-rc.1', sha256='5747f91cf4417023304dcc92fd07e3617ac712ca1eeb698880979bbca3f54865',
-            url='https://github.com/hpc/libcircle/releases/download/0.2.1-rc.1/libcircle-0.2.1-rc.1.tar.gz')
+    version('develop', branch='master')
+    version('0.2.1-rc.1', sha256='5747f91cf4417023304dcc92fd07e3617ac712ca1eeb698880979bbca3f54865')
 
     depends_on('mpi')
 
-    @when('@develop')
+    @when('@master')
     def autoreconf(self, spec, prefix):
         with working_dir(self.configure_directory):
             # Bootstrap with autotools


### PR DESCRIPTION
Must run the included `autogen.sh` script for auto tools when building from master. Spack's built-in auto-re-conf-whatever doesn't quite work. 

Tagging @adammoody 