### PR TITLE
New package: py-cmake-format

### DIFF
--- a/var/spack/repos/builtin/packages/py-cmake-format/package.py
+++ b/var/spack/repos/builtin/packages/py-cmake-format/package.py
@@ -7,14 +7,9 @@ from spack import *
 
 
 class PyCmakeFormat(PythonPackage):
-    """cmake-format project provides Quality Assurance (QA) tools for cmake.
-
-- cmake-annotate can generate pretty HTML from your listfiles
-- cmake-format   can format your listfiles nicely so that they don’t look
-                 like crap.
-- cmake-lint     can check your listfiles for problems
-- ctest-to       can parse a ctest output tree and translate it into a more
-                 structured format (either JSON or XML)."""
+    """cmake-format project provides Quality Assurance (QA) tools for
+    cmake. Tools include cmake-annotate, cmake-format, cmake-lint,
+    and ctest-to."""
 
     homepage = "https://pypi.python.org/pypi/cmake-format"
     url      = "https://pypi.io/packages/source/c/cmake_format/cmake_format-0.6.9.tar.gz"

--- a/var/spack/repos/builtin/packages/py-cmake-format/package.py
+++ b/var/spack/repos/builtin/packages/py-cmake-format/package.py
@@ -10,9 +10,11 @@ class PyCmakeFormat(PythonPackage):
     """cmake-format project provides Quality Assurance (QA) tools for cmake.
 
 - cmake-annotate can generate pretty HTML from your listfiles
-- cmake-format   can format your listfiles nicely so that they don’t look like crap.
+- cmake-format   can format your listfiles nicely so that they don’t look
+                 like crap.
 - cmake-lint     can check your listfiles for problems
-- ctest-to       can parse a ctest output tree and translate it into a more structured format (either JSON or XML)."""
+- ctest-to       can parse a ctest output tree and translate it into a more
+                 structured format (either JSON or XML)."""
 
     homepage = "https://pypi.python.org/pypi/cmake-format"
     url      = "https://pypi.io/packages/source/c/cmake_format/cmake_format-0.6.9.tar.gz"

--- a/var/spack/repos/builtin/packages/py-cmake-format/package.py
+++ b/var/spack/repos/builtin/packages/py-cmake-format/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyCmakeFormat(PythonPackage):
+    """cmake-format project provides Quality Assurance (QA) tools for cmake.
+
+- cmake-annotate can generate pretty HTML from your listfiles
+- cmake-format   can format your listfiles nicely so that they don’t look like crap.
+- cmake-lint     can check your listfiles for problems
+- ctest-to       can parse a ctest output tree and translate it into a more structured format (either JSON or XML)."""
+
+    homepage = "https://pypi.python.org/pypi/cmake-format"
+    url      = "https://pypi.io/packages/source/c/cmake_format/cmake_format-0.6.9.tar.gz"
+
+    version('0.6.9', sha256='b2f8bf2e9c6651126f2f2954b7803222b0faf6b8649eabc4d965ea97483a4d20')
+
+    depends_on('py-setuptools',  type=('build', 'run'))
+    depends_on('py-six@1.13.0:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-six/package.py
+++ b/var/spack/repos/builtin/packages/py-six/package.py
@@ -14,6 +14,7 @@ class PySix(PythonPackage):
 
     import_modules = ['six']
 
+    version('1.14.0', sha256='236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a')
     version('1.12.0', sha256='d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73')
     version('1.11.0', sha256='70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9')
     version('1.10.0', sha256='105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a')


### PR DESCRIPTION
* Provide a new python package `py-cmake-format`. This package is similar to the familiar _clang-format_, but it standardizes the format of CMake files, https://pypi.python.org/pypi/cmake-format
   * Requires a slightly newer version of `py-six`, so I updated that `package.py` in the same PR.
```
cmake-format project provides Quality Assurance (QA) tools for cmake.

- cmake-annotate can generate pretty HTML from your listfiles
- cmake-format   can format your listfiles nicely so that they don’t look 
                 like crap.
- cmake-lint     can check your listfiles for problems
- ctest-to       can parse a ctest output tree and translate it into a more 
                 structured format (either JSON or XML).
```