### PR TITLE
Update Trilinos: Add Mesquite as optional package

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/fix_clang_errors_12_18_1.patch
+++ b/var/spack/repos/builtin/packages/trilinos/fix_clang_errors_12_18_1.patch
@@ -1,0 +1,39 @@
+From 01b88601a85691da73042089778db6db5bf6cf01 Mon Sep 17 00:00:00 2001
+From: Jean-Paul Pelteret <jppelteret@gmail.com>
+Date: Sat, 1 Feb 2020 05:48:48 +0100
+Subject: [PATCH] Fix Clang 8.0.0 compiler errors 12.18.1
+
+---
+ packages/belos/tpetra/src/solvers/Belos_Tpetra_Krylov.hpp | 2 +-
+ packages/muelu/src/Interface/MueLu_ParameterListUtils.cpp | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/packages/belos/tpetra/src/solvers/Belos_Tpetra_Krylov.hpp b/packages/belos/tpetra/src/solvers/Belos_Tpetra_Krylov.hpp
+index d4f72bc..302dfc2 100644
+--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_Krylov.hpp
++++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_Krylov.hpp
+@@ -126,7 +126,7 @@ public:
+   virtual void
+   getDefaultParameters (Teuchos::ParameterList& params) const
+   {
+-    const SolverInput<SC> input;
++    const SolverInput<SC> input{};
+     const int verbosity = 0;
+     const std::string implResScal = input.needToScale ?
+       "Norm of Preconditioned Initial Residual" : "None"; // ???
+diff --git a/packages/muelu/src/Interface/MueLu_ParameterListUtils.cpp b/packages/muelu/src/Interface/MueLu_ParameterListUtils.cpp
+index 051a2df..a703aff 100644
+--- a/packages/muelu/src/Interface/MueLu_ParameterListUtils.cpp
++++ b/packages/muelu/src/Interface/MueLu_ParameterListUtils.cpp
+@@ -143,7 +143,7 @@ namespace MueLu {
+ 
+   // Usage: GetMLSubList(paramList, "smoother", 2);
+   const Teuchos::ParameterList & GetMLSubList(const Teuchos::ParameterList & paramList, const std::string & type, int levelID) {
+-    static const Teuchos::ParameterList emptyParamList;
++    static const Teuchos::ParameterList emptyParamList{};
+ 
+     char levelChar[11];
+     sprintf(levelChar, "(level %d)", levelID);
+-- 
+2.10.1 (Apple Git-78)
+

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -361,6 +361,7 @@ class Trilinos(CMakePackage):
     patch('xlf_tpetra.patch', when='@12.12.1%xl')
     patch('xlf_tpetra.patch', when='@12.12.1%xl_r')
     patch('xlf_tpetra.patch', when='@12.12.1%clang')
+    patch('fix_clang_errors_12_18_1.patch', when='@12.18.1%clang')
 
     def url_for_version(self, version):
         url = "https://github.com/trilinos/Trilinos/archive/trilinos-release-{0}.tar.gz"

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -185,6 +185,8 @@ class Trilinos(CMakePackage):
             description='Enable DataTransferKit')
     variant('fortrilinos',  default=False,
             description='Enable ForTrilinos')
+    variant('mesquite',     default=False,
+            description='Enable Mesquite')
 
     resource(name='dtk',
              git='https://github.com/ornl-cees/DataTransferKit.git',
@@ -208,6 +210,21 @@ class Trilinos(CMakePackage):
              tag='develop',
              placement='packages/ForTrilinos',
              when='+fortrilinos')
+    resource(name='mesquite',
+             url='https://github.com/trilinos/mesquite/archive/trilinos-release-12-12-1.tar.gz',
+             sha256='e0d09b0939dbd461822477449dca611417316e8e8d8268fd795debb068edcbb5',
+             placement='packages/mesquite',
+             when='+mesquite @12.12.1:12.16.99')
+    resource(name='mesquite',
+             git='https://github.com/trilinos/mesquite.git',
+             commit='20a679679b5cdf15bf573d66c5dc2b016e8b9ca1',  # branch trilinos-release-12-12-1
+             placement='packages/mesquite',
+             when='+mesquite @12.18.1:12.18.99')
+    resource(name='mesquite',
+             git='https://github.com/trilinos/mesquite.git',
+             tag='develop',
+             placement='packages/mesquite',
+             when='+mesquite @develop')
 
     conflicts('+amesos2', when='~teuchos')
     conflicts('+amesos2', when='~tpetra')
@@ -266,6 +283,8 @@ class Trilinos(CMakePackage):
     conflicts('+fortrilinos', when='~fortran')
     conflicts('+fortrilinos', when='@:99')
     conflicts('+fortrilinos', when='@master')
+    # Only allow Mesquite with Trilinos 12.12 and up, and develop
+    conflicts('+mesquite', when='@0:12.10.99,master')
     # Can only use one type of SuperLU
     conflicts('+superlu-dist', when='+superlu')
     # For Trilinos v11 we need to force SuperLUDist=OFF, since only the
@@ -417,6 +436,8 @@ class Trilinos(CMakePackage):
                 'ON' if '+kokkos' in spec else 'OFF'),
             '-DTrilinos_ENABLE_MiniTensor=%s' % (
                 'ON' if '+minitensor' in spec else 'OFF'),
+            '-DTrilinos_ENABLE_Mesquite:BOOL=%s' % (
+                'ON' if '+mesquite' in spec else 'OFF'),
             '-DTrilinos_ENABLE_ML:BOOL=%s' % (
                 'ON' if '+ml' in spec else 'OFF'),
             '-DTrilinos_ENABLE_MueLu:BOOL=%s' % (


### PR DESCRIPTION
Also fix a build error that occurs when using an old compiler.