### PR TITLE
Buildcache cmd:  add install -o/--otherarch option for installing macOS buildcaches on linux

### DIFF
--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -76,6 +76,10 @@ def setup_parser(subparser):
     install.add_argument('-u', '--unsigned', action='store_true',
                          help="install unsigned buildcache" +
                               " tarballs for testing")
+    install.add_argument('-o', '--otherarch', action='store_true',
+                         help="install specs from other architectures" +
+                              " instead of default platform and OS")
+
     arguments.add_common_arguments(install, ['specs'])
     install.set_defaults(func=installtarball)
 
@@ -252,7 +256,8 @@ def find_matching_specs(pkgs, allow_multiple_matches=False, env=None):
     return specs_from_cli
 
 
-def match_downloaded_specs(pkgs, allow_multiple_matches=False, force=False):
+def match_downloaded_specs(pkgs, allow_multiple_matches=False, force=False,
+                           other_arch=False):
     """Returns a list of specs matching the not necessarily
        concretized specs given from cli
 
@@ -266,7 +271,7 @@ def match_downloaded_specs(pkgs, allow_multiple_matches=False, force=False):
     # List of specs that match expressions given via command line
     specs_from_cli = []
     has_errors = False
-    allarch = False
+    allarch = other_arch
     specs = bindist.get_specs(force, allarch)
     for pkg in pkgs:
         matches = []
@@ -387,7 +392,8 @@ def installtarball(args):
         tty.die("build cache file installation requires" +
                 " at least one package spec argument")
     pkgs = set(args.specs)
-    matches = match_downloaded_specs(pkgs, args.multiple, args.force)
+    matches = match_downloaded_specs(pkgs, args.multiple, args.force,
+                                     args.otherarch)
 
     for match in matches:
         install_tarball(match, args)

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -391,7 +391,7 @@ _spack_buildcache_create() {
 _spack_buildcache_install() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -f --force -m --multiple -a --allow-root -u --unsigned"
+        SPACK_COMPREPLY="-h --help -f --force -m --multiple -a --allow-root -u --unsigned -o --otherarch"
     else
         _all_packages
     fi


### PR DESCRIPTION
This allows get_specs to download spec for buildcaches from other OS. For example you can install macOS buildaches on linux (with the appropriate fake compiler entry for clang on macOS).