### PR TITLE
Update and fix bcftools package

### DIFF
--- a/var/spack/repos/builtin/packages/bcftools/fix_mk.patch
+++ b/var/spack/repos/builtin/packages/bcftools/fix_mk.patch
@@ -1,0 +1,16 @@
+diff -ru a/plugins/fixploidy.mk b/plugins/fixploidy.mk
+--- a/plugins/fixploidy.mk	2014-10-09 04:01:22.000000000 -0500
++++ b/plugins/fixploidy.mk	2020-01-13 21:55:28.926309796 -0600
+@@ -1,2 +1,2 @@
+-plugins/fixploidy.so: plugins/fixploidy.c version.h version.c ploidy.h ploidy.c $(HTSDIR)/libhts.so
+-	$(CC) $(CFLAGS) $(INCLUDES) -fPIC -shared -o $@ ploidy.c version.c $< -L$(HTSDIR) -lhts
++plugins/fixploidy.so: plugins/fixploidy.c version.h version.c ploidy.h ploidy.c
++	$(CC) $(CFLAGS) $(INCLUDES) -fPIC -shared -o $@ ploidy.c version.c $< $(HTSLIB)
+diff -ru a/plugins/vcf2sex.mk b/plugins/vcf2sex.mk
+--- a/plugins/vcf2sex.mk	2014-10-09 04:01:22.000000000 -0500
++++ b/plugins/vcf2sex.mk	2020-01-13 21:55:55.056277406 -0600
+@@ -1,2 +1,2 @@
+-plugins/vcf2sex.so: plugins/vcf2sex.c version.h version.c ploidy.h ploidy.c $(HTSDIR)/libhts.so
+-	$(CC) $(CFLAGS) $(INCLUDES) -fPIC -shared -o $@ ploidy.c version.c $< -L$(HTSDIR) -lhts
++plugins/vcf2sex.so: plugins/vcf2sex.c version.h version.c ploidy.h ploidy.c
++	$(CC) $(CFLAGS) $(INCLUDES) -fPIC -shared -o $@ ploidy.c version.c $< $(HTSLIB)

--- a/var/spack/repos/builtin/packages/bcftools/guess-ploidy.py_2to3.patch
+++ b/var/spack/repos/builtin/packages/bcftools/guess-ploidy.py_2to3.patch
@@ -1,0 +1,13 @@
+--- a/misc/guess-ploidy.py	2017-04-07 04:52:44.000000000 -0500
++++ b/misc/guess-ploidy.py	2020-01-14 10:59:49.738128654 -0600
+@@ -33,8 +33,8 @@
+ csv.register_dialect('tab', delimiter='\t', quoting=csv.QUOTE_NONE)
+ 
+ if len(sys.argv) != 3:
+-    print >> sys.stderr, 'About: Plot output of "bcftools +guess-ploidy -v"'
+-    print >> sys.stderr, 'Usage: guess-ploidy.py <guess-ploidy.out> <image-prefix>'
++    print('About: Plot output of "bcftools +guess-ploidy -v"', file=sys.stderr)
++    print('Usage: guess-ploidy.py <guess-ploidy.out> <image-prefix>', file=sys.stderr)
+     sys.exit()
+ 
+ prefix = sys.argv[2]

