### PR TITLE
Set netcdf-fortran to build serially with Intel compiler

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-fortran/no_parallel_build.patch
+++ b/var/spack/repos/builtin/packages/netcdf-fortran/no_parallel_build.patch
@@ -1,0 +1,12 @@
+--- a/fortran/Makefile.in	2019-09-18 12:29:45.000000000 -0500
++++ b/fortran/Makefile.in	2020-01-24 10:56:03.660035265 -0600
+@@ -1095,6 +1095,9 @@
+ @USE_LOGGING_TRUE@	echo '      integer nf_set_log_level' >> netcdf.inc
+ @USE_LOGGING_TRUE@	echo '      external nf_set_log_level' >> netcdf.inc
+ 
++# Turn off parallel builds in this directory.
++.NOTPARALLEL:
++
+ # Tell versions [3.59,3.63) of GNU make to not export all variables.
+ # Otherwise a system limit (for SysV at least) may be exceeded.
+ .NOEXPORT:

--- a/var/spack/repos/builtin/packages/netcdf-fortran/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-fortran/package.py
@@ -36,6 +36,10 @@ class NetcdfFortran(AutotoolsPackage):
     # https://github.com/Unidata/netcdf-fortran/issues/94
     patch('nag.patch', when='@:4.4.4%nag')
 
+    # Parallel builds do not work in the fortran directory. This patch is
+    # derived from https://github.com/Unidata/netcdf-fortran/pull/211
+    patch('no_parallel_build.patch', when='@4.5.2')
+
     def flag_handler(self, name, flags):
         if name in ['cflags', 'fflags'] and '+pic' in self.spec:
             flags.append(self.compiler.pic_flag)
@@ -73,8 +77,3 @@ class NetcdfFortran(AutotoolsPackage):
             config_args.append('F77=%s' % self.spec['mpi'].mpif77)
 
         return config_args
-
-    # Parallel builds do not work when using the Intel compiler
-    @when('%intel')
-    def build(self, spec, prefix):
-        make(parallel=False)

--- a/var/spack/repos/builtin/packages/netcdf-fortran/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-fortran/package.py
@@ -73,3 +73,8 @@ class NetcdfFortran(AutotoolsPackage):
             config_args.append('F77=%s' % self.spec['mpi'].mpif77)
 
         return config_args
+
+    # Parallel builds do not work when using the Intel compiler
+    @when('%intel')
+    def build(self, spec, prefix):
+        make(parallel=False)


### PR DESCRIPTION
This PR turns off parallel builds when the Intel compiler is used.
Builds with the Intel compiler will fail otherwise.