### PR TITLE
bugfix: fix install_missing_compilers option bug from v0.14.0

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -182,6 +182,9 @@ def _packages_needed_to_bootstrap_compiler(pkg):
     # concrete CompilerSpec has less info than concrete Spec
     # concretize as Spec to add that information
     dep.concretize()
+    # mark compiler as depended-on by the package that uses it
+    dep._dependents[pkg.name] = spack.spec.DependencySpec(
+        pkg.spec, dep, ('build',))
     packages = [(s.package, False) for
                 s in dep.traverse(order='post', root=False)]
     packages.append((dep.package, True))
@@ -1548,6 +1551,21 @@ class BuildTask(object):
         self.dependencies = set(package_id(d.package) for d in
                                 self.spec.dependencies() if
                                 package_id(d.package) != self.pkg_id)
+
+        # Handle bootstrapped compiler
+        #
+        # The boostrapped compiler is not a dependency in the spec, but it is
+        # a dependency of the build task. Here we add it to self.dependencies
+        compiler_spec = self.spec.compiler
+        arch_spec = self.spec.architecture
+        if not spack.compilers.compilers_for_spec(compiler_spec,
+                                                  arch_spec=arch_spec):
+            # The compiler is in the queue, identify it as dependency
+            dep = spack.compilers.pkg_spec_for_compiler(compiler_spec)
+            dep.architecture = arch_spec
+            dep.concretize()
+            dep_id = package_id(dep.package)
+            self.dependencies.add(dep_id)
 
         # List of uninstalled dependencies, which is used to establish
         # the priority of the build task.

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1554,7 +1554,7 @@ class BuildTask(object):
 
         # Handle bootstrapped compiler
         #
-        # The boostrapped compiler is not a dependency in the spec, but it is
+        # The bootstrapped compiler is not a dependency in the spec, but it is
         # a dependency of the build task. Here we add it to self.dependencies
         compiler_spec = self.spec.compiler
         arch_spec = self.spec.architecture


### PR DESCRIPTION
Bug: when installing with `install_missing_compilers: true` in the config.yaml, leaf nodes of the package will be pulled from the queue for installation before the underlying compiler is installed.

Fix: Mark bootstrapped compilers as having a dependent of the package they are bootstrapped for. Do not mark the package as having a dependency on the compiler, as that would change the hash. Rather, we separately compute the compiler, if not already installed, as one of the dependents of the BuildTask object when pushing tasks to the queue.

To reproduce, try to install the following environment to a Spack instance in which `gcc@5.5.0` is not already configured as an available compiler.

```
spack:
  specs: [zlib%gcc@5.5.0]
  config:
    install_missing_compilers: true
```