### PR TITLE
Update version r-remotes for 2.1.1

### DIFF
--- a/var/spack/repos/builtin/packages/r-remotes/package.py
+++ b/var/spack/repos/builtin/packages/r-remotes/package.py
@@ -16,6 +16,7 @@ class RRemotes(RPackage):
     url      = "https://cloud.r-project.org/src/contrib/remotes_2.1.0.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/remotes"
 
+    version('2.1.1', sha256='4e590746fce618094089372b185e1ea234b3337b23c44c44118e942d0fb5118b')
     version('2.1.0', sha256='8944c8f6fc9f0cd0ca04d6cf1221b716eee08facef9f4b4c4d91d0346d6d68a7')
 
     depends_on('r@3.0.0:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-remotes/package.py
+++ b/var/spack/repos/builtin/packages/r-remotes/package.py
@@ -10,7 +10,7 @@ class RRemotes(RPackage):
     """Download and install R packages stored in 'GitHub', 'BitBucket', or
     plain 'subversion' or 'git' repositories. This package provides the
     'install_*' functions in 'devtools'. Indeed most of the code was copied
-    over from 'devtools'."""
+    over from 'devtools'. """
 
     homepage = "https://github.com/r-lib/remotes#readme"
     url      = "https://cloud.r-project.org/src/contrib/remotes_2.1.0.tar.gz"


### PR DESCRIPTION
Adding new version `2.1.1` to `r-remotes`.