### PR TITLE
packages.yaml: allow virtuals to specify buildable: false

### DIFF
--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -124,6 +124,39 @@ The ``buildable`` does not need to be paired with external packages.
 It could also be used alone to forbid packages that may be
 buggy or otherwise undesirable.
 
+Virtual packages in Spack can also be specified as not buildable, and
+external implementations can be provided. In the example above,
+OpenMPI is configured as not buildable, but Spack will often prefer
+other MPI implementations over the externally available OpenMPI. Spack
+can be configured with every MPI provider not buildable individually,
+but more conveniently:
+
+.. code-block:: yaml
+
+   packages:
+     mpi:
+       buildable: False
+     openmpi:
+       paths:
+         openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64: /opt/openmpi-1.4.3
+         openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64+debug: /opt/openmpi-1.4.3-debug
+         openmpi@1.6.5%intel@10.1 arch=linux-debian7-x86_64: /opt/openmpi-1.6.5-intel
+
+Implementations can also be listed immediately under the virtual they provide:
+
+.. code-block:: yaml
+
+   packages:
+     mpi:
+       buildable: False
+         openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64: /opt/openmpi-1.4.3
+         openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64+debug: /opt/openmpi-1.4.3-debug
+         openmpi@1.6.5%intel@10.1 arch=linux-debian7-x86_64: /opt/openmpi-1.6.5-intel
+         mpich@3.3 %clang@9.0.0 arch=linux-debian7-x86_64: /opt/mpich-3.3-intel
+
+Spack can then use any of the listed external implementations of MPI
+to satisfy a dependency, and will choose depending on the compiler and
+architecture.
 
 .. _concretization-preferences:
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1035,6 +1035,13 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             for s, constraints in self.provided.items() if s.name == vpkg_name
         )
 
+    def virtuals_provided(self):
+        """
+        virtual packages provided by this package with its spec
+        """
+        return [vspec for vspec, constraints in self.provided.items()
+                if any(self.spec.satisfies(c) for c in constraints)]
+
     @property
     def installed(self):
         """Installation status of a package.

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1035,6 +1035,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             for s, constraints in self.provided.items() if s.name == vpkg_name
         )
 
+    @property
     def virtuals_provided(self):
         """
         virtual packages provided by this package with its spec

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -171,25 +171,18 @@ def spec_externals(spec):
 
     external_specs = []
     for name in names:
-        pkg_paths = allpkgs.get(name, {}).get('paths', None)
-        pkg_modules = allpkgs.get(name, {}).get('modules', None)
+        pkg_paths = allpkgs.get(name, {}).get('paths', {})
+        pkg_modules = allpkgs.get(name, {}).get('modules', {})
         if (not pkg_paths) and (not pkg_modules):
             continue
 
         for external_spec, path in iteritems(pkg_paths):
-            if not path:
-                # skip entries without paths (avoid creating extra Specs)
-                continue
-
             external_spec = spack.spec.Spec(
                 external_spec, external_path=canonicalize_path(path))
             if external_spec.satisfies(spec):
                 external_specs.append(external_spec)
 
         for external_spec, module in iteritems(pkg_modules):
-            if not module:
-                continue
-
             external_spec = spack.spec.Spec(
                 external_spec, external_module=module)
             if external_spec.satisfies(spec):

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -193,8 +193,6 @@ def is_spec_buildable(spec):
     allpkgs = spack.config.get('packages')
     do_not_build = [name for name, entry in allpkgs.items()
                     if not entry.get('buildable', True)]
-    print(spec.name)
-    print(not (spec.name in do_not_build or any(spec.package.provides(name) for name in do_not_build)))
     return not (spec.name in do_not_build or
                 any(spec.package.provides(name) for name in do_not_build))
 

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -6,7 +6,6 @@
 import stat
 
 from six import string_types
-from six import iteritems
 
 import spack.repo
 import spack.error
@@ -167,18 +166,19 @@ def spec_externals(spec):
 
     external_specs = []
     for name in names:
-        pkg_paths = allpkgs.get(name, {}).get('paths', {})
-        pkg_modules = allpkgs.get(name, {}).get('modules', {})
+        pkg_config = allpkgs.get(name, {})
+        pkg_paths = pkg_config.get('paths', {})
+        pkg_modules = pkg_config.get('modules', {})
         if (not pkg_paths) and (not pkg_modules):
             continue
 
