### PR TITLE
libedit package: add version 3.1-20191231

### DIFF
--- a/var/spack/repos/builtin/packages/libedit/package.py
+++ b/var/spack/repos/builtin/packages/libedit/package.py
@@ -11,6 +11,7 @@ class Libedit(AutotoolsPackage):
     homepage = "http://thrysoee.dk/editline/"
     url      = "http://thrysoee.dk/editline/libedit-20170329-3.1.tar.gz"
 
+    version('3.1-20191231', sha256='dbb82cb7e116a5f8025d35ef5b4f7d4a3cdd0a3909a146a39112095a2d229071')
     version('3.1-20170329', sha256='91f2d90fbd2a048ff6dad7131d9a39e690fd8a8fd982a353f1333dd4017dd4be')
     version('3.1-20160903', sha256='0ccbd2e7d46097f136fcb1aaa0d5bc24e23bb73f57d25bee5a852a683eaa7567')
     version('3.1-20150325', sha256='c88a5e4af83c5f40dda8455886ac98923a9c33125699742603a88a0253fcc8c5')


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/14846

This new version of libedit can make use of an ncurses dependency built with `+termlib` (which moves some symbols into a separate `libtinfo`).