### PR TITLE
Update hugo version and add extended variant

### DIFF
--- a/var/spack/repos/builtin/packages/hugo/package.py
+++ b/var/spack/repos/builtin/packages/hugo/package.py
@@ -13,14 +13,21 @@ class Hugo(Package):
     homepage = "https://gohugo.io"
     url      = "https://github.com/gohugoio/hugo/archive/v0.53.tar.gz"
 
+    version('0.68.3', sha256='38e743605e45e3aafd9563feb9e78477e72d79535ce83b56b243ff991d3a2b6e')
     version('0.53', sha256='48e65a33d3b10527101d13c354538379d9df698e5c38f60f4660386f4232e65c')
 
     # Uses go modules.
     # See https://gohugo.io/getting-started/installing/#fetch-from-github
     depends_on('go@1.11:', when='@0.48:', type='build')
 
+    variant('extended', default=False, description="Enable extended features")
+
     def install(self, spec, prefix):
+        go_args = ['build']
+        if self.spec.satisfies('+extended'):
+            go_args.extend(['--tags', 'extended'])
+
         go = which('go')
-        go('build')
+        go(*go_args)
         mkdir(prefix.bin)
         install('hugo', prefix.bin)


### PR DESCRIPTION
- Add info for version 0.68.3
- Add variant to package that enables the "extended" features.  It
  works with both of the existing versions (not sure how far back it
  goes, but confirmed that it's valid fro 0.53).

Tested on OS X with go@1.14.1.