### PR TITLE
workaround for otf2's erroneous python2 configure requirement

### DIFF
--- a/var/spack/repos/builtin/packages/otf2/package.py
+++ b/var/spack/repos/builtin/packages/otf2/package.py
@@ -32,5 +32,6 @@ class Otf2(AutotoolsPackage):
             'F77={0}'.format(spack_f77),
             'FC={0}'.format(spack_fc),
             'CFLAGS={0}'.format(self.compiler.pic_flag),
-            'CXXFLAGS={0}'.format(self.compiler.pic_flag)
+            'CXXFLAGS={0}'.format(self.compiler.pic_flag),
+            'PYTHON_FOR_GENERATOR=:'
         ]


### PR DESCRIPTION
This resolves an erroneous requirement by `otf2`'s python configure script, which requires a `python 2` version when `python 2` is NOT in fact specifically needed for `otf2`. Replacement for PR https://github.com/spack/spack/pull/15499 