### PR TITLE
py-torch: Fix v1.4.0 by adding v1.4.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -51,7 +51,12 @@ class PyTorch(PythonPackage, CudaPackage):
     ]
 
     version('master', branch='master', submodules=True)
-    version('1.4.0', tag='v1.4.0', submodules=True)
+    version('1.4.1', tag='v1.4.1', submodules=True)
+    # the following v1.4.0 tag is correct.
+    # v1.4.1 contains one fix on v1.4.0 to correct
+    # a broken tag on the fbgemm submodule
+    # see https://github.com/pytorch/pytorch/issues/35149
+    version('1.4.0', tag='v1.4.1', submodules=True)
     version('1.3.1', tag='v1.3.1', submodules=True)
     version('1.3.0', tag='v1.3.0', submodules=True)
     version('1.2.0', tag='v1.2.0', submodules=True)

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -55,7 +55,6 @@ class PyTorch(PythonPackage, CudaPackage):
     # see https://github.com/pytorch/pytorch/issues/35149
     version('1.4.0', tag='v1.4.0', submodules=True,
             submodules_delete=['third_party/fbgemm'])
-    conflicts('+fbgemm', when='@1.4.0')
     version('1.3.1', tag='v1.3.1', submodules=True)
     version('1.3.0', tag='v1.3.0', submodules=True)
     version('1.2.0', tag='v1.2.0', submodules=True)
@@ -105,6 +104,8 @@ class PyTorch(PythonPackage, CudaPackage):
     conflicts('+redis', when='@:1.0')
     conflicts('+zstd', when='@:1.0')
     conflicts('+tbb', when='@:1.1')
+    # see https://github.com/pytorch/pytorch/issues/35149
+    conflicts('+fbgemm', when='@1.4.0')
 
     cuda_arch_conflict = ('This version of Torch/Caffe2 only supports compute '
                           'capabilities ')

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -52,11 +52,10 @@ class PyTorch(PythonPackage, CudaPackage):
 
     version('master', branch='master', submodules=True)
     version('1.4.1', tag='v1.4.1', submodules=True)
-    # the following v1.4.0 tag is correct.
-    # v1.4.1 contains one fix on v1.4.0 to correct
-    # a broken tag on the fbgemm submodule
     # see https://github.com/pytorch/pytorch/issues/35149
-    version('1.4.0', tag='v1.4.1', submodules=True)
+    version('1.4.0', tag='v1.4.0', submodules=True,
+            submodules_delete=['third_party/fbgemm'])
+    conflicts('+fbgemm', when='@1.4.0')
     version('1.3.1', tag='v1.3.1', submodules=True)
     version('1.3.0', tag='v1.3.0', submodules=True)
     version('1.2.0', tag='v1.2.0', submodules=True)


### PR DESCRIPTION
version/tag hack so that 1.4.0 is still workable.
see pytorch/pytorch#35149