### PR TITLE
openfoam: modified flex to be a build + link dependency

### DIFF
--- a/var/spack/repos/builtin/packages/openfoam-org/package.py
+++ b/var/spack/repos/builtin/packages/openfoam-org/package.py
@@ -84,7 +84,7 @@ class OpenfoamOrg(Package):
 
     depends_on('mpi')
     depends_on('zlib')
-    depends_on('flex',  type='build')
+    depends_on('flex')
     depends_on('cmake', type='build')
 
     # Require scotch with ptscotch - corresponds to standard OpenFOAM setup


### PR DESCRIPTION
fixes #15863

Since `openfoam-org` needs "FlexInclude.h" `flex` needs to be also a link dependency.