### PR TITLE
Add option "--first" for "spack load"

### DIFF
--- a/lib/spack/docs/workflows.rst
+++ b/lib/spack/docs/workflows.rst
@@ -284,8 +284,10 @@ have some drawbacks:
    The ``spack load`` and ``spack module tcl loads`` commands, on the
    other hand, are not very smart: if the user-supplied spec matches
    more than one installed package, then ``spack module tcl loads`` will
-   fail. This may change in the future.  For now, the workaround is to
-   be more specific on any ``spack load`` commands that fail.
+   fail. This default behavior may change in the future.  For now, 
+   the workaround is to either be more specific on any failing ``spack load`` 
+   commands or to use ``spack load --first`` to allow spack to load the 
+   first matching spec.
 
 
 """"""""""""""""""""""

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -193,7 +193,8 @@ def disambiguate_spec(spec, env, local=False, installed=True, first=False):
     return disambiguate_spec_from_hashes(spec, hashes, local, installed, first)
 
 
-def disambiguate_spec_from_hashes(spec, hashes, local=False, installed=True, first=False):
+def disambiguate_spec_from_hashes(spec, hashes, local=False,
+                                  installed=True, first=False):
     """Given a spec and a list of hashes, get concrete spec the spec refers to.
 
     Arguments:

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -177,7 +177,7 @@ def elide_list(line_list, max_num=10):
         return line_list
 
 
-def disambiguate_spec(spec, env, local=False, installed=True):
+def disambiguate_spec(spec, env, local=False, installed=True, first=False):
     """Given a spec, figure out which installed package it refers to.
 
     Arguments:
@@ -190,10 +190,10 @@ def disambiguate_spec(spec, env, local=False, installed=True):
             database query. See ``spack.database.Database._query`` for details.
     """
     hashes = env.all_hashes() if env else None
-    return disambiguate_spec_from_hashes(spec, hashes, local, installed)
+    return disambiguate_spec_from_hashes(spec, hashes, local, installed, first)
 
 
-def disambiguate_spec_from_hashes(spec, hashes, local=False, installed=True):
+def disambiguate_spec_from_hashes(spec, hashes, local=False, installed=True, first=False):
     """Given a spec and a list of hashes, get concrete spec the spec refers to.
 
     Arguments:
@@ -212,6 +212,9 @@ def disambiguate_spec_from_hashes(spec, hashes, local=False, installed=True):
                                               installed=installed)
     if not matching_specs:
         tty.die("Spec '%s' matches no installed packages." % spec)
+
+    elif first:
+        return matching_specs[0]
 
     elif len(matching_specs) > 1:
         format_string = '{name}{@version}{%compiler}{arch=architecture}'

--- a/lib/spack/spack/cmd/load.py
+++ b/lib/spack/spack/cmd/load.py
@@ -34,6 +34,14 @@ def setup_parser(subparser):
         help="print csh commands to load the package")
 
     subparser.add_argument(
+        '--first',
+        action='store_true',
+        default=False,
+        dest='load_first',
+        help="load the first match if multiple packages match the spec"
+    )
+
+    subparser.add_argument(
         '--only',
         default='package,dependencies',
         dest='things_to_load',
@@ -47,7 +55,7 @@ the dependencies"""
 
 def load(parser, args):
     env = ev.get_env(args, 'load')
