### PR TITLE
Minor fixes to set_permissions() in file_permissions.py

### DIFF
--- a/lib/spack/spack/util/file_permissions.py
+++ b/lib/spack/spack/util/file_permissions.py
@@ -25,10 +25,14 @@ def set_permissions(path, perms, group=None):
     # Preserve higher-order bits of file permissions
     perms |= os.stat(path).st_mode & (st.S_ISUID | st.S_ISGID | st.S_ISVTX)
 
-    # Do not let users create world writable suid binaries
-    if perms & st.S_ISUID and perms & st.S_IWGRP:
-        raise InvalidPermissionsError(
-            "Attepting to set suid with world writable")
+    # Do not let users create world/group writable suid binaries
+    if perms & st.S_ISUID:
+        if perms & st.S_IWOTH:
+            raise InvalidPermissionsError(
+                "Attempting to set suid with world writable")
+        if perms & st.S_IWGRP:
+            raise InvalidPermissionsError(
+                "Attempting to set suid with group writable")
 
     fs.chmod_x(path, perms)
 


### PR DESCRIPTION
Fix typo in alert message.
Check and alert for both world and group writable permissions before
setting suid (previously only checked for group, but comments/alert claimed was
checking world writable)