### PR TITLE
Advice to users are hidden when rendering issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,14 +1,21 @@
 ---
-name: Bug report 
+name: "\U0001F41E Bug report" 
 about: Report a bug in the core of Spack (command not working as expected, etc.) 
-labels: bug
+labels: "bug,triage"
 ---
 
-
+<!--
 *Explain, in a clear and concise way, the command you ran and the result you were trying to achieve.
 Example: "I ran Spack find to list all the installed packages and..."*
+-->
 
 
+### Spack version
+<!-- Add the output to the command below -->
+```console
+$ spack --version
+
+```
 
 ### Steps to reproduce the issue
 
@@ -20,7 +27,7 @@ $ spack <command2> <spec>
 
 ### Error Message
 
-If Spack reported an error, provide the error message. If it did not report an error
+<!--If Spack reported an error, provide the error message. If it did not report an error
 but the output appears incorrect, provide the incorrect output. If there was no error
 message and no output but the result is incorrect, describe how it does not match
 what you expect. To provide more information you might re-run the commands with 
@@ -31,19 +38,27 @@ $ spack -d --stacktrace <command2> <spec>
 ...
 ```
 that activate the full debug output. 
-
+-->
 
 ### Information on your system
-
+<!--
 This includes:
 
  1. which platform you are using
  2. any relevant configuration detail (custom `packages.yaml` or `modules.yaml`, etc.)
 
------
+-->
 
+### General information
+
+- [ ] I have run `spack --version` and reported the version of Spack
+- [ ] I have searched the issues of this repo and believe this is not a duplicate
+- [ ] I have run the failing commands in debug mode and reported the output
+
+<!--
 We encourage you to try, as much as possible, to reduce your problem to the minimal example that still reproduces the issue. That would help us a lot in fixing it quickly and effectively!
 
 If you want to ask a question about the tool (how to use it, what it can currently do, etc.), try the `#general` channel on our Slack first. We have a welcoming community and chances are you'll get your reply faster and without opening an issue.
 
 Other than that, thanks for taking the time to contribute to Spack!
+-->

--- a/.github/ISSUE_TEMPLATE/build_error.md
+++ b/.github/ISSUE_TEMPLATE/build_error.md
@@ -1,19 +1,24 @@
 ---
-name: Build error 
+name: "\U0001F4A5 Build error" 
 about: Some package in Spack didn't build correctly  
 labels: "build-error"
 ---
 
-*Thanks for taking the time to report this build failure. To proceed with the
+<!--*Thanks for taking the time to report this build failure. To proceed with the
 report please:*
 1. Title the issue "Installation issue: <name-of-the-package>".
 2. Provide the information required below.
-3. Remove the template instructions before posting the issue.
 
 We encourage you to try, as much as possible, to reduce your problem to the minimal example that still reproduces the issue. That would help us a lot in fixing it quickly and effectively!
+-->
 
 
----
+### Spack version
+<!-- Add the output to the command below -->
+```console
+$ spack --version
+
+```
 
 ### Steps to reproduce the issue
 
@@ -24,7 +29,7 @@ $ spack install <spec> # Fill in the exact spec you are using
 
 ### Platform and user environment
 
-Please report your OS here:
+<!-- Please report your OS here:
 ```commandline
 $ uname -a 
 Linux nuvolari 4.15.0-29-generic #31-Ubuntu SMP Tue Jul 17 15:39:52 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
@@ -37,10 +42,11 @@ and, if relevant, post or attach:
 - `compilers.yaml`
 
 to the issue
+-->
 
 ### Additional information
 
-Sometimes the issue benefits from additional details. In these cases there are
+<!--Sometimes the issue benefits from additional details. In these cases there are
 a few things we can suggest doing. First of all, you can post the full output of:
 ```console
 $ spack spec --install-status <spec>
@@ -75,4 +81,9 @@ will provide additional debug information. After the failure you will find two f
     failed object after Spack's compiler wrapper did its processing 
 
 You can post or attach those files to provide maintainers with more information on what
-is causing the failure.
+is causing the failure.-->
+
+### General information
+
+- [ ] I have run `spack --version` and reported the version of Spack
+- [ ] I have searched the issues of this repo and believe this is not a duplicate

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,28 +1,33 @@
 ---
-name: Feature request 
+name: "\U0001F38A Feature request" 
 about: Suggest adding a feature that is not yet in Spack  
-labels: feature
+labels: feature,triage
 
 ---
 
-*Please add a concise summary of your suggestion here.*
+<!--*Please add a concise summary of your suggestion here.*-->
 
 ### Rationale
 
-*Is your feature request related to a problem? Please describe it!*
+<!--*Is your feature request related to a problem? Please describe it!*-->
 
 ### Description
 
-*Describe the solution you'd like and the alternatives you have considered.*
+<!--*Describe the solution you'd like and the alternatives you have considered.*-->
 
 
 ### Additional information
-*Add any other context about the feature request here.*
+<!--*Add any other context about the feature request here.*-->
 
 
------
+### General information
+
+- [ ] I have run `spack --version` and reported the version of Spack
+- [ ] I have searched the issues of this repo and believe this is not a duplicate
 
 
-If you want to ask a question about the tool (how to use it, what it can currently do, etc.), try the `#general` channel on our Slack first. We have a welcoming community and chances are you'll get your reply faster and without opening an issue.
+
+<!--If you want to ask a question about the tool (how to use it, what it can currently do, etc.), try the `#general` channel on our Slack first. We have a welcoming community and chances are you'll get your reply faster and without opening an issue.
 
 Other than that, thanks for taking the time to contribute to Spack!
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: "\U0001F38A Feature request" 
 about: Suggest adding a feature that is not yet in Spack  
-labels: feature,triage
+labels: feature
 
 ---
 

--- a/.github/workflows/linux_build_tests.yaml
+++ b/.github/workflows/linux_build_tests.yaml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         package: [lz4, mpich, tut, py-setuptools, openjpeg, r-rcpp]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Cache ccache's store
       uses: actions/cache@v1
       with:


### PR DESCRIPTION
This PR makes a few minor improvements to issue templates:

- [x] Adds fancy unicode emoticon next to the title :slightly_smiling_face: 
- [x] Turn advice to users into comments, so that they'll not be displayed if not removed
- [x] Adds a field to report which Spack version the user is running
- [x] Automatically marks bug reports  as "triage"
- [x] Adds a final checklist for convenience of users reporting an issue