### PR TITLE
hpctoolkit: limit binutils to <= 2.33.1

### DIFF
--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -60,7 +60,7 @@ class Hpctoolkit(AutotoolsPackage):
         ' +graph +regex +shared +multithreaded visibility=global'
     )
 
-    depends_on('binutils+libiberty~nls', type='link')
+    depends_on('binutils@:2.33.1+libiberty~nls', type='link')
     depends_on('boost' + boost_libs)
     depends_on('bzip2+shared', type='link')
     depends_on('dyninst@9.3.2:')


### PR DESCRIPTION
HPCToolKit <= 2020.03.01 does not build with binutils 2.34.

@mwkrentel I used a version constraint here since I'm assuming that at some point before the next point release, `master` will be buildable with binutils@2.34. If you would rather wait to add that until after `master` *actually* builds with that, then I can remove it.