### PR TITLE
pdt: Add clang compiler

### DIFF
--- a/var/spack/repos/builtin/packages/pdt/package.py
+++ b/var/spack/repos/builtin/packages/pdt/package.py
@@ -45,6 +45,8 @@ class Pdt(AutotoolsPackage):
             options.append('-pgCC')
         elif self.compiler.name == 'gcc':
             options.append('-GNU')
+        elif self.compiler.name == 'clang':
+            options.append('-clang')
         else:
             raise InstallError('Unknown/unsupported compiler family')
 


### PR DESCRIPTION
Add ability to build with clang compiler. Tested and working on

Power9, Red Hat Enterprise Linux Server release 7.6 (Maipo)
x86, Ubuntu 19.04
aarch64, Ubuntu 19.04

with `clang@8.0.X`.

Pinging @khuck 