### PR TITLE
spack-python should exec `spack python`

### DIFF
--- a/bin/spack-python
+++ b/bin/spack-python
@@ -22,4 +22,4 @@
 #
 # This is compatible across platforms.
 #
-/usr/bin/env spack python "$@"
+exec /usr/bin/env spack python "$@"


### PR DESCRIPTION
The current implementation of `spack-python` will leave an extra shell around while it runs.  That shell should really replace itself with spack.

- [x] add exec to spack-python script