### PR TITLE
Uniquify suffixes added to module names

### DIFF
--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -36,7 +36,6 @@ import os.path
 import re
 
 import llnl.util.filesystem
-from llnl.util.lang import dedupe
 import llnl.util.tty as tty
 import spack.build_environment as build_environment
 import spack.error
@@ -425,7 +424,7 @@ class BaseConfiguration(object):
         for constraint, suffix in self.conf.get('suffixes', {}).items():
             if constraint in self.spec:
                 suffixes.append(suffix)
-        suffixes = list(dedupe(suffixes))
+        suffixes = sorted(set(suffixes))
         if self.hash:
             suffixes.append(self.hash)
         return suffixes

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -36,6 +36,7 @@ import os.path
 import re
 
 import llnl.util.filesystem
+from llnl.util.lang import dedupe
 import llnl.util.tty as tty
 import spack.build_environment as build_environment
 import spack.error
@@ -424,7 +425,7 @@ class BaseConfiguration(object):
         for constraint, suffix in self.conf.get('suffixes', {}).items():
             if constraint in self.spec:
                 suffixes.append(suffix)
-        suffixes = sorted(set(suffixes))
+        suffixes = list(dedupe(suffixes))
         if self.hash:
             suffixes.append(self.hash)
         return suffixes

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -424,6 +424,7 @@ class BaseConfiguration(object):
         for constraint, suffix in self.conf.get('suffixes', {}).items():
             if constraint in self.spec:
                 suffixes.append(suffix)
+        suffixes = sorted(set(suffixes))
         if self.hash:
             suffixes.append(self.hash)
         return suffixes

--- a/lib/spack/spack/test/data/modules/tcl/suffix.yaml
+++ b/lib/spack/spack/test/data/modules/tcl/suffix.yaml
@@ -5,3 +5,4 @@ tcl:
     suffixes:
       '+debug': foo
       '~debug': bar
+      '^mpich': foo

--- a/lib/spack/spack/test/data/modules/tcl/suffix.yaml
+++ b/lib/spack/spack/test/data/modules/tcl/suffix.yaml
@@ -4,5 +4,5 @@ tcl:
   mpileaks:
     suffixes:
       '+debug': foo
-      '^mpich': foo
       '~debug': bar
+      '^mpich': foo

--- a/lib/spack/spack/test/data/modules/tcl/suffix.yaml
+++ b/lib/spack/spack/test/data/modules/tcl/suffix.yaml
@@ -4,5 +4,5 @@ tcl:
   mpileaks:
     suffixes:
       '+debug': foo
-      '~debug': bar
       '^mpich': foo
+      '~debug': bar

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -215,9 +215,10 @@ class TestTcl(object):
 
         writer, spec = factory('mpileaks+debug arch=x86-linux')
         assert 'foo' in writer.layout.use_name
+        assert 'foo-foo' not in writer.layout.use_name
 
         writer, spec = factory('mpileaks~debug arch=x86-linux')
-        assert 'bar' in writer.layout.use_name
+        assert 'bar-foo' in writer.layout.use_name
 
     def test_setup_environment(self, modulefile_content, module_configuration):
         """Tests the internal set-up of run-time environment."""

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -218,9 +218,7 @@ class TestTcl(object):
         assert 'foo-foo' not in writer.layout.use_name
 
         writer, spec = factory('mpileaks~debug arch=x86-linux')
-        # Note: ordering is based on YAML input in
-        # test/data/modules/tcl/suffix.yaml
-        assert 'foo-bar' in writer.layout.use_name
+        assert 'bar-foo' in writer.layout.use_name
 
     def test_setup_environment(self, modulefile_content, module_configuration):
         """Tests the internal set-up of run-time environment."""

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -218,7 +218,9 @@ class TestTcl(object):
         assert 'foo-foo' not in writer.layout.use_name
 
         writer, spec = factory('mpileaks~debug arch=x86-linux')
-        assert 'bar-foo' in writer.layout.use_name
+        # Note: ordering is based on YAML input in
+        # test/data/modules/tcl/suffix.yaml
+        assert 'foo-bar' in writer.layout.use_name
 
     def test_setup_environment(self, modulefile_content, module_configuration):
         """Tests the internal set-up of run-time environment."""


### PR DESCRIPTION
Consider a user that wants to mark CUDA-enabled modules with a `-cuda` suffix. To also account for libraries that use cuda-enabled MPI (perhaps to differentiate them from the same library that uses non-cuda MPI), they set their `modules.yaml` file to:
```yaml
modules:
  enable::
    - lmod
  lmod:
    all:
      suffixes:
        '+cuda': 'cuda'
        '^mpi+cuda': 'cuda'
```
Although this creates non-conflicting module names for `foo ^mpi+cuda` and `foo ^mpi~cuda`, it gives `bar+cuda ^mpi+cuda` an suffix of `-cuda-cuda`.

This patch deduplicates module extensions so that the latter suffix will simplify to `-cuda`. It also sorts the suffixes to improve robustness.