### PR TITLE
log: Overhaul Windows Logger with Pipes and FHs

### DIFF
--- a/lib/spack/spack/llnl/util/tty/log.py
+++ b/lib/spack/spack/llnl/util/tty/log.py
@@ -925,9 +925,11 @@ def _writer_daemon(
 
 def dup_fh(fh: int) -> int:
     if sys.platform != "win32":
-        return
+        # return impossible value
+        # since fhs are unsigned
+        return -1
     # Define function signatures for safety
-    kernel32.DuplicateHandle.argtypes = [
+    ctypes.windll.kernel32.DuplicateHandle.argtypes = [
         wintypes.HANDLE,  # hSourceProcessHandle
         wintypes.HANDLE,  # hSourceHandle
         wintypes.HANDLE,  # hTargetProcessHandle
@@ -949,10 +951,7 @@ def dup_fh(fh: int) -> int:
         DUPLICATE_SAME_ACCESS,
     )
 
-    if not success:
-        raise ctypes.WinError()
-
-    if not target_handle.value:
+    if not success or not target_handle.value:
         raise ctypes.WinError()
 
     return target_handle.value

--- a/lib/spack/spack/llnl/util/tty/log.py
+++ b/lib/spack/spack/llnl/util/tty/log.py
@@ -22,8 +22,9 @@ from typing import IO, Callable, List, Optional, Tuple
 import spack.llnl.util.tty as tty
 
 if sys.platform == "win32":
-    import msvcrt
     import ctypes.wintypes as wintypes
+    import msvcrt
+
     kernel32 = ctypes.windll.kernel32
 
 try:
@@ -921,38 +922,50 @@ def _writer_daemon(
         control_fd.send(echo)
 
 
-def dup_fh(fh: int) -> int:
-    if sys.platform != "win32":
-        # return impossible value
-        # since fhs are unsigned
-        return -1
-    # Define function signatures for safety
-    kernel32.DuplicateHandle.argtypes = [
-        wintypes.HANDLE,  # hSourceProcessHandle
-        wintypes.HANDLE,  # hSourceHandle
-        wintypes.HANDLE,  # hTargetProcessHandle
-        ctypes.POINTER(wintypes.HANDLE),  # lpTargetHandle
-        wintypes.DWORD,  # dwDesiredAccess
-        wintypes.BOOL,  # bInheritHandle
-        wintypes.DWORD,  # dwOptions
-    ]
-    current_process = kernel32.GetCurrentProcess()
-    target_handle = wintypes.HANDLE()
+if sys.platform == "win32":
+    # dont define this outside windows, otherwise mypy complains
+    # or we'd have to # type: ignore on basically every line of
+    # this method
+    def dup_fh(fh: int) -> int:
+        """Windows Only
+        Duplicates Windows file handles. Useful when
+        we need multiple references to a single file handle
+        that all can be closed independently
 
-    success = kernel32.DuplicateHandle(
-        current_process,
-        wintypes.HANDLE(fh),
-        current_process,
-        ctypes.byref(target_handle),
-        0,
-        True,
-        DUPLICATE_SAME_ACCESS,
-    )
+        uses DuplicateHandle from the win32 api
 
-    if not success or not target_handle.value:
-        raise ctypes.WinError()
+        Arguments:
+            fh: OS level file handle to be duplicated
 
-    return target_handle.value
+        Returns: integer representing the new, identical file handle
+        """
+        # Define function signatures for safety
+        kernel32.DuplicateHandle.argtypes = [
+            wintypes.HANDLE,  # hSourceProcessHandle
+            wintypes.HANDLE,  # hSourceHandle
+            wintypes.HANDLE,  # hTargetProcessHandle
+            ctypes.POINTER(wintypes.HANDLE),  # lpTargetHandle
+            wintypes.DWORD,  # dwDesiredAccess
+            wintypes.BOOL,  # bInheritHandle
+            wintypes.DWORD,  # dwOptions
+        ]
+        current_process = kernel32.GetCurrentProcess()
+        target_handle = wintypes.HANDLE()
+
+        success = kernel32.DuplicateHandle(
+            current_process,
+            wintypes.HANDLE(fh),
+            current_process,
+            ctypes.byref(target_handle),
+            0,
+            True,
+            DUPLICATE_SAME_ACCESS,
+        )
+
+        if not success or not target_handle.value:
+            raise ctypes.WinError()
+
+        return target_handle.value
 
 
 def force_echo_on(force_echo: bool, controls: List[str]):

--- a/lib/spack/spack/llnl/util/tty/log.py
+++ b/lib/spack/spack/llnl/util/tty/log.py
@@ -5,28 +5,36 @@
 """Utility classes for logging the output of blocks of code."""
 import atexit
 import ctypes
+import ctypes.wintypes as wintypes
 import errno
 import io
 import multiprocessing
+import multiprocessing.connection
 import os
 import re
 import select
 import signal
 import sys
-import threading
 import traceback
 from contextlib import contextmanager
 from multiprocessing.connection import Connection
 from threading import Thread
-from typing import IO, Callable, Optional, Tuple
+from typing import IO, Callable, List, Optional, Tuple
 
 import spack.llnl.util.tty as tty
+
+if sys.platform == "win32":
+    import msvcrt
+
+    kernel32 = ctypes.windll.kernel32
 
 try:
     import termios
 except ImportError:
     termios = None  # type: ignore[assignment]
 
+# win32api constants
+DUPLICATE_SAME_ACCESS = 0x00000002
 
 esc, bell, lbracket, bslash, newline = r"\x1b", r"\x07", r"\[", r"\\", r"\n"
 # Ansi Control Sequence Introducers (CSI) are a well-defined format
@@ -547,67 +555,84 @@ class StreamWrapper:
     def __init__(self, sys_attr):
         self.sys_attr = sys_attr
         self.saved_stream = None
-        if sys.platform.startswith("win32"):
-            if hasattr(sys, "gettotalrefcount"):  # debug build
-                libc = ctypes.CDLL("ucrtbased")
-            else:
-                libc = ctypes.CDLL("api-ms-win-crt-stdio-l1-1-0")
 
-            kernel32 = ctypes.WinDLL("kernel32")
+        kernel32.SetStdHandle.argtypes = [wintypes.DWORD, wintypes.HANDLE]  # nStdHandle  # hHandle
 
-            # https://docs.microsoft.com/en-us/windows/console/getstdhandle
-            if self.sys_attr == "stdout":
-                STD_HANDLE = -11
-            elif self.sys_attr == "stderr":
-                STD_HANDLE = -12
-            else:
-                raise KeyError(self.sys_attr)
+        kernel32.GetStdHandle.argtypes = [wintypes.DWORD]
+        kernel32.GetStdHandle.restype = wintypes.HANDLE
 
-            c_stdout = kernel32.GetStdHandle(STD_HANDLE)
-            self.libc = libc
-            self.c_stream = c_stdout
+        # https://docs.microsoft.com/en-us/windows/console/getstdhandle
+        if self.sys_attr == "stdout":
+            self.STD_HANDLE = -11
+        elif self.sys_attr == "stderr":
+            self.STD_HANDLE = -12
         else:
-            self.libc = ctypes.CDLL(None)
-            self.c_stream = ctypes.c_void_p.in_dll(self.libc, self.sys_attr)
-        self.sys_stream = getattr(sys, self.sys_attr)
-        self.orig_stream_fd = self.sys_stream.fileno()
-        # Save a copy of the original stdout fd in saved_stream
-        self.saved_stream = os.dup(self.orig_stream_fd)
+            raise KeyError(self.sys_attr)
 
-    def redirect_stream(self, to_fd):
+        self.saved_stream = getattr(sys, self.sys_attr)
+        self.saved_std_fd = self.saved_stream.fileno()
+        self.saved_std_handle = ctypes.windll.kernel32.GetStdHandle(self.STD_HANDLE)
+        self.saved_stream_fd = os.dup(self.saved_std_fd)
+        self.redirect_fd = None
+
+    def redirect_stream(self, write_conn):
         """Redirect stdout to the given file descriptor."""
-        # Flush the C-level buffer stream
-        if sys.platform.startswith("win32"):
-            self.libc.fflush(None)
-        else:
-            self.libc.fflush(self.c_stream)
-        # Flush and close sys_stream - also closes the file descriptor (fd)
-        sys_stream = getattr(sys, self.sys_attr)
-        sys_stream.flush()
-        sys_stream.close()
-        # Make orig_stream_fd point to the same file as to_fd
-        os.dup2(to_fd, self.orig_stream_fd)
-        # Set sys_stream to a new stream that points to the redirected fd
-        new_buffer = open(self.orig_stream_fd, "wb")
-        new_stream = io.TextIOWrapper(new_buffer)
-        setattr(sys, self.sys_attr, new_stream)
-        self.sys_stream = getattr(sys, self.sys_attr)
+        self.flush()
+        # Get fd for new stream
+        redirect_h = write_conn.fileno()
+        dup_redirect_h = dup_fh(redirect_h)
+        # ensure inheritable handles
+        os.set_handle_inheritable(redirect_h, True)
+        # Todo: investigate if this is neccesary if we do the above before the handle dup
+        os.set_handle_inheritable(dup_redirect_h, True)
+        # get the Windows FH for our directed stream
+        self.redirect_fd = msvcrt.open_osfhandle(dup_redirect_h, os.O_WRONLY)
+        # redirect at the os kernel level
+        ctypes.windll.kernel32.SetStdHandle(self.STD_HANDLE, wintypes.HANDLE(redirect_h))
+        # redirect at C level
+        os.dup2(self.redirect_fd, self.saved_std_fd)
+        # get the stream for the writer connection
+        setattr(
+            sys,
+            self.sys_attr,
+            os.fdopen(
+                self.saved_std_fd,
+                "w",
+                encoding="utf-8",
+                buffering=1,
+                errors="replace",
+                closefd=False,
+                newline="\n",
+            ),
+        )
 
     def flush(self):
-        if sys.platform.startswith("win32"):
-            self.libc.fflush(None)
-        else:
-            self.libc.fflush(self.c_stream)
-        self.sys_stream.flush()
+        # get current system stream for the standard fd we're redirecting
+        sys_stream = getattr(sys, self.sys_attr)
+        try:
+            if sys_stream:
+                # Flush the system stream before redirection
+                sys_stream.flush()
+        except BaseException:
+            # swallow flush errors
+            pass
 
     def close(self):
         """Redirect back to the original system stream, and close stream"""
         try:
-            if self.saved_stream is not None:
-                self.redirect_stream(self.saved_stream)
+            self.flush()
+            if self.saved_stream_fd is not None:
+                # restore os handle
+                ctypes.windll.kernel32.SetStdHandle(self.STD_HANDLE, self.saved_std_handle)
+                # restore c fd
+                os.dup2(self.saved_stream_fd, self.saved_std_fd)
+                # python level
+                setattr(sys, self.sys_attr, self.saved_stream)
         finally:
-            if self.saved_stream is not None:
-                os.close(self.saved_stream)
+            if self.redirect_fd is not None:
+                os.close(self.redirect_fd)
+            if self.saved_stream_fd is not None:
+                os.close(self.saved_stream_fd)
 
 
 class winlog:
@@ -630,60 +655,37 @@ class winlog:
         self.old_stdout = sys.stdout
         self.old_stderr = sys.stderr
         self.append = append
+        self.filter_fn = filter_fn
+        self.read_p, self.write_p = None, None
+        self._thread = None
 
     def __enter__(self):
         if self._active:
             raise RuntimeError("Can't re-enter the same log_output!")
 
-        # Open both write and reading on logfile
-        write_mode = "ab+" if self.append else "wb+"
-        self.writer = open(self.logfile, mode=write_mode)
-        self.reader = open(self.logfile, mode="rb+")
+        self.read_p, self.write_p = multiprocessing.Pipe(duplex=False)
 
         # Dup stdout so we can still write to it after redirection
-        self.echo_writer = open(os.dup(sys.stdout.fileno()), "w", encoding=sys.stdout.encoding)
-        # Redirect stdout and stderr to write to logfile
-        self.stderr.redirect_stream(self.writer.fileno())
-        self.stdout.redirect_stream(self.writer.fileno())
-        self._kill = threading.Event()
-
-        def background_reader(reader, echo_writer, _kill):
-            # for each line printed to logfile, read it
-            # if echo: write line to user
-            try:
-                while True:
-                    is_killed = _kill.wait(0.1)
-                    # Flush buffered build output to file
-                    # stdout/err fds refer to log file
-                    self.stderr.flush()
-                    self.stdout.flush()
-
-                    line = reader.readline()
-                    if self.echo and line:
-                        echo_writer.write("{0}".format(line.decode()))
-                        echo_writer.flush()
-
-                    if is_killed:
-                        break
-            finally:
-                reader.close()
+        original_stdout_fd = sys.stdout.fileno()
+        echo_writer = os.fdopen(os.dup(original_stdout_fd), "w", encoding="utf-8", newline="\n")
 
         self._active = True
         self._thread = Thread(
-            target=background_reader, args=(self.reader, self.echo_writer, self._kill)
+            target=self._background_reader,
+            args=(self.read_p, self.logfile, echo_writer, self.append, self.echo, self.filter_fn),
         )
         self._thread.start()
+        # Redirect stdout and stderr to write to logfile
+        self.stderr.redirect_stream(self.write_p)
+        self.stdout.redirect_stream(self.write_p)
+
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.writer.close()
-        self.echo_writer.flush()
-        self.stdout.flush()
-        self.stderr.flush()
-        self._kill.set()
-        self._thread.join()
         self.stdout.close()
         self.stderr.close()
+        self.write_p.close()
+        self._thread.join()
         self._active = False
 
     @contextmanager
@@ -691,7 +693,69 @@ class winlog:
         """Context manager to force local echo, even if echo is off."""
         if not self._active:
             raise RuntimeError("Can't call force_echo() outside log_output region!")
-        yield
+        sys.stdout.write(xon)
+        sys.stdout.flush()
+        try:
+            yield
+        finally:
+            sys.stdout.write(xoff)
+            sys.stdout.flush()
+
+    @staticmethod
+    def _background_reader(
+        read: multiprocessing.connection.PipeConnection,
+        logfile: str,
+        stdout: io.TextIOBase,
+        append: bool,
+        echo: bool,
+        filter_fn: Callable,
+    ):
+        force_echo = False
+
+        # Open both write and reading on logfile
+        write_mode = "ab+" if append else "wb+"
+        log_writer = open(logfile, mode=write_mode)
+        try:
+            while True:
+                data = read.recv_bytes(maxlength=4096)
+                # import pdb; pdb.set_trace()
+                if not data:
+                    # the pipe is closed or otherwise inaccesible
+                    return
+                norm_data = data.decode(encoding="utf-8", errors="replace")
+                # stdout.write(data.decode())
+                clean_line, num_controls = control.subn("", norm_data)
+
+                log_writer.write(_strip(clean_line).encode(encoding="utf-8"))
+                log_writer.flush()
+                if echo or force_echo:
+                    output = clean_line
+                    if filter_fn:
+                        output = filter_fn(output)
+                    enc = stdout.encoding
+                    if enc != "utf-8":
+                        output = output.encode(enc, "replace").decode(enc)
+                    stdout.write(output)
+                    stdout.flush()
+                if num_controls > 0:
+                    controls = control.findall(norm_data)
+                    force_echo = force_echo_on(force_echo, controls)
+                if read.closed:
+                    break
+
+        # swallow valid errors
+        except EOFError:
+            pass
+        except OSError:
+            pass
+        except BaseException as e:
+            tty.error(f"Exception in log writer thread! {e}", stream=stdout)
+            traceback.print_exc(file=stdout)
+        finally:
+            read.close()
+            log_writer.close()
+            stdout.flush()
+            stdout.close()
 
 
 def _writer_daemon(
@@ -835,10 +899,7 @@ def _writer_daemon(
 
                             if num_controls > 0:
                                 controls = control.findall(line)
-                                if xon in controls:
-                                    force_echo = True
-                                if xoff in controls:
-                                    force_echo = False
+                                force_echo = force_echo_on(force_echo, controls)
 
                             if not _input_available(read_file):
                                 break
@@ -860,6 +921,47 @@ def _writer_daemon(
 
         # send echo value back to the parent so it can be preserved.
         control_fd.send(echo)
+
+
+def dup_fh(fh: int) -> int:
+    # Define function signatures for safety
+    kernel32.DuplicateHandle.argtypes = [
+        wintypes.HANDLE,  # hSourceProcessHandle
+        wintypes.HANDLE,  # hSourceHandle
+        wintypes.HANDLE,  # hTargetProcessHandle
+        ctypes.POINTER(wintypes.HANDLE),  # lpTargetHandle
+        wintypes.DWORD,  # dwDesiredAccess
+        wintypes.BOOL,  # bInheritHandle
+        wintypes.DWORD,  # dwOptions
+    ]
+    current_process = ctypes.windll.kernel32.GetCurrentProcess()
+    target_handle = wintypes.HANDLE()
+
+    success = ctypes.windll.kernel32.DuplicateHandle(
+        current_process,
+        wintypes.HANDLE(fh),
+        current_process,
+        ctypes.byref(target_handle),
+        0,
+        True,
+        DUPLICATE_SAME_ACCESS,
+    )
+
+    if not success:
+        raise ctypes.WinError()
+
+    if not target_handle.value:
+        raise ctypes.WinError()
+
+    return target_handle.value
+
+
+def force_echo_on(force_echo: bool, controls: List[str]):
+    if xon in controls:
+        return True
+    if xoff in controls:
+        return False
+    return force_echo
 
 
 def _input_available(f):

--- a/lib/spack/spack/llnl/util/tty/log.py
+++ b/lib/spack/spack/llnl/util/tty/log.py
@@ -703,7 +703,7 @@ class winlog:
 
     @staticmethod
     def _background_reader(
-        read: multiprocessing.connection.PipeConnection,
+        read,
         logfile: str,
         stdout: io.TextIOBase,
         append: bool,

--- a/lib/spack/spack/llnl/util/tty/log.py
+++ b/lib/spack/spack/llnl/util/tty/log.py
@@ -705,7 +705,7 @@ class winlog:
     ):
         force_echo = False
 
-        write_mode = "ab+" if append else "wb+"
+        write_mode = "ab" if append else "wb"
         log_writer = open(logfile, mode=write_mode)
         try:
             while True:

--- a/lib/spack/spack/llnl/util/tty/log.py
+++ b/lib/spack/spack/llnl/util/tty/log.py
@@ -580,17 +580,11 @@ class StreamWrapper:
         # Get fd for new stream
         redirect_h = write_conn.fileno()
         dup_redirect_h = dup_fh(redirect_h)
-        # ensure inheritable handles
         os.set_handle_inheritable(redirect_h, True)
-        # Todo: investigate if this is neccesary if we do the above before the handle dup
         os.set_handle_inheritable(dup_redirect_h, True)
-        # get the Windows FH for our directed stream
         self.redirect_fd = msvcrt.open_osfhandle(dup_redirect_h, os.O_WRONLY)
-        # redirect at the os kernel level
         kernel32.SetStdHandle(self.STD_HANDLE, wintypes.HANDLE(redirect_h))
-        # redirect at C level
         os.dup2(self.redirect_fd, self.saved_std_fd)
-        # get the stream for the writer connection
         setattr(
             sys,
             self.sys_attr,

--- a/lib/spack/spack/llnl/util/tty/log.py
+++ b/lib/spack/spack/llnl/util/tty/log.py
@@ -569,9 +569,9 @@ class StreamWrapper:
             raise KeyError(self.sys_attr)
 
         self.saved_stream = getattr(sys, self.sys_attr)
-        self.saved_std_fd = self.saved_stream.fileno()
+        self.std_fd = self.saved_stream.fileno()
         self.saved_std_handle = kernel32.GetStdHandle(self.STD_HANDLE)
-        self.saved_stream_fd = os.dup(self.saved_std_fd)
+        self.saved_stream_fd = os.dup(self.std_fd)
         self.redirect_fd = None
 
     def redirect_stream(self, write_conn):
@@ -581,15 +581,14 @@ class StreamWrapper:
         redirect_h = write_conn.fileno()
         dup_redirect_h = dup_fh(redirect_h)
         os.set_handle_inheritable(redirect_h, True)
-        os.set_handle_inheritable(dup_redirect_h, True)
         self.redirect_fd = msvcrt.open_osfhandle(dup_redirect_h, os.O_WRONLY)
         kernel32.SetStdHandle(self.STD_HANDLE, wintypes.HANDLE(redirect_h))
-        os.dup2(self.redirect_fd, self.saved_std_fd)
+        os.dup2(self.redirect_fd, self.std_fd)
         setattr(
             sys,
             self.sys_attr,
             os.fdopen(
-                self.saved_std_fd,
+                self.std_fd,
                 "w",
                 encoding="utf-8",
                 buffering=1,
@@ -619,7 +618,7 @@ class StreamWrapper:
                 # restore os handle
                 kernel32.SetStdHandle(self.STD_HANDLE, self.saved_std_handle)
                 # restore c fd
-                os.dup2(self.saved_stream_fd, self.saved_std_fd)
+                os.dup2(self.saved_stream_fd, self.std_fd)
                 # python level
                 setattr(sys, self.sys_attr, self.saved_stream)
         finally:
@@ -706,7 +705,6 @@ class winlog:
     ):
         force_echo = False
 
-        # Open both write and reading on logfile
         write_mode = "ab+" if append else "wb+"
         log_writer = open(logfile, mode=write_mode)
         try:

--- a/lib/spack/spack/llnl/util/tty/log.py
+++ b/lib/spack/spack/llnl/util/tty/log.py
@@ -708,7 +708,7 @@ class winlog:
         stdout: io.TextIOBase,
         append: bool,
         echo: bool,
-        filter_fn: Callable,
+        filter_fn: Optional[Callable],
     ):
         force_echo = False
 

--- a/lib/spack/spack/llnl/util/tty/log.py
+++ b/lib/spack/spack/llnl/util/tty/log.py
@@ -5,11 +5,10 @@
 """Utility classes for logging the output of blocks of code."""
 import atexit
 import ctypes
-import ctypes.wintypes as wintypes
+
 import errno
 import io
 import multiprocessing
-import multiprocessing.connection
 import os
 import re
 import select
@@ -25,7 +24,7 @@ import spack.llnl.util.tty as tty
 
 if sys.platform == "win32":
     import msvcrt
-
+    import ctypes.wintypes as wintypes
     kernel32 = ctypes.windll.kernel32
 
 try:

--- a/lib/spack/spack/llnl/util/tty/log.py
+++ b/lib/spack/spack/llnl/util/tty/log.py
@@ -924,6 +924,8 @@ def _writer_daemon(
 
 
 def dup_fh(fh: int) -> int:
+    if sys.platform != "win32":
+        return
     # Define function signatures for safety
     kernel32.DuplicateHandle.argtypes = [
         wintypes.HANDLE,  # hSourceProcessHandle

--- a/lib/spack/spack/llnl/util/tty/log.py
+++ b/lib/spack/spack/llnl/util/tty/log.py
@@ -606,8 +606,9 @@ class StreamWrapper:
             if sys_stream:
                 # Flush the system stream before redirection
                 sys_stream.flush()
-        except BaseException:
+        except BaseException as e:
             # swallow flush errors
+            tty.debug(f"Encountered error flushing stream: {e}")
             pass
 
     def close(self):
@@ -711,12 +712,10 @@ class winlog:
         try:
             while True:
                 data = read.recv_bytes(maxlength=4096)
-                # import pdb; pdb.set_trace()
                 if not data:
                     # the pipe is closed or otherwise inaccesible
                     return
                 norm_data = data.decode(encoding="utf-8", errors="replace")
-                # stdout.write(data.decode())
                 clean_line, num_controls = control.subn("", norm_data)
 
                 log_writer.write(_strip(clean_line).encode(encoding="utf-8"))
@@ -747,7 +746,6 @@ class winlog:
         finally:
             read.close()
             log_writer.close()
-            stdout.flush()
             stdout.close()
 
 

--- a/lib/spack/spack/llnl/util/tty/log.py
+++ b/lib/spack/spack/llnl/util/tty/log.py
@@ -5,7 +5,6 @@
 """Utility classes for logging the output of blocks of code."""
 import atexit
 import ctypes
-
 import errno
 import io
 import multiprocessing
@@ -570,7 +569,7 @@ class StreamWrapper:
 
         self.saved_stream = getattr(sys, self.sys_attr)
         self.saved_std_fd = self.saved_stream.fileno()
-        self.saved_std_handle = ctypes.windll.kernel32.GetStdHandle(self.STD_HANDLE)
+        self.saved_std_handle = kernel32.GetStdHandle(self.STD_HANDLE)
         self.saved_stream_fd = os.dup(self.saved_std_fd)
         self.redirect_fd = None
 
@@ -587,7 +586,7 @@ class StreamWrapper:
         # get the Windows FH for our directed stream
         self.redirect_fd = msvcrt.open_osfhandle(dup_redirect_h, os.O_WRONLY)
         # redirect at the os kernel level
-        ctypes.windll.kernel32.SetStdHandle(self.STD_HANDLE, wintypes.HANDLE(redirect_h))
+        kernel32.SetStdHandle(self.STD_HANDLE, wintypes.HANDLE(redirect_h))
         # redirect at C level
         os.dup2(self.redirect_fd, self.saved_std_fd)
         # get the stream for the writer connection
@@ -622,7 +621,7 @@ class StreamWrapper:
             self.flush()
             if self.saved_stream_fd is not None:
                 # restore os handle
-                ctypes.windll.kernel32.SetStdHandle(self.STD_HANDLE, self.saved_std_handle)
+                kernel32.SetStdHandle(self.STD_HANDLE, self.saved_std_handle)
                 # restore c fd
                 os.dup2(self.saved_stream_fd, self.saved_std_fd)
                 # python level
@@ -928,7 +927,7 @@ def dup_fh(fh: int) -> int:
         # since fhs are unsigned
         return -1
     # Define function signatures for safety
-    ctypes.windll.kernel32.DuplicateHandle.argtypes = [
+    kernel32.DuplicateHandle.argtypes = [
         wintypes.HANDLE,  # hSourceProcessHandle
         wintypes.HANDLE,  # hSourceHandle
         wintypes.HANDLE,  # hTargetProcessHandle
@@ -937,10 +936,10 @@ def dup_fh(fh: int) -> int:
         wintypes.BOOL,  # bInheritHandle
         wintypes.DWORD,  # dwOptions
     ]
-    current_process = ctypes.windll.kernel32.GetCurrentProcess()
+    current_process = kernel32.GetCurrentProcess()
     target_handle = wintypes.HANDLE()
 
-    success = ctypes.windll.kernel32.DuplicateHandle(
+    success = kernel32.DuplicateHandle(
         current_process,
         wintypes.HANDLE(fh),
         current_process,

--- a/lib/spack/spack/test/llnl/util/tty/log.py
+++ b/lib/spack/spack/test/llnl/util/tty/log.py
@@ -8,8 +8,6 @@ import sys
 from types import ModuleType
 from typing import Optional
 
-import pytest
-
 import spack.llnl.util.tty.log as log
 from spack.llnl.util.filesystem import working_dir
 from spack.util.executable import Executable
@@ -21,9 +19,6 @@ try:
     termios = term_mod
 except ImportError:
     pass
-
-
-pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
 @contextlib.contextmanager
@@ -165,4 +160,21 @@ def test_log_subproc_and_echo_output(capfd, tmp_path: pathlib.Path):
 
         # Check captured output (echoed content)
         # Note: 'logged' is not echoed because force_echo() scope ended
-        assert capfd.readouterr()[0] == "echo\n"
+        # "print(echo)" above automatically uses an "\r\n" on Windows
+        # and will replace any \n with \r\n (so end=\n does not work)
+        # \r\n is expected and correct here
+        newline = "\r\n" if sys.platform == "win32" else "\n"
+        assert capfd.readouterr()[0] == f"echo{newline}"
+
+
+def test_nested_logging_contexts(tmp_path):
+    with working_dir(str(tmp_path)):
+        with log.log_output("foo.txt"):
+            with log.log_output("bar.txt"):
+                print("inner")
+            print("outer")
+
+        with open("foo.txt", "r", encoding="utf-8") as f:
+            assert f.read() == "outer\n"
+        with open("bar.txt", "r", encoding="utf-8") as f:
+            assert f.read() == "inner\n"

--- a/lib/spack/spack/test/llnl/util/tty/log.py
+++ b/lib/spack/spack/test/llnl/util/tty/log.py
@@ -175,6 +175,10 @@ def test_nested_logging_contexts(capfd, tmp_path):
             print("outer")
 
         with open("foo.txt", "r", encoding="utf-8") as f:
-            assert f.read() == "outer\n"
+            log_captured_out = f.read()
+            assert "outer\n" in log_captured_out
+            assert "inner\n" not in log_captured_out
         with open("bar.txt", "r", encoding="utf-8") as f:
-            assert f.read() == "inner\n"
+            log_captured_out = f.read()
+            assert "inner\n" in log_captured_out
+            assert "outer\n" not in log_captured_out

--- a/lib/spack/spack/test/llnl/util/tty/log.py
+++ b/lib/spack/spack/test/llnl/util/tty/log.py
@@ -163,6 +163,11 @@ def test_log_subproc_and_echo_output(capfd, tmp_path: pathlib.Path):
         # Note: "print(echo)" above automatically uses an "\r\n" on Windows
         # and will replace any \n with \r\n (so end=\n does not work)
         # \r\n is expected and correct here
+        # Note: the above line ending constraint is an artifact of
+        # pytest's capfd. This is potentially (however unlikely)
+        # subject to change with future versions of pytest.
+        # if this test suddenly starts failing, verifying the line
+        # endings from capfd is a good starting place.
         newline = "\r\n" if sys.platform == "win32" else "\n"
         assert capfd.readouterr()[0] == f"echo{newline}"
 

--- a/lib/spack/spack/test/llnl/util/tty/log.py
+++ b/lib/spack/spack/test/llnl/util/tty/log.py
@@ -160,7 +160,7 @@ def test_log_subproc_and_echo_output(capfd, tmp_path: pathlib.Path):
 
         # Check captured output (echoed content)
         # Note: 'logged' is not echoed because force_echo() scope ended
-        # "print(echo)" above automatically uses an "\r\n" on Windows
+        # Note: "print(echo)" above automatically uses an "\r\n" on Windows
         # and will replace any \n with \r\n (so end=\n does not work)
         # \r\n is expected and correct here
         newline = "\r\n" if sys.platform == "win32" else "\n"

--- a/lib/spack/spack/test/llnl/util/tty/log.py
+++ b/lib/spack/spack/test/llnl/util/tty/log.py
@@ -167,7 +167,7 @@ def test_log_subproc_and_echo_output(capfd, tmp_path: pathlib.Path):
         assert capfd.readouterr()[0] == f"echo{newline}"
 
 
-def test_nested_logging_contexts(tmp_path):
+def test_nested_logging_contexts(capfd, tmp_path):
     with working_dir(str(tmp_path)):
         with log.log_output("foo.txt"):
             with log.log_output("bar.txt"):


### PR DESCRIPTION
Redo how we handle IO direction for logging on Windows

Previous we closed sys.stdout, replaced it with a new buffer pointing at the logging file, and then dup2'd to redirect stdout. The logfile was then read from a thread, controlled by the main spack thread, and said reader thread forwarded on the logging context to main Spack's dup'd stdout.

This is deeply insufficient for a number of use cases:

It did not support filtering, unicode, control characters, or force_echo

All echo, including force_echo when supported, was racey, due to the disparate mechanisms by which reader thread behavior was controlled vs the context from which it obtained information. I.e. the reader thread could be killed or echo turned off, before any stdout buffers could be flushed (or whatever out-of-sync ordering) and the reader thread wouldn't see the log output it was supposed to echo prior to turning echo off or terminating.

Nested logging, or cached references to stdout and stderr were invalidated. Previously, on io redirection, we were closing stdout and replacing it with our new buffer. On io restoration, we were restored a buffer pointing at console stdout to sys.stdout, but any cached references to stdout (i.e. nested logging contexts or pytest) were invalidated.

Now we:

* do not close whatever sys.stdout refers to, we mearly store a reference to it
* do not construct a new buffer from python's api, instead we perform redirection from the ground up, starting with fhs to fds and compose a buffer from the existing fh's fd.
* Use pipes for communication with our reader thread, which enables filtering, control characters, etc and allows for non racey echo behavior.

At a glance:

* Redirects IO starting at the Windows file handle (fh) level
* Properly maps fhs to fds, and obtains the appropriate buffer wrapping each
* Enables proper subprocess io redirection inheritance
* Manages shared file handles between stderr and stdout on redirect
* Properly redirects IO at each level of handling, kernel, C, and python
* Ensures cached references to console streams are not invalidated
* Ensures correct order of release for buffers -> fhs

Moves toward a unified logging class by introducing fundamental support
 for the concepts leveraged by the non Windows logger classes like pipes


Also enabled logging testing for Windows

Adds a test for nested logging context managers.