### PR TITLE
gtkorvo-dill: fix argument type of clear_cache

### DIFF
--- a/var/spack/repos/builtin/packages/gtkorvo-dill/2.1-fix-clear_cache.patch
+++ b/var/spack/repos/builtin/packages/gtkorvo-dill/2.1-fix-clear_cache.patch
@@ -1,0 +1,148 @@
+diff -ur spack-src.org/CMakeLists.txt spack-src/CMakeLists.txt
+--- spack-src.org/CMakeLists.txt	2020-03-26 16:38:53.358339744 +0900
++++ spack-src/CMakeLists.txt	2020-03-26 16:44:04.581014766 +0900
+@@ -184,6 +184,9 @@
+ CHECK_INCLUDE_FILES(malloc.h HAVE_MALLOC_H)
+ CHECK_INCLUDE_FILES(memory.h HAVE_MEMORY_H)
+ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
++include(CheckSymbolExists)
++check_symbol_exists(__clear_cache "" CLEAR_CACHE_DEFINED)
++message(STATUS "Clear cache defined is ${CLEAR_CACHE_DEFINED}")
+ 
+ set (NO_DISASSEMBLER TRUE)
+ if (ENABLE_DISASSEMBLY)
+diff -ur spack-src.org/arm6.c spack-src/arm6.c
+--- spack-src.org/arm6.c	2020-03-26 16:38:53.358339744 +0900
++++ spack-src/arm6.c	2020-03-26 16:45:20.428978615 +0900
+@@ -1524,22 +1524,9 @@
+ }
+ 
+ 
+-/* Clear the instruction cache from `beg' to `end'.  This makes an
+-   inline system call to SYS_cacheflush.  */
+-#define CLEAR_INSN_CACHE(BEG, END)                                      \
+-{                                                                       \
+-  register unsigned long _beg __asm ("a1") = (unsigned long) (BEG);     \
+-  register unsigned long _end __asm ("a2") = (unsigned long) (END);     \
+-  register unsigned long _flg __asm ("a3") = 0;                         \
+-  __asm __volatile ("swi 0x9f0002               @ sys_cacheflush"       \
+-                    : "=r" (_beg)                                       \
+-                    : "0" (_beg), "r" (_end), "r" (_flg));              \
+-}
+-/*
+- *  Cache flush code grabbed from a Dec 1999 posting on libc-hacker 
+- *  mailing list
+- */
+-extern void __clear_cache(char*, char *);
++#ifndef CLEAR_CACHE_DEFINED
++extern void __clear_cache(void *, void *);
++#endif
+ 
+ static void
+ arm6_flush(void *base, void *limit)
+diff -ur spack-src.org/arm6_rt.c spack-src/arm6_rt.c
+--- spack-src.org/arm6_rt.c	2020-03-26 16:38:53.358339744 +0900
++++ spack-src/arm6_rt.c	2020-03-26 16:48:18.927720543 +0900
+@@ -109,22 +109,9 @@
+     }
+ }
+ 
+-/* Clear the instruction cache from `beg' to `end'.  This makes an
+-   inline system call to SYS_cacheflush.  */
+-#define CLEAR_INSN_CACHE(BEG, END)                                      \
+-{                                                                       \
+-  register unsigned long _beg __asm ("a1") = (unsigned long) (BEG);     \
+-  register unsigned long _end __asm ("a2") = (unsigned long) (END);     \
+-  register unsigned long _flg __asm ("a3") = 0;                         \
+-  __asm __volatile ("swi 0x9f0002               @ sys_cacheflush"       \
+-                    : "=r" (_beg)                                       \
+-                    : "0" (_beg), "r" (_end), "r" (_flg));              \
+-}
+-/*
+- *  Cache flush code grabbed from a Dec 1999 posting on libc-hacker 
+- *  mailing list
+- */
+-extern void __clear_cache(char*, char *);
++#ifndef CLEAR_CACHE_DEFINED
++extern void __clear_cache(void *, void *);
++#endif
+ 
+ static void
+ arm6_flush(void *base, void *limit)
+diff -ur spack-src.org/arm8.c spack-src/arm8.c
+--- spack-src.org/arm8.c	2020-03-26 16:38:53.358339744 +0900
++++ spack-src/arm8.c	2020-03-26 16:49:38.386063473 +0900
+@@ -1524,22 +1524,9 @@
+ }
+ 
+ 
+-/* Clear the instruction cache from `beg' to `end'.  This makes an
+-   inline system call to SYS_cacheflush.  */
+-#define CLEAR_INSN_CACHE(BEG, END)                                      \
+-{                                                                       \
+-  register unsigned long _beg __asm ("a1") = (unsigned long) (BEG);     \
+-  register unsigned long _end __asm ("a2") = (unsigned long) (END);     \
+-  register unsigned long _flg __asm ("a3") = 0;                         \
+-  __asm __volatile ("swi 0x9f0002               @ sys_cacheflush"       \
+-                    : "=r" (_beg)                                       \
+-                    : "0" (_beg), "r" (_end), "r" (_flg));              \
+-}
+-/*
+- *  Cache flush code grabbed from a Dec 1999 posting on libc-hacker 
+- *  mailing list
+- */
+-extern void __clear_cache(char*, char *);
++#ifndef CLEAR_CACHE_DEFINED
++extern void __clear_cache(void *, void *);
++#endif
+ 
+ static void
+ arm8_flush(void *base, void *limit)
+diff -ur spack-src.org/arm8_rt.c spack-src/arm8_rt.c
+--- spack-src.org/arm8_rt.c	2020-03-26 16:38:53.358339744 +0900
++++ spack-src/arm8_rt.c	2020-03-26 16:50:37.902312532 +0900
+@@ -109,22 +109,9 @@
+     }
+ }
+ 
+-/* Clear the instruction cache from `beg' to `end'.  This makes an
+-   inline system call to SYS_cacheflush.  */
+-#define CLEAR_INSN_CACHE(BEG, END)                                      \
+-{                                                                       \
+-  register unsigned long _beg __asm ("a1") = (unsigned long) (BEG);     \
+-  register unsigned long _end __asm ("a2") = (unsigned long) (END);     \
+-  register unsigned long _flg __asm ("a3") = 0;                         \
+-  __asm __volatile ("swi 0x9f0002               @ sys_cacheflush"       \
+-                    : "=r" (_beg)                                       \
+-                    : "0" (_beg), "r" (_end), "r" (_flg));              \
+-}
+-/*
+- *  Cache flush code grabbed from a Dec 1999 posting on libc-hacker 
+- *  mailing list
+- */
+-extern void __clear_cache(char*, char *);
++#ifndef CLEAR_CACHE_DEFINED
++extern void __clear_cache(void *, void *);
++#endif
+ 
+ static void
+ arm8_flush(void *base, void *limit)
+diff -ur spack-src.org/config.h.cmake spack-src/config.h.cmake
+--- spack-src.org/config.h.cmake	2020-03-26 16:38:53.358339744 +0900
++++ spack-src/config.h.cmake	2020-03-26 16:52:52.256419382 +0900
+@@ -13,10 +13,13 @@
+ #cmakedefine HAVE_DIS_ASM_H
+ 
+ /* Define to 1 if you have the <dlfcn.h> header file. */
+-#undef HAVE_DLFCN_H
++#cmakedefine HAVE_DLFCN_H
+ 
+ /* Define to 1 if you have the <inttypes.h> header file. */
+-#undef HAVE_INTTYPES_H
++#cmakedefine HAVE_INTTYPES_H
++
++/* Define to 1 if you have __clear_cache is defined  */
++#cmakedefine CLEAR_CACHE_DEFINED
+ 
+ /* Define to 1 if you have the <malloc.h> header file. */
+ #cmakedefine HAVE_MALLOC_H

