### PR TITLE
Output lib.perl5 as a string to avoid null byte?

### DIFF
--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -124,8 +124,8 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         # [1] https://metacpan.org/pod/ExtUtils::MakeMaker#INSTALL_BASE
         # [2] via the activate method in the PackageBase class
         # [3] https://metacpan.org/pod/distribution/perl/INSTALL#APPLLIB_EXP
-        config_args.append('-Accflags=-DAPPLLIB_EXP=\\"' +
-                           self.prefix.lib.perl5 + '\\"')
+        config_args.append('-Accflags=-DAPPLLIB_EXP=\\"%s\\"' %
+                           self.prefix.lib.perl5)
 
         # Discussion of -fPIC for Intel at:
         # https://github.com/spack/spack/pull/3081 and


### PR DESCRIPTION
As identified in https://github.com/spack/spack/pull/15311 
an extraneous null byte on the INC path reported by perl causes autoconf to fail. 
I suspect the config argument passed in has a null byte because it was not converted to a string before adding it to the config arg.  This fix ensures the path is represented as a string.

```
==> 34041: margo: Executing phase: 'autoreconf'
==> [2020-03-03-17:34:52.148978, 34047] '/bin/sh' './prepare.sh'
Regenerating build files...
Invalid \0 character in @INC entry for require: /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/perl-5.30.1-gym4yxljhkkp6b4vuovipvlr34h3rlrq/lib/perl5\0 at /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/share/autoconf/Autom4te/Channels.pm line 70.
Invalid \0 character in @INC entry for require: /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/perl-5.30.1-gym4yxljhkkp6b4vuovipvlr34h3rlrq/lib/site_perl/5.30.1/ppc64le-linux-thread-multi\0 at /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/share/autoconf/Autom4te/Channels.pm line 70.
Invalid \0 character in @INC entry for require: /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/perl-5.30.1-gym4yxljhkkp6b4vuovipvlr34h3rlrq/lib/site_perl/5.30.1\0 at /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/share/autoconf/Autom4te/Channels.pm line 70.
Invalid \0 character in @INC entry for require: /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/perl-5.30.1-gym4yxljhkkp6b4vuovipvlr34h3rlrq/lib/5.30.1/ppc64le-linux-thread-multi\0 at /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/share/autoconf/Autom4te/Channels.pm line 70.
Invalid \0 character in @INC entry for require: /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/perl-5.30.1-gym4yxljhkkp6b4vuovipvlr34h3rlrq/lib/5.30.1\0 at /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/share/autoconf/Autom4te/Channels.pm line 70.
Can't locate strict.pm in @INC (you may need to install the strict module) (@INC contains: /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/share/autoconf /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/perl-5.30.1-gym4yxljhkkp6b4vuovipvlr34h3rlrq/lib/perl5����������������������������������������������� /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/perl-5.30.1-gym4yxljhkkp6b4vuovipvlr34h3rlrq/lib/site_perl/5.30.1/ppc64le-linux-thread-multi����������������������������������������������� /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/perl-5.30.1-gym4yxljhkkp6b4vuovipvlr34h3rlrq/lib/site_perl/5.30.1����������������������������������������������� /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/perl-5.30.1-gym4yxljhkkp6b4vuovipvlr34h3rlrq/lib/5.30.1/ppc64le-linux-thread-multi����������������������������������������������� /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/perl-5.30.1-gym4yxljhkkp6b4vuovipvlr34h3rlrq/lib/5.30.1�����������������������������������������������) at /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/share/autoconf/Autom4te/Channels.pm line 70.
BEGIN failed--compilation aborted at /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/share/autoconf/Autom4te/Channels.pm line 70.
Compilation failed in require at /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/share/autoconf/Autom4te/ChannelDefs.pm line 19.
BEGIN failed--compilation aborted at /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/share/autoconf/Autom4te/ChannelDefs.pm line 19.
Compilation failed in require at /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/bin/autoreconf line 39.
BEGIN failed--compilation aborted at /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/bin/autoreconf line 39.
```
