### PR TITLE
Make debuggers find source code for spack installed packages

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -425,6 +425,15 @@ then
     esac
 fi
 
+if [[ "x${SPACK_DEBUGSRC_REMAP}" != "x" ]];
+then
+  # Translate debugging source location flags
+  case "$mode" in
+      cpp|cc|ccld)
+          flags=("${flags[@]}" "${SPACK_DEBUGSRC_REMAP}") ;;
+  esac
+fi
+
 # Prepend include directories
 IFS=':' read -ra include_dirs <<< "$SPACK_INCLUDE_DIRS"
 if [[ $mode == cpp || $mode == cc || $mode == as || $mode == ccld ]]; then

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -213,6 +213,9 @@ def set_compiler_environment_variables(pkg, env):
     isa_arg = spec.architecture.target.optimization_flags(compiler)
     env.set('SPACK_TARGET_ARGS', isa_arg)
 
+    env.set('SPACK_DEBUGSRC_REMAP',
+            compiler.remap_debugsrc(pkg.stage.source_path, spec.source_target))
+
     # Trap spack-tracked compiler flags as appropriate.
     # env_flags are easy to accidentally override.
     inject_flags = {}

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -458,6 +458,12 @@ class Compiler(object):
             itertools.product(prefixes, compiler_names, suffixes)
         ]
 
+    def remap_debugsrc(self, from_dir, to_dir):
+        """If the compiler supports options to translate source paths
+        to a different prefix, it should override this method and return
+        a filled-in option"""
+        return ""
+
     def setup_custom_environment(self, pkg, env):
         """Set any environment variables necessary to use the compiler."""
         pass

--- a/lib/spack/spack/compilers/clang.py
+++ b/lib/spack/spack/compilers/clang.py
@@ -335,3 +335,7 @@ class Clang(Compiler):
             os.symlink(developer_root, xcode_link)
 
         env.set('DEVELOPER_DIR', xcode_link)
+
+    def remap_debugsrc(self, from_dir, to_dir):
+        real_from_dir = os.path.realpath(from_dir)
+        return "-fdebug-prefix-map=%s=%s" % (real_from_dir, to_dir)

--- a/lib/spack/spack/compilers/gcc.py
+++ b/lib/spack/spack/compilers/gcc.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import re
-
+import os
 import spack.compilers.clang
 
 from spack.compiler import Compiler, UnsupportedCompilerFlag
@@ -185,3 +185,9 @@ class Gcc(Compiler):
     @property
     def stdcxx_libs(self):
         return ('-lstdc++', )
+
+    def remap_debugsrc(self, from_dir, to_dir):
+        option = "-ffile-prefix-map" if self.spec.satisfies('gcc@8:') \
+                 else "-fdebug-prefix-map"
+        real_from_dir = os.path.realpath(from_dir)
+        return "%s=%s=%s" % (option, real_from_dir, to_dir)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3901,6 +3901,10 @@ class Spec(object):
         # to give to the attribute the appropriate comparison semantic
         return self.architecture.target.microarchitecture
 
+    @property
+    def source_target(self):
+        return os.path.join(self.prefix, 'share', self.name, 'src')
+
 
 class LazySpecCache(collections.defaultdict):
     """Cache for Specs that uses a spec_like as key, and computes lazily


### PR DESCRIPTION
This makes it so debug information in spack produced binaries point to source code locations in the install area, rather than in the stage area.  When mixed with the 'spack install --source' option, this lets you debug spack installed packages out of the box, without having to remap source locations in your debugger first.

This uses the gcc/clang option -fdebug-prefix-map, and it only works on those compilers.  The option tells gcc/clang that, even though they're building in the stage area, to pretend the source files are in the $PREFIX/share/$PKGNAME/src area.

Currently, this is always on.  I haven't seen any drawback to using the option.  Should there be options to turn this off anyways?

For the --source option, we decided that source installations would not be part of the spec.  This is takes things farther and is modifying the DWARF information, which does change installed bits.  But not in any way that should affect program behavior.  Do we want to track this in the spec?  

I have thoughts on improving this for relocatable packages and other compilers.  But that's significantly more work, and this is a start.

Consider this a WIP.  Just before sending out this PR I saw it fail to translate a python build's debug location.  That needs some debugging.  But we can start any discussion.

