### PR TITLE
Finer selection of virtual providers

### DIFF
--- a/bin/spack
+++ b/bin/spack
@@ -42,6 +42,9 @@ sys.path.insert(0, spack_lib_path)
 # Add external libs
 spack_external_libs = os.path.join(spack_lib_path, "external")
 
+if sys.version_info[:1] == (2,):
+    sys.path.insert(0, os.path.join(spack_external_libs, 'py2'))
+
 if sys.version_info[:2] == (2, 6):
     sys.path.insert(0, os.path.join(spack_external_libs, 'py26'))
 

--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -1206,7 +1206,16 @@ for ``lapack`` and ``blas``:
        ^openblas@0.3.9%gcc@9.0.1~consistent_fpcsr~ilp64+pic+shared threads=none arch=linux-ubuntu18.04-broadwell
 
 The ``^<virtual>=<spec>`` syntax tells Spack to use ``<spec>`` to satisfy the
-requested virtual, and to only use other virtuals provided by it as a last resort.
+requested virtual (so ``^mpi=intel-parallel-studio`` tells Spack to use
+``intel-parallel-studio`` as the ``mpi`` provider) and to consider its other virtual
+dependencies after any other explicitly mentioned package. Adding ``^openblas``
+to the spec thus means that ``openblas`` will then be used for ``lapack``, and
+``blas`` because it is specified explicitly.
+
+In this example, that covers all the virtual dependencies, but if there were other
+virtual dependencies, Spack could try to satisfy them with ``intel-parallel-studio``.
+For instance, if another package depended on ``tbb`` or ``daal`` (which ``intel-parallel-studio``
+also provides), Spack could use ``intel-parallel-studio`` to satisfy them as a last resort.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^
 Specifying Specs by Hash

--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -1167,6 +1167,43 @@ any MPI implementation will do.  If another package depends on
 error.  Likewise, if you try to plug in some package that doesn't
 provide MPI, Spack will raise an error.
 
+""""""""""""""""""""""""""""""""""""""""
+Explicit binding of virtual dependencies
+""""""""""""""""""""""""""""""""""""""""
+
+There are packages that provide more than just one virtual dependency.
+When interacting with them users might be willing to pick only
+a single virtual dependency from the package and use different providers for
+the others. For instance we might want to use ``intel-parallel-studio`` for
+``mpi`` and ``openblas`` for both ``lapack`` and ``blas``:
+
+.. code-block:: console
+
+   $ spack spec netlib-scalapack ^mpi=intel-parallel-studio@cluster+mpi ^openblas
+   Input spec
+   --------------------------------
+   netlib-scalapack
+       ^intel-parallel-studio@cluster+mpi
+       ^openblas
+
+   Concretized
+   --------------------------------
+   netlib-scalapack@2.1.0%gcc@9.0.1 build_type=RelWithDebInfo patches=f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2 ~pic+shared arch=linux-ubuntu18.04-broadwell
+       ^cmake@3.16.5%gcc@9.0.1~doc+ncurses+openssl+ownlibs~qt arch=linux-ubuntu18.04-broadwell
+           ^ncurses@6.2%gcc@9.0.1~symlinks+termlib arch=linux-ubuntu18.04-broadwell
+               ^pkgconf@1.6.3%gcc@9.0.1 arch=linux-ubuntu18.04-broadwell
+           ^openssl@1.1.1e%gcc@9.0.1+systemcerts arch=linux-ubuntu18.04-broadwell
+               ^perl@5.30.1%gcc@9.0.1+cpanm+shared+threads arch=linux-ubuntu18.04-broadwell
+                   ^gdbm@1.18.1%gcc@9.0.1 arch=linux-ubuntu18.04-broadwell
+                       ^readline@8.0%gcc@9.0.1 arch=linux-ubuntu18.04-broadwell
+               ^zlib@1.2.11%gcc@9.0.1+optimize+pic+shared arch=linux-ubuntu18.04-broadwell
+       ^intel-parallel-studio@cluster%gcc@9.0.1~advisor auto_dispatch=none ~clck+daal~gdb~ilp64~inspector+ipp~itac+mkl+mpi~newdtags+rpath+shared+tbb threads=none ~vtune arch=linux-ubuntu18.04-broadwell
+       ^openblas@0.3.9%gcc@9.0.1~consistent_fpcsr~ilp64+pic+shared threads=none arch=linux-ubuntu18.04-broadwell
+
+The ``^<virtual>=<spec>`` syntax tells Spack to use that ``spec`` for the virtual
+that has been specified and gives the lowest possible concretization priority to
+all the other virtual dependencies that are provided by the same package.
+
 ^^^^^^^^^^^^^^^^^^^^^^^^
 Specifying Specs by Hash
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -1172,10 +1172,15 @@ Explicit binding of virtual dependencies
 """"""""""""""""""""""""""""""""""""""""
 
 There are packages that provide more than just one virtual dependency.
-When interacting with them users might be willing to pick only
-a single virtual dependency from the package and use different providers for
-the others. For instance we might want to use ``intel-parallel-studio`` for
-``mpi`` and ``openblas`` for both ``lapack`` and ``blas``:
+When interacting with them users might want to pick only
+a single virtual dependency from one package and use different providers for
+the others. For example, consider these two packages:
+
+* ``intel-parallel-studio``, which provides ``mpi``, ``lapack``, and ``blas``
+* ``openblas``, which provides ``lapack`` and ``blas``
+
+We might want to use ``intel-parallel-studio`` for ``mpi`` and ``openblas``
+for ``lapack`` and ``blas``:
 
 .. code-block:: console
 
@@ -1200,9 +1205,8 @@ the others. For instance we might want to use ``intel-parallel-studio`` for
        ^intel-parallel-studio@cluster%gcc@9.0.1~advisor auto_dispatch=none ~clck+daal~gdb~ilp64~inspector+ipp~itac+mkl+mpi~newdtags+rpath+shared+tbb threads=none ~vtune arch=linux-ubuntu18.04-broadwell
        ^openblas@0.3.9%gcc@9.0.1~consistent_fpcsr~ilp64+pic+shared threads=none arch=linux-ubuntu18.04-broadwell
 
-The ``^<virtual>=<spec>`` syntax tells Spack to use that ``spec`` for the virtual
-that has been specified and gives the lowest possible concretization priority to
-all the other virtual dependencies that are provided by the same package.
+The ``^<virtual>=<spec>`` syntax tells Spack to use ``<spec>`` to satisfy the
+requested virtual, and to only use other virtuals provided by it as a last resort.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^
 Specifying Specs by Hash

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2422,8 +2422,8 @@ Packages can provide multiple virtual dependencies and sometimes, due mainly
 to implementation details, they need to provide them simultaneously. A good
 example for such a case is ``openblas``. This package provides both the ``lapack``
 and ``blas`` APIs in a single library called ``libopenblas`` therefore, if a
-spec is using ``openblas`` for one of the two virtuals, it needs to use it
-also for the other.
+spec is using ``openblas`` for one of the two virtuals, it must use it
+for the other, as well.
 
 To express this constraint in a package, the two virtual dependencies must be
 listed in the same ``provides`` directive:

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2414,6 +2414,41 @@ The ``provides("mpi")`` call tells Spack that the ``mpich`` package
 can be used to satisfy the dependency of any package that
 ``depends_on('mpi')``.
 
+""""""""""""""""""""""""""""""""""""""""""""""
+Providing multiple dependencies simultaneously
+""""""""""""""""""""""""""""""""""""""""""""""
+
+Packages can provide multiple virtual dependencies and sometimes, due mainly
+to implementation details, they need to provide them simultaneously. A good
+example for such a case is ``openblas``. This package provides both the ``lapack``
+and ``blas`` APIs in a single library called ``libopenblas`` therefore, if a
+spec is using ``openblas`` for one of the two virtuals, it needs to use it
+also for the other.
+
+To express this constraint in a package, the two virtual dependencies must be
+listed in the same ``provides`` directive:
+
+.. code-block:: python
+
+   provides('blas', 'lapack')
+
+This makes it impossible to select ``openblas`` as a provider for one of the two
+virtual dependencies and not for the other. Any request to do so results in an
+error message:
+
+.. code-block:: console
+
+   $ spack spec netlib-scalapack  ^openblas ^blas=atlas
+   Input spec
+   --------------------------------
+   netlib-scalapack
+       ^atlas
+       ^openblas
+
+   Concretized
+   --------------------------------
+   ==> Error: "openblas" needs to be a provider for "blas" if used as a provider for "lapack"
+
 ^^^^^^^^^^^^^^^^^^^^
 Versioned Interfaces
 ^^^^^^^^^^^^^^^^^^^^

--- a/lib/spack/external/__init__.py
+++ b/lib/spack/external/__init__.py
@@ -17,6 +17,13 @@ argparse
   vendored copy ever needs to be updated again:
   https://github.com/spack/spack/pull/6786/commits/dfcef577b77249106ea4e4c69a6cd9e64fa6c418
 
+chainmap
+--------
+
+* Homepage: https://bitbucket.org/jeunice/chainmap/src/default/
+* Usage: Port of collections.ChainMap for Python 2.6 and 2.7
+* Version: 1.0.3
+
 ctest_log_parser
 ----------------
 

--- a/lib/spack/external/__init__.py
+++ b/lib/spack/external/__init__.py
@@ -23,6 +23,7 @@ chainmap
 * Homepage: https://bitbucket.org/jeunice/chainmap/src/default/
 * Usage: Port of collections.ChainMap for Python 2.6 and 2.7
 * Version: 1.0.3
+* License: https://bitbucket.org/jeunice/chainmap/src/default/LICENSE.txt
 
 ctest_log_parser
 ----------------

--- a/lib/spack/external/py2/chainmap.py
+++ b/lib/spack/external/py2/chainmap.py
@@ -1,0 +1,154 @@
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
+
+
+try:
+    from thread import get_ident
+except ImportError:
+    try:
+        from threading import _get_ident as get_ident
+    except ImportError:
+        from threading import get_ident
+
+
+def _recursive_repr(fillvalue='...'):
+    'Decorator to make a repr function return fillvalue for a recursive call'
+
+    def decorating_function(user_function):
+        repr_running = set()
+
+        def wrapper(self):
+            key = id(self), get_ident()
+            if key in repr_running:
+                return fillvalue
+            repr_running.add(key)
+            try:
+                result = user_function(self)
+            finally:
+                repr_running.discard(key)
+            return result
+
+        # Can't use functools.wraps() here because of bootstrap issues
+        wrapper.__module__ = getattr(user_function, '__module__')
+        wrapper.__doc__ = getattr(user_function, '__doc__')
+        wrapper.__name__ = getattr(user_function, '__name__')
+        wrapper.__annotations__ = getattr(user_function, '__annotations__', {})
+        return wrapper
+
+    return decorating_function
+
+
+class ChainMap(MutableMapping):
+    """
+    A ChainMap groups multiple dicts (or other mappings) together to create a
+    single, updateable view.
+
+    The underlying mappings are stored in a list.  That list is public and can
+    accessed or updated using the *maps* attribute.  There is no other state.
+
+    Lookups search the underlying mappings successively until a key is found. In
+    contrast, writes, updates, and deletions only operate on the first mapping.
+    """
+
+    def __init__(self, *maps):
+        """
+        Initialize a ChainMap by setting *maps* to the given mappings.
+        If no mappings are provided, a single empty dictionary is used.
+        """
+        self.maps = list(maps) or [{}]          # always at least one map
+
+    def __missing__(self, key):
+        raise KeyError(key)
+
+    def __getitem__(self, key):
+        for mapping in self.maps:
+            try:
+                return mapping[key]             # can't use 'key in mapping' with defaultdict
+            except KeyError:
+                pass
+        return self.__missing__(key)            # support subclasses that define __missing__
+
+    def get(self, key, default=None):
+        return self[key] if key in self else default
+
+    def __len__(self):
+        return len(set().union(*self.maps))     # reuses stored hash values if possible
+
+    def __iter__(self):
+        return iter(set().union(*self.maps))
+
+    def __contains__(self, key):
+        return any(key in m for m in self.maps)
+
+    def __bool__(self):
+        return any(self.maps)
+
+    @_recursive_repr()
+    def __repr__(self):
+        return '{0.__class__.__name__}({1})'.format(
+            self, ', '.join(map(repr, self.maps)))
+
+    @classmethod
+    def fromkeys(cls, iterable, *args):
+        "Create a ChainMap with a single dict created from the iterable."
+        return cls(dict.fromkeys(iterable, *args))
+
+    def copy(self):
+        """
+        New ChainMap or subclass with a new copy of ``maps[0]`` and refs 
+        to ``maps[1:]``
+        """
+        return self.__class__(self.maps[0].copy(), *self.maps[1:])
+
+    __copy__ = copy
+
+    def new_child(self, m=None):                # like Django's Context.push()
+        """
+        New ChainMap with a new map followed by all previous maps. If no
+        map is provided, an empty dict is used.
+        """
+        if m is None:
+            m = {}
+        return self.__class__(m, *self.maps)
+
+    @property
+    def parents(self):                          # like Django's Context.pop()
+        "New ChainMap from ``maps[1:]``."
+        return self.__class__(*self.maps[1:])
+
+    def __setitem__(self, key, value):
+        self.maps[0][key] = value
+
+    def __delitem__(self, key):
+        try:
+            del self.maps[0][key]
+        except KeyError:
+            raise KeyError('Key not found in the first mapping: {0!r}'.format(key))
+
+    def popitem(self):
+        """
+        Remove and return an item pair from ``maps[0]``. Raise ``KeyError`` is 
+        ``maps[0]`` is empty.
+        """
+        try:
+            return self.maps[0].popitem()
+        except KeyError:
+            raise KeyError('No keys found in the first mapping.')
+
+    def pop(self, key, *args):
+        """
+        Remove ``key`` from ``maps[0]`` and return its value. Raise ``KeyError``
+        if ``key`` not in ``maps[0]``.
+        """
+        try:
+            return self.maps[0].pop(key, *args)
+        except KeyError:
+            raise KeyError('Key not found in the first mapping: {0!r}'.format(key))
+
+    def clear(self):
+        """
+        Clear ```maps[0]```, leaving ``maps[1:]`` intact.
+        """
+        self.maps[0].clear()

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -168,7 +168,7 @@ def parse_specs(args, **kwargs):
         return specs
 
     except spack.spec.SpecParseError as e:
-        msg = e.message + "\n" + str(e.string) + "\n"
+        msg = str(e) + "\n" + str(e) + "\n"
         msg += (e.pos + 2) * " " + "^"
         raise spack.error.SpackError(msg)
 

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -673,6 +673,7 @@ class Database(object):
         spec = data[hash_key].spec
         spec_dict = installs[hash_key]['spec']
         if 'dependencies' in spec_dict[spec.name]:
+            reconstruct_virtuals_on_edges = False
             yaml_deps = spec_dict[spec.name]['dependencies']
             for item in spack.spec.Spec.read_yaml_dep_specs(yaml_deps):
                 dname, dhash, dtypes, virtuals = item
@@ -697,7 +698,14 @@ class Database(object):
                     tty.warn(msg)
                     continue
 
+                if virtuals is None:
+                    reconstruct_virtuals_on_edges = True
+                    virtuals = []
+
                 spec._add_dependency(child, dtypes, virtuals=virtuals)
+
+            if reconstruct_virtuals_on_edges:
+                spec.reconstruct_virtuals_on_edges()
 
     def _read_from_file(self, filename):
         """Fill database from file, do not maintain old data.

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -674,8 +674,8 @@ class Database(object):
         spec_dict = installs[hash_key]['spec']
         if 'dependencies' in spec_dict[spec.name]:
             yaml_deps = spec_dict[spec.name]['dependencies']
