### PR TITLE
More debug info for concretizer errors

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2498,6 +2498,8 @@ class Spec(object):
         else:
             # merge package/vdep information into spec
             try:
+                tty.debug(
+                    "{0} applying constraint {1}".format(self.name, str(dep)))
                 changed |= spec_deps[dep.name].constrain(dep)
             except spack.error.UnsatisfiableSpecError as e:
                 fmt = 'An unsatisfiable {0}'.format(e.constraint_type)


### PR DESCRIPTION
This prints out debug information about which specs are applying which constraints.

Spack's greedy concretizer can make mistakes that later cause it to think that a spec cannot be concretized. See for example https://github.com/spack/spack/issues/14792. At the point where it encounters a conflict, it is difficult to know which other specs applied the constraints that are now causing a conflict. This prints out a list of all the constraints applied by all specs. If you get an error like

```
python requires gettext variant ~libxml2, but spec asked for +libxml2
```

you can pipe the debug output to a file and then grep for instances of

* dependencies requiring gettext+libxml2
* dependencies asking for gettext by itself (and if this occurs early enough in the concretization, Spack can choose a default value for libxml2 that later creates a conflict)