### PR TITLE
Add a gpfs variant to openmpi package

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -239,6 +239,7 @@ class Openmpi(AutotoolsPackage):
     variant('pmi', default=False, description='Enable PMI support')
     variant('cxx', default=False, description='Enable C++ MPI bindings')
     variant('cxx_exceptions', default=False, description='Enable C++ Exception support')
+    variant('gpfs', default=True, description='Enable GPFS support (if present)')
     # Adding support to build a debug version of OpenMPI that activates
     # Memchecker, as described here:
     #
@@ -406,6 +407,11 @@ class Openmpi(AutotoolsPackage):
     def autoreconf(self, spec, prefix):
         perl = which('perl')
         perl('autogen.pl')
+
+    def setup_build_environment(self, env):
+        if '~gpfs' in self.spec:
+            env.set('ac_cv_header_gpfs_h', 'no')
+            env.set('ac_cv_header_gpfs_fcntl_h', 'no')
 
     def configure_args(self):
         spec = self.spec


### PR DESCRIPTION
Open MPI will detect and link against GPFS if it is present on the system. This variant allows this to be disabled, even if GPFS is present.

Closes #15746