### PR TITLE
Protobuf's cmake environment does not properly handle being exported

### DIFF
--- a/var/spack/repos/builtin/packages/protobuf/package.py
+++ b/var/spack/repos/builtin/packages/protobuf/package.py
@@ -39,6 +39,9 @@ class Protobuf(CMakePackage):
 
     variant('shared', default=True,
             description='Enables the build of shared libraries')
+    variant('build_type', default='Release',
+            description='The build type to build',
+            values=('Debug', 'Release'))
 
     depends_on('zlib')
 


### PR DESCRIPTION
and found when using the RelWithDebInfo build type.  Change protobuf
to only support Release and Debug build types.