### PR TITLE
Add py-poetry dependency to py-archspec and add new versions

### DIFF
--- a/var/spack/repos/builtin/packages/py-archspec/package.py
+++ b/var/spack/repos/builtin/packages/py-archspec/package.py
@@ -21,6 +21,5 @@ class PyArchspec(PythonPackage):
 
     depends_on('py-click@7.1.2:7', type=('build', 'run'))
     depends_on('py-six@1.13.0:1', type=('build', 'run'))
-    depends_on('py-poetry@1.1.12 ^python@3.7:', type=('build', 'run'))
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-archspec/package.py
+++ b/var/spack/repos/builtin/packages/py-archspec/package.py
@@ -12,7 +12,10 @@ class PyArchspec(PythonPackage):
 
     maintainers = ['alalazo']
 
+    version('0.1.3', sha256='a1aa7abde4d4ce38d115dfd572584906fa8e192e3272b8897e7b4fa1213ec27c')
+    version('0.1.2', sha256='8bb998370f0dc3e509d57c13724ab4109d761fd74af20da26fbe513b0fe01c46')
     version('0.1.1', sha256='34bafad493b41208857232e21776216d716de37ab051a6a4a1cc1653f7e26423')
+    version('0.1.0', sha256='a4431d0bbe9c9dd7b293c39d8e7590034d512ce5f5a1278a6cbdf61b33f7202d')
 
     depends_on('python@2.7:2.8,3.5:', type=('build', 'run'))
 

--- a/var/spack/repos/builtin/packages/py-archspec/package.py
+++ b/var/spack/repos/builtin/packages/py-archspec/package.py
@@ -18,5 +18,6 @@ class PyArchspec(PythonPackage):
 
     depends_on('py-click@7.1.2:7', type=('build', 'run'))
     depends_on('py-six@1.13.0:1', type=('build', 'run'))
+    depends_on('py-poetry@1.1.12 ^python@3.7:', type=('build', 'run'))
 
     depends_on('py-setuptools', type='build')


### PR DESCRIPTION
Currently, py-archspec does not install poetry as a dependency, but it is required. This PR simply adds Poetry as a dependency. Since Poetry's project site, states that it will work for Python 3.7+, that is reflected in the `depends_on` statement. 

This PR also adds new versions of py-archspec with their associated checksums. 