### PR TITLE
Adding an option to build the C api for Umpire.

### DIFF
--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -16,6 +16,13 @@ class Umpire(CMakePackage):
 
     version('develop', branch='develop', submodules='True')
     version('master', branch='master', submodules='True')
+    version('2.1.0', tag='v2.1.0', submodules='True')
+    version('2.0.0', tag='v2.0.0', submodules='True')
+    version('1.1.0', tag='v1.1.0', submodules='True')
+    version('1.0.1', tag='v1.0.1', submodules='True')
+    version('1.0.0', tag='v1.0.0', submodules='True')
+    version('0.3.5', tag='v0.3.5', submodules='True')
+    version('0.3.4', tag='v0.3.4', submodules='True')
     version('0.3.3', tag='v0.3.3', submodules='True')
     version('0.3.2', tag='v0.3.2', submodules='True')
     version('0.3.1', tag='v0.3.1', submodules='True')

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -29,7 +29,8 @@ class Umpire(CMakePackage):
     version('0.1.3', tag='v0.1.3', submodules='True')
 
     variant('cuda', default=False, description='Build with CUDA support')
-    variant('fortran', default=False, description='Build C/Fortran API')
+    variant('fortran', default=False, description='Build Fortran API')
+    variant('c', default=False, description='Build C API')
     variant('numa', default=False, description='Enable NUMA support')
 
     depends_on('cuda', when='+cuda')
@@ -49,6 +50,9 @@ class Umpire(CMakePackage):
                 '-DCUDA_TOOLKIT_ROOT_DIR=%s' % (spec['cuda'].prefix)])
         else:
             options.append('-DENABLE_CUDA=Off')
+
+        if '+c' in spec:
+            options.append('-DENABLE_C=On')
 
         if '+fortran' in spec:
             options.append('-DENABLE_FORTRAN=On')

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -37,7 +37,7 @@ class Umpire(CMakePackage):
 
     variant('cuda', default=False, description='Build with CUDA support')
     variant('fortran', default=False, description='Build Fortran API')
-    variant('c', default=False, description='Build C API')
+    variant('c', default=True, description='Build C API')
     variant('numa', default=False, description='Enable NUMA support')
 
     depends_on('cuda', when='+cuda')
@@ -45,6 +45,7 @@ class Umpire(CMakePackage):
     depends_on('cmake@3.9:', when='+cuda', type='build')
 
     conflicts('+numa', when='@:0.3.2')
+    conflicts('~c', when='+fortran', msg='Fortran API requires C API')
 
     def cmake_args(self):
         spec = self.spec


### PR DESCRIPTION
This is useful if you need to link to a C code and you're using a compiler suite that doesn't support fortran.