### PR TITLE
intel-tbb: update to new tar file names for 2020 versions

### DIFF
--- a/var/spack/repos/builtin/packages/intel-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-tbb/package.py
@@ -19,12 +19,10 @@ class IntelTbb(Package):
     homepage = "http://www.threadingbuildingblocks.org/"
 
     # Note: when adding new versions, please check and update the
-    # patches and filters below as needed.
+    # patches, filters and url_for_version() below as needed.
 
-    # See url_for_version() below.
-
-    version('2020.1', sha256='72cffaeac3b50b117c4e2279f9162308d35873b3e744aff5a088beff6f65c9af')
-    version('2020',   sha256='db80f4f7abb95c2d08fe64abdc0a9250903e4c725f1c667ac517450de426023a')
+    version('2020.1', sha256='48d51c63b16787af54e1ee4aaf30042087f20564b4eecf9a032d5568bc2f0bf8')
+    version('2020.0', sha256='8eed2377ac62e6ac10af5a8303ce861e4525ffe491a061b48e8fe094fc741ce9')
     version('2019.9', sha256='15652f5328cf00c576f065e5cd3eaf3317422fe82afb67a9bcec0dc065bd2abe')
     version('2019.8', sha256='7b1fd8caea14be72ae4175896510bf99c809cd7031306a1917565e6de7382fba')
     version('2019.7', sha256='4204a93f4c0fd989fb6f79acae74feb02ee39725c93968773d9b6efeb75c7a6a')
@@ -108,12 +106,21 @@ class IntelTbb(Package):
     # Some very old systems don't support transactional memory.
     patch("disable-tm.patch", when='~tm')
 
+    # Version and tar file names:
+    #  2020.0 --> v2020.0.tar.gz  starting with 2020
+    #  2017.1 --> 2017_U1.tar.gz  starting with 2017
+    #  2017   --> 2017.tar.gz
+    #  4.4.6  --> 4.4.6.tar.gz
+    #
     def url_for_version(self, version):
-        url = 'https://github.com/01org/tbb/archive/{0}.tar.gz'
-        if (version[0] >= 2017) and len(version) > 1:
-            return url.format('{0}_U{1}'.format(version[0], version[1]))
+        url = 'https://github.com/intel/tbb/archive/{0}.tar.gz'
+        if version[0] >= 2020:
+            name = 'v{0}'.format(version)
+        elif version[0] >= 2017 and len(version) > 1:
+            name = '{0}_U{1}'.format(version[0], version[1])
         else:
-            return url.format(version)
+            name = '{0}'.format(version)
+        return url.format(name)
 
     def coerce_to_spack(self, tbb_build_subdir):
         for compiler in ["icc", "gcc", "clang"]:


### PR DESCRIPTION
Starting with 2020, the tar files are named v2020.0.tar.gz,
v2020.1.tar.gz, etc, not 2020_U1.tar.gz.

https://github.com/intel/tbb/releases

The previous commit (7a10478708) fixed the checksum mismatch, but
didn't update url_for_version (my bad).

----------

Sorry I didn't notice the name change and fix url_for_version() in the
previous commit.  Intel provides the old names for compatibility, so
it looked like the old names were correct.  :-(

The contents of the two tar files (2020_U1.tar.gz and v2020.1.tar.gz)
are identical except for the top-level directory name.  But that's
enough to change the sha sum.

Better to adapt sooner rather than later I guess.

ping @tgamblin who reviewed the previous commit