### PR TITLE
Add package: py-deprecated

### DIFF
--- a/var/spack/repos/builtin/packages/py-deprecated/package.py
+++ b/var/spack/repos/builtin/packages/py-deprecated/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyDeprecated(PythonPackage):
+    """Python @deprecated decorator to deprecate old python classes,
+    functions or methods."""
+
+    homepage = "https://github.com/tantale/deprecated"
+    url = "https://github.com/tantale/deprecated/archive/v1.2.7.tar.gz"
+
+    version("1.2.7", sha256="7db3c814ddcac9d79c5bae8a0e82a5bba55cb8e46f3d611d0d8611c34a72a783")
+
+    depends_on("python@2.7:2.8,3.4:", type=("build", "run"))
+    depends_on("py-wrapt@1.10:1.99999", type=("build", "run"))
+    depends_on("py-setuptools", type="build")


### PR DESCRIPTION
This PR adds the ["Deprecated"](https://pypi.org/project/Deprecated) python module.

The dependency information has been extracted from the project's [`setup.py`](https://github.com/tantale/deprecated/blob/master/setup.py).