--- a/var/spack/repos/builtin/packages/bcftools/makefile_12.patch
+++ b/var/spack/repos/builtin/packages/bcftools/makefile_12.patch
@@ -1,0 +1,109 @@
+--- a/Makefile	2015-02-03 10:27:19.000000000 -0600
++++ b/Makefile	2020-01-13 21:22:54.554904229 -0600
+@@ -30,10 +30,11 @@
+ 
+ # Adjust $(HTSDIR) to point to your top-level htslib directory
+ HTSDIR = htslib-1.2.1
+-include $(HTSDIR)/htslib.mk
+-HTSLIB = $(HTSDIR)/libhts.a
+-BGZIP  = $(HTSDIR)/bgzip
+-TABIX  = $(HTSDIR)/tabix
++#include $(HTSDIR)/htslib.mk
++HTSINC = $(HTSDIR)/include
++HTSLIB = -L$(HTSDIR)/lib -lhts
++BGZIP  = $(HTSDIR)/bin/bgzip
++TABIX  = $(HTSDIR)/bin/tabix
+ 
+ CC       = gcc
+ CFLAGS   = -g -Wall -Wc++-compat -O2
+@@ -44,7 +45,7 @@
+            vcfcall.o mcall.o vcmp.o gvcf.o reheader.o convert.o vcfconvert.o tsv2vcf.o \
+            vcfcnv.o HMM.o vcfplugin.o consensus.o ploidy.o version.o \
+            ccall.o em.o prob1.o kmin.o # the original samtools calling
+-INCLUDES = -I. -I$(HTSDIR)
++INCLUDES = -I. -I$(HTSINC)
+ 
+ # The polysomy command is not compiled by default because it brings dependency
+ # on libgsl. The command can be compiled wth `make USE_GPL=1`. See the INSTALL
+@@ -52,7 +53,7 @@
+ ifdef USE_GPL
+     CFLAGS += -DUSE_GPL
+     OBJS   += polysomy.o
+-    LDLIBS  = -lgsl -lcblas
++    LDLIBS  = -lgsl -lgslcblas
+ endif
+ 
+ prefix      = /usr/local
+@@ -102,8 +103,8 @@
+ PLUGINS = $(PLUGINC:.c=.so)
+ PLUGINM = $(PLUGINC:.c=.mk)
+ 
+-%.so: %.c version.h version.c $(HTSDIR)/libhts.so
+-	$(CC) $(CFLAGS) $(INCLUDES) -fPIC -shared -o $@ version.c $< -L$(HTSDIR) -lhts
++%.so: %.c version.h version.c
++	$(CC) $(CFLAGS) $(INCLUDES) -fPIC -shared -o $@ version.c $< $(HTSLIB)
+ 
+ -include $(PLUGINM)
+ 
+@@ -116,20 +117,20 @@
+ tsv2vcf_h = tsv2vcf.h $(htslib_vcf_h)
+ filter_h = filter.h $(htslib_vcf_h)
+ prob1_h = prob1.h $(htslib_vcf_h) $(call_h)
+-roh_h = HMM.h $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(HTSDIR)/htslib/kstring.h $(HTSDIR)/htslib/kseq.h $(bcftools_h)
++roh_h = HMM.h $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(HTSINC)/htslib/kstring.h $(HTSINC)/htslib/kseq.h $(bcftools_h)
+ cnv_h = HMM.h $(htslib_vcf_h) $(htslib_synced_bcf_reader_h)
+ 
+ main.o: main.c $(htslib_hts_h) version.h $(bcftools_h)
+-vcfannotate.o: vcfannotate.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(HTSDIR)/htslib/kseq.h $(bcftools_h) vcmp.h $(filter_h)
+-vcfplugin.o: vcfplugin.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(HTSDIR)/htslib/kseq.h $(bcftools_h) vcmp.h $(filter_h)
+-vcfcall.o: vcfcall.c $(htslib_vcf_h) $(HTSDIR)/htslib/kfunc.h $(htslib_synced_bcf_reader_h) $(bcftools_h) $(call_h) $(prob1_h)
+-vcfconcat.o: vcfconcat.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(HTSDIR)/htslib/kseq.h $(bcftools_h)
++vcfannotate.o: vcfannotate.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(HTSINC)/htslib/kseq.h $(bcftools_h) vcmp.h $(filter_h)
++vcfplugin.o: vcfplugin.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(HTSINC)/htslib/kseq.h $(bcftools_h) vcmp.h $(filter_h)
++vcfcall.o: vcfcall.c $(htslib_vcf_h) $(HTSINC)/htslib/kfunc.h $(htslib_synced_bcf_reader_h) $(bcftools_h) $(call_h) $(prob1_h)
++vcfconcat.o: vcfconcat.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(HTSINC)/htslib/kseq.h $(bcftools_h)
+ vcfconvert.o: vcfconvert.c $(htslib_vcf_h) $(htslib_bgzf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h) $(filter_h) $(convert_h) $(tsv2vcf_h)
+ vcffilter.o: vcffilter.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h) $(filter_h) rbuf.h
+ vcfgtcheck.o: vcfgtcheck.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h)
+ vcfindex.o: vcfindex.c $(htslib_vcf_h) $(htslib_tbx_h)
+ vcfisec.o: vcfisec.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h) $(filter_h)
+-vcfmerge.o: vcfmerge.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h) vcmp.h $(HTSDIR)/htslib/khash.h
++vcfmerge.o: vcfmerge.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h) vcmp.h $(HTSINC)/htslib/khash.h
+ vcfnorm.o: vcfnorm.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_faidx_h) $(bcftools_h) rbuf.h
+ vcfquery.o: vcfquery.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h) $(filter_h) $(convert_h)
+ vcfroh.o: vcfroh.c $(roh_h)
+@@ -137,20 +138,20 @@
+ vcfsom.o: vcfsom.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h)
+ vcfstats.o: vcfstats.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(htslib_faidx_h) $(bcftools_h)
+ vcfview.o: vcfview.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h) $(filter_h)
+-reheader.o: reheader.c $(htslib_vcf_h) $(htslib_bgzf_h) $(HTSDIR)/htslib/kseq.h $(bcftools_h)
++reheader.o: reheader.c $(htslib_vcf_h) $(htslib_bgzf_h) $(HTSINC)/htslib/kseq.h $(bcftools_h)
+ tabix.o: tabix.c $(htslib_bgzf_h) $(htslib_tbx_h)
+-ccall.o: ccall.c $(HTSDIR)/htslib/kfunc.h $(call_h) kmin.h $(prob1_h)
++ccall.o: ccall.c $(HTSINC)/htslib/kfunc.h $(call_h) kmin.h $(prob1_h)
+ convert.o: convert.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h) $(convert_h)
+ tsv2vcf.o: tsv2vcf.c $(tsv2vcf_h)
+ em.o: em.c $(htslib_vcf_h) kmin.h $(call_h)
+-filter.o: filter.c $(HTSDIR)/htslib/khash_str2int.h $(filter_h) $(bcftools_h) $(htslib_hts_defs_h) $(htslib_vcfutils_h)
++filter.o: filter.c $(HTSINC)/htslib/khash_str2int.h $(filter_h) $(bcftools_h) $(htslib_hts_defs_h) $(htslib_vcfutils_h)
+ gvcf.o: gvcf.c $(call_h)
+ kmin.o: kmin.c kmin.h
+-mcall.o: mcall.c $(HTSDIR)/htslib/kfunc.h $(call_h)
++mcall.o: mcall.c $(HTSINC)/htslib/kfunc.h $(call_h)
+ prob1.o: prob1.c $(prob1_h)
+ vcmp.o: vcmp.c $(htslib_hts_h) vcmp.h
+ polysomy.o: polysomy.c $(htslib_hts_h)
+-consensus.o: consensus.c $(htslib_hts_h) $(HTSDIR)/htslib/kseq.h rbuf.h $(bcftools_h) $(HTSDIR)/htslib/regidx.h
++consensus.o: consensus.c $(htslib_hts_h) $(HTSINC)/htslib/kseq.h rbuf.h $(bcftools_h) $(HTSINC)/htslib/regidx.h
+ version.o: version.h version.c
+ 
+ test/test-rbuf.o: test/test-rbuf.c rbuf.h
+@@ -158,7 +159,7 @@
+ test/test-rbuf: test/test-rbuf.o
+ 	$(CC) $(CFLAGS) -o $@ -lm -ldl $<
+ 
+-bcftools: $(HTSLIB) $(OBJS)
++bcftools: $(OBJS)
+ 	$(CC) $(CFLAGS) -o $@ $(OBJS) $(HTSLIB) -lpthread -lz -lm -ldl $(LDLIBS)
+ 
+ doc/bcftools.1: doc/bcftools.txt

