### PR TITLE
simulationio: Correct HDF5 dependency bounds

### DIFF
--- a/var/spack/repos/builtin/packages/simulationio/package.py
+++ b/var/spack/repos/builtin/packages/simulationio/package.py
@@ -23,7 +23,7 @@ class Simulationio(CMakePackage):
     variant('pic', default=True,
             description="Produce position-independent code")
 
-    depends_on('hdf5 +cxx @:1.10.0-patch1')
+    depends_on('hdf5 +cxx @1.10.1:')
     depends_on('julia', when='+julia', type=('build', 'run'))
     depends_on('py-h5py', when='+python', type=('build', 'run'))
     depends_on('py-numpy', when='+python', type=('build', 'run'))


### PR DESCRIPTION
The HDF5 dependency bound was inverted. (How did this ever compile? There is a cmake check.)