### PR TITLE
Detached signing

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1736,14 +1736,17 @@ def download_tarball(
     mirrors = [fetch_url_to_mirror(mirror_metadata) for mirror_metadata in urls_and_versions]
 
     for mirror, layout_version in mirrors:
-        # Override mirror's default if
-        currently_unsigned = unsigned if unsigned is not None else not mirror.signed
-
         # If it's an OCI index, do things differently, since we cannot compose URLs.
         fetch_url = mirror.fetch_url
 
         # TODO: refactor this to some "nice" place.
         if spack.oci.image.is_oci_url(fetch_url):
+            if not unsigned:
+                warnings.warn(
+                    "Code signing is currently not supported for OCI images. "
+                    "Specify unsigned to silence this warning."
+                )
+
             ref = ImageReference.from_url(fetch_url).with_tag(_oci_default_tag(spec))
 
             # Fetch the manifest
@@ -1803,7 +1806,13 @@ def download_tarball(
             return tarball_stage
         else:
             cache_type = get_url_buildcache_class(layout_version=layout_version)
-            cache_entry = cache_type(fetch_url, spec, allow_unsigned=currently_unsigned)
+            cache_entry = cache_type(
+                fetch_url,
+                spec,
+                notary=spack.notary.select_notary(
+                    mirror, signed=not unsigned if unsigned is not None else None
+                ),
+            )
 
             try:
                 cache_entry.fetch_archive()

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -77,7 +77,7 @@ import spack.util.url as url_util
 import spack.util.web as web_util
 from spack import traverse
 from spack.llnl.util.filesystem import mkdirp
-from spack.notary import Notary
+from spack.notary import Notary, NonSigningNotary
 from spack.oci.image import (
     Digest,
     ImageReference,
@@ -947,11 +947,11 @@ def _do_create_tarball(
 
 
 def _exists_in_buildcache(
-    spec: spack.spec.Spec, out_url: str, allow_unsigned: bool = False
+    spec: spack.spec.Spec, out_url: str, notary: Optional[Notary] = None
 ) -> URLBuildcacheEntry:
     """creates and returns (after checking existence) a URLBuildcacheEntry"""
     cache_type = get_url_buildcache_class(CURRENT_BUILD_CACHE_LAYOUT_VERSION)
-    cache_entry = cache_type(out_url, spec, allow_unsigned=allow_unsigned)
+    cache_entry = cache_type(out_url, spec, notary=notary)
     return cache_entry
 
 
@@ -1167,7 +1167,7 @@ def _url_push(
 
     exists_futures = [
         executor.submit(
-            _exists_in_buildcache, spec, out_url, allow_unsigned=False if notary else True
+            _exists_in_buildcache, spec, out_url, notary=notary
         )
         for spec in specs
     ]
@@ -2288,7 +2288,7 @@ def _get_keys(
         mirror_url, *cache_class.get_relative_path_components(BuildcacheComponent.KEY)
     )
     key_index_manifest_url = url_util.join(keys_prefix, "keys.manifest.json")
-    index_entry = cache_class(mirror_url, allow_unsigned=True)
+    index_entry = cache_class(mirror_url, notary=NonSigningNotary())
 
     try:
         index_manifest = index_entry.read_manifest(manifest_url=key_index_manifest_url)
@@ -2305,7 +2305,7 @@ def _get_keys(
     saved_fingerprints = []
     for fingerprint, _ in json_index["keys"].items():
         key_manifest_url = url_util.join(keys_prefix, f"{fingerprint}.key.manifest.json")
-        key_entry = cache_class(mirror_url, allow_unsigned=True)
+        key_entry = cache_class(mirror_url, notary=NonSigningNotary())
         try:
             key_manifest = key_entry.read_manifest(manifest_url=key_manifest_url)
             key_blob_path = key_entry.fetch_blob(key_manifest.data[0])
@@ -2424,7 +2424,7 @@ def needs_rebuild(spec, mirror_url):
     # format of the name, in order to determine if the package
     # needs to be rebuilt.
     cache_class = get_url_buildcache_class(layout_version=CURRENT_BUILD_CACHE_LAYOUT_VERSION)
-    cache_entry = cache_class(mirror_url, spec, allow_unsigned=True)
+    cache_entry = cache_class(mirror_url, spec, notary=NonSigningNotary())
     exists = cache_entry.exists([BuildcacheComponent.SPEC, BuildcacheComponent.TARBALL])
     return not exists
 
@@ -2499,7 +2499,7 @@ def download_single_spec(
 
     for url in urls:
         cache_class = get_url_buildcache_class(layout_version=layout_version)
-        cache_entry = cache_class(url, concrete_spec, allow_unsigned=True)
+        cache_entry = cache_class(url, concrete_spec, notary=NonSigningNotary())
 
         try:
             cache_entry.fetch_metadata()
@@ -2808,7 +2808,7 @@ class DefaultIndexHandler(IndexHandler):
             return FetchIndexResult(etag=None, hash=None, data=None, fresh=True)
 
         # Otherwise, download the index blob
-        cache_entry = cache_class(self.url, allow_unsigned=True)
+        cache_entry = cache_class(self.url, notary=NonSigningNotary())
         computed_hash, result = self.fetch_index_blob(cache_entry, index_blob_record)
         cache_entry.destroy()
 
@@ -2870,7 +2870,7 @@ class EtagIndexHandler(IndexHandler):
                 "etag", None
             )
 
-        cache_entry = cache_class(self.url, allow_unsigned=True)
+        cache_entry = cache_class(self.url, notary=NonSigningNotary())
         computed_hash, result = self.fetch_index_blob(cache_entry, index_blob_record)
         cache_entry.destroy()
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -2590,7 +2590,7 @@ class IndexHandler:
 
         manifest = BuildcacheManifest.from_dict(
             # Currently we do not sign buildcache index, but we could
-            cache_class.verify_and_extract_manifest(result, verify=False)
+            spack.spec.Spec.extract_json_from_clearsig(result)
         )
         blob_record = manifest.get_blob_records(
             cache_class.component_to_media_type(BuildcacheComponent.INDEX)

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -2590,7 +2590,7 @@ class IndexHandler:
 
         manifest = BuildcacheManifest.from_dict(
             # Currently we do not sign buildcache index, but we could
-            spack.spec.Spec.extract_json_from_clearsig(result)
+            spack.util.gpg.extract_json_from_clearsig(result)
         )
         blob_record = manifest.get_blob_records(
             cache_class.component_to_media_type(BuildcacheComponent.INDEX)

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -2382,7 +2382,7 @@ def _url_push_keys(
     tmpdir: str,
     update_index: bool = False,
 ):
-    """Upload pgp public keys to the given mrrors"""
+    """Upload pgp public keys to the given mirrors"""
     if not keys:
         return
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -54,6 +54,7 @@ import spack.llnl.util.filesystem as fsys
 import spack.llnl.util.lang
 import spack.llnl.util.tty as tty
 import spack.mirrors.mirror
+import spack.notary
 import spack.oci.image
 import spack.oci.oci
 import spack.oci.opener
@@ -77,7 +78,7 @@ import spack.util.url as url_util
 import spack.util.web as web_util
 from spack import traverse
 from spack.llnl.util.filesystem import mkdirp
-from spack.notary import Notary, NonSigningNotary
+from spack.notary import Notary
 from spack.oci.image import (
     Digest,
     ImageReference,
@@ -1166,10 +1167,7 @@ def _url_push(
     errors: List[Tuple[spack.spec.Spec, BaseException]] = []
 
     exists_futures = [
-        executor.submit(
-            _exists_in_buildcache, spec, out_url, notary=notary
-        )
-        for spec in specs
+        executor.submit(_exists_in_buildcache, spec, out_url, notary=notary) for spec in specs
     ]
 
     cache_entries = {
@@ -1229,6 +1227,7 @@ def _url_push(
     if notary:
         keys_tmpdir = os.path.join(tmpdir, "keys")
         os.mkdir(keys_tmpdir)
+        print(notary.get_keys())
         _url_push_keys(
             out_url, keys=notary.get_keys(), update_index=update_index, tmpdir=keys_tmpdir
         )
@@ -2288,7 +2287,7 @@ def _get_keys(
         mirror_url, *cache_class.get_relative_path_components(BuildcacheComponent.KEY)
     )
     key_index_manifest_url = url_util.join(keys_prefix, "keys.manifest.json")
-    index_entry = cache_class(mirror_url, notary=NonSigningNotary())
+    index_entry = cache_class(mirror_url)
 
     try:
         index_manifest = index_entry.read_manifest(manifest_url=key_index_manifest_url)
@@ -2305,7 +2304,7 @@ def _get_keys(
     saved_fingerprints = []
     for fingerprint, _ in json_index["keys"].items():
         key_manifest_url = url_util.join(keys_prefix, f"{fingerprint}.key.manifest.json")
-        key_entry = cache_class(mirror_url, notary=NonSigningNotary())
+        key_entry = cache_class(mirror_url)
         try:
             key_manifest = key_entry.read_manifest(manifest_url=key_manifest_url)
             key_blob_path = key_entry.fetch_blob(key_manifest.data[0])
@@ -2383,7 +2382,10 @@ def _url_push_keys(
     tmpdir: str,
     update_index: bool = False,
 ):
-    """Upload pgp public keys to the given mirrors"""
+    """Upload pgp public keys to the given mrrors"""
+    if not keys:
+        return
+
     cache_class = get_url_buildcache_class()
 
     for mirror in mirrors:
@@ -2394,7 +2396,7 @@ def _url_push_keys(
 
         for key, file in keys:
             cache_class.push_local_file_as_blob(
-                local_file_path=file,
+                local_file_path=str(file),
                 mirror_url=push_url,
                 manifest_name=f"{key}.key",
                 component_type=BuildcacheComponent.KEY,
@@ -2424,7 +2426,7 @@ def needs_rebuild(spec, mirror_url):
     # format of the name, in order to determine if the package
     # needs to be rebuilt.
     cache_class = get_url_buildcache_class(layout_version=CURRENT_BUILD_CACHE_LAYOUT_VERSION)
-    cache_entry = cache_class(mirror_url, spec, notary=NonSigningNotary())
+    cache_entry = cache_class(mirror_url, spec)
     exists = cache_entry.exists([BuildcacheComponent.SPEC, BuildcacheComponent.TARBALL])
     return not exists
 
@@ -2499,7 +2501,7 @@ def download_single_spec(
 
     for url in urls:
         cache_class = get_url_buildcache_class(layout_version=layout_version)
-        cache_entry = cache_class(url, concrete_spec, notary=NonSigningNotary())
+        cache_entry = cache_class(url, concrete_spec)
 
         try:
             cache_entry.fetch_metadata()
@@ -2808,7 +2810,7 @@ class DefaultIndexHandler(IndexHandler):
             return FetchIndexResult(etag=None, hash=None, data=None, fresh=True)
 
         # Otherwise, download the index blob
-        cache_entry = cache_class(self.url, notary=NonSigningNotary())
+        cache_entry = cache_class(self.url)
         computed_hash, result = self.fetch_index_blob(cache_entry, index_blob_record)
         cache_entry.destroy()
 
@@ -2870,7 +2872,7 @@ class EtagIndexHandler(IndexHandler):
                 "etag", None
             )
 
-        cache_entry = cache_class(self.url, notary=NonSigningNotary())
+        cache_entry = cache_class(self.url)
         computed_hash, result = self.fetch_index_blob(cache_entry, index_blob_record)
         cache_entry.destroy()
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1155,9 +1155,9 @@ class FancyProgress:
 def _url_push(
     specs: List[spack.spec.Spec],
     out_url: str,
-    notary: Optional[Notary],
     force: bool,
     update_index: bool,
+    notary: Optional[Notary],
     tmpdir: str,
     executor: concurrent.futures.Executor,
 ) -> Tuple[List[spack.spec.Spec], List[Tuple[spack.spec.Spec, BaseException]]]:

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -77,6 +77,7 @@ import spack.util.url as url_util
 import spack.util.web as web_util
 from spack import traverse
 from spack.llnl.util.filesystem import mkdirp
+from spack.notary import Notary
 from spack.oci.image import (
     Digest,
     ImageReference,
@@ -637,20 +638,6 @@ def warn_v2_layout(mirror_url: str, action: str) -> bool:
     return True
 
 
-def select_signing_key() -> str:
-    keys = spack.util.gpg.signing_keys()
-    num = len(keys)
-    if num > 1:
-        raise PickKeyException(str(keys))
-    elif num == 0:
-        raise NoKeyException(
-            "No default key available for signing.\n"
-            "Use spack gpg init and spack gpg create"
-            " to create a default key."
-        )
-    return keys[0]
-
-
 def _push_index(db: BuildCacheDatabase, temp_dir: str, cache_prefix: str, name: str = ""):
     """Generate the index, compute its hash, and push the files to the mirror"""
     index_json_path = os.path.join(temp_dir, spack.database.INDEX_JSON_FILE)
@@ -976,12 +963,12 @@ def prefixes_to_relocate(spec):
 
 
 def _url_upload_tarball_and_specfile(
-    spec: spack.spec.Spec, tmpdir: str, cache_entry: URLBuildcacheEntry, signing_key: Optional[str]
+    spec: spack.spec.Spec, tmpdir: str, cache_entry: URLBuildcacheEntry, notary: Optional[Notary]
 ):
     tarball = os.path.join(tmpdir, f"{spec.dag_hash()}.tar.gz")
     checksum, _ = create_tarball(spec, tarball)
 
-    cache_entry.push_binary_package(spec, tarball, "sha256", checksum, tmpdir, signing_key)
+    cache_entry.push_binary_package(spec, tarball, "sha256", checksum, tmpdir, notary)
 
 
 class Uploader:
@@ -1087,11 +1074,11 @@ class URLUploader(Uploader):
         mirror: spack.mirrors.mirror.Mirror,
         force: bool,
         update_index: bool,
-        signing_key: Optional[str],
+        notary: Optional[Notary],
     ) -> None:
         super().__init__(mirror, force, update_index)
         self.url = mirror.push_url
-        self.signing_key = signing_key
+        self.notary = notary
 
     def push(
         self, specs: List[spack.spec.Spec]
@@ -1101,7 +1088,7 @@ class URLUploader(Uploader):
             out_url=self.url,
             force=self.force,
             update_index=self.update_index,
-            signing_key=self.signing_key,
+            notary=self.notary,
             tmpdir=self.tmpdir,
             executor=self.executor,
         )
@@ -1111,7 +1098,7 @@ def make_uploader(
     mirror: spack.mirrors.mirror.Mirror,
     force: bool = False,
     update_index: bool = False,
-    signing_key: Optional[str] = None,
+    notary: Optional[Notary] = None,
     base_image: Optional[str] = None,
 ) -> Uploader:
     """Builder for the appropriate uploader based on the mirror type"""
@@ -1120,9 +1107,7 @@ def make_uploader(
             mirror=mirror, force=force, update_index=update_index, base_image=base_image
         )
     else:
-        return URLUploader(
-            mirror=mirror, force=force, update_index=update_index, signing_key=signing_key
-        )
+        return URLUploader(mirror=mirror, force=force, update_index=update_index, notary=notary)
 
 
 def _format_spec(spec: spack.spec.Spec) -> str:
@@ -1169,7 +1154,7 @@ class FancyProgress:
 def _url_push(
     specs: List[spack.spec.Spec],
     out_url: str,
-    signing_key: Optional[str],
+    notary: Optional[Notary],
     force: bool,
     update_index: bool,
     tmpdir: str,
@@ -1182,7 +1167,7 @@ def _url_push(
 
     exists_futures = [
         executor.submit(
-            _exists_in_buildcache, spec, out_url, allow_unsigned=False if signing_key else True
+            _exists_in_buildcache, spec, out_url, allow_unsigned=False if notary else True
         )
         for spec in specs
     ]
@@ -1215,11 +1200,7 @@ def _url_push(
 
     upload_futures = [
         executor.submit(
-            _url_upload_tarball_and_specfile,
-            spec,
-            tmpdir,
-            cache_entries[spec.dag_hash()],
-            signing_key,
+            _url_upload_tarball_and_specfile, spec, tmpdir, cache_entries[spec.dag_hash()], notary
         )
         for spec in specs_to_upload
     ]
@@ -1245,10 +1226,12 @@ def _url_push(
     cache_class = get_url_buildcache_class(layout_version=CURRENT_BUILD_CACHE_LAYOUT_VERSION)
     cache_class.maybe_push_layout_json(out_url)
 
-    if signing_key:
+    if notary:
         keys_tmpdir = os.path.join(tmpdir, "keys")
         os.mkdir(keys_tmpdir)
-        _url_push_keys(out_url, keys=[signing_key], update_index=update_index, tmpdir=keys_tmpdir)
+        _url_push_keys(
+            out_url, keys=notary.get_keys(), update_index=update_index, tmpdir=keys_tmpdir
+        )
 
     if update_index:
         index_tmpdir = os.path.join(tmpdir, "index")
@@ -2387,17 +2370,11 @@ def _get_keys_v2(mirror_url, install=False, trust=False, force=False) -> Optiona
 
 def _url_push_keys(
     *mirrors: Union[spack.mirrors.mirror.Mirror, str],
-    keys: List[str],
+    keys: List[Tuple[str, pathlib.Path]],
     tmpdir: str,
     update_index: bool = False,
 ):
     """Upload pgp public keys to the given mirrors"""
-    keys = spack.util.gpg.public_keys(*(keys or ()))
-    files = [os.path.join(tmpdir, f"{key}.pub") for key in keys]
-
-    for key, file in zip(keys, files):
-        spack.util.gpg.export_keys(file, [key])
-
     cache_class = get_url_buildcache_class()
 
     for mirror in mirrors:
@@ -2406,7 +2383,7 @@ def _url_push_keys(
         tty.debug(f"Pushing public keys to {url_util.format(push_url)}")
         pushed_a_key = False
 
-        for key, file in zip(keys, files):
+        for key, file in keys:
             cache_class.push_local_file_as_blob(
                 local_file_path=file,
                 mirror_url=push_url,
@@ -2933,26 +2910,6 @@ class NoGpgException(spack.error.SpackError):
 
     def __init__(self, msg):
         super().__init__(msg)
-
-
-class NoKeyException(spack.error.SpackError):
-    """
-    Raised when gpg has no default key added.
-    """
-
-    def __init__(self, msg):
-        super().__init__(msg)
-
-
-class PickKeyException(spack.error.SpackError):
-    """
-    Raised when multiple keys can be used to sign.
-    """
-
-    def __init__(self, keys):
-        err_msg = "Multiple keys available for signing\n%s\n" % keys
-        err_msg += "Use spack buildcache create -k <key hash> to pick a key."
-        super().__init__(err_msg)
 
 
 class NewLayoutException(spack.error.SpackError):

--- a/lib/spack/spack/buildcache_migrate.py
+++ b/lib/spack/spack/buildcache_migrate.py
@@ -13,6 +13,7 @@ import spack.database as spack_db
 import spack.error
 import spack.llnl.util.tty as tty
 import spack.mirrors.mirror
+import spack.notary
 import spack.spec
 import spack.stage
 import spack.util.crypto
@@ -74,7 +75,7 @@ class MigrationException(spack.error.SpackError):
 
 
 def _migrate_spec(
-    s: spack.spec.Spec, mirror_url: str, tmpdir: str, unsigned: bool = False, signing_key: str = ""
+    s: spack.spec.Spec, mirror_url: str, tmpdir: str, notary: Optional[Notary] = None
 ) -> MigrateSpecResult:
     """Parallelizable function to migrate a single spec"""
     print_spec = f"{s.name}/{s.dag_hash()[:7]}"
@@ -82,7 +83,7 @@ def _migrate_spec(
     # Check if the spec file exists in the new location and exit early if so
 
     v3_cache_class = get_url_buildcache_class(layout_version=3)
-    v3_cache_entry = v3_cache_class(mirror_url, s, allow_unsigned=unsigned)
+    v3_cache_entry = v3_cache_class(mirror_url, s, notary=notary)
     exists = v3_cache_entry.exists([BuildcacheComponent.SPEC, BuildcacheComponent.TARBALL])
     v3_cache_entry.destroy()
 
@@ -95,7 +96,7 @@ def _migrate_spec(
         url_util.join(mirror_url, "build_cache", v2_tarball_name(s, ".spec.json.sig"))
     ]
 
-    if unsigned:
+    if notary:
         v2_metadata_urls.append(
             url_util.join(mirror_url, "build_cache", v2_tarball_name(s, ".spec.json"))
         )
@@ -115,7 +116,7 @@ def _migrate_spec(
 
     spec_dict = {}
 
-    if unsigned:
+    if notary:
         # User asked for unsigned, if we found a signed specfile, just ignore
         # the signature
         if v2_spec_url.endswith(".sig"):
@@ -229,14 +230,19 @@ def _migrate_spec(
         # line length.
 
     # Possibly sign the manifest
-    if not unsigned:
-        manifest_path = sign_file(signing_key, manifest_path)
+    if notary:
+        signature_path, manifest_path = notary.sign(manifest_path)
 
     v3_manifest_url = v3_cache_class.get_manifest_url(s, mirror_url)
 
     # Push the manifest
     try:
-        web_util.push_to_url(manifest_path, v3_manifest_url, keep_original=True)
+        if signature_path == manifest_path:
+            web_util.push_to_url(manifest_path, v3_manifest_url, keep_original=True)
+        else:
+            # Don't handle detached signature migration right now
+            raise Exception
+
     except Exception:
         return MigrateSpecResult(False, f"Failed to push manifest for {print_spec}")
 
@@ -253,10 +259,10 @@ def migrate(
     will attempt to verify signatures and re-sign specs, and will fail if not
     able to do so.  If delete_existing is True, spack will delete the original
     contents of the mirror once the migration is complete."""
-    signing_key = ""
+    notary = None
     if not unsigned:
         try:
-            signing_key = spack.binary_distribution.select_signing_key()
+            notary = spack.notary.select_notary(mirror)
         except (
             spack.binary_distribution.NoKeyException,
             spack.binary_distribution.PickKeyException,
@@ -300,7 +306,7 @@ def migrate(
         # Run the tasks in parallel if possible
         executor = spack.util.parallel.make_concurrent_executor()
         migrate_futures = [
-            executor.submit(_migrate_spec, spec, mirror_url, tmpdir, unsigned, signing_key)
+            executor.submit(_migrate_spec, spec, mirror_url, tmpdir, notary)
             for spec in specs_to_migrate
         ]
 
@@ -334,11 +340,11 @@ def migrate(
             spack.binary_distribution._push_index(db, index_tmpdir, mirror_url)
 
             # Push the public part of the signing key
-            if not unsigned:
+            if notary:
                 keys_tmpdir = os.path.join(tmpdir, "keys")
                 os.mkdir(keys_tmpdir)
                 spack.binary_distribution._url_push_keys(
-                    mirror_url, keys=[signing_key], update_index=True, tmpdir=keys_tmpdir
+                    mirror_url, keys=notary.get_keys(), update_index=True, tmpdir=keys_tmpdir
                 )
         else:
             tty.warn("No specs migrated, did you mean to perform an unsigned migration instead?")

--- a/lib/spack/spack/buildcache_migrate.py
+++ b/lib/spack/spack/buildcache_migrate.py
@@ -13,6 +13,7 @@ import spack.database as spack_db
 import spack.error
 import spack.llnl.util.tty as tty
 import spack.mirrors.mirror
+import spack.notary
 import spack.spec
 import spack.stage
 import spack.util.crypto
@@ -114,7 +115,7 @@ def _migrate_spec(
 
     spec_dict = {}
 
-    if notary:
+    if not notary:
         # User asked for unsigned, if we found a signed specfile, just ignore
         # the signature
         if v2_spec_url.endswith(".sig"):
@@ -128,7 +129,7 @@ def _migrate_spec(
         )
         with open(local_signed_pre_verify, "w", encoding="utf-8") as fd:
             fd.write(spec_contents)
-        if not try_verify(local_signed_pre_verify):
+        if not try_verify(notary, local_signed_pre_verify):
             return MigrateSpecResult(False, f"Failed to verify signature of {print_spec}")
         with open(local_signed_pre_verify, encoding="utf-8") as fd:
             spec_dict = spack.util.gpg.extract_json_from_clearsig(fd.read())
@@ -219,8 +220,8 @@ def _migrate_spec(
         "data": [tarball_blob_record.to_dict(), metadata_blob_record.to_dict()],
     }
 
-    manifest_path = os.path.join(tmpdir, f"{s.dag_hash()}.manifest.json")
-    with open(manifest_path, "w", encoding="utf-8") as f:
+    manifest_path = pathlib.Path(os.path.join(tmpdir, f"{s.dag_hash()}.manifest.json"))
+    with manifest_path.open("w", encoding="utf-8") as f:
         json.dump(manifest, f, indent=0, separators=(",", ":"))
         # Note: when using gpg clear sign, we need to avoid long lines (19995
         # chars). If lines are longer, they are truncated without error. So,
@@ -261,10 +262,7 @@ def migrate(
     if not unsigned:
         try:
             notary = spack.notary.select_notary(mirror)
-        except (
-            spack.binary_distribution.NoKeyException,
-            spack.binary_distribution.PickKeyException,
-        ):
+        except (spack.notary.NoKeyException, spack.notary.PickKeyException):
             raise MigrationException(
                 "Signed migration requires exactly one secret key in keychain"
             )

--- a/lib/spack/spack/buildcache_migrate.py
+++ b/lib/spack/spack/buildcache_migrate.py
@@ -92,13 +92,9 @@ def _migrate_spec(
 
     # Try to fetch the spec metadata
     v2_metadata_urls = [
-        url_util.join(mirror_url, "build_cache", v2_tarball_name(s, ".spec.json.sig"))
+        url_util.join(mirror_url, "build_cache", v2_tarball_name(s, ".spec.json.sig")),
+        url_util.join(mirror_url, "build_cache", v2_tarball_name(s, ".spec.json")),
     ]
-
-    if notary:
-        v2_metadata_urls.append(
-            url_util.join(mirror_url, "build_cache", v2_tarball_name(s, ".spec.json"))
-        )
 
     spec_contents = None
 
@@ -229,8 +225,9 @@ def _migrate_spec(
         # line length.
 
     # Possibly sign the manifest
+    signature_path = manifest_path
     if notary:
-        signature_path, manifest_path = notary.sign(manifest_path)
+        manifest_path, signature_path = notary.sign(manifest_path)
 
     v3_manifest_url = v3_cache_class.get_manifest_url(s, mirror_url)
 
@@ -261,7 +258,7 @@ def migrate(
     notary = None
     if not unsigned:
         try:
-            notary = spack.notary.select_notary(mirror)
+            notary = spack.notary.select_notary(mirror, signed=not unsigned)
         except (spack.notary.NoKeyException, spack.notary.PickKeyException):
             raise MigrationException(
                 "Signed migration requires exactly one secret key in keychain"

--- a/lib/spack/spack/buildcache_migrate.py
+++ b/lib/spack/spack/buildcache_migrate.py
@@ -6,14 +6,13 @@ import json
 import os
 import pathlib
 import tempfile
-from typing import NamedTuple
+from typing import NamedTuple, Optional
 
 import spack.binary_distribution
 import spack.database as spack_db
 import spack.error
 import spack.llnl.util.tty as tty
 import spack.mirrors.mirror
-import spack.notary
 import spack.spec
 import spack.stage
 import spack.util.crypto
@@ -21,14 +20,13 @@ import spack.util.gpg
 import spack.util.parallel
 import spack.util.url as url_util
 import spack.util.web as web_util
-
-from .enums import InstallRecordStatus
-from .url_buildcache import (
+from spack.enums import InstallRecordStatus
+from spack.notary import Notary
+from spack.url_buildcache import (
     BlobRecord,
     BuildcacheComponent,
     compressed_json_from_dict,
     get_url_buildcache_class,
-    sign_file,
     try_verify,
 )
 

--- a/lib/spack/spack/buildcache_migrate.py
+++ b/lib/spack/spack/buildcache_migrate.py
@@ -258,7 +258,9 @@ def migrate(
     notary = None
     if not unsigned:
         try:
-            notary = spack.notary.select_notary(mirror, signed=not unsigned)
+            notary = spack.notary.select_notary(mirror, signed=True)
+            if not notary.is_signing:
+                raise spack.notary.NoKeyException("")
         except (spack.notary.NoKeyException, spack.notary.PickKeyException):
             raise MigrationException(
                 "Signed migration requires exactly one secret key in keychain"
@@ -304,6 +306,7 @@ def migrate(
         ]
 
         success_count = 0
+        errors_detected = False
 
         tty.msg("Migration summary:")
         for spec, migrate_future in zip(specs_to_migrate, migrate_futures):
@@ -314,6 +317,7 @@ def migrate(
                 tty.msg(msg)
             else:
                 tty.error(msg)
+                errors_detected = True
             # The migrated index should have the same specs as the original index,
             # modulo any specs that we failed to migrate for whatever reason. So
             # to avoid having to re-fetch all the spec files now, just mark them
@@ -339,11 +343,15 @@ def migrate(
                 spack.binary_distribution._url_push_keys(
                     mirror_url, keys=notary.get_keys(), update_index=True, tmpdir=keys_tmpdir
                 )
-        else:
-            tty.warn("No specs migrated, did you mean to perform an unsigned migration instead?")
+
+        if errors_detected:
+            tty.warn(
+                "Failed to migrated some specs, did you "
+                "mean to perform an unsigned migration instead?"
+            )
 
         # Delete the old layout if the user requested it
-        if delete_existing:
+        if not errors_detected and delete_existing:
             delete_prefix = url_util.join(mirror_url, "build_cache")
             tty.msg(f"Recursively deleting {delete_prefix}")
             web_util.remove_url(delete_prefix, recursive=True)

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -26,6 +26,7 @@ import spack.llnl.util.filesystem as fs
 import spack.llnl.util.tty as tty
 import spack.main
 import spack.mirrors.mirror
+import spack.notary
 import spack.paths
 import spack.repo
 import spack.spec
@@ -608,24 +609,25 @@ def can_verify_binaries():
     return len(gpg_util.public_keys()) >= 1
 
 
-def push_to_build_cache(spec: spack.spec.Spec, mirror_url: str, sign_binaries: bool) -> bool:
+def push_to_build_cache(
+    spec: spack.spec.Spec, mirror: spack.mirrors.mirror.Mirror, sign_binaries: bool
+) -> bool:
     """Push one or more binary packages to the mirror.
 
     Arguments:
 
         spec: Installed spec to push
-        mirror_url: URL of target mirror
+        mirror: URL of target mirror
         sign_binaries: If True, spack will attempt to sign binary package before pushing.
     """
     tty.debug(f"Pushing to build cache ({'signed' if sign_binaries else 'unsigned'})")
-    signing_key = spack.binary_distribution.select_signing_key() if sign_binaries else None
-    mirror = spack.mirrors.mirror.Mirror.from_url(mirror_url)
+    notary = spack.notary.select_notary(mirror, signed=sign_binaries)
     try:
-        with spack.binary_distribution.make_uploader(mirror, signing_key=signing_key) as uploader:
+        with spack.binary_distribution.make_uploader(mirror, notary=notary) as uploader:
             uploader.push_or_raise([spec])
         return True
     except spack.binary_distribution.PushToBuildCacheError as e:
-        tty.error(f"Problem writing to {mirror_url}: {e}")
+        tty.error(f"Problem writing to {mirror.push_url}: {e}")
         return False
 
 
@@ -1239,7 +1241,10 @@ if ($LASTEXITCODE -ne 0){{
 
 
 def create_buildcache(
-    input_spec: spack.spec.Spec, *, destination_mirror_urls: List[str], sign_binaries: bool = False
+    input_spec: spack.spec.Spec,
+    *,
+    destination_mirrors: List[spack.mirrors.mirror.Mirror],
+    sign_binaries: bool = False,
 ) -> List[PushResult]:
     """Create the buildcache at the provided mirror(s).
 
@@ -1252,10 +1257,10 @@ def create_buildcache(
     """
     results = []
 
-    for mirror_url in destination_mirror_urls:
+    for mirror in destination_mirrors:
         results.append(
             PushResult(
-                success=push_to_build_cache(input_spec, mirror_url, sign_binaries), url=mirror_url
+                success=push_to_build_cache(input_spec, mirror, sign_binaries), url=mirror.push_url
             )
         )
 

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -807,7 +807,7 @@ def sync_fn(args):
         cache_class = get_url_buildcache_class(
             layout_version=spack.binary_distribution.CURRENT_BUILD_CACHE_LAYOUT_VERSION
         )
-        src_cache_entry = cache_class(src_mirror_url, s, allow_unsigned=True)
+        src_cache_entry = cache_class(src_mirror_url, s)
         src_cache_entry.read_manifest()
         copy_buildcache_entry(src_cache_entry, dest_mirror_url)
 
@@ -832,9 +832,7 @@ def manifest_copy(
         cache_class = get_url_buildcache_class(
             layout_version=spack.binary_distribution.CURRENT_BUILD_CACHE_LAYOUT_VERSION
         )
-        src_cache_entry = cache_class(
-            cache_class.get_base_url(copy_obj["src"]), allow_unsigned=True
-        )
+        src_cache_entry = cache_class(cache_class.get_base_url(copy_obj["src"]))
         src_cache_entry.read_manifest(manifest_url=copy_obj["src"])
         if dest_mirror:
             destination_url = dest_mirror.push_url

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -19,6 +19,7 @@ import spack.environment as ev
 import spack.error
 import spack.llnl.util.tty as tty
 import spack.mirrors.mirror
+import spack.notary
 import spack.oci.image
 import spack.oci.oci
 import spack.spec
@@ -499,9 +500,7 @@ def push_fn(args):
         unsigned = True
 
     # Select a signing key, or None if unsigned.
-    signing_key = (
-        None if unsigned else (args.key or spack.binary_distribution.select_signing_key())
-    )
+    signing_key = None if unsigned else spack.notary.select_notary(mirror, args.key)
 
     specs = _specs_to_be_packaged(
         roots,

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -485,22 +485,8 @@ def push_fn(args):
 
     push_url = mirror.push_url
 
-    # When neither --signed, --unsigned nor --key are specified, use the mirror's default.
-    if args.signed is None and not args.key:
-        unsigned = not mirror.signed
-    else:
-        unsigned = not (args.key or args.signed)
-
-    # For OCI images, we require dependencies to be pushed for now.
-    if spack.oci.image.is_oci_url(mirror.push_url) and not unsigned:
-        tty.warn(
-            "Code signing is currently not supported for OCI images. "
-            "Use --unsigned to silence this warning."
-        )
-        unsigned = True
-
     # Select a signing key, or None if unsigned.
-    signing_key = None if unsigned else spack.notary.select_notary(mirror, args.key)
+    notary = spack.notary.select_notary(mirror, key=args.key, signed=args.signed)
 
     specs = _specs_to_be_packaged(
         roots,
@@ -541,7 +527,7 @@ def push_fn(args):
         mirror=mirror,
         force=args.force,
         update_index=args.update_index,
-        signing_key=signing_key,
+        notary=notary,
         base_image=args.base_image,
     ) as uploader:
         skipped, upload_errors = uploader.push(specs=specs)

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -597,7 +597,7 @@ def ci_rebuild(args):
         # will result in a non-zero exit code. Pushing is best-effort.
         for result in spack_ci.create_buildcache(
             input_spec=job_spec,
-            destination_mirror_urls=[buildcache_destination.push_url],
+            destination_mirrors=[buildcache_destination],
             sign_binaries=spack_ci.can_sign_binaries(),
         ):
             if not result.success:

--- a/lib/spack/spack/cmd/gpg.py
+++ b/lib/spack/spack/cmd/gpg.py
@@ -13,7 +13,6 @@ import spack.paths
 import spack.stage
 import spack.util.gpg
 import spack.util.url
-from spack.cmd.common import arguments
 
 description = "handle GPG actions for spack"
 section = "packaging"

--- a/lib/spack/spack/cmd/gpg.py
+++ b/lib/spack/spack/cmd/gpg.py
@@ -8,6 +8,7 @@ import tempfile
 
 import spack.binary_distribution
 import spack.mirrors.mirror
+import spack.notary
 import spack.paths
 import spack.stage
 import spack.util.gpg
@@ -198,7 +199,10 @@ def gpg_publish(args):
 
     with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpdir:
         spack.binary_distribution._url_push_keys(
-            mirror, keys=args.keys, tmpdir=tmpdir, update_index=args.update_index
+            mirror,
+            keys=spack.notary.get_notary(mirror).get_keys(),
+            tmpdir=tmpdir,
+            update_index=args.update_index,
         )
 
 

--- a/lib/spack/spack/cmd/gpg.py
+++ b/lib/spack/spack/cmd/gpg.py
@@ -200,7 +200,7 @@ def gpg_publish(args):
     with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpdir:
         spack.binary_distribution._url_push_keys(
             mirror,
-            keys=spack.notary.get_notary(mirror).get_keys(),
+            keys=spack.notary.select_notary(mirror).get_keys(),
             tmpdir=tmpdir,
             update_index=args.update_index,
         )

--- a/lib/spack/spack/cmd/gpg.py
+++ b/lib/spack/spack/cmd/gpg.py
@@ -7,6 +7,7 @@ import os
 import tempfile
 
 import spack.binary_distribution
+import spack.cmd.common.arguments as arguments
 import spack.mirrors.mirror
 import spack.notary
 import spack.paths

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -124,6 +124,7 @@ CONFIG_DEFAULTS = {
         "license_dir": spack.paths.default_license_dir,
     },
     "concretizer": {"externals": {"completion": "default_variants"}},
+    "signing": {"gpg": "detached"},
 }
 
 #: metavar to use for commands that accept scopes

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -124,7 +124,6 @@ CONFIG_DEFAULTS = {
         "license_dir": spack.paths.default_license_dir,
     },
     "concretizer": {"externals": {"completion": "default_variants"}},
-    "signing": {"gpg": "detached"},
 }
 
 #: metavar to use for commands that accept scopes

--- a/lib/spack/spack/hooks/autopush.py
+++ b/lib/spack/spack/hooks/autopush.py
@@ -5,6 +5,7 @@
 import spack.binary_distribution
 import spack.llnl.util.tty as tty
 import spack.mirrors.mirror
+import spack.notary
 
 
 def post_install(spec, explicit):
@@ -21,9 +22,9 @@ def post_install(spec, explicit):
 
     # Push the package to all autopush mirrors
     for mirror in spack.mirrors.mirror.MirrorCollection(binary=True, autopush=True).values():
-        signing_key = spack.binary_distribution.select_signing_key() if mirror.signed else None
+        notary = spack.notary.select_notary(mirror) if mirror.signed else None
         with spack.binary_distribution.make_uploader(
-            mirror=mirror, force=True, signing_key=signing_key
+            mirror=mirror, force=True, notary=notary
         ) as uploader:
             uploader.push_or_raise([spec])
         tty.msg(f"{spec.name}: Pushed to build cache: '{mirror.name}'")

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -8,7 +8,6 @@ from typing import IO, Any, Dict, Iterator, List, Mapping, Optional, Tuple, Unio
 
 import spack.config
 import spack.llnl.util.tty as tty
-import spack.util.gpg
 import spack.util.path
 import spack.util.spack_yaml as syaml
 import spack.util.url as url_util
@@ -20,6 +19,7 @@ supported_url_schemes = ("file", "http", "https", "sftp", "ftp", "s3", "gs", "oc
 
 #: The layout version spack can current install
 SUPPORTED_LAYOUT_VERSIONS = (3, 2)
+DEFAULT_SIGNING_TYPE = "pgp-cleartext"
 
 
 def _url_or_path_to_url(url_or_path: str) -> str:
@@ -124,10 +124,13 @@ class Mirror:
         if not self.signed:
             return None
 
+        if isinstance(self._data, str):
+            return DEFAULT_SIGNING_TYPE
+
         # Get the signature type from the config
-        sig_type = self._data.get("signed", "pgp-cleartext")
+        sig_type = self._data.get("signed", DEFAULT_SIGNING_TYPE)
         if isinstance(sig_type, bool):
-            sig_type = "pgp-cleartext"
+            sig_type = DEFAULT_SIGNING_TYPE
 
         return sig_type
 

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -131,6 +131,8 @@ class Mirror:
         sig_type = self._data.get("signed", DEFAULT_SIGNING_TYPE)
         if isinstance(sig_type, bool):
             sig_type = DEFAULT_SIGNING_TYPE
+        else:
+            sig_type = sig_type.get("type")
 
         return sig_type
 

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -117,7 +117,19 @@ class Mirror:
         if is_oci_url(self.fetch_url):
             return False
 
-        return isinstance(self._data, str) or self._data.get("signed", True)
+        return isinstance(self._data, str) or bool(self._data.get("signed", True))
+
+    @property
+    def signing_type(self) -> Optional[str]:
+        if not self.signed:
+            return None
+
+        # Get the signature type from the config
+        sig_type = self._data.get("signed", "pgp-cleartext")
+        if isinstance(sig_type, bool):
+            sig_type = "pgp-cleartext"
+
+        return sig_type
 
     @property
     def autopush(self) -> bool:
@@ -391,9 +403,6 @@ class Mirror:
 
     def get_endpoint_url(self, direction: str) -> Optional[str]:
         return self._get_value("endpoint_url", direction)
-
-    def get_signing_type(self, direction: str) -> spack.util.gpg.Signature:
-        return self._get_value("signing_type", direction)
 
 
 class MirrorCollection(Mapping[str, Mirror]):

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -8,6 +8,7 @@ from typing import IO, Any, Dict, Iterator, List, Mapping, Optional, Tuple, Unio
 
 import spack.config
 import spack.llnl.util.tty as tty
+import spack.util.gpg
 import spack.util.path
 import spack.util.spack_yaml as syaml
 import spack.util.url as url_util
@@ -390,6 +391,9 @@ class Mirror:
 
     def get_endpoint_url(self, direction: str) -> Optional[str]:
         return self._get_value("endpoint_url", direction)
+
+    def get_signing_type(self, direction: str) -> spack.util.gpg.Signature:
+        return self._get_value("signing_type", direction)
 
 
 class MirrorCollection(Mapping[str, Mirror]):

--- a/lib/spack/spack/notary.py
+++ b/lib/spack/spack/notary.py
@@ -1,15 +1,18 @@
+import abc
+import os
 import pathlib
-from abc import abstractmethod
+import warnings
 from typing import List, Optional, Tuple, Union
 
+import spack.config
 import spack.error
 import spack.util.executable
 import spack.util.gpg
 from spack.mirrors.mirror import Mirror
 
 
-class Notary:
-    @abstractmethod
+class Notary(metaclass=abc.ABCMeta):
+    @abc.abstractmethod
     def sign(self, blob: Union[str, pathlib.Path]) -> Tuple[pathlib.Path, pathlib.Path]:
         """Sign a blob
 
@@ -17,11 +20,11 @@ class Notary:
             blob: Path to blob to sign
 
         Returns:
-            Path to the signature and path to original blob
+            Path to original blob and the to the signature
         """
         pass
 
-    @abstractmethod
+    @abc.abstractmethod
     def verify(
         self, blob: Union[str, pathlib.Path], signature: Optional[Union[str, pathlib.Path]]
     ) -> bool:
@@ -29,16 +32,76 @@ class Notary:
 
         Args:
             blob: Path to blob to validate
-            signature: (optional) signature of the blob. If not provided, the blob is assumed to also contain the signature (cleartext)
+            signature: (optional) signature of the blob. If not provided, the blob is assumed to
+                       also be the signature
 
         Returns:
             Boolean denoting if blob is valid and path to file with any signature data attached
         """
         pass
 
-    def get_keys(self) -> List[Tuple[str, pathlib.Path]]:
-        """Return list of public key names to key files"""
+    @abc.abstractmethod
+    def get_keys(self, *keys, tmpdir=None) -> List[Tuple[str, pathlib.Path]]:
+        """Return list of public key names to key files.
+
+        Args:
+            keys: list of specific keys to list if they exist
+            tmpdir: (optional) Root directory to place key files
+        """
         pass
+
+    @property
+    def is_signing(cls):
+        return True
+
+    @property
+    def is_validating(cls):
+        return True
+
+
+class NonSigningNotary(Notary):
+    def sign(self, blob: Union[str, pathlib.Path]) -> Tuple[pathlib.Path, pathlib.Path]:
+        """Sign a blob
+
+        Args:
+            blob: Path to blob to sign
+
+        Returns:
+            Path to original blob and the to the signature
+        """
+        return blob, blob
+
+    def verify(
+        self, blob: Union[str, pathlib.Path], signature: Optional[Union[str, pathlib.Path]]
+    ) -> bool:
+        """Verify the signature is valid for the blob
+
+        Args:
+            blob: Path to blob to validate
+            signature: (optional) signature of the blob. If not provided, the blob is assumed to
+                       also be the signature
+
+        Returns:
+            Boolean denoting if blob is valid and path to file with any signature data attached
+        """
+        return True
+
+    def get_keys(self, *keys, tmpdir=None) -> List[Tuple[str, pathlib.Path]]:
+        """Return list of public key names to key files.
+
+        Args:
+            keys: list of specific keys to list if they exist
+            tmpdir: (optional) Root directory to place key files
+        """
+        return []
+
+    @property
+    def is_signing(cls):
+        return False
+
+    @property
+    def is_validating(cls):
+        return False
 
 
 class GpgNotary(Notary):
@@ -49,7 +112,6 @@ class GpgNotary(Notary):
         self.key = key
         self.cleartext = signature_type == spack.util.gpg.Signature.Cleartext
 
-    @abstractmethod
     def sign(self, blob: Union[str, pathlib.Path]) -> Tuple[pathlib.Path, pathlib.Path]:
         """Sign a blob
 
@@ -57,17 +119,18 @@ class GpgNotary(Notary):
             blob: Path to blob to sign
 
         Returns:
-            Path to the signature and path to original blob
+            Path to original blob and the to the signature. If they are the same path,
+            then then signature wraps the original blob content (cleartext).
         """
-        signed_file_path = f"{blob}.sig"
+        signed_file_path = f"{blob}.asc"
         signopt = "--clearsign" if self.cleartext else "--detach-sign"
         self.gpg(signopt, "--armor", "--local-user", self.key, "--output", signed_file_path, blob)
-        if detached:
+        if not self.cleartext:
             return blob, signed_file_path
         return signed_file_path, signed_file_path
 
-    @abstractmethod
     def verify(
+        self,
         blob: Union[str, pathlib.Path],
         signature: Optional[Union[str, pathlib.Path]] = None,
         output: Optional[pathlib.Path] = None,
@@ -76,7 +139,8 @@ class GpgNotary(Notary):
 
         Args:
             blob: Path to blob to validate
-            signature: (optional) signature of the blob. If not provided, the blob is assumed to also contain the signature (cleartext)
+            signature: (optional) signature of the blob. If not provided, the blob is assumed to
+                                  also contain the signature (cleartext)
 
         Returns:
             Boolean denoting if blob is valid
@@ -84,7 +148,7 @@ class GpgNotary(Notary):
         args = [signature or blob]
         if signature:
             args.append(blob)
-        suppress_warnings = config.get("config:suppress_gpg_warnings", False)
+        suppress_warnings = spack.config.get("config:suppress_gpg_warnings", False)
         kwargs = {"error": str} if suppress_warnings else {}
         try:
             self.gpg("--verify", *args, **kwargs)
@@ -92,8 +156,16 @@ class GpgNotary(Notary):
             return False
         return True
 
-    def get_keys(self) -> List[Tuple[str, pathlib.Path]]:
-        """Return list of public key files"""
+    def get_keys(self, *keys, tmpdir=None) -> List[Tuple[str, pathlib.Path]]:
+        """Return list of public key names to key files.
+
+        Args:
+            keys: list of specific keys to list if they exist
+            tmpdir: Root directory to place key files
+        """
+
+        if tmpdir is None:
+            tmpdir = os.getcwd()
 
         keys = spack.util.gpg.public_keys(*(keys or ()))
         files = [os.path.join(tmpdir, f"{key}.pub") for key in keys]
@@ -104,26 +176,44 @@ class GpgNotary(Notary):
         return zip(keys, files)
 
 
-def select_notary(mirror: Mirror, key: Optional[str]) -> Notary:
+def select_notary(
+    mirror: Mirror, key: Optional[str] = None, signed: Optional[bool] = None
+) -> Notary:
     """Select the correct notary for a mirror
 
     Args:
         mirror: Mirror to configure notary for
         key: Specific key name/id to use for the notary
     """
+    if signed is None and key is None:
+        signed = mirror.signed
+    else:
+        signed = bool(key or signed)
+
+    if not signed:
+        return NonSigningNotary()
+
+    if spack.oci.image.is_oci_url(mirror.push_url):
+        warnings.warn(
+            "Code signing is currently not supported for OCI images. "
+            "Specify unsigned to silence this warning."
+        )
+
     # This calls spack.util.gpg.init
     keys = spack.util.gpg.signing_keys()
     num = len(keys)
-    if num > 1:
-        raise PickKeyException(str(keys))
-    elif num == 0:
-        raise NoKeyException(
-            "No keys available for signing.\n"
-            "Use spack gpg init and spack gpg create"
-            " to create a default key."
-        )
+    if not key:
+        if num > 1:
+            raise PickKeyException(str(keys))
+        elif num == 0:
+            raise NoKeyException(
+                "No keys available for signing.\n"
+                "Use spack gpg init and spack gpg create"
+                " to create a default key."
+            )
     elif key not in keys:
         raise NoKeyException(f"Could not find specified key {key} in keyring.")
+
     # Assumes the gpg state is initialized.
     # TODO: Don't rely on global state
     return GpgNotary(spack.util.gpg.GPG, key or keys[0], mirror.signing_type)

--- a/lib/spack/spack/notary.py
+++ b/lib/spack/spack/notary.py
@@ -6,6 +6,7 @@ from typing import List, Optional, Tuple, Union
 
 import spack.config
 import spack.error
+import spack.oci.image
 import spack.util.executable
 import spack.util.gpg
 from spack.mirrors.mirror import Mirror
@@ -26,7 +27,7 @@ class Notary(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def verify(
-        self, blob: Union[str, pathlib.Path], signature: Optional[Union[str, pathlib.Path]]
+        self, blob: Union[str, pathlib.Path], signature: Optional[Union[str, pathlib.Path]] = None
     ) -> bool:
         """Verify the signature is valid for the blob
 
@@ -69,10 +70,10 @@ class NonSigningNotary(Notary):
         Returns:
             Path to original blob and the to the signature
         """
-        return blob, blob
+        return pathlib.Path(blob), pathlib.Path(blob)
 
     def verify(
-        self, blob: Union[str, pathlib.Path], signature: Optional[Union[str, pathlib.Path]]
+        self, blob: Union[str, pathlib.Path], signature: Optional[Union[str, pathlib.Path]] = None
     ) -> bool:
         """Verify the signature is valid for the blob
 
@@ -107,10 +108,10 @@ class NonSigningNotary(Notary):
 class GpgNotary(Notary):
     """Verify and sign GPG signatures using a specific key"""
 
-    def __init__(self, gpg, key: str, signature_type: spack.util.gpg.Signature):
+    def __init__(self, gpg, key: str, signature_type: str):
         self.gpg = gpg
         self.key = key
-        self.cleartext = signature_type == spack.util.gpg.Signature.Cleartext
+        self.cleartext = signature_type == "pgp-cleartext"
 
     def sign(self, blob: Union[str, pathlib.Path]) -> Tuple[pathlib.Path, pathlib.Path]:
         """Sign a blob
@@ -122,18 +123,15 @@ class GpgNotary(Notary):
             Path to original blob and the to the signature. If they are the same path,
             then then signature wraps the original blob content (cleartext).
         """
-        signed_file_path = f"{blob}.asc"
+        signed_file_path = pathlib.Path(f"{blob}.asc")
         signopt = "--clearsign" if self.cleartext else "--detach-sign"
         self.gpg(signopt, "--armor", "--local-user", self.key, "--output", signed_file_path, blob)
         if not self.cleartext:
-            return blob, signed_file_path
+            return pathlib.Path(blob), signed_file_path
         return signed_file_path, signed_file_path
 
     def verify(
-        self,
-        blob: Union[str, pathlib.Path],
-        signature: Optional[Union[str, pathlib.Path]] = None,
-        output: Optional[pathlib.Path] = None,
+        self, blob: Union[str, pathlib.Path], signature: Optional[Union[str, pathlib.Path]] = None
     ) -> bool:
         """Verify the signature is valid for the blob
 
@@ -167,13 +165,13 @@ class GpgNotary(Notary):
         if tmpdir is None:
             tmpdir = os.getcwd()
 
-        keys = spack.util.gpg.public_keys(*(keys or ()))
-        files = [os.path.join(tmpdir, f"{key}.pub") for key in keys]
+        keys: List[str] = spack.util.gpg.public_keys(*(keys or ()))
+        files = [pathlib.Path(os.path.join(tmpdir, f"{key}.pub")) for key in keys]
 
         for key, file in zip(keys, files):
             spack.util.gpg.export_keys(file, [key])
 
-        return zip(keys, files)
+        return list(zip(keys, files))
 
 
 def select_notary(
@@ -200,7 +198,7 @@ def select_notary(
         )
 
     # This calls spack.util.gpg.init
-    keys = spack.util.gpg.signing_keys()
+    keys: List[str] = spack.util.gpg.signing_keys()
     num = len(keys)
     if not key:
         if num > 1:
@@ -216,7 +214,7 @@ def select_notary(
 
     # Assumes the gpg state is initialized.
     # TODO: Don't rely on global state
-    return GpgNotary(spack.util.gpg.GPG, key or keys[0], mirror.signing_type)
+    return GpgNotary(spack.util.gpg.GPG, key or keys[0], mirror.signing_type or "pgp-clearsign")
 
 
 class PickKeyException(spack.error.SpackError):

--- a/lib/spack/spack/notary.py
+++ b/lib/spack/spack/notary.py
@@ -196,13 +196,14 @@ class GpgNotary(Notary):
         if tmpdir is None:
             tmpdir = os.getcwd()
 
-        keys: List[str] = spack.util.gpg.public_keys(*(keys or ()))
-        files = [pathlib.Path(os.path.join(tmpdir, f"{key}.pub")) for key in keys]
+        key_files: List[Tuple[str, pathlib.Path]] = [
+            (key, pathlib.Path(os.path.join(tmpdir, f"{key}.pub"))) for k in spack.util.gpg.public_keys(*(keys or ()))
+        ]
 
-        for key, file in zip(keys, files):
+        for key, file in key_files.items():
             spack.util.gpg.export_keys(str(file), [key])
 
-        return list(zip(keys, files))
+        return key_files
 
     @property
     def is_signing(self):

--- a/lib/spack/spack/notary.py
+++ b/lib/spack/spack/notary.py
@@ -1,0 +1,142 @@
+import pathlib
+from abc import abstractmethod
+from typing import List, Optional, Tuple, Union
+
+import spack.error
+import spack.util.executable
+import spack.util.gpg
+from spack.mirrors.mirror import Mirror
+
+
+class Notary:
+    @abstractmethod
+    def sign(self, blob: Union[str, pathlib.Path]) -> Tuple[pathlib.Path, pathlib.Path]:
+        """Sign a blob
+
+        Args:
+            blob: Path to blob to sign
+
+        Returns:
+            Path to the signature and path to original blob
+        """
+        pass
+
+    @abstractmethod
+    def verify(
+        self, blob: Union[str, pathlib.Path], signature: Optional[Union[str, pathlib.Path]]
+    ) -> bool:
+        """Verify the signature is valid for the blob
+
+        Args:
+            blob: Path to blob to validate
+            signature: (optional) signature of the blob. If not provided, the blob is assumed to also contain the signature (cleartext)
+
+        Returns:
+            Boolean denoting if blob is valid and path to file with any signature data attached
+        """
+        pass
+
+    def get_keys(self) -> List[Tuple[str, pathlib.Path]]:
+        """Return list of public key names to key files"""
+        pass
+
+
+class GpgNotary(Notary):
+    """Verify and sign GPG signatures using a specific key"""
+
+    def __init__(self, gpg, key: str, signature_type: spack.util.gpg.Signature):
+        self.gpg = gpg
+        self.key = key
+        self.cleartext = signature_type == spack.util.gpg.Signature.Cleartext
+
+    @abstractmethod
+    def sign(self, blob: Union[str, pathlib.Path]) -> Tuple[pathlib.Path, pathlib.Path]:
+        """Sign a blob
+
+        Args:
+            blob: Path to blob to sign
+
+        Returns:
+            Path to the signature and path to original blob
+        """
+        signed_file_path = f"{blob}.sig"
+        signopt = "--clearsign" if self.cleartext else "--detach-sign"
+        self.gpg(signopt, "--armor", "--local-user", self.key, "--output", signed_file_path, blob)
+        if detached:
+            return blob, signed_file_path
+        return signed_file_path, signed_file_path
+
+    @abstractmethod
+    def verify(
+        blob: Union[str, pathlib.Path],
+        signature: Optional[Union[str, pathlib.Path]] = None,
+        output: Optional[pathlib.Path] = None,
+    ) -> bool:
+        """Verify the signature is valid for the blob
+
+        Args:
+            blob: Path to blob to validate
+            signature: (optional) signature of the blob. If not provided, the blob is assumed to also contain the signature (cleartext)
+
+        Returns:
+            Boolean denoting if blob is valid
+        """
+        args = [signature or blob]
+        if signature:
+            args.append(blob)
+        suppress_warnings = config.get("config:suppress_gpg_warnings", False)
+        kwargs = {"error": str} if suppress_warnings else {}
+        try:
+            self.gpg("--verify", *args, **kwargs)
+        except spack.util.executable.ProcessError:
+            return False
+        return True
+
+    def get_keys(self) -> List[Tuple[str, pathlib.Path]]:
+        """Return list of public key files"""
+
+        keys = spack.util.gpg.public_keys(*(keys or ()))
+        files = [os.path.join(tmpdir, f"{key}.pub") for key in keys]
+
+        for key, file in zip(keys, files):
+            spack.util.gpg.export_keys(file, [key])
+
+        return zip(keys, files)
+
+
+def select_notary(mirror: Mirror, key: Optional[str]) -> Notary:
+    """Select the correct notary for a mirror
+
+    Args:
+        mirror: Mirror to configure notary for
+        key: Specific key name/id to use for the notary
+    """
+    # This calls spack.util.gpg.init
+    keys = spack.util.gpg.signing_keys()
+    num = len(keys)
+    if num > 1:
+        raise PickKeyException(str(keys))
+    elif num == 0:
+        raise NoKeyException(
+            "No keys available for signing.\n"
+            "Use spack gpg init and spack gpg create"
+            " to create a default key."
+        )
+    elif key not in keys:
+        raise NoKeyException(f"Could not find specified key {key} in keyring.")
+    # Assumes the gpg state is initialized.
+    # TODO: Don't rely on global state
+    return GpgNotary(spack.util.gpg.GPG, key or keys[0], mirror.signing_type)
+
+
+class PickKeyException(spack.error.SpackError):
+    """Raised when multiple keys can be used to sign."""
+
+    def __init__(self, keys):
+        err_msg = "Multiple keys available for signing\n%s\n" % keys
+        err_msg += "Use spack buildcache create -k <key hash> to pick a key."
+        super().__init__(err_msg)
+
+
+class NoKeyException(spack.error.SpackError):
+    """Raised when gpg has no to key added."""

--- a/lib/spack/spack/notary.py
+++ b/lib/spack/spack/notary.py
@@ -61,11 +61,11 @@ class Notary(metaclass=abc.ABCMeta):
         pass
 
     @property
-    def is_signing(cls):
+    def is_signing(self):
         return True
 
     @property
-    def is_validating(cls):
+    def is_validating(self):
         return True
 
 
@@ -106,11 +106,11 @@ class NonSigningNotary(Notary):
         return []
 
     @property
-    def is_signing(cls):
+    def is_signing(self):
         return False
 
     @property
-    def is_validating(cls):
+    def is_validating(self):
         return False
 
 
@@ -203,6 +203,13 @@ class GpgNotary(Notary):
             spack.util.gpg.export_keys(str(file), [key])
 
         return list(zip(keys, files))
+
+    @property
+    def is_signing(self):
+        # Attempt to load the Gpg signing key to ensure that this notary
+        # can actual sign things
+        _ = self._signing_key
+        return True
 
 
 def select_notary(

--- a/lib/spack/spack/notary.py
+++ b/lib/spack/spack/notary.py
@@ -12,6 +12,15 @@ import spack.util.gpg
 from spack.mirrors.mirror import Mirror
 
 
+def _raise_no_signing_keys():
+    """Helper function to raise a consistent error when
+    there are no default signing keys available"""
+    raise NoKeyException(
+        "No keys available for signing.\n"
+        "Use spack gpg init and spack gpg create to create a default key."
+    )
+
+
 class Notary(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def sign(self, blob: Union[str, pathlib.Path]) -> Tuple[pathlib.Path, pathlib.Path]:
@@ -108,10 +117,24 @@ class NonSigningNotary(Notary):
 class GpgNotary(Notary):
     """Verify and sign GPG signatures using a specific key"""
 
-    def __init__(self, gpg, key: str, signature_type: str):
+    def __init__(self, gpg, key: Optional[str] = None, signature_type: Optional[str] = None):
         self.gpg = gpg
         self.key = key
         self.cleartext = signature_type == "pgp-cleartext"
+
+    @property
+    def _signing_key(self):
+        if self.key:
+            return self.key
+
+        # Fallback here to get the first private key in the keyring
+        # TODO: Don't use the global state, use the passed gpg
+        keys: List[str] = spack.util.gpg.signing_keys()
+        if not keys:
+            _raise_no_signing_keys()
+        self.key = keys[0]
+
+        return self.key
 
     def sign(self, blob: Union[str, pathlib.Path]) -> Tuple[pathlib.Path, pathlib.Path]:
         """Sign a blob
@@ -125,7 +148,15 @@ class GpgNotary(Notary):
         """
         signed_file_path = pathlib.Path(f"{blob}.asc")
         signopt = "--clearsign" if self.cleartext else "--detach-sign"
-        self.gpg(signopt, "--armor", "--local-user", self.key, "--output", signed_file_path, blob)
+        self.gpg(
+            signopt,
+            "--armor",
+            "--local-user",
+            self._signing_key,
+            "--output",
+            str(signed_file_path),
+            str(blob),
+        )
         if not self.cleartext:
             return pathlib.Path(blob), signed_file_path
         return signed_file_path, signed_file_path
@@ -169,7 +200,7 @@ class GpgNotary(Notary):
         files = [pathlib.Path(os.path.join(tmpdir, f"{key}.pub")) for key in keys]
 
         for key, file in zip(keys, files):
-            spack.util.gpg.export_keys(file, [key])
+            spack.util.gpg.export_keys(str(file), [key])
 
         return list(zip(keys, files))
 
@@ -197,18 +228,14 @@ def select_notary(
             "Specify unsigned to silence this warning."
         )
 
-    # This calls spack.util.gpg.init
-    keys: List[str] = spack.util.gpg.signing_keys()
+    # Attempt to get a list of signing keys.
+    # If there are none, then fall back to a list of None and defer the error
+    # to the call point of Notary::sign to allow for verify
+    keys: List[str] = spack.util.gpg.signing_keys() or [None]
     num = len(keys)
     if not key:
         if num > 1:
             raise PickKeyException(str(keys))
-        elif num == 0:
-            raise NoKeyException(
-                "No keys available for signing.\n"
-                "Use spack gpg init and spack gpg create"
-                " to create a default key."
-            )
     elif key not in keys:
         raise NoKeyException(f"Could not find specified key {key} in keyring.")
 

--- a/lib/spack/spack/schema/mirrors.py
+++ b/lib/spack/spack/schema/mirrors.py
@@ -98,8 +98,8 @@ mirror_entry = {
             "oneOf": [
                 {
                     "type": "boolean",
-                    "description": "Whether to require GPG signature verification for packages from "
-                    "this mirror",
+                    "description": "Whether to require GPG signature verification for packages "
+                    "from this mirror",
                 },
                 {
                     "type": "object",

--- a/lib/spack/spack/schema/mirrors.py
+++ b/lib/spack/spack/schema/mirrors.py
@@ -106,8 +106,8 @@ mirror_entry = {
                     "properties": {
                         "type": {
                             "type": "string",
-                            "enum": ["pgp_clearsign", "pgp_detached"],
-                            "default": "gnupg-detached",
+                            "enum": ["pgp-cleartext", "pgp-detached"],
+                            "default": "pgp-detached",
                         }
                     },
                 },

--- a/lib/spack/spack/schema/mirrors.py
+++ b/lib/spack/spack/schema/mirrors.py
@@ -104,8 +104,12 @@ mirror_entry = {
                 {
                     "type": "object",
                     "properties": {
-                        "type": {"type": "string", "enum", ["gnupg-clearsign", "gnupg-detached"], "default": "gnupg-detached"},
-                    }
+                        "type": {
+                            "type": "string",
+                            "enum": ["gnupg-clearsign", "gnupg-detached"],
+                            "default": "gnupg-detached",
+                        }
+                    },
                 },
             ]
         },

--- a/lib/spack/spack/schema/mirrors.py
+++ b/lib/spack/spack/schema/mirrors.py
@@ -106,7 +106,7 @@ mirror_entry = {
                     "properties": {
                         "type": {
                             "type": "string",
-                            "enum": ["gnupg-clearsign", "gnupg-detached"],
+                            "enum": ["pgp_clearsign", "pgp_detached"],
                             "default": "gnupg-detached",
                         }
                     },

--- a/lib/spack/spack/schema/mirrors.py
+++ b/lib/spack/spack/schema/mirrors.py
@@ -95,9 +95,19 @@ mirror_entry = {
             "precompiled packages",
         },
         "signed": {
-            "type": "boolean",
-            "description": "Whether to require GPG signature verification for packages from "
-            "this mirror",
+            "oneOf": [
+                {
+                    "type": "boolean",
+                    "description": "Whether to require GPG signature verification for packages from "
+                    "this mirror",
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "type": {"type": "string", "enum", ["gnupg-clearsign", "gnupg-detached"], "default": "gnupg-detached"},
+                    }
+                },
+            ]
         },
         "fetch": {
             **fetch_and_push,

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -26,6 +26,7 @@ import spack.environment as ev
 import spack.hooks.sbang as sbang
 import spack.main
 import spack.mirrors.mirror
+import spack.notary
 import spack.oci.image
 import spack.spec
 import spack.stage
@@ -153,8 +154,13 @@ def test_push_and_fetch_keys(mock_gnupghome, tmp_path: pathlib.Path):
         assert len(keys) == 1
         fpr = keys[0]
 
+        notary = spack.notary.GpgNotary(spack.util.gpg.GPG, fpr)
+        key_files = notary.get_keys()
+        assert len(key_files) == 1
+        assert key_files[0][0] == fpr
+
         spack.binary_distribution._url_push_keys(
-            mirror, keys=[fpr], tmpdir=str(tmp_path), update_index=True
+            mirror, keys=key_files, tmpdir=str(tmp_path), update_index=True
         )
 
     # dir 2: import the key from the mirror, and confirm that its fingerprint

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -1129,7 +1129,7 @@ def test_url_buildcache_entry_v3(monkeypatch, tmp_path: pathlib.Path):
     cache_class = get_url_buildcache_class(
         spack.binary_distribution.CURRENT_BUILD_CACHE_LAYOUT_VERSION
     )
-    build_cache = cache_class(mirror_url, s, allow_unsigned=True)
+    build_cache = cache_class(mirror_url, s)
 
     manifest = build_cache.read_manifest()
     spec_dict = build_cache.fetch_metadata()

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -14,6 +14,7 @@ import spack.concretize
 import spack.environment as ev
 import spack.error
 import spack.llnl.util.filesystem as fs
+import spack.mirrors.mirror
 import spack.paths
 import spack.repo as repo
 import spack.util.git
@@ -450,7 +451,11 @@ def test_ci_create_buildcache(working_env, config, monkeypatch):
     monkeypatch.setattr(ci, "push_to_build_cache", lambda a, b, c: True)
 
     results = ci.create_buildcache(
-        Spec(), destination_mirror_urls=["file:///fake-url-one", "file:///fake-url-two"]
+        Spec(),
+        destination_mirrors=[
+            spack.mirrors.mirror.Mirror("file:///fake-url-one"),
+            spack.mirrors.mirror.Mirror("file:///fake-url-two"),
+        ],
     )
 
     assert len(results) == 2
@@ -460,7 +465,9 @@ def test_ci_create_buildcache(working_env, config, monkeypatch):
     assert result2.success
     assert result2.url == "file:///fake-url-two"
 
-    results = ci.create_buildcache(Spec(), destination_mirror_urls=["file:///fake-url-one"])
+    results = ci.create_buildcache(
+        Spec(), destination_mirrors=[spack.mirrors.mirror.Mirror("file:///fake-url-one")]
+    )
 
     assert len(results) == 1
     assert results[0].success

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -1317,7 +1317,6 @@ def test_buildcache_check_index_full(
     blob_path = tmp_path / "blobs" / "sha256"
     with open(tmp_path / "v3" / "manifests" / "index" / index_name, "r", encoding="utf-8") as fd:
         manifest = json.load(fd)
-        print(manifest)
         digest = manifest["data"][0]["checksum"]
         blob_path = blob_path / digest[:2] / digest
 

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -105,7 +105,7 @@ def tests_buildcache_create_env(
     cache_class = get_url_buildcache_class(
         layout_version=spack.binary_distribution.CURRENT_BUILD_CACHE_LAYOUT_VERSION
     )
-    cache_entry = cache_class(mirror_url, spec, allow_unsigned=True)
+    cache_entry = cache_class(mirror_url, spec)
     assert cache_entry.exists([BuildcacheComponent.SPEC, BuildcacheComponent.TARBALL])
     cache_entry.destroy()
 
@@ -334,7 +334,7 @@ def test_buildcache_create_install(
     cache_class = get_url_buildcache_class(
         layout_version=spack.binary_distribution.CURRENT_BUILD_CACHE_LAYOUT_VERSION
     )
-    cache_entry = cache_class(mirror_url, spec, allow_unsigned=True)
+    cache_entry = cache_class(mirror_url, spec)
     manifest_path = os.path.join(
         str(tmp_path),
         *cache_class.get_relative_path_components(BuildcacheComponent.SPEC),
@@ -602,7 +602,7 @@ def test_url_buildcache_entry_v2_exists(
     spec = spack.concretize.concretize_one("libdwarf")
 
     # In v2 we have to ask for both, because we need to have the spec to have the tarball
-    build_cache = v2_cache_class(mirror_url, spec, allow_unsigned=True)
+    build_cache = v2_cache_class(mirror_url, spec)
     assert not build_cache.exists([BuildcacheComponent.TARBALL])
     assert not build_cache.exists([BuildcacheComponent.SPEC])
     # But if we do ask for both, they should be there in this case
@@ -612,11 +612,11 @@ def test_url_buildcache_entry_v2_exists(
     tarball_path = build_cache._get_tarball_url(spec, mirror_url)[7:]
 
     os.remove(tarball_path)
-    build_cache = v2_cache_class(mirror_url, spec, allow_unsigned=True)
+    build_cache = v2_cache_class(mirror_url, spec)
     assert not build_cache.exists([BuildcacheComponent.SPEC, BuildcacheComponent.TARBALL])
 
     os.remove(spec_path)
-    build_cache = v2_cache_class(mirror_url, spec, allow_unsigned=True)
+    build_cache = v2_cache_class(mirror_url, spec)
     assert not build_cache.exists([BuildcacheComponent.SPEC, BuildcacheComponent.TARBALL])
 
 
@@ -793,9 +793,7 @@ def test_buildcache_prune_orphaned_blobs(tmp_path, mutable_database, mock_gnupgh
     spec = mutable_database.query_local("libelf", installed=True)[0]
     buildcache("push", "--update-index", "my-mirror", f"/{spec.dag_hash()}")
 
-    cache_entry = URLBuildcacheEntry(
-        mirror_url=f"file://{mirror_directory}", spec=spec, allow_unsigned=True
-    )
+    cache_entry = URLBuildcacheEntry(mirror_url=f"file://{mirror_directory}", spec=spec)
 
     blob_urls = [
         URLBuildcacheEntry.get_blob_url(mirror_url=f"file://{mirror_directory}", record=blob)
@@ -835,9 +833,7 @@ def test_buildcache_prune_orphaned_manifest(tmp_path, mutable_database, mock_gnu
 
     # Create a cache entry and read the manifest, which should succeed
     # as we haven't pruned anything yet
-    cache_entry = URLBuildcacheEntry(
-        mirror_url=f"file://{mirror_directory}", spec=spec, allow_unsigned=True
-    )
+    cache_entry = URLBuildcacheEntry(mirror_url=f"file://{mirror_directory}", spec=spec)
     manifest = cache_entry.read_manifest()
 
     manifest_url = f"file://{cache_entry.get_manifest_url(spec=spec, mirror_url=mirror_directory)}"
@@ -872,9 +868,7 @@ def test_buildcache_prune_direct_with_keeplist(
     specs = mutable_database.query_local("libelf", installed=True)
     spec1 = specs[0]
 
-    cache_entry = URLBuildcacheEntry(
-        mirror_url=f"file://{mirror_directory}", spec=spec1, allow_unsigned=True
-    )
+    cache_entry = URLBuildcacheEntry(mirror_url=f"file://{mirror_directory}", spec=spec1)
     manifest_url = cache_entry.get_manifest_url(spec1, f"file://{mirror_directory}")
 
     # Push the first spec (package only, no dependencies)
@@ -912,9 +906,7 @@ def test_buildcache_prune_direct_removes_unlisted(
     keeplist_file = tmp_path / "keeplist.txt"
     keeplist_file.write_text("0" * 32)
 
-    cache_entry = URLBuildcacheEntry(
-        mirror_url=f"file://{mirror_directory}", spec=spec1, allow_unsigned=True
-    )
+    cache_entry = URLBuildcacheEntry(mirror_url=f"file://{mirror_directory}", spec=spec1)
     manifest_url = cache_entry.get_manifest_url(spec1, f"file://{mirror_directory}")
 
     assert web_util.url_exists(manifest_url)
@@ -974,9 +966,7 @@ def test_buildcache_prune_new_specs_race_condition(
 
     buildcache("push", "--only", "package", "--update-index", "my-mirror", f"/{spec.dag_hash()}")
 
-    cache_entry = URLBuildcacheEntry(
-        mirror_url=f"file://{mirror_directory}", spec=spec, allow_unsigned=True
-    )
+    cache_entry = URLBuildcacheEntry(mirror_url=f"file://{mirror_directory}", spec=spec)
     manifest_url = cache_entry.get_manifest_url(spec, f"file://{mirror_directory}")
 
     def mock_stat_url(url: str):

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -937,7 +937,7 @@ def test_push_to_build_cache_exceptions(monkeypatch, tmp_path: pathlib.Path, cap
 
     # Input doesn't matter, as we are faking exceptional output
     url = tmp_path.as_uri()
-    ci.push_to_build_cache(spack.spec.Spec(), spack.mirrors.mirror.Mirror(**dict(url=url)), False)
+    ci.push_to_build_cache(spack.spec.Spec(), spack.mirrors.mirror.Mirror(url), False)
     assert f"Problem writing to {url}: Error: Access Denied" in capfd.readouterr().err
 
 

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -19,6 +19,7 @@ import spack.concretize
 import spack.environment as ev
 import spack.hash_types as ht
 import spack.main
+import spack.mirrors.mirror
 import spack.paths
 import spack.repo
 import spack.spec
@@ -848,6 +849,9 @@ spack:
             )
         env_cmd("create", "test", "./spack.yaml")
         with ev.read("test") as current_env:
+            mirrors = spack.mirrors.mirror.MirrorCollection(binary=True)
+            dest_mirror = mirrors["buildcache-destination"]
+
             current_env.concretize()
             install_cmd("--keep-stage")
 
@@ -858,7 +862,7 @@ spack:
                 ypfd.write(spec_json)
 
             for s in concrete_spec.traverse():
-                ci.push_to_build_cache(s, mirror_url, True)
+                ci.push_to_build_cache(s, dest_mirror, True)
 
             # Now test the --prune-dag (default) option of spack ci generate
             mirror_cmd("add", "test-ci", mirror_url)
@@ -933,7 +937,7 @@ def test_push_to_build_cache_exceptions(monkeypatch, tmp_path: pathlib.Path, cap
 
     # Input doesn't matter, as we are faking exceptional output
     url = tmp_path.as_uri()
-    ci.push_to_build_cache(spack.spec.Spec(), url, False)
+    ci.push_to_build_cache(spack.spec.Spec(), spack.mirrors.mirror.Mirror(**dict(url=url)), False)
     assert f"Problem writing to {url}: Error: Access Denied" in capfd.readouterr().err
 
 

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -190,6 +190,7 @@ class URLBuildcacheEntry:
     SPEC_MEDIATYPE = f"application/vnd.spack.spec.v{spack.spec.SPECFILE_FORMAT_VERSION}+json"
     TARBALL_MEDIATYPE = "application/vnd.spack.install.v2.tar+gzip"
     PUBLIC_KEY_MEDIATYPE = "application/pgp-keys"
+    PGP_SIGNATURE_MEDIATYPE = "application/pgp-signature"
     PUBLIC_KEY_INDEX_MEDIATYPE = "application/vnd.spack.keyindex.v1+json"
     BUILDCACHE_INDEX_FILE = "index.manifest.json"
     COMPONENT_PATHS = {
@@ -198,6 +199,7 @@ class URLBuildcacheEntry:
         BuildcacheComponent.INDEX: [f"v{LAYOUT_VERSION}", "manifests", "index"],
         BuildcacheComponent.KEY: [f"v{LAYOUT_VERSION}", "manifests", "key"],
         BuildcacheComponent.SPEC: [f"v{LAYOUT_VERSION}", "manifests", "spec"],
+        BuildcacheComponent.SIG: [f"v{LAYOUT_VERSION}", "manifests", "sig"],
         BuildcacheComponent.KEY_INDEX: [f"v{LAYOUT_VERSION}", "manifests", "key"],
         BuildcacheComponent.TARBALL: ["blobs"],
         BuildcacheComponent.LAYOUT_JSON: [f"v{LAYOUT_VERSION}", "layout.json"],
@@ -285,6 +287,24 @@ class URLBuildcacheEntry:
         )
 
     @classmethod
+    def get_sig_url_for_file(cls, file: str, fingerprint: str, mirror_url: str) -> str:
+        assert os.path.exists(file)
+        with open(file, "rb") as fd:
+            return cls.get_sig_url_for_content(fd.read(), fingerprint, mirror_url)
+
+    @classmethod
+    def get_sig_url_for_content(cls, content: bytes, fingerprint: str, mirror_url: str) -> str:
+        digest = hashlib.sha256(content).hexdigest()
+        return cls.get_sig_url_for_digest(digest, fingerprint, mirror_url)
+
+    @classmethod
+    def get_sig_url_for_digest(cls, digest: str, fingerprint: str, mirror_url: str) -> str:
+        path_components = cls.get_relative_path_components(BuildcacheComponent.SIG)
+        return url_util.join(
+            mirror_url, *path_components, digest[:2], digest + ".asc"
+        )
+
+    @classmethod
     def get_buildcache_component_include_pattern(
         cls, buildcache_component: BuildcacheComponent
     ) -> str:
@@ -295,6 +315,8 @@ class URLBuildcacheEntry:
             return "*.manifest.json"
         elif buildcache_component == BuildcacheComponent.SPEC:
             return "*.spec.manifest.json"
+        elif buildcache_component == BuildcacheComponent.SIG:
+            return "*.sig.manifest.json"
         elif buildcache_component == BuildcacheComponent.INDEX:
             return ".*index.manifest.json"
         elif buildcache_component == BuildcacheComponent.KEY:
@@ -317,6 +339,9 @@ class URLBuildcacheEntry:
             return cls.PUBLIC_KEY_MEDIATYPE
         elif component == BuildcacheComponent.KEY_INDEX:
             return cls.PUBLIC_KEY_INDEX_MEDIATYPE
+        elif buildcache_component == BuildcacheComponent.SIG:
+            # TODO support for cosign
+            return cls.PGP_SIGNATURE_MEDIATYPE
 
         raise BuildcacheEntryError(f"Not a blob component: {component}")
 
@@ -420,25 +445,91 @@ class URLBuildcacheEntry:
 
         return True
 
+    def _fetch_detached_sig(self, fprs: List[str]) -> Optional[BlobRecord]
+        if not self.spec:
+            raise BuildcacheEntryError("A spec is required to read a manifests for spec signatures")
+
+        # Try to read the manifests for the known public keys
+        for fingerprint in fprs:
+            sig_manifest_url = URLBuildcacheEntry.get_sig_manifest_url(, self.mirror_url)
+            try:
+                # Read the signature (signatures are never signed)
+                manifest = URLBuildcacheEntry.read_manifest_from_url(sig_manifest_url, verify=False)
+                sig = manifest.get_blob_records(self.component_to_media_type(BuildcacheComponent.SIG))
+
+                # Skip records with signatures we don't understand
+                if not sig:
+                    tty.error(f"Found empty signature manifest: {self.spec.dag_hash}@{fpr}")
+                    continue
+
+                tty.debug(f"Found signature {self.spec.dag_hash}@{fpr}")
+                return sig
+
+            except BuildcacheEntryError:
+                continue
+
+        return None
+
     @classmethod
     def verify_and_extract_manifest(cls, manifest_contents: str, verify: bool = False) -> dict:
         """Possibly verify clearsig, then extract contents and return as json"""
-        if spack.util.gpg.is_clearsig(manifest_contents):
-            if verify:
+        # Cache the manifest on disc if we are going to verify
+        if verify:
+            manifest_path = os.path.join(tmpdir, "manifest.json.sig")
+            # Try to verify and raise if we fail
+            with TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpdir:
+                # Cache the contents for use with GPG
+                with open(manifest_path, "w", encoding="utf-8") as fd:
+                    fd.write(manifest_contents)
+
+                # If the manifest isn't cleartext signed, look for detached signatures
+                signature = None
+                if spack.util.gpg.is_clearsig(manifest_contents):
+                    # TODO: Have better control over the signatures to search
+                    fprs = spack.util.gpg.public_keys()
+                    detached_sigs = self._fetch_detached_sig(manifest_contents)
+                    if not detached_sigs:
+                        raise NoVerifyException("No signature found for verification")
+
+                    signature = self.fetch_blob(detached_sigs)
+
                 # Try to verify and raise if we fail
-                with TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpdir:
-                    manifest_path = os.path.join(tmpdir, "manifest.json.sig")
-                    with open(manifest_path, "w", encoding="utf-8") as fd:
-                        fd.write(manifest_contents)
-                    if not try_verify(manifest_path):
-                        raise NoVerifyException("Signature could not be verified")
+                if not try_verify(manifest_path, signature):
+                    raise NoVerifyException("Signature could not be verified")
 
-            return spack.util.gpg.extract_json_from_clearsig(manifest_contents)
-        elif verify:
-            raise NoVerifyException("Required signature was not found on manifest")
-        return json.loads(manifest_contents)
+        # Return the manifest contents
+        if spack.util.gpg.is_clearsig(manifest_contents):
+            return spack.spec.Spec.extract_json_from_clearsig(manifest_contents)
+        else:
+            return json.loads(manifest_contents)
 
-    def read_manifest(self, manifest_url: Optional[str] = None) -> BuildcacheManifest:
+    @classmethod
+    def read_manifest_from_url(self, manifest_url: str, verify: Optional[bool] = None) -> BuildcacheManifest:
+        """Read and process the the buildcache entry manifest."""
+        manifest = None
+        manifest_contents = ""
+
+        try:
+            manifest_contents = web_util.read_text(manifest_url)
+        except (web_util.SpackWebError, OSError) as e:
+            raise BuildcacheEntryError(f"Error reading manifest at {manifest_url}") from e
+
+        if not manifest_contents:
+            raise BuildcacheEntryError("Unable to read manifest or manifest empty")
+
+        verify = verify if verify is not None else not self.allow_unsigned
+        manifest_contents = cls.verify_and_extract_manifest(
+            manifest_contents, verify=verify
+        )
+
+        manifest = BuildcacheManifest.from_dict(manifest_contents)
+
+        if manifest.version != 3:
+            raise BuildcacheEntryError("Layout version mismatch in fetched manifest")
+
+        return manifest
+
+    def read_manifest(self, manifest_url: Optional[str] = None, verify: Optional[bool] = None) -> BuildcacheManifest:
         """Read and process the the buildcache entry manifest.
 
         If no manifest url is provided, build the url from the internal spec and
@@ -463,23 +554,7 @@ class URLBuildcacheEntry:
         self.remote_manifest_url = manifest_url
         manifest_contents = ""
 
-        try:
-            manifest_contents = web_util.read_text(manifest_url)
-        except (web_util.SpackWebError, OSError) as e:
-            raise BuildcacheEntryError(f"Error reading manifest at {manifest_url}") from e
-
-        if not manifest_contents:
-            raise BuildcacheEntryError("Unable to read manifest or manifest empty")
-
-        manifest_contents = self.verify_and_extract_manifest(
-            manifest_contents, verify=not self.allow_unsigned
-        )
-
-        self.manifest = BuildcacheManifest.from_dict(manifest_contents)
-
-        if self.manifest.version != 3:
-            raise BuildcacheEntryError("Layout version mismatch in fetched manifest")
-
+        self.manifest = self.read_manifest_from_url(manifest_url, verify)
         return self.manifest
 
     def fetch_metadata(self) -> dict:
@@ -752,6 +827,7 @@ class URLBuildcacheEntryV2(URLBuildcacheEntry):
         BuildcacheComponent.INDEX: ["build_cache"],
         BuildcacheComponent.KEY: ["build_cache", "_pgp"],
         BuildcacheComponent.SPEC: ["build_cache"],
+        BuildcacheComponent.SIG: ["build_cache"],
         BuildcacheComponent.KEY_INDEX: ["build_cache", "_pgp"],
         BuildcacheComponent.TARBALL: ["build_cache"],
         BuildcacheComponent.LAYOUT_JSON: ["build_cache", "layout.json"],
@@ -1330,7 +1406,7 @@ def sign_file(key: str, file_path: str) -> str:
     return signed_file_path
 
 
-def try_verify(specfile_path):
+def try_verify(specfile_path, sigfile=None):
     """Utility function to attempt to verify a local file.  Assumes the
     file is a clearsigned signature file.
 
@@ -1343,7 +1419,10 @@ def try_verify(specfile_path):
     suppress = config.get("config:suppress_gpg_warnings", False)
 
     try:
-        spack.util.gpg.verify(specfile_path, suppress_warnings=suppress)
+        if sigfile:
+            spack.util.gpg.verify(sigfile, file=specfile_path, suppress_warnings=suppress)
+        else:
+            spack.util.gpg.verify(specfile_path, suppress_warnings=suppress)
     except Exception:
         return False
 

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -14,8 +14,8 @@ import urllib.parse
 from contextlib import closing, contextmanager
 from datetime import datetime
 from pathlib import Path
-from tempfile import TemporaryDirectory
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
+from tempfile import TemporaryDirectory, mkdtemp
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
 import spack.vendor.jsonschema
 
@@ -289,18 +289,19 @@ class URLBuildcacheEntry:
         )
 
     @classmethod
-    def get_sig_url_for_file(cls, file: str, fingerprint: str, mirror_url: str) -> str:
+    def get_sig_url_for_file(cls, file: str, mirror_url: str) -> str:
         assert os.path.exists(file)
-        with open(file, "rb") as fd:
-            return cls.get_sig_url_for_content(fd.read(), fingerprint, mirror_url)
+        with open(file, "r", encoding="utf-8") as fd:
+            return cls.get_sig_url_for_content(fd.read(), mirror_url)
 
     @classmethod
-    def get_sig_url_for_content(cls, content: bytes, fingerprint: str, mirror_url: str) -> str:
-        digest = hashlib.sha256(content).hexdigest()
-        return cls.get_sig_url_for_digest(digest, fingerprint, mirror_url)
+    def get_sig_url_for_content(cls, content: str, mirror_url: str) -> str:
+        hasher = hash_fun_for_algo("sha256")()
+        hasher.update(content.encode())
+        return cls.get_sig_url_for_digest(hasher.hexdigest(), mirror_url)
 
     @classmethod
-    def get_sig_url_for_digest(cls, digest: str, fingerprint: str, mirror_url: str) -> str:
+    def get_sig_url_for_digest(cls, digest: str, mirror_url: str) -> str:
         path_components = cls.get_relative_path_components(BuildcacheComponent.SIG)
         return url_util.join(mirror_url, *path_components, digest[:2], digest + ".asc")
 
@@ -339,7 +340,7 @@ class URLBuildcacheEntry:
             return cls.PUBLIC_KEY_MEDIATYPE
         elif component == BuildcacheComponent.KEY_INDEX:
             return cls.PUBLIC_KEY_INDEX_MEDIATYPE
-        elif buildcache_component == BuildcacheComponent.SIG:
+        elif component == BuildcacheComponent.SIG:
             # TODO support for cosign
             return cls.PGP_SIGNATURE_MEDIATYPE
 
@@ -453,18 +454,22 @@ class URLBuildcacheEntry:
             manifest_contents, mirror_url
         )
         # Read the signature (signatures are never signed)
-        manifest = URLBuildcacheEntry.read_manifest_from_url(sig_manifest_url, verify=False)
+        manifest = URLBuildcacheEntry.read_manifest_from_url(
+            sig_manifest_url, mirror_url, verify=False
+        )
         sigs = manifest.get_blob_records(cls.component_to_media_type(BuildcacheComponent.SIG))
 
         # Skip records with signatures we don't understand
         if not sigs:
-            raise BuildcacheEntryError(f"Found empty signature manifest")
+            raise BuildcacheEntryError("Found empty signature manifest")
 
-        blob_url = cls.get_blob_url(mirror_url, detached_sigs[0])
+        blob_url = cls.get_blob_url(mirror_url, sigs[0])
         return web_util.read_text(blob_url)
 
     @classmethod
-    def read_manifest_from_url(cls, manifest_url: str, verify: bool = True) -> BuildcacheManifest:
+    def read_manifest_from_url(
+        cls, manifest_url: str, mirror_url: str, verify: bool = True
+    ) -> BuildcacheManifest:
         """Read and process the the buildcache entry manifest."""
         manifest = None
         manifest_contents = ""
@@ -497,9 +502,7 @@ class URLBuildcacheEntry:
 
         return manifest
 
-    def read_manifest(
-        self, manifest_url: Optional[str] = None, verify: Optional[bool] = None
-    ) -> BuildcacheManifest:
+    def read_manifest(self, manifest_url: Optional[str] = None) -> BuildcacheManifest:
         """Read and process the the buildcache entry manifest.
 
         If no manifest url is provided, build the url from the internal spec and
@@ -522,9 +525,9 @@ class URLBuildcacheEntry:
             manifest_url = self.get_manifest_url(self.spec, self.mirror_url)
 
         self.remote_manifest_url = manifest_url
-        manifest_contents = ""
-
-        self.manifest = self.read_manifest_from_url(manifest_url, verify)
+        self.manifest = self.read_manifest_from_url(
+            manifest_url, self.mirror_url, verify=not self.allow_unsigned
+        )
         return self.manifest
 
     def fetch_metadata(self) -> dict:
@@ -650,7 +653,7 @@ class URLBuildcacheEntry:
             with compression_writer(blob_to_push, compression, checksum_algo) as (
                 fout,
                 checker,
-            ), open(local_file_path, "rb") as fin:
+            ), open(local_file_path, "rb", encoding="utf-8") as fin:
                 shutil.copyfileobj(fin, fout)
 
             record = BlobRecord(
@@ -1386,22 +1389,22 @@ def try_verify(data: str, sig: Optional[str] = None):
 
     try:
         # Make a working directory for verification
-        tmppath = tempfile.mkdtemp(dir=spack.stage.get_stage_root())
+        tmppath = mkdtemp(dir=spack.stage.get_stage_root())
         if not os.path.exists(data):
             data_path = os.path.join(tmppath, "data.txt")
-            with open(data_path, "rb") as fd:
+            with open(data_path, "r", encoding="utf-8") as fd:
                 fd.write(data)
         else:
             data_path = data
 
-        if sig and not os.path.exists(sig):
-            sig_path = os.path.join(tmppath, "data.txt")
-            with open(sig_path, "rb") as fd:
-                fd.write(sig)
-        else:
-            sig_path = sig
+        if sig:
+            if not os.path.exists(sig):
+                sig_path = os.path.join(tmppath, "data.txt")
+                with open(sig_path, "r", encoding="utf-8") as fd:
+                    fd.write(sig)
+            else:
+                sig_path = sig
 
-        if sigfile:
             spack.util.gpg.verify(sig_path, file=data_path, suppress_warnings=suppress)
         else:
             spack.util.gpg.verify(data_path, suppress_warnings=suppress)

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -15,7 +15,7 @@ from contextlib import closing, contextmanager
 from datetime import datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 import spack.vendor.jsonschema
 
@@ -57,6 +57,8 @@ class BuildcacheComponent(enum.Enum):
     MANIFEST = enum.auto()
     # metadata file for a binary package
     SPEC = enum.auto()
+    # metadata file for a manifest signature
+    SIG = enum.auto()
     # things that live in the blobs directory
     BLOB = enum.auto()
     # binary mirror index
@@ -300,9 +302,7 @@ class URLBuildcacheEntry:
     @classmethod
     def get_sig_url_for_digest(cls, digest: str, fingerprint: str, mirror_url: str) -> str:
         path_components = cls.get_relative_path_components(BuildcacheComponent.SIG)
-        return url_util.join(
-            mirror_url, *path_components, digest[:2], digest + ".asc"
-        )
+        return url_util.join(mirror_url, *path_components, digest[:2], digest + ".asc")
 
     @classmethod
     def get_buildcache_component_include_pattern(
@@ -445,70 +445,31 @@ class URLBuildcacheEntry:
 
         return True
 
-    def _fetch_detached_sig(self, fprs: List[str]) -> Optional[BlobRecord]
-        if not self.spec:
-            raise BuildcacheEntryError("A spec is required to read a manifests for spec signatures")
-
+    @classmethod
+    def _fetch_detached_sig(cls, manifest_contents: str, mirror_url: str) -> str:
+        """Fetch the detached signature for a manifest"""
         # Try to read the manifests for the known public keys
-        for fingerprint in fprs:
-            sig_manifest_url = URLBuildcacheEntry.get_sig_manifest_url(, self.mirror_url)
-            try:
-                # Read the signature (signatures are never signed)
-                manifest = URLBuildcacheEntry.read_manifest_from_url(sig_manifest_url, verify=False)
-                sig = manifest.get_blob_records(self.component_to_media_type(BuildcacheComponent.SIG))
+        sig_manifest_url = URLBuildcacheEntry.get_sig_url_for_content(
+            manifest_contents, mirror_url
+        )
+        # Read the signature (signatures are never signed)
+        manifest = URLBuildcacheEntry.read_manifest_from_url(sig_manifest_url, verify=False)
+        sigs = manifest.get_blob_records(cls.component_to_media_type(BuildcacheComponent.SIG))
 
-                # Skip records with signatures we don't understand
-                if not sig:
-                    tty.error(f"Found empty signature manifest: {self.spec.dag_hash}@{fpr}")
-                    continue
+        # Skip records with signatures we don't understand
+        if not sigs:
+            raise BuildcacheEntryError(f"Found empty signature manifest")
 
-                tty.debug(f"Found signature {self.spec.dag_hash}@{fpr}")
-                return sig
-
-            except BuildcacheEntryError:
-                continue
-
-        return None
+        blob_url = cls.get_blob_url(mirror_url, detached_sigs[0])
+        return web_util.read_text(blob_url)
 
     @classmethod
-    def verify_and_extract_manifest(cls, manifest_contents: str, verify: bool = False) -> dict:
-        """Possibly verify clearsig, then extract contents and return as json"""
-        # Cache the manifest on disc if we are going to verify
-        if verify:
-            manifest_path = os.path.join(tmpdir, "manifest.json.sig")
-            # Try to verify and raise if we fail
-            with TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpdir:
-                # Cache the contents for use with GPG
-                with open(manifest_path, "w", encoding="utf-8") as fd:
-                    fd.write(manifest_contents)
-
-                # If the manifest isn't cleartext signed, look for detached signatures
-                signature = None
-                if spack.util.gpg.is_clearsig(manifest_contents):
-                    # TODO: Have better control over the signatures to search
-                    fprs = spack.util.gpg.public_keys()
-                    detached_sigs = self._fetch_detached_sig(manifest_contents)
-                    if not detached_sigs:
-                        raise NoVerifyException("No signature found for verification")
-
-                    signature = self.fetch_blob(detached_sigs)
-
-                # Try to verify and raise if we fail
-                if not try_verify(manifest_path, signature):
-                    raise NoVerifyException("Signature could not be verified")
-
-        # Return the manifest contents
-        if spack.util.gpg.is_clearsig(manifest_contents):
-            return spack.spec.Spec.extract_json_from_clearsig(manifest_contents)
-        else:
-            return json.loads(manifest_contents)
-
-    @classmethod
-    def read_manifest_from_url(self, manifest_url: str, verify: Optional[bool] = None) -> BuildcacheManifest:
+    def read_manifest_from_url(cls, manifest_url: str, verify: bool = True) -> BuildcacheManifest:
         """Read and process the the buildcache entry manifest."""
         manifest = None
         manifest_contents = ""
 
+        # Read the manifest and cache it in the tmpdir for verify
         try:
             manifest_contents = web_util.read_text(manifest_url)
         except (web_util.SpackWebError, OSError) as e:
@@ -517,11 +478,18 @@ class URLBuildcacheEntry:
         if not manifest_contents:
             raise BuildcacheEntryError("Unable to read manifest or manifest empty")
 
-        verify = verify if verify is not None else not self.allow_unsigned
-        manifest_contents = cls.verify_and_extract_manifest(
-            manifest_contents, verify=verify
-        )
+        if verify:
+            # If the manifest isn't cleartext signed, look for detached signatures
+            signature = None
+            if not spack.util.gpg.is_clearsig(manifest_contents):
+                signature = cls._fetch_detached_sig(manifest_contents, mirror_url)
 
+            # Try to verify and raise if we fail
+            if not try_verify(manifest_contents, signature):
+                raise NoVerifyException("Signature could not be verified")
+
+        # Extract the contents of the manifest
+        manifest_contents = spack.util.gpg.extract_json_from_clearsig(manifest_contents)
         manifest = BuildcacheManifest.from_dict(manifest_contents)
 
         if manifest.version != 3:
@@ -529,7 +497,9 @@ class URLBuildcacheEntry:
 
         return manifest
 
-    def read_manifest(self, manifest_url: Optional[str] = None, verify: Optional[bool] = None) -> BuildcacheManifest:
+    def read_manifest(
+        self, manifest_url: Optional[str] = None, verify: Optional[bool] = None
+    ) -> BuildcacheManifest:
         """Read and process the the buildcache entry manifest.
 
         If no manifest url is provided, build the url from the internal spec and
@@ -1075,10 +1045,6 @@ class URLBuildcacheEntryV2(URLBuildcacheEntry):
         raise BuildcacheEntryError("v2 buildcache layout is unaware of manifests and blobs")
 
     @classmethod
-    def verify_and_extract_manifest(cls, manifest_contents: str, verify: bool = False) -> dict:
-        raise BuildcacheEntryError("v2 buildcache entries do not have a manifest file")
-
-    @classmethod
     def push_blob(cls, mirror_url: str, blob_path: str, record: BlobRecord) -> None:
         raise BuildcacheEntryError("v2 buildcache layout is unaware of manifests and blobs")
 
@@ -1406,7 +1372,7 @@ def sign_file(key: str, file_path: str) -> str:
     return signed_file_path
 
 
-def try_verify(specfile_path, sigfile=None):
+def try_verify(data: str, sig: Optional[str] = None):
     """Utility function to attempt to verify a local file.  Assumes the
     file is a clearsigned signature file.
 
@@ -1419,14 +1385,33 @@ def try_verify(specfile_path, sigfile=None):
     suppress = config.get("config:suppress_gpg_warnings", False)
 
     try:
-        if sigfile:
-            spack.util.gpg.verify(sigfile, file=specfile_path, suppress_warnings=suppress)
+        # Make a working directory for verification
+        tmppath = tempfile.mkdtemp(dir=spack.stage.get_stage_root())
+        if not os.path.exists(data):
+            data_path = os.path.join(tmppath, "data.txt")
+            with open(data_path, "rb") as fd:
+                fd.write(data)
         else:
-            spack.util.gpg.verify(specfile_path, suppress_warnings=suppress)
+            data_path = data
+
+        if sig and not os.path.exists(sig):
+            sig_path = os.path.join(tmppath, "data.txt")
+            with open(sig_path, "rb") as fd:
+                fd.write(sig)
+        else:
+            sig_path = sig
+
+        if sigfile:
+            spack.util.gpg.verify(sig_path, file=data_path, suppress_warnings=suppress)
+        else:
+            spack.util.gpg.verify(data_path, suppress_warnings=suppress)
     except Exception:
         return False
+    finally:
+        # Cleanup workdir
+        shutil.rmtree(tmppath)
 
-    return True
+        return True
 
 
 class MirrorMetadata:

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -19,7 +19,6 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
 import spack.vendor.jsonschema
 
-import spack.config as config
 import spack.database
 import spack.error
 import spack.hash_types as ht
@@ -614,13 +613,13 @@ class URLBuildcacheEntry:
         """Given a BuildcacheManifest, push it to the mirror using the given manifest
         name.  The component_type is used to indicate what type of thing the manifest
         represents, so it can be placed in the correct relative path within the mirror.
-        If a signing_key is provided, it will be used to clearsign the manifest before
+        If a notary is provided, it will be used to clearsign the manifest before
         pushing it."""
         # write the manifest to a temporary location
         manifest_file_name = f"{manifest_name}.manifest.json"
-        manifest_path = os.path.join(tmpdir, manifest_file_name)
-        os.makedirs(os.path.dirname(manifest_path), exist_ok=True)
-        with open(manifest_path, "w", encoding="utf-8") as f:
+        manifest_path = Path(os.path.join(tmpdir, manifest_file_name))
+        manifest_path.parent.mkdir(exist_ok=True)
+        with manifest_path.open("w", encoding="utf-8") as f:
             json.dump(manifest.to_dict(), f, indent=0, separators=(",", ":"))
             # Note: when using gpg clear sign, we need to avoid long lines (19995
             # chars). If lines are longer, they are truncated without error. So,
@@ -634,8 +633,10 @@ class URLBuildcacheEntry:
             mirror_url, *cls.get_relative_path_components(component_type), manifest_file_name
         )
 
-        web_util.push_to_url(manifest_path, manifest_destination_url, keep_original=False)
-        web_util.push_to_url()
+        web_util.push_to_url(str(manifest_path), manifest_destination_url, keep_original=False)
+        if manifest_path != signature_path:
+            sig_destination_url = cls.get_sig_url_for_file(str(manifest_path), mirror_url)
+            web_util.push_to_url(str(signature_path), sig_destination_url, keep_original=False)
 
     @classmethod
     def push_local_file_as_blob(
@@ -685,7 +686,7 @@ class URLBuildcacheEntry:
         checksum_algorithm: str,
         tarball_checksum: str,
         tmpdir: str,
-        signing_key: Optional[Notary],
+        notary: Optional[Notary],
     ) -> None:
         """Convenience method to push tarball, specfile, and manifest to the remote mirror
 
@@ -765,8 +766,8 @@ class URLBuildcacheEntry:
         }
 
         # write the manifest to a temporary location
-        manifest_path = os.path.join(tmpdir, f"{spec.dag_hash()}.manifest.json")
-        with open(manifest_path, "w", encoding="utf-8") as f:
+        manifest_path = Path(os.path.join(tmpdir, f"{spec.dag_hash()}.manifest.json"))
+        with manifest_path.open("w", encoding="utf-8") as f:
             json.dump(manifest, f, indent=0, separators=(",", ":"))
             # Note: when using gpg clear sign, we need to avoid long lines (19995
             # chars). If lines are longer, they are truncated without error. So,
@@ -774,18 +775,17 @@ class URLBuildcacheEntry:
             # line length.
 
         # possibly sign the manifest
-        if signing_key:
-            signature_path, manifest_path = signing_key.sign(manifest_path)
+        if notary:
+            signature_path, manifest_path = notary.sign(manifest_path)
 
         # Push the manifest file to the remote. The remote manifest url for
         # a given concrete spec is fixed, so we don't have to recompute it,
         # even if we deleted the pre-existing one.
         web_util.push_to_url(manifest_path, self.remote_manifest_url, keep_original=False)
-        if signature_path != manifest_path:
+        if manifest_path != signature_path:
             # This is a detached style signature, upload as a sig
-            web_util.push_to_url(
-                signature_path, self.signature_url_from_path(manifest_path), keeep_original=False
-            )
+            sig_destination_url = self.get_sig_url_for_file(str(manifest_path), self.mirror_url)
+            web_util.push_to_url(signature_path, sig_destination_url, keep_original=False)
 
     def destroy(self):
         """Destroy any existing stages"""
@@ -948,7 +948,7 @@ class URLBuildcacheEntryV2(URLBuildcacheEntry):
 
         self.local_specfile_path = self.spec_stage.save_filename
 
-        if not self.notary and not try_verify(self.notary, self.local_specfile_path):
+        if self.notary and not try_verify(self.notary, self.local_specfile_path):
             raise NoVerifyException(f"Signature on {self.remote_spec_url} could not be verified")
 
         # Check spec file for validity and read it, or else cleanup and exit early
@@ -1071,7 +1071,7 @@ class URLBuildcacheEntryV2(URLBuildcacheEntry):
         manifest: BuildcacheManifest,
         tmpdir: str,
         component_type: BuildcacheComponent = BuildcacheComponent.SPEC,
-        signing_key: Optional[str] = None,
+        notary: Optional[Notary] = None,
     ) -> None:
         raise BuildcacheEntryError("v2 buildcache layout is unaware of manifests and blobs")
 
@@ -1093,7 +1093,7 @@ class URLBuildcacheEntryV2(URLBuildcacheEntry):
         checksum_algorithm: str,
         tarball_checksum: str,
         tmpdir: str,
-        signing_key: Optional[str],
+        notary: Optional[Notary] = None,
     ) -> None:
         raise BuildcacheEntryError("Spack can no longer push v2 buildcache entries")
 
@@ -1390,8 +1390,6 @@ def try_verify(notary: Notary, data: str, sig: Optional[str] = None):
     Returns:
         ``True`` if the signature could be verified, ``False`` otherwise.
     """
-    suppress = config.get("config:suppress_gpg_warnings", False)
-
     try:
         # Make a working directory for verification
         tmppath = mkdtemp(dir=spack.stage.get_stage_root())
@@ -1410,9 +1408,9 @@ def try_verify(notary: Notary, data: str, sig: Optional[str] = None):
             else:
                 sig_path = sig
 
-            valid, _ = notary.verify(sig_path, file=data_path, suppress_warnings=suppress)
+            valid = notary.verify(data_path, sig_path)
         else:
-            valid, _ = notary.verify(data_path, suppress_warnings=suppress)
+            valid = notary.verify(data_path)
 
         return valid
     except Exception:

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -32,6 +32,7 @@ import spack.util.crypto
 import spack.util.gpg
 import spack.util.url as url_util
 import spack.util.web as web_util
+from spack.notary import Notary
 from spack.schema.url_buildcache_manifest import schema as buildcache_manifest_schema
 from spack.util.archive import ChecksumWriter
 from spack.util.crypto import hash_fun_for_algo
@@ -208,12 +209,15 @@ class URLBuildcacheEntry:
     }
 
     def __init__(
-        self, mirror_url: str, spec: Optional[spack.spec.Spec] = None, allow_unsigned: bool = False
+        self,
+        mirror_url: str,
+        spec: Optional[spack.spec.Spec] = None,
+        notary: Optional[Notary] = None,
     ):
         """Lazily initialize the object"""
         self.mirror_url: str = mirror_url
         self.spec: Optional[spack.spec.Spec] = spec
-        self.allow_unsigned: bool = allow_unsigned
+        self.notary = notary
         self.manifest: Optional[BuildcacheManifest] = None
         self.remote_manifest_url: str = ""
         self.stages: Dict[BlobRecord, spack.stage.Stage] = {}
@@ -455,7 +459,7 @@ class URLBuildcacheEntry:
         )
         # Read the signature (signatures are never signed)
         manifest = URLBuildcacheEntry.read_manifest_from_url(
-            sig_manifest_url, mirror_url, verify=False
+            sig_manifest_url, mirror_url, notary=None
         )
         sigs = manifest.get_blob_records(cls.component_to_media_type(BuildcacheComponent.SIG))
 
@@ -468,7 +472,7 @@ class URLBuildcacheEntry:
 
     @classmethod
     def read_manifest_from_url(
-        cls, manifest_url: str, mirror_url: str, verify: bool = True
+        cls, manifest_url: str, mirror_url: str, notary: Optional[Notary] = None
     ) -> BuildcacheManifest:
         """Read and process the the buildcache entry manifest."""
         manifest = None
@@ -483,14 +487,14 @@ class URLBuildcacheEntry:
         if not manifest_contents:
             raise BuildcacheEntryError("Unable to read manifest or manifest empty")
 
-        if verify:
+        if notary:
             # If the manifest isn't cleartext signed, look for detached signatures
             signature = None
             if not spack.util.gpg.is_clearsig(manifest_contents):
                 signature = cls._fetch_detached_sig(manifest_contents, mirror_url)
 
             # Try to verify and raise if we fail
-            if not try_verify(manifest_contents, signature):
+            if not try_verify(notary, manifest_contents, signature):
                 raise NoVerifyException("Signature could not be verified")
 
         # Extract the contents of the manifest
@@ -526,7 +530,7 @@ class URLBuildcacheEntry:
 
         self.remote_manifest_url = manifest_url
         self.manifest = self.read_manifest_from_url(
-            manifest_url, self.mirror_url, verify=not self.allow_unsigned
+            manifest_url, self.mirror_url, notary=self.notary
         )
         return self.manifest
 
@@ -622,13 +626,16 @@ class URLBuildcacheEntry:
             # line length.
 
         if signing_key:
-            manifest_path = sign_file(signing_key, manifest_path)
+            manifest_path, signature_path = sign_file(
+                signing_key, manifest_path, sigtype=self.sigtype
+            )
 
         manifest_destination_url = url_util.join(
             mirror_url, *cls.get_relative_path_components(component_type), manifest_file_name
         )
 
         web_util.push_to_url(manifest_path, manifest_destination_url, keep_original=False)
+        web_util.push_to_url()
 
     @classmethod
     def push_local_file_as_blob(
@@ -678,7 +685,7 @@ class URLBuildcacheEntry:
         checksum_algorithm: str,
         tarball_checksum: str,
         tmpdir: str,
-        signing_key: Optional[str],
+        signing_key: Optional[Notary],
     ) -> None:
         """Convenience method to push tarball, specfile, and manifest to the remote mirror
 
@@ -768,12 +775,17 @@ class URLBuildcacheEntry:
 
         # possibly sign the manifest
         if signing_key:
-            manifest_path = sign_file(signing_key, manifest_path)
+            signature_path, manifest_path = signing_key.sign(manifest_path)
 
         # Push the manifest file to the remote. The remote manifest url for
         # a given concrete spec is fixed, so we don't have to recompute it,
         # even if we deleted the pre-existing one.
-        web_util.push_to_url(manifest_path, self.remote_manifest_url, keep_original=False)
+        web_util.push_to_url(manifest_path, self.remote_manifest_url, keep_original=Falseb)
+        if signature_path != manifest_path:
+            # This is a detached style signature, upload as a sig
+            web_util.push_to_url(
+                signature_path, self.signature_url_from_path(manifest_path), keeep_original=False
+            )
 
     def destroy(self):
         """Destroy any existing stages"""
@@ -810,12 +822,12 @@ class URLBuildcacheEntryV2(URLBuildcacheEntry):
         self,
         push_url_base: str,
         spec: Optional[spack.spec.Spec] = None,
-        allow_unsigned: bool = False,
+        notary: Optional[Notary] = None,
     ):
         """Lazily initialize the object"""
         self.mirror_url: str = push_url_base
         self.spec: Optional[spack.spec.Spec] = spec
-        self.allow_unsigned: bool = allow_unsigned
+        self.notary: bool = notary
 
         self.has_metadata: bool = False
         self.has_tarball: bool = False
@@ -917,7 +929,7 @@ class URLBuildcacheEntryV2(URLBuildcacheEntry):
         if not self.remote_spec_url:
             raise BuildcacheEntryError(f"Mirror {self.mirror_url} does not have metadata for spec")
 
-        if not self.allow_unsigned and self.has_unsigned:
+        if not self.notary and self.has_unsigned:
             raise BuildcacheEntryError(
                 f"Mirror {self.mirror_url} does not have signed metadata for spec"
             )
@@ -936,7 +948,7 @@ class URLBuildcacheEntryV2(URLBuildcacheEntry):
 
         self.local_specfile_path = self.spec_stage.save_filename
 
-        if not self.allow_unsigned and not try_verify(self.local_specfile_path):
+        if not self.notary and not try_verify(self.notary, self.local_specfile_path):
             raise NoVerifyException(f"Signature on {self.remote_spec_url} could not be verified")
 
         # Check spec file for validity and read it, or else cleanup and exit early
@@ -1146,7 +1158,7 @@ def _entries_from_cache_aws_cli(url: str, tmpspecsdir: str, component_type: Buil
         return file_list, read_fn
 
     def file_read_method(manifest_path: str) -> URLBuildcacheEntry:
-        cache_entry = cache_class(mirror_url=url, allow_unsigned=True)
+        cache_entry = cache_class(mirror_url=url, notary=None)
         cache_entry.read_manifest(manifest_url=manifest_path)
         return cache_entry
 
@@ -1223,7 +1235,7 @@ def _entries_from_cache_fallback(url: str, tmpspecsdir: str, component_type: Bui
     cache_class = get_url_buildcache_class(layout_version=CURRENT_BUILD_CACHE_LAYOUT_VERSION)
 
     def url_read_method(manifest_url: str) -> URLBuildcacheEntry:
-        cache_entry = cache_class(mirror_url=url, allow_unsigned=True)
+        cache_entry = cache_class(mirror_url=url, notary=None)
         cache_entry.read_manifest(manifest_url)
         return cache_entry
 
@@ -1368,16 +1380,9 @@ def get_valid_spec_file(path: str, max_supported_layout: int) -> Tuple[Dict, int
     return spec_dict, layout_version
 
 
-def sign_file(key: str, file_path: str) -> str:
-    """sign and return the path to the signed file"""
-    signed_file_path = f"{file_path}.sig"
-    spack.util.gpg.sign(key, file_path, signed_file_path, clearsign=True)
-    return signed_file_path
-
-
-def try_verify(data: str, sig: Optional[str] = None):
-    """Utility function to attempt to verify a local file.  Assumes the
-    file is a clearsigned signature file.
+def try_verify(notary: Notary, data: str, sig: Optional[str] = None):
+    """Utility function to attempt to verify a local file. Handles translating
+    in memory data to on disc layout needed by the notary
 
     Args:
         specfile_path (str): Path to file to be verified.
@@ -1405,9 +1410,11 @@ def try_verify(data: str, sig: Optional[str] = None):
             else:
                 sig_path = sig
 
-            spack.util.gpg.verify(sig_path, file=data_path, suppress_warnings=suppress)
+            valid, _ = notary.verify(sig_path, file=data_path, suppress_warnings=suppress)
         else:
-            spack.util.gpg.verify(data_path, suppress_warnings=suppress)
+            valid, _ = notary.verify(data_path, suppress_warnings=suppress)
+
+        return valid
     except Exception:
         return False
     finally:

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -472,7 +472,7 @@ class URLBuildcacheEntry:
 
     @classmethod
     def read_manifest_from_url(
-        cls, manifest_url: str, mirror_url: str, notary: Optional[Notary] = None
+        cls, manifest_url: str, mirror_url: str, notary: Optional[Notary]
     ) -> BuildcacheManifest:
         """Read and process the the buildcache entry manifest."""
         manifest = None
@@ -487,7 +487,9 @@ class URLBuildcacheEntry:
         if not manifest_contents:
             raise BuildcacheEntryError("Unable to read manifest or manifest empty")
 
-        if notary:
+        # If this notary is capable of validation try to very the signature
+        # is_validating checked here to avoid trying to fetch detached signatures
+        if notary and notary.is_validating:
             # If the manifest isn't cleartext signed, look for detached signatures
             signature = None
             if not spack.util.gpg.is_clearsig(manifest_contents):
@@ -607,7 +609,7 @@ class URLBuildcacheEntry:
         manifest: BuildcacheManifest,
         tmpdir: str,
         component_type: BuildcacheComponent = BuildcacheComponent.SPEC,
-        signing_key: Optional[str] = None,
+        notary: Optional[Notary] = None,
     ) -> None:
         """Given a BuildcacheManifest, push it to the mirror using the given manifest
         name.  The component_type is used to indicate what type of thing the manifest
@@ -625,10 +627,8 @@ class URLBuildcacheEntry:
             # here we still add newlines, but no indent, so save on file size and
             # line length.
 
-        if signing_key:
-            manifest_path, signature_path = sign_file(
-                signing_key, manifest_path, sigtype=self.sigtype
-            )
+        if notary:
+            manifest_path, signature_path = notary.sign(manifest_path)
 
         manifest_destination_url = url_util.join(
             mirror_url, *cls.get_relative_path_components(component_type), manifest_file_name
@@ -780,7 +780,7 @@ class URLBuildcacheEntry:
         # Push the manifest file to the remote. The remote manifest url for
         # a given concrete spec is fixed, so we don't have to recompute it,
         # even if we deleted the pre-existing one.
-        web_util.push_to_url(manifest_path, self.remote_manifest_url, keep_original=Falseb)
+        web_util.push_to_url(manifest_path, self.remote_manifest_url, keep_original=False)
         if signature_path != manifest_path:
             # This is a detached style signature, upload as a sig
             web_util.push_to_url(
@@ -827,7 +827,7 @@ class URLBuildcacheEntryV2(URLBuildcacheEntry):
         """Lazily initialize the object"""
         self.mirror_url: str = push_url_base
         self.spec: Optional[spack.spec.Spec] = spec
-        self.notary: bool = notary
+        self.notary: Optional[Notary] = notary
 
         self.has_metadata: bool = False
         self.has_tarball: bool = False

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -1396,15 +1396,15 @@ def try_verify(notary: Notary, data: str, sig: Optional[str] = None):
         tmppath = mkdtemp(dir=spack.stage.get_stage_root())
         if not os.path.exists(data):
             data_path = os.path.join(tmppath, "data.txt")
-            with open(data_path, "r", encoding="utf-8") as fd:
+            with open(data_path, "w", encoding="utf-8") as fd:
                 fd.write(data)
         else:
             data_path = data
 
         if sig:
             if not os.path.exists(sig):
-                sig_path = os.path.join(tmppath, "data.txt")
-                with open(sig_path, "r", encoding="utf-8") as fd:
+                sig_path = os.path.join(tmppath, "sig.txt")
+                with open(sig_path, "w", encoding="utf-8") as fd:
                     fd.write(sig)
             else:
                 sig_path = sig

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -625,7 +625,7 @@ class URLBuildcacheEntry:
             # chars). If lines are longer, they are truncated without error. So,
             # here we still add newlines, but no indent, so save on file size and
             # line length.
-
+        signature_path = manifest_path
         if notary:
             manifest_path, signature_path = notary.sign(manifest_path)
 
@@ -775,8 +775,9 @@ class URLBuildcacheEntry:
             # line length.
 
         # possibly sign the manifest
+        signature_path = manifest_path
         if notary:
-            signature_path, manifest_path = notary.sign(manifest_path)
+            manifest_path, signature_path = notary.sign(manifest_path)
 
         # Push the manifest file to the remote. The remote manifest url for
         # a given concrete spec is fixed, so we don't have to recompute it,
@@ -1418,8 +1419,6 @@ def try_verify(notary: Notary, data: str, sig: Optional[str] = None):
     finally:
         # Cleanup workdir
         shutil.rmtree(tmppath)
-
-        return True
 
 
 class MirrorMetadata:

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -660,7 +660,7 @@ class URLBuildcacheEntry:
             with compression_writer(blob_to_push, compression, checksum_algo) as (
                 fout,
                 checker,
-            ), open(local_file_path, "rb", encoding="utf-8") as fin:
+            ), open(local_file_path, "rb") as fin:
                 shutil.copyfileobj(fin, fout)
 
             record = BlobRecord(

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -24,6 +24,9 @@ SOCKET_DIR = None
 #: GNUPGHOME environment variable in the context of this Python module
 GNUPGHOME = None
 
+CLEARSIGN = "clearsign"
+DETACHED_SIG = "detached"
+
 #: Regular expression to pull spec contents out of clearsigned signature
 #: file.
 CLEARSIGN_FILE_REGEX = re.compile(

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -2,8 +2,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import contextlib
+import enum
 import errno
 import functools
+import json
 import os
 import re
 from typing import Any, Dict, List
@@ -24,8 +26,10 @@ SOCKET_DIR = None
 #: GNUPGHOME environment variable in the context of this Python module
 GNUPGHOME = None
 
-CLEARSIGN = "clearsign"
-DETACHED_SIG = "detached"
+
+class Signature(enum.Enum):
+    Cleartext = enum.auto()
+    Detached = enum.auto()
 
 #: Regular expression to pull spec contents out of clearsigned signature
 #: file.
@@ -76,15 +80,22 @@ CLEARSIGN_FILE_REGEX = re.compile(
 )
 
 
+def is_clearsig(data) -> bool:
+    """Check if data is wrapped in a cleartext signature"""
+    magic_string = "-----BEGIN PGP SIGNED MESSAGE-----"
+    return data.startswith(magic_string)
+
+
 def extract_message_from_clearsig(data) -> str:
+    """Extract a message from a cleartext signature"""
     m = CLEARSIGN_FILE_REGEX.search(data)
     if m:
         return m.group(1)
     return data
 
 
-def extract_json_from_clearsig(data) -> str:
-    import json
+def extract_json_from_clearsig(data) -> Dict[Any, Any]:
+    """Extract a message as json from a cleartext signature"""
     return json.loads(extract_message_from_clearsig(data))
 
 

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -65,6 +65,29 @@ def clear():
     GPG, GPGCONF, SOCKET_DIR, GNUPGHOME = None, None, None, None
 
 
+#: Regular expression to pull spec contents out of clearsigned signature
+#: file.
+CLEARSIGN_FILE_REGEX = re.compile(
+    (
+        r"^-----BEGIN PGP SIGNED MESSAGE-----"
+        r"\s+Hash:\s+[^\s]+\s+(.+)-----BEGIN PGP SIGNATURE-----"
+    ),
+    re.MULTILINE | re.DOTALL,
+)
+
+
+def extract_message_from_clearsig(data) -> str:
+    m = CLEARSIGN_FILE_REGEX.search(data)
+    if m:
+        return m.group(1)
+    return data
+
+
+def extract_json_from_clearsig(data) -> str:
+    import json
+    return json.loads(extract_message_from_clearsig(data))
+
+
 def init(gnupghome=None, force=False):
     """Initialize the global objects in the module, if not set.
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Allow signing spec.json files using a detached key. This allows uploading the signature as a separate artifact to build caches which may be fetched when required.