### PR TITLE
[WIP] libfabric: Install Logic in fabtests

### DIFF
--- a/var/spack/repos/builtin/packages/libfabric/package.py
+++ b/var/spack/repos/builtin/packages/libfabric/package.py
@@ -148,7 +148,7 @@ class Libfabric(AutotoolsPackage):
         super(Libfabric, self).install(spec, prefix)
 
         # Build and install fabtests, if available
-        if not os.path.isdir('fabtests'):
+        if not os.path.isdir('fabtests') or not self.run_tests:
             return
         with working_dir('fabtests'):
             configure = Executable('./configure')
@@ -162,7 +162,7 @@ class Libfabric(AutotoolsPackage):
         fi_info()
 
         # Run fabtests test suite if available
-        if not os.path.isdir('fabtests'):
+        if not os.path.isdir('fabtests') or not self.run_tests:
             return
         if self.spec.satisfies('@1.8.0,1.9.0'):
             # make test seems broken.


### PR DESCRIPTION
This does not fix the OSX issue, but should fix a logic issue in the install phase of libfabric for the default (non-test) install. This is likely causing the build errors on OSX.

See https://github.com/spack/spack/pull/15405#issuecomment-600362176
Re.: #15244 #15405 #15440

@LDAmorim @sethrj @carns @soumagne @ChristianTackeGSI I don't have OSX at hand and only see this in CI, can one of you please verify this fixes the spack build error?
Also, this might need an upstream bug report. 