### PR TITLE
Make `Repo*` depend only on an `Index`

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2559,7 +2559,9 @@ def _concretize_task(packed_arguments) -> Tuple[int, Spec, float]:
 
 def make_repo_path(root):
     """Make a RepoPath from the repo subdirectories in an environment."""
-    path = spack.repo.RepoPath(cache=spack.caches.MISC_CACHE)
+    path = spack.repo.RepoPath(
+        index_factory=spack.repo.IndexFactory(cache=spack.caches.MISC_CACHE)
+    )
 
     if os.path.isdir(root):
         for repo_root in os.listdir(root):

--- a/lib/spack/spack/provider_index.py
+++ b/lib/spack/spack/provider_index.py
@@ -92,10 +92,6 @@ class ProviderIndex(_IndexBase):
 
             restrict: "restricts" values to the verbatim input specs; do not
                 pre-apply package's constraints.
-
-        TODO: rename this.  It is intended to keep things as broad
-        TODO: as possible without overly restricting results, so it is
-        TODO: not the best name.
         """
         self.repository = repository
         self.restrict = restrict

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -584,7 +584,8 @@ class RepoIndex:
     defined by ``Indexer``, so that the ``RepoIndex`` can read, generate,
     and update stored indices.
 
-    Generated indexes are accessed by name via ``__getitem__()``."""
+    Generated indexes are accessed by name via ``__getitem__()``.
+    """
 
     def __init__(
         self,
@@ -628,7 +629,8 @@ class RepoIndex:
         because the main bottleneck here is loading all the packages.  It
         can take tens of seconds to regenerate sequentially, and we'd
         rather only pay that cost once rather than on several
-        invocations."""
+        invocations.
+        """
         for name, indexer in self.indexers.items():
             self.indexes[name] = self._build_index(name, indexer)
 
@@ -1230,9 +1232,6 @@ class Repo:
 
     def exists(self, pkg_name: str) -> bool:
         """Whether a package with the supplied name exists."""
-        if pkg_name is None:
-            return False
-
         # if the FastPackageChecker is already constructed, use it
         if self._fast_package_checker:
             return pkg_name in self._pkg_checker

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -668,6 +668,10 @@ class RepoIndex:
 
         return indexer.index
 
+    def all_package_names(self) -> List[str]:
+        """Returns the list of all package names in the repository"""
+        return sorted(self.checker.keys())
+
 
 class RepoPath:
     """A RepoPath is a list of repos that function as one.
@@ -1204,7 +1208,7 @@ class Repo:
 
     def all_package_names(self, include_virtuals: bool = False) -> List[str]:
         """Returns a sorted list of all package names in the Repo."""
-        names = sorted(self._pkg_checker.keys())
+        names = self.index.all_package_names()
         if include_virtuals:
             return names
         return [x for x in names if not self.is_virtual(x)]

--- a/lib/spack/spack/test/cmd/pkg.py
+++ b/lib/spack/spack/test/cmd/pkg.py
@@ -132,8 +132,8 @@ def test_pkg_add(git, mock_pkg_git_repo):
         finally:
             shutil.rmtree("mockpkg-e")
             # Removing a package mid-run disrupts Spack's caching
-            if spack.repo.PATH.repos[0]._fast_package_checker:
-                spack.repo.PATH.repos[0]._fast_package_checker.invalidate()
+            if spack.repo.PATH.repos[0].index.checker:
+                spack.repo.PATH.repos[0].index.checker.invalidate()
 
     with pytest.raises(spack.main.SpackCommandError):
         pkg("add", "does-not-exist")

--- a/lib/spack/spack/test/cmd/pkg.py
+++ b/lib/spack/spack/test/cmd/pkg.py
@@ -42,7 +42,9 @@ def mock_pkg_git_repo(git, tmp_path_factory):
     shutil.copytree(spack.paths.mock_packages_path, str(repo_dir))
 
     repo_cache = spack.util.file_cache.FileCache(str(root_dir / "cache"))
-    mock_repo = spack.repo.RepoPath(str(repo_dir), cache=repo_cache)
+    mock_repo = spack.repo.RepoPath(
+        str(repo_dir), index_factory=spack.repo.IndexFactory(cache=repo_cache)
+    )
     mock_repo_packages = mock_repo.repos[0].packages_path
 
     with working_dir(mock_repo_packages):

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1734,7 +1734,7 @@ class TestConcretize:
         builder.remove("pkg-c")
         with spack.repo.use_repositories(builder.root, override=False) as repos:
             # TODO (INJECT CONFIGURATION): unclear why the cache needs to be invalidated explicitly
-            repos.repos[0]._pkg_checker.invalidate()
+            repos.repos[0].index.checker.invalidate()
             with spack.config.override("concretizer:reuse", True):
                 s = Spec("pkg-c").concretized()
             assert s.namespace == "builtin.mock"

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -230,7 +230,9 @@ class Changing(Package):
                 self.repo_dir = repo_directory
                 cache_dir = tmp_path_factory.mktemp("cache")
                 self.repo_cache = spack.util.file_cache.FileCache(str(cache_dir))
-                self.repo = spack.repo.Repo(str(repo_directory), cache=self.repo_cache)
+                self.repo = spack.repo.Repo(
+                    str(repo_directory), index_factory=spack.repo.IndexFactory(self.repo_cache)
+                )
 
             def change(self, changes=None):
                 changes = changes or {}
@@ -256,7 +258,9 @@ class Changing(Package):
                 package_py.write_text(changing_pkg_str)
 
                 # Re-add the repository
-                self.repo = spack.repo.Repo(str(self.repo_dir), cache=self.repo_cache)
+                self.repo = spack.repo.Repo(
+                    str(self.repo_dir), index_factory=spack.repo.IndexFactory(self.repo_cache)
+                )
                 repository.put_first(self.repo)
 
         _changing_pkg = _ChangingPackage(repo_dir)

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -2026,7 +2026,7 @@ repo:
             f.write(pkg_str)
 
     repo_cache = spack.util.file_cache.FileCache(str(tmpdir.join("cache")))
-    return spack.repo.Repo(repo_path, cache=repo_cache)
+    return spack.repo.Repo(repo_path, index_factory=spack.repo.IndexFactory(repo_cache))
 
 
 @pytest.fixture()

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -160,7 +160,8 @@ def test_handle_unknown_package(temporary_store, config, mock_packages, tmp_path
     layout = temporary_store.layout
 
     repo_cache = spack.util.file_cache.FileCache(str(tmp_path / "cache"))
-    mock_db = spack.repo.RepoPath(spack.paths.mock_packages_path, cache=repo_cache)
+    factory = spack.repo.IndexFactory(cache=repo_cache)
+    mock_db = spack.repo.RepoPath(spack.paths.mock_packages_path, index_factory=factory)
 
     not_in_mock = set.difference(
         set(spack.repo.all_package_names()), set(mock_db.all_package_names())


### PR DESCRIPTION
This refactor makes `Repo` and `RepoPath` not depend directly on a filesystem checker and a cache. Those dependencies are pushed down to the index, so we can implement new strategies to index repositories, e.g. #45823 or #45831 .

**Note**: The design of `Repo`, `RepoPath`, `Indexers` etc. is a bit :recycle: since many objects depend on each other. The overall architecture can be simplified by extracting a few methods from `Repo` that do not depend on indexes, for instance `is_virtual_safe`, and `get_pkg_class`. I will save this refactor for a following PR.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
