### PR TITLE
sourceware.org no longer supports https downloads

### DIFF
--- a/var/spack/repos/builtin/packages/bzip2/package.py
+++ b/var/spack/repos/builtin/packages/bzip2/package.py
@@ -14,7 +14,7 @@ class Bzip2(Package):
     and six times faster at decompression."""
 
     homepage = "https://sourceware.org/bzip2/"
-    url      = "https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz"
+    url      = "ftp://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz"
 
     # The server is sometimes a bit slow to respond
     fetch_options = {'timeout': 60}

--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -17,8 +17,8 @@ class Elfutils(AutotoolsPackage):
     version of elfutils."""
 
     homepage = "https://fedorahosted.org/elfutils/"
-    url      = "ftp://sourceware.org/elfutils/ftp/0.178/elfutils-0.178.tar.bz2"
-    list_url = "ftp://sourceware.org/elfutils/ftp"
+    url      = "ftp://sourceware.org/pub/elfutils/0.178/elfutils-0.178.tar.bz2"
+    list_url = "https://sourceware.org/elfutils/ftp"
     list_depth = 1
 
     # Sourceware is often slow to respond.

--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -17,8 +17,8 @@ class Elfutils(AutotoolsPackage):
     version of elfutils."""
 
     homepage = "https://fedorahosted.org/elfutils/"
-    url      = "https://sourceware.org/elfutils/ftp/0.178/elfutils-0.178.tar.bz2"
-    list_url = "https://sourceware.org/elfutils/ftp"
+    url      = "ftp://sourceware.org/elfutils/ftp/0.178/elfutils-0.178.tar.bz2"
+    list_url = "ftp://sourceware.org/elfutils/ftp"
     list_depth = 1
 
     # Sourceware is often slow to respond.


### PR DESCRIPTION
change the urls used for downloads from sourceware.org to use ftp rather than https. https no longer supports access to download files.

this change is urgent to fix dependence issues for the "hpctoolkit" package.

other interested parties: @mwkrentel @martyitz @mxz297