### PR TITLE
Removed code duplication in a few tests

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -23,7 +23,7 @@ from llnl.util.filesystem import mkdirp, install_tree
 import spack.cmd
 import spack.config as config
 import spack.fetch_strategy as fs
-import spack.util.gpg as gpg_util
+import spack.util.gpg
 import spack.relocate as relocate
 import spack.util.spack_yaml as syaml
 import spack.mirror
@@ -33,7 +33,6 @@ import spack.util.web as web_util
 from spack.spec import Spec
 from spack.stage import Stage
 from spack.util.gpg import Gpg
-from spack.util.executable import ProcessError
 
 _build_cache_relative_path = 'build_cache'
 
@@ -108,14 +107,6 @@ class NewLayoutException(spack.error.SpackError):
     Raised if directory layout is different from buildcache.
     """
     pass
-
-
-def has_gnupg2():
-    try:
-        gpg_util.Gpg.gpg()('--version', output=os.devnull)
-        return True
-    except ProcessError:
-        return False
 
 
 def build_cache_relative_path():
@@ -243,7 +234,7 @@ def checksum_tarball(file):
 
 def sign_tarball(key, force, specfile_path):
     # Sign the packages if keys available
-    if not has_gnupg2():
+    if not spack.util.gpg.has_gnupg2():
         raise NoGpgException(
             "gpg2 is not available in $PATH .\n"
             "Use spack install gnupg and spack load gnupg.")

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -234,27 +234,31 @@ def checksum_tarball(file):
 
 def sign_tarball(key, force, specfile_path):
     # Sign the packages if keys available
-    if not spack.util.gpg.has_gnupg2():
+    if spack.util.gpg.Gpg.gpg() is None:
         raise NoGpgException(
             "gpg2 is not available in $PATH .\n"
             "Use spack install gnupg and spack load gnupg.")
-    else:
-        if key is None:
-            keys = Gpg.signing_keys()
-            if len(keys) == 1:
-                key = keys[0]
-            if len(keys) > 1:
-                raise PickKeyException(str(keys))
-            if len(keys) == 0:
-                msg = "No default key available for signing.\n"
-                msg += "Use spack gpg init and spack gpg create"
-                msg += " to create a default key."
-                raise NoKeyException(msg)
+
+    if key is None:
+        keys = Gpg.signing_keys()
+        if len(keys) == 1:
+            key = keys[0]
+
+        if len(keys) > 1:
+            raise PickKeyException(str(keys))
+
+        if len(keys) == 0:
+            msg = "No default key available for signing.\n"
+            msg += "Use spack gpg init and spack gpg create"
+            msg += " to create a default key."
+            raise NoKeyException(msg)
+
     if os.path.exists('%s.asc' % specfile_path):
         if force:
             os.remove('%s.asc' % specfile_path)
         else:
             raise NoOverwriteException('%s.asc' % specfile_path)
+
     Gpg.sign(key, specfile_path, '%s.asc' % specfile_path)
 
 

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -12,16 +12,7 @@ import spack.main as spack_main
 import spack.config as cfg
 import spack.paths as spack_paths
 import spack.spec as spec
-import spack.util.gpg as gpg_util
 import spack.util.web as web_util
-
-
-@pytest.fixture(scope='function')
-def testing_gpg_directory(tmpdir):
-    old_gpg_path = gpg_util.GNUPGHOME
-    gpg_util.GNUPGHOME = str(tmpdir.join('gpg'))
-    yield
-    gpg_util.GNUPGHOME = old_gpg_path
 
 
 @pytest.fixture
@@ -50,7 +41,7 @@ def test_urlencode_string():
     assert(s_enc == 'Spack+Test+Project')
 
 
-def test_import_signing_key(testing_gpg_directory):
+def test_import_signing_key(mock_gnupghome):
     signing_key_dir = spack_paths.mock_gpg_keys_path
     signing_key_path = os.path.join(signing_key_dir, 'package-signing-key')
     with open(signing_key_path) as fd:

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -14,7 +14,6 @@ import spack.ci as ci
 import spack.config
 import spack.environment as ev
 import spack.hash_types as ht
-import spack.util.gpg as gpg_util
 from spack.main import SpackCommand
 import spack.paths as spack_paths
 import spack.repo as repo
@@ -31,14 +30,6 @@ gpg_cmd = SpackCommand('gpg')
 install_cmd = SpackCommand('install')
 buildcache_cmd = SpackCommand('buildcache')
 git = exe.which('git', required=True)
-
-
-@pytest.fixture(scope='function')
-def testing_gpg_directory(tmpdir):
-    old_gpg_path = gpg_util.GNUPGHOME
-    gpg_util.GNUPGHOME = str(tmpdir.join('gpg'))
-    yield
-    gpg_util.GNUPGHOME = old_gpg_path
 
 
 @pytest.fixture()
@@ -393,7 +384,7 @@ spack:
 
 def test_ci_rebuild_basic(tmpdir, mutable_mock_env_path, env_deactivate,
                           install_mockery, mock_packages,
-                          testing_gpg_directory):
+                          mock_gnupghome):
     working_dir = tmpdir.join('working_dir')
 
     mirror_dir = working_dir.join('mirror')
@@ -505,7 +496,7 @@ def test_ci_pushyaml(tmpdir):
 @pytest.mark.disable_clean_stage_check
 def test_push_mirror_contents(tmpdir, mutable_mock_env_path, env_deactivate,
                               install_mockery, mock_packages, mock_fetch,
-                              mock_stage, testing_gpg_directory):
+                              mock_stage, mock_gnupghome):
     working_dir = tmpdir.join('working_dir')
 
     mirror_dir = working_dir.join('mirror')

--- a/lib/spack/spack/test/cmd/gpg.py
+++ b/lib/spack/spack/test/cmd/gpg.py
@@ -7,8 +7,9 @@ import os
 
 import pytest
 
+import spack.util.gpg
+
 from spack.paths import mock_gpg_data_path, mock_gpg_keys_path
-import spack.util.gpg as gpg_util
 from spack.main import SpackCommand
 from spack.util.executable import ProcessError
 
@@ -18,16 +19,8 @@ def gpg():
     return SpackCommand('gpg')
 
 
-def has_gnupg2():
-    try:
-        gpg_util.Gpg.gpg()('--version', output=os.devnull)
-        return True
-    except Exception:
-        return False
-
-
 @pytest.mark.maybeslow
-@pytest.mark.skipif(not has_gnupg2(),
+@pytest.mark.skipif(not spack.util.gpg.has_gnupg2(),
                     reason='These tests require gnupg2')
 def test_gpg(gpg, tmpdir, mock_gnupghome):
     # Verify a file with an empty keyring.
@@ -69,7 +62,7 @@ def test_gpg(gpg, tmpdir, mock_gnupghome):
         '--export', str(keypath),
         'Spack testing 1',
         'spack@googlegroups.com')
-    keyfp = gpg_util.Gpg.signing_keys()[0]
+    keyfp = spack.util.gpg.Gpg.signing_keys()[0]
 
     # List the keys.
     # TODO: Test the output here.

--- a/lib/spack/spack/test/cmd/gpg.py
+++ b/lib/spack/spack/test/cmd/gpg.py
@@ -14,14 +14,6 @@ from spack.util.executable import ProcessError
 
 
 @pytest.fixture(scope='function')
-def testing_gpg_directory(tmpdir):
-    old_gpg_path = gpg_util.GNUPGHOME
-    gpg_util.GNUPGHOME = str(tmpdir.join('gpg'))
-    yield
-    gpg_util.GNUPGHOME = old_gpg_path
-
-
-@pytest.fixture(scope='function')
 def gpg():
     return SpackCommand('gpg')
 
@@ -37,7 +29,7 @@ def has_gnupg2():
 @pytest.mark.maybeslow
 @pytest.mark.skipif(not has_gnupg2(),
                     reason='These tests require gnupg2')
-def test_gpg(gpg, tmpdir, testing_gpg_directory):
+def test_gpg(gpg, tmpdir, mock_gnupghome):
     # Verify a file with an empty keyring.
     with pytest.raises(ProcessError):
         gpg('verify', os.path.join(mock_gpg_data_path, 'content.txt'))

--- a/lib/spack/spack/test/cmd/gpg.py
+++ b/lib/spack/spack/test/cmd/gpg.py
@@ -20,7 +20,7 @@ def gpg():
 
 
 @pytest.mark.maybeslow
-@pytest.mark.skipif(not spack.util.gpg.has_gnupg2(),
+@pytest.mark.skipif(not spack.util.gpg.Gpg.gpg(),
                     reason='These tests require gnupg2')
 def test_gpg(gpg, tmpdir, mock_gnupghome):
     # Verify a file with an empty keyring.

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -33,6 +33,8 @@ import spack.platforms.test
 import spack.repo
 import spack.stage
 import spack.util.executable
+import spack.util.gpg
+
 from spack.util.pattern import Bunch
 from spack.dependency import Dependency
 from spack.package import PackageBase
@@ -669,6 +671,12 @@ def module_configuration(monkeypatch, request):
             {}
         )
     return _impl
+
+
+@pytest.fixture()
+def mock_gnupghome(tmpdir, monkeypatch):
+    monkeypatch.setattr(spack.util.gpg, 'GNUPGHOME', str(tmpdir.join('gpg')))
+
 
 ##########
 # Fake archives and repositories

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -19,24 +19,16 @@ import spack.repo
 import spack.store
 import spack.binary_distribution as bindist
 import spack.cmd.buildcache as buildcache
+import spack.util.gpg
 from spack.spec import Spec
 from spack.paths import mock_gpg_keys_path
 from spack.fetch_strategy import URLFetchStrategy, FetchStrategyComposite
-from spack.util.executable import ProcessError
 from spack.relocate import needs_binary_relocation, needs_text_relocation
 from spack.relocate import strings_contains_installroot
 from spack.relocate import get_patchelf, relocate_text, relocate_links
 from spack.relocate import substitute_rpath, get_relative_rpaths
 from spack.relocate import macho_replace_paths, macho_make_paths_relative
 from spack.relocate import modify_macho_object, macho_get_paths
-
-
-def has_gnupg2():
-    try:
-        spack.util.gpg.Gpg.gpg()('--version', output=os.devnull)
-        return True
-    except ProcessError:
-        return False
 
 
 def fake_fetchify(url, pkg):
@@ -99,7 +91,7 @@ echo $PATH"""
     buildcache.setup_parser(parser)
 
     # Create a private key to sign package with if gpg2 available
