### PR TITLE
med: add a space between literal and identifier.

### DIFF
--- a/var/spack/repos/builtin/packages/med/add_space.patch
+++ b/var/spack/repos/builtin/packages/med/add_space.patch
@@ -1,0 +1,20 @@
+--- spack-src/tools/medimport/2.3.1/MED231champRefInfoEtRenMaabuilt.cxx.org	2020-01-28 16:02:49.656440054 +0900
++++ spack-src/tools/medimport/2.3.1/MED231champRefInfoEtRenMaabuilt.cxx	2020-01-28 16:03:45.222261190 +0900
+@@ -95,7 +95,7 @@
+     SSCRUTE(maai); goto ERROR;
+   }
+   if ( MAJ_231_232_chaine(maai,maaf) ) {
+-    fprintf(stdout,"  >>> Normalisation du nom de maillage par défaut [%s] associé au champ [%s] pour (n°dt,n°it) ("IFORMAT","IFORMAT")\n",maai,champ,numdt,numo);
++    fprintf(stdout,"  >>> Normalisation du nom de maillage par défaut [%s] associé au champ [%s] pour (n°dt,n°it) (" IFORMAT "," IFORMAT ")\n",maai,champ,numdt,numo);
+     ret = _MEDattrStringEcrire(datagroup2,MED_NOM_MAI,MED_TAILLE_NOM,maaf);
+     EXIT_IF(ret < 0,"Renommage du maillage en",maaf);
+     fprintf(stdout,"  >>> Normalisation du nom du maillage par défaut [%s] ... OK ... \n",maaf);
+@@ -120,7 +120,7 @@
+   
+   if ( MAJ_231_232_chaine(maa,maaf) ) {
+   
+-    fprintf(stdout,"  >>> Normalisation du nom de maillage [%s] associé au champ [%s] pour (n°dt,n°it) ("IFORMAT","IFORMAT")\n",maa,champ,numdt,numo);
++    fprintf(stdout,"  >>> Normalisation du nom de maillage [%s] associé au champ [%s] pour (n°dt,n°it) (" IFORMAT "," IFORMAT ")\n",maa,champ,numdt,numo);
+     /* on accede au maillage */
+     strcpy(chemini,chemin);
+     strcat(chemini,maa);

--- a/var/spack/repos/builtin/packages/med/package.py
+++ b/var/spack/repos/builtin/packages/med/package.py
@@ -22,6 +22,9 @@ class Med(CMakePackage):
     depends_on('mpi')
     depends_on('hdf5@:1.8.19+mpi')
 
+    # C++11 requires a space between literal and identifier
+    patch('add_space.patch')
+
     # FIXME This is minimal installation.
 
     def cmake_args(self):


### PR DESCRIPTION
error:
`invalid suffix on literal; C++11 requires a space between literal and identifier [-Wreserved-user-defined-literal]`

I added a space between literal and identifier at spots where error occured.