### PR TITLE
Quantum-Espresso: qe-6.5 fails to detect MKL for FFT

### DIFF
--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -230,7 +230,18 @@ class QuantumEspresso(Package):
         # appear twice in in link line but this is harmless
         lapack_blas = spec['lapack'].libs + spec['blas'].libs
 
-        options.append('BLAS_LIBS={0}'.format(lapack_blas.ld_flags))
+        # qe-6.5 fails to detect MKL for FFT if BLAS_LIBS is set due to
+        # an unfortunate upsteam change in their autoconf/configure:
+        # - qe-6.5/install/m4/x_ac_qe_blas.m4 only sets 'have_blas'
+        #   but no 'have_mkl' if BLAS_LIBS is set (which seems to be o.k.)
+        # - however, qe-6.5/install/m4/x_ac_qe_fft.m4 in 6.5 unfortunately
+        #   relies on x_ac_qe_blas.m4 to detect MKL and set 'have_mkl'
+        # - qe-5.4 up to 6.4.1 had a different logic and worked fine with
+        #   BLAS_LIBS being set
+        # However, MKL is correctly picked up by qe-6.5 for BLAS and FFT if
+        # MKLROOT is set (which SPACK does automatically for ^intel-mkl)
+        if not ('quantum-espresso@6.5' in spec and '^intel-mkl' in spec):
+            options.append('BLAS_LIBS={0}'.format(lapack_blas.ld_flags))
 
         if '+scalapack' in spec:
             scalapack_option = 'intel' if '^intel-mkl' in spec else 'yes'

--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -78,7 +78,7 @@ class QuantumEspresso(Package):
     # Conflicts
     # MKL with 64-bit integers not supported.
     conflicts(
-        '^intel-mkl+ilp64',
+        '^mkl+ilp64',
         msg='Quantum ESPRESSO does not support MKL 64-bit integer variant'
     )
 
@@ -211,7 +211,7 @@ class QuantumEspresso(Package):
         # you need to pass it in the FFTW_INCLUDE and FFT_LIBS directory.
         # QE supports an internal FFTW2, but only an external FFTW3 interface.
 
-        if '^intel-mkl' in spec:
+        if '^mkl' in spec:
             # A seperate FFT library is not needed when linking against MKL
             options.append(
                 'FFTW_INCLUDE={0}'.format(join_path(env['MKLROOT'],
@@ -239,12 +239,12 @@ class QuantumEspresso(Package):
         # - qe-5.4 up to 6.4.1 had a different logic and worked fine with
         #   BLAS_LIBS being set
         # However, MKL is correctly picked up by qe-6.5 for BLAS and FFT if
-        # MKLROOT is set (which SPACK does automatically for ^intel-mkl)
-        if not ('quantum-espresso@6.5' in spec and '^intel-mkl' in spec):
+        # MKLROOT is set (which SPACK does automatically for ^mkl)
+        if not ('quantum-espresso@6.5' in spec and '^mkl' in spec):
             options.append('BLAS_LIBS={0}'.format(lapack_blas.ld_flags))
 
         if '+scalapack' in spec:
-            scalapack_option = 'intel' if '^intel-mkl' in spec else 'yes'
+            scalapack_option = 'intel' if '^mkl' in spec else 'yes'
             options.append('--with-scalapack={0}'.format(scalapack_option))
 
         if '+elpa' in spec:


### PR DESCRIPTION
qe-6.5 fails to detect MKL for FFT if BLAS_LIBS is set due to
an unfortunate upsteam change in their autoconf/configure:
- qe-6.5/install/m4/x_ac_qe_blas.m4 only sets 'have_blas'
  but no 'have_mkl' if BLAS_LIBS is set (which seems to be o.k.)
- however, qe-6.5/install/m4/x_ac_qe_fft.m4 in 6.5 unfortunately
  relies on x_ac_qe_blas.m4 to detect MKL and set 'have_mkl'
- qe-5.4 up to 6.4.1 had a different logic and worked fine with
  BLAS_LIBS being set
However, MKL is correctly picked up by qe-6.5 for BLAS and FFT if
MKLROOT is set (which SPACK does automatically for ^intel-mkl).
Thus, do not set BLAS_LIBS when compiling qe-6.5 with intel-mkl.

@naromero77 / @alalazo:
This PR has been split off from #15242 for separating distinct parts and easier merging.