### PR TITLE
naming.py: add NamingScheme

### DIFF
--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -253,10 +253,9 @@ def list_packages(rev: str, repo: "Repo") -> List[str]:
     ]
 
     # take the directory names with one-level-deep package files
+    naming_scheme = nm.get_naming_scheme(repo.package_api)
     package_names = [
-        nm.pkg_dir_to_pkg_name(line[0], repo.package_api)
-        for line in package_paths
-        if len(line) == 2
+        naming_scheme.pkg_dir_to_pkg_name(line[0]) for line in package_paths if len(line) == 2
     ]
 
     return sorted(set(package_names))
@@ -294,11 +293,12 @@ def get_all_package_diffs(type: str, repo: "Repo", rev1="HEAD^1", rev2="HEAD") -
 
     lines = [] if not out else re.split(r"\s+", out)
     changed: Set[str] = set()
+    naming_scheme = nm.get_naming_scheme(repo.package_api)
     for path in lines:
         dir_name, _, _ = path.partition("/")
-        if not nm.valid_module_name(dir_name, repo.package_api):
+        if not naming_scheme.valid_module_name(dir_name):
             continue
-        pkg_name = nm.pkg_dir_to_pkg_name(dir_name, repo.package_api)
+        pkg_name = naming_scheme.pkg_dir_to_pkg_name(dir_name)
         if pkg_name not in added and pkg_name not in removed:
             changed.add(pkg_name)
 
@@ -413,6 +413,7 @@ class FastPackageChecker(Mapping[str, float]):
         cache: Dict[str, float] = {}
         # Don't use os.path.join in the loop cause it's slow and redundant.
         package_py_suffix = f"{os.path.sep}{package_file_name}"
+        naming_scheme = nm.get_naming_scheme(self.package_api)
 
         # Use a file descriptor for the packages directory to avoid repeated path resolution.
         with _directory_fd(self.packages_path) as fd, os.scandir(self.packages_path) as entries:
@@ -441,7 +442,7 @@ class FastPackageChecker(Mapping[str, float]):
 
                 # Only consider package.py files in directories that are valid module names under
                 # the current package API
-                if not nm.valid_module_name(entry.name, self.package_api):
+                if not naming_scheme.valid_module_name(entry.name):
                     x, y = self.package_api
                     pkg_file = os.path.join(self.packages_path, entry.name, package_file_name)
                     tty.warn(
@@ -451,7 +452,7 @@ class FastPackageChecker(Mapping[str, float]):
                     continue
 
                 # Store the mtime by package name.
-                cache[nm.pkg_dir_to_pkg_name(entry.name, self.package_api)] = sinfo.st_mtime
+                cache[naming_scheme.pkg_dir_to_pkg_name(entry.name)] = sinfo.st_mtime
 
         return cache
 
@@ -1136,6 +1137,7 @@ class Repo:
         config = self._read_config()
 
         self.package_api = _parse_package_api_version(config)
+        self.naming_scheme = nm.get_naming_scheme(self.package_api)
         self.subdirectory = _validate_and_normalize_subdir(
             config.get("subdirectory", packages_dir_name), root, self.package_api
         )
@@ -1192,7 +1194,7 @@ class Repo:
 
             # check that all subdirectories are valid module names
             check(
-                all(nm.valid_module_name(x, self.package_api) for x in self.namespace.split(".")),
+                all(self.naming_scheme.valid_module_name(x) for x in self.namespace.split(".")),
                 f"Invalid namespace '{self.namespace}' in repo '{self.root}'",
             )
 
@@ -1236,7 +1238,7 @@ class Repo:
         * ``foo_bar_baz`` -> ``foo_bar_baz``, ``foo-bar-baz``, ``foo_bar-baz``, ``foo-bar_baz``
         """
         if self.package_api >= (2, 0):
-            if nm.pkg_dir_to_pkg_name(import_name, package_api=self.package_api) in self:
+            if self.naming_scheme.pkg_dir_to_pkg_name(import_name) in self:
                 return import_name
             return None
 
@@ -1383,7 +1385,7 @@ class Repo:
         """Given a package name, get the directory containing its package.py file."""
         _, unqualified_name = self.partition_package_name(pkg_name)
         return os.path.join(
-            self.packages_path, nm.pkg_name_to_pkg_dir(unqualified_name, self.package_api)
+            self.packages_path, self.naming_scheme.pkg_name_to_pkg_dir(unqualified_name)
         )
 
     def filename_for_package_name(self, pkg_name: str) -> str:
@@ -1414,7 +1416,7 @@ class Repo:
     def package_path(self, name: str) -> str:
         """Get path to package.py file for this repo."""
         return os.path.join(
-            self.packages_path, nm.pkg_name_to_pkg_dir(name, self.package_api), package_file_name
+            self.packages_path, self.naming_scheme.pkg_name_to_pkg_dir(name), package_file_name
         )
 
     def all_package_paths(self) -> Generator[str, None, None]:
@@ -1475,7 +1477,7 @@ class Repo:
         according to Spack's naming convention.
         """
         _, pkg_name = self.partition_package_name(pkg_name)
-        fullname = f"{self.full_namespace}.{nm.pkg_name_to_pkg_dir(pkg_name, self.package_api)}"
+        fullname = f"{self.full_namespace}.{self.naming_scheme.pkg_name_to_pkg_dir(pkg_name)}"
         if self.package_api >= (2, 0):
             fullname += ".package"
 

--- a/lib/spack/spack/repo_migrate.py
+++ b/lib/spack/spack/repo_migrate.py
@@ -48,9 +48,8 @@ def migrate_v1_to_v2(
 
     namespace = repo.namespace.split(".")
 
-    if not all(
-        spack.util.naming.valid_module_name(part, package_api=(2, 0)) for part in namespace
-    ):
+    naming_scheme = spack.util.naming.get_naming_scheme((2, 0))
+    if not all(naming_scheme.valid_module_name(part) for part in namespace):
         print(
             f"Cannot upgrade from v1 to v2, because the namespace '{repo.namespace}' is not a "
             "valid Python module",

--- a/lib/spack/spack/util/naming.py
+++ b/lib/spack/spack/util/naming.py
@@ -99,7 +99,7 @@ class NamingSchemeV2(NamingScheme):
 
     def pkg_name_to_pkg_dir(self, name: str) -> str:
         name = name.replace("-", "_")
-        if re.match(r"^[0-9]", name) or name in RESERVED_NAMES_ONLY_LOWERCASE:
+        if name[0].isdigit() or name in RESERVED_NAMES_ONLY_LOWERCASE:
             name = f"_{name}"
         return name
 


### PR DESCRIPTION
Currently naming.py has 3 functions that take `package_api` as an
argument:

* `pkg_dir_to_pkg_name`
* `pkg_name_to_pkg_dir`
* `valid_module_name`

This commit splits them into separate functions for package api v1 and
v2, which is a bit cleaner when reading `naming.py`, as we can document
the different schemes better.

It also helps moving the static branch on the package api out of loops
when iterating over packages from a given repo:

```python
naming_scheme = get_naming_scheme(package_api)
for pkg in pkgs:
  if naming_scheme.valid_module_name(pkg_name):
    ...
```

Also, use `name[0].isdigit()` in `pkg_name_to_pkg_dir`, which mirrors
`mod_name[1].isdigit()` in `valid_module_name`.
