### PR TITLE
unifyfs: add patch to fix #15292

### DIFF
--- a/var/spack/repos/builtin/packages/unifyfs/auto-mount.patch
+++ b/var/spack/repos/builtin/packages/unifyfs/auto-mount.patch
@@ -1,0 +1,25 @@
+diff --git a/client/src/pmpi_wrappers.c b/client/src/pmpi_wrappers.c
+index ac86d39..38755f5 100644
+--- a/client/src/pmpi_wrappers.c
++++ b/client/src/pmpi_wrappers.c
+@@ -14,7 +14,6 @@
+ 
+ #include "pmpi_wrappers.h"
+ #include "unifyfs.h"
+-#include <mpi.h>
+ #include <stdio.h>
+ 
+ int unifyfs_mpi_init(int* argc, char*** argv)
+diff --git a/client/src/pmpi_wrappers.h b/client/src/pmpi_wrappers.h
+index b90057c..995e44b 100644
+--- a/client/src/pmpi_wrappers.h
++++ b/client/src/pmpi_wrappers.h
+@@ -15,6 +15,8 @@
+ #ifndef UNIFYFS_PMPI_WRAPPERS_H
+ #define UNIFYFS_PMPI_WRAPPERS_H
+ 
++#include <mpi.h>
++
+ /* MPI_Init PMPI wrapper */
+ int unifyfs_mpi_init(int* argc, char*** argv);
+ int MPI_Init(int* argc, char*** argv);

--- a/var/spack/repos/builtin/packages/unifyfs/package.py
+++ b/var/spack/repos/builtin/packages/unifyfs/package.py
@@ -28,7 +28,6 @@ class Unifyfs(AutotoolsPackage):
     variant('pmi', default='False', description='Enable PMI2 build options')
     variant('pmix', default='False', description='Enable PMIx build options')
 
-    depends_on('openssl')
     depends_on('autoconf',  type='build')
     depends_on('automake',  type='build')
     depends_on('libtool',   type='build')
@@ -44,6 +43,7 @@ class Unifyfs(AutotoolsPackage):
     depends_on('margo')
     depends_on('mercury+bmi+sm')
     depends_on('mpi')
+    depends_on('openssl')
 
     # Optional dependencies
     depends_on('hdf5', when='+hdf5')
@@ -53,6 +53,10 @@ class Unifyfs(AutotoolsPackage):
     # Known compatibility issues with ifort and xlf. Fixes coming.
     conflicts('%intel', when='+fortran')
     conflicts('%xl', when='+fortran')
+
+    # Fix broken --enable-mpi-mount config option for version 0.9.0
+    # See https://github.com/LLNL/UnifyFS/issues/467
+    patch('auto-mount.patch', when='@0.9.0')
 
     # Parallel disabled to prevent tests from being run out-of-order when
     # installed with the --test={root, all} option.


### PR DESCRIPTION
UnifyFS had a bug with the `--enable-mpi-mount` config option, which corresponds to the `auto-mount` variant. This bug was fixed in the UnifyFS dev branch, however remains broken for the 0.9.0 version.

This adds a patch to the `unifyfs` package to fix the `auto-mount` variant when installing with version 0.9.0.

**Update:** the following paragraph is no longer valid.

This also removes the `openssl` dependency as `unifyfs` does not directly depend on it. This was said to be a non-explicit dependency in #15258, but I have been unable to duplicate this. However, if it is needed, it is likely a non-explicit dependency of one of unifyfs's dependencies and should be added there.

Fixes: #15292