### PR TITLE
When replacing path text in ELF binaries do not include null byte padding in search string

### DIFF
--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -447,7 +447,7 @@ def replace_prefix_bin(path_name, old_dir, new_dir):
         data = f.read()
         f.seek(0)
         original_data_len = len(data)
-        pat = re.compile(old_dir.encode('utf-8') + b'([^\0]*?)\0')
+        pat = re.compile(old_dir.encode('utf-8'))
         if not pat.search(data):
             return
         ndata = pat.sub(replace, data)


### PR DESCRIPTION
@eugeneswalker got this error using buildcache installs on RHEL8.
```
==> Relocating package from
  /super/absurdly/ridiculously/obnoxiously/long/path/for/relocation to /opt/spack/opt/spack.
==> Error: Doing a binary string replacement in /opt/spack/opt/spack/linux-rhel8-x86_64/gcc-7.3.0/pkgconf-1.6.3-mrunufrcl6il7w5yqi43dxmeshtdzsi2/lib/libpkgconf.so.3.0.0 failed.
The size of the file changed from 253992 to 254172
when it should have remanined the same.
```

This was tracked to using null byte strings in the search pattern for path text in the binary file. This method works for Mach-o paths but not for path strings in ELF binaries. Removing the null bytes from the string fixes the error.