### PR TITLE
Environments: specify packages for developer builds

### DIFF
--- a/lib/spack/spack/cmd/dev_build.py
+++ b/lib/spack/spack/cmd/dev_build.py
@@ -77,7 +77,7 @@ def dev_build(self, args):
     source_path = os.path.abspath(source_path)
 
     # Forces the build to run out of the source directory.
-    spec.constrain('dev_build=true dev_path=%s' % source_path)
+    spec.constrain('dev_path=%s' % source_path)
 
     spec.concretize()
     package = spack.repo.get(spec)

--- a/lib/spack/spack/cmd/dev_build.py
+++ b/lib/spack/spack/cmd/dev_build.py
@@ -76,7 +76,7 @@ def dev_build(self, args):
         source_path = os.getcwd()
     source_path = os.path.abspath(source_path)
 
-    # Forces the build to run out of the current directory.
+    # Forces the build to run out of the source directory.
     spec.constrain('dev_build=true dev_path=%s' % source_path)
 
     spec.concretize()

--- a/lib/spack/spack/cmd/dev_build.py
+++ b/lib/spack/spack/cmd/dev_build.py
@@ -77,7 +77,7 @@ def dev_build(self, args):
     source_path = os.path.abspath(source_path)
 
     # Forces the build to run out of the current directory.
-    spec.develop = source_path
+    spec.constrain('dev_build=true dev_path=%s' % source_path)
 
     spec.concretize()
     package = spack.repo.get(spec)

--- a/lib/spack/spack/cmd/dev_build.py
+++ b/lib/spack/spack/cmd/dev_build.py
@@ -12,7 +12,6 @@ import spack.config
 import spack.cmd
 import spack.cmd.common.arguments as arguments
 import spack.repo
-from spack.stage import DIYStage
 
 description = "developer build: build from code in current working directory"
 section = "build"

--- a/lib/spack/spack/cmd/dev_build.py
+++ b/lib/spack/spack/cmd/dev_build.py
@@ -72,6 +72,14 @@ def dev_build(self, args):
             "spack dev-build spec must have a single, concrete version. "
             "Did you forget a package version number?")
 
+    source_path = args.source_path
+    if source_path is None:
+        source_path = os.getcwd()
+    source_path = os.path.abspath(source_path)
+
+    # Forces the build to run out of the current directory.
+    spec.develop = source_path
+
     spec.concretize()
     package = spack.repo.get(spec)
 
@@ -79,14 +87,6 @@ def dev_build(self, args):
         tty.error("Already installed in %s" % package.prefix)
         tty.msg("Uninstall or try adding a version suffix for this dev build.")
         sys.exit(1)
-
-    source_path = args.source_path
-    if source_path is None:
-        source_path = os.getcwd()
-    source_path = os.path.abspath(source_path)
-
-    # Forces the build to run out of the current directory.
-    package.stage = DIYStage(source_path)
 
     # disable checksumming if requested
     if args.no_checksum:

--- a/lib/spack/spack/cmd/dev_build.py
+++ b/lib/spack/spack/cmd/dev_build.py
@@ -97,7 +97,6 @@ def dev_build(self, args):
         keep_prefix=args.keep_prefix,
         install_deps=not args.ignore_deps,
         verbose=not args.quiet,
-        keep_stage=True,   # don't remove source dir for dev build.
         dirty=args.dirty,
         stop_before=args.before,
         stop_at=args.until)

--- a/lib/spack/spack/cmd/develop.py
+++ b/lib/spack/spack/cmd/develop.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
-import llnl.util.tty as tty
 
 import spack.cmd
 import spack.cmd.common.arguments as arguments

--- a/lib/spack/spack/cmd/develop.py
+++ b/lib/spack/spack/cmd/develop.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
 
+import llnl.util.tty as tty
+
 import spack.cmd
 import spack.cmd.common.arguments as arguments
 import spack.environment as ev
@@ -16,10 +18,11 @@ level = "long"
 
 
 def setup_parser(subparser):
-    subparser.add_argument('-p', '--path',
-                           help='Source location of package')
-    subparser.add_argument('--no-clone', action='store_true',
-                           help='The package already exists at the source path')
+    subparser.add_argument(
+        '-p', '--path', help='Source location of package')
+    subparser.add_argument(
+        '--no-clone', action='store_true',
+        help='Do not clone. The package already exists at the source path')
     arguments.add_common_arguments(subparser, ['spec'])
 
 

--- a/lib/spack/spack/cmd/develop.py
+++ b/lib/spack/spack/cmd/develop.py
@@ -18,8 +18,8 @@ level = "long"
 def setup_parser(subparser):
     subparser.add_argument('-p', '--path',
                            help='Source location of package')
-    subparser.add_argument('-c', '--clone', action='store_true',
-                           help='Clone package into source path')
+    subparser.add_argument('--no-clone', action='store_true',
+                           help='The package already exists at the source path')
     arguments.add_common_arguments(subparser, ['spec'])
 
 
@@ -27,27 +27,43 @@ def develop(parser, args):
     env = ev.get_env(args, 'develop', required=True)
 
     if not args.spec:
-        raise SpackError("No spec provided to spack develop command")
+        if args.no_clone:
+            raise SpackError("No spec provided to spack develop command")
+        else:
+            # download all dev specs
+            for name, entry in env.dev_specs.items():
+                path = entry.get('path', name)
+                abspath = path if os.path.isabs(path) else os.path.join(
+                    env.path, path)
+                if os.path.exists(abspath):
+                    msg = "Skipping developer download of %s" % entry['spec']
+                    msg += " because its path already exists."
+                    tty.msg(msg)
+                    continue
+                spack.spec.Spec(entry['spec']).package.fetcher.clone(abspath)
+
+            if not env.dev_specs:
+                tty.warn("No develop specs to download")
 
     specs = spack.cmd.parse_specs(args.spec)
-    if len(specs) != 1:
-        raise SpackError("spack develop requires exactly one named spec")
+    if len(specs) > 1:
+        raise SpackError("spack develop requires at most one named spec")
 
     spec = specs[0]
     if not spec.versions.concrete:
         raise SpackError("Packages to develop must have a concrete version")
 
-    if args.clone:
-        path = args.path or spec.name
-    else:
+    if args.no_clone:
         path = args.path
+    else:
+        path = args.path or spec.name
 
     if not path:
         raise SpackError("Must provide either path or clone argument")
-    elif not (args.clone or os.path.exists(path)):
+    elif args.no_clone and not os.path.exists(path):
         raise SpackError("Provided path %s does not exist" % args.path)
 
     with env.write_transaction():
-        changed = env.develop(spec, path, args.clone)
+        changed = env.develop(spec, path, not args.no_clone)
         if changed:
             env.write()

--- a/lib/spack/spack/cmd/develop.py
+++ b/lib/spack/spack/cmd/develop.py
@@ -56,15 +56,16 @@ def develop(parser, args):
     if not spec.versions.concrete:
         raise SpackError("Packages to develop must have a concrete version")
 
-    if args.no_clone:
-        path = args.path
-    else:
-        path = args.path or spec.name
+    # default path is relative path to spec.name
+    path = args.path or spec.name
 
-    if not path:
-        raise SpackError("Must provide either path or clone argument")
-    elif args.no_clone and not os.path.exists(path):
-        raise SpackError("Provided path %s does not exist" % args.path)
+    # get absolute path to check
+    abspath = path
+    if not os.path.isabs(abspath):
+        abspath = os.path.join(env.path, path)
+
+    if args.no_clone and not os.path.exists(abspath):
+        raise SpackError("Provided path %s does not exist" % abspath)
 
     with env.write_transaction():
         changed = env.develop(spec, path, not args.no_clone)

--- a/lib/spack/spack/cmd/develop.py
+++ b/lib/spack/spack/cmd/develop.py
@@ -12,7 +12,7 @@ import spack.environment as ev
 
 from spack.error import SpackError
 
-description = 'add a spec to an environments dev-build information'
+description = "add a spec to an environment's dev-build information"
 section = "environments"
 level = "long"
 

--- a/lib/spack/spack/cmd/develop.py
+++ b/lib/spack/spack/cmd/develop.py
@@ -83,7 +83,7 @@ def develop(parser, args):
     # clone default: only if the path doesn't exist
     clone = args.clone
     if clone is None:
-        clone = os.path.exists(abspath)
+        clone = not os.path.exists(abspath)
 
     if not clone and not os.path.exists(abspath):
         raise SpackError("Provided path %s does not exist" % abspath)

--- a/lib/spack/spack/cmd/develop.py
+++ b/lib/spack/spack/cmd/develop.py
@@ -28,6 +28,11 @@ def setup_parser(subparser):
     clone_group.add_argument(
         '--clone', action='store_true', dest='clone', default=None,
         help='Clone the package even if the path already exists')
+
+    subparser.add_argument(
+        '-f', '--force',
+        help='Remove any files or directories that block cloning source code')
+
     arguments.add_common_arguments(subparser, ['spec'])
 
 
@@ -81,6 +86,15 @@ def develop(parser, args):
 
     if not clone and not os.path.exists(abspath):
         raise SpackError("Provided path %s does not exist" % abspath)
+
+    if clone and os.path.exists(abspath):
+        if args.force:
+            shutil.rmtree(abspath)
+        else:
+            raise SpackError(
+                "Path %s already exists and cannot be cloned to." % abspath
+                " Use `spack develop -f` to overwrite."
+            )
 
     with env.write_transaction():
         changed = env.develop(spec, path, clone)

--- a/lib/spack/spack/cmd/develop.py
+++ b/lib/spack/spack/cmd/develop.py
@@ -2,9 +2,11 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import glob
 import os
 
 import llnl.util.tty as tty
+import llnl.util.filesystem as fs
 
 import spack.cmd
 import spack.cmd.common.arguments as arguments
@@ -43,6 +45,8 @@ def develop(parser, args):
             path = entry.get('path', name)
             abspath = path if os.path.isabs(path) else os.path.join(
                 env.path, path)
+            fs.mkdirp(abspath)
+
             if os.path.exists(abspath):
                 msg = "Skipping developer download of %s" % entry['spec']
                 msg += " because its path already exists."
@@ -50,14 +54,29 @@ def develop(parser, args):
                 continue
 
             stage = spack.spec.Spec(entry['spec']).package.stage
-            # Iterate over composite strategy to update path
-            # This will include resources in what we clone
-            for stage_obj in stage:
-                stage_obj.path = abspath
-                stage_obj.source_path = abspath
             stage.create()
             stage.fetch()
             stage.expand_archive()
