### PR TITLE
asp.py: speed up cache key

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -899,6 +899,30 @@ class ErrorHandler:
         raise UnsatisfiableSpecError(msg)
 
 
+def _strip_asp_problem(asp_problem: Iterable[str]) -> List[str]:
+    """Remove empty lines from an ASP program."""
+    return [stmt for stmt in asp_problem if stmt]
+
+
+def _make_cache_key(asp_problem: str, control_file_paths: List[str]) -> str:
+    """Make a key for fetching a solve from the concretization cache.
+
+    A key comprises the entire input to clingo, i.e., the problem instance plus the
+    control files.  The problem instance is assumed to already be sorted and stripped.
+
+    Changes to the control files always invalidate the cache.
+
+    Arguments:
+        asp_problem: pre-processed string representation of the ASP problem instance
+        control_file_paths: list of paths to control files we'll send to clingo
+    """
+    components = [asp_problem]
+    for path in control_file_paths:
+        with open(path, "r", encoding="utf-8") as f:
+            components.append(f.read())
+    return "\n".join(components)
+
+
 class PyclingoDriver:
     def __init__(self, conc_cache: Optional[ConcretizationCache] = None) -> None:
         """Driver for the Python clingo interface.
@@ -917,27 +941,6 @@ class PyclingoDriver:
         """
         parent_dir = os.path.dirname(__file__)
         return [os.path.join(parent_dir, rel_path) for rel_path in control_files]