-            for dname, dhash, dtypes in spack.spec.Spec.read_yaml_dep_specs(
-                    yaml_deps):
+            for item in spack.spec.Spec.read_yaml_dep_specs(yaml_deps):
+                dname, dhash, dtypes, virtuals = item
                 # It is important that we always check upstream installations
                 # in the same order, and that we always check the local
                 # installation first: if a downstream Spack installs a package
@@ -697,7 +697,7 @@ class Database(object):
                     tty.warn(msg)
                     continue
 
-                spec._add_dependency(child, dtypes)
+                spec._add_dependency(child, dtypes, virtuals=virtuals)
 
     def _read_from_file(self, filename):
         """Fill database from file, do not maintain old data.
@@ -1104,7 +1104,9 @@ class Database(object):
             ):
                 dkey = dep.spec.dag_hash()
                 upstream, record = self.query_by_spec_hash(dkey)
-                new_spec._add_dependency(record.spec, dep.deptypes)
+                new_spec._add_dependency(
+                    record.spec, dep.deptypes, virtuals=dep.virtuals
+                )
                 if not upstream:
                     record.ref_count += 1
 

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -434,9 +434,8 @@ def provides(*specs, **kwargs):
 
         spec_objs = [spack.spec.Spec(x) for x in specs]
         spec_names = [x.name for x in spec_objs]
+        pkg.used_together.setdefault(when_spec, []).append(set(spec_names))
         for provided_spec in spec_objs:
-            pkg.used_together[provided_spec.name] = spec_names
-
             if pkg.name == provided_spec.name:
                 raise CircularReferenceError(
                     "Package '%s' cannot provide itself.")

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -408,11 +408,19 @@ def extends(spec, **kwargs):
     return _execute_extends
 
 
-@directive(dicts=('provided', 'provided_together'))
+@directive(dicts=('provided', 'used_together'))
 def provides(*specs, **kwargs):
-    """Allows packages to provide a virtual dependency.  If a package provides
-       'mpi', other packages can declare that they depend on "mpi", and spack
-       can use the providing package to satisfy the dependency.
+    """Allows packages to provide a virtual dependency.
+
+    If a package provides 'mpi', other packages can declare that they
+    depend on "mpi", and spack can use the providing package to satisfy
+    the dependency.
+
+    Args:
+        *specs: virtual specs provided by this package
+        **kwargs:
+
+            when: condition when this provides clause needs to be considered
     """
     def _execute_provides(pkg):
         when = kwargs.get('when')
@@ -427,7 +435,7 @@ def provides(*specs, **kwargs):
         spec_objs = [spack.spec.Spec(x) for x in specs]
         spec_names = [x.name for x in spec_objs]
         for provided_spec in spec_objs:
-            pkg.provided_together[provided_spec.name] = spec_names
+            pkg.used_together[provided_spec.name] = spec_names
 
             if pkg.name == provided_spec.name:
                 raise CircularReferenceError(

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1438,10 +1438,17 @@ class Environment(object):
             specs_by_hash[dag_hash] = Spec.from_node_dict(node_dict)
 
         for dag_hash, node_dict in json_specs_by_hash.items():
+            reconstruct_virtuals_on_edges = False
             for dep_name, dep_hash, deptypes, virtuals in (
                     Spec.dependencies_from_node_dict(node_dict)):
+                if virtuals is None:
+                    virtuals = []
+                    reconstruct_virtuals_on_edges = True
                 specs_by_hash[dag_hash]._add_dependency(
                     specs_by_hash[dep_hash], deptypes, virtuals=virtuals)
+
+            if reconstruct_virtuals_on_edges:
+                specs_by_hash[dag_hash].reconstruct_virtuals_on_edges()
 
         # If we are reading an older lockfile format (which uses dag hashes
         # that exclude build deps), we use this to convert the old

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1438,10 +1438,10 @@ class Environment(object):
             specs_by_hash[dag_hash] = Spec.from_node_dict(node_dict)
 
         for dag_hash, node_dict in json_specs_by_hash.items():
-            for dep_name, dep_hash, deptypes in (
+            for dep_name, dep_hash, deptypes, virtuals in (
                     Spec.dependencies_from_node_dict(node_dict)):
                 specs_by_hash[dag_hash]._add_dependency(
-                    specs_by_hash[dep_hash], deptypes)
+                    specs_by_hash[dep_hash], deptypes, virtuals=virtuals)
 
         # If we are reading an older lockfile format (which uses dag hashes
         # that exclude build deps), we use this to convert the old

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -183,7 +183,7 @@ def _packages_needed_to_bootstrap_compiler(pkg):
     dep.concretize()
     # mark compiler as depended-on by the package that uses it
     dep._dependents[pkg.name] = spack.spec.DependencySpec(
-        pkg.spec, dep, ('build',))
+        pkg.spec, dep, ('build',), virtuals=None)
     packages = [(s.package, False) for
                 s in dep.traverse(order='post', root=False)]
     packages.append((dep.package, True))

--- a/lib/spack/spack/parse.py
+++ b/lib/spack/spack/parse.py
@@ -3,12 +3,12 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import itertools
 import re
 import shlex
 import sys
-import itertools
-from six import string_types
 
+import six
 import spack.error
 
 
@@ -142,7 +142,7 @@ class Parser(object):
             sys.exit(1)
 
     def setup(self, text):
-        if isinstance(text, string_types):
+        if isinstance(text, six.string_types):
             text = shlex.split(str(text))
         self.text = text
         self.push_tokens(self.lexer.lex(text))

--- a/lib/spack/spack/provider_index.py
+++ b/lib/spack/spack/provider_index.py
@@ -350,9 +350,11 @@ class IndexWithBindings(abc.Mapping, _IndexBase):
                 continue
 
             assert len(s) == 1, specs
-            binds.append(str(s[0]))
-            highest.update_with(s[0], only=(v,))
-            lowest.update_with(s[0], exclude=(v,))
+            s = s[0]
+            binds.append(str(s))
+            virtual_deps = s.package.provided_together.get(v, (v,))
+            highest.update_with(s, only=virtual_deps)
+            lowest.update_with(s, exclude=virtual_deps)
 
         non_binds = [x for x in specs if str(x) not in binds]
         middle = ProviderIndex(non_binds, restrict=True)
@@ -365,9 +367,10 @@ class IndexWithBindings(abc.Mapping, _IndexBase):
             if not spec.satisfies(constraint, strict=True):
                 continue
 
+            binds = spec.package.provided_together[vspec]
             is_highest = True
-            self.providers.maps[0].update_with(spec, only=(vspec,))
-            self.providers.maps[2].update_with(spec, exclude=(vspec,))
+            self.providers.maps[0].update_with(spec, only=binds)
+            self.providers.maps[2].update_with(spec, exclude=binds)
 
         if not is_highest:
             self.providers.maps[1].update_with(spec)

--- a/lib/spack/spack/provider_index.py
+++ b/lib/spack/spack/provider_index.py
@@ -365,7 +365,7 @@ class IndexWithBindings(abc.Mapping, _IndexBase):
             assert len(s) == 1, specs
             s = s[0]
             binds.append(str(s))
-            virtual_deps = s.package.provided_together.get(v, (v,))
+            virtual_deps = s.package.used_together.get(v, (v,))
             highest.update_with(s, only=virtual_deps)
             lowest.update_with(s, exclude=virtual_deps)
 
@@ -380,7 +380,7 @@ class IndexWithBindings(abc.Mapping, _IndexBase):
             if not spec.satisfies(constraint, strict=True):
                 continue
 
