### PR TITLE
Force non-interactive git fetch

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -787,7 +787,7 @@ class GitFetchStrategy(VCSFetchStrategy):
 
         try:
             self._clone_and_checkout()
-        except:
+        except Exception:
             if os.path.exists(self.stage.source_path):
                 shutil.rmtree(self.stage.source_path)
             raise

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -785,6 +785,14 @@ class GitFetchStrategy(VCSFetchStrategy):
             tty.msg("Already fetched {0}".format(self.stage.source_path))
             return
 
+        try:
+            self._clone_and_checkout()
+        except:
+            if os.path.exists(self.stage.source_path):
+                shutil.rmtree(self.stage.source_path)
+            raise
+
+    def _clone_and_checkout(self):
         tty.msg("Cloning git repository: {0}".format(self._repo_info()))
 
         git = self.git

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -742,6 +742,8 @@ class GitFetchStrategy(VCSFetchStrategy):
             if not spack.config.get('config:verify_ssl'):
                 self._git.add_default_env('GIT_SSL_NO_VERIFY', 'true')
 
+            self._git.add_default_call_setting('disable_stdin', True)
+
         return self._git
 
     @property

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -499,7 +499,7 @@ def add_single_spec(spec, mirror_root, mirror_stats):
     tty.msg("Adding package {pkg} to mirror".format(
         pkg=spec.format("{name}{@version}")
     ))
-    num_retries = 3
+    num_retries = 2
     while num_retries > 0:
         try:
             with spec.package.stage as pkg_stage:


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/13604

This closes stdin for all Git fetches; this allows Spack to automatically fail in the case that a git URL was misconfigured such that Spack attempts to pull from somewhere that requires user credentials. Without this, commands like `spack mirror --all` would stall for such misconfigured packages.

At the moment this assumes that all Spack packages intend to pull from Git repositories without credentials.

TODOs

- [ ] add testing
- [ ] add an option for users who create a private Spack package that does in fact need to prompt the user for credentials during a Git pull

See also: https://github.com/spack/spack/pull/13925: that PR adds timeouts to fetchers, which is not a good approach for misconfigured git repositories but may be useful for stalling URL fetches. That being said it may be better to configure more sensitive timeouts via curl as https://github.com/spack/spack/pull/13881 does.