### PR TITLE
Windows: add msvc versioning to binary compatibility

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -314,6 +314,7 @@ def get_msvc_runtime(compiler) -> Optional[spack.spec.Spec]:
         runtime_spec = spack.spec.Spec(f"msvc-toolset@={str(msc_version)}")
         runtime_spec.external_path = compiler.prefix
         return runtime_spec
+    return None
 
 
 def all_msvc_runtimes() -> Set[spack.spec.Spec]:
@@ -354,7 +355,7 @@ def using_libc_compatibility() -> bool:
 
 def using_msvc_compatibility() -> bool:
     """Returns True if we're using MSVC Toolset version
-     to determine binary compatibility"""
+    to determine binary compatibility"""
     return spack.platforms.host().name == "windows"
 
 
@@ -1019,7 +1020,9 @@ def _external_config_with_implicit_externals(configuration):
             if runtime_spec and runtime_spec not in seen:
                 seen.add(runtime_spec)
                 entry = {"spec": f"{runtime_spec}", "prefix": runtime_spec.external_path}
-                packages_yaml.setdefault(runtime_spec.name, {}).setdefault("externals", []).append(entry)
+                packages_yaml.setdefault(runtime_spec.name, {}).setdefault("externals", []).append(
+                    entry
+                )
     return packages_yaml
 
 
@@ -2576,7 +2579,11 @@ class SpackSolverSetup:
             elif using_msvc_compatibility():
                 clauses.append(fn.attr("needs_msvc_runtime"))
                 for runtime in self.msvc_runtimes:
-                    clauses.append(fn.attr("compatible_msvc_runtime", spec.name, runtime.name, runtime.version))
+                    clauses.append(
+                        fn.attr(
+                            "compatible_msvc_runtime", spec.name, runtime.name, runtime.version
+                        )
+                    )
         # add all clauses from dependencies
         if transitive:
             # TODO: Eventually distinguish 2 deps on the same pkg (build and link)
@@ -2610,9 +2617,13 @@ class SpackSolverSetup:
                         for msvc_runtime in self.msvc_runtimes:
                             if msvc_is_compatible(msvc_runtime, dep):
                                 clauses.append(
-                                    fn.attr("compatible_msvc_runtime", spec.name, msvc_runtime.name, msvc_runtime.version)
+                                    fn.attr(
+                                        "compatible_msvc_runtime",
+                                        spec.name,
+                                        msvc_runtime.name,
+                                        msvc_runtime.version,
+                                    )
                                 )
-                        
 
                     # We know dependencies are real for concrete specs. For abstract
                     # specs they just mean the dep is somehow in the DAG.
@@ -3306,7 +3317,7 @@ class SpackSolverSetup:
                         f"{current_msvc_runtime.name}@={current_msvc_runtime.version}",
                         when=f"%{compiler.name}@={compiler.version}",
                         type="link",
-                        description=f"MSC Toolset is {current_msvc_runtime} when using {compiler}"
+                        description=f"MSC Toolset is {current_msvc_runtime} when using {compiler}",
                     )
 
         recorder.consume_facts()

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -316,9 +316,23 @@ def libc_is_compatible(lhs: spack.spec.Spec, rhs: spack.spec.Spec) -> bool:
     )
 
 
+def msvc_is_compatible(lhs: spack.spec.Spec, rhs: spack.spec.Spec) -> bool:
+    """MSVC compatibility is determined by Visual Studio Toolchain version
+    Compatible versions can have different paths, and are only defined by a single
+    name "msvc-toolset". So long as the Version we're concretizing with is >=
+    than the version of a dep
+    """
+    return lhs.version >= rhs.version
+
 def using_libc_compatibility() -> bool:
     """Returns True if we are currently using libc compatibility"""
     return spack.platforms.host().name == "linux"
+
+
+def using_msvc_compatibility() -> bool:
+    """Returns True if we're using MSVC Toolset version
+     to determine binary compatibility"""
+    return spack.platforms.host().name == "windows"
 
 
 def c_compiler_runs(compiler) -> bool:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -308,6 +308,23 @@ def all_libcs() -> Set[spack.spec.Spec]:
     return {libc} if libc else set()
 
 
+def get_msvc_runtime(compiler) -> Optional[spack.spec.Spec]:
+    if hasattr(compiler.package, "determine_msc_toolchain_version"):
+        msc_version = compiler.package.determine_msc_toolchain_version()
+        runtime_spec = spack.spec.Spec(f"msvc-toolset@={str(msc_version)}")
+        return runtime_spec
+
+
+def all_msvc_runtimes() -> Set[spack.spec.Spec]:
+    """Return a set of all msvc-runtimes modeled by configured MSVC compilers"""
+    msvcs = set()
+    for comp in spack.compilers.config.all_compilers_from(spack.config.CONFIG):
+        runtime_spec = get_msvc_runtime(comp)
+        if runtime_spec:
+            msvcs.add(runtime_spec)
+    return msvcs
+
+
 def libc_is_compatible(lhs: spack.spec.Spec, rhs: spack.spec.Spec) -> bool:
     return (
         lhs.name == rhs.name
@@ -322,7 +339,12 @@ def msvc_is_compatible(lhs: spack.spec.Spec, rhs: spack.spec.Spec) -> bool:
     name "msvc-toolset". So long as the Version we're concretizing with is >=
     than the version of a dep
     """
