### PR TITLE
Dont remove clashing modules

### DIFF
--- a/lib/spack/spack/cmd/modules/__init__.py
+++ b/lib/spack/spack/cmd/modules/__init__.py
@@ -349,10 +349,13 @@ def refresh(module_type, specs, args):
     spack.modules.common.generate_module_index(
         module_type_root, writers, overwrite=args.delete_tree
     )
+    spack.modules.common.generate_reverse_module_index(
+        module_type_root, writers, overwrite=args.delete_tree
+    )
     errors = []
     for x in writers:
         try:
-            x.write(overwrite=True)
+            x.write(overwrite=True, do_update_index=False)
         except spack.error.SpackError as e:
             msg = f"{x.layout.filename}: {e.message}"
             errors.append(msg)

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -228,7 +228,7 @@ def root_path(name, module_set_name):
     return spack.util.path.canonicalize_path(path)
 
 
-def generate_module_index(root, modules, overwrite=False):
+def generate_module_index(root, modules, remove_hashes=None, overwrite=False):
     index_path = os.path.join(root, "module-index.yaml")
     if overwrite or not os.path.exists(index_path):
         entries = syaml.syaml_dict()
@@ -240,7 +240,41 @@ def generate_module_index(root, modules, overwrite=False):
     for m in modules:
         entry = {"path": m.layout.filename, "use_name": m.layout.use_name}
         entries[m.spec.dag_hash()] = entry
+
+    if remove_hashes is not None:
+        for hash in remove_hashes:
+            try:
+                entries.pop(hash)
+            except KeyError:
+                tty.debug(f'Attempted to remove nonexistent hash "{hash}" from module index')
+
     index = {"module_index": entries}
+    llnl.util.filesystem.mkdirp(root)
+    with open(index_path, "w") as index_file:
+        syaml.dump(index, default_flow_style=False, stream=index_file)
+
+
+def generate_reverse_module_index(root, modules, remove_paths=None, overwrite=False):
+    index_path = os.path.join(root, "module-index-reverse.yaml")
+    if overwrite or not os.path.exists(index_path):
+        entries = syaml.syaml_dict()
+    else:
+        with open(index_path) as index_file:
+            yaml_content = syaml.load(index_file)
+            entries = yaml_content["reverse_module_index"]
+
+    for m in modules:
+        entries[m.layout.filename] = m.spec.dag_hash()
+
+    if remove_paths is not None:
+        for path in remove_paths:
+            try:
+                entries.pop(path)
+            except KeyError:
+                msg = f'Attempted to remove nonexistent path "{path}" from reverse module index'
+                tty.debug(msg)
+
+    index = {"reverse_module_index": entries}
     llnl.util.filesystem.mkdirp(root)
     with open(index_path, "w") as index_file:
         syaml.dump(index, default_flow_style=False, stream=index_file)
@@ -264,6 +298,15 @@ def read_module_index(root):
         return {}
     with open(index_path) as index_file:
         return _read_module_index(index_file)
+
+
+def read_reverse_module_index(root):
+    index_path = os.path.join(root, "module-index-reverse.yaml")
+    if not os.path.exists(index_path):
+        return {}
+    with open(index_path) as index_file:
+        yaml_content = syaml.load(index_file)
+        return yaml_content["reverse_module_index"]
 
 
 def _read_module_index(str_or_file):
@@ -897,13 +940,14 @@ class BaseModuleFileWriter:
         # ... and return the first match
         return choices.pop(0)
 
-    def write(self, overwrite=False):
+    def write(self, overwrite=False, do_update_index=True):
         """Writes the module file.
 
         Args:
-            overwrite (bool): if True it is fine to overwrite an already
-                existing file. If False the operation is skipped an we print
-                a warning to the user.
+            overwrite (bool): if True it is fine to overwrite a module owned by another package.
+                If False the operation is skipped an we print a warning to the user.
+            do_update_index (bool): enables/disables the updating of `module-index.yaml`
+                and `module-index-reverse.yaml`.
         """
         # Return immediately if the module is excluded
         if self.conf.excluded:
@@ -911,12 +955,23 @@ class BaseModuleFileWriter:
             tty.debug(msg.format(self.spec.cshort_spec))
             return
 
