### PR TITLE
Package bugfix: z3+python

### DIFF
--- a/var/spack/repos/builtin/packages/z3/package.py
+++ b/var/spack/repos/builtin/packages/z3/package.py
@@ -22,6 +22,7 @@ class Z3(MakefilePackage):
 
     variant('python', default=False, description='Enable python binding')
     depends_on('python', type=('build', 'run'))
+    extends('python', when='+python')
 
     # Referenced: https://github.com/Z3Prover/z3/issues/1016
     patch('fix_1016_1.patch', when='@:4.4.1')
@@ -31,9 +32,18 @@ class Z3(MakefilePackage):
 
     def configure_args(self):
         spec = self.spec
-        return [
-            '--python' if '+python' in spec else ''
-        ]
+
+        args = []
+
+        if spec.satisfies('+python'):
+            args.append('--python')
+            args.append(
+                '--pypkgdir=%s' % join_path(
+                    prefix.lib,
+                    'python%s' % spec['python'].version.up_to(2),
+                    'site-packages'))
+
+        return args
 
     def bootstrap(self, spec, prefix):
         options = ['--prefix={0}'.format(prefix)] + self.configure_args()


### PR DESCRIPTION
Configure z3+python to build the python libraries inside its own prefix and extend python as other packages do

Previously, z3 was installing it's python API into the python install prefix, which breaks Spack's fundamental model of separating installs into separate prefixes.