### PR TITLE
Create a generic storage interface

### DIFF
--- a/lib/spack/spack/storage/__init__.py
+++ b/lib/spack/spack/storage/__init__.py
@@ -1,0 +1,28 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# Import any modules with storage implementions from here,
+# so they get registered without introducing any import
+# cycles.
+from .gcs import GCS  # noqa: F401
+from .localfs import LocalFileSystem  # noqa: F401
+from .s3 import S3  # noqa: F401
+from .storage_base import (
+    DuplicateStorageSchema,
+    StorageBase,
+    UnimplementedStorageInterface,
+    UnknownStorageTypeError,
+    from_url,
+    storage,
+)
+from .url_generic import URLStore  # noqa: F401
+
+__all__ = [
+    "storage",
+    "StorageBase",
+    "from_url",
+    "DuplicateStorageSchema",
+    "UnknownStorageTypeError",
+    "UnimplementedStorageInterface",
+]

--- a/lib/spack/spack/storage/credentials.py
+++ b/lib/spack/spack/storage/credentials.py
@@ -1,0 +1,79 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+from typing import Optional
+
+import spack.error
+
+
+class Credentials:
+    """Class for storing credentials"""
+
+    _attributes = [
+        "token",
+        "token_variable",
+        "access_pair_id",
+        "access_pair_id_variable",
+        "access_pair_secret",
+        "access_pair_secret_variable",
+    ]
+
+    def __init__(self, **kwargs):
+
+        for k, v in kwargs.items():
+            if k in self._attributes:
+                setattr(self, "_" + k, v)
+            elif k == "access_pair":
+                assert type(v) in (tuple, list)
+
+                setattr(self, "access_pair_id", v[0])
+                setattr(self, "access_pair_secret", v[1])
+
+    @property
+    def token(self) -> Optional[str]:
+        token = getattr(self, "_token", None)
+        if token:
+            return self.token
+        else:
+            return self._get_cred_from_env("_token_variable")
+
+    @property
+    def access_id(self) -> Optional[str]:
+        access_pair_id = getattr(self, "_access_pair_id", None)
+        if access_pair_id:
+            return access_pair_id
+        else:
+            return self._get_cred_from_env("_access_pair_id_variable")
+
+    @property
+    def access_secret(self) -> Optional[str]:
+        access_pair_secret = getattr(self, "_access_pair_secret", None)
+        if access_pair_secret:
+            return access_pair_secret
+        else:
+            return self._get_cred_from_env("_access_pair_secret_variable")
+        return None
+
+    @property
+    def access_profile(self) -> Optional[str]:
+        access_profile = getattr(self, "_access_profile", None)
+        if access_profile:
+            return access_profile
+        return None
+
+    def _get_cred_from_env(self, attribute) -> Optional[str]:
+        var = getattr(self, attribute, None)
+        if var:
+            try:
+                return os.environ[var]
+            except KeyError as e:
+                label = " ".join([part.capitalize() for part in attribute.split("_")[:-1]])
+                raise CredentialVariableNotFound(f"{label}: {var}") from e
+        else:
+            return None
+
+
+class CredentialVariableNotFound(spack.error.SpackError):
+    """Could not find the given credential variable in environment"""

