### PR TITLE
Fix use of sys.executable for module/env commands

### DIFF
--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -919,7 +919,8 @@ def environment_after_sourcing_files(*files, **kwargs):
         source_file = ' '.join(source_file)
 
         dump_cmd = 'import os, json; print(json.dumps(dict(os.environ)))'
-        dump_environment = sys.executable + ' -c "{0}"'.format(dump_cmd)
+        dump_environment = 'PYTHONHOME="{0}" "{1}" -c "{2}"'.format(
+            sys.prefix, sys.executable, dump_cmd)
 
         # Try to source the file
         source_file_arguments = ' '.join([

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -17,6 +17,7 @@ import six
 
 import llnl.util.tty as tty
 import spack.util.executable as executable
+from spack.util.module_cmd import py_cmd
 
 from llnl.util.lang import dedupe
 
@@ -918,9 +919,8 @@ def environment_after_sourcing_files(*files, **kwargs):
         source_file.extend(x for x in file_and_args)
         source_file = ' '.join(source_file)
 
-        dump_cmd = 'import os, json; print(json.dumps(dict(os.environ)))'
         dump_environment = 'PYTHONHOME="{0}" "{1}" -c "{2}"'.format(
-            sys.prefix, sys.executable, dump_cmd)
+            sys.prefix, sys.executable, py_cmd)
 
         # Try to source the file
         source_file_arguments = ' '.join([

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -32,7 +32,7 @@ def module(*args):
     if args[0] in module_change_commands:
         # Do the module manipulation, then output the environment in JSON
         # and read the JSON back in the parent process to update os.environ
-        module_cmd += ' > /dev/null; PYTHONHOME="{0}" "{1}" -c "{2}"'.format(
+        module_cmd += ' > /dev/null; PYTHONHOME="{0}" "{1}" -c {2}'.format(
             sys.prefix, sys.executable, py_cmd)
         module_p  = subprocess.Popen(module_cmd,
                                      stdout=subprocess.PIPE,

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -32,7 +32,8 @@ def module(*args):
     if args[0] in module_change_commands:
         # Do the module manipulation, then output the environment in JSON
         # and read the JSON back in the parent process to update os.environ
-        module_cmd += ' >/dev/null;' + sys.executable + ' -c %s' % py_cmd
+        module_cmd += ' > /dev/null; PYTHONHOME="{0}" "{1}" -c "{2}"'.format(
+            sys.prefix, sys.executable, py_cmd)
         module_p  = subprocess.Popen(module_cmd,
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.STDOUT,

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -18,7 +18,7 @@ import llnl.util.tty as tty
 # This list is not exhaustive. Currently we only use load and unload
 # If we need another option that changes the environment, add it here.
 module_change_commands = ['load', 'swap', 'unload', 'purge', 'use', 'unuse']
-py_cmd = 'import os, import json; print(json.dumps(dict(os.environ)))'
+py_cmd = 'import os; import json; print(json.dumps(dict(os.environ)))'
 
 # This is just to enable testing. I hate it but we can't find a better way
 _test_mode = False

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -18,7 +18,7 @@ import llnl.util.tty as tty
 # This list is not exhaustive. Currently we only use load and unload
 # If we need another option that changes the environment, add it here.
 module_change_commands = ['load', 'swap', 'unload', 'purge', 'use', 'unuse']
-py_cmd = "'import os;import json;print(json.dumps(dict(os.environ)))'"
+py_cmd = 'import os, import json; print(json.dumps(dict(os.environ)))'
 
 # This is just to enable testing. I hate it but we can't find a better way
 _test_mode = False
@@ -32,7 +32,7 @@ def module(*args):
     if args[0] in module_change_commands:
         # Do the module manipulation, then output the environment in JSON
         # and read the JSON back in the parent process to update os.environ
-        module_cmd += ' > /dev/null; PYTHONHOME="{0}" "{1}" -c {2}'.format(
+        module_cmd += ' > /dev/null; PYTHONHOME="{0}" "{1}" -c "{2}"'.format(
             sys.prefix, sys.executable, py_cmd)
         module_p  = subprocess.Popen(module_cmd,
                                      stdout=subprocess.PIPE,


### PR DESCRIPTION
@zzotta can you see if this fixes #14491 for you?

I'm not sure whether the quotes are necessary or not. I wanted to be robust in case `python` is installed in a directory containing spaces. Honestly, we should probably rewrite all of this stuff so that it doesn't use `shell=True`, and then it shouldn't be necessary anymore.

@s-sajid-ali @chissg 