### PR TITLE
Automatically detect import_modules in PythonPackage

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -227,6 +227,10 @@ class PythonPackage(PackageBase):
 
         self.setup_py('build_scripts', *args)
 
+    def build_scripts_args(self, spec, prefix):
+        """Arguments to pass to build_scripts."""
+        return []
+
     def clean(self, spec, prefix):
         """Clean up temporary files from 'build' command."""
         args = self.clean_args(spec, prefix)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2048,13 +2048,9 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             return
 
         for name in self.build_time_test_callbacks:
-            try:
-                fn = getattr(self, name)
-                tty.msg('RUN-TESTS: build-time tests [{0}]'.format(name))
-                fn()
-            except AttributeError:
-                msg = 'RUN-TESTS: method not implemented [{0}]'
-                tty.warn(msg.format(name))
+            fn = getattr(self, name)
+            tty.msg('RUN-TESTS: build-time tests [{0}]'.format(name))
+            fn()
 
     @on_package_attributes(run_tests=True)
     def _run_default_install_time_test_callbacks(self):
@@ -2067,13 +2063,9 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             return
 
         for name in self.install_time_test_callbacks:
-            try:
-                fn = getattr(self, name)
-                tty.msg('RUN-TESTS: install-time tests [{0}]'.format(name))
-                fn()
-            except AttributeError:
-                msg = 'RUN-TESTS: method not implemented [{0}]'
-                tty.warn(msg.format(name))
+            fn = getattr(self, name)
+            tty.msg('RUN-TESTS: install-time tests [{0}]'.format(name))
+            fn()
 
 
 inject_flags = PackageBase.inject_flags

--- a/var/spack/repos/builtin/packages/aws-parallelcluster/package.py
+++ b/var/spack/repos/builtin/packages/aws-parallelcluster/package.py
@@ -18,10 +18,6 @@ class AwsParallelcluster(PythonPackage):
         'sean-smith', 'demartinofra', 'enrico-usai', 'lukeseawalker', 'rexcsn',
         'ddeidda', 'tilne'
     ]
-    import_modules = [
-        'pcluster', 'awsbatch', 'pcluster.dcv', 'pcluster.configure',
-        'pcluster.config', 'pcluster.networking'
-    ]
 
     version('2.6.0', sha256='aaed6962cf5027206834ac24b3d312da91e0f96ae8607f555e12cb124b869f0c')
     version('2.5.1', sha256='4fd6e14583f8cf81f9e4aa1d6188e3708d3d14e6ae252de0a94caaf58be76303')

--- a/var/spack/repos/builtin/packages/mercurial/package.py
+++ b/var/spack/repos/builtin/packages/mercurial/package.py
@@ -13,13 +13,6 @@ class Mercurial(PythonPackage):
     homepage = "https://www.mercurial-scm.org"
     url      = "https://www.mercurial-scm.org/release/mercurial-5.3.tar.gz"
 
-    import_modules = [
-        'hgext', 'hgext3rd', 'mercurial', 'hgext.convert', 'hgext.fsmonitor',
-        'hgext.highlight', 'hgext.largefiles', 'hgext.zeroconf',
-        'hgext.fsmonitor.pywatchman', 'mercurial.hgweb',
-        'mercurial.httpclient', 'mercurial.pure'
-    ]
-
     version('5.3',   sha256='e57ff61d6b67695149dd451922b40aa455ab02e01711806a131a1e95c544f9b9')
     version('5.1.2', sha256='15af0b090b23649e0e53621a88dde97b55a734d7cb08b77d3df284db70d44e2e')
     version('5.1.1', sha256='35fc8ba5e0379c1b3affa2757e83fb0509e8ac314cbd9f1fd133cf265d16e49f')

--- a/var/spack/repos/builtin/packages/py-aenum/package.py
+++ b/var/spack/repos/builtin/packages/py-aenum/package.py
@@ -13,8 +13,6 @@ class PyAenum(PythonPackage):
     homepage = "https://bitbucket.org/stoneleaf/aenum"
     url      = "https://pypi.io/packages/source/a/aenum/aenum-2.1.2.tar.gz"
 
-    import_modules = ['aenum']
-
     version('2.1.2', sha256='a3208e4b28db3a7b232ff69b934aef2ea1bf27286d9978e1e597d46f490e4687')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-alabaster/package.py
+++ b/var/spack/repos/builtin/packages/py-alabaster/package.py
@@ -13,8 +13,6 @@ class PyAlabaster(PythonPackage):
     homepage = "https://alabaster.readthedocs.io/"
     url      = "https://pypi.io/packages/source/a/alabaster/alabaster-0.7.10.tar.gz"
 
-    import_modules = ['alabaster']
-
     version('0.7.12', sha256='a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02')
     version('0.7.10', sha256='37cdcb9e9954ed60912ebc1ca12a9d12178c26637abdf124e3cde2341c257fe0')
     version('0.7.9',  sha256='47afd43b08a4ecaa45e3496e139a193ce364571e7e10c6a87ca1a4c57eb7ea08')

--- a/var/spack/repos/builtin/packages/py-appdirs/package.py
+++ b/var/spack/repos/builtin/packages/py-appdirs/package.py
@@ -13,8 +13,6 @@ class PyAppdirs(PythonPackage):
     homepage = "https://github.com/ActiveState/appdirs"
     url      = "https://pypi.io/packages/source/a/appdirs/appdirs-1.4.3.tar.gz"
 
-    import_modules = ['appdirs']
-
     version('1.4.3', sha256='9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92')
     version('1.4.0', sha256='8fc245efb4387a4e3e0ac8ebcc704582df7d72ff6a42a53f5600bbb18fdaadc5')
 

--- a/var/spack/repos/builtin/packages/py-atomicwrites/package.py
+++ b/var/spack/repos/builtin/packages/py-atomicwrites/package.py
@@ -12,8 +12,6 @@ class PyAtomicwrites(PythonPackage):
     homepage = "https://github.com/untitaker/python-atomicwrites"
     url      = "https://pypi.io/packages/source/a/atomicwrites/atomicwrites-1.3.0.tar.gz"
 
-    import_modules = ['atomicwrites']
-
     version('1.3.0', sha256='75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6')
     version('1.1.5', sha256='240831ea22da9ab882b551b31d4225591e5e447a68c5e188db5b89ca1d487585')
 

--- a/var/spack/repos/builtin/packages/py-attrs/package.py
+++ b/var/spack/repos/builtin/packages/py-attrs/package.py
@@ -12,6 +12,8 @@ class PyAttrs(PythonPackage):
     homepage = "http://attrs.org/"
     url      = "https://pypi.io/packages/source/a/attrs/attrs-19.2.0.tar.gz"
 
+    import_modules = ['attr']
+
     version('19.2.0', sha256='f913492e1663d3c36f502e5e9ba6cd13cf19d7fab50aa13239e420fef95e1396')
     version('19.1.0', sha256='f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399')
     version('18.1.0', sha256='e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b')

--- a/var/spack/repos/builtin/packages/py-attrs/package.py
+++ b/var/spack/repos/builtin/packages/py-attrs/package.py
@@ -12,8 +12,6 @@ class PyAttrs(PythonPackage):
     homepage = "http://attrs.org/"
     url      = "https://pypi.io/packages/source/a/attrs/attrs-19.2.0.tar.gz"
 
-    import_modules = ['attr']
-
     version('19.2.0', sha256='f913492e1663d3c36f502e5e9ba6cd13cf19d7fab50aa13239e420fef95e1396')
     version('19.1.0', sha256='f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399')
     version('18.1.0', sha256='e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b')

--- a/var/spack/repos/builtin/packages/py-babel/package.py
+++ b/var/spack/repos/builtin/packages/py-babel/package.py
@@ -14,8 +14,6 @@ class PyBabel(PythonPackage):
     homepage = "http://babel.pocoo.org/en/latest/"
     url      = "https://pypi.io/packages/source/B/Babel/Babel-2.7.0.tar.gz"
 
-    import_modules = ['babel', 'babel.localtime', 'babel.messages']
-
     version('2.7.0', sha256='e86135ae101e31e2c8ec20a4e0c5220f4eed12487d5cf3f78be7e98d3a57fc28')
     version('2.6.0', sha256='8cba50f48c529ca3fa18cf81fa9403be176d374ac4d60738b839122dfaaa3d23')
     version('2.4.0', sha256='8c98f5e5f8f5f088571f2c6bd88d530e331cbbcb95a7311a0db69d3dca7ec563')

--- a/var/spack/repos/builtin/packages/py-boto3/package.py
+++ b/var/spack/repos/builtin/packages/py-boto3/package.py
@@ -12,11 +12,6 @@ class PyBoto3(PythonPackage):
     homepage = "https://github.com/boto/boto3"
     url      = "https://pypi.io/packages/source/b/boto3/boto3-1.10.44.tar.gz"
 
-    import_modules = [
-        'boto3', 'boto3.s3', 'boto3.resources', 'boto3.dynamodb',
-        'boto3.docs', 'boto3.ec2'
-    ]
-
     version('1.10.44', sha256='adc0c0269bd65967fd528d7cd826304f381d40d94f2bf2b09f58167e5ac05d86')
     version('1.10.38', sha256='6cdb063b2ae5ac7b93ded6b6b17e3da1325b32232d5ff56e6800018d4786bba6')
     version('1.9.169', sha256='9d8bd0ca309b01265793b7e8d7b88c1df439737d77c8725988f0277bbf58d169')

--- a/var/spack/repos/builtin/packages/py-botocore/package.py
+++ b/var/spack/repos/builtin/packages/py-botocore/package.py
@@ -12,8 +12,6 @@ class PyBotocore(PythonPackage):
     homepage = "https://github.com/boto/botocore"
     url      = "https://pypi.io/packages/source/b/botocore/botocore-1.13.44.tar.gz"
 
-    import_modules = ['botocore']
-
     version('1.13.44',  sha256='a4409008c32a3305b9c469c5cc92edb5b79d6fcbf6f56fe126886b545f0a4f3f')
     version('1.13.38',  sha256='15766a367f39dba9de3c6296aaa7da31030f08a0117fd12685e7df682d8acee2')
     version('1.12.169', sha256='25b44c3253b5ed1c9093efb57ffca440c5099a2d62fa793e8b6c52e72f54b01e')

