### PR TITLE
MAINT: Charliecloud OSX error

### DIFF
--- a/var/spack/repos/builtin/packages/charliecloud/package.py
+++ b/var/spack/repos/builtin/packages/charliecloud/package.py
@@ -34,9 +34,7 @@ class Charliecloud(AutotoolsPackage):
     depends_on('py-sphinx',           type='build', when='+docs')
     depends_on('py-sphinx-rtd-theme', type='build', when='+docs')
 
-    if sys.platform == 'darwin':
-       raise InstallError("This package does not build on Mac OS X\n"
-                          "see: https://github.com/hpc/charliecloud/issues/42")
+    conflicts('platform=darwin', msg='This package does not build on macOS')
 
     # bash automated testing harness (bats)
     depends_on('bats@0.4.0', type='test')

--- a/var/spack/repos/builtin/packages/charliecloud/package.py
+++ b/var/spack/repos/builtin/packages/charliecloud/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-import sys
 
 
 class Charliecloud(AutotoolsPackage):

--- a/var/spack/repos/builtin/packages/charliecloud/package.py
+++ b/var/spack/repos/builtin/packages/charliecloud/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+import sys
 
 
 class Charliecloud(AutotoolsPackage):
@@ -32,6 +33,10 @@ class Charliecloud(AutotoolsPackage):
     depends_on('rsync',               type='build', when='+docs')
     depends_on('py-sphinx',           type='build', when='+docs')
     depends_on('py-sphinx-rtd-theme', type='build', when='+docs')
+
+    if sys.platform == 'darwin':
+       raise InstallError("This package does not build on Mac OS X\n"
+                          "see: https://github.com/hpc/charliecloud/issues/42")
 
     # bash automated testing harness (bats)
     depends_on('bats@0.4.0', type='test')


### PR DESCRIPTION
* raise an appropriate error when attempting to build
`Charliecloud` on Mac OSX, since it will otherwise fail
with a more confusing configure stage link check failure

cc @reidpr @junghans 

Technically, the configure stage will almost certainly fail with `FreeBSD` as well since linker checks are Linux-specific at the moment, but maybe start with this for now.