### PR TITLE
exiv2: add zlib and expat dependency.

### DIFF
--- a/var/spack/repos/builtin/packages/exiv2/package.py
+++ b/var/spack/repos/builtin/packages/exiv2/package.py
@@ -15,3 +15,6 @@ class Exiv2(CMakePackage):
     url      = "https://github.com/Exiv2/exiv2/archive/v0.27.2.tar.gz"
 
     version('0.27.2', sha256='3dbcaf01fbc5b98d42f091d1ff0d4b6cd9750dc724de3d9c0d113948570b2934')
+
+    depends_on('zlib', type='link')
+    depends_on('expat@2.2.6:', type='link')


### PR DESCRIPTION
exiv2 use zlib and expat.
https://github.com/Exiv2/exiv2#24-dependencies
But the dependencies are missing.
This PR is added the dependencies.