### PR TITLE
[dd4hep] Make DDDigi work with current TBB releases

### DIFF
--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -22,9 +22,9 @@ class Dd4hep(CMakePackage):
     version('1.11.0', commit='280c7d748d56a704699408ac8e57815d029b169a')
     version('1.10.0', commit='9835d1813c07d9d5850d1e68276c0171d1726801')
 
-    # Workarounds for various TBB issues in current DD4hep package
-    # Submitted upstream as https://github.com/AIDASoft/DD4hep/pull/613 .
-    patch('tbb-workarounds.patch', when='@1.11.0:')
+    # Workarounds for various TBB issues in DD4hep v1.11
+    # See https://github.com/AIDASoft/DD4hep/pull/613 .
+    patch('tbb-workarounds.patch', when='@1.11.0')
 
     variant('xercesc', default=False, description="Enable 'Detector Builders' based on XercesC")
     variant('geant4', default=False, description="Enable the simulation part based on Geant4")

--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -22,6 +22,10 @@ class Dd4hep(CMakePackage):
     version('1.11.0', commit='280c7d748d56a704699408ac8e57815d029b169a')
     version('1.10.0', commit='9835d1813c07d9d5850d1e68276c0171d1726801')
 
+    # Workarounds for various TBB issues in current DD4hep package
+    # Submitted upstream as https://github.com/AIDASoft/DD4hep/pull/613 .
+    patch('tbb-workarounds.patch', when='@1.11.0:')
+
     variant('xercesc', default=False, description="Enable 'Detector Builders' based on XercesC")
     variant('geant4', default=False, description="Enable the simulation part based on Geant4")
     variant('testing', default=False, description="Enable and build tests")

--- a/var/spack/repos/builtin/packages/dd4hep/tbb-workarounds.patch
+++ b/var/spack/repos/builtin/packages/dd4hep/tbb-workarounds.patch
@@ -1,0 +1,41 @@
+diff --git a/DDDigi/CMakeLists.txt b/DDDigi/CMakeLists.txt
+index e6fb1096..88eb5c92 100644
+--- a/DDDigi/CMakeLists.txt
++++ b/DDDigi/CMakeLists.txt
+@@ -34,12 +34,10 @@ target_include_directories(DDDigi
+ 
+ FIND_PACKAGE(TBB QUIET)
+ if(TBB_FOUND)
+-  dd4hep_print( "|++> TBB_INCLUDE_DIR -->  ${TBB_INCLUDE_DIR}")
+-  dd4hep_print( "|++> TBB_LIBRARY     -->  ${TBB_LIBRARY}")
++  dd4hep_print( "|++> TBB_IMPORTED_TARGETS -->  ${TBB_IMPORTED_TARGETS}")
+   dd4hep_print( "|++> TBB found. DDDigi will run multi threaded.")
+   target_compile_definitions(DDDigi PUBLIC DD4HEP_USE_TBB)
+-  target_link_libraries(DDDigi ${TBB_LIBRARY})
+-  target_include_directories(DDDigi ${TBB_INCLUDE_DIRS})
++  target_link_libraries(DDDigi PUBLIC ${TBB_IMPORTED_TARGETS})
+ else()
+   dd4hep_print( "|++> TBB not found. DDDigi will only work single threaded.")
+ endif()
+diff --git a/DDDigi/src/DigiKernel.cpp b/DDDigi/src/DigiKernel.cpp
+index d62c6694..f2c2e86c 100644
+--- a/DDDigi/src/DigiKernel.cpp
++++ b/DDDigi/src/DigiKernel.cpp
+@@ -91,7 +91,7 @@ public:
+   DigiEventAction*  action = 0;
+   Wrapper(DigiContext& c, DigiEventAction* a)
+     : context(c), action(a) {}
+-  Wrapper(Wrapper&& copy) = delete;
++  Wrapper(Wrapper&& copy) = default;
+   Wrapper(const Wrapper& copy) = default;
+   Wrapper& operator=(Wrapper&& copy) = delete;
+   Wrapper& operator=(const Wrapper& copy) = delete;
+@@ -111,7 +111,7 @@ class DigiKernel::Processor {
+   DigiKernel& kernel;
+ public: 
+   Processor(DigiKernel& k) : kernel(k) {}
+-  Processor(Processor&& l) = delete;
++  Processor(Processor&& l) = default;
+   Processor(const Processor& l) = default;
+   void operator()()  const {
+     int todo = 1;


### PR DESCRIPTION
This will allow current releases of DD4hep to build against current TBB releases provided by Spack, while waiting for [upstream patch integration](https://github.com/AIDASoft/DD4hep/pull/613).