### PR TITLE
Fix OpenBLAS 0.2 build, 0.38+ Intel builds, and variant name

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/lapack-0.3.9-xerbl.patch
+++ b/var/spack/repos/builtin/packages/openblas/lapack-0.3.9-xerbl.patch
@@ -1,0 +1,14 @@
+diff --git a/lapack-netlib/SRC/sorhr_col.f b/lapack-netlib/SRC/sorhr_col.f
+index 38976245..600c19fb 100644
+--- a/lapack-netlib/SRC/sorhr_col.f
++++ b/lapack-netlib/SRC/sorhr_col.f
+@@ -282,7 +282,8 @@
+      $                   NPLUSONE
+ *     ..
+ *     .. External Subroutines ..
+-      EXTERNAL           SCOPY, SLAORHR_COL_GETRFNP, SSCAL, STRSM, XERBLA
++      EXTERNAL           SCOPY, SLAORHR_COL_GETRFNP, SSCAL, STRSM,
++     $                   XERBLA
+ *     ..
+ *     .. Intrinsic Functions ..
+       INTRINSIC          MAX, MIN

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -60,6 +60,8 @@ class Openblas(MakefilePackage):
     patch('openblas_icc_openmp.patch', when='@:0.2.20%intel@16.0:')
     patch('openblas_icc_fortran.patch', when='%intel@16.0:')
     patch('openblas_icc_fortran2.patch', when='%intel@18.0:')
+    # See https://github.com/spack/spack/issues/15385
+    patch('lapack-0.3.9-xerbl.patch', when='@0.3.8: %intel')
 
     # Fixes compilation error on POWER8 with GCC 7
     # https://github.com/xianyi/OpenBLAS/pull/1098
@@ -94,6 +96,7 @@ class Openblas(MakefilePackage):
     # Add conditions to f_check to determine the Fujitsu compiler
     patch('openblas_fujitsu.patch', when='%fj')
 
+    # See https://github.com/spack/spack/issues/3036
     conflicts('%intel@16', when='@0.2.15:0.2.19')
 
     @property

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -38,7 +38,7 @@ class Openblas(MakefilePackage):
     variant('ilp64', default=False, description='Force 64-bit Fortran native integers')
     variant('pic', default=True, description='Build position independent code')
     variant('shared', default=True, description='Build shared libraries')
-    variant('consistentFPCSR', default=False, description='Synchronize FP CSR between threads (x86/x86_64 only)')
+    variant('consistent_fpcsr', default=False, description='Synchronize FP CSR between threads (x86/x86_64 only)')
 
     variant(
         'threads', default='none',
@@ -98,6 +98,8 @@ class Openblas(MakefilePackage):
 
     # See https://github.com/spack/spack/issues/3036
     conflicts('%intel@16', when='@0.2.15:0.2.19')
+    conflicts('+consistent_fpcsr', when='threads=none',
+              msg='FPCSR consistency only applies to multithreading')
 
     @property
     def parallel(self):
@@ -251,7 +253,7 @@ class Openblas(MakefilePackage):
 
         # Synchronize floating-point control and status register (FPCSR)
         # between threads (x86/x86_64 only).
-        if '+consistentFPCSR' in self.spec:
+        if '+consistent_fpcsr' in self.spec:
             make_defs += ['CONSISTENT_FPCSR=1']
 
         # Prevent errors in `as` assembler from newer instructions


### PR DESCRIPTION
See https://github.com/spack/spack/issues/15385 . I verified OpenBLAS 0.3.9 now installs on intel%18 and 0.2.20 installs on my mac. I also changed the mixed-case `consistentFPCSR` variant name to `consistent_fpcsr` as per https://github.com/spack/spack/issues/15239 .