### PR TITLE
meson: Add 0.53.2 and fix setuptools dependency

### DIFF
--- a/var/spack/repos/builtin/packages/meson/package.py
+++ b/var/spack/repos/builtin/packages/meson/package.py
@@ -14,6 +14,7 @@ class Meson(PythonPackage):
     homepage = "http://mesonbuild.com/"
     url      = "https://github.com/mesonbuild/meson/archive/0.49.0.tar.gz"
 
+    version('0.53.2', sha256='eab4f5d5dde12d002b7ddd958a9a0658589b63622b6cea2715e0235b95917888')
     version('0.49.1', sha256='a944e7f25a2bc8e4ba3502ab5835d8a8b8f2530415c9d6fcffb53e0abaea2ced')
     version('0.49.0', sha256='11bc959e7173e714e4a4e85dd2bd9d0149b0a51c8ba82d5f44cc63735f603c74')
     version('0.42.0', sha256='6c318a2da3859326a37f8a380e3c50e97aaabff6990067218dffffea674ed76f')
@@ -23,7 +24,7 @@ class Meson(PythonPackage):
     variant('ninjabuild', default=True)
 
     depends_on('python@3:', type=('build', 'run'))
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools', type=('build', 'run'))
     depends_on('ninja', when='+ninjabuild', type=('build', 'run'))
 
     # By default, Meson strips the rpath on installation. This patch disables


### PR DESCRIPTION
py-setuptools is actually required for running meson.