### PR TITLE
config: add hardware property in packages.yaml.

### DIFF
--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -89,7 +89,7 @@ properties = {
                             'type': 'object',
                             'additionalProperties': False,
                             'properties': {
-                                'node': {
+                                'host': {
                                     'type': 'object',
                                     'additionalProperties': False,
                                     'require': ['name', 'compiler'],

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -82,6 +82,29 @@ properties = {
                             {'type': 'array',
                              'items': {'type': 'string'}}],
                     },
+                    'hardware': {
+                        'type': 'array',
+                        'additionalProperties': False,
+                        'items': [{
+                            'type': 'object',
+                            'additionalProperties': False,
+                            'properties': {
+                                'node': {
+                                    'type': 'object',
+                                    'additionalProperties': False,
+                                    'require': ['name', 'compiler'],
+                                    'properties': {
+                                        'name': {'type': 'string'},
+                                        'compiler': {
+                                            'type': 'array',
+                                            'default': [],
+                                            'items': {'type': 'string'}
+                                        },
+                                    }
+                                }
+                            }
+                        }],
+                    },
                 },
             },
         },


### PR DESCRIPTION
This PR changes the behavior of packages.py in the hardware.py host added in #15009.
Currently, only compiler priority can be registered.

example:
```yaml
packages:
    all:
        hardware:
            - host:
                name: backend
                compiler: [fj, gcc]
'''

