### PR TITLE
pegtl: change to virtual destructor

### DIFF
--- a/var/spack/repos/builtin/packages/pegtl/change_to_virtual_destructor.patch
+++ b/var/spack/repos/builtin/packages/pegtl/change_to_virtual_destructor.patch
@@ -1,0 +1,13 @@
+--- spack-src/src/example/pegtl/json_classes.hpp.org	2020-02-14 11:07:25.117102793 +0900
++++ spack-src/src/example/pegtl/json_classes.hpp	2020-02-14 11:08:06.841397607 +0900
+@@ -35,9 +35,7 @@
+       {
+       }
+ 
+-      ~json_base()
+-      {
+-      }
++      virtual ~json_base() = default;
+    };
+ 
+    inline std::ostream& operator<<( std::ostream& o, const json_base& j )

--- a/var/spack/repos/builtin/packages/pegtl/package.py
+++ b/var/spack/repos/builtin/packages/pegtl/package.py
@@ -18,9 +18,9 @@ class Pegtl(CMakePackage):
     url      = "https://github.com/taocpp/PEGTL/tarball/2.1.4"
     git      = "https://github.com/taocpp/PEGTL.git"
 
-    version('develop', branch='master')
+    version('master', branch='master')
     version('2.1.4', sha256='d990dccc07b4d9ba548326d11c5c5e34fa88b34fe113cb5377da03dda29f23f2')
     version('2.0.0', sha256='5aae0505077e051cae4d855c38049cc6cf71103a6cc8d0ddef01a576e8a60cc0')
 
     # Ref: https://github.com/taocpp/PEGTL/blob/master/src/example/pegtl/json_classes.hpp
-    patch('change_to_virtual_destructor.patch')
+    patch('change_to_virtual_destructor.patch', when='@:2.4')

--- a/var/spack/repos/builtin/packages/pegtl/package.py
+++ b/var/spack/repos/builtin/packages/pegtl/package.py
@@ -21,3 +21,6 @@ class Pegtl(CMakePackage):
     version('develop', branch='master')
     version('2.1.4', sha256='d990dccc07b4d9ba548326d11c5c5e34fa88b34fe113cb5377da03dda29f23f2')
     version('2.0.0', sha256='5aae0505077e051cae4d855c38049cc6cf71103a6cc8d0ddef01a576e8a60cc0')
+
+    # Ref: https://github.com/taocpp/PEGTL/blob/master/src/example/pegtl/json_classes.hpp
+    patch('change_to_virtual_destructor.patch')


### PR DESCRIPTION
- error
```
  >> 1084    /usr/lib/gcc/aarch64-redhat-linux/4.8.5/../../../../include/c++/4.
             8.5/ext/new_allocator.h:124:29: error: destructor called on non-fi
             nal 'examples::string_json' that has virtual functions but non-vir
             tual destructor [-Werror,-Wdelete-non-virtual-dtor]
     1085            destroy(_Up* __p) { __p->~_Up(); }
     1086                                ^
```

I changed destructor to virtual destructor.
Ref: https://github.com/taocpp/PEGTL/commit/340110292b35d367205953a59e7eab28e1f4a0bb#diff-1273613920dbf566d89ea5cf50609053
