### PR TITLE
suite-sparse: fix installation for v5.X

### DIFF
--- a/var/spack/repos/builtin/packages/suite-sparse/package.py
+++ b/var/spack/repos/builtin/packages/suite-sparse/package.py
@@ -34,6 +34,7 @@ class SuiteSparse(Package):
 
     depends_on('blas')
     depends_on('lapack')
+    depends_on('m4', type='build', when='@5.0.0:')
     depends_on('cmake', when='@5.2.0:', type='build')
 
     depends_on('metis@5.1.0', when='@4.5.1:')
@@ -64,7 +65,6 @@ class SuiteSparse(Package):
         pic_flag  = self.compiler.pic_flag if '+pic' in spec else ''
 
         make_args = [
-            'INSTALL=%s' % prefix,
             # By default, the Makefile uses the Intel compilers if
             # they are found. The AUTOCC flag disables this behavior,
             # forcing it to use Spack's compiler wrappers.
@@ -134,6 +134,7 @@ class SuiteSparse(Package):
         if '@5.4.0:' in self.spec:
             make('default', *make_args)
 
+        make_args.append('INSTALL=%s' % prefix)
         make('install', *make_args)
 
     @property


### PR DESCRIPTION
fixes #15184
fixes #14654
fixes #10313

- [x] GraphBLAS depends on m4 according to CMake error message
- [x] Do not use INSTALL= when compiling the library as advised [here](https://github.com/DrTimothyAldenDavis/SuiteSparse)