### PR TITLE
snap-korf: updated package

### DIFF
--- a/var/spack/repos/builtin/packages/snap-korf/package.py
+++ b/var/spack/repos/builtin/packages/snap-korf/package.py
@@ -21,7 +21,10 @@ class SnapKorf(MakefilePackage):
     depends_on('sqlite')
     depends_on('sparsehash')
 
-    conflicts('%gcc@5:', when='@2013-11-29')
+    patch('snap-korf_2013-11-29_gcc8.patch', when='%gcc@8:', working_dir='./Zoe')
+    patch('snap-korf_2013-11-29_gcc8.patch2', when='%gcc@8:')
+    
+    conflicts('%gcc@5', when='@2013-11-29')
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)


### PR DESCRIPTION
Snap doesn't compile without this little not beautiful modification as stated here:
https://www.biostars.org/p/302712
To my understanding this is the same patch applied by debian in the snap package.