### PR TITLE
Fix concretization of ncurses+termlib

### DIFF
--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -26,7 +26,7 @@ class Ncurses(AutotoolsPackage, GNUMirrorPackage):
 
     variant('symlinks', default=False,
             description='Enables symlinks. Needed on AFS filesystem.')
-    variant('termlib', default=False,
+    variant('termlib', default=True,
             description='Enables termlib needs for gnutls in emacs.')
 
     depends_on('pkgconfig', type='build')


### PR DESCRIPTION
This is a workaround until @tgamblin finishes the new concretizer, which will be smart enough to handle these issues on its own. Suggestion came from @danlipsa in #14793:

> If termlib is really needed, the ncourses/package.py should be changed to make termlib variant True.

Fixes #14793 along with #14844 

@becker33 @scheibelp @danlipsa @glennpj 