### PR TITLE
Fujitsu compiler: Defining option that is always added.

### DIFF
--- a/lib/spack/spack/compilers/fj.py
+++ b/lib/spack/spack/compilers/fj.py
@@ -61,3 +61,7 @@ class Fj(spack.compiler.Compiler):
     @property
     def pic_flag(self):
         return "-KPIC"
+
+    def setup_custom_environment(self, pkg, env):
+        env.append_flags('fcc_ENV', '-Nclang')
+        env.append_flags('FCC_ENV', '-Nclang')


### PR DESCRIPTION
There is required option when building OSS with Fujitsu compiler. We set it in the `compilers.yaml` until now, but I modified to be defined in the compiler source.