### PR TITLE
spack audit packages: allow namespace in package names

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -572,12 +572,14 @@ def _ensure_all_package_names_are_lowercase(pkgs, error_cls):
     reserved_names = ("all",)
     badname_regex, errors = re.compile(r"[_A-Z]"), []
     for pkg_name in pkgs:
-        if pkg_name in reserved_names:
-            error_msg = f"The name '{pkg_name}' is reserved, and cannot be used for packages"
+        short_name = pkg_name.split(".")[-1]
+
+        if short_name in reserved_names:
+            error_msg = f"The name '{short_name}' is reserved, and cannot be used for packages"
             errors.append(error_cls(error_msg, []))
 
-        if badname_regex.search(pkg_name):
-            error_msg = f"Package name '{pkg_name}' should be lowercase and must not contain '_'"
+        if badname_regex.search(short_name):
+            error_msg = f"Package name '{short_name}' should be lowercase and must not contain '_'"
             errors.append(error_cls(error_msg, []))
     return errors
 
@@ -1224,7 +1226,8 @@ def _named_specs_in_when_arguments(pkgs, error_cls):
 
         def _refers_to_pkg(when):
             when_spec = spack.spec.Spec(when)
-            return when_spec.name is None or when_spec.name == pkg_name
+            # pkg_class.name strips namespace from pkg_name, more suitable check
+            return when_spec.name is None or when_spec.name == pkg_cls.name
 
         def _error_items(when_dict):
             for when, elts in when_dict.items():

--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -543,12 +543,14 @@ def _ensure_all_package_names_are_lowercase(pkgs, error_cls):
     reserved_names = ("all",)
     badname_regex, errors = re.compile(r"[_A-Z]"), []
     for pkg_name in pkgs:
-        if pkg_name in reserved_names:
-            error_msg = f"The name '{pkg_name}' is reserved, and cannot be used for packages"
+        short_name = pkg_name.split(".")[-1]
+
+        if short_name in reserved_names:
+            error_msg = f"The name '{short_name}' is reserved, and cannot be used for packages"
             errors.append(error_cls(error_msg, []))
 
-        if badname_regex.search(pkg_name):
-            error_msg = f"Package name '{pkg_name}' should be lowercase and must not contain '_'"
+        if badname_regex.search(short_name):
+            error_msg = f"Package name '{short_name}' should be lowercase and must not contain '_'"
             errors.append(error_cls(error_msg, []))
     return errors
 
@@ -1363,7 +1365,8 @@ def _named_specs_in_when_arguments(pkgs, error_cls):
 
         def _refers_to_pkg(when):
             when_spec = spack.spec.Spec(when)
-            return not when_spec.name or when_spec.name == pkg_name
+            # pkg_class.name strips namespace from pkg_name, more suitable check
+            return when_spec.name is None or when_spec.name == pkg_cls.name
 
         def _error_items(when_dict):
             for when, elts in when_dict.items():


### PR DESCRIPTION
Currently, `spack audit packages namespace.name` fails for any

1. Package that has an anonymous `when` clause in any directive
2. Repo with an `_` in the namespace

This PR fixes both issues.