### PR TITLE
openPMD-api: Default +adios1

### DIFF
--- a/var/spack/repos/builtin/packages/openpmd-api/package.py
+++ b/var/spack/repos/builtin/packages/openpmd-api/package.py
@@ -26,7 +26,7 @@ class OpenpmdApi(CMakePackage):
             description='Enable parallel I/O')
     variant('hdf5', default=True,
             description='Enable HDF5 support')
-    variant('adios1', default=False,
+    variant('adios1', default=True,
             description='Enable ADIOS1 support')
     variant('adios2', default=False,
             description='Enable ADIOS2 support')


### PR DESCRIPTION
Enable the ADIOS1 backend by default.

This was only disabled until the build recipes (adios1 and its dependencies, e.g. sz) are mature enough in Spack to not affect/crash the default spec of openpmd-api.