### PR TITLE
fix: write `created` time field with OCI buildcache config

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1311,6 +1311,23 @@ def _oci_put_manifest(
 
     # Create an oci.image.config file
     config = copy.deepcopy(base_config)
+    
+    # Set the created timestamp from the spec's installation time if available
+    if "created" not in config:
+        # Try to get installation time from the database
+        db = spack.store.STORE.db
+        record = db.get_record(specs[0])
+        if record and record.installation_time:
+            # Convert Unix timestamp to RFC 3339 format
+            install_datetime = datetime.datetime.fromtimestamp(
+                record.installation_time, tz=datetime.timezone.utc
+            )
+            config["created"] = install_datetime.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+        else:
+            # Fallback to current time
+            config["created"] = datetime.datetime.now(
+                datetime.timezone.utc
+            ).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
 
     # Add the diff ids of the blobs
     for s in expected_blobs:

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1311,7 +1311,7 @@ def _oci_put_manifest(
 
     # Create an oci.image.config file
     config = copy.deepcopy(base_config)
-    
+
     # Set the created timestamp from the spec's installation time if available
     if "created" not in config:
         # Try to get installation time from the database
@@ -1322,12 +1322,12 @@ def _oci_put_manifest(
             install_datetime = datetime.datetime.fromtimestamp(
                 record.installation_time, tz=datetime.timezone.utc
             )
-            config["created"] = install_datetime.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+            config["created"] = install_datetime.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         else:
             # Fallback to current time
-            config["created"] = datetime.datetime.now(
-                datetime.timezone.utc
-            ).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+            config["created"] = datetime.datetime.now(datetime.timezone.utc).strftime(
+                "%Y-%m-%dT%H:%M:%S.%fZ"
+            )
 
     # Add the diff ids of the blobs
     for s in expected_blobs:

--- a/lib/spack/spack/oci/image.py
+++ b/lib/spack/spack/oci/image.py
@@ -230,8 +230,24 @@ def ensure_valid_tag(tag: str) -> str:
     return sanitized
 
 
-def default_config(architecture: str, os: str):
+def default_config(architecture: str, os: str, created: Optional[str] = None):
+    """Create a default OCI image config.
+
+    Args:
+        architecture: The architecture of the image (e.g., "amd64", "arm64")
+        os: The operating system of the image (e.g., "linux")
+        created: Optional RFC 3339 timestamp string. If not provided, current time is used.
+
+    Returns:
+        A dictionary representing the OCI image config
+    """
+    import datetime
+
+    if created is None:
+        created = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
     return {
+        "created": created,
         "architecture": architecture,
         "os": os,
         "rootfs": {"type": "layers", "diff_ids": []},

--- a/lib/spack/spack/oci/image.py
+++ b/lib/spack/spack/oci/image.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import datetime
 import re
 import urllib.parse
 from typing import Optional, Union
@@ -230,7 +231,7 @@ def ensure_valid_tag(tag: str) -> str:
     return sanitized
 
 
-def default_config(architecture: str, os: str, created: Optional[str] = None):
+def default_config(architecture: str, os: str):
     """Create a default OCI image config.
 
     Args:
@@ -241,10 +242,7 @@ def default_config(architecture: str, os: str, created: Optional[str] = None):
     Returns:
         A dictionary representing the OCI image config
     """
-    import datetime
-
-    if created is None:
-        created = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    created = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
     return {
         "created": created,

--- a/lib/spack/spack/test/oci/integration_test.py
+++ b/lib/spack/spack/test/oci/integration_test.py
@@ -415,13 +415,12 @@ def test_oci_config_created_timestamp(mutable_database):
         # Parse the timestamp (RFC 3339 format)
         # The format should be like: 2015-10-31T22:22:56.015925234Z
         try:
-            # Remove the Z and parse
-            if created_str.endswith("Z"):
-                created_dt = datetime.datetime.strptime(
-                    created_str[:-1], "%Y-%m-%dT%H:%M:%S.%f"
-                ).replace(tzinfo=datetime.timezone.utc)
-            else:
-                created_dt = datetime.datetime.fromisoformat(created_str)
+            # Parse RFC 3339 timestamp with Z suffix
+            if not created_str.endswith("Z"):
+                pytest.fail(f"Timestamp should end with 'Z': {created_str}")
+            created_dt = datetime.datetime.strptime(
+                created_str[:-1], "%Y-%m-%dT%H:%M:%S.%f"
+            ).replace(tzinfo=datetime.timezone.utc)
         except ValueError as e:
             pytest.fail(f"Invalid timestamp format '{created_str}': {e}")
 

--- a/lib/spack/spack/test/oci/integration_test.py
+++ b/lib/spack/spack/test/oci/integration_test.py
@@ -383,3 +383,58 @@ def test_best_effort_upload(mutable_database: spack.database.Database, monkeypat
 
             # Test with issubset, cause we don't have the blob of libdwarf as it has no manifest.
             assert expected_digests and expected_digests.issubset(pkg_to_all_digests[s.name])
+
+
+def test_oci_config_created_timestamp(mutable_database):
+    """Test that OCI images have a valid 'created' timestamp instead of epoch time."""
+    import datetime
+
+    registry = InMemoryOCIRegistry("example.com")
+
+    with oci_servers(registry):
+        mirror("add", "oci-test", "oci://example.com/image")
+
+        # Push a package to the OCI registry
+        buildcache("push", "oci-test", "mpileaks^mpich")
+
+        # Get the tag for the pushed image
+        spec = mutable_database.query_local("mpileaks^mpich")[0]
+        tag = spack.binary_distribution._oci_default_tag(spec)
+        image_ref = ImageReference.from_string(f"example.com/image:{tag}")
+
+        # Fetch the manifest and config
+        manifest, config = get_manifest_and_config(image_ref)
+
+        # Verify that the config has a 'created' field
+        assert "created" in config, "Config should have a 'created' field"
+
+        # Verify that the created timestamp is valid and not the Unix epoch
+        created_str = config["created"]
+        assert created_str is not None, "Created timestamp should not be None"
+
+        # Parse the timestamp (RFC 3339 format)
+        # The format should be like: 2015-10-31T22:22:56.015925234Z
+        try:
+            # Remove the Z and parse
+            if created_str.endswith("Z"):
+                created_dt = datetime.datetime.strptime(
+                    created_str[:-1], "%Y-%m-%dT%H:%M:%S.%f"
+                ).replace(tzinfo=datetime.timezone.utc)
+            else:
+                created_dt = datetime.datetime.fromisoformat(created_str)
+        except ValueError as e:
+            pytest.fail(f"Invalid timestamp format '{created_str}': {e}")
+
+        # Verify it's not the Unix epoch (1970-01-01)
+        epoch = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
+        assert created_dt > epoch, (
+            f"Created timestamp {created_str} should not be Unix epoch time "
+            f"(which displays as Dec 31, 1969 in some time zones)"
+        )
+
+        # Verify it's a reasonable timestamp (between 2020 and now + 1 day)
+        year_2020 = datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)
+        tomorrow = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
+        assert (
+            year_2020 < created_dt < tomorrow
+        ), f"Created timestamp {created_str} should be between 2020 and now"

--- a/lib/spack/spack/test/oci/integration_test.py
+++ b/lib/spack/spack/test/oci/integration_test.py
@@ -434,6 +434,6 @@ def test_oci_config_created_timestamp(mutable_database):
         # Verify it's a reasonable timestamp (between 2020 and now + 1 day)
         year_2020 = datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)
         tomorrow = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
-        assert (
-            year_2020 < created_dt < tomorrow
-        ), f"Created timestamp {created_str} should be between 2020 and now"
+        assert year_2020 < created_dt < tomorrow, (
+            f"Created timestamp {created_str} should be between 2020 and now"
+        )


### PR DESCRIPTION
It is hard to have buildcache on a gitlab container registry and keep it from growing incessantly because there is no timestamp information uploaded:
<img width="771" height="193" alt="image" src="https://github.com/user-attachments/assets/ee95cf93-5401-468b-8643-21a1b35264af" />

This PR adds the `created` field to the OCI config (https://github.com/opencontainers/image-spec/blob/main/config.md#properties), and fills this with the package installation date, or now if no installation date is present. Added tests for coverage.