### PR TITLE
Fix gcc 8.3 build on macOS 10.14

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -197,6 +197,12 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
             # https://trac.macports.org/ticket/56502#no1
             # see also: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=83531
             patch('darwin/headers-10.13-fix.patch', when='@5.5.0')
+        if macos_version() >= Version('10.14'):
+            # Fix system headers for Mojave SDK:
+            # https://github.com/Homebrew/homebrew-core/pull/39041
+            patch('https://raw.githubusercontent.com/Homebrew/formula-patches/master/gcc/8.3.0-xcode-bug-_Atomic-fix.patch',
+                  sha256='33ee92bf678586357ee8ab9d2faddf807e671ad37b97afdd102d5d153d03ca84',
+                  when='@6:8')
         if macos_version() >= Version('10.15'):
             # Fix system headers for Catalina SDK
             # (otherwise __OSX_AVAILABLE_STARTING ends up undefined)


### PR DESCRIPTION
This applies a homebrew patch (https://github.com/Homebrew/homebrew-core/pull/39041) to the spack-installed GCC for version 8.3.

---

Build error before this patch:
```
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/sys/sysctl.h:83,
                 from /var/folders/fy/x2xtwh1n7fn0_0q2kk29xkv9vvmbqb/T/s3j/spack-stage/spack-stage-gcc-8.3.0-qif3yy4p3yh4vq5upji4bqu6l4w6hjww/spack-src/gcc/config/darwin-driver.c:30:
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/sys/ucred.h:94:2: error: '_Atomic' does not name a type
  _Atomic u_long          cr_ref;  /* reference count */
  ^~~~~~~
make[3]: *** [darwin-driver.o] Error 1
```