### PR TITLE
Hdf5 add variant api

### DIFF
--- a/.github/workflows/linux_build_tests.yaml
+++ b/.github/workflows/linux_build_tests.yaml
@@ -5,6 +5,7 @@ on:
     branches:
     - master
     - develop
+    - hdf5-add-variant-api
   pull_request:
     branches:
     - master

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+
+
 import shutil
 import sys
 

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -236,24 +236,24 @@ class Hdf5(AutotoolsPackage):
         extra_args += self.enable_or_disable('hl')
         extra_args += self.enable_or_disable('fortran')
 
-        # Set the api version 
+        # Set the api version
         if 'api=none' in self.spec:
-            extra_args.append('')
+                extra_args.append('')
 
-	if 'api=v114' in self.spec:
-            extra_args.append('--with-default-api-version=v114')
-	
-	if 'api=v112' in self.spec:
-            extra_args.append('--with-default-api-version=v112')
-        
-	if 'api=v110' in self.spec:
-            extra_args.append('--with-default-api-version=v110')
+        if 'api=v114' in self.spec:
+                extra_args.append('--with-default-api-version=v114')
+
+        if 'api=v112' in self.spec:
+                extra_args.append('--with-default-api-version=v112')
+
+        if 'api=v110' in self.spec:
+                extra_args.append('--with-default-api-version=v110')
 
 	if 'api=v18' in self.spec:
-            extra_args.append('--with-default-api-version=v18')
+                extra_args.append('--with-default-api-version=v18')
 
 	if 'api=v16' in self.spec:
-            extra_args.append('--with-default-api-version=v16')
+                extra_args.append('--with-default-api-version=v16')
 
         if '+szip' in self.spec:
             extra_args.append('--with-szlib=%s' % self.spec['szip'].prefix)

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -60,16 +60,15 @@ class Hdf5(AutotoolsPackage):
     variant('szip', default=False, description='Enable szip support')
     variant('pic', default=True,
             description='Produce position-independent code (for shared libs)')
-            
+
     # Build HDF5 with API compaitibility.
-    variant('api', default='none', description='choose api compatibiity',
-            values=('v114', 'v112', 'v110', 'v18', 'v16'), multi=False)
-    
-    conflicts('api=v114', when='@1.6:1.12.99',msg='v114 is not compatible with this release')
-    conflicts('api=v112', when='@1.6:1.10.99',msg='v112 is not compatible with this release')
-    conflicts('api=v110', when='@1.6:1.8.99',msg='v110 is not compatible with this release')
-    conflicts('api=v18', when='@1.6:1.6.99',msg='v18 is not compatible with this release')
-    
+    variant('api', default='none', description='choose api compatibiity', values=('v114', 'v112', 'v110', 'v18', 'v16'), multi=False)
+
+    conflicts('api=v114', when='@1.6:1.12.99', msg='v114 is not compatible with this release')
+    conflicts('api=v112', when='@1.6:1.10.99', msg='v112 is not compatible with this release')
+    conflicts('api=v110', when='@1.6:1.8.99', msg='v110 is not compatible with this release')
+    conflicts('api=v18', when='@1.6:1.6.99', msg='v18 is not compatible with this release')
+
     depends_on('autoconf', type='build', when='@develop')
     depends_on('automake', type='build', when='@develop')
     depends_on('libtool',  type='build', when='@develop')
@@ -238,22 +237,22 @@ class Hdf5(AutotoolsPackage):
 
         # Set the api version
         if 'api=none' in self.spec:
-                extra_args.append('')
+            extra_args.append('')
 
         if 'api=v114' in self.spec:
-                extra_args.append('--with-default-api-version=v114')
+            extra_args.append('--with-default-api-version=v114')
 
         if 'api=v112' in self.spec:
-                extra_args.append('--with-default-api-version=v112')
+            extra_args.append('--with-default-api-version=v112')
 
         if 'api=v110' in self.spec:
