### PR TITLE
ROSS: v7.2.0

### DIFF
--- a/var/spack/repos/builtin/packages/ross/package.py
+++ b/var/spack/repos/builtin/packages/ross/package.py
@@ -13,7 +13,11 @@ class Ross(CMakePackage):
     git      = "https://github.com/ROSS-org/ROSS.git"
     url      = "https://github.com/ROSS-org/ROSS/archive/v7.0.0.tar.gz"
 
-    version('develop', branch='master')
+    version('develop', branch='develop')
+    version('master', branch='master')
+    version('7.2.0', sha256='c937f4c7baa1918b6cd08f4eafae8cab44eddcd4aaa1175c23ff8562583ad726')
+    version('7.1.1', sha256='550e3288cefedcbc7e6ca16cfbee0477b70399d63e94f554b60b32d714029722')
+    version('7.1.0', sha256='478063f36d96466faef3db3cc15e1c0e1a8b60b9152fcce0eedf367be8252733')
     version('7.0.1', sha256='40780dada4ab501d2b8ea229f70b9fea920404431d7a60081ba84dd4a50b2517')
     version('7.0.0', sha256='fd16be2c86d9d71ae64eef67c02933471ab758c8a5b01b04fe358d9228fc581e')
     version('6.0.0', sha256='07ff70518a58503e116bb7386f490e901212798afdd471da1bcd34f78a7e6030')


### PR DESCRIPTION
And 'master' and 'develop' versions to properly match branches.