### PR TITLE
new package: intel-mpi-benchmarks

### DIFF
--- a/var/spack/repos/builtin/packages/intel-mpi-benchmarks/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi-benchmarks/package.py
@@ -7,9 +7,12 @@ from spack import *
 
 
 class IntelMpiBenchmarks(MakefilePackage):
-    """Intel(R) MPI Benchmarks provides a set of elementary benchmarks that conform to MPI-1, MPI-2, and MPI-3 standard. 
-       You can run all of the supported benchmarks, or a subset specified in the command line using one executable file. 
-       Use command-line parameters to specify various settings, such as time measurement, message lengths, and selection of communicators. """
+    """Intel(R) MPI Benchmarks provides a set of elementary benchmarks
+       that conform to MPI-1, MPI-2, and MPI-3 standard.
+       You can run all of the supported benchmarks, or a subset specified
+       in the command line using one executable file.
+       Use command-line parameters to specify various settings, such as
+       time measurement, message lengths, and selection of communicators. """
 
     homepage = "https://software.intel.com/en-us/articles/intel-mpi-benchmarks"
     url      = "https://github.com/intel/mpi-benchmarks/archive/IMB-v2019.5.tar.gz"
@@ -23,18 +26,70 @@ class IntelMpiBenchmarks(MakefilePackage):
 
     depends_on('mpi')
 
+    variant(
+        'benchmark', default='all',
+        values=('mpi1', 'ext', 'io', 'nbc',
+                'p2p', 'rma', 'mt', 'all'),
+        multi=True,
+        description='Specify which benchmarks to build')
+
     def build(self, spec, prefix):
         env['CC'] = spec['mpi'].mpicc
         env['CXX'] = spec['mpi'].mpicxx
 
-        make("all")
+        if 'benchmark=all' in spec:
+            make("all")
+
+        if 'benchmark=mpi1' in spec:
+            make('IMB-MPI1')
+
+        if 'benchmark=ext' in spec:
+            make('IMB-EXT')
+
+        if 'benchmark=io' in spec:
+            make('IMB-IO')
+
+        if 'benchmark=nbc' in spec:
+            make('IMB-NBC')
+
+        if 'benchmark=p2p' in spec:
+            make('IMB-P2P')
+
+        if 'benchmark=rma' in spec:
+            make('IMB-RMA')
+
+        if 'benchmark=mt' in spec:
+            make('IMB-MT')
 
     def install(self, spec, prefix):
         mkdir(prefix.bin)
-        install('IMB-EXT',  prefix.bin)
-        install('IMB-IO',   prefix.bin)
-        install('IMB-MPI1', prefix.bin)
-        install('IMB-MT',   prefix.bin)
-        install('IMB-NBC',  prefix.bin)
-        install('IMB-P2P',  prefix.bin)
-        install('IMB-RMA',  prefix.bin)
+
+        if 'benchmark=all' in spec:
+            install('IMB-EXT',  prefix.bin)
+            install('IMB-IO',   prefix.bin)
+            install('IMB-MPI1', prefix.bin)
+            install('IMB-MT',   prefix.bin)
+            install('IMB-NBC',  prefix.bin)
+            install('IMB-P2P',  prefix.bin)
+            install('IMB-RMA',  prefix.bin)
+
+        if 'benchmark=mpi1' in spec:
+            install('IMB-MPI1', prefix.bin)
+
+        if 'benchmark=ext' in spec:
+            install('IMB-EXT', prefix.bin)
+
+        if 'benchmark=io' in spec:
+            install('IMB-IO', prefix.bin)
+
+        if 'benchmark=nbc' in spec:
+            install('IMB-NBC', prefix.bin)
+
+        if 'benchmark=p2p' in spec:
+            install('IMB-P2P', prefix.bin)
+
+        if 'benchmark=rma' in spec:
+            install('IMB-RMA', prefix.bin)
+
+        if 'benchmark=mt' in spec:
+            install('IMB-MT', prefix.bin)

--- a/var/spack/repos/builtin/packages/intel-mpi-benchmarks/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi-benchmarks/package.py
@@ -21,15 +21,20 @@ class IntelMpiBenchmarks(MakefilePackage):
     version('2019.3', sha256='4f256d11bfed9ca6166548486d61a062e67be61f13dd9f30690232720e185f31')
     version('2019.2', sha256='0bc2224a913073aaa5958f6ae08341e5fcd39cedc6722a09bfd4a3d7591a340b')
 
-    depends_on('gmake', type='build')
     depends_on('mpi')
 
-    def install(self, spec, prefix):
+    def build(self, spec, prefix):
         env['CC'] = spec['mpi'].mpicc
         env['CXX'] = spec['mpi'].mpicxx
-        env['F77'] = spec['mpi'].mpif77
-        env['FC'] = spec['mpi'].mpifci
 
-        make('install all')
+        make("all")
 
-
+    def install(self, spec, prefix):
+        mkdir(prefix.bin)
+        install('IMB-EXT',  prefix.bin)
+        install('IMB-IO',   prefix.bin)
+        install('IMB-MPI1', prefix.bin)
+        install('IMB-MT',   prefix.bin)
+        install('IMB-NBC',  prefix.bin)
+        install('IMB-P2P',  prefix.bin)
+        install('IMB-RMA',  prefix.bin)

--- a/var/spack/repos/builtin/packages/intel-mpi-benchmarks/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi-benchmarks/package.py
@@ -30,6 +30,6 @@ class IntelMpiBenchmarks(MakefilePackage):
         env['F77'] = spec['mpi'].mpif77
         env['FC'] = spec['mpi'].mpifci
 
-        install('all')
+        make('install all')
 
 

