### PR TITLE
Document how to add conditional dependencies

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2004,7 +2004,8 @@ package. In that case, you could say something like:
    depends_on('mpi', when='+mpi')
 
 ``when`` can include constraints on the variant, version, compiler, etc. and
-the syntax is the same as for Specs written on the command line.
+the :mod:`syntax<spack.spec>` is the same as for Specs written on the command
+line.
 
 .. _dependency_dependency_patching:
 

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -1989,6 +1989,23 @@ inject the dependency's ``prefix/lib`` directory, but the package needs to
 be in ``PATH`` and ``PYTHONPATH`` during the build process and later when
 a user wants to run the package.
 
+^^^^^^^^^^^^^^^^^^^^^^^^
+Conditional dependencies
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+You may have a package that only requires a dependency under certain
+conditions. For example, you may have a package that has optional MPI support,
+- MPI is only a dependency when you want to enable MPI support for the
+package. In that case, you could say something like:
+
+.. code-block:: python
+
+   variant('mpi', default=False)
+   depends_on('mpi', when='+mpi')
+
+``when`` can include constraints on the variant, version, compiler, etc. and
+the syntax is the same as for Specs written on the command line.
+
 .. _dependency_dependency_patching:
 
 ^^^^^^^^^^^^^^^^^^^

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2007,6 +2007,10 @@ package. In that case, you could say something like:
 the :mod:`syntax<spack.spec>` is the same as for Specs written on the command
 line.
 
+If a dependency/feature of a package isn't typically used, you can save time
+by making it conditional (since Spack will not build the dependency unless it
+is required for the Spec).
+
 .. _dependency_dependency_patching:
 
 ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Fixes #510

We haven't explicitly mentioned how to add conditional dependencies to a package in the documentation. This adds a section on how to do that.