### PR TITLE
libhio: specify use of external json

### DIFF
--- a/var/spack/repos/builtin/packages/libhio/package.py
+++ b/var/spack/repos/builtin/packages/libhio/package.py
@@ -56,7 +56,7 @@ class Libhio(AutotoolsPackage):
         args.append('--with-external_bz2={0}'.format(spec['bzip2'].prefix))
         if '+hdf5' in spec:
             args.append('--with-hdf5={0}'.format(spec['hdf5'].prefix))
-            
+
         args.append('--with-external-json={0}'.format(spec['json-c'].prefix))
 
         return args

--- a/var/spack/repos/builtin/packages/libhio/package.py
+++ b/var/spack/repos/builtin/packages/libhio/package.py
@@ -59,5 +59,4 @@ class Libhio(AutotoolsPackage):
             
         args.append('--with-external-json={0}'.format(spec['json-c'].prefix))
 
-
         return args

--- a/var/spack/repos/builtin/packages/libhio/package.py
+++ b/var/spack/repos/builtin/packages/libhio/package.py
@@ -56,5 +56,8 @@ class Libhio(AutotoolsPackage):
         args.append('--with-external_bz2={0}'.format(spec['bzip2'].prefix))
         if '+hdf5' in spec:
             args.append('--with-hdf5={0}'.format(spec['hdf5'].prefix))
+            
+        args.append('--with-external-json={0}'.format(spec['json-c'].prefix))
+
 
         return args


### PR DESCRIPTION
libhio has been building it's own json.  With this change, libhio will rely on the json installed by spack.