### PR TITLE
Fix parsing of rocketmq URL

### DIFF
--- a/lib/spack/spack/test/url_parse.py
+++ b/lib/spack/spack/test/url_parse.py
@@ -74,6 +74,8 @@ from spack.version import Version
     ('numpy-1.12.0-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl', 'numpy-1.12.0'),  # noqa
     # PyPI - exe
     ('PyYAML-3.12.win-amd64-py3.5.exe', 'PyYAML-3.12'),
+    # Combinations of multiple patterns - bin, release
+    ('rocketmq-all-4.5.2-bin-release', 'rocketmq-all-4.5.2'),
     # Combinations of multiple patterns - all
     ('p7zip_9.04_src_all', 'p7zip_9.04'),
     # Combinations of multiple patterns - run

--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -175,6 +175,7 @@ def strip_version_suffixes(path):
 
         # Download version
         r'release',
+        r'bin',
         r'stable',
         r'[Ff]inal',
         r'rel',


### PR DESCRIPTION
@darmac with this you won't need any `url_for_version` in #14442.