### PR TITLE
package: add variant for building hdf5 with static library option

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -63,6 +63,8 @@ class Hdf5(AutotoolsPackage):
     variant('pic', default=True,
             description='Produce position-independent code (for shared libs)')
 
+    conflicts('~static', when='~shared')
+
     depends_on('autoconf', type='build', when='@develop')
     depends_on('automake', type='build', when='@develop')
     depends_on('libtool',  type='build', when='@develop')

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -50,7 +50,7 @@ class Hdf5(AutotoolsPackage):
     variant('shared', default=True,
             description='Builds a shared version of the library')
     variant('static', default=False,
-	    description='Enable static building')
+            description='Enable static building')
 
     variant('hl', default=False, description='Enable the high-level library')
     variant('cxx', default=False, description='Enable C++ support')
@@ -257,8 +257,8 @@ class Hdf5(AutotoolsPackage):
             extra_args.append('--disable-shared')
             extra_args.append('--enable-static-exec')
 
-	if '+static' in self.spec:
-	    extra_args.append('--enable-static')
+        if '+static' in self.spec:
+            extra_args.append('--enable-static')
 
         if '+pic' in self.spec:
             extra_args += ['%s=%s' % (f, self.compiler.pic_flag)

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -49,6 +49,8 @@ class Hdf5(AutotoolsPackage):
             description='Builds a debug version of the library')
     variant('shared', default=True,
             description='Builds a shared version of the library')
+    variant('static', default=False,
+	    description='Enable static building')
 
     variant('hl', default=False, description='Enable the high-level library')
     variant('cxx', default=False, description='Enable C++ support')
@@ -254,6 +256,9 @@ class Hdf5(AutotoolsPackage):
         else:
             extra_args.append('--disable-shared')
             extra_args.append('--enable-static-exec')
+
+	if '+static' in self.spec:
+	    extra_args.append('--enable-static')
 
         if '+pic' in self.spec:
             extra_args += ['%s=%s' % (f, self.compiler.pic_flag)

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -49,7 +49,7 @@ class Hdf5(AutotoolsPackage):
             description='Builds a debug version of the library')
     variant('shared', default=True,
             description='Builds a shared version of the library')
-    variant('static', default=False,
+    variant('static', default=True,
             description='Enable static building')
 
     variant('hl', default=False, description='Enable the high-level library')
@@ -258,7 +258,9 @@ class Hdf5(AutotoolsPackage):
             extra_args.append('--enable-static-exec')
 
         if '+static' in self.spec:
-            extra_args.append('--enable-static')
+            extra_args.append('--enable-static=yes')
+        else:
+            extra_args.append('--enable-static=no')
 
         if '+pic' in self.spec:
             extra_args += ['%s=%s' % (f, self.compiler.pic_flag)


### PR DESCRIPTION
This PR adds a variant to the hdf5 package for building with static libraries enabled. Default behavior is set to false to preserve preexisting behavior. 