-            binds = spec.package.provided_together[vspec]
+            binds = spec.package.used_together[vspec]
             is_highest = True
             self.providers.maps[0].update_with(spec, only=binds)
             self.providers.maps[2].update_with(spec, exclude=binds)

--- a/lib/spack/spack/provider_index.py
+++ b/lib/spack/spack/provider_index.py
@@ -13,6 +13,11 @@ import six
 import spack.error
 import spack.util.spack_json as sjson
 
+try:
+    from collections import ChainMap  # novm
+except ImportError:
+    from chainmap import ChainMap
+
 
 def _cross_provider_maps(lmap, rmap):
     """Return a dictionary that combines constraint requests from both input.
@@ -352,8 +357,7 @@ class IndexWithBindings(abc.Mapping, _IndexBase):
         non_binds = [x for x in specs if str(x) not in binds]
         middle = ProviderIndex(non_binds, restrict=True)
 
-        import collections
-        self.providers = collections.ChainMap(highest, middle, lowest)
+        self.providers = ChainMap(highest, middle, lowest)
 
     def update_with(self, spec):
         is_highest = False

--- a/lib/spack/spack/provider_index.py
+++ b/lib/spack/spack/provider_index.py
@@ -201,17 +201,18 @@ class ProviderIndex(abc.Mapping, _IndexBase):
             # FIXME: Here we need to use k.name since the key is a Spec and
             # FIXME: llnl.util.lang.total_ordering interferes with string
             # FIXME: comparison
-            pkg_provided = {
-                k: v for k, v in pkg_provided.items() if k.name in only
-            }
+            pkg_provided = dict(
+                (k, v) for k, v in pkg_provided.items() if k.name in only
+            )
 
         if exclude is not None:
             # FIXME: Here we need to use k.name since the key is a Spec and
             # FIXME: llnl.util.lang.total_ordering interferes with string
             # FIXME: comparison
-            pkg_provided = {
-                k: v for k, v in pkg_provided.items() if k.name not in exclude
-            }
+            pkg_provided = dict(
+                (k, v) for k, v in pkg_provided.items()
+                if k.name not in exclude
+            )
 
         for provided_spec, provider_specs in six.iteritems(pkg_provided):
             for provider_spec in provider_specs:

--- a/lib/spack/spack/provider_index.py
+++ b/lib/spack/spack/provider_index.py
@@ -198,17 +198,17 @@ class ProviderIndex(abc.Mapping, _IndexBase):
 
         pkg_provided = spec.package_class.provided
         if only is not None:
-            # FIXME: Here we need to use k.name since the key is a Spec and
-            # FIXME: llnl.util.lang.total_ordering interferes with string
-            # FIXME: comparison
+            # Here we need to use k.name since the key is a Spec and
+            # llnl.util.lang.total_ordering interferes with string
+            # comparison
             pkg_provided = dict(
                 (k, v) for k, v in pkg_provided.items() if k.name in only
             )
 
         if exclude is not None:
-            # FIXME: Here we need to use k.name since the key is a Spec and
-            # FIXME: llnl.util.lang.total_ordering interferes with string
-            # FIXME: comparison
+            # Here we need to use k.name since the key is a Spec and
+            # llnl.util.lang.total_ordering interferes with string
+            # comparison
             pkg_provided = dict(
                 (k, v) for k, v in pkg_provided.items()
                 if k.name not in exclude

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -248,6 +248,9 @@ class TagIndex(Mapping):
 class Indexer(object):
     """Adaptor for indexes that need to be generated when repos are updated."""
 
+    def __init__(self):
+        self.index = None
+
     def create(self):
         self.index = self._create()
 
@@ -309,7 +312,7 @@ class ProviderIndexer(Indexer):
 
     def update(self, pkg_fullname):
         self.index.remove_provider(pkg_fullname)
-        self.index.update(pkg_fullname)
+        self.index.update_with(pkg_fullname)
 
     def write(self, stream):
         self.index.to_json(stream)
@@ -631,7 +634,7 @@ class RepoPath(object):
         if namespace:
             fullspace = get_full_namespace(namespace)
             if fullspace not in self.by_namespace:
-                raise UnknownNamespaceError(spec.namespace)
+                raise UnknownNamespaceError(namespace)
             return self.by_namespace[fullspace]
 
         # If there's no namespace, search in the RepoPath.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3438,9 +3438,18 @@ class Spec(object):
         """
         spec = self._autospec(spec)
 
-        # if anonymous or same name, we only have to look at the root
         if not spec.name or spec.name == self.name:
+            # If anonymous or same name, we only have to look at the root
             return self.satisfies(spec)
+        elif self._concrete and spec.virtual:
+            # For virtual dependencies we need to check edges, not nodes
+            for dspec in self.traverse_edges(
+                    deptype=all, cover='edges', root=False
+            ):
+                provides_this_virtual = spec.name in dspec.virtuals
+                if provides_this_virtual and dspec.spec.satisfies(spec):
+                    return True
+            return False
         else:
             return any(s.satisfies(spec) for s in self.traverse(root=False))
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1826,7 +1826,9 @@ class Spec(object):
             elif isinstance(elt, dict):
                 # new format: elements of dependency spec are keyed.
                 dag_hash, deptypes = elt['hash'], elt['type']
-                virtuals = elt['provides']
+                # {}.get instead of subscripting is needed for backward
+                # compatibility. Without it reindex would fail
+                virtuals = elt.get('provides', [])
             else:
                 raise spack.error.SpecError(
                     "Couldn't parse dependency types in spec.")

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2411,7 +2411,7 @@ class Spec(object):
         # providing multiple virtual dependencies together
         for virtual_dep in list(self.providers):
             provider_spec = self.providers.providers_for(virtual_dep)[0]
-            vdeps = provider_spec.package.provided_together[virtual_dep]
+            vdeps = provider_spec.package.used_together[virtual_dep]
             # A single entry means this virtual dependency is not tied
             # to other virtual dependencies
             if len(vdeps) == 1:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1173,12 +1173,9 @@ class Spec(object):
     def _add_explicit_provider(self, virtual, spec):
         # We cannot provide the same virtual multiple times
         if virtual in self._explicit_providers:
-            # TODO: add an error message
             msg = 'virtual dependency "{0}" cannot be specified multiple times'
             raise ValueError(msg.format(virtual))
 
-        # TODO: need to manage the case in which multiple
-        # TODO: virtual dependencies are provided together
         self._explicit_providers[virtual] = spec
 
     #

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -992,6 +992,7 @@ class Spec(object):
         self._dependents = DependencyMap()
         self._dependencies = DependencyMap()
         self.namespace = None
+        self._explicit_providers = {}
 
         self._hash = None
         self._build_hash = None
@@ -1168,6 +1169,17 @@ class Spec(object):
         arch = self.architecture
         if arch and not arch.platform and (arch.os or arch.target):
             self._set_architecture(platform=spack.architecture.platform().name)
+
+    def _add_explicit_provider(self, virtual, spec):
+        # We cannot provide the same virtual multiple times
+        if virtual in self._explicit_providers:
+            # TODO: add an error message
+            msg = 'virtual dependency "{0}" cannot be specified multiple times'
+            raise ValueError(msg.format(virtual))
+
+        # TODO: need to manage the case in which multiple
+        # TODO: virtual dependencies are provided together
+        self._explicit_providers[virtual] = spec
 
     #
     # Public interface
@@ -1392,6 +1404,17 @@ class Spec(object):
     @prefix.setter
     def prefix(self, value):
         self._prefix = spack.util.prefix.Prefix(value)
+
+    @property
+    def providers(self):
+        try:
+            return spack.provider_index.IndexWithBindings(
+                self.traverse(), self._explicit_providers
+            )
+        except spack.error.SpackError:
+            # This case should take care of cases where a spec
+            # has unknown namespaces or similar things.
+            return spack.provider_index.IndexWithBindings([], {})
 
     def _spec_hash(self, hash):
         """Utility method for computing different types of Spec hashes.
@@ -2108,8 +2131,9 @@ class Spec(object):
               a problem.
         """
         # Make an index of stuff this spec already provides
-        self_index = spack.provider_index.ProviderIndex(
-            self.traverse(), restrict=True)
+        self_index = spack.provider_index.IndexWithBindings(
+            self.traverse(), self._explicit_providers
+        )
         changed = False
         done = False
 
@@ -2187,7 +2211,7 @@ class Spec(object):
                     changed = True
 
                 spec._dependencies.owner = spec
-                self_index.update(spec)
+                self_index.update_with(spec)
                 done = False
                 break
 
@@ -2214,6 +2238,9 @@ class Spec(object):
         if not self.name:
             raise spack.error.SpecError(
                 "Attempting to concretize anonymous spec")
+
+        # Check that the explicit bindings are correct
+        self._verify_bindings()
 
         if self._concrete:
             return
@@ -2365,6 +2392,22 @@ class Spec(object):
         # Check if we can produce an optimized binary (will throw if
         # there are declared inconsistencies)
         self.architecture.target.optimization_flags(self.compiler)
+
+    def _verify_bindings(self):
+        """Check if the explicit bindings are correct."""
+        missing = []
+        for v, s in self._explicit_providers.items():
+            index = spack.provider_index.ProviderIndex([s], restrict=True)
+            providers = index.providers_for(v)
+            if not providers:
+                missing.append((v, s))
+
+        if missing:
+            msg = "explicit bindings cannot be satisfied [{0}]"
+            detail = []
+            for v, s in missing:
+                detail.append('"{0}" does not provide "{1}"'.format(str(s), v))
+            raise ValueError(msg.format(", ".join(detail)))
 
     def _mark_concrete(self, value=True):
         """Mark this spec and its dependencies as concrete.
@@ -2555,7 +2598,9 @@ class Spec(object):
             if provider:
                 dep = provider
         else:
-            index = spack.provider_index.ProviderIndex([dep], restrict=True)
+            index = spack.provider_index.IndexWithBindings(
+                [dep], self._explicit_providers
+            )
             items = list(spec_deps.items())
             for name, vspec in items:
                 if not vspec.virtual:
@@ -2569,7 +2614,7 @@ class Spec(object):
                     required = index.providers_for(vspec.name)
                     if required:
                         raise UnsatisfiableProviderSpecError(required[0], dep)
-            provider_index.update(dep)
+            provider_index.update_with(dep)
 
         # If the spec isn't already in the set of dependencies, add it.
         # Note: dep is always owned by this method. If it's from the
@@ -2703,10 +2748,11 @@ class Spec(object):
                 else:
                     all_spec_deps[name].constrain(spec)
 
-        # Initialize index of virtual dependency providers if
-        # concretize didn't pass us one already
-        provider_index = spack.provider_index.ProviderIndex(
-            [s for s in all_spec_deps.values()], restrict=True)
+        # FIXME: Revisit this part
+        bindings = getattr(self, '_explicit_providers', {})
+        provider_index = spack.provider_index.IndexWithBindings(
+            [s for s in all_spec_deps.values()], bindings
+        )
 
         # traverse the package DAG and fill out dependencies according
         # to package files & their 'when' specs
@@ -3018,10 +3064,12 @@ class Spec(object):
                 return False
 
         # For virtual dependencies, we need to dig a little deeper.
-        self_index = spack.provider_index.ProviderIndex(
-            self.traverse(), restrict=True)
-        other_index = spack.provider_index.ProviderIndex(
-            other.traverse(), restrict=True)
+        self_index = spack.provider_index.IndexWithBindings(
+            self.traverse(), self._explicit_providers
+        )
+        other_index = spack.provider_index.IndexWithBindings(
+            other.traverse(), other._explicit_providers
+        )
 
         # This handles cases where there are already providers for both vpkgs
         if not self_index.satisfies(other_index):
@@ -3159,6 +3207,7 @@ class Spec(object):
             self._dup_deps(other, deptypes, caches)
 
         self._concrete = other._concrete
+        self._explicit_providers = other._explicit_providers
 
         if caches:
             self._hash = other._hash
@@ -3259,8 +3308,7 @@ class Spec(object):
                 itertools.chain(
                     # Regular specs
                     (x for x in self.traverse() if x.name == name),
-                    (x for x in self.traverse()
-                     if (not x.virtual) and x.package.provides(name))
+                    self.providers.providers_for(name)
                 )
             )
         except StopIteration:
@@ -4156,11 +4204,17 @@ class SpecParser(spack.parse.Parser):
                 # of the form ^vdep=spec if we have to bind a vdep to a
                 # particular provider.
                 self.expect(ID)
-
+                dep_or_virtual = self.token.value
                 if self.accept(EQ):
+                    # ^vdep=spec
+                    virtual_dependency = dep_or_virtual
                     self.expect(VAL)
-
-                dep = self.spec(self.token.value)
+                    # Implicit recursion on the parser below
+                    dep = Spec(self.token.value)
+                    specs[-1]._add_explicit_provider(virtual_dependency, dep)
+                else:
+                    # ^spec
+                    dep = self.spec(self.token.value)
 
             # Raise an error if the previous spec is already
             # concrete (assigned by hash)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -609,7 +609,7 @@ class DependencySpec(object):
     - virtuals: list of strings, representing virtual dependencies.
     """
 
