### PR TITLE
Basic attempt to force msmpi over intel

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -320,7 +320,7 @@ class CMakeBuilder(BaseBuilder):
     #: Callback names for build-time test
     build_time_test_callbacks = ["check"]
 
-    dependency_args = []
+    dependency_args: List[str] = []
 
     @property
     def archive_files(self):

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -320,7 +320,9 @@ class CMakeBuilder(BaseBuilder):
     #: Callback names for build-time test
     build_time_test_callbacks = ["check"]
 
-    dependency_args: List[str] = []
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.dependency_args = []
 
     @property
     def archive_files(self):
@@ -358,7 +360,7 @@ class CMakeBuilder(BaseBuilder):
         return args
 
     @staticmethod
-    def setup_dependent_cmake_package(module, dependent_spec, *propagated_args):
+    def setup_dependent_cmake_package(dependent_spec, *propagated_args):
         """Helper method to propagate required CMake cache definitions to dependent
         packages"""
         if dependent_spec.satisfies("build_system=cmake"):

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -356,6 +356,18 @@ class CMakeBuilder(BaseBuilder):
         return args
 
     @staticmethod
+    def setup_dependent_cmake_package(module, dependent_spec, *propegated_args):
+        """Helper method to propegate required CMake cache definitions to dependent
+        packages"""
+        if CMakeBuilder in type(dependent_spec.package.builder).__mro__:
+            dependent_std_args_stub = type(dependent_spec.package.builder).cmake_args
+
+            def new_cmake_args(self):
+                return propegated_args + dependent_std_args_stub(self)
+
+            type(dependent_spec.package.builder).cmake_args = new_cmake_args
+
+    @staticmethod
     def std_args(pkg, generator=None):
         """Computes the standard cmake arguments for a generic package"""
         default_generator = "Ninja" if sys.platform == "win32" else "Unix Makefiles"
@@ -549,13 +561,6 @@ class CMakeBuilder(BaseBuilder):
     def build_directory(self):
         """Full-path to the directory to use when building the package."""
         return os.path.join(self.pkg.stage.path, self.build_dirname)
-
-
-    def setup_dependent_cmake_args(self, module, dependent_spec):
-        base_args = dependent_spec.pkg.cmake_args()
-
-
-
 
     def cmake_args(self):
         """List of all the arguments that must be passed to cmake, except:

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -358,11 +358,11 @@ class CMakeBuilder(BaseBuilder):
         return args
 
     @staticmethod
-    def setup_dependent_cmake_package(module, dependent_spec, *propegated_args):
-        """Helper method to propegate required CMake cache definitions to dependent
+    def setup_dependent_cmake_package(module, dependent_spec, *propagated_args):
+        """Helper method to propagate required CMake cache definitions to dependent
         packages"""
         if dependent_spec.satisfies("build_system=cmake"):
-            dependent_spec.package.builder.dependency_args += propegated_args
+            dependent_spec.package.builder.dependency_args += propagated_args
 
 
     @staticmethod

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -364,7 +364,6 @@ class CMakeBuilder(BaseBuilder):
         if dependent_spec.satisfies("build_system=cmake"):
             dependent_spec.package.builder.dependency_args += propagated_args
 
-
     @staticmethod
     def std_args(pkg, generator=None):
         """Computes the standard cmake arguments for a generic package"""

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -550,6 +550,13 @@ class CMakeBuilder(BaseBuilder):
         """Full-path to the directory to use when building the package."""
         return os.path.join(self.pkg.stage.path, self.build_dirname)
 
