### PR TITLE
Hdf patch

### DIFF
--- a/var/spack/repos/builtin/packages/hdf/package.py
+++ b/var/spack/repos/builtin/packages/hdf/package.py
@@ -53,6 +53,7 @@ class Hdf(AutotoolsPackage):
 
         if '+libtirpc' in spec:
             config_args.append('LIBS=-ltirpc')
-            config_args.append('CPPFLAGS=-I{0}/include/tirpc'.format(spec['libtirpc'].prefix))
+            config_args.append('CPPFLAGS=-I{0}/include/tirpc'.format(
+                spec['libtirpc'].prefix))
 
         return config_args

--- a/var/spack/repos/builtin/packages/hdf/package.py
+++ b/var/spack/repos/builtin/packages/hdf/package.py
@@ -21,9 +21,11 @@ class Hdf(AutotoolsPackage):
     version('4.2.11', sha256='c3f7753b2fb9b27d09eced4d2164605f111f270c9a60b37a578f7de02de86d24')
 
     variant('szip', default=False, description="Enable szip support")
+    variant('libtirpc', default=False, description="Use xdr library from libtirpc package; if false, will use system or hdf internal")
 
     depends_on('jpeg@6b:')
     depends_on('szip', when='+szip')
+    depends_on('libtirpc', when='+libtirpc')
     depends_on('zlib@1.1.4:')
 
     depends_on('bison', type='build')
@@ -48,5 +50,9 @@ class Hdf(AutotoolsPackage):
             config_args.append('--with-szlib={0}'.format(spec['szip'].prefix))
         else:
             config_args.append('--without-szlib')
+
+        if '+libtirpc' in spec:
+            config_args.append('LIBS=-ltirpc')
+            config_args.append('CPPFLAGS=-I{0}/include/tirpc'.format(spec['libtirpc'].prefix))
 
         return config_args


### PR DESCRIPTION
Update to hdf package.py to add libtirpc variant
    
    This adds a boolean 'libtirpc' variant to the hdf package.
    Default is false, which will reproduce previous behavior (which
    was to rely either on system xdr headers/library, or have hdf use
    it's builtin xdr lib/headers (which are only for 32 bit))
    
    If true, a dependency is added on 'libtirpc', and the LIBS and
    CPPFLAGS are updated in the configure command to find te libtirpc
    library and xdr.h header.
