### PR TITLE
intel-xed does not support python>3.7

### DIFF
--- a/var/spack/repos/builtin/packages/intel-xed/package.py
+++ b/var/spack/repos/builtin/packages/intel-xed/package.py
@@ -42,7 +42,8 @@ class IntelXed(Package):
 
     variant('debug', default=False, description='Enable debug symbols')
 
-    depends_on('python@2.7:', type='build')
+    # python module 'platform.linux_distribution' was removed in python 3.8
+    depends_on('python@2.7:3.7', type='build')
 
     conflicts('target=ppc64:', msg='intel-xed only runs on x86')
     conflicts('target=ppc64le:', msg='intel-xed only runs on x86')


### PR DESCRIPTION
Fix intel-xed build error:
```
'./mfile.py' '--clean'
module 'platform' has no attribute 'linux_distribution'
```
`platform.linux_distribution` was deprecated in python 3.5 and removed in 3.8