### PR TITLE
tests: Preliminary libsigsegv smoke tests (updated)

### DIFF
--- a/var/spack/repos/builtin/packages/libsigsegv/package.py
+++ b/var/spack/repos/builtin/packages/libsigsegv/package.py
@@ -25,15 +25,6 @@ class Libsigsegv(AutotoolsPackage, GNUMirrorPackage):
     def configure_args(self):
         return ['--enable-shared']
 
-    def _attempt_it(self, exe, options, expected, status, installed, purpose):
-        """Run the test and output PASSED or FAILED based on the results."""
-        try:
-            self.run_test(exe, options, expected, status, installed, purpose)
-            print('PASSED')
-        except Exception as exc:
-            tty.error(exc)
-            print('FAILED')
-
     def test(self):
         # Start by compiling and linking the simple program
         prog = 'data/smoke_test'
@@ -47,10 +38,10 @@ class Libsigsegv(AutotoolsPackage, GNUMirrorPackage):
             '-lsigsegv',
             '-Wl,-R{0}'.format(self.prefix.lib)]
         reason = 'test ability to link to the library'
-        self._attempt_it('cc', options, [], None, False, purpose=reason)
+        self.run_test('cc', options, [], None, False, purpose=reason)
 
         # Now run the program and confirm the output matches expectations
         with open('./data/smoke_test.out', 'r') as fd:
             expected = fd.read()
         reason = 'test ability to use the library'
-        self._attempt_it(prog, options, expected, None, False, purpose=reason)
+        self.run_test(prog, options, expected, None, False, purpose=reason)

--- a/var/spack/repos/builtin/packages/libsigsegv/package.py
+++ b/var/spack/repos/builtin/packages/libsigsegv/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import llnl.util.tty as tty
+
 from spack import *
 
 
@@ -18,5 +20,37 @@ class Libsigsegv(AutotoolsPackage, GNUMirrorPackage):
 
     patch('patch.new_config_guess', when='@2.10')
 
+    test_requires_compiler = True
+
     def configure_args(self):
         return ['--enable-shared']
+
+    def _attempt_it(self, exe, options, expected, status, installed, purpose):
+        """Run the test and output PASSED or FAILED based on the results."""
+        try:
+            self.run_test(exe, options, expected, status, installed, purpose)
+            print('PASSED')
+        except Exception as exc:
+            tty.error(exc)
+            print('FAILED')
+
+    def test(self):
+        # Start by compiling and linking the simple program
+        prog = 'data/smoke_test'
+
+        options = [
+            '-I{0}'.format(self.prefix.include),
+            '{0}.c'.format(prog),
+            '-o',
+            prog,
+            '-L{0}'.format(self.prefix.lib),
+            '-lsigsegv',
+            '-Wl,-R{0}'.format(self.prefix.lib)]
+        reason = 'test ability to link to the library'
+        self._attempt_it('cc', options, [], None, False, purpose=reason)
+
+        # Now run the program and confirm the output matches expectations
+        with open('./data/smoke_test.out', 'r') as fd:
+            expected = fd.read()
+        reason = 'test ability to use the library'
+        self._attempt_it(prog, options, expected, None, False, purpose=reason)

--- a/var/spack/repos/builtin/packages/libsigsegv/package.py
+++ b/var/spack/repos/builtin/packages/libsigsegv/package.py
@@ -44,4 +44,4 @@ class Libsigsegv(AutotoolsPackage, GNUMirrorPackage):
         with open('./data/smoke_test.out', 'r') as fd:
             expected = fd.read()
         reason = 'test ability to use the library'
-        self.run_test(prog, options, expected, None, False, purpose=reason)
+        self.run_test(prog, [], expected, None, False, purpose=reason)

--- a/var/spack/repos/builtin/packages/libsigsegv/test/smoke_test.c
+++ b/var/spack/repos/builtin/packages/libsigsegv/test/smoke_test.c
@@ -1,0 +1,64 @@
+/* Simple libsigsegv include test 
+ *
+ * Inspired by libsigsegv's test cases.
+ */
+
+#include "sigsegv.h"
+#include <stdio.h>
+#include <stdlib.h>   /* for exit */
+# include <stddef.h>  /* for NULL on SunOS4 */
+#include <setjmp.h>   /* for controlling handler-related flow */
+
+
+jmp_buf mainbuf;
+
+char *message = "Hello, World!";
+
+volatile int handler_called = 0;
+
+static void
+handler_continuation(void *arg1, void *arg2, void *arg3)
+{
+     /* Go back to where we started */
+    longjmp(mainbuf, handler_called);
+}
+
+int
+handler(void *fault_address, int serious)
+{
+    handler_called++;
+    if (handler_called > 2)
+        abort();
+    printf("Caught sigsegv #%d\n", handler_called);
+
+    return sigsegv_leave_handler(handler_continuation, NULL, NULL, NULL);
+}
+
+void printit(char *m)
+{
+    if (handler_called <= 0)
+        /* Force SIGSEGV */
+        printf("%s\n", *m);
+    else
+        /* Print it correctly. */
+        printf("%s\n", m);
+}
+
+int
+main(void)
+{
+    /* Install the sigsegv handler */
+    sigsegv_install_handler(&handler);
+
+    char *msg = "Hello, World!";
+    int calls = setjmp(mainbuf);
+
+    /* This will be called multiple times thanks to the handler. */
+    printit(msg);
+
+    /* Stop the cycle after the first two calls. */
+    if (calls > 1)
+        exit(0);
+
+    exit(0);
+}

--- a/var/spack/repos/builtin/packages/libsigsegv/test/smoke_test.out
+++ b/var/spack/repos/builtin/packages/libsigsegv/test/smoke_test.out
@@ -1,0 +1,2 @@
+Caught sigsegv #1
+Hello, World!

--- a/var/spack/repos/builtin/packages/libsigsegv/test/smoke_test.out
+++ b/var/spack/repos/builtin/packages/libsigsegv/test/smoke_test.out
@@ -1,2 +1,2 @@
 Caught sigsegv #1
-Hello, World!
+Hello World!


### PR DESCRIPTION
Replaces #15091 

The preliminary "smoke" tests for `libsigsegv` involve building a small C program and ensuring the output from running it match expectations.  This PR updates the previous one to use the latest version of `run_test` from `features/spack-test` branch.

Compilation options were gleaned from those generated during the normal test build process for the library.