--- a/lib/spack/spack/storage/gcs.py
+++ b/lib/spack/spack/storage/gcs.py
@@ -1,0 +1,58 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+import io
+import pathlib
+import re
+import urllib
+from datetime import datetime
+from typing import IO, Iterator, Optional, Union
+
+import spack.util.gcs as gcs
+
+from .storage_base import StatResult, StorageBase, storage
+
+
+@storage("gs")
+@storage("gcs")
+class GCS(StorageBase):
+    def __init__(self, url, **kwargs):
+        super().__init__(url)
+        self.client = gcs.gcs_client()
+
+    def _blob_url(self, key: Union[str, pathlib.Path]) -> str:
+        prefix = re.sub(r"^/*", "/", self.url.path)
+        blob_path = str(pathlib.PurePosixPath(pathlib.Path(prefix) / key)).lstrip("/")
+        return urllib.parse.urljoin(urllib.parse.urlunparse(self.url), blob_path)
+
+    def read(self, key: Union[str, pathlib.Path]) -> IO[str]:
+        blob = gcs.GCSBlob(self._blob_url(key), self.client)
+        return blob.get_blob_byte_stream()
+
+    def write(self, key: Union[str, pathlib.Path], data: Optional[IO[str]] = None):
+        if not data:
+            data = io.StringIO()
+
+        bucket = gcs.GCSBucket(self.url, self.client)
+        blob_path = urllib.parse.urlparse(self._blob_url(key)).path
+        blob = bucket.blob(blob_path)
+        blob.upload_from_file(data)
+
+    def _list(self) -> Iterator[str]:
+        bucket = gcs.GCSBucket(self.url)
+        return bucket.get_all_blobs(recursive=True)
+
+    def delete(self, key: Union[str, pathlib.Path]):
+        blob = gcs.GCSBlob(self._blob_url(key), self.client)
+        blob.delete_blob()
+
+    def stat(self, key: Union[str, pathlib.Path]) -> StatResult:
+        blob = gcs.GCSBlob(self._blob_url(key), self.client)
+        header = blob.get_blob_headers()
+        return StatResult(
+            int(header["Content-Length"]),
+            datetime.strptime(header["Last-Modified"], "%Y-%m-%d-%H:%M:%S.%f"),
+            created_at=datetime.strptime(header["Created-At"], "%Y-%m-%d-%H:%M:%S.%f"),
+        )

--- a/lib/spack/spack/storage/localfs.py
+++ b/lib/spack/spack/storage/localfs.py
@@ -1,0 +1,78 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import pathlib
+from datetime import datetime
+from typing import IO, Iterator, Optional, Union
+
+import spack.util.file_cache as fc
+
+from .storage_base import StatResult, StorageBase, storage
+
+
+@storage("file")
+class LocalFileSystem(StorageBase):
+    def __init__(self, url, **kwargs):
+        super().__init__(url)
+
+        timeout = kwargs.get("timeout", 120)
+        self.file_cache = fc.FileCache(self.url.path, timeout)
+
+    def read(self, key: Union[str, pathlib.Path]) -> IO[str]:
+        return open(key, "r", encoding="utf-8")
+
+    def read_transaction(self, key: Union[str, pathlib.Path]):
+        return self.file_cache.read_transaction(key)
+
+    def write(self, key: Union[str, pathlib.Path], data: Optional[IO[str]] = None):
+        if not data:
+            self.file_cache.init_entry(key)
+        else:
+            with self.file_cache.write_transaction(key) as (old, out):
+                out.write(data.read())
+
+    def write_transaction(self, key: Union[str, pathlib.Path]):
+        return self.file_cache.write_transaction(key)
+
+    def _list(self) -> Iterator[str]:
+        root = pathlib.Path(self.url.path)
+        for node in self._list_node(root, recursive=True):
+            yield str(node.relative_to(self.url.path))
+
+    def _list_node(self, root: pathlib.Path, recursive: bool = True) -> Iterator[pathlib.Path]:
+        dirstack = []
+        for node in root.iterdir():
+            if node.is_dir():
+                dirstack.append(node)
+            else:
+                yield node
+
+        if recursive:
+            for dnode in dirstack:
+                for node in self._list_node(dnode, recursive):
+                    yield node
+
+    def delete(self, key: Union[str, pathlib.Path], prune: bool = False):
+        node = self.file_cache.cache_path(key)
+
+        if node.is_file():
+            node.unlink(missing_ok=True)
+        if node.is_dir():
+            node.rmdir()
+
+    def stat(self, key: Union[str, pathlib.Path]) -> Optional[StatResult]:
+        node = self.file_cache.cache_path(key)
+        if node.exists():
+            result = node.stat()
+            return StatResult(
+                result.st_size,
+                datetime.fromtimestamp(result.st_mtime),
+                datetime.fromtimestamp(result.st_ctime),
+                datetime.fromtimestamp(result.st_atime),
+            )
+        return None
+
+    @property
+    def is_lockable(self) -> bool:
+        return True

