### PR TITLE
NAG compiler fix: skip implicit RPATH detection

### DIFF
--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -250,13 +250,13 @@ class Compiler(object):
     PrgEnv_compiler = None
 
     def __init__(self, cspec, operating_system, target,
-                 paths, modules=[], alias=None, environment=None,
+                 paths, modules=None, alias=None, environment=None,
                  extra_rpaths=None, enable_implicit_rpaths=None,
                  **kwargs):
         self.spec = cspec
         self.operating_system = str(operating_system)
         self.target = target
-        self.modules = modules
+        self.modules = modules or []
         self.alias = alias
         self.extra_rpaths = extra_rpaths
         self.enable_implicit_rpaths = enable_implicit_rpaths

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -317,6 +317,10 @@ class Compiler(object):
         first_compiler = next((c for c in paths if c), None)
         if not first_compiler:
             return []
+        if not cls.verbose_flag():
+            # In this case there is no mechanism to learn what link directories
+            # are used by the compiler
+            return []
 
         try:
             tmpdir = tempfile.mkdtemp(prefix='spack-implicit-link-info')


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/15776

Skip collection of compiler link paths if compiler does not define a verbose flag. This includes NAG.

`verbose_flag()` is not implemented for the NAG compiler in Spack. It is possible that `-V` is the appropriate choice for this. Since link-path detection logic involves compiling a C file, I'm not sure if it should be run at all if the available exe is meant for compiling Fortran.