### PR TITLE
Add command to facilitate easy Spack/Python/OS reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,21 +1,11 @@
 ---
-name: "\U0001F41E Bug report" 
-about: Report a bug in the core of Spack (command not working as expected, etc.) 
+name: "\U0001F41E Bug report"
+about: Report a bug in the core of Spack (command not working as expected, etc.)
 labels: "bug,triage"
 ---
 
-<!--
-*Explain, in a clear and concise way, the command you ran and the result you were trying to achieve.
-Example: "I ran Spack find to list all the installed packages and..."*
--->
-
-
-### Spack version
-<!-- Add the output to the command below -->
-```console
-$ spack --version
-
-```
+<!-- Explain, in a clear and concise way, the command you ran and the result you were trying to achieve.
+Example: "I ran `spack find` to list all the installed packages and ..." -->
 
 ### Steps to reproduce the issue
 
@@ -27,38 +17,34 @@ $ spack <command2> <spec>
 
 ### Error Message
 
-<!--If Spack reported an error, provide the error message. If it did not report an error
-but the output appears incorrect, provide the incorrect output. If there was no error
-message and no output but the result is incorrect, describe how it does not match
-what you expect. To provide more information you might re-run the commands with 
-the additional -d/--stacktrace flags:
+<!-- If Spack reported an error, provide the error message. If it did not report an error but the output appears incorrect, provide the incorrect output. If there was no error message and no output but the result is incorrect, describe how it does not match what you expect. -->
 ```console
-$ spack -d --stacktrace <command1> <spec>
-$ spack -d --stacktrace <command2> <spec>
-...
+$ spack --debug --stacktrace <command>
 ```
-that activate the full debug output. 
--->
 
 ### Information on your system
-<!--
-This includes:
 
- 1. which platform you are using
- 2. any relevant configuration detail (custom `packages.yaml` or `modules.yaml`, etc.)
+<!-- Please include the output of the following commands: -->
+```console
+$ spack --version
 
--->
+$ spack python --version
 
-### General information
+$ spack arch
 
+```
+
+<!-- If you have any relevant configuration detail (custom `packages.yaml` or `modules.yaml`, etc.) you can add that here as well. -->
+
+### Additional information
+
+<!-- These boxes can be checked by replacing [ ] with [x] or by clicking them after submitting the issue. -->
 - [ ] I have run `spack --version` and reported the version of Spack
 - [ ] I have searched the issues of this repo and believe this is not a duplicate
 - [ ] I have run the failing commands in debug mode and reported the output
 
-<!--
-We encourage you to try, as much as possible, to reduce your problem to the minimal example that still reproduces the issue. That would help us a lot in fixing it quickly and effectively!
+<!-- We encourage you to try, as much as possible, to reduce your problem to the minimal example that still reproduces the issue. That would help us a lot in fixing it quickly and effectively!
 
 If you want to ask a question about the tool (how to use it, what it can currently do, etc.), try the `#general` channel on our Slack first. We have a welcoming community and chances are you'll get your reply faster and without opening an issue.
 
-Other than that, thanks for taking the time to contribute to Spack!
--->
+Other than that, thanks for taking the time to contribute to Spack! -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -31,7 +31,7 @@ $ spack --debug --stacktrace <command>
 ### Additional information
 
 <!-- These boxes can be checked by replacing [ ] with [x] or by clicking them after submitting the issue. -->
-- [ ] I have run `spack --version` and reported the version of Spack
+- [ ] I have run `spack debug report` and reported the version of Spack/Python/Platform
 - [ ] I have searched the issues of this repo and believe this is not a duplicate
 - [ ] I have run the failing commands in debug mode and reported the output
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,15 +24,7 @@ $ spack --debug --stacktrace <command>
 
 ### Information on your system
 
-<!-- Please include the output of the following commands: -->
-```console
-$ spack --version
-
-$ spack python --version
-
-$ spack arch
-
-```
+<!-- Please include the output of `spack debug report` -->
 
 <!-- If you have any relevant configuration detail (custom `packages.yaml` or `modules.yaml`, etc.) you can add that here as well. -->
 

--- a/lib/spack/spack/cmd/debug.py
+++ b/lib/spack/spack/cmd/debug.py
@@ -88,6 +88,7 @@ def report(args):
     print('* **Platform:**', architecture.Arch(
         architecture.platform(), 'frontend', 'frontend'))
 
