### PR TITLE
new package: BART

### DIFF
--- a/var/spack/repos/builtin/packages/bart/Makefile.patch
+++ b/var/spack/repos/builtin/packages/bart/Makefile.patch
@@ -1,0 +1,30 @@
+--- a/Makefile	2020-04-08 17:21:01.982819829 -0500
++++ b/Makefile	2020-04-08 17:21:42.982804931 -0500
+@@ -289,7 +289,7 @@
+ ifeq ($(BUILDTYPE), MacOSX)
+ CUDA_L := -L$(CUDA_BASE)/lib -lcufft -lcudart -lcublas -m64 -lstdc++
+ else
+-CUDA_L := -L$(CUDA_BASE)/lib64 -lcufft -lcudart -lcublas -lstdc++ -Wl,-rpath $(CUDA_BASE)/lib64
++CUDA_L := -L$(CUDA_BASE)/lib64 -lcufft -lcudart -lcublas -lstdc++
+ endif 
+ else
+ CUDA_H :=
+@@ -327,14 +327,13 @@
+ CPPFLAGS += -DUSE_ACML
+ else
+ BLAS_H := -I$(BLAS_BASE)/include
+-ifeq ($(BUILDTYPE), MacOSX)
+-BLAS_L := -L$(BLAS_BASE)/lib -lopenblas
++ifeq ($(OPENBLAS),1)
++BLAS_L := -lopenblas
+ else
+ ifeq ($(NOLAPACKE),1)
+-BLAS_L := -L$(BLAS_BASE)/lib -llapack -lblas
+-CPPFLAGS += -Isrc/lapacke
++BLAS_L := -llapack -lcblas
+ else
+-BLAS_L := -L$(BLAS_BASE)/lib -llapacke -lblas
++BLAS_L := -llapacke -lcblas
+ endif
+ endif
+ endif

