### PR TITLE
spack load: allow the new 'spack load' to load missing/renamed packages

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1100,7 +1100,7 @@ class Environment(object):
 
         errors = []
         for _, spec in self.concretized_specs():
-            if spec in self.default_view and spec.package.installed:
+            if spec in self.default_view and spec.install_status():
                 try:
                     mods = uenv.environment_modifications_for_spec(
                         spec, self.default_view)

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -637,7 +637,11 @@ class RepoPath(object):
             fullspace = get_full_namespace(namespace)
             if fullspace not in self.by_namespace:
                 raise UnknownNamespaceError(spec.namespace)
-            return self.by_namespace[fullspace]
+            if not self.by_namespace[fullspace]._fallthrough:
+                return self.by_namespace[fullspace]
+            else:
+                if name in self.by_namespace[fullspace]:
+                    return self.by_namespace[fullspace]
 
         # If there's no namespace, search in the RepoPath.
         for repo in self.repos:
@@ -746,6 +750,7 @@ class Repo(object):
         self._modules = {}
         self._classes = {}
         self._instances = {}
+        self._fallthrough = False
 
         # Maps that goes from package name to corresponding file stat
         self._fast_package_checker = None

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -442,6 +442,11 @@ class RepoPath(object):
         repos (list): list Repo objects or paths to put in this RepoPath
     """
 
+    def copy(self):
+        clone = RepoPath.__new__(RepoPath)
+        clone.__init__(*self.repos)
+        return clone
+
     def __init__(self, *repos):
         self.repos = []
         self.by_namespace = nm.NamespaceTrie()

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -170,18 +170,13 @@ def test_env_modifications_error_on_activate(
 
     e = ev.read('test')
     with e:
-        install('cmake-client')
+        install('trivial-install-test-package-broken-runtime')
 
-    def setup_error(pkg, env):
-        raise RuntimeError("cmake-client had issues!")
-
-    pkg = spack.repo.path.get_pkg_class("cmake-client")
-    monkeypatch.setattr(pkg, "setup_run_environment", setup_error)
     with e:
         pass
 
     _, err = capfd.readouterr()
-    assert "cmake-client had issues!" in err
+    assert "runtime setup had issues!" in err
     assert "Warning: couldn't get environment settings" in err
 
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -185,6 +185,33 @@ def test_env_modifications_error_on_activate(
     assert "Warning: couldn't get environment settings" in err
 
 
+def test_env_renamed_package_no_error_on_activate(
+        install_mockery, mock_fetch, monkeypatch, capfd):
+    """Ensure that a package that installed, but renamed or
+       removed from the spack code can still be loaded via
+       an environment activation"""
+    env('create', 'test')
+    install = SpackCommand('install')
+
+    @property
+    def find_nothing(spec, *args):
+        pkg = spack.repo.get(spec)
+        if '.spack/repos/' in spack.repo.path.repos[0].root:
+            return pkg
+        else:
+            raise spack.repo.UnknownPackageError(
+                'Repo package access is disabled for test')
+
+    e = ev.read('test')
+    with e:
+        install('trivial-install-test-package')
+
+    monkeypatch.setattr(spack.spec.Spec,
+                        'package', find_nothing)
+    with e:
+        pass
+
+
 def test_env_install_same_spec_twice(install_mockery, mock_fetch, capfd):
     env('create', 'test')
 

--- a/var/spack/repos/builtin.mock/packages/trivial-install-test-package-broken-runtime/package.py
+++ b/var/spack/repos/builtin.mock/packages/trivial-install-test-package-broken-runtime/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class TrivialInstallTestPackageBrokenRuntime(Package):
+    """This package is a stub with a trivial install method.  It allows us
+       to test the install and uninstall logic of spack."""
+    homepage = "http://www.example.com/trivial_install"
+    url      = "http://www.unit-test-should-replace-this-url/trivial_install-1.0.tar.gz"
+
+    version('1.0', 'foobarbaz')
+
+    def install(self, spec, prefix):
+        configure('--prefix=%s' % prefix)
+        make()
+        make('install')
+
+    def setup_run_environment(self, spec):
+        raise RuntimeError("runtime setup had issues!")


### PR DESCRIPTION
    The new 'spack load' doesn't load packages that have been
    removed/renamed. Switch the repo during load time
    to use the provenance created during install. If this doesn't exist,
    fall back to attempting to use what's currently in the spack tree
    (i.e. external packages)
