### PR TITLE
Emit a sensible error message if compiler's target is overly specific

### DIFF
--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -417,7 +417,7 @@ def get_compilers(config, cspec=None, arch_spec=None):
             # there's an error in the underlying configuration
             if llnl.util.cpu.targets[target].family == family:
                 msg = ('the "target" field in compilers.yaml accepts only '
-                       'target families [substitute "{0}" with "{1}"'
+                       'target families [replace "{0}" with "{1}"'
                        ' in "{2}" specification]')
                 msg = msg.format(str(target), family, items.get('spec', '??'))
                 raise ValueError(msg)

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -413,6 +413,14 @@ def get_compilers(config, cspec=None, arch_spec=None):
             assert arch_spec is None
 
         if arch_spec and target and (target != family and target != 'any'):
+            # If the family of the target is the family we are seeking,
+            # there's an error in the underlying configuration
+            if llnl.util.cpu.targets[target].family == family:
+                msg = ('the "target" field in compilers.yaml accepts only '
+                       'target families [substitute "{0}" with "{1}"'
+                       ' in "{2}" specification]')
+                msg = msg.format(str(target), family, items.get('spec', '??'))
+                raise ValueError(msg)
             continue
 
         compilers.append(_compiler_from_config_entry(items))

--- a/lib/spack/spack/test/compilers.py
+++ b/lib/spack/spack/test/compilers.py
@@ -485,3 +485,28 @@ def test_fj_version_detection(version_str, expected_version):
 def test_detecting_mixed_toolchains(compiler_spec, expected_result, config):
     compiler = spack.compilers.compilers_for_spec(compiler_spec).pop()
     assert spack.compilers.is_mixed_toolchain(compiler) is expected_result
+
+
+@pytest.mark.regression('14798,13733')
+def test_raising_if_compiler_target_is_over_specific(config):
+    # Compiler entry with an overly specific target
+    compilers = [{'compiler': {
+        'spec': 'gcc@9.0.1',
+        'paths': {
+            'cc': '/usr/bin/gcc-9',
+            'cxx': '/usr/bin/g++-9',
+            'f77': '/usr/bin/gfortran-9',
+            'fc': '/usr/bin/gfortran-9'
+        },
+        'flags': {},
+        'operating_system': 'ubuntu18.04',
+        'target': 'haswell',
+        'modules': [],
+        'environment': {},
+        'extra_rpaths': []
+    }}]
+    arch_spec = spack.spec.ArchSpec(('linux', 'ubuntu18.04', 'haswell'))
+    with spack.config.override('compilers', compilers):
+        cfg = spack.compilers.get_compiler_config()
+        with pytest.raises(ValueError):
+            spack.compilers.get_compilers(cfg, 'gcc@9.0.1', arch_spec)


### PR DESCRIPTION
fixes #14798
fixes #13733

Compiler specifications require a generic architecture family as their target. This commit improves the error message that is displayed to users if they edit `compilers.yaml` and use an overly specific name.