### PR TITLE
Add support for `<key>=*` for architecture-related variants

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -230,6 +230,8 @@ def _make_microarchitecture(name: str) -> spack.vendor.archspec.cpu.Microarchite
 class ArchSpec:
     """Aggregate the target platform, the operating system and the target microarchitecture."""
 
+    ANY_TARGET = _make_microarchitecture("*")
+
     @staticmethod
     def default_arch():
         """Return the default architecture"""
@@ -403,6 +405,11 @@ class ArchSpec:
         for attribute in ("platform", "os"):
             other_attribute = getattr(other, attribute)
             self_attribute = getattr(self, attribute)
+
+            # platform=* or os=*
+            if self_attribute and other_attribute == "*":
+                return True
+
             if other_attribute and self_attribute != other_attribute:
                 return False
 
@@ -441,6 +448,10 @@ class ArchSpec:
         # other_target is there and strict=True
         if self.target is None:
             return False
+
+        # self.target is not None, and other is target=*
+        if other.target == ArchSpec.ANY_TARGET:
+            return True
 
         return bool(self._target_intersection(other))
 

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2399,6 +2399,15 @@ def test_edge_representation(parent_str, child_str, kwargs, expected_str, expect
         ("mpileaks foo=abc", [("foo=*", True), ("bar=*", False)]),
         # Check the semantics for architecture related key value pairs
         (
+            "mpileaks",
+            [
+                ("target=*", False),
+                ("os=*", False),
+                ("platform=*", False),
+                ("target=* platform=*", False),
+            ],
+        ),
+        (
             "mpileaks target=x86_64",
             [
                 ("target=*", True),

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2390,3 +2390,39 @@ def test_edge_representation(parent_str, child_str, kwargs, expected_str, expect
     edge = DependencySpec(parent, child, depflag=0, **kwargs)
     assert str(edge) == expected_str
     assert repr(edge) == expected_repr
+
+
+@pytest.mark.parametrize(
+    "spec_str,assertions",
+    [
+        # Check <key>=* semantics for a "regular" variant
+        ("mpileaks foo=abc", [("foo=*", True), ("bar=*", False)]),
+        # Check the semantics for architecture related key value pairs
+        (
+            "mpileaks target=x86_64",
+            [
+                ("target=*", True),
+                ("os=*", False),
+                ("platform=*", False),
+                ("target=* platform=*", False),
+            ],
+        ),
+        ("mpileaks os=debian6", [("target=*", False), ("os=*", True), ("platform=*", False)]),
+        ("mpileaks platform=linux", [("target=*", False), ("os=*", False), ("platform=*", True)]),
+        ("mpileaks platform=linux", [("target=*", False), ("os=*", False), ("platform=*", True)]),
+        (
+            "mpileaks platform=linux target=x86_64",
+            [
+                ("target=*", True),
+                ("os=*", False),
+                ("platform=*", True),
+                ("target=* platform=*", True),
+            ],
+        ),
+    ],
+)
+def test_attribute_existence_in_satisfies(spec_str, assertions, mock_packages, config):
+    """Tests the semantics of <key>=* when used in Spec.satisfies"""
+    s = Spec(spec_str)
+    for test, expected in assertions:
+        assert s.satisfies(test) is expected


### PR DESCRIPTION
fixes #51124

This is coded in an adhoc way in the ArchSpec class. We might want to revisit this class in the future.

**Before the PR**
```python
Spack version 1.1.0.dev0
Python 3.13.2, Linux x86_64
>>> from spack.spec import Spec
>>> s = Spec("target=x86_64")
>>> probe = Spec("target=*")
>>> s.satisfies(probe)
False
>>> s = Spec("foo=x86_64")
>>> probe = Spec("foo=*")
>>> s.satisfies(probe)
True
>>> probe = Spec("platform=*")
>>> s = Spec("platform=linux")
>>> s.satisfies(probe)
False
```

**After the PR**
```python
Spack version 1.1.0.dev0
Python 3.13.2, Linux x86_64
>>> from spack.spec import Spec
>>> s = Spec("target=x86_64")
>>> probe = Spec("target=*")
>>> s.satisfies(probe)
True
>>> s = Spec("foo=x86_64")
>>> probe = Spec("foo=*")
>>> s.satisfies(probe)
True
>>> probe = Spec("platform=*")
>>> s = Spec("platform=linux")
>>> s.satisfies(probe)
True
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
