### PR TITLE
amrex: Update to version 20.01

### DIFF
--- a/var/spack/repos/builtin/packages/amrex/package.py
+++ b/var/spack/repos/builtin/packages/amrex/package.py
@@ -12,11 +12,13 @@ class Amrex(CMakePackage):
     mesh refinement (AMR) applications."""
 
     homepage = "https://amrex-codes.github.io/amrex/"
+    url      = "https://github.com/AMReX-Codes/amrex/archive/20.01.tar.gz"
     git      = "https://github.com/AMReX-Codes/amrex.git"
 
     maintainers = ['mic84', 'asalmgren']
 
     version('develop', branch='development')
+    version('20.01', sha256='f7026d267ca5de79ec7e740264d54230f419776d40feae705e939be0b1d8e0d3')
     version('19.10', commit='52844b32b7da11e9733b9a7f4a782e51de7f5e1e')  # tag:19.10
     version('19.08', commit='bdd1146139e8727a513d451075f900c172eb81fd')  # tag:19.08
     version('18.10.1', commit='260b53169badaa760b91dfc60ea6b2ea3d9ccf06')  # tag:18.10.1


### PR DESCRIPTION
Now using Github releases instead of git commits.