### PR TITLE
package: add additional configuration options for binutils

### DIFF
--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -35,6 +35,9 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
     variant('libiberty', default=False, description='Also install libiberty.')
     variant('nls', default=True, description='Enable Native Language Support')
     variant('headers', default=False, description='Install extra headers (e.g. ELF)')
+    variant('lto', default=False, description='Enable lto.')
+    variant('ld', default=False, description='Enable ld.')
+    variant('interwork', default=False, description='Enable interwork.')
 
     patch('cr16.patch', when='@:2.29.1')
     patch('update_symbol-2.26.patch', when='@2.26')
@@ -67,6 +70,15 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
             '--with-system-zlib',
             '--with-sysroot=/',
         ]
+
+        if '+lto' in spec:
+            configure_args.append('--enable-lto')
+
+        if '+ld' in spec:
+            configure_args.append('--enable-ld')
+
+        if '+interwork' in spec:
+            configure_args.append('--enable-interwork')
 
         if '+gold' in spec:
             configure_args.append('--enable-gold')


### PR DESCRIPTION
Add additional compile time configuration toggles for binutils. Specifically lto, ld, and interwork have been added as package variants with the defaults set to false to not change any pre-exisiting behavior. 