### PR TITLE
libquo: Update default version from 1.3 to 1.3.1.

### DIFF
--- a/var/spack/repos/builtin/packages/libquo/package.py
+++ b/var/spack/repos/builtin/packages/libquo/package.py
@@ -13,10 +13,11 @@ class Libquo(AutotoolsPackage):
     single- and multi-threaded libraries."""
 
     homepage = "https://github.com/lanl/libquo"
-    url      = "http://lanl.github.io/libquo/dists/libquo-1.3.tar.gz"
+    url      = "http://lanl.github.io/libquo/dists/libquo-1.3.1.tar.gz"
     git      = "https://github.com/lanl/libquo.git"
 
     version('develop', branch='master')
+    version('1.3.1', sha256='407f7c61cc80aa934cf6086f3516a31dee3b803047713c297102452c3d7d6ed1')
     version('1.3',   sha256='61b0beff15eae4be94b5d3cbcbf7bf757659604465709ed01827cbba45efcf90')
     version('1.2.9', sha256='0a64bea8f52f9eecd89e4ab82fde1c5bd271f3866c612da0ce7f38049409429b')
 


### PR DESCRIPTION
Hello,

I'm the maintainer of libquo and just released v1.3.1.

This commit moves the libquo package from 1.3 to 1.3.1.

Thank you.