### PR TITLE
Don't patch latest version of HDF5

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -114,7 +114,7 @@ class Hdf5(AutotoolsPackage):
 
     # Disable MPI C++ interface when C++ is disabled, otherwise downstream
     # libraries fail to link; see https://github.com/spack/spack/issues/12586
-    patch('h5public-skip-mpicxx.patch', when='+mpi~cxx',
+    patch('h5public-skip-mpicxx.patch', when='@:1.8.21,1.10.0:1.10.5+mpi~cxx',
           sha256='b61e2f058964ad85be6ee5ecea10080bf79e73f83ff88d1fa4b602d00209da9c')
 
     filter_compiler_wrappers('h5cc', 'h5c++', 'h5fc', relative_root='bin')


### PR DESCRIPTION
Fixes #14537 

Based on https://github.com/spack/spack/issues/12586#issuecomment-532322303, it appears this patch is no longer needed in HDF5 1.10.6.

@hightower8083 @omsai