### PR TITLE
py-decorator: add 4.4.2

### DIFF
--- a/var/spack/repos/builtin/packages/py-decorator/package.py
+++ b/var/spack/repos/builtin/packages/py-decorator/package.py
@@ -12,8 +12,9 @@ class PyDecorator(PythonPackage):
        various non-trivial examples."""
 
     homepage = "https://github.com/micheles/decorator"
-    url      = "https://pypi.io/packages/source/d/decorator/decorator-4.4.0.tar.gz"
+    url      = "https://pypi.io/packages/source/d/decorator/decorator-4.4.2.tar.gz"
 
+    version('4.4.2', sha256='e3a62f0520172440ca0dcc823749319382e377f37f140a0b99ef45fecb84bfe7')
     version('4.4.0', sha256='86156361c50488b84a3f148056ea716ca587df2f0de1d34750d35c21312725de')
     version('4.3.2', sha256='33cd704aea07b4c28b3eb2c97d288a06918275dac0ecebdaf1bc8a48d98adb9e')
     version('4.3.0', sha256='c39efa13fbdeb4506c476c9b3babf6a718da943dab7811c206005a4a956c080c')


### PR DESCRIPTION
Successfully installs on macOS 10.15.3 with Python 3.7.6 and Clang 11.0.0.