### PR TITLE
fujitsu compiler: Delete custom environment function.

### DIFF
--- a/lib/spack/spack/compilers/fj.py
+++ b/lib/spack/spack/compilers/fj.py
@@ -61,7 +61,3 @@ class Fj(spack.compiler.Compiler):
     @property
     def pic_flag(self):
         return "-KPIC"
-
-    def setup_custom_environment(self, pkg, env):
-        env.append_flags('fcc_ENV', '-Nclang')
-        env.append_flags('FCC_ENV', '-Nclang')


### PR DESCRIPTION
This option is no longer needed, as the option "-Nclang" is now specified elsewhere.
Delete `setup_custom_environment`.