### PR TITLE
bugfix: make `_source_single_file` work in venvs

### DIFF
--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -918,8 +918,14 @@ def environment_after_sourcing_files(*files, **kwargs):
         source_file.extend(x for x in file_and_args)
         source_file = ' '.join(source_file)
 
+        # If the environment contains 'python' use it, if not
+        # go with sys.executable. Below we just need a working
+        # Python interpreter, not necessarily sys.executable.
+        python_command = executable.which('python')
+        python_command = 'python' if python_command else sys.executable
+
         dump_cmd = 'import os, json; print(json.dumps(dict(os.environ)))'
-        dump_environment = 'python -c "{0}"'.format(dump_cmd)
+        dump_environment = python_command + ' -c "{0}"'.format(dump_cmd)
 
         # Try to source the file
         source_file_arguments = ' '.join([

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -921,11 +921,11 @@ def environment_after_sourcing_files(*files, **kwargs):
         # If the environment contains 'python' use it, if not
         # go with sys.executable. Below we just need a working
         # Python interpreter, not necessarily sys.executable.
-        python_command = executable.which('python')
-        python_command = 'python' if python_command else sys.executable
+        python_cmd = executable.which('python3', 'python', 'python2')
+        python_cmd = python_cmd.name if python_cmd else sys.executable
 
         dump_cmd = 'import os, json; print(json.dumps(dict(os.environ)))'
-        dump_environment = python_command + ' -c "{0}"'.format(dump_cmd)
+        dump_environment = python_cmd + ' -c "{0}"'.format(dump_cmd)
 
         # Try to source the file
         source_file_arguments = ' '.join([

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -17,7 +17,6 @@ import six
 
 import llnl.util.tty as tty
 import spack.util.executable as executable
-from spack.util.module_cmd import py_cmd
 
 from llnl.util.lang import dedupe
 
@@ -919,8 +918,8 @@ def environment_after_sourcing_files(*files, **kwargs):
         source_file.extend(x for x in file_and_args)
         source_file = ' '.join(source_file)
 
-        dump_environment = 'PYTHONHOME="{0}" "{1}" -c "{2}"'.format(
-            sys.prefix, sys.executable, py_cmd)
+        dump_cmd = 'import os, json; print(json.dumps(dict(os.environ)))'
+        dump_environment = sys.executable + ' -c "{0}"'.format(dump_cmd)
 
         # Try to source the file
         source_file_arguments = ' '.join([

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -919,7 +919,7 @@ def environment_after_sourcing_files(*files, **kwargs):
         source_file = ' '.join(source_file)
 
         dump_cmd = 'import os, json; print(json.dumps(dict(os.environ)))'
-        dump_environment = sys.executable + ' -c "{0}"'.format(dump_cmd)
+        dump_environment = 'python -c "{0}"'.format(dump_cmd)
 
         # Try to source the file
         source_file_arguments = ' '.join([

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -18,7 +18,7 @@ import llnl.util.tty as tty
 # This list is not exhaustive. Currently we only use load and unload
 # If we need another option that changes the environment, add it here.
 module_change_commands = ['load', 'swap', 'unload', 'purge', 'use', 'unuse']
-py_cmd = 'import os; import json; print(json.dumps(dict(os.environ)))'
+py_cmd = "'import os;import json;print(json.dumps(dict(os.environ)))'"
 
 # This is just to enable testing. I hate it but we can't find a better way
 _test_mode = False
@@ -32,8 +32,7 @@ def module(*args):
     if args[0] in module_change_commands:
         # Do the module manipulation, then output the environment in JSON
         # and read the JSON back in the parent process to update os.environ
-        module_cmd += ' > /dev/null; PYTHONHOME="{0}" "{1}" -c "{2}"'.format(
-            sys.prefix, sys.executable, py_cmd)
+        module_cmd += ' >/dev/null;' + sys.executable + ' -c %s' % py_cmd
         module_p  = subprocess.Popen(module_cmd,
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.STDOUT,


### PR DESCRIPTION
See issue #14568 

Currently unit tests for Spack don't run cleanly under `venvs`. This aims at fixing the issue while not regressing on #14252 and #14491. Bonus if anybody could suggest a way to test this patch for all these issues.