-    def __init__(self, parent, spec, deptypes, virtuals=None):
+    def __init__(self, parent, spec, deptypes, virtuals):
         self.parent = parent
         self.spec = spec
         self.deptypes = tuple(sorted(set(deptypes)))
@@ -1180,7 +1180,7 @@ class Spec(object):
                 "Cannot depend on '%s' twice" % spec)
 
         # create an edge and add to parent and child
-        dspec = DependencySpec(self, spec, deptypes)
+        dspec = DependencySpec(self, spec, deptypes, virtuals=None)
         self._dependencies[spec.name] = dspec
         spec._dependents[self.name] = dspec
 
@@ -1357,9 +1357,9 @@ class Spec(object):
             if not dspec:
                 # make a fake dspec for the root.
                 if direction == 'parents':
-                    dspec = DependencySpec(self, None, ())
+                    dspec = DependencySpec(self, None, (), virtuals=None)
                 else:
-                    dspec = DependencySpec(None, self, ())
+                    dspec = DependencySpec(None, self, (), virtuals=None)
             return (d, dspec) if depth else dspec
 
         yield_me = yield_root or d > 0
@@ -2123,7 +2123,7 @@ class Spec(object):
 
     def _replace_with(self, concrete):
         """Replace this virtual spec with a concrete spec."""
-        assert(self.virtual)
+        assert self.virtual
         for name, dep_spec in self._dependents.items():
             dependent = dep_spec.parent
             deptypes = dep_spec.deptypes
@@ -4267,7 +4267,8 @@ class SpecParser(spack.parse.Parser):
                     # Implicit recursion on the parser below
                     self.expect(VAL)
                     dep = Spec(self.token.value)
-                    specs[-1]._add_explicit_provider(virtuals[-1], dep)
+                    for v in virtuals:
+                        specs[-1]._add_explicit_provider(v, dep)
 
             # Raise an error if the previous spec is already
             # concrete (assigned by hash)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2411,7 +2411,9 @@ class Spec(object):
         # providing multiple virtual dependencies together
         for virtual_dep in list(self.providers):
             provider_spec = self.providers.providers_for(virtual_dep)[0]
-            vdeps = provider_spec.package.used_together[virtual_dep]
+            vdeps = spack.provider_index.used_together(
+                provider_spec, virtual_dep
+            )
             # A single entry means this virtual dependency is not tied
             # to other virtual dependencies
             if len(vdeps) == 1:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1615,7 +1615,7 @@ class Spec(object):
                  syaml.syaml_dict([
                      ('hash', dspec.spec._cached_hash(hash)),
                      ('type', sorted(str(s) for s in dspec.deptypes)),
-                     ('virtuals', sorted(str(s) for s in dspec.virtuals))
+                     ('provides', sorted(str(s) for s in dspec.virtuals))
                  ])
                  ) for name, dspec in sorted(deps.items())
             ])
@@ -1828,7 +1828,7 @@ class Spec(object):
                 dag_hash, deptypes = elt['hash'], elt['type']
                 # FIXME: Document why we are using "get"
                 # FIXME: instead of subscripts (ci.py)
-                virtuals = elt.get('virtuals', [])
+                virtuals = elt.get('provides', [])
             else:
                 raise spack.error.SpecError(
                     "Couldn't parse dependency types in spec.")

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1981,7 +1981,6 @@ class Spec(object):
                     dag_node, dependency_types = spec_and_dependency_types(s)
 
                 dependency_spec = spec_builder({dag_node: s_dependencies})
-                # FIXME: check "virtuals" argument
                 spec._add_dependency(
                     dependency_spec, dependency_types, virtuals=[]
                 )

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1826,9 +1826,7 @@ class Spec(object):
             elif isinstance(elt, dict):
                 # new format: elements of dependency spec are keyed.
                 dag_hash, deptypes = elt['hash'], elt['type']
-                # FIXME: Document why we are using "get"
-                # FIXME: instead of subscripts (ci.py)
-                virtuals = elt.get('provides', [])
+                virtuals = elt['provides']
             else:
                 raise spack.error.SpecError(
                     "Couldn't parse dependency types in spec.")

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2368,6 +2368,26 @@ class Spec(object):
             msg += "    For each package listed, choose another spec\n"
             raise SpecDeprecatedError(msg)
 
+        # Check that there are no inconsistencies with providers
+        # providing multiple virtual dependencies together
+        for virtual_dep in list(self.providers):
+            provider_spec = self.providers.providers_for(virtual_dep)[0]
+            vdeps = provider_spec.package.provided_together[virtual_dep]
+            # A single entry means this virtual dependency is not tied
+            # to other virtual dependencies
+            if len(vdeps) == 1:
+                continue
+
+            missing = ['"{0}"'.format(v) for v in vdeps
+                       if self[v] != provider_spec]
+            if missing:
+                msg = ('"{0}" needs to be a provider for {1} if used as '
+                       'a provider for "{2}"')
+                msg = msg.format(
+                    provider_spec.name, ', '.join(missing), virtual_dep
+                )
+                raise ValueError(msg)
+
         # Now that the spec is concrete we should check if
         # there are declared conflicts
         #

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1430,7 +1430,7 @@ class Spec(object):
         self._prefix = spack.util.prefix.Prefix(value)
 
     @property
-    def providers(self):
+    def _providers(self):
         try:
             return spack.provider_index.IndexWithBindings(
                 self.traverse(), self._user_requested_providers
@@ -2409,8 +2409,8 @@ class Spec(object):
 
         # Check that there are no inconsistencies with providers
         # providing multiple virtual dependencies together
-        for virtual_dep in list(self.providers):
-            provider_spec = self.providers.providers_for(virtual_dep)[0]
+        for virtual_dep in list(self._providers):
+            provider_spec = self._providers.providers_for(virtual_dep)[0]
             vdeps = spack.provider_index.used_together(
                 provider_spec, virtual_dep
             )
@@ -3396,7 +3396,7 @@ class Spec(object):
                 itertools.chain(
                     # Regular specs
                     (x for x in self.traverse() if x.name == name),
-                    self.providers.providers_for(name)
+                    self._providers.providers_for(name)
                 )
             )
         except StopIteration:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1204,7 +1204,9 @@ class Spec(object):
             msg = 'virtual dependency "{0}" cannot be specified multiple times'
             raise ValueError(msg.format(virtual))
 
-        self._user_requested_providers[virtual] = spec
+        # Specs here need to be copied, otherwise we'll bring in a reference
+        # to an object that will be modified in-place during concretization
+        self._user_requested_providers[virtual] = spec.copy()
 
     def reconstruct_virtuals_on_edges(self):
         """Reconstruct virtuals on edges. Used to read from old DB

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -50,7 +50,7 @@ line is a spec for a particular installation of the mpileaks package.
 Here is the EBNF grammar for a spec::
 
   spec-list    = { spec [ dep-list ] }
-  dep_list     = { ^ spec }
+  dep_list     = { ^ spec | ^ id=spec }
   spec         = id [ options ]
   options      = { @version-list | +variant | -variant | ~variant |
                    %compiler | arch=architecture | [ flag ]=value}
@@ -4103,36 +4103,7 @@ class SpecParser(spack.parse.Parser):
                     specs.append(self.spec_by_hash())
 
                 elif self.accept(DEP):
-                    if not specs:
-                        # We're parsing an anonymous spec beginning with a
-                        # dependency. Push the token to recover after creating
-                        # anonymous spec
-                        self.push_tokens([self.token])
-                        specs.append(self.spec(None))
-                    else:
-                        dep = None
-                        if self.accept(FILE):
-                            # this may return None, in which case we backtrack
-                            dep = self.spec_from_file()
-
-                        if not dep and self.accept(HASH):
-                            # We're finding a dependency by hash for an
-                            # anonymous spec
-                            dep = self.spec_by_hash()
-                            dep = dep.copy(deps=('link', 'run'))
-
-                        if not dep:
-                            # We're adding a dependency to the last spec
-                            self.expect(ID)
-                            dep = self.spec(self.token.value)
-
-                        # Raise an error if the previous spec is already
-                        # concrete (assigned by hash)
-                        if specs[-1]._hash:
-                            raise RedundantSpecError(specs[-1], 'dependency')
-                        # command line deps get empty deptypes now.
-                        # Real deptypes are assigned later per packages.
-                        specs[-1]._add_dependency(dep, ())
+                    self._parse_dependency(specs)
 
                 else:
                     # If the next token can be part of a valid anonymous spec,
@@ -4152,6 +4123,52 @@ class SpecParser(spack.parse.Parser):
             raise SpecParseError(e)
 
         return specs
+
+    def _parse_dependency(self, specs):
+        """Parse the bit of a spec after a dependency sigil ^
+
+        Prerequisite is that the last accepted token was DEP.
+
+        Args:
+            specs: list of specs to be updated while parsing
+        """
+        if not specs:
+            # We're parsing an anonymous spec beginning with a
+            # dependency. Push the token to recover after creating
+            # anonymous spec
+            self.push_tokens([self.token])
+            specs.append(self.spec(None))
+        else:
+            dep = None
+            if self.accept(FILE):
+                # this may return None, in which case we backtrack
+                dep = self.spec_from_file()
+
+            if not dep and self.accept(HASH):
+                # We're finding a dependency by hash for an
+                # anonymous spec
+                dep = self.spec_by_hash()
+                dep = dep.copy(deps=('link', 'run'))
+
+            if not dep:
+                # We're adding a dependency to the last spec. This dependency
+                # can be either of the form ^spec i.e. a usual dependency or
+                # of the form ^vdep=spec if we have to bind a vdep to a
+                # particular provider.
+                self.expect(ID)
+
+                if self.accept(EQ):
+                    self.expect(VAL)
+
+                dep = self.spec(self.token.value)
+
+            # Raise an error if the previous spec is already
+            # concrete (assigned by hash)
+            if specs[-1]._hash:
+                raise RedundantSpecError(specs[-1], 'dependency')
+            # command line deps get empty deptypes now.
+            # Real deptypes are assigned later per packages.
+            specs[-1]._add_dependency(dep, ())
 
     def spec_from_file(self):
         """Read a spec from a filename parsed on the input stream.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1019,7 +1019,7 @@ class Spec(object):
         self._dependents = DependencyMap()
         self._dependencies = DependencyMap()
         self.namespace = None
