### PR TITLE
Fixups for jupyter

### DIFF
--- a/var/spack/repos/builtin/packages/py-ipython/package.py
+++ b/var/spack/repos/builtin/packages/py-ipython/package.py
@@ -18,7 +18,8 @@ class PyIpython(PythonPackage):
     version('3.1.0', sha256='532092d3f06f82b1d8d1e5c37097eae19fcf025f8f6a4b670dd49c3c338d5624')
     version('2.3.1', sha256='3e98466aa2fe54540bcba9aa6e01a39f40110d67668c297340c4b9514b7cc49c')
 
-    depends_on('python@2.7:2.8,3.3:')
+    depends_on('python@2.7:2.8,3.3:', type=('build', 'run'), when='@:6')
+    depends_on('python@3.5:', type=('build', 'run'), when='@7:')
 
     depends_on('py-backports-shutil-get-terminal-size', type=('build', 'run'), when="^python@:3.2")
     depends_on('py-pathlib2', type=('build', 'run'), when="^python@:3.3")
@@ -32,5 +33,3 @@ class PyIpython(PythonPackage):
     depends_on('py-pexpect',                    type=('build', 'run'))
     depends_on('py-backcall',                   type=('build', 'run'), when="^python@3.3:")
     depends_on('py-appnope', type=('build', 'run'), when='platform=darwin')
-
-    conflicts('^python@2.7:2.8', when='@7.0.0:')

--- a/var/spack/repos/builtin/packages/py-ipywidgets/package.py
+++ b/var/spack/repos/builtin/packages/py-ipywidgets/package.py
@@ -12,6 +12,7 @@ class PyIpywidgets(PythonPackage):
     homepage = "https://github.com/ipython/ipywidgets"
     url      = "https://github.com/ipython/ipywidgets/archive/5.2.2.tar.gz"
 
+    version('7.5.1', sha256='e4253384886aabbaf10966916a2cf9ffa72551bd045d536fa2a379f14b50cec3')
     version('7.4.2', sha256='f156165e8a855ed862fdf48e72700bdcd6956d089a2018c5b36d358255d45b2b')
     version('5.2.2', sha256='d61ab8bb12b90981a3a6010429816d70eaa041e622043207bcb74239b664d4f3')
 
@@ -23,6 +24,11 @@ class PyIpywidgets(PythonPackage):
     depends_on('py-traitlets@4.2.1:', type=('build', 'run'))
     depends_on('py-traitlets@4.3.1:', type=('build', 'run'), when='@6:')
     depends_on('py-nbformat@4.2.0:', type=('build', 'run'), when='@6:')
-    depends_on('py-widgetsnbextension@3.4.0:3.4.999', type=('build', 'run'), when='@6:')
+    depends_on('py-widgetsnbextension@1.2.6:1.9', type=('build', 'run'),
+               when='@5.2.2')
+    depends_on('py-widgetsnbextension@3.4.0:3.4.999', type=('build', 'run'),
+               when='@7.4.2')
+    depends_on('py-widgetsnbextension@3.5.0:3.5.999', type=('build', 'run'),
+               when='@7.5.1')
     depends_on('py-mock', type='test', when='^python@2.7:2.8')
     depends_on('py-nose', type='test')

--- a/var/spack/repos/builtin/packages/py-jupyter-console/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter-console/package.py
@@ -12,6 +12,7 @@ class PyJupyterConsole(PythonPackage):
     homepage = "https://github.com/jupyter/jupyter_console"
     url      = "https://github.com/jupyter/jupyter_console/archive/5.0.0.tar.gz"
 
+    version('6.1.0', sha256='838c95c99ce52978e1660e7a30dd933dede158e2f4da1bc5fad1a8fad44570b7')
     version('5.2.0', sha256='371d03aeefcf48967f2f00af4c1709f52d2a688deee33f395c6330e4e8aa171c')
     version('5.0.0', sha256='e966b2b5bf9a1e8c5bd11a6335bb11f68ec585ea39b801721b2ed9dd964468fa')
     version('4.1.1', sha256='0bb06a1f878d0c44c2f6f66406a80f949bcd86f3508035500af7dceffb9cc7dc')
