### PR TITLE
Set http:// in homepage for a few packages

### DIFF
--- a/var/spack/repos/builtin/packages/bowtie2/package.py
+++ b/var/spack/repos/builtin/packages/bowtie2/package.py
@@ -11,7 +11,7 @@ class Bowtie2(Package):
     """Bowtie 2 is an ultrafast and memory-efficient tool for aligning
        sequencing reads to long reference sequences"""
 
-    homepage = "bowtie-bio.sourceforge.net/bowtie2/index.shtml"
+    homepage = "http://bowtie-bio.sourceforge.net/bowtie2/index.shtml"
     url      = "http://downloads.sourceforge.net/project/bowtie-bio/bowtie2/2.3.1/bowtie2-2.3.1-source.zip"
 
     version('2.3.5.1', sha256='335c8dafb1487a4a9228ef922fbce4fffba3ce8bc211e2d7085aac092155a53f')

--- a/var/spack/repos/builtin/packages/exuberant-ctags/package.py
+++ b/var/spack/repos/builtin/packages/exuberant-ctags/package.py
@@ -8,7 +8,7 @@ from spack import *
 
 class ExuberantCtags(AutotoolsPackage):
     """The canonical ctags generator"""
-    homepage = "ctags.sourceforge.net"
+    homepage = "http://ctags.sourceforge.net"
     url      = "http://downloads.sourceforge.net/project/ctags/ctags/5.8/ctags-5.8.tar.gz"
 
     version('5.8', sha256='0e44b45dcabe969e0bbbb11e30c246f81abe5d32012db37395eb57d66e9e99c7')

--- a/var/spack/repos/builtin/packages/perl-want/package.py
+++ b/var/spack/repos/builtin/packages/perl-want/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlWant(PerlPackage):
     """A generalisation of wantarray."""
 
-    homepage = "search.cpan.org/~robin/Want/Want.pm"
+    homepage = "http://search.cpan.org/~robin/Want/Want.pm"
     url      = "http://search.cpan.org/CPAN/authors/id/R/RO/ROBIN/Want-0.29.tar.gz"
 
     version('0.29', sha256='b4e4740b8d4cb783591273c636bd68304892e28d89e88abf9273b1de17f552f7')

--- a/var/spack/repos/builtin/packages/samtools/package.py
+++ b/var/spack/repos/builtin/packages/samtools/package.py
@@ -11,8 +11,8 @@ class Samtools(Package):
        the SAM format, including sorting, merging, indexing and generating
        alignments in a per-position format"""
 
-    homepage = "www.htslib.org"
-    url = "https://github.com/samtools/samtools/releases/download/1.3.1/samtools-1.3.1.tar.bz2"
+    homepage = "http://www.htslib.org"
+    url      = "https://github.com/samtools/samtools/releases/download/1.3.1/samtools-1.3.1.tar.bz2"
 
     version('1.10', sha256='7b9ec5f05d61ec17bd9a82927e45d8ef37f813f79eb03fe06c88377f1bd03585')
     version('1.9', sha256='083f688d7070082411c72c27372104ed472ed7a620591d06f928e653ebc23482')


### PR DESCRIPTION
This PR adds 'http://' to the homepage setting of a few packages that do
not have it set. Not having that set can cause problems with some wiki
apps when embedding the homepage value into markdown syntax.

- bowtie2
- exuberant-ctags
- perl-want
- samtools