### PR TITLE
libunwind: remove version 2018.10.12, add stable branch

### DIFF
--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -64,7 +64,7 @@ class Caliper(CMakePackage):
     depends_on('libpfm4@4.8:4.99', when='+libpfm')
 
     depends_on('mpi', when='+mpi')
-    depends_on('unwind@2018.10.12,1.2:1.99', when='+callpath')
+    depends_on('unwind@1.2:1.99', when='+callpath')
 
     depends_on('sosflow@spack', when='@1.0:1.99+sosflow')
 

--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -69,7 +69,7 @@ class Hpctoolkit(AutotoolsPackage):
     depends_on('libdwarf')
     depends_on('libmonitor+hpctoolkit')
     depends_on('libmonitor+bgq', when='+bgq')
-    depends_on('libunwind@1.4: +xz')
+    depends_on('libunwind@1.4:,stable +xz')
     depends_on('mbedtls+pic')
     depends_on('xerces-c transcoder=iconv')
     depends_on('xz', type='link')

--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -69,7 +69,7 @@ class Hpctoolkit(AutotoolsPackage):
     depends_on('libdwarf')
     depends_on('libmonitor+hpctoolkit')
     depends_on('libmonitor+bgq', when='+bgq')
-    depends_on('libunwind@1.4:,stable +xz')
+    depends_on('libunwind@1.4: +xz')
     depends_on('mbedtls+pic')
     depends_on('xerces-c transcoder=iconv')
     depends_on('xz', type='link')

--- a/var/spack/repos/builtin/packages/libunwind/package.py
+++ b/var/spack/repos/builtin/packages/libunwind/package.py
@@ -15,8 +15,8 @@ class Libunwind(AutotoolsPackage):
     git      = "https://github.com/libunwind/libunwind"
     maintainers = ['mwkrentel']
 
-    version('develop', branch='master')
-    version('stable',  branch='v1.4-stable')
+    version('master', branch='master')
+    version('1.4-head', branch='v1.4-stable')
     version('1.4-rc1', sha256='1928459139f048f9b4aca4bb5010540cb7718d44220835a2980b85429007fa9f')
     version('1.3.1', sha256='43997a3939b6ccdf2f669b50fdb8a4d3205374728c2923ddc2354c65260214f8', preferred=True)
     version('1.2.1', sha256='3f3ecb90e28cbe53fba7a4a27ccce7aad188d3210bb1964a923a731a27a75acb')
@@ -26,15 +26,15 @@ class Libunwind(AutotoolsPackage):
             description='Support xz (lzma) compressed symbol tables.')
 
     variant('zlib', default=False,
-            description='Support zlib compressed symbol tables (develop '
+            description='Support zlib compressed symbol tables (master '
             'branch only).')
 
     # The libunwind releases contain the autotools generated files,
     # but the git repo snapshots do not.
-    depends_on('autoconf', type='build', when='@develop,stable')
-    depends_on('automake', type='build', when='@develop,stable')
-    depends_on('libtool',  type='build', when='@develop,stable')
-    depends_on('m4',       type='build', when='@develop,stable')
+    depends_on('autoconf', type='build', when='@master,1.4-head')
+    depends_on('automake', type='build', when='@master,1.4-head')
+    depends_on('libtool',  type='build', when='@master,1.4-head')
+    depends_on('m4',       type='build', when='@master,1.4-head')
 
     depends_on('xz', type='link', when='+xz')
     depends_on('zlib', type='link', when='+zlib')
@@ -56,7 +56,7 @@ class Libunwind(AutotoolsPackage):
             args.append('--disable-minidebuginfo')
 
         # zlib support is only in the master branch (for now).
-        if spec.satisfies('@develop'):
+        if spec.satisfies('@master'):
             if '+zlib' in spec:
                 args.append('--enable-zlibdebuginfo')
             else:

