### PR TITLE
Features/spack test subcommands

### DIFF
--- a/lib/spack/spack/cmd/clean.py
+++ b/lib/spack/spack/cmd/clean.py
@@ -82,9 +82,7 @@ def clean(parser, args):
 
     if args.test_stage:
         tty.msg("Removing files in test stage")
-        test_stage_root = sup.canonicalize_path(
-            spack.config.get('config:test_stage', ''))
-        fs.remove_directory_contents(test_stage_root)
+        spack.cmd.test.test_remove(NamedTuple({'name': None}))
 
     if args.python_cache:
         tty.msg('Removing python cache files')

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -8,8 +8,11 @@ import os
 import argparse
 import textwrap
 import datetime
+import fnmatch
+import re
 
 import llnl.util.tty as tty
+from llnl.util.filesystem import mkdirp
 
 import spack.environment as ev
 import spack.cmd
@@ -23,27 +26,35 @@ level = "long"
 
 
 def setup_parser(subparser):
-    subparser.add_argument('--keep-stage', action='store_true',
-                           help='Keep testing directory for debugging')
-    subparser.add_argument(
+    sp = subparser.add_subparsers(metavar='SUBCOMMAND', dest='test_command')
+
+    # Run
+    run_parser = sp.add_parser('run', help=test_run.__doc__)
+
+    run_parser.add_argument(
+        '-n', '--name', help="The name of the test. Default is current time"
+    )
+    run_parser.add_argument('--keep-stage', action='store_true',
+                            help='Keep testing directory for debugging')
+    run_parser.add_argument(
         '--log-format',
         default=None,
         choices=spack.report.valid_formats,
         help="format to be used for log files"
     )
-    subparser.add_argument(
+    run_parser.add_argument(
         '--log-file',
         default=None,
         help="filename for the log file. if not passed a default will be used"
     )
-    arguments.add_cdash_args(subparser, False)
-    subparser.add_argument(
+    arguments.add_cdash_args(run_parser, False)
+    run_parser.add_argument(
         '--help-cdash',
         action='store_true',
         help="Show usage instructions for CDash reporting"
     )
 
-    length_group = subparser.add_mutually_exclusive_group()
+    length_group = run_parser.add_mutually_exclusive_group()
     length_group.add_argument(
         '--smoke', action='store_true', dest='smoke_test', default=True,
         help='run smoke tests (default)')
@@ -51,17 +62,31 @@ def setup_parser(subparser):
         '--capability', action='store_false', dest='smoke_test', default=True,
         help='run full capability tests using pavilion')
 
-    cd_group = subparser.add_mutually_exclusive_group()
+    cd_group = run_parser.add_mutually_exclusive_group()
     arguments.add_common_arguments(cd_group, ['clean', 'dirty'])
 
-    arguments.add_common_arguments(subparser, ['installed_specs'])
+    arguments.add_common_arguments(run_parser, ['installed_specs'])
 
+    # List
+    list_parser = sp.add_parser('list', help=test_list.__doc__)
+    list_parser.add_argument(
+        'filter', nargs=argparse.REMAINDER,
+        help='optional case-insensitive glob patterns to filter results.')
 
-def test(parser, args):
-    # record test time
-    now = datetime.datetime.now()
-    tty.msg("Spack test at %s" % now.strftime('%Y-%m-%d_%H:%M:%S'))
+    # Status
+    status_parser = sp.add_parser('status', help=test_status.__doc__)
+    status_parser.add_argument('name', help="Test for which to provide status")
 
+    # Status
+    results_parser = sp.add_parser('results', help=test_results.__doc__)
+    results_parser.add_argument('name', help="Test for which to print results")
+
+def test_run(args):
+    """Run tests for the specified installed packages
+
+    If no specs are listed, run tests for all packages in the current
+    environment or all installed packages if there is no active environment.
+    """
     # cdash help option
     if args.help_cdash:
         parser = argparse.ArgumentParser(
@@ -74,6 +99,11 @@ environment variables:
         arguments.add_cdash_args(parser, True)
         parser.print_help()
         return
+
+    # record test time; this will be default test name
+    now = datetime.datetime.now()
+    test_name = args.name or now.strftime('%Y-%m-%d_%H:%M:%S')
+    tty.msg("Spack test %s" % test_name)
 
     # Get specs to test
     env = ev.get_env(args, 'test')
@@ -101,26 +131,119 @@ environment variables:
         else:
             log_file = os.path.join(
                 os.getcwd(),
-                'test-%s' % now.strftime('%Y-%m-%d_%H:%M:%S'))
+                'test-%s' % test_name)
         reporter.filename = log_file
     reporter.specs = specs_to_test
 
     # test_stage_dir
-    test_name = now.strftime('%Y-%m-%d_%H:%M:%S')
-    stage = os.path.join(
-        spack.util.path.canonicalize_path(
-            spack.config.get('config:test_stage', os.getcwd())),
-        test_name)
+    stage = _get_stage(test_name)
+    mkdirp(stage)
 
     with reporter('test', stage):
         if args.smoke_test:
             for spec in specs_to_test:
                 try:
                     spec.package.do_test(
-                        time=now,
+                        name=test_name,
                         remove_directory=not args.keep_stage,
                         dirty=args.dirty)
+                    with open(_get_results_file(test_name), 'a') as f:
+                        f.write("%s PASSED\n" % spec.format("{name}-{hash:7}"))
                 except BaseException:
-                    pass  # Test is logged, go on to other tests
+                    with open(_get_results_file(test_name), 'a') as f:
+                        f.write("%s FAILED\n" % spec.format("{name}-{hash:7}"))
         else:
             raise NotImplementedError
+
+
+def test_list(args):
+    """
+    List tests that are running or have available results.
+    """
+    stage_dir = _get_stage()
+    tests = os.listdir(stage_dir)
+
+    # Filter tests by filter argument
+    if args.filter:
+        def create_filter(f):
+            raw = fnmatch.translate('f' if '*' in f or '?' in f
+                                    else '*' + f + '*')
+            return re.compile(raw, flags=re.IGNORECASE)
+        filters = [create_filter(f) for f in args.filter]
+
+        def match(t, f):
+            return f.match(t)
+        tests = [t for t in tests if any(match(t, f) for f in filters)]
+
+    if tests:
+        # TODO: Make these specify results vs active
+        msg = "Spack test results available for the following tests:\n"
+        msg += "        %s\n" % ' '.join(tests)
+        msg += "    Run `spack clean -t` to remove all tests"
+        tty.msg(msg)
+    else:
+        msg = "No test results match the query\n"
+        msg += "        Tests may have been removed using `spack clean -t`"
+        tty.msg(msg)
+
+
+def test_status(args):
+    """
+    Get the current status for a particular Spack test ensemble.
+    """
+    name = args.name
+    stage = _get_stage(name)
+
+    if os.path.exists(stage):
+        # TODO: Make this handle capability tests too
+        tty.msg("Test %s completed" % name)
+    else:
+        tty.msg("Test %s no longer available" % name)
+
+
+def test_results(args):
+    """
+    Get the results for a particular Spack test ensemble.
+    """
+    name = args.name
+    stage = _get_stage(name)
+
+    # TODO: Make this handle capability tests too
+    # The results file may turn out to be a placeholder for future work
+    if os.path.exists(stage):
+        results_file = _get_results_file(name)
+        if os.path.exists(results_file):
+            msg = "Results for test %s: \n" % name
+            with open(results_file, 'r') as f:
+                lines = f.readlines()
+            for line in lines:
+                msg += "        %s" % line
+            tty.msg(msg)
+        else:
+            msg = "Test %s has no results.\n" % name
+            msg += "        Check if it is active with "
+            msg += "`spack test status %s`" % name
+            tty.msg(msg)
+    else:
+        tty.msg("No test %s found in test stage" % name)
+
+
+def test(parser, args):
+    globals()['test_%s' % args.test_command](args)
+
+
+def _get_stage(name=None):
+    """
+    Return the test stage for the named test or the overall test stage.
+    """
+    stage_dir = spack.util.path.canonicalize_path(
+        spack.config.get('config:test_stage', os.getcwd()))
+    return os.path.join(stage_dir, name) if name else stage_dir
+
+
+def _get_results_file(name):
+    """
+    Return the results file for the named test.
+    """
+    stage = _get_stage(name)
+    return os.path.join(stage, 'results.txt')

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -31,11 +31,16 @@ def setup_parser(subparser):
     # Run
     run_parser = sp.add_parser('run', help=test_run.__doc__)
 
+    name_help_msg = "Name the test for subsequent access."
+    name_help_msg += " Default is the timestamp of the run formatted"
+    name_help_msg += " 'YYYY-MM-DD_HH:MM:SS'"
+    run_parser.add_argument('-n', '--name', help=name_help_msg)
+
     run_parser.add_argument(
-        '-n', '--name', help="The name of the test. Default is current time"
+        '--keep-stage',
+        action='store_true',
+        help='Keep testing directory for debugging'
     )
-    run_parser.add_argument('--keep-stage', action='store_true',
-                            help='Keep testing directory for debugging')
     run_parser.add_argument(
         '--log-format',
         default=None,

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1467,7 +1467,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
 
     test_requires_compiler = False
 
-    def do_test(self, time, remove_directory=False, dirty=False):
+    def do_test(self, name, remove_directory=False, dirty=False):
         if self.test_requires_compiler:
             compilers = spack.compilers.compilers_for_spec(
                 self.spec.compiler, arch_spec=self.spec.architecture)
@@ -1478,11 +1478,10 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
                           self.spec.compiler)
                 return
 
-        test_name = time.strftime('%Y-%m-%d_%H:%M:%S')
         test_stage = Prefix(os.path.join(
             sup.canonicalize_path(
                 spack.config.get('config:test_stage', os.getcwd())),
-            test_name))
+            name))
         if not os.path.exists(test_stage):
             mkdirp(test_stage)
         test_log_file = os.path.join(test_stage, self.test_log_name)
