### PR TITLE
py-onnx: only use py-typing if python < 3.5

### DIFF
--- a/var/spack/repos/builtin/packages/py-onnx/package.py
+++ b/var/spack/repos/builtin/packages/py-onnx/package.py
@@ -17,8 +17,9 @@ class PyOnnx(PythonPackage):
        on the capabilities needed for inferencing (scoring)."""
 
     homepage = "https://github.com/onnx/onnx"
-    url      = "https://pypi.io/packages/source/O/Onnx/onnx-1.5.0.tar.gz"
+    url      = "https://pypi.io/packages/source/O/Onnx/onnx-1.6.0.tar.gz"
 
+    version('1.6.0', sha256='3b88c3fe521151651a0403c4d131cb2e0311bd28b753ef692020a432a81ce345')
     version('1.5.0', sha256='1a584a4ef62a6db178c257fffb06a9d8e61b41c0a80bfd8bcd8a253d72c4b0b4')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-onnx/package.py
+++ b/var/spack/repos/builtin/packages/py-onnx/package.py
@@ -26,7 +26,7 @@ class PyOnnx(PythonPackage):
     depends_on('py-protobuf+cpp', type=('build', 'run'))
     depends_on('py-numpy', type=('build', 'run'))
     depends_on('py-six', type=('build', 'run'))
-    depends_on('py-typing@3.6.4:', type=('build', 'run'))
+    depends_on('py-typing@3.6.4:', when='^python@:3.4.999', type=('build', 'run'))
     depends_on('py-typing-extensions@3.6.4:', type=('build', 'run'))
     depends_on('cmake@3.1:', type='build')
 


### PR DESCRIPTION
avoids a 'Callable has no attribute __abc_registry' error. See
onnx/onnx#2199 and python/typing#573