### PR TITLE
an argument 'buf_size' of 'h5fget_file_image_c' should be intent(out).

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -6,8 +6,6 @@
 import shutil
 import sys
 
-import os.path
-
 from spack import *
 
 
@@ -124,16 +122,16 @@ class Hdf5(AutotoolsPackage):
     # result, aggressive compilers such as Fujitsu's may do a wrong
     # optimization to cause an error.
     def patch(self):
-        if os.path.exists('fortran/src/H5Fff.F90'):
-            filter_file(
-                r'INTEGER\(SIZE_T\), INTENT\(IN\) :: buf_size',
-                'INTEGER(SIZE_T), INTENT(OUT) :: buf_size',
-                'fortran/src/H5Fff.F90')
-        if os.path.exists('fortran/src/H5Fff_F03.f90'):
-            filter_file(
-                r'INTEGER\(SIZE_T\), INTENT\(IN\) :: buf_size',
-                'INTEGER(SIZE_T), INTENT(OUT) :: buf_size',
-                'fortran/src/H5Fff_F03.f90')
+        filter_file(
+            'INTEGER(SIZE_T), INTENT(IN) :: buf_size',
+            'INTEGER(SIZE_T), INTENT(OUT) :: buf_size',
+            'fortran/src/H5Fff.F90',
+            string=True, ignore_absent=True)
+        filter_file(
+            'INTEGER(SIZE_T), INTENT(IN) :: buf_size',
+            'INTEGER(SIZE_T), INTENT(OUT) :: buf_size',
+            'fortran/src/H5Fff_F03.f90',
+            string=True, ignore_absent=True)
 
     filter_compiler_wrappers('h5cc', 'h5c++', 'h5fc', relative_root='bin')
 

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -6,6 +6,8 @@
 import shutil
 import sys
 
+import os.path
+
 from spack import *
 
 
@@ -116,6 +118,21 @@ class Hdf5(AutotoolsPackage):
     # libraries fail to link; see https://github.com/spack/spack/issues/12586
     patch('h5public-skip-mpicxx.patch', when='@:1.8.21,1.10.0:1.10.5+mpi~cxx',
           sha256='b61e2f058964ad85be6ee5ecea10080bf79e73f83ff88d1fa4b602d00209da9c')
+
+    # The argument 'buf_size' of the C function 'h5fget_file_image_c' is declared as intent(in) though
+    # it is modified by the invocation. As a result, aggressive compilers such as Fujitsu's may do a
+    # wrong optimization to cause an error.
+    def patch(self):
+        if os.path.exists('fortran/src/H5Fff.F90'):
+            filter_file(
+                'INTEGER\(SIZE_T\), INTENT\(IN\) :: buf_size',
+                'INTEGER(SIZE_T), INTENT(OUT) :: buf_size',
+                'fortran/src/H5Fff.F90')
+        if os.path.exists('fortran/src/H5Fff_F03.f90'):
+            filter_file(
+                'INTEGER\(SIZE_T\), INTENT\(IN\) :: buf_size',
+                'INTEGER(SIZE_T), INTENT(OUT) :: buf_size',
+                'fortran/src/H5Fff_F03.f90')
 
     filter_compiler_wrappers('h5cc', 'h5c++', 'h5fc', relative_root='bin')
 

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -119,18 +119,19 @@ class Hdf5(AutotoolsPackage):
     patch('h5public-skip-mpicxx.patch', when='@:1.8.21,1.10.0:1.10.5+mpi~cxx',
           sha256='b61e2f058964ad85be6ee5ecea10080bf79e73f83ff88d1fa4b602d00209da9c')
 
-    # The argument 'buf_size' of the C function 'h5fget_file_image_c' is declared as intent(in) though
-    # it is modified by the invocation. As a result, aggressive compilers such as Fujitsu's may do a
-    # wrong optimization to cause an error.
+    # The argument 'buf_size' of the C function 'h5fget_file_image_c' is
+    # declared as intent(in) though it is modified by the invocation. As a
+    # result, aggressive compilers such as Fujitsu's may do a wrong
+    # optimization to cause an error.
     def patch(self):
         if os.path.exists('fortran/src/H5Fff.F90'):
             filter_file(
-                'INTEGER\(SIZE_T\), INTENT\(IN\) :: buf_size',
+                r'INTEGER\(SIZE_T\), INTENT\(IN\) :: buf_size',
                 'INTEGER(SIZE_T), INTENT(OUT) :: buf_size',
                 'fortran/src/H5Fff.F90')
         if os.path.exists('fortran/src/H5Fff_F03.f90'):
             filter_file(
-                'INTEGER\(SIZE_T\), INTENT\(IN\) :: buf_size',
+                r'INTEGER\(SIZE_T\), INTENT\(IN\) :: buf_size',
                 'INTEGER(SIZE_T), INTENT(OUT) :: buf_size',
                 'fortran/src/H5Fff_F03.f90')
 


### PR DESCRIPTION
The argument 'buf_size' of the C function 'h5fget_file_image_c' is declared as intent(in) in its interface block in 'H5Fff.F90' or 'H5Fff_F03.f90' though it is modified by the invocation. As a result, aggressive compilers such as Fujitsu's may do a wrong optimization to generate a wrong result, and a test during the installation fails. So, 'buf_size' should be declared as intent(out).

Note: This fix should be temporal and the bug should be fixed by the developer. I'll report it to them.