### PR TITLE
Fix intel-mkl package

### DIFF
--- a/var/spack/repos/builtin/packages/cpio/package.py
+++ b/var/spack/repos/builtin/packages/cpio/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Cpio(AutotoolsPackage, GNUMirrorPackage):
+    """GNU cpio copies files into or out of a cpio or tar archive. The
+       archive can be another file on the disk, a magnetic tape, or a pipe.
+    """
+    homepage = "https://www.gnu.org/software/cpio/"
+    gnu_mirror_path = "cpio/cpio-2.13.tar.gz"
+
+    version('2.13', sha256='e87470d9c984317f658567c03bfefb6b0c829ff17dbf6b0de48d71a4c8f3db88')
+
+    build_directory = 'spack-build'

--- a/var/spack/repos/builtin/packages/intel-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-mkl/package.py
@@ -54,6 +54,8 @@ class IntelMkl(IntelPackage):
     version('11.3.2.181', sha256='bac04a07a1fe2ae4996a67d1439ee90c54f31305e8663d1ccfce043bed84fc27',
             url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/8711/l_mkl_11.3.2.181.tgz')
 
+    depends_on('cpio', type='build')
+
     variant('shared', default=True, description='Builds shared library')
     variant('ilp64', default=False, description='64 bit integers')
     variant(


### PR DESCRIPTION
This PR adds a `cpio` package and makes it available during the build of `intel-mkl`.

Fixes #14855