### PR TITLE
Environments/views: only override spec prefix for non-external packages

### DIFF
--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -399,6 +399,11 @@ packages:
 
         e = ev.create('test', initial_yaml)
         e.concretize()
+        # Note: normally installing specs in a test environment requires doing
+        # a fake install, but not for external specs since no actions are
+        # taken to install them. The installation commands also include
+        # post-installation functions like DB-registration, so are important
+        # to do (otherwise the package is not considered installed).
         e.install_all()
         e.write()
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -370,6 +370,49 @@ env:
     assert not e2.specs_by_hash
 
 
+@pytest.mark.usefixtures('config')
+def test_env_view_external_prefix(tmpdir_factory, mutable_database,
+                                  mock_packages):
+    fake_prefix = tmpdir_factory.mktemp('a-prefix')
+    fake_bin = fake_prefix.join('bin')
+    fake_bin.ensure(dir=True)
+
+    initial_yaml = StringIO("""\
+env:
+  specs:
+  - a
+  view: true
+""")
+
+    external_config = StringIO("""\
+packages:
+  a:
+    paths:
+      a: {a_prefix}
+    buildable: false
+""".format(a_prefix=str(fake_prefix)))
+    external_config_dict = spack.util.spack_yaml.load_config(external_config)
+
+    test_scope = spack.config.InternalConfigScope(
+        'env-external-test', data=external_config_dict)
+    with spack.config.override(test_scope):
+
+        e = ev.create('test', initial_yaml)
+        e.concretize()
+        e.install_all()
+        e.write()
+
+        env_modifications = e.add_default_view_to_shell('sh')
+        individual_modifications = env_modifications.split('\n')
+
+        def path_includes_fake_prefix(cmd):
+            return 'export PATH' in cmd and str(fake_bin) in cmd
+
+        assert any(
+            path_includes_fake_prefix(cmd) for cmd in individual_modifications
+        )
+
+
 def test_init_with_file_and_remove(tmpdir):
     """Ensure a user can remove from any position in the spack.yaml file."""
     path = tmpdir.join('spack.yaml')

--- a/lib/spack/spack/user_environment.py
+++ b/lib/spack/spack/user_environment.py
@@ -65,7 +65,7 @@ def environment_modifications_for_spec(spec, view=None):
     This list is specific to the location of the spec or its projection in
     the view."""
     spec = spec.copy()
-    if view:
+    if view and not spec.external:
         spec.prefix = prefix.Prefix(view.view().get_projection_for_spec(spec))
 
     # generic environment modifications determined by inspecting the spec


### PR DESCRIPTION
For an environment that contains externally-defined packages (i.e. with `buildable: False` in `packages.yaml`), Spack was treating external packages as having the same prefix as other packages in the view. This allows external packages to retain their true prefix (as they are not actually linked into the view like Spack-installed packages).

~I haven't yet thoroughly checked this to ensure e.g. that this keeps system paths out of the shell modifications.~ (EDIT: there is now a test for that)

Fixes https://github.com/spack/spack/issues/14797
Fixes https://github.com/spack/spack/issues/14743

TODOs:

- [x] add test about removing system paths for external packages in views
- [x] confirm that test fails prior to this update