### PR TITLE
update pmdk to 1.8

### DIFF
--- a/var/spack/repos/builtin/packages/pmdk/package.py
+++ b/var/spack/repos/builtin/packages/pmdk/package.py
@@ -17,13 +17,15 @@ class Pmdk(Package):
     git      = "https://github.com/pmem/pmdk.git"
 
     version('develop', branch='master')
+    version('1.8',     sha256='a241ea76ef76d233cb92826b6823ed48091a2fb6963282a4fea848dbce68aa21')
     version('1.7', sha256='865ce1b422bc83109cb4a63dcff8fd1077eea3617e668faf6a043208d8be03ca')
     version('1.6',     sha256='3b99e6c30709326a94d2e73a9247a8dfb58d0a394c5b7714e5c3d8a3ad2e2e9f')
     version('1.5',     sha256='6b069d7207febeb62440e89245e8b18fcdf40b6170d2ec2ef33c252ed16db2d4')
 
     depends_on('ncurses', when='@1.6:')
     # documentation requires doxygen and a bunch of other dependencies
-    patch('0001-make-doc-building-explicit.patch')
+    patch('0001-make-doc-building-explicit.patch', when="@:1.7")
+    patch('pmem-1.8-disable-docs.patch', when='@1.8')
 
     def install(self, spec, prefix):
         make_args = [
@@ -33,8 +35,8 @@ class Pmdk(Package):
             'BUILD_RPMEM=n',
         ]
 
-        # pmdk is particular about the ARCH specification, must be
-        # exactly "x86_64" for build to work
+        # pmdk prior to 1.8 was particular about the ARCH specification, must
+        # be exactly "x86_64" for build to work
         if spec.target.family == 'x86_64':
             make_args += ['ARCH=x86_64']
 

--- a/var/spack/repos/builtin/packages/pmdk/pmem-1.8-disable-docs.patch
+++ b/var/spack/repos/builtin/packages/pmdk/pmem-1.8-disable-docs.patch
@@ -1,0 +1,19 @@
+--- pmdk-1.8/Makefile	2020-01-31 06:42:27.000000000 -0500
++++ pmdk-1.8.nodocs/Makefile	2020-02-03 13:51:24.844691000 -0500
+@@ -79,7 +79,7 @@ rpm : override DESTDIR="$(CURDIR)/$(RPM_
+ dpkg: override DESTDIR="$(CURDIR)/$(DPKG_BUILDDIR)"
+ rpm dpkg: override prefix=/usr
+ 
+-all: doc
++all:
+ 	$(MAKE) -C src $@
+ 
+ doc:
+@@ -151,7 +151,6 @@ install: all
+ 
+ install uninstall:
+ 	$(MAKE) -C src $@
+-	$(MAKE) -C doc $@
+ 
+ .PHONY: all clean clobber test check cstyle check-license install uninstall\
+ 	source rpm dpkg pkg-clean pcheck check-remote format doc require-rpmem\


### PR DESCRIPTION
new upstream release
- notable in that it has experimental powerpc-le support (e.g. summit)
- required a new patch to disable documentation