### PR TITLE
libgcrypt: fix macOS tests

### DIFF
--- a/var/spack/repos/builtin/packages/libgcrypt/package.py
+++ b/var/spack/repos/builtin/packages/libgcrypt/package.py
@@ -7,14 +7,10 @@ from spack import *
 
 
 class Libgcrypt(AutotoolsPackage):
-    """Libgcrypt is a general purpose cryptographic library based on
-    the code from GnuPG. It provides functions for all cryptographic
-    building blocks: symmetric ciphers, hash algorithms, MACs, public
-    key algorithms, large integer functions, random numbers and a lot
-    of supporting functions."""
+    """Cryptographic library based on the code from GnuPG."""
 
-    homepage = "http://www.gnu.org/software/libgcrypt/"
-    url = "https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.8.5.tar.bz2"
+    homepage = "https://gnupg.org/software/libgcrypt/index.html"
+    url      = "https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.8.5.tar.bz2"
 
     version('1.8.5', sha256='3b4a2a94cb637eff5bdebbcaf46f4d95c4f25206f459809339cdada0eb577ac3')
     version('1.8.4', sha256='f638143a0672628fde0cad745e9b14deb85dffb175709cacc1f4fe24b93f2227')
@@ -23,3 +19,18 @@ class Libgcrypt(AutotoolsPackage):
     version('1.6.2', sha256='de084492a6b38cdb27b67eaf749ceba76bf7029f63a9c0c3c1b05c88c9885c4c')
 
     depends_on('libgpg-error@1.25:')
+
+    def check(self):
+        # Without this hack, `make check` fails on macOS when SIP is enabled
+        # https://bugs.gnupg.org/gnupg/issue2056
+        # https://github.com/Homebrew/homebrew-core/pull/3004
+        if self.spec.satisfies('platform=darwin'):
+            old = self.prefix.lib.join('libgcrypt.20.dylib')
+            new = join_path(
+                self.stage.source_path, 'src', '.libs', 'libgcrypt.20.dylib')
+            filename = 'tests/.libs/random'
+
+            install_name_tool = Executable('install_name_tool')
+            install_name_tool('-change', old, new, filename)
+
+        make('check')


### PR DESCRIPTION
Successfully builds and passes all tests on macOS 10.15.3 with Clang 11.0.0.