### PR TITLE
bmi depends on automake for build

### DIFF
--- a/var/spack/repos/builtin/packages/bmi/package.py
+++ b/var/spack/repos/builtin/packages/bmi/package.py
@@ -15,6 +15,7 @@ class Bmi(AutotoolsPackage):
     version('develop', branch='master')
 
     depends_on('autoconf', type='build')
+    depends_on('automake', type='build')
 
     # need to override 'autoreconf' so we can run BMI's 'prepare' script
     def autoreconf(self, spec, prefix):


### PR DESCRIPTION
Package `bmi` currently has a non-explicit build dependency on `automake`. This PR makes the dependency explicit.

@carns @ax3l @scottwittenburg