### PR TITLE
qthreads: add additional configuration options

### DIFF
--- a/var/spack/repos/builtin/packages/qthreads/package.py
+++ b/var/spack/repos/builtin/packages/qthreads/package.py
@@ -42,6 +42,7 @@ class Qthreads(AutotoolsPackage):
         multi=False,
         description='Specify which scheduler policy to use')
     variant('static', default=True, description='Build static library')
+    variant('stack_size', default='4096', description='Specify number of bytes to use in a stack. Default is 4096')
 
     depends_on("hwloc@1.0:1.99", when="+hwloc")
 
@@ -63,6 +64,8 @@ class Qthreads(AutotoolsPackage):
         else:
             args.append('--enable-static=no')
 
-        args.append('--with-scheduler=%s', self.spec.variants['scheduler'].value)
+        args.append('--with-default-stack-size=%s' % self.spec.variants['stack_size'].value)
+
+        args.append('--with-scheduler=%s' % self.spec.variants['scheduler'].value)
 
         return args

--- a/var/spack/repos/builtin/packages/qthreads/package.py
+++ b/var/spack/repos/builtin/packages/qthreads/package.py
@@ -33,6 +33,15 @@ class Qthreads(AutotoolsPackage):
         default=True,
         description='hwloc support'
     )
+    variant('spawn_cache',
+            default=True,
+            description='sets if qthreads should use a worker specific cache of spawns')
+    variant('scheduler', default='nemesis',
+        values=('nemesis', 'lifo', 'mutexfifo', 'mtsfifo',
+                'sherwood', 'distrib', 'nottingham'),
+        multi=False,
+        description='Specify which scheduler policy to use')
+    variant('static', default=True, description='Build static library')
 
     depends_on("hwloc@1.0:1.99", when="+hwloc")
 
@@ -45,4 +54,15 @@ class Qthreads(AutotoolsPackage):
                 "--with-hwloc=%s" % spec["hwloc"].prefix]
         else:
             args = ["--with-topology=no"]
+
+        if '~spawn_cache' in self.spec:
+            args.append('--disable-spawn-cache')
+
+        if '+static' in self.spec:
+            args.append('--enable-static=yes')
+        else:
+            args.append('--enable-static=no')
+
+        args.append('--with-scheduler=%s', self.spec.variants['scheduler'].value)
+
         return args


### PR DESCRIPTION
This pr adds variants to the QThreads package for the following:
- disabling spawn cache
- toggling static library building
- specifying scheduling policy
- specifying the default stack size

In all cases default behavior is preserved. 