### PR TITLE
bugfix: `spack -V` should use `working_dir()` instead of `git -C`

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -22,6 +22,7 @@ import warnings
 from six import StringIO
 
 import llnl.util.cpu
+import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 import llnl.util.tty.color as color
 from llnl.util.tty.log import log_output
@@ -125,8 +126,9 @@ def get_version():
     if os.path.exists(git_path):
         git = exe.which("git")
         if git:
-            desc = git("-C", spack.paths.prefix, "describe", "--tags",
-                       output=str, fail_on_error=False)
+            with fs.working_dir(spack.paths.prefix):
+                desc = git(
+                    "describe", "--tags", output=str, fail_on_error=False)
 
             if git.returncode == 0:
                 match = re.match(r"v([^-]+)-([^-]+)-g([a-f\d]+)", desc)


### PR DESCRIPTION
- `git -C` doesn't work on git before 1.8.5
- `working_dir` gets us the same effect