### PR TITLE
bugfix: resolve undefined source_pkg_dir failure

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -407,7 +407,10 @@ def dump_packages(spec, path):
                 source_repo = spack.repo.Repo(source_repo_root)
                 source_pkg_dir = source_repo.dirname_for_package_name(
                     node.name)
-            except spack.repo.RepoError:
+            except spack.repo.RepoError as err:
+                tty.debug('Failed to create source repo for {0}: {1}'
+                          .format(node.name, str(err)))
+                source_pkg_dir = None
                 tty.warn("Warning: Couldn't copy in provenance for {0}"
                          .format(node.name))
 
@@ -419,10 +422,10 @@ def dump_packages(spec, path):
 
         # Get the location of the package in the dest repo.
         dest_pkg_dir = repo.dirname_for_package_name(node.name)
-        if node is not spec:
-            install_tree(source_pkg_dir, dest_pkg_dir)
-        else:
+        if node is spec:
             spack.repo.path.dump_provenance(node, dest_pkg_dir)
+        elif source_pkg_dir:
+            install_tree(source_pkg_dir, dest_pkg_dir)
 
 
 def install_msg(name, pid):

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import py
 import pytest
 
 import llnl.util.tty as tty
@@ -15,6 +16,22 @@ import spack.installer as inst
 import spack.util.lock as lk
 import spack.repo
 import spack.spec
+
+
+def _mock_repo(root, namespace):
+    """Create an empty repository at the specified root
+
+    Args:
+        root (str): path to the mock repository root
+        namespace (str):  mock repo's namespace
+    """
+    repodir = py.path.local(root) if isinstance(root, str) else root
+    repodir.ensure(spack.repo.packages_dir_name, dir=True)
+    yaml = repodir.join('repo.yaml')
+    yaml.write("""
+repo:
+   namespace: {0}
+""".format(namespace))
 
 
 def _noop(*args, **kwargs):
@@ -284,11 +301,47 @@ def test_packages_needed_to_bootstrap_compiler(install_mockery, monkeypatch):
         inst._packages_needed_to_bootstrap_compiler(spec.package)
 
 
-def test_dump_packages_deps(install_mockery, tmpdir):
-    """Test to add coverage to dump_packages."""
+def test_dump_packages_deps(install_mockery, tmpdir, monkeypatch, capsys):
+    """Test to add coverage to dump_packages with dependencies."""
+    orig_bpp = spack.store.layout.build_packages_path
+    orig_dirname = spack.repo.Repo.dirname_for_package_name
+    repo_err_msg = "Mock dirname_for_package_name"
+
+    def bpp_path(spec):
+        # Perform the original function
+        source = orig_bpp(spec)
+        # Mock the required directory structure for the repository
+        _mock_repo(os.path.join(source, spec.namespace), spec.namespace)
+        return source
+
+    def _repoerr(repo, name):
+        if name == 'cmake':
+            raise spack.repo.RepoError(repo_err_msg)
+        else:
+            return orig_dirname(repo, name)
+
+    # First the "happy" path of skipping "installed" dependent package
     spec = spack.spec.Spec('simple-inheritance').concretized()
-    with tmpdir.as_cwd():
-        inst.dump_packages(spec, '.')
+    inst.dump_packages(spec, str(tmpdir))
+
+    # Now mock the creation of the required directory structure to cover
+    # the try-except block
+    monkeypatch.setattr(spack.store.layout, 'build_packages_path', bpp_path)
+
+    # The call to install_tree will raise the exception since not mocking
+    # creation of dependency package files within *install* directories.
+    with pytest.raises(IOError, match=str(tmpdir)):
+        with tmpdir.as_cwd():
+            inst.dump_packages(spec, str(tmpdir))
+
+    # Now try the error path, which requires the mock directory structure
+    # above
+    monkeypatch.setattr(spack.repo.Repo, 'dirname_for_package_name', _repoerr)
+    with pytest.raises(spack.repo.RepoError, match=repo_err_msg):
+        inst.dump_packages(spec, str(tmpdir))
+
+    out = str(capsys.readouterr()[1])
+    assert "Couldn't copy in provenance for cmake" in out
 
 
 @pytest.mark.tld


### PR DESCRIPTION
This PR fixes a bug in and adds a test for `dump_packages`.

Note the changes were pulled from #15237 to highlight the bug fix.