### PR TITLE
bugfix:  Add dependents when initialize spec from yaml

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1919,13 +1919,7 @@ class Spec(object):
 
             yaml_deps = node[name]['dependencies']
             for dname, dhash, dtypes in Spec.read_yaml_dep_specs(yaml_deps):
-                dspec = DependencySpec(deps[name], deps[dname], dtypes)
-
-                # Fill in dependencies by looking them up by name in deps dict
-                deps[name]._dependencies[dname] = dspec
-
-                # Fill in dependents by looking them up by dname in deps dict
-                deps[dname]._dependents[name] = dspec
+                deps[name]._add_dependency(deps[dname], dtypes)
 
         return spec
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1920,8 +1920,10 @@ class Spec(object):
             yaml_deps = node[name]['dependencies']
             for dname, dhash, dtypes in Spec.read_yaml_dep_specs(yaml_deps):
                 dspec = DependencySpec(deps[name], deps[dname], dtypes)
+
                 # Fill in dependencies by looking them up by name in deps dict
                 deps[name]._dependencies[dname] = dspec
+
                 # Fill in dependents by looking them up by dname in deps dict
                 deps[dname]._dependents[name] = dspec
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1919,9 +1919,11 @@ class Spec(object):
 
             yaml_deps = node[name]['dependencies']
             for dname, dhash, dtypes in Spec.read_yaml_dep_specs(yaml_deps):
+                dspec = DependencySpec(deps[name], deps[dname], dtypes)
                 # Fill in dependencies by looking them up by name in deps dict
-                deps[name]._dependencies[dname] = DependencySpec(
-                    deps[name], deps[dname], dtypes)
+                deps[name]._dependencies[dname] = dspec
+                # Fill in dependents by looking them up by dname in deps dict
+                deps[dname]._dependents[name] = dspec
 
         return spec
 

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -84,16 +84,24 @@ class TestConcretizePreferences(object):
             'mpileaks', debug=True, opt=True, shared=False, static=False
         )
 
-    def test_preferred_compilers(self, mutable_mock_repo):
+    def test_preferred_compilers(self):
         """Test preferred compilers are applied correctly
         """
-        update_packages('mpileaks', 'compiler', ['clang@3.3'])
-        spec = concretize('mpileaks')
-        assert spec.compiler == spack.spec.CompilerSpec('clang@3.3')
+        # Need to make sure the test uses an available compiler
+        compiler_list = spack.compilers.all_compiler_specs()
+        assert compiler_list
 
-        update_packages('mpileaks', 'compiler', ['gcc@4.5.0'])
+        # Try the first available compiler
+        compiler = str(compiler_list[0])
+        update_packages('mpileaks', 'compiler', [compiler])
         spec = concretize('mpileaks')
-        assert spec.compiler == spack.spec.CompilerSpec('gcc@4.5.0')
+        assert spec.compiler == spack.spec.CompilerSpec(compiler)
+
+        # Try the last available compiler
+        compiler = str(compiler_list[-1])
+        update_packages('mpileaks', 'compiler', [compiler])
+        spec = concretize('mpileaks')
+        assert spec.compiler == spack.spec.CompilerSpec(compiler)
 
     def test_preferred_target(self, mutable_mock_repo):
         """Test preferred compilers are applied correctly

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -15,15 +15,15 @@ from spack.version import Version
 
 
 @pytest.fixture()
-def concretize_scope(config, tmpdir):
+def concretize_scope(mutable_config, tmpdir):
     """Adds a scope for concretization preferences"""
     tmpdir.ensure_dir('concretize')
-    config.push_scope(
+    mutable_config.push_scope(
         ConfigScope('concretize', str(tmpdir.join('concretize'))))
 
     yield
 
-    config.pop_scope()
+    mutable_config.pop_scope()
     spack.repo.path._provider_index = None
 
 


### PR DESCRIPTION
Fixes #15219

The new build process, introduced in #13100 , relies on a spec's dependents in addition to their dependencies.  Loading a spec from a `yaml` file was not initializing the dependents.  This PR corrects that oversight.