### PR TITLE
Add support for ssh/scp mirrors and binary caches

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -2898,16 +2898,21 @@ class SCPIndexFetcher(IndexFetcher):
         url_index_manifest = urllib.parse.urlparse(cache_class.get_index_url(self.url, self.view))
 
         try:
-            with tempfile.NamedTemporaryFile("rb", dir=spack.stage.get_stage_root()) as tmp:
-                from spack.util.ssh import SSHConnection
+            from spack.util.ssh import SSHConnection
 
-                ssh = SSHConnection.from_url(url_index_manifest)
-                ssh.fetch(url_index_manifest.path, tmp.name)
+            f, tmp_path = tempfile.mkstemp(dir=spack.stage.get_stage_root())
+            f.close()
+
+            ssh = SSHConnection.from_url(url_index_manifest)
+            ssh.fetch(url_index_manifest.path, tmp_path)
+            with open(tmp_path, "rb") as tmp:
                 response = io.BytesIO(tmp.read())
         except Exception as e:
             raise FetchIndexError(
                 f"Could not read index manifest from {url_index_manifest.geturl()}"
             ) from e
+        finally:
+            os.remove(tmp_path)
 
         index_blob_record = self.get_index_manifest(response)
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -2884,12 +2884,47 @@ class EtagIndexFetcher(IndexFetcher):
         )
 
 
+class SCPIndexFetcher(IndexFetcher):
+    """Fetcher for buildcache index, cache invalidation via manifest contents"""
+
+    def __init__(self, mirror_metadata: MirrorMetadata, local_hash):
+        self.url = mirror_metadata.url
+        self.layout_version = mirror_metadata.version
+        self.local_hash = local_hash
+
+    def conditional_fetch(self) -> FetchIndexResult:
+        cache_class = get_url_buildcache_class(layout_version=self.layout_version)
+        url_index_manifest = cache_class.get_index_url(self.url)
+
+        try:
+            _, _, response = web_util.read_from_ssh_url(url_index_manifest)
+        except Exception as e:
+            raise FetchIndexError(
+                f"Could not read index manifest from {url_index_manifest}"
+            ) from e
+
+        index_blob_record = self.get_index_manifest(response)
+
+        # Early exit if our cache is up to date.
+        if self.local_hash and self.local_hash == index_blob_record.checksum:
+            return FetchIndexResult(etag=None, hash=None, data=None, fresh=True)
+
+        # Otherwise, download the index blob
+        cache_entry = cache_class(self.url, allow_unsigned=True)
+        computed_hash, result = self.fetch_index_blob(cache_entry, index_blob_record)
+        cache_entry.destroy()
+
+        return FetchIndexResult(etag=None, hash=computed_hash, data=result, fresh=False)
+
+
 def get_index_fetcher(
     scheme: str, mirror_metadata: MirrorMetadata, cache_entry: Dict[str, str]
 ) -> IndexFetcher:
     if scheme == "oci":
         # TODO: Actually etag and OCI are not mutually exclusive...
         return OCIIndexFetcher(mirror_metadata, cache_entry.get("index_hash", None))
+    elif scheme in ("ssh", "scp"):
+        return SCPIndexFetcher(mirror_metadata, local_hash=cache_entry.get("index_hash", None))
     elif cache_entry.get("etag"):
         if mirror_metadata.version < 3:
             return EtagIndexFetcherV2(mirror_metadata.url, cache_entry["etag"])

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -58,7 +58,6 @@ import spack.util.parallel
 import spack.util.path
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
-import spack.util.ssh as ssh_util
 import spack.util.timer as timer
 import spack.util.url as url_util
 import spack.util.web as web_util
@@ -2898,8 +2897,12 @@ class SCPIndexFetcher(IndexFetcher):
         url_index_manifest = urllib.parse.urlparse(cache_class.get_index_url(self.url))
 
         try:
-            ssh = ssh_util.SSHConnection.from_url(url_index_manifest)
-            response = ssh.read(url_index_manifest.path)
+            with tempfile.NamedTemporaryFile("rb", dir=spack.stage.get_stage_root()) as tmp:
+                from spack.util.ssh import SSHConnection
+
+                ssh = SSHConnection.from_url(url_index_manifest)
+                ssh.fetch(url_index_manifest.path, tmp.name)
+                response = io.BytesIO(tmp.read())
         except Exception as e:
             raise FetchIndexError(
                 f"Could not read index manifest from {url_index_manifest.geturl()}"

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -2890,11 +2890,12 @@ class SCPIndexFetcher(IndexFetcher):
     def __init__(self, mirror_metadata: MirrorMetadata, local_hash):
         self.url = mirror_metadata.url
         self.layout_version = mirror_metadata.version
+        self.view = mirror_metadata.view
         self.local_hash = local_hash
 
     def conditional_fetch(self) -> FetchIndexResult:
         cache_class = get_url_buildcache_class(layout_version=self.layout_version)
-        url_index_manifest = urllib.parse.urlparse(cache_class.get_index_url(self.url))
+        url_index_manifest = urllib.parse.urlparse(cache_class.get_index_url(self.url, self.view))
 
         try:
             with tempfile.NamedTemporaryFile("rb", dir=spack.stage.get_stage_root()) as tmp:

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -58,6 +58,7 @@ import spack.util.parallel
 import spack.util.path
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
+import spack.util.ssh as ssh_util
 import spack.util.timer as timer
 import spack.util.url as url_util
 import spack.util.web as web_util
@@ -2894,13 +2895,14 @@ class SCPIndexFetcher(IndexFetcher):
 
     def conditional_fetch(self) -> FetchIndexResult:
         cache_class = get_url_buildcache_class(layout_version=self.layout_version)
-        url_index_manifest = cache_class.get_index_url(self.url)
+        url_index_manifest = urllib.parse.urlparse(cache_class.get_index_url(self.url))
 
         try:
-            _, _, response = web_util.read_from_ssh_url(url_index_manifest)
+            ssh = ssh_util.SSHConnection.from_url(url_index_manifest)
+            response = ssh.read(url_index_manifest.path)
         except Exception as e:
             raise FetchIndexError(
-                f"Could not read index manifest from {url_index_manifest}"
+                f"Could not read index manifest from {url_index_manifest.geturl()}"
             ) from e
 
         index_blob_record = self.get_index_manifest(response)

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -1417,6 +1417,46 @@ class GCSFetchStrategy(URLFetchStrategy):
 
 
 @fetcher
+class SCPFetchStrategy(URLFetchStrategy):
+    """FetchStrategy that pulls from an SSH/SCP server."""
+
+    url_attr = "scp"
+
+    @_needs_stage
+    def fetch(self):
+        if not (self.url.startswith("scp://") or self.url.startswith("ssh://")):
+            raise spack.error.FetchError(
+                f"{self.__class__.__name__} can only fetch from scp:// or ssh:// urls."
+            )
+        if self.archive_file:
+            tty.debug(f"Already downloaded {self.archive_file}")
+            return
+        self._fetch_scp(self.url)
+        if not self.archive_file:
+            raise FailedDownloadError(
+                RuntimeError(f"Missing archive {self.archive_file} after fetching")
+            )
+
+    @_needs_stage
+    def _fetch_scp(self, url):
+        save_file = self.stage.save_filename
+
+        if os.path.lexists(save_file):
+            os.remove(save_file)
+
+        try:
+            tty.msg(f"Fetching {url}")
+            web_util.fetch_from_ssh_url(url, save_file)
+        except Exception as e:
+            # clean up archive on failure.
+            if self.archive_file:
+                os.remove(self.archive_file)
+            if os.path.lexists(save_file):
+                os.remove(save_file)
+            raise FailedDownloadError(e) from e
+
+
+@fetcher
 class FetchAndVerifyExpandedFile(URLFetchStrategy):
     """Fetch strategy that verifies the content digest during fetching,
     as well as after expanding it."""
@@ -1712,6 +1752,7 @@ def from_url_scheme(url: str, **kwargs) -> FetchStrategy:
         "https": "url",
         "ftp": "url",
         "ftps": "url",
+        "ssh": "scp",
     }
 
     scheme = parsed_url.scheme

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -50,6 +50,7 @@ import spack.util.archive
 import spack.util.crypto as crypto
 import spack.util.executable
 import spack.util.git