@@ -19,8 +20,12 @@ class PyJupyterConsole(PythonPackage):
     version('4.0.3', sha256='b1867a89b693f247e9089a8f367fa4f27af6eac27930cad2966054adfa7b9aa1')
     version('4.0.2', sha256='116a56763899bbb12c762f865372eb52c08619ef070c237c7f1387e192bfd3df')
 
-    depends_on('python@2.7:2.8,3.3:')
+    depends_on('python@2.7:2.8,3.3:', type=('build', 'run'))
+    depends_on('python@3.5:', type=('build', 'run'), when='@6:')
     depends_on('py-jupyter-client', type=('build', 'run'))
+    depends_on('py-ipython@:5.8.0', type=('build', 'run'), when='@:5')
     depends_on('py-ipython', type=('build', 'run'))
     depends_on('py-ipykernel', type=('build', 'run'))
     depends_on('py-pygments', type=('build', 'run'))
+    depends_on('py-prompt-toolkit@1.0.0:1.9', type=('build', 'run'), when='@:5')
+    depends_on('py-prompt-toolkit@2.0.0:2.9,3.0.2:3.1.0', type=('build', 'run'), when='@6:')

--- a/var/spack/repos/builtin/packages/py-jupyter-console/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter-console/package.py
@@ -28,4 +28,4 @@ class PyJupyterConsole(PythonPackage):
     depends_on('py-ipykernel', type=('build', 'run'))
     depends_on('py-pygments', type=('build', 'run'))
     depends_on('py-prompt-toolkit@1.0.0:1.9', type=('build', 'run'), when='@:5')
-    depends_on('py-prompt-toolkit@2.0.0:2.9,3.0.2:3.1.0', type=('build', 'run'), when='@6:')
+    depends_on('py-prompt-toolkit@2.0.0:2.999,3.0.2:3.0.999', type=('build', 'run'), when='@6:')

--- a/var/spack/repos/builtin/packages/py-jupyter-console/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter-console/package.py
@@ -27,5 +27,5 @@ class PyJupyterConsole(PythonPackage):
     depends_on('py-ipython', type=('build', 'run'))
     depends_on('py-ipykernel', type=('build', 'run'))
     depends_on('py-pygments', type=('build', 'run'))
-    depends_on('py-prompt-toolkit@1.0.0:1.9', type=('build', 'run'), when='@:5')
+    depends_on('py-prompt-toolkit@1.0.0:1.999', type=('build', 'run'), when='@:5')
     depends_on('py-prompt-toolkit@2.0.0:2.999,3.0.2:3.0.999', type=('build', 'run'), when='@6:')

--- a/var/spack/repos/builtin/packages/py-pyqt5/package.py
+++ b/var/spack/repos/builtin/packages/py-pyqt5/package.py
@@ -36,6 +36,7 @@ class PyPyqt5(SIPPackage):
     depends_on('qt@5:+opengl')
     depends_on('python@2.6:', type=('build', 'run'))
     depends_on('py-enum34', type=('build', 'run'), when='^python@:3.3')
+    depends_on('py-sip', type=('build', 'run'))
 
     depends_on('qscintilla', when='+qsci')
 
