### PR TITLE
Explicitly set -e instead of relying on shebang

### DIFF
--- a/share/spack/qa/run-bootstrap-tests
+++ b/share/spack/qa/run-bootstrap-tests
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 #
 # Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
@@ -12,6 +12,9 @@
 # Usage:
 #     run-bootstrap-tests
 #
+
+set -e
+
 . "$(dirname $0)/setup.sh"
 check_dependencies ${coverage} git hg svn
 

--- a/share/spack/qa/run-build-tests
+++ b/share/spack/qa/run-build-tests
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 #
 # Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
@@ -14,6 +14,9 @@
 # Usage:
 #     run-build-tests
 #
+
+set -e
+
 . "$(dirname $0)/setup.sh"
 check_dependencies ${coverage} git hg svn
 

--- a/share/spack/qa/run-doc-tests
+++ b/share/spack/qa/run-doc-tests
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 #
 # Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
@@ -14,6 +14,9 @@
 # Usage:
 #     run-doc-tests
 #
+
+set -e
+
 . "$(dirname $0)/setup.sh"
 check_dependencies sphinx-apidoc sphinx-build dot git hg svn
 

--- a/share/spack/qa/run-flake8-tests
+++ b/share/spack/qa/run-flake8-tests
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 #
 # Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
@@ -14,6 +14,9 @@
 # Usage:
 #     run-flake8-tests
 #
+
+set -e
+
 . "$(dirname $0)/setup.sh"
 check_dependencies flake8
 

--- a/share/spack/qa/run-unit-tests
+++ b/share/spack/qa/run-unit-tests
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 #
 # Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
@@ -16,6 +16,8 @@
 #     Optionally add one or more unit tests
 #     to only run these tests.
 #
+
+set -e
 
 #-----------------------------------------------------------
 # Run a few initial commands and set up test environment

--- a/share/spack/qa/setup.sh
+++ b/share/spack/qa/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 #
 # Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
@@ -9,6 +9,8 @@
 # Description:
 #     Common setup code to be sourced by Spack's test scripts.
 #
+
+set -e
 
 QA_DIR="$(dirname ${BASH_SOURCE[0]})"
 export SPACK_ROOT=$(realpath "$QA_DIR/../../..")


### PR DESCRIPTION
Attempt to debug #14560

Our unit tests are failing for zsh, but Travis passes overall, and I'm not sure why.