+    # msc toolset v144 is part of VS22 which is "v143", MS decided to change their
+    # versioning scheme part way through VS22's lifetime
+    if rhs.version == spack.version.Version("144") and lhs.version == spack.version.Version("143"):
+        return True
     return lhs.version >= rhs.version
+
 
 def using_libc_compatibility() -> bool:
     """Returns True if we are currently using libc compatibility"""
@@ -980,16 +1002,23 @@ def _external_config_with_implicit_externals(configuration):
     packages_yaml = _normalize_packages_yaml(configuration.get("packages"))
 
     # Add externals for libc from compilers on Linux
-    if not using_libc_compatibility():
+    if not (using_libc_compatibility() or using_msvc_compatibility()):
         return packages_yaml
 
     seen = set()
     for compiler in spack.compilers.config.all_compilers_from(configuration):
-        libc = CompilerPropertyDetector(compiler).default_libc()
-        if libc and libc not in seen:
-            seen.add(libc)
-            entry = {"spec": f"{libc}", "prefix": libc.external_path}
-            packages_yaml.setdefault(libc.name, {}).setdefault("externals", []).append(entry)
+        if using_libc_compatibility():
+            libc = CompilerPropertyDetector(compiler).default_libc()
+            if libc and libc not in seen:
+                seen.add(libc)
+                entry = {"spec": f"{libc}", "prefix": libc.external_path}
+                packages_yaml.setdefault(libc.name, {}).setdefault("externals", []).append(entry)
+        elif using_msvc_compatibility():
+            runtime_spec = get_msvc_runtime(compiler)
+            if runtime_spec and runtime_spec not in seen:
+                seen.add(runtime_spec)
+                entry = {"spec": f"{runtime_spec}", "prefix": compiler.prefix}
+                packages_yaml.setdefault(runtime_spec.name, {}).setdefault("externals", []).append(entry)
     return packages_yaml
 
 
@@ -1178,6 +1207,8 @@ class PyclingoDriver:
             control_files.append("when_possible.lp")
         if using_libc_compatibility():
             control_files.append("libc_compatibility.lp")
+        elif using_msvc_compatibility():
+            control_files.append("msvc_compatibility.lp")
         else:
             control_files.append("os_compatibility.lp")
         if setup.enable_splicing:
@@ -1549,6 +1580,9 @@ class SpackSolverSetup:
 
         # list of unique libc specs targeted by compilers (or an educated guess if no compiler)
         self.libcs: List[spack.spec.Spec] = []
+
+        # List of unique msvc_runtime specs targeted by compilers
+        self.msvc_runtimes: List[spack.spec.Spec] = []
 
         # If true, we have to load the code for synthesizing splices
         self.enable_splicing: bool = spack.config.CONFIG.get("concretizer:splice:automatic")
