### PR TITLE
netcdf-fortran: add new variants

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -182,6 +182,7 @@ class NetcdfC(AutotoolsPackage):
             else:
                 config_args.append('--disable-parallel4')
 
+        if self.spec.satisfies('@4.3.2:'):
             config_args += self.enable_or_disable('jna')
 
         # Starting version 4.1.3, --with-hdf5= and other such configure options

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -182,10 +182,7 @@ class NetcdfC(AutotoolsPackage):
             else:
                 config_args.append('--disable-parallel4')
 
-        if '+jna' in self.spec:
-            config_args.append('--enable-jna')
-        else:
-            config_args.append('--disable-jna')
+            config_args += self.enable_or_disable('jna')
 
         # Starting version 4.1.3, --with-hdf5= and other such configure options
         # are removed. Variables CPPFLAGS, LDFLAGS, and LD_LIBRARY_PATH must be

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -61,6 +61,7 @@ class NetcdfC(AutotoolsPackage):
             description='Produce position-independent code (for shared libs)')
     variant('shared', default=True, description='Enable shared library')
     variant('dap', default=False, description='Enable DAP support')
+    variant('jna', default=False, description='Enable JNA support')
 
     # It's unclear if cdmremote can be enabled if '--enable-netcdf-4' is passed
     # to the configure script. Since netcdf-4 support is mandatory we comment
@@ -180,6 +181,11 @@ class NetcdfC(AutotoolsPackage):
                 config_args.append('--enable-parallel4')
             else:
                 config_args.append('--disable-parallel4')
+
+        if '+jna' in self.spec:
+            config_args.append('--enable-jna')
+        else:
+            config_args.append('--disable-jna')
 
         # Starting version 4.1.3, --with-hdf5= and other such configure options
         # are removed. Variables CPPFLAGS, LDFLAGS, and LD_LIBRARY_PATH must be

--- a/var/spack/repos/builtin/packages/netcdf-fortran/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-fortran/package.py
@@ -27,12 +27,7 @@ class NetcdfFortran(AutotoolsPackage):
     variant('pic', default=True,
             description='Produce position-independent code (for shared libs)')
     variant('shared', default=True, description='Enable shared library')
-    variant('dap', default=False, description='Enable DAP support')
-    variant('jna', default=False, description='Enable JNA support')
-    variant('doxygen', default=True, description='Enable doxygen docs')
-    variant('ncgen4', default=True, description='Enable generating netcdf-4 data')
-    variant('pnetcdf', default=True, description='Enable parallel-netcdf')
-    variant('netcdf4', default=False, description='Enable netcdf-4 data structure')
+    variant('doc', default=False, description='Enable building docs')
 
     # We need to build with MPI wrappers if parallel I/O features is enabled:
     # https://www.unidata.ucar.edu/software/netcdf/docs/building_netcdf_fortran.html
@@ -40,6 +35,7 @@ class NetcdfFortran(AutotoolsPackage):
 
     depends_on('netcdf-c~mpi', when='~mpi')
     depends_on('netcdf-c+mpi', when='+mpi')
+    depends_on('doxygen', when='+doc', type='build')
 
     # The default libtool.m4 is too old to handle NAG compiler properly:
     # https://github.com/Unidata/netcdf-fortran/issues/94
@@ -122,37 +118,12 @@ class NetcdfFortran(AutotoolsPackage):
             config_args.append('FC=%s' % self.spec['mpi'].mpifc)
             config_args.append('F77=%s' % self.spec['mpi'].mpif77)
 
-        if '+dap' in self.spec:
-            config_args.append('--enable-dap')
-        else:
-            config_args.append('--disable-dap')
-
         if '+pic' in self.spec:
             config_args.append('--with-pic')
         else:
             config_args.append('--without-pic')
 
-        if '+jna' in self.spec:
-            config_args.append('--enable-jna')
-        else:
-            config_args.append('--disable-jna')
-
-        if '+pnetcdf' in self.spec:
-            config_args.append('--enable-pnetcdf')
-        else:
-            config_args.append('--disable-pnetcdf')
-
-        if '+netcdf4' in self.spec:
-            config_args.append('--enable-netcdf-4')
-        else:
-            config_args.append('--disable-netcdf-4')
-
-        if '+ncgen4' in self.spec:
-            config_args.append('--enable-ncgen4')
-        else:
-            config_args.append('--disable-ncgen4')
-
-        if '+doxygen' in self.spec:
+        if '+doc' in self.spec:
             config_args.append('--enable-doxygen')
         else:
             config_args.append('--disable-doxygen')

