### PR TITLE
Update tcsh package

### DIFF
--- a/var/spack/repos/builtin/packages/tcsh/package.py
+++ b/var/spack/repos/builtin/packages/tcsh/package.py
@@ -15,10 +15,11 @@ class Tcsh(AutotoolsPackage):
     syntax."""
 
     homepage = "http://www.tcsh.org/"
-    url      = "http://ftp.funet.fi/pub/mirrors/ftp.astron.com/pub/tcsh/old/tcsh-6.20.00.tar.gz"
+    url      = "http://ftp.funet.fi/pub/mirrors/ftp.astron.com/pub/tcsh/tcsh-6.20.00.tar.gz"
+    list_url = "http://ftp.funet.fi/pub/mirrors/ftp.astron.com/pub/tcsh/old/"
 
-    version('6.21.00', sha256='c438325448371f59b12a4c93bfd3f6982e6f79f8c5aef4bc83aac8f62766e972',
-            url='http://ftp.funet.fi/pub/mirrors/ftp.astron.com/pub/tcsh/tcsh-6.21.00.tar.gz')
+    version('6.22.02', sha256='ed287158ca1b00ba477e8ea57bac53609838ebcfd05fcb05ca95021b7ebe885b')
+    version('6.21.00', sha256='c438325448371f59b12a4c93bfd3f6982e6f79f8c5aef4bc83aac8f62766e972')
     version('6.20.00', sha256='b89de7064ab54dac454a266cfe5d8bf66940cb5ed048d0c30674ea62e7ecef9d')
 
     def fedora_patch(commit, file, **kwargs):  # noqa
@@ -40,7 +41,7 @@ class Tcsh(AutotoolsPackage):
     # Downstream patches
     fedora_patch('8a6066c901fb4fc75013dd488ba958387f00c74d', 'tcsh-6.20.00-manpage-memoryuse.patch', sha256='3a4e60fe56a450632140c48acbf14d22850c1d72835bf441e3f8514d6c617a9f')  # noqa: E501
 
-    depends_on('ncurses')
+    depends_on('ncurses+termlib')
 
     @run_after('install')
     def link_csh(self):


### PR DESCRIPTION
This PR adds some fixes for the tcsh package.

- Adds new version
- adds list_url so fetching works for current and old tarballs
- sets ncurses dependency explicitly to `ncurses+termlib`

If `+termlib` is not set then it will link against the system libtinfo.