### PR TITLE
libssh2: fix linking on macOS

### DIFF
--- a/var/spack/repos/builtin/packages/libgit2/package.py
+++ b/var/spack/repos/builtin/packages/libgit2/package.py
@@ -57,6 +57,7 @@ class Libgit2(CMakePackage):
     # Build Dependencies
     depends_on('cmake@2.8:', type='build', when="@:0.28")
     depends_on('cmake@3.5:', type='build', when="@0.99:")
+    depends_on('pkgconfig', type='build')
 
     # Runtime Dependencies
     depends_on('libssh2', when='+ssh')

--- a/var/spack/repos/builtin/packages/libssh2/package.py
+++ b/var/spack/repos/builtin/packages/libssh2/package.py
@@ -28,3 +28,9 @@ class Libssh2(CMakePackage):
         spec = self.spec
         return [
             '-DBUILD_SHARED_LIBS=%s' % ('YES' if '+shared' in spec else 'NO')]
+
+    @run_after('install')
+    def darwin_fix(self):
+        # The shared library is not installed correctly on Darwin; fix this
+        if self.spec.satisfies('platform=darwin'):
+            fix_darwin_install_name(self.prefix.lib)


### PR DESCRIPTION
Fixes #15887 

### Before
```console
$ otool -L /Users/Adam/spack/opt/spack/darwin-catalina-x86_64/clang-11.0.3-apple/libssh2-1.8.0-bwme3nb5vpustesfddxwqbevjk5zm2gd/lib/libssh2.dylib 
/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/clang-11.0.3-apple/libssh2-1.8.0-bwme3nb5vpustesfddxwqbevjk5zm2gd/lib/libssh2.dylib:
	libssh2.1.dylib (compatibility version 1.0.0, current version 1.0.1)
	/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/clang-11.0.3-apple/openssl-1.1.1f-hsoj6gr47qcrz623ak4ngcccg4hmcwpn/lib/libssl.1.1.dylib (compatibility version 1.1.0, current version 1.1.0)
	/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/clang-11.0.3-apple/openssl-1.1.1f-hsoj6gr47qcrz623ak4ngcccg4hmcwpn/lib/libcrypto.1.1.dylib (compatibility version 1.1.0, current version 1.1.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.100.1)
```
### After
```console
$ otool -L /Users/Adam/spack/opt/spack/darwin-catalina-x86_64/clang-11.0.3-apple/libssh2-1.8.0-bwme3nb5vpustesfddxwqbevjk5zm2gd/lib/libssh2.dylib 
/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/clang-11.0.3-apple/libssh2-1.8.0-bwme3nb5vpustesfddxwqbevjk5zm2gd/lib/libssh2.dylib:
	/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/clang-11.0.3-apple/libssh2-1.8.0-bwme3nb5vpustesfddxwqbevjk5zm2gd/lib/libssh2.dylib (compatibility version 1.0.0, current version 1.0.1)
	/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/clang-11.0.3-apple/openssl-1.1.1f-hsoj6gr47qcrz623ak4ngcccg4hmcwpn/lib/libssl.1.1.dylib (compatibility version 1.1.0, current version 1.1.0)
	/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/clang-11.0.3-apple/openssl-1.1.1f-hsoj6gr47qcrz623ak4ngcccg4hmcwpn/lib/libcrypto.1.1.dylib (compatibility version 1.1.0, current version 1.1.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.100.1)
```

`libgit2` still doesn't link to `libssh2`, but I think that's for another reason.

@DiegoMagdaleno @hartzell @trws can one of you test this?