### PR TITLE
Update yaml-cpp package to enable for build of old api

### DIFF
--- a/var/spack/repos/builtin/packages/yaml-cpp/package.py
+++ b/var/spack/repos/builtin/packages/yaml-cpp/package.py
@@ -20,6 +20,7 @@ class YamlCpp(CMakePackage):
     version('0.6.3', sha256='77ea1b90b3718aa0c324207cb29418f5bced2354c2e483a9523d98c3460af1ed')
     version('0.6.2', sha256='e4d8560e163c3d875fd5d9e5542b5fd5bec810febdcba61481fe5fc4e6b1fd05')
     version('0.5.3', sha256='decc5beabb86e8ed9ebeb04358d5363a5c4f72d458b2c788cb2f3ac9c19467b2')
+    version('0.3.0', sha256='ab8d0e07aa14f10224ed6682065569761f363ec44bc36fcdb2946f6d38fe5a89')
 
     variant('shared', default=True,
             description='Enable build of shared libraries')
@@ -30,7 +31,7 @@ class YamlCpp(CMakePackage):
     variant('tests', default=False,
             description='Build yaml-cpp tests using internal gtest')
 
-    depends_on('boost@:1.66.99', when='@:0.5.3')
+    depends_on('boost@:1.66.99', when='@0.5.0:0.5.3')
 
     conflicts('%gcc@:4.7', when='@0.6.0:', msg="versions 0.6.0: require c++11 support")
     conflicts('%clang@:3.3.0', when='@0.6.0:', msg="versions 0.6.0: require c++11 support")
@@ -76,3 +77,10 @@ class YamlCpp(CMakePackage):
         ])
 
         return options
+
+    def url_for_version(self, version):
+        url = "https://github.com/jbeder/yaml-cpp/archive/{0}-{1}.tar.gz"
+        if version < Version('0.5.3'):
+            return url.format('release', version)
+        else:
+            return url.format('yaml-cpp', version)


### PR DESCRIPTION
The old api is found in version 0.3.0 which uses a different release
name, so the url function was updated to properly find the older
releases. Also, this removes the boost constraint on the 0.3.0 version
which does not need it.