### PR TITLE
boost: boost-python in 1.72.0 broken with cxxstd=98

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -178,6 +178,9 @@ class Boost(Package):
     conflicts('+taggedlayout', when='+versionedlayout')
     conflicts('+numpy', when='~python')
 
+    # boost-python in 1.72.0 broken with cxxstd=98
+    conflicts('cxxstd=98', when='+mpi+python @1.72.0:')
+
     # Container's Extended Allocators were not added until 1.56.0
     conflicts('+container', when='@:1.55.99')
 

--- a/var/spack/repos/builtin/packages/py-espressopp/package.py
+++ b/var/spack/repos/builtin/packages/py-espressopp/package.py
@@ -27,7 +27,7 @@ class PyEspressopp(CMakePackage):
 
     depends_on("cmake@2.8:", type='build')
     depends_on("mpi")
-    depends_on("boost+serialization+filesystem+system+python+mpi", when='@1.9.4:')
+    depends_on("boost+serialization+filesystem+system+python+mpi cxxstd=11", when='@1.9.4:')
     extends("python")
     depends_on("python@2:2.8")
     depends_on("py-mpi4py@2.0.0:", when='@1.9.4', type=('build', 'run'))


### PR DESCRIPTION
Also reported in https://github.com/espressopp/espressopp/issues/300#issuecomment-609449146
Fix #15869 