### PR TITLE
Allow ':' in key name to denote overrides for set() and override().

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -825,8 +825,8 @@ def _process_config_path(path):
         raise syaml.SpackYAMLError("Illegal leading `:' in path `{0}'".
                                    format(path), '')
     while path:
-        front, _, path = path.partition(':')
-        if (_ and not path) or path.startswith(':'):
+        front, sep, path = path.partition(':')
+        if (sep and not path) or path.startswith(':'):
             path = path.lstrip(':')
             front = syaml.syaml_str(front)
             front.override = True

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -783,8 +783,6 @@ def _merge_yaml(dest, source):
     Config file authors can optionally end any attribute in a dict
     with `::` instead of `:`, and the key will override that of the
     parent instead of merging.
-
-    If override is True, then source will be copied to dest unconditionally.
     """
     def they_are(t):
         return isinstance(dest, t) and isinstance(source, t)

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -787,6 +787,7 @@ def _merge_yaml(dest, source):
     def they_are(t):
         return isinstance(dest, t) and isinstance(source, t)
 
+    # If source is None, overwrite with source.
     if source is None:
         return None
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -506,7 +506,7 @@ class Configuration(object):
 
         Accepts the path syntax described in ``get()``.
         """
-        parts = _process_path(path)
+        parts = _process_config_path(path)
         section = parts.pop(0)
 
         if not parts:
@@ -819,7 +819,7 @@ def _merge_yaml(dest, source, override=False):
 # Process a path argument to config.set() that may contain overrides ('::' or
 # trailing ':')
 #
-def _process_path(path):
+def _process_config_path(path):
     result = []
     if path.startswith(':'):
         raise syaml.SpackYAMLError("Illegal leading `:' in path `{0}'".

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -843,12 +843,18 @@ def _process_config_path(path):
     if path.startswith(':'):
         raise syaml.SpackYAMLError("Illegal leading `:' in path `{0}'".
                                    format(path), '')
+    seen_override_in_path = False
     while path:
         front, sep, path = path.partition(':')
         if (sep and not path) or path.startswith(':'):
+            if seen_override_in_path:
+                raise syaml.SpackYAMLError("Meaningless second override"
+                                           " indicator `::' in path `{0}'".
+                                           format(path), '')
             path = path.lstrip(':')
             front = syaml.syaml_str(front)
             front.override = True
+            seen_override_in_path = True
         result.append(front)
     return result
 

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -881,7 +881,7 @@ def test_internal_config_section_override(mock_low_high_config,
                                             'build_stage': wanted_list
                                         }
                                     }))
