### PR TITLE
[rsync] Use popt and zlib

### DIFF
--- a/var/spack/repos/builtin/packages/rsync/package.py
+++ b/var/spack/repos/builtin/packages/rsync/package.py
@@ -14,3 +14,9 @@ class Rsync(AutotoolsPackage):
     version('3.1.3', sha256='55cc554efec5fdaad70de921cd5a5eeb6c29a95524c715f3bbf849235b0800c0')
     version('3.1.2', sha256='ecfa62a7fa3c4c18b9eccd8c16eaddee4bd308a76ea50b5c02a5840f09c0a1c2')
     version('3.1.1', sha256='7de4364fcf5fe42f3bdb514417f1c40d10bbca896abe7e7f2c581c6ea08a2621')
+
+    depends_on('zlib')
+    depends_on('popt')
+
+    def configure_args(self):
+        return ['--with-included-zlib=no']


### PR DESCRIPTION
popt and zlib are available as spack packages.
So use them instead of building internal ones.