### PR TITLE
Remove unneeded dependency on gzip for libmng

### DIFF
--- a/var/spack/repos/builtin/packages/libmng/package.py
+++ b/var/spack/repos/builtin/packages/libmng/package.py
@@ -16,7 +16,6 @@ class Libmng(CMakePackage):
     version('2.0.3', sha256='cf112a1fb02f5b1c0fce5cab11ea8243852c139e669c44014125874b14b7dfaa')
     version('2.0.2', sha256='4908797bb3541fb5cd8fffbe0b1513ed163509f2a4d57a78b26a96f8d1dd05a2')
 
-    depends_on("gzip")
     depends_on("jpeg")
     depends_on("zlib")
     depends_on("lcms")


### PR DESCRIPTION
Libmng only needs gzip to compress man files for distribution, so it
builds fine without it. The spack
gzip currently fails to compile.

```
config.status: linking /var/folders/fy/x2xtwh1n7fn0_0q2kk29xkv9vvmbqb/T/spack-stage/s3j/spack-stage-gzip-1.10-iatwtuk2l5xgwmuh4pwu5bf27yezpydj/spack-src/GNUmakefile to GNUmakefile
config.status: executing depfiles commands
==> Executing phase: 'build'
==> [2020-02-14-09:32:45.502913] 'make' '-j12'
make: GNUmakefile: Too many levels of symbolic links
make: stat: GNUmakefile: Too many levels of symbolic links
make: *** No rule to make target `GNUmakefile'.  Stop.
```