### PR TITLE
multiprocessing: allow Spack to run uninterrupted in background

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -40,6 +40,7 @@ packages:
       pil: [py-pillow]
       pkgconfig: [pkgconf, pkg-config]
       scalapack: [netlib-scalapack]
+      sycl: [hipsycl]
       szip: [libszip, libaec]
       tbb: [intel-tbb]
       unwind: [libunwind]

--- a/lib/spack/llnl/util/tty/log.py
+++ b/lib/spack/llnl/util/tty/log.py
@@ -22,7 +22,7 @@ import llnl.util.tty as tty
 
 try:
     import termios
-except:
+except ImportError:
     termios = None
 
 # Use this to strip escape sequences
@@ -119,7 +119,6 @@ class _keyboard_input(object):
 
             except Exception:
                 pass  # some OS's do not support termios, so ignore
-
 
     def __exit__(self, exc_type, exception, traceback):
         """If termios was avaialble, restore old settings."""

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -498,7 +498,6 @@ def test_cdash_upload_clean_build(tmpdir, mock_fetch, install_mockery, capfd):
             assert '</Build>' in content
             assert '<Text>' not in content
 
-
 @pytest.mark.disable_clean_stage_check
 def test_cdash_upload_extra_params(tmpdir, mock_fetch, install_mockery, capfd):
     # capfd interferes with Spack's capture of e.g., Build.xml output

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -498,6 +498,7 @@ def test_cdash_upload_clean_build(tmpdir, mock_fetch, install_mockery, capfd):
             assert '</Build>' in content
             assert '<Text>' not in content
 
+
 @pytest.mark.disable_clean_stage_check
 def test_cdash_upload_extra_params(tmpdir, mock_fetch, install_mockery, capfd):
     # capfd interferes with Spack's capture of e.g., Build.xml output


### PR DESCRIPTION
Spack currently cannot run as a background process uninterrupted because some of the logging functions used in the install method (especially to create the dynamic verbosity toggle with the `v` key) cause the OS to issue a `SIGTTOU` to Spack when it's backgrounded.

This PR puts the necessary gatekeeping in place so that Spack doesn't do anything that will cause a signal to stop the process when operating as a background process.