### PR TITLE
PythonPackage: run test_imports in run env context

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -18,6 +18,7 @@ import llnl.util.tty as tty
 from llnl.util.filesystem import HeaderList, LibraryList, join_path
 
 import spack.builder
+import spack.build_environment
 import spack.config
 import spack.context
 import spack.deptypes as dt

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -243,8 +243,7 @@ class PythonExtension(spack.package_base.PackageBase):
                     self.spec, context=spack.context.Context.RUN
                 )
                 mods = setup_context.get_env_modifications()
-                with mods.set_env():
-                    python("-c", f"import {module}")
+                python("-c", f"import {module}", env=mods)
 
     def update_external_dependencies(self, extendee_spec=None):
         """

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -17,8 +17,8 @@ import llnl.util.lang as lang
 import llnl.util.tty as tty
 from llnl.util.filesystem import HeaderList, LibraryList, join_path
 
-import spack.builder
 import spack.build_environment
+import spack.builder
 import spack.config
 import spack.context
 import spack.deptypes as dt

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -19,6 +19,7 @@ from llnl.util.filesystem import HeaderList, LibraryList, join_path
 
 import spack.builder
 import spack.config
+import spack.context
 import spack.deptypes as dt
 import spack.detection
 import spack.multimethod
@@ -237,7 +238,12 @@ class PythonExtension(spack.package_base.PackageBase):
                 purpose=f"checking import of {module}",
                 work_dir="spack-test",
             ):
-                python("-c", f"import {module}")
+                setup_context = spack.build_environment.SetupContext(
+                    self.spec, context=spack.context.Context.RUN
+                )
+                mods = setup_context.get_env_modifications()
+                with mods.set_env():
+                    python("-c", f"import {module}")
 
     def update_external_dependencies(self, extendee_spec=None):
         """

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -450,31 +450,6 @@ class EnvironmentModifications:
 
         return Trace(filename=filename, lineno=lineno, context=current_context)
 
-    @contextlib.contextmanager
-    def set_env(self, env: Optional[MutableMapping[str, str]] = None):
-        """Temporarily sets and restores environment variables.
-
-        Args:
-            env: environment to be modified. If None, os.environ will be used.
-        """
-        env = os.environ if env is None else env
-
-        saved = {}
-        for var, value in self.group_by_name().items():
-            if var in env:
-                saved[var] = env[var]
-
-        self.apply_modifications(env)
-
-        yield
-
-        for var, value in self.group_by_name().items():
-            if var in saved:
-                env[var] = saved[var]
-            else:
-                if var in env:
-                    del env[var]
-
     @system_env_normalize
     def set(self, name: str, value: str, *, force: bool = False, raw: bool = False):
         """Stores a request to set an environment variable.

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -450,6 +450,31 @@ class EnvironmentModifications:
 
         return Trace(filename=filename, lineno=lineno, context=current_context)
 
+    @contextlib.contextmanager
+    def set_env(self, env: Optional[MutableMapping[str, str]] = None):
+        """Temporarily sets and restores environment variables.
+
+        Args:
+            env: environment to be modified. If None, os.environ will be used.
+        """
+        env = os.environ if env is None else env
+
+        saved = {}
+        for var, value in self.group_by_name().items():
+            if var in env:
+                saved[var] = env[var]
+
+        self.apply_modifications(env)
+
+        yield
+
+        for var, value in self.group_by_name().items():
+            if var in saved:
+                env[var] = saved[var]
+            else:
+                if var in env:
+                    del env[var]
+
     @system_env_normalize
     def set(self, name: str, value: str, *, force: bool = False, raw: bool = False):
         """Stores a request to set an environment variable.


### PR DESCRIPTION
This PR aims to address #45801 by running the PythonPackage `test_imports` inside a run environment context. With this PR, I am now able to run `spack install --test all` on python packages without failures due to failing imports as reported in that issue.

Note: Circular import because `build_environment.py` includes `build_systems/python.py`.

Todo:
- [ ] Same applies to SIPPackage `test_imports`