### PR TITLE
Add more unit tests to "spack.relocate"

### DIFF
--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -182,10 +182,8 @@ def _normalize_relative_paths(start_path, relative_paths):
     return normalized_paths
 
 
-def set_placeholder(dirname):
-    """
-    return string of @'s with same length
-    """
+def _placeholder(dirname):
+    """String of  of @'s with same length of the argument"""
     return '@' * len(dirname)
 
 
@@ -704,7 +702,7 @@ def relocate_links(linknames, old_layout_root, new_layout_root,
     link target is create by replacing the old install prefix with the new
     install prefix.
     """
-    placeholder = set_placeholder(old_layout_root)
+    placeholder = _placeholder(old_layout_root)
     link_names = [os.path.join(new_install_prefix, linkname)
                   for linkname in linknames]
     for link_name in link_names:

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -25,7 +25,6 @@ from spack.paths import mock_gpg_keys_path
 from spack.fetch_strategy import URLFetchStrategy, FetchStrategyComposite
 from spack.relocate import needs_binary_relocation, needs_text_relocation
 from spack.relocate import relocate_text, relocate_links
-from spack.relocate import get_relative_elf_rpaths
 from spack.relocate import get_normalized_elf_rpaths
 from spack.relocate import macho_make_paths_relative
 from spack.relocate import macho_make_paths_normal
@@ -564,11 +563,6 @@ def test_macho_make_paths():
 
 
 def test_elf_paths():
-    out = get_relative_elf_rpaths(
-        '/usr/bin/test', '/usr',
-        ('/usr/lib', '/usr/lib64', '/opt/local/lib'))
-    assert out == ['$ORIGIN/../lib', '$ORIGIN/../lib64', '/opt/local/lib']
-
     out = get_normalized_elf_rpaths(
         '/usr/bin/test',
         ['$ORIGIN/../lib', '$ORIGIN/../lib64', '/opt/local/lib'])

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -25,7 +25,6 @@ from spack.paths import mock_gpg_keys_path
 from spack.fetch_strategy import URLFetchStrategy, FetchStrategyComposite
 from spack.relocate import needs_binary_relocation, needs_text_relocation
 from spack.relocate import relocate_text, relocate_links
-from spack.relocate import get_normalized_elf_rpaths
 from spack.relocate import macho_make_paths_relative
 from spack.relocate import macho_make_paths_normal
 from spack.relocate import set_placeholder, macho_find_paths
@@ -560,10 +559,3 @@ def test_macho_make_paths():
                    '/Users/Shared/spack/pkgB/libB.dylib',
                    '/usr/local/lib/libloco.dylib':
                    '/usr/local/lib/libloco.dylib'}
-
-
-def test_elf_paths():
-    out = get_normalized_elf_rpaths(
-        '/usr/bin/test',
-        ['$ORIGIN/../lib', '$ORIGIN/../lib64', '/opt/local/lib'])
-    assert out == ['/usr/lib', '/usr/lib64', '/opt/local/lib']

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -27,7 +27,7 @@ from spack.relocate import needs_binary_relocation, needs_text_relocation
 from spack.relocate import relocate_text, relocate_links
 from spack.relocate import macho_make_paths_relative
 from spack.relocate import macho_make_paths_normal
-from spack.relocate import set_placeholder, macho_find_paths
+from spack.relocate import _placeholder, macho_find_paths
 from spack.relocate import file_is_relocatable
 
 
@@ -226,7 +226,7 @@ def test_relocate_links(tmpdir):
         old_install_prefix = os.path.join(
             '%s' % old_layout_root, 'debian6', 'test')
         old_binname = os.path.join(old_install_prefix, 'binfile')
-        placeholder = set_placeholder(old_layout_root)
+        placeholder = _placeholder(old_layout_root)
         re.sub(old_layout_root, placeholder, old_binname)
         filenames = ['link.ln', 'outsideprefix.ln']
         new_layout_root = os.path.join(

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -181,9 +181,13 @@ def test_make_relative_paths(start_path, path_root, paths, expected):
 
 
 @pytest.mark.parametrize('start_path,relative_paths,expected', [
+    # $ORIGIN will be replaced with os.path.dirname('usr/bin/test')
+    # and then normalized
     ('/usr/bin/test',
      ['$ORIGIN/../lib', '$ORIGIN/../lib64', '/opt/local/lib'],
-     ['/usr/lib', '/usr/lib64', '/opt/local/lib'])
+     ['/usr/lib', '/usr/lib64', '/opt/local/lib']),
+    # Relative path without $ORIGIN
+    ('/usr/bin/test', ['../local/lib'], ['../local/lib']),
 ])
 def test_normalize_relative_paths(start_path, relative_paths, expected):
     normalized = spack.relocate._normalize_relative_paths(

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -178,3 +178,15 @@ def test_existing_rpaths(patchelf_behavior, expected, mock_patchelf):
 def test_make_relative_paths(start_path, path_root, paths, expected):
     relatives = spack.relocate._make_relative(start_path, path_root, paths)
     assert relatives == expected
+
+
+@pytest.mark.parametrize('start_path,relative_paths,expected', [
+    ('/usr/bin/test',
+     ['$ORIGIN/../lib', '$ORIGIN/../lib64', '/opt/local/lib'],
+     ['/usr/lib', '/usr/lib64', '/opt/local/lib'])
+])
+def test_normalize_relative_paths(start_path, relative_paths, expected):
+    normalized = spack.relocate._normalize_relative_paths(
+        start_path, relative_paths
+    )
+    assert normalized == expected

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -169,3 +169,12 @@ def test_existing_rpaths(patchelf_behavior, expected, mock_patchelf):
     path = mock_patchelf(patchelf_behavior)
     rpaths = spack.relocate._elf_rpaths_for(path)
     assert rpaths == expected
+
+
+@pytest.mark.parametrize('start_path,path_root,paths,expected', [
+    ('/usr/bin/test', '/usr', ['/usr/lib', '/usr/lib64', '/opt/local/lib'],
+     ['$ORIGIN/../lib', '$ORIGIN/../lib64', '/opt/local/lib'])
+])
+def test_make_relative_paths(start_path, path_root, paths, expected):
+    relatives = spack.relocate._make_relative(start_path, path_root, paths)
+    assert relatives == expected


### PR DESCRIPTION
This PR introduces trivial refactoring in:
- `get_existing_elf_rpaths`
- `get_relative_elf_rpaths`
- `get_normalized_elf_rpaths`
- `set_placeholder`

mainly to be more consistent with practices used in other parts of the code and to simplify functions locally. It also adds or reworks unit tests for these functions and extends their docstrings.