### PR TITLE
arpack-ng: ILP64 support

### DIFF
--- a/var/spack/repos/builtin/packages/arpack-ng/package.py
+++ b/var/spack/repos/builtin/packages/arpack-ng/package.py
@@ -108,7 +108,11 @@ class ArpackNg(Package):
         if '+mpi' in spec:
             options.append('-DMPI=ON')
 
-        # TODO: -DINTERFACE64=ON
+        # If 64-bit BLAS is used:
+        if (spec.satisfies('^openblas+ilp64') or
+            spec.satisfies('^intel-mkl+ilp64') or
+            spec.satisfies('^intel-parallel-studio+mkl+ilp64')):
+            options.append('-DINTERFACE64=1')
 
         if '+shared' in spec:
             options.append('-DBUILD_SHARED_LIBS=ON')


### PR DESCRIPTION
Details about ILP64 support: `INTERFACE64=1` are described on the [ARPACK-NG GitHub website](https://github.com/opencollab/arpack-ng).