### PR TITLE
Added optimized version of Blis for AMD

### DIFF
--- a/var/spack/repos/builtin/packages/amdblis/package.py
+++ b/var/spack/repos/builtin/packages/amdblis/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.pkg.builtin.blis import BlisBase
+
+
+class Amdblis(BlisBase):
+    """AMD Optimized BLIS.
+
+    BLIS is a portable software framework for instantiating high-performance
+    BLAS-like dense linear algebra libraries. The framework was designed to
+    isolate essential kernels of computation that, when optimized, immediately
+    enable optimized implementations of most of its commonly used and
+    computationally intensive operations.
+    """
+
+    homepage = "https://developer.amd.com/amd-aocl/blas-library/"
+    url = "https://github.com/amd/blis/archive/2.1.tar.gz"
+    git = "https://github.com/amd/blis.git"
+
+    version('2.1', sha256='3b1d611d46f0f13b3c0917e27012e0f789b23dbefdddcf877b20327552d72fb3')

--- a/var/spack/repos/builtin/packages/blis/package.py
+++ b/var/spack/repos/builtin/packages/blis/package.py
@@ -3,39 +3,16 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-
 # Although this looks like an Autotools package, it's not one. Refer to:
 # https://github.com/flame/blis/issues/17
 # https://github.com/flame/blis/issues/195
 # https://github.com/flame/blis/issues/197
 
 
-class Blis(Package):
-    """BLIS is a portable software framework for instantiating high-performance
-    BLAS-like dense linear algebra libraries. The framework was designed to
-    isolate essential kernels of computation that, when optimized, immediately
-    enable optimized implementations of most of its commonly used and
-    computationally intensive operations. BLIS is written in ISO C99 and
-    available under a new/modified/3-clause BSD license. While BLIS exports a
-    new BLAS-like API, it also includes a BLAS compatibility layer which gives
-    application developers access to BLIS implementations via traditional BLAS
-    routine calls. An object-based API unique to BLIS is also available."""
-
-    homepage = "https://github.com/flame/blis"
-    url      = "https://github.com/flame/blis/archive/0.4.0.tar.gz"
-    git      = "https://github.com/flame/blis.git"
-
-    version('master', branch='master')
-    version('0.6.1', sha256='76b22f29b7789cf117c0873d2a6b2a6d61f903869168148f2e7306353c105c37')
-    version('0.6.0', sha256='ad5765cc3f492d0c663f494850dafc4d72f901c332eb442f404814ff2995e5a9')
-    version('0.5.0', sha256='1a004d69c139e8a0448c6a6007863af3a8c3551b8d9b8b73fe08e8009f165fa8')
-    version('0.4.0', sha256='9c7efd75365a833614c01b5adfba93210f869d92e7649e0b5d9edc93fc20ea76')
-    version('0.3.2', sha256='b87e42c73a06107d647a890cbf12855925777dc7124b0c7698b90c5effa7f58f')
-    version('0.3.1', sha256='957f28d47c5cf71ffc62ce8cc1277e17e44d305b1c2fa8506b0b55617a9f28e4')
-    version('0.3.0', sha256='d34d17df7bdc2be8771fe0b7f867109fd10437ac91e2a29000a4a23164c7f0da')
-    version('0.2.2', sha256='4a7ecb56034fb20e9d1d8b16e2ef587abbc3d30cb728e70629ca7e795a7998e8')
-
+class BlisBase(Package):
+    """Base class for building BLIS, shared with the AMD optimized version
+    of the library in the 'amdblis' package.
+    """
     depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
 
     variant(
@@ -73,10 +50,6 @@ class Blis(Package):
 
     provides('blas', when="+blas")
     provides('blas', when="+cblas")
-
-    # Problems with permissions on installed libraries:
-    # https://github.com/flame/blis/issues/343
-    patch('Makefile_0.6.0.patch', when='@0.4.0:0.6.0')
 
     phases = ['configure', 'build', 'install']
 
@@ -128,3 +101,36 @@ class Blis(Package):
         # The shared library is not installed correctly on Darwin; fix this
         if self.spec.satisfies('platform=darwin'):
             fix_darwin_install_name(self.prefix.lib)
+
+
+class Blis(BlisBase):
+    """BLIS is a portable software framework for instantiating high-performance
+    BLAS-like dense linear algebra libraries.
+
+    The framework was designed to isolate essential kernels of computation
+    that, when optimized, immediately enable optimized implementations of
+    most of its commonly used and computationally intensive operations. BLIS
+    is written in ISO C99 and available under a new/modified/3-clause BSD
+    license. While BLIS exports a new BLAS-like API, it also includes a
+    BLAS compatibility layer which gives application developers access to
+    BLIS implementations via traditional BLAS routine calls.
+    An object-based API unique to BLIS is also available.
+    """
+
+    homepage = "https://github.com/flame/blis"
+    url = "https://github.com/flame/blis/archive/0.4.0.tar.gz"
+    git = "https://github.com/flame/blis.git"
+
+    version('master', branch='master')
+    version('0.6.1', sha256='76b22f29b7789cf117c0873d2a6b2a6d61f903869168148f2e7306353c105c37')
+    version('0.6.0', sha256='ad5765cc3f492d0c663f494850dafc4d72f901c332eb442f404814ff2995e5a9')
+    version('0.5.0', sha256='1a004d69c139e8a0448c6a6007863af3a8c3551b8d9b8b73fe08e8009f165fa8')
+    version('0.4.0', sha256='9c7efd75365a833614c01b5adfba93210f869d92e7649e0b5d9edc93fc20ea76')
+    version('0.3.2', sha256='b87e42c73a06107d647a890cbf12855925777dc7124b0c7698b90c5effa7f58f')
+    version('0.3.1', sha256='957f28d47c5cf71ffc62ce8cc1277e17e44d305b1c2fa8506b0b55617a9f28e4')
+    version('0.3.0', sha256='d34d17df7bdc2be8771fe0b7f867109fd10437ac91e2a29000a4a23164c7f0da')
+    version('0.2.2', sha256='4a7ecb56034fb20e9d1d8b16e2ef587abbc3d30cb728e70629ca7e795a7998e8')
+
+    # Problems with permissions on installed libraries:
+    # https://github.com/flame/blis/issues/343
+    patch('Makefile_0.6.0.patch', when='@0.4.0:0.6.0')


### PR DESCRIPTION
The Blis package has been refactored to be able to reuse the build logic for the fork of the project optimized for AMD.