### PR TITLE
Package rename: intel-mkl-dnn -> dnnl

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -154,7 +154,7 @@ class PyTorch(PythonPackage, CudaPackage):
     # TODO: See if there is a way to use an external mkldnn installation.
     # Currently, only older versions of py-torch use an external mkldnn
     # library.
-    depends_on('intel-mkl-dnn', when='@0.4:0.4.1+mkldnn')
+    depends_on('dnnl', when='@0.4:0.4.1+mkldnn')
     # TODO: add dependency: https://github.com/Maratyszcza/NNPACK
     # depends_on('nnpack', when='+nnpack')
     depends_on('qnnpack', when='+qnnpack')


### PR DESCRIPTION
This PR includes the following changes:

- [x] Intel MKL DNN was renamed to DNNL
- [x] Variants were added to control CPU/GPU runtimes
- [x] Intel MKL dependency was removed
- [x] macOS builds TBB by default instead of OpenMP

The previous package built fine, but a few of the unit tests were failing (see https://github.com/intel/mkl-dnn/issues/680). With the TBB runtime, all tests pass on macOS 10.15.4 with Clang 11.0.3.

@rsdubtso Thanks for your help in debugging this! If you see anything else in our package that should be changed, let me know. Also, if you or any other DNNL devs would like to be added as "maintainers" of this package, let me know. You don't have to be Spack experts, it just gives us someone to ping when a user encounters build issues or someone submits a PR to change the Spack package and we need reviewers.