### PR TITLE
spack containerize: permit to install OS packages in the build stage

### DIFF
--- a/lib/spack/docs/containers.rst
+++ b/lib/spack/docs/containers.rst
@@ -160,7 +160,8 @@ of environments:
 
        # Additional system packages that are needed at runtime
        os_packages:
-       - libgomp
+         final:
+         - libgomp
 
        # Extra instructions
        extra_instructions:
@@ -196,6 +197,10 @@ The tables below describe the configuration options that are currently supported
    * - ``strip``
      - Whether to strip binaries
      - ``true`` (default) or ``false``
+     - No
+   * - ``os_packages``
+     - Equivalent to specifying the same packages for ``build`` and ``final``
+     - Valid packages for the current OS
      - No
    * - ``os_packages.build``
      - System packages needed at build-time

--- a/lib/spack/docs/containers.rst
+++ b/lib/spack/docs/containers.rst
@@ -197,9 +197,13 @@ The tables below describe the configuration options that are currently supported
      - Whether to strip binaries
      - ``true`` (default) or ``false``
      - No
-   * - ``os_packages``
-     - System packages to be installed
-     - Valid packages for the ``final`` OS
+   * - ``os_packages.build``
+     - System packages needed at build-time
+     - Valid packages for the current OS
+     - No
+   * - ``os_packages.final``
+     - System packages needed at run-time
+     - Valid packages for the current OS
      - No
    * - ``extra_instructions:build``
      - Extra instructions (e.g. `RUN`, `COPY`, etc.) at the end of the ``build`` stage

--- a/lib/spack/spack/container/writers/__init__.py
+++ b/lib/spack/spack/container/writers/__init__.py
@@ -123,21 +123,21 @@ class PathContext(tengine.Context):
     @tengine.context_property
     def os_packages_final(self):
         """Additional system packages that are needed at run-time."""
+        return self._os_packages_for_stage('final')
+
+    @tengine.context_property
+    def os_packages_build(self):
+        """Additional system packages that are needed at build-time."""
+        return self._os_packages_for_stage('build')
+
+    def _os_packages_for_stage(self, stage):
         os_packages = self.container_config.get('os_packages', {})
         # To simplify the configuration YAML it's possible to specify
         # a list directly. In that case we assume the packages are for
         # the final stage.
         if isinstance(os_packages, Sequence):
-            os_packages = {'final': os_packages}
-
-        package_list = os_packages.get('final', None)
-        return self._package_info_from(package_list)
-
-    @tengine.context_property
-    def os_packages_build(self):
-        """Additional system packages that are needed at build-time."""
-        os_packages = self.container_config.get('os_packages', {})
-        package_list = os_packages.get('build', None)
+            os_packages = {stage: os_packages}
+        package_list = os_packages.get(stage, None)
         return self._package_info_from(package_list)
 
     def _package_info_from(self, package_list):

