### PR TITLE
Temporary fix for tensorflow until a better solution is found

### DIFF
--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -248,6 +248,8 @@ class PyTensorflow(Package, CudaPackage):
     def setup_build_environment(self, env):
         spec = self.spec
 
+        env.set('SPACK_INCLUDE_DIRS', '', force=True)
+
         # Please specify the location of python
         env.set('PYTHON_BIN_PATH', spec['python'].command.path)
 


### PR DESCRIPTION
As discussed in https://github.com/bazelbuild/bazel/issues/10437#issuecomment-580028159. 

I've also tried using the `transitive_rpaths` approach ([on a different fork](https://github.com/s-sajid-ali/spack/blob/transitive_rpaths_tf/var/spack/repos/builtin/packages/py-tensorflow/package.py)), but that didn't work. 

I'd prefer unsetting `SPACK_INCLUDE_DIRS` over switching `CC` to `self.compiler.cc` because this still allows the spack compiler wrapper to set target arch flags appropriately. 

I've successfully built and tested `py-tensorflow` with this modification : 
```
[sajid@xrm-backup ~]$ spack install py-tensorflow@2.1.0%gcc@7.4.0 ~cuda ~nccl ^python@3.7.4 ^bazel@0.29.1 ^intel-mkl ^jdk@1.8.0_241-b07 ^/e4jkv5
==> py-tensorflow is already installed in /home/sajid/packages/spack/opt/spack/linux-rhel8-skylake_avx512/gcc-7.4.0/py-tensorflow-2.1.0-l3cs6pxbqeylvq72ikm7caiph4germ73
```

@adamjstewart, @Sinan81  : Is this is an acceptable solution for now ?

@coreyjadams @pramodk @pat-s : Does this solve any of your problems ?