### PR TITLE
Patch to reorder library search for TERMINFO

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -190,6 +190,13 @@ class Llvm(CMakePackage):
             '-DPYTHON_EXECUTABLE:PATH={0}'.format(spec['python'].command.path),
         ]
 
+        if '+termlib' in spec['ncurses']:
+            cmake_args.extend([
+                '-DCURSES_TINFO:STRING=tinfo'])
+        else:
+            cmake_args.extend([
+                '-DCURSES_TINFO:STRING=ncurses'])
+
         projects = []
 
         # TODO: Instead of unconditionally disabling CUDA, add a "cuda" variant

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -104,7 +104,7 @@ class Llvm(CMakePackage):
     depends_on('perl-data-dumper', type=('build'))
 
     # ncurses dependency
-    depends_on('ncurses+termlib')
+    depends_on('ncurses')
 
     # lldb dependencies
     depends_on('swig', when='+lldb')
@@ -146,6 +146,9 @@ class Llvm(CMakePackage):
 
     # https://bugs.llvm.org/show_bug.cgi?id=39696
     patch('thread-p9.patch', when='@develop+libcxx')
+
+    # Change search order of tinfo symbols
+    patch('terminfo.patch')
 
     @run_before('cmake')
     def check_darwin_lldb_codesign_requirement(self):

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -148,7 +148,9 @@ class Llvm(CMakePackage):
     patch('thread-p9.patch', when='@develop+libcxx')
 
     # Change search order of tinfo symbols
-    patch('terminfo.patch')
+    patch('terminfo.patch', when='@:5')
+    patch('terminfo_6.patch', when='@6:7')
+    patch('terminfo_8.patch', when='@8:')
 
     @run_before('cmake')
     def check_darwin_lldb_codesign_requirement(self):

--- a/var/spack/repos/builtin/packages/llvm/terminfo.patch
+++ b/var/spack/repos/builtin/packages/llvm/terminfo.patch
@@ -1,35 +1,25 @@
-diff -ru a/compiler-rt/cmake/config-ix.cmake b/compiler-rt/cmake/config-ix.cmake
---- a/compiler-rt/cmake/config-ix.cmake	2019-12-11 13:15:30.000000000 -0600
-+++ b/compiler-rt/cmake/config-ix.cmake	2020-02-11 21:48:47.046753452 -0600
-@@ -125,7 +125,7 @@
- 
- # Look for terminfo library, used in unittests that depend on LLVMSupport.
- if(LLVM_ENABLE_TERMINFO)
--  foreach(library terminfo tinfo curses ncurses ncursesw)
-+    foreach(library ${CURSES_TINFO} terminfo tinfo curses ncurses ncursesw)
-     string(TOUPPER ${library} library_suffix)
-     check_library_exists(
-       ${library} setupterm "" COMPILER_RT_HAS_TERMINFO_${library_suffix})
 diff -ru a/llvm/cmake/config-ix.cmake b/llvm/cmake/config-ix.cmake
---- a/llvm/cmake/config-ix.cmake	2019-12-11 13:15:30.000000000 -0600
-+++ b/llvm/cmake/config-ix.cmake	2020-02-11 21:48:07.371843873 -0600
-@@ -141,7 +141,7 @@
-     endif()
-     if(LLVM_ENABLE_TERMINFO)
-       set(HAVE_TERMINFO 0)
--      foreach(library terminfo tinfo curses ncurses ncursesw)
-+      foreach(library ${CURSES_TINFO} terminfo tinfo curses ncurses ncursesw)
-         string(TOUPPER ${library} library_suffix)
-         check_library_exists(${library} setupterm "" HAVE_TERMINFO_${library_suffix})
-         if(HAVE_TERMINFO_${library_suffix})
+--- a/llvm/cmake/config-ix.cmake	2018-03-28 15:25:17.000000000 -0500
++++ b/llvm/cmake/config-ix.cmake	2020-02-21 12:42:22.947107749 -0600
+@@ -143,7 +143,7 @@
+   endif()
+   if(LLVM_ENABLE_TERMINFO)
+     set(HAVE_TERMINFO 0)
+-    foreach(library tinfo terminfo curses ncurses ncursesw)
++    foreach(library ${CURSES_TINFO} tinfo terminfo curses ncurses ncursesw)
+       string(TOUPPER ${library} library_suffix)
+       check_library_exists(${library} setupterm "" HAVE_TERMINFO_${library_suffix})
+       if(HAVE_TERMINFO_${library_suffix})
+Only in b/llvm/cmake: config-ix.cmake.orig
+Only in b/llvm/cmake: config-ix.cmake.rej
 diff -ru a/llvm/CMakeLists.txt b/llvm/CMakeLists.txt