@@ -2533,11 +2567,15 @@ class SpackSolverSetup:
                 clauses.append(fn.attr("virtual_on_incoming_edges", spec.name, virtual))
 
         # If the spec is external and concrete, we allow all the libcs on the system
-        if spec.external and spec.concrete and using_libc_compatibility():
-            clauses.append(fn.attr("needs_libc", spec.name))
-            for libc in self.libcs:
-                clauses.append(fn.attr("compatible_libc", spec.name, libc.name, libc.version))
-
+        if spec.external and spec.concrete:
+            if using_libc_compatibility():
+                clauses.append(fn.attr("needs_libc", spec.name))
+                for libc in self.libcs:
+                    clauses.append(fn.attr("compatible_libc", spec.name, libc.name, libc.version))
+            elif using_msvc_compatibility():
+                clauses.append(fn.attr("needs_msvc_runtime"))
+                for runtime in self.msvc_runtimes:
+                    clauses.append(fn.attr("compatible_msvc_runtime", spec.name, runtime.name, runtime.version))
         # add all clauses from dependencies
         if transitive:
             # TODO: Eventually distinguish 2 deps on the same pkg (build and link)
@@ -2565,6 +2603,15 @@ class SpackSolverSetup:
                                     fn.attr("compatible_libc", spec.name, libc.name, libc.version)
                                 )
                         continue
+
+                    if "msvc-runtime" in dspec.virtuals:
+                        clauses.append(fn.attr("needs_msvc_runtime", spec.name))
+                        for msvc_runtime in self.msvc_runtimes:
+                            if msvc_is_compatible(msvc_runtime, dep):
+                                clauses.append(
+                                    fn.attr("compatible_msvc_runtime", spec.name, msvc_runtime.name, msvc_runtime.version)
+                                )
+                        
 
                     # We know dependencies are real for concrete specs. For abstract
                     # specs they just mean the dep is somehow in the DAG.
@@ -3016,6 +3063,7 @@ class SpackSolverSetup:
         self.possible_virtuals = node_counter.possible_virtuals()
         self.pkgs = node_counter.possible_dependencies()
         self.libcs = sorted(all_libcs())  # type: ignore[type-var]
+        self.msvc_runtimes = sorted(all_msvc_runtimes())  # type: ignore[type-var]
 
         # Fail if we already know an unreachable node is requested
         for spec in specs:
@@ -3040,6 +3088,9 @@ class SpackSolverSetup:
         if using_libc_compatibility():
             for libc in self.libcs:
                 self.gen.fact(fn.host_libc(libc.name, libc.version))
+        elif using_msvc_compatibility():
+            for runtime in self.msvc_runtimes:
+                self.gen.fact(fn.host_msvc(runtime.name, runtime.version))
 
         if not allow_deprecated:
             self.gen.fact(fn.deprecated_versions_not_allowed())
@@ -3216,31 +3267,46 @@ class SpackSolverSetup:
                 description=f"Add the compiler wrapper when using {compiler}",
             )
 
-            if not using_libc_compatibility():
-                continue
+            # TODO: we don't actually need the msvc runtime in the DAG
+            # So do we need to include this?
+            if using_libc_compatibility():
+                current_libc = None
+                if compiler.external or compiler.installed:
+                    current_libc = CompilerPropertyDetector(compiler).default_libc()
+                else:
+                    try:
+                        current_libc = compiler["libc"]
+                    except (KeyError, RuntimeError) as e:
+                        tty.debug(f"{compiler} cannot determine libc because: {e}")
 
