### PR TITLE
libcircle depends on a provider of pkgconfig for build

### DIFF
--- a/var/spack/repos/builtin/packages/libcircle/package.py
+++ b/var/spack/repos/builtin/packages/libcircle/package.py
@@ -19,7 +19,7 @@ class Libcircle(AutotoolsPackage):
     version('0.2.1-rc.1', sha256='5747f91cf4417023304dcc92fd07e3617ac712ca1eeb698880979bbca3f54865')
 
     depends_on('mpi')
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')
 
     @when('@master')
     def autoreconf(self, spec, prefix):


### PR DESCRIPTION
Change package `libcircle` so that it depends on a provider of pkgconfig, as opposed to specifically requiring pkg-config. @adammoody @adamjstewart 