@@ -1531,7 +1530,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
 
         spack.build_environment.fork(
             self, test_process, dirty=dirty, fake=False, context='test',
-            test_name=test_name)
+            test_name=name)
 
     def test(self):
         pass

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1410,9 +1410,45 @@ _spack_stage() {
 _spack_test() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --keep-stage --log-format --log-file --cdash-upload-url --cdash-build --cdash-site --cdash-track --cdash-buildstamp --help-cdash --smoke --capability --clean --dirty"
+        SPACK_COMPREPLY="-h --help"
+    else
+        SPACK_COMPREPLY="run list status results"
+    fi
+}
+
+_spack_test_run() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help -n --name --keep-stage --log-format --log-file --cdash-upload-url --cdash-build --cdash-site --cdash-track --cdash-buildstamp --help-cdash --smoke --capability --clean --dirty"
     else
         _installed_packages
+    fi
+}
+
+_spack_test_list() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help"
+    else
+        _all_packages
+    fi
+}
+
+_spack_test_status() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help"
+    else
+        SPACK_COMPREPLY=""
+    fi
+}
+
+_spack_test_results() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help"
+    else
+        SPACK_COMPREPLY=""
     fi
 }
 


### PR DESCRIPTION
The "capability" tests we have planned through pavilion2 are asynchronous using the resource manager, so we have to have separate commands for launching, checking on, and getting results from tests.

This PR adds `run`, `list`, `status`, and `results` subcommands to the `spack test` command. The `run` command is all that is necessary for the smoke tests, but the other commands are still valid.

This PR adds all other components necessary to make the separate commands work in the smoke-test case.