### PR TITLE
dev-build: --drop-in <shell>

### DIFF
--- a/lib/spack/spack/cmd/dev_build.py
+++ b/lib/spack/spack/cmd/dev_build.py
@@ -37,6 +37,9 @@ def setup_parser(subparser):
     subparser.add_argument(
         '-q', '--quiet', action='store_true', dest='quiet',
         help="do not display verbose build output while installing")
+    subparser.add_argument(
+        '--drop-in', type=str, dest='shell', default=None,
+        help="drop into a build environment in a new shell, e.g. bash, zsh")
     arguments.add_common_arguments(subparser, ['spec'])
 
     stop_group = subparser.add_mutually_exclusive_group()
@@ -98,3 +101,8 @@ def dev_build(self, args):
         dirty=args.dirty,
         stop_before=args.before,
         stop_at=args.until)
+
+    # drop into the build environment of the package?
+    if args.shell is not None:
+        spack.build_environment.setup_package(package, dirty=False)
+        os.execvp(args.shell, [args.shell])

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -76,6 +76,17 @@ def test_dev_build_before_until(tmpdir, mock_packages, install_mockery):
                       'dev-build-test-install@0.0.0')
 
 
+def test_dev_build_drop_in(tmpdir, mock_packages, monkeypatch,
+                           install_mockery):
+    def print_spack_cc(*args):
+        # Eat arguments and print environment variable to test
+        print(os.environ['CC'])
+    monkeypatch.setattr(os, 'execvp', print_spack_cc)
+    output = dev_build('-b', 'edit', '--drop-in', 'sh',
+                       'dev-build-test-install@0.0.0')
+    assert "lib/spack/env" in output
+
+
 def test_dev_build_fails_already_installed(tmpdir, mock_packages,
                                            install_mockery):
     spec = spack.spec.Spec('dev-build-test-install@0.0.0').concretized()

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -697,7 +697,7 @@ _spack_deprecate() {
 _spack_dev_build() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -j --jobs -d --source-path -i --ignore-dependencies -n --no-checksum --keep-prefix --skip-patch -q --quiet -b --before -u --until --clean --dirty"
+        SPACK_COMPREPLY="-h --help -j --jobs -d --source-path -i --ignore-dependencies -n --no-checksum --keep-prefix --skip-patch -q --quiet --drop-in -b --before -u --until --clean --dirty"
     else
         _all_packages
     fi
@@ -706,7 +706,7 @@ _spack_dev_build() {
 _spack_diy() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -j --jobs -d --source-path -i --ignore-dependencies -n --no-checksum --keep-prefix --skip-patch -q --quiet -b --before -u --until --clean --dirty"
+        SPACK_COMPREPLY="-h --help -j --jobs -d --source-path -i --ignore-dependencies -n --no-checksum --keep-prefix --skip-patch -q --quiet --drop-in -b --before -u --until --clean --dirty"
     else
         _all_packages
     fi


### PR DESCRIPTION
Add a `--drop-in <shell>` option to `spack dev-build`. This option will automatically run a `spack build-env <spec> -- <shell>` at the end of a `dev-build`, e.g. to quickly drop-and-devel into a build phase of a package.

Example usage:
```
spack dev-build --before cmake --drop-in bash openpmd-api@develop
```

- [x] fix issue in spec
- [x] rebase after #14699