### PR TITLE
Initial OpenMPI smoke tests

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -545,3 +545,103 @@ class Openmpi(AutotoolsPackage):
                     tty.debug("File not present: " + exe)
                 else:
                     copy(script_stub, exe)
+
+    def _run_test(self, exe, options, expected, status):
+        """Run the test and confirm obtain the expected results
+        Args:
+            exe (str): the name of the executable
+            options (list of str): list of options to pass to the runner
+            expected (list of str): list of expected output strings
+            status (int or None): the expected process status if int or None
+                if the test is expected to succeed
+        """
+        result = 'fail with status {0}'.format(status) if status else 'succeed'
+        tty.msg('test: {0}: expect to {1}'.format(exe, result))
+        runner = which(exe)
+        assert runner is not None
+
+        try:
+            output = runner(*options, output=str.split, error=str.split)
+            assert not status, 'Expected execution to fail'
+        except ProcessError as err:
+            output = str(err)
+            status_msg = 'exited with status {0}'.format(status)
+            expected_msg = 'Expected \'{0}\' in \'{1}\''.format(
+                status_msg, err.message)
+            assert status_msg in output, expected_msg
+
+        for check in expected:
+            assert check in output
+
+    def _test_check_versions(self):
+        # TBD: How fragile is the list of files expected to be in the bin dir?
+        # TBD: How fragile are the exit codes for commands without --version?
+
+        comp_vers = str(self.spec.compiler.version)
+        spec_vers = str(self.spec.version)
+        bad_option = 'unknown option'
+        checks = {
+            'mpiCC': ([comp_vers], None),
+            'mpic++': ([comp_vers], None),
+            'mpicc': ([comp_vers], None),
+            'mpicxx': ([comp_vers], None),
+            'mpiexec': ([spec_vers], None),
+            'mpif77': ([comp_vers], None),
+            'mpif90': ([comp_vers], None),
+            'mpifort': ([comp_vers], None),
+            'mpirun': ([spec_vers], None),
+            'ompi-clean': ([bad_option], 213),
+            'ompi-dvm': ([spec_vers], None),
+            'ompi-ps': ([bad_option], 213),
+            'ompi-server': ([bad_option], 1),
+            'ompi-top': ([bad_option], 1),
+            'ompi_info': ([spec_vers], None),
+            'opal_wrapper': (['Cannot open configuration file'], 243),
+            'orte-clean': ([bad_option], 213),
+            'orte-dvm': ([spec_vers], None),
+            'orte-info': (['did not have enough parameters'], 1),
+            'orte-ps': ([bad_option], 213),
+            'orte-server': ([bad_option], 1),
+            'orte-top': ([bad_option], 1),
+            'ortecc': ([comp_vers], None),
+            #'orted': ([bad_option], 213),
+            'orted': ([bad_option], 1),
+            'orterun': ([spec_vers], None),
+            'oshCC': ([comp_vers], None),
+            'oshc++': ([comp_vers], None),
+            'oshcc': ([comp_vers], None),
+            'oshcxx': ([comp_vers], None),
+            'oshfort': ([comp_vers], None),
+            'oshmem_info': ([spec_vers], None),
+            'oshrun': ([spec_vers], None),
+            'prun': ([spec_vers], None),
+            'shmemCC': ([comp_vers], None),
+            'shmemc++': ([comp_vers], None),
+            'shmemcc': ([comp_vers], None),
+            'shmemcxx': ([comp_vers], None),
+            'shmemfort': ([comp_vers], None),
+            'shmemrun': ([spec_vers], None),
+        }
+
+        print('TLD: version=%s' % spec_vers)
+        failed = []
+        for exe in checks:
+            expected, status = checks[exe]
+            try:
+                self._run_test(exe, ['--version'], expected, status)
+            except Exception as exc:
+                print('ERROR: Version check failed for {0}: {1}'
+                      .format(exe, str(exc)))
+                failed.append(exe)
+
+        num_failed = len(failed)
+        assert num_failed == 0, \
+            '{0} of {1} version checks failed: {2}' \
+            .format(num_failed, len(checks), failed)
+
+    def test(self):
+        """Perform smoke tests on the installed package."""
+        # Simple version check tests on known packages
+        self._test_check_versions()
+
+        # TODO: Add and execute simple MPI test programs


### PR DESCRIPTION
This is a set of smoke tests for the `openmpi` package.  

This PR leverages the `_run_test` function introduced in #15092 to perform version checks, check expected result status, and check expected output.  This PR introduces the notion of running a complete set of checks before terminating (versus terminating on the first failure).

Follow-on work will introduce simple executable programs for the major languages -- C, C++, and Fortran -- that must be compiled and run.  Tests to check the rpath _may_ be introduced.  According to John Gyllenhaal (LLNL), these types of tests -- if they were run on multiple nodes with multiple tasks -- could catch 95% of the problems with an installation.

TODO:

- [ ] Determine if the version checks are too fragile wrt different versions of openmpi
        (There are differences e.g., eight of the version tests fail for v2.0.0.)
- [ ] Add simple test that is compiled and run for C*
- [ ] Add simple test that is compiled and run for C++*
- [ ] Add simple test that is compiled and run for FORTRAN/F90*

*These should be designed and implemented with an eye toward sharing them across MPI providers.