### PR TITLE
openPMD-api: HDF5 1.12.0 Support

### DIFF
--- a/var/spack/repos/builtin/packages/openpmd-api/hdf5-1.12.0.patch
+++ b/var/spack/repos/builtin/packages/openpmd-api/hdf5-1.12.0.patch
@@ -1,0 +1,23 @@
+From 61ccc18cdd478c6281466f1f77de416559234dd8 Mon Sep 17 00:00:00 2001
+From: Axel Huebl <axel.huebl@plasma.ninja>
+Date: Tue, 17 Mar 2020 10:51:20 -0700
+Subject: [PATCH] HDF5: H5Oget_info Compatibility
+
+Update to work with HDF5 1.12.0 signature.
+Macro for older releases.
+---
+ src/IO/HDF5/HDF5IOHandler.cpp | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/IO/HDF5/HDF5IOHandler.cpp b/src/IO/HDF5/HDF5IOHandler.cpp
+index 7043861b..c125e1f4 100644
+--- a/src/IO/HDF5/HDF5IOHandler.cpp
++++ b/src/IO/HDF5/HDF5IOHandler.cpp
+@@ -1535,3 +1535,7 @@ void HDF5IOHandlerImpl::listAttributes(Writable* writable,
+     H5O_info_t object_info;
+     herr_t status;
++#if H5_VERSION_GE(1,12,0)
++    status = H5Oget_info(node_id, &object_info, H5O_INFO_NUM_ATTRS);
++#else
+     status = H5Oget_info(node_id, &object_info);
++#endif

--- a/var/spack/repos/builtin/packages/openpmd-api/package.py
+++ b/var/spack/repos/builtin/packages/openpmd-api/package.py
@@ -55,6 +55,10 @@ class OpenpmdApi(CMakePackage):
 
     extends('python', when='+python')
 
+    # Fix breaking HDF5 1.12.0 API
+    # https://github.com/openPMD/openPMD-api/pull/696
+    patch('hdf5-1.12.0.patch', when='@:0.11.0 +hdf5')
+
     def cmake_args(self):
         spec = self.spec
 


### PR DESCRIPTION
Fix API breakage in HDF5 1.12.0 for released versions.

cc @eugeneswalker: took me a day longer than expected due to the shelter-in-place announcement yesterday. Thank you again for reporting!

Refs.:
- https://github.com/openPMD/openPMD-api/pull/696
- Fix #15502