### PR TITLE
When spack install checks for buildcaches only add urls for current arch

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -668,7 +668,7 @@ def extract_tarball(spec, filename, allow_root=False, unsigned=False,
 _cached_specs = None
 
 
-def get_specs(force=False):
+def get_specs(force=False, use_arch=False):
     """
     Get spec.yaml's for build caches available on mirror
     """
@@ -695,7 +695,10 @@ def get_specs(force=False):
                 for file in files:
                     if re.search('spec.yaml', file):
                         link = url_util.join(fetch_url_build_cache, file)
-                        urls.add(link)
+                        if use_arch and re.search(spack.architecture(), file):
+                            urls.add(link)
+                        else:
+                            urls.add(link)
         else:
             tty.msg("Finding buildcaches at %s" %
                     url_util.format(fetch_url_build_cache))
@@ -703,7 +706,10 @@ def get_specs(force=False):
                 url_util.join(fetch_url_build_cache, 'index.html'))
             for link in links:
                 if re.search("spec.yaml", link):
-                    urls.add(link)
+                    if use_arch and re.search(spack.architecture(), link):
+                        urls.add(link)
+                    else:
+                        urls.add(link)
 
     _cached_specs = []
     for link in urls:

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1507,7 +1507,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
 
     def try_install_from_binary_cache(self, explicit):
         tty.msg('Searching for binary cache of %s' % self.name)
-        specs = binary_distribution.get_specs()
+        specs = binary_distribution.get_specs(use_arch=True)
         binary_spec = spack.spec.Spec.from_dict(self.spec.to_dict())
         binary_spec._mark_concrete()
         if binary_spec not in specs:


### PR DESCRIPTION
spack install command calls spack.package.try_install_from_binary_cache() which calls spack.binary_distribution.get_specs().

spack.binary_distribution.get_specs() was modified in
#13002
to allow listing and installing buildcaches for macOS on a linux host.

In the case where a mirror contains buildcaches for multiple OSes the spack install command can spend more time downloading all of the specs from the build_cache directory than it takes to install the buildcache. The is especially true when using pipelines and the buildcache download directory is cleared between steps.

I modified the get_specs() command to accept a filter option and pass the current OS as the filter option when get_specs() is called from spack.package.try_install_from_binary_cache()