### PR TITLE
Previous qt package file changes broke the openspeedshop gui build.  

### DIFF
--- a/var/spack/repos/builtin/packages/openspeedshop/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop/package.py
@@ -96,7 +96,7 @@ class Openspeedshop(CMakePackage):
 
     depends_on("libxml2")
 
-    depends_on("qt@3.3.8b", when='gui=qt3')
+    depends_on("qt@3:3.9", when='gui=qt3')
 
     # Dependencies for the openspeedshop cbtf packages.
     depends_on("cbtf@develop", when='@develop', type=('build', 'link', 'run'))

--- a/var/spack/repos/builtin/packages/openspeedshop/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop/package.py
@@ -96,7 +96,7 @@ class Openspeedshop(CMakePackage):
 
     depends_on("libxml2")
 
-    depends_on("qt@3", when='gui=qt3')
+    depends_on("qt@3.3.8b", when='gui=qt3')
 
     # Dependencies for the openspeedshop cbtf packages.
     depends_on("cbtf@develop", when='@develop', type=('build', 'link', 'run'))

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -132,9 +132,10 @@ class Qt(Package):
     depends_on("sqlite+column_metadata", when='+sql%intel', type=('build', 'run'))
 
     depends_on("libpng@1.2.57", when='@3')
+    depends_on("libsm", when='@3')
     depends_on("pcre+multibyte", when='@5.0:5.8')
     depends_on("inputproto", when='@:5.8')
-    depends_on("openssl@:1.0.999", when='@:5.9+ssl')
+    depends_on("openssl@:1.0.999", when='@4:5.9+ssl')
 
     depends_on("glib", when='@4:')
     depends_on("libpng", when='@4:')


### PR DESCRIPTION
This puts back the changes that caused the breakage.
Also add depends_on for libSM for the qt 3 build.  On some platforms the installed libSM is out of sync with libuuid causing build link errors.

Change the broke build:
```
@@ -149,7 +134,7 @@ class Qt(Package):
     depends_on("libpng@1.2.57", when='@3')
     depends_on("pcre+multibyte", when='@5.0:5.8')
     depends_on("inputproto", when='@:5.8')
-    depends_on("openssl@:1.0.999", when='@:5.9+ssl~krellpatch')
+    depends_on("openssl@:1.0.999", when='@:5.9+ssl')
```