### PR TITLE
spack containerize: allow copying files into the container

### DIFF
--- a/lib/spack/docs/containers.rst
+++ b/lib/spack/docs/containers.rst
@@ -201,6 +201,10 @@ The tables below describe the configuration options that are currently supported
      - System packages to be installed
      - Valid packages for the ``final`` OS
      - No
+   * - ``extra_instructions:setup``
+     - Extra instructions (e.g. `RUN`, `COPY`, etc.) at the beginning of the ``build`` stage
+     - Anything understood by the current ``format``
+     - No
    * - ``extra_instructions:build``
      - Extra instructions (e.g. `RUN`, `COPY`, etc.) at the end of the ``build`` stage
      - Anything understood by the current ``format``

--- a/lib/spack/docs/containers.rst
+++ b/lib/spack/docs/containers.rst
@@ -197,6 +197,14 @@ The tables below describe the configuration options that are currently supported
      - Whether to strip binaries
      - ``true`` (default) or ``false``
      - No
+   * - ``copy:build``
+     - Files to be copied into the build stage
+     - Any valid file on the host
+     - No
+   * - ``copy:final``
+     - Files to be copied into the final stage
+     - Any valid file on the host or from the build stage
+     - No
    * - ``os_packages``
      - System packages to be installed
      - Valid packages for the ``final`` OS

--- a/lib/spack/spack/container/writers/__init__.py
+++ b/lib/spack/spack/container/writers/__init__.py
@@ -139,6 +139,36 @@ class PathContext(tengine.Context):
         return Extras(setup=setup, build=build, final=final)
 
     @tengine.context_property
+    def from_host_to_build(self):
+        """Files that needs to be copied from the host to the build stage."""
+        return self._files_to_be_copied('build')
+
+    @tengine.context_property
+    def from_host_to_final(self):
+        """Files that needs to be copied from the host to the build stage."""
+        files = self._files_to_be_copied('final')
+        files = [x for x in files if not x.source.startswith('build:')]
+        return files
+
+    @tengine.context_property
+    def from_build_to_final(self):
+        """Files that needs to be copied from the host to the build stage."""
+        files = self._files_to_be_copied('final')
+        files = [x for x in files if x.source.startswith('build:')]
+        return files
+
+    def _files_to_be_copied(self, destination_stage):
+        copy_config = self.container_config.get('copy', {})
+        CopyItem = collections.namedtuple(
+            'CopyItem', ['source', 'destination']
+        )
+        files = []
+        for item in copy_config.get(destination_stage, []):
+            source, destination = item['source'], item['destination']
+            files.append(CopyItem(source=source, destination=destination))
+        return files
+
+    @tengine.context_property
     def labels(self):
         return self.container_config.get('labels', {})
 

--- a/lib/spack/spack/container/writers/__init__.py
+++ b/lib/spack/spack/container/writers/__init__.py
@@ -132,10 +132,11 @@ class PathContext(tengine.Context):
 
     @tengine.context_property
     def extra_instructions(self):
-        Extras = collections.namedtuple('Extra', ['build', 'final'])
+        Extras = collections.namedtuple('Extra', ['setup', 'build', 'final'])
         extras = self.container_config.get('extra_instructions', {})
+        setup = extras.get('setup', None)
         build, final = extras.get('build', None), extras.get('final', None)
-        return Extras(build=build, final=final)
+        return Extras(setup=setup, build=build, final=final)
 
     @tengine.context_property
     def labels(self):