--- a/var/spack/repos/builtin/packages/py-cairocffi/package.py
+++ b/var/spack/repos/builtin/packages/py-cairocffi/package.py
@@ -14,7 +14,6 @@ class PyCairocffi(PythonPackage):
 
     homepage = "https://github.com/Kozea/cairocffi"
     url      = "https://pypi.io/packages/source/c/cairocffi/cairocffi-1.0.2.tar.gz"
-    import_modules = ['cairocffi']
 
     version('1.0.2', sha256='01ac51ae12c4324ca5809ce270f9dd1b67f5166fe63bd3e497e9ea3ca91946ff')
 

--- a/var/spack/repos/builtin/packages/py-certifi/package.py
+++ b/var/spack/repos/builtin/packages/py-certifi/package.py
@@ -14,8 +14,6 @@ class PyCertifi(PythonPackage):
     homepage = "http://certifi.io/"
     url      = "https://pypi.io/packages/source/c/certifi/certifi-2019.6.16.tar.gz"
 
-    import_modules = ['certifi']
-
     version('2019.9.11', sha256='e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50')
     version('2019.6.16', sha256='945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695')
     version('2019.3.9',  sha256='b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae')

--- a/var/spack/repos/builtin/packages/py-cffi/package.py
+++ b/var/spack/repos/builtin/packages/py-cffi/package.py
@@ -13,8 +13,6 @@ class PyCffi(PythonPackage):
     homepage = "https://cffi.readthedocs.io/en/latest/"
     url      = "https://pypi.io/packages/source/c/cffi/cffi-1.13.0.tar.gz"
 
-    import_modules = ['cffi']
-
     version('1.13.0', sha256='8fe230f612c18af1df6f348d02d682fe2c28ca0a6c3856c99599cdacae7cf226')
     version('1.12.2', sha256='e113878a446c6228669144ae8a56e268c91b7f1fafae927adc4879d9849e0ea7')
     version('1.11.5', sha256='e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4')

--- a/var/spack/repos/builtin/packages/py-cloudpickle/package.py
+++ b/var/spack/repos/builtin/packages/py-cloudpickle/package.py
@@ -12,8 +12,6 @@ class PyCloudpickle(PythonPackage):
     homepage = "https://github.com/cloudpipe/cloudpickle"
     url      = "https://pypi.io/packages/source/c/cloudpickle/cloudpickle-0.5.2.tar.gz"
 
-    import_modules = ['cloudpickle']
-
     version('1.2.1', sha256='603244e0f552b72a267d47a7d9b347b27a3430f58a0536037a290e7e0e212ecf')
     version('0.5.2', sha256='b0e63dd89ed5285171a570186751bc9b84493675e99e12789e9a5dc5490ef554')
 

--- a/var/spack/repos/builtin/packages/py-codecov/package.py
+++ b/var/spack/repos/builtin/packages/py-codecov/package.py
@@ -12,8 +12,6 @@ class PyCodecov(PythonPackage):
     homepage = "https://github.com/codecov/codecov-python"
     url      = "https://pypi.io/packages/source/c/codecov/codecov-2.0.15.tar.gz"
 
-    import_modules = ['codecov']
-
     version('2.0.15', sha256='8ed8b7c6791010d359baed66f84f061bba5bd41174bf324c31311e8737602788')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-counter/package.py
+++ b/var/spack/repos/builtin/packages/py-counter/package.py
@@ -10,8 +10,6 @@ class PyCounter(PythonPackage):
     """Counter package defines the "counter.Counter" class similar to
        bags or multisets in other languages."""
 
-    import_modules = ['counter']
-
     homepage = "https://github.com/KelSolaar/Counter"
     url      = "https://pypi.io/packages/source/C/Counter/Counter-1.0.0.tar.gz"
 

--- a/var/spack/repos/builtin/packages/py-cvxopt/package.py
+++ b/var/spack/repos/builtin/packages/py-cvxopt/package.py
@@ -13,8 +13,6 @@ class PyCvxopt(PythonPackage):
     homepage = "http://cvxopt.org/"
     url      = "https://pypi.io/packages/source/c/cvxopt/cvxopt-1.1.9.tar.gz"
 
-    import_modules = ['cvxopt']
-
     version('1.1.9', sha256='8f157e7397158812cabd340b68546f1baa55a486ed0aad8bc26877593dc2983d')
 
     variant('gsl',   default=False, description='Use GSL random number generators for constructing random matrices')

--- a/var/spack/repos/builtin/packages/py-cython/package.py
+++ b/var/spack/repos/builtin/packages/py-cython/package.py
@@ -12,14 +12,6 @@ class PyCython(PythonPackage):
     homepage = "https://pypi.python.org/pypi/cython"
     url      = "https://pypi.io/packages/source/c/cython/Cython-0.29.14.tar.gz"
 
-    import_modules = [
-        'cython', 'Cython', 'Cython.Build', 'Cython.Compiler',
-        'Cython.Runtime', 'Cython.Distutils', 'Cython.Debugger',
-        'Cython.Debugger.Tests', 'Cython.Plex', 'Cython.Tests',
-        'Cython.Build.Tests', 'Cython.Compiler.Tests', 'Cython.Utility',
-        'Cython.Tempita', 'pyximport',
-    ]
-
     version('0.29.14', sha256='e4d6bb8703d0319eb04b7319b12ea41580df44fd84d83ccda13ea463c6801414')
     version('0.29.13', sha256='c29d069a4a30f472482343c866f7486731ad638ef9af92bfe5fca9c7323d638e')
     version('0.29.10', sha256='26229570d6787ff3caa932fe9d802960f51a89239b990d275ae845405ce43857')

--- a/var/spack/repos/builtin/packages/py-dask/package.py
+++ b/var/spack/repos/builtin/packages/py-dask/package.py
@@ -55,22 +55,3 @@ class PyDask(PythonPackage):
 
     # Requirements for dask.distributed
     depends_on('py-distributed@1.22:',  type=('build', 'run'), when='+distributed')
-
-    @property
-    def import_modules(self):
-        modules = [
-            'dask', 'dask.bytes', 'dask.diagnostics', 'dask.store'
-        ]
-
-        if '+array' in self.spec:
-            modules.append('dask.array')
-
-        if '+bag' in self.spec:
-            modules.append('dask.bag')
-
-        if '+dataframe' in self.spec:
-            modules.extend([
-                'dask.dataframe', 'dask.dataframe.io', 'dask.dataframe.tseries'
-            ])
-
-        return modules

--- a/var/spack/repos/builtin/packages/py-docopt/package.py
+++ b/var/spack/repos/builtin/packages/py-docopt/package.py
@@ -12,8 +12,6 @@ class PyDocopt(PythonPackage):
     homepage = "http://docopt.org/"
     url      = "https://pypi.io/packages/source/d/docopt/docopt-0.6.2.tar.gz"
 
