### PR TITLE
mpich: Allow building with external hwloc library

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -97,7 +97,7 @@ spack package at this time.''',
     depends_on('findutils', type='build')
     depends_on('pkgconfig', type='build')
 
-    depends_on('hwloc @1.0.0:', when='+hwloc')
+    depends_on('hwloc@2.0.0:', when='@3.3: +hwloc')
 
     depends_on('libfabric', when='netmod=ofi')
     # The ch3 ofi netmod results in crashes with libfabric 1.7

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -121,10 +121,10 @@ spack package at this time.''',
     depends_on("autoconf@2.67:", when='@develop', type=("build"))
 
     # building with "+hwloc' also requires regenerating autotools files
-    depends_on('automake@1.15:', when='+hwloc', type="build")
-    depends_on('libtool@2.4.4:', when='+hwloc', type="build")
-    depends_on("m4", when="+hwloc", type="build"),
-    depends_on("autoconf@2.67:", when='+hwloc', type="build")
+    depends_on('automake@1.15:', when='@3.3 +hwloc', type="build")
+    depends_on('libtool@2.4.4:', when='@3.3 +hwloc', type="build")
+    depends_on("m4", when="@3.3 +hwloc", type="build"),
+    depends_on("autoconf@2.67:", when='@3.3 +hwloc', type="build")
 
     conflicts('device=ch4', when='@:3.2')
     conflicts('netmod=ofi', when='@:3.1.4')
@@ -179,10 +179,8 @@ spack package at this time.''',
         """Not needed usually, configure should be already there"""
         # If configure exists nothing needs to be done
         
-        hwloc_patch_sha256 = \
-            'eb982de3366d48cbc55eb5e0df43373a45d9f51df208abf0835a72dc6c0b4774'
         if (os.path.exists(self.configure_abs_path) and
-            ('patches=' + hwloc_patch_sha256) not in spec):
+            not spec.satisfies('@3.3 +hwloc'):
             return
         # Else bootstrap with autotools
         bash = which('bash')

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -76,8 +76,10 @@ spack package at this time.''',
     # Fix using an external hwloc
     # See https://github.com/pmodels/mpich/issues/4038
     # and https://github.com/pmodels/mpich/pull/3540
+    _hwloc_patch_sha256 = \
+        'eb982de3366d48cbc55eb5e0df43373a45d9f51df208abf0835a72dc6c0b4774'
     patch('https://github.com/pmodels/mpich/commit/8a851b317ee57366cd15f4f28842063d8eff4483.patch',
-          sha256='eb982de3366d48cbc55eb5e0df43373a45d9f51df208abf0835a72dc6c0b4774',
+          sha256=_hwloc_patch_sha256,
           when='@3.3 +hwloc')
 
     # fix MPI_Barrier segmentation fault
@@ -178,7 +180,9 @@ spack package at this time.''',
     def autoreconf(self, spec, prefix):
         """Not needed usually, configure should be already there"""
         # If configure exists nothing needs to be done
-        if os.path.exists(self.configure_abs_path) and 'patches=eb982de3366d48cbc55eb5e0df43373a45d9f51df208abf0835a72dc6c0b4774' not in spec:
+        
+        if (os.path.exists(self.configure_abs_path) and
+            ('patches=' + _hwloc_patch_sha256) not in spec):
             return
         # Else bootstrap with autotools
         bash = which('bash')

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -76,6 +76,7 @@ spack package at this time.''',
     # Fix using an external hwloc
     # See https://github.com/pmodels/mpich/issues/4038
     # and https://github.com/pmodels/mpich/pull/3540
