### PR TITLE
`spack -V` is more descriptive for dev branches

### DIFF
--- a/lib/spack/spack/test/main.py
+++ b/lib/spack/spack/test/main.py
@@ -1,0 +1,63 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+import llnl.util.filesystem as fs
+
+import spack.paths
+from spack.main import get_version, main
+
+
+def test_get_version_no_match_git(tmpdir, working_env):
+    git = str(tmpdir.join("git"))
+    with open(git, "w") as f:
+        f.write("""#!/bin/sh
+echo v0.13.3
+""")
+    fs.set_executable(git)
+
+    os.environ["PATH"] = str(tmpdir)
+    assert spack.spack_version == get_version()
+
+
+def test_get_version_match_git(tmpdir, working_env):
+    git = str(tmpdir.join("git"))
+    with open(git, "w") as f:
+        f.write("""#!/bin/sh
+echo v0.13.3-912-g3519a1762
+""")
+    fs.set_executable(git)
+
+    os.environ["PATH"] = str(tmpdir)
+    assert "0.13.3-912-3519a1762" == get_version()
+
+
+def test_get_version_no_repo(tmpdir, monkeypatch):
+    monkeypatch.setattr(spack.paths, "prefix", str(tmpdir))
+    assert spack.spack_version == get_version()
+
+
+def test_get_version_no_git(tmpdir, working_env):
+    os.environ["PATH"] = str(tmpdir)
+    assert spack.spack_version == get_version()
+
+
+def test_main_calls_get_version(tmpdir, capsys, working_env):
+    os.environ["PATH"] = str(tmpdir)
+    main(["-V"])
+    assert spack.spack_version == capsys.readouterr()[0].strip()
+
+
+def test_get_version_bad_git(tmpdir, working_env):
+    bad_git = str(tmpdir.join("git"))
+    with open(bad_git, "w") as f:
+        f.write("""#!/bin/sh
+exit 1
+""")
+    fs.set_executable(bad_git)
+
+    os.environ["PATH"] = str(tmpdir)
+    assert spack.spack_version == get_version()


### PR DESCRIPTION
Closes #8119.

`spack -V` previously always returned the version of spack from `spack.spack_version`.  This gives us a general idea of what version users are on, but if they're on `develop` or on some branch, we have to ask more questions.

This PR makes `spack -V` check whether this instance of Spack is a git repository, and if it is, it appends useful information from `git describe --tags` to the version.  Specifically, it adds:

  - number of commits since the last release tag
  - abbreviated (but unique) commit hash

So, if you're on `develop` you might get something like this:

```console
$ spack -V
0.13.3-912-3519a1762
```

This means you're on commit 3519a1762, which is 912 commits ahead of the 0.13.3 release.

If you are on a release branch, or if you are using a tarball of Spack,
you'll get the usual `spack.spack_version`:

```console
$ spack -V
0.13.3
```

This should help when asking users what version they are on, since a lot
of people use the `develop` branch.