### PR TITLE
mpip: add demangling and setjmp variants

### DIFF
--- a/var/spack/repos/builtin/packages/mpip/package.py
+++ b/var/spack/repos/builtin/packages/mpip/package.py
@@ -17,7 +17,10 @@ class Mpip(AutotoolsPackage):
     version("3.4.1", sha256="688bf37d73211e6a915f9fc59c358282a266d166c0a10af07a38a01a473296f0")
 
     variant('shared', default=False, description="Build the shared library")
-    variant('demangling', default=False)
+    variant('demangling', default=False, description="Build with demangling support")
+    variant('setjmp',
+            default=False,
+            description="Use setjmp instead of glic backtrace() to generate stack traces")
 
     depends_on("elf")
     depends_on("libdwarf")
@@ -41,5 +44,10 @@ class Mpip(AutotoolsPackage):
             config_args.append('--enable-demangling')
         else:
             config_args.append('--disable-demangling')
+
+        if '+setjmp' in self.spec:
+            config_args.append('--enable-setjmp')
+        else:
+            config_args.append('--disable-setjmp')
 
         return config_args

--- a/var/spack/repos/builtin/packages/mpip/package.py
+++ b/var/spack/repos/builtin/packages/mpip/package.py
@@ -20,7 +20,7 @@ class Mpip(AutotoolsPackage):
     variant('demangling', default=False, description="Build with demangling support")
     variant('setjmp',
             default=False,
-            description="Use setjmp instead of glic backtrace() to generate stack traces")
+            description="Replace glic backtrace() with setjmp for stack trace")
 
     depends_on("elf")
     depends_on("libdwarf")

--- a/var/spack/repos/builtin/packages/mpip/package.py
+++ b/var/spack/repos/builtin/packages/mpip/package.py
@@ -17,6 +17,7 @@ class Mpip(AutotoolsPackage):
     version("3.4.1", sha256="688bf37d73211e6a915f9fc59c358282a266d166c0a10af07a38a01a473296f0")
 
     variant('shared', default=False, description="Build the shared library")
+    variant('demangling', default=False)
 
     depends_on("elf")
     depends_on("libdwarf")
@@ -35,5 +36,10 @@ class Mpip(AutotoolsPackage):
         config_args = ['--without-f77']
         config_args.append("--with-cc=%s" % self.spec['mpi'].mpicc)
         config_args.append("--with-cxx=%s" % self.spec['mpi'].mpicxx)
+
+        if '+demangling' in self.spec:
+            config_args.append('--enable-demangling')
+        else:
+            config_args.append('--disable-demangling')
 
         return config_args


### PR DESCRIPTION
Adds variants for enabling/disabling demangling and setjmp. Preexisting behavior is preserved in default settings. 