### PR TITLE
Set MPI providers for test config

### DIFF
--- a/lib/spack/spack/architecture.py
+++ b/lib/spack/spack/architecture.py
@@ -441,7 +441,7 @@ class Arch(object):
         return arch_for_spec(spec)
 
 
-@memoized
+# @memoized
 def get_platform(platform_name):
     """Returns a platform object that corresponds to the given name."""
     platform_list = all_platforms()
@@ -477,7 +477,7 @@ def arch_for_spec(arch_spec):
     return Arch(arch_plat, arch_spec.os, arch_spec.target)
 
 
-@memoized
+# @memoized
 def all_platforms():
     classes = []
     mod_path = spack.paths.platform_path
@@ -498,7 +498,7 @@ def all_platforms():
     return classes
 
 
-@memoized
+# @memoized
 def platform():
     """Detects the platform for this machine.
 
@@ -516,7 +516,7 @@ def platform():
             return platform_cls()
 
 
-@memoized
+# @memoized
 def sys_type():
     """Print out the "default" platform-os-target tuple for this machine.
 
@@ -533,7 +533,7 @@ def sys_type():
     return str(arch)
 
 
-@memoized
+# @memoized
 def compatible_sys_types():
     """Returns a list of all the systypes compatible with the current host."""
     compatible_archs = []

--- a/lib/spack/spack/architecture.py
+++ b/lib/spack/spack/architecture.py
@@ -441,7 +441,7 @@ class Arch(object):
         return arch_for_spec(spec)
 
 
-# @memoized
+@memoized
 def get_platform(platform_name):
     """Returns a platform object that corresponds to the given name."""
     platform_list = all_platforms()
@@ -477,7 +477,7 @@ def arch_for_spec(arch_spec):
     return Arch(arch_plat, arch_spec.os, arch_spec.target)
 
 
-# @memoized
+@memoized
 def all_platforms():
     classes = []
     mod_path = spack.paths.platform_path
@@ -498,7 +498,7 @@ def all_platforms():
     return classes
 
 
-# @memoized
+@memoized
 def platform():
     """Detects the platform for this machine.
 
@@ -516,7 +516,7 @@ def platform():
             return platform_cls()
 
 
-# @memoized
+@memoized
 def sys_type():
     """Print out the "default" platform-os-target tuple for this machine.
 
@@ -533,7 +533,7 @@ def sys_type():
     return str(arch)
 
 
-# @memoized
+@memoized
 def compatible_sys_types():
     """Returns a list of all the systypes compatible with the current host."""
     compatible_archs = []

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -159,7 +159,19 @@ def compiler_list(args):
     tty.msg("Available compilers")
     index = index_by(spack.compilers.all_compilers(scope=args.scope),
                      lambda c: (c.spec.name, c.operating_system, c.target))
