### PR TITLE
Limit the number of spec files downloaded to find matches for buildcaches

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -661,7 +661,7 @@ def extract_tarball(spec, filename, allow_root=False, unsigned=False,
 
 
 #: Internal cache for get_specs
-_cached_specs = []
+_cached_specs = None
 
 
 def get_specs(force=False, use_arch=False, names=[]):
@@ -682,9 +682,9 @@ def get_specs(force=False, use_arch=False, names=[]):
                                                     names_pattern)
     name_re = re.compile(regex_pattern)
 
-#    if _cached_specs:
-#        tty.debug("Using previously-retrieved specs")
-#        return _cached_specs
+    if _cached_specs:
+        tty.debug("Using previously-retrieved specs")
+        return _cached_specs
 
     if not spack.mirror.MirrorCollection():
         tty.debug("No Spack mirrors are currently configured")
@@ -714,6 +714,7 @@ def get_specs(force=False, use_arch=False, names=[]):
                 m = name_re.search(link)
                 if m:
                     urls.add(link)
+    _cached_specs = []
     for link in urls:
         with Stage(link, name="build_cache", keep=True) as stage:
             if force and os.path.exists(stage.save_filename):
@@ -729,8 +730,7 @@ def get_specs(force=False, use_arch=False, names=[]):
                 # we need to mark this spec concrete on read-in.
                 spec = Spec.from_yaml(f)
                 spec._mark_concrete()
-                if spec not in set(_cached_specs):
-                    _cached_specs.append(spec)
+                _cached_specs.append(spec)
 
     return _cached_specs
 

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -417,13 +417,14 @@ def install_tarball(spec, args):
 
 def listspecs(args):
     """list binary packages available from mirrors"""
-    specs = set()
+    specs = list()
     if args.specs:
         for s in bindist.get_specs(force=args.force, use_arch=args.arch,
                                    names=args.specs):
-            specs.add(s)
+            if s not in set(specs):
+                specs.append(s)
     else:
-        specs = set(bindist.get_specs(force=args.force, use_arch=args.arch))
+        specs = bindist.get_specs(force=args.force, use_arch=args.arch)
     display_specs(specs, args, all_headers=True)
 
 

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -87,6 +87,8 @@ def setup_parser(subparser):
                            help='show variants in output (can be long)')
     listcache.add_argument('-f', '--force', action='store_true',
                            help="force new download of specs")
+    listcache.add_argument('-a', '--arch', action='store_true',
+                           help="only list spec for the default architecture")
     arguments.add_common_arguments(listcache, ['specs'])
     listcache.set_defaults(func=listspecs)
 
@@ -263,10 +265,10 @@ def match_downloaded_specs(pkgs, allow_multiple_matches=False, force=False):
     # List of specs that match expressions given via command line
     specs_from_cli = []
     has_errors = False
-    specs = bindist.get_specs(force)
     for pkg in pkgs:
         matches = []
         tty.msg("buildcache spec(s) matching %s \n" % pkg)
+        specs = bindist.get_specs(names=[pkg])
         for spec in sorted(specs):
             if pkg.startswith('/'):
                 pkghash = pkg.replace('/', '')
@@ -415,10 +417,13 @@ def install_tarball(spec, args):
 
 def listspecs(args):
     """list binary packages available from mirrors"""
-    specs = bindist.get_specs(args.force)
+    specs = set()
     if args.specs:
-        constraints = set(args.specs)
-        specs = [s for s in specs if any(s.satisfies(c) for c in constraints)]
+        for s in bindist.get_specs(force=args.force, use_arch=args.arch,
+                                   names=args.specs):
+            specs.add(s)
+    else:
+        specs = set(bindist.get_specs(force=args.force, use_arch=args.arch))
     display_specs(specs, args, all_headers=True)
 
 

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -419,8 +419,8 @@ def listspecs(args):
     """list binary packages available from mirrors"""
     specs = list()
     if args.specs:
-        for s in bindist.get_specs(force=args.force, use_arch=args.arch,
-                                   names=args.specs):
+        for s in bindist.get_specs(args.force, args.arch,
+                                   args.specs):
             if s not in set(specs):
                 specs.append(s)
     else:

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1510,7 +1510,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
 
     def try_install_from_binary_cache(self, explicit):
         tty.msg('Searching for binary cache of %s' % self.name)
-        specs = binary_distribution.get_specs(use_arch=True)
+        specs = binary_distribution.get_specs(use_arch=True, names=[self.name])
         binary_spec = spack.spec.Spec.from_dict(self.spec.to_dict())
         binary_spec._mark_concrete()
         if binary_spec not in specs:

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -17,7 +17,7 @@ buildcache = spack.main.SpackCommand('buildcache')
 def mock_get_specs(database, monkeypatch):
     specs = database.query_local()
     monkeypatch.setattr(
-        spack.binary_distribution, 'get_specs', lambda x: specs
+        spack.binary_distribution, 'get_specs', lambda x, y, z: specs
     )
 
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -400,7 +400,7 @@ _spack_buildcache_install() {
 _spack_buildcache_list() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -l --long -L --very-long -v --variants -f --force"
+        SPACK_COMPREPLY="-h --help -l --long -L --very-long -v --variants -f --force -a --arch"
     else
         _all_packages
     fi


### PR DESCRIPTION
Further limit the number of spec files downloaded by spack install process when it looks for buildcaches. Use the package name or hash in a regex along with current platform and os to match urls for spec files before they are downloaded.