### PR TITLE
don't try to create failures/ directory in upstream repo

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -311,7 +311,7 @@ class Database(object):
         if not os.path.exists(self._db_dir):
             mkdirp(self._db_dir)
 
-        if not os.path.exists(self._failure_dir):
+        if not os.path.exists(self._failure_dir) and not is_upstream:
             mkdirp(self._failure_dir)
 
         self.is_upstream = is_upstream


### PR DESCRIPTION
When trying to use an upstream spack repository that is read-only, in particular,
the one on Summit, I got an error because Spack was trying to create the failures/
subdir in the upstream .spack_db.

This adds a little check to prevent slack from trying to mkdir failures/ in an upstream
repo.