### PR TITLE
bugfix: resolve StopIteration message attribute failure

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1154,7 +1154,7 @@ class PackageInstaller(object):
         except StopIteration as e:
             # A StopIteration exception means that do_install was asked to
             # stop early from clients.
-            tty.msg('{0} {1}'.format(self.pid, e.message))
+            tty.msg('{0} {1}'.format(self.pid, str(e)))
             tty.msg('Package stage directory : {0}'
                     .format(pkg.stage.source_path))
 

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -391,6 +391,27 @@ def test_install_task_use_cache(install_mockery, monkeypatch):
     assert spec.package.name in installer.installed
 
 
+def test_install_task_stop_iter(install_mockery, monkeypatch, capfd):
+    """Test _install_task to cover the StopIteration exception."""
+    mock_err_msg = 'mock stop iteration'
+
+    def _raise(installer, pkg):
+        raise StopIteration(mock_err_msg)
+
+    spec, installer = create_installer('a')
+    task = create_build_task(spec.package)
+
+    monkeypatch.setattr(spack.package.PackageBase, 'unit_test_check', _true)
+    monkeypatch.setattr(inst.PackageInstaller, '_setup_install_dir', _raise)
+
+    installer._install_task(task)
+    out = capfd.readouterr()[0]
+
+    assert mock_err_msg in out
+    assert 'Package stage directory' in out
+    assert spec.package.stage.source_path in out
+
+
 def test_release_lock_write_n_exception(install_mockery, tmpdir, capsys):
     """Test _release_lock for supposed write lock with exception."""
     spec, installer = create_installer('trivial-install-test-package')


### PR DESCRIPTION
Testing the install `StopIteration` exception resulted in an attribute error:

```AttributeError: 'StopIteration' object has no attribute 'message'```

This PR adds a unit test and resolves that error.

Note that this work was originally part of #15237 but was pulled out to highlight that the change resolves a bug in the code.