### PR TITLE
Fix concretization of python+libxml2

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -71,7 +71,7 @@ class Python(AutotoolsPackage):
     extendable = True
 
     # Variants to avoid cyclical dependencies for concretizer
-    variant('libxml2', default=False,
+    variant('libxml2', default=True,
             description='Use a gettext library build with libxml2')
 
     variant(


### PR DESCRIPTION
This is a workaround until @tgamblin finishes the new concretizer, which will be smart enough to handle these issues on its own. Suggestion came from @danlipsa in #14792:

> The fix would be to change the libxml2 variant to True in python/package.py

Fixes #14792 
Fixes #14827 

Doesn't seem to reintroduce any of the issues fixed by #13847 

@becker33 @scheibelp @danlipsa @SteVwonder 