---- a/llvm/CMakeLists.txt	2019-12-11 13:15:30.000000000 -0600
-+++ b/llvm/CMakeLists.txt	2020-02-11 21:46:23.029080764 -0600
-@@ -327,6 +327,7 @@
+--- a/llvm/CMakeLists.txt	2018-03-28 15:25:17.000000000 -0500
++++ b/llvm/CMakeLists.txt	2020-02-21 12:41:09.577235055 -0600
+@@ -358,6 +358,7 @@
    CACHE STRING "Set target to use for LLVM JIT or use \"host\" for automatic detection.")
  
  option(LLVM_ENABLE_TERMINFO "Use terminfo database if available." ON)
 +set(CURSES_TINFO "" CACHE STRING "Set library where tinfo symbols are.")
  
- set(LLVM_ENABLE_LIBXML2 "ON" CACHE STRING "Use libxml2 if available. Can be ON, OFF, or FORCE_ON")
+ option(LLVM_ENABLE_LIBEDIT "Use libedit if available." ON)
  

--- a/var/spack/repos/builtin/packages/llvm/terminfo.patch
+++ b/var/spack/repos/builtin/packages/llvm/terminfo.patch
@@ -1,0 +1,11 @@
+--- a/llvm/cmake/config-ix.cmake	2019-12-11 13:15:30.000000000 -0600
++++ b/llvm/cmake/config-ix.cmake	2020-02-07 18:46:04.172859510 -0600
+@@ -141,7 +141,7 @@
+     endif()
+     if(LLVM_ENABLE_TERMINFO)
+       set(HAVE_TERMINFO 0)
+-      foreach(library terminfo tinfo curses ncurses ncursesw)
++      foreach(library terminfo curses ncurses ncursesw tinfo)
+         string(TOUPPER ${library} library_suffix)
+         check_library_exists(${library} setupterm "" HAVE_TERMINFO_${library_suffix})
+         if(HAVE_TERMINFO_${library_suffix})

--- a/var/spack/repos/builtin/packages/llvm/terminfo.patch
+++ b/var/spack/repos/builtin/packages/llvm/terminfo.patch
@@ -1,11 +1,35 @@
+diff -ru a/compiler-rt/cmake/config-ix.cmake b/compiler-rt/cmake/config-ix.cmake
+--- a/compiler-rt/cmake/config-ix.cmake	2019-12-11 13:15:30.000000000 -0600
++++ b/compiler-rt/cmake/config-ix.cmake	2020-02-11 21:48:47.046753452 -0600
+@@ -125,7 +125,7 @@
+ 
+ # Look for terminfo library, used in unittests that depend on LLVMSupport.
+ if(LLVM_ENABLE_TERMINFO)
+-  foreach(library terminfo tinfo curses ncurses ncursesw)
++    foreach(library ${CURSES_TINFO} terminfo tinfo curses ncurses ncursesw)
+     string(TOUPPER ${library} library_suffix)
+     check_library_exists(
+       ${library} setupterm "" COMPILER_RT_HAS_TERMINFO_${library_suffix})
+diff -ru a/llvm/cmake/config-ix.cmake b/llvm/cmake/config-ix.cmake
 --- a/llvm/cmake/config-ix.cmake	2019-12-11 13:15:30.000000000 -0600
-+++ b/llvm/cmake/config-ix.cmake	2020-02-07 18:46:04.172859510 -0600
++++ b/llvm/cmake/config-ix.cmake	2020-02-11 21:48:07.371843873 -0600
 @@ -141,7 +141,7 @@
      endif()
      if(LLVM_ENABLE_TERMINFO)
        set(HAVE_TERMINFO 0)
 -      foreach(library terminfo tinfo curses ncurses ncursesw)
-+      foreach(library terminfo curses ncurses ncursesw tinfo)
++      foreach(library ${CURSES_TINFO} terminfo tinfo curses ncurses ncursesw)
          string(TOUPPER ${library} library_suffix)
          check_library_exists(${library} setupterm "" HAVE_TERMINFO_${library_suffix})
          if(HAVE_TERMINFO_${library_suffix})
+diff -ru a/llvm/CMakeLists.txt b/llvm/CMakeLists.txt
+--- a/llvm/CMakeLists.txt	2019-12-11 13:15:30.000000000 -0600
++++ b/llvm/CMakeLists.txt	2020-02-11 21:46:23.029080764 -0600
+@@ -327,6 +327,7 @@
+   CACHE STRING "Set target to use for LLVM JIT or use \"host\" for automatic detection.")
+ 
+ option(LLVM_ENABLE_TERMINFO "Use terminfo database if available." ON)
++set(CURSES_TINFO "" CACHE STRING "Set library where tinfo symbols are.")
+ 
+ set(LLVM_ENABLE_LIBXML2 "ON" CACHE STRING "Use libxml2 if available. Can be ON, OFF, or FORCE_ON")
+ 

