### PR TITLE
Add setdefault option to tcl module

### DIFF
--- a/lib/spack/spack/cmd/modules/lmod.py
+++ b/lib/spack/spack/cmd/modules/lmod.py
@@ -4,12 +4,11 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import functools
-import os
-
-import llnl.util.filesystem
 
 import spack.cmd.common.arguments
 import spack.cmd.modules
+import spack.config
+import spack.modules.lmod
 
 
 def add_command(parser, command_dict):
@@ -41,12 +40,19 @@ def setdefault(module_type, specs, args):
     # https://lmod.readthedocs.io/en/latest/060_locating.html#marking-a-version-as-default
     #
     spack.cmd.modules.one_spec_or_raise(specs)
-    writer = spack.modules.module_types['lmod'](
-        specs[0], args.module_set_name)
-
-    module_folder = os.path.dirname(writer.layout.filename)
-    module_basename = os.path.basename(writer.layout.filename)
-    with llnl.util.filesystem.working_dir(module_folder):
-        if os.path.exists('default') and os.path.islink('default'):
-            os.remove('default')
-        os.symlink(module_basename, 'default')
+    spec = specs[0]
+    data = {
+        'modules': {
+            args.module_set_name: {
+                'lmod': {
+                    'defaults': [str(spec)]
+                }
+            }
+        }
+    }
+    # Need to clear the cache if a SpackCommand is called during scripting
+    spack.modules.lmod.configuration_registry = {}
+    scope = spack.config.InternalConfigScope('lmod-setdefault', data)
+    with spack.config.override(scope):
+        writer = spack.modules.module_types['lmod'](spec, args.module_set_name)
+        writer.update_module_defaults()

--- a/lib/spack/spack/cmd/modules/tcl.py
+++ b/lib/spack/spack/cmd/modules/tcl.py
@@ -4,7 +4,11 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import functools
+import os
 
+import llnl.util.filesystem
+
+import spack.cmd.common.arguments
 import spack.cmd.modules
 
 
@@ -12,8 +16,37 @@ def add_command(parser, command_dict):
     tcl_parser = parser.add_parser(
         'tcl', help='manipulate non-hierarchical module files'
     )
-    spack.cmd.modules.setup_parser(tcl_parser)
+    sp = spack.cmd.modules.setup_parser(tcl_parser)
+
+    # Set default module file for a package
+    setdefault_parser = sp.add_parser(
+        'setdefault', help='set the default module file for a package'
+    )
+    spack.cmd.common.arguments.add_common_arguments(
+        setdefault_parser, ['constraint']
+    )
+
+    callbacks = dict(spack.cmd.modules.callbacks.items())
+    callbacks['setdefault'] = setdefault
 
     command_dict['tcl'] = functools.partial(
-        spack.cmd.modules.modules_cmd, module_type='tcl'
+        spack.cmd.modules.modules_cmd, module_type='tcl', callbacks=callbacks
     )
+
+
+def setdefault(module_type, specs, args):
+    """Set the default module file, when multiple are present"""
+    spack.cmd.modules.one_spec_or_raise(specs)
+    writer = spack.modules.module_types['tcl'](
+        specs[0], args.module_set_name
+    )
+
+    module_folder = os.path.dirname(writer.layout.filename)
+    module_basename = os.path.basename(writer.layout.filename)
+    with llnl.util.filesystem.working_dir(module_folder):
+        if os.path.exists('.version'):
+            os.remove('.version')
+        version_file = os.path.join(module_folder, '.version')
+        with open(version_file, mode='w') as f:
+            f.write('#%Module\n')
+            f.write('set ModulesVersion %s\n' % module_basename)

--- a/lib/spack/spack/cmd/modules/tcl.py
+++ b/lib/spack/spack/cmd/modules/tcl.py
@@ -7,6 +7,7 @@ import functools
 import spack.cmd.common.arguments
 import spack.cmd.modules
 import spack.config
+import spack.modules.tcl
 
 
 def add_command(parser, command_dict):
@@ -40,11 +41,12 @@ def setdefault(module_type, specs, args):
         'modules': {
             args.module_set_name: {
                 'tcl': {
-                    'defaults': [str(spec[0])]
+                    'defaults': [str(spec)]
                 }
             }
         }
     }
+    spack.modules.tcl.configuration_registry = {}
     scope = spack.config.InternalConfigScope('tcl-setdefault', data)
     with spack.config.override(scope):
         writer = spack.modules.module_types['tcl'](spec, args.module_set_name)

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -906,6 +906,9 @@ class BaseModuleFileWriter(object):
             fp.set_permissions_by_spec(self.layout.filename, self.spec)
 
         # Symlink defaults if needed
+        self.update_module_defaults()
+
+    def update_module_defaults(self):
         if any(self.spec.satisfies(default) for default in self.conf.defaults):
             # This spec matches a default, it needs to be symlinked to default
             # Symlink to a tmp location first and move, so that existing

--- a/lib/spack/spack/test/cmd/module.py
+++ b/lib/spack/spack/test/cmd/module.py
@@ -178,10 +178,18 @@ writer_cls = spack.modules.lmod.LmodModulefileWriter
 
 @pytest.mark.db
 def test_setdefault_command(
-        mutable_database, module_configuration
+        mutable_database, mutable_config
 ):
-    module_configuration('autoload_direct')
-
+    data = {
+        'default': {
+            'enable': ['lmod'],
+            'lmod': {
+                'core_compilers': ['clang@3.3'],
+                'hierarchy': ['mpi']
+            }
+        }
+    }
+    spack.config.set('modules', data)
     # Install two different versions of a package
     other_spec, preferred = 'a@1.0', 'a@2.0'
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1373,7 +1373,7 @@ _spack_module_tcl() {
     then
         SPACK_COMPREPLY="-h --help -n --name"
     else
-        SPACK_COMPREPLY="refresh find rm loads"
+        SPACK_COMPREPLY="refresh find rm loads setdefault"
     fi
 }
 
@@ -1408,6 +1408,15 @@ _spack_module_tcl_loads() {
     if $list_options
     then
         SPACK_COMPREPLY="-h --help --input-only -p --prefix -x --exclude -r --dependencies"
+    else
+        _installed_packages
+    fi
+}
+
+_spack_module_tcl_setdefault() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help"
     else
         _installed_packages
     fi


### PR DESCRIPTION
This PR introduces the command

```
spack module tcl setdefault <package>
```

similar to the lmod command.

Closes #13714