### PR TITLE
Add support for pre-release builds of Rust (beta, master, nightly)

### DIFF
--- a/var/spack/repos/builtin/packages/rust/package.py
+++ b/var/spack/repos/builtin/packages/rust/package.py
@@ -65,6 +65,14 @@ class Rust(Package):
     depends_on('libssh2')
     depends_on('libgit2')
 
+    # Pre-release Versions
+    version('master', branch='master', submodules=True)
+
+    # These version strings are officially supported, but aren't explicitly
+    # listed because there's no stable checksum for them.
+    # version('nightly')
+    # version('beta')
+
     # Version Notes:
     # Here's some information on why your favorite Rust version may be missing.
     #
@@ -324,6 +332,37 @@ class Rust(Package):
         ]
     }
 
+    # Specifies the strings which represent a pre-release Rust version. These
+    # always bootstrap with the latest beta release.
+    #
+    # NOTE: These are moving targets, and therefore have no stable checksum. Be
+    # sure to specify "-n" or "--no-checksum" when installing these versions.
+    rust_prerelease_versions = ["beta", "nightly", "master"]
+
+    for prerelease_version in rust_prerelease_versions:
+        for rust_target, rust_arch_list in iteritems(rust_archs):
+            for rust_arch in rust_arch_list:
+                # All pre-release builds are built with the latest beta
+                # compiler.
+                resource(
+                    name='rust-beta-{target}'.format(
+                        target=rust_target
+                    ),
+                    url='https://static.rust-lang.org/dist/rust-beta-{target}.tar.gz'.format(
+                        target=rust_target
+                    ),
+                    # Fake SHA - checksums should never be checked for
+                    # pre-release builds, anyway
+                    sha256='0000000000000000000000000000000000000000000000000000000000000000',
+                    destination='spack_bootstrap_stage',
+                    when='@{version} platform={platform} target={target}'\
+                        .format(
+                            version=prerelease_version,
+                            platform=rust_arch['platform'],
+                            target=rust_arch['target']
+                        )
+                )
+
     # This loop generates resources for each binary distribution, and maps
     # them to the version of the compiler they bootstrap. This is in place
     # of listing each resource explicitly, which would be potentially even
@@ -372,14 +411,30 @@ class Rust(Package):
                 self.spec.architecture
             ))
 
+    def check_newer(self, version):
+        if '@master' in self.spec or '@beta' in self.spec or \
+           '@nightly' in self.spec:
+            return True
+
+        return '@{0}:'.format(version) in self.spec
+
     def configure(self, spec, prefix):
         target = self.get_rust_target()
+
+        # Bootstrapping compiler selection:
+        # Pre-release compilers use the latest beta release for the
+        # bootstrapping compiler.
+        # Versioned releases bootstrap themselves.
+        if '@beta' in spec or '@nightly' in spec or '@master' in spec:
+            bootstrap_version = 'beta'
+        else:
+            bootstrap_version = spec.version
         # See the NOTE above the resource loop - should be host architecture,
         # not target aarchitecture if we're to support cross-compiling.
         bootstrapping_install = Executable(
             './spack_bootstrap_stage/rust-{version}-{target}/install.sh'
             .format(
-                version=spec.version,
+                version=bootstrap_version,
                 target=target
             )
         )
@@ -407,7 +462,8 @@ class Rust(Package):
         ar = which('ar', required=True)
 
         # build.tools was introduced in Rust 1.25
-        tools_spec = 'tools={0}'.format(tools) if '@1.25:' in self.spec else ''
+        tools_spec = \
+            'tools={0}'.format(tools) if self.check_newer('1.25') else ''
         # This is a temporary fix due to rust 1.42 breaking self bootstrapping
         # See: https://github.com/rust-lang/rust/issues/69953
         #
@@ -416,6 +472,18 @@ class Rust(Package):
         # the latest set of warning.
         deny_warnings_spec = \
             'deny-warnings = false' if '@1.42.0' in self.spec else ''
+
+        # "Nightly" and master builds want a path to rustfmt - otherwise, it
+        # will try to download rustfmt from the Internet. We'll give it rustfmt
+        # for the bootstrapping compiler, but it ultimately shouldn't matter
+        # because this package never invokes it. To be clear, rustfmt from the
+        # bootstrapping compiler is probably incorrect. See: src/stage0.txt in
+        # Rust to see what the current "official" rustfmt version for Rust is.
+        if '@master' in spec or '@nightly' in spec:
+            rustfmt_spec = \
+                'rustfmt="{0}"'.format(join_path(boot_bin, 'rustfmt'))
+        else:
+            rustfmt_spec = ''
 
         with open('config.toml', 'w') as out_file:
             out_file.write("""\
@@ -427,6 +495,7 @@ vendor = true
 extended = true
 verbose = 2
 {tools_spec}
+{rustfmt_spec}
 
 [rust]
 channel = "stable"
@@ -446,7 +515,8 @@ sysconfdir = "etc"
                 target=target,
                 deny_warnings_spec=deny_warnings_spec,
                 ar=ar.path,
-                tools_spec=tools_spec
+                tools_spec=tools_spec,
+                rustfmt_spec=rustfmt_spec
             )
             )
 


### PR DESCRIPTION
This PR adds support for building pre-release versions of Rust, including the latest beta and nightly releases, along with building from the master branch at https://github.com/rust-lang/rust.

These releases all only build with `-n`/`--no-checksum`.

The "beta" and "nightly" versions are not "advertised" because spack requires all `version`s to have a checksum, unless they're a source control version.

"beta" and "nightly" _should_ build offline, but I haven't tested it. "master" will not because it fetches its Rust dependencies from Rust's package manager.

It's hypothetically possible to support specific nightly releases of Rust, but this PR doesn't support that. If anybody is interested in implementing this, the source code for a specific nightly release of Rust is hosted at a slightly different URL scheme than the one used by the moving target pre-releases and official releases. For example, the source for the nightly release of Rust for 1/31/2020 is hosted at: `https://static.rust-lang.org/dist/2020-01-31/rustc-nightly-src.tar.gz`

Note: as of this writing, the `rustfmt` component does not build for the latest "nightly" release: https://github.com/rust-lang/rust/issues/71077

You can disable the rustfmt build by adding `-rustfmt` when building the "rust" package. "master" also couldn't build "clippy" when I tried, which I resolved by specifying `-clippy`. I assume this is also transient.