### PR TITLE
py-astpretty: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-astpretty/package.py
+++ b/var/spack/repos/builtin/packages/py-astpretty/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyAstpretty(PythonPackage):
+    """Pretty print the output of python stdlib `ast.parse`."""
+
+    homepage = "https://github.com/asottile/astpretty"
+    url      = "https://pypi.io/packages/source/a/astpretty/astpretty-2.0.0.tar.gz"
+
+    version('2.0.0', sha256='e4724bfd753636ba4a84384702e9796e5356969f40af2596d846ce64addde086')
+
+    variant('typed', default=False, description='Add support for typed comments')
+
+    depends_on('python@3.6.1:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')
+    depends_on('py-typed-ast', type=('build', 'run'), when='+typed')

--- a/var/spack/repos/builtin/packages/py-astpretty/package.py
+++ b/var/spack/repos/builtin/packages/py-astpretty/package.py
@@ -17,5 +17,5 @@ class PyAstpretty(PythonPackage):
     variant('typed', default=False, description='Add support for typed comments')
 
     depends_on('python@3.6.1:', type=('build', 'run'))
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-typed-ast', type=('build', 'run'), when='+typed')


### PR DESCRIPTION
Successfully installs on macOS 10.15.3 with Clang 11.0.0 and Python 3.7.6.