### PR TITLE
lastz: set compile commands for each compiler

### DIFF
--- a/var/spack/repos/builtin/packages/lastz/package.py
+++ b/var/spack/repos/builtin/packages/lastz/package.py
@@ -17,5 +17,9 @@ class Lastz(MakefilePackage):
     # cast from char to signed char
     patch('cast_signed_char.patch')
 
+    # set compile commands for each compiler
+    def edit(self, spec, prefix):
+        filter_file('gcc', spack_cc, 'src/Makefile')
+
     def install(self, spec, prefix):
         make('install', 'LASTZ_INSTALL={0}'.format(prefix.bin))


### PR DESCRIPTION
- `lastz` always uses only gnu compiler, so I fixed makefiles to use compile commands of specified compiler on Spack.