### PR TITLE
denovogear: fixed comparison error

### DIFF
--- a/var/spack/repos/builtin/packages/denovogear/newmat6.cpp.patch
+++ b/var/spack/repos/builtin/packages/denovogear/newmat6.cpp.patch
@@ -1,0 +1,11 @@
+--- spack-src/src/contrib/newmat/newmat6.cpp.org	2020-03-19 14:06:13.679032667 +0900
++++ spack-src/src/contrib/newmat/newmat6.cpp	2020-03-19 14:07:34.267492838 +0900
+@@ -428,7 +428,7 @@
+ {
+    if (&gm == this) { REPORT tag_val = -1; return; }
+    REPORT
+-   if (indx > 0) { delete [] indx; indx = 0; }
++   if (indx != NULL) { delete [] indx; indx = 0; }
+    ((CroutMatrix&)gm).get_aux(*this);
+    Eq(gm);
+ }

--- a/var/spack/repos/builtin/packages/denovogear/package.py
+++ b/var/spack/repos/builtin/packages/denovogear/package.py
@@ -25,3 +25,5 @@ class Denovogear(CMakePackage):
     depends_on('zlib', type=('link'))
 
     patch('stream-open.patch', when='@:1.1.1')
+    # fix: ordered comparison between pointer and zero.
+    patch('newmat6.cpp.patch')


### PR DESCRIPTION
- error
```
  >> 162    /tmp/pytest-of-ogura/pytest-77/mock-stage0/spack-stage-denovogear-1
            .1.1-ukwgywcis5clcaibvlqdn6wdfimw4vue/spack-src/src/contrib/newmat/
            newmat6.cpp:431:13: error: ordered comparison between pointer and z
            ero ('int *' and 'int')
     163       if (indx > 0) { delete [] indx; indx = 0; }
     164           ~~~~ ^ ~

```
I changed comparison from `indx > 0` to `indx != NULL`
I submitted this pull request.
https://github.com/ultimatesource/denovogear/pull/309