### PR TITLE
Hack to select iconv implementation - libiconv vs. libc iconv. 

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -27,6 +27,7 @@ packages:
       glx: [mesa+glx, opengl]
       glu: [mesa-glu, openglu]
       golang: [gcc]
+      iconv: [libiconv]
       ipp: [intel-ipp]
       java: [openjdk, jdk, ibm-java]
       jpeg: [libjpeg-turbo, libjpeg]

--- a/var/spack/repos/builtin/packages/apr-util/package.py
+++ b/var/spack/repos/builtin/packages/apr-util/package.py
@@ -24,7 +24,7 @@ class AprUtil(AutotoolsPackage):
 
     depends_on('apr')
     depends_on('expat')
-    depends_on('libiconv')
+    depends_on('iconv')
 
     depends_on('openssl', when='+crypto')
     depends_on('gdbm', when='+gdbm')

--- a/var/spack/repos/builtin/packages/apr-util/package.py
+++ b/var/spack/repos/builtin/packages/apr-util/package.py
@@ -38,7 +38,7 @@ class AprUtil(AutotoolsPackage):
         args = [
             '--with-apr={0}'.format(spec['apr'].prefix),
             '--with-expat={0}'.format(spec['expat'].prefix),
-            '--with-iconv={0}'.format(spec['libiconv'].prefix),
+            '--with-iconv={0}'.format(spec['iconv'].prefix),
             # TODO: Add support for the following database managers
             '--without-ndbm',
             '--without-berkeley-db',

--- a/var/spack/repos/builtin/packages/bash/package.py
+++ b/var/spack/repos/builtin/packages/bash/package.py
@@ -19,7 +19,7 @@ class Bash(AutotoolsPackage, GNUMirrorPackage):
 
     depends_on('ncurses')
     depends_on('readline@5.0:')
-    depends_on('libiconv')
+    depends_on('iconv')
 
     patches = [
         ('5.0', '001', 'f2fe9e1f0faddf14ab9bfa88d450a75e5d028fedafad23b88716bd657c737289'),

--- a/var/spack/repos/builtin/packages/bash/package.py
+++ b/var/spack/repos/builtin/packages/bash/package.py
@@ -49,7 +49,7 @@ class Bash(AutotoolsPackage, GNUMirrorPackage):
             '--with-curses',
             '--enable-readline',
             '--with-installed-readline',
-            '--with-libiconv-prefix={0}'.format(spec['libiconv'].prefix),
+            '--with-libiconv-prefix={0}'.format(spec['iconv'].prefix),
         ]
 
     def check(self):

--- a/var/spack/repos/builtin/packages/dcmtk/package.py
+++ b/var/spack/repos/builtin/packages/dcmtk/package.py
@@ -32,7 +32,7 @@ class Dcmtk(CMakePackage):
     depends_on('libxml2', type=('build', 'link'), when='+xml')
 
     variant('iconv', default=True, description="Charset conversion support (iconv)")
-    depends_on('libiconv', type=('build', 'link'))
+    depends_on('iconv', type=('build', 'link'))
 
     variant('cxx11', default=False, description="Enable c++11 features")
     variant('stl', default=True, description="Use native STL implementation")

--- a/var/spack/repos/builtin/packages/diffutils/package.py
+++ b/var/spack/repos/builtin/packages/diffutils/package.py
@@ -18,7 +18,7 @@ class Diffutils(AutotoolsPackage, GNUMirrorPackage):
 
     build_directory = 'spack-build'
 
-    depends_on('libiconv')
+    depends_on('iconv')
 
     def setup_build_environment(self, env):
         if self.spec.satisfies('%fj'):

--- a/var/spack/repos/builtin/packages/doxygen/package.py
+++ b/var/spack/repos/builtin/packages/doxygen/package.py
@@ -45,13 +45,13 @@ class Doxygen(CMakePackage):
     patch('shared_ptr.patch', when='@1.8.14')
 
     def patch(self):
-        if self.spec.satisfies('libc+iconv'):
+        if self.spec['iconv'].name == 'libc':
             return
         # On Linux systems, iconv is provided by libc. Since CMake finds the
         # symbol in libc, it does not look for libiconv, which leads to linker
         # errors. This makes sure that CMake always looks for the external
         # libconv instead.
-#        filter_file('check_function_exists(iconv_open ICONV_IN_GLIBC)',
-#                    'set(ICONV_IN_GLIBC FALSE)',
-#                    join_path('cmake', 'FindIconv.cmake'),
-#                    string=True)
+        filter_file('check_function_exists(iconv_open ICONV_IN_GLIBC)',
+                    'set(ICONV_IN_GLIBC FALSE)',
+                    join_path('cmake', 'FindIconv.cmake'),
+                    string=True)

--- a/var/spack/repos/builtin/packages/doxygen/package.py
+++ b/var/spack/repos/builtin/packages/doxygen/package.py
@@ -29,7 +29,7 @@ class Doxygen(CMakePackage):
 
     depends_on("cmake@2.8.12:", type='build')
     depends_on("python", type='build')  # 2 or 3 OK; used in CMake build
-    depends_on("libiconv")
+    depends_on("iconv")
     depends_on("flex", type='build')
     # code.l just checks subminor version <=2.5.4 or >=2.5.33
     # but does not recognize 2.6.x as newer...could be patched if needed
@@ -45,6 +45,8 @@ class Doxygen(CMakePackage):
     patch('shared_ptr.patch', when='@1.8.14')
 
     def patch(self):
+        if self.spec.satisfies('libc+iconv'):
+            return
         # On Linux systems, iconv is provided by libc. Since CMake finds the
         # symbol in libc, it does not look for libiconv, which leads to linker
         # errors. This makes sure that CMake always looks for the external

--- a/var/spack/repos/builtin/packages/doxygen/package.py
+++ b/var/spack/repos/builtin/packages/doxygen/package.py
@@ -51,7 +51,7 @@ class Doxygen(CMakePackage):
         # symbol in libc, it does not look for libiconv, which leads to linker
         # errors. This makes sure that CMake always looks for the external
         # libconv instead.
-        filter_file('check_function_exists(iconv_open ICONV_IN_GLIBC)',
-                    'set(ICONV_IN_GLIBC FALSE)',
-                    join_path('cmake', 'FindIconv.cmake'),
-                    string=True)
+#        filter_file('check_function_exists(iconv_open ICONV_IN_GLIBC)',
+#                    'set(ICONV_IN_GLIBC FALSE)',
+#                    join_path('cmake', 'FindIconv.cmake'),
+#                    string=True)

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -101,7 +101,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
     depends_on('isl@0.15:0.18', when='@6:8.9')
     depends_on('isl@0.15:0.20', when='@9:')
     depends_on('zlib', when='@6:')
-    depends_on('libiconv', when='platform=darwin')
+    depends_on('iconv', when='platform=darwin')
     depends_on('gnat', when='languages=ada')
     depends_on('binutils~libiberty', when='+binutils')
     depends_on('zip', type='build', when='languages=java')

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -341,7 +341,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
             options.extend([
                 '--with-native-system-header-dir=/usr/include',
                 '--with-sysroot={0}'.format(macos_sdk_path()),
-                '--with-libiconv-prefix={0}'.format(spec['libiconv'].prefix)
+                '--with-libiconv-prefix={0}'.format(spec['iconv'].prefix)
             ])
 
         return options

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -250,7 +250,7 @@ class Gdal(AutotoolsPackage):
 
         if '+libiconv' in spec:
             args.append('--with-libiconv-prefix={0}'.format(
-                spec['libiconv'].prefix))
+                spec['iconv'].prefix))
         else:
             args.append('--with-libiconv-prefix=no')
 

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -107,7 +107,7 @@ class Gdal(AutotoolsPackage):
     # Optional dependencies
     depends_on('libtool', type='build', when='+libtool')
     depends_on('zlib', when='+libz')
