### PR TITLE
New package: r-watermelon

### DIFF
--- a/var/spack/repos/builtin/packages/r-fdb-infiniummethylation-hg19/package.py
+++ b/var/spack/repos/builtin/packages/r-fdb-infiniummethylation-hg19/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class RFdbInfiniummethylationHg19(RPackage):
+    """Compiled HumanMethylation27 and HumanMethylation450 annotations."""
+
+    # No available git repository
+    homepage = "https://bioconductor.org/packages/release/data/annotation/html/FDb.InfiniumMethylation.hg19.html"
+    url      = "https://bioconductor.org/packages/release/data/annotation/src/contrib/FDb.InfiniumMethylation.hg19_2.2.0.tar.gz"
+
+    version('2.2.0', sha256='605aa3643588a2f40a942fa760b92662060a0dfedb26b4e4cd6f1a78b703093f')
+
+    depends_on('r@2.10:', type=('build', 'run'))
+    depends_on('r-genomicfeatures@1.7.22:', type=('build', 'run'))
+    depends_on('r-txdb-hsapiens-ucsc-hg19-knowngene', type=('build', 'run'))
+    depends_on('r-org-hs-eg-db', type=('build', 'run'))
+    depends_on('r-annotationdbi', type=('build', 'run'))
+    depends_on('r-biostrings', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-illuminahumanmethylation450kanno-ilmn12-hg19/package.py
+++ b/var/spack/repos/builtin/packages/r-illuminahumanmethylation450kanno-ilmn12-hg19/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class RIlluminahumanmethylation450kannoIlmn12Hg19(RPackage):
+    """Manifests and annotation for Illumina's 450k array data."""
+
+    # This package is available via bioconductor but there is no available git
+    # repository.
+    homepage = "https://bioconductor.org/packages/release/data/annotation/html/IlluminaHumanMethylation450kanno.ilmn12.hg19.html"
+    url      = "https://bioconductor.org/packages/release/data/annotation/src/contrib/IlluminaHumanMethylation450kanno.ilmn12.hg19_0.6.0.tar.gz"
+
+    version('0.6.0', sha256='249b8fd62add3c95b5047b597cff0868d26a98862a47cebd656edcd175a73b15')
+
+    depends_on('r@3.3.0:', type=('build', 'run'))
+    depends_on('r-minfi@1.19.15:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-lumi/package.py
+++ b/var/spack/repos/builtin/packages/r-lumi/package.py
@@ -1,0 +1,37 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class RLumi(RPackage):
+    """The lumi package provides an integrated solution for the Illumina
+    microarray data analysis. It includes functions of Illumina BeadStudio
+    (GenomeStudio) data input, quality control, BeadArray-specific variance
+    stabilization, normalization and gene annotation at the probe level. It
+    also includes the functions of processing Illumina methylation microarrays,
+    especially Illumina Infinium methylation microarrays."""
+
+    homepage = "https://bioconductor.org/packages/release/bioc/html/lumi.html"
+    git      = "https://git.bioconductor.org/packages/lumi"
+
+    version('2.38.0', commit='321d480d44ce9a0c02ce5af1bddc1f549abdea59')
+
+    depends_on('r@2.10:', type=('build', 'run'))
+    depends_on('r-biobase@2.5.5:', type=('build', 'run'))
+    depends_on('r-affy@1.23.4:', type=('build', 'run'))
+    depends_on('r-methylumi@2.3.2:', type=('build', 'run'))
+    depends_on('r-genomicfeatures', type=('build', 'run'))
+    depends_on('r-genomicranges', type=('build', 'run'))
+    depends_on('r-annotate', type=('build', 'run'))
+    depends_on('r-lattice', type=('build', 'run'))
+    depends_on('r-mgcv@1.4-0:', type=('build', 'run'))
+    depends_on('r-nleqslv', type=('build', 'run'))
+    depends_on('r-kernsmooth', type=('build', 'run'))
+    depends_on('r-preprocesscore', type=('build', 'run'))
+    depends_on('r-rsqlite', type=('build', 'run'))
+    depends_on('r-dbi', type=('build', 'run'))
+    depends_on('r-annotationdbi', type=('build', 'run'))
+    depends_on('r-mass', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-matrixstats/package.py
+++ b/var/spack/repos/builtin/packages/r-matrixstats/package.py
@@ -18,6 +18,7 @@ class RMatrixstats(RPackage):
     url      = "https://cloud.r-project.org/src/contrib/matrixStats_0.52.2.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/matrixStats"
 
+    version('0.55.0', sha256='16d6bd90eee4cee8df4c15687de0f9b72730c03e56603c2998007d4533e8db19')
     version('0.54.0', sha256='8f0db4e181300a208b9aedbebfdf522a2626e6675d2662656efb8ba71b05a06f')
     version('0.52.2', sha256='39da6aa6b109f89a141dab8913d981abc4fbd3f8be9e206f92e382cc5270d2a5')
 

--- a/var/spack/repos/builtin/packages/r-methylumi/package.py
+++ b/var/spack/repos/builtin/packages/r-methylumi/package.py
@@ -1,0 +1,41 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class RMethylumi(RPackage):
+    """This package provides classes for holding and manipulating Illumina
+    methylation data. Based on eSet, it can contain MIAME information, sample
+    information, feature information, and multiple matrices of data. An
+    "intelligent" import function, methylumiR can read the Illumina text files
+    and create a MethyLumiSet. methylumIDAT can directly read raw IDAT files
+    from HumanMethylation27 and HumanMethylation450 microarrays. Normalization,
+    background correction, and quality control features for GoldenGate,
+    Infinium, and Infinium HD arrays are also included."""
+
+    homepage = "https://bioconductor.org/packages/release/bioc/html/methylumi.html"
+    git      = "https://git.bioconductor.org/packages/methylumi"
+
+    version('2.32.0', commit='e2a29c1b214c0d43c7325d176f9ce41dcf8e2f9d')
+
+    depends_on('r@2.13:', type=('build', 'run'))
+    depends_on('r-biobase', type=('build', 'run'))
+    depends_on('r-scales', type=('build', 'run'))
+    depends_on('r-reshape2', type=('build', 'run'))
+    depends_on('r-ggplot2', type=('build', 'run'))
+    depends_on('r-matrixstats', type=('build', 'run'))
+    depends_on('r-fdb-infiniummethylation-hg19@2.2.0:', type=('build', 'run'))
+    depends_on('r-minfi', type=('build', 'run'))
+    depends_on('r-biocgenerics', type=('build', 'run'))
+    depends_on('r-iranges', type=('build', 'run'))
+    depends_on('r-genomeinfodb', type=('build', 'run'))
+    depends_on('r-genomicranges', type=('build', 'run'))
+    depends_on('r-summarizedexperiment', type=('build', 'run'))
+    depends_on('r-lattice', type=('build', 'run'))
+    depends_on('r-annotate', type=('build', 'run'))
+    depends_on('r-genefilter', type=('build', 'run'))
+    depends_on('r-annotationdbi', type=('build', 'run'))
+    depends_on('r-illuminaio', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-roc/package.py
+++ b/var/spack/repos/builtin/packages/r-roc/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class RRoc(RPackage):
+    """Provide utilities for ROC, with microarray focus."""
+
+    homepage = "https://bioconductor.org/packages/release/bioc/html/ROC.html"
+    git      = "https://git.bioconductor.org/packages/ROC"
+
+    version('1.62.0', commit='60250fdb091f6a938709b8a2cffe6442ee22a9a2')
+
+    depends_on('r@1.9.0:', type=('build', 'run'))
+    depends_on('r-knitr', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-txdb-hsapiens-ucsc-hg19-knowngene/package.py
+++ b/var/spack/repos/builtin/packages/r-txdb-hsapiens-ucsc-hg19-knowngene/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class RTxdbHsapiensUcscHg19Knowngene(RPackage):
+    """Exposes an annotation databases generated from UCSC by exposing these as
+    TxDb objects."""
+
+    # This is a bioconductor package but there is no available git repo.
+    homepage = "https://bioconductor.org/packages/release/data/annotation/html/TxDb.Hsapiens.UCSC.hg19.knownGene.html"
+    url      = "https://bioconductor.org/packages/release/data/annotation/src/contrib/TxDb.Hsapiens.UCSC.hg19.knownGene_3.2.2.tar.gz"
+
+    version('3.2.2', sha256='063de2b1174782a0b2b8ab7f04a0bdf3c43252cb67c685a9f8ef2b8e318352e9')
+
+    depends_on('r-genomicfeatures@1.21.30:', type=('build', 'run'))
+    depends_on('r-annotationdbi', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-watermelon/package.py
+++ b/var/spack/repos/builtin/packages/r-watermelon/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class RWatermelon(RPackage):
+    """Illumina 450 methylation array normalization and metrics."""
+
+    homepage = "https://bioconductor.org/packages/release/bioc/html/wateRmelon.html"
+    git      = "https://git.bioconductor.org/packages/wateRmelon"
+
+    version('1.30.0', commit='66d7579fe49206d965832288df7937c3d43ed578')
+
+    depends_on('r@2.10:', type=('build', 'run'))
+    depends_on('r-biobase', type=('build', 'run'))
+    depends_on('r-limma', type=('build', 'run'))
+    depends_on('r-matrixstats', type=('build', 'run'))
+    depends_on('r-methylumi', type=('build', 'run'))
+    depends_on('r-lumi', type=('build', 'run'))
+    depends_on('r-roc', type=('build', 'run'))
+    depends_on('r-illuminahumanmethylation450kanno-ilmn12-hg19', type=('build', 'run'))
+    depends_on('r-illuminaio', type=('build', 'run'))


### PR DESCRIPTION
This PR creates the r-watermelon package, along with dependencies.

- new package: r-fdb-infiniummethylation-hg19
- new package: r-illuminahumanmethylation450kanno-ilmn12-hg19
- new package: r-lumi
- new package: r-methylumi
- new package: r-roc
- new package: r-txdb-hsapiens-ucsc-hg19-knowngene
- updated package: r-matrixstats, new version needed as a dependency