### PR TITLE
trilinos: setting old GO default values for older trilinos versions

### DIFF
--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -155,7 +155,7 @@ class Dealii(CMakePackage, CudaPackage):
     depends_on('slepc@:3.6.3',     when='@:8.4.1+slepc+petsc+mpi')
     depends_on('slepc~arpack',     when='+slepc+petsc+mpi+int64')
     depends_on('sundials@:3~pthread', when='@9.0:+sundials')
-    depends_on('trilinos gotype=int', when='+trilinos')
+    depends_on('trilinos gotype=int', when='+trilinos@12.18.1:')
     # Both Trilinos and SymEngine bundle the Teuchos RCP library.
     # This leads to conflicts between macros defined in the included
     # headers when they are not compiled in the same mode.

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -721,17 +721,36 @@ class Trilinos(CMakePackage):
             'explicit_template_instantiation'))
 
         if '+explicit_template_instantiation' in spec and '+tpetra' in spec:
-            gotype = spec.variants['gotype'].value
             options.extend([
                 define('Tpetra_INST_DOUBLE', True),
-                define('Tpetra_INST_INT_INT', gotype == 'int'),
-                define('Tpetra_INST_INT_LONG', gotype == 'long'),
-                define('Tpetra_INST_INT_LONG_LONG', gotype == 'long_long'),
                 define('Tpetra_INST_COMPLEX_DOUBLE', complex_s),
                 define('Tpetra_INST_COMPLEX_FLOAT', float_s and complex_s),
                 define('Tpetra_INST_FLOAT', float_s),
                 define('Tpetra_INST_SERIAL', True),
             ])
+
+            gotype = spec.variants['gotype'].value
+            # default in older Trilinos versions to enable multiple GOs
+            if ((gotype == 'none') and spec.satisfies('@:12.14.1')):
+                options.extend([
+                    '-DTpetra_INST_INT_INT:BOOL=ON',
+                    '-DTpetra_INST_INT_LONG:BOOL=ON',
+                    '-DTpetra_INST_INT_LONG_LONG:BOOL=ON'
+                ])
+            # set default GO in newer versions to long
+            elif (gotype == 'none'):
+                options.extend([
+                    '-DTpetra_INST_INT_INT:BOOL=OFF',
+                    '-DTpetra_INST_INT_LONG:BOOL=ON',
+                    '-DTpetra_INST_INT_LONG_LONG:BOOL=OFF'
+                ])
+            # if another GO is specified, use this
+            else:
+                options.extend([
+                    define('Tpetra_INST_INT_INT', gotype == 'int'),
+                    define('Tpetra_INST_INT_LONG', gotype == 'long'),
+                    define('Tpetra_INST_INT_LONG_LONG', gotype == 'long_long'),
+                ])
 
         # disable due to compiler / config errors:
         if spec.satisfies('%xl') or spec.satisfies('%xl_r'):


### PR DESCRIPTION
... in order to not break the installation of older versions.
I hope this fixes [issue 15423](https://github.com/spack/spack/issues/15423)

Also adjusting dealii package to just explicitly set GO if trilinos >= 12.18.1 is installed and use the old default otherwise.

Maybe this is a good chance to also merge [pull request 14215](https://github.com/spack/spack/pull/14215)