### PR TITLE
cpprestsdk: fix common error and, use boost@1.69.0 or lower

### DIFF
--- a/var/spack/repos/builtin/packages/cpprestsdk/Release.patch
+++ b/var/spack/repos/builtin/packages/cpprestsdk/Release.patch
@@ -1,0 +1,45 @@
+diff -ur spack-src/Release.org/include/pplx/pplxlinux.h spack-src/Release/include/pplx/pplxlinux.h
+--- spack-src/Release.org/include/pplx/pplxlinux.h	2020-03-12 13:52:40.161917503 +0900
++++ spack-src/Release/include/pplx/pplxlinux.h	2020-03-12 14:05:50.834896829 +0900
+@@ -240,6 +240,11 @@
+     {
+     public:
+         _PPLXIMP virtual void schedule( TaskProc_t proc, _In_ void* param);
++#if defined(__APPLE__)
++    virtual ~apple_scheduler() {}
++#else
++    virtual ~linux_scheduler() {}
++#endif
+     };
+ 
+ } // namespace details
+diff -ur spack-src/Release.org/libs/websocketpp/websocketpp/transport/asio/connection.hpp spack-src/Release/libs/websocketpp/websocketpp/transport/asio/connection.hpp
+--- spack-src/Release.org/libs/websocketpp/websocketpp/transport/asio/connection.hpp	2020-03-12 13:52:40.201921703 +0900
++++ spack-src/Release/libs/websocketpp/websocketpp/transport/asio/connection.hpp	2020-03-12 14:09:13.586186467 +0900
+@@ -422,7 +422,7 @@
+         m_io_service = io_service;
+ 
+         if (config::enable_multithreading) {
+-            m_strand = lib::make_shared<boost::asio::strand>(
++            m_strand = lib::make_shared<boost::asio::io_service::strand>(
+                 lib::ref(*io_service));
+ 
+             m_async_read_handler = m_strand->wrap(lib::bind(
+diff -ur spack-src/Release.org/src/uri/uri.cpp spack-src/Release/src/uri/uri.cpp
+--- spack-src/Release.org/src/uri/uri.cpp	2020-03-12 13:52:40.241925902 +0900
++++ spack-src/Release/src/uri/uri.cpp	2020-03-12 13:53:58.610152210 +0900
+@@ -22,12 +22,12 @@
+     // canonicalize components first
+ 
+     // convert scheme to lowercase
+-    std::transform(m_scheme.begin(), m_scheme.end(), m_scheme.begin(), [this](utility::char_t c) {
++    std::transform(m_scheme.begin(), m_scheme.end(), m_scheme.begin(), [](utility::char_t c) {
+         return (utility::char_t)tolower(c);
+     });
+ 
+     // convert host to lowercase
+-    std::transform(m_host.begin(), m_host.end(), m_host.begin(), [this](utility::char_t c) {
++    std::transform(m_host.begin(), m_host.end(), m_host.begin(), [](utility::char_t c) {
+         return (utility::char_t)tolower(c);
+     });
+ 

--- a/var/spack/repos/builtin/packages/cpprestsdk/package.py
+++ b/var/spack/repos/builtin/packages/cpprestsdk/package.py
@@ -17,6 +17,11 @@ class Cpprestsdk(CMakePackage):
 
     version('2.9.1', sha256='537358760acd782f4d2ed3a85d92247b4fc423aff9c85347dc31dbb0ab9bab16')
 
-    depends_on('boost')
+    depends_on('boost@:1.69.0')
+
+    # Ref: https://github.com/microsoft/cpprestsdk/commit/f9f518e4ad84577eb684ad8235181e4495299af4
+    # Ref: https://github.com/Microsoft/cpprestsdk/commit/6b2e0480018530b616f61d5cdc786c92ba148bb7
+    # Ref: https://github.com/microsoft/cpprestsdk/commit/70c1b14f39f5d47984fdd8a31fc357ebb5a37851
+    patch('Release.patch')
 
     root_cmakelists_dir = 'Release'


### PR DESCRIPTION
I found and fixed the following errors when building `cpprestsdk`.

- [-Werror,-Wunused-lambda-capture]
```
  >> 147    /tmp/pytest-of-ogura/pytest-77/mock-stage0/spack-stage-cpprestsdk-2
            .9.1-lgfw6z2gh2lvm25uus246cw2itmm62vb/spack-src/Release/src/uri/uri
            .cpp:25:73: error: lambda capture 'this' is not used [-Werror,-Wunu
            sed-lambda-capture]
```
I removed not used `this`.
Ref: https://github.com/microsoft/cpprestsdk/commit/70c1b14f39f5d47984fdd8a31fc357ebb5a37851


- [-Werror,-Wdelete-non-virtual-dtor]
```
  >> 139    /home/ogura/karatsu/fujitsu_compilers_for_sve_20190731/fujitsu_comp
            ilers_sve_own_20190731/sve_own/clang-comp/bin/../include/c++/v1/mem
            ory:3656:5: error: destructor called on non-final 'pplx::details::l
            inux_scheduler' that has virtual functions but non-virtual destruct
            or [-Werror,-Wdelete-non-virtual-dtor]
     140        __data_.second().~_Tp();
     141        ^
```
I added virtual destructor to class.
Ref: https://github.com/microsoft/cpprestsdk/commit/f9f518e4ad84577eb684ad8235181e4495299af4


- error: no matching function for call to 'make_shared'
```
  >> 169    /tmp/pytest-of-ogura/pytest-77/mock-stage0/spack-stage-cpprestsdk-2
            .9.1-zbzjokez2xnzbanmtnxqd37ziqykejht/spack-src/Release/libs/websoc
            ketpp/websocketpp/transport/asio/connection.hpp:425:24: error: no m
            atching function for call to 'make_shared'
     170                m_strand = lib::make_shared<boost::asio::strand>(
     171                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
I fixed strand.
Ref: https://github.com/Microsoft/cpprestsdk/commit/6b2e0480018530b616f61d5cdc786c92ba148bb7

If boost@1.70.0 or later is used, an error occured. 
```
  >> 176    /home/ogura/noguchi/spack/opt/spack/linux-centos7-thunderx2/fj-4.0.
            0/boost-1.72.0-kjyta52lqpm3fdu6ate4qghsdl5a6gvn/include/boost/asio/
            impl/executor.hpp:179:22: error: no member named 'context' in 'std:
            :__1::reference_wrapper<boost::asio::io_context>'
     177        return executor_.context();
     178               ~~~~~~~~~ ^
```
Probably due to the websocketpp module included in cpprestsdk.
"get_io_service" used in websocket was removed in boost@1.70.0.
So I set the version to used to 1.69.0 or lower.
Ref: https://www.boost.org/doc/libs/1_70_0/doc/html/boost_asio/history.html