-        self._explicit_providers = {}
+        self._user_requested_providers = {}
 
         self._hash = None
         self._build_hash = None
@@ -1197,13 +1197,13 @@ class Spec(object):
         if arch and not arch.platform and (arch.os or arch.target):
             self._set_architecture(platform=spack.architecture.platform().name)
 
-    def _add_explicit_provider(self, virtual, spec):
+    def _add_user_requested_provider(self, virtual, spec):
         # We cannot provide the same virtual multiple times
-        if virtual in self._explicit_providers:
+        if virtual in self._user_requested_providers:
             msg = 'virtual dependency "{0}" cannot be specified multiple times'
             raise ValueError(msg.format(virtual))
 
-        self._explicit_providers[virtual] = spec
+        self._user_requested_providers[virtual] = spec
 
     #
     # Public interface
@@ -1433,7 +1433,7 @@ class Spec(object):
     def providers(self):
         try:
             return spack.provider_index.IndexWithBindings(
-                self.traverse(), self._explicit_providers
+                self.traverse(), self._user_requested_providers
             )
         except spack.error.SpackError:
             # This case should take care of cases where a spec
@@ -2169,7 +2169,7 @@ class Spec(object):
         """
         # Make an index of stuff this spec already provides
         self_index = spack.provider_index.IndexWithBindings(
-            self.traverse(), self._explicit_providers
+            self.traverse(), self._user_requested_providers
         )
         changed = False
         done = False
@@ -2455,7 +2455,7 @@ class Spec(object):
     def _verify_bindings(self):
         """Check if the explicit bindings are correct."""
         missing = []
-        for v, s in self._explicit_providers.items():
+        for v, s in self._user_requested_providers.items():
             index = spack.provider_index.ProviderIndex([s], restrict=True)
             providers = index.providers_for(v)
             if not providers:
@@ -2670,7 +2670,7 @@ class Spec(object):
                 dep = provider
         else:
             index = spack.provider_index.IndexWithBindings(
-                [dep], self._explicit_providers
+                [dep], self._user_requested_providers
             )
             items = list(spec_deps.items())
             for name, vspec in items:
@@ -2824,8 +2824,7 @@ class Spec(object):
                 else:
                     all_spec_deps[name].constrain(spec)
 
-        # FIXME: Revisit this part
-        bindings = getattr(self, '_explicit_providers', {})
+        bindings = getattr(self, '_user_requested_providers', {})
         provider_index = spack.provider_index.IndexWithBindings(
             [s for s in all_spec_deps.values()], bindings
         )
@@ -3142,10 +3141,10 @@ class Spec(object):
 
         # For virtual dependencies, we need to dig a little deeper.
         self_index = spack.provider_index.IndexWithBindings(
-            self.traverse(), self._explicit_providers
+            self.traverse(), self._user_requested_providers
         )
         other_index = spack.provider_index.IndexWithBindings(
-            other.traverse(), other._explicit_providers
+            other.traverse(), other._user_requested_providers
         )
 
         # This handles cases where there are already providers for both vpkgs
@@ -3284,7 +3283,7 @@ class Spec(object):
             self._dup_deps(other, deptypes, caches)
 
         self._concrete = other._concrete
-        self._explicit_providers = other._explicit_providers
+        self._user_requested_providers = other._user_requested_providers
 
         if caches:
             self._hash = other._hash
@@ -4311,7 +4310,7 @@ class SpecParser(spack.parse.Parser):
                     self.expect(VAL)
                     dep = Spec(self.token.value)
                     for v in virtuals:
-                        specs[-1]._add_explicit_provider(v, dep)
+                        specs[-1]._add_user_requested_provider(v, dep)
 
             # Raise an error if the previous spec is already
             # concrete (assigned by hash)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -654,9 +654,10 @@ class DependencySpec(object):
                 self.virtuals)
 
     def __str__(self):
-        return "%s %s--> %s" % (self.parent.name if self.parent else None,
-                                self.deptypes,
-                                self.spec.name if self.spec else None)
+        return "%s %s[%s]--> %s" % (self.parent.name if self.parent else None,
+                                    self.deptypes,
+                                    ', '.join(self.virtuals),
+                                    self.spec.name if self.spec else None)
 
 
 _valid_compiler_flags = [
@@ -1173,7 +1174,7 @@ class Spec(object):
                 "Spec for '%s' cannot have two compilers." % self.name)
         self.compiler = compiler
 
-    def _add_dependency(self, spec, deptypes, virtuals=None):
+    def _add_dependency(self, spec, deptypes, virtuals):
         """Called by the parser to add another spec as a dependency."""
         if spec.name in self._dependencies:
             raise DuplicateDependencyError(
@@ -1817,18 +1818,22 @@ class Spec(object):
         for dep_name, elt in dependency_dict.items():
             if isinstance(elt, six.string_types):
                 # original format, elt is just the dependency hash.
-                dag_hash, deptypes = elt, ['build', 'link']
+                dag_hash, deptypes, virtuals = elt, ['build', 'link'], []
             elif isinstance(elt, tuple):
                 # original deptypes format: (used tuples, not future-proof)
                 dag_hash, deptypes = elt
+                virtuals = []
             elif isinstance(elt, dict):
                 # new format: elements of dependency spec are keyed.
                 dag_hash, deptypes = elt['hash'], elt['type']
+                # FIXME: Document why we are using "get"
+                # FIXME: instead of subscripts (ci.py)
+                virtuals = elt.get('virtuals', [])
             else:
                 raise spack.error.SpecError(
                     "Couldn't parse dependency types in spec.")
 
-            yield dep_name, dag_hash, list(deptypes)
+            yield dep_name, dag_hash, list(deptypes), virtuals[:]
 
     @staticmethod
     def from_literal(spec_dict, normal=True):
@@ -1976,7 +1981,10 @@ class Spec(object):
                     dag_node, dependency_types = spec_and_dependency_types(s)
 
                 dependency_spec = spec_builder({dag_node: s_dependencies})
-                spec._add_dependency(dependency_spec, dependency_types)
+                # FIXME: check "virtuals" argument
+                spec._add_dependency(
+                    dependency_spec, dependency_types, virtuals=[]
+                )
 
             return spec
 
@@ -2007,8 +2015,11 @@ class Spec(object):
                 continue
 
             yaml_deps = node[name]['dependencies']
-            for dname, dhash, dtypes in Spec.read_yaml_dep_specs(yaml_deps):
-                deps[name]._add_dependency(deps[dname], dtypes)
+            for item in Spec.read_yaml_dep_specs(yaml_deps):
+                dname, dhash, dtypes, virtuals = item
+                deps[name]._add_dependency(
+                    deps[dname], dtypes, virtuals=virtuals
+                )
 
         return spec
 
@@ -2126,6 +2137,7 @@ class Spec(object):
     def _replace_with(self, concrete):
         """Replace this virtual spec with a concrete spec."""
         assert self.virtual
+        virtuals = [self.name]
         for name, dep_spec in self._dependents.items():
             dependent = dep_spec.parent
             deptypes = dep_spec.deptypes
@@ -2136,7 +2148,9 @@ class Spec(object):
 
             # add the replacement, unless it is already a dep of dependent.
             if concrete.name not in dependent._dependencies:
-                dependent._add_dependency(concrete, deptypes)
+                dependent._add_dependency(
+                    concrete, deptypes, virtuals=virtuals
+                )
 
     def _expand_virtual_packages(self, concretizer):
         """Find virtual packages in this spec, replace them with providers,
@@ -2567,11 +2581,21 @@ class Spec(object):
         return dep
 
     def _find_provider(self, vdep, provider_index):
-        """Find provider for a virtual spec in the provider index.
-           Raise an exception if there is a conflicting virtual
-           dependency already in this spec.
+        """Find a provider for a virtual spec in the provider
+        index and return it.
+
+        Raise an exception if there is a conflicting virtual
+        dependency already in this spec.
+
+        Args:
+            vdep: virtual spec
+            provider_index: provider index to be used
+
+        Raises:
+           MultipleProviderError: if multiple providers are found
+           UnsatisfiableProviderSpecError: if no provider can be found
         """
-        assert(vdep.virtual)
+        assert vdep.virtual
 
         # note that this defensively copies.
         providers = provider_index.providers_for(vdep)
@@ -2637,10 +2661,12 @@ class Spec(object):
 
         # If it's a virtual dependency, try to find an existing
         # provider in the spec, and merge that.
+        virtuals = []
         if dep.virtual:
             visited.add(dep.name)
             provider = self._find_provider(dep, provider_index)
             if provider:
+                virtuals.append(dep.name)
                 dep = provider
         else:
             index = spack.provider_index.IndexWithBindings(
@@ -2652,6 +2678,7 @@ class Spec(object):
                     continue
 
                 if index.providers_for(vspec):
+                    virtuals.append(vspec.name)
                     vspec._replace_with(dep)
                     del spec_deps[vspec.name]
                     changed = True
@@ -2697,7 +2724,11 @@ class Spec(object):
         # Add merged spec to my deps and recurse
         spec_dependency = spec_deps[dep.name]
         if dep.name not in self._dependencies:
-            self._add_dependency(spec_dependency, dependency.type)
+            self._add_dependency(
+                spec_dependency, dependency.type, virtuals=virtuals
+            )
+        elif virtuals:
+            self._dependencies[spec_dependency.name].update_virtuals(virtuals)
 
         changed |= spec_dependency._normalize_helper(
             visited, spec_deps, provider_index, tests)
@@ -2954,7 +2985,8 @@ class Spec(object):
             dep_spec_copy = other.get_dependency(name)
             dep_copy = dep_spec_copy.spec
             deptypes = dep_spec_copy.deptypes
-            self._add_dependency(dep_copy.copy(), deptypes)
+            virtuals = dep_spec_copy.virtuals
+            self._add_dependency(dep_copy.copy(), deptypes, virtuals=virtuals)
             changed = True
 
         return changed
@@ -4242,7 +4274,7 @@ class SpecParser(spack.parse.Parser):
             self.push_tokens([self.token])
             specs.append(self.spec(None))
         else:
-            dep = None
+            dep, virtuals = None, []
             if self.accept(FILE):
                 # this may return None, in which case we backtrack
                 dep = self.spec_from_file()
@@ -4260,7 +4292,6 @@ class SpecParser(spack.parse.Parser):
                 # to a particular provider.
                 self.expect(ID)
 
-                virtuals, dep = [], None
                 # case 1: ^spec
                 if not self.next or not (
                     # This condition identifies virtual dependency binding
@@ -4288,7 +4319,7 @@ class SpecParser(spack.parse.Parser):
                 raise RedundantSpecError(specs[-1], 'dependency')
             # command line deps get empty deptypes now.
             # Real deptypes are assigned later per packages.
-            specs[-1]._add_dependency(dep, ())
+            specs[-1]._add_dependency(dep, (), virtuals=virtuals)
 
     def spec_from_file(self):
         """Read a spec from a filename parsed on the input stream.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1173,14 +1173,14 @@ class Spec(object):
                 "Spec for '%s' cannot have two compilers." % self.name)
         self.compiler = compiler
 
-    def _add_dependency(self, spec, deptypes):
+    def _add_dependency(self, spec, deptypes, virtuals=None):
         """Called by the parser to add another spec as a dependency."""
         if spec.name in self._dependencies:
             raise DuplicateDependencyError(
                 "Cannot depend on '%s' twice" % spec)
 
         # create an edge and add to parent and child
