### PR TITLE
Buildcache: add unit tests for normalized path functions in relocate.py

### DIFF
--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -26,7 +26,9 @@ from spack.fetch_strategy import URLFetchStrategy, FetchStrategyComposite
 from spack.relocate import needs_binary_relocation, needs_text_relocation
 from spack.relocate import relocate_text, relocate_links
 from spack.relocate import get_relative_elf_rpaths
+from spack.relocate import get_normalized_elf_rpaths
 from spack.relocate import macho_make_paths_relative
+from spack.relocate import macho_make_paths_normal
 from spack.relocate import set_placeholder, macho_find_paths
 from spack.relocate import file_is_relocatable
 
@@ -471,7 +473,7 @@ def test_replace_paths(tmpdir):
 
 
 def test_macho_make_paths():
-    out = macho_make_paths_relative('/Users/Shares/spack/pkgC/lib/libC.dylib',
+    out = macho_make_paths_relative('/Users/Shared/spack/pkgC/lib/libC.dylib',
                                     '/Users/Shared/spack',
                                     ('/Users/Shared/spack/pkgA/lib',
                                      '/Users/Shared/spack/pkgB/lib',
@@ -481,18 +483,42 @@ def test_macho_make_paths():
                                      '/usr/local/lib/libloco.dylib'),
                                     '/Users/Shared/spack/pkgC/lib/libC.dylib')
     assert out == {'/Users/Shared/spack/pkgA/lib':
-                   '@loader_path/../../../../Shared/spack/pkgA/lib',
+                   '@loader_path/../../pkgA/lib',
                    '/Users/Shared/spack/pkgB/lib':
-                   '@loader_path/../../../../Shared/spack/pkgB/lib',
+                   '@loader_path/../../pkgB/lib',
                    '/usr/local/lib': '/usr/local/lib',
                    '/Users/Shared/spack/pkgA/libA.dylib':
-                   '@loader_path/../../../../Shared/spack/pkgA/libA.dylib',
+                   '@loader_path/../../pkgA/libA.dylib',
                    '/Users/Shared/spack/pkgB/libB.dylib':
-                   '@loader_path/../../../../Shared/spack/pkgB/libB.dylib',
+                   '@loader_path/../../pkgB/libB.dylib',
                    '/usr/local/lib/libloco.dylib':
                    '/usr/local/lib/libloco.dylib',
                    '/Users/Shared/spack/pkgC/lib/libC.dylib':
                    '@rpath/libC.dylib'}
+
+    out = macho_make_paths_normal('/Users/Shared/spack/pkgC/lib/libC.dylib',
+                                  ('@loader_path/../../pkgA/lib',
+                                   '@loader_path/../../pkgB/lib',
+                                   '/usr/local/lib'),
+                                  ('@loader_path/../../pkgA/libA.dylib',
+                                   '@loader_path/../../pkgB/libB.dylib',
+                                   '/usr/local/lib/libloco.dylib'),
+                                  '@rpath/libC.dylib')
+
+    assert out == {'@rpath/libC.dylib':
+                   '/Users/Shared/spack/pkgC/lib/libC.dylib',
+                   '@loader_path/../../pkgA/lib':
+                   '/Users/Shared/spack/pkgA/lib',
+                   '@loader_path/../../pkgB/lib':
+                   '/Users/Shared/spack/pkgB/lib',
+                   '/usr/local/lib': '/usr/local/lib',
+                   '@loader_path/../../pkgA/libA.dylib':
+                   '/Users/Shared/spack/pkgA/libA.dylib',
+                   '@loader_path/../../pkgB/libB.dylib':
+                   '/Users/Shared/spack/pkgB/libB.dylib',
+                   '/usr/local/lib/libloco.dylib':
+                   '/usr/local/lib/libloco.dylib'
+                   }
 
     out = macho_make_paths_relative('/Users/Shared/spack/pkgC/bin/exeC',
                                     '/Users/Shared/spack',
@@ -515,9 +541,35 @@ def test_macho_make_paths():
                    '/usr/local/lib/libloco.dylib':
                    '/usr/local/lib/libloco.dylib'}
 
+    out = macho_make_paths_normal('/Users/Shared/spack/pkgC/bin/exeC',
+                                  ('@loader_path/../../pkgA/lib',
+                                   '@loader_path/../../pkgB/lib',
+                                   '/usr/local/lib'),
+                                  ('@loader_path/../../pkgA/libA.dylib',
+                                      '@loader_path/../../pkgB/libB.dylib',
+                                      '/usr/local/lib/libloco.dylib'),
+                                  None)
+
+    assert out == {'@loader_path/../../pkgA/lib':
+                   '/Users/Shared/spack/pkgA/lib',
+                   '@loader_path/../../pkgB/lib':
+                   '/Users/Shared/spack/pkgB/lib',
+                   '/usr/local/lib': '/usr/local/lib',
+                   '@loader_path/../../pkgA/libA.dylib':
+                   '/Users/Shared/spack/pkgA/libA.dylib',
+                   '@loader_path/../../pkgB/libB.dylib':
+                   '/Users/Shared/spack/pkgB/libB.dylib',
+                   '/usr/local/lib/libloco.dylib':
+                   '/usr/local/lib/libloco.dylib'}
+
 
 def test_elf_paths():
     out = get_relative_elf_rpaths(
         '/usr/bin/test', '/usr',
         ('/usr/lib', '/usr/lib64', '/opt/local/lib'))
     assert out == ['$ORIGIN/../lib', '$ORIGIN/../lib64', '/opt/local/lib']
+
+    out = get_normalized_elf_rpaths(
+        '/usr/bin/test',
+        ['$ORIGIN/../lib', '$ORIGIN/../lib64', '/opt/local/lib'])
+    assert out == ['/usr/lib', '/usr/lib64', '/opt/local/lib']


### PR DESCRIPTION
Also fixes a bug in the test for relative paths.