### PR TITLE
geant4: new version 10.6 plus simplifications

### DIFF
--- a/var/spack/repos/builtin/packages/g4abla/package.py
+++ b/var/spack/repos/builtin/packages/g4abla/package.py
@@ -11,7 +11,7 @@ class G4abla(Package):
     """Geant4 data for nuclear shell effects in INCL/ABLA hadronic mode"""
     homepage = "http://geant4.web.cern.ch"
     url = "http://geant4-data.web.cern.ch/geant4-data/datasets/G4ABLA.3.0.tar.gz"
-    
+
     maintainers = ['drbenmorgan']
 
     # Only versions relevant to Geant4 releases built by spack are added

--- a/var/spack/repos/builtin/packages/g4abla/package.py
+++ b/var/spack/repos/builtin/packages/g4abla/package.py
@@ -11,18 +11,23 @@ class G4abla(Package):
     """Geant4 data for nuclear shell effects in INCL/ABLA hadronic mode"""
     homepage = "http://geant4.web.cern.ch"
     url = "http://geant4-data.web.cern.ch/geant4-data/datasets/G4ABLA.3.0.tar.gz"
+    
     maintainers = ['drbenmorgan']
 
-    version(
-        '3.0', sha256='99fd4dcc9b4949778f14ed8364088e45fa4ff3148b3ea36f9f3103241d277014')
-    version(
-        '3.1', sha256='7698b052b58bf1b9886beacdbd6af607adc1e099fc730ab6b21cf7f090c027ed')
+    # Only versions relevant to Geant4 releases built by spack are added
+    version('3.1', sha256='7698b052b58bf1b9886beacdbd6af607adc1e099fc730ab6b21cf7f090c027ed')
+    version('3.0', sha256='99fd4dcc9b4949778f14ed8364088e45fa4ff3148b3ea36f9f3103241d277014')
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
         install_path = join_path(prefix.share, 'data', 'G4ABLA{0}'
                                  .format(self.version))
         install_tree(self.stage.source_path, install_path)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        install_path = join_path(prefix.share, 'data', 'G4ABLA{0}'
+                                 .format(self.version))
+        env.set('G4ABLADATA', install_path)
 
     def url_for_version(self, version):
         """Handle version string."""

