### PR TITLE
Bypass build_cache/index.html read when trying to download spec.yaml for concretized spec.

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -660,10 +660,43 @@ def extract_tarball(spec, filename, allow_root=False, unsigned=False,
         shutil.rmtree(tmpdir)
 
 
+# Internal cache for downloaded specs
+_cached_specs = None
+
+
+def try_download_specs(urls=None, force=False):
+    '''
+    Try to download the urls and cache them
+    '''
+    global _cached_specs
+    _cached_specs = []
+    if urls is None:
+        return {}
+    for link in urls:
+        with Stage(link, name="build_cache", keep=True) as stage:
+            if force and os.path.exists(stage.save_filename):
+                os.remove(stage.save_filename)
+            if not os.path.exists(stage.save_filename):
+                try:
+                    stage.fetch()
+                except fs.FetchError:
+                    continue
+            with open(stage.save_filename, 'r') as f:
+                # read the spec from the build cache file. All specs
+                # in build caches are concrete (as they are built) so
+                # we need to mark this spec concrete on read-in.
+                spec = Spec.from_yaml(f)
+                spec._mark_concrete()
+                _cached_specs.append(spec)
+
+    return _cached_specs
+
+
 def get_spec(spec=None, force=False):
     """
     Check if spec.yaml exists on mirrors and return it if it does
     """
+    global _cached_specs
     urls = set()
     if spec is None:
         return {}
@@ -699,7 +732,7 @@ def get_specs(force=False, use_arch=False, names=None):
     """
     Get spec.yaml's for build caches available on mirror
     """
-
+    global _cached_specs
     arch = architecture.Arch(architecture.platform(),
                              'default_os', 'default_target')
     arch_pattern = ('([^-]*-[^-]*-[^-]*)')
@@ -748,38 +781,6 @@ def get_specs(force=False, use_arch=False, names=None):
                     urls.add(link)
 
     return try_download_specs(urls=urls, force=force)
-
-
-# Internal cache for try_download_specs
-_cached_specs = None
-
-
-def try_download_specs(urls=None, force=False):
-    '''
-    Try to download the urls and cache them
-    '''
-    global _cached_specs
-    _cached_specs = []
-    if urls is None:
-        return {}
-    for link in urls:
-        with Stage(link, name="build_cache", keep=True) as stage:
-            if force and os.path.exists(stage.save_filename):
-                os.remove(stage.save_filename)
-            if not os.path.exists(stage.save_filename):
-                try:
-                    stage.fetch()
-                except fs.FetchError:
-                    continue
-            with open(stage.save_filename, 'r') as f:
-                # read the spec from the build cache file. All specs
-                # in build caches are concrete (as they are built) so
-                # we need to mark this spec concrete on read-in.
-                spec = Spec.from_yaml(f)
-                spec._mark_concrete()
-                _cached_specs.append(spec)
-
-    return _cached_specs
 
 
 def get_keys(install=False, trust=False, force=False):

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1510,7 +1510,8 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
 
     def try_install_from_binary_cache(self, explicit):
         tty.msg('Searching for binary cache of %s' % self.name)
-        specs = binary_distribution.get_specs(use_arch=True, names=[self.name])
+        specs = binary_distribution.get_spec(spec=self.spec,
+                                             force=False)
         binary_spec = spack.spec.Spec.from_dict(self.spec.to_dict())
         binary_spec._mark_concrete()
         if binary_spec not in specs:


### PR DESCRIPTION
Add binary_distribution::get_spec which takes concretized spec.
Add binary_distribution::try_download_specs for downloading of spec.yaml files to cache.
get_spec is used by package::try_install_from_binary_cache to download only the spec.yaml
for the concretized spec if it exists.

This arose from a discussion with @eugeneswalke. Muliple pipelines write to the same build_cache and the index.html is not updating correctly when two processes content for writing index.html.  Buildcaches that are available are skipped by spack install because they don't have a link in index.html.