### PR TITLE
Efischer/190813 remove tildes

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -28,7 +28,7 @@ packages:
       glu: [mesa-glu, openglu]
       golang: [gcc]
       ipp: [intel-ipp]
-      java: [jdk, openjdk, ibm-java]
+      java: [openjdk, jdk, ibm-java]
       jpeg: [libjpeg-turbo, libjpeg]
       lapack: [openblas]
       mariadb-client: [mariadb-c-client, mariadb]

--- a/var/spack/repos/builtin/packages/accfft/package.py
+++ b/var/spack/repos/builtin/packages/accfft/package.py
@@ -20,7 +20,7 @@ class Accfft(CMakePackage, CudaPackage):
     variant('shared', default=True, description='Enables the build of shared libraries')
 
     # See: http://accfft.org/articles/install/#installing-dependencies
-    depends_on('fftw+float+double~mpi+openmp')
+    depends_on('fftw+float+double+openmp')
 
     depends_on('parallel-netcdf', when='+pnetcdf')
 

--- a/var/spack/repos/builtin/packages/albany/package.py
+++ b/var/spack/repos/builtin/packages/albany/package.py
@@ -54,7 +54,7 @@ class Albany(CMakePackage):
 
     # Add dependencies
     depends_on('mpi')
-    depends_on('trilinos~superlu-dist+isorropia+tempus+rythmos+teko+intrepid+intrepid2+minitensor+phalanx+pnetcdf+nox+piro+rol+shards+stk+superlu@master,develop')
+    depends_on('trilinos~superlu-dist+isorropia+tempus+rythmos+teko+intrepid+intrepid2+minitensor+phalanx+pnetcdf+nox+piro+rol+shards+stk+superlu@master,develop')   # superlu-dist & superlu are mutually exclusive
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/aoflagger/package.py
+++ b/var/spack/repos/builtin/packages/aoflagger/package.py
@@ -16,7 +16,7 @@ class Aoflagger(CMakePackage):
     version('2.10.0', sha256='3ec1188d37101acf2029575ebc09c50b19c158c88a12b55ac5d25a96bd8fc18d')
 
     depends_on('casacore+python+fftw@1.9.99:')
-    depends_on('fftw~mpi@3.0:')
+    depends_on('fftw@3.0:')
     depends_on('boost+python@:1.66.99')
     depends_on('libxml2')
     depends_on('lapack')

--- a/var/spack/repos/builtin/packages/arrow/package.py
+++ b/var/spack/repos/builtin/packages/arrow/package.py
@@ -26,7 +26,7 @@ class Arrow(CMakePackage):
     depends_on('python', when='+python')
     depends_on('py-numpy', when='+python')
     depends_on('rapidjson')
-    depends_on('snappy~shared')
+    depends_on('snappy~shared')   # Generates static library (with PIC code)
     depends_on('zlib+pic')
     depends_on('zstd+pic')
 

--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -73,9 +73,9 @@ class Ascent(Package):
     ###########################################################################
 
     depends_on("cmake@3.9.2:3.9.999", type='build')
-    depends_on("conduit~python", when="~python")
+    depends_on("conduit", when="~python")
     depends_on("conduit+python", when="+python+shared")
-    depends_on("conduit~shared~python", when="~shared")
+    depends_on("conduit~shared~python", when="~shared")   # ~shared is OK for now
 
     #######################
     # Python
@@ -97,12 +97,12 @@ class Ascent(Package):
     #############################
 
     depends_on("vtkh@develop",             when="+vtkh")
-    depends_on("vtkh@develop~openmp",      when="+vtkh~openmp")
+    depends_on("vtkh@develop",      when="+vtkh~openmp")
     depends_on("vtkh@develop+cuda+openmp", when="+vtkh+cuda+openmp")
-    depends_on("vtkh@develop+cuda~openmp", when="+vtkh+cuda~openmp")
+    depends_on("vtkh@develop+cuda", when="+vtkh+cuda~openmp")
 
     depends_on("vtkh@develop~shared",             when="~shared+vtkh")
-    depends_on("vtkh@develop~shared~openmp",      when="~shared+vtkh~openmp")
+    depends_on("vtkh@develop~shared",      when="~shared+vtkh~openmp")
     depends_on("vtkh@develop~shared+cuda",        when="~shared+vtkh+cuda")
     depends_on("vtkh@develop~shared+cuda~openmp", when="~shared+vtkh+cuda~openmp")
 

--- a/var/spack/repos/builtin/packages/conduit/package.py
+++ b/var/spack/repos/builtin/packages/conduit/package.py
@@ -51,6 +51,7 @@ class Conduit(Package):
     # package variants
     ###########################################################################
 
+    # TODO: Change to link_type='shared'|'static'
     variant("shared", default=True, description="Build Conduit as shared libs")
     variant('test', default=True, description='Enable Conduit unit tests')
 

--- a/var/spack/repos/builtin/packages/snappy/package.py
+++ b/var/spack/repos/builtin/packages/snappy/package.py
@@ -14,6 +14,7 @@ class Snappy(CMakePackage):
 
     version('1.1.7', 'ee9086291c9ae8deb4dac5e0b85bf54a')
 
+    # TODO: Change to link_type=('shared'|'pic'|'static')
     variant('shared', default=True, description='Build shared libraries')
     variant('pic', default=True, description='Build position independent code')
 

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -97,6 +97,7 @@ class Trilinos(CMakePackage):
             description='Compile with parallel-netcdf')
     variant('suite-sparse', default=True,
             description='Compile with SuiteSparse solvers')
+    # TODO: Change to superlu=('standard'|'dist')
     variant('superlu-dist', default=False,
             description='Compile with SuperluDist solvers')
     variant('superlu',      default=False,

--- a/var/spack/repos/builtin/packages/vtkh/package.py
+++ b/var/spack/repos/builtin/packages/vtkh/package.py
@@ -40,6 +40,7 @@ class Vtkh(Package):
     version('develop', branch='develop', submodules=True)
     version('0.1.0', branch='develop', tag='v0.1.0', submodules=True)
 
+    # TODO: Change to link_type='shared'|'static'
     variant("shared", default=True, description="Build vtk-h as shared libs")
     variant("mpi", default=True, description="build mpi support")
     variant("tbb", default=False, description="build tbb support")


### PR DESCRIPTION
@tgamblin @alalazo @scheibelp 

Sample PR to remove tildes (negative variants) from `depends_on()` directives.  This is because such directives can cause spurious concretization errors.  (And they have in the past; sorry I can't figure out where right now).

The problem with this PR is that some on/off variants are used to model features; whereas others are used to model mutually exclusive alternatives.  Tildes in `depends_on()` are only a problem for feature-type variants; whereas alternative-type variants should probably be converted to use Spack's multi-valued variant mechanism.

This PR is woefully incomplete.  It is presented for demo purposes only at this point, not to merge.
