### PR TITLE
archspec: update vendored version

### DIFF
--- a/lib/spack/spack/vendor/archspec/cpu/alias.py
+++ b/lib/spack/spack/vendor/archspec/cpu/alias.py
@@ -3,9 +3,11 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Aliases for microarchitecture features."""
+from typing import Callable, Dict
+
 from .schema import TARGETS_JSON, LazyDictionary
 
-_FEATURE_ALIAS_PREDICATE = {}
+_FEATURE_ALIAS_PREDICATE: Dict[str, Callable] = {}
 
 
 class FeatureAliasTest:

--- a/lib/spack/spack/vendor/archspec/cpu/detect.py
+++ b/lib/spack/spack/vendor/archspec/cpu/detect.py
@@ -10,7 +10,7 @@ import re
 import struct
 import subprocess
 import warnings
-from typing import Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
 from ..vendor.cpuid.cpuid import CPUID
 from .microarchitecture import TARGETS, Microarchitecture, generic_microarchitecture
@@ -22,7 +22,7 @@ INFO_FACTORY = collections.defaultdict(list)
 
 #: Mapping from micro-architecture families (x86_64, ppc64le, etc.) to
 #: functions checking the compatibility of the host with a given target
-COMPATIBILITY_CHECKS = {}
+COMPATIBILITY_CHECKS: Dict[str, Callable[[Microarchitecture, Microarchitecture], bool]] = {}
 
 # Constants for commonly used architectures
 X86_64 = "x86_64"
@@ -68,7 +68,7 @@ def partial_uarch(
 @detection(operating_system="Linux")
 def proc_cpuinfo() -> Microarchitecture:
     """Returns a partial Microarchitecture, obtained from scanning ``/proc/cpuinfo``"""
-    data = {}
+    data: Dict[str, Any] = {}
     with open("/proc/cpuinfo") as file:  # pylint: disable=unspecified-encoding
         for line in file:
             key, separator, value = line.partition(":")
@@ -100,12 +100,15 @@ def proc_cpuinfo() -> Microarchitecture:
 
     if architecture in (PPC64LE, PPC64):
         generation_match = re.search(r"POWER(\d+)", data.get("cpu", ""))
+        # There might be no match under emulated environments. For instance
+        # emulating a ppc64le with QEMU and Docker still reports the host
+        # /proc/cpuinfo and not a Power
+        if generation_match is None:
+            return partial_uarch(generation=0)
+
         try:
             generation = int(generation_match.group(1))
-        except AttributeError:
-            # There might be no match under emulated environments. For instance
-            # emulating a ppc64le with QEMU and Docker still reports the host
-            # /proc/cpuinfo and not a Power
+        except ValueError:
             generation = 0
         return partial_uarch(generation=generation)
 
@@ -210,7 +213,7 @@ WINDOWS_MAPPING = {
 }
 
 
-def _machine():
+def _machine() -> str:
     """Return the machine architecture we are on"""
     operating_system = platform.system()
 
@@ -246,25 +249,31 @@ def sysctl_info() -> Microarchitecture:
     child_environment = _ensure_bin_usrbin_in_path()
 
     def sysctl(*args: str) -> str:
-        return _check_output(["sysctl"] + list(args), env=child_environment).strip()
+        return _check_output(["sysctl", *args], env=child_environment).strip()
 
     if _machine() == X86_64:
-        features = (
-            f'{sysctl("-n", "machdep.cpu.features").lower()} '
-            f'{sysctl("-n", "machdep.cpu.leaf7_features").lower()}'
+        raw_features = sysctl(
+            "-n",
+            "machdep.cpu.features",
+            "machdep.cpu.leaf7_features",
+            "machdep.cpu.extfeatures",
         )
-        features = set(features.split())
+        features = set(raw_features.lower().split())
 
         # Flags detected on Darwin turned to their linux counterpart
-        for darwin_flag, linux_flag in TARGETS_JSON["conversions"]["darwin_flags"].items():
-            if darwin_flag in features:
-                features.update(linux_flag.split())
+        for darwin_flags, linux_flags in TARGETS_JSON["conversions"]["darwin_flags"].items():
+            if all(x in features for x in darwin_flags.split()):
+                features.update(linux_flags.split())
 
         return partial_uarch(vendor=sysctl("-n", "machdep.cpu.vendor"), features=features)
 
     model = "unknown"
     model_str = sysctl("-n", "machdep.cpu.brand_string").lower()
-    if "m2" in model_str:
+    if "m4" in model_str:
+        model = "m4"
+    elif "m3" in model_str:
+        model = "m3"
+    elif "m2" in model_str:
         model = "m2"
     elif "m1" in model_str:
         model = "m1"
@@ -335,7 +344,7 @@ def compatible_microarchitectures(info: Microarchitecture) -> List[Microarchitec
     ]
 
 
-def host():
+def host() -> Microarchitecture:
     """Detects the host micro-architecture and returns it."""
     # Retrieve information on the host's cpu
     info = detected_info()
@@ -374,7 +383,7 @@ def compatibility_check(architecture_family: Union[str, Tuple[str, ...]]):
 
     A compatibility check function takes a partial Microarchitecture object as a first argument,
     and an arbitrary target Microarchitecture as the second argument. It returns True if the
-    target is compatible with first argument, False otherwise.
+    target is compatible with the first argument, False otherwise.
 
     Args:
         architecture_family: architecture family for which this test can be used
@@ -393,8 +402,8 @@ def compatibility_check(architecture_family: Union[str, Tuple[str, ...]]):
 @compatibility_check(architecture_family=(PPC64LE, PPC64))
 def compatibility_check_for_power(info, target):
     """Compatibility check for PPC64 and PPC64LE architectures."""
-    # We can use a target if it descends from our machine type and our
-    # generation (9 for POWER9, etc) is at least its generation.
+    # We can use a target if it descends from our machine type, and our
+    # generation (9 for POWER9, etc.) is at least its generation.
     arch_root = TARGETS[_machine()]
     return (
         target == arch_root or arch_root in target.ancestors

--- a/lib/spack/spack/vendor/archspec/cpu/microarchitecture.py
+++ b/lib/spack/spack/vendor/archspec/cpu/microarchitecture.py
@@ -8,7 +8,7 @@ import platform
 import re
 import sys
 import warnings
-from typing import IO, List, Set, Tuple
+from typing import IO, Any, Dict, List, Optional, Set, Tuple, Union
 
 from . import schema
 from .alias import FEATURE_ALIASES
@@ -34,43 +34,48 @@ def coerce_target_names(func):
 
 
 class Microarchitecture:
-    """Represents a specific CPU micro-architecture.
-
-    Args:
-        name (str): name of the micro-architecture (e.g. skylake).
-        parents (list): list of parents micro-architectures, if any.
-            Parenthood is considered by cpu features and not
-            chronologically. As such each micro-architecture is
-            compatible with its ancestors. For example "skylake",
-            which has "broadwell" as a parent, supports running binaries
-            optimized for "broadwell".
-        vendor (str): vendor of the micro-architecture
-        features (set of str): supported CPU flags. Note that the semantic
-            of the flags in this field might vary among architectures, if
-            at all present. For instance x86_64 processors will list all
-            the flags supported by a given CPU while Arm processors will
-            list instead only the flags that have been added on top of the
-            base model for the current micro-architecture.
-        compilers (dict): compiler support to generate tuned code for this
-            micro-architecture. This dictionary has as keys names of
-            supported compilers, while values are list of dictionaries
-            with fields:
-
-            * name: name of the micro-architecture according to the
-                compiler. This is the name passed to the ``-march`` option
-                or similar. Not needed if the name is the same as that
-                passed in as argument above.
-            * versions: versions that support this micro-architecture.
-
-        generation (int): generation of the micro-architecture, if relevant.
-        cpu_part (str): cpu part of the architecture, if relevant.
-    """
+    """A specific CPU micro-architecture"""
 
     # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-instance-attributes
     #: Aliases for micro-architecture's features
     feature_aliases = FEATURE_ALIASES
 
-    def __init__(self, name, parents, vendor, features, compilers, generation=0, cpu_part=""):
+    def __init__(
+        self,
+        name: str,
+        parents: List["Microarchitecture"],
+        vendor: str,
+        features: Set[str],
+        compilers: Dict[str, List[Dict[str, str]]],
+        generation: int = 0,
+        cpu_part: str = "",
+    ):
+        """
+        Args:
+            name: name of the micro-architecture (e.g. ``icelake``)
+            parents: list of parent micro-architectures, if any. Parenthood is considered by
+                cpu features and not chronologically. As such, each micro-architecture is
+                compatible with its ancestors. For example, ``skylake``, which has ``broadwell``
+                as a parent, supports running binaries optimized for ``broadwell``.
+            vendor: vendor of the micro-architecture
+            features: supported CPU flags. Note that the semantic of the flags in this field might
+                vary among architectures, if at all present. For instance, x86_64 processors will
+                list all the flags supported by a given CPU, while Arm processors will list instead
+                only the flags that have been added on top of the base model for the current
+                micro-architecture.
+            compilers: compiler support to generate tuned code for this micro-architecture. This
+                dictionary has as keys names of supported compilers, while values are a list of
+                dictionaries with fields:
+
+                * name: name of the micro-architecture according to the compiler. This is the name
+                    passed to the ``-march`` option or similar. Not needed if it is the same as
+                    ``self.name``.
+                * versions: versions that support this micro-architecture.
+                * flags: flags to be passed to the compiler to generate optimized code
+
+            generation: generation of the micro-architecture, if relevant.
+            cpu_part: cpu part of the architecture, if relevant.
+        """
         self.name = name
         self.parents = parents
         self.vendor = vendor
@@ -82,14 +87,18 @@ class Microarchitecture:
         self.cpu_part = cpu_part
 
         # Cache the "ancestor" computation
-        self._ancestors = None
+        self._ancestors: Optional[List["Microarchitecture"]] = None
         # Cache the "generic" computation
-        self._generic = None
+        self._generic: Optional["Microarchitecture"] = None
         # Cache the "family" computation
-        self._family = None
+        self._family: Optional["Microarchitecture"] = None
+
+        # ssse3 implies sse3; on Linux sse3 is not mentioned in /proc/cpuinfo, so add it ad-hoc.
+        if "ssse3" in self.features:
+            self.features.add("sse3")
 
     @property
-    def ancestors(self):
+    def ancestors(self) -> List["Microarchitecture"]:
         """All the ancestors of this microarchitecture."""
         if self._ancestors is None:
             value = self.parents[:]
@@ -98,14 +107,14 @@ class Microarchitecture:
             self._ancestors = value
         return self._ancestors
 
-    def _to_set(self):
+    def _to_set(self) -> Set[str]:
         """Returns a set of the nodes in this microarchitecture DAG."""
         # This function is used to implement subset semantics with
         # comparison operators
         return set([str(self)] + [str(x) for x in self.ancestors])
 
     @coerce_target_names
-    def __eq__(self, other):
+    def __eq__(self, other: Union[str, "Microarchitecture"]) -> bool:
         if not isinstance(other, Microarchitecture):
             return NotImplemented
 
@@ -119,43 +128,43 @@ class Microarchitecture:
             and self.cpu_part == other.cpu_part
         )
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self.name)
 
     @coerce_target_names
-    def __ne__(self, other):
+    def __ne__(self, other: Union[str, "Microarchitecture"]) -> bool:
         return not self == other
 
     @coerce_target_names
-    def __lt__(self, other):
+    def __lt__(self, other: Union[str, "Microarchitecture"]) -> bool:
         if not isinstance(other, Microarchitecture):
             return NotImplemented
 
         return self._to_set() < other._to_set()
 
     @coerce_target_names
-    def __le__(self, other):
+    def __le__(self, other: Union[str, "Microarchitecture"]) -> bool:
         return (self == other) or (self < other)
 
     @coerce_target_names
-    def __gt__(self, other):
+    def __gt__(self, other: Union[str, "Microarchitecture"]) -> bool:
         if not isinstance(other, Microarchitecture):
             return NotImplemented
 
         return self._to_set() > other._to_set()
 
     @coerce_target_names
-    def __ge__(self, other):
+    def __ge__(self, other: Union[str, "Microarchitecture"]) -> bool:
         return (self == other) or (self > other)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.name!r})"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
     def tree(self, fp: IO[str] = sys.stdout, indent: int = 4) -> None:
-        """Format the partial order of ancestors of this microarchitecture as a tree."""
+        """Format the partial order of this microarchitecture's ancestors as a tree."""
         seen: Set[str] = set()
         stack: List[Tuple[int, Microarchitecture]] = [(0, self)]
         while stack:
@@ -168,7 +177,7 @@ class Microarchitecture:
             for parent in reversed(current.parents):
                 stack.append((level + indent, parent))
 
-    def __contains__(self, feature):
+    def __contains__(self, feature: str) -> bool:
         # Feature must be of a string type, so be defensive about that
         if not isinstance(feature, str):
             msg = "only objects of string types are accepted [got {0}]"
@@ -184,7 +193,7 @@ class Microarchitecture:
         return match_alias(self)
 
     @property
-    def family(self):
+    def family(self) -> "Microarchitecture":
         """Returns the architecture family a given target belongs to"""
         if self._family is None:
             roots = [x for x in [self] + self.ancestors if not x.ancestors]
@@ -196,14 +205,14 @@ class Microarchitecture:
         return self._family
 
     @property
-    def generic(self):
+    def generic(self) -> "Microarchitecture":
         """Returns the best generic architecture that is compatible with self"""
         if self._generic is None:
             generics = [x for x in [self] + self.ancestors if x.vendor == "generic"]
             self._generic = max(generics, key=lambda x: len(x.ancestors))
         return self._generic
 
-    def to_dict(self):
+    def to_dict(self) -> Dict[str, Any]:
         """Returns a dictionary representation of this object."""
         return {
             "name": str(self.name),
@@ -228,20 +237,19 @@ class Microarchitecture:
             cpu_part=data.get("cpupart", ""),
         )
 