-        # Print a warning in case I am accidentally overwriting
-        # a module file that is already there (name clash)
-        if not overwrite and os.path.exists(self.layout.filename):
-            message = "Module file {0.filename} exists and will not be overwritten"
-            tty.warn(message.format(self.layout))
-            return
+        if not self.test_ownership():
+            if overwrite:
+                tty.warn(
+                    f"Module file {self.layout.filename} was previously used by another package "
+                    + f"but is now being overwritten by {self.spec.cshort_spec}"
+                )
+            else:
+                tty.warn(
+                    f"Module file {self.layout.filename} will not be overwritten due to lack of "
+                    + "ownership."
+                )
+                return
+
+        # register this spec to this module file in the module index
+        if do_update_index:
+            self.add_to_module_index()
+            self.add_to_reverse_module_index()
 
         # If we are here it means it's ok to write the module file
         msg = "\tWRITE: {0} [{1}]"
@@ -1040,20 +1095,44 @@ class BaseModuleFileWriter:
                 with open(modulerc_path, "w") as f:
                     f.write("\n".join(content))
 
+    def test_ownership(self) -> bool:
+        """Check the reverse module index to see if another package is using the file."""
+        reverse_module_index = read_reverse_module_index(self.layout.dirname())
+        try:
+            owner_dag_hash = reverse_module_index[self.layout.filename]
+        except KeyError:
+            tty.debug(
+                f'Ownership of unregistered modulefile "{self.layout.filename}" '
+                + f'has been granted to "{self.spec.cshort_spec}"'
+            )
+            return True
+        return owner_dag_hash == self.spec.dag_hash()
+
     def remove(self):
         """Deletes the module file."""
-        mod_file = self.layout.filename
-        if os.path.exists(mod_file):
-            try:
-                os.remove(mod_file)  # Remove the module file
-                self.remove_module_defaults()  # Remove default targeting module file
-                self.update_module_hiddenness(remove=True)  # Remove hide cmd in modulerc
-                os.removedirs(
-                    os.path.dirname(mod_file)
-                )  # Remove all the empty directories from the leaf up
-            except OSError:
-                # removedirs throws OSError on first non-empty directory found
-                pass
+        mod_file_path = self.layout.filename
+        if not os.path.exists(mod_file_path):
+            tty.warn(f'Attempted to delete nonexistent module file "{self.layout.filename}"')
+            return
+        if not self.test_ownership():
+            tty.warn(
+                "Module file will not be deleted due to lack of ownership:\n"
+                + f"file: '{mod_file_path}'\n"
+                + f"spec: '{self.spec.format(self.spec.cshort_spec)}'"
+            )
+            return
+        try:
+            os.remove(mod_file_path)  # Remove the module file
+            self.remove_module_defaults()  # Remove default targeting module file
+            self.update_module_hiddenness(remove=True)  # Remove hide cmd in modulerc
+            self.delete_from_module_index()
+            self.delete_from_reverse_module_index()
+            os.removedirs(
+                os.path.dirname(mod_file_path)
+            )  # Remove all the empty directories from the leaf up
+        except OSError:
+            # removedirs throws OSError on first non-empty directory found
+            pass
 
     def remove_module_defaults(self):
         if not any(self.spec.satisfies(default) for default in self.conf.defaults):
@@ -1066,6 +1145,20 @@ class BaseModuleFileWriter:
             os.unlink(default_symlink)
         except OSError:
             pass
+
+    def add_to_module_index(self):
+        generate_module_index(self.layout.dirname(), [self])
+
+    def add_to_reverse_module_index(self):
+        generate_reverse_module_index(self.layout.dirname(), [self])
+
+    def delete_from_module_index(self):
+        generate_module_index(self.layout.dirname(), [], remove_hashes=[self.spec.dag_hash()])
+
+    def delete_from_reverse_module_index(self):
+        generate_reverse_module_index(
+            self.layout.dirname(), [], remove_paths=[self.layout.filename]
+        )
 
 
 @contextlib.contextmanager

--- a/lib/spack/spack/test/modules/conftest.py
+++ b/lib/spack/spack/test/modules/conftest.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import pathlib
+import random
+import string
 
 import pytest
 
@@ -44,7 +46,8 @@ def factory(request, mock_modules_root):
 
 @pytest.fixture()
 def mock_module_filename(monkeypatch, tmp_path):
