### PR TITLE
Fix Silo build on %clang@9

### DIFF
--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -41,6 +41,32 @@ class Silo(AutotoolsPackage):
             flags.append('-ldl')
         return (flags, None, None)
 
+    @when('%clang@9:')
+    def patch(self):
+        # Clang 9 and later include macro definitions in <math.h> that conflict
+        # with typedefs DOMAIN and RANGE used in Silo plugins.
+        # It looks like the upstream fpzip repo has been fixed, but that change
+        # hasn't yet made it into silo.
+        # https://github.com/LLNL/fpzip/blob/master/src/pcmap.h
+
+        def repl(match):
+            # Change macro-like uppercase to title-case.
+            return match.group(1).title()
+
+        files_to_filter = [
+            "src/fpzip/codec.h",
+            "src/fpzip/pcdecoder.inl",
+            "src/fpzip/pcencoder.inl",
+            "src/fpzip/pcmap.h",
+            "src/fpzip/pcmap.inl",
+            "src/fpzip/read.cpp",
+            "src/fpzip/write.cpp",
+            "src/hzip/hzmap.h",
+            "src/hzip/hzresidual.h",
+        ]
+
+        filter_file(r'\b(DOMAIN|RANGE|UNION)\b', repl, *files_to_filter)
+
     def configure_args(self):
         spec = self.spec
         config_args = [


### PR DESCRIPTION
The `<math.h>` implementation in libc++ distributed with clang@9 differs from the one in clang@8: it uses `#include_next` to include the system's `math.h`, which defines macros `DOMAIN` and `RANGE`. There are a few files in Silo that unwittingly use these macro-like names as type names. Since Silo has no public repo I can't submit a patch directly, but it looks like the upstream [fpzip library](https://github.com/LLNL/fpzip) is available and the [peccant source files have been fixed](https://github.com/LLNL/fpzip/blob/master/src/pcmap.h).

```
In file included from read.cpp:3:
In file included from ./pcdecoder.h:5:
./pcmap.h:17:13: error: expected member name or ';' after declaration
specifiers
  typedef T DOMAIN;
  ~~~~~~~~~ ^
/usr/include/math.h:335:18: note: expanded from macro 'DOMAIN'
\# define DOMAIN         1
                        ^
In file included from read.cpp:3:
In file included from ./pcdecoder.h:5:
./pcmap.h:21:17: error: expected parameter declarator
  RANGE forward(DOMAIN d) const { return d >> shift; }
                ^
/usr/include/math.h:335:18: note: expanded from macro 'DOMAIN'
\# define DOMAIN         1
```