### PR TITLE
Get py-torch to build caffe2

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -100,30 +100,27 @@ class PyTorch(PythonPackage, CudaPackage):
     conflicts('+redis', when='@:1.0')
     conflicts('+zstd', when='@:1.0')
     conflicts('+tbb', when='@:1.1')
+
+    cuda_arch_conflict = """This version of Torch/Caffe2 only supports compute
+    capabilities """
+
     conflicts('cuda_arch=none', when='+cuda+caffe2',
               msg='Must specify CUDA compute capabilities of your GPU, see '
               'https://developer.nvidia.com/cuda-gpus')
     conflicts('cuda_arch=52', when='@1.3.0:+cuda+caffe2',
-              msg='This version of Torch only supports compute capabilities '
-              '>= 5.3')
+              msg='{0}'.format(cuda_arch_conflict) + '>=5.3')
     conflicts('cuda_arch=50', when='@1.3.0:+cuda+caffe2',
-              msg='This version of Torch only supports compute capabilities '
-              '>= 5.3')
+              msg='{0}'.format(cuda_arch_conflict) + '>=5.3')
     conflicts('cuda_arch=35', when='@1.3.0:+cuda+caffe2',
-              msg='This version of Torch only supports compute capabilities '
-              '>= 5.3')
+              msg='{0}'.format(cuda_arch_conflict) + '>=5.3')
     conflicts('cuda_arch=32', when='@1.3.0:+cuda+caffe2',
-              msg='This version of Torch only supports compute capabilities '
-              '>= 5.3')
+              msg='{0}'.format(cuda_arch_conflict) + '>=5.3')
     conflicts('cuda_arch=30', when='@1.3.0:+cuda+caffe2',
-              msg='This version of Torch only supports compute capabilities '
-              '>= 5.3')
+              msg='{0}'.format(cuda_arch_conflict) + '>=5.3')
     conflicts('cuda_arch=30', when='@1.2.0:+cuda+caffe2',
-              msg='This version of Torch only supports compute capabilities '
-              '>= 3.2')
+              msg='{0}'.format(cuda_arch_conflict) + '>=3.2')
     conflicts('cuda_arch=20', when='@1.0.0:+cuda+caffe2',
-              msg='This version of Torch only supports compute capabilities '
-              '>= 3.0')
+              msg='{0}'.format(cuda_arch_conflict) + '>=3.0')
 
     # Required dependencies
     depends_on('cmake@3.5:', type='build')

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -101,26 +101,26 @@ class PyTorch(PythonPackage, CudaPackage):
     conflicts('+zstd', when='@:1.0')
     conflicts('+tbb', when='@:1.1')
 
-    cuda_arch_conflict = """This version of Torch/Caffe2 only supports compute
-    capabilities """
+    cuda_arch_conflict = ('This version of Torch/Caffe2 only supports compute '
+                          'capabilities ')
 
     conflicts('cuda_arch=none', when='+cuda+caffe2',
               msg='Must specify CUDA compute capabilities of your GPU, see '
               'https://developer.nvidia.com/cuda-gpus')
     conflicts('cuda_arch=52', when='@1.3.0:+cuda+caffe2',
-              msg='{0}'.format(cuda_arch_conflict) + '>=5.3')
+              msg=cuda_arch_conflict + '>=5.3')
     conflicts('cuda_arch=50', when='@1.3.0:+cuda+caffe2',
-              msg='{0}'.format(cuda_arch_conflict) + '>=5.3')
+              msg=cuda_arch_conflict + '>=5.3')
     conflicts('cuda_arch=35', when='@1.3.0:+cuda+caffe2',
-              msg='{0}'.format(cuda_arch_conflict) + '>=5.3')
+              msg=cuda_arch_conflict + '>=5.3')
     conflicts('cuda_arch=32', when='@1.3.0:+cuda+caffe2',
-              msg='{0}'.format(cuda_arch_conflict) + '>=5.3')
+              msg=cuda_arch_conflict + '>=5.3')
     conflicts('cuda_arch=30', when='@1.3.0:+cuda+caffe2',
-              msg='{0}'.format(cuda_arch_conflict) + '>=5.3')
+              msg=cuda_arch_conflict + '>=5.3')
     conflicts('cuda_arch=30', when='@1.2.0:+cuda+caffe2',
-              msg='{0}'.format(cuda_arch_conflict) + '>=3.2')
+              msg=cuda_arch_conflict + '>=3.2')
     conflicts('cuda_arch=20', when='@1.0.0:+cuda+caffe2',
-              msg='{0}'.format(cuda_arch_conflict) + '>=3.0')
+              msg=cuda_arch_conflict + '>=3.0')
 
     # Required dependencies
     depends_on('cmake@3.5:', type='build')

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -153,7 +153,7 @@ class PyTorch(PythonPackage, CudaPackage):
     # depends_on('fbgemm', when='+fbgemm')
     # TODO: add dependency: https://github.com/ROCmSoftwarePlatform/MIOpen
     # depends_on('miopen', when='+miopen')
-    # TODO: See if there is a way to use an externale mkldnn installation.
+    # TODO: See if there is a way to use an external mkldnn installation.
     # Currently, only older versions of py-torch use an external mkldnn
     # library.
     depends_on('intel-mkl-dnn', when='@0.4:0.4.1+mkldnn')

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -118,10 +118,10 @@ class PyTorch(PythonPackage, CudaPackage):
     conflicts('cuda_arch=30', when='@1.3.0:+cuda+caffe2',
               msg='This version of Torch only supports compute capabilities '
               '>= 5.3')
-    conflicts('cuda_arch=30', when='@1.2.0+cuda+caffe2',
+    conflicts('cuda_arch=30', when='@1.2.0:+cuda+caffe2',
               msg='This version of Torch only supports compute capabilities '
               '>= 3.2')
-    conflicts('cuda_arch=20', when='@1.2.0+cuda+caffe2',
+    conflicts('cuda_arch=20', when='@1.0.0:+cuda+caffe2',
               msg='This version of Torch only supports compute capabilities '
               '>= 3.0')
 


### PR DESCRIPTION
This PR gets the py-torch package to build with caffe2, and closes #14576. If building on a machine with CUDA but no GPU the build
will try to build with all compute capabilities. Older compute
capabilities are not supported so the build will fail. The list of
capabilities can be passed to the build using values set in the
cuda_arch variant. Likewise, conflicts are also set to catch if the
unsupported capabilities are listed in cuda_arch.

This PR also sets version constraints on using an external mkldnn for
newer versions. Currenly, only versions up to 0.4 use an external mkldnn
library. Also, the cuda variant is set to True, which restores
previous behavior.