### PR TITLE
bugfix/tests:  Correct exception message matching

### DIFF
--- a/lib/spack/spack/test/cmd/create.py
+++ b/lib/spack/spack/test/cmd/create.py
@@ -95,11 +95,15 @@ def test_create_template(parser, mock_test_repo, args, name, expected):
     (' ', 'name must be provided'),
     ('bad#name', 'name can only contain'),
 ])
-def test_create_template_bad_name(parser, mock_test_repo, name, expected):
+def test_create_template_bad_name(
+        parser, mock_test_repo, name, expected, capsys):
     """Test template creation with bad name options."""
     constr_args = parser.parse_args(['--skip-editor', '-n', name])
-    with pytest.raises(SystemExit, matches=expected):
+    with pytest.raises(SystemExit):
         spack.cmd.create.create(parser, constr_args)
+
+    captured = capsys.readouterr()
+    assert expected in str(captured)
 
 
 def test_build_system_guesser_no_stage(parser):
@@ -108,7 +112,7 @@ def test_build_system_guesser_no_stage(parser):
 
     # Ensure get the expected build system
     with pytest.raises(AttributeError,
-                       matches="'NoneType' object has no attribute"):
+                       match="'NoneType' object has no attribute"):
         guesser(None, '/the/url/does/not/matter')
 
 
@@ -142,7 +146,7 @@ def test_get_name_urls(parser, url, expected):
     assert name == expected
 
 
-def test_get_name_error(parser, monkeypatch):
+def test_get_name_error(parser, monkeypatch, capsys):
     """Test get_name UndetectableNameError exception path."""
     def _parse_name_offset(path, v):
         raise UndetectableNameError(path)
@@ -152,5 +156,7 @@ def test_get_name_error(parser, monkeypatch):
     url = 'downloads.sourceforge.net/noapp/'
     args = parser.parse_args([url])
 
-    with pytest.raises(SystemExit, matches="Couldn't guess a name"):
+    with pytest.raises(SystemExit):
         spack.cmd.create.get_name(args)
+    captured = capsys.readouterr()
+    assert "Couldn't guess a name" in str(captured)

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -169,7 +169,7 @@ def test_git_extra_fetch(tmpdir):
 def test_needs_stage():
     """Trigger a NoStageError when attempt a fetch without a stage."""
     with pytest.raises(spack.fetch_strategy.NoStageError,
-                       matches=_mock_transport_error):
+                       match=r"set_stage.*before calling fetch"):
         fetcher = GitFetchStrategy(git='file:///not-a-real-git-repo')
         fetcher.fetch()
 

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -316,14 +316,14 @@ def test_uninstall_by_spec_errors(mutable_database):
     """Test exceptional cases with the uninstall command."""
 
     # Try to uninstall a spec that has not been installed
-    rec = mutable_database.get_record('zmpi')
-    with pytest.raises(InstallError, matches="not installed"):
-        PackageBase.uninstall_by_spec(rec.spec)
+    spec = Spec('dependent-install')
+    spec.concretize()
+    with pytest.raises(InstallError, match="is not installed"):
+        PackageBase.uninstall_by_spec(spec)
 
     # Try an unforced uninstall of a spec with dependencies
     rec = mutable_database.get_record('mpich')
-
-    with pytest.raises(PackageStillNeededError, matches="cannot uninstall"):
+    with pytest.raises(PackageStillNeededError, match="Cannot uninstall"):
         PackageBase.uninstall_by_spec(rec.spec)
 
 

--- a/lib/spack/spack/test/llnl/util/cpu.py
+++ b/lib/spack/spack/test/llnl/util/cpu.py
@@ -245,7 +245,7 @@ def test_unsupported_optimization_flags(target_name, compiler, version):
     target = llnl.util.cpu.targets[target_name]
     with pytest.raises(
             llnl.util.cpu.UnsupportedMicroarchitecture,
-            matches='cannot produce optimized binary'
+            match='cannot produce optimized binary'
     ):
         target.optimization_flags(compiler, version)
 
@@ -287,5 +287,5 @@ def test_invalid_family():
         vendor='Imagination', features=[], compilers={}, generation=0
     )
     with pytest.raises(AssertionError,
-                       matches='a target is expected to belong'):
+                       match='a target is expected to belong'):
         multi_parents.family

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -116,13 +116,13 @@ class TestCopyTree:
 
         # Make sure we get the right error if we try to copy a parent into
         # a descendent directory.
-        with pytest.raises(ValueError, matches="Cannot copy"):
+        with pytest.raises(ValueError, match="Cannot copy"):
             with fs.working_dir(str(stage)):
                 fs.copy_tree('source', 'source/sub/directory')
 
         # Only point with this check is to make sure we don't try to perform
         # the copy.
-        with pytest.raises(IOError, matches="No such file or directory"):
+        with pytest.raises(IOError, match="No such file or directory"):
             with fs.working_dir(str(stage)):
                 fs.copy_tree('foo/ba', 'foo/bar')
 

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -927,8 +927,11 @@ def test_stage_create_replace_path(tmp_build_stage_dir):
     assert os.path.isdir(stage.path)
 
 
-def test_cannot_access():
+def test_cannot_access(capsys):
     """Ensure can_access dies with the expected error."""
-    with pytest.raises(SystemExit, matches='Insufficient permissions'):
+    with pytest.raises(SystemExit):
         # It's far more portable to use a non-existent filename.
         spack.stage.ensure_access('/no/such/file')
+
+    captured = capsys.readouterr()
+    assert 'Insufficient permissions' in str(captured)


### PR DESCRIPTION
This commit makes two fundamental corrections to affected tests:
1) Changes `matches` to the correct `match` argument for `pytest.raises` (except tests checking for `SystemExit`);
2) Replaces the `match` argument for tests expecting `SystemExit` (since the exit code is retained instead) with `capsys` error message capture.

Both changes are needed to ensure the associated exception message is actually checked.