### PR TITLE
py-sacremoses: add new version

### DIFF
--- a/var/spack/repos/builtin/packages/py-sacremoses/package.py
+++ b/var/spack/repos/builtin/packages/py-sacremoses/package.py
@@ -8,9 +8,9 @@ class PySacremoses(PythonPackage):
     """LGPL MosesTokenizer in Python."""
 
     homepage = "https://github.com/alvations/sacremoses"
-    url      = "https://pypi.io/packages/source/s/sacremoses/sacremoses-0.0.38.tar.gz"
+    url      = "https://pypi.io/packages/source/s/sacremoses/sacremoses-0.0.39.tar.gz"
 
-    version('0.0.38', sha256='34dcfaacf9fa34a6353424431f0e4fcc60e8ebb27ffee320d57396690b712a3b')
+    version('0.0.39', sha256='53fad38b93dd5bf1657a68d52bcca5d681d4246477a764b7791a2abd5c7d1f4c')
 
     depends_on('py-setuptools', type='build')
     depends_on('py-regex', type=('build', 'run'))


### PR DESCRIPTION
I just added this package yesterday and reported a strange build warning at https://github.com/alvations/sacremoses/issues/91. A new release contains a fix, so I figure there's no point in keeping the old release in the package.

Successfully builds on macOS 10.15.4 with Clang 11.0.3 and Python 3.7.6.