### PR TITLE
sbang: Fix perl binary detection

### DIFF
--- a/bin/sbang
+++ b/bin/sbang
@@ -103,10 +103,10 @@ interpreter_f="${interpreter_v[0]}"
 
 # Invoke any interpreter found, or raise an error if none was found.
 if [[ -n "$interpreter_f" ]]; then
-    if [[ "${interpreter_f##*/}" = "perl" ]]; then
-        exec $interpreter_v -x "$@"
+    if [[ "${interpreter_f##*/}" = "perl"* ]]; then
+        exec $interpreter -x "$@"
     else
-        exec $interpreter_v "$@"
+        exec $interpreter "$@"
     fi
 else
     echo "error: sbang found no interpreter in $script"


### PR DESCRIPTION
The perl binary can also be called `perlX.Y.Z` if using a development build or simply using the versioned binary.

We were also dropping all sbang arguments, since `exec $interpreter_v` was only using the first element of the `interpreter_v` array.

This fixes the underlying problem of #14536. We should still apply #14536 to be on the safe side, though.