### PR TITLE
package: add additional configuration options to lmod

### DIFF
--- a/var/spack/repos/builtin/packages/lmod/package.py
+++ b/var/spack/repos/builtin/packages/lmod/package.py
@@ -46,7 +46,7 @@ class Lmod(AutotoolsPackage):
     depends_on('lua-luafilesystem', type=('build', 'run'))
     depends_on('tcl', type=('build', 'link', 'run'))
 
-    variant('auto-swap', default=False, description='Enable auto swapping conflicting modules')
+    variant('auto_swap', default=False, description='Enable auto swapping conflicting modules')
     variant('redirect', default=True, description='Enables redirect instead of pager')
 
     patch('fix_tclsh_paths.patch', when='@:6.4.3')
@@ -72,7 +72,7 @@ class Lmod(AutotoolsPackage):
     def configure_args(self):
         args = []
 
-        if '+auto-swap' in self.spec:
+        if '+auto_swap' in self.spec:
             args.append('--with-autoSwap=yes')
         else:
             args.append('--with-autoSwap=no')

--- a/var/spack/repos/builtin/packages/lmod/package.py
+++ b/var/spack/repos/builtin/packages/lmod/package.py
@@ -46,6 +46,9 @@ class Lmod(AutotoolsPackage):
     depends_on('lua-luafilesystem', type=('build', 'run'))
     depends_on('tcl', type=('build', 'link', 'run'))
 
+    variant('auto-swap', default=False, description='Enable auto swapping conflicting modules')
+    variant('redirect', default=True, description='Enables redirect instead of pager')
+
     patch('fix_tclsh_paths.patch', when='@:6.4.3')
     patch('0001-fix-problem-with-MODULESHOME-and-issue-271.patch', when='@7.3.28:7.4.10')
 
@@ -65,3 +68,18 @@ class Lmod(AutotoolsPackage):
         if self.spec.version <= Version('6.4.3'):
             for tclscript in glob('src/*.tcl'):
                 filter_file(r'^#!.*tclsh', '#!@path_to_tclsh@', tclscript)
+
+    def configure_args(self):
+        args = []
+
+        if '+auto-swap' in self.spec:
+            args.append('--with-autoSwap=yes')
+        else:
+            args.append('--with-autoSwap=no')
+
+        if '+redirect' in self.spec:
+            args.append('--with-redirect=yes')
+        else:
+            args.append('--with-redirect=no')
+
+        return args


### PR DESCRIPTION
Lmod is missing a few configuration options. I've added some as variants. Now auto-swapping of modules and redirects can be enabled or disabled. 

