### PR TITLE
openPMD-api: With ADIOS2 by Default

### DIFF
--- a/var/spack/repos/builtin/packages/openpmd-api/package.py
+++ b/var/spack/repos/builtin/packages/openpmd-api/package.py
@@ -26,9 +26,9 @@ class OpenpmdApi(CMakePackage):
             description='Enable parallel I/O')
     variant('hdf5', default=True,
             description='Enable HDF5 support')
-    variant('adios1', default=True,
+    variant('adios1', default=False,
             description='Enable ADIOS1 support')
-    variant('adios2', default=False,
+    variant('adios2', default=True,
             description='Enable ADIOS2 support')
     variant('python', default=False,
             description='Enable Python bindings')
@@ -40,9 +40,9 @@ class OpenpmdApi(CMakePackage):
     depends_on('hdf5@1.8.13:', when='+hdf5')
     depends_on('hdf5@1.8.13: ~mpi', when='~mpi +hdf5')
     depends_on('hdf5@1.8.13: +mpi', when='+mpi +hdf5')
-    depends_on('adios@1.13.1:', when='+adios1')
-    depends_on('adios@1.13.1: ~mpi', when='~mpi +adios1')
-    depends_on('adios@1.13.1: +mpi', when='+mpi +adios1')
+    depends_on('adios@1.13.1: ~sz', when='+adios1')
+    depends_on('adios@1.13.1: ~mpi ~sz', when='~mpi +adios1')
+    depends_on('adios@1.13.1: +mpi ~sz', when='+mpi +adios1')
     depends_on('adios2@2.5.0:', when='+adios2')
     depends_on('adios2@2.5.0: ~mpi', when='~mpi +adios2')
     depends_on('adios2@2.5.0: +mpi', when='+mpi +adios2')


### PR DESCRIPTION
Replace the deprecated ADIOS1 backend default with ADIOS2 default.
Disable `sz` in ADIOS1 since we do not need it and it conflicts with supported version ranges between ADIOS2 and ADIOS1 if someone enables both.