### PR TITLE
Add CUDA aware support for UCX and OpenMPI

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -236,6 +236,7 @@ class Openmpi(AutotoolsPackage):
     variant('thread_multiple', default=False,
             description='Enable MPI_THREAD_MULTIPLE support')
     variant('cuda', default=False, description='Enable CUDA support')
+    variant('cuda_aware', default=False, description='Enable CUDA Aware MPI support')
     variant('pmi', default=False, description='Enable PMI support')
     variant('cxx_exceptions', default=True, description='Enable C++ Exception support')
     # Adding support to build a debug version of OpenMPI that activates
@@ -284,6 +285,8 @@ class Openmpi(AutotoolsPackage):
     depends_on('valgrind~mpi', when='+memchecker')
     depends_on('ucx', when='fabrics=ucx')
     depends_on('ucx +thread_multiple', when='fabrics=ucx +thread_multiple')
+    depends_on('ucx +cuda', when='fabrics=ucx +cuda')
+    depends_on('ucx +cuda +gdrcopy', when='+cuda_aware')
     depends_on('ucx +thread_multiple', when='@3.0.0: fabrics=ucx')
     depends_on('libfabric', when='fabrics=libfabric')
     depends_on('slurm', when='schedulers=slurm')
@@ -291,6 +294,22 @@ class Openmpi(AutotoolsPackage):
     depends_on('binutils+libiberty', when='fabrics=mxm')
 
     conflicts('+cuda', when='@:1.6')  # CUDA support was added in 1.7
+    conflicts('~cuda', when='+cuda_aware',
+            msg='CUDA aware MPI depends on CUDA')
+    conflicts('fabrics=none', when='+cuda_aware',
+            msg='CUDA aware MPI could only be used with UCX')
+    conflicts('fabrics=auto', when='+cuda_aware',
+            msg='CUDA aware MPI could only be used with UCX')
+    conflicts('fabrics=psm', when='+cuda_aware',
+            msg='CUDA aware MPI could only be used with UCX')
+    conflicts('fabrics=psm2', when='+cuda_aware',
+            msg='CUDA aware MPI could only be used with UCX')
+    conflicts('fabrics=verb2', when='+cuda_aware',
+            msg='CUDA aware MPI could only be used with UCX')
+    conflicts('fabrics=mxm', when='+cuda_aware',
+            msg='CUDA aware MPI could only be used with UCX')
+    conflicts('fabrics=libmxm', when='+cuda_aware',
+            msg='CUDA aware MPI could only be used with UCX')
     conflicts('fabrics=psm2', when='@:1.8')  # PSM2 support was added in 1.10.0
     conflicts('fabrics=mxm', when='@:1.5.3')  # MXM support was added in 1.5.4
     conflicts('+pmi', when='@:1.5.4')  # PMI support was added in 1.5.5

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -235,8 +235,7 @@ class Openmpi(AutotoolsPackage):
     variant('vt', default=True, description='Build VampirTrace support')
     variant('thread_multiple', default=False,
             description='Enable MPI_THREAD_MULTIPLE support')
-    variant('cuda', default=False, description='Enable CUDA support')
-    variant('cuda_aware', default=False, description='Enable CUDA Aware MPI support')
+    variant('cuda', default=False, description='Enable CUDA-aware support')
     variant('pmi', default=False, description='Enable PMI support')
     variant('cxx_exceptions', default=True, description='Enable C++ Exception support')
     # Adding support to build a debug version of OpenMPI that activates
@@ -285,8 +284,7 @@ class Openmpi(AutotoolsPackage):
     depends_on('valgrind~mpi', when='+memchecker')
     depends_on('ucx', when='fabrics=ucx')
     depends_on('ucx +thread_multiple', when='fabrics=ucx +thread_multiple')
-    depends_on('ucx +cuda', when='fabrics=ucx +cuda')
-    depends_on('ucx +cuda +gdrcopy', when='+cuda_aware')
+    depends_on('ucx +cuda +gdrcopy', when='fabrics=ucx +cuda')
     depends_on('ucx +thread_multiple', when='@3.0.0: fabrics=ucx')
     depends_on('libfabric', when='fabrics=libfabric')
     depends_on('slurm', when='schedulers=slurm')
@@ -294,22 +292,24 @@ class Openmpi(AutotoolsPackage):
     depends_on('binutils+libiberty', when='fabrics=mxm')
 
     conflicts('+cuda', when='@:1.6')  # CUDA support was added in 1.7
