### PR TITLE
skip gpg tests when no gpg executable

### DIFF
--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -13,6 +13,7 @@ import spack.config as cfg
 import spack.paths as spack_paths
 import spack.spec as spec
 import spack.util.web as web_util
+import spack.util.gpg
 
 
 @pytest.fixture
@@ -41,6 +42,16 @@ def test_urlencode_string():
     assert(s_enc == 'Spack+Test+Project')
 
 
+def has_gpg():
+    try:
+        gpg = spack.util.gpg.Gpg.gpg()
+    except spack.util.gpg.SpackGPGError:
+        gpg = None
+    return bool(gpg)
+no_gpg = not has_gpg()
+
+
+@pytest.mark.skipif(no_gpg, reason='This test requires gpg')
 def test_import_signing_key(mock_gnupghome):
     signing_key_dir = spack_paths.mock_gpg_keys_path
     signing_key_path = os.path.join(signing_key_dir, 'package-signing-key')

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -48,10 +48,9 @@ def has_gpg():
     except spack.util.gpg.SpackGPGError:
         gpg = None
     return bool(gpg)
-no_gpg = not has_gpg()
 
 
-@pytest.mark.skipif(no_gpg, reason='This test requires gpg')
+@pytest.mark.skipif(not has_gpg(), reason='This test requires gpg')
 def test_import_signing_key(mock_gnupghome):
     signing_key_dir = spack_paths.mock_gpg_keys_path
     signing_key_path = os.path.join(signing_key_dir, 'package-signing-key')

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -39,7 +39,6 @@ def has_gpg():
     except spack.util.gpg.SpackGPGError:
         gpg = None
     return bool(gpg)
-no_gpg = not has_gpg()
 
 
 @pytest.fixture()
@@ -504,7 +503,7 @@ def test_ci_pushyaml(tmpdir):
 
 
 @pytest.mark.disable_clean_stage_check
-@pytest.mark.skipif(no_gpg, reason='This test requires gpg')
+@pytest.mark.skipif(not has_gpg(), reason='This test requires gpg')
 def test_push_mirror_contents(tmpdir, mutable_mock_env_path, env_deactivate,
                               install_mockery, mock_packages, mock_fetch,
                               mock_stage, mock_gnupghome):

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -21,6 +21,7 @@ from spack.spec import Spec
 from spack.test.conftest import MockPackage, MockPackageMultiRepo
 import spack.util.executable as exe
 import spack.util.spack_yaml as syaml
+import spack.util.gpg
 
 
 ci_cmd = SpackCommand('ci')
@@ -30,6 +31,15 @@ gpg_cmd = SpackCommand('gpg')
 install_cmd = SpackCommand('install')
 buildcache_cmd = SpackCommand('buildcache')
 git = exe.which('git', required=True)
+
+
+def has_gpg():
+    try:
+        gpg = spack.util.gpg.Gpg.gpg()
+    except spack.util.gpg.SpackGPGError:
+        gpg = None
+    return bool(gpg)
+no_gpg = not has_gpg()
 
 
 @pytest.fixture()
@@ -494,6 +504,7 @@ def test_ci_pushyaml(tmpdir):
 
 
 @pytest.mark.disable_clean_stage_check
+@pytest.mark.skipif(no_gpg, reason='This test requires gpg')
 def test_push_mirror_contents(tmpdir, mutable_mock_env_path, env_deactivate,
                               install_mockery, mock_packages, mock_fetch,
                               mock_stage, mock_gnupghome):

--- a/lib/spack/spack/test/cmd/gpg.py
+++ b/lib/spack/spack/test/cmd/gpg.py
@@ -52,8 +52,16 @@ def test_no_gpg_in_path(tmpdir, mock_gnupghome, monkeypatch):
         spack.util.gpg.Gpg.gpg()
 
 
+def has_gpg():
+    try:
+        gpg = spack.util.gpg.Gpg.gpg()
+    except spack.util.gpg.SpackGPGError:
+        gpg = None
+    return bool(gpg)
+no_gpg = not has_gpg()
+
 @pytest.mark.maybeslow
-@pytest.mark.skipif(not spack.util.gpg.Gpg.gpg(),
+@pytest.mark.skipif(no_gpg,
                     reason='These tests require gnupg2')
 def test_gpg(tmpdir, mock_gnupghome):
     # Verify a file with an empty keyring.

--- a/lib/spack/spack/test/cmd/gpg.py
+++ b/lib/spack/spack/test/cmd/gpg.py
@@ -58,10 +58,10 @@ def has_gpg():
     except spack.util.gpg.SpackGPGError:
         gpg = None
     return bool(gpg)
-no_gpg = not has_gpg()
+
 
 @pytest.mark.maybeslow
-@pytest.mark.skipif(no_gpg,
+@pytest.mark.skipif(not has_gpg(),
                     reason='These tests require gnupg2')
 def test_gpg(tmpdir, mock_gnupghome):
     # Verify a file with an empty keyring.

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -37,7 +37,6 @@ def has_gpg():
     except spack.util.gpg.SpackGPGError:
         gpg = None
     return bool(gpg)
-no_gpg = not has_gpg()
 
 
 def fake_fetchify(url, pkg):
@@ -47,7 +46,7 @@ def fake_fetchify(url, pkg):
     pkg.fetcher = fetcher
 
 
-@pytest.mark.skipif(no_gpg, reason='This test requires gpg')
+@pytest.mark.skipif(not has_gpg(), reason='This test requires gpg')
 @pytest.mark.usefixtures('install_mockery', 'mock_gnupghome')
 def test_buildcache(mock_archive, tmpdir):
     # tweak patchelf to only do a download

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -31,6 +31,15 @@ from spack.relocate import macho_replace_paths, macho_make_paths_relative
 from spack.relocate import modify_macho_object, macho_get_paths
 
 
+def has_gpg():
+    try:
+        gpg = spack.util.gpg.Gpg.gpg()
+    except spack.util.gpg.SpackGPGError:
+        gpg = None
+    return bool(gpg)
+no_gpg = not has_gpg()
+
+
 def fake_fetchify(url, pkg):
     """Fake the URL for a package so it downloads from a file."""
     fetcher = FetchStrategyComposite()
@@ -38,6 +47,7 @@ def fake_fetchify(url, pkg):
     pkg.fetcher = fetcher
 
 
+@pytest.mark.skipif(no_gpg, reason='This test requires gpg')
 @pytest.mark.usefixtures('install_mockery', 'mock_gnupghome')
 def test_buildcache(mock_archive, tmpdir):
     # tweak patchelf to only do a download


### PR DESCRIPTION
Since #14594 there are tests that fail when no gpg executable is present. This PR skips those tests in that circumstance.