-        for external_spec, path in iteritems(pkg_paths):
+        for external_spec, path in pkg_paths.items():
             external_spec = spack.spec.Spec(
                 external_spec, external_path=canonicalize_path(path))
             if external_spec.satisfies(spec):
                 external_specs.append(external_spec)
 
-        for external_spec, module in iteritems(pkg_modules):
+        for external_spec, module in pkg_modules.items():
             external_spec = spack.spec.Spec(
                 external_spec, external_module=module)
             if external_spec.satisfies(spec):

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -23,11 +23,6 @@ def _spec_type(component):
     return _lesser_spec_types.get(component, spack.spec.Spec)
 
 
-def get_packages_config():
-    """Wrapper around get_packages_config() to validate semantics."""
-    return spack.config.get('packages')
-
-
 class PackagePrefs(object):
     """Defines the sort order for a set of specs.
 
@@ -100,7 +95,7 @@ class PackagePrefs(object):
             pkglist.append('all')
 
         for pkg in pkglist:
-            pkg_entry = get_packages_config().get(pkg)
+            pkg_entry = spack.config.get('packages').get(pkg)
             if not pkg_entry:
                 continue
 
@@ -144,7 +139,8 @@ class PackagePrefs(object):
     def preferred_variants(cls, pkg_name):
         """Return a VariantMap of preferred variants/values for a spec."""
         for pkg in (pkg_name, 'all'):
-            variants = get_packages_config().get(pkg, {}).get('variants', '')
+            variants = spack.config.get('packages').get(pkg, {}).get(
+                'variants', '')
             if variants:
                 break
 
@@ -165,7 +161,7 @@ def spec_externals(spec):
     # break circular import.
     from spack.util.module_cmd import get_path_from_module # NOQA: ignore=F401
 
-    allpkgs = get_packages_config()
+    allpkgs = spack.config.get('packages')
     names = [spec.name]
     names += [vspec.name for vspec in spec.package.virtuals_provided]
 
@@ -194,7 +190,7 @@ def spec_externals(spec):
 
 def is_spec_buildable(spec):
     """Return true if the spec pkgspec is configured as buildable"""
-    allpkgs = get_packages_config()
+    allpkgs = spack.config.get('packages')
     do_not_build = [name for name in allpkgs
                     if not allpkgs[name].get('buildable', True)]
     return not (spec.name in do_not_build or

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -193,6 +193,8 @@ def is_spec_buildable(spec):
     allpkgs = spack.config.get('packages')
     do_not_build = [name for name, entry in allpkgs.items()
                     if not entry.get('buildable', True)]
+    print(spec.name)
+    print(not (spec.name in do_not_build or any(spec.package.provides(name) for name in do_not_build)))
     return not (spec.name in do_not_build or
                 any(spec.package.provides(name) for name in do_not_build))
 

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -167,7 +167,7 @@ def spec_externals(spec):
 
     allpkgs = get_packages_config()
     names = [spec.name]
-    names += [vspec.name for vspec in spec.package.virtuals_provided()]
+    names += [vspec.name for vspec in spec.package.virtuals_provided]
 
     external_specs = []
     for name in names:

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -162,8 +162,8 @@ def spec_externals(spec):
     from spack.util.module_cmd import get_path_from_module # NOQA: ignore=F401
 
     allpkgs = spack.config.get('packages')
-    names = [spec.name]
-    names += [vspec.name for vspec in spec.package.virtuals_provided]
+    names = set([spec.name])
+    names |= set(vspec.name for vspec in spec.package.virtuals_provided)
 
     external_specs = []
     for name in names:

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -191,8 +191,8 @@ def spec_externals(spec):
 def is_spec_buildable(spec):
     """Return true if the spec pkgspec is configured as buildable"""
     allpkgs = spack.config.get('packages')
-    do_not_build = [name for name in allpkgs
-                    if not allpkgs[name].get('buildable', True)]
+    do_not_build = [name for name, entry in allpkgs.items()
+                    if not entry.get('buildable', True)]
     return not (spec.name in do_not_build or
                 any(spec.package.provides(name) for name in do_not_build))
 

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -194,7 +194,7 @@ all:
         spack.config.set('packages', conf, scope='concretize')
 
         # should be no error for 'all':
-        spack.package_prefs.get_packages_config()
+        spack.config.get('packages')
 
     def test_external_mpi(self):
         # make sure this doesn't give us an external first.

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -185,17 +185,6 @@ class TestConcretizePreferences(object):
         spec.concretize()
         assert spec.version == Version('0.2.15.develop')
 
-    def test_all_is_not_a_virtual(self):
-        """Verify that `all` is allowed in packages.yaml."""
-        conf = syaml.load_config("""\
-all:
-        variants: [+mpi]
-""")
-        spack.config.set('packages', conf, scope='concretize')
-
-        # should be no error for 'all':
-        spack.config.get('packages')
-
     def test_external_mpi(self):
         # make sure this doesn't give us an external first.
         spec = Spec('mpi')

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -219,7 +219,6 @@ mpich:
         spec.concretize()
         assert spec['mpich'].external_path == '/dummy/path'
 
-
     def test_external_module(self, save_module_func):
         """Test that packages can find externals specified by module
 
