### PR TITLE
hdf5: prefer version 1.10 for now

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -25,7 +25,10 @@ class Hdf5(AutotoolsPackage):
 
     version('1.12.0', sha256='a62dcb276658cb78e6795dd29bf926ed7a9bc4edf6e77025cd2c689a8f97c17a')
 
-    version('1.10.6', sha256='5f9a3ee85db4ea1d3b1fa9159352aebc2af72732fc2f58c96a3f0768dba0e9aa')
+    # HDF5 1.12 broke API compatibility, so we currently prefer the latest
+    # 1.10 release.  packages that want later versions of HDF5 should specify,
+    # e.g., depends_on("hdf5@1.12:") to get 1.12 or higher.
+    version('1.10.6', sha256='5f9a3ee85db4ea1d3b1fa9159352aebc2af72732fc2f58c96a3f0768dba0e9aa', preferred=True)
     version('1.10.5', sha256='6d4ce8bf902a97b050f6f491f4268634e252a63dadd6656a1a9be5b7b7726fa8')
     version('1.10.4', sha256='8f60dc4dd6ab5fcd23c750d1dc5bca3d0453bdce5c8cdaf0a4a61a9d1122adb2')
     version('1.10.3', sha256='b600d7c914cfa80ae127cd1a1539981213fee9994ac22ebec9e3845e951d9b39')


### PR DESCRIPTION
HDF5 1.12 broke backward compatibility, so we're preferring version 1.10 for now.  Packages that need the new API should specify:

    depends_on("hdf5@1.12:")

to be explicit. We can eventually change the preference, but at the moment most libraries have not udpated to use the new HDF5.