+
+            # glob all files and directories in the stage source_path
+            hidden_entries = glob.glob(os.path.join(stage.source_path, '.*'))
+            entries = glob.glob(os.path.join(stage.source_path, '*'))
+
+            # Move all files from stage to destination directory
+            # Include hidden files for VCS repo history
+            for entry in hidden_entries + entries:
+                if os.path.isdir(entry):
+                    dest = os.path.join(abspath, os.path.basename(entry))
+                    shutil.copytree(entry, dest)
+                else:
+                    shutil.copy2(entry, abspath)
+
+            # copy archive file if we downloaded from url -- replaces for vcs
+            if stage.archive_file and os.path.exists(stage.archive_file):
+                shutil.copy2(stage.archive_file, abspath)
+
+            # remove leftover stage
+            stage.destroy()
 
         if not env.dev_specs:
             tty.warn("No develop specs to download")

--- a/lib/spack/spack/cmd/develop.py
+++ b/lib/spack/spack/cmd/develop.py
@@ -44,7 +44,7 @@ def develop(parser, args):
                 tty.msg(msg)
                 continue
 
-            stage = package = spack.spec.Spec(entry['spec']).package.stage
+            stage = spack.spec.Spec(entry['spec']).package.stage
             # Iterate over composite strategy to update path
             # This will include resources in what we clone
             for stage_obj in stage:

--- a/lib/spack/spack/cmd/develop.py
+++ b/lib/spack/spack/cmd/develop.py
@@ -91,10 +91,9 @@ def develop(parser, args):
         if args.force:
             shutil.rmtree(abspath)
         else:
-            raise SpackError(
-                "Path %s already exists and cannot be cloned to." % abspath
-                " Use `spack develop -f` to overwrite."
-            )
+            msg = "Path %s already exists and cannot be cloned to." % abspath
+            msg += " Use `spack develop -f` to overwrite."
+            raise SpackError(msg)
 
     with env.write_transaction():
         changed = env.develop(spec, path, clone)

--- a/lib/spack/spack/cmd/develop.py
+++ b/lib/spack/spack/cmd/develop.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
+import shutil
 
 import llnl.util.tty as tty
 

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -392,13 +392,8 @@ environment variables:
                 if not answer:
                     tty.die('Reinstallation aborted.')
 
-            for abstract, concrete in zip(abstract_specs, specs):
-                if concrete in installed:
-                    with fs.replace_directory_transaction(concrete.prefix):
-                        install_spec(args, kwargs, abstract, concrete)
-                else:
-                    install_spec(args, kwargs, abstract, concrete)
+            # overwrite all concrete explicit specs from this build
+            kwargs['overwrite'] = [spec.dag_hash() for spec in specs]
 
-        else:
-            for abstract, concrete in zip(abstract_specs, specs):
-                install_spec(args, kwargs, abstract, concrete)
+        for abstract, concrete in zip(abstract_specs, specs):
+            install_spec(args, kwargs, abstract, concrete)

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -383,7 +383,7 @@ class Concretizer(object):
                 msg += " '%s' set to 'any' and preference is." % name
                 msg += "'%s'. Set the variant to a non 'any'" % var.value
                 msg += " value or set a preference for variant '%s'." % name
-                raise UnsatisfiableVariantSpecError(msg)
+                raise vt.UnsatisfiableVariantSpecError(msg)
 
         return changed
 

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -74,7 +74,7 @@ class Concretizer(object):
                 continue
             if dep.name in dev_info:
                 path = dev_info[dep.name]['path']