@@ -69,7 +70,7 @@ class PyPyqt5(SIPPackage):
                 pydir = join_path(site_packages_dir, 'PyQt5')
                 python = self.spec['python'].command
                 python('configure.py', '--pyqt=PyQt5',
-                       '--sip=' + self.prefix.bin.sip,
+                       '--sip=' + self.spec['py-sip'].prefix.bin.sip,
                        '--qsci-incdir=' +
                        self.spec['qscintilla'].prefix.include,
                        '--qsci-libdir=' + self.spec['qscintilla'].prefix.lib,
@@ -77,7 +78,7 @@ class PyPyqt5(SIPPackage):
                        '--apidir=' + self.prefix.share.qsci,
                        '--destdir=' + pydir,
                        '--pyqt-sipdir=' + self.prefix.share.sip.PyQt5,
-                       '--sip-incdir=' + python_include_dir,
+                       '--sip-incdir=' + self.spec['py-sip'].prefix.include,
                        '--stubsdir=' + pydir)
 
                 # Fix build errors

--- a/var/spack/repos/builtin/packages/py-pyqt5/package.py
+++ b/var/spack/repos/builtin/packages/py-pyqt5/package.py
@@ -52,7 +52,8 @@ class PyPyqt5(SIPPackage):
         args = [
             '--pyuic5-interpreter', self.spec['python'].command.path,
             '--sipdir', self.prefix.share.sip.PyQt5,
-            '--stubsdir', join_path(self.spec['python'].package.site_packages_dir, 'PyQt5'),
+            '--stubsdir', join_path(
+                self.spec['python'].package.site_packages_dir, 'PyQt5'),
         ]
         if '+qsci' in self.spec:
             args.extend(['--qsci-api-destdir', self.prefix.share.qsci])
@@ -66,7 +67,8 @@ class PyPyqt5(SIPPackage):
                 'spack-resource-qscintilla/QScintilla_gpl-' +
                 str(self.spec['qscintilla'].version), 'Python')
             with working_dir(rsrc_py_path):
-                pydir = join_path(self.spec['python'].package.site_packages_dir, 'PyQt5')
+                pydir = join_path(
+                    self.spec['python'].package.site_packages_dir, 'PyQt5')
                 python = self.spec['python'].command
                 python('configure.py', '--pyqt=PyQt5',
                        '--sip=' + self.prefix.bin.sip,

--- a/var/spack/repos/builtin/packages/py-pyqt5/package.py
+++ b/var/spack/repos/builtin/packages/py-pyqt5/package.py
@@ -36,7 +36,6 @@ class PyPyqt5(SIPPackage):
     depends_on('qt@5:+opengl')
     depends_on('python@2.6:', type=('build', 'run'))
     depends_on('py-enum34', type=('build', 'run'), when='^python@:3.3')
-    depends_on('py-sip', type=('build', 'run'))
 
     depends_on('qscintilla', when='+qsci')
 
@@ -53,7 +52,7 @@ class PyPyqt5(SIPPackage):
         args = [
             '--pyuic5-interpreter', self.spec['python'].command.path,
             '--sipdir', self.prefix.share.sip.PyQt5,
-            '--stubsdir', join_path(self.site_packages_dir, 'PyQt5'),
+            '--stubsdir', join_path(site_packages_dir, 'PyQt5'),
         ]
         if '+qsci' in self.spec:
             args.extend(['--qsci-api-destdir', self.prefix.share.qsci])
@@ -67,10 +66,10 @@ class PyPyqt5(SIPPackage):
                 'spack-resource-qscintilla/QScintilla_gpl-' +
                 str(self.spec['qscintilla'].version), 'Python')
             with working_dir(rsrc_py_path):
-                pydir = join_path(self.site_packages_dir, 'PyQt5')
+                pydir = join_path(site_packages_dir, 'PyQt5')
                 python = self.spec['python'].command
                 python('configure.py', '--pyqt=PyQt5',
-                       '--sip=' + self.spec['py-sip'].prefix.bin.sip,
+                       '--sip=' + self.prefix.bin.sip,
                        '--qsci-incdir=' +
                        self.spec['qscintilla'].prefix.include,
                        '--qsci-libdir=' + self.spec['qscintilla'].prefix.lib,
@@ -78,7 +77,7 @@ class PyPyqt5(SIPPackage):
                        '--apidir=' + self.prefix.share.qsci,
                        '--destdir=' + pydir,
                        '--pyqt-sipdir=' + self.prefix.share.sip.PyQt5,
-                       '--sip-incdir=' + self.spec['py-sip'].prefix.include,
+                       '--sip-incdir=' + python_include_dir,
                        '--stubsdir=' + pydir)
 
                 # Fix build errors

