### PR TITLE
HIP language support

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -33,6 +33,7 @@ packages:
       glu: [mesa-glu, openglu]
       golang: [go, gcc]
       go-or-gccgo-bootstrap: [go-bootstrap, gcc]
+      hip-lang: [llvm-amdgpu]
       iconv: [libiconv]
       ipp: [intel-oneapi-ipp]
       java: [openjdk, jdk]

--- a/lib/spack/spack/build_systems/compiler.py
+++ b/lib/spack/spack/build_systems/compiler.py
@@ -199,9 +199,20 @@ class CompilerPackage(spack.package_base.PackageBase):
             return self.spec.extra_attributes["compilers"].get("cxx", None)
         return self._cxx_path()
 
+    @property
+    def hip(self) -> Optional[str]:
+        assert self.spec.concrete, "cannot retrieve HIP compiler, spec is not concrete"
+        if self.spec.external:
+            return self.spec.extra_attributes["compilers"].get("hip", None)
+        return self._hip_path()
+
     def _cxx_path(self) -> Optional[str]:
         """Returns the path to the C++ compiler, if the package was installed by Spack"""
         return None
+
+    def _hip_path(self) -> Optional[str]:
+        """Returns the path to the HIP compiler, if the package was installed by Spack"""
+        return self._cxx_path()
 
     @property
     def fortran(self):

--- a/lib/spack/spack/build_systems/rocm.py
+++ b/lib/spack/spack/build_systems/rocm.py
@@ -77,7 +77,7 @@
 import os
 
 import spack.variant
-from spack.directives import conflicts, depends_on, variant
+from spack.directives import conflicts, depends_on, requires, variant
 from spack.package_base import PackageBase
 from spack.util.environment import EnvironmentModifications
 
@@ -140,9 +140,7 @@ class ROCmPackage(PackageBase):
         when="+rocm",
     )
 
-    depends_on("llvm-amdgpu", type="build", when="+rocm")
-    depends_on("hsa-rocr-dev", when="+rocm")
-    depends_on("hip +rocm", when="+rocm")
+    depends_on("hip-lang", type="build", when="+rocm")
 
     # need amd gpu type for rocm builds
     conflicts("amdgpu_target=none", when="+rocm")
@@ -183,14 +181,14 @@ class ROCmPackage(PackageBase):
 
     # Add compiler minimum versions based on the first release where the
     # processor is included in llvm/lib/Support/TargetParser.cpp
-    depends_on("llvm-amdgpu@5.2.0:", when="amdgpu_target=gfx940")
-    depends_on("llvm-amdgpu@5.7.0:", when="amdgpu_target=gfx941")
-    depends_on("llvm-amdgpu@5.7.0:", when="amdgpu_target=gfx942")
-    depends_on("llvm-amdgpu@5.2.0:", when="amdgpu_target=gfx1036")
-    depends_on("llvm-amdgpu@5.3.0:", when="amdgpu_target=gfx1100")
-    depends_on("llvm-amdgpu@5.3.0:", when="amdgpu_target=gfx1101")
-    depends_on("llvm-amdgpu@5.3.0:", when="amdgpu_target=gfx1102")
-    depends_on("llvm-amdgpu@5.3.0:", when="amdgpu_target=gfx1103")
+    requires("%[virtuals=hip-lang] llvm-amdgpu@5.2.0:", when="amdgpu_target=gfx940")
+    requires("%[virtuals=hip-lang] llvm-amdgpu@5.7.0:", when="amdgpu_target=gfx941")
+    requires("%[virtuals=hip-lang] llvm-amdgpu@5.7.0:", when="amdgpu_target=gfx942")
+    requires("%[virtuals=hip-lang] llvm-amdgpu@5.2.0:", when="amdgpu_target=gfx1036")
+    requires("%[virtuals=hip-lang] llvm-amdgpu@5.3.0:", when="amdgpu_target=gfx1100")
+    requires("%[virtuals=hip-lang] llvm-amdgpu@5.3.0:", when="amdgpu_target=gfx1101")
+    requires("%[virtuals=hip-lang] llvm-amdgpu@5.3.0:", when="amdgpu_target=gfx1102")
+    requires("%[virtuals=hip-lang] llvm-amdgpu@5.3.0:", when="amdgpu_target=gfx1103")
 
     # Compiler conflicts
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1421,6 +1421,7 @@ compiler(Compiler) :- compiler_supports_target(Compiler, _, _).
 language("c").
 language("cxx").
 language("fortran").