--- a/var/spack/repos/builtin/packages/gtkorvo-dill/2.4-fix-clear_cache.patch
+++ b/var/spack/repos/builtin/packages/gtkorvo-dill/2.4-fix-clear_cache.patch
@@ -1,0 +1,148 @@
+diff -ur spack-src.org/CMakeLists.txt spack-src/CMakeLists.txt
+--- spack-src.org/CMakeLists.txt	2020-03-26 09:35:43.403836842 +0900
++++ spack-src/CMakeLists.txt	2020-03-26 09:37:57.397837929 +0900
+@@ -267,6 +267,9 @@
+ CHECK_INCLUDE_FILES(stdarg.h STDC_HEADERS)
+ CHECK_INCLUDE_FILES(malloc.h HAVE_MALLOC_H)
+ CHECK_INCLUDE_FILES(memory.h HAVE_MEMORY_H)
++include(CheckSymbolExists)
++check_symbol_exists(__clear_cache "" CLEAR_CACHE_DEFINED)
++message(STATUS "Clear cache defined is ${CLEAR_CACHE_DEFINED}")
+ 
+ set (NO_DISASSEMBLER TRUE)
+ if (DILL_ENABLE_DISASSEMBLY)
+diff -ur spack-src.org/arm6.c spack-src/arm6.c
+--- spack-src.org/arm6.c	2020-03-26 09:35:43.403836842 +0900
++++ spack-src/arm6.c	2020-03-26 09:40:06.021306329 +0900
+@@ -1526,22 +1526,9 @@
+ }
+ 
+ 
+-/* Clear the instruction cache from `beg' to `end'.  This makes an
+-   inline system call to SYS_cacheflush.  */
+-#define CLEAR_INSN_CACHE(BEG, END)                                      \
+-{                                                                       \
+-  register unsigned long _beg __asm ("a1") = (unsigned long) (BEG);     \
+-  register unsigned long _end __asm ("a2") = (unsigned long) (END);     \
+-  register unsigned long _flg __asm ("a3") = 0;                         \
+-  __asm __volatile ("swi 0x9f0002               @ sys_cacheflush"       \
+-                    : "=r" (_beg)                                       \
+-                    : "0" (_beg), "r" (_end), "r" (_flg));              \
+-}
+-/*
+- *  Cache flush code grabbed from a Dec 1999 posting on libc-hacker 
+- *  mailing list
+- */
+-extern void __clear_cache(char*, char *);
++#ifndef CLEAR_CACHE_DEFINED
++extern void __clear_cache(void *, void *);
++#endif
+ 
+ static void
+ arm6_flush(void *base, void *limit)
+diff -ur spack-src.org/arm6_rt.c spack-src/arm6_rt.c
+--- spack-src.org/arm6_rt.c	2020-03-26 09:35:43.403836842 +0900
++++ spack-src/arm6_rt.c	2020-03-26 09:41:59.823222738 +0900
+@@ -109,22 +109,9 @@
+     }
+ }
+ 
+-/* Clear the instruction cache from `beg' to `end'.  This makes an
+-   inline system call to SYS_cacheflush.  */
+-#define CLEAR_INSN_CACHE(BEG, END)                                      \
+-{                                                                       \
+-  register unsigned long _beg __asm ("a1") = (unsigned long) (BEG);     \
+-  register unsigned long _end __asm ("a2") = (unsigned long) (END);     \
+-  register unsigned long _flg __asm ("a3") = 0;                         \
+-  __asm __volatile ("swi 0x9f0002               @ sys_cacheflush"       \
+-                    : "=r" (_beg)                                       \
+-                    : "0" (_beg), "r" (_end), "r" (_flg));              \
+-}
+-/*
+- *  Cache flush code grabbed from a Dec 1999 posting on libc-hacker 
+- *  mailing list
+- */
+-extern void __clear_cache(char*, char *);
++#ifndef CLEAR_CACHE_DEFINED
++extern void __clear_cache(void *, void *);
++#endif
+ 
+ static void
+ arm6_flush(void *base, void *limit)
+diff -ur spack-src.org/arm8.c spack-src/arm8.c
+--- spack-src.org/arm8.c	2020-03-26 09:35:43.403836842 +0900
++++ spack-src/arm8.c	2020-03-26 09:43:04.630008776 +0900
+@@ -1524,22 +1524,9 @@
+ }
+ 
+ 
+-/* Clear the instruction cache from `beg' to `end'.  This makes an
+-   inline system call to SYS_cacheflush.  */
+-#define CLEAR_INSN_CACHE(BEG, END)                                      \
+-{                                                                       \
+-  register unsigned long _beg __asm ("a1") = (unsigned long) (BEG);     \
+-  register unsigned long _end __asm ("a2") = (unsigned long) (END);     \
+-  register unsigned long _flg __asm ("a3") = 0;                         \
+-  __asm __volatile ("swi 0x9f0002               @ sys_cacheflush"       \
+-                    : "=r" (_beg)                                       \
+-                    : "0" (_beg), "r" (_end), "r" (_flg));              \
+-}
+-/*
+- *  Cache flush code grabbed from a Dec 1999 posting on libc-hacker 
+- *  mailing list
+- */
+-extern void __clear_cache(char*, char *);
++#ifndef CLEAR_CACHE_DEFINED
++extern void __clear_cache(void *, void *);
++#endif
+ 
+ static void
+ arm8_flush(void *base, void *limit)
+diff -ur spack-src.org/arm8_rt.c spack-src/arm8_rt.c
+--- spack-src.org/arm8_rt.c	2020-03-26 09:35:43.403836842 +0900
++++ spack-src/arm8_rt.c	2020-03-26 09:44:19.027799105 +0900
+@@ -109,22 +109,9 @@
+     }
+ }
+ 
+-/* Clear the instruction cache from `beg' to `end'.  This makes an
+-   inline system call to SYS_cacheflush.  */
+-#define CLEAR_INSN_CACHE(BEG, END)                                      \
+-{                                                                       \
+-  register unsigned long _beg __asm ("a1") = (unsigned long) (BEG);     \
+-  register unsigned long _end __asm ("a2") = (unsigned long) (END);     \
+-  register unsigned long _flg __asm ("a3") = 0;                         \
+-  __asm __volatile ("swi 0x9f0002               @ sys_cacheflush"       \
+-                    : "=r" (_beg)                                       \
+-                    : "0" (_beg), "r" (_end), "r" (_flg));              \
+-}
+-/*
+- *  Cache flush code grabbed from a Dec 1999 posting on libc-hacker 
+- *  mailing list
+- */
+-extern void __clear_cache(char*, char *);
++#ifndef CLEAR_CACHE_DEFINED
++extern void __clear_cache(void *, void *);
++#endif
+ 
+ static void
+ arm8_flush(void *base, void *limit)
+diff -ur spack-src.org/config.h.cmake spack-src/config.h.cmake
+--- spack-src.org/config.h.cmake	2020-03-26 09:35:43.403836842 +0900
++++ spack-src/config.h.cmake	2020-03-26 09:46:56.124248964 +0900
+@@ -16,10 +16,13 @@
+ #cmakedefine HAVE_DIS_ASM_H
+ 
+ /* Define to 1 if you have the <dlfcn.h> header file. */
+-#undef HAVE_DLFCN_H
++#cmakedefine HAVE_DLFCN_H
+ 
+ /* Define to 1 if you have the <inttypes.h> header file. */
+-#undef HAVE_INTTYPES_H
++#cmakedefine HAVE_INTTYPES_H
++
++/* Define to 1 if you have __clear_cache is defined  */
++#cmakedefine CLEAR_CACHE_DEFINED
+ 
+ /* Define to 1 if you have the <malloc.h> header file. */
+ #cmakedefine HAVE_MALLOC_H