-            current_libc = None
-            if compiler.external or compiler.installed:
-                current_libc = CompilerPropertyDetector(compiler).default_libc()
-            else:
-                try:
-                    current_libc = compiler["libc"]
-                except (KeyError, RuntimeError) as e:
-                    tty.debug(f"{compiler} cannot determine libc because: {e}")
-
-            if current_libc:
-                recorder("*").depends_on(
-                    "libc",
-                    when=f"%{compiler.name}@{compiler.versions}",
-                    type="link",
-                    description=f"Add libc when using {compiler}",
-                )
-                recorder("*").depends_on(
-                    f"{current_libc.name}@={current_libc.version}",
-                    when=f"%{compiler.name}@{compiler.versions}",
-                    type="link",
-                    description=f"Libc is {current_libc} when using {compiler}",
-                )
+                if current_libc:
+                    recorder("*").depends_on(
+                        "libc",
+                        when=f"%{compiler.name}@{compiler.versions}",
+                        type="link",
+                        description=f"Add libc when using {compiler}",
+                    )
+                    recorder("*").depends_on(
+                        f"{current_libc.name}@={current_libc.version}",
+                        when=f"%{compiler.name}@{compiler.versions}",
+                        type="link",
+                        description=f"Libc is {current_libc} when using {compiler}",
+                    )
+            elif using_msvc_compatibility():
+                current_msvc_runtime = get_msvc_runtime(compiler)
+                if current_msvc_runtime:
+                    recorder("*").depends_on(
+                        "msvc-runtime",
+                        when=f"%{compiler.name}@{compiler.version}",
+                        type="link",
+                        description=f"Add msvc-runtime when using compiler {compiler}",
+                    )
+                    recorder("*").depends_on(
+                        f"{current_msvc_runtime.name}@={current_msvc_runtime.version}",
+                        when=f"%{compiler.name}@={compiler.version}",
+                        type="link",
+                        description=f"MSC Toolset is {current_msvc_runtime} when using {compiler}"
+                    )
 
         recorder.consume_facts()
 
@@ -3733,6 +3799,7 @@ class SpecBuilder:
                 r"^.*_satisfies$",
                 r"^.*_set$",
                 r"^compatible_libc$",
+                r"^compatible_msvc_runtime$",
                 r"^dependency_holds$",
                 r"^external_conditions_hold$",
                 r"^package_hash$",

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -312,6 +312,7 @@ def get_msvc_runtime(compiler) -> Optional[spack.spec.Spec]:
     if hasattr(compiler.package, "determine_msc_toolchain_version"):
         msc_version = compiler.package.determine_msc_toolchain_version()
         runtime_spec = spack.spec.Spec(f"msvc-toolset@={str(msc_version)}")
+        runtime_spec.external_path = compiler.prefix
         return runtime_spec
 
 
@@ -1017,7 +1018,7 @@ def _external_config_with_implicit_externals(configuration):
             runtime_spec = get_msvc_runtime(compiler)
             if runtime_spec and runtime_spec not in seen:
                 seen.add(runtime_spec)
-                entry = {"spec": f"{runtime_spec}", "prefix": compiler.prefix}
+                entry = {"spec": f"{runtime_spec}", "prefix": runtime_spec.external_path}
                 packages_yaml.setdefault(runtime_spec.name, {}).setdefault("externals", []).append(entry)
     return packages_yaml
 

--- a/lib/spack/spack/solver/msvc_compatibility.lp
+++ b/lib/spack/spack/solver/msvc_compatibility.lp
@@ -11,33 +11,31 @@
 
 % A package cannot be reused if the msvc is not compatible with it
 error(100, "Cannot reuse {0} since we cannot determine msvc compatibility", ReusedPackage)
-  :- provider(node(X, MsvcToolsetPackage), node(0, "msvc")),
-     attr("version", node(X, MsvcToolsetPackage), MsvcToolsetVersion),
-     attr("hash", node(R, ReusedPackage), Hash),
-     % msvc packages can be reused without the "compatible_msvc_toolset" attribute
-     ReusedPackage != MsvcToolsetPackage,
-     not attr("compatible_msvc_toolset", node(R, ReusedPackage), MsvcToolsetPackage, MsvcToolsetVersion).
+  :- provider(node(X, MsvcRuntimePackage), node(0, "msvc-runtime")),
+     attr("version", node(X, MsvcRuntimePackage), MsvcRuntimeVersion),
+     concrete(node(R, Reusedpackage)),
+     attr("needs_msvc_runtime", node(R, ReusedPackage)),
+     not attr("compatible_msvc_runtime", node(R, ReusedPackage), MsvcRuntimePackage, MsvcRuntimeVersion).
 
