### PR TITLE
Use replace_prefix_text on binaries instead so null padding is not done.

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -558,7 +558,7 @@ def relocate_package(workdir, spec, allow_root):
                           (new_path, old_path))
             else:
                 for path_name in files_to_relocate:
-                    relocate.replace_prefix_bin(path_name, old_path, new_path)
+                    relocate.replace_prefix_text(path_name, old_path, new_path)
     else:
         path_names = set()
         for filename in buildinfo['relocate_binaries']:

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -124,8 +124,8 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         # [1] https://metacpan.org/pod/ExtUtils::MakeMaker#INSTALL_BASE
         # [2] via the activate method in the PackageBase class
         # [3] https://metacpan.org/pod/distribution/perl/INSTALL#APPLLIB_EXP
-        config_args.append('-Accflags=-DAPPLLIB_EXP=\\"' +
-                           self.prefix.lib.perl5 + '\\"')
+        config_args.append('-Accflags=-DAPPLLIB_EXP=\\"%s\\"' %
+                           self.prefix.lib.perl5)
 
         # Discussion of -fPIC for Intel at:
         # https://github.com/spack/spack/pull/3081 and


### PR DESCRIPTION
As identified in https://github.com/spack/spack/pull/15311
Using null padding when replacing strings in binaries  leads to an extraneous null byte on the INC path reported by perl which causes autoconf to fail. 

```
==> 34041: margo: Executing phase: 'autoreconf'
==> [2020-03-03-17:34:52.148978, 34047] '/bin/sh' './prepare.sh'
Regenerating build files...
Invalid \0 character in @INC entry for require: /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/perl-5.30.1-gym4yxljhkkp6b4vuovipvlr34h3rlrq/lib/perl5\0 at /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/share/autoconf/Autom4te/Channels.pm line 70.
Invalid \0 character in @INC entry for require: /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/perl-5.30.1-gym4yxljhkkp6b4vuovipvlr34h3rlrq/lib/site_perl/5.30.1/ppc64le-linux-thread-multi\0 at /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/share/autoconf/Autom4te/Channels.pm line 70.
Invalid \0 character in @INC entry for require: /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/perl-5.30.1-gym4yxljhkkp6b4vuovipvlr34h3rlrq/lib/site_perl/5.30.1\0 at /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/share/autoconf/Autom4te/Channels.pm line 70.
Invalid \0 character in @INC entry for require: /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/perl-5.30.1-gym4yxljhkkp6b4vuovipvlr34h3rlrq/lib/5.30.1/ppc64le-linux-thread-multi\0 at /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/share/autoconf/Autom4te/Channels.pm line 70.
Invalid \0 character in @INC entry for require: /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/perl-5.30.1-gym4yxljhkkp6b4vuovipvlr34h3rlrq/lib/5.30.1\0 at /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/share/autoconf/Autom4te/Channels.pm line 70.
Can't locate strict.pm in @INC (you may need to install the strict module) (@INC contains: /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/share/autoconf /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/perl-5.30.1-gym4yxljhkkp6b4vuovipvlr34h3rlrq/lib/perl5                                                /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/perl-5.30.1-gym4yxljhkkp6b4vuovipvlr34h3rlrq/lib/site_perl/5.30.1/ppc64le-linux-thread-multi                                                /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/perl-5.30.1-gym4yxljhkkp6b4vuovipvlr34h3rlrq/lib/site_perl/5.30.1                                                /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/perl-5.30.1-gym4yxljhkkp6b4vuovipvlr34h3rlrq/lib/5.30.1/ppc64le-linux-thread-multi                                                /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/perl-5.30.1-gym4yxljhkkp6b4vuovipvlr34h3rlrq/lib/5.30.1                                               ) at /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/share/autoconf/Autom4te/Channels.pm line 70.
BEGIN failed--compilation aborted at /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/share/autoconf/Autom4te/Channels.pm line 70.
Compilation failed in require at /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/share/autoconf/Autom4te/ChannelDefs.pm line 19.
BEGIN failed--compilation aborted at /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/share/autoconf/Autom4te/ChannelDefs.pm line 19.
Compilation failed in require at /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/bin/autoreconf line 39.
BEGIN failed--compilation aborted at /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/bin/autoreconf line 39.
```

