### PR TITLE
Update the icu4c package

### DIFF
--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -13,16 +13,11 @@ class Icu4c(AutotoolsPackage):
 
     homepage = "http://site.icu-project.org/"
 
-    version('65.1',
-            sha256='53e37466b3d6d6d01ead029e3567d873a43a5d1c668ed2278e253b683136d948')
-    version('64.1',
-            sha256='92f1b7b9d51b396679c17f35a2112423361b8da3c1b9de00aa94fd768ae296e6')
-    version('60.1',
-            sha256='f8f5a6c8fbf32c015a467972bdb1477dc5f5d5dfea908b6ed218715eeb5ee225')
-    version('58.2',
-            sha256='2b0a4410153a9b20de0e20c7d8b66049a72aef244b53683d0d7521371683da0c')
-    version('57.1',
-            sha256='ff8c67cb65949b1e7808f2359f2b80f722697048e90e7cfc382ec1fe229e9581')
+    version('65.1', sha256='53e37466b3d6d6d01ead029e3567d873a43a5d1c668ed2278e253b683136d948')
+    version('64.1', sha256='92f1b7b9d51b396679c17f35a2112423361b8da3c1b9de00aa94fd768ae296e6')
+    version('60.1', sha256='f8f5a6c8fbf32c015a467972bdb1477dc5f5d5dfea908b6ed218715eeb5ee225')
+    version('58.2', sha256='2b0a4410153a9b20de0e20c7d8b66049a72aef244b53683d0d7521371683da0c')
+    version('57.1', sha256='ff8c67cb65949b1e7808f2359f2b80f722697048e90e7cfc382ec1fe229e9581')
 
     variant('cxxstd',
             default='11',

--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -12,14 +12,22 @@ class Icu4c(AutotoolsPackage):
     C/C++ interface."""
 
     homepage = "http://site.icu-project.org/"
-    url      = "http://download.icu-project.org/files/icu4c/57.1/icu4c-57_1-src.tgz"
-    list_url = "http://download.icu-project.org/files/icu4c"
-    list_depth = 2
+    url      = "https://github.com/unicode-org/icu/releases/download/release-65-1/icu4c-65_1-src.tgz"
 
-    version('64.1', sha256='92f1b7b9d51b396679c17f35a2112423361b8da3c1b9de00aa94fd768ae296e6')
-    version('60.1', sha256='f8f5a6c8fbf32c015a467972bdb1477dc5f5d5dfea908b6ed218715eeb5ee225')
-    version('58.2', sha256='2b0a4410153a9b20de0e20c7d8b66049a72aef244b53683d0d7521371683da0c')
-    version('57.1', sha256='ff8c67cb65949b1e7808f2359f2b80f722697048e90e7cfc382ec1fe229e9581')
+    version('65.1',
+            sha256='53e37466b3d6d6d01ead029e3567d873a43a5d1c668ed2278e253b683136d948')
+    version('64.1',
+            sha256='92f1b7b9d51b396679c17f35a2112423361b8da3c1b9de00aa94fd768ae296e6',
+            url='http://download.icu-project.org/files/icu4c/64.1/icu4c-64_1-src.tgz'),
+    version('60.1',
+            sha256='f8f5a6c8fbf32c015a467972bdb1477dc5f5d5dfea908b6ed218715eeb5ee225',
+            url='http://download.icu-project.org/files/icu4c/60.1/icu4c-60_1-src.tgz'),
+    version('58.2',
+            sha256='2b0a4410153a9b20de0e20c7d8b66049a72aef244b53683d0d7521371683da0c',
+            url='http://download.icu-project.org/files/icu4c/58.2/icu4c-58_2-src.tgz')
+    version('57.1',
+            sha256='ff8c67cb65949b1e7808f2359f2b80f722697048e90e7cfc382ec1fe229e9581',
+            url='http://download.icu-project.org/files/icu4c/57.1/icu4c-57_1-src.tgz')
 
     variant('cxxstd',
             default='11',
@@ -35,8 +43,8 @@ class Icu4c(AutotoolsPackage):
     configure_directory = 'source'
 
     def url_for_version(self, version):
-        url = "http://download.icu-project.org/files/icu4c/{0}/icu4c-{1}-src.tgz"
-        return url.format(version.dotted, version.underscored)
+        url = "https://github.com/unicode-org/icu/releases/download/release-{0}/icu4c-{1}-src.tgz"
+        return url.format(version.dashed, version.underscored)
 
     def flag_handler(self, name, flags):
         if name == 'cxxflags':
@@ -46,6 +54,12 @@ class Icu4c(AutotoolsPackage):
                          'cxx{0}_flag'.format(
                              self.spec.variants['cxxstd'].value)))
         return (None, flags, None)
+
+    # Need to make sure that locale is UTF-8 in order to process source
+    # files in UTF-8.
+    @when('@59:')
+    def setup_build_environment(self, env):
+        env.set('LC_ALL', 'en_US.UTF-8')
 
     def configure_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -12,6 +12,7 @@ class Icu4c(AutotoolsPackage):
     C/C++ interface."""
 
     homepage = "http://site.icu-project.org/"
+    url      = "https://github.com/unicode-org/icu/releases/download/release-65-1/icu4c-65_1-src.tgz"
 
     version('65.1', sha256='53e37466b3d6d6d01ead029e3567d873a43a5d1c668ed2278e253b683136d948')
     version('64.1', sha256='92f1b7b9d51b396679c17f35a2112423361b8da3c1b9de00aa94fd768ae296e6')

--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -12,22 +12,17 @@ class Icu4c(AutotoolsPackage):
     C/C++ interface."""
 
     homepage = "http://site.icu-project.org/"
-    url      = "https://github.com/unicode-org/icu/releases/download/release-65-1/icu4c-65_1-src.tgz"
 
     version('65.1',
             sha256='53e37466b3d6d6d01ead029e3567d873a43a5d1c668ed2278e253b683136d948')
     version('64.1',
-            sha256='92f1b7b9d51b396679c17f35a2112423361b8da3c1b9de00aa94fd768ae296e6',
-            url='http://download.icu-project.org/files/icu4c/64.1/icu4c-64_1-src.tgz'),
+            sha256='92f1b7b9d51b396679c17f35a2112423361b8da3c1b9de00aa94fd768ae296e6')
     version('60.1',
-            sha256='f8f5a6c8fbf32c015a467972bdb1477dc5f5d5dfea908b6ed218715eeb5ee225',
-            url='http://download.icu-project.org/files/icu4c/60.1/icu4c-60_1-src.tgz'),
+            sha256='f8f5a6c8fbf32c015a467972bdb1477dc5f5d5dfea908b6ed218715eeb5ee225')
     version('58.2',
-            sha256='2b0a4410153a9b20de0e20c7d8b66049a72aef244b53683d0d7521371683da0c',
-            url='http://download.icu-project.org/files/icu4c/58.2/icu4c-58_2-src.tgz')
+            sha256='2b0a4410153a9b20de0e20c7d8b66049a72aef244b53683d0d7521371683da0c')
     version('57.1',
-            sha256='ff8c67cb65949b1e7808f2359f2b80f722697048e90e7cfc382ec1fe229e9581',
-            url='http://download.icu-project.org/files/icu4c/57.1/icu4c-57_1-src.tgz')
+            sha256='ff8c67cb65949b1e7808f2359f2b80f722697048e90e7cfc382ec1fe229e9581')
 
     variant('cxxstd',
             default='11',
@@ -43,8 +38,12 @@ class Icu4c(AutotoolsPackage):
     configure_directory = 'source'
 
     def url_for_version(self, version):
-        url = "https://github.com/unicode-org/icu/releases/download/release-{0}/icu4c-{1}-src.tgz"
-        return url.format(version.dashed, version.underscored)
+        if version >= Version('65'):
+            url = "https://github.com/unicode-org/icu/releases/download/release-{0}/icu4c-{1}-src.tgz"
+            return url.format(version.dashed, version.underscored)
+        else:
+            url = "http://download.icu-project.org/files/icu4c/{0}/icu4c-{1}-src.tgz"
+            return url.format(version.dotted, version.underscored)
 
     def flag_handler(self, name, flags):
         if name == 'cxxflags':


### PR DESCRIPTION
This PR makes several changes to the icu4c package

1. add updated version to 65.1
2. modify the default url as project has moved to github
3. set UTF-8 locale to support building from source files in UTF-8
format

Note that the older versions are not available on github so explicit urls
were used. This PR will close #14399.