-                abs_path = path if os.path.isabs(path) else os.path.join(
+                path = path if os.path.isabs(path) else os.path.join(
                     env.path, path)
                 dep.develop = path
                 dep.constrain(dev_info[dep.name]['spec'])

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -72,7 +72,7 @@ class Concretizer(object):
                 # there's nothing more to do
                 continue
             elif 'dev_path' in dep.variants:
-                var = dep.variants.setdefault(
+                dep.variants.setdefault(
                     'dev_build', vt.BoolValuedVariant('dev_build', True))
                 changed = True
                 continue
@@ -82,15 +82,15 @@ class Concretizer(object):
                 path = path if os.path.isabs(path) else os.path.join(
                     env.path, path)
 
-                path_var = dep.variants.setdefault(
+                dep.variants.setdefault(
                     'dev_path', vt.SingleValuedVariant('dev_path', path))
-                dev_var = dep.variants.setdefault(
+                dep.variants.setdefault(
                     'dev_build', vt.BoolValuedVariant('dev_build', True))
                 dep.constrain(dev_info[dep.name]['spec'])
                 changed = True
             elif any('develop' in dep_dep.variants
                      for dep_dep in dep.traverse()):
-                var = dep.variants.setdefault(
+                dep.variants.setdefault(
                     'dev_build', vt.BoolValuedVariant('dev_build', True))
                 changed = True
         return changed

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -73,9 +73,9 @@ class Concretizer(object):
             if dep.develop:
                 continue
             if dep.name in dev_info:
-                root = env.path  # We know it exists if dev_info does
                 path = dev_info[dep.name]['path']
-                path = path if os.path.isabs(path) else os.path.join(root, path)
+                abs_path = path if os.path.isabs(path) else os.path.join(
+                    env.path, path)
                 dep.develop = path
                 dep.constrain(dev_info[dep.name]['spec'])
                 changed = True

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -73,10 +73,13 @@ class Concretizer(object):
             if dep.develop:
                 continue
             if dep.name in dev_info:
-                dep.develop = dev_info[dep.name]['path']
+                root = env.path  # We know it exists if dev_info does
+                path = dev_info[dep.name]['path']
+                path = path if os.path.isabs(path) else os.path.join(root, path)
+                dep.develop = path
                 dep.constrain(dev_info[dep.name]['spec'])
                 changed = True
-            if any(dep_dep.develop for dep_dep in dep.traverse()):
+            elif any(dep_dep.develop for dep_dep in dep.traverse()):
                 dep.develop = True
                 changed = True
         return changed

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -88,8 +88,10 @@ class Concretizer(object):
                     'dev_build', vt.BoolValuedVariant('dev_build', True))
                 dep.constrain(dev_info[dep.name]['spec'])
                 changed = True
-            elif any('develop' in dep_dep.variants
-                     for dep_dep in dep.traverse()):
+            elif 'dev_build' in dep.variants:
+                # Not direct dev build and already set transitively
+                continue
+            elif any('dev_build' in dd.variants for dd in dep.traverse()):
                 dep.variants.setdefault(
                     'dev_build', vt.BoolValuedVariant('dev_build', True))
                 changed = True

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -377,7 +377,7 @@ class Concretizer(object):
                 msg += " '%s' set to 'any' and preference is." % name
                 msg += "'%s'. Set the variant to a non 'any'" % var.value
                 msg += " value or set a preference for variant '%s'." % name
-                raise vt.UnsatisfiableVariantSpecError(msg)
+                raise NonDeterministicVariantError(msg)
 
         return changed
 
@@ -805,3 +805,7 @@ class NoBuildError(spack.error.SpackError):
         msg = ("The spec\n    '%s'\n    is configured as not buildable, "
                "and no matching external installs were found")
         super(NoBuildError, self).__init__(msg % spec)
+
+
+class NonDeterministicVariantError(spack.error.SpecError):
+    """Raised when a spec variant is set to 'any' and concretizes to 'none'."""

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -50,7 +50,7 @@ from spack.version import Version, VersionChecksumError
 __all__ = []
 
 #: These are variant names used by Spack internally; packages can't use them
-reserved_names = ['patches']
+reserved_names = ['patches', 'dev_path', 'dev_build']
 
 _patch_order_index = 0
 

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -50,7 +50,7 @@ from spack.version import Version, VersionChecksumError
 __all__ = []
 
 #: These are variant names used by Spack internally; packages can't use them
-reserved_names = ['patches', 'dev_path', 'dev_build']
+reserved_names = ['patches', 'dev_path']
 
 _patch_order_index = 0
 

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -716,6 +716,8 @@ class Environment(object):
             # do not check paths because `spack develop` will clone all develop
             # specs when run with no args
             # default path is the spec name
+            assert re.match(r'{0}?(.*{0})*.*'.format(os.sep),
+                            entry.get('path', name))
             if 'path' not in entry:
                 self.dev_specs[name]['path'] = name
 

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -711,12 +711,10 @@ class Environment(object):
         # Retrieve dev-build packages:
         self.dev_specs = configuration['develop']
         for name, entry in self.dev_specs.items():
-            # Path must exist and spec must include version
+            # spec must include a concrete version
             assert Spec(entry['spec']).version
-            path = entry['path']
-            path = path if os.path.isabs(path) else os.path.join(
-                self.path, path)
-            assert os.path.exists(path)
+            # do not check paths because `spack develop` will clone all develop
+            # specs when run with no args
 
     @property
     def user_specs(self):

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -713,9 +713,6 @@ class Environment(object):
         for name, entry in self.dev_specs.items():
             # spec must include a concrete version
             assert Spec(entry['spec']).version.concrete
-            # very basic regex match for a valid path, do not test existence
-            assert re.match(r'{0}?(.*{0})*.*'.format(os.sep),
-                            entry.get('path', name))
             # default path is the spec name
             if 'path' not in entry:
                 self.dev_specs[name]['path'] = name

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1352,8 +1352,9 @@ class Environment(object):
             return True
 
         # if it's not a direct dev build and its dependencies haven't
-        # changed, it hasn't changed. Don't use satisfaction here because if it
-        # exists, then we need the value later
+        # changed, it hasn't changed.
+        # We don't merely check satisfaction (spec.satisfies('dev_path=any')
+        # because we need the value of the variant in the next block of code
         dev_path_var = spec.variants.get('dev_path', None)
         if not dev_path_var:
             return False

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -715,6 +715,9 @@ class Environment(object):
             assert Spec(entry['spec']).version
             # do not check paths because `spack develop` will clone all develop
             # specs when run with no args
+            # default path is the spec name
+            if 'path' not in entry:
+                self.dev_specs[name]['path'] = name
 
     @property
     def user_specs(self):
@@ -1673,7 +1676,12 @@ class Environment(object):
         yaml_dict['view'] = view
 
         if self.dev_specs:
-            yaml_dict['develop'] = self.dev_specs
+            # Remove entries that are mirroring defaults
+            write_dev_specs = copy.deepcopy(self.dev_specs)
+            for name, entry in write_dev_specs.items():
+                if entry['path'] == name:
+                    del entry['path']
+            yaml_dict['develop'] = write_dev_specs
         else:
             yaml_dict.pop('develop', None)
 

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -712,7 +712,7 @@ class Environment(object):
         self.dev_specs = configuration['develop']
         for name, entry in self.dev_specs.items():
             # spec must include a concrete version
-            assert Spec(entry['spec']).version
+            assert Spec(entry['spec']).version.concrete
             # do not check paths because `spack develop` will clone all develop
             # specs when run with no args
             # default path is the spec name

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import collections
+import glob
 import os
 import re
 import sys
@@ -1035,17 +1036,36 @@ class Environment(object):
                     (spec, path))
 
         if clone:
+            # Get the source code via staging API
+            stage = spec.package.stage
+            stage.create()
+            stage.fetch()
+            stage.expand_archive()
+
+            # glob all files and directories in the stage source_path
+            hidden_entries = glob.glob(os.path.join(stage.source_path, '.*'))
+            entries = glob.glob(os.path.join(stage.source_path, '*'))
+
+            # Create destination directory
             abspath = path if os.path.isabs(path) else os.path.join(
                 self.path, path)
+            fs.mkdirp(abspath)
 
-            # Iterate over composite strategy to update path
-            # This will include resources in what we clone
-            for stage_obj in spec.package.stage:
-                stage_obj.path = abspath
-                stage_obj.source_path = abspath
-            spec.package.stage.create()
-            spec.package.stage.fetch()
-            spec.package.stage.expand_archive()
+            # Move all files from stage to destination directory
+            # Include hidden files for VCS repo history
+            for entry in hidden_entries + entries:
+                if os.path.isdir(entry):
+                    dest = os.path.join(abspath, os.path.basename(entry))
+                    shutil.copytree(entry, dest)
+                else:
+                    shutil.copy2(entry, abspath)
+
+            # copy archive file if we downloaded from url -- replaces for vcs
+            if stage.archive_file and os.path.exists(stage.archive_file):
+                shutil.copy2(stage.archive_file, abspath)
+
+            # remove leftover stage
+            stage.destroy()
 
         # If it wasn't already in the list, append it
         self.dev_specs[spec.name] = {'path': path, 'spec': str(spec)}

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -990,7 +990,15 @@ class Environment(object):
                 del self.specs_by_hash[dag_hash]
 
     def develop(self, spec, path, clone=False):
-        """Add dev-build info for spec, set to version and path.
+        """Add dev-build info for package
+
+        Args:
+            spec (Spec): Set constraints on development specs. Must include a
+        concrete version.
+            path (string): Path to find code for developer builds. Relative
+        paths will be resolved relative to the environment.
+            clone (bool, default False): Clone the package code to the path.
+        If clone is False Spack will assume the code is already present at path.
 
         Returns (bool): True iff the environment was changed.
         """

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -30,7 +30,6 @@ import spack.stage
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
 import spack.config
-import spack.fetch_strategy as fetch
 import spack.user_environment as uenv
 from spack.filesystem_view import YamlFilesystemView
 import spack.util.environment
@@ -715,7 +714,8 @@ class Environment(object):
             # Path must exist and spec must include version
             assert Spec(entry['spec']).version
             path = entry['path']
-            path = path if os.path.isabs(path) else os.path.join(self.path, path)
+            path = path if os.path.isabs(path) else os.path.join(
+                self.path, path)
             assert os.path.exists(path)
 
     @property
@@ -1019,7 +1019,8 @@ class Environment(object):
 
         if clone:
             # Not really cloning if it's a url-fetched version
-            abspath = path if os.path.isabs(path) else os.path.join(self.path, path)
+            abspath = path if os.path.isabs(path) else os.path.join(
+                self.path, path)
             spec.package.fetcher.clone(abspath)
 
         # If it wasn't already in the list, append it
@@ -1346,14 +1347,16 @@ class Environment(object):
                 # Use verbose for dev-build packages
                 install_args['verbose'] = True
 
-                # Determine whether source has changed since it was last installed
+                # Determine whether source has changed since it was last
+                # installed
                 force = False
                 _, record = spack.store.db.query_by_spec_hash(spec.dag_hash())
                 if record:
-                    source_mtime = fs.last_modification_time_recursive(source_path)
+                    source_mtime = fs.last_modification_time_recursive(
+                        source_path)
                     install_time = record.installation_time
                     if source_mtime > install_time:
-                        force=True
+                        force = True
 
                 # overwrite if the source changed
                 if force:

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1338,7 +1338,7 @@ class Environment(object):
                     return True
 
                 # if any dep needs overwrite, then overwrite this package
-                any_rebuild = any(needs_overwite(dep) for dep in deps)
+                any_rebuild = any(needs_overwrite(dep) for dep in deps)
                 if any_rebuild:
                     return True
 

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1032,7 +1032,6 @@ class Environment(object):
                     (spec, path))
 
         if clone:
-            # Not really cloning if it's a url-fetched version
             abspath = path if os.path.isabs(path) else os.path.join(
                 self.path, path)
 

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -998,7 +998,8 @@ class Environment(object):
             path (string): Path to find code for developer builds. Relative
         paths will be resolved relative to the environment.
             clone (bool, default False): Clone the package code to the path.
-        If clone is False Spack will assume the code is already present at path.
+        If clone is False Spack will assume the code is already present at
+        path.
 
         Returns (bool): True iff the environment was changed.
         """

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1012,11 +1012,13 @@ class Environment(object):
                         tty.msg("Updating development path for spec %s" % spec)
                         break
                 else:
-                    tty.msg("Updating development spec for package %s" %
-                            spec.name)
+                    msg = "Updating development spec for package "
+                    msg += "%s with path %s" % (spec.name, path)
+                    tty.msg(msg)
                     break
         else:
-            tty.msg("Configuring spec %s for development" % spec)
+            tty.msg("Configuring spec %s for development at path %s" %
+                    (spec, path))
 
         if clone:
             # Not really cloning if it's a url-fetched version

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -713,11 +713,10 @@ class Environment(object):
         for name, entry in self.dev_specs.items():
             # spec must include a concrete version
             assert Spec(entry['spec']).version.concrete
-            # do not check paths because `spack develop` will clone all develop
-            # specs when run with no args
-            # default path is the spec name
+            # very basic regex match for a valid path, do not test existence
             assert re.match(r'{0}?(.*{0})*.*'.format(os.sep),
                             entry.get('path', name))
+            # default path is the spec name
             if 'path' not in entry:
                 self.dev_specs[name]['path'] = name
 

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1325,19 +1325,6 @@ class Environment(object):
 
         for dev_pkg, entry in self.dev_specs.items():
             if spec.name == dev_pkg:
-                dev_spec = entry['spec']
-                if not spec.satisfies(dev_spec, strict=True):
-                    msg = 'Spec %s' % spec
-                    msg += ' does not match development spec %s' % dev_spec
-                    msg += ' for package %s' % spec.name
-                    raise SpackEnvironmentError(msg)
-
-                # setup stage
-                path = entry['path']
-                source_path = path if os.path.isabs(path) else os.path.join(
-                    self.path, path)
-                package.stage = spack.stage.DIYStage(source_path)
-
                 # Don't delete dev-build stages
                 install_args['keep_stage'] = True
 

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1406,15 +1406,11 @@ class Environment(object):
         with spack.store.db.read_transaction():
             for concretized_hash in self.concretized_order:
                 spec = self.specs_by_hash[concretized_hash]
-                if not spec.package.installed or any(
-                    spec.satisfies(d) for d in self.dev_specs
-                ):
+                if not spec.package.installed or spec.satisfies('+dev_build'):
+                    # If it's a dev build it could need to be reinstalled
                     specs_to_install.append(spec)
 
-        # Sort by total deps so specs have to be installed after dependencies
-        # This ensures dev-builds done in appropriate order
-        for spec in sorted(specs_to_install,
-                           key=lambda spec: len(list(spec.traverse()))):
+        for spec in specs_to_install:
             # Parse cli arguments and construct a dictionary
             # that will be passed to Package.do_install API
             kwargs = dict()

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -994,14 +994,15 @@ class Environment(object):
 
         Args:
             spec (Spec): Set constraints on development specs. Must include a
-        concrete version.
+                concrete version.
             path (string): Path to find code for developer builds. Relative
-        paths will be resolved relative to the environment.
+                paths will be resolved relative to the environment.
             clone (bool, default False): Clone the package code to the path.
-        If clone is False Spack will assume the code is already present at
-        path.
+                If clone is False Spack will assume the code is already present
+                at ``path``.
 
-        Returns (bool): True iff the environment was changed.
+        Return:
+            (bool): True iff the environment was changed.
         """
         spec = spec.copy()  # defensive copy since we access cached attributes
 

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1318,15 +1318,18 @@ class Environment(object):
             def needs_overwrite(spec):
                 # Overwrite the install if it's a dev build (non-transitive)
                 # and the code has been changed since the last install
+                dev_path_var = spec.variants.get('dev_path', None)
+                if not dev_path_var:
+                    # if the variant exists, it is a path
+                    return False
                 _, record = spack.store.db.query_by_spec_hash(spec.dag_hash())
                 if not record or not record.installed:
                     return False
-                mtime = fs.last_modification_time_recursive(spec.develop)
+                mtime = fs.last_modification_time_recursive(dev_path_var.value)
                 return mtime > record.installation_time
 
             ret.extend([d.dag_hash() for d in spec.traverse(root=True)
-                        if isinstance(d.develop, six.string_types) and
-                        needs_overwrite(d)])
+                        if needs_overwrite(d)])
 
         return ret
 

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -835,6 +835,14 @@ class GitFetchStrategy(VCSFetchStrategy):
         with working_dir(path):
             git(*checkout_args)
 
+        # checkout submodules if necessary
+        if self.submodules:
+            with working_dir(path):
+                args = ['submodule', 'update', '--init', '--recursive']
+                if not spack.config.get('config:debug'):
+                    args.insert(1, '--quiet')
+                git(*args)
+
     @_needs_stage
     def fetch(self):
         if self.stage.expanded:

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -118,13 +118,6 @@ class FetchStrategy(object):
             shutil.move(directory, self.stage.source_path)
 
     # Subclasses need to implement these methods
-    def clone(self):
-        """Fetch source code archive or repo without a stage.
-
-        Returns:
-            bool: True on success, False on failure.
-        """
-
     def fetch(self):
         """Fetch source code archive or repo.
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -565,7 +565,6 @@ install_args_docstring = """
                 otherwise, the default is to install as many dependencies as
                 possible (i.e., best effort installation).
             fake (bool): Don't really build; install fake stub files instead.
-            force (bool): Install again, even if already installed.
             install_deps (bool): Install dependencies before installing this
                 package
             install_source (bool): By default, source is not installed, but

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1566,7 +1566,8 @@ class PackageInstaller(object):
                     if rec and rec.installed:
                         if rec.installation_time < self.overwrite_time:
                             if os.path.exists(rec.path):
-                                with fs.replace_directory_transaction(rec.path):
+                                with fs.replace_directory_transaction(
+                                        rec.path):
                                     self._install_task(task, **kwargs)
                             else:
                                 tty.debug("Missing installation to overwrite")

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1565,7 +1565,11 @@ class PackageInstaller(object):
                     rec, _ = self._check_db(pkg.spec)
                     if rec and rec.installed:
                         if rec.installation_time < self.overwrite_time:
-                            with fs.replace_directory_transaction(rec.path):
+                            if os.path.exists(rec.path):
+                                with fs.replace_directory_transaction(rec.path):
+                                    self._install_task(task, **kwargs)
+                            else:
+                                tty.debug("Missing installation to overwrite")
                                 self._install_task(task, **kwargs)
                     else:
                         # overwriting nothing

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1560,10 +1560,10 @@ class PackageInstaller(object):
             # lock on the package.
             try:
                 if pkg.spec.dag_hash() in self.overwrite:
-                    # If it's actually overwriting, do a fs transaction
                     rec, _ = self._check_db(pkg.spec)
                     if rec and rec.installed:
                         if rec.installation_time < self.overwrite_time:
+                            # If it's actually overwriting, do a fs transaction
                             if os.path.exists(rec.path):
                                 with fs.replace_directory_transaction(
                                         rec.path):

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -916,6 +916,10 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         return stage
 
     def _make_stage(self):
+        # If it's a dev package (not transitively), use a DIY stage object
+        if isinstance(self.spec.develop, six.string_types):
+            return spack.stage.DIYStage(self.spec.develop)
+
         # Construct a composite stage on top of the composite FetchStrategy
         composite_fetcher = self.fetcher
         composite_stage = StageComposite()

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1592,6 +1592,13 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         their build process.
 
         Args:"""
+        # Non-transitive dev specs need to keep the dev stage and be built from
+        # source every time
+        if isinstance(self.spec.develop, six.string_types):
+            kwargs.update({
+                'keep_stage': True,
+                'use_cache': False,
+            })
         builder = PackageInstaller(self)
         builder.install(**kwargs)
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1235,9 +1235,6 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         Creates a stage directory and downloads the tarball for this package.
         Working directory will be set to the stage directory.
         """
-        if not self.spec.concrete:
-            raise ValueError("Can only fetch concrete packages.")
-
         if not self.has_code:
             tty.debug('No fetch required for {0}: package has no code.'
                       .format(self.name))
@@ -1281,9 +1278,6 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
 
     def do_stage(self, mirror_only=False):
         """Unpacks and expands the fetched tarball."""
-        if not self.spec.concrete:
-            raise ValueError("Can only stage concrete packages.")
-
         # Always create the stage directory at this point.  Why?  A no-code
         # package may want to use the installation process to install metadata.
         self.stage.create()

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1598,9 +1598,6 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         dev_path_var = self.spec.variants.get('dev_path', None)
         if dev_path_var:
             kwargs['keep_stage'] = True
-        dev_build_var = self.spec.variants.get('dev_build', None)
-        if dev_build_var:
-            kwargs['use_cache'] = False
 
         builder = PackageInstaller(self)
         builder.install(**kwargs)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2699,6 +2699,10 @@ class Spec(object):
 
         if user_spec_deps:
             for name, spec in user_spec_deps.items():
+                if not name:
+                    msg = "Attempted to normalize anonymous dependency spec"
+                    msg += " %s" % spec
+                    raise InvalidSpecDetected(msg)
                 if name not in all_spec_deps:
                     all_spec_deps[name] = spec
                 else:
@@ -2850,6 +2854,9 @@ class Spec(object):
         # check and be more specific about what's wrong.
         if not other.satisfies_dependencies(self):
             raise UnsatisfiableDependencySpecError(other, self)
+
+        if any(not d.name for d in other.traverse(root=False)):
+            raise UnconstrainableDependencySpecError(other)
 
         # Handle common first-order constraints directly
         changed = False
@@ -4124,8 +4131,23 @@ class SpecParser(spack.parse.Parser):
 
                         if not dep:
                             # We're adding a dependency to the last spec
-                            self.expect(ID)
-                            dep = self.spec(self.token.value)
+                            if self.accept(ID):
+                                self.previous = self.token
+                                if self.accept(EQ):
+                                    # This is an anonymous dep with a key=value
+                                    # push tokens to be parsed as part of the
+                                    # dep spec
+                                    self.push_tokens(
+                                        [self.previous, self.token])
+                                    dep_name = None
+                                else:
+                                    # named dep (standard)
+                                    dep_name = self.token.value
+                                self.previous = None
+                            else:
+                                # anonymous dep
+                                dep_name = None
+                            dep = self.spec(dep_name)
 
                         # Raise an error if the previous spec is already
                         # concrete (assigned by hash)
@@ -4508,6 +4530,14 @@ class UnsatisfiableDependencySpecError(spack.error.UnsatisfiableSpecError):
     def __init__(self, provided, required):
         super(UnsatisfiableDependencySpecError, self).__init__(
             provided, required, "dependency")
+
+
+class UnconstrainableDependencySpecError(spack.error.SpecError):
+    """Raised when attempting to constrain by an anonymous dependency spec"""
+    def __init__(self, spec):
+        msg = "Cannot constrain by spec '%s'. Cannot constrain by a" % spec
+        msg += " spec containing anonymous dependencies"
+        super(UnconstrainableDependencySpecError, self).__init__(msg)
 
 
 class AmbiguousHashError(spack.error.SpecError):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -959,7 +959,7 @@ class Spec(object):
 
     def __init__(self, spec_like=None,
                  normal=False, concrete=False, external_path=None,
-                 external_modules=None, full_hash=None, develop=False):
+                 external_modules=None, full_hash=None):
         """Create a new Spec.
 
         Arguments:
@@ -992,8 +992,6 @@ class Spec(object):
         self._dependents = DependencyMap()
         self._dependencies = DependencyMap()
         self.namespace = None
-
-        self.develop = develop
 
         self._hash = None
         self._build_hash = None
@@ -1552,9 +1550,6 @@ class Spec(object):
                 ('extra_attributes', self.extra_attributes)
             ])
 
-        if self.develop:
-            d['develop'] = self.develop
-
         if not self._concrete:
             d['concrete'] = False
 
@@ -1694,8 +1689,6 @@ class Spec(object):
         spec.namespace = node.get('namespace', None)
         spec._hash = node.get('hash', None)
         spec._build_hash = node.get('build_hash', None)
-
-        spec.develop = node.get('develop', False)
 
         if 'version' in node or 'versions' in node:
             spec.versions = vn.VersionList.from_dict(node)
@@ -2070,7 +2063,7 @@ class Spec(object):
             # still need to select a concrete package later.
             if not self.virtual:
                 changed |= any(
-                    (concretizer.concretize_develop(self),
+                    (concretizer.concretize_develop(self),  # special variant
                      concretizer.concretize_architecture(self),
                      concretizer.concretize_compiler(self),
                      concretizer.adjust_target(self),
@@ -3120,8 +3113,7 @@ class Spec(object):
                        self.concrete != other.concrete and
                        self.external_path != other.external_path and
                        self.external_modules != other.external_modules and
-                       self.compiler_flags != other.compiler_flags and
-                       self.develop != other.develop)
+                       self.compiler_flags != other.compiler_flags)
 
         self._package = None
 
@@ -3151,8 +3143,6 @@ class Spec(object):
         self.external_modules = other.external_modules
         self.extra_attributes = other.extra_attributes
         self.namespace = other.namespace
-
-        self.develop = other.develop
 
         # Cached fields are results of expensive operations.
         # If we preserved the original structure, we can copy them
@@ -3359,8 +3349,7 @@ class Spec(object):
                 self.variants,
                 self.architecture,
                 self.compiler,
-                self.compiler_flags,
-                self.develop)
+                self.compiler_flags)
 
     def eq_node(self, other):
         """Equality with another spec, not including dependencies."""

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -279,6 +279,7 @@ class Stage(object):
         self.skip_checksum_for_mirror = True
 
         self.srcdir = None
