### PR TITLE
Remove some Intel MKL/Parallel Studio variants

### DIFF
--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -79,8 +79,7 @@ class Cp2k(MakefilePackage, CudaPackage):
     depends_on('openblas threads=openmp', when='blas=openblas +openmp')
     depends_on('lapack', when='blas=openblas ~openmp')
 
-    depends_on('intel-mkl', when="blas=mkl ~openmp")
-    depends_on('intel-mkl threads=openmp', when='blas=mkl +openmp')
+    depends_on('mkl', when="blas=mkl")
 
     conflicts('blas=accelerate', '+openmp')  # there is no Accelerate with OpenMP support
 

--- a/var/spack/repos/builtin/packages/elemental/package.py
+++ b/var/spack/repos/builtin/packages/elemental/package.py
@@ -61,9 +61,8 @@ class Elemental(CMakePackage):
     # Allow Elemental to build internally when using 8-byte ints
     depends_on('openblas threads=openmp', when='blas=openblas +openmp_blas ~int64_blas')
 
-    depends_on('intel-mkl', when="blas=mkl ~openmp_blas ~int64_blas")
-    depends_on('intel-mkl threads=openmp', when='blas=mkl +openmp_blas ~int64_blas')
-    depends_on('intel-mkl@2017.1 +openmp +ilp64', when='blas=mkl +openmp_blas +int64_blas')
+    depends_on('intel-mkl', when='blas=mkl ~int64_blas')
+    depends_on('intel-mkl@2017.1', when='blas=mkl +openmp_blas +int64_blas')
 
     depends_on('veclibfort', when='blas=accelerate')
 

--- a/var/spack/repos/builtin/packages/hpl/package.py
+++ b/var/spack/repos/builtin/packages/hpl/package.py
@@ -105,8 +105,7 @@ class Hpl(AutotoolsPackage):
             'CFLAGS=-O3'
         ]
 
-        if (self.spec.satisfies('^intel-mkl') or
-            self.spec.satisfies('^intel-parallel-studio+mkl')):
+        if '^mkl' in spec:
             config.append('LDFLAGS={0}'.format(
                 self.spec['blas'].libs.ld_flags))
 

--- a/var/spack/repos/builtin/packages/hydrogen/package.py
+++ b/var/spack/repos/builtin/packages/hydrogen/package.py
@@ -68,9 +68,9 @@ class Hydrogen(CMakePackage):
     depends_on('openblas threads=openmp +lip64', when='blas=openblas +openmp_blas +int64_blas')
 
     depends_on('intel-mkl', when="blas=mkl ~openmp_blas ~int64_blas")
-    depends_on('intel-mkl +ilp64', when="blas=mkl ~openmp_blas +int64_blas")
-    depends_on('intel-mkl threads=openmp', when='blas=mkl +openmp_blas ~int64_blas')
-    depends_on('intel-mkl@2017.1 +openmp +ilp64', when='blas=mkl +openmp_blas +int64_blas')
+    depends_on('intel-mkl', when="blas=mkl ~openmp_blas +int64_blas")
+    depends_on('intel-mkl', when='blas=mkl +openmp_blas ~int64_blas')
+    depends_on('intel-mkl@2017.1', when='blas=mkl +openmp_blas +int64_blas')
 
     depends_on('veclibfort', when='blas=accelerate')
     conflicts('blas=accelerate +openmp_blas')

--- a/var/spack/repos/builtin/packages/intel-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-mkl/package.py
@@ -56,21 +56,12 @@ class IntelMkl(IntelPackage):
 
     depends_on('cpio', type='build')
 
-    variant('shared', default=True, description='Builds shared library')
-    variant('ilp64', default=False, description='64 bit integers')
-    variant(
-        'threads', default='none',
-        description='Multithreading support',
-        values=('openmp', 'tbb', 'none'),
-        multi=False
-    )
-
     provides('blas')
     provides('lapack')
     provides('scalapack')
     provides('mkl')
     provides('fftw-api@3', when='@2017:')
 
-    if sys.platform == 'darwin':
-        # there is no libmkl_gnu_thread on macOS
-        conflicts('threads=openmp', when='%gcc')
+    # Note: there is no libmkl_gnu_thread on macOS
+    # if sys.platform == 'darwin':
+    #    conflicts('threads=openmp', when='%gcc')

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -129,16 +129,6 @@ class IntelParallelStudio(IntelPackage):
             description='Add rpath to .cfg files')
     variant('newdtags', default=False,
             description='Allow use of --enable-new-dtags in MPI wrappers')