--- a/var/spack/repos/builtin/packages/netcdf-fortran/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-fortran/package.py
@@ -27,8 +27,6 @@ class NetcdfFortran(AutotoolsPackage):
     variant('pic', default=True,
             description='Produce position-independent code (for shared libs)')
     variant('shared', default=True, description='Enable shared library')
-    variant('pic', default=True,
-            description='Produce position-independent code (for shared libs)')
     variant('dap', default=False, description='Enable DAP support')
     variant('jna', default=False, description='Enable JNA support')
     variant('doxygen', default=True, description='Enable doxygen docs')

--- a/var/spack/repos/builtin/packages/netcdf-fortran/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-fortran/package.py
@@ -27,6 +27,14 @@ class NetcdfFortran(AutotoolsPackage):
     variant('pic', default=True,
             description='Produce position-independent code (for shared libs)')
     variant('shared', default=True, description='Enable shared library')
+    variant('pic', default=True,
+            description='Produce position-independent code (for shared libs)')
+    variant('dap', default=False, description='Enable DAP support')
+    variant('jna', default=False, description='Enable JNA support')
+    variant('doxygen', default=True, description='Enable doxygen docs')
+    variant('ncgen4', default=True, description='Enable generating netcdf-4 data')
+    variant('pnetcdf', default=True, description='Enable parallel-netcdf')
+    variant('netcdf4', default=False, description='Enable netcdf-4 data structure')
 
     # We need to build with MPI wrappers if parallel I/O features is enabled:
     # https://www.unidata.ucar.edu/software/netcdf/docs/building_netcdf_fortran.html
@@ -115,6 +123,41 @@ class NetcdfFortran(AutotoolsPackage):
             config_args.append('CC=%s' % self.spec['mpi'].mpicc)
             config_args.append('FC=%s' % self.spec['mpi'].mpifc)
             config_args.append('F77=%s' % self.spec['mpi'].mpif77)
+
+        if '+dap' in self.spec:
+            config_args.append('--enable-dap')
+        else:
+            config_args.append('--disable-dap')
+
+        if '+pic' in self.spec:
+            config_args.append('--with-pic')
+        else:
+            config_args.append('--without-pic')
+
+        if '+jna' in self.spec:
+            config_args.append('--enable-jna')
+        else:
+            config_args.append('--disable-jna')
+
+        if '+pnetcdf' in self.spec:
+            config_args.append('--enable-pnetcdf')
+        else:
+            config_args.append('--disable-pnetcdf')
+
+        if '+netcdf4' in self.spec:
+            config_args.append('--enable-netcdf-4')
+        else:
+            config_args.append('--disable-netcdf-4')
+
+        if '+ncgen4' in self.spec:
+            config_args.append('--enable-ncgen4')
+        else:
+            config_args.append('--disable-ncgen4')
+
+        if '+doxygen' in self.spec:
+            config_args.append('--enable-doxygen')
+        else:
+            config_args.append('--disable-doxygen')
 
         return config_args
 

--- a/var/spack/repos/builtin/packages/netcdf-fortran/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-fortran/package.py
@@ -118,11 +118,6 @@ class NetcdfFortran(AutotoolsPackage):
             config_args.append('FC=%s' % self.spec['mpi'].mpifc)
             config_args.append('F77=%s' % self.spec['mpi'].mpif77)
 
-        if '+pic' in self.spec:
-            config_args.append('--with-pic')
-        else:
-            config_args.append('--without-pic')
-
         if '+doc' in self.spec:
             config_args.append('--enable-doxygen')
         else:


### PR DESCRIPTION
This PR adds the following variants for building netcdf-fortran:
- PIC
- DAP
- JNA
- Doxygen documentation
- ncgen4
- pnetcdf
- netcdf4
 
All variants have explicit toggles for enable/disable and I did my best to preserve existing behaviors with the default values. 