### PR TITLE
MPICH: optionally build without libxml2.

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/nag_libtool_2.4.2_0.patch
+++ b/var/spack/repos/builtin/packages/mpich/nag_libtool_2.4.2_0.patch
@@ -1,0 +1,29 @@
+--- a/configure
++++ b/configure
+@@ -11563,6 +11563,8 @@ _LT_EOF
+ 	lf95*)				# Lahey Fortran 8.1
+ 	  whole_archive_flag_spec=
+ 	  tmp_sharedflag='--shared' ;;
++	nagfor*)			# NAGFOR 5.3
++	  tmp_sharedflag='-Wl,-shared' ;;
+ 	xl[cC]* | bgxl[cC]* | mpixl[cC]*) # IBM XL C 8.0 on PPC (deal with xlf below)
+ 	  tmp_sharedflag='-qmkshrobj'
+ 	  tmp_addflag= ;;
+@@ -19036,6 +19038,8 @@ _LT_EOF
+ 	lf95*)				# Lahey Fortran 8.1
+ 	  whole_archive_flag_spec_F77=
+ 	  tmp_sharedflag='--shared' ;;
++	nagfor*)			# NAGFOR 5.3
++	  tmp_sharedflag='-Wl,-shared' ;;
+ 	xl[cC]* | bgxl[cC]* | mpixl[cC]*) # IBM XL C 8.0 on PPC (deal with xlf below)
+ 	  tmp_sharedflag='-qmkshrobj'
+ 	  tmp_addflag= ;;
+@@ -22116,6 +22120,8 @@ _LT_EOF
+ 	lf95*)				# Lahey Fortran 8.1
+ 	  whole_archive_flag_spec_FC=
+ 	  tmp_sharedflag='--shared' ;;
++	nagfor*)			# NAGFOR 5.3
++	  tmp_sharedflag='-Wl,-shared' ;;
+ 	xl[cC]* | bgxl[cC]* | mpixl[cC]*) # IBM XL C 8.0 on PPC (deal with xlf below)
+ 	  tmp_sharedflag='-qmkshrobj'
+ 	  tmp_addflag= ;;

--- a/var/spack/repos/builtin/packages/mpich/nag_libtool_2.4.2_1.patch
+++ b/var/spack/repos/builtin/packages/mpich/nag_libtool_2.4.2_1.patch
@@ -1,0 +1,71 @@
+--- a/confdb/ltmain.sh
++++ b/confdb/ltmain.sh
+@@ -180,6 +180,20 @@ func_basename ()
+     func_basename_result=`$ECHO "${1}" | $SED "$basename"`
+ } # func_basename may be replaced by extended shell implementation
+ 
++# Calculate cc_basename.  Skip known compiler wrappers and cross-prefix.
++func_cc_basename ()
++{
++    for cc_temp in $*""; do
++      case $cc_temp in
++        compile | *[\\/]compile | ccache | *[\\/]ccache ) ;;
++        distcc | *[\\/]distcc | purify | *[\\/]purify ) ;;
++        \-*) ;;
++        *) break;;
++      esac
++    done
++    func_cc_basename_result=`$ECHO "$cc_temp" | $SED "s%.*/%%; s%^$host_alias-%%"`
++}
++
+ 
+ # func_dirname_and_basename file append nondir_replacement
+ # perform func_basename and func_dirname in a single function
+@@ -6419,6 +6433,13 @@ func_mode_link ()
+ 	# Convert "-framework foo" to "foo.ltframework"
+ 	if test -n "$inherited_linker_flags"; then
+ 	  tmp_inherited_linker_flags=`$ECHO "$inherited_linker_flags" | $SED 's/-framework \([^ $]*\)/\1.ltframework/g'`
++
++	  # Additionally convert " -pthread" to " -Wl,-pthread" for nagfor
++	  func_cc_basename $CC
++	  case $func_cc_basename_result in
++	    nagfor*) tmp_inherited_linker_flags=`$ECHO "$tmp_inherited_linker_flags" | $SED 's/ -pthread/ -Wl,-pthread/g'` ;;
++	  esac
++
+ 	  for tmp_inherited_linker_flag in $tmp_inherited_linker_flags; do
+ 	    case " $new_inherited_linker_flags " in
+ 	      *" $tmp_inherited_linker_flag "*) ;;
+@@ -8001,6 +8022,13 @@ EOF
+ 	  ;;
+       esac
+ 
++      # Time to revert the changes made for nagfor.
++      func_cc_basename $CC
++      case $func_cc_basename_result in
++        nagfor*)
++          new_inherited_linker_flags=`$ECHO " $new_inherited_linker_flags" | $SED 's% -Wl,-pthread% -pthread%g'` ;;
++      esac
++
+       # move library search paths that coincide with paths to not yet
+       # installed libraries to the beginning of the library search list
+       new_libs=
+--- a/configure
++++ b/configure
+@@ -11614,6 +11614,8 @@ _LT_EOF
+ 	  whole_archive_flag_spec=
+ 	  tmp_sharedflag='--shared' ;;
+ 	nagfor*)			# NAGFOR 5.3
++	  whole_archive_flag_spec='${wl}--whole-archive`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` ${wl}--no-whole-archive'
++	  compiler_needs_object=yes
+ 	  tmp_sharedflag='-Wl,-shared' ;;
+ 	xl[cC]* | bgxl[cC]* | mpixl[cC]*) # IBM XL C 8.0 on PPC (deal with xlf below)
+ 	  tmp_sharedflag='-qmkshrobj'
+@@ -19246,6 +19248,8 @@ _LT_EOF
+ 	  whole_archive_flag_spec_FC=
+ 	  tmp_sharedflag='--shared' ;;
+ 	nagfor*)			# NAGFOR 5.3
++	  whole_archive_flag_spec_FC='${wl}--whole-archive`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` ${wl}--no-whole-archive'
++	  compiler_needs_object_FC=yes
+ 	  tmp_sharedflag='-Wl,-shared' ;;
+ 	xl[cC]* | bgxl[cC]* | mpixl[cC]*) # IBM XL C 8.0 on PPC (deal with xlf below)
+ 	  tmp_sharedflag='-qmkshrobj'

