### PR TITLE
Intel compiler: fix env vars before install

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -202,6 +202,9 @@ class Python(AutotoolsPackage):
         # Need this to allow python build to find the Python installation.
         env.set('MACOSX_DEPLOYMENT_TARGET', platform.mac_ver()[0])
 
+        env.unset('PYTHONPATH')
+        env.unset('PYTHONHOME')
+
     def configure_args(self):
         spec = self.spec
         config_args = []


### PR DESCRIPTION
Not clearing `PYTHONPATH` from intel compiler modules loaded by default (which also define a `PYTHONPATH` and `PYTHONHOME`) causes the following error (similar error on linux) : https://bugs.python.org/issue27054

@adamjstewart 