### PR TITLE
[WIP] Chaining shared Spack

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -673,16 +673,13 @@ def _config():
         # The user configuration will store the install trees that are used
         # by this spack instance
         install_trees = cfg.get('config:install_trees')
+
         if not install_trees:
             if shared_install_trees:
-                if install_tree and not (install_tree == 'home'):
-                    raise ValueError("The specified install tree does not exist")
-
+                # If this is a shared spack instance, then the default for
+                # users is to put new installations in the home directory
                 install_trees = {'home': '~/.spack/installs'}
             else:
-                if install_tree and not (install_tree == 'spack'):
-                    raise ValueError("The specified install tree does not exist")
-
                 install_trees = {'spack': spack.paths.opt_path}
             cfg.set('config:install_trees', install_trees, 'user')
 
@@ -691,6 +688,9 @@ def _config():
                 install_tree = 'home'
             else:
                 install_tree = 'spack'
+
+        if install_tree not in install_trees:
+            raise ValueError("The specified install tree does not exist")
 
         install_root = install_trees[install_tree]
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -711,8 +711,6 @@ def _config():
                 pass
             raise ValueError("The specified install tree does not exist")
 
-        install_root = install_trees[install_tree]
-
         scope_name = 'install_tree:' + install_tree
         install_root = install_trees[install_tree]
         install_config_path = os.path.join(install_root, 'config')

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -670,6 +670,17 @@ def _config():
         # install tree
         cfg.push_scope(ConfigScope(*user_configuration_path))
 
+    # add command-line scopes
+    _add_command_line_scopes(cfg, command_line_scopes)
+
+    # we make a special scope for spack commands so that they can
+    # override configuration options.
+    cfg.push_scope(InternalConfigScope('command_line'))
+
+    # TODO: this allows command-line scopes to specify new install trees.
+    # The added install_tree_scope needs to be lower precedence than all
+    # command line scopes.
+    if not shared_tree_scope:
         # The user configuration will store the install trees that are used
         # by this spack instance
         install_trees = cfg.get('config:install_trees')
@@ -698,13 +709,6 @@ def _config():
         install_root = install_trees[install_tree]
         install_config_path = os.path.join(install_root, 'config')
         cfg.push_scope(ConfigScope(scope_name, install_config_path))
-
-    # add command-line scopes
-    _add_command_line_scopes(cfg, command_line_scopes)
-
-    # we make a special scope for spack commands so that they can
-    # override configuration options.
-    cfg.push_scope(InternalConfigScope('command_line'))
 
     return cfg
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -694,6 +694,7 @@ def _config():
                 install_trees = {'spack': '$spack/opt/spack'}
             cfg.set('config:install_trees', install_trees, 'user')
 
+        default_install_tree = (not install_tree)
         if not install_tree:
             if shared_install_trees:
                 install_tree = 'home'
@@ -701,6 +702,13 @@ def _config():
                 install_tree = 'spack'
 
         if install_tree not in install_trees:
+            if default_install_tree:
+                # In this case, we have either (a) added a shared install tree
+                # or (b) removed all shared install trees, the former is
+                # unexpected, and the latter will likely result in serious
+                # issues (e.g. missing dependencies for locally-installed
+                # packages)
+                pass
             raise ValueError("The specified install tree does not exist")
 
         install_root = install_trees[install_tree]

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -673,8 +673,26 @@ def _config():
         # The user configuration will store the install trees that are used
         # by this spack instance
         install_trees = cfg.get('config:install_trees')
