### PR TITLE
Expand external CLI

### DIFF
--- a/bin/spack_cmd.bat
+++ b/bin/spack_cmd.bat
@@ -54,7 +54,9 @@ if defined py_exe (
     "%py_exe%" "%SPACK_ROOT%\bin\haspywin.py"
 )
 
-set "EDITOR=notepad"
+if not defined EDITOR (
+    set "EDITOR=notepad"
+)
 
 DOSKEY spacktivate=spack env activate $*
 

--- a/bin/spack_cmd.bat
+++ b/bin/spack_cmd.bat
@@ -54,10 +54,6 @@ if defined py_exe (
     "%py_exe%" "%SPACK_ROOT%\bin\haspywin.py"
 )
 
-if not defined EDITOR (
-    set "EDITOR=notepad"
-)
-
 DOSKEY spacktivate=spack env activate $*
 
 @echo **********************************************************************

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -502,6 +502,21 @@ def display_specs(specs, args=None, **kwargs):
     output.flush()
 
 
+def confirm_removal(specs, display_args):
+    """Display the list of specs to be removed and ask for confirmation.
+
+    Args:
+        specs (list): specs to be removed
+    """
+    tty.msg("The following packages will be uninstalled:\n")
+    display_specs(specs, **display_args)
+    print("")
+    answer = tty.get_yes_or_no("Do you want to proceed?", default=False)
+    if not answer:
+        tty.msg("Aborting uninstallation")
+        sys.exit(0)
+
+
 def filter_loaded_specs(specs):
     """Filter a list of specs returning only those that are
     currently loaded."""

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -18,6 +18,7 @@ import spack.cmd.common.arguments
 import spack.cray_manifest as cray_manifest
 import spack.detection
 import spack.error
+import spack.util.editor
 import spack.util.environment
 
 description = "manage external packages in Spack configuration"
@@ -65,7 +66,15 @@ def setup_parser(subparser):
     )
 
     list_parser = sp.add_parser("list", help="list detectable packages, by repository and name")
-    list_parser.add_argument("--detected", "-d", action="store_true", default=False, required=False, help="list detectable packages that have been detected externally and are present in packages.yaml")
+    list_parser.add_argument(
+        "--detected",
+        "-d",
+        action="store_true",
+        default=False,
+        required=False,
+        help=('list detectable packages that have been'
+              'detected externally and are present in packages.yaml')
+    )
 
     read_cray_manifest = sp.add_parser(
         "read-cray-manifest",
@@ -92,6 +101,14 @@ def setup_parser(subparser):
         help=("if a manifest file cannot be parsed, fail and report the " "full stack trace"),
     )
 
+    edit_parser = sp.add_parser("edit", help="open packages.yaml in $EDITOR")
+    edit_parser.add_argument(
+        "--scope",
+        choices=scopes,
+        metavar=scopes_metavar,
+        default=spack.config.default_modify_scope("packages"),
+        help="configuration scope to modify",
+    )
 
 def external_find(args):
     if args.all or not (args.tags or args.packages):
@@ -246,11 +263,17 @@ def external_list(args):
             colify.colify(pkgs, indent=4, output=sys.stdout)
 
 
+def external_edit(args):
+    ext_packages_yaml_path = spack.config.config.get_config_filename(args.scope, "packages")
+    spack.util.editor.editor(ext_packages_yaml_path)
+
+
 def external(parser, args):
     action = {
         "find": external_find,
         "list": external_list,
         "read-cray-manifest": external_read_cray_manifest,
+        "edit" : external_edit,
     }
     action[args.external_command](args)
 

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -64,7 +64,8 @@ def setup_parser(subparser):
         "package Spack knows how to find."
     )
 
