### PR TITLE
glib: Add new stable versions

### DIFF
--- a/var/spack/repos/builtin/packages/glib/meson-gettext.patch
+++ b/var/spack/repos/builtin/packages/glib/meson-gettext.patch
@@ -1,0 +1,34 @@
+--- a/meson.build
++++ b/meson.build
+@@ -1916,10 +1916,14 @@ endif
+ # proxy-libintl subproject.
+ # FIXME: glib-gettext.m4 has much more checks to detect broken/uncompatible
+ # implementations. This could be extended if issues are found in some platforms.
+-if cc.has_function('ngettext')
++gettext_opt = get_option('gettext')
++found_gettext = false
++if ['auto', 'libc'].contains(gettext_opt) and cc.has_function('ngettext')
+   libintl = []
+   have_bind_textdomain_codeset = cc.has_function('bind_textdomain_codeset')
+-else
++  found_gettext = true
++endif
++if not found_gettext and ['auto', 'external'].contains(gettext_opt)
+   libintl = cc.find_library('intl', required : false)
+   if not libintl.found()
+     libintl = subproject('proxy-libintl').get_variable('intl_dep')
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -9,6 +9,12 @@ option('iconv',
+        value : 'auto',
+        description : 'iconv implementation to use (\'libc\' = \'Part of the C library\'; \'external\' = \'External libiconv\'; \'auto\' = \'Auto-detect which iconv is available\')')
+ 
++option('gettext',
++       type : 'combo',
++       choices : ['auto', 'libc', 'external'],
++       value : 'auto',
++       description : 'gettext implementation to use (\'libc\' = \'Part of the C library\'; \'external\' = \'External libintl\'; \'auto\' = \'Auto-detect which gettext is available\')')
++
+ option('charsetalias_dir',
+        type : 'string',
+        value : '',

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -8,7 +8,7 @@ from spack import *
 import os.path
 
 
-class Glib(AutotoolsPackage):
+class Glib(Package):
     """GLib provides the core application building blocks for
     libraries and applications written in C.
 
@@ -21,6 +21,11 @@ class Glib(AutotoolsPackage):
     homepage = "https://developer.gnome.org/glib/"
     url      = "https://ftp.gnome.org/pub/gnome/sources/glib/2.53/glib-2.53.1.tar.xz"
 
+    version('2.64.1', sha256='17967603bcb44b6dbaac47988d80c29a3d28519210b28157c2bd10997595bbc7')
+    version('2.62.6', sha256='104fa26fbefae8024ff898330c671ec23ad075c1c0bce45c325c6d5657d58b9c')
+    version('2.60.7', sha256='8b12c0af569afd3b71200556ad751bad4cf4bf7bc4b5f880638459a42ca86310')
+    version('2.58.3', sha256='8f43c31767e88a25da72b52a40f3301fefc49a665b56dc10ee7cc9565cbe7481')
+    version('2.56.4', sha256='27f703d125efb07f8a743666b580df0b4095c59fc8750e8890132c91d437504c')
     version('2.56.3', sha256='a9a4c5b4c81b6c75bc140bdf5e32120ef3ce841b7413214ecf5f987acec74cb2')
     version('2.56.2', sha256='d64abd16813501c956c4e123ae79f47f1b58de573df9fdd3b0795f1e2c1aa789')
     version('2.56.1', sha256='40ef3f44f2c651c7a31aedee44259809b6f03d3d20be44545cd7d177221c0b8d')
@@ -38,6 +43,10 @@ class Glib(AutotoolsPackage):
         description='Enable tracing support'
     )
 
+    depends_on('meson@0.49.2:', when='@2.61.2:', type='build')
+    depends_on('meson@0.48.0:', when='@2.58.0:', type='build')
+    depends_on('ninja', when='@2.58.0:', type='build')
+
     depends_on('pkgconfig', type='build')
     depends_on('libffi')
     depends_on('zlib')
@@ -52,20 +61,76 @@ class Glib(AutotoolsPackage):
     patch('g_date_strftime.patch', when='@2.42.1')
     # Clang doesn't seem to acknowledge the pragma lines to disable the -Werror
     # around a legitimate usage.
-    patch('no-Werror=format-security.patch')
+    patch('no-Werror=format-security.patch', when='@:2.57.99')
     # Patch to prevent compiler errors in kernels older than 2.6.35
     patch('old-kernels.patch', when='@2.56.0:2.56.1 os=rhel6')
     patch('old-kernels.patch', when='@2.56.0:2.56.1 os=centos6')
     patch('old-kernels.patch', when='@2.56.0:2.56.1 os=scientific6')
+
+    # glib prefers the libc version of gettext, which breaks the build if the
+    # external version is also found.
+    patch('meson-gettext.patch', when='@2.58.0:')
 
     def url_for_version(self, version):
         """Handle glib's version-based custom URLs."""
         url = 'http://ftp.gnome.org/pub/gnome/sources/glib'
         return url + '/%s/glib-%s.tar.xz' % (version.up_to(2), version)
 
+    def meson_args(self):
+        args = ['-Dgettext=external']
+        if self.spec.satisfies('@2.63.5:'):
+            if '+libmount' in self.spec:
+                args.append('-Dlibmount=enabled')
+            else:
+                args.append('-Dlibmount=disabled')
+        else:
+            if '+libmount' in self.spec:
+                args.append('-Dlibmount=true')
+            else:
+                args.append('-Dlibmount=false')
+        if 'libc' in self.spec:
+            args.append('-Diconv=libc')
+        else:
+            if self.spec.satisfies('@2.61.0:'):
+                args.append('-Diconv=external')
+            else:
+                args.append('-Diconv=gnu')
+        if 'tracing=dtrace' in self.spec:
+            args.append('-Ddtrace=true')
+        else:
+            args.append('-Ddtrace=false')
+        if 'tracing=systemtap' in self.spec:
+            args.append('-Dsystemtap=true')
+        else:
+            args.append('-Dsystemtap=false')
+        if self.spec.satisfies('@2.59.0:'):
+            args.append('-Dselinux=disabled')
+        else:
+            args.append('-Dselinux=false')
+        args.append('-Dgtk_doc=false')
+        return args
+
+    def install(self, spec, prefix):
+        with working_dir('spack-build', create=True):
+            # We cannot simply do
+            #   meson('..', *std_meson_args, *self.meson_args())
+            # because that is not Python 2 compatible. Instead, collect
+            # arguments into a temporary buffer first.
+            args = []
+            args.extend(std_meson_args)
+            args.extend(self.meson_args())
+            meson('..', *args)
+            ninja('-v')
+            if self.run_tests:
+                ninja('test')
+            ninja('install')
+
     def configure_args(self):
         args = []
-        args.extend(self.enable_or_disable('libmount'))
+        if '+libmount' in self.spec:
+            args.append('--enable-libmount')
+        else:
+            args.append('--disable-libmount')
         if self.spec.satisfies('@2.53.4:'):
             args.append('--with-python={0}'.format(
                 os.path.basename(self.spec['python'].command.path))
@@ -74,7 +139,10 @@ class Glib(AutotoolsPackage):
             args.append('--with-libiconv=maybe')
         else:
             args.append('--with-libiconv=gnu')
-        args.extend(self.enable_or_disable('tracing'))
+        if 'tracing=dtrace' in self.spec or 'tracing=systemtap' in self.spec:
+            args.append('--enable-tracing')
+        else:
+            args.append('--disable-tracing')
         # SELinux is not available in Spack, so glib should not use it.
         args.append('--disable-selinux')
         # glib should not use the globally installed gtk-doc. Otherwise,
@@ -91,11 +159,21 @@ class Glib(AutotoolsPackage):
         args.append('GTKDOC_REBASE={0}'.format(true))
         return args
 
+    @when('@:2.57.99')
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix), *self.configure_args())
+        make()
+        if self.run_tests:
+            make('check')
+        make('install')
+        if self.run_tests:
+            make('installcheck')
+
     @property
     def dtrace_copy_path(self):
         return join_path(self.stage.source_path, 'dtrace-copy')
 
-    @run_before('configure')
+    @run_before('install')
     def fix_python_path(self):
         if not self.spec.satisfies('@2.53.4:'):
             return
@@ -107,7 +185,7 @@ class Glib(AutotoolsPackage):
                         os.path.basename(self.spec['python'].command.path)),
                     *files)
 
-    @run_before('configure')
+    @run_before('install')
     def fix_dtrace_usr_bin_path(self):
         if 'tracing=dtrace' not in self.spec:
             return


### PR DESCRIPTION
Newer versions of glib require Meson, so this PR adds support for that using a hybrid approach. glib@5.28: will be built using Meson, older versions still make use of Autotools.

I have done test builds of all versions added in this PR (plus a few dependents). I will also forward the Meson patch upstream soon.