### PR TITLE
pumi: sim version check, meshes via submodule, ctest

### DIFF
--- a/var/spack/repos/builtin/packages/pumi/package.py
+++ b/var/spack/repos/builtin/packages/pumi/package.py
@@ -39,7 +39,9 @@ class Pumi(CMakePackage):
             description="Enable Simmetrix SimModSuite Support: 'base' enables "
             "the minimum set of functionality, 'kernels' adds CAD kernel "
             "support to 'base', and 'full' enables all functionality.")
-    variant('simmodsuite_version_check', default=True)
+    variant('simmodsuite_version_check', default=True,
+            description="Enable check of Simmetrix SimModSuite version."
+            "Disable the check for testing new versions.")
 
     depends_on('mpi')
     depends_on('cmake@3:', type='build')

--- a/var/spack/repos/builtin/packages/pumi/package.py
+++ b/var/spack/repos/builtin/packages/pumi/package.py
@@ -40,7 +40,7 @@ class Pumi(CMakePackage):
             "the minimum set of functionality, 'kernels' adds CAD kernel "
             "support to 'base', and 'full' enables all functionality.")
     variant('simmodsuite_version_check', default=True,
-            description="Enable check of Simmetrix SimModSuite version."
+            description="Enable check of Simmetrix SimModSuite version. "
             "Disable the check for testing new versions.")
 
     depends_on('mpi')

--- a/var/spack/repos/builtin/packages/pumi/package.py
+++ b/var/spack/repos/builtin/packages/pumi/package.py
@@ -24,9 +24,7 @@ class Pumi(CMakePackage):
     # We will use the scorec/core master branch as the 'nightly' version
     # of pumi in spack.  The master branch is more stable than the
     # scorec/core develop branch and we perfer not to expose spack users
-    # to the added instability. The spack version string is 'develop' since
-    # it compares greater than a numbered version (e.g., 2.1.0). The spack
-    # version string 'master' compares less than a numbered version.
+    # to the added instability.
     version('master', submodules=True, branch='master')
     version('2.2.1', commit='cd826205db21b8439026db1f6af61a8ed4a18564')  # tag 2.2.1
     version('2.2.0', commit='8c7e6f13943893b2bc1ece15003e4869a0e9634f')  # tag 2.2.0

--- a/var/spack/repos/builtin/packages/pumi/package.py
+++ b/var/spack/repos/builtin/packages/pumi/package.py
@@ -27,7 +27,7 @@ class Pumi(CMakePackage):
     # to the added instability. The spack version string is 'develop' since
     # it compares greater than a numbered version (e.g., 2.1.0). The spack
     # version string 'master' compares less than a numbered version.
-    version('develop', submodules=True, branch='master')
+    version('master', submodules=True, branch='master')
     version('2.2.1', commit='cd826205db21b8439026db1f6af61a8ed4a18564')  # tag 2.2.1
     version('2.2.0', commit='8c7e6f13943893b2bc1ece15003e4869a0e9634f')  # tag 2.2.0
     version('2.1.0', commit='840fbf6ec49a63aeaa3945f11ddb224f6055ac9f')
@@ -93,4 +93,4 @@ class Pumi(CMakePackage):
         """Run ctest after building project."""
 
         with working_dir(self.build_directory):
-            ctest('-j1')
+            ctest(parallel=False)

--- a/var/spack/repos/builtin/packages/pumi/package.py
+++ b/var/spack/repos/builtin/packages/pumi/package.py
@@ -27,7 +27,7 @@ class Pumi(CMakePackage):
     # to the added instability. The spack version string is 'develop' since
     # it compares greater than a numbered version (e.g., 2.1.0). The spack
     # version string 'master' compares less than a numbered version.
-    version('develop', branch='master')
+    version('develop', submodules=True, branch='master')
     version('2.2.1', commit='cd826205db21b8439026db1f6af61a8ed4a18564')  # tag 2.2.1
     version('2.2.0', commit='8c7e6f13943893b2bc1ece15003e4869a0e9634f')  # tag 2.2.0
     version('2.1.0', commit='840fbf6ec49a63aeaa3945f11ddb224f6055ac9f')
@@ -41,6 +41,7 @@ class Pumi(CMakePackage):
             description="Enable Simmetrix SimModSuite Support: 'base' enables "
             "the minimum set of functionality, 'kernels' adds CAD kernel "
             "support to 'base', and 'full' enables all functionality.")
+    variant('simmodsuite_version_check', default=True)
 
     depends_on('mpi')
     depends_on('cmake@3:', type='build')
@@ -69,7 +70,10 @@ class Pumi(CMakePackage):
             '-DCMAKE_Fortran_COMPILER=%s' % spec['mpi'].mpifc,
             '-DPUMI_FORTRAN_INTERFACE=%s' %
             ('ON' if '+fortran' in spec else 'OFF'),
-            '-DMDS_ID_TYPE=%s' % ('long' if '+int64' in spec else 'int')
+            '-DMDS_ID_TYPE=%s' % ('long' if '+int64' in spec else 'int'),
+            '-DSKIP_SIMMETRIX_VERSION_CHECK=%s' %
+            ('ON' if '~simmodsuite_version_check' in spec else 'OFF'),
+            '-DMESHES=%s' % join_path(self.stage.source_path, 'pumi_meshes')
         ]
         if self.spec.satisfies('simmodsuite=base'):
             args.append('-DENABLE_SIMMETRIX=ON')
@@ -82,3 +86,11 @@ class Pumi(CMakePackage):
             mpi_id = spec['mpi'].name + spec['mpi'].version.string
             args.append('-DSIM_MPI=' + mpi_id)
         return args
+
+    @run_after('build')
+    @on_package_attributes(run_tests=True)
+    def check(self):
+        """Run ctest after building project."""
+
+        with working_dir(self.build_directory):
+            ctest('-j1')


### PR DESCRIPTION
This PR adds support for ctest and the submodule containing the input files needed to run the tests.  It also adds a flag to control the simmetrix-simmodsuite version check which is useful for testing.