### PR TITLE
Spec: change how package hash is computed

### DIFF
--- a/lib/spack/spack/hash_types.py
+++ b/lib/spack/spack/hash_types.py
@@ -77,8 +77,11 @@ def _package_hash_override(spec) -> str:
     if spec.external:
         return "x" * 32
 
-    hash_content = [_content_hash(s).encode("utf-8") for s in _package_hash_nodes(spec)]
-    b32_hash = base64.b32encode(hashlib.sha256(bytes().join(hash_content)).digest()).lower()
+    hash_algorithm = hashlib.sha256()
+    for s in _package_hash_nodes(spec):
+        hash_algorithm.update(_content_hash(s).encode("utf-8"))
+
+    b32_hash = base64.b32encode(hash_algorithm.digest()).lower()
     return b32_hash.decode("utf-8")
 
 

--- a/lib/spack/spack/hash_types.py
+++ b/lib/spack/spack/hash_types.py
@@ -2,11 +2,18 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Definitions that control how Spack creates Spec hashes."""
+import base64
+import hashlib
+from typing import Any, Callable, Iterable, List, Optional
 
-from typing import Any, Callable, List, Optional
+from spack.vendor.typing_extensions import TYPE_CHECKING
 
 import spack.deptypes as dt
 import spack.repo
+import spack.traverse
+
+if TYPE_CHECKING:
+    import spack.spec
 
 HASHES: List["SpecHashDescriptor"] = []
 
@@ -57,15 +64,34 @@ dag_hash = SpecHashDescriptor(
 )
 
 
-def _content_hash_override(spec):
+def _content_hash(spec):
     pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
     pkg = pkg_cls(spec)
     return pkg.content_hash()
 
 
+def _package_hash_override(spec) -> str:
+    # Externals won't have a package hash, since their package.py file is not considered when
+    # they are installed. The content hash of external's package.py file is instead considered
+    # whenever they are dependencies of other packages.
+    if spec.external:
+        return "x" * 32
+
+    hash_content = [_content_hash(s).encode("utf-8") for s in _package_hash_nodes(spec)]
+    b32_hash = base64.b32encode(hashlib.sha256(bytes().join(hash_content)).digest()).lower()
+    return b32_hash.decode("utf-8")
+
+
+def _package_hash_nodes(spec) -> Iterable["spack.spec.Spec"]:
+    # Sorting by name is fine. We won't have duplicate build dependencies on a single node
+    build_deps = sorted(spec.dependencies(deptype=dt.BUILD), key=lambda x: x.name)
+    for s in spack.traverse.traverse_nodes([spec, *build_deps], deptype=("link", "run")):
+        yield s
+
+
 #: Package hash used as part of dag hash
 package_hash = SpecHashDescriptor(
-    depflag=0, package_hash=True, name="package_hash", override=_content_hash_override
+    depflag=0, package_hash=True, name="package_hash", override=_package_hash_override
 )
 
 

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -1385,11 +1385,14 @@ class TestConcretize:
         assert ht.build_hash(root) == ht.build_hash(new_root_with_reuse)
         assert ht.build_hash(root) != ht.build_hash(new_root_without_reuse)
 
-        # DAG hash should be the same with reuse since only the dependency changed
-        assert root.dag_hash() == new_root_with_reuse.dag_hash()
+        # Ensure we reused the same spec. DAG hash changes due to the change in package.py
+        # that might affect the build of "root", even though the dependencies are the same
+        assert root["changing"].dag_hash() == new_root_with_reuse["changing"].dag_hash()
+        assert root.dag_hash() != new_root_with_reuse.dag_hash()
+        assert root.package_hash() != new_root_with_reuse.package_hash()
 
-        # Structure and package hash will be different without reuse
-        assert root.dag_hash() != new_root_without_reuse.dag_hash()
+        # If we didn't reuse, then the DAG hash of dependencies changes
+        assert root["changing"].dag_hash() != new_root_without_reuse["changing"].dag_hash()
 
     @pytest.mark.regression("43663")
     def test_no_reuse_when_variant_condition_does_not_hold(self, mutable_database, mock_packages):
@@ -4278,3 +4281,32 @@ def test_when_possible_above_all(mutable_config, mock_packages):
     for result in solver.solve_in_rounds(specs):
         criteria = sorted(result.criteria, reverse=True)
         assert criteria[0].name == "number of input specs not concretized"
+
+
+def test_package_hash_on_changes_to_package_py(mutable_config, repo_with_changing_recipe):
+    """Tests that the package hash of an external spec stays the same when the package.py changes.
+    Instead, the package has of a spec depending on that external would change its package hash,
+    on a change to the external package recipe.
+    """
+    packages_yaml = syaml.load_config(
+        """
+packages:
+  changing:
+    buildable: false
+    externals:
+    - spec: "changing@1.0"
+      prefix: /path
+"""
+    )
+    mutable_config.set("packages", packages_yaml["packages"])
+
+    root_before = spack.concretize.concretize_one("root")
+    assert root_before["changing"].external
+
+    repo_with_changing_recipe.change({"delete_variant": True})
+
+    root_after = spack.concretize.concretize_one("root")
+    assert root_after["changing"].external
+
+    assert root_after.package_hash() != root_before.package_hash()
+    assert root_after["changing"].package_hash() == root_before["changing"].package_hash()

--- a/lib/spack/spack/test/util/package_hash.py
+++ b/lib/spack/spack/test/util/package_hash.py
@@ -4,6 +4,7 @@
 
 import ast
 import os
+import random
 
 import pytest
 
@@ -12,6 +13,7 @@ import spack.directives_meta
 import spack.paths
 import spack.repo
 import spack.util.package_hash as ph
+from spack.hash_types import _package_hash_nodes
 from spack.spec import Spec
 from spack.util.unparse import unparse
 
@@ -457,3 +459,25 @@ def test_multimethod_resolution(spec_str, source, expected, not_expected):
         assert item in filtered
     for item in not_expected:
         assert item not in filtered
+
+
+@pytest.mark.parametrize("spec_str", ["mpileaks", "mpich2", "callpath"])
+def test_stable_ordering_for_package_hash(spec_str, default_mock_concretization, monkeypatch):
+    """Tests that the order of the nodes used to compute the package hash stays stable when
+    the dependencies are returned in random order.
+    """
+    root = default_mock_concretization(spec_str)
+
+    expected_order = list(_package_hash_nodes(root))
+
+    original_fn = Spec.dependencies
+
+    def _dependency_shuffle(spec, *args, **kwargs):
+        result = original_fn(spec, *args, **kwargs)
+        random.shuffle(result)
+        return result
+
+    monkeypatch.setattr(Spec, "dependencies", _dependency_shuffle)
+
+    for _ in range(5):
+        assert list(_package_hash_nodes(root)) == expected_order


### PR DESCRIPTION
Refers to point (2) in https://github.com/spack/spack/pull/51118#issuecomment-3223844388

Up to now the package hash models only the content of the current node. This is not entirely correct, since building a concrete spec is also influenced by the package.py of dependencies, via callback methods like `setup_build_environment` etc.

This PR changes how we compute the package hash in the following way:
- The package hash of external specs is a known constant
- The package hash of built specs includes the content hash of all the dependencies

In this way we can capture changes in callback methods that are currently not accounted for by the hash.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
