### PR TITLE
openPMD-api: adios_config to run env

### DIFF
--- a/var/spack/repos/builtin/packages/openpmd-api/package.py
+++ b/var/spack/repos/builtin/packages/openpmd-api/package.py
@@ -104,6 +104,7 @@ class OpenpmdApi(CMakePackage):
             env.prepend_path('CMAKE_PREFIX_PATH', spec['mpi'].prefix)
         if spec.satisfies("+adios1"):
             env.prepend_path('CMAKE_PREFIX_PATH', spec['adios'].prefix)
+            env.prepend_path('PATH', spec['adios'].prefix.bin)  # adios-config
         if spec.satisfies("+adios2"):
             env.prepend_path('CMAKE_PREFIX_PATH', spec['adios2'].prefix)
         if spec.satisfies("+hdf5"):


### PR DESCRIPTION
Popular CMake find-scripts for ADIOS1 search for this binary instead of looking up `CMAKE_PREFIX_PATH`. Eases usage for downstream projects that just to `spack load` without `-r`.

Follow-up to #14599 that was caught in nightly deployment testing on OSX: https://dev.azure.com/axelhuebl/openPMD-api/_build/results?buildId=161&view=results