### PR TITLE
pgi: add missing paths in setup_run_environment

### DIFF
--- a/var/spack/repos/builtin/packages/pgi/package.py
+++ b/var/spack/repos/builtin/packages/pgi/package.py
@@ -91,6 +91,9 @@ class Pgi(Package):
     def setup_run_environment(self, env):
         prefix = Prefix(join_path(self.prefix, 'linux86-64', self.version))
 
+        env.prepend_path('PATH', prefix.bin)
+        env.prepend_path('MANPATH', prefix.man)
+        env.prepend_path('LD_LIBRARY_PATH', prefix.lib)
         env.set('CC',  join_path(prefix.bin, 'pgcc'))
         env.set('CXX', join_path(prefix.bin, 'pgc++'))
         env.set('F77', join_path(prefix.bin, 'pgfortran'))


### PR DESCRIPTION
Adjust PATH, MANPATH and LD_LIBRARY_PATH in the run environment.

These are also set in the module-files in the PGI compiler itself:
```
e.g. <pgi-install-path>/modulefiles/pgi/19.10:
...
    setenv PGI $pgihome
    setenv CC $pgidir/bin/pgcc
    setenv FC $pgidir/bin/pgfortran
    setenv F90 $pgidir/bin/pgfortran
    setenv F77 $pgidir/bin/pgfortran
    setenv CPP /bin/cpp
    setenv CXX $pgidir/bin/pgc++
    prepend-path PATH $pgidir/bin
    prepend-path MANPATH $pgidir/man
    if { $kern == "Darwin" } {
      prepend-path DYLD_LIBRARY_PATH $pgidir/lib
    } elseif { $kern == "Linux" } {
      prepend-path LD_LIBRARY_PATH $pgidir/lib
    }
...
```