--- a/var/spack/repos/builtin/packages/bart/bart_path.patch
+++ b/var/spack/repos/builtin/packages/bart/bart_path.patch
@@ -1,0 +1,107 @@
+diff -ru a/matlab/bart.m b/matlab/bart.m
+--- a/matlab/bart.m	2020-04-10 18:50:50.056248692 -0500
++++ b/matlab/bart.m	2020-04-10 18:52:20.541178180 -0500
+@@ -11,7 +11,7 @@
+ 		return
+ 	end
+ 
+-	bart_path = getenv('TOOLBOX_PATH');
++	bart_path = [getenv('TOOLBOX_PATH') '/bin'];
+ 	isWSL = false;
+ 
+ 	if isempty(bart_path)
+diff -ru a/python/bart.py b/python/bart.py
+--- a/python/bart.py	2020-04-10 18:50:50.056248692 -0500
++++ b/python/bart.py	2020-04-10 19:18:09.481950358 -0500
+@@ -19,7 +19,7 @@
+         return None
+ 
+     try:
+-        bart_path = os.environ['TOOLBOX_PATH'] + '/bart '
++        bart_path = os.environ['TOOLBOX_PATH'] + '/bin '
+     except:
+         bart_path = None
+     isWSL = False
+diff -ru a/scripts/espirit_econ.sh b/scripts/espirit_econ.sh
+--- a/scripts/espirit_econ.sh	2020-04-10 18:50:50.055248693 -0500
++++ b/scripts/espirit_econ.sh	2020-04-10 19:13:06.463193324 -0500
+@@ -56,8 +56,6 @@
+ fi
+ 
+ 
+-export PATH=$TOOLBOX_PATH:$PATH
+-
+ input=$(readlink -f "$1")
+ output=$(readlink -f "$2")
+ 
+@@ -67,7 +65,7 @@
+ 	exit 1
+ fi
+ 
+-if [ ! -e $TOOLBOX_PATH/bart ] ; then
++if [ ! -e $TOOLBOX_PATH/bin/bart ] ; then
+         echo "\$TOOLBOX_PATH is not set correctly!" >&2
+ 	exit 1
+ fi
+diff -ru a/scripts/grasp.sh b/scripts/grasp.sh
+--- a/scripts/grasp.sh	2020-04-10 18:50:50.055248693 -0500
++++ b/scripts/grasp.sh	2020-04-10 19:13:31.461173327 -0500
+@@ -90,8 +90,6 @@
+ fi
+ 
+ 
+-export PATH=$TOOLBOX_PATH:$PATH
+-
+ input=$(readlink -f "$1")
+ output=$(readlink -f "$2")
+ 
+@@ -101,7 +99,7 @@
+ 	exit 1
+ fi
+ 
+-if [ ! -e $TOOLBOX_PATH/bart ] ; then
++if [ ! -e $TOOLBOX_PATH/bin/bart ] ; then
+         echo "\$TOOLBOX_PATH is not set correctly!" >&2
+ 	exit 1
+ fi
+diff -ru a/scripts/octview.m b/scripts/octview.m
+--- a/scripts/octview.m	2020-04-10 18:50:50.055248693 -0500
++++ b/scripts/octview.m	2020-04-10 19:14:33.386123750 -0500
+@@ -1,6 +1,6 @@
+ #! /usr/bin/octave -qf
+ 
+-addpath(strcat(getenv("TOOLBOX_PATH"), "/matlab"));
++addpath(strcat(getenv("TOOLBOX_PATH"), "/bin", "/matlab"));
+ arg_list = argv();
+ 
+ 
+diff -ru a/scripts/profile.sh b/scripts/profile.sh
+--- a/scripts/profile.sh	2020-04-10 18:50:50.055248693 -0500
++++ b/scripts/profile.sh	2020-04-10 19:15:00.723101850 -0500
+@@ -45,7 +45,7 @@
+         exit 1
+ fi
+ 
+-if [ ! -e $TOOLBOX_PATH/bart ] ; then
++if [ ! -e $TOOLBOX_PATH/bin/bart ] ; then
+         echo "\$TOOLBOX_PATH is not set correctly!" >&2
+         exit 1
+ fi
+@@ -57,7 +57,7 @@
+ cd $WORKDIR
+ 
+ 
+-nm --defined-only $TOOLBOX_PATH/bart | cut -c11-16,19- | sort > bart.syms
++nm --defined-only $TOOLBOX_PATH/bin/bart | cut -c11-16,19- | sort > bart.syms
+ 
+ 
+ cat $in	| grep "^TRACE" \
+diff -ru a/startup.m b/startup.m
+--- a/startup.m	2020-04-10 18:50:50.048248699 -0500
++++ b/startup.m	2020-04-10 18:51:40.390209486 -0500
+@@ -1,4 +1,3 @@
+ % set Matlab path and TOOLBOX_PATH environment variable
+-addpath(fullfile(pwd, 'matlab'));
+-setenv('TOOLBOX_PATH', pwd);
++addpath(fullfile(getenv('TOOLBOX_PATH'), 'matlab'));
+ 

--- a/var/spack/repos/builtin/packages/bart/package.py
+++ b/var/spack/repos/builtin/packages/bart/package.py
@@ -39,7 +39,7 @@ class Bart(MakefilePackage, CudaPackage):
         env['PREFIX'] = prefix
         env['FFTW_BASE'] = spec['fftw'].prefix
 
-        if spec['blas'].name in 'openblas':
+        if spec['blas'].name == 'openblas':
             env['OPENBLAS'] = '1'
 
         if spec['blas'].name in ['intel-mkl', 'intel-parallel-studio']:

