### PR TITLE
config: add initial hardware.yaml schema

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -50,6 +50,7 @@ import spack.paths
 import spack.architecture
 import spack.schema
 import spack.schema.compilers
+import spack.schema.hardware
 import spack.schema.mirrors
 import spack.schema.repos
 import spack.schema.packages
@@ -65,6 +66,7 @@ import spack.util.spack_yaml as syaml
 #: Dict from section names -> schema for that section
 section_schemas = {
     'compilers': spack.schema.compilers.schema,
+    'hardware': spack.schema.hardware.schema,
     'mirrors': spack.schema.mirrors.schema,
     'repos': spack.schema.repos.schema,
     'packages': spack.schema.packages.schema,

--- a/lib/spack/spack/schema/hardware.py
+++ b/lib/spack/spack/schema/hardware.py
@@ -16,21 +16,26 @@ properties = {
         'required': ['nodes'],
         'properties': {
             'nodes': {
-                'type': 'object',
-                'additionalProperties': False,
-                'patternProperties': {
-                    r'\w[\w-]*': {  # node name
-                        'type': 'object',
-                        'additionalProperties': False,
-                        'required': ['target', 'operating_system'],
-                        'properties': {
-                            'operating_system': {'type': 'string'},
-                            'target': {'type': 'string'}
+                'type': 'array',
+                'items': [{
+                    'type': 'object',
+                    'additionalProperties': False,
+                    'properties': {
+                        'node': {
+                            'type': 'object',
+                            'additionalProperties': False,
+                            'required': ['name', 'target', 'operating_system'],
+                            'properties': {
+                                'name': {'type': 'string'},
+                                'operating_system': {'type': 'string'},
+                                'target': {'type': 'string'}
+                            }
                         }
                     }
-                }
+                }]
             }
         }
+
     }
 }
 

--- a/lib/spack/spack/schema/hardware.py
+++ b/lib/spack/spack/schema/hardware.py
@@ -1,0 +1,45 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""Schema for hardware.yaml configuration file.
+
+.. literalinclude:: _spack_root/lib/spack/spack/schema/hardware.py
+   :lines: 11-
+"""
+#: Properties for inclusion in other schemas
+properties = {
+    'hardware': {
+        'type': 'object',
+        'additionalProperties': False,
+        'required': ['nodes'],
+        'properties': {
+            'nodes': {
+                'type': 'object',
+                'additionalProperties': False,
+                'patternProperties': {
+                    r'\w[\w-]*': {  # node name
+                        'type': 'object',
+                        'additionalProperties': False,
+                        'required': ['target', 'operating_system'],
+                        'properties': {
+                            'operating_system': {'type': 'string'},
+                            'target': {'type': 'string'}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+#: Full schema with metadata
+schema = {
+    '$schema': 'http://json-schema.org/schema#',
+    'title': 'Spack hardware configuration file schema',
+    'type': 'object',
+    'additionalProperties': False,
+    'properties': properties,
+}

--- a/lib/spack/spack/schema/hardware.py
+++ b/lib/spack/spack/schema/hardware.py
@@ -13,7 +13,7 @@ properties = {
     'hardware': {
         'type': 'object',
         'additionalProperties': False,
-        'required': ['nodes'],
+        'required': ['hosts'],
         'properties': {
             'hosts': {
                 'type': 'array',

--- a/lib/spack/spack/schema/hardware.py
+++ b/lib/spack/spack/schema/hardware.py
@@ -15,13 +15,13 @@ properties = {
         'additionalProperties': False,
         'required': ['nodes'],
         'properties': {
-            'nodes': {
+            'hosts': {
                 'type': 'array',
                 'items': [{
                     'type': 'object',
                     'additionalProperties': False,
                     'properties': {
-                        'node': {
+                        'host': {
                             'type': 'object',
                             'additionalProperties': False,
                             'required': ['name', 'target', 'operating_system'],

--- a/lib/spack/spack/schema/merged.py
+++ b/lib/spack/spack/schema/merged.py
@@ -15,6 +15,7 @@ import spack.schema.compilers
 import spack.schema.config
 import spack.schema.container
 import spack.schema.gitlab_ci
+import spack.schema.hardware
 import spack.schema.mirrors
 import spack.schema.modules
 import spack.schema.packages
@@ -29,6 +30,7 @@ properties = union_dicts(
     spack.schema.config.properties,
     spack.schema.container.properties,
     spack.schema.gitlab_ci.properties,
+    spack.schema.hardware.properties,
     spack.schema.mirrors.properties,
     spack.schema.modules.properties,
     spack.schema.packages.properties,

--- a/lib/spack/spack/test/schema.py
+++ b/lib/spack/spack/test/schema.py
@@ -100,6 +100,7 @@ def test_module_suffixes(module_suffixes_schema):
     'compilers',
     'config',
     'env',
+    'hardware',
     'merged',
     'mirrors',
     'modules',


### PR DESCRIPTION
For cross-compilation, we are adding an optional `hardware.yaml` config file, which can be used to describe the types of target environments available on the system.  Currently this includes the microarchitecture target (`target`) and the OS running on each node (`operating_system`).

For example, on Fugaku, we might use the following hardware.yaml to describe the machine's nodes:

```yaml
hardware:
    hosts:
        - host:
            name: frontend1
            operating_system: rhel7
            target: cascadelake
        - host:
           name: frontend2
           operating_system: rhel7
           target: thunderx2
        - host:
            name: backend
            operating_system: rhel8
            target: a64fx
```

Other properties, e.g., an optional `sysroot`, or a section describing available networks, can come later.  We expect that this file might also contain hints for setting default values of variants (e.g. you could ask what network fabrics are available on your node and decide how to build `openmpi` based on that. 

The concretizer will use this file to determine what the build environment and the target environment look like, and it will construct build dependencies to run on the host running Spack, and the DAG root + run and link dependencies to run on a selected type of node.  That will come later; this is just the first cut at the schema.