### PR TITLE
add cython as dependency of plumed

### DIFF
--- a/var/spack/repos/builtin/packages/plumed/package.py
+++ b/var/spack/repos/builtin/packages/plumed/package.py
@@ -68,6 +68,7 @@ class Plumed(AutotoolsPackage):
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
     depends_on('libtool', type='build')
+    depends_on('py-cython', type='build')
 
     force_autoreconf = True
 

--- a/var/spack/repos/builtin/packages/plumed/package.py
+++ b/var/spack/repos/builtin/packages/plumed/package.py
@@ -68,7 +68,7 @@ class Plumed(AutotoolsPackage):
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
     depends_on('libtool', type='build')
-    depends_on('py-cython', type='build')
+    depends_on('py-cython', type='build', when='@2.5:')
 
     force_autoreconf = True
 


### PR DESCRIPTION
Plumed uses cython in its build process. Adding the dependency to Spack prevents getting a random (old) version from the environment and seeing errors like `Error compiling Cython file: Cannot convert 'void *' to Python object` during build. 