### PR TITLE
default/../packages: tbb += intel-oneapi-tbb

### DIFF
--- a/etc/spack/defaults/base/packages.yaml
+++ b/etc/spack/defaults/base/packages.yaml
@@ -59,7 +59,7 @@ packages:
       scalapack: [netlib-scalapack, amdscalapack]
       sycl: [hipsycl]
       szip: [libaec, libszip]
-      tbb: [intel-tbb]
+      tbb: [intel-tbb, intel-oneapi-tbb]
       unwind: [libunwind]
       uuid: [util-linux-uuid, libuuid]
       wasi-sdk: [wasi-sdk-prebuilt]

--- a/etc/spack/defaults/base/packages.yaml
+++ b/etc/spack/defaults/base/packages.yaml
@@ -61,7 +61,7 @@ packages:
       scalapack: [netlib-scalapack, amdscalapack]
       sycl: [hipsycl]
       szip: [libaec, libszip]
-      tbb: [intel-tbb]
+      tbb: [intel-tbb, intel-oneapi-tbb]
       unwind: [libunwind]
       uuid: [util-linux-uuid, libuuid]
       wasi-sdk: [wasi-sdk-prebuilt]


### PR DESCRIPTION
It is my understanding that `intel-oneapi-tbb` can also provide `tbb`.

This is already overridden at e.g.
https://github.com/spack/spack-packages/blob/ca47e8f3222c8192c50da97d9a852b273dcdd103/stacks/aws-pcluster-x86_64_v4/spack.yaml#L150
or assumed in packages e.g.
https://github.com/spack/spack-packages/blob/ca47e8f3222c8192c50da97d9a852b273dcdd103/repos/spack_repo/builtin/packages/pmemkv/package.py#L51