-    import_modules = ['docopt']
-
     version('0.6.2', sha256='49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-docutils/package.py
+++ b/var/spack/repos/builtin/packages/py-docutils/package.py
@@ -16,17 +16,6 @@ class PyDocutils(PythonPackage):
     homepage = "http://docutils.sourceforge.net/"
     url      = "https://pypi.io/packages/source/d/docutils/docutils-0.15.2.tar.gz"
 
-    import_modules = [
-        'docutils', 'docutils.languages', 'docutils.parsers',
-        'docutils.readers', 'docutils.transforms', 'docutils.utils',
-        'docutils.writers', 'docutils.parsers.rst',
-        'docutils.parsers.rst.directives', 'docutils.parsers.rst.languages',
-        'docutils.utils.math', 'docutils.writers.html4css1',
-        'docutils.writers.html5_polyglot', 'docutils.writers.latex2e',
-        'docutils.writers.odf_odt', 'docutils.writers.pep_html',
-        'docutils.writers.s5_html', 'docutils.writers.xetex'
-    ]
-
     version('0.15.2', sha256='a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99')
     version('0.14',   sha256='51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274')
     version('0.13.1', sha256='718c0f5fb677be0f34b781e04241c4067cbd9327b66bdd8e763201130f5175be')

--- a/var/spack/repos/builtin/packages/py-dxchange/package.py
+++ b/var/spack/repos/builtin/packages/py-dxchange/package.py
@@ -14,8 +14,6 @@ class PyDxchange(PythonPackage):
     homepage = "https://github.com/data-exchange/dxchange"
     url      = "https://github.com/data-exchange/dxchange/archive/v0.1.2.tar.gz"
 
-    import_modules = ['dxchange']
-
     version('0.1.2', sha256='d005b036b6323d0dffd5944c3da0b8a90496d96277654e72b53717058dd5fd87')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-dxfile/package.py
+++ b/var/spack/repos/builtin/packages/py-dxfile/package.py
@@ -13,8 +13,6 @@ class PyDxfile(PythonPackage):
     homepage = "https://github.com/data-exchange/dxfile"
     url      = "https://github.com/data-exchange/dxfile/archive/v0.4.tar.gz"
 
-    import_modules = ['dxfile']
-
     version('0.4', sha256='b7729eebdc7c99a66a8b339fc10019aa8565e02bd12708540fb3f47935f004c7')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-entrypoints/package.py
+++ b/var/spack/repos/builtin/packages/py-entrypoints/package.py
@@ -12,8 +12,6 @@ class PyEntrypoints(PythonPackage):
     homepage = "https://pypi.python.org/pypi/entrypoints"
     url      = "https://pypi.io/packages/source/e/entrypoints/entrypoints-0.2.3.tar.gz"
 
-    import_modules = ['entrypoints']
-
     version('0.3', sha256='c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451')
     version('0.2.3', sha256='d2d587dde06f99545fb13a383d2cd336a8ff1f359c5839ce3a64c917d10c029f')
 

--- a/var/spack/repos/builtin/packages/py-fiona/package.py
+++ b/var/spack/repos/builtin/packages/py-fiona/package.py
@@ -13,7 +13,6 @@ class PyFiona(PythonPackage):
     url      = "https://pypi.io/packages/source/F/Fiona/Fiona-1.8.6.tar.gz"
 
     maintainers = ['adamjstewart']
-    import_modules = ['fiona', 'fiona.fio']
 
     version('1.8.6',  sha256='fa31dfe8855b9cd0b128b47a4df558f1b8eda90d2181bff1dd9854e5556efb3e')
     version('1.7.12', sha256='8b54eb8422d7c502bb7776b184018186bede1a489cf438a7a47f992ade6a0e51')

--- a/var/spack/repos/builtin/packages/py-fiscalyear/package.py
+++ b/var/spack/repos/builtin/packages/py-fiscalyear/package.py
@@ -17,7 +17,6 @@ class PyFiscalyear(PythonPackage):
     git      = "https://github.com/adamjstewart/fiscalyear.git"
 
     maintainers = ['adamjstewart']
-    import_modules = ['fiscalyear']
 
     version('master', branch='master')
     version('0.2.0', sha256='f513616aeb03046406c56d7c69cd9e26f6a12963c71c1410cc3d4532a5bfee71')

--- a/var/spack/repos/builtin/packages/py-freezegun/package.py
+++ b/var/spack/repos/builtin/packages/py-freezegun/package.py
@@ -13,8 +13,6 @@ class PyFreezegun(PythonPackage):
     homepage = "https://github.com/spulec/freezegun"
     url      = "https://pypi.io/packages/source/f/freezegun/freezegun-0.3.12.tar.gz"
 
-    import_modules = ['freezegun']
-
     version('0.3.12', sha256='2a4d9c8cd3c04a201e20c313caf8b6338f1cfa4cda43f46a94cc4a9fd13ea5e7')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-funcsigs/package.py
+++ b/var/spack/repos/builtin/packages/py-funcsigs/package.py
@@ -12,8 +12,6 @@ class PyFuncsigs(PythonPackage):
     homepage = "https://pypi.python.org/pypi/funcsigs"
     url      = "https://pypi.io/packages/source/f/funcsigs/funcsigs-1.0.2.tar.gz"
 
-    import_modules = ['funcsigs']
-
     version('1.0.2', sha256='a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50')
     version('0.4',   sha256='d83ce6df0b0ea6618700fe1db353526391a8a3ada1b7aba52fed7a61da772033')
 

--- a/var/spack/repos/builtin/packages/py-geopandas/package.py
+++ b/var/spack/repos/builtin/packages/py-geopandas/package.py
@@ -17,9 +17,6 @@ class PyGeopandas(PythonPackage):
     url      = "https://pypi.io/packages/source/g/geopandas/geopandas-0.5.0.tar.gz"
 
     maintainers = ['adamjstewart']
-    import_modules = [
-        'geopandas', 'geopandas.io', 'geopandas.tools', 'geopandas.datasets'
-    ]
 
     version('0.5.0', sha256='d075d2ab61a502ab92ec6b72aaf9610a1340ec24ed07264fcbdbe944b9e68954')
     version('0.4.0', sha256='9f5d24d23f33e6d3267a633025e4d9e050b3a1e86d41a96d3ccc5ad95afec3db')

--- a/var/spack/repos/builtin/packages/py-h5py/package.py
+++ b/var/spack/repos/builtin/packages/py-h5py/package.py
@@ -13,8 +13,6 @@ class PyH5py(PythonPackage):
     homepage = "http://www.h5py.org/"
     url      = "https://pypi.io/packages/source/h/h5py/h5py-2.10.0.tar.gz"
 
-    import_modules = ['h5py', 'h5py._hl']
-
     version('2.10.0', sha256='84412798925dc870ffd7107f045d7659e60f5d46d1c70c700375248bf6bf512d')
     version('2.9.0', sha256='9d41ca62daf36d6b6515ab8765e4c8c4388ee18e2a665701fef2b41563821002')
     version('2.8.0', sha256='e626c65a8587921ebc7fb8d31a49addfdd0b9a9aa96315ea484c09803337b955')

--- a/var/spack/repos/builtin/packages/py-hacking/package.py
+++ b/var/spack/repos/builtin/packages/py-hacking/package.py
@@ -12,8 +12,6 @@ class PyHacking(PythonPackage):
     homepage = "https://docs.openstack.org/hacking/latest/"
     url      = "https://pypi.io/packages/source/h/hacking/hacking-1.1.0.tar.gz"
 
-    import_modules = ['hacking']
-
     version('1.1.0', sha256='23a306f3a1070a4469a603886ba709780f02ae7e0f1fc7061e5c6fb203828fee')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-hypothesis/package.py
+++ b/var/spack/repos/builtin/packages/py-hypothesis/package.py
@@ -12,14 +12,6 @@ class PyHypothesis(PythonPackage):
     homepage = "https://github.com/HypothesisWorks/hypothesis-python"
     url      = "https://pypi.io/packages/source/h/hypothesis/hypothesis-4.41.2.tar.gz"
 
-    import_modules = [
-        'hypothesis', 'hypothesis.searchstrategy', 'hypothesis.extra',
-        'hypothesis.utils', 'hypothesis.vendor', 'hypothesis.internal',
-        'hypothesis.internal.conjecture'
-    ]
-
-    # TODO: Add missing dependency required to import hypothesis.extra.django
-
     version('4.41.2', sha256='6847df3ffb4aa52798621dd007e6b61dbcf2d76c30ba37dc2699720e2c734b7a')
     version('4.24.3', sha256='fd90a319f409f34a173156ca704d6c0c6c0bb30a2e43dbf26aced2c75569e5d5')
     version('4.7.2',  sha256='87944c6379f77634474b88abbf1e5ed5fe966637cc926131eda5e2af5b54a608')

--- a/var/spack/repos/builtin/packages/py-imagesize/package.py
+++ b/var/spack/repos/builtin/packages/py-imagesize/package.py
@@ -13,8 +13,6 @@ class PyImagesize(PythonPackage):
     homepage = "https://github.com/shibukawa/imagesize_py"
     url      = "https://pypi.io/packages/source/i/imagesize/imagesize-0.7.1.tar.gz"
 
-    import_modules = ['imagesize']
-
     version('1.1.0',  sha256='f3832918bc3c66617f92e35f5d70729187676313caa60c187eb0f28b8fe5e3b5')
     version('0.7.1', sha256='0ab2c62b87987e3252f89d30b7cedbec12a01af9274af9ffa48108f2c13c6062')
 

--- a/var/spack/repos/builtin/packages/py-jinja2/package.py
+++ b/var/spack/repos/builtin/packages/py-jinja2/package.py
@@ -14,8 +14,6 @@ class PyJinja2(PythonPackage):
     homepage = "https://palletsprojects.com/p/jinja/"
     url      = "https://pypi.io/packages/source/J/Jinja2/Jinja2-2.10.3.tar.gz"
 
-    import_modules = ['jinja2']
-
     version('2.10.3', sha256='9fe95f19286cfefaa917656583d020be14e7859c6b0252588391e47db34527de')
     version('2.10.1', sha256='065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013')
     version('2.10',   sha256='f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4')

--- a/var/spack/repos/builtin/packages/py-jmespath/package.py
+++ b/var/spack/repos/builtin/packages/py-jmespath/package.py
@@ -12,8 +12,6 @@ class PyJmespath(PythonPackage):
     homepage = "https://github.com/jmespath/jmespath.py"
     url      = "https://pypi.io/packages/source/j/jmespath/jmespath-0.9.4.tar.gz"
 
-    import_modules = ['jmespath']
-
     version('0.9.4', sha256='bde2aef6f44302dfb30320115b17d030798de8c4110e28d5cf6cf91a7a31074c')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-joblib/package.py
+++ b/var/spack/repos/builtin/packages/py-joblib/package.py
@@ -12,11 +12,6 @@ class PyJoblib(PythonPackage):
     homepage = "http://packages.python.org/joblib/"
     url      = "https://pypi.io/packages/source/j/joblib/joblib-0.14.0.tar.gz"
 
-    import_modules = [
-        'joblib', 'joblib.externals', 'joblib.externals.cloudpickle',
-        'joblib.externals.loky', 'joblib.externals.loky.backend'
-    ]
-
     version('0.14.0', sha256='6fcc57aacb4e89451fd449e9412687c51817c3f48662c3d8f38ba3f8a0a193ff')
     version('0.13.2', sha256='315d6b19643ec4afd4c41c671f9f2d65ea9d787da093487a81ead7b0bac94524')
     version('0.11', sha256='7b8fd56df36d9731a83729395ccb85a3b401f62a96255deb1a77220c00ed4085')

--- a/var/spack/repos/builtin/packages/py-kmodes/package.py
+++ b/var/spack/repos/builtin/packages/py-kmodes/package.py
@@ -13,8 +13,6 @@ class PyKmodes(PythonPackage):
     homepage = "https://github.com/nicodv/kmodes"
     url      = "https://pypi.io/packages/source/k/kmodes/kmodes-0.10.1.tar.gz"
 
-    import_modules = ['kmodes', 'kmodes.util']
-
     version('0.10.1', sha256='3222c2f672a6356be353955c02d1e38472d9f6074744b4ffb0c058e8c2235ea1')
 
     depends_on('python@3.4:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-latexcodec/package.py
+++ b/var/spack/repos/builtin/packages/py-latexcodec/package.py
@@ -12,8 +12,6 @@ class PyLatexcodec(PythonPackage):
     homepage = "http://latexcodec.readthedocs.io"
     url      = "https://pypi.io/packages/source/l/latexcodec/latexcodec-1.0.4.tar.gz"
 
-    import_modules = ['latexcodec']
-
     version('1.0.4', sha256='62bf8a3ee298f169a4d014dad5522bc1325b54dc98789a453fd338620387cb6c')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-locket/package.py
+++ b/var/spack/repos/builtin/packages/py-locket/package.py
@@ -12,6 +12,4 @@ class PyLocket(PythonPackage):
     homepage = "http://github.com/mwilliamson/locket.py"
     url      = "https://pypi.io/packages/source/l/locket/locket-0.2.0.tar.gz"
 
-    import_modules = ['locket']
-
     version('0.2.0', sha256='1fee63c1153db602b50154684f5725564e63a0f6d09366a1cb13dffcec179fb4')

--- a/var/spack/repos/builtin/packages/py-markupsafe/package.py
+++ b/var/spack/repos/builtin/packages/py-markupsafe/package.py
@@ -15,8 +15,6 @@ class PyMarkupsafe(PythonPackage):
     homepage = "http://www.pocoo.org/projects/markupsafe/"
     url      = "https://pypi.io/packages/source/M/MarkupSafe/MarkupSafe-1.1.1.tar.gz"
 
-    import_modules = ['markupsafe']
-
     version('1.1.1', sha256='29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b')
     version('1.0',   sha256='a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665')
     version('0.23',  sha256='a4ec1aff59b95a14b45eb2e23761a0179e98319da5a7eb76b56ea8cdc7b871c3')

--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -17,16 +17,6 @@ class PyMatplotlib(PythonPackage):
 
     maintainers = ['adamjstewart']
 
-    import_modules = [
-        'mpl_toolkits', 'matplotlib', 'mpl_toolkits.axes_grid1',
-        'mpl_toolkits.axes_grid', 'mpl_toolkits.mplot3d',
-        'mpl_toolkits.axisartist', 'matplotlib.compat', 'matplotlib.tri',
-        'matplotlib.axes', 'matplotlib.sphinxext', 'matplotlib.cbook',
-        'matplotlib.backends', 'matplotlib.style', 'matplotlib.projections',
-        'matplotlib.testing', 'matplotlib.backends.qt_editor',
-        'matplotlib.testing.jpl_units'
-    ]
-
     version('3.2.0', sha256='651d76daf9168250370d4befb09f79875daa2224a9096d97dfc3ed764c842be4')
     version('3.1.3', sha256='db3121f12fb9b99f105d1413aebaeb3d943f269f3d262b45586d12765866f0c6')
     version('3.1.2', sha256='8e8e2c2fe3d873108735c6ee9884e6f36f467df4a143136209cff303b183bada')

--- a/var/spack/repos/builtin/packages/py-more-itertools/package.py
+++ b/var/spack/repos/builtin/packages/py-more-itertools/package.py
@@ -12,8 +12,6 @@ class PyMoreItertools(PythonPackage):
     homepage = "https://github.com/erikrose/more-itertools"
     url      = "https://pypi.io/packages/source/m/more-itertools/more-itertools-7.2.0.tar.gz"
 
-    import_modules = ['more_itertools', 'more_itertools.tests']
-
     version('7.2.0', sha256='409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832')
     version('5.0.0', sha256='38a936c0a6d98a38bcc2d03fdaaedaba9f412879461dd2ceff8d37564d6522e4')
     version('4.3.0', sha256='c476b5d3a34e12d40130bc2f935028b5f636df8f372dc2c1c01dc19681b2039e')

--- a/var/spack/repos/builtin/packages/py-nose/package.py
+++ b/var/spack/repos/builtin/packages/py-nose/package.py
@@ -13,10 +13,6 @@ class PyNose(PythonPackage):
     homepage = "https://pypi.python.org/pypi/nose"
     url      = "https://pypi.io/packages/source/n/nose/nose-1.3.4.tar.gz"
 
-    import_modules = [
-        'nose', 'nose.ext', 'nose.plugins', 'nose.sphinx', 'nose.tools'
-    ]
-
     version('1.3.7', sha256='f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98')
     version('1.3.6', sha256='f61e0909a743eed37b1207e38a8e7b4a2fe0a82185e36f2be252ef1b3f901758')
     version('1.3.4', sha256='76bc63a4e2d5e5a0df77ca7d18f0f56e2c46cfb62b71103ba92a92c79fab1e03')

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -22,13 +22,6 @@ class PyNumpy(PythonPackage):
     maintainers = ['adamjstewart']
     install_time_test_callbacks = ['install_test', 'import_module_test']
 
-    import_modules = [
-        'numpy', 'numpy.compat', 'numpy.core', 'numpy.distutils', 'numpy.doc',
-        'numpy.f2py', 'numpy.fft', 'numpy.lib', 'numpy.linalg', 'numpy.ma',
-        'numpy.matrixlib', 'numpy.polynomial', 'numpy.random', 'numpy.testing',
-        'numpy.distutils.command', 'numpy.distutils.fcompiler'
-    ]
-
     version('master', branch='master')
     version('1.18.1', sha256='b6ff59cee96b454516e47e7721098e6ceebef435e3e21ac2d6c3b8b02628eb77')
     version('1.18.0', sha256='a9d72d9abaf65628f0f31bbb573b7d9304e43b1e6bbae43149c17737a42764c4')

--- a/var/spack/repos/builtin/packages/py-olefile/package.py
+++ b/var/spack/repos/builtin/packages/py-olefile/package.py
@@ -12,8 +12,6 @@ class PyOlefile(PythonPackage):
     homepage = "https://www.decalage.info/python/olefileio"
     url      = "https://pypi.io/packages/source/o/olefile/olefile-0.44.zip"
 
-    import_modules = ['olefile']
-
     version('0.44', sha256='61f2ca0cd0aa77279eb943c07f607438edf374096b66332fae1ee64a6f0f73ad')
 
     depends_on('python@2.6:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-openslide-python/package.py
+++ b/var/spack/repos/builtin/packages/py-openslide-python/package.py
@@ -14,8 +14,6 @@ class PyOpenslidePython(PythonPackage):
 
     version('1.1.1', sha256='33c390fe43e3d7d443fafdd66969392d3e9efd2ecd5d4af73c3dbac374485ed5')
 
-    import_modules = ['openslide']
-
     depends_on('openslide@3.4.0:')
     depends_on('python@2.6:2.8,3.3:')
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-ordereddict/package.py
+++ b/var/spack/repos/builtin/packages/py-ordereddict/package.py
@@ -13,6 +13,4 @@ class PyOrdereddict(PythonPackage):
     homepage = "https://pypi.python.org/pypi/ordereddict"
     url      = "https://pypi.io/packages/source/o/ordereddict/ordereddict-1.1.tar.gz"
 
-    import_modules = ['ordereddict']
-
     version('1.1', sha256='1c35b4ac206cef2d24816c89f89cf289dd3d38cf7c449bb3fab7bf6d43f01b1f')

--- a/var/spack/repos/builtin/packages/py-oset/package.py
+++ b/var/spack/repos/builtin/packages/py-oset/package.py
@@ -12,8 +12,6 @@ class PyOset(PythonPackage):
     homepage = "https://pypi.python.org/pypi/oset"
     url      = "https://pypi.io/packages/source/o/oset/oset-0.1.3.tar.gz"
 
-    import_modules = ['oset']
-
     version('0.1.3', sha256='4c1fd7dec96eeff9d3260995a8e37f9f415d0bdb79975f57824e68716ac8f904')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-packaging/package.py
+++ b/var/spack/repos/builtin/packages/py-packaging/package.py
@@ -12,8 +12,6 @@ class PyPackaging(PythonPackage):
     homepage = "https://github.com/pypa/packaging"
     url      = "https://pypi.io/packages/source/p/packaging/packaging-19.2.tar.gz"
 
-    import_modules = ['packaging']
-
     version('19.2', sha256='28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47')
     version('19.1', sha256='c491ca87294da7cc01902edbe30a5bc6c4c28172b5138ab4e4aa1b9d7bfaeafe')
     version('19.0', sha256='0c98a5d0be38ed775798ece1b9727178c4469d9c3b4ada66e8e6b7849f8732af')

--- a/var/spack/repos/builtin/packages/py-pandas/package.py
+++ b/var/spack/repos/builtin/packages/py-pandas/package.py
@@ -20,19 +20,6 @@ class PyPandas(PythonPackage):
     url = "https://pypi.io/packages/source/p/pandas/pandas-0.25.1.tar.gz"
 
     maintainers = ['adamjstewart']
-    import_modules = [
-        'pandas', 'pandas.compat', 'pandas.core', 'pandas.util', 'pandas.io',
-        'pandas.tseries', 'pandas._libs', 'pandas.plotting', 'pandas.arrays',
-        'pandas.api', 'pandas.errors', 'pandas._config', 'pandas.compat.numpy',
-        'pandas.core.reshape', 'pandas.core.tools', 'pandas.core.util',
-        'pandas.core.dtypes', 'pandas.core.groupby', 'pandas.core.internals',
-        'pandas.core.computation', 'pandas.core.arrays', 'pandas.core.ops',
-        'pandas.core.sparse', 'pandas.core.indexes', 'pandas.io.msgpack',
-        'pandas.io.formats', 'pandas.io.excel', 'pandas.io.json',
-        'pandas.io.sas', 'pandas.io.clipboard', 'pandas._libs.tslibs',
-        'pandas.plotting._matplotlib', 'pandas.api.types',
-        'pandas.api.extensions'
-    ]
 
     version('0.25.1', sha256='cb2e197b7b0687becb026b84d3c242482f20cbb29a9981e43604eb67576da9f6')
     version('0.25.0', sha256='914341ad2d5b1ea522798efa4016430b66107d05781dbfe7cf05eba8f37df995')

--- a/var/spack/repos/builtin/packages/py-partd/package.py
+++ b/var/spack/repos/builtin/packages/py-partd/package.py
@@ -12,8 +12,6 @@ class PyPartd(PythonPackage):
     homepage = "http://github.com/dask/partd/"
     url      = "https://pypi.io/packages/source/p/partd/partd-0.3.8.tar.gz"
 
-    import_modules = ['partd']
-
     version('0.3.8', sha256='67291f1c4827cde3e0148b3be5d69af64b6d6169feb9ba88f0a6cfe77089400f')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-pathlib2/package.py
+++ b/var/spack/repos/builtin/packages/py-pathlib2/package.py
@@ -12,8 +12,6 @@ class PyPathlib2(PythonPackage):
     homepage = "https://pypi.python.org/pypi/pathlib2"
     url      = "https://pypi.io/packages/source/p/pathlib2/pathlib2-2.3.2.tar.gz"
 
-    import_modules = ['pathlib2']
-
     version('2.3.3', sha256='25199318e8cc3c25dcb45cbe084cc061051336d5a9ea2a12448d3d8cb748f742')
     version('2.3.2', sha256='8eb170f8d0d61825e09a95b38be068299ddeda82f35e96c3301a8a5e7604cb83')
     version('2.1.0', sha256='deb3a960c1d55868dfbcac98432358b92ba89d95029cddd4040db1f27405055c')

--- a/var/spack/repos/builtin/packages/py-pep8/package.py
+++ b/var/spack/repos/builtin/packages/py-pep8/package.py
@@ -12,8 +12,6 @@ class PyPep8(PythonPackage):
     homepage = "https://pep8.readthedocs.org/"
     url      = "https://pypi.io/packages/source/p/pep8/pep8-1.7.1.tar.gz"
 
-    import_modules = ['pep8']
-
     version('1.7.1', sha256='fe249b52e20498e59e0b5c5256aa52ee99fc295b26ec9eaa85776ffdb9fe6374')
 
     depends_on('py-setuptools', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-pillow/package.py
+++ b/var/spack/repos/builtin/packages/py-pillow/package.py
@@ -16,7 +16,6 @@ class PyPillow(PythonPackage):
     url      = "https://pypi.io/packages/source/P/Pillow/Pillow-7.0.0.tar.gz"
 
     maintainers = ['adamjstewart']
-    import_modules = ['PIL']
 
     version('7.0.0', sha256='4d9ed9a64095e031435af120d3c910148067087541131e82b3e8db302f4c8946')
     version('6.2.2', sha256='db9ff0c251ed066d367f53b64827cc9e18ccea001b986d08c265e53625dab950')

--- a/var/spack/repos/builtin/packages/py-pluggy/package.py
+++ b/var/spack/repos/builtin/packages/py-pluggy/package.py
@@ -12,8 +12,6 @@ class PyPluggy(PythonPackage):
     homepage = "https://github.com/pytest-dev/pluggy"
     url      = "https://pypi.io/packages/source/p/pluggy/pluggy-0.13.0.tar.gz"
 
-    import_modules = ['pluggy']
-
     version('0.13.0', sha256='fa5fa1622fa6dd5c030e9cad086fa19ef6a0cf6d7a2d12318e10cb49d6d68f34')
     version('0.12.0', sha256='0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc')
     version('0.7.1', sha256='95eb8364a4708392bae89035f45341871286a333f749c3141c20573d2b3876e1')

--- a/var/spack/repos/builtin/packages/py-projectq/package.py
+++ b/var/spack/repos/builtin/packages/py-projectq/package.py
@@ -19,11 +19,6 @@ class PyProjectq(PythonPackage):
     homepage = "https://projectq.ch"
     git      = "https://github.com/projectq-framework/projectq.git"
 
-    # Provided python modules
-    import_modules = ['projectq', 'projectq.backends', 'projectq.cengines',
-                      'projectq.libs', 'projectq.meta', 'projectq.ops',
-                      'projectq.setups', 'projectq.types']
-
     # Versions
     version('develop', branch='develop')
     version('0.3.6', commit='fa484fe037a3a1772127bbd00fe4628ddba34611')

--- a/var/spack/repos/builtin/packages/py-py/package.py
+++ b/var/spack/repos/builtin/packages/py-py/package.py
@@ -12,11 +12,6 @@ class PyPy(PythonPackage):
     homepage = "http://pylib.readthedocs.io/en/latest/"
     url      = "https://pypi.io/packages/source/p/py/py-1.8.0.tar.gz"
 
-    import_modules = [
-        'py', 'py._process', 'py._vendored_packages', 'py._path',
-        'py._log', 'py._code', 'py._io'
-    ]
-
     version('1.8.0', sha256='dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53')
     version('1.5.4',  sha256='3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7')
     version('1.5.3',  sha256='29c9fab495d7528e80ba1e343b958684f4ace687327e6f789a94bf3d1915f881')

--- a/var/spack/repos/builtin/packages/py-pybtex/package.py
+++ b/var/spack/repos/builtin/packages/py-pybtex/package.py
@@ -14,18 +14,6 @@ class PyPybtex(PythonPackage):
     homepage = "https://pybtex.org"
     url      = "https://pypi.io/packages/source/P/Pybtex/pybtex-0.21.tar.gz"
 
-    import_modules = [
-        'custom_fixers', 'pybtex', 'pybtex.style', 'pybtex.tests',
-        'pybtex.database', 'pybtex.backends', 'pybtex.bibtex',
-        'pybtex.charwidths', 'pybtex.markup', 'pybtex.plugin',
-        'pybtex.style.sorting', 'pybtex.style.names',
-        'pybtex.style.labels', 'pybtex.style.formatting',
-        'pybtex.tests.database_test', 'pybtex.tests.bst_parser_test',
-        'pybtex.tests.data', 'pybtex.database.output',
-        'pybtex.database.input', 'pybtex.database.format',
-        'pybtex.database.convert'
-    ]
-
     version('0.21', sha256='af8a6c7c74954ad305553b118d2757f68bc77c5dd5d5de2cc1fd16db90046000')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-pycparser/package.py
+++ b/var/spack/repos/builtin/packages/py-pycparser/package.py
@@ -12,8 +12,6 @@ class PyPycparser(PythonPackage):
     homepage = "https://github.com/eliben/pycparser"
     url      = "https://pypi.io/packages/source/p/pycparser/pycparser-2.19.tar.gz"
 
-    import_modules = ['pycparser', 'pycparser.ply']
-
     version('2.19', sha256='a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3')
     version('2.18', sha256='99a8ca03e29851d96616ad0404b4aad7d9ee16f25c9f9708a11faf2810f7b226')
     version('2.17', sha256='0aac31e917c24cb3357f5a4d5566f2cc91a19ca41862f6c3c22dc60a629673b6')

--- a/var/spack/repos/builtin/packages/py-pygments/package.py
+++ b/var/spack/repos/builtin/packages/py-pygments/package.py
@@ -12,11 +12,6 @@ class PyPygments(PythonPackage):
     homepage = "http://pygments.org/"
     url      = "https://pypi.io/packages/source/P/Pygments/Pygments-2.4.2.tar.gz"
 
-    import_modules = [
-        'pygments', 'pygments.filters', 'pygments.formatters',
-        'pygments.lexers', 'pygments.styles'
-    ]
-
     version('2.4.2', sha256='881c4c157e45f30af185c1ffe8d549d48ac9127433f2c380c24b84572ad66297')
     version('2.3.1', sha256='5ffada19f6203563680669ee7f53b64dabbeb100eb51b61996085e99c03b284a')
     version('2.2.0', sha256='dbae1046def0efb574852fab9e90209b23f556367b5a320c0bcb871c77c3e8cc')

--- a/var/spack/repos/builtin/packages/py-pyparsing/package.py
+++ b/var/spack/repos/builtin/packages/py-pyparsing/package.py
@@ -11,8 +11,6 @@ class PyPyparsing(PythonPackage):
     homepage = "http://pyparsing.wikispaces.com/"
     url      = "https://pypi.io/packages/source/p/pyparsing/pyparsing-2.4.2.tar.gz"
 
-    import_modules = ['pyparsing']
-
     version('2.4.2',  sha256='6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80')
     version('2.4.0',  sha256='1873c03321fc118f4e9746baf201ff990ceb915f433f23b395f5580d1840cb2a')
     version('2.3.1',  sha256='66c9268862641abcac4a96ba74506e594c884e3f57690a696d21ad8210ed667a')

--- a/var/spack/repos/builtin/packages/py-pyproj/package.py
+++ b/var/spack/repos/builtin/packages/py-pyproj/package.py
@@ -14,7 +14,6 @@ class PyPyproj(PythonPackage):
     git      = "https://github.com/pyproj4/pyproj.git"
 
     maintainers = ['citibeth', 'adamjstewart']
-    import_modules = ['pyproj']
 
     version('2.2.0',   sha256='0a4f793cc93539c2292638c498e24422a2ec4b25cb47545addea07724b2a56e5')
     version('2.1.3',   sha256='99c52788b01a7bb9a88024bf4d40965c0a66a93d654600b5deacf644775f424d')

--- a/var/spack/repos/builtin/packages/py-pyqt4/package.py
+++ b/var/spack/repos/builtin/packages/py-pyqt4/package.py
@@ -17,13 +17,6 @@ class PyPyqt4(SIPPackage):
     url      = "http://sourceforge.net/projects/pyqt/files/PyQt4/PyQt-4.12.3/PyQt4_gpl_x11-4.12.3.tar.gz"
 
     sip_module = 'PyQt4.sip'
-    import_modules = [
-        'PyQt4', 'PyQt4.Qt', 'PyQt4.QtCore', 'PyQt4.QtDeclarative',
-        'PyQt4.QtDesigner', 'PyQt4.QtGui', 'PyQt4.QtHelp',
-        'PyQt4.QtMultimedia', 'PyQt4.QtNetwork', 'PyQt4.QtOpenGL',
-        'PyQt4.QtScript', 'PyQt4.QtScriptTools', 'PyQt4.QtSql', 'PyQt4.QtSvg',
-        'PyQt4.QtTest', 'PyQt4.QtWebKit', 'PyQt4.QtXml', 'PyQt4.QtXmlPatterns'
-    ]
 
     version('4.12.3', sha256='a00f5abef240a7b5852b7924fa5fdf5174569525dc076cd368a566619e56d472')
     version('4.11.3', sha256='853780dcdbe2e6ba785d703d059b096e1fc49369d3e8d41a060be874b8745686',

--- a/var/spack/repos/builtin/packages/py-pyqt5/package.py
+++ b/var/spack/repos/builtin/packages/py-pyqt5/package.py
@@ -17,14 +17,6 @@ class PyPyqt5(SIPPackage):
     list_url = "https://www.riverbankcomputing.com/software/pyqt/download5"
 
     sip_module = 'PyQt5.sip'
-    import_modules = [
-        'PyQt5', 'PyQt5.QtCore', 'PyQt5.QtGui', 'PyQt5.QtHelp',
-        'PyQt5.QtMultimedia', 'PyQt5.QtMultimediaWidgets', 'PyQt5.QtNetwork',
-        'PyQt5.QtOpenGL', 'PyQt5.QtPrintSupport', 'PyQt5.QtQml',
-        'PyQt5.QtQuick', 'PyQt5.QtSvg', 'PyQt5.QtTest', 'PyQt5.QtWebChannel',
-        'PyQt5.QtWebSockets', 'PyQt5.QtWidgets', 'PyQt5.QtXml',
-        'PyQt5.QtXmlPatterns'
-    ]
 
     version('5.13.0', sha256='0cdbffe5135926527b61cc3692dd301cd0328dd87eeaf1313e610787c46faff9')
     version('5.12.3', sha256='0db0fa37debab147450f9e052286f7a530404e2aaddc438e97a7dcdf56292110')

--- a/var/spack/repos/builtin/packages/py-pytest/package.py
+++ b/var/spack/repos/builtin/packages/py-pytest/package.py
@@ -12,8 +12,6 @@ class PyPytest(PythonPackage):
     homepage = "http://pytest.org/"
     url      = "https://pypi.io/packages/source/p/pytest/pytest-5.2.1.tar.gz"
 
-    import_modules = ['pytest']
-
     version('5.2.1', sha256='ca563435f4941d0cb34767301c27bc65c510cb82e90b9ecf9cb52dc2c63caaa0')
     version('5.1.1', sha256='c3d5020755f70c82eceda3feaf556af9a341334414a8eca521a18f463bcead88')
     version('4.6.5', sha256='8fc39199bdda3d9d025d3b1f4eb99a192c20828030ea7c9a0d2840721de7d347')

--- a/var/spack/repos/builtin/packages/py-python-dateutil/package.py
+++ b/var/spack/repos/builtin/packages/py-python-dateutil/package.py
@@ -12,10 +12,6 @@ class PyPythonDateutil(PythonPackage):
     homepage = "https://dateutil.readthedocs.io/"
     url      = "https://pypi.io/packages/source/p/python-dateutil/python-dateutil-2.8.0.tar.gz"
 
-    import_modules = [
-        'dateutil', 'dateutil.zoneinfo', 'dateutil.parser', 'dateutil.tz'
-    ]
-
     version('2.8.0', sha256='c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e')
     version('2.7.5', sha256='88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02')
     version('2.5.2', sha256='063907ef47f6e187b8fe0728952e4effb587a34f2dc356888646f9b71fbb2e4b')

--- a/var/spack/repos/builtin/packages/py-pytz/package.py
+++ b/var/spack/repos/builtin/packages/py-pytz/package.py
@@ -12,8 +12,6 @@ class PyPytz(PythonPackage):
     homepage = "http://pythonhosted.org/pytz"
     url      = "https://pypi.io/packages/source/p/pytz/pytz-2019.3.tar.gz"
 
-    import_modules = ['pytz']
-
     version('2019.3', sha256='b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be')
     version('2019.1', sha256='d747dd3d23d77ef44c6a3526e274af6efeb0a6f1afd5a69ba4d5be4098c8e141')
     version('2018.4', sha256='c06425302f2cf668f1bba7a0a03f3c1d34d4ebeef2c72003da308b3947c7f749')

--- a/var/spack/repos/builtin/packages/py-pywavelets/package.py
+++ b/var/spack/repos/builtin/packages/py-pywavelets/package.py
@@ -16,8 +16,6 @@ class PyPywavelets(PythonPackage):
 
     version('0.5.2', sha256='ce36e2f0648ea1781490b09515363f1f64446b0eac524603e5db5e180113bed9')
 
-    import_modules = ['pywt', 'pywt.data']
-
     depends_on('py-setuptools', type='build')
     depends_on('py-cython', type='build')
     depends_on('py-numpy@1.9.1:',  type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-rasterio/package.py
+++ b/var/spack/repos/builtin/packages/py-rasterio/package.py
@@ -17,7 +17,6 @@ class PyRasterio(PythonPackage):
     url      = "https://pypi.io/packages/source/r/rasterio/rasterio-1.0.24.tar.gz"
 
     maintainers = ['adamjstewart']
-    import_modules = ['rasterio', 'rasterio.rio']
 
     version('1.0.24', sha256='4839479621045211f66868ec49625979693450bc2e476f23e7e8ac4804eaf452')
     version('1.0a12', sha256='47d460326e04c64590ff56952271a184a6307f814efc34fb319c12e690585f3c')

--- a/var/spack/repos/builtin/packages/py-requests/package.py
+++ b/var/spack/repos/builtin/packages/py-requests/package.py
@@ -12,17 +12,6 @@ class PyRequests(PythonPackage):
     homepage = "http://python-requests.org"
     url = "https://pypi.io/packages/source/r/requests/requests-2.22.0.tar.gz"
 
-    import_modules = [
-        'requests', 'requests.packages', 'requests.packages.chardet',
-        'requests.packages.urllib3', 'requests.packages.idna',
-        'requests.packages.chardet.cli', 'requests.packages.urllib3.util',
-        'requests.packages.urllib3.packages',
-        'requests.packages.urllib3.contrib',
-        'requests.packages.urllib3.packages.ssl_match_hostname',
-        'requests.packages.urllib3.packages.backports',
-        'requests.packages.urllib3.contrib._securetransport'
-    ]
-
     version('2.22.0', sha256='11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4')
     version('2.21.0', sha256='502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e')
     version('2.14.2', sha256='a274abba399a23e8713ffd2b5706535ae280ebe2b8069ee6a941cb089440d153')

--- a/var/spack/repos/builtin/packages/py-rsa/package.py
+++ b/var/spack/repos/builtin/packages/py-rsa/package.py
@@ -12,8 +12,6 @@ class PyRsa(PythonPackage):
     homepage = "https://stuvel.eu/rsa"
     url      = "https://pypi.io/packages/source/r/rsa/rsa-3.4.2.tar.gz"
 
-    import_modules = ['rsa']
-
     version('4.0',   sha256='1a836406405730121ae9823e19c6e806c62bbad73f890574fff50efa4122c487')
     version('3.4.2', sha256='25df4e10c263fb88b5ace923dd84bf9aa7f5019687b5e55382ffcdb8bede9db5')
 

--- a/var/spack/repos/builtin/packages/py-s3transfer/package.py
+++ b/var/spack/repos/builtin/packages/py-s3transfer/package.py
@@ -12,8 +12,6 @@ class PyS3transfer(PythonPackage):
     homepage = "https://github.com/boto/s3transfer"
     url      = "https://pypi.io/packages/source/s/s3transfer/s3transfer-0.2.1.tar.gz"
 
-    import_modules = ['s3transfer']
-
     version('0.2.1', sha256='6efc926738a3cd576c2a79725fed9afde92378aa5c6a957e3af010cb019fac9d')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-scandir/package.py
+++ b/var/spack/repos/builtin/packages/py-scandir/package.py
@@ -12,8 +12,6 @@ class PyScandir(PythonPackage):
     homepage = "https://github.com/benhoyt/scandir"
     url      = "https://pypi.io/packages/source/s/scandir/scandir-1.9.0.tar.gz"
 
-    import_modules = ['scandir']
-
     version('1.10.0', sha256='4d4631f6062e658e9007ab3149a9b914f3548cb38bfb021c64f39a025ce578ae')
     version('1.9.0',  sha256='44975e209c4827fc18a3486f257154d34ec6eaec0f90fef0cca1caa482db7064')
     version('1.6',    sha256='e0278a2d4bc6c0569aedbe66bf26c8ab5b2b08378b3289de49257f23ac624338')

--- a/var/spack/repos/builtin/packages/py-scikit-learn/package.py
+++ b/var/spack/repos/builtin/packages/py-scikit-learn/package.py
@@ -16,22 +16,6 @@ class PyScikitLearn(PythonPackage):
     maintainers = ['adamjstewart']
     install_time_test_callbacks = ['install_test', 'import_module_test']
 
-    import_modules = [
-        'sklearn', 'sklearn.tree', 'sklearn.metrics', 'sklearn.ensemble',
-        'sklearn.experimental', 'sklearn.cluster',
-        'sklearn.feature_extraction', 'sklearn.__check_build',
-        'sklearn.semi_supervised', 'sklearn.gaussian_process',
-        'sklearn.compose', 'sklearn.datasets', 'sklearn.externals',
-        'sklearn.linear_model', 'sklearn.impute', 'sklearn.utils',
-        'sklearn.covariance', 'sklearn.neural_network',
-        'sklearn.feature_selection', 'sklearn.inspection', 'sklearn.svm',
-        'sklearn.manifold', 'sklearn.mixture', 'sklearn.preprocessing',
-        'sklearn.model_selection', 'sklearn._build_utils',
-        'sklearn.decomposition', 'sklearn.cross_decomposition',
-        'sklearn.neighbors', 'sklearn.metrics.cluster',
-        'sklearn.ensemble._hist_gradient_boosting'
-    ]
-
     version('master', branch='master')
     version('0.22.1', sha256='51ee25330fc244107588545c70e2f3570cfc4017cff09eed69d6e1d82a212b7d')
     version('0.22',   sha256='314abf60c073c48a1e95feaae9f3ca47a2139bd77cebb5b877c23a45c9e03012')

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -17,19 +17,6 @@ class PyScipy(PythonPackage):
     maintainers = ['adamjstewart']
     install_time_test_callbacks = ['install_test', 'import_module_test']
 
-    import_modules = [
-        'scipy', 'scipy._build_utils', 'scipy._lib', 'scipy.cluster',
-        'scipy.constants', 'scipy.fftpack', 'scipy.integrate',
-        'scipy.interpolate', 'scipy.io', 'scipy.linalg', 'scipy.misc',
-        'scipy.ndimage', 'scipy.odr', 'scipy.optimize', 'scipy.signal',
-        'scipy.sparse', 'scipy.spatial', 'scipy.special', 'scipy.stats',
-        'scipy.io.arff', 'scipy.io.harwell_boeing', 'scipy.io.matlab',
-        'scipy.optimize._lsq', 'scipy.sparse.csgraph', 'scipy.sparse.linalg',
-        'scipy.sparse.linalg.dsolve', 'scipy.sparse.linalg.eigen',
-        'scipy.sparse.linalg.isolve', 'scipy.sparse.linalg.eigen.arpack',
-        'scipy.sparse.linalg.eigen.lobpcg', 'scipy.special._precompute'
-    ]
-
     version('1.4.1',  sha256='dee1bbf3a6c8f73b6b218cb28eed8dd13347ea2f87d572ce19b289d6fd3fbc59')
     version('1.4.0',  sha256='31f7cfa93b01507c935c12b535e24812594002a02a56803d7cd063e9920d25e8')
     version('1.3.3',  sha256='64bf4e8ae0db2d42b58477817f648d81e77f0b381d0ea4427385bba3f959380a')

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -13,14 +13,6 @@ class PySetuptools(PythonPackage):
     homepage = "https://github.com/pypa/setuptools"
     url      = "https://pypi.io/packages/source/s/setuptools/setuptools-41.0.1.zip"
 
-    import_modules = [
-        'setuptools', 'pkg_resources', 'setuptools._vendor',
-        'setuptools.command', 'setuptools.extern',
-        'setuptools._vendor.packaging', 'pkg_resources._vendor',
-        'pkg_resources.extern', 'pkg_resources._vendor.packaging',
-        'easy_install'
-    ]
-
     version('41.4.0', sha256='7eae782ccf36b790c21bde7d86a4f303a441cd77036b25c559a602cf5186ce4d')
     version('41.0.1', sha256='a222d126f5471598053c9a77f4b5d4f26eaa1f150ad6e01dcf1a42e185d05613')
     version('41.0.0', sha256='79d30254b6fe7a8e672e43cd85f13a9f3f2a50080bc81d851143e2219ef0dcb1')

--- a/var/spack/repos/builtin/packages/py-shapely/package.py
+++ b/var/spack/repos/builtin/packages/py-shapely/package.py
@@ -14,10 +14,6 @@ class PyShapely(PythonPackage):
     url      = "https://pypi.io/packages/source/S/Shapely/Shapely-1.6.4.post2.tar.gz"
 
     maintainers = ['adamjstewart']
-    import_modules = [
-        'shapely', 'shapely.geometry', 'shapely.algorithms',
-        'shapely.examples', 'shapely.speedups', 'shapely.vectorized',
-    ]
 
     version('1.6.4.post2', sha256='c4b87bb61fc3de59fc1f85e71a79b0c709dc68364d9584473697aad4aa13240f')
     version('1.6.4', sha256='b10bc4199cfefcf1c0e5d932eac89369550320ca4bdf40559328d85f1ca4f655')

--- a/var/spack/repos/builtin/packages/py-six/package.py
+++ b/var/spack/repos/builtin/packages/py-six/package.py
@@ -12,8 +12,6 @@ class PySix(PythonPackage):
     homepage = "https://pypi.python.org/pypi/six"
     url      = "https://pypi.io/packages/source/s/six/six-1.11.0.tar.gz"
 
-    import_modules = ['six']
-
     version('1.12.0', sha256='d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73')
     version('1.11.0', sha256='70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9')
     version('1.10.0', sha256='105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a')

--- a/var/spack/repos/builtin/packages/py-snowballstemmer/package.py
+++ b/var/spack/repos/builtin/packages/py-snowballstemmer/package.py
@@ -13,8 +13,6 @@ class PySnowballstemmer(PythonPackage):
     homepage = "https://github.com/shibukawa/snowball_py"
     url      = "https://pypi.io/packages/source/s/snowballstemmer/snowballstemmer-2.0.0.tar.gz"
 
-    import_modules = ['snowballstemmer']
-
     version('2.0.0', sha256='df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52')
     version('1.2.1', sha256='919f26a68b2c17a7634da993d91339e288964f93c274f1343e3bbbe2096e1128')
 

--- a/var/spack/repos/builtin/packages/py-spefile/package.py
+++ b/var/spack/repos/builtin/packages/py-spefile/package.py
@@ -13,8 +13,6 @@ class PySpefile(PythonPackage):
     homepage = "https://github.com/conda-forge/spefile-feedstock"
     git      = "https://github.com/conda-forge/spefile-feedstock.git"
 
-    import_modules = ['spefile']
-
     version('1.6', commit='24394e066da8dee5e7608f556ca0203c9db217f9')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-sphinx/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx/package.py
@@ -12,16 +12,6 @@ class PySphinx(PythonPackage):
     homepage = "http://sphinx-doc.org"
     url      = "https://pypi.io/packages/source/S/Sphinx/Sphinx-2.2.0.tar.gz"
 
-    import_modules = [
-        'sphinx', 'sphinx.testing', 'sphinx.ext', 'sphinx.pycode',
-        'sphinx.search', 'sphinx.transforms', 'sphinx.builders',
-        'sphinx.directives', 'sphinx.util', 'sphinx.environment',
-        'sphinx.writers', 'sphinx.domains', 'sphinx.locale',
-        'sphinx.ext.napoleon', 'sphinx.ext.autosummary', 'sphinx.pycode.pgen2',
-        'sphinx.transforms.post_transforms', 'sphinx.util.stemmer',
-        'sphinx.environment.collectors', 'sphinx.environment.adapters'
-    ]
-
     version('2.2.0', sha256='0d586b0f8c2fc3cc6559c5e8fd6124628110514fda0e5d7c82e682d749d2e845')
     version('1.8.4', sha256='c1c00fc4f6e8b101a0d037065043460dffc2d507257f2f11acaed71fd2b0c83c')
     version('1.8.2', sha256='120732cbddb1b2364471c3d9f8bfd4b0c5b550862f99a65736c77f970b142aea')

--- a/var/spack/repos/builtin/packages/py-sphinxcontrib-bibtex/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinxcontrib-bibtex/package.py
@@ -12,8 +12,6 @@ class PySphinxcontribBibtex(PythonPackage):
     homepage = "https://pypi.python.org/pypi/sphinxcontrib-bibtex"
     url      = "https://pypi.io/packages/source/s/sphinxcontrib-bibtex/sphinxcontrib-bibtex-0.3.5.tar.gz"
 
-    import_modules = ['sphinxcontrib', 'sphinxcontrib.bibtex']
-
     version('0.3.5', sha256='c93e2b4a0d14f0ab726f95f0a33c1675965e9df3ed04839635577b8f978206cd')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-sphinxcontrib-programoutput/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinxcontrib-programoutput/package.py
@@ -13,9 +13,6 @@ class PySphinxcontribProgramoutput(PythonPackage):
     homepage = "https://sphinxcontrib-programoutput.readthedocs.org/"
     url      = "https://pypi.io/packages/source/s/sphinxcontrib-programoutput/sphinxcontrib-programoutput-0.15.tar.gz"
 
-    # FIXME: These import tests don't work for some reason
-    # import_modules = ['sphinxcontrib', 'sphinxcontrib.programoutput']
-
     version('0.15', sha256='80dd5b4eab780a13ff2c23500cac3dbf0e04ef9976b409ef25a47c263ef8ab94')
     version('0.10', sha256='fdee94fcebb0d8fddfccac5c4fa560f6177d5340c4349ee447c890bea8857094')
 

--- a/var/spack/repos/builtin/packages/py-sphinxcontrib-websupport/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinxcontrib-websupport/package.py
@@ -13,12 +13,6 @@ class PySphinxcontribWebsupport(PythonPackage):
     homepage = "http://sphinx-doc.org/"
     url      = "https://pypi.io/packages/source/s/sphinxcontrib-websupport/sphinxcontrib-websupport-1.1.2.tar.gz"
 
-    # FIXME: These import tests don't work for some reason
-    # import_modules = [
-    #     'sphinxcontrib', 'sphinxcontrib.websupport',
-    #     'sphinxcontrib.websupport.storage', 'sphinxcontrib.websupport.search'
-    # ]
-
     version('1.1.2', sha256='1501befb0fdf1d1c29a800fdbf4ef5dc5369377300ddbdd16d2cd40e54c6eefc')
     version('1.1.0', sha256='9de47f375baf1ea07cdb3436ff39d7a9c76042c10a769c52353ec46e4e8fc3b9')
     version('1.0.1', sha256='7a85961326aa3a400cd4ad3c816d70ed6f7c740acd7ce5d78cd0a67825072eb9')

--- a/var/spack/repos/builtin/packages/py-tables/package.py
+++ b/var/spack/repos/builtin/packages/py-tables/package.py
@@ -13,10 +13,6 @@ class PyTables(PythonPackage):
     homepage = "http://www.pytables.org/"
     url      = "https://pypi.io/packages/source/t/tables/tables-3.6.1.tar.gz"
 
-    import_modules = [
-        'tables', 'tables.misc', 'tables.nodes', 'tables.scripts'
-    ]
-
     version('3.6.1', sha256='49a972b8a7c27a8a173aeb05f67acb45fe608b64cd8e9fa667c0962a60b71b49')
     version('3.6.0', sha256='db3488214864fb313a611fca68bf1c9019afe4e7877be54d0e61c84416603d4d')
     version('3.5.2', sha256='b220e32262bab320aa41d33125a7851ff898be97c0de30b456247508e2cc33c2')

--- a/var/spack/repos/builtin/packages/py-testrepository/package.py
+++ b/var/spack/repos/builtin/packages/py-testrepository/package.py
@@ -12,14 +12,6 @@ class PyTestrepository(PythonPackage):
     homepage = "https://launchpad.net/testrepository"
     url      = "https://pypi.io/packages/source/t/testrepository/testrepository-0.0.20.tar.gz"
 
-    import_modules = [
-        'testrepository', 'testrepository.arguments',
-        'testrepository.commands', 'testrepository.repository',
-        'testrepository.tests', 'testrepository.tests.arguments',
-        'testrepository.tests.commands', 'testrepository.tests.repository',
-        'testrepository.tests.ui', 'testrepository.ui',
-    ]
-
     version('0.0.20', sha256='752449bc98c20253ec4611c40564aea93d435a5bf3ff672208e01cc10e5858eb')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-tifffile/package.py
+++ b/var/spack/repos/builtin/packages/py-tifffile/package.py
@@ -12,8 +12,6 @@ class PyTifffile(PythonPackage):
     homepage = "https://github.com/blink1073/tifffile"
     url      = "https://pypi.io/packages/source/t/tifffile/tifffile-0.12.1.tar.gz"
 
-    import_modules = ['tifffile']
-
     version('0.12.1', sha256='802367effe86b0d1e64cb5c2ed886771f677fa63260b945e51a27acccdc08fa1')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-tomopy/package.py
+++ b/var/spack/repos/builtin/packages/py-tomopy/package.py
@@ -14,11 +14,6 @@ class PyTomopy(PythonPackage):
     homepage = "http://tomopy.readthedocs.io/en/latest/index.html"
     url      = "https://github.com/tomopy/tomopy/archive/1.0.0.tar.gz"
 
-    import_modules = [
-        'tomopy', 'doc', 'tomopy.util', 'tomopy.sim', 'tomopy.recon',
-        'tomopy.prep', 'tomopy.misc', 'tomopy.io', 'doc.demo'
-    ]
-
     version('1.0.0', sha256='ee45f7a062e5a66d6f18a904d2e204e48d85a1ce1464156f9e2f6353057dfe4c')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-toolz/package.py
+++ b/var/spack/repos/builtin/packages/py-toolz/package.py
@@ -12,8 +12,6 @@ class PyToolz(PythonPackage):
     homepage = "http://github.com/pytoolz/toolz/"
     url      = "https://pypi.io/packages/source/t/toolz/toolz-0.9.0.tar.gz"
 
-    import_modules = ['toolz', 'tlz', 'toolz.curried', 'toolz.sandbox']
-
     version('0.9.0', sha256='929f0a7ea7f61c178bd951bdae93920515d3fbdbafc8e6caf82d752b9b3b31c9')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -16,39 +16,6 @@ class PyTorch(PythonPackage, CudaPackage):
     install_time_test_callbacks = ['install_test', 'import_module_test']
 
     maintainers = ['adamjstewart']
-    import_modules = [
-        'tools', 'caffe2', 'torch', 'tools.cwrap', 'tools.autograd',
-        'tools.setup_helpers', 'tools.shared', 'tools.jit', 'tools.pyi',
-        'tools.nnwrap', 'tools.cwrap.plugins', 'caffe2.core', 'caffe2.proto',
-        'caffe2.python', 'caffe2.distributed', 'caffe2.perfkernels',
-        'caffe2.experiments', 'caffe2.contrib', 'caffe2.quantization',
-        'caffe2.core.nomnigraph', 'caffe2.python.ideep', 'caffe2.python.mint',
-        'caffe2.python.layers', 'caffe2.python.onnx', 'caffe2.python.trt',
-        'caffe2.python.models', 'caffe2.python.docs', 'caffe2.python.modeling',
-        'caffe2.python.mkl', 'caffe2.python.examples',
-        'caffe2.python.predictor', 'caffe2.python.helpers',
-        'caffe2.python.rnn', 'caffe2.python.onnx.bin',
-        'caffe2.python.models.seq2seq', 'caffe2.experiments.python',
-        'caffe2.contrib.nnpack', 'caffe2.contrib.warpctc',
-        'caffe2.contrib.nccl', 'caffe2.contrib.playground',
-        'caffe2.contrib.gloo', 'caffe2.contrib.script', 'caffe2.contrib.prof',
-        'caffe2.contrib.tensorboard', 'caffe2.contrib.aten',
-        'caffe2.contrib.playground.resnetdemo',
-        'caffe2.contrib.script.examples', 'caffe2.contrib.aten.docs',
-        'caffe2.quantization.server', 'torch.nn', 'torch.onnx',
-        'torch.distributed', 'torch.autograd', 'torch.multiprocessing',
-        'torch.cuda', 'torch.backends', 'torch.optim', 'torch.utils',
-        'torch.contrib', 'torch.jit', 'torch.sparse',
-        'torch.for_onnx', 'torch._thnn', 'torch.distributions',
-        'torch.nn.parallel', 'torch.nn._functions', 'torch.nn.backends',
-        'torch.nn.utils', 'torch.nn.modules', 'torch.nn.parallel.deprecated',
-        'torch.nn._functions.thnn', 'torch.distributed.deprecated',
-        'torch.autograd._functions', 'torch.backends.cuda',
-        'torch.backends.mkl', 'torch.backends.mkldnn', 'torch.backends.openmp',
-        'torch.backends.cudnn', 'torch.utils.backcompat',
-        'torch.utils.bottleneck', 'torch.utils.ffi', 'torch.utils.tensorboard',
-        'torch.utils.data', 'torch.utils.data._utils'
-    ]
 
     version('master', branch='master', submodules=True)
     version('1.4.0', tag='v1.4.0', submodules=True)

--- a/var/spack/repos/builtin/packages/py-torchvision/package.py
+++ b/var/spack/repos/builtin/packages/py-torchvision/package.py
@@ -14,12 +14,6 @@ class PyTorchvision(PythonPackage):
     url      = "https://github.com/pytorch/vision/archive/v0.5.0.tar.gz"
 
     maintainers = ['adamjstewart']
-    import_modules = [
-        'torchvision', 'torchvision.datasets', 'torchvision.models',
-        'torchvision.transforms', 'torchvision.ops',
-        'torchvision.models.segmentation',
-        'torchvision.models.detection'
-    ]
 
     version('0.5.0', sha256='eb9afc93df3d174d975ee0914057a9522f5272310b4d56c150b955c287a4d74d')
     version('0.4.2', sha256='1184a27eab85c9e784bacc6f9d6fec99e168ab4eda6047ef9f709e7fdb22d8f9')

--- a/var/spack/repos/builtin/packages/py-typing/package.py
+++ b/var/spack/repos/builtin/packages/py-typing/package.py
@@ -13,8 +13,6 @@ class PyTyping(PythonPackage):
     homepage = "https://docs.python.org/3/library/typing.html"
     url      = "https://pypi.io/packages/source/t/typing/typing-3.7.4.1.tar.gz"
 
-    import_modules = ['typing']
-
     version('3.7.4.1', sha256='91dfe6f3f706ee8cc32d38edbbf304e9b7583fb37108fef38229617f8b3eba23')
     version('3.6.6', sha256='4027c5f6127a6267a435201981ba156de91ad0d1d98e9ddc2aa173453453492d')
     version('3.6.4', sha256='d400a9344254803a2368533e4533a4200d21eb7b6b729c173bc38201a74db3f2')

--- a/var/spack/repos/builtin/packages/py-vermin/package.py
+++ b/var/spack/repos/builtin/packages/py-vermin/package.py
@@ -12,8 +12,6 @@ class PyVermin(PythonPackage):
     homepage = "https://github.com/netromdk/vermin"
     url      = "https://github.com/netromdk/vermin/archive/v0.10.0.tar.gz"
 
-    import_modules = ['vermin']
-
     version('0.10.0', sha256='3458a4d084bba5c95fd7208888aaf0e324a07ee092786ee4e5529f539ab4951f')
 
     depends_on('python@2.7:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-wxmplot/package.py
+++ b/var/spack/repos/builtin/packages/py-wxmplot/package.py
@@ -12,8 +12,6 @@ class PyWxmplot(PythonPackage):
     homepage = "https://newville.github.io/wxmplot/"
     url      = "https://pypi.io/packages/source/w/wxmplot/wxmplot-0.9.38.tar.gz"
 
-    import_modules = ['wxmplot']
-
     version('0.9.38', sha256='82dc64abb42bdd03ec7067a3aa2a475001f2bc8e4772149bae47facf460c0081')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-wxpython/package.py
+++ b/var/spack/repos/builtin/packages/py-wxpython/package.py
@@ -12,18 +12,6 @@ class PyWxpython(PythonPackage):
     homepage = "https://www.wxpython.org/"
     url      = "https://pypi.io/packages/source/w/wxPython/wxPython-4.0.6.tar.gz"
 
-    import_modules = [
-        'wx', 'wx.tools', 'wx.py', 'wx.lib', 'wx.lib.analogclock',
-        'wx.lib.floatcanvas', 'wx.lib.plot', 'wx.lib.mixins', 'wx.lib.gizmos',
-        'wx.lib.art', 'wx.lib.pdfviewer', 'wx.lib.colourchooser',
-        'wx.lib.masked', 'wx.lib.ogl', 'wx.lib.wxcairo', 'wx.lib.agw',
-        'wx.lib.pubsub', 'wx.lib.editor', 'wx.lib.analogclock.lib_setup',
-        'wx.lib.floatcanvas.Utilities', 'wx.lib.plot.examples',
-        'wx.lib.agw.aui', 'wx.lib.agw.ribbon', 'wx.lib.agw.persist',
-        'wx.lib.pubsub.core', 'wx.lib.pubsub.utils', 'wx.lib.pubsub.core.arg1',
-        'wx.lib.pubsub.core.kwargs'
-    ]
-
     version('4.0.6', sha256='35cc8ae9dd5246e2c9861bb796026bbcb9fb083e4d49650f776622171ecdab37')
 
     depends_on('wxwidgets')

--- a/var/spack/repos/builtin/packages/py-zope-event/package.py
+++ b/var/spack/repos/builtin/packages/py-zope-event/package.py
@@ -12,10 +12,6 @@ class PyZopeEvent(PythonPackage):
     homepage = "http://github.com/zopefoundation/zope.event"
     url      = "https://pypi.io/packages/source/z/zope.event/zope.event-4.3.0.tar.gz"
 
-    # FIXME: No idea why this import test fails.
-    # Maybe some kind of namespace issue?
-    # import_modules = ['zope.event']
-
     version('4.3.0', sha256='e0ecea24247a837c71c106b0341a7a997e3653da820d21ef6c08b32548f733e7')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-zope-interface/package.py
+++ b/var/spack/repos/builtin/packages/py-zope-interface/package.py
@@ -15,10 +15,6 @@ class PyZopeInterface(PythonPackage):
     homepage = "https://github.com/zopefoundation/zope.interface"
     url      = "https://pypi.io/packages/source/z/zope.interface/zope.interface-4.5.0.tar.gz"
 
-    # FIXME: No idea why these import tests fail.
-    # Maybe some kind of namespace issue?
-    # import_modules = ['zope.interface', 'zope.interface.common']
-
     version('4.5.0', sha256='57c38470d9f57e37afb460c399eb254e7193ac7fb8042bd09bdc001981a9c74c')
 
     depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))


### PR DESCRIPTION
Previously, users were required to override `import_modules` for every PythonPackage that they wanted import tests for. Now, we automatically locate module files and packages. Users can still override `import_modules` for weird cases.

- [ ] Automatically detect `import_modules`
- [ ] Remove no longer needed `import_modules` from packages
- [ ] Update PythonPackage documentation

Note that these `import_module_test`s now exist for all 850+ PythonPackages in Spack, and these tests can be run after installation has already finished, making these great smoke tests for existing Spack installations.