### PR TITLE
cuda: add libxml2 as a dependency

### DIFF
--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -73,6 +73,14 @@ class Cuda(Package):
     # Mojave support -- only macOS High Sierra 10.13 is supported.
     conflicts('arch=darwin-mojave-x86_64')
 
+    depends_on('libxml2', when='@10.1.243:')
+
+    def setup_build_environment(self, env):
+        if self.spec.satisfies('@10.1.243:'):
+            libxml2_home  = self.spec['libxml2'].prefix
+            env.set('LIBXML2HOME', libxml2_home)
+            env.append_path('LD_LIBRARY_PATH', libxml2_home.lib)
+
     def setup_run_environment(self, env):
         env.set('CUDA_HOME', self.prefix)
 


### PR DESCRIPTION
Installing `cuda` in, e.g., a container that does not have `libxml2` installed revealed this issue:

```
[ubuntu] ~: spack install cuda
==> Installing cuda
==> Searching for binary cache of cuda
==> No binary for cuda found: installing from source
==> Fetching http://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda_10.2.89_440.33.01_linux.run
################################################################################################################################################################################################################################## 100.0%
==> Staging unexpanded archive /tmp/root/spack-stage/spack-stage-cuda-10.2.89-3pzuxaqcsscqhzwfnkbpc2oi2xujokut/cuda_10.2.89_440.33.01_linux.run in /tmp/root/spack-stage/spack-stage-cuda-10.2.89-3pzuxaqcsscqhzwfnkbpc2oi2xujokut/spack-src
==> Created stage in /tmp/root/spack-stage/spack-stage-cuda-10.2.89-3pzuxaqcsscqhzwfnkbpc2oi2xujokut
==> No patches needed for cuda
==> Building cuda [Package]
==> Executing phase: 'install'
==> Error: ProcessError: Command exited with status 127:
    '/tmp/root/spack-stage/spack-stage-cuda-10.2.89-3pzuxaqcsscqhzwfnkbpc2oi2xujokut/spack-src/cuda_10.2.89_440.33.01_linux.run' '--silent' '--override' '--toolkit' '--installpath=/work/env1/spack/opt/spack/linux-ubuntu18.04-haswell/gcc-7.4.0/cuda-10.2.89-3pzuxaqcsscqhzwfnkbpc2oi2xujokut'

1 error found in build log:
     2    ==> [2020-02-05-19:54:36.152297] '/bin/chmod' '+x' '/tmp/root/spack-stage/spack-stage-cuda-10.2.89-3pzuxaqcsscqhzwfnkbpc2oi2xujokut/spack-src/cuda_10.2.89_440.33.01_linux.run'
     3    ==> [2020-02-05-19:54:36.157081] '/tmp/root/spack-stage/spack-stage-cuda-10.2.89-3pzuxaqcsscqhzwfnkbpc2oi2xujokut/spack-src/cuda_10.2.89_440.33.01_linux.run' '--silent' '--override' '--toolkit' '--installpath=/work/env1/sp
          ack/opt/spack/linux-ubuntu18.04-haswell/gcc-7.4.0/cuda-10.2.89-3pzuxaqcsscqhzwfnkbpc2oi2xujokut'
  >> 4    ./cuda-installer: error while loading shared libraries: libxml2.so.2: cannot open shared object file: No such file or directory

See build log for details:
  /tmp/root/spack-stage/spack-stage-cuda-10.2.89-3pzuxaqcsscqhzwfnkbpc2oi2xujokut/spack-build-out.txt

[ubuntu] ~:
```