-    specs = [spack.cmd.disambiguate_spec(spec, env)
+    specs = [spack.cmd.disambiguate_spec(spec, env, first=args.load_first)
              for spec in spack.cmd.parse_specs(args.specs)]
 
     if not args.shell:

--- a/lib/spack/spack/test/cmd/load.py
+++ b/lib/spack/spack/test/cmd/load.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
+import pytest
 from spack.main import SpackCommand
 import spack.spec
 import spack.user_environment as uenv
@@ -88,8 +89,8 @@ def test_load_first(install_mockery, mock_fetch, mock_archive, mock_packages):
     install('libelf@0.8.12')
     install('libelf@0.8.13')
     # Now there are two versions of libelf; This should cause an error
-    out = load('--sh', 'libelf', fail_on_error=False)
-    assert 'export' not in out
+    with pytest.raises(spack.main.SpackCommandError):
+        load('--sh', 'libelf')
     # This should not cause an error
     assert load('--sh', '--first', 'libelf')
 

--- a/lib/spack/spack/test/cmd/load.py
+++ b/lib/spack/spack/test/cmd/load.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
 import pytest
-from spack.main import SpackCommand
+from spack.main import SpackCommand, SpackCommandError
 import spack.spec
 import spack.user_environment as uenv
 
@@ -88,11 +88,12 @@ def test_load_first(install_mockery, mock_fetch, mock_archive, mock_packages):
     """Test with and without the --first option"""
     install('libelf@0.8.12')
     install('libelf@0.8.13')
-    # Now there are two versions of libelf; This should cause an error
-    with pytest.raises(spack.main.SpackCommandError):
+    # Now there are two versions of libelf
+    with pytest.raises(SpackCommandError):
+        # This should cause an error due to multiple versions
         load('--sh', 'libelf')
-    # This should not cause an error
-    assert load('--sh', '--first', 'libelf')
+    # Using --first should avoid the error condition
+    load('--sh', '--first', 'libelf')
 
 
 def test_load_fails_no_shell(install_mockery, mock_fetch, mock_archive,

--- a/lib/spack/spack/test/cmd/load.py
+++ b/lib/spack/spack/test/cmd/load.py
@@ -82,14 +82,16 @@ def test_load_includes_run_env(install_mockery, mock_fetch, mock_archive,
     assert 'export FOOBAR=mpileaks' in sh_out
     assert 'setenv FOOBAR mpileaks' in csh_out
 
+
 def test_load_first(install_mockery, mock_fetch, mock_archive, mock_packages):
-    """Tests that the --first option works"""
-    install('cmake+doc')
-    #install('cmake~doc')
-
-    sh_out = load('--sh', 'cmake')
-
-    assert 'export' in sh_out
+    """Test with and without the --first option"""
+    install('libelf@0.8.12')
+    install('libelf@0.8.13')
+    # Now there are two versions of libelf; This should cause an error
+    out = load('--sh', 'libelf', fail_on_error=False)
+    assert 'export' not in out
+    # This should not cause an error
+    assert load('--sh', '--first', 'libelf')
 
 
 def test_load_fails_no_shell(install_mockery, mock_fetch, mock_archive,

--- a/lib/spack/spack/test/cmd/load.py
+++ b/lib/spack/spack/test/cmd/load.py
@@ -82,6 +82,15 @@ def test_load_includes_run_env(install_mockery, mock_fetch, mock_archive,
     assert 'export FOOBAR=mpileaks' in sh_out
     assert 'setenv FOOBAR mpileaks' in csh_out
 
+def test_load_first(install_mockery, mock_fetch, mock_archive, mock_packages):
+    """Tests that the --first option works"""
+    install('cmake+doc')
+    #install('cmake~doc')
+
+    sh_out = load('--sh', 'cmake')
+
+    assert 'export' in sh_out
+
 
 def test_load_fails_no_shell(install_mockery, mock_fetch, mock_archive,
                              mock_packages):

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -980,7 +980,7 @@ _spack_list() {
 _spack_load() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -r --dependencies --sh --csh --only"
+        SPACK_COMPREPLY="-h --help -r --dependencies --sh --csh --first --only"
     else
         _installed_packages
     fi


### PR DESCRIPTION
This features adds the "--first" option for "spack load" which circumvents the error condition when multiple packages match the requested spec.  Instead, it just loads the first matching package.

The motivation for this feature is the situation where spack is being used in an automated workflow (like CI) where we would like to install and load dependencies for a build outside of spack.  In this case, we need (e.g.) cmake@3.16.2, but we don't care about the details beyond that.  When multiple specs match, there is an error that breaks the whole build.  Instead, just load one!

This feature was discussed with @luszczek .