### PR TITLE
Allow setting the gitopts using repo set

### DIFF
--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -100,6 +100,16 @@ def setup_parser(subparser: argparse.ArgumentParser):
         action="append",
         default=[],
     )
+    git_group = set_parser.add_mutually_exclusive_group()
+    git_group.add_argument(
+        "--branch", nargs="?", default=None, help="name of a branch to track for the repo"
+    )
+    git_group.add_argument(
+        "--tag", nargs="?", default=None, help="name of a tag to track for the repo"
+    )
+    git_group.add_argument(
+        "--commit", nargs="?", default=None, help="name of a commit to checkout for the repo"
+    )
     set_parser.add_argument(
         "--scope",
         action=arguments.ConfigScope,
@@ -444,9 +454,18 @@ def repo_set(args):
     if args.path:
         updated_entry["paths"] = args.path
 
+    # If the git checkout property is set, pop the old values
+    # and update with the new
+    if args.commit or args.tag or args.branch:
+        for label in ("commit", "tag", "branch"):
+            if label in updated_entry:
+                updated_entry.pop(label)
+            argv = getattr(args, label)
+            if argv:
+                updated_entry.update({label: argv})
+
     scope_repos[namespace] = updated_entry
     spack.config.set("repos", scope_repos, args.scope)
-
     tty.msg(f"Updated repo '{namespace}'")
 
 

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1638,17 +1638,9 @@ class RemoteRepoDescriptor(RepoDescriptor):
         super().__init__(name)
         self.repository = repository
 
-        checkout_vars = [branch, commit, tag]
-        if any(checkout_vars):
-            itvars = iter(checkout_vars)
-            if any(itvars) and any(itvars):
-                raise spack.error.ConfigError(
-                    "repo git checkout is ambiguous, only one option should be present"
-                )
-
-        self.branch = branch
-        self.commit = commit
-        self.tag = tag
+        self.ref: Optional[spack.util.git.GitRef] = spack.util.git.ref_from_strings(
+            branch=branch, tag=tag, commit=commit
+        )
         self.destination = destination
         self.relative_paths = relative_paths
         self.error: Optional[str] = None
@@ -1695,17 +1687,17 @@ class RemoteRepoDescriptor(RepoDescriptor):
                         self.branch = ref_match.group(1)
 
                     # determine the branch and remote if no config values exist
-                    elif not (self.commit or self.tag or self.branch):
+                    elif not self.ref:
                         self.branch = git("rev-parse", "--abbrev-ref", "HEAD", output=str).strip()
                         remote = git("config", f"branch.{self.branch}.remote", output=str).strip()
 
-                    if self.commit:
-                        spack.util.git.pull_checkout_commit(self.commit, git_exe=git)
+                    if self.ref.type == spack.util.git.GitRefType.COMMIT:
+                        spack.util.git.pull_checkout_commit(self.ref.commit, git_exe=git)
 
-                    elif self.tag:
-                        spack.util.git.pull_checkout_tag(self.tag, remote, depth, git_exe=git)
+                    elif self.ref.type == spack.util.git.GitRefType.TAG:
+                        spack.util.git.pull_checkout_tag(self.ref.ref, remote, depth, git_exe=git)
 
-                    elif self.branch:
+                    elif self.ref.type == spack.util.git.GitRefType.BRANCH:
                         # if the branch already exists we should use the
                         # previously configured remote
                         try:
@@ -1714,7 +1706,7 @@ class RemoteRepoDescriptor(RepoDescriptor):
                         except spack.util.executable.ProcessError:
                             pass
                         spack.util.git.pull_checkout_branch(
-                            self.branch, remote=remote, depth=depth, git_exe=git
+                            self.ref.ref, remote=remote, depth=depth, git_exe=git
                         )
 
             except spack.util.executable.ProcessError:

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1637,6 +1637,15 @@ class RemoteRepoDescriptor(RepoDescriptor):
     ) -> None:
         super().__init__(name)
         self.repository = repository
+
+        checkout_vars = [branch, commit, tag]
+        if any(checkout_vars):
+            itvars = iter(checkout_vars)
+            if any(itvars) and any(itvars):
+                raise spack.error.ConfigError(
+                    "repo git checkout is ambiguous, only one option should be present"
+                )
+
         self.branch = branch
         self.commit = commit
         self.tag = tag

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -676,10 +676,29 @@ def test_repo_set_git_config(mutable_config):
     repo("set", "--scope=user", "--destination", "/custom/path", "test-repo")
     repo("set", "--scope=user", "--path", "subdir1", "--path", "subdir2", "test-repo")
 
+    repo("set", "--scope=user", "--commit", "c702f5b89", "test-repo")
+
     # Check that the user config has the updated entry
     user_repos = spack.config.get("repos", scope="user")
     assert user_repos["test-repo"]["paths"] == ["subdir1", "subdir2"]
     assert user_repos["test-repo"]["destination"] == "/custom/path"
+    assert user_repos["test-repo"].get("commit") == "c702f5b89"
+    assert user_repos["test-repo"].get("branch") is None
+    assert user_repos["test-repo"].get("tag") is None
+
+    repo("set", "--scope=user", "--branch", "develop", "test-repo")
+
+    user_repos = spack.config.get("repos", scope="user")
+    assert user_repos["test-repo"].get("commit") is None
+    assert user_repos["test-repo"].get("branch") == "develop"
+    assert user_repos["test-repo"].get("tag") is None
+
+    repo("set", "--scope=user", "--tag", "release-tag", "test-repo")
+
+    user_repos = spack.config.get("repos", scope="user")
+    assert user_repos["test-repo"].get("commit") is None
+    assert user_repos["test-repo"].get("branch") is None
+    assert user_repos["test-repo"].get("tag") == "release-tag"
 
     # Check that site scope is unchanged
     site_repos = spack.config.get("repos", scope="site")

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -3,8 +3,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Single util module where Spack should get a git executable."""
 
+import enum
 import os
 import sys
+from collections import namedtuple
 from typing import List, Optional, overload
 
 from _vendoring.typing_extensions import Literal
@@ -18,6 +20,43 @@ import spack.util.executable as exe
 def _find_git() -> Optional[str]:
     """Find the git executable in the system path."""
     return exe.which_string("git", required=False)
+
+
+class GitRefType(enum.Enum):
+    REF = enum.auto()
+    COMMIT = enum.auto()
+    TAG = enum.auto()
+    BRANCH = enum.auto()
+
+
+GitRef = namedtuple("GitRef", ["ref", "commit", "type"])
+
+
+def ref_from_strings(
+    commit: str = "", tag: str = "", branch: str = "", ref: str = ""
+) -> Optional[GitRef]:
+    if ref:
+        assert not any((commit, tag, branch))
+        return GitRef(ref, None, GitRefType.REF)
+
+    # Tag and Branch cannot both be set
+    assert not (tag and branch)
+
+    # Only one of branch or tag can be set
+    # If tag or branch is set, use that over
+    # commit for the ref type
+    ref = tag or branch or commit
+
+    t = None
+    if tag:
+        t = GitRefType.TAG
+    elif branch:
+        t = GitRefType.BRANCH
+
+    if not t and commit:
+        t = GitRefType.COMMIT
+
+    return GitRef(ref, commit, t) if t else None
 
 
 @overload


### PR DESCRIPTION
For the use cases where we want to set repo parameters but don't want to clone the repo yet.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

CC: @alecbcs 