-        default_install_tree = next(install_trees.keys())
-        install_tree = install_tree or default_install_tree
+        if not install_trees:
+            if shared_install_trees:
+                if install_tree and not (install_tree == 'home'):
+                    raise ValueError("The specified install tree does not exist")
+
+                install_trees = {'home': '~/.spack/installs'}
+            else:
+                if install_tree and not (install_tree == 'spack'):
+                    raise ValueError("The specified install tree does not exist")
+
+                install_trees = {'spack': spack.paths.opt_path}
+            cfg.set('config:install_trees', install_trees, 'user')
+
+        if not install_tree:
+            if shared_install_trees:
+                install_tree = 'home'
+            else:
+                install_tree = 'spack'
+
+        install_root = install_trees[install_tree]
 
         scope_name = 'install_tree:' + install_tree
         install_root = install_trees[install_tree]

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -680,7 +680,7 @@ def _config():
                 # users is to put new installations in the home directory
                 install_trees = {'home': '~/.spack/installs'}
             else:
-                install_trees = {'spack': spack.paths.opt_path}
+                install_trees = {'spack': '$spack/opt/spack'}
             cfg.set('config:install_trees', install_trees, 'user')
 
         if not install_tree:

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -370,7 +370,7 @@ def make_argument_parser(**kwargs):
         '--pdb', action='store_true',
         help="run spack under the pdb debugger")
     parser.add_argument(
-        '--install-root',
+        '--install-tree',
         help="select which tree to install to")
     parser.add_argument(
         '--init-upstream',

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -655,10 +655,12 @@ def print_setup_info(*info):
         path = spack.util.path.canonicalize_path(path)
         module_to_roots[name].append(path)
 
-    other_spack_instances = spack.config.get(
-        'upstreams') or {}
+    # Get all upstream directories here
     for install_properties in other_spack_instances.values():
-        upstream_module_roots = install_properties.get('modules', {})
+        # For each upstream install root, if there is a 'modules' directory,
+        # then create a dictionary: each subdir of that directory should be
+        # 'tcl' or etc. and the dictionary is from subdir name to full path
+        upstream_module_roots = None
         upstream_module_roots = dict(
             (k, v) for k, v in upstream_module_roots.items()
             if k in module_to_roots

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -655,7 +655,8 @@ def print_setup_info(*info):
         path = spack.util.path.canonicalize_path(path)
         module_to_roots[name].append(path)
 
-    upstream_roots = spack.store.upstream_install_roots(spack.store.root)
+    # Invoke str() to resolve LazyReference
+    upstream_roots = spack.store.upstream_install_roots(str(spack.store.root))
     for upstream_root in upstream_roots:
         # For each upstream install root, if there is a 'modules' directory,
         # then create a dictionary: each subdir of that directory should be

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -369,6 +369,12 @@ def make_argument_parser(**kwargs):
     parser.add_argument(
         '--pdb', action='store_true',
         help="run spack under the pdb debugger")
+    parser.add_argument(
+        '--install-root',
+        help="select which tree to install to")
+    parser.add_argument(
+        '--init-upstream'
+        help="when initializing an install tree, this names an upstream")
 
     env_group = parser.add_mutually_exclusive_group()
     env_group.add_argument(
@@ -460,6 +466,14 @@ def setup_main_options(args):
     if args.insecure:
         tty.warn("You asked for --insecure. Will NOT check SSL certificates.")
         spack.config.set('config:verify_ssl', False, scope='command_line')
+
+    if args.install_tree:
+        # Note: if an install tree is named, this needs to be pulled from the
+        # configuration (maps install tree *names* to actual paths)
+        spack.store.install_tree = args.install_tree
+
+    if args.init_upstream:
+        spack.store.init_upstream = args.init_upstream
 
     # when to use color (takes always, auto, or never)
     color.set_color_when(args.color)

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -655,12 +655,16 @@ def print_setup_info(*info):
         path = spack.util.path.canonicalize_path(path)
         module_to_roots[name].append(path)
 
-    # Get all upstream directories here
-    for install_properties in other_spack_instances.values():
+    upstream_roots = spack.store.upstream_install_roots(spack.store.root)
+    for upstream_root in upstream_roots:
         # For each upstream install root, if there is a 'modules' directory,
         # then create a dictionary: each subdir of that directory should be
-        # 'tcl' or etc. and the dictionary is from subdir name to full path
-        upstream_module_roots = None
+        # 'tcl' or etc. and the dictionary maps subdir name to full path
+        modules_root = os.path.join(upstream_root, 'modules')
+        upstream_module_roots = dict(
+            (module_type, os.path.join(modules_root, module_type))
+            for module_type in os.listdir(modules_root)
+        )
         upstream_module_roots = dict(
             (k, v) for k, v in upstream_module_roots.items()
             if k in module_to_roots

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -373,7 +373,7 @@ def make_argument_parser(**kwargs):
         '--install-root',
         help="select which tree to install to")
     parser.add_argument(
-        '--init-upstream'
+        '--init-upstream',
         help="when initializing an install tree, this names an upstream")
 
     env_group = parser.add_mutually_exclusive_group()

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -286,6 +286,9 @@ def read_module_indices():
     module_indices = []
 
     if not uses_old_module_index:
+        # New spack upstream instances do not require specifying module root
+        # locations in the config, since modules are now stored in the install
+        # tree by default.
         upstream_roots = spack.store.upstream_install_roots(
             str(spack.store.root))
         for upstream_root in upstream_roots:

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -216,7 +216,9 @@ def root_path(name):
     """
     # Root folders where the various module files should be written
     roots = spack.config.get('config:module_roots', {})
-    path = roots.get(name, os.path.join(spack.paths.share_path, name))
+    module_base = os.path.join(spack.store.root, 'modules')
+
+    path = roots.get(name, os.path.join(module_base, name))
     return spack.util.path.canonicalize_path(path)
 
 
@@ -275,14 +277,33 @@ def read_module_indices():
     other_spack_instances = spack.config.get(
         'upstreams') or {}
 
+    uses_old_module_index = False
+    for install_properties in other_spack_instances.values():
+        if 'modules' in install_properties:
+            uses_old_module_index = True
+            break
+
     module_indices = []
 
-    for install_properties in other_spack_instances.values():
-        module_type_to_index = {}
-        module_type_to_root = install_properties.get('modules', {})
-        for module_type, root in module_type_to_root.items():
-            module_type_to_index[module_type] = read_module_index(root)
-        module_indices.append(module_type_to_index)
+    if not uses_old_module_index:
+        upstream_roots = spack.store.upstream_install_roots(
+            str(spack.store.root))
+        for upstream_root in upstream_roots:
+            module_type_to_index = {}
+            upstream_module_root = os.path.join(upstream_root, 'modules')
+            for module_type in os.listdir(upstream_module_root):
+                module_type_root = os.path.join(
+                    upstream_module_root, module_type)
+                module_type_to_index[module_type] = read_module_index(
+                    module_type_root)
+            module_indices.append(module_type_to_index)
+    else:
+        for install_properties in other_spack_instances.values():
+            module_type_to_index = {}
+            module_type_to_root = install_properties.get('modules', {})
+            for module_type, root in module_type_to_root.items():
+                module_type_to_index[module_type] = read_module_index(root)
+            module_indices.append(module_type_to_index)
 
     return module_indices
 

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -20,7 +20,6 @@ properties = {
                 'type': 'string',
                 'enum': ['rpath', 'runpath']
             },
-            'install_tree': {'type': 'string'},
             'install_hash_length': {'type': 'integer', 'minimum': 1},
             'install_path_scheme': {'type': 'string'},
             'build_stage': {

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -53,6 +53,22 @@ properties = {
                     'error': False
                 },
             },
+            'install_trees': {
+                'type': 'object',
+                'default': {},
+                'additionalProperties': False,
+                'patternProperties': {
+                    r'\w[\w-]*': {'type': 'string'}
+                }
+            },
+            'shared_install_trees': {
+                'type': 'object',
+                'default': {},
+                'additionalProperties': False,
+                'patternProperties': {
+                    r'\w[\w-]*': {'type': 'string'}
+                }
+            },
             'source_cache': {'type': 'string'},
             'misc_cache': {'type': 'string'},
             'connect_timeout': {'type': 'integer', 'minimum': 0},

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -149,6 +149,7 @@ def upstream_install_roots(root):
             install_roots.append(upstream_root)
             upstream_root_description = os.path.join(
                 upstream_root, 'upstream-spack')
+    return install_roots
 
 
 def upstream_dbs_from_pointers(root):

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -109,7 +109,6 @@ def _store():
     root = spack.util.path.canonicalize_path(root)
 
     return Store(root,
-                 init_upstream_path,
                  spack.config.get('config:install_path_scheme'),
                  spack.config.get('config:install_hash_length'))
 
@@ -125,7 +124,7 @@ layout = llnl.util.lang.LazyReference(lambda: store.layout)
 
 def upstream_set(root):
     upstream_root_description = os.path.join(root, 'upstream-spack')
-    if os.path.exists(upstream_root_description)
+    return os.path.exists(upstream_root_description)
 
 
 def initialize_upstream_pointer_if_unset(root, init_upstream_root):

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -85,15 +85,17 @@ def _store():
     shared_install_trees = spack.config.get('config:shared_install_trees')
 
     if install_tree:
-        # if this install tree didn't exist before, create it. if there are
-        # shared install trees available, point the new install tree at one of
-        # them.
-        root = install_trees[install_tree]
+        if install_tree in install_trees:
+            root = install_trees[install_tree]
+        elif install_tree in shared_install_trees:
+            root = shared_install_trees[install_tree]
+        else:
+            # TODO: provide the user an option to create a new install tree
+            raise ValueError("Specified install tree does not exist: {0}"
+                             .format(install_tree))
     elif shared_install_trees:
-        # if no install tree is specified and there are shared install trees,
-        # then we are in user mode: the install tree is in ~
-        # if the ~ install tree does not yet exist, create it and automatically
-        # have it set one of the shared install trees as an upstream
+        # If no install tree is specified and there are shared install trees,
+        # then we are in user mode, and the install tree is in ~
         root = user_install_root
     else:
         # If this is not a shared spack instance, then by default we will place

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -137,7 +137,7 @@ def initialize_upstream_pointer_if_unset(root, init_upstream_root):
             f.write(init_upstream_root)
 
 
-def upstream_dbs_from_pointers(root):
+def upstream_install_roots(root):
     # Each installation root directory contains a file that points to the
     # upstream installation used (if any). This constructs a sequence of
     # upstream installations by recursively following these references.
@@ -150,7 +150,10 @@ def upstream_dbs_from_pointers(root):
             upstream_root_description = os.path.join(
                 upstream_root, 'upstream-spack')
 
-    return _construct_upstream_dbs_from_install_roots(install_roots)
+
+def upstream_dbs_from_pointers(root):
+    return _construct_upstream_dbs_from_install_roots(
+        upstream_install_roots(root))
 
 
 def upstream_dbs_from_config():


### PR DESCRIPTION
(This is very preliminary and I don't recommend even trying to use this at this point, but it covers some of the most essential changes that need to be made)

Changes which allow for a single system-installed Spack, with an installation root maintained by a system admin and an installation root maintained by a user (but for example admins can set config values that apply to any user of the Spack instance). Overall this is intended to allow admins to deploy an instance of Spack which looks like any other system-installed tool.

This includes:

* Move module roots to install tree root (not strictly required but in general for users they need to be located outside the Spack prefix)
  * This means that users no longer have to specify upstream module roots as shown in https://spack.readthedocs.io/en/v0.14.1/chain.html
* Add config scope associated with the install tree itself (this allows admins to assign specific permissions to the packages installed that are meant to be available to all users)

TODOs:

- [ ] Testing
- [ ] Move download cache to `~` (users can't store cached archives in the Spack prefix)

Non-essential TODOs:

- [ ] It came up that indices (e.g. the provider cache) should be instanced on a per-install-tree basis, that is important for correctness in general but is not essential to this PR
- [.] Having some means of automatically checking an upstream download cache would simplify shared deployments of Spack. As it is, admins can create mirrors and add them to the config that users see.