@@ -250,7 +249,6 @@ mpi:
         spec = Spec('mpi')
         spec.concretize()
         assert spec['mpich'].external_path == '/dummy/path'
-
 
     def test_config_permissions_from_all(self, configure_permissions):
         # Although these aren't strictly about concretization, they are

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -185,23 +185,6 @@ class TestConcretizePreferences(object):
         spec.concretize()
         assert spec.version == Version('0.2.15.develop')
 
-    def test_no_virtuals_in_packages_yaml(self):
-        """Verify that virtuals are not allowed in packages.yaml."""
-
-        # set up a packages.yaml file with a vdep as a key.  We use
-        # syaml.load_config here to make sure source lines in the config are
-        # attached to parsed strings, as the error message uses them.
-        conf = syaml.load_config("""\
-mpi:
-    paths:
-      mpi-with-lapack@2.1: /path/to/lapack
-""")
-        spack.config.set('packages', conf, scope='concretize')
-
-        # now when we get the packages.yaml config, there should be an error
-        with pytest.raises(spack.package_prefs.VirtualInPackagesYAMLError):
-            spack.package_prefs.get_packages_config()
-
     def test_all_is_not_a_virtual(self):
         """Verify that `all` is allowed in packages.yaml."""
         conf = syaml.load_config("""\

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -208,7 +208,7 @@ mpich:
         spec.concretize()
         assert spec['mpich'].external_path == '/dummy/path'
 
-    def test_external_module(self, save_module_func):
+    def test_external_module(self, monkeypatch):
         """Test that packages can find externals specified by module
 
         The specific code for parsing the module is tested elsewhere.
@@ -216,7 +216,7 @@ mpich:
         # make sure this doesn't give us an external first.
         def mock_module(cmd, module):
             return 'prepend-path PATH /dummy/path'
-        spack.util.module_cmd.module = mock_module
+        monkeypatch.setattr(spack.util.module_cmd, 'module', mock_module)
 
         spec = Spec('mpi')
         spec.concretize()

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1152,16 +1152,3 @@ def clear_directive_functions():
     # proceeding with subsequent tests that may depend on the original
     # functions.
     spack.directives.DirectiveMeta._directives_to_be_executed = []
-
-
-#########
-# Fixture to cache module function
-# The test is responsible for mocking it
-#########
-@pytest.fixture
-def save_module_func():
-    old_func = spack.util.module_cmd.module
-
-    yield
-
-    spack.util.module_cmd.module = old_func

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1040,6 +1040,9 @@ class MockPackage(object):
         self.conflicts = {}
         self.patches = {}
 
+    def provides(self, vname):
+        return vname in self.provided
+
 
 class MockPackageMultiRepo(object):
     def __init__(self, packages):

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1043,6 +1043,7 @@ class MockPackage(object):
     def provides(self, vname):
         return vname in self.provided
 
+    @property
     def virtuals_provided(self):
         return [v.name for v, c in self.provided]
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1151,3 +1151,16 @@ def clear_directive_functions():
     # proceeding with subsequent tests that may depend on the original
     # functions.
     spack.directives.DirectiveMeta._directives_to_be_executed = []
+
+
+#########
+# Fixture to cache module function
+# The test is responsible for mocking it
+#########
+@pytest.fixture
+def save_module_func():
+    old_func = spack.util.module_cmd.module
+
+    yield
+
+    spack.util.module_cmd.module = old_func

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1043,6 +1043,9 @@ class MockPackage(object):
     def provides(self, vname):
         return vname in self.provided
 
+    def virtuals_provided(self):
+        return [v.name for v, c in self.provided]
+
 
 class MockPackageMultiRepo(object):
     def __init__(self, packages):

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -52,52 +52,52 @@ def check_mirror():
         mirror_root = os.path.join(stage.path, 'test-mirror')
         # register mirror with spack config
         mirrors = {'spack-mirror-test': 'file://' + mirror_root}
-        spack.config.set('mirrors', mirrors)
-        with spack.config.override('config:checksum', False):
-            specs = [Spec(x).concretized() for x in repos]
-            spack.mirror.create(mirror_root, specs)
-
-        # Stage directory exists
-        assert os.path.isdir(mirror_root)
-
-        for spec in specs:
-            fetcher = spec.package.fetcher[0]
-            per_package_ref = os.path.join(
-                spec.name, '-'.join([spec.name, str(spec.version)]))
-            mirror_paths = spack.mirror.mirror_archive_paths(
-                fetcher,
-                per_package_ref)
-            expected_path = os.path.join(
-                mirror_root, mirror_paths.storage_path)
-            assert os.path.exists(expected_path)
-
-        # Now try to fetch each package.
-        for name, mock_repo in repos.items():
-            spec = Spec(name).concretized()
-            pkg = spec.package
-
+        with spack.config.override('mirrors', mirrors):
             with spack.config.override('config:checksum', False):
-                with pkg.stage:
-                    pkg.do_stage(mirror_only=True)
+                specs = [Spec(x).concretized() for x in repos]
+                spack.mirror.create(mirror_root, specs)
 
-                    # Compare the original repo with the expanded archive
-                    original_path = mock_repo.path
-                    if 'svn' in name:
-                        # have to check out the svn repo to compare.
-                        original_path = os.path.join(
-                            mock_repo.path, 'checked_out')
+            # Stage directory exists
+            assert os.path.isdir(mirror_root)
 
-                        svn = which('svn', required=True)
-                        svn('checkout', mock_repo.url, original_path)
+            for spec in specs:
+                fetcher = spec.package.fetcher[0]
+                per_package_ref = os.path.join(
+                    spec.name, '-'.join([spec.name, str(spec.version)]))
+                mirror_paths = spack.mirror.mirror_archive_paths(
+                    fetcher,
+                    per_package_ref)
+                expected_path = os.path.join(
+                    mirror_root, mirror_paths.storage_path)
+                assert os.path.exists(expected_path)
 
-                    dcmp = filecmp.dircmp(
-                        original_path, pkg.stage.source_path)
+            # Now try to fetch each package.
+            for name, mock_repo in repos.items():
+                spec = Spec(name).concretized()
+                pkg = spec.package
 
-                    # make sure there are no new files in the expanded
-                    # tarball
-                    assert not dcmp.right_only
-                    # and that all original files are present.
-                    assert all(l in exclude for l in dcmp.left_only)
+                with spack.config.override('config:checksum', False):
+                    with pkg.stage:
+                        pkg.do_stage(mirror_only=True)
+
+                        # Compare the original repo with the expanded archive
+                        original_path = mock_repo.path
+                        if 'svn' in name:
+                            # have to check out the svn repo to compare.
+                            original_path = os.path.join(
+                                mock_repo.path, 'checked_out')
+
+                            svn = which('svn', required=True)
+                            svn('checkout', mock_repo.url, original_path)
+
+                        dcmp = filecmp.dircmp(
+                            original_path, pkg.stage.source_path)
+
+                        # make sure there are no new files in the expanded
+                        # tarball
+                        assert not dcmp.right_only
+                        # and that all original files are present.
+                        assert all(l in exclude for l in dcmp.left_only)
 
 
 def test_url_mirror(mock_archive):

--- a/lib/spack/spack/test/module_parsing.py
+++ b/lib/spack/spack/test/module_parsing.py
@@ -23,21 +23,12 @@ test_module_lines = ['prepend-path LD_LIBRARY_PATH /path/to/lib',
 
 @pytest.fixture
 def module_function_test_mode():
-    old_mode = spack.util.module_cmd._test_mode
-    spack.util.module_cmd._test_mode = True
+    old_cmd = spack.util.module_cmd._cmd_template
+    spack.util.module_cmd._cmd_template = "'. %s 2>&1' % args[1]"
 
     yield
 
-    spack.util.module_cmd._test_mode = old_mode
-
-
-@pytest.fixture
-def save_module_func():
-    old_func = spack.util.module_cmd.module
-
-    yield
-
-    spack.util.module_cmd.module = old_func
+    spack.util.module_cmd._cmd_template = old_cmd
 
 
 def test_module_function_change_env(tmpdir, working_env,

--- a/lib/spack/spack/test/module_parsing.py
+++ b/lib/spack/spack/test/module_parsing.py
@@ -20,19 +20,11 @@ test_module_lines = ['prepend-path LD_LIBRARY_PATH /path/to/lib',
                      'setenv LDFLAGS -L/path/to/lib',
                      'prepend-path PATH /path/to/bin']
 
-
-@pytest.fixture
-def module_function_test_mode():
-    old_cmd = spack.util.module_cmd._cmd_template
-    spack.util.module_cmd._cmd_template = "'. %s 2>&1' % args[1]"
-
-    yield
-
-    spack.util.module_cmd._cmd_template = old_cmd
+_test_template = "'. %s 2>&1' % args[1]"
 
 
-def test_module_function_change_env(tmpdir, working_env,
-                                    module_function_test_mode):
+def test_module_function_change_env(tmpdir, working_env, monkeypatch):
+    monkeypatch.setattr(spack.util.module_cmd, '_cmd_template', _test_template)
     src_file = str(tmpdir.join('src_me'))
     with open(src_file, 'w') as f:
         f.write('export TEST_MODULE_ENV_VAR=TEST_SUCCESS\n')
@@ -44,7 +36,8 @@ def test_module_function_change_env(tmpdir, working_env,
     assert os.environ['NOT_AFFECTED'] == "NOT_AFFECTED"
 
 
-def test_module_function_no_change(tmpdir, module_function_test_mode):
+def test_module_function_no_change(tmpdir, monkeypatch):
+    monkeypatch.setattr(spack.util.module_cmd, '_cmd_template', _test_template)
     src_file = str(tmpdir.join('src_me'))
     with open(src_file, 'w') as f:
         f.write('echo TEST_MODULE_FUNCTION_PRINT')
@@ -56,11 +49,11 @@ def test_module_function_no_change(tmpdir, module_function_test_mode):
     assert os.environ == old_env
 
 
-def test_get_path_from_module_faked(save_module_func):
+def test_get_path_from_module_faked(monkeypatch):
     for line in test_module_lines:
         def fake_module(*args):
             return line
-        spack.util.module_cmd.module = fake_module
+        monkeypatch.setattr(spack.util.module_cmd, 'module', fake_module)
 
         path = get_path_from_module('mod')
         assert path == '/path/to'

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -853,12 +853,14 @@ class TestSpecDag(object):
         self.check_diamond_deptypes(s)
         self.check_diamond_normalized_dag(s)
 
+    @pytest.mark.usefixtures('config')
     def test_concretize_deptypes(self):
         """Ensure that dependency types are preserved after concretization."""
         s = Spec('dt-diamond')
         s.concretize()
         self.check_diamond_deptypes(s)
 
+    @pytest.mark.usefixtures('config')
     def test_copy_deptypes(self):
         """Ensure that dependency types are preserved by spec copy."""
         s1 = Spec('dt-diamond')
@@ -877,6 +879,7 @@ class TestSpecDag(object):
         s4 = s3.copy()
         self.check_diamond_deptypes(s4)
 
+    @pytest.mark.usefixtures('config')
     def test_getitem_query(self):
         s = Spec('mpileaks')
         s.concretize()
@@ -908,6 +911,7 @@ class TestSpecDag(object):
         assert 'fortran' in query.extra_parameters
         assert query.isvirtual
 
+    @pytest.mark.usefixtures('config')
     def test_getitem_exceptional_paths(self):
         s = Spec('mpileaks')
         s.concretize()

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -387,7 +387,6 @@ class TestSpecDag(object):
         with pytest.raises(spack.spec.UnsatisfiableArchitectureSpecError):
             spec.normalize()
 
-    @pytest.mark.usefixtures('config')
     def test_invalid_dep(self):
         spec = Spec('libelf ^mpich')
         with pytest.raises(spack.spec.InvalidDependencyError):
@@ -602,7 +601,6 @@ class TestSpecDag(object):
         copy_ids = set(id(s) for s in copy.traverse())
         assert not orig_ids.intersection(copy_ids)
 
-    @pytest.mark.usefixtures('config')
     def test_copy_concretized(self):
         orig = Spec('mpileaks')
         orig.concretize()
@@ -853,14 +851,12 @@ class TestSpecDag(object):
         self.check_diamond_deptypes(s)
         self.check_diamond_normalized_dag(s)
 
-    @pytest.mark.usefixtures('config')
     def test_concretize_deptypes(self):
         """Ensure that dependency types are preserved after concretization."""
         s = Spec('dt-diamond')
         s.concretize()
         self.check_diamond_deptypes(s)
 
-    @pytest.mark.usefixtures('config')
     def test_copy_deptypes(self):
         """Ensure that dependency types are preserved by spec copy."""
         s1 = Spec('dt-diamond')
@@ -879,7 +875,6 @@ class TestSpecDag(object):
         s4 = s3.copy()
         self.check_diamond_deptypes(s4)
 
-    @pytest.mark.usefixtures('config')
     def test_getitem_query(self):
         s = Spec('mpileaks')
         s.concretize()
@@ -911,7 +906,6 @@ class TestSpecDag(object):
         assert 'fortran' in query.extra_parameters
         assert query.isvirtual
 
-    @pytest.mark.usefixtures('config')
     def test_getitem_exceptional_paths(self):
         s = Spec('mpileaks')
         s.concretize()

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -21,6 +21,7 @@ module_change_commands = ['load', 'swap', 'unload', 'purge', 'use', 'unuse']
 py_cmd = "'import os;import json;print(json.dumps(dict(os.environ)))'"
 _cmd_template = "'module ' + ' '.join(args) + ' 2>&1'"
 
+
 def module(*args):
     module_cmd = eval(_cmd_template)  # So we can monkeypatch for testing
     if args[0] in module_change_commands:

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -19,16 +19,10 @@ import llnl.util.tty as tty
 # If we need another option that changes the environment, add it here.
 module_change_commands = ['load', 'swap', 'unload', 'purge', 'use', 'unuse']
 py_cmd = "'import os;import json;print(json.dumps(dict(os.environ)))'"
-
-# This is just to enable testing. I hate it but we can't find a better way
-_test_mode = False
-
+_cmd_template = "'module ' + ' '.join(args) + ' 2>&1'"
 
 def module(*args):
-    module_cmd = 'module ' + ' '.join(args) + ' 2>&1'
-    if _test_mode:
-        tty.warn('module function operating in test mode')
-        module_cmd = ". %s 2>&1" % args[1]
+    module_cmd = eval(_cmd_template)  # So we can monkeypatch for testing
     if args[0] in module_change_commands:
         # Do the module manipulation, then output the environment in JSON
         # and read the JSON back in the parent process to update os.environ


### PR DESCRIPTION
Currently, to force Spack to use an external MPI, you have to specify `buildable: False` for every MPI provider in Spack in your packages.yaml file. This is both tedious and fragile, as new MPI providers can be added and break your workflow when you do a git pull.

This PR allows you to specify an entire virtual dependency as non-buildable, and specify particular implementations to be built:
```yaml
packages:
all:
    providers:
        mpi: [mpich]
mpi:
    buildable: false
    paths:
        mpich@3.2 %gcc@7.3.0: /usr/packages/mpich-3.2-gcc-7.3.0
```
will force all Spack builds to use the specified mpich install.