--- a/var/spack/repos/builtin/packages/libunwind/package.py
+++ b/var/spack/repos/builtin/packages/libunwind/package.py
@@ -26,7 +26,8 @@ class Libunwind(AutotoolsPackage):
             description='Support xz (lzma) compressed symbol tables.')
 
     variant('zlib', default=False,
-            description='Support zlib compressed symbol tables (develop branch only).')
+            description='Support zlib compressed symbol tables (develop '
+            'branch only).')
 
     # The libunwind releases contain the autotools generated files,
     # but the git repo snapshots do not.

--- a/var/spack/repos/builtin/packages/libunwind/package.py
+++ b/var/spack/repos/builtin/packages/libunwind/package.py
@@ -13,9 +13,10 @@ class Libunwind(AutotoolsPackage):
     homepage = "http://www.nongnu.org/libunwind/"
     url      = "http://download.savannah.gnu.org/releases/libunwind/libunwind-1.1.tar.gz"
     git      = "https://github.com/libunwind/libunwind"
+    maintainers = ['mwkrentel']
 
     version('develop', branch='master')
-    version('2018.10.12', commit='f551e16213c52169af8bda554e4051b756a169cc')
+    version('stable',  branch='v1.4-stable')
     version('1.4-rc1', sha256='1928459139f048f9b4aca4bb5010540cb7718d44220835a2980b85429007fa9f')
     version('1.3.1', sha256='43997a3939b6ccdf2f669b50fdb8a4d3205374728c2923ddc2354c65260214f8', preferred=True)
     version('1.2.1', sha256='3f3ecb90e28cbe53fba7a4a27ccce7aad188d3210bb1964a923a731a27a75acb')
@@ -24,14 +25,18 @@ class Libunwind(AutotoolsPackage):
     variant('xz', default=False,
             description='Support xz (lzma) compressed symbol tables.')
 
+    variant('zlib', default=False,
+            description='Support zlib compressed symbol tables (develop branch only).')
+
     # The libunwind releases contain the autotools generated files,
     # but the git repo snapshots do not.
-    depends_on('autoconf', type='build', when='@2018:')
-    depends_on('automake', type='build', when='@2018:')
-    depends_on('libtool',  type='build', when='@2018:')
-    depends_on('m4',       type='build', when='@2018:')
+    depends_on('autoconf', type='build', when='@develop,stable')
+    depends_on('automake', type='build', when='@develop,stable')
+    depends_on('libtool',  type='build', when='@develop,stable')
+    depends_on('m4',       type='build', when='@develop,stable')
 
     depends_on('xz', type='link', when='+xz')
+    depends_on('zlib', type='link', when='+zlib')
 
     conflicts('platform=darwin',
               msg='Non-GNU libunwind needs ELF libraries Darwin does not have')
@@ -48,5 +53,12 @@ class Libunwind(AutotoolsPackage):
             args.append('--enable-minidebuginfo')
         else:
             args.append('--disable-minidebuginfo')
+
+        # zlib support is only in the master branch (for now).
+        if spec.satisfies('@develop'):
+            if '+zlib' in spec:
+                args.append('--enable-zlibdebuginfo')
+            else:
+                args.append('--disable-zlibdebuginfo')
 
         return args


### PR DESCRIPTION
Finish cleaning up the libunwind version numbers.  The 2018.10.12
snapshot number didn't fit well with spack's ordering (my bad), and
1.4-rc1 is a near identical replacement.

Add a version for the 1.4-stable branch.

Add a variant for zlib compressed symbol tables (develop branch only).

Adjust packages caliper and hpctoolkit to adapt to the changes.

Add myself as maintainer.

----------

I grep'ed the package.py files and only caliper and hpctoolkit
mentioned 2018.10.12, so no other package should be affected.

@daboehme This is the (tiny) change to the caliper recipe that I told
you about last week.

For libunwind, 'stable' is at the low end of the spack ordering,
although based on the git repo, it should go 1.4 < stable < develop.

This is mildly inconvenient in some places.  For example, in
hpctoolkit, I have to say `depends_on('libunwind@1.4:,stable')`
instead of the more natural `depends_on('libunwind@1.4:')`.

Would it make sense to add 'stable' as a special, high-order version
name like develop and master?

Or, could we add support for a per-package way of adjusting the
ordering?
