### PR TITLE
performance: add a verification file to the database

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -917,7 +917,9 @@ class Database(object):
                 self._write_to_file(f)
             os.rename(temp_file, self._index_path)
             with open(self._verifier_path, 'w') as f:
-                f.write(str(uuid.uuid4()))
+                new_verifier = str(uuid.uuid4())
+                f.write(new_verifier)
+                self.last_seen_verifier = new_verifier
         except BaseException as e:
             tty.debug(e)
             # Clean up temp file if something goes wrong.

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -26,7 +26,12 @@ import os
 import socket
 import sys
 import time
-import uuid
+try:
+    import uuid
+    _use_uuid = True
+except ImportError:
+    _use_uuid = False
+    pass
 
 import llnl.util.tty as tty
 import six
@@ -916,10 +921,11 @@ class Database(object):
             with open(temp_file, 'w') as f:
                 self._write_to_file(f)
             os.rename(temp_file, self._index_path)
-            with open(self._verifier_path, 'w') as f:
-                new_verifier = str(uuid.uuid4())
-                f.write(new_verifier)
-                self.last_seen_verifier = new_verifier
+            if _use_uuid:
+                with open(self._verifier_path, 'w') as f:
+                    new_verifier = str(uuid.uuid4())
+                    f.write(new_verifier)
+                    self.last_seen_verifier = new_verifier
         except BaseException as e:
             tty.debug(e)
             # Clean up temp file if something goes wrong.
@@ -936,11 +942,12 @@ class Database(object):
         """
         if os.path.isfile(self._index_path):
             current_verifier = ''
-            try:
-                with open(self._verifier_path, 'r') as f:
-                    current_verifier = f.read()
-            except BaseException:
-                pass
+            if _use_uuid:
+                try:
+                    with open(self._verifier_path, 'r') as f:
+                        current_verifier = f.read()
+                except BaseException:
+                    pass
             if ((current_verifier != self.last_seen_verifier) or
                     (current_verifier == '')):
                 self.last_seen_verifier = current_verifier

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -942,7 +942,7 @@ class Database(object):
             except BaseException:
                 pass
             if ((current_verifier != self.last_seen_verifier) or
-                (current_verifier == '')):
+                    (current_verifier == '')):
                 self.last_seen_verifier = current_verifier
                 # Read from file if a database exists
                 self._read_from_file(self._index_path)
@@ -1355,7 +1355,7 @@ class Database(object):
             # TODO: handling of hashes restriction is not particularly elegant.
             hash_key = query_spec.dag_hash()
             if (hash_key in self._data and
-                (not hashes or hash_key in hashes)):
+                    (not hashes or hash_key in hashes)):
                 return [self._data[hash_key].spec]
             else:
                 return []

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -525,6 +525,8 @@ def database(mock_store, mock_packages, config):
     """This activates the mock store, packages, AND config."""
     with use_store(mock_store):
         yield mock_store.db
+    # Force reading the database again between tests
+    mock_store.db.last_seen_verifier = ''
 
 
 @pytest.fixture(scope='function')
@@ -543,7 +545,6 @@ def mutable_database(database, _store_dir_and_cache):
     store_path.remove(rec=1)
     store_cache.copy(store_path, mode=True, stat=True)
     store_path.join('.spack-db').chmod(mode=0o555, rec=1)
-    database.last_seen_verifier = ''
 
 
 @pytest.fixture()

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -543,6 +543,7 @@ def mutable_database(database, _store_dir_and_cache):
     store_path.remove(rec=1)
     store_cache.copy(store_path, mode=True, stat=True)
     store_path.join('.spack-db').chmod(mode=0o555, rec=1)
+    database.last_seen_verifier = ''
 
 
 @pytest.fixture()

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -475,6 +475,21 @@ def test_015_write_and_read(mutable_database):
         assert new_rec.installed == rec.installed
 
 
+def test_017_write_and_read_without_uuid(mutable_database, monkeypatch):
+    monkeypatch.setattr(spack.database, '_use_uuid', False)
+    # write and read DB
+    with spack.store.db.write_transaction():
+        specs = spack.store.db.query()
+        recs = [spack.store.db.get_record(s) for s in specs]
+
+    for spec, rec in zip(specs, recs):
+        new_rec = spack.store.db.get_record(spec)
+        assert new_rec.ref_count == rec.ref_count
+        assert new_rec.spec == rec.spec
+        assert new_rec.path == rec.path
+        assert new_rec.installed == rec.installed
+
+
 def test_020_db_sanity(database):
     """Make sure query() returns what's actually in the db."""
     _check_db_sanity(database)

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -13,6 +13,7 @@ import multiprocessing
 import os
 import pytest
 import json
+import uuid
 
 import llnl.util.lock as lk
 from llnl.util.tty.colify import colify
@@ -517,7 +518,8 @@ def test_041_ref_counts_deprecate(mutable_database):
     zmpi = mutable_database.query_one('zmpi')
 
     mutable_database.deprecate(mpich, zmpi)
-    mutable_database._check_ref_counts()
+    with mutable_database.read_transaction():
+        mutable_database._check_ref_counts()
 
 
 def test_050_basic_query(database):
@@ -703,6 +705,8 @@ def test_old_external_entries_prefix(mutable_database):
 
     with open(spack.store.db._index_path, 'w') as f:
         f.write(json.dumps(db_obj))
+    with open(spack.store.db._verifier_path, 'w') as f:
+        f.write(str(uuid.uuid4()))
 
     record = spack.store.db.get_record(s)
 

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -13,7 +13,12 @@ import multiprocessing
 import os
 import pytest
 import json
-import uuid
+try:
+    import uuid
+    _use_uuid = True
+except ImportError:
+    _use_uuid = False
+    pass
 
 import llnl.util.lock as lk
 from llnl.util.tty.colify import colify
@@ -704,8 +709,9 @@ def test_old_external_entries_prefix(mutable_database):
 
     with open(spack.store.db._index_path, 'w') as f:
         f.write(json.dumps(db_obj))
-    with open(spack.store.db._verifier_path, 'w') as f:
-        f.write(str(uuid.uuid4()))
+    if _use_uuid:
+        with open(spack.store.db._verifier_path, 'w') as f:
+            f.write(str(uuid.uuid4()))
 
     record = spack.store.db.get_record(s)
 

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -518,8 +518,7 @@ def test_041_ref_counts_deprecate(mutable_database):
     zmpi = mutable_database.query_one('zmpi')
 
     mutable_database.deprecate(mpich, zmpi)
-    with mutable_database.read_transaction():
-        mutable_database._check_ref_counts()
+    mutable_database._check_ref_counts()
 
 
 def test_050_basic_query(database):


### PR DESCRIPTION
fixes #15030
fixes #15040 


Add a file containing a unique uuid that is regenerated at database
write time. Use this uuid to suppress re-parsing the database
contents if we know a previous uuid and the uuid has not changed.