### PR TITLE
primer3: move to github, add 2.5.0, fix 2.3.7

### DIFF
--- a/var/spack/repos/builtin/packages/primer3/package.py
+++ b/var/spack/repos/builtin/packages/primer3/package.py
@@ -28,7 +28,8 @@ class Primer3(MakefilePackage):
     # https://github.com/primer3-org/primer3/issues/3
     def patch(self):
         if self.spec.version == Version('2.3.7'):
-            filter_file(r'^(CC_OPTS.*)', r'\1 -fpermissive', join_path('src', 'Makefile'))
+            filter_file(r'^(CC_OPTS.*)', r'\1 -fpermissive',
+                        join_path('src', 'Makefile'))
 
     def install(self, spec, prefix):
         with working_dir(self.build_directory):

--- a/var/spack/repos/builtin/packages/primer3/package.py
+++ b/var/spack/repos/builtin/packages/primer3/package.py
@@ -12,12 +12,23 @@ class Primer3(MakefilePackage):
        ubiquitous tool in genetics and molecular biology. Primer3
        can also design hybridization probes and sequencing primers."""
 
-    homepage = "http://primer3.sourceforge.net/"
-    url      = "https://sourceforge.net/projects/primer3/files/primer3/2.3.7/primer3-2.3.7.tar.gz/download"
+    homepage = "https://primer3.org/"
+    url      = "https://github.com/primer3-org/primer3/archive/v2.3.7.tar.gz"
 
-    version('2.3.7', sha256='9e37a301d2ca9e5034c9a9d4afcb3e90041f6cc44c658b63598d0ccfcb176e5e')
+    version('2.5.0', sha256='7581e2fa3228ef0ee1ffa427b2aa0a18fc635d561208327471daf59d1b804da0')
+    version('2.3.7', sha256='f7ac3e64dc89b7c80882bf0f52c2c0a58572f5fdafd178680d4a7ae91b6c465b')
 
     build_directory = 'src'
+
+    # Prior to May 15, 2018, the code contained invalid pointer/int
+    # comparisons, leading to compilers that default to strict mode
+    # failing to compile thal.c.
+    # This prevents building 2.3.7 w/ gcc@8.4.0.  Details here:
+    # https://github.com/primer3-org/primer3/issues/2
+    # https://github.com/primer3-org/primer3/issues/3
+    def patch(self):
+        if self.spec.version == Version('2.3.7'):
+            filter_file(r'^(CC_OPTS.*)', r'\1 -fpermissive', join_path('src', 'Makefile'))
 
     def install(self, spec, prefix):
         with working_dir(self.build_directory):


### PR DESCRIPTION
- The Primer3 project moved to GitHub.

  - update the URL
  - compare the tarballs 2.3.7 from Sourceforge and github, no
    significant differences (e.g. the Sourceforge tarball contained a
    couple of "tmp" files).
  - update the signature for the 2.3.7 tarball.

- @2.3.7 doesn't build with gcc@8.4.0, there's a dubious pointer/int
  comparison that causes an error.  It was fixed upstream in newer
  versions, apply simple patch to this version so that it continues to
  be build-able with newer compilers.  See:

  - https://github.com/primer3-org/primer3/issues/2
  - https://github.com/primer3-org/primer3/issues/3

- Add info for @2.5.0, which builds cleanly.