### PR TITLE
draco: update versions

### DIFF
--- a/var/spack/repos/builtin/packages/draco/d710-python2.patch
+++ b/var/spack/repos/builtin/packages/draco/d710-python2.patch
@@ -1,0 +1,62 @@
+diff --git a/config/ApplicationUnitTest.cmake b/config/ApplicationUnitTest.cmake
+index a0a79858..0c47b72a 100644
+--- a/config/ApplicationUnitTest.cmake
++++ b/config/ApplicationUnitTest.cmake
+@@ -249,7 +249,7 @@ macro( aut_register_test )
+   endif(VERBOSE_DEBUG)
+
+   # Look for python, which is used to drive application unit tests
+-  if( NOT PYTHONINTERP_FOUND )
++  if( NOT Python_Interpreter_FOUND )
+      # python should have been found when vendor_libraries.cmake was run.
+     message( FATAL_ERROR "Draco requires python. Python not found in PATH.")
+   endif()
+@@ -289,7 +289,7 @@ macro( aut_register_test )
+   if (${PYTHON_TEST})
+     add_test(
+       NAME ${ctestname_base}${argname}
+-      COMMAND "${PYTHON_EXECUTABLE}"
++      COMMAND "${Python_EXECUTABLE}"
+       ${aut_DRIVER}
+       ${SHARED_ARGUMENTS}
+       )
+diff --git a/config/draco-config-install.cmake.in b/config/draco-config-install.cmake.in
+index c5bf1c75..a16f72f4 100644
+--- a/config/draco-config-install.cmake.in
++++ b/config/draco-config-install.cmake.in
+@@ -107,8 +107,9 @@ set( WITH_CUDA "@WITH_CUDA@" )
+ #endif()
+
+ # Python
+-set( PYTHONINTERP_FOUND "@PYTHONINTERP_FOUND@" )
+-set( PYTHON_EXECUTABLE "@PYTHON_EXECUTABLE@" )
++set( Python_FOUND "@Python_FOUND@" )
++set( Python_Interpreter_FOUND "@Python_Interpreter_FOUND@" )
++set( Python_EXECUTABLE "@Python_EXECUTABLE@" )
+
+ ## ---------------------------------------------------------------------------
+ ## Set useful general variables
+diff --git a/config/vendor_libraries.cmake b/config/vendor_libraries.cmake
+index c3e079bc..6b393eb4 100644
+--- a/config/vendor_libraries.cmake
++++ b/config/vendor_libraries.cmake
+@@ -16,7 +16,7 @@ include( setupMPI ) # defines the macros setupMPILibrariesUnix|Windows
+ macro( setupPython )
+
+   message( STATUS "Looking for Python...." )
+-  find_package(PythonInterp 2.7 QUIET REQUIRED)
++  find_package(Python 2.7 QUIET REQUIRED COMPONENTS Interpreter)
+   #  PYTHONINTERP_FOUND - Was the Python executable found
+   #  PYTHON_EXECUTABLE  - path to the Python interpreter
+   set_package_properties( PythonInterp PROPERTIES
+@@ -25,8 +25,8 @@ macro( setupPython )
+     TYPE REQUIRED
+     PURPOSE "Required for running tests and accessing features that rely on matplotlib."
+     )
+-  if( PYTHONINTERP_FOUND )
+-    message( STATUS "Looking for Python....found ${PYTHON_EXECUTABLE}" )
++  if( Python_Interpreter_FOUND )
++    message( STATUS "Looking for Python....found ${Python_EXECUTABLE}" )
+   else()
+     message( STATUS "Looking for Python....not found" )
+   endif()

