### PR TITLE
Fix non-root installations; update homepage

### DIFF
--- a/var/spack/repos/builtin/packages/util-linux/package.py
+++ b/var/spack/repos/builtin/packages/util-linux/package.py
@@ -9,7 +9,7 @@ from spack import *
 class UtilLinux(AutotoolsPackage):
     """Util-linux is a suite of essential utilities for any Linux system."""
 
-    homepage = "http://freecode.com/projects/util-linux"
+    homepage = "https://github.com/karelzak/util-linux"
     url      = "https://www.kernel.org/pub/linux/utils/util-linux/v2.29/util-linux-2.29.2.tar.gz"
     list_url = "https://www.kernel.org/pub/linux/utils/util-linux"
     list_depth = 1
@@ -36,6 +36,7 @@ class UtilLinux(AutotoolsPackage):
     def configure_args(self):
         config_args = [
             '--disable-use-tty-group',
+            '--disable-makeinstall-chown',
         ]
         config_args.extend(self.enable_or_disable('libuuid'))
         return config_args


### PR DESCRIPTION
This pull request adds `--disable-makeinstall-chown` flag to the configuration arguments. Without this flag, installation procedure involves changing the ownership on some files to root:root. So, the installation fails if the package is installed as a non-root user.

```
5 errors found in build log:
     1290    for I in uname26 linux32 linux64   i386 x86_64     ; do \
     1291       cd /home/ubuntu/spack/opt/spack/linux-ubuntu18.04-haswell/gcc-7.5.0/util-linux-2.35.1-fvfws3jh
             pjdhsw3a53taa5yrscxacyy2/bin && ln -sf setarch $I ; \
     1292    done
     1293    chown root:root /home/ubuntu/spack/opt/spack/linux-ubuntu18.04-haswell/gcc-7.5.0/util-linux-2.3
             5.1-fvfws3jhpjdhsw3a53taa5yrscxacyy2/bin/mount
     1294    chown: changing ownership of '/home/ubuntu/spack/opt/spack/linux-ubuntu18.04-haswell/gcc-7.5.0/
             util-linux-2.35.1-fvfws3jhpjdhsw3a53taa5yrscxacyy2/bin/mount': Operation not permitted
     1295    Makefile:14981: recipe for target 'install-exec-hook-mount' failed
  >> 1296    make[4]: *** [install-exec-hook-mount] Error 1
     1297    make[4]: Leaving directory '/tmp/ubuntu/spack-stage/spack-stage-util-linux-2.35.1-fvfws3jhpjdhs
             w3a53taa5yrscxacyy2/spack-src'
     1298    Makefile:14271: recipe for target 'install-exec-am' failed
  >> 1299    make[3]: *** [install-exec-am] Error 2
     1300    make[3]: Leaving directory '/tmp/ubuntu/spack-stage/spack-stage-util-linux-2.35.1-fvfws3jhpjdhs
             w3a53taa5yrscxacyy2/spack-src'
     1301    Makefile:13668: recipe for target 'install-am' failed
  >> 1302    make[2]: *** [install-am] Error 2
     1303    make[2]: Leaving directory '/tmp/ubuntu/spack-stage/spack-stage-util-linux-2.35.1-fvfws3jhpjdhs
             w3a53taa5yrscxacyy2/spack-src'
     1304    Makefile:13356: recipe for target 'install-recursive' failed
  >> 1305    make[1]: *** [install-recursive] Error 1
     1306    make[1]: Leaving directory '/tmp/ubuntu/spack-stage/spack-stage-util-linux-2.35.1-fvfws3jhpjdhs
             w3a53taa5yrscxacyy2/spack-src'
     1307    Makefile:13662: recipe for target 'install' failed
  >> 1308    make: *** [install] Error 2
```

In addition, the specified home page has not been updated since 2014. Project's new home appears to be on github now.