### PR TITLE
feat: allow install_source in package_attributes; use installed source for build [WIP]

### DIFF
--- a/lib/spack/docs/packages_yaml.rst
+++ b/lib/spack/docs/packages_yaml.rst
@@ -745,3 +745,18 @@ Attributes set this way will be accessible to any method executed in the package
 Values for these attributes may be any value parseable by yaml.
 
 These can only be applied to specific packages, not "all" or virtual packages.
+
+A possible use case is to control whether source code should be installed alongside the package for debugging purposes:
+
+.. code-block:: yaml
+
+   packages:
+     cmake:
+       package_attributes:
+         install_source: true
+
+The ``install_source`` attribute, when set to ``true``, will cause Spack to copy the package source code to ``<prefix>/share/<package-name>/src/`` before building.
+This is equivalent to using the ``--source`` flag with ``spack install``, but allows you to configure it on a per-package basis.
+The command-line ``--source`` flag will override package-level settings.
+
+Note that source installation is automatically skipped for packages installed with ``spack develop``, since the source is already available at the development path and copying it would be redundant.

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -2575,7 +2575,14 @@ class BuildProcessInstaller:
         self.fake = install_args.get("fake", False)
 
         # whether to install source code with the package
-        self.install_source = install_args.get("install_source", False)
+        # Priority: command-line flag > package attribute > default (False)
+        if install_args.get("install_source", False):
+            # Command-line --source flag takes precedence
+            self.install_source = True
+        else:
+            # Check package attribute, fall back to False
+            pkg_attr_source = getattr(pkg, "install_source", None)
+            self.install_source = pkg_attr_source if pkg_attr_source is not None else False
 
         is_develop = pkg.spec.is_develop
         # whether to keep the build stage after installation
@@ -2631,6 +2638,9 @@ class BuildProcessInstaller:
                 else:
                     self.pkg.do_stage()
 
