### PR TITLE
BLD: add XL support for pfunit (isolated version)

### DIFF
--- a/var/spack/repos/builtin/packages/pfunit/package.py
+++ b/var/spack/repos/builtin/packages/pfunit/package.py
@@ -50,7 +50,6 @@ class Pfunit(CMakePackage):
     # specific version, a patch has been
     # developed to stub deferred procedures
     # that interfere with inheritance/building
-    patch("xl-deferred.patch", when='@3.2.8.mod1 %xl_r')
     patch("xl-deferred.patch", when='@3.2.9 %xl_r')
 
     def patch(self):
@@ -69,8 +68,7 @@ class Pfunit(CMakePackage):
             '-DOPENMP=%s' % ('YES' if '+openmp' in spec else 'NO'),
             '-DMAX_RANK=%s' % spec.variants['max_array_rank'].value]
 
-        if (spec.satisfies('@3.2.9 %xl_r') or
-            spec.satisfies('@3.2.8.mod1 %xl_r')):
+        if spec.satisfies('@3.2.9 %xl_r'):
             # DCMAKE_Fortran_MODULE_DIRECTORY setting is
             # not sufficient for XLF build, at least on rzansel
             # need to create the path so module files can be placed

--- a/var/spack/repos/builtin/packages/pfunit/package.py
+++ b/var/spack/repos/builtin/packages/pfunit/package.py
@@ -76,7 +76,7 @@ class Pfunit(CMakePackage):
             # not sufficient for XLF build, at least on rzansel
             # need to create the path so module files can be placed
             # appropriately
-            pathlib.Path(spec.prefix.include).mkdir(parents=True, exist_ok=True)
+            mkdir(self.prefix.include)
             args.append('-DCMAKE_Fortran_STANDARD_INCLUDE_DIRECTORIES=%s' % spec.prefix.include)
 
         if spec.satisfies('+mpi'):

--- a/var/spack/repos/builtin/packages/pfunit/package.py
+++ b/var/spack/repos/builtin/packages/pfunit/package.py
@@ -6,8 +6,6 @@
 #
 from spack import *
 import glob
-import os
-import pathlib
 
 
 class Pfunit(CMakePackage):
@@ -52,8 +50,8 @@ class Pfunit(CMakePackage):
     # specific version, a patch has been
     # developed to stub deferred procedures
     # that interfere with inheritance/building
+    patch("xl-deferred.patch", when='@3.2.8.mod1 %xl_r')
     patch("xl-deferred.patch", when='@3.2.9 %xl_r')
-
 
     def patch(self):
         # The package tries to put .mod files in directory ./mod;
@@ -71,13 +69,19 @@ class Pfunit(CMakePackage):
             '-DOPENMP=%s' % ('YES' if '+openmp' in spec else 'NO'),
             '-DMAX_RANK=%s' % spec.variants['max_array_rank'].value]
 
-        if spec.satisfies('@3.2.9 %xl_r'):
+        if (spec.satisfies('@3.2.9 %xl_r') or
+            spec.satisfies('@3.2.8.mod1 %xl_r')):
             # DCMAKE_Fortran_MODULE_DIRECTORY setting is
             # not sufficient for XLF build, at least on rzansel
             # need to create the path so module files can be placed
             # appropriately
