### PR TITLE
Source devnull in environment_after_sourcing_files

### DIFF
--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -602,7 +602,8 @@ class EnvironmentModifications(object):
 
         # Compute the environments before and after sourcing
         before = sanitize(
-            dict(os.environ), blacklist=blacklist, whitelist=whitelist
+            environment_after_sourcing_files(os.devnull, **kwargs),
+            blacklist=blacklist, whitelist=whitelist
         )
         file_and_args = (filename,) + arguments
         after = sanitize(


### PR DESCRIPTION
fixes #15775

`spack.util.environment_after_sourcing_files` compares the local environment against a shell environment after having sourced a file; but this ends up including the default shell profile and rc, which might differ from the local environment.

To change this, compare against the default shell environment, expressed here as (effectively) `source /dev/null`.