### PR TITLE
Bugfix: Compiler flags propagate to all dependecies

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -846,7 +846,6 @@ class PyclingoDriver:
         if not setup.concretize_everything:
             self.control.load(os.path.join(parent_dir, "when_possible.lp"))
 
-
         has_propagation = False
         for spec in specs:
             for dep in spec.traverse(root=True):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -846,10 +846,11 @@ class PyclingoDriver:
         if not setup.concretize_everything:
             self.control.load(os.path.join(parent_dir, "when_possible.lp"))
 
+        tty.debug(f"Pyclingodriver attrs: {self.__dir__()}")
         has_propagation = False
         for spec in specs:
             for dep in spec.traverse(root=True):
-                has_propagation |= self._compiler_flag_has_propagation(dep.compiler_flags)
+                has_propagation |= self._compiler_flags_has_propagation(dep.compiler_flags)
         if has_propagation:
             self.control.load(os.path.join(parent_dir, "propagation.lp"))
 
@@ -1013,7 +1014,7 @@ class ConcreteSpecsByHash(collections.abc.Mapping):
     def __iter__(self):
         return iter(self.data)
 
-    def _compiler_flag_has_propagation(self, flags):
+    def _compiler_flags_has_propagation(self, flags):
         for _, flag_vals in flags.items():
             if any(val.propagate for val in flag_vals):
                 return True

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1898,7 +1898,7 @@ class SpackSolverSetup:
                 clauses.append(f.node_flag(spec.name, flag_type, flag))
                 clauses.append(f.node_flag_source(spec.name, flag_type, spec.name))
                 if not spec.concrete and flag.propagate is True:
-                    clauses.append(f.node_flag_propagate(spec.name, flag_type, flag, spec.name))
+                    clauses.append(f.node_flag_possible_prop(spec.name, flag_type, flag, spec.name))
 
         # dependencies
         if spec.concrete:
@@ -2712,7 +2712,7 @@ class _Head:
     node_compiler_version = fn.attr("node_compiler_version_set")
     node_flag = fn.attr("node_flag_set")
     node_flag_source = fn.attr("node_flag_source")
-    node_flag_propagate = fn.attr("node_flag_propagate")
+    node_flag_propagation_candidate = fn.attr("node_flag_propagation_candidate")
     variant_propagation_candidate = fn.attr("variant_propagation_candidate")
 
 
@@ -2729,7 +2729,7 @@ class _Body:
     node_compiler_version = fn.attr("node_compiler_version")
     node_flag = fn.attr("node_flag")
     node_flag_source = fn.attr("node_flag_source")
-    node_flag_propagate = fn.attr("node_flag_propagate")
+    node_flag_propagation_candidate = fn.attr("node_flag_propagation_candidate")
     variant_propagation_candidate = fn.attr("variant_propagation_candidate")
 
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -847,7 +847,7 @@ class PyclingoDriver:
             self.control.load(os.path.join(parent_dir, "when_possible.lp"))
 
         for spec in specs:
-            if self._compiler_flags_has_propagation(spec.compiler_flags):
+            if self._compiler_flags_has_propagation(spec):
                 self.control.load(os.path.join(parent_dir, "propagation.lp"))
                 break
 
@@ -940,10 +940,11 @@ class PyclingoDriver:
 
         return result, timer, self.control.statistics
 
-    def _compiler_flags_has_propagation(self, flags):
-        for _, flag_vals in flags.items():
-            if any(val.propagate for val in flag_vals):
-                return True
+    def _compiler_flags_has_propagation(self, spec):
+        for dep in spec.traverse():
+            for _, flag_vals in dep.compiler_flags.items():
+                if any(val.propagate for val in flag_vals):
+                    return True
         return False
 
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -41,6 +41,7 @@ import spack.platforms
 import spack.repo
 import spack.spec
 import spack.store
+import spack.traverse
 import spack.util.crypto
 import spack.util.elf
 import spack.util.libc

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1898,7 +1898,9 @@ class SpackSolverSetup:
                 clauses.append(f.node_flag(spec.name, flag_type, flag))
                 clauses.append(f.node_flag_source(spec.name, flag_type, spec.name))
                 if not spec.concrete and flag.propagate is True:
-                    clauses.append(f.node_flag_possible_prop(spec.name, flag_type, flag, spec.name))
+                    clauses.append(
+                        f.node_flag_possible_prop(spec.name, flag_type, flag, spec.name)
+                    )
 
         # dependencies
         if spec.concrete:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -851,7 +851,6 @@ class PyclingoDriver:
                 self.control.load(os.path.join(parent_dir, "propagation.lp"))
                 break
 
-
         # Binary compatibility is based on libc on Linux, and on the os tag elsewhere
         if using_libc_compatibility():
             self.control.load(os.path.join(parent_dir, "libc_compatibility.lp"))

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -41,7 +41,6 @@ import spack.platforms
 import spack.repo
 import spack.spec
 import spack.store
-import spack.traverse
 import spack.util.crypto
 import spack.util.elf
 import spack.util.libc
@@ -316,7 +315,7 @@ def using_libc_compatibility() -> bool:
 
 
 def specs_are_propagating_compiler_flags(specs):
-    for node in spack.traverse.traverse_nodes(specs):
+    for node in traverse.traverse_nodes(specs):
         for _, flag_vals in node.compiler_flags.items():
             if any(val.propagate for val in flag_vals):
                 return True

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -845,6 +845,13 @@ class PyclingoDriver:
         self.control.load(os.path.join(parent_dir, "display.lp"))
         if not setup.concretize_everything:
             self.control.load(os.path.join(parent_dir, "when_possible.lp"))
