### PR TITLE
Disable RPATH/RUNPATH forcing for mixed toolchains.

### DIFF
--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -5,7 +5,6 @@
 
 import contextlib
 import os
-import platform
 import re
 import itertools
 import shutil
@@ -248,14 +247,10 @@ class Compiler(object):
 
     @property
     def disable_new_dtags(self):
-        if platform.system() == 'Darwin':
-            return ''
         return '--disable-new-dtags'
 
     @property
     def enable_new_dtags(self):
-        if platform.system() == 'Darwin':
-            return ''
         return '--enable-new-dtags'
 
     @property

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -316,15 +316,23 @@ def test_parallel_false_is_not_propagating(config, mock_packages):
         assert m.make_jobs == expected_jobs
 
 
-@pytest.mark.parametrize('config_setting,expected_flag', [
-    ('runpath', '' if platform.system() == 'Darwin' else '--enable-new-dtags'),
-    ('rpath', '' if platform.system() == 'Darwin' else '--disable-new-dtags'),
+@pytest.mark.parametrize('config_setting,compiler_spec, expected_flag', [
+    # Non-mixed toolchain
+    ('runpath', 'gcc@4.5.0',
+     '' if platform.system() == 'Darwin' else '--enable-new-dtags'),
+    ('rpath', 'gcc@4.5.0',
+     '' if platform.system() == 'Darwin' else '--disable-new-dtags'),
+    # Mixed toolchain
+    ('runpath', 'clang@8.0.0', ''),
+    ('rpath', 'clang@8.0.0', ''),
 ])
+@pytest.mark.filterwarnings("ignore:microarchitecture specific")
+@pytest.mark.filterwarnings("ignore:RPATH/RUNPATH forcing")
 def test_setting_dtags_based_on_config(
-        config_setting, expected_flag, config, mock_packages
+        config_setting, compiler_spec, expected_flag, config, mock_packages
 ):
     # Pick a random package to be able to set compiler's variables
-    s = spack.spec.Spec('cmake')
+    s = spack.spec.Spec('cmake%' + compiler_spec)
     s.concretize()
     pkg = s.package
 

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -622,3 +622,28 @@ def test_filter_enable_new_dtags(wrapper_flags):
         result = cc(*(test_args + ['-Wl,--enable-new-dtags']), output=str)
         result = result.strip().split('\n')
         assert '-Wl,--enable-new-dtags' not in result
+
+
+@pytest.mark.regression('9160')
+def test_keep_dtags(wrapper_flags):
+    with set_env(SPACK_TEST_COMMAND='dump-args',
+                 SPACK_DTAGS_TO_ADD='',
+                 SPACK_DTAGS_TO_STRIP=''):
+        result = ld(*test_args, output=str).strip().split('\n')
+        assert '--enable-new-dtags' not in result
+        assert '--disable-new-dtags' not in result
+        result = cc(*test_args, output=str).strip().split('\n')
+        assert '-Wl,--enable-new-dtags' not in result
+        assert '-Wl,--disable-new-dtags' not in result
+
+        result = ld(*(test_args + ['--enable-new-dtags']), output=str)
+        assert '--enable-new-dtags' in result
+        result = cc(*(test_args + ['-Wl,--enable-new-dtags']), output=str)
+        result = result.strip().split('\n')
+        assert '-Wl,--enable-new-dtags' in result
+
+        result = ld(*(test_args + ['--disable-new-dtags']), output=str)
+        assert '--disable-new-dtags' in result
+        result = cc(*(test_args + ['-Wl,--disable-new-dtags']), output=str)
+        result = result.strip().split('\n')
+        assert '-Wl,--disable-new-dtags' in result

--- a/lib/spack/spack/test/data/config/compilers.yaml
+++ b/lib/spack/spack/test/data/config/compilers.yaml
@@ -135,7 +135,7 @@ compilers:
     target: x86_64
 - compiler:
     spec: clang@8.0.0
-    operating_system: redhat7
+    operating_system: {0.name}{0.version}
     paths:
       cc: /path/to/clang-8
       cxx: /path/to/clang++-8


### PR DESCRIPTION
Compilers in mixed toolchains, e.g. NAG/GCC, might require different linker prefixes. Without this, it becomes impossible to build packages requiring both C and Fortran compilers at all.

Another solution would be to override `disable_new_dtags` and `enable_new_dtags` properties in the `Nag` class so they would return empty lines.