--- a/var/spack/repos/builtin/packages/g4abla/package.py
+++ b/var/spack/repos/builtin/packages/g4abla/package.py
@@ -25,7 +25,7 @@ class G4abla(Package):
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        install_path = join_path(prefix.share, 'data', 'G4ABLA{0}'
+        install_path = join_path(self.prefix.share, 'data', 'G4ABLA{0}'
                                  .format(self.version))
         env.set('G4ABLADATA', install_path)
 

--- a/var/spack/repos/builtin/packages/g4emlow/package.py
+++ b/var/spack/repos/builtin/packages/g4emlow/package.py
@@ -27,7 +27,7 @@ class G4emlow(Package):
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        install_path = join_path(prefix.share, 'data', 'G4EMLOW{0}'
+        install_path = join_path(self.prefix.share, 'data', 'G4EMLOW{0}'
                                  .format(self.version))
         env.set('G4LEDATA', install_path)
 

--- a/var/spack/repos/builtin/packages/g4emlow/package.py
+++ b/var/spack/repos/builtin/packages/g4emlow/package.py
@@ -11,12 +11,14 @@ class G4emlow(Package):
     """Geant4 data files for low energy electromagnetic processes."""
     homepage = "http://geant4.web.cern.ch"
     url = "http://geant4-data.web.cern.ch/geant4-data/datasets/G4EMLOW.6.50.tar.gz"
+    
     maintainers = ['drbenmorgan']
 
-    version(
-        '6.50', sha256='c97be73fece5fb4f73c43e11c146b43f651c6991edd0edf8619c9452f8ab1236')
-    version(
-        '7.3', sha256='583aa7f34f67b09db7d566f904c54b21e95a9ac05b60e2bfb794efb569dba14e')
+    # Only versions relevant to Geant4 releases built by spack are added
+    version('7.9', sha256='4abf9aa6cda91e4612676ce4d2d8a73b91184533aa66f9aad19a53a8c4dc3aff')
+    version('7.7', sha256='16dec6adda6477a97424d749688d73e9bd7d0b84d0137a67cf341f1960984663')
+    version('7.3', sha256='583aa7f34f67b09db7d566f904c54b21e95a9ac05b60e2bfb794efb569dba14e')
+    version('6.50', sha256='c97be73fece5fb4f73c43e11c146b43f651c6991edd0edf8619c9452f8ab1236')
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
@@ -24,6 +26,11 @@ class G4emlow(Package):
                                  .format(self.version))
         install_tree(self.stage.source_path, install_path)
 
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        install_path = join_path(prefix.share, 'data', 'G4EMLOW{0}'
+                                 .format(self.version))
+        env.set('G4LEDATA', install_path)
+
     def url_for_version(self, version):
         """Handle version string."""
-        return ("http://geant4.web.cern.ch/support/source/G4EMLOW.%s.tar.gz" % version)
+        return ("http://geant4-data.web.cern.ch/geant4-data/datasets/G4EMLOW.%s.tar.gz" % version)

--- a/var/spack/repos/builtin/packages/g4emlow/package.py
+++ b/var/spack/repos/builtin/packages/g4emlow/package.py
@@ -11,7 +11,7 @@ class G4emlow(Package):
     """Geant4 data files for low energy electromagnetic processes."""
     homepage = "http://geant4.web.cern.ch"
     url = "http://geant4-data.web.cern.ch/geant4-data/datasets/G4EMLOW.6.50.tar.gz"
-    
+
     maintainers = ['drbenmorgan']
 
     # Only versions relevant to Geant4 releases built by spack are added

--- a/var/spack/repos/builtin/packages/g4ensdfstate/package.py
+++ b/var/spack/repos/builtin/packages/g4ensdfstate/package.py
@@ -14,8 +14,9 @@ class G4ensdfstate(Package):
 
     maintainers = ['drbenmorgan']
 
-    version('2.1', sha256='933e7f99b1c70f24694d12d517dfca36d82f4e95b084c15d86756ace2a2790d9')
+    # Only versions relevant to Geant4 releases built by spack are added
     version('2.2', sha256='dd7e27ef62070734a4a709601f5b3bada6641b111eb7069344e4f99a01d6e0a6')
+    version('2.1', sha256='933e7f99b1c70f24694d12d517dfca36d82f4e95b084c15d86756ace2a2790d9')
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
@@ -24,7 +25,9 @@ class G4ensdfstate(Package):
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        env.set('G4ENSDFSTATEDATA', self.prefix.share.data)
+        install_path = join_path(prefix.share, 'data', 'G4ENSDFSTATE{0}'
+                                 .format(self.version))
+        env.set('G4ENSDFSTATEDATA', install_path)
 
     def url_for_version(self, version):
         """Handle version string."""

--- a/var/spack/repos/builtin/packages/g4ensdfstate/package.py
+++ b/var/spack/repos/builtin/packages/g4ensdfstate/package.py
@@ -25,7 +25,7 @@ class G4ensdfstate(Package):
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        install_path = join_path(prefix.share, 'data', 'G4ENSDFSTATE{0}'
+        install_path = join_path(self.prefix.share, 'data', 'G4ENSDFSTATE{0}'
                                  .format(self.version))
         env.set('G4ENSDFSTATEDATA', install_path)
 

--- a/var/spack/repos/builtin/packages/g4incl/package.py
+++ b/var/spack/repos/builtin/packages/g4incl/package.py
@@ -7,28 +7,28 @@
 from spack import *
 
 
-class G4tendl(Package):
-    """Geant4 data for incident particles [optional]"""
+class G4incl(Package):
+    """Geant4 data for evaluated particle cross-sections on natural
+    composition of elements"""
     homepage = "http://geant4.web.cern.ch"
-    url = "http://geant4-data.web.cern.ch/geant4-data/datasets/G4TENDL.1.3.tar.gz"
+    url = "http://geant4-data.web.cern.ch/geant4-data/datasets/G4INCL.1.0.tar.gz"
 
     maintainers = ['drbenmorgan']
 
     # Only versions relevant to Geant4 releases built by spack are added
-    version('1.3.2', sha256='3b2987c6e3bee74197e3bd39e25e1cc756bb866c26d21a70f647959fc7afb849')
-    version('1.3', sha256='52ad77515033a5d6f995c699809b464725a0e62099b5e55bf07c8bdd02cd3bce')
+    version('1.0', sha256='716161821ae9f3d0565fbf3c2cf34f4e02e3e519eb419a82236eef22c2c4367d')
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
-        install_path = join_path(prefix.share, 'data', "G4TENDL{0}"
+        install_path = join_path(prefix.share, 'data', "G4INCL{0}"
                                  .format(self.version))
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        install_path = join_path(prefix.share, 'data', 'G4TENDL{0}'
+        install_path = join_path(prefix.share, 'data', 'G4INCL{0}'
                                  .format(self.version))
-        env.set('G4PARTICLEHPDATA', install_path)
+        env.set('G4INCLDATA', install_path)
 
     def url_for_version(self, version):
         """Handle version string."""
-        return ("http://geant4-data.web.cern.ch/geant4-data/datasets/G4TENDL.%s.tar.gz" % version)
+        return ("http://geant4-data.web.cern.ch/geant4-data/datasets/G4INCL.%s.tar.gz" % version)

--- a/var/spack/repos/builtin/packages/g4incl/package.py
+++ b/var/spack/repos/builtin/packages/g4incl/package.py
@@ -25,7 +25,7 @@ class G4incl(Package):
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        install_path = join_path(prefix.share, 'data', 'G4INCL{0}'
+        install_path = join_path(self.prefix.share, 'data', 'G4INCL{0}'
                                  .format(self.version))
         env.set('G4INCLDATA', install_path)
 

--- a/var/spack/repos/builtin/packages/g4ndl/package.py
+++ b/var/spack/repos/builtin/packages/g4ndl/package.py
@@ -14,6 +14,7 @@ class G4ndl(Package):
 
     maintainers = ['drbenmorgan']
 
+    version('4.6', sha256='9d287cf2ae0fb887a2adce801ee74fb9be21b0d166dab49bcbee9408a5145408')
     version('4.5', sha256='cba928a520a788f2bc8229c7ef57f83d0934bb0c6a18c31ef05ef4865edcdf8e')
 
     def install(self, spec, prefix):
@@ -21,6 +22,11 @@ class G4ndl(Package):
         install_path = join_path(prefix.share, 'data', 'G4NDL{0}'
                                  .format(self.version))
         install_tree(self.stage.source_path, install_path)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        install_path = join_path(prefix.share, 'data', 'G4NDL{0}'
+                                 .format(self.version))
+        env.set('G4NEUTRONHPDATA', install_path)
 
     def url_for_version(self, version):
         """Handle version string."""

--- a/var/spack/repos/builtin/packages/g4ndl/package.py
+++ b/var/spack/repos/builtin/packages/g4ndl/package.py
@@ -24,7 +24,7 @@ class G4ndl(Package):
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        install_path = join_path(prefix.share, 'data', 'G4NDL{0}'
+        install_path = join_path(self.prefix.share, 'data', 'G4NDL{0}'
                                  .format(self.version))
         env.set('G4NEUTRONHPDATA', install_path)
 

--- a/var/spack/repos/builtin/packages/g4neutronxs/package.py
+++ b/var/spack/repos/builtin/packages/g4neutronxs/package.py
@@ -26,7 +26,7 @@ class G4neutronxs(Package):
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        install_path = join_path(prefix.share, 'data', 'G4NEUTRONXS{0}'
+        install_path = join_path(self.prefix.share, 'data', 'G4NEUTRONXS{0}'
                                  .format(self.version))
         env.set('G4NEUTRONXSDATA', install_path)
 

--- a/var/spack/repos/builtin/packages/g4neutronxs/package.py
+++ b/var/spack/repos/builtin/packages/g4neutronxs/package.py
@@ -15,6 +15,8 @@ class G4neutronxs(Package):
 
     maintainers = ['drbenmorgan']
 
+    # Only versions relevant to Geant4 releases built by spack are added
+    # Dataset not used after Geant4 10.4.x
     version('1.4', sha256='57b38868d7eb060ddd65b26283402d4f161db76ed2169437c266105cca73a8fd')
 
     def install(self, spec, prefix):
@@ -22,6 +24,11 @@ class G4neutronxs(Package):
         install_path = join_path(prefix.share, 'data', 'G4NEUTRONXS{0}'
                                  .format(self.version))
         install_tree(self.stage.source_path, install_path)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        install_path = join_path(prefix.share, 'data', 'G4NEUTRONXS{0}'
+                                 .format(self.version))
+        env.set('G4NEUTRONXSDATA', install_path)
 
     def url_for_version(self, version):
         """Handle version string."""

--- a/var/spack/repos/builtin/packages/g4particlexs/package.py
+++ b/var/spack/repos/builtin/packages/g4particlexs/package.py
@@ -26,7 +26,7 @@ class G4particlexs(Package):
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        install_path = join_path(prefix.share, 'data', 'G4PARTICLEXS{0}'
+        install_path = join_path(self.prefix.share, 'data', 'G4PARTICLEXS{0}'
                                  .format(self.version))
         env.set('G4PARTICLEXSDATA', install_path)
 

--- a/var/spack/repos/builtin/packages/g4particlexs/package.py
+++ b/var/spack/repos/builtin/packages/g4particlexs/package.py
@@ -7,28 +7,29 @@
 from spack import *
 
 
-class G4tendl(Package):
-    """Geant4 data for incident particles [optional]"""
+class G4particlexs(Package):
+    """Geant4 data for evaluated particle cross-sections on
+    natural composition of elements"""
     homepage = "http://geant4.web.cern.ch"
-    url = "http://geant4-data.web.cern.ch/geant4-data/datasets/G4TENDL.1.3.tar.gz"
+    url = "http://geant4-data.web.cern.ch/geant4-data/datasets/G4PARTICLEXS.2.1.tar.gz"
 
     maintainers = ['drbenmorgan']
 
     # Only versions relevant to Geant4 releases built by spack are added
-    version('1.3.2', sha256='3b2987c6e3bee74197e3bd39e25e1cc756bb866c26d21a70f647959fc7afb849')
-    version('1.3', sha256='52ad77515033a5d6f995c699809b464725a0e62099b5e55bf07c8bdd02cd3bce')
+    version('2.1', sha256='094d103372bbf8780d63a11632397e72d1191dc5027f9adabaf6a43025520b41')
+    version('1.1', sha256='100a11c9ed961152acfadcc9b583a9f649dda4e48ab314fcd4f333412ade9d62')
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
-        install_path = join_path(prefix.share, 'data', "G4TENDL{0}"
+        install_path = join_path(prefix.share, 'data', "G4PARTICLEXS{0}"
                                  .format(self.version))
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        install_path = join_path(prefix.share, 'data', 'G4TENDL{0}'
+        install_path = join_path(prefix.share, 'data', 'G4PARTICLEXS{0}'
                                  .format(self.version))
-        env.set('G4PARTICLEHPDATA', install_path)
+        env.set('G4PARTICLEXSDATA', install_path)
 
     def url_for_version(self, version):
         """Handle version string."""
-        return ("http://geant4-data.web.cern.ch/geant4-data/datasets/G4TENDL.%s.tar.gz" % version)
+        return ("http://geant4-data.web.cern.ch/geant4-data/datasets/G4PARTICLEXS.%s.tar.gz" % version)

--- a/var/spack/repos/builtin/packages/g4photonevaporation/package.py
+++ b/var/spack/repos/builtin/packages/g4photonevaporation/package.py
@@ -29,7 +29,7 @@ class G4photonevaporation(Package):
 
     def setup_dependent_run_environment(self, env, dependent_spec):
         install_path = join_path(self.prefix.share, 'data',
-                                'PhotonEvaporation{0}'
+                                 'PhotonEvaporation{0}'
                                  .format(self.version))
         env.set('G4LEVELGAMMADATA', install_path)
 

--- a/var/spack/repos/builtin/packages/g4photonevaporation/package.py
+++ b/var/spack/repos/builtin/packages/g4photonevaporation/package.py
@@ -28,7 +28,7 @@ class G4photonevaporation(Package):
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        install_path = join_path(prefix.share, 'data', 'PhotonEvaporation{0}'
+        install_path = join_path(self.prefix.share, 'data', 'PhotonEvaporation{0}'
                                  .format(self.version))
         env.set('G4LEVELGAMMADATA', install_path)
 

--- a/var/spack/repos/builtin/packages/g4photonevaporation/package.py
+++ b/var/spack/repos/builtin/packages/g4photonevaporation/package.py
@@ -28,7 +28,8 @@ class G4photonevaporation(Package):
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        install_path = join_path(self.prefix.share, 'data', 'PhotonEvaporation{0}'
+        install_path = join_path(self.prefix.share, 'data',
+                                'PhotonEvaporation{0}'
                                  .format(self.version))
         env.set('G4LEVELGAMMADATA', install_path)
 

--- a/var/spack/repos/builtin/packages/g4photonevaporation/package.py
+++ b/var/spack/repos/builtin/packages/g4photonevaporation/package.py
@@ -14,8 +14,11 @@ class G4photonevaporation(Package):
 
     maintainers = ['drbenmorgan']
 
-    version('4.3.2', sha256='d4641a6fe1c645ab2a7ecee09c34e5ea584fb10d63d2838248bfc487d34207c7')
+    # Only versions relevant to Geant4 releases built by spack are added
+    version('5.5', sha256='5995dda126c18bd7f68861efde87b4af438c329ecbe849572031ceed8f5e76d7')
+    version('5.3', sha256='d47ababc8cbe548065ef644e9bd88266869e75e2f9e577ebc36bc55bf7a92ec8')
     version('5.2', sha256='83607f8d36827b2a7fca19c9c336caffbebf61a359d0ef7cee44a8bcf3fc2d1f')
+    version('4.3.2', sha256='d4641a6fe1c645ab2a7ecee09c34e5ea584fb10d63d2838248bfc487d34207c7')
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
@@ -23,6 +26,11 @@ class G4photonevaporation(Package):
                                  'PhotonEvaporation{0}'
                                  .format(self.version))
         install_tree(self.stage.source_path, install_path)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        install_path = join_path(prefix.share, 'data', 'PhotonEvaporation{0}'
+                                 .format(self.version))
+        env.set('G4LEVELGAMMADATA', install_path)
 
     def url_for_version(self, version):
         """Handle version string."""

--- a/var/spack/repos/builtin/packages/g4pii/package.py
+++ b/var/spack/repos/builtin/packages/g4pii/package.py
@@ -14,6 +14,7 @@ class G4pii(Package):
 
     maintainers = ['drbenmorgan']
 
+    # Only versions relevant to Geant4 releases built by spack are added
     version('1.3', sha256='6225ad902675f4381c98c6ba25fc5a06ce87549aa979634d3d03491d6616e926')
 
     def install(self, spec, prefix):
@@ -21,6 +22,11 @@ class G4pii(Package):
         install_path = join_path(prefix.share, 'data', 'G4PII{0}'
                                  .format(self.version))
         install_tree(self.stage.source_path, install_path)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        install_path = join_path(prefix.share, 'data', 'G4PII{0}'
+                                 .format(self.version))
+        env.set('G4PIIDATA', install_path)
 
     def url_for_version(self, version):
         """Handle version string."""

--- a/var/spack/repos/builtin/packages/g4pii/package.py
+++ b/var/spack/repos/builtin/packages/g4pii/package.py
@@ -24,7 +24,7 @@ class G4pii(Package):
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        install_path = join_path(prefix.share, 'data', 'G4PII{0}'
+        install_path = join_path(self.prefix.share, 'data', 'G4PII{0}'
                                  .format(self.version))
         env.set('G4PIIDATA', install_path)
 

--- a/var/spack/repos/builtin/packages/g4radioactivedecay/package.py
+++ b/var/spack/repos/builtin/packages/g4radioactivedecay/package.py
@@ -22,12 +22,14 @@ class G4radioactivedecay(Package):
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
-        install_path = join_path(prefix.share, 'data', 'RadioactiveDecay{0}'
+        install_path = join_path(prefix.share, 'data',
+                                 'RadioactiveDecay{0}'
                                  .format(self.version))
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        install_path = join_path(self.prefix.share, 'data', 'RadioactiveDecay{0}'
+        install_path = join_path(self.prefix.share, 'data',
+                                 'RadioactiveDecay{0}'
                                  .format(self.version))
         env.set('G4RADIOACTIVEDATA', install_path)
 

--- a/var/spack/repos/builtin/packages/g4radioactivedecay/package.py
+++ b/var/spack/repos/builtin/packages/g4radioactivedecay/package.py
@@ -14,14 +14,22 @@ class G4radioactivedecay(Package):
 
     maintainers = ['drbenmorgan']
 
-    version('5.1.1', sha256='f7a9a0cc998f0d946359f2cb18d30dff1eabb7f3c578891111fc3641833870ae')
+    # Only versions relevant to Geant4 releases built by spack are added
+    version('5.4', sha256='240779da7d13f5bf0db250f472298c3804513e8aca6cae301db97f5ccdcc4a61')
+    version('5.3', sha256='5c8992ac57ae56e66b064d3f5cdfe7c2fee76567520ad34a625bfb187119f8c1')
     version('5.2', sha256='99c038d89d70281316be15c3c98a66c5d0ca01ef575127b6a094063003e2af5d')
+    version('5.1.1', sha256='f7a9a0cc998f0d946359f2cb18d30dff1eabb7f3c578891111fc3641833870ae')
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
         install_path = join_path(prefix.share, 'data', 'RadioactiveDecay{0}'
                                  .format(self.version))
         install_tree(self.stage.source_path, install_path)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        install_path = join_path(prefix.share, 'data', 'RadioactiveDecay{0}'
+                                 .format(self.version))
+        env.set('G4RADIOACTIVEDATA', install_path)
 
     def url_for_version(self, version):
         """Handle version string."""

--- a/var/spack/repos/builtin/packages/g4radioactivedecay/package.py
+++ b/var/spack/repos/builtin/packages/g4radioactivedecay/package.py
@@ -27,7 +27,7 @@ class G4radioactivedecay(Package):
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        install_path = join_path(prefix.share, 'data', 'RadioactiveDecay{0}'
+        install_path = join_path(self.prefix.share, 'data', 'RadioactiveDecay{0}'
                                  .format(self.version))
         env.set('G4RADIOACTIVEDATA', install_path)
 

--- a/var/spack/repos/builtin/packages/g4realsurface/package.py
+++ b/var/spack/repos/builtin/packages/g4realsurface/package.py
@@ -14,15 +14,21 @@ class G4realsurface(Package):
 
     maintainers = ['drbenmorgan']
 
-    version('1.0', sha256='3e2d2506600d2780ed903f1f2681962e208039329347c58ba1916740679020b1')
-    version('2.1', sha256='2a287adbda1c0292571edeae2082a65b7f7bd6cf2bf088432d1d6f889426dcf3')
+    # Only versions relevant to Geant4 releases built by spack are added
     version('2.1.1', sha256='90481ff97a7c3fa792b7a2a21c9ed80a40e6be386e581a39950c844b2dd06f50')
+    version('2.1', sha256='2a287adbda1c0292571edeae2082a65b7f7bd6cf2bf088432d1d6f889426dcf3')
+    version('1.0', sha256='3e2d2506600d2780ed903f1f2681962e208039329347c58ba1916740679020b1')
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
         install_path = join_path(prefix.share, 'data', 'RealSurface{0}'
                                  .format(self.version))
         install_tree(self.stage.source_path, install_path)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        install_path = join_path(prefix.share, 'data', 'RealSurface{0}'
+                                 .format(self.version))
+        env.set('G4REALSURFACEDATA', install_path)
 
     def url_for_version(self, version):
         """Handle version string."""

--- a/var/spack/repos/builtin/packages/g4realsurface/package.py
+++ b/var/spack/repos/builtin/packages/g4realsurface/package.py
@@ -26,7 +26,7 @@ class G4realsurface(Package):
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        install_path = join_path(prefix.share, 'data', 'RealSurface{0}'
+        install_path = join_path(self.prefix.share, 'data', 'RealSurface{0}'
                                  .format(self.version))
         env.set('G4REALSURFACEDATA', install_path)
 

--- a/var/spack/repos/builtin/packages/g4saiddata/package.py
+++ b/var/spack/repos/builtin/packages/g4saiddata/package.py
@@ -25,7 +25,7 @@ class G4saiddata(Package):
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        install_path = join_path(prefix.share, 'data', 'G4SAIDDATA{0}'
+        install_path = join_path(self.prefix.share, 'data', 'G4SAIDDATA{0}'
                                  .format(self.version))
         env.set('G4SAIDXSDATA', install_path)
 

--- a/var/spack/repos/builtin/packages/g4saiddata/package.py
+++ b/var/spack/repos/builtin/packages/g4saiddata/package.py
@@ -14,6 +14,8 @@ class G4saiddata(Package):
 
     maintainers = ['drbenmorgan']
 
+    # Only versions relevant to Geant4 releases built by spack are added
+    version('2.0', sha256='1d26a8e79baa71e44d5759b9f55a67e8b7ede31751316a9e9037d80090c72e91')
     version('1.1', sha256='a38cd9a83db62311922850fe609ecd250d36adf264a88e88c82ba82b7da0ed7f')
 
     def install(self, spec, prefix):
@@ -21,6 +23,11 @@ class G4saiddata(Package):
         install_path = join_path(prefix.share, 'data', 'G4SAIDDATA{0}'
                                  .format(self.version))
         install_tree(self.stage.source_path, install_path)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        install_path = join_path(prefix.share, 'data', 'G4SAIDDATA{0}'
+                                 .format(self.version))
+        env.set('G4SAIDXSDATA', install_path)
 
     def url_for_version(self, version):
         """Handle version string."""

--- a/var/spack/repos/builtin/packages/g4tendl/package.py
+++ b/var/spack/repos/builtin/packages/g4tendl/package.py
@@ -25,7 +25,7 @@ class G4tendl(Package):
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        install_path = join_path(prefix.share, 'data', 'G4TENDL{0}'
+        install_path = join_path(self.prefix.share, 'data', 'G4TENDL{0}'
                                  .format(self.version))
         env.set('G4PARTICLEHPDATA', install_path)
 

--- a/var/spack/repos/builtin/packages/geant4-data/package.py
+++ b/var/spack/repos/builtin/packages/geant4-data/package.py
@@ -8,90 +8,89 @@ import os
 import glob
 
 
-class Geant4Data(Package):
-    """An umbrella package to hold Geant4 data packages"""
+class Geant4Data(BundlePackage):
+    """A bundle package to hold Geant4 data packages"""
 
     homepage = "http://geant4.cern.ch"
-    url      = "http://geant4-data.web.cern.ch/geant4-data/ReleaseNotes/ReleaseNotes4.10.3.html"
 
     maintainers = ['drbenmorgan']
 
-    version('10.03.p03', sha256='3e0d4d4e6854c8667d930fd5beaec09b7e6ec41f4847935e5d6a2720d0094b30', expand=False)
-    version('10.04', sha256='f67fb899b99348a1a7e471a05f249f972e7e303c78238fc5f693b99968642255', expand=False)
+    version('10.6.0')
+    version('10.5.1')
+    version('10.4.3')
+    version('10.4.0')
+    version('10.3.3')
 
-    # geant4@10.03.p03
-    depends_on("g4abla@3.0", when='@10.03.p03 ')
-    depends_on("g4emlow@6.50", when='@10.03.p03 ')
-    depends_on("g4ndl@4.5", when='@10.03.p03 ')
-    depends_on("g4neutronxs@1.4", when='@10.03.p03 ')
-    depends_on("g4saiddata@1.1", when='@10.03.p03 ')
-    depends_on("g4ensdfstate@2.1", when='@10.03.p03 ')
-    depends_on("g4photonevaporation@4.3.2", when='@10.03.p03 ')
-    depends_on("g4pii@1.3", when='@10.03.p03 ')
-    depends_on("g4radioactivedecay@5.1.1", when='@10.03.p03 ')
-    depends_on("g4realsurface@1.0", when='@10.03.p03 ')
-    depends_on("g4tendl@1.3", when='@10.03.p03 ')
-    # geant4@10.04
-    depends_on("g4abla@3.1", when='@10.04 ')
-    depends_on("g4emlow@7.3", when='@10.04 ')
-    depends_on("g4ndl@4.5", when='@10.04 ')
-    depends_on("g4neutronxs@1.4", when='@10.04 ')
-    depends_on("g4saiddata@1.1", when='@10.04 ')
-    depends_on("g4ensdfstate@2.2", when='@10.04 ')
-    depends_on("g4photonevaporation@5.2", when='@10.04 ')
-    depends_on("g4pii@1.3", when='@10.04 ')
-    depends_on("g4radioactivedecay@5.2", when='@10.04 ')
-    depends_on("g4realsurface@2.1", when='@10.04 ')
-    depends_on("g4tendl@1.3.2", when='@10.04 ')
+    # Add install phase so we can create the data "view"
+    phases = ['install']
+
+    # For clarity, declare deps on a Major-Minor version basis as
+    # they generally don't change on the patch level
+    # Can move to declaring on a dataset basis if needed
+    # geant4@10.6.X
+    depends_on("g4ndl@4.6", when='@10.6.0')
+    depends_on("g4emlow@7.9", when='@10.6.0')
+    depends_on("g4photonevaporation@5.5", when='@10.6.0')
+    depends_on("g4radioactivedecay@5.4", when='@10.6.0')
+    depends_on("g4particlexs@2.1", when='@10.6.0')
+    depends_on("g4pii@1.3", when='@10.6.0')
+    depends_on("g4realsurface@2.1.1", when='@10.6.0')
+    depends_on("g4saiddata@2.0", when='@10.6.0')
+    depends_on("g4abla@3.1", when='@10.6.0')
+    depends_on("g4incl@1.0", when='@10.6.0')
+    depends_on("g4ensdfstate@2.2", when='@10.6.0')
+
+    # geant4@10.5.X
+    depends_on("g4ndl@4.5", when='@10.5.0:10.5.9999')
+    depends_on("g4emlow@7.7", when='@10.5.0:10.5.9999')
+    depends_on("g4photonevaporation@5.3", when='@10.5.0:10.5.9999')
+    depends_on("g4radioactivedecay@5.3", when='@10.5.0:10.5.9999')
+    depends_on("g4particlexs@1.1", when='@10.5.0:10.5.9999')
+    depends_on("g4pii@1.3", when='@10.5.0:10.5.9999')
+    depends_on("g4realsurface@2.1.1", when='@10.5.0:10.5.9999')
+    depends_on("g4saiddata@2.0", when='@10.5.0:10.5.9999')
+    depends_on("g4abla@3.1", when='@10.5.0:10.5.9999')
+    depends_on("g4incl@1.0", when='@10.5.0:10.5.9999')
+    depends_on("g4ensdfstate@2.2", when='@10.5.0:10.5.9999')
+
+    # geant4@10.4.X
+    depends_on("g4ndl@4.5", when='@10.4.0:10.4.9999')
+    depends_on("g4emlow@7.3", when='@10.4.0:10.4.9999')
+    depends_on("g4photonevaporation@5.2", when='@10.4.0:10.4.9999')
+    depends_on("g4radioactivedecay@5.2", when='@10.4.0:10.4.9999')
+    depends_on("g4neutronxs@1.4", when='@10.4.0:10.4.9999')
+    depends_on("g4pii@1.3", when='@10.4.0:10.4.9999')
+
+    depends_on("g4realsurface@2.1.1", when='@10.4.2:10.4.9999')
+    depends_on("g4realsurface@2.1", when='@10.4.0:10.4.1')
+
+    depends_on("g4saiddata@1.1", when='@10.4.0:10.4.9999')
+    depends_on("g4abla@3.1", when='@10.4.0:10.4.9999')
+    depends_on("g4ensdfstate@2.2", when='@10.4.0:10.4.9999')
+
+    # geant4@10.3.X
+    depends_on("g4ndl@4.5", when='@10.3.0:10.3.9999')
+    depends_on("g4emlow@6.50", when='@10.3.0:10.3.9999')
+
+    depends_on("g4photonevaporation@4.3.2", when='@10.3.1:10.3.9999')
+    depends_on("g4photonevaporation@4.3", when='@10.3.0')
+
+    depends_on("g4radioactivedecay@5.1.1", when='@10.3.1:10.3.9999')
+    depends_on("g4radioactivedecay@5.1", when='@10.3.0')
+
+    depends_on("g4neutronxs@1.4", when='@10.3.0:10.3.9999')
+    depends_on("g4pii@1.3", when='@10.3.0:10.3.9999')
+    depends_on("g4realsurface@1.0", when='@10.3.0:10.3.9999')
+    depends_on("g4saiddata@1.1", when='@10.3.0:10.3.9999')
+    depends_on("g4abla@3.0", when='@10.3.0:10.3.9999')
+    depends_on("g4ensdfstate@2.1", when='@10.3.0:10.3.9999')
 
     def install(self, spec, prefix):
         spec = self.spec
-        version = self.version
-        major = version[0]
-        minor = version[1]
-        if len(version) > 2:
-            patch = version[-1]
-        else:
-            patch = 0
-        data = 'Geant4-%s.%s.%s/data' % (major, minor, patch)
+        data = '{0}-{1}'.format(self.name, self.version.dotted)
         datadir = join_path(spec.prefix.share, data)
-        with working_dir(datadir, create=True):
-            for d in glob.glob('%s/share/data/*' %
-                               spec['g4abla'].prefix):
-                os.symlink(d, os.path.basename(d))
-            for d in glob.glob('%s/share/data/*' %
-                               spec['g4emlow'].prefix):
-                os.symlink(d, os.path.basename(d))
-            for d in glob.glob('%s/share/data/*' %
-                               spec['g4ndl'].prefix):
-                os.symlink(d, os.path.basename(d))
-            for d in glob.glob('%s/share/data/*' %
-                               spec['g4saiddata'].prefix):
-                os.symlink(d, os.path.basename(d))
-            for d in glob.glob('%s/share/data/*' %
-                               spec['g4neutronxs'].prefix):
-                os.symlink(d, os.path.basename(d))
-            for d in glob.glob('%s/share/data/*' %
-                               spec['g4ensdfstate'].prefix):
-                os.symlink(d, os.path.basename(d))
-            for d in glob.glob('%s/share/data/*' %
-                               spec['g4photonevaporation'].prefix):
-                os.symlink(d, os.path.basename(d))
-            for d in glob.glob('%s/share/data/*' %
-                               spec['g4pii'].prefix):
-                os.symlink(d, os.path.basename(d))
-            for d in glob.glob('%s/share/data/*' %
-                               spec['g4radioactivedecay'].prefix):
-                os.symlink(d, os.path.basename(d))
-            for d in glob.glob('%s/share/data/*' %
-                               spec['g4realsurface'].prefix):
-                os.symlink(d, os.path.basename(d))
-            for d in glob.glob('%s/share/data/*' %
-                               spec['g4tendl'].prefix):
-                os.symlink(d, os.path.basename(d))
 
-    def url_for_version(self, version):
-        """Handle version string."""
-        url = 'http://geant4-data.web.cern.ch/geant4-data/ReleaseNotes/'
-        url = url + 'ReleaseNotes4.{0}.{1}.html'.format(version[0], version[1])
-        return url
+        with working_dir(datadir, create=True):
+            for s in spec.dependencies():
+                for d in glob.glob('{0}/share/data/*'.format(s.prefix)):
+                    os.symlink(d, os.path.basename(d))

--- a/var/spack/repos/builtin/packages/geant4-data/package.py
+++ b/var/spack/repos/builtin/packages/geant4-data/package.py
@@ -92,5 +92,5 @@ class Geant4Data(BundlePackage):
 
         with working_dir(datadir, create=True):
             for s in spec.dependencies():
-                for d in glob.glob('{0}/share/data/*'.format(s.prefix)):
+                for d in glob.glob('{0}/data/*'.format(s.prefix.share)):
                     os.symlink(d, os.path.basename(d))

--- a/var/spack/repos/builtin/packages/geant4/geant4-10.4.3-cxx17-removed-features.patch
+++ b/var/spack/repos/builtin/packages/geant4/geant4-10.4.3-cxx17-removed-features.patch
@@ -1,0 +1,18 @@
+diff --git a/cmake/Modules/G4BuildSettings.cmake b/cmake/Modules/G4BuildSettings.cmake
+index f68cb0a44..6bf4b6948 100644
+--- a/cmake/Modules/G4BuildSettings.cmake
++++ b/cmake/Modules/G4BuildSettings.cmake
+@@ -205,6 +205,13 @@ endif()
+ # Add Definition to flags for temporary back compatibility
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DG4USE_STD11")
+ 
++# Spack patch to support use of C++ features deprecated/removed in C++17
++# Only checked on AppleClang for now
++if(GEANT4_BUILD_CXXSTD GREATER 14)
++  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_LIBCPP_ENABLE_CXX17_REMOVED_FEATURES=1")
++endif()
++#----
++
+ # Hold any appropriate compile flag(s) in variable for later export to
+ # config files. Needed to support clients using late CMake 2.8 where compile features
+ # are not available.

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-import os
-import glob
 
 
 class Geant4(CMakePackage):
@@ -15,46 +13,51 @@ class Geant4(CMakePackage):
     science."""
 
     homepage = "http://geant4.cern.ch/"
-    url = "http://geant4.cern.ch/support/source/geant4.10.01.p03.tar.gz"
+    url = "https://gitlab.cern.ch/geant4/geant4/-/archive/v10.6.0/geant4-v10.6.0.tar.gz"
 
     maintainers = ['drbenmorgan']
 
-    version('10.05.p01', sha256='f4a292220500fad17e0167ce3153e96e3410ecbe96284e572dc707f63523bdff')
-    version('10.04', sha256='f6d883132f110eb036c69da2b21df51f13c585dc7b99d4211ddd32f4ccee1670')
-    version('10.03.p03', sha256='a164f49c038859ab675eec474d08c9d02be8c4be9c0c2d3aa8e69adf89e1e138')
+    version('10.6.0', sha256='eebe6a170546064ff81ab3b00f513ccd1d4122a026514982368d503ac55a4ee4')
+    version('10.5.1', sha256='2397eb859dc4de095ff66059d8bda9f060fdc42e10469dd7890946293eeb0e39')
+    version('10.4.3', sha256='67f3bb6405a2c77e573936c2b933f5a4a33915aa379626a2eb3012009b91e1da')
+    version('10.4.0', sha256='e919b9b0a88476e00c0b18ab65d40e6a714b55ee4778f66bac32a5396c22aa74')
+    version('10.3.3', sha256='bcd36a453da44de9368d1d61b0144031a58e4b43a6d2d875e19085f2700a89d8')
 
-    variant('qt', default=False, description='Enable Qt support')
+    _cxxstd_values = ('11', '14', '17')
+    variant('cxxstd',
+            default=_cxxstd_values[0],
+            values=_cxxstd_values,
+            multi=False,
+            description='Use the specified C++ standard when building.')
+
+    variant('threads', default=True, description='Build with multithreading')
     variant('vecgeom', default=False, description='Enable vecgeom support')
     variant('opengl', default=False, description='Optional OpenGL support')
     variant('x11', default=False, description='Optional X11 support')
     variant('motif', default=False, description='Optional motif support')
-    variant('threads', default=True, description='Build with multithreading')
-    variant('data', default=True, description='Install geant4 data')
-
-    variant('cxxstd',
-            default='11',
-            values=('11', '14', '17'),
-            multi=False,
-            description='Use the specified C++ standard when building.')
+    variant('qt', default=False, description='Enable Qt support')
 
     depends_on('cmake@3.5:', type='build')
+    depends_on('cmake@3.8:', type='build', when='@10.6.0:')
 
-    # C++11 support
-    depends_on("xerces-c cxxstd=11", when="cxxstd=11")
-    depends_on("clhep@2.3.3.0: cxxstd=11", when="@10.03.p03: cxxstd=11")
-    depends_on("vecgeom cxxstd=11", when="+vecgeom cxxstd=11")
+    depends_on("expat")
+    depends_on("zlib")
 
-    # C++14 support
-    depends_on("xerces-c cxxstd=14", when="cxxstd=14")
-    depends_on("clhep@2.3.3.0: cxxstd=14", when="@10.03.p03: cxxstd=14")
-    depends_on("vecgeom cxxstd=14", when="+vecgeom cxxstd=14")
+    depends_on('geant4-data@10.6.0', when='@10.6.0')
+    depends_on('geant4-data@10.5.1', when='@10.5.1')
+    depends_on('geant4-data@10.4.3', when='@10.4.3')
+    depends_on('geant4-data@10.4.0', when='@10.4.0')
+    depends_on('geant4-data@10.3.3', when='@10.3.3')
 
-    # C++17 support
-    depends_on("xerces-c cxxstd=17", when="cxxstd=17")
-    depends_on("clhep@2.3.3.0: cxxstd=17", when="@10.03.p03: cxxstd=17")
-    patch('cxx17.patch', when='@:10.03.p99 cxxstd=17')
-    patch('cxx17_geant4_10_0.patch', level=1, when='@10.04.00: cxxstd=17')
-    depends_on("vecgeom cxxstd=17", when="+vecgeom cxxstd=17")
+    for std in _cxxstd_values:
+        # CLHEP version requirements to be reviewed
+        depends_on('clhep@2.3.3.0: cxxstd='+std, when='@10.3.3: cxxstd='+std)
+
+        # Spack only supports Xerces-c 3 and above, so no need for version req
+        depends_on('xerces-c cxxstd='+std, when='cxxstd='+std)
+
+        # Vecgeom will need specific versions for each Geant4 version
+        depends_on('vecgeom cxxstd='+std, when='+vecgeom cxxstd='+std)
 
     depends_on("expat")
     depends_on("zlib")
@@ -65,34 +68,48 @@ class Geant4(CMakePackage):
     depends_on("motif", when='+motif')
     depends_on("qt@4.8:", when="+qt")
 
-    # if G4 data not installed with geant4
-    # depend on G4 data packages
-    # this allows external data installations
-    # to avoid duplication
-
-    depends_on('geant4-data@10.03.p03', when='@10.03.p03 ~data')
-    depends_on('geant4-data@10.04', when='@10.04 ~data')
-    depends_on('geant4-data@10.05.p01', when='@10.05.p01 ~data')
-
     # As released, 10.03.03 has issues with respect to using external
     # CLHEP.
-    patch('CLHEP-10.03.03.patch', level=1, when='@10.03.p03')
+    patch('CLHEP-10.03.03.patch', level=1, when='@10.3.3')
+    # These patches can be applied independent of the cxxstd value?
+    patch('cxx17.patch', when='@:10.3.99 cxxstd=17')
+    patch('cxx17_geant4_10_0.patch', level=1, when='@10.4.0 cxxstd=17')
 
     def cmake_args(self):
         spec = self.spec
+        on_or_off = lambda opt: 'ON' if '+' + opt in spec else 'OFF'
 
+        # Core options
         options = [
-            '-DGEANT4_USE_GDML=ON',
+            '-DGEANT4_BUILD_CXXSTD=c++{0}'.format(
+                self.spec.variants['cxxstd'].value),
             '-DGEANT4_USE_SYSTEM_CLHEP=ON',
-            '-DGEANT4_USE_SYSTEM_CLHEP_GRANULAR=ON',
-            '-DGEANT4_USE_G3TOG4=ON',
-            '-DGEANT4_INSTALL_DATA=ON',
-            '-DGEANT4_BUILD_TLS_MODEL=global-dynamic',
             '-DGEANT4_USE_SYSTEM_EXPAT=ON',
             '-DGEANT4_USE_SYSTEM_ZLIB=ON',
-            '-DXERCESC_ROOT_DIR:STRING=%s' %
-            spec['xerces-c'].prefix, ]
+            '-DGEANT4_USE_G3TOG4=ON',
+            '-DGEANT4_USE_GDML=ON',
+            '-DXERCESC_ROOT_DIR={0}'.format(spec['xerces-c'].prefix)
+        ]
 
+        # Multithreading
+        options.append('-DGEANT4_BUILD_MULTITHREADED=' + on_or_off('threads'))
+        if '+threads' in spec:
+            # This should be a variant
+            options.append('-DGEANT4_BUILD_TLS_MODEL=global-dynamic')
+
+        # install the data with geant4
+        datadir = spec['geant4-data'].prefix.share
+        dataver = 'geant4-data-{0}'.format(spec['geant4-data'].version)
+        datapath = join_path(datadir, dataver)
+        options.append('-DGEANT4_INSTALL_DATADIR={0}'.format(datapath))
+
+        # Vecgeom
+        if '+vecgeom' in spec:
+            options.append('-DGEANT4_USE_USOLIDS=ON')
+            options.append('-DUSolids_DIR=%s' % spec[
+                'vecgeom'].prefix.lib.CMake.USolids)
+
+        # Visualization options
         if 'platform=darwin' not in spec:
             if "+x11" in spec and "+opengl" in spec:
                 options.append('-DGEANT4_USE_OPENGL_X11=ON')
@@ -101,61 +118,10 @@ class Geant4(CMakePackage):
             if "+x11" in spec:
                 options.append('-DGEANT4_USE_RAYTRACER_X11=ON')
 
-        options.append('-DGEANT4_BUILD_CXXSTD=c++{0}'.format(
-                       self.spec.variants['cxxstd'].value))
-
         if '+qt' in spec:
             options.append('-DGEANT4_USE_QT=ON')
             options.append(
                 '-DQT_QMAKE_EXECUTABLE=%s' %
                 spec['qt'].prefix.bin.qmake)
 
-        if '+vecgeom' in spec:
-            options.append('-DGEANT4_USE_USOLIDS=ON')
-            options.append('-DUSolids_DIR=%s' % spec[
-                'vecgeom'].prefix.lib.CMake.USolids)
-
-        on_or_off = lambda opt: 'ON' if '+' + opt in spec else 'OFF'
-        options.append('-DGEANT4_BUILD_MULTITHREADED=' + on_or_off('threads'))
-
-        # install the data with geant4
-        options.append('-DGEANT4_INSTALL_DATA=' + on_or_off('data'))
-
         return options
-
-    def url_for_version(self, version):
-        """Handle Geant4's unusual version string."""
-        return ("http://geant4.cern.ch/support/source/geant4.%s.tar.gz" % version)
-
-    @run_before('cmake')
-    def make_data_links(self):
-        if '+data' in self.spec:
-            return
-        spec = self.spec
-        version = self.version
-        major = version[0]
-        minor = version[1]
-        if len(version) > 2:
-            patch = version[-1]
-        else:
-            patch = 0
-        datadir = 'Geant4-%s.%s.%s/data' % (major, minor, patch)
-        with working_dir(join_path(spec.prefix.share, datadir),
-                         create=True):
-            dirs = glob.glob('%s/%s/*' %
-                             (spec['geant4-data'].prefix.share, datadir))
-            for d in dirs:
-                target = os.readlink(d)
-                os.symlink(target, os.path.basename(target))
-
-    def setup_dependent_build_environment(self, env, dependent_spec):
-        version = self.version
-        major = version[0]
-        minor = version[1]
-        if len(version) > 2:
-            patch = version[-1]
-        else:
-            patch = 0
-        datadir = 'Geant4-%s.%s.%s' % (major, minor, patch)
-        env.append_path('CMAKE_MODULE_PATH', join_path(
-            self.prefix.lib64, datadir, 'Modules'))

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -51,13 +51,14 @@ class Geant4(CMakePackage):
 
     for std in _cxxstd_values:
         # CLHEP version requirements to be reviewed
-        depends_on('clhep@2.3.3.0: cxxstd='+std, when='@10.3.3: cxxstd='+std)
+        depends_on('clhep@2.3.3.0: cxxstd=' + std,
+                   when='@10.3.3: cxxstd=' + std)
 
-        # Spack only supports Xerces-c 3 and above, so no need for version req
-        depends_on('xerces-c cxxstd='+std, when='cxxstd='+std)
+        # Spack only supports Xerces-c 3 and above, so no version req
+        depends_on('xerces-c cxxstd=' + std, when='cxxstd=' + std)
 
         # Vecgeom will need specific versions for each Geant4 version
-        depends_on('vecgeom cxxstd='+std, when='+vecgeom cxxstd='+std)
+        depends_on('vecgeom cxxstd=' + std, when='+vecgeom cxxstd=' + std)
 
     depends_on("expat")
     depends_on("zlib")

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -81,6 +81,7 @@ class Geant4(CMakePackage):
     # These patches can be applied independent of the cxxstd value?
     patch('cxx17.patch', when='@:10.3.99 cxxstd=17')
     patch('cxx17_geant4_10_0.patch', level=1, when='@10.4.0 cxxstd=17')
+    patch('geant4-10.4.3-cxx17-removed-features.patch', level=1, when='@10.4.3 cxxstd=17')
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -100,7 +100,8 @@ class Geant4(CMakePackage):
         ]
 
         # Multithreading
-        options.append(self.define_from_variant('GEANT4_BUILD_MULTITHREADED', 'threads'))
+        options.append(self.define_from_variant('GEANT4_BUILD_MULTITHREADED',
+                                                'threads'))
         if '+threads' in spec:
             # This should be a variant
             options.append('-DGEANT4_BUILD_TLS_MODEL=global-dynamic')

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -40,14 +40,14 @@ class Geant4(CMakePackage):
     depends_on('cmake@3.5:', type='build')
     depends_on('cmake@3.8:', type='build', when='@10.6.0:')
 
-    depends_on("expat")
-    depends_on("zlib")
-
     depends_on('geant4-data@10.6.0', when='@10.6.0')
     depends_on('geant4-data@10.5.1', when='@10.5.1')
     depends_on('geant4-data@10.4.3', when='@10.4.3')
     depends_on('geant4-data@10.4.0', when='@10.4.0')
     depends_on('geant4-data@10.3.3', when='@10.3.3')
+
+    depends_on("expat")
+    depends_on("zlib")
 
     for std in _cxxstd_values:
         # CLHEP version requirements to be reviewed
@@ -57,17 +57,23 @@ class Geant4(CMakePackage):
         # Spack only supports Xerces-c 3 and above, so no version req
         depends_on('xerces-c cxxstd=' + std, when='cxxstd=' + std)
 
-        # Vecgeom will need specific versions for each Geant4 version
-        depends_on('vecgeom cxxstd=' + std, when='+vecgeom cxxstd=' + std)
+        # Vecgeom specific versions for each Geant4 version
+        depends_on('vecgeom@1.1.5 cxxstd=' + std,
+                   when='@10.6.0:10.6.99 +vecgeom cxxstd=' + std)
+        depends_on('vecgeom@1.1.0 cxxstd=' + std,
+                   when='@10.5.0:10.5.99 +vecgeom cxxstd=' + std)
+        depends_on('vecgeom@0.5.2 cxxstd=' + std,
+                   when='@10.4.0:10.4.99 +vecgeom cxxstd=' + std)
+        depends_on('vecgeom@0.3rc cxxstd=' + std,
+                   when='@10.3.0:10.3.99 +vecgeom cxxstd=' + std)
 
-    depends_on("expat")
-    depends_on("zlib")
+    # Visualization driver ependencies
     depends_on("gl", when='+opengl')
     depends_on("glx", when='+opengl+x11')
     depends_on("libx11", when='+x11')
     depends_on("libxmu", when='+x11')
     depends_on("motif", when='+motif')
-    depends_on("qt@4.8:", when="+qt")
+    depends_on("qt@5:", when="+qt")
 
     # As released, 10.03.03 has issues with respect to using external
     # CLHEP.

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -81,7 +81,8 @@ class Geant4(CMakePackage):
     # These patches can be applied independent of the cxxstd value?
     patch('cxx17.patch', when='@:10.3.99 cxxstd=17')
     patch('cxx17_geant4_10_0.patch', level=1, when='@10.4.0 cxxstd=17')
-    patch('geant4-10.4.3-cxx17-removed-features.patch', level=1, when='@10.4.3 cxxstd=17')
+    patch('geant4-10.4.3-cxx17-removed-features.patch',
+          level=1, when='@10.4.3 cxxstd=17')
 
     def cmake_args(self):
         spec = self.spec
@@ -107,7 +108,8 @@ class Geant4(CMakePackage):
 
         # install the data with geant4
         datadir = spec['geant4-data'].prefix.share
-        dataver = 'geant4-data-{0}'.format(spec['geant4-data'].version)
+        dataver = '{0}-{1}'.format(spec['geant4-data'].name,
+                                   spec['geant4-data'].version.dotted)
         datapath = join_path(datadir, dataver)
         options.append('-DGEANT4_INSTALL_DATADIR={0}'.format(datapath))
 

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -86,7 +86,6 @@ class Geant4(CMakePackage):
 
     def cmake_args(self):
         spec = self.spec
-        on_or_off = lambda opt: 'ON' if '+' + opt in spec else 'OFF'
 
         # Core options
         options = [
@@ -101,7 +100,7 @@ class Geant4(CMakePackage):
         ]
 
         # Multithreading
-        options.append('-DGEANT4_BUILD_MULTITHREADED=' + on_or_off('threads'))
+        options.append(self.define_from_variant('GEANT4_BUILD_MULTITHREADED', 'threads'))
         if '+threads' in spec:
             # This should be a variant
             options.append('-DGEANT4_BUILD_TLS_MODEL=global-dynamic')

--- a/var/spack/repos/builtin/packages/vecgeom/package.py
+++ b/var/spack/repos/builtin/packages/vecgeom/package.py
@@ -21,6 +21,7 @@ class Vecgeom(CMakePackage, CudaPackage):
     version('1.1.6', sha256='c4806a6b67d01b40074b8cc6865d78574a6a1c573be51696f2ecdf98b9cb954a')
     version('1.1.5', sha256='da674f3bbc75c30f56c1a2d251fa8930c899f27fa64b03a36569924030d87b95')
     version('1.1.3', sha256='ada09e8b6b2fa6c058290302b2cb5a6c2e644192aab1623c31d18c6a2f4c01c8')
+    version('1.1.0', sha256='e9d1ef83ff591fe4f9ef744a4d3155a3dc7e90ddb6735b24f3afe4c2dc3f7064')
     version('1.0.1', sha256='1eae7ac9014c608e8d8db5568058b8c0fea1a1dc7a8f54157a3a1c997b6fd9eb')
     version('0.5.2', tag='v00.05.02',
             commit='a7e0828c915ff936a79e672d1dd84b087a323b51')


### PR DESCRIPTION
This is a fairly major refactor and simplification of Geant4 and its associated data packages, and *will* changes hashes of previous installs. I think this is worthwhile for long term maintenance of the package, so this PR is "Draft" for now to get early eyes on it and discuss with interested parties.

The primary change is the removal of the `data` variant so the physics model data packages are always installed by the `g4XXX` packages, then used by Geant4 itself through the `geant4-data` package. `geant4-data` is now a `BundlePackage` whose version maps to that of `geant4` and depends on the `g4XXX` packages at the exact versions the `geant4` version supports. It creates a "view" (more on that later) of the data so Geant4's install mechanisms sees a single directory. Each `g4XXX` package also now sets the appropriate runtime environment.

I believe removal of the `data` variant is worthwhile as the external data is platform/arch independent, so really benefits reuse and reducing install sizes.

The second breaking change is to move the versioning to "standard" semantic versioning, so `10.6.0` rather than `10.06.p00`. This is just to make the packaging cleaner and simple, plus the use of the Geant4 GitLab repo.

The remainder of the updates are pure simplification and cleanup. 

One potential issue to look at is the "view" creation in `geant4-data`. All this does is create a directory `<prefix>/share/geant4-data-<version>/` and create symlinks in that to the `g4xxx` data  directories. That works, and Geant4's seems fine with it. However, if a spack environment/view is created and `geant4-data` installed in this, the symlinks under `<viewprefix>/share/geant4-data-<version>/` are created as normal but empty directories.

I'm not sure this is critical as the environment variables needed by Geant4 are set correctly, but feels like I've missed something.