### PR TITLE
Refactor gpg module and add ability to trust a key from URL

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -648,7 +648,7 @@ def select_signing_key() -> str:
             "Use spack gpg init and spack gpg create"
             " to create a default key."
         )
-    return keys[0]
+    return str(keys[0])
 
 
 def _push_index(db: BuildCacheDatabase, temp_dir: str, cache_prefix: str, name: str = ""):

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -581,7 +581,7 @@ def import_signing_key(base64_signing_key: str) -> None:
         with open(sign_key_path, "w", encoding="utf-8") as fd:
             fd.write(decoded_key)
 
-        key_import_output = spack_gpg("trust", sign_key_path)
+        key_import_output = spack_gpg("trust", "-y", sign_key_path)
         tty.debug(f"spack gpg trust {sign_key_path}")
         tty.debug(key_import_output)
 
@@ -1053,7 +1053,11 @@ def reproduce_ci_job(url, work_dir, autostart, gpg_url, runtime, use_local_head)
                 f"share/spack/setup-env.{platform_script_ext}",
             ),
         ],
-        ["spack", "gpg", "trust", mounted_gpg_path if job_image else gpg_path] if gpg_path else [],
+        (
+            ["spack", "gpg", "trust", "-y", mounted_gpg_path if job_image else gpg_path]
+            if gpg_path
+            else []
+        ),
         ["spack", "env", "activate", mounted_env_dir if job_image else repro_dir],
         [
             (

--- a/lib/spack/spack/cmd/gpg.py
+++ b/lib/spack/spack/cmd/gpg.py
@@ -5,6 +5,7 @@
 import argparse
 import os
 import tempfile
+import urllib
 
 import spack.binary_distribution
 import spack.mirrors.mirror
@@ -12,6 +13,7 @@ import spack.paths
 import spack.stage
 import spack.util.gpg
 import spack.util.url
+import spack.util.web as web_util
 from spack.cmd.common import arguments
 
 description = "handle GPG actions for spack"
@@ -29,7 +31,9 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     verify.set_defaults(func=gpg_verify, subparser=verify)
 
     trust = subparsers.add_parser("trust", help=gpg_trust.__doc__)
-    trust.add_argument("keyfile", type=str, help="add a key to the trust store")
+    trust.add_argument(
+        "keyfile", type=str, help="add a keyfile from path or url to the trust store"
+    )
     trust.set_defaults(func=gpg_trust, subparser=trust)
 
     untrust = subparsers.add_parser("untrust", help=gpg_untrust.__doc__)
@@ -180,7 +184,12 @@ def gpg_sign(args):
 
 def gpg_trust(args):
     """add a key to the keyring"""
-    spack.util.gpg.trust(args.keyfile)
+    url = urllib.parse.urlparse(args.keyfile)
+    if url.scheme in ["", "file"]:
+        spack.util.gpg.trust(args.keyfile)
+    else:
+        with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpdir:
+            spack.util.gpg.trust(web_util.fetch_url_text(args.keyfile, dest_dir=tmpdir))
 
 
 def gpg_init(args):

--- a/lib/spack/spack/cmd/gpg.py
+++ b/lib/spack/spack/cmd/gpg.py
@@ -146,6 +146,7 @@ def gpg_create(args):
     if args.export or args.secret:
         new_sec_keys = set(spack.util.gpg.signing_keys())
         new_keys = new_sec_keys.difference(old_sec_keys)
+        new_keys = [str(k) for k in new_keys]
 
     if args.export:
         spack.util.gpg.export_keys(args.export, new_keys)
@@ -157,7 +158,7 @@ def gpg_export(args):
     """export a gpg key, optionally including secret key"""
     keys = args.keys
     if not keys:
-        keys = spack.util.gpg.signing_keys()
+        keys = [str(k) for k in spack.util.gpg.signing_keys()]
     spack.util.gpg.export_keys(args.location, keys, args.secret)
 
 
@@ -181,7 +182,7 @@ def gpg_sign(args):
     if not output:
         output = args.spec[0] + ".asc"
     # TODO: Support the package format Spack creates.
-    spack.util.gpg.sign(key, " ".join(args.spec), output, args.clearsign)
+    spack.util.gpg.sign(str(key), " ".join(args.spec), output, args.clearsign)
 
 
 def gpg_trust(args):
@@ -197,7 +198,7 @@ def gpg_trust(args):
             keys = spack.util.gpg.extract_public_keys(keyfile)
             tty.msg(f"Keys to be imported from {args.keyfile}")
             for key in keys:
-                tty.msg(f"  {key[0]} ({key[1]})")
+                tty.msg(f"{key:short}")
 
             answer = tty.get_yes_or_no("Do you want to proceed?", default=False)
             if not answer:

--- a/lib/spack/spack/cmd/gpg.py
+++ b/lib/spack/spack/cmd/gpg.py
@@ -15,6 +15,7 @@ import spack.util.gpg
 import spack.util.url
 import spack.util.web as web_util
 from spack.cmd.common import arguments
+from spack.llnl.util import tty
 
 description = "handle GPG actions for spack"
 section = "packaging"
@@ -34,6 +35,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     trust.add_argument(
         "keyfile", type=str, help="add a keyfile from path or url to the trust store"
     )
+    arguments.add_common_arguments(trust, ["yes_to_all"])
     trust.set_defaults(func=gpg_trust, subparser=trust)
 
     untrust = subparsers.add_parser("untrust", help=gpg_untrust.__doc__)
@@ -185,11 +187,23 @@ def gpg_sign(args):
 def gpg_trust(args):
     """add a key to the keyring"""
     url = urllib.parse.urlparse(args.keyfile)
-    if url.scheme in ["", "file"]:
-        spack.util.gpg.trust(args.keyfile)
-    else:
-        with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpdir:
-            spack.util.gpg.trust(web_util.fetch_url_text(args.keyfile, dest_dir=tmpdir))
+    with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpdir:
+        if url.scheme in ["", "file"]:
+            keyfile = args.keyfile
+        else:
+            keyfile = web_util.fetch_url_text(args.keyfile, dest_dir=tmpdir)
+
+        if not args.yes_to_all:
+            keys = spack.util.gpg.extract_public_keys(keyfile)
+            tty.msg(f"Keys to be imported from {args.keyfile}")
+            for key in keys:
+                tty.msg(f"  {key[0]} ({key[1]})")
+
+            answer = tty.get_yes_or_no("Do you want to proceed?", default=False)
+            if not answer:
+                tty.die("Aborting trust keys")
+
+        spack.util.gpg.trust(keyfile)
 
 
 def gpg_init(args):

--- a/lib/spack/spack/cmd/gpg.py
+++ b/lib/spack/spack/cmd/gpg.py
@@ -79,12 +79,18 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     )
     create.set_defaults(func=gpg_create, subparser=create)
 
-    list = subparsers.add_parser("list", help=gpg_list.__doc__)
-    list.add_argument("--trusted", action="store_true", default=True, help="list trusted keys")
-    list.add_argument(
+    glist = subparsers.add_parser("list", help=gpg_list.__doc__)
+    glist.add_argument(
+        "--fmt",
+        "-f",
+        action="store",
+        help="Format to list keys with (default (gpg), colons, keys, <key format string>)",
+    )
+    glist.add_argument("--trusted", action="store_true", default=True, help="list trusted keys")
+    glist.add_argument(
         "--signing", action="store_true", help="list keys which may be used for signing"
     )
-    list.set_defaults(func=gpg_list, subparser=list)
+    glist.set_defaults(func=gpg_list, subparser=glist)
 
     init = subparsers.add_parser("init", help=gpg_init.__doc__)
     init.add_argument("--from", metavar="DIR", type=str, dest="import_dir", help=argparse.SUPPRESS)
@@ -164,7 +170,7 @@ def gpg_export(args):
 
 def gpg_list(args):
     """list keys available in the keyring"""
-    spack.util.gpg.list(args.trusted, args.signing)
+    spack.util.gpg.list(args.trusted, args.signing, args.fmt)
 
 
 def gpg_sign(args):

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -151,7 +151,7 @@ def test_push_and_fetch_keys(mock_gnupghome, tmp_path: pathlib.Path):
 
         keys = spack.util.gpg.public_keys()
         assert len(keys) == 1
-        fpr = keys[0]
+        fpr = str(keys[0])
 
         spack.binary_distribution._url_push_keys(
             mirror, keys=[fpr], tmpdir=str(tmp_path), update_index=True
@@ -166,7 +166,7 @@ def test_push_and_fetch_keys(mock_gnupghome, tmp_path: pathlib.Path):
 
         new_keys = spack.util.gpg.public_keys()
         assert len(new_keys) == 1
-        assert new_keys[0] == fpr
+        assert str(new_keys[0]) == fpr
 
 
 @pytest.mark.maybeslow

--- a/lib/spack/spack/test/cmd/gpg.py
+++ b/lib/spack/spack/test/cmd/gpg.py
@@ -48,7 +48,6 @@ def test_find_gpg(cmd_name, version, tmp_path: pathlib.Path, mock_gnupghome, mon
     else:
         spack.util.gpg.init(force=True)
         assert spack.util.gpg.GPG is not None
-        assert spack.util.gpg.GPGCONF is not None
 
 
 def test_no_gpg_in_path(tmp_path: pathlib.Path, mock_gnupghome, monkeypatch, mutable_config):

--- a/lib/spack/spack/test/cmd/gpg.py
+++ b/lib/spack/spack/test/cmd/gpg.py
@@ -103,7 +103,7 @@ def test_gpg(tmp_path: pathlib.Path, mutable_config, mock_gnupghome):
         "Spack testing 1",
         "spack@googlegroups.com",
     )
-    keyfp = spack.util.gpg.signing_keys()[0]
+    keyfp = spack.util.gpg.signing_keys()[0].fpr
 
     # List the keys.
     # TODO: Test the output here.

--- a/lib/spack/spack/test/cmd/gpg.py
+++ b/lib/spack/spack/test/cmd/gpg.py
@@ -167,7 +167,7 @@ def test_gpg(tmp_path: pathlib.Path, mutable_config, mock_gnupghome):
         gpg("verify", str(test_path))
 
     # Trust the exported key.
-    gpg("trust", str(export_path))
+    gpg("trust", "-y", str(export_path))
 
     # Verification should now succeed again.
     gpg("verify", str(test_path))

--- a/lib/spack/spack/test/util/util_gpg.py
+++ b/lib/spack/spack/test/util/util_gpg.py
@@ -20,13 +20,13 @@ def has_socket_dir():
 def test_parse_gpg_output_case_one():
     now = int(time.time())
     # Two keys, fingerprint for primary keys, but not subkeys
-    output = f"""sec::2048:1:AAAAAAAAAAAAAAAA:{now}:AAAAAAAAAA:::::::::
+    output = f"""sec::2048:1:AAAAAAAAAAAAAAAA:{now}:{now}:::::::::
 fpr:::::::::XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:
-uid:::::::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA::Joe (Test) <j.s@s.com>:
+uid:::::{now}::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA::Joe (Test) <j.s@s.com>:
 ssb::2048:1:AAAAAAAAAAAAAAAA:{now}::::::::::
-sec::2048:1:AAAAAAAAAAAAAAAA:{now}:AAAAAAAAAA:::::::::
+sec::2048:1:AAAAAAAAAAAAAAAA:{now}:{now}:::::::::
 fpr:::::::::YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY:
-uid:::::::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA::Joe (Test) <j.s@s.com>:
+uid:::::{now}::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA::Joe (Test) <j.s@s.com>:
 ssb::2048:1:AAAAAAAAAAAAAAAA:{now}::::::::::
 """
     keys = spack.util.gpg._parse_gpg_output(output)
@@ -42,7 +42,7 @@ def test_parse_gpg_output_case_two():
     output = f"""sec:-:2048:1:AAAAAAAAAA:{now}:::-:::escaESCA:::+:::23::0:
 fpr:::::::::XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:
 grp:::::::::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA:
-uid:-::::AAAAAAAAA::AAAAAAAAA::Joe (Test) <j.s@s.com>::::::::::0:
+uid:-::::{now}::AAAAAAAAA::Joe (Test) <j.s@s.com>::::::::::0:
 ssb:-:2048:1:AAAAAAAAA:{now}:::::esa:::+:::23:
 fpr:::::::::YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY:
 grp:::::::::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA:
@@ -56,14 +56,14 @@ grp:::::::::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA:
 def test_parse_gpg_output_case_three():
     now = int(time.time())
     # Two keys, fingerprint for primary keys as well as subkeys
-    output = f"""sec::2048:1:AAAAAAAAAAAAAAAA:{now}:AAAAAAAAAA:::::::::
+    output = f"""sec::2048:1:AAAAAAAAAAAAAAAA:{now}:{now}:::::::::
 fpr:::::::::WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW:
-uid:::::::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA::Joe (Test) <j.s@s.com>:
+uid:::::{now}::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA::Joe (Test) <j.s@s.com>:
 ssb::2048:1:AAAAAAAAAAAAAAAA:{now}::::::::::
 fpr:::::::::XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:
-sec::2048:1:AAAAAAAAAAAAAAAA:{now}:AAAAAAAAAA:::::::::
+sec::2048:1:AAAAAAAAAAAAAAAA:{now}:{now}:::::::::
 fpr:::::::::YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY:
-uid:::::::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA::Joe (Test) <j.s@s.com>:
+uid:::::{now}::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA::Joe (Test) <j.s@s.com>:
 ssb::2048:1:AAAAAAAAAAAAAAAA:{now}::::::::::
 fpr:::::::::ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ:"""
 
@@ -74,7 +74,6 @@ fpr:::::::::ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ:"""
     assert keys[1].fpr == "YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY"
 
 
-@pytest.mark.requires_executables("gpg2")
 def test_really_long_gnupghome_dir(tmp_path: pathlib.Path, has_socket_dir):
     if not has_socket_dir:
         pytest.skip("This test requires /var/run/user/$(id -u)")

--- a/lib/spack/spack/test/util/util_gpg.py
+++ b/lib/spack/spack/test/util/util_gpg.py
@@ -4,6 +4,7 @@
 
 import os
 import pathlib
+import time
 
 import pytest
 
@@ -17,57 +18,60 @@ def has_socket_dir():
 
 
 def test_parse_gpg_output_case_one():
+    now = int(time.time())
     # Two keys, fingerprint for primary keys, but not subkeys
-    output = """sec::2048:1:AAAAAAAAAAAAAAAA:AAAAAAAAAA:AAAAAAAAAA:::::::::
+    output = f"""sec::2048:1:AAAAAAAAAAAAAAAA:{now}:AAAAAAAAAA:::::::::
 fpr:::::::::XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:
 uid:::::::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA::Joe (Test) <j.s@s.com>:
-ssb::2048:1:AAAAAAAAAAAAAAAA:AAAAAAAAAA::::::::::
-sec::2048:1:AAAAAAAAAAAAAAAA:AAAAAAAAAA:AAAAAAAAAA:::::::::
+ssb::2048:1:AAAAAAAAAAAAAAAA:{now}::::::::::
+sec::2048:1:AAAAAAAAAAAAAAAA:{now}:AAAAAAAAAA:::::::::
 fpr:::::::::YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY:
 uid:::::::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA::Joe (Test) <j.s@s.com>:
-ssb::2048:1:AAAAAAAAAAAAAAAA:AAAAAAAAAA::::::::::
+ssb::2048:1:AAAAAAAAAAAAAAAA:{now}::::::::::
 """
-    keys = spack.util.gpg._parse_secret_keys_output(output)
+    keys = spack.util.gpg._parse_gpg_output(output)
 
     assert len(keys) == 2
-    assert keys[0] == "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-    assert keys[1] == "YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY"
+    assert keys[0].fpr == "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    assert keys[1].fpr == "YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY"
 
 
 def test_parse_gpg_output_case_two():
+    now = int(time.time())
     # One key, fingerprint for primary key as well as subkey
-    output = """sec:-:2048:1:AAAAAAAAAA:AAAAAAAA:::-:::escaESCA:::+:::23::0:
+    output = f"""sec:-:2048:1:AAAAAAAAAA:{now}:::-:::escaESCA:::+:::23::0:
 fpr:::::::::XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:
 grp:::::::::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA:
 uid:-::::AAAAAAAAA::AAAAAAAAA::Joe (Test) <j.s@s.com>::::::::::0:
-ssb:-:2048:1:AAAAAAAAA::::::esa:::+:::23:
+ssb:-:2048:1:AAAAAAAAA:{now}:::::esa:::+:::23:
 fpr:::::::::YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY:
 grp:::::::::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA:
 """
-    keys = spack.util.gpg._parse_secret_keys_output(output)
+    keys = spack.util.gpg._parse_gpg_output(output)
 
     assert len(keys) == 1
-    assert keys[0] == "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    assert keys[0].fpr == "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 
 
 def test_parse_gpg_output_case_three():
+    now = int(time.time())
     # Two keys, fingerprint for primary keys as well as subkeys
-    output = """sec::2048:1:AAAAAAAAAAAAAAAA:AAAAAAAAAA:AAAAAAAAAA:::::::::
+    output = f"""sec::2048:1:AAAAAAAAAAAAAAAA:{now}:AAAAAAAAAA:::::::::
 fpr:::::::::WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW:
 uid:::::::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA::Joe (Test) <j.s@s.com>:
-ssb::2048:1:AAAAAAAAAAAAAAAA:AAAAAAAAAA::::::::::
+ssb::2048:1:AAAAAAAAAAAAAAAA:{now}::::::::::
 fpr:::::::::XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:
-sec::2048:1:AAAAAAAAAAAAAAAA:AAAAAAAAAA:AAAAAAAAAA:::::::::
+sec::2048:1:AAAAAAAAAAAAAAAA:{now}:AAAAAAAAAA:::::::::
 fpr:::::::::YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY:
 uid:::::::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA::Joe (Test) <j.s@s.com>:
-ssb::2048:1:AAAAAAAAAAAAAAAA:AAAAAAAAAA::::::::::
+ssb::2048:1:AAAAAAAAAAAAAAAA:{now}::::::::::
 fpr:::::::::ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ:"""
 
-    keys = spack.util.gpg._parse_secret_keys_output(output)
+    keys = spack.util.gpg._parse_gpg_output(output)
 
     assert len(keys) == 2
-    assert keys[0] == "WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW"
-    assert keys[1] == "YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY"
+    assert keys[0].fpr == "WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW"
+    assert keys[1].fpr == "YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY"
 
 
 @pytest.mark.requires_executables("gpg2")

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -162,7 +162,6 @@ class GpgKeyType(enum.Flag):
             for mem in cls:
                 if mem.value == value:
                     return mem
-            print(value)
 
         kname = value.strip().lower()
         if kname == "pub":
@@ -287,18 +286,6 @@ class GpgKey:
         self.uid: List[GpgUserId] = []
         self.subkey: List[GpgKey] = []
 
-    @staticmethod
-    def from_colons(colons: str) -> Optional["GpgKey"]:
-        keys = _parse_gpg_output(colons)
-        if len(keys) > 1:
-            tty.warn("Multiple primary keys detected while parsing. Returning first key.")
-            return keys[0]
-
-        if len(keys) == 1:
-            return keys[0]
-
-        return None
-
     def add(self, data: Dict[str, str]):
         """Add metadata to a key"""
 
@@ -323,11 +310,8 @@ class GpgKey:
         if isinstance(otherkey, str):
             return self.fpr == otherkey
         elif isinstance(otherkey, GpgKey):
-            return f"{self:c}" == f"{otherkey:c}"
-            # return (
-            #     self.fpr == otherkey.fpr and
-            #     _subkey_fpr_list(self) == _subkey_fpr_list(otherkey
-            # )
+            # return f"{self:c}" == f"{otherkey:c}"
+            return self.fpr == otherkey.fpr
         else:
             return NotImplemented
 
@@ -352,13 +336,14 @@ class GpgKey:
             data["updated_at"] = int(self.updated_at.timestamp())
 
         data["owner_trust"] = self.owner_trust.value
-        data["capabilities"] = ""
+        cap_list = set()
         if self.subkey:
-            data["capabilities"] += "".join([c.value.upper() for c in self.capabilities])
+            cap_list.update([c.value.upper() for c in self.capabilities])
             for k in self.subkey:
-                data["capabilities"] += "".join([c.value.lower() for c in k.capabilities])
+                cap_list.update([c.value.lower() for c in k.capabilities])
         else:
-            data["capabilities"] += "".join([c.value.lower() for c in self.capabilities])
+            cap_list.update([c.value.lower() for c in self.capabilities])
+        data["capabilities"] = "".join(sorted(cap_list))
 
         data["compliance"] = self.compliance.value
 
@@ -487,27 +472,7 @@ class Gpg:
 
         return self._socket_dir
 
-    @overload
-    def list_keys(self, *fprs, ktype: GpgKeyType = GpgKeyType.PUBLIC) -> List[GpgKey]: ...
-
-    @overload
-    def list_keys(self, *fprs, fmt: str, ktype: GpgKeyType = GpgKeyType.PUBLIC) -> None: ...
-
-    def list_keys(
-        self, *fprs, ktype: GpgKeyType = GpgKeyType.PUBLIC, fmt: str = "keys", output=sys.stdout
-    ) -> Optional[Union[str, List[GpgKey]]]:
-        """List known keys.
-
-        Args:
-            fprs: list of key fingerprints
-            ktype: Type of dey to list (default: PUBLIC)
-            fmt: format to print/return keys (default: None)
-                "default" (or None) -> return default output from gpg
-                "keys"              -> return list of GpgKey objects
-                "colons"            -> return output from gpg --with-colons
-                GpgKey format       ->  See GpgKey __format__
-            output: stream to send string output to (str or stream passed to print(output))
-        """
+    def _list_keys(self, *fprs, colons: bool = True, ktype: GpgKeyType = GpgKeyType.PUBLIC) -> str:
         gpg_args = []
 
         # Determine the list option
@@ -520,32 +485,38 @@ class Gpg:
 
         # Determine output format
         # colons or a spack abbreviated format
-        if fmt == "colons" or fmt != "default":
+        if colons:
             gpg_args.append("--with-colons")
 
         # Get list of keys from keyring
-        out = self.gpg(*gpg_args, "--fingerprint", *fprs, output=str)
+        return self.gpg(*gpg_args, "--fingerprint", *fprs, output=str)
 
-        buffer = ""
-        if fmt not in ("colons", "default"):
+    def keys(self, *fprs, ktype: GpgKeyType = GpgKeyType.PUBLIC):
+        return _parse_gpg_output(self._list_keys(*fprs, colons = True, ktype=ktype))
+
+    def list_keys(
+            self, *fprs, ktype: GpgKeyType = GpgKeyType.PUBLIC, fmt: str = ""
+    ) -> Union[str, List[GpgKey]]:
+        """List known keys.
+
+        Args:
+            fprs: list of key fingerprints
+            ktype: Type of dey to list (default: PUBLIC)
+            fmt: format to print/return keys (default: None)
+                default (aka "") -> return default output from gpg
+                GpgKey format string->  See GpgKey __format__
+        """
+
+        # Get list of keys from keyring
+        out = self._list_keys(*fprs, colons=bool(fmt), ktype=ktype)
+        if fmt:
+            buffer = ""
             keys = _parse_gpg_output(out)
-            if fmt == "keys":
-                return keys
-
             for key in keys:
                 buffer += f"{{key:{fmt}}}".format(key=key)
-        else:
-            buffer = out
-
-        if not buffer:
-            return None
-
-        if output == str:
             return buffer
         else:
-            print(buffer.strip(), file=output, flush=True)
-
-        return None
+            return out
 
     def trust(self, keyfile: str, ultimate: bool = True):
         """Import a public key from a file and trust it.
@@ -562,7 +533,7 @@ class Gpg:
             return
 
         # Set trust to ultimate
-        known_keys = self.list_keys()
+        known_keys = self.keys()
         for key in keys:
             # Skip over keys we cannot find a fingerprint for.
             if known_keys and key not in known_keys:
@@ -818,14 +789,14 @@ Expire-Date: %(expires)s
 def signing_keys(*args) -> List[GpgKey]:
     """Return the keys that can be used to sign binaries."""
     assert GPG
-    return GPG.list_keys(*args, ktype=GpgKeyType.SECRET)
+    return GPG.keys(*args, ktype=GpgKeyType.SECRET)
 
 
 @_autoinit
 def public_keys(*args) -> List[GpgKey]:
     """Return a list of fingerprints"""
     assert GPG
-    return GPG.list_keys(*args, ktype=GpgKeyType.PUBLIC)
+    return GPG.keys(*args, ktype=GpgKeyType.PUBLIC)
 
 
 @_autoinit
@@ -876,9 +847,9 @@ def untrust(signing: bool, *keys):
     """
     assert GPG
     if signing:
-        GPG.untrust(GPG.list_keys(*keys, ktype=GpgKeyType.SECRET))
+        GPG.untrust(GPG.keys(*keys, ktype=GpgKeyType.SECRET))
 
-    untrust_keys = GPG.list_keys(*keys, ktype=GpgKeyType.PUBLIC)
+    untrust_keys = GPG.keys(*keys, ktype=GpgKeyType.PUBLIC)
     GPG.untrust(untrust_keys)
 
 
@@ -927,11 +898,11 @@ def list(trusted: bool, signing: bool, fmt: str = "default"):
 
     if trusted:
         tty.msg("Trusted keys")
-        GPG.list_keys(ktype=GpgKeyType.PUBLIC, fmt=fmt)
+        print(GPG.list_keys(ktype=GpgKeyType.PUBLIC, fmt=fmt))
 
     if signing:
         tty.msg("Signing keys")
-        GPG.list_keys(ktype=GpgKeyType.SECRET, fmt=fmt)
+        print(GPG.list_keys(ktype=GpgKeyType.SECRET, fmt=fmt))
 
 
 def _verify_exe_or_raise(exe):

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -7,23 +7,55 @@ import enum
 import errno
 import functools
 import os
+import pathlib
 import re
-from typing import Any, Callable, Dict, List, Optional
+import sys
+from typing import Any, Callable, Dict, List, Optional, Union, overload
 
 import spack.error
 import spack.llnl.util.filesystem
+import spack.llnl.util.tty as tty
 import spack.paths
 import spack.util.executable
 import spack.version
+from spack.util.executable import Executable
+
+GPG_NAMES = ("gpg", "gpg2")
+GPGCONF_NAMES = ("gpgconf", "gpg2conf", "gpgconf2")
 
 #: Executable instance for "gpg", initialized lazily
-GPG = None
+GPG: Optional["Gpg"] = None
 #: Executable instance for "gpgconf", initialized lazily
-GPGCONF = None
+GPGCONF: Optional[Executable] = None
 #: Socket directory required if a non default home directory is used
 SOCKET_DIR = None
 #: GNUPGHOME environment variable in the context of this Python module
 GNUPGHOME = None
+
+#:
+_GPG_FIELD_MAP = [
+    "type",
+    "trust",
+    "len",
+    "key_algo",
+    "key_id",
+    "created_at",
+    "expire_at",
+    "misc",
+    "owner_trust",
+    "uid",
+    "sig_class",
+    "capabilities",
+    "issuer_cert",
+    "flag",
+    "token",
+    "hash_algo",
+    "curve_name",
+    "compliance",
+    "updated_at",
+    "origin",
+    "comment",
+]
 
 
 class GpgKeyCapability(enum.Enum):
@@ -50,7 +82,7 @@ class GpgKeyTrust(enum.Enum):
     INVALID = "i"
     REVOKED = "r"
     EXPIRED = "e"
-    UNKNOWN = "q"  # - o
+    UNKNOWN = "-"  # - o
     NEVER = "n"
     MARGINAL = "m"
     FULL = "f"
@@ -111,14 +143,57 @@ class GpgKeyCompliance(enum.Enum):
     UNKNOWN = 0
 
 
-class GpgKeyType(enum.Enum):
+class GpgKeyType(enum.Flag):
     """Gpg Key types"""
 
-    PUBLIC = "pub"
-    SUBKEY = "sub"
-    SECRET = "sec"
-    SECRET_SUBKEY = "ssb"
-    REVOCATION = "rvk"
+    PUBLIC = enum.auto()
+    SUBKEY = enum.auto()
+    SECRET = enum.auto()
+    REVOCATION = enum.auto()
+
+    SECRET_SUBKEY_ONLY = enum.auto()
+
+    PUBLIC_SUBKEY = PUBLIC | SUBKEY
+    SECRET_SUBKEY = SECRET | SUBKEY
+
+    @classmethod
+    def _missing_(cls, value):
+        if not isinstance(value, str):
+            for mem in cls:
+                if mem.value == value:
+                    return mem
+            print(value)
+
+        kname = value.strip().lower()
+        if kname == "pub":
+            return GpgKeyType.PUBLIC
+        if kname == "sub":
+            return GpgKeyType.PUBLIC_SUBKEY
+        if kname == "sec":
+            return GpgKeyType.SECRET
+        if kname == "sec#":
+            return GpgKeyType.SECRET_SUBKEY_ONLY
+        if kname == "ssb":
+            return GpgKeyType.SECRET_SUBKEY
+        if kname == "rvk":
+            return GpgKeyType.REVOCATION
+        return None
+
+    def __str__(self):
+        if self == GpgKeyType.PUBLIC:
+            return "pub"
+        if self == GpgKeyType.PUBLIC_SUBKEY:
+            return "sub"
+        if self == GpgKeyType.SECRET:
+            return "sec"
+        if self == GpgKeyType.SECRET_SUBKEY_ONLY:
+            return "sec#"
+        if self == GpgKeyType.SECRET_SUBKEY:
+            return "ssb"
+        if self == GpgKeyType.REVOCATION:
+            return "rvk"
+
+        return self.name
 
 
 class GpgSigType(enum.Enum):
@@ -135,24 +210,51 @@ class GpgUserId:
 
         self.type = data["type"]
         self.trust = GpgKeyTrust(data["trust"])
+        if not data["created_at"]:
+            tty.warn("GPG Key User ID has no creation date")
+            self.created_at = None
+        else:
+            self.created_at = datetime.datetime.fromtimestamp(int(data["created_at"]))
         self.hash = data["misc"]
         self.uid = data["uid"]
+        self.origin = data.get("origin")
+
+    def _format_colons(self) -> str:
+        data: Dict[str, Any] = {}
+        data["type"] = self.type
+        data["trust"] = self.trust.value
+        if self.created_at:
+            data["created_at"] = int(self.created_at.timestamp())
+        data["misc"] = self.hash
+        data["uid"] = self.uid
+        data["origin"] = self.origin or ""
+
+        return ":".join([str(data.get(f, "")) for f in _GPG_FIELD_MAP])
 
 
 class GpgSignature:
     def __init__(self, data: Dict[str, str]):
-        assert data["type"] in ("sig", "rev", "rvs")
-
+        self.type = GpgSigType(data["type"])
         self.algo = GpgKeyAlgorithm(int(data["key_algo"]))
         self.id = data["key_id"]
         self.created_at = datetime.datetime.fromtimestamp(int(data["created_at"]))
         self.uid = data["uid"]
         self.sig_class = data["sig_class"]
 
+    def _format_colons(self) -> str:
+        data: Dict[str, Any] = {}
+        data["type"] = self.type.value
+        data["key_algo"] = self.algo.value
+        data["key_id"] = self.id
+        data["created_at"] = int(self.created_at.timestamp())
+        data["uid"] = self.uid
+        data["sig_class"] = self.sig_class
+        return ":".join([str(data.get(f, "")) for f in _GPG_FIELD_MAP])
+
 
 class GpgKey:
     def __init__(self, data: Dict[str, str]):
-        assert data["type"] in ("pub", "sec", "sub", "ssb")
+        assert data["type"] in ("pub", "sec", "sec#", "sub", "ssb")
 
         self.type = GpgKeyType(data["type"])
 
@@ -185,6 +287,18 @@ class GpgKey:
         self.uid: List[GpgUserId] = []
         self.subkey: List[GpgKey] = []
 
+    @staticmethod
+    def from_colons(colons: str) -> Optional["GpgKey"]:
+        keys = _parse_gpg_output(colons)
+        if len(keys) > 1:
+            tty.warn("Multiple primary keys detected while parsing. Returning first key.")
+            return keys[0]
+
+        if len(keys) == 1:
+            return keys[0]
+
+        return None
+
     def add(self, data: Dict[str, str]):
         """Add metadata to a key"""
 
@@ -202,10 +316,18 @@ class GpgKey:
             self.rev.append(GpgSignature(data))
 
     def __eq__(self, otherkey):
+        def _subkey_fpr_list(key):
+            # return an ordered list of key fingerprints for comparison
+            return set([k.fpr for k in key.subkey])
+
         if isinstance(otherkey, str):
             return self.fpr == otherkey
         elif isinstance(otherkey, GpgKey):
-            return self.fpr == otherkey.fpr
+            return f"{self:c}" == f"{otherkey:c}"
+            # return (
+            #     self.fpr == otherkey.fpr and
+            #     _subkey_fpr_list(self) == _subkey_fpr_list(otherkey
+            # )
         else:
             return NotImplemented
 
@@ -215,25 +337,327 @@ class GpgKey:
     def __str__(self):
         return self.fpr
 
+    def _format_colons(self) -> List[str]:
+        data: Dict[str, Any] = {}
+        data["type"] = self.type
+        data["trust"] = self.trust.value
+
+        data["len"] = self.key_len
+        data["key_algo"] = self.key_algorithm.value
+        data["key_id"] = self.key_id
+        data["created_at"] = int(self.created_at.timestamp())
+        if self.expires_at:
+            data["expired_at"] = int(self.expires_at.timestamp())
+        if self.updated_at:
+            data["updated_at"] = int(self.updated_at.timestamp())
+
+        data["owner_trust"] = self.owner_trust.value
+        data["capabilities"] = ""
+        if self.subkey:
+            data["capabilities"] += "".join([c.value.upper() for c in self.capabilities])
+            for k in self.subkey:
+                data["capabilities"] += "".join([c.value.lower() for c in k.capabilities])
+        else:
+            data["capabilities"] += "".join([c.value.lower() for c in self.capabilities])
+
+        data["compliance"] = self.compliance.value
+
+        data["origin"] = self.origin or ""
+        data["comment"] = self.comment
+
+        colons = []
+        nkey_fields = len(_GPG_FIELD_MAP)
+        if self.type.value & GpgKeyType.SUBKEY.value:
+            nkey_fields -= 3
+        colons.append(":".join([str(data.get(f, "")) for f in _GPG_FIELD_MAP[: nkey_fields + 1]]))
+
+        if self.fpr:
+            fpr_data = {}
+            fpr_data["type"] = "fpr"
+            fpr_data["uid"] = self.fpr
+            colons.append(":".join([str(fpr_data.get(f, "")) for f in _GPG_FIELD_MAP[:11]]))
+
+        for u in self.uid:
+            colons.append(u._format_colons())
+
+        for s in self.sig:
+            colons.append(s._format_colons())
+
+        for r in self.rev:
+            colons.append(r._format_colons())
+
+        for k in self.subkey:
+            colons.extend(k._format_colons())
+
+        return colons
+
     def __format__(self, fspec):
         """Formatted output for GPG key
 
         Default:
             <fingerprint>
 
-        g[pg] - GPG style output (without colons)
-        c[olons] - GPG style output (with colons)
+        c[olons] - Output everything using a gpg style colon format ie.
         s[hort] - Shortened output ie. <fingerprint> (<uid>)
+        f[pr] - Fingerprint only output ie. <fingerprint>
         """
 
-        if fspec.startswith("g"):
-            return GPG("--list-keys", "--fingerprint", self.fpr, output=str)
-        elif fspec.startswith("c"):
-            return GPG("--list-keys", "--fingerprint", "--with-colons", self.fpr, output=str)
-        elif fspec.startswith("s"):
+        if fspec.startswith("s"):
             return f"{self.fpr} ({self.uid[0].uid})"
-        else:
+        elif fspec.startswith("f"):
             return self.fpr
+        elif fspec.startswith("c"):
+            return "\n".join(self._format_colons())
+        else:
+            return str(self)
+
+
+class Gpg:
+    """Wrapper for GPG"""
+
+    def __init__(self, gnupghome: Optional[str] = None):
+        self.home = Gpg._init_gnupghome(gnupghome)
+        self._gpg: Optional[Executable] = None
+        self._gpgconf: Optional[Executable] = None
+        self._socket_dir: Optional[pathlib.Path] = None
+
+    @staticmethod
+    def _init_gnupghome(gnupghome: Optional[str] = None) -> pathlib.Path:
+        # Make sure that the gnupghome exists
+        gnupghome = gnupghome or os.getenv("SPACK_GNUPGHOME") or spack.paths.gpg_path
+        if not os.path.exists(gnupghome):
+            os.makedirs(gnupghome)
+            os.chmod(gnupghome, 0o700)
+
+        if not os.path.isdir(gnupghome):
+            msg = 'gnupghome "{0}" exists and is not a directory'.format(gnupghome)
+            raise SpackGPGError(msg)
+
+        return pathlib.Path(gnupghome)
+
+    def _create_gpgfn(
+        self, *find_gpgfn: Callable[..., Optional[Executable]]
+    ) -> List[Optional[Executable]]:
+        """Create a GPG function wrapper"""
+        import spack.bootstrap
+
+        fnwrappers = []
+        with spack.bootstrap.ensure_bootstrap_configuration():
+            spack.bootstrap.ensure_gpg_in_path_or_raise()
+            for finder in find_gpgfn:
+                gpgfn = finder()
+                fnwrappers.append(gpgfn)
+
+        for gpgfn in fnwrappers:
+            if gpgfn:
+                gpgfn.add_default_env("GNUPGHOME", str(self.home))
+
+        return fnwrappers
+
+    @property
+    def gpg(self):
+        if not self._gpg:
+            self._gpg = self._create_gpgfn(_gpg)[0]
+            # Ensure the GPG Socket exists
+            _ = self.socket_dir
+
+        return self._gpg
+
+    def __call__(self, *args, **kwargs):
+        return self.gpg(*args, **kwargs)
+
+    @property
+    def conf(self) -> Optional[Executable]:
+        if not self._gpgconf:
+            self._gpgconf = self._create_gpgfn(_gpgconf)[0]
+
+        return self._gpgconf
+
+    @property
+    def socket_dir(self) -> Optional[pathlib.Path]:
+        if self._socket_dir:
+            return self._socket_dir
+
+        if self.conf:
+            # Set the socket dir if not using GnuPG defaults
+            self._socket_dir = _socket_dir(self.conf)
+
+            if self._socket_dir is not None:
+                self.conf("--create-socketdir")
+
+        return self._socket_dir
+
+    @overload
+    def list_keys(self, *fprs, ktype: GpgKeyType = GpgKeyType.PUBLIC) -> List[GpgKey]: ...
+
+    @overload
+    def list_keys(self, *fprs, fmt: str, ktype: GpgKeyType = GpgKeyType.PUBLIC) -> None: ...
+
+    def list_keys(
+        self, *fprs, ktype: GpgKeyType = GpgKeyType.PUBLIC, fmt: str = "keys", output=sys.stdout
+    ) -> Optional[Union[str, List[GpgKey]]]:
+        """List known keys.
+
+        Args:
+            fprs: list of key fingerprints
+            ktype: Type of dey to list (default: PUBLIC)
+            fmt: format to print/return keys (default: None)
+                "default" (or None) -> return default output from gpg
+                "keys"              -> return list of GpgKey objects
+                "colons"            -> return output from gpg --with-colons
+                GpgKey format       ->  See GpgKey __format__
+            output: stream to send string output to (str or stream passed to print(output))
+        """
+        gpg_args = []
+
+        # Determine the list option
+        if GpgKeyType.PUBLIC in ktype:
+            gpg_args.append("--list-public-keys")
+        elif GpgKeyType.SECRET in ktype:
+            gpg_args.append("--list-secret-keys")
+        else:
+            gpg_args.append("--list-keys")
+
+        # Determine output format
+        # colons or a spack abbreviated format
+        if fmt == "colons" or fmt != "default":
+            gpg_args.append("--with-colons")
+
+        # Get list of keys from keyring
+        out = self.gpg(*gpg_args, "--fingerprint", *fprs, output=str)
+
+        buffer = ""
+        if fmt not in ("colons", "default"):
+            keys = _parse_gpg_output(out)
+            if fmt == "keys":
+                return keys
+
+            for key in keys:
+                buffer += f"{{key:{fmt}}}".format(key=key)
+        else:
+            buffer = out
+
+        if not buffer:
+            return None
+
+        if output == str:
+            return buffer
+        else:
+            print(buffer.strip(), file=output, flush=True)
+
+        return None
+
+    def trust(self, keyfile: str, ultimate: bool = True):
+        """Import a public key from a file and trust it.
+
+        Args:
+            keyfile: file with the public key
+        """
+        keys = extract_public_keys(keyfile)
+
+        # Import them
+        self.gpg("--batch", "--import", keyfile)
+
+        if not ultimate:
+            return
+
+        # Set trust to ultimate
+        known_keys = self.list_keys()
+        for key in keys:
+            # Skip over keys we cannot find a fingerprint for.
+            if known_keys and key not in known_keys:
+                continue
+
+            r, w = os.pipe()
+            with contextlib.closing(os.fdopen(r, "r")) as rc:
+                with contextlib.closing(os.fdopen(w, "w")) as wc:
+                    wc.write("{0}:6:\n".format(str(key)))
+                self.gpg("--import-ownertrust", input=rc)
+
+    def untrust(self, keys: List[GpgKey]):
+        """Delete known keys.
+
+        Args:
+            keys: keys to be deleted
+        """
+        skeys = [str(k) for k in keys if GpgKeyType.SECRET in k.type]
+        if skeys:
+            self.gpg("--batch", "--yes", "--delete-secret-keys", *skeys)
+
+        pkeys = [str(k) for k in keys if GpgKeyType.PUBLIC in k.type]
+        if pkeys:
+            self.gpg("--batch", "--yes", "--delete-keys", *pkeys)
+
+    def verify(
+        self,
+        signature: Union[str, pathlib.Path],
+        blob: Union[str, pathlib.Path],
+        suppress_warnings: bool = False,
+    ):
+        """Verify the signature on a blob.
+
+        Args:
+            signature: signature file (or clearsigned file)
+            blob: blob to be verified.  If None, then signature is
+                assumed to be a clearsigned file.
+            suppress_warnings: whether or not to suppress warnings
+                from GnuPG
+        """
+        args = [str(signature)]
+        if blob and str(blob) != str(signature):
+            args.append(str(blob))
+        kwargs = {"error": str} if suppress_warnings else {}
+        print('args: {" ".join(args)}')
+        self.gpg("--verify", *args, **kwargs)
+
+    def sign(
+        self,
+        blob: Union[str, pathlib.Path],
+        output: Union[str, pathlib.Path] = "",
+        key: Optional[Union[str, GpgKey]] = None,
+        armor: bool = True,
+        clearsign: bool = False,
+    ):
+        """Sign a file with a key.
+
+        Args:
+            blob: file to be signed
+            output: output file (default: f"{blob}.sig")
+            key: key to be used to sign (default: first secret key in keyring)
+            armor: ascii armored output
+            clearsign: if True wraps the document in an ASCII-armored
+                signature, if False creates a detached signature
+        """
+        args = []
+        if armor:
+            args.append("--armor")
+
+        if key:
+            args.extend(["--local-user", str(key)])
+
+        if output:
+            args.extend(["--output", str(output)])
+
+        args.append("--clearsign" if clearsign else "--detach-sign")
+        self.gpg(*args, blob)
+
+    def export_keys(self, keyfile: str, keys: List[GpgKey], ktype: GpgKeyType = GpgKeyType.PUBLIC):
+        """Export public keys to a location passed as argument.
+
+        Args:
+            keyfile: where to export the keys
+            keys: keys to be exported
+            secret: whether to export secret keys or not
+        """
+        args = ["--armor", "--output", keyfile]
+
+        if GpgKeyType.SECRET in ktype:
+            args.append("--export-secret-keys")
+        else:
+            args.extend(["--yes", "--batch", "--export"])
+
+        fprs = [str(k) for k in keys]
+        self.gpg(*args, *fprs)
 
 
 def clear():
@@ -243,56 +667,17 @@ def clear():
 
 
 def init(gnupghome: Optional[str] = None, force: bool = False):
-    """Initialize the global objects in the module, if not set.
-
-    When calling any gpg executable, the GNUPGHOME environment
-    variable is set to:
-
-    1. The value of the ``gnupghome`` argument, if not None
-    2. The value of the "SPACK_GNUPGHOME" environment variable, if set
-    3. The default gpg path for Spack otherwise
-
-    Args:
-        gnupghome: value to be used for GNUPGHOME when calling
-            GnuPG executables
-        force: if True forces the re-initialization even if the
-            global objects are set already
-    """
+    """Initialize the global state for Gpg."""
     global GPG, GPGCONF, SOCKET_DIR, GNUPGHOME
-    import spack.bootstrap
 
     if force:
         clear()
 
-    # If the executables are already set, there's nothing to do
     if GPG and GNUPGHOME:
         return
 
-    # Set the value of GNUPGHOME to be used in this module
-    GNUPGHOME = gnupghome or os.getenv("SPACK_GNUPGHOME") or spack.paths.gpg_path
-
-    # Set the executable objects for "gpg" and "gpgconf"
-    with spack.bootstrap.ensure_bootstrap_configuration():
-        spack.bootstrap.ensure_gpg_in_path_or_raise()
-        GPG, GPGCONF = _gpg(), _gpgconf()
-
-    GPG.add_default_env("GNUPGHOME", GNUPGHOME)
-    if GPGCONF:
-        GPGCONF.add_default_env("GNUPGHOME", GNUPGHOME)
-        # Set the socket dir if not using GnuPG defaults
-        SOCKET_DIR = _socket_dir(GPGCONF)
-
-    # Make sure that the GNUPGHOME exists
-    if not os.path.exists(GNUPGHOME):
-        os.makedirs(GNUPGHOME)
-        os.chmod(GNUPGHOME, 0o700)
-
-    if not os.path.isdir(GNUPGHOME):
-        msg = 'GNUPGHOME "{0}" exists and is not a directory'.format(GNUPGHOME)
-        raise SpackGPGError(msg)
-
-    if SOCKET_DIR is not None:
-        GPGCONF("--create-socketdir")
+    GPG = Gpg(gnupghome)
+    GNUPGHOME, GPGCONF, SOCKET_DIR = GPG.home, GPG.conf, GPG.socket_dir
 
 
 def _autoinit(func: Callable[..., Any]):
@@ -321,53 +706,32 @@ def gnupghome_override(dir: str):
     global GPG, GPGCONF, SOCKET_DIR, GNUPGHOME
 
     # Store backup values
-    _GPG, _GPGCONF = GPG, GPGCONF
-    _SOCKET_DIR, _GNUPGHOME = SOCKET_DIR, GNUPGHOME
-    clear()
+    _GPG = GPG
 
-    # Clear global state
-    init(gnupghome=dir, force=True)
+    # Reset global state
+    clear()
+    GPG = Gpg(gnupghome=dir)
+    GNUPGHOME, GPGCONF, SOCKET_DIR = GPG.home, GPG.conf, GPG.socket_dir
 
     yield
 
+    # Restore previous state
     clear()
-    GPG, GPGCONF = _GPG, _GPGCONF
-    SOCKET_DIR, GNUPGHOME = _SOCKET_DIR, _GNUPGHOME
+    GPG = _GPG
+    if GPG:
+        GNUPGHOME, GPGCONF, SOCKET_DIR = GPG.home, GPG.conf, GPG.socket_dir
 
 
 def _parse_gpg_fields(karray: List[str]):
     """Parse gpg line into a dict"""
-    fields = [
-        "type",
-        "trust",
-        "len",
-        "key_algo",
-        "key_id",
-        "created_at",
-        "expire_at",
-        "misc",
-        "owner_trust",
-        "uid",
-        "sig_class",
-        "capabilities",
-        "issuer_cert",
-        "flag",
-        "token",
-        "hash_algo",
-        "curve_name",
-        "compliance",
-        "updated_at",
-        "origin",
-        "comment",
-    ]
     data = {}
-    for key, value in zip(fields, karray):
+    for key, value in zip(_GPG_FIELD_MAP, karray):
         data[key] = value
 
     return data
 
 
-def _parse_gpg_output(output: str):
+def _parse_gpg_output(output: str) -> List[GpgKey]:
     current_key: Optional[GpgKey] = None
     current_subkey: Optional[GpgKey] = None
     keys = []
@@ -382,7 +746,7 @@ def _parse_gpg_output(output: str):
             continue
 
         # Start of a new key
-        if data["type"] in ("pub", "sec"):
+        if data["type"] in ("pub", "sec", "sec#"):
             if current_subkey:
                 assert current_key
                 current_key.subkey.append(current_subkey)
@@ -416,6 +780,8 @@ def _parse_gpg_output(output: str):
     if current_key:
         if current_subkey:
             current_key.subkey.append(current_subkey)
+            # Sort subkeys by creation time, then by capability
+            current_key.subkey.sort(key=lambda k: k.created_at)
         keys.append(current_key)
 
     return keys
@@ -449,19 +815,17 @@ Expire-Date: %(expires)s
 
 
 @_autoinit
-def signing_keys(*args) -> List[str]:
+def signing_keys(*args) -> List[GpgKey]:
     """Return the keys that can be used to sign binaries."""
     assert GPG
-    output: str = GPG("--list-secret-keys", "--with-colons", "--fingerprint", *args, output=str)
-    return _parse_gpg_output(output)
+    return GPG.list_keys(*args, ktype=GpgKeyType.SECRET)
 
 
 @_autoinit
-def public_keys(*args):
+def public_keys(*args) -> List[GpgKey]:
     """Return a list of fingerprints"""
     assert GPG
-    output = GPG("--list-public-keys", "--with-colons", "--fingerprint", *args, output=str)
-    return _parse_gpg_output(output)
+    return GPG.list_keys(*args, ktype=GpgKeyType.PUBLIC)
 
 
 @_autoinit
@@ -474,11 +838,8 @@ def export_keys(location: str, keys: List[GpgKey], secret: bool = False):
         secret: whether to export secret keys or not
     """
     assert GPG
-    fprs = [str(k) for k in keys]
-    if secret:
-        GPG("--export-secret-keys", "--armor", "--output", location, *fprs)
-    else:
-        GPG("--batch", "--yes", "--armor", "--export", "--output", location, *fprs)
+    ktype = GpgKeyType.SECRET if secret else GpgKeyType.PUBLIC
+    GPG.export_keys(location, keys, ktype=ktype)
 
 
 @_autoinit
@@ -502,23 +863,7 @@ def trust(keyfile: str):
         keyfile: file with the public key
     """
     assert GPG
-    keys = extract_public_keys(keyfile)
-
-    # Import them
-    GPG("--batch", "--import", keyfile)
-
-    # Set trust to ultimate
-    known_keys = public_keys()
-    for key in keys:
-        # Skip over keys we cannot find a fingerprint for.
-        if key not in known_keys:
-            continue
-
-        r, w = os.pipe()
-        with contextlib.closing(os.fdopen(r, "r")) as rc:
-            with contextlib.closing(os.fdopen(w, "w")) as wc:
-                wc.write("{0}:6:\n".format(str(key)))
-            GPG("--import-ownertrust", input=rc)
+    GPG.trust(keyfile, ultimate=True)
 
 
 @_autoinit
@@ -531,11 +876,10 @@ def untrust(signing: bool, *keys):
     """
     assert GPG
     if signing:
-        skeys = [str(k) for k in signing_keys(*keys)]
-        GPG("--batch", "--yes", "--delete-secret-keys", *skeys)
+        GPG.untrust(GPG.list_keys(*keys, ktype=GpgKeyType.SECRET))
 
-    pkeys = [str(k) for k in public_keys(*keys)]
-    GPG("--batch", "--yes", "--delete-keys", *pkeys)
+    untrust_keys = GPG.list_keys(*keys, ktype=GpgKeyType.PUBLIC)
+    GPG.untrust(untrust_keys)
 
 
 @_autoinit
@@ -551,8 +895,7 @@ def sign(key: str, file: str, output: str, clearsign: bool = False):
             signature, if False creates a detached signature
     """
     assert GPG
-    signopt = "--clearsign" if clearsign else "--detach-sign"
-    GPG(signopt, "--armor", "--local-user", key, "--output", output, file)
+    GPG.sign(file, output, key, clearsign=clearsign)
 
 
 @_autoinit
@@ -567,15 +910,13 @@ def verify(signature: str, file: Optional[str] = None, suppress_warnings: bool =
             from GnuPG
     """
     assert GPG
-    args = [signature]
-    if file:
-        args.append(file)
-    kwargs = {"error": str} if suppress_warnings else {}
-    GPG("--verify", *args, **kwargs)
+    if not file:
+        file = signature
+    GPG.verify(signature, file, suppress_warnings=suppress_warnings)
 
 
 @_autoinit
-def list(trusted: bool, signing: bool):
+def list(trusted: bool, signing: bool, fmt: str = "default"):
     """List known keys.
 
     Args:
@@ -583,14 +924,18 @@ def list(trusted: bool, signing: bool):
         signing: if True list private keys
     """
     assert GPG
+
     if trusted:
-        GPG("--list-public-keys")
+        tty.msg("Trusted keys")
+        GPG.list_keys(ktype=GpgKeyType.PUBLIC, fmt=fmt)
 
     if signing:
-        GPG("--list-secret-keys")
+        tty.msg("Signing keys")
+        GPG.list_keys(ktype=GpgKeyType.SECRET, fmt=fmt)
 
 
 def _verify_exe_or_raise(exe):
+    """"""
     msg = (
         "Spack requires gpgconf version >= 2\n"
         "  To install a suitable version using Spack, run\n"
@@ -610,12 +955,12 @@ def _verify_exe_or_raise(exe):
         raise SpackGPGError(msg)
 
 
-def _gpgconf():
-    exe = spack.util.executable.which("gpgconf", "gpg2conf", "gpgconf2")
-    _verify_exe_or_raise(exe)
-
+def _gpgconf() -> Optional[Executable]:
+    """Get executable for gpgconf if it exists"""
     # ensure that the gpgconf we found can run "gpgconf --create-socketdir"
     try:
+        exe = spack.util.executable.which(*GPGCONF_NAMES, required=True)
+        _verify_exe_or_raise(exe)
         exe("--dry-run", "--create-socketdir", output=os.devnull, error=os.devnull)
     except spack.util.executable.ProcessError:
         # no dice
@@ -624,21 +969,29 @@ def _gpgconf():
     return exe
 
 
-def _gpg():
-    exe = spack.util.executable.which("gpg2", "gpg")
+def _gpg() -> Executable:
+    """Get executable for gpg"""
+    exe = spack.util.executable.which(*GPG_NAMES, required=True)
     _verify_exe_or_raise(exe)
     return exe
 
 
-def _socket_dir(gpgconf):
-    # Try to ensure that (/var)/run/user/$(id -u) exists so that
-    # `gpgconf --create-socketdir` can be run later.
-    #
-    # NOTE(opadron): This action helps prevent a large class of
-    #                "file-name-too-long" errors in gpg.
+def _socket_dir(gpgconf) -> Optional[pathlib.Path]:
+    """Try to ensure that (/var)/run/user/$(id -u) exists so that
+       `gpgconf --create-socketdir` can be run later.
 
-    # If there is no suitable gpgconf, don't even bother trying to
-    # pre-create a user run dir.
+    NOTE(opadron): This action helps prevent a large class of
+                   "file-name-too-long" errors in gpg.
+
+    If there is no suitable gpgconf, don't even bother trying to
+    pre-create a user run dir.
+
+    Args:
+            gpgconf: spack.util.executable.Excutable for gpgconf
+
+    Returns:
+        path to gpg socket directory
+    """
     if not gpgconf:
         return None
 
@@ -676,6 +1029,6 @@ def _socket_dir(gpgconf):
 
         # return the last iteration that provides a usable user run dir
         if user_dir is not None:
-            result = user_dir
+            result = pathlib.Path(user_dir)
 
     return result

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -2,11 +2,13 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import contextlib
+import datetime
+import enum
 import errno
 import functools
 import os
 import re
-from typing import List
+from typing import Any, Callable, Dict, List, Optional
 
 import spack.error
 import spack.llnl.util.filesystem
@@ -24,13 +26,223 @@ SOCKET_DIR = None
 GNUPGHOME = None
 
 
+class GpgKeyCapability(enum.Enum):
+    """Gpg Capabilities"""
+
+    ENCRYPT = "e"
+    SIGN = "s"
+    CERTIFY = "c"
+    AUTHENTICATE = "a"
+    DISABLED = "D"
+    UNKNOWN = "?"
+
+    @classmethod
+    def _missing_(cls, value):
+        for cap in cls:
+            if value.lower() == cap.value:
+                return cap
+        return GpgKeyCapability.UNKNOWN
+
+
+class GpgKeyTrust(enum.Enum):
+    """Gpg Trust normalized for Field 1 and Field 9"""
+
+    INVALID = "i"
+    REVOKED = "r"
+    EXPIRED = "e"
+    UNKNOWN = "q"  # - o
+    NEVER = "n"
+    MARGINAL = "m"
+    FULL = "f"
+    ULTIMATE = "u"
+    KNOWN = "w"
+    SPECIAL = "s"
+
+    @classmethod
+    def _missing_(cls, value):
+        # If it is not found, then it is unknown
+        return GpgKeyTrust.UNKNOWN
+
+
+class GpgKeyAlgorithm(enum.Enum):
+    """Gpg Algormithms"""
+
+    RSA = 1
+    RSA_SO = 2
+    RSA_EO = 3
+    ELGAMAL_EO = 16
+    DSA = 17
+    EC = 18
+    ECDSA = 19
+    ELGAMAL = 20
+    DH = 21
+    LIBGCRYPT = 256
+
+    @classmethod
+    def _missing_(cls, value):
+        if value > 255:
+            return GpgKeyAlgorithm.LIBGCRYPT
+        return None
+
+    def __str__(cls):
+        name = cls.name.lower()
+        name = name.replace("_so", " (Signing only)")
+        name = name.replace("_eo", " (Encryption only)")
+        return name
+
+    def __format__(cls, fspec):
+        """Format type with length
+        ex. f"{gpg_algo:{gpg_len}}"
+        """
+        int(fspec)
+        name = cls.name.lower()
+        name = name.replace("_so", f"{fspec} (Signing only)")
+        name = name.replace("_eo", f"{fspec} (Encryption only)")
+        return name
+
+
+class GpgKeyCompliance(enum.Enum):
+    """Gpg compliance codes"""
+
+    RFC4880BIS = 8
+    DE_VS = 23
+    DE_VS_EXP = 2023
+    VULN = 6001
+    UNKNOWN = 0
+
+
+class GpgKeyType(enum.Enum):
+    """Gpg Key types"""
+
+    PUBLIC = "pub"
+    SUBKEY = "sub"
+    SECRET = "sec"
+    SECRET_SUBKEY = "ssb"
+    REVOCATION = "rvk"
+
+
+class GpgSigType(enum.Enum):
+    """Gpg Key signature types"""
+
+    SIGNATURE = "sig"
+    REVOCATION = "rev"
+    REVOCATION_SO = "rvs"
+
+
+class GpgUserId:
+    def __init__(self, data: Dict[str, str]):
+        assert data["type"] in ("uid", "uat")
+
+        self.type = data["type"]
+        self.trust = GpgKeyTrust(data["trust"])
+        self.hash = data["misc"]
+        self.uid = data["uid"]
+
+
+class GpgSignature:
+    def __init__(self, data: Dict[str, str]):
+        assert data["type"] in ("sig", "rev", "rvs")
+
+        self.algo = GpgKeyAlgorithm(int(data["key_algo"]))
+        self.id = data["key_id"]
+        self.created_at = datetime.datetime.fromtimestamp(int(data["created_at"]))
+        self.uid = data["uid"]
+        self.sig_class = data["sig_class"]
+
+
+class GpgKey:
+    def __init__(self, data: Dict[str, str]):
+        assert data["type"] in ("pub", "sec", "sub", "ssb")
+
+        self.type = GpgKeyType(data["type"])
+
+        self.trust = GpgKeyTrust(data["trust"])
+        self.key_len = data["len"]
+        self.key_algorithm = GpgKeyAlgorithm(int(data["key_algo"]))
+        self.key_id = data["key_id"]
+        self.created_at = datetime.datetime.fromtimestamp(int(data["created_at"]))
+        self.expires_at: Optional[datetime.datetime] = None
+        if data.get("expired_at"):
+            self.expires_at = datetime.datetime.fromtimestamp(int(data["expired_at"]))
+
+        self.owner_trust = GpgKeyTrust(data["owner_trust"])
+
+        self.capabilities = set()
+        for cap in data.get("capabilities", []):
+            self.capabilities.add(GpgKeyCapability(cap))
+
+        self.compliance = GpgKeyCompliance(int(data.get("compliance") or 0))
+
+        self.updated_at: Optional[datetime.datetime] = None
+        if data.get("updated_at"):
+            self.updated_at = datetime.datetime.fromtimestamp(int(data["updated_at"]))
+        self.origin = data.get("origin")
+        self.comment = data.get("comment", "")
+
+        self.fpr: str = ""
+        self.rev: List[GpgSignature] = []
+        self.sig: List[GpgSignature] = []
+        self.uid: List[GpgUserId] = []
+        self.subkey: List[GpgKey] = []
+
+    def add(self, data: Dict[str, str]):
+        """Add metadata to a key"""
+
+        if data["type"] in ("fpr", "fp2"):
+            self.fpr = data["uid"]
+
+        elif data["type"] in ("uid", "uat"):
+            self.uid.append(GpgUserId(data))
+
+        elif data["type"] == "sig":
+            self.sig.append(GpgSignature(data))
+
+        elif data["type"] == "rev":
+            assert self.trust == GpgKeyTrust.REVOKED
+            self.rev.append(GpgSignature(data))
+
+    def __eq__(self, otherkey):
+        if isinstance(otherkey, str):
+            return self.fpr == otherkey
+        elif isinstance(otherkey, GpgKey):
+            return self.fpr == otherkey.fpr
+        else:
+            return NotImplemented
+
+    def __hash__(self):
+        return hash(self.fpr)
+
+    def __str__(self):
+        return self.fpr
+
+    def __format__(self, fspec):
+        """Formatted output for GPG key
+
+        Default:
+            <fingerprint>
+
+        g[pg] - GPG style output (without colons)
+        c[olons] - GPG style output (with colons)
+        s[hort] - Shortened output ie. <fingerprint> (<uid>)
+        """
+
+        if fspec.startswith("g"):
+            return GPG("--list-keys", "--fingerprint", self.fpr, output=str)
+        elif fspec.startswith("c"):
+            return GPG("--list-keys", "--fingerprint", "--with-colons", self.fpr, output=str)
+        elif fspec.startswith("s"):
+            return f"{self.fpr} ({self.uid[0].uid})"
+        else:
+            return self.fpr
+
+
 def clear():
     """Reset the global state to uninitialized."""
     global GPG, GPGCONF, SOCKET_DIR, GNUPGHOME
     GPG, GPGCONF, SOCKET_DIR, GNUPGHOME = None, None, None, None
 
 
-def init(gnupghome=None, force=False):
+def init(gnupghome: Optional[str] = None, force: bool = False):
     """Initialize the global objects in the module, if not set.
 
     When calling any gpg executable, the GNUPGHOME environment
@@ -41,9 +253,9 @@ def init(gnupghome=None, force=False):
     3. The default gpg path for Spack otherwise
 
     Args:
-        gnupghome (str): value to be used for GNUPGHOME when calling
+        gnupghome: value to be used for GNUPGHOME when calling
             GnuPG executables
-        force (bool): if True forces the re-initialization even if the
+        force: if True forces the re-initialization even if the
             global objects are set already
     """
     global GPG, GPGCONF, SOCKET_DIR, GNUPGHOME
@@ -83,12 +295,12 @@ def init(gnupghome=None, force=False):
         GPGCONF("--create-socketdir")
 
 
-def _autoinit(func):
+def _autoinit(func: Callable[..., Any]):
     """Decorator to ensure that global variables have been initialized before
     running the decorated function.
 
     Args:
-        func (callable): decorated function
+        func: decorated function
     """
 
     @functools.wraps(func)
@@ -100,11 +312,11 @@ def _autoinit(func):
 
 
 @contextlib.contextmanager
-def gnupghome_override(dir):
+def gnupghome_override(dir: str):
     """Set the GNUPGHOME to a new location for this context.
 
     Args:
-        dir (str): new value for GNUPGHOME
+        dir: new value for GNUPGHOME
     """
     global GPG, GPGCONF, SOCKET_DIR, GNUPGHOME
 
@@ -123,55 +335,90 @@ def gnupghome_override(dir):
     SOCKET_DIR, GNUPGHOME = _SOCKET_DIR, _GNUPGHOME
 
 
-def _parse_secret_keys_output(output: str) -> List[str]:
-    keys: List[str] = []
-    found_sec = False
-    for line in output.split("\n"):
-        if found_sec:
-            if line.startswith("fpr"):
-                keys.append(line.split(":")[9])
-                found_sec = False
-            elif line.startswith("ssb"):
-                found_sec = False
-        elif line.startswith("sec"):
-            found_sec = True
-    return keys
+def _parse_gpg_fields(karray: List[str]):
+    """Parse gpg line into a dict"""
+    fields = [
+        "type",
+        "trust",
+        "len",
+        "key_algo",
+        "key_id",
+        "created_at",
+        "expire_at",
+        "misc",
+        "owner_trust",
+        "uid",
+        "sig_class",
+        "capabilities",
+        "issuer_cert",
+        "flag",
+        "token",
+        "hash_algo",
+        "curve_name",
+        "compliance",
+        "updated_at",
+        "origin",
+        "comment",
+    ]
+    data = {}
+    for key, value in zip(fields, karray):
+        data[key] = value
+
+    return data
 
 
-def _parse_public_keys_output(output):
-    """
-    Returns a list of public keys with their fingerprints
-    """
+def _parse_gpg_output(output: str):
+    current_key: Optional[GpgKey] = None
+    current_subkey: Optional[GpgKey] = None
     keys = []
-    found_pub = False
-    current_pub_key = ""
     for line in output.split("\n"):
-        if found_pub:
-            if line.startswith("fpr"):
-                keys.append((current_pub_key, line.split(":")[9]))
-                found_pub = False
-            elif line.startswith("ssb"):
-                found_pub = False
-        elif line.startswith("pub"):
-            current_pub_key = line.split(":")[4]
-            found_pub = True
+        # Only parse lines with colons
+        if ":" not in line:
+            continue
+
+        data = _parse_gpg_fields(line.split(":"))
+        # Skip special fields, Spack doesn't use them
+        if data["type"] in ("cfg", "pfc", "pkd", "tfs", "tru", "spk"):
+            continue
+
+        # Start of a new key
+        if data["type"] in ("pub", "sec"):
+            if current_subkey:
+                assert current_key
+                current_key.subkey.append(current_subkey)
+                current_subkey = None
+            if current_key:
+                keys.append(current_key)
+            current_key = GpgKey(data)
+
+        # This should never happen, but in case it does continue
+        # as spack doesn't care about lines before the first key
+        # is found.
+        if not current_key:
+            continue
+
+        # Start of a new subkey
+        if data["type"] in ("sub", "ssb"):
+            if current_subkey:
+                current_key.subkey.append(current_subkey)
+            current_subkey = GpgKey(data)
+
+        # For the fields that can be in both key and subkey
+        if data["type"] in ("sig", "fpr", "fp2"):
+            if current_subkey:
+                current_subkey.add(data)
+            else:
+                current_key.add(data)
+        else:
+            current_key.add(data)
+
+    # Append the last keys
+    if current_key:
+        if current_subkey:
+            current_key.subkey.append(current_subkey)
+        keys.append(current_key)
+
     return keys
-
-
-def _get_unimported_public_keys(output):
-    keys = []
-    for line in output.split("\n"):
-        if line.startswith("pub"):
-            keys.append(line.split(":")[4])
-    return keys
-
-
-def _get_key_uids(output):
-    uids = []
-    for line in output.split("\n"):
-        if line.startswith("uid"):
-            uids.append(line.split(":")[-2])
-    return uids
 
 
 class SpackGPGError(spack.error.SpackError):
@@ -206,122 +453,120 @@ def signing_keys(*args) -> List[str]:
     """Return the keys that can be used to sign binaries."""
     assert GPG
     output: str = GPG("--list-secret-keys", "--with-colons", "--fingerprint", *args, output=str)
-    return _parse_secret_keys_output(output)
-
-
-@_autoinit
-def public_keys_to_fingerprint(*args):
-    """Return the keys that can be used to verify binaries."""
-    output = GPG("--list-public-keys", "--with-colons", "--fingerprint", *args, output=str)
-    return _parse_public_keys_output(output)
+    return _parse_gpg_output(output)
 
 
 @_autoinit
 def public_keys(*args):
     """Return a list of fingerprints"""
-    keys_and_fpr = public_keys_to_fingerprint(*args)
-    return [key_and_fpr[1] for key_and_fpr in keys_and_fpr]
+    assert GPG
+    output = GPG("--list-public-keys", "--with-colons", "--fingerprint", *args, output=str)
+    return _parse_gpg_output(output)
 
 
 @_autoinit
-def export_keys(location, keys, secret=False):
+def export_keys(location: str, keys: List[GpgKey], secret: bool = False):
     """Export public keys to a location passed as argument.
 
     Args:
-        location (str): where to export the keys
-        keys (list): keys to be exported
-        secret (bool): whether to export secret keys or not
+        location: where to export the keys
+        keys: keys to be exported
+        secret: whether to export secret keys or not
     """
+    assert GPG
+    fprs = [str(k) for k in keys]
     if secret:
-        GPG("--export-secret-keys", "--armor", "--output", location, *keys)
+        GPG("--export-secret-keys", "--armor", "--output", location, *fprs)
     else:
-        GPG("--batch", "--yes", "--armor", "--export", "--output", location, *keys)
+        GPG("--batch", "--yes", "--armor", "--export", "--output", location, *fprs)
 
 
 @_autoinit
-def extract_public_keys(keyfile):
+def extract_public_keys(keyfile: str):
     """Extract the public key ids from a file
 
     Args:
-        keyfile (str): file with the public key
+        keyfile: file with the public key
     """
+    assert GPG
     # Get the public keys we are about to import
-    output = GPG("--with-colons", keyfile, output=str, error=str)
-    return zip(_get_unimported_public_keys(output), _get_key_uids(output))
+    output = GPG("--with-colons", "--with-fingerprint", keyfile, output=str, error=str)
+    return [k for k in _parse_gpg_output(output) if k.type == GpgKeyType.PUBLIC]
 
 
 @_autoinit
-def trust(keyfile):
+def trust(keyfile: str):
     """Import a public key from a file and trust it.
 
     Args:
-        keyfile (str): file with the public key
+        keyfile: file with the public key
     """
-    # Get the public keys we are about to import
-    output = GPG("--with-colons", keyfile, output=str, error=str)
-    keys = _get_unimported_public_keys(output)
+    assert GPG
+    keys = extract_public_keys(keyfile)
 
     # Import them
     GPG("--batch", "--import", keyfile)
 
     # Set trust to ultimate
-    key_to_fpr = dict(public_keys_to_fingerprint())
+    known_keys = public_keys()
     for key in keys:
         # Skip over keys we cannot find a fingerprint for.
-        if key not in key_to_fpr:
+        if key not in known_keys:
             continue
 
-        fpr = key_to_fpr[key]
         r, w = os.pipe()
-        with contextlib.closing(os.fdopen(r, "r")) as r:
-            with contextlib.closing(os.fdopen(w, "w")) as w:
-                w.write("{0}:6:\n".format(fpr))
-            GPG("--import-ownertrust", input=r)
+        with contextlib.closing(os.fdopen(r, "r")) as rc:
+            with contextlib.closing(os.fdopen(w, "w")) as wc:
+                wc.write("{0}:6:\n".format(str(key)))
+            GPG("--import-ownertrust", input=rc)
 
 
 @_autoinit
-def untrust(signing, *keys):
+def untrust(signing: bool, *keys):
     """Delete known keys.
 
     Args:
-        signing (bool): if True deletes the secret keys
+        signing: if True deletes the secret keys
         *keys: keys to be deleted
     """
+    assert GPG
     if signing:
-        skeys = signing_keys(*keys)
+        skeys = [str(k) for k in signing_keys(*keys)]
         GPG("--batch", "--yes", "--delete-secret-keys", *skeys)
 
-    pkeys = public_keys(*keys)
+    pkeys = [str(k) for k in public_keys(*keys)]
     GPG("--batch", "--yes", "--delete-keys", *pkeys)
 
 
 @_autoinit
-def sign(key, file, output, clearsign=False):
+def sign(key: str, file: str, output: str, clearsign: bool = False):
     """Sign a file with a key.
 
     Args:
         key: key to be used to sign
-        file (str): file to be signed
-        output (str): output file (either the clearsigned file or
+        file: file to be signed
+        output: output file (either the clearsigned file or
             the detached signature)
-        clearsign (bool): if True wraps the document in an ASCII-armored
+        clearsign: if True wraps the document in an ASCII-armored
             signature, if False creates a detached signature
     """
+    assert GPG
     signopt = "--clearsign" if clearsign else "--detach-sign"
     GPG(signopt, "--armor", "--local-user", key, "--output", output, file)
 
 
 @_autoinit
-def verify(signature, file=None, suppress_warnings=False):
+def verify(signature: str, file: Optional[str] = None, suppress_warnings: bool = False):
     """Verify the signature on a file.
 
     Args:
-        signature (str): signature of the file (or clearsigned file)
-        file (str): file to be verified.  If None, then signature is
+        signature: signature of the file (or clearsigned file)
+        file: file to be verified.  If None, then signature is
             assumed to be a clearsigned file.
-        suppress_warnings (bool): whether or not to suppress warnings
+        suppress_warnings: whether or not to suppress warnings
             from GnuPG
     """
+    assert GPG
     args = [signature]
     if file:
         args.append(file)
@@ -330,13 +575,14 @@ def verify(signature, file=None, suppress_warnings=False):
 
 
 @_autoinit
-def list(trusted, signing):
+def list(trusted: bool, signing: bool):
     """List known keys.
 
     Args:
-        trusted (bool): if True list public keys
-        signing (bool): if True list private keys
+        trusted: if True list public keys
+        signing: if True list private keys
     """
+    assert GPG
     if trusted:
         GPG("--list-public-keys")
 

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -166,6 +166,14 @@ def _get_unimported_public_keys(output):
     return keys
 
 
+def _get_key_uids(output):
+    uids = []
+    for line in output.split("\n"):
+        if line.startswith("uid"):
+            uids.append(line.split(":")[-2])
+    return uids
+
+
 class SpackGPGError(spack.error.SpackError):
     """Class raised when GPG errors are detected."""
 
@@ -228,6 +236,18 @@ def export_keys(location, keys, secret=False):
         GPG("--export-secret-keys", "--armor", "--output", location, *keys)
     else:
         GPG("--batch", "--yes", "--armor", "--export", "--output", location, *keys)
+
+
+@_autoinit
+def extract_public_keys(keyfile):
+    """Extract the public key ids from a file
+
+    Args:
+        keyfile (str): file with the public key
+    """
+    # Get the public keys we are about to import
+    output = GPG("--with-colons", keyfile, output=str, error=str)
+    return zip(_get_unimported_public_keys(output), _get_key_uids(output))
 
 
 @_autoinit

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1273,7 +1273,7 @@ _spack_gpg_verify() {
 _spack_gpg_trust() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help"
+        SPACK_COMPREPLY="-h --help -y --yes-to-all"
     else
         SPACK_COMPREPLY=""
     fi
@@ -1307,7 +1307,7 @@ _spack_gpg_create() {
 }
 
 _spack_gpg_list() {
-    SPACK_COMPREPLY="-h --help --trusted --signing"
+    SPACK_COMPREPLY="-h --help --fmt -f --trusted --signing"
 }
 
 _spack_gpg_init() {

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1982,10 +1982,12 @@ complete -c spack -n '__fish_spack_using_command gpg verify' -s h -l help -f -a 
 complete -c spack -n '__fish_spack_using_command gpg verify' -s h -l help -d 'show this help message and exit'
 
 # spack gpg trust
-set -g __fish_spack_optspecs_spack_gpg_trust h/help
+set -g __fish_spack_optspecs_spack_gpg_trust h/help y/yes-to-all
 
 complete -c spack -n '__fish_spack_using_command gpg trust' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command gpg trust' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command gpg trust' -s y -l yes-to-all -f -a yes_to_all
+complete -c spack -n '__fish_spack_using_command gpg trust' -s y -l yes-to-all -d 'assume "yes" is the answer to every confirmation request'
 
 # spack gpg untrust
 set -g __fish_spack_optspecs_spack_gpg_untrust h/help signing
@@ -2022,9 +2024,11 @@ complete -c spack -n '__fish_spack_using_command gpg create' -l export-secret -r
 complete -c spack -n '__fish_spack_using_command gpg create' -l export-secret -r -d 'export the private key to a file'
 
 # spack gpg list
-set -g __fish_spack_optspecs_spack_gpg_list h/help trusted signing
+set -g __fish_spack_optspecs_spack_gpg_list h/help f/fmt= trusted signing
 complete -c spack -n '__fish_spack_using_command gpg list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command gpg list' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command gpg list' -l fmt -s f -r -f -a fmt
+complete -c spack -n '__fish_spack_using_command gpg list' -l fmt -s f -r -d 'Format to list keys with (default (gpg), colons, keys, <key format string>)'
 complete -c spack -n '__fish_spack_using_command gpg list' -l trusted -f -a trusted
 complete -c spack -n '__fish_spack_using_command gpg list' -l trusted -d 'list trusted keys'
 complete -c spack -n '__fish_spack_using_command gpg list' -l signing -f -a signing


### PR DESCRIPTION
Often build caches will host their public keys in a common location to be downloaded. This allows users to use spack to download and trust keys directly rather than as two steps.

In addition to URL support, also refactor the gpg module in preparation for better localized gpg agent control. This is going to be nice to have to better support multiple keyrings for signing/managing keys.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
