### PR TITLE
use os.sep instead of null byte to pad replacement paths in binaries

### DIFF
--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -412,7 +412,8 @@ def replace_prefix_bin(path_name, old_dir, new_dir):
         if padding < 0:
             return data
         return match.group().replace(old_dir.encode('utf-8'),
-                                     new_dir.encode('utf-8')) + b'\0' * padding
+                                     new_dir.encode('utf-8') +
+                                     os.sep.encode('utf-8') * padding)
 
     with open(path_name, 'rb+') as f:
         data = f.read()

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -412,8 +412,8 @@ def replace_prefix_bin(path_name, old_dir, new_dir):
         if padding < 0:
             return data
         return match.group().replace(old_dir.encode('utf-8'),
-                                     new_dir.encode('utf-8') +
-                                     os.sep.encode('utf-8') * padding)
+                                     os.sep.encode('utf-8') * padding +
+                                     new_dir.encode('utf-8'))
 
     with open(path_name, 'rb+') as f:
         data = f.read()


### PR DESCRIPTION
As identified in https://github.com/spack/spack/pull/15311
Using null padding when replacing strings in binaries  leads to an extraneous null byte on the INC path reported by perl which causes autoconf to fail. 

```
==> 34041: margo: Executing phase: 'autoreconf'
==> [2020-03-03-17:34:52.148978, 34047] '/bin/sh' './prepare.sh'
Regenerating build files...
Invalid \0 character in @INC entry for require: /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/perl-5.30.1-gym4yxljhkkp6b4vuovipvlr34h3rlrq/lib/perl5\0 at /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/share/autoconf/Autom4te/Channels.pm line 70.
Invalid \0 character in @INC entry for require: /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/perl-5.30.1-gym4yxljhkkp6b4vuovipvlr34h3rlrq/lib/site_perl/5.30.1/ppc64le-linux-thread-multi\0 at /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/share/autoconf/Autom4te/Channels.pm line 70.
Invalid \0 character in @INC entry for require: /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/perl-5.30.1-gym4yxljhkkp6b4vuovipvlr34h3rlrq/lib/site_perl/5.30.1\0 at /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/share/autoconf/Autom4te/Channels.pm line 70.
Invalid \0 character in @INC entry for require: /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/perl-5.30.1-gym4yxljhkkp6b4vuovipvlr34h3rlrq/lib/5.30.1/ppc64le-linux-thread-multi\0 at /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/share/autoconf/Autom4te/Channels.pm line 70.
Invalid \0 character in @INC entry for require: /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/perl-5.30.1-gym4yxljhkkp6b4vuovipvlr34h3rlrq/lib/5.30.1\0 at /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/share/autoconf/Autom4te/Channels.pm line 70.
Can't locate strict.pm in @INC (you may need to install the strict module) (@INC contains: /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/share/autoconf /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/perl-5.30.1-gym4yxljhkkp6b4vuovipvlr34h3rlrq/lib/perl5����������������������������������������������� /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/perl-5.30.1-gym4yxljhkkp6b4vuovipvlr34h3rlrq/lib/site_perl/5.30.1/ppc64le-linux-thread-multi����������������������������������������������� /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/perl-5.30.1-gym4yxljhkkp6b4vuovipvlr34h3rlrq/lib/site_perl/5.30.1����������������������������������������������� /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/perl-5.30.1-gym4yxljhkkp6b4vuovipvlr34h3rlrq/lib/5.30.1/ppc64le-linux-thread-multi����������������������������������������������� /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/perl-5.30.1-gym4yxljhkkp6b4vuovipvlr34h3rlrq/lib/5.30.1�����������������������������������������������) at /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/share/autoconf/Autom4te/Channels.pm line 70.
BEGIN failed--compilation aborted at /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/share/autoconf/Autom4te/Channels.pm line 70.
Compilation failed in require at /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/share/autoconf/Autom4te/ChannelDefs.pm line 19.
BEGIN failed--compilation aborted at /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/share/autoconf/Autom4te/ChannelDefs.pm line 19.
Compilation failed in require at /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/bin/autoreconf line 39.
BEGIN failed--compilation aborted at /opt/local/spack/linux-ubuntu18.04-ppc64le/gcc-7.4.0/autoconf-2.69-7krxxvgzuflqega7revu4yiux4p6zxps/bin/autoreconf line 39.
```

