### PR TITLE
add new charmpp backend

### DIFF
--- a/var/spack/repos/builtin/packages/charmpp/package.py
+++ b/var/spack/repos/builtin/packages/charmpp/package.py
@@ -56,11 +56,11 @@ class Charmpp(Package):
         "backend",
         default="netlrts",
         values=("mpi", "multicore", "netlrts", "verbs", "gni",
-                "ucx","ofi", "pami", "pamilrts"),
+                "ucx", "ofi", "pami", "pamilrts"),
         description="Set the backend to use"
     )
 
-    #https://github.com/UIUC-PPL/charm/issues/2477
+    # https://github.com/UIUC-PPL/charm/issues/2477
     variant(
         "ucx-pmi",
         default="simplePMI",
@@ -204,7 +204,7 @@ class Charmpp(Package):
                 for libdir in spec["mpi"].libs.directories
             ])
 
-        if "backend=ucx" in spec :
+        if "backend=ucx" in spec:
             options.extend(["--basedir=%s" % spec["ucx"].prefix])
         if "+papi" in spec:
             options.extend(["papi", "--basedir=%s" % spec["papi"].prefix])

--- a/var/spack/repos/builtin/packages/charmpp/package.py
+++ b/var/spack/repos/builtin/packages/charmpp/package.py
@@ -63,7 +63,7 @@ class Charmpp(Package):
     #https://github.com/UIUC-PPL/charm/issues/2477
     variant(
         "ucx-pmi",
-        defaults="simplePMI",
+        default="simplePMI",
         values=("simplePMI", "slrumPMI", "slurmPMI2", "PMIx")
     )
 

--- a/var/spack/repos/builtin/packages/charmpp/package.py
+++ b/var/spack/repos/builtin/packages/charmpp/package.py
@@ -65,6 +65,7 @@ class Charmpp(Package):
         "ucx-pmi",
         default="simplePMI",
         values=("simplePMI", "slrumPMI", "slurmPMI2", "PMIx")
+        description="The ucx backend needs PMI to run!"
     )
 
     # Other options

--- a/var/spack/repos/builtin/packages/charmpp/package.py
+++ b/var/spack/repos/builtin/packages/charmpp/package.py
@@ -64,8 +64,8 @@ class Charmpp(Package):
     variant(
         "ucx-pmi",
         default="simplePMI",
-        values=("simplePMI", "slrumPMI", "slurmPMI2", "PMIx")
-        description="The ucx backend needs PMI to run!",
+        values=("simplePMI", "slrumPMI", "slurmPMI2", "PMIx"),
+        description="The ucx backend needs PMI to run!"
     )
 
     # Other options

--- a/var/spack/repos/builtin/packages/charmpp/package.py
+++ b/var/spack/repos/builtin/packages/charmpp/package.py
@@ -64,7 +64,7 @@ class Charmpp(Package):
     variant(
         "ucx-pmi",
         default="simplePMI",
-        values=("simplePMI", "slrumPMI", "slurmPMI2", "PMIx"),
+        values=("simplePMI", "slurmPMI", "slurmPMI2", "PMIx"),
         description="The ucx backend needs PMI to run!"
     )
 

--- a/var/spack/repos/builtin/packages/charmpp/package.py
+++ b/var/spack/repos/builtin/packages/charmpp/package.py
@@ -65,7 +65,7 @@ class Charmpp(Package):
         "ucx-pmi",
         default="simplePMI",
         values=("simplePMI", "slrumPMI", "slurmPMI2", "PMIx")
-        description="The ucx backend needs PMI to run!"
+        description="The ucx backend needs PMI to run!",
     )
 
     # Other options

