### PR TITLE
Cscope: fix linking and update to v15.9

### DIFF
--- a/var/spack/repos/builtin/packages/cscope/package.py
+++ b/var/spack/repos/builtin/packages/cscope/package.py
@@ -18,7 +18,6 @@ class Cscope(AutotoolsPackage):
             url = "https://sourceforge.net/projects/cscope/files/cscope/v15.9/cscope-15.9.tar.gz"
         return url
 
-
     version('15.9', sha256='c5505ae075a871a9cd8d9801859b0ff1c09782075df281c72c23e72115d9f159')
     version('15.8b', sha256='4889d091f05aa0845384b1e4965aa31d2b20911fb2c001b2cdcffbcb7212d3af')
 

--- a/var/spack/repos/builtin/packages/cscope/package.py
+++ b/var/spack/repos/builtin/packages/cscope/package.py
@@ -12,13 +12,6 @@ class Cscope(AutotoolsPackage):
     homepage = "http://cscope.sourceforge.net/"
     url = "https://sourceforge.net/projects/cscope/files/cscope/v15.9/cscope-15.9.tar.gz"
 
-    def url_for_version(self, version):
-        url = "https://sourceforge.net/projects/cscope/files/cscope/{0}{1}/cscope-{1}.tar.gz"
-        if version >= Version('15.9'):
-            return url.format('v', version)
-        else:
-            return url.format('', version)
-
     version('15.9', sha256='c5505ae075a871a9cd8d9801859b0ff1c09782075df281c72c23e72115d9f159')
     version('15.8b', sha256='4889d091f05aa0845384b1e4965aa31d2b20911fb2c001b2cdcffbcb7212d3af')
 
@@ -29,3 +22,10 @@ class Cscope(AutotoolsPackage):
     depends_on('pkgconfig', type='build')
 
     build_targets = ['CURSES_LIBS=-lncursesw -ltinfo']
+
+    def url_for_version(self, version):
+        url = "https://sourceforge.net/projects/cscope/files/cscope/{0}{1}/cscope-{1}.tar.gz"
+        if version >= Version('15.9'):
+            return url.format('v', version)
+        else:
+            return url.format('', version)

--- a/var/spack/repos/builtin/packages/cscope/package.py
+++ b/var/spack/repos/builtin/packages/cscope/package.py
@@ -20,4 +20,4 @@ class Cscope(AutotoolsPackage):
     depends_on('bison', type='build')
     depends_on('pkgconfig', type='build')
 
-    build_targets = ['CURSES_LIBS=-lncursesw']
+    build_targets = ['CURSES_LIBS=-lncursesw -ltinfo']

--- a/var/spack/repos/builtin/packages/cscope/package.py
+++ b/var/spack/repos/builtin/packages/cscope/package.py
@@ -10,6 +10,7 @@ class Cscope(AutotoolsPackage):
     """Cscope is a developer's tool for browsing source code."""
 
     homepage = "http://cscope.sourceforge.net/"
+    url = "https://sourceforge.net/projects/cscope/files/cscope/v15.9/cscope-15.9.tar.gz"
 
     def url_for_version(self, version):
         url = "https://sourceforge.net/projects/cscope/files/cscope/{0}{1}/cscope-{1}.tar.gz"

--- a/var/spack/repos/builtin/packages/cscope/package.py
+++ b/var/spack/repos/builtin/packages/cscope/package.py
@@ -10,8 +10,16 @@ class Cscope(AutotoolsPackage):
     """Cscope is a developer's tool for browsing source code."""
 
     homepage = "http://cscope.sourceforge.net/"
-    url      = "http://downloads.sourceforge.net/project/cscope/cscope/15.8b/cscope-15.8b.tar.gz"
 
+    def url_for_version(self, version):
+        if '@:15.8b' in self.spec:
+            url = "https://sourceforge.net/projects/cscope/files/cscope/v15.9/cscope-15.9.tar.gz"
+        else:
+            url = "https://sourceforge.net/projects/cscope/files/cscope/v15.9/cscope-15.9.tar.gz"
+        return url
+
+
+    version('15.9', sha256='c5505ae075a871a9cd8d9801859b0ff1c09782075df281c72c23e72115d9f159')
     version('15.8b', sha256='4889d091f05aa0845384b1e4965aa31d2b20911fb2c001b2cdcffbcb7212d3af')
 
     depends_on('ncurses')

--- a/var/spack/repos/builtin/packages/cscope/package.py
+++ b/var/spack/repos/builtin/packages/cscope/package.py
@@ -18,7 +18,7 @@ class Cscope(AutotoolsPackage):
             return url.format('v', version)
         else:
             return url.format('', version)
-    
+
     version('15.9', sha256='c5505ae075a871a9cd8d9801859b0ff1c09782075df281c72c23e72115d9f159')
     version('15.8b', sha256='4889d091f05aa0845384b1e4965aa31d2b20911fb2c001b2cdcffbcb7212d3af')
 

--- a/var/spack/repos/builtin/packages/cscope/package.py
+++ b/var/spack/repos/builtin/packages/cscope/package.py
@@ -12,12 +12,12 @@ class Cscope(AutotoolsPackage):
     homepage = "http://cscope.sourceforge.net/"
 
     def url_for_version(self, version):
-        if '@:15.8b' in self.spec:
-            url = "https://sourceforge.net/projects/cscope/files/cscope/v15.9/cscope-15.9.tar.gz"
+        url = "https://sourceforge.net/projects/cscope/files/cscope/{0}{1}/cscope-{1}.tar.gz"
+        if version >= Version('15.9'):
+            return url.format('v', version)
         else:
-            url = "https://sourceforge.net/projects/cscope/files/cscope/v15.9/cscope-15.9.tar.gz"
-        return url
-
+            return url.format('', version)
+    
     version('15.9', sha256='c5505ae075a871a9cd8d9801859b0ff1c09782075df281c72c23e72115d9f159')
     version('15.8b', sha256='4889d091f05aa0845384b1e4965aa31d2b20911fb2c001b2cdcffbcb7212d3af')
 


### PR DESCRIPTION
I hope this fixes [issue 15355](https://github.com/spack/spack/issues/15355) and updates cscope.