### PR TITLE
Fixing GCC compiler setting for PDT package

### DIFF
--- a/var/spack/repos/builtin/packages/pdt/package.py
+++ b/var/spack/repos/builtin/packages/pdt/package.py
@@ -43,6 +43,10 @@ class Pdt(AutotoolsPackage):
             options.append('-icpc')
         elif self.compiler.name == 'pgi':
             options.append('-pgCC')
+        elif self.compiler.name == 'gcc':
+            options.append('-GNU')
+        else:
+            raise InstallError('Unknown/unsupported compiler family')
 
         configure(*options)
 


### PR DESCRIPTION
Fixes #14588.  The PDT configuration detected ppc64le, and decided that XL should be the default compiler.  This PR will check whether the Spack compiler is GCC and correctly use the -GNU flag. If one of the supported PDT compilers are not found, the PDT installation will now fail with an error message.