--- a/var/spack/repos/builtin/packages/mpich/nag_libtool_2.4.2_2.patch
+++ b/var/spack/repos/builtin/packages/mpich/nag_libtool_2.4.2_2.patch
@@ -1,0 +1,11 @@
+--- a/configure
++++ b/configure
+@@ -22237,6 +22237,8 @@ _LT_EOF
+ 	  whole_archive_flag_spec_F77=
+ 	  tmp_sharedflag='--shared' ;;
+ 	nagfor*)			# NAGFOR 5.3
++	  whole_archive_flag_spec_F77='${wl}--whole-archive`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` ${wl}--no-whole-archive'
++	  compiler_needs_object_F77=yes
+ 	  tmp_sharedflag='-Wl,-shared' ;;
+ 	xl[cC]* | bgxl[cC]* | mpixl[cC]*) # IBM XL C 8.0 on PPC (deal with xlf below)
+ 	  tmp_sharedflag='-qmkshrobj'

--- a/var/spack/repos/builtin/packages/mpich/nag_libtool_2.4.6.patch
+++ b/var/spack/repos/builtin/packages/mpich/nag_libtool_2.4.6.patch
@@ -1,0 +1,69 @@
+--- a/confdb/ltmain.sh
++++ b/confdb/ltmain.sh
+@@ -7867,6 +7867,13 @@ func_mode_link ()
+ 	# Convert "-framework foo" to "foo.ltframework"
+ 	if test -n "$inherited_linker_flags"; then
+ 	  tmp_inherited_linker_flags=`$ECHO "$inherited_linker_flags" | $SED 's/-framework \([^ $]*\)/\1.ltframework/g'`
++
++	  # Additionally convert " -pthread" to " -Wl,-pthread" for nagfor
++	  func_cc_basename $CC
++	  case $func_cc_basename_result in
++	    nagfor*) tmp_inherited_linker_flags=`$ECHO "$tmp_inherited_linker_flags" | $SED 's/ -pthread/ -Wl,-pthread/g'` ;;
++	  esac
++
+ 	  for tmp_inherited_linker_flag in $tmp_inherited_linker_flags; do
+ 	    case " $new_inherited_linker_flags " in
+ 	      *" $tmp_inherited_linker_flag "*) ;;
+@@ -8886,7 +8893,8 @@ func_mode_link ()
+ 	  xlcverstring="$wl-compatibility_version $wl$minor_current $wl-current_version $wl$minor_current.$revision"
+ 	  verstring="-compatibility_version $minor_current -current_version $minor_current.$revision"
+           # On Darwin other compilers
+-          case $CC in
++          func_cc_basename $CC
++          case $func_cc_basename_result in
+               nagfor*)
+                   verstring="$wl-compatibility_version $wl$minor_current $wl-current_version $wl$minor_current.$revision"
+                   ;;
+@@ -9498,6 +9506,13 @@ EOF
+ 	  ;;
+       esac
+ 
++      # Time to revert the changes made for nagfor.
++      func_cc_basename $CC
++      case $func_cc_basename_result in
++        nagfor*)
++          new_inherited_linker_flags=`$ECHO " $new_inherited_linker_flags" | $SED 's% -Wl,-pthread% -pthread%g'` ;;
++      esac
++
+       # move library search paths that coincide with paths to not yet
+       # installed libraries to the beginning of the library search list
+       new_libs=
+--- a/configure
++++ b/configure
+@@ -12583,6 +12583,8 @@ _LT_EOF
+ 	  whole_archive_flag_spec=
+ 	  tmp_sharedflag='--shared' ;;
+         nagfor*)                        # NAGFOR 5.3
++          whole_archive_flag_spec='$wl--whole-archive`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` $wl--no-whole-archive'
++          compiler_needs_object=yes
+           tmp_sharedflag='-Wl,-shared' ;;
+ 	xl[cC]* | bgxl[cC]* | mpixl[cC]*) # IBM XL C 8.0 on PPC (deal with xlf below)
+ 	  tmp_sharedflag='-qmkshrobj'
+@@ -20684,6 +20686,8 @@ _LT_EOF
+ 	  whole_archive_flag_spec_FC=
+ 	  tmp_sharedflag='--shared' ;;
+         nagfor*)                        # NAGFOR 5.3
++          whole_archive_flag_spec_FC='$wl--whole-archive`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` $wl--no-whole-archive'
++          compiler_needs_object_FC=yes
+           tmp_sharedflag='-Wl,-shared' ;;
+ 	xl[cC]* | bgxl[cC]* | mpixl[cC]*) # IBM XL C 8.0 on PPC (deal with xlf below)
+ 	  tmp_sharedflag='-qmkshrobj'
+@@ -23958,6 +23962,8 @@ _LT_EOF
+ 	  whole_archive_flag_spec_F77=
+ 	  tmp_sharedflag='--shared' ;;
+         nagfor*)                        # NAGFOR 5.3
++          whole_archive_flag_spec_F77='$wl--whole-archive`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` $wl--no-whole-archive'
++          compiler_needs_object_F77=yes
+           tmp_sharedflag='-Wl,-shared' ;;
+ 	xl[cC]* | bgxl[cC]* | mpixl[cC]*) # IBM XL C 8.0 on PPC (deal with xlf below)
+ 	  tmp_sharedflag='-qmkshrobj'

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -145,7 +145,9 @@ spack package at this time.''',
     conflicts('pmi=pmi2', when='device=ch3 netmod=ofi')
     conflicts('pmi=pmix', when='device=ch3')
 
-    # Avoid identical installations with different specs.
+    # MPICH does not require libxml2 and libpciaccess for versions before 3.3
+    # when ~hydra is set: prevent users from setting +libxml2 and +pci in this
+    # case to avoid generating an identical MPICH installation.
     conflicts('+pci', when='@:3.2~hydra')
     conflicts('+libxml2', when='@:3.2~hydra')
 

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -89,6 +89,23 @@ spack package at this time.''',
           sha256='c7d4ecf865dccff5b764d9c66b6a470d11b0b1a5b4f7ad1ffa61079ad6b5dede',
           when='@3.3:3.3.0')
 
