### PR TITLE
Improve containerize - add input/output selection

### DIFF
--- a/lib/spack/spack/cmd/containerize.py
+++ b/lib/spack/spack/cmd/containerize.py
@@ -12,14 +12,41 @@ section = "container"
 level = "long"
 
 
+def setup_parser(subparser):
+    subparser.add_argument(
+        '-f', '--file', default=None,
+        dest='specfile', metavar='SPEC_YAML_FILE',
+        help="spack.yaml for which to generate the recipe. If not provided"
+             "try the env_dir provided by `spack -e`, if that also doesn't"
+             "exist try `./spack.yaml`.")
+    subparser.add_argument(
+        '-r', '--recipefile', default=None,
+        dest='recipefile',
+        help="name of the recipefile to generate. If None print to stdout.")
+
+
 def containerize(parser, args):
-    config_dir = args.env_dir or os.getcwd()
-    config_file = os.path.abspath(os.path.join(config_dir, 'spack.yaml'))
-    if not os.path.exists(config_file):
-        msg = 'file not found: {0}'
-        raise ValueError(msg.format(config_file))
+    if args.specfile is not None:
+        config_file = args.specfile
+        print(config_file)
+    else:
+        config_dir = args.env_dir or os.getcwd()
+        config_file = os.path.abspath(os.path.join(config_dir, 'spack.yaml'))
+        if not os.path.exists(config_file):
+            msg = "No spack.yaml explicitly provided (-f) and "
+            if args.env_dir:
+                msg += "the environment {0} does not have a spack.yaml"
+                msg = msg.format(args.env_dir)
+            else:
+                msg += "the current directory does not have a spack.yaml"
+            raise ValueError(msg.format(config_file))
 
     config = spack.container.validate(config_file)
 
     recipe = spack.container.recipe(config)
-    print(recipe)
+    if args.specfile is not None:
+        with open(args.recipefile, 'w') as f:
+            print("Writing container recipe to {0}".format(args.recipefile))
+            f.write(recipe)
+    else:
+        print(recipe)

--- a/lib/spack/spack/test/container/cli.py
+++ b/lib/spack/spack/test/container/cli.py
@@ -4,9 +4,29 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import llnl.util.filesystem as fs
 import spack.main
+import os
 
 
 containerize = spack.main.SpackCommand('containerize')
+
+
+def test_output(tmpdir):
+    filename = str(tmpdir.join('spack.yaml'))
+    with open(filename, 'w') as f:
+        f.write("""\
+spack:
+  # add package specs to the `specs` list
+  specs:
+    - callpath
+  container:
+    format: docker
+    base:
+      image: "ubuntu:18.04"
+      spack: "develop"
+    strip: true
+""")
+    containerize('-f', filename, '-r', 'recipe')
+    assert os.path.exists(os.path.join('.', 'recipe'))
 
 
 def test_command(configuration_dir, capsys):

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -629,7 +629,7 @@ _spack_configure() {
 }
 
 _spack_containerize() {
-    SPACK_COMPREPLY="-h --help"
+    SPACK_COMPREPLY="-h --help -f --file -r --recipefile"
 }
 
 _spack_create() {


### PR DESCRIPTION
* add a subparser
  * to manually specify the spack.yaml from which to
    create the container recipe (-f)
  * to provide a filename to write the recipe to. Useful
    if other output appears on the terminal (e.g. warnings)

The commit message describes it. Basically I was a bit annoyed that I couldn't just trigger the recipe building, but had to either `cd` into the environment directory or `spack env activate` the environment in order to containerize. This PR adds two options to the `spack containerize` command:
- `-f specfile` where specfile is a path/to/spack.yaml of the environment you want to containerize
- `-r recipefile` where recipefile is a path/to/recipe where the container recipe should be printed to. This frees up the console to do reporting.

I think this is a bit of a quality-of-life improvement for the containerize command and makes its behaviour a bit more obvious. The price is a bit more complicated logic in the parsing. On the plus side the error message in case of not finding a `spack.yaml` should be a bit more informative now. I'm not attached to any of the variable names, and maybe `specfile` should be something different. But I'm not up to date with the naming scheme for the whole environment related files, so suggestions are welcome.