### PR TITLE
Ensure overrides are removed even when an exception is raised.

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -590,10 +590,12 @@ def override(path_or_scope, value=None):
         config.push_scope(overrides)
         config.set(path_or_scope, value, scope=scope_name)
 
-    yield config
+    try:
+        yield config
 
-    scope = config.remove_scope(overrides.name)
-    assert scope is overrides
+    finally:
+        scope = config.remove_scope(overrides.name)
+        assert scope is overrides
 
 
 #: configuration scopes added on the command line


### PR DESCRIPTION
This will ensure that the failure of a test using `config.override()` will not leave the configuration polluted for subsequent tests.