### PR TITLE
Make spack pip installable

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,45 @@
+name: deploy
+on:
+  release:
+    types:
+      - published
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v4.2.2
+      - name: Set up python
+        uses: actions/setup-python@v5.6.0
+        with:
+          python-version: '3.13'
+      - name: Install pip dependencies
+        run: pip install build
+      - name: List pip dependencies
+        run: pip list
+      - name: Build project
+        run: python3 -m build
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: pypi-dist
+          path: dist/
+  pypi:
+    name: pypi
+    needs:
+      - build
+    environment:
+      name: pypi
+      url: https://pypi.org/p/spack
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4.3.0
+        with:
+          name: pypi-dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.12.4

--- a/lib/spack/spack/paths.py
+++ b/lib/spack/spack/paths.py
@@ -31,7 +31,7 @@ sbang_script = os.path.join(bin_path, "sbang")
 
 # spack directory hierarchy
 lib_path = os.path.join(prefix, "lib", "spack")
-module_path = os.path.join(lib_path, "spack")
+module_path = os.path.dirname(os.path.realpath(__file__))
 vendor_path = os.path.join(module_path, "vendor")
 command_path = os.path.join(module_path, "cmd")
 analyzers_path = os.path.join(module_path, "analyzers")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,16 @@ classifiers = [
     "Topic :: System :: Software Distribution",
     "Topic :: System :: Systems Administration",
 ]
-dependencies = ["clingo"]
+dependencies = [
+    "archspec",
+    "clingo",
+    "distro",
+    "jsonschema",
+    "jinja2",
+    "macholib",
+    "ruamel.yaml",
+    "typing_extensions",
+]
 dynamic = ["version"]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dynamic = ["version"]
 
 [project.scripts]
 # https://packaging.python.org/en/latest/specifications/entry-points/
-spack = "lib.spack.spack.main:main"
+spack = "spack.main:main"
 
 [tool.hatch.version]
 path = "lib/spack/spack/__init__.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,9 +89,7 @@ issues = "https://github.com/spack/spack/issues"
 
 [tool.hatch.build.targets.wheel]
 # https://hatch.pypa.io/latest/config/build/
-packages = ["lib/spack"]
-include = ["etc/spack/defaults"]
-exclude = ["lib/spack/docs"]
+packages = ["lib/spack/spack", "lib/spack/spack_installable", "etc/spack/defaults"]
 
 [tool.hatch.build.targets.wheel.sources]
 "etc/spack/defaults" = "spack/etc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ issues = "https://github.com/spack/spack/issues"
 [tool.hatch.build.targets.wheel]
 # https://hatch.pypa.io/latest/config/build/
 packages = ["lib/spack/spack", "lib/spack/spack_installable", "etc/spack/defaults"]
+exclude = ["lib/spack/spack/test"]
 
 [tool.hatch.build.targets.wheel.sources]
 "etc/spack/defaults" = "spack/etc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dynamic = ["version"]
 
 [project.scripts]
 # https://packaging.python.org/en/latest/specifications/entry-points/
-spack = "lib.spack.spack_installable.main:main"
+spack = "lib.spack.spack.main:main"
 
 [tool.hatch.version]
 path = "lib/spack/spack/__init__.py"
@@ -89,7 +89,7 @@ issues = "https://github.com/spack/spack/issues"
 
 [tool.hatch.build.targets.wheel]
 # https://hatch.pypa.io/latest/config/build/
-packages = ["lib/spack/spack", "lib/spack/spack_installable", "etc/spack/defaults"]
+packages = ["lib/spack/spack", "etc/spack/defaults"]
 exclude = ["lib/spack/spack/test"]
 
 [tool.hatch.build.targets.wheel.sources]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,61 @@
+# https://packaging.python.org/en/latest/specifications/pyproject-toml/
 [project]
 name = "spack"
 description = "The spack package manager"
+readme = "README.md"
 requires-python = ">=3.6"
