### PR TITLE
Bugfix: put environment lock in the right place

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -724,7 +724,7 @@ class Environment(object):
         """The location of the lock file used to synchronize multiple
         processes updating the same environment.
         """
-        return os.path.join(self.path, 'transaction_lock')
+        return os.path.join(self.env_subdir_path, 'transaction_lock')
 
     @property
     def lock_path(self):


### PR DESCRIPTION
locate the environment lock in the hidden environment directory rather than the root of the environment