### PR TITLE
Set 'fflags' as FCFLAGS when the flags must be passed to Autotools.

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -43,7 +43,7 @@ parameters=(
 # The compiler input variables are checked for sanity later:
 #   SPACK_CC, SPACK_CXX, SPACK_F77, SPACK_FC
 # The default compiler flags are passed from these variables:
-#   SPACK_CFLAGS, SPACK_CXXFLAGS, SPACK_FCFLAGS, SPACK_FFLAGS,
+#   SPACK_CFLAGS, SPACK_CXXFLAGS, SPACK_FFLAGS,
 #   SPACK_LDFLAGS, SPACK_LDLIBS
 # Debug env var is optional; set to "TRUE" for debug logging:
 #   SPACK_DEBUG

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -263,6 +263,12 @@ class AutotoolsPackage(PackageBase):
             if values:
                 values_str = '{0}={1}'.format(flag.upper(), ' '.join(values))
                 self.configure_flag_args.append(values_str)
+        # Spack's fflags are meant for both F77 and FC, therefore we
+        # additionaly set FCFLAGS if required.
+        values = flags.get('fflags', None)
+        if values:
+            values_str = 'FCFLAGS={0}'.format(' '.join(values))
+            self.configure_flag_args.append(values_str)
 
     def configure(self, spec, prefix):
         """Runs configure with the arguments specified in


### PR DESCRIPTION
Spack's `fflags` are meant for both `f77` and `fc`. Therefore, they must to be passed as `FFLAGS` and `FCFLAGS` to the configure scripts of Autotools-based packages.