### PR TITLE
New package Jali - unstructured mesh infrastructure for multiphysics applications

### DIFF
--- a/var/spack/repos/builtin/packages/jali/package.py
+++ b/var/spack/repos/builtin/packages/jali/package.py
@@ -1,0 +1,56 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Jali(CMakePackage):
+    """Jali is a parallel unstructured mesh infrastructure library designed for use by multi-physics simulations. It supports 2D and 3D arbitrary polyhedral meshes distributed over hundreds to thousands of nodes. Jali can read and write Exodus II meshes along with fields and sets on the mesh and support for other formats is partially implemented or is in the plans. Jali is built upon MSTK (https://github.com/MeshToolkit/MSTK), an open source general purpose unstructured mesh infrastructure library from Los Alamos National Laboratory. While it has been made to work with other mesh frameworks such as MOAB and STKmesh in the past, support for maintaining the interface to these frameworks has been suspended for now. Jali supports distributed as well as on-node parallelism. Support of on-node parallelism is through direct use of the mesh calls in multi-threaded constructs or through use of "tiles" which are submeshes or sub-partitions of a partition destined for a compute node."""
+
+    homepage = "https://github.com/lanl/jali"
+    git      = "https://github.com/lanl/jali"
+    url      = "https://github.com/lanl/jali/archive/1.1.1.tar.gz"
+
+    maintainers = ['raovgarimella']
+
+    version('master', branch='master')
+    version('1.1.1', sha256='33dd340b16bf7f82dc5a1f97b6d036868ae86d622f0a94f2bc781a44ad87eb11')
+    version('1.1.0', sha256='783dfcd6a9284af83bb380ed257fa8b0757dc2f7f9196d935eb974fb6523c644')
+    version('1.0.5', sha256='979170615d33a7bf20c96bd4d0285e05a2bbd901164e377a8bccbd9af9463801')
+
+    variant('mstk', default=True, description='Enable MSTK')
+
+    # dependencies
+    depends_on('cmake@3.13:', type='build')
+
+    #
+    depends_on('mpi', when='+parallel')
+
+    depends_on('boost')
+
+    depends_on('mstk@3.3.0: +exodusii+parallel~use_markers partitioner=all', when='+mstk')
+
+    depends_on('zoltan -fortran')
+    depends_on('metis')
+    depends_on('exodusii')
+
+
+    # Unit testing variant
+    depends_on('unittest-cpp', type='test')
+
+    def cmake_args(self):
+        options = []
+        if '+with_mstk' in self.spec:
+            options.append('-DENABLE_MSTK_Mesh=ON')
+        else:
+            options.append('-DENABLE_MSTK_Mesh=OFF')
+
+        # Unit test variant
+        if self.run_tests:
+            options.append('-DENABLE_Tests=ON')
+        else:
+            options.append('-DENABLE_Tests=OFF')
+
+        return options

--- a/var/spack/repos/builtin/packages/jali/package.py
+++ b/var/spack/repos/builtin/packages/jali/package.py
@@ -16,7 +16,7 @@ class Jali(CMakePackage):
     maintainers = ['raovgarimella']
 
     version('master', branch='master')
-    version('1.1.1', sha256='33dd340b16bf7f82dc5a1f97b6d036868ae86d622f0a94f2bc781a44ad87eb11')
+    version('1.1.1', sha256='c96c000b3893ea7f15bbc886524476dd466ae145e77deedc27e412fcc3541207')
     version('1.1.0', sha256='783dfcd6a9284af83bb380ed257fa8b0757dc2f7f9196d935eb974fb6523c644')
     version('1.0.5', sha256='979170615d33a7bf20c96bd4d0285e05a2bbd901164e377a8bccbd9af9463801')
 
@@ -25,8 +25,7 @@ class Jali(CMakePackage):
     # dependencies
     depends_on('cmake@3.13:', type='build')
 
-    #
-    depends_on('mpi', when='+parallel')
+    depends_on('mpi')
 
     depends_on('boost')
 
@@ -35,7 +34,6 @@ class Jali(CMakePackage):
     depends_on('zoltan -fortran')
     depends_on('metis')
     depends_on('exodusii')
