### PR TITLE
rapidjson: delete '-march' flags when using Fujitsu compiler.

### DIFF
--- a/var/spack/repos/builtin/packages/rapidjson/package.py
+++ b/var/spack/repos/builtin/packages/rapidjson/package.py
@@ -22,3 +22,6 @@ class Rapidjson(CMakePackage):
     patch('0001-turn-off-Werror.patch')
 
     patch('arm.patch', when='@1.1.0 target=aarch64: %gcc@:5.9')
+
+    # Not correspond to define '-march=native' with Fujitsu compiler.
+    patch('remove_march.patch', when='%fj')

--- a/var/spack/repos/builtin/packages/rapidjson/remove_march.patch
+++ b/var/spack/repos/builtin/packages/rapidjson/remove_march.patch
@@ -1,0 +1,11 @@
+--- spack-src/CMakeLists.txt.org	2020-01-08 17:39:08.831616711 +0900
++++ spack-src/CMakeLists.txt	2020-01-08 17:39:27.431716190 +0900
+@@ -73,7 +73,7 @@
+         endif()
+     endif()
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -Wall -Wextra -Wno-missing-field-initializers")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-missing-field-initializers")
+     if (RAPIDJSON_BUILD_CXX11)
+         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+     endif()


### PR DESCRIPTION
Fujitsu compiler does not correspond to define '-march=native'.
So, I Fixed to delete '-march=native' when using Fujitsu compiler.