+
+    def setup_dependent_cmake_args(self, module, dependent_spec):
+        base_args = dependent_spec.pkg.cmake_args()
+
+
+
+
     def cmake_args(self):
         """List of all the arguments that must be passed to cmake, except:
 

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -323,6 +323,7 @@ class TestCMakePackage:
     def test_cmake_dependent_args(self, concretize_and_setup, monkeypatch):
         def cmake_arg_check(*options):
             assert "-DDEP_TEST_ARG=ON" in options
+
         s = concretize_and_setup("cmake-client-dependent")
         monkeypatch.setattr(s.package.module, "cmake", cmake_arg_check)
 

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -320,9 +320,11 @@ class TestCMakePackage:
         option = spack.build_systems.cmake.CMakeBuilder.define_hip_architectures(s.package)
         assert "-DCMAKE_HIP_ARCHITECTURES:STRING=gfx900" == option
 
-    def test_cmake_dependent_args(self, concretize_and_setup):
-        s = concretize_and_setup("cmake-client-dep")
-        assert s.package.builder.dependency_args == ["-DDEP_TEST_ARG=ON"]
+    def test_cmake_dependent_args(self, concretize_and_setup, monkeypatch):
+        def cmake_arg_check(*options):
+            assert "-DDEP_TEST_ARG=ON" in options
+        s = concretize_and_setup("cmake-client-dependent")
+        monkeypatch.setattr(s.package.module, "cmake", cmake_arg_check)
 
 
 @pytest.mark.usefixtures("config", "mock_packages")

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -255,7 +255,7 @@ spack:
                 e.install_all()
 
 
-@pytest.mark.usefixtures("config", "mock_packages")
+@pytest.mark.usefixtures("config", "mock_packages", "working_env")
 class TestCMakePackage:
     def test_cmake_std_args(self, default_mock_concretization):
         # Call the function on a CMakePackage instance

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -320,6 +320,10 @@ class TestCMakePackage:
         option = spack.build_systems.cmake.CMakeBuilder.define_hip_architectures(s.package)
         assert "-DCMAKE_HIP_ARCHITECTURES:STRING=gfx900" == option
 
+    def test_cmake_dependent_args(self, concretize_and_setup):
+        s = concretize_and_setup("cmake-client-dep")
+        assert s.package.builder.dependency_args == ["-DDEP_TEST_ARG=ON"]
+
 
 @pytest.mark.usefixtures("config", "mock_packages")
 class TestDownloadMixins:

--- a/var/spack/repos/builtin.mock/packages/cmake-client-dep/package.py
+++ b/var/spack/repos/builtin.mock/packages/cmake-client-dep/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin.mock/packages/cmake-client-dep/package.py
+++ b/var/spack/repos/builtin.mock/packages/cmake-client-dep/package.py
@@ -6,14 +6,8 @@
 from spack.package import *
 
 
-def check(condition, msg):
-    """Raise an install error if condition is False."""
-    if not condition:
-        raise InstallError(msg)
-
-
 class CmakeClientDep(CMakePackage):
-    """A dummy package that uses cmake."""
+    """A stub CMake package that depends on another CMake package: cmake-client"""
 
     homepage = "https://www.example.com"
     url = "https://www.example.com/cmake-client-1.0.tar.gz"

--- a/var/spack/repos/builtin.mock/packages/cmake-client-dep/package.py
+++ b/var/spack/repos/builtin.mock/packages/cmake-client-dep/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+from spack.package import *
+
+
+def check(condition, msg):
+    """Raise an install error if condition is False."""
+    if not condition:
+        raise InstallError(msg)
+
+
+class CmakeClientDep(CMakePackage):
+    """A dummy package that uses cmake."""
+
+    homepage = "https://www.example.com"
+    url = "https://www.example.com/cmake-client-1.0.tar.gz"
+
+    version("1.0", sha256="a5b529fb5415a8a33281ddde4317bd68bd6a2317db1f96565c541c53f67e8f9a")
+
+    depends_on("cmake-client")

--- a/var/spack/repos/builtin.mock/packages/cmake-client-dependent/package.py
+++ b/var/spack/repos/builtin.mock/packages/cmake-client-dependent/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class CmakeClientDep(CMakePackage):
+class CmakeClientDependent(CMakePackage):
     """A stub CMake package that depends on another CMake package: cmake-client"""
 
     homepage = "https://www.example.com"

--- a/var/spack/repos/builtin.mock/packages/cmake-client/package.py
+++ b/var/spack/repos/builtin.mock/packages/cmake-client/package.py
@@ -89,7 +89,7 @@ class CmakeClient(CMakePackage):
             self.spec["cmake"].link_arg == "test link arg",
             "link arg on dependency spec not readable from " "setup_dependent_package.",
         )
-        self.builder.setup_dependent_cmake_package(module, dspec, "-DDEP_TEST_ARG=ON")
+        self.builder.setup_dependent_cmake_package(dspec, "-DDEP_TEST_ARG=ON")
 
     def cmake(self, spec, prefix):
         assert self.callback_counter == 1

--- a/var/spack/repos/builtin.mock/packages/cmake-client/package.py
+++ b/var/spack/repos/builtin.mock/packages/cmake-client/package.py
@@ -89,6 +89,7 @@ class CmakeClient(CMakePackage):
             self.spec["cmake"].link_arg == "test link arg",
             "link arg on dependency spec not readable from " "setup_dependent_package.",
         )
+        self.builder.setup_dependent_cmake_package(module, dspec, "-DDEP_TEST_ARG=ON")
 
     def cmake(self, spec, prefix):
         assert self.callback_counter == 1

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -7,6 +7,7 @@ import os
 import sys
 from pathlib import Path
 
+from spack.build_systems.cmake import CMakeBuilder
 from spack.package import *
 
 
@@ -833,13 +834,10 @@ class Boost(Package):
         # Disable find package's config mode for versions of Boost that
         # didn't provide it. See https://github.com/spack/spack/issues/20169
         # and https://cmake.org/cmake/help/latest/module/FindBoost.html
-        if self.spec.satisfies("boost@:1.69.0") and dependent_spec.satisfies("build_system=cmake"):
-            args_fn = type(dependent_spec.package.builder).cmake_args
-
-            def _cmake_args(self):
-                return ["-DBoost_NO_BOOST_CMAKE=ON"] + args_fn(self)
-
-            type(dependent_spec.package.builder).cmake_args = _cmake_args
+        if self.spec.satisfies("boost@:1.69.0"):
+            CMakeBuilder.setup_dependent_cmake_args(
+                module, dependent_spec, CMakeBuilder.define("Boost_NO_BOOST_CMAKE", True)
+            )
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         if "+context" in self.spec and "context-impl" in self.spec.variants:

--- a/var/spack/repos/builtin/packages/msmpi/package.py
+++ b/var/spack/repos/builtin/packages/msmpi/package.py
@@ -55,8 +55,7 @@ class Msmpi(Package):
         self.spec.mpicxx = dependent_module.spack_cxx
         self.spec.mpifc = dependent_module.spack_fc
         self.spec.mpif77 = dependent_module.spack_f77
-        CMakeBuilder.setup_dependent_cmake_project(
-            module,
+        CMakeBuilder.setup_dependent_cmake_package(
             dependent_spec,
             CMakeBuilder.define("MPI_EXECUTABLE", self.prefix.bin.mpiexec),
             CMakeBuilder.define("MPI_SKIP_COMPILER_WRAPPER", True),

--- a/var/spack/repos/builtin/packages/msmpi/package.py
+++ b/var/spack/repos/builtin/packages/msmpi/package.py
@@ -54,12 +54,17 @@ class Msmpi(Package):
         self.spec.mpicxx = dependent_module.spack_cxx
         self.spec.mpifc = dependent_module.spack_fc
         self.spec.mpif77 = dependent_module.spack_f77
+        dependent_module.std_cmake_args.extend(["-DMPI_SKIP_COMPILER_WRAPPER=ON", "-DMPI_ASSUME_NO_BUILTIN_MPI=ON"])
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.set("MPIEXEC_EXECUTABLE", self.pkg.spec.prefix.bin)
 
 
 class GenericBuilder(GenericBuilder):
     def setup_build_environment(self, env):
         ifort_root = os.path.join(*self.pkg.compiler.fc.split(os.path.sep)[:-2])
         env.set("SPACK_IFORT", ifort_root)
+
 
     def is_64bit(self):
         return "64" in str(self.pkg.spec.target.family)

--- a/var/spack/repos/builtin/packages/msmpi/package.py
+++ b/var/spack/repos/builtin/packages/msmpi/package.py
@@ -55,9 +55,6 @@ class Msmpi(Package):
         self.spec.mpicxx = dependent_module.spack_cxx
         self.spec.mpifc = dependent_module.spack_fc
         self.spec.mpif77 = dependent_module.spack_f77
-        dependent_module.std_cmake_args.extend(
-            ["-DMPI_SKIP_COMPILER_WRAPPER=ON", "-DMPI_ASSUME_NO_BUILTIN_MPI=ON"]
-        )
         CMakeBuilder.setup_dependent_cmake_project(
             module,
             dependent_spec,


### PR DESCRIPTION
CMake builds on Windows are detecting Intel MPI when available over the concretized MSMPI.
This occurs because CMake prefers MPI derived from a compiler wrapper, which Intel MPI provides, over MPI without it.
Intel MPI is present and detectable in the environment because A) a lack of general sandboxing and B) when we invoke the MSVC compiler (with an associated OneAPI) the OneAPI compiler vcvars are invoked in addition to the MSVC vcvars, which imports intel's MPI into the environment, and exposes it for detection.

This PR resolves this by adding to the CMake builder, introducing a new method that allows packages to inject required CMake args into the CMake command line arguments of their dependent packages.

This method is designed to be invoked within the context of a package's `setup_dependent_package` method, and takes the dependent spec and module, modifying the dependent module's `cmake_args` method to include the arguments required by the specifying package.

To the end of the issue described above, this function allows MSMPI to specify CMake options to its dependents that force the use of MSMPI over other MPI implementations.
Another example of similar behavior is in the `boost` package, where boost needs to propagate CMake args to its dependencies. This solution was based on the existing implementation in the boost package (which has since been refactored to use this approach, see the boost diff for a good example of a before and after). 