--- a/lib/spack/spack/schema/container.py
+++ b/lib/spack/spack/schema/container.py
@@ -55,6 +55,7 @@ container_schema = {
             'type': 'object',
             'additionalProperties': False,
             'properties': {
+                'setup': {'type': 'string'},
                 'build': {'type': 'string'},
                 'final': {'type': 'string'}
             }

--- a/lib/spack/spack/schema/container.py
+++ b/lib/spack/spack/schema/container.py
@@ -4,6 +4,17 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Schema for the 'container' subsection of Spack environments."""
 
+#: Represents a source/destination pair when copying objects
+#: in a container image
+_source_destination_pair = {
+    'type': 'object',
+    'properties': {
+        'source': {'type': 'string'},
+        'destination': {'type': 'string'}
+    },
+    'required': ['source', 'destination']
+}
+
 #: Schema for the container attribute included in Spack environments
 container_schema = {
     'type': 'object',
@@ -33,6 +44,21 @@ container_schema = {
                 }
             },
             'required': ['image', 'spack']
+        },
+        # Copy resources from host or previous stages into the container
+        'copy': {
+            'type': 'object',
+            'properties': {
+                'build': {
+                    'type': 'array',
+                    'items': _source_destination_pair
+                },
+                'final': {
+                    'type': 'array',
+                    'items': _source_destination_pair
+                }
+            },
+            'additionalProperties': False
         },
         # Whether or not to strip installed binaries
         'strip': {

--- a/share/spack/templates/container/Dockerfile
+++ b/share/spack/templates/container/Dockerfile
@@ -1,6 +1,11 @@
 # Build stage with Spack pre-installed and ready to be used
 FROM {{ build.image }}:{{ build.tag }} as builder
 
+{% if extra_instructions.setup %}
+# Custom instructions before building the packages
+{{ extra_instructions.setup }}
+{% endif %}
+
 # What we want to install and how we want to install it
 # is specified in a manifest file (spack.yaml)
 RUN mkdir {{ paths.environment }} \
@@ -23,6 +28,7 @@ RUN cd {{ paths.environment }} && \
     spack env activate --sh -d . >> /etc/profile.d/z10_spack_environment.sh
 
 {% if extra_instructions.build %}
+# Custom instructions at the end of the build stage
 {{ extra_instructions.build }}
 {% endif %}
 
@@ -41,6 +47,7 @@ RUN {{ os_packages.update }}                                   \
 {% endif %}
 
 {% if extra_instructions.final %}
+# Custom instructions at the end of the final stage
 {{ extra_instructions.final }}
 {% endif %}
 

--- a/share/spack/templates/container/Dockerfile
+++ b/share/spack/templates/container/Dockerfile
@@ -1,6 +1,10 @@
 # Build stage with Spack pre-installed and ready to be used
 FROM {{ build.image }}:{{ build.tag }} as builder
 
+{% for item in from_host_to_build %}
+COPY {{ item.source }} {{ item.destination }}
+{% endfor %}
+
 {% if extra_instructions.setup %}
 # Custom instructions before building the packages
 {{ extra_instructions.setup }}
@@ -39,6 +43,13 @@ COPY --from=builder {{ paths.environment }} {{ paths.environment }}
 COPY --from=builder {{ paths.store }} {{ paths.store }}
 COPY --from=builder {{ paths.view }} {{ paths.view }}
 COPY --from=builder /etc/profile.d/z10_spack_environment.sh /etc/profile.d/z10_spack_environment.sh
+{% for item in from_build_to_final %}
+COPY --from=builder {{ item.source | replace('build:', '') }} {{ item.destination }}
+{% endfor %}
+
+{% for item in from_host_to_final %}
+COPY {{ item.source }} {{ item.destination }}
+{% endfor %}
 
 {% if os_packages %}
 RUN {{ os_packages.update }}                                   \

--- a/share/spack/templates/container/singularity.def
+++ b/share/spack/templates/container/singularity.def
@@ -2,6 +2,13 @@ Bootstrap: docker
 From: {{ build.image }}:{{ build.tag }}
 Stage: build
 
+{% if from_host_to_build %}
+%files
+{% for item in from_host_to_build %}
+  {{item.source}} {{item.destination}}
+{% endfor %}
+
+{% endif %}
 %post
 {% if extra_instructions.setup %}
   # Custom instructions before building the packages
@@ -54,7 +61,17 @@ Stage: final
   {{ paths.store }} /opt
   {{ paths.view }} /opt
   {{ paths.environment }}/environment_modifications.sh {{ paths.environment }}/environment_modifications.sh
+{% for item in from_build_to_final %}
+  {{ item.source | replace('build:', '') }} {{ item.destination }}
+{% endfor %}
+{% if from_host_to_final %}
 
+%files
+{% for item in from_host_to_final %}
+  {{item.source}} {{item.destination}}
+{% endfor %}
+
+{% endif %}
 %post
 {% if os_packages.list %}
   # Update, install and cleanup of system packages

--- a/share/spack/templates/container/singularity.def
+++ b/share/spack/templates/container/singularity.def
@@ -3,6 +3,10 @@ From: {{ build.image }}:{{ build.tag }}
 Stage: build
 
 %post
+{% if extra_instructions.setup %}
+  # Custom instructions before building the packages
+{{ extra_instructions.setup | indent(width=2, first=True) }}
+{% endif %}
   # Create the manifest file for the installation in /opt/spack-environment
   mkdir {{ paths.environment }} && cd {{ paths.environment }}
   cat << EOF > spack.yaml
@@ -24,7 +28,9 @@ EOF
     awk -F: '{print $1}' | xargs strip -s
 {% endif %}
 {% if extra_instructions.build %}
-{{ extra_instructions.build }}
+
+  # Custom instructions at the end of the build stage
+{{ extra_instructions.build | indent(width=2, first=True) }}
 {% endif %}
 
 
@@ -59,7 +65,9 @@ Stage: final
   # Modify the environment without relying on sourcing shell specific files at startup
   cat {{ paths.environment }}/environment_modifications.sh >> $SINGULARITY_ENVIRONMENT
 {% if extra_instructions.final %}
-{{ extra_instructions.final }}
+
+  # Custom instructions at the end of the final stage
+{{ extra_instructions.final | indent(width=2, first=True) }}
 {% endif %}
 
 {% if runscript %}


### PR DESCRIPTION
refers #14802

This PR adds the ability to copy arbitrary files or directories:

- From the host to the build stage
- From the host to the final stage
- From the build stage to the final stage

It also adds the ability to inject arbitrary instructions before the Spack environment is concretized and built (i.e. at the beginning of the build stage).