### PR TITLE
pdt: add PIC support as variant

### DIFF
--- a/var/spack/repos/builtin/packages/pdt/package.py
+++ b/var/spack/repos/builtin/packages/pdt/package.py
@@ -30,6 +30,8 @@ class Pdt(AutotoolsPackage):
     version('3.19',   sha256='d57234077e2e999f2acf9860ea84369a4694b50cc17fa6728e5255dc5f4a2160')
     version('3.18.1', sha256='d06c2d1793fadebf169752511e5046d7e02cf3fead6135a35c34b1fee6d6d3b2')
 
+    variant('pic', default=False, description="Builds with pic")
+
     def patch(self):
         if self.spec.satisfies('%clang'):
             filter_file(r'PDT_GXX=g\+\+ ',
@@ -49,6 +51,9 @@ class Pdt(AutotoolsPackage):
             options.append('-clang')
         else:
             raise InstallError('Unknown/unsupported compiler family')
+
+        if '+pic' in spec:
+            options.append('-useropt=-fPIC')
 
         configure(*options)
 

--- a/var/spack/repos/builtin/packages/pdt/package.py
+++ b/var/spack/repos/builtin/packages/pdt/package.py
@@ -53,7 +53,7 @@ class Pdt(AutotoolsPackage):
             raise InstallError('Unknown/unsupported compiler family')
 
         if '+pic' in spec:
-            options.append('-useropt=-fPIC')
+            options.append('-useropt=' + self.compiler.pic_flag)
 
         configure(*options)
 


### PR DESCRIPTION
Adds variant to pdt for building with pic support. As far as I could tell there was no way to explicitly disable this, only explicitly turn it on so there is no disabling in an else statement. 