+        self._src_path = None
 
         # TODO: This uses a protected member of tempfile, but seemed the only
         # TODO: way to get a temporary name.  It won't be the same as the
@@ -393,12 +394,22 @@ class Stage(object):
     @property
     def expanded(self):
         """Returns True if source path expanded; else False."""
-        return os.path.exists(self.source_path)
+        return (os.path.exists(self.source_path) and not
+                all(os.path.join(self.path, a) in self.expected_archive_files
+                    for a in os.listdir(self.source_path)))
 
     @property
     def source_path(self):
         """Returns the well-known source directory path."""
-        return os.path.join(self.path, _source_path_subdir)
+        return self._src_path or os.path.join(self.path, _source_path_subdir)
+
+    @source_path.setter
+    def source_path(self, value):
+        """Set source path to alternate value."""
+        if os.path.isabs(value):
+            self._src_path = value
+        else:
+            self._src_path = os.path.join(self.path, value)
 
     def fetch(self, mirror_only=False, err_msg=None):
         """Retrieves the code or archive

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -279,7 +279,6 @@ class Stage(object):
         self.skip_checksum_for_mirror = True
 
         self.srcdir = None
-        self._src_path = None
 
         # TODO: This uses a protected member of tempfile, but seemed the only
         # TODO: way to get a temporary name.  It won't be the same as the
@@ -394,22 +393,12 @@ class Stage(object):
     @property
     def expanded(self):
         """Returns True if source path expanded; else False."""
-        return (os.path.exists(self.source_path) and not
-                all(os.path.join(self.path, a) in self.expected_archive_files
-                    for a in os.listdir(self.source_path)))
+        return os.path.exists(self.source_path)
 
     @property
     def source_path(self):
         """Returns the well-known source directory path."""
-        return self._src_path or os.path.join(self.path, _source_path_subdir)
-
-    @source_path.setter
-    def source_path(self, value):
-        """Set source path to alternate value."""
-        if os.path.isabs(value):
-            self._src_path = value
-        else:
-            self._src_path = os.path.join(self.path, value)
+        return os.path.join(self.path, _source_path_subdir)
 
     def fetch(self, mirror_only=False, err_msg=None):
         """Retrieves the code or archive
@@ -699,10 +688,6 @@ class StageComposite:
     @property
     def path(self):
         return self[0].path
-
-    @path.setter
-    def path(self, value):
-        self[0].path = value
 
     @property
     def archive_file(self):

--- a/lib/spack/spack/test/cache_fetch.py
+++ b/lib/spack/spack/test/cache_fetch.py
@@ -32,5 +32,5 @@ def test_fetch(tmpdir):
     fetcher = CacheURLFetchStrategy(url=url)
     with Stage(fetcher, path=testpath) as stage:
         source_path = stage.source_path
-        mkdirp(source_path)
+        mkdirp(os.path.join(source_path, 'test'))
         fetcher.fetch()

--- a/lib/spack/spack/test/cache_fetch.py
+++ b/lib/spack/spack/test/cache_fetch.py
@@ -32,5 +32,5 @@ def test_fetch(tmpdir):
     fetcher = CacheURLFetchStrategy(url=url)
     with Stage(fetcher, path=testpath) as stage:
         source_path = stage.source_path
-        mkdirp(os.path.join(source_path, 'test'))
+        mkdirp(source_path)
         fetcher.fetch()

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -326,5 +326,5 @@ env:
 
     # Ensure variants set properly
     for dep in (dep_spec, spec['dev-build-test-install']):