+import spack.util.ssh as ssh_util
 import spack.util.url as url_util
 import spack.util.web as web_util
 import spack.version
@@ -1446,7 +1447,11 @@ class SCPFetchStrategy(URLFetchStrategy):
 
         try:
             tty.msg(f"Fetching {url}")
-            web_util.fetch_from_ssh_url(url, save_file)
+            if isinstance(url, str):
+                url = urllib.parse.urlparse(url)
+
+            ssh = ssh_util.SSHConnection.from_url(url)
+            ssh.fetch(url.path, save_file)
         except Exception as e:
             # clean up archive on failure.
             if self.archive_file:

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -50,7 +50,6 @@ import spack.util.archive
 import spack.util.crypto as crypto
 import spack.util.executable
 import spack.util.git
-import spack.util.ssh as ssh_util
 import spack.util.url as url_util
 import spack.util.web as web_util
 import spack.version
@@ -1450,7 +1449,9 @@ class SCPFetchStrategy(URLFetchStrategy):
             if isinstance(url, str):
                 url = urllib.parse.urlparse(url)
 
-            ssh = ssh_util.SSHConnection.from_url(url)
+            from spack.util.ssh import SSHConnection
+
+            ssh = SSHConnection.from_url(url)
             ssh.fetch(url.path, save_file)
         except Exception as e:
             # clean up archive on failure.

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -81,7 +81,7 @@ class Mirror:
         if urllib.parse.urlparse(url).scheme not in supported_url_schemes:
             raise ValueError(
                 f'"{url}" is not a valid mirror URL. '
-                f"Scheme must be one of {supported_url_schemes}."
+                f"Scheme must be one of {sorted(supported_url_schemes)}."
             )
         return Mirror(url)
 

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -16,7 +16,7 @@ from spack.error import MirrorError
 from spack.oci.image import is_oci_url
 
 #: What schemes do we support
-supported_url_schemes = (
+supported_url_schemes = {
     "file",
     "http",
     "https",
@@ -28,7 +28,7 @@ supported_url_schemes = (
     "oci+http",
     "ssh",
     "scp",
-)
+}
 
 #: The layout version spack can current install
 SUPPORTED_LAYOUT_VERSIONS = (3, 2)

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -16,7 +16,19 @@ from spack.error import MirrorError
 from spack.oci.image import is_oci_url
 
 #: What schemes do we support
-supported_url_schemes = ("file", "http", "https", "sftp", "ftp", "s3", "gs", "oci", "oci+http")
+supported_url_schemes = (
+    "file",
+    "http",
+    "https",
+    "sftp",
+    "ftp",
+    "s3",
+    "gs",
+    "oci",
+    "oci+http",
+    "ssh",
+    "scp",
+)
 
 #: The layout version spack can current install
 SUPPORTED_LAYOUT_VERSIONS = (3, 2)

--- a/lib/spack/spack/test/util/remote_file_cache.py
+++ b/lib/spack/spack/test/util/remote_file_cache.py
@@ -20,7 +20,7 @@ gitlab_url = "https://gitlab.fake.io/user/repo/-/blob/config/defaults"
     "path,err",
     [
         ("ssh://git@github.com:spack/", "Unsupported URL scheme"),
-        ("bad:///this/is/a/file/url/include.yaml", "Invalid URL scheme"),
+        ("bad:///this/is/a/file/url/include.yaml", "Unsupported URL scheme"),
     ],
 )
 def test_rfc_local_path_bad_scheme(path, err):

--- a/lib/spack/spack/util/remote_file_cache.py
+++ b/lib/spack/spack/util/remote_file_cache.py
@@ -15,7 +15,6 @@ import spack.llnl.util.tty as tty
 import spack.util.crypto
 from spack.llnl.util.filesystem import copy, join_path, mkdirp
 from spack.util.path import canonicalize_path
-from spack.util.url import validate_scheme
 
 
 def raw_github_gitlab_url(url: str) -> str:
@@ -94,55 +93,50 @@ def local_path(raw_path: str, sha256: str, dest: Optional[str] = None) -> str:
     if url.scheme in file_schemes:
         return os.path.normpath(path)
 
