### PR TITLE
package r-readbitmap Change jpeg dependency

### DIFF
--- a/var/spack/repos/builtin/packages/r-readbitmap/package.py
+++ b/var/spack/repos/builtin/packages/r-readbitmap/package.py
@@ -24,5 +24,5 @@ class RReadbitmap(RPackage):
     depends_on('r-png', type=('build', 'run'))
     depends_on('r-tiff', type=('build', 'run'))
 
-    depends_on('libjpeg')
+    depends_on('jpeg')
     depends_on('libpng')


### PR DESCRIPTION
This PR corrects the jpeg dependency in r-readbitmap to use the jpeg
virtual dependency.