### PR TITLE
Don't show warnings for quotes during environment inspection

### DIFF
--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -935,7 +935,10 @@ def environment_after_sourcing_files(*files, **kwargs):
             source_file, suppress_output,
             concatenate_on_success, dump_environment,
         ])
-        output = shell(source_file_arguments, output=str, env=environment)
+        output = shell(
+            source_file_arguments, output=str, env=environment,
+            warn_quotes=False
+        )
         environment = json.loads(output)
 
         # If we're in python2, convert to str objects instead of unicode

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -85,6 +85,8 @@ class Executable(object):
             ignore_errors (int or list): A list of error codes to ignore.
                 If these codes are returned, this process will not raise
                 an exception even if ``fail_on_error`` is set to ``True``
+            warn_quotes (bool): Warn if quotes are present in args. Default
+                ``True``
             input: Where to read stdin from
             output: Where to send stdout
             error: Where to send stderr
@@ -141,15 +143,18 @@ class Executable(object):
         estream, close_estream = streamify(error,  'w')
         istream, close_istream = streamify(input,  'r')
 
-        quoted_args = [arg for arg in args if re.search(r'^"|^\'|"$|\'$', arg)]
-        if quoted_args:
-            tty.warn(
-                "Quotes in command arguments can confuse scripts like"
-                " configure.",
-                "The following arguments may cause problems when executed:",
-                str("\n".join(["    " + arg for arg in quoted_args])),
-                "Quotes aren't needed because spack doesn't use a shell.",
-                "Consider removing them")
+        if kwargs.get('warn_quotes', True):
+            quoted_args = [
+                arg for arg in args if re.search(r'^"|^\'|"$|\'$', arg)]
+            if quoted_args:
+                tty.warn(
+                    "Quotes in command arguments can confuse scripts like"
+                    " configure.",
+                    "The following arguments may cause problems when"
+                    "  executed:",
+                    str("\n".join(["    " + arg for arg in quoted_args])),
+                    "Quotes aren't needed because spack doesn't use a shell.",
+                    "Consider removing them")
 
         cmd = self.exe + list(args)
 


### PR DESCRIPTION
`Executable` looks for arguments that contain quotes and issues a warning if found; but for some internal cases (e.g., running an embedded script with `-c`) quotes are necessary, but still generate warning messages to the end-user.

This adds a `_warn_quotes` kwarg to `Executable.__call__` so that the caller can intentionally opt-out of warnings.