### PR TITLE
spec: add an option to show only runtime requirements of a spec

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -500,7 +500,7 @@ def display_specs(specs, args=None, **kwargs):
         formatted = []
         for spec in specs:
             if deps:
-                for depth, dep in traverse.traverse_tree([spec], depth_first=False):
+                for depth, dep in traverse.traverse_tree([spec]):
                     formatted.append((fmt(dep.spec, depth), dep.spec))
                 formatted.append(("", None))  # mark newlines
             else:

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -514,7 +514,7 @@ def display_specs(specs, args=None, **kwargs):
         formatted = []
         for spec in specs:
             if deps:
-                for depth, dep in traverse.traverse_tree([spec], depth_first=False):
+                for depth, dep in traverse.traverse_tree([spec]):
                     formatted.append((fmt(dep.spec, depth), dep.spec))
                 formatted.append(("", None))  # mark newlines
             else:

--- a/lib/spack/spack/cmd/common/env_utility.py
+++ b/lib/spack/spack/cmd/common/env_utility.py
@@ -116,9 +116,8 @@ def emulate_env_utility(cmd_name, context: Context, args):
                 status_fn=spack.spec.Spec.install_status,
                 hashlen=7,
                 hashes=True,
-                # This shows more than necessary, but we cannot dynamically change deptypes
-                # in Spec.tree(...).
-                deptypes="all" if context == Context.BUILD else ("build", "test", "link", "run"),
+                direct_deptypes=visitor.direct_deps,
+                transitive_deptypes=dt.LINK | dt.RUN,
             ),
         )
 

--- a/lib/spack/spack/cmd/common/env_utility.py
+++ b/lib/spack/spack/cmd/common/env_utility.py
@@ -115,9 +115,8 @@ def emulate_env_utility(cmd_name, context: Context, args):
                 status_fn=spack.spec.Spec.install_status,
                 hashlen=7,
                 hashes=True,
-                # This shows more than necessary, but we cannot dynamically change deptypes
-                # in Spec.tree(...).
-                deptypes="all" if context == Context.BUILD else ("build", "test", "link", "run"),
+                direct_deptypes=visitor.direct_deps,
+                transitive_deptypes=dt.LINK | dt.RUN,
             ),
         )
 

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -9,6 +9,7 @@ import llnl.util.tty as tty
 
 import spack
 import spack.cmd
+import spack.deptypes as dt
 import spack.environment as ev
 import spack.hash_types as ht
 import spack.spec
@@ -71,9 +72,9 @@ for further documentation regarding the spec syntax, see:
         "-t", "--types", action="store_true", default=False, help="show dependency types"
     )
     subparser.add_argument(
-        '--runtime', action='store_true',
-        help='only show the dependencies that are strictly '
-             'required for the package to run'
+        "--show-runtime-deps",
+        action="store_true",
+        help="only show transitive runtime dependencies",
     )
     arguments.add_common_arguments(subparser, ["specs"])
     arguments.add_concretizer_args(subparser)
@@ -114,11 +115,11 @@ def spec(parser, args):
                 print(spec.format(args.format))
         return
 
-    with tree_context():
-        deptypes = ('build', 'link', 'run')
-        if args.runtime:
-            deptypes = ('link', 'run')
+    deptypes = dt.ALL
+    if args.show_runtime_deps:
+        deptypes = dt.LINK | dt.RUN
 
