### PR TITLE
r: Lower optimization level when using Fujitsu compiler@4.1.0.

### DIFF
--- a/var/spack/repos/builtin/packages/r/change_optflags_tmp.patch
+++ b/var/spack/repos/builtin/packages/r/change_optflags_tmp.patch
@@ -1,0 +1,67 @@
+diff -ur R-3.6.3.org/configure R-3.6.3/configure
+--- R-3.6.3.org/configure	2020-03-09 11:09:16.060825352 +0900
++++ R-3.6.3/configure	2020-03-09 11:10:47.011280195 +0900
+@@ -6470,13 +6470,13 @@
+   CFLAGS=$ac_save_CFLAGS
+ elif test $ac_cv_prog_cc_g = yes; then
+   if test "$GCC" = yes; then
+-    CFLAGS="-g -O2"
++    CFLAGS="-g -O1"
+   else
+     CFLAGS="-g"
+   fi
+ else
+   if test "$GCC" = yes; then
+-    CFLAGS="-O2"
++    CFLAGS="-O1"
+   else
+     CFLAGS=
+   fi
+@@ -7445,13 +7445,13 @@
+   FCFLAGS=$ac_save_FCFLAGS
+ elif test $ac_cv_prog_fc_g = yes; then
+   if test "x$ac_cv_fc_compiler_gnu" = xyes; then
+-    FCFLAGS="-g -O2"
++    FCFLAGS="-g -O1"
+   else
+     FCFLAGS="-g"
+   fi
+ else
+   if test "x$ac_cv_fc_compiler_gnu" = xyes; then
+-    FCFLAGS="-O2"
++    FCFLAGS="-O1"
+   else
+     FCFLAGS=
+   fi
+@@ -7717,13 +7717,13 @@
+   CXXFLAGS=$ac_save_CXXFLAGS
+ elif test $ac_cv_prog_cxx_g = yes; then
+   if test "$GXX" = yes; then
+-    CXXFLAGS="-g -O2"
++    CXXFLAGS="-g -O1"
+   else
+     CXXFLAGS="-g"
+   fi
+ else
+   if test "$GXX" = yes; then
+-    CXXFLAGS="-O2"
++    CXXFLAGS="-O1"
+   else
+     CXXFLAGS=
+   fi
+@@ -8336,13 +8336,13 @@
+   OBJCFLAGS=$ac_save_OBJCFLAGS
+ elif test $ac_cv_prog_objc_g = yes; then
+   if test "$GOBJC" = yes; then
+-    OBJCFLAGS="-g -O2"
++    OBJCFLAGS="-g -O1"
+   else
+     OBJCFLAGS="-g"
+   fi
+ else
+   if test "$GOBJC" = yes; then
+-    OBJCFLAGS="-O2"
++    OBJCFLAGS="-O1"
+   else
+     OBJCFLAGS=
+   fi

--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -86,6 +86,12 @@ class R(AutotoolsPackage):
 
     patch('zlib.patch', when='@:3.3.2')
 
+    # R cannot be built with '-O2' optimization
+    # with Fujitsu Compiler @4.1.0 now.
+    # Until the Fujitsu compiler resolves this problem,
+    # temporary fix to lower the optimization level.
+    patch('change_optflags_tmp.patch', when='%fj@4.1.0')
+
     filter_compiler_wrappers(
         'Makeconf', relative_root=os.path.join('rlib', 'R', 'etc')
     )


### PR DESCRIPTION
R cannot be built with '-O2' optimization when using Fujitsu Compiler@4.1.0 now, but we will fix this problem. Until this problem is fixed, we need to temporary fix to lower the optimization level.
This fix will be removed if the problem is resolved in the future.