+                if self.install_source:
+                    self._install_source()
+
             self.timer.stop("stage")
 
             tty.debug(
@@ -2648,9 +2658,6 @@ class BuildProcessInstaller:
             if self.fake:
                 _do_fake_install(self.pkg)
             else:
-                if self.install_source:
-                    self._install_source()
-
                 self._real_install()
 
             # Run post install hooks before build stage is removed.
@@ -2672,6 +2679,15 @@ class BuildProcessInstaller:
     def _install_source(self) -> None:
         """Install source code from stage into share/pkg/src if necessary."""
         pkg = self.pkg
+
+        # Skip for develop specs - source is already at dev_path
+        if pkg.spec.is_develop:
+            tty.debug(
+                f"{self.pre} Skipping source installation for develop spec "
+                f"(source at {pkg.stage.source_path})"
+            )
+            return
+
         if not os.path.isdir(pkg.stage.source_path):
             return
 
@@ -2679,6 +2695,11 @@ class BuildProcessInstaller:
         tty.debug(f"{self.pre} Copying source to {src_target}")
 
         fs.install_tree(pkg.stage.source_path, src_target)
+
+        if hasattr(pkg, "build_directory"):
+            if pkg.stage.source_path != pkg.build_directory:
+                tty.warn(f"{self.pre} Using copied source for out-of-source build")
+                pkg.stage.source_path = src_target
 
     def _real_install(self) -> None:
 

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -26,6 +26,7 @@ import spack.installer
 import spack.llnl.util.filesystem as fs
 import spack.llnl.util.tty as tty
 import spack.package_base
+import spack.repo
 import spack.store
 from spack.error import SpackError, SpecSyntaxError
 from spack.installer import PackageInstaller
@@ -35,6 +36,7 @@ from spack.spec import Spec
 install = SpackCommand("install")
 env = SpackCommand("env")
 add = SpackCommand("add")
+develop = SpackCommand("develop")
 mirror = SpackCommand("mirror")
 uninstall = SpackCommand("uninstall")
 buildcache = SpackCommand("buildcache")
@@ -195,6 +197,102 @@ def test_install_with_source(mock_packages, mock_archive, mock_fetch, install_mo
     assert filecmp.cmp(
         os.path.join(mock_archive.path, "configure"), os.path.join(src, "configure")
     )
+
+
+@pytest.mark.disable_clean_stage_check
+def test_install_with_source_from_package_attribute(
+    mock_packages, mock_archive, mock_fetch, install_mockery, mutable_config
+):
+    """Verify that source installation can be configured via package_attributes."""
+    # Configure package to install source via package_attributes
+    conf = {"trivial-install-test-package": {"package_attributes": {"install_source": True}}}
+    spack.config.set("packages", conf, scope="command_line")
+
+    # Reinitialize the repository to pick up package attributes
+    spack.repo.PATH = spack.repo.RepoPath.from_config(spack.config.CONFIG)
+
+    # Install without --source flag (should still install source due to package attribute)
+    install("--keep-stage", "trivial-install-test-package")
+
+    spec = spack.concretize.concretize_one("trivial-install-test-package")
+    src = os.path.join(spec.prefix.share, "trivial-install-test-package", "src")
+
+    # Verify source was installed
+    assert os.path.exists(src), "Source directory should exist"
+    assert filecmp.cmp(
+        os.path.join(mock_archive.path, "configure"), os.path.join(src, "configure")
+    )
+
+
+@pytest.mark.disable_clean_stage_check
+def test_install_source_command_overrides_package_attribute(
+    mock_packages, mock_archive, mock_fetch, install_mockery, mutable_config
+):
+    """Verify that --source flag overrides package_attributes setting."""
+    # Configure package to NOT install source
+    conf = {"trivial-install-test-package": {"package_attributes": {"install_source": False}}}
+    spack.config.set("packages", conf, scope="command_line")
+
+    # Reinitialize the repository to pick up package attributes
+    spack.repo.PATH = spack.repo.RepoPath.from_config(spack.config.CONFIG)
+
+    # Install WITH --source flag (should override package attribute)
+    install("--source", "--keep-stage", "trivial-install-test-package")
+
+    spec = spack.concretize.concretize_one("trivial-install-test-package")
+    src = os.path.join(spec.prefix.share, "trivial-install-test-package", "src")
+
+    # Verify source was installed despite package attribute saying false
+    assert os.path.exists(src), "Source directory should exist (--source overrides config)"
+    assert filecmp.cmp(
+        os.path.join(mock_archive.path, "configure"), os.path.join(src, "configure")
+    )
+
+
+@pytest.mark.disable_clean_stage_check
+def test_install_source_skipped_for_develop_specs(
+    tmp_path, mock_packages, mock_archive, mock_fetch, install_mockery, mutable_mock_env_path
+):
+    """Verify that source installation is skipped for develop specs."""
+    env("create", "test")
+
+    # Create a fake development directory with package files
+    dev_path = tmp_path / "dev-source"
+    dev_path.mkdir()
+    (dev_path / "configure").write_text("#!/bin/sh\necho 'configure from dev'")
+
+    with ev.read("test") as e:
+        # Configure to install source (should be ignored for develop specs)
+        conf = {"trivial-install-test-package": {"package_attributes": {"install_source": True}}}
+        spack.config.set("packages", conf, scope="command_line")
+        spack.repo.PATH = spack.repo.RepoPath.from_config(spack.config.CONFIG)
+
+        # Add and develop the package
+        add("trivial-install-test-package@develop")
+        develop("--no-clone", "--path", str(dev_path), "trivial-install-test-package@develop")
+
+        # Concretize and install
+        e.concretize()
+        e.write()
+        e.install_specs()
+
+        # Get the installed spec
+        specs = e.all_specs()
+        develop_specs = [s for s in specs if s.name == "trivial-install-test-package"]
+        assert len(develop_specs) >= 1
+        spec = develop_specs[0]
+
+        # Verify it's a develop spec
+        assert spec.is_develop, "Spec should be a develop spec"
+
+        # Verify source was NOT copied to prefix (develop specs should skip this)
+        src = os.path.join(spec.prefix.share, "trivial-install-test-package", "src")
+        assert not os.path.exists(src), (
+            "Source should NOT be installed for develop specs " "(source remains at dev_path)"
+        )
+
+        # Verify the development path still exists
+        assert os.path.exists(str(dev_path)), "Development directory should still exist"
 
 
 def test_install_env_variables(mock_packages, mock_archive, mock_fetch, install_mockery):


### PR DESCRIPTION
This PR adds support for `install_source` in package_attributes:
```yaml
packages:
  cmake:
    package_attributes:
      install_source: true
```
The main motivation is to have debug symbols that resolve to source code inside the install prefix.

There are some issues that remain unresolved:
- This moves `_install_source` from after the build to before the build.
  - A failing build ends up with installed source, which is not yet up.
  - Only out-of-source-tree builds will use the installed source. In-source-tree builds still use the stage path copy, so the debug symbols will not resolve to installed source.

Tests may be overly wordy since written with the help of AI.