### PR TITLE
Tmux should look for tinfo in -ltinfo

### DIFF
--- a/var/spack/repos/builtin/packages/tmux/package.py
+++ b/var/spack/repos/builtin/packages/tmux/package.py
@@ -32,4 +32,4 @@ class Tmux(AutotoolsPackage):
     # used by configure to e.g. find libtinfo
     depends_on('pkgconfig', type='build')
     depends_on('libevent')
-    depends_on('ncurses+termlib')
+    depends_on('ncurses')

--- a/var/spack/repos/builtin/packages/tmux/package.py
+++ b/var/spack/repos/builtin/packages/tmux/package.py
@@ -33,4 +33,3 @@ class Tmux(AutotoolsPackage):
     depends_on('pkgconfig', type='build')
     depends_on('libevent')
     depends_on('ncurses+termlib')
-

--- a/var/spack/repos/builtin/packages/tmux/package.py
+++ b/var/spack/repos/builtin/packages/tmux/package.py
@@ -30,13 +30,9 @@ class Tmux(AutotoolsPackage):
     version('1.9a', sha256='c5e3b22b901cf109b20dab54a4a651f0471abd1f79f6039d79b250d21c2733f5')
 
     depends_on('libevent')
-    # assumes that the default is ncurses+termlib, see configure_args below
-    depends_on('ncurses')
+    depends_on('ncurses+termlib')
 
     def flag_handler(self, name, flags):
         if name == 'cppflags':
             flags.append(self.spec['ncurses'].headers.include_flags)
         return (None, flags, None)
-
-    def configure_args(self):
-        return ['LIBTINFO_LIBS=-ltinfo']

--- a/var/spack/repos/builtin/packages/tmux/package.py
+++ b/var/spack/repos/builtin/packages/tmux/package.py
@@ -29,6 +29,8 @@ class Tmux(AutotoolsPackage):
     version('2.1', sha256='31564e7bf4bcef2defb3cb34b9e596bd43a3937cad9e5438701a81a5a9af6176')
     version('1.9a', sha256='c5e3b22b901cf109b20dab54a4a651f0471abd1f79f6039d79b250d21c2733f5')
 
+    # used by configure to e.g. find libtinfo
+    depends_on('pkgconfig', type='build')
     depends_on('libevent')
     depends_on('ncurses+termlib')
 

--- a/var/spack/repos/builtin/packages/tmux/package.py
+++ b/var/spack/repos/builtin/packages/tmux/package.py
@@ -34,7 +34,3 @@ class Tmux(AutotoolsPackage):
     depends_on('libevent')
     depends_on('ncurses+termlib')
 
-    def flag_handler(self, name, flags):
-        if name == 'cppflags':
-            flags.append(self.spec['ncurses'].headers.include_flags)
-        return (None, flags, None)

--- a/var/spack/repos/builtin/packages/tmux/package.py
+++ b/var/spack/repos/builtin/packages/tmux/package.py
@@ -30,6 +30,7 @@ class Tmux(AutotoolsPackage):
     version('1.9a', sha256='c5e3b22b901cf109b20dab54a4a651f0471abd1f79f6039d79b250d21c2733f5')
 
     depends_on('libevent')
+    # assumes that the default is ncurses+termlib, see configure_args below
     depends_on('ncurses')
 
     def flag_handler(self, name, flags):
@@ -38,4 +39,4 @@ class Tmux(AutotoolsPackage):
         return (None, flags, None)
 
     def configure_args(self):
-        return ['LIBTINFO_LIBS=-lncurses']
+        return ['LIBTINFO_LIBS=-ltinfo']


### PR DESCRIPTION
Tmux tests for `setupterm` functionality in its configure script.

Our ncurses package provides terminfo functionality when built with
+termlib, which is the default.  That functionality is in a separate
library, called `libtinfo`. 

This ensures that ncurses is built to include termlib support and 
removes the override for the library location, trusting our pkg-config
to sniff it out.

All versions of tmux in its package definition built successfully on a CentOS box and ldd shows the binary was linked against spack libtinfo.

Additional details in: https://github.com/spack/spack/issues/15281

Closes #15281