### PR TITLE
likwid: new version 5.0.1

### DIFF
--- a/var/spack/repos/builtin/packages/likwid/package.py
+++ b/var/spack/repos/builtin/packages/likwid/package.py
@@ -19,7 +19,9 @@ class Likwid(Package):
     homepage = "https://github.com/RRZE-HPC/likwid"
     url      = "https://github.com/RRZE-HPC/likwid/archive/v5.0.0.tar.gz"
     git      = "https://github.com/RRZE-HPC/likwid.git"
+    maintainers = ['TomTheBear']
 
+    version('5.0.1', sha256='3757b0cb66e8af0116f9288c7f90543acbd8e2af8f72f77aef447ca2b3e76453')
     version('5.0.0', sha256='26623f5a1a5fec19d798f0114774a5293d1c93a148538b9591a13e50930fa41e')
     version('4.3.4', sha256='5c0d1c66b25dac8292a02232f06454067f031a238f010c62f40ef913c6609a83')
     version('4.3.3', sha256='a681378cd66c1679ca840fb5fac3136bfec93c01b3d78cc1d00a641db325a9a3')


### PR DESCRIPTION
includes in partitular fixes for likwid-mpirun but also better support
for ARM and POWER but also other bugfixes.

For full support of ARM and POWER, #14183 has to be merged, too.

Added TomTheBear as maintainer. He is the current main developer of
LIKWID.