-    # If scheme is not valid, path is not a supported url.
-    if validate_scheme(url.scheme):
-        # Fetch files from supported URL schemes.
-        if url.scheme in ("http", "https", "ftp"):
-            if not dest:
-                raise ValueError("Requires the destination argument to cache remote files")
-            assert os.path.isabs(dest), (
-                f"Remote file destination '{dest}' must be an absolute path"
-            )
-
-            # Stage the remote configuration file
-            tmpdir = tempfile.mkdtemp()
-            try:
-                staged_path = fetch_remote_text_file(path, tmpdir)
-
-                # Ensure the sha256 is expected.
-                checksum = spack.util.crypto.checksum(hashlib.sha256, staged_path)
-                if sha256 and checksum != sha256:
-                    raise ValueError(
-                        f"Actual sha256 ('{checksum}') does not match expected ('{sha256}')"
-                    )
-
-                # Help the user by reporting the required checksum.
-                if not sha256:
-                    raise ValueError(f"Requires sha256 ('{checksum}') to cache remote files.")
-
-                # Copy the file to the destination directory
-                dest_dir = join_path(dest, checksum)
-                if not os.path.exists(dest_dir):
-                    mkdirp(dest_dir)
-
-                cache_path = join_path(dest_dir, os.path.basename(staged_path))
-                copy(staged_path, cache_path)
-                tty.debug(f"Cached {raw_path} in {cache_path}")
-
-                # Stash the associated URL to aid with debugging
-                with open(join_path(dest_dir, "source_url.txt"), "w", encoding="utf-8") as f:
-                    f.write(f"{raw_path}\n")
-
-                return cache_path
-
-            except ValueError as err:
-                tty.warn(f"Unable to cache {raw_path}: {str(err)}")
-                raise
-
-            finally:
-                shutil.rmtree(tmpdir)
-
+    # Fetch files from supported URL schemes.
+    if url.scheme not in ("http", "https", "ftp"):
         raise ValueError(f"Unsupported URL scheme ({url.scheme}) in {raw_path}")
 
-    else:
-        raise ValueError(f"Invalid URL scheme ({url.scheme}) in {raw_path}")
+    if not dest:
+        raise ValueError("Requires the destination argument to cache remote files")
+    assert os.path.isabs(dest), (
+        f"Remote file destination '{dest}' must be an absolute path"
+    )
+
+    # Stage the remote configuration file
+    tmpdir = tempfile.mkdtemp()
+    try:
+        staged_path = fetch_remote_text_file(path, tmpdir)
+
+        # Ensure the sha256 is expected.
+        checksum = spack.util.crypto.checksum(hashlib.sha256, staged_path)
+        if sha256 and checksum != sha256:
+            raise ValueError(
+                f"Actual sha256 ('{checksum}') does not match expected ('{sha256}')"
+            )
+
+        # Help the user by reporting the required checksum.
+        if not sha256:
+            raise ValueError(f"Requires sha256 ('{checksum}') to cache remote files.")
+
+        # Copy the file to the destination directory
+        dest_dir = join_path(dest, checksum)
+        if not os.path.exists(dest_dir):
+            mkdirp(dest_dir)
+
+        cache_path = join_path(dest_dir, os.path.basename(staged_path))
+        copy(staged_path, cache_path)
+        tty.debug(f"Cached {raw_path} in {cache_path}")
+
+        # Stash the associated URL to aid with debugging
+        with open(join_path(dest_dir, "source_url.txt"), "w", encoding="utf-8") as f:
+            f.write(f"{raw_path}\n")
+
+        return cache_path
+
+    except ValueError as err:
+        tty.warn(f"Unable to cache {raw_path}: {str(err)}")
+        raise
+
+    finally:
+        shutil.rmtree(tmpdir)

--- a/lib/spack/spack/util/remote_file_cache.py
+++ b/lib/spack/spack/util/remote_file_cache.py
@@ -99,9 +99,8 @@ def local_path(raw_path: str, sha256: str, dest: Optional[str] = None) -> str:
 
     if not dest:
         raise ValueError("Requires the destination argument to cache remote files")
-    assert os.path.isabs(dest), (
-        f"Remote file destination '{dest}' must be an absolute path"
-    )
+
+    assert os.path.isabs(dest), f"Remote file destination '{dest}' must be an absolute path"
 
     # Stage the remote configuration file
     tmpdir = tempfile.mkdtemp()
@@ -111,9 +110,7 @@ def local_path(raw_path: str, sha256: str, dest: Optional[str] = None) -> str:
         # Ensure the sha256 is expected.
         checksum = spack.util.crypto.checksum(hashlib.sha256, staged_path)
         if sha256 and checksum != sha256:
-            raise ValueError(
-                f"Actual sha256 ('{checksum}') does not match expected ('{sha256}')"
-            )
+            raise ValueError(f"Actual sha256 ('{checksum}') does not match expected ('{sha256}')")
 
         # Help the user by reporting the required checksum.
         if not sha256:

--- a/lib/spack/spack/util/ssh.py
+++ b/lib/spack/spack/util/ssh.py
@@ -11,7 +11,6 @@ import warnings
 from pathlib import Path
 
 import spack.error
-import spack.stage
 from spack.llnl.util import tty
 from spack.util.executable import which
 
@@ -81,6 +80,8 @@ class SSHConnection(object):
         self.scp(shlex.quote(f"{self.netloc}:{remote_path}"), dest, fail_on_error=True)
 
     def read(self, remote_path):
+        import spack.stage
+
         with tempfile.NamedTemporaryFile("rb", dir=spack.stage.get_stage_root()) as tmp:
             try:
                 self.fetch(remote_path, tmp.name)

--- a/lib/spack/spack/util/ssh.py
+++ b/lib/spack/spack/util/ssh.py
@@ -18,7 +18,7 @@ from spack.util.executable import which
 
 class SSHConnection(object):
     # used to cache connection objects and avoid checking SSH config multiple times
-    _connections = {}
+    _connections: dict[str, "SSHConnection"] = {}
 
     @classmethod
     def from_url(cls, url):

--- a/lib/spack/spack/util/ssh.py
+++ b/lib/spack/spack/util/ssh.py
@@ -89,7 +89,8 @@ class SSHConnection(object):
                 return io.BytesIO(tmp.read())
             except Exception as e:
                 raise SpackSSHError(
-                    f"Download of ssh://{self.netloc}:{remote_path} failed: {e.__class__.__name__}: {e}"
+                    f"Download of ssh://{self.netloc}:{remote_path} failed: "
+                    f"{e.__class__.__name__}: {e}"
                 )
 
     def push(self, local_path, remote_path, keep_original=True):

--- a/lib/spack/spack/util/ssh.py
+++ b/lib/spack/spack/util/ssh.py
@@ -9,6 +9,7 @@ import tempfile
 import urllib.parse
 import warnings
 from pathlib import Path
+from typing import Dict
 
 import spack.error
 from spack.llnl.util import tty
@@ -17,7 +18,7 @@ from spack.util.executable import which
 
 class SSHConnection(object):
     # used to cache connection objects and avoid checking SSH config multiple times
-    _connections: dict[str, "SSHConnection"] = {}
+    _connections: Dict[str, "SSHConnection"] = {}
 
     @classmethod
     def from_url(cls, url):