--- a/var/spack/repos/builtin/packages/bcftools/makefile_13.patch
+++ b/var/spack/repos/builtin/packages/bcftools/makefile_13.patch
@@ -1,0 +1,102 @@
+--- a/Makefile	2016-10-02 21:23:39.289320362 -0500
++++ b/Makefile	2016-10-02 21:30:41.163562704 -0500
+@@ -30,10 +30,11 @@
+ 
+ # Adjust $(HTSDIR) to point to your top-level htslib directory
+ HTSDIR = htslib-1.3.1
+-include $(HTSDIR)/htslib.mk
+-HTSLIB = $(HTSDIR)/libhts.a
+-BGZIP  = $(HTSDIR)/bgzip
+-TABIX  = $(HTSDIR)/tabix
++#include $(HTSDIR)/htslib.mk
++HTSINC = $(HTSDIR)/include
++HTSLIB = -L$(HTSDIR)/lib -lhts
++BGZIP  = $(HTSDIR)/bin/bgzip
++TABIX  = $(HTSDIR)/bin/tabix
+ 
+ CC       = gcc
+ CPPFLAGS =
+@@ -48,7 +49,7 @@
+            vcfcnv.o HMM.o vcfplugin.o consensus.o ploidy.o version.o \
+            ccall.o em.o prob1.o kmin.o # the original samtools calling
+ 
+-EXTRA_CPPFLAGS = -I. -I$(HTSDIR) -DPLUGINPATH=\"$(pluginpath)\"
++EXTRA_CPPFLAGS = -I. -I$(HTSINC) -DPLUGINPATH=\"$(pluginpath)\"
+ GSL_LIBS       =
+ 
+ # The polysomy command is not compiled by default because it brings dependency
+@@ -57,7 +58,7 @@
+ ifdef USE_GPL
+     EXTRA_CPPFLAGS += -DUSE_GPL
+     OBJS += polysomy.o peakfit.o
+-    GSL_LIBS = -lgsl -lcblas
++    GSL_LIBS = -lgsl -lgslcblas
+ endif
+ 
+ prefix      = /usr/local
+@@ -136,20 +137,20 @@
+ filter_h = filter.h $(htslib_vcf_h)
+ ploidy_h = ploidy.h $(htslib_regidx_h)
+ prob1_h = prob1.h $(htslib_vcf_h) $(call_h)
+-roh_h = HMM.h $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(HTSDIR)/htslib/kstring.h $(HTSDIR)/htslib/kseq.h $(bcftools_h)
++roh_h = HMM.h $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(HTSINC)/htslib/kstring.h $(HTSINC)/htslib/kseq.h $(bcftools_h)
+ cnv_h = HMM.h $(htslib_vcf_h) $(htslib_synced_bcf_reader_h)
+ 
+ main.o: main.c $(htslib_hts_h) version.h $(bcftools_h)
+-vcfannotate.o: vcfannotate.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(HTSDIR)/htslib/kseq.h $(bcftools_h) vcmp.h $(filter_h)
+-vcfplugin.o: vcfplugin.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(HTSDIR)/htslib/kseq.h $(bcftools_h) vcmp.h $(filter_h)
+-vcfcall.o: vcfcall.c $(htslib_vcf_h) $(HTSDIR)/htslib/kfunc.h $(htslib_synced_bcf_reader_h) $(HTSDIR)/htslib/khash_str2int.h $(bcftools_h) $(call_h) $(prob1_h) $(ploidy_h)
+-vcfconcat.o: vcfconcat.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(HTSDIR)/htslib/kseq.h $(htslib_bgzf_h) $(htslib_tbx_h) $(bcftools_h)
++vcfannotate.o: vcfannotate.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(HTSINC)/htslib/kseq.h $(bcftools_h) vcmp.h $(filter_h)
++vcfplugin.o: vcfplugin.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(HTSINC)/htslib/kseq.h $(bcftools_h) vcmp.h $(filter_h)
++vcfcall.o: vcfcall.c $(htslib_vcf_h) $(HTSINC)/htslib/kfunc.h $(htslib_synced_bcf_reader_h) $(HTSINC)/htslib/khash_str2int.h $(bcftools_h) $(call_h) $(prob1_h) $(ploidy_h)
++vcfconcat.o: vcfconcat.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(HTSINC)/htslib/kseq.h $(htslib_bgzf_h) $(htslib_tbx_h) $(bcftools_h)
+ vcfconvert.o: vcfconvert.c $(htslib_vcf_h) $(htslib_bgzf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h) $(filter_h) $(convert_h) $(tsv2vcf_h)
+ vcffilter.o: vcffilter.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h) $(filter_h) rbuf.h
+ vcfgtcheck.o: vcfgtcheck.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h)
+ vcfindex.o: vcfindex.c $(htslib_vcf_h) $(htslib_tbx_h)
+ vcfisec.o: vcfisec.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h) $(filter_h)
+-vcfmerge.o: vcfmerge.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h) vcmp.h $(HTSDIR)/htslib/khash.h
++vcfmerge.o: vcfmerge.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h) vcmp.h $(HTSINC)/htslib/khash.h
+ vcfnorm.o: vcfnorm.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_faidx_h) $(bcftools_h) rbuf.h
+ vcfquery.o: vcfquery.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h) $(filter_h) $(convert_h)
+ vcfroh.o: vcfroh.c $(roh_h)
+@@ -157,22 +158,22 @@
+ vcfsom.o: vcfsom.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h)
+ vcfstats.o: vcfstats.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(htslib_faidx_h) $(bcftools_h)
+ vcfview.o: vcfview.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h) $(filter_h)
+-reheader.o: reheader.c $(htslib_vcf_h) $(htslib_bgzf_h) $(htslib_tbx_h) $(HTSDIR)/htslib/kseq.h $(bcftools_h)
++reheader.o: reheader.c $(htslib_vcf_h) $(htslib_bgzf_h) $(htslib_tbx_h) $(HTSINC)/htslib/kseq.h $(bcftools_h)
+ tabix.o: tabix.c $(htslib_bgzf_h) $(htslib_tbx_h)
+-ccall.o: ccall.c $(HTSDIR)/htslib/kfunc.h $(call_h) kmin.h $(prob1_h)
++ccall.o: ccall.c $(HTSINC)/htslib/kfunc.h $(call_h) kmin.h $(prob1_h)
+ convert.o: convert.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h) $(convert_h)
+ tsv2vcf.o: tsv2vcf.c $(tsv2vcf_h)
+ em.o: em.c $(htslib_vcf_h) kmin.h $(call_h)
+-filter.o: filter.c $(HTSDIR)/htslib/khash_str2int.h $(filter_h) $(bcftools_h) $(htslib_hts_defs_h) $(htslib_vcfutils_h)
++filter.o: filter.c $(HTSINC)/htslib/khash_str2int.h $(filter_h) $(bcftools_h) $(htslib_hts_defs_h) $(htslib_vcfutils_h)
+ gvcf.o: gvcf.c $(call_h)
+ kmin.o: kmin.c kmin.h
+-mcall.o: mcall.c $(HTSDIR)/htslib/kfunc.h $(call_h)
++mcall.o: mcall.c $(HTSINC)/htslib/kfunc.h $(call_h)
+ prob1.o: prob1.c $(prob1_h)
+ vcmp.o: vcmp.c $(htslib_hts_h) vcmp.h
+-ploidy.o: ploidy.c $(htslib_regidx_h) $(HTSDIR)/htslib/khash_str2int.h $(HTSDIR)/htslib/kseq.h $(htslib_hts_h) $(bcftools_h) $(ploidy_h)
++ploidy.o: ploidy.c $(htslib_regidx_h) $(HTSINC)/htslib/khash_str2int.h $(HTSINC)/htslib/kseq.h $(htslib_hts_h) $(bcftools_h) $(ploidy_h)
+ polysomy.o: polysomy.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(bcftools_h) peakfit.h
+-peakfit.o: peakfit.c peakfit.h $(htslib_hts_h) $(HTSDIR)/htslib/kstring.h
+-consensus.o: consensus.c $(htslib_hts_h) $(HTSDIR)/htslib/kseq.h rbuf.h $(bcftools_h) $(HTSDIR)/htslib/regidx.h
++peakfit.o: peakfit.c peakfit.h $(htslib_hts_h) $(HTSINC)/htslib/kstring.h
++consensus.o: consensus.c $(htslib_hts_h) $(HTSINC)/htslib/kseq.h rbuf.h $(bcftools_h) $(HTSINC)/htslib/regidx.h
+ version.o: version.h version.c
+ 
+ test/test-rbuf.o: test/test-rbuf.c rbuf.h
+@@ -180,7 +181,7 @@
+ test/test-rbuf: test/test-rbuf.o
+ 	$(CC) $(LDFLAGS) -o $@ $^ -lm $(LIBS)
+ 
+-bcftools: $(HTSLIB) $(OBJS)
++bcftools: $(OBJS)
+ 	$(CC) -rdynamic $(LDFLAGS) -o $@ $(OBJS) $(HTSLIB) -lpthread -lz -lm -ldl $(GSL_LIBS) $(LIBS)
+ 
+ doc/bcftools.1: doc/bcftools.txt

