### PR TITLE
mesa: check aarch64 system type as well

### DIFF
--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -101,7 +101,7 @@ class Mesa(AutotoolsPackage):
         args_gallium_drivers = ['swrast']
         args_dri_drivers = []
 
-        if spec.target.family == 'arm':
+        if spec.target.family == 'arm' or spec.target.family == 'aarch64':
             args.append('--disable-libunwind')
 
         num_frontends = 0


### PR DESCRIPTION
to disable use of libunwind.  Without this mesa fails to build
using recent Cray compilers - cce 9 and higher -  on aarch64 systems.

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>