### PR TITLE
Add spack config list command for tab completion

### DIFF
--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -56,6 +56,8 @@ def setup_parser(subparser):
         '--print-file', action='store_true',
         help="print the file name that would be edited")
 
+    sp.add_parser('list', help='list configuration sections')
+
 
 def _get_scope_and_section(args):
     """Extract config scope and section from arguments."""
@@ -83,7 +85,6 @@ def config_get(args):
 
     With no arguments and an active environment, print the contents of
     the environment's manifest file (spack.yaml).
-
     """
     scope, section = _get_scope_and_section(args)
 
@@ -113,7 +114,6 @@ def config_edit(args):
 
     With no arguments and an active environment, edit the spack.yaml for
     the active environment.
-
     """
     scope, section = _get_scope_and_section(args)
     if not scope and not section:
@@ -127,8 +127,19 @@ def config_edit(args):
         editor(config_file)
 
 
+def config_list(args):
+    """List the possible configuration sections.
+
+    Used primarily for shell tab completion scripts.
+    """
+    print(' '.join(list(spack.config.section_schemas)))
+
+
 def config(parser, args):
-    action = {'get': config_get,
-              'blame': config_blame,
-              'edit': config_edit}
+    action = {
+        'get': config_get,
+        'blame': config_blame,
+        'edit': config_edit,
+        'list': config_list,
+    }
     action[args.config_command](args)

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -91,3 +91,9 @@ def test_config_edit_fails_correctly_with_no_env(mutable_mock_env_path):
 def test_config_get_fails_correctly_with_no_env(mutable_mock_env_path):
     output = config('get', fail_on_error=False)
     assert "requires a section argument or an active environment" in output
+
+
+def test_config_list():
+    output = config('list')
+    assert 'compilers' in output
+    assert 'packages' in output

--- a/share/spack/bash/spack-completion.in
+++ b/share/spack/bash/spack-completion.in
@@ -218,7 +218,7 @@ _keys() {
 _config_sections() {
     if [[ -z "${SPACK_CONFIG_SECTIONS:-}" ]]
     then
-        SPACK_CONFIG_SECTIONS="compilers mirrors repos packages modules config upstreams"
+        SPACK_CONFIG_SECTIONS="$(spack config list)"
     fi
     SPACK_COMPREPLY="$SPACK_CONFIG_SECTIONS"
 }

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -218,7 +218,7 @@ _keys() {
 _config_sections() {
     if [[ -z "${SPACK_CONFIG_SECTIONS:-}" ]]
     then
-        SPACK_CONFIG_SECTIONS="compilers mirrors repos packages modules config upstreams"
+        SPACK_CONFIG_SECTIONS="$(spack config list)"
     fi
     SPACK_COMPREPLY="$SPACK_CONFIG_SECTIONS"
 }
@@ -584,7 +584,7 @@ _spack_config() {
     then
         SPACK_COMPREPLY="-h --help --scope"
     else
-        SPACK_COMPREPLY="get blame edit"
+        SPACK_COMPREPLY="get blame edit list"
     fi
 }
 
@@ -613,6 +613,10 @@ _spack_config_edit() {
     else
         _config_sections
     fi
+}
+
+_spack_config_list() {
+    SPACK_COMPREPLY="-h --help"
 }
 
 _spack_configure() {


### PR DESCRIPTION
This command allows you to get a list of all valid configuration sections from the command-line. Its intended use is in Spack's tab completion scripts.