### PR TITLE
Pad binary test replacement with os.sep instead of b\0

### DIFF
--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -412,7 +412,8 @@ def replace_prefix_bin(path_name, old_dir, new_dir):
         if padding < 0:
             return data
         return match.group().replace(old_dir.encode('utf-8'),
-                                     new_dir.encode('utf-8')) + os.sep * padding
+                                     new_dir.encode('utf-8') +
+                                     os.sep.encode('utf-8') * padding)
 
     with open(path_name, 'rb+') as f:
         data = f.read()

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -413,7 +413,7 @@ def replace_prefix_bin(path_name, old_dir, new_dir):
             return data
         return match.group().replace(old_dir.encode('utf-8'),
                                      new_dir.encode('utf-8') +
-                                     os.sep.encode('utf-8') * padding)
+                                     b' ' * padding)
 
     with open(path_name, 'rb+') as f:
         data = f.read()

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -412,7 +412,7 @@ def replace_prefix_bin(path_name, old_dir, new_dir):
         if padding < 0:
             return data
         return match.group().replace(old_dir.encode('utf-8'),
-                                     new_dir.encode('utf-8')) + b'\0' * padding
+                                     new_dir.encode('utf-8')) + os.sep * padding
 
     with open(path_name, 'rb+') as f:
         data = f.read()


### PR DESCRIPTION
When replacing text in binary files the difference in the old path and the new path is padded with nulls. This leads to extraneous nulls in perl @INC path as shown in the attached log. The suggested solution of padding with '/' or os.sep did not work. Padding with spaces might work.

[spack-build-out.txt](https://github.com/spack/spack/files/4283568/spack-build-out.txt)
