### PR TITLE
Build graphite2 with Intel compiler

### DIFF
--- a/var/spack/repos/builtin/packages/graphite2/package.py
+++ b/var/spack/repos/builtin/packages/graphite2/package.py
@@ -16,3 +16,5 @@ class Graphite2(CMakePackage):
     url      = "https://github.com/silnrsi/graphite/releases/download/1.3.13/graphite2-1.3.13.tgz"
 
     version('1.3.13', sha256='dd63e169b0d3cf954b397c122551ab9343e0696fb2045e1b326db0202d875f06')
+
+    patch('regparm.patch')

--- a/var/spack/repos/builtin/packages/graphite2/regparm.patch
+++ b/var/spack/repos/builtin/packages/graphite2/regparm.patch
@@ -1,0 +1,11 @@
+--- a/src/inc/Machine.h	2018-12-20 00:28:50.000000000 -0600
++++ b/src/inc/Machine.h	2020-01-26 19:15:29.965965418 -0600
+@@ -46,7 +46,7 @@
+ #endif
+ #else
+ #define     HOT             __attribute__((hot))
+-#if defined(__x86_64)
++#if defined(__x86_64) && !defined(__INTEL_COMPILER)
+ #define     REGPARM(n)      __attribute__((hot, regparm(n)))
+ #else
+ #define     REGPARM(n)


### PR DESCRIPTION
This PR sets the definition of REGPARM when building with the Intel
compiler.