+        flags = []
+        for spec in specs:
+            flags.append(spec.compiler_flags)
+
+        if self._compiler_flag_has_propagation(flags):
+            self.control.load(os.path.join(parent_dir, "propagation.lp"))
+
 
         # Binary compatibility is based on libc on Linux, and on the os tag elsewhere
         if using_libc_compatibility():
@@ -933,6 +940,13 @@ class PyclingoDriver:
             )
 
         return result, timer, self.control.statistics
+
+    def _compiler_flag_has_propagation(self, flags):
+        for flag in flags:
+            for flag_type, flag_vals in flag.items():
+                if any(val.propagate for val in flag_vals):
+                    return True
+        return False
 
 
 class ConcreteSpecsByHash(collections.abc.Mapping):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1898,7 +1898,7 @@ class SpackSolverSetup:
                 clauses.append(f.node_flag(spec.name, flag_type, flag))
                 clauses.append(f.node_flag_source(spec.name, flag_type, spec.name))
                 if not spec.concrete and flag.propagate is True:
-                    clauses.append(f.node_flag_propagate(spec.name, flag_type))
+                    clauses.append(f.node_flag_propagate(spec.name, flag_type, flag, spec.name))
 
         # dependencies
         if spec.concrete:

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -395,7 +395,7 @@ imposed_nodes(ConditionID, PackageNode, node(X, A1))
 attr(Name, node(X, A1))             :- impose(ID, PackageNode), imposed_constraint(ID, Name, A1),             imposed_nodes(ID, PackageNode, node(X, A1)).
 attr(Name, node(X, A1), A2)         :- impose(ID, PackageNode), imposed_constraint(ID, Name, A1, A2),         imposed_nodes(ID, PackageNode, node(X, A1)), not multiple_nodes_attribute(Name).
 attr(Name, node(X, A1), A2, A3)     :- impose(ID, PackageNode), imposed_constraint(ID, Name, A1, A2, A3),     imposed_nodes(ID, PackageNode, node(X, A1)), not multiple_nodes_attribute(Name).
-attr(Name, node(X, A1), A2, A3, A4) :- impose(ID, PackageNode), imposed_constraint(ID, Name, A1, A2, A3, A4), imposed_nodes(ID, PackageNode, node(X, A1)).
+attr(Name, node(X, A1), A2, A3, A4) :- impose(ID, PackageNode), imposed_constraint(ID, Name, A1, A2, A3, A4), imposed_nodes(ID, PackageNode, node(X, A1)), not multiple_nodes_attribute(Name).
 
 % For node flag sources we need to look at the condition_set of the source, since it is the dependent
 % of the package on which I want to impose the constraint
@@ -407,8 +407,10 @@ attr("node_flag_source", node(X, A1), A2, node(Y, A3))
 % For node flag propagation, we need to look at the condition_set of the source, since it is the ancestor
 % of the package on which we want to impose the constraint
 attr("node_flag_propagation_candidate", node(X, A1), A2, A3, node(Y, A4))
-  :- impose(ID, node(X, A1)),
+  :- impose(ID, node(X, TriggerPkg)),
      imposed_constraint(ID, "node_flag_propagation_candidate", A1, A2, A3, A4),
+     condition_set(node(X, TriggerPkg), node(X, A1)),
+     condition_set(node(X, TriggerPkg), node(Y, A4)),
      condition_set(node(Y, A4), node(X, A1)).
 
 % if the structure of the program ever could change so that node_flag_source can be in a condition, we will need a case for it here.

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1283,6 +1283,7 @@ attr("node_flag_compiler_default", PackageNode)
 
 % if a flag is set to something or inherited, it's included
 attr("node_flag", PackageNode, FlagType, Flag) :- attr("node_flag_set", PackageNode, FlagType, Flag).
+%attr("node_flag", PackageNode, FlagType, Flag) :- attr("node_flag_propagate", PackageNode, FlagType, Flag, _).
 
 attr("node_flag_propagate", PackageNode, FlagType, Flag, Source) :-
   attr("node_flag_propagation_candidate", PackageNode, FlagType, Flag, Source),

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -114,6 +114,7 @@ unification_set(SetID, VirtualNode)
 
 % Node attributes that have multiple node arguments (usually, only the first argument is a node)
 multiple_nodes_attribute("node_flag_source").
+multiple_nodes_attribute("node_flag_propagation_candidate").
 multiple_nodes_attribute("depends_on").
 multiple_nodes_attribute("virtual_on_edge").
 multiple_nodes_attribute("provider_set").

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -114,7 +114,6 @@ unification_set(SetID, VirtualNode)
 
 % Node attributes that have multiple node arguments (usually, only the first argument is a node)
 multiple_nodes_attribute("node_flag_source").
-multiple_nodes_attribute("node_flag_possible_prop").
 multiple_nodes_attribute("depends_on").
 multiple_nodes_attribute("virtual_on_edge").
 multiple_nodes_attribute("provider_set").
@@ -1272,6 +1271,30 @@ attr("node_flag_compiler_default", PackageNode)
 
 % if a flag is set to something or inherited, it's included
 attr("node_flag", PackageNode, FlagType, Flag) :- attr("node_flag_set", PackageNode, FlagType, Flag).