-    variant('shared',   default=True,
-            description='Builds shared library')
-    variant('ilp64',    default=False,
-            description='64 bit integers')
-    variant(
-        'threads', default='none',
-        description='Multithreading support',
-        values=('openmp', 'none'),
-        multi=False
-    )
 
     auto_dispatch_options = IntelPackage.auto_dispatch_options
     variant(
@@ -150,16 +140,8 @@ class IntelParallelStudio(IntelPackage):
     # Components available in all editions
     variant('daal', default=True,
             description='Install the Intel DAAL libraries')
-    variant('gdb',  default=False,
-            description='Install the Intel Debugger for Heterogeneous Compute')
-    variant('ipp',  default=True,
-            description='Install the Intel IPP libraries')
-    variant('mkl',  default=True,
-            description='Install the Intel MKL library')
     variant('mpi',  default=True,
             description='Install the Intel MPI library')
-    variant('tbb',  default=True,
-            description='Install the Intel TBB libraries')
 
     # Components only available in the Professional and Cluster Editions
     variant('advisor',   default=False,
@@ -176,17 +158,16 @@ class IntelParallelStudio(IntelPackage):
     provides('daal',        when='+daal')
     provides('ipp',         when='+ipp')
 
-    provides('mkl',         when='+mkl')
-    provides('blas',        when='+mkl')
-    provides('lapack',      when='+mkl')
-    provides('scalapack',   when='+mkl')
+    provides('mkl')
+    provides('blas')
+    provides('lapack')
+    provides('scalapack')
 
     provides('mpi',         when='+mpi')
-    provides('tbb',         when='+tbb')
 
     # For TBB, static linkage is not and has never been supported by Intel:
     # https://www.threadingbuildingblocks.org/faq/there-version-tbb-provides-statically-linked-libraries
-    conflicts('+tbb',       when='~shared')
+    provides('tbb')
 
     conflicts('+advisor',   when='@composer.0:composer.9999')
     conflicts('+clck',      when='@composer.0:composer.9999')

--- a/var/spack/repos/builtin/packages/kaldi/package.py
+++ b/var/spack/repos/builtin/packages/kaldi/package.py
@@ -67,7 +67,7 @@ class Kaldi(Package):    # Does not use Autotools
             configure_args.append('--atlas-root=' + spec['blas'].prefix)
             if '+pthread' in spec['blas'].variants:
                 configure_args.append('--threaded-atlas')
-        elif '^intel-parallel-studio' in spec or '^intel-mkl' in spec:
+        elif '^mkl' in spec:
             configure_args.append('--mathlib=MKL')
             configure_args.append('--mkl-root=' + spec['blas'].prefix)
             if '+openmp' in spec['blas'].variants:

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -170,7 +170,7 @@ class PyNumpy(PythonPackage):
 
         # Tell numpy where to find BLAS/LAPACK libraries
         with open('site.cfg', 'w') as f:
-            if '^intel-mkl' in spec or '^intel-parallel-studio+mkl' in spec:
+            if '^mkl' in spec:
                 f.write('[mkl]\n')
                 # FIXME: as of @1.11.2, numpy does not work with separately
                 # specified threading and interface layers. A workaround is a
@@ -240,8 +240,7 @@ class PyNumpy(PythonPackage):
         # https://numpy.org/devdocs/user/building.html#blas
         if 'blas' not in spec:
             blas = ''
-        elif spec['blas'].name == 'intel-mkl' or \
-                spec['blas'].name == 'intel-parallel-studio':
+        elif '^mkl' in spec:
             blas = 'mkl'
         elif spec['blas'].name == 'blis':
             blas = 'blis'
@@ -259,8 +258,7 @@ class PyNumpy(PythonPackage):
         # https://numpy.org/devdocs/user/building.html#lapack
         if 'lapack' not in spec:
             lapack = ''
-        elif spec['lapack'].name == 'intel-mkl' or \
-                spec['lapack'].name == 'intel-parallel-studio':
+        elif '^mkl' in spec:
             lapack = 'mkl'
         elif spec['lapack'].name == 'openblas':
             lapack = 'openblas'

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -92,8 +92,7 @@ class Qmcpack(CMakePackage, CudaPackage):
     conflicts('^openblas+ilp64',
               msg='QMCPACK does not support OpenBLAS 64-bit integer variant')
 
-    conflicts('^intel-mkl+ilp64',
-              msg='QMCPACK does not support MKL 64-bit integer variant')
+    # Note: QMCPACK does not support the MKL 64-bit integer interface
 
     # QMCPACK 3.6.0 or later requires support for C++14
     compiler_warning = 'QMCPACK 3.6.0 or later requires a ' \
@@ -118,9 +117,9 @@ class Qmcpack(CMakePackage, CudaPackage):
     # try to use Intel MKL with a non-Intel compiler.
     mkl_warning = 'QMCPACK releases prior to 3.5.0 require the ' \
                   'Intel compiler when linking against Intel MKL'
-    conflicts('%gcc', when='@:3.4.0 ^intel-mkl', msg=mkl_warning)
-    conflicts('%pgi', when='@:3.4.0 ^intel-mkl', msg=mkl_warning)
-    conflicts('%llvm', when='@:3.4.0 ^intel-mkl', msg=mkl_warning)
+    conflicts('%gcc', when='@:3.4.0 ^mkl', msg=mkl_warning)
+    conflicts('%pgi', when='@:3.4.0 ^mkl', msg=mkl_warning)
+    conflicts('%llvm', when='@:3.4.0 ^mkl', msg=mkl_warning)
 
     # Dependencies match those in the QMCPACK manual.
     # FIXME: once concretizer can unite unconditional and conditional
@@ -323,7 +322,7 @@ class Qmcpack(CMakePackage, CudaPackage):
         # Next two environment variables were introduced in QMCPACK 3.5.0
         # Prior to v3.5.0, these lines should be benign but CMake
         # may issue a warning.
-        if 'intel-mkl' in spec:
+        if '^mkl' in spec:
             args.append('-DENABLE_MKL=1')
             args.append('-DMKL_ROOT=%s' % env['MKLROOT'])
         else:

--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -76,11 +76,7 @@ class QuantumEspresso(Package):
     patch('dspev_drv_elpa.patch', when='@6.1.0:+patch+elpa ^elpa@2016.05.003')
 
     # Conflicts
-    # MKL with 64-bit integers not supported.
-    conflicts(
-        '^mkl+ilp64',
-        msg='Quantum ESPRESSO does not support MKL 64-bit integer variant'
-    )
+    # Note: MKL with 64-bit integers not supported.
 
     # We can't ask for scalapack or elpa if we don't want MPI
     conflicts(

--- a/var/spack/repos/builtin/packages/sirius/package.py
+++ b/var/spack/repos/builtin/packages/sirius/package.py
@@ -152,7 +152,7 @@ class Sirius(CMakePackage, CudaPackage):
                     spec['scalapack'].libs.joined(';')),
             ]
 
-        if spec['blas'].name in ['intel-mkl', 'intel-parallel-studio']:
+        if '^mkl' in spec:
             args += ['-DUSE_MKL=ON']
 
         if '+elpa' in spec:

--- a/var/spack/repos/builtin/packages/suite-sparse/package.py
+++ b/var/spack/repos/builtin/packages/suite-sparse/package.py
@@ -31,6 +31,7 @@ class SuiteSparse(Package):
     variant('pic',  default=True,  description='Build position independent code (required to link with shared libraries)')
     variant('cuda', default=False, description='Build with CUDA')
     variant('openmp', default=False, description='Build with OpenMP')
+    variant('mkl64', default=False, description='Build with 64 bit MKL interface.')
 
     depends_on('blas')
     depends_on('lapack')
@@ -96,9 +97,7 @@ class SuiteSparse(Package):
         ]
 
         # 64bit blas in UMFPACK:
