### PR TITLE
fish: add version 3.1.0 and switch to cmake

### DIFF
--- a/var/spack/repos/builtin/packages/fish/package.py
+++ b/var/spack/repos/builtin/packages/fish/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class Fish(AutotoolsPackage):
+class Fish(CMakePackage):
     """fish is a smart and user-friendly command line shell for OS X, Linux, and
     the rest of the family.
     """
@@ -17,7 +17,5 @@ class Fish(AutotoolsPackage):
 
     depends_on('ncurses')
 
+    version('3.1.0', sha256='e5db1e6839685c56f172e1000c138e290add4aa521f187df4cd79d4eab294368')
     version('3.0.0', sha256='ea9dd3614bb0346829ce7319437c6a93e3e1dfde3b7f6a469b543b0d2c68f2cf')
-    version('2.7.1', sha256='e42bb19c7586356905a58578190be792df960fa81de35effb1ca5a5a981f0c5a')
-    version('2.7.0', sha256='3a76b7cae92f9f88863c35c832d2427fb66082f98e92a02203dc900b8fa87bcb')
-    version('2.2.0', sha256='a76339fd14ce2ec229283c53e805faac48c3e99d9e3ede9d82c0554acfc7b77a')


### PR DESCRIPTION
Versions >= 3.1 do not support Autotools. Versions < 3 do not support building with CMake.