--- a/lib/spack/spack/schema/container.py
+++ b/lib/spack/spack/schema/container.py
@@ -4,6 +4,14 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Schema for the 'container' subsection of Spack environments."""
 
+#: List of packages for the schema below
+_list_of_packages = {
+    'type': 'array',
+    'items': {
+        'type': 'string'
+    }
+}
+
 #: Schema for the container attribute included in Spack environments
 container_schema = {
     'type': 'object',
@@ -41,10 +49,13 @@ container_schema = {
         },
         # Additional system packages that are needed at runtime
         'os_packages': {
-            'type': 'array',
-            'items': {
-                'type': 'string'
-            }
+            'anyOf': [
+                _list_of_packages,
+                {'type': 'object',
+                 'properties': {'build': _list_of_packages,
+                                'final': _list_of_packages},
+                 'additionalProperties': False}
+            ]
         },
         # Add labels to the image
         'labels': {

--- a/lib/spack/spack/test/container/docker.py
+++ b/lib/spack/spack/test/container/docker.py
@@ -29,13 +29,14 @@ def test_build_and_run_images(minimal_configuration):
 def test_packages(minimal_configuration):
     # In this minimal configuration we don't have packages
     writer = writers.create(minimal_configuration)
-    assert writer.os_packages is None
+    assert writer.os_packages_build is None
+    assert writer.os_packages_final is None
 
     # If we add them a list should be returned
     pkgs = ['libgomp1']
     minimal_configuration['spack']['container']['os_packages'] = pkgs
     writer = writers.create(minimal_configuration)
-    p = writer.os_packages
+    p = writer.os_packages_final
     assert p.update
     assert p.install
     assert p.clean

--- a/share/spack/templates/container/Dockerfile
+++ b/share/spack/templates/container/Dockerfile
@@ -1,6 +1,13 @@
 # Build stage with Spack pre-installed and ready to be used
 FROM {{ build.image }}:{{ build.tag }} as builder
 
+{% if os_packages_build %}
+# Install OS packages needed to build the software
+RUN {{ os_packages_build.update }}                                   \
+ && {{ os_packages_build.install }}{% for pkg in os_packages_build.list %} {{ pkg }}{% endfor %} \
+ && {{ os_packages_build.clean }}
+{% endif %}
+
 # What we want to install and how we want to install it
 # is specified in a manifest file (spack.yaml)
 RUN mkdir {{ paths.environment }} \
@@ -34,10 +41,10 @@ COPY --from=builder {{ paths.store }} {{ paths.store }}
 COPY --from=builder {{ paths.view }} {{ paths.view }}
 COPY --from=builder /etc/profile.d/z10_spack_environment.sh /etc/profile.d/z10_spack_environment.sh
 
-{% if os_packages %}
-RUN {{ os_packages.update }}                                   \
- && {{ os_packages.install }}{% for pkg in os_packages.list %} {{ pkg }}{% endfor %} \
- && {{ os_packages.clean }}
+{% if os_packages_final %}
+RUN {{ os_packages_final.update }}                                   \
+ && {{ os_packages_final.install }}{% for pkg in os_packages_final.list %} {{ pkg }}{% endfor %} \
+ && {{ os_packages_final.clean }}
 {% endif %}
 
 {% if extra_instructions.final %}

--- a/share/spack/templates/container/Dockerfile
+++ b/share/spack/templates/container/Dockerfile
@@ -3,8 +3,8 @@ FROM {{ build.image }}:{{ build.tag }} as builder
 
 {% if os_packages_build %}
 # Install OS packages needed to build the software
-RUN {{ os_packages_build.update }}                                   \
- && {{ os_packages_build.install }}{% for pkg in os_packages_build.list %} {{ pkg }}{% endfor %} \
+RUN {{ os_packages_build.update }} \
+ && {{ os_packages_build.install }} {{ os_packages_build.list | join | replace('\n', ' ') }} \
  && {{ os_packages_build.clean }}
 {% endif %}
 
@@ -42,8 +42,8 @@ COPY --from=builder {{ paths.view }} {{ paths.view }}
 COPY --from=builder /etc/profile.d/z10_spack_environment.sh /etc/profile.d/z10_spack_environment.sh
 
 {% if os_packages_final %}
-RUN {{ os_packages_final.update }}                                   \
- && {{ os_packages_final.install }}{% for pkg in os_packages_final.list %} {{ pkg }}{% endfor %} \
+RUN {{ os_packages_final.update }} \
+ && {{ os_packages_final.install }} {{ os_packages_final.list | join | replace('\n', ' ') }} \
  && {{ os_packages_final.clean }}
 {% endif %}
 

--- a/share/spack/templates/container/singularity.def
+++ b/share/spack/templates/container/singularity.def
@@ -3,6 +3,13 @@ From: {{ build.image }}:{{ build.tag }}
 Stage: build
 
 %post
+{% if os_packages_build.list %}
+  # Update, install and cleanup of system packages needed at build-time
+  {{ os_packages_build.update }}
+  {{ os_packages_build.install }} {{ os_packages_build.list | join | replace('\n', ' ') }}
+  {{ os_packages_build.clean }}
+
+{% endif %}
   # Create the manifest file for the installation in /opt/spack-environment
   mkdir {{ paths.environment }} && cd {{ paths.environment }}
   cat << EOF > spack.yaml
@@ -50,11 +57,11 @@ Stage: final
   {{ paths.environment }}/environment_modifications.sh {{ paths.environment }}/environment_modifications.sh
 
 %post
-{% if os_packages.list %}
-  # Update, install and cleanup of system packages
-  {{ os_packages.update }}
-  {{ os_packages.install }} {{ os_packages.list | join | replace('\n', ' ') }}
-  {{ os_packages.clean }}
+{% if os_packages_final.list %}
+  # Update, install and cleanup of system packages needed at run-time
+  {{ os_packages_final.update }}
+  {{ os_packages_final.install }} {{ os_packages_final.list | join | replace('\n', ' ') }}
+  {{ os_packages_final.clean }}
 {% endif %}
   # Modify the environment without relying on sourcing shell specific files at startup
   cat {{ paths.environment }}/environment_modifications.sh >> $SINGULARITY_ENVIRONMENT


### PR DESCRIPTION
refers #14802

This PR permits to install OS packages in the build stage. As such it enables the example shown in the issue above:
```yaml
spack:
  specs:
  - gromacs@2019.4 build_type=Release
  - openmpi@3.1.4 fabrics=verbs
  - fftw precision=float
  packages:
    all:
      target: [broadwell]

  container:
    format: singularity

    base:
      image: "ubuntu:18.04"
      spack: develop

    strip: true

    os_packages:
      build:
      - libibverbs-dev
      final:
      - libibverbs1
      - libgomp1
```
to be built.