### PR TITLE
octave: enable 64-bit BLAS builds.

### DIFF
--- a/var/spack/repos/builtin/packages/octave/package.py
+++ b/var/spack/repos/builtin/packages/octave/package.py
@@ -268,6 +268,12 @@ class Octave(AutotoolsPackage, GNUMirrorPackage):
             ])
         else:
             config_args.append("--without-z")
+            
+        # If 64-bit BLAS is used:
+        if (spec.satisfies('^openblas+ilp64') or
+            spec.satisfies('^intel-mkl+ilp64') or
+            spec.satisfies('^intel-parallel-studio+mkl+ilp64')):
+            config_args.append('F77_INTEGER_8_FLAG=-fdefault-integer-8')
 
         return config_args
 

--- a/var/spack/repos/builtin/packages/octave/package.py
+++ b/var/spack/repos/builtin/packages/octave/package.py
@@ -268,7 +268,7 @@ class Octave(AutotoolsPackage, GNUMirrorPackage):
             ])
         else:
             config_args.append("--without-z")
-            
+
         # If 64-bit BLAS is used:
         if (spec.satisfies('^openblas+ilp64') or
             spec.satisfies('^intel-mkl+ilp64') or


### PR DESCRIPTION
Perform necessary actions [as described in the manual](https://octave.org/doc/v5.2.0/Compiling-Octave-with-64_002dbit-Indexing.html) to build Octave against BLAS implementations supporting 64-bit indices.