--- a/var/spack/repos/builtin/packages/bcftools/makefile_14.patch
+++ b/var/spack/repos/builtin/packages/bcftools/makefile_14.patch
@@ -1,0 +1,64 @@
+--- a/Makefile	2017-03-13 09:55:48.000000000 -0500
++++ b/Makefile	2020-01-13 17:42:49.359554802 -0600
+@@ -30,13 +30,14 @@
+ 
+ # Adjust $(HTSDIR) to point to your top-level htslib directory
+ HTSDIR = htslib-1.4
+-include $(HTSDIR)/htslib.mk
+-include $(HTSDIR)/htslib_static.mk
+-HTSLIB = $(HTSDIR)/libhts.a
+-BGZIP  = $(HTSDIR)/bgzip
+-TABIX  = $(HTSDIR)/tabix
+-HTSLIB_LDFLAGS = $(HTSLIB_static_LDFLAGS)
+-HTSLIB_LIBS = $(HTSLIB_static_LIBS)
++#include $(HTSDIR)/htslib.mk
++#include $(HTSDIR)/htslib_static.mk
++HTSINC = $(HTSDIR)/include
++HTSLIB = -L$(HTSDIR)/lib -lhts
++BGZIP  = $(HTSDIR)/bin/bgzip
++TABIX  = $(HTSDIR)/bin/tabix
++#HTSLIB_LDFLAGS = $(HTSLIB_static_LDFLAGS)
++#HTSLIB_LIBS = $(HTSLIB_static_LIBS)
+ 
+ CC       = gcc
+ CPPFLAGS =
+@@ -51,7 +52,7 @@
+ endif
+ 
+ # TODO Use configure or htslib.pc to add -rdynamic/-ldl conditionally
+-ALL_CPPFLAGS = -I. $(HTSLIB_CPPFLAGS) $(CPPFLAGS)
++ALL_CPPFLAGS = -I. -I$(HTSINC)
+ ALL_LDFLAGS  = $(DYNAMIC_FLAGS) $(HTSLIB_LDFLAGS) $(LDFLAGS)
+ ALL_LIBS     = -lm -lz -ldl $(LIBS)
+ 
+@@ -64,7 +65,7 @@
+            mpileup.o bam2bcf.o bam2bcf_indel.o bam_sample.o \
+            ccall.o em.o prob1.o kmin.o # the original samtools calling
+ 
+-EXTRA_CPPFLAGS = -I. -I$(HTSDIR) -DPLUGINPATH=\"$(pluginpath)\"
++EXTRA_CPPFLAGS = -I. -I$(HTSINC) -DPLUGINPATH=\"$(pluginpath)\"
+ GSL_LIBS       =
+ 
+ # The polysomy command is not compiled by default because it brings dependency
+@@ -73,7 +74,7 @@
+ ifdef USE_GPL
+     EXTRA_CPPFLAGS += -DUSE_GPL
+     OBJS += polysomy.o peakfit.o
+-    GSL_LIBS = -lgsl -lcblas
++    GSL_LIBS = -lgsl -lgslcblas
+ endif
+ 
+ prefix      = /usr/local
+@@ -208,10 +209,10 @@
+ 
+ test/test-regidx.o: test/test-regidx.c regidx.h
+ 
+-test/test-regidx: test/test-regidx.o regidx.o $(HTSLIB)
++test/test-regidx: test/test-regidx.o regidx.o
+ 	$(CC) $(ALL_LDFLAGS) -o $@ $^ $(HTSLIB) -lpthread $(HTSLIB_LIBS) $(ALL_LIBS)
+ 
+-bcftools: $(HTSLIB) $(OBJS)
++bcftools: $(OBJS)
+ 	$(CC) $(ALL_LDFLAGS) -o $@ $(OBJS) $(HTSLIB) -lpthread $(HTSLIB_LIBS) $(GSL_LIBS) $(ALL_LIBS)
+ 
+ doc/bcftools.1: doc/bcftools.txt

