### PR TITLE
Bugfix: For spack buildcache check, Handle specs where only the hash is

### DIFF
--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -609,7 +609,7 @@ def get_concrete_spec(args):
 
     if spec_str:
         try:
-            spec = Spec(spec_str)
+            spec = find_matching_specs(spec_str)[0]
             spec.concretize()
         except SpecError as spec_error:
             tty.error('Unable to concrectize spec {0}'.format(args.spec))


### PR DESCRIPTION
provided (#15662).

Prior to this fix, the checked Spec object would not be populated, and
concretization would fail.