### PR TITLE
Use shutil.copy2 in install_tree

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -456,7 +456,7 @@ def copy_tree(src, dest, symlinks=True, ignore=None, _permissions=False):
             if os.path.isdir(s):
                 mkdirp(d)
             else:
-                shutil.copyfile(s, d)
+                shutil.copy2(s, d)
 
         if _permissions:
             set_install_permissions(d)


### PR DESCRIPTION
Sometimes one needs to preserve the (relative order) of mtimes on installed files.  So it's better to just copy over all the metadata from the source tree to the install tree. If permissions need fixing, that will be done anyway afterwards.

One major use case are resource()s: They're unpacked in one place and then copied to their final place using install_tree(). If the resource is a source tree using autoconf/automake, resetting mtimes uncorrectly might force unwanted autoconf/etc calls.