### PR TITLE
UPC++ 2020.3.0 update

### DIFF
--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -10,7 +10,7 @@ def cross_detect():
     if spack.architecture.platform().name == 'cray':
         if which('srun'):
             return 'cray-aries-slurm'
-        if which('alps'):
+        if which('aprun'):
             return 'cray-aries-alps'
     return 'none'
 
@@ -35,7 +35,7 @@ class Upcxx(Package):
             description="UPC++ cross-compile target (autodetect by default)")
 
     conflicts('cross=none', when='platform=cray',
-              msg='None is unacceptable on Cray.')
+              msg='None is unacceptable on Cray. Please specify an appropriate "cross" value')
 
     depends_on('cuda', when='+cuda')
     depends_on('python@2.7.5:2.999', type=("build", "run"))

--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -110,6 +110,10 @@ class Upcxx(Package):
             installsh(prefix)
         else:
             if 'platform=cray' in self.spec: 
+                # Spack loads the cray-libsci module incorrectly on ALCF theta, breaking the compiler
+                # cray-libsci is completely irrelevant to our build, so disable it
+                for var in ['PE_PKGCONFIG_PRODUCTS', 'PE_PKGCONFIG_LIBS']:
+                    env[var]=":".join(filter(lambda x: "libsci" not in x.lower(),env[var].split(":")))
                 # undo spack compiler wrappers - the compiler must work post-install
                 # the hack above no longer works after the fix to issue #287
                 real_cc = join_path(env['CRAYPE_DIR'],'bin','cc')

--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -43,6 +43,9 @@ class Upcxx(Package):
     depends_on('python@2.7.5:2.999', type=("build", "run"), when='@:2019.9.0')
     depends_on('python@2.7.5:', type=("build", "run"), when='@2020.3.0:')
 
+    # All flags should be passed to the build-env in autoconf-like vars
+    flag_handler = env_flags
+
     def url_for_version(self, version):
         if version > Version('2019.3.2'):
             url = "https://bitbucket.org/berkeleylab/upcxx/downloads/upcxx-{0}.tar.gz"
@@ -79,6 +82,10 @@ class Upcxx(Package):
             env.set('UPCXX_NETWORK', 'aries')
 
     def install(self, spec, prefix):
+        # UPC++ follows the autoconf naming convention for LDLIBS, which is 'LIBS'
+        if (env.get('LDLIBS')): 
+            env['LIBS'] = env['LDLIBS']
+
         if spec.version <= Version('2019.9.0'):
             env['CC'] = self.compiler.cc
             env['CXX'] = self.compiler.cxx

--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -25,6 +25,10 @@ class Upcxx(Package):
     homepage = "https://upcxx.lbl.gov"
     maintainers = ['bonachea']
 
+    git = 'https://bonachea@bitbucket.org/berkeleylab/upcxx.git'
+    version('develop', branch='develop')
+    version('master',  branch='master')
+
     version('2020.3.0', sha256='01be35bef4c0cfd24e9b3d50c88866521b9cac3ad4cbb5b1fc97aea55078810f')
     version('2019.9.0', sha256='7d67ccbeeefb59de9f403acc719f52127a30801a2c2b9774a1df03f850f8f1d4')
     version('2019.3.2', sha256='dcb0b337c05a0feb2ed5386f5da6c60342412b49cab10f282f461e74411018ad')

--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -112,4 +112,18 @@ class Upcxx(Package):
             make()
 
             make('install')
-   
+  
+    @run_after('install')
+    @on_package_attributes(run_tests=True)
+    def test_install(self):
+        if self.spec.version <= Version('2019.9.0'):
+            spack.main.send_warning_to_tty("run_tests not supported in UPC++ version " + self.spec.version.string + " -- SKIPPED")
+        else:
+            test_networks='NETWORKS=$(CONDUITS)' # enable testing of unofficial conduits (mpi)
+            make('test_install', test_networks)  # builds hello world against installed tree in all configurations
+            make('tests-clean')                  # cleanup
+            make('tests', test_networks)         # builds all tests for all networks in debug mode
+            if 'cross=none' in self.spec:
+                make('run-tests','NETWORKS=smp') # runs tests for smp backend
+            make('tests-clean')   # cleanup
+

