### PR TITLE
database: maintain in memory consistency when removing specs

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1128,6 +1128,10 @@ class Database(object):
 
         del self._data[key]
         for dep in rec.spec.dependencies(_tracked_deps):
+            # FIXME: the two lines below needs to be updated once #11983 is
+            # FIXME: fixed. The "if" statement should be deleted and specs are
+            # FIXME: to be removed from dependents by hash and not by name.
+            # FIXME: See https://github.com/spack/spack/pull/15777#issuecomment-607818955
             if dep._dependents.get(spec.name):
                 del dep._dependents[spec.name]
             self._decrement_ref_count(dep)


### PR DESCRIPTION
fixes #15773

The performance improvements done in #14693 where leaving the DB in an inconsistent state when specs were removed from it. This PR updates the DB internal state whenever it is written to file, but does that using a dictionary that still resides in memory to maintain the performance gain of #14693.