### PR TITLE
Package hashing: fix detection of directives

### DIFF
--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -98,6 +98,10 @@ class TestPackage(object):
         assert spec1.package.content_hash(content=content1) != \
             spec2.package.content_hash(content=content2)
 
+    def test_parse_dynamic_function_call(self):
+        spec = Spec("hash-test4").concretized()
+        spec.package.content_hash()
+
     # Below tests target direct imports of spack packages from the
     # spack.pkg namespace
     def test_import_package(self):

--- a/lib/spack/spack/util/package_hash.py
+++ b/lib/spack/spack/util/package_hash.py
@@ -43,6 +43,7 @@ class RemoveDirectives(ast.NodeTransformer):
     def is_directive(self, node):
         return (isinstance(node, ast.Expr) and
                 node.value and isinstance(node.value, ast.Call) and
+                isinstance(node.value.func, ast.Name) and
                 node.value.func.id in spack.directives.__all__)
 
     def is_spack_attr(self, node):

--- a/lib/spack/spack/util/package_hash.py
+++ b/lib/spack/spack/util/package_hash.py
@@ -41,6 +41,20 @@ class RemoveDirectives(ast.NodeTransformer):
         self.spec = spec
 
     def is_directive(self, node):
+        """Check to determine if the node is a valid directive
+
+        Directives are assumed to be represented in the AST as a named function
+        call expression.  This means that they will NOT be represented by a
+        named function call within a function call expression (e.g., as
+        callbacks are sometimes represented).
+
+        Args:
+            node (AST): the AST node being checked
+
+        Returns:
+            (bool): ``True`` if the node represents a known directive,
+                ``False`` otherwise
+        """
         return (isinstance(node, ast.Expr) and
                 node.value and isinstance(node.value, ast.Call) and
                 isinstance(node.value.func, ast.Name) and

--- a/var/spack/repos/builtin.mock/packages/hash-test4/package.py
+++ b/var/spack/repos/builtin.mock/packages/hash-test4/package.py
@@ -5,8 +5,6 @@
 
 from spack import *
 
-import os
-
 
 class HashTest4(Package):
     """This package isn't compared with others, but it contains constructs

--- a/var/spack/repos/builtin.mock/packages/hash-test4/package.py
+++ b/var/spack/repos/builtin.mock/packages/hash-test4/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+import os
+
+
+class HashTest4(Package):
+    """This package isn't compared with others, but it contains constructs
+       that package hashing logic has tripped over in the past.
+    """
+
+    homepage = "http://www.hashtest4.org"
+    url = "http://www.hashtest1.org/downloads/hashtest4-1.1.tar.bz2"
+
+    version('1.1', 'a' * 32)
+
+    def install(self, spec, prefix):
+        pass
+
+    @staticmethod
+    def examine_prefix(pkg):
+        pass
+
+    run_after('install')(
+        examine_prefix)


### PR DESCRIPTION
Fixes: https://github.com/spack/spack/issues/14735
Fixes: #15079 

When checking if a function call is a directive, add a preliminary check to ensure that the name of the function is available in the AST (this is always true for directives, so we can return `False` if the function call doesn't have a name).

The check for directives was tripping over logic added to `py-pillow`:

```
run_after('install')(PythonPackage.sanity_check_prefix)
```

the hashing logic was checking the names of function calls. But this particular function call (i.e. `...(PythonPackage.sanity_check_prefix)`) doesn't have a name (or at least it doesn't have a name that can be determined by examining the AST); that will always be true for directives.

TODOs:

- [x] add a regression test