### PR TITLE
py-notebook: make py-setuptools a run dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-notebook/package.py
+++ b/var/spack/repos/builtin/packages/py-notebook/package.py
@@ -25,7 +25,7 @@ class PyNotebook(PythonPackage):
 
     depends_on('python@2.7:2.8,3.3:', type=('build', 'run'))
     depends_on('python@3.5:', type=('build', 'run'), when='@6:')
-    depends_on('py-setuptools', type=('build', 'run') , when='@5:')
+    depends_on('py-setuptools', type=('build', 'run'), when='@5:')
     depends_on('py-jinja2', type=('build', 'run'))
     depends_on('py-tornado@4.0:6.999', type=('build', 'run'), when='@:5.7.4')
     depends_on('py-tornado@4.1:6.999', type=('build', 'run'), when='@5.7.5:6.0.1')

--- a/var/spack/repos/builtin/packages/py-notebook/package.py
+++ b/var/spack/repos/builtin/packages/py-notebook/package.py
@@ -25,7 +25,7 @@ class PyNotebook(PythonPackage):
 
     depends_on('python@2.7:2.8,3.3:', type=('build', 'run'))
     depends_on('python@3.5:', type=('build', 'run'), when='@6:')
-    depends_on('py-setuptools', type='build', when='@5:')
+    depends_on('py-setuptools', type=('build', 'run') , when='@5:')
     depends_on('py-jinja2', type=('build', 'run'))
     depends_on('py-tornado@4.0:6.999', type=('build', 'run'), when='@:5.7.4')
     depends_on('py-tornado@4.1:6.999', type=('build', 'run'), when='@5.7.5:6.0.1')


### PR DESCRIPTION
The py-setuptools dependency in py-notebook needs to be a run
dependency. The following message is received if it is not in the run
environment.

Traceback (most recent call last):  File "/opt/ssoft/apps/2020.1/linu
x-centos7-sandybridge/gcc-9.2.0/py-notebook-6.0.1-6usbn4c/bin/jupyter-notebook",
line 6, in <module>
    from pkg_resources import load_entry_point
Module NotFoundError: No module named 'pkg_resources'