+
+attr("node_flag_propagate", PackageNode, FlagType, Flag, Source) :-
+  attr("node_flag_propagation_candidate", PackageNode, FlagType, Flag, Source),
+  not attr("node_flag_set", PackageNode, FlagType, _).
+
+% source is a node() attribute
+attr("node_flag_propagation_candidate", PackageNode, FlagType, Flag, Source) :-
+  same_compiler(ParentNode, PackageNode),
+  attr("node_flag_propagation_candidate", ParentNode, FlagType, _, Source),
+  attr("node_flag", Source, FlagType, Flag),
+  flag_type(FlagType).
+
+error(100, "{0} and {1} cannot both propagate compiler flags '{2}' to {3}", Source1, Source2, PackageNode, FlagType) :-
+  same_compiler(Source1, PackageNode),
+  same_compiler(Source2, PackageNode),
+  attr("node_flag_propagate", _, FlagType, _, Source1),
+  attr("node_flag_propagate", _, FlagType, _, Source2),
+  Source1 < Source2.
+
+attr("node_flag_source", PackageNode, FlagType, Q)
+  :- attr("node_flag_propagate", PackageNode, FlagType, _, Q).
+
+attr("node_flag", PackageNode, FlagType, Flag) :- attr("node_flag_propagate", PackageNode, FlagType, Flag, _).
+
 
 % if no node flags are set for a type, there are no flags.
 attr("no_flags", PackageNode, FlagType)

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1248,30 +1248,9 @@ same_compiler(PackageNode, DependencyNode)
      node_compiler(DependencyNode, CompilerID),
      compiler_id(CompilerID).
 
-% propagate flags when compiler match
-attr("node_flag_propagate", PackageNode, FlagType, Flag, Source) :- % source is a node() attribute
-  attr("node_flag_possible_prop", PackageNode, FlagType, Flag, Source),
-  not attr("node_flag_set", PackageNode, FlagType, _).
-
-attr("node_flag_possible_prop", PackageNode, FlagType, Flag, Source) :- % source is a node() attribute
-  same_compiler(ParentNode, PackageNode),
-  attr("node_flag_possible_prop", ParentNode, FlagType, _, Source),
-  attr("node_flag", Source, FlagType, Flag),
-  flag_type(FlagType).
-
-error(100, "{0} and {1} cannot both propagate compiler flags '{2}' to {3}", Source1, Source2, PackageNode, FlagType) :-
-  same_compiler(Source1, PackageNode),
-  same_compiler(Source2, PackageNode),
-  attr("node_flag_propagate", _, FlagType, _, Source1),
-  attr("node_flag_propagate", _, FlagType, _, Source2),
-  Source1 < Source2.
-
 % remember where flags came from
 attr("node_flag_source", PackageNode, FlagType, PackageNode)
   :- attr("node_flag_set", PackageNode, FlagType, _).
-
-attr("node_flag_source", PackageNode, FlagType, Q)
-  :- attr("node_flag_propagate", PackageNode, FlagType, _, Q).
 
 % compiler flags from compilers.yaml are put on nodes if compiler matches
 attr("node_flag", PackageNode, FlagType, Flag)
@@ -1293,7 +1272,6 @@ attr("node_flag_compiler_default", PackageNode)
 
 % if a flag is set to something or inherited, it's included
 attr("node_flag", PackageNode, FlagType, Flag) :- attr("node_flag_set", PackageNode, FlagType, Flag).
-attr("node_flag", PackageNode, FlagType, Flag) :- attr("node_flag_propagate", PackageNode, FlagType, Flag, _).
 
 % if no node flags are set for a type, there are no flags.
 attr("no_flags", PackageNode, FlagType)

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1283,31 +1283,6 @@ attr("node_flag_compiler_default", PackageNode)
 
 % if a flag is set to something or inherited, it's included
 attr("node_flag", PackageNode, FlagType, Flag) :- attr("node_flag_set", PackageNode, FlagType, Flag).
-%attr("node_flag", PackageNode, FlagType, Flag) :- attr("node_flag_propagate", PackageNode, FlagType, Flag, _).
-
-attr("node_flag_propagate", PackageNode, FlagType, Flag, Source) :-
-  attr("node_flag_propagation_candidate", PackageNode, FlagType, Flag, Source),
-  not attr("node_flag_set", PackageNode, FlagType, _).
-
-% source is a node() attribute
-attr("node_flag_propagation_candidate", PackageNode, FlagType, Flag, Source) :-
-  same_compiler(ParentNode, PackageNode),
-  attr("node_flag_propagation_candidate", ParentNode, FlagType, _, Source),
-  attr("node_flag", Source, FlagType, Flag),
-  flag_type(FlagType).
-
-error(100, "{0} and {1} cannot both propagate compiler flags '{2}' to {3}", Source1, Source2, PackageNode, FlagType) :-
-  same_compiler(Source1, PackageNode),
-  same_compiler(Source2, PackageNode),
-  attr("node_flag_propagate", _, FlagType, _, Source1),
-  attr("node_flag_propagate", _, FlagType, _, Source2),
-  Source1 < Source2.
-
-attr("node_flag_source", PackageNode, FlagType, Q)
-  :- attr("node_flag_propagate", PackageNode, FlagType, _, Q).
-
-attr("node_flag", PackageNode, FlagType, Flag) :- attr("node_flag_propagate", PackageNode, FlagType, Flag, _).
-
 
 % if no node flags are set for a type, there are no flags.
 attr("no_flags", PackageNode, FlagType)

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1262,14 +1262,23 @@ node_flag_inherited(DependencyNode, FlagType, Flag)
 :- node_flag_inherited(PackageNode, FlagType, Flag),
    can_inherit_flags(PackageNode, DependencyNode, FlagType),
    attr("node_flag_propagate", PackageNode, FlagType).
