### PR TITLE
netcdf-c: remove maxdims and maxvars variant

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -76,22 +76,6 @@ class NetcdfC(AutotoolsPackage):
     # variant('cdmremote', default=False,
     #         description='Enable CDM Remote support')
 
-    # These variants control the number of dimensions (i.e. coordinates and
-    # attributes) and variables (e.g. time, entity ID, number of coordinates)
-    # that can be used in any particular NetCDF file.
-    variant(
-        'maxdims',
-        default=1024,
-        description='Defines the maximum dimensions of NetCDF files.',
-        values=is_integral
-    )
-    variant(
-        'maxvars',
-        default=8192,
-        description='Defines the maximum variables of NetCDF files.',
-        values=is_integral
-    )
-
     # The patch for 4.7.0 touches configure.ac. See force_autoreconf below.
     depends_on('autoconf', type='build', when='@4.7.0')
     depends_on('automake', type='build', when='@4.7.0')
@@ -156,20 +140,6 @@ class NetcdfC(AutotoolsPackage):
     def force_autoreconf(self):
         # The patch for 4.7.0 touches configure.ac.
         return self.spec.satisfies('@4.7.0')
-
-    def patch(self):
-        try:
-            max_dims = int(self.spec.variants['maxdims'].value)
-            max_vars = int(self.spec.variants['maxvars'].value)
-        except (ValueError, TypeError):
-            raise TypeError('NetCDF variant values max[dims|vars] must be '
-                            'integer values.')
-
-        ff = FileFilter(join_path('include', 'netcdf.h'))
-        ff.filter(r'^(#define\s+NC_MAX_DIMS\s+)\d+(.*)$',
-                  r'\1{0}\2'.format(max_dims))
-        ff.filter(r'^(#define\s+NC_MAX_VARS\s+)\d+(.*)$',
-                  r'\1{0}\2'.format(max_vars))
 
     def configure_args(self):
         cflags = []

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -5,6 +5,7 @@
 
 from spack import *
 
+
 class NetcdfC(AutotoolsPackage):
     """NetCDF (network Common Data Form) is a set of software libraries and
     machine-independent data formats that support the creation, access, and

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -5,17 +5,6 @@
 
 from spack import *
 
-import numbers
-
-
-def is_integral(x):
-    """Any integer value"""
-    try:
-        return isinstance(int(x), numbers.Integral) and not isinstance(x, bool)
-    except ValueError:
-        return False
-
-
 class NetcdfC(AutotoolsPackage):
     """NetCDF (network Common Data Form) is a set of software libraries and
     machine-independent data formats that support the creation, access, and


### PR DESCRIPTION
I'm not sure of the correct protocol to do this, so decided to make a stab and hopefully it works or I'm told the correct way...

The `maxdims` and `maxvars` variants for the NetCDF package were, to the best of my knowledge, only ever used for the Exodus library in the SEACAS package (which I maintain).  In versions of NetCDF prior to 4.4.0, Exodus required that the `NC_MAX_DIMS` and `NC_MAX_VARS` be increased over the default values.  This requirement was removed in 4.4.0 and later.

I do not know of any way to make a variant depend on the version and since the `maxdims` and `maxvars` variants are integer values and not boolean, then every build of NetCDF will have  these variants.  Typically `maxdims=1024 maxvars=8192` and the build will patch the `netcdf.h` include file for every build even though it is (almost) never needed. 

The SEACAS package has a NetCDF version requirement of >4.6.2, so it no longer specifies the `maxdims` or `maxvars` variant and I could find no other package in spack that uses this variant either, so removal should not break anything *in* spack.  However, there is no guarantee that some other external package doesn't use the variant, so I'm not sure of the correct way to remove the variant.  

For this PR, I simply removed the variants.  If there is a way to specify use of the variant tied to a specific version, I couldn't find it anywhere...