### PR TITLE
Recover coverage from subprocesses during unit tests

### DIFF
--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -154,7 +154,7 @@ def test(parser, args, unknown_args):
 
     # The default is to test the core of Spack. If the option `--extension`
     # has been used, then test that extension.
-    pytest_root = spack.paths.test_path
+    pytest_root = spack.paths.spack_root
     if args.extension:
         target = args.extension
         extensions = spack.config.get('config:extensions')

--- a/lib/spack/spack/test/cmd/test.py
+++ b/lib/spack/spack/test/cmd/test.py
@@ -6,6 +6,7 @@
 from spack.main import SpackCommand
 
 spack_test = SpackCommand('test')
+cmd_test_py = 'lib/spack/spack/test/cmd/test.py'
 
 
 def test_list():
@@ -16,13 +17,13 @@ def test_list():
 
 
 def test_list_with_pytest_arg():
-    output = spack_test('--list', 'cmd/test.py')
-    assert output.strip() == "cmd/test.py"
+    output = spack_test('--list', cmd_test_py)
+    assert output.strip() == cmd_test_py
 
 
 def test_list_with_keywords():
     output = spack_test('--list', '-k', 'cmd/test.py')
-    assert output.strip() == "cmd/test.py"
+    assert output.strip() == cmd_test_py
 
 
 def test_list_long(capsys):
@@ -44,7 +45,7 @@ def test_list_long(capsys):
 
 def test_list_long_with_pytest_arg(capsys):
     with capsys.disabled():
-        output = spack_test('--list-long', 'cmd/test.py')
+        output = spack_test('--list-long', cmd_test_py)
     assert "test.py::\n" in output
     assert "test_list" in output
     assert "test_list_with_pytest_arg" in output
@@ -74,7 +75,7 @@ def test_list_names():
 
 
 def test_list_names_with_pytest_arg():
-    output = spack_test('--list-names', 'cmd/test.py')
+    output = spack_test('--list-names', cmd_test_py)
     assert "test.py::test_list\n" in output
     assert "test.py::test_list_with_pytest_arg\n" in output
     assert "test.py::test_list_with_keywords\n" in output

--- a/lib/spack/spack/test/llnl/util/log.py
+++ b/lib/spack/spack/test/llnl/util/log.py
@@ -32,7 +32,8 @@ def test_log_python_output_with_fd_stream(capfd, tmpdir):
         with open('foo.txt') as f:
             assert f.read() == 'logged\n'
 
-        assert capfd.readouterr() == ('', '')
+        # Coverage is cluttering stderr during tests
+        assert capfd.readouterr()[0] == ''
 
 
 def test_log_python_output_and_echo_output(capfd, tmpdir):
@@ -42,7 +43,8 @@ def test_log_python_output_and_echo_output(capfd, tmpdir):
                 print('echo')
             print('logged')
 
-        assert capfd.readouterr() == ('echo\n', '')
+        # Coverage is cluttering stderr during tests
+        assert capfd.readouterr()[0] == 'echo\n'
 
         with open('foo.txt') as f:
             assert f.read() == 'echo\nlogged\n'
@@ -75,7 +77,8 @@ def test_log_subproc_and_echo_output(capfd, tmpdir):
                 echo('echo')
             print('logged')
 
-        assert capfd.readouterr() == ('echo\n', '')
+        # Coverage is cluttering stderr during tests
+        assert capfd.readouterr()[0] == 'echo\n'
 
         with open('foo.txt') as f:
             assert f.read() == 'logged\n'

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 # content of pytest.ini
 [pytest]
 addopts = --durations=20 -ra
-testpaths = .
+testpaths = lib/spack/spack/test
 python_files = *.py
 markers =
   db: tests that require creating a DB

--- a/share/spack/qa/run-unit-tests
+++ b/share/spack/qa/run-unit-tests
@@ -37,16 +37,12 @@ bin/spack -h
 bin/spack help -a
 
 # Profile and print top 20 lines for a simple call to spack spec
-bin/spack -p --lines 20 spec mpileaks%gcc ^elfutils@0.170
+spack -p --lines 20 spec mpileaks%gcc ^elfutils@0.170
 
 #-----------------------------------------------------------
 # Run unit tests with code coverage
 #-----------------------------------------------------------
-extra_args=""
-if [[ -n "$@" ]]; then
-    extra_args="-k $@"
-fi
-$coverage_run bin/spack test -x --verbose "$extra_args"
+$coverage_run $(which spack) test -x --verbose
 
 #-----------------------------------------------------------
 # Run tests for setup-env.sh


### PR DESCRIPTION
Moving `pytest.ini` to Spack's root folder since apparently moving to another folder during tests
causes `coverage` to output coverage files within `lib/spack/spack/test` with no coverage data.

Currently `spack test` can be run from any directory, but coverage will be correctly measured only if run from Spack's root folder.