### PR TITLE
py-diskcache: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-diskcache/package.py
+++ b/var/spack/repos/builtin/packages/py-diskcache/package.py
@@ -1,0 +1,16 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class PyDiskcache(PythonPackage):
+    """Disk Cache -- Disk and file backed persistent cache."""
+
+    homepage = "http://www.grantjenks.com/docs/diskcache/"
+    url      = "https://pypi.io/packages/source/d/diskcache/diskcache-4.1.0.tar.gz"
+
+    version('4.1.0', sha256='bcee5a59f9c264e2809e58d01be6569a3bbb1e36a1e0fb83f7ef9b2075f95ce0')
+
+    depends_on('py-setuptools', type='build')
+    depends_on('py-tox', type='test')


### PR DESCRIPTION
Successfully installs on macOS 10.15.3 with Python 3.7.6 and Clang 11.0.3.