### PR TITLE
x.org: mirror mixin

### DIFF
--- a/lib/spack/spack/build_systems/xorg.py
+++ b/lib/spack/spack/build_systems/xorg.py
@@ -1,0 +1,37 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import spack.util.url
+import spack.package
+
+
+class XorgPackage(spack.package.PackageBase):
+    """Mixin that takes care of setting url and mirrors for x.org
+       packages."""
+    #: Path of the package in a x.org mirror
+    xorg_mirror_path = None
+
+    #: List of x.org mirrors used by Spack
+    base_mirrors = [
+        'https://www.x.org/archive/individual/',
+        'https://mirrors.ircam.fr/pub/x.org/individual/',
+        'http://xorg.mirrors.pair.com/individual/'
+    ]
+
+    @property
+    def urls(self):
+        self._ensure_xorg_mirror_path_is_set_or_raise()
+        return [
+            spack.util.url.join(m, self.xorg_mirror_path,
+                                resolve_href=True)
+            for m in self.base_mirrors
+        ]
+
+    def _ensure_xorg_mirror_path_is_set_or_raise(self):
+        if self.xorg_mirror_path is None:
+            cls_name = type(self).__name__
+            msg = ('{0} must define a `xorg_mirror_path` attribute'
+                   ' [none defined]')
+            raise AttributeError(msg.format(cls_name))

--- a/lib/spack/spack/pkgkit.py
+++ b/lib/spack/spack/pkgkit.py
@@ -32,6 +32,7 @@ from spack.build_systems.meson import MesonPackage
 from spack.build_systems.sip import SIPPackage
 from spack.build_systems.gnu import GNUMirrorPackage
 from spack.build_systems.sourceware import SourcewarePackage
+from spack.build_systems.xorg import XorgPackage
 
 from spack.mixins import filter_compiler_wrappers
 

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -219,3 +219,72 @@ class TestCMakePackage(object):
 
         with pytest.raises(KeyError, match="not a variant"):
             pkg.define_from_variant('NONEXISTENT')
+
+
+@pytest.mark.usefixtures('config', 'mock_packages')
+class TestGNUMirrorPackage(object):
+
+    def test_define(self):
+        s = Spec('mirror-gnu')
+        s.concretize()
+        pkg = spack.repo.get(s)
+
+        s = Spec('mirror-gnu-broken')
+        s.concretize()
+        pkg_broken = spack.repo.get(s)
+
+        cls_name = type(pkg_broken).__name__
+        with pytest.raises(AttributeError,
+                           match=r'{0} must define a `gnu_mirror_path` '
+                                 r'attribute \[none defined\]'
+                                 .format(cls_name)):
+            pkg_broken.urls
+
+        assert pkg.urls[0] == 'https://ftpmirror.gnu.org/' \
+                              'make/make-4.2.1.tar.gz'
+
+
+@pytest.mark.usefixtures('config', 'mock_packages')
+class TestSourcewarePackage(object):
+
+    def test_define(self):
+        s = Spec('mirror-sourceware')
+        s.concretize()
+        pkg = spack.repo.get(s)
+
+        s = Spec('mirror-sourceware-broken')
+        s.concretize()
+        pkg_broken = spack.repo.get(s)
+
+        cls_name = type(pkg_broken).__name__
+        with pytest.raises(AttributeError,
+                           match=r'{0} must define a `sourceware_mirror_path` '
+                                 r'attribute \[none defined\]'
+                                 .format(cls_name)):
+            pkg_broken.urls
+
+        assert pkg.urls[0] == 'https://sourceware.org/pub/' \
+                              'bzip2/bzip2-1.0.8.tar.gz'
+
+
+@pytest.mark.usefixtures('config', 'mock_packages')
+class TestXorgPackage(object):
+
+    def test_define(self):
+        s = Spec('mirror-xorg')
+        s.concretize()
+        pkg = spack.repo.get(s)
+
+        s = Spec('mirror-xorg-broken')
+        s.concretize()
+        pkg_broken = spack.repo.get(s)
+
+        cls_name = type(pkg_broken).__name__
+        with pytest.raises(AttributeError,
+                           match=r'{0} must define a `xorg_mirror_path` '
+                                 r'attribute \[none defined\]'
+                                 .format(cls_name)):
+            pkg_broken.urls
+
+        assert pkg.urls[0] == 'https://www.x.org/archive/individual/' \
+                              'util/util-macros-1.19.1.tar.bz2'

--- a/var/spack/repos/builtin.mock/packages/mirror-gnu-broken/package.py
+++ b/var/spack/repos/builtin.mock/packages/mirror-gnu-broken/package.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class MirrorGnuBroken(AutotoolsPackage, GNUMirrorPackage):
+    """Simple GNU package"""
+
+    homepage = "https://www.gnu.org/software/make/"
+    url      = "https://ftpmirror.gnu.org/make/make-4.2.1.tar.gz"
+
+    version('4.2.1', sha256='e40b8f018c1da64edd1cc9a6fce5fa63b2e707e404e20cad91fbae337c98a5b7')

