### PR TITLE
flatbuffers: Allow building shared libraries

### DIFF
--- a/var/spack/repos/builtin/packages/flatbuffers/package.py
+++ b/var/spack/repos/builtin/packages/flatbuffers/package.py
@@ -17,3 +17,16 @@ class Flatbuffers(CMakePackage):
     version('1.10.0', sha256='3714e3db8c51e43028e10ad7adffb9a36fc4aa5b1a363c2d0c4303dd1be59a7c')
     version('1.9.0', sha256='5ca5491e4260cacae30f1a5786d109230db3f3a6e5a0eb45d0d0608293d247e3')
     version('1.8.0', sha256='c45029c0a0f1a88d416af143e34de96b3091642722aa2d8c090916c6d1498c2e')
+
+    variant('shared', default=True,
+            description='Build shared instead of static libraries')
+
+    def cmake_args(self):
+        args = []
+        args.append('-DFLATBUFFERS_BUILD_SHAREDLIB={0}'.format(
+            'ON' if '+shared' in self.spec else 'OFF'))
+        args.append('-DFLATBUFFERS_BUILD_FLATLIB={0}'.format(
+            'ON' if '+shared' not in self.spec else 'OFF'))
+        if 'darwin' in self.spec.architecture:
+            args.append('-DCMAKE_MACOSX_RPATH=ON')
+        return args


### PR DESCRIPTION
Added a shared variant, that switches between shared and static library building, like with most cmake packages.