### PR TITLE
Fix py-pillow tests

### DIFF
--- a/var/spack/repos/builtin/packages/py-pillow/package.py
+++ b/var/spack/repos/builtin/packages/py-pillow/package.py
@@ -103,6 +103,8 @@ class PyPillow(PythonPackage):
         return args
 
     # Tests need to be re-added since `phases` was overridden
-    run_after('build_ext')(PythonPackage.test)
-    run_after('install')(PythonPackage.import_module_test)
+    run_after('build_ext')(
+        PythonPackage._run_default_build_time_test_callbacks)
+    run_after('install')(
+        PythonPackage._run_default_install_time_test_callbacks)
     run_after('install')(PythonPackage.sanity_check_prefix)


### PR DESCRIPTION
In #14666, @aweits reported that the `py-pillow` tests are being run regardless of whether `--test=root` was requested. This PR fixes that.