### PR TITLE
New package: r-fdb-infiniummethylation-hg18

### DIFF
--- a/var/spack/repos/builtin/packages/r-fdb-infiniummethylation-hg18/package.py
+++ b/var/spack/repos/builtin/packages/r-fdb-infiniummethylation-hg18/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class RFdbInfiniummethylationHg18(RPackage):
+    """Compiled HumanMethylation27 and HumanMethylation450 annotations"""
+
+    # This is a bioconductor package but there is no available git repository
+    homepage = "http://bioconductor.org/packages/release/data/annotation/html/FDb.InfiniumMethylation.hg18.html"
+    url      = "http://bioconductor.org/packages/release/data/annotation/src/contrib/FDb.InfiniumMethylation.hg18_2.2.0.tar.gz"
+
+    version('2.2.0', sha256='4a9028ac03c11fffbab731ea750bc7f9b0884fc43c6a8dac6eb2c644e4c79f6f')
+
+    depends_on('r@2.10:', type=('build', 'run'))
+    depends_on('r-genomicfeatures@1.7.22:', type=('build', 'run'))
+    depends_on('r-txdb-hsapiens-ucsc-hg18-knowngene', type=('build', 'run'))
+    depends_on('r-org-hs-eg-db', type=('build', 'run'))
+    depends_on('r-annotationdbi', type=('build', 'run'))
+    depends_on('r-biostrings', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-txdb-hsapiens-ucsc-hg18-knowngene/package.py
+++ b/var/spack/repos/builtin/packages/r-txdb-hsapiens-ucsc-hg18-knowngene/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class RTxdbHsapiensUcscHg18Knowngene(RPackage):
+    """Exposes an annotation databases generated from UCSC by exposing these as
+    TxDb objects"""
+
+    # This is a bioconductor package but ther is no available git repo
+    homepage = "http://bioconductor.org/packages/release/data/annotation/html/TxDb.Hsapiens.UCSC.hg18.knownGene.html"
+    url      = "http://bioconductor.org/packages/release/data/annotation/src/contrib/TxDb.Hsapiens.UCSC.hg18.knownGene_3.2.2.tar.gz"
+
+    version('3.2.2', sha256='bc9ca40b4eab87f5ca64a4b876d42502b9b8e9f5983d745bfe0ee349d97b69fa')
+
+    depends_on('r-genomicfeatures@1.21.30:', type=('build', 'run'))
+    depends_on('r-annotationdbi', type=('build', 'run'))


### PR DESCRIPTION
This PR adds the r-fdb-infiniummethylation-hg18 package and the needed
dependency of r-txdb-hsapiens-ucsc-hg18-knowngene.