--- a/var/spack/repos/builtin/packages/bcftools/package.py
+++ b/var/spack/repos/builtin/packages/bcftools/package.py
@@ -95,7 +95,7 @@ class Bcftools(AutotoolsPackage):
     @when('@1.2:1.4')
     def install(self, spec, prefix):
         make_options = self.set_make_options()
-        make(*make_options, 'install')
+        make('install', *make_options)
 
         if spec.satisfies('@1.2'):
             mkdirp(self.prefix.libexec.bcftools)

--- a/var/spack/repos/builtin/packages/bcftools/package.py
+++ b/var/spack/repos/builtin/packages/bcftools/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+import glob
 
 
 class Bcftools(AutotoolsPackage):
@@ -15,6 +16,7 @@ class Bcftools(AutotoolsPackage):
     homepage = "http://samtools.github.io/bcftools/"
     url      = "https://github.com/samtools/bcftools/releases/download/1.3.1/bcftools-1.3.1.tar.bz2"
 
+    version('1.10.2', sha256='f57301869d0055ce3b8e26d8ad880c0c1989bf25eaec8ea5db99b60e31354e2c')
     version('1.9', sha256='6f36d0e6f16ec4acf88649fb1565d443acf0ba40f25a9afd87f14d14d13070c8')
     version('1.8', sha256='4acbfd691f137742e0be63d09f516434f0faf617a5c60f466140e0677915fced')
     version('1.7', sha256='dd4f63d91b0dffb0f0ce88ac75c2387251930c8063f7799611265083f8d302d1')