--- a/var/spack/repos/builtin/packages/intel-mpi-benchmarks/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi-benchmarks/package.py
@@ -30,41 +30,48 @@ class IntelMpiBenchmarks(MakefilePackage):
         'benchmark', default='all',
         values=('mpi1', 'ext', 'io', 'nbc',
                 'p2p', 'rma', 'mt', 'all'),
-        multi=True,
-        description='Specify which benchmarks to build')
+        multi=False,
+        description='Specify which benchmark to build')
 
     def build(self, spec, prefix):
         env['CC'] = spec['mpi'].mpicc
         env['CXX'] = spec['mpi'].mpicxx
 
-        if 'benchmark=all' in spec:
-            make("all")
-
         if 'benchmark=mpi1' in spec:
             make('IMB-MPI1')
-
-        if 'benchmark=ext' in spec:
+        elif 'benchmark=ext' in spec:
             make('IMB-EXT')
-
-        if 'benchmark=io' in spec:
+        elif 'benchmark=io' in spec:
             make('IMB-IO')
-
-        if 'benchmark=nbc' in spec:
+        elif 'benchmark=nbc' in spec:
             make('IMB-NBC')
-
-        if 'benchmark=p2p' in spec:
+        elif 'benchmark=p2p' in spec:
             make('IMB-P2P')
-
-        if 'benchmark=rma' in spec:
+        elif 'benchmark=rma' in spec:
             make('IMB-RMA')
-
-        if 'benchmark=mt' in spec:
+        elif 'benchmark=mt' in spec:
             make('IMB-MT')
+        else:
+            make("all")
 
     def install(self, spec, prefix):
         mkdir(prefix.bin)
 
-        if 'benchmark=all' in spec:
+        if 'benchmark=mpi1' in spec:
+            install('IMB-MPI1', prefix.bin)
+        elif 'benchmark=ext' in spec:
+            install('IMB-EXT', prefix.bin)
+        elif 'benchmark=io' in spec:
+            install('IMB-IO', prefix.bin)
+        elif 'benchmark=nbc' in spec:
+            install('IMB-NBC', prefix.bin)
+        elif 'benchmark=p2p' in spec:
+            install('IMB-P2P', prefix.bin)
+        elif 'benchmark=rma' in spec:
+            install('IMB-RMA', prefix.bin)
+        elif 'benchmark=mt' in spec:
+            install('IMB-MT', prefix.bin)
+        else:
             install('IMB-EXT',  prefix.bin)
             install('IMB-IO',   prefix.bin)
             install('IMB-MPI1', prefix.bin)
@@ -72,24 +79,3 @@ class IntelMpiBenchmarks(MakefilePackage):
             install('IMB-NBC',  prefix.bin)
             install('IMB-P2P',  prefix.bin)
             install('IMB-RMA',  prefix.bin)
-
-        if 'benchmark=mpi1' in spec:
-            install('IMB-MPI1', prefix.bin)
-
-        if 'benchmark=ext' in spec:
-            install('IMB-EXT', prefix.bin)
-
-        if 'benchmark=io' in spec:
-            install('IMB-IO', prefix.bin)
-
-        if 'benchmark=nbc' in spec:
-            install('IMB-NBC', prefix.bin)
-
-        if 'benchmark=p2p' in spec:
-            install('IMB-P2P', prefix.bin)
-
-        if 'benchmark=rma' in spec:
-            install('IMB-RMA', prefix.bin)
-
-        if 'benchmark=mt' in spec:
-            install('IMB-MT', prefix.bin)

--- a/var/spack/repos/builtin/packages/intel-mpi-benchmarks/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi-benchmarks/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class IntelMpiBenchmarks(MakefilePackage):
+    """Intel(R) MPI Benchmarks provides a set of elementary benchmarks that conform to MPI-1, MPI-2, and MPI-3 standard. 
+       You can run all of the supported benchmarks, or a subset specified in the command line using one executable file. 
+       Use command-line parameters to specify various settings, such as time measurement, message lengths, and selection of communicators. """
+
+    homepage = "https://software.intel.com/en-us/articles/intel-mpi-benchmarks"
+    url      = "https://github.com/intel/mpi-benchmarks/archive/IMB-v2019.5.tar.gz"
+
+    maintainers = ['carsonwoods']
+
+    version('2019.5', sha256='61f8e872a3c3076af53007a68e4da3a8d66be2ba7a051dc21e626a4e2d26e651')
+
+    depends_on('gmake', type='build')
+    depends_on('mpi')
+
+    def install(self, spec, prefix):
+        env['CC'] = spec['mpi'].mpicc
+        env['CXX'] = spec['mpi'].mpicxx
+        env['F77'] = spec['mpi'].mpif77
+        env['FC'] = spec['mpi'].mpifci
+
+        install('all')
+
+

--- a/var/spack/repos/builtin/packages/intel-mpi-benchmarks/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi-benchmarks/package.py
@@ -17,6 +17,9 @@ class IntelMpiBenchmarks(MakefilePackage):
     maintainers = ['carsonwoods']
 
     version('2019.5', sha256='61f8e872a3c3076af53007a68e4da3a8d66be2ba7a051dc21e626a4e2d26e651')
+    version('2019.4', sha256='aeb336be10275c1a2f579b491b6631122876b461ac7148b1d0764f13b7552690')
+    version('2019.3', sha256='4f256d11bfed9ca6166548486d61a062e67be61f13dd9f30690232720e185f31')
+    version('2019.2', sha256='0bc2224a913073aaa5958f6ae08341e5fcd39cedc6722a09bfd4a3d7591a340b')
 
     depends_on('gmake', type='build')
     depends_on('mpi')


### PR DESCRIPTION
Currently, the only way that the Intel MPI benchmarks can be installed through Spack is by installing the entire Intel MPI implementation. This PR adds a new package that is only the Intel MPI benchmarks so that they can be run independently. 