-    ordered_sections = sorted(index.items(), key=lambda item: item[0])
+
+    # For a container, take each element which does not evaluate to false and
+    # convert it to a string. For elements which evaluate to False (e.g. None)
+    # convert them to '' (in which case it still evaluates to False but is a
+    # string type). Tuples produced by this are guaranteed to be comparable in
+    # Python 3
+    convert_str = (
+        lambda tuple_container :
+        tuple(str(x) if x else '' for x in tuple_container))
+
+    index_str_keys = list(
+        (convert_str(x), y) for x, y in index.items())
+    ordered_sections = sorted(index_str_keys, key=lambda item: item[0])
     for i, (key, compilers) in enumerate(ordered_sections):
         if i >= 1:
             print()

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -166,7 +166,7 @@ def compiler_list(args):
     # string type). Tuples produced by this are guaranteed to be comparable in
     # Python 3
     convert_str = (
-        lambda tuple_container :
+        lambda tuple_container:
         tuple(str(x) if x else '' for x in tuple_container))
 
     index_str_keys = list(

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -110,7 +110,7 @@ def current_host(request, monkeypatch):
     # spack.architecture.get_platform.cache.clear()
 
 
-@pytest.mark.usefixtures('config', 'mock_packages')
+@pytest.mark.usefixtures('mutable_config', 'mock_packages')
 class TestConcretize(object):
     def test_concretize(self, spec):
         check_concretize(spec)

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -96,7 +96,7 @@ def current_host(request, monkeypatch):
     target = llnl.util.cpu.targets[cpu]
 
     # this function is memoized, so clear its state for testing
-    # spack.architecture.get_platform.cache.clear()
+    spack.architecture.get_platform.cache.clear()
 
     if not is_preference:
         monkeypatch.setattr(llnl.util.cpu, 'host', lambda: target)
@@ -107,7 +107,7 @@ def current_host(request, monkeypatch):
             yield target
 
     # clear any test values fetched
-    # spack.architecture.get_platform.cache.clear()
+    spack.architecture.get_platform.cache.clear()
 
 
 @pytest.mark.usefixtures('mutable_config', 'mock_packages')

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -110,13 +110,17 @@ def current_host(request, monkeypatch):
 
     # clear any test values fetched
     spack.architecture.get_platform.cache.clear()
-    # TODO: if the caches are cleared, and we use 'config' instead of
-    # 'mutable_config' for the below tests, then fewer of the succeeding
-    # flag handler tests fail (some of them still fail though).
-    spack.config.config.clear_caches()
+    # TODO: when using 'config' instead of  'mutable_config' for the below
+    # then some flag handler tests fail. If we call clear_caches() here, then
+    # fewer of those tests fail (some of them still fail though). Using
+    # mutable_config is the only way to get all the tests to pass.
+    # spack.config.config.clear_caches()
 
 
-@pytest.mark.usefixtures('config', 'mock_packages')
+# Note: I recommend using mutable_config here since the current_host fixture
+# changes the config. Undoing that creates problems for other tests (see the
+# other comments).
+@pytest.mark.usefixtures('mutable_config', 'mock_packages')
 class TestConcretize(object):
     def test_concretize(self, spec):
         check_concretize(spec)

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -12,7 +12,6 @@ import spack.repo
 
 from spack.concretize import find_spec, NoValidVersionError
 from spack.error import SpecError
-from spack.package_prefs import PackagePrefs
 from spack.spec import Spec, CompilerSpec, ConflictsInSpecError
 from spack.version import ver
 from spack.test.conftest import MockPackage, MockPackageMultiRepo

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -103,8 +103,6 @@ def current_host(request, monkeypatch):
         monkeypatch.setattr(spack.platforms.test.Test, 'default', cpu)
         yield target
     else:
-        # There's a cache that needs to be cleared for unit tests
-        PackagePrefs._packages_config_cache = None
         with spack.config.override('packages:all', {'target': [cpu]}):
             yield target
 

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -96,7 +96,7 @@ def current_host(request, monkeypatch):
     target = llnl.util.cpu.targets[cpu]
 
     # this function is memoized, so clear its state for testing
-    spack.architecture.get_platform.cache.clear()
+    # spack.architecture.get_platform.cache.clear()
 
     if not is_preference:
         monkeypatch.setattr(llnl.util.cpu, 'host', lambda: target)
@@ -109,7 +109,7 @@ def current_host(request, monkeypatch):
             yield target
 
     # clear any test values fetched
-    spack.architecture.get_platform.cache.clear()
+    # spack.architecture.get_platform.cache.clear()
 
 
 @pytest.mark.usefixtures('config', 'mock_packages')

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -103,14 +103,20 @@ def current_host(request, monkeypatch):
         monkeypatch.setattr(spack.platforms.test.Test, 'default', cpu)
         yield target
     else:
+        # TODO: I suspect any test using config.override (which is only used
+        # for tests) should use the 'mutable_config' fixture
         with spack.config.override('packages:all', {'target': [cpu]}):
             yield target
 
     # clear any test values fetched
     spack.architecture.get_platform.cache.clear()
+    # TODO: if the caches are cleared, and we use 'config' instead of
+    # 'mutable_config' for the below tests, then fewer of the succeeding
+    # flag handler tests fail (some of them still fail though).
+    spack.config.config.clear_caches()
 
 
-@pytest.mark.usefixtures('mutable_config', 'mock_packages')
+@pytest.mark.usefixtures('config', 'mock_packages')
 class TestConcretize(object):
     def test_concretize(self, spec):
         check_concretize(spec)

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -601,6 +601,9 @@ class TestConcretize(object):
         with pytest.raises(NoValidVersionError, match="no valid versions"):
             Spec(spec).concretized()
 
+    # TODO: these tests aren't supposed to change the config, but without the
+    # mutable_config fixture, the execution of these tests cause later
+    # flag_handler tests to fail.
     @pytest.mark.parametrize('spec, best_achievable', [
         ('mpileaks%gcc@4.4.7', 'core2'),
         ('mpileaks%gcc@4.8', 'haswell'),

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -100,7 +100,7 @@ class TestConcretizePreferences(object):
         # Try the last available compiler
         compiler = str(compiler_list[-1])
         update_packages('mpileaks', 'compiler', [compiler])
-        spec = concretize('mpileaks')
+        spec = concretize('mpileaks os=redhat6 target=x86')
         assert spec.compiler == spack.spec.CompilerSpec(compiler)
 
     def test_preferred_target(self, mutable_mock_repo):

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -433,7 +433,7 @@ def mutable_config(tmpdir_factory, configuration_dir):
     configuration_dir.copy(mutable_dir)
 
     cfg = spack.config.Configuration(
-        *[spack.config.ConfigScope(name, str(mutable_dir))
+        *[spack.config.ConfigScope(name, str(mutable_dir.join(name)))
           for name in ['site', 'system', 'user']])
 
     with use_configuration(cfg):

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -439,6 +439,8 @@ def mutable_config(tmpdir_factory, configuration_dir, monkeypatch):
     with use_configuration(cfg):
         yield cfg
 
+    spack.config.config.clear_caches()
+
 
 @pytest.fixture()
 def mock_low_high_config(tmpdir):

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -442,7 +442,11 @@ def mutable_config(tmpdir_factory, configuration_dir):
     with use_configuration(cfg):
         yield cfg
 
-    spack.config.config.clear_caches()
+    # TODO: this should be done, but it would actually undo the one-time setup
+    # that occurs for the configuration_dir fixture and interferes with tests
+    # using the 'config' fixture. To allow this, the 'config' fixture needs
+    # to be refactored to reassemble the scopes into a config every time.
+    # spack.config.config.clear_caches()
 
 
 @pytest.fixture()

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -442,7 +442,7 @@ def mutable_config(tmpdir_factory, configuration_dir):
     with use_configuration(cfg):
         yield cfg
 
-    spack.config.config.clear_caches()
+    # spack.config.config.clear_caches()
 
 
 @pytest.fixture()

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -422,9 +422,6 @@ def mock_configuration(configuration_dir):
 @pytest.fixture(scope='function')
 def config(mock_configuration):
     """This fixture activates/deactivates the mock configuration."""
-    # TODO: note that any test which ends up calling config.clear_caches will
-    # remove the builtin scope. So future uses of the 'config' fixture would
-    # be missing this scope.
     with use_configuration(mock_configuration):
         yield mock_configuration
 
@@ -441,8 +438,6 @@ def mutable_config(tmpdir_factory, configuration_dir):
 
     with use_configuration(cfg):
         yield cfg
-
-    # spack.config.config.clear_caches()
 
 
 @pytest.fixture()

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -442,11 +442,7 @@ def mutable_config(tmpdir_factory, configuration_dir):
     with use_configuration(cfg):
         yield cfg
 
-    # TODO: this should be done, but it would actually undo the one-time setup
-    # that occurs for the configuration_dir fixture and interferes with tests
-    # using the 'config' fixture. To allow this, the 'config' fixture needs
-    # to be refactored to reassemble the scopes into a config every time.
-    # spack.config.config.clear_caches()
+    spack.config.config.clear_caches()
 
 
 @pytest.fixture()

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -422,6 +422,9 @@ def mock_configuration(configuration_dir):
 @pytest.fixture(scope='function')
 def config(mock_configuration):
     """This fixture activates/deactivates the mock configuration."""
+    # TODO: note that any test which ends up calling config.clear_caches will
+    # remove the builtin scope. So future uses of the 'config' fixture would
+    # be missing this scope.
     with use_configuration(mock_configuration):
         yield mock_configuration
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -427,7 +427,7 @@ def config(mock_configuration):
 
 
 @pytest.fixture(scope='function')
-def mutable_config(tmpdir_factory, configuration_dir, monkeypatch):
+def mutable_config(tmpdir_factory, configuration_dir):
     """Like config, but tests can modify the configuration."""
     mutable_dir = tmpdir_factory.mktemp('mutable_config').join('tmp')
     configuration_dir.copy(mutable_dir)

--- a/lib/spack/spack/test/data/config/packages.yaml
+++ b/lib/spack/spack/test/data/config/packages.yaml
@@ -1,4 +1,7 @@
 packages:
+  all:
+    providers:
+      mpi: [openmpi, mpich]
   externaltool:
     buildable: False
     paths:


### PR DESCRIPTION
For tests that use the real Spack package repository, the config needs to avoid using MPI providers that are not intended to be installed by Spack. Without this, it is possible that Spack tests which concretize the MPI virtual will end up trying to use an implementation that it shouldn't (e.g. one that is always provided externally).

See: https://github.com/spack/spack/pull/15666 (and specifically the tests for it at https://travis-ci.org/github/spack/spack/jobs/672203234)