--- a/var/spack/repos/builtin/packages/draco/d710.patch
+++ b/var/spack/repos/builtin/packages/draco/d710.patch
@@ -1,0 +1,62 @@
+diff --git a/config/ApplicationUnitTest.cmake b/config/ApplicationUnitTest.cmake
+index a0a79858..0c47b72a 100644
+--- a/config/ApplicationUnitTest.cmake
++++ b/config/ApplicationUnitTest.cmake
+@@ -249,7 +249,7 @@ macro( aut_register_test )
+   endif(VERBOSE_DEBUG)
+
+   # Look for python, which is used to drive application unit tests
+-  if( NOT PYTHONINTERP_FOUND )
++  if( NOT Python_Interpreter_FOUND )
+      # python should have been found when vendor_libraries.cmake was run.
+     message( FATAL_ERROR "Draco requires python. Python not found in PATH.")
+   endif()
+@@ -289,7 +289,7 @@ macro( aut_register_test )
+   if (${PYTHON_TEST})
+     add_test(
+       NAME ${ctestname_base}${argname}
+-      COMMAND "${PYTHON_EXECUTABLE}"
++      COMMAND "${Python_EXECUTABLE}"
+       ${aut_DRIVER}
+       ${SHARED_ARGUMENTS}
+       )
+diff --git a/config/draco-config-install.cmake.in b/config/draco-config-install.cmake.in
+index c5bf1c75..a16f72f4 100644
+--- a/config/draco-config-install.cmake.in
++++ b/config/draco-config-install.cmake.in
+@@ -107,8 +107,9 @@ set( WITH_CUDA "@WITH_CUDA@" )
+ #endif()
+
+ # Python
+-set( PYTHONINTERP_FOUND "@PYTHONINTERP_FOUND@" )
+-set( PYTHON_EXECUTABLE "@PYTHON_EXECUTABLE@" )
++set( Python_FOUND "@Python_FOUND@" )
++set( Python_Interpreter_FOUND "@Python_Interpreter_FOUND@" )
++set( Python_EXECUTABLE "@Python_EXECUTABLE@" )
+
+ ## ---------------------------------------------------------------------------
+ ## Set useful general variables
+diff --git a/config/vendor_libraries.cmake b/config/vendor_libraries.cmake
+index c3e079bc..6b393eb4 100644
+--- a/config/vendor_libraries.cmake
++++ b/config/vendor_libraries.cmake
+@@ -16,7 +16,7 @@ include( setupMPI ) # defines the macros setupMPILibrariesUnix|Windows
+ macro( setupPython )
+
+   message( STATUS "Looking for Python...." )
+-  find_package(PythonInterp 2.7 QUIET REQUIRED)
++  find_package(Python 3.5 QUIET REQUIRED COMPONENTS Interpreter)
+   #  PYTHONINTERP_FOUND - Was the Python executable found
+   #  PYTHON_EXECUTABLE  - path to the Python interpreter
+   set_package_properties( PythonInterp PROPERTIES
+@@ -25,8 +25,8 @@ macro( setupPython )
+     TYPE REQUIRED
+     PURPOSE "Required for running tests and accessing features that rely on matplotlib."
+     )
+-  if( PYTHONINTERP_FOUND )
+-    message( STATUS "Looking for Python....found ${PYTHON_EXECUTABLE}" )
++  if( Python_Interpreter_FOUND )
++    message( STATUS "Looking for Python....found ${Python_EXECUTABLE}" )
+   else()
+     message( STATUS "Looking for Python....not found" )
+   endif()

