### PR TITLE
Remove tinfo linking from llvm

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -103,10 +103,8 @@ class Llvm(CMakePackage):
     # openmp dependencies
     depends_on('perl-data-dumper', type=('build'))
 
-    # ncurses dependency
-    depends_on('ncurses+termlib')
-
     # lldb dependencies
+    depends_on('ncurses', when='+lldb')
     depends_on('swig', when='+lldb')
     depends_on('libedit', when='+lldb')
     depends_on('py-six', when='@5.0.0: +lldb +python')
@@ -183,6 +181,7 @@ class Llvm(CMakePackage):
             '-DLLVM_REQUIRES_RTTI:BOOL=ON',
             '-DLLVM_ENABLE_RTTI:BOOL=ON',
             '-DLLVM_ENABLE_EH:BOOL=ON',
+            '-DLLVM_ENABLE_TERMINFO:BOOL=OFF',
             '-DCLANG_DEFAULT_OPENMP_RUNTIME:STRING=libomp',
             '-DPYTHON_EXECUTABLE:PATH={0}'.format(spec['python'].command.path),
         ]


### PR DESCRIPTION
This PR fixes a problem introduced in #14561 where the +termlib variant
of ncurses was depended on. That was needed because llvm was linking
against libtinfo. That caused problems for other packages.

This PR disables linking against libtinfo and restores the
previous settings for the ncurses dependency.