@@ -23,8 +25,22 @@ class Bcftools(AutotoolsPackage):
     version('1.3.1', sha256='12c37a4054cbf1980223e2b3a80a7fdb3fd850324a4ba6832e38fdba91f1b924')
     version('1.2', sha256='53c628339020dd45334a007c9cefdaf1cba3f1032492ec813b116379fa684fd6')
 
-    depends_on('libzip', when='@1.8:')
+    variant('libgsl',
+            default=False,
+            description='build options that require the GNU scientific '
+            'library')
 
+    variant('perl-filters',
+            default=False,
+            description='build in support for PERL scripts in -i/-e '
+            'filtering expressions, for @1.8:')
+
+    depends_on('gsl', when='+libgsl')
+    depends_on('py-matplotlib', when='@1.6:', type='run')
+    depends_on('perl', when='@1.8:~perl-filters', type='run')
+    depends_on('perl', when='@1.8:+perl-filters', type=('build', 'run'))
+
+    depends_on('htslib@1.10.2', when='@1.10.2')
     depends_on('htslib@1.9', when='@1.9')
     depends_on('htslib@1.8', when='@1.8')
     depends_on('htslib@1.7',   when='@1.7')
@@ -33,8 +49,59 @@ class Bcftools(AutotoolsPackage):
     depends_on('htslib@1.3.1', when='@1.3.1')
     depends_on('htslib@1.2', when='@1.2')
 
