### PR TITLE
spec dag: add dependence on mock configuration

### DIFF
--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -189,7 +189,7 @@ def test_conditional_dep_with_user_constraints():
         assert ('y@3' in spec)
 
 
-@pytest.mark.usefixtures('mutable_mock_repo')
+@pytest.mark.usefixtures('mutable_mock_repo', 'config')
 class TestSpecDag(object):
 
     def test_conflicting_package_constraints(self, set_dependency):


### PR DESCRIPTION
Without this PR on my development box:
```console
$ uname -a
Linux nuvolari 5.3.0-42-generic #34~18.04.1-Ubuntu SMP Fri Feb 28 13:42:26 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux
```
I get the following errors:
```console
$ spack test -k spec_dag
...
>           raise NoCompilersForArchError(arch, available_os_targets)
E           spack.concretize.NoCompilersForArchError: No compilers found for operating system debian6 and target x86_64.
E           If previous installations have succeeded, the operating system may have been updated.
E           Compilers are defined for the following operating systems and targets:
E               ubuntu18.04-x86_64
E               Run 'spack compiler find' to add compilers.

lib/spack/spack/concretize.py:639: NoCompilersForArchError
================================================================== 2469 tests deselected ===================================================================
=================================================== 4 failed, 40 passed, 2469 deselected in 8.63 seconds ===================================================
```