### PR TITLE
CitcomS: add maintainer, master version, python dep

### DIFF
--- a/var/spack/repos/builtin/packages/citcoms/package.py
+++ b/var/spack/repos/builtin/packages/citcoms/package.py
@@ -12,7 +12,11 @@ class Citcoms(AutotoolsPackage):
 
     homepage = "https://geodynamics.org/cig/software/citcoms/"
     url      = "https://github.com/geodynamics/citcoms/releases/download/v3.3.1/CitcomS-3.3.1.tar.gz"
+    git      = "https://github.com/geodynamics/citcoms.git"
 
+    maintainers = ['adamjstewart']
+
+    version('master', branch='master', submodules=True)
     version('3.3.1', sha256='e3520e0a933e4699d31e86fe309b8c154ea6ecb0f42a1cf6f25e8d13d825a4b3')
     version('3.2.0', sha256='773a14d91ecbb4a4d1e04317635fab79819d83c57b47f19380ff30b9b19cb07a')
 
@@ -23,6 +27,11 @@ class Citcoms(AutotoolsPackage):
     # Required dependencies
     depends_on('mpi')
     depends_on('zlib')
+    depends_on('python@:2', type='run')  # needed for post-processing scripts
+    depends_on('automake', when='@master', type='build')
+    depends_on('autoconf', when='@master', type='build')
+    depends_on('libtool',  when='@master', type='build')
+    depends_on('m4',       when='@master', type='build')
 
     # Optional dependencies
     depends_on('hc', when='+ggrd')


### PR DESCRIPTION
Successfully installs on macOS 10.15.4 with Clang 11.0.3.