### PR TITLE
precice: add version 2.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/precice/package.py
+++ b/var/spack/repos/builtin/packages/precice/package.py
@@ -19,6 +19,7 @@ class Precice(CMakePackage):
     maintainers = ['fsimonis', 'MakisH']
 
     version('develop', branch='develop')
+    version('2.0.0', sha256='c8979d366f06e35626a8da08a1c589df77ec13972eb524a1ba99a011e245701f')
     version('1.6.1', sha256='7d0c54faa2c69e52304f36608d93c408629868f16f3201f663a0f9b2008f0763')
     version('1.6.0', sha256='c3b16376fda9eb3449adb6cc3c1e267c3dc792a5d118e37d93a32a59b5a4bc6f')
     version('1.5.2', sha256='051e0d7655a91f8681901e5c92812e48f33a5779309e2f104c99f5a687e1a418')
@@ -44,9 +45,14 @@ class Precice(CMakePackage):
     depends_on('libxml2')
     depends_on('mpi', when='+mpi')
     depends_on('petsc@3.6:', when='+petsc')
-    depends_on('python@2.7:2.8', when='+python', type=('build', 'run'))
+
+    # Python 3 support was added in version 2.0
+    depends_on('python@2.7:2.8', when='@:1.9+python', type=('build', 'run'))
+    depends_on('python@3:', when='@2:+python', type=('build', 'run'))
+
     # numpy 1.17+ requires Python 3
-    depends_on('py-numpy@:1.16', when='+python', type=('build', 'run'))
+    depends_on('py-numpy@:1.16', when='@:1.9+python', type=('build', 'run'))
+    depends_on('py-numpy@1.17:', when='@2:+python', type=('build', 'run'))
 
     # We require C++11 compiler support as well as
     # library support for time manipulators (N2071, N2072)
@@ -62,6 +68,17 @@ class Precice(CMakePackage):
         # The xSDK installation policies were implemented after 1.5.2
         xsdk_mode = spec.satisfies("@1.6:")
 
+        # Select the correct CMake variables by version
+        mpi_option     = "MPI"
+        if spec.satisfies("@2:"):
+            mpi_option    = "PRECICE_MPICommunication"
+        petsc_option   = "PETSC"
+        if spec.satisfies("@2:"):
+            petsc_option  = "PRECICE_PETScMapping"
+        python_option  = "PYTHON"
+        if spec.satisfies("@2:"):
+            python_option = "PRECICE_PythonActions"
+
         def variant_bool(feature, on='ON', off='OFF'):
             """Ternary for spec variant to ON/OFF string"""
             if feature in spec:
@@ -70,8 +87,9 @@ class Precice(CMakePackage):
 
         cmake_args = [
             '-DBUILD_SHARED_LIBS:BOOL=%s' % variant_bool('+shared'),
-            '-DMPI:BOOL=%s' % variant_bool('+mpi'),
         ]
+
+        cmake_args.append('-D%s:BOOL=%s' % (mpi_option, variant_bool('+mpi')))
 
         # Boost
         if xsdk_mode:
@@ -95,13 +113,16 @@ class Precice(CMakePackage):
 
         # PETSc
         if '+petsc' in spec:
+            if xsdk_mode:
+                cmake_args.append('-DTPL_ENABLE_PETSC:BOOL=ON')
+            else:
+                cmake_args.append('-D%s:BOOL=ON' % petsc_option)
             cmake_args.extend([
-                '-DTPL_ENABLE_PETSC:BOOL=ON' if xsdk_mode else '-DPETSC=ON',
                 '-DPETSC_DIR=%s' % spec['petsc'].prefix,
                 '-DPETSC_ARCH=.'
             ])
         else:
-            cmake_args.append('-DPETSC:BOOL=OFF')
+            cmake_args.append('-D%s:BOOL=OFF' % petsc_option)
 
         # Python
         if '+python' in spec:
@@ -111,13 +132,16 @@ class Precice(CMakePackage):
                 spec['py-numpy'].prefix,
                 spec['python'].package.site_packages_dir,
                 'numpy', 'core', 'include')
+            if xsdk_mode:
+                cmake_args.append('-DTPL_ENABLE_PYTHON:BOOL=ON')
+            else:
+                cmake_args.append('-D%s:BOOL=ON' % python_option)
             cmake_args.extend([
-                '-DTPL_ENABLE_PYTHON:BOOL=ON' if xsdk_mode else '-DPYTHON=ON',
                 '-DPYTHON_INCLUDE_DIR=%s' % python_include,
                 '-DNumPy_INCLUDE_DIR=%s' % numpy_include,
                 '-DPYTHON_LIBRARY=%s' % python_library
             ])
         else:
-            cmake_args.append('-DPYTHON:BOOL=OFF')
+            cmake_args.append('-D%s:BOOL=OFF' % python_option)
 
         return cmake_args


### PR DESCRIPTION
This PR adds
* version 2.0.0 of the xSDK member preCICE
* python3 dependency
* support for new CMake variables.