### PR TITLE
Add environment variable support for dependent packages from external configurations

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -715,7 +715,6 @@ def get_rpath_deps(pkg: spack.package_base.PackageBase) -> List[spack.spec.Spec]
 
 def setup_package(pkg, dirty, context: Context = Context.BUILD):
     """Execute all environment setup routines."""
-    tty.debug("AAL: In setup_package")
     if context not in (Context.BUILD, Context.TEST):
         raise ValueError(f"'context' must be Context.BUILD or Context.TEST - got {context}")
 
@@ -783,7 +782,6 @@ def setup_package(pkg, dirty, context: Context = Context.BUILD):
     # Make sure nothing's strange about the Spack environment.
     validate(env_mods, tty.warn)
     env_mods.apply_modifications()
-    print(f" AAL: LD_LIBRARY_PATH: {os.environ.get('LD_LIBRARY_PATH')}")
 
     # Return all env modifications we controlled (excluding module related ones)
     env_base.extend(env_mods)

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -715,6 +715,7 @@ def get_rpath_deps(pkg: spack.package_base.PackageBase) -> List[spack.spec.Spec]
 
 def setup_package(pkg, dirty, context: Context = Context.BUILD):
     """Execute all environment setup routines."""
+    tty.debug("AAL: In setup_package")
     if context not in (Context.BUILD, Context.TEST):
         raise ValueError(f"'context' must be Context.BUILD or Context.TEST - got {context}")
 
@@ -782,6 +783,7 @@ def setup_package(pkg, dirty, context: Context = Context.BUILD):
     # Make sure nothing's strange about the Spack environment.
     validate(env_mods, tty.warn)
     env_mods.apply_modifications()
+    print(f" AAL: LD_LIBRARY_PATH: {os.environ.get('LD_LIBRARY_PATH')}")
 
     # Return all env modifications we controlled (excluding module related ones)
     env_base.extend(env_mods)
@@ -1010,6 +1012,9 @@ class SetupContext:
         from leaf to root. That way externals cannot contribute search paths that would shadow
         Spack's prefixes, and dependents override variables set by dependencies."""
         env = EnvironmentModifications()
+        packages_config = spack.config.get("packages")
+        processed_packages = set()
+
         for dspec, flag in chain(self.external, self.nonexternal):
             tty.debug(f"Adding env modifications for {dspec.name}")
             pkg = dspec.package
@@ -1033,12 +1038,23 @@ class SetupContext:
                         pkg.setup_dependent_run_environment(run_env_mods, spec)
                 pkg.setup_run_environment(run_env_mods)
 
-                external_env = (dspec.extra_attributes or {}).get("environment", {})
-                if external_env:
-                    run_env_mods.extend(spack.schema.environment.parse(external_env))
+                # Custom environment variables from packages.yaml
+                if dspec.name not in processed_packages:
+                    processed_packages.add(dspec.name)
+                    package_entry = packages_config.get(dspec.name, {})
+                    package_externals = package_entry.get("externals", [])
+                    for external in package_externals:
+                        package_environment = external.get("environment", {})
+                        if package_environment:
+                            env_config = spack.schema.environment.parse(package_environment)
+                            run_env_mods.extend(env_config)
+
+                    external_env = (dspec.extra_attributes or {}).get("environment", {})
+                    if external_env:
+                        run_env_mods.extend(spack.schema.environment.parse(external_env))
 
                 if self.context == Context.BUILD:
-                    # Don't let the runtime environment of comiler like dependencies leak into the
+                    # Don't let the runtime environment of compiler like dependencies leak into the
                     # build env
                     run_env_mods.drop("CC", "CXX", "F77", "FC")
                 env.extend(run_env_mods)

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -894,3 +894,29 @@ def test_build_process_timeout(mock_build_process, runtime, timeout, expected_ca
     _ = spack.build_environment.complete_build_process(process)
 
     assert _TestProcess.calls == expected_calls
+
+
+def test_set_external_env_variables(mock_packages, mutable_config, working_env):
+    zlib_config = {
+        "externals": [
+            {
+                "spec": "zlib@1.2.13",
+                "prefix": "/usr",
+                "environment": {
+                    "set": {
+                        "LD_LIBRARY_PATH": "/test/fake/lib"
+                    }
+                }
+            }
+        ],
+        "buildable": False
+    }
+
+    spack.config.set("packages:zlib", zlib_config)
+    zlib_spec = spack.concretize.concretize_one("zlib")
+    setup_context = spack.build_environment.SetupContext(zlib_spec, context=Context.RUN)
+    env_modifications = setup_context.get_env_modifications()
+    test_env = os.environ.copy()
+    env_modifications.apply_modifications(test_env)
+
+    assert test_env["LD_LIBRARY_PATH"] == "/test/fake/lib"

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -902,14 +902,10 @@ def test_set_external_env_variables(mock_packages, mutable_config, working_env):
             {
                 "spec": "zlib@1.2.13",
                 "prefix": "/usr",
-                "environment": {
-                    "set": {
-                        "LD_LIBRARY_PATH": "/test/fake/lib"
-                    }
-                }
+                "environment": {"set": {"LD_LIBRARY_PATH": "/test/fake/lib"}},
             }
         ],
-        "buildable": False
+        "buildable": False,
     }
 
     spack.config.set("packages:zlib", zlib_config)

--- a/lib/spack/spack/user_environment.py
+++ b/lib/spack/spack/user_environment.py
@@ -11,7 +11,6 @@ import spack.spec
 import spack.util.environment as environment
 from spack import traverse
 from spack.context import Context
-from spack.schema.environment import parse
 
 #: Environment variable name Spack uses to track individually loaded packages
 spack_loaded_hashes_var = "SPACK_LOADED_HASHES"
@@ -113,17 +112,6 @@ def environment_modifications_for_specs(
     if set_package_py_globals:
         setup_context.set_all_package_py_globals()
     env.extend(setup_context.get_env_modifications())
-
-    # Custom environment modifications from packages.yaml
-    packages_config = spack.config.get("packages")
-    for spec in specs:
-        package_entry = packages_config.get(spec.name, {})
-        package_externals = package_entry.get("externals", [])
-        for external in package_externals:
-            package_environment = external.get("environment", {})
-            if package_environment:
-                env_config = parse(package_environment)
-                env.extend(env_config)
 
     # Apply view projections if any.
     if view:

--- a/lib/spack/spack/user_environment.py
+++ b/lib/spack/spack/user_environment.py
@@ -11,6 +11,7 @@ import spack.spec
 import spack.util.environment as environment
 from spack import traverse
 from spack.context import Context
+from spack.schema.environment import parse
 
 #: Environment variable name Spack uses to track individually loaded packages
 spack_loaded_hashes_var = "SPACK_LOADED_HASHES"
@@ -112,6 +113,17 @@ def environment_modifications_for_specs(
     if set_package_py_globals:
         setup_context.set_all_package_py_globals()
     env.extend(setup_context.get_env_modifications())
+
+    # Custom environment modifications from packages.yaml
+    packages_config = spack.config.get("packages")
+    for spec in specs:
+        package_entry = packages_config.get(spec.name, {})
+        package_externals = package_entry.get("externals", [])
+        for external in package_externals:
+            package_environment = external.get("environment", {})
+            if package_environment:
+                env_config = parse(package_environment)
+                env.extend(env_config)
 
     # Apply view projections if any.
     if view:


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Implement support for parsing environment variables defined in packages.yaml external configurations. Dependent packages can use external package environment variables during the build process with `spack install` and package loading with `spack load`.

This capability is documented here: https://spack.readthedocs.io/en/v0.21.3/configuration.html#environment-modifications but didn't appear to be implemented.