### PR TITLE
r-mass: Add version '7.3-51.5' and fix checksum.

### DIFF
--- a/var/spack/repos/builtin/packages/r-mass/package.py
+++ b/var/spack/repos/builtin/packages/r-mass/package.py
@@ -14,7 +14,8 @@ class RMass(RPackage):
     url      = "https://cloud.r-project.org/src/contrib/MASS_7.3-47.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/MASS"
 
-    version('7.3-51.4', sha256='9911d546a8d29dc906b46cb53ef8aad76d23566f4fc3b52778a1201f8a9b2c74')
+    version('7.3-51.5', sha256='464c0615cef01820cde2bb8457e81575d6755ae9b3ac99f3bfaaac47d43d15cc')
+    version('7.3-51.4', sha256='844270a2541eaed420871dfb61d681aa67ee57126645fb6b144b436c25698eeb')
     version('7.3-51.3', sha256='5b0e0e7704d43a94b08dcc4b3fe600b9723d1b3e446dd393e82d39ddf66608b6')
     version('7.3-47',   sha256='ed44cdabe84fff3553122267ade61d5cc68071c435f7645d36c8f2e4e9f9c6bf')
 


### PR DESCRIPTION
Added new version '7.3-51.5', and fix checksum of '7.3-51.4'.
Package of '7.3-51.4' was moved to archive directory, and was modified following points.
```
[usr@apollo13 r-mass]$ diff -ur MASS MASS_new
diff -ur MASS/DESCRIPTION MASS_new/DESCRIPTION
--- MASS/DESCRIPTION    2019-04-26 22:18:59.000000000 +0900
+++ MASS_new/DESCRIPTION        2019-03-31 16:55:05.000000000 +0900
@@ -33,4 +33,4 @@
   David Firth [ctb]
 Maintainer: Brian Ripley <ripley@stats.ox.ac.uk>
 Repository: CRAN
-Date/Publication: 2019-04-26 13:18:59 UTC
+Date/Publication: 2019-03-31 07:55:05 UTC
diff -ur MASS/MD5 MASS_new/MD5
--- MASS/MD5    2019-04-26 22:18:59.000000000 +0900
+++ MASS_new/MD5        2019-03-31 16:55:05.000000000 +0900
@@ -1,4 +1,4 @@
-a2dbb5e4e548578e5d6fce1c6683d531 *DESCRIPTION
+cd846d9af9038c65eb2b8bde3fa0952f *DESCRIPTION
 35aff05a505ecf7e81e0473767794ca9 *INDEX
 e0d1ab11f24f7e3ff569541429d65825 *LICENCE.note
 0ac7b30ad35a4c19ea69d76a6a366b02 *NAMESPACE
```