### PR TITLE
Show the packaga name for a missing patch sha256

### DIFF
--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -346,7 +346,8 @@ class PatchCache(object):
         sha_index = self.index.get(sha256)
         if not sha_index:
             raise NoSuchPatchError(
-                "Couldn't find patch with sha256: %s" % sha256)
+                "Couldn't find patch for package %s with sha256: %s"
+                % (pkg.fullname, sha256))
 
         patch_dict = sha_index.get(pkg.fullname)
         if not patch_dict:


### PR DESCRIPTION
When a patches sha256 is missing, also show the packagename, so that analyzing is easier.