### PR TITLE
NetCDF packages: switch to the official FTP server

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -13,15 +13,17 @@ class NetcdfC(AutotoolsPackage):
 
     homepage = "http://www.unidata.ucar.edu/software/netcdf"
     git      = "https://github.com/Unidata/netcdf-c.git"
-    url      = "https://www.gfd-dennou.org/arch/netcdf/unidata-mirror/netcdf-c-4.7.2.tar.gz"
+    url      = "ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-c-4.7.3.tar.gz"
 
     def url_for_version(self, version):
         if version >= Version('4.6.2'):
-            url = "https://www.gfd-dennou.org/arch/netcdf/unidata-mirror/netcdf-c-{0}.tar.gz"
+            url = "ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-c-{0}.tar.gz"
         else:
-            url = "https://www.gfd-dennou.org/arch/netcdf/unidata-mirror/netcdf-{0}.tar.gz"
+            url = "ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-{0}.tar.gz"
 
         return url.format(version.dotted)
+
+    maintainers = ['skosukhin', 'WardF']
 
     version('master', branch='master')
     version('4.7.3',   sha256='8e8c9f4ee15531debcf83788594744bd6553b8489c06a43485a15c93b4e0448b')

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -12,10 +12,12 @@ class NetcdfCxx4(AutotoolsPackage):
     sharing of array-oriented scientific data. This is the C++ distribution."""
 
     homepage = "https://www.unidata.ucar.edu/software/netcdf"
-    url      = "https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-cxx4-4.3.1.tar.gz"
+    url      = "ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-cxx4-4.3.1.tar.gz"
+
+    maintainers = ['WardF']
 
     version('4.3.1', sha256='6a1189a181eed043b5859e15d5c080c30d0e107406fbb212c8fb9814e90f3445')
-    version('4.3.0', sha256='f4766d5a19c91093be80ddd2eaf1fbbd8d203854cc69fc73d2ad293b099ac799')
+    version('4.3.0', sha256='e34fbc6aba243ec82c23e9ee99db2430555ada849c54c1f3ab081b0ddd0f5f30')
 
     # Usually the configure automatically inserts the pic flags, but we can
     # force its usage with this variant.

--- a/var/spack/repos/builtin/packages/netcdf-fortran/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-fortran/package.py
@@ -13,9 +13,9 @@ class NetcdfFortran(AutotoolsPackage):
     distribution."""
 
     homepage = "https://www.unidata.ucar.edu/software/netcdf"
-    url      = "https://www.gfd-dennou.org/arch/netcdf/unidata-mirror/netcdf-fortran-4.5.2.tar.gz"
+    url      = "ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-fortran-4.5.2.tar.gz"
 
-    maintainers = ['skosukhin']
+    maintainers = ['skosukhin', 'WardF']
 
     version('4.5.2', sha256='b959937d7d9045184e9d2040a915d94a7f4d0185f4a9dceb8f08c94b0c3304aa')
     version('4.4.5', sha256='2467536ce29daea348c736476aa8e684c075d2f6cab12f3361885cb6905717b8')


### PR DESCRIPTION
It looks like the official FTP server (ftp://ftp.unidata.ucar.edu/pub/netcdf) provides only recent versions of the packages and according to the [official page](https://www.unidata.ucar.edu/downloads/netcdf/) older versions should be downloaded from GitHub. The [fallback solution](https://www.gfd-dennou.org/arch/netcdf/unidata-mirror/) that we used doesn't offer old versions anymore too. Hence, it's time to finally switch to GitHub. Unfortunately, the tarballs that are available there have slightly different contents, which is why we need to update the checksums too. I am going to show the difference in the following comments.

Closes #15752