### PR TITLE
eigen variants have been removed

### DIFF
--- a/var/spack/repos/builtin/packages/libmesh/package.py
+++ b/var/spack/repos/builtin/packages/libmesh/package.py
@@ -79,10 +79,7 @@ class Libmesh(AutotoolsPackage):
               'variant.')
 
     depends_on('boost', when='+boost')
-    # The Scotch dependency of Eigen is not used by libMesh. Since Scotch can
-    # only be used with certain versions of flex it conflicts with several
-    # versions of GCC, so explicitly disable it.
-    depends_on('eigen~scotch', when='+eigen')
+    depends_on('eigen', when='+eigen')
     depends_on('hdf5+mpi', when='+hdf5+mpi')
     depends_on('mpi', when='+mpi')
     depends_on('mpi', when='+slepc')

--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -105,7 +105,7 @@ class Opencv(CMakePackage, CudaPackage):
     # the current development branch of OpenCV. See #8461 for more information.
     patch('dnn_cuda.patch', when='@3.3.0:3.4.1+cuda+dnn')
 
-    depends_on('eigen~mpfr', when='+eigen', type='build')
+    depends_on('eigen', when='+eigen', type='build')
 
     depends_on('zlib', when='+zlib')
     depends_on('libpng', when='+png')

--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -105,8 +105,7 @@ class Opencv(CMakePackage, CudaPackage):
     # the current development branch of OpenCV. See #8461 for more information.
     patch('dnn_cuda.patch', when='@3.3.0:3.4.1+cuda+dnn')
 
-    depends_on('eigen', when='+eigen', type='build')
-
+    depends_on('eigen', when='+eigen')
     depends_on('zlib', when='+zlib')
     depends_on('libpng', when='+png')
     depends_on('jpeg', when='+jpeg')


### PR DESCRIPTION
ref: https://github.com/spack/spack/pull/15357

CC: @alalazo @adamjstewart 

I think I got them all, but maybe it would be good to have a second person fact check.  I was just grepping for `depends_on` piped to `grep -i eigen` and checking that `spack spec <pkg>+eigen` can concretize.  Prior to this you'll get an error.