### PR TITLE
Add spack2 and spack3 commands

### DIFF
--- a/bin/spack2
+++ b/bin/spack2
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# Forces `spack` to be run with Python 2, even if both Python 2 and 3
+# are installed. Useful for debugging Python 2 compatibility bugs.
+
+python2 $(which spack) "$@"

--- a/bin/spack3
+++ b/bin/spack3
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# Forces `spack` to be run with Python 3, even if both Python 2 and 3
+# are installed. Useful for debugging Python 3 compatibility bugs.
+
+python3 $(which spack) "$@"

--- a/share/spack/bash/spack-completion.in
+++ b/share/spack/bash/spack-completion.in
@@ -64,6 +64,10 @@ _bash_completion_spack() {
     # compatibility mode. See https://github.com/spack/spack/pull/4079
     subfunction=${subfunction//-/_}
 
+    # spack2 and spack3 are wrappers around spack
+    subfunction=${subfunction/#_spack2/_spack}
+    subfunction=${subfunction/#_spack3/_spack}
+
     # However, the word containing the current cursor position needs to be
     # added regardless of whether or not it is a flag. This allows us to
     # complete something like `spack install --keep-st[]`
@@ -302,7 +306,7 @@ _pretty_print() {
     done
 }
 
-complete -o bashdefault -o default -F _bash_completion_spack spack
+complete -o bashdefault -o default -F _bash_completion_spack spack spack2 spack3
 
 # Spack commands
 #

--- a/share/spack/qa/completion-test.sh
+++ b/share/spack/qa/completion-test.sh
@@ -58,6 +58,10 @@ contains 'hdf5' _spack_completions spack install -v ''
 # XFAIL: Fails for Python 2.6 because pkg_resources not found?
 #contains 'compilers.py' _spack_completions spack test ''
 
+title 'Testing spack2 and spack3 wrappers'
+contains 'compiler' _spack_completions spack2 ''
+contains 'compiler' _spack_completions spack3 ''
+
 title 'Testing debugging functions'
 
 # This is a particularly tricky case that involves the following situation:

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -64,6 +64,10 @@ _bash_completion_spack() {
     # compatibility mode. See https://github.com/spack/spack/pull/4079
     subfunction=${subfunction//-/_}
 
+    # spack2 and spack3 are wrappers around spack
+    subfunction=${subfunction/#_spack2/_spack}
+    subfunction=${subfunction/#_spack3/_spack}
+
     # However, the word containing the current cursor position needs to be
     # added regardless of whether or not it is a flag. This allows us to
     # complete something like `spack install --keep-st[]`
@@ -302,7 +306,7 @@ _pretty_print() {
     done
 }
 
-complete -o bashdefault -o default -F _bash_completion_spack spack
+complete -o bashdefault -o default -F _bash_completion_spack spack spack2 spack3
 
 # Spack commands
 #


### PR DESCRIPTION
Currently, my `.bashrc` contains:
```bash
alias spack2='python2 $(which spack)'
alias spack3='python3 $(which spack)'
```
This is very useful for quickly debugging Python 2/3 compatibility bugs. The only downside is that bash tab completion doesn't support aliases. This PR adds `spack2` and `spack3` executables so that tab completion will work properly.

P.S. This PR definitely isn't required, if you don't want to merge it because it makes our `bin` directory more complicated, that's perfectly fine, feel free to close it.