### PR TITLE
gromacs: install header files

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -91,6 +91,9 @@ class Gromacs(CMakePackage):
 
         options = []
 
+        if self.spec.satisfies('@2020:'):
+            options.append('-DGMX_INSTALL_LEGACY_API=ON')
+
         if '+mpi' in self.spec:
             options.append('-DGMX_MPI:BOOL=ON')
 


### PR DESCRIPTION
It is only a couple of files, so adding a variant seems unneeded.