-% A msvc toolset is needed in the DAG
-:- has_built_packages(), not provider(_, node(0, "msvc-toolset")).
+% If we have a compiler we're guarunteed to have an MSVC Runtime
+% Ensure it's compatible
+error(100, "Cannot reuse {0} since we cannot determine msvc-runtime compatibility", ReusedPackage)
+  :- not provider(_, node(0, "msvc-runtime")),
+     concrete(node(R, ReusedPackage)),
+     attr("needs_msvc_runtime", node(R, ReusedPackage)),
+     not attr("compatible_msvc_runtime", node(R, ReusedPackage), _, _).
 
-% Non-msvc reused specs must be host msvc compatible. In case we build packages, we get a
-% host compatible msvc provider from other rules. If nothing is built, there is no msvc provider,
+% Non-libc reused specs must be host libc compatible. In case we build packages, we get a
+% host compatible libc provider from other rules. If nothing is built, there is no libc provider,
 % since it's pruned from reusable specs, meaning we have to explicitly impose reused specs are host
 % compatible.
-:- attr("hash", node(R, ReusedPackage), Hash),
-   not provider(node(R, ReusedPackage), node(0, "msvc-toolset")),
-   not attr("compatible_msvc_toolset", node(R, ReusedPackage), _, _).
+%:- attr("hash", node(R, ReusedPackage), Hash),
+%   not provider(node(R, ReusedPackage), node(0, "msvc-runtime")),
+%   not attr("compatible_msvc_runtime", node(R, ReusedPackage), _, _).
 
-% The msvc provider must be one that a compiler can target
+% The msvc-runtime provider must be one that a compiler can target
 :- has_built_packages(),
-   provider(node(X, MsvcToolsetPackage), node(0, "msvc-toolset")),
-   attr("node", node(X, MsvcToolsetPackage)),
-   attr("version", node(X, MsvcToolsetPackage), MsvcToolsetVersion),
-   not host_msvc(MsvcToolsetPackage, MsvcToolsetVersion).
-
-% A built node must depend on msvc
-:- build(PackageNode),
-   provider(MsvcToolsetNode, node(0, "msvc-toolset")),
-   not external(PackageNode),
-   not depends_on(PackageNode, MsvcToolsetNode).
+   provider(node(X, MsvcRuntimePackage), node(0, "msvc-runtime")),
+   attr("node", node(X, MsvcRuntimePackage)),
+   attr("version", node(X, MsvcRuntimePackage), MsvcRuntimeVersion),
+   not host_msvc(MsvcRuntimePackage, MsvcRuntimeVersion).

--- a/lib/spack/spack/solver/msvc_compatibility.lp
+++ b/lib/spack/spack/solver/msvc_compatibility.lp
@@ -1,0 +1,43 @@
+% Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+% Spack Project Developers. See the top-level COPYRIGHT file for details.
+%
+% SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+%=============================================================================
+% msvc compatibility rules for reusing solves.
+%
+% These rules are used on Windows w/ MSVC
+%=============================================================================
+
+% A package cannot be reused if the msvc is not compatible with it
+error(100, "Cannot reuse {0} since we cannot determine msvc compatibility", ReusedPackage)
+  :- provider(node(X, MsvcToolsetPackage), node(0, "msvc")),
+     attr("version", node(X, MsvcToolsetPackage), MsvcToolsetVersion),
+     attr("hash", node(R, ReusedPackage), Hash),
+     % msvc packages can be reused without the "compatible_msvc_toolset" attribute
+     ReusedPackage != MsvcToolsetPackage,
+     not attr("compatible_msvc_toolset", node(R, ReusedPackage), MsvcToolsetPackage, MsvcToolsetVersion).
+
+% A msvc toolset is needed in the DAG
+:- has_built_packages(), not provider(_, node(0, "msvc-toolset")).
+
+% Non-msvc reused specs must be host msvc compatible. In case we build packages, we get a
+% host compatible msvc provider from other rules. If nothing is built, there is no msvc provider,
+% since it's pruned from reusable specs, meaning we have to explicitly impose reused specs are host
+% compatible.
+:- attr("hash", node(R, ReusedPackage), Hash),
+   not provider(node(R, ReusedPackage), node(0, "msvc-toolset")),
+   not attr("compatible_msvc_toolset", node(R, ReusedPackage), _, _).
+
+% The msvc provider must be one that a compiler can target
+:- has_built_packages(),
+   provider(node(X, MsvcToolsetPackage), node(0, "msvc-toolset")),
+   attr("node", node(X, MsvcToolsetPackage)),
+   attr("version", node(X, MsvcToolsetPackage), MsvcToolsetVersion),
+   not host_msvc(MsvcToolsetPackage, MsvcToolsetVersion).
+
+% A built node must depend on msvc
+:- build(PackageNode),
+   provider(MsvcToolsetNode, node(0, "msvc-toolset")),
+   not external(PackageNode),
+   not depends_on(PackageNode, MsvcToolsetNode).

