### PR TITLE
fix spack env loads example

### DIFF
--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -382,11 +382,12 @@ the Environment.
 Loading
 ^^^^^^^
 
-Once an environment has been installed, the following creates a load script for it:
+Once an environment has been installed, the following creates a load
+script for it:
 
 .. code-block:: console
 
-   $ spack env myenv loads -r
+   $ spack env loads -r
 
 This creates a file called ``loads`` in the environment directory.
 Sourcing that file in Bash will make the environment available to the


### PR DESCRIPTION
The example in the docs is incorrect -- spack env expects a subcommand:

```
$ spack env myenv loads -r
usage: spack env [-h] SUBCOMMAND ...
spack env: error: argument SUBCOMMAND: invalid choice: 'myenv' choose from:
    activate  create  deactivate  list  loads  ls  remove  rm  st  status  view
```

I also have a question about the resulting `loads` script.  The docs cheerfully state: *This creates a file called loads in the environment directory. Sourcing that file in Bash will make the environment available to the user; and can be included in .bashrc files, etc.*

However, when I try to source the script on a vanilla Ubuntu 18.04 box, I get:

```
$ source path/to/spack/var/spack/environments/myenv/loads
module: command not found
module: command not found
module: command not found
module: command not found
module: command not found
```

Apparently, the script expects that lmod (or some kin) is already installed on the system.  Shouldn't the docs at least mention this, and better yet, explain how this process could be bootstrapped by a spack-provided lmod?