### PR TITLE
Fix lua build, missing deref of self for spec

### DIFF
--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -139,7 +139,7 @@ class Lua(Package):
 
         if dependent_spec.package.extends(self.spec):
             env.prepend_path('LUA_PATH', ';'.join(lua_patterns), separator=';')
-            if '+shared' in spec:
+            if '+shared' in self.spec:
                 env.prepend_path('LUA_CPATH', ';'.join(lua_cpatterns),
                                  separator=';')
 


### PR DESCRIPTION
Looks like something changed and a case was missed.

Function doesn't have a spec arg, need to dereference it off of
self.

Builds on OS X.