-    depends_on('libiconv', when='+libiconv')
+    depends_on('iconv', when='+libiconv')
     depends_on('xz', when='+liblzma')
     depends_on('zstd', when='+zstd @2.3:')
     depends_on('postgresql', when='+pg')

--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -177,7 +177,7 @@ class Git(AutotoolsPackage):
     depends_on('curl')
     depends_on('expat')
     depends_on('gettext')
-    depends_on('libiconv')
+    depends_on('iconv')
     depends_on('libidn2')
     depends_on('openssl')
     depends_on('pcre', when='@:2.13')

--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -221,7 +221,7 @@ class Git(AutotoolsPackage):
         configure_args = [
             '--with-curl={0}'.format(spec['curl'].prefix),
             '--with-expat={0}'.format(spec['expat'].prefix),
-            '--with-iconv={0}'.format(spec['libiconv'].prefix),
+            '--with-iconv={0}'.format(spec['iconv'].prefix),
             '--with-openssl={0}'.format(spec['openssl'].prefix),
             '--with-perl={0}'.format(spec['perl'].command.path),
             '--with-zlib={0}'.format(spec['zlib'].prefix),

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -70,7 +70,10 @@ class Glib(AutotoolsPackage):
             args.append('--with-python={0}'.format(
                 os.path.basename(self.spec['python'].command.path))
             )
-        args.append('--with-libiconv=gnu')
+        if 'libc' in self.spec:
+            args.append('--with-libiconv=maybe')
+        else:
+            args.append('--with-libiconv=gnu')
         args.extend(self.enable_or_disable('tracing'))
         # SELinux is not available in Spack, so glib should not use it.
         args.append('--disable-selinux')

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -46,7 +46,7 @@ class Glib(AutotoolsPackage):
     depends_on('python', type=('build', 'run'), when='@2.53.4:')
     depends_on('pcre+utf', when='@2.48:')
     depends_on('util-linux', when='+libmount')
-    depends_on('libiconv')
+    depends_on('iconv')
 
     # The following patch is needed for gcc-6.1
     patch('g_date_strftime.patch', when='@2.42.1')

--- a/var/spack/repos/builtin/packages/gnupg/package.py
+++ b/var/spack/repos/builtin/packages/gnupg/package.py
@@ -25,7 +25,7 @@ class Gnupg(AutotoolsPackage):
     depends_on('libgpg-error@1.24:')
     depends_on('npth@1.2:')
     depends_on('zlib')
-    depends_on('libiconv')
+    depends_on('iconv')
 
     def configure_args(self):
         return [

--- a/var/spack/repos/builtin/packages/gnupg/package.py
+++ b/var/spack/repos/builtin/packages/gnupg/package.py
@@ -36,7 +36,7 @@ class Gnupg(AutotoolsPackage):
             '--with-ksba-prefix='         + self.spec['libksba'].prefix,
             '--with-npth-prefix='         + self.spec['npth'].prefix,
             '--without-ldap',
-            '--with-libiconv-prefix='     + self.spec['libiconv'].prefix,
+            '--with-libiconv-prefix='     + self.spec['iconv'].prefix,
             '--without-regex',
             '--with-zlib='                + self.spec['zlib'].prefix,
             '--without-bzip2',

--- a/var/spack/repos/builtin/packages/gnuplot/package.py
+++ b/var/spack/repos/builtin/packages/gnuplot/package.py
@@ -55,7 +55,7 @@ class Gnuplot(AutotoolsPackage):
     depends_on('readline')
     depends_on('pkgconfig', type='build')
     depends_on('libxpm')
-    depends_on('libiconv')
+    depends_on('iconv')
 
     # optional dependencies:
     depends_on('libcerf', when='+libcerf')

--- a/var/spack/repos/builtin/packages/grass/package.py
+++ b/var/spack/repos/builtin/packages/grass/package.py
@@ -259,4 +259,3 @@ class Grass(AutotoolsPackage):
 
         makefile = FileFilter('include/Make/Platform.make')
         makefile.filter(r'^ICONVLIB\s*=.*', 'ICONVLIB = -liconv')
-

--- a/var/spack/repos/builtin/packages/grass/package.py
+++ b/var/spack/repos/builtin/packages/grass/package.py
@@ -254,5 +254,9 @@ class Grass(AutotoolsPackage):
     # hence invoke the following function afterwards
     @run_after('configure')
     def fix_iconv_linking(self):
+        if self.spec['iconv'].name != 'libiconv':
+            return
+
         makefile = FileFilter('include/Make/Platform.make')
         makefile.filter(r'^ICONVLIB\s*=.*', 'ICONVLIB = -liconv')
+

--- a/var/spack/repos/builtin/packages/grass/package.py
+++ b/var/spack/repos/builtin/packages/grass/package.py
@@ -58,7 +58,7 @@ class Grass(AutotoolsPackage):
     # http://htmlpreview.github.io/?https://github.com/OSGeo/grass/blob/master/REQUIREMENTS.html
     # General requirements
     depends_on('gmake@3.81:', type='build')
-    depends_on('libiconv')
+    depends_on('iconv')
     depends_on('zlib')
     depends_on('flex', type='build')
     depends_on('bison', type='build')

--- a/var/spack/repos/builtin/packages/gtksourceview/package.py
+++ b/var/spack/repos/builtin/packages/gtksourceview/package.py
@@ -35,7 +35,7 @@ class Gtksourceview(AutotoolsPackage):
     depends_on('pango')
     depends_on('gdk-pixbuf')
     depends_on('atk')
-    depends_on('libiconv')
+    depends_on('iconv')
 
     def url_for_version(self, version):
         url  = 'https://download.gnome.org/sources/gtksourceview/'

--- a/var/spack/repos/builtin/packages/lftp/package.py
+++ b/var/spack/repos/builtin/packages/lftp/package.py
@@ -27,7 +27,7 @@ class Lftp(AutotoolsPackage):
     def configure_args(self):
         return [
             '--with-expat={0}'.format(self.spec['expat'].prefix),
-            '--with-libiconv={0}'.format(self.spec['libiconv'].prefix),
+            '--with-libiconv={0}'.format(self.spec['iconv'].prefix),
             '--with-openssl={0}'.format(self.spec['openssl'].prefix),
             '--with-readline={0}'.format(self.spec['readline'].prefix),
             '--with-zlib={0}'.format(self.spec['zlib'].prefix),

--- a/var/spack/repos/builtin/packages/lftp/package.py
+++ b/var/spack/repos/builtin/packages/lftp/package.py
@@ -18,7 +18,7 @@ class Lftp(AutotoolsPackage):
     version('4.6.4', sha256='791e783779d3d6b519d0c23155430b9785f2854023eb834c716f5ba78873b15a')
 
     depends_on('expat')
-    depends_on('libiconv')
+    depends_on('iconv')
     depends_on('ncurses')
     depends_on('openssl')
     depends_on('readline')

--- a/var/spack/repos/builtin/packages/libc/package.py
+++ b/var/spack/repos/builtin/packages/libc/package.py
@@ -1,0 +1,37 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install libc
+#
+# You can edit this file again by typing:
+#
+#     spack edit libc
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+from spack import *
+
+
+class Libc(Package):
+    """Dummy libc package to provide `iconv` virtual package"""
+
+    homepage = "https://en.wikipedia.org/wiki/C_standard_library"
+    url      = ""
+
+    version('1.0')  # Dummy
+    variant('iconv', default=False, description='Set to True if libc provides iconv')
+    provides('iconv', when='+iconv')
+
+    def install(self, spec, prefix):
+        return

--- a/var/spack/repos/builtin/packages/libc/package.py
+++ b/var/spack/repos/builtin/packages/libc/package.py
@@ -3,23 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-# ----------------------------------------------------------------------------
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install libc
-#
-# You can edit this file again by typing:
-#
-#     spack edit libc
-#
-# See the Spack documentation for more information on packaging.
-# ----------------------------------------------------------------------------
-
 from spack import *
 
 

--- a/var/spack/repos/builtin/packages/libc/package.py
+++ b/var/spack/repos/builtin/packages/libc/package.py
@@ -28,10 +28,9 @@ class Libc(Package):
 
     homepage = "https://en.wikipedia.org/wiki/C_standard_library"
     url      = ""
+    has_code = False
+    phases = []
 
     version('1.0')  # Dummy
     variant('iconv', default=False, description='Set to True if libc provides iconv')
     provides('iconv', when='+iconv')
-
-    def install(self, spec, prefix):
-        return

--- a/var/spack/repos/builtin/packages/libgd/package.py
+++ b/var/spack/repos/builtin/packages/libgd/package.py
@@ -31,7 +31,7 @@ class Libgd(AutotoolsPackage):
     depends_on('gettext', type='build')
     depends_on('pkgconfig', type='build')
 
-    depends_on('libiconv')
+    depends_on('iconv')
     depends_on('libpng')
     depends_on('jpeg')
     depends_on('libtiff')

--- a/var/spack/repos/builtin/packages/libiconv/package.py
+++ b/var/spack/repos/builtin/packages/libiconv/package.py
@@ -20,6 +20,7 @@ class Libiconv(AutotoolsPackage, GNUMirrorPackage):
     # We cannot set up a warning for gets(), since gets() is not part
     # of C11 any more and thus might not exist.
     patch('gets.patch', when='@1.14')
+    provides('iconv')
 
     conflicts('@1.14', when='%gcc@5:')
 

--- a/var/spack/repos/builtin/packages/libspatialite/package.py
+++ b/var/spack/repos/builtin/packages/libspatialite/package.py
@@ -21,5 +21,5 @@ class Libspatialite(AutotoolsPackage):
     depends_on('proj@:5')
     depends_on('geos')
     depends_on('freexl')
-    depends_on('libiconv')
+    depends_on('iconv')
     depends_on('libxml2')

--- a/var/spack/repos/builtin/packages/libunistring/package.py
+++ b/var/spack/repos/builtin/packages/libunistring/package.py
@@ -19,7 +19,7 @@ class Libunistring(AutotoolsPackage, GNUMirrorPackage):
     version('0.9.7', sha256='2e3764512aaf2ce598af5a38818c0ea23dedf1ff5460070d1b6cee5c3336e797')
     version('0.9.6', sha256='2df42eae46743e3f91201bf5c100041540a7704e8b9abfd57c972b2d544de41b')
 
-    depends_on('libiconv')
+    depends_on('iconv')
 
     # glibc 2.28+ removed libio.h and thus _IO_ftrylockfile
     patch('removed_libio.patch', when='@:0.9.9')

--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -49,7 +49,7 @@ class Libxml2(AutotoolsPackage):
         spec = self.spec
 
         args = ['--with-lzma={0}'.format(spec['xz'].prefix),
-                '--with-iconv={0}'.format(spec['libiconv'].prefix)]
+                '--with-iconv={0}'.format(spec['iconv'].prefix)]
 
         if '+python' in spec:
             args.extend([

--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -23,7 +23,7 @@ class Libxml2(AutotoolsPackage):
     variant('python', default=False, description='Enable Python support')
 
     depends_on('pkgconfig@0.9.0:', type='build')
-    depends_on('libiconv')
+    depends_on('iconv')
     depends_on('zlib')
     depends_on('xz')
 

--- a/var/spack/repos/builtin/packages/libxslt/package.py
+++ b/var/spack/repos/builtin/packages/libxslt/package.py
@@ -26,7 +26,7 @@ class Libxslt(AutotoolsPackage):
     variant('python', default=False, description='Build Python bindings')
 
     depends_on('pkgconfig@0.9.0:', type='build')
-    depends_on('libiconv')
+    depends_on('iconv')
     depends_on('libxml2')
     depends_on('libxml2+python', when='+python')
     depends_on('xz')

--- a/var/spack/repos/builtin/packages/mono/package.py
+++ b/var/spack/repos/builtin/packages/mono/package.py
@@ -50,6 +50,6 @@ class Mono(AutotoolsPackage):
 
     def configure_args(self):
         args = []
-        li = self.spec['libiconv'].prefix
+        li = self.spec['iconv'].prefix
         args.append('--with-libiconv-prefix={p}'.format(p=li))
         return args

--- a/var/spack/repos/builtin/packages/mono/package.py
+++ b/var/spack/repos/builtin/packages/mono/package.py
@@ -25,7 +25,7 @@ class Mono(AutotoolsPackage):
     # Spack's openssl interacts badly with mono's vendored
     # "boringssl", don't drag it in w/ cmake
     depends_on('cmake~openssl', type=('build'))
-    depends_on('libiconv')
+    depends_on('iconv')
     depends_on('perl', type=('build'))
 
     version('6.8.0.105', sha256='578799c44c3c86a9eb5daf6dec6c60a24341940fd376371956d4a46cf8612178',

--- a/var/spack/repos/builtin/packages/ncl/package.py
+++ b/var/spack/repos/builtin/packages/ncl/package.py
@@ -48,7 +48,7 @@ class Ncl(Package):
     # Extra dependencies that may be missing from build system:
     depends_on('bison', type='build')
     depends_on('flex+lex')
-    depends_on('libiconv')
+    depends_on('iconv')
     depends_on('tcsh')
 
     # Also, the manual says that ncl requires zlib, but that comes as a
@@ -57,7 +57,7 @@ class Ncl(Package):
     # The following dependencies are required, otherwise several components
     # fail to compile:
     depends_on('curl')
-    depends_on('libiconv')
+    depends_on('iconv')
     depends_on('libx11')
     depends_on('libxaw')
     depends_on('libxmu')

--- a/var/spack/repos/builtin/packages/poppler/package.py
+++ b/var/spack/repos/builtin/packages/poppler/package.py
@@ -49,7 +49,7 @@ class Poppler(CMakePackage):
     depends_on('qt@4.0:', when='+qt')
     depends_on('zlib', when='+zlib')
     depends_on('cairo@1.10.0:', when='+glib')
-    depends_on('libiconv', when='+iconv')
+    depends_on('iconv', when='+iconv')
     depends_on('jpeg', when='+jpeg')
     depends_on('libpng', when='+png')
     depends_on('libtiff', when='+tiff')

--- a/var/spack/repos/builtin/packages/procps/package.py
+++ b/var/spack/repos/builtin/packages/procps/package.py
@@ -35,7 +35,7 @@ class Procps(AutotoolsPackage):
 
     def configure_args(self):
         return [
-            '--with-libiconv-prefix={0}'.format(self.spec['libiconv'].prefix),
+            '--with-iconv-prefix={0}'.format(self.spec['libiconv'].prefix),
             '--with-libintl-prefix={0}'.format(self.spec['gettext'].prefix),
             '--with-ncurses',
             # Required to avoid libintl linking errors

--- a/var/spack/repos/builtin/packages/procps/package.py
+++ b/var/spack/repos/builtin/packages/procps/package.py
@@ -35,7 +35,7 @@ class Procps(AutotoolsPackage):
 
     def configure_args(self):
         return [
-            '--with-iconv-prefix={0}'.format(self.spec['libiconv'].prefix),
+            '--with-libiconv-prefix={0}'.format(self.spec['iconv'].prefix),
             '--with-libintl-prefix={0}'.format(self.spec['gettext'].prefix),
             '--with-ncurses',
             # Required to avoid libintl linking errors

--- a/var/spack/repos/builtin/packages/procps/package.py
+++ b/var/spack/repos/builtin/packages/procps/package.py
@@ -23,7 +23,7 @@ class Procps(AutotoolsPackage):
     depends_on('m4',       type='build')
     depends_on('pkgconfig@0.9.0:', type='build')
     depends_on('dejagnu',  type='test')
-    depends_on('libiconv')
+    depends_on('iconv')
     depends_on('gettext')
     depends_on('ncurses')
 

--- a/var/spack/repos/builtin/packages/tar/package.py
+++ b/var/spack/repos/builtin/packages/tar/package.py
@@ -29,5 +29,5 @@ class Tar(AutotoolsPackage, GNUMirrorPackage):
 
     def configure_args(self):
         return [
-            '--with-libiconv-prefix={0}'.format(self.spec['libiconv'].prefix),
+            '--with-libiconv-prefix={0}'.format(self.spec['iconv'].prefix),
         ]

--- a/var/spack/repos/builtin/packages/tar/package.py
+++ b/var/spack/repos/builtin/packages/tar/package.py
@@ -19,7 +19,7 @@ class Tar(AutotoolsPackage, GNUMirrorPackage):
     version('1.29', sha256='cae466e6e58c7292355e7080248f244db3a4cf755f33f4fa25ca7f9a7ed09af0')
     version('1.28', sha256='6a6b65bac00a127a508533c604d5bf1a3d40f82707d56f20cefd38a05e8237de')
 
-    depends_on('libiconv')
+    depends_on('iconv')
 
     patch('tar-pgi.patch',    when='@1.29')
     patch('config-pgi.patch', when='@:1.29')

--- a/var/spack/repos/builtin/packages/unixodbc/package.py
+++ b/var/spack/repos/builtin/packages/unixodbc/package.py
@@ -16,5 +16,5 @@ class Unixodbc(AutotoolsPackage):
 
     version('2.3.4', sha256='2e1509a96bb18d248bf08ead0d74804957304ff7c6f8b2e5965309c632421e39')
 
-    depends_on('libiconv')
+    depends_on('iconv')
     depends_on('libtool')

--- a/var/spack/repos/builtin/packages/wget/package.py
+++ b/var/spack/repos/builtin/packages/wget/package.py
@@ -43,7 +43,7 @@ class Wget(AutotoolsPackage, GNUMirrorPackage):
 
     depends_on('perl@5.12.0:', type='build')
     depends_on('pkgconfig', type='build')
-    depends_on('libiconv')
+    depends_on('iconv')
 
     depends_on('valgrind', type='test')
 

--- a/var/spack/repos/builtin/packages/xerces-c/package.py
+++ b/var/spack/repos/builtin/packages/xerces-c/package.py
@@ -45,7 +45,7 @@ class XercesC(AutotoolsPackage):
             multi=False,
             description='Use the specified transcoder')
 
-    depends_on('libiconv', type='link', when='transcoder=gnuiconv')
+    depends_on('iconv', type='link', when='transcoder=gnuiconv')
     depends_on('icu4c',    type='link', when='transcoder=icu')
 
     # Pass flags to configure.  This is necessary for CXXFLAGS or else

--- a/var/spack/repos/builtin/packages/xerces-c/package.py
+++ b/var/spack/repos/builtin/packages/xerces-c/package.py
@@ -61,7 +61,7 @@ class XercesC(AutotoolsPackage):
 
         # There is no --with-pkg for gnuiconv.
         if name == 'ldflags' and 'transcoder=gnuiconv' in spec:
-            flags.append(spec['libiconv'].libs.ld_flags)
+            flags.append(spec['iconv'].libs.ld_flags)
 
         return (None, None, flags)
 


### PR DESCRIPTION
We at SFT-SPI would like to use libc's implementation of iconv, as opposed to libiconv one. This PR introduces a new virtual package `iconv` and a dummy package `libc` to provide it. 

lib's and libiconv's implementation of iconv should be compatible on API level, but I'm testing this just in case.

Packages that directly depend on libiconv:
- [x] apr-util
- [x] dcmtk
- [x] doxygen
- [x] gdal
- [x] glib
- [x] gnuplot
- [x] gtksourceview
- [x] libgd
- [x] libunistring
- [x] libxslt
- [x] ncl
- [x] procps
- [x] unixodbc
- [x] xerces-c
- [x] bash
- [x] diffutils
- [x] gcc
- [x] git
- [x] gnupg
- [x] grass
- [x] lftp
- [x] libspatialite
- [x] libxml2
- [x] mono
- [x] poppler
- [x] tar
- [x] wget