--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -58,10 +58,13 @@ class Upcxx(Package):
         return url.format(version)
 
     def setup_build_environment(self, env):
+        env.set('UPCXX_PYTHON', self.spec['python'].command.path) # ensure we use the correct python
+
         if '+mpi' in self.spec:
             env.set('GASNET_CONFIGURE_ARGS','--enable-mpi --enable-mpi-compat')
         else:
             env.set('GASNET_CONFIGURE_ARGS','--without-mpicc')
+
 
         if 'cross=none' not in self.spec:
             env.set('CROSS', self.spec.variants['cross'].value)
@@ -71,6 +74,8 @@ class Upcxx(Package):
             env.set('UPCXX_CUDA_NVCC', self.spec['cuda'].prefix.bin.nvcc)
 
     def setup_run_environment(self, env):
+        env.set('UPCXX_PYTHON', self.spec['python'].command.path) # ensure we use the correct python
+
         env.set('UPCXX_INSTALL', self.prefix)
         env.set('UPCXX', self.prefix.bin.upcxx)
         if 'platform=cray' in self.spec:

--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -25,6 +25,7 @@ class Upcxx(Package):
     homepage = "https://upcxx.lbl.gov"
     maintainers = ['bonachea']
 
+    version('2020.3.0', sha256='01be35bef4c0cfd24e9b3d50c88866521b9cac3ad4cbb5b1fc97aea55078810f')
     version('2019.9.0', sha256='7d67ccbeeefb59de9f403acc719f52127a30801a2c2b9774a1df03f850f8f1d4')
     version('2019.3.2', sha256='dcb0b337c05a0feb2ed5386f5da6c60342412b49cab10f282f461e74411018ad')
 
@@ -38,7 +39,9 @@ class Upcxx(Package):
               msg='None is unacceptable on Cray. Please specify an appropriate "cross" value')
 
     depends_on('cuda', when='+cuda')
-    depends_on('python@2.7.5:2.999', type=("build", "run"))
+    # Require Python2 2.7.5+ up to 2019.9.0, 2020.3.0 and later also permit Python3
+    depends_on('python@2.7.5:2.999', type=("build", "run"), when='@:2019.9.0')
+    depends_on('python@2.7.5:', type=("build", "run"), when='@2020.3.0:')
 
     def url_for_version(self, version):
         if version > Version('2019.3.2'):


### PR DESCRIPTION
## Summary

This PR updates and improves the Spack package for [UPC++](https://upcxx.lbl.gov).
I'm an LBL employee and developer on the UPC++ team, as well as the maintainer of this Spack package.

### Key Improvements:
* Adding new 2020.3.0 release and support for use of develop/master branches
    - Our build infrastructure underwent a major change in this release, switching from a hand-rolled Python2 script to a bash-based autoconf work-alike. 
    - The new build system is NOT using autotools (nor does it support some of the more esoteric autoconf options), but the user interface for common builds is similar.
* Add explicit support for an MPI optional dependency
    - New `mpi` variant enables use of the MPI-based spawner (most relevant on loosely coupled clusters), and the (unofficial) mpi-conduit backend
    - This variant is OFF by default, since UPC++ works fine without MPI on many systems, increasing the likelihood first-time Spack users get a working build without needing to correctly setup MPI
* Add support for post-install testing using the test support deployed in the new build infrastructure
* Fix or workaround a few bugs observed during testing 

### Status

The new package has been validated with a variety of specs across over seven different systems, including: NERSC cori, ALCF Theta, OLCF Summit, an in-house Linux cluster, and macOS laptops (Mojave and Catalina).  

This PR is ready for review.

