### PR TITLE
Preliminary libxml2 tests

### DIFF
--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -83,11 +83,9 @@ class Libxml2(AutotoolsPackage):
                 if the test is expected to succeed
         """
         result = 'fail with status {0}'.format(status) if status else 'succeed'
-        tty.msg('test: {0} {1}: expect to {2}'
-                .format(exe, ' '.join(options), result))
+        tty.msg('test: {0}: expect to {1}'.format(exe, result))
         runner = which(exe)
         assert runner is not None
-        assert runner.path == join_path(self.prefix.bin, exe)
 
         try:
             output = runner(*options, output=str.split, error=str.split)

--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -5,6 +5,7 @@
 
 import os
 
+import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 
 from spack import *
@@ -105,6 +106,7 @@ class Libxml2(AutotoolsPackage):
         assert runner is not None
 
         dtd_path = './data/info.dtd'
+        test_fn = 'test.xml'
         exec_checks = {
             'xml2-config': [
                 (['--version'], [str(self.spec.version)], None)],
@@ -112,10 +114,10 @@ class Libxml2(AutotoolsPackage):
                 (['--version'],
                  ['using libxml', str(self.spec.version).replace('.', '0')],
                  None),
-                (['--auto', '-o', 'test.xml'], [], None),
-                (['--postvalid', 'test.xml'],
+                (['--auto', '-o', test_fn], [], None),
+                (['--postvalid', test_fn],
                  ['validity error', 'no DTD found', 'does not validate'], 3),
-                (['--dtdvalid', dtd_path, 'test.xml'],
+                (['--dtdvalid', dtd_path, test_fn],
                  ['validity error', 'does not follow the DTD'], 3),
                 (['--dtdvalid', dtd_path, './data/info.xml'], [], None)],
             'xmlcatalog': [
@@ -128,6 +130,9 @@ class Libxml2(AutotoolsPackage):
                 tty.msg('test: Ensuring \'{0} {1}\' {2}'
                         .format(exe, ' '.join(options), result))
                 self._run_test(runner, options, expected, status)
+
+        # Perform some cleanup
+        fs.force_remove(test_fn)
 
     def test(self):
         """Perform smoke tests on the installed package"""

--- a/var/spack/repos/builtin/packages/libxml2/test/info.dtd
+++ b/var/spack/repos/builtin/packages/libxml2/test/info.dtd
@@ -1,0 +1,2 @@
+<!ELEMENT info (data)>
+<!ELEMENT data (#PCDATA)>

--- a/var/spack/repos/builtin/packages/libxml2/test/info.xml
+++ b/var/spack/repos/builtin/packages/libxml2/test/info.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<info>
+<data>abc</data>
+</info>


### PR DESCRIPTION
This is a set of smoke tests that leverage executables generated by the `libxml2` package.

TODO

- [x] Determine the amount of library usage available in the installed files in `bin`
- [x] Create smoke tests that succeed and fail with `xmllint`
- [x] Refactor `_run_tests` so it can be lifted (and re-used) at the package level