+language("hip-lang").
 language_runtime("fortran-rt").
 
 error(10, "Only external, or concrete, compilers are allowed for the {0} language", Language)

--- a/var/spack/repos/builtin/packages/comgr/package.py
+++ b/var/spack/repos/builtin/packages/comgr/package.py
@@ -68,7 +68,7 @@ class Comgr(CMakePackage):
     depends_on("zlib-api", type="link")
     depends_on("z3", type="link")
     depends_on("ncurses", type="link")
-    requires(f"%[virtuals=c,cxx] llvm-amdgpu")
+    requires("%[virtuals=c,cxx] llvm-amdgpu")
 
     for ver in [
         "5.3.0",

--- a/var/spack/repos/builtin/packages/comgr/package.py
+++ b/var/spack/repos/builtin/packages/comgr/package.py
@@ -68,6 +68,7 @@ class Comgr(CMakePackage):
     depends_on("zlib-api", type="link")
     depends_on("z3", type="link")
     depends_on("ncurses", type="link")
+    requires(f"%[virtuals=c,cxx] llvm-amdgpu")
 
     for ver in [
         "5.3.0",
@@ -94,12 +95,9 @@ class Comgr(CMakePackage):
         "6.3.3",
         "master",
     ]:
-        # llvm libs are linked statically, so this *could* be a build dep
-        depends_on(f"llvm-amdgpu@{ver}", when=f"@{ver}")
-
-        # aomp may not build rocm-device-libs as part of llvm-amdgpu, so make
-        # that a conditional dependency
-        depends_on(f"rocm-device-libs@{ver}", when=f"@{ver} ^llvm-amdgpu ~rocm-device-libs")
+        # in reality this should be a link type dep, but libLLVM is linked statically,
+        # and just requiring llvm-amdgpu as a compiler suffices for now.
+        requires(f"%llvm-amdgpu@{ver}", when=f"@{ver}")
         depends_on(f"rocm-cmake@{ver}", when=f"@{ver}", type="build")
 
     for ver in [

--- a/var/spack/repos/builtin/packages/compiler-wrapper/cc.sh
+++ b/var/spack/repos/builtin/packages/compiler-wrapper/cc.sh
@@ -320,7 +320,7 @@ _command_from_flags() {
 
     case "$_lang" in
         c) command=cc ;;
-        c++|f77|f95) command="$_lang" ;;
+        c++|f77|f95|hip) command="$_lang" ;;
         *) command="$command_from_argv0" ;;  # drop unknown languages
     esac
 }
@@ -364,6 +364,14 @@ case "$command" in
         lang_flags=F
         debug_flags="-g"
         vcheck_flags="${SPACK_ALWAYS_FFLAGS}"
+        ;;
+    hip)
+        command="$SPACK_HIPCXX"
+        language="HIP"
+        comp="HIPCXX"
+        lang_flags=HIP
+        debug_flags="-g"
+        vcheck_flags="${SPACK_ALWAYS_HIPCXXFLAGS}"
         ;;
     ld|ld.gold|ld.lld)
         mode=ld

--- a/var/spack/repos/builtin/packages/compiler-wrapper/package.py
+++ b/var/spack/repos/builtin/packages/compiler-wrapper/package.py
@@ -43,7 +43,7 @@ class CompilerWrapper(Package):
     if sys.platform != "win32":
         version(
             "1.0",
-            sha256="c65a9d2b2d4eef67ab5cb0684d706bb9f005bb2be94f53d82683d7055bdb837c",
+            sha256="db44e5898aa9b8605e3cfe53a51649b4df504066f0f13562432f584fc88a5038",
             expand=False,
         )
     else:

