### PR TITLE
[WIP] AutotoolsPackage: ld access in /

### DIFF
--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -282,6 +282,12 @@ class AutotoolsPackage(PackageBase):
         with working_dir(self.build_directory, create=True):
             inspect.getmodule(self).configure(*options)
 
+    def setup_build_environment(self, env):
+        # avoid permission denied on
+        # /sbin/ldconfig.real:
+        #   Can't create temporary cache file /etc/ld.so.cache~: Permission denied
+        env.set('ac_cv_path_LDCONFIG', 'true')
+
     def build(self, spec, prefix):
         """Makes the build targets specified by
         :py:attr:``~.AutotoolsPackage.build_targets``


### PR DESCRIPTION
This PR tries to get rid of the (non-fatal) warning
```
/sbin/ldconfig.real:
  Can't create temporary cache file /etc/ld.so.cache~:
    Permission denied
```

when installing packages such as `ncurses`.

The proposed patch, setting an env recommended by @junghans, does not seam to fix this yet, as far as I could test on Ubuntu 18.04 with `GNU ld (GNU Binutils for Ubuntu) 2.30` and GCC 7.5.0.
