### PR TITLE
patch aws-parallelcluster so that it doesn't require enum34

### DIFF
--- a/var/spack/repos/builtin/packages/aws-parallelcluster/enum34.patch
+++ b/var/spack/repos/builtin/packages/aws-parallelcluster/enum34.patch
@@ -1,0 +1,17 @@
+diff -Naur a/setup.py b/setup.py
+--- a/setup.py	2020-02-06 15:40:26.000000000 -0600
++++ b/setup.py	2020-02-06 15:41:17.000000000 -0600
+@@ -27,10 +27,12 @@
+     "future>=0.16.0,<=0.18.2",
+     "tabulate>=0.8.2,<=0.8.3",
+     "ipaddress>=1.0.22",
+-    "enum34>=1.1.6",
+     "PyYAML>=5.1.2",
+ ]
+ 
++if sys.version_info < (3, 4):
++    REQUIRES.append("enum34>=1.1.6")
++
+ if sys.version_info[0] == 2:
+     REQUIRES.append("configparser>=3.5.0,<=3.8.1")
+ 

--- a/var/spack/repos/builtin/packages/aws-parallelcluster/package.py
+++ b/var/spack/repos/builtin/packages/aws-parallelcluster/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+import os
 
 
 class AwsParallelcluster(PythonPackage):
@@ -12,8 +13,15 @@ class AwsParallelcluster(PythonPackage):
 
     homepage = "https://github.com/aws/aws-parallelcluster"
     url      = "https://pypi.io/packages/source/a/aws-parallelcluster/aws-parallelcluster-2.5.1.tar.gz"
-    maintainers = ['sean-smith', 'demartinofra', 'enrico-usai',
-                   'lukeseawalker', 'rexcsn', 'ddeidda', 'tilne']
+
+    maintainers = [
+        'sean-smith', 'demartinofra', 'enrico-usai', 'lukeseawalker', 'rexcsn',
+        'ddeidda', 'tilne'
+    ]
+    import_modules = [
+        'pcluster', 'awsbatch', 'pcluster.dcv', 'pcluster.configure',
+        'pcluster.config', 'pcluster.networking'
+    ]
 
     version('2.5.1', sha256='4fd6e14583f8cf81f9e4aa1d6188e3708d3d14e6ae252de0a94caaf58be76303')
     version('2.5.0', sha256='3b0209342ea0d9d8cc95505456103ad87c2d4e35771aa838765918194efd0ad3')
@@ -30,3 +38,12 @@ class AwsParallelcluster(PythonPackage):
 
     # https://github.com/aws/aws-parallelcluster/pull/1633
     patch('enum34.patch', when='@:2.5.1')
+
+    @run_after('install')
+    @on_package_attributes(run_tests=True)
+    def install_test(self):
+        # Make sure executables work
+        for exe in ['awsbhosts', 'awsbkill', 'awsbout', 'awsbqueues',
+                    'awsbstat', 'awsbsub', 'pcluster']:
+            exe = Executable(os.path.join(self.prefix.bin, exe))
+            exe('--help')

--- a/var/spack/repos/builtin/packages/aws-parallelcluster/package.py
+++ b/var/spack/repos/builtin/packages/aws-parallelcluster/package.py
@@ -24,6 +24,6 @@ class AwsParallelcluster(PythonPackage):
     depends_on('py-future@0.16.0:0.18.2', type=('build', 'run'))
     depends_on('py-tabulate@0.8.2:0.8.3', type=('build', 'run'))
     depends_on('py-ipaddress@1.0.22:', type=('build', 'run'))
