### PR TITLE
Resolve 'Call' object has no attribute 'id'

### DIFF
--- a/lib/spack/spack/util/package_hash.py
+++ b/lib/spack/spack/util/package_hash.py
@@ -43,6 +43,7 @@ class RemoveDirectives(ast.NodeTransformer):
     def is_directive(self, node):
         return (isinstance(node, ast.Expr) and
                 node.value and isinstance(node.value, ast.Call) and
+                isinstance(node.value.func, ast.Name) and
                 node.value.func.id in spack.directives.__all__)
 
     def is_spack_attr(self, node):

--- a/lib/spack/spack/util/package_hash.py
+++ b/lib/spack/spack/util/package_hash.py
@@ -41,6 +41,20 @@ class RemoveDirectives(ast.NodeTransformer):
         self.spec = spec
 
     def is_directive(self, node):
+        """Check to determine if the node is a valid directive
+
+        Directives are assumed to be represented in the AST as a named function
+        call expression.  This means that they will NOT be represented by a
+        named function call within a function call expression (e.g., as
+        callbacks are sometimes represented).
+
+        Args:
+            node (AST): the AST node being checked
+
+        Returns:
+            (bool): ``True`` if the node represents a known directive,
+                ``False`` otherwise
+        """
         return (isinstance(node, ast.Expr) and
                 node.value and isinstance(node.value, ast.Call) and
                 isinstance(node.value.func, ast.Name) and


### PR DESCRIPTION
Fixes #15079 
Duplicates #14763 

Added an extra check to handle a nested `Call` expression in the AST when processing package directives for some packages (e.g., opengl).