### PR TITLE
fix: change typo dependnecies to dependencies

### DIFF
--- a/lib/spack/spack/cmd/dependents.py
+++ b/lib/spack/spack/cmd/dependents.py
@@ -30,7 +30,7 @@ def setup_parser(subparser):
 
 def inverted_dependencies():
     """Iterate through all packages and return a dictionary mapping package
-       names to possible dependnecies.
+       names to possible dependencies.
 
        Virtual packages are included as sources, so that you can query
        dependents of, e.g., `mpi`, but virtuals are not included as

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3120,7 +3120,7 @@ class Spec(object):
             A copy of this spec.
 
         Examples:
-            Deep copy with dependnecies::
+            Deep copy with dependencies::
 
                 spec.copy()
                 spec.copy(deps=True)


### PR DESCRIPTION
Fixes a typo I came across in the docs when looking for information about dependent packages.