### PR TITLE
Added additional raja versions

### DIFF
--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -14,6 +14,9 @@ class Raja(CMakePackage):
 
     version('develop', branch='develop', submodules='True')
     version('master',  branch='master',  submodules='True')
+    version('0.11.0', tag='v0.11.0', submodules="True")
+    version('0.10.0', tag='v0.10.0', submodules="True")
+    version('0.9.0', tag='v0.9.0', submodules="True")
     version('0.8.0', tag='v0.8.0', submodules="True")
     version('0.7.0', tag='v0.7.0', submodules="True")
     version('0.6.0', tag='v0.6.0', submodules="True")


### PR DESCRIPTION
Updating the raja versions so I can use the newest raja features.

It would be really nice if spack had something like [uscan](https://manpages.debian.org/buster/devscripts/uscan.1.en.html) in debian to automatically add new versions to the package as they become available.