### PR TITLE
sourceware.org: mirror mixin

### DIFF
--- a/lib/spack/spack/build_systems/sourceware.py
+++ b/lib/spack/spack/build_systems/sourceware.py
@@ -1,0 +1,37 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import spack.util.url
+import spack.package
+
+
+class SourcewarePackage(spack.package.PackageBase):
+    """Mixin that takes care of setting url and mirrors for Sourceware.org
+       packages."""
+    #: Path of the package in a Sourceware mirror
+    sourceware_mirror_path = None
+
+    #: List of Sourceware mirrors used by Spack
+    base_mirrors = [
+        'https://sourceware.org/pub/',
+        'https://mirrors.kernel.org/sourceware/',
+        'https://ftp.gwdg.de/pub/linux/sources.redhat.com/'
+    ]
+
+    @property
+    def urls(self):
+        self._ensure_sourceware_mirror_path_is_set_or_raise()
+        return [
+            spack.util.url.join(m, self.sourceware_mirror_path,
+                                resolve_href=True)
+            for m in self.base_mirrors
+        ]
+
+    def _ensure_sourceware_mirror_path_is_set_or_raise(self):
+        if self.sourceware_mirror_path is None:
+            cls_name = type(self).__name__
+            msg = ('{0} must define a `sourceware_mirror_path` attribute'
+                   ' [none defined]')
+            raise AttributeError(msg.format(cls_name))

--- a/lib/spack/spack/pkgkit.py
+++ b/lib/spack/spack/pkgkit.py
@@ -31,6 +31,7 @@ from spack.build_systems.intel import IntelPackage
 from spack.build_systems.meson import MesonPackage
 from spack.build_systems.sip import SIPPackage
 from spack.build_systems.gnu import GNUMirrorPackage
+from spack.build_systems.sourceware import SourcewarePackage
 
 from spack.mixins import filter_compiler_wrappers
 

--- a/var/spack/repos/builtin/packages/bzip2/package.py
+++ b/var/spack/repos/builtin/packages/bzip2/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class Bzip2(Package):
+class Bzip2(Package, SourcewarePackage):
     """bzip2 is a freely available, patent free high-quality data
     compressor. It typically compresses files to within 10% to 15%
     of the best available techniques (the PPM family of statistical
@@ -14,10 +14,7 @@ class Bzip2(Package):
     and six times faster at decompression."""
 
     homepage = "https://sourceware.org/bzip2/"
-    url      = "https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz"
-
-    # The server is sometimes a bit slow to respond
-    fetch_options = {'timeout': 60}
+    sourceware_mirror_path = "bzip2/bzip2-1.0.8.tar.gz"
 
     version('1.0.8', sha256='ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269')
     version('1.0.7', sha256='e768a87c5b1a79511499beb41500bcc4caf203726fff46a6f5f9ad27fe08ab2b')

--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -8,7 +8,7 @@ import glob
 import os.path
 
 
-class Elfutils(AutotoolsPackage):
+class Elfutils(AutotoolsPackage, SourcewarePackage):
     """elfutils is a collection of various binary tools such as
     eu-objdump, eu-readelf, and other utilities that allow you to
     inspect and manipulate ELF files. Refer to Table 5.Tools Included
@@ -17,12 +17,9 @@ class Elfutils(AutotoolsPackage):
     version of elfutils."""
 
     homepage = "https://fedorahosted.org/elfutils/"
-    url      = "https://sourceware.org/elfutils/ftp/0.178/elfutils-0.178.tar.bz2"
+    sourceware_mirror_path = "elfutils/0.178/elfutils-0.178.tar.bz2"
     list_url = "https://sourceware.org/elfutils/ftp"
     list_depth = 1
-
-    # Sourceware is often slow to respond.
-    fetch_options = {'timeout': 60}
 
     version('0.178', sha256='31e7a00e96d4e9c4bda452e1f2cdac4daf8abd24f5e154dee232131899f3a0f2')
     version('0.177', sha256='fa489deccbcae7d8c920f60d85906124c1989c591196d90e0fd668e3dc05042e')

--- a/var/spack/repos/builtin/packages/libffi/package.py
+++ b/var/spack/repos/builtin/packages/libffi/package.py
@@ -6,18 +6,15 @@
 from spack import *
 
 
-class Libffi(AutotoolsPackage):
+class Libffi(AutotoolsPackage, SourcewarePackage):
     """The libffi library provides a portable, high level programming
     interface to various calling conventions. This allows a programmer
     to call any function specified by a call interface description at
     run time."""
     homepage = "https://sourceware.org/libffi/"
+    sourceware_mirror_path = "libffi/libffi-3.2.1.tar.gz"
 
-    # The server is sometimes a bit slow to respond
-    fetch_options = {'timeout': 60}
-
-    version('3.2.1', sha256='d06ebb8e1d9a22d19e38d63fdb83954253f39bedc5d46232a05645685722ca37',
-            url="https://sourceware.org/pub/libffi/libffi-3.2.1.tar.gz")
+    version('3.2.1', sha256='d06ebb8e1d9a22d19e38d63fdb83954253f39bedc5d46232a05645685722ca37')
 
     @property
     def headers(self):

--- a/var/spack/repos/builtin/packages/lvm2/package.py
+++ b/var/spack/repos/builtin/packages/lvm2/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-class Lvm2(AutotoolsPackage):
+class Lvm2(AutotoolsPackage, SourcewarePackage):
     """LVM2 is the userspace toolset that provides logical volume
     management facilities on linux.
 
@@ -18,10 +18,7 @@ class Lvm2(AutotoolsPackage):
     """
 
     homepage = "https://www.sourceware.org/lvm2"
-    url = "https://sourceware.org/pub/lvm2/releases/LVM2.2.03.05.tgz"
-
-    # The server is sometimes a bit slow to respond
-    fetch_options = {'timeout': 60}
+    sourceware_mirror_path = "lvm2/LVM2.2.03.05.tgz"
 
     version('2.03.05', sha256='ca52815c999b20c6d25e3192f142f081b93d01f07b9d787e99664b169dba2700')
     version('2.03.04', sha256='f151f36fc0039997d2d9369b607b9262568b1a268afe19fd1535807355402142')

--- a/var/spack/repos/builtin/packages/valgrind/package.py
+++ b/var/spack/repos/builtin/packages/valgrind/package.py
@@ -8,7 +8,7 @@ import glob
 import sys
 
 
-class Valgrind(AutotoolsPackage):
+class Valgrind(AutotoolsPackage, SourcewarePackage):
     """An instrumentation framework for building dynamic analysis.
 
     There are Valgrind tools that can automatically detect many memory
@@ -19,11 +19,8 @@ class Valgrind(AutotoolsPackage):
     under the GNU General Public License, version 2.
     """
     homepage = "http://valgrind.org/"
-    url      = "https://sourceware.org/pub/valgrind/valgrind-3.13.0.tar.bz2"
+    sourceware_mirror_path = "valgrind/valgrind-3.13.0.tar.bz2"
     git      = "git://sourceware.org/git/valgrind.git"
-
-    # The server is sometimes a bit slow to respond
-    fetch_options = {'timeout': 60}
 
     version('develop', branch='master')
     version('3.15.0', sha256='417c7a9da8f60dd05698b3a7bc6002e4ef996f14c13f0ff96679a16873e78ab1')


### PR DESCRIPTION
sourceware.org is often quite overrun and times out or returns in certificate errors.

Since libffi, bzip2, elfutils, etc. are quite fundamental in build chains, let's add some official mirrors.

This should fix the bi-daily errors I see on nightly integration tests.