### PR TITLE
testing:  Correct pytest.raises matches to match

### DIFF
--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -755,7 +755,7 @@ def test_query_spec_with_non_conditional_virtual_dependency(database):
 def test_failed_spec_path_error(database):
     """Ensure spec not concrete check is covered."""
     s = spack.spec.Spec('a')
-    with pytest.raises(ValueError, matches='Concrete spec required'):
+    with pytest.raises(ValueError, match='Concrete spec required'):
         spack.store.db._failed_spec_path(s)
 
 

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -245,7 +245,7 @@ def test_ensure_locked_have(install_mockery, tmpdir):
 def test_package_id(install_mockery):
     """Test to cover package_id functionality."""
     pkg = spack.repo.get('trivial-install-test-package')
-    with pytest.raises(ValueError, matches='spec is not concretized'):
+    with pytest.raises(ValueError, match='spec is not concretized'):
         inst.package_id(pkg)
 
     spec = spack.spec.Spec('trivial-install-test-package')
@@ -280,7 +280,7 @@ def test_packages_needed_to_bootstrap_compiler(install_mockery, monkeypatch):
 
     # Test up to the dependency check
     monkeypatch.setattr(spack.compilers, 'compilers_for_spec', _no_compilers)
-    with pytest.raises(spack.repo.UnknownPackageError, matches='not found'):
+    with pytest.raises(spack.repo.UnknownPackageError, match='not found'):
         inst._packages_needed_to_bootstrap_compiler(spec.package)
 
 
@@ -300,7 +300,7 @@ def test_check_deps_status_errs(install_mockery, monkeypatch):
     orig_fn = spack.database.Database.prefix_failed
     monkeypatch.setattr(spack.database.Database, 'prefix_failed', _true)
 
-    with pytest.raises(inst.InstallError, matches='install failure'):
+    with pytest.raises(inst.InstallError, match='install failure'):
         installer._check_deps_status()
 
     monkeypatch.setattr(spack.database.Database, 'prefix_failed', orig_fn)
@@ -308,7 +308,7 @@ def test_check_deps_status_errs(install_mockery, monkeypatch):
     # Ensure do not acquire the lock
     monkeypatch.setattr(inst.PackageInstaller, '_ensure_locked', _not_locked)
 
-    with pytest.raises(inst.InstallError, matches='write locked by another'):
+    with pytest.raises(inst.InstallError, match='write locked by another'):
         installer._check_deps_status()
 
 
@@ -485,7 +485,7 @@ def test_install_uninstalled_deps(install_mockery, monkeypatch, capsys):
     monkeypatch.setattr(inst.PackageInstaller, '_update_failed', _noop)
 
     msg = 'Cannot proceed with dependent-install'
-    with pytest.raises(spack.installer.InstallError, matches=msg):
+    with pytest.raises(spack.installer.InstallError, match=msg):
         installer.install()
 
     out = str(capsys.readouterr())
@@ -503,7 +503,7 @@ def test_install_failed(install_mockery, monkeypatch, capsys):
     monkeypatch.setattr(inst.PackageInstaller, '_install_task', _noop)
 
     msg = 'Installation of b failed'
-    with pytest.raises(spack.installer.InstallError, matches=msg):
+    with pytest.raises(spack.installer.InstallError, match=msg):
         installer.install()
 
     out = str(capsys.readouterr())
@@ -622,7 +622,7 @@ def test_install_dir_exists(install_mockery, monkeypatch, capfd):
 
     spec, installer = create_installer('b')
 
-    with pytest.raises(dl.InstallDirectoryAlreadyExistsError, matches=err):
+    with pytest.raises(dl.InstallDirectoryAlreadyExistsError, match=err):
         installer.install()
 
     assert 'b' in installer.installed

--- a/lib/spack/spack/test/llnl/util/lock.py
+++ b/lib/spack/spack/test/llnl/util/lock.py
@@ -1272,7 +1272,7 @@ def test_downgrade_write_fails(tmpdir):
         lock = lk.Lock('lockfile')
         lock.acquire_read()
         msg = 'Cannot downgrade lock from write to read on file: lockfile'
-        with pytest.raises(lk.LockDowngradeError, matches=msg):
+        with pytest.raises(lk.LockDowngradeError, match=msg):
             lock.downgrade_write_to_read()
 
 
@@ -1292,5 +1292,5 @@ def test_upgrade_read_fails(tmpdir):
         lock = lk.Lock('lockfile')
         lock.acquire_write()
         msg = 'Cannot upgrade lock from read to write on file: lockfile'
-        with pytest.raises(lk.LockUpgradeError, matches=msg):
+        with pytest.raises(lk.LockUpgradeError, match=msg):
             lock.upgrade_read_to_write()


### PR DESCRIPTION
`pytest.raises` ignores `matches` arguments so this PR changes them to the proper argument, namely `match`.

Note these corrections were part of #15237 but have been separated since they address a separate issue.