### PR TITLE
remove catch-all exception handling in buildcache command

### DIFF
--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -361,13 +361,9 @@ def _createtarball(env, spec_yaml, packages, directory, key, no_deps, force,
 
     for spec in specs:
         tty.msg('creating binary cache file for package %s ' % spec.format())
-        try:
-            bindist.build_tarball(spec, outdir, force, rel,
-                                  unsigned, allow_root, signkey,
-                                  not no_rebuild_index)
-        except Exception as e:
-            tty.warn('%s' % e)
-            pass
+        bindist.build_tarball(spec, outdir, force, rel,
+                              unsigned, allow_root, signkey,
+                              not no_rebuild_index)
 
 
 def createtarball(args):

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -3,7 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import errno
 import platform
+import os
 
 import pytest
 
@@ -41,3 +43,12 @@ def test_buildcache_list_duplicates(mock_get_specs, capsys):
         output = buildcache('list', 'mpileaks', '@2.3')
 
     assert output.count('mpileaks') == 3
+
+
+def test_buildcache_create_fail_on_perm_denied(tmpdir_factory):
+    """Ensure that buildcache create fails on permission denied error."""
+    tmpdir = str(tmpdir_factory.mktemp('mock_buildcache'))
+    os.chmod(tmpdir, 0)
+    with pytest.raises(OSError) as error:
+        buildcache('create', '-d', tmpdir, '--unsigned', 'zlib')
+    assert error.value.errno == errno.EACCES

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -5,7 +5,6 @@
 
 import errno
 import platform
-import os
 
 import pytest
 
@@ -13,6 +12,7 @@ import spack.main
 import spack.binary_distribution
 
 buildcache = spack.main.SpackCommand('buildcache')
+install = spack.main.SpackCommand('install')
 
 
 @pytest.fixture()
@@ -45,10 +45,14 @@ def test_buildcache_list_duplicates(mock_get_specs, capsys):
     assert output.count('mpileaks') == 3
 
 
-def test_buildcache_create_fail_on_perm_denied(tmpdir_factory):
+def test_buildcache_create_fail_on_perm_denied(
+        install_mockery, mock_fetch, monkeypatch, tmpdir):
     """Ensure that buildcache create fails on permission denied error."""
-    tmpdir = str(tmpdir_factory.mktemp('mock_buildcache'))
-    os.chmod(tmpdir, 0)
+    install('trivial-install-test-package')
+
+    tmpdir.chmod(0)
     with pytest.raises(OSError) as error:
-        buildcache('create', '-d', tmpdir, '--unsigned', 'zlib')
+        buildcache('create', '-d', str(tmpdir),
+                   '--unsigned', 'trivial-install-test-package')
     assert error.value.errno == errno.EACCES
+    tmpdir.chmod(0o700)

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -205,6 +205,8 @@ def push_to_url(
                     # needs to be done in separate steps.
                     shutil.copy2(local_file_path, remote_file_path)
                     os.remove(local_file_path)
+                else:
+                    raise
 
     elif remote_url.scheme == 's3':
         if extra_args is None:


### PR DESCRIPTION
Closes #15157 
Issue originally identified in #15090