### PR TITLE
Get vtk-8.2.0 to build

### DIFF
--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -91,6 +91,9 @@ class Vtk(CMakePackage):
     depends_on('libpng')
     depends_on('libtiff')
     depends_on('zlib')
+    depends_on('eigen', when='@8.2.0:')
+    depends_on('double-conversion', when='@8.2.0:')
+    depends_on('sqlite', when='@8.2.0:')
 
     def url_for_version(self, version):
         url = "http://www.vtk.org/files/release/{0}/VTK-{1}.tar.gz"
@@ -117,8 +120,6 @@ class Vtk(CMakePackage):
             # However, in a few cases we can't do without them yet
             '-DVTK_USE_SYSTEM_GL2PS:BOOL=OFF',
             '-DVTK_USE_SYSTEM_LIBHARU=OFF',
-            '-DVTK_USE_SYSTEM_LIBPROJ4:BOOL=OFF',
-            '-DVTK_USE_SYSTEM_OGGTHEORA:BOOL=OFF',
 
             '-DNETCDF_DIR={0}'.format(spec['netcdf-c'].prefix),
             '-DNETCDF_C_ROOT={0}'.format(spec['netcdf-c'].prefix),
@@ -131,6 +132,20 @@ class Vtk(CMakePackage):
             '-DVTK_WRAP_JAVA=OFF',
             '-DVTK_WRAP_TCL=OFF',
         ]
+
+        # Some variable names have changed
+        if spec.satisfies('@8.2.0:'):
+            cmake_args.extend([
+                '-DVTK_USE_SYSTEM_OGG:BOOL=OFF',
+                '-DVTK_USE_SYSTEM_THEORA:BOOL=OFF',
+                '-DVTK_USE_SYSTEM_LIBPROJ:BOOL=OFF',
+                '-DVTK_USE_SYSTEM_PUGIXML:BOOL=OFF',
+            ])
+        else:
+            cmake_args.extend([
+                '-DVTK_USE_SYSTEM_OGGTHEORA:BOOL=OFF',
+                '-DVTK_USE_SYSTEM_LIBPROJ4:BOOL=OFF',
+            ])
 
         if '+mpi' in spec:
             cmake_args.extend([


### PR DESCRIPTION
This PR adds some extra dependencies needed for vtk-8.2.0. It also
handles the variable name changes to turn off some of the external
libraries.