### PR TITLE
unifyfs depends on openssl

### DIFF
--- a/var/spack/repos/builtin/packages/unifyfs/package.py
+++ b/var/spack/repos/builtin/packages/unifyfs/package.py
@@ -28,6 +28,7 @@ class Unifyfs(AutotoolsPackage):
     variant('pmi', default='False', description='Enable PMI2 build options')
     variant('pmix', default='False', description='Enable PMIx build options')
 
+    depends_on('openssl')
     depends_on('autoconf',  type='build')
     depends_on('automake',  type='build')
     depends_on('libtool',   type='build')


### PR DESCRIPTION
Package `unifyfs` currently has a non-explicit dependency on `openssl`. This PR makes the dependency explicit.

@CamStan @tgamblin 