### PR TITLE
falcon: Set Py_None to return value

### DIFF
--- a/var/spack/repos/builtin/packages/falcon/Py_None.patch
+++ b/var/spack/repos/builtin/packages/falcon/Py_None.patch
@@ -1,0 +1,10 @@
+--- spack-src/src/c/ext_falcon.c.org	2020-01-15 17:40:41.279400137 +0900
++++ spack-src/src/c/ext_falcon.c	2020-01-15 17:44:47.785718088 +0900
+@@ -9,5 +9,6 @@
+ 
+     m = Py_InitModule("ext_falcon", SpamMethods);
+     if (m == NULL)
+-        return;
++        Py_INCREF(Py_None);
++        return Py_None;
+ }

--- a/var/spack/repos/builtin/packages/falcon/package.py
+++ b/var/spack/repos/builtin/packages/falcon/package.py
@@ -28,3 +28,7 @@ class Falcon(PythonPackage):
     depends_on('pacbio-daligner', type='run')
     depends_on('pacbio-dextractor', type='run')
     depends_on('pacbio-damasker', type='run')
+
+    # Python version 3 and later should return
+    # a value of PyObject type. [-Wreturn-type]
+    patch('Py_None.patch', when='^python@3:')


### PR DESCRIPTION
error: 
`non-void function 'initext_falcon' should return a value [-Wreturn-type]`

I set Py_None to return value because Python version 3 and later should return a value of PyObject type.