-    filename = tmp_path / "module"
+    random_chars = "".join(random.choices(string.ascii_lowercase, k=5))
+    filename = tmp_path / f"module-{random_chars}"
     # Set for both module types so we can test both
     monkeypatch.setattr(spack.modules.lmod.LmodFileLayout, "filename", str(filename))
     monkeypatch.setattr(spack.modules.tcl.TclFileLayout, "filename", str(filename))

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -24,7 +24,7 @@ pytestmark = [
 ]
 
 
-@pytest.mark.usefixtures("config", "mock_packages", "mock_module_filename")
+@pytest.mark.usefixtures("config", "mock_packages")
 class TestTcl:
     def test_simple_case(self, modulefile_content, module_configuration):
         """Tests the generation of a simple Tcl module file."""
@@ -352,6 +352,115 @@ class TestTcl:
 
         assert len(index) == 1
         assert index[s3.dag_hash()].use_name == w3.layout.use_name
+
+    def test_reverse_module_index(self, module_configuration, factory, tmpdir_factory):
+        module_configuration("suffix")
+
+        w1, s1 = factory("mpileaks")
+        w2, s2 = factory("callpath")
+        w3, s3 = factory("openblas")
+
+        test_root = str(tmpdir_factory.mktemp("module-root"))
+
+        spack.modules.common.generate_reverse_module_index(test_root, [w1, w2])
+
+        index = spack.modules.common.read_reverse_module_index(test_root)
+
+        assert index[w1.layout.filename] == s1.dag_hash()
+        assert index[w2.layout.filename] == s2.dag_hash()
+
+        spack.modules.common.generate_reverse_module_index(test_root, [w3])
+
+        index = spack.modules.common.read_reverse_module_index(test_root)
+
+        assert len(index) == 3
+        assert index[w1.layout.filename] == s1.dag_hash()
+        assert index[w2.layout.filename] == s2.dag_hash()
+
+        spack.modules.common.generate_reverse_module_index(test_root, [w3], overwrite=True)
+
+        index = spack.modules.common.read_reverse_module_index(test_root)
+
+        assert len(index) == 1
+        assert index[w3.layout.filename] == s3.dag_hash()
+
+    def test_module_index_update(self, module_configuration, factory, tmpdir_factory):
+        w1, _ = factory("mpileaks")
+        w2, _ = factory("callpath")
+        w3, _ = factory("openblas")
+        assert w2.layout.dirname() == w1.layout.dirname()
+        assert w3.layout.dirname() == w1.layout.dirname()
+        module_index_root = w1.layout.dirname()
+
+        w1.write()
+        w2.write()
+        assert len(spack.modules.common.read_module_index(module_index_root)) == 2
+
+        w3.write()
+        assert len(spack.modules.common.read_module_index(module_index_root)) == 3
+
+        w3.remove()
+        assert len(spack.modules.common.read_module_index(module_index_root)) == 2
+
+        w2.remove()
+        w1.remove()
+        assert len(spack.modules.common.read_module_index(module_index_root)) == 0
+
+    @pytest.mark.usefixtures("mock_module_filename")
+    def test_clash(self, factory):
+        """Tests that w2 cannot overwrite or delete module owned by w1"""
+        w1, _ = factory("mpileaks")
+        w2, _ = factory("callpath")
+        assert w1.layout.filename == w2.layout.filename  # pytest usefixtures should cause clash
+        clashing_modulefile_path = w1.layout.filename
+
+        w1.write()
+        before_mtime = os.path.getmtime(clashing_modulefile_path)
+        w2.write()
+        after_mtime = os.path.getmtime(clashing_modulefile_path)
+        assert before_mtime == after_mtime  # module was not overwritten
+        w2.remove()
+        assert os.path.isfile(clashing_modulefile_path)  # module was not deleted
+        w1.remove()
+        assert not os.path.isfile(clashing_modulefile_path)  # module was deleted
+
+    @pytest.mark.usefixtures("mock_module_filename")
+    def test_clash2(self, factory):
+        """Tests that w1 is able to delete its module even when w2 would like to use it"""
+        w1, _ = factory("mpileaks")
+        w2, _ = factory("callpath")
+        assert w1.layout.filename == w2.layout.filename  # pytest usefixtures should cause clash
+        clashing_modulefile_path = w1.layout.filename
+
+        w1.write()
+        before_mtime = os.path.getmtime(clashing_modulefile_path)
+        w2.write()
+        after_mtime = os.path.getmtime(clashing_modulefile_path)
+        assert before_mtime == after_mtime  # module was not overwritten
+        w1.remove()
+        assert not os.path.isfile(clashing_modulefile_path)  # module was deleted
+
+    @pytest.mark.usefixtures("mock_module_filename")
+    def test_clash_overwrite(self, factory):
+        """Tests that ownership of module transfers from w1 to w2 when overwrite=True"""
+        w1, _ = factory("mpileaks")
+        w2, _ = factory("callpath")
+        assert w1.layout.filename == w2.layout.filename  # pytest usefixtures should cause clash
+
+        w1.write()
+        w2.write(overwrite=True)
+        assert w2.test_ownership()
+
+    @pytest.mark.usefixtures("mock_module_filename")
+    def test_clash_no_owner_specified(self, factory):
+        """Tests that ownership of module transfers from w1 to w2 when no owner is specified"""
+        w1, _ = factory("mpileaks")
+        w2, _ = factory("callpath")
+        assert w1.layout.filename == w2.layout.filename  # pytest usefixtures should cause clash
+
+        w1.write(do_update_index=False)
+        w2.write()
+        assert w2.test_ownership()
 
     def test_suffixes(self, module_configuration, factory):
         """Tests adding suffixes to module file name."""


