### PR TITLE
MPark.Variant: Patch NVCC C++14 Build 2

### DIFF
--- a/var/spack/repos/builtin/packages/mpark-variant/nvcc.patch
+++ b/var/spack/repos/builtin/packages/mpark-variant/nvcc.patch
@@ -1,27 +1,40 @@
-From 443d9454e8a665cef01cbf63036648a6e0ad9ffd Mon Sep 17 00:00:00 2001
-From: Axel Huebl <axel.huebl@plasma.ninja>
-Date: Mon, 25 Nov 2019 17:56:38 -0800
-Subject: [PATCH] NVCC: Avoid Specific Constexpr Construct
+From d7fb6201cbe830c2aef35b3fd0df040f9eae6d4d Mon Sep 17 00:00:00 2001
+From: Gavin Ridley <gavin.keith.ridley@gmail.com>
+Date: Tue, 31 Dec 2019 14:42:14 -0500
+Subject: [PATCH] now compiles in nvcc 10.2
 
-Out of the many C++14 `constexpr` constructs, one does not compile
-with NVCC - even when using `-std=c++14 --expt-relaxed-constexpr`.
-Seen with all versions of NVCC so far (latest tests with 10.1 and
-10.2).
 ---
- include/mpark/variant.hpp | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ include/mpark/variant.hpp | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/include/mpark/variant.hpp b/include/mpark/variant.hpp
-index ef496619b..728e69395 100644
+index ef496619b..f4848db88 100644
 --- a/include/mpark/variant.hpp
 +++ b/include/mpark/variant.hpp
-@@ -1998,7 +1998,7 @@ namespace mpark {
-     return false;
-   }
- 
--#ifdef MPARK_CPP14_CONSTEXPR
-+#if defined(MPARK_CPP14_CONSTEXPR) && !defined(__NVCC__)
+@@ -2001,20 +2001,20 @@ namespace mpark {
+ #ifdef MPARK_CPP14_CONSTEXPR
    namespace detail {
  
-     inline constexpr bool all(std::initializer_list<bool> bs) {
+-    inline constexpr bool all(std::initializer_list<bool> bs) {
++    inline constexpr bool any(std::initializer_list<bool> bs) {
+       for (bool b : bs) {
+-        if (!b) {
+-          return false;
++        if (b) {
++          return true;
+         }
+       }
+-      return true;
++      return false;
+     }
+ 
+   }  // namespace detail
+ 
+   template <typename Visitor, typename... Vs>
+   inline constexpr decltype(auto) visit(Visitor &&visitor, Vs &&... vs) {
+-    return (detail::all({!vs.valueless_by_exception()...})
++    return (!detail::any({vs.valueless_by_exception()...})
+                 ? (void)0
+                 : throw_bad_variant_access()),
+            detail::visitation::variant::visit_value(
 

--- a/var/spack/repos/builtin/packages/mpark-variant/package.py
+++ b/var/spack/repos/builtin/packages/mpark-variant/package.py
@@ -16,8 +16,8 @@ class MparkVariant(CMakePackage):
     version('1.4.0', sha256='8f6b28ab3640b5d76d5b6664dda7257a4405ce59179220431b8fd196c79b2ecb')
     version('1.3.0', sha256='d0f7e41f818fcc839797a8017e76b8b66b323651c304cff641a83a56ae9943c6')
 
-    # Ref.: https://github.com/mpark/variant/pull/71
-    patch('nvcc.patch')
+    # Ref.: https://github.com/mpark/variant/pull/73
+    patch('nvcc.patch', when='@:1.4.0')
 
     conflicts('%gcc@:4.7')
     conflicts('%clang@:3.5')


### PR DESCRIPTION
Update the patch (#13901) to fix builds with NVCC <= 10.2.89 with the accepted PR for upcoming releases of the library.

Ref.: https://github.com/mpark/variant/pull/73