### PR TITLE
Make internal concretization API more stable

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2964,8 +2964,9 @@ class Spec:
 
     def _mark_root_concrete(self, value=True):
         """Mark just this spec (not dependencies) concrete."""
+        if value is True:
+            self._validate_version()
         self._concrete = value
-        self._validate_version()
 
     def _validate_version(self):
         # Specs that were concretized with just a git sha as version, without associated

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2130,6 +2130,10 @@ class Spec:
         if not hash.attr:
             return self.spec_hash(hash)[:length]
 
+        # On an abstract spec, the only thing safe to cache is the package hash
+        if not self.concrete and hash.name != ht.package_hash.name:
+            return self.spec_hash(hash)[:length]
+
         hash_string = getattr(self, hash.attr, None)
         if hash_string:
             return hash_string[:length]

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2964,8 +2964,6 @@ class Spec:
 
     def _mark_root_concrete(self, value=True):
         """Mark just this spec (not dependencies) concrete."""
-        if (not value) and self.concrete and self.installed:
-            return
         self._concrete = value
         self._validate_version()
 
@@ -2994,13 +2992,9 @@ class Spec:
         Only for internal use -- client code should use "concretize"
         unless there is a need to force a spec to be concrete.
         """
-        # if set to false, clear out all hashes (set to None or remove attr)
-        # may need to change references to respect None
         for s in self.traverse():
-            if (not value) and s.concrete and s.installed:
-                continue
-            elif not value:
-                s.clear_caches()
+            if value is False:
+                s.clear_caches(ignore=(ht.package_hash.attr,))
             s._mark_root_concrete(value)
 
     def _finalize_concretization(self):


### PR DESCRIPTION
fixes #47973

This fixes the inconsistency in hash computation observed on subsequent deconcretizations / reconcretizations of specs using the internal API. 

Modifications:
- [x] Never cache `dag_hash` and `process_hash` on abstract specs
- [x] Simplify `_mark_concrete` logic, by removing a check

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
