### PR TITLE
F18 update April 2020

### DIFF
--- a/var/spack/repos/builtin/packages/f18/package.py
+++ b/var/spack/repos/builtin/packages/f18/package.py
@@ -21,9 +21,12 @@ class F18(CMakePackage):
             description='The build type to build',
             values=('Debug', 'Release', 'RelWithDebInfo'))
 
+    variant('fir', default='False', description='Build with support for FIR')
+
     # Dependencies
     depends_on('cmake@3.9.0:', type='build')
-    depends_on('llvm+clang@7:')
+    depends_on('llvm+clang@9:', when='~fir')
+    depends_on('llvm+clang+mlir@10:', when='+fir')
 
     # Conflicts
     compiler_warning = 'F18 requires a compiler with support for C++17'

--- a/var/spack/repos/builtin/packages/f18/package.py
+++ b/var/spack/repos/builtin/packages/f18/package.py
@@ -34,3 +34,20 @@ class F18(CMakePackage):
     conflicts('%gcc@:7.1', msg=compiler_warning)
     conflicts('%intel', msg=compiler_warning)
     conflicts('%pgi', msg=compiler_warning)
+
+    def cmake_args(self):
+        spec = self.spec
+        args = ['-DLLVM_DIR=%s' % self.spec['llvm'].prefix.lib.cmake.llvm]
+        # Tests have linking errors with older compilers (before GCC 8.x).
+        # Don't build tests for now.
+        # https://bugs.llvm.org/show_bug.cgi?id=45463
+        args.append('-DFLANG_INCLUDE_TESTS:BOOL=OFF')
+
+        if '+fir' in spec:
+            args.append('-DLINK_WITH_FIR:BOOL=ON')
+            args.append(
+                '-DMLIR_DIR=%s' % self.spec['llvm'].prefix.lib.cmake.mlir)
+        else:
+            args.append('-DLINK_WITH_FIR:BOOL=OFF')
+
+        return args

--- a/var/spack/repos/builtin/packages/f18/package.py
+++ b/var/spack/repos/builtin/packages/f18/package.py
@@ -26,7 +26,7 @@ class F18(CMakePackage):
     # Dependencies
     depends_on('cmake@3.9.0:', type='build')
     depends_on('llvm+clang@9:', when='~fir')
-    depends_on('llvm+clang+mlir@10:', when='+fir')
+    depends_on('llvm+clang+mlir@10.0.1:', when='+fir')
 
     # Conflicts
     compiler_warning = 'F18 requires a compiler with support for C++17'

--- a/var/spack/repos/builtin/packages/f18/package.py
+++ b/var/spack/repos/builtin/packages/f18/package.py
@@ -41,7 +41,10 @@ class F18(CMakePackage):
         # Tests have linking errors with older compilers (before GCC 8.x).
         # Don't build tests for now.
         # https://bugs.llvm.org/show_bug.cgi?id=45463
-        args.append('-DFLANG_INCLUDE_TESTS:BOOL=OFF')
+        if self.run_tests:
+            args.append('-DFLANG_INCLUDE_TESTS:BOOL=ON')
+        else:
+            args.append('-DFLANG_INCLUDE_TESTS:BOOL=OFF')
 
         if '+fir' in spec:
             args.append('-DLINK_WITH_FIR:BOOL=ON')


### PR DESCRIPTION
@trws 

Most likely this will be the last update to `f18` before it gets merged into `llvm.`

Changes included are:
- Update LLVM dependencies
- Support FIR
- Workaround for flang test failure