-
 
     # Unit testing variant
     depends_on('unittest-cpp', type='test')

--- a/var/spack/repos/builtin/packages/jali/package.py
+++ b/var/spack/repos/builtin/packages/jali/package.py
@@ -7,22 +7,9 @@ from spack import *
 
 
 class Jali(CMakePackage):
-    """Jali is a parallel unstructured mesh infrastructure library
-designed for use by multi-physics simulations. It supports 2D and 3D
-arbitrary polyhedral meshes distributed over hundreds to thousands of
-nodes. Jali can read and write Exodus II meshes along with fields and
-sets on the mesh and support for other formats is partially
-implemented or is in the plans. Jali is built upon MSTK
-(https://github.com/MeshToolkit/MSTK), an open source general purpose
-unstructured mesh infrastructure library from Los Alamos National
-Laboratory. While it has been made to work with other mesh frameworks
-such as MOAB and STKmesh in the past, support for maintaining the
-interface to these frameworks has been suspended for now. Jali
-supports distributed as well as on-node parallelism. Support of
-on-node parallelism is through direct use of the mesh calls in
-multi-threaded constructs or through use of "tiles" which are
-submeshes or sub-partitions of a partition destined for a compute
-node."""
+    """Jali is a parallel, unstructured mesh infrastructure library designed
+    for use by multi-physics simulations.
+    """
 
     homepage = "https://github.com/lanl/jali"
     git      = "https://github.com/lanl/jali"

--- a/var/spack/repos/builtin/packages/jali/package.py
+++ b/var/spack/repos/builtin/packages/jali/package.py
@@ -7,7 +7,22 @@ from spack import *
 
 
 class Jali(CMakePackage):
-    """Jali is a parallel unstructured mesh infrastructure library designed for use by multi-physics simulations. It supports 2D and 3D arbitrary polyhedral meshes distributed over hundreds to thousands of nodes. Jali can read and write Exodus II meshes along with fields and sets on the mesh and support for other formats is partially implemented or is in the plans. Jali is built upon MSTK (https://github.com/MeshToolkit/MSTK), an open source general purpose unstructured mesh infrastructure library from Los Alamos National Laboratory. While it has been made to work with other mesh frameworks such as MOAB and STKmesh in the past, support for maintaining the interface to these frameworks has been suspended for now. Jali supports distributed as well as on-node parallelism. Support of on-node parallelism is through direct use of the mesh calls in multi-threaded constructs or through use of "tiles" which are submeshes or sub-partitions of a partition destined for a compute node."""
+    """Jali is a parallel unstructured mesh infrastructure library
+designed for use by multi-physics simulations. It supports 2D and 3D
+arbitrary polyhedral meshes distributed over hundreds to thousands of
+nodes. Jali can read and write Exodus II meshes along with fields and
+sets on the mesh and support for other formats is partially
+implemented or is in the plans. Jali is built upon MSTK
+(https://github.com/MeshToolkit/MSTK), an open source general purpose
+unstructured mesh infrastructure library from Los Alamos National
+Laboratory. While it has been made to work with other mesh frameworks
+such as MOAB and STKmesh in the past, support for maintaining the
+interface to these frameworks has been suspended for now. Jali
+supports distributed as well as on-node parallelism. Support of
+on-node parallelism is through direct use of the mesh calls in
+multi-threaded constructs or through use of "tiles" which are
+submeshes or sub-partitions of a partition destined for a compute
+node."""
 
     homepage = "https://github.com/lanl/jali"
     git      = "https://github.com/lanl/jali"

--- a/var/spack/repos/builtin/packages/mstk/package.py
+++ b/var/spack/repos/builtin/packages/mstk/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/var/spack/repos/builtin/packages/mstk/package.py
+++ b/var/spack/repos/builtin/packages/mstk/package.py
@@ -93,11 +93,11 @@ class Mstk(CMakePackage):
             options.append('-DENABLE_METIS=OFF')
             options.append('-DENABLE_ZOLTAN=OFF')
         else:
-            if 'zoltan' or 'all' in self.spec:
+            if 'zoltan' in self.spec:
                 options.append('-DENABLE_ZOLTAN=ON')
             else:
                 options.append('-DENABLE_ZOLTAN=OFF')
