### PR TITLE
r-truncdist: new package at 1.0-2

### DIFF
--- a/var/spack/repos/builtin/packages/r-truncdist/package.py
+++ b/var/spack/repos/builtin/packages/r-truncdist/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class RTruncdist(RPackage):
+    """truncdist: Truncated Random Variables"""
+
+    homepage = "https://cloud.r-project.org/package=truncdist"
+    url      = "https://cloud.r-project.org/src/contrib/truncdist_1.0-2.tar.gz"
+    list_url = "https://cloud.r-project.org/src/contrib/Archive/truncdist"
+
+    version('1.0-2', sha256='b848b68bdd983bd496fa7327632ffa8add8d2231229b8af5c8bc29d823e1300a')
+
+    depends_on('r@2.0.1:', type=('build', 'run'))
+    depends_on('r-evd', type=('build', 'run'))


### PR DESCRIPTION
depends on `r-evd` in #14847 