### PR TITLE
Jinja2: add posix path filter

### DIFF
--- a/lib/spack/spack/tengine.py
+++ b/lib/spack/spack/tengine.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import itertools
+import pathlib
 import textwrap
 from typing import List, Optional, Tuple
 
@@ -100,9 +101,15 @@ def quote(text):
     return ['"{0}"'.format(line) for line in text]
 
 
+def posixpaths(text):
+    """Converts a path to posix style path separators"""
+    return pathlib.Path(text).as_posix()
+
+
 def _set_filters(env):
     """Sets custom filters to the template engine environment"""
     env.filters["textwrap"] = textwrap.wrap
     env.filters["prepend_to_line"] = prepend_to_line
     env.filters["join"] = "\n".join
     env.filters["quote"] = quote
+    env.filters["posixpaths"] = posixpaths

--- a/share/spack/templates/bootstrap/spack.yaml
+++ b/share/spack/templates/bootstrap/spack.yaml
@@ -10,18 +10,18 @@ spack:
 {% for spec in environment_specs %}
     - "{{ spec }}"
 {% endfor %}
-  view: {{ environment_path }}/view
+  view: {{ environment_path|posixpaths }}/view
 
   config:
     install_tree:
-      root: {{ store_path }}
+      root: {{ store_path|posixpaths }}
 
   packages:
     python:
       buildable: false
       externals:
         - spec: "{{ python_spec }}"
-          prefix: "{{ python_prefix }}"
+          prefix: "{{ python_prefix|posixpaths }}"
 
     py-typed-ast:
       require: "+wheel"


### PR DESCRIPTION
Apply filter to bootstrap template, without it, Windows paths are written with literal `\` and the resulting yaml becomes un-processable due to "invalid escape sequences"