### PR TITLE
Update davix and ROOT version requirement

### DIFF
--- a/var/spack/repos/builtin/packages/davix/package.py
+++ b/var/spack/repos/builtin/packages/davix/package.py
@@ -14,7 +14,9 @@ class Davix(CMakePackage):
     list_url = "http://grid-deployment.web.cern.ch/grid-deployment/dms/lcgutil/tar/davix/"
     list_depth = 1
 
+    version('0.7.5', sha256='d920ca976846875d83af4dc50c99280bb3741fcf8351d5733453e70fa5fe6fc8')
     version('0.7.3', sha256='cd46276e72c6a0da1e2ad30eb66ec509a4c023687767c62a66713fa8c23d328a')
+    version('0.6.9', sha256='fbd97eb5fdf82ca48770d06bf8e2805b35f23255478aa381a9d25a49eb98e348')
     version('0.6.8', sha256='e1820f4cc3fc44858ae97197a3922cce2a1130ff553b080ba19e06eb8383ddf7')
 
     depends_on('pkgconfig', type='build')

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -207,7 +207,7 @@ class Root(CMakePackage):
     depends_on('py-numpy', when='+tmva')
 
     # Optional dependencies
-    depends_on('davix',     when='+davix')
+    depends_on('davix @0.7.1:', when='+davix')
     depends_on('cfitsio',   when='+fits')
     depends_on('fftw',      when='+fftw')
     depends_on('graphviz',  when='+graphviz')


### PR DESCRIPTION
Adds latest version of DaviX toolkit and adds a version requirement from ROOT.
```
-- Checking for module 'davix>=0.6.4'
--   Found davix, version 0.6.8
CMake Warning at cmake/modules/SearchInstalledSoftware.cmake:960 (message):
  Davix versions 0.6.8 to 0.7.0 have a bug and do not work with ROOT, please
  upgrade to 0.7.1 or later.
```