--- a/var/spack/repos/builtin.mock/packages/mirror-gnu/package.py
+++ b/var/spack/repos/builtin.mock/packages/mirror-gnu/package.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class MirrorGnu(AutotoolsPackage, GNUMirrorPackage):
+    """Simple GNU package"""
+
+    homepage = "https://www.gnu.org/software/make/"
+    gnu_mirror_path = "make/make-4.2.1.tar.gz"
+
+    version('4.2.1', sha256='e40b8f018c1da64edd1cc9a6fce5fa63b2e707e404e20cad91fbae337c98a5b7')

--- a/var/spack/repos/builtin.mock/packages/mirror-sourceware-broken/mirror-gnu-broken/package.py
+++ b/var/spack/repos/builtin.mock/packages/mirror-sourceware-broken/mirror-gnu-broken/package.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class MirrorGnuBroken(AutotoolsPackage, GNUMirrorPackage):
+    """Simple GNU package"""
+
+    homepage = "https://www.gnu.org/software/make/"
+    url      = "https://ftpmirror.gnu.org/make/make-4.2.1.tar.gz"
+
+    version('4.2.1', sha256='e40b8f018c1da64edd1cc9a6fce5fa63b2e707e404e20cad91fbae337c98a5b7')

--- a/var/spack/repos/builtin.mock/packages/mirror-sourceware-broken/package.py
+++ b/var/spack/repos/builtin.mock/packages/mirror-sourceware-broken/package.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class MirrorSourcewareBroken(AutotoolsPackage, SourcewarePackage):
+    """Simple sourceware.org package"""
+
+    homepage = "https://sourceware.org/bzip2/"
+    url      = "https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz"
+
+    version('1.0.8', sha256='ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269')

--- a/var/spack/repos/builtin.mock/packages/mirror-sourceware/package.py
+++ b/var/spack/repos/builtin.mock/packages/mirror-sourceware/package.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class MirrorSourceware(AutotoolsPackage, SourcewarePackage):
+    """Simple sourceware.org package"""
+
+    homepage = "https://sourceware.org/bzip2/"
+    sourceware_mirror_path = "bzip2/bzip2-1.0.8.tar.gz"
+
+    version('1.0.8', sha256='ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269')

--- a/var/spack/repos/builtin.mock/packages/mirror-xorg-broken/package.py
+++ b/var/spack/repos/builtin.mock/packages/mirror-xorg-broken/package.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class MirrorXorgBroken(AutotoolsPackage, XorgPackage):
+    """Simple x.org package"""
+
+    homepage = "http://cgit.freedesktop.org/xorg/util/macros/"
+    url      = "https://www.x.org/archive/individual/util/util-macros-1.19.1.tar.bz2"
+
+    version('1.19.1', sha256='18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6')

--- a/var/spack/repos/builtin.mock/packages/mirror-xorg/package.py
+++ b/var/spack/repos/builtin.mock/packages/mirror-xorg/package.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class MirrorXorg(AutotoolsPackage, XorgPackage):
+    """Simple x.org package"""
+
+    homepage = "http://cgit.freedesktop.org/xorg/util/macros/"
+    xorg_mirror_path = "util/util-macros-1.19.1.tar.bz2"
+
+    version('1.19.1', sha256='18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6')

--- a/var/spack/repos/builtin/packages/util-macros/package.py
+++ b/var/spack/repos/builtin/packages/util-macros/package.py
@@ -6,13 +6,13 @@
 from spack import *
 
 
-class UtilMacros(AutotoolsPackage):
+class UtilMacros(AutotoolsPackage, XorgPackage):
     """This is a set of autoconf macros used by the configure.ac scripts in
     other Xorg modular packages, and is needed to generate new versions
     of their configure scripts with autoconf."""
 
     homepage = "http://cgit.freedesktop.org/xorg/util/macros/"
-    url = "https://www.x.org/archive/individual/util/util-macros-1.19.1.tar.bz2"
+    xorg_mirror_path = "util/util-macros-1.19.1.tar.bz2"
 
     version('1.19.1', sha256='18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6')
     version('1.19.0', sha256='2835b11829ee634e19fa56517b4cfc52ef39acea0cd82e15f68096e27cbed0ba')


### PR DESCRIPTION
According to my nightly CI/CD tests, x.org is another large provider of software in common build chains that is often down.

Added a hand-selected amount of mirrors that is well up-to-sync. Tested with `util-macros` that has a quite "recent" patch release.

Other packages to follow in an individual PR.