### PR TITLE
AutotoolsPackage: add aclocal for all build deps

### DIFF
--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -219,11 +219,11 @@ class AutotoolsPackage(PackageBase):
             # This line is what is needed most of the time
             # --install, --verbose, --force
             autoreconf_args = ['-ivf']
-            if 'pkgconfig' in spec:
-                autoreconf_args += [
-                    '-I',
-                    os.path.join(spec['pkgconfig'].prefix, 'share', 'aclocal'),
-                ]
+            for dep in spec.dependencies(deptype='build'):
+                if os.path.exists(dep.prefix.share.aclocal):
+                    autoreconf_args.extend([
+                        '-I', dep.prefix.share.aclocal
+                    ])
             autoreconf_args += self.autoreconf_extra_args
             m.autoreconf(*autoreconf_args)
 


### PR DESCRIPTION
During the `autoreconf` phase, we need to explicitly pass a list of directories in which to look for m4 headers. Previously, we only checked for `pkgconfig`, but there are many other packages that provide m4 headers. For example, among the software I currently have installed, I see the following packages with m4 headers:

* automake
* cmake
* freetype
* gettext
* libgpg-error
* libksba
* libassuan
* curl
* libgcrypt
* libtool
* npth
* autoconf-archive

For a concrete example, while working on #15783, autoreconf failed unless autoconf-archive was added. I've also had problems with gettext being missing in the past.