-dependencies = ["clingo", "setuptools"]
+license = "MIT OR Apache-2.0"
+license-files = ["LICENSE-*"]
+authors = [
+    {name="Todd Gamblin", email="tgamblin@llnl.gov"},
+]
+maintainers = [
+    {name="Todd Gamblin", email="tgamblin@llnl.gov"},
+    {name="Adam J. Stewart", email="ajstewart426@gmail.com"},
+]
+keywords = [
+    "python",
+    "windows",
+    "macos",
+    "linux",
+    "package-manager",
+    "hpc",
+    "scientific-computing",
+    "spack",
+    "build-tools",
+    "radiuss",
+    "hpsf"
+]
+classifiers = [
+    # https://pypi.org/classifiers/
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Intended Audience :: End Users/Desktop",
+    "Intended Audience :: Information Technology",
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: System Administrators",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: System :: Installation/Setup",
+    "Topic :: System :: Software Distribution",
+    "Topic :: System :: Systems Administration",
+]
+dependencies = ["clingo"]
 dynamic = ["version"]
 
 [project.scripts]
+# https://packaging.python.org/en/latest/specifications/entry-points/
 spack = "lib.spack.spack_installable.main:main"
 
 [tool.hatch.version]
@@ -16,8 +66,6 @@ dev = [
   "pip>=21.3",
   "pytest",
   "pytest-xdist",
-  "setuptools",
-  "click",
   "black",
   "mypy",
   "isort",
@@ -27,24 +75,26 @@ dev = [
 ci = ["pytest-cov", "codecov[toml]"]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.26"]
 build-backend = "hatchling.build"
 
+# https://packaging.python.org/en/latest/specifications/well-known-project-urls/
+[project.urls]
+homepage = "https://spack.io/"
+source = "https://github.com/spack/spack"
+changelog = "https://github.com/spack/spack/blob/develop/CHANGELOG.md"
+releasenotes = "https://github.com/spack/spack/releases"
+documentation = "https://spack.readthedocs.io/en/latest/"
+issues = "https://github.com/spack/spack/issues"
+
 [tool.hatch.build.targets.wheel]
-include = [
-  "/bin",
-  "/etc",
-  "/lib",
-  "/share",
-  "/var",
-  "CITATION.cff",
-  "COPYRIGHT",
-  "LICENSE-APACHE",
-  "LICENSE-MIT",
-  "NOTICE",
-  "README.md",
-  "SECURITY.md",
-]
+# https://hatch.pypa.io/latest/config/build/
+packages = ["lib/spack"]
+include = ["etc/spack/defaults"]
+exclude = ["lib/spack/docs"]
+
+[tool.hatch.build.targets.wheel.sources]
+"etc/spack/defaults" = "spack/etc"
 
 [tool.hatch.envs.default]
 features = ["dev"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,16 +51,7 @@ classifiers = [
     "Topic :: System :: Software Distribution",
     "Topic :: System :: Systems Administration",
 ]
-dependencies = [
-    "archspec",
-    "clingo",
-    "distro",
-    "jsonschema",
-    "jinja2",
-    "macholib",
-    "ruamel.yaml",
-    "typing_extensions",
-]
+dependencies = ["clingo"]
 dynamic = ["version"]
 
 [project.scripts]


### PR DESCRIPTION
Follow-up to #32616 with newer package metadata
Closes #50238 without the custom shell scripts to maintain
Closes #1385 after a nice long wait

### Pitch

One of our goals for Spack 1.0 (or shortly thereafter) is to make Spack as easy to install as possible. This PR does two things (which could be separated into separate PRs if desired):

- [x] Support `pip install .` for installation (by modifying pyproject.toml, may require additional changes)
- [x] Support `pip install spack` for installation (by adding continuous deployment to PyPI)

### Usage

To test this PR, simply clone this branch and run:
```
python -m build
```
You can then see what gets placed in the sdist and bdist using:
```
tar tvzf dist/*.tar.gz
unzip -l dist/*.whl 
```
The package can be installed using:
```
pip install .
```
You can then run `spack help` and other commands to test things.

### sdist

At the moment, every file that is tracked by git ends up in the sdist. We can and should minimize this to remove random CI files, metadata, and tests.

### bdist

At the moment, the package will be installed with the following hierarchy:
```
<prefix>/bin/
    spack
<prefix>/lib/pythonX.Y/site-packages/
    spack/
        etc/
```
We need to decide what layout we plan to support, as this would currently require changing a lot of import paths to support.

### Resources

For those unfamiliar with Python packaging, the following resources are useful:

* https://packaging.python.org/en/latest/tutorials/packaging-projects/
* https://packaging.python.org/en/latest/guides/writing-pyproject-toml/
* https://packaging.python.org/en/latest/specifications/pyproject-toml/
* https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
* https://hatch.pypa.io/latest/config/build/
* https://github.com/pypa/gh-action-pypi-publish