--- a/var/spack/repos/builtin/packages/draco/d730.patch
+++ b/var/spack/repos/builtin/packages/draco/d730.patch
@@ -1,0 +1,34 @@
+diff --git a/config/platform_checks.cmake b/config/platform_checks.cmake
+index c9841b0d..84bf07f5 100644
+--- a/config/platform_checks.cmake
++++ b/config/platform_checks.cmake
+@@ -85,6 +85,7 @@ macro( query_craype )
+       set( CRAY_PE ON CACHE BOOL
+         "Are we building in a Cray Programming Environment?")
+
++      if (FALSE)
+       # We expect developers to use the Cray compiler wrappers (especially in
+       # setupMPI.cmake). See also
+       # https://cmake.org/cmake/help/latest/module/FindMPI.html
+@@ -111,6 +112,7 @@ macro( query_craype )
+ "Otherwise please email this error message and other related information to"
+ " draco@lanl.gov.\n" )
+       endif()
++      endif()
+       message( STATUS
+         "Looking to see if we are building in a Cray Environment..."
+         "found version $ENV{CRAYPE_VERSION}.")
+
+diff --git a/config/setupMPI.cmake b/config/setupMPI.cmake
+index da522499..5b5e27c5 100644
+--- a/config/setupMPI.cmake
++++ b/config/setupMPI.cmake
+@@ -51,7 +51,7 @@ function( setMPIflavorVer )
+     if( DEFINED ENV{CRAY_MPICH2_VER} )
+       set( MPI_VERSION $ENV{CRAY_MPICH2_VER} )
+     endif()
+-  elseif( ${MPI_FLAVOR} STREQUAL "spectrum" )
++  elseif( "${MPI_FLAVOR}" STREQUAL "spectrum" )
+     if( DEFINED ENV{LMOD_MPI_VERSION} )
+       set( LMOD_MPI_VERSION $ENV{LMOD_MPI_VERSION} )
+     endif()

