### PR TITLE
Use separate build directory for gzip

### DIFF
--- a/var/spack/repos/builtin/packages/gzip/package.py
+++ b/var/spack/repos/builtin/packages/gzip/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from spack import *
+import os
 
 
 class Gzip(AutotoolsPackage):
@@ -13,3 +14,8 @@ class Gzip(AutotoolsPackage):
     url      = "https://ftp.gnu.org/gnu/gzip/gzip-1.10.tar.gz"
 
     version('1.10', sha256='c91f74430bf7bc20402e1f657d0b252cb80aa66ba333a25704512af346633c68')
+
+    @property
+    def build_directory(self):
+        # Gzip makes a recursive symlink if built in-source
+        return os.path.join(self.stage.path, 'spack-build')

--- a/var/spack/repos/builtin/packages/gzip/package.py
+++ b/var/spack/repos/builtin/packages/gzip/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from spack import *
-import os
 
 
 class Gzip(AutotoolsPackage):
@@ -15,7 +14,7 @@ class Gzip(AutotoolsPackage):
 
     version('1.10', sha256='c91f74430bf7bc20402e1f657d0b252cb80aa66ba333a25704512af346633c68')
 
-    @property
-    def build_directory(self):
-        # Gzip makes a recursive symlink if built in-source
-        return os.path.join(self.stage.path, 'spack-build')
+    depends_on('gmake', type='build')
+
+    # Gzip makes a recursive symlink if built in-source
+    build_directory = 'spack-build'


### PR DESCRIPTION
At least on mac systems (perhaps because of a case sensitivity issue?)
gzip fails to build inside the source tree:
```
config.status: linking /var/folders/fy/x2xtwh1n7fn0_0q2kk29xkv9vvmbqb/T/spack-stage/s3j/spack-stage-gzip-1.10-iatwtuk2l5xgwmuh4pwu5bf27yezpydj/spack-src/GNUmakefile to GNUmakefile
config.status: executing depfiles commands
==> Executing phase: 'build'
==> [2020-02-14-09:32:45.502913] 'make' '-j12'
make: GNUmakefile: Too many levels of symbolic links
make: stat: GNUmakefile: Too many levels of symbolic links
make: *** No rule to make target `GNUmakefile'.  Stop.
```