-            if 'metis' or 'all' in self.spec:
+            if 'metis' in self.spec:
                 options.append('-DENABLE_METIS=ON')
             else:
                 options.append('-DENABLE_METIS=OFF')

--- a/var/spack/repos/builtin/packages/mstk/package.py
+++ b/var/spack/repos/builtin/packages/mstk/package.py
@@ -27,10 +27,6 @@ class Mstk(CMakePackage):
 
     maintainers = ['raovgarimella', 'julienloiseau']
 
-    def url_for_version(self, version):
-        url = 'https://github.com/MeshToolkit/MSTK/archive/{0}.tar.gz'
-        return url.format(version)
-    
     version('master', branch='master')
     version('3.3.1', sha256='9fdb0c33c1b68714d708b355d963547cf41332812658d4560d4db43904fc78de')
     version('3.3.0', sha256='205c48fb5619937b5dd83788da739b7c2060155b7c41793e29ce05422b8f7dfb')

--- a/var/spack/repos/builtin/packages/mstk/package.py
+++ b/var/spack/repos/builtin/packages/mstk/package.py
@@ -46,7 +46,7 @@ class Mstk(CMakePackage):
     variant('use_markers', default=True, description='Enable use of markers')
     variant('parallel', default=False, description='Enable Parallel Support')
     variant('partitioner', default='none',
-            values=('none', 'metis', 'zoltan','all'),
+            values=('none', 'metis', 'zoltan', 'all'),
             multi=False, description='Choose partitioner')
     conflicts('partitioner=none', when='+parallel')
     conflicts('partitioner=all', when='-parallel')
@@ -65,7 +65,6 @@ class Mstk(CMakePackage):
     depends_on('zoltan -fortran', when='partitioner=all')
     depends_on('metis', when='partitioner=metis')
     depends_on('metis', when='partitioner=all')
-
 
     # Exodusii variant
     # The default exodusii build with mpi support
@@ -102,7 +101,6 @@ class Mstk(CMakePackage):
                 options.append('-DENABLE_METIS=ON')
             else:
                 options.append('-DENABLE_METIS=OFF')
-
 
         # ExodusII variant
         if '+exodusii' in self.spec:

--- a/var/spack/repos/builtin/packages/mstk/package.py
+++ b/var/spack/repos/builtin/packages/mstk/package.py
@@ -74,8 +74,8 @@ class Mstk(CMakePackage):
     depends_on('unittest-cpp', type='test')
 
     # Unit testing variant
-    depends_on("unittest-cpp", when='+enable_tests')
-    
+    depends_on('unittest-cpp', when='+enable_tests')
+
     def cmake_args(self):
         options = []
         if '+use_markers' in self.spec:

--- a/var/spack/repos/builtin/packages/mstk/package.py
+++ b/var/spack/repos/builtin/packages/mstk/package.py
@@ -73,9 +73,6 @@ class Mstk(CMakePackage):
     # Unit testing variant
     depends_on('unittest-cpp', type='test')
 
-    # Unit testing variant
-    depends_on('unittest-cpp', when='+enable_tests')
-
     def cmake_args(self):
         options = []
         if '+use_markers' in self.spec:

--- a/var/spack/repos/builtin/packages/mstk/package.py
+++ b/var/spack/repos/builtin/packages/mstk/package.py
@@ -25,7 +25,7 @@ class Mstk(CMakePackage):
     git      = "https://github.com/MeshToolkit/MSTK"
     url      = "https://github.com/MeshToolkit/MSTK/archive/3.3.1.tar.gz"
 
-    maintainers = ['julienloiseau','raovgarimella']
+    maintainers = ['raovgarimella','julienloiseau']
 
     version('master', branch='master')
     version('3.3.1', sha256='9fdb0c33c1b68714d708b355d963547cf41332812658d4560d4db43904fc78de')
@@ -42,30 +42,35 @@ class Mstk(CMakePackage):
     version('3.0.1', sha256='d44e4bf01b118b1d19710aa839b3f5f0c1a8391264a435f641ba4bd23bcf45ec')
     version('3.0.0', sha256='d993ff5fc6c431067eb97e4089835c7790397d9c1ad88a56523c0591d451df19')
 