--- a/var/spack/repos/builtin/packages/bart/package.py
+++ b/var/spack/repos/builtin/packages/bart/package.py
@@ -1,0 +1,84 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Bart(MakefilePackage, CudaPackage):
+    """BART: Toolbox for Computational Magnetic Resonance Imaging"""
+
+    homepage = "https://mrirecon.github.io/bart/"
+    url      = "https://github.com/mrirecon/bart/archive/v0.5.00.tar.gz"
+
+    version('0.5.00', sha256='30eedcda0f0ef3808157542e0d67df5be49ee41e4f41487af5c850632788f643')
+
+    # patch to fix build with MKL
+    patch('https://github.com/mrirecon/bart/commit/b62ca4972d5ac41a44217a5c27123c15daae74db.patch',
+          sha256='8fd1be181da928448da750b32d45ee6dce7ba6af0424617c4f8d653cf3f05445',
+          when='@0.5.00')
+
+    # patch to fix Makefile for openblas and cuda
+    patch('Makefile.patch')
+
+    # patch to set path to bart
+    patch('bart_path.patch')
+
+    depends_on('libpng')
+    depends_on('fftw')
+    depends_on('blas')
+    depends_on('lapack')
+    depends_on('py-numpy')
+    depends_on('py-matplotlib')
+    extends('python')
+
+    conflicts('^atlas', msg='BART does not currently support atlas')
+
+    def edit(self, spec, prefix):
+        env['PREFIX'] = prefix
+        env['FFTW_BASE'] = spec['fftw'].prefix
+
+        if spec['blas'].name in 'openblas':
+            env['OPENBLAS'] = '1'
+
+        if spec['blas'].name in ['intel-mkl', 'intel-parallel-studio']:
+            env['MKL'] = '1'
+            env['MKL_BASE'] = env['MKLROOT']
+        else:
+            env['BLAS_BASE'] = spec['blas'].prefix
+
+        if '^netlib-lapack+lapacke' not in spec:
+            env['NOLAPACKE'] = '1'
+
+        if '+cuda' in spec:
+            cuda_arch = self.spec.variants['cuda_arch'].value
+            env['CUDA'] = '1'
+            env['CUDA_BASE'] = spec['cuda'].prefix
+            env['GPUARCH_FLAGS'] = ' '.join(self.cuda_flags(cuda_arch))
+
+    def install(self, spec, prefix):
+        python_dir = join_path(prefix,
+                               spec['python'].package.site_packages_dir)
+
+        make('install')
+
+        install_tree('scripts', prefix.scripts)
+        install_tree('matlab', prefix.matlab)
+        install('startup.m', prefix)
+
+        install('python/bart.py', python_dir)
+        install('python/cfl.py', python_dir)
+        install('python/wslsupport.py', python_dir)
+
+        if '^python@3:' in spec:
+            install('python/bartview3.py', join_path(prefix.bin, 'bartview'))
+            filter_file(r'#!/usr/bin/python3', '#!/usr/bin/env python',
+                        prefix.bin.bartview)
+        else:
+            install('python/bartview.py', join_path(prefix.bin, 'bartview'))
+            filter_file(r'#!/usr/bin/python', '#!/usr/bin/env python',
+                        prefix.bin.bartview)
+
+    def setup_run_environment(self, env):
+        env.set('TOOLBOX_PATH', self.prefix)

--- a/var/spack/repos/builtin/packages/bart/package.py
+++ b/var/spack/repos/builtin/packages/bart/package.py
@@ -29,8 +29,8 @@ class Bart(MakefilePackage, CudaPackage):
     depends_on('fftw')
     depends_on('blas')
     depends_on('lapack')
-    depends_on('py-numpy')
-    depends_on('py-matplotlib')
+    depends_on('py-numpy', type='run')
+    depends_on('py-matplotlib', type='run')
     extends('python')
 
     conflicts('^atlas', msg='BART does not currently support atlas')


### PR DESCRIPTION
This PR adds the BART (Berkeley Advanced Reconstruction Toolset)
package.

Despite the presence of CMake files, this package builds with a
Makefile. It looks like the project is moving away from cmake. The patch
for MKL has been committed upstream so should only be necessary for this
version of BART.  The Makefile patch is meant for working with Spack and
would not be useful upstream. The bart scripts are still setup to use
bart with the subcommands being individual binaries. This patches those
to use the single binary with built-in subcommands and assumes that
spack is providing the TOOLBOX environment variable and setting PATH.