### PR TITLE
Change error to warning after best attempt to remove mirror

### DIFF
--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -366,8 +366,15 @@ def mirror_remove(args):
     scopes = [args.scope] if args.scope else reversed(list(spack.config.CONFIG.scopes.keys()))
 
     removed = False
+    skipped_scopes = []
     for scope in scopes:
-        removed_from_this_scope = spack.mirrors.utils.remove(name, scope)
+        try:
+            removed_from_this_scope = spack.mirrors.utils.remove(name, scope)
+        except spack.config.ConfigFileError as e:
+            tty.debug(f"Skipping 'mirror rm' for scope: {scope}\nReason: {e}")
+            skipped_scopes.append(scope)
+            continue
+
         if removed_from_this_scope:
             tty.msg(f"Removed mirror {name} from {scope} scope")
 
@@ -375,8 +382,21 @@ def mirror_remove(args):
         if removed and not args.all_scopes:
             return
 
+    rc = 0
+    if skipped_scopes:
+        msg = f"Could not edit scopes: {comma_or(skipped_scopes)}"
+        if args.all_scopes:
+            rc = 1
+            tty.error(msg)
+        elif not removed:
+            tty.warn(msg)
+
     if not removed:
-        tty.die(f"No mirror with name {name} in {comma_or(scopes)} scope")
+        visited_scopes = list(set(scopes) - set(skipped_scopes))
+        rc = 1
+        tty.error(f"No mirror with name {name} in {comma_or(visited_scopes)} scope")
+
+    return rc
 
 
 def _configure_mirror(args):
@@ -748,4 +768,4 @@ def mirror(parser, args):
     if args.no_checksum:
         spack.config.CONFIG.set("config:checksum", False, scope="command_line")
 
-    action[args.mirror_command](args)
+    return action[args.mirror_command](args)

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -368,7 +368,7 @@ def mirror_remove(args):
     removed = False
     skipped_scopes = []
     # Traverse scopes in order from highest to lowest
-    for scope in reversed(scopes):
+    for scope in scopes:
         try:
             removed_from_this_scope = spack.mirrors.utils.remove(name, scope)
         except spack.config.ConfigFileError as e:

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -367,13 +367,17 @@ def mirror_remove(args):
 
     removed = False
     skipped_scopes = []
-    for scope in scopes:
+    # Traverse scopes in order from highest to lowest
+    for scope in reversed(scopes):
         try:
             removed_from_this_scope = spack.mirrors.utils.remove(name, scope)
         except spack.config.ConfigFileError as e:
             tty.debug(f"Skipping 'mirror rm' for scope: {scope}\nReason: {e}")
             skipped_scopes.append(scope)
-            continue
+            if not args.all_scopes:
+                break
+            else:
+                continue
 
         if removed_from_this_scope:
             tty.msg(f"Removed mirror {name} from {scope} scope")
@@ -385,7 +389,7 @@ def mirror_remove(args):
     rc = 0
     if skipped_scopes:
         msg = f"Could not edit scopes: {comma_or(skipped_scopes)}"
-        if args.all_scopes:
+        if args.all_scopes or args.scope:
             rc = 1
             tty.error(msg)
         elif not removed:
@@ -394,7 +398,8 @@ def mirror_remove(args):
     if not removed:
         visited_scopes = list(set(scopes) - set(skipped_scopes))
         rc = 1
-        tty.error(f"No mirror with name {name} in {comma_or(visited_scopes)} scope")
+        if visited_scopes:
+            tty.error(f"No mirror with name {name} in {comma_or(visited_scopes)} scope")
 
     return rc
 

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -130,8 +130,20 @@ def remove(name, scope):
     if not mirrors:
         mirrors = syaml.syaml_dict()
 
+    mirrors_orig = {**mirrors}
     removed = mirrors.pop(name, False)
