### PR TITLE
Replace direct call to patchelf with get_existing_elf_rpaths which handles exceptions.

### DIFF
--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -684,13 +684,6 @@ def file_is_relocatable(file, paths_to_relocate=None):
 
     strings = Executable('strings')
 
-    # if we're relocating patchelf itself, use it
-
-    if file[-13:] == "/bin/patchelf":
-        patchelf = Executable(file)
-    else:
-        patchelf = Executable(get_patchelf())
-
     # Remove the RPATHS from the strings in the executable
     set_of_strings = set(strings(file, output=str).split())
 

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -700,8 +700,8 @@ def file_is_relocatable(file, paths_to_relocate=None):
 
     if platform.system().lower() == 'linux':
         if m_subtype == 'x-executable' or m_subtype == 'x-sharedlib':
-            rpaths = patchelf('--print-rpath', file, output=str).strip()
-            set_of_strings.discard(rpaths.strip())
+            rpaths = get_existing_elf_rpaths(file)
+            set_of_strings.discard(rpaths)
     if platform.system().lower() == 'darwin':
         if m_subtype == 'x-mach-binary':
             rpaths, deps, idpath = macho_get_paths(file)

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -693,7 +693,7 @@ def file_is_relocatable(file, paths_to_relocate=None):
 
     if platform.system().lower() == 'linux':
         if m_subtype == 'x-executable' or m_subtype == 'x-sharedlib':
-            rpaths = get_existing_elf_rpaths(file)
+            rpaths = set(get_existing_elf_rpaths(file))
             set_of_strings.discard(rpaths)
     if platform.system().lower() == 'darwin':
         if m_subtype == 'x-mach-binary':


### PR DESCRIPTION
As reported by @eugeneswalker call to relocate::is_file_relocatable throws an exception. In get_existing_elf_rpaths this exception is handled correctly. Replace direct call to patchelf with call to get_existing_elf_rpaths.
[pdt.txt](https://github.com/spack/spack/files/4199429/pdt.txt)