+=======
+attr("node_flag_propagate", Package, FlagType, Flag, Source) :-
+  node_compiler(Source, CompilerID),
+  node_compiler(Package, CompilerID),
+  depends_on(Parent, Package),
+  attr("node_flag_propagate", Parent, _, _, Source),
+  attr("node_flag_value", Source, FlagType, Flag),
+  not attr("node_flag_set", Package, FlagType, _).
+  compiler_id(CompilerID),
+  flag_type(FlagType).
+>>>>>>> b44c47bc83 (Simplify node_flag_propagate and propagate past 1st level dependencies)
 
 error(100, "{0} and {1} cannot both propagate compiler flags '{2}' to {3}", Source1, Source2, Package, FlagType) :-
   depends_on(Source1, Package),
   depends_on(Source2, Package),
-  attr("node_flag_propagate", Source1, FlagType),
-  attr("node_flag_propagate", Source2, FlagType),
-  can_inherit_flags(Source1, Package, FlagType),
-  can_inherit_flags(Source2, Package, FlagType),
+  attr("node_flag_propagate", _, FlagType, _, Source1),
+  attr("node_flag_propagate", _, FlagType, _, Source2),
   Source1 < Source2.
 
 % remember where flags came from

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -350,7 +350,7 @@ trigger_condition_holds(ID, RequestorNode) :-
   attr(Name, node(X, A1), A2, A3, A4) : condition_requirement(ID, Name, A1, A2, A3, A4), condition_nodes(ID, PackageNode, node(X, A1)), not multiple_nodes_attribute(Name);
   % Special cases
   attr("node_flag_source", node(X, A1), A2, node(Y, A3)) : condition_requirement(ID, "node_flag_source", A1, A2, A3), condition_nodes(ID, PackageNode, node(X, A1)), condition_nodes(ID, PackageNode, node(Y, A3));
-  attr("node_flag_propagation_candidate", node(X, A1), A2, A3, node(Y, A4)) : condition_reuqirement(ID, "node_flag_propagation_candidate", A1, A2, A3, A4), condition_nodes(ID, PackageNode, node(X, A1)), condition_nodes(ID, PackageNode, node(Y, A4));
+  attr("node_flag_propagation_candidate", node(X, A1), A2, A3, node(Y, A4)) : condition_requirement(ID, "node_flag_propagation_candidate", A1, A2, A3, A4), condition_nodes(ID, PackageNode, node(X, A1)), condition_nodes(ID, PackageNode, node(Y, A4));
   % if the structure of the program ever could change so that node_flag_source can be in a condition, we will need a case for it here.
   not cannot_hold(ID, PackageNode).
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -114,6 +114,7 @@ unification_set(SetID, VirtualNode)
 
 % Node attributes that have multiple node arguments (usually, only the first argument is a node)
 multiple_nodes_attribute("node_flag_source").
+multiple_nodes_attribute("node_flag_possible_prop").
 multiple_nodes_attribute("depends_on").
 multiple_nodes_attribute("virtual_on_edge").
 multiple_nodes_attribute("provider_set").
@@ -1253,17 +1254,14 @@ attr("node_flag_propagate", Package, FlagType, Flag, Source) :-
   not attr("node_flag_set", Package, FlagType, _).
 
 attr("node_flag_possible_prop", Package, FlagType, Flag, Source) :-
-  node_compiler(Source, CompilerID),
-  node_compiler(Package, CompilerID),
-  depends_on(Parent, Package),
+  same_compiler(Parent, Package),
   attr("node_flag_possible_prop", Parent, _, _, Source),
   attr("node_flag", Source, FlagType, Flag),
-  compiler_id(CompilerID),
   flag_type(FlagType).
 
 error(100, "{0} and {1} cannot both propagate compiler flags '{2}' to {3}", Source1, Source2, Package, FlagType) :-
-  depends_on(Source1, Package),
-  depends_on(Source2, Package),
+  same_compiler(Source1, Package),
+  same_compiler(Source2, Package),
   attr("node_flag_propagate", _, FlagType, _, Source1),
   attr("node_flag_propagate", _, FlagType, _, Source2),
   Source1 < Source2.