-    spack.config.CONFIG.set("mirrors", mirrors, scope=scope)
+    # If the mirror `name` was not removed from this scope, don't try to modify the scope
+    # This can lead to false errors
+    if not removed:
+        return removed
+
+    try:
+        spack.config.CONFIG.set("mirrors", mirrors, scope=scope)
+    except Exception as e:
+        # Preserve the in-memory state of the mirrors config if set fails
+        spack.config.CONFIG.set("mirrors", mirrors_orig, scope=scope)
+        raise e
+
     return bool(removed)
 
 

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -4,6 +4,7 @@
 
 import os
 import pathlib
+import stat
 
 import pytest
 
@@ -298,6 +299,66 @@ mpich@1.0
     expected_exclude = {spack.spec.Spec(x) for x in ["mpich@3.0.1", "mpich@3.0.2", "mpich@1.0"]}
     assert expected_include <= set(mirror_specs)
     assert not any(spec.satisfies(y) for spec in mirror_specs for y in expected_exclude)
+
+
+@pytest.mark.parametrize("ro_scope_name", ("system", "site"))
+def test_mirror_remove_read_only_scope(mutable_config, tmp_path: pathlib.Path, ro_scope_name):
+    # Expected scope ordering (highest to lowest):
+    #   - command_line
+    #   - user
+    #   - system
+    #   - site
+    #   - site:base
+    #   - _builtin
+
+    # add a new mirror to two scopes
+    mirror("add", "--scope=site", "mock", str(tmp_path / "mock_mirror"))
+    mirror("add", "--scope=system", "mock", str(tmp_path / "mock_mirror"))
+
+    w_scope_name = "system" if ro_scope_name == "site" else "site"
+
+    # Make the system scope unwritable
+    ro_scope = mutable_config.scopes.get(ro_scope_name)
+    os.chmod(os.path.join(getattr(ro_scope, "path")), stat.S_IREAD | stat.S_IEXEC)
+    os.chmod(os.path.join(getattr(ro_scope, "path"), "mirrors.yaml"), stat.S_IREAD)
+
+    # Remove the mock mirror from all scopes, should fail on unwritable scope
+    with pytest.raises(SpackCommandError):
+        mirror("rm", "--all-scopes", "mock")
+
+    w_scope_output = mirror("list", f"--scope={w_scope_name}")
+    ro_scope_output = mirror("list", f"--scope={ro_scope_name}")
+    assert "mock" not in w_scope_output
+    assert "mock" in ro_scope_output
+
+    # Fail to remove when only RO scope mirror is present
+    with pytest.raises(SpackCommandError):
+        mirror("rm", "mock")
+
+    w_scope_output = mirror("list", f"--scope={w_scope_name}")
+    ro_scope_output = mirror("list", f"--scope={ro_scope_name}")
+    assert "mock" not in w_scope_output
+    assert "mock" in ro_scope_output
+
+    # Check removing RO with either higher or lower scope containing mirror name
+    # being RO.
+    mirror("add", f"--scope={w_scope_name}", "mock", str(tmp_path / "mock_mirror"))
+    if ro_scope_name == "site":
+        out = mirror("rm", "mock")
+        assert "Removed mirror mock from system scope" in out
+
+        w_scope_output = mirror("list", f"--scope={w_scope_name}")
+        assert "mock" not in w_scope_output
+    else:  # ro_scope_name == "site"
+        # This fails to remove the from a higher scope mirror 'mock'
+        with pytest.raises(SpackCommandError):
+            mirror("rm", "mock")
+
+        w_scope_output = mirror("list", f"--scope={w_scope_name}")
+        assert "mock" in w_scope_output
+
+    ro_scope_output = mirror("list", f"--scope={ro_scope_name}")
+    assert "mock" in ro_scope_output
 
 
 def test_mirror_remove_by_scope(mutable_config, tmp_path: pathlib.Path):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Fix error where `spack mirror rm` dies if it cannot write to system scope.

CC @zackgalbreath for finding this bug!