### PR TITLE
py-gpaw: Add libvdwxc as variant 

### DIFF
--- a/var/spack/repos/builtin/packages/py-gpaw/package.py
+++ b/var/spack/repos/builtin/packages/py-gpaw/package.py
@@ -21,6 +21,7 @@ class PyGpaw(PythonPackage):
     variant('scalapack', default=True,
             description='Build with ScaLAPACK support')
     variant('fftw', default=True, description='Build with FFTW support')
+    variant('libvdwxc', default=True, description='Build with libvdwxc support')
 
     depends_on('mpi', when='+mpi', type=('build', 'link', 'run'))
     depends_on('python@2.6:', type=('build', 'run'), when='@:1.3.0')

--- a/var/spack/repos/builtin/packages/py-gpaw/package.py
+++ b/var/spack/repos/builtin/packages/py-gpaw/package.py
@@ -35,6 +35,7 @@ class PyGpaw(PythonPackage):
     depends_on('fftw+mpi', when='+fftw +mpi')
     depends_on('fftw~mpi', when='+fftw ~mpi')
     depends_on('scalapack', when='+scalapack')
+    depends_on('libvdwxc', when='+libvdwxc')
 
     patch('libxc.patch', when='@1.3.0')
 
@@ -75,6 +76,9 @@ class PyGpaw(PythonPackage):
         if '+fftw' in spec:
             libs += spec['fftw'].libs
             include_dirs.append(spec['fftw'].prefix.include)
+        if '+libvdwxc' in spec:
+            libs += spec['libvdwxc'].libs
+            include_dirs.append(spec['libvdwxc'].prefix.include)
 
         lib_dirs = list(libs.directories)
         libs = list(libs.names)
@@ -101,3 +105,5 @@ class PyGpaw(PythonPackage):
                 f.write("define_macros += {0}\n".format(scalapack_macros))
             if '+fftw' in spec:
                 f.write("fftw = True\n")
+            if '+libvdwxc' in spec:
+                f.write("libvdwxc = True\n")


### PR DESCRIPTION
From the documentation of GPAW, an additional variant of libvdwxc is added https://wiki.fysik.dtu.dk/gpaw/documentation/xc/libvdwxc.html

I suggest to enable the libvdwxc variant by default.