### PR TITLE
boost: Fix for Version Comparison on Newer Clang on Darwin

### DIFF
--- a/var/spack/repos/builtin/packages/boost/darwin_clang_version.patch
+++ b/var/spack/repos/builtin/packages/boost/darwin_clang_version.patch
@@ -1,0 +1,31 @@
+From 40960b23338da0a359d6aa83585ace09ad8804d2 Mon Sep 17 00:00:00 2001
+From: Bo Anderson <mail@boanderson.me>
+Date: Sun, 29 Mar 2020 14:55:08 +0100
+Subject: [PATCH] Fix compiler version check on macOS
+
+Fixes #440.
+---
+ src/tools/darwin.jam | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/src/tools/darwin.jam b/src/tools/darwin.jam
+index 8d477410b0..97e7ecb851 100644
+--- tools/build/src/tools/darwin.jam
++++ tools/build/src/tools/darwin.jam
+@@ -137,13 +137,14 @@ rule init ( version ? : command * : options * : requirement * )
+     # - Set the toolset generic common options.
+     common.handle-options darwin : $(condition) : $(command) : $(options) ;
+     
++    real-version = [ regex.split $(real-version) \\. ] ;
+     # - GCC 4.0 and higher in Darwin does not have -fcoalesce-templates.
+-    if $(real-version) < "4.0.0"
++    if [ version.version-less $(real-version) : 4 0 ]
+     {
+         flags darwin.compile.c++ OPTIONS $(condition) : -fcoalesce-templates ;
+     }
+     # - GCC 4.2 and higher in Darwin does not have -Wno-long-double.
+-    if $(real-version) < "4.2.0"
++    if [ version.version-less $(real-version) : 4 2 ]
+     {
+         flags darwin.compile OPTIONS $(condition) : -Wno-long-double ;
+     }

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -203,6 +203,12 @@ class Boost(Package):
     patch('boost_1.63.0_pgi.patch', when='@1.63.0%pgi')
     patch('boost_1.63.0_pgi_17.4_workaround.patch', when='@1.63.0%pgi@17.4')
 
+    # Fix for version comparison on newer Clang on darwin
+    # See: https://github.com/boostorg/build/issues/440
+    # See: https://github.com/macports/macports-ports/pull/6726
+    patch('darwin_clang_version.patch', level=0,
+          when='@1.56.0:1.72.0 platform=darwin')
+
     # Fix the bootstrap/bjam build for Cray
     patch('bootstrap-path.patch', when='@1.39.0: platform=cray')
 


### PR DESCRIPTION
Applying to boost @1.56.0:1.72.0 as that's the version range, where this patch can be cleanly applied. I was not able to test this myself, but got positive feedback.

See: https://github.com/boostorg/build/issues/440
See: https://github.com/macports/macports-ports/pull/6726

Maintainer-Ping: @hainest