--- a/var/spack/repos/builtin/packages/compiler-wrapper/package.py
+++ b/var/spack/repos/builtin/packages/compiler-wrapper/package.py
@@ -43,7 +43,7 @@ class CompilerWrapper(Package):
     if sys.platform != "win32":
         version(
             "1.0",
-            sha256="db44e5898aa9b8605e3cfe53a51649b4df504066f0f13562432f584fc88a5038",
+            sha256="01db837305c8e181f142da3341c8438e0a7b4e03f0361df19d5784ab68b3c1f2",
             expand=False,
         )
     else:

--- a/var/spack/repos/builtin/packages/compiler-wrapper/package.py
+++ b/var/spack/repos/builtin/packages/compiler-wrapper/package.py
@@ -156,6 +156,9 @@ class CompilerWrapper(Package):
             _var_list.append(("fortran", "fortran", "F77", "SPACK_F77"))
             _var_list.append(("fortran", "fortran", "FC", "SPACK_FC"))
 
+        if dependent_spec.has_virtual_dependency("hip-lang"):
+            _var_list.append(("hip-lang", "hip", "HIPCXX", "SPACK_HIPCXX"))
+
         # The package is not used as a compiler, so skip this setup
         if not _var_list:
             return

--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -69,6 +69,8 @@ class Hip(CMakePackage):
     depends_on("libedit", type="build")
     depends_on("perl@5.10:", type=("build", "run"))
 
+    requires("%[virtuals=c,cxx] llvm-amdgpu")
+
     test_requires_compiler = True
 
     with when("+rocm"):
@@ -123,8 +125,8 @@ class Hip(CMakePackage):
             "6.3.3",
         ]:
             depends_on(f"hsa-rocr-dev@{ver}", when=f"@{ver}")
+            requires(f"%llvm-amdgpu@{ver}", when=f"@{ver}")
             depends_on(f"comgr@{ver}", when=f"@{ver}")
-            depends_on(f"llvm-amdgpu@{ver} +rocm-device-libs", when=f"@{ver}")
             depends_on(f"rocminfo@{ver}", when=f"@{ver}")
             depends_on(f"roctracer-dev-api@{ver}", when=f"@{ver}")
 

--- a/var/spack/repos/builtin/packages/hipify-clang/package.py
+++ b/var/spack/repos/builtin/packages/hipify-clang/package.py
@@ -57,7 +57,7 @@ class HipifyClang(CMakePackage):
     depends_on("cxx", type="build")
 
     depends_on("cmake@3.5:", type="build")
