### PR TITLE
Use CudaPackage mixin for py-torch

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -7,7 +7,7 @@ from spack import *
 
 
 # TODO: try switching to CMakePackage for more control over build
-class PyTorch(PythonPackage):
+class PyTorch(PythonPackage, CudaPackage):
     """Tensors and Dynamic neural networks in Python
     with strong GPU acceleration."""
 
@@ -61,7 +61,6 @@ class PyTorch(PythonPackage):
     version('0.4.0', tag='v0.4.0', submodules=True)
     version('0.3.1', tag='v0.3.1', submodules=True)
 
-    variant('cuda', default=True, description='Enables CUDA build')
     variant('cudnn', default=True, description='Enables the cuDNN build')
     variant('magma', default=False, description='Enables the MAGMA build')
     variant('fbgemm', default=False, description='Enables the FBGEMM build')


### PR DESCRIPTION
This PR adds CudaPackage in order to pick up the cuda/compiler conflicts
defined in CudaPackage.