### PR TITLE
diffutils: Changed the handling of undeclared functions from warning …

### DIFF
--- a/var/spack/repos/builtin/packages/diffutils/package.py
+++ b/var/spack/repos/builtin/packages/diffutils/package.py
@@ -19,3 +19,8 @@ class Diffutils(AutotoolsPackage, GNUMirrorPackage):
     build_directory = 'spack-build'
 
     depends_on('libiconv')
+
+    def setup_build_environment(self, env):
+        if self.spec.satisfies('%fj'):
+            env.append_flags('CFLAGS',
+                             '-Werror=implicit-function-declaration')

--- a/var/spack/repos/builtin/packages/diffutils/package.py
+++ b/var/spack/repos/builtin/packages/diffutils/package.py
@@ -23,4 +23,4 @@ class Diffutils(AutotoolsPackage, GNUMirrorPackage):
     def setup_build_environment(self, env):
         if self.spec.satisfies('%fj'):
             env.append_flags('CFLAGS',
-                             '-Werror=implicit-function-declaration')
+                             '-Qunused-arguments')


### PR DESCRIPTION
…to error.

Fujitsu compiler is based on Clang compiler, so it got following errors.
```
configure: error: cannot detect from compiler exit status or warnings
```
https://github.com/spack/spack/pull/13778
The changes of the above pull requesut is needed for Fujitsu compiler, but it seems to stop updating.
I want to merge quickly these changes, so I submitted new pull request about only Fujitsu compiler.