+    @staticmethod
     def _hwloc_patch_sha256():
         return 'eb982de3366d48cbc55eb5e0df43373a45d9f51df208abf0835a72dc6c0b4774'
     patch('https://github.com/pmodels/mpich/commit/8a851b317ee57366cd15f4f28842063d8eff4483.patch',

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -76,10 +76,10 @@ spack package at this time.''',
     # Fix using an external hwloc
     # See https://github.com/pmodels/mpich/issues/4038
     # and https://github.com/pmodels/mpich/pull/3540
-    _hwloc_patch_sha256 = \
-        'eb982de3366d48cbc55eb5e0df43373a45d9f51df208abf0835a72dc6c0b4774'
+    def _hwloc_patch_sha256():
+        return 'eb982de3366d48cbc55eb5e0df43373a45d9f51df208abf0835a72dc6c0b4774'
     patch('https://github.com/pmodels/mpich/commit/8a851b317ee57366cd15f4f28842063d8eff4483.patch',
-          sha256=_hwloc_patch_sha256,
+          sha256=_hwloc_patch_sha256(),
           when='@3.3 +hwloc')
 
     # fix MPI_Barrier segmentation fault
@@ -182,7 +182,7 @@ spack package at this time.''',
         # If configure exists nothing needs to be done
         
         if (os.path.exists(self.configure_abs_path) and
-            ('patches=' + _hwloc_patch_sha256) not in spec):
+            ('patches=' + _hwloc_patch_sha256()) not in spec):
             return
         # Else bootstrap with autotools
         bash = which('bash')

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -178,7 +178,7 @@ spack package at this time.''',
     def autoreconf(self, spec, prefix):
         """Not needed usually, configure should be already there"""
         # If configure exists nothing needs to be done
-        if os.path.exists(self.configure_abs_path) and '+hwloc' not in spec:
+        if os.path.exists(self.configure_abs_path) and 'patches=eb982de3366d48cbc55eb5e0df43373a45d9f51df208abf0835a72dc6c0b4774' not in spec:
             return
         # Else bootstrap with autotools
         bash = which('bash')

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -76,9 +76,9 @@ spack package at this time.''',
     # Fix using an external hwloc
     # See https://github.com/pmodels/mpich/issues/4038
     # and https://github.com/pmodels/mpich/pull/3540
-    patch('https://github.com/pmodels/mpich/commit/86ee1097d4507154cd18f8d8f5fcc0c53f106e11.patch',
-          sha256='27a339d9a879440cc37e1a89680a289d2c06797953fa226045b32d9247b8a1ea',
-          when='+hwloc')
+    patch('https://github.com/pmodels/mpich/commit/8a851b317ee57366cd15f4f28842063d8eff4483.patch',
+          sha256='eb982de3366d48cbc55eb5e0df43373a45d9f51df208abf0835a72dc6c0b4774',
+          when='@3.3 +hwloc')
 
     # fix MPI_Barrier segmentation fault
     # see https://lists.mpich.org/pipermail/discuss/2016-May/004764.html

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -121,10 +121,10 @@ spack package at this time.''',
     depends_on("autoconf@2.67:", when='@develop', type=("build"))
 
     # building with "+hwloc' also requires regenerating autotools files
-    depends_on('automake@1.15:', when='+hwloc', type=("build"))
-    depends_on('libtool@2.4.4:', when='+hwloc', type=("build"))
-    depends_on("m4", when="+hwloc", type=("build")),
-    depends_on("autoconf@2.67:", when='+hwloc', type=("build"))
+    depends_on('automake@1.15:', when='+hwloc', type="build")
+    depends_on('libtool@2.4.4:', when='+hwloc', type="build")
+    depends_on("m4", when="+hwloc", type="build"),
+    depends_on("autoconf@2.67:", when='+hwloc', type="build")
 
     conflicts('device=ch4', when='@:3.2')
     conflicts('netmod=ofi', when='@:3.1.4')

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -179,7 +179,7 @@ spack package at this time.''',
         """Not needed usually, configure should be already there"""
         # If configure exists nothing needs to be done
         
-        hwloc_patch_sha = \
+        hwloc_patch_sha256 = \
             'eb982de3366d48cbc55eb5e0df43373a45d9f51df208abf0835a72dc6c0b4774'
         if (os.path.exists(self.configure_abs_path) and
             ('patches=' + hwloc_patch_sha256) not in spec):

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -199,7 +199,7 @@ spack package at this time.''',
         config_args = [
             '--enable-shared',
             '--with-hwloc-prefix={0}'.format(
-                spec['hwloc'].prefix if '+hwloc' else 'embedded'),
+                spec['hwloc'].prefix if '^hwloc' in spec else 'embedded'),
             '--with-pm={0}'.format('hydra' if '+hydra' in spec else 'no'),
             '--{0}-romio'.format('enable' if '+romio' in spec else 'disable'),
             '--{0}-ibverbs'.format('with' if '+verbs' in spec else 'without'),

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -76,11 +76,8 @@ spack package at this time.''',
     # Fix using an external hwloc
     # See https://github.com/pmodels/mpich/issues/4038
     # and https://github.com/pmodels/mpich/pull/3540
-    @staticmethod
-    def _hwloc_patch_sha256():
-        return 'eb982de3366d48cbc55eb5e0df43373a45d9f51df208abf0835a72dc6c0b4774'
     patch('https://github.com/pmodels/mpich/commit/8a851b317ee57366cd15f4f28842063d8eff4483.patch',
-          sha256=_hwloc_patch_sha256(),
+          sha256='eb982de3366d48cbc55eb5e0df43373a45d9f51df208abf0835a72dc6c0b4774',
           when='@3.3 +hwloc')
 
     # fix MPI_Barrier segmentation fault
