### PR TITLE
Add new CLI option "Extract"

### DIFF
--- a/lib/spack/spack/cmd/extract.py
+++ b/lib/spack/spack/cmd/extract.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import pathlib
+
+import llnl.util.filesystem
+import llnl.util.tty
+
+import spack.util.compression
+
+description = "extract/decompress archive in place"
+section = "system"
+level = "short"
+
+
+def setup_parser(subparser):
+    subparser.add_argument(
+        "archive",
+        action="store",
+        type=pathlib.Path,
+        help="archive (compressed or not) to be extracted",
+    )
+
+
+def extract(parser, args):
+    archive = args.archive
+    extractor = spack.util.compression.decompressor_for(str(archive))
+    with llnl.util.filesystem.working_dir(archive.parent):
+        out_path = extractor(str(archive))
+        llnl.util.tty.info(f"Archive extracted to {archive.parent / out_path}")

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -401,7 +401,7 @@ _spack() {
     then
         SPACK_COMPREPLY="-h --help -H --all-help --color -c --config -C --config-scope -d --debug --timestamp --pdb -e --env -D --env-dir -E --no-env --use-env-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -b --bootstrap -p --profile --sorted-profile --lines -v --verbose --stacktrace --backtrace -V --version --print-shell-vars"
     else
-        SPACK_COMPREPLY="add arch audit blame bootstrap build-env buildcache cd change checksum ci clean clone commands compiler compilers concretize concretise config containerize containerise create debug dependencies dependents deprecate dev-build develop diff docs edit env extensions external fetch find gc gpg graph help info install license list load location log-parse maintainers make-installer mark mirror module patch pkg providers pydoc python reindex remove rm repo resource restage solve spec stage style tags test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
+        SPACK_COMPREPLY="add arch audit blame bootstrap build-env buildcache cd change checksum ci clean clone commands compiler compilers concretize concretise config containerize containerise create debug dependencies dependents deprecate dev-build develop diff docs edit env extensions external extract fetch find gc gpg graph help info install license list load location log-parse maintainers make-installer mark mirror module patch pkg providers pydoc python reindex remove rm repo resource restage solve spec stage style tags test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
     fi
 }
 
@@ -1133,6 +1133,15 @@ _spack_external_list() {
 
 _spack_external_read_cray_manifest() {
     SPACK_COMPREPLY="-h --help --file --directory --ignore-default-dir --dry-run --fail-on-error"
+}
+
+_spack_extract() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help"
+    else
+        SPACK_COMPREPLY=""
+    fi
 }
 
 _spack_fetch() {

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -382,6 +382,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a edit -d 'open pac
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a env -d 'manage virtual environments'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a extensions -d 'list extensions for package'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a external -d 'manage external packages in Spack configuration'
+complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a extract -d 'extract/decompress archive in place'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a fetch -d 'fetch archives for packages'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a find -d 'list and search installed packages'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a gc -d 'remove specs that are now no longer needed'
@@ -1624,6 +1625,12 @@ complete -c spack -n '__fish_spack_using_command external read-cray-manifest' -l
 complete -c spack -n '__fish_spack_using_command external read-cray-manifest' -l dry-run -d 'don\'t modify DB with files that are read'
 complete -c spack -n '__fish_spack_using_command external read-cray-manifest' -l fail-on-error -f -a fail_on_error
 complete -c spack -n '__fish_spack_using_command external read-cray-manifest' -l fail-on-error -d 'if a manifest file cannot be parsed, fail and report the full stack trace'
+
+# spack extract
+set -g __fish_spack_optspecs_spack_extract h/help
+
+complete -c spack -n '__fish_spack_using_command extract' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command extract' -s h -l help -d 'show this help message and exit'
 
 # spack fetch
 set -g __fish_spack_optspecs_spack_fetch h/help n/no-checksum deprecated m/missing D/dependencies


### PR DESCRIPTION
"Extract" will leverage Spack's compression util to decompress and extract archives specified on the command line.

This is useful when performing some of the actions Spack does under the hood manually to debug/diagnose issues with components of these processes or when starting development from a spack env, or creating a new spack package.

`spack stage` effectively provides identical functionality but I wanted to decouple it from a Spack stage.

If we don't want to pollute the CLI with this that's understandable, I've just needed this exact functionality numerous times and was tired of dropping into a spack shell to accomplish this.

(The primary audience here are users on Windows where native utilities for decompression are limited to `tar`)