### PR TITLE
slurm: new version, system configuration path

### DIFF
--- a/var/spack/repos/builtin/packages/slurm/package.py
+++ b/var/spack/repos/builtin/packages/slurm/package.py
@@ -24,6 +24,7 @@ class Slurm(AutotoolsPackage):
     homepage = 'https://slurm.schedmd.com'
     url = 'https://github.com/SchedMD/slurm/archive/slurm-17-02-6-1.tar.gz'
 
+    version('18-08-9-1', sha256='32eb0b612ca18ade1e35c3c9d3b4d71aba2b857446841606a9e54d0a417c3b03')
     version('18-08-0-1', sha256='62129d0f2949bc8a68ef86fe6f12e0715cbbf42f05b8da6ef7c3e7e7240b50d9')
     version('17-11-9-2', sha256='6e34328ed68262e776f524f59cca79ac75bcd18030951d45ea545a7ba4c45906')
     version('17-02-6-1', sha256='97b3a3639106bd6d44988ed018e2657f3d640a3d5c105413d05b4721bc8ee25e')
@@ -35,6 +36,8 @@ class Slurm(AutotoolsPackage):
     variant('hdf5', default=False, description='Enable hdf5 support')
     variant('readline', default=True, description='Enable readline support')
     variant('pmix', default=False, description='Enable PMIx support')
+    variant('sysconfdir', default='PREFIX/etc', values=any,
+            description='Set system configuration path (possibly /etc/slurm)')
 
     # TODO: add variant for BG/Q and Cray support
 
@@ -93,6 +96,10 @@ class Slurm(AutotoolsPackage):
             args.append('--with-pmix={0}'.format(spec['pmix'].prefix))
         else:
             args.append('--without-pmix')
+
+        sysconfdir = spec.variants['sysconfdir'].value
+        if sysconfdir != 'PREFIX/etc':
+            args.append('--sysconfdir={0}'.format(sysconfdir))
 
         return args
 


### PR DESCRIPTION
* Add version 18-08-9-1
* Add variant to allow setting the sysconfdir

About sysconfdir:

slurm has a server and a client.
To use the correct communication channel, the client needs to be able to read the correct config.  This config is in PREFIX/etc.

Let's assume one has the server part installed as a system package. This generally is a good idea, so that the server gets started during boot. This means, that the config is in `/etc/slurm`.

If one now wants to use the client part (library!) via spack, one has a problem: spack's slurm looks in `SPACK-PACKAGE-PREFIX/etc` for the config.

There needs to be a way to let the spack installed package use the system's config.

So add a variant to override the path during build:
`sysconfdir=/etc/slurm`.

This is much like what happened in #15307 for munge.