-    conflicts('~cuda', when='+cuda_aware',
-            msg='CUDA aware MPI depends on CUDA')
-    conflicts('fabrics=none', when='+cuda_aware',
-            msg='CUDA aware MPI could only be used with UCX')
-    conflicts('fabrics=auto', when='+cuda_aware',
-            msg='CUDA aware MPI could only be used with UCX')
-    conflicts('fabrics=psm', when='+cuda_aware',
-            msg='CUDA aware MPI could only be used with UCX')
-    conflicts('fabrics=psm2', when='+cuda_aware',
-            msg='CUDA aware MPI could only be used with UCX')
-    conflicts('fabrics=verb2', when='+cuda_aware',
-            msg='CUDA aware MPI could only be used with UCX')
-    conflicts('fabrics=mxm', when='+cuda_aware',
-            msg='CUDA aware MPI could only be used with UCX')
-    conflicts('fabrics=libmxm', when='+cuda_aware',
-            msg='CUDA aware MPI could only be used with UCX')
+
+    # after 2.0, CUDA-aware MPI requires UCX as fabrics
+    # mark all other fabrics as conflicts
+    conflicts('fabrics=none', when='+cuda @2.0.0:',
+            msg='CUDA-aware MPI could only be built with UCX')
+    conflicts('fabrics=auto', when='+cuda @2.0.0:',
+            msg='CUDA-aware MPI could only be built with UCX')
+    conflicts('fabrics=psm', when='+cuda @2.0.0:',
+            msg='CUDA-aware MPI could only be built with UCX')
+    conflicts('fabrics=psm2', when='+cuda @2.0.0:',
+            msg='CUDA-aware MPI could only be built with UCX')
+    conflicts('fabrics=verb2', when='+cuda @2.0.0:',
+            msg='CUDA-aware MPI could only be built with UCX')
+    conflicts('fabrics=mxm', when='+cuda @2.0.0:',
+            msg='CUDA-aware MPI could only be built with UCX')
+    conflicts('fabrics=libmxm', when='+cuda @2.0.0:',
+            msg='CUDA-aware MPI could only be built with UCX')
+
     conflicts('fabrics=psm2', when='@:1.8')  # PSM2 support was added in 1.10.0
     conflicts('fabrics=mxm', when='@:1.5.3')  # MXM support was added in 1.5.4
     conflicts('+pmi', when='@:1.5.4')  # PMI support was added in 1.5.5

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -296,19 +296,19 @@ class Openmpi(AutotoolsPackage):
     # after 2.0, CUDA-aware MPI requires UCX as fabrics
     # mark all other fabrics as conflicts
     conflicts('fabrics=none', when='+cuda @2.0.0:',
-            msg='CUDA-aware MPI could only be built with UCX')
+              msg='CUDA-aware MPI could only be built with UCX')
     conflicts('fabrics=auto', when='+cuda @2.0.0:',
-            msg='CUDA-aware MPI could only be built with UCX')
+              msg='CUDA-aware MPI could only be built with UCX')
     conflicts('fabrics=psm', when='+cuda @2.0.0:',
-            msg='CUDA-aware MPI could only be built with UCX')
+              msg='CUDA-aware MPI could only be built with UCX')
     conflicts('fabrics=psm2', when='+cuda @2.0.0:',
-            msg='CUDA-aware MPI could only be built with UCX')
+              msg='CUDA-aware MPI could only be built with UCX')
     conflicts('fabrics=verb2', when='+cuda @2.0.0:',
-            msg='CUDA-aware MPI could only be built with UCX')
+              msg='CUDA-aware MPI could only be built with UCX')
     conflicts('fabrics=mxm', when='+cuda @2.0.0:',
-            msg='CUDA-aware MPI could only be built with UCX')
+              msg='CUDA-aware MPI could only be built with UCX')
     conflicts('fabrics=libmxm', when='+cuda @2.0.0:',
-            msg='CUDA-aware MPI could only be built with UCX')
+              msg='CUDA-aware MPI could only be built with UCX')
 
     conflicts('fabrics=psm2', when='@:1.8')  # PSM2 support was added in 1.10.0
     conflicts('fabrics=mxm', when='@:1.5.3')  # MXM support was added in 1.5.4

--- a/var/spack/repos/builtin/packages/ucx/package.py
+++ b/var/spack/repos/builtin/packages/ucx/package.py
@@ -56,4 +56,3 @@ class Ucx(AutotoolsPackage):
         if '+gdrcopy' in spec:
             config_args.append('--with-gdrcopy')
         return config_args
-

--- a/var/spack/repos/builtin/packages/ucx/package.py
+++ b/var/spack/repos/builtin/packages/ucx/package.py
@@ -38,7 +38,7 @@ class Ucx(AutotoolsPackage):
             description='Enable CUDA support')
 
     variant('gdrcopy', default=False,
-            description='Enable gdrcopy support')
+            description='Enable gdrcopy support (it needs to be installed system-wide)')
 
     depends_on('numactl')
     depends_on('rdma-core')

--- a/var/spack/repos/builtin/packages/ucx/package.py
+++ b/var/spack/repos/builtin/packages/ucx/package.py
@@ -34,8 +34,15 @@ class Ucx(AutotoolsPackage):
     variant('thread_multiple', default=False,
             description='Enable thread support in UCP and UCT')
 
+    variant('cuda', default=False,
+            description='Enable CUDA support')
+
+    variant('gdrcopy', default=False,
+            description='Enable gdrcopy support')
+
     depends_on('numactl')
     depends_on('rdma-core')
+    depends_on('cuda', when='+cuda')
 
     def configure_args(self):
         spec = self.spec
@@ -44,4 +51,9 @@ class Ucx(AutotoolsPackage):
             config_args.append('--enable-mt')
         else:
             config_args.append('--disable-mt')
+        if '+cuda' in spec:
+            config_args.append('--with-cuda={0}'.format(spec['cuda'].prefix))
+        if '+gdrcopy' in spec:
+            config_args.append('--with-gdrcopy')
         return config_args
+


### PR DESCRIPTION
According to https://www.open-mpi.org/faq/?category=buildcuda, OpenMPI could be made CUDA-aware by using UCX built with `gdrcopy` and `CUDA`.

Although ucx is able to detect the existence of CUDA and gdrcopy when configuring, I believe an explicit flag would be more informative.

BTW it there a way to express that when `cuda_aware` is enabled, `fabrics` must be `ucx`? The current implementation is ugly for I have to include all other fabrics in `conflicts` section explicitly.