### PR TITLE
Add 33.2.1 version with checksum to lua-luaposix

### DIFF
--- a/var/spack/repos/builtin/packages/lua-luaposix/package.py
+++ b/var/spack/repos/builtin/packages/lua-luaposix/package.py
@@ -13,6 +13,7 @@ class LuaLuaposix(Package):
     url      = "https://github.com/luaposix/luaposix/archive/release-v33.4.0.tar.gz"
 
     version('33.4.0', sha256='e66262f5b7fe1c32c65f17a5ef5ffb31c4d1877019b4870a5d373e2ab6526a21')
+    version('33.2.1', sha256='4fb34dfea67f4cf3194cdecc6614c9aea67edc3c4093d34137669ea869c358e1')
 
     extends("lua")
 


### PR DESCRIPTION
Add version 33.2.1 with checksum to the lua-luaposix package. 