### PR TITLE
environment concretization: transactional concretization

### DIFF
--- a/lib/spack/spack/environment/__init__.py
+++ b/lib/spack/spack/environment/__init__.py
@@ -598,6 +598,7 @@ corresponding group.
 from .environment import (
     TOP_LEVEL_KEY,
     Environment,
+    EnvironmentConcretizer,
     SpackEnvironmentConfigError,
     SpackEnvironmentDevelopError,
     SpackEnvironmentError,
@@ -638,6 +639,7 @@ from .environment import (
 __all__ = [
     "TOP_LEVEL_KEY",
     "Environment",
+    "EnvironmentConcretizer",
     "SpackEnvironmentConfigError",
     "SpackEnvironmentDevelopError",
     "SpackEnvironmentError",

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1716,15 +1716,32 @@ class Environment:
             List of specs that have been concretized. Each entry is a tuple of
             the user spec and the corresponding concretized spec.
         """
-        # TODO: should this revert the updates coming from included envs
         old_concretized_roots = self.concretized_roots[:]
         old_specs_by_hash = self.specs_by_hash.copy()
+
+        # This is slightly complicated to pass by value the correct portion of the way
+        # down the stack
+        old_included_roots = {
+            env_name: concretized_user_specs[:]
+            for env_name, concretized_user_specs in self.included_concretized_user_specs.items()
+        }
+        old_included_order = {
+            env_name: concretized_order[:]
+            for env_name, concretized_order in self.included_concretized_order.items()
+        }
+        old_included_by_hash = {
+            env_name: env_by_hash.copy()
+            for env_name, env_by_hash in self.included_specs_by_hash.items()
+        }
 
         try:
             return EnvironmentConcretizer(self).concretize(force=force, tests=tests)
         except BaseException:
-            self.concretized_roots = old_concretized_roots[:]
-            self.specs_by_hash = old_specs_by_hash.copy()
+            self.concretized_roots = old_concretized_roots
+            self.specs_by_hash = old_specs_by_hash
+            self.included_concretized_user_specs = old_included_roots
+            self.included_concretized_order = old_included_order
+            self.included_specs_by_hash = old_included_by_hash
             raise
 
     def sync_concretized_specs(self) -> None:

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1723,8 +1723,8 @@ class Environment:
         try:
             return EnvironmentConcretizer(self).concretize(force=force, tests=tests)
         except BaseException:
-            self.concretized_user_specs = old_concretized_user_specs[:]
-            self.specs_by_hash = old_specs_by_hash
+            self.concretized_roots = old_concretized_roots[:]
+            self.specs_by_hash = old_specs_by_hash.copy()
             raise
 
     def sync_concretized_specs(self) -> None:

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1718,7 +1718,7 @@ class Environment:
         """
         # TODO: should this revert the updates coming from included envs
         old_concretized_roots = self.concretized_roots[:]
-        old_specs_by_hash = self.specs_by_hash
+        old_specs_by_hash = self.specs_by_hash.copy()
 
         try:
             return EnvironmentConcretizer(self).concretize(force=force, tests=tests)

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1718,6 +1718,7 @@ class Environment:
         """
         old_concretized_roots = self.concretized_roots[:]
         old_specs_by_hash = self.specs_by_hash.copy()
+        old_concrete_data = self.included_concrete_spec_data
 
         # This is slightly complicated to pass by value the correct portion of the way
         # down the stack
@@ -1742,6 +1743,7 @@ class Environment:
             self.included_concretized_user_specs = old_included_roots
             self.included_concretized_order = old_included_order
             self.included_specs_by_hash = old_included_by_hash
+            self.included_concrete_spec_data = old_concrete_data
             raise
 
     def sync_concretized_specs(self) -> None:

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1716,7 +1716,15 @@ class Environment:
             List of specs that have been concretized. Each entry is a tuple of
             the user spec and the corresponding concretized spec.
         """
-        return EnvironmentConcretizer(self).concretize(force=force, tests=tests)
+        # TODO: should this revert the updates coming from included envs
+        old_concretized_roots = self.concretized_roots[:]
+        old_specs_by_hash = self.specs_by_hash
+
+        try:
+            return EnvironmentConcretizer(self).concretize(force=force, tests=tests)
+        except BaseException:
+            self.concretized_user_specs = old_concretized_user_specs[:]
+            self.specs_by_hash = old_specs_by_hash
 
     def sync_concretized_specs(self) -> None:
         """Removes concrete specs that no longer correlate to a user spec"""

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1725,6 +1725,7 @@ class Environment:
         except BaseException:
             self.concretized_user_specs = old_concretized_user_specs[:]
             self.specs_by_hash = old_specs_by_hash
+            raise
 
     def sync_concretized_specs(self) -> None:
         """Removes concrete specs that no longer correlate to a user spec"""

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1718,17 +1718,12 @@ class Environment:
         """
         old_concretized_roots = self.concretized_roots[:]
         old_specs_by_hash = self.specs_by_hash.copy()
-        old_concrete_data = self.included_concrete_spec_data
 
         # This is slightly complicated to pass by value the correct portion of the way
         # down the stack
-        old_included_roots = {
-            env_name: concretized_user_specs[:]
-            for env_name, concretized_user_specs in self.included_concretized_user_specs.items()
-        }
-        old_included_order = {
-            env_name: concretized_order[:]
-            for env_name, concretized_order in self.included_concretized_order.items()
+        old_concrete_data = {
+            env_name: env_data.copy()
+            for env_name, env_data in self.included_concrete_spec_data.items()
         }
         old_included_by_hash = {
             env_name: env_by_hash.copy()
@@ -1740,8 +1735,6 @@ class Environment:
         except BaseException:
             self.concretized_roots = old_concretized_roots
             self.specs_by_hash = old_specs_by_hash
-            self.included_concretized_user_specs = old_included_roots
-            self.included_concretized_order = old_included_order
             self.included_specs_by_hash = old_included_by_hash
             self.included_concrete_spec_data = old_concrete_data
             raise

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -3749,6 +3749,11 @@ def test_query_develop_specs(tmp_path: pathlib.Path):
     [
         (True, (spack.concretize, "concretize_specs_together")),
         ("when_possible", (spack.solver.asp.Solver, "solve_in_rounds")),
+        # An earlier failure so that we test the case where the internal state
+        # has been changed, but the pointer to the internal variables has not change.
+        # This effectively tests that we are properly copying by value not by
+        # reference for the transactional concretization
+        (True, (spack.environment.Environment, "_get_specs_to_concretize")),
     ],
 )
 def test_concretize_transactional(unify, method_to_fail, monkeypatch):
@@ -3756,7 +3761,13 @@ def test_concretize_transactional(unify, method_to_fail, monkeypatch):
     e.unify = unify
 
     e.add("mpi")
+    e.add("zlib")
     e.concretize()
+
+    # remove one spec and add another to ensure we test with changes before
+    # and after the environment is cleared during concretization
+    e.remove("zlib")
+    e.add("libelf")
 
     def fail(*args, **kwargs):
         raise Exception("Test failures")
@@ -3764,12 +3775,12 @@ def test_concretize_transactional(unify, method_to_fail, monkeypatch):
     location, method = method_to_fail
     monkeypatch.setattr(location, method, fail)
 
-    first_user_specs = e.concretized_user_specs
-    first_order = e.concretized_order
-    first_hash_dict = e.specs_by_hash
+    first_user_specs = e.concretized_user_specs[:]
+    first_order = e.concretized_order[:]
+    first_hash_dict = e.specs_by_hash.copy()
 
     try:
-        e.concretize(force=True)
+        e.concretize()
     except Exception:
         pass
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -3741,9 +3741,6 @@ def test_virtual_spec_concretize_together(mutable_config):
         assert any(s.package.provides("mpi") for _, s in e.concretized_specs())
 
 
-<<<<<<< HEAD
-def test_query_develop_specs(tmp_path: pathlib.Path):
-=======
 @pytest.mark.parametrize(
     "unify,method_to_fail",
     [
@@ -3789,8 +3786,7 @@ def test_concretize_transactional(unify, method_to_fail, monkeypatch):
     assert e.specs_by_hash == first_hash_dict
 
 
-def test_query_develop_specs():
->>>>>>> 265d80cee3 (test for transactional concretization)
+def test_query_develop_specs(tmp_path: pathlib.Path):
     """Test whether a spec is develop'ed or not"""
     srcdir = tmp_path / "here"
     srcdir.mkdir()

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -3750,7 +3750,7 @@ def test_virtual_spec_concretize_together(mutable_config):
         # has been changed, but the pointer to the internal variables has not change.
         # This effectively tests that we are properly copying by value not by
         # reference for the transactional concretization
-        (True, (spack.environment.Environment, "_get_specs_to_concretize")),
+        (True, (ev.Environment, "_get_specs_to_concretize")),
     ],
 )
 def test_concretize_transactional(unify, method_to_fail, monkeypatch):

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -3772,8 +3772,7 @@ def test_concretize_transactional(unify, method_to_fail, monkeypatch):
     location, method = method_to_fail
     monkeypatch.setattr(location, method, fail)
 
-    first_user_specs = e.concretized_user_specs[:]
-    first_order = e.concretized_order[:]
+    first_roots = e.concretized_roots[:]
     first_hash_dict = e.specs_by_hash.copy()
 
     try:
@@ -3781,8 +3780,7 @@ def test_concretize_transactional(unify, method_to_fail, monkeypatch):
     except Exception:
         pass
 
-    assert e.concretized_user_specs == first_user_specs
-    assert e.concretized_order == first_order
+    assert e.concretized_roots == first_roots
     assert e.specs_by_hash == first_hash_dict
 
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -3744,18 +3744,18 @@ def test_virtual_spec_concretize_together(mutable_config):
 @pytest.mark.parametrize(
     "unify,method_to_fail",
     [
-        (True, (spack.concretize, "concretize_specs_together")),
+        (True, (spack.concretize, "concretize_together")),
         ("when_possible", (spack.solver.asp.Solver, "solve_in_rounds")),
         # An earlier failure so that we test the case where the internal state
         # has been changed, but the pointer to the internal variables has not change.
         # This effectively tests that we are properly copying by value not by
         # reference for the transactional concretization
-        (True, (ev.Environment, "_get_specs_to_concretize")),
+        (True, (ev.EnvironmentConcretizer, "concretize")),
     ],
 )
-def test_concretize_transactional(unify, method_to_fail, monkeypatch):
+def test_concretize_transactional(unify, method_to_fail, monkeypatch, mutable_config):
+    spack.config.set("concretizer:unify", unify)
     e = ev.create("test")
-    e.unify = unify
 
     e.add("mpi")
     e.add("zlib")
@@ -3779,6 +3779,8 @@ def test_concretize_transactional(unify, method_to_fail, monkeypatch):
         e.concretize()
     except Exception:
         pass
+    else:
+        assert False, "concretization failure required for testing"
 
     assert e.concretized_roots == first_roots
     assert e.specs_by_hash == first_hash_dict

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -3741,7 +3741,45 @@ def test_virtual_spec_concretize_together(mutable_config):
         assert any(s.package.provides("mpi") for _, s in e.concretized_specs())
 
 
+<<<<<<< HEAD
 def test_query_develop_specs(tmp_path: pathlib.Path):
+=======
+@pytest.mark.parametrize(
+    "unify,method_to_fail",
+    [
+        (True, (spack.concretize, "concretize_specs_together")),
+        ("when_possible", (spack.solver.asp.Solver, "solve_in_rounds")),
+    ],
+)
+def test_concretize_transactional(unify, method_to_fail, monkeypatch):
+    e = ev.create("test")
+    e.unify = unify
+
+    e.add("mpi")
+    e.concretize()
+
+    def fail(*args, **kwargs):
+        raise Exception("Test failures")
+
+    location, method = method_to_fail
+    monkeypatch.setattr(location, method, fail)
+
+    first_user_specs = e.concretized_user_specs
+    first_order = e.concretized_order
+    first_hash_dict = e.specs_by_hash
+
+    try:
+        e.concretize(force=True)
+    except Exception:
+        pass
+
+    assert e.concretized_user_specs == first_user_specs
+    assert e.concretized_order == first_order
+    assert e.specs_by_hash == first_hash_dict
+
+
+def test_query_develop_specs():
+>>>>>>> 265d80cee3 (test for transactional concretization)
     """Test whether a spec is develop'ed or not"""
     srcdir = tmp_path / "here"
     srcdir.mkdir()


### PR DESCRIPTION
Currently, failed concretization can undo user spec state. This is a problem.

Fixed in this PR by making all environment concretization transactional.

@tgamblin as we discussed.