### PR TITLE
Buildcache: join rpaths returned by get_existing_elf_rpaths with ':'.

### DIFF
--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -693,7 +693,7 @@ def file_is_relocatable(file, paths_to_relocate=None):
 
     if platform.system().lower() == 'linux':
         if m_subtype == 'x-executable' or m_subtype == 'x-sharedlib':
-            rpaths = set(get_existing_elf_rpaths(file))
+            rpaths = ':'.join(get_existing_elf_rpaths(file))
             set_of_strings.discard(rpaths)
     if platform.system().lower() == 'darwin':
         if m_subtype == 'x-mach-binary':


### PR DESCRIPTION
This reproduces the behavior of spack.relocate.file_is_relocatable(patchelf) expected by test_patchelf_is_relocatable which was broken by
https://github.com/spack/spack/pull/14929
