### PR TITLE
allow variable substitution in all configuration strings

### DIFF
--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -614,6 +614,11 @@ You can use this in conjunction with the ``-C`` / ``--config-scope`` argument to
 
    $ spack -C /path/to/my/scope config get packages
 
+If you want to see the fully merged configuration with variables expanded, you can use the `--expand-vars` flag:
+
+.. code-block:: console
+
+   $ spack config get --expand-vars
 
 .. _cmd-spack-config-blame:
 

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -52,6 +52,9 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         default=None,
         help="show configuration as seen by this environment spec group (requires active env)",
     )
+    get_parser.add_argument(
+        "--expand-vars", action="store_true", default=False, help="expand variables in the output"
+    )
 
     blame_parser = sp.add_parser(
         "blame", help="print configuration annotated with source file:line"
@@ -68,6 +71,9 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         metavar="group",
         default=None,
         help="show configuration as seen by this environment spec group (requires active env)",
+    )
+    blame_parser.add_argument(
+        "--expand-vars", action="store_true", default=False, help="expand variables in the output"
     )
 
     edit_parser = sp.add_parser("edit", help="edit configuration file")
@@ -213,13 +219,15 @@ def _print_configuration_helper(args, *, blame: bool) -> None:
     yaml = blame or not args.json
 
     if args.section is not None:
-        spack.config.CONFIG.print_section(args.section, yaml=yaml, blame=blame, scope=args.scope)
+        spack.config.CONFIG.print_section(
+            args.section, yaml=yaml, blame=blame, scope=args.scope, expand_vars=args.expand_vars
+        )
         return
 
-    print_flattened_configuration(blame=blame, yaml=yaml)
+    print_flattened_configuration(blame=blame, yaml=yaml, expand_vars=args.expand_vars)
 
 
-def print_flattened_configuration(*, blame: bool, yaml: bool) -> None:
+def print_flattened_configuration(*, blame: bool, yaml: bool, expand_vars: bool) -> None:
     """Prints to stdout a flattened version of the configuration.
 
     Args:
@@ -235,7 +243,7 @@ def print_flattened_configuration(*, blame: bool, yaml: bool) -> None:
         flattened[spack.schema.env.TOP_LEVEL_KEY] = syaml.syaml_dict()
 
     for config_section in spack.config.SECTION_SCHEMAS:
-        current = spack.config.get(config_section)
+        current = spack.config.get(config_section, expand_vars=expand_vars)
         flattened[spack.schema.env.TOP_LEVEL_KEY][config_section] = current
     if blame or yaml:
         syaml.dump_config(flattened, stream=sys.stdout, default_flow_style=False, blame=blame)

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -818,6 +818,8 @@ class Configuration:
         Note that the memoization cache for this function is cleared whenever
         any function decorated with ``@_config_mutator`` is called.
         """
+        from spack.util.path import substitute_path_variables
+
         _validate_section_name(section)
 
         if scope is not None and _merged_scope is not None:
@@ -862,6 +864,23 @@ class Configuration:
                 updated_scopes.append(config_scope)
 
             merged_section = spack.schema.merge_yaml(merged_section, data)
+
+        def substitute_vars(s):
+            if isinstance(s, syaml.syaml_str):
+                ret = syaml.syaml_str(substitute_path_variables(s))
+                syaml.mark(ret, s)
+                return ret
+            elif isinstance(s, str):
+                return substitute_path_variables(s)
+            elif isinstance(s, dict):
+                for k, v in s.items():
+                    s[k] = substitute_vars(v)
+            elif isinstance(s, list):
+                for i, item in enumerate(s):
+                    s[i] = substitute_vars(item)
+            return s
+
+        substitute_vars(merged_section)
 
         self.updated_scopes_by_section[section] = updated_scopes
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -983,7 +983,13 @@ class Configuration:
         yield from self.scopes.values()
 
     def print_section(
-        self, section: str, yaml: bool = True, blame: bool = False, *, scope: Optional[str] = None, expand_vars: bool = True
+        self,
+        section: str,
+        yaml: bool = True,
+        blame: bool = False,
+        *,
+        scope: Optional[str] = None,
+        expand_vars: bool = True,
     ) -> None:
         """Print a configuration to stdout.
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -731,7 +731,11 @@ class Configuration:
         scope._write_section(section)
 
     def get_config(
-        self, section: str, scope: Optional[str] = None, _merged_scope: Optional[str] = None
+        self,
+        section: str,
+        scope: Optional[str] = None,
+        _merged_scope: Optional[str] = None,
+        expand_vars: bool = True,
     ) -> YamlConfigDict:
         """Get configuration settings for a section.
 
