### PR TITLE
Fix Python version compatibility tests for vermin 0.10.0

### DIFF
--- a/lib/spack/spack/cmd/list.py
+++ b/lib/spack/spack/cmd/list.py
@@ -23,7 +23,7 @@ import spack.cmd.common.arguments as arguments
 from spack.version import VersionList
 
 if sys.version_info > (3, 1):
-    from html import escape
+    from html import escape  # novm
 else:
     from cgi import escape
 

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -21,7 +21,7 @@ import multiprocessing.pool
 
 try:
     # Python 2 had these in the HTMLParser package.
-    from HTMLParser import HTMLParser, HTMLParseError
+    from HTMLParser import HTMLParser, HTMLParseError  # novm
 except ImportError:
     # In Python 3, things moved to html.parser
     from html.parser import HTMLParser
@@ -80,7 +80,7 @@ if sys.version_info[0] < 3:
         Process = NonDaemonProcess
 else:
 
-    class NonDaemonContext(type(multiprocessing.get_context())):
+    class NonDaemonContext(type(multiprocessing.get_context())):  # novm
         Process = NonDaemonProcess
 
     class NonDaemonPool(multiprocessing.pool.Pool):
@@ -128,7 +128,7 @@ def read_from_url(url, accept_content_type=None):
                 warn_no_ssl_cert_checking()
             else:
                 # User wants SSL verification, and it *can* be provided.
-                context = ssl.create_default_context()
+                context = ssl.create_default_context()  # novm
         else:
             # User has explicitly indicated that they do not want SSL
             # verification.


### PR DESCRIPTION
All of a sudden, all of our recent PRs have been failing the "python version check" GitHub action. It looks like a new, smarter version of vermin (0.10.0) was just released today, detecting new incompatible sections of code. Luckily all of these versions are guarded by `sys.version_info` checks or try-except blocks. This PR adds `# novm` to the lines that were causing the tests to fail.