### PR TITLE
Dev workflow tools

### DIFF
--- a/lib/spack/docs/contribution_guide.rst
+++ b/lib/spack/docs/contribution_guide.rst
@@ -707,18 +707,29 @@ After all changed files are committed, you can push the branch to your fork and 
    $ git push origin --set-upstream
 
 Development Workflow Tools
---------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Spack provides a some of tools to assist in adhering to contribution rules and interacting with the Spack development
-workflow. To install the workflow tools for Spack run ``source share/spack/setup-dev.sh``.
+All developer workflow tools can be installed using by sourcing ``share/spack/setup-dev.sh``.
 
-As part of the Linux Foundation all commits require a DCO signoff similar to ``Signed-off-by: User Name <name@email.net>``.
-This can be achieved by adding the ``--signoff`` option when commiting or by using a git ``prepare-commit-msg`` hook. Spack
-provides a simple hook script that to handle this in ``share/spack/git/hooks/prepare-commit-msg``. This can be installed either
-by running the ``share/spack/setup-dev.sh`` script or by copying ``share/spack/git/hooks/prepare-commit-msg`` into ``.git/hooks/``.
+.. note::
+   Spack does not endorse or recommend any development workflow tools.
+   The tools provider here are contributed by community members that have found personally useful when contributing to Spack.
+   Tools are contributed under the same license terms as Spack and therefore provide no warranty.
+   Developers may use them at their own peril.
 
