### PR TITLE
intel-tbb: fix sha256 sums for 2020 versions

### DIFF
--- a/var/spack/repos/builtin/packages/intel-tbb/makefile-debug.patch
+++ b/var/spack/repos/builtin/packages/intel-tbb/makefile-debug.patch
@@ -1,0 +1,42 @@
+The debug targets were removed starting with rev 2020.
+This patch restores them.
+
+
+--- tbb-2020/Makefile.orig	2019-12-18 02:42:41.000000000 -0600
++++ tbb-2020/Makefile	2020-02-09 00:27:17.058452442 -0600
+@@ -26,15 +26,19 @@
+ all: tbb tbbmalloc tbbproxy test examples
+ 
+ tbb: mkdir
++	$(MAKE) -C "$(work_dir)_debug"  -r -f $(tbb_root)/build/Makefile.tbb cfg=debug
+ 	$(MAKE) -C "$(work_dir)_release"  -r -f $(tbb_root)/build/Makefile.tbb cfg=release
+ 
+ tbbmalloc: mkdir
++	$(MAKE) -C "$(work_dir)_debug"  -r -f $(tbb_root)/build/Makefile.tbbmalloc cfg=debug malloc
+ 	$(MAKE) -C "$(work_dir)_release"  -r -f $(tbb_root)/build/Makefile.tbbmalloc cfg=release malloc
+ 
+ tbbproxy: mkdir
++	$(MAKE) -C "$(work_dir)_debug"  -r -f $(tbb_root)/build/Makefile.tbbproxy cfg=debug tbbproxy
+ 	$(MAKE) -C "$(work_dir)_release"  -r -f $(tbb_root)/build/Makefile.tbbproxy cfg=release tbbproxy
+ 
+ tbbbind: mkdir
++	$(MAKE) -C "$(work_dir)_debug"  -r -f $(tbb_root)/build/Makefile.tbbbind cfg=debug tbbbind
+ 	$(MAKE) -C "$(work_dir)_release"  -r -f $(tbb_root)/build/Makefile.tbbbind cfg=release tbbbind
+ 
+ test: tbb tbbmalloc $(if $(use_proxy),tbbproxy)
+@@ -42,6 +46,7 @@
+ 	-$(MAKE) -C "$(work_dir)_release"  -r -f $(tbb_root)/build/Makefile.test cfg=release
+ 
+ rml: mkdir
++	$(MAKE) -C "$(work_dir)_debug"  -r -f $(tbb_root)/build/Makefile.rml cfg=debug
+ 	$(MAKE) -C "$(work_dir)_release"  -r -f $(tbb_root)/build/Makefile.rml cfg=release
+ 
+ examples: tbb tbbmalloc
+@@ -64,6 +69,7 @@
+ 	$(shell $(MAKE) -s -i -r -C examples -f Makefile tbb_root=.. clean >$(NUL) 2>$(NUL))
+ 
+ mkdir:
++	$(shell $(MD) "$(work_dir)_debug" >$(NUL) 2>$(NUL))
+ 	$(shell $(MD) "$(work_dir)_release" >$(NUL) 2>$(NUL))
+ 	@echo Created the $(work_dir)_release directory
+ 

--- a/var/spack/repos/builtin/packages/intel-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-tbb/package.py
@@ -23,8 +23,8 @@ class IntelTbb(Package):
 
     # See url_for_version() below.
 
-    version('2020.1', sha256='48d51c63b16787af54e1ee4aaf30042087f20564b4eecf9a032d5568bc2f0bf8')
-    version('2020.0', sha256='8eed2377ac62e6ac10af5a8303ce861e4525ffe491a061b48e8fe094fc741ce9')
+    version('2020.1', sha256='72cffaeac3b50b117c4e2279f9162308d35873b3e744aff5a088beff6f65c9af')
+    version('2020',   sha256='db80f4f7abb95c2d08fe64abdc0a9250903e4c725f1c667ac517450de426023a')
     version('2019.9', sha256='15652f5328cf00c576f065e5cd3eaf3317422fe82afb67a9bcec0dc065bd2abe')
     version('2019.8', sha256='7b1fd8caea14be72ae4175896510bf99c809cd7031306a1917565e6de7382fba')
     version('2019.7', sha256='4204a93f4c0fd989fb6f79acae74feb02ee39725c93968773d9b6efeb75c7a6a')
@@ -101,6 +101,9 @@ class IntelTbb(Package):
     # Patch cmakeConfig.cmake.in to find the libraries where we install them.
     patch("tbb_cmakeConfig-2019.5.patch", level=0, when='@2019.5:')
     patch("tbb_cmakeConfig.patch", level=0, when='@2017.7:2019.4')
+
+    # Restore the debug targets.
+    patch("makefile-debug.patch", when="@2020:")
 
     # Some very old systems don't support transactional memory.
     patch("disable-tm.patch", when='~tm')


### PR DESCRIPTION
Fixes #14850.  Commit 6b1958219 added versions 2020 and 2020.1 for
intel-tbb as part of updating several intel packages but added the
wrong sha256 sums for the github/01org repository.

Also, version 2020 is 2020, not 2020.0.

Add patch makefile-debug to restore the debug targets.

----------

Please double check my sha256 sums.  Just a simple wget for 2020 and
2020.1 to make sure these are the right sha256 sums for the
github/01org repo.

@robert-mijakovic Where did you get the sha256 sums?  Were they from a
professional version of TBB or something?  Anyway, I think these are
correct for github/01org.
