### PR TITLE
Fix handling of filter_file exceptions

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -201,7 +201,6 @@ def filter_file(regex, repl, *filenames, **kwargs):
                         output_file.writelines(input_file.readlines())
 
         except BaseException:
-            os.remove(tmp_filename)
             # clean up the original file on failure.
             shutil.move(backup_filename, filename)
             raise


### PR DESCRIPTION
Our exception handler currently raises an exception of its own when handling an error in a `filter_file` operation. Because the temp file is removed in the `finally` block, we should not remove it in the `except` block.

This removes the first call to remove the file, now the code reports the appropriate exception from `filter_file`