### PR TITLE
py-tensorflow-estimator: fix build

### DIFF
--- a/var/spack/repos/builtin/packages/py-tensorflow-estimator/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow-estimator/package.py
@@ -13,16 +13,17 @@ class PyTensorflowEstimator(Package):
     homepage = "https://github.com/tensorflow/estimator"
     url      = "https://github.com/tensorflow/estimator/archive/v1.13.0.tar.gz"
 
+    version('2.1', sha256='1d74c8181b981748976fa33ad97d3434c3cf2b7e29a0b00861365fe8329dbc4e')
     version('2.0.0', sha256='6f4bdf1ab219e1f1cba25d2af097dc820f56479f12a839853d97422fe4d8b465')
-    version('1.13.0', sha256='a787b150ff436636df723e507019c72a5d6486cfe506886279d380166953f12f', preferred=True)
+    version('1.13.0', sha256='a787b150ff436636df723e507019c72a5d6486cfe506886279d380166953f12f')
 
     extends('python')
 
+    depends_on('py-tensorflow@2.1.0:',  when='@2.1')
     depends_on('py-tensorflow@2.0.0',  when='@2.0.0')
     depends_on('py-tensorflow@1.13.1', when='@1.13.0')
 
-    depends_on('bazel@0.19.0', type='build')
-    depends_on('py-pip', type='build')
+    depends_on('bazel@0.19.0:', type='build')
     depends_on('py-funcsigs@1.0.2:', type=('build', 'run'))
 
     def install(self, spec, prefix):
@@ -33,15 +34,37 @@ class PyTensorflowEstimator(Package):
         env['TEST_TMPDIR'] = tmp_path
         env['HOME'] = tmp_path
 
-        # bazel uses system PYTHONPATH instead of spack paths
-        bazel('--action_env', 'PYTHONPATH={0}'.format(env['PYTHONPATH']),
-              '//tensorflow_estimator/tools/pip_package:build_pip_package')
+        args = [
+            # Don't allow user or system .bazelrc to override build settings
+            '--nohome_rc',
+            '--nosystem_rc',
+            # Bazel does not work properly on NFS, switch to /tmp
+            '--output_user_root=' + tmp_path,
+            'build',
+            # Spack logs don't handle colored output well
+            '--color=no',
+            '--jobs={0}'.format(make_jobs),
+            # Enable verbose output for failures
+            '--verbose_failures',
+            # Show (formatted) subcommands being executed
+            '--subcommands=pretty_print',
+            # Ask bazel to explain what it's up to
+            # Needs a filename as argument
+            '--explain=explainlogfile.txt',
+            # Increase verbosity of explanation,
+            '--verbose_explanations',
+            # bazel uses system PYTHONPATH instead of spack paths
+            '--action_env', 'PYTHONPATH={0}'.format(env['PYTHONPATH']),
+            '//tensorflow_estimator/tools/pip_package:build_pip_package',
+        ]
+
+        bazel(*args)
 
         build_pip_package = Executable(join_path(
             'bazel-bin/tensorflow_estimator/tools',
             'pip_package/build_pip_package'))
-        build_pip_package(tmp_path)
-
-        pip = Executable('pip')
-        pip('install', '--prefix={0}'.format(prefix),
-            '--find-links={0}'.format(tmp_path), 'tensorflow-estimator')
+        buildpath = join_path(self.stage.source_path, 'spack-build')
+        build_pip_package('--src', buildpath)
+        with working_dir(buildpath):
+            setup_py('install', '--prefix={0}'.format(prefix),
+                     '--single-version-externally-managed', '--root=/')


### PR DESCRIPTION
Change the build to work again, and be more in line with the other
tensorflow packages. Add version 2.1.