### PR TITLE
Re-introduce the libs property in the mesa package

### DIFF
--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -174,3 +174,11 @@ class Mesa(AutotoolsPackage):
         args.append('--with-dri-drivers=' + ','.join(args_dri_drivers))
 
         return args
+
+    @property
+    def libs(self):
+        for dir in ['lib64', 'lib']:
+            libs = find_libraries('libGL', join_path(self.prefix, dir),
+                                  shared=True, recursive=False)
+            if libs:
+                return libs


### PR DESCRIPTION
The `libs` property was originally introduced in the `mesa` package in #8904 but then it was removed (unintentionally, I assume) in #10482.