### PR TITLE
Split: Fabtest/libfabric

### DIFF
--- a/var/spack/repos/builtin/packages/fabtests/package.py
+++ b/var/spack/repos/builtin/packages/fabtests/package.py
@@ -7,15 +7,30 @@ from spack import *
 
 
 class Fabtests(AutotoolsPackage):
-    """Fabtests provides a set of examples that uses libfabric.
-
-    DEPRECATED. Fabtests has merged with the libfabric git repo."""
+    """Fabtests provides a set of runtime analysis tools and examples that use
+       libfabric."""
 
     homepage = "http://libfabric.org"
-    url      = "https://github.com/ofiwg/fabtests/releases/download/v1.5.3/fabtests-1.5.3.tar.gz"
+    url = "https://github.com/ofiwg/libfabric/releases/download/v1.9.1/fabtests-1.9.1.tar.bz2"
 
+    version('1.9.1', sha256='6f8ced2c6b3514759a0e177c8b2a19125e4ef0714d4cc0fe0386b33bd6cd5585')
+    version('1.9.0', sha256='60cc21db7092334904cbdafd142b2403572976018a22218e7c453195caef366e')
+    version('1.8.1', sha256='e9005d8fe73ca3849c872649c29811846bd72a62f897ecab73a08c7a9514f37b')
+    # old releases, published in a separate repository
+    version('1.6.2', sha256='37405c6202f5b1aa81f8ea211237a2d87937f06254fa3ed44a9b69ac73b234e8')
+    version('1.6.1', sha256='d357466b868fdaf1560d89ffac4c4e93a679486f1b4221315644d8d3e21174bf')
     version('1.6.0', sha256='dc3eeccccb005205017f5af60681ede15782ce202a0103450a6d56a7ff515a67')
     version('1.5.3', sha256='3835b3bf86cd00d23df0ddba8bf317e4a195e8d5c3c2baa918b373d548f77f29')
+    version('1.5.0', sha256='1dddd446c3f1df346899f9a8636f1b4265de5b863103ae24876e9f0c1e40a69d')
+    version('1.4.2', sha256='3b78d0ca1b223ff21b7f5b3627e67e358e3c18b700f86b017e2233fee7e88c2e')
 
-    depends_on('libfabric@1.6.0', when='@1.6.0')
-    depends_on('libfabric@1.5.3', when='@1.5.3')
+    for v in ['1.4.2', '1.5.0', '1.5.3', '1.6.0', '1.6.1', '1.6.2',
+              '1.8.1', '1.9.0', '1.9.1']:
+        depends_on('libfabric@{0}'.format(v), when='@{0}'.format(v))
+
+    def url_for_version(self, version):
+        if version >= Version('1.8.1'):
+            url = "https://github.com/ofiwg/libfabric/releases/download/v{0}/fabtests-{0}.tar.bz2"
+        else:
+            url = "https://github.com/ofiwg/fabtests/releases/download/v{0}/fabtests-{0}.tar.gz"
+        return url.format(version.dotted)

--- a/var/spack/repos/builtin/packages/libfabric/package.py
+++ b/var/spack/repos/builtin/packages/libfabric/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
 from spack import *
 
 
@@ -74,43 +73,6 @@ class Libfabric(AutotoolsPackage):
     depends_on('automake', when='@develop', type='build')
     depends_on('libtool', when='@develop', type='build')
 
