### PR TITLE
perl: Fix binary detection

### DIFF
--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -305,7 +305,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         Returns:
             Executable: the Perl command
         """
-        for ver in (self.spec.version, ''):
+        for ver in ('', self.spec.version):
             path = os.path.join(self.prefix.bin, '{0}{1}'.format(
                 self.spec.name, ver))
             if os.path.exists(path):


### PR DESCRIPTION
Looks like I broke something with #14509. :frowning_face: Sorry I did not catch this earlier.

It seems that stable versions of perl also install a `perlX.Y.Z` binary. However, it seems that this binary can hang if used in conjunction with Spack's sbang workaround, as observed during automake's build.

@adamjstewart