### PR TITLE
Debugging: package gets incorrect patch

### DIFF
--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -247,6 +247,9 @@ class UrlPatch(Patch):
 
         self._stage = spack.stage.Stage(fetcher, mirror_paths=mirror_ref)
         self._stage.create()
+        if os.listdir(self._stage.path):
+            tty.warn("[Issue:15780] This directory should be empty: "
+                     + str(self._stage.path))
         return self._stage
 
     def clean(self):

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -286,6 +286,10 @@ class Stage(object):
         self.name = name
         if name is None:
             self.name = stage_prefix + next(tempfile._get_candidate_names())
+            tty.debug(
+                "[Issue:15780] {0}".format(str(url_or_fetch_strategy)))
+            tty.debug(
+                "[Issue:15780] {0}".format(str(id(self))))
         self.mirror_paths = mirror_paths
 
         # Use the provided path or construct an optionally named stage path.


### PR DESCRIPTION
This is intended for debugging https://github.com/spack/spack/issues/15780

It includes statements to keep track of stages and check whether different patches are being placed in the same stage directory.