### PR TITLE
octave: mkoctfile doesn't use compiler wrappers

### DIFF
--- a/var/spack/repos/builtin/packages/octave/helloworld.cc
+++ b/var/spack/repos/builtin/packages/octave/helloworld.cc
@@ -1,0 +1,11 @@
+#include <octave/oct.h>
+
+DEFUN_DLD (helloworld, args, nargout,
+           "Hello World Help String")
+{
+  octave_stdout << "Hello World has "
+                << args.length () << " input arguments and "
+                << nargout << " output arguments.\n";
+
+  return octave_value_list ();
+}

--- a/var/spack/repos/builtin/packages/octave/package.py
+++ b/var/spack/repos/builtin/packages/octave/package.py
@@ -9,10 +9,13 @@ import sys
 
 class Octave(AutotoolsPackage, GNUMirrorPackage):
     """GNU Octave is a high-level language, primarily intended for numerical
-    computations. It provides a convenient command line interface for solving
-    linear and nonlinear problems numerically, and for performing other
-    numerical experiments using a language that is mostly compatible with
-    Matlab. It may also be used as a batch-oriented language."""
+    computations.
+
+    It provides a convenient command line interface for solving linear and
+    nonlinear problems numerically, and for performing other numerical
+    experiments using a language that is mostly compatible with Matlab.
+    It may also be used as a batch-oriented language.
+    """
 
     homepage = "https://www.gnu.org/software/octave/"
     gnu_mirror_path = "octave/octave-4.0.0.tar.gz"


### PR DESCRIPTION
fixes #14702 
fixes #4874

This PR patches `mkoctfile.in.cc` so that the real compilers are used instead of Spack compiler wrappers. The result is:
```console
$ mkoctfile -p CC
/usr/bin/gcc-9

$ strings ./mkoctfile | grep spack
/home/culpo/PycharmProjects/spack/opt/spack/linux-ubuntu18.04-broadwell/gcc-9.0.1/octave-5.1.0-udv3gkc3pqwvh3zgvk3dxrxqyw7iiydb/lib:/home/culpo/PycharmProjects/spack/opt/spack/linux-ubuntu18.04-broadwell/gcc-9.0.1/octave-5.1.0-udv3gkc3pqwvh3zgvk3dxrxqyw7iiydb/lib64:/home/culpo/PycharmProjects/spack/opt/spack/linux-ubuntu18.04-broadwell/gcc-9.0.1/openblas-0.3.7-uokct4hhjbmvuwjhv6f27jyzgnaartl2/lib:/home/culpo/PycharmProjects/spack/opt/spack/linux-ubuntu18.04-broadwell/gcc-9.0.1/pcre-8.42-gbithje7unewjy3vr4xm3nxwy5t623yt/lib:/home/culpo/PycharmProjects/spack/opt/spack/linux-ubuntu18.04-broadwell/gcc-9.0.1/readline-8.0-urdw22aaycjl4no4mop7tocm6v4c2qsd/lib:/home/culpo/PycharmProjects/spack/opt/spack/linux-ubuntu18.04-broadwell/gcc-9.0.1/ncurses-6.1-leuzbbhmhg23tbrukc3hpmcl2ilttoka/lib
/home/culpo/PycharmProjects/spack/opt/spack/linux-ubuntu18.04-broadwell/gcc-9.0.1/octave-5.1.0-udv3gkc3pqwvh3zgvk3dxrxqyw7iiydb
-L/home/culpo/PycharmProjects/spack/opt/spack/linux-ubuntu18.04-broadwell/gcc-9.0.1/openblas-0.3.7-uokct4hhjbmvuwjhv6f27jyzgnaartl2/lib -lopenblas
/tmp/culpo/spack-stage/spack-stage-octave-5.1.0-udv3gkc3pqwvh3zgvk3dxrxqyw7iiydb/spack-src
```
so apparently there are no references anymore to any of the compiler wrapper.