### PR TITLE
cryptsetup: restrict the version of automake if @2.2.1

### DIFF
--- a/var/spack/repos/builtin/packages/cryptsetup/package.py
+++ b/var/spack/repos/builtin/packages/cryptsetup/package.py
@@ -34,7 +34,7 @@ class Cryptsetup(AutotoolsPackage):
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
 
-    depends_on('automake@:1.16.1', when='@2.2.1')
+    depends_on('automake@:1.16.1', when='@2.2.1', type='build')
 
     # Upstream includes support for discovering the location of the libintl
     # library but is missing the bit in the Makefile.ac that includes it in

--- a/var/spack/repos/builtin/packages/cryptsetup/package.py
+++ b/var/spack/repos/builtin/packages/cryptsetup/package.py
@@ -34,6 +34,8 @@ class Cryptsetup(AutotoolsPackage):
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
 
+    depends_on('automake@:1.16.1', when='@2.2.1')
+
     # Upstream includes support for discovering the location of the libintl
     # library but is missing the bit in the Makefile.ac that includes it in
     # the LDFLAGS. See https://gitlab.com/cryptsetup/cryptsetup/issues/479


### PR DESCRIPTION
fixes #15706