### PR TITLE
Fix mtune flag for gcc 4.1.2

### DIFF
--- a/lib/spack/llnl/util/cpu/microarchitectures.json
+++ b/lib/spack/llnl/util/cpu/microarchitectures.json
@@ -51,12 +51,12 @@
       "compilers": {
         "gcc": [
           {
-            "versions": "4.2.0:",
+            "versions": "4.1.2:",
             "name": "x86-64",
             "flags": "-march={name} -mtune=generic"
           },
           {
-            "versions": ":4.1.2",
+            "versions": ":4.1.1",
             "name": "x86-64",
             "flags": "-march={name} -mtune={name}"
           }


### PR DESCRIPTION
Even on gcc 4.1.2 `-mtune=x86-64` is deprecated and will produce warnings (or errors with -Werror, see #12928).