### PR TITLE
Allow Spack Environments with '-h' in the name

### DIFF
--- a/share/spack/csh/spack.csh
+++ b/share/spack/csh/spack.csh
@@ -66,7 +66,7 @@ case cd:
     [ $#_sp_args -gt 0 ] && set _sp_arg = ($_sp_args[1])
     shift _sp_args
 
-    if ( "$_sp_arg" == "-h" ) then
+    if ( "$_sp_arg" == "-h" || "$_sp_args" == "--help" ) then
         \spack cd -h
     else
         cd `\spack location $_sp_arg $_sp_args`
@@ -78,7 +78,7 @@ case env:
     set _sp_arg=""
     [ $#_sp_args -gt 0 ] && set _sp_arg = ($_sp_args[1])
 
-    if ( "$_sp_arg" == "-h" ) then
+    if ( "$_sp_arg" == "-h" || "$_sp_arg" == "--help" ) then
         \spack env -h
     else
         switch ($_sp_arg)
@@ -86,12 +86,18 @@ case env:
                 set _sp_env_arg=""
                 [ $#_sp_args -gt 1 ] && set _sp_env_arg = ($_sp_args[2])
 
-                if ( "$_sp_env_arg" == "" || "$_sp_args" =~ "*--sh*" || "$_sp_args" =~ "*--csh*" || "$_sp_args" =~ "*-h*" ) then
-                    # no args or args contain -h/--help, --sh, or --csh: just execute
+                # Space needed here to differentiate between `-h`
+                # argument and environments with "-h" in the name.
+                if ( "$_sp_env_arg" == "" || \
+                     "$_sp_args" =~ "* --sh*" || \
+                     "$_sp_args" =~ "* --csh*" || \
+                     "$_sp_args" =~ "* -h*" || \
+                     "$_sp_args" =~ "* --help*" ) then
+                    # No args or args contain --sh, --csh, or -h/--help: just execute.
                     \spack $_sp_flags env $_sp_args
                 else
                     shift _sp_args  # consume 'activate' or 'deactivate'
-                    # actual call to activate: source the output
+                    # Actual call to activate: source the output.
                     eval `\spack $_sp_flags env activate --csh $_sp_args`
                 endif
                 breaksw
@@ -99,30 +105,40 @@ case env:
                 set _sp_env_arg=""
                 [ $#_sp_args -gt 1 ] && set _sp_env_arg = ($_sp_args[2])
 
-                if ( "$_sp_env_arg" != "" ) then
-                    # with args: execute the command
+                # Space needed here to differentiate between `--sh`
+                # argument and environments with "--sh" in the name.
+                if ( "$_sp_args" =~ "* --sh*" || \
+                     "$_sp_args" =~ "* --csh*" ) then
+                    # Args contain --sh or --csh: just execute.
                     \spack $_sp_flags env $_sp_args
+                else if ( "$_sp_env_arg" != "" ) then
+                    # Any other arguments are an error or -h/--help: just run help.
+                    \spack $_sp_flags env deactivate -h
                 else
-                    # no args: source the output
+                    # No args: source the output of the command.
                     eval `\spack $_sp_flags env deactivate --csh`
                 endif
                 breaksw
             default:
-                echo default
                 \spack $_sp_flags env $_sp_args
                 breaksw
         endsw
     endif
+    breaksw
+
 case load:
 case unload:
-    # Space in `-h` portion is important for differentiating -h option
-    # from variants that begin with "h" or packages with "-h" in name
-    if ( "$_sp_spec" =~ "*--sh*" || "$_sp_spec" =~ "*--csh*" || \
-         " $_sp_spec" =~ "* -h*" || "$_sp_spec" =~ "*--help*") then
-        # IF a shell is given, print shell output
+    # Get --sh, --csh, -h, or --help arguments.
+    # Space needed here to differentiate between `-h`
+    # argument and specs with "-h" in the name.
+    if ( " $_sp_spec" =~ "* --sh*" || \
+         " $_sp_spec" =~ "* --csh*" || \
+         " $_sp_spec" =~ "* -h*" || \
+         " $_sp_spec" =~ "* --help*") then
+        # Args contain --sh, --csh, or -h/--help: just execute.
         \spack $_sp_flags $_sp_subcommand $_sp_spec
     else
-        # otherwise eval with csh
+        # Otherwise, eval with csh.
         eval `\spack $_sp_flags $_sp_subcommand --csh $_sp_spec || \
              echo "exit 1"`
     endif

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -114,36 +114,45 @@ spack() {
                 command spack env -h
             else
                 case $_sp_arg in
-                    # get --sh, --csh, --help, or -h arguments
-                    # space is important for -h case to differentiate between `-h`
-                    # argument and environments with "-h" in the name
                     activate)
+                        # Get --sh, --csh, or -h/--help arguments.
+                        # Space needed here becauses regexes start with a space
+                        # and `-h` may be the only argument.
                         _a=" $@"
+                        # Space needed here to differentiate between `-h`
+                        # argument and environments with "-h" in the name.
+                        # Also see: https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html#Shell-Parameter-Expansion
                         if [ -z ${1+x} ] || \
                            [ "${_a#* --sh}" != "$_a" ] || \
                            [ "${_a#* --csh}" != "$_a" ] || \
                            [ "${_a#* -h}" != "$_a" ] || \
                            [ "${_a#* --help}" != "$_a" ];
                         then
-                            # no args or args contain -h/--help, --sh, or --csh: just execute
+                            # No args or args contain --sh, --csh, or -h/--help: just execute.
                             command spack env activate "$@"
                         else
-                            # actual call to activate: source the output
+                            # Actual call to activate: source the output.
                             eval $(command spack $_sp_flags env activate --sh "$@")
                         fi
                         ;;
                     deactivate)
-                        _a="$@"
+                        # Get --sh, --csh, or -h/--help arguments.
+                        # Space needed here becauses regexes start with a space
+                        # and `-h` may be the only argument.
+                        _a=" $@"
+                        # Space needed here to differentiate between `-h`
+                        # argument and environments with "-h" in the name.
+                        # Also see: https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html#Shell-Parameter-Expansion
                         if [ "${_a#* --sh}" != "$_a" ] || \
                            [ "${_a#* --csh}" != "$_a" ];
                         then
-                            # just  execute the command if --sh or --csh are provided
+                            # Args contain --sh or --csh: just execute.
                             command spack env deactivate "$@"
                         elif [ -n "$*" ]; then
-                            # any other arguments are an error or help, so just run help
+                            # Any other arguments are an error or -h/--help: just run help.
                             command spack env deactivate -h
                         else
-                            # no args: source the output of the command
+                            # No args: source the output of the command.
                             eval $(command spack $_sp_flags env deactivate --sh)
                         fi
                         ;;
@@ -155,17 +164,19 @@ spack() {
             return
             ;;
         "load"|"unload")
-            # get --sh, --csh, --help, or -h arguments
-            # space is important for -h case to differentiate between `-h`
-            # argument and specs with "-h" in package name or variant settings
+            # Get --sh, --csh, -h, or --help arguments.
+            # Space needed here becauses regexes start with a space
+            # and `-h` may be the only argument.
             _a=" $@"
+            # Space needed here to differentiate between `-h`
+            # argument and specs with "-h" in the name.
+            # Also see: https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html#Shell-Parameter-Expansion
             if [ "${_a#* --sh}" != "$_a" ] || \
                 [ "${_a#* --csh}" != "$_a" ] || \
                 [ "${_a#* -h}" != "$_a" ] || \
                 [ "${_a#* --help}" != "$_a" ];
             then
-                # just  execute the command if --sh or --csh are provided
-                # or if the -h or --help arguments are provided
+                # Args contain --sh, --csh, or -h/--help: just execute.
                 command spack $_sp_flags $_sp_subcommand "$@"
             else
                 eval $(command spack $_sp_flags $_sp_subcommand --sh "$@" || \

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -122,7 +122,8 @@ spack() {
                         if [ -z ${1+x} ] || \
                            [ "${_a#* --sh}" != "$_a" ] || \
                            [ "${_a#* --csh}" != "$_a" ] || \
-                           [ "${_a#* -h}" != "$_a" ];
+                           [ "${_a#* -h}" != "$_a" ] || \
+                           [ "${_a#* --help}" != "$_a" ];
                         then
                             # no args or args contain -h/--help, --sh, or --csh: just execute
                             command spack env activate "$@"

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -114,12 +114,15 @@ spack() {
                 command spack env -h
             else
                 case $_sp_arg in
+                    # get --sh, --csh, --help, or -h arguments
+                    # space is important for -h case to differentiate between `-h`
+                    # argument and environments with "-h" in the name
                     activate)
-                        _a="$@"
+                        _a=" $@"
                         if [ -z ${1+x} ] || \
-                           [ "${_a#*--sh}" != "$_a" ] || \
-                           [ "${_a#*--csh}" != "$_a" ] || \
-                           [ "${_a#*-h}" != "$_a" ];
+                           [ "${_a#* --sh}" != "$_a" ] || \
+                           [ "${_a#* --csh}" != "$_a" ] || \
+                           [ "${_a#* -h}" != "$_a" ];
                         then
                             # no args or args contain -h/--help, --sh, or --csh: just execute
                             command spack env activate "$@"
@@ -130,8 +133,8 @@ spack() {
                         ;;
                     deactivate)
                         _a="$@"
-                        if [ "${_a#*--sh}" != "$_a" ] || \
-                           [ "${_a#*--csh}" != "$_a" ];
+                        if [ "${_a#* --sh}" != "$_a" ] || \
+                           [ "${_a#* --csh}" != "$_a" ];
                         then
                             # just  execute the command if --sh or --csh are provided
                             command spack env deactivate "$@"

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -140,8 +140,8 @@ spack() {
                         # Space needed here becauses regexes start with a space
                         # and `-h` may be the only argument.
                         _a=" $@"
-                        # Space needed here to differentiate between `-h`
-                        # argument and environments with "-h" in the name.
+                        # Space needed here to differentiate between `--sh`
+                        # argument and environments with "--sh" in the name.
                         # Also see: https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html#Shell-Parameter-Expansion
                         if [ "${_a#* --sh}" != "$_a" ] || \
                            [ "${_a#* --csh}" != "$_a" ];


### PR DESCRIPTION
@cookgb can you test this out?

It's not hard to add unit tests for this, but currently our tests only create a single environment (`spack_test_env`). I could rename this to `spack-test-h` or something like that.

Fixes #15425