### PR TITLE
Synchronized env update for install

### DIFF
--- a/lib/spack/spack/cmd/add.py
+++ b/lib/spack/spack/cmd/add.py
@@ -25,10 +25,11 @@ def setup_parser(subparser):
 def add(parser, args):
     env = ev.get_env(args, 'add', required=True)
 
-    for spec in spack.cmd.parse_specs(args.specs):
-        if not env.add(spec, args.list_name):
-            tty.msg("Package {0} was already added to {1}"
-                    .format(spec.name, env.name))
-        else:
-            tty.msg('Adding %s to environment %s' % (spec, env.name))
-    env.write()
+    with env.write_transaction():
+        for spec in spack.cmd.parse_specs(args.specs):
+            if not env.add(spec, args.list_name):
+                tty.msg("Package {0} was already added to {1}"
+                        .format(spec.name, env.name))
+            else:
+                tty.msg('Adding %s to environment %s' % (spec, env.name))
+        env.write()

--- a/lib/spack/spack/cmd/concretize.py
+++ b/lib/spack/spack/cmd/concretize.py
@@ -18,6 +18,7 @@ def setup_parser(subparser):
 
 def concretize(parser, args):
     env = ev.get_env(args, 'concretize', required=True)
-    concretized_specs = env.concretize(force=args.force)
-    ev.display_specs(concretized_specs)
-    env.write()
+    with env.write_transaction():
+        concretized_specs = env.concretize(force=args.force)
+        ev.display_specs(concretized_specs)
+        env.write()

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -226,7 +226,7 @@ def install_spec(cli_args, kwargs, abstract_spec, spec):
             with env.write_transaction():
                 concrete = env.concretize_and_add(
                     abstract_spec, spec)
-                env.write()
+                env.write(regenerate_views=False)
             env._install(concrete, **kwargs)
             env.regenerate_views()
         else:

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -223,8 +223,12 @@ def install_spec(cli_args, kwargs, abstract_spec, spec):
         # handle active environment, if any
         env = ev.get_env(cli_args, 'install')
         if env:
-            env.install(abstract_spec, spec, **kwargs)
-            env.write()
+            with env.write_transaction():
+                synchronized_env = ev.Environment(env.path)
+                concrete = synchronized_env.concretize_and_add(
+                    abstract_spec, spec)
+                synchronized_env.write()
+            env._install(concrete, **kwargs)
         else:
             spec.package.do_install(**kwargs)
 

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -263,12 +263,15 @@ environment variables:
         env = ev.get_env(args, 'install')
         if env:
             if not args.only_concrete:
-                concretized_specs = env.concretize()
-                ev.display_specs(concretized_specs)
+                with env.write_transaction():
+                    synchronized_env = ev.Environment(env.path)
+                    concretized_specs = synchronized_env.concretize()
+                    ev.display_specs(concretized_specs)
 
-                # save view regeneration for later, so that we only do it
-                # once, as it can be slow.
-                env.write(regenerate_views=False)
+                    # save view regeneration for later, so that we only do it
+                    # once, as it can be slow.
+                    synchronized_env.write(regenerate_views=False)
+                env = synchronized_env
 
             tty.msg("Installing environment %s" % env.name)
             env.install_all(args)

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -228,7 +228,8 @@ def install_spec(cli_args, kwargs, abstract_spec, spec):
                 concrete = synchronized_env.concretize_and_add(
                     abstract_spec, spec)
                 synchronized_env.write()
-            env._install(concrete, **kwargs)
+            synchronized_env._install(concrete, **kwargs)
+            synchronized_env.regenerate_views()
         else:
             spec.package.do_install(**kwargs)
 

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -224,12 +224,11 @@ def install_spec(cli_args, kwargs, abstract_spec, spec):
         env = ev.get_env(cli_args, 'install')
         if env:
             with env.write_transaction():
-                synchronized_env = ev.Environment(env.path)
-                concrete = synchronized_env.concretize_and_add(
+                concrete = env.concretize_and_add(
                     abstract_spec, spec)
-                synchronized_env.write()
-            synchronized_env._install(concrete, **kwargs)
-            synchronized_env.regenerate_views()
+                env.write()
+            env._install(concrete, **kwargs)
+            env.regenerate_views()
         else:
             spec.package.do_install(**kwargs)
 
@@ -265,14 +264,12 @@ environment variables:
         if env:
             if not args.only_concrete:
                 with env.write_transaction():
-                    synchronized_env = ev.Environment(env.path)
-                    concretized_specs = synchronized_env.concretize()
+                    concretized_specs = env.concretize()
                     ev.display_specs(concretized_specs)
 
                     # save view regeneration for later, so that we only do it
                     # once, as it can be slow.
-                    synchronized_env.write(regenerate_views=False)
-                env = synchronized_env
+                    env.write(regenerate_views=False)
 
             tty.msg("Installing environment %s" % env.name)
             env.install_all(args)

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -228,7 +228,8 @@ def install_spec(cli_args, kwargs, abstract_spec, spec):
                     abstract_spec, spec)
                 env.write(regenerate_views=False)
             env._install(concrete, **kwargs)
-            env.regenerate_views()
+            with env.write_transaction():
+                env.regenerate_views()
         else:
             spec.package.do_install(**kwargs)
 
@@ -273,7 +274,10 @@ environment variables:
 
             tty.msg("Installing environment %s" % env.name)
             env.install_all(args)
-            env.regenerate_views()
+            with env.write_transaction():
+                # It is not strictly required to synchronize view regeneration
+                # but doing so can prevent redundant work in the filesystem.
+                env.regenerate_views()
             return
         else:
             tty.die("install requires a package argument or a spack.yaml file")

