### PR TITLE
Make tags case insensitive

### DIFF
--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -240,6 +240,7 @@ class TagIndex(Mapping):
 
         # Add it again under the appropriate tags
         for tag in getattr(package, 'tags', []):
+            tag = tag.lower()
             self._tag_dict[tag].append(package.name)
 
 
@@ -1002,6 +1003,7 @@ class Repo(object):
         index = self.tag_index
 
         for t in tags:
+            t = t.lower()
             v &= set(index[t])
 
         return sorted(v)

--- a/lib/spack/spack/test/cmd/list.py
+++ b/lib/spack/spack/test/cmd/list.py
@@ -37,6 +37,14 @@ def test_list_tags():
     assert 'cloverleaf3d' in output
     assert 'hdf5' not in output
 
+    output = list('--tags', 'hpc')
+    assert 'nek5000' in output
+    assert 'mfem' in output
+
+    output = list('--tags', 'HPC')
+    assert 'nek5000' in output
+    assert 'mfem' in output
+
 
 def test_list_format_name_only():
     output = list('--format', 'name_only')


### PR DESCRIPTION
Currently, tags are case sensitive, which is unintuitive:
```console
$ spack list -t hpc
==> 2 packages.
nek5000  nektools
$ spack list -t HPC
==> 1 packages.
mfem
$ spack list -t Hpc
==> 0 packages.
```

This change makes them case insensitive:
```console
$ spack list -t hpc
==> 3 packages.
mfem  nek5000  nektools
$ spack list -t HPC
==> 3 packages.
mfem  nek5000  nektools
$ spack list -t Hpc
==> 3 packages.
mfem  nek5000  nektools
```