### PR TITLE
Simplify Build Error template

### DIFF
--- a/.github/ISSUE_TEMPLATE/build_error.md
+++ b/.github/ISSUE_TEMPLATE/build_error.md
@@ -1,89 +1,43 @@
 ---
-name: "\U0001F4A5 Build error" 
-about: Some package in Spack didn't build correctly  
+name: "\U0001F4A5 Build error"
+about: Some package in Spack didn't build correctly
+title: "Installation issue: "
 labels: "build-error"
 ---
 
-<!--*Thanks for taking the time to report this build failure. To proceed with the
-report please:*
+<!-- Thanks for taking the time to report this build failure. To proceed with the report please:
+
 1. Title the issue "Installation issue: <name-of-the-package>".
 2. Provide the information required below.
 
-We encourage you to try, as much as possible, to reduce your problem to the minimal example that still reproduces the issue. That would help us a lot in fixing it quickly and effectively!
--->
-
-
-### Spack version
-<!-- Add the output to the command below -->
-```console
-$ spack --version
-
-```
+We encourage you to try, as much as possible, to reduce your problem to the minimal example that still reproduces the issue. That would help us a lot in fixing it quickly and effectively! -->
 
 ### Steps to reproduce the issue
 
+<!-- Fill in the exact spec you are trying to build and the relevant part of the error message -->
 ```console
-$ spack install <spec> # Fill in the exact spec you are using
-... # and the relevant part of the error message
+$ spack install <spec>
+...
 ```
 
-### Platform and user environment
+### Information on your system
 
-<!-- Please report your OS here:
-```commandline
-$ uname -a 
-Linux nuvolari 4.15.0-29-generic #31-Ubuntu SMP Tue Jul 17 15:39:52 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
-$ lsb_release -d
-Description:	Ubuntu 18.04.1 LTS
-``` 
-and, if relevant, post or attach:
+<!-- Please include the output of `spack debug report` -->
 
-- `packages.yaml`
-- `compilers.yaml`
-
-to the issue
--->
+<!-- If you have any relevant configuration detail (custom `packages.yaml` or `modules.yaml`, etc.) you can add that here as well. -->
 
 ### Additional information
 
-<!--Sometimes the issue benefits from additional details. In these cases there are
-a few things we can suggest doing. First of all, you can post the full output of:
-```console
-$ spack spec --install-status <spec>
-...
-```
-to show people whether Spack installed a faulty software or if it was not able to
-build it at all. 
+<!-- Please upload the following files. They should be present in the stage directory of the failing build. Also upload any config.log or similar file if one exists. -->
+* [spack-build-out.txt]()
+* [spack-build-env.txt]()
 
-If your build didn't make it past the configure stage, Spack as also commands to parse 
-logs and report error and warning messages:
-```console
-$ spack log-parse --show=errors,warnings <file-to-parse>
-```
-You might want to run this command on the `config.log` or any other similar file
-found in the stage directory: 
-```console
-$ spack location -s <spec>
-```
-In case in `config.log` there are other settings that you think might be the cause 
-of the build failure, you can consider attaching the file to this issue.
-
-Rebuilding the package with the following options:
-```console
-$ spack -d install -j 1 <spec>
-...
-```
-will provide additional debug information. After the failure you will find two files in the current directory:
-
-1. `spack-cc-<spec>.in`, which contains details on the command given in input 
-    to Spack's compiler wrapper  
-1. `spack-cc-<spec>.out`, which contains the command used to compile / link the 
-    failed object after Spack's compiler wrapper did its processing 
-
-You can post or attach those files to provide maintainers with more information on what
-is causing the failure.-->
+<!-- Some packages have maintainers who have volunteered to debug build failures. Run `spack maintainers <name-of-the-package>` and @mention them here if they exist. -->
 
 ### General information
 
-- [ ] I have run `spack --version` and reported the version of Spack
+<!-- These boxes can be checked by replacing [ ] with [x] or by clicking them after submitting the issue. -->
+- [ ] I have run `spack debug report` and reported the version of Spack/Python/Platform
+- [ ] I have run `spack maintainers <name-of-the-package>` and @mentioned any maintainers
+- [ ] I have uploaded the build log and environment files
 - [ ] I have searched the issues of this repo and believe this is not a duplicate


### PR DESCRIPTION
This PR simplifies the template that describes the process of reporting a build error for a Spack package. It removes a lot of debugging things that I don't believe are particularly useful, and adds several new things. The simpler the process is, the more likely users are to fill in the template instead of ignoring it.

- [x] Add an initial title to make sure things stay uniform
- [x] Replace `spack --version` with the new `spack debug report`
- [x] Request that users upload `spack-build-out.txt` and `spack-build-env.txt`
- [x] Request that users @mention maintainers