-    sp.add_parser("list", help="list detectable packages, by repository and name")
+    list_parser = sp.add_parser("list", help="list detectable packages, by repository and name")
+    list_parser.add_argument("--detected", "-d", action="store_true", default=False, required=False, help="list detectable packages that have been detected externally and are present in packages.yaml")
 
     read_cray_manifest = sp.add_parser(
         "read-cray-manifest",
@@ -231,13 +232,18 @@ def _collect_and_consume_cray_manifest_files(
 
 
 def external_list(args):
-    # Trigger a read of all packages, might take a long time.
-    list(spack.repo.path.all_package_classes())
-    # Print all the detectable packages
-    tty.msg("Detectable packages per repository")
-    for namespace, pkgs in sorted(spack.package_base.detectable_packages.items()):
-        print("Repository:", namespace)
-        colify.colify(pkgs, indent=4, output=sys.stdout)
+    if args.detected:
+        # Only list specs currently in packages.yaml
+        present_externals = spack.detection.common._externals_in_packages_yaml()
+        spack.cmd.display_specs(present_externals)
+    else:
+        # Trigger a read of all packages, might take a long time.
+        list(spack.repo.path.all_package_classes())
+        # Print all the detectable packages
+        tty.msg("Detectable packages per repository")
+        for namespace, pkgs in sorted(spack.package_base.detectable_packages.items()):
+            print("Repository:", namespace)
+            colify.colify(pkgs, indent=4, output=sys.stdout)
 
 
 def external(parser, args):

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -18,7 +18,6 @@ import spack.cmd.common.arguments
 import spack.cray_manifest as cray_manifest
 import spack.detection
 import spack.error
-import spack.util.editor
 import spack.util.environment
 
 description = "manage external packages in Spack configuration"
@@ -103,15 +102,6 @@ def setup_parser(subparser):
         "--fail-on-error",
         action="store_true",
         help=("if a manifest file cannot be parsed, fail and report the " "full stack trace"),
-    )
-
-    edit_parser = sp.add_parser("edit", help="open packages.yaml in $EDITOR")
-    edit_parser.add_argument(
-        "--scope",
-        choices=scopes,
-        metavar=scopes_metavar,
-        default=spack.config.default_modify_scope("packages"),
-        help="configuration scope to modify",
     )
 
     remove_parser = sp.add_parser("remove", help="remove external packages from packages.yaml")
@@ -285,11 +275,6 @@ def external_list(args):
             colify.colify(pkgs, indent=4, output=sys.stdout)
 
 
-def external_edit(args):
-    ext_packages_yaml_path = spack.config.config.get_config_filename(args.scope, "packages")
-    spack.util.editor.editor(ext_packages_yaml_path)
-
-
 def _report_removed(path, specs):
     tty.msg("The following packages have been removed from {}:".format(path))
     spack.cmd.display_specs(specs, display_args)
@@ -324,7 +309,6 @@ def external(parser, args):
         "find": external_find,
         "list": external_list,
         "read-cray-manifest": external_read_cray_manifest,
-        "edit": external_edit,
         "remove": external_remove,
     }
     action[args.external_command](args)

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -373,7 +373,7 @@ def uninstall_specs(args, specs):
         return
 
     if not args.yes_to_all:
-        confirm_removal(uninstall_list)
+        spack.cmd.confirm_removal(uninstall_list, display_args)
 
     # Uninstall everything on the list
     do_uninstall(uninstall_list, args.force)
@@ -385,21 +385,6 @@ def uninstall_specs(args, specs):
             env.write()
 
         env.regenerate_views()
-
-
-def confirm_removal(specs):
-    """Display the list of specs to be removed and ask for confirmation.
-
-    Args:
-        specs (list): specs to be removed
-    """
-    tty.msg("The following packages will be uninstalled:\n")
-    spack.cmd.display_specs(specs, **display_args)
-    print("")
-    answer = tty.get_yes_or_no("Do you want to proceed?", default=False)
-    if not answer:
-        tty.msg("Aborting uninstallation")
-        sys.exit(0)
 
 
 def uninstall(parser, args):

--- a/lib/spack/spack/detection/__init__.py
+++ b/lib/spack/spack/detection/__init__.py
@@ -2,7 +2,13 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-from .common import DetectedPackage, executable_prefix, update_configuration
+from .common import (
+    DetectedPackage,
+    executable_prefix,
+    get_matching_external_specs,
+    remove_specs_from_configuration,
+    update_configuration,
+)
 from .path import by_executable, by_library, executables_in_path
 
 __all__ = [
@@ -12,4 +18,6 @@ __all__ = [
     "executables_in_path",
     "executable_prefix",
     "update_configuration",
+    "get_matching_external_specs",
+    "remove_specs_from_configuration",
 ]

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -256,7 +256,13 @@ def remove_specs_from_configuration(specs, scope):
         # *pkg_cfg[spec.name].values() will unpack to
         # nothing if there is not a single defined element of the cfg
         # for that package
-        if not list(*pkg_cfg[spec.name].values()):
+
+        def entry_empty(pkg_entry):
+            for x in pkg_entry.values():
+                if x:
+                    return False
+
+        if entry_empty(pkg_cfg[spec.name]):
             pkg_cfg.pop(spec.name)
     spack.config.set("packages", pkg_cfg, scope=scope)
     return removed_specs

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1024,7 +1024,7 @@ _spack_external() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="find list read-cray-manifest"
+        SPACK_COMPREPLY="find list read-cray-manifest edit remove"
     fi
 }
 
@@ -1038,11 +1038,24 @@ _spack_external_find() {
 }
 
 _spack_external_list() {
-    SPACK_COMPREPLY="-h --help"
+    SPACK_COMPREPLY="-h --help --detected -d"
 }
 
 _spack_external_read_cray_manifest() {
     SPACK_COMPREPLY="-h --help --file --directory --dry-run --fail-on-error"
+}
+
+_spack_external_edit() {
+    SPACK_COMPREPLY="-h --help --scope"
+}
+
+_spack_external_remove() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help --scope -a --all -y --yes-to-all"
+    else
+        _all_packages
+    fi
 }
 
 _spack_fetch() {


### PR DESCRIPTION
Add support for three new facets of the `spack external` CLI.
 1) Adds support for the `spack external remove` command, which allows users to remove externally detected packages from the command line
2) Adds support for `spack external edit` which opens the pacakges.yaml file in the user $EDITOR env variable.
3) Adds support for the `--detected` flag to existing command `spack external list` which lists packages that have already been detected as externals. 

This effort is based on #19351 and motivated by the paraview Windows porting process. 

Note: This PR also stops the Spack setup script for CMD from clobbering the user defined $EDITOR env variable. If the rest of this PR does not make it in, that change should anyway.