### PR TITLE
munge: new version, local state path, misc

### DIFF
--- a/var/spack/repos/builtin/packages/munge/package.py
+++ b/var/spack/repos/builtin/packages/munge/package.py
@@ -10,14 +10,28 @@ import os
 class Munge(AutotoolsPackage):
     """ MUNGE Uid 'N' Gid Emporium """
     homepage = "https://code.google.com/p/munge/"
-    url      = "https://github.com/dun/munge/releases/download/munge-0.5.13/munge-0.5.13.tar.xz"
+    url      = "https://github.com/dun/munge/releases/download/munge-0.5.14/munge-0.5.14.tar.xz"
+    maintainers = ['ChristianTackeGSI']
+
+    version('0.5.14', sha256='6606a218f18090fa1f702e3f6fb608073eb6aafed534cf7dd81b67b2e0d30640')
     version('0.5.13', sha256='99753dfd06a4f063c36f3fb0eb1964f394feb649937d94c4734d85b7964144da')
     version('0.5.12', sha256='e972e3c3e947995a99e023f5758047db16cfe2f0c2c9ca76399dc1511fa71be8')
     version('0.5.11', sha256='8e075614f81cb0a6df21a0aafdc825498611a04429d0876f074fc828739351a5',
             url='https://github.com/dun/munge/releases/download/munge-0.5.11/munge-0.5.11.tar.bz2')
 
+    variant('localstatedir', default='PREFIX/var', values=any,
+            description='Set local state path (possibly to /var)')
+
     depends_on('openssl')
     depends_on('libgcrypt')
+    depends_on('bzip2')
+
+    def configure_args(self):
+        args = []
+        localstatedir = self.spec.variants['localstatedir'].value
+        if localstatedir != 'PREFIX/var':
+            args.append('--localstatedir={0}'.format(localstatedir))
+        return args
 
     def install(self, spec, prefix):
         os.makedirs(os.path.join(prefix, "lib/systemd/system"))


### PR DESCRIPTION
* Add version 0.5.14
* Add variant to allow setting the localstatedir: See below
* Add bzip2 dependency
* Add myself to maintainers (I just think, I can care for this package)

About localstatedir:

munge has a server and a client.
They communicate via unix domain sockets.
This socket is in PREFIX/var.
This package provides the client, the server, and development part (headers, libraries).

Let's assume one has the server part installed as a system package.  This generally is a good idea, so that the server gets started during boot. This means, that the socket is in the system's `/var`.

If one now wants to use the client part (library!) via spack, one has a problem: spack's munge looks in SPACK-PACKAGE-PREFIX/var for the socket.

There needs to be a way to let the spack installed package use the system's socket.

So add a variant to override the path during build: `localstatedir=/var`.