### PR TITLE
Added version 0.12.0 to py-pyfftw

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyfftw/package.py
+++ b/var/spack/repos/builtin/packages/py-pyfftw/package.py
@@ -20,6 +20,5 @@ class PyPyfftw(PythonPackage):
     depends_on('fftw')
     depends_on('py-setuptools',        type='build')
     depends_on('py-cython@0.29:0.999', type='build')
-    depends_on('py-numpy@1.10:1.999',   type=('build', 'run'))
     depends_on('py-numpy@1.6:',        type=('build', 'run'), when='@:0.10.4')
     depends_on('py-numpy@1.10:',       type=('build', 'run'), when='@0.11.0:')

--- a/var/spack/repos/builtin/packages/py-pyfftw/package.py
+++ b/var/spack/repos/builtin/packages/py-pyfftw/package.py
@@ -23,4 +23,5 @@ class PyPyfftw(PythonPackage):
     depends_on('py-numpy@1.10:1.999,   type=('build', 'run'))
     depends_on('py-numpy@1.6:',        type=('build', 'run'), when='@0.10.4')
     depends_on('py-numpy@1.10:',       type=('build', 'run'), when='@0.11.1')
-    depends_on('py-scipy@0.12.0:',     type=('build', 'run'))
+
+    variant('py-scipy', default=False, description='Scipy dependency is optional')

--- a/var/spack/repos/builtin/packages/py-pyfftw/package.py
+++ b/var/spack/repos/builtin/packages/py-pyfftw/package.py
@@ -21,6 +21,5 @@ class PyPyfftw(PythonPackage):
     depends_on('py-setuptools',        type='build')
     depends_on('py-cython@0.29:0.999', type='build')
     depends_on('py-numpy@1.10:1.999',   type=('build', 'run'))
-    depends_on('py-numpy@1.6:',        type=('build', 'run'), when='@0.10.4')
-    depends_on('py-numpy@1.10:',       type=('build', 'run'), when='@0.11.1')
-
+    depends_on('py-numpy@1.6:',        type=('build', 'run'), when='@:0.10.4')
+    depends_on('py-numpy@1.10:',       type=('build', 'run'), when='@0.11.0:')

--- a/var/spack/repos/builtin/packages/py-pyfftw/package.py
+++ b/var/spack/repos/builtin/packages/py-pyfftw/package.py
@@ -20,7 +20,7 @@ class PyPyfftw(PythonPackage):
     depends_on('fftw')
     depends_on('py-setuptools',        type='build')
     depends_on('py-cython@0.29:0.999', type='build')
-    depends_on('py-numpy@1.10:1.999,   type=('build', 'run'))
+    depends_on('py-numpy@1.10:1.999',   type=('build', 'run'))
     depends_on('py-numpy@1.6:',        type=('build', 'run'), when='@0.10.4')
     depends_on('py-numpy@1.10:',       type=('build', 'run'), when='@0.11.1')
 

--- a/var/spack/repos/builtin/packages/py-pyfftw/package.py
+++ b/var/spack/repos/builtin/packages/py-pyfftw/package.py
@@ -13,6 +13,7 @@ class PyPyfftw(PythonPackage):
     homepage = "http://hgomersall.github.com/pyFFTW"
     url      = "https://pypi.io/packages/source/p/pyFFTW/pyFFTW-0.10.4.tar.gz"
 
+    version('0.12.0', sha256='60988e823ca75808a26fd79d88dbae1de3699e72a293f812aa4534f8a0a58cb0')
     version('0.11.1', sha256='05ea28dede4c3aaaf5c66f56eb0f71849d0d50f5bc0f53ca0ffa69534af14926')
     version('0.10.4', sha256='739b436b7c0aeddf99a48749380260364d2dc027cf1d5f63dafb5f50068ede1a')
 

--- a/var/spack/repos/builtin/packages/py-pyfftw/package.py
+++ b/var/spack/repos/builtin/packages/py-pyfftw/package.py
@@ -24,4 +24,3 @@ class PyPyfftw(PythonPackage):
     depends_on('py-numpy@1.6:',        type=('build', 'run'), when='@0.10.4')
     depends_on('py-numpy@1.10:',       type=('build', 'run'), when='@0.11.1')
 
-    variant('py-scipy', default=False, description='Scipy dependency is optional')

--- a/var/spack/repos/builtin/packages/py-pyfftw/package.py
+++ b/var/spack/repos/builtin/packages/py-pyfftw/package.py
@@ -21,4 +21,4 @@ class PyPyfftw(PythonPackage):
     depends_on('py-setuptools',        type='build')
     depends_on('py-cython@0.29:0.999', type='build')
     depends_on('py-numpy@1.6:',        type=('build', 'run'), when='@:0.10.4')
-    depends_on('py-numpy@1.10:',       type=('build', 'run'), when='@0.11.0:')
+    depends_on('py-numpy@1.10:1.999',  type=('build', 'run'), when='@0.11.0:')

--- a/var/spack/repos/builtin/packages/py-pyfftw/package.py
+++ b/var/spack/repos/builtin/packages/py-pyfftw/package.py
@@ -18,7 +18,9 @@ class PyPyfftw(PythonPackage):
     version('0.10.4', sha256='739b436b7c0aeddf99a48749380260364d2dc027cf1d5f63dafb5f50068ede1a')
 
     depends_on('fftw')
-    depends_on('py-setuptools',    type='build')
-    depends_on('py-cython',        type='build')
-    depends_on('py-numpy@1.6:',    type=('build', 'run'))
-    depends_on('py-scipy@0.12.0:', type=('build', 'run'))
+    depends_on('py-setuptools',        type='build')
+    depends_on('py-cython@0.29:0.999', type='build')
+    depends_on('py-numpy@1.10:1.999,   type=('build', 'run'))
+    depends_on('py-numpy@1.6:',        type=('build', 'run'), when='@0.10.4')
+    depends_on('py-numpy@1.10:',       type=('build', 'run'), when='@0.11.1')
+    depends_on('py-scipy@0.12.0:',     type=('build', 'run'))


### PR DESCRIPTION
Hi all,
This small PR allows **pyfftw** version 0.12.0 to be fetched/pulled in order to fix #15218.

---

#### Successful **pyfftw** installation on the system with:

 1. macOS Catalina - %clang@11.0.0-apple (but with gcc@9.2.0 fortran compilers - see compilers.yaml below)
 2. spack installed python (@3.7.6)
 3. spack installed py-scipy (@1.4.1)
 4. spack installed py-pfftw (@0.11.1)
 5. spack commit 
```console
$ git rev-parse HEAD
f7d13b4779dd3caa8046ff92a07342bdbccb2969
```