### PR TITLE
motif: add pkgconfig dependency

### DIFF
--- a/var/spack/repos/builtin/packages/motif/package.py
+++ b/var/spack/repos/builtin/packages/motif/package.py
@@ -33,6 +33,7 @@ class Motif(AutotoolsPackage):
     depends_on("autoconf", type="build")
     depends_on("m4", type="build")
     depends_on("libtool", type="build")
+    depends_on("pkgconfig", type="build")
 
     patch('add_xbitmaps_dependency.patch')
 


### PR DESCRIPTION
Couldn't build without this. Successfully builds on macOS 10.15.4 with Clang 11.0.3.