-        assert dep.satisfies('+dev_build dev_path=%s' % build_dir)
-    assert spec.satisfies('+dev_build')
+        assert dep.satisfies('dev_path=%s' % build_dir)
+    assert spec.satisfies('^dev_path=any')

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -2,7 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import pytest
+
 import os
 import pytest
 import spack.spec

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -28,6 +28,8 @@ def test_dev_build_basics(tmpdir, mock_packages, install_mockery):
     with open(os.path.join(spec.prefix, spec.package.filename), 'r') as f:
         assert f.read() == spec.package.replacement_string
 
+    assert os.path.exists(str(tmpdir))
+
 
 def test_dev_build_before(tmpdir, mock_packages, install_mockery):
     spec = spack.spec.Spec('dev-build-test-install@0.0.0',
@@ -81,6 +83,7 @@ def test_dev_build_until_last_phase(tmpdir, mock_packages, install_mockery):
 
     assert os.path.exists(spec.prefix)
     assert spack.store.db.query(spec, installed=True)
+    assert os.path.exists(str(tmpdir))
 
 
 def test_dev_build_before_until(tmpdir, mock_packages, install_mockery):

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -15,7 +15,8 @@ env = SpackCommand('env')
 
 
 def test_dev_build_basics(tmpdir, mock_packages, install_mockery):
-    spec = spack.spec.Spec('dev-build-test-install@0.0.0').concretized()
+    spec = spack.spec.Spec('dev-build-test-install@0.0.0',
+                           develop=str(tmpdir)).concretized()
 
     with tmpdir.as_cwd():
         with open(spec.package.filename, 'w') as f:
@@ -29,7 +30,8 @@ def test_dev_build_basics(tmpdir, mock_packages, install_mockery):
 
 
 def test_dev_build_before(tmpdir, mock_packages, install_mockery):
-    spec = spack.spec.Spec('dev-build-test-install@0.0.0').concretized()
+    spec = spack.spec.Spec('dev-build-test-install@0.0.0',
+                           develop=str(tmpdir)).concretized()
 
     with tmpdir.as_cwd():
         with open(spec.package.filename, 'w') as f:
@@ -45,7 +47,8 @@ def test_dev_build_before(tmpdir, mock_packages, install_mockery):
 
 
 def test_dev_build_until(tmpdir, mock_packages, install_mockery):
-    spec = spack.spec.Spec('dev-build-test-install@0.0.0').concretized()
+    spec = spack.spec.Spec('dev-build-test-install@0.0.0',
+                           develop=str(tmpdir)).concretized()
 
     with tmpdir.as_cwd():
         with open(spec.package.filename, 'w') as f:
@@ -63,7 +66,8 @@ def test_dev_build_until(tmpdir, mock_packages, install_mockery):
 
 def test_dev_build_until_last_phase(tmpdir, mock_packages, install_mockery):
     # Test that we ignore the last_phase argument if it is already last
-    spec = spack.spec.Spec('dev-build-test-install@0.0.0').concretized()
+    spec = spack.spec.Spec('dev-build-test-install@0.0.0',
+                           develop=str(tmpdir)).concretized()
 
     with tmpdir.as_cwd():
         with open(spec.package.filename, 'w') as f:
@@ -80,7 +84,8 @@ def test_dev_build_until_last_phase(tmpdir, mock_packages, install_mockery):
 
 
 def test_dev_build_before_until(tmpdir, mock_packages, install_mockery):
-    spec = spack.spec.Spec('dev-build-test-install@0.0.0').concretized()
+    spec = spack.spec.Spec('dev-build-test-install@0.0.0',
+                           develop=str(tmpdir)).concretized()
 
     with tmpdir.as_cwd():
         with open(spec.package.filename, 'w') as f:
@@ -122,7 +127,8 @@ def test_dev_build_drop_in(tmpdir, mock_packages, monkeypatch,
 
 def test_dev_build_fails_already_installed(tmpdir, mock_packages,
                                            install_mockery):
-    spec = spack.spec.Spec('dev-build-test-install@0.0.0').concretized()
+    spec = spack.spec.Spec('dev-build-test-install@0.0.0',
+                           develop=str(tmpdir)).concretized()
 
     with tmpdir.as_cwd():
         with open(spec.package.filename, 'w') as f:
@@ -159,7 +165,7 @@ def test_dev_build_env(tmpdir, mock_packages, install_mockery,
     # we can concretize outside environment because it has no dev-build deps
     build_dir = tmpdir.mkdir('build')
     spec = spack.spec.Spec('dev-build-test-install@0.0.0',
-                           develop=True).concretized()
+                           develop=str(build_dir)).concretized()
     with build_dir.as_cwd():
         with open(spec.package.filename, 'w') as f:
             f.write(spec.package.original_string)
@@ -194,7 +200,7 @@ def test_dev_build_env_version_mismatch(tmpdir, mock_packages, install_mockery,
     # we can concretize outside environment because it has no dev-build deps
     build_dir = tmpdir.mkdir('build')
     spec = spack.spec.Spec('dev-build-test-install@0.0.0',
-                           develop=True).concretized()
+                           develop=str(build_dir)).concretized()
     with build_dir.as_cwd():
         with open(spec.package.filename, 'w') as f:
             f.write(spec.package.original_string)

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -15,8 +15,8 @@ env = SpackCommand('env')
 
 
 def test_dev_build_basics(tmpdir, mock_packages, install_mockery):
-    spec = spack.spec.Spec('dev-build-test-install@0.0.0',
-                           develop=str(tmpdir)).concretized()
+    spec = spack.spec.Spec('dev-build-test-install@0.0.0 dev_path=%s' % tmpdir)
+    spec.concretize()
 
     with tmpdir.as_cwd():
         with open(spec.package.filename, 'w') as f:
@@ -32,8 +32,8 @@ def test_dev_build_basics(tmpdir, mock_packages, install_mockery):
 
 
 def test_dev_build_before(tmpdir, mock_packages, install_mockery):
-    spec = spack.spec.Spec('dev-build-test-install@0.0.0',
-                           develop=str(tmpdir)).concretized()
+    spec = spack.spec.Spec('dev-build-test-install@0.0.0 dev_path=%s' % tmpdir)
+    spec.concretize()
 
     with tmpdir.as_cwd():
         with open(spec.package.filename, 'w') as f:
@@ -49,8 +49,8 @@ def test_dev_build_before(tmpdir, mock_packages, install_mockery):
 
 
 def test_dev_build_until(tmpdir, mock_packages, install_mockery):
-    spec = spack.spec.Spec('dev-build-test-install@0.0.0',
-                           develop=str(tmpdir)).concretized()
+    spec = spack.spec.Spec('dev-build-test-install@0.0.0 dev_path=%s' % tmpdir)
+    spec.concretize()
 
     with tmpdir.as_cwd():
         with open(spec.package.filename, 'w') as f:
@@ -68,8 +68,8 @@ def test_dev_build_until(tmpdir, mock_packages, install_mockery):
 
 def test_dev_build_until_last_phase(tmpdir, mock_packages, install_mockery):
     # Test that we ignore the last_phase argument if it is already last
-    spec = spack.spec.Spec('dev-build-test-install@0.0.0',
-                           develop=str(tmpdir)).concretized()
+    spec = spack.spec.Spec('dev-build-test-install@0.0.0 dev_path=%s' % tmpdir)
+    spec.concretize()
 
     with tmpdir.as_cwd():
         with open(spec.package.filename, 'w') as f:
@@ -87,8 +87,8 @@ def test_dev_build_until_last_phase(tmpdir, mock_packages, install_mockery):
 
 
 def test_dev_build_before_until(tmpdir, mock_packages, install_mockery):
-    spec = spack.spec.Spec('dev-build-test-install@0.0.0',
-                           develop=str(tmpdir)).concretized()
+    spec = spack.spec.Spec('dev-build-test-install@0.0.0 dev_path=%s' % tmpdir)
+    spec.concretize()
 
     with tmpdir.as_cwd():
         with open(spec.package.filename, 'w') as f:
@@ -130,8 +130,8 @@ def test_dev_build_drop_in(tmpdir, mock_packages, monkeypatch,
 
 def test_dev_build_fails_already_installed(tmpdir, mock_packages,
                                            install_mockery):
-    spec = spack.spec.Spec('dev-build-test-install@0.0.0',
-                           develop=str(tmpdir)).concretized()
+    spec = spack.spec.Spec('dev-build-test-install@0.0.0 dev_path=%s' % tmpdir)
+    spec.concretize()
 
     with tmpdir.as_cwd():
         with open(spec.package.filename, 'w') as f:
@@ -167,8 +167,10 @@ def test_dev_build_env(tmpdir, mock_packages, install_mockery,
     # setup dev-build-test-install package for dev build
     # we can concretize outside environment because it has no dev-build deps
     build_dir = tmpdir.mkdir('build')
-    spec = spack.spec.Spec('dev-build-test-install@0.0.0',
-                           develop=str(build_dir)).concretized()
+    spec = spack.spec.Spec('dev-build-test-install@0.0.0 dev_path=%s' %
+                           build_dir)
+    spec.concretize()
+
     with build_dir.as_cwd():
         with open(spec.package.filename, 'w') as f:
             f.write(spec.package.original_string)
@@ -202,8 +204,9 @@ def test_dev_build_env_version_mismatch(tmpdir, mock_packages, install_mockery,
     # setup dev-build-test-install package for dev build
     # we can concretize outside environment because it has no dev-build deps
     build_dir = tmpdir.mkdir('build')
-    spec = spack.spec.Spec('dev-build-test-install@0.0.0',
-                           develop=str(build_dir)).concretized()
+    spec = spack.spec.Spec('dev-build-test-install@0.0.0 dev_path=%s' % tmpdir)
+    spec.concretize()
+
     with build_dir.as_cwd():
         with open(spec.package.filename, 'w') as f:
             f.write(spec.package.original_string)

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -237,7 +237,9 @@ def test_dev_build_multiple(tmpdir, mock_packages, install_mockery,
                             mutable_mock_env_path, mock_fetch):
     """Test spack install with multiple developer builds"""
     # setup dev-build-test-install package for dev build
-    # don't concretize outside environment -- dev info will be wrong
+    # Wait to concretize inside the environment to set dev_path on the specs;
+    # without the environment, the user would need to set dev_path for both the
+    # root and dependency if they wanted a dev build for both.
     leaf_dir = tmpdir.mkdir('leaf')
     leaf_spec = spack.spec.Spec('dev-build-test-install@0.0.0')
     with leaf_dir.as_cwd():

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -165,6 +165,7 @@ def test_dev_build_fails_no_version(mock_packages):
 
 def test_dev_build_env(tmpdir, mock_packages, install_mockery,
                        mutable_mock_env_path):
+    """Test Spack does dev builds for packages in develop section of env."""
     # setup dev-build-test-install package for dev build
     build_dir = tmpdir.mkdir('build')
     spec = spack.spec.Spec('dev-build-test-install@0.0.0 dev_path=%s' %
@@ -201,6 +202,7 @@ env:
 
 def test_dev_build_env_version_mismatch(tmpdir, mock_packages, install_mockery,
                                         mutable_mock_env_path):
+    """Test Spack constraints concretization by develop specs."""
     # setup dev-build-test-install package for dev build
     build_dir = tmpdir.mkdir('build')
     spec = spack.spec.Spec('dev-build-test-install@0.0.0 dev_path=%s' % tmpdir)
@@ -233,6 +235,7 @@ env:
 
 def test_dev_build_multiple(tmpdir, mock_packages, install_mockery,
                             mutable_mock_env_path, mock_fetch):
+    """Test spack install with multiple developer builds"""
     # setup dev-build-test-install package for dev build
     # don't concretize outside environment -- dev info will be wrong
     leaf_dir = tmpdir.mkdir('leaf')
@@ -285,6 +288,9 @@ env:
 
 def test_dev_build_env_dependency(tmpdir, mock_packages, install_mockery,
                                   mock_fetch, mutable_mock_env_path):
+    """
+    Test non-root specs in an environment are properly marked for dev builds.
+    """
     # setup dev-build-test-install package for dev build
     build_dir = tmpdir.mkdir('build')
     spec = spack.spec.Spec('dependent-of-dev-build@0.0.0')

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -166,7 +166,6 @@ def test_dev_build_fails_no_version(mock_packages):
 def test_dev_build_env(tmpdir, mock_packages, install_mockery,
                        mutable_mock_env_path):
     # setup dev-build-test-install package for dev build
-    # we can concretize outside environment because it has no dev-build deps
     build_dir = tmpdir.mkdir('build')
     spec = spack.spec.Spec('dev-build-test-install@0.0.0 dev_path=%s' %
                            build_dir)
@@ -203,7 +202,6 @@ env:
 def test_dev_build_env_version_mismatch(tmpdir, mock_packages, install_mockery,
                                         mutable_mock_env_path):
     # setup dev-build-test-install package for dev build
-    # we can concretize outside environment because it has no dev-build deps
     build_dir = tmpdir.mkdir('build')
     spec = spack.spec.Spec('dev-build-test-install@0.0.0 dev_path=%s' % tmpdir)
     spec.concretize()
@@ -288,7 +286,6 @@ env:
 def test_dev_build_env_dependency(tmpdir, mock_packages, install_mockery,
                                   mock_fetch, mutable_mock_env_path):
     # setup dev-build-test-install package for dev build
-    # we can concretize outside environment because it has no dev-build deps
     build_dir = tmpdir.mkdir('build')
     spec = spack.spec.Spec('dependent-of-dev-build@0.0.0')
     dep_spec = spack.spec.Spec('dev-build-test-install')
@@ -342,7 +339,6 @@ def test_dev_build_rebuild_on_source_changes(
     ``test_spec = dependent-of-dev-build`` tests rebuild for changes to dep
     """
     # setup dev-build-test-install package for dev build
-    # we can concretize outside environment because it has no dev-build deps
     build_dir = tmpdir.mkdir('build')
     spec = spack.spec.Spec('dev-build-test-install@0.0.0 dev_path=%s' %
                            build_dir)

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -331,8 +331,8 @@ env:
     assert spec.satisfies('^dev_path=any')
 
 
-@pytest.mark.parametrize('test_spec',['dev-build-test-install',
-                                      'dependent-of-dev-build'])
+@pytest.mark.parametrize('test_spec', ['dev-build-test-install',
+                                       'dependent-of-dev-build'])
 def test_dev_build_rebuild_on_source_changes(
         test_spec, tmpdir, mock_packages, install_mockery,
         mutable_mock_env_path, mock_fetch):
@@ -371,7 +371,7 @@ env:
 """ % (test_spec, build_dir))
 
         env('create', 'test', './spack.yaml')
-        with ev.read('test') as e:
+        with ev.read('test'):
             install()
 
             reset_string()  # so the package will accept rebuilds

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -376,7 +376,7 @@ env:
 
             reset_string()  # so the package will accept rebuilds
 
-            fs.touch(os.path.join(build_dir, 'test'))
+            fs.touch(os.path.join(str(build_dir), 'test'))
             output = install()
 
     assert 'Installing %s' % test_spec in output

--- a/lib/spack/spack/test/cmd/develop.py
+++ b/lib/spack/spack/test/cmd/develop.py
@@ -1,0 +1,51 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import pytest
+import os
+import llnl.util.filesystem as fs
+
+import spack.spec
+import spack.environment as ev
+from spack.main import SpackCommand
+
+develop = SpackCommand('develop')
+env = SpackCommand('env')
+
+
+@pytest.mark.usefixtures('mutable_mock_env_path', 'mock_packages')
+class TestDevelop(object):
+    def check_develop(self, env, spec, path=None):
+        path = path or spec.name
+
+        # check in memory representation
+        assert spec.name in env.dev_specs
+        dev_specs_entry = env.dev_specs[spec.name]
+        assert dev_specs_entry['path'] == path
+        assert dev_specs_entry['spec'] == str(spec)
+
+        # check yaml representation
+        yaml = ev.config_dict(env.yaml)
+        assert spec.name in yaml['develop']
+        yaml_entry = yaml['develop'][spec.name]
+        assert yaml_entry['spec'] == str(spec)
+        if path == spec.name:
+            # default paths aren't written out
+            assert 'path' not in yaml_entry
+        else:
+            assert yaml_entry['path'] == path
+
+    def test_develop_no_path_no_clone(self):
+        env('create', 'test')
+        with ev.read('test') as e:
+            # develop checks that the path exists
+            fs.mkdirp(os.path.join(e.path, 'mpich'))
+            develop('--no-clone', 'mpich@1.0')
+            self.check_develop(e, spack.spec.Spec('mpich@1.0'))
+
+    def test_develop_no_clone(self, tmpdir):
+        env('create', 'test')
+        with ev.read('test') as e:
+            develop('--no-clone', '-p', str(tmpdir), 'mpich@1.0')
+            self.check_develop(e, spack.spec.Spec('mpich@1.0'), str(tmpdir))

--- a/lib/spack/spack/test/cmd/develop.py
+++ b/lib/spack/spack/test/cmd/develop.py
@@ -52,7 +52,7 @@ class TestDevelop(object):
             develop('--no-clone', '-p', str(tmpdir), 'mpich@1.0')
             self.check_develop(e, spack.spec.Spec('mpich@1.0'), str(tmpdir))
 
-    def test_develop(self):
+    def test_develop(self, mock_fetch):
         env('create', 'test')
         with ev.read('test') as e:
             develop('mpich@1.0')

--- a/lib/spack/spack/test/cmd/develop.py
+++ b/lib/spack/spack/test/cmd/develop.py
@@ -52,7 +52,7 @@ class TestDevelop(object):
             develop('--no-clone', '-p', str(tmpdir), 'mpich@1.0')
             self.check_develop(e, spack.spec.Spec('mpich@1.0'), str(tmpdir))
 
-    def test_develop(self, mock_fetch):
+    def test_develop(self):
         env('create', 'test')
         with ev.read('test') as e:
             develop('mpich@1.0')
@@ -68,3 +68,25 @@ class TestDevelop(object):
             # test develop with no args
             develop()
             self.check_develop(e, spack.spec.Spec('mpich@1.0'))
+
+    def test_develop_twice(self):
+        env('create', 'test')
+        with ev.read('test') as e:
+            develop('mpich@1.0')
+            self.check_develop(e, spack.spec.Spec('mpich@1.0'))
+
+            develop('mpich@1.0')
+            # disk representation isn't updated unless we write
+            # second develop command doesn't change it, so we don't write
+            # but we check disk representation
+            e.write()
+            self.check_develop(e, spack.spec.Spec('mpich@1.0'))
+            assert len(e.dev_specs) == 1
+
+    def test_develop_update_path(self, tmpdir):
+        env('create', 'test')
+        with ev.read('test') as e:
+            develop('mpich@1.0')
+            develop('-p', str(tmpdir), 'mpich@1.0')
+            self.check_develop(e, spack.spec.Spec('mpich@1.0'), str(tmpdir))
+            assert len(e.dev_specs) == 1

--- a/lib/spack/spack/test/cmd/develop.py
+++ b/lib/spack/spack/test/cmd/develop.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import pytest
 import os
+import shutil
 import llnl.util.filesystem as fs
 
 import spack.spec
@@ -14,7 +15,8 @@ develop = SpackCommand('develop')
 env = SpackCommand('env')
 
 
-@pytest.mark.usefixtures('mutable_mock_env_path', 'mock_packages')
+@pytest.mark.usefixtures(
+    'mutable_mock_env_path', 'mock_packages', 'mock_fetch')
 class TestDevelop(object):
     def check_develop(self, env, spec, path=None):
         path = path or spec.name
@@ -49,3 +51,20 @@ class TestDevelop(object):
         with ev.read('test') as e:
             develop('--no-clone', '-p', str(tmpdir), 'mpich@1.0')
             self.check_develop(e, spack.spec.Spec('mpich@1.0'), str(tmpdir))
+
+    def test_develop(self):
+        env('create', 'test')
+        with ev.read('test') as e:
+            develop('mpich@1.0')
+            self.check_develop(e, spack.spec.Spec('mpich@1.0'))
+
+    def test_develop_no_args(self):
+        env('create', 'test')
+        with ev.read('test') as e:
+            # develop and remove it
+            develop('mpich@1.0')
+            shutil.rmtree(os.path.join(e.path, 'mpich'))
+
+            # test develop with no args
+            develop()
+            self.check_develop(e, spack.spec.Spec('mpich@1.0'))

--- a/lib/spack/spack/test/cmd/develop.py
+++ b/lib/spack/spack/test/cmd/develop.py
@@ -90,3 +90,11 @@ class TestDevelop(object):
             develop('-p', str(tmpdir), 'mpich@1.0')
             self.check_develop(e, spack.spec.Spec('mpich@1.0'), str(tmpdir))
             assert len(e.dev_specs) == 1
+
+    def test_develop_update_spec(self):
+        env('create', 'test')
+        with ev.read('test') as e:
+            develop('mpich@1.0')
+            develop('mpich@2.0')
+            self.check_develop(e, spack.spec.Spec('mpich@2.0'))
+            assert len(e.dev_specs) == 1

--- a/lib/spack/spack/test/cmd/location.py
+++ b/lib/spack/spack/test/cmd/location.py
@@ -39,7 +39,7 @@ def mock_spec():
 
     # Make it look like the source was actually expanded.
     source_path = pkg.stage.source_path
-    mkdirp(source_path)
+    mkdirp(os.path.join(source_path, 'test'))
     yield spec, pkg
 
     # Remove the spec from the mock stage area.

--- a/lib/spack/spack/test/cmd/location.py
+++ b/lib/spack/spack/test/cmd/location.py
@@ -39,7 +39,7 @@ def mock_spec():
 
     # Make it look like the source was actually expanded.
     source_path = pkg.stage.source_path
-    mkdirp(os.path.join(source_path, 'test'))
+    mkdirp(source_path)
     yield spec, pkg
 
     # Remove the spec from the mock stage area.

--- a/lib/spack/spack/test/cmd/undevelop.py
+++ b/lib/spack/spack/test/cmd/undevelop.py
@@ -35,8 +35,8 @@ env:
             after = spack.spec.Spec('mpich').concretized()
 
     # Removing dev spec from environment changes concretization
-    assert before.satisfies('+dev_build')
-    assert not after.satisfies('+dev_build')
+    assert before.satisfies('dev_path=any')
+    assert not after.satisfies('dev_path=any')
 
 
 def test_undevelop_nonexistent(tmpdir, mock_packages, mutable_mock_env_path):
@@ -59,7 +59,7 @@ env:
         with ev.read('test') as e:
             concretize()
             before = e.specs_by_hash
-            undevelop('package-not-in-develop')
+            undevelop('package-not-in-develop')  # does nothing
             concretize('-f')
             after = e.specs_by_hash
 

--- a/lib/spack/spack/test/cmd/undevelop.py
+++ b/lib/spack/spack/test/cmd/undevelop.py
@@ -1,0 +1,66 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import spack.spec
+import spack.environment as ev
+from spack.main import SpackCommand
+
+undevelop = SpackCommand('undevelop')
+env = SpackCommand('env')
+concretize = SpackCommand('concretize')
+
+def test_undevelop(tmpdir, mock_packages, mutable_mock_env_path):
+    # setup environment
+    envdir = tmpdir.mkdir('env')
+    with envdir.as_cwd():
+        with open('spack.yaml', 'w') as f:
+            f.write("""\
+env:
+  specs:
+  - mpich
+
+  develop:
+    mpich:
+      spec: mpich@1.0
+      path: /fake/path
+""")
+
+        env('create', 'test', './spack.yaml')
+        with ev.read('test'):
+            before = spack.spec.Spec('mpich').concretized()
+            undevelop('mpich')
+            after = spack.spec.Spec('mpich').concretized()
+
+    # Removing dev spec from environment changes concretization
+    assert before.satisfies('+dev_build')
+    assert not after.satisfies('+dev_build')
+
+
+def test_undevelop_nonexistent(tmpdir, mock_packages, mutable_mock_env_path):
+    # setup environment
+    envdir = tmpdir.mkdir('env')
+    with envdir.as_cwd():
+        with open('spack.yaml', 'w') as f:
+            f.write("""\
+env:
+  specs:
+  - mpich
+
+  develop:
+    mpich:
+      spec: mpich@1.0
+      path: /fake/path
+""")
+
+        env('create', 'test', './spack.yaml')
+        with ev.read('test') as e:
+            concretize()
+            before = e.specs_by_hash
+            undevelop('package-not-in-develop')
+            concretize('-f')
+            after = e.specs_by_hash
+
+    # nothing should have changed
+    assert before == after

--- a/lib/spack/spack/test/cmd/undevelop.py
+++ b/lib/spack/spack/test/cmd/undevelop.py
@@ -11,6 +11,7 @@ undevelop = SpackCommand('undevelop')
 env = SpackCommand('env')
 concretize = SpackCommand('concretize')
 
+
 def test_undevelop(tmpdir, mock_packages, mutable_mock_env_path):
     # setup environment
     envdir = tmpdir.mkdir('env')

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -644,3 +644,12 @@ class TestConcretize(object):
         with pytest.raises(spack.error.SpecError):
             s = Spec('+variant')
             s.concretize()
+
+    def test_concretize_anonymous_dep(self):
+        with pytest.raises(spack.error.SpecError):
+            s = Spec('mpileaks ^%gcc')
+            s.concretize()
+
+        with pytest.raises(spack.error.SpecError):
+            s = Spec('mpileaks ^cflags=-g')
+            s.concretize()

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -9,6 +9,7 @@ import stat
 import spack.package_prefs
 import spack.repo
 import spack.util.spack_yaml as syaml
+from spack.concretize import NonDeterministicVariantError
 from spack.config import ConfigScope, ConfigError
 from spack.spec import Spec
 from spack.version import Version
@@ -83,6 +84,16 @@ class TestConcretizePreferences(object):
         assert_variant_values(
             'mpileaks', debug=True, opt=True, shared=False, static=False
         )
+
+    def test_preferred_variants_from_any(self):
+        update_packages('multivalue-variant', 'variants', 'foo=bar')
+        assert_variant_values(
+            'multivalue-variant foo=any', foo=('bar',)
+        )
+
+        update_packages('multivalue-variant', 'variants', 'foo=none')
+        with pytest.raises(NonDeterministicVariantError):
+            concretize('multivalue-variant foo=any')
 
     def test_preferred_compilers(self):
         """Test preferred compilers are applied correctly

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -86,6 +86,13 @@ class TestConcretizePreferences(object):
         )
 
     def test_preferred_variants_from_any(self):
+        """
+        Test that 'foo=any' concretizes to any non-none value
+
+        Test that concretization of variants raises an error attempting
+        non-deterministic concretization from 'any' when preferred value is
+        'none'.
+        """
         update_packages('multivalue-variant', 'variants', 'foo=bar')
         assert_variant_values(
             'multivalue-variant foo=any', foo=('bar',)

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -160,7 +160,7 @@ def test_git_extra_fetch(tmpdir):
 
     fetcher = GitFetchStrategy(git='file:///not-a-real-git-repo')
     with Stage(fetcher, path=testpath) as stage:
-        mkdirp(stage.source_path)
+        mkdirp(os.path.join(stage.source_path, 'test'))
         fetcher.fetch()   # Use fetcher to fetch for code coverage
         shutil.rmtree(stage.source_path)
 

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -160,7 +160,7 @@ def test_git_extra_fetch(tmpdir):
 
     fetcher = GitFetchStrategy(git='file:///not-a-real-git-repo')
     with Stage(fetcher, path=testpath) as stage:
-        mkdirp(os.path.join(stage.source_path, 'test'))
+        mkdirp(source_path)
         fetcher.fetch()   # Use fetcher to fetch for code coverage
         shutil.rmtree(stage.source_path)
 

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -160,7 +160,7 @@ def test_git_extra_fetch(tmpdir):
 
     fetcher = GitFetchStrategy(git='file:///not-a-real-git-repo')
     with Stage(fetcher, path=testpath) as stage:
-        mkdirp(source_path)
+        mkdirp(stage.source_path)
         fetcher.fetch()   # Use fetcher to fetch for code coverage
         shutil.rmtree(stage.source_path)
 

--- a/lib/spack/spack/test/hg_fetch.py
+++ b/lib/spack/spack/test/hg_fetch.py
@@ -84,5 +84,5 @@ def test_hg_extra_fetch(tmpdir):
     fetcher = HgFetchStrategy(hg='file:///not-a-real-hg-repo')
     with Stage(fetcher, path=testpath) as stage:
         source_path = stage.source_path
-        mkdirp(source_path)
+        mkdirp(os.path.join(source_path, 'test'))
         fetcher.fetch()

--- a/lib/spack/spack/test/hg_fetch.py
+++ b/lib/spack/spack/test/hg_fetch.py
@@ -84,5 +84,5 @@ def test_hg_extra_fetch(tmpdir):
     fetcher = HgFetchStrategy(hg='file:///not-a-real-hg-repo')
     with Stage(fetcher, path=testpath) as stage:
         source_path = stage.source_path
-        mkdirp(os.path.join(source_path, 'test'))
+        mkdirp(source_path)
         fetcher.fetch()

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -512,12 +512,6 @@ def test_unconcretized_install(install_mockery, mock_fetch, mock_packages):
     with pytest.raises(ValueError, match="only install concrete packages"):
         spec.package.do_install()
 
-    with pytest.raises(ValueError, match="only fetch concrete packages"):
-        spec.package.do_fetch()
-
-    with pytest.raises(ValueError, match="only stage concrete packages"):
-        spec.package.do_stage()
-
     with pytest.raises(ValueError, match="only patch concrete packages"):
         spec.package.do_patch()
 

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -918,10 +918,11 @@ class TestSpecSematics(object):
     def test_combination_of_any_or_none(self):
         # Test that using 'none' and another value raises
         with pytest.raises(spack.variant.InvalidVariantValueCombinationError):
-            spec = Spec('multivalue-variant foo=none,bar')
+            Spec('multivalue-variant foo=none,bar')
 
+        # Test that using 'any' and another value raises
         with pytest.raises(spack.variant.InvalidVariantValueCombinationError):
-            spec = Spec('multivalue-variant foo=any,bar')
+            Spec('multivalue-variant foo=any,bar')
 
     @pytest.mark.skipif(
         sys.version_info[0] == 2, reason='__wrapped__ requires python 3'

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -272,6 +272,8 @@ class TestSpecSematics(object):
         check_satisfies('mpich foo=true', 'mpich+foo')
         check_satisfies('mpich~foo', 'mpich foo=FALSE')
         check_satisfies('mpich foo=False', 'mpich~foo')
+        check_satisfies('mpich foo=any', 'mpich~foo')
+        check_satisfies('mpich +foo', 'mpich foo=any')
 
     def test_satisfies_multi_value_variant(self):
         # Check quoting
@@ -283,6 +285,12 @@ class TestSpecSematics(object):
                         'multivalue-variant foo=bar,baz')
 
         # A more constrained spec satisfies a less constrained one
+        check_satisfies('multivalue-variant foo="bar,baz"',
+                        'multivalue-variant foo=any')
+
+        check_satisfies('multivalue-variant foo=any',
+                        'multivalue-variant foo="bar,baz"')
+
         check_satisfies('multivalue-variant foo="bar,baz"',
                         'multivalue-variant foo="bar"')
 
@@ -307,6 +315,7 @@ class TestSpecSematics(object):
         a.concretize()
 
         assert a.satisfies('foobar=bar')
+        assert a.satisfies('foobar=any')
 
         # Assert that an autospec generated from a literal
         # gives the right result for a single valued variant
@@ -440,6 +449,10 @@ class TestSpecSematics(object):
         check_unsatisfiable('mpich', 'mpich+foo', True)
         check_unsatisfiable('mpich', 'mpich~foo', True)
         check_unsatisfiable('mpich', 'mpich foo=1', True)
+
+        # None and any do not satisfy each other
+        check_unsatisfiable('foo=none', 'foo=any')
+        check_unsatisfiable('foo=any', 'foo=none')
 
     def test_unsatisfiable_variant_mismatch(self):
         # No matchi in specs
@@ -608,6 +621,11 @@ class TestSpecSematics(object):
             'multivalue-variant foo="baz"'
         )
 
+        check_constrain(
+            'libelf foo=bar,baz', 'libelf foo=bar,baz', 'libelf foo=any')
+        check_constrain(
+            'libelf foo=bar,baz', 'libelf foo=any', 'libelf foo=bar,baz')
+
     def test_constrain_compiler_flags(self):
         check_constrain(
             'libelf cflags="-O3" cppflags="-Wall"',
@@ -648,6 +666,8 @@ class TestSpecSematics(object):
         check_invalid_constraint('libelf+debug', 'libelf~debug')
         check_invalid_constraint('libelf+debug~foo', 'libelf+debug+foo')
         check_invalid_constraint('libelf debug=True', 'libelf debug=False')
+        check_invalid_constraint('libelf foo=none', 'libelf foo=any')
+        check_invalid_constraint('libelf foo=any', 'libelf foo=none')
 
         check_invalid_constraint(
             'libelf cppflags="-O3"', 'libelf cppflags="-O2"')
@@ -661,6 +681,7 @@ class TestSpecSematics(object):
         check_constrain_changed('libelf', '%gcc')
         check_constrain_changed('libelf%gcc', '%gcc@4.5')
         check_constrain_changed('libelf', '+debug')
+        check_constrain_changed('libelf', 'debug=any')
         check_constrain_changed('libelf', '~debug')
         check_constrain_changed('libelf', 'debug=2')
         check_constrain_changed('libelf', 'cppflags="-O3"')
@@ -680,6 +701,7 @@ class TestSpecSematics(object):
         check_constrain_not_changed('libelf+debug', '+debug')
         check_constrain_not_changed('libelf~debug', '~debug')
         check_constrain_not_changed('libelf debug=2', 'debug=2')
+        check_constrain_not_changed('libelf debug=2', 'debug=any')
         check_constrain_not_changed(
             'libelf cppflags="-O3"', 'cppflags="-O3"')
 
@@ -893,13 +915,13 @@ class TestSpecSematics(object):
                 for x in ('cflags', 'cxxflags', 'fflags')
             )
 
-    def test_any_combination_of(self):
-        # Test that using 'none' and another value raise during concretization
-        spec = Spec('multivalue-variant foo=none,bar')
-        with pytest.raises(spack.error.SpecError) as exc_info:
-            spec.concretize()
+    def test_combination_of_any_or_none(self):
+        # Test that using 'none' and another value raises
+        with pytest.raises(spack.variant.InvalidVariantValueCombinationError):
+            spec = Spec('multivalue-variant foo=none,bar')
 
-        assert "is mutually exclusive with any of the" in str(exc_info.value)
+        with pytest.raises(spack.variant.InvalidVariantValueCombinationError):
+            spec = Spec('multivalue-variant foo=any,bar')
 
     @pytest.mark.skipif(
         sys.version_info[0] == 2, reason='__wrapped__ requires python 3'

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -7,6 +7,7 @@ import sys
 import pytest
 
 from spack.error import SpecError, UnsatisfiableSpecError
+from spack.spec import UnconstrainableDependencySpecError
 from spack.spec import Spec, SpecFormatSigilError, SpecFormatStringError
 from spack.variant import InvalidVariantValueError, UnknownVariantError
 from spack.variant import MultipleValuesInExclusiveVariantError
@@ -80,7 +81,8 @@ def check_constrain_not_changed(spec, constraint):
 def check_invalid_constraint(spec, constraint):
     spec = Spec(spec)
     constraint = Spec(constraint)
-    with pytest.raises(UnsatisfiableSpecError):
+    with pytest.raises((UnsatisfiableSpecError,
+                        UnconstrainableDependencySpecError)):
         spec.constrain(constraint)
 
 
@@ -674,6 +676,7 @@ class TestSpecSematics(object):
         check_invalid_constraint(
             'libelf platform=test target=be os=be', 'libelf target=fe os=fe'
         )
+        check_invalid_constraint('libdwarf', '^%gcc')
 
     def test_constrain_changed(self):
         check_constrain_changed('libelf', '@1.0')

--- a/lib/spack/spack/test/svn_fetch.py
+++ b/lib/spack/spack/test/svn_fetch.py
@@ -89,6 +89,6 @@ def test_svn_extra_fetch(tmpdir):
         assert stage is not None
 
         source_path = stage.source_path
-        mkdirp(source_path)
+        mkdirp(os.path.join(source_path, 'test'))
 
         fetcher.fetch()

--- a/lib/spack/spack/test/svn_fetch.py
+++ b/lib/spack/spack/test/svn_fetch.py
@@ -89,6 +89,6 @@ def test_svn_extra_fetch(tmpdir):
         assert stage is not None
 
         source_path = stage.source_path
-        mkdirp(os.path.join(source_path, 'test'))
+        mkdirp(source_path)
 
         fetcher.fetch()

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -27,6 +27,7 @@ except ImportError:
 
 special_variant_values = [None, 'none', 'any']
 
+
 class Variant(object):
     """Represents a variant in a package, as declared in the
     variant directive.
@@ -270,7 +271,7 @@ class AbstractVariant(object):
             # values need to be hashed
             value = re.split(r'\s*,\s*', str(value))
             value = list(map(lambda x: 'any' if str(x).upper() == 'ANY' else x,
-                        value))
+                             value))
 
         for val in special_variant_values:
             if val in value and len(value) > 1:

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -604,6 +604,9 @@ def substitute_abstract_variants(spec):
     failed = []
     for name, v in spec.variants.items():
         if name in spack.directives.reserved_names:
+            if name == 'dev_path':
+                new_variant = SingleValuedVariant(name, v._original_value)
+                spec.variants.substitute(new_variant)
             continue
         pkg_variant = spec.package_class.variants.get(name, None)
         if not pkg_variant:

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -401,8 +401,8 @@ class MultiValuedVariant(AbstractVariant):
         Returns:
             bool: True or False
         """
-        # If the superclass doesn't satisfy the superclass, it doesn't satisfy
-        # this handles conflicts between none and any
+        # If it doesn't satisfy as an AbstractVariant, it doesn't satisfy as a
+        # MultiValuedVariant this handles conflicts between none and any
         super_sat = super(MultiValuedVariant, self).satisfies(other)
 
         # Otherwise we want all the values in `other` to be also in `self`
@@ -410,7 +410,7 @@ class MultiValuedVariant(AbstractVariant):
                               'any' in other or 'any' in self)
 
 
-class SingleValuedVariant(MultiValuedVariant):
+class SingleValuedVariant(AbstractVariant):
     """A variant that can hold multiple values, but one at a time."""
 
     def _value_setter(self, value):
@@ -427,10 +427,9 @@ class SingleValuedVariant(MultiValuedVariant):
 
     @implicit_variant_conversion
     def satisfies(self, other):
-        # If it doesn't satisfy as an abstract variant, it doesn't satisfy
-        # This handles conflicts between none and any
-        # Notice we're skipping a level in the MRO
-        abstract_sat = super(MultiValuedVariant, self).satisfies(other)
+        # If it doesn't satisfy as an AbstractVariant, it doesn't satisfy as a
+        # SingleValuedVariant this handles conflicts between none and any
+        abstract_sat = super(SingleValuedVariant, self).satisfies(other)
 
         return abstract_sat and (self.value == other.value or
                                  other.value == 'any' or self.value == 'any')

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -128,7 +128,7 @@ class Variant(object):
             raise InvalidVariantValueError(self, not_allowed_values, pkg)
 
         # Validate the group of values if needed
-        if self.group_validator is not None:
+        if self.group_validator is not None and value != ('any',):
             self.group_validator(pkg.name, self.name, value)
 
     @property

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -728,7 +728,7 @@ _spack_dev_build() {
 _spack_develop() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -p --path -c --clone"
+        SPACK_COMPREPLY="-h --help -p --path --no-clone"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -728,7 +728,7 @@ _spack_dev_build() {
 _spack_develop() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -p --path --no-clone"
+        SPACK_COMPREPLY="-h --help -p --path --no-clone --clone"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -728,7 +728,7 @@ _spack_dev_build() {
 _spack_develop() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -p --path --no-clone --clone"
+        SPACK_COMPREPLY="-h --help -p --path --no-clone --clone -f --force"
     else
         _all_packages
     fi

--- a/var/spack/repos/builtin.mock/packages/dependent-of-dev-build/package.py
+++ b/var/spack/repos/builtin.mock/packages/dependent-of-dev-build/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class DependentOfDevBuild(Package):
+    homepage = "example.com"
+    url = "fake.com"
+
+    version('0.0.0', sha256='0123456789abcdefgh')
+
+    depends_on('dev-build-test-install')
+
+    def install(self, spec, prefix):
+        with open(prefix.filename, 'w') as f:
+            f.write("This file is installed")


### PR DESCRIPTION
closes #18401 

**Updated 2020-05-15**

fixes #12003

With this feature, we allow developers to specify package(s) they are working on in an environment.

For example, if I were a developer of both `trilinos` and `hdf5`, I could specify in an environment

```
spack:
  specs:
  - trilinos
  - hdf5
  - mpich

  dev-build:
    trilinos:
      source: /path/to/my/trilinos/source
      version: mytrilinosversion
    hdf5:
      source: /path/to/my/hdf5/source
      version: myhdf5version

  concretization: together
```
I could then install my development versions of both packages, with trilinos using my development version of hdf5 with the simple command `spack install`.

TODO:
- [x] `spack develop` command to add packages as dev-build
- [x] `spack undevelop` command to turn dev-build packages into TPLs
- [x] Ensure `spack remove` removes dev-build packages fully
- [x] work out strategies for reinstalling dev-build packages on install of dependents
- [x] work out automatically cloning repos from `spack develop` command
- [x] add automatic cloning capabilities to non-git fetchers
- [ ] testing
- [ ] documentation

MOVED TO OTHER PRs:
- [ ] git integration to compare git commits to versions

Proposed workflow:

1. `spack env create myenv`  create an environment managed by Spack
2. `spack env activate myenv`  tell spack to use that environment
3. `spack add TPL1 TPL2`  add packages to environment as normal (spack fetches them)
4. `spack develop 1PL1@commit 1PL2@commit application@commit`  add 1st party dependencies to environment as dev-build
5. `spack install`   installs application, 1PL1, 1PL2, TPL1, TPL2
6. <do some development on any of 1PL1, 1PL2, application>
7. `spack install` or `spack install application`  reinstalls application, 1PL1, 1PL2
8. `spack undevelop 1PL2`  done developing, now we fetch it with Spack
9. `spack install`  reinstalls application, 1PL1, does not reinstall 1PL2