### PR TITLE
amdblis: fix display spack info and virtual package setting.

### DIFF
--- a/var/spack/repos/builtin/packages/amdblis/package.py
+++ b/var/spack/repos/builtin/packages/amdblis/package.py
@@ -21,7 +21,3 @@ class Amdblis(BlisBase):
     git = "https://github.com/amd/blis.git"
 
     version('2.1', sha256='3b1d611d46f0f13b3c0917e27012e0f789b23dbefdddcf877b20327552d72fb3')
-
-    @property
-    def libs(self):
-        return find_libraries(['libblis'], root=self.prefix, recursive=True)

--- a/var/spack/repos/builtin/packages/amdblis/package.py
+++ b/var/spack/repos/builtin/packages/amdblis/package.py
@@ -15,8 +15,13 @@ class Amdblis(BlisBase):
     computationally intensive operations.
     """
 
+    _name = 'amdblis'
     homepage = "https://developer.amd.com/amd-aocl/blas-library/"
     url = "https://github.com/amd/blis/archive/2.1.tar.gz"
     git = "https://github.com/amd/blis.git"
 
     version('2.1', sha256='3b1d611d46f0f13b3c0917e27012e0f789b23dbefdddcf877b20327552d72fb3')
+
+    @property
+    def libs(self):
+        return find_libraries(['libblis'], root=self.prefix, recursive=True)

--- a/var/spack/repos/builtin/packages/blis/package.py
+++ b/var/spack/repos/builtin/packages/blis/package.py
@@ -102,6 +102,10 @@ class BlisBase(Package):
         if self.spec.satisfies('platform=darwin'):
             fix_darwin_install_name(self.prefix.lib)
 
+    @property
+    def libs(self):
+        return find_libraries(['libblis'], root=self.prefix, recursive=True)
+
 
 class Blis(BlisBase):
     """BLIS is a portable software framework for instantiating high-performance


### PR DESCRIPTION
In `spack info amdblis` , package name is blis.
And amdblis dose not provide blas virtual package.
This PR fixes those problems.
<pre>
$ spack info amdblis
Package:   blis

Description:
    AMD Optimized BLIS. BLIS is a portable software framework for
    instantiating high-performance BLAS-like dense linear algebra libraries.
    The framework was designed to isolate essential kernels of computation
    that, when optimized, immediately enable optimized implementations of
    most of its commonly used and computationally intensive operations.

Homepage: https://developer.amd.com/amd-aocl/blas-library/

Tags:
    None

Preferred version:
    2.1    https://github.com/amd/blis/archive/2.1.tar.gz

Safe versions:
    2.1    https://github.com/amd/blis/archive/2.1.tar.gz

Variants:
    Name [Default]    Allowed values          Descriptio
    ==============    ====================    ======================

    blas [on]         True, False             BLAS compatibility
    cblas [on]        True, False             CBLAS compatibility
    shared [on]       True, False             Build shared library
    static [on]       True, False             Build static library
    threads [none]    pthreads, openmp,       Multithreading support
                      none

Installation Phases:
    configure    build    install

Build Dependencies:
    python

Link Dependencies:
    None

Run Dependencies:
    python

Virtual Packages:
    blis+cblas provides blas
    blis+blas provides blas
$ spack install superlu-mt ^amdblis
==> Error: Package superlu-mt does not depend on amdblis
</pre>