-Spack CI utilizes `deferred pipelines <https://github.com/spack/spack-infrastructure/blob/main/docs/deferred_pipelines.md>` to avoid
-having pull requests build packages that have changed but have not yet been built by the ``develop`` pipeline. Spack provides a custom
-git command to allow users to rebase on the commit associated with the latest run ``develop`` pipeline to reduce the amount of time PRs
-need to wait in before CI can be started. This script is in ``share/spack/git/git-spack-rebase`` and can be installed by adding ``share/spack/git/``
-to the ``PATH`` or sourcing the ``share/spack/setup-dev.sh`` script.
+DCO Signoff
+"""""""""""
+
+As part of the Linux Foundation all commits are required to contain a DCO signoff in the form of ``Signed-off-by: User Name <name@email.net>``.
+This can be achieved by adding the ``--signoff`` option when commiting or by using a git ``prepare-commit-msg`` hook.
+Spack provides a git hook script that can be used to automte adding the DCO signoff ``share/spack/git/hooks/prepare-commit-msg``.
+This can be installed by copying ``share/spack/git/hooks/prepare-commit-msg`` into ``.git/hooks/``.
+
+Deferred Pipeline Rebase
+""""""""""""""""""""""""
+
+Spack CI utilizes `deferred pipelines <https://github.com/spack/spack-infrastructure/blob/main/docs/deferred_pipelines.md>` to avoid having pull requests build packages that have changed but have not yet been built by the ``develop`` pipeline.
+Spack provides a custom git command to allow users to rebase on the commit associated with the latest run ``develop`` pipeline.
+Using this command canto reduce the amount of time PRs need to wait in before CI can be started.
+The command script is in ``share/spack/git/git-spack-rebase``.
+To use it add ``share/spack/git/`` to the ``PATH`` (this is how the ``spack-dev.sh`` script does it) or copy the script to a directory already in your path.

--- a/lib/spack/docs/contribution_guide.rst
+++ b/lib/spack/docs/contribution_guide.rst
@@ -604,7 +604,7 @@ Now, we need to switch to the branch you submitted for your PR and rebase it on 
 .. code-block:: console
 
    $ git checkout <descriptive_branch_name>
-   $ git rebase develop
+   $ git rebase --signoff develop
 
 Git will likely ask you to resolve conflicts.
 Edit the file that it says cannot be merged automatically and resolve the conflict.
@@ -654,8 +654,8 @@ Now you can cherry-pick relevant commits:
 
 .. code-block:: console
 
-   $ git cherry-pick <hash1>
-   $ git cherry-pick <hash2>
+   $ git cherry-pick --signoff <hash1>
+   $ git cherry-pick --signoff <hash2>
 
 Push the modified branch to your fork:
 
@@ -705,3 +705,20 @@ After all changed files are committed, you can push the branch to your fork and 
 .. code-block:: console
 
    $ git push origin --set-upstream
+
+Development Workflow Tools
+--------------------------
+
+Spack provides a some of tools to assist in adhering to contribution rules and interacting with the Spack development
+workflow. To install the workflow tools for Spack run ``source share/spack/setup-dev.sh``.
+
+As part of the Linux Foundation all commits require a DCO signoff similar to ``Signed-off-by: User Name <name@email.net>``.
+This can be achieved by adding the ``--signoff`` option when commiting or by using a git ``prepare-commit-msg`` hook. Spack
+provides a simple hook script that to handle this in ``share/spack/git/hooks/prepare-commit-msg``. This can be installed either
+by running the ``share/spack/setup-dev.sh`` script or by copying ``share/spack/git/hooks/prepare-commit-msg`` into ``.git/hooks/``.
+
+Spack CI utilizes `deferred pipelines <https://github.com/spack/spack-infrastructure/blob/main/docs/deferred_pipelines.md>` to avoid
+having pull requests build packages that have changed but have not yet been built by the ``develop`` pipeline. Spack provides a custom
+git command to allow users to rebase on the commit associated with the latest run ``develop`` pipeline to reduce the amount of time PRs
+need to wait in before CI can be started. This script is in ``share/spack/git/git-spack-rebase`` and can be installed by adding ``share/spack/git/``
+to the ``PATH`` or sourcing the ``share/spack/setup-dev.sh`` script.

--- a/share/spack/git/git-spack-rebase
+++ b/share/spack/git/git-spack-rebase
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
 print_help () {
   echo "git-spack-rebase"
   echo ""

--- a/share/spack/git/git-spack-rebase
+++ b/share/spack/git/git-spack-rebase
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+print_help () {
+  echo "git-spack-rebase"
+  echo ""
+  echo "  Git command for rebasing on the sha of the most recently completed"
+  echo "  develop pipeline."a
+  echo ""
+  echo "  Usage:"
+  echo ""
+  echo "    git-spack-rebase [-h|--help]"
+  echo "    git-spack-rebase [git-rebase options...]"
+}
+
+debug () {
+  if [ ! -z $SPACK_DEBUG ]; then
+    echo "$@" 1>&2
+  fi
+}
+
+quiet () {
+  if [ ! -z $SPACK_DEBUG ]; then
+    "$@"
+  else
+    "$@" 1> /dev/null 2> /dev/null
+  fi
+}
+
+# store the regular ops
+rebase_opts=""
+while [ ! -z $1 ]; do
+  case $1 in
+    -h|--help) print_help; exit 0;;
+    -*) rebase_opts="$rebase_opts $1"; shift;;
+    *) break;;
+  esac
+done
+echo "${rebase_opts[@]}"
+
+echo $1
+echo $2
+remote="${1:-origin}"
+target_branch="${2:-develop}"
+readonly remote
+readonly target_branch
+
+gitlab_host=${SPACK_GITLAB_HOST:-"https://gitlab.spack.io"}
+
+# Determine if this repo is spack/spack or spack/spack-packages
+# Using the project slug instead of number requires encoding the
+# project name
+spack_upstream=$(git remote get-url ${remote})
+if [ "${spack_upstream}" == *"-packages" ]; then
+  repo_name="spack%2Fspack-packages"
+else
+  repo_name="spack%2Fspack"
+fi
+
+# Get the second to last target_branch (develop) pipeline commit
+debug "${gitlab_host}/api/v4/projects/${repo_name}/pipelines?ref=${target_branch}&per_page=2"
+target_sha=$(curl -LSs "${gitlab_host}/api/v4/projects/${repo_name}/pipelines?ref=${target_branch}&per_page=2" | jq -r .[1].sha)
+debug "Rebasing on hash: $target_sha"
+
+debug "Fetching upstream"
+quiet git fetch $remote $target_branch
+
+echo "Rebasing on sha $target_sha"
+git rebase $rebase_opts $target_sha

--- a/share/spack/git/hooks/prepare-commit-msg
+++ b/share/spack/git/hooks/prepare-commit-msg
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+NAME=$(git config user.name)
+EMAIL=$(git config user.email)
+
+ret=0
+
+if [ -z "$NAME" ]; then
+    echo "empty config for user.name"
+    echo ""
+    echo "Set it with"
+    echo "    git config --global user.name \"John Doe\""
+    ret=1
+fi
+
+if [ -z "$EMAIL" ]; then
+    echo "empty config for user.email"
+    echo ""
+    echo "Set it with"
+    echo "    git config --global user.email john.doe@domain.com"
+    ret=1
+fi
+
+if [ $ret -ne 0 ]; then
+  exit $ret
+fi
+
+git interpret-trailers --if-exists doNothing --trailer \
+    "Signed-off-by: $NAME <$EMAIL>" \
+    --in-place "$1"

--- a/share/spack/setup-dev.sh
+++ b/share/spack/setup-dev.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 # Setup spack
 source share/spack/setup-env.sh
 

--- a/share/spack/setup-dev.sh
+++ b/share/spack/setup-dev.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
 
+# Setup spack
+source share/spack/setup-env.sh
+
 # Install git hooks for spack git workflow
 cp share/spack/git/hooks/* .git/hooks/
+
+# Add the spack git commands to the path
+_spack_pathadd PATH share/spack/git/

--- a/share/spack/setup-dev.sh
+++ b/share/spack/setup-dev.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Install git hooks for spack git workflow
+cp share/spack/git/hooks/* .git/hooks/


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Add developer tools for working with Spack.

Initially adding tools for
* automated DCO signoff
* deferred pipelines aware rebase (for both spack and spack packages)

Added `--signoff` to examples of doing rebase/cherry-pick.