### PR TITLE
fast-global-file-status: add openssl dependency.

### DIFF
--- a/var/spack/repos/builtin/packages/fast-global-file-status/package.py
+++ b/var/spack/repos/builtin/packages/fast-global-file-status/package.py
@@ -18,6 +18,7 @@ class FastGlobalFileStatus(AutotoolsPackage):
     depends_on('mrnet')
     depends_on('mount-point-attributes')
     depends_on('mpi')
+    depends_on('openssl')
 
     def configure_args(self):
         spec = self.spec


### PR DESCRIPTION
fast-file-status is required openssl.
https://github.com/LLNL/FastGlobalFileStatus/blob/master/README line 50
But the dependency is missing.
This PR add openssl dependency.