-    def optimization_flags(self, compiler, version):
-        """Returns a string containing the optimization flags that needs
-        to be used to produce code optimized for this micro-architecture.
+    def optimization_flags(self, compiler: str, version: str) -> str:
+        """Returns a string containing the optimization flags that needs to be used to produce
+        code optimized for this micro-architecture.
 
-        The version is expected to be a string of dot separated digits.
+        The version is expected to be a string of dot-separated digits.
 
-        If there is no information on the compiler passed as argument the
-        function returns an empty string. If it is known that the compiler
-        version we want to use does not support this architecture the function
-        raises an exception.
+        If there is no information on the compiler passed as an argument, the function returns an
+        empty string. If it is known that the compiler version we want to use does not support
+        this architecture, the function raises an exception.
 
         Args:
-            compiler (str): name of the compiler to be used
-            version (str): version of the compiler to be used
+            compiler: name of the compiler to be used
+            version: version of the compiler to be used
 
         Raises:
             UnsupportedMicroarchitecture: if the requested compiler does not support
@@ -252,7 +260,7 @@ class Microarchitecture:
         if compiler not in self.family.compilers:
             return ""
 
-        # If we have information but it stops before this
+        # If we have information, but it stops before this
         # microarchitecture, fall back to the best known target
         if compiler not in self.compilers:
             best_target = [x for x in self.ancestors if compiler in x.compilers][0]
