### PR TITLE
Blacklist Lmod variable modifications when sourcing files

### DIFF
--- a/lib/spack/spack/test/data/sourceme_lmod.sh
+++ b/lib/spack/spack/test/data/sourceme_lmod.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+export LMOD_VARIABLE=foo
+export LMOD_ANOTHER_VARIABLE=bar
+export NEW_VAR=new

--- a/lib/spack/spack/test/environment_modifications.py
+++ b/lib/spack/spack/test/environment_modifications.py
@@ -437,3 +437,14 @@ def test_from_environment_diff(before, after, search_list):
 
     for item in search_list:
         assert item in mod
+
+
+@pytest.mark.regression('15775')
+def test_blacklist_lmod_variables():
+    # Construct the list of environment modifications
+    file = os.path.join(datadir, 'sourceme_lmod.sh')
+    env = EnvironmentModifications.from_sourcing_file(file)
+
+    # Check that variables related to lmod are not in there
+    modifications = env.group_by_name()
+    assert not any(x.startswith('LMOD_') for x in modifications)

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -597,7 +597,9 @@ class EnvironmentModifications(object):
             'SHLVL', '_', 'PWD', 'OLDPWD', 'PS1', 'PS2', 'ENV',
             # Environment modules v4
             'LOADEDMODULES', '_LMFILES_', 'BASH_FUNC_module()', 'MODULEPATH',
-            'MODULES_(.*)', r'(\w*)_mod(quar|share)'
+            'MODULES_(.*)', r'(\w*)_mod(quar|share)',
+            # Lmod configuration
+            r'LMOD_(.*)', 'MODULERCFILE'
         ])
 
         # Compute the environments before and after sourcing


### PR DESCRIPTION
fixes #15775

Add all the variables listed [here](https://lmod.readthedocs.io/en/latest/090_configuring_lmod.html) to the list of those blacklisted when constructing environment modifications by sourcing files.