### PR TITLE
sentencepiece: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/sentencepiece/package.py
+++ b/var/spack/repos/builtin/packages/sentencepiece/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class Sentencepiece(CMakePackage):
+    """Unsupervised text tokenizer for Neural Network-based text generation.
+
+    This is the C++ package."""
+
+    homepage = "https://github.com/google/sentencepiece"
+    url      = "https://github.com/google/sentencepiece/archive/v0.1.85.tar.gz"
+
+    maintainers = ['adamjstewart']
+
+    version('0.1.85', sha256='dd4956287a1b6af3cbdbbd499b7227a859a4e3f41c9882de5e6bdd929e219ae6')
+
+    depends_on('cmake@3.1:', type='build')
+    depends_on('gperftools')  # optional, 10-40% performance improvement


### PR DESCRIPTION
Successfully installs on macOS 10.15.3 with Clang 11.0.0.