--- a/var/spack/repos/builtin/packages/draco/d740.patch
+++ b/var/spack/repos/builtin/packages/draco/d740.patch
@@ -1,0 +1,21 @@
+diff --git a/config/platform_checks.cmake b/config/platform_checks.cmake
+index c9841b0d..aeecc767 100644
+--- a/config/platform_checks.cmake
++++ b/config/platform_checks.cmake
+@@ -88,6 +88,8 @@ macro( query_craype )
+       # We expect developers to use the Cray compiler wrappers (especially in
+       # setupMPI.cmake). See also
+       # https://cmake.org/cmake/help/latest/module/FindMPI.html
++      if( NOT "$ENV{CXX}" MATCHES "/lib/spack/env/" )
++        # skip this check if building from within spack.
+       if( NOT "$ENV{CXX}" MATCHES "CC$" OR
+           NOT "$ENV{CC}" MATCHES "cc$" OR
+           NOT "$ENV{FC}" MATCHES "ftn$" OR
+@@ -110,6 +112,7 @@ macro( query_craype )
+ "   export CRAYPE_LINK_TYPE=dynamic\n"
+ "Otherwise please email this error message and other related information to"
+ " draco@lanl.gov.\n" )
++        endif()
+       endif()
+       message( STATUS
+         "Looking to see if we are building in a Cray Environment..."

--- a/var/spack/repos/builtin/packages/draco/package.py
+++ b/var/spack/repos/builtin/packages/draco/package.py
@@ -15,6 +15,7 @@ class Draco(CMakePackage):
     homepage = "https://github.com/lanl/draco"
     url = "https://github.com/lanl/Draco/archive/draco-7_1_0.zip"
     git = "https://github.com/lanl/Draco.git"
+    maintainers = ['KineticTheory']
 
     version('develop', branch='develop')
     version('7.4.0',  sha256='61da2c3feace0e92c5410c9e9e613708fdf8954b1367cdc62c415329b0ddab6e')

--- a/var/spack/repos/builtin/packages/draco/package.py
+++ b/var/spack/repos/builtin/packages/draco/package.py
@@ -58,7 +58,7 @@ class Draco(CMakePackage):
     # Fix python discovery.
     patch('d710.patch', when='@7.1.0^python@3:')
     patch('d710-python2.patch', when='@7.1.0^python@2.7:2.99')
-    patch('d730.patch', when='@7.3.0:7.3.99') 
+    patch('d730.patch', when='@7.3.0:7.3.99')
     patch('d740.patch', when='@7.4.0:7.4.99')
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/draco/package.py
+++ b/var/spack/repos/builtin/packages/draco/package.py
@@ -35,7 +35,7 @@ class Draco(CMakePackage):
     variant('libquo',   default=True, description='Enable Quo wrapper')
     variant('parmetis', default=True, description='Enable Parmetis support')
     variant('qt',       default=False, description='Enable Qt support')
-    variant('superlu-dist', default=True, description='Enable SuperLU-DIST support')
+    variant('superlu_dist', default=True, description='Enable SuperLU-DIST support')
 
     depends_on('gsl')
     depends_on('mpi@3:',      type=('build', 'link', 'run'))
@@ -53,7 +53,7 @@ class Draco(CMakePackage):
     depends_on('parmetis',    when='+parmetis')
     depends_on('qt',          when='+qt',
                type=('build', 'link', 'run'))
-    depends_on('superlu-dist@:5.99', when='+superlu-dist')
+    depends_on('superlu-dist@:5.99', when='+superlu_dist')
 
     # Fix python discovery.
     patch('d710.patch', when='@7.1.0^python@3:')

--- a/var/spack/repos/builtin/packages/draco/package.py
+++ b/var/spack/repos/builtin/packages/draco/package.py
@@ -17,40 +17,49 @@ class Draco(CMakePackage):
     git = "https://github.com/lanl/Draco.git"
 
     version('develop', branch='develop')
+    version('7.4.0',  sha256='61da2c3feace0e92c5410c9e9e613708fdf8954b1367cdc62c415329b0ddab6e')
+    version('7.3.0',  sha256='dc47ef6c1e04769ea177a10fc6ddf506f3e1e8d36eb5d49f4bc38cc509e24f10')
     version('7.2.0',  sha256='ac4eac03703d4b7344fa2390a54140533c5e1f6ea0d59ef1f1d525c434ebe639')
-    version('7_1_0',  sha256='eca6bb86eb930837fb5e09b76c85c200b2c1522267cc66f81f2ec11a8262b5c9')
-    version('6_25_0', sha256='e27eba44f397e7d111ff9a45b518b186940f75facfc6f318d76bd0e72f987440')
-    version('6_23_0', sha256='edf20308746c06647087cb4e6ae7656fd057a89091a22bcba8f17a52e28b7849')
-    version('6_22_0', sha256='4d1ed54944450c4ec7d00d7ba371469506c6985922f48f780bae2580c9335b86')
-    version('6_21_0', sha256='f1ac88041606cdb1dfddd3bc74db0f1e15d8fc9d0a1eed939c8aa0fa63a85b55')
-    version('6_20_1', sha256='b1c51000c9557e0818014713fce70d681869c50ed9c4548dcfb2e9219c354ebe')
-    version('6_20_0', sha256='a6e3142c1c90b09c4ff8057bfee974369b815122b01d1f7b57888dcb9b1128f6')
+    version('7.1.0',  sha256='eca6bb86eb930837fb5e09b76c85c200b2c1522267cc66f81f2ec11a8262b5c9')
+    version('6.25.0', sha256='e27eba44f397e7d111ff9a45b518b186940f75facfc6f318d76bd0e72f987440')
+    version('6.23.0', sha256='edf20308746c06647087cb4e6ae7656fd057a89091a22bcba8f17a52e28b7849')
+    version('6.22.0', sha256='4d1ed54944450c4ec7d00d7ba371469506c6985922f48f780bae2580c9335b86')
+    version('6.21.0', sha256='f1ac88041606cdb1dfddd3bc74db0f1e15d8fc9d0a1eed939c8aa0fa63a85b55')
+    version('6.20.1', sha256='b1c51000c9557e0818014713fce70d681869c50ed9c4548dcfb2e9219c354ebe')
+    version('6.20.0', sha256='a6e3142c1c90b09c4ff8057bfee974369b815122b01d1f7b57888dcb9b1128f6')
 
     variant('build_type', default='Release', description='CMake build type',
             values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel'))
-    variant('eospac',   default=False, description='Enable EOSPAC Support')
-    variant('lapack',   default=False, description='Enable LAPACK Wrapper')
-    variant('parmetis', default=False, description='Enable Parmetis Support')
-    variant('qt',       default=False, description='Enable Qt Support')
-    variant('superlu_dist', default=False, description='Enable SuperLU-DIST Support')
+    variant('eospac',   default=True, description='Enable EOSPAC support')
+    variant('lapack',   default=True, description='Enable LAPACK wrapper')
+    variant('libquo',   default=True, description='Enable Quo wrapper')
+    variant('parmetis', default=True, description='Enable Parmetis support')
+    variant('qt',       default=False, description='Enable Qt support')
+    variant('superlu-dist', default=True, description='Enable SuperLU-DIST support')
 
-    depends_on('gsl',       type=('build', 'link'))
-    depends_on('mpi@3:',    type=('build', 'link', 'run'))
-    depends_on('numdiff',   type='build')
+    depends_on('gsl')
+    depends_on('mpi@3:',      type=('build', 'link', 'run'))
+    depends_on('numdiff',     type='build')
     depends_on('python@2.7:', type=('build', 'run'))
-    depends_on('random123', type='build')
+    depends_on('random123',   type='build')
 
-    depends_on('cmake@3.9:',  when='@:6.99',       type='build')
-    depends_on('cmake@3.11:', when='@7.0.0:7.1.9', type='build')
-    depends_on('cmake@3.14:', when='@7.2:',        type='build')
-    depends_on('eospac@6.3:', when='+eospac',      type=('build', 'link'))
-    depends_on('lapack',      when='+lapack',      type=('build', 'link'))
-    depends_on('metis',       when='+parmetis',    type=('build', 'link'))
-    depends_on('parmetis',    when='+parmetis',    type=('build', 'link'))
+    depends_on('cmake@3.9:',  when='@:6.99',        type='build')
+    depends_on('cmake@3.11:', when='@7.0.0:7.1.99', type='build')
+    depends_on('cmake@3.14:', when='@7.2:',         type='build')
+    depends_on('eospac@6.3:', when='+eospac')
+    depends_on('lapack',      when='+lapack')
+    depends_on('libquo',      when='@7.4.0:+libquo')
+    depends_on('metis',       when='+parmetis')
+    depends_on('parmetis',    when='+parmetis')
     depends_on('qt',          when='+qt',
                type=('build', 'link', 'run'))
-    depends_on('superlu-dist@:5.99', when='+superlu-dist',
-               type=('build', 'link'))
+    depends_on('superlu-dist@:5.99', when='+superlu-dist')
+
+    # Fix python discovery.
+    patch('d710.patch', when='@7.1.0^python@3:')
+    patch('d710-python2.patch', when='@7.1.0^python@2.7:2.99')
+    patch('d730.patch', when='@7.3.0:7.3.99') 
+    patch('d740.patch', when='@7.4.0:7.4.99')
 
     def url_for_version(self, version):
         url = "https://github.com/lanl/Draco/archive/draco-{0}.zip"
@@ -63,11 +72,3 @@ class Draco(CMakePackage):
             '-DBUILD_TESTING={0}'.format('ON' if self.run_tests else 'OFF')
         ])
         return options
-
-    @run_after('build')
-    @on_package_attributes(run_tests=True)
-    def check(self):
-        """Run ctest after building project."""
-
-        with working_dir(self.build_directory):
-            ctest()


### PR DESCRIPTION
+ Added versions 7.3.0 and 7.4.0.
+ Change several variants to be default TRUE since most consumers need these variants enabled (eospac, lapack, parmetis, superlu-dist). Change variant name for `+superlu_dist` to use hyphen instead of underscore.  This makes the variant name consistent with the spackage name for `superlu-dist`.
+ Clean up `depends_on` instructions and avoid specifying `type` when possible.
+ Provide patch files that are necessary for some machines (mostly Cray machines).