### PR TITLE
[acts-core] New version + new repository

### DIFF
--- a/var/spack/repos/builtin/packages/acts-core/package.py
+++ b/var/spack/repos/builtin/packages/acts-core/package.py
@@ -30,10 +30,11 @@ class ActsCore(CMakePackage):
     """
 
     homepage = "http://acts.web.cern.ch/ACTS/"
-    git      = "https://gitlab.cern.ch/acts/acts-core.git"
+    git      = "https://github.com/acts-project/acts.git"
     maintainers = ['HadrienG2']
 
     version('develop', branch='master')
+    version('0.20.0', commit='1d37a849a9c318e8ca4fa541ef8433c1f004637b')
     version('0.19.0', commit='408335636486c421c6222a64372250ef12544df6')
     version('0.18.0', commit='d58a68cf75b52a5e0f563bc237f09250aa9da80c')
     version('0.17.0', commit='0789f654ff484b013fd27e5023cf342785ea8d97')


### PR DESCRIPTION
In order to facilitate outside contribution, the Acts project is moving from a CERN-hosted Gitlab instance to Github. During this migration process, a new release was also tagged.