### PR TITLE
add missing python build dependency to htop

### DIFF
--- a/var/spack/repos/builtin/packages/htop/package.py
+++ b/var/spack/repos/builtin/packages/htop/package.py
@@ -18,6 +18,7 @@ class Htop(AutotoolsPackage):
     version('2.0.2', sha256='179be9dccb80cee0c5e1a1f58c8f72ce7b2328ede30fb71dcdf336539be2f487')
 
     depends_on('ncurses')
+    depends_on('python+pythoncmd', type='build')
 
     def configure_args(self):
         return ['--enable-shared']


### PR DESCRIPTION
htop requires a `python` binary on the PATH in order to be build. 

The shebang in [scripts/MakeHeader.py](https://github.com/hishamhm/htop/blob/master/scripts/MakeHeader.py) is `#!/usr/bin/env python` leading to the error below. This affects all versions in spack. I think it doesn't trigger usually, as the host system typically comes with a `python` binary/symlink. Technically the explicit variant is not needed, as we default to True, but it's not PEP compliant so we might want to change it in the future.

Found this while setting up my Ubuntu on Windows which comes with python3.6
```
==> Error: ProcessError: Command exited with status 2:
    'make' '-j8'

16 errors found in build log:
     93     ./scripts/MakeHeader.py DisplayOptionsPanel.c
     94     ./scripts/MakeHeader.py Header.c
     95     ./scripts/MakeHeader.py htop.c
     96     ./scripts/MakeHeader.py ProcessList.c
     97     ./scripts/MakeHeader.py SignalsPanel.c
     98     ./scripts/MakeHeader.py StringUtils.c
  >> 99     /usr/bin/env: 'python': No such file or directory
  >> 100    /usr/bin/env: 'python': No such file or directory
     101    Makefile:1416: recipe for target 'CategoriesPanel.h' failed
  >> 102    make: *** [CategoriesPanel.h] Error 127
     103    make: *** Waiting for unfinished jobs....
     104    Makefile:1416: recipe for target 'Header.h' failed
  >> 105    make: *** [Header.h] Error 127
  >> 106    /usr/bin/env: 'python': No such file or directory
     107    Makefile:1416: recipe for target 'htop.h' failed
  >> 108    make: *** [htop.h] Error 127
  >> 109    /usr/bin/env: 'python': No such file or directory
     110    Makefile:1416: recipe for target 'MainPanel.h' failed
  >> 111    make: *** [MainPanel.h] Error 127
  >> 112    /usr/bin/env: 'python': No such file or directory
     113    Makefile:1416: recipe for target 'DisplayOptionsPanel.h' failed
  >> 114    make: *** [DisplayOptionsPanel.h] Error 127
  >> 115    /usr/bin/env: 'python': No such file or directory
     116    Makefile:1416: recipe for target 'SignalsPanel.h' failed
  >> 117    make: *** [SignalsPanel.h] Error 127
  >> 118    /usr/bin/env: 'python': No such file or directory
     119    Makefile:1416: recipe for target 'StringUtils.h' failed
  >> 120    make: *** [StringUtils.h] Error 127
  >> 121    /usr/bin/env: 'python': No such file or directory
     122    Makefile:1416: recipe for target 'ProcessList.h' failed
  >> 123    make: *** [ProcessList.h] Error 127
```