-            mkdir(self.prefix.include)
-            args.append('-DCMAKE_Fortran_STANDARD_INCLUDE_DIRECTORIES=%s' % spec.prefix.include)
+            try:
+                mkdir(self.prefix.include)
+            except FileExistsError:
+                pass
+
+            args.append('-DCMAKE_Fortran_STANDARD_INCLUDE_DIRECTORIES=%s' %
+                        spec.prefix.include)
 
         if spec.satisfies('+mpi'):
             args.extend(['-DMPI=YES', '-DMPI_USE_MPIEXEC=YES',

--- a/var/spack/repos/builtin/packages/pfunit/xl-deferred.patch
+++ b/var/spack/repos/builtin/packages/pfunit/xl-deferred.patch
@@ -1,0 +1,112 @@
+commit 65ca2dfc67a24a5267e7386103af973c81419d47
+Author: Tyler John Edward Reddy <reddy5@rzansel49.coral.llnl.gov>
+Date:   Mon Mar 23 16:17:58 2020 -0700
+
+    BUG: patch deferred procedures for XLF
+    
+    * use stubbing instead of deferred procedures
+    for pfunit 3.2.9, to enable compilation with XLF
+
+diff --git a/source/BaseTestRunner.F90 b/source/BaseTestRunner.F90
+index 5f8977a..80b76c6 100644
+--- a/source/BaseTestRunner.F90
++++ b/source/BaseTestRunner.F90
+@@ -31,26 +31,21 @@ module BaseTestRunner_mod
+       private
+ 
+    contains
+-      procedure(run2), deferred :: run
++      procedure :: run => run
+    end type BaseTestRunner
+ 
+-   abstract interface
+-
+-      ! TODO - report bug to NAG.  If this is named "run" then
+-      ! RubustRunner fails to compile with message about conflicting types
++   contains
+ 
+-      function run2(this, aTest, context) result(result)
++      function run(this, aTest, context) result(result)
+          use Test_mod
+          use ParallelContext_mod
+          use TestResult_mod
+-         import BaseTestRunner
+ 
+          type (TestResult) :: result
+          class (BaseTestRunner), target, intent(inout) :: this
+          class (Test), intent(inout) :: aTest
+          class (ParallelContext), intent(in) :: context
+-      end function run2
++      end function run
+ 
+-   end interface
+ 
+ end module BaseTestRunner_mod
+diff --git a/source/TestListener.F90 b/source/TestListener.F90
+index 8cd12d7..aba94ee 100644
+--- a/source/TestListener.F90
++++ b/source/TestListener.F90
+@@ -31,11 +31,11 @@ module TestListener_mod
+       private
+       logical :: useDebug = .false.
+    contains
+-     procedure(addFailure), deferred :: addFailure
+-     procedure(startTest), deferred :: startTest
+-     procedure(endTest), deferred :: endTest
++     procedure :: addFailure =>  addFailure
++     procedure :: startTest => startTest
++     procedure :: endTest => endTest
+ !     procedure(startRun), deferred :: startRun  ! make deferred when ready
+-     procedure(endRun), deferred :: endRun    ! make deferred when ready
++     procedure :: endRun => endRun    ! make deferred when ready
+      procedure :: addError
+      procedure :: setDebug
+      procedure :: debug
+@@ -45,23 +45,21 @@ module TestListener_mod
+      class (TestListener), pointer :: pListener
+    end type ListenerPointer
+ 
+-   abstract interface
++   contains
++
+       subroutine addFailure(this, testName, exceptions)
+          use Exception_mod
+-         import TestListener
+          class (TestListener), intent(inout) :: this
+          character(len=*), intent(in) :: testName
+          type (Exception), intent(in) :: exceptions(:)
+       end subroutine addFailure
+ 
+       subroutine startTest(this, testName)
+-         import TestListener
+          class (TestListener), intent(inout) :: this
+          character(len=*), intent(in) :: testName
+       end subroutine startTest
+     
+       subroutine endTest(this, testName)
+-         import TestListener
+          class (TestListener), intent(inout) :: this
+          character(len=*), intent(in) :: testName
+       end subroutine endTest
+@@ -75,15 +73,10 @@ module TestListener_mod
+       ! Stub for future implementation.
+       subroutine endRun(this, result)
+          use AbstractTestResult_mod, only : AbstractTestResult
+-         import TestListener
+          class (TestListener), intent(inout) :: this
+          class (AbstractTestResult), intent(in) :: result
+       end subroutine endRun
+ 
+-   end interface
+-
+-contains
+-
+    ! Most scenarios in Fortran cannot diagnose true errors, so
+    ! an empty stub is provided here for convenience.
+    subroutine addError(this, testName, exceptions)
+@@ -105,4 +98,5 @@ contains
+        debug = this%useDebug
+     end function debug
+ 
++
+  end module TestListener_mod


### PR DESCRIPTION
* pfunit `3.2.9` can now be built with XL compiler
toolchain; fixes are limited to this version because
the required changes were complex and time consuming
to test

* the changes include adding support for `xl_r` spec,
Fortran module path handling tailored to XLF, and a moderately-sized
patch to avoid an apparent issue XLF has with deferred
procedure handling in inheritance chains

cc: @AndrewGaspar @cferenba @gshipman @junghans 

Probably needs careful review. Haven't tried executing tests with it yet, but build succeeds with spack in my hands.