Instead of padding the path string with null padding just replace the string using replace_prefix_text.

Using replace_prefix_bin results in the string  below in
 ./lib/5.30.0/x86_64-linux-thread-multi/CORE/libperl.so
```
^@^@^@Module name required with -%c option^@^@^@^@Invalid module name %.*s with -%c option: contains single ':'^@^@^@"-%c" is on the #! line, it must also be used on the command line%s^@^@^@^@^@Can't emulate -%.1s on #! line^@^@Unrecognized switch: -%.1s  (-h will show valid options)^@^@^@^@^@^@^@^@HASH_FUNCTION = %s HASH_SEED = 0x^@^@^@^@^@^@^@use Config; Config::config_vars(qw%c%s%c)^@^@^@^@^@^@^@Unrecognized switch: -%s  (-h will show valid options)^@^@Illegal switch in PERL5OPT: -%c^@/build/test/spack/opt/spack/linux-rhel7-x86_64/gcc-7.3.0/perl-5.30.0-4phcley553xeyj6mab7oa3ak6szhiea5/lib/perl5^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@/build/test/spack/opt/spack/linux-rhel7-x86_64/gcc-7.3.0/perl-5.30.0-4phcley553xeyj6mab7oa3ak6szhiea5/lib/site_perl/5.30.0/x86_64-linux-thread-multi^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@/build/test/spack/opt/spack/linux-rhel7-x86_64/gcc-7.3.0/perl-5.30.0-4phcley553xeyj6mab7oa3ak6szhiea5/lib/site_perl/5.30.0^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@/build/test/spack/opt/spack/linux-rhel7-x86_64/gcc-7.3.0/perl-5.30.0-4phcley553xeyj6mab7oa3ak6szhiea5/lib/5.30.0/x86_64-linux-thread-multi^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@/build/test/spack/opt/spack/linux-rhel7-x86_64/gcc-7.3.0/perl-5.30.0-4phcley553xeyj6mab7oa3ak6szhiea5/lib/5.30.0^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@Wrong syntax (suid) fd script name "%s"
```

Using replace_prefix_text results in the string below in
./lib/5.30.0/x86_64-linux-thread-multi/CORE/libperl.so
```
^@^@^@Module name required with -%c option^@^@^@^@Invalid module name %.*s with -%c option: contains single ':'^@^@^@"-%c" is on the #! line, it must also be used on the command line%s^@^@^@^@^@Can't emulate -%.1s on #! line^@^@Unrecognized switch: -%.1s  (-h will show valid options)^@^@^@^@^@^@^@^@HASH_FUNCTION = %s HASH_SEED = 0x^@^@^@^@^@^@^@use Config; Config::config_vars(qw%c%s%c)^@^@^@^@^@^@^@Unrecognized switch: -%s  (-h will show valid options)^@^@Illegal switch in PERL5OPT: -%c^@/build/test/spack/opt/spack/linux-rhel7-x86_64/gcc-7.3.0/perl-5.30.0-4phcley553xeyj6mab7oa3ak6szhiea5/lib/perl5^@^@^@/build/test/spack/opt/spack/linux-rhel7-x86_64/gcc-7.3.0/perl-5.30.0-4phcley553xeyj6mab7oa3ak6szhiea5/lib/site_perl/5.30.0/x86_64-linux-thread-multi^@^@^@^@^@^@/build/test/spack/opt/spack/linux-rhel7-x86_64/gcc-7.3.0/perl-5.30.0-4phcley553xeyj6mab7oa3ak6szhiea5/lib/site_perl/5.30.0^@^@^@^@^@^@^@^@/build/test/spack/opt/spack/linux-rhel7-x86_64/gcc-7.3.0/perl-5.30.0-4phcley553xeyj6mab7oa3ak6szhiea5/lib/5.30.0/x86_64-linux-thread-multi^@^@^@^@^@^@^@^@/build/test/spack/opt/spack/linux-rhel7-x86_64/gcc-7.3.0/perl-5.30.0-4phcley553xeyj6mab7oa3ak6szhiea5/lib/5.30.0^@^@Wrong syntax (suid) fd script name "%s"
```