@@ -757,7 +761,9 @@ class Configuration:
            }
 
         """
-        return self._get_config_memoized(section, scope=scope, _merged_scope=_merged_scope)
+        return self._get_config_memoized(
+            section, scope=scope, _merged_scope=_merged_scope, expand_vars=expand_vars
+        )
 
     def deepcopy_as_builtin(
         self, section: str, scope: Optional[str] = None, *, line_info: bool = False
@@ -811,7 +817,7 @@ class Configuration:
 
     @lang.memoized
     def _get_config_memoized(
-        self, section: str, scope: Optional[str], _merged_scope: Optional[str]
+        self, section: str, scope: Optional[str], _merged_scope: Optional[str], expand_vars: bool
     ) -> YamlConfigDict:
         """Memoized helper for ``get_config()``.
 
@@ -871,7 +877,8 @@ class Configuration:
                 syaml.mark(ret, s)
                 return ret
             elif isinstance(s, str):
-                return substitute_path_variables(s)
+                ret = substitute_path_variables(s)
+                return ret
             elif isinstance(s, dict):
                 for k, v in s.items():
                     s[k] = substitute_vars(v)
@@ -880,7 +887,8 @@ class Configuration:
                     s[i] = substitute_vars(item)
             return s
 
-        substitute_vars(merged_section)
+        if expand_vars:
+            substitute_vars(merged_section)
 
         self.updated_scopes_by_section[section] = updated_scopes
 
@@ -894,7 +902,13 @@ class Configuration:
             ret = syaml.syaml_dict(ret)
         return ret
 
-    def get(self, path: str, default: Optional[Any] = None, scope: Optional[str] = None) -> Any:
+    def get(
+        self,
+        path: str,
+        default: Optional[Any] = None,
+        scope: Optional[str] = None,
+        expand_vars: bool = True,
+    ) -> Any:
         """Get a config section or a single value from one.
 
         Accepts a path syntax that allows us to grab nested config map
@@ -911,7 +925,7 @@ class Configuration:
         parts = process_config_path(path)
         section = parts.pop(0)
 
-        value = self.get_config(section, scope=scope)
+        value = self.get_config(section, scope=scope, expand_vars=expand_vars)
 
         while parts:
             key = parts.pop(0)
@@ -969,7 +983,7 @@ class Configuration:
         yield from self.scopes.values()
 
     def print_section(
-        self, section: str, yaml: bool = True, blame: bool = False, *, scope: Optional[str] = None
+        self, section: str, yaml: bool = True, blame: bool = False, *, scope: Optional[str] = None, expand_vars: bool = True
     ) -> None:
         """Print a configuration to stdout.
 
@@ -978,10 +992,11 @@ class Configuration:
             yaml: If True, output in YAML format, otherwise JSON (ignored when blame is True).
             blame: Whether to include source locations for each entry.
             scope: The configuration scope to use.
