### PR TITLE
modern-wheel: add virtual destructor to BaseMultiParms class

### DIFF
--- a/var/spack/repos/builtin/packages/modern-wheel/add_virtual_destructor.patch
+++ b/var/spack/repos/builtin/packages/modern-wheel/add_virtual_destructor.patch
@@ -1,0 +1,17 @@
+--- spack-src/test/prototype_factory_test.cpp.org	2020-02-07 11:17:24.321582233 +0900
++++ spack-src/test/prototype_factory_test.cpp	2020-02-07 11:18:25.598262173 +0900
+@@ -58,6 +58,7 @@
+   virtual clone_type clone(int a) = 0;
+   virtual clone_type clone(int a, int b) = 0;
+   virtual int get() = 0;
++  virtual ~BaseMultiParms() {}
+ };
+ 
+ class DerivedSum : public BaseMultiParms {
+@@ -121,4 +122,4 @@
+   auto objb = factory.create(0, 3, 6);
+   BOOST_CHECK_EQUAL(objb->get(), 9);
+ }
+-BOOST_AUTO_TEST_SUITE_END()
+\ No newline at end of file
++BOOST_AUTO_TEST_SUITE_END()

--- a/var/spack/repos/builtin/packages/modern-wheel/package.py
+++ b/var/spack/repos/builtin/packages/modern-wheel/package.py
@@ -14,6 +14,7 @@ class ModernWheel(CMakePackage):
 
     homepage = "https://github.com/alalazo/modern_wheel"
     url      = "https://github.com/alalazo/modern_wheel/archive/1.2.tar.gz"
+    maintainers = ['alalazo']
 
     version('1.2', sha256='48612f698d7159f0eb10d93ddc3e2682b06a54d3a836ff227636be3261aed15e')
     version('1.1', sha256='d8ba4891257b96108e9b9406a556f8ced3b71ce85c3fcdca6bfd9cc37bf010a3')

--- a/var/spack/repos/builtin/packages/modern-wheel/package.py
+++ b/var/spack/repos/builtin/packages/modern-wheel/package.py
@@ -35,6 +35,9 @@ class ModernWheel(CMakePackage):
     depends_on('boost           +system +filesystem', when='@:1.1.999')
     depends_on('boost@:1.65.999 +system +filesystem', when='@1.2:')
 
+    # add virtual destructor to BaseMultiParms class.
+    patch('add_virtual_destructor.patch')
+
     def cmake_args(self):
         spec = self.spec
         return [


### PR DESCRIPTION
- error
```
  >> 99     /usr/lib/gcc/aarch64-redhat-linux/4.8.5/../../../../include/c++/4.8
            .5/ext/new_allocator.h:124:29: error: destructor called on non-fina
            l '(anonymous namespace)::DerivedSum' that has virtual functions bu
            t non-virtual destructor [-Werror,-Wdelete-non-virtual-dtor]
     100            destroy(_Up* __p) { __p->~_Up(); }
     101                                ^

```
All base classes with a virtual function should define a virtual destructor.
So I added virtual destructor to base class.