### PR TITLE
Add gmsh v4.5.4 with new options

### DIFF
--- a/var/spack/repos/builtin/packages/gmsh/package.py
+++ b/var/spack/repos/builtin/packages/gmsh/package.py
@@ -64,6 +64,7 @@ class Gmsh(CMakePackage):
     depends_on('metis', when='+metis')
 
     conflicts('+slepc', when='~petsc')
+    conflicts('+oce', when='+opencascade')
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/gmsh/package.py
+++ b/var/spack/repos/builtin/packages/gmsh/package.py
@@ -19,6 +19,7 @@ class Gmsh(CMakePackage):
     homepage = 'http://gmsh.info'
     url = 'http://gmsh.info/src/gmsh-4.4.1-source.tgz'
 
+    version('4.5.4', sha256='ccf8c74f43cbe3c371abe79862025d41642b3538a0148f018949494e3b3e2ecd')
     version('4.4.1', sha256='853c6438fc4e4b765206e66a514b09182c56377bb4b73f1d0d26eda7eb8af0dc')
     version('4.2.2', sha256='e9ee9f5c606bbec5f2adbb8c3d6023c4e2577f487fa4e4ecfcfc94a241cc8dcc')
     version('4.0.0',  sha256='fb0c8afa37425c6f4315ab3b3124e9e102fcf270a35198423a4002796f04155f')
@@ -31,16 +32,18 @@ class Gmsh(CMakePackage):
 
     variant('shared',      default=True,  description='Enables the build of shared libraries')
     variant('mpi',         default=True,  description='Builds MPI support for parser and solver')
-    variant('openmp',      default=False,  description='Enable OpenMP support')
+    variant('openmp',      default=False, description='Enable OpenMP support')
     variant('fltk',        default=False, description='Enables the build of the FLTK GUI')
     variant('hdf5',        default=False, description='Enables HDF5 support')
     variant('compression', default=True,  description='Enables IO compression through zlib')
     variant('netgen',      default=False, description='Build with Netgen')
+    variant('opencascade', default=False, description='Build with OpenCASCADE')
     variant('oce',         default=False, description='Build with OCE')
     variant('petsc',       default=False, description='Build with PETSc')
     variant('slepc',       default=False, description='Build with SLEPc (only when PETSc is enabled)')
     variant('tetgen',      default=False, description='Build with Tetgen')
-    variant('metis',       default=False,  description='Build with Metis')
+    variant('metis',       default=False, description='Build with Metis')
+    variant('privateapi',  default=False, description='Enable the private API')
 
     depends_on('blas')
     depends_on('lapack')
@@ -51,6 +54,7 @@ class Gmsh(CMakePackage):
     depends_on('fltk', when='+fltk')
     depends_on('hdf5', when='+hdf5')
     depends_on('netgen', when='+netgen')
+    depends_on('opencascade', when='+opencascade')
     depends_on('oce',  when='+oce')
     depends_on('petsc+mpi', when='+petsc+mpi')
     depends_on('petsc', when='+petsc~mpi')
@@ -95,6 +99,9 @@ class Gmsh(CMakePackage):
 
         if '+oce' in spec:
             env['CASROOT'] = self.spec['oce'].prefix
+            options.append('-DENABLE_OCC=ON')
+        elif '+opencascade' in spec:
+            env['CASROOT'] = self.spec['opencascade'].prefix
             options.append('-DENABLE_OCC=ON')
         else:
             options.append('-DENABLE_OCC=OFF')
@@ -141,5 +148,10 @@ class Gmsh(CMakePackage):
 
         if '+compression' in spec:
             options.append('-DENABLE_COMPRESSED_IO:BOOL=ON')
+
+        if '+privateapi' in spec:
+            options.append('-DENABLE_PRIVATE_API=ON')
+        else:
+            options.append('-DENABLE_PRIVATE_API=OFF')
 
         return options


### PR DESCRIPTION
This adds OpenCASCADE as an alternative to the oce package.
A new variant 'privateapi' is added to enable the gmsh private API.