### PR TITLE
acts-core: Fix build

### DIFF
--- a/var/spack/repos/builtin/packages/acts-core/package.py
+++ b/var/spack/repos/builtin/packages/acts-core/package.py
@@ -76,7 +76,7 @@ class ActsCore(CMakePackage):
     depends_on('eigen @3.2.9:', type='build')
     depends_on('nlohmann-json @3.2.0:', when='@0.14.0: +json')
     depends_on('root @6.10: cxxstd=14', when='+tgeo @:0.8.0')
-    depends_on('root @6.10:', when='+tgeo @0.8.1:')
+    depends_on('root @6.10: cxxstd=17', when='+tgeo @0.8.1:')
     depends_on('dd4hep @1.2:', when='+dd4hep')
 
     def cmake_args(self):


### PR DESCRIPTION
Older versions require C++17 and newer ones force C++17 anyway. The build fails if root uses an older C++ standard.

@HadrienG2 