### PR TITLE
Add py-torch 1.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -51,6 +51,7 @@ class PyTorch(PythonPackage, CudaPackage):
     ]
 
     version('master', branch='master', submodules=True)
+    version('1.4.0', tag='v1.4.0', submodules=True)
     version('1.3.1', tag='v1.3.1', submodules=True)
     version('1.3.0', tag='v1.3.0', submodules=True)
     version('1.2.0', tag='v1.2.0', submodules=True)


### PR DESCRIPTION
Successfully builds on macOS 10.15.2 with Python 3.7.4 and Clang 11.0.0.

Note that this is the last release to support Python 2.