### PR TITLE
Bugfix: config:install_hash_length ignored

### DIFF
--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -190,6 +190,7 @@ class YamlDirectoryLayout(DirectoryLayout):
             "{architecture}/"
             "{compiler.name}-{compiler.version}/"
             "{name}-{version}-{hash}")
+        self.path_scheme = self.path_scheme.lower()
         if self.hash_len is not None:
             if re.search(r'{hash:\d+}', self.path_scheme):
                 raise InvalidDirectoryLayoutParametersError(

--- a/lib/spack/spack/test/config_values.py
+++ b/lib/spack/spack/test/config_values.py
@@ -1,0 +1,41 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import spack.spec
+
+def test_set_install_hash_length(mock_packages, mutable_config, monkeypatch):
+    # spack.store.layout caches initial config values, so we monkeypatch
+    mutable_config.set('config:install_hash_length', 5)
+    monkeypatch.setattr(spack.store, 'store', spack.store._store())
+
+    spec = spack.spec.Spec('libelf').concretized()
+    prefix = spec.prefix
+    hash = prefix.rsplit('-')[-1]
+
+    assert len(hash) == 5
+
+    mutable_config.set('config:install_hash_length', 9)
+    monkeypatch.setattr(spack.store, 'store', spack.store._store())
+
+    spec = spack.spec.Spec('libelf').concretized()
+    prefix = spec.prefix
+    hash = prefix.rsplit('-')[-1]
+
+    assert len(hash) == 9
+
+
+
+def test_set_install_hash_length_upper_case(mock_packages, mutable_config,
+                                            monkeypatch):
+    # spack.store.layout caches initial config values, so we monkeypatch
+    mutable_config.set('config:install_path_scheme', '{name}-{HASH}')
+    mutable_config.set('config:install_hash_length', 5)
+    monkeypatch.setattr(spack.store, 'store', spack.store._store())
+
+    spec = spack.spec.Spec('libelf').concretized()
+    prefix = spec.prefix
+    hash = prefix.rsplit('-')[-1]
+
+    assert len(hash) == 5

--- a/lib/spack/spack/test/config_values.py
+++ b/lib/spack/spack/test/config_values.py
@@ -5,6 +5,7 @@
 
 import spack.spec
 
+
 def test_set_install_hash_length(mock_packages, mutable_config, monkeypatch):
     # spack.store.layout caches initial config values, so we monkeypatch
     mutable_config.set('config:install_hash_length', 5)
@@ -24,7 +25,6 @@ def test_set_install_hash_length(mock_packages, mutable_config, monkeypatch):
     hash = prefix.rsplit('-')[-1]
 
     assert len(hash) == 9
-
 
 
 def test_set_install_hash_length_upper_case(mock_packages, mutable_config,


### PR DESCRIPTION
Bug report from slack:

> Hi All,
> I've set: `install_hash_length: 4` in my config.yaml, yet when I install software, Spack still uses the full length hash.  This is correctly picked up when I type: `spack config get config`
>
> I know that UI can use the alternate method: `install_path_scheme: '{name}/{version}/{hash:7}'` but just thought I'd ask to see if anyone else had noticed this?
>
> (I'm using 0.14.1)

This bug was caused by comparing a value that is case-insensitive against a lower-case string. This PR fixes it and adds testing.

Developer note: This PR adds a new testing file `lib/spack/spack/test/config_values.py` for testing that configuration values are picked up properly. The existing `lib/spack/spack/test/config.py` is focused on the internal functions of the config system, so I thought separating them was appropriate.