-    requires(f"%[virtuals=c,cxx] llvm-amdgpu")
+    requires("%[virtuals=c,cxx] llvm-amdgpu")
 
     for ver in [
         "5.3.0",

--- a/var/spack/repos/builtin/packages/hipify-clang/package.py
+++ b/var/spack/repos/builtin/packages/hipify-clang/package.py
@@ -57,6 +57,8 @@ class HipifyClang(CMakePackage):
     depends_on("cxx", type="build")
 
     depends_on("cmake@3.5:", type="build")
+    requires(f"%[virtuals=c,cxx] llvm-amdgpu")
+
     for ver in [
         "5.3.0",
         "5.3.3",
@@ -82,7 +84,7 @@ class HipifyClang(CMakePackage):
         "6.3.3",
         "master",
     ]:
-        depends_on(f"llvm-amdgpu@{ver}", when=f"@{ver}")
+        requires(f"%llvm-amdgpu@{ver}", when=f"@{ver}")
 
     for ver in [
         "5.5.0",

--- a/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
+++ b/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
@@ -64,6 +64,7 @@ class HsaRocrDev(CMakePackage):
     depends_on("numactl")
     depends_on("pkgconfig")
     depends_on("libdrm", when="@6.3:")
+    requires(f"%[virtuals=c,cxx] llvm-amdgpu")
 
     for ver in [
         "5.3.0",
@@ -112,9 +113,7 @@ class HsaRocrDev(CMakePackage):
         "6.3.3",
         "master",
     ]:
-        depends_on(f"llvm-amdgpu@{ver}", when=f"@{ver}")
-        # allow standalone rocm-device-libs (useful for aomp)
-        depends_on(f"rocm-device-libs@{ver}", when=f"@{ver} ^llvm-amdgpu ~rocm-device-libs")
+        requires(f"%llvm-amdgpu@{ver}", when=f"@{ver}")
 
     for ver in [
         "5.5.0",

--- a/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
+++ b/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
@@ -64,7 +64,7 @@ class HsaRocrDev(CMakePackage):
     depends_on("numactl")
     depends_on("pkgconfig")
     depends_on("libdrm", when="@6.3:")
-    requires(f"%[virtuals=c,cxx] llvm-amdgpu")
+    requires("%[virtuals=c,cxx] llvm-amdgpu")
 
     for ver in [
         "5.3.0",

--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -23,6 +23,7 @@ class LlvmAmdgpu(CMakePackage, LlvmDetection, CompilerPackage):
         "c": "rocmcc/amdclang",
         "cxx": "rocmcc/amdclang++",
         "fortran": "rocmcc/amdflang",
+        "hip-lang": "rocmcc/amdclang++",
     }
 
     stdcxx_libs = ("-lstdc++",)

--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -59,6 +59,7 @@ class LlvmAmdgpu(CMakePackage, LlvmDetection, CompilerPackage):
         version("5.3.0", sha256="4e3fcddb5b8ea8dcaa4417e0e31a9c2bbdc9e7d4ac3401635a636df32905c93e")
 
     provides("c", "cxx")
+    provides("hip-lang")
     provides("fortran")
 
     variant(
@@ -372,3 +373,20 @@ class LlvmAmdgpu(CMakePackage, LlvmDetection, CompilerPackage):
 
     def _fortran_path(self):
         return os.path.join(self.spec.prefix.bin, "amdflang")
+
+    @classmethod
+    def runtime_constraints(cls, *, spec, pkg):
+        """Callback function to inject runtime-related rules into the solver.
+
+        Rule-injection is obtained through method calls of the ``pkg`` argument.
+
+        Args:
+            spec: spec that will inject runtime dependencies
+            pkg: object used to forward information to the solver
+        """
+        pkg("*").depends_on(
+            "hip +rocm",
+            when="%[virtuals=hip-lang] llvm-amdgpu",
+            type="link",
+            description="If any package uses %llvm-amdgpu for hip-lang, it depends on hip",
+        )


### PR DESCRIPTION
Now that the compilers as dependencies PR is merged, we can consider more language virtuals. This PR Is about making HIP a language.

* add language `hip-lang` (easier than renaming `hip -> hip-runtime` and making `hip` the language virtual)
* make `hip` package a runtime using a tag
* replace `depends_on("llvm-amdgpu")` with `requires("%[virtuals=c,cxx] llvm-amdgpu)` in hip and its dependencies
* add `hip` property to compilers for hip compiler path
* update compiler wrapper to infer language from `-x hip` (partially extracted to #49698)
* Set `HIPCXX` to the compiler wrapper and `SPACK_HIPCXX` to the hip compiler in the build environment. CMake respects the `HIPCXX` variable to initialize `CMAKE_HIP_COMPILER`, but I must say I'm not 100% sure it's common.

For those confused about `hipcc`: that is a compiler wrapper itself, which should call Spack's compiler wrapper for clang++ instead of clang++ directly. We shouldn't wrap it the other way around.

TODO:
- [ ] make `hipcc` dispatch to compiler wrapper instead of clang directly