### PR TITLE
Caliper depends on python3.

### DIFF
--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -6,7 +6,6 @@
 from spack import *
 
 import sys
-import os
 
 
 class Caliper(CMakePackage):

--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -79,7 +79,7 @@ class Caliper(CMakePackage):
         spec = self.spec
 
         args = [
-            ('-DPYTHON_EXECUTABLE=%s' % 
+            ('-DPYTHON_EXECUTABLE=%s' %
                 spec['python'].command.path),
             '-DBUILD_TESTING=Off',
             '-DBUILD_DOCS=Off',

--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -8,6 +8,7 @@ from spack import *
 import sys
 import os
 
+
 class Caliper(CMakePackage):
     """Caliper is a program instrumentation and performance measurement
     framework. It is designed as a performance analysis toolbox in a

--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -81,7 +81,7 @@ class Caliper(CMakePackage):
 
         args = [
             ('-DPYTHON_EXECUTABLE=%s' % 
-                os.path.join(spec['python'].prefix.bin, 'python3')),
+                spec['python'].command.path),
             '-DBUILD_TESTING=Off',
             '-DBUILD_DOCS=Off',
             '-DBUILD_SHARED_LIBS=%s' % ('On' if '+shared'  in spec else 'Off'),

--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 import sys
-
+import os
 
 class Caliper(CMakePackage):
     """Caliper is a program instrumentation and performance measurement
@@ -69,7 +69,7 @@ class Caliper(CMakePackage):
     depends_on('sosflow@spack', when='@1.0:1.99+sosflow')
 
     depends_on('cmake', type='build')
-    depends_on('python', type='build')
+    depends_on('python@3:', type='build')
 
     # sosflow support not yet in 2.0
     conflicts('+sosflow', '@2.0.0:2.2.99')
@@ -79,6 +79,8 @@ class Caliper(CMakePackage):
         spec = self.spec
 
         args = [
+            ('-DPYTHON_EXECUTABLE=%s' % 
+                os.path.join(spec['python'].prefix.bin, 'python3')),
             '-DBUILD_TESTING=Off',
             '-DBUILD_DOCS=Off',
             '-DBUILD_SHARED_LIBS=%s' % ('On' if '+shared'  in spec else 'Off'),


### PR DESCRIPTION
The package needs to be told where to find it.