### PR TITLE
Bump Open Babel to 3

### DIFF
--- a/var/spack/repos/builtin/packages/openbabel/package.py
+++ b/var/spack/repos/builtin/packages/openbabel/package.py
@@ -12,18 +12,24 @@ class Openbabel(CMakePackage):
     search, convert, analyze, or store data from molecular modeling, chemistry,
     solid-state materials, biochemistry, or related areas."""
 
-    homepage = "http://openbabel.org/wiki/Main_Page"
-    url      = "https://sourceforge.net/projects/openbabel/files/openbabel/2.4.1/openbabel-2.4.1.tar.gz"
+    homepage = 'https://openbabel.org/wiki/Main_Page'
+    url = 'https://github.com/openbabel/openbabel/archive/openbabel-3-0-0.tar.gz'
+    git = 'https://github.com/openbabel/openbabel.git'
 
-    version('2.4.1', sha256='204136582cdfe51d792000b20202de8950218d617fd9c6e18cee36706a376dfc')
+    version('master', branch='master')
+    version('3.0.0', tag='openbabel-3-0-0')
+    version('2.4.1', tag='openbabel-2-4-1')
+    version('2.4.0', tag='openbabel-2-4-0')
 
     variant('python', default=True, description='Build Python bindings')
 
     extends('python', when='+python')
 
     depends_on('python', type=('build', 'run'), when='+python')
-    depends_on('cmake@2.4.8:', type='build')
-    depends_on('pkgconfig',   type='build')
+    depends_on('cmake@3.1:', type='build')
+    depends_on('pkgconfig', type='build')
+    depends_on('swig@2.0:', type='build', when='+python')
+    depends_on('boost')
     depends_on('cairo')       # required to support PNG depiction
     depends_on('eigen@3.0:')  # required if using the language bindings
     depends_on('libxml2')     # required to read/write CML files, XML formats
@@ -43,6 +49,7 @@ class Openbabel(CMakePackage):
             args.extend([
                 '-DPYTHON_BINDINGS=ON',
                 '-DPYTHON_EXECUTABLE={0}'.format(spec['python'].command.path),
+                '-DRUN_SWIG=ON',
             ])
         else:
             args.append('-DPYTHON_BINDINGS=OFF')
@@ -56,6 +63,6 @@ class Openbabel(CMakePackage):
         obabel('-:C1=CC=CC=C1Br', '-omol')
 
         if '+python' in self.spec:
-            # Attempt to import the Python modules
-            for module in ['openbabel', 'pybel']:
-                python('-c', 'import {0}'.format(module))
+            python('-c', 'import openbabel')
+            if self.spec.version < Version('3.0.0'):
+                python('-c', 'import pybel')


### PR DESCRIPTION
Actually installation fails as following (similar to #13637):
```shelsession
$ spack install openbabel
==> Error: An unsatisfiable variant constraint has been detected for spec:

    gettext@0.20.1%gcc@8.3.0+bzip2+curses+git~libunistring+libxml2+tar+xz arch=linux-debian10-skylake


while trying to concretize the partial spec:

    python@3.7.6%gcc@8.3.0+bz2+ctypes+dbm~debug~libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4~uuid+zlib arch=linux-debian10-skylake
        ^pkgconf@1.6.3%gcc@8.3.0 arch=linux-debian10-skylake


python requires gettext variant ~libxml2, but spec asked for +libxml2

```

But I hope this works.