### PR TITLE
macsio: cast JsonGetInt from int to unsigned int

### DIFF
--- a/var/spack/repos/builtin/packages/macsio/cast.patch
+++ b/var/spack/repos/builtin/packages/macsio/cast.patch
@@ -1,0 +1,11 @@
+--- spack-src/plugins/macsio_silo.c.org	2020-02-04 10:48:08.031770849 +0900
++++ spack-src/plugins/macsio_silo.c	2020-02-04 10:48:48.175592435 +0900
+@@ -706,7 +706,7 @@
+     char fileName[256];
+     MACSIO_MIF_baton_t *bat;
+     MACSIO_MIF_ioFlags_t ioFlags = {MACSIO_MIF_WRITE,
+-        JsonGetInt(main_obj, "clargs/exercise_scr")&0x1};
++        (unsigned int)JsonGetInt(main_obj, "clargs/exercise_scr")&0x1};
+ 
+     /* Without this barrier, I get strange behavior with Silo's MACSIO_MIF interface */
+ //#warning CONFIRM THIS IS STILL NEEDED

--- a/var/spack/repos/builtin/packages/macsio/package.py
+++ b/var/spack/repos/builtin/packages/macsio/package.py
@@ -43,7 +43,7 @@ class Macsio(CMakePackage):
     depends_on('scr', when="+scr")
 
     # Ref: https://github.com/LLNL/MACSio/commit/51b8c40cd9813adec5dd4dd6cee948bb9ddb7ee1
-    patch('cast.patch')
+    patch('cast.patch', when='@1.1')
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/macsio/package.py
+++ b/var/spack/repos/builtin/packages/macsio/package.py
@@ -42,6 +42,9 @@ class Macsio(CMakePackage):
     depends_on('typhonio', when="+typhonio")
     depends_on('scr', when="+scr")
 
+    # Ref: https://github.com/LLNL/MACSio/commit/51b8c40cd9813adec5dd4dd6cee948bb9ddb7ee1
+    patch('cast.patch')
+
     def cmake_args(self):
         spec = self.spec
         cmake_args = []


### PR DESCRIPTION
- Fix narrowing error
```
  >> 84     /tmp/pytest-of-ogura/pytest-77/mock-stage0/spack-stage-macsio-1.1-b
            oj45ykokozxfqahtdfktmn2yvpbmovq/spack-src/plugins/macsio_silo.c:709
            :9: error: non-constant-expression cannot be narrowed from type 'in
            t' to 'unsigned int' in initializer list [-Wc++11-narrowing]
     85             JsonGetInt(main_obj, "clargs/exercise_scr")&0x1};
     86             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

I did typecast for `JsonGetInt` to 'unsigned int'.
I did the same fix as the reference.
・Ref: https://github.com/LLNL/MACSio/commit/51b8c40cd9813adec5dd4dd6cee948bb9ddb7ee1#diff-211e5531b37ad0c24fea756d482d80f9

I submitted this pull request to upstream.
・upstream: https://github.com/LLNL/MACSio/pull/20