Using replace_prefix_bin results in the string  below in
 ./lib/5.30.0/x86_64-linux-thread-multi/CORE/libperl.so
```
^@^@^@Module name required with -%c option^@^@^@^@Invalid module name %.*s with -%c option: contains single ':'^@^@^@"-%c" is on the #! line, it must also be used on the command line%s^@^@^@^@^@Can't emulate -%.1s on #! line^@^@Unrecognized switch: -%.1s  (-h will show valid options)^@^@^@^@^@^@^@^@HASH_FUNCTION = %s HASH_SEED = 0x^@^@^@^@^@^@^@use Config; Config::config_vars(qw%c%s%c)^@^@^@^@^@^@^@Unrecognized switch: -%s  (-h will show valid options)^@^@Illegal switch in PERL5OPT: -%c^@/build/test/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.4.0/perl-5.30.1-4w7z5dgootcyq547qc7na23ljqeu4tst/lib/perl5^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@/build/test/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.4.0/perl-5.30.1-4w7z5dgootcyq547qc7na23ljqeu4tst/lib/site_perl/5.30.1/x86_64-linux-thread-multi^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@/build/test/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.4.0/perl-5.30.1-4w7z5dgootcyq547qc7na23ljqeu4tst/lib/site_perl/5.30.1^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@/build/test/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.4.0/perl-5.30.1-4w7z5dgootcyq547qc7na23ljqeu4tst/lib/5.30.1/x86_64-linux-thread-multi^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@/build/test/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.4.0/perl-5.30.1-4w7z5dgootcyq547qc7na23ljqeu4tst/lib/5.30.1^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@Wrong syntax (suid) fd script name "%s"
```

Instead of padding the path string with null padding use os.sep as padding.

Using the updated replace_prefix_bin results in the string shown below in
 ./lib/5.30.0/x86_64-linux-thread-multi/CORE/libperl.so
```
^@^@^@Module name required with -%c option^@^@^@^@Invalid module name %.*s with -%c option: contains single ':'^@^@^@"-%c" is on the #! line, it must also be used on the command line%s^@^@^@^@^@Can't emulate -%.1s on #! line^@^@Unrecognized switch: -%.1s  (-h will show valid options)^@^@^@^@^@^@^@^@HASH_FUNCTION = %s HASH_SEED = 0x^@^@^@^@^@^@^@use Config; Config::config_vars(qw%c%s%c)^@^@^@^@^@^@^@Unrecognized switch: -%s  (-h will show valid options)^@^@Illegal switch in PERL5OPT: -%c^@//////////////////////////////////////////////////////////build/test/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.4.0/perl-5.30.1-4w7z5dgootcyq547qc7na23ljqeu4tst/lib/perl5^@^@//////////////////////////////////////////////////////////build/test/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.4.0/perl-5.30.1-4w7z5dgootcyq547qc7na23ljqeu4tst/lib/site_perl/5.30.1/x86_64-linux-thread-multi^@^@^@^@^@//////////////////////////////////////////////////////////build/test/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.4.0/perl-5.30.1-4w7z5dgootcyq547qc7na23ljqeu4tst/lib/site_perl/5.30.1^@^@^@^@^@^@^@//////////////////////////////////////////////////////////build/test/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.4.0/perl-5.30.1-4w7z5dgootcyq547qc7na23ljqeu4tst/lib/5.30.1/x86_64-linux-thread-multi^@^@^@^@^@^@^@//////////////////////////////////////////////////////////build/test/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.4.0/perl-5.30.1-4w7z5dgootcyq547qc7na23ljqeu4tst/lib/5.30.1^@Wrong syntax (suid) fd script name "%s"
```