### PR TITLE
OpenMPI: patch for NAG.

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/nag_ltmain_1.patch
+++ b/var/spack/repos/builtin/packages/openmpi/nag_ltmain_1.patch
@@ -1,0 +1,49 @@
+--- a/config/ltmain.sh
++++ b/config/ltmain.sh
+@@ -7860,14 +7860,15 @@ func_mode_link ()
+ 	func_source "$lib"
+ 
+ 	# Convert "-framework foo" to "foo.ltframework"
+-        # and "-pthread" to "-Wl,-pthread" if NAG compiler
+ 	if test -n "$inherited_linker_flags"; then
+-          case "$CC" in
+-            *nagfor*)
+-	      tmp_inherited_linker_flags=`$ECHO "$inherited_linker_flags" | $SED 's/-framework \([^ $]*\)/\1.ltframework/g' | $SED 's/-pthread/-Wl,-pthread/g'`;;
+-            *)
+-	      tmp_inherited_linker_flags=`$ECHO "$inherited_linker_flags" | $SED 's/-framework \([^ $]*\)/\1.ltframework/g'`;;
+-          esac
++	  tmp_inherited_linker_flags=`$ECHO "$inherited_linker_flags" | $SED 's/-framework \([^ $]*\)/\1.ltframework/g'`
++
++	  # Additionally convert " -pthread" to " -Wl,-pthread" for nagfor
++	  func_cc_basename $CC
++	  case $func_cc_basename_result in
++	    nagfor*) tmp_inherited_linker_flags=`$ECHO "$tmp_inherited_linker_flags" | $SED 's/ -pthread/ -Wl,-pthread/g'` ;;
++	  esac
++
+ 	  for tmp_inherited_linker_flag in $tmp_inherited_linker_flags; do
+ 	    case " $new_inherited_linker_flags " in
+ 	      *" $tmp_inherited_linker_flag "*) ;;
+@@ -8887,7 +8888,8 @@ func_mode_link ()
+ 	  xlcverstring="$wl-compatibility_version $wl$minor_current $wl-current_version $wl$minor_current.$revision"
+ 	  verstring="-compatibility_version $minor_current -current_version $minor_current.$revision"
+           # On Darwin other compilers
+-          case $CC in
++          func_cc_basename $CC
++          case $func_cc_basename_result in
+               nagfor*)
+                   verstring="$wl-compatibility_version $wl$minor_current $wl-current_version $wl$minor_current.$revision"
+                   ;;
+@@ -9499,6 +9501,13 @@ EOF
+ 	  ;;
+       esac
+ 
++      # Time to revert the changes made for nagfor.
++      func_cc_basename $CC
++      case $func_cc_basename_result in
++        nagfor*)
++          new_inherited_linker_flags=`$ECHO " $new_inherited_linker_flags" | $SED 's% -Wl,-pthread% -pthread%g'` ;;
++      esac
++
+       # move library search paths that coincide with paths to not yet
+       # installed libraries to the beginning of the library search list
+       new_libs=