-    variant('parallel', default='none', description='Enable Parallel Support',
-            values=('none', 'metis', 'zoltan', 'parmetis'), multi=True)
     variant('exodusii', default=False, description='Enable ExodusII')
-    variant('use_markers', default=True, description='Enable MSTK to use markers')
-    variant('enable_tests', default=True, description='Enable unit testing')
+    variant('use_markers', default=True, description='Enable use of markers')
+    variant('enable_tests', default=False, description='Enable unit testing')
+    variant('parallel', default=False, description='Enable Parallel Support')
+    variant('partitioner', default='none',
+            values=('none', 'metis', 'zoltan','all'),
+            multi=False, description='Choose partitioner')
+    conflicts('partitioner=none', when='+parallel')
+    conflicts('partitioner=all', when='-parallel')
+    conflicts('partitioner=zoltan', when='-parallel')
 
-    depends_on("cmake@3.8:", type='build')
+    # MSTK turns on METIS only for parallel buildsu
+    conflicts('partitioner=metis', when='-parallel')
 
-    # Parallel variant
-    depends_on("mpi", when='parallel=metis')
-    depends_on("mpi", when='parallel=zoltan')
-    depends_on("mpi", when='parallel=parmetis')
-    depends_on("zoltan -fortran", when='parallel=zoltan')
-    depends_on("zoltan -fortran +parmetis", when='parallel=parmetis')
-    depends_on("zoltan -fortran +parmetis", when="parallel=zoltan +exodusii")
-    depends_on("metis", when="parallel=zoltan +exodusii")
+    # dependencies
+    depends_on('cmake@3.11:', type='build')
 
-    depends_on("metis", when='parallel=metis')
-    depends_on("metis", when='parallel=parmetis')
+    #
+    depends_on('mpi', when='+parallel')
+
+    depends_on('zoltan -fortran', when='partitioner=zoltan')
+    depends_on('zoltan -fortran', when='partitioner=all')
+    depends_on('metis', when='partitioner=metis')
+    depends_on('metis', when='partitioner=all')
+
 
     # Exodusii variant
     # The default exodusii build with mpi support
-    # It includes netcdf which includes hdf5
-    depends_on("exodusii", when='+exodusii')
+    depends_on('exodusii', when='+exodusii')
 
     # Unit testing variant
     depends_on('unittest-cpp', type='test')
@@ -81,29 +86,24 @@ class Mstk(CMakePackage):
             options.append('-DMSTK_USE_MARKERS=OFF')
 
         # Parallel variant
-        if not self.spec.satisfies('parallel=none'):
-            # Use mpi for compilation
-            options.append('-DCMAKE_CXX_COMPILER=' + self.spec['mpi'].mpicxx)
-            options.append('-DCMAKE_C_COMPILER=' + self.spec['mpi'].mpicc)
+        if '+parallel' in self.spec:
             options.append('-DENABLE_PARALLEL=ON')
         else:
             options.append('-DENABLE_PARALLEL=OFF')
 
-        if ("parmetis" in self.spec or "zoltan" in self.spec and
-            "+exodusii" in self.spec):
-            options.append('-DENABLE_METIS=ON')
-            options.append('-DENABLE_ZOLTAN=ON')
-            options.append('-DZOLTAN_NEEDS_ParMETIS=ON')
+        if 'partitioner=none' in self.spec:
+            options.append('-DENABLE_METIS=OFF')
+            options.append('-DENABLE_ZOLTAN=OFF')
         else:
-            if "zoltan" in self.spec:
+            if 'zoltan' or 'all' in self.spec:
                 options.append('-DENABLE_ZOLTAN=ON')
             else:
                 options.append('-DENABLE_ZOLTAN=OFF')
-            if "metis" in self.spec:
+            if 'metis' or 'all' in self.spec:
                 options.append('-DENABLE_METIS=ON')
             else:
                 options.append('-DENABLE_METIS=OFF')