-    assert wanted_list == mock_low_high_config.get('config:build_stage')
+    assert mock_low_high_config.get('config:build_stage') == wanted_list
 
 
 def test_internal_config_dict_override(mock_low_high_config,
@@ -890,7 +890,7 @@ def test_internal_config_dict_override(mock_low_high_config,
     wanted_dict = config_override_dict['config']['info:']
     mock_low_high_config.push_scope(spack.config.InternalConfigScope
                                     ('high', config_override_dict))
-    assert wanted_dict == mock_low_high_config.get('config:info')
+    assert mock_low_high_config.get('config:info') == wanted_dict
 
 
 def test_internal_config_list_override(mock_low_high_config,
@@ -899,14 +899,14 @@ def test_internal_config_list_override(mock_low_high_config,
     wanted_list = config_override_list['config']['build_stage:']
     mock_low_high_config.push_scope(spack.config.InternalConfigScope
                                     ('high', config_override_list))
-    assert wanted_list == mock_low_high_config.get('config:build_stage')
+    assert mock_low_high_config.get('config:build_stage') == wanted_list
 
 
 def test_set_section_override(mock_low_high_config, write_config_file):
     write_config_file('config', config_merge_list, 'low')
     wanted_list = config_override_list['config']['build_stage:']
     with spack.config.override('config::build_stage', wanted_list):
-        assert wanted_list == mock_low_high_config.get('config:build_stage')
+        assert mock_low_high_config.get('config:build_stage') == wanted_list
     assert config_merge_list['config']['build_stage'] == \
         mock_low_high_config.get('config:build_stage')
 

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -46,7 +46,19 @@ config_merge_list = {
 
 config_override_list = {
     'config': {
-        'build_stage:': ['patha', 'pathb']}}
+        'build_stage:': ['pathd', 'pathe']}}
+
+config_merge_dict = {
+    'config': {
+        'info': {
+            'a': 3,
+            'b': 4}}}
+
+config_override_dict = {
+    'config': {
+        'info:': {
+            'a': 7,
+            'c': 9}}}
 
 
 @pytest.fixture()
@@ -382,7 +394,7 @@ def test_read_config_override_list(mock_low_high_config, write_config_file):
     write_config_file('config', config_override_list, 'high')
     assert spack.config.get('config') == {
         'install_tree': 'install_tree_path',
-        'build_stage': ['patha', 'pathb']
+        'build_stage': config_override_list['config']['build_stage:']
     }
 
 
@@ -857,3 +869,67 @@ def test_dotkit_in_config_does_not_raise(
     # we throw a a deprecation warning without raising
     assert '_sp_sys_type' in captured[0]  # stdout
     assert 'Warning' in captured[1]  # stderr
+
+
+def test_internal_config_section_override(mock_low_high_config,
+                                          write_config_file):
+    write_config_file('config', config_merge_list, 'low')
+    wanted_list = config_override_list['config']['build_stage:']
+    mock_low_high_config.push_scope(spack.config.InternalConfigScope
+                                    ('high', {
+                                        'config:': {
+                                            'build_stage': wanted_list
+                                        }
+                                    }))
+    assert wanted_list == mock_low_high_config.get('config:build_stage')
+
+
+def test_internal_config_dict_override(mock_low_high_config,
+                                       write_config_file):
+    write_config_file('config', config_merge_dict, 'low')
+    wanted_dict = config_override_dict['config']['info:']
+    mock_low_high_config.push_scope(spack.config.InternalConfigScope
+                                    ('high', config_override_dict))
+    assert wanted_dict == mock_low_high_config.get('config:info')
+
+
+def test_internal_config_list_override(mock_low_high_config,
+                                       write_config_file):
+    write_config_file('config', config_merge_list, 'low')
+    wanted_list = config_override_list['config']['build_stage:']
+    mock_low_high_config.push_scope(spack.config.InternalConfigScope
+                                    ('high', config_override_list))
+    assert wanted_list == mock_low_high_config.get('config:build_stage')
+
+
+def test_set_section_override(mock_low_high_config, write_config_file):
+    write_config_file('config', config_merge_list, 'low')
+    wanted_list = config_override_list['config']['build_stage:']
+    with spack.config.override('config::build_stage', wanted_list):
+        assert wanted_list == mock_low_high_config.get('config:build_stage')
+    assert config_merge_list['config']['build_stage'] == \
+        mock_low_high_config.get('config:build_stage')
+
+
+def test_set_list_override(mock_low_high_config, write_config_file):
+    write_config_file('config', config_merge_list, 'low')
+    wanted_list = config_override_list['config']['build_stage:']
+    with spack.config.override('config:build_stage:', wanted_list):
+        assert wanted_list == mock_low_high_config.get('config:build_stage')
+    assert config_merge_list['config']['build_stage'] == \
+        mock_low_high_config.get('config:build_stage')
+
+
+def test_set_dict_override(mock_low_high_config, write_config_file):
+    write_config_file('config', config_merge_dict, 'low')
+    wanted_dict = config_override_dict['config']['info:']
+    with spack.config.override('config:info:', wanted_dict):
+        assert wanted_dict == mock_low_high_config.get('config:info')
+    assert config_merge_dict['config']['info'] == \
+        mock_low_high_config.get('config:info')
+
+
+def test_set_bad_path(config):
+    with pytest.raises(syaml.SpackYAMLError):
+        with spack.config.override(':bad:path', ''):
+            pass

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -930,6 +930,13 @@ def test_set_dict_override(mock_low_high_config, write_config_file):
 
 
 def test_set_bad_path(config):
-    with pytest.raises(syaml.SpackYAMLError):
+    with pytest.raises(syaml.SpackYAMLError, match='Illegal leading'):
         with spack.config.override(':bad:path', ''):
+            pass
+
+
+def test_bad_path_double_override(config):
+    with pytest.raises(syaml.SpackYAMLError,
+                       match='Meaningless second override'):
+        with spack.config.override('bad::double:override::directive', ''):
             pass


### PR DESCRIPTION
Fixes #14416.

* Allows `spack.config.InternalConfigScope` and `spack.config.Configuration.set()` to handle keys with trailing ':' to indicate replacement vs merge behavior with respect to lower priority scopes.
* Lists may now be replaced rather than merged (this behavior was previously only available for dictionaries).
* Tests of the new behavior.
* In `spack.config._merge_yaml()`:
  * New optional Boolean argument `override` for use in nested contexts.
  * Minor logic improvements and simplification.