### PR TITLE
verify `other.exe` attr exists before use in __eq__

### DIFF
--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -209,7 +209,7 @@ class Executable(object):
                 istream.close()
 
     def __eq__(self, other):
-        return self.exe == other.exe
+        return hasattr(other, 'exe') and self.exe == other.exe
 
     def __neq__(self, other):
         return not (self == other)


### PR DESCRIPTION
Sphinx 3.0 inspects signatures for type hints, and when doing so will error on this method.  Thanks for spotting this quickly @adamjstewart.