### PR TITLE
unqlite: Patching unqlite to be able to build a shared library

### DIFF
--- a/var/spack/repos/builtin/packages/unqlite/0001-Removed-the-STATIC-key-word-to-enable-building-a-sha.patch
+++ b/var/spack/repos/builtin/packages/unqlite/0001-Removed-the-STATIC-key-word-to-enable-building-a-sha.patch
@@ -1,0 +1,26 @@
+From 7c14b18c4967c04344ceba2da90467cd27ee5678 Mon Sep 17 00:00:00 2001
+From: Matthieu Dorier <mdorier@anl.gov>
+Date: Thu, 2 Apr 2020 12:43:19 +0100
+Subject: [PATCH] Removed the STATIC key word to enable building a shared
+ library
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f2bb3cd..efb63a7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -18,7 +18,7 @@ SET(SOURCES_UNQLITE
+ )
+ 
+ SET(UNQLITE_STATIC_LIB unqlite)
+-ADD_LIBRARY(${UNQLITE_STATIC_LIB} STATIC ${HEADERS_UNQLITE} ${SOURCES_UNQLITE})
++ADD_LIBRARY(${UNQLITE_STATIC_LIB} ${HEADERS_UNQLITE} ${SOURCES_UNQLITE})
+ 
+ INSTALL(TARGETS ${UNQLITE_STATIC_LIB} COMPONENT devel ARCHIVE DESTINATION lib)
+ INSTALL(FILES ${HEADERS_UNQLITE} COMPONENT devel DESTINATION include)
+-- 
+2.20.1
+

--- a/var/spack/repos/builtin/packages/unqlite/package.py
+++ b/var/spack/repos/builtin/packages/unqlite/package.py
@@ -20,5 +20,5 @@ class Unqlite(CMakePackage):
     patch('0001-Removed-the-STATIC-key-word-to-enable-building-a-sha.patch')
 
     def cmake_args(self):
-        args = ["-DBUILD_SHARED_LIBS:BOOL=ON" ]
+        args = ["-DBUILD_SHARED_LIBS:BOOL=ON"]
         return args

--- a/var/spack/repos/builtin/packages/unqlite/package.py
+++ b/var/spack/repos/builtin/packages/unqlite/package.py
@@ -16,3 +16,9 @@ class Unqlite(CMakePackage):
 
     version('master', branch='master')
     version('1.1.9', sha256='33d5b5e7b2ca223942e77d31112d2e20512bc507808414451c8a98a7be5e15c0')
+
+    patch('0001-Removed-the-STATIC-key-word-to-enable-building-a-sha.patch')
+
+    def cmake_args(self):
+        args = ["-DBUILD_SHARED_LIBS:BOOL=ON" ]
+        return args

--- a/var/spack/repos/builtin/packages/unqlite/package.py
+++ b/var/spack/repos/builtin/packages/unqlite/package.py
@@ -17,6 +17,8 @@ class Unqlite(CMakePackage):
     version('master', branch='master')
     version('1.1.9', sha256='33d5b5e7b2ca223942e77d31112d2e20512bc507808414451c8a98a7be5e15c0')
 
+    # This patch corresponds to https://github.com/symisc/unqlite/pull/99
+    # It should restricted to @1.1.9 once the PR lands
     patch('0001-Removed-the-STATIC-key-word-to-enable-building-a-sha.patch')
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/unqlite/package.py
+++ b/var/spack/repos/builtin/packages/unqlite/package.py
@@ -18,7 +18,7 @@ class Unqlite(CMakePackage):
     version('1.1.9', sha256='33d5b5e7b2ca223942e77d31112d2e20512bc507808414451c8a98a7be5e15c0')
 
     # This patch corresponds to https://github.com/symisc/unqlite/pull/99
-    # It should restricted to @1.1.9 once the PR lands
+    # It should restricted to @1.1.9 once the PR lands.
     patch('0001-Removed-the-STATIC-key-word-to-enable-building-a-sha.patch')
 
     def cmake_args(self):


### PR DESCRIPTION
This PR adds a patch to unqlite to enable building it a shared library instead of of static one, and adds the necessary cmake_args to build the shared library by default from Spack.