### PR TITLE
buildcache list: restore original behavior of allowing constraints on command line

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -727,23 +727,18 @@ def get_spec(spec=None, force=False):
     return try_download_specs(urls=urls, force=force)
 
 
-def get_specs(force=False, use_arch=False, names=None):
+def get_specs(force=False, allarch=False):
     """
     Get spec.yaml's for build caches available on mirror
     """
     arch = architecture.Arch(architecture.platform(),
                              'default_os', 'default_target')
     arch_pattern = ('([^-]*-[^-]*-[^-]*)')
-    if use_arch:
+    if not allarch:
         arch_pattern = '(%s-%s-[^-]*)' % (arch.platform, arch.os)
 
-    if names is None:
-        names = ['']
-    names_or_hashes = [name.replace('/', '') for name in names]
-    names_pattern = '|'.join(names_or_hashes)
-    regex_pattern = '%s(.*)(%s)(.*)(spec.yaml$)' % (arch_pattern,
-                                                    names_pattern)
-    name_re = re.compile(regex_pattern)
+    regex_pattern = '%s(.*)(spec.yaml$)' % (arch_pattern)
+    arch_re = re.compile(regex_pattern)
 
     if not spack.mirror.MirrorCollection():
         tty.debug("No Spack mirrors are currently configured")
@@ -760,7 +755,7 @@ def get_specs(force=False, use_arch=False, names=None):
             if os.path.exists(mirror_dir):
                 files = os.listdir(mirror_dir)
                 for file in files:
-                    m = name_re.search(file)
+                    m = arch_re.search(file)
                     if m:
                         link = url_util.join(fetch_url_build_cache, file)
                         urls.add(link)
@@ -770,7 +765,7 @@ def get_specs(force=False, use_arch=False, names=None):
             p, links = web_util.spider(
                 url_util.join(fetch_url_build_cache, 'index.html'))
             for link in links:
-                m = name_re.search(link)
+                m = arch_re.search(link)
                 if m:
                     urls.add(link)
 

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -87,8 +87,9 @@ def setup_parser(subparser):
                            help='show variants in output (can be long)')
     listcache.add_argument('-f', '--force', action='store_true',
                            help="force new download of specs")
-    listcache.add_argument('-a', '--arch', action='store_true',
-                           help="only list spec for the default architecture")
+    listcache.add_argument('-a', '--allarch', action='store_true',
+                           help="list specs for all available architectures" +
+                                 " instead of default platform and OS")
     arguments.add_common_arguments(listcache, ['specs'])
     listcache.set_defaults(func=listspecs)
 
@@ -265,10 +266,11 @@ def match_downloaded_specs(pkgs, allow_multiple_matches=False, force=False):
     # List of specs that match expressions given via command line
     specs_from_cli = []
     has_errors = False
+    allarch = False
+    specs = bindist.get_specs(force, allarch)
     for pkg in pkgs:
         matches = []
         tty.msg("buildcache spec(s) matching %s \n" % pkg)
-        specs = bindist.get_specs(names=[pkg])
         for spec in sorted(specs):
             if pkg.startswith('/'):
                 pkghash = pkg.replace('/', '')
@@ -417,14 +419,10 @@ def install_tarball(spec, args):
 
 def listspecs(args):
     """list binary packages available from mirrors"""
-    specs = list()
+    specs = bindist.get_specs(args.force, args.allarch)
     if args.specs:
-        for s in bindist.get_specs(args.force, args.arch,
-                                   args.specs):
-            if s not in set(specs):
-                specs.append(s)
-    else:
-        specs = bindist.get_specs(force=args.force, use_arch=args.arch)
+        constraints = set(args.specs)
+        specs = [s for s in specs if any(s.satisfies(c) for c in constraints)]
     display_specs(specs, args, all_headers=True)
 
 

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -17,7 +17,7 @@ buildcache = spack.main.SpackCommand('buildcache')
 def mock_get_specs(database, monkeypatch):
     specs = database.query_local()
     monkeypatch.setattr(
-        spack.binary_distribution, 'get_specs', lambda x, y, z: specs
+        spack.binary_distribution, 'get_specs', lambda x, y: specs
     )
 
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -400,7 +400,7 @@ _spack_buildcache_install() {
 _spack_buildcache_list() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -l --long -L --very-long -v --variants -f --force -a --arch"
+        SPACK_COMPREPLY="-h --help -l --long -L --very-long -v --variants -f --force -a --allarch"
     else
         _all_packages
     fi


### PR DESCRIPTION
like pkg@version.