--- a/var/spack/repos/builtin/packages/msvc-toolset/package.py
+++ b/var/spack/repos/builtin/packages/msvc-toolset/package.py
@@ -6,7 +6,7 @@ from spack.package import *
 
 
 class MsvcToolset(BundlePackage):
-    """Msvc Toolset - high level representation of the suite 
+    """Msvc Toolset - high level representation of the suite
     of tools containing Microsofts Visual C/C++ compilers, linkers
     runtimes, and other tools/libraries
 
@@ -15,7 +15,6 @@ class MsvcToolset(BundlePackage):
 
     homepage = "https://learn.microsoft.com/en-us/cpp/"
 
-
     maintainers("johnwparent")
 
     license("Microsoft Product Terms", checked_by="johnwparent")
@@ -23,10 +22,10 @@ class MsvcToolset(BundlePackage):
     # Each of these correspond to a specific version of VS
     # There is technically a 144 but that's a part of VS 2022
     # and is therefor still version 143
-    version("144") # VS 22 (not a typo, MS changed its versioning)
-    version("143") # VS 22
-    version("142") # VS 19
-    version("141") # VS 17
+    version("144")  # VS 22 (not a typo, MS changed its versioning)
+    version("143")  # VS 22
+    version("142")  # VS 19
+    version("141")  # VS 17
     # Spack does not support VS older than 17
 
     provides("msvc-runtime")

--- a/var/spack/repos/builtin/packages/msvc-toolset/package.py
+++ b/var/spack/repos/builtin/packages/msvc-toolset/package.py
@@ -8,7 +8,7 @@ from spack.package import *
 class MsvcToolset(BundlePackage):
     """Msvc Toolset - high level representation of the suite 
     of tools containing Microsofts Visual C/C++ compilers, linkers
-    and other tools/libraries
+    runtimes, and other tools/libraries
 
     Cannot be installed via Spack
     """

--- a/var/spack/repos/builtin/packages/msvc-toolset/package.py
+++ b/var/spack/repos/builtin/packages/msvc-toolset/package.py
@@ -1,0 +1,40 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class MsvcToolset(BundlePackage):
+    """Msvc Toolset - high level representation of the suite 
+    of tools containing Microsofts Visual C/C++ compilers, linkers
+    and other tools/libraries
+
+    Cannot be installed via Spack
+    """
+
+    homepage = "https://learn.microsoft.com/en-us/cpp/"
+
+
+    maintainers("johnwparent")
+
+    license("Microsoft Product Terms", checked_by="johnwparent")
+
+    # Each of these correspond to a specific version of VS
+    # There is technically a 144 but that's a part of VS 2022
+    # and is therefor still version 143
+    version("144") # VS 22 (not a typo, MS changed its versioning)
+    version("143") # VS 22
+    version("142") # VS 19
+    version("141") # VS 17
+    # Spack does not support VS older than 17
+
+    provides("msvc-runtime")
+
+    @property
+    def libs(self):
+        return LibraryList([])
+
+    @property
+    def headers(self):
+        return HeaderList([])

--- a/var/spack/repos/builtin/packages/msvc/package.py
+++ b/var/spack/repos/builtin/packages/msvc/package.py
@@ -169,6 +169,9 @@ class Msvc(Package, CompilerPackage):
         for msvc_version in sorted(MSC_TOOLCHAIN_MATRIX.keys(), key=lambda x: Version(x), reverse=True):
             if self.version.joined > Version(msvc_version):
                 return Version(MSC_TOOLCHAIN_MATRIX[msvc_version])
