### PR TITLE
spack extensions prints list of extendable packages

### DIFF
--- a/lib/spack/spack/cmd/extensions.py
+++ b/lib/spack/spack/cmd/extensions.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import argparse
+import sys
 
 import llnl.util.tty as tty
 from llnl.util.tty.colify import colify
@@ -21,6 +22,8 @@ level = "long"
 
 
 def setup_parser(subparser):
+    subparser.epilog = 'If called without argument returns ' \
+                       'the list of all valid extendable packages'
     arguments.add_common_arguments(subparser, ['long', 'very_long'])
     subparser.add_argument('-d', '--deps', action='store_true',
                            help='output dependencies along with found specs')
@@ -42,7 +45,19 @@ def setup_parser(subparser):
 
 def extensions(parser, args):
     if not args.spec:
-        tty.die("extensions requires a package spec.")
+        # If called without arguments, list all the extendable packages
+        isatty = sys.stdout.isatty()
+        if isatty:
+            tty.info('Extendable packages:')
+
+        extendable_pkgs = []
+        for name in spack.repo.all_package_names():
+            pkg = spack.repo.get(name)
+            if pkg.extendable:
+                extendable_pkgs.append(name)
+
+        colify(extendable_pkgs, indent=4)
+        return
 
     # Checks
     spec = cmd.parse_specs(args.spec)

--- a/lib/spack/spack/test/cmd/extensions.py
+++ b/lib/spack/spack/test/cmd/extensions.py
@@ -69,6 +69,11 @@ def test_extensions(mock_packages, python_database, capsys):
     check_output(1, 1)
 
 
+def test_extensions_no_arguments(mock_packages):
+    out = extensions()
+    assert 'python' in out
+
+
 def test_extensions_raises_if_not_extendable(mock_packages):
     with pytest.raises(SpackCommandError):
         extensions("flake8")

--- a/share/spack/bash/spack-completion.in
+++ b/share/spack/bash/spack-completion.in
@@ -226,7 +226,7 @@ _config_sections() {
 _extensions() {
     if [[ -z "${SPACK_EXTENSIONS:-}" ]]
     then
-        SPACK_EXTENSIONS="aspell go-bootstrap go icedtea jdk kim-api lua matlab mofem-cephas octave openjdk perl python r ruby rust tcl yorick"
+        SPACK_EXTENSIONS="$(spack extensions)"
     fi
     SPACK_COMPREPLY="$SPACK_EXTENSIONS"
 }

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -226,7 +226,7 @@ _config_sections() {
 _extensions() {
     if [[ -z "${SPACK_EXTENSIONS:-}" ]]
     then
-        SPACK_EXTENSIONS="aspell go-bootstrap go icedtea jdk kim-api lua matlab mofem-cephas octave openjdk perl python r ruby rust tcl yorick"
+        SPACK_EXTENSIONS="$(spack extensions)"
     fi
     SPACK_COMPREPLY="$SPACK_EXTENSIONS"
 }


### PR DESCRIPTION
Closes #1356

This behavior is modeled after the `spack providers` command, which prints a list of valid virtual packages if no argument is supplied. Its intended use is for Spack's shell tab completion scripts.

This command is currently slower than I would like for tab completion, so if there are any ways to speed it up let me know.