+    with tree_context():
         print(
             spack.spec.tree(
                 concrete_specs,

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -70,6 +70,11 @@ for further documentation regarding the spec syntax, see:
     subparser.add_argument(
         "-t", "--types", action="store_true", default=False, help="show dependency types"
     )
+    subparser.add_argument(
+        '--runtime', action='store_true',
+        help='only show the dependencies that are strictly '
+             'required for the package to run'
+    )
     arguments.add_common_arguments(subparser, ["specs"])
     arguments.add_concretizer_args(subparser)
 
@@ -110,6 +115,10 @@ def spec(parser, args):
         return
 
     with tree_context():
+        deptypes = ('build', 'link', 'run')
+        if args.runtime:
+            deptypes = ('link', 'run')
+
         print(
             spack.spec.tree(
                 concrete_specs,
@@ -117,6 +126,7 @@ def spec(parser, args):
                 format=fmt,
                 hashlen=None if args.very_long else 7,
                 show_types=args.types,
+                deptypes=deptypes,
                 status_fn=install_status_fn if args.install_status else None,
                 hashes=args.long or args.very_long,
                 key=spack.traverse.by_dag_hash,

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -65,16 +65,17 @@ for further documentation regarding the spec syntax, see:
         "--cover",
         action="store",
         default="nodes",
-        choices=["nodes", "edges", "paths"],
+        choices=["nodes", "edges"],
         help="how extensively to traverse the DAG (default: nodes)",
     )
     subparser.add_argument(
         "-t", "--types", action="store_true", default=False, help="show dependency types"
     )
     subparser.add_argument(
-        "--show-runtime-deps",
-        action="store_true",
-        help="only show transitive runtime dependencies",
+        "--show-runtime-deps", action="store_true", help="show transitive runtime dependencies"
+    )
+    subparser.add_argument(
+        "--show-build-deps", action="store_true", help="show transitive runtime dependencies"
     )
     arguments.add_common_arguments(subparser, ["specs"])
     arguments.add_concretizer_args(subparser)
@@ -115,9 +116,12 @@ def spec(parser, args):
                 print(spec.format(args.format))
         return
 
-    deptypes = dt.ALL
-    if args.show_runtime_deps:
-        deptypes = dt.LINK | dt.RUN
+    if not args.show_runtime_deps and not args.show_build_deps:
+        direct_deptypes = dt.ALL
+        transitive_deptypes = dt.ALL
+    else:
+        direct_deptypes = dt.ALL if args.show_build_deps else dt.NONE
+        transitive_deptypes = dt.LINK | dt.RUN if args.show_runtime_deps else dt.NONE
 
     with tree_context():
         print(
@@ -127,7 +131,8 @@ def spec(parser, args):
                 format=fmt,
                 hashlen=None if args.very_long else 7,
                 show_types=args.types,
-                deptypes=deptypes,
+                direct_deptypes=direct_deptypes,
+                transitive_deptypes=transitive_deptypes,
                 status_fn=install_status_fn if args.install_status else None,
                 hashes=args.long or args.very_long,
                 key=spack.traverse.by_dag_hash,

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -67,16 +67,17 @@ for further documentation regarding the spec syntax, see:
         "--cover",
         action="store",
         default="nodes",
-        choices=["nodes", "edges", "paths"],
+        choices=["nodes", "edges"],
         help="how extensively to traverse the DAG (default: nodes)",
     )
     subparser.add_argument(
         "-t", "--types", action="store_true", default=False, help="show dependency types"
     )
     subparser.add_argument(
-        "--show-runtime-deps",
-        action="store_true",
-        help="only show transitive runtime dependencies",
+        "--show-runtime-deps", action="store_true", help="show transitive runtime dependencies"
+    )
+    subparser.add_argument(
+        "--show-build-deps", action="store_true", help="show transitive runtime dependencies"
     )
     arguments.add_common_arguments(subparser, ["specs"])
     arguments.add_concretizer_args(subparser)
@@ -117,9 +118,12 @@ def spec(parser, args):
                 print(spec.format(args.format))
         return
 
-    deptypes = dt.ALL
-    if args.show_runtime_deps:
-        deptypes = dt.LINK | dt.RUN
+    if not args.show_runtime_deps and not args.show_build_deps:
+        direct_deptypes = dt.ALL
+        transitive_deptypes = dt.ALL
+    else:
+        direct_deptypes = dt.ALL if args.show_build_deps else dt.NONE
+        transitive_deptypes = dt.LINK | dt.RUN if args.show_runtime_deps else dt.NONE
 
     with tree_context():
         print(
@@ -129,7 +133,8 @@ def spec(parser, args):
                 format=fmt,
                 hashlen=None if args.very_long else 7,
                 show_types=args.types,
-                deptypes=deptypes,
+                direct_deptypes=direct_deptypes,
+                transitive_deptypes=transitive_deptypes,
                 status_fn=install_status_fn if args.install_status else None,
                 hashes=args.long or args.very_long,
                 key=spack.traverse.by_dag_hash,

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -72,6 +72,11 @@ for further documentation regarding the spec syntax, see:
     subparser.add_argument(
         "-t", "--types", action="store_true", default=False, help="show dependency types"
     )
+    subparser.add_argument(
+        '--runtime', action='store_true',
+        help='only show the dependencies that are strictly '
+             'required for the package to run'
+    )
     arguments.add_common_arguments(subparser, ["specs"])
     arguments.add_concretizer_args(subparser)
 
@@ -112,6 +117,10 @@ def spec(parser, args):
         return
 
     with tree_context():
+        deptypes = ('build', 'link', 'run')
+        if args.runtime:
+            deptypes = ('link', 'run')
+
         print(
             spack.spec.tree(
                 concrete_specs,
@@ -119,6 +128,7 @@ def spec(parser, args):
                 format=fmt,
                 hashlen=None if args.very_long else 7,
                 show_types=args.types,
+                deptypes=deptypes,
                 status_fn=install_status_fn if args.install_status else None,
                 hashes=args.long or args.very_long,
                 key=spack.traverse.by_dag_hash,

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -7,6 +7,7 @@ import sys
 
 import spack
 import spack.cmd
+import spack.deptypes as dt
 import spack.environment as ev
 import spack.hash_types as ht
 import spack.llnl.util.lang as lang
@@ -73,9 +74,9 @@ for further documentation regarding the spec syntax, see:
         "-t", "--types", action="store_true", default=False, help="show dependency types"
     )
     subparser.add_argument(
-        '--runtime', action='store_true',
-        help='only show the dependencies that are strictly '
-             'required for the package to run'
+        "--show-runtime-deps",
+        action="store_true",
+        help="only show transitive runtime dependencies",
     )
     arguments.add_common_arguments(subparser, ["specs"])
     arguments.add_concretizer_args(subparser)
@@ -116,11 +117,11 @@ def spec(parser, args):
                 print(spec.format(args.format))
         return
 
-    with tree_context():
-        deptypes = ('build', 'link', 'run')
-        if args.runtime:
-            deptypes = ('link', 'run')
+    deptypes = dt.ALL
+    if args.show_runtime_deps:
+        deptypes = dt.LINK | dt.RUN
 
+    with tree_context():
         print(
             spack.spec.tree(
                 concrete_specs,

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1384,7 +1384,6 @@ def tree(
     deptypes: Union[dt.DepFlag, dt.DepTypes] = dt.ALL,
     show_types: bool = False,
     depth_first: bool = False,
-    recurse_dependencies: bool = True,
     status_fn: Optional[Callable[["Spec"], InstallStatus]] = None,
     prefix: Optional[Callable[["Spec"], str]] = None,
     key: Callable[["Spec"], Any] = id,
@@ -1405,7 +1404,6 @@ def tree(
         deptypes: dependency types to be represented in the tree
         show_types: if True, show the (merged) dependency type of a node
         depth_first: if True, traverse the DAG depth first when representing it as a tree
-        recurse_dependencies: if True, recurse on dependencies
         status_fn: optional callable that takes a node as an argument and return its
             installation status
         prefix: optional callable that takes a node as an argument and return its
@@ -1466,10 +1464,6 @@ def tree(
         if d > 0:
             out += "^"
         out += node.format(format, color=color) + "\n"
-
-        # Check if we wanted just the first line
-        if not recurse_dependencies:
-            break
 
     return out
 
@@ -4202,7 +4196,6 @@ class Spec:
         deptypes: Union[dt.DepTypes, dt.DepFlag] = dt.ALL,
         show_types: bool = False,
         depth_first: bool = False,
-        recurse_dependencies: bool = True,
         status_fn: Optional[Callable[["Spec"], InstallStatus]] = None,
         prefix: Optional[Callable[["Spec"], str]] = None,
         key=id,
@@ -4224,7 +4217,6 @@ class Spec:
             deptypes: dependency types to be represented in the tree
             show_types: if True, show the (merged) dependency type of a node
             depth_first: if True, traverse the DAG depth first when representing it as a tree
-            recurse_dependencies: if True, recurse on dependencies
             status_fn: optional callable that takes a node as an argument and return its
                 installation status
             prefix: optional callable that takes a node as an argument and return its
@@ -4242,7 +4234,6 @@ class Spec:
             deptypes=deptypes,
             show_types=show_types,
             depth_first=depth_first,
-            recurse_dependencies=recurse_dependencies,
             status_fn=status_fn,
             prefix=prefix,
             key=key,

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1316,7 +1316,6 @@ def tree(
     deptypes: Union[dt.DepFlag, dt.DepTypes] = dt.ALL,
     show_types: bool = False,
     depth_first: bool = False,
-    recurse_dependencies: bool = True,
     status_fn: Optional[Callable[["Spec"], InstallStatus]] = None,
     prefix: Optional[Callable[["Spec"], str]] = None,
     key: Callable[["Spec"], Any] = id,
@@ -1339,7 +1338,6 @@ def tree(
         deptypes: dependency types to be represented in the tree
         show_types: if True, show the (merged) dependency type of a node
         depth_first: if True, traverse the DAG depth first when representing it as a tree
-        recurse_dependencies: if True, recurse on dependencies
         status_fn: optional callable that takes a node as an argument and return its
             installation status
         prefix: optional callable that takes a node as an argument and return its
@@ -1412,10 +1410,6 @@ def tree(
             )
             + "\n"
         )
-
-        # Check if we wanted just the first line
-        if not recurse_dependencies:
-            break
 
     return out
 
@@ -4627,7 +4621,6 @@ class Spec:
         deptypes: Union[dt.DepTypes, dt.DepFlag] = dt.ALL,
         show_types: bool = False,
         depth_first: bool = False,
-        recurse_dependencies: bool = True,
         status_fn: Optional[Callable[["Spec"], InstallStatus]] = None,
         prefix: Optional[Callable[["Spec"], str]] = None,
         key=id,
@@ -4651,7 +4644,6 @@ class Spec:
             deptypes: dependency types to be represented in the tree
             show_types: if True, show the (merged) dependency type of a node
             depth_first: if True, traverse the DAG depth first when representing it as a tree
-            recurse_dependencies: if True, recurse on dependencies
             status_fn: optional callable that takes a node as an argument and return its
                 installation status
             prefix: optional callable that takes a node as an argument and return its
@@ -4673,7 +4665,6 @@ class Spec:
             deptypes=deptypes,
             show_types=show_types,
             depth_first=depth_first,
-            recurse_dependencies=recurse_dependencies,
             status_fn=status_fn,
             prefix=prefix,
             key=key,

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1313,9 +1313,9 @@ def tree(
     cover: spack.traverse.CoverType = "nodes",
     indent: int = 0,
     format: str = DEFAULT_FORMAT,
-    deptypes: Union[dt.DepFlag, dt.DepTypes] = dt.ALL,
+    direct_deptypes: Union[dt.DepFlag, dt.DepTypes] = dt.ALL,
+    transitive_deptypes: Union[dt.DepFlag, dt.DepTypes] = dt.ALL,
     show_types: bool = False,
-    depth_first: bool = False,
     status_fn: Optional[Callable[["Spec"], InstallStatus]] = None,
     prefix: Optional[Callable[["Spec"], str]] = None,
     key: Callable[["Spec"], Any] = id,
@@ -1337,7 +1337,6 @@ def tree(
         format: format to be used to print each node
         deptypes: dependency types to be represented in the tree
         show_types: if True, show the (merged) dependency type of a node
-        depth_first: if True, traverse the DAG depth first when representing it as a tree
         status_fn: optional callable that takes a node as an argument and return its
             installation status
         prefix: optional callable that takes a node as an argument and return its
@@ -1352,19 +1351,18 @@ def tree(
     if color is None:
         color = clr.get_color_when()
 
-    # reduce deptypes over all in-edges when covering nodes
-    if show_types and cover == "nodes":
-        deptype_lookup: Dict[str, dt.DepFlag] = collections.defaultdict(dt.DepFlag)
-        for edge in spack.traverse.traverse_edges(
-            specs, cover="edges", deptype=deptypes, root=False
-        ):
-            deptype_lookup[edge.spec.dag_hash()] |= edge.depflag
+    # When showing dependency types, we need to show the edge to which it applies
+    cover = "edges" if show_types else cover
 
     # SupportsRichComparisonT issue with List[Spec]
     sorted_specs: List["Spec"] = sorted(specs)  # type: ignore[type-var]
 
     for d, dep_spec in spack.traverse.traverse_tree(
-        sorted_specs, cover=cover, deptype=deptypes, depth_first=depth_first, key=key
+        sorted_specs,
+        cover=cover,
+        direct_deptypes=direct_deptypes,
+        transitive_deptypes=transitive_deptypes,
+        key=key,
     ):
         node = dep_spec.spec
 
@@ -1388,14 +1386,7 @@ def tree(
             out += clr.colorize("@K{%s}  ", color=color) % node.dag_hash(hashlen)
 
         if show_types:
-            if cover == "nodes":
-                depflag = deptype_lookup[dep_spec.spec.dag_hash()]
-            else:
-                # when covering edges or paths, we show dependency
-                # types only for the edge through which we visited
-                depflag = dep_spec.depflag
-
-            type_chars = dt.flag_to_chars(depflag)
+            type_chars = dt.flag_to_chars(dep_spec.depflag)
             out += "[%s]  " % type_chars
 
         out += "    " * d
@@ -4618,9 +4609,9 @@ class Spec:
         cover: spack.traverse.CoverType = "nodes",
         indent: int = 0,
         format: str = DEFAULT_FORMAT,
-        deptypes: Union[dt.DepTypes, dt.DepFlag] = dt.ALL,
+        direct_deptypes: Union[dt.DepTypes, dt.DepFlag] = dt.NONE,
+        transitive_deptypes: Union[dt.DepTypes, dt.DepFlag] = dt.ALL,
         show_types: bool = False,
-        depth_first: bool = False,
         status_fn: Optional[Callable[["Spec"], InstallStatus]] = None,
         prefix: Optional[Callable[["Spec"], str]] = None,
         key=id,
@@ -4641,9 +4632,9 @@ class Spec:
             cover: either ``"nodes"`` or ``"edges"``
             indent: extra indentation for the tree being printed
             format: format to be used to print each node
-            deptypes: dependency types to be represented in the tree
+            direct_deptypes: edge types to follow to depth 1
+            transitive_deptypes: edge types to follow to arbitrary depth
             show_types: if True, show the (merged) dependency type of a node
-            depth_first: if True, traverse the DAG depth first when representing it as a tree
             status_fn: optional callable that takes a node as an argument and return its
                 installation status
             prefix: optional callable that takes a node as an argument and return its
@@ -4662,9 +4653,9 @@ class Spec:
             cover=cover,
             indent=indent,
             format=format,
-            deptypes=deptypes,
+            direct_deptypes=direct_deptypes,
+            transitive_deptypes=transitive_deptypes,
             show_types=show_types,
-            depth_first=depth_first,
             status_fn=status_fn,
             prefix=prefix,
             key=key,

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -114,16 +114,6 @@ def _parse_types(string):
     return result
 
 
-def test_spec_deptypes_nodes():
-    output = spec("--types", "--cover", "nodes", "--no-install-status", "dt-diamond")
-    types = _parse_types(output)
-
-    assert types["dt-diamond"] == ["    "]
-    assert types["dt-diamond-left"] == ["bl  "]
-    assert types["dt-diamond-right"] == ["bl  "]
-    assert types["dt-diamond-bottom"] == ["blr "]
-
-
 def test_spec_deptypes_edges():
     output = spec("--types", "--cover", "edges", "--no-install-status", "dt-diamond")
     types = _parse_types(output)

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -117,16 +117,6 @@ def _parse_types(string):
     return result
 
 
-def test_spec_deptypes_nodes():
-    output = spec("--types", "--cover", "nodes", "--no-install-status", "dt-diamond")
-    types = _parse_types(output)
-
-    assert types["dt-diamond"] == ["    "]
-    assert types["dt-diamond-left"] == ["bl  "]
-    assert types["dt-diamond-right"] == ["bl  "]
-    assert types["dt-diamond-bottom"] == ["blr "]
-
-
 def test_spec_deptypes_edges():
     output = spec("--types", "--cover", "edges", "--no-install-status", "dt-diamond")
     types = _parse_types(output)

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -872,9 +872,9 @@ class TestSpecDag:
     def test_spec_tree_respect_deptypes(self):
         # Version-test-root uses version-test-pkg as a build dependency
         s = spack.concretize.concretize_one("version-test-root")
-        out = s.tree(deptypes="all")
+        out = s.tree(transitive_deptypes="all")
         assert "version-test-pkg" in out
-        out = s.tree(deptypes=("link", "run"))
+        out = s.tree(transitive_deptypes=("link", "run"))
         assert "version-test-pkg" not in out
 
     @pytest.mark.parametrize(
@@ -922,27 +922,59 @@ class TestSpecDag:
         assert len(mpileaks["libelf"].edges_from_dependents(depflag=dt.LINK)) == 2
 
 
-def test_tree_cover_nodes_reduce_deptype():
-    """Test that tree output with deptypes sticks to the sub-dag of interest, instead of looking
-    at in-edges from nodes not reachable from the root."""
+def test_mixed_deptype_tree():
+    """Test whether the correct sub-dag is displayed as tree when following selected deptypes"""
     a, b, c, d = Spec("a"), Spec("b"), Spec("c"), Spec("d")
-    a.add_dependency_edge(d, depflag=dt.BUILD, virtuals=())
-    a.add_dependency_edge(b, depflag=dt.LINK, virtuals=())
-    b.add_dependency_edge(d, depflag=dt.LINK, virtuals=())
-    c.add_dependency_edge(d, depflag=dt.RUN | dt.TEST, virtuals=())
+    a.add_dependency_edge(c, depflag=dt.BUILD, virtuals=())
+    a.add_dependency_edge(b, depflag=dt.LINK | dt.TEST, virtuals=())
+    b.add_dependency_edge(c, depflag=dt.LINK, virtuals=())
+    b.add_dependency_edge(d, depflag=dt.BUILD | dt.RUN, virtuals=())
     assert (
-        a.tree(cover="nodes", show_types=True)
+        a.tree(direct_deptypes=dt.BUILD, transitive_deptypes=dt.NONE, show_types=True)
         == """\
 [    ]  a
-[ l  ]      ^b
-[bl  ]      ^d
+[b   ]      ^c
 """
     )
     assert (
-        c.tree(cover="nodes", show_types=True)
+        a.tree(direct_deptypes=dt.LINK, transitive_deptypes=dt.NONE, show_types=True)
         == """\
-[    ]  c
-[  rt]      ^d
+[    ]  a
+[ l t]      ^b
+"""
+    )
+    assert (
+        a.tree(direct_deptypes=dt.NONE, transitive_deptypes=dt.LINK, show_types=True)
+        == """\
+[    ]  a
+[ l t]      ^b
+[ l  ]          ^c
+"""
+    )
+    assert (
+        a.tree(direct_deptypes=dt.NONE, transitive_deptypes=dt.LINK | dt.RUN, show_types=True)
+        == """\
+[    ]  a
+[ l t]      ^b
+[ l  ]          ^c
+[b r ]          ^d
+"""
+    )
+    assert (
+        a.tree(direct_deptypes=dt.BUILD, transitive_deptypes=dt.LINK, show_types=True)
+        == """\
+[    ]  a
+[ l t]      ^b
+[ l  ]          ^c
+[b   ]      ^c
+"""
+    )
+    assert (
+        a.tree(direct_deptypes=dt.BUILD | dt.TEST, transitive_deptypes=dt.RUN, show_types=True)
+        == """\
+[    ]  a
+[ l t]      ^b
+[b   ]      ^c
 """
     )
 

--- a/lib/spack/spack/test/traverse.py
+++ b/lib/spack/spack/test/traverse.py
@@ -233,20 +233,12 @@ def test_breadth_first_versus_depth_first_tree(abstract_specs_chain):
 
     # BFS should find all nodes as direct deps
     assert [
-        (depth, edge.spec.name)
-        for (depth, edge) in traverse.traverse_tree([s], cover="nodes", depth_first=False)
+        (depth, edge.spec.name) for (depth, edge) in traverse.traverse_tree([s], cover="nodes")
     ] == [(0, "chain-a"), (1, "chain-b"), (1, "chain-c"), (1, "chain-d")]
-
-    # DFS will discover all nodes along the chain a -> b -> c -> d.
-    assert [
-        (depth, edge.spec.name)
-        for (depth, edge) in traverse.traverse_tree([s], cover="nodes", depth_first=True)
-    ] == [(0, "chain-a"), (1, "chain-b"), (2, "chain-c"), (3, "chain-d")]
 
     # When covering all edges, we should never exceed depth 2 in BFS.
     assert [
-        (depth, edge.spec.name)
-        for (depth, edge) in traverse.traverse_tree([s], cover="edges", depth_first=False)
+        (depth, edge.spec.name) for (depth, edge) in traverse.traverse_tree([s], cover="edges")
     ] == [
         (0, "chain-a"),
         (1, "chain-b"),
@@ -256,36 +248,21 @@ def test_breadth_first_versus_depth_first_tree(abstract_specs_chain):
         (1, "chain-d"),
     ]
 
-    # In DFS we see the chain again.
-    assert [
-        (depth, edge.spec.name)
-        for (depth, edge) in traverse.traverse_tree([s], cover="edges", depth_first=True)
-    ] == [
-        (0, "chain-a"),
-        (1, "chain-b"),
-        (2, "chain-c"),
-        (3, "chain-d"),
-        (1, "chain-c"),
-        (1, "chain-d"),
-    ]
-
 
 @pytest.mark.parametrize("cover", ["nodes", "edges"])
-@pytest.mark.parametrize("depth_first", [True, False])
-def test_tree_traversal_with_key(cover, depth_first, abstract_specs_chain):
+def test_tree_traversal_with_key(cover, abstract_specs_chain):
     """Compare two multisource traversals of the same DAG. In one case the DAG consists of unique
     Spec instances, in the second case there are identical copies of nodes and edges. Traversal
     should be equivalent when nodes are identified by dag_hash."""
     a = abstract_specs_chain["chain-a"]
     c = abstract_specs_chain["chain-c"]
-    kwargs = {"cover": cover, "depth_first": depth_first}
     dag_hash = lambda s: s.dag_hash()
 
     # Traverse DAG spanned by a unique set of Spec instances
-    first = traverse.traverse_tree([a, c], key=id, **kwargs)
+    first = traverse.traverse_tree([a, c], key=id, cover=cover)
 
     # Traverse equivalent DAG with copies of Spec instances included, keyed by dag hash.
-    second = traverse.traverse_tree([a, c.copy()], key=dag_hash, **kwargs)
+    second = traverse.traverse_tree([a, c.copy()], key=dag_hash, cover=cover)
 
     # Check that the same nodes are discovered at the same depth
     node_at_depth_first = [(depth, dag_hash(edge.spec)) for (depth, edge) in first]
@@ -297,33 +274,13 @@ def test_breadth_first_versus_depth_first_printing(abstract_specs_chain):
     """Test breadth-first versus depth-first tree printing."""
     s = abstract_specs_chain["chain-a"]
 
-    args = {"format": "{name}", "color": False}
-
-    dfs_tree_nodes = """\
-chain-a
-    ^chain-b
-        ^chain-c
-            ^chain-d
-"""
-    assert s.tree(depth_first=True, **args) == dfs_tree_nodes
-
     bfs_tree_nodes = """\
 chain-a
     ^chain-b
     ^chain-c
     ^chain-d
 """
-    assert s.tree(depth_first=False, **args) == bfs_tree_nodes
-
-    dfs_tree_edges = """\
-chain-a
-    ^chain-b
-        ^chain-c
-            ^chain-d
-    ^chain-c
-    ^chain-d
-"""
-    assert s.tree(depth_first=True, cover="edges", **args) == dfs_tree_edges
+    assert s.tree(format="{name}", color=False) == bfs_tree_nodes
 
     bfs_tree_edges = """\
 chain-a
@@ -333,7 +290,7 @@ chain-a
         ^chain-d
     ^chain-d
 """
-    assert s.tree(depth_first=False, cover="edges", **args) == bfs_tree_edges
+    assert s.tree(cover="edges", format="{name}", color=False) == bfs_tree_edges
 
 
 @pytest.fixture()

--- a/lib/spack/spack/traverse.py
+++ b/lib/spack/spack/traverse.py
@@ -28,6 +28,10 @@ if TYPE_CHECKING:
 # Export only the high-level API.
 __all__ = ["traverse_edges", "traverse_nodes", "traverse_tree"]
 
+OrderType = Literal["pre", "post", "breadth", "topo"]
+CoverType = Literal["nodes", "edges"]
+DirectionType = Literal["children", "parents"]
+
 
 #: Data class that stores a directed edge together with depth at
 #: which the target vertex was found. It is passed to ``accept``
@@ -202,7 +206,6 @@ def get_visitor_from_args(
             ``edges`` -- If a node has been visited once but is reached along a
             new path, it's accepted, but not recursively followed. This traverses
             each 'edge' in the DAG once.
-            ``paths`` -- Explore every unique path reachable from the root.
             This descends into visited subtrees and will accept nodes multiple
             times if they're reachable by multiple paths.
         direction (str): ``children`` or ``parents``. If ``children``, does a traversal
@@ -337,7 +340,13 @@ def traverse_depth_first_with_visitor(edges, visitor):
 # Helper functions for generating a tree using breadth-first traversal
 
 
-def breadth_first_to_tree_edges(roots, deptype="all", key=id):
+def breadth_first_to_tree_edges(
+    roots,
+    direct_type: dt.DepFlag = dt.ALL,
+    transitive_type: dt.DepFlag = dt.RUN | dt.LINK,
+    key=id,
+    cover: CoverType = "nodes",
+):
     """This produces an adjacency list (with edges) and a map of parents.
     There may be nodes that are reached through multiple edges. To print as
     a tree, one should use the parents dict to verify if the path leading to
@@ -346,26 +355,19 @@ def breadth_first_to_tree_edges(roots, deptype="all", key=id):
     edges = defaultdict(list)
     parents = dict()
 
-    for edge in traverse_edges(roots, order="breadth", cover="edges", deptype=deptype, key=key):
+    visitor = MixedDepthVisitor(direct=direct_type, transitive=transitive_type, key=key)
+    root_edges = with_artificial_edges(roots)
+
+    for edge in traverse_breadth_first_edges_generator(root_edges, visitor):
         parent_id = None if edge.parent is None else key(edge.parent)
         child_id = key(edge.spec)
+        if cover == "nodes" and child_id in parents:
+            continue
         edges[parent_id].append(edge)
         if child_id not in parents:
             parents[child_id] = parent_id
 
     return edges, parents
-
-
-def breadth_first_to_tree_nodes(roots, deptype="all", key=id):
-    """This produces a list of edges that forms a tree; every node has no more
-    that one incoming edge."""
-    edges = defaultdict(list)
-
-    for edge in traverse_edges(roots, order="breadth", cover="nodes", deptype=deptype, key=key):
-        parent_id = None if edge.parent is None else key(edge.parent)
-        edges[parent_id].append(edge)
-
-    return edges
 
 
 def traverse_breadth_first_tree_edges(parent_id, edges, parents, key=id, depth=0):
@@ -381,13 +383,6 @@ def traverse_breadth_first_tree_edges(parent_id, edges, parents, key=id, depth=0
             continue
 
         yield from traverse_breadth_first_tree_edges(child_id, edges, parents, key, depth + 1)
-
-
-def traverse_breadth_first_tree_nodes(parent_id, edges, key=id, depth=0):
-    for edge in edges[parent_id]:
-        yield (depth, edge)
-        for item in traverse_breadth_first_tree_nodes(key(edge.spec), edges, key, depth + 1):
-            yield item
 
 
 def traverse_topo_edges_generator(edges, visitor, key=id, root=True, all_edges=False):
@@ -439,10 +434,6 @@ def traverse_topo_edges_generator(edges, visitor, key=id, root=True, all_edges=F
 
 
 # High-level API: traverse_edges, traverse_nodes, traverse_tree.
-
-OrderType = Literal["pre", "post", "breadth", "topo"]
-CoverType = Literal["nodes", "edges", "paths"]
-DirectionType = Literal["children", "parents"]
 
 
 @overload
@@ -515,9 +506,6 @@ def traverse_edges(
             ``nodes`` -- Visit each unique node in the dag only once.
             ``edges`` -- If a node has been visited once but is reached along a new path, it's
             accepted, but not recursively followed. This traverses each 'edge' in the DAG once.
-            ``paths`` -- Explore every unique path reachable from the root. This descends into
-            visited subtrees and will accept nodes multiple times if they're reachable by multiple
-            paths.
         direction: ``children`` or ``parents``. If ``children``, does a traversal of this spec's
             children.  If ``parents``, traverses upwards in the DAG towards the root.
         deptype: allowed dependency types
@@ -532,8 +520,6 @@ def traverse_edges(
     """
     # validate input
     if order == "topo":
-        if cover == "paths":
-            raise ValueError("cover=paths not supported for order=topo")
         if visited is not None:
             raise ValueError("visited set not implemented for order=topo")
     elif order not in ("post", "pre", "breadth"):
@@ -627,9 +613,6 @@ def traverse_nodes(
             ``nodes`` -- Visit each unique node in the dag only once.
             ``edges`` -- If a node has been visited once but is reached along a new path, it's
             accepted, but not recursively followed. This traverses each 'edge' in the DAG once.
-            ``paths`` -- Explore every unique path reachable from the root. This descends into
-            visited subtrees and will accept nodes multiple times if they're reachable by multiple
-            paths.
         direction: ``children`` or ``parents``. If ``children``, does a traversal of this spec's
             children.  If ``parents``, traverses upwards in the DAG towards the root.
         deptype: allowed dependency types
@@ -659,9 +642,9 @@ def traverse_nodes(
 def traverse_tree(
     specs: Sequence["spack.spec.Spec"],
     cover: CoverType = "nodes",
-    deptype: Union[dt.DepFlag, dt.DepTypes] = "all",
+    direct_deptypes: Union[dt.DepFlag, dt.DepTypes] = "all",
+    transitive_deptypes: Union[dt.DepFlag, dt.DepTypes] = "all",
     key: Callable[["spack.spec.Spec"], Any] = id,
-    depth_first: bool = True,
 ) -> Iterable[Tuple[int, "spack.spec.DependencySpec"]]:
     """
     Generator that yields ``(depth, DependencySpec)`` tuples in the depth-first
@@ -675,29 +658,26 @@ def traverse_tree(
             ``edges`` -- If a node has been visited once but is reached along a
             new path, it's accepted, but not recursively followed. This traverses each 'edge' in
             the DAG once.
-            ``paths`` -- Explore every unique path reachable from the root. This descends into
-            visited subtrees and will accept nodes multiple times if they're reachable by multiple
-            paths.
-        deptype: allowed dependency types
+        direct_deptype: what edge types to include from the roots (not transitive).
+        transitive_deptype: what edges types to follow transitively from the roots.
         key: function that takes a spec and outputs a key for uniqueness test.
-        depth_first: Explore the tree in depth-first or breadth-first order. When setting
-            ``depth_first=True`` and ``cover=nodes``, each spec only occurs once at the shallowest
-            level, which is useful when rendering the tree in a terminal.
 
     Returns:
         A generator that yields ``(depth, DependencySpec)`` tuples in such an order that a tree can
         be printed.
     """
-    # BFS only makes sense when going over edges and nodes, for paths the tree is
-    # identical to DFS, which is much more efficient then.
-    if not depth_first and cover == "edges":
-        edges, parents = breadth_first_to_tree_edges(specs, deptype, key)
-        return traverse_breadth_first_tree_edges(None, edges, parents, key)
-    elif not depth_first and cover == "nodes":
-        edges = breadth_first_to_tree_nodes(specs, deptype, key)
-        return traverse_breadth_first_tree_nodes(None, edges, key)
-
-    return traverse_edges(specs, order="pre", cover=cover, deptype=deptype, key=key, depth=True)
+    if not isinstance(direct_deptypes, dt.DepFlag):
+        direct_deptypes = dt.canonicalize(direct_deptypes)
+    if not isinstance(transitive_deptypes, dt.DepFlag):
+        transitive_deptypes = dt.canonicalize(transitive_deptypes)
+    edges, parents = breadth_first_to_tree_edges(
+        specs,
+        direct_type=direct_deptypes,
+        transitive_type=transitive_deptypes,
+        key=key,
+        cover=cover,
+    )
+    return traverse_breadth_first_tree_edges(None, edges, parents, key)
 
 
 def by_dag_hash(s: "spack.spec.Spec") -> str:

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1840,7 +1840,7 @@ _spack_restage() {
 _spack_solve() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --show --timers --stats -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -y --yaml -j --json --format -c --cover -t --types -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
+        SPACK_COMPREPLY="-h --help --show --timers --stats -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -y --yaml -j --json --format -c --cover -t --types --show-runtime-deps -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
     else
         _all_packages
     fi
@@ -1849,7 +1849,7 @@ _spack_solve() {
 _spack_spec() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -y --yaml -j --json --format -c --cover -t --types -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
+        SPACK_COMPREPLY="-h --help -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -y --yaml -j --json --format -c --cover -t --types --show-runtime-deps -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1840,7 +1840,7 @@ _spack_restage() {
 _spack_solve() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --show --timers --stats -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -y --yaml -j --json --format -c --cover -t --types --show-runtime-deps -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
+        SPACK_COMPREPLY="-h --help --show --timers --stats -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -y --yaml -j --json --format -c --cover -t --types --show-runtime-deps --show-build-deps -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
     else
         _all_packages
     fi
@@ -1849,7 +1849,7 @@ _spack_solve() {
 _spack_spec() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -y --yaml -j --json --format -c --cover -t --types --show-runtime-deps -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
+        SPACK_COMPREPLY="-h --help -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -y --yaml -j --json --format -c --cover -t --types --show-runtime-deps --show-build-deps -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1920,7 +1920,7 @@ _spack_restage() {
 _spack_solve() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --show --timers --stats -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -y --yaml -j --json --format --non-defaults -c --cover -t --types -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
+        SPACK_COMPREPLY="-h --help --show --timers --stats -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -y --yaml -j --json --format --non-defaults -c --cover -t --types --show-runtime-deps --show-build-deps -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
     else
         _all_packages
     fi
@@ -1929,7 +1929,7 @@ _spack_solve() {
 _spack_spec() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -y --yaml -j --json --format --non-defaults -c --cover -t --types -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
+        SPACK_COMPREPLY="-h --help -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -y --yaml -j --json --format --non-defaults -c --cover -t --types --show-runtime-deps --show-build-deps -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2798,7 +2798,7 @@ complete -c spack -n '__fish_spack_using_command restage' -s h -l help -f -a hel
 complete -c spack -n '__fish_spack_using_command restage' -s h -l help -d 'show this help message and exit'
 
 # spack solve
-set -g __fish_spack_optspecs_spack_solve h/help show= timers stats l/long L/very-long N/namespaces I/install-status no-install-status y/yaml j/json format= c/cover= t/types U/fresh reuse fresh-roots deprecated
+set -g __fish_spack_optspecs_spack_solve h/help show= timers stats l/long L/very-long N/namespaces I/install-status no-install-status y/yaml j/json format= c/cover= t/types show-runtime-deps U/fresh reuse fresh-roots deprecated
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 solve' -f -k -a '(__fish_spack_specs_or_id)'
 complete -c spack -n '__fish_spack_using_command solve' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command solve' -s h -l help -d 'show this help message and exit'
@@ -2828,6 +2828,8 @@ complete -c spack -n '__fish_spack_using_command solve' -s c -l cover -r -f -a '
 complete -c spack -n '__fish_spack_using_command solve' -s c -l cover -r -d 'how extensively to traverse the DAG (default: nodes)'
 complete -c spack -n '__fish_spack_using_command solve' -s t -l types -f -a types
 complete -c spack -n '__fish_spack_using_command solve' -s t -l types -d 'show dependency types'
+complete -c spack -n '__fish_spack_using_command solve' -l show-runtime-deps -f -a show_runtime_deps
+complete -c spack -n '__fish_spack_using_command solve' -l show-runtime-deps -d 'only show transitive runtime dependencies'
 complete -c spack -n '__fish_spack_using_command solve' -s U -l fresh -f -a concretizer_reuse
 complete -c spack -n '__fish_spack_using_command solve' -s U -l fresh -d 'do not reuse installed deps; build newest configuration'
 complete -c spack -n '__fish_spack_using_command solve' -l reuse -f -a concretizer_reuse
@@ -2838,7 +2840,7 @@ complete -c spack -n '__fish_spack_using_command solve' -l deprecated -f -a conf
 complete -c spack -n '__fish_spack_using_command solve' -l deprecated -d 'allow concretizer to select deprecated versions'
 
 # spack spec
-set -g __fish_spack_optspecs_spack_spec h/help l/long L/very-long N/namespaces I/install-status no-install-status y/yaml j/json format= c/cover= t/types U/fresh reuse fresh-roots deprecated
+set -g __fish_spack_optspecs_spack_spec h/help l/long L/very-long N/namespaces I/install-status no-install-status y/yaml j/json format= c/cover= t/types show-runtime-deps U/fresh reuse fresh-roots deprecated
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 spec' -f -k -a '(__fish_spack_specs_or_id)'
 complete -c spack -n '__fish_spack_using_command spec' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command spec' -s h -l help -d 'show this help message and exit'
@@ -2862,6 +2864,8 @@ complete -c spack -n '__fish_spack_using_command spec' -s c -l cover -r -f -a 'n
 complete -c spack -n '__fish_spack_using_command spec' -s c -l cover -r -d 'how extensively to traverse the DAG (default: nodes)'
 complete -c spack -n '__fish_spack_using_command spec' -s t -l types -f -a types
 complete -c spack -n '__fish_spack_using_command spec' -s t -l types -d 'show dependency types'
+complete -c spack -n '__fish_spack_using_command spec' -l show-runtime-deps -f -a show_runtime_deps
+complete -c spack -n '__fish_spack_using_command spec' -l show-runtime-deps -d 'only show transitive runtime dependencies'
 complete -c spack -n '__fish_spack_using_command spec' -s U -l fresh -f -a concretizer_reuse
 complete -c spack -n '__fish_spack_using_command spec' -s U -l fresh -d 'do not reuse installed deps; build newest configuration'
 complete -c spack -n '__fish_spack_using_command spec' -l reuse -f -a concretizer_reuse

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2798,7 +2798,7 @@ complete -c spack -n '__fish_spack_using_command restage' -s h -l help -f -a hel
 complete -c spack -n '__fish_spack_using_command restage' -s h -l help -d 'show this help message and exit'
 
 # spack solve
-set -g __fish_spack_optspecs_spack_solve h/help show= timers stats l/long L/very-long N/namespaces I/install-status no-install-status y/yaml j/json format= c/cover= t/types show-runtime-deps U/fresh reuse fresh-roots deprecated
+set -g __fish_spack_optspecs_spack_solve h/help show= timers stats l/long L/very-long N/namespaces I/install-status no-install-status y/yaml j/json format= c/cover= t/types show-runtime-deps show-build-deps U/fresh reuse fresh-roots deprecated
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 solve' -f -k -a '(__fish_spack_specs_or_id)'
 complete -c spack -n '__fish_spack_using_command solve' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command solve' -s h -l help -d 'show this help message and exit'
@@ -2824,12 +2824,14 @@ complete -c spack -n '__fish_spack_using_command solve' -s j -l json -f -a forma
 complete -c spack -n '__fish_spack_using_command solve' -s j -l json -d 'print concrete spec as JSON'
 complete -c spack -n '__fish_spack_using_command solve' -l format -r -f -a format
 complete -c spack -n '__fish_spack_using_command solve' -l format -r -d 'print concrete spec with the specified format string'
-complete -c spack -n '__fish_spack_using_command solve' -s c -l cover -r -f -a 'nodes edges paths'
+complete -c spack -n '__fish_spack_using_command solve' -s c -l cover -r -f -a 'nodes edges'
 complete -c spack -n '__fish_spack_using_command solve' -s c -l cover -r -d 'how extensively to traverse the DAG (default: nodes)'
 complete -c spack -n '__fish_spack_using_command solve' -s t -l types -f -a types
 complete -c spack -n '__fish_spack_using_command solve' -s t -l types -d 'show dependency types'
 complete -c spack -n '__fish_spack_using_command solve' -l show-runtime-deps -f -a show_runtime_deps
-complete -c spack -n '__fish_spack_using_command solve' -l show-runtime-deps -d 'only show transitive runtime dependencies'
+complete -c spack -n '__fish_spack_using_command solve' -l show-runtime-deps -d 'show transitive runtime dependencies'
+complete -c spack -n '__fish_spack_using_command solve' -l show-build-deps -f -a show_build_deps
+complete -c spack -n '__fish_spack_using_command solve' -l show-build-deps -d 'show transitive runtime dependencies'
 complete -c spack -n '__fish_spack_using_command solve' -s U -l fresh -f -a concretizer_reuse
 complete -c spack -n '__fish_spack_using_command solve' -s U -l fresh -d 'do not reuse installed deps; build newest configuration'
 complete -c spack -n '__fish_spack_using_command solve' -l reuse -f -a concretizer_reuse
@@ -2840,7 +2842,7 @@ complete -c spack -n '__fish_spack_using_command solve' -l deprecated -f -a conf
 complete -c spack -n '__fish_spack_using_command solve' -l deprecated -d 'allow concretizer to select deprecated versions'
 
 # spack spec
-set -g __fish_spack_optspecs_spack_spec h/help l/long L/very-long N/namespaces I/install-status no-install-status y/yaml j/json format= c/cover= t/types show-runtime-deps U/fresh reuse fresh-roots deprecated
+set -g __fish_spack_optspecs_spack_spec h/help l/long L/very-long N/namespaces I/install-status no-install-status y/yaml j/json format= c/cover= t/types show-runtime-deps show-build-deps U/fresh reuse fresh-roots deprecated
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 spec' -f -k -a '(__fish_spack_specs_or_id)'
 complete -c spack -n '__fish_spack_using_command spec' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command spec' -s h -l help -d 'show this help message and exit'
@@ -2860,12 +2862,14 @@ complete -c spack -n '__fish_spack_using_command spec' -s j -l json -f -a format
 complete -c spack -n '__fish_spack_using_command spec' -s j -l json -d 'print concrete spec as JSON'
 complete -c spack -n '__fish_spack_using_command spec' -l format -r -f -a format
 complete -c spack -n '__fish_spack_using_command spec' -l format -r -d 'print concrete spec with the specified format string'
-complete -c spack -n '__fish_spack_using_command spec' -s c -l cover -r -f -a 'nodes edges paths'
+complete -c spack -n '__fish_spack_using_command spec' -s c -l cover -r -f -a 'nodes edges'
 complete -c spack -n '__fish_spack_using_command spec' -s c -l cover -r -d 'how extensively to traverse the DAG (default: nodes)'
 complete -c spack -n '__fish_spack_using_command spec' -s t -l types -f -a types
 complete -c spack -n '__fish_spack_using_command spec' -s t -l types -d 'show dependency types'
 complete -c spack -n '__fish_spack_using_command spec' -l show-runtime-deps -f -a show_runtime_deps
-complete -c spack -n '__fish_spack_using_command spec' -l show-runtime-deps -d 'only show transitive runtime dependencies'
+complete -c spack -n '__fish_spack_using_command spec' -l show-runtime-deps -d 'show transitive runtime dependencies'
+complete -c spack -n '__fish_spack_using_command spec' -l show-build-deps -f -a show_build_deps
+complete -c spack -n '__fish_spack_using_command spec' -l show-build-deps -d 'show transitive runtime dependencies'
 complete -c spack -n '__fish_spack_using_command spec' -s U -l fresh -f -a concretizer_reuse
 complete -c spack -n '__fish_spack_using_command spec' -s U -l fresh -d 'do not reuse installed deps; build newest configuration'
 complete -c spack -n '__fish_spack_using_command spec' -l reuse -f -a concretizer_reuse

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2996,7 +2996,7 @@ complete -c spack -n '__fish_spack_using_command restage' -s h -l help -f -a hel
 complete -c spack -n '__fish_spack_using_command restage' -s h -l help -d 'show this help message and exit'
 
 # spack solve
-set -g __fish_spack_optspecs_spack_solve h/help show= timers stats l/long L/very-long N/namespaces I/install-status no-install-status y/yaml j/json format= non-defaults c/cover= t/types f/force U/fresh reuse fresh-roots deprecated
+set -g __fish_spack_optspecs_spack_solve h/help show= timers stats l/long L/very-long N/namespaces I/install-status no-install-status y/yaml j/json format= non-defaults c/cover= t/types show-runtime-deps show-build-deps f/force U/fresh reuse fresh-roots deprecated
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 solve' -f -k -a '(__fish_spack_specs_or_id)'
 complete -c spack -n '__fish_spack_using_command solve' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command solve' -s h -l help -d 'show this help message and exit'
@@ -3024,10 +3024,14 @@ complete -c spack -n '__fish_spack_using_command solve' -l format -r -f -a forma
 complete -c spack -n '__fish_spack_using_command solve' -l format -r -d 'print concrete spec with the specified format string'
 complete -c spack -n '__fish_spack_using_command solve' -l non-defaults -f -a non_defaults
 complete -c spack -n '__fish_spack_using_command solve' -l non-defaults -d 'highlight non-default versions or variants'
-complete -c spack -n '__fish_spack_using_command solve' -s c -l cover -r -f -a 'nodes edges paths'
+complete -c spack -n '__fish_spack_using_command solve' -s c -l cover -r -f -a 'nodes edges'
 complete -c spack -n '__fish_spack_using_command solve' -s c -l cover -r -d 'how extensively to traverse the DAG (default: nodes)'
 complete -c spack -n '__fish_spack_using_command solve' -s t -l types -f -a types
 complete -c spack -n '__fish_spack_using_command solve' -s t -l types -d 'show dependency types'
+complete -c spack -n '__fish_spack_using_command solve' -l show-runtime-deps -f -a show_runtime_deps
+complete -c spack -n '__fish_spack_using_command solve' -l show-runtime-deps -d 'show transitive runtime dependencies'
+complete -c spack -n '__fish_spack_using_command solve' -l show-build-deps -f -a show_build_deps
+complete -c spack -n '__fish_spack_using_command solve' -l show-build-deps -d 'show transitive runtime dependencies'
 complete -c spack -n '__fish_spack_using_command solve' -s f -l force -f -a concretizer_force
 complete -c spack -n '__fish_spack_using_command solve' -s f -l force -d 'allow changes to concretized specs in spack.lock (in an env)'
 complete -c spack -n '__fish_spack_using_command solve' -s U -l fresh -f -a concretizer_reuse
@@ -3040,7 +3044,7 @@ complete -c spack -n '__fish_spack_using_command solve' -l deprecated -f -a conf
 complete -c spack -n '__fish_spack_using_command solve' -l deprecated -d 'allow concretizer to select deprecated versions'
 
 # spack spec
-set -g __fish_spack_optspecs_spack_spec h/help l/long L/very-long N/namespaces I/install-status no-install-status y/yaml j/json format= non-defaults c/cover= t/types f/force U/fresh reuse fresh-roots deprecated
+set -g __fish_spack_optspecs_spack_spec h/help l/long L/very-long N/namespaces I/install-status no-install-status y/yaml j/json format= non-defaults c/cover= t/types show-runtime-deps show-build-deps f/force U/fresh reuse fresh-roots deprecated
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 spec' -f -k -a '(__fish_spack_specs_or_id)'
 complete -c spack -n '__fish_spack_using_command spec' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command spec' -s h -l help -d 'show this help message and exit'
@@ -3062,10 +3066,14 @@ complete -c spack -n '__fish_spack_using_command spec' -l format -r -f -a format
 complete -c spack -n '__fish_spack_using_command spec' -l format -r -d 'print concrete spec with the specified format string'
 complete -c spack -n '__fish_spack_using_command spec' -l non-defaults -f -a non_defaults
 complete -c spack -n '__fish_spack_using_command spec' -l non-defaults -d 'highlight non-default versions or variants'
-complete -c spack -n '__fish_spack_using_command spec' -s c -l cover -r -f -a 'nodes edges paths'
+complete -c spack -n '__fish_spack_using_command spec' -s c -l cover -r -f -a 'nodes edges'
 complete -c spack -n '__fish_spack_using_command spec' -s c -l cover -r -d 'how extensively to traverse the DAG (default: nodes)'
 complete -c spack -n '__fish_spack_using_command spec' -s t -l types -f -a types
 complete -c spack -n '__fish_spack_using_command spec' -s t -l types -d 'show dependency types'
+complete -c spack -n '__fish_spack_using_command spec' -l show-runtime-deps -f -a show_runtime_deps
+complete -c spack -n '__fish_spack_using_command spec' -l show-runtime-deps -d 'show transitive runtime dependencies'
+complete -c spack -n '__fish_spack_using_command spec' -l show-build-deps -f -a show_build_deps
+complete -c spack -n '__fish_spack_using_command spec' -l show-build-deps -d 'show transitive runtime dependencies'
 complete -c spack -n '__fish_spack_using_command spec' -s f -l force -f -a concretizer_force
 complete -c spack -n '__fish_spack_using_command spec' -s f -l force -d 'allow changes to concretized specs in spack.lock (in an env)'
 complete -c spack -n '__fish_spack_using_command spec' -s U -l fresh -f -a concretizer_reuse


### PR DESCRIPTION
related to #23586

This PR permits to display just the "runtime" part of a spec (i.e. what needs to be deployed to use a software, without build dependencies).

### Example

```console
$ spack spec --show-runtime-deps -t gnupg openssl minisign
Input spec
--------------------------------
[    ]  gnupg

Concretized
--------------------------------
[    ]  gnupg@2.2.25%gcc@11.1.0 arch=linux-ubuntu18.04-broadwell
[bl  ]      ^libassuan@2.5.3%gcc@11.1.0 arch=linux-ubuntu18.04-broadwell
[bl  ]          ^libgpg-error@1.37%gcc@11.1.0 arch=linux-ubuntu18.04-broadwell
[bl  ]      ^libgcrypt@1.9.1%gcc@11.1.0 arch=linux-ubuntu18.04-broadwell
[bl  ]      ^libiconv@1.16%gcc@11.1.0 arch=linux-ubuntu18.04-broadwell
[bl  ]      ^libksba@1.4.0%gcc@11.1.0 arch=linux-ubuntu18.04-broadwell
[bl  ]      ^npth@1.6%gcc@11.1.0 arch=linux-ubuntu18.04-broadwell
[  r ]      ^pinentry@1.1.0%gcc@11.1.0 arch=linux-ubuntu18.04-broadwell
[bl  ]      ^zlib@1.2.11%gcc@11.1.0+optimize+pic+shared arch=linux-ubuntu18.04-broadwell

Input spec
--------------------------------
[    ]  openssl

Concretized
--------------------------------
[    ]  openssl@1.1.1k%gcc@11.1.0~docs+systemcerts arch=linux-ubuntu18.04-broadwell
[bl  ]      ^zlib@1.2.11%gcc@11.1.0+optimize+pic+shared arch=linux-ubuntu18.04-broadwell

Input spec
--------------------------------
[    ]  minisign

Concretized
--------------------------------
[    ]  minisign@0.9%gcc@11.1.0~ipo+static build_type=RelWithDebInfo arch=linux-ubuntu18.04-broadwell
[bl  ]      ^libsodium@1.0.18%gcc@11.1.0 arch=linux-ubuntu18.04-broadwell
```