+            expand_vars: Whether to expand variables.
         """
         try:
             data = syaml.syaml_dict()
-            data[section] = self.get_config(section, scope=scope)
+            data[section] = self.get_config(section, scope=scope, expand_vars=expand_vars)
             if yaml or blame:
                 syaml.dump_config(data, stream=sys.stdout, default_flow_style=False, blame=blame)
             else:
@@ -1665,9 +1680,11 @@ def add(fullpath: str, scope: Optional[str] = None) -> None:
     CONFIG.set(path, new, scope)
 
 
-def get(path: str, default: Optional[Any] = None, scope: Optional[str] = None) -> Any:
+def get(
+    path: str, default: Optional[Any] = None, scope: Optional[str] = None, expand_vars: bool = True
+) -> Any:
     """Module-level wrapper for ``Configuration.get()``."""
-    return CONFIG.get(path, default, scope)
+    return CONFIG.get(path, default, scope, expand_vars=expand_vars)
 
 
 _set = set  #: save this before defining set -- maybe config.set was ill-advised :)

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -488,7 +488,7 @@ def _rewrite_relative_repos_paths_on_relocation(env, init_file_dir, copied_env=F
             # only rewrite when we have a path-based repository
             if not isinstance(entry, str):
                 continue
-            repo_path = substitute_path_variables(entry)
+            repo_path = str(entry)  # wipe out mark to not change directory in this case
             expanded_path = spack.util.path.canonicalize_path(repo_path, default_wd=init_file_dir)
 
             # Skip if the substituted and expanded path is the same (e.g. when absolute)

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -733,7 +733,7 @@ class RepoPath:
         """Create a RepoPath from a configuration object."""
         overrides = {
             pkg_name: {
-                k: spack.util.path.substitute_path_variables(v)
+                k: spack.util.path.substitute_path_variables(v) if isinstance(v, str) else v
                 for k, v in data["package_attributes"].items()
             }
             for pkg_name, data in config.get_config("packages").items()

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -731,15 +731,11 @@ class RepoPath:
     @staticmethod
     def from_config(config: spack.config.Configuration) -> "RepoPath":
         """Create a RepoPath from a configuration object."""
-
-        def replace_vars_in_package_attrs(attrs):
-            for a in ("git", "url"):
-                if a in attrs:
-                    attrs[a] = spack.util.path.substitute_path_variables(attrs[a])
-            return attrs
-
         overrides = {
-            pkg_name: replace_vars_in_package_attrs(data["package_attributes"])
+            pkg_name: {
+                k: spack.util.path.substitute_path_variables(v)
+                for k, v in data["package_attributes"].items()
+            }
             for pkg_name, data in config.get_config("packages").items()
             if pkg_name != "all" and "package_attributes" in data
         }

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -731,8 +731,15 @@ class RepoPath:
     @staticmethod
     def from_config(config: spack.config.Configuration) -> "RepoPath":
         """Create a RepoPath from a configuration object."""
+
+        def replace_vars_in_package_attrs(attrs):
+            for a in ("git", "url"):
+                if a in attrs:
+                    attrs[a] = spack.util.path.substitute_path_variables(attrs[a])
+            return attrs
+
         overrides = {
-            pkg_name: data["package_attributes"]
+            pkg_name: replace_vars_in_package_attrs(data["package_attributes"])
             for pkg_name, data in config.get_config("packages").items()
             if pkg_name != "all" and "package_attributes" in data
         }

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -732,10 +732,7 @@ class RepoPath:
     def from_config(config: spack.config.Configuration) -> "RepoPath":
         """Create a RepoPath from a configuration object."""
         overrides = {
-            pkg_name: {
-                k: spack.util.path.substitute_path_variables(v) if isinstance(v, str) else v
-                for k, v in data["package_attributes"].items()
-            }
+            pkg_name: data["package_attributes"]
             for pkg_name, data in config.get_config("packages").items()
             if pkg_name != "all" and "package_attributes" in data
         }

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -170,7 +170,11 @@ def test_get_config_roundtrip(mutable_config):
     """Test that ``spack config get [--json] <section>`` roundtrips correctly."""
     json_roundtrip = json.loads(config("get", "--json", "config"))
     yaml_roundtrip = syaml.load(config("get", "config"))
-    assert json_roundtrip["config"] == yaml_roundtrip["config"] == mutable_config.get("config")
+    assert (
+        json_roundtrip["config"]
+        == yaml_roundtrip["config"]
+        == mutable_config.get("config", expand_vars=False)
+    )
 
 
 def test_get_all_config_roundtrip(mutable_config):
@@ -179,7 +183,7 @@ def test_get_all_config_roundtrip(mutable_config):
     yaml_roundtrip = syaml.load(config("get"))
     assert json_roundtrip == yaml_roundtrip
     for section in spack.config.SECTION_SCHEMAS:
-        assert json_roundtrip["spack"][section] == mutable_config.get(section)
+        assert json_roundtrip["spack"][section] == mutable_config.get(section, expand_vars=False)
 
 
 def test_get_config_scope_merged(mock_low_high_config):

--- a/lib/spack/spack/test/cmd/develop.py
+++ b/lib/spack/spack/test/cmd/develop.py
@@ -28,7 +28,7 @@ env = SpackCommand("env")
 @pytest.mark.usefixtures("mutable_mock_env_path", "mock_packages", "mock_fetch", "mutable_config")
 class TestDevelop:
     def check_develop(self, env, spec, path=None, build_dir=None):
-        path = path or spec.name
+        path = spack.util.path.substitute_path_variables(path) if path else spec.name
 
         # check in memory representation
         assert spec.name in env.dev_specs

--- a/lib/spack/spack/test/concretization/preferences.py
+++ b/lib/spack/spack/test/concretization/preferences.py
@@ -167,11 +167,16 @@ class TestConcretizePreferences:
                 {"url": "http://www.somewhereelse.com/mpileaks-1.0.tar.gz"},
                 "http://www.somewhereelse.com/mpileaks-2.3.tar.gz",
             ),
+            (
+                {"url": "$SOMEPATH/mpileaks-1.0.tar.gz"},
+                "file:///some/where/else/mpileaks-2.3.tar.gz",
+            ),
             ({}, "http://www.spack.llnl.gov/mpileaks-2.3.tar.gz"),
         ],
     )
-    def test_config_set_pkg_property_url(self, update, expected, mock_packages_repo):
+    def test_config_set_pkg_property_url(self, update, expected, mock_packages_repo, monkeypatch):
         """Test setting an existing attribute in the package class"""
+        monkeypatch.setenv("SOMEPATH", "file:///some/where/else")
         update_packages("mpileaks", "package_attributes", update)
         with spack.repo.use_repositories(mock_packages_repo):
             spec = concretize("mpileaks")

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -2093,7 +2093,9 @@ def test_missing_include_scope_write_directory(mock_missing_dir_include_scopes):
     install_tree = syaml.syaml_dict({"install_tree": {"root": "$spack/tmp/spack"}})
     spack.config.CONFIG.set("config", install_tree, scope="sub_base")
     assert os.path.exists(spack.config.CONFIG.scopes["sub_base"].path)
-    install_root = spack.config.CONFIG.get("config:install_tree:root", scope="sub_base")
+    install_root = spack.config.CONFIG.get(
+        "config:install_tree:root", scope="sub_base", expand_vars=False
+    )
     assert install_root == "$spack/tmp/spack"
 
 
@@ -2103,7 +2105,9 @@ def test_missing_include_scope_write_file(mock_missing_file_include_scopes):
     install_tree = syaml.syaml_dict({"install_tree": {"root": "$spack/tmp/spack"}})
     spack.config.CONFIG.set("config", install_tree, scope="sub_base")
     assert os.path.exists(spack.config.CONFIG.scopes["sub_base"].path)
-    install_root = spack.config.CONFIG.get("config:install_tree:root", scope="sub_base")
+    install_root = spack.config.CONFIG.get(
+        "config:install_tree:root", scope="sub_base", expand_vars=False
+    )
     assert install_root == "$spack/tmp/spack"
 
 

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -917,7 +917,9 @@ def test_single_file_scope(config, env_yaml):
         assert spack.config.get("packages:externalmodule:buildable") is False
         assert spack.config.get("repos") == {
             "z": "/x/y/z",
-            "builtin_mock": "$spack/var/spack/test_repos/spack_repo/builtin_mock",
+            "builtin_mock": spack_path.canonicalize_path(
+                "$spack/var/spack/test_repos/spack_repo/builtin_mock"
+            ),
         }
 
 
@@ -956,7 +958,9 @@ spack:
         assert not spack.config.get("packages:externalmodule")
         assert spack.config.get("repos") == {
             "z": "/x/y/z",
-            "builtin_mock": "$spack/var/spack/test_repos/spack_repo/builtin_mock",
+            "builtin_mock": spack_path.canonicalize_path(
+                "$spack/var/spack/test_repos/spack_repo/builtin_mock"
+            ),
         }
 
 

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -915,11 +915,9 @@ def test_single_file_scope(config, env_yaml):
         assert spack.config.get("config:checksum") is True
         assert spack.config.get("config:checksum") is True
         assert spack.config.get("packages:externalmodule:buildable") is False
-        assert spack.config.get("repos") == {
+        assert spack.config.get("repos", expand_vars=False) == {
             "z": "/x/y/z",
-            "builtin_mock": spack_path.canonicalize_path(
-                "$spack/var/spack/test_repos/spack_repo/builtin_mock"
-            ),
+            "builtin_mock": "$spack/var/spack/test_repos/spack_repo/builtin_mock",
         }
 
 
@@ -956,11 +954,9 @@ spack:
         # from the lower config scopes
         assert spack.config.get("config:checksum") is True
         assert not spack.config.get("packages:externalmodule")
-        assert spack.config.get("repos") == {
+        assert spack.config.get("repos", expand_vars=False) == {
             "z": "/x/y/z",
-            "builtin_mock": spack_path.canonicalize_path(
-                "$spack/var/spack/test_repos/spack_repo/builtin_mock"
-            ),
+            "builtin_mock": "$spack/var/spack/test_repos/spack_repo/builtin_mock",
         }
 
 

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -195,11 +195,17 @@ def substitute_config_variables(path):
     return re.sub(r"(\$\w+\b|\$\{\w+\})", repl, path)
 
 
+HOME_PREFIX = re.compile(rf"^~(?:[A-Za-z0-9_.-]+)?{re.escape(os.path.sep)}")
+
+
 def substitute_path_variables(path):
     """Substitute config vars, expand environment vars, expand user home."""
     path = substitute_config_variables(path)
     path = os.path.expandvars(path)
-    path = os.path.expanduser(path)
+    # ignore cases where ~ and ~user aren't used with a path separator
+    # this is to prevent ~variant strings from being expanded
+    if HOME_PREFIX.match(path):
+        path = os.path.expanduser(path)
     return path
 
 

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -32,7 +32,6 @@ import spack.error
 import spack.llnl.url
 import spack.util.executable
 import spack.util.parallel
-import spack.util.path
 import spack.util.url as url_util
 from spack.llnl.util import lang, tty
 from spack.llnl.util.filesystem import mkdirp, rename, working_dir
@@ -142,7 +141,7 @@ def custom_ssl_certs() -> Optional[Tuple[bool, str]]:
     ssl_certs = spack.config.get("config:ssl_certs")
     if not ssl_certs:
         return None
-    path = spack.util.path.substitute_path_variables(ssl_certs)
+    path = ssl_certs
     if not os.path.isabs(path):
         tty.debug(f"certs: relative path not allowed: {path}")
         return None

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -844,7 +844,7 @@ _spack_config() {
 _spack_config_get() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --json --group"
+        SPACK_COMPREPLY="-h --help --json --group --expand-vars"
     else
         _config_sections
     fi
@@ -853,7 +853,7 @@ _spack_config_get() {
 _spack_config_blame() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --group"
+        SPACK_COMPREPLY="-h --help --group --expand-vars"
     else
         _config_sections
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1263,7 +1263,7 @@ complete -c spack -n '__fish_spack_using_command config' -l scope -r -f -a '_bui
 complete -c spack -n '__fish_spack_using_command config' -l scope -r -d 'configuration scope to read/modify'
 
 # spack config get
-set -g __fish_spack_optspecs_spack_config_get h/help json group=
+set -g __fish_spack_optspecs_spack_config_get h/help json group= expand-vars
 complete -c spack -n '__fish_spack_using_command_pos 0 config get' -f -a 'bootstrap cdash ci compilers concretizer config definitions develop env_vars include mirrors modules packages repos toolchains upstreams view'
 complete -c spack -n '__fish_spack_using_command config get' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command config get' -s h -l help -d 'show this help message and exit'
@@ -1273,12 +1273,14 @@ complete -c spack -n '__fish_spack_using_command config get' -l group -r -f -a g
 complete -c spack -n '__fish_spack_using_command config get' -l group -r -d 'show configuration as seen by this environment spec group (requires active env)'
 
 # spack config blame
-set -g __fish_spack_optspecs_spack_config_blame h/help group=
+set -g __fish_spack_optspecs_spack_config_blame h/help group= expand-vars
 complete -c spack -n '__fish_spack_using_command_pos 0 config blame' -f -a 'bootstrap cdash ci compilers concretizer config definitions develop env_vars include mirrors modules packages repos toolchains upstreams view'
 complete -c spack -n '__fish_spack_using_command config blame' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command config blame' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command config blame' -l group -r -f -a group
 complete -c spack -n '__fish_spack_using_command config blame' -l group -r -d 'show configuration as seen by this environment spec group (requires active env)'
+complete -c spack -n '__fish_spack_using_command config blame' -l expand-vars -f -a expand_vars
+complete -c spack -n '__fish_spack_using_command config blame' -l expand-vars -d 'expand variables in the output'
 
 # spack config edit
 set -g __fish_spack_optspecs_spack_config_edit h/help print-file

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1271,6 +1271,8 @@ complete -c spack -n '__fish_spack_using_command config get' -l json -f -a json
 complete -c spack -n '__fish_spack_using_command config get' -l json -d 'output configuration as JSON'
 complete -c spack -n '__fish_spack_using_command config get' -l group -r -f -a group
 complete -c spack -n '__fish_spack_using_command config get' -l group -r -d 'show configuration as seen by this environment spec group (requires active env)'
+complete -c spack -n '__fish_spack_using_command config get' -l expand-vars -f -a expand_vars
+complete -c spack -n '__fish_spack_using_command config get' -l expand-vars -d 'expand variables in the output'
 
 # spack config blame
 set -g __fish_spack_optspecs_spack_config_blame h/help group= expand-vars


### PR DESCRIPTION
This allows using Spack configuration variables and environment variables in more places inside of the Spack configuration. This was originally started to allow `package_attributes` to make use of environment variables.

Example:
```yaml
# example: SITE_SPECIFIC_GIT_MIRROR=file:///some/local/shared/location
packages:
   foo:
      package_attributes:
         git: $SITE_SPECIFIC_GIT_MIRROR/foo.git
```

This was then further extended to perform variables substitution on all strings of the configuration. To maintain consistency with existing commands like `spack config get` and `spack config blame`, these were extended with a `--expand-vars` option which defaults to `False`. Internally all read configs are always expanded.