+
 def debug(parser, args):
     action = {
         'create-db-tarball': create_db_tarball,

--- a/lib/spack/spack/cmd/debug.py
+++ b/lib/spack/spack/cmd/debug.py
@@ -83,9 +83,9 @@ def create_db_tarball(args):
 
 
 def report(args):
-    print('* Spack:', get_version())
-    print('* Python:', platform.python_version())
-    print('* Platform:', architecture.Arch(
+    print('* **Spack:**', get_version())
+    print('* **Python:**', platform.python_version())
+    print('* **Platform:**', architecture.Arch(
         architecture.platform(), 'frontend', 'frontend'))
 
 def debug(parser, args):

--- a/lib/spack/spack/cmd/debug.py
+++ b/lib/spack/spack/cmd/debug.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import platform
 import re
 from datetime import datetime
 from glob import glob
@@ -11,7 +12,9 @@ from glob import glob
 import llnl.util.tty as tty
 from llnl.util.filesystem import working_dir
 
+import spack.architecture as architecture
 import spack.paths
+from spack.main import get_version
 from spack.util.executable import which
 
 description = "debugging commands for troubleshooting Spack"
@@ -23,6 +26,7 @@ def setup_parser(subparser):
     sp = subparser.add_subparsers(metavar='SUBCOMMAND', dest='debug_command')
     sp.add_parser('create-db-tarball',
                   help="create a tarball of Spack's installation metadata")
+    sp.add_parser('report', help='print information useful for bug reports')
 
 
 def _debug_tarball_suffix():
@@ -78,6 +82,15 @@ def create_db_tarball(args):
     tty.msg('Created %s' % tarball_name)
 
 
+def report(args):
+    print('* Spack:', get_version())
+    print('* Python:', platform.python_version())
+    print('* Platform:', architecture.Arch(
+        architecture.platform(), 'frontend', 'frontend'))
+
 def debug(parser, args):
-    action = {'create-db-tarball': create_db_tarball}
+    action = {
+        'create-db-tarball': create_db_tarball,
+        'report': report,
+    }
     action[args.debug_command](args)

--- a/lib/spack/spack/cmd/debug.py
+++ b/lib/spack/spack/cmd/debug.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from __future__ import print_function
+
 import os
 import platform
 import re

--- a/lib/spack/spack/cmd/python.py
+++ b/lib/spack/spack/cmd/python.py
@@ -21,6 +21,9 @@ level = "long"
 
 def setup_parser(subparser):
     subparser.add_argument(
+        '-V', '--version', action='store_true',
+        help='print the Python version number and exit')
+    subparser.add_argument(
         '-c', dest='python_command', help='command to execute')
     subparser.add_argument(
         '-m', dest='module', action='store',
@@ -31,6 +34,10 @@ def setup_parser(subparser):
 
 
 def python(parser, args, unknown_args):
+    if args.version:
+        print('Python', platform.python_version())
+        return
+
     if args.module:
         sys.argv = ['spack-python'] + unknown_args + args.python_args
         runpy.run_module(args.module, run_name="__main__", alter_sys=True)

--- a/lib/spack/spack/cmd/python.py
+++ b/lib/spack/spack/cmd/python.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from __future__ import print_function
+
 import os
 import sys
 import code

--- a/lib/spack/spack/test/cmd/debug.py
+++ b/lib/spack/spack/test/cmd/debug.py
@@ -3,12 +3,15 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import platform
+
 import pytest
 
 import os
 import os.path
 
-from spack.main import SpackCommand
+import spack.architecture as architecture
+from spack.main import SpackCommand, get_version
 from spack.util.executable import which
 
 debug = SpackCommand('debug')
@@ -41,3 +44,12 @@ def test_create_db_tarball(tmpdir, database):
 
             spec_suffix = '%s/.spack/spec.yaml' % spec.dag_hash()
             assert spec_suffix in contents
+
+
+def test_report():
+    out = debug('report')
+    arch = architecture.Arch(architecture.platform(), 'frontend', 'frontend')
+
+    assert get_version() in out
+    assert platform.python_version() in out
+    assert str(arch) in out

--- a/lib/spack/spack/test/cmd/python.py
+++ b/lib/spack/spack/test/cmd/python.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import platform
+
 import pytest
 
 import spack
@@ -14,6 +16,11 @@ python = SpackCommand('python')
 def test_python():
     out = python('-c', 'import spack; print(spack.spack_version)')
     assert out.strip() == spack.spack_version
+
+
+def test_python_version():
+    out = python('-V')
+    assert platform.python_version() in out
 
 
 def test_python_with_module():

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -655,11 +655,15 @@ _spack_debug() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="create-db-tarball"
+        SPACK_COMPREPLY="create-db-tarball report"
     fi
 }
 
 _spack_debug_create_db_tarball() {
+    SPACK_COMPREPLY="-h --help"
+}
+
+_spack_debug_report() {
     SPACK_COMPREPLY="-h --help"
 }
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1272,7 +1272,7 @@ _spack_pydoc() {
 _spack_python() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -c -m"
+        SPACK_COMPREPLY="-h --help -V --version -c -m"
     else
         SPACK_COMPREPLY=""
     fi


### PR DESCRIPTION
This flag will help us diagnose bug reports. It's more reliable than asking users to run `python --version`, as Spack includes magic to use Python 3 automatically if the `python3` executable is found.