--- a/var/spack/repos/builtin/packages/llvm/terminfo_6.patch
+++ b/var/spack/repos/builtin/packages/llvm/terminfo_6.patch
@@ -1,0 +1,23 @@
+diff -ru a/llvm/cmake/config-ix.cmake b/llvm/cmake/config-ix.cmake
+--- a/llvm/cmake/config-ix.cmake	2019-02-08 15:00:26.000000000 -0600
++++ b/llvm/cmake/config-ix.cmake	2020-02-21 11:57:49.398238837 -0600
+@@ -128,7 +128,7 @@
+     endif()
+     if(LLVM_ENABLE_TERMINFO)
+       set(HAVE_TERMINFO 0)
+-      foreach(library tinfo terminfo curses ncurses ncursesw)
++      foreach(library ${CURSES_TINFO} tinfo terminfo curses ncurses ncursesw)
+         string(TOUPPER ${library} library_suffix)
+         check_library_exists(${library} setupterm "" HAVE_TERMINFO_${library_suffix})
+         if(HAVE_TERMINFO_${library_suffix})
+diff -ru a/llvm/CMakeLists.txt b/llvm/CMakeLists.txt
+--- a/llvm/CMakeLists.txt	2019-02-08 15:00:26.000000000 -0600
++++ b/llvm/CMakeLists.txt	2020-02-21 11:59:21.743038955 -0600
+@@ -354,6 +354,7 @@
+   CACHE STRING "Set target to use for LLVM JIT or use \"host\" for automatic detection.")
+ 
+ option(LLVM_ENABLE_TERMINFO "Use terminfo database if available." ON)
++set(CURSES_TINFO "" CACHE STRING "Set library where tinfo symbols are.")
+ 
+ set(LLVM_ENABLE_LIBXML2 "ON" CACHE STRING "Use libxml2 if available. Can be ON, OFF, or FORCE_ON")
+ 

--- a/var/spack/repos/builtin/packages/llvm/terminfo_8.patch
+++ b/var/spack/repos/builtin/packages/llvm/terminfo_8.patch
@@ -1,0 +1,35 @@
+diff -ru a/compiler-rt/cmake/config-ix.cmake b/compiler-rt/cmake/config-ix.cmake
+--- a/compiler-rt/cmake/config-ix.cmake	2019-12-11 13:15:30.000000000 -0600
++++ b/compiler-rt/cmake/config-ix.cmake	2020-02-11 21:48:47.046753452 -0600
+@@ -125,7 +125,7 @@
+ 
+ # Look for terminfo library, used in unittests that depend on LLVMSupport.
+ if(LLVM_ENABLE_TERMINFO)
+-  foreach(library terminfo tinfo curses ncurses ncursesw)
++    foreach(library ${CURSES_TINFO} terminfo tinfo curses ncurses ncursesw)
+     string(TOUPPER ${library} library_suffix)
+     check_library_exists(
+       ${library} setupterm "" COMPILER_RT_HAS_TERMINFO_${library_suffix})
+diff -ru a/llvm/cmake/config-ix.cmake b/llvm/cmake/config-ix.cmake
+--- a/llvm/cmake/config-ix.cmake	2019-12-11 13:15:30.000000000 -0600
++++ b/llvm/cmake/config-ix.cmake	2020-02-11 21:48:07.371843873 -0600
+@@ -141,7 +141,7 @@
+     endif()
+     if(LLVM_ENABLE_TERMINFO)
+       set(HAVE_TERMINFO 0)
+-      foreach(library terminfo tinfo curses ncurses ncursesw)
++      foreach(library ${CURSES_TINFO} terminfo tinfo curses ncurses ncursesw)
+         string(TOUPPER ${library} library_suffix)
+         check_library_exists(${library} setupterm "" HAVE_TERMINFO_${library_suffix})
+         if(HAVE_TERMINFO_${library_suffix})
+diff -ru a/llvm/CMakeLists.txt b/llvm/CMakeLists.txt
+--- a/llvm/CMakeLists.txt	2019-12-11 13:15:30.000000000 -0600
++++ b/llvm/CMakeLists.txt	2020-02-11 21:46:23.029080764 -0600
+@@ -327,6 +327,7 @@
+   CACHE STRING "Set target to use for LLVM JIT or use \"host\" for automatic detection.")
+ 
+ option(LLVM_ENABLE_TERMINFO "Use terminfo database if available." ON)
++set(CURSES_TINFO "" CACHE STRING "Set library where tinfo symbols are.")
+ 
+ set(LLVM_ENABLE_LIBXML2 "ON" CACHE STRING "Use libxml2 if available. Can be ON, OFF, or FORCE_ON")
+ 


### PR DESCRIPTION
This PR is alternative to #14853. This reorders the search path for
TERMINFO symbols so that the ncurses library has a higher priority. This
should work better with the default setting of the spack ncurses
package.