### PR TITLE
Default to +termlib for ncurses to satisfy LLVM

### DIFF
--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -26,7 +26,7 @@ class Ncurses(AutotoolsPackage, GNUMirrorPackage):
 
     variant('symlinks', default=False,
             description='Enables symlinks. Needed on AFS filesystem.')
-    variant('termlib', default=False,
+    variant('termlib', default=True,
             description='Enables termlib needs for gnutls in emacs.')
 
     depends_on('pkgconfig', type='build')


### PR DESCRIPTION
Alternative to https://github.com/spack/spack/pull/14853 removes default conflict for LLVM and other ncurses-based packages. See https://github.com/spack/spack/issues/14793 .