--- a/var/spack/repos/builtin/packages/charmpp/package.py
+++ b/var/spack/repos/builtin/packages/charmpp/package.py
@@ -18,10 +18,10 @@ class Charmpp(Package):
     (your laptop) to the largest supercomputers."""
 
     homepage = "http://charmplusplus.org"
-    url      = "https://charm.cs.illinois.edu/distrib/charm-6.8.2.tar.gz"
+    url      = "https://github.com/UIUC-PPL/charm/archive/v6.10.0.tar.gz"
     git      = "https://github.com/UIUC-PPL/charm.git"
 
-    version("develop", branch="charm")
+    version("develop", branch="master")
     version('6.10.0', sha256='7c526a78aa0c202b7f0418b345138e7dc40496f0bb7b9e301e0381980450b25c')
     version("6.9.0", sha256="85ed660e46eeb7a6fc6b32deab08226f647c244241948f6b592ebcd2b6050cbd")
     version("6.8.2", sha256="08e6001b0e9cd00ebde179f76098767149bf7e454f29028fb9a8bfb55778698e")
@@ -263,13 +263,14 @@ class Charmpp(Package):
                         pass
         shutil.rmtree(join_path(prefix, "tmp"))
 
-        # A broken 'doc' link in the prefix can break the build.
-        # Remove it and replace it if it is broken.
-        try:
-            os.stat(prefix.doc)
-        except OSError:
-            os.remove(prefix.doc)
-            mkdirp(prefix.doc)
+        if self.spec.satisfies('@6.9.99'):
+            # A broken 'doc' link in the prefix can break the build.
+            # Remove it and replace it if it is broken.
+            try:
+                os.stat(prefix.doc)
+            except OSError:
+                os.remove(prefix.doc)
+                mkdirp(prefix.doc)
 
     @run_after('install')
     @on_package_attributes(run_tests=True)

--- a/var/spack/repos/builtin/packages/charmpp/package.py
+++ b/var/spack/repos/builtin/packages/charmpp/package.py
@@ -110,7 +110,7 @@ class Charmpp(Package):
     depends_on("ucx", when="backend=ucx")
     depends_on("slurm@:17-11-9-2", when="ucx-pmi=slurmPMI")
     depends_on("slurm@17-11-9-2:", when="ucx-pmi=slurmPMI2")
-    depends_on("openmpi+pmi+ucx", when="ucx-pmi=PMIx")
+    depends_on("openmpi+pmi backend=ucx", when="ucx-pmi=PMIx")
 
     # Git versions of Charm++ require automake and autoconf
     depends_on("automake", when="@develop")

--- a/var/spack/repos/builtin/packages/charmpp/package.py
+++ b/var/spack/repos/builtin/packages/charmpp/package.py
@@ -110,7 +110,7 @@ class Charmpp(Package):
     depends_on("ucx", when="backend=ucx")
     depends_on("slurm@:17-11-9-2", when="ucx-pmi=slurmPMI")
     depends_on("slurm@17-11-9-2:", when="ucx-pmi=slurmPMI2")
-    depends_on("openmpi+pmi backend=ucx", when="ucx-pmi=PMIx")
+    depends_on("openmpi+pmi fabrics=ucx", when="ucx-pmi=PMIx")
 
     # Git versions of Charm++ require automake and autoconf
     depends_on("automake", when="@develop")


### PR DESCRIPTION
As per https://github.com/UIUC-PPL/charm/issues/2477, an extra configuration step is needed when `backend=ucx`, hence I added a variant `ucx_pmi`. The default setting of `ucx_pmi` does not break the current logic but I'm not sure if there is a better way to do this (which would require a variant that is defined only if another variant is set to a particular value! ).

The doc error no longer exists for the latest charmpp release, hence it should only be fixed for older versions.

Fetching the latest version fails on develop, thus I switched to the github url but the checksums don't match. Perhaps someone who knows more about this package can point out what's going on. 
```
[sajid@xrmlite ~]$ cd ~/packages/spack/ && git checkout develop && git log -n 1  && spack fetch charmpp@6.10.0
Already on 'develop'
Your branch is up to date with 'origin/develop'.
commit 9b3f5f3890025494ffa620d144d22a4734c8fcee (HEAD -> develop, upstream/develop, origin/develop, origin/HEAD)
Author: ktsai7 <35276356+ktsai7@users.noreply.github.com>
Date:   Mon Feb 24 12:22:25 2020 -0700

    update flecsi and legion package.py (#15159)

    * update flecsi and legion package.py

    * comment out a conflict

    * update to use extend
==> Fetching from /home/sajid/packages/spack/var/spack/cache/_source-cache/archive/7c/7c526a78aa0c202b7f0418b345138e7dc40496f0bb7b9e301e0381980450b25c.tar.gz failed.
==> Fetching file:///tmp/pytest-of-sajid/pytest-7/test_ci_rebuild_basic0/working_dir/local_mirror/charmpp/charmpp-6.10.0.tar.gz
curl: (37) Couldn't open file /tmp/pytest-of-sajid/pytest-7/test_ci_rebuild_basic0/working_dir/local_mirror/charmpp/charmpp-6.10.0.tar.gz
==> Failed to fetch file from URL: file:///tmp/pytest-of-sajid/pytest-7/test_ci_rebuild_basic0/working_dir/local_mirror/charmpp/charmpp-6.10.0.tar.gz
    Curl failed with error 37
==> Fetching from file:///tmp/pytest-of-sajid/pytest-7/test_ci_rebuild_basic0/working_dir/local_mirror/charmpp/charmpp-6.10.0.tar.gz failed.
==> Fetching file:///tmp/pytest-of-sajid/pytest-7/test_ci_rebuild_basic0/working_dir/local_mirror/_source-cache/archive/7c/7c526a78aa0c202b7f0418b345138e7dc40496f0bb7b9e301e0381980450b25c.tar.gz
curl: (37) Couldn't open file /tmp/pytest-of-sajid/pytest-7/test_ci_rebuild_basic0/working_dir/local_mirror/_source-cache/archive/7c/7c526a78aa0c202b7f0418b345138e7dc40496f0bb7b9e301e0381980450b25c.tar.gz
==> Failed to fetch file from URL: file:///tmp/pytest-of-sajid/pytest-7/test_ci_rebuild_basic0/working_dir/local_mirror/_source-cache/archive/7c/7c526a78aa0c202b7f0418b345138e7dc40496f0bb7b9e301e0381980450b25c.tar.gz
    Curl failed with error 37
==> Fetching from file:///tmp/pytest-of-sajid/pytest-7/test_ci_rebuild_basic0/working_dir/local_mirror/_source-cache/archive/7c/7c526a78aa0c202b7f0418b345138e7dc40496f0bb7b9e301e0381980450b25c.tar.gz failed.
==> Fetching https://charm.cs.illinois.edu/distrib/charm-6.10.0.tar.gz

curl: (35) error:1425F102:SSL routines:ssl_choose_client_version:unsupported protocol
==> Failed to fetch file from URL: https://charm.cs.illinois.edu/distrib/charm-6.10.0.tar.gz
    Curl failed with error 35
==> Fetching from https://charm.cs.illinois.edu/distrib/charm-6.10.0.tar.gz failed.
==> Error: All fetchers failed for spack-stage-charmpp-6.10.0-tirx7n7uwlvu7qok5etanggopadumynv
[sajid@xrmlite spack]$
``` 


Requesting @matthiasdiener for review.