--- a/lib/spack/spack/storage/s3.py
+++ b/lib/spack/spack/storage/s3.py
@@ -1,0 +1,113 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import io
+import os
+import pathlib
+import re
+from datetime import datetime
+from typing import IO, Iterator, Optional, Union
+
+import spack.config as cfg
+from spack.util.s3 import WrapStream, _parse_s3_endpoint_url
+from spack.util.web import _list_s3_objects
+
+from .credentials import Credentials
+from .storage_base import StatResult, StorageBase, storage
+
+
+@storage("s3")
+class S3(StorageBase):
+    def __init__(self, url, **kwargs):
+        super().__init__(url)
+
+        self.endpoint_url = kwargs.get("endpoint_url") or os.environ.get("S3_ENDPOINT_URL")
+        # Configure the override endpoint URL
+        if self.endpoint_url:
+            self.endpoint_url = _parse_s3_endpoint_url(self.endpoint_url)
+
+        self.creds = Credentials(**kwargs)
+
+        # Create the s3 client
+        self.client = self._get_client()
+
+    def _real_key(self, key: Union[str, pathlib.Path]) -> str:
+        prefix = re.sub(r"^/*", "/", self.url.path)
+        return str(pathlib.PurePosixPath(pathlib.Path(prefix) / key))
+
+    def read(self, key: Union[str, pathlib.Path]) -> IO[str]:
+        """Read the"""
+        obj = self.client.get_object(Bucket=self.url.netloc, Key=self._real_key(key))
+        return WrapStream(obj["Body"])  # type: ignore
+
+    def write(self, key: Union[str, pathlib.Path], data: Optional[IO[str]] = None):
+        # Create a dummy buffer to init the s3 entry
+        if not data:
+            data = io.StringIO()
+        self.client.put_object(Bucket=self.url.netloc, Key=self._real_key(key), Body=data.read())
+
+    def _list(self) -> Iterator[str]:
+        list_head = None
+        bucket = self.url.netloc
+
+        while True:
+            contents, list_head = _list_s3_objects(
+                self.client, bucket, self._real_key("/"), 1024, start_after=list_head
+            )
+
+            for x in contents:
+                yield x
+
+            if not list_head:
+                break
+
+    def delete(self, key: Union[str, pathlib.Path]):
+        self.client.delete_object(Bucket=self.url.netloc, Key=self._real_key(key))
+
+    def stat(self, key: Union[str, pathlib.Path]) -> StatResult:
+        obj = self.client.head_object(Bucket=self.url.netloc, Key=self._real_key(key))
+        headers = obj["ResponseMetadata"]["HTTPHeaders"]
+        return StatResult(
+            int(headers["Content-Length"]),
+            datetime.strptime(headers["Last-Modified"], "%Y-%m-%d-%H:%M:%S.%f"),
+        )
+
+    def _get_client(self):
+        from boto3 import Session
+        from botocore import UNSIGNED
+        from botocore._client import Config
+        from botocore.exceptions import ClientError
+
+        connection_args = dict()
+
+        access_token = self.creds.token
+        access_id = self.creds.access_id
+        access_secret = self.creds.access_secret
+        access_profile = self.creds.access_profile
+
+        if access_token:
+            connection_args["aws_session_token"] = access_token
+
+        if access_id and access_secret:
+            connection_args["aws_access_key_id"] = access_id
+            connection_args["aws_secret_access_key"] = access_secret
+
+        if access_profile:
+            connection_args["profile_name"] = access_profile
+
+        session = Session(**connection_args)
+
+        client_args = {"use_ssl": cfg.get("config:verify_ssl")}
+
+        if self.endpoint_url:
+            client_args["endpoint_url"] = self.endpoint_url
+
+        # if no access credentials provided above, then access anonymously
+        if not session.get_credentials():
+            client_args["config"] = Config(signature_version=UNSIGNED)
+
+        client = session.client("s3", **client_args)
+        client.ClientError = ClientError
+
+        return client

