### PR TITLE
Fix QT4 platform detection for linux clang

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -355,6 +355,14 @@ class Qt(Package):
             with open(conf_file, 'a') as f:
                 f.write("QMAKE_CXXFLAGS += -std=gnu++98\n")
 
+    @when('@4 %clang')
+    def patch(self):
+        (mkspec_dir, platform) = self.get_mkspec()
+        conf_file = os.path.join(mkspec_dir, platform, "qmake.conf")
+
+        with open(conf_file, 'a') as f:
+            f.write("QMAKE_CXXFLAGS += -std=gnu++98\n")
+
     @property
     def common_config_args(self):
         # incomplete list is here http://doc.qt.io/qt-5/configure-options.html


### PR DESCRIPTION
The previous incantation for QT platform detection worked for QT5 linux clang (see https://github.com/spack/spack/issues/13650) but apparently not for QT4 linux clang. I can now successfully compile QT 4.8.7 with clang 9, gcc 8, or intel 18 on linux.

I've also marked myself as a maintainer of QT since I have to deal with this 💩 package so much.