### PR DESCRIPTION
fixes https://github.com/spack/spack/issues/40180

In the event of a name clash, uninstalling either package will delete the clashing modulefile, even if that package previously said:
```
==> Warning: Module file ... exists and will not be overwritten
```

This is a problem because I can install `foobar` which has a dependency on `barfoo`, which name clashes with my already installed `barfoo`, and then when I run the garbage collector my original `barfoo` module disappears. This is especially a problem for systems which don't use hashes in module names, which appears to be [most of them](https://github.com/search?q=repo%3Aspack%2Fspack-configs+%22hash_length%3A+0%22&type=code).

In my original fix, `BaseModuleFileWriter.remove` and `.write` would do a linear search over the module index to see if more than one package claims to use a module. If so, then don't remove. But this introduces a new edge case: if I have two versions of `barfoo` installed, one implicit one explicit, and I `spack uninstall` the explicit version, the module will not be deleted. This leaves behind a module that points to a nonexistent directory.

Instead, I created `module-index-reverse.yaml`, which is a 1:1 mapping from module file path to dag hash. When a `ModuleFileWriter` does `write(overwrite=True)`, it will take ownership away from another package by overwriting the dag hash. This gets rid of the linear search, allows Spack to make a more informative error message, and prevents any broken behavior. The cost is that now the module index takes up ~twice as much space on disk.

I also removed the logic where "if a module file already exists, don't overwrite it." The comment in the source code indicates that this is in place to prevent clashes, and that is no longer necessary. The result of a `write(overwrite=True)` is the same, but now the user gets a warning that the module file changes hands from one package to another. However, a `write(overwrite=False)` will now overwrite the module if the module is owned by that package. As far as I know, the only time that `write(overwrite=False)` is called is when installing a new package, which can't possibly be the owner of the module if it is just being installed.

In the past, there has been no garuntee that the contents of `module-index.yaml` are up to date: modules created/destroyed during `spack install` and `spack uninstall` are not accounted for. I made it so that `BaseModuleFileWriter.write` and `.remove` also update the module index. I don't feel great about adding all this I/O, but `update_module_hiddenness` is already truncating a file on every `write` or `remove`.

In order for **that** to work, I had to add functionality to `generate_module_index` for removing particular elements.

Then I ran into a problem with a unit test. Because "mock modulefiles" use a `filename` that has nothing to do with any spec, there was a module clash and my new logic caused some old logic to be skipped as a result. So I modified the mock modulefile class to add random characters to the `filename`. And then I removed this property `mock_modulefile_name` from the list of "fixtures" for that unit test, because when it's a "fixture" it gets re-used for multiple different modules.

### added unit tests:
* check that `module-index.yaml` is updated upon `BaseModuleFileWriter.write` and `BaseModuleFileWriter.remove`
* made `test_reverse_module_index` which mirrors the logic of `test_module_index`
* Tests that w2 cannot overwrite or delete module owned by w1
* Tests that w1 is able to delete its module even when w2 would like to use it
* Tests that ownership of module transfers from w1 to w2 when overwrite=True
* Tests that ownership of module transfers from w1 to w2 when no owner is specified