### PR TITLE
bazel: add missing dependency on zip

### DIFF
--- a/var/spack/repos/builtin/packages/bazel/package.py
+++ b/var/spack/repos/builtin/packages/bazel/package.py
@@ -92,6 +92,7 @@ class Bazel(Package):
     # https://docs.bazel.build/versions/master/install-compile-source.html#bootstrap-unix-prereq
     depends_on('jdk@1.8.0:1.8.999', type=('build', 'run'))
     depends_on('python', type=('build', 'run'))
+    depends_on('zip', type=('build', 'run'))
 
     # Pass Spack environment variables to the build
     patch('bazelruleclassprovider-0.25.patch', when='@0.25:')


### PR DESCRIPTION
bazel needs working zip / unzip executables as pointed out in https://docs.bazel.build/versions/master/install.html .