### PR TITLE
Synchronize env reading and uninstall

### DIFF
--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -205,9 +205,6 @@ def do_uninstall(env, specs, force):
             # want to uninstall.
             spack.package.Package.uninstall_by_spec(item, force=True)
 
-        if env:
-            _remove_from_env(item, env)
-
     # A package is ready to be uninstalled when nothing else references it,
     # unless we are requested to force uninstall it.
     is_ready = lambda x: not spack.store.db.query_by_spec_hash(x)[1].ref_count
@@ -225,10 +222,6 @@ def do_uninstall(env, specs, force):
         packages = [x for x in packages if x not in ready]
         for item in ready:
             item.do_uninstall(force=force)
-
-    # write any changes made to the active environment
-    if env:
-        env.write()
 
 
 def get_uninstall_list(args, specs, env):
@@ -317,9 +310,15 @@ def uninstall_specs(args, specs):
     if not args.yes_to_all:
         confirm_removal(anything_to_do)
 
-    # just force-remove things in the remove list
-    for spec in remove_list:
-        _remove_from_env(spec, env)
+    if env:
+        # Remove all the specs that are supposed to be uninstalled or just
+        # removed.
+        with env.write_transaction():
+            for spec in remove_list:
+                _remove_from_env(spec, env)
+            for spec in uninstall_list:
+                _remove_from_env(spec, env)
+            env.write()
 
     # Uninstall everything on the list
     do_uninstall(env, uninstall_list, args.force)

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -6,6 +6,7 @@
 from __future__ import print_function
 
 import sys
+import itertools
 
 import spack.cmd
 import spack.environment as ev
@@ -314,9 +315,7 @@ def uninstall_specs(args, specs):
         # Remove all the specs that are supposed to be uninstalled or just
         # removed.
         with env.write_transaction():
-            for spec in remove_list:
-                _remove_from_env(spec, env)
-            for spec in uninstall_list:
+            for spec in itertools.chain(remove_list, uninstall_list):
                 _remove_from_env(spec, env)
             env.write()
 

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1477,8 +1477,7 @@ class Environment(object):
 
         # Remove yaml sections that are shadowing defaults
         # construct garbage path to ensure we don't find a manifest by accident
-        env_dir = None
-        try:
+        with fs.temp_cwd() as env_dir:
             env_dir = tempfile.mkdtemp()
             bare_env = Environment(env_dir, with_view=self.view_path_default)
             keys_present = list(yaml_dict.keys())
@@ -1486,9 +1485,6 @@ class Environment(object):
                 if yaml_dict[key] == config_dict(bare_env.yaml).get(key, None):
                     if key not in raw_yaml_dict:
                         del yaml_dict[key]
-        finally:
-            if env_dir:
-                shutil.rmtree(env_dir)
 
         # if all that worked, write out the manifest file at the top level
         # Only actually write if it has changed or was never written

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -568,6 +568,9 @@ class Environment(object):
         self.clear()
 
         if init_file:
+            # If we are creating the environment from an init file, we don't
+            # need to lock, because there are no Spack operations which alter
+            # the init file.
             with fs.open_if_filename(init_file) as f:
                 if hasattr(f, 'name') and f.name.endswith('.lock'):
                     self._read_manifest(default_manifest_yaml)

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -569,7 +569,7 @@ class Environment(object):
 
         if init_file:
             # If we are creating the environment from an init file, we don't
-            # need to lock, because there are no Spack operations which alter
+            # need to lock, because there are no Spack operations that alter
             # the init file.
             with fs.open_if_filename(init_file) as f:
                 if hasattr(f, 'name') and f.name.endswith('.lock'):
@@ -579,7 +579,7 @@ class Environment(object):
                 else:
                     self._read_manifest(f, raw_yaml=default_manifest_yaml)
         else:
-            with self.read_transaction():
+            with lk.ReadTransaction(self.txlock):
                 self._read()
 
         if with_view is False:
@@ -627,9 +627,6 @@ class Environment(object):
     def write_transaction(self):
         """Get a write lock context manager for use in a `with` block."""
         return lk.WriteTransaction(self.txlock, acquire=self._re_read)
-
-    def read_transaction(self):
-        return lk.ReadTransaction(self.txlock)
 
     def _read_manifest(self, f, raw_yaml=None):
         """Read manifest file and set up user specs."""

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -575,7 +575,8 @@ class Environment(object):
                 else:
                     self._read_manifest(f, raw_yaml=default_manifest_yaml)
         else:
-            self._read()
+            with self.read_transaction():
+                self._read()
 
         if with_view is False:
             self.views = {}
@@ -622,6 +623,9 @@ class Environment(object):
     def write_transaction(self):
         """Get a write lock context manager for use in a `with` block."""
         return lk.WriteTransaction(self.txlock, acquire=self._re_read)
+
+    def read_transaction(self):
+        return lk.ReadTransaction(self.txlock)
 
     def _read_manifest(self, f, raw_yaml=None):
         """Read manifest file and set up user specs."""

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -8,7 +8,6 @@ import os
 import re
 import sys
 import shutil
-import tempfile
 import copy
 import socket
 
@@ -1478,7 +1477,6 @@ class Environment(object):
         # Remove yaml sections that are shadowing defaults
         # construct garbage path to ensure we don't find a manifest by accident
         with fs.temp_cwd() as env_dir:
-            env_dir = tempfile.mkdtemp()
             bare_env = Environment(env_dir, with_view=self.view_path_default)
             keys_present = list(yaml_dict.keys())
             for key in keys_present:


### PR DESCRIPTION
* `Environment.__init__` is now synchronized with all writing operations
* `spack uninstall` now synchronizes its updates to any associated environment
  * A side effect of this is that the environment is no longer updated piecemeal as specs are uninstalled - all specs are removed from the environment before they are uninstalled