### PR TITLE
libtree: new versions 1.0.4 and 1.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/libtree/package.py
+++ b/var/spack/repos/builtin/packages/libtree/package.py
@@ -15,4 +15,6 @@ class Libtree(CMakePackage):
 
     maintainers = ['haampie']
 
+    version('1.1.0', sha256='6cf36fb9a4c8c3af01855527d4931110732bb2d1c19be9334c689f1fd1c78536')
+    version('1.0.4', sha256='b15a54b6f388b8bd8636e288fcb581029f1e65353660387b0096a554ad8e9e45')
     version('1.0.3', sha256='67ce886c191d50959a5727246cdb04af38872cd811c9ed4e3822f77a8f40b20b')


### PR DESCRIPTION
Bumps versions of https://github.com/haampie/libtree