-        dspec = DependencySpec(self, spec, deptypes, virtuals=None)
+        dspec = DependencySpec(self, spec, deptypes, virtuals=virtuals)
         self._dependencies[spec.name] = dspec
         spec._dependents[self.name] = dspec
 
@@ -1613,7 +1613,9 @@ class Spec(object):
                 (name,
                  syaml.syaml_dict([
                      ('hash', dspec.spec._cached_hash(hash)),
-                     ('type', sorted(str(s) for s in dspec.deptypes))])
+                     ('type', sorted(str(s) for s in dspec.deptypes)),
+                     ('virtuals', sorted(str(s) for s in dspec.virtuals))
+                 ])
                  ) for name, dspec in sorted(deps.items())
             ])
 
@@ -3268,22 +3270,32 @@ class Spec(object):
         return changed
 
     def _dup_deps(self, other, deptypes, caches):
+        """Duplicates in self the dependencies from another spec.
+
+        Args:
+            other (Spec): spec from which we want to duplicate the dependencies
+            deptypes (tuple): dependency types that needs to be copied
+            caches: caches used to copy specs
+        """
         new_specs = {self.name: self}
-        for dspec in other.traverse_edges(cover='edges',
-                                          root=False):
-            if (dspec.deptypes and
-                not any(d in deptypes for d in dspec.deptypes)):
+        for dspec in other.traverse_edges(cover='edges', root=False):
+            # Skip dependencies if they are not of the correct type
+            if dspec.deptypes and not (set(deptypes) & set(dspec.deptypes)):
                 continue
 
-            if dspec.parent.name not in new_specs:
-                new_specs[dspec.parent.name] = dspec.parent.copy(
-                    deps=False, caches=caches)
-            if dspec.spec.name not in new_specs:
-                new_specs[dspec.spec.name] = dspec.spec.copy(
-                    deps=False, caches=caches)
+            # Copy the edge but first create every node that is not
+            # already in the DAG
+            parent, child = dspec.parent.name, dspec.spec.name
+            copy_kwargs = {'deps': False, 'caches': caches}
+            if parent not in new_specs:
+                new_specs[parent] = dspec.parent.copy(**copy_kwargs)
 
-            new_specs[dspec.parent.name]._add_dependency(
-                new_specs[dspec.spec.name], dspec.deptypes)
+            if child not in new_specs:
+                new_specs[child] = dspec.spec.copy(**copy_kwargs)
+
+            new_specs[parent]._add_dependency(
+                new_specs[child], dspec.deptypes, virtuals=dspec.virtuals
+            )
 
     def copy(self, deps=True, **kwargs):
         """Make a copy of this spec.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4244,20 +4244,30 @@ class SpecParser(spack.parse.Parser):
             if not dep:
                 # We're adding a dependency to the last spec. This dependency
                 # can be either of the form ^spec i.e. a usual dependency or
-                # of the form ^vdep=spec if we have to bind a vdep to a
-                # particular provider.
+                # of the form ^vdep[,vdep,...]=spec if we have to bind a vdep
+                # to a particular provider.
                 self.expect(ID)
-                dep_or_virtual = self.token.value
-                if self.accept(EQ):
-                    # ^vdep=spec
-                    virtual_dependency = dep_or_virtual
-                    self.expect(VAL)
-                    # Implicit recursion on the parser below
-                    dep = Spec(self.token.value)
-                    specs[-1]._add_explicit_provider(virtual_dependency, dep)
-                else:
-                    # ^spec
+
+                virtuals, dep = [], None
+                # case 1: ^spec
+                if not self.next or not (
+                    # This condition identifies virtual dependency binding
+                    self.next.is_a(EQ) or self.next.is_a(COMMA)
+                ):
                     dep = self.spec(self.token.value)
+
+                # case 2: ^vdep[,vdep,...]=spec
+                else:
+                    virtuals.append(self.token.value)
+                    while self.accept(COMMA):
+                        self.expect(ID)
+                        virtuals.append(self.token.value)
+                    # Ensure there's an '=' sigil
+                    self.expect(EQ)
+                    # Implicit recursion on the parser below
+                    self.expect(VAL)
+                    dep = Spec(self.token.value)
+                    specs[-1]._add_explicit_provider(virtuals[-1], dep)
 
             # Raise an error if the previous spec is already
             # concrete (assigned by hash)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3408,13 +3408,15 @@ class Spec(object):
             query_parameters = re.split(r'\s*,\s*', csv)
 
         try:
-            value = next(
-                itertools.chain(
-                    # Regular specs
-                    (x for x in self.traverse() if x.name == name),
-                    self._providers.providers_for(name)
-                )
-            )
+            # Translate the name of virtual specs to its real spec
+            real_name = next(itertools.chain(
+                (x.name for x in self._providers.providers_for(name)), [name]
+            ))
+            # Get the spec (this will ensure we get the same object ID
+            # for a spec both if we use its real name or its virtual name)
+            value = next(iter(
+                [x for x in self.traverse() if x.name == real_name]
+            ))
         except StopIteration:
             raise KeyError("No spec with name %s in %s" % (name, self))
 

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -339,3 +339,18 @@ def test_setting_dtags_based_on_config(
 
         dtags_to_add = modifications['SPACK_DTAGS_TO_ADD'][0]
         assert dtags_to_add.value == expected_flag
+
+
+def test_monkey_patching_works_across_virtual(config, mock_packages):
+    # Create a DAG containing a virtual spec
+    s = spack.spec.Spec('mpileaks ^mpich')
+    s.concretize()
+
+    # Mock what setup_dependent_package might do e.g. monkey
+    # patch the spec
+    s['mpich'].foo = 'foo'
+
+    # Assert the attribut can be found regardless the name
+    # we use to access mpich
+    assert s['mpich'].foo == 'foo'
+    assert s['mpi'].foo == 'foo'

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -27,6 +27,20 @@ except ImportError:
     collections_abc = collections
 
 
+def concretize_and_marshal(spec_str):
+    """Concretize a spec string and marshal it to a byte string.
+
+    Args:
+        spec_str: spec string to be concretized and marshaled
+
+    Returns:
+        String of bytes
+    """
+    s = spack.spec.Spec(spec_str)
+    s.concretize()
+    return ci.format_root_spec(s, main_phase=True, strip_compiler=False)
+
+
 @pytest.fixture
 def tmp_scope():
     """Creates a temporary configuration scope"""
@@ -95,30 +109,21 @@ def test_configure_compilers(mutable_config):
     assert_present(last_config)
 
 
-def test_get_concrete_specs(config, mock_packages):
-    root_spec = (
-        'eJztkk1uwyAQhfc5BbuuYjWObSKuUlURYP5aDBjjBPv0RU7iRI6qpKuqUtnxzZvRwHud'
-        'YxSt1oCMyuVoBdI5MN8paxDYZK/ZbkLYU3kqAuA0Dtz6BgGtTB8XdG87BCgzwXbwXArY'
-        'CxYQiLtqXxUTpLZxSjN/mWlwwxAQlJ7v8wpFtsvK1UXSOUyTjvRKB2Um7LBPhZD0l1md'
-        'xJ7VCATfszOiXGOR9np7vwDn7lCMS8SXQNf3RCtyBTVzzNTMUMXmfWrFeR+UngEAEncS'
-        'ASjKwZcid7ERNldthBxjX46mMD2PsJnlYXDs2rye3l+vroOkJJ54SXgZPklLRQmx61sm'
-        'cgKNVFRO0qlpf2pojq1Ro7OG56MY+Bgc1PkIo/WkaT8OVcrDYuvZkJdtBl/+XCZ+NQBJ'
-        'oKg1h6X/VdXRoyE2OWeH6lCXZdHGrauUZAWFw/YJ/0/39OefN3F4Kle3cXjYsF684ZqG'
-        'Tbap/uPwbRx+YPStIQ8bvgA7G6YE'
-    )
+def test_get_concrete_specs(config):
+    root_spec = concretize_and_marshal('bzip2 ^libiconv')
 
     dep_builds = 'diffutils;libiconv'
     spec_map = ci.get_concrete_specs(root_spec, 'bzip2', dep_builds, 'NONE')
 
-    assert('root' in spec_map and 'deps' in spec_map)
+    assert 'root' in spec_map and 'deps' in spec_map
 
-    nonconc_root_spec = 'archive-files'
+    nonconc_root_spec = 'bzip2'
     dep_builds = ''
     spec_map = ci.get_concrete_specs(
-        nonconc_root_spec, 'archive-files', dep_builds, 'FIND_ANY')
+        nonconc_root_spec, 'bzip2', dep_builds, 'FIND_ANY')
 
-    assert('root' in spec_map and 'deps' in spec_map)
-    assert('archive-files' in spec_map)
+    assert 'root' in spec_map and 'deps' in spec_map
+    assert 'bzip2' in spec_map
 
 
 def test_register_cdash_build():
@@ -132,17 +137,8 @@ def test_register_cdash_build():
         ci.register_cdash_build(build_name, base_url, project, site, track)
 
 
-def test_relate_cdash_builds(config, mock_packages):
-    root_spec = (
-        'eJztkk1uwyAQhfc5BbuuYjWObSKuUlURYP5aDBjjBPv0RU7iRI6qpKuqUtnxzZvRwHud'
-        'YxSt1oCMyuVoBdI5MN8paxDYZK/ZbkLYU3kqAuA0Dtz6BgGtTB8XdG87BCgzwXbwXArY'
-        'CxYQiLtqXxUTpLZxSjN/mWlwwxAQlJ7v8wpFtsvK1UXSOUyTjvRKB2Um7LBPhZD0l1md'
-        'xJ7VCATfszOiXGOR9np7vwDn7lCMS8SXQNf3RCtyBTVzzNTMUMXmfWrFeR+UngEAEncS'
-        'ASjKwZcid7ERNldthBxjX46mMD2PsJnlYXDs2rye3l+vroOkJJ54SXgZPklLRQmx61sm'
-        'cgKNVFRO0qlpf2pojq1Ro7OG56MY+Bgc1PkIo/WkaT8OVcrDYuvZkJdtBl/+XCZ+NQBJ'
-        'oKg1h6X/VdXRoyE2OWeH6lCXZdHGrauUZAWFw/YJ/0/39OefN3F4Kle3cXjYsF684ZqG'
-        'Tbap/uPwbRx+YPStIQ8bvgA7G6YE'
-    )
+def test_relate_cdash_builds(config):
+    root_spec = concretize_and_marshal('bzip2 ^libiconv')
 
     dep_builds = 'diffutils;libiconv'
     spec_map = ci.get_concrete_specs(root_spec, 'bzip2', dep_builds, 'NONE')

--- a/lib/spack/spack/test/cmd/dependencies.py
+++ b/lib/spack/spack/test/cmd/dependencies.py
@@ -53,8 +53,8 @@ def test_direct_installed_dependencies(mock_packages, database):
     with color_when(False):
         out = dependencies('--installed', 'mpileaks^mpich')
 
-    lines = [l for l in out.strip().split('\n') if not l.startswith('--')]
-    hashes = set([re.split(r'\s+', l)[0] for l in lines])
+    lines = [x for x in out.strip().split('\n') if not x.startswith('--')]
+    hashes = set([re.split(r'\s+', x)[0] for x in lines])
 
     expected = set([spack.store.db.query_one(s).dag_hash(7)
                     for s in ['mpich', 'callpath^mpich']])
@@ -67,8 +67,8 @@ def test_transitive_installed_dependencies(mock_packages, database):
     with color_when(False):
         out = dependencies('--installed', '--transitive', 'mpileaks^zmpi')
 
-    lines = [l for l in out.strip().split('\n') if not l.startswith('--')]
-    hashes = set([re.split(r'\s+', l)[0] for l in lines])
+    lines = [x for x in out.strip().split('\n') if not x.startswith('--')]
+    hashes = set([re.split(r'\s+', x)[0] for x in lines])
 
     expected = set([spack.store.db.query_one(s).dag_hash(7)
                     for s in ['zmpi', 'callpath^zmpi', 'fake',

--- a/lib/spack/spack/test/cmd/dependencies.py
+++ b/lib/spack/spack/test/cmd/dependencies.py
@@ -13,7 +13,9 @@ from spack.main import SpackCommand
 
 dependencies = SpackCommand('dependencies')
 
-mpis = ['mpich', 'mpich2', 'multi-provider-mpi', 'zmpi']
+mpis = [
+    'intel-parallel-studio', 'mpich', 'mpich2', 'multi-provider-mpi', 'zmpi'
+]
 mpi_deps = ['fake']
 
 

--- a/lib/spack/spack/test/cmd/module.py
+++ b/lib/spack/spack/test/cmd/module.py
@@ -84,7 +84,7 @@ def test_remove_and_add(database, module_type):
         return
 
     rm_cli_args = ['rm', '-y', 'mpileaks']
-    module_files = _module_files(module_type, 'mpileaks')
+    module_files = _module_files(module_type, 'mpileaks ^mpich')
     for item in module_files:
         assert os.path.exists(item)
 

--- a/lib/spack/spack/test/cmd/module.py
+++ b/lib/spack/spack/test/cmd/module.py
@@ -84,7 +84,7 @@ def test_remove_and_add(database, module_type):
         return
 
     rm_cli_args = ['rm', '-y', 'mpileaks']
-    module_files = _module_files(module_type, 'mpileaks ^mpich')
+    module_files = _module_files(module_type, 'mpileaks')
     for item in module_files:
         assert os.path.exists(item)
 

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -15,7 +15,7 @@ spec = SpackCommand('spec')
 
 
 def test_spec():
-    output = spec('mpileaks')
+    output = spec('mpileaks ^mpich')
 
     assert 'mpileaks@2.3' in output
     assert 'callpath@1.0' in output
@@ -26,7 +26,7 @@ def test_spec():
 
 
 def test_spec_yaml():
-    output = spec('--yaml', 'mpileaks')
+    output = spec('--yaml', 'mpileaks ^mpich')
 
     mpileaks = spack.spec.Spec.from_yaml(output)
     assert 'mpileaks' in mpileaks
@@ -38,7 +38,7 @@ def test_spec_yaml():
 
 
 def test_spec_json():
-    output = spec('--json', 'mpileaks')
+    output = spec('--json', 'mpileaks ^mpich')
 
     mpileaks = spack.spec.Spec.from_json(output)
     assert 'mpileaks' in mpileaks

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -283,7 +283,7 @@ class TestConcretize(object):
 
     def test_concretize_two_virtuals_with_two_bound(self):
         """Test a package with multiple virtual deps and two of them preset."""
-        Spec('hypre ^openblas ^netlib-lapack').concretize()
+        Spec('hypre ^atlas ^netlib-lapack').concretize()
 
     def test_concretize_two_virtuals_with_dual_provider(self):
         """Test a package with multiple virtual dependencies and force a provider

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -644,3 +644,21 @@ class TestConcretize(object):
         with pytest.raises(spack.error.SpecError):
             s = Spec('+variant')
             s.concretize()