+    patch('makefile_12.patch', when='@1.2')
+    patch('fix_mk.patch', when='@1.2')
+    patch('makefile_13.patch', when='@1.3')
+    patch('makefile_14.patch', when='@1.4')
+    patch('guess-ploidy.py_2to3.patch', when='@1.6:1.9')
+
+    @when('@1.5:')
     def configure_args(self):
         args = []
+
         args.append('--with-htslib={0}'.format(self.spec['htslib'].prefix))
+        args.extend(self.enable_or_disable('libgsl'))
+
+        if self.spec.satisfies('@1.8:'):
+            args.extend(self.enable_or_disable('perl-filters'))
 
         return args
+
+    @when('@1.2:1.4')
+    def set_make_options(self):
+        options = []
+
+        options.append('prefix={0}'.format(self.prefix))
+        options.append('HTSDIR={0}'.format(self.spec['htslib'].prefix))
+
+        if '+libgsl' in self.spec:
+            options.append('USE_GPL=1')
+
+        return options
+
+    @when('@1.2:1.4')
+    def autoreconf(self, spec, prefix):
+        touch('configure')
+
+    @when('@1.2:1.4')
+    def configure(self, spec, prefix):
+        pass
+
+    @when('@1.2:1.4')
+    def build(self, spec, prefix):
+        make_options = self.set_make_options()
+        make(*make_options)
+
+    @when('@1.2:1.4')
+    def install(self, spec, prefix):
+        make_options = self.set_make_options()
+        make(*make_options, 'install')
+
+        if spec.satisfies('@1.2'):
+            mkdirp(self.prefix.libexec.bcftools)
+            for files in glob.glob('plugins/*.so'):
+                install(files, self.prefix.libexec.bcftools)
+
+    @when('@1.2')
+    def setup_run_environment(self, env):
+        env.set('BCFTOOLS_PLUGINS', self.prefix.libexec.bcftools)

--- a/var/spack/repos/builtin/packages/bcftools/package.py
+++ b/var/spack/repos/builtin/packages/bcftools/package.py
@@ -33,7 +33,7 @@ class Bcftools(AutotoolsPackage):
     variant('perl-filters',
             default=False,
             description='build in support for PERL scripts in -i/-e '
-            'filtering expressions, for @1.8:')
+            'filtering expressions, for versions >= 1.8.')
 
     depends_on('gsl', when='+libgsl')
     depends_on('py-matplotlib', when='@1.6:', type='run')


### PR DESCRIPTION
This PR updates bcftools to 1.10.2 and is dependent on PR #14504.

This PR also fixes builds of other versions. Versions 1.2-1.4 did not
use autotools so when the packaeg was converted to use autotools with
version 1.6 those older versions could no longer build. Also, those
versions needed to be patched to use an external htsllib. The method of
finding the external htslib is also different for those older versions.

In addition, this PR adds two variants to bcftools:

- libgsl
- perl-filters

Finally, dependencies for perl and python are added, and an unused
dependency for libzip was removed.