--- a/lib/spack/spack/storage/storage_base.py
+++ b/lib/spack/spack/storage/storage_base.py
@@ -1,0 +1,235 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import pathlib
+import urllib.parse
+import uuid
+from contextlib import contextmanager
+from datetime import datetime
+from typing import IO, Callable, Dict, Iterator, Optional, Type, Union
+
+import spack.error
+
+
+class StatResult:
+    """Result from stating a key in Storage."""
+
+    def __init__(
+        self,
+        size: int,
+        mtime: datetime,
+        created_at: Optional[datetime] = None,
+        accessed_at: Optional[datetime] = None,
+    ):
+        self.size = size
+        self.mtime = mtime
+        self.ctime = created_at
+        self.atime = accessed_at
+
+    size: int
+    mtime: datetime
+    ctime: Optional[datetime]
+    atime: Optional[datetime]
+
+    def __str__(self):
+        return f"{self.size} bytes, {self.mtime}"
+
+
+class StorageBase:
+    """Storage is an abstract class that implements APIs with the guarentee
+    of atomic reads and writes to a backing storage location.
+    """
+
+    def __init__(self, url: Union[str, urllib.parse.ParseResult]):
+        if not isinstance(url, urllib.parse.ParseResult):
+            self.url = urllib.parse.urlparse(url)
+        else:
+            self.url = url
+
+        self._can_write: Optional[bool] = None
+
+    def try_read(self, key: Union[str, pathlib.Path]) -> Optional[IO[str]]:
+        """Attempt to get object from storage. On failure return None.
+
+        Args:
+            key: key of the item in the store
+        """
+        try:
+            return self.read(key)
+        except Exception:
+            return None
+
+    def read(self, key: Union[str, pathlib.Path]) -> IO[str]:
+        """Read object from storage without locking guarentees.
+
+        Args:
+            key: key of the item in the store
+        """
+        raise UnimplementedStorageInterface("read")
+
+    @contextmanager
+    def read_transaction(self, key: Union[str, pathlib.Path]):
+        """Create a reading context. If storage 'is_lockable' this guarantees
+        no write occurs during read. Otherwise guarentees atomic read.
+
+            Args:
+                key: key of the item in the store
+
+            Return:
+                reading context that yields an Optional[IO[str]]
+        """
+        yield self.try_read(key)
+
+    def write(self, key: Union[str, pathlib.Path], stream: Optional[IO[str]] = None):
+        """Write object into storage. This operation is generally atomic.
+
+        Args:
+            key: key of the item in the store
+            steam (optional): stream of data to write.
+                If this is none than the file simply created in the store.
+        """
+        raise UnimplementedStorageInterface("write")
+
+    @contextmanager
+    def write_transaction(self, key: Union[str, pathlib.Path]):
+        """Create a write transaction context. If storage 'is_lockable' this
+        guarantees single writer. Otherwise guarentees an atomic write.
+
+            Args:
+                key: key of the item in the store
+
+            Returns:
+                A Context manager the produces a tuple of two streams.
+                    1. A stream to the current content stored at the key if it exists or None.
+                    2. A local stream that will be written to the key when exiting the context.
+        """
+        from io import StringIO
+
+        # Create a local write buffer
+        write_buffer = StringIO()
+        yield self.read(key), write_buffer  # type: ignore
+
+        write_buffer.seek(0)
+        self.write(key, write_buffer)
+
+    def list(self, filter_fn: Optional[Callable[[str], bool]] = None) -> Iterator[str]:
+        """List objects in storage with prefix.
+
+        Args:
+            filter_fn: A callback to filter the results of the list
+        """
+
+        if not filter_fn:
+            filter_fn = lambda x: True
+
+        for item in self._list():
+            if filter_fn(item):
+                yield item
+
+    def list_prefix(self, prefix: Union[str, pathlib.Path]) -> Iterator[str]:
+        prefix_filter = lambda key: str(key).lstrip("/").startswith(str(prefix).lstrip("/"))
+        for item in self.list(prefix_filter):
+            yield item
+
+    def _list(self) -> Iterator[str]:
+        """List all objects in the store"""
+        raise UnimplementedStorageInterface("_list")
+
+    def delete(self, key: Union[str, pathlib.Path]):
+        """Delete a key from the storage."""
+        raise UnimplementedStorageInterface("delete")
+
+    def stat(self, key: Union[str, pathlib.Path]) -> Optional[StatResult]:
+        raise UnimplementedStorageInterface("stat")
+
+    @property
+    def is_lockable(self) -> bool:
+        """Check if the key in the storage is lockable."""
+        return False
+
+    @property
+    def can_write(self) -> bool:
+        if self._can_write is not None:
+            return self._can_write
+
+        # Probe writing to the store.
+        # All storage should raise on failure to write
+        test_key = str(uuid.uuid4())
+        try:
+            with self.write_transaction(test_key) as (_, new):
+                new.write(".")
+            self.delete(test_key)
+            self._can_write = True
+        except Exception:
+            self._can_write = False
+            pass
+
+        return self._can_write
+
+
+_storage_types: Dict[str, Dict[str, Type[StorageBase]]] = {}
+
+
+def storage(storage_type: str, storage_id: Optional[str] = None):
+    """Register a new storage type.
+
+    Args:
+        storage_type: The primary key denoting the type of the underlying store.
+        storage_id (optional): a way to override the storage implementation for kwown
+            netlocs with more advanced query capabilities (ie. binaries.spack.io)
+    """
+
+    def register(cls):
+        if storage_type not in _storage_types:
+            _storage_types[storage_type] = {}
+
+        stores = _storage_types[storage_type]
+        name = storage_id or "__default__"
+
+        if name in stores:
+            raise DuplicateStorageSchema(f"{name} was previously registered as {storage_type}")
+
+        assert issubclass(cls, StorageBase)
+
+        stores[name] = cls
+        return cls
+
+    return register
+
+
+def from_url(url: Union[str, urllib.parse.ParseResult], **kwargs) -> StorageBase:
+    """Construct a registered storage object from a URL"""
+    if not isinstance(url, urllib.parse.ParseResult):
+        url = urllib.parse.urlparse(url)
+
+    storage_type = url.scheme
+    storage_name = "__default__"
+
+    try:
+        stores = _storage_types.get(url.scheme, {})
+        if stores:
+            if url.netloc and url.netloc in stores:
+                storage_name = url.netloc
+
+            return stores[storage_name](url, **kwargs)
+        else:
+            return _storage_types.get("__default__", {})[storage_name](url, **kwargs)
+
+    except KeyError as e:
+        raise UnknownStorageTypeError(f"type: {storage_type}, name: {storage_name}") from e
+
+
+class DuplicateStorageSchema(spack.error.SpackError):
+    """Duplicate names registered under the same storage scheme"""
+
+
+class UnknownStorageTypeError(spack.error.SpackError):
+    """Unknown storage type and or name detected"""
+
+
+class UnimplementedStorageInterface(spack.error.SpackError):
+    """Storage interface not implemented"""
+
+    def __init__(self, interface):
+        super().__init__(f"Unimplemented interface: {interface}")