--- a/var/spack/repos/builtin/packages/py-pyqt5/package.py
+++ b/var/spack/repos/builtin/packages/py-pyqt5/package.py
@@ -52,7 +52,7 @@ class PyPyqt5(SIPPackage):
         args = [
             '--pyuic5-interpreter', self.spec['python'].command.path,
             '--sipdir', self.prefix.share.sip.PyQt5,
-            '--stubsdir', join_path(
+            '--stubsdir', join_path(self.prefix,
                 self.spec['python'].package.site_packages_dir, 'PyQt5'),
         ]
         if '+qsci' in self.spec:
@@ -67,7 +67,7 @@ class PyPyqt5(SIPPackage):
                 'spack-resource-qscintilla/QScintilla_gpl-' +
                 str(self.spec['qscintilla'].version), 'Python')
             with working_dir(rsrc_py_path):
-                pydir = join_path(
+                pydir = join_path(self.prefix,
                     self.spec['python'].package.site_packages_dir, 'PyQt5')
                 python = self.spec['python'].command
                 python('configure.py', '--pyqt=PyQt5',

--- a/var/spack/repos/builtin/packages/py-pyqt5/package.py
+++ b/var/spack/repos/builtin/packages/py-pyqt5/package.py
@@ -52,7 +52,7 @@ class PyPyqt5(SIPPackage):
         args = [
             '--pyuic5-interpreter', self.spec['python'].command.path,
             '--sipdir', self.prefix.share.sip.PyQt5,
-            '--stubsdir', join_path(site_packages_dir, 'PyQt5'),
+            '--stubsdir', join_path(self.spec['python'].package.site_packages_dir, 'PyQt5'),
         ]
         if '+qsci' in self.spec:
             args.extend(['--qsci-api-destdir', self.prefix.share.qsci])
@@ -66,7 +66,7 @@ class PyPyqt5(SIPPackage):
                 'spack-resource-qscintilla/QScintilla_gpl-' +
                 str(self.spec['qscintilla'].version), 'Python')
             with working_dir(rsrc_py_path):
-                pydir = join_path(site_packages_dir, 'PyQt5')
+                pydir = join_path(self.spec['python'].package.site_packages_dir, 'PyQt5')
                 python = self.spec['python'].command
                 python('configure.py', '--pyqt=PyQt5',
                        '--sip=' + self.prefix.bin.sip,

--- a/var/spack/repos/builtin/packages/py-pyqt5/package.py
+++ b/var/spack/repos/builtin/packages/py-pyqt5/package.py
@@ -53,7 +53,7 @@ class PyPyqt5(SIPPackage):
         args = [
             '--pyuic5-interpreter', self.spec['python'].command.path,
             '--sipdir', self.prefix.share.sip.PyQt5,
-            '--stubsdir', join_path(site_packages_dir, 'PyQt5'),
+            '--stubsdir', join_path(self.site_packages_dir, 'PyQt5'),
         ]
         if '+qsci' in self.spec:
             args.extend(['--qsci-api-destdir', self.prefix.share.qsci])
@@ -67,7 +67,7 @@ class PyPyqt5(SIPPackage):
                 'spack-resource-qscintilla/QScintilla_gpl-' +
                 str(self.spec['qscintilla'].version), 'Python')
             with working_dir(rsrc_py_path):
-                pydir = join_path(site_packages_dir, 'PyQt5')
+                pydir = join_path(self.site_packages_dir, 'PyQt5')
                 python = self.spec['python'].command
                 python('configure.py', '--pyqt=PyQt5',
                        '--sip=' + self.spec['py-sip'].prefix.bin.sip,

--- a/var/spack/repos/builtin/packages/py-pyqt5/package.py
+++ b/var/spack/repos/builtin/packages/py-pyqt5/package.py
@@ -52,8 +52,10 @@ class PyPyqt5(SIPPackage):
         args = [
             '--pyuic5-interpreter', self.spec['python'].command.path,
             '--sipdir', self.prefix.share.sip.PyQt5,
-            '--stubsdir', join_path(self.prefix,
-                self.spec['python'].package.site_packages_dir, 'PyQt5'),
+            '--stubsdir', join_path(
+                self.prefix,
+                self.spec['python'].package.site_packages_dir,
+                'PyQt5'),
         ]
         if '+qsci' in self.spec:
             args.extend(['--qsci-api-destdir', self.prefix.share.qsci])
@@ -67,8 +69,10 @@ class PyPyqt5(SIPPackage):
                 'spack-resource-qscintilla/QScintilla_gpl-' +
                 str(self.spec['qscintilla'].version), 'Python')
             with working_dir(rsrc_py_path):
-                pydir = join_path(self.prefix,
-                    self.spec['python'].package.site_packages_dir, 'PyQt5')
+                pydir = join_path(
+                    self.prefix,
+                    self.spec['python'].package.site_packages_dir,
+                    'PyQt5')
                 python = self.spec['python'].command
                 python('configure.py', '--pyqt=PyQt5',
                        '--sip=' + self.prefix.bin.sip,

--- a/var/spack/repos/builtin/packages/py-qtconsole/package.py
+++ b/var/spack/repos/builtin/packages/py-qtconsole/package.py
@@ -25,5 +25,6 @@ class PyQtconsole(PythonPackage):
     depends_on('py-traitlets',           type=('build', 'run'))
     depends_on('py-ipython-genutils',    type=('build', 'run'), when='@4.5.1:')
     depends_on('py-sphinx@1.3:',         type=('build', 'run'), when='+docs')
+    depends_on('py-pyqt5',               type=('build', 'run'))
 
     depends_on('py-mock', type='test', when='^python@2.7:2.8')

--- a/var/spack/repos/builtin/packages/py-qtconsole/package.py
+++ b/var/spack/repos/builtin/packages/py-qtconsole/package.py
@@ -17,7 +17,7 @@ class PyQtconsole(PythonPackage):
 
     variant('doc', default=False, description='Build documentation')
 
-    depends_on('python@2.7:2.8,3.3:', type=('build', 'run'))
+    depends_on('python@2.7:2.8,3.3:',    type=('build', 'run'))
     depends_on('py-ipykernel@4.1:',      type=('build', 'run'))
     depends_on('py-jupyter-client@4.1:', type=('build', 'run'))
     depends_on('py-jupyter-core',        type=('build', 'run'))
@@ -25,6 +25,6 @@ class PyQtconsole(PythonPackage):
     depends_on('py-traitlets',           type=('build', 'run'))
     depends_on('py-ipython-genutils',    type=('build', 'run'), when='@4.5.1:')
     depends_on('py-sphinx@1.3:',         type=('build', 'run'), when='+docs')
-    depends_on('py-pyqt5',               type=('build', 'run'))
+    depends_on('py-pyqt5',               type='run')
 
     depends_on('py-mock', type='test', when='^python@2.7:2.8')


### PR DESCRIPTION
This PR fixes a few things for some jupyter related packages.

py-ipython:
- make the python depends_on statements reflect needs of different
  versions
- remove an unneeded conflicts directive

py-ipywidgets:
- add new version
- set version constraints for py-widgetsnbextension

py-jupyter-console
- add new version
- set python dependencies for versions as needed
- set version constraint for py-ipython
- set version constraints for py-prompt-toolkit

py-pyqt5
- build with py-sip

py-qtconsole
- add dependency on py-pyqt5