### PR TITLE
Add new version of libfabric that builds on macOS

### DIFF
--- a/var/spack/repos/builtin/packages/libfabric/package.py
+++ b/var/spack/repos/builtin/packages/libfabric/package.py
@@ -12,21 +12,22 @@ class Libfabric(AutotoolsPackage):
        fabric communication services to applications."""
 
     homepage = "https://libfabric.org/"
+    url      = "https://github.com/ofiwg/libfabric/releases/download/v1.8.0/libfabric-1.8.0.tar.bz2"
     git      = "https://github.com/ofiwg/libfabric.git"
 
-    version('develop', branch='master')
+    version('master', branch='master')
     version('1.9.1rc1', sha256='fdf89a0797f0d923aaef2c41cc70be45716e4d07dc5d318365b9c17795eb49ab')
-    version('1.9.0', sha256='559bfb7376c38253c936d0b104591c3394880376d676894895706c4f5f88597c')
+    version('1.9.0', sha256='559bfb7376c38253c936d0b104591c3394880376d676894895706c4f5f88597c', preferred=True)
     version('1.8.1', sha256='3c560b997f9eafd89f961dd8e8a29a81aad3e39aee888e3f3822da419047dc88')
     version('1.8.0', sha256='c4763383a96af4af52cd81b3b094227f5cf8e91662f861670965994539b7ee37')
-    version('1.7.1', sha256='312e62c57f79b7274f89c41823932c00b15f1cc8de9c1f8dce17cd7fdae66fa1')
-    version('1.7.0', sha256='9d7059e2ef48341f967f2a20ee215bc50f9079b32aad485f654098f83040e4be')
-    version('1.6.2', sha256='b1a9cf8c47189a1c918f8b5710d05cb50df6b47a1c9b2ba51d927e97503b4df0')
-    version('1.6.1', sha256='ac85f18bbf09226e868d72771ecba39cfdb7915aab3aeb855c95f8be7817f8bc')
-    version('1.6.0', sha256='cd7d4543cf706820e4a33003457eff97336b5160f35d0e8b001aea18b5470423')
-    version('1.5.3', sha256='770e505185074b4c66a0c33ac2155670142746a71a6299c286f6d5cd220cbff8')
-    version('1.5.0', sha256='f62709e70fab6abea719402da854f3c6ab60369be6b1e31e4f77554c7454da28')
-    version('1.4.2', sha256='858e30d92b69ee5e47ac10a8ac0c731b491d75a6e28267a128f3d6eb43f940a1')
+    version('1.7.1', sha256='f4e9cc48319763cff4943de96bf527b737c9f1d6ac3088b8b5c75d07bd719569')
+    version('1.7.0', sha256='b3dd9cc0fa36fe8c3b9997ba279ec831a905704816c25fe3c4c09fc7eeceaac4')
+    version('1.6.2', sha256='ec63f61f5e529964ef65fd101627d8782c0efc2b88b3d5fc7f0bfd2c1e95ab2c')
+    version('1.6.1', sha256='33215a91450e2234ebdc7c467f041b6757f76f5ba926425e89d80c27b3fd7da2')
+    version('1.6.0', sha256='b3ce7bd655052ea4da7bf01a3177d96d94e5f41b3fd6011ac43f50fcb2dc7581')
+    version('1.5.3', sha256='f62a40da06f8951db267a59a4ee7363b6ee60a7abbc55cd5db6c8b067d93fa0c')
+    version('1.5.0', sha256='88a8ad6772f11d83e5b6f7152a908ffcb237af273a74a1bd1cb4202f577f1f23')
+    version('1.4.2', sha256='5d027d7e4e34cb62508803e51d6bd2f477932ad68948996429df2bfff37ca2a5')
 
     fabrics = ('psm',
                'psm2',
@@ -108,13 +109,6 @@ class Libfabric(AutotoolsPackage):
 
     conflicts('@1.9.0', when='platform=darwin',
               msg='This distribution is missing critical files')
-
-    def url_for_version(self, version):
-        return '{base}/v{version}/libfabric-{version}.tar.{ext}'.format(
-            base='https://github.com/ofiwg/libfabric/releases/download',
-            version=str(version),
-            ext=('bz2' if version >= Version('1.8') else 'gz')
-        )
 
     def setup_build_environment(self, env):
         if self.run_tests:

--- a/var/spack/repos/builtin/packages/libfabric/package.py
+++ b/var/spack/repos/builtin/packages/libfabric/package.py
@@ -12,16 +12,13 @@ class Libfabric(AutotoolsPackage):
        fabric communication services to applications."""
 
     homepage = "https://libfabric.org/"
-    url      = "https://github.com/ofiwg/libfabric/releases/download/v1.6.1/libfabric-1.6.1.tar.gz"
     git      = "https://github.com/ofiwg/libfabric.git"
 
     version('develop', branch='master')
-    version('1.9.0', sha256='559bfb7376c38253c936d0b104591c3394880376d676894895706c4f5f88597c',
-       url='https://github.com/ofiwg/libfabric/releases/download/v1.9.0/libfabric-1.9.0.tar.bz2')
-    version('1.8.1', sha256='3c560b997f9eafd89f961dd8e8a29a81aad3e39aee888e3f3822da419047dc88',
-       url='https://github.com/ofiwg/libfabric/releases/download/v1.8.1/libfabric-1.8.1.tar.bz2')
-    version('1.8.0', sha256='c4763383a96af4af52cd81b3b094227f5cf8e91662f861670965994539b7ee37',
-       url='https://github.com/ofiwg/libfabric/releases/download/v1.8.0/libfabric-1.8.0.tar.bz2')
+    version('1.9.1rc1', sha256='fdf89a0797f0d923aaef2c41cc70be45716e4d07dc5d318365b9c17795eb49ab')
+    version('1.9.0', sha256='559bfb7376c38253c936d0b104591c3394880376d676894895706c4f5f88597c')
+    version('1.8.1', sha256='3c560b997f9eafd89f961dd8e8a29a81aad3e39aee888e3f3822da419047dc88')
+    version('1.8.0', sha256='c4763383a96af4af52cd81b3b094227f5cf8e91662f861670965994539b7ee37')
     version('1.7.1', sha256='312e62c57f79b7274f89c41823932c00b15f1cc8de9c1f8dce17cd7fdae66fa1')
     version('1.7.0', sha256='9d7059e2ef48341f967f2a20ee215bc50f9079b32aad485f654098f83040e4be')
     version('1.6.2', sha256='b1a9cf8c47189a1c918f8b5710d05cb50df6b47a1c9b2ba51d927e97503b4df0')
@@ -108,6 +105,16 @@ class Libfabric(AutotoolsPackage):
              url='https://github.com/ofiwg/fabtests/releases/download/v1.4.2/fabtests-1.4.2.tar.gz',
              sha256='3b78d0ca1b223ff21b7f5b3627e67e358e3c18b700f86b017e2233fee7e88c2e',
              placement='fabtests', when='@1.4.2')
+
+    conflicts('@1.9.0', when='platform=darwin',
+              msg='This distribution is missing critical files')
+
+    def url_for_version(self, version):
+        return '{base}/v{version}/libfabric-{version}.tar.{ext}'.format(
+            base='https://github.com/ofiwg/libfabric/releases/download',
+            version=str(version),
+            ext=('bz2' if version >= Version('1.8') else 'gz')
+        )
 
     def setup_build_environment(self, env):
         if self.run_tests:


### PR DESCRIPTION
See https://github.com/ofiwg/libfabric/issues/5339

Fixes https://github.com/spack/spack/issues/15244

Also reduced copy-paste of URLs with `url_for_version`.