@@ -1272,10 +1270,8 @@ error(100, "{0} and {1} cannot both propagate compiler flags '{2}' to {3}", Sour
 attr("node_flag_source", PackageNode, FlagType, PackageNode)
   :- attr("node_flag_set", PackageNode, FlagType, _).
 
-attr("node_flag_source", DependencyNode, FlagType, Q)
-  :- attr("node_flag_source", PackageNode, FlagType, Q),
-     node_flag_inherited(DependencyNode, FlagType, _),
-     attr("node_flag_propagate", PackageNode, FlagType).
+attr("node_flag_source", PackageNode, FlagType, Q)
+  :- attr("node_flag_propagate", PackageNode, FlagType, _, Q).
 
 % compiler flags from compilers.yaml are put on nodes if compiler matches
 attr("node_flag", PackageNode, FlagType, Flag)
@@ -1297,7 +1293,7 @@ attr("node_flag_compiler_default", PackageNode)
 
 % if a flag is set to something or inherited, it's included
 attr("node_flag", PackageNode, FlagType, Flag) :- attr("node_flag_set", PackageNode, FlagType, Flag).
-attr("node_flag", PackageNode, FlagType, Flag) :- node_flag_inherited(PackageNode, FlagType, Flag).
+attr("node_flag", PackageNode, FlagType, Flag) :- attr("node_flag_propagate", PackageNode, FlagType, Flag, _).
 
 % if no node flags are set for a type, there are no flags.
 attr("no_flags", PackageNode, FlagType)

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1255,7 +1255,7 @@ attr("node_flag_propagate", Package, FlagType, Flag, Source) :-
 
 attr("node_flag_possible_prop", Package, FlagType, Flag, Source) :-
   same_compiler(Parent, Package),
-  attr("node_flag_possible_prop", Parent, _, _, Source),
+  attr("node_flag_possible_prop", Parent, FlagType, _, Source),
   attr("node_flag", Source, FlagType, Flag),
   flag_type(FlagType).
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1249,19 +1249,19 @@ same_compiler(PackageNode, DependencyNode)
      compiler_id(CompilerID).
 
 % propagate flags when compiler match
-attr("node_flag_propagate", Package, FlagType, Flag, Source) :-
-  attr("node_flag_possible_prop", Package, FlagType, Flag, Source),
-  not attr("node_flag_set", Package, FlagType, _).
+attr("node_flag_propagate", PackageNode, FlagType, Flag, Source) :- % source is a node() attribute
+  attr("node_flag_possible_prop", PackageNode, FlagType, Flag, Source),
+  not attr("node_flag_set", PackageNode, FlagType, _).
 
-attr("node_flag_possible_prop", Package, FlagType, Flag, Source) :-
-  same_compiler(Parent, Package),
-  attr("node_flag_possible_prop", Parent, FlagType, _, Source),
+attr("node_flag_possible_prop", PackageNode, FlagType, Flag, Source) :- % source is a node() attribute
+  same_compiler(ParentNode, PackageNode),
+  attr("node_flag_possible_prop", ParentNode, FlagType, _, Source),
   attr("node_flag", Source, FlagType, Flag),
   flag_type(FlagType).
 
-error(100, "{0} and {1} cannot both propagate compiler flags '{2}' to {3}", Source1, Source2, Package, FlagType) :-
-  same_compiler(Source1, Package),
-  same_compiler(Source2, Package),
+error(100, "{0} and {1} cannot both propagate compiler flags '{2}' to {3}", Source1, Source2, PackageNode, FlagType) :-
+  same_compiler(Source1, PackageNode),
+  same_compiler(Source2, PackageNode),
   attr("node_flag_propagate", _, FlagType, _, Source1),
   attr("node_flag_propagate", _, FlagType, _, Source2),
   Source1 < Source2.

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1241,38 +1241,25 @@ error(100, "Compiler {1}@{2} requested for {0} cannot be found. Set install_miss
 % Compiler flags
 %-----------------------------------------------------------------------------
 
-% propagate flags when compiler match
-can_inherit_flags(PackageNode, DependencyNode, FlagType)
-  :- same_compiler(PackageNode, DependencyNode),
-     not attr("node_flag_set", DependencyNode, FlagType, _),
-     flag_type(FlagType).
-
 same_compiler(PackageNode, DependencyNode)
   :- depends_on(PackageNode, DependencyNode),
      node_compiler(PackageNode, CompilerID),
      node_compiler(DependencyNode, CompilerID),
      compiler_id(CompilerID).
 
-node_flag_inherited(DependencyNode, FlagType, Flag)
-  :- attr("node_flag_set", PackageNode, FlagType, Flag),
-     can_inherit_flags(PackageNode, DependencyNode, FlagType),
-     attr("node_flag_propagate", PackageNode, FlagType).
-
-% Ensure propagation
-:- node_flag_inherited(PackageNode, FlagType, Flag),
-   can_inherit_flags(PackageNode, DependencyNode, FlagType),
-   attr("node_flag_propagate", PackageNode, FlagType).
-=======
+% propagate flags when compiler match
 attr("node_flag_propagate", Package, FlagType, Flag, Source) :-
+  attr("node_flag_possible_prop", Package, FlagType, Flag, Source),
+  not attr("node_flag_set", Package, FlagType, _).
+
+attr("node_flag_possible_prop", Package, FlagType, Flag, Source) :-
   node_compiler(Source, CompilerID),
   node_compiler(Package, CompilerID),
   depends_on(Parent, Package),
-  attr("node_flag_propagate", Parent, _, _, Source),
+  attr("node_flag_possible_prop", Parent, _, _, Source),
   attr("node_flag", Source, FlagType, Flag),
-  not attr("node_flag_set", Package, FlagType, _),
   compiler_id(CompilerID),
   flag_type(FlagType).
->>>>>>> b44c47bc83 (Simplify node_flag_propagate and propagate past 1st level dependencies)
 
 error(100, "{0} and {1} cannot both propagate compiler flags '{2}' to {3}", Source1, Source2, Package, FlagType) :-
   depends_on(Source1, Package),

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1269,7 +1269,7 @@ attr("node_flag_propagate", Package, FlagType, Flag, Source) :-
   depends_on(Parent, Package),
   attr("node_flag_propagate", Parent, _, _, Source),
   attr("node_flag_value", Source, FlagType, Flag),
-  not attr("node_flag_set", Package, FlagType, _).
+  not attr("node_flag_set", Package, FlagType, _),
   compiler_id(CompilerID),
   flag_type(FlagType).
 >>>>>>> b44c47bc83 (Simplify node_flag_propagate and propagate past 1st level dependencies)

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1268,7 +1268,7 @@ attr("node_flag_propagate", Package, FlagType, Flag, Source) :-
   node_compiler(Package, CompilerID),
   depends_on(Parent, Package),
   attr("node_flag_propagate", Parent, _, _, Source),
-  attr("node_flag_value", Source, FlagType, Flag),
+  attr("node_flag", Source, FlagType, Flag),
   not attr("node_flag_set", Package, FlagType, _),
   compiler_id(CompilerID),
   flag_type(FlagType).

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -346,9 +346,11 @@ trigger_condition_holds(ID, RequestorNode) :-
   attr(Name, node(X, A1))             : condition_requirement(ID, Name, A1),             condition_nodes(ID, PackageNode, node(X, A1));
   attr(Name, node(X, A1), A2)         : condition_requirement(ID, Name, A1, A2),         condition_nodes(ID, PackageNode, node(X, A1));
   attr(Name, node(X, A1), A2, A3)     : condition_requirement(ID, Name, A1, A2, A3),     condition_nodes(ID, PackageNode, node(X, A1)), not multiple_nodes_attribute(Name);
-  attr(Name, node(X, A1), A2, A3, A4) : condition_requirement(ID, Name, A1, A2, A3, A4), condition_nodes(ID, PackageNode, node(X, A1));
+  attr(Name, node(X, A1), A2, A3, A4) : condition_requirement(ID, Name, A1, A2, A3, A4), condition_nodes(ID, PackageNode, node(X, A1)), not multiple_nodes_attribute(Name);
   % Special cases
   attr("node_flag_source", node(X, A1), A2, node(Y, A3)) : condition_requirement(ID, "node_flag_source", A1, A2, A3), condition_nodes(ID, PackageNode, node(X, A1)), condition_nodes(ID, PackageNode, node(Y, A3));
+  attr("node_flag_propagation_candidate", node(X, A1), A2, A3, node(Y, A4)) : condition_reuqirement(ID, "node_flag_propagation_candidate", A1, A2, A3, A4), condition_nodes(ID, PackageNode, node(X, A1)), condition_nodes(ID, PackageNode, node(Y, A4));
+  % if the structure of the program ever could change so that node_flag_source can be in a condition, we will need a case for it here.
   not cannot_hold(ID, PackageNode).
 
 condition_holds(ConditionID, node(X, Package))
@@ -400,6 +402,15 @@ attr("node_flag_source", node(X, A1), A2, node(Y, A3))
   :- impose(ID, node(X, A1)),
      imposed_constraint(ID, "node_flag_source", A1, A2, A3),
      condition_set(node(Y, A3), node(X, A1)).
+
+% For node flag propagation, we need to look at the condition_set of the source, since it is the ancestor
+% of the package on which we want to impose the constraint
+attr("node_flag_propagation_candidate", node(X, A1), A2, A3, node(Y, A4))
+  :- impose(ID, node(X, A1)),
+     imposed_constraint(ID, "node_flag_propagation_candidate", A1, A2, A3, A4),
+     condition_set(node(Y, A4), node(X, A1)).
+
+% if the structure of the program ever could change so that node_flag_source can be in a condition, we will need a case for it here.
 
 % Provider set is relevant only for literals, since it's the only place where `^[virtuals=foo] bar`
 % might appear in the HEAD of a rule

--- a/lib/spack/spack/solver/propagation.lp
+++ b/lib/spack/spack/solver/propagation.lp
@@ -9,12 +9,12 @@
 
 % propagate flags when compiler match
 attr("node_flag_propagate", PackageNode, FlagType, Flag, Source) :- % source is a node() attribute
-  attr("node_flag_possible_prop", PackageNode, FlagType, Flag, Source),
+  attr("node_flag_propagation_candidate", PackageNode, FlagType, Flag, Source),
   not attr("node_flag_set", PackageNode, FlagType, _).
 
-attr("node_flag_possible_prop", PackageNode, FlagType, Flag, Source) :- % source is a node() attribute
+attr("node_flag_propagation_candidate", PackageNode, FlagType, Flag, Source) :- % source is a node() attribute
   same_compiler(ParentNode, PackageNode),
-  attr("node_flag_possible_prop", ParentNode, FlagType, _, Source),
+  attr("node_flag_propagation_candidate", ParentNode, FlagType, _, Source),
   attr("node_flag", Source, FlagType, Flag),
   flag_type(FlagType).
 

--- a/lib/spack/spack/solver/propagation.lp
+++ b/lib/spack/spack/solver/propagation.lp
@@ -1,0 +1,32 @@
+% Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+% Spack Project Developers. See the top-level COPYRIGHT file for details.
+%
+% SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+%=============================================================================
+% TODO: Later
+%=============================================================================
+
+#program propagate_node_flag.
+% propagate flags when compiler match
+attr("node_flag_propagate", PackageNode, FlagType, Flag, Source) :- % source is a node() attribute
+  attr("node_flag_possible_prop", PackageNode, FlagType, Flag, Source),
+  not attr("node_flag_set", PackageNode, FlagType, _).
+
+attr("node_flag_possible_prop", PackageNode, FlagType, Flag, Source) :- % source is a node() attribute
+  same_compiler(ParentNode, PackageNode),
+  attr("node_flag_possible_prop", ParentNode, FlagType, _, Source),
+  attr("node_flag", Source, FlagType, Flag),
+  flag_type(FlagType).
+
+error(100, "{0} and {1} cannot both propagate compiler flags '{2}' to {3}", Source1, Source2, PackageNode, FlagType) :-
+  same_compiler(Source1, PackageNode),
+  same_compiler(Source2, PackageNode),
+  attr("node_flag_propagate", _, FlagType, _, Source1),
+  attr("node_flag_propagate", _, FlagType, _, Source2),
+  Source1 < Source2.
+
+attr("node_flag_source", PackageNode, FlagType, Q)
+  :- attr("node_flag_propagate", PackageNode, FlagType, _, Q).
+
+attr("node_flag", PackageNode, FlagType, Flag) :- attr("node_flag_propagate", PackageNode, FlagType, Flag, _).

--- a/lib/spack/spack/solver/propagation.lp
+++ b/lib/spack/spack/solver/propagation.lp
@@ -7,7 +7,6 @@
 % TODO: Later
 %=============================================================================
 
-#program propagate_node_flag.
 % propagate flags when compiler match
 attr("node_flag_propagate", PackageNode, FlagType, Flag, Source) :- % source is a node() attribute
   attr("node_flag_possible_prop", PackageNode, FlagType, Flag, Source),

--- a/lib/spack/spack/solver/propagation.lp
+++ b/lib/spack/spack/solver/propagation.lp
@@ -1,17 +1,17 @@
-% Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+% Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
 % Spack Project Developers. See the top-level COPYRIGHT file for details.
 %
 % SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 %=============================================================================
-% TODO: Later
+% Propagation for compiler flags to speed-up solves
 %=============================================================================
 
-% propagate flags when compiler match
 attr("node_flag_propagate", PackageNode, FlagType, Flag, Source) :- % source is a node() attribute
   attr("node_flag_propagation_candidate", PackageNode, FlagType, Flag, Source),
   not attr("node_flag_set", PackageNode, FlagType, _).
 
+% propagate flags when compiler match
 attr("node_flag_propagation_candidate", PackageNode, FlagType, Flag, Source) :- % source is a node() attribute
   same_compiler(ParentNode, PackageNode),
   attr("node_flag_propagation_candidate", ParentNode, FlagType, _, Source),

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -425,17 +425,17 @@ class TestConcretize:
         spec = Spec("callpath cflags=='-g'")
         spec.concretize()
 
-        assert spec.satisfies("^dyninst cflags='-g'")
-        assert spec.satisfies("^libelf cflags='-g'")
+        for dep in spec.traverse():
+            assert dep.satisfies("cflags='-g'")
 
     @pytest.mark.only_clingo(
         "Optional compiler propagation isn't deprecated for original concretizer"
     )
     def test_concretize_compiler_flag_does_not_propagate(self):
-        spec = Spec("callpath cflags='-g'")
+        spec = Spec("hypre cflags='-g' ^openblas")
         spec.concretize()
 
-        assert not spec.satisfies("^dyninst cflags='-g'")
+        assert not spec.satisfies("^openblas cflags='-g'")
 
     @pytest.mark.only_clingo(
         "Optional compiler propagation isn't deprecated for original concretizer"
@@ -455,8 +455,9 @@ class TestConcretize:
         spec = Spec("callpath cflags=='-g' cxxflags='-O3'")
         spec.concretize()
 
-        assert spec.satisfies("^dyninst cflags='-g'")
-        assert not spec.satisfies("^dyninst cxxflags='-O3'")
+        for dep in spec.traverse(root=False):
+            assert dep.satisfies("cflags='-g'")
+            assert not dep.satisfies("cxxflags='-O3'")
 
     def test_mixing_compilers_only_affects_subdag(self):
         spack.config.set("packages:all:compiler", ["clang", "gcc"])

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -434,6 +434,7 @@ class TestConcretize:
     def test_concretize_non_root_compiler_flag_propagate(self):
         spec = Spec("callpath ^dyninst cflags=='-g'")
         spec.concretize()
+        print(spec)
 
         assert spec.satisfies("^libdwarf cflags='-g'")
         assert spec.satisfies("^libelf cflags='-g'")
@@ -441,7 +442,7 @@ class TestConcretize:
     @pytest.mark.only_clingo(
         "Optional compiler propagation isn't deprecated for original concretizer"
     )
-    def test_concretize_compiler_flag_does_not_propagate(self):
+    def test_concretize_not_compiler_flag_propagate(self):
         spec = Spec("hypre cflags='-g' ^openblas")
         spec.concretize()
 
@@ -451,7 +452,7 @@ class TestConcretize:
     @pytest.mark.only_clingo(
         "Optional compiler propagation isn't deprecated for original concretizer"
     )
-    def test_concretize_propagate_compiler_flag_not_passed_to_dependent(self):
+    def test_concretize_compiler_flag_propagate_not_passed_to_dependent(self):
         spec = Spec("callpath cflags=='-g' ^dyninst cflags='-O3'")
         spec.concretize()
 
@@ -462,7 +463,7 @@ class TestConcretize:
     @pytest.mark.only_clingo(
         "Optional compiler propagation isn't deprecated for original concretizer"
     )
-    def test_concretize_propagate_specified_compiler_flag(self):
+    def test_concretize_specified_compiler_flag_propagate(self):
         spec = Spec("callpath cflags=='-g' cxxflags='-O3'")
         spec.concretize()
 

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -435,7 +435,8 @@ class TestConcretize:
         spec = Spec("hypre cflags='-g' ^openblas")
         spec.concretize()
 
-        assert not spec.satisfies("^openblas cflags='-g'")
+        for dep in spec.traverse(root=False):
+            assert not dep.satisfies("cflags='-g'")
 
     @pytest.mark.only_clingo(
         "Optional compiler propagation isn't deprecated for original concretizer"

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -422,10 +422,11 @@ class TestConcretize:
         "Optional compiler propagation isn't deprecated for original concretizer"
     )
     def test_concretize_compiler_flag_propagate(self):
-        spec = Spec("hypre cflags=='-g' ^openblas")
+        spec = Spec("callpath cflags=='-g'")
         spec.concretize()
 
-        assert spec.satisfies("^openblas cflags='-g'")
+        assert spec.satisfies("^dyninst cflags='-g'")
+        assert spec.satisfies("^libelf cflags='-g'")
 
     @pytest.mark.only_clingo(
         "Optional compiler propagation isn't deprecated for original concretizer"

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -432,10 +432,10 @@ class TestConcretize:
         "Optional compiler propagation isn't deprecated for original concretizer"
     )
     def test_concretize_compiler_flag_does_not_propagate(self):
-        spec = Spec("hypre cflags='-g' ^openblas")
+        spec = Spec("callpath cflags='-g'")
         spec.concretize()
 
-        assert not spec.satisfies("^openblas cflags='-g'")
+        assert not spec.satisfies("^dyninst cflags='-g'")
 
     @pytest.mark.only_clingo(
         "Optional compiler propagation isn't deprecated for original concretizer"

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -441,11 +441,12 @@ class TestConcretize:
         "Optional compiler propagation isn't deprecated for original concretizer"
     )
     def test_concretize_propagate_compiler_flag_not_passed_to_dependent(self):
-        spec = Spec("hypre cflags=='-g' ^openblas cflags='-O3'")
+        spec = Spec("callpath cflags=='-g' ^dyninst cflags='-O3'")
         spec.concretize()
 
         assert set(spec.compiler_flags["cflags"]) == set(["-g"])
-        assert spec.satisfies("^openblas cflags='-O3'")
+        assert spec.satisfies("^dyninst cflags='-O3'")
+        assert spec.satisfies("^libelf cflags='-g'")
 
     def test_mixing_compilers_only_affects_subdag(self):
         spack.config.set("packages:all:compiler", ["clang", "gcc"])

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -431,6 +431,16 @@ class TestConcretize:
     @pytest.mark.only_clingo(
         "Optional compiler propagation isn't deprecated for original concretizer"
     )
+    def test_concretize_non_root_compiler_flag_propagate(self):
+        spec = Spec("callpath ^dyninst cflags=='-g'")
+        spec.concretize()
+
+        assert spec.satisfies("^libdwarf cflags='-g'")
+        assert spec.satisfies("^libelf cflags='-g'")
+
+    @pytest.mark.only_clingo(
+        "Optional compiler propagation isn't deprecated for original concretizer"
+    )
     def test_concretize_compiler_flag_does_not_propagate(self):
         spec = Spec("hypre cflags='-g' ^openblas")
         spec.concretize()

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -448,6 +448,16 @@ class TestConcretize:
         assert spec.satisfies("^dyninst cflags='-O3'")
         assert spec.satisfies("^libelf cflags='-g'")
 
+    @pytest.mark.only_clingo(
+        "Optional compiler propagation isn't deprecated for original concretizer"
+    )
+    def test_concretize_propagate_specified_compiler_flag(self):
+        spec = Spec("callpath cflags=='-g' cxxflags='-O3'")
+        spec.concretize()
+
+        assert spec.satisfies("^dyninst cflags='-g'")
+        assert not spec.satisfies("^dyninst cxxflags='-O3'")
+
     def test_mixing_compilers_only_affects_subdag(self):
         spack.config.set("packages:all:compiler", ["clang", "gcc"])
         spec = Spec("dt-diamond%gcc ^dt-diamond-bottom%clang").concretized()

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -463,10 +463,12 @@ class TestConcretize:
     @pytest.mark.only_clingo(
         "Optional compiler propagation isn't deprecated for original concretizer"
     )
-    def test_concretize_specified_compiler_flag_propagate(self):
-        spec = Spec("callpath cflags=='-g' cxxflags='-O3'")
-        spec.concretize()
+    @pytest.mark.parametrize("spec_name", ["callpath", "mpich", "hypre"])
+    def test_concretize_specified_compiler_flag_propagate(self, spec_name):
+        spec = Spec(f"{spec_name} cflags=='-g' cxxflags='-O3'").concretized()
 
+        assert spec.satisfies("cflags='-g'")
+        assert spec.satisfies("cxxflags='-O3'")
         for dep in spec.traverse(root=False):
             assert dep.satisfies("cflags='-g'")
             assert not dep.satisfies("cxxflags='-O3'")


### PR DESCRIPTION
Bug: Compiler flags are not propagating past the root packages' first level dependencies and we didn't have a test for this.