### PR TITLE
Woptim/extend commit fetch

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -862,6 +862,9 @@ class GitFetchStrategy(VCSFetchStrategy):
                 )
 
             with working_dir(dest):
+                # By defaults, on all references are fetched by the clone
+                fetch_args = ["fetch", "origin", "--depth 1", commit]
+                git(*fetch_args)
                 checkout_args = ["checkout", commit]
                 if not debug:
                     checkout_args.insert(1, "--quiet")

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -863,7 +863,7 @@ class GitFetchStrategy(VCSFetchStrategy):
 
             with working_dir(dest):
                 # By defaults, on all references are fetched by the clone
-                fetch_args = ["fetch", "origin", "--depth 1", commit]
+                fetch_args = ["fetch", "origin", commit]
                 git(*fetch_args)
                 checkout_args = ["checkout", commit]
                 if not debug:

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -1336,6 +1336,10 @@ class CommitLookup(object):
             # won't properly update the local rev-list)
             self.fetcher.git("fetch", "--tags", output=os.devnull, error=os.devnull)
 
+            # We need to do an attempt at fetching the commit in order to
+            # be sure to get it in case it comes from a PR in a fork.
+            self.fetcher.git("fetch", "%s^{commit}" % ref, output=os.devnull, error=os.devnull)
+
             # Ensure ref is a commit object known to git
             # Note the brackets are literals, the ref replaces the format string
             try:

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -1338,7 +1338,7 @@ class CommitLookup(object):
 
             # We need to do an attempt at fetching the commit in order to
             # be sure to get it in case it comes from a PR in a fork.
-            self.fetcher.git("fetch", "origin", "%s^{commit}" % ref, output=os.devnull, error=os.devnull)
+            self.fetcher.git("fetch", "origin", "%s" % ref, output=os.devnull, error=os.devnull)
 
             # Ensure ref is a commit object known to git
             # Note the brackets are literals, the ref replaces the format string

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -1338,7 +1338,7 @@ class CommitLookup(object):
 
             # We need to do an attempt at fetching the commit in order to
             # be sure to get it in case it comes from a PR in a fork.
-            self.fetcher.git("fetch", "%s^{commit}" % ref, output=os.devnull, error=os.devnull)
+            self.fetcher.git("fetch", "origin", "%s^{commit}" % ref, output=os.devnull, error=os.devnull)
 
             # Ensure ref is a commit object known to git
             # Note the brackets are literals, the ref replaces the format string


### PR DESCRIPTION
This PR is an improvement of the git fetch mechanism to allow Spack to retrieve package commits that originate from a PR in a fork repository.

## Use case

We use Spack in our CI to install / manage our projects dependencies. Doing so, we integrate packaging closer to the developer workflow. With the recent ability to install a package for a specific commit, Spack opened the door to easy testing of changes in the dependency tree, allowing us to test Pull Requests (PRs) instead of waiting for the release.

## Limitation

Spack is unable to retrieve commits if they originate from a PR from a fork. Indeed, if one wants to do so while cloning a project, it is necessary to specifically fetch the reference: the data exists on the server, but a clone won’t download it.

## Solution

This PR addresses that by adding a fetch step to try to get the specified hash. Now, even PRs from fork can be built.

## Security note

I wanted to mention that there might be a security concern about this: everyone can create a PR from a fork, which means that Spack would be able install code from virtually anywhere without this code to belong to the original code base.

However, I believe that this risk is mitigated by several things:
1. The commit hash is specified by the user, it is not possible to randomly pick a hash, the user likely knows what he is doing and is responsible for it.
2. No hash-install can be specified in the package itself: hash-installs are only supported on command line. Therefore, a hash cannot be hidden in a package.
3. An error in the hash will almost certainly result in a failure to find the reference rather than the install of code from an unknown source: no risk of proximity hacking of a hash.
