### PR TITLE
add libfabric/lib to SPACK_COMPILER_EXTRA_RPATHS when bulding with intelmpi@2019+

### DIFF
--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -1073,6 +1073,15 @@ class IntelPackage(PackageBase):
                 # which performs dizzyingly similar but necessarily different
                 # actions, and (b) function code leaves a bit more breathing
                 # room within the suffocating corset of flake8 line length.
+
+                # Intel MPI since 2019 depends on libfabric which is not in the
+                # lib directory but in a directory of its own which should be
+                # included in the rpath
+                if self.version >= ver('2019'):
+                    d = ancestor(self.component_lib_dir('mpi'))
+                    libfabrics_path = os.path.join(d, 'libfabric', 'lib')
+                    env.append_path('SPACK_COMPILER_EXTRA_RPATHS',
+                                    libfabrics_path)
             else:
                 raise InstallError('compilers_of_client arg required for MPI')
 


### PR DESCRIPTION
- seems to be a workaround for #11140 and #12493 not finding an appropriate libfabrics.so

Fixes #11140
Fixes #12493
Fixes #15522