### PR TITLE
Update and fix the r-rhtslib package

### DIFF
--- a/var/spack/repos/builtin/packages/r-rhtslib/find_deps-1.12.patch
+++ b/var/spack/repos/builtin/packages/r-rhtslib/find_deps-1.12.patch
@@ -1,0 +1,19 @@
+--- a/src/htslib-1.7/Makefile.Rhtslib	2020-02-08 17:12:30.000000000 -0600
++++ b/src/htslib-1.7/Makefile.Rhtslib	2020-02-08 19:08:45.969675431 -0600
+@@ -37,13 +37,13 @@
+ # Default libraries to link if configure is not used
+ htslib_default_libs = -lz -lm -lbz2 -llzma
+ 
+-CPPFLAGS =
++CPPFLAGS += $(BZIP2_INCLUDE) $(XZ_INCLUDE)
+ # TODO: probably update cram code to make it compile cleanly with -Wc++-compat
+ # For testing strict C99 support add -std=c99 -D_XOPEN_SOURCE=600
+ #CFLAGS   = -g -Wall -O2 -pedantic -std=c99 -D_XOPEN_SOURCE=600 -D__FUNCTION__=__func__
+-CFLAGS   = -g -Wall -O2
++CFLAGS   += -g -Wall -O2
+ EXTRA_CFLAGS_PIC = -fpic
+-LDFLAGS  =
++LDFLAGS  += $(BZIP2_LIB) $(XZ_LIB)
+ LIBS     = $(htslib_default_libs)
+ 
+ prefix      = /usr/local

--- a/var/spack/repos/builtin/packages/r-rhtslib/find_deps-1.16.patch
+++ b/var/spack/repos/builtin/packages/r-rhtslib/find_deps-1.16.patch
@@ -1,0 +1,18 @@
+--- a/src/htslib-1.7/Makefile.Rhtslib	2020-02-08 13:25:34.000000000 -0600
++++ b/src/htslib-1.7/Makefile.Rhtslib	2020-02-08 21:02:01.434363322 -0600
+@@ -37,13 +37,13 @@
+ # Default libraries to link if configure is not used
+ htslib_default_libs = -lz -lm -lbz2 -llzma
+ 
+-CPPFLAGS += -D_FILE_OFFSET_BITS=64
++CPPFLAGS += -D_FILE_OFFSET_BITS=64 $(BZIP2_INCLUDE) $(XZ_INCLUDE)
+ # TODO: probably update cram code to make it compile cleanly with -Wc++-compat
+ # For testing strict C99 support add -std=c99 -D_XOPEN_SOURCE=600
+ #CFLAGS   = -g -Wall -O2 -pedantic -std=c99 -D_XOPEN_SOURCE=600 -D__FUNCTION__=__func__
+ CFLAGS += -fpic
+ EXTRA_CFLAGS_PIC =
+-#LDFLAGS  =
++LDFLAGS  += $(BZIP2_LIB) $(XZ_LIB)
+ LIBS     = $(htslib_default_libs)
+ 
+ prefix      = /usr/local

--- a/var/spack/repos/builtin/packages/r-rhtslib/package.py
+++ b/var/spack/repos/builtin/packages/r-rhtslib/package.py
@@ -18,6 +18,7 @@ class RRhtslib(RPackage):
     homepage = "https://bioconductor.org/packages/Rhtslib"
     git      = "https://git.bioconductor.org/packages/Rhtslib.git"
 
+    version('1.18.1', commit='751a2ebaed43b7991204b27bd6c7870645001d82')
     version('1.16.3', commit='3ed0b5db2ee3cf0df1c6096fde8855c8485eebd4')
     version('1.14.1', commit='4be260720f845a34d0ac838278fce1363f645230')
     version('1.12.1', commit='e3487b1355995d09b28fde5d0a7504a3e79a7203')
