### PR TITLE
Update CLHEP fetch URL and version

### DIFF
--- a/var/spack/repos/builtin/packages/clhep/package.py
+++ b/var/spack/repos/builtin/packages/clhep/package.py
@@ -10,10 +10,11 @@ from spack import *
 class Clhep(CMakePackage):
     """CLHEP is a C++ Class Library for High Energy Physics. """
     homepage = "http://proj-clhep.web.cern.ch/proj-clhep/"
-    url      = "http://proj-clhep.web.cern.ch/proj-clhep/DISTRIBUTION/tarFiles/clhep-2.2.0.5.tgz"
+    url      = "http://proj-clhep.web.cern.ch/proj-clhep/dist1/clhep-2.4.1.3.tgz"
     list_url = "https://proj-clhep.web.cern.ch/proj-clhep/"
     list_depth = 1
 
+    version('2.4.1.3', sha256='27c257934929f4cb1643aa60aeaad6519025d8f0a1c199bc3137ad7368245913')
     version('2.4.1.2', sha256='ff96e7282254164380460bc8cf2dff2b58944084eadcd872b5661eb5a33fa4b8')
     version('2.4.1.0', sha256='d14736eb5c3d21f86ce831dc1afcf03d423825b35c84deb6f8fd16773528c54d')
     version('2.4.0.4', sha256='eb013841c57990befa1e977a11a552ab8328733c1c3b6cecfde86da40dc22113')


### PR DESCRIPTION
It looks like the CLHEP fetch url has changed:
```
==> Fetching http://proj-clhep.web.cern.ch/proj-clhep/DISTRIBUTION/tarFiles/clhep-2.4.1.2.tgz
-#O#-  #    #
curl: (22) The requested URL returned error: 404 Not Found
==> Failed to fetch file from URL: http://proj-clhep.web.cern.ch/proj-clhep/DISTRIBUTION/tarFiles/clhep-2.4.1.2.tgz
    URL http://proj-clhep.web.cern.ch/proj-clhep/DISTRIBUTION/tarFiles/clhep-2.4.1.2.tgz was not found!
==> Fetching from http://proj-clhep.web.cern.ch/proj-clhep/DISTRIBUTION/tarFiles/clhep-2.4.1.2.tgz failed.
==> Cannot find version 2.4.1.2 in url_list
==> Error: FetchError: All fetchers failed for spack-stage-clhep-2.4.1.2-27z42fmkngktzmf6gde6incbg4y5xwx2
```

I'm updating based on the [official clhep download page](http://proj-clhep.web.cern.ch/proj-clhep/clhep23.html).