### PR TITLE
gitignore: pytest cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 .coverage
 \#*
 .#*
+.cache
 lib/spack/spack/test/.cache
 /bin/spackc
 *.in.log


### PR DESCRIPTION
@alalazo I believe #15354 moved the cache directory that pytest uses to store failed test results.