### PR TITLE
lmod: update version of lmod to v8.3, updated docstring

### DIFF
--- a/var/spack/repos/builtin/packages/lmod/package.py
+++ b/var/spack/repos/builtin/packages/lmod/package.py
@@ -2,23 +2,25 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-from spack import *
 from glob import glob
 
 
 class Lmod(AutotoolsPackage):
     """Lmod is a Lua based module system that easily handles the MODULEPATH
-    Hierarchical problem. Environment Modules provide a convenient way to
-    dynamically change the users' environment through modulefiles. This
-    includes easily adding or removing directories to the PATH environment
-    variable. Modulefiles for Library packages provide environment variables
-    that specify where the library and header files can be found.
+    Hierarchical problem.
+
+    Environment Modules provide a convenient way to dynamically change the
+    users' environment through modulefiles. This includes easily adding or
+    removing directories to the PATH environment variable. Modulefiles for
+    Library packages provide environment variables that specify where the
+    library and header files can be found.
     """
 
     homepage = 'https://www.tacc.utexas.edu/research-development/tacc-projects/lmod'
     url      = 'https://github.com/TACC/Lmod/archive/7.4.11.tar.gz'
 
+    version('8.3',    sha256='c2c2e9e6b387b011ee617cb009a2199caac8bf200330cb8a065ceedee09e664a')
+    version('8.2.10', sha256='15676d82235faf5c755a747f0e318badb1a5c3ff1552fa8022c67ff083ee9e2f')
     version('8.1.5',  sha256='3e5846d3d8e593cbcdfa0aed1474569bf5b5cfd19fd288de22051823d449d344')
     version('8.0.9',  sha256='9813c22ae4dd21eb3dc480f6ce307156512092b4bca954bf8aacc15944f23673')
     version('7.8.15', sha256='00a257f5073d656adc73045997c28f323b7a4f6d901f1c57b7db2b0cd6bee6e6')


### PR DESCRIPTION
The first sentence in the docstring has been separated in its own paragraph since some tools (e.g. module generation) will use that as a short description.