### PR TITLE
add charliecloud/0.14; remove umoci/skopeo; remove builder variant

### DIFF
--- a/var/spack/repos/builtin/packages/charliecloud/package.py
+++ b/var/spack/repos/builtin/packages/charliecloud/package.py
@@ -16,7 +16,7 @@ class Charliecloud(AutotoolsPackage):
     version('master', branch='master')
     version('0.14',   sha256='4ae23c2d6442949e16902f9d5604dbd1d6059aeb5dd461b11fc5c74d49dcb194')
 
-    depends_on('python@3.5:', type=('run')
+    depends_on('python@3.5:', type='run')
     depends_on('py-lark-parser', type='run')
 
     # man pages and html docs variant

--- a/var/spack/repos/builtin/packages/charliecloud/package.py
+++ b/var/spack/repos/builtin/packages/charliecloud/package.py
@@ -9,6 +9,7 @@ from spack import *
 class Charliecloud(AutotoolsPackage):
     """Lightweight user-defined software stacks for HPC."""
 
+    maintainers = ['j-ogas']
     homepage = "https://hpc.github.io/charliecloud"
     url      = "https://github.com/hpc/charliecloud/releases/download/v0.14/charliecloud-0.9.10.tar.gz"
     git      = "https://github.com/hpc/charliecloud.git"
@@ -16,8 +17,9 @@ class Charliecloud(AutotoolsPackage):
     version('master', branch='master')
     version('0.14',   sha256='4ae23c2d6442949e16902f9d5604dbd1d6059aeb5dd461b11fc5c74d49dcb194')
 
-    depends_on('python@3.5:', type='run')
+    depends_on('python@3.5:',    type='run')
     depends_on('py-lark-parser', type='run')
+    depends_on('py-requests',    type='run')
 
     # man pages and html docs variant
     variant('docs', default=False, description='Build man pages and html docs')
@@ -32,7 +34,9 @@ class Charliecloud(AutotoolsPackage):
 
         args = []
 
-        if '+docs' not in self.spec:
+        if '+docs' in self.spec:
+            args.append('--enable-html')
+        else:
             args.append('--disable-html')
 
         return args

--- a/var/spack/repos/builtin/packages/charliecloud/package.py
+++ b/var/spack/repos/builtin/packages/charliecloud/package.py
@@ -10,21 +10,16 @@ class Charliecloud(AutotoolsPackage):
     """Lightweight user-defined software stacks for HPC."""
 
     homepage = "https://hpc.github.io/charliecloud"
-    url      = "https://github.com/hpc/charliecloud/releases/download/v0.9.10/charliecloud-0.9.10.tar.gz"
+    url      = "https://github.com/hpc/charliecloud/releases/download/v0.14/charliecloud-0.9.10.tar.gz"
     git      = "https://github.com/hpc/charliecloud.git"
 
     version('master', branch='master')
-    version('0.13',   sha256='5740bff6e410ca99484c1bdf3dbe834c0f753c846d55c19d6162967a3e2718e0')
+    version('0.14',   sha256='4ae23c2d6442949e16902f9d5604dbd1d6059aeb5dd461b11fc5c74d49dcb194')
 
-    depends_on('python@3.4:', type=('build', 'run'))
+    depends_on('python@3.5:', type=('run')
+    depends_on('py-lark-parser', type='run')
 
-    # experimental builder (ch-grow)
-    variant('builder', default=False, description='Bundle dependencies for unprivileged builder (ch-grow)')
-    depends_on('py-lark-parser', type='run', when='+builder')
-    depends_on('skopeo', type='run', when='+builder')
-    depends_on('umoci', type='run', when='+builder')
-
-    # man pages and html docs
+    # man pages and html docs variant
     variant('docs', default=False, description='Build man pages and html docs')
     depends_on('rsync',               type='build', when='+docs')
     depends_on('py-sphinx',           type='build', when='+docs')
@@ -39,8 +34,5 @@ class Charliecloud(AutotoolsPackage):
 
         if '+docs' not in self.spec:
             args.append('--disable-html')
-
-        if '+builder' not in self.spec:
-            args.append('--disable-ch-grow')
 
         return args

--- a/var/spack/repos/builtin/packages/charliecloud/package.py
+++ b/var/spack/repos/builtin/packages/charliecloud/package.py
@@ -17,6 +17,11 @@ class Charliecloud(AutotoolsPackage):
     version('master', branch='master')
     version('0.14',   sha256='4ae23c2d6442949e16902f9d5604dbd1d6059aeb5dd461b11fc5c74d49dcb194')
 
+    depends_on('m4',       type='build')
+    depends_on('autoconf', type='build')
+    depends_on('automake', type='build')
+    depends_on('libtool',  type='build')
+
     depends_on('python@3.5:',    type='run')
     depends_on('py-lark-parser', type='run')
     depends_on('py-requests',    type='run')


### PR DESCRIPTION

We've had issues (#14605, [636](https://github.com/hpc/charliecloud/pull/636)) with our spack builder variant. In short, you simply couldn't install Charliecloud with said variant.

To reduce Charliecloud dependencies and simplify packaging we replaced `skopeo` and `umoci` functionality with a native python3 script, [ch-tug](https://github.com/hpc/charliecloud/pull/616).

We'd like to remove the builder variant completely. Charliecloud 0.13 (unsupported) was the last release depending on skopeo and umoci, thus this PR removes it completely.

