### PR TITLE
Mark binutils-related conflicts

### DIFF
--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -44,6 +44,9 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
     depends_on('m4', type='build', when='@:2.29.99 +gold')
     depends_on('bison', type='build', when='@:2.29.99 +gold')
 
+    conflicts('+gold', when='platform=darwin',
+              msg="Binutils cannot build linkers on macOS")
+
     def configure_args(self):
         spec = self.spec
 

--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -5,6 +5,7 @@
 
 from spack import *
 import glob
+import sys
 
 
 class Binutils(AutotoolsPackage, GNUMirrorPackage):
@@ -28,7 +29,8 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
 
     variant('plugins', default=False,
             description="enable plugins, needed for gold linker")
-    variant('gold', default=True, description="build the gold linker")
+    variant('gold', default=(sys.platform != 'darwin'),
+            description="build the gold linker")
     variant('libiberty', default=False, description='Also install libiberty.')
     variant('nls', default=True, description='Enable Native Language Support')
     variant('headers', default=False, description='Install extra headers (e.g. ELF)')

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -187,6 +187,8 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
     conflicts('languages=jit', when='+nvptx')
     conflicts('languages=objc', when='+nvptx')
     conflicts('languages=obj-c++', when='+nvptx')
+    # NVPTX build disables bootstrap
+    conflicts('+binutils', when='+nvptx')
 
     # Binutils can't build ld on macOS
     conflicts('+binutils', when='platform=darwin')
@@ -295,18 +297,20 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
 
         # Binutils
         if spec.satisfies('+binutils'):
-            ldflags = str(self.rpath_args)
+            stage1_ldflags = str(self.rpath_args)
+            boot_ldflags = stage1_ldflags + ' -static-libstdc++ -static-libgcc'
             if '%gcc' in spec:
-                ldflags += ' -static-libstdc++ -static-libgcc'
+                stage1_ldflags = boot_ldflags
             binutils = spec['binutils'].prefix.bin
             options.extend([
                 '--with-sysroot=/',
-                '--with-stage1-ldflags=' + ldflags,
-                '--with-boot-ldflags=' + ldflags,
+                '--with-stage1-ldflags=' + stage1_ldflags,
+                '--with-boot-ldflags=' + boot_ldflags,
                 '--with-gnu-ld',
                 '--with-ld=' + binutils.ld,
                 '--with-gnu-as',
                 '--with-as=' + binutils.join('as'),
+                '--enable-bootstrap',
             ])
 
         # MPC

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+import sys
 
 
 class Llvm(CMakePackage):
@@ -71,7 +72,7 @@ class Llvm(CMakePackage):
             description="Build the LLVM C++ standard library")
     variant('compiler-rt', default=True,
             description="Build LLVM compiler runtime, including sanitizers")
-    variant('gold', default=True,
+    variant('gold', default=(sys.platform != 'darwin'),
             description="Add support for LTO with the gold linker plugin")
     variant('shared_libs', default=False,
             description="Build all components as shared libraries, faster, "


### PR DESCRIPTION
When binutils builds on macOS, it omits `ld` and other key components. Additionally, `gcc+binutils %clang` sends invalid arguments to the linker since it assumes it's being built with GCC. This MR:
- marks `binutils+gold` as conflicting with `platform=darwin` since `ld.gold` doesn't actually get built in this case;
- marks `gcc+binutils` on darwin as well, for the same reasons
- marks `gcc+binutils+nvptx` as conflicting since `+binutils` requires bootstrapping and `+nvptx` explicitly disables it.

## Configure errors when building with %clang
```
configure: error: C compiler cannot create executables
See `config.log' for more details.
checking for C compiler default output file name... checking for suffix of object files... checking for C compiler default output file name... make[2]: *** [configure-stage1-libdecnumber] Error 77
```
where closer inspection of `spack-src/spack-build/libdecnumber/config.log` shows
```
configure:2649: /ornldev/code/spack/lib/spack/env/clang/clang -g   -Wl,-rpath,/ornldev/code/spack/opt/spack/clang-11.0.0-apple/gcc/f2gezvp/lib -Wl,-rpath,/ornldev/code/spack/opt/spack/clang-11.0.0-apple/gcc/f2gezvp/lib64 -Wl,-rpath,/ornldev/code/spack/opt/spack/clang-11.0.0-apple/binutils/alksglg/lib -Wl,-rpath,/ornldev/code/spack/opt/spack/clang-11.0.0-apple/gmp/icsy6fw/lib -Wl,-rpath,/ornldev/code/spack/opt/spack/clang-11.0.0-apple/isl/uvsapsa/lib -Wl,-rpath,/ornldev/code/spack/opt/spack/clang-11.0.0-apple/libiconv/jg6ekuh/lib -Wl,-rpath,/ornldev/code/spack/opt/spack/clang-11.0.0-apple/mpc/eam5ugi/lib -Wl,-rpath,/ornldev/code/spack/opt/spack/clang-11.0.0-apple/mpfr/pzmx6wv/lib -Wl,-rpath,/ornldev/code/spack/opt/spack/clang-11.0.0-apple/zlib/xj36ejk/lib -static-libstdc++ -static-libgcc -Wl,-no_pie  conftest.c  >&5
clang: error: unsupported option '-static-libgcc'
configure:2653: $? = 1
configure:2690: result: 
configure: failed program was:
| /* confdefs.h */
| #define PACKAGE_NAME "libdecnumber"
| #define PACKAGE_TARNAME "libdecnumber"
| #define PACKAGE_VERSION " "
| #define PACKAGE_STRING "libdecnumber  "
| #define PACKAGE_BUGREPORT "gcc-bugs@gcc.gnu.org"
| #define PACKAGE_URL ""
| /* end confdefs.h.  */
| 
| int
| main ()
| {
| 
|   ;
|   return 0;
| }
configure:2696: error: in `/private/var/folders/fy/x2xtwh1n7fn0_0q2kk29xkv9vvmbqb/T/s3j/spack-stage/spack-stage-gcc-8.3.0-f2gezvpdyzaxh3drmmiz6i2ou22vgbip/spack-src/spack-build/libdecnumber':
configure:2700: error: C compiler cannot create executables
See `config.log' for more details.
```

## After fixing that error but still using +binutils

```
configure: error: cannot execute: /ornldev/code/spack/opt/spack/clang-11.0.0-apple/binutils/alksglg/bin/ld: check --with-ld or env. var. DEFAULT_LINKER
```