### PR TITLE
Suite sparse compilation fix for 5.7.0 and 5.7.1

### DIFF
--- a/var/spack/repos/builtin/packages/suite-sparse/package.py
+++ b/var/spack/repos/builtin/packages/suite-sparse/package.py
@@ -131,7 +131,7 @@ class SuiteSparse(Package):
         # In those SuiteSparse versions calling "make install" in one go is
         # not possible, mainly because of GraphBLAS.  Thus compile first and
         # install in a second run.
-        if (self.spec.version >= Version('5.4.0')):
+        if '@5.4.0:' in self.spec:
             make('default', *make_args)
 
         make('install', *make_args)

--- a/var/spack/repos/builtin/packages/suite-sparse/package.py
+++ b/var/spack/repos/builtin/packages/suite-sparse/package.py
@@ -131,8 +131,7 @@ class SuiteSparse(Package):
         # In those SuiteSparse versions calling "make install" in one go is
         # not possible, mainly because of GraphBLAS.  Thus compile first and
         # install in a second run.
-        if (self.spec.version >= Version('5.4.0') and
-            self.spec.version <= Version('5.6.0')):
+        if (self.spec.version >= Version('5.4.0')):
             make('default', *make_args)
 
         make('install', *make_args)


### PR DESCRIPTION
Newest suite-sparse versions also need separate make run to compile successfully