### PR TITLE
dev-build: stop before phase

### DIFF
--- a/lib/spack/spack/cmd/dev_build.py
+++ b/lib/spack/spack/cmd/dev_build.py
@@ -37,10 +37,15 @@ def setup_parser(subparser):
     subparser.add_argument(
         '-q', '--quiet', action='store_true', dest='quiet',
         help="do not display verbose build output while installing")
-    subparser.add_argument(
+    arguments.add_common_arguments(subparser, ['spec'])
+
+    stop_group = subparser.add_mutually_exclusive_group()
+    stop_group.add_argument(
+        '-b', '--before', type=str, dest='before', default=None,
+        help="phase to stop before when installing (default None)")
+    stop_group.add_argument(
         '-u', '--until', type=str, dest='until', default=None,
         help="phase to stop after when installing (default None)")
-    arguments.add_common_arguments(subparser, ['spec'])
 
     cd_group = subparser.add_mutually_exclusive_group()
     arguments.add_common_arguments(cd_group, ['clean', 'dirty'])
@@ -91,4 +96,5 @@ def dev_build(self, args):
         verbose=not args.quiet,
         keep_stage=True,   # don't remove source dir for dev build.
         dirty=args.dirty,
+        stop_before=args.before,
         stop_at=args.until)

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -562,6 +562,8 @@ install_args_docstring = """
                 even with exceptions.
             restage (bool): Force spack to restage the package source.
             skip_patch (bool): Skip patch stage of build if True.
+            stop_before (InstallPhase): stop execution before this
+                installation phase (or None)
             stop_at (InstallPhase): last installation phase to be executed
                 (or None)
             tests (bool or list or set): False to run no tests, True to test
@@ -779,12 +781,20 @@ class PackageInstaller(object):
         Ensures the package being installed has a valid last phase before
         proceeding with the installation.
 
-        The ``stop_at`` argument is removed from the installation arguments.
+        The ``stop_before`` or ``stop_at`` arguments are removed from the
+        installation arguments.
 
         Args:
             kwargs:
+              ``stop_before``': stop before execution of this phase (or None)
               ``stop_at``': last installation phase to be executed (or None)
         """
+        self.pkg.stop_before_phase = kwargs.pop('stop_before', None)
+        if self.pkg.stop_before_phase is not None and \
+           self.pkg.stop_before_phase not in self.pkg.phases:
+            tty.die('\'{0}\' is not an allowed phase for package {1}'
+                    .format(self.pkg.stop_before_phase, self.pkg.name))
+
         self.pkg.last_phase = kwargs.pop('stop_at', None)
         if self.pkg.last_phase is not None and \
                 self.pkg.last_phase not in self.pkg.phases:
@@ -1504,8 +1514,10 @@ class PackageInstaller(object):
                 self._update_installed(task)
 
                 # If we installed then we should keep the prefix
+                stop_before_phase = getattr(pkg, 'stop_before_phase', None)
                 last_phase = getattr(pkg, 'last_phase', None)
-                keep_prefix = last_phase is None or keep_prefix
+                keep_prefix = keep_prefix or \
+                    (stop_before_phase is None and last_phase is None)
 
             except spack.directory_layout.InstallDirectoryAlreadyExistsError:
                 tty.debug("Keeping existing install prefix in place.")

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -115,7 +115,11 @@ class InstallPhase(object):
         return phase_wrapper
 
     def _on_phase_start(self, instance):
-        pass
+        # If a phase has a matching stop_before_phase attribute,
+        # stop the installation process raising a StopIteration
+        if getattr(instance, 'stop_before_phase', None) == self.name:
+            raise StopIteration('Stopping before \'{0}\' phase'
+                                .format(self.name))
 
     def _on_phase_exit(self, instance):
         # If a phase has a matching last_phase attribute,

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -697,7 +697,7 @@ _spack_deprecate() {
 _spack_dev_build() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -j --jobs -d --source-path -i --ignore-dependencies -n --no-checksum --keep-prefix --skip-patch -q --quiet -u --until --clean --dirty"
+        SPACK_COMPREPLY="-h --help -j --jobs -d --source-path -i --ignore-dependencies -n --no-checksum --keep-prefix --skip-patch -q --quiet -b --before -u --until --clean --dirty"
     else
         _all_packages
     fi
@@ -706,7 +706,7 @@ _spack_dev_build() {
 _spack_diy() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -j --jobs -d --source-path -i --ignore-dependencies -n --no-checksum --keep-prefix --skip-patch -q --quiet -u --until --clean --dirty"
+        SPACK_COMPREPLY="-h --help -j --jobs -d --source-path -i --ignore-dependencies -n --no-checksum --keep-prefix --skip-patch -q --quiet -b --before -u --until --clean --dirty"
     else
         _all_packages
     fi


### PR DESCRIPTION
This is a proposal to change or add to the `--until` option of `spack dev-build`.

Often, I want to run my own CMake/configure/manually-build-step and taking CMake packages as an example, there is often no phase before the first `cmake` phase to stop *after* (this is what `--until` does).

`--until` currently stops *after* a phase, which makes `-u install` (or whatever is the last phase of a package) useless as this is the same as no option. I would generally propose to change the meaning of `-u|--until` to stop at start of that specified phase, but in case we want to avoid breakage we can also add something like `-b|--before`.

Note: somehow the build environment is not set up when testing this, e.g. no `LD_LIBRARY_PATH` and `CMAKE_PREFIX_PATH` is set on `spack dev-build --before cmake <package-name>` ... this is a preparation for #14887