### PR TITLE
py-memory-profiler: add new version

### DIFF
--- a/var/spack/repos/builtin/packages/py-memory-profiler/package.py
+++ b/var/spack/repos/builtin/packages/py-memory-profiler/package.py
@@ -10,9 +10,10 @@ class PyMemoryProfiler(PythonPackage):
     """A module for monitoring memory usage of a python program"""
 
     homepage = "https://github.com/fabianp/memory_profiler"
-    url      = "https://pypi.io/packages/source/m/memory_profiler/memory_profiler-0.47.tar.gz"
+    url      = "https://pypi.io/packages/source/m/memory_profiler/memory_profiler-0.57.0.tar.gz"
 
-    version('0.47', sha256='e992f2a341a5332dad1ad4a008eeac7cfe78c7ea4abdf7535a3e7e79093328cb')
+    version('0.57.0', sha256='23b196f91ea9ac9996e30bfab1e82fecc30a4a1d24870e81d1e81625f786a2c3')
+    version('0.47',   sha256='e992f2a341a5332dad1ad4a008eeac7cfe78c7ea4abdf7535a3e7e79093328cb')
 
     depends_on('py-setuptools', type='build')
-    depends_on('py-psutil',        type=('build', 'run'))
+    depends_on('py-psutil', type=('build', 'run'))


### PR DESCRIPTION
Successfully installs on macOS 10.15.4 with Python 3.7.6 and Clang 11.0.3.