### PR TITLE
Fixed DIY package missing MPI dependency

### DIFF
--- a/var/spack/repos/builtin/packages/diy/package.py
+++ b/var/spack/repos/builtin/packages/diy/package.py
@@ -16,6 +16,10 @@ class Diy(CMakePackage):
     version('3.5.0', sha256='b3b5490441d521b6e9b33471c782948194bf95c7c3df3eb97bc5cf4530b91576')
     version('master', branch='master')
 
+    depends_on('mpi')
+
     def cmake_args(self):
-        args = ['-Dbuild_examples=off', '-Dbuild_tests=off']
+        args = ['-Dbuild_examples=off',
+                '-Dbuild_tests=off',
+                '-DCMAKE_CXX_COMPILER=%s' % self.spec['mpi'].mpicxx]
         return args


### PR DESCRIPTION
This PR fixes the DIY package, adding the proper MPI dependency.