### PR TITLE
[libfabric@1.9.0] Fix C++ header usage

### DIFF
--- a/var/spack/repos/builtin/packages/libfabric/package.py
+++ b/var/spack/repos/builtin/packages/libfabric/package.py
@@ -59,6 +59,12 @@ class Libfabric(AutotoolsPackage):
     variant('kdreg', default=False,
             description='Enable kdreg on supported Cray platforms')
 
+    # For version 1.9.0:
+    # headers: fix forward-declaration of enum fi_collective_op with C++
+    patch('https://github.com/ofiwg/libfabric/commit/2e95b0efd85fa8a3d814128e34ec57ffd357460e.patch',
+          sha256='71f06e8bf0adeccd425b194ac524e4d596469e9dab9e7a4f8bb209e6b9a454f4',
+          when='@1.9.0')
+
     depends_on('rdma-core', when='fabrics=verbs')
     depends_on('opa-psm2', when='fabrics=psm2')
     depends_on('psm', when='fabrics=psm')


### PR DESCRIPTION
Fix from libfabric's git for 1.9.0.

Compiling C++ software against libfabric@1.9.0 doesn't work
without this patch.

See: https://github.com/ofiwg/libfabric/commit/2e95b0efd85fa8a3d814128e34ec57ffd357460e