@@ -325,16 +333,16 @@ class Microarchitecture:
         raise UnsupportedMicroarchitecture(msg)
 
 
-def generic_microarchitecture(name):
+def generic_microarchitecture(name: str) -> Microarchitecture:
     """Returns a generic micro-architecture with no vendor and no features.
 
     Args:
-        name (str): name of the micro-architecture
+        name: name of the micro-architecture
     """
     return Microarchitecture(name, parents=[], vendor="generic", features=set(), compilers={})
 
 
-def version_components(version):
+def version_components(version: str) -> Tuple[str, str]:
     """Decomposes the version passed as input in version number and
     suffix and returns them.
 
@@ -342,7 +350,7 @@ def version_components(version):
     string is returned.
 
     Args:
-        version (str): version to be decomposed into its components
+        version: version to be decomposed into its components
     """
     match = re.match(r"([\d.]*)(-?)(.*)", str(version))
     if not match:
@@ -356,7 +364,7 @@ def version_components(version):
 
 def _known_microarchitectures():
     """Returns a dictionary of the known micro-architectures. If the
-    current host platform is unknown adds it too as a generic target.
+    current host platform is unknown, add it too as a generic target.
     """
 
     def fill_target_from_dict(name, data, targets):

--- a/lib/spack/spack/vendor/archspec/cpu/schema.py
+++ b/lib/spack/spack/vendor/archspec/cpu/schema.py
@@ -9,7 +9,7 @@ import collections.abc
 import json
 import os
 import pathlib
