### PR TITLE
py-voluptuous add new versions

### DIFF
--- a/var/spack/repos/builtin/packages/py-voluptuous/package.py
+++ b/var/spack/repos/builtin/packages/py-voluptuous/package.py
@@ -9,8 +9,10 @@ from spack import *
 class PyVoluptuous(PythonPackage):
     """Voluptous, despite the name, is a Python data validation library."""
     homepage = "https://github.com/alecthomas/voluptuous"
-    url      = "https://github.com/alecthomas/voluptuous/archive/0.11.5.tar.gz"
+    url      = "https://pypi.io/packages/source/v/voluptuous/voluptuous-0.11.5.tar.gz"
 
-    version('0.11.5', sha256='01adf0b6c6f61bd11af6e10ca52b7d4057dd0be0343eb9283c878cf3af56aee4')
+    version('0.11.7', sha256='2abc341dbc740c5e2302c7f9b8e2e243194fb4772585b991931cb5b22e9bf456')
+    version('0.11.6', sha256='d2ca99ae1d1ed0313e8965720d1d75a780fc7f312fea4e3dbbb56ccfe5a8306d')
+    version('0.11.5', sha256='567a56286ef82a9d7ae0628c5842f65f516abcb496e74f3f59f1d7b28df314ef')
 
     depends_on('py-setuptools', type='build')


### PR DESCRIPTION
- download from pypi instead of github, since versions `>0.11.5` are only on pypi
- add new versions `0.11.6`, `0.11.7`
