### PR TITLE
Bugfix: Spack fails when the system python is not built with xml support

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -946,7 +946,7 @@ class SvnFetchStrategy(VCSFetchStrategy):
     def get_source_id(self):
         try:
             import xml.etree.ElementTree
-        except:
+        except ImportError:
             # This python install doesn't have xml support
             output = self.svn('info', self.url, output=str)
             if not output:


### PR DESCRIPTION
We import xml in `lib/spack/spack/fetch_strategy.py` because we use it to compute the source id.

Solution: only use xml for svn source_id if python has xml support, and only import within the function that needs it. Code for the "no xml" case taken from the pre-xml version of the function.