### PR TITLE
Fix silex build 

### DIFF
--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -32,13 +32,20 @@ class Silo(AutotoolsPackage):
     depends_on('mpi', when='+mpi')
     depends_on('hdf5+mpi', when='+mpi')
     depends_on('qt@4.8:4.9', when='+silex')
+    depends_on('readline')
     depends_on('zlib')
 
     patch('remove-mpiposix.patch', when='@4.8:4.10.2')
 
     def flag_handler(self, name, flags):
-        if name == 'ldflags' and self.spec['hdf5'].satisfies('~shared'):
-            flags.append('-ldl')
+        spec = self.spec
+        if name == 'ldflags':
+            if spec['hdf5'].satisfies('~shared'):
+                flags.append('-ldl')
+            flags.append(spec['readline'].libs.search_flags)
+        elif name in ('cflags', 'cxxflags', 'fcflags'):
+            if '+pic' in spec:
+                flags.append(self.compiler.pic_flag)
         return (flags, None, None)
 
     @when('%clang@9:')
@@ -82,12 +89,6 @@ class Silo(AutotoolsPackage):
 
         if '+silex' in spec:
             config_args.append('--with-Qt-dir=%s' % spec['qt'].prefix)
-
-        if '+pic' in spec:
-            config_args += [
-                'CFLAGS={0}'.format(self.compiler.pic_flag),
-                'CXXFLAGS={0}'.format(self.compiler.pic_flag),
-                'FCFLAGS={0}'.format(self.compiler.pic_flag)]
 
         if '+mpi' in spec:
             config_args.append('CC=%s' % spec['mpi'].mpicc)

--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -31,7 +31,8 @@ class Silo(AutotoolsPackage):
     depends_on('hdf5~mpi', when='~mpi')
     depends_on('mpi', when='+mpi')
     depends_on('hdf5+mpi', when='+mpi')
-    depends_on('qt@4.8:4.9', when='+silex')
+    depends_on('qt~framework@4.8:4.9', when='+silex')
+    depends_on('libx11', when='+silex')
     depends_on('readline')
     depends_on('zlib')
 
@@ -88,7 +89,13 @@ class Silo(AutotoolsPackage):
         ]
 
         if '+silex' in spec:
-            config_args.append('--with-Qt-dir=%s' % spec['qt'].prefix)
+            x = spec['libx11']
+            config_args.extend([
+                '--with-Qt-dir=' + spec['qt'].prefix,
+                '--with-Qt-lib=QtGui -lQtCore',
+                '--x-includes=' + x.prefix.include,
+                '--x-libraries=' + x.prefix.lib,
+            ])
 
         if '+mpi' in spec:
             config_args.append('CC=%s' % spec['mpi'].mpicc)

--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -31,7 +31,7 @@ class Silo(AutotoolsPackage):
     depends_on('hdf5~mpi', when='~mpi')
     depends_on('mpi', when='+mpi')
     depends_on('hdf5+mpi', when='+mpi')
-    depends_on('qt', when='+silex')
+    depends_on('qt@4.8:4.9', when='+silex')
     depends_on('zlib')
 
     patch('remove-mpiposix.patch', when='@4.8:4.10.2')


### PR DESCRIPTION
I don't think `silo+silex` has ever compiled correctly before now. With this fix I can successfully build on my mac (and so it's even more likely to build on windows).

- Restrict to QT4
- Specify QT libs so `autoconf` doesn't default to choosing the alphabetical first library (libqt3support)
- Specify x11 lib and includes
- Add another general missing dependency on readline

Fixes https://github.com/spack/spack/issues/5154