--- a/lib/spack/spack/util/ssh.py
+++ b/lib/spack/spack/util/ssh.py
@@ -11,6 +11,7 @@ import warnings
 from pathlib import Path
 
 import spack.error
+import spack.stage
 from spack.llnl.util import tty
 from spack.util.executable import which
 
@@ -80,7 +81,7 @@ class SSHConnection(object):
         self.scp(shlex.quote(f"{self.netloc}:{remote_path}"), dest, fail_on_error=True)
 
     def read(self, remote_path):
-        with tempfile.NamedTemporaryFile("rb") as tmp:
+        with tempfile.NamedTemporaryFile("rb", dir=spack.stage.get_stage_root()) as tmp:
             try:
                 self.fetch(remote_path, tmp.name)
                 return io.BytesIO(tmp.read())

--- a/lib/spack/spack/util/ssh.py
+++ b/lib/spack/spack/util/ssh.py
@@ -2,16 +2,13 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import io
 import os
 import shlex
-import tempfile
 import urllib.parse
 import warnings
 from pathlib import Path
 from typing import Dict
 
-import spack.error
 from spack.llnl.util import tty
 from spack.util.executable import which
 
@@ -80,19 +77,6 @@ class SSHConnection(object):
     def fetch(self, remote_path, dest):
         self.scp(shlex.quote(f"{self.netloc}:{remote_path}"), dest, fail_on_error=True)
 
