### PR TITLE
intel-tbb: Fix install names on Darwin

### DIFF
--- a/var/spack/repos/builtin/packages/intel-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-tbb/package.py
@@ -9,6 +9,7 @@ import inspect
 import platform
 import sys
 
+
 class IntelTbb(Package):
     """Widely used C++ template library for task parallelism.
     Intel Threading Building Blocks (Intel TBB) lets you easily write parallel
@@ -201,7 +202,7 @@ class IntelTbb(Package):
                           'tbb_config_generator.cmake')
             with working_dir(join_path(self.stage.source_path, 'cmake')):
                 inspect.getmodule(self).cmake(*cmake_args)
-    
+
     @run_after('install')
     def darwin_fix(self):
         # Replace @rpath in ids with full path

--- a/var/spack/repos/builtin/packages/intel-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-tbb/package.py
@@ -7,7 +7,7 @@ from spack import *
 import glob
 import inspect
 import platform
-
+import sys
 
 class IntelTbb(Package):
     """Widely used C++ template library for task parallelism.
@@ -201,3 +201,9 @@ class IntelTbb(Package):
                           'tbb_config_generator.cmake')
             with working_dir(join_path(self.stage.source_path, 'cmake')):
                 inspect.getmodule(self).cmake(*cmake_args)
+    
+    @run_after('install')
+    def darwin_fix(self):
+        # Replace @rpath in ids with full path
+        if sys.platform == 'darwin':
+            fix_darwin_install_name(self.prefix.lib)


### PR DESCRIPTION
Intel-TBB's libraries on Darwin are installed with "@rpath" prefixed to their install names. This was found to cause issues building the `root` package on Darwin due to libtbb not being found when running some of the generated tools linking to it.

Follow example from other packages with the same issue and fixup up install names for intel-tbb post install.