### PR TITLE
libnrm depends on pkg-config for build

### DIFF
--- a/var/spack/repos/builtin/packages/libnrm/package.py
+++ b/var/spack/repos/builtin/packages/libnrm/package.py
@@ -18,6 +18,7 @@ class Libnrm(AutotoolsPackage):
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
     depends_on('libtool', type='build')
+    depends_on('pkgconfig', type='build')
 
     depends_on('libzmq')
     depends_on('mpich')


### PR DESCRIPTION
Package `libnrm` currently has a non-explicit build dependency on `pkgconfig`. This PR makes this build dependency explicit. @freuk @scheibelp @scottwittenburg 