--- a/var/spack/repos/builtin/packages/gtkorvo-dill/package.py
+++ b/var/spack/repos/builtin/packages/gtkorvo-dill/package.py
@@ -20,6 +20,10 @@ class GtkorvoDill(CMakePackage):
     version('2.4', sha256='ed7745d13e8c6a556f324dcc0e48a807fc993bdd5bb1daa94c1df116cb7e81fa')
     version('2.1', sha256='7671e1f3c25ac6a4ec2320cec2c342a2f668efb170e3dba186718ed17d2cf084')
 
+    # Ref: https://github.com/GTkorvo/dill/commit/dac6dfcc7fdaceeb4c157f9ecdf5ecc28f20477f
+    patch('2.4-fix-clear_cache.patch', when='@2.4')
+    patch('2.1-fix-clear_cache.patch', when='@2.1')
+
     def cmake_args(self):
         args = []
         if self.spec.satisfies('@2.4:'):


### PR DESCRIPTION
- error
```
  >> 101    /tmp/pytest-of-ogura/pytest-77/mock-stage0/spack-stage-gtkorvo-dill
            -2.4-dqt4eofp33rvnb3sv5cbl5hd3lnpbw37/spack-src/arm8_rt.c:127:13: e
            rror: conflicting types for '__clear_cache'
     102    extern void __clear_cache(char*, char *);
     103                ^
```
Only define `__clear_cache` if not defined, and fix for match the argument type of the built-in function `__clear_cache`.
Ref: https://github.com/GTkorvo/dill/commit/dac6dfcc7fdaceeb4c157f9ecdf5ecc28f20477f