@@ -182,8 +179,10 @@ spack package at this time.''',
         """Not needed usually, configure should be already there"""
         # If configure exists nothing needs to be done
         
+        hwloc_patch_sha = \
+            'eb982de3366d48cbc55eb5e0df43373a45d9f51df208abf0835a72dc6c0b4774'
         if (os.path.exists(self.configure_abs_path) and
-            ('patches=' + _hwloc_patch_sha256()) not in spec):
+            ('patches=' + hwloc_patch_sha256) not in spec):
             return
         # Else bootstrap with autotools
         bash = which('bash')

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -178,9 +178,8 @@ spack package at this time.''',
     def autoreconf(self, spec, prefix):
         """Not needed usually, configure should be already there"""
         # If configure exists nothing needs to be done
-        
         if (os.path.exists(self.configure_abs_path) and
-            not spec.satisfies('@3.3 +hwloc'):
+            not spec.satisfies('@3.3 +hwloc')):
             return
         # Else bootstrap with autotools
         bash = which('bash')

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -31,6 +31,7 @@ class Mpich(AutotoolsPackage):
     version('3.1',   sha256='fcf96dbddb504a64d33833dc455be3dda1e71c7b3df411dfcf9df066d7c32c39')
     version('3.0.4', sha256='cf638c85660300af48b6f776e5ecd35b5378d5905ec5d34c3da7a27da0acf0b3')
 
+    variant('hwloc', default=True,  description='Use external hwloc package')
     variant('hydra', default=True,  description='Build the hydra process manager')
     variant('romio', default=True,  description='Enable ROMIO MPI I/O implementation')
     variant('verbs', default=False, description='Build support for OpenFabrics verbs.')
@@ -72,6 +73,13 @@ spack package at this time.''',
         'mpicc', 'mpicxx', 'mpif77', 'mpif90', 'mpifort', relative_root='bin'
     )
 
+    # Fix using an external hwloc
+    # See https://github.com/pmodels/mpich/issues/4038
+    # and https://github.com/pmodels/mpich/pull/3540
+    patch('https://github.com/pmodels/mpich/commit/86ee1097d4507154cd18f8d8f5fcc0c53f106e11.patch',
+          sha256='27a339d9a879440cc37e1a89680a289d2c06797953fa226045b32d9247b8a1ea',
+          when='+hwloc')
+
     # fix MPI_Barrier segmentation fault
     # see https://lists.mpich.org/pipermail/discuss/2016-May/004764.html
     # and https://lists.mpich.org/pipermail/discuss/2016-June/004768.html
@@ -88,6 +96,8 @@ spack package at this time.''',
 
     depends_on('findutils', type='build')
     depends_on('pkgconfig', type='build')
+
+    depends_on('hwloc @1.0.0:', when='+hwloc')
 
     depends_on('libfabric', when='netmod=ofi')
     # The ch3 ofi netmod results in crashes with libfabric 1.7
@@ -109,6 +119,12 @@ spack package at this time.''',
     depends_on('libtool@2.4.4:', when='@develop', type=("build"))
     depends_on("m4", when="@develop", type=("build")),
     depends_on("autoconf@2.67:", when='@develop', type=("build"))
+
+    # building with "+hwloc' also requires regenerating autotools files
+    depends_on('automake@1.15:', when='+hwloc', type=("build"))
+    depends_on('libtool@2.4.4:', when='+hwloc', type=("build"))
+    depends_on("m4", when="+hwloc", type=("build")),
+    depends_on("autoconf@2.67:", when='+hwloc', type=("build"))
 
     conflicts('device=ch4', when='@:3.2')
     conflicts('netmod=ofi', when='@:3.1.4')
@@ -162,7 +178,7 @@ spack package at this time.''',
     def autoreconf(self, spec, prefix):
         """Not needed usually, configure should be already there"""
         # If configure exists nothing needs to be done
-        if os.path.exists(self.configure_abs_path):
+        if os.path.exists(self.configure_abs_path) and '+hwloc' not in spec:
             return
         # Else bootstrap with autotools
         bash = which('bash')
@@ -182,6 +198,8 @@ spack package at this time.''',
         spec = self.spec
         config_args = [
             '--enable-shared',
+            '--with-hwloc-prefix={0}'.format(
+                spec['hwloc'].prefix if '+hwloc' else 'embedded'),
             '--with-pm={0}'.format('hydra' if '+hydra' in spec else 'no'),
             '--{0}-romio'.format('enable' if '+romio' in spec else 'disable'),
             '--{0}-ibverbs'.format('with' if '+verbs' in spec else 'without'),


### PR DESCRIPTION
This is in principle supported already, but requires a patch to avoid build errors.

Closes https://github.com/spack/spack/issues/15302.