### PR TITLE
unifyfs: new release version

### DIFF
--- a/var/spack/repos/builtin/packages/unifyfs/package.py
+++ b/var/spack/repos/builtin/packages/unifyfs/package.py
@@ -16,11 +16,11 @@ class Unifyfs(AutotoolsPackage):
 
     homepage = "https://github.com/LLNL/UnifyFS"
     git      = "https://github.com/LLNL/UnifyFS.git"
-    url      = "https://github.com/LLNL/UnifyFS/releases/download/v0.2.0/unifycr-0.2.0.tar.gz"
+    url      = "https://github.com/LLNL/UnifyFS/releases/download/v0.9.0/unifyfs-0.9.0.tar.gz"
     maintainers = ['CamStan']
 
     version('develop', branch='dev', preferred=True)
-    version('0.2.0', sha256='7439b0e885234bc64e8cbb449d8abfadd386692766b6f00647a7b6435efb2066')
+    version('0.9.0', sha256='e6c73e22ef1c23f3141646aa17058b69c1c4e526886771f8fe982da924265b0f')
 
     variant('hdf5', default='False', description='Build with parallel HDF5 (install with `^hdf5~mpi` for serial)')
     variant('fortran', default='False', description='Build with gfortran support')


### PR DESCRIPTION
This updates the UnifyFS package to account for the latest 0.9.0 version and removes support for version 0.2.0.