### PR TITLE
Updates to TAU package

### DIFF
--- a/var/spack/repos/builtin/packages/tau/package.py
+++ b/var/spack/repos/builtin/packages/tau/package.py
@@ -67,6 +67,8 @@ class Tau(Package):
     variant('cuda', default=False, description='Activates CUDA support')
     variant('fortran', default=darwin_default, description='Activates Fortran support')
     variant('io', default=True, description='Activates POSIX I/O support')
+    variant('adios2', default=False, description='Activates ADIOS2 output support')
+    variant('sqlite', default=True, description='Activates SQLite3 output support')
 
     # Support cross compiling.
     # This is a _reasonable_ subset of the full set of TAU
@@ -88,9 +90,11 @@ class Tau(Package):
     depends_on('binutils+libiberty+headers~nls', when='+binutils')
     depends_on('python@2.7:', when='+python')
     depends_on('libunwind', when='+libunwind')
-    depends_on('mpi', when='+mpi')
+    depends_on('mpi', when='+mpi', type=('build', 'run', 'link'))
     depends_on('cuda', when='+cuda')
     depends_on('gasnet', when='+gasnet')
+    depends_on('adios2', when='+adios2')
+    depends_on('sqlite', when='+sqlite')
 
     # Elf only required from 2.28.1 on
     conflicts('+libelf', when='@:2.28.0')
@@ -145,8 +149,7 @@ class Tau(Package):
         # TAU configure, despite the name , seems to be a manually
         # written script (nothing related to autotools).  As such it has
         # a few #peculiarities# that make this build quite hackish.
-        options = ["-prefix=%s" % prefix,
-                   "-iowrapper"]
+        options = ["-prefix=%s" % prefix]
 
         if '+craycnl' in spec:
             options.append('-arch=craycnl')
@@ -206,6 +209,11 @@ class Tau(Package):
             options.append("-otf=%s" % spec['otf2'].prefix)
 
         if '+mpi' in spec:
+            env['CC'] = spec['mpi'].mpicc
+            env['CXX'] = spec['mpi'].mpicxx
+            env['F77'] = spec['mpi'].mpif77
+            env['FC'] = spec['mpi'].mpifc
+
             options.append('-mpi')
             if '+comm' in spec:
                 options.append('-PROFILECOMMUNICATORS')
@@ -218,6 +226,12 @@ class Tau(Package):
 
         if '+cuda' in spec:
             options.append("-cuda=%s" % spec['cuda'].prefix)
+
+        if '+adios2' in spec:
+            options.append("-adios=%s" % spec['adios2'].prefix)
+
+        if '+sqlite' in spec:
+            options.append("-sqlite3=%s" % spec['sqlite'].prefix)
 
         if '+phase' in spec:
             options.append('-PROFILEPHASE')


### PR DESCRIPTION
2 changes:

1) Adding ADIOS2 and SQLite3 output support to TAU.  Also fixing MPI include and library paths.
2) Setup package to use MPI the way Spack recommends, and remove extra -iowrapper option from configure.