### PR TITLE
Add support for git_sparse_paths in version()

### DIFF
--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -18,7 +18,7 @@ spack_version = __version__
 #: version is incremented when the package API is extended in a backwards-compatible way. The major
 #: version is incremented upon breaking changes. This version is changed independently from the
 #: Spack version.
-package_api_version = (2, 2)
+package_api_version = (2, 3)
 
 #: The minimum Package API version that this version of Spack is compatible with. This should
 #: always be a tuple of the form ``(major, 0)``, since compatibility with vX.Y implies

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -163,6 +163,7 @@ def version(
     tag: Optional[str] = None,
     branch: Optional[str] = None,
     get_full_repo: Optional[bool] = None,
+    git_sparse_paths: Optional[bool] = None,
     submodules: Union[SubmoduleCallback, Optional[bool]] = None,
     submodules_delete: Optional[bool] = None,
     # other version control
@@ -197,6 +198,7 @@ def version(
             ("hg", hg),
             ("cvs", cvs),
             ("get_full_repo", get_full_repo),
+            ("git_sparse_paths", git_sparse_paths),
             ("branch", branch),
             ("submodules", submodules),
             ("submodules_delete", submodules_delete),

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -748,6 +748,9 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     #: TestSuite instance used to manage stand-alone tests for 1+ specs.
     test_suite: Optional[Any] = None
 
+    #: A list of sub-directories to checkout with a git sparse checkout.  Added in version 2.3.
+    git_sparse_paths: List[str] = []
+
     def __init__(self, spec: spack.spec.Spec) -> None:
         # this determines how the package should be built.
         self.spec = spec

--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -365,6 +365,21 @@ def test_package_can_have_sparse_checkout_properties_with_gitversion(
     assert fetcher.git_sparse_paths == pkg_cls.git_sparse_paths
 
 
+def test_package_version_can_have_sparse_checkout_properties(
+    mock_packages, mock_fetch, mock_stage
+):
+    spec = Spec("git-sparsepaths-version")
+    pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
+    assert hasattr(pkg_cls, "git_sparse_paths")
+    assert pkg_cls.git_sparse_paths == []
+
+    version = "1.0"
+    fetcher = spack.fetch_strategy.for_package_version(pkg_cls(spec), version)
+    assert isinstance(fetcher, spack.fetch_strategy.GitFetchStrategy)
+    assert hasattr(fetcher, "git_sparse_paths")
+    assert fetcher.git_sparse_paths == ["foo", "bar"]
+
+
 def test_package_can_depend_on_commit_of_dependency(mock_packages, config):
     spec = spack.concretize.concretize_one(Spec("git-ref-commit-dep@1.0.0"))
     assert spec.satisfies(f"^git-ref-package commit={'a' * 40}")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/git_sparsepaths_version/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/git_sparsepaths_version/package.py
@@ -1,0 +1,16 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin_mock.build_systems.generic import Package
+
+from spack.package import *
+
+
+class GitSparsepathsVersion(Package):
+    """Mock package with git_sparse_paths attribute"""
+
+    homepage = "http://www.git-fetch-example.com"
+    git = "https://a/really.com/big/repo.git"
+
+    version("1.0", tag="v1.0", git_sparse_paths=["foo", "bar"])


### PR DESCRIPTION
The docs already indicate this is supported.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
