### PR TITLE
triangle: add X11 dependency.

### DIFF
--- a/var/spack/repos/builtin/packages/triangle/package.py
+++ b/var/spack/repos/builtin/packages/triangle/package.py
@@ -18,6 +18,8 @@ class Triangle(Package):
 
     version('1.6', sha256='1766327add038495fa3499e9b7cc642179229750f7201b94f8e1b7bee76f8480')
 
+    depends_on('libx11', type='link')
+
     def install(self, spec, prefix):
         make()
         mkdirp(prefix.bin)


### PR DESCRIPTION
Triangle is used libX11. but dependency is missing.
This PR add libX11 dependency to triangle.