### PR TITLE
xsetpointer: fix wrong dependency type.

### DIFF
--- a/var/spack/repos/builtin/packages/xsetpointer/package.py
+++ b/var/spack/repos/builtin/packages/xsetpointer/package.py
@@ -14,9 +14,9 @@ class Xsetpointer(AutotoolsPackage):
 
     version('1.0.1', sha256='54be93b20fd6f1deac67246d6e214a60b02dcfbf05295e43751f7a04edb986ac')
 
-    depends_on('libxi')
-    depends_on('libx11')
+    depends_on('libxi', type='link')
+    depends_on('libx11', type='link')
+    depends_on('inputproto@1.4:', type='link')
 
-    depends_on('inputproto@1.4:', type='build')
     depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')


### PR DESCRIPTION
xsetpointer use inputproto's include file.
But dependency type of inputproto is 'build'.
This PR change dependency type to 'link'.