### PR TITLE
Module files won't use CPATH by default, but language specific vars

### DIFF
--- a/etc/spack/defaults/modules.yaml
+++ b/etc/spack/defaults/modules.yaml
@@ -30,7 +30,8 @@ modules:
     lib64:
       - LIBRARY_PATH
     include:
-      - CPATH
+      - C_INCLUDE_PATH
+      - CPLUS_INCLUDE_PATH
     lib/pkgconfig:
       - PKG_CONFIG_PATH
     lib64/pkgconfig:

--- a/etc/spack/defaults/modules.yaml
+++ b/etc/spack/defaults/modules.yaml
@@ -32,6 +32,9 @@ modules:
     include:
       - C_INCLUDE_PATH
       - CPLUS_INCLUDE_PATH
+      # The INCLUDE env variable specifies paths to look for
+      # .mod file for Intel Fortran compilers
+      - INCLUDE
     lib/pkgconfig:
       - PKG_CONFIG_PATH
     lib64/pkgconfig:


### PR DESCRIPTION
fixes #11555

Every path in `CPATH` is equivalent to a `-I` path to the compiler, while every path in `*_INCLUDE_PATH` is equivalent to `-isystem`. The latter avoids the noise due to warnings coming from 3rd party libraries that a project depends on.