+
+
+@pytest.mark.parametrize('spec_str,ensure_present,ensure_absent', [
+    ('fftw ^mpi=intel-parallel-studio@cluster', ['mpi'], ['lapack'])
+])
+def test_subscript_for_concretized_specs(
+        spec_str, ensure_present, ensure_absent
+):
+    s = Spec(spec_str)
+    s.concretize()
+
+    for dep in ensure_present:
+        msg = '"{0}" should be present in "{1}"'
+        assert dep in s, msg.format(dep, spec_str)
+
+    for dep in ensure_absent:
+        msg = '"{0}" should not be present in "{1}"'
+        assert dep not in s, msg.format(dep, spec_str)

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -114,12 +114,12 @@ class TestConcretizePreferences(object):
         spec = concretize('mpich')
         assert str(spec.target) == preferred
 
-        spec = concretize('mpileaks')
+        spec = concretize('mpileaks ^mpich')
         assert str(spec['mpileaks'].target) == default
         assert str(spec['mpich'].target) == preferred
 
         update_packages('mpileaks', 'target', [preferred])
-        spec = concretize('mpileaks')
+        spec = concretize('mpileaks ^mpich')
         assert str(spec['mpich'].target) == preferred
         assert str(spec['mpich'].target) == preferred
 

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -200,7 +200,7 @@ def test_try_install_from_binary_cache(install_mockery, mock_packages,
         spec = spack.spec.Spec('mpi').concretized()
         return {spec: None}
 
-    spec = spack.spec.Spec('mpich')
+    spec = spack.spec.Spec('intel-parallel-studio')
     spec.concretize()
 
     monkeypatch.setattr(spack.binary_distribution, 'get_spec', _spec)

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -200,7 +200,7 @@ def test_try_install_from_binary_cache(install_mockery, mock_packages,
         spec = spack.spec.Spec('mpi').concretized()
         return {spec: None}
 
-    spec = spack.spec.Spec('intel-parallel-studio')
+    spec = spack.spec.Spec('mpich')
     spec.concretize()
 
     monkeypatch.setattr(spack.binary_distribution, 'get_spec', _spec)

--- a/lib/spack/spack/test/modules/lmod.py
+++ b/lib/spack/spack/test/modules/lmod.py
@@ -27,8 +27,8 @@ def compiler(request):
 
 @pytest.fixture(params=[
     ('mpich@3.0.4', ('mpi',)),
-    ('mpich@3.0.1', []),
-    ('openblas@0.2.15', ('blas',)),
+    ('mpich@3.0.1', tuple()),
+    ('atlas@0.2.15', ('blas',)),
     ('openblas-with-lapack@0.2.15', ('blas', 'lapack'))
 ])
 def provider(request):

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -267,11 +267,11 @@ class TestTcl(object):
         """Tests adding suffixes to module file name."""
         module_configuration('suffix')
 
-        writer, spec = factory('mpileaks+debug arch=x86-linux')
+        writer, spec = factory('mpileaks+debug arch=x86-linux ^mpich')
         assert 'foo' in writer.layout.use_name
         assert 'foo-foo' not in writer.layout.use_name
 
-        writer, spec = factory('mpileaks~debug arch=x86-linux')
+        writer, spec = factory('mpileaks~debug arch=x86-linux ^mpich')
         assert 'foo-bar' in writer.layout.use_name
         assert 'baz' not in writer.layout.use_name
 

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -26,6 +26,7 @@ def mpileaks_possible_deps(mock_packages, mpi_names):
         'callpath': set(['dyninst'] + mpi_names),
         'dyninst': set(['libdwarf', 'libelf']),
         'fake': set(),
+        'intel-parallel-studio': set(),
         'libdwarf': set(['libelf']),
         'libelf': set(),
         'mpich': set(),
@@ -39,8 +40,8 @@ def mpileaks_possible_deps(mock_packages, mpi_names):
 
 def test_possible_dependencies(mock_packages, mpileaks_possible_deps):
     mpileaks = spack.repo.get('mpileaks')
-    assert mpileaks_possible_deps == (
-        mpileaks.possible_dependencies(expand_virtuals=True))
+    result = mpileaks.possible_dependencies(expand_virtuals=True)
+    assert mpileaks_possible_deps == result
 
     assert {
         'callpath': set(['dyninst', 'mpi']),

--- a/lib/spack/spack/test/provider_index.py
+++ b/lib/spack/spack/test/provider_index.py
@@ -18,8 +18,11 @@ Tests assume that mock packages provide this::
                     mpi@:10.0: set([zmpi])},
     'stuff': {stuff: set([externalvirtual])}}
 """
+import pytest
+
 from six import StringIO
 
+import spack.provider_index
 import spack.repo
 from spack.provider_index import ProviderIndex
 from spack.spec import Spec
@@ -73,3 +76,15 @@ def test_copy(mock_packages):
     p = ProviderIndex(spack.repo.all_package_names())
     q = p.copy()
     assert p == q
+
+
+@pytest.mark.parametrize('spec_str,vspec,expected', [
+    ('openblas', 'lapack', ['blas', 'lapack', 'another']),
+    ('openblas@0.2.14', 'lapack', ['blas', 'lapack', 'another']),
+    ('openblas@0.2.15', 'lapack', ['blas', 'lapack']),
+])
+@pytest.mark.usefixtures('config', 'mock_packages')
+def test_conditional_computation_used_together(spec_str, vspec, expected):
+    s = Spec(spec_str)
+    together = spack.provider_index.used_together(s, vspec)
+    assert together == set(expected)

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -119,7 +119,7 @@ def test_installed_deps():
             setattr(spec.package, 'installed', True)
 
         a_spec = Spec('a')
-        a_spec._add_dependency(c_installed, default)
+        a_spec._add_dependency(c_installed, default, virtuals=None)
         a_spec.concretize()
 
         assert a_spec['d'].version == spack.version.Version('3')
@@ -145,7 +145,7 @@ def test_specify_preinstalled_dep():
             setattr(spec.package, 'installed', True)
 
         a_spec = Spec('a')
-        a_spec._add_dependency(b_spec, default)
+        a_spec._add_dependency(b_spec, default, virtuals=None)
         a_spec.concretize()
 
         assert set(x.name for x in a_spec.traverse()) == set(['a', 'b', 'c'])

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -1002,15 +1002,15 @@ class TestSpecSematics(object):
          [('mpi', 'mpich'), ('lapack', 'openblas'), ('blas', 'openblas')]),
         # Test that we can mix dependencies that provide an overlapping
         # sets of virtual dependencies
-        # ('netlib-scalapack ^mpi=intel-parallel-studio ^lapack=openblas',
-        # [('mpi', 'intel-parallel-studio'), ('lapack', 'openblas'),
-        #  ('blas', 'openblas')]),
+        ('netlib-scalapack ^mpi=intel-parallel-studio ^lapack=openblas',
+         [('mpi', 'intel-parallel-studio'), ('lapack', 'openblas'),
+          ('blas', 'openblas')]),
         ('netlib-scalapack ^mpi=intel-parallel-studio ^openblas',
          [('mpi', 'intel-parallel-studio'), ('lapack', 'openblas'),
           ('blas', 'openblas')]),
-        # ('netlib-scalapack ^intel-parallel-studio ^lapack=openblas',
-        #  [('mpi', 'intel-parallel-studio'), ('lapack', 'openblas'),
-        #   ('blas', 'openblas')]),
+        ('netlib-scalapack ^intel-parallel-studio ^lapack=openblas',
+         [('mpi', 'intel-parallel-studio'), ('lapack', 'openblas'),
+          ('blas', 'openblas')]),
     ])
     def test_parse_virtual_deps_bindings(self, spec_str, specs_in_dag):
         s = Spec(spec_str)

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -1011,6 +1011,9 @@ class TestSpecSematics(object):
         ('netlib-scalapack ^intel-parallel-studio ^lapack=openblas',
          [('mpi', 'intel-parallel-studio'), ('lapack', 'openblas'),
           ('blas', 'openblas')]),
+        # Test that we can bind more than one virtual to the same provider
+        ('netlib-scalapack ^lapack,blas=openblas',
+         [('lapack', 'openblas'), ('blas', 'openblas')]),
     ])
     def test_virtual_deps_bindings(self, spec_str, specs_in_dag):
         s = Spec(spec_str)

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -989,7 +989,28 @@ class TestSpecSematics(object):
             s.concretize()
 
     @pytest.mark.parametrize('spec_str,specs_in_dag', [
-        ('hdf5+mpi ^mpi=mpich', [('mpich', 'mpich'), ('mpi', 'mpich')])
+        ('hdf5+mpi ^mpi=mpich', [('mpich', 'mpich'), ('mpi', 'mpich')]),
+        # Try different combinations with packages that provides a
+        # disjoint set of virtual dependencies
+        ('netlib-scalapack ^mpich ^openblas',
+         [('mpi', 'mpich'), ('lapack', 'openblas'), ('blas', 'openblas')]),
+        ('netlib-scalapack ^mpi=mpich ^openblas',
+         [('mpi', 'mpich'), ('lapack', 'openblas'), ('blas', 'openblas')]),
+        ('netlib-scalapack ^mpich ^lapack=openblas',
+         [('mpi', 'mpich'), ('lapack', 'openblas'), ('blas', 'openblas')]),
+        ('netlib-scalapack ^mpi=mpich ^lapack=openblas',
+         [('mpi', 'mpich'), ('lapack', 'openblas'), ('blas', 'openblas')]),
+        # Test that we can mix dependencies that provide an overlapping
+        # sets of virtual dependencies
+        # ('netlib-scalapack ^mpi=intel-parallel-studio ^lapack=openblas',
+        # [('mpi', 'intel-parallel-studio'), ('lapack', 'openblas'),
+        #  ('blas', 'openblas')]),
+        ('netlib-scalapack ^mpi=intel-parallel-studio ^openblas',
+         [('mpi', 'intel-parallel-studio'), ('lapack', 'openblas'),
+          ('blas', 'openblas')]),
+        # ('netlib-scalapack ^intel-parallel-studio ^lapack=openblas',
+        #  [('mpi', 'intel-parallel-studio'), ('lapack', 'openblas'),
+        #   ('blas', 'openblas')]),
     ])
     def test_parse_virtual_deps_bindings(self, spec_str, specs_in_dag):
         s = Spec(spec_str)

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -989,12 +989,14 @@ class TestSpecSematics(object):
             s.concretize()
 
     @pytest.mark.parametrize('spec_str,specs_in_dag', [
-        ('hdf5+mpi ^mpi=mpich', ['mpich'])
+        ('hdf5+mpi ^mpi=mpich', [('mpich', 'mpich'), ('mpi', 'mpich')])
     ])
     def test_parse_virtual_deps_bindings(self, spec_str, specs_in_dag):
         s = Spec(spec_str)
-        for expected in specs_in_dag:
-            assert expected in s
+        s.concretize()
+        for label, expected in specs_in_dag:
+            assert label in s
+            assert s[label].satisfies(expected, strict=True)
 
 
 @pytest.mark.regression('3887')

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -1012,12 +1012,22 @@ class TestSpecSematics(object):
          [('mpi', 'intel-parallel-studio'), ('lapack', 'openblas'),
           ('blas', 'openblas')]),
     ])
-    def test_parse_virtual_deps_bindings(self, spec_str, specs_in_dag):
+    def test_virtual_deps_bindings(self, spec_str, specs_in_dag):
         s = Spec(spec_str)
         s.concretize()
         for label, expected in specs_in_dag:
             assert label in s
             assert s[label].satisfies(expected, strict=True)
+
+    @pytest.mark.parametrize('spec_str', [
+        'netlib-scalapack ^intel-parallel-studio ^openblas',
+        'netlib-scalapack ^blas=atlas ^openblas',
+        'netlib-scalapack ^lapack=intel-parallel-studio ^openblas',
+    ])
+    def test_unsatisfiable_virtual_deps_bindings(self, spec_str):
+        s = Spec(spec_str)
+        with pytest.raises(Exception):
+            s.concretize()
 
 
 @pytest.mark.regression('3887')

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -988,6 +988,14 @@ class TestSpecSematics(object):
         with pytest.raises(UnknownVariantError, match=r'package has no such'):
             s.concretize()
 
+    @pytest.mark.parametrize('spec_str,specs_in_dag', [
+        ('hdf5+mpi ^mpi=mpich', ['mpich'])
+    ])
+    def test_parse_virtual_deps_bindings(self, spec_str, specs_in_dag):
+        s = Spec(spec_str)
+        for expected in specs_in_dag:
+            assert expected in s
+
 
 @pytest.mark.regression('3887')
 @pytest.mark.parametrize('spec_str', [

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -1032,6 +1032,24 @@ class TestSpecSematics(object):
         with pytest.raises(Exception):
             s.concretize()
 
+    @pytest.mark.parametrize('spec_str,expected_providers', [
+        ('netlib-scalapack ^mpi=mpich ^lapack=openblas',
+         {'mpich': ['mpi'], 'openblas': ['blas', 'lapack']}),
+        ('netlib-scalapack ^mpi=mpich ^lapack,blas=openblas',
+         {'mpich': ['mpi'], 'openblas': ['blas', 'lapack']}),
+        ('netlib-scalapack ^mpi=intel-parallel-studio ^openblas',
+         {'intel-parallel-studio': ['mpi'], 'openblas': ['blas', 'lapack']}),
+    ])
+    def test_virtual_deps_as_edge_attributes(
+            self, spec_str, expected_providers
+    ):
+        s = Spec(spec_str)
+        s.concretize()
+        for name, expected_virtuals in expected_providers.items():
+            assert name in s._dependencies
+            expected_virtuals = tuple(sorted(expected_virtuals))
+            assert expected_virtuals == s._dependencies[name].virtuals
+
 
 @pytest.mark.regression('3887')
 @pytest.mark.parametrize('spec_str', [

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -805,3 +805,16 @@ class TestSpecSyntax(object):
     ])
     def test_target_tokenization(self, expected_tokens, spec_string):
         self.check_lex(expected_tokens, spec_string)
+
+    @pytest.mark.parametrize('expected_tokens,spec_string', [
+        ([Token(sp.ID, 'hdf5'),
+          Token(sp.DEP),
+          Token(sp.ID, 'mpi'),
+          Token(sp.EQ),
+          Token(sp.VAL, 'openmpi')],
+         'hdf5 ^mpi=openmpi')
+    ])
+    def test_provider_preferences_tokenization(
+            self, expected_tokens, spec_string
+    ):
+        self.check_lex(expected_tokens, spec_string)

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -812,7 +812,15 @@ class TestSpecSyntax(object):
           Token(sp.ID, 'mpi'),
           Token(sp.EQ),
           Token(sp.VAL, 'openmpi')],
-         'hdf5 ^mpi=openmpi')
+         'hdf5 ^mpi=openmpi'),
+        ([Token(sp.ID, 'netlib-scalapack'),
+          Token(sp.DEP),
+          Token(sp.ID, 'lapack'),
+          Token(sp.COMMA),
+          Token(sp.ID, 'blas'),
+          Token(sp.EQ),
+          Token(sp.VAL, 'openblas')],
+         'netlib-scalapack ^lapack,blas=openblas')
     ])
     def test_provider_preferences_tokenization(
             self, expected_tokens, spec_string

--- a/var/spack/repos/builtin.mock/packages/atlas/package.py
+++ b/var/spack/repos/builtin.mock/packages/atlas/package.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class Atlas(Package):
+    """Simple package with one optional dependency"""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/a-1.0.tar.gz"
+
+    version('1.0', '0123456789abcdef0123456789abcdef')
+
+    provides('blas')

--- a/var/spack/repos/builtin.mock/packages/hdf5/package.py
+++ b/var/spack/repos/builtin.mock/packages/hdf5/package.py
@@ -12,4 +12,4 @@ class Hdf5(Package):
 
     variant('mpi', default=True, description='Debug variant')
 
-    depends_on('mpi', when='mpi')
+    depends_on('mpi', when='+mpi')

--- a/var/spack/repos/builtin.mock/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin.mock/packages/intel-parallel-studio/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class IntelParallelStudio(Package):
+    """Intel Parallel Studio."""
+
+    homepage = "https://software.intel.com/en-us/intel-parallel-studio-xe"
+    url = 'http://tec/16225/parallel_studio_xe_2020_cluster_edition.tgz'
+
+    version('cluster.2020.0', sha256='573b1d20707d68ce85b')
+
+    provides('mpi')
+    provides('scalapack')
+    provides('blas', 'lapack')

--- a/var/spack/repos/builtin.mock/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin.mock/packages/intel-parallel-studio/package.py
@@ -14,6 +14,6 @@ class IntelParallelStudio(Package):
 
     version('cluster.2020.0', sha256='573b1d20707d68ce85b')
 
-    provides('mpi')
+    provides('mpi@:3')
     provides('scalapack')
     provides('blas', 'lapack')

--- a/var/spack/repos/builtin.mock/packages/netlib-scalapack/package.py
+++ b/var/spack/repos/builtin.mock/packages/netlib-scalapack/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class NetlibScalapack(Package):
+    homepage = "http://www.netlib.org/scalapack/"
+    url = "http://www.netlib.org/scalapack/scalapack-2.1.0.tgz"
+
+    version('2.1.0', 'b1d3e3e425b2e44a06760ff173104bdf')
+
+    provides('scalapack')
+
+    depends_on('mpi')
+    depends_on('lapack')
+    depends_on('blas')

--- a/var/spack/repos/builtin.mock/packages/openblas/package.py
+++ b/var/spack/repos/builtin.mock/packages/openblas/package.py
@@ -9,8 +9,8 @@ from spack import *
 class Openblas(Package):
     """OpenBLAS: An optimized BLAS library"""
     homepage = "http://www.openblas.net"
-    url      = "http://github.com/xianyi/OpenBLAS/archive/v0.2.15.tar.gz"
+    url = "http://github.com/xianyi/OpenBLAS/archive/v0.2.15.tar.gz"
 
     version('0.2.15', 'b1190f3d3471685f17cfd1ec1d252ac9')
 
-    provides('blas')
+    provides('blas', 'lapack')

--- a/var/spack/repos/builtin.mock/packages/openblas/package.py
+++ b/var/spack/repos/builtin.mock/packages/openblas/package.py
@@ -12,5 +12,7 @@ class Openblas(Package):
     url = "http://github.com/xianyi/OpenBLAS/archive/v0.2.15.tar.gz"
 
     version('0.2.15', 'b1190f3d3471685f17cfd1ec1d252ac9')
+    version('0.2.14', 'b1190f3d3471685f17cfd1ec1d252ac9')
 
     provides('blas', 'lapack')
+    provides('blas@:2.0', 'lapack@:3.0', 'another', when='@0.2.14')

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -49,8 +49,7 @@ class Openblas(MakefilePackage):
     )
 
     # virtual dependency
-    provides('blas')
-    provides('lapack')
+    provides('blas', 'lapack')
 
     # OpenBLAS >=3.0 has an official way to disable internal parallel builds
     patch('make.patch', when='@0.2.16:0.2.20')


### PR DESCRIPTION
fixes #15443
closes #17439

This PR implements what is described in #15443:

- [x] Finer selection of virtual packages, with an extension to the spec language
- [x] Unit tests to stress the new code
- [x] Documentation of the new feature
- [x] Rebase after #14934 is merged and check there are no regressions on features
- [x] Add attributes on DAG edges to account for virtual dependencies
- [x] Handle conditionals in `provides` correctly
- [ ] Rebase after #15256 is merged, revisit extension to the spec language