-    resource(name='fabtests',
-             url='https://github.com/ofiwg/libfabric/releases/download/v1.9.1/fabtests-1.9.1.tar.bz2',
-             sha256='6f8ced2c6b3514759a0e177c8b2a19125e4ef0714d4cc0fe0386b33bd6cd5585',
-             placement='fabtests', when='@1.9.1')
-    resource(name='fabtests',
-             url='https://github.com/ofiwg/libfabric/releases/download/v1.9.0/fabtests-1.9.0.tar.bz2',
-             sha256='60cc21db7092334904cbdafd142b2403572976018a22218e7c453195caef366e',
-             placement='fabtests', when='@1.9.0')
-    resource(name='fabtests',
-             url='https://github.com/ofiwg/libfabric/releases/download/v1.8.0/fabtests-1.8.0.tar.gz',
-             sha256='4b9af18c9c7c8b28eaeac4e6e9148bd2ea7dc6b6f00f8e31c90a6fc536c5bb6c',
-             placement='fabtests', when='@1.8.0')
-    resource(name='fabtests',
-             url='https://github.com/ofiwg/libfabric/releases/download/v1.7.0/fabtests-1.7.0.tar.gz',
-             sha256='ebb4129dc69dc0e1f48310ce1abb96673d8ddb18166bc595312ebcb96e803de9',
-             placement='fabtests', when='@1.7.0')
-    resource(name='fabtests',
-             url='https://github.com/ofiwg/fabtests/releases/download/v1.6.1/fabtests-1.6.1.tar.gz',
-             sha256='d357466b868fdaf1560d89ffac4c4e93a679486f1b4221315644d8d3e21174bf',
-             placement='fabtests', when='@1.6.1')
-    resource(name='fabtests',
-             url='https://github.com/ofiwg/fabtests/releases/download/v1.6.0/fabtests-1.6.0.tar.gz',
-             sha256='dc3eeccccb005205017f5af60681ede15782ce202a0103450a6d56a7ff515a67',
-             placement='fabtests', when='@1.6.0')
-    resource(name='fabtests',
-             url='https://github.com/ofiwg/fabtests/releases/download/v1.5.3/fabtests-1.5.3.tar.gz',
-             sha256='3835b3bf86cd00d23df0ddba8bf317e4a195e8d5c3c2baa918b373d548f77f29',
-             placement='fabtests', when='@1.5.3')
-    resource(name='fabtests',
-             url='https://github.com/ofiwg/fabtests/releases/download/v1.5.0/fabtests-1.5.0.tar.gz',
-             sha256='1dddd446c3f1df346899f9a8636f1b4265de5b863103ae24876e9f0c1e40a69d',
-             placement='fabtests', when='@1.5.0')
-    resource(name='fabtests',
-             url='https://github.com/ofiwg/fabtests/releases/download/v1.4.2/fabtests-1.4.2.tar.gz',
-             sha256='3b78d0ca1b223ff21b7f5b3627e67e358e3c18b700f86b017e2233fee7e88c2e',
-             placement='fabtests', when='@1.4.2')
-
     conflicts('@1.9.0', when='platform=darwin',
               msg='This distribution is missing critical files')
 
@@ -122,10 +84,6 @@ class Libfabric(AutotoolsPackage):
     def autoreconf(self, spec, prefix):
         bash = which('bash')
         bash('./autogen.sh')
-
-        if self.run_tests:
-            with working_dir('fabtests'):
-                bash('./autogen.sh')
 
     def configure_args(self):
         args = []
@@ -143,29 +101,6 @@ class Libfabric(AutotoolsPackage):
 
         return args
 
-    def install(self, spec, prefix):
-        # Call main install method
-        super(Libfabric, self).install(spec, prefix)
-
-        # Build and install fabtests, if available
-        if not os.path.isdir('fabtests'):
-            return
-        with working_dir('fabtests'):
-            configure = Executable('./configure')
-            configure('--prefix={0}'.format(self.prefix),
-                      '--with-libfabric={0}'.format(self.prefix))
-            make()
-            make('install')
-
     def installcheck(self):
         fi_info = Executable(self.prefix.bin.fi_info)
         fi_info()
-
-        # Run fabtests test suite if available
-        if not os.path.isdir('fabtests'):
-            return
-        if self.spec.satisfies('@1.8.0,1.9.0'):
-            # make test seems broken.
-            return
-        with working_dir('fabtests'):
-            make('test')


### PR DESCRIPTION
Fabtests provides runtime analysis tools and examples of libfabric.

As with other projects that are [tightly version-bound](https://github.com/ofiwg/libfabric/blob/33ea19fd66119b8218dc50678f240d44084c2690/.travis.yml#L110-L118), e.g. `py-adios` and `adios`, the fact that releases stem from the same repo does not imply they should be the same package.

Remove resources, which [complicate the libfabric build](https://github.com/spack/spack/issues/15244), and update the fabtests package accordingly.

See https://github.com/spack/spack/pull/15405#issuecomment-600362176
See https://github.com/spack/spack/pull/15405#issuecomment-600501395
Re.: #15244 #15405 #15440

CC: @LDAmorim @sethrj @carns @soumagne @ChristianTackeGSI please confirm this works for you. Be aware that `fabtests` are probably still failing on OSX, which is an upstream issue, but libfabric should now install fine again on OSX.

CCing also @baberlevi as he previously edited these files, too.