### PR TITLE
lastz: cast from char to signed char

### DIFF
--- a/var/spack/repos/builtin/packages/lastz/cast_signed_char.patch
+++ b/var/spack/repos/builtin/packages/lastz/cast_signed_char.patch
@@ -1,0 +1,70 @@
+--- spack-src/src/sequences.c.org	2020-02-27 16:51:13.380985769 +0900
++++ spack-src/src/sequences.c	2020-02-27 16:55:38.641465062 +0900
+@@ -5086,14 +5086,14 @@
+ 		// find the next header
+ 
+ 		ch = seq_getc (_seq);
+-		if (ch == EOF) goto failure;
++		if ((signed char)ch == EOF) goto failure;
+ 
+ 		if ((allowComments) && (ch == '#'))
+ 			{ // comment, skip to end-of-line and go back and try again
+ 			while (ch != '\n')
+ 				{
+ 				ch = seq_getc (_seq);
+-				if (ch == EOF) goto failure;
++				if ((signed char)ch == EOF) goto failure;
+ 				}
+ 			continue;
+ 			}
+@@ -5117,12 +5117,12 @@
+ 		leadingWhite = 0;
+ 
+ 		ch = seq_getc (_seq);
+-		if (ch == EOF) goto failure;
++		if ((signed char)ch == EOF) goto failure;
+ 		while ((ch != '\n') && (isspace (ch)))
+ 			{
+ 			leadingWhite++;
+ 			ch = seq_getc (_seq);
+-			if (ch == EOF) goto failure;
++			if ((signed char)ch == EOF) goto failure;
+ 			}
+ 
+ 		if (ch == '\n')
+@@ -5137,7 +5137,7 @@
+ 				break;								//  .. truncate the header)
+ 			*(s++) = ch;
+ 			ch = seq_getc (_seq);
+-			if (ch == EOF) goto failure;
++			if ((signed char)ch == EOF) goto failure;
+ 			}
+ 		*s = 0;
+ 
+@@ -5231,7 +5231,7 @@
+ 		debugNamesFile_14;
+ 
+ 		ch = seq_getc (_seq);
+-		if (ch == EOF) goto failure;
++		if ((signed char)ch == EOF) goto failure;
+ 
+ 		if (ch != '@')
+ 			suicidef ("internal error in find_next_fastq_coi\n"
+@@ -5241,7 +5241,7 @@
+ 		// read the header
+ 
+ 		ch = seq_getc (_seq);
+-		if (ch == EOF) goto failure;
++		if ((signed char)ch == EOF) goto failure;
+ 
+ 		s = buffer;
+ 		while ((ch != '\n') && (ch != '\r'))
+@@ -5250,7 +5250,7 @@
+ 				break;								//  .. truncate the header)
+ 			*(s++) = ch;
+ 			ch = seq_getc (_seq);
+-			if (ch == EOF) goto failure;
++			if ((signed char)ch == EOF) goto failure;
+ 			}
+ 		*s = 0;
+ 

--- a/var/spack/repos/builtin/packages/lastz/package.py
+++ b/var/spack/repos/builtin/packages/lastz/package.py
@@ -14,5 +14,8 @@ class Lastz(MakefilePackage):
 
     version('1.04.00', sha256='a4c2c7a77430387e96dbc9f5bdc75874334c672be90f5720956c0f211abf9f5a')
 
+    # cast from char to signed char
+    patch('cast_signed_char.patch')
+
     def install(self, spec, prefix):
         make('install', 'LASTZ_INSTALL={0}'.format(prefix.bin))


### PR DESCRIPTION
- error

```
  >> 41    sequences.c:5089:3: error: comparison is always false due to limited
            range of data type [-Werror=type-limits]
     42       if (ch == EOF) goto failure;
     43       ^
```
I did typecast for `ch` to 'signed char'.