-    def read(self, remote_path):
-        import spack.stage
-
-        with tempfile.NamedTemporaryFile("rb", dir=spack.stage.get_stage_root()) as tmp:
-            try:
-                self.fetch(remote_path, tmp.name)
-                return io.BytesIO(tmp.read())
-            except Exception as e:
-                raise SpackSSHError(
-                    f"Download of ssh://{self.netloc}:{remote_path} failed: "
-                    f"{e.__class__.__name__}: {e}"
-                )
-
     def push(self, local_path, remote_path, keep_original=True):
         self.ssh(
             self.netloc,
@@ -102,7 +86,3 @@ class SSHConnection(object):
         self.scp(local_path, shlex.quote(f"{self.netloc}:{remote_path}"), fail_on_error=True)
         if not keep_original:
             os.remove(local_path)
-
-
-class SpackSSHError(spack.error.SpackError):
-    """Superclass for Spack SSH errors."""

--- a/lib/spack/spack/util/ssh.py
+++ b/lib/spack/spack/util/ssh.py
@@ -22,36 +22,44 @@ class SSHConnection(object):
         if isinstance(url, str):
             url = urllib.parse.urlparse(url)
         if url.netloc not in cls._connections:
-            cls._connections[url.netloc] = SSHConnection(url.netloc)
-        return cls._connections[url.netloc]
+            cls._connections[url.netloc]
 
-    def __init__(self, netloc):
+    def __init__(self, url):
         SSH_DEFAULT_ARGS = [] if tty.is_debug() else ["-q", "-o", "LogLevel=QUIET"]
         self.ssh = which("ssh", required=True).with_default_args(*SSH_DEFAULT_ARGS)
         self.scp = which("scp", required=True).with_default_args(*SSH_DEFAULT_ARGS)
-        self.netloc = netloc
+        if url.username:
+            self.ssh.add_default_arg("-l", url.username)
+            self.scp.add_default_arg("-l", url.username)
+        if url.port:
+            self.ssh.add_default_arg("-p", url.port)
+            self.scp.add_default_arg("-p", url.port)
+        self.url = url
 
         has_control_master = False
-        for config_line in self.ssh("-G", netloc, fail_on_error=True, output=str).splitlines():
+        for config_line in self.ssh(
+            "-G", self.url.hostname, fail_on_error=True, output=str
+        ).splitlines():
             if config_line == "controlmaster true" or config_line == "controlmaster auto":
                 has_control_master = True
                 break
 
         if not has_control_master:
             warnings.warn(
-                f"Minimize SSH connections to {netloc} via 'ControlMaster' in your SSH config!"
+                f"Minimize SSH connections to {self.url.netloc} via "
+                f"'ControlMaster' in your SSH config!"
             )
 
     def exists(self, path):
-        self.ssh(self.netloc, f"test -e {shlex.quote(path)}", fail_on_error=False)
+        self.ssh(self.url.hostname, f"test -e {shlex.quote(path)}", fail_on_error=False)
         return self.ssh.returncode == 0
 
     def list_path(self, path, recursive=False):
         if recursive:
-            output = self.ssh(self.netloc, f"find {shlex.quote(path)} -type f", output=str)
+            output = self.ssh(self.url.hostname, f"find {shlex.quote(path)} -type f", output=str)
         else:
             output = self.ssh(
-                self.netloc, f"find {shlex.quote(path)} -maxdepth 1 -type f", output=str
+                self.url.hostname, f"find {shlex.quote(path)} -maxdepth 1 -type f", output=str
             )
         return (
             [str(Path(p.strip()).relative_to(path)) for p in output.splitlines()] if output else []
@@ -60,10 +68,11 @@ class SSHConnection(object):
     def stat_path(self, path):
         output = (
             self.ssh(
-                self.netloc,
+                self.url.hostname,
                 f'stat -c "%s %Y" {shlex.quote(path)} 2>/dev/null || '  # Linux
                 f'stat -f "%z %m" {shlex.quote(path)} 2>/dev/null',  # MacOS / BSD
                 output=str,
+                fail_on_error=False,
             )
             .strip()
             .split()
@@ -75,14 +84,14 @@ class SSHConnection(object):
         return size, mtime
 
     def fetch(self, remote_path, dest):
-        self.scp(shlex.quote(f"{self.netloc}:{remote_path}"), dest, fail_on_error=True)
+        self.scp(f"{self.url.hostname}:{remote_path}", dest, fail_on_error=True)
 
     def push(self, local_path, remote_path, keep_original=True):
         self.ssh(
-            self.netloc,
+            self.url.hostname,
             f"mkdir -p {shlex.quote(os.path.dirname(remote_path))}",
             fail_on_error=True,
         )
-        self.scp(local_path, shlex.quote(f"{self.netloc}:{remote_path}"), fail_on_error=True)
+        self.scp(local_path, f"{self.url.hostname}:{remote_path}", fail_on_error=True)
         if not keep_original:
             os.remove(local_path)

--- a/lib/spack/spack/util/ssh.py
+++ b/lib/spack/spack/util/ssh.py
@@ -12,6 +12,8 @@ from typing import Dict
 from spack.llnl.util import tty
 from spack.util.executable import which
 
+SSH_DEFAULT_ARGS = [] if tty.is_debug() else ["-q", "-o", "LogLevel=QUIET"]
+
 
 class SSHConnection(object):
     # used to cache connection objects and avoid checking SSH config multiple times
@@ -25,30 +27,44 @@ class SSHConnection(object):
             cls._connections[url.netloc]
 
     def __init__(self, url):
-        SSH_DEFAULT_ARGS = [] if tty.is_debug() else ["-q", "-o", "LogLevel=QUIET"]
-        self.ssh = which("ssh", required=True).with_default_args(*SSH_DEFAULT_ARGS)
-        self.scp = which("scp", required=True).with_default_args(*SSH_DEFAULT_ARGS)
-        if url.username:
-            self.ssh.add_default_arg("-l", url.username)
-            self.scp.add_default_arg("-l", url.username)
-        if url.port:
-            self.ssh.add_default_arg("-p", url.port)
-            self.scp.add_default_arg("-p", url.port)
+        self._ssh = None
+        self._scp = None
         self.url = url
 
-        has_control_master = False
-        for config_line in self.ssh(
-            "-G", self.url.hostname, fail_on_error=True, output=str
-        ).splitlines():
-            if config_line == "controlmaster true" or config_line == "controlmaster auto":
-                has_control_master = True
-                break
+    @property
+    def _default_ssh_args(self):
+        args = SSH_DEFAULT_ARGS[:]
+        if self.url.username:
+            args.extend(["-l", self.url.username])
+        if self.url.port:
+            args.extend(["-p", self.url.port])
+        return args
 
-        if not has_control_master:
-            warnings.warn(
-                f"Minimize SSH connections to {self.url.netloc} via "
-                f"'ControlMaster' in your SSH config!"
-            )
+    @property
+    def ssh(self):
+        if self._ssh is None:
+            self._ssh = which("ssh", required=True).with_default_args(self._default_ssh_args)
+
+            has_control_master = False
+            for config_line in self._ssh(
+                "-G", self.url.hostname, fail_on_error=True, output=str
+            ).splitlines():
+                if config_line == "controlmaster true" or config_line == "controlmaster auto":
+                    has_control_master = True
+                    break
+
+            if not has_control_master:
+                warnings.warn(
+                    f"Minimize SSH connections to {self.url.netloc} via "
+                    f"'ControlMaster' in your SSH config!"
+                )
+        return self._ssh
+
+    @property
+    def scp(self):
+        if self.ssh and self._scp is None:
+            self._scp = which("scp", required=True).with_default_args(self._default_ssh_args)
+        return self._scp
 
     def exists(self, path):
         self.ssh(self.url.hostname, f"test -e {shlex.quote(path)}", fail_on_error=False)

--- a/lib/spack/spack/util/ssh.py
+++ b/lib/spack/spack/util/ssh.py
@@ -1,0 +1,104 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import io
+import os
+import shlex
+import tempfile
+import urllib.parse
+import warnings
+from pathlib import Path
+
+import spack.error
+from spack.llnl.util import tty
+from spack.util.executable import which
+
+
+class SSHConnection(object):
+    # used to cache connection objects and avoid checking SSH config multiple times
+    _connections = {}
+
+    @classmethod
+    def from_url(cls, url):
+        if isinstance(url, str):
+            url = urllib.parse.urlparse(url)
+        if url.netloc not in cls._connections:
+            cls._connections[url.netloc] = SSHConnection(url.netloc)
+        return cls._connections[url.netloc]
+
+    def __init__(self, netloc):
+        SSH_DEFAULT_ARGS = [] if tty.is_debug() else ["-q", "-o", "LogLevel=QUIET"]
+        self.ssh = which("ssh", required=True).with_default_args(*SSH_DEFAULT_ARGS)
+        self.scp = which("scp", required=True).with_default_args(*SSH_DEFAULT_ARGS)
+        self.netloc = netloc
+
+        has_control_master = False
+        for config_line in self.ssh("-G", netloc, fail_on_error=True, output=str).splitlines():
+            if config_line == "controlmaster true" or config_line == "controlmaster auto":
+                has_control_master = True
+                break
+
+        if not has_control_master:
+            warnings.warn(
+                f"Minimize SSH connections to {netloc} via 'ControlMaster' in your SSH config!"
+            )
+
+    def exists(self, path):
+        self.ssh(self.netloc, f"test -e {shlex.quote(path)}", fail_on_error=False)
+        return self.ssh.returncode == 0
+
+    def list_path(self, path, recursive=False):
+        if recursive:
+            output = self.ssh(self.netloc, f"find {shlex.quote(path)} -type f", output=str)
+        else:
+            output = self.ssh(
+                self.netloc, f"find {shlex.quote(path)} -maxdepth 1 -type f", output=str
+            )
+        return (
+            [str(Path(p.strip()).relative_to(path)) for p in output.splitlines()] if output else []
+        )
+
+    def stat_path(self, path):
+        output = (
+            self.ssh(
+                self.netloc,
+                f'stat -c "%s %Y" {shlex.quote(path)} 2>/dev/null || '  # Linux
+                f'stat -f "%z %m" {shlex.quote(path)} 2>/dev/null',  # MacOS / BSD
+                output=str,
+            )
+            .strip()
+            .split()
+        )
+        if self.ssh.returncode != 0:
+            return None
+        size = int(output[0])
+        mtime = float(output[1])
+        return size, mtime
+
+    def fetch(self, remote_path, dest):
+        self.scp(shlex.quote(f"{self.netloc}:{remote_path}"), dest, fail_on_error=True)
+
+    def read(self, remote_path):
+        with tempfile.NamedTemporaryFile("rb") as tmp:
+            try:
+                self.fetch(remote_path, tmp.name)
+                return io.BytesIO(tmp.read())
+            except Exception as e:
+                raise SpackSSHError(
+                    f"Download of ssh://{self.netloc}:{remote_path} failed: {e.__class__.__name__}: {e}"
+                )
+
+    def push(self, local_path, remote_path, keep_original=True):
+        self.ssh(
+            self.netloc,
+            f"mkdir -p {shlex.quote(os.path.dirname(remote_path))}",
+            fail_on_error=True,
+        )
+        self.scp(local_path, shlex.quote(f"{self.netloc}:{remote_path}"), fail_on_error=True)
+        if not keep_original:
+            os.remove(local_path)
+
+
+class SpackSSHError(spack.error.SpackError):
+    """Superclass for Spack SSH errors."""

--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -44,7 +44,7 @@ def is_path_instead_of_url(path_or_url):
     where urls should be used. This utility can be used to validate
     and promote paths to urls."""
     return (
-        bool(re.match(r"^[a-zA-Z]:[\\/]", path_or_url)) # for Windows paths
+        bool(re.match(r"^[a-zA-Z]:[\\/]", path_or_url))  # for Windows paths
         or not urllib.parse.urlparse(path_or_url).scheme
     )
 

--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -16,26 +16,6 @@ from typing import Optional
 from spack.util.path import sanitize_filename
 
 
-def validate_scheme(scheme):
-    """Returns true if the URL scheme is generally known to Spack. This function
-    helps mostly in validation of paths vs urls, as Windows paths such as
-    C:/x/y/z (with backward not forward slash) may parse as a URL with scheme
-    C and path /x/y/z."""
-    return scheme in (
-        "file",
-        "http",
-        "https",
-        "ftp",
-        "s3",
-        "gs",
-        "ssh",
-        "git",
-        "oci",
-        "ssh",
-        "scp",
-    )
-
-
 def local_file_path(url):
     """Get a local file path from a url.
 
@@ -63,7 +43,10 @@ def is_path_instead_of_url(path_or_url):
     """Historically some config files and spack commands used paths
     where urls should be used. This utility can be used to validate
     and promote paths to urls."""
-    return not validate_scheme(urllib.parse.urlparse(path_or_url).scheme)
+    return (
+        bool(re.match(r"^[a-zA-Z]:[\\/]", path_or_url)) # for Windows paths
+        or not urllib.parse.urlparse(path_or_url).scheme
+    )
 
 
 def format(parsed_url):

--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -21,7 +21,19 @@ def validate_scheme(scheme):
     helps mostly in validation of paths vs urls, as Windows paths such as
     C:/x/y/z (with backward not forward slash) may parse as a URL with scheme
     C and path /x/y/z."""
-    return scheme in ("file", "http", "https", "ftp", "s3", "gs", "ssh", "git", "oci")
+    return scheme in (
+        "file",
+        "http",
+        "https",
+        "ftp",
+        "s3",
+        "gs",
+        "ssh",
+        "git",
+        "oci",
+        "ssh",
+        "scp",
+    )
 
 
 def local_file_path(url):
@@ -72,7 +84,8 @@ def join(base: str, *components: str, resolve_href: bool = False, **kwargs) -> s
        For example ``https://example.com/a/b + c/d = https://example.com/a/b/c/d``. If
        ``resolve_href=True``, the behavior is how a browser would resolve the URL:
        ``https://example.com/a/c/d``.
-    2. ``s3://``, ``gs://``, ``oci://`` URLs are joined like ``http://`` URLs.
+    2. ``s3://``, ``gs://``, ``oci://``, ``ssh://`` and ``scp://`` URLs are joined like
+       ``http://`` URLs.
     3. It accepts multiple components for convenience. Note that ``components[1:]`` are treated as
        literal path components and appended to ``components[0]`` separated by slashes."""
     # Ensure a trailing slash in the path component of the base URL to get os.path.join-like
@@ -86,8 +99,24 @@ def join(base: str, *components: str, resolve_href: bool = False, **kwargs) -> s
     try:
         # NOTE: we temporarily modify urllib internals so s3 and gs schemes are treated like http.
         # This is non-portable, and may be forward incompatible with future cpython versions.
-        urllib.parse.uses_netloc = [*old_netloc, "s3", "gs", "oci", "oci+http"]  # type: ignore
-        urllib.parse.uses_relative = [*old_relative, "s3", "gs", "oci", "oci+http"]  # type: ignore
+        urllib.parse.uses_netloc = [  # type: ignore
+            *old_netloc,
+            "s3",
+            "gs",
+            "oci",
+            "oci+http",
+            "ssh",
+            "scp",
+        ]
+        urllib.parse.uses_relative = [  # type: ignore
+            *old_relative,
+            "s3",
+            "gs",
+            "oci",
+            "oci+http",
+            "ssh",
+            "scp",
+        ]
         return urllib.parse.urljoin(base, "/".join(components), **kwargs)
     finally:
         urllib.parse.uses_netloc = old_netloc  # type: ignore

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -15,6 +15,7 @@ import ssl
 import stat
 import sys
 import time
+import tempfile
 import traceback
 import urllib.parse
 from html.parser import HTMLParser
@@ -274,9 +275,30 @@ class ExtractMetadataParser(HTMLParser):
                     self.base_url = val
 
 
+def fetch_from_ssh_url(url, dest):
+    if isinstance(url, str):
+        url = urllib.parse.urlparse(url)
+
+    scp = spack.util.executable.which("scp", required=True)
+    scp_args = [] if tty.is_debug() else ["-q", "-o", "LogLevel=QUIET"]
+    scp(*scp_args, f"{url.netloc}:{url.path}", dest, fail_on_error=True)
+
+
+def read_from_ssh_url(url):
+    with tempfile.NamedTemporaryFile("rb") as tmp:
+        try:
+            fetch_from_ssh_url(url, tmp.name)
+            return url, {}, io.BytesIO(tmp.read())
+        except Exception as e:
+            raise SpackWebError(f"Download of {url.geturl()} failed: {e.__class__.__name__}: {e}")
+
+
 def read_from_url(url, accept_content_type=None):
     if isinstance(url, str):
         url = urllib.parse.urlparse(url)
+
+    if url.scheme in ("ssh", "scp"):
+        return read_from_ssh_url(url)
 
     # Timeout in seconds for web requests
     request = Request(url.geturl(), headers={"User-Agent": SPACK_USER_AGENT})
@@ -374,6 +396,25 @@ def push_to_url(local_file_path, remote_path, keep_original=True, extra_args=Non
     elif remote_url.scheme == "gs":
         gcs = GCSBlob(remote_url)
         gcs.upload_to_blob(local_file_path)
+        if not keep_original:
+            os.remove(local_file_path)
+
+    elif remote_url.scheme in ("ssh", "scp"):
+        ssh = spack.util.executable.which("ssh", required=True)
+        scp = spack.util.executable.which("scp", required=True)
+        common_args = [] if tty.is_debug() else ["-q", "-o", "LogLevel=QUIET"]
+        ssh(
+            *common_args,
+            remote_url.netloc,
+            f'mkdir -p "{os.path.dirname(remote_url.path)}"',
+            fail_on_error=True,
+        )
+        scp(
+            *common_args,
+            local_file_path,
+            f"{remote_url.netloc}:{remote_url.path}",
+            fail_on_error=True,
+        )
         if not keep_original:
             os.remove(local_file_path)
 
@@ -551,6 +592,12 @@ def url_exists(url, curl=None):
     tty.debug("Checking existence of {0}".format(url))
     url_result = urllib.parse.urlparse(url)
 
+    if url_result.scheme in ("ssh", "scp"):
+        ssh = spack.util.executable.which("ssh", required=True)
+        ssh_args = [] if tty.is_debug() else ["-q", "-o", "LogLevel=QUIET"]
+        ssh(*ssh_args, url_result.netloc, f"test -e {url_result.path}", fail_on_error=False)
+        return ssh.returncode == 0
+
     # Use curl if configured to do so
     fetch_method = spack.config.get("config:url_fetch_method", "urllib")
     use_curl = fetch_method.startswith("curl") and url_result.scheme not in ("gs", "s3")
@@ -717,6 +764,19 @@ def list_url(url, recursive=False):
         gcs = GCSBucket(url)
         return gcs.get_all_blobs(recursive=recursive)
 
+    elif url.scheme in ("ssh", "scp"):
+        ssh = spack.util.executable.which("ssh", required=True)
+        ssh_args = [] if tty.is_debug() else ["-q", "-o", "LogLevel=QUIET"]
+        if recursive:
+            output = ssh(*ssh_args, url.netloc, f"find {url.path} -type f", output=str)
+        else:
+            output = ssh(*ssh_args, url.netloc, f"find {url.path} -maxdepth 1 -type f", output=str)
+        return (
+            [str(Path(p.strip()).relative_to(url.path)) for p in output.splitlines()]
+            if output
+            else []
+        )
+
 
 def stat_url(url: str) -> Optional[Tuple[int, float]]:
     """Get stat result for a URL.
@@ -752,6 +812,20 @@ def stat_url(url: str) -> Optional[Tuple[int, float]]:
 
         mtime = head_request["LastModified"].timestamp()
         size = head_request["ContentLength"]
+        return size, mtime
+
+    elif parsed_url.scheme in ("ssh", "scp"):
+        ssh = spack.util.executable.which("ssh", required=True)
+        ssh_args = [] if tty.is_debug() else ["-q", "-o", "LogLevel=QUIET"]
+        output = (
+            ssh(*ssh_args, parsed_url.netloc, f'stat -c "%s %Y" "{parsed_url.path}"', output=str)
+            .strip()
+            .split()
+        )
+        if ssh.returncode != 0:
+            return None
+        size = int(output[0])
+        mtime = float(output[1])
         return size, mtime
 
     else:

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -281,7 +281,7 @@ def read_from_url(url, accept_content_type=None):
 
     if url.scheme in ("ssh", "scp"):
         ssh = SSHConnection.from_url(url)
-        return url, {}, ssh.read(url.path)
+        return url.geturl(), {}, ssh.read(url.path)
 
     # Timeout in seconds for web requests
     request = Request(url.geturl(), headers={"User-Agent": SPACK_USER_AGENT})

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -834,7 +834,8 @@ def stat_url(url: str) -> Optional[Tuple[int, float]]:
             ssh(
                 *ssh_args,
                 parsed_url.netloc,
-                f'stat -c "%s %Y" {shlex.quote(parsed_url.path)}',
+                f'stat -c "%s %Y" {shlex.quote(parsed_url.path)} 2>/dev/null || '  # Linux
+                f'stat -f "%z %m" {shlex.quote(parsed_url.path)} 2>/dev/null',  # MacOS / BSD
                 output=str,
             )
             .strip()

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -9,14 +9,12 @@ import io
 import json
 import os
 import re
-import shlex
 import shutil
 import socket
 import ssl
 import stat
 import sys
 import time
-import tempfile
 import traceback
 import urllib.parse
 from html.parser import HTMLParser
@@ -42,6 +40,7 @@ from spack.llnl.util.filesystem import mkdirp, rename, working_dir
 from .executable import CommandNotFoundError, Executable
 from .gcs import GCSBlob, GCSBucket, GCSHandler
 from .s3 import UrllibS3Handler, get_s3_session
+from .ssh import SSHConnection
 
 
 def is_transient_error(e: Exception) -> bool:
@@ -276,30 +275,13 @@ class ExtractMetadataParser(HTMLParser):
                     self.base_url = val
 
 
-def fetch_from_ssh_url(url, dest):
-    if isinstance(url, str):
-        url = urllib.parse.urlparse(url)
-
-    scp = spack.util.executable.which("scp", required=True)
-    scp_args = [] if tty.is_debug() else ["-q", "-o", "LogLevel=QUIET"]
-    scp(*scp_args, shlex.quote(f"{url.netloc}:{url.path}"), dest, fail_on_error=True)
-
-
-def read_from_ssh_url(url):
-    with tempfile.NamedTemporaryFile("rb") as tmp:
-        try:
-            fetch_from_ssh_url(url, tmp.name)
-            return url, {}, io.BytesIO(tmp.read())
-        except Exception as e:
-            raise SpackWebError(f"Download of {url.geturl()} failed: {e.__class__.__name__}: {e}")
-
-
 def read_from_url(url, accept_content_type=None):
     if isinstance(url, str):
         url = urllib.parse.urlparse(url)
 
     if url.scheme in ("ssh", "scp"):
-        return read_from_ssh_url(url)
+        ssh = SSHConnection.from_url(url)
+        return url, {}, ssh.read(url.path)
 
     # Timeout in seconds for web requests
     request = Request(url.geturl(), headers={"User-Agent": SPACK_USER_AGENT})
@@ -401,23 +383,8 @@ def push_to_url(local_file_path, remote_path, keep_original=True, extra_args=Non
             os.remove(local_file_path)
 
     elif remote_url.scheme in ("ssh", "scp"):
-        ssh = spack.util.executable.which("ssh", required=True)
-        scp = spack.util.executable.which("scp", required=True)
-        common_args = [] if tty.is_debug() else ["-q", "-o", "LogLevel=QUIET"]
-        ssh(
-            *common_args,
-            remote_url.netloc,
-            f"mkdir -p {shlex.quote(os.path.dirname(remote_url.path))}",
-            fail_on_error=True,
-        )
-        scp(
-            *common_args,
-            local_file_path,
-            shlex.quote(f"{remote_url.netloc}:{remote_url.path}"),
-            fail_on_error=True,
-        )
-        if not keep_original:
-            os.remove(local_file_path)
+        ssh = SSHConnection.from_url(remote_url)
+        ssh.push(local_file_path, remote_url.path, keep_original=keep_original)
 
     else:
         raise NotImplementedError(f"Unrecognized URL scheme: {remote_url.scheme}")
@@ -594,15 +561,8 @@ def url_exists(url, curl=None):
     url_result = urllib.parse.urlparse(url)
 
     if url_result.scheme in ("ssh", "scp"):
-        ssh = spack.util.executable.which("ssh", required=True)
-        ssh_args = [] if tty.is_debug() else ["-q", "-o", "LogLevel=QUIET"]
-        ssh(
-            *ssh_args,
-            url_result.netloc,
-            f"test -e {shlex.quote(url_result.path)}",
-            fail_on_error=False,
-        )
-        return ssh.returncode == 0
+        ssh = SSHConnection.from_url(url_result)
+        return ssh.exists(url_result.path)
 
     # Use curl if configured to do so
     fetch_method = spack.config.get("config:url_fetch_method", "urllib")
@@ -771,24 +731,8 @@ def list_url(url, recursive=False):
         return gcs.get_all_blobs(recursive=recursive)
 
     elif url.scheme in ("ssh", "scp"):
-        ssh = spack.util.executable.which("ssh", required=True)
-        ssh_args = [] if tty.is_debug() else ["-q", "-o", "LogLevel=QUIET"]
-        if recursive:
-            output = ssh(
-                *ssh_args, url.netloc, f"find {shlex.quote(url.path)} -type f", output=str
-            )
-        else:
-            output = ssh(
-                *ssh_args,
-                url.netloc,
-                f"find {shlex.quote(url.path)} -maxdepth 1 -type f",
-                output=str,
-            )
-        return (
-            [str(Path(p.strip()).relative_to(url.path)) for p in output.splitlines()]
-            if output
-            else []
-        )
+        ssh = SSHConnection.from_url(url)
+        return ssh.list_path(url.path, recursive=recursive)
 
 
 def stat_url(url: str) -> Optional[Tuple[int, float]]:
@@ -828,24 +772,8 @@ def stat_url(url: str) -> Optional[Tuple[int, float]]:
         return size, mtime
 
     elif parsed_url.scheme in ("ssh", "scp"):
-        ssh = spack.util.executable.which("ssh", required=True)
-        ssh_args = [] if tty.is_debug() else ["-q", "-o", "LogLevel=QUIET"]
-        output = (
-            ssh(
-                *ssh_args,
-                parsed_url.netloc,
-                f'stat -c "%s %Y" {shlex.quote(parsed_url.path)} 2>/dev/null || '  # Linux
-                f'stat -f "%z %m" {shlex.quote(parsed_url.path)} 2>/dev/null',  # MacOS / BSD
-                output=str,
-            )
-            .strip()
-            .split()
-        )
-        if ssh.returncode != 0:
-            return None
-        size = int(output[0])
-        mtime = float(output[1])
-        return size, mtime
+        ssh = SSHConnection.from_url(parsed_url)
+        return ssh.stat_path(parsed_url.path)
 
     else:
         raise NotImplementedError(f"Unrecognized URL scheme: {parsed_url.scheme}")

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -9,6 +9,7 @@ import io
 import json
 import os
 import re
+import shlex
 import shutil
 import socket
 import ssl
@@ -281,7 +282,7 @@ def fetch_from_ssh_url(url, dest):
 
     scp = spack.util.executable.which("scp", required=True)
     scp_args = [] if tty.is_debug() else ["-q", "-o", "LogLevel=QUIET"]
-    scp(*scp_args, f"{url.netloc}:{url.path}", dest, fail_on_error=True)
+    scp(*scp_args, shlex.quote(f"{url.netloc}:{url.path}"), dest, fail_on_error=True)
 
 
 def read_from_ssh_url(url):
@@ -406,13 +407,13 @@ def push_to_url(local_file_path, remote_path, keep_original=True, extra_args=Non
         ssh(
             *common_args,
             remote_url.netloc,
-            f'mkdir -p "{os.path.dirname(remote_url.path)}"',
+            f"mkdir -p {shlex.quote(os.path.dirname(remote_url.path))}",
             fail_on_error=True,
         )
         scp(
             *common_args,
             local_file_path,
-            f"{remote_url.netloc}:{remote_url.path}",
+            shlex.quote(f"{remote_url.netloc}:{remote_url.path}"),
             fail_on_error=True,
         )
         if not keep_original:
@@ -595,7 +596,12 @@ def url_exists(url, curl=None):
     if url_result.scheme in ("ssh", "scp"):
         ssh = spack.util.executable.which("ssh", required=True)
         ssh_args = [] if tty.is_debug() else ["-q", "-o", "LogLevel=QUIET"]
-        ssh(*ssh_args, url_result.netloc, f"test -e {url_result.path}", fail_on_error=False)
+        ssh(
+            *ssh_args,
+            url_result.netloc,
+            f"test -e {shlex.quote(url_result.path)}",
+            fail_on_error=False,
+        )
         return ssh.returncode == 0
 
     # Use curl if configured to do so
@@ -768,9 +774,16 @@ def list_url(url, recursive=False):
         ssh = spack.util.executable.which("ssh", required=True)
         ssh_args = [] if tty.is_debug() else ["-q", "-o", "LogLevel=QUIET"]
         if recursive:
-            output = ssh(*ssh_args, url.netloc, f"find {url.path} -type f", output=str)
+            output = ssh(
+                *ssh_args, url.netloc, f"find {shlex.quote(url.path)} -type f", output=str
+            )
         else:
-            output = ssh(*ssh_args, url.netloc, f"find {url.path} -maxdepth 1 -type f", output=str)
+            output = ssh(
+                *ssh_args,
+                url.netloc,
+                f"find {shlex.quote(url.path)} -maxdepth 1 -type f",
+                output=str,
+            )
         return (
             [str(Path(p.strip()).relative_to(url.path)) for p in output.splitlines()]
             if output
@@ -818,7 +831,12 @@ def stat_url(url: str) -> Optional[Tuple[int, float]]:
         ssh = spack.util.executable.which("ssh", required=True)
         ssh_args = [] if tty.is_debug() else ["-q", "-o", "LogLevel=QUIET"]
         output = (
-            ssh(*ssh_args, parsed_url.netloc, f'stat -c "%s %Y" "{parsed_url.path}"', output=str)
+            ssh(
+                *ssh_args,
+                parsed_url.netloc,
+                f'stat -c "%s %Y" {shlex.quote(parsed_url.path)}',
+                output=str,
+            )
             .strip()
             .split()
         )


### PR DESCRIPTION
Implements #14199 by using the ssh/scp client on your system and utilizes your existing SSH client configuration.

This allows registering, pushing and using `ssh://` and `scp://` mirrors and build caches.
