### PR TITLE
Fix vim build with ^ncurses+termlib

### DIFF
--- a/var/spack/repos/builtin/packages/vim/package.py
+++ b/var/spack/repos/builtin/packages/vim/package.py
@@ -81,7 +81,10 @@ class Vim(AutotoolsPackage):
 
         configure_args = ["--enable-fail-if-missing"]
 
-        configure_args.append("--with-tlib=ncursesw")
+        if '+termlib' in spec['ncurses']:
+            configure_args.append("--with-tlib=tinfow")
+        else:
+            configure_args.append("--with-tlib=ncursesw")
 
         configure_args.append("--with-features=" + feature_set)
 


### PR DESCRIPTION
This PR will set the approriate library if ncurses is built with a
separate tinfo library.