+    # This patch for Libtool 2.4.2 enables shared libraries for NAG and is
+    # applied by MPICH starting version 3.1.
+    patch('nag_libtool_2.4.2_0.patch', when='@:3.0%nag')
+
+    # This patch for Libtool 2.4.2 fixes the problem with '-pthread' flag and
+    # enables convenience libraries for NAG. Starting version 3.1, the order of
+    # checks for FC and F77 is changed, therefore we need to apply the patch in
+    # two steps (the patch files can be merged once the support for versions
+    # 3.1 and older is dropped).
+    patch('nag_libtool_2.4.2_1.patch', when='@:3.1.3%nag')
+    patch('nag_libtool_2.4.2_2.patch', when='@:3.1.3%nag')
+
+    # This patch for Libtool 2.4.6 does the same as the previous two. The
+    # problem is not fixed upstream yet and the upper version constraint is
+    # given just to avoid application of the patch to the develop version.
+    patch('nag_libtool_2.4.6.patch', when='@3.1.4:3.3%nag')
+
     depends_on('findutils', type='build')
     depends_on('pkgconfig', type='build')
 
@@ -194,6 +211,7 @@ spack package at this time.''',
     def configure_args(self):
         spec = self.spec
         config_args = [
+            '--disable-silent-rules',
             '--enable-shared',
             '--with-pm={0}'.format('hydra' if '+hydra' in spec else 'no'),
             '--{0}-romio'.format('enable' if '+romio' in spec else 'disable'),


### PR DESCRIPTION
The dependencies on `libpciaccess` and `libxml2` come from the embedded `hwloc`, which, before MPICH 3.3, was used only for Hydra. Additionally, it is possible to use `hwloc`'s custom implementation of XML parsing instead of `libxml2`, which might be useful. For example, `libxml2.la` contains `-pthread` flag, which might not be recognized by Fortran compiler, e.g. NAG.