-from typing import Tuple
+from typing import Optional, Tuple
 
 
 class LazyDictionary(collections.abc.MutableMapping):
@@ -55,7 +55,9 @@ DIR_FROM_ENVIRONMENT = "ARCHSPEC_CPU_DIR"
 EXTENSION_DIR_FROM_ENVIRONMENT = "ARCHSPEC_EXTENSION_CPU_DIR"
 
 
-def _json_file(filename: str, allow_custom: bool = False) -> Tuple[pathlib.Path, pathlib.Path]:
+def _json_file(
+    filename: str, allow_custom: bool = False
+) -> Tuple[pathlib.Path, Optional[pathlib.Path]]:
     """Given a filename, returns the absolute path for the main JSON file, and an
     optional absolute path for an extension JSON file.
 
@@ -98,8 +100,7 @@ def _load(json_file: pathlib.Path, extension_file: pathlib.Path):
     return data
 
 
-#: In memory representation of the data in microarchitectures.json,
-#: loaded on first access
+#: In memory representation of the data in microarchitectures.json, loaded on first access
 TARGETS_JSON = LazyDictionary(_load, *_json_file("microarchitectures.json", allow_custom=True))
 
 #: JSON schema for microarchitectures.json, loaded on first access

--- a/lib/spack/spack/vendor/archspec/json/cpu/microarchitectures.json
+++ b/lib/spack/spack/vendor/archspec/json/cpu/microarchitectures.json
@@ -508,7 +508,9 @@
         "ssse3",
         "sse4_1",
         "sse4_2",
-        "popcnt"
+        "popcnt",
+        "lahf_lm",
+        "cx16"
       ],
       "compilers": {
         "gcc": [
@@ -577,6 +579,8 @@
         "sse4_1",
         "sse4_2",
         "popcnt",
+        "lahf_lm",
+        "cx16",
         "aes",
         "pclmulqdq"
       ],
@@ -642,6 +646,8 @@
         "sse4_1",
         "sse4_2",
         "popcnt",
+        "lahf_lm",
+        "cx16",
         "aes",
         "pclmulqdq",
         "avx"
@@ -720,6 +726,8 @@
         "sse4_1",
         "sse4_2",
         "popcnt",
+        "lahf_lm",
+        "cx16",
         "aes",
         "pclmulqdq",
         "avx",
@@ -801,6 +809,10 @@
         "sse4_1",
         "sse4_2",
         "popcnt",
+        "abm",
+        "lahf_lm",
+        "xsave",
+        "cx16",
         "aes",
         "pclmulqdq",
         "avx",
@@ -885,7 +897,11 @@
         "ssse3",
         "sse4_1",
         "sse4_2",
+        "abm",
         "popcnt",
+        "xsave",
+        "lahf_lm",
+        "cx16",
         "aes",
         "pclmulqdq",
         "avx",
@@ -964,6 +980,10 @@
         "sse4_1",
         "sse4_2",
         "popcnt",
+        "abm",
+        "lahf_lm",
+        "xsave",
+        "cx16",
         "aes",
         "pclmulqdq",
         "avx",
@@ -1045,7 +1065,11 @@
         "sse4_1",
         "sse4_2",
         "popcnt",
+        "abm",
+        "lahf_lm",
+        "cx16",
         "aes",
+        "xsave",
         "pclmulqdq",
         "avx",
         "rdrand",
@@ -1128,6 +1152,9 @@
         "sse4_1",
         "sse4_2",
         "popcnt",
+        "abm",
+        "lahf_lm",
+        "cx16",
         "aes",
         "pclmulqdq",
         "avx",
@@ -1141,6 +1168,7 @@
         "rdseed",
         "adx",
         "clflushopt",
+        "xsave",
         "xsavec",
         "xsaveopt",
         "avx512f",
@@ -1221,6 +1249,9 @@
         "sse4_1",
         "sse4_2",
         "popcnt",
+        "abm",
+        "lahf_lm",
+        "cx16",
         "aes",
         "pclmulqdq",
         "avx",
@@ -1234,6 +1265,7 @@
         "rdseed",
         "adx",
         "clflushopt",
+        "xsave",
         "xsavec",
         "xsaveopt",
         "avx512f",
@@ -1243,7 +1275,7 @@
         "avx512cd",
         "avx512vbmi",
         "avx512ifma",
-        "sha"
+        "sha_ni"
       ],
       "compilers": {
         "gcc": [
@@ -1310,6 +1342,9 @@
         "sse4_1",
         "sse4_2",
         "popcnt",
+        "abm",
+        "lahf_lm",
+        "cx16",
         "aes",
         "pclmulqdq",
         "avx",
@@ -1323,6 +1358,7 @@
         "rdseed",
         "adx",
         "clflushopt",
+        "xsave",
         "xsavec",
         "xsaveopt",
         "avx512f",
@@ -1399,7 +1435,11 @@
         "sse4_1",
         "sse4_2",
         "popcnt",
+        "abm",
+        "lahf_lm",
+        "cx16",
         "aes",
+        "sha_ni",
         "pclmulqdq",
         "avx",
         "rdrand",
@@ -1412,6 +1452,7 @@
         "rdseed",
         "adx",
         "clflushopt",
+        "xsave",
         "xsavec",
         "xsaveopt",
         "avx512f",
@@ -1512,6 +1553,10 @@
         "sse4_1",
         "sse4_2",
         "popcnt",
+        "abm",
+        "lahf_lm",
+        "cx16",
+        "sha_ni",
         "aes",
         "pclmulqdq",
         "avx",
@@ -1525,6 +1570,7 @@
         "rdseed",
         "adx",
         "clflushopt",
+        "xsave",
         "xsavec",
         "xsaveopt",
         "avx512f",
@@ -1658,6 +1704,10 @@
         "sse",
         "sse2",
         "sse4a",
+        "popcnt",
+        "lahf_lm",
+        "cx16",
+        "xsave",
         "abm",
         "avx",
         "xop",
@@ -1730,6 +1780,10 @@
         "sse",
         "sse2",
         "sse4a",
+        "popcnt",
+        "lahf_lm",
+        "cx16",
+        "xsave",
         "abm",
         "avx",
         "xop",
@@ -1806,6 +1860,10 @@
         "sse",
         "sse2",
         "sse4a",
+        "popcnt",
+        "lahf_lm",
+        "cx16",
+        "xsave",
         "abm",
         "avx",
         "xop",
@@ -1885,6 +1943,10 @@
         "sse",
         "sse2",
         "sse4a",
+        "popcnt",
+        "lahf_lm",
+        "cx16",
+        "xsave",
         "abm",
         "avx",
         "xop",
@@ -1986,10 +2048,13 @@
         "sse4_1",
         "sse4_2",
         "abm",
+        "xsave",
         "xsavec",
         "xsaveopt",
         "clflushopt",
-        "popcnt"
+        "popcnt",
+        "lahf_lm",
+        "cx16"
       ],
       "compilers": {
         "gcc": [
@@ -2072,11 +2137,13 @@
         "sse4_1",
         "sse4_2",
         "abm",
+        "xsave",
         "xsavec",
         "xsaveopt",
         "clflushopt",
         "popcnt",
-        "clwb"
+        "clwb",
+        "lahf_lm"
       ],
       "compilers": {
         "gcc": [
@@ -2159,10 +2226,12 @@
         "sse4_1",
         "sse4_2",
         "abm",
+        "xsave",
         "xsavec",
         "xsaveopt",
         "clflushopt",
         "popcnt",
+        "lahf_lm",
         "clwb",
         "vaes",
         "vpclmulqdq",
@@ -2250,10 +2319,12 @@
         "sse4_1",
         "sse4_2",
         "abm",
+        "xsave",
         "xsavec",
         "xsaveopt",
         "clflushopt",
         "popcnt",
+        "lahf_lm",
         "clwb",
         "vaes",
         "vpclmulqdq",
@@ -2354,7 +2425,6 @@
         "clflushopt",
         "clwb",
         "clzero",
-        "cppc",
         "cx16",
         "f16c",
         "flush_l1d",
@@ -2365,9 +2435,11 @@
         "mmx",
         "movbe",
         "movdir64b",
+        "lahf_lm",
         "movdiri",
         "pclmulqdq",
         "popcnt",
+        "pku",
         "rdseed",
         "sse",
         "sse2",
@@ -2378,6 +2450,7 @@
         "tsc_adjust",
         "vaes",
         "vpclmulqdq",
+        "xsave",
         "xsavec",
         "xsaveopt"
       ],
@@ -2827,6 +2900,27 @@
           {
             "versions": ":",
             "flags": "-march=armv8.5-a -mtune=generic"
+          }
+        ]
+      }
+    },
+    "armv8.6a": {
+      "from": [
+        "armv8.5a"
+      ],
+      "vendor": "generic",
+      "features": [],
+      "compilers": {
+        "gcc": [
+          {
+            "versions": "10.1:",
+            "flags": "-march=armv8.6-a -mtune=generic"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "11:",
+            "flags": "-march=armv8.6-a -mtune=generic"
           }
         ]
       }
@@ -3613,6 +3707,182 @@
       },
       "cpupart": "0x032"
     },
+    "m3": {
+      "from": [
+        "m2",
+        "armv8.6a"
+      ],
+      "vendor": "Apple",
+      "features": [
+        "fp",
+        "asimd",
+        "evtstrm",
+        "aes",
+        "pmull",
+        "sha1",
+        "sha2",
+        "crc32",
+        "atomics",
+        "fphp",
+        "asimdhp",
+        "cpuid",
+        "asimdrdm",
+        "jscvt",
+        "fcma",
+        "lrcpc",
+        "dcpop",
+        "sha3",
+        "asimddp",
+        "sha512",
+        "asimdfhm",
+        "dit",
+        "uscat",
+        "ilrcpc",
+        "flagm",
+        "ssbs",
+        "sb",
+        "paca",
+        "pacg",
+        "dcpodp",
+        "flagm2",
+        "frint",
+        "ecv",
+        "bf16",
+        "i8mm",
+        "bti"
+      ],
+      "compilers": {
+        "gcc": [
+          {
+            "versions": "8.0:",
+            "flags": "-march=armv8.5-a -mtune=generic"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "9.0:12.0",
+            "flags": "-march=armv8.5-a"
+          },
+          {
+            "versions": "13.0:",
+            "flags": "-mcpu=apple-m1"
+          },
+          {
+            "versions": "16.0:",
+            "flags": "-mcpu=apple-m3"
+          }
+        ],
+        "apple-clang": [
+          {
+            "versions": "11.0:12.5",
+            "flags": "-march=armv8.5-a"
+          },
+          {
+            "versions": "13.0:14.0.2",
+            "flags": "-mcpu=apple-m1"
+          },
+          {
+            "versions": "14.0.2:15",
+            "flags": "-mcpu=apple-m2"
+          },
+          {
+            "versions": "16:",
+            "flags": "-mcpu=apple-m3"
+          }
+        ]
+      },
+      "cpupart": "Unknown"
+    },
+    "m4": {
+      "from": [
+        "m3",
+        "armv8.6a"
+      ],
+      "vendor": "Apple",
+      "features": [
+        "fp",
+        "asimd",
+        "evtstrm",
+        "aes",
+        "pmull",
+        "sha1",
+        "sha2",
+        "crc32",
+        "atomics",
+        "fphp",
+        "asimdhp",
+        "cpuid",
+        "asimdrdm",
+        "jscvt",
+        "fcma",
+        "lrcpc",
+        "dcpop",
+        "sha3",
+        "asimddp",
+        "sha512",
+        "asimdfhm",
+        "dit",
+        "uscat",
+        "ilrcpc",
+        "flagm",
+        "ssbs",
+        "sb",
+        "paca",
+        "pacg",
+        "dcpodp",
+        "flagm2",
+        "frint",
+        "ecv",
+        "bf16",
+        "i8mm",
+        "bti",
+        "sme",
+        "sme2"
+      ],
+      "compilers": {
+        "clang": [
+          {
+            "versions": "9.0:12.0",
+            "flags": "-march=armv8.5-a"
+          },
+          {
+            "versions": "13.0:",
+            "flags": "-mcpu=apple-m1"
+          },
+          {
+            "versions": "16.0:18",
+            "flags": "-mcpu=apple-m3"
+          },
+          {
+            "versions": "19:",
+            "flags": "-mcpu=apple-m4"
+          }
+        ],
+        "apple-clang": [
+          {
+            "versions": "11.0:12.5",
+            "flags": "-march=armv8.5-a"
+          },
+          {
+            "versions": "13.0:14.0.2",
+            "flags": "-mcpu=apple-m1"
+          },
+          {
+            "versions": "14.0.2:15",
+            "flags": "-mcpu=apple-m2"
+          },
+          {
+            "versions": "16:",
+            "flags": "-mcpu=apple-m3"
+          },
+          {
+            "versions": "17:",
+            "flags": "-mcpu=apple-m4"
+          }
+        ]
+      },
+      "cpupart": "Unknown"
+    },
     "arm": {
       "from": [],
       "vendor": "generic",
@@ -3774,6 +4044,9 @@
       "sse4.1": "sse4_1",
       "sse4.2": "sse4_2",
       "avx1.0": "avx",
+      "lahf": "lahf_lm",
+      "sha": "sha_ni",
+      "popcnt lzcnt": "abm",
       "clfsopt": "clflushopt",
       "xsave": "xsavec xsaveopt"
     }

--- a/var/spack/vendoring/vendor.txt
+++ b/var/spack/vendoring/vendor.txt
@@ -9,4 +9,4 @@ macholib==1.16.2
   altgraph==0.17.3
 ruamel.yaml==0.17.21
 typing_extensions==4.1.1
-archspec @ git+https://github.com/archspec/archspec.git@77f3f81df3dd80b7e538e2e41bc4485fbec2dbaa
+archspec @ git+https://github.com/archspec/archspec.git@0aec32368faa199fe3e6a549207ceffad78600cb


### PR DESCRIPTION
This updates the version of archspec we use to https://github.com/archspec/archspec/commit/0aec32368faa199fe3e6a549207ceffad78600cb

This includes:
- Support for Apple M3 and Apple M4
- Better support for Zen5
- Fixes for old x86_64 microarchitectures

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