-
-    def _make_cache_key(self, asp_problem: List[str], control_file_paths: List[str]) -> str:
-        """Make a key for fetching a solve from the concretization cache.
-
-        A key comprises the entire input to clingo, i.e., the problem instance plus the
-        control files.  The problem instance is assumed to already be sorted and stripped of
-        comments and empty lines.
-
-        The control files are stripped but not sorted, so changes to the control files will cause
-        cache misses if they modify any code.
-
-        Arguments:
-            asp_problem: list of statements in the ASP program
-            control_file_paths: list of paths to control files we'll send to clingo
-        """
-        lines = list(asp_problem)
-        for path in control_file_paths:
-            with open(path, "r", encoding="utf-8") as f:
-                lines.extend(strip_asp_problem(f.readlines()))
-
-        return "\n".join(lines)
 
     def _run_clingo(
         self,
@@ -1096,7 +1099,7 @@ class PyclingoDriver:
         timer.stop("setup")
 
         timer.start("ordering")
-        # print the output with comments, etc. if the user asked
+        # print the original ASP program if requested
         problem = problem_builder.asp_problem
         if output.out is not None:
             output.out.write("\n".join(problem))
@@ -1104,15 +1107,14 @@ class PyclingoDriver:
         if output.setup_only:
             return Result(specs), None, None
 
-        # strip the problem of comments and empty lines
-        problem = strip_asp_problem(problem)
-        randomize = "SPACK_SOLVER_RANDOMIZATION" in os.environ
-        if randomize:
-            # create a shuffled copy -- useful for understanding performance variation
-            problem = random.sample(problem, len(problem))
+        # strip and order the ASP problem for caching and deterministic solves
+        problem = _strip_asp_problem(problem)
+        if "SPACK_SOLVER_RANDOMIZATION" in os.environ:
+            # shuffling is used in benchmarking to rule out variability due to input ordering
+            random.shuffle(problem)
         else:
-            problem.sort()  # sort for deterministic output
-
+            problem.sort()
+        problem_str = "\n".join(problem)
         timer.stop("ordering")
 
         timer.start("cache-check")
@@ -1121,23 +1123,24 @@ class PyclingoDriver:
 
         # load control files to add to the input representation
         control_file_paths = self._control_file_paths(control_files)
-        cache_key = self._make_cache_key(problem, control_file_paths)
 
-        # try to fetch from the cache
+        # try to fetch from the cache; only compute the key if the cache is enabled
         result = None
+        cache_key = None
         if cache:
+            cache_key = _make_cache_key(problem_str, control_file_paths)
             result, concretization_stats = cache.fetch(cache_key, specs)
         timer.stop("cache-check")
 
         # run the solver
         if result is None:
             tty.debug("Starting concretizer")
-            result = self._run_clingo(specs, setup, "\n".join(problem), control_file_paths, timer)
+            result = self._run_clingo(specs, setup, problem_str, control_file_paths, timer)
             result.raise_if_unsat()
             concretization_stats = self.control.statistics
 
             # write result back to the cache *before* post-processing
-            if cache:
+            if cache and cache_key is not None:
                 cache.store(cache_key, result, self.control.statistics)
 
         # apply post-concretization transformations
@@ -3388,19 +3391,6 @@ class _Body:
     variant_value = fn.attr("variant_value")
     node_flag = fn.attr("node_flag")
     propagate = fn.attr("propagate")
-
-
-def strip_asp_problem(asp_problem: Iterable[str]) -> List[str]:
-    """Remove comments and empty lines from an ASP program."""
-
-    def strip_statement(stmt: str) -> str:
-        lines = [line for line in stmt.split("\n") if not line.startswith("%")]
-        return "".join(line.strip() for line in lines if line)
-
-    value = [strip_statement(stmt) for stmt in asp_problem]
-    value = [s for s in value if s]
-
-    return value
 
 
 class ProblemInstanceBuilder:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -884,6 +884,30 @@ class ErrorHandler:
         raise UnsatisfiableSpecError(msg)
 
 
+def _strip_asp_problem(asp_problem: Iterable[str]) -> List[str]:
+    """Remove empty lines from an ASP program."""
+    return [stmt for stmt in asp_problem if stmt]
+
+
+def _make_cache_key(asp_problem: str, control_file_paths: List[str]) -> str:
+    """Make a key for fetching a solve from the concretization cache.
+
+    A key comprises the entire input to clingo, i.e., the problem instance plus the
+    control files.  The problem instance is assumed to already be sorted and stripped.
+
+    Changes to the control files always invalidate the cache.
+
+    Arguments:
+        asp_problem: pre-processed string representation of the ASP problem instance
+        control_file_paths: list of paths to control files we'll send to clingo
+    """
+    components = [asp_problem]
+    for path in control_file_paths:
+        with open(path, "r", encoding="utf-8") as f:
+            components.append(f.read())
+    return "\n".join(components)
+
+
 class PyclingoDriver:
     def __init__(self, conc_cache: Optional[ConcretizationCache] = None) -> None:
         """Driver for the Python clingo interface.
@@ -902,27 +926,6 @@ class PyclingoDriver:
         """
         parent_dir = os.path.dirname(__file__)
         return [os.path.join(parent_dir, rel_path) for rel_path in control_files]
-
-    def _make_cache_key(self, asp_problem: List[str], control_file_paths: List[str]) -> str:
-        """Make a key for fetching a solve from the concretization cache.
-
-        A key comprises the entire input to clingo, i.e., the problem instance plus the
-        control files.  The problem instance is assumed to already be sorted and stripped of
-        comments and empty lines.
-
-        The control files are stripped but not sorted, so changes to the control files will cause
-        cache misses if they modify any code.
-
-        Arguments:
-            asp_problem: list of statements in the ASP program
-            control_file_paths: list of paths to control files we'll send to clingo
-        """
-        lines = list(asp_problem)
-        for path in control_file_paths:
-            with open(path, "r", encoding="utf-8") as f:
-                lines.extend(strip_asp_problem(f.readlines()))
-
-        return "\n".join(lines)
 
     def _run_clingo(
         self,
@@ -1085,7 +1088,7 @@ class PyclingoDriver:
         timer.stop("setup")
 
         timer.start("ordering")
-        # print the output with comments, etc. if the user asked
+        # print the original ASP program if requested
         problem = problem_builder.asp_problem
         if output.out is not None:
             output.out.write("\n".join(problem))
@@ -1093,33 +1096,32 @@ class PyclingoDriver:
         if output.setup_only:
             return Result(specs), None, None
 
-        # strip the problem of comments and empty lines
-        problem = strip_asp_problem(problem)
-        randomize = "SPACK_SOLVER_RANDOMIZATION" in os.environ
-        if randomize:
-            # create a shuffled copy -- useful for understanding performance variation
-            problem = random.sample(problem, len(problem))
+        # strip and order the ASP problem for caching and deterministic solves
+        problem = _strip_asp_problem(problem)
+        if "SPACK_SOLVER_RANDOMIZATION" in os.environ:
+            # shuffling is used in benchmarking to rule out variability due to input ordering
+            random.shuffle(problem)
         else:
-            problem.sort()  # sort for deterministic output
-
+            problem.sort()
+        problem_str = "\n".join(problem)
         timer.stop("ordering")
 
         timer.start("cache-check")
         # load control files to add to the input representation
         control_file_paths = self._control_file_paths(control_files)
-        cache_key = self._make_cache_key(problem, control_file_paths)
-
         result, concretization_stats = None, None
         conc_cache_enabled = spack.config.get("concretizer:concretization_cache:enable", False)
         if conc_cache_enabled and self._conc_cache:
+            cache_key = _make_cache_key(problem_str, control_file_paths)
             result, concretization_stats = self._conc_cache.fetch(cache_key)
+        else:
+            cache_key = None
         timer.stop("cache-check")
 
         # run the solver and store the result, if it wasn't cached already
         if not result:
-            problem_repr = "\n".join(problem)
-            result = self._run_clingo(specs, setup, problem_repr, control_file_paths, timer)
-            if conc_cache_enabled and self._conc_cache:
+            result = self._run_clingo(specs, setup, problem_str, control_file_paths, timer)
+            if self._conc_cache and cache_key is not None:
                 self._conc_cache.store(cache_key, result, self.control.statistics)
 
         if output.timers:
@@ -3324,19 +3326,6 @@ class _Body:
     variant_value = fn.attr("variant_value")
     node_flag = fn.attr("node_flag")
     propagate = fn.attr("propagate")
-
-
-def strip_asp_problem(asp_problem: Iterable[str]) -> List[str]:
-    """Remove comments and empty lines from an ASP program."""
-
-    def strip_statement(stmt: str) -> str:
-        lines = [line for line in stmt.split("\n") if not line.startswith("%")]
-        return "".join(line.strip() for line in lines if line)
-
-    value = [strip_statement(stmt) for stmt in asp_problem]
-    value = [s for s in value if s]
-
-    return value
 
 
 class ProblemInstanceBuilder:

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4757,7 +4757,7 @@ def test_concretization_cache_asp_canonicalization(asp_file):
 
     with open(path, "r", encoding="utf-8") as f:
         original = [line.strip() for line in f.readlines()]
-        stripped = spack.solver.asp.strip_asp_problem(original)
+        stripped = spack.solver.asp._strip_asp_problem(original)
 
     diff = list(difflib.unified_diff(original, stripped))
 

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -1,7 +1,6 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import difflib
 import gzip
 import json
 import os
@@ -4739,35 +4738,24 @@ def test_concretization_cache_removes_bad_spec_data(corrupt_cache_entry):
     )
 
 
-@pytest.mark.parametrize(
-    "asp_file",
-    [
-        "concretize.lp",
-        "heuristic.lp",
-        "display.lp",
-        "direct_dependency.lp",
-        "when_possible.lp",
-        "libc_compatibility.lp",
-        "os_compatibility.lp",
-        "splices.lp",
-    ],
-)
-def test_concretization_cache_asp_canonicalization(asp_file):
-    path = os.path.join(os.path.dirname(spack.solver.asp.__file__), asp_file)
+def test_concretization_cache_asp_canonicalization():
+    """Canonicalization strips empty lines"""
+    input = """\
+% ID of the nodes in the "root" link-run sub-DAG
+#const min_dupe_id = 0.
 
-    with open(path, "r", encoding="utf-8") as f:
-        original = [line.strip() for line in f.readlines()]
-        stripped = spack.solver.asp._strip_asp_problem(original)
-
-    diff = list(difflib.unified_diff(original, stripped))
-
-    assert all(
-        [
-            line == "-" or line.startswith("-%")
-            for line in diff
-            if line.startswith("-") and not line.startswith("---")
-        ]
-    )
+% Allow clingo to create nodes
+{ attr("node", node(0..X-1, Package))         } :- max_dupes(Package, X), not virtual(Package).
+{ attr("virtual_node", node(0..X-1, Package)) } :- max_dupes(Package, X), virtual(Package).
+"""
+    output = """\
+% ID of the nodes in the "root" link-run sub-DAG
+#const min_dupe_id = 0.
+% Allow clingo to create nodes
+{ attr("node", node(0..X-1, Package))         } :- max_dupes(Package, X), not virtual(Package).
+{ attr("virtual_node", node(0..X-1, Package)) } :- max_dupes(Package, X), virtual(Package).
+"""
+    assert spack.solver.asp._strip_asp_problem(input.splitlines()) == output.splitlines()
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4509,7 +4509,7 @@ def test_concretization_cache_asp_canonicalization(asp_file):
 
     with open(path, "r", encoding="utf-8") as f:
         original = [line.strip() for line in f.readlines()]
-        stripped = spack.solver.asp.strip_asp_problem(original)
+        stripped = spack.solver.asp._strip_asp_problem(original)
 
     diff = list(difflib.unified_diff(original, stripped))
 


### PR DESCRIPTION
* when caching is disabled, do not compute a multi-megabyte cache key
  string redundantly
* do not attempt to remove comments, as they account for only ~2% of the
  size, and are unlikely to change without other changes in ASP
  rules/facts that invalidate the cache.
* restore use of in-place `random.shuffle` for the benchmarking use
  case, instead of a copying version.

Removing the inner iteration from `strip_asp_problem` speeds up the
function by a factor ~20: on a real-world 12.8MB problem instance
(244k statements, hdf5+mpi with reuse against a 5.3MB database index)
it drops from 144ms to 7ms per solve, and the `ordering` timer phase
of `spack solve --timers` drops from ~158ms to ~36ms.

It's minor, but it's both shorter in implementation and faster.