-            options.append('-DZOLTAN_NEEDS_ParMETIS=OFF')
+
 
         # ExodusII variant
         if '+exodusii' in self.spec:
@@ -116,5 +116,5 @@ class Mstk(CMakePackage):
             options.append('-DENABLE_Tests=ON')
         else:
             options.append('-DENABLE_Tests=OFF')
-            
+
         return options

--- a/var/spack/repos/builtin/packages/mstk/package.py
+++ b/var/spack/repos/builtin/packages/mstk/package.py
@@ -27,6 +27,10 @@ class Mstk(CMakePackage):
 
     maintainers = ['raovgarimella', 'julienloiseau']
 
+    def url_for_version(self, version):
+        url = 'https://github.com/MeshToolkit/MSTK/archive/{0}.tar.gz'
+        return url.format(version)
+    
     version('master', branch='master')
     version('3.3.1', sha256='9fdb0c33c1b68714d708b355d963547cf41332812658d4560d4db43904fc78de')
     version('3.3.0', sha256='205c48fb5619937b5dd83788da739b7c2060155b7c41793e29ce05422b8f7dfb')

--- a/var/spack/repos/builtin/packages/mstk/package.py
+++ b/var/spack/repos/builtin/packages/mstk/package.py
@@ -27,6 +27,10 @@ class Mstk(CMakePackage):
 
     maintainers = ['raovgarimella','julienloiseau']
 
+    def url_for_version(self, version):
+        url = 'https://github.com/MeshToolkit/MSTK/archive/{0}.tar.gz'
+        return url.format(version)
+    
     version('master', branch='master')
     version('3.3.1', sha256='9fdb0c33c1b68714d708b355d963547cf41332812658d4560d4db43904fc78de')
     version('3.3.0', sha256='205c48fb5619937b5dd83788da739b7c2060155b7c41793e29ce05422b8f7dfb')

--- a/var/spack/repos/builtin/packages/mstk/package.py
+++ b/var/spack/repos/builtin/packages/mstk/package.py
@@ -25,12 +25,8 @@ class Mstk(CMakePackage):
     git      = "https://github.com/MeshToolkit/MSTK"
     url      = "https://github.com/MeshToolkit/MSTK/archive/3.3.1.tar.gz"
 
-    maintainers = ['raovgarimella','julienloiseau']
+    maintainers = ['raovgarimella', 'julienloiseau']
 
-    def url_for_version(self, version):
-        url = 'https://github.com/MeshToolkit/MSTK/archive/{0}.tar.gz'
-        return url.format(version)
-    
     version('master', branch='master')
     version('3.3.1', sha256='9fdb0c33c1b68714d708b355d963547cf41332812658d4560d4db43904fc78de')
     version('3.3.0', sha256='205c48fb5619937b5dd83788da739b7c2060155b7c41793e29ce05422b8f7dfb')
@@ -48,7 +44,6 @@ class Mstk(CMakePackage):
 
     variant('exodusii', default=False, description='Enable ExodusII')
     variant('use_markers', default=True, description='Enable use of markers')
-    variant('enable_tests', default=False, description='Enable unit testing')
     variant('parallel', default=False, description='Enable Parallel Support')
     variant('partitioner', default='none',
             values=('none', 'metis', 'zoltan','all'),
@@ -116,7 +111,7 @@ class Mstk(CMakePackage):
             options.append('-DENABLE_ExodusII=OFF')
 
         # Unit test variant
-        if '+enable_tests' in self.spec:
+        if self.run_tests:
             options.append('-DENABLE_Tests=ON')
         else:
             options.append('-DENABLE_Tests=OFF')

--- a/var/spack/repos/builtin/packages/mstk/package.py
+++ b/var/spack/repos/builtin/packages/mstk/package.py
@@ -73,6 +73,9 @@ class Mstk(CMakePackage):
     # Unit testing variant
     depends_on('unittest-cpp', type='test')
 
+    # Unit testing variant
+    depends_on("unittest-cpp", when='+enable_tests')
+    
     def cmake_args(self):
         options = []
         if '+use_markers' in self.spec:


### PR DESCRIPTION
Jali is a parallel unstructured mesh infrastructure library designed for use by multi-physics simulations.