### PR TITLE
Python: add 3.8.2

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -31,6 +31,7 @@ class Python(AutotoolsPackage):
 
     maintainers = ['adamjstewart']
 
+    version('3.8.2',  sha256='e634a7a74776c2b89516b2e013dda1728c89c8149b9863b8cea21946daf9d561')
     version('3.8.1',  sha256='c7cfa39a43b994621b245e029769e9126caa2a93571cee2e743b213cceac35fb')
     version('3.8.0',  sha256='f1069ad3cae8e7ec467aa98a6565a62a48ef196cb8f1455a245a08db5e1792df')
     version('3.7.6',  sha256='aeee681c235ad336af116f08ab6563361a0c81c537072c1b309d6e4050aa2114', preferred=True)


### PR DESCRIPTION
Closes #13256

It looks like 3.8.2 is significantly less buggy than 3.8.0. I was able to install NumPy with this version and it passed all tests with no issues. I think we should still keep Python 3.7 as preferred until Anaconda and Homebrew update to Python 3.8.

Successfully builds on macOS 10.15.3 with Clang 11.0.0.