### PR TITLE
superlu-dist: enforce OpenMP=OFF

### DIFF
--- a/var/spack/repos/builtin/packages/superlu-dist/package.py
+++ b/var/spack/repos/builtin/packages/superlu-dist/package.py
@@ -72,6 +72,7 @@ class SuperluDist(CMakePackage):
             args.append('-Denable_openmp=ON')
         else:
             args.append('-Denable_openmp=OFF')
+            args.append('-DCMAKE_DISABLE_FIND_PACKAGE_OpenMP=ON')
 
         if '+shared' in spec:
             args.append('-DBUILD_SHARED_LIBS:BOOL=ON')


### PR DESCRIPTION
The `enable_openmp` is broken in some older version.