### PR TITLE
Handle variable expansion for paths and managed env names for includes

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -280,10 +280,10 @@ def as_env_dir(name_or_dir):
     if is_env_dir(path):
         return path
     else:
-        validate_env_name(name_or_dir)
-        if not exists(name_or_dir):
-            raise SpackEnvironmentError("no such environment '%s'" % name_or_dir)
-        return root(name_or_dir)
+        path = environment_dir_from_name(name_or_dir)
+        if not is_env_dir(path):
+            raise SpackEnvironmentError("could not find environment with name '%s'" % name_or_dir)
+        return path
 
 
 def environment_from_name_or_dir(name_or_dir):
@@ -295,7 +295,7 @@ def read(name):
     """Get an environment with the supplied name."""
     validate_env_name(name)
     if not exists(name):
-        raise SpackEnvironmentError("no such environment '%s'" % name)
+        raise SpackEnvironmentError("could not read environment '%s'" % name)
     return Environment(root(name))
 
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -318,8 +318,9 @@ def is_env_dir(path):
 
 def as_env_dir(name_or_dir):
     """Translate an environment name or directory to the environment directory"""
-    if is_env_dir(name_or_dir):
-        return name_or_dir
+    path = substitute_path_variables(name_or_dir)
+    if is_env_dir(path):
+        return path
     else:
         validate_env_name(name_or_dir)
         if not exists(name_or_dir):
@@ -410,9 +411,11 @@ def create_in_dir(
             manifest.set_default_view(with_view)
 
         if include_concrete is not None:
-            set_included_envs_to_env_paths(include_concrete)
-            validate_included_envs_exists(include_concrete)
-            validate_included_envs_concrete(include_concrete)
+            # Validate included concrete envs
+            included_concrete_env_paths = [as_env_dir(e) for e in include_concrete]
+            validate_included_envs_exists(included_concrete_env_paths)
+            validate_included_envs_concrete(included_concrete_env_paths)
+            # Add unmodified paths to the config
             manifest.set_include_concrete(include_concrete)
 
         manifest.flush()
@@ -561,7 +564,7 @@ def validate_included_envs_exists(include_concrete: List[str]) -> None:
 
     missing_envs = set()
 
-    for i, env_name in enumerate(include_concrete):
+    for env_name in include_concrete:
         if not is_env_dir(env_name):
             missing_envs.add(env_name)
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -313,6 +313,7 @@ def active(name):
 
 def is_env_dir(path):
     """Whether a directory contains a spack environment."""
+    path = substitute_path_variables(path)
     return os.path.isdir(path) and os.path.exists(os.path.join(path, manifest_name))
 
 
@@ -587,7 +588,7 @@ def validate_included_envs_concrete(include_concrete: List[str]) -> None:
     non_concrete_envs = set()
 
     for env_path in include_concrete:
-        if not os.path.exists(os.path.join(env_path, lockfile_name)):
+        if not os.path.exists(os.path.join(as_env_dir(env_path), lockfile_name)):
             non_concrete_envs.add(environment_name(env_path))
 
     if non_concrete_envs:

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -337,7 +337,7 @@ def read(name):
     """Get an environment with the supplied name."""
     validate_env_name(name)
     if not exists(name):
-        raise SpackEnvironmentError("could not read environment '%s'" % name)
+        raise SpackEnvironmentError("no such environment '%s'" % name)
     return Environment(root(name))
 
 
@@ -412,9 +412,10 @@ def create_in_dir(
 
         if include_concrete is not None:
             # Validate included concrete envs
-            included_concrete_env_paths = [as_env_dir(e) for e in include_concrete]
-            validate_included_envs_exists(included_concrete_env_paths)
-            validate_included_envs_concrete(included_concrete_env_paths)
+            set_included_envs_to_env_paths(include_concrete)
+            validate_included_envs_exists(include_concrete)
+            validate_included_envs_concrete(include_concrete)
+
             # Add unmodified paths to the config
             manifest.set_include_concrete(include_concrete)
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -337,7 +337,7 @@ def read(name):
     """Get an environment with the supplied name."""
     validate_env_name(name)
     if not exists(name):
-        raise SpackEnvironmentError("no such environment '%s'" % name)
+        raise SpackEnvironmentError("could not read environment '%s'" % name)
     return Environment(root(name))
 
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1953,7 +1953,7 @@ def test_env_include_concrete_env_yaml(env_name):
     combined_yaml = combined.manifest["spack"]
 
     assert "include_concrete" in combined_yaml
-    assert test.path in combined_yaml["include_concrete"]
+    assert environ in combined_yaml["include_concrete"]
 
 
 @pytest.mark.regression("45766")
@@ -1988,8 +1988,8 @@ def test_env_multiple_include_concrete_envs():
 
     combined_yaml = combined.manifest["spack"]
 
-    assert test1.path in combined_yaml["include_concrete"][0]
-    assert test2.path in combined_yaml["include_concrete"][1]
+    assert "test1" in combined_yaml["include_concrete"][0]
+    assert "test2" in combined_yaml["include_concrete"][1]
 
     # No local specs in the combined env
     assert not combined_yaml["specs"]
@@ -2001,7 +2001,7 @@ def test_env_include_concrete_envs_lockfile():
     combined_yaml = combined.manifest["spack"]
 
     assert "include_concrete" in combined_yaml
-    assert test1.path in combined_yaml["include_concrete"]
+    assert "test1" in combined_yaml["include_concrete"]
 
     with open(combined.lock_path, encoding="utf-8") as f:
         lockfile_as_dict = combined._read_lockfile(f)

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -2229,7 +2229,8 @@ def test_concretize_nested_include_concrete_envs():
     test1.concretize()
     test1.write()
 
-    env("create", "--include-concrete", "test1", "test2")
+    os.environ["TEST1_ROOT"] = test1.path
+    env("create", "--include-concrete", "${TEST1_ROOT}", "test2")
     test2 = ev.read("test2")
     with test2:
         add("libelf")

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -2339,7 +2339,8 @@ def test_concretize_nested_include_concrete_envs():
     test1.concretize()
     test1.write()
 
-    env("create", "--include-concrete", "test1", "test2")
+    os.environ["TEST1_ROOT"] = test1.path
+    env("create", "--include-concrete", "${TEST1_ROOT}", "test2")
     test2 = ev.read("test2")
     with test2:
         add("libelf")

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -919,5 +919,5 @@ def test_environment_from_name_or_dir(mock_packages, mutable_mock_env_path, tmp_
     assert dir_env.name == test_env.name
     assert dir_env.path == test_env.path
 
-    with pytest.raises(ev.SpackEnvironmentError, match="no such environment"):
+    with pytest.raises(ev.SpackEnvironmentError, match="could not find environment with name"):
         _ = ev.environment_from_name_or_dir("fake-env")


### PR DESCRIPTION
Allow including environments using the managed env name or using config path alias like `$spack` or environment variables (as can be used with `include` paths).

Also update the CLI to not expand the path when adding included concrete environments to the config. This should allow better consistency between what is expressed on the CLI and what is reflected in the config.