### PR TITLE
spack.relocate: add unit test

### DIFF
--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -90,10 +90,8 @@ def _patchelf():
     if spec.package.installed and os.path.exists(exe_path): 
         return exe_path
     
-    # Skip darwin or test platform
-    # FIXME: remove requirement for test platform
-    if (str(spack.architecture.platform()) == 'test' or
-        str(spack.architecture.platform()) == 'darwin'):
+    # Skip darwin
+    if str(spack.architecture.platform()) == 'darwin':
         return None
     
     # Install the spec and return the path top patchelf
@@ -109,7 +107,7 @@ def get_existing_elf_rpaths(path_name):
 
     # if we're relocating patchelf itself, use it
 
-    if path_name[-13:] == "/bin/patchelf":
+    if path_name.endswith("/bin/patchelf"):
         patchelf = executable.Executable(path_name)
     else:
         patchelf = executable.Executable(_patchelf())

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -2,8 +2,6 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-
 import os
 import platform
 import re
@@ -73,28 +71,28 @@ class BinaryTextReplaceError(spack.error.SpackError):
 
 def _patchelf():
     """Return the full path to the patchelf binary, if available, else None.
-    
-    Search first the current PATH for patchelf. If not found, try to look 
-    if the preferred patchelf spec is installed and if not install it.
-    
-    Return None on Darwin or if patchelf cannot be found. 
+
+    Search first the current PATH for patchelf. If not found, try to look
+    if the default patchelf spec is installed and if not install it.
+
+    Return None on Darwin or if patchelf cannot be found.
     """
     # Check if patchelf is already in the PATH
     patchelf = spack.util.executable.which('patchelf')
     if patchelf is not None:
         return patchelf.path
-    
+
     # Check if patchelf spec is installed
     spec = spack.spec.Spec('patchelf').concretized()
     exe_path = os.path.join(spec.prefix.bin, "patchelf")
-    if spec.package.installed and os.path.exists(exe_path): 
+    if spec.package.installed and os.path.exists(exe_path):
         return exe_path
-    
+
     # Skip darwin
     if str(spack.architecture.platform()) == 'darwin':
         return None
-    
-    # Install the spec and return the path top patchelf
+
+    # Install the spec and return its path
     spec.package.do_install()
     return exe_path if os.path.exists(exe_path) else None
 

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -64,7 +64,7 @@ def test_file_is_relocatable(source_file, is_relocatable):
     'patchelf', 'strings', 'file'
 )
 def test_patchelf_is_relocatable():
-    patchelf = spack.relocate.get_patchelf()
+    patchelf = spack.relocate._patchelf()
     assert llnl.util.filesystem.is_exe(patchelf)
     assert spack.relocate.file_is_relocatable(patchelf)
 

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -3,15 +3,18 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import collections
 import os.path
 import platform
 import shutil
 
-import pytest
-
 import llnl.util.filesystem
+import pytest
+import spack.architecture
+import spack.concretize
 import spack.paths
 import spack.relocate
+import spack.spec
 import spack.store
 import spack.tengine
 import spack.util.executable
@@ -43,6 +46,47 @@ def source_file(tmpdir, is_relocatable):
         src.write(text)
 
     return src
+
+
+@pytest.fixture(params=['which_found', 'installed', 'to_be_installed'])
+def expected_patchelf_path(request, mutable_database, monkeypatch):
+    """Prepare the stage to tests different cases that can occur
+    when searching for patchelf.
+    """
+    case = request.param
+
+    # Mock the which function
+    which_fn = {
+        'which_found': lambda x: collections.namedtuple(
+            '_', ['path']
+        )('/usr/bin/patchelf')
+    }
+    monkeypatch.setattr(
+        spack.util.executable, 'which',
+        which_fn.setdefault(case, lambda x: None)
+    )
+    if case == 'which_found':
+        return '/usr/bin/patchelf'
+
+    # TODO: Mock a case for Darwin architecture
+
+    spec = spack.spec.Spec('patchelf')
+    spec.concretize()
+
+    patchelf_cls = type(spec.package)
+    do_install = patchelf_cls.do_install
+    expected_path = os.path.join(spec.prefix.bin, 'patchelf')
+
+    def do_install_mock(self, **kwargs):
+        do_install(self, fake=True)
+        with open(expected_path):
+            pass
+
+    monkeypatch.setattr(patchelf_cls, 'do_install', do_install_mock)
+    if case == 'installed':
+        spec.package.do_install()
+
+    return expected_path
 
 
 @pytest.mark.requires_executables(
@@ -87,3 +131,12 @@ def test_file_is_relocatable_errors(tmpdir):
         with pytest.raises(ValueError) as exc_info:
             spack.relocate.file_is_relocatable('delete.me')
         assert 'is not an absolute path' in str(exc_info.value)
+
+
+@pytest.mark.skipif(
+    platform.system().lower() != 'linux',
+    reason='implementation for MacOS still missing'
+)
+def test_search_patchelf(expected_patchelf_path):
+    current = spack.relocate._patchelf()
+    assert current == expected_patchelf_path


### PR DESCRIPTION
This PR is a minor refactoring of a couple of functions in `spack.relocate` to be more in line with current practices in other parts Spack (see single commit descriptions for details). It also adds a unit test for the function searching for `patchelf`.