-    if has_gnupg2():
+    if spack.util.gpg.has_gnupg2():
         spack.util.gpg.Gpg.create(name='test key 1', expires='0',
                                   email='spack@googlegroups.com',
                                   comment='Spack test key')

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -91,7 +91,7 @@ echo $PATH"""
     buildcache.setup_parser(parser)
 
     # Create a private key to sign package with if gpg2 available
-    if spack.util.gpg.has_gnupg2():
+    if spack.util.gpg.Gpg.gpg():
         spack.util.gpg.Gpg.create(name='test key 1', expires='0',
                                   email='spack@googlegroups.com',
                                   comment='Spack test key')

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -31,14 +31,6 @@ from spack.relocate import macho_replace_paths, macho_make_paths_relative
 from spack.relocate import modify_macho_object, macho_get_paths
 
 
-@pytest.fixture(scope='function')
-def testing_gpg_directory(tmpdir):
-    old_gpg_path = spack.util.gpg.GNUPGHOME
-    spack.util.gpg.GNUPGHOME = str(tmpdir.join('gpg'))
-    yield
-    spack.util.gpg.GNUPGHOME = old_gpg_path
-
-
 def has_gnupg2():
     try:
         spack.util.gpg.Gpg.gpg()('--version', output=os.devnull)
@@ -54,7 +46,7 @@ def fake_fetchify(url, pkg):
     pkg.fetcher = fetcher
 
 
-@pytest.mark.usefixtures('install_mockery', 'testing_gpg_directory')
+@pytest.mark.usefixtures('install_mockery', 'mock_gnupghome')
 def test_buildcache(mock_archive, tmpdir):
     # tweak patchelf to only do a download
     spec = Spec("patchelf")

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -112,11 +112,3 @@ class Gpg(object):
             cls.gpg()('--list-public-keys')
         if signing:
             cls.gpg()('--list-secret-keys')
-
-
-def has_gnupg2():
-    try:
-        Gpg.gpg()('--version', output=os.devnull)
-        return True
-    except Exception:
-        return False

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -112,3 +112,11 @@ class Gpg(object):
             cls.gpg()('--list-public-keys')
         if signing:
             cls.gpg()('--list-secret-keys')
+
+
+def has_gnupg2():
+    try:
+        Gpg.gpg()('--version', output=os.devnull)
+        return True
+    except Exception:
+        return False


### PR DESCRIPTION
refers #14594 

Details:

- [x] Factored to a common place the fixture `testing_gpg_directory`, renamed it as `mock_gnupghome`
- [x] Removed altogether the function `has_gnupg2`

For `has_gnupg2`, since we were not trying to parse the version from the output of:
```console
$ gpg2 --version
```
this is effectively equivalent to check if `spack.util.gpg.GPG.gpg()` was found. If we need to ensure version is `^2.X` it's probably better to do it in `spack.util.gpg.GPG.gpg()` than in a separate function.