### PR TITLE
Faster spec parsing and imports

### DIFF
--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -932,7 +932,7 @@ class Repo(object):
                     tty.warn("Patch file did not exist: %s" % patch.path)
 
         # Install the package.py file itself.
-        install(self.filename_for_package_name(spec), path)
+        install(self.filename_for_package_name(spec.name), path)
 
     def purge(self):
         """Clear entire package instance cache."""
@@ -974,20 +974,12 @@ class Repo(object):
     def extensions_for(self, extendee_spec):
         return [p for p in self.all_packages() if p.extends(extendee_spec)]
 
-    def _check_namespace(self, spec):
-        """Check that the spec's namespace is the same as this repository's."""
-        if spec.namespace and spec.namespace != self.namespace:
-            raise UnknownNamespaceError(spec.namespace)
-
-    @autospec
-    def dirname_for_package_name(self, spec):
+    def dirname_for_package_name(self, pkg_name):
         """Get the directory name for a particular package.  This is the
            directory that contains its package.py file."""
-        self._check_namespace(spec)
-        return os.path.join(self.packages_path, spec.name)
+        return os.path.join(self.packages_path, pkg_name)
 
-    @autospec
-    def filename_for_package_name(self, spec):
+    def filename_for_package_name(self, pkg_name):
         """Get the filename for the module we should load for a particular
            package.  Packages for a Repo live in
            ``$root/<package_name>/package.py``
@@ -996,8 +988,7 @@ class Repo(object):
            package doesn't exist yet, so callers will need to ensure
            the package exists before importing.
         """
-        self._check_namespace(spec)
-        pkg_dir = self.dirname_for_package_name(spec.name)
+        pkg_dir = self.dirname_for_package_name(pkg_name)
         return os.path.join(pkg_dir, package_file_name)
 
     @property

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1117,6 +1117,18 @@ class Spec(object):
         self._dependencies[spec.name] = dspec
         spec._dependents[self.name] = dspec
 
+    def _add_default_platform(self):
+        """If a spec has an os or a target and no platform, give it
+           the default platform.
+
+           This is private because it is used by the parser -- it's not
+           expected to be used outside of ``spec.py``.
+
+        """
+        arch = self.architecture
+        if arch and not arch.platform and (arch.os or arch.target):
+            self._set_architecture(platform=spack.architecture.platform().name)
+
     #
     # Public interface
     #
@@ -4053,14 +4065,6 @@ class SpecParser(spack.parse.Parser):
         except spack.parse.ParseError as e:
             raise SpecParseError(e)
 
-        # If the spec has an os or a target and no platform, give it
-        # the default platform
-        platform_default = spack.architecture.platform().name
-        for spec in specs:
-            for s in spec.traverse():
-                if s.architecture and not s.architecture.platform and \
-                        (s.architecture.os or s.architecture.target):
-                    s._set_architecture(platform=platform_default)
         return specs
 
     def spec_from_file(self):
@@ -4192,6 +4196,7 @@ class SpecParser(spack.parse.Parser):
             else:
                 break
 
+        spec._add_default_platform()
         return spec
 
     def variant(self, name=None):


### PR DESCRIPTION
Importing `package.py` files involves a lot of spec parsing, which currently takes the bulk of the time.  This `test.py` script:

```python
#!/usr/bin/env spack-python
import spack.repo
for name in spack.repo.all_package_names():
    spack.repo.path.get_pkg_class(name)
```

takes ~8.5s on my machine on current `develop`.  With the changes included here, it takes 7.4s.  It's small but it makes a difference when importing lots of files.  The new concretizer will import a lot of packages, so I'm trying to speed this up.

- [x] Avoid auto-creating `Spec` objects in `filename_for_package_name()` when all we need is a package name.
- [x] Avoid calling `traverse()` in `SpecParser`