### PR TITLE
abinit: fix dependency on fftw

### DIFF
--- a/var/spack/repos/builtin/packages/abinit/package.py
+++ b/var/spack/repos/builtin/packages/abinit/package.py
@@ -71,7 +71,7 @@ class Abinit(AutotoolsPackage):
     # depends_on('elpa~openmp', when='+elpa+mpi~openmp')
     # depends_on('elpa+openmp', when='+elpa+mpi+openmp')
 
-    depends_on('fftw precision=float')
+    depends_on('fftw precision=float,double')
     depends_on('fftw~openmp', when='~openmp')
     depends_on('fftw+openmp', when='+openmp')
 


### PR DESCRIPTION
fixes #14578

Abinit's recipe requires double precision FFTW libraries for linking.