### PR TITLE
Automatically set flags for NAG compiler

### DIFF
--- a/lib/spack/spack/compilers/nag.py
+++ b/lib/spack/spack/compilers/nag.py
@@ -60,7 +60,8 @@ class Nag(spack.compiler.Compiler):
         return '-Wl,-Wl,,'
 
     # The NAG compiler is more strict than other compilers, and most packages
-    # will fail to build without these flags set
+    # will fail to build without these flags set. See:
+    # https://www.nag.co.uk/nagware/np/r70_doc/manual/compiler_2_4.html#OPTIONS
     def setup_custom_environment(self, pkg, env):
         env.append_flags('FFLAGS', '-mismatch -dusty')
         env.append_flags('FCFLAGS', '-mismatch -dusty')

--- a/lib/spack/spack/compilers/nag.py
+++ b/lib/spack/spack/compilers/nag.py
@@ -58,3 +58,9 @@ class Nag(spack.compiler.Compiler):
     @property
     def linker_arg(self):
         return '-Wl,-Wl,,'
+
+    # The NAG compiler is more strict than other compilers, and most packages
+    # will fail to build without these flags set
+    def setup_custom_environment(self, pkg, env):
+        env.append_flags('FFLAGS', '-mismatch -dusty')
+        env.append_flags('FCFLAGS', '-mismatch -dusty')


### PR DESCRIPTION
Inspired by #14657, I decided to automatically add the flags needed by the NAG Fortran compiler to build most packages. This is the same advice we give in https://spack.readthedocs.io/en/latest/getting_started.html#nag and what I used at ANL back in the day. Pinging @ThemosTsikas in case he has any thoughts about always adding these flags. I believe @skosukhin @willfurnass also use NAG with Spack.