### PR TITLE
charmpp: add version 6.10.1+cleanups

### DIFF
--- a/var/spack/repos/builtin/packages/charmpp/package.py
+++ b/var/spack/repos/builtin/packages/charmpp/package.py
@@ -18,10 +18,12 @@ class Charmpp(Package):
     (your laptop) to the largest supercomputers."""
 
     homepage = "http://charmplusplus.org"
-    url      = "https://charm.cs.illinois.edu/distrib/charm-6.8.2.tar.gz"
+    url      = "http://charm.cs.illinois.edu/distrib/charm-6.8.2.tar.gz"
     git      = "https://github.com/UIUC-PPL/charm.git"
 
-    version("develop", branch="charm")
+    version("develop", branch="master")
+
+    version('6.10.1', sha256='ab96198105daabbb8c8bdf370f87b0523521ce502c656cb6cd5b89f69a2c70a8')
     version('6.10.0', sha256='7c526a78aa0c202b7f0418b345138e7dc40496f0bb7b9e301e0381980450b25c')
     version("6.9.0", sha256="85ed660e46eeb7a6fc6b32deab08226f647c244241948f6b592ebcd2b6050cbd")
     version("6.8.2", sha256="08e6001b0e9cd00ebde179f76098767149bf7e454f29028fb9a8bfb55778698e")


### PR DESCRIPTION
- change URL to http as our server only supports TLSv1.0, which
not all HTTPS clients accept anymore (see also #15186)
- change name of development branch to 'master'