+            # if the current version isnt newer than anything available in the matrix it's not a version
+            # Spack supports as the lowest version in the matrix is the oldest version of VS17
+        raise RuntimeError(f"Current MSVC Version: {self.version} is unsupported by Spack")
 
     @property
     def short_msvc_version(self):

--- a/var/spack/repos/builtin/packages/msvc/package.py
+++ b/var/spack/repos/builtin/packages/msvc/package.py
@@ -25,10 +25,10 @@ def get_latest_valid_fortran_pth():
 
 
 MSC_TOOLCHAIN_MATRIX = {
-    "191025017" : "141",
-    "192027508" : "142",
-    "193030705" : "143",
-    "194033811" : "144"
+    "191025017": "141",
+    "192027508": "142",
+    "193030705": "143",
+    "194033811": "144",
 }
 
 
@@ -163,14 +163,17 @@ class Msvc(Package, CompilerPackage):
             "c": {"11": "/std:c11", "17": "/std:c17"},
         }
         return flags[language][standard]
-    
+
     def determine_msc_toolchain_version(self):
         """Determines the MSC Toolchain version from compiler version"""
-        for msvc_version in sorted(MSC_TOOLCHAIN_MATRIX.keys(), key=lambda x: Version(x), reverse=True):
+        for msvc_version in sorted(
+            MSC_TOOLCHAIN_MATRIX.keys(), key=lambda x: Version(x), reverse=True
+        ):
             if self.version.joined > Version(msvc_version):
                 return Version(MSC_TOOLCHAIN_MATRIX[msvc_version])
-            # if the current version isnt newer than anything available in the matrix it's not a version
-            # Spack supports as the lowest version in the matrix is the oldest version of VS17
+            # if the current version isnt newer than anything available
+            # in the matrix it's not a version Spack supports as the
+            # lowest version in the matrix is the oldest version of VS17
         raise RuntimeError(f"Current MSVC Version: {self.version} is unsupported by Spack")
 
     @property

--- a/var/spack/repos/builtin/packages/msvc/package.py
+++ b/var/spack/repos/builtin/packages/msvc/package.py
@@ -24,6 +24,14 @@ def get_latest_valid_fortran_pth():
     return FC_PATH[sort_fc_ver[-1]] if sort_fc_ver else None
 
 
+MSC_TOOLCHAIN_MATRIX = {
+    "191025017" : "141",
+    "192027508" : "142",
+    "193030705" : "143",
+    "194033811" : "144"
+}
+
+
 class Msvc(Package, CompilerPackage):
     """
     Microsoft Visual C++ is a compiler for the C, C++, C++/CLI and C++/CX programming languages.
@@ -155,6 +163,12 @@ class Msvc(Package, CompilerPackage):
             "c": {"11": "/std:c11", "17": "/std:c17"},
         }
         return flags[language][standard]
+    
+    def determine_msc_toolchain_version(self):
+        """Determines the MSC Toolchain version from compiler version"""
+        for msvc_version in sorted(MSC_TOOLCHAIN_MATRIX.keys(), key=lambda x: Version(x), reverse=True):
+            if self.version.joined > Version(msvc_version):
+                return Version(MSC_TOOLCHAIN_MATRIX[msvc_version])
 
     @property
     def short_msvc_version(self):


### PR DESCRIPTION
Currently with a lack of a libc analog, Windows binary compatibility is computed based off the host Windows OS version, which is a very long version string that Windows updates very frequently without actually changing anything significant about the OS (and Windows is incredibly backwards compatible anyway). This leads to frequent build cache invalidations, the inability to use public buildcaches, and even local binaries quickly falling out of re-useability. 

Instead, we should use the binary compatibility scheme laid out in the [MSVC docs](https://learn.microsoft.com/en-us/cpp/porting/binary-compat-2015-2017?view=msvc-170) to determine when binary compatibility is viable. 

Currently this is naive re-implementation of the libc compatibility work for the Windows platform and MSVC compiler. 



