### PR TITLE
Update tree for v1.8.0

### DIFF
--- a/var/spack/repos/builtin/packages/tree/package.py
+++ b/var/spack/repos/builtin/packages/tree/package.py
@@ -18,6 +18,7 @@ class Tree(Package):
     homepage = "http://mama.indstate.edu/users/ice/tree/"
     url      = "http://mama.indstate.edu/users/ice/tree/src/tree-1.7.0.tgz"
 
+    version('1.8.0', sha256='715d5d4b434321ce74706d0dd067505bb60c5ea83b5f0b3655dae40aa6f9b7c2')
     version('1.7.0', sha256='6957c20e82561ac4231638996e74f4cfa4e6faabc5a2f511f0b4e3940e8f7b12')
 
     def install(self, spec, prefix):
@@ -30,6 +31,10 @@ class Tree(Package):
             'hash.o',
             'color.o'
         ]
+        # version 1.8.0 added file.c
+        if spec.version >= Version('1.8.0'):
+            objs.append('file.o')
+
         if (sys.platform == 'darwin'):
             objs.append('strverscmp.o')
 


### PR DESCRIPTION
- add version info for v1.8.0

- v1.8.0 adds a new source file, `file.c`, which need to be included
  in our hardcoded list of objects to link.

  I discovered this while demonstrating "how easy it is to add a new
  package to Spack", only to scratch my head when it failed `spack
  install` but worked when I ran `make` in the stage dir.  Finally
  looked at tree/package.py and it All Became Clear.

  Perhaps someone should rewrite this to use MakefilePackage, but the
  Makefile starts off with a bunch of twisty turny "uncomment these
  lines to run on this platform", so it might not be worth it.