--- a/lib/spack/spack/cmd/remove.py
+++ b/lib/spack/spack/cmd/remove.py
@@ -31,10 +31,11 @@ def setup_parser(subparser):
 def remove(parser, args):
     env = ev.get_env(args, 'remove', required=True)
 
-    if args.all:
-        env.clear()
-    else:
-        for spec in spack.cmd.parse_specs(args.specs):
-            tty.msg('Removing %s from environment %s' % (spec, env.name))
-            env.remove(spec, args.list_name, force=args.force)
-    env.write()
+    with env.write_transaction():
+        if args.all:
+            env.clear()
+        else:
+            for spec in spack.cmd.parse_specs(args.specs):
+                tty.msg('Removing %s from environment %s' % (spec, env.name))
+                env.remove(spec, args.list_name, force=args.force)
+        env.write()

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1172,17 +1172,16 @@ class Environment(object):
         that needs to be done separately with a call to write().
 
         """
-        with spack.store.db.read_transaction():
-            for concretized_hash in self.concretized_order:
-                spec = self.specs_by_hash[concretized_hash]
+        for concretized_hash in self.concretized_order:
+            spec = self.specs_by_hash[concretized_hash]
 
-                # Parse cli arguments and construct a dictionary
-                # that will be passed to Package.do_install API
-                kwargs = dict()
-                if args:
-                    spack.cmd.install.update_kwargs_from_args(args, kwargs)
+            # Parse cli arguments and construct a dictionary
+            # that will be passed to Package.do_install API
+            kwargs = dict()
+            if args:
+                spack.cmd.install.update_kwargs_from_args(args, kwargs)
 
-                self._install(spec, **kwargs)
+            self._install(spec, **kwargs)
 
     def all_specs_by_hash(self):
         """Map of hashes to spec for all specs in this environment."""

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1007,11 +1007,11 @@ class Environment(object):
         This will automatically concretize the single spec, but it won't
         affect other as-yet unconcretized specs.
         """
-        concrete = concretize_and_add(self, user_spec, concrete_spec)
+        concrete = self.concretize_and_add(user_spec, concrete_spec)
 
         self._install(concrete, **install_args)
 
-    def concretize_and_add(self, spec, concrete_spec=None):
+    def concretize_and_add(self, user_spec, concrete_spec=None):
         if self.concretization == 'together':
             msg = 'cannot install a single spec in an environment that is ' \
                   'configured to be concretized together. Run instead:\n\n' \

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -36,7 +36,7 @@ import spack.architecture as architecture
 from spack.spec import Spec
 from spack.spec_list import SpecList, InvalidSpecConstraintError
 from spack.variant import UnknownVariantError
-import spack.util.lock as slock
+import spack.util.lock as lk
 
 #: environment variable used to indicate the active environment
 spack_env_var = 'SPACK_ENV'
@@ -559,7 +559,7 @@ class Environment(object):
         """
         self.path = os.path.abspath(path)
 
-        self.txlock = slock.Lock(self._transaction_lock_path)
+        self.txlock = lk.Lock(self._transaction_lock_path)
 
         # This attribute will be set properly from configuration
         # during concretization
@@ -621,7 +621,7 @@ class Environment(object):
 
     def write_transaction(self):
         """Get a write lock context manager for use in a `with` block."""
-        return slock.WriteTransaction(self.txlock, acquire=self._re_read)
+        return lk.WriteTransaction(self.txlock, acquire=self._re_read)
 
     def _read_manifest(self, f, raw_yaml=None):
         """Read manifest file and set up user specs."""

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1190,19 +1190,15 @@ class Environment(object):
         # a large amount of time due to repeatedly acquiring and releasing
         # locks, this does an initial check across all specs within a single
         # DB read transaction to reduce time spent in this case.
+        uninstalled_specs = []
         with spack.store.db.read_transaction():
-            all_installed = True
             for concretized_hash in self.concretized_order:
                 spec = self.specs_by_hash[concretized_hash]
                 all_installed &= bool(spec.package.installed)
-                if not all_installed:
-                    break
-            if all_installed:
-                return
+                if not spec.package.installed:
+                    uninstalled_specs.append(spec)
 
-        for concretized_hash in self.concretized_order:
-            spec = self.specs_by_hash[concretized_hash]
-
+        for spec in uninstalled_specs:
             # Parse cli arguments and construct a dictionary
             # that will be passed to Package.do_install API
             kwargs = dict()

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1194,7 +1194,6 @@ class Environment(object):
         with spack.store.db.read_transaction():
             for concretized_hash in self.concretized_order:
                 spec = self.specs_by_hash[concretized_hash]
-                all_installed &= bool(spec.package.installed)
                 if not spec.package.installed:
                     uninstalled_specs.append(spec)
 


### PR DESCRIPTION
This is a minimal set of edits to get parallel installs as implemented in https://github.com/spack/spack/pull/13100 working with environments.

What it currently does:

* adds a lock file for an environment that is stored in the environment directory
* adds `Environment.write_transaction`
* makes use of `Environment.write_transaction` in `cmd.install`

(UPDATE: now passing) ~One test is currently failing, which I think is an issue with the testing framwork vs. the actual logic (since I cannot manually reproduce the error when manually running through commands executed in the test).~

TODOs

- [x] fix the test
- [x] (lower priority) synchronize other actions like `spack add`, `spack rm` etc.; this isn't strictly necessary for correcting parallel Spack installs but it should be done (perhaps later)
- [x] introduce similar logic to `Database.write_transaction` to `Environment.write_transaction`, which would include re-reading the environment (this would possibly allow moving the transaction logic from `cmd.install` to `Environment`