### PR TITLE
Cray bugfix: TERM missing while reading default target

### DIFF
--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -7,7 +7,7 @@ import os
 import re
 import llnl.util.tty as tty
 from spack.paths import build_env_path
-from spack.util.executable import which
+from spack.util.executable import Executable
 from spack.architecture import Platform, Target, NoPlatformError
 from spack.operating_systems.cray_frontend import CrayFrontend
 from spack.operating_systems.cnl import Cnl
@@ -117,9 +117,9 @@ class Cray(Platform):
         '''
         # env -i /bin/bash -lc echo $CRAY_CPU_TARGET 2> /dev/null
         if getattr(self, 'default', None) is None:
-            env = which('env')
             output = Executable('/bin/bash')('-lc', 'echo $CRAY_CPU_TARGET',
-                env={'TERM': os.environ['TERM']}, output=str, error=os.devnull)
+                                             env={'TERM': os.environ['TERM']},
+                                             output=str, error=os.devnull)
             output = ''.join(output.split())  # remove all whitespace
             if output:
                 self.default = output

--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -61,7 +61,7 @@ class Cray(Platform):
                 _target = os.environ.get('SPACK_' + name.upper())
             if _target is None and name == 'back_end':
                 _target = self._default_target_from_env()
-            if _target is not None:
+            if _target:
                 safe_name = _target.replace('-', '_')
                 setattr(self, name, safe_name)
                 self.add_target(name, self.targets[safe_name])
@@ -118,7 +118,8 @@ class Cray(Platform):
         # env -i /bin/bash -lc echo $CRAY_CPU_TARGET 2> /dev/null
         if getattr(self, 'default', None) is None:
             env = which('env')
-            output = env("-i", "/bin/bash", "-lc", "echo $CRAY_CPU_TARGET",
+            output = env("-i", "TERM=%s" % os.environ['TERM'],
+                         "/bin/bash", "-lc", "echo $CRAY_CPU_TARGET",
                          output=str, error=os.devnull)
             self.default = output.strip()
             tty.debug("Found default module:%s" % self.default)

--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -61,7 +61,7 @@ class Cray(Platform):
                 _target = os.environ.get('SPACK_' + name.upper())
             if _target is None and name == 'back_end':
                 _target = self._default_target_from_env()
-            if _target:
+            if _target is not None:
                 safe_name = _target.replace('-', '_')
                 setattr(self, name, safe_name)
                 self.add_target(name, self.targets[safe_name])
@@ -118,11 +118,12 @@ class Cray(Platform):
         # env -i /bin/bash -lc echo $CRAY_CPU_TARGET 2> /dev/null
         if getattr(self, 'default', None) is None:
             env = which('env')
-            output = env("-i", "TERM=%s" % os.environ['TERM'],
-                         "/bin/bash", "-lc", "echo $CRAY_CPU_TARGET",
-                         output=str, error=os.devnull)
-            self.default = output.strip()
-            tty.debug("Found default module:%s" % self.default)
+            output = Executable('/bin/bash')('-lc', 'echo $CRAY_CPU_TARGET',
+                env={'TERM': os.environ['TERM']}, output=str, error=os.devnull)
+            output = ''.join(output.split())  # remove all whitespace
+            if output:
+                self.default = output
+                tty.debug("Found default module:%s" % self.default)
         return self.default
 
     def _avail_targets(self):


### PR DESCRIPTION
Bug: Spack hangs on some Cray machines

Reason: The `TERM` environment variable is necessary to run `bash -lc "echo $CRAY_CPU_TARGET"`, but we run that command within `env -i`, which wipes the environment.

Fix: Manually forward the `TERM` environment variable to `env -i /bin/bash -lc "echo $CRAY_CPU_TARGET"`