### PR TITLE
Use CMake for libmng package

### DIFF
--- a/var/spack/repos/builtin/packages/libmng/package.py
+++ b/var/spack/repos/builtin/packages/libmng/package.py
@@ -6,16 +6,19 @@
 from spack import *
 
 
-class Libmng(AutotoolsPackage):
-    """libmng -THE reference library for reading, displaying, writing
+class Libmng(CMakePackage):
+    """THE reference library for reading, displaying, writing
        and examining Multiple-Image Network Graphics.  MNG is the animation
-       extension to the popular PNG image-format."""
+       extension to the popular PNG image format."""
     homepage = "http://sourceforge.net/projects/libmng/"
     url      = "http://downloads.sourceforge.net/project/libmng/libmng-devel/2.0.3/libmng-2.0.3.tar.gz"
 
     version('2.0.3', sha256='cf112a1fb02f5b1c0fce5cab11ea8243852c139e669c44014125874b14b7dfaa')
     version('2.0.2', sha256='4908797bb3541fb5cd8fffbe0b1513ed163509f2a4d57a78b26a96f8d1dd05a2')
 
+    variant('shared', default=True, description="Build shared library version")
+
+    depends_on("gzip")
     depends_on("jpeg")
     depends_on("zlib")
     depends_on("lcms")
@@ -25,11 +28,9 @@ class Libmng(AutotoolsPackage):
         filter_file(r'^(\#include \<jpeglib\.h\>)',
                     '#include<stdio.h>\n\\1', 'libmng_types.h')
 
-    @run_before('configure')
-    def clean_configure_directory(self):
-        """Without this, configure crashes with:
+    def cmake_args(self):
+        args = [('WITH_LCMS2', True),
+                ('WITH_LCMS1', False)]
 
-            configure: error: source directory already configured;
-            run "make distclean" there first
-        """
-        make('distclean')
+        return ['-D{0}:BOOL={1}'.format(key, 'ON' if val else 'OFF')
+                for (key, val) in args]

--- a/var/spack/repos/builtin/packages/libmng/package.py
+++ b/var/spack/repos/builtin/packages/libmng/package.py
@@ -16,8 +16,6 @@ class Libmng(CMakePackage):
     version('2.0.3', sha256='cf112a1fb02f5b1c0fce5cab11ea8243852c139e669c44014125874b14b7dfaa')
     version('2.0.2', sha256='4908797bb3541fb5cd8fffbe0b1513ed163509f2a4d57a78b26a96f8d1dd05a2')
 
-    variant('shared', default=True, description="Build shared library version")
-
     depends_on("gzip")
     depends_on("jpeg")
     depends_on("zlib")
@@ -29,8 +27,5 @@ class Libmng(CMakePackage):
                     '#include<stdio.h>\n\\1', 'libmng_types.h')
 
     def cmake_args(self):
-        args = [('WITH_LCMS2', True),
-                ('WITH_LCMS1', False)]
-
-        return ['-D{0}:BOOL={1}'.format(key, 'ON' if val else 'OFF')
-                for (key, val) in args]
+        return ['-DWITH_LCMS2:BOOL=ON',
+                '-DWITH_LCMS1:BOOL=OFF']


### PR DESCRIPTION
The autoconf-based libmng package fails on intel, but all versions of the library spack include cmakelists, so use that instead.