-        if (spec.satisfies('^openblas+ilp64') or
-            spec.satisfies('^intel-mkl+ilp64') or
-            spec.satisfies('^intel-parallel-studio+mkl+ilp64')):
+        if '^openblas+ilp64' in spec or ('^mkl' in spec and '+mkl64' in spec):
             make_args.append('UMFPACK_CONFIG=-DLONGBLAS="long long"')
 
         # SuiteSparse defaults to using '-fno-common -fexceptions' in


### PR DESCRIPTION
- This PR concerns the intel-mkl, intel-parallel-studio packages and packages depending on them that may be affected

- The variants do not change the composition of the intel-mkl and intel-parallel-sudio packages. They are only there to denote various components/features of the package which are bundled in the installation regardless of the value of the variant. Dependent packages have started using the variants to distinguish between variants that should really belong to them. This has the unfortunate consequence that often unnecessary fetching/installation steps are performed of Intel MKL/Parallel Studio causing increased disk consumption and wasting time.

- [TODO] Most variants for intel-parallel-studio can be removed if the corresponding `conflict` clauses are propagated to depending packages and the version information in `when=` is made explicit there. At the moment, these variants appear to serve as a convenient alias to the version information in the `when=` statement. If that is the intended behaviour and frequent installations is not an issue, I will rescind the PR.

- The following packages depend on Intel MKL and Intel Parallel Studio
  but do not need to be modified:
    
    namd
    py-numpy
    petsc
    sirius
    plasma
    ghost
    py-torch
    dftfe
    hpl
    slate
    intel-mkl-dnn
    kaldi
    abyss
    gaudi
    intel-mpi
    esmf
    sirius
    converge
    exabayes
    r-rmpi
    intel

- The following dependent packages may need further work: 
    
    suite-sparse
    qmcpack
    dealii 

    Appropriate variants may need to be introduced.