### PR TITLE
geant4: Removed unnecessary definition of xerces-c.

### DIFF
--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -58,7 +58,6 @@ class Geant4(CMakePackage):
 
     depends_on("expat")
     depends_on("zlib")
-    depends_on("xerces-c")
     depends_on("gl", when='+opengl')
     depends_on("glx", when='+opengl+x11')
     depends_on("libx11", when='+x11')


### PR DESCRIPTION
@drbenmorgan
I got error when installing `geant4`.
```
==> Error: An unsatisfiable variant constraint has been detected for spec:

    xerces-c@3.2.2%fj@4.1.0 cxxstd=default transcoder=gnuiconv arch=linux-rhel8-thunderx2


while trying to concretize the partial spec:

    geant4@10.05.p01%fj@4.1.0 build_type=RelWithDebInfo cxxstd=11 +data~motif~opengl~qt+threads~vecgeom~x11 arch=linux-rhel8-thunderx2
        ^cmake@3.16.2%fj@4.1.0~doc+ncurses+openssl+ownlibs~qt arch=linux-rhel8-thunderx2
            ^ncurses
                ^pkgconfig
            ^openssl
                ^perl@5.14.0:
                    ^gdbm
                        ^readline
                ^zlib@1.2.11%fj@4.1.0+optimize+pic+shared arch=linux-rhel8-thunderx2


geant4 requires xerces-c variant cxxstd=11, but spec asked for cxxstd=default
```
Variants of 'cxxstd' can be selected one of [11,14,17], and 3 types of `xerces-c` dependency corresponding to cxxstd are already defined below.
```
    # C++11 support
    depends_on("xerces-c cxxstd=11", when="cxxstd=11")
    depends_on("clhep@2.3.3.0: cxxstd=11", when="@10.03.p03: cxxstd=11")
    depends_on("vecgeom cxxstd=11", when="+vecgeom cxxstd=11")

    # C++14 support
    depends_on("xerces-c cxxstd=14", when="cxxstd=14")
    depends_on("clhep@2.3.3.0: cxxstd=14", when="@10.03.p03: cxxstd=14")
    depends_on("vecgeom cxxstd=14", when="+vecgeom cxxstd=14")

    # C++17 support
    depends_on("xerces-c cxxstd=17", when="cxxstd=17")
    depends_on("clhep@2.3.3.0: cxxstd=17", when="@10.03.p03: cxxstd=17")
    patch('cxx17.patch', when='@:10.03.p99 cxxstd=17')
    patch('cxx17_geant4_10_0.patch', level=1, when='@10.04.00: cxxstd=17')
    depends_on("vecgeom cxxstd=17", when="+vecgeom cxxstd=17")
```
So, I think that following definition is unnecessary.
```
    depends_on("xerces-c")
```
Could you confirm this fix?