### PR TITLE
openmpi: swat btl/uct ucx 1.7 bug

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -75,6 +75,8 @@ class Openmpi(AutotoolsPackage):
     list_url = "http://www.open-mpi.org/software/ompi/"
     git = "https://github.com/open-mpi/ompi.git"
 
+    maintainers = ['hppritcha']
+
     version('develop', branch='master')
 
     # Current
@@ -424,6 +426,10 @@ class Openmpi(AutotoolsPackage):
 
         if spec.satisfies('@3.0.0:', strict=True):
             config_args.append('--with-zlib={0}'.format(spec['zlib'].prefix))
+
+        if spec.satisfies('@4.0.0:4.0.2'):
+            # uct btl doesn't work with some UCX versions so just disable
+            config_args.append('--enable-mca-no-build=btl-uct')
 
         # some scientific packages ignore deprecated/remove symbols. Re-enable
         # them for now, for discussion see


### PR DESCRIPTION
Unfortunately UCX 1.7.0 is appearing in RPMS before it's officially released.
There's a problem with Open MPI 4.0.x where x < 3 and this version of UCX,
namely that the UCT BTL fails to compile.

See https://github.com/open-mpi/ompi/issues/7128

This patch works around the problem by disabling the build of the UCT BTL
for releases 4.0.0 to 4.0.2.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>