--- a/var/spack/repos/builtin/packages/openmpi/nag_ltmain_2.patch
+++ b/var/spack/repos/builtin/packages/openmpi/nag_ltmain_2.patch
@@ -1,0 +1,49 @@
+--- a/config/ltmain.sh
++++ b/config/ltmain.sh
+@@ -7860,14 +7860,15 @@ func_mode_link ()
+ 	func_source "$lib"
+ 
+ 	# Convert "-framework foo" to "foo.ltframework"
+-        # and "-pthread" to "-Wl,-pthread" if NAG compiler
+ 	if test -n "$inherited_linker_flags"; then
+-          case "$CC" in
+-            nagfor*)
+-	      tmp_inherited_linker_flags=`$ECHO "$inherited_linker_flags" | $SED 's/-framework \([^ $]*\)/\1.ltframework/g' | $SED 's/-pthread/-Wl,-pthread/g'`;;
+-            *)
+-	      tmp_inherited_linker_flags=`$ECHO "$inherited_linker_flags" | $SED 's/-framework \([^ $]*\)/\1.ltframework/g'`;;
+-          esac
++	  tmp_inherited_linker_flags=`$ECHO "$inherited_linker_flags" | $SED 's/-framework \([^ $]*\)/\1.ltframework/g'`
++
++	  # Additionally convert " -pthread" to " -Wl,-pthread" for nagfor
++	  func_cc_basename $CC
++	  case $func_cc_basename_result in
++	    nagfor*) tmp_inherited_linker_flags=`$ECHO "$tmp_inherited_linker_flags" | $SED 's/ -pthread/ -Wl,-pthread/g'` ;;
++	  esac
++
+ 	  for tmp_inherited_linker_flag in $tmp_inherited_linker_flags; do
+ 	    case " $new_inherited_linker_flags " in
+ 	      *" $tmp_inherited_linker_flag "*) ;;
+@@ -8887,7 +8888,8 @@ func_mode_link ()
+ 	  xlcverstring="$wl-compatibility_version $wl$minor_current $wl-current_version $wl$minor_current.$revision"
+ 	  verstring="-compatibility_version $minor_current -current_version $minor_current.$revision"
+           # On Darwin other compilers
+-          case $CC in
++          func_cc_basename $CC
++          case $func_cc_basename_result in
+               nagfor*)
+                   verstring="$wl-compatibility_version $wl$minor_current $wl-current_version $wl$minor_current.$revision"
+                   ;;
+@@ -9499,6 +9501,13 @@ EOF
+ 	  ;;
+       esac
+ 
++      # Time to revert the changes made for nagfor.
++      func_cc_basename $CC
++      case $func_cc_basename_result in
++        nagfor*)
++          new_inherited_linker_flags=`$ECHO " $new_inherited_linker_flags" | $SED 's% -Wl,-pthread% -pthread%g'` ;;
++      esac
++
+       # move library search paths that coincide with paths to not yet
+       # installed libraries to the beginning of the library search list
+       new_libs=

--- a/var/spack/repos/builtin/packages/openmpi/nag_ltmain_3.patch
+++ b/var/spack/repos/builtin/packages/openmpi/nag_ltmain_3.patch
@@ -1,0 +1,40 @@
+--- a/config/ltmain.sh
++++ b/config/ltmain.sh
+@@ -7862,6 +7862,13 @@ func_mode_link ()
+ 	# Convert "-framework foo" to "foo.ltframework"
+ 	if test -n "$inherited_linker_flags"; then
+ 	  tmp_inherited_linker_flags=`$ECHO "$inherited_linker_flags" | $SED 's/-framework \([^ $]*\)/\1.ltframework/g'`
++
++	  # Additionally convert " -pthread" to " -Wl,-pthread" for nagfor
++	  func_cc_basename $CC
++	  case $func_cc_basename_result in
++	    nagfor*) tmp_inherited_linker_flags=`$ECHO "$tmp_inherited_linker_flags" | $SED 's/ -pthread/ -Wl,-pthread/g'` ;;
++	  esac
++
+ 	  for tmp_inherited_linker_flag in $tmp_inherited_linker_flags; do
+ 	    case " $new_inherited_linker_flags " in
+ 	      *" $tmp_inherited_linker_flag "*) ;;
+@@ -8881,7 +8888,8 @@ func_mode_link ()
+ 	  xlcverstring="$wl-compatibility_version $wl$minor_current $wl-current_version $wl$minor_current.$revision"
+ 	  verstring="-compatibility_version $minor_current -current_version $minor_current.$revision"
+           # On Darwin other compilers
+-          case $CC in
++          func_cc_basename $CC
++          case $func_cc_basename_result in
+               nagfor*)
+                   verstring="$wl-compatibility_version $wl$minor_current $wl-current_version $wl$minor_current.$revision"
+                   ;;
+@@ -9493,6 +9501,13 @@ EOF
+ 	  ;;
+       esac
+ 
++      # Time to revert the changes made for nagfor.
++      func_cc_basename $CC
++      case $func_cc_basename_result in
++        nagfor*)
++          new_inherited_linker_flags=`$ECHO " $new_inherited_linker_flags" | $SED 's% -Wl,-pthread% -pthread%g'` ;;
++      esac
++
+       # move library search paths that coincide with paths to not yet
+       # installed libraries to the beginning of the library search list
+       new_libs=

