### PR TITLE
py-onnx: Remove 'dllexport_decl'.

### DIFF
--- a/var/spack/repos/builtin/packages/py-onnx/package.py
+++ b/var/spack/repos/builtin/packages/py-onnx/package.py
@@ -28,3 +28,6 @@ class PyOnnx(PythonPackage):
     depends_on('py-six', type=('build', 'run'))
     depends_on('py-typing@3.6.4:', type=('build', 'run'))
     depends_on('py-typing-extensions@3.6.4:', type=('build', 'run'))
+
+    # 'python_out' does not recognize dllexport_decl.
+    patch('remove_dllexport_decl.patch', when='@:1.6.0')

--- a/var/spack/repos/builtin/packages/py-onnx/remove_dllexport_decl.patch
+++ b/var/spack/repos/builtin/packages/py-onnx/remove_dllexport_decl.patch
@@ -1,0 +1,11 @@
+--- spack-src/CMakeLists.txt.org	2020-03-24 14:01:58.856142450 +0900
++++ spack-src/CMakeLists.txt	2020-03-24 14:01:05.715872685 +0900
+@@ -204,7 +204,7 @@
+         ${ONNX_DLLEXPORT_STR}${CMAKE_CURRENT_BINARY_DIR})
+     if(BUILD_ONNX_PYTHON)
+       list(APPEND PROTOC_ARGS --python_out
+-                  ${ONNX_DLLEXPORT_STR}${CMAKE_CURRENT_BINARY_DIR})
++                  ${CMAKE_CURRENT_BINARY_DIR})
+       if(ONNX_GEN_PB_TYPE_STUBS)
+         # Haven't figured out how to generate mypy stubs on Windows yet
+         if(NOT WIN32)


### PR DESCRIPTION
I got error following when installing `py-onnx`.
```
     91    [  7%] Running C++ protocol buffer compiler on /tmp/n0013/spack-stage/spack-stage-p
           y-onnx-1.5.0-bzrosaagawrtjc5zjbefjb2hrncnwfhr/spack-src/.setuptools-cmake-build/onn
           x/onnx-ml.proto
     92    --python_out: onnx/onnx-ml.proto: Unknown generator option: dllexport_decl
```
It seems that 'python_out' does not recognize dllexport_decl. So, Apply the following fix patch.
Ref: https://github.com/onnx/onnx/pull/2482

This fix will be included in the upstream package version:1.7.0.