### PR TITLE
vendoring: remove dependency on setuptools from vendored pytest

### DIFF
--- a/lib/spack/external/__init__.py
+++ b/lib/spack/external/__init__.py
@@ -88,10 +88,11 @@ pytest
 * Homepage: https://pypi.python.org/pypi/pytest
 * Usage: Testing framework used by Spack.
 * Version: 3.2.5 (last version supporting Python 2.6)
-* Note: This package has been slightly modified to improve
-  Python 2.6 compatibility. See the following commit if the
-  vendored copy ever needs to be updated again:
-  https://github.com/spack/spack/pull/6801/commits/ff513c39f2c67ff615de5cbc581dd69a8ec96526
+* Note: This package has been slightly modified:
+  * We improve Python 2.6 compatibility. See:
+    https://github.com/spack/spack/pull/6801.
+  * We have patched pytest not to depend on setuptools. See:
+    https://github.com/spack/spack/pull/15612
 
 ruamel.yaml
 ------
@@ -125,4 +126,5 @@ altgraph
 * Homepage: https://altgraph.readthedocs.io/en/latest/index.html
 * Usage: dependency of macholib
 * Version: 0.16.1
+
 """

--- a/lib/spack/external/_pytest/config.py
+++ b/lib/spack/external/_pytest/config.py
@@ -1028,33 +1028,12 @@ class Config(object):
             except SystemError:
                 mode = 'plain'
             else:
-                self._mark_plugins_for_rewrite(hook)
+                # REMOVED FOR SPACK: This routine imports `pkg_resources` from
+                # `setuptools`, but we do not need it for Spack. We have removed
+                # it from Spack to avoid a dependency on setuptools.
+                # self._mark_plugins_for_rewrite(hook)
+                pass
         self._warn_about_missing_assertion(mode)
-
-    def _mark_plugins_for_rewrite(self, hook):
-        """
-        Given an importhook, mark for rewrite any top-level
-        modules or packages in the distribution package for
-        all pytest plugins.
-        """
-        import pkg_resources
-        self.pluginmanager.rewrite_hook = hook
-
-        # 'RECORD' available for plugins installed normally (pip install)
-        # 'SOURCES.txt' available for plugins installed in dev mode (pip install -e)
-        # for installed plugins 'SOURCES.txt' returns an empty list, and vice-versa
-        # so it shouldn't be an issue
-        metadata_files = 'RECORD', 'SOURCES.txt'
-
-        package_files = (
-            entry.split(',')[0]
-            for entrypoint in pkg_resources.iter_entry_points('pytest11')
-            for metadata in metadata_files
-            for entry in entrypoint.dist._get_metadata(metadata)
-        )
-
-        for name in _iter_rewritable_modules(package_files):
-            hook.mark_rewrite(name)
 
     def _warn_about_missing_assertion(self, mode):
         try:
@@ -1081,7 +1060,12 @@ class Config(object):
         self._checkversion()
         self._consider_importhook(args)
         self.pluginmanager.consider_preparse(args)
-        self.pluginmanager.load_setuptools_entrypoints('pytest11')
+
+        # REMOVED FOR SPACK: This routine imports `pkg_resources` from
+        # `setuptools`, but we do not need it for Spack. We have removed
+        # it from Spack to avoid a dependency on setuptools.
+        # self.pluginmanager.load_setuptools_entrypoints('pytest11')
+
         self.pluginmanager.consider_env()
         self.known_args_namespace = ns = self._parser.parse_known_args(args, namespace=self.option.copy())
         if self.known_args_namespace.confcutdir is None and self.inifile:

--- a/lib/spack/external/_pytest/vendored_packages/pluggy.py
+++ b/lib/spack/external/_pytest/vendored_packages/pluggy.py
@@ -497,26 +497,6 @@ class PluginManager(object):
                                 "unknown hook %r in plugin %r" %
                                 (name, hookimpl.plugin))
 
-    def load_setuptools_entrypoints(self, entrypoint_name):
-        """ Load modules from querying the specified setuptools entrypoint name.
-        Return the number of loaded plugins. """
-        from pkg_resources import (iter_entry_points, DistributionNotFound,
-                                   VersionConflict)
-        for ep in iter_entry_points(entrypoint_name):
-            # is the plugin registered or blocked?
-            if self.get_plugin(ep.name) or self.is_blocked(ep.name):
-                continue
-            try:
-                plugin = ep.load()
-            except DistributionNotFound:
-                continue
-            except VersionConflict as e:
-                raise PluginValidationError(
-                    "Plugin %r could not be loaded: %s!" % (ep.name, e))
-            self.register(plugin, name=ep.name)
-            self._plugin_distinfo.append((plugin, ep.dist))
-        return len(self._plugin_distinfo)
-
     def list_plugin_distinfo(self):
         """ return list of distinfo/plugin tuples for all setuptools registered
         plugins. """


### PR DESCRIPTION
Closes #15369.
Closes #9034.
Follow-up of #9261.

Previously, `spack test` would fail within a new spack environment, because it could not import `pkg_resources` (part of `setuptools`) Parts of `pytest` use `setuptools`, but we do not need them for Spack, so it's an unnecessary dependency.

Patching `pytest` is nasty but it's a lot simpler than vendoring yet another mess of packages.  Also, recent versions of `pytest` do not depend on `setuptools` (see pytest-dev/pytest#5063).  We're just stuck with an old version of `pytest` because we still support Python 2.6.

Astute readers may note that `jinja2` also uses `pkg_resources`, but we don't use any parts of it that actually import `pkg_resources`.  So we do not need to remove these imports from `jinja2`.

- [x] Remove the parts of `pytest` that need setuptools
