### PR TITLE
fix sz package

### DIFF
--- a/var/spack/repos/builtin/packages/sz/package.py
+++ b/var/spack/repos/builtin/packages/sz/package.py
@@ -71,6 +71,9 @@ class Sz(CMakePackage):
         else:
             configure_args.append("--disable-fortran")
         configure(*configure_args)
+        # at least the v2.0.2.0 tarball contains object files
+        # which need to be cleaned out
+        make("clean")
 
     def cmake_args(self):
         """configure the package with CMake for version 2.1.8.1 and later"""


### PR DESCRIPTION
At least the v2.0.2.0 tar ball contains compiled object files etc, which
cause the build to fail on other architectures (ppc64le in particular), so
this patch adds a `make clean` after configuring first.