### PR TITLE
bugfix: gpg2 is called 'gpg' on macOS

### DIFF
--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -11,6 +11,7 @@ import itertools
 import os
 import os.path
 import shutil
+import tempfile
 import xml.etree.ElementTree
 
 import ordereddict_backport
@@ -674,9 +675,19 @@ def module_configuration(monkeypatch, request):
 
 
 @pytest.fixture()
-def mock_gnupghome(tmpdir, monkeypatch):
-    monkeypatch.setattr(spack.util.gpg, 'GNUPGHOME', str(tmpdir.join('gpg')))
+def mock_gnupghome(monkeypatch):
+    # GNU PGP can't handle paths longer than 108 characters (wtf!@#$) so we
+    # have to make our own tmpdir with a shorter name than pytest's.
+    # This comes up because tmp paths on macOS are already long-ish, and
+    # pytest makes them longer.
+    short_name_tmpdir = tempfile.mkdtemp()
+    monkeypatch.setattr(spack.util.gpg, 'GNUPGHOME', short_name_tmpdir)
+    monkeypatch.setattr(spack.util.gpg.Gpg, '_gpg', None)
 
+    yield
+
+    # clean up, since we are doing this manually
+    shutil.rmtree(short_name_tmpdir)
 
 ##########
 # Fake archives and repositories

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -4,10 +4,14 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import re
 
+import spack.error
 import spack.paths
-from spack.util.executable import Executable
+import spack.version
+from spack.util.executable import which
 
+_gnupg_version_re = r"^gpg \(GnuPG\) (.*)$"
 
 GNUPGHOME = spack.paths.gpg_path
 
@@ -28,15 +32,39 @@ def parse_keys_output(output):
 
 
 class Gpg(object):
+    _gpg = None
+
     @staticmethod
     def gpg():
         # TODO: Support loading up a GPG environment from a built gpg.
-        gpg = Executable('gpg2')
-        if not os.path.exists(GNUPGHOME):
-            os.makedirs(GNUPGHOME)
-            os.chmod(GNUPGHOME, 0o700)
-        gpg.add_default_env('GNUPGHOME', GNUPGHOME)
-        return gpg
+        if Gpg._gpg is None:
+            gpg = which('gpg2', 'gpg')
+
+            if not gpg:
+                raise SpackGPGError("Spack requires gpg version 2 or higher.")
+
+            # ensure that the version is actually >= 2 if we find 'gpg'
+            if gpg.name == 'gpg':
+                output = gpg('--version', output=str)
+                match = re.search(_gnupg_version_re, output, re.M)
+
+                if not match:
+                    raise SpackGPGError("Couldn't determine version of gpg")
+
+                v = spack.version.Version(match.group(1))
+                if v < spack.version.Version('2'):
+                    raise SpackGPGError("Spack requires GPG version >= 2")
+
+            # make the GNU PG path if we need to
+            # TODO: does this need to be in the spack directory?
+            # we should probably just use GPG's regular conventions
+            if not os.path.exists(GNUPGHOME):
+                os.makedirs(GNUPGHOME)
+                os.chmod(GNUPGHOME, 0o700)
+            gpg.add_default_env('GNUPGHOME', GNUPGHOME)
+
+            Gpg._gpg = gpg
+        return Gpg._gpg
 
     @classmethod
     def create(cls, **kwargs):
@@ -112,3 +140,7 @@ class Gpg(object):
             cls.gpg()('--list-public-keys')
         if signing:
             cls.gpg()('--list-secret-keys')
+
+
+class SpackGPGError(spack.error.SpackError):
+    """Class raised when GPG errors are detected."""


### PR DESCRIPTION
The `gpg2` command isn't always around; it's sometimes called `gpg`.  This is the case with the brew-installed version, and it's breaking our tests.

- [x] Look for both 'gpg2' and 'gpg' when finding the command

This fixes the currently breaking macOS tests.