### PR TITLE
cmake: Fix spack install inside ctest

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -175,6 +175,10 @@ class Cmake(Package):
         # Make sure to create an optimized release build
         args.append('-DCMAKE_BUILD_TYPE=Release')
 
+        # Install CMake correctly, even if `spack install` runs
+        # inside a ctest environment
+        args.append('-DCMake_TEST_INSTALL=OFF')
+
         # When building our own private copy of curl then we need to properly
         # enable / disable oepnssl
         if '+ownlibs' in spec:


### PR DESCRIPTION
If one runs `spack install cmake` inside ctest, then cmake sometimes fails to install properly.

Fixes:

1. Improve environment cleaning: Remove `$DASHBOARD_TEST_FROM_CTEST`

2. Add `-DCMake_TEST_INSTALL=OFF` to `bootstrap_args()`

Both alone would fix the issue, but it seems more sensible to apply them together: Cleaning the environment is anyway a good idea and passing explicit options seems good too.