### PR TITLE
papi: add additional variants

### DIFF
--- a/var/spack/repos/builtin/packages/papi/package.py
+++ b/var/spack/repos/builtin/packages/papi/package.py
@@ -37,10 +37,14 @@ class Papi(AutotoolsPackage):
     variant('rapl', default=False, description='Enable RAPL support')
     variant('lmsensors', default=False, description='Enable lm_sensors support')
     variant('sde', default=False, description='Enable software defined events')
+    variant('static', default=True, description='Enable building static libraries')
+    variant('shared', default=True, description='Enable building shared libraries')
+    variant('shlib_tools', default=False, description='Enable building dynamic tools')
 
     depends_on('lm-sensors', when='+lmsensors')
 
     conflicts('%gcc@8:', when='@5.3.0', msg='Requires GCC version less than 8.0')
+    conflicts('~static', when='~shared')
 
     # Does not build with newer versions of gcc, see
     # https://bitbucket.org/icl/papi/issues/46/cannot-compile-on-arch-linux

--- a/var/spack/repos/builtin/packages/papi/package.py
+++ b/var/spack/repos/builtin/packages/papi/package.py
@@ -71,13 +71,13 @@ class Papi(AutotoolsPackage):
 
         # The logic above enables specific components
         # The logic below explicitly disable variants when specified
-        if '~static' in spec:
+        if '~static' in self.spec:
             options.append('--with-static-lib=no')
 
-        if '~shared' in spec:
+        if '~shared' in self.spec:
             options.append('--with-shared-lib=no')
 
-        if '~shlib_tools' in spec:
+        if '~shlib_tools' in self.spec:
             options.append('--without-shlib')
 
         return options

--- a/var/spack/repos/builtin/packages/papi/package.py
+++ b/var/spack/repos/builtin/packages/papi/package.py
@@ -68,6 +68,18 @@ class Papi(AutotoolsPackage):
                           self.spec.variants)
         if variants:
             options.append('--with-components={0}'.format(' '.join(variants)))
+
+        # The logic above enables specific components
+        # The logic below explicitly disable variants when specified
+        if '~static' in spec:
+            options.append('--with-static-lib=no')
+
+        if '~shared' in spec:
+            options.append('--with-shared-lib=no')
+
+        if '~shlib_tools' in spec:
+            options.append('--without-shlib')
+
         return options
 
     @run_before('configure')


### PR DESCRIPTION
This PR adds variants to the Papi package for additional configuration options. Specifically, explicitly enabling static building, shared building, and building shlib-tools is now supported.