### PR TITLE
package: add additional configuration options for gdb

### DIFF
--- a/var/spack/repos/builtin/packages/gdb/package.py
+++ b/var/spack/repos/builtin/packages/gdb/package.py
@@ -34,6 +34,10 @@ class Gdb(AutotoolsPackage, GNUMirrorPackage):
     variant('python', default=True, description='Compile with Python support')
     variant('xz', default=True, description='Compile with lzma support')
     variant('source-highlight', default=False, description='Compile with source-highlight support')
+    variant('lto', default=False, description='Enable lto')
+    variant('quad', default=False, description='Enable quad')
+    variant('gold', default=False, description='Enable gold linker')
+    variant('ld', default=False, description='Enable ld')
 
     # Required dependency
     depends_on('texinfo', type='build')
@@ -51,4 +55,17 @@ class Gdb(AutotoolsPackage, GNUMirrorPackage):
             args.append('--with-python')
             args.append('LDFLAGS={0}'.format(
                 self.spec['python'].libs.ld_flags))
+
+        if '+lto' in self.spec:
+            args.append('--enable-lto')
+
+        if '+quad' in self.spec:
+            args.append('--with-quad')
+
+        if '+gold' in self.spec:
+            args.append('--enable-gold')
+
+        if '+ld' in self.spec:
+            args.append('--enable-ld')
+
         return args


### PR DESCRIPTION
Add additional compile time configuration options for the gdb package. Specifically, variants have been added for lto, quad, gold, and ld support, with the default set to false to preserve existing behavior. 