### PR TITLE
environment-modules: add version 4.5.0

### DIFF
--- a/var/spack/repos/builtin/packages/environment-modules/package.py
+++ b/var/spack/repos/builtin/packages/environment-modules/package.py
@@ -12,10 +12,11 @@ class EnvironmentModules(Package):
     """
 
     homepage = 'https://cea-hpc.github.io/modules/'
-    url = 'https://github.com/cea-hpc/modules/releases/download/v4.4.1/modules-4.4.1.tar.gz'
+    url = 'https://github.com/cea-hpc/modules/releases/download/v4.5.0/modules-4.5.0.tar.gz'
 
     maintainers = ['xdelaruelle']
 
+    version('4.5.0', sha256='5f46336f612553af5553d99347f387f733de0aaa0d80d4572e67615289382ec8')
     version('4.4.1', sha256='3c20cfb2ff8a4d74ac6d566e7b5fa9dd220d96d17e6d8a4ae29b1ec0107ee407')
     version('4.4.0', sha256='4dd55ad6cc684905e891ad1ba9e3c542e79eea0a9cd9a0e99cd77abe6ed63fab')
     version('4.3.1', sha256='979efb5b3d3c8df2c3c364aaba61f97a459456fc5bbc092dfc02677da63e5654')
@@ -92,7 +93,7 @@ class EnvironmentModules(Package):
                 # Variables in quarantine are empty during module command
                 # start-up and they will be restored to the value they had
                 # in the environment once the command starts
-                '--with-quarantine-vars=LD_LIBRARY_PATH'
+                '--with-quarantine-vars=LD_LIBRARY_PATH LD_PRELOAD'
             ])
 
         if '@4.0.0:' in self.spec:


### PR DESCRIPTION
New feature release in the v4 series.

Release announcement: https://timeline.noticeable.io/cbzeG7wTvAIqj21zbUmx/posts/modules-latest-aka-4-5-0-released

In addition to introducing new version 4.5.0, the quarantine variable list of Modules is updated to also include `LD_PRELOAD` in addition to `LD_LIBRARY_PATH` (to avoid side-effect when the first depends on the latter).