### PR TITLE
unifyfs: remove numa dependency

### DIFF
--- a/var/spack/repos/builtin/packages/unifyfs/package.py
+++ b/var/spack/repos/builtin/packages/unifyfs/package.py
@@ -19,13 +19,12 @@ class Unifyfs(AutotoolsPackage):
     url      = "https://github.com/LLNL/UnifyFS/releases/download/v0.9.0/unifyfs-0.9.0.tar.gz"
     maintainers = ['CamStan']
 
-    version('develop', branch='dev', preferred=True)
+    version('develop', branch='dev')
     version('0.9.0', sha256='e6c73e22ef1c23f3141646aa17058b69c1c4e526886771f8fe982da924265b0f')
 
+    variant('auto-mount', default='True', description='Enable automatic mount/unmount in MPI_Init/Finalize')
     variant('hdf5', default='False', description='Build with parallel HDF5 (install with `^hdf5~mpi` for serial)')
     variant('fortran', default='False', description='Build with gfortran support')
-    variant('numa', default='False', description='Build with NUMA')
-    variant('pmpi', default='False', description='Enable transparent mount/unmount at MPI_Init/Finalize')
     variant('pmi', default='False', description='Enable PMI2 build options')
     variant('pmix', default='False', description='Enable PMIx build options')
 
@@ -47,12 +46,9 @@ class Unifyfs(AutotoolsPackage):
 
     # Optional dependencies
     depends_on('hdf5', when='+hdf5')
-    depends_on('numactl',  when='+numa')
 
     conflicts('^mercury~bmi')
     conflicts('^mercury~sm')
-    # UnifyFS depends on numactl, which doesn't currently build on darwin.
-    conflicts('platform=darwin', when='+numa')
     # Known compatibility issues with ifort and xlf. Fixes coming.
     conflicts('%intel', when='+fortran')
     conflicts('%xl', when='+fortran')
@@ -84,15 +80,13 @@ class Unifyfs(AutotoolsPackage):
             else:  # parallel HDF5
                 return spec[name].prefix.bin.h5pcc
 
-        args.extend(self.with_or_without('numa',
-                                         lambda x: spec['numactl'].prefix))
         args.extend(self.with_or_without('hdf5', hdf5_compiler_path))
+
+        if '+auto-mount' in spec:
+            args.append('--enable-mpi-mount')
 
         if '+fortran' in spec:
             args.append('--enable-fortran')
-
-        if '+pmpi' in spec:
-            args.append('--enable-mpi-mount')
 
         if '+pmi' in spec:
             args.append('--enable-pmi')


### PR DESCRIPTION
UnifyFS no longer has an option to depend on numa. This removes the numa variant, dependency, and associated conflict.

This commit also
- renames the `pmpi` variant to the more appropriate `auto-mount`
- changes the preferred version to the most recent release