### PR TITLE
ssht: Correct recipe

### DIFF
--- a/var/spack/repos/builtin/packages/ssht/float_conversion.patch
+++ b/var/spack/repos/builtin/packages/ssht/float_conversion.patch
@@ -1,0 +1,11 @@
+--- spack-src/src/c/ssht_sampling.h
++++ spack-src/src/c/ssht_sampling.h
+@@ -89,7 +89,7 @@
+  */
+ static inline void ssht_sampling_ind2elm(int *el, int *m, int ind) {
+ 
+-  *el = sqrt(ind);
++  *el = lrint(floor(sqrt(ind)));
+   *m = ind - (*el)*(*el) - (*el);
+ 
+ }

--- a/var/spack/repos/builtin/packages/ssht/package.py
+++ b/var/spack/repos/builtin/packages/ssht/package.py
@@ -7,18 +7,41 @@ from spack import *
 
 
 class Ssht(Package):
-    """The SSHT code provides functionality to perform fast and exact
-    spin spherical harmonic transforms."""
+    """ssht: Spin spherical harmonic transforms
+
+    The SSHT code provides functionality to perform fast and exact
+    spin spherical harmonic transforms based on the sampling theorem
+    on the sphere derived in our paper: A novel sampling theorem on
+    the sphere <http://dx.doi.org/10.1109/TSP.2011.2166394>.
+    """
 
     homepage = "https://astro-informatics.github.io/ssht/"
     git      = "https://github.com/astro-informatics/ssht.git"
+
+    maintainers = ['eschnett']
 
     version('1.2b1', commit='7378ce8853897cbd1b08adebf7ec088c1e40f860')
 
     depends_on('fftw')
 
+    patch('float_conversion.patch')
+
     def install(self, spec, prefix):
-        make('default')
-        install_tree('include/c', join_path(prefix, 'include'))
+        make('default', 'SSHTDIR=.')
+        mkdirp(join_path(prefix, 'include'))
+        install('src/c/ssht.h',
+                join_path(prefix, 'include', 'ssht.h'))
+        install('src/c/ssht_adjoint.h',
+                join_path(prefix, 'include', 'ssht_adjoint.h'))
+        install('src/c/ssht_core.h',
+                join_path(prefix, 'include', 'ssht_core.h'))
+        install('src/c/ssht_dl.h',
+                join_path(prefix, 'include', 'ssht_dl.h'))
+        install('src/c/ssht_error.h',
+                join_path(prefix, 'include', 'ssht_error.h'))
+        install('src/c/ssht_sampling.h',
+                join_path(prefix, 'include', 'ssht_sampling.h'))
+        install('src/c/ssht_types.h',
+                join_path(prefix, 'include', 'ssht_types.h'))
         install_tree('doc/c', join_path(prefix, 'doc'))
         install_tree('lib/c', join_path(prefix, 'lib'))


### PR DESCRIPTION
- Tell make about the source code path
- Install actual header files, not a wrapper with wrong paths
- Add a patch to prevent compiler warnings
- Improve description

The first two of these changes are necessary to make the package build and install.