--- a/lib/spack/spack/storage/url_generic.py
+++ b/lib/spack/spack/storage/url_generic.py
@@ -1,0 +1,30 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import codecs
+import pathlib
+import urllib
+from typing import IO, Union
+
+import spack.util.web as web_util
+
+from .storage_base import StorageBase, storage
+
+
+@storage("__default__")
+@storage("http")
+@storage("https")
+class URLStore(StorageBase):
+
+    def read(self, key: Union[str, pathlib.Path]) -> IO[str]:  # type: ignore[return-type]
+        key_path = str(pathlib.Path(self.url.path) / key)
+        key_url = urllib.parse.urljoin(urllib.parse.urlunparse(self.url), key_path)
+        _, _, resp = web_util.read_from_url(key_url)
+        return codecs.getreader("utf-8")(resp)  # type: ignore
+
+    # Unimplemented methods
+    #  -  write
+    #  -  list
+    #  -  delete
+    #  -  stat

--- a/lib/spack/spack/util/gcs.py
+++ b/lib/spack/spack/util/gcs.py
@@ -172,7 +172,7 @@ class GCSBlob:
 
         self.client = client or gcs_client()
 
-        self.bucket = GCSBucket(url)
+        self.bucket = GCSBucket(url, client)
 
         self.blob_path = self.url.path.lstrip("/")
 
@@ -221,6 +221,9 @@ class GCSBlob:
             "Content-encoding": blob.content_encoding,
             "Content-language": blob.content_language,
             "MD5Hash": blob.md5_hash,
+            "Content-Length": blob.size,
+            "Last-Modified": blob.time_created,
+            "Created-At": blob.time_created,
         }
 
         return headers


### PR DESCRIPTION
Create a new storage module in an attempt to containerize the different types of storage supported by Spack and use them more similarly to the existing `spack.util.file_cache` model.

Implement the concretizer cache using the new storage API to allow for sharing concretization caches between CI jobs using s3.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