@@ -30,3 +31,19 @@ class RRhtslib(RPackage):
     depends_on('xz', type=('build', 'link', 'run'))
     depends_on('curl', type=('build', 'link', 'run'))
     depends_on('gmake', type='build')
+
+    # Some versions of this package will leave the temporary installation
+    # directory in the htslib shared object. R will fix this if patchelf is
+    # available
+    depends_on('patchelf', when='@1.12:1.14', type='build')
+
+    patch('use_spack_Makeconf.patch', when='@1.12:')
+    patch('find_deps-1.12.patch', when='@1.12:1.14')
+    patch('find_deps-1.16.patch', when='@1.16:')
+
+    @when('@1.12:')
+    def setup_build_environment(self, env):
+        env.set('BZIP2_INCLUDE', self.spec['bzip2'].headers.include_flags)
+        env.set('XZ_INCLUDE', self.spec['xz'].headers.include_flags)
+        env.set('BZIP2_LIB', self.spec['bzip2'].libs.search_flags)
+        env.set('XZ_LIB', self.spec['xz'].libs.search_flags)

--- a/var/spack/repos/builtin/packages/r-rhtslib/use_spack_Makeconf.patch
+++ b/var/spack/repos/builtin/packages/r-rhtslib/use_spack_Makeconf.patch
@@ -1,0 +1,11 @@
+--- a/src/Makevars.common	2020-02-08 17:12:30.000000000 -0600
++++ b/src/Makevars.common	2020-02-08 20:34:49.573031195 -0600
+@@ -3,7 +3,7 @@
+ INCLUDE_DIR=${R_PACKAGE_DIR}/include
+ USRLIB_DIR=${R_PACKAGE_DIR}/usrlib${R_ARCH}
+ 
+-R_ETC_MAKECONF=${R_HOME}/etc${R_ARCH}/Makeconf
++R_ETC_MAKECONF=${R_HOME}/etc${R_ARCH}/Makeconf.spack
+ 
+ ## Preprocessor options. Keep Rhtslib::pkgconfig() function (defined in
+ ## R/zzz.R) in sync with this.

--- a/var/spack/repos/builtin/packages/r-rsamtools/package.py
+++ b/var/spack/repos/builtin/packages/r-rsamtools/package.py
@@ -18,6 +18,7 @@ class RRsamtools(RPackage):
     homepage = "https://bioconductor.org/packages/Rsamtools"
     git      = "https://git.bioconductor.org/packages/Rsamtools.git"
 
+    version('2.2.1', commit='f10084658b4c9744961fcacd79c0ae9a7a40cd30')
     version('2.0.3', commit='17d254cc026574d20db67474260944bf60befd70')
     version('1.34.1', commit='0ec1d45c7a14b51d019c3e20c4aa87c6bd2b0d0c')
     version('1.32.3', commit='0aa3f134143b045aa423894de81912becf64e4c2')
@@ -42,6 +43,7 @@ class RRsamtools(RPackage):
     depends_on('r-iranges@2.13.12:', when='@1.32.3:', type=('build', 'run'))
     depends_on('r-xvector@0.19.7:', when='@1.32.3:', type=('build', 'run'))
 
-    depends_on('r-rhtslib@1.16.3:', when='@2.0.3:', type=('build', 'run'))
+    depends_on('r-rhtslib@1.16.3', when='@2.0.3', type=('build', 'run'))
+    depends_on('r-rhtslib@1.17.7:', when='@2.2.1:', type=('build', 'run'))
 
     depends_on('gmake', type='build')


### PR DESCRIPTION
This PR adds an updated version to the r-rhtslib package as well as fix
the build.

- add patches to use compiler flags from R
- add variables for bzip2 and xz dependencies
- use the spack Makeconf file when building the in-tree htslib
- make patchelf available to allow R to remove reference to temporary
  installation directory in htslib shared object
- Add new version of r-rsamtools as the r-rsamtools and r-rhtlib
  packages are closely paired.