### PR TITLE
WarpX: master is the new develop

### DIFF
--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -18,8 +18,9 @@ class Warpx(MakefilePackage):
     homepage = "https://ecp-warpx.github.io/index.html"
     git      = "https://github.com/ECP-WarpX/WarpX.git"
 
+    maintainers = ['ax3l', 'dpgrote', 'MaxThevenet', 'RemiLehe']
+
     version('master', tag='master')
-    version('dev', tag='dev')
 
     depends_on('mpi')
 
@@ -40,11 +41,6 @@ class Warpx(MakefilePackage):
     resource(name='amrex',
              git='https://github.com/AMReX-Codes/amrex.git',
              when='@master',
-             tag='master')
-
-    resource(name='amrex',
-             git='https://github.com/AMReX-Codes/amrex.git',
-             when='@dev',
              tag='development')
 
     resource(name='picsar',


### PR DESCRIPTION
WarpX removed the `dev` branch in favor of a simpler, `master`-centric development model.
`master` is the new development branch and there is no stable branch anymore (we use tags and release branches instead).

We intentionally do not tag other versions than the development branch yet.

Adding @dpgrote @remilehe @maxthevenet and me as package maintainers, too.