### PR TITLE
libcircle depends on pkg-config for build

### DIFF
--- a/var/spack/repos/builtin/packages/libcircle/package.py
+++ b/var/spack/repos/builtin/packages/libcircle/package.py
@@ -19,6 +19,7 @@ class Libcircle(AutotoolsPackage):
     version('0.2.1-rc.1', sha256='5747f91cf4417023304dcc92fd07e3617ac712ca1eeb698880979bbca3f54865')
 
     depends_on('mpi')
+    depends_on('pkg-config', type='build')
 
     @when('@master')
     def autoreconf(self, spec, prefix):


### PR DESCRIPTION
Package `libcircle` currently has a non-explicit build dependency on `pkg-config`. This PR makes this build dependency explicit. @scottwittenburg @adammoody 