-    depends_on('py-enum34@1.1.6:', when='^python@:3.3', type=('build', 'run'))
+    depends_on('py-enum34@1.1.6:', type=('build', 'run'))
     depends_on('py-pyyaml@5.1.2:', type=('build', 'run'))
     depends_on('py-configparser@3.5.0:3.8.1', when='^python@:2', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/aws-parallelcluster/package.py
+++ b/var/spack/repos/builtin/packages/aws-parallelcluster/package.py
@@ -19,11 +19,14 @@ class AwsParallelcluster(PythonPackage):
     version('2.5.0', sha256='3b0209342ea0d9d8cc95505456103ad87c2d4e35771aa838765918194efd0ad3')
 
     depends_on('python@2.7:', type=('build', 'run'))
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-boto3@1.10.15:', type=('build', 'run'))
     depends_on('py-future@0.16.0:0.18.2', type=('build', 'run'))
     depends_on('py-tabulate@0.8.2:0.8.3', type=('build', 'run'))
     depends_on('py-ipaddress@1.0.22:', type=('build', 'run'))
-    depends_on('py-enum34@1.1.6:', type=('build', 'run'))
+    depends_on('py-enum34@1.1.6:', when='^python@:3.3', type=('build', 'run'))
     depends_on('py-pyyaml@5.1.2:', type=('build', 'run'))
     depends_on('py-configparser@3.5.0:3.8.1', when='^python@:2', type=('build', 'run'))
+
+    # https://github.com/aws/aws-parallelcluster/pull/1633
+    patch('enum34.patch', when='@:2.5.1')

--- a/var/spack/repos/builtin/packages/py-enum34/package.py
+++ b/var/spack/repos/builtin/packages/py-enum34/package.py
@@ -9,16 +9,16 @@ from spack import *
 class PyEnum34(PythonPackage):
     """Python 3.4 Enum backported to 3.3, 3.2, 3.1, 2.7, 2.6, 2.5, and 2.4."""
 
-    homepage = "https://pypi.python.org/pypi/enum34"
+    homepage = "https://bitbucket.org/stoneleaf/enum34/src"
     url      = "https://pypi.io/packages/source/e/enum34/enum34-1.1.6.tar.gz"
 
     version('1.1.6', sha256='8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1')
 
     # enum34 is a backport of the enum library from Python 3.4. It is not
     # intended to be used with Python 3.4+. In fact, it won't build at all
-    # for Python 3.6+, as new constructs were added to builtin enum module
-    # that aren't present in enum34. See:
-    # https://bitbucket.org/stoneleaf/enum34/issues/19/enum34-isnt-compatible-with-python-36
+    # for Python 3.6+, as new constructs were added to the builtin enum
+    # library that aren't present in enum34. See:
+    # https://bitbucket.org/stoneleaf/enum34/issues/19
     depends_on('python@:3.5', type=('build', 'run'))
     depends_on('py-ordereddict', when='^python@:2.6', type=('build', 'run'))
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-enum34/package.py
+++ b/var/spack/repos/builtin/packages/py-enum34/package.py
@@ -14,6 +14,11 @@ class PyEnum34(PythonPackage):
 
     version('1.1.6', sha256='8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1')
 
-    depends_on('python')
+    # enum34 is a backport of the enum library from Python 3.4. It is not
+    # intended to be used with Python 3.4+. In fact, it won't build at all
+    # for Python 3.6+, as new constructs were added to builtin enum module
+    # that aren't present in enum34. See:
+    # https://bitbucket.org/stoneleaf/enum34/issues/19/enum34-isnt-compatible-with-python-36
+    depends_on('python@:3.5', type=('build', 'run'))
     depends_on('py-ordereddict', when='^python@:2.6', type=('build', 'run'))
     depends_on('py-setuptools', type='build')


### PR DESCRIPTION
When I try to run `pcluster configure` with Python 3.7.6, I get the following error:
```
$ pcluster configure
Traceback (most recent call last):
  File "/Users/Adam/.spack/darwin/.spack-env/view/bin/pcluster", line 7, in <module>
    from pkg_resources import load_entry_point
  File "/Users/Adam/.spack/darwin/.spack-env/view/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3250, in <module>
    @_call_aside
  File "/Users/Adam/.spack/darwin/.spack-env/view/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3234, in _call_aside
    f(*args, **kwargs)
  File "/Users/Adam/.spack/darwin/.spack-env/view/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3263, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/Users/Adam/.spack/darwin/.spack-env/view/lib/python3.7/site-packages/pkg_resources/__init__.py", line 583, in _build_master
    ws.require(__requires__)
  File "/Users/Adam/.spack/darwin/.spack-env/view/lib/python3.7/site-packages/pkg_resources/__init__.py", line 900, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/Users/Adam/.spack/darwin/.spack-env/view/lib/python3.7/site-packages/pkg_resources/__init__.py", line 786, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'enum34>=1.1.6' distribution was not found and is required by aws-parallelcluster
```
It seems `enum34` is required even for Python 3.4+, where it is a builtin library.

@sean-smith @demartinofra @enrico-usai @lukeseawalker @rexcsn @ddeidda @tilne I wonder if it would be possible to use the builtin enum module in Python 3.4+ so the extra dependency wouldn't be required.