### PR TITLE
Compilers require an exact match on version during concretization

### DIFF
--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -362,7 +362,16 @@ class Concretizer(object):
         # compiler_for_spec Should think whether this can be more
         # efficient
         def _proper_compiler_style(cspec, aspec):
-            return spack.compilers.compilers_for_spec(cspec, arch_spec=aspec)
+            compilers = spack.compilers.compilers_for_spec(
+                cspec, arch_spec=aspec
+            )
+            # If the spec passed as argument is concrete we want to check
+            # the versions match exactly
+            if (cspec.concrete and compilers and
+                cspec.version != compilers[0].version):
+                return []
+
+            return compilers
 
         if spec.compiler and spec.compiler.concrete:
             if (self.check_for_compiler_existence and not
@@ -403,7 +412,9 @@ class Concretizer(object):
                     return True
                 else:
                     # No compiler with a satisfactory spec was found
-                    raise UnavailableCompilerVersionError(other_compiler)
+                    raise UnavailableCompilerVersionError(
+                        other_compiler, spec.architecture
+                    )
         else:
             # We have no hints to go by, grab any compiler
             compiler_list = spack.compilers.all_compiler_specs()

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -368,7 +368,7 @@ class Concretizer(object):
             # If the spec passed as argument is concrete we want to check
             # the versions match exactly
             if (cspec.concrete and compilers and
-                cspec.version != compilers[0].version):
+                cspec.version not in [c.version for c in compilers]):
                 return []
 
             return compilers

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -620,3 +620,16 @@ class TestConcretize(object):
         with spack.concretize.disable_compiler_existence_check():
             s = Spec(spec).concretized()
             assert str(s.architecture.target) == str(expected)
+
+    @pytest.mark.regression('8735,14730')
+    def test_compiler_version_matches_any_entry_in_compilers_yaml(self):
+        # Ensure that a concrete compiler with different compiler version
+        # doesn't match (here it's 4.5 vs. 4.5.0)
+        with pytest.raises(spack.concretize.UnavailableCompilerVersionError):
+            s = Spec('mpileaks %gcc@4.5')
+            s.concretize()
+
+        # An abstract compiler with a version list could resolve to 4.5.0
+        s = Spec('mpileaks %gcc@4.5:')
+        s.concretize()
+        assert str(s.compiler.version) == '4.5.0'


### PR DESCRIPTION
fixes #14730
fixes #8735

Spack now requires an exact match of the compiler version requested by the user. A loose constraint can be given to Spack by using a version range instead of a concrete version (e.g. `4.5:` instead of `4.5`).