-                extra_args.append('--with-default-api-version=v110')
+            extra_args.append('--with-default-api-version=v110')
 
-	if 'api=v18' in self.spec:
-                extra_args.append('--with-default-api-version=v18')
+        if 'api=v18' in self.spec:
+            extra_args.append('--with-default-api-version=v18')
 
-	if 'api=v16' in self.spec:
-                extra_args.append('--with-default-api-version=v16')
+        if 'api=v16' in self.spec:
+            extra_args.append('--with-default-api-version=v16')
 
         if '+szip' in self.spec:
             extra_args.append('--with-szlib=%s' % self.spec['szip'].prefix)

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -60,7 +60,16 @@ class Hdf5(AutotoolsPackage):
     variant('szip', default=False, description='Enable szip support')
     variant('pic', default=True,
             description='Produce position-independent code (for shared libs)')
-
+            
+    # Build HDF5 with API compaitibility.
+    variant('api', default='none', description='choose api compatibiity',
+            values=('v114', 'v112', 'v110', 'v18', 'v16'), multi=False)
+    
+    conflicts('api=v114', when='@1.6:1.12.99',msg='v114 is not compatible with this release')
+    conflicts('api=v112', when='@1.6:1.10.99',msg='v112 is not compatible with this release')
+    conflicts('api=v110', when='@1.6:1.8.99',msg='v110 is not compatible with this release')
+    conflicts('api=v18', when='@1.6:1.6.99',msg='v18 is not compatible with this release')
+    
     depends_on('autoconf', type='build', when='@develop')
     depends_on('automake', type='build', when='@develop')
     depends_on('libtool',  type='build', when='@develop')
@@ -226,6 +235,25 @@ class Hdf5(AutotoolsPackage):
         extra_args += self.enable_or_disable('cxx')
         extra_args += self.enable_or_disable('hl')
         extra_args += self.enable_or_disable('fortran')
+
+        # Set the api version 
+        if 'api=none' in self.spec:
+            extra_args.append('')
+
+        if 'api=v114' in self.spec:
+            extra_args.append('--with-default-api-version=v114')
+            
+        if 'api=v112' in self.spec:
+            extra_args.append('--with-default-api-version=v112')
+            
+	    if 'api=v110' in self.spec:
+            extra_args.append('--with-default-api-version=v110')
+
+	    if 'api=v18' in self.spec:
+            extra_args.append('--with-default-api-version=v18')
+
+	    if 'api=v16' in self.spec:
+            extra_args.append('--with-default-api-version=v16')
 
         if '+szip' in self.spec:
             extra_args.append('--with-szlib=%s' % self.spec['szip'].prefix)

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -240,19 +240,19 @@ class Hdf5(AutotoolsPackage):
         if 'api=none' in self.spec:
             extra_args.append('')
 
-        if 'api=v114' in self.spec:
+	if 'api=v114' in self.spec:
             extra_args.append('--with-default-api-version=v114')
-            
-        if 'api=v112' in self.spec:
+	
+	if 'api=v112' in self.spec:
             extra_args.append('--with-default-api-version=v112')
-            
-	    if 'api=v110' in self.spec:
+        
+	if 'api=v110' in self.spec:
             extra_args.append('--with-default-api-version=v110')
 
-	    if 'api=v18' in self.spec:
+	if 'api=v18' in self.spec:
             extra_args.append('--with-default-api-version=v18')
 
-	    if 'api=v16' in self.spec:
+	if 'api=v16' in self.spec:
             extra_args.append('--with-default-api-version=v16')
 
         if '+szip' in self.spec:


### PR DESCRIPTION
Added a variant to HDF5 package.py to allow the selection of the API version. 

variant('api', default='none', description='choose api compatibiity',
            values=('v114', 'v112', 'v110', 'v18', 'v16'), multi=False)

"spack install hdf5" will build latest release 1.12.0 with it's default api version v112
"spack install hdf5 api=v110" will build latest release with the v110 api   
 