### PR TITLE
trnascan-se: add and configure infernal dependency

### DIFF
--- a/var/spack/repos/builtin/packages/trnascan-se/package.py
+++ b/var/spack/repos/builtin/packages/trnascan-se/package.py
@@ -13,3 +13,12 @@ class TrnascanSe(AutotoolsPackage):
     url      = "http://trna.ucsc.edu/software/trnascan-se-2.0.0.tar.gz"
 
     version('2.0.0',    sha256='0dde1c07142e4bf77b21d53ddf3eeb1ef8c52248005a42323d13f8d7c798100c')
+
+    depends_on('infernal@1.1.2', type='run', when='@2.0.0')
+
+    @run_after('install')
+    def setup_infernal(self):
+        with working_dir(self.prefix.bin):
+            filter_file('infernal_dir: {bin_dir}',
+                        'infernal_dir: %s' % self.spec['infernal'].prefix.bin,
+                        'tRNAscan-SE.conf', string=True)

--- a/var/spack/repos/builtin/packages/trnascan-se/package.py
+++ b/var/spack/repos/builtin/packages/trnascan-se/package.py
@@ -16,9 +16,7 @@ class TrnascanSe(AutotoolsPackage):
 
     depends_on('infernal@1.1.2', type='run', when='@2.0.0')
 
-    @run_after('install')
-    def setup_infernal(self):
-        with working_dir(self.prefix.bin):
-            filter_file('infernal_dir: {bin_dir}',
-                        'infernal_dir: %s' % self.spec['infernal'].prefix.bin,
-                        'tRNAscan-SE.conf', string=True)
+    def patch(self):
+        filter_file('infernal_dir: {bin_dir}',
+                    'infernal_dir: %s' % self.spec['infernal'].prefix.bin,
+                    'tRNAscan-SE.conf.src', string=True)


### PR DESCRIPTION
trnascan-se needs an infernal installation to function properly. This adds infernal as a dep and configures the path to the installation in the tRNAscan config.