--- a/var/spack/repos/builtin/packages/openmpi/nag_ltmain_4.patch
+++ b/var/spack/repos/builtin/packages/openmpi/nag_ltmain_4.patch
@@ -1,0 +1,49 @@
+--- a/config/ltmain.sh
++++ b/config/ltmain.sh
+@@ -7860,14 +7860,15 @@ func_mode_link ()
+ 	func_source "$lib"
+ 
+ 	# Convert "-framework foo" to "foo.ltframework"
+-        # and "-pthread" to "-Wl,-pthread" if NAG compiler
+ 	if test -n "$inherited_linker_flags"; then
+-          case "$CC" in
+-            nagfor*)
+-	      tmp_inherited_linker_flags=`$ECHO "$inherited_linker_flags" | $SED 's/-framework \([^ $]*\)/\1.ltframework/g' | $SED 's/-pthread/-Wl,-pthread'`;;
+-            *)
+-	      tmp_inherited_linker_flags=`$ECHO "$inherited_linker_flags" | $SED 's/-framework \([^ $]*\)/\1.ltframework/g'`;;
+-          esac
++	  tmp_inherited_linker_flags=`$ECHO "$inherited_linker_flags" | $SED 's/-framework \([^ $]*\)/\1.ltframework/g'`
++
++	  # Additionally convert " -pthread" to " -Wl,-pthread" for nagfor
++	  func_cc_basename $CC
++	  case $func_cc_basename_result in
++	    nagfor*) tmp_inherited_linker_flags=`$ECHO "$tmp_inherited_linker_flags" | $SED 's/ -pthread/ -Wl,-pthread/g'` ;;
++	  esac
++
+ 	  for tmp_inherited_linker_flag in $tmp_inherited_linker_flags; do
+ 	    case " $new_inherited_linker_flags " in
+ 	      *" $tmp_inherited_linker_flag "*) ;;
+@@ -8887,7 +8888,8 @@ func_mode_link ()
+ 	  xlcverstring="$wl-compatibility_version $wl$minor_current $wl-current_version $wl$minor_current.$revision"
+ 	  verstring="-compatibility_version $minor_current -current_version $minor_current.$revision"
+           # On Darwin other compilers
+-          case $CC in
++          func_cc_basename $CC
++          case $func_cc_basename_result in
+               nagfor*)
+                   verstring="$wl-compatibility_version $wl$minor_current $wl-current_version $wl$minor_current.$revision"
+                   ;;
+@@ -9499,6 +9501,13 @@ EOF
+ 	  ;;
+       esac
+ 
++      # Time to revert the changes made for nagfor.
++      func_cc_basename $CC
++      case $func_cc_basename_result in
++        nagfor*)
++          new_inherited_linker_flags=`$ECHO " $new_inherited_linker_flags" | $SED 's% -Wl,-pthread% -pthread%g'` ;;
++      esac
++
+       # move library search paths that coincide with paths to not yet
+       # installed libraries to the beginning of the library search list
+       new_libs=

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -203,6 +203,13 @@ class Openmpi(AutotoolsPackage):
     patch('btl_vader.patch', when='@3.0.1:3.0.2')
     patch('btl_vader.patch', when='@3.1.0:3.1.2')
 
+    # Reported upstream: https://github.com/open-mpi/ompi/pull/6378
+    # We support only versions based on Libtool 2.4.6.
+    patch('nag_ltmain_1.patch', when='@2.1.4:2.1.999,3.0.1:4%nag')
+    patch('nag_ltmain_2.patch', when='@2.1.2:2.1.3,3.0.0%nag')
+    patch('nag_ltmain_3.patch', when='@2.0.0:2.1.1%nag')
+    patch('nag_ltmain_4.patch', when='@1.10.4:1.10.999%nag')
+
     variant(
         'fabrics',
         values=disjoint_sets(
@@ -398,6 +405,7 @@ class Openmpi(AutotoolsPackage):
         spec = self.spec
         config_args = [
             '--enable-shared',
+            '--disable-silent-rules'
         ]
 
         # Add extra_rpaths dirs from compilers.yaml into link wrapper


### PR DESCRIPTION
This fixes the problem with NAG compiler for versions of OpenMPI that are based on Libtool 2.4.6. Versions that use older versions of Libtool need to be patched too but I assume that nobody is interested in them. The problem is reported upstream a year ago: https://github.com/open-mpi/ompi/pull/6378.