### PR TITLE
(fix zsh) stop word splitting from leaking out of setup-env.sh 

### DIFF
--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -336,7 +336,7 @@ fi;
 _sp_multi_pathadd() {
     local IFS=':'
     if [ "$_sp_shell" = zsh ]; then
-        setopt sh_word_split
+        emulate -L sh
     fi
     for pth in $2; do
         for systype in ${_sp_compatible_sys_types}; do


### PR DESCRIPTION
The pathadd function was using setopt to configure zsh for word
splitting, which leaks out of the function and breaks default
functionality in a number of external zsh plugins and packages.  This
switches to emulate -L, just as the spack function uses, to keep the
setting local to the function.