### PR TITLE
Patch Mathematica

### DIFF
--- a/var/spack/repos/builtin/packages/mathematica/package.py
+++ b/var/spack/repos/builtin/packages/mathematica/package.py
@@ -32,7 +32,7 @@ class Mathematica(Package):
 
     def install(self, spec, prefix):
         # Backup .spack because Mathematica moves it but never restores it
-        copy('{0}/.spack'.format(prefix), self.stage)
+        copy_tree(join_path(prefix, '.spack'), self.stage)
 
         sh = which('sh')
         sh(self.stage.archive_file, '--', '-auto', '-verbose',
@@ -48,4 +48,4 @@ class Mathematica(Package):
             ln('-s', ws_path, ws_link_path)
 
         # Move back .spack where it belongs
-        copy('self.stage/.spack', '{0}/.spack'.format(prefix))
+        copy_tree(join_path(self.stage, '.spack'), prefix)

--- a/var/spack/repos/builtin/packages/mathematica/package.py
+++ b/var/spack/repos/builtin/packages/mathematica/package.py
@@ -35,7 +35,8 @@ class Mathematica(Package):
         # Backup .spack because Mathematica moves it but never restores it
         rand_suffix = random.randint(1, 65536)
         cp = which('cp')
-        cp('-a', '{0}/.spack'.format(prefix), '/tmp/.spack-{0}'.format(rand_suffix))
+        cp('-a', '{0}/.spack'.format(prefix),
+           '/tmp/.spack-{0}'.format(rand_suffix))
 
         sh = which('sh')
         sh(self.stage.archive_file, '--', '-auto', '-verbose',

--- a/var/spack/repos/builtin/packages/mathematica/package.py
+++ b/var/spack/repos/builtin/packages/mathematica/package.py
@@ -5,7 +5,6 @@
 
 from spack import *
 import os
-import random
 
 
 class Mathematica(Package):
@@ -33,10 +32,7 @@ class Mathematica(Package):
 
     def install(self, spec, prefix):
         # Backup .spack because Mathematica moves it but never restores it
-        rand_suffix = random.randint(1, 65536)
-        cp = which('cp')
-        cp('-a', '{0}/.spack'.format(prefix),
-           '/tmp/.spack-{0}'.format(rand_suffix))
+        copy('{0}/.spack'.format(prefix), self.stage)
 
         sh = which('sh')
         sh(self.stage.archive_file, '--', '-auto', '-verbose',
@@ -52,5 +48,4 @@ class Mathematica(Package):
             ln('-s', ws_path, ws_link_path)
 
         # Move back .spack where it belongs
-        mv = which('mv')
-        mv('/tmp/.spack-{0}'.format(rand_suffix), '{0}/.spack'.format(prefix))
+        copy('self.stage/.spack', '{0}/.spack'.format(prefix))

--- a/var/spack/repos/builtin/packages/mathematica/package.py
+++ b/var/spack/repos/builtin/packages/mathematica/package.py
@@ -5,6 +5,7 @@
 
 from spack import *
 import os
+import random
 
 
 class Mathematica(Package):
@@ -31,6 +32,11 @@ class Mathematica(Package):
     license_url      = 'https://reference.wolfram.com/language/tutorial/RegistrationAndPasswords.html#857035062'
 
     def install(self, spec, prefix):
+        # Backup .spack because Mathematica moves it but never restores it
+        rand_suffix = random.randint(1, 65536)
+        cp = which('cp')
+        cp('-a', '{0}/.spack'.format(prefix), '/tmp/.spack-{0}'.format(rand_suffix))
+
         sh = which('sh')
         sh(self.stage.archive_file, '--', '-auto', '-verbose',
            '-targetdir={0}'.format(prefix),
@@ -43,3 +49,7 @@ class Mathematica(Package):
             ln = which('ln')
             ws_path = os.path.join(prefix, 'Executables', 'wolframscript')
             ln('-s', ws_path, ws_link_path)
+
+        # Move back .spack where it belongs
+        mv = which('mv')
+        mv('/tmp/.spack-{0}'.format(rand_suffix), '{0}/.spack'.format(prefix))


### PR DESCRIPTION
Mathematica installer moves all files and directories from installation directory to a backup one. The problem is that it also moves .spack to this backup location. Once it's done it does not move .spack back where it was.

My patch creates a copy of .spack to /tmp then moves it back right before exiting the install call.