### PR TITLE
Installer only error for redistributable binaries when using cache-only

### DIFF
--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -227,6 +227,17 @@ class RebuildDecision:
 PrunerCallback = Callable[[spack.spec.Spec], RebuildDecision]
 
 
+def create_redistribution_pruner() -> PrunerCallback:
+    """Return a filter to skip CI for Specs that cannot be stored in a binary cache."""
+
+    def redistributable_filter(s: spack.spec.Spec) -> RebuildDecision:
+        if s.package.redistribute_binary:
+            return RebuildDecision(True, "redistributable")
+        return RebuildDecision(False, "not redistributable")
+
+    return redistributable_filter
+
+
 def create_unaffected_pruner(affected_specs: Set[spack.spec.Spec]) -> PrunerCallback:
     """Given a set of "affected" specs, return a filter that prunes specs
     not in the set."""
@@ -507,6 +518,9 @@ def generate_pipeline(env: ev.Environment, args) -> None:
 
     # Optionally add various pruning filters
     pruning_filters = []
+
+    if not options.private:
+        pruning_filters.append(create_redistribution_pruner())
 
     # Possibly prune specs that were unaffected by the change
     if options.prune_untouched:

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -230,12 +230,12 @@ PrunerCallback = Callable[[spack.spec.Spec], RebuildDecision]
 def create_redistribution_pruner() -> PrunerCallback:
     """Return a filter to skip CI for Specs that cannot be stored in a binary cache."""
 
-    def redistributable_filter(s: spack.spec.Spec) -> RebuildDecision:
+    def redistribute_binary_filter(s: spack.spec.Spec) -> RebuildDecision:
         if s.package.redistribute_binary:
-            return RebuildDecision(True, "redistributable")
-        return RebuildDecision(False, "not redistributable")
+            return RebuildDecision(True, "binary is redistributable")
+        return RebuildDecision(False, "binary is not redistributable")
 
-    return redistributable_filter
+    return redistribute_binary_filter
 
 
 def create_unaffected_pruner(affected_specs: Set[spack.spec.Spec]) -> PrunerCallback:
@@ -382,6 +382,7 @@ def collect_pipeline_options(env: ev.Environment, args) -> PipelineOptions:
     options.prune_external = args.prune_externals
     options.check_index_only = args.index_only
     options.forward_variables = args.forward_variable or []
+    options.private = args.private
 
     ci_config = cfg.get("ci")
 

--- a/lib/spack/spack/ci/common.py
+++ b/lib/spack/spack/ci/common.py
@@ -365,6 +365,7 @@ class PipelineOptions:
         pipeline_type: Optional[PipelineType] = None,
         require_signing: bool = False,
         cdash_handler: Optional["CDashHandler"] = None,
+        private: bool = False,
     ):
         """
         Args:
@@ -403,6 +404,7 @@ class PipelineOptions:
         self.require_signing = require_signing
         self.cdash_handler = cdash_handler
         self.forward_variables: List[str] = []
+        self.private = private
 
 
 class PipelineNode:

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -71,6 +71,11 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         "path to the file where generated jobs file should be written. "
         "default is .gitlab-ci.yml in the root of the repository",
     )
+    generate.add_argument(
+        "--private",
+        action="store_true",
+        help="for CI with a private mirror, include non-redistributable packages",
+    )
     prune_dag_group = generate.add_mutually_exclusive_group()
     prune_dag_group.add_argument(
         "--prune-dag",

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1267,10 +1267,17 @@ class BuildTask(Task):
                 self.success_result = ExecuteResult.SUCCESS
                 return
             elif self.cache_only:
-                self.error_result = spack.error.InstallError(
-                    "No binary found when cache-only was specified", pkg=pkg
-                )
-                return
+                # only require cache for packages with redistrubutable binaries
+                if not pkg.redistribute_binary:
+                    tty.msg(
+                        f"No binary for {pkg_id} which is not redistributable:"
+                        " installing from source"
+                    )
+                else:
+                    self.error_result = spack.error.InstallError(
+                        "No binary found when cache-only was specified", pkg=pkg
+                    )
+                    return
             else:
                 tty.msg(f"No binary for {pkg_id} found: installing from source")
 

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -353,13 +353,21 @@ spack:
         assert ci_obj["custom_attribute"] == "custom!"
 
 
-def test_ci_generate_pkg_with_deps(ci_generate_test, tmp_path: pathlib.Path, ci_base_environment):
+@pytest.mark.parametrize("private", [True, False])
+def test_ci_generate_pkg_with_deps(
+    ci_generate_test, tmp_path: pathlib.Path, ci_base_environment, private
+):
     """Test pipeline generation for a package w/ dependencies"""
+    extra_args = []
+    if private:
+        extra_args.append("--private")
+
     spack_yaml, outputfile, _ = ci_generate_test(
         f"""\
 spack:
   specs:
     - dependent-install
+    - no-redistribute-dependent
   mirrors:
     buildcache-destination: {tmp_path / 'ci-mirror'}
   ci:
@@ -375,12 +383,22 @@ spack:
         build-job:
           tags:
             - donotcare
-"""
+""",
+        *extra_args,
     )
     yaml_contents = syaml.load(outputfile.read_text())
 
     found = []
     for ci_key, ci_obj in yaml_contents.items():
+        if "no-redistribute-dependent" in ci_key:
+            assert "stage" in ci_obj
+            assert ci_obj["stage"] == "stage-1"
+            found.append("no-redistribute-dependent")
+        elif "no-redistribute" in ci_key:
+            # This should only be allowed when private is enabled
+            assert private and "stage" in ci_obj
+            assert private and ci_obj["stage"] == "stage-0"
+            found.append("no-redistribute")
         if "dependency-install" in ci_key:
             assert "stage" in ci_obj
             assert ci_obj["stage"] == "stage-0"
@@ -390,6 +408,8 @@ spack:
             assert ci_obj["stage"] == "stage-1"
             found.append("dependent-install")
 
+    assert private == ("no-redistribute" in found)
+    assert "no-redistribute-dependent" in found
     assert "dependent-install" in found
     assert "dependency-install" in found
 

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -152,6 +152,20 @@ def test_install_from_cache_errors(install_mockery):
     assert not spec.package.installed_from_binary_cache
 
 
+def test_install_from_cache_no_redistribute(install_mockery, capfd):
+    """Test to ensure cover install from cache errors."""
+    spec = spack.concretize.concretize_one("no-redistribute")
+    assert spec.concrete
+
+    # Check with cache-only
+    PackageInstaller(
+        [spec.package], package_cache_only=True, dependencies_cache_only=True
+    ).install()
+    assert not spec.package.installed_from_binary_cache
+    out = capfd.readouterr()[0]
+    assert "installing from source" in out
+
+
 def test_install_from_cache_ok(install_mockery, monkeypatch):
     """Test to ensure cover _install_from_cache to the return."""
     spec = spack.concretize.concretize_one("trivial-install-test-package")

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -706,7 +706,7 @@ _spack_ci() {
 }
 
 _spack_ci_generate() {
-    SPACK_COMPREPLY="-h --help --output-file --prune-dag --no-prune-dag --prune-unaffected --no-prune-unaffected --prune-externals --no-prune-externals --check-index-only --artifacts-root --forward-variable -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated -j --jobs"
+    SPACK_COMPREPLY="-h --help --output-file --private --prune-dag --no-prune-dag --prune-unaffected --no-prune-unaffected --prune-externals --no-prune-externals --check-index-only --artifacts-root --forward-variable -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated -j --jobs"
 }
 
 _spack_ci_rebuild_index() {

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -956,11 +956,13 @@ complete -c spack -n '__fish_spack_using_command ci' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command ci' -s h -l help -d 'show this help message and exit'
 
 # spack ci generate
-set -g __fish_spack_optspecs_spack_ci_generate h/help output-file= prune-dag no-prune-dag prune-unaffected no-prune-unaffected prune-externals no-prune-externals check-index-only artifacts-root= forward-variable= f/force U/fresh reuse fresh-roots deprecated j/jobs=
+set -g __fish_spack_optspecs_spack_ci_generate h/help output-file= private prune-dag no-prune-dag prune-unaffected no-prune-unaffected prune-externals no-prune-externals check-index-only artifacts-root= forward-variable= f/force U/fresh reuse fresh-roots deprecated j/jobs=
 complete -c spack -n '__fish_spack_using_command ci generate' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command ci generate' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command ci generate' -l output-file -r -f -a output_file
 complete -c spack -n '__fish_spack_using_command ci generate' -l output-file -r -d 'pathname for the generated gitlab ci yaml file'
+complete -c spack -n '__fish_spack_using_command ci generate' -l private -f -a private
+complete -c spack -n '__fish_spack_using_command ci generate' -l private -d 'for CI with a private mirror, include non-redistributable packages'
 complete -c spack -n '__fish_spack_using_command ci generate' -l prune-dag -f -a prune_dag
 complete -c spack -n '__fish_spack_using_command ci generate' -l prune-dag -d 'skip up-to-date specs'
 complete -c spack -n '__fish_spack_using_command ci generate' -l no-prune-dag -f -a prune_dag

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/no_redistribute/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/no_redistribute/package.py
@@ -15,8 +15,9 @@ class NoRedistribute(Package):
     url = "http://www.example.com/no-redistribute-1.0.tar.gz"
 
     redistribute(source=False, binary=False)
+    has_code = False
 
-    version("1.0", "0123456789abcdef0123456789abcdef")
+    version("1.0")
 
     def install(self, spec, prefix):
         # sanity_check_prefix requires something in the install directory


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Check if a package has redistributeable binaries before erroring on a `cache-only` install.

In Spack CI, the primary objective is to build packages to populate a build cache. Adding an option to skip pushing non-redistrubutable